### PR TITLE
Set community conduct boundaries

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 concurrency:
   group: security-${{ github.ref }}
@@ -36,7 +37,13 @@ jobs:
           .venv/bin/pip install --disable-pip-version-check slither-analyzer==0.11.5
 
       - name: Run Slither
-        run: .venv/bin/slither . --config-file slither.config.json
+        run: .venv/bin/slither . --config-file slither.config.json --sarif slither.sarif
+
+      - name: Publish Slither results
+        if: always() && github.event_name == 'push'
+        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          sarif_file: slither.sarif
 
       - name: Measure source coverage
         run: forge coverage --exclude-tests --report lcov --report-file lcov.info

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Community conduct
+
+Programmable is a technical collaboration space. Discussion should stay direct, specific and grounded in code,
+transactions or other reproducible evidence.
+
+## Expected
+
+- Critique the work, not the person.
+- Give reviewers enough context to verify a claim.
+- Respect contributors regardless of identity, background or level of experience.
+- Keep issues and pull requests relevant to the repository.
+- Move unpatched security findings to private vulnerability reporting.
+
+## Not accepted
+
+- Harassment, threats, discriminatory language or targeted intimidation.
+- Publishing another person's private information.
+- Impersonation, spam or coordinated manipulation.
+- Deliberately false security, deployment or affiliation claims.
+- Public disclosure of an unpatched vulnerability.
+
+## Moderation
+
+Maintainers may edit, hide or remove content, lock a thread or limit participation when conduct disrupts the project or
+puts contributors at risk. Decisions are based on observed behavior in project spaces.
+
+Use GitHub's report-content controls for harassment, threats, impersonation or private-information exposure. For a
+non-sensitive repository moderation problem, open an issue with the smallest useful context. Report vulnerabilities
+through [GitHub private vulnerability reporting](https://github.com/0xprogrammable/programmable/security/advisories/new).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Programmable publishes independent Uniswap v4 launch models. Start with the rele
 before changing a contract or proposing a new model.
 
 Changes should be small, reviewable and covered by a test that fails before the fix.
+Participation is governed by [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 
 ## New launch models
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -9,6 +9,7 @@ the interface, but cannot rewrite deployed behavior or remove locked liquidity.
 | --- | --- | --- |
 | Repository verification | Every pull request and push to `main` | Formatting, build, tests, registry and gas snapshot |
 | Security workflow | Every pull request and push to `main` | Slither, coverage floor and workflow lint |
+| Code scanning | Every push to `main` | Publishes Slither SARIF results in GitHub Security |
 | Ethereum bytecode evidence | Daily and on demand | Published runtime code hashes still match Ethereum |
 
 A failed public RPC request can also fail the Ethereum evidence workflow. Investigate provider availability before

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 | [Classic security properties](security/CLASSIC_PROPERTIES.md) | Permissions, accounting, invariants and MEV boundaries |
 | [Operations](OPERATIONS.md) | Automated evidence, monitoring status and incident response |
 | [Hook Builder Program](../BUILDER_PROGRAM.md) | External model submission and acceptance terms |
+| [Community conduct](../CODE_OF_CONDUCT.md) | Participation and moderation boundaries |
 | [Support](../SUPPORT.md) | Correct route for public and private reports |
 
 Model-specific behavior belongs under [`models/`](../models/). Machine-readable release records are under


### PR DESCRIPTION
Add a concise project-specific conduct policy for public issues, pull requests and external model submissions. It defines acceptable technical discussion, prohibited behavior, moderation boundaries and the correct private route for vulnerabilities.

No contact address or enforcement service is claimed.