### PR TITLE
Activate the current Classic Ethereum release

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -7,7 +7,7 @@ accounted for. [`models/registry.json`](models/registry.json) is the canonical m
 
 | Model | Lifecycle | Ethereum release | Documentation |
 | --- | --- | --- | --- |
-| Classic | **Available** | [`classic-v2`](releases/classic-v2/RELEASE.md) | [Open model](models/classic/README.md) |
+| Classic | **Available** | [`classic-v3`](releases/classic-v3/RELEASE.md) | [Open model](models/classic/README.md) |
 | Deep | **Design** | None | [Open design](models/deep/README.md) |
 
 `Available` means the exact source, parameters, deployment, runtime hashes and security status are public. It does not
@@ -25,12 +25,12 @@ mean that a model has received an independent audit.
   </a>
 </p>
 
-**Available on Ethereum.** Classic creates a fixed-supply token, initializes its native ETH pool, locks the complete
-launch position and executes the creator's initial buy in one transaction. Its current launch configuration uses a
-`1.00%` disclosed ETH-denominated swap fee.
+**Available on Ethereum.** Classic creates a fixed-supply token, initializes its native ETH pool, permanently locks the
+complete launch position and executes the creator's initial buy in one transaction. Creators select separate immutable
+buy and sell fees, direct native ETH rewards to as many as five wallets and may lock or vest the initial buy.
 
 [Behavior and fees](models/classic/README.md) ·
-[Release record](releases/classic-v2/RELEASE.md) ·
+[Release record](releases/classic-v3/RELEASE.md) ·
 [Ethereum deployment](deployments/ethereum.json) ·
 [Security properties](docs/security/CLASSIC_PROPERTIES.md)
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ receive a version-specific acceptance record before release.
 
 ## Security and operations
 
-The live Classic contracts are non-upgradeable and expose no administrator role, pause function, mint path, blacklist
-or mutable fee allocation. Classic has not received an independent smart-contract audit or public security contest.
+The live Classic hook and launcher are non-upgradeable and expose no pause function, mint path, blacklist or
+post-launch fee setter. A disclosed Community Takeover authority can replace future creator-reward recipients only
+after accrued ETH is checkpointed. Classic has not received an independent smart-contract audit or public security
+contest.
 
 | Area | Record |
 | --- | --- |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,7 +51,7 @@ Passing CI, a local fork or a testnet deployment does not satisfy this gate.
 
 ## GitHub release
 
-Release tags use the model's technical release identifier, such as `classic-v2`. The release page contains:
+Release tags use the model's technical release identifier, such as `classic-v3`. The release page contains:
 
 - a concise behavior summary;
 - links to the model, security and deployment records;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,17 @@
 
 ## Current status
 
-Security properties are recorded per launch model. Classic is currently the only available model. It has unit,
-integration, fuzz, invariant, regression, static-analysis and coverage checks. It has not received an independent
-smart-contract audit or public security contest.
+Classic is the only available launch model. Its current Ethereum release has unit, integration, fuzz, invariant,
+regression and Mainnet-fork coverage. All seven release contracts are Etherscan exact matches and Sourcify matches.
+Classic has not received an independent smart-contract audit or public security contest.
 
-These checks are evidence, not a safety guarantee.
+These records are evidence, not a safety guarantee.
 
 | Record | Scope |
 | --- | --- |
 | [Classic security properties](docs/security/CLASSIC_PROPERTIES.md) | Trust boundaries, permissions, accounting and invariant evidence |
+| [Classic Slither review](docs/security/SLITHER_CLASSIC_V3.md) | Static-analysis findings and manual dispositions |
+| [Classic release](releases/classic-v3/RELEASE.md) | Version-bound source, tests and Mainnet lifecycle evidence |
 | [Operations](docs/OPERATIONS.md) | Automated checks, monitoring status and incident response |
 | [Independent reviews](audits/README.md) | Published external reports, currently none |
 | [Ethereum deployment](deployments/ethereum.json) | Addresses, transactions, runtime hashes and verification status |
@@ -33,26 +35,32 @@ time.
 
 ## Classic control model
 
-The live Classic contracts are non-upgradeable and expose no administrator role, pause function, mint path, blacklist
-or mutable fee allocation. This removes administrative recovery as well as administrative control.
+The fee hook, launcher, policy, factories and vault implementations are non-upgradeable. The hook and launcher expose
+no owner, pause function, blacklist, post-launch fee setter or token mint path.
+
+The current release has one disclosed administrative role: the Community Takeover authority. It can replace only a
+reward vault's future beneficiaries and shares. The vault checkpoints accrued ETH before any replacement, preserving
+the prior wallets' historic rewards. The authority cannot alter fee rates, token supply, trading or launch liquidity.
 
 The intended properties include:
 
 - only `PoolManager` may enter swap callbacks;
-- each pool is registered once and bound to its recorded creator;
-- the pool shape, hook permissions and public fee disclosure remain fixed;
+- each pool is registered once with immutable buy and sell fees;
+- the fixed `0.10` percentage-point Programmable share is deducted from the selected fee;
 - the complete launch supply enters permanent position custody;
-- creator and Programmable claims are accounted separately in native ETH;
-- unrelated callers cannot redirect a claim;
+- each beneficiary alone controls its claims and future payout-wallet changes;
+- prior rewards remain with the wallet that earned them after a payout or CTO change;
+- initial-buy custody schedules and beneficiaries are immutable;
 - token transfers have no tax; and
 - unsupported partial-fill accounting reverts.
 
-The detailed property-to-test map is in
+The property-to-test map is in
 [`docs/security/CLASSIC_PROPERTIES.md`](docs/security/CLASSIC_PROPERTIES.md).
 
 ## Trust assumptions
 
 - Pinned Uniswap v4, liquidity-launcher and UERC20 contracts behave as documented.
+- The disclosed CTO authority is used only for reviewed Community Takeovers.
 - Ethereum consensus and native ETH settlement remain available.
 - Integrators use the exact addresses and runtime hashes in
   [`deployments/ethereum.json`](deployments/ethereum.json).
@@ -61,8 +69,8 @@ The detailed property-to-test map is in
 ## Known limitations
 
 - There is no emergency pause or upgrade path.
-- A native ETH recipient that rejects payment can block its direct claim until that recipient uses its authorized
-  redirect function.
+- A compromised CTO authority can replace future creator-reward recipients after existing rewards are checkpointed.
+- A native ETH recipient that rejects payment can block its own claim transaction.
 - Swaps that produce unsupported partial-fill accounting revert.
 - Public ordering and sandwich risks remain applicable to swaps.
 - Metadata and project links may be indexed inconsistently by third-party services.

--- a/deployments/ethereum.json
+++ b/deployments/ethereum.json
@@ -2,27 +2,51 @@
   "schemaVersion": 1,
   "network": "ethereum",
   "chainId": 1,
-  "release": "classic-v2",
-  "deploymentBlock": 25624128,
-  "sourceCommitment": "0x6bf2c70c5ab2a64a62f2c27e6be859e3428f2c35e6e2db5255b569b9f9eb1287",
+  "release": "classic-v3",
+  "deploymentBlock": 25639532,
+  "sourceCommitment": "0x58991ed1743aaba5f1988a4576d36eb10af70b96bdb61661ba96e1f80acc9800",
   "contracts": {
+    "ctoAuthority": {
+      "address": "0x9746469Cd79fdDc5aA7218e7dd51c829ee518c0C",
+      "transactionHash": "0x8587ebdb0dc1626ccb65e00722bfde005f62bf0c492ce4f7574a2164f3081969",
+      "runtimeCodeHash": "0x7beafb575fba4ffce22da7b3f927df8248eebc6c33e77cb43ed967a91a36984c",
+      "etherscan": "https://etherscan.io/address/0x9746469Cd79fdDc5aA7218e7dd51c829ee518c0C#code"
+    },
+    "rewardVaultFactory": {
+      "address": "0xF28967f9DFaC3Ca21384b59D6D75C8106b3eab2a",
+      "transactionHash": "0xd9eb626691fa213004b0a533e569b85e8987a6bd3a77b7719affffa9b8e33aa3",
+      "runtimeCodeHash": "0x874ec76f396807bfcbbdd88cc2fd534f10201242ad0479a05fe5d2ee937616ee",
+      "etherscan": "https://etherscan.io/address/0xF28967f9DFaC3Ca21384b59D6D75C8106b3eab2a#code"
+    },
+    "initialBuyVestingWalletFactory": {
+      "address": "0xDe21b9c0Cc0AfDB9be20e8236113f066BB8C66f4",
+      "transactionHash": "0x0e548eaebe72120fc44314be890455a3e39af59b249d49d0614399e7831fa300",
+      "runtimeCodeHash": "0x13b7578a8abd0bc0ba724b5815d9bd0aff0d07c2677c00d2577004e8c1f6d5f4",
+      "etherscan": "https://etherscan.io/address/0xDe21b9c0Cc0AfDB9be20e8236113f066BB8C66f4#code"
+    },
+    "launchPolicy": {
+      "address": "0x53a4d1E6ab184389D3581085AB73CD3549B20d1a",
+      "transactionHash": "0x8d8d92587026d3d355cd800491b6550a18904182df77fc1eb01dd3e8526fa046",
+      "runtimeCodeHash": "0xb6b31b6cf326784774e13f6d60f9b251dde118469a506fa3b1c124c9f11b49be",
+      "etherscan": "https://etherscan.io/address/0x53a4d1E6ab184389D3581085AB73CD3549B20d1a#code"
+    },
     "hookFactory": {
-      "address": "0xD405D8d88D7E4Dae4e1dAdce9A458234D9A5fd67",
-      "transactionHash": "0xed9c5627991c6f84334415737e6a0937c614c2630a80cbf0eba8f07621d4c417",
-      "runtimeCodeHash": "0x8dd7205952dba3efad6f58a4b0193171c4ed825145319c908bc47dab1911c128",
-      "etherscan": "https://etherscan.io/address/0xD405D8d88D7E4Dae4e1dAdce9A458234D9A5fd67#code"
+      "address": "0x61c616E98F9f71bFe813FE4359D012de2Ae70770",
+      "transactionHash": "0xf8c0ee6cc0bbc11bc8f8d081b9f4c67be99b4ce12b2967c0353660a2263a1ad4",
+      "runtimeCodeHash": "0x068ef58aed42a9772bd63614d535071627ff2812001b884cf936816bff8ce163",
+      "etherscan": "https://etherscan.io/address/0x61c616E98F9f71bFe813FE4359D012de2Ae70770#code"
     },
     "feeHook": {
-      "address": "0x025a386eAa79f6067d29848FD05ccC71bEAb20CC",
-      "transactionHash": "0xf1d91138194f59b9067c6563ee1127e0527a87e90bb311b71d7eccb797822b7c",
-      "runtimeCodeHash": "0x274e29fb8d19f0607533ac7582827db0236ab546bb393d52049229b2ffe74381",
-      "etherscan": "https://etherscan.io/address/0x025a386eAa79f6067d29848FD05ccC71bEAb20CC#code"
+      "address": "0x35Fe236EA82F7cF525c9719d7df8F49F94D720CC",
+      "transactionHash": "0x402b3a5d7ace6d6a296bc9fdb461cf79ae56e197d7d4e5baf8544de19a5c49da",
+      "runtimeCodeHash": "0x3eba781023d3146ed9b502ac5b402d39cea4c34a14f64c878cb9ea62149590f1",
+      "etherscan": "https://etherscan.io/address/0x35Fe236EA82F7cF525c9719d7df8F49F94D720CC#code"
     },
     "launcher": {
-      "address": "0xD240D06f8586eB799f20056054e5b527405E6bAd",
-      "transactionHash": "0x86a6f1b3992ed8ad6d450970b78e94b29f298afd048a6a0cfa0cf253e9e98fdc",
-      "runtimeCodeHash": "0xd229555c79c61874549a1991c43df172104e1db3087ba8fca8804675b7440d36",
-      "etherscan": "https://etherscan.io/address/0xD240D06f8586eB799f20056054e5b527405E6bAd#code"
+      "address": "0xC3bd04aAc2fb2ba58efD7Eb673E544E0B80De770",
+      "transactionHash": "0xc25f6a3b13b0789b4f69e28229b0b969184dbc3682555ea7e15bf731f5b1a150",
+      "runtimeCodeHash": "0x9cc9723456c471d90ac838c02fa4fc47ed4b7e82c85358e71deec978c48d2dc8",
+      "etherscan": "https://etherscan.io/address/0xC3bd04aAc2fb2ba58efD7Eb673E544E0B80De770#code"
     },
     "positionForwarderFactory": {
       "address": "0x291a9ff1059d225d02B1659430804486404dB507",
@@ -33,6 +57,8 @@
   "sourceVerification": {
     "sourcify": "match",
     "etherscan": "exact-match",
-    "checkedAt": "2026-07-27T17:59:01Z"
+    "releaseContractCount": 7,
+    "scope": "Programmable release contracts; the position forwarder factory is a pinned official dependency",
+    "checkedAt": "2026-07-29T16:27:29Z"
   }
 }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -10,7 +10,7 @@ the interface, but cannot rewrite deployed behavior or remove locked liquidity.
 | Repository verification | Every pull request and push to `main` | Formatting, build, tests, registry and gas snapshot |
 | Security workflow | Every pull request and push to `main` | Slither, coverage floor and workflow lint |
 | Code scanning | Every push to `main` | Publishes Slither SARIF results in GitHub Security |
-| Ethereum evidence | Every release pull request, daily and on demand | Runtime hashes match Ethereum and candidate lifecycle tests pass on a Mainnet fork |
+| Ethereum evidence | Every release pull request, daily and on demand | Runtime hashes match Ethereum and the official-contract lifecycle passes on a Mainnet fork |
 
 A failed public RPC request can also fail the Ethereum evidence workflow. Investigate provider availability before
 interpreting a failure as a contract change.

--- a/docs/security/CLASSIC_PROPERTIES.md
+++ b/docs/security/CLASSIC_PROPERTIES.md
@@ -1,71 +1,87 @@
 # Classic security properties
 
-This document maps the intended Classic properties to the contracts and tests that exercise them. It is a review aid,
-not an audit report.
+This document maps the intended `classic-v3` properties to the contracts and tests that exercise them. It is a review
+aid, not an audit report.
 
 ## Trust boundaries
 
 ```mermaid
 flowchart LR
-    creator["Token creator"] -->|"launch + initial ETH buy"| launcher["MemeLaunchV1"]
-    launcher --> factory["UERC20Factory"]
+    creator["Token creator"] -->|"launch + initial buy"| launcher["MemeLaunchV2"]
     launcher --> manager["Uniswap v4 PoolManager"]
-    launcher --> position["PositionManager"]
-    launcher --> lock["PositionFeesForwarder<br/>no operator · maximum timelock"]
-    trader["Trader or router"] --> manager
-    manager -->|"v4 callbacks only"| hook["EthCreatorFeeHookV2"]
-    hook -->|"fixed creator claim"| creator
-    hook -->|"fixed platform claim"| treasury["Programmable treasury"]
-    position --> lock
+    launcher --> position["Permanent position custody"]
+    manager -->|"v4 callbacks only"| hook["EthCreatorFeeHookV3"]
+    hook --> vault["ClassicRewardVaultV1"]
+    vault --> beneficiaries["Current beneficiaries"]
+    hook --> treasury["Programmable treasury"]
+    cto["CTO authority"] -->|"future rewards only"| vault
+    creator --> custody["Optional initial-buy custody"]
 ```
 
-The launcher, hook and factories are non-upgradeable. None exposes an owner, administrator, pause function or parameter
-setter. The external Uniswap and UERC20 contracts are pinned dependencies and remain separate trust assumptions.
+The launcher, hook, policy, factories and vault implementations are non-upgradeable. The fee hook and launcher expose
+no owner, pause function, fee setter, blacklist or mint path.
+
+`ClassicCtoAuthorityV1` is the one administrative trust boundary. Its current authority can replace a reward vault's
+future beneficiary configuration. The vault checkpoints accrued ETH first, so the authority cannot redirect historic
+rewards, alter buy or sell fees, change supply, pause trading or remove launch liquidity.
 
 ## State and authorization
 
-Slither's function and state-write printers were used to review the public write paths. The relevant authorization
-rules are:
-
-| Action | Authorized caller | Destination control |
+| Action | Authorized caller | Effect |
 | --- | --- | --- |
-| Register a pool | Creator recorded by the launched token | Creator and fee are fixed |
-| Enter a hook callback | Uniswap v4 `PoolManager` | Pool shape and registration are checked |
-| Trigger a creator claim | Anyone | Payment goes only to the recorded creator |
-| Redirect a creator claim | Recorded creator | Creator selects the replacement destination |
-| Trigger a platform claim | Anyone | Payment goes only to the immutable treasury |
-| Redirect a platform claim | Immutable treasury | Treasury selects the replacement destination |
+| Launch | Any wallet that supplies the minimum initial buy | Creates one token, pool, vault and locked position |
+| Register a pool | The recorded token creator, the launcher | Stores immutable buy fee, sell fee and reward vault |
+| Enter hook callbacks | Uniswap v4 `PoolManager` | Applies the registered directional fee |
+| Claim creator rewards | Current or historic beneficiary | Pays only rewards owned by the caller |
+| Change one payout wallet | Current wallet for that allocation | Moves only future accrual to the new wallet |
+| Replace future reward configuration | Current CTO authority | Checkpoints first, then activates the new split |
+| Transfer CTO authority | Current authority proposes; new authority accepts | Two-step authority transfer |
+| Claim Programmable rewards | Immutable treasury | Pays the treasury or its selected claim destination |
+| Release custodied initial-buy tokens | Immutable launch-wallet beneficiary | Releases only according to the launch schedule |
 | Remove or transfer launch liquidity | No configured actor | Position forwarder has no operator and maximum timelock |
 
-## Accounting
+## Fee accounting
 
-For gross native ETH amount `x`, total fee rate `t` and fixed Programmable rate `p`:
+For gross native ETH amount `x`, directional fee rate `t` and fixed Programmable rate `p`:
 
 ```text
-totalFee    = floor(x × t / 10,000)
-platformFee = floor(x × p / 10,000)
-creatorFee  = totalFee - platformFee
+totalFee       = floor(x × t / 10,000)
+programmable   = floor(x × p / 10,000)
+creatorRewards = totalFee - programmable
 ```
 
+`p` is always `10` basis points. `t` is set independently for buys and sells from `100` to `1000` basis points in
+`100`-basis-point steps. The Programmable share is deducted from the selected total and is never added on top.
+
 For exact native output, the hook rounds the gross amount up before applying the split so the requested net amount is
-preserved. The implementation uses Uniswap `FullMath` and OpenZeppelin `SafeCast`. Unsupported partial fills revert
-instead of leaving fee accounting ambiguous.
+preserved. Unsupported partial fills revert instead of leaving fee accounting ambiguous.
+
+## Reward checkpoints
+
+The reward vault pulls all newly accrued creator fees before a payout-wallet or CTO configuration change:
+
+- ETH received before a beneficiary changes its wallet remains claimable by the previous wallet;
+- ETH received after the change follows the new wallet;
+- a CTO cannot take historic rewards from the prior configuration;
+- active shares are positive, unique and total `100%`; and
+- deterministic division remainders go to the final active beneficiary.
 
 ## Invariants and evidence
 
 | Property | Primary evidence |
 | --- | --- |
-| Pool fee configuration never changes | `invariant_poolFeeConfigurationNeverChanges` |
-| Public fee disclosure never changes | `invariant_publicFeeDisclosureNeverChanges` |
-| Native claims cover internal accounting | `invariant_nativeClaimsAlwaysCoverInternalAccounting` |
-| Fees do not remain as loose hook balances | `invariant_feesNeverAccumulateAsLooseHookBalances` |
-| Hook callback mask remains exact | `invariant_callbackMaskRemainsExact` |
-| Unauthorized claims cannot redirect funds | `test_unregisteredPoolCannotBeClaimedAndPermissionlessClaimCannotRedirect` |
-| Creator claim reentrancy is blocked | `test_creatorClaimBlocksReceiveReentrancyWithoutBlockingPayout` |
-| Complete supply enters permanent custody | `test_exactSupplyIsAccountedForInOneSidedPermanentlyCustodiedPosition` |
+| Directional fee economics never change | `invariant_directionalEconomicsNeverChange` |
+| Native claims exactly cover accrued accounting | `invariant_nativeClaimsExactlyCoverAccruedAccounting` |
+| Reward configuration and dependencies remain bound | `invariant_rewardConfigurationNeverChanges` |
+| Claim and payout accounting is conserved | `invariant_claimAndPayoutAccountingIsConserved` |
+| Hook callback mask and loose balances remain exact | `invariant_callbackMaskAndLooseBalancesRemainExact` |
+| All reward-vault ETH remains claimable or claimed | `invariant_allReceivedEthIsClaimableOrAlreadyClaimed` |
+| Active reward shares always total `100%` | `invariant_activeSharesAlwaysTotalOneHundredPercent` |
+| CTO and vault dependencies never change | `invariant_ctoAuthorityAndVaultDependenciesNeverChange` |
+| Full official-contract lifecycle works on a Mainnet fork | `test_fullLifecycleUsesOfficialMainnetContractsAndBeneficiaryOwnedClaims` |
 
-The complete suites are in [`test/`](../../test/). CI runs unit, integration, fuzz, invariant, regression, static-analysis
-and coverage checks.
+The complete suites are in [`test/`](../../test/). CI separates deterministic unit, fuzz and invariant tests from the
+network-backed Mainnet-fork evidence.
 
 ## Ordering and MEV
 
@@ -73,14 +89,16 @@ Token creation, pool initialization, permanent position custody and the creator'
 No third party can trade against an uninitialized Classic pool between those steps.
 
 The launch transaction can still be observed, delayed, censored or reordered before inclusion. Once launched, swaps
-have the normal ordering and sandwich risks of public AMM trading. Slippage limits, deadlines and transaction routing
-belong to the router or calling interface; the hook does not claim to prevent MEV.
+have the normal ordering and sandwich risks of a public AMM. Slippage limits, deadlines and routing belong to the
+router or calling interface; the hook does not claim to prevent MEV.
 
-Classic uses no oracle. A future model that depends on price observations needs its own oracle and ordering analysis.
+Classic uses no oracle.
 
 ## Manual review boundaries
 
-- Token metadata and project links are public and should never contain secrets.
+- A compromised CTO authority can replace future creator-reward recipients after checkpointing.
+- The lack of pause and upgrade paths removes administrative recovery as well as upgrade risk.
+- A beneficiary contract that rejects native ETH can block only its own claim transaction.
 - Contract addresses must be read from the release manifest rather than inferred from the interface.
-- A broken RPC, indexer or metadata service can affect visibility without changing onchain contract behavior.
-- The absence of upgrade and pause authority removes administrative control and also removes administrative recovery.
+- A broken RPC, indexer or metadata service can affect visibility without changing onchain behavior.
+- Permanent lock properties depend on the pinned forwarder and PositionManager semantics.

--- a/models/classic/README.md
+++ b/models/classic/README.md
@@ -4,12 +4,12 @@
 **Network:** Ethereum<br>
 **Pair:** Native ETH
 
-Classic launches a fixed-supply token, initializes its Uniswap v4 pool, locks the launch position and completes the
-creator's initial buy in one transaction.
+Classic launches a fixed-supply token, initializes its Uniswap v4 pool, permanently locks the launch position and
+completes the creator's initial buy in one transaction.
 
 [Launch Classic](https://programmable.family) ·
 [Model manifest](model.json) ·
-[Release record](../../releases/classic-v2/RELEASE.md) ·
+[Release record](../../releases/classic-v3/RELEASE.md) ·
 [Deployment record](../../deployments/ethereum.json) ·
 [Security properties](../../docs/security/CLASSIC_PROPERTIES.md)
 
@@ -20,37 +20,71 @@ flowchart LR
     creator["Creator"] -->|"launch + initial buy"| launcher["Classic launcher"]
     launcher --> token["Fixed-supply token"]
     launcher --> pool["Uniswap v4 pool"]
-    launcher --> position["Locked one-sided position"]
-    pool <--> hook["Creator fee hook"]
-    hook -->|"claim ETH"| creator
-    hook -->|"claim ETH"| treasury["Programmable"]
+    launcher --> position["Permanently locked position"]
+    pool <--> hook["Directional fee hook"]
+    hook --> vault["Creator reward vault"]
+    vault --> beneficiaries["1–5 beneficiaries"]
+    hook --> treasury["Programmable"]
 ```
 
 The launcher:
 
 1. creates a one-billion-token UERC20;
-2. registers and initializes its native ETH pool;
-3. places the complete token supply into a one-sided position;
-4. sends the position to a forwarder with no operator and a maximum timelock; and
-5. executes the creator's initial buy.
+2. registers separate immutable buy and sell fees;
+3. initializes the native ETH pool;
+4. places the complete token supply into a one-sided position;
+5. sends the position to a forwarder with no operator and a maximum timelock; and
+6. executes the creator's initial buy.
 
 The initial buy must be at least `0.0006 ETH`. There is no separate ETH liquidity deposit.
 
 ## Fees
 
-| Fee | Current launch setting |
+| Setting | Value |
 | --- | --- |
-| Total swap fee | `1.00%` |
-| Creator share | `0.90%` |
-| Programmable share | `0.10%` |
+| Buy fee | `1%` to `10%`, selected at launch |
+| Sell fee | `1%` to `10%`, selected separately at launch |
+| Programmable share | `0.10` percentage points |
+| Creator share | Selected directional fee minus `0.10` percentage points |
 | Token transfer tax | None |
 | Uniswap v4 LP fee | Zero |
 
-The fee is collected in native ETH on both buys and sells. Creator and Programmable claims are recorded separately in
-`PoolManager`, and each claim has an immutable recipient.
+Fees are collected in native ETH. The Programmable share is deducted from the selected buy or sell fee, never added on
+top. Fee rates cannot change after launch.
 
-The deployed hook accepts total fee configurations from `1%` to `10%` in one-point increments. Programmable currently
-launches Classic at `1%`.
+## Creator rewards
+
+Creator rewards can go to:
+
+- the launch wallet;
+- one external wallet; or
+- a fixed percentage split across two to five wallets.
+
+Shares must total `100%`. Each active beneficiary alone can claim its rewards. A beneficiary may replace its own payout
+wallet without approval from the new wallet. The vault checkpoints first, so ETH earned before the change remains
+claimable by the previous wallet and only future rewards move.
+
+### Community Takeover authority
+
+The disclosed CTO authority may replace the complete reward configuration for future rewards. The vault checkpoints
+all accrued ETH before the change, so the authority cannot move rewards already earned by prior beneficiaries. The
+authority itself can move only through a two-step transfer.
+
+This is a deliberate administrative trust boundary. It exists for approved Community Takeovers and does not control
+token supply, fee rates, trading or launch liquidity.
+
+## Initial-buy custody
+
+The launch wallet chooses one immutable custody schedule:
+
+| Mode | Behavior |
+| --- | --- |
+| Unlocked | Initial-buy tokens go directly to the launch wallet |
+| Fixed lock | All tokens release after the selected date |
+| Linear vesting | Tokens vest continuously from launch to the final date |
+| Cliff plus linear | Vesting starts after the cliff and completes on the final date |
+
+Scheduled custody supports durations from `1` to `3650` days. The launch-wallet beneficiary cannot be replaced.
 
 ## Liquidity custody
 
@@ -69,30 +103,34 @@ come from the hook rather than from removing or selling launch liquidity.
 
 ## Deployed contracts
 
-Technical contract names are retained because they identify the verified immutable source.
+Technical names identify the verified immutable release.
 
 | Contract | Address |
 | --- | --- |
-| `MemeLaunchV1` | [`0xD240…E6bAd`](https://etherscan.io/address/0xD240D06f8586eB799f20056054e5b527405E6bAd#code) |
-| `EthCreatorFeeHookV2` | [`0x025a…b20CC`](https://etherscan.io/address/0x025a386eAa79f6067d29848FD05ccC71bEAb20CC#code) |
-| `EthCreatorFeeHookFactoryV2` | [`0xD405…5fd67`](https://etherscan.io/address/0xD405D8d88D7E4Dae4e1dAdce9A458234D9A5fd67#code) |
+| `MemeLaunchV2` | [`0xC3bd…De770`](https://etherscan.io/address/0xC3bd04aAc2fb2ba58efD7Eb673E544E0B80De770#code) |
+| `EthCreatorFeeHookV3` | [`0x35Fe…720CC`](https://etherscan.io/address/0x35Fe236EA82F7cF525c9719d7df8F49F94D720CC#code) |
+| `EthCreatorFeeHookFactoryV3` | [`0x61c6…70770`](https://etherscan.io/address/0x61c616E98F9f71bFe813FE4359D012de2Ae70770#code) |
+| `ClassicRewardVaultFactoryV1` | [`0xF289…eab2a`](https://etherscan.io/address/0xF28967f9DFaC3Ca21384b59D6D75C8106b3eab2a#code) |
+| `ClassicInitialBuyVestingWalletFactoryV1` | [`0xDe21…C66f4`](https://etherscan.io/address/0xDe21b9c0Cc0AfDB9be20e8236113f066BB8C66f4#code) |
+| `ClassicLaunchPolicyV1` | [`0x53a4…20d1a`](https://etherscan.io/address/0x53a4d1E6ab184389D3581085AB73CD3549B20d1a#code) |
+| `ClassicCtoAuthorityV1` | [`0x9746…18c0C`](https://etherscan.io/address/0x9746469Cd79fdDc5aA7218e7dd51c829ee518c0C#code) |
 | `LockedPositionFeeForwarderFactoryV1` | [`0x291a…4dB507`](https://etherscan.io/address/0x291a9ff1059d225d02B1659430804486404dB507#code) |
 
-Transactions and runtime code hashes are recorded in
-[`deployments/ethereum.json`](../../deployments/ethereum.json). Contract parameters are recorded in the
-[Classic specification](../../spec/classic-v2.json).
+Transactions, runtime hashes and source-verification records are in
+[`deployments/ethereum.json`](../../deployments/ethereum.json). The full deployment and lifecycle record is in
+[`releases/classic-v3/mainnet-manifest.json`](../../releases/classic-v3/mainnet-manifest.json).
 
 ## Source and tests
 
 | Area | Path |
 | --- | --- |
-| Launcher | [`src/MemeLaunchV1.sol`](../../src/MemeLaunchV1.sol) |
-| Fee hook | [`src/EthCreatorFeeHookV2.sol`](../../src/EthCreatorFeeHookV2.sol) |
-| Hook factory | [`src/EthCreatorFeeHookFactoryV2.sol`](../../src/EthCreatorFeeHookFactoryV2.sol) |
-| Position custody | [`src/LockedPositionFeeForwarderFactoryV1.sol`](../../src/LockedPositionFeeForwarderFactoryV1.sol) |
+| Launcher | [`src/MemeLaunchV2.sol`](../../src/MemeLaunchV2.sol) |
+| Fee hook | [`src/EthCreatorFeeHookV3.sol`](../../src/EthCreatorFeeHookV3.sol) |
+| Reward vault | [`src/ClassicRewardVaultV1.sol`](../../src/ClassicRewardVaultV1.sol) |
+| Initial-buy custody | [`src/ClassicInitialBuyVestingWalletV1.sol`](../../src/ClassicInitialBuyVestingWalletV1.sol) |
+| CTO authority | [`src/ClassicCtoAuthorityV1.sol`](../../src/ClassicCtoAuthorityV1.sol) |
 | Tests | [`test/`](../../test/) |
 
-Classic has unit, integration, fuzz, invariant and regression coverage. It has not received an independent
+Classic has unit, integration, fuzz, invariant and Mainnet-fork coverage. It has not received an independent
 smart-contract audit or public security contest. The full trust model and known limitations are in
-[`SECURITY.md`](../../SECURITY.md), with the property-to-test map in
-[`docs/security/CLASSIC_PROPERTIES.md`](../../docs/security/CLASSIC_PROPERTIES.md).
+[`SECURITY.md`](../../SECURITY.md).

--- a/models/classic/model.json
+++ b/models/classic/model.json
@@ -4,11 +4,11 @@
   "id": "classic",
   "name": "Classic",
   "status": "available",
-  "summary": "A fixed-supply token with a native ETH Uniswap v4 pool, permanently locked launch liquidity and disclosed ETH-denominated swap fees.",
+  "summary": "A fixed-supply token with independent buy and sell fees, beneficiary-owned ETH rewards, optional initial-buy custody and permanently locked Uniswap v4 liquidity.",
   "documentation": "models/classic/README.md",
-  "currentRelease": "classic-v2",
-  "releaseManifest": "releases/classic-v2/manifest.json",
-  "specification": "spec/classic-v2.json",
+  "currentRelease": "classic-v3",
+  "releaseManifest": "releases/classic-v3/manifest.json",
+  "specification": "spec/classic-v3.json",
   "deployment": "deployments/ethereum.json",
   "security": "SECURITY.md",
   "network": {
@@ -17,19 +17,39 @@
   },
   "contracts": [
     {
-      "deploymentKey": "launcher",
-      "name": "MemeLaunchV1",
-      "address": "0xD240D06f8586eB799f20056054e5b527405E6bAd"
+      "deploymentKey": "ctoAuthority",
+      "name": "ClassicCtoAuthorityV1",
+      "address": "0x9746469Cd79fdDc5aA7218e7dd51c829ee518c0C"
     },
     {
-      "deploymentKey": "feeHook",
-      "name": "EthCreatorFeeHookV2",
-      "address": "0x025a386eAa79f6067d29848FD05ccC71bEAb20CC"
+      "deploymentKey": "rewardVaultFactory",
+      "name": "ClassicRewardVaultFactoryV1",
+      "address": "0xF28967f9DFaC3Ca21384b59D6D75C8106b3eab2a"
+    },
+    {
+      "deploymentKey": "initialBuyVestingWalletFactory",
+      "name": "ClassicInitialBuyVestingWalletFactoryV1",
+      "address": "0xDe21b9c0Cc0AfDB9be20e8236113f066BB8C66f4"
+    },
+    {
+      "deploymentKey": "launchPolicy",
+      "name": "ClassicLaunchPolicyV1",
+      "address": "0x53a4d1E6ab184389D3581085AB73CD3549B20d1a"
     },
     {
       "deploymentKey": "hookFactory",
-      "name": "EthCreatorFeeHookFactoryV2",
-      "address": "0xD405D8d88D7E4Dae4e1dAdce9A458234D9A5fd67"
+      "name": "EthCreatorFeeHookFactoryV3",
+      "address": "0x61c616E98F9f71bFe813FE4359D012de2Ae70770"
+    },
+    {
+      "deploymentKey": "feeHook",
+      "name": "EthCreatorFeeHookV3",
+      "address": "0x35Fe236EA82F7cF525c9719d7df8F49F94D720CC"
+    },
+    {
+      "deploymentKey": "launcher",
+      "name": "MemeLaunchV2",
+      "address": "0xC3bd04aAc2fb2ba58efD7Eb673E544E0B80De770"
     },
     {
       "deploymentKey": "positionForwarderFactory",

--- a/models/registry.json
+++ b/models/registry.json
@@ -13,7 +13,7 @@
       "id": "classic",
       "name": "Classic",
       "status": "available",
-      "summary": "A fixed-supply token with a native ETH Uniswap v4 pool, permanently locked launch liquidity and disclosed ETH-denominated swap fees.",
+      "summary": "A fixed-supply token with independent buy and sell fees, beneficiary-owned ETH rewards, optional initial-buy custody and permanently locked Uniswap v4 liquidity.",
       "manifest": "models/classic/model.json",
       "documentation": "models/classic/README.md"
     },

--- a/releases/classic-v2/RELEASE.md
+++ b/releases/classic-v2/RELEASE.md
@@ -1,6 +1,7 @@
 # Classic Ethereum release
 
-`classic-v2` is the current immutable Classic contract release used by the Programmable interface on Ethereum.
+`classic-v2` is a historical immutable Classic contract release. New Classic launches use
+[`classic-v3`](../classic-v3/RELEASE.md).
 
 ## Evidence
 

--- a/releases/classic-v3/RELEASE.md
+++ b/releases/classic-v3/RELEASE.md
@@ -1,0 +1,35 @@
+# Classic Ethereum release
+
+`classic-v3` is the immutable Classic contract release used by the Programmable interface on Ethereum.
+
+## What changed
+
+- Buy and sell fees are configured independently from `1%` to `10%`.
+- The fixed Programmable share remains `0.10` percentage points and is deducted from the selected fee.
+- Creator rewards can use the launch wallet, one external wallet or an immutable split across as many as five wallets.
+- Each active beneficiary controls its own claim and may redirect only its future reward share.
+- The initial buy can remain unlocked or use a fixed lock, linear vesting or cliff-plus-linear vesting.
+- A disclosed Community Takeover authority can replace only the future reward configuration after accrued rewards are
+  checkpointed.
+
+Technical release names identify immutable deployments. The launch model remains **Classic** in the interface.
+
+## Evidence
+
+| Record | Source |
+| --- | --- |
+| Fixed parameters | [`spec/classic-v3.json`](../../spec/classic-v3.json) |
+| Ethereum deployment | [`deployments/ethereum.json`](../../deployments/ethereum.json) |
+| Full Mainnet evidence | [`mainnet-manifest.json`](mainnet-manifest.json) |
+| Machine-readable release | [`manifest.json`](manifest.json) |
+| SHA-256 checksums | [`SHA256SUMS`](SHA256SUMS) |
+| Security properties | [`SECURITY.md`](../../SECURITY.md) |
+| Model behavior | [`models/classic/README.md`](../../models/classic/README.md) |
+
+All seven release contracts are Etherscan exact matches and Sourcify matches. The recorded Mainnet lifecycle covers the
+launch, a buy, token and router approvals, a sell, a creator claim and a Programmable claim.
+
+## Review status
+
+The release has unit, integration, fuzz, invariant, regression and Mainnet-fork coverage. It has not received an
+independent smart-contract audit or public security contest.

--- a/releases/classic-v3/SHA256SUMS
+++ b/releases/classic-v3/SHA256SUMS
@@ -1,0 +1,4 @@
+ecd0cfbd408359745baa8bcc3cf64da77f4cb448014091e60b1183121bbaaa1c  deployments/ethereum.json
+78bbd80666a5de0a372094d8652bddd70f464c09d21ed3b850f37598e6a251f7  releases/classic-v3/manifest.json
+645e2acebb7853ba4e2611a88e291a7908ecefd0262b2c632871606225a1fc02  spec/classic-v3.json
+0e89840aeedddbd28b3e5160debd336afefbb15b1a78e388aa15b2c8eeefbebf  releases/classic-v3/mainnet-manifest.json

--- a/releases/classic-v3/manifest.json
+++ b/releases/classic-v3/manifest.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../../models/schema/release.schema.json",
+  "schemaVersion": 1,
+  "release": "classic-v3",
+  "model": "classic",
+  "status": "available",
+  "network": {
+    "name": "Ethereum",
+    "chainId": 1
+  },
+  "sourcePublicationCommit": "ae5e757c0249e2efe494580bd9c255a0de7a77c3",
+  "compiler": {
+    "solc": "0.8.26",
+    "evmVersion": "cancun",
+    "optimizerRuns": 1000
+  },
+  "evidence": {
+    "specification": "spec/classic-v3.json",
+    "deployment": "deployments/ethereum.json",
+    "security": "SECURITY.md",
+    "tests": [
+      "test/ClassicLaunchPolicyV1.t.sol",
+      "test/ClassicInitialBuyVestingWalletV1.t.sol",
+      "test/ClassicRewardVaultV1.t.sol",
+      "test/EthCreatorFeeHookV3.t.sol",
+      "test/MemeLaunchV2.t.sol",
+      "test/invariant/ClassicRewardVaultV1Invariant.t.sol",
+      "test/invariant/ClassicV3FeeAccountingInvariant.t.sol",
+      "test/ClassicV3MainnetFork.t.sol"
+    ]
+  },
+  "review": {
+    "independentAudit": false,
+    "publicContest": false,
+    "sourceVerification": "Etherscan exact match and Sourcify match for all seven release contracts"
+  }
+}


### PR DESCRIPTION
This marks the verified Classic Ethereum deployment as the current available release.

The activation is bound to public source commit ae5e757c0249e2efe494580bd9c255a0de7a77c3. It updates the model registry, deployment record, security properties and release evidence without changing deployed bytecode.

Verified before publication:

- 120 deterministic Foundry tests
- 1 complete Mainnet-fork lifecycle test
- 8 recorded runtime code hashes matched Ethereum
- model registry, release evidence, documentation links and SHA-256 checksums
- formatting, build sizes and gas snapshot

All seven Programmable release contracts are Etherscan exact matches and Sourcify matches. No independent audit or public security contest is claimed.