### PR TITLE
Define production branch workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /outputs/qa/
 /artifacts/
 /.codex-temp-programmable-readme-gif/
+/.worktrees/
 *.tsbuildinfo
 
 # Local publishing masters and article drafts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Programmable workspace rules
+
+## Canonical repository
+
+- The public product repository is `https://github.com/0xprogrammable/programmable`.
+- `production` is the canonical full-product branch and the only branch used for website production releases.
+- `main` remains the public contracts and release-evidence branch. Never deploy the website from `main`.
+- Confirm the destination remote before every push. Do not assume that a remote named `origin` is canonical.
+- Preserve unrelated local changes. Never clean, reset, or overwrite a dirty worktree to simplify a task.
+
+## Parallel work
+
+- Every parallel workstream uses its own Git worktree and `codex/` branch.
+- Assign explicit path ownership before implementation. Two active workstreams must not edit the same files.
+- Feature worktrees may produce local or preview builds. They must not deploy production.
+- Only the integration owner may combine workstreams, run the complete release gate, and publish after explicit authorization.
+- Product branches target `production`. Contract-only evidence may target `main` only when the task explicitly says so.
+- Handoffs must include the branch, commit, changed paths, checks run, and remaining release blockers.
+
+## Path ownership
+
+- Web product: `app/`, `components/`, browser-facing files in `lib/`, and referenced assets in `public/`.
+- Contracts: `contracts/src/`, `contracts/test/`, `contracts/script/`, `contracts/spec/`, and `contracts/security/`.
+- Operations: `ops/` and narrowly assigned operational scripts.
+- Shared integration: `config/`, shared onchain readers in `lib/onchain/`, release manifests, and deployment bindings. These require an integration-owner review.
+- Documentation and brand assets: `docs/`, `README.md`, `public/brand/`, and `public/og/`.
+
+## Release discipline
+
+- `tested`, `deployed`, `source verified`, `lifecycle verified`, and `available` are separate states.
+- Do not describe a model as live from a build, simulation, fork test, source match, or UI implementation alone.
+- Production activation requires exact deployment evidence, runtime checks, provider-backed lifecycle verification, monitoring, and a clean integration build.
+- Production deploys must use a clean integration worktree at the exact reviewed `production` commit.
+- Never expose secrets, private keys, personal identities, or local environment files in commits, logs, screenshots, or public artifacts.
+
+See [docs/PROJECT-STRUCTURE.md](docs/PROJECT-STRUCTURE.md) for the directory map.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ npm run contracts:sepolia:validate
 
 Key references:
 
+- [`docs/PROJECT-STRUCTURE.md`](./docs/PROJECT-STRUCTURE.md)
 - [`docs/uniswap-source-provenance.md`](./docs/uniswap-source-provenance.md)
 - [`contracts/security/MAINNET-READINESS.md`](./contracts/security/MAINNET-READINESS.md)
 - [`contracts/security/CLASSIC-V3.md`](./contracts/security/CLASSIC-V3.md)

--- a/docs/PROJECT-STRUCTURE.md
+++ b/docs/PROJECT-STRUCTURE.md
@@ -1,0 +1,42 @@
+# Project structure
+
+Programmable is one repository with three product layers: the web application, the contract workspace, and release tooling.
+
+```text
+Programmable/
+├── app/          Next.js routes, pages, and API handlers
+├── components/   Shared interface components
+├── lib/          Product logic, onchain readers, and integrations
+├── public/       Runtime web assets, brand files, and social previews
+├── contracts/    Foundry contracts, tests, scripts, specifications, and evidence
+├── config/       Shared application configuration
+├── scripts/      Development, verification, and release utilities
+├── tests/        Application and integration tests
+├── docs/         Maintained product, security, and operations documentation
+├── outputs/      Research reports and ignored QA output
+├── artifacts/    Ignored local publishing masters
+├── work/         Ignored research checkouts
+└── tmp/          Ignored temporary evidence and local captures
+```
+
+## Source directories
+
+`app/`, `components/`, `lib/`, `contracts/`, `config/`, `scripts/`, `tests/`, `docs/`, and referenced files in `public/` are product source. Changes in these paths belong in a scoped branch and must pass their relevant checks.
+
+## Branch model
+
+- `production` contains the complete reviewed product and is the only source for website production releases.
+- `main` contains the public contract and release-evidence history. It is not a website deployment source.
+- `codex/*` branches contain one scoped workstream and merge through a pull request.
+
+New product work starts from `production` unless a contract-only task explicitly targets `main`. Production is never deployed from a feature branch or a dirty worktree.
+
+## Local generated directories
+
+`node_modules/`, `.next/`, `contracts/out/`, `contracts/cache/`, `artifacts/`, `outputs/qa/`, `work/`, and most of `tmp/` are local or generated. Do not commit them unless a release specification explicitly requires a particular evidence file.
+
+Some files under `tmp/` and `contracts/broadcast/` may contain deployment evidence. Inspect them before cleanup. Never treat those directories as disposable without checking their contents.
+
+## Worktree convention
+
+Parallel tasks use separate worktrees. Use responsibility-based names such as `programmable-web`, `programmable-classic`, or `programmable-integrations`. A feature task owns only its assigned paths. The `production` integration worktree is the sole place where completed branches are combined, verified, and prepared for release.


### PR DESCRIPTION
Defines the repository workflow used for website releases.

The new `production` branch is the only source for production website deployments. Product work uses scoped `codex/*` branches and separate worktrees, then merges through a pull request. The public `main` branch remains the contracts and release-evidence history.

This also records path ownership, release-state terminology, and the rule that production deploys must come from a clean integration worktree at the exact reviewed commit.

Checks:

- `git diff --check`
- staged Gitleaks scan
