### PR TITLE
Hide unreleased Deep model

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ The current public launch flow creates a fixed supply of 1,000,000,000 tokens th
 - The complete launch allocation enters one permanently locked, one-sided Uniswap v4 position
 - Launching has no protocol fee or liquidity deposit
 - The creator makes an initial buy of at least 0.0006 ETH and pays Ethereum gas
-- The public interface currently uses a fixed 1.00% swap fee
-- The creator receives 0.90% and Programmable receives 0.10%
+- Buy and sell fees are set separately from 1% to 10% in whole percentage points
+- Programmable receives 0.10%; the remainder goes to the configured creator-reward recipients
+- Creator rewards can go to one wallet or a fixed split of up to five wallets
+- Initial Buy tokens can remain unlocked, use a fixed lock, vest linearly or vest after a cliff
 - The fee applies only in the canonical hooked pool, not to ordinary ERC-20 transfers
 
 The 0.10% Programmable share is deducted from the selected swap fee. It is not added on top.
@@ -66,7 +68,7 @@ The public read model pairs canonical launch events, ignores unrecognized shared
 
 ## Release status
 
-The active Classic deployment is recorded in [`contracts/deployments/mainnet-classic-v2.json`](./contracts/deployments/mainnet-classic-v2.json). Its deployment receipts, constructor configuration, runtime code hashes and signed launch, buy, sell and claim lifecycle have been reconciled through two RPC providers. The deployed contracts have exact source matches on Etherscan and Sourcify.
+The active Classic deployment is recorded in [`contracts/deployments/mainnet-classic-v3.json`](./contracts/deployments/mainnet-classic-v3.json). Its deployment receipts, constructor configuration, runtime code hashes and signed launch, buy, sell and claim lifecycle have been reconciled through two RPC providers. The deployed contracts have exact source matches on Etherscan and Sourcify.
 
 The V1 and V2 Stock-Paired deployments remain immutable historical releases.
 Their public indexer records preserve the quote asset, v4 pool ordering, hook,

--- a/app/docs/models/[model]/page.tsx
+++ b/app/docs/models/[model]/page.tsx
@@ -5,12 +5,10 @@ import { ExternalLink } from "lucide-react";
 import { DocsShell } from "@/components/docs-shell";
 import styles from "@/components/docs-experience.module.css";
 
-type ModelSlug = "classic" | "deep" | "stock-paired";
+type ModelSlug = "classic" | "stock-paired";
 
 const classicEvidenceCommit =
   "1fb9558af4f0248de75d5c7983f80036e32f47cb";
-const deepSourceCommit =
-  "db4599b7e3280c381a500c6f738ec2a2c244ca35";
 const stockPairedEvidenceCommit =
   "ef2bbb51336a20aa2886dad0232f61495e8f2911";
 
@@ -22,11 +20,6 @@ const modelMetadata: Record<
     title: "Classic",
     description:
       "Configure buy and sell fees, creator rewards and Initial Buy custody for a fixed-supply Uniswap v4 token.",
-  },
-  deep: {
-    title: "Deep",
-    description:
-      "An unreleased model designed to turn its fee share into permanently pool-bound liquidity.",
   },
   "stock-paired": {
     title: "Stock-Paired",
@@ -376,157 +369,6 @@ function ClassicDocs() {
   );
 }
 
-function DeepDocs() {
-  return (
-    <DocsShell
-      currentPath="/docs/models/deep"
-      kicker="Launch model · In development"
-      title="Deep"
-      description="A fixed-supply launch designed to turn trading fees into permanently pool-bound liquidity."
-    >
-      <section>
-        <span className={styles.sectionEyebrow}>Release status</span>
-        <h2>Documented, not publicly launchable</h2>
-        <p className={styles.lead}>
-          Deep is still behind the production release gate. Its contracts,
-          source verification, launch lifecycle and live automation evidence
-          must all match before the Launch page can enable it.
-        </p>
-        <div className={styles.callout}>
-          <strong>Coming soon means no Mainnet launch is available.</strong>
-          <p>
-            Tests, simulations and a completed interface do not change that
-            status.
-          </p>
-        </div>
-      </section>
-
-      <section>
-        <span className={styles.sectionEyebrow}>Model</span>
-        <h2>Trading fees return to the original pool</h2>
-        <div className={styles.flow}>
-          <div className={styles.flowItem}>
-            <span>Swap</span>
-            <strong>A trade pays the fixed 1.00% hook fee in ETH</strong>
-          </div>
-          <div className={styles.flowItem}>
-            <span>Growth share</span>
-            <strong>0.90% accrues inside the pool&apos;s growth vault</strong>
-          </div>
-          <div className={styles.flowItem}>
-            <span>Compound</span>
-            <strong>Bounded ETH buys tokens in the original pool</strong>
-          </div>
-          <div className={styles.flowItem}>
-            <span>Liquidity</span>
-            <strong>ETH and tokens enter permanent full-range liquidity</strong>
-          </div>
-        </div>
-        <p>
-          The remaining 0.10% accrues to the Programmable treasury. Deep has no
-          creator reward, payout address, rescue path or liquidity-removal
-          control.
-        </p>
-      </section>
-
-      <section>
-        <span className={styles.sectionEyebrow}>Automation</span>
-        <h2>Five minutes is the earliest eligible retry</h2>
-        <p>
-          After release, an offchain executor would pay gas and check eligible
-          pools. When a vault has enough accounted fees and its safety checks
-          pass, it could compound no more than once in an eligible five-minute
-          window. A failed or ineligible cycle would be skipped and checked
-          again later.
-        </p>
-        <div className={styles.factGrid}>
-          <div className={styles.fact}>
-            <span>Minimum interval</span>
-            <strong>5 minutes after a successful compound</strong>
-          </div>
-          <div className={styles.fact}>
-            <span>Minimum pending growth</span>
-            <strong>0.002 ETH</strong>
-          </div>
-          <div className={styles.fact}>
-            <span>Per-cycle maximum</span>
-            <strong>0.25 ETH before tighter depth limits</strong>
-          </div>
-          <div className={styles.fact}>
-            <span>Oracle history</span>
-            <strong>30-minute pool observations required</strong>
-          </div>
-        </div>
-      </section>
-
-      <section>
-        <span className={styles.sectionEyebrow}>Protection</span>
-        <h2>Growth is bounded by live pool conditions</h2>
-        <ul className={styles.contentList}>
-          <li>
-            Spot, short-window and long-window pool prices must remain within
-            fixed deviation limits.
-          </li>
-          <li>
-            The internal buy must stay within the per-cycle price-impact limit.
-          </li>
-          <li>
-            The growth budget is capped by accounted ETH and permanent,
-            factory-proven pool depth.
-          </li>
-          <li>
-            The swap and liquidity addition happen atomically. A failed
-            compound changes neither accounting nor liquidity.
-          </li>
-        </ul>
-      </section>
-
-      <section>
-        <span className={styles.sectionEyebrow}>Boundaries</span>
-        <h2>What deeper liquidity does not solve</h2>
-        <ul className={styles.contentList}>
-          <li>It does not guarantee demand or prevent the token price falling.</li>
-          <li>It does not remove all manipulation, MEV or execution risk.</li>
-          <li>
-            An offchain executor is required. Smart contracts do not wake
-            themselves every five minutes.
-          </li>
-          <li>
-            Uniswap protocol fees, if enabled for the pool, are separate from
-            the fixed Programmable hook fee.
-          </li>
-        </ul>
-        <div className={styles.sourceLinks}>
-          <a
-            href={`https://github.com/0xprogrammable/programmable/blob/${deepSourceCommit}/docs/superpowers/specs/2026-07-29-deep-eth-buy-and-lock-design.md`}
-            target="_blank"
-            rel="noreferrer"
-          >
-            Design specification
-            <ExternalLink aria-hidden="true" size={13} />
-          </a>
-          <a
-            href={`https://github.com/0xprogrammable/programmable/blob/${deepSourceCommit}/contracts/security/DEEP-V3.md`}
-            target="_blank"
-            rel="noreferrer"
-          >
-            Security notes
-            <ExternalLink aria-hidden="true" size={13} />
-          </a>
-          <a
-            href={`https://github.com/0xprogrammable/programmable/blob/${deepSourceCommit}/contracts/deployments/mainnet-deep-full-range-v3.json`}
-            target="_blank"
-            rel="noreferrer"
-          >
-            Release status
-            <ExternalLink aria-hidden="true" size={13} />
-          </a>
-        </div>
-      </section>
-    </DocsShell>
-  );
-}
-
 function StockPairedDocs() {
   const launcher = "0x195750f33caD5eF2DF857a53226B421297A1e79e";
   const hook = "0x7773D183fe7B60d4F1885047fa42b815a62Fe0Cc";
@@ -750,6 +592,5 @@ export default async function ModelDocsPage({
   if (!isModelSlug(model)) notFound();
 
   if (model === "classic") return <ClassicDocs />;
-  if (model === "deep") return <DeepDocs />;
   return <StockPairedDocs />;
 }

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -40,9 +40,9 @@ export default function DocsPage() {
         <div className={styles.callout}>
           <strong>Release status is part of the product.</strong>
           <p>
-            Classic is available for public launches. Deep is documented but
-            not deployed. Stock-Paired has a verified Mainnet deployment but
-            remains restricted in the interface.
+            Classic is available for public launches. Stock-Paired has a
+            verified Mainnet deployment but remains restricted in the
+            interface.
           </p>
         </div>
 
@@ -60,21 +60,6 @@ export default function DocsPage() {
             </p>
             <span className={styles.modelLink}>
               Read Classic
-              <ArrowRight aria-hidden="true" size={14} />
-            </span>
-          </Link>
-
-          <Link className={styles.modelCard} href="/docs/models/deep">
-            <span className={styles.modelCardHeader}>
-              <strong>Deep</strong>
-              <span className={styles.status}>In development</span>
-            </span>
-            <p>
-              Designed to use its fee share to buy the token and add
-              permanently pool-bound liquidity.
-            </p>
-            <span className={styles.modelLink}>
-              Read Deep
               <ArrowRight aria-hidden="true" size={14} />
             </span>
           </Link>
@@ -185,10 +170,8 @@ export default function DocsPage() {
           under the current configuration.
         </p>
         <p>
-          Stock-Paired rewards accrue in its selected quote token. Deep is
-          designed without creator rewards because its 0.90% model share is
-          reserved for liquidity growth. Profile shows the claims available to
-          the connected wallet.
+          Stock-Paired rewards accrue in its selected quote token. Profile
+          shows the claims available to the connected wallet.
         </p>
         <div className={styles.callout}>
           <strong>Claiming cannot change the launch economics.</strong>

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -18,7 +18,6 @@ export const docsNavigation = [
     label: "Launch models",
     items: [
       { href: "/docs/models/classic", label: "Classic" },
-      { href: "/docs/models/deep", label: "Deep" },
       { href: "/docs/models/stock-paired", label: "Stock-Paired" },
     ],
   },
@@ -60,12 +59,6 @@ export const docsSearchItems: DocsSearchItem[] = [
     description:
       "Directional swap fees, ETH creator rewards and Initial Buy custody.",
     href: "/docs/models/classic",
-  },
-  {
-    title: "Deep",
-    description:
-      "An unreleased model designed to return trading fees to locked liquidity.",
-    href: "/docs/models/deep",
   },
   {
     title: "Stock-Paired",

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -6,7 +6,6 @@ import { ArrowLeft, ArrowRight } from "lucide-react";
 
 import launchExperience from "@/components/launch-experience.module.css";
 import { isConfiguredClassicV3ReleaseReady } from "@/lib/classic-v3-release";
-import { isConfiguredDeepV3ReleaseReady } from "@/lib/deep-v3-release";
 import { resolveImplementedLaunchModel } from "@/lib/launch-model-gating";
 import type { LaunchModel } from "@/lib/launch";
 
@@ -16,8 +15,6 @@ const launchEnvironment =
     : "production";
 const classicV3LaunchAvailable =
   isConfiguredClassicV3ReleaseReady(launchEnvironment);
-const deepLaunchAvailable =
-  isConfiguredDeepV3ReleaseReady(launchEnvironment);
 
 function loadLaunchForm() {
   return import("@/components/launch-builder");
@@ -73,7 +70,6 @@ export function LaunchExperience({
     if (
       !model ||
       (model === "classic-v3" && !classicV3LaunchAvailable) ||
-      (model === "deep" && !deepLaunchAvailable) ||
       (model === "stock-paired" && !stockPairedPublicLaunchEnabled)
     ) {
       return;
@@ -243,57 +239,6 @@ export function LaunchModelPicker({
           </span>
         </button>
 
-        <button
-          className={`launch-model-card launch-model-card-deep ${launchExperience.modelCard}`}
-          data-launch-model-option="deep"
-          data-launch-model-available={deepLaunchAvailable}
-          type="button"
-          disabled={!deepLaunchAvailable}
-          aria-describedby="launch-model-deep-description"
-          onPointerEnter={deepLaunchAvailable ? preloadAvailableForm : undefined}
-          onFocus={deepLaunchAvailable ? preloadAvailableForm : undefined}
-          onClick={() => onChoose("deep")}
-        >
-          <span
-            className={`launch-model-art launch-model-art-deep ${launchExperience.modelArt}`}
-            aria-hidden="true"
-          >
-            <Image
-              src="/brand/programmable-deep-liquidity-teaser-v1-1774x887.webp"
-              alt=""
-              fill
-              sizes="(max-width: 520px) calc(100vw - 28px), (max-width: 800px) calc(100vw - 48px), 500px"
-            />
-          </span>
-
-          <span
-            className={`launch-model-card-body ${launchExperience.modelBody}`}
-          >
-            <span
-              className={`launch-model-card-heading ${launchExperience.modelHeading}`}
-            >
-              <strong>Deep</strong>
-              {!deepLaunchAvailable ? (
-                <small data-status="pending">Coming soon</small>
-              ) : null}
-            </span>
-            <span
-              className={`launch-model-description ${launchExperience.modelDescription}`}
-              id="launch-model-deep-description"
-            >
-              Trading fees automatically deepen the original locked Uniswap
-              v4 pool.
-            </span>
-            {deepLaunchAvailable ? (
-              <span
-                className={`launch-model-action ${launchExperience.modelAction}`}
-              >
-                Launch
-                <ArrowRight aria-hidden="true" size={16} />
-              </span>
-            ) : null}
-          </span>
-        </button>
       </div>
     </div>
   );

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -16,9 +16,9 @@
 
 .modelGrid {
   gap: 18px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   margin-top: clamp(28px, 4svh, 42px);
-  max-width: 1220px;
+  max-width: 820px;
 }
 
 .modelCard {

--- a/tests/docs-navigation.test.ts
+++ b/tests/docs-navigation.test.ts
@@ -149,11 +149,11 @@ describe("Docs navigation state", () => {
     expect(getDocsSearchResults("")).toEqual([]);
   });
 
-  it("describes launch-model availability without implying a public release", () => {
+  it("keeps hidden models out of search and describes Stock-Paired accurately", () => {
     const deepResults = getDocsSearchResults("deep");
     const stockResults = getDocsSearchResults("stock");
 
-    expect(deepResults[0]?.description).toContain("unreleased");
+    expect(deepResults).toEqual([]);
     expect(stockResults[0]?.description).toContain("restricted");
   });
 

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -158,34 +158,27 @@ describe("unreleased launch model gating", () => {
     ).toEqual([-1, -1, 0, -1, -1, -1]);
   });
 
-  it("shows verified Stock-Paired beside Classic and Deep without Adaptive", () => {
+  it("shows only Classic and Stock-Paired in the public model picker", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
         onChoose: () => undefined,
       }),
     );
 
-    expect(html.match(/data-launch-model-option=/g)).toHaveLength(3);
+    expect(html.match(/data-launch-model-option=/g)).toHaveLength(2);
     expect(html).toContain('data-launch-model-option="classic"');
-    expect(html).toContain('data-launch-model-option="deep"');
     expect(html).toContain('data-launch-model-option="stock-paired"');
     expect(html).toContain("<strong>Classic</strong>");
-    expect(html).toContain("<strong>Deep</strong>");
     expect(html).toContain("<strong>Stock-Paired</strong>");
     expect(html).toContain("Coming soon");
-    expect(html).toContain(
-      'aria-describedby="launch-model-deep-description"',
-    );
     expect(html).not.toContain("launch-model-classic-details");
     expect(html).not.toContain("launch-model-stock-details");
-    expect(html).not.toContain("launch-model-deep-details");
     const stockButton = html.match(
       /<button[^>]*data-launch-model-option="stock-paired"[^>]*>/,
     )?.[0];
     expect(stockButton).toContain("disabled");
-    expect(html).toContain(
-      "Trading fees automatically deepen the original locked Uniswap",
-    );
+    expect(html).not.toContain('data-launch-model-option="deep"');
+    expect(html).not.toContain("<strong>Deep</strong>");
     expect(html).not.toMatch(/adaptive/i);
     expect(html).not.toContain("LiquidityGrowth");
     expect(html).not.toContain("Liquidity Growth");


### PR DESCRIPTION
Removes Deep from the public launch picker and documentation while keeping its internal source and release evidence intact. The public launch page now shows Classic and Stock-Paired only. Also updates the Classic README details to match the current Mainnet release.