### PR TITLE
Show Initial Buy ownership in Classic

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6593,21 +6593,48 @@ html[data-theme="dark"] .theme-toggle-sun {
 .classic-v3-split-row label > span:first-child,
 .profile-v3-payout > span {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 640;
 }
 
-.classic-v3-fee-control > small,
 .classic-v3-reward-note {
-  color: var(--muted);
-  font-size: 11.5px;
-  line-height: 1.35;
+  color: var(--text-soft);
+  font-size: 13px;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.classic-v3-fee-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  justify-content: space-between;
+  margin: 0;
+}
+
+.classic-v3-fee-breakdown > div {
+  align-items: baseline;
+  display: inline-flex;
+  gap: 5px;
+  min-width: 0;
   white-space: nowrap;
 }
 
-.classic-v3-fee-control > small span {
-  color: var(--border-strong);
-  margin: 0 3px;
+.classic-v3-fee-breakdown dt,
+.classic-v3-fee-breakdown dd {
+  margin: 0;
+}
+
+.classic-v3-fee-breakdown dt {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.classic-v3-fee-breakdown dd {
+  color: var(--text-soft);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
 }
 
 .classic-v3-fees legend,
@@ -6765,7 +6792,7 @@ html[data-theme="dark"] .theme-toggle-sun {
   background: transparent;
   color: var(--muted);
   font: inherit;
-  font-size: 13px;
+  font-size: 13.5px;
   font-weight: 650;
   padding: 0 10px;
   white-space: nowrap;
@@ -6865,9 +6892,62 @@ html[data-theme="dark"] .theme-toggle-sun {
   background: var(--surface-soft);
   border: 1px solid var(--border);
   border-radius: 16px;
-  grid-template-columns: minmax(0, 1fr) minmax(190px, 246px);
+  column-gap: 12px;
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(190px, 230px);
   margin: 0;
   padding: 13px;
+  row-gap: 12px;
+}
+
+.classic-v3-amount-label {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.classic-v3-amount-label strong {
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.classic-v3-amount-label small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.classic-v3-buy-preview {
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 8px;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding-top: 11px;
+}
+
+.classic-v3-buy-preview > span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.classic-v3-buy-preview small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.classic-v3-buy-preview strong {
+  color: var(--text);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .classic-v3-initial-buy .meme-dev-buy-input button {
@@ -6903,7 +6983,7 @@ html[data-theme="dark"] .theme-toggle-sun {
 .classic-v3-custody legend,
 .classic-v3-custody label > span:first-child {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 650;
 }
 
@@ -7274,8 +7354,12 @@ html[data-theme="dark"] .theme-toggle-sun {
   }
 
   .classic-v3-reward-mode button {
-    font-size: 12px;
+    font-size: 12.5px;
     padding-inline: 4px;
+  }
+
+  .classic-v3-buy-preview {
+    grid-template-columns: 1fr;
   }
 
 }

--- a/components/launch-builder.tsx
+++ b/components/launch-builder.tsx
@@ -77,6 +77,7 @@ import {
   createDeepDraft,
   createEmptyDraft,
   createStockPairedDraft,
+  getClassicInitialBuyPreview,
   maximumClassicDevBuyWei,
   MEME_MIN_INITIAL_BUY_ETH,
   MEME_MIN_INITIAL_BUY_ETH_LABEL,
@@ -2971,6 +2972,16 @@ const initialBuyAccessOptions: readonly LaunchSelectOption<
   { value: "cliff-linear", label: "Cliff, then linear vesting" },
 ];
 
+const compactInitialBuyTokenFormatter = new Intl.NumberFormat("en-US", {
+  compactDisplay: "short",
+  maximumFractionDigits: 2,
+  notation: "compact",
+});
+
+const initialBuySupplyFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+});
+
 function EnhancedClassicFeeStep({
   draft,
   setDraft,
@@ -3005,12 +3016,19 @@ function EnhancedClassicFeeStep({
     return Number.isFinite(share) ? total + share : total;
   }, 0);
   const splitIsComplete = Math.abs(splitTotal - 100) < 0.001;
+  const initialBuyPreview = getClassicInitialBuyPreview(
+    draft.initialBuyEth,
+    draft.buySwapFeePercent,
+  );
+  const initialBuyTokenLabel = draft.tokenSymbol.trim()
+    ? `$${draft.tokenSymbol.trim().toUpperCase()}`
+    : "tokens";
   const rewardNote =
     draft.rewardDestinationMode === "launcher"
-      ? "Rewards go to the launch wallet"
+      ? "Paid to the launch wallet"
       : draft.rewardDestinationMode === "external"
-        ? "Rewards go to one wallet"
-        : "Each wallet claims its own share";
+        ? "Paid to the selected wallet"
+        : "Each recipient claims their share";
 
   return (
     <section className="classic-v3-settings" aria-labelledby="classic-v3-fees">
@@ -3042,12 +3060,20 @@ function EnhancedClassicFeeStep({
                       updateClassicV3Draft({ [key]: value })
                     }
                   />
-                  <small>
-                    {Number.isFinite(creatorFeeBps)
-                      ? formatClassicV3Percent(creatorFeeBps)
-                      : "—"}{" "}
-                    creator <span>·</span> 0.10% Programmable
-                  </small>
+                  <dl className="classic-v3-fee-breakdown">
+                    <div>
+                      <dt>Creator</dt>
+                      <dd>
+                        {Number.isFinite(creatorFeeBps)
+                          ? formatClassicV3Percent(creatorFeeBps)
+                          : "—"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Programmable</dt>
+                      <dd>0.10%</dd>
+                    </div>
+                  </dl>
                 </div>
               );
             })}
@@ -3079,7 +3105,7 @@ function EnhancedClassicFeeStep({
               </button>
             ))}
           </div>
-          <small className="classic-v3-reward-note">{rewardNote}</small>
+          <p className="classic-v3-reward-note">{rewardNote}</p>
         </fieldset>
       </div>
 
@@ -3186,11 +3212,14 @@ function EnhancedClassicFeeStep({
       </div>
 
       <div className="classic-v3-initial-buy">
-        <label className="meme-dev-buy" htmlFor="classic-v3-dev-buy">
-          <span>
+        <div className="meme-dev-buy">
+          <label
+            className="classic-v3-amount-label"
+            htmlFor="classic-v3-dev-buy"
+          >
             <strong>Amount</strong>
             <small>Minimum {MEME_MIN_INITIAL_BUY_ETH_LABEL}</small>
-          </span>
+          </label>
           <span className="meme-dev-buy-input">
             <input
               id="classic-v3-dev-buy"
@@ -3215,7 +3244,29 @@ function EnhancedClassicFeeStep({
             </button>
             <span>ETH</span>
           </span>
-        </label>
+          <div
+            className="classic-v3-buy-preview"
+            role="status"
+            aria-live="polite"
+          >
+            <span>
+              <small>Estimated tokens</small>
+              <strong>
+                {initialBuyPreview
+                  ? `≈ ${compactInitialBuyTokenFormatter.format(initialBuyPreview.tokenAmount)} ${initialBuyTokenLabel}`
+                  : "—"}
+              </strong>
+            </span>
+            <span>
+              <small>Share of supply</small>
+              <strong>
+                {initialBuyPreview
+                  ? `≈ ${initialBuySupplyFormatter.format(initialBuyPreview.supplyPercent)}%`
+                  : "—"}
+              </strong>
+            </span>
+          </div>
+        </div>
 
         <fieldset
           className="classic-v3-custody"

--- a/lib/launch.ts
+++ b/lib/launch.ts
@@ -1,4 +1,4 @@
-import { parseEther } from "viem";
+import { formatEther, parseEther } from "viem";
 
 export const PLATFORM_FEE_BPS = 10;
 export const CLASSIC_TOTAL_SWAP_FEE_PERCENT = "1";
@@ -14,6 +14,12 @@ export const MEME_MIN_INITIAL_BUY_WEI = 600_000_000_000_000n;
 export const MEME_MIN_INITIAL_BUY_ETH = "0.0006";
 export const MEME_MIN_INITIAL_BUY_ETH_LABEL =
   `${MEME_MIN_INITIAL_BUY_ETH} ETH`;
+const MEME_MIN_USABLE_TICK = -887_200;
+const MEME_INITIAL_SQRT_PRICE = 1.0001 ** (MEME_INITIAL_TICK / 2);
+const MEME_MIN_SQRT_PRICE = 1.0001 ** (MEME_MIN_USABLE_TICK / 2);
+const MEME_INITIAL_LIQUIDITY =
+  MEME_TOKEN_SUPPLY_WHOLE /
+  (MEME_INITIAL_SQRT_PRICE - MEME_MIN_SQRT_PRICE);
 export const ADAPTIVE_MIN_FDV_INDEX = -887_272;
 export const ADAPTIVE_MAX_FDV_INDEX = 887_272;
 export const ADAPTIVE_MIN_FEE_BPS = 100;
@@ -49,6 +55,13 @@ export type ClassicInitialBuyCustodyMode =
   | "fixed-lock"
   | "linear"
   | "cliff-linear";
+
+export type ClassicInitialBuyPreview = {
+  grossEthAmount: number;
+  poolEthAmount: number;
+  tokenAmount: number;
+  supplyPercent: number;
+};
 
 export type AdaptiveCurvePointDraft = {
   fdvIndex: number;
@@ -246,6 +259,58 @@ export function parseInitialBuyWei(value: string | null | undefined) {
   } catch {
     return null;
   }
+}
+
+export function getClassicInitialBuyPreview(
+  initialBuyEth: string,
+  buyFeePercent: string,
+): ClassicInitialBuyPreview | null {
+  const initialBuyWei = parseInitialBuyWei(initialBuyEth);
+  const normalizedFeePercent = Number(buyFeePercent.trim());
+
+  if (
+    initialBuyWei === null ||
+    !Number.isInteger(normalizedFeePercent) ||
+    normalizedFeePercent < 1 ||
+    normalizedFeePercent > 10
+  ) {
+    return null;
+  }
+
+  const grossEthAmount = Number(formatEther(initialBuyWei));
+  const poolEthAmount = grossEthAmount * (1 - normalizedFeePercent / 100);
+
+  if (
+    !Number.isFinite(grossEthAmount) ||
+    !Number.isFinite(poolEthAmount) ||
+    poolEthAmount <= 0
+  ) {
+    return null;
+  }
+
+  const nextSqrtPrice =
+    (MEME_INITIAL_LIQUIDITY * MEME_INITIAL_SQRT_PRICE) /
+    (MEME_INITIAL_LIQUIDITY +
+      poolEthAmount * MEME_INITIAL_SQRT_PRICE);
+  const tokenAmount = Math.max(
+    0,
+    Math.min(
+      MEME_TOKEN_SUPPLY_WHOLE,
+      MEME_INITIAL_LIQUIDITY *
+        (MEME_INITIAL_SQRT_PRICE - nextSqrtPrice),
+    ),
+  );
+
+  if (!Number.isFinite(tokenAmount) || tokenAmount <= 0) {
+    return null;
+  }
+
+  return {
+    grossEthAmount,
+    poolEthAmount,
+    tokenAmount,
+    supplyPercent: (tokenAmount / MEME_TOKEN_SUPPLY_WHOLE) * 100,
+  };
 }
 
 export function parseOptionalInitialBuyWei(value: string | null | undefined) {

--- a/tests/launch.test.ts
+++ b/tests/launch.test.ts
@@ -5,6 +5,7 @@ import {
   buildLaunchSummary,
   buildPlainTextPlan,
   createEmptyDraft,
+  getClassicInitialBuyPreview,
   getDraftAssetLabel,
   getInitialBuyEthLabel,
   getMemeFeeBreakdown,
@@ -91,6 +92,30 @@ describe("Classic launch plan", () => {
         gasPriceWei: 2n,
       }),
     ).toBe(0n);
+  });
+
+  it("previews the initial buy output and share of the fixed supply", () => {
+    const minimumBuy = getClassicInitialBuyPreview("0.0006", "1");
+    const largerBuy = getClassicInitialBuyPreview("0.03", "1");
+
+    expect(minimumBuy).not.toBeNull();
+    expect(minimumBuy?.poolEthAmount).toBeCloseTo(0.000594, 12);
+    expect(minimumBuy?.tokenAmount).toBeCloseTo(437_971.7816, 3);
+    expect(minimumBuy?.supplyPercent).toBeCloseTo(0.043797, 5);
+    expect(largerBuy?.tokenAmount).toBeCloseTo(21_438_505.518, 2);
+    expect(largerBuy?.supplyPercent).toBeCloseTo(2.143851, 5);
+  });
+
+  it("accounts for the selected buy fee in the initial buy preview", () => {
+    const onePercentFee = getClassicInitialBuyPreview("0.03", "1");
+    const tenPercentFee = getClassicInitialBuyPreview("0.03", "10");
+
+    expect(tenPercentFee?.tokenAmount).toBeLessThan(
+      onePercentFee?.tokenAmount ?? 0,
+    );
+    expect(getClassicInitialBuyPreview("0.0005", "1")).toBeNull();
+    expect(getClassicInitialBuyPreview("0.03", "1.5")).toBeNull();
+    expect(getClassicInitialBuyPreview("0.03", "11")).toBeNull();
   });
 
   it("copies the selected Dev Buy into the launch summary", () => {


### PR DESCRIPTION
Classic now shows the estimated token amount and percentage of the fixed supply beneath Initial Buy. The estimate includes the selected buy fee and launch-curve price impact.

The fee split and reward destination are easier to read, and the Initial Buy layout has been tightened across desktop and mobile.

Checks: ESLint, TypeScript, 664 tests, production build, and browser QA in light and dark mode at desktop and mobile sizes.