### PR TITLE
Index Classic V3 launches

### DIFF
--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -1275,7 +1275,7 @@ export function TokenDetailView({ address }: { address: string }) {
     activeState.phase === "loading"
       ? "Loading token"
       : activeState.phase === "not-found"
-        ? "This token was not launched through Programmable"
+        ? "This token is not in the Programmable launch index yet"
         : activeState.phase === "not-deployed"
           ? "No verified launch data is available"
           : activeState.message;

--- a/lib/classic-v3.ts
+++ b/lib/classic-v3.ts
@@ -58,6 +58,7 @@ export const classicV3HookAbi = parseAbi([
   "function TICK_SPACING() view returns (int24)",
   "function feeDisclosure(bytes32 poolId) view returns (uint16 buySwapFeeBps,uint16 sellSwapFeeBps,uint16 buyCreatorFeeBps,uint16 sellCreatorFeeBps,uint16 launcherFeeBps,uint16 transferTaxBps,uint24 lpFeePips,address rewardVault)",
   "function poolFeeConfig(bytes32 poolId) view returns (address rewardVault,address registrar,uint16 buySwapFeeBps,uint16 sellSwapFeeBps,bool registered,uint256 creatorFeesAccrued)",
+  "function launcherFeesAccrued() view returns (uint256)",
 ]);
 
 export const classicV3HookFactoryAbi = parseAbi([

--- a/lib/onchain/classic-v3-read-model.ts
+++ b/lib/onchain/classic-v3-read-model.ts
@@ -1,0 +1,507 @@
+import {
+  createPublicClient,
+  formatUnits,
+  getAddress,
+  http,
+  keccak256,
+  parseAbiItem,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { mainnet, sepolia } from "viem/chains";
+
+import {
+  classicRewardVaultAbi,
+  classicRewardVaultFactoryAbi,
+  classicV3HookAbi,
+} from "../classic-v3";
+import {
+  getConfiguredClassicV3Release,
+  isClassicV3ReleaseVerified,
+} from "../classic-v3-release";
+import type { LauncherToken } from "../tokens";
+import { stateViewReadAbi, uerc20ReadAbi } from "./abis";
+import {
+  marketCapNativeWadFromSqrtPriceX96,
+  nativePriceWadFromSqrtPriceX96,
+} from "./math";
+import { buildTokenLinks, sanitizeImageUrl } from "./metadata";
+import type { ExploreReadModel, ReadyOnchainDeployment } from "./types";
+
+const launchedEvent = parseAbiItem(
+  "event MemeTokenLaunchedV2(address indexed deployer,address indexed token,bytes32 indexed poolId,address feeHook,address rewardVault,address positionRecipient,uint256 positionTokenId,uint16 buySwapFeeBps,uint16 sellSwapFeeBps,bytes32 rewardConfigurationHash,bytes32 launchHash)",
+);
+const feeEvent = parseAbiItem(
+  "event NativeSwapFeesAccrued(bytes32 indexed poolId,address indexed swapSender,bool indexed isBuy,uint16 appliedTotalSwapFeeBps,uint256 grossNativeAmount,uint256 creatorFee,uint256 launcherFee)",
+);
+
+type ClassicV3Release = {
+  launcher: Address;
+  hook: Address;
+  rewardVaultFactory: Address;
+  launcherRuntimeCodeHash: Hex;
+  hookRuntimeCodeHash: Hex;
+  rewardVaultFactoryRuntimeCodeHash: Hex;
+  startBlock: bigint;
+};
+
+type LaunchRecord = {
+  deployer: Address;
+  token: Address;
+  poolId: Hex;
+  feeHook: Address;
+  rewardVault: Address;
+  positionRecipient: Address;
+  positionTokenId: bigint;
+  buySwapFeeBps: number;
+  sellSwapFeeBps: number;
+  rewardConfigurationHash: Hex;
+  launchHash: Hex;
+  blockNumber: bigint;
+  transactionHash: Hex;
+  transactionIndex: number;
+  logIndex: number;
+};
+
+type FeeVolume = {
+  grossNativeAmount: bigint;
+  creatorFees: bigint;
+  launcherFees: bigint;
+  swapCount: number;
+};
+
+export type ClassicV3ExploreSlice = {
+  tokens: LauncherToken[];
+  launcherFeesAccrued: bigint;
+};
+
+const EMPTY_VOLUME: FeeVolume = {
+  grossNativeAmount: 0n,
+  creatorFees: 0n,
+  launcherFees: 0n,
+  swapCount: 0,
+};
+
+function minimum(left: bigint, right: bigint) {
+  return left < right ? left : right;
+}
+
+function sameHex(left: string, right: string) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function clientFor(config: ReadyOnchainDeployment, endpoint: string) {
+  return createPublicClient({
+    chain: config.chainId === 1 ? mainnet : sepolia,
+    batch: { multicall: true },
+    transport: http(endpoint, { retryCount: 2, timeout: 12_000 }),
+  });
+}
+
+function resolveClassicV3Release(
+  config: ReadyOnchainDeployment,
+): ClassicV3Release | null {
+  const configured = getConfiguredClassicV3Release(config.environment);
+  const { appManifest, releaseManifest } = configured;
+  if (
+    configured.chainId !== config.chainId ||
+    !isClassicV3ReleaseVerified(
+      appManifest,
+      releaseManifest,
+      config.chainId,
+    )
+  ) {
+    return null;
+  }
+  const startBlock = appManifest.deploymentBlocks?.memeLaunchV2;
+  if (!Number.isSafeInteger(startBlock) || (startBlock ?? -1) < 0) return null;
+  return {
+    launcher: getAddress(appManifest.memeLaunchV2 as string),
+    hook: getAddress(appManifest.ethCreatorFeeHookV3 as string),
+    rewardVaultFactory: getAddress(
+      appManifest.classicRewardVaultFactoryV1 as string,
+    ),
+    launcherRuntimeCodeHash:
+      appManifest.runtimeCodeHashes?.memeLaunchV2 as Hex,
+    hookRuntimeCodeHash:
+      appManifest.runtimeCodeHashes?.ethCreatorFeeHookV3 as Hex,
+    rewardVaultFactoryRuntimeCodeHash:
+      appManifest.runtimeCodeHashes?.classicRewardVaultFactoryV1 as Hex,
+    startBlock: BigInt(startBlock as number),
+  };
+}
+
+async function assertRuntime(
+  client: PublicClient,
+  address: Address,
+  expectedHash: Hex,
+  blockNumber: bigint,
+  label: string,
+) {
+  const code = await client.getCode({ address, blockNumber });
+  if (!code || code === "0x" || keccak256(code) !== expectedHash) {
+    throw new Error(`${label} runtime does not match the Classic V3 release`);
+  }
+}
+
+async function readEvents(
+  client: PublicClient,
+  config: ReadyOnchainDeployment,
+  release: ClassicV3Release,
+  toBlock: bigint,
+) {
+  const launches: LaunchRecord[] = [];
+  const volumes = new Map<string, FeeVolume>();
+  for (
+    let fromBlock = release.startBlock;
+    fromBlock <= toBlock;
+    fromBlock += config.logBlockRange
+  ) {
+    const rangeEnd = minimum(
+      toBlock,
+      fromBlock + config.logBlockRange - 1n,
+    );
+    const [launchLogs, feeLogs] = await Promise.all([
+      client.getLogs({
+        address: release.launcher,
+        event: launchedEvent,
+        fromBlock,
+        toBlock: rangeEnd,
+        strict: true,
+      }),
+      client.getLogs({
+        address: release.hook,
+        event: feeEvent,
+        fromBlock,
+        toBlock: rangeEnd,
+        strict: true,
+      }),
+    ]);
+    for (const log of launchLogs) {
+      if (log.removed || log.blockNumber === null) continue;
+      launches.push({
+        deployer: getAddress(log.args.deployer),
+        token: getAddress(log.args.token),
+        poolId: log.args.poolId,
+        feeHook: getAddress(log.args.feeHook),
+        rewardVault: getAddress(log.args.rewardVault),
+        positionRecipient: getAddress(log.args.positionRecipient),
+        positionTokenId: log.args.positionTokenId,
+        buySwapFeeBps: log.args.buySwapFeeBps,
+        sellSwapFeeBps: log.args.sellSwapFeeBps,
+        rewardConfigurationHash: log.args.rewardConfigurationHash,
+        launchHash: log.args.launchHash,
+        blockNumber: log.blockNumber,
+        transactionHash: log.transactionHash,
+        transactionIndex: log.transactionIndex,
+        logIndex: log.logIndex,
+      });
+    }
+    for (const log of feeLogs) {
+      if (log.removed) continue;
+      const key = log.args.poolId.toLowerCase();
+      const current = volumes.get(key) ?? { ...EMPTY_VOLUME };
+      current.grossNativeAmount += log.args.grossNativeAmount;
+      current.creatorFees += log.args.creatorFee;
+      current.launcherFees += log.args.launcherFee;
+      current.swapCount += 1;
+      volumes.set(key, current);
+    }
+  }
+  return { launches, volumes };
+}
+
+function eventFingerprint(value: Awaited<ReturnType<typeof readEvents>>) {
+  return JSON.stringify(
+    {
+      launches: value.launches,
+      volumes: [...value.volumes.entries()].sort(([left], [right]) =>
+        left.localeCompare(right),
+      ),
+    },
+    (_, item) => (typeof item === "bigint" ? item.toString() : item),
+  );
+}
+
+function assertUniqueLaunches(
+  launches: readonly LaunchRecord[],
+  release: ClassicV3Release,
+) {
+  const tokens = new Set<string>();
+  const pools = new Set<string>();
+  for (const launch of launches) {
+    const token = launch.token.toLowerCase();
+    const pool = launch.poolId.toLowerCase();
+    if (
+      tokens.has(token) ||
+      pools.has(pool) ||
+      !sameHex(launch.feeHook, release.hook)
+    ) {
+      throw new Error(`Invalid Classic V3 launch provenance for ${launch.token}`);
+    }
+    tokens.add(token);
+    pools.add(pool);
+  }
+}
+
+async function hydrateToken(
+  client: PublicClient,
+  config: ReadyOnchainDeployment,
+  release: ClassicV3Release,
+  launch: LaunchRecord,
+  volume: FeeVolume,
+  timestamp: bigint,
+  snapshotBlock: bigint,
+): Promise<LauncherToken> {
+  const [
+    name,
+    symbol,
+    decimals,
+    totalSupply,
+    recordedCreator,
+    metadata,
+    slot0,
+    activeLiquidity,
+    disclosure,
+    poolConfig,
+    factoryVault,
+    vaultHook,
+    vaultPoolId,
+    vaultConfigurationHash,
+  ] = await Promise.all([
+    client.readContract({ address: launch.token, abi: uerc20ReadAbi, functionName: "name", blockNumber: snapshotBlock }),
+    client.readContract({ address: launch.token, abi: uerc20ReadAbi, functionName: "symbol", blockNumber: snapshotBlock }),
+    client.readContract({ address: launch.token, abi: uerc20ReadAbi, functionName: "decimals", blockNumber: snapshotBlock }),
+    client.readContract({ address: launch.token, abi: uerc20ReadAbi, functionName: "totalSupply", blockNumber: snapshotBlock }),
+    client.readContract({ address: launch.token, abi: uerc20ReadAbi, functionName: "creator", blockNumber: snapshotBlock }),
+    client.readContract({ address: launch.token, abi: uerc20ReadAbi, functionName: "metadata", blockNumber: snapshotBlock }).catch(() => null),
+    client.readContract({ address: config.stateView, abi: stateViewReadAbi, functionName: "getSlot0", args: [launch.poolId], blockNumber: snapshotBlock }),
+    client.readContract({ address: config.stateView, abi: stateViewReadAbi, functionName: "getLiquidity", args: [launch.poolId], blockNumber: snapshotBlock }),
+    client.readContract({ address: release.hook, abi: classicV3HookAbi, functionName: "feeDisclosure", args: [launch.poolId], blockNumber: snapshotBlock }),
+    client.readContract({ address: release.hook, abi: classicV3HookAbi, functionName: "poolFeeConfig", args: [launch.poolId], blockNumber: snapshotBlock }),
+    client.readContract({ address: release.rewardVaultFactory, abi: classicRewardVaultFactoryAbi, functionName: "isFactoryVault", args: [launch.rewardVault], blockNumber: snapshotBlock }),
+    client.readContract({ address: launch.rewardVault, abi: classicRewardVaultAbi, functionName: "feeHook", blockNumber: snapshotBlock }),
+    client.readContract({ address: launch.rewardVault, abi: classicRewardVaultAbi, functionName: "poolId", blockNumber: snapshotBlock }),
+    client.readContract({ address: launch.rewardVault, abi: classicRewardVaultAbi, functionName: "configurationHash", blockNumber: snapshotBlock }),
+  ]);
+  const [sqrtPriceX96, currentTick, protocolFeePips, lpFeePips] = slot0;
+  const [
+    buySwapFeeBps,
+    sellSwapFeeBps,
+    buyCreatorFeeBps,
+    sellCreatorFeeBps,
+    launcherFeeBps,
+    transferTaxBps,
+    disclosedLpFeePips,
+    disclosedRewardVault,
+  ] = disclosure;
+  const [configuredVault, registrar, configuredBuyFee, configuredSellFee, registered, creatorFeesAccrued] = poolConfig;
+  if (
+    getAddress(recordedCreator) !== release.launcher ||
+    !factoryVault ||
+    !sameHex(vaultHook, release.hook) ||
+    !sameHex(vaultPoolId, launch.poolId) ||
+    !sameHex(vaultConfigurationHash, launch.rewardConfigurationHash) ||
+    !sameHex(disclosedRewardVault, launch.rewardVault) ||
+    !sameHex(configuredVault, launch.rewardVault) ||
+    !sameHex(registrar, release.launcher) ||
+    !registered ||
+    buySwapFeeBps !== launch.buySwapFeeBps ||
+    sellSwapFeeBps !== launch.sellSwapFeeBps ||
+    configuredBuyFee !== launch.buySwapFeeBps ||
+    configuredSellFee !== launch.sellSwapFeeBps ||
+    buyCreatorFeeBps + launcherFeeBps !== buySwapFeeBps ||
+    sellCreatorFeeBps + launcherFeeBps !== sellSwapFeeBps ||
+    launcherFeeBps !== 10 ||
+    transferTaxBps !== 0 ||
+    disclosedLpFeePips !== 0 ||
+    lpFeePips !== 0
+  ) {
+    throw new Error(`Classic V3 launch state mismatch for ${launch.token}`);
+  }
+  const tokenPriceEthWei = nativePriceWadFromSqrtPriceX96(sqrtPriceX96, decimals);
+  const marketCapEthWei = marketCapNativeWadFromSqrtPriceX96(totalSupply, sqrtPriceX96);
+  const description = metadata?.[0]?.trim() || undefined;
+  const website = metadata?.[1] ?? "";
+  const image = metadata?.[2] ?? "";
+  const extraData = metadata?.[3] ?? "0x";
+  return {
+    id: `${config.chainId}:${launch.token.toLowerCase()}`,
+    name,
+    symbol,
+    description,
+    imageUrl: sanitizeImageUrl(image) ?? undefined,
+    links: buildTokenLinks(website, extraData),
+    tokenAddress: launch.token,
+    hookAddress: launch.feeHook,
+    poolId: launch.poolId,
+    creatorAddress: launch.deployer,
+    rewardVaultAddress: launch.rewardVault,
+    positionRecipient: launch.positionRecipient,
+    positionTokenId: launch.positionTokenId.toString(),
+    launchHash: launch.launchHash,
+    launchBlockNumber: launch.blockNumber.toString(),
+    launchTransactionHash: launch.transactionHash,
+    launchTransactionIndex: launch.transactionIndex,
+    launchLogIndex: launch.logIndex,
+    launchedAt: new Date(Number(timestamp) * 1_000).toISOString(),
+    totalSupply: formatUnits(totalSupply, decimals),
+    totalSupplyRaw: totalSupply.toString(),
+    tokenDecimals: decimals,
+    tokenPriceEth: formatUnits(tokenPriceEthWei, 18),
+    tokenPriceEthWei: tokenPriceEthWei.toString(),
+    marketCapEth: formatUnits(marketCapEthWei, 18),
+    marketCapEthWei: marketCapEthWei.toString(),
+    grossVolumeEth: formatUnits(volume.grossNativeAmount, 18),
+    grossVolumeWei: volume.grossNativeAmount.toString(),
+    creatorFeesGeneratedEth: formatUnits(volume.creatorFees, 18),
+    creatorFeesGeneratedWei: volume.creatorFees.toString(),
+    launcherFeesGeneratedEth: formatUnits(volume.launcherFees, 18),
+    launcherFeesGeneratedWei: volume.launcherFees.toString(),
+    creatorFeesAccruedEth: formatUnits(creatorFeesAccrued, 18),
+    creatorFeesAccruedWei: creatorFeesAccrued.toString(),
+    swapCount: volume.swapCount,
+    currentTick,
+    activeLiquidity: activeLiquidity.toString(),
+    protocolFeePips,
+    lpFeePips,
+    buyHookFeeBps: buySwapFeeBps,
+    sellHookFeeBps: sellSwapFeeBps,
+    creatorFeeBps:
+      buyCreatorFeeBps === sellCreatorFeeBps ? buyCreatorFeeBps : undefined,
+    buyCreatorFeeBps,
+    sellCreatorFeeBps,
+    programmableFeeBps: launcherFeeBps,
+    launcherFeeBps,
+    transferTaxBps,
+    totalSwapFeeBps: Math.max(buySwapFeeBps, sellSwapFeeBps),
+    launchModel: "classic",
+    launchModelVersion: "classic-v3",
+    liquidityPath: "meme",
+    metadataExtraData: extraData,
+  };
+}
+
+export function isClassicV3ExploreReleaseReady(
+  config: ReadyOnchainDeployment,
+) {
+  return resolveClassicV3Release(config) !== null;
+}
+
+export async function readClassicV3ExploreModel(
+  config: ReadyOnchainDeployment,
+  snapshotBlockNumber: string,
+): Promise<ClassicV3ExploreSlice> {
+  const release = resolveClassicV3Release(config);
+  if (!release || !/^(?:0|[1-9]\d*)$/.test(snapshotBlockNumber)) {
+    return { tokens: [], launcherFeesAccrued: 0n };
+  }
+  const toBlock = BigInt(snapshotBlockNumber);
+  if (toBlock < release.startBlock) {
+    return { tokens: [], launcherFeesAccrued: 0n };
+  }
+  const clients = [
+    clientFor(config, config.rpcUrl),
+    ...(config.rpcUrlSecondary
+      ? [clientFor(config, config.rpcUrlSecondary)]
+      : []),
+  ];
+  await Promise.all(
+    clients.flatMap((client) => [
+      assertRuntime(client, release.launcher, release.launcherRuntimeCodeHash, toBlock, "Classic V3 launcher"),
+      assertRuntime(client, release.hook, release.hookRuntimeCodeHash, toBlock, "Classic V3 hook"),
+      assertRuntime(client, release.rewardVaultFactory, release.rewardVaultFactoryRuntimeCodeHash, toBlock, "Classic V3 reward vault factory"),
+      assertRuntime(client, config.stateView, config.stateViewRuntimeCodeHash, toBlock, "Uniswap StateView"),
+    ]),
+  );
+  const [eventSets, launcherFees] = await Promise.all([
+    Promise.all(clients.map((client) => readEvents(client, config, release, toBlock))),
+    Promise.all(
+      clients.map((client) =>
+        client.readContract({
+          address: release.hook,
+          abi: classicV3HookAbi,
+          functionName: "launcherFeesAccrued",
+          blockNumber: toBlock,
+        }),
+      ),
+    ),
+  ]);
+  const fingerprint = eventFingerprint(eventSets[0]);
+  if (
+    eventSets.some((candidate) => eventFingerprint(candidate) !== fingerprint) ||
+    launcherFees.some((value) => value !== launcherFees[0])
+  ) {
+    throw new Error("Independent RPCs disagree on Classic V3 state");
+  }
+  const { launches, volumes } = eventSets[0];
+  assertUniqueLaunches(launches, release);
+  const timestamps = new Map<string, bigint>();
+  await Promise.all(
+    [...new Set(launches.map((launch) => launch.blockNumber.toString()))].map(
+      async (blockNumber) => {
+        const block = await clients[0].getBlock({ blockNumber: BigInt(blockNumber) });
+        timestamps.set(blockNumber, block.timestamp);
+      },
+    ),
+  );
+  const tokenSets = await Promise.all(
+    clients.map((client) =>
+      Promise.all(
+        launches.map((launch) =>
+          hydrateToken(
+            client,
+            config,
+            release,
+            launch,
+            volumes.get(launch.poolId.toLowerCase()) ?? EMPTY_VOLUME,
+            timestamps.get(launch.blockNumber.toString()) ?? 0n,
+            toBlock,
+          ),
+        ),
+      ),
+    ),
+  );
+  const tokenFingerprint = JSON.stringify(tokenSets[0]);
+  if (tokenSets.some((candidate) => JSON.stringify(candidate) !== tokenFingerprint)) {
+    throw new Error("Independent RPCs disagree on Classic V3 token state");
+  }
+  return { tokens: tokenSets[0], launcherFeesAccrued: launcherFees[0] };
+}
+
+export function mergeClassicV3ExploreModel<T extends ExploreReadModel>(
+  model: T,
+  slice: ClassicV3ExploreSlice,
+): T {
+  if (model.status !== "ready") return model;
+  const tokens = new Map(
+    model.tokens.map((token) => [token.tokenAddress.toLowerCase(), token]),
+  );
+  const alreadyIncluded =
+    slice.tokens.length > 0 &&
+    slice.tokens.every((token) => {
+      const existing = tokens.get(token.tokenAddress.toLowerCase());
+      return (
+        existing?.launchModelVersion === "classic-v3" &&
+        existing.launchTransactionHash === token.launchTransactionHash
+      );
+    });
+  for (const token of slice.tokens) {
+    const key = token.tokenAddress.toLowerCase();
+    const existing = tokens.get(key);
+    if (existing && existing.launchTransactionHash !== token.launchTransactionHash) {
+      throw new Error(`Duplicate token across launch releases: ${token.tokenAddress}`);
+    }
+    tokens.set(key, token);
+  }
+  const launcherFeesAccrued =
+    BigInt(model.launcherFeesAccruedWei) +
+    (alreadyIncluded ? 0n : slice.launcherFeesAccrued);
+  return {
+    ...model,
+    tokens: [...tokens.values()],
+    launcherFeesAccruedWei: launcherFeesAccrued.toString(),
+    launcherFeesAccruedEth: formatUnits(launcherFeesAccrued, 18),
+  } as T;
+}

--- a/lib/onchain/indexer-feed.ts
+++ b/lib/onchain/indexer-feed.ts
@@ -129,7 +129,8 @@ function launchIdentity(token: LauncherToken) {
   const modelVersion =
     token.launchModel === "deep"
       ? token.deepReleaseVersion ?? null
-      : token.launchModel === "stock-paired"
+      : token.launchModel === "stock-paired" ||
+          token.launchModelVersion === "classic-v3"
         ? token.launchModelVersion ?? null
         : null;
 
@@ -317,8 +318,7 @@ export function serializeIndexerToken(
     transferTaxBps === undefined ||
     programmableFeeBps === undefined ||
     (!isDeepV3 &&
-      (creatorFeeBps === undefined ||
-        buyCreatorFeeBps === null ||
+      (buyCreatorFeeBps === null ||
         sellCreatorFeeBps === null)) ||
     (isDeepV3 && growthFeeBps === null)
   ) {

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -46,6 +46,11 @@ import type {
 } from "./types";
 import { readDurableExploreModel } from "./durable-model";
 import {
+  isClassicV3ExploreReleaseReady,
+  mergeClassicV3ExploreModel,
+  readClassicV3ExploreModel,
+} from "./classic-v3-read-model";
+import {
   isDeepExploreReleaseReady,
   mergeDeepExploreModel,
   readDeepExploreModel,
@@ -770,6 +775,12 @@ async function readReadyRegistryModel(
     throw new Error("The Classic registry has no confirmed snapshot");
   }
   const snapshotBlockNumber = registry.snapshot.blockNumber;
+  if (isClassicV3ExploreReleaseReady(config)) {
+    registry = mergeClassicV3ExploreModel(
+      registry,
+      await readClassicV3ExploreModel(config, snapshotBlockNumber),
+    );
+  }
   if (isDeepExploreReleaseReady(config)) {
     registry = mergeDeepExploreModel(
       registry,
@@ -852,6 +863,9 @@ export async function readExploreModel(
     isStockPairedExploreReleaseReady(config)
       ? "stock-paired-ready"
       : "stock-paired-off",
+    isClassicV3ExploreReleaseReady(config)
+      ? "classic-v3-ready"
+      : "classic-v3-off",
   ].join(":");
   if (
     cachedRead &&
@@ -866,6 +880,15 @@ export async function readExploreModel(
       const durable = await readDurableExploreModel(config);
       if (durable.status === "ready") {
         let model = durable.envelope.payload.model;
+        if (model.snapshot && isClassicV3ExploreReleaseReady(config)) {
+          model = mergeClassicV3ExploreModel(
+            model,
+            await readClassicV3ExploreModel(
+              config,
+              model.snapshot.blockNumber,
+            ),
+          );
+        }
         if (
           model.snapshot &&
           isStockPairedExploreReleaseReady(config)

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -126,6 +126,7 @@ export type LauncherToken = {
   totalSwapFeeBps: number;
   launchModel?: "classic" | "adaptive" | "deep" | "stock-paired";
   launchModelVersion?:
+    | "classic-v3"
     | "stock-paired-v1"
     | "stock-paired-v2"
     | "stock-paired-v3";

--- a/lib/trade/server.ts
+++ b/lib/trade/server.ts
@@ -13,6 +13,10 @@ import mainnetDeployments from "../../contracts/dependencies/ethereum-mainnet.js
 import sepoliaDeployments from "../../contracts/dependencies/ethereum-sepolia.json";
 import mainnetDeepV3Manifest from "../../contracts/deployments/mainnet-deep-full-range-v3.json";
 import {
+  getConfiguredClassicV3Release,
+  isClassicV3ReleaseVerified,
+} from "../classic-v3-release";
+import {
   NATIVE_ETH,
   amountOutMinimum,
   assertClassicDeadline,
@@ -287,6 +291,50 @@ export function resolveClassicTradeDeployment(
   return deployment;
 }
 
+export function resolveClassicV3TradeDeployment(
+  chainId: number,
+): ClassicTradeRelease {
+  const official = getPinnedOfficialTradeStack(chainId);
+  const environment =
+    chainId === 1
+      ? "production"
+      : chainId === 11_155_111
+        ? "rehearsal"
+        : null;
+  if (!environment) {
+    throw new ClassicTradeUnavailableError(
+      `Classic V3 trading is not supported on chain ${chainId}`,
+    );
+  }
+  const { appManifest, releaseManifest } =
+    getConfiguredClassicV3Release(environment);
+  if (!isClassicV3ReleaseVerified(appManifest, releaseManifest, chainId)) {
+    throw new ClassicTradeUnavailableError(
+      `Classic V3 trading has no verified release on chain ${chainId}`,
+    );
+  }
+  const hookRuntimeCodeHash =
+    appManifest.runtimeCodeHashes?.ethCreatorFeeHookV3;
+  if (
+    typeof appManifest.ethCreatorFeeHookV3 !== "string" ||
+    typeof hookRuntimeCodeHash !== "string" ||
+    !isHex(hookRuntimeCodeHash) ||
+    hookRuntimeCodeHash.length !== 66
+  ) {
+    throw new ClassicTradeUnavailableError(
+      `Classic V3 trading has no pinned hook release on chain ${chainId}`,
+    );
+  }
+  const deployment: ClassicTradeRelease = {
+    ...official,
+    launchModel: "classic",
+    hook: getAddress(appManifest.ethCreatorFeeHookV3),
+    hookRuntimeCodeHash,
+  };
+  assertClassicTradeDeployment(deployment);
+  return deployment;
+}
+
 function verifiedIndexedToken(
   model: ExploreReadModel,
   chainId: number,
@@ -342,7 +390,10 @@ export function resolveTradeDeployment(
     );
   }
   if (launchModel === "classic") {
-    const deployment = resolveClassicTradeDeployment(chainId);
+    const deployment =
+      verified.launchModelVersion === "classic-v3"
+        ? resolveClassicV3TradeDeployment(chainId)
+        : resolveClassicTradeDeployment(chainId);
     assertVerifiedTradeToken(model, deployment, token);
     return deployment;
   }

--- a/tests/classic-v3-read-model.test.ts
+++ b/tests/classic-v3-read-model.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeClassicV3ExploreModel } from "../lib/onchain/classic-v3-read-model";
+import type { ExploreReadModel } from "../lib/onchain/types";
+import type { LauncherToken } from "../lib/tokens";
+
+const token: LauncherToken = {
+  id: "1:0x0000000000000000000000000000000000000001",
+  name: "Classic V3",
+  symbol: "CV3",
+  tokenAddress: "0x0000000000000000000000000000000000000001",
+  hookAddress: "0x0000000000000000000000000000000000000002",
+  poolId: `0x${"11".repeat(32)}`,
+  launchTransactionHash: `0x${"22".repeat(32)}`,
+  launchedAt: "2026-07-30T00:00:00.000Z",
+  totalSwapFeeBps: 100,
+  launchModel: "classic",
+  launchModelVersion: "classic-v3",
+  liquidityPath: "meme",
+};
+
+const model: ExploreReadModel = {
+  status: "ready",
+  tokens: [],
+  snapshot: {
+    chainId: 1,
+    blockNumber: "1",
+    blockHash: `0x${"33".repeat(32)}`,
+    confirmations: 12,
+  },
+  creatorClaims: [],
+  launcherFeesAccruedWei: "5",
+  launcherFeesAccruedEth: "0.000000000000000005",
+};
+
+describe("Classic V3 Explore merge", () => {
+  it("adds the release once and remains idempotent", () => {
+    const merged = mergeClassicV3ExploreModel(model, {
+      tokens: [token],
+      launcherFeesAccrued: 7n,
+    });
+    expect(merged.tokens).toEqual([token]);
+    expect(merged.launcherFeesAccruedWei).toBe("12");
+
+    const repeated = mergeClassicV3ExploreModel(merged, {
+      tokens: [token],
+      launcherFeesAccrued: 7n,
+    });
+    expect(repeated.launcherFeesAccruedWei).toBe("12");
+  });
+
+  it("rejects a conflicting launch identity", () => {
+    expect(() =>
+      mergeClassicV3ExploreModel(
+        { ...model, tokens: [token] },
+        {
+          tokens: [
+            {
+              ...token,
+              launchTransactionHash: `0x${"44".repeat(32)}`,
+            },
+          ],
+          launcherFeesAccrued: 0n,
+        },
+      ),
+    ).toThrow("Duplicate token across launch releases");
+  });
+});

--- a/tests/trade-prepare.test.ts
+++ b/tests/trade-prepare.test.ts
@@ -21,6 +21,7 @@ import {
   parseClassicTradeRequest,
   prepareClassicTrade,
   resolveClassicTradeDeployment,
+  resolveClassicV3TradeDeployment,
   resolveTradeDeployment,
   type ClassicTradeRelease,
   type ClassicTradeRuntimeClient,
@@ -493,6 +494,21 @@ describe("Trade request boundary", () => {
         TOKEN,
       ),
     ).toThrow("eligible verified release");
+  });
+
+  it("routes indexed Classic V3 launches through the verified V3 hook", () => {
+    const deployment = resolveClassicV3TradeDeployment(1);
+    const registry = readyRegistry(TOKEN, {}, deployment, {
+      launchModelVersion: "classic-v3",
+    });
+
+    expect(resolveTradeDeployment(1, registry, TOKEN)).toMatchObject({
+      chainId: 1,
+      launchModel: "classic",
+      hook: deployment.hook,
+      hookRuntimeCodeHash: deployment.hookRuntimeCodeHash,
+    });
+    expect(deployment.hook).not.toBe(resolveClassicTradeDeployment(1).hook);
   });
 
   it("rejects a Deep registry record with the wrong release hook", () => {


### PR DESCRIPTION
## What changed

Adds the verified Classic V3 release to the Explore registry and routes indexed Classic V3 tokens through the exact verified V3 hook. The token detail fallback no longer makes a false provenance claim when an address has not been indexed yet.

## Root cause

Classic V3 launches used a dedicated launcher and hook, but the central Explore and trade registry only indexed the older Classic release. Valid launches therefore returned 404 and could not prepare trades.

## Validation

- 56 targeted tests passed
- TypeScript check passed
- Production build passed
- Live mainnet Classic V3 read indexed the verified canary