### PR TITLE
Serve Classic V3 from the durable index

### DIFF
--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -880,15 +880,6 @@ export async function readExploreModel(
       const durable = await readDurableExploreModel(config);
       if (durable.status === "ready") {
         let model = durable.envelope.payload.model;
-        if (model.snapshot && isClassicV3ExploreReleaseReady(config)) {
-          model = mergeClassicV3ExploreModel(
-            model,
-            await readClassicV3ExploreModel(
-              config,
-              model.snapshot.blockNumber,
-            ),
-          );
-        }
         if (
           model.snapshot &&
           isStockPairedExploreReleaseReady(config)


### PR DESCRIPTION
## What changed

Serves Classic V3 launches from the durable minute-by-minute index instead of repeating the full onchain scan during every public Explore request.

## Root cause

Concurrent public requests repeated the same verified RPC reads and could exceed the provider rate limit. The operational indexer had already persisted all Classic V3 launches, so those reads did not belong in the request path.

## Validation

- 25 focused tests passed
- TypeScript check passed
- Production build passed
- Durable production index contains 97 launches including Classic V3
- Explore and Classic V3 token detail return HTTP 200