### PR TITLE
Keep public Explore reads off RPC

### DIFF
--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -879,19 +879,7 @@ export async function readExploreModel(
     if (config.environment === "production") {
       const durable = await readDurableExploreModel(config);
       if (durable.status === "ready") {
-        let model = durable.envelope.payload.model;
-        if (
-          model.snapshot &&
-          isStockPairedExploreReleaseReady(config)
-        ) {
-          model = mergeStockPairedExploreModel(
-            model,
-            await readStockPairedExploreModel(
-              config,
-              model.snapshot.blockNumber,
-            ),
-          );
-        }
+        const model = durable.envelope.payload.model;
         try {
           return await enrichExploreModelWithUsd(model, config);
         } catch (error) {


### PR DESCRIPTION
## What changed

Public Explore, token detail and profile reads now use the signed durable index exactly as stored. All release-specific onchain scans remain in the authenticated minute-by-minute indexer.

## Root cause

The public durable path still refreshed Stock-Paired state on every request. Concurrent requests could therefore exceed the RPC provider limit even after Classic V3 moved into the durable index.

## Validation

- 25 focused tests passed
- TypeScript check passed
- Production build passed
- Stable production restored while this patch passes CI