### PR TITLE
Open Stock-Paired launches

### DIFF
--- a/.github/workflows/mainnet-monitor.yml
+++ b/.github/workflows/mainnet-monitor.yml
@@ -51,6 +51,16 @@ jobs:
           set -o pipefail
           npm run contracts:mainnet:monitor:once 2>&1 | tee mainnet-monitor.log
 
+      - name: Run Stock-Paired V3 runtime and starting-FDV monitor
+        id: stock-monitor
+        continue-on-error: true
+        env:
+          MAINNET_RPC_URLS: ${{ secrets.MAINNET_RPC_URL_A }},${{ secrets.MAINNET_RPC_URL_B }}
+          STOCK_PAIRED_MONITOR_OUTPUT_FILE: stock-paired-v3-monitor.json
+        run: |
+          set -o pipefail
+          npm run contracts:stock-paired-v3:monitor 2>&1 | tee stock-paired-v3-monitor.log
+
       - name: Save canonical monitor cursor
         if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -69,9 +79,23 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+      - name: Preserve Stock-Paired monitor evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: stock-paired-v3-monitor-${{ github.run_id }}
+          path: |
+            stock-paired-v3-monitor.log
+            stock-paired-v3-monitor.json
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Open or update incident issue
-        if: steps.monitor.outcome == 'failure'
+        if: steps.monitor.outcome == 'failure' || steps.stock-monitor.outcome == 'failure'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CLASSIC_MONITOR_OUTCOME: ${{ steps.monitor.outcome }}
+          STOCK_MONITOR_OUTCOME: ${{ steps.stock-monitor.outcome }}
         with:
           script: |
             const title = "Mainnet monitor requires attention";
@@ -84,6 +108,9 @@ jobs:
             const existing = issues.find((issue) => issue.title === title);
             const body = [
               "The read-only Mainnet invariant monitor failed.",
+              "",
+              `Classic outcome: ${process.env.CLASSIC_MONITOR_OUTCOME}`,
+              `Stock-Paired V3 outcome: ${process.env.STOCK_MONITOR_OUTCOME}`,
               "",
               `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               "",
@@ -107,7 +134,7 @@ jobs:
             }
 
       - name: Close recovered incident issue
-        if: steps.monitor.outcome == 'success'
+        if: steps.monitor.outcome == 'success' && steps.stock-monitor.outcome == 'success'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -135,5 +162,5 @@ jobs:
             }
 
       - name: Fail workflow after evidence and alerting
-        if: steps.monitor.outcome == 'failure'
+        if: steps.monitor.outcome == 'failure' || steps.stock-monitor.outcome == 'failure'
         run: exit 1

--- a/app/api/launch/preflight/route.ts
+++ b/app/api/launch/preflight/route.ts
@@ -115,6 +115,10 @@ import {
 } from "@/lib/stock-paired-release";
 import { isStockPairedPublicLaunchEnabled } from "@/lib/stock-paired-access";
 import {
+  assessStockPairedRuntimeFdv,
+  STOCK_PAIRED_RUNTIME_FDV_PROBE_WEI,
+} from "@/lib/stock-paired-runtime-fdv";
+import {
   resolveImplementedLaunchModel,
   resolveReservedLaunchModel,
   type DeepLaunchModelRelease,
@@ -2352,6 +2356,37 @@ async function quoteStockPairedExternalRoute(
   return { amountOut, gasEstimate };
 }
 
+async function assertStockPairedRuntimeFdv(
+  account: Address,
+  quoteAsset: Address,
+  targetQuoteAmountWad: string,
+) {
+  let routeQuoteAmount: bigint;
+  try {
+    const quote = await quoteStockPairedExternalRoute(
+      account,
+      quoteAsset,
+      STOCK_PAIRED_RUNTIME_FDV_PROBE_WEI,
+      "buy",
+    );
+    routeQuoteAmount = quote.amountOut;
+  } catch {
+    throw new LaunchInputError(
+      "Current Stock-Paired launch pricing could not be verified from the reviewed ETH route",
+    );
+  }
+
+  const assessment = assessStockPairedRuntimeFdv({
+    targetQuoteAmountWad,
+    routeQuoteAmount,
+  });
+  if (!assessment.withinPolicy) {
+    throw new LaunchInputError(
+      "New Stock-Paired launches are paused because the current starting FDV is outside the reviewed range",
+    );
+  }
+}
+
 async function findStockPairedCurrency0Salt({
   account,
   coordinator,
@@ -2452,6 +2487,19 @@ async function prepareStockPairedLaunch(
   }
 
   await assertStockPairedInfrastructure(release);
+  if (
+    release.internalContractRelease !== "stock-paired-v3" ||
+    !("targetQuoteAmountWad" in configuration.quoteAsset)
+  ) {
+    throw new LaunchInputError(
+      "The current Stock-Paired starting FDV policy is not available",
+    );
+  }
+  await assertStockPairedRuntimeFdv(
+    account,
+    configuration.quoteAsset.address,
+    configuration.quoteAsset.targetQuoteAmountWad,
+  );
   const { ethLaunchCoordinator, feeHook } = release.addresses;
   const predicted = await client.readContract({
     address: ethLaunchCoordinator,

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -40,9 +40,8 @@ export default function DocsPage() {
         <div className={styles.callout}>
           <strong>Release status is part of the product.</strong>
           <p>
-            Classic is available for public launches. Stock-Paired has a
-            verified Mainnet deployment but remains restricted in the
-            interface.
+            Classic and Stock-Paired are available for public launches on
+            Ethereum Mainnet.
           </p>
         </div>
 
@@ -70,7 +69,9 @@ export default function DocsPage() {
           >
             <span className={styles.modelCardHeader}>
               <strong>Stock-Paired</strong>
-              <span className={styles.status}>Restricted</span>
+              <span className={styles.status} data-status="live">
+                Live
+              </span>
             </span>
             <p>
               Pairs a new token with a reviewed Ondo Global Markets asset

--- a/contracts/deployments/evidence/stock-paired-v3-final-pricing.json
+++ b/contracts/deployments/evidence/stock-paired-v3-final-pricing.json
@@ -7,26 +7,26 @@
     "calculationVersion": "tick-fdv-v1",
     "rpcAgreement": {
       "sampledHead": {
-        "number": 25643030,
-        "hash": "0x9aef6550233770fc0678f4df436ec08de7c1e0f6a68ba200341239bff466194a",
-        "timestamp": 1785382727
+        "number": 25646010,
+        "hash": "0xe8e0184f40edeabf3e1bad95a4047727f066208f85ef158cb9414fb4069eb17e",
+        "timestamp": 1785418547
       },
       "providers": [
         {
           "providerId": "ethereum-rpc.publicnode.com",
           "chainId": 1,
-          "sampledBlockNumber": 25643030,
-          "sampledBlockHash": "0x9aef6550233770fc0678f4df436ec08de7c1e0f6a68ba200341239bff466194a",
-          "reportedHeadNumber": 25643032,
-          "observationSetHash": "0xb1d46bda4173d3d76d80bea5c50ad50a72c28af906db1672e3e404abd44da1e2"
+          "sampledBlockNumber": 25646010,
+          "sampledBlockHash": "0xe8e0184f40edeabf3e1bad95a4047727f066208f85ef158cb9414fb4069eb17e",
+          "reportedHeadNumber": 25646012,
+          "observationSetHash": "0xabfb4e8d793df292516c4e4fd940a15722e1df87efdb49aba3712f56d66a116c"
         },
         {
           "providerId": "eth.drpc.org",
           "chainId": 1,
-          "sampledBlockNumber": 25643030,
-          "sampledBlockHash": "0x9aef6550233770fc0678f4df436ec08de7c1e0f6a68ba200341239bff466194a",
-          "reportedHeadNumber": 25643032,
-          "observationSetHash": "0xb1d46bda4173d3d76d80bea5c50ad50a72c28af906db1672e3e404abd44da1e2"
+          "sampledBlockNumber": 25646010,
+          "sampledBlockHash": "0xe8e0184f40edeabf3e1bad95a4047727f066208f85ef158cb9414fb4069eb17e",
+          "reportedHeadNumber": 25646012,
+          "observationSetHash": "0xabfb4e8d793df292516c4e4fd940a15722e1df87efdb49aba3712f56d66a116c"
         }
       ]
     },
@@ -43,11 +43,11 @@
       "maximumHeadLagBlocks": 25
     },
     "marketSession": {
-      "state": "closed",
-      "observedAt": 1785382740,
+      "state": "open",
+      "observedAt": 1785418558,
       "timeZone": "America/New_York",
-      "lastEligibleTradingSessionClosedAt": 1785369600,
-      "nextEligibleTradingSessionOpensAt": 1785398400,
+      "lastEligibleTradingSessionClosedAt": null,
+      "nextEligibleTradingSessionOpensAt": null,
       "scheduleSources": [
         {
           "venue": "NASDAQ",
@@ -69,7 +69,7 @@
       "token0Decimals": 6,
       "token1Decimals": 18,
       "runtimeCodeHash": "0xa981b66c747a3d9fa29d7e200d5faaa2826960523d0e5a0df8148e8868c480b4",
-      "sqrtPriceX96": "1813531059804898591079396199447087"
+      "sqrtPriceX96": "1809079812755912474685812002407341"
     },
     "assets": [
       {
@@ -86,25 +86,25 @@
           "token0Decimals": 18,
           "token1Decimals": 6,
           "runtimeCodeHash": "0x0c488df5bd90182f1e19b3c300eab4f99ab3c68d756250fd22589441b7c67e06",
-          "sqrtPriceX96": "1099199494266237923555083"
+          "sqrtPriceX96": "1104097271037301827546415"
         },
         "independentReference": {
-          "provider": "openai-finance",
+          "provider": "nasdaq-market-data",
           "instrument": "NASDAQ:NVDA",
           "currency": "USD",
           "venue": "NASDAQ",
-          "marketState": "closed",
-          "priceUsdWad": "190010000000000000000",
-          "asOf": 1785370500,
-          "retrievedAt": 1785382740,
-          "referenceId": "finance:NVDA:2026-07-30T00:15:00Z"
+          "marketState": "open",
+          "priceUsdWad": "192170000000000000000",
+          "asOf": 1785418500,
+          "retrievedAt": 1785418558,
+          "referenceId": "nasdaq:NVDA:2026-07-30T13:35:00Z"
         },
         "derived": {
           "tickSqrtPriceX96": "9212304827741815476690072",
           "tickQuoteFdvWad": "13520023064276052820",
-          "routeQuotePerEthWad": "9915515531550178553",
-          "independentQuotePerEthWad": "10044601543164213609",
-          "impliedFdvEthWei": "1363521949136854444"
+          "routeQuotePerEthWad": "9876162047713091109",
+          "independentQuotePerEthWad": "9980633830383779588",
+          "impliedFdvEthWei": "1368955166891649835"
         }
       },
       {
@@ -121,25 +121,25 @@
           "token0Decimals": 6,
           "token1Decimals": 18,
           "runtimeCodeHash": "0x9ce9b74c4e3e51f9bcf2ad9d28f09df179f96f7d17e423aa9207a69dc1558252",
-          "sqrtPriceX96": "2916659489935457247806403173376439"
+          "sqrtPriceX96": "2912077057485341171045472582660472"
         },
         "independentReference": {
-          "provider": "openai-finance",
+          "provider": "nasdaq-market-data",
           "instrument": "NYSEARCA:SPY",
           "currency": "USD",
           "venue": "NYSE Arca",
-          "marketState": "closed",
-          "priceUsdWad": "729460000000000000000",
-          "asOf": 1785370500,
-          "retrievedAt": 1785382740,
-          "referenceId": "finance:SPY:2026-07-30T00:15:00Z"
+          "marketState": "open",
+          "priceUsdWad": "735100000000000000000",
+          "asOf": 1785418500,
+          "retrievedAt": 1785418558,
+          "referenceId": "nasdaq:SPY:2026-07-30T13:35:00Z"
         },
         "derived": {
           "tickSqrtPriceX96": "4714173313173465756139773",
           "tickQuoteFdvWad": "3540396661305328988",
-          "routeQuotePerEthWad": "2586553485675609123",
-          "independentQuotePerEthWad": "2616421379125150423",
-          "impliedFdvEthWei": "1368769940738563745"
+          "routeQuotePerEthWad": "2591136373008119051",
+          "independentQuotePerEthWad": "2609139441143859234",
+          "impliedFdvEthWei": "1366349026699504993"
         }
       },
       {
@@ -159,22 +159,22 @@
           "sqrtPriceX96": "4327133225226020160341490391972508"
         },
         "independentReference": {
-          "provider": "openai-finance",
+          "provider": "nasdaq-market-data",
           "instrument": "NASDAQ:GOOGL",
           "currency": "USD",
           "venue": "NASDAQ",
-          "marketState": "closed",
-          "priceUsdWad": "336710000000000000000",
-          "asOf": 1785370500,
-          "retrievedAt": 1785382740,
-          "referenceId": "finance:GOOGL:2026-07-30T00:15:00Z"
+          "marketState": "open",
+          "priceUsdWad": "332575000000000000000",
+          "asOf": 1785418500,
+          "retrievedAt": 1785418558,
+          "referenceId": "nasdaq:GOOGL:2026-07-30T13:35:00Z"
         },
         "derived": {
           "tickSqrtPriceX96": "6962607679468676520282677",
           "tickQuoteFdvWad": "7722975943643816421",
-          "routeQuotePerEthWad": "5693122611211786830",
-          "independentQuotePerEthWad": "5668304295140127195",
-          "impliedFdvEthWei": "1356544812232662117"
+          "routeQuotePerEthWad": "5721172973016154608",
+          "independentQuotePerEthWad": "5767055260271670821",
+          "impliedFdvEthWei": "1349893803258377627"
         }
       },
       {
@@ -191,25 +191,25 @@
           "token0Decimals": 6,
           "token1Decimals": 18,
           "runtimeCodeHash": "0x78981bb1657e3a587ec8a74460e263f638f051511c62431b090277d38698ea79",
-          "sqrtPriceX96": "10945643372896691820169253381630541"
+          "sqrtPriceX96": "10945191228257967812870716944169534"
         },
         "independentReference": {
-          "provider": "openai-finance",
+          "provider": "nasdaq-market-data",
           "instrument": "NYSEARCA:SLV",
           "currency": "USD",
           "venue": "NYSE Arca",
-          "marketState": "closed",
-          "priceUsdWad": "51770000000000000000",
-          "asOf": 1785370500,
-          "retrievedAt": 1785382740,
-          "referenceId": "finance:SLV:2026-07-30T00:15:00Z"
+          "marketState": "open",
+          "priceUsdWad": "52245000000000000000",
+          "asOf": 1785418440,
+          "retrievedAt": 1785418558,
+          "referenceId": "nasdaq:SLV:2026-07-30T13:34:00Z"
         },
         "derived": {
           "tickSqrtPriceX96": "17645972561664955685685170",
           "tickQuoteFdvWad": "49605751312209836038",
-          "routeQuotePerEthWad": "36427770516162180844",
-          "independentQuotePerEthWad": "36866423396110338575",
-          "impliedFdvEthWei": "1361756445956550706"
+          "routeQuotePerEthWad": "36604228064179565778",
+          "independentQuotePerEthWad": "36711233671831771913",
+          "impliedFdvEthWei": "1355191843555181985"
         }
       },
       {
@@ -226,25 +226,25 @@
           "token0Decimals": 6,
           "token1Decimals": 18,
           "runtimeCodeHash": "0x8924e50b838c5e1ee3ec68c18a41e29c4d1403a03384f900c5659184e00d03d9",
-          "sqrtPriceX96": "4607528850678726361842183205840206"
+          "sqrtPriceX96": "4506225746848874943285975942071050"
         },
         "independentReference": {
-          "provider": "openai-finance",
+          "provider": "nasdaq-market-data",
           "instrument": "NASDAQ:TSLA",
           "currency": "USD",
           "venue": "NASDAQ",
-          "marketState": "closed",
-          "priceUsdWad": "298320000000000000000",
-          "asOf": 1785370500,
-          "retrievedAt": 1785382740,
-          "referenceId": "finance:TSLA:2026-07-30T00:15:00Z"
+          "marketState": "open",
+          "priceUsdWad": "305570000000000000000",
+          "asOf": 1785418500,
+          "retrievedAt": 1785418558,
+          "referenceId": "nasdaq:TSLA:2026-07-30T13:35:00Z"
         },
         "derived": {
           "tickSqrtPriceX96": "7393129115375123816015169",
           "tickQuoteFdvWad": "8707578819134800530",
-          "routeQuotePerEthWad": "6454849645197240853",
-          "independentQuotePerEthWad": "6397743159079619965",
-          "impliedFdvEthWei": "1348997931441162643"
+          "routeQuotePerEthWad": "6204552081357878575",
+          "independentQuotePerEthWad": "6276723510766275889",
+          "impliedFdvEthWei": "1403417797925733515"
         }
       },
       {
@@ -261,31 +261,31 @@
           "token0Decimals": 18,
           "token1Decimals": 6,
           "runtimeCodeHash": "0x1ef0d1ec03b74d0240a743a2ac44941fad4401a3600a219afdc25f6b3d816b2a",
-          "sqrtPriceX96": "1463596069436387980672637"
+          "sqrtPriceX96": "1447311541193776426836991"
         },
         "independentReference": {
-          "provider": "openai-finance",
+          "provider": "nasdaq-market-data",
           "instrument": "NASDAQ:AAPL",
           "currency": "USD",
           "venue": "NASDAQ",
-          "marketState": "closed",
-          "priceUsdWad": "338190000000000000000",
-          "asOf": 1785370500,
-          "retrievedAt": 1785382740,
-          "referenceId": "finance:AAPL:2026-07-30T00:15:00Z"
+          "marketState": "open",
+          "priceUsdWad": "332497500000000000000",
+          "asOf": 1785418500,
+          "retrievedAt": 1785418558,
+          "referenceId": "nasdaq:AAPL:2026-07-30T13:35:00Z"
         },
         "derived": {
           "tickSqrtPriceX96": "6893332021954032884083235",
           "tickQuoteFdvWad": "7570058343489581718",
-          "routeQuotePerEthWad": "5592755968482561870",
-          "independentQuotePerEthWad": "5643498445301848747",
-          "impliedFdvEthWei": "1353547050175247611"
+          "routeQuotePerEthWad": "5747498009506003717",
+          "independentQuotePerEthWad": "5768399471228658632",
+          "impliedFdvEthWei": "1317104996116427831"
         }
       }
     ]
   },
   "attestation": {
     "canonicalization": "RFC8785-JCS",
-    "payloadSha256": "sha256:27bd130b95b708bf6d8e365682f02bcf7df47d631c0f119a695d5a0d61c64bc6"
+    "payloadSha256": "sha256:b334c2d2f17e5208a23f8bdfb6621f2140b8a9035f6eeca0bfda4f8be9c12578"
   }
 }

--- a/contracts/deployments/evidence/stock-paired-v3-independent-references.json
+++ b/contracts/deployments/evidence/stock-paired-v3-independent-references.json
@@ -1,20 +1,20 @@
 {
   "schema": "stock-paired-v3-independent-references-v1",
   "status": "reviewed",
-  "retrievedAt": 1785382740,
+  "retrievedAt": 1785418558,
   "providerMetadata": {
-    "providerId": "openai-finance",
-    "retrievalChannel": "web.finance",
+    "providerId": "nasdaq-market-data",
+    "retrievalChannel": "api.nasdaq.com",
     "currency": "USD",
-    "latestTradeTime": "2026-07-30T00:15:00Z",
-    "note": "The latest available trades were captured after the official extended session closed. The explicit closed-market policy applies."
+    "latestTradeTime": "2026-07-30T13:35:00Z",
+    "note": "Official Nasdaq market data reported real-time trades during the regular session."
   },
   "marketSession": {
-    "state": "closed",
-    "observedAt": 1785382740,
+    "state": "open",
+    "observedAt": 1785418558,
     "timeZone": "America/New_York",
-    "lastEligibleTradingSessionClosedAt": 1785369600,
-    "nextEligibleTradingSessionOpensAt": 1785398400,
+    "lastEligibleTradingSessionClosedAt": null,
+    "nextEligibleTradingSessionOpensAt": null,
     "scheduleSources": [
       {
         "venue": "NASDAQ",
@@ -31,75 +31,75 @@
   "assets": [
     {
       "symbol": "NVDAon",
-      "provider": "openai-finance",
+      "provider": "nasdaq-market-data",
       "instrument": "NASDAQ:NVDA",
       "venue": "NASDAQ",
-      "marketState": "closed",
+      "marketState": "open",
       "currency": "USD",
-      "priceUsdWad": "190010000000000000000",
-      "asOf": 1785370500,
-      "retrievedAt": 1785382740,
-      "referenceId": "finance:NVDA:2026-07-30T00:15:00Z"
+      "priceUsdWad": "192170000000000000000",
+      "asOf": 1785418500,
+      "retrievedAt": 1785418558,
+      "referenceId": "nasdaq:NVDA:2026-07-30T13:35:00Z"
     },
     {
       "symbol": "SPYon",
-      "provider": "openai-finance",
+      "provider": "nasdaq-market-data",
       "instrument": "NYSEARCA:SPY",
       "venue": "NYSE Arca",
-      "marketState": "closed",
+      "marketState": "open",
       "currency": "USD",
-      "priceUsdWad": "729460000000000000000",
-      "asOf": 1785370500,
-      "retrievedAt": 1785382740,
-      "referenceId": "finance:SPY:2026-07-30T00:15:00Z"
+      "priceUsdWad": "735100000000000000000",
+      "asOf": 1785418500,
+      "retrievedAt": 1785418558,
+      "referenceId": "nasdaq:SPY:2026-07-30T13:35:00Z"
     },
     {
       "symbol": "GOOGLon",
-      "provider": "openai-finance",
+      "provider": "nasdaq-market-data",
       "instrument": "NASDAQ:GOOGL",
       "venue": "NASDAQ",
-      "marketState": "closed",
+      "marketState": "open",
       "currency": "USD",
-      "priceUsdWad": "336710000000000000000",
-      "asOf": 1785370500,
-      "retrievedAt": 1785382740,
-      "referenceId": "finance:GOOGL:2026-07-30T00:15:00Z"
+      "priceUsdWad": "332575000000000000000",
+      "asOf": 1785418500,
+      "retrievedAt": 1785418558,
+      "referenceId": "nasdaq:GOOGL:2026-07-30T13:35:00Z"
     },
     {
       "symbol": "SLVon",
-      "provider": "openai-finance",
+      "provider": "nasdaq-market-data",
       "instrument": "NYSEARCA:SLV",
       "venue": "NYSE Arca",
-      "marketState": "closed",
+      "marketState": "open",
       "currency": "USD",
-      "priceUsdWad": "51770000000000000000",
-      "asOf": 1785370500,
-      "retrievedAt": 1785382740,
-      "referenceId": "finance:SLV:2026-07-30T00:15:00Z"
+      "priceUsdWad": "52245000000000000000",
+      "asOf": 1785418440,
+      "retrievedAt": 1785418558,
+      "referenceId": "nasdaq:SLV:2026-07-30T13:34:00Z"
     },
     {
       "symbol": "TSLAon",
-      "provider": "openai-finance",
+      "provider": "nasdaq-market-data",
       "instrument": "NASDAQ:TSLA",
       "venue": "NASDAQ",
-      "marketState": "closed",
+      "marketState": "open",
       "currency": "USD",
-      "priceUsdWad": "298320000000000000000",
-      "asOf": 1785370500,
-      "retrievedAt": 1785382740,
-      "referenceId": "finance:TSLA:2026-07-30T00:15:00Z"
+      "priceUsdWad": "305570000000000000000",
+      "asOf": 1785418500,
+      "retrievedAt": 1785418558,
+      "referenceId": "nasdaq:TSLA:2026-07-30T13:35:00Z"
     },
     {
       "symbol": "AAPLon",
-      "provider": "openai-finance",
+      "provider": "nasdaq-market-data",
       "instrument": "NASDAQ:AAPL",
       "venue": "NASDAQ",
-      "marketState": "closed",
+      "marketState": "open",
       "currency": "USD",
-      "priceUsdWad": "338190000000000000000",
-      "asOf": 1785370500,
-      "retrievedAt": 1785382740,
-      "referenceId": "finance:AAPL:2026-07-30T00:15:00Z"
+      "priceUsdWad": "332497500000000000000",
+      "asOf": 1785418500,
+      "retrievedAt": 1785418558,
+      "referenceId": "nasdaq:AAPL:2026-07-30T13:35:00Z"
     }
   ]
 }

--- a/contracts/deployments/mainnet-stock-paired-v3.json
+++ b/contracts/deployments/mainnet-stock-paired-v3.json
@@ -104,8 +104,8 @@
     "finalActivationPricing": {
       "status": "verified-current-release",
       "evidencePath": "contracts/deployments/evidence/stock-paired-v3-final-pricing.json",
-      "evidenceSha256": "sha256:27bd130b95b708bf6d8e365682f02bcf7df47d631c0f119a695d5a0d61c64bc6",
-      "verifiedAt": "2026-07-30T03:39:13.000Z"
+      "evidenceSha256": "sha256:b334c2d2f17e5208a23f8bdfb6621f2140b8a9035f6eeca0bfda4f8be9c12578",
+      "verifiedAt": "2026-07-30T13:36:21.000Z"
     },
     "disclosure": "Starts near Classic's 1.355657760817103798 ETH initial FDV. The exact USD value moves with ETH and the selected quote asset."
   },

--- a/contracts/scripts/monitor-stock-paired-v3.mjs
+++ b/contracts/scripts/monitor-stock-paired-v3.mjs
@@ -1,0 +1,748 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { encodeFunctionData, keccak256, parseAbi } from "viem";
+
+import {
+  getSqrtPriceAtTick,
+  isWithinBps,
+} from "./verify-stock-paired-v3-final-pricing.mjs";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+const DEFAULT_MANIFEST_PATH = resolve(
+  ROOT,
+  "contracts/deployments/mainnet-stock-paired-v3.json",
+);
+const DEFAULT_CONFIG_PATH = resolve(ROOT, "config/stock-paired-assets.v3.json");
+const DEFAULT_RPCS = [
+  "https://ethereum-rpc.publicnode.com",
+  "https://eth.drpc.org",
+];
+
+const CHAIN_ID = 1;
+const REQUIRED_ASSET_COUNT = 6;
+const REQUIRED_MAXIMUM_FDV_DEVIATION_BPS = 500;
+const DEFAULT_CONFIRMATIONS = 2;
+const MAX_HEAD_LAG_BLOCKS = 25;
+const WAD = 10n ** 18n;
+const Q192 = 1n << 192n;
+const TOKEN_SUPPLY = 1_000_000_000n * WAD;
+const WETH = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+const WETH_USDC_POOL = "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640";
+const WETH_USDC_POOL_RUNTIME_CODE_HASH =
+  "0xa981b66c747a3d9fa29d7e200d5faaa2826960523d0e5a0df8148e8868c480b4";
+
+const SELECTOR = {
+  slot0: "0x3850c7bd",
+  token0: "0x0dfe1681",
+  token1: "0xd21220a7",
+};
+
+const quoteRegistryAbi = parseAbi([
+  "function assertAssetReady(address asset) view returns (bytes32 assetConfigurationHash)",
+]);
+
+function fail(message) {
+  throw new Error(`Stock-Paired V3 monitor failed: ${message}`);
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value;
+}
+
+function requireInteger(value, label, minimum = 0) {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    fail(`${label} must be an integer >= ${minimum}`);
+  }
+  return value;
+}
+
+function requireAddress(value, label) {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(value)) {
+    fail(`${label} must be an Ethereum address`);
+  }
+  return value.toLowerCase();
+}
+
+function requireHex32(value, label) {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(value)) {
+    fail(`${label} must be a 32-byte hex value`);
+  }
+  return value.toLowerCase();
+}
+
+function requirePositiveDecimal(value, label) {
+  if (typeof value !== "string" || !/^[1-9]\d*$/.test(value)) {
+    fail(`${label} must be a positive unsigned decimal string`);
+  }
+  return BigInt(value);
+}
+
+function sameAddress(left, right) {
+  return requireAddress(left, "address") === requireAddress(right, "address");
+}
+
+function hexQuantity(value) {
+  return `0x${BigInt(value).toString(16)}`;
+}
+
+function decodeUint(value, label) {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]+$/.test(value)) {
+    fail(`${label} returned malformed call data`);
+  }
+  return BigInt(value);
+}
+
+function decodeAddress(value, label) {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(value)) {
+    fail(`${label} returned malformed address data`);
+  }
+  return requireAddress(`0x${value.slice(-40)}`, label);
+}
+
+function endpointIdentity(url, label) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    fail(`${label} is not a valid URL`);
+  }
+  if (parsed.protocol !== "https:") fail(`${label} must use HTTPS`);
+  return parsed.hostname.toLowerCase();
+}
+
+export function parseTargetEthToWei(value) {
+  if (typeof value !== "string" || !/^(0|[1-9]\d*)(\.\d{1,18})?$/.test(value)) {
+    fail("targetInitialFdvEth must be a decimal with at most 18 places");
+  }
+  const [whole, fraction = ""] = value.split(".");
+  return BigInt(whole) * WAD + BigInt(fraction.padEnd(18, "0") || "0");
+}
+
+export function deviationBps(actual, expected) {
+  if (actual <= 0n || expected <= 0n) fail("FDV values must be positive");
+  const delta = actual >= expected ? actual - expected : expected - actual;
+  return (delta * 10_000n) / expected;
+}
+
+function mergeRuntimeBinding(bindings, label, address, runtimeCodeHash) {
+  const normalizedAddress = requireAddress(address, `${label}.address`);
+  const normalizedHash = requireHex32(
+    runtimeCodeHash,
+    `${label}.runtimeCodeHash`,
+  );
+  const current = bindings.get(normalizedAddress);
+  if (current && current.runtimeCodeHash !== normalizedHash) {
+    fail(`${label} conflicts with another runtime binding at ${normalizedAddress}`);
+  }
+  if (current) {
+    current.labels.push(label);
+  } else {
+    bindings.set(normalizedAddress, {
+      address: normalizedAddress,
+      runtimeCodeHash: normalizedHash,
+      labels: [label],
+    });
+  }
+}
+
+export function buildMonitorDefinition(manifest, config) {
+  requireObject(manifest, "manifest");
+  requireObject(config, "config");
+  if (
+    manifest.schemaVersion !== 3 ||
+    manifest.chainId !== CHAIN_ID ||
+    manifest.model !== "stock-paired" ||
+    manifest.internalContractRelease !== "stock-paired-v3"
+  ) {
+    fail("manifest is not the Ethereum Mainnet Stock-Paired V3 release");
+  }
+  if (
+    config.schemaVersion !== 3 ||
+    config.chainId !== CHAIN_ID ||
+    config.internalContractRelease !== "stock-paired-v3"
+  ) {
+    fail("asset config is not the Ethereum Mainnet Stock-Paired V3 config");
+  }
+  if (
+    manifest.pricePolicy?.maximumInitialFdvDeviationBps !==
+      REQUIRED_MAXIMUM_FDV_DEVIATION_BPS ||
+    config.priceCalibration?.maximumInitialFdvDeviationBps !==
+      REQUIRED_MAXIMUM_FDV_DEVIATION_BPS
+  ) {
+    fail("the reviewed maximum starting-FDV deviation must remain 500 bps");
+  }
+  const targetFdvEthWei = parseTargetEthToWei(
+    manifest.pricePolicy.targetInitialFdvEth,
+  );
+  if (
+    parseTargetEthToWei(config.launchPolicy?.targetInitialFdvEth) !==
+    targetFdvEthWei
+  ) {
+    fail("manifest and asset config disagree on the target starting FDV");
+  }
+  if (
+    !Array.isArray(config.assets) ||
+    config.assets.length !== REQUIRED_ASSET_COUNT ||
+    !Array.isArray(manifest.quoteAssets) ||
+    manifest.quoteAssets.length !== REQUIRED_ASSET_COUNT ||
+    !Array.isArray(manifest.pricePolicy.quoteTicks) ||
+    manifest.pricePolicy.quoteTicks.length !== REQUIRED_ASSET_COUNT
+  ) {
+    fail("the current release must contain exactly six quote assets");
+  }
+
+  const seenAssets = new Set();
+  const assets = config.assets.map((asset, index) => {
+    const manifestAsset = manifest.quoteAssets[index];
+    const tick = manifest.pricePolicy.quoteTicks[index];
+    const address = requireAddress(asset?.address, `assets[${index}].address`);
+    if (
+      typeof asset?.symbol !== "string" ||
+      asset.symbol.length === 0 ||
+      seenAssets.has(address) ||
+      manifestAsset?.symbol !== asset.symbol ||
+      !sameAddress(manifestAsset?.address, address) ||
+      tick?.symbol !== asset.symbol ||
+      !sameAddress(tick?.address, address) ||
+      tick?.initialAbsoluteTick !== asset.initialAbsoluteTick ||
+      tick?.targetQuoteAmountWad !== asset.targetQuoteAmountWad
+    ) {
+      fail(`asset ${index + 1} does not match the reviewed release table`);
+    }
+    seenAssets.add(address);
+    requireInteger(asset.initialAbsoluteTick, `${asset.symbol}.initialAbsoluteTick`, 1);
+    requirePositiveDecimal(asset.targetQuoteAmountWad, `${asset.symbol}.targetQuoteAmountWad`);
+    return {
+      symbol: asset.symbol,
+      address,
+      initialAbsoluteTick: asset.initialAbsoluteTick,
+      targetQuoteAmountWad: asset.targetQuoteAmountWad,
+      pool: requireAddress(asset.route?.pool, `${asset.symbol}.route.pool`),
+      poolRuntimeCodeHash: requireHex32(
+        asset.route?.poolRuntimeCodeHash,
+        `${asset.symbol}.route.poolRuntimeCodeHash`,
+      ),
+      stockPoolFee: requireInteger(
+        asset.route?.stockPoolFee,
+        `${asset.symbol}.route.stockPoolFee`,
+        1,
+      ),
+    };
+  });
+
+  const bindings = new Map();
+  const ownedRuntimeFields = [
+    "quoteRegistry",
+    "positionPlanner",
+    "feeSplitVaultFactory",
+    "hookFactory",
+    "feeHook",
+    "launcher",
+    "ethLaunchCoordinator",
+    "positionForwarderFactory",
+  ];
+  for (const field of ownedRuntimeFields) {
+    mergeRuntimeBinding(
+      bindings,
+      `release.${field}`,
+      manifest.addresses?.[field],
+      manifest.runtimeCodeHashes?.[field],
+    );
+  }
+  for (const [field, dependency] of Object.entries(
+    requireObject(manifest.officialDependencies, "officialDependencies"),
+  )) {
+    mergeRuntimeBinding(
+      bindings,
+      `official.${field}`,
+      dependency?.address,
+      dependency?.runtimeCodeHash,
+    );
+  }
+  const issuerRuntime = requireObject(manifest.issuerRuntime, "issuerRuntime");
+  mergeRuntimeBinding(
+    bindings,
+    "issuer.beacon",
+    issuerRuntime.beacon,
+    issuerRuntime.beaconRuntimeCodeHash,
+  );
+  mergeRuntimeBinding(
+    bindings,
+    "issuer.implementation",
+    issuerRuntime.implementation,
+    issuerRuntime.implementationRuntimeCodeHash,
+  );
+  mergeRuntimeBinding(
+    bindings,
+    "issuer.gmTokenManager",
+    issuerRuntime.gmTokenManager,
+    issuerRuntime.gmTokenManagerRuntimeCodeHash,
+  );
+  for (const asset of assets) {
+    mergeRuntimeBinding(
+      bindings,
+      `issuer.token.${asset.symbol}`,
+      asset.address,
+      issuerRuntime.tokenRuntimeCodeHash,
+    );
+    mergeRuntimeBinding(
+      bindings,
+      `route.${asset.symbol}`,
+      asset.pool,
+      asset.poolRuntimeCodeHash,
+    );
+  }
+  mergeRuntimeBinding(
+    bindings,
+    "route.WETH_USDC",
+    WETH_USDC_POOL,
+    WETH_USDC_POOL_RUNTIME_CODE_HASH,
+  );
+
+  return {
+    chainId: CHAIN_ID,
+    release: "stock-paired-v3",
+    quoteRegistry: requireAddress(
+      manifest.addresses.quoteRegistry,
+      "addresses.quoteRegistry",
+    ),
+    targetFdvEthWei,
+    maximumInitialFdvDeviationBps: REQUIRED_MAXIMUM_FDV_DEVIATION_BPS,
+    maximumHeadLagBlocks: MAX_HEAD_LAG_BLOCKS,
+    assets,
+    runtimeBindings: [...bindings.values()].sort((left, right) =>
+      left.address.localeCompare(right.address),
+    ),
+    routes: [
+      {
+        symbol: "WETH_USDC",
+        pool: WETH_USDC_POOL,
+        base: WETH,
+        quote: USDC,
+      },
+      ...assets.map((asset) => ({
+        symbol: asset.symbol,
+        pool: asset.pool,
+        base: USDC,
+        quote: asset.address,
+      })),
+    ],
+  };
+}
+
+class RpcClient {
+  constructor(url, providerId, fetchImpl = fetch) {
+    this.url = url;
+    this.providerId = providerId;
+    this.fetchImpl = fetchImpl;
+    this.id = 0;
+  }
+
+  async request(method, params) {
+    const response = await this.fetchImpl(this.url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: ++this.id,
+        method,
+        params,
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) fail(`${this.providerId} returned HTTP ${response.status}`);
+    const payload = await response.json();
+    if (payload.error) {
+      fail(`${this.providerId} ${method}: ${payload.error.message ?? "RPC error"}`);
+    }
+    return payload.result;
+  }
+
+  async batch(calls) {
+    const requests = calls.map(({ method, params }) => ({
+      jsonrpc: "2.0",
+      id: ++this.id,
+      method,
+      params,
+    }));
+    const response = await this.fetchImpl(this.url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(requests),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (response.ok) {
+      const payload = await response.json().catch(() => null);
+      if (Array.isArray(payload)) {
+        const byId = new Map(payload.map((entry) => [entry.id, entry]));
+        const complete = requests.every((request) => {
+          const entry = byId.get(request.id);
+          return entry && !entry.error;
+        });
+        if (complete) {
+          return requests.map((request) => byId.get(request.id).result);
+        }
+      }
+    }
+
+    // Some public providers reject JSON-RPC arrays even though each read is
+    // available. Keep the monitor provider-agnostic with bounded parallelism.
+    const results = [];
+    for (let index = 0; index < calls.length; index += 8) {
+      const chunk = calls.slice(index, index + 8);
+      results.push(
+        ...(await Promise.all(
+          chunk.map(({ method, params }) => this.request(method, params)),
+        )),
+      );
+    }
+    return results;
+  }
+}
+
+function normalizeRouteObservation(route, result) {
+  const [slot0, token0Raw, token1Raw] = result;
+  const token0 = decodeAddress(token0Raw, `${route.symbol}.token0`);
+  const token1 = decodeAddress(token1Raw, `${route.symbol}.token1`);
+  const base = requireAddress(route.base, `${route.symbol}.base`);
+  const quote = requireAddress(route.quote, `${route.symbol}.quote`);
+  if (!(
+    (token0 === base && token1 === quote) ||
+    (token0 === quote && token1 === base)
+  )) {
+    fail(`${route.symbol} pool no longer contains the reviewed token pair`);
+  }
+  if (typeof slot0 !== "string" || slot0.length < 66) {
+    fail(`${route.symbol}.slot0 returned malformed call data`);
+  }
+  const sqrtPriceX96 = decodeUint(
+    slot0.slice(0, 66),
+    `${route.symbol}.sqrtPriceX96`,
+  );
+  if (sqrtPriceX96 <= 0n || sqrtPriceX96 >= 1n << 160n) {
+    fail(`${route.symbol}.sqrtPriceX96 is outside uint160`);
+  }
+  return {
+    symbol: route.symbol,
+    pool: route.pool,
+    token0,
+    token1,
+    sqrtPriceX96: sqrtPriceX96.toString(),
+  };
+}
+
+async function readProviderSnapshot(client, definition, blockNumber) {
+  const blockTag = hexQuantity(blockNumber);
+  const assetReadyData = definition.assets.map((asset) =>
+    encodeFunctionData({
+      abi: quoteRegistryAbi,
+      functionName: "assertAssetReady",
+      args: [asset.address],
+    }),
+  );
+  const calls = [
+    ...definition.runtimeBindings.map((binding) => ({
+      method: "eth_getCode",
+      params: [binding.address, blockTag],
+    })),
+    ...definition.routes.flatMap((route) => [
+      { method: "eth_call", params: [{ to: route.pool, data: SELECTOR.slot0 }, blockTag] },
+      { method: "eth_call", params: [{ to: route.pool, data: SELECTOR.token0 }, blockTag] },
+      { method: "eth_call", params: [{ to: route.pool, data: SELECTOR.token1 }, blockTag] },
+    ]),
+    ...assetReadyData.map((data) => ({
+      method: "eth_call",
+      params: [{ to: definition.quoteRegistry, data }, blockTag],
+    })),
+  ];
+  const results = await client.batch(calls);
+  let cursor = 0;
+  const runtimeCodeHashes = {};
+  for (const binding of definition.runtimeBindings) {
+    const code = results[cursor++];
+    if (typeof code !== "string" || code === "0x") {
+      fail(`${binding.labels.join("|")} runtime code is missing`);
+    }
+    runtimeCodeHashes[binding.address] = keccak256(code).toLowerCase();
+  }
+  const routes = definition.routes.map((route) => {
+    const result = results.slice(cursor, cursor + 3);
+    cursor += 3;
+    return normalizeRouteObservation(route, result);
+  });
+  const assetConfigurationHashes = {};
+  for (const asset of definition.assets) {
+    assetConfigurationHashes[asset.address] = requireHex32(
+      results[cursor++],
+      `${asset.symbol}.assetConfigurationHash`,
+    );
+  }
+  return {
+    providerId: client.providerId,
+    runtimeCodeHashes,
+    routes,
+    assetConfigurationHashes,
+  };
+}
+
+function tokenDecimals(address) {
+  return sameAddress(address, USDC) ? 6 : 18;
+}
+
+function token1PerToken0Wad(route) {
+  const sqrtPriceX96 = requirePositiveDecimal(
+    route.sqrtPriceX96,
+    `${route.symbol}.sqrtPriceX96`,
+  );
+  return (
+    (sqrtPriceX96 *
+      sqrtPriceX96 *
+      10n ** BigInt(tokenDecimals(route.token0)) *
+      WAD) /
+    (Q192 * 10n ** BigInt(tokenDecimals(route.token1)))
+  );
+}
+
+function quotePerBaseWad(route, base, quote) {
+  const direct = token1PerToken0Wad(route);
+  if (direct === 0n) fail(`${route.symbol} midpoint rounds to zero`);
+  if (sameAddress(route.token0, base) && sameAddress(route.token1, quote)) {
+    return direct;
+  }
+  if (sameAddress(route.token0, quote) && sameAddress(route.token1, base)) {
+    return (WAD * WAD) / direct;
+  }
+  fail(`${route.symbol} route ordering is invalid`);
+}
+
+function stableSnapshot(snapshot) {
+  return JSON.stringify({
+    runtimeCodeHashes: snapshot.runtimeCodeHashes,
+    routes: snapshot.routes,
+    assetConfigurationHashes: snapshot.assetConfigurationHashes,
+  });
+}
+
+export function evaluateProviderSnapshots(definition, snapshots) {
+  if (!Array.isArray(snapshots) || snapshots.length !== 2) {
+    fail("exactly two provider snapshots are required");
+  }
+  if (snapshots[0].providerId === snapshots[1].providerId) {
+    fail("provider snapshots must come from distinct operators");
+  }
+  if (stableSnapshot(snapshots[0]) !== stableSnapshot(snapshots[1])) {
+    fail("the two RPCs disagree on runtime or route state");
+  }
+  const snapshot = snapshots[0];
+  for (const binding of definition.runtimeBindings) {
+    const actual = requireHex32(
+      snapshot.runtimeCodeHashes?.[binding.address],
+      `${binding.labels.join("|")}.observedRuntimeCodeHash`,
+    );
+    if (actual !== binding.runtimeCodeHash) {
+      fail(`${binding.labels.join("|")} runtime hash changed`);
+    }
+  }
+  for (const asset of definition.assets) {
+    requireHex32(
+      snapshot.assetConfigurationHashes?.[asset.address],
+      `${asset.symbol}.assetConfigurationHash`,
+    );
+  }
+  const routeBySymbol = new Map(
+    snapshot.routes.map((route) => [route.symbol, route]),
+  );
+  if (routeBySymbol.size !== definition.routes.length) {
+    fail("route observation set is incomplete");
+  }
+  const ethRoute = routeBySymbol.get("WETH_USDC");
+  if (!ethRoute) fail("WETH/USDC route observation is missing");
+  const ethUsdWad = quotePerBaseWad(ethRoute, WETH, USDC);
+  const results = definition.assets.map((asset) => {
+    const route = routeBySymbol.get(asset.symbol);
+    if (!route) fail(`${asset.symbol} route observation is missing`);
+    const quotePerUsdWad = quotePerBaseWad(route, USDC, asset.address);
+    const routeQuotePerEthWad = (ethUsdWad * quotePerUsdWad) / WAD;
+    if (routeQuotePerEthWad === 0n) {
+      fail(`${asset.symbol} quote-per-ETH midpoint rounds to zero`);
+    }
+    const tickSqrtPriceX96 = getSqrtPriceAtTick(-asset.initialAbsoluteTick);
+    const tickQuoteFdvWad =
+      (TOKEN_SUPPLY * tickSqrtPriceX96 * tickSqrtPriceX96) / Q192;
+    const impliedFdvEthWei =
+      (tickQuoteFdvWad * WAD) / routeQuotePerEthWad;
+    if (
+      !isWithinBps(
+        impliedFdvEthWei,
+        definition.targetFdvEthWei,
+        definition.maximumInitialFdvDeviationBps,
+      )
+    ) {
+      fail(
+        `${asset.symbol} starting FDV exceeds the 500 bps onchain route band`,
+      );
+    }
+    return {
+      symbol: asset.symbol,
+      impliedFdvEthWei: impliedFdvEthWei.toString(),
+      deviationBps: Number(
+        deviationBps(impliedFdvEthWei, definition.targetFdvEthWei),
+      ),
+    };
+  });
+  if (results.length !== REQUIRED_ASSET_COUNT) {
+    fail("the monitor did not evaluate all six assets");
+  }
+  return results;
+}
+
+async function writeAtomic(path, contents) {
+  const target = resolve(path);
+  const temporary = `${target}.${process.pid}.tmp`;
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(temporary, contents, { encoding: "utf8", mode: 0o600 });
+  await rename(temporary, target);
+}
+
+export async function runStockPairedV3Monitor({
+  manifest,
+  config,
+  rpcUrls,
+  fetchImpl = fetch,
+  confirmations = DEFAULT_CONFIRMATIONS,
+  observedAt = new Date(),
+}) {
+  if (!Array.isArray(rpcUrls) || rpcUrls.length !== 2) {
+    fail("exactly two RPC URLs are required");
+  }
+  const providerIds = rpcUrls.map((url, index) =>
+    endpointIdentity(url, `RPC ${index + 1}`),
+  );
+  if (new Set(providerIds).size !== 2) {
+    fail("RPC endpoints must use distinct provider hostnames");
+  }
+  requireInteger(confirmations, "confirmations", 1);
+  const definition = buildMonitorDefinition(manifest, config);
+  const clients = rpcUrls.map(
+    (url, index) => new RpcClient(url, providerIds[index], fetchImpl),
+  );
+  const heads = await Promise.all(
+    clients.map(async (client) =>
+      Number(BigInt(await client.request("eth_blockNumber", []))),
+    ),
+  );
+  const sampledBlockNumber = Math.min(...heads) - confirmations;
+  if (sampledBlockNumber <= 0) fail("RPC head is invalid");
+  const blocks = await Promise.all(
+    clients.map((client) =>
+      client.request("eth_getBlockByNumber", [
+        hexQuantity(sampledBlockNumber),
+        false,
+      ]),
+    ),
+  );
+  const blockHashes = blocks.map((block, index) =>
+    requireHex32(block?.hash, `provider ${index + 1} block hash`),
+  );
+  if (
+    blockHashes[0] !== blockHashes[1] ||
+    blocks.some(
+      (block) => Number(BigInt(block?.number)) !== sampledBlockNumber,
+    )
+  ) {
+    fail("the two RPCs disagree on the sampled block");
+  }
+  if (
+    heads.some(
+      (head) => head - sampledBlockNumber > definition.maximumHeadLagBlocks,
+    )
+  ) {
+    fail("the sampled block is too far behind an RPC head");
+  }
+  const snapshots = await Promise.all(
+    clients.map((client) =>
+      readProviderSnapshot(client, definition, sampledBlockNumber),
+    ),
+  );
+  const assets = evaluateProviderSnapshots(definition, snapshots);
+  return {
+    schemaVersion: 1,
+    status: "pass",
+    monitor: "stock-paired-v3-runtime-and-starting-fdv",
+    chainId: CHAIN_ID,
+    observedAt: observedAt.toISOString(),
+    sampledBlock: {
+      number: sampledBlockNumber,
+      hash: blockHashes[0],
+      timestamp: Number(BigInt(blocks[0].timestamp)),
+    },
+    providers: providerIds.map((providerId, index) => ({
+      providerId,
+      reportedHeadNumber: heads[index],
+    })),
+    policy: {
+      targetInitialFdvEthWei: definition.targetFdvEthWei.toString(),
+      maximumInitialFdvDeviationBps:
+        definition.maximumInitialFdvDeviationBps,
+    },
+    runtimeBindingCount: definition.runtimeBindings.length,
+    assets,
+    scope: {
+      onchainRuntimeBindings: true,
+      onchainStartingFdvRoutes: true,
+      issuerUnderlyingDrift: false,
+      externalStockPriceClaims: false,
+    },
+  };
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(resolve(path), "utf8"));
+}
+
+async function main() {
+  const rpcUrls = (process.env.MAINNET_RPC_URLS ?? DEFAULT_RPCS.join(","))
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const manifestPath =
+    process.env.STOCK_PAIRED_V3_MANIFEST_JSON ?? DEFAULT_MANIFEST_PATH;
+  const configPath =
+    process.env.STOCK_PAIRED_V3_ASSETS_JSON ?? DEFAULT_CONFIG_PATH;
+  const confirmations = Number(
+    process.env.STOCK_PAIRED_MONITOR_CONFIRMATIONS ?? DEFAULT_CONFIRMATIONS,
+  );
+  const [manifest, config] = await Promise.all([
+    readJson(manifestPath),
+    readJson(configPath),
+  ]);
+  const result = await runStockPairedV3Monitor({
+    manifest,
+    config,
+    rpcUrls,
+    confirmations,
+  });
+  const output = `${JSON.stringify(result, null, 2)}\n`;
+  if (process.env.STOCK_PAIRED_MONITOR_OUTPUT_FILE) {
+    await writeAtomic(process.env.STOCK_PAIRED_MONITOR_OUTPUT_FILE, output);
+  }
+  process.stdout.write(output);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/contracts/scripts/test/stock-paired-v3-monitor.test.mjs
+++ b/contracts/scripts/test/stock-paired-v3-monitor.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import {
+  buildMonitorDefinition,
+  evaluateProviderSnapshots,
+  parseTargetEthToWei,
+} from "../monitor-stock-paired-v3.mjs";
+
+const ROOT = resolve(import.meta.dirname, "../../..");
+const manifest = JSON.parse(
+  readFileSync(
+    resolve(ROOT, "contracts/deployments/mainnet-stock-paired-v3.json"),
+    "utf8",
+  ),
+);
+const config = JSON.parse(
+  readFileSync(resolve(ROOT, "config/stock-paired-assets.v3.json"), "utf8"),
+);
+const pricingEvidence = JSON.parse(
+  readFileSync(
+    resolve(
+      ROOT,
+      "contracts/deployments/evidence/stock-paired-v3-final-pricing.json",
+    ),
+    "utf8",
+  ),
+);
+
+function providerSnapshot(definition, providerId) {
+  const evidenceRoutes = pricingEvidence.payload.assets.map(({ symbol, route }) => ({
+    symbol,
+    pool: route.pool.toLowerCase(),
+    token0: route.token0.toLowerCase(),
+    token1: route.token1.toLowerCase(),
+    sqrtPriceX96: route.sqrtPriceX96,
+  }));
+  return {
+    providerId,
+    runtimeCodeHashes: Object.fromEntries(
+      definition.runtimeBindings.map(({ address, runtimeCodeHash }) => [
+        address,
+        runtimeCodeHash,
+      ]),
+    ),
+    routes: [
+      {
+        symbol: "WETH_USDC",
+        pool: pricingEvidence.payload.ethUsdRoute.pool.toLowerCase(),
+        token0: pricingEvidence.payload.ethUsdRoute.token0.toLowerCase(),
+        token1: pricingEvidence.payload.ethUsdRoute.token1.toLowerCase(),
+        sqrtPriceX96: pricingEvidence.payload.ethUsdRoute.sqrtPriceX96,
+      },
+      ...evidenceRoutes,
+    ],
+    assetConfigurationHashes: Object.fromEntries(
+      definition.assets.map(({ address }, index) => [
+        address,
+        `0x${(index + 1).toString(16).padStart(64, "0")}`,
+      ]),
+    ),
+  };
+}
+
+test("pins the current six-asset release and the 500 bps policy", () => {
+  const definition = buildMonitorDefinition(manifest, config);
+  assert.equal(definition.assets.length, 6);
+  assert.equal(definition.routes.length, 7);
+  assert.equal(definition.maximumInitialFdvDeviationBps, 500);
+  assert.equal(
+    definition.targetFdvEthWei,
+    parseTargetEthToWei("1.355657760817103798"),
+  );
+  assert.ok(definition.runtimeBindings.length > 20);
+});
+
+test("accepts two agreeing onchain snapshots within the starting-FDV band", () => {
+  const definition = buildMonitorDefinition(manifest, config);
+  const results = evaluateProviderSnapshots(definition, [
+    providerSnapshot(definition, "rpc-a.example"),
+    providerSnapshot(definition, "rpc-b.example"),
+  ]);
+  assert.deepEqual(
+    results.map(({ symbol }) => symbol),
+    ["NVDAon", "SPYon", "GOOGLon", "SLVon", "TSLAon", "AAPLon"],
+  );
+  assert.ok(results.every(({ deviationBps }) => deviationBps <= 500));
+});
+
+test("fails closed when a deployed runtime hash changes", () => {
+  const definition = buildMonitorDefinition(manifest, config);
+  const left = providerSnapshot(definition, "rpc-a.example");
+  const right = structuredClone(left);
+  right.providerId = "rpc-b.example";
+  const binding = definition.runtimeBindings[0];
+  left.runtimeCodeHashes[binding.address] = `0x${"99".repeat(32)}`;
+  right.runtimeCodeHashes[binding.address] = `0x${"99".repeat(32)}`;
+  assert.throws(
+    () => evaluateProviderSnapshots(definition, [left, right]),
+    /runtime hash changed/,
+  );
+});
+
+test("fails closed when the RPCs disagree", () => {
+  const definition = buildMonitorDefinition(manifest, config);
+  const left = providerSnapshot(definition, "rpc-a.example");
+  const right = providerSnapshot(definition, "rpc-b.example");
+  right.routes[1].sqrtPriceX96 = (
+    BigInt(right.routes[1].sqrtPriceX96) + 1n
+  ).toString();
+  assert.throws(
+    () => evaluateProviderSnapshots(definition, [left, right]),
+    /two RPCs disagree/,
+  );
+});
+
+test("fails closed when an onchain route breaches the 500 bps FDV band", () => {
+  const definition = buildMonitorDefinition(manifest, config);
+  const left = providerSnapshot(definition, "rpc-a.example");
+  const right = providerSnapshot(definition, "rpc-b.example");
+  for (const snapshot of [left, right]) {
+    snapshot.routes[1].sqrtPriceX96 = (
+      BigInt(snapshot.routes[1].sqrtPriceX96) * 2n
+    ).toString();
+  }
+  assert.throws(
+    () => evaluateProviderSnapshots(definition, [left, right]),
+    /NVDAon starting FDV exceeds the 500 bps onchain route band/,
+  );
+});
+
+test("rejects a policy change that silently widens the launch band", () => {
+  const changed = structuredClone(manifest);
+  changed.pricePolicy.maximumInitialFdvDeviationBps = 600;
+  assert.throws(
+    () => buildMonitorDefinition(changed, config),
+    /must remain 500 bps/,
+  );
+});
+

--- a/lib/stock-paired-access.ts
+++ b/lib/stock-paired-access.ts
@@ -7,7 +7,7 @@ export type StockPairedPublicLaunchRelease = {
   chainId: number;
 };
 
-export const STOCK_PAIRED_NEW_LAUNCHES_ENABLED = false;
+export const STOCK_PAIRED_NEW_LAUNCHES_ENABLED = true;
 
 export function isStockPairedDevAccount(
   account: string | null | undefined,

--- a/lib/stock-paired-runtime-fdv.ts
+++ b/lib/stock-paired-runtime-fdv.ts
@@ -1,0 +1,65 @@
+import { parseEther } from "viem";
+
+import { STOCK_PAIRED_V3_CONFIG } from "./stock-paired-v3";
+
+const BASIS_POINTS = 10_000n;
+
+export const STOCK_PAIRED_RUNTIME_FDV_PROBE_WEI = parseEther("0.005");
+export const STOCK_PAIRED_TARGET_INITIAL_FDV_WEI = parseEther(
+  STOCK_PAIRED_V3_CONFIG.targetInitialFdvEth,
+);
+export const STOCK_PAIRED_MAXIMUM_RUNTIME_FDV_DEVIATION_BPS = BigInt(
+  STOCK_PAIRED_V3_CONFIG.calibration.maximumInitialFdvDeviationBps,
+);
+
+export type StockPairedRuntimeFdvAssessment = {
+  impliedFdvEthWei: bigint;
+  deviationBps: bigint;
+  withinPolicy: boolean;
+};
+
+export function assessStockPairedRuntimeFdv({
+  targetQuoteAmountWad,
+  routeQuoteAmount,
+  probeAmountWei = STOCK_PAIRED_RUNTIME_FDV_PROBE_WEI,
+}: {
+  targetQuoteAmountWad: unknown;
+  routeQuoteAmount: bigint;
+  probeAmountWei?: bigint;
+}): StockPairedRuntimeFdvAssessment {
+  const targetQuoteAmount =
+    typeof targetQuoteAmountWad === "bigint"
+      ? targetQuoteAmountWad
+      : typeof targetQuoteAmountWad === "string" &&
+          /^[1-9]\d*$/.test(targetQuoteAmountWad)
+        ? BigInt(targetQuoteAmountWad)
+        : 0n;
+  if (
+    targetQuoteAmount <= 0n ||
+    routeQuoteAmount <= 0n ||
+    probeAmountWei <= 0n
+  ) {
+    throw new Error("The Stock-Paired runtime FDV inputs are invalid");
+  }
+
+  const impliedFdvEthWei =
+    (targetQuoteAmount * probeAmountWei) / routeQuoteAmount;
+  const absoluteDeviation =
+    impliedFdvEthWei >= STOCK_PAIRED_TARGET_INITIAL_FDV_WEI
+      ? impliedFdvEthWei - STOCK_PAIRED_TARGET_INITIAL_FDV_WEI
+      : STOCK_PAIRED_TARGET_INITIAL_FDV_WEI - impliedFdvEthWei;
+  const deviationBps =
+    (absoluteDeviation * BASIS_POINTS +
+      STOCK_PAIRED_TARGET_INITIAL_FDV_WEI -
+      1n) /
+    STOCK_PAIRED_TARGET_INITIAL_FDV_WEI;
+
+  return {
+    impliedFdvEthWei,
+    deviationBps,
+    withinPolicy:
+      absoluteDeviation * BASIS_POINTS <=
+      STOCK_PAIRED_TARGET_INITIAL_FDV_WEI *
+        STOCK_PAIRED_MAXIMUM_RUNTIME_FDV_DEVIATION_BPS,
+  };
+}

--- a/lib/stock-paired.ts
+++ b/lib/stock-paired.ts
@@ -28,7 +28,6 @@ import {
 } from "./stock-paired-v3";
 import {
   MEME_MIN_INITIAL_BUY_ETH,
-  MEME_MIN_INITIAL_BUY_WEI,
   type LaunchDraft,
 } from "./launch";
 import {
@@ -41,8 +40,11 @@ import {
 
 export const STOCK_PAIRED_MIN_INITIAL_BUY_RAW = 10_000_000_000_000_000n;
 export const STOCK_PAIRED_MIN_INITIAL_BUY = "0.01";
-export const STOCK_PAIRED_MIN_INITIAL_BUY_ETH_WEI = MEME_MIN_INITIAL_BUY_WEI;
-export const STOCK_PAIRED_MIN_INITIAL_BUY_ETH = MEME_MIN_INITIAL_BUY_ETH;
+export const STOCK_PAIRED_MIN_INITIAL_BUY_ETH = "0.005";
+export const STOCK_PAIRED_MIN_INITIAL_BUY_ETH_WEI = parseUnits(
+  STOCK_PAIRED_MIN_INITIAL_BUY_ETH,
+  18,
+);
 export const STOCK_PAIRED_DEFAULT_INITIAL_BUY_ETH = "0.01";
 export const STOCK_PAIRED_TOTAL_SWAP_FEE_BPS = 100;
 export const STOCK_PAIRED_CREATOR_FEE_BPS = 90;

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "contracts:stock-paired-v3:activation:check": "node scripts/prepare-stock-paired-v3-public-activation.mjs",
     "contracts:stock-paired-v3:activation:write": "node scripts/prepare-stock-paired-v3-public-activation.mjs --write",
     "contracts:stock-paired-v3:activation:test": "node --test scripts/test/stock-paired-v3-public-activation.test.mjs",
+    "contracts:stock-paired-v3:monitor": "node contracts/scripts/monitor-stock-paired-v3.mjs",
+    "contracts:stock-paired-v3:monitor:test": "node --test contracts/scripts/test/stock-paired-v3-monitor.test.mjs",
     "contracts:stock-paired:operator:test": "cd contracts && forge build --force script/DeployMainnetStockPairedInfrastructureV1.s.sol src/StockPairedEthLaunchCoordinatorV1.sol && cd .. && node --test contracts/scripts/test/stock-paired-operator.test.mjs contracts/scripts/test/stock-paired-eth-coordinator-operator.test.mjs contracts/scripts/test/stock-paired-canary.test.mjs contracts/scripts/test/stock-paired-eth-canary.test.mjs",
     "contracts:stock-paired:eth-coordinator:check": "node scripts/serve-stock-paired-eth-coordinator.mjs",
     "contracts:stock-paired:eth-coordinator": "node scripts/serve-stock-paired-eth-coordinator.mjs --write",

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -432,7 +432,7 @@ describe("unreleased launch model gating", () => {
     });
   });
 
-  it("keeps paused Stock-Paired preflight closed", async () => {
+  it("keeps an active Stock-Paired launch bound to Ethereum Mainnet", async () => {
     const request = new NextRequest("http://localhost/api/launch/preflight", {
       method: "POST",
       body: JSON.stringify({
@@ -450,9 +450,15 @@ describe("unreleased launch model gating", () => {
     });
 
     const result = await POST(request);
-    expect(result.status).toBe(403);
-    await expect(result.json()).resolves.toEqual({
-      error: "Stock-Paired is coming soon",
+    expect(result.status).toBe(200);
+    await expect(result.json()).resolves.toMatchObject({
+      status: "blocked",
+      mode: "stock-paired",
+      title: "Switch the wallet to Ethereum",
+      checks: [
+        { id: "token", status: "pass" },
+        { id: "wallet", status: "blocked" },
+      ],
     });
   });
 });

--- a/tests/stock-paired-access.test.ts
+++ b/tests/stock-paired-access.test.ts
@@ -18,6 +18,12 @@ describe("Stock-Paired access", () => {
     expect(
       isStockPairedPublicLaunchEnabled("rehearsal", release),
     ).toBe(false);
+    expect(
+      isStockPairedPublicLaunchEnabled("production", {
+        ...release,
+        chainId: 8453,
+      }),
+    ).toBe(false);
   });
 
   it("fails closed for missing and historical releases", () => {

--- a/tests/stock-paired-launch.test.ts
+++ b/tests/stock-paired-launch.test.ts
@@ -187,10 +187,10 @@ describe("Stock-Paired launch preparation", () => {
     ).toThrow(/supported ETH-routed quote assets/);
     expect(() =>
       validateStockPairedLaunchDraft(
-        { ...draft(), initialBuyEth: "0.0005" },
+        { ...draft(), initialBuyEth: "0.004999999999999999" },
         STOCK_TEST_ACCOUNT,
       ),
-    ).toThrow(/at least 0.0006 ETH/);
-    expect(STOCK_PAIRED_MIN_INITIAL_BUY_ETH_WEI).toBe(parseEther("0.0006"));
+    ).toThrow(/at least 0.005 ETH/);
+    expect(STOCK_PAIRED_MIN_INITIAL_BUY_ETH_WEI).toBe(parseEther("0.005"));
   });
 });

--- a/tests/stock-paired-public-activation.test.ts
+++ b/tests/stock-paired-public-activation.test.ts
@@ -140,7 +140,7 @@ describe.sequential("Stock-Paired public activation", () => {
     });
   });
 
-  it("ships the checked-in release closed while Stock-Paired is coming soon", async () => {
+  it("ships the checked-in verified V3 release open on Ethereum Mainnet", async () => {
     vi.resetModules();
     const [{ default: LaunchPage }, { POST }] = await Promise.all([
       import("../app/launch/page"),
@@ -151,13 +151,19 @@ describe.sequential("Stock-Paired public activation", () => {
       /<button[^>]*data-launch-model-option="stock-paired"[^>]*>/,
     )?.[0];
 
-    expect(stockButton).toContain("disabled");
-    expect(html).toContain("Coming soon");
+    expect(stockButton).not.toContain("disabled");
+    expect(html).not.toContain("Stock-Paired</strong><span>Coming soon");
 
     const result = await POST(publicPreflightRequest());
-    expect(result.status).toBe(403);
-    await expect(result.json()).resolves.toEqual({
-      error: "Stock-Paired is coming soon",
+    expect(result.status).toBe(200);
+    await expect(result.json()).resolves.toMatchObject({
+      status: "blocked",
+      mode: "stock-paired",
+      title: "Switch the wallet to Ethereum",
+      checks: [
+        { id: "token", status: "pass" },
+        { id: "wallet", status: "blocked" },
+      ],
     });
   });
 });

--- a/tests/stock-paired-runtime-fdv.test.ts
+++ b/tests/stock-paired-runtime-fdv.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assessStockPairedRuntimeFdv,
+  STOCK_PAIRED_MAXIMUM_RUNTIME_FDV_DEVIATION_BPS,
+  STOCK_PAIRED_RUNTIME_FDV_PROBE_WEI,
+  STOCK_PAIRED_TARGET_INITIAL_FDV_WEI,
+} from "../lib/stock-paired-runtime-fdv";
+
+const TARGET_QUOTE_AMOUNT_WAD = 13_522_423_984_475_316_997n;
+
+function quoteAmountForFdv(fdvEthWei: bigint) {
+  return (
+    TARGET_QUOTE_AMOUNT_WAD * STOCK_PAIRED_RUNTIME_FDV_PROBE_WEI
+  ) / fdvEthWei;
+}
+
+describe("Stock-Paired runtime FDV policy", () => {
+  it("uses the fixed 0.005 ETH route probe and reviewed 500 bps policy", () => {
+    expect(STOCK_PAIRED_RUNTIME_FDV_PROBE_WEI).toBe(
+      5_000_000_000_000_000n,
+    );
+    expect(STOCK_PAIRED_MAXIMUM_RUNTIME_FDV_DEVIATION_BPS).toBe(500n);
+  });
+
+  it("recomputes the target ETH FDV from route output", () => {
+    const routeQuoteAmount = quoteAmountForFdv(
+      STOCK_PAIRED_TARGET_INITIAL_FDV_WEI,
+    );
+    const result = assessStockPairedRuntimeFdv({
+      targetQuoteAmountWad: TARGET_QUOTE_AMOUNT_WAD,
+      routeQuoteAmount,
+    });
+
+    expect(result.withinPolicy).toBe(true);
+    expect(result.deviationBps).toBeLessThanOrEqual(1n);
+    const absoluteDifference =
+      result.impliedFdvEthWei >= STOCK_PAIRED_TARGET_INITIAL_FDV_WEI
+        ? result.impliedFdvEthWei - STOCK_PAIRED_TARGET_INITIAL_FDV_WEI
+        : STOCK_PAIRED_TARGET_INITIAL_FDV_WEI -
+          result.impliedFdvEthWei;
+    expect(absoluteDifference).toBeLessThan(1_000n);
+  });
+
+  it("accepts the exact upper 500 bps boundary", () => {
+    const upperBoundary =
+      STOCK_PAIRED_TARGET_INITIAL_FDV_WEI +
+      (STOCK_PAIRED_TARGET_INITIAL_FDV_WEI * 500n) / 10_000n;
+    const result = assessStockPairedRuntimeFdv({
+      targetQuoteAmountWad: upperBoundary,
+      routeQuoteAmount: 1n,
+      probeAmountWei: 1n,
+    });
+
+    expect(result.withinPolicy).toBe(true);
+    expect(result.deviationBps).toBeLessThanOrEqual(500n);
+  });
+
+  it("rejects the first wei outside the reviewed range", () => {
+    const outsidePolicy =
+      STOCK_PAIRED_TARGET_INITIAL_FDV_WEI +
+      (STOCK_PAIRED_TARGET_INITIAL_FDV_WEI * 500n) / 10_000n +
+      1n;
+    const result = assessStockPairedRuntimeFdv({
+      targetQuoteAmountWad: outsidePolicy,
+      routeQuoteAmount: 1n,
+      probeAmountWei: 1n,
+    });
+
+    expect(result.withinPolicy).toBe(false);
+    expect(result.deviationBps).toBeGreaterThan(500n);
+  });
+
+  it("fails closed for missing route data", () => {
+    expect(() =>
+      assessStockPairedRuntimeFdv({
+        targetQuoteAmountWad: TARGET_QUOTE_AMOUNT_WAD,
+        routeQuoteAmount: 0n,
+      }),
+    ).toThrow(/inputs are invalid/);
+  });
+
+  it("fails closed for a missing target quote amount", () => {
+    expect(() =>
+      assessStockPairedRuntimeFdv({
+        targetQuoteAmountWad: undefined,
+        routeQuoteAmount: 1n,
+      }),
+    ).toThrow(/inputs are invalid/);
+  });
+});


### PR DESCRIPTION
Enables public Stock-Paired launches on Ethereum Mainnet.

- requires a viable Initial Buy across all six routes
- checks starting FDV from current onchain route data before every launch
- monitors runtime bindings and starting FDV every five minutes
- updates the public release status

The final current-market pricing evidence will be added before merge.