### PR TITLE
Clarify Stock-Paired launch model

### DIFF
--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -225,8 +225,8 @@ export function LaunchModelPicker({
               className={`launch-model-description ${launchExperience.modelDescription}`}
               id="launch-model-stock-description"
             >
-              Pair a token with a reviewed Ondo Global Markets asset in a
-              Uniswap v4 pool.
+              Launch a token on Ethereum with a tokenized stock, ETF, or
+              commodity as its quote asset on Uniswap v4.
             </span>
             {stockPairedPublicLaunchEnabled ? (
               <span


### PR DESCRIPTION
Updates the Stock-Paired launch card to explain that tokens can use tokenized stocks, ETFs, or commodities as their Uniswap v4 quote asset. Stock-Paired remains publicly enabled. Validated with focused activation tests, TypeScript, ESLint, and the production build.