### PR TITLE
Fix Stock-Paired launch preflight

### DIFF
--- a/app/api/launch/preflight/route.ts
+++ b/app/api/launch/preflight/route.ts
@@ -100,6 +100,7 @@ import {
   STOCK_PAIRED_MIN_INITIAL_BUY_RAW,
   STOCK_PAIRED_PROGRAMMABLE_FEE_BPS,
   STOCK_PAIRED_TOTAL_SWAP_FEE_BPS,
+  stockPairedRegistryContainsReleaseAssets,
   validateStockPairedLaunchDraft,
 } from "@/lib/stock-paired";
 import {
@@ -2207,7 +2208,10 @@ async function assertStockPairedInfrastructure(
     lpFeePips !== 0 ||
     tickSpacing !== 200 ||
     !factoryRecognizesHook ||
-    registryAssetCount !== BigInt(quoteAssets.length) ||
+    !stockPairedRegistryContainsReleaseAssets(
+      registryAssetCount,
+      quoteAssets.length,
+    ) ||
     (BigInt(feeHook) & HOOK_FLAG_MASK) !== REQUIRED_FEE_HOOK_FLAGS
   ) {
     throw new Error(

--- a/lib/stock-paired.ts
+++ b/lib/stock-paired.ts
@@ -52,6 +52,18 @@ export const STOCK_PAIRED_PROGRAMMABLE_FEE_BPS = 10;
 export const STOCK_PAIRED_CURRENCY0_SEARCH_ATTEMPTS = 256;
 export const STOCK_PAIRED_LEGACY_INITIAL_ABSOLUTE_TICK = 191_200;
 
+export function stockPairedRegistryContainsReleaseAssets(
+  registryAssetCount: bigint,
+  releaseAssetCount: number,
+) {
+  return (
+    registryAssetCount >= 0n &&
+    Number.isSafeInteger(releaseAssetCount) &&
+    releaseAssetCount > 0 &&
+    registryAssetCount >= BigInt(releaseAssetCount)
+  );
+}
+
 const stockPairedCurrency0SaltParameters = parseAbiParameters(
   "string domain, bytes32 baseSalt, uint256 attempt",
 );

--- a/tests/stock-paired-launch.test.ts
+++ b/tests/stock-paired-launch.test.ts
@@ -11,6 +11,7 @@ import {
   STOCK_PAIRED_ETH_QUOTE_ASSETS,
   STOCK_PAIRED_MIN_INITIAL_BUY_ETH_WEI,
   STOCK_QUOTE_ASSETS,
+  stockPairedRegistryContainsReleaseAssets,
   stockPairedEthLaunchCoordinatorAbi,
   validateStockPairedLaunchDraft,
 } from "../lib/stock-paired";
@@ -39,6 +40,13 @@ function draft() {
 }
 
 describe("Stock-Paired launch preparation", () => {
+  it("accepts an append-only registry containing more assets than the active release", () => {
+    expect(stockPairedRegistryContainsReleaseAssets(11n, 6)).toBe(true);
+    expect(stockPairedRegistryContainsReleaseAssets(6n, 6)).toBe(true);
+    expect(stockPairedRegistryContainsReleaseAssets(5n, 6)).toBe(false);
+    expect(stockPairedRegistryContainsReleaseAssets(11n, 0)).toBe(false);
+  });
+
   it("derives bounded deterministic salts and identifies canonical currency0 ordering", () => {
     const first = deriveStockPairedCurrency0Salt(salt, 0);
     const second = deriveStockPairedCurrency0Salt(salt, 1);


### PR DESCRIPTION
The V3 release uses six approved quote assets from an append-only registry that currently contains eleven assets. The preflight incorrectly required those counts to be equal, which blocked every public launch before simulation.

This change accepts registries that contain the complete active release set while retaining the per-asset address, support, configuration hash, route, runtime, fee, and hook-permission checks.

Checks:
- 24 focused tests
- TypeScript
- ESLint
- production build
- read-only Ethereum Mainnet launch simulation reached ready