### PR TITLE
Show confirmed Stock-Paired launches immediately

### DIFF
--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -878,7 +878,10 @@ export async function readExploreModel(
   const value = (async () => {
     if (config.environment === "production") {
       const durable = await readDurableExploreModel(config);
-      if (durable.status === "ready") {
+      if (
+        durable.status === "ready" &&
+        !isStockPairedExploreReleaseReady(config)
+      ) {
         const model = durable.envelope.payload.model;
         try {
           return await enrichExploreModelWithUsd(model, config);
@@ -887,10 +890,16 @@ export async function readExploreModel(
           return model;
         }
       }
-      console.warn("Durable Explore index unavailable; using live RPCs", {
-        reason: durable.reason,
-        detail: durable.detail,
-      });
+      if (durable.status === "ready") {
+        console.info(
+          "Stock-Paired is active; using confirmed live launch events",
+        );
+      } else {
+        console.warn("Durable Explore index unavailable; using live RPCs", {
+          reason: durable.reason,
+          detail: durable.detail,
+        });
+      }
     }
     const model = await readReadyRegistryModel(config);
     try {


### PR DESCRIPTION
Use confirmed live launch events while Stock-Paired is active instead of serving a durable snapshot that can lag new launches by up to 15 minutes.\n\nChecked: npm run typecheck; git diff --check.