### PR TITLE
Make Stock-Paired index refresh resilient

### DIFF
--- a/app/api/ops/index/route.ts
+++ b/app/api/ops/index/route.ts
@@ -10,8 +10,10 @@ import {
 import { writePortfolioHistorySnapshot } from "../../../../lib/profile/portfolio-history-storage.server";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 60;
+export const maxDuration = 90;
 export const runtime = "nodejs";
+
+const INDEX_READ_ATTEMPTS = 2;
 
 function isAuthorized(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
@@ -47,7 +49,27 @@ export async function GET(request: NextRequest) {
         "The verified production release is not operationally eligible",
       );
     }
-    const model = await readLiveExploreModel(deployment);
+    let model: Awaited<ReturnType<typeof readLiveExploreModel>> | null =
+      null;
+    let lastReadError: unknown;
+    for (let attempt = 1; attempt <= INDEX_READ_ATTEMPTS; attempt += 1) {
+      try {
+        model = await readLiveExploreModel(deployment);
+        break;
+      } catch (error) {
+        lastReadError = error;
+        if (attempt < INDEX_READ_ATTEMPTS) {
+          console.warn("Programmable index read will retry", {
+            attempt,
+            errorName:
+              error instanceof Error ? error.name : "UnknownIndexError",
+          });
+        }
+      }
+    }
+    if (!model) {
+      throw lastReadError ?? new Error("Index read failed");
+    }
     if (model.status !== "ready") {
       throw new Error("The live Explore model is not ready");
     }

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -878,10 +878,7 @@ export async function readExploreModel(
   const value = (async () => {
     if (config.environment === "production") {
       const durable = await readDurableExploreModel(config);
-      if (
-        durable.status === "ready" &&
-        !isStockPairedExploreReleaseReady(config)
-      ) {
+      if (durable.status === "ready") {
         const model = durable.envelope.payload.model;
         try {
           return await enrichExploreModelWithUsd(model, config);
@@ -890,16 +887,10 @@ export async function readExploreModel(
           return model;
         }
       }
-      if (durable.status === "ready") {
-        console.info(
-          "Stock-Paired is active; using confirmed live launch events",
-        );
-      } else {
-        console.warn("Durable Explore index unavailable; using live RPCs", {
-          reason: durable.reason,
-          detail: durable.detail,
-        });
-      }
+      console.warn("Durable Explore index unavailable; using live RPCs", {
+        reason: durable.reason,
+        detail: durable.detail,
+      });
     }
     const model = await readReadyRegistryModel(config);
     try {


### PR DESCRIPTION
Revert the full live-RPC Explore fallback because it can time out under load. Keep the one-minute durable index and retry one transient live read within a 90-second cron invocation.\n\nChecked: npm run typecheck; git diff --check.