### PR TITLE
Restore Explore during index lag

### DIFF
--- a/lib/onchain/config.ts
+++ b/lib/onchain/config.ts
@@ -124,7 +124,7 @@ function resolveOnchainDeployment(
     ),
     logBlockRange: positiveBigInt(
       process.env.PROGRAMMABLE_LOG_BLOCK_RANGE,
-      10_000n,
+      5_000n,
       1n,
       100_000n,
     ),

--- a/lib/onchain/durable-model.ts
+++ b/lib/onchain/durable-model.ts
@@ -155,7 +155,14 @@ export type DurableExploreRead =
     }
   | {
       status: "unavailable";
-      reason: "not-configured" | "missing" | "invalid" | "stale";
+      reason: "stale";
+      detail: string;
+      envelope: DurableExploreEnvelope;
+      ageMs: number;
+    }
+  | {
+      status: "unavailable";
+      reason: "not-configured" | "missing" | "invalid";
       detail: string;
     };
 
@@ -771,6 +778,8 @@ export function validateDurableExploreEnvelope(
       status: "unavailable",
       reason: "stale",
       detail: `The durable index is ${Math.floor(ageMs / 1_000)} seconds old`,
+      envelope: value as unknown as DurableExploreEnvelope,
+      ageMs,
     };
   }
   return {

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -4,6 +4,7 @@ import {
   getAddress,
   http,
   keccak256,
+  ResponseBodyTooLargeError,
   type Address,
   type Hex,
   type PublicClient,
@@ -197,59 +198,73 @@ async function indexVerifiedEvents(
   const volumes = new Map<string, FeeVolume>();
   const creatorClaims: CreatorClaimEventRecord[] = [];
 
-  for (
-    let fromBlock = config.deploymentBlock;
-    fromBlock <= toBlock;
-    fromBlock += config.logBlockRange
-  ) {
+  let fromBlock = config.deploymentBlock;
+  let logBlockRange = config.logBlockRange;
+  while (fromBlock <= toBlock) {
     const rangeEnd = minimum(
       toBlock,
-      fromBlock + config.logBlockRange - 1n,
+      fromBlock + logBlockRange - 1n,
     );
+    const readLogs = () =>
+      Promise.all([
+        client.getLogs({
+          address: config.launcher,
+          event: memeTokenLaunchedEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+        client.getLogs({
+          address: config.launcher,
+          event: memeLiquidityConfiguredEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+        client.getLogs({
+          address: config.launcher,
+          event: memeCreatorInitialBuyEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+        client.getLogs({
+          address: config.feeHook,
+          event: nativeSwapFeesAccruedEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+        client.getLogs({
+          address: config.feeHook,
+          event: creatorFeesClaimedEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+      ]);
+    let logs: Awaited<ReturnType<typeof readLogs>>;
+    try {
+      logs = await readLogs();
+    } catch (error) {
+      if (error instanceof ResponseBodyTooLargeError && rangeEnd > fromBlock) {
+        logBlockRange = logBlockRange > 1n ? logBlockRange / 2n : 1n;
+        console.warn("Explore log range reduced after oversized RPC response", {
+          fromBlock: fromBlock.toString(),
+          attemptedToBlock: rangeEnd.toString(),
+          nextRange: logBlockRange.toString(),
+        });
+        continue;
+      }
+      throw error;
+    }
     const [
       launchLogs,
       liquidityLogs,
       initialBuyLogs,
       feeLogs,
       claimLogs,
-    ] =
-      await Promise.all([
-      client.getLogs({
-        address: config.launcher,
-        event: memeTokenLaunchedEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      }),
-      client.getLogs({
-        address: config.launcher,
-        event: memeLiquidityConfiguredEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      }),
-      client.getLogs({
-        address: config.launcher,
-        event: memeCreatorInitialBuyEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      }),
-      client.getLogs({
-        address: config.feeHook,
-        event: nativeSwapFeesAccruedEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      }),
-      client.getLogs({
-        address: config.feeHook,
-        event: creatorFeesClaimedEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      }),
-    ]);
+    ] = logs;
 
     for (const log of launchLogs) {
       if (log.removed || log.blockNumber === null) continue;
@@ -331,6 +346,7 @@ async function indexVerifiedEvents(
         logIndex: log.logIndex,
       });
     }
+    fromBlock = rangeEnd + 1n;
   }
 
   return {
@@ -878,7 +894,17 @@ export async function readExploreModel(
   const value = (async () => {
     if (config.environment === "production") {
       const durable = await readDurableExploreModel(config);
-      if (durable.status === "ready") {
+      if (
+        durable.status === "ready" ||
+        (durable.status === "unavailable" &&
+          durable.reason === "stale")
+      ) {
+        if (durable.status === "unavailable") {
+          console.warn("Serving the last verified Explore index", {
+            reason: durable.reason,
+            ageSeconds: Math.floor(durable.ageMs / 1_000),
+          });
+        }
         const model = durable.envelope.payload.model;
         try {
           return await enrichExploreModelWithUsd(model, config);

--- a/tests/onchain-config.test.ts
+++ b/tests/onchain-config.test.ts
@@ -98,7 +98,7 @@ describe("onchain deployment manifest boundary", () => {
   it("never permits a zero log block range", () => {
     vi.stubEnv("PROGRAMMABLE_LOG_BLOCK_RANGE", "0");
     expect(getOnchainDeployment("production").logBlockRange).toBe(
-      10_000n,
+      5_000n,
     );
 
     vi.stubEnv("PROGRAMMABLE_LOG_BLOCK_RANGE", "1");

--- a/tests/onchain-durable-model.test.ts
+++ b/tests/onchain-durable-model.test.ts
@@ -269,6 +269,29 @@ describe("durable onchain snapshot replacement", () => {
       }),
     ).toBe(false);
   });
+
+  it("preserves a validated snapshot when it is stale", () => {
+    const value = envelope("programmable-durable-index-v1");
+    value.payload.generatedAt = new Date(Date.now() - 120_000).toISOString();
+    value.contentHash = keccak256(
+      toBytes(JSON.stringify(value.payload)),
+    );
+
+    const result = validateDurableExploreEnvelope(
+      value,
+      deployment,
+      60_000,
+    );
+
+    expect(result).toMatchObject({
+      status: "unavailable",
+      reason: "stale",
+      envelope: value,
+    });
+    if (result.status === "unavailable" && result.reason === "stale") {
+      expect(result.ageMs).toBeGreaterThanOrEqual(120_000);
+    }
+  });
 });
 
 describe("durable Deep release binding", () => {


### PR DESCRIPTION
What changed

- Serve the last validated Explore snapshot when the durable index is stale instead of falling back to an unbounded live-chain read
- Reduce the default RPC log window from 10,000 to 5,000 blocks
- Automatically halve the log window when viem rejects an oversized RPC response
- Keep the operations health endpoint fail-closed while the index is stale

Root cause

The durable Explore index stopped refreshing after an eth_getLogs response exceeded viem's 10 MB response limit. Once the snapshot passed the 15-minute freshness window, public Explore reads repeated the same oversized live-chain scan and returned HTTP 503.

Checks

- 19 focused onchain/index tests passed
- TypeScript passed
- ESLint passed for the changed files
- Next.js production build passed

The full Vitest run reached 669 passing tests. Seven unrelated release-verifier tests require bootstrapped Foundry submodules and generated artifacts that are not present in a fresh worktree.