### PR TITLE
Rebind Explore index cron

### DIFF
--- a/app/api/ops/index-v2/route.ts
+++ b/app/api/ops/index-v2/route.ts
@@ -1,0 +1,5 @@
+export { GET } from "../index/route";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 90;
+export const runtime = "nodejs";

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "crons": [
     {
-      "path": "/api/ops/index",
+      "path": "/api/ops/index-v2",
       "schedule": "* * * * *"
     }
   ]


### PR DESCRIPTION
## What changed

- move the production scheduler to a versioned index endpoint
- keep the existing authenticated index implementation as the single source of truth
- force Vercel to replace the cron definition that remained pinned after an earlier rollback

## Checks

- `npx tsc --noEmit`
- `npx eslint app/api/ops/index-v2/route.ts app/api/ops/index/route.ts`
- `npm run build`