### PR TITLE
Prevent overlapping index refreshes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/ops/index-v2",
-      "schedule": "* * * * *"
+      "schedule": "*/2 * * * *"
     }
   ]
 }


### PR DESCRIPTION
The legacy refresh currently runs longer than one minute, so consecutive cron invocations overlap and repeatedly time out. This changes the temporary legacy schedule to every two minutes while the incremental read model remains behind its release gates.\n\nChecks: lint, typecheck, 676 tests, contract build, production build.