### PR TITLE
Allow index refreshes to complete

### DIFF
--- a/app/api/ops/index-v2/route.ts
+++ b/app/api/ops/index-v2/route.ts
@@ -1,5 +1,5 @@
 export { GET } from "../index/route";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 90;
+export const maxDuration = 300;
 export const runtime = "nodejs";

--- a/app/api/ops/index/route.ts
+++ b/app/api/ops/index/route.ts
@@ -10,7 +10,7 @@ import {
 import { writePortfolioHistorySnapshot } from "../../../../lib/profile/portfolio-history-storage.server";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 90;
+export const maxDuration = 300;
 export const runtime = "nodejs";
 
 const INDEX_READ_ATTEMPTS = 1;

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/ops/index-v2",
-      "schedule": "*/2 * * * *"
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Raises the legacy index refresh duration limit to five minutes and runs the temporary full refresh every five minutes. This prevents guaranteed 90-second termination while the incremental read model is finalized.\n\nChecks:\n- npm run lint\n- npm run typecheck\n- npm run build\n- compiled function manifest records 300-second duration for both index routes