### PR TITLE
Retry transient index refresh failures

### DIFF
--- a/app/api/ops/index/route.ts
+++ b/app/api/ops/index/route.ts
@@ -13,7 +13,7 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 export const runtime = "nodejs";
 
-const INDEX_READ_ATTEMPTS = 1;
+const INDEX_READ_ATTEMPTS = 2;
 
 function isAuthorized(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;


### PR DESCRIPTION
Restores one bounded retry for the legacy Explore refresh now that the function has a 300 second runtime window.

Checks:
- ESLint
- TypeScript
- Production build