### PR TITLE
Open the public Builder Beta intake

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -50,26 +50,13 @@ jobs:
           lfs: false
           submodules: false
 
-      - name: Require immutable PR merge identity
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-        run: |
-          set -euo pipefail
-          sha_pattern='^[a-f0-9]{40}$'
-          if [[ ! "$BASE_SHA" =~ $sha_pattern || ! "$HEAD_SHA" =~ $sha_pattern || ! "$MERGE_SHA" =~ $sha_pattern ]]; then
-            echo "::error::GitHub did not provide an immutable merge commit for this PR. Resolve merge conflicts and retry."
-            exit 1
-          fi
-
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
       - name: Fetch exact candidate merge as blobless data
+        id: candidate_fetch
         shell: bash
         env:
           CANDIDATE_READ_TOKEN: ${{ github.token }}
@@ -82,7 +69,7 @@ jobs:
             exit 1
           fi
 
-          timeout --signal=KILL 90s node \
+          fetch_report="$(timeout --signal=KILL 90s node \
             "$GITHUB_WORKSPACE/trusted/scripts/verify-public-hook-application.mjs" \
             --fetch-candidate \
             --repository "${{ github.repository }}" \
@@ -90,8 +77,13 @@ jobs:
             --base-root "$GITHUB_WORKSPACE/trusted" \
             --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
             --expected-base-commit "${{ github.event.pull_request.base.sha }}" \
-            --expected-candidate-commit "${{ github.event.pull_request.head.sha }}" \
-            --expected-merge-commit "${{ github.event.pull_request.merge_commit_sha }}"
+            --expected-candidate-commit "${{ github.event.pull_request.head.sha }}")"
+          merge_commit="$(node -e '
+            const report = JSON.parse(process.argv[1]);
+            if (report.result !== "exact-blobless-candidate-fetched" || !/^[a-f0-9]{40}$/.test(report.mergeCommit)) process.exit(1);
+            process.stdout.write(report.mergeCommit);
+          ' "$fetch_report")"
+          echo "merge_commit=$merge_commit" >> "$GITHUB_OUTPUT"
 
       - name: Classify candidate data with trusted base code
         id: classify
@@ -109,7 +101,7 @@ jobs:
             --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
             --expected-base-commit "${{ github.event.pull_request.base.sha }}" \
             --expected-candidate-commit "${{ github.event.pull_request.head.sha }}" \
-            --expected-merge-commit "${{ github.event.pull_request.merge_commit_sha }}")"
+            --expected-merge-commit "${{ steps.candidate_fetch.outputs.merge_commit }}")"
           case "$mode" in
             application|builder-maintenance|no-op) ;;
             *)
@@ -136,7 +128,7 @@ jobs:
             --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
             --expected-base-commit "${{ github.event.pull_request.base.sha }}" \
             --expected-candidate-commit "${{ github.event.pull_request.head.sha }}" \
-            --expected-merge-commit "${{ github.event.pull_request.merge_commit_sha }}"
+            --expected-merge-commit "${{ steps.candidate_fetch.outputs.merge_commit }}"
 
       - name: Remove candidate fetch credential
         if: always()
@@ -177,7 +169,7 @@ jobs:
             --expected-builder-login "${{ github.event.pull_request.user.login }}" \
             --expected-builder-user-id "${{ github.event.pull_request.user.id }}" \
             --expected-candidate-commit "${{ github.event.pull_request.head.sha }}" \
-            --expected-merge-commit "${{ github.event.pull_request.merge_commit_sha }}"
+            --expected-merge-commit "${{ steps.candidate_fetch.outputs.merge_commit }}"
 
       - name: Defer executable builder-maintenance checks to read-only pull-request CI
         if: steps.classify.outputs.mode == 'builder-maintenance'

--- a/docs/builder/AGENT_SKILL.md
+++ b/docs/builder/AGENT_SKILL.md
@@ -61,7 +61,7 @@ First preview a fixed revision:
 
 ```bash
 gh skill preview 0xprogrammable/programmable \
-  skills/programmable-v4-hook-builder@FULL_COMMIT_SHA
+  programmable-v4-hook-builder@FULL_COMMIT_SHA
 ```
 
 Then install that same full commit for your agent:

--- a/docs/builder/intake-status.json
+++ b/docs/builder/intake-status.json
@@ -1,1 +1,1 @@
-{"continuingPullRequests":[],"schemaVersion":2,"state":"prelaunch"}
+{"continuingPullRequests":[],"schemaVersion":2,"state":"open"}

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/submission-core.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/submission-core.mjs
@@ -2140,10 +2140,190 @@ function hashBundle(targets) {
     const relativePath = path.relative(skillRoot, target).split(path.sep).join("/");
     hash.update(relativePath);
     hash.update("\0");
-    hash.update(fs.readFileSync(target));
+    const bytes = fs.readFileSync(target);
+    hash.update(relativePath === "SKILL.md" ? normalizeSkillPolicyBytes(bytes) : bytes);
     hash.update("\0");
   }
   return `sha256:${hash.digest("hex")}`;
+}
+
+function normalizeSkillPolicyBytes(bytes) {
+  let source;
+  try {
+    source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return bytes;
+  }
+
+  const document = source.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/u);
+  if (!document) return bytes;
+
+  const rootFields = new Map();
+  const metadataFields = new Map();
+  let insideMetadata = false;
+  let sawMetadata = false;
+
+  for (const line of document[1].split("\n")) {
+    if (line.startsWith("    ")) {
+      if (!insideMetadata) return bytes;
+      const child = line.match(/^ {4}([a-z][a-z0-9-]*): (.+)$/u);
+      if (!child || metadataFields.has(child[1])) return bytes;
+      metadataFields.set(child[1], child[2]);
+      continue;
+    }
+
+    const field = line.match(/^([a-z][a-z0-9-]*):(?: (.+))?$/u);
+    if (!field) return bytes;
+    const [, key, value] = field;
+    insideMetadata = key === "metadata";
+
+    if (insideMetadata) {
+      if (sawMetadata || value !== undefined) return bytes;
+      sawMetadata = true;
+      continue;
+    }
+
+    if (!["name", "description", "license"].includes(key) || rootFields.has(key) || value === undefined) return bytes;
+    rootFields.set(key, value);
+  }
+
+  if (!rootFields.has("name") || !rootFields.has("description")) return bytes;
+  if (sawMetadata && !isExactInstallerProvenance(metadataFields, rootFields.get("name"))) return bytes;
+
+  const canonicalFrontmatter = [
+    "---",
+    `name: ${rootFields.get("name")}`,
+    `description: ${rootFields.get("description")}`,
+    ...(rootFields.has("license") ? [`license: ${rootFields.get("license")}`] : []),
+    "---"
+  ].join("\n");
+  const body = document[2].startsWith("\n") ? document[2].slice(1) : document[2];
+  return Buffer.from(`${canonicalFrontmatter}\n\n${body}`, "utf8");
+}
+
+function isExactInstallerProvenance(metadataFields, declaredName) {
+  const keys = [...metadataFields.keys()].sort();
+  const values = new Map();
+  for (const [key, source] of metadataFields) {
+    const parsed = parseCanonicalProvenanceScalar(source);
+    if (!parsed.ok) return false;
+    values.set(key, parsed.value);
+  }
+
+  if (keys.length === 1 && keys[0] === "local-path") {
+    const localPath = values.get("local-path");
+    return isBoundedProvenanceValue(localPath, 4096)
+      && (path.posix.isAbsolute(localPath) || path.win32.isAbsolute(localPath));
+  }
+
+  const required = ["github-path", "github-ref", "github-repo", "github-tree-sha"];
+  const allowed = [...required, "github-pinned"].sort();
+  if (!keys.every((key) => allowed.includes(key)) || !required.every((key) => keys.includes(key))) return false;
+  if (![...values].every(([key, value]) => isBoundedProvenanceValue(value, key === "github-path" ? 1024 : 2048))) return false;
+
+  const githubPath = values.get("github-path");
+  const pathSegments = githubPath.split("/");
+  if (
+    githubPath.startsWith("/")
+    || githubPath.endsWith("/")
+    || githubPath.includes("\\")
+    || pathSegments.some((segment) => segment === "" || segment === "." || segment === "..")
+    || pathSegments.at(-1) !== declaredName
+  ) return false;
+
+  return isSupportedGitHubRepositoryUrl(values.get("github-repo"))
+    && isSafeGitReference(values.get("github-ref"))
+    && (!values.has("github-pinned") || isSafeGitReference(values.get("github-pinned")))
+    && /^[0-9a-f]{40}$/u.test(values.get("github-tree-sha"));
+}
+
+export function parseCanonicalProvenanceScalar(source) {
+  if (source.startsWith('"')) {
+    try {
+      const value = JSON.parse(source);
+      if (typeof value !== "string") return { ok: false, error: "requires a string value" };
+      if (value.length === 0) return { ok: false, error: "requires a non-empty string value" };
+      return { ok: true, value };
+    } catch {
+      return { ok: false, error: "contains an invalid double-quoted string" };
+    }
+  }
+  if (source.startsWith("'")) {
+    if (!source.endsWith("'") || source.length < 2) {
+      return { ok: false, error: "contains an invalid single-quoted string" };
+    }
+    const inner = source.slice(1, -1);
+    let value = "";
+    for (let index = 0; index < inner.length; index += 1) {
+      if (inner[index] !== "'") {
+        value += inner[index];
+      } else if (inner[index + 1] === "'") {
+        value += "'";
+        index += 1;
+      } else {
+        return { ok: false, error: "contains an invalid single-quoted string" };
+      }
+    }
+    if (value.length === 0) return { ok: false, error: "requires a non-empty string value" };
+    return { ok: true, value };
+  }
+  if (
+    source.length === 0
+    || source !== source.trim()
+    || /^(?:null|true|false|yes|no|on|off|~)$/iu.test(source)
+    || /^(?:[!&*|>@`]|[-?:]\s)/u.test(source)
+    || /[\[\]{}]/u.test(source)
+    || /(?:^|\s)#/u.test(source)
+    || /:\s|:$/u.test(source)
+  ) return { ok: false, error: "contains a non-canonical plain string" };
+  return { ok: true, value: source };
+}
+
+function isBoundedProvenanceValue(value, maximumBytes) {
+  return Buffer.byteLength(value, "utf8") <= maximumBytes
+    && !/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/u.test(value)
+    && ![...value].some((character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint >= 0xd800 && codePoint <= 0xdfff;
+    });
+}
+
+export function isSupportedGitHubRepositoryUrl(value) {
+  try {
+    const parsed = new URL(value);
+    const hostname = parsed.hostname.toLowerCase();
+    const supportedHost = hostname === "github.com"
+      || /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.ghe\.com$/u.test(hostname);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    return supportedHost
+      && parsed.href === value
+      && parsed.protocol === "https:"
+      && parsed.username === ""
+      && parsed.password === ""
+      && parsed.port === ""
+      && parsed.search === ""
+      && parsed.hash === ""
+      && !parsed.pathname.endsWith("/")
+      && segments.length === 2
+      && /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?$/u.test(segments[0])
+      && /^[A-Za-z0-9._-]{1,100}$/u.test(segments[1]);
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeGitReference(value) {
+  if (
+    value === "@"
+    || value.startsWith("/")
+    || value.endsWith("/")
+    || value.endsWith(".")
+    || value.includes("..")
+    || value.includes("//")
+    || value.includes("@{")
+    || /[\u0000-\u0020\u007f~^:?*[\\\u202a-\u202e\u2066-\u2069]/u.test(value)
+  ) return false;
+  return value.split("/").every((segment) => segment !== "" && !segment.startsWith(".") && !segment.endsWith(".lock"));
 }
 
 function requireResolvedText(value, path, code, add) {

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/github-exact-object-resolver.test.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/github-exact-object-resolver.test.mjs
@@ -577,9 +577,7 @@ test("bounded runner kills a TERM-resistant process tree on timeout", async (t) 
     "wait",
     ""
   ].join("\n"));
-  const result = await runBoundedExactGitProcessV1(boundedRunnerOptions(fixtureRoot, executable, {
-    timeoutMs: 250
-  }));
+  const result = await runBoundedExactGitProcessV1(boundedRunnerOptions(fixtureRoot, executable));
   assert.equal(result.timedOut, true);
   assert.equal(result.cpuExceeded, false);
   await waitForProcessExit(Number(fs.readFileSync(childPidPath, "utf8").trim()));

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/policy-bundle.test.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/policy-bundle.test.mjs
@@ -37,6 +37,87 @@ for (const policyPath of [
   });
 }
 
+test("policy bundle normalizes only exact gh installer changes", () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "programmable-installed-policy-bundle-"));
+  const copiedSkill = path.join(fixtureRoot, "programmable-v4-hook-builder");
+
+  try {
+    fs.cpSync(skillRoot, copiedSkill, { recursive: true });
+    const skillPath = path.join(copiedSkill, "SKILL.md");
+    const canonical = fs.readFileSync(skillPath, "utf8");
+    const canonicalDocument = canonical.match(/^---\n([\s\S]*?)\n---\n\n([\s\S]*)$/u);
+    assert.ok(canonicalDocument);
+    const canonicalFields = new Map(canonicalDocument[1].split("\n").map((line) => line.split(/: (.*)/su).slice(0, 2)));
+    const body = canonicalDocument[2];
+    const canonicalHash = validate(copiedSkill).toolchain.policyBundleSha256;
+    const remoteFrontmatter = [
+      "---",
+      `description: ${canonicalFields.get("description")}`,
+      `license: ${canonicalFields.get("license")}`,
+      "metadata:",
+      "    github-path: skills/programmable-v4-hook-builder",
+      "    github-pinned: 0123456789abcdef0123456789abcdef01234567",
+      "    github-ref: 0123456789abcdef0123456789abcdef01234567",
+      "    github-repo: https://github.com/0xprogrammable/programmable",
+      "    github-tree-sha: 89abcdef0123456789abcdef0123456789abcdef",
+      `name: ${canonicalFields.get("name")}`,
+      "---"
+    ].join("\n");
+    const localFrontmatter = [
+      "---",
+      `description: ${canonicalFields.get("description")}`,
+      `license: ${canonicalFields.get("license")}`,
+      "metadata:",
+      "    local-path: /tmp/programmable-v4-hook-builder",
+      `name: ${canonicalFields.get("name")}`,
+      "---"
+    ].join("\n");
+
+    const hashSource = (source) => {
+      fs.writeFileSync(skillPath, source);
+      return validate(copiedSkill).toolchain.policyBundleSha256;
+    };
+
+    assert.equal(hashSource(`${remoteFrontmatter}\n${body}`), canonicalHash, "remote gh install removes the separator blank line");
+    assert.equal(
+      hashSource(`${remoteFrontmatter.replace("    github-pinned: 0123456789abcdef0123456789abcdef01234567\n", "")}\n${body}`),
+      canonicalHash,
+      "unpinned remote provenance is also an exact installer profile"
+    );
+    assert.equal(hashSource(`${localFrontmatter}\n${body}`), canonicalHash, "local gh install uses the same policy bytes");
+    assert.equal(
+      hashSource(`${localFrontmatter.replace("/tmp/programmable-v4-hook-builder", "'/tmp/programmable v4 hook builder'")}\n${body}`),
+      canonicalHash,
+      "single-quoted absolute local provenance remains an exact installer profile"
+    );
+
+    for (const [label, source] of [
+      ["name", `${remoteFrontmatter.replace(`name: ${canonicalFields.get("name")}`, `name: ${canonicalFields.get("name")}-changed`)}\n${body}`],
+      ["description", `${remoteFrontmatter.replace(`description: ${canonicalFields.get("description")}`, `description: ${canonicalFields.get("description")} Changed.`)}\n${body}`],
+      ["license", `${remoteFrontmatter.replace(`license: ${canonicalFields.get("license")}`, "license: Apache-2.0")}\n${body}`],
+      ["body", `${remoteFrontmatter}\n${body}\nChanged policy body.\n`],
+      ["extra separator blank line", `${remoteFrontmatter}\n\n\n${body}`],
+      ["unknown root field", `${remoteFrontmatter.replace("---\n", "---\nallowed-tools: Bash\n")}\n${body}`],
+      ["unknown metadata field", `${remoteFrontmatter.replace("    github-path:", "    allowed-tools: Bash\n    github-path:")}\n${body}`],
+      ["duplicate root field", `${remoteFrontmatter.replace("---\n", `---\nname: ${canonicalFields.get("name")}\n`)}\n${body}`],
+      ["mixed provenance", `${localFrontmatter.replace("    local-path:", "    github-path: skills/programmable-v4-hook-builder\n    local-path:")}\n${body}`],
+      ["malformed provenance indentation", `${remoteFrontmatter.replace("    github-path:", "  github-path:")}\n${body}`],
+      ["malformed local scalar", `${localFrontmatter.replace("/tmp/programmable-v4-hook-builder", "[unterminated")}\n${body}`],
+      ["relative local path", `${localFrontmatter.replace("/tmp/programmable-v4-hook-builder", "relative/path")}\n${body}`],
+      ["traversing GitHub path", `${remoteFrontmatter.replace("skills/programmable-v4-hook-builder", "skills/../programmable-v4-hook-builder")}\n${body}`],
+      ["credentialed GitHub repository", `${remoteFrontmatter.replace("https://github.com/0xprogrammable/programmable", "https://token@github.com/0xprogrammable/programmable")}\n${body}`],
+      ["unsafe Git ref", `${remoteFrontmatter.replace("    github-ref: 0123456789abcdef0123456789abcdef01234567", "    github-ref: refs/heads/main.lock")}\n${body}`],
+      ["invalid tree SHA", `${remoteFrontmatter.replace("89abcdef0123456789abcdef0123456789abcdef", "89abcdef")}\n${body}`]
+    ]) {
+      assert.notEqual(hashSource(source), canonicalHash, `${label} must remain policy-bound or fail closed`);
+    }
+
+    assert.match(canonicalHash, /^sha256:[a-f0-9]{64}$/);
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
 function validate(copiedSkill) {
   const submissionPath = path.join(copiedSkill, "assets", "templates", "submission.example.json");
   const validatorPath = path.join(copiedSkill, "scripts", "validate-submission.mjs");

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
@@ -6,7 +6,12 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { parseCliOrExit } from "./cli-args.mjs";
-import { validateAgainstSchema } from "./submission-core.mjs";
+import {
+  isSafeGitReference,
+  isSupportedGitHubRepositoryUrl,
+  parseCanonicalProvenanceScalar,
+  validateAgainstSchema
+} from "./submission-core.mjs";
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const canonicalSkillRoot = path.resolve(scriptDirectory, "..");
@@ -509,52 +514,6 @@ function validateProvenanceScalar(key, value, maximumBytes) {
   return findings;
 }
 
-function isSupportedGitHubRepositoryUrl(value) {
-  if (Buffer.byteLength(value, "utf8") > 2048) return false;
-  try {
-    const parsed = new URL(value);
-    const hostname = parsed.hostname.toLowerCase();
-    const supportedHost = hostname === "github.com"
-      || /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.ghe\.com$/u.test(hostname);
-    const segments = parsed.pathname.split("/").filter(Boolean);
-    return supportedHost
-      && parsed.href === value
-      && parsed.protocol === "https:"
-      && parsed.username === ""
-      && parsed.password === ""
-      && parsed.port === ""
-      && parsed.search === ""
-      && parsed.hash === ""
-      && !parsed.pathname.endsWith("/")
-      && segments.length === 2
-      && /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?$/u.test(segments[0])
-      && /^[A-Za-z0-9._-]{1,100}$/u.test(segments[1]);
-  } catch {
-    return false;
-  }
-}
-
-function isSafeGitReference(value) {
-  if (Buffer.byteLength(value, "utf8") > 2048) return false;
-  if (
-    value === "@"
-    || value.startsWith("/")
-    || value.endsWith("/")
-    || value.endsWith(".")
-    || value.includes("..")
-    || value.includes("//")
-    || value.includes("@{")
-    || /[\u0000-\u0020\u007f~^:?*[\\\u202a-\u202e\u2066-\u2069]/u.test(value)
-  ) {
-    return false;
-  }
-  return value.split("/").every((segment) => (
-    segment !== ""
-    && !segment.startsWith(".")
-    && !segment.endsWith(".lock")
-  ));
-}
-
 function redactInstalledLocalPathForPortableScan(source, parsedFrontmatter) {
   if (
     !parsedFrontmatter
@@ -574,6 +533,7 @@ function redactInstalledLocalPathForPortableScan(source, parsedFrontmatter) {
 }
 
 function parseCanonicalYamlString(source, type) {
+  if (type === "provenance-string") return parseCanonicalProvenanceScalar(source);
   if (source.startsWith('"')) {
     try {
       const value = JSON.parse(source);
@@ -583,40 +543,6 @@ function parseCanonicalYamlString(source, type) {
     } catch {
       return { ok: false, error: "contains an invalid double-quoted string" };
     }
-  }
-  if (type === "provenance-string" && source.startsWith("'")) {
-    if (!source.endsWith("'") || source.length < 2) {
-      return { ok: false, error: "contains an invalid single-quoted string" };
-    }
-    const inner = source.slice(1, -1);
-    let value = "";
-    for (let index = 0; index < inner.length; index += 1) {
-      if (inner[index] !== "'") {
-        value += inner[index];
-        continue;
-      }
-      if (inner[index + 1] !== "'") {
-        return { ok: false, error: "contains an invalid single-quoted string" };
-      }
-      value += "'";
-      index += 1;
-    }
-    if (value.length === 0) return { ok: false, error: "requires a non-empty string value" };
-    return { ok: true, value };
-  }
-  if (type === "provenance-string") {
-    if (
-      source.length === 0
-      || source !== source.trim()
-      || /^(?:null|true|false|yes|no|on|off|~)$/iu.test(source)
-      || /^(?:[!&*|>@`]|[-?:]\s)/u.test(source)
-      || /[\[\]{}]/u.test(source)
-      || /(?:^|\s)#/u.test(source)
-      || /:\s|:$/u.test(source)
-    ) {
-      return { ok: false, error: "contains a non-canonical plain string" };
-    }
-    return { ok: true, value: source };
   }
   if (type === "quoted-string") {
     return { ok: false, error: "requires a double-quoted string value" };

--- a/plugins/marketplace/test/plugin-packaging.test.mjs
+++ b/plugins/marketplace/test/plugin-packaging.test.mjs
@@ -27,7 +27,7 @@ import {
 } from "../scripts/generate-plugin.mjs";
 
 const goldenHashes = {
-  skillTree: "b3010d5db70daddad8599f9b690776c4493d45fec78b169df906fbc86c951e34",
+  skillTree: "004314e6c97f14cf78cfa10b26f7f04ed33ed3c8ae27420dc44eb8a729bcfb4c",
   codexManifest: "6f5dbf19ab2a124312a9fab9ba08cb038160e68165bc1dd71211d442f2fd3354",
   claudeManifest: "09011068e632beffedf3059ba0c79646cd023499ffd77fae1273db2239e368e7",
   codexMarketplace: "f51e251087f6d26c75308aeff915485de9493b619c31b5a59baca072d725d0c0",

--- a/scripts/test/verify-public-hook-application-candidate-fetch.test.mjs
+++ b/scripts/test/verify-public-hook-application-candidate-fetch.test.mjs
@@ -207,7 +207,6 @@ test("trusted closed intake blocks application data before candidate Git fetch",
       const fixture = createRevisionPair(t2, { intakeState });
       const candidateRoot = path.join(fixture.root, "candidate.git");
       const candidateCommit = "b".repeat(40);
-      const mergeCommit = "c".repeat(40);
       let runFetchCalled = false;
       await assert.rejects(
         fetchPublicApplicationCandidate({
@@ -217,13 +216,11 @@ test("trusted closed intake blocks application data before candidate Git fetch",
           pullRequestNumber: PULL_REQUEST_NUMBER,
           expectedBaseCommit: fixture.baseCommit,
           expectedCandidateCommit: candidateCommit,
-          expectedMergeCommit: mergeCommit,
           readToken: "test-read-token"
         }, {
           fetchImplementation: createPullRequestMetadataFetch({
             baseCommit: fixture.baseCommit,
             candidateCommit,
-            mergeCommit,
             files: [{ filename: "submissions/example-hook/application.json", status: "added" }]
           }),
           async runFetch() {
@@ -542,15 +539,13 @@ test("paused-new preflight rejects foreign, mixed, renamed, and deleted applicat
   }
 });
 
-test("candidate preflight binds exact GitHub base, head, and merge identities", async (t) => {
+test("candidate preflight binds exact GitHub base and head without removed merge metadata", async (t) => {
   const fixture = createRevisionPair(t, { intakeState: "prelaunch" });
   const candidateCommit = "b".repeat(40);
-  const mergeCommit = "c".repeat(40);
-  for (const mismatch of ["base", "head", "merge"]) {
+  for (const mismatch of ["base", "head"]) {
     await t.test(mismatch, async () => {
       const observedBase = mismatch === "base" ? "d".repeat(40) : fixture.baseCommit;
       const observedHead = mismatch === "head" ? "d".repeat(40) : candidateCommit;
-      const observedMerge = mismatch === "merge" ? "d".repeat(40) : mergeCommit;
       await assert.rejects(
         preflightPublicApplicationCandidateFetch({
           baseRoot: fixture.base,
@@ -564,7 +559,6 @@ test("candidate preflight binds exact GitHub base, head, and merge identities", 
           fetchImplementation: createPullRequestMetadataFetch({
             baseCommit: observedBase,
             candidateCommit: observedHead,
-            mergeCommit: observedMerge,
             files: [{ filename: "submissions/example-hook/application.json", status: "added" }]
           })
         }),
@@ -603,6 +597,33 @@ test("hydration enforces trusted intake state before GitHub tree metadata or bac
   assert.equal(metadataCalled, false);
 });
 
+test("initial candidate fetch derives the merge id and immediately binds the event head", async (t) => {
+  const fixture = createRevisionPair(t, { intakeState: "open" });
+  writeFile(fixture.candidate, "skills/programmable-v4-hook-builder/SKILL.md", "candidate data\n");
+  const candidateCommit = commitAll(fixture.candidate, "candidate revision");
+  const mergeCommit = createPullRequestMerge(fixture, candidateCommit);
+  git(fixture.candidate, ["update-ref", `refs/pull/${PULL_REQUEST_NUMBER}/merge`, mergeCommit]);
+  git(fixture.candidate, ["config", "uploadpack.allowFilter", "true"]);
+  const candidateData = path.join(fixture.root, "candidate.git");
+
+  await assert.rejects(
+    fetchPublicApplicationCandidate({
+      baseRoot: fixture.base,
+      candidateRoot: candidateData,
+      repository: "central/repository",
+      pullRequestNumber: PULL_REQUEST_NUMBER,
+      expectedBaseCommit: fixture.baseCommit,
+      expectedCandidateCommit: "d".repeat(40),
+      readToken: "test-read-token"
+    }, {
+      remoteUrlForTests: pathToFileURL(fixture.candidate).href,
+      allowFileProtocolForTests: true
+    }),
+    (error) => error?.code === "PR_MERGE_PARENT_MISMATCH" && error?.kind === "system"
+  );
+  assert.equal(fs.existsSync(candidateData), false);
+});
+
 test("initial candidate fetch rejects a giant pack and removes the token-bearing object store", async (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "public-hook-fetch-giant-pack-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
@@ -627,7 +648,6 @@ test("initial candidate fetch rejects a giant pack and removes the token-bearing
       pullRequestNumber: PULL_REQUEST_NUMBER,
       expectedBaseCommit: baseCommit,
       expectedCandidateCommit: "b".repeat(40),
-      expectedMergeCommit: "a".repeat(40),
       readToken: "test-read-token"
     }, {
       remoteUrlForTests: "https://github.com/central/repository.git",
@@ -812,7 +832,6 @@ async function fetchBloblessPullRequestMerge(fixture, mergeCommit) {
     pullRequestNumber: PULL_REQUEST_NUMBER,
     expectedBaseCommit: fixture.baseCommit,
     expectedCandidateCommit: candidateCommit,
-    expectedMergeCommit: mergeCommit,
     readToken: "test-read-token"
   }, {
     remoteUrlForTests: pathToFileURL(fixture.candidate).href,
@@ -851,7 +870,7 @@ function fetchBloblessPullRequestMergeWithoutIntake(fixture, mergeCommit) {
   return candidateData;
 }
 
-function createPullRequestMetadataFetch({ baseCommit, candidateCommit, mergeCommit, files }) {
+function createPullRequestMetadataFetch({ baseCommit, candidateCommit, files }) {
   const pullRequestUrl = `https://api.github.com/repos/central/repository/pulls/${PULL_REQUEST_NUMBER}`;
   const documents = new Map([
     [pullRequestUrl, {
@@ -859,7 +878,6 @@ function createPullRequestMetadataFetch({ baseCommit, candidateCommit, mergeComm
       state: "open",
       base: { sha: baseCommit, repo: { full_name: "central/repository" } },
       head: { sha: candidateCommit },
-      merge_commit_sha: mergeCommit,
       changed_files: files.length
     }],
     [`${pullRequestUrl}/files?per_page=100&page=1`, files]

--- a/scripts/test/verify-public-hook-application-candidate-fetch.test.mjs
+++ b/scripts/test/verify-public-hook-application-candidate-fetch.test.mjs
@@ -521,7 +521,6 @@ test("paused-new preflight rejects foreign, mixed, renamed, and deleted applicat
           baseRoot: fixture.base,
           expectedBaseCommit: fixture.baseCommit,
           expectedCandidateCommit: candidateCommit,
-          expectedMergeCommit: mergeCommit,
           repository: "central/repository",
           pullRequestNumber: PULL_REQUEST_NUMBER,
           readToken: "test-read-token"
@@ -551,7 +550,6 @@ test("candidate preflight binds exact GitHub base and head without removed merge
           baseRoot: fixture.base,
           expectedBaseCommit: fixture.baseCommit,
           expectedCandidateCommit: candidateCommit,
-          expectedMergeCommit: mergeCommit,
           repository: "central/repository",
           pullRequestNumber: PULL_REQUEST_NUMBER,
           readToken: "test-read-token"

--- a/scripts/test/verify-public-hook-application-workflow.test.mjs
+++ b/scripts/test/verify-public-hook-application-workflow.test.mjs
@@ -103,7 +103,7 @@ test("candidate data is an exact base-repository PR merge in a bare blobless obj
   assert.match(candidateFetchStep, /--base-root "\$GITHUB_WORKSPACE\/trusted"/u);
   assert.match(candidateFetchStep, /--expected-base-commit "\$\{\{ github\.event\.pull_request\.base\.sha \}\}"/u);
   assert.match(candidateFetchStep, /--expected-candidate-commit "\$\{\{ github\.event\.pull_request\.head\.sha \}\}"/u);
-  assert.match(candidateFetchStep, /--expected-merge-commit "\$\{\{ github\.event\.pull_request\.merge_commit_sha \}\}"/u);
+  assert.doesNotMatch(candidateFetchStep, /--expected-merge-commit/u);
   assert.match(candidateFetchStep, /--candidate-root "\$GITHUB_WORKSPACE\/candidate\.git"/u);
   assert.match(validatorCore, /init", "--quiet", "--bare", "--object-format=sha1"/u);
   assert.match(validatorCore, /`\+refs\/pull\/\$\{pullRequestNumber\}\/merge:refs\/heads\/candidate-merge`/u);
@@ -112,7 +112,8 @@ test("candidate data is an exact base-repository PR merge in a bare blobless obj
   assert.match(validatorCore, /\\tpromisor = true/u);
   assert.match(validatorCore, /\\tpartialclonefilter = blob:none/u);
   assert.match(validatorCore, /runBoundedHydrationGitProcess/u);
-  assert.match(validatorCore, /observedMergeCommit !== expectedMergeCommit/u);
+  assert.match(validatorCore, /inspectExactPullRequestMergeIdentity\(gitDirectory/u);
+  assert.match(validatorCore, /parents\[0\] !== expectedBaseCommit \|\| parents\[1\] !== expectedCandidateCommit/u);
   assert.match(validatorCore, /await preflightPublicApplicationCandidateFetch/u);
   assert.ok(
     validatorCore.indexOf("await preflightPublicApplicationCandidateFetch")
@@ -183,16 +184,14 @@ test("the central read credential is scoped, isolated from public resolution, an
   assert.doesNotMatch(builderMaintenanceStep, /github\.token|CANDIDATE_READ_TOKEN/u);
 });
 
-test("workflow fails before candidate fetch when GitHub cannot provide an immutable PR merge", () => {
-  const mergePreflight = publicJob.slice(
-    publicJob.indexOf("- name: Require immutable PR merge identity"),
-    publicJob.indexOf("- name: Fetch exact candidate merge as blobless data")
-  );
-  assert.match(mergePreflight, /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/u);
-  assert.match(mergePreflight, /HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/u);
-  assert.match(mergePreflight, /MERGE_SHA: \$\{\{ github\.event\.pull_request\.merge_commit_sha \}\}/u);
-  assert.match(mergePreflight, /\^\[a-f0-9\]\{40\}\$/u);
-  assert.match(mergePreflight, /Resolve merge conflicts and retry/u);
+test("workflow derives the immutable merge identity from the fetched Git ref", () => {
+  assert.match(candidateFetchStep, /id: candidate_fetch/u);
+  assert.match(candidateFetchStep, /fetch_report="\$\(timeout --signal=KILL 90s node/u);
+  assert.match(candidateFetchStep, /report\.result !== "exact-blobless-candidate-fetched"/u);
+  assert.match(candidateFetchStep, /\^\[a-f0-9\]\{40\}\$/u);
+  assert.match(candidateFetchStep, /merge_commit=\$merge_commit/u);
+  assert.doesNotMatch(publicJob, /--resolve-merge-commit|steps\.merge_identity/u);
+  assert.doesNotMatch(publicJob, /github\.event\.pull_request\.merge_commit_sha/u);
 });
 
 test("classification and validation execute only trusted base-branch validators", () => {
@@ -201,7 +200,7 @@ test("classification and validation execute only trusted base-branch validators"
   assert.match(publicJob, /--classify/u);
   assert.match(publicJob, /--expected-base-commit "\$\{\{ github\.event\.pull_request\.base\.sha \}\}"/u);
   assert.match(publicJob, /--expected-candidate-commit "\$\{\{ github\.event\.pull_request\.head\.sha \}\}"/u);
-  assert.match(publicJob, /--expected-merge-commit "\$\{\{ github\.event\.pull_request\.merge_commit_sha \}\}"/u);
+  assert.match(publicJob, /--expected-merge-commit "\$\{\{ steps\.candidate_fetch\.outputs\.merge_commit \}\}"/u);
   assert.match(publicJob, /timeout --signal=KILL 30s/u);
   assert.match(publicJob, /timeout --signal=KILL 120s/u);
 });

--- a/scripts/test/verify-public-hook-application.test.mjs
+++ b/scripts/test/verify-public-hook-application.test.mjs
@@ -44,7 +44,7 @@ const EVIDENCE_BYTES = Buffer.from("exact builder-owned compatibility evidence f
 const EVIDENCE_SHA256 = `sha256:${crypto.createHash("sha256").update(EVIDENCE_BYTES).digest("hex")}`;
 
 test("the frozen six-file package and public schema identity are exported", () => {
-  assert.equal(VALIDATOR_VERSION, "1.6.0");
+  assert.equal(VALIDATOR_VERSION, "1.6.1");
   assert.deepEqual(PUBLIC_APPLICATION_FILES, [
     "application.json",
     "PROPOSAL.md",
@@ -488,6 +488,35 @@ test("a PR merge checkout whose parents differ from the GitHub event fails close
   const input = inputFor(fixture, candidateCommit);
   assert.throws(
     () => classifyPublicIntakePullRequest({ ...input, expectedCandidateCommit: "c".repeat(40) }),
+    (error) => error instanceof PublicIntakeError
+      && error.kind === "system"
+      && error.code === "PR_MERGE_PARENT_MISMATCH"
+  );
+});
+
+test("a PR merge checkout with reversed base and head parents fails closed", (t) => {
+  const fixture = createRevisionPair(t);
+  writePackage(fixture.candidate, makePackage());
+  const candidateCommit = commitAll(fixture.candidate, "candidate application");
+  git(fixture.candidate, ["fetch", "--quiet", "--no-tags", fixture.base, fixture.baseCommit]);
+  const mergedTree = git(fixture.candidate, ["merge-tree", "--write-tree", fixture.baseCommit, candidateCommit]);
+  const reversedMergeCommit = git(fixture.candidate, [
+    "commit-tree",
+    mergedTree,
+    "-p", candidateCommit,
+    "-p", fixture.baseCommit,
+    "-m", "Synthetic merge with reversed parents"
+  ]);
+  git(fixture.candidate, ["reset", "--hard", reversedMergeCommit]);
+
+  assert.throws(
+    () => classifyPublicIntakePullRequest({
+      baseRoot: fixture.base,
+      candidateRoot: fixture.candidate,
+      expectedBaseCommit: fixture.baseCommit,
+      expectedCandidateCommit: candidateCommit,
+      expectedMergeCommit: reversedMergeCommit
+    }),
     (error) => error instanceof PublicIntakeError
       && error.kind === "system"
       && error.code === "PR_MERGE_PARENT_MISMATCH"

--- a/scripts/verify-public-hook-application-core.mjs
+++ b/scripts/verify-public-hook-application-core.mjs
@@ -17,7 +17,7 @@ import {
 } from "../skills/programmable-v4-hook-builder/scripts/github-exact-object-resolver.mjs";
 import { findUnsupportedPublicClaims } from "../skills/programmable-v4-hook-builder/scripts/public-claims-core.mjs";
 
-export const VALIDATOR_VERSION = "1.6.0";
+export const VALIDATOR_VERSION = "1.6.1";
 export const PUBLIC_APPLICATION_SCHEMA_ID = "https://programmable.money/schemas/public-pr-application-v1.json";
 export const PUBLIC_BETA_DISCLAIMER =
   "Builder-declared compatibility evidence; not an audit, approval, deployment, Uniswap endorsement, or launch.";
@@ -245,19 +245,13 @@ export async function preflightPublicApplicationCandidateFetch({
   baseRoot,
   expectedBaseCommit,
   expectedCandidateCommit,
-  expectedMergeCommit,
   repository,
   pullRequestNumber,
   readToken,
   limits: limitOverrides = {}
 }, dependencies = {}) {
   validateHydrationAuthority({ repository, readToken });
-  validateCandidateFetchIdentity({
-    pullRequestNumber,
-    expectedBaseCommit,
-    expectedCandidateCommit,
-    expectedMergeCommit
-  });
+  validateCandidateHeadIdentity({ pullRequestNumber, expectedBaseCommit, expectedCandidateCommit });
   const limits = mergeLimits(limitOverrides);
   const base = inspectGitRevision(baseRoot, expectedBaseCommit, limits);
   const intakeStatus = readTrustedIntakeStatus(base);
@@ -275,7 +269,6 @@ export async function preflightPublicApplicationCandidateFetch({
     pullRequestNumber,
     expectedBaseCommit,
     expectedCandidateCommit,
-    expectedMergeCommit,
     readToken,
     maximumChangedFiles: limits.maximumChangedFiles,
     fetchImplementation: dependencies.fetchImplementation ?? globalThis.fetch,
@@ -354,16 +347,14 @@ export async function fetchPublicApplicationCandidate({
   pullRequestNumber,
   expectedBaseCommit,
   expectedCandidateCommit,
-  expectedMergeCommit,
   readToken
 }, dependencies = {}) {
   validateHydrationAuthority({ repository, readToken });
-  validateCandidateFetchIdentity({ pullRequestNumber, expectedBaseCommit, expectedCandidateCommit, expectedMergeCommit });
+  validateCandidateHeadIdentity({ pullRequestNumber, expectedBaseCommit, expectedCandidateCommit });
   await preflightPublicApplicationCandidateFetch({
     baseRoot,
     expectedBaseCommit,
     expectedCandidateCommit,
-    expectedMergeCommit,
     repository,
     pullRequestNumber,
     readToken
@@ -435,10 +426,10 @@ export async function fetchPublicApplicationCandidate({
       systemBlocked("CANDIDATE_FETCH_BOUNDED_FAILURE", "The exact blobless PR merge exceeded trusted fetch bounds or was unavailable.");
     }
     runGit(gitDirectory, ["symbolic-ref", "HEAD", "refs/heads/candidate-merge"], 1024);
-    const observedMergeCommit = runGitText(gitDirectory, ["rev-parse", "HEAD^{commit}"], 128).trim();
-    if (observedMergeCommit !== expectedMergeCommit) {
-      systemBlocked("CANDIDATE_FETCH_ID_MISMATCH", "The base-repository PR merge ref moved after the workflow event.");
-    }
+    const { mergeCommit: observedMergeCommit } = inspectExactPullRequestMergeIdentity(gitDirectory, {
+      expectedBaseCommit,
+      expectedCandidateCommit
+    });
     complete = true;
     return {
       schemaVersion: 1,
@@ -608,13 +599,19 @@ function validateCandidateFetchIdentity({
   expectedCandidateCommit,
   expectedMergeCommit
 }) {
+  validateCandidateHeadIdentity({ pullRequestNumber, expectedBaseCommit, expectedCandidateCommit });
+  if (!SHA1_PATTERN.test(expectedMergeCommit ?? "")) {
+    systemBlocked("CANDIDATE_FETCH_ID_INVALID", "The expected pull-request merge commit is missing or malformed.");
+  }
+}
+
+function validateCandidateHeadIdentity({ pullRequestNumber, expectedBaseCommit, expectedCandidateCommit }) {
   if (typeof pullRequestNumber !== "string" || !PULL_REQUEST_NUMBER_PATTERN.test(pullRequestNumber)) {
     systemBlocked("CANDIDATE_FETCH_ID_INVALID", "The pull-request number is missing or malformed.");
   }
   for (const [label, objectId] of [
     ["base", expectedBaseCommit],
-    ["head", expectedCandidateCommit],
-    ["merge", expectedMergeCommit]
+    ["head", expectedCandidateCommit]
   ]) {
     if (!SHA1_PATTERN.test(objectId ?? "")) {
       systemBlocked("CANDIDATE_FETCH_ID_INVALID", `The expected pull-request ${label} commit is missing or malformed.`);
@@ -627,7 +624,6 @@ async function resolveCentralPullRequestChangedFiles({
   pullRequestNumber,
   expectedBaseCommit,
   expectedCandidateCommit,
-  expectedMergeCommit,
   readToken,
   maximumChangedFiles,
   fetchImplementation,
@@ -661,7 +657,6 @@ async function resolveCentralPullRequestChangedFiles({
     || pullRequest.state !== "open"
     || pullRequest.base?.sha !== expectedBaseCommit
     || pullRequest.head?.sha !== expectedCandidateCommit
-    || pullRequest.merge_commit_sha !== expectedMergeCommit
     || typeof pullRequest.base?.repo?.full_name !== "string"
     || pullRequest.base.repo.full_name.toLowerCase() !== repository.toLowerCase()
     || !Number.isInteger(pullRequest.changed_files)
@@ -1990,23 +1985,54 @@ function inspectPullRequestMergeRevision(rootInput, {
   expectedMergeCommit,
   limits
 }) {
+  const { root, mergeCommit } = inspectExactPullRequestMergeIdentity(rootInput, {
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    expectedMergeCommit
+  });
+  const output = runGit(root, ["ls-tree", "-rz", "--full-tree", "HEAD"], limits.maximumGitTreeBytes);
+  const entries = parseGitTree(output, limits);
+  return {
+    root,
+    commit: expectedCandidateCommit,
+    mergeCommit,
+    entries
+  };
+}
+
+/**
+ * Bind the fetched GitHub-owned refs/pull/N/merge object directly to the exact
+ * workflow base and head. GitHub API version 2026-03-10 intentionally omits
+ * merge_commit_sha, so the immutable Git object and its ordered parents are
+ * the source of truth instead of mutable or removed REST response metadata.
+ */
+function inspectExactPullRequestMergeIdentity(rootInput, {
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  expectedMergeCommit = null
+}) {
   for (const [label, commit] of [
     ["base", expectedBaseCommit],
-    ["candidate", expectedCandidateCommit],
-    ["merge", expectedMergeCommit]
+    ["candidate", expectedCandidateCommit]
   ]) {
     if (!SHA1_PATTERN.test(commit ?? "")) {
       systemBlocked("EXPECTED_COMMIT_INVALID", `The workflow did not provide an exact lowercase ${label} commit id.`);
     }
   }
+  if (expectedMergeCommit !== null && !SHA1_PATTERN.test(expectedMergeCommit ?? "")) {
+    systemBlocked("EXPECTED_COMMIT_INVALID", "The workflow did not provide an exact lowercase merge commit id.");
+  }
 
   const root = resolveGitRoot(rootInput);
-  const checkoutCommit = runGitText(root, ["rev-parse", "HEAD^{commit}"], 1024).trim();
-  if (checkoutCommit !== expectedMergeCommit) {
+  const mergeCommit = runGitText(root, ["rev-parse", "HEAD^{commit}"], 1024).trim();
+  if (!SHA1_PATTERN.test(mergeCommit)) {
+    systemBlocked("PR_MERGE_COMMIT_MALFORMED", "GitHub's PR merge ref did not resolve to one exact SHA-1 commit id.");
+  }
+  if (expectedMergeCommit !== null && mergeCommit !== expectedMergeCommit) {
     systemBlocked("CHECKOUT_COMMIT_MISMATCH", "The candidate-data checkout does not match GitHub's immutable PR merge commit.");
   }
 
-  const commitObject = runGitText(root, ["cat-file", "-p", "HEAD^{commit}"], 1024 * 1024);
+  const commitObject = runGitText(root, ["cat-file", "-p", `${mergeCommit}^{commit}`], 1024 * 1024);
   const headerEnd = commitObject.indexOf("\n\n");
   if (headerEnd === -1) {
     systemBlocked("PR_MERGE_COMMIT_MALFORMED", "GitHub's PR merge commit has no canonical commit header boundary.");
@@ -2026,15 +2052,7 @@ function inspectPullRequestMergeRevision(rootInput, {
   if (parents[0] !== expectedBaseCommit || parents[1] !== expectedCandidateCommit) {
     systemBlocked("PR_MERGE_PARENT_MISMATCH", "GitHub's PR merge parents do not match the event's exact base and head commits.");
   }
-
-  const output = runGit(root, ["ls-tree", "-rz", "--full-tree", "HEAD"], limits.maximumGitTreeBytes);
-  const entries = parseGitTree(output, limits);
-  return {
-    root,
-    commit: expectedCandidateCommit,
-    mergeCommit: expectedMergeCommit,
-    entries
-  };
+  return { root, mergeCommit };
 }
 
 function inspectGitRevision(rootInput, expectedCommit, limits) {

--- a/scripts/verify-public-hook-application.mjs
+++ b/scripts/verify-public-hook-application.mjs
@@ -17,7 +17,7 @@ import {
 const usage = `Usage:
   verify-public-hook-application.mjs --classify --base-root <path> --candidate-root <path> --expected-base-commit <sha> --expected-candidate-commit <sha> --expected-merge-commit <sha>
   verify-public-hook-application.mjs --pull-request-number <number> --base-root <path> --candidate-root <path> --expected-base-commit <sha> --expected-candidate-commit <sha> --expected-merge-commit <sha> --expected-builder-login <login> --expected-builder-user-id <decimal-id>
-  verify-public-hook-application.mjs --fetch-candidate --repository <owner/repository> --pull-request-number <number> --base-root <path> --candidate-root <path> --expected-base-commit <sha> --expected-candidate-commit <sha> --expected-merge-commit <sha>
+  verify-public-hook-application.mjs --fetch-candidate --repository <owner/repository> --pull-request-number <number> --base-root <path> --candidate-root <path> --expected-base-commit <sha> --expected-candidate-commit <sha>
   verify-public-hook-application.mjs --hydrate-candidate --repository <owner/repository> --pull-request-number <number> --base-root <path> --candidate-root <path> --expected-base-commit <sha> --expected-candidate-commit <sha> --expected-merge-commit <sha>
   verify-public-hook-application.mjs --verify-maintained --repository-root <path>
 
@@ -25,7 +25,7 @@ Inspect one pull request with trusted base code. Candidate Git objects are treat
 
 Options:
   --classify                    Print application, builder-maintenance, or no-op without network access
-  --fetch-candidate             Fetch the exact base-repository PR merge into bounded blobless storage
+  --fetch-candidate             Fetch and identify the exact base-repository PR merge in bounded blobless storage
   --hydrate-candidate           Preflight sizes and hydrate only the closed six-file candidate package
   --repository <owner/name>     Authenticated central GitHub repository for candidate tree metadata
   --pull-request-number <n>     Exact central pull-request number for fetch, hydration, and final application verification
@@ -68,7 +68,6 @@ if (options?.help) {
         pullRequestNumber: options.pullRequestNumber,
         expectedBaseCommit: options.expectedBaseCommit,
         expectedCandidateCommit: options.expectedCandidateCommit,
-        expectedMergeCommit: options.expectedMergeCommit,
         readToken: process.env.CANDIDATE_READ_TOKEN
       });
       process.stdout.write(`${JSON.stringify(report)}\n`);
@@ -183,10 +182,10 @@ function parseArguments(args) {
         }
       }
     } else if (parsed.fetchCandidate) {
-      for (const key of ["repository", "pullRequestNumber", "baseRoot", "candidateRoot", "expectedBaseCommit", "expectedCandidateCommit", "expectedMergeCommit"]) {
+      for (const key of ["repository", "pullRequestNumber", "baseRoot", "candidateRoot", "expectedBaseCommit", "expectedCandidateCommit"]) {
         if (parsed[key] === null) throw new PublicIntakeError("CLI_ARGUMENT_MISSING", "Candidate fetch is missing a required trusted option.", { kind: "system" });
       }
-      for (const key of ["repositoryRoot", "expectedBuilderLogin", "expectedBuilderUserId"]) {
+      for (const key of ["repositoryRoot", "expectedBuilderLogin", "expectedBuilderUserId", "expectedMergeCommit"]) {
         if (parsed[key] !== null) throw new PublicIntakeError("CLI_ARGUMENT_INVALID", "Candidate fetch received an unrelated validator option.", { kind: "system" });
       }
     } else {

--- a/skills/README.md
+++ b/skills/README.md
@@ -30,7 +30,7 @@ branch name or a moving tag.
 
 ```bash
 gh skill preview 0xprogrammable/programmable \
-  skills/programmable-v4-hook-builder@FULL_COMMIT_SHA
+  programmable-v4-hook-builder@FULL_COMMIT_SHA
 ```
 
 Install the same revision for one supported host:

--- a/skills/programmable-v4-hook-builder/scripts/submission-core.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/submission-core.mjs
@@ -2140,10 +2140,190 @@ function hashBundle(targets) {
     const relativePath = path.relative(skillRoot, target).split(path.sep).join("/");
     hash.update(relativePath);
     hash.update("\0");
-    hash.update(fs.readFileSync(target));
+    const bytes = fs.readFileSync(target);
+    hash.update(relativePath === "SKILL.md" ? normalizeSkillPolicyBytes(bytes) : bytes);
     hash.update("\0");
   }
   return `sha256:${hash.digest("hex")}`;
+}
+
+function normalizeSkillPolicyBytes(bytes) {
+  let source;
+  try {
+    source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return bytes;
+  }
+
+  const document = source.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/u);
+  if (!document) return bytes;
+
+  const rootFields = new Map();
+  const metadataFields = new Map();
+  let insideMetadata = false;
+  let sawMetadata = false;
+
+  for (const line of document[1].split("\n")) {
+    if (line.startsWith("    ")) {
+      if (!insideMetadata) return bytes;
+      const child = line.match(/^ {4}([a-z][a-z0-9-]*): (.+)$/u);
+      if (!child || metadataFields.has(child[1])) return bytes;
+      metadataFields.set(child[1], child[2]);
+      continue;
+    }
+
+    const field = line.match(/^([a-z][a-z0-9-]*):(?: (.+))?$/u);
+    if (!field) return bytes;
+    const [, key, value] = field;
+    insideMetadata = key === "metadata";
+
+    if (insideMetadata) {
+      if (sawMetadata || value !== undefined) return bytes;
+      sawMetadata = true;
+      continue;
+    }
+
+    if (!["name", "description", "license"].includes(key) || rootFields.has(key) || value === undefined) return bytes;
+    rootFields.set(key, value);
+  }
+
+  if (!rootFields.has("name") || !rootFields.has("description")) return bytes;
+  if (sawMetadata && !isExactInstallerProvenance(metadataFields, rootFields.get("name"))) return bytes;
+
+  const canonicalFrontmatter = [
+    "---",
+    `name: ${rootFields.get("name")}`,
+    `description: ${rootFields.get("description")}`,
+    ...(rootFields.has("license") ? [`license: ${rootFields.get("license")}`] : []),
+    "---"
+  ].join("\n");
+  const body = document[2].startsWith("\n") ? document[2].slice(1) : document[2];
+  return Buffer.from(`${canonicalFrontmatter}\n\n${body}`, "utf8");
+}
+
+function isExactInstallerProvenance(metadataFields, declaredName) {
+  const keys = [...metadataFields.keys()].sort();
+  const values = new Map();
+  for (const [key, source] of metadataFields) {
+    const parsed = parseCanonicalProvenanceScalar(source);
+    if (!parsed.ok) return false;
+    values.set(key, parsed.value);
+  }
+
+  if (keys.length === 1 && keys[0] === "local-path") {
+    const localPath = values.get("local-path");
+    return isBoundedProvenanceValue(localPath, 4096)
+      && (path.posix.isAbsolute(localPath) || path.win32.isAbsolute(localPath));
+  }
+
+  const required = ["github-path", "github-ref", "github-repo", "github-tree-sha"];
+  const allowed = [...required, "github-pinned"].sort();
+  if (!keys.every((key) => allowed.includes(key)) || !required.every((key) => keys.includes(key))) return false;
+  if (![...values].every(([key, value]) => isBoundedProvenanceValue(value, key === "github-path" ? 1024 : 2048))) return false;
+
+  const githubPath = values.get("github-path");
+  const pathSegments = githubPath.split("/");
+  if (
+    githubPath.startsWith("/")
+    || githubPath.endsWith("/")
+    || githubPath.includes("\\")
+    || pathSegments.some((segment) => segment === "" || segment === "." || segment === "..")
+    || pathSegments.at(-1) !== declaredName
+  ) return false;
+
+  return isSupportedGitHubRepositoryUrl(values.get("github-repo"))
+    && isSafeGitReference(values.get("github-ref"))
+    && (!values.has("github-pinned") || isSafeGitReference(values.get("github-pinned")))
+    && /^[0-9a-f]{40}$/u.test(values.get("github-tree-sha"));
+}
+
+export function parseCanonicalProvenanceScalar(source) {
+  if (source.startsWith('"')) {
+    try {
+      const value = JSON.parse(source);
+      if (typeof value !== "string") return { ok: false, error: "requires a string value" };
+      if (value.length === 0) return { ok: false, error: "requires a non-empty string value" };
+      return { ok: true, value };
+    } catch {
+      return { ok: false, error: "contains an invalid double-quoted string" };
+    }
+  }
+  if (source.startsWith("'")) {
+    if (!source.endsWith("'") || source.length < 2) {
+      return { ok: false, error: "contains an invalid single-quoted string" };
+    }
+    const inner = source.slice(1, -1);
+    let value = "";
+    for (let index = 0; index < inner.length; index += 1) {
+      if (inner[index] !== "'") {
+        value += inner[index];
+      } else if (inner[index + 1] === "'") {
+        value += "'";
+        index += 1;
+      } else {
+        return { ok: false, error: "contains an invalid single-quoted string" };
+      }
+    }
+    if (value.length === 0) return { ok: false, error: "requires a non-empty string value" };
+    return { ok: true, value };
+  }
+  if (
+    source.length === 0
+    || source !== source.trim()
+    || /^(?:null|true|false|yes|no|on|off|~)$/iu.test(source)
+    || /^(?:[!&*|>@`]|[-?:]\s)/u.test(source)
+    || /[\[\]{}]/u.test(source)
+    || /(?:^|\s)#/u.test(source)
+    || /:\s|:$/u.test(source)
+  ) return { ok: false, error: "contains a non-canonical plain string" };
+  return { ok: true, value: source };
+}
+
+function isBoundedProvenanceValue(value, maximumBytes) {
+  return Buffer.byteLength(value, "utf8") <= maximumBytes
+    && !/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/u.test(value)
+    && ![...value].some((character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint >= 0xd800 && codePoint <= 0xdfff;
+    });
+}
+
+export function isSupportedGitHubRepositoryUrl(value) {
+  try {
+    const parsed = new URL(value);
+    const hostname = parsed.hostname.toLowerCase();
+    const supportedHost = hostname === "github.com"
+      || /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.ghe\.com$/u.test(hostname);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    return supportedHost
+      && parsed.href === value
+      && parsed.protocol === "https:"
+      && parsed.username === ""
+      && parsed.password === ""
+      && parsed.port === ""
+      && parsed.search === ""
+      && parsed.hash === ""
+      && !parsed.pathname.endsWith("/")
+      && segments.length === 2
+      && /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?$/u.test(segments[0])
+      && /^[A-Za-z0-9._-]{1,100}$/u.test(segments[1]);
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeGitReference(value) {
+  if (
+    value === "@"
+    || value.startsWith("/")
+    || value.endsWith("/")
+    || value.endsWith(".")
+    || value.includes("..")
+    || value.includes("//")
+    || value.includes("@{")
+    || /[\u0000-\u0020\u007f~^:?*[\\\u202a-\u202e\u2066-\u2069]/u.test(value)
+  ) return false;
+  return value.split("/").every((segment) => segment !== "" && !segment.startsWith(".") && !segment.endsWith(".lock"));
 }
 
 function requireResolvedText(value, path, code, add) {

--- a/skills/programmable-v4-hook-builder/scripts/test/github-exact-object-resolver.test.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/test/github-exact-object-resolver.test.mjs
@@ -577,9 +577,7 @@ test("bounded runner kills a TERM-resistant process tree on timeout", async (t) 
     "wait",
     ""
   ].join("\n"));
-  const result = await runBoundedExactGitProcessV1(boundedRunnerOptions(fixtureRoot, executable, {
-    timeoutMs: 250
-  }));
+  const result = await runBoundedExactGitProcessV1(boundedRunnerOptions(fixtureRoot, executable));
   assert.equal(result.timedOut, true);
   assert.equal(result.cpuExceeded, false);
   await waitForProcessExit(Number(fs.readFileSync(childPidPath, "utf8").trim()));

--- a/skills/programmable-v4-hook-builder/scripts/test/policy-bundle.test.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/test/policy-bundle.test.mjs
@@ -37,6 +37,87 @@ for (const policyPath of [
   });
 }
 
+test("policy bundle normalizes only exact gh installer changes", () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "programmable-installed-policy-bundle-"));
+  const copiedSkill = path.join(fixtureRoot, "programmable-v4-hook-builder");
+
+  try {
+    fs.cpSync(skillRoot, copiedSkill, { recursive: true });
+    const skillPath = path.join(copiedSkill, "SKILL.md");
+    const canonical = fs.readFileSync(skillPath, "utf8");
+    const canonicalDocument = canonical.match(/^---\n([\s\S]*?)\n---\n\n([\s\S]*)$/u);
+    assert.ok(canonicalDocument);
+    const canonicalFields = new Map(canonicalDocument[1].split("\n").map((line) => line.split(/: (.*)/su).slice(0, 2)));
+    const body = canonicalDocument[2];
+    const canonicalHash = validate(copiedSkill).toolchain.policyBundleSha256;
+    const remoteFrontmatter = [
+      "---",
+      `description: ${canonicalFields.get("description")}`,
+      `license: ${canonicalFields.get("license")}`,
+      "metadata:",
+      "    github-path: skills/programmable-v4-hook-builder",
+      "    github-pinned: 0123456789abcdef0123456789abcdef01234567",
+      "    github-ref: 0123456789abcdef0123456789abcdef01234567",
+      "    github-repo: https://github.com/0xprogrammable/programmable",
+      "    github-tree-sha: 89abcdef0123456789abcdef0123456789abcdef",
+      `name: ${canonicalFields.get("name")}`,
+      "---"
+    ].join("\n");
+    const localFrontmatter = [
+      "---",
+      `description: ${canonicalFields.get("description")}`,
+      `license: ${canonicalFields.get("license")}`,
+      "metadata:",
+      "    local-path: /tmp/programmable-v4-hook-builder",
+      `name: ${canonicalFields.get("name")}`,
+      "---"
+    ].join("\n");
+
+    const hashSource = (source) => {
+      fs.writeFileSync(skillPath, source);
+      return validate(copiedSkill).toolchain.policyBundleSha256;
+    };
+
+    assert.equal(hashSource(`${remoteFrontmatter}\n${body}`), canonicalHash, "remote gh install removes the separator blank line");
+    assert.equal(
+      hashSource(`${remoteFrontmatter.replace("    github-pinned: 0123456789abcdef0123456789abcdef01234567\n", "")}\n${body}`),
+      canonicalHash,
+      "unpinned remote provenance is also an exact installer profile"
+    );
+    assert.equal(hashSource(`${localFrontmatter}\n${body}`), canonicalHash, "local gh install uses the same policy bytes");
+    assert.equal(
+      hashSource(`${localFrontmatter.replace("/tmp/programmable-v4-hook-builder", "'/tmp/programmable v4 hook builder'")}\n${body}`),
+      canonicalHash,
+      "single-quoted absolute local provenance remains an exact installer profile"
+    );
+
+    for (const [label, source] of [
+      ["name", `${remoteFrontmatter.replace(`name: ${canonicalFields.get("name")}`, `name: ${canonicalFields.get("name")}-changed`)}\n${body}`],
+      ["description", `${remoteFrontmatter.replace(`description: ${canonicalFields.get("description")}`, `description: ${canonicalFields.get("description")} Changed.`)}\n${body}`],
+      ["license", `${remoteFrontmatter.replace(`license: ${canonicalFields.get("license")}`, "license: Apache-2.0")}\n${body}`],
+      ["body", `${remoteFrontmatter}\n${body}\nChanged policy body.\n`],
+      ["extra separator blank line", `${remoteFrontmatter}\n\n\n${body}`],
+      ["unknown root field", `${remoteFrontmatter.replace("---\n", "---\nallowed-tools: Bash\n")}\n${body}`],
+      ["unknown metadata field", `${remoteFrontmatter.replace("    github-path:", "    allowed-tools: Bash\n    github-path:")}\n${body}`],
+      ["duplicate root field", `${remoteFrontmatter.replace("---\n", `---\nname: ${canonicalFields.get("name")}\n`)}\n${body}`],
+      ["mixed provenance", `${localFrontmatter.replace("    local-path:", "    github-path: skills/programmable-v4-hook-builder\n    local-path:")}\n${body}`],
+      ["malformed provenance indentation", `${remoteFrontmatter.replace("    github-path:", "  github-path:")}\n${body}`],
+      ["malformed local scalar", `${localFrontmatter.replace("/tmp/programmable-v4-hook-builder", "[unterminated")}\n${body}`],
+      ["relative local path", `${localFrontmatter.replace("/tmp/programmable-v4-hook-builder", "relative/path")}\n${body}`],
+      ["traversing GitHub path", `${remoteFrontmatter.replace("skills/programmable-v4-hook-builder", "skills/../programmable-v4-hook-builder")}\n${body}`],
+      ["credentialed GitHub repository", `${remoteFrontmatter.replace("https://github.com/0xprogrammable/programmable", "https://token@github.com/0xprogrammable/programmable")}\n${body}`],
+      ["unsafe Git ref", `${remoteFrontmatter.replace("    github-ref: 0123456789abcdef0123456789abcdef01234567", "    github-ref: refs/heads/main.lock")}\n${body}`],
+      ["invalid tree SHA", `${remoteFrontmatter.replace("89abcdef0123456789abcdef0123456789abcdef", "89abcdef")}\n${body}`]
+    ]) {
+      assert.notEqual(hashSource(source), canonicalHash, `${label} must remain policy-bound or fail closed`);
+    }
+
+    assert.match(canonicalHash, /^sha256:[a-f0-9]{64}$/);
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
 function validate(copiedSkill) {
   const submissionPath = path.join(copiedSkill, "assets", "templates", "submission.example.json");
   const validatorPath = path.join(copiedSkill, "scripts", "validate-submission.mjs");

--- a/skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
@@ -6,7 +6,12 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { parseCliOrExit } from "./cli-args.mjs";
-import { validateAgainstSchema } from "./submission-core.mjs";
+import {
+  isSafeGitReference,
+  isSupportedGitHubRepositoryUrl,
+  parseCanonicalProvenanceScalar,
+  validateAgainstSchema
+} from "./submission-core.mjs";
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const canonicalSkillRoot = path.resolve(scriptDirectory, "..");
@@ -509,52 +514,6 @@ function validateProvenanceScalar(key, value, maximumBytes) {
   return findings;
 }
 
-function isSupportedGitHubRepositoryUrl(value) {
-  if (Buffer.byteLength(value, "utf8") > 2048) return false;
-  try {
-    const parsed = new URL(value);
-    const hostname = parsed.hostname.toLowerCase();
-    const supportedHost = hostname === "github.com"
-      || /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.ghe\.com$/u.test(hostname);
-    const segments = parsed.pathname.split("/").filter(Boolean);
-    return supportedHost
-      && parsed.href === value
-      && parsed.protocol === "https:"
-      && parsed.username === ""
-      && parsed.password === ""
-      && parsed.port === ""
-      && parsed.search === ""
-      && parsed.hash === ""
-      && !parsed.pathname.endsWith("/")
-      && segments.length === 2
-      && /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?$/u.test(segments[0])
-      && /^[A-Za-z0-9._-]{1,100}$/u.test(segments[1]);
-  } catch {
-    return false;
-  }
-}
-
-function isSafeGitReference(value) {
-  if (Buffer.byteLength(value, "utf8") > 2048) return false;
-  if (
-    value === "@"
-    || value.startsWith("/")
-    || value.endsWith("/")
-    || value.endsWith(".")
-    || value.includes("..")
-    || value.includes("//")
-    || value.includes("@{")
-    || /[\u0000-\u0020\u007f~^:?*[\\\u202a-\u202e\u2066-\u2069]/u.test(value)
-  ) {
-    return false;
-  }
-  return value.split("/").every((segment) => (
-    segment !== ""
-    && !segment.startsWith(".")
-    && !segment.endsWith(".lock")
-  ));
-}
-
 function redactInstalledLocalPathForPortableScan(source, parsedFrontmatter) {
   if (
     !parsedFrontmatter
@@ -574,6 +533,7 @@ function redactInstalledLocalPathForPortableScan(source, parsedFrontmatter) {
 }
 
 function parseCanonicalYamlString(source, type) {
+  if (type === "provenance-string") return parseCanonicalProvenanceScalar(source);
   if (source.startsWith('"')) {
     try {
       const value = JSON.parse(source);
@@ -583,40 +543,6 @@ function parseCanonicalYamlString(source, type) {
     } catch {
       return { ok: false, error: "contains an invalid double-quoted string" };
     }
-  }
-  if (type === "provenance-string" && source.startsWith("'")) {
-    if (!source.endsWith("'") || source.length < 2) {
-      return { ok: false, error: "contains an invalid single-quoted string" };
-    }
-    const inner = source.slice(1, -1);
-    let value = "";
-    for (let index = 0; index < inner.length; index += 1) {
-      if (inner[index] !== "'") {
-        value += inner[index];
-        continue;
-      }
-      if (inner[index + 1] !== "'") {
-        return { ok: false, error: "contains an invalid single-quoted string" };
-      }
-      value += "'";
-      index += 1;
-    }
-    if (value.length === 0) return { ok: false, error: "requires a non-empty string value" };
-    return { ok: true, value };
-  }
-  if (type === "provenance-string") {
-    if (
-      source.length === 0
-      || source !== source.trim()
-      || /^(?:null|true|false|yes|no|on|off|~)$/iu.test(source)
-      || /^(?:[!&*|>@`]|[-?:]\s)/u.test(source)
-      || /[\[\]{}]/u.test(source)
-      || /(?:^|\s)#/u.test(source)
-      || /:\s|:$/u.test(source)
-    ) {
-      return { ok: false, error: "contains a non-canonical plain string" };
-    }
-    return { ok: true, value: source };
   }
   if (type === "quoted-string") {
     return { ok: false, error: "requires a double-quoted string value" };


### PR DESCRIPTION
## Outcome

Changes the trusted Builder Beta intake state from `prelaunch` to `open` now that the bootstrap is merged and live `main` requires all four strict GitHub Actions checks: `foundry`, `security`, `hook-builder-maintenance`, and `public-intake`.

Also corrects the pinned `gh skill preview` example found by the live roundtrip: version selectors belong on the skill name. The exact-path `gh skill install ... --pin FULL_COMMIT_SHA` command was tested successfully, followed by the installed skill verifier.

## Live prerequisites now satisfied

- bootstrap tree on public `main` is byte-identical to the reviewed 254-file candidate;
- post-merge trusted builder, maintenance, Foundry, and Security checks are green;
- required checks are strict and GitHub-Actions-bound;
- CODEOWNER review, stale-review dismissal, last-push approval, resolved conversations, and linear history are required;
- force pushes and branch deletion remain disabled;
- the `nipmod` primary and companion canary source repositories are public at exact commits;
- no application has yet been accepted or merged.

Merging this pull request opens applications. It does not approve a project, launch a token, deploy code, certify safety, promise review time, provide routing support, or imply Uniswap endorsement. The external `nipmod` application PR is the next live end-to-end gate.