### PR TITLE
Fix runtime-independent Node protocol closure

### DIFF
--- a/docs/builder/AGENT_SKILL.md
+++ b/docs/builder/AGENT_SKILL.md
@@ -63,7 +63,7 @@ First preview the protected Builder release tag:
 
 ```bash
 gh skill preview 0xprogrammable/programmable \
-  programmable-v4-hook-builder@programmable-v4-builder-v0.1.0
+  programmable-v4-hook-builder@programmable-v4-builder-v0.1.1
 ```
 
 Then install that same release for your agent. User scope is the beginner default because it keeps the project
@@ -74,7 +74,7 @@ gh skill install 0xprogrammable/programmable \
   skills/programmable-v4-hook-builder \
   --agent codex \
   --scope user \
-  --pin programmable-v4-builder-v0.1.0
+  --pin programmable-v4-builder-v0.1.1
 ```
 
 Replace `codex` with `claude-code` or `github-copilot` when appropriate. Use `--scope project` only when the project

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/review-target-core.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/review-target-core.mjs
@@ -39,6 +39,15 @@ const nodeBuiltinSpecifiers = new Set(builtinModules.flatMap((specifier) => (
   specifier.startsWith("node:") ? [specifier, specifier.slice(5)] : [specifier, `node:${specifier}`]
 )));
 
+function isNodeBuiltinSpecifier(specifier) {
+  // The node: protocol is runtime-owned and can never resolve to an npm
+  // package. Accept it independently of the validator host's Node release so
+  // a newer pinned companion runtime cannot be misclassified by an older
+  // central validator. Unsupported future built-ins still fail in the exact
+  // companion build/test workflow.
+  return specifier.startsWith("node:") || nodeBuiltinSpecifiers.has(specifier);
+}
+
 class UnsupportedClosureError extends Error {
   constructor(closureCode, message) {
     super(message);
@@ -740,7 +749,7 @@ function extractJavaScriptDependencies(source, importer, declaredPackages) {
     }
     if (
       !isLocalJavaScriptSpecifier(specifier)
-      && !nodeBuiltinSpecifiers.has(specifier)
+      && !isNodeBuiltinSpecifier(specifier)
       && ![...declaredPackageNames].some((packageName) => isExactDeclaredPackageSpecifier(specifier, packageName))
     ) {
       throw new UnsupportedClosureError(

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/companion-manifest-v2.test.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/companion-manifest-v2.test.mjs
@@ -106,7 +106,7 @@ function fixture() {
     }, null, 2)}\n`,
     "src/main.ts": 'import "three";\nimport { add } from "./math";\nexport const score = add(1, 2);\n',
     "src/math.ts": "export const add = (left: number, right: number) => left + right;\n",
-    "test/main.test.ts": 'import { score } from "../src/main";\nif (score !== 3) throw new Error("bad score");\n',
+    "test/main.test.ts": 'import test from "node:test";\nimport { score } from "../src/main";\ntest("score", () => { if (score !== 3) throw new Error("bad score"); });\n',
     "vite.config.ts": 'import { defineConfig } from "vite";\nexport default defineConfig({});\n'
   };
   const records = new Map(Object.entries(files).map(([filePath, source], index) => {

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/review-target.test.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/review-target.test.mjs
@@ -594,10 +594,11 @@ test("review target permits Node built-ins and exactly declared package roots an
     additionalFiles: {
       "submissions/fixture/app/entry.ts": [
         'import assert from "node:assert/strict";',
+        'import test from "node:test";',
         'import fs from "fs";',
         'import path from "path";',
         'import { Pool } from "@uniswap/v4-sdk/entities/pool";',
-        "export const visible = assert.ok && fs.readFile && path.resolve && Pool;"
+        "export const visible = assert.ok && test && fs.readFile && path.resolve && Pool;"
       ].join("\n")
     }
   });

--- a/plugins/marketplace/test/plugin-packaging.test.mjs
+++ b/plugins/marketplace/test/plugin-packaging.test.mjs
@@ -27,7 +27,7 @@ import {
 } from "../scripts/generate-plugin.mjs";
 
 const goldenHashes = {
-  skillTree: "d854b618f18aba0b7679349bf898d0d21601d4e220efde767a790e9d6bee5efc",
+  skillTree: "02ac338ca7d19fdf155ace9cde944c70b941bce535752f690118bd355a84a2f1",
   codexManifest: "6f5dbf19ab2a124312a9fab9ba08cb038160e68165bc1dd71211d442f2fd3354",
   claudeManifest: "09011068e632beffedf3059ba0c79646cd023499ffd77fae1273db2239e368e7",
   codexMarketplace: "f51e251087f6d26c75308aeff915485de9493b619c31b5a59baca072d725d0c0",

--- a/skills/programmable-v4-hook-builder/scripts/review-target-core.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/review-target-core.mjs
@@ -39,6 +39,15 @@ const nodeBuiltinSpecifiers = new Set(builtinModules.flatMap((specifier) => (
   specifier.startsWith("node:") ? [specifier, specifier.slice(5)] : [specifier, `node:${specifier}`]
 )));
 
+function isNodeBuiltinSpecifier(specifier) {
+  // The node: protocol is runtime-owned and can never resolve to an npm
+  // package. Accept it independently of the validator host's Node release so
+  // a newer pinned companion runtime cannot be misclassified by an older
+  // central validator. Unsupported future built-ins still fail in the exact
+  // companion build/test workflow.
+  return specifier.startsWith("node:") || nodeBuiltinSpecifiers.has(specifier);
+}
+
 class UnsupportedClosureError extends Error {
   constructor(closureCode, message) {
     super(message);
@@ -740,7 +749,7 @@ function extractJavaScriptDependencies(source, importer, declaredPackages) {
     }
     if (
       !isLocalJavaScriptSpecifier(specifier)
-      && !nodeBuiltinSpecifiers.has(specifier)
+      && !isNodeBuiltinSpecifier(specifier)
       && ![...declaredPackageNames].some((packageName) => isExactDeclaredPackageSpecifier(specifier, packageName))
     ) {
       throw new UnsupportedClosureError(

--- a/skills/programmable-v4-hook-builder/scripts/test/companion-manifest-v2.test.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/test/companion-manifest-v2.test.mjs
@@ -106,7 +106,7 @@ function fixture() {
     }, null, 2)}\n`,
     "src/main.ts": 'import "three";\nimport { add } from "./math";\nexport const score = add(1, 2);\n',
     "src/math.ts": "export const add = (left: number, right: number) => left + right;\n",
-    "test/main.test.ts": 'import { score } from "../src/main";\nif (score !== 3) throw new Error("bad score");\n',
+    "test/main.test.ts": 'import test from "node:test";\nimport { score } from "../src/main";\ntest("score", () => { if (score !== 3) throw new Error("bad score"); });\n',
     "vite.config.ts": 'import { defineConfig } from "vite";\nexport default defineConfig({});\n'
   };
   const records = new Map(Object.entries(files).map(([filePath, source], index) => {

--- a/skills/programmable-v4-hook-builder/scripts/test/review-target.test.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/test/review-target.test.mjs
@@ -594,10 +594,11 @@ test("review target permits Node built-ins and exactly declared package roots an
     additionalFiles: {
       "submissions/fixture/app/entry.ts": [
         'import assert from "node:assert/strict";',
+        'import test from "node:test";',
         'import fs from "fs";',
         'import path from "path";',
         'import { Pool } from "@uniswap/v4-sdk/entities/pool";',
-        "export const visible = assert.ok && fs.readFile && path.resolve && Pool;"
+        "export const visible = assert.ok && test && fs.readFile && path.resolve && Pool;"
       ].join("\n")
     }
   });


### PR DESCRIPTION
## Outcome

Makes `node:` protocol recognition independent of the central validator Node release.

This preserves closed dependency verification: `node:` is runtime-owned and cannot resolve to npm, while the exact pinned companion build and test workflow still rejects unsupported runtime modules.

Regression coverage now includes `node:test` in both companion closure and general review-target checks. This fixes the live multi-repository Builder canary without weakening architecture or security review.