### PR TITLE
Document one-command Builder install

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ Bring an idea or an existing public Uniswap v4 project. The portable
 [Programmable v4 Builder skill](skills/programmable-v4-hook-builder/SKILL.md) helps a compatible coding agent build
 and repair the project, bind one exact revision and prepare a small public application pull request.
 
+Install it interactively with one command:
+
+```bash
+gh skill install 0xprogrammable/programmable
+```
+
+To preselect the Builder while keeping the agent setup interactive:
+
+```bash
+gh skill install 0xprogrammable/programmable programmable-v4-hook-builder
+```
+
 The complete project stays in the builder-controlled public GitHub repository. `package` validates its local review
 package. `prepare-pr` then resolves the clean pushed revision and generates exactly six central files under
 [`submissions/`](submissions/), binding the immutable GitHub numeric repository id, full commit, full tree and evidence

--- a/docs/builder/AGENT_SKILL.md
+++ b/docs/builder/AGENT_SKILL.md
@@ -51,13 +51,28 @@ Ethereum Mainnet-only. Base, Unichain, Sepolia and unknown EVM chains remain rev
 or release gates and no launch claim. Exact official deployment references preserve their runtime-unverified trust tier;
 they are not silently promoted to Programmable-tested deployments.
 
-## Install the exact revision you reviewed
+## Install the Builder
 
 The canonical package is
 [`skills/programmable-v4-hook-builder`](../../skills/programmable-v4-hook-builder/SKILL.md). It uses the common Agent
 Skills layout and keeps portable frontmatter to `name`, `description` and the SPDX license identifier. The complete
 license text remains in `LICENSE.txt`. Host-specific UI metadata is optional and does not control the skill's security
 policy.
+
+For an interactive install, use the repository-only command:
+
+```bash
+gh skill install 0xprogrammable/programmable
+```
+
+To preselect the Builder while keeping the agent setup interactive:
+
+```bash
+gh skill install 0xprogrammable/programmable programmable-v4-hook-builder
+```
+
+Without a version argument, `gh skill` selects the latest tagged release. For reproducible review work, preview and
+install the exact protected revision below.
 
 First preview the protected Builder release tag:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -23,14 +23,31 @@ candidate.
 
 Read the [builder guide](../docs/builder/AGENT_SKILL.md) before using it on production code.
 
-## Install the protected Builder release
+## Quick install
+
+Install interactively with one command:
+
+```bash
+gh skill install 0xprogrammable/programmable
+```
+
+To preselect the Builder while keeping the agent setup interactive:
+
+```bash
+gh skill install 0xprogrammable/programmable programmable-v4-hook-builder
+```
+
+Without a version argument, `gh skill` selects the repository's latest tagged release. Use the protected-release
+instructions below only when a review or organization policy requires an exact version pin.
+
+## Install an exact protected Builder release
 
 Inspect the skill before installing it. The release tag below is protected against update and deletion. A full reviewed
 commit SHA remains an equivalent pin when an organization requires commit-only policy.
 
 ```bash
 gh skill preview 0xprogrammable/programmable \
-  programmable-v4-hook-builder@programmable-v4-builder-v0.1.0
+  programmable-v4-hook-builder@programmable-v4-builder-v0.1.1
 ```
 
 Install the same revision for one supported host:
@@ -41,21 +58,21 @@ gh skill install 0xprogrammable/programmable \
   skills/programmable-v4-hook-builder \
   --agent codex \
   --scope user \
-  --pin programmable-v4-builder-v0.1.0
+  --pin programmable-v4-builder-v0.1.1
 
 # Claude Code
 gh skill install 0xprogrammable/programmable \
   skills/programmable-v4-hook-builder \
   --agent claude-code \
   --scope user \
-  --pin programmable-v4-builder-v0.1.0
+  --pin programmable-v4-builder-v0.1.1
 
 # GitHub Copilot
 gh skill install 0xprogrammable/programmable \
   skills/programmable-v4-hook-builder \
   --agent github-copilot \
   --scope user \
-  --pin programmable-v4-builder-v0.1.0
+  --pin programmable-v4-builder-v0.1.1
 ```
 
 The `gh skill` command chooses the host-specific destination. Its skill commands are currently a preview feature, and


### PR DESCRIPTION
## Summary
- make the repository-only `gh skill install 0xprogrammable/programmable` command the primary interactive quick start
- document the skill-name shortcut for users who want to preselect the Builder
- retain exact protected-release pins for reproducible review work
- update the skills overview from v0.1.0 to the current v0.1.1 release

## Verification
- exercised the repository-only interactive install through skill discovery against v0.1.1
- `node --test scripts/test/check-documentation-links.test.mjs`
- `node scripts/check-documentation-links.mjs`
- `node skills/programmable-v4-hook-builder/scripts/verify-skill.mjs`
- `git diff --check`