### PR TITLE
Accept fee evidence from declared contract paths

### DIFF
--- a/scripts/test/verify-public-hook-application-candidate-fetch.test.mjs
+++ b/scripts/test/verify-public-hook-application-candidate-fetch.test.mjs
@@ -737,8 +737,11 @@ function makePackage() {
     ...PRIMARY,
     sourcePaths: [...new Set([
       ...PRIMARY.sourcePaths,
+      submissionPath
+    ])].sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right))),
+    contractPaths: [...new Set([
+      ...PRIMARY.contractPaths,
       "src/ProgrammableFeeHook.sol",
-      submissionPath,
       "test/ProgrammableFeeHook.t.sol"
     ])].sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)))
   };

--- a/scripts/test/verify-public-hook-application.test.mjs
+++ b/scripts/test/verify-public-hook-application.test.mjs
@@ -84,6 +84,12 @@ test("pure package validation accepts a canonical hash-bound review package", ()
   assert.equal(result.application.applicationRevision, 1);
   assert.equal(result.compatibility.result, "architecture-review-required");
   assert.equal(result.evidenceIndex.attestation, "builder-declared-untrusted");
+  assert.deepEqual(result.application.programmableFee.evidence.sourcePaths, ["src/ProgrammableFeeHook.sol"]);
+  assert.deepEqual(result.application.programmableFee.evidence.testPaths, ["test/ProgrammableFeeHook.t.sol"]);
+  assert.ok(result.application.source.primary.contractPaths.includes("src/ProgrammableFeeHook.sol"));
+  assert.ok(result.application.source.primary.contractPaths.includes("test/ProgrammableFeeHook.t.sol"));
+  assert.equal(result.application.source.primary.sourcePaths.includes("src/ProgrammableFeeHook.sol"), false);
+  assert.equal(result.application.source.primary.sourcePaths.includes("test/ProgrammableFeeHook.t.sol"), false);
 });
 
 test("trusted package validation rejects legacy and malformed mandatory fee projections", () => {
@@ -2235,9 +2241,12 @@ function makePackage({
     ...primary,
     sourcePaths: [...new Set([
       ...(primary.sourcePaths ?? []),
-      feeSourcePath,
-      feeTestPath,
       submissionPath
+    ])].sort(compareUtf8),
+    contractPaths: [...new Set([
+      ...(primary.contractPaths ?? []),
+      feeSourcePath,
+      feeTestPath
     ])].sort(compareUtf8)
   };
   const programmableFee = makeProgrammableFee({ feeSourcePath, feeTestPath });

--- a/scripts/verify-public-hook-application-core.mjs
+++ b/scripts/verify-public-hook-application-core.mjs
@@ -2565,6 +2565,7 @@ function validateProgrammableFeeProjection(fee, source) {
   const boundSourcePaths = new Set();
   for (const repository of [source.primary, ...source.companions]) {
     for (const entryPath of repository.sourcePaths ?? []) boundSourcePaths.add(entryPath);
+    for (const entryPath of repository.contractPaths ?? []) boundSourcePaths.add(entryPath);
   }
   for (const [paths, label] of [
     [fee.evidence.sourcePaths, "Fee source paths"],


### PR DESCRIPTION
## What changed

- treat exact `contractPaths` as valid source bindings for Programmable fee implementation and tests
- keep `submission.json` bound through ordinary `sourcePaths`
- make trusted fixtures match the real builder projection instead of putting Solidity files in the wrong source bucket
- add assertions for the realistic split

## Evidence

The v0.2.0 Arena Bounty canary exposed this at the central hydration gate with `PROGRAMMABLE_FEE_PROJECTION_INVALID`. The exact generated six-file canary package now passes pure trusted validation with the immutable Programmable wallet and implemented fee path.

Targeted trusted intake: 186 passed, 1 expected platform skip.