### PR TITLE
Release Programmable Builder v0.2.1

### DIFF
--- a/docs/builder/AGENT_SKILL.md
+++ b/docs/builder/AGENT_SKILL.md
@@ -78,7 +78,7 @@ First preview the protected Builder release tag:
 
 ```bash
 gh skill preview 0xprogrammable/programmable \
-  programmable-v4-hook-builder@programmable-v4-builder-v0.2.0
+  programmable-v4-hook-builder@programmable-v4-builder-v0.2.1
 ```
 
 Then install that same release for your agent. User scope is the beginner default because it keeps the project
@@ -89,15 +89,16 @@ gh skill install 0xprogrammable/programmable \
   skills/programmable-v4-hook-builder \
   --agent codex \
   --scope user \
-  --pin programmable-v4-builder-v0.2.0
+  --pin programmable-v4-builder-v0.2.1
 ```
 
 Replace `codex` with `claude-code` or `github-copilot` when appropriate. Use `--scope project` only when the project
 intentionally tracks the installed `.agents/` package or excludes that complete generated directory from Git. An
 untracked project-scoped installation makes the worktree dirty and correctly blocks `prepare-pr`.
 
-Builder `v0.1.1` remains available only to reproduce legacy records. New launch applications use `v0.2.0`, whose
-mandatory fee policy is part of the schema, checker, templates, and evidence contract.
+Builder `v0.1.1` remains available only to reproduce pre-fee legacy records, and `v0.2.0` preserves the first
+fee-policy release. New launch applications use `v0.2.1`, which keeps the same mandatory fee contract and includes the
+end-to-end trusted-intake correction for declared Solidity contract paths.
 
 From the installed skill directory, run `node scripts/verify-skill.mjs --installed`; it accepts the bounded source
 tracking fields added by `gh skill` while keeping the rest of the portable package checks unchanged. Those fields are

--- a/docs/builder/PUBLIC_GITHUB_PR_BETA.md
+++ b/docs/builder/PUBLIC_GITHUB_PR_BETA.md
@@ -68,7 +68,7 @@ for the permissionless path.
 
 ### Mandatory Programmable fee
 
-Every new launch application uses Builder `v0.2.0` and declares the root `programmableFee` policy:
+Every new launch application uses Builder `v0.2.1` and declares the root `programmableFee` policy:
 
 - `effective total = max(builder-selected total, 10 bps)`;
 - exactly `10 bps` (`0.10%`) belongs to Programmable and the project receives the remainder;

--- a/plugins/marketplace/metadata/plugin.json
+++ b/plugins/marketplace/metadata/plugin.json
@@ -3,7 +3,7 @@
   "marketplaceName": "programmable-repo",
   "marketplaceDisplayName": "Programmable",
   "pluginName": "programmable",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "displayName": "Programmable v4 Builder",
   "description": "Package the Programmable v4 Builder skill for coding agents.",
   "shortDescription": "Build Uniswap v4 projects with Programmable",

--- a/plugins/marketplace/plugins/programmable/.claude-plugin/plugin.json
+++ b/plugins/marketplace/plugins/programmable/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "programmable",
   "displayName": "Programmable v4 Builder",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Package the Programmable v4 Builder skill for coding agents.",
   "author": {
     "name": "Programmable"

--- a/plugins/marketplace/plugins/programmable/.codex-plugin/plugin.json
+++ b/plugins/marketplace/plugins/programmable/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "programmable",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Package the Programmable v4 Builder skill for coding agents.",
   "author": {
     "name": "Programmable"

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/assets/examples/README.md
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/assets/examples/README.md
@@ -25,7 +25,7 @@ Run the compatibility preflight separately:
 node scripts/validate-submission.mjs submission.json
 ```
 
-A structurally ready example is still a proposal. For Builder `v0.2.0`, every materialized scenario also inherits the
+A structurally ready example is still a proposal. For Builder `v0.2.1`, every materialized scenario also inherits the
 mandatory root `programmableFee` policy from the canonical template. A scenario may vary project economics, but cannot
 replace the 10 bps canonical-pool platform allocation with an LP fee, transfer tax, router charge, app payment, or
 alternative pool. The examples are not audits, deployments, proof of live fee collection, routing approvals, or

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/references/programmable-fee-policy.md
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/references/programmable-fee-policy.md
@@ -2,10 +2,10 @@
 
 Policy id: `programmable-volume-fee-v1`  
 Policy version: `1.0.0`  
-Builder release: `programmable-v4-builder-v0.2.0`
+Builder release: `programmable-v4-builder-v0.2.1`
 
-Apply this policy to every new Programmable launch application. Builder release `v0.1.1` remains reproducible for
-legacy review records, but it is not the current policy for a new launch application.
+Apply this policy to every new Programmable launch application. Builder releases `v0.1.1` and `v0.2.0` remain
+reproducible for earlier review records, but they are not the current release for a new launch application.
 
 This policy does not narrow which ideas may be proposed. A missing or incomplete integration produces an architecture
 or changes-required result. It never turns the project category itself into an automatic rejection. It also does not

--- a/plugins/marketplace/test/plugin-packaging.test.mjs
+++ b/plugins/marketplace/test/plugin-packaging.test.mjs
@@ -27,9 +27,9 @@ import {
 } from "../scripts/generate-plugin.mjs";
 
 const goldenHashes = {
-  skillTree: "c5716600973d15e238e014db6ab65deaeec3ae19fa3c4e194b7994cf28d7107f",
-  codexManifest: "e74bce863cb9fc55f7dabc8ba981061aaf454a7fcc15885857ff5259638e816f",
-  claudeManifest: "e7c2b7d1854f836ccc4e0fd5924f87ee68c20e5386ef00c5aec39b33d40f4304",
+  skillTree: "92dd44f39c929d2fed15367d514cdc861dfb4973d405d36e6d0a6955374d21c8",
+  codexManifest: "a834b200145d050ac30e0cd8881965c7f87dae6650f49eff72e21ac860f7d353",
+  claudeManifest: "77108bc56ad454fded5bc58722ad1ffadac49f87ca303dc422c9ddade583f1b5",
   codexMarketplace: "f51e251087f6d26c75308aeff915485de9493b619c31b5a59baca072d725d0c0",
   claudeMarketplace: "214475551068f84d699cada5adf4518ab3bd2bfe750be6ac4688bcd6ed1ef9c7"
 };

--- a/skills/README.md
+++ b/skills/README.md
@@ -48,7 +48,7 @@ commit SHA remains an equivalent pin when an organization requires commit-only p
 
 ```bash
 gh skill preview 0xprogrammable/programmable \
-  programmable-v4-hook-builder@programmable-v4-builder-v0.2.0
+  programmable-v4-hook-builder@programmable-v4-builder-v0.2.1
 ```
 
 Install the same revision for one supported host:
@@ -59,29 +59,30 @@ gh skill install 0xprogrammable/programmable \
   skills/programmable-v4-hook-builder \
   --agent codex \
   --scope user \
-  --pin programmable-v4-builder-v0.2.0
+  --pin programmable-v4-builder-v0.2.1
 
 # Claude Code
 gh skill install 0xprogrammable/programmable \
   skills/programmable-v4-hook-builder \
   --agent claude-code \
   --scope user \
-  --pin programmable-v4-builder-v0.2.0
+  --pin programmable-v4-builder-v0.2.1
 
 # GitHub Copilot
 gh skill install 0xprogrammable/programmable \
   skills/programmable-v4-hook-builder \
   --agent github-copilot \
   --scope user \
-  --pin programmable-v4-builder-v0.2.0
+  --pin programmable-v4-builder-v0.2.1
 ```
 
 The `gh skill` command chooses the host-specific destination. Its skill commands are currently a preview feature, and
 host behavior still depends on each agent's sandbox, tool permissions, and Agent Skills implementation. Installation
 does not grant wallet access, deployment authority, review approval, or permission to publish external changes.
 
-Builder `v0.1.1` remains available only to reproduce legacy review records. Use `v0.2.0` for new launch applications;
-it adds the mandatory Programmable fee policy and evidence gates.
+Builder `v0.1.1` remains available only to reproduce pre-fee legacy records, and `v0.2.0` preserves the first
+fee-policy release. Use `v0.2.1` for new launch applications; it keeps the mandatory Programmable fee policy and adds
+the end-to-end trusted-intake correction for declared Solidity contract paths.
 
 For repository-scoped use, change `--scope user` to `--scope project` only when the generated `.agents/` directory is
 intentionally committed or excluded from Git; otherwise it makes the project worktree dirty and blocks `prepare-pr`.

--- a/skills/programmable-v4-hook-builder/assets/examples/README.md
+++ b/skills/programmable-v4-hook-builder/assets/examples/README.md
@@ -25,7 +25,7 @@ Run the compatibility preflight separately:
 node scripts/validate-submission.mjs submission.json
 ```
 
-A structurally ready example is still a proposal. For Builder `v0.2.0`, every materialized scenario also inherits the
+A structurally ready example is still a proposal. For Builder `v0.2.1`, every materialized scenario also inherits the
 mandatory root `programmableFee` policy from the canonical template. A scenario may vary project economics, but cannot
 replace the 10 bps canonical-pool platform allocation with an LP fee, transfer tax, router charge, app payment, or
 alternative pool. The examples are not audits, deployments, proof of live fee collection, routing approvals, or

--- a/skills/programmable-v4-hook-builder/references/programmable-fee-policy.md
+++ b/skills/programmable-v4-hook-builder/references/programmable-fee-policy.md
@@ -2,10 +2,10 @@
 
 Policy id: `programmable-volume-fee-v1`  
 Policy version: `1.0.0`  
-Builder release: `programmable-v4-builder-v0.2.0`
+Builder release: `programmable-v4-builder-v0.2.1`
 
-Apply this policy to every new Programmable launch application. Builder release `v0.1.1` remains reproducible for
-legacy review records, but it is not the current policy for a new launch application.
+Apply this policy to every new Programmable launch application. Builder releases `v0.1.1` and `v0.2.0` remain
+reproducible for earlier review records, but they are not the current release for a new launch application.
 
 This policy does not narrow which ideas may be proposed. A missing or incomplete integration produces an architecture
 or changes-required result. It never turns the project category itself into an automatic rejection. It also does not


### PR DESCRIPTION
## Release

- make v0.2.1 the documented protected Builder release
- carry the successful end-to-end trusted-intake correction from #59
- update Codex and Claude plugin metadata and deterministic golden hashes
- keep v0.2.0 available as the immutable first fee-policy release

## Verification

- real Arena Bounty six-file application passed trusted central intake in #58
- plugin packaging: 10/10
- canonical and installed skill verification passed
- plugin generation and documentation links passed
- `gh skill publish --dry-run` passed

The mandatory fee economics and owner wallet are unchanged.