### PR TITLE
fix(read-model): close live projection block gaps

### DIFF
--- a/lib/data-pipeline/postgres-projector.ts
+++ b/lib/data-pipeline/postgres-projector.ts
@@ -4007,72 +4007,12 @@ function parseProjectionCandidateRow(
   });
 }
 
-function transactionAlignedProjectionPage<T extends Readonly<{
-  candidate: StoredProjectionCandidate;
-}>>(rows: readonly T[], maximum: number): readonly T[] {
-  if (rows.length <= maximum) return Object.freeze([...rows]);
-  const boundaryTransaction = rows[maximum]!.candidate.transactionHash;
-  const page = rows.slice(0, maximum);
-  while (
-    page.length > 0 &&
-    page[page.length - 1]!.candidate.transactionHash === boundaryTransaction
-  ) {
-    page.pop();
-  }
-  if (page.length === 0) return projectorValidationFailure();
-  return Object.freeze(page);
-}
-
 const REWARD_DELTA_PROJECTION_KINDS = Object.freeze(new Set([
   "creator-fee-checkpoint",
   "beneficiary-claim",
   "payout-change",
   "reward-configuration-activation",
 ]));
-
-function isolateRewardTransaction<T extends Readonly<{
-  candidate: StoredProjectionCandidate;
-  action: "project" | "ignore";
-}>>(
-  entries: readonly T[],
-  resolutions: ReadonlyMap<string, ProjectionResolution>,
-): readonly T[] {
-  let transactionStart = 0;
-  while (transactionStart < entries.length) {
-    const transactionHash = entries[transactionStart]!.candidate.transactionHash;
-    let transactionEnd = transactionStart + 1;
-    while (
-      transactionEnd < entries.length &&
-      entries[transactionEnd]!.candidate.transactionHash === transactionHash
-    ) {
-      transactionEnd += 1;
-    }
-    const transaction = entries.slice(transactionStart, transactionEnd);
-    const rewardSources = new Set<HexAddress>();
-    for (const entry of transaction) {
-      const resolution = resolutions.get(entry.candidate.candidateId);
-      if (
-        entry.action === "project" &&
-        resolution &&
-        REWARD_DELTA_PROJECTION_KINDS.has(resolution.projectionKind)
-      ) {
-        rewardSources.add(entry.candidate.sourceAddress);
-      }
-    }
-    if (rewardSources.size > 0) {
-      if (transactionStart > 0) {
-        return Object.freeze(entries.slice(0, transactionStart));
-      }
-      // The caller supplies the complete remainder of this exact block when a
-      // reward transaction is first. Keeping every vault and every later
-      // reward occurrence is required because eth_call observes block-end
-      // state, not transaction-intermediate state.
-      return Object.freeze([...entries]);
-    }
-    transactionStart = transactionEnd;
-  }
-  return Object.freeze([...entries]);
-}
 
 function rewardVaultsForProjection<T extends Readonly<{
   candidate: StoredProjectionCandidate;
@@ -4522,51 +4462,80 @@ export function createPostgresReleaseProjectionStore(input: {
           }
         };
 
+        const ingestionProvesBlockTerminal = (
+          candidate: StoredProjectionCandidate,
+        ) => {
+          const cursorBlock = BigInt(ingestionCursor.blockNumber);
+          const candidateBlock = BigInt(candidate.blockNumber);
+          if (cursorBlock > candidateBlock) return true;
+          return cursorBlock === candidateBlock &&
+            ingestionCursor.isBlockBoundary &&
+            ingestionCursor.blockHash === candidate.blockHash;
+        };
+
         let batchKind: NonNullable<ReleaseProjectionPlan["batchKind"]> =
           "normal";
         let entries: readonly (typeof resolvedEntries)[number][];
         const first = resolvedEntries[0]!;
-        const firstTransactionHash = first.candidate.transactionHash;
-        const firstTransactionIsOversized =
-          resolvedEntries.length > PROJECTOR_MAXIMUM_CANDIDATES_PER_PAGE &&
-          resolvedEntries[PROJECTOR_MAXIMUM_CANDIDATES_PER_PAGE]!.candidate
-              .transactionHash === firstTransactionHash;
-        if (firstTransactionIsOversized) {
-          const completedTransaction = await completePrefix(
-            (entry) =>
-              entry.candidate.transactionHash === firstTransactionHash,
+        const normalLimit = Math.min(
+          PROJECTOR_MAXIMUM_CANDIDATES_PER_PAGE,
+          resolvedEntries.length,
+        );
+        let terminalPrefixLength = 0;
+        for (let index = 0; index < normalLimit; index += 1) {
+          const current = resolvedEntries[index]!;
+          const next = resolvedEntries[index + 1];
+          if (next && next.candidate.blockHash !== current.candidate.blockHash) {
+            terminalPrefixLength = index + 1;
+          }
+        }
+        const normalTerminal = resolvedEntries[normalLimit - 1]!;
+        if (
+          resolvedEntries.length <= PROJECTOR_MAXIMUM_CANDIDATES_PER_PAGE &&
+          ingestionProvesBlockTerminal(normalTerminal.candidate)
+        ) {
+          terminalPrefixLength = resolvedEntries.length;
+        }
+
+        if (terminalPrefixLength === 0) {
+          const firstBlockHash = first.candidate.blockHash;
+          const completedBlock = await completePrefix(
+            (entry) => entry.candidate.blockHash === firstBlockHash,
           );
-          if (completedTransaction === null) return null;
-          entries = completedTransaction;
-          batchKind = "oversized-transaction";
-          if (containsRewardProjection(entries, resolutions)) {
-            const rewardBlockHash = first.candidate.blockHash;
-            const completedRewardBlock = await completePrefix(
-              (entry) => entry.candidate.blockHash === rewardBlockHash,
-            );
-            if (completedRewardBlock === null) return null;
-            entries = completedRewardBlock;
-            batchKind = "reward-block";
+          if (completedBlock === null) return null;
+          entries = completedBlock;
+          if (entries.length > PROJECTOR_MAXIMUM_CANDIDATES_PER_PAGE) {
+            batchKind = new Set(
+                  entries.map(({ candidate }) => candidate.transactionHash),
+                ).size === 1
+              ? "oversized-transaction"
+              : "oversized-block";
           }
         } else {
-          const page = transactionAlignedProjectionPage(
-            resolvedEntries,
-            PROJECTOR_MAXIMUM_CANDIDATES_PER_PAGE,
+          entries = Object.freeze(
+            resolvedEntries.slice(0, terminalPrefixLength),
           );
-          const isolated = isolateRewardTransaction(page, resolutions);
-          if (
-            isolated.length === page.length &&
-            containsRewardProjection(page, resolutions)
-          ) {
-            const rewardBlockHash = first.candidate.blockHash;
+        }
+
+        if (containsRewardProjection(entries, resolutions)) {
+          const rewardEntry = entries.find((entry) =>
+            containsRewardProjection([entry], resolutions)
+          );
+          if (!rewardEntry) return projectorValidationFailure();
+          const rewardBlockHash = rewardEntry.candidate.blockHash;
+          const rewardBlockStart = entries.findIndex(
+            (entry) => entry.candidate.blockHash === rewardBlockHash,
+          );
+          if (rewardBlockStart > 0) {
+            entries = Object.freeze(entries.slice(0, rewardBlockStart));
+            batchKind = "normal";
+          } else {
             const completedRewardBlock = await completePrefix(
               (entry) => entry.candidate.blockHash === rewardBlockHash,
             );
             if (completedRewardBlock === null) return null;
             entries = completedRewardBlock;
             batchKind = "reward-block";
-          } else {
-            entries = isolated;
           }
         }
         if (

--- a/lib/data-pipeline/projector-projection.ts
+++ b/lib/data-pipeline/projector-projection.ts
@@ -94,7 +94,11 @@ export type ReleaseProjectionPlan = Readonly<{
     model: ProjectorRewardModel;
     baseline: ProjectorRewardBaseline;
   }>[];
-  batchKind?: "normal" | "oversized-transaction" | "reward-block";
+  batchKind?:
+    | "normal"
+    | "oversized-transaction"
+    | "oversized-block"
+    | "reward-block";
 }>;
 
 export type VerifiedReleaseProjection = Readonly<{
@@ -225,7 +229,12 @@ function assertPlan(plan: ReleaseProjectionPlan): void {
     plan.entries.length > maximum ||
     !Array.isArray(plan.dynamicSources) ||
     !Array.isArray(plan.knownPools) ||
-    !["normal", "oversized-transaction", "reward-block"].includes(batchKind)
+    ![
+      "normal",
+      "oversized-transaction",
+      "oversized-block",
+      "reward-block",
+    ].includes(batchKind)
   ) {
     throw invalidInput("postgres", "projection-plan");
   }
@@ -241,6 +250,12 @@ function assertPlan(plan: ReleaseProjectionPlan): void {
     new Set(plan.entries.map(({ candidate }) => candidate.blockHash)).size !== 1
   ) {
     throw invalidInput("postgres", "projection-reward-block");
+  }
+  if (
+    batchKind === "oversized-block" &&
+    new Set(plan.entries.map(({ candidate }) => candidate.blockHash)).size !== 1
+  ) {
+    throw invalidInput("postgres", "projection-atomic-block");
   }
   const ids = new Set<string>();
   let previous:

--- a/supabase/migrations/20260802060000_exact_liquidity_event_source.sql
+++ b/supabase/migrations/20260802060000_exact_liquidity_event_source.sql
@@ -1,0 +1,180 @@
+-- Liquidity configuration events deliberately omit poolId. The pool is bound
+-- by the launch occurrence; the liquidity occurrence binds token + launchHash
+-- and has a release-specific event type.
+
+set role programmable_migrator;
+
+create or replace function programmable_private.stage_launch_position_liquidity_v1(
+  p_launch_position_liquidity_fact_id uuid,
+  p_launch_projection_id uuid,
+  p_run_id uuid,
+  p_position_recipient bytea,
+  p_position_token_id numeric,
+  p_token_liquidity_amount numeric,
+  p_locked_token_dust numeric, -- gitleaks:allow
+  p_initial_sqrt_price_x96 numeric,
+  p_initial_tick integer,
+  p_tick_lower integer,
+  p_tick_upper integer,
+  p_source_occurrence_id uuid,
+  p_fact_commitment bytea,
+  p_verified_at timestamptz default pg_catalog.clock_timestamp()
+)
+returns uuid
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $function$
+declare
+  header programmable_private.run_headers%rowtype;
+  launch programmable_private.launch_projections%rowtype;
+  occurrence programmable_private.chain_event_occurrences%rowtype;
+  materialization
+    programmable_private.chain_event_occurrence_materializations%rowtype;
+  position_id numeric;
+  liquidity_amount numeric;
+  locked_dust numeric;
+  sqrt_price numeric;
+  tick_policy_ok boolean;
+  liquidity_event_ok boolean;
+  existing programmable_private.launch_position_liquidity_facts%rowtype;
+  created_audit_id uuid;
+begin
+  perform programmable_private.assert_caller('programmable_projector');
+  select * into header from programmable_private.run_headers
+  where run_id = p_run_id and run_kind = 'projection';
+  if not found or exists (
+    select 1 from programmable_private.run_lifecycle_outcomes
+    where run_id = p_run_id
+  ) then
+    raise exception using
+      errcode = '55000',
+      message = 'launch liquidity requires an open projection run';
+  end if;
+  perform programmable_private.assert_current_epoch(
+    header.chain_id, header.release_id, header.model_id, header.source_group,
+    header.epoch_id, header.captured_pointer_generation
+  );
+  select * into launch from programmable_private.launch_projections
+  where launch_projection_id = p_launch_projection_id
+    and projection_run_id = p_run_id
+    and chain_id = header.chain_id
+    and release_id = header.release_id
+    and model_id = header.model_id
+    and epoch_id = header.epoch_id
+    and pointer_generation = header.captured_pointer_generation;
+  select * into occurrence
+  from programmable_private.chain_event_occurrences
+  where occurrence_id = p_source_occurrence_id;
+  select * into materialization
+  from programmable_private.chain_event_occurrence_materializations
+  where occurrence_id = p_source_occurrence_id
+    and chain_id = header.chain_id
+    and release_id = header.release_id
+    and model_id = header.model_id
+    and source_group = header.source_group
+    and epoch_id = header.epoch_id
+    and pointer_generation = header.captured_pointer_generation;
+  position_id := programmable_private.validate_uint256(p_position_token_id);
+  liquidity_amount :=
+    programmable_private.validate_uint256(p_token_liquidity_amount);
+  locked_dust := programmable_private.validate_uint256(p_locked_token_dust);
+  sqrt_price := programmable_private.validate_uint256(p_initial_sqrt_price_x96);
+  tick_policy_ok :=
+    p_tick_lower < p_initial_tick and p_initial_tick < p_tick_upper
+    or (
+      header.release_id in ('classic-v2', 'classic-v3')
+      and header.model_id in ('classic', header.release_id)
+      and p_tick_lower < p_initial_tick
+      and p_initial_tick = p_tick_upper
+    );
+  liquidity_event_ok :=
+    header.release_id = 'classic-v2'
+      and occurrence.event_type = 'MemeLiquidityConfigured'
+    or header.release_id = 'classic-v3'
+      and occurrence.event_type = 'MemeLiquidityConfiguredV2'
+    or header.release_id in (
+      'stock-paired-v1', 'stock-paired-v2', 'stock-paired-v3'
+    ) and occurrence.event_type = 'StockPairedLiquidityConfigured';
+  if launch.launch_projection_id is null
+     or occurrence.occurrence_id is null
+     or materialization.materialization_id is null
+     or materialization.event_type is distinct from occurrence.event_type
+     or not coalesce(liquidity_event_ok, false)
+     or occurrence.block_number > launch.promoted_block_number
+     or pg_catalog.octet_length(p_position_recipient) <> 20
+     or p_initial_tick not between -887272 and 887272
+     or p_tick_lower not between -887272 and 887272
+     or p_tick_upper not between -887272 and 887272
+     or not coalesce(tick_policy_ok, false)
+     or liquidity_amount is null
+     or locked_dust is null
+     or liquidity_amount + locked_dust > launch.total_supply
+     or pg_catalog.octet_length(p_fact_commitment) <> 32
+     or programmable_private.json_hex_bytes_v1(
+       materialization.decoded_payload, 'token', 20
+     ) is distinct from launch.token
+     or programmable_private.json_hex_bytes_v1(
+       materialization.decoded_payload, 'launchHash', 32
+     ) is distinct from launch.launch_hash
+  then
+    raise exception using
+      errcode = '23514',
+      message = 'launch position/liquidity lacks exact canonical source';
+  end if;
+  select * into existing
+  from programmable_private.launch_position_liquidity_facts
+  where launch_projection_id = p_launch_projection_id;
+  if found then
+    if existing.launch_position_liquidity_fact_id
+         <> p_launch_position_liquidity_fact_id
+       or existing.position_recipient <> p_position_recipient
+       or existing.position_token_id <> position_id
+       or existing.token_liquidity_amount <> liquidity_amount
+       or existing.locked_token_dust <> locked_dust
+       or existing.initial_sqrt_price_x96 <> sqrt_price
+       or existing.initial_tick <> p_initial_tick
+       or existing.tick_lower <> p_tick_lower
+       or existing.tick_upper <> p_tick_upper
+       or existing.source_occurrence_id <> p_source_occurrence_id
+       or existing.fact_commitment <> p_fact_commitment
+    then
+      raise exception using
+        errcode = '23505', message = 'launch liquidity replay conflict';
+    end if;
+    return existing.launch_position_liquidity_fact_id;
+  end if;
+  created_audit_id := programmable_private.append_mutation_audit(
+    'launch_position_liquidity.stage', p_fact_commitment,
+    p_run_id, p_verified_at
+  );
+  insert into programmable_private.launch_position_liquidity_facts (
+    launch_position_liquidity_fact_id, launch_projection_id,
+    chain_id, release_id, model_id, source_group, epoch_id,
+    pointer_generation, token, pool_id, position_recipient,
+    position_token_id, token_liquidity_amount, locked_token_dust,
+    initial_sqrt_price_x96, initial_tick, tick_lower, tick_upper,
+    source_occurrence_id, source_logical_event_id,
+    source_occurrence_block_hash, projection_run_id,
+    fact_commitment, verified_at, audit_id
+  ) values (
+    p_launch_position_liquidity_fact_id, launch.launch_projection_id,
+    launch.chain_id, launch.release_id, launch.model_id, header.source_group,
+    launch.epoch_id, launch.pointer_generation, launch.token, launch.pool_id,
+    p_position_recipient::programmable_private.eth_address,
+    position_id::programmable_private.uint256_value,
+    liquidity_amount::programmable_private.uint256_value,
+    locked_dust::programmable_private.uint256_value,
+    sqrt_price::programmable_private.uint256_value,
+    p_initial_tick, p_tick_lower, p_tick_upper,
+    occurrence.occurrence_id, occurrence.logical_event_id,
+    occurrence.block_hash, p_run_id,
+    p_fact_commitment::programmable_private.bytes32_value,
+    p_verified_at, created_audit_id
+  );
+  return p_launch_position_liquidity_fact_id;
+end
+$function$;
+
+reset role;

--- a/supabase/tests/database/005_reward_seed_and_projection.test.sql
+++ b/supabase/tests/database/005_reward_seed_and_projection.test.sql
@@ -287,7 +287,8 @@ from (values
   ('91400000-0000-0000-0000-000000000019'::uuid, 'reward_configuration_activation', 'reward_vault', 'CtoRewardConfigurationActivated', decode(repeat('40', 32), 'hex')),
   ('91400000-0000-0000-0000-000000000020'::uuid, 'reward_vault', 'reward_vault', 'BeneficiaryFeesClaimed', decode(repeat('31', 32), 'hex')),
   ('91400000-0000-0000-0000-000000000021'::uuid, 'claim', 'reward_vault', 'BeneficiaryFeesClaimed', decode(repeat('32', 32), 'hex')),
-  ('91400000-0000-0000-0000-000000000022'::uuid, 'reward_vault', 'reward_vault', 'PayoutWalletChanged', decode(repeat('33', 32), 'hex'))
+  ('91400000-0000-0000-0000-000000000022'::uuid, 'reward_vault', 'reward_vault', 'PayoutWalletChanged', decode(repeat('33', 32), 'hex')),
+  ('91400000-0000-0000-0000-000000000023'::uuid, 'launch_liquidity', 'launcher', 'MemeLiquidityConfiguredV2', decode(repeat('34', 32), 'hex'))
 ) as rule(rule_id, projection_kind, source_role, event_type, commitment);
 select programmable_private.append_release_launch_requirement(
   requirement_id, '91000000-0000-0000-0000-000000000001', ordinal,
@@ -576,6 +577,51 @@ select programmable_private.resolve_envio_candidate(
   '2026-07-31T03:01:09.097Z'
 );
 select programmable_private.append_envio_candidate(
+  programmable_private.derive_envio_candidate_id(
+    1, decode(repeat('aa', 32), 'hex'), decode(repeat('a4', 32), 'hex'), 13
+  ),
+  '93000000-0000-0000-0000-000000000001',
+  25639599, decode(repeat('aa', 32), 'hex'), decode(repeat('a4', 32), 'hex'),
+  4, 13, decode(repeat('31', 20), 'hex'), decode(repeat('43', 32), 'hex'),
+  'MemeLiquidityConfiguredV2', array[decode(repeat('43', 32), 'hex')],
+  decode('0104', 'hex'),
+  '{"token":"0x7171717171717171717171717171717171717171","totalSupply":"1000000000000000000000000","tokenLiquidityAmount":"999999999999999999999999","lockedTokenDust":"1","initialTick":"0","tickLower":"-887220","tickUpper":"0","lpFeePips":"3000","launchHash":"0x7474747474747474747474747474747474747474747474747474747474747474"}'::jsonb,
+  decode(repeat('44', 32), 'hex'),
+  programmable_private.derive_envio_candidate_id(
+    1, decode(repeat('aa', 32), 'hex'), decode(repeat('a4', 32), 'hex'), 13
+  ),
+  '92000000-0000-0000-0000-000000000003',
+  decode(repeat('45', 32), 'hex'), '2026-07-31T03:01:09.098Z'
+);
+select programmable_private.append_release_neutral_envio_candidate(
+  programmable_private.derive_envio_candidate_id(
+    1, decode(repeat('aa', 32), 'hex'), decode(repeat('a4', 32), 'hex'), 13
+  ),
+  '910c0000-0000-0000-0000-000000000001',
+  25639599, decode(repeat('aa', 32), 'hex'), decode(repeat('a4', 32), 'hex'),
+  4, 13, decode(repeat('31', 20), 'hex'), decode(repeat('43', 32), 'hex'),
+  'MemeLiquidityConfiguredV2', array[decode(repeat('43', 32), 'hex')],
+  decode('0104', 'hex'),
+  '{"token":"0x7171717171717171717171717171717171717171","totalSupply":"1000000000000000000000000","tokenLiquidityAmount":"999999999999999999999999","lockedTokenDust":"1","initialTick":"0","tickLower":"-887220","tickUpper":"0","lpFeePips":"3000","launchHash":"0x7474747474747474747474747474747474747474747474747474747474747474"}'::jsonb,
+  decode(repeat('44', 32), 'hex'),
+  programmable_private.derive_envio_candidate_id(
+    1, decode(repeat('aa', 32), 'hex'), decode(repeat('a4', 32), 'hex'), 13
+  ),
+  '92000000-0000-0000-0000-000000000003',
+  decode(repeat('45', 32), 'hex'), '2026-07-31T03:01:09.0985Z',
+  'canonical-events', 'ClassicV3Launcher'
+);
+select programmable_private.resolve_envio_candidate(
+  '91220000-0000-0000-0000-000000000013',
+  '93000000-0000-0000-0000-000000000001',
+  programmable_private.derive_envio_candidate_id(
+    1, decode(repeat('aa', 32), 'hex'), decode(repeat('a4', 32), 'hex'), 13
+  ),
+  '91100000-0000-0000-0000-000000000001', null,
+  decode(repeat('51', 32), 'hex'), decode(repeat('46', 32), 'hex'),
+  '2026-07-31T03:01:09.099Z'
+);
+select programmable_private.append_envio_candidate(
   programmable_private.derive_envio_candidate_id(1, decode(repeat('aa', 32), 'hex'), decode(repeat('b1', 32), 'hex'), 16),
   '93000000-0000-0000-0000-000000000001',
   25639599,
@@ -648,6 +694,20 @@ select programmable_private.append_chain_event_occurrence(
   1::smallint,
   decode('70726f6772616d6d61626c653a6f6363757272656e63653a76310053', 'hex'),
   decode(repeat('56', 32), 'hex'), '2026-07-31T03:01:12Z'
+);
+select programmable_private.append_chain_event_occurrence(
+  '96000000-0000-0000-0000-000000000008',
+  '96100000-0000-0000-0000-000000000008',
+  '93000000-0000-0000-0000-000000000001',
+  programmable_private.derive_envio_candidate_id(
+    1, decode(repeat('aa', 32), 'hex'), decode(repeat('a4', 32), 'hex'), 13
+  ),
+  1, '2026-07-31T02:58:24.500Z', 'decoder-v1',
+  decode(repeat('51', 32), 'hex'),
+  '95000000-0000-0000-0000-000000000599',
+  1::smallint,
+  decode('70726f6772616d6d61626c653a6f6363757272656e63653a76310075', 'hex'),
+  decode(repeat('47', 32), 'hex'), '2026-07-31T03:01:12.500Z'
 );
 select programmable_private.append_chain_event_occurrence(
   '96000000-0000-0000-0000-000000000001',
@@ -756,7 +816,7 @@ select throws_ok(
       999999999999999999999999, 1,
       79228162514264337593543950336,
       0, 0, 887220,
-      '96100000-0000-0000-0000-000000000004',
+      '96100000-0000-0000-0000-000000000008',
       decode(repeat('6e', 32), 'hex'),
       '2026-07-31T03:02:02.440Z'
     )
@@ -772,7 +832,7 @@ select programmable_private.stage_launch_position_liquidity_v1(
   999999999999999999999999, 1,
   79228162514264337593543950336,
   0, -887220, 0,
-  '96100000-0000-0000-0000-000000000004',
+  '96100000-0000-0000-0000-000000000008',
   decode(repeat('6f', 32), 'hex'),
   '2026-07-31T03:02:02.450Z'
 );
@@ -797,12 +857,14 @@ select programmable_private.promote_projection_run(
     '96100000-0000-0000-0000-000000000004'::uuid,
     '96100000-0000-0000-0000-000000000005'::uuid,
     '96100000-0000-0000-0000-000000000006'::uuid,
-    '96100000-0000-0000-0000-000000000007'::uuid
+    '96100000-0000-0000-0000-000000000007'::uuid,
+    '96100000-0000-0000-0000-000000000008'::uuid
   ],
   array[]::uuid[], array[]::uuid[],
   array[
     '91220000-0000-0000-0000-000000000010'::uuid,
-    '91220000-0000-0000-0000-000000000011'::uuid
+    '91220000-0000-0000-0000-000000000011'::uuid,
+    '91220000-0000-0000-0000-000000000013'::uuid
   ],
   array['explore-list']::text[],
   decode(repeat('75', 32), 'hex'), '2026-07-31T03:02:03Z'
@@ -4298,7 +4360,7 @@ select ok(
   (
     select pg_catalog.jsonb_array_length(source_bindings) = 5
        and pg_catalog.jsonb_array_length(dynamic_source_templates) = 2
-       and pg_catalog.jsonb_array_length(projection_event_rules) = 22
+       and pg_catalog.jsonb_array_length(projection_event_rules) = 23
        and pg_catalog.jsonb_array_length(
          launch_completeness_requirements
        ) = 4

--- a/tests/data-pipeline/postgres-projector-store.test.ts
+++ b/tests/data-pipeline/postgres-projector-store.test.ts
@@ -1742,11 +1742,13 @@ describe("release-scoped projector Postgres commit", () => {
       index: number,
       transactionHash: `0x${string}`,
       transactionIndex: number,
+      candidateBlockHash: `0x${string}` = blockHash,
+      candidateBlockNumber = "25650001",
     ) => ({
-      candidate_id: `1:${blockHash}:${transactionHash}:${index}`,
+      candidate_id: `1:${candidateBlockHash}:${transactionHash}:${index}`,
       provider_deployment_id: IDS[0],
-      block_number: "25650001",
-      block_hash: bytes(blockHash),
+      block_number: candidateBlockNumber,
+      block_hash: bytes(candidateBlockHash),
       transaction_hash: bytes(transactionHash),
       transaction_index: String(transactionIndex),
       block_global_log_index: String(index),
@@ -1766,8 +1768,8 @@ describe("release-scoped projector Postgres commit", () => {
       ...Array.from({ length: 40 }, (_, index) =>
         candidateRow(index, firstTransactionHash, 1)
       ),
-      candidateRow(40, bytes32("a"), 2),
-      candidateRow(41, bytes32("b"), 3),
+      candidateRow(40, bytes32("a"), 2, bytes32("c"), "25650002"),
+      candidateRow(41, bytes32("b"), 3, bytes32("c"), "25650002"),
     ];
     let sequence = 1;
     const store = createPostgresReleaseProjectionStore({
@@ -1809,6 +1811,107 @@ describe("release-scoped projector Postgres commit", () => {
     expect(following?.entries.map(({ candidate }) =>
       candidate.blockGlobalLogIndex
     )).toEqual([40, 41]);
+  });
+
+  it("trims a normal page to a provider block terminal", async () => {
+    const executor = new ReleaseProjectionExecutor();
+    const firstBlockHash = bytes32("c");
+    const secondBlockHash = bytes32("d");
+    const candidateRow = (
+      index: number,
+      blockHash: `0x${string}`,
+      blockNumber: string,
+    ) => ({
+      candidate_id: `1:${blockHash}:${bytes32(String(index % 10))}:${index}`,
+      provider_deployment_id: IDS[0],
+      block_number: blockNumber,
+      block_hash: bytes(blockHash),
+      transaction_hash: bytes(bytes32(String(index % 10))),
+      transaction_index: String(index),
+      block_global_log_index: String(index),
+      source_address: bytes(address("1")),
+      event_signature: bytes(bytes32("f")),
+      event_type: "UnknownEvent",
+      ordered_topics: [bytes(bytes32("f"))],
+      raw_data: Buffer.alloc(0),
+      decoded_payload: {},
+      payload_hash: bytes(bytes32("1")),
+      content_commitment: bytes(bytes32("2")),
+      contract_name: "UnknownContract",
+      status: "pending",
+      attempt_count: "0",
+    });
+    executor.candidateRows = [
+      ...Array.from({ length: 20 }, (_value, index) =>
+        candidateRow(index, firstBlockHash, "25650001")
+      ),
+      ...Array.from({ length: 20 }, (_value, index) =>
+        candidateRow(index + 20, secondBlockHash, "25650002")
+      ),
+    ];
+    const store = createPostgresReleaseProjectionStore({
+      executor,
+      providers: PROVIDERS,
+      rpcEvidenceBindings: RPC_EVIDENCE_BINDINGS,
+      scope: {
+        releaseId: "classic-v2",
+        modelId: "classic",
+        sourceGroup: "core",
+      },
+      runtimeFence: RUNTIME_FENCE,
+      uuid: () => "81500000-0000-4000-8000-000000000001",
+      now: () => new Date("2026-07-31T18:00:00.000Z"),
+    });
+
+    const plan = await store.readProjectionPlan();
+    expect(plan).toMatchObject({ batchKind: "normal" });
+    expect(plan?.entries).toHaveLength(20);
+    expect(new Set(plan?.entries.map(({ candidate }) => candidate.blockHash)))
+      .toEqual(new Set([firstBlockHash]));
+  });
+
+  it("completes an oversized multi-transaction block atomically", async () => {
+    const executor = new ReleaseProjectionExecutor();
+    const blockHash = bytes32("d");
+    executor.candidateRows = Array.from({ length: 40 }, (_value, index) => ({
+      candidate_id: `1:${blockHash}:${bytes32(String(index % 10))}:${index}`,
+      provider_deployment_id: IDS[0],
+      block_number: "25650001",
+      block_hash: bytes(blockHash),
+      transaction_hash: bytes(bytes32(String(index % 10))),
+      transaction_index: String(index),
+      block_global_log_index: String(index),
+      source_address: bytes(address("1")),
+      event_signature: bytes(bytes32("f")),
+      event_type: "UnknownEvent",
+      ordered_topics: [bytes(bytes32("f"))],
+      raw_data: Buffer.alloc(0),
+      decoded_payload: {},
+      payload_hash: bytes(bytes32("1")),
+      content_commitment: bytes(bytes32("2")),
+      contract_name: "UnknownContract",
+      status: "pending",
+      attempt_count: "0",
+    }));
+    const store = createPostgresReleaseProjectionStore({
+      executor,
+      providers: PROVIDERS,
+      rpcEvidenceBindings: RPC_EVIDENCE_BINDINGS,
+      scope: {
+        releaseId: "classic-v2",
+        modelId: "classic",
+        sourceGroup: "core",
+      },
+      runtimeFence: RUNTIME_FENCE,
+      uuid: () => "81600000-0000-4000-8000-000000000001",
+      now: () => new Date("2026-07-31T18:00:00.000Z"),
+    });
+
+    const plan = await store.readProjectionPlan();
+    expect(plan).toMatchObject({ batchKind: "oversized-block" });
+    expect(plan?.entries).toHaveLength(40);
+    expect(new Set(plan?.entries.map(({ candidate }) => candidate.blockHash)))
+      .toEqual(new Set([blockHash]));
   });
 
   it.each([500, 501, 4_096])(


### PR DESCRIPTION
## Summary
- end normal release projection pages only at configured-provider block terminals
- process oversized multi-transaction blocks atomically
- validate liquidity sources against the actual release event schema without requiring an absent poolId
- cover the live-data failure modes in runtime and PGlite tests

## Verification
- npm test: 1581 passed, 7 skipped
- npm run db:test:pglite: 24/24 passed
- npm run typecheck
- npm run lint
- npm run build

Production deployment remains intentionally unchanged pending candidate restore, migration, backfill, staged gates, and promotion.