### PR TITLE
fix: make restore manifests portable across Postgres builds

### DIFF
--- a/scripts/data-pipeline/candidate-restore.mjs
+++ b/scripts/data-pipeline/candidate-restore.mjs
@@ -125,6 +125,8 @@ export const PINNED_PRE_ATTESTATION_SNAPSHOT = Object.freeze({
     "0x5921ceacba6b7d3c636d3571fd7ebe9fad599626d03372836d0e6293e358c597",
   structuralManifestSha256:
     "0x1546ad4cf2312e3143cf8cd57422f4040924521db4531d2ef2b1a9875f662ef8",
+  portableStructuralManifestSha256:
+    "0x0b95ed1e28d2684aa920be5058c7815b604986a611f67d7900c42d181875e80b",
 });
 export const CANDIDATE_PG_RESTRICT_KEY =
   "b3679e8b178535bbc58f9c9c43690a8c7e310ade8bd93360f15004be385b02d2";
@@ -470,6 +472,9 @@ function validateBackupEvidence(value, {
   repositoryCommit,
 } = {}) {
   const evidence = plainObject(value, "database backup evidence");
+  const hasPortableStructuralManifest =
+    Object.hasOwn(evidence, "sourcePortableStructuralManifestSha256") ||
+    Object.hasOwn(evidence, "restoredPortableStructuralManifestSha256");
   if (
     evidence.kind !== "programmable-database-backup-restore-evidence" ||
     evidence.schemaVersion !== 1 ||
@@ -485,8 +490,14 @@ function validateBackupEvidence(value, {
     evidence.restoredManifestSha256 !== evidence.sourceManifestSha256 ||
     (evidence.sourceStructuralManifestSha256 !== undefined &&
       (!SHA256.test(evidence.sourceStructuralManifestSha256) ||
+        !SHA256.test(evidence.restoredStructuralManifestSha256 ?? ""))) ||
+    (hasPortableStructuralManifest
+      ? !SHA256.test(evidence.sourcePortableStructuralManifestSha256 ?? "") ||
+        evidence.restoredPortableStructuralManifestSha256 !==
+          evidence.sourcePortableStructuralManifestSha256
+      : evidence.sourceStructuralManifestSha256 !== undefined &&
         evidence.restoredStructuralManifestSha256 !==
-          evidence.sourceStructuralManifestSha256)) ||
+          evidence.sourceStructuralManifestSha256) ||
     !Number.isSafeInteger(evidence.tableCount) ||
     evidence.tableCount <= 0 ||
     !Number.isSafeInteger(evidence.rowCount) ||
@@ -534,6 +545,12 @@ function backupReference(evidence) {
       : {
           structuralManifestSha256:
             validated.sourceStructuralManifestSha256,
+        }),
+    ...(validated.sourcePortableStructuralManifestSha256 === undefined
+      ? {}
+      : {
+          portableStructuralManifestSha256:
+            validated.sourcePortableStructuralManifestSha256,
         }),
     tableCount: validated.tableCount,
     rowCount: validated.rowCount,
@@ -619,6 +636,14 @@ export function buildCandidateSafetyBackupEvidence(input) {
       input.currentManifest?.structuralManifestSha256
   ) {
     throw new Error("Candidate structure changed after the safety backup");
+  }
+  if (
+    !SHA256.test(backupEvidence.sourcePortableStructuralManifestSha256 ?? "") ||
+    !SHA256.test(input.currentManifest?.portableStructuralManifestSha256 ?? "") ||
+    backupEvidence.sourcePortableStructuralManifestSha256 !==
+      input.currentManifest.portableStructuralManifestSha256
+  ) {
+    throw new Error("Candidate portable structure changed after the safety backup");
   }
   if (
     input.currentManifest?.tableCount !== backupEvidence.tableCount ||
@@ -709,6 +734,7 @@ export function validateCandidateSafetyBackupEvidence(value, {
     !SHA256.test(backup.archiveListSha256 ?? "") ||
     !SHA256.test(backup.manifestSha256 ?? "") ||
     !SHA256.test(backup.structuralManifestSha256 ?? "") ||
+    !SHA256.test(backup.portableStructuralManifestSha256 ?? "") ||
     !Number.isSafeInteger(backup.bytes) ||
     backup.bytes <= 0 ||
     !Number.isSafeInteger(backup.tableCount) ||
@@ -2084,6 +2110,8 @@ export async function createCandidateRestorePlan(input) {
       migrationSourceClosure,
       structuralManifestSha256:
         PINNED_PRE_ATTESTATION_SNAPSHOT.structuralManifestSha256,
+      portableStructuralManifestSha256:
+        PINNED_PRE_ATTESTATION_SNAPSHOT.portableStructuralManifestSha256,
     }),
     safetyBackup: Object.freeze({
       ...safety,
@@ -2099,6 +2127,8 @@ export async function createCandidateRestorePlan(input) {
       manifestSha256: snapshot.manifestSha256,
       structuralManifestSha256:
         PINNED_PRE_ATTESTATION_SNAPSHOT.structuralManifestSha256,
+      portableStructuralManifestSha256:
+        PINNED_PRE_ATTESTATION_SNAPSHOT.portableStructuralManifestSha256,
       tableCount: snapshot.tableCount,
       rowCount: snapshot.rowCount,
       databaseMode: "candidate-only",
@@ -2165,6 +2195,8 @@ export function validateCandidateRestorePlan(value) {
       canonicalJson(PINNED_BASELINE_MIGRATION_SOURCE_CLOSURE) ||
     plan.snapshot?.structuralManifestSha256 !==
       PINNED_PRE_ATTESTATION_SNAPSHOT.structuralManifestSha256 ||
+    plan.snapshot?.portableStructuralManifestSha256 !==
+      PINNED_PRE_ATTESTATION_SNAPSHOT.portableStructuralManifestSha256 ||
     plan.snapshot?.bytes !== PINNED_PRE_ATTESTATION_SNAPSHOT.bytes ||
     canonicalJson(plan.snapshot?.schemas) !== canonicalJson(CANDIDATE_RESTORE_SCHEMAS) ||
     !SHA256.test(plan.safetyBackup?.safetyEvidenceSha256 ?? "") ||
@@ -2172,6 +2204,7 @@ export function validateCandidateRestorePlan(value) {
     !SHA256.test(plan.safetyBackup?.archiveListSha256 ?? "") ||
     !SHA256.test(plan.safetyBackup?.manifestSha256 ?? "") ||
     !SHA256.test(plan.safetyBackup?.structuralManifestSha256 ?? "") ||
+    !SHA256.test(plan.safetyBackup?.portableStructuralManifestSha256 ?? "") ||
     !Number.isSafeInteger(plan.safetyBackup?.bytes) ||
     plan.safetyBackup.bytes <= 0 ||
     canonicalJson(plan.postgresToolchain) !==
@@ -2179,6 +2212,8 @@ export function validateCandidateRestorePlan(value) {
     plan.postRestore?.manifestSha256 !== plan.snapshot.manifestSha256 ||
     plan.postRestore?.structuralManifestSha256 !==
       plan.snapshot.structuralManifestSha256 ||
+    plan.postRestore?.portableStructuralManifestSha256 !==
+      plan.snapshot.portableStructuralManifestSha256 ||
     plan.postRestore?.tableCount !== plan.snapshot.tableCount ||
     plan.postRestore?.rowCount !== plan.snapshot.rowCount ||
     plan.postRestore?.databaseMode !== "candidate-only" ||
@@ -2287,8 +2322,9 @@ function assertPostRestore({ plan, manifest, state }) {
   const fence = assertCandidateFence(state, "fenced");
   if (
     manifest?.manifestSha256 !== plan.postRestore.manifestSha256 ||
-    manifest?.structuralManifestSha256 !==
-      plan.postRestore.structuralManifestSha256 ||
+    !SHA256.test(manifest?.structuralManifestSha256 ?? "") ||
+    manifest?.portableStructuralManifestSha256 !==
+      plan.postRestore.portableStructuralManifestSha256 ||
     manifest?.tableCount !== plan.postRestore.tableCount ||
     manifest?.rowCount !== plan.postRestore.rowCount ||
     fence.databaseMode !== plan.postRestore.databaseMode ||
@@ -2481,6 +2517,8 @@ export async function applyCandidateRestore(input) {
       currentManifest.manifestSha256 === plan.safetyBackup.manifestSha256 &&
       currentManifest.structuralManifestSha256 ===
         plan.safetyBackup.structuralManifestSha256 &&
+      currentManifest.portableStructuralManifestSha256 ===
+        plan.safetyBackup.portableStructuralManifestSha256 &&
       currentManifest.tableCount === plan.safetyBackup.tableCount &&
       currentManifest.rowCount === plan.safetyBackup.rowCount;
     let restoredStateMatches = false;
@@ -2570,6 +2608,8 @@ export async function applyCandidateRestore(input) {
         tableCount: manifest.tableCount,
         rowCount: manifest.rowCount,
         structuralManifestSha256: manifest.structuralManifestSha256,
+        portableStructuralManifestSha256:
+          manifest.portableStructuralManifestSha256,
       }),
       migrationCount: restoredMigrationCount,
       candidateFence: fence,
@@ -2771,6 +2811,8 @@ export async function createCandidateSafetyRecoveryPlan(input) {
       candidateState: safetyEvidence.currentCandidateState,
       manifestSha256: safety.manifestSha256,
       structuralManifestSha256: safety.structuralManifestSha256,
+      portableStructuralManifestSha256:
+        safety.portableStructuralManifestSha256,
       tableCount: safety.tableCount,
       rowCount: safety.rowCount,
     }),
@@ -2811,6 +2853,7 @@ export function validateCandidateSafetyRecoveryPlan(value) {
     !SHA256.test(plan.safetyBackup?.archiveListSha256 ?? "") ||
     !SHA256.test(plan.safetyBackup?.manifestSha256 ?? "") ||
     !SHA256.test(plan.safetyBackup?.structuralManifestSha256 ?? "") ||
+    !SHA256.test(plan.safetyBackup?.portableStructuralManifestSha256 ?? "") ||
     !SHA256.test(plan.safetyBackup?.cleanClosureSha256 ?? "") ||
     !Number.isSafeInteger(plan.safetyBackup?.cleanClosureStatementCount) ||
     plan.safetyBackup.cleanClosureStatementCount < 1 ||
@@ -2822,9 +2865,12 @@ export function validateCandidateSafetyRecoveryPlan(value) {
     plan.safetyBackup.securityClosureStatementCount < 1 ||
     !SHA256.test(plan.postRestore?.manifestSha256 ?? "") ||
     !SHA256.test(plan.postRestore?.structuralManifestSha256 ?? "") ||
+    !SHA256.test(plan.postRestore?.portableStructuralManifestSha256 ?? "") ||
     plan.postRestore.manifestSha256 !== plan.safetyBackup.manifestSha256 ||
     plan.postRestore.structuralManifestSha256 !==
       plan.safetyBackup.structuralManifestSha256 ||
+    plan.postRestore.portableStructuralManifestSha256 !==
+      plan.safetyBackup.portableStructuralManifestSha256 ||
     plan.postRestore.tableCount !== plan.safetyBackup.tableCount ||
     plan.postRestore.rowCount !== plan.safetyBackup.rowCount
   ) {
@@ -3031,8 +3077,9 @@ export async function applyCandidateSafetyRecovery(input) {
           promotedCandidateState(state, plan.currentProductCommit),
         ) === canonicalJson(plan.postRestore.candidateState) &&
         manifest.manifestSha256 === plan.postRestore.manifestSha256 &&
-        manifest.structuralManifestSha256 ===
-          plan.postRestore.structuralManifestSha256 &&
+        SHA256.test(manifest.structuralManifestSha256 ?? "") &&
+        manifest.portableStructuralManifestSha256 ===
+          plan.postRestore.portableStructuralManifestSha256 &&
         manifest.tableCount === plan.postRestore.tableCount &&
         manifest.rowCount === plan.postRestore.rowCount;
     } catch {
@@ -3084,8 +3131,9 @@ export async function applyCandidateSafetyRecovery(input) {
         promotedCandidateState(state, plan.currentProductCommit),
       ) !== canonicalJson(plan.postRestore.candidateState) ||
       manifest.manifestSha256 !== plan.postRestore.manifestSha256 ||
-      manifest.structuralManifestSha256 !==
-        plan.postRestore.structuralManifestSha256 ||
+      !SHA256.test(manifest.structuralManifestSha256 ?? "") ||
+      manifest.portableStructuralManifestSha256 !==
+        plan.postRestore.portableStructuralManifestSha256 ||
       manifest.tableCount !== plan.postRestore.tableCount ||
       manifest.rowCount !== plan.postRestore.rowCount
     ) {
@@ -3186,8 +3234,9 @@ export function validateCandidateRestoreResult(value) {
       PINNED_PRE_ATTESTATION_SNAPSHOT.schemaSqlSha256 ||
     result.snapshot?.manifestSha256 !==
       PINNED_PRE_ATTESTATION_SNAPSHOT.manifestSha256 ||
-    result.snapshot?.structuralManifestSha256 !==
-      PINNED_PRE_ATTESTATION_SNAPSHOT.structuralManifestSha256 ||
+    !SHA256.test(result.snapshot?.structuralManifestSha256 ?? "") ||
+    result.snapshot?.portableStructuralManifestSha256 !==
+      PINNED_PRE_ATTESTATION_SNAPSHOT.portableStructuralManifestSha256 ||
     !Number.isSafeInteger(result.snapshot?.tableCount) ||
     !Number.isSafeInteger(result.snapshot?.rowCount) ||
     !Number.isSafeInteger(result.migrationCount) ||

--- a/scripts/data-pipeline/candidate-restore.test.mjs
+++ b/scripts/data-pipeline/candidate-restore.test.mjs
@@ -62,10 +62,12 @@ const TOOLCHAIN_EVIDENCE = Object.freeze({
   ...OFFICIAL_POSTGRES_17_TOOLCHAIN,
   toolchainSha256: sha256(canonicalJson(OFFICIAL_POSTGRES_17_TOOLCHAIN)),
 });
-const RESTORED_STRUCTURAL_MANIFEST =
-  PINNED_PRE_ATTESTATION_SNAPSHOT.structuralManifestSha256;
+const HOSTED_RESTORED_STRUCTURAL_MANIFEST = `0x${"9".repeat(64)}`;
+const RESTORED_PORTABLE_STRUCTURAL_MANIFEST =
+  PINNED_PRE_ATTESTATION_SNAPSHOT.portableStructuralManifestSha256;
 const SAFETY_MANIFEST = `0x${"e".repeat(64)}`;
 const SAFETY_STRUCTURAL_MANIFEST = `0x${"f".repeat(64)}`;
+const SAFETY_PORTABLE_STRUCTURAL_MANIFEST = `0x${"d".repeat(64)}`;
 
 const PINNED_SNAPSHOT_EVIDENCE = Object.freeze({
   kind: "programmable-database-backup-restore-evidence",
@@ -161,13 +163,17 @@ function manifest({ restored = false } = {}) {
   return restored
     ? {
         manifestSha256: PINNED_PRE_ATTESTATION_SNAPSHOT.manifestSha256,
-        structuralManifestSha256: RESTORED_STRUCTURAL_MANIFEST,
+        structuralManifestSha256: HOSTED_RESTORED_STRUCTURAL_MANIFEST,
+        portableStructuralManifestSha256:
+          RESTORED_PORTABLE_STRUCTURAL_MANIFEST,
         tableCount: PINNED_SNAPSHOT_EVIDENCE.tableCount,
         rowCount: PINNED_SNAPSHOT_EVIDENCE.rowCount,
       }
     : {
         manifestSha256: SAFETY_MANIFEST,
         structuralManifestSha256: SAFETY_STRUCTURAL_MANIFEST,
+        portableStructuralManifestSha256:
+          SAFETY_PORTABLE_STRUCTURAL_MANIFEST,
         tableCount: 121,
         rowCount: 147_999,
       };
@@ -199,6 +205,10 @@ function rawSafetyEvidence(archive) {
     restoredManifestSha256: current.manifestSha256,
     sourceStructuralManifestSha256: current.structuralManifestSha256,
     restoredStructuralManifestSha256: current.structuralManifestSha256,
+    sourcePortableStructuralManifestSha256:
+      current.portableStructuralManifestSha256,
+    restoredPortableStructuralManifestSha256:
+      current.portableStructuralManifestSha256,
     tableCount: current.tableCount,
     rowCount: current.rowCount,
     postgresVersion: "PostgreSQL 17.10",
@@ -543,6 +553,8 @@ test("pinned pre-attestation evidence is exact and rejects every mutation", () =
       "0x5921ceacba6b7d3c636d3571fd7ebe9fad599626d03372836d0e6293e358c597",
     structuralManifestSha256:
       "0x1546ad4cf2312e3143cf8cd57422f4040924521db4531d2ef2b1a9875f662ef8",
+    portableStructuralManifestSha256:
+      "0x0b95ed1e28d2684aa920be5058c7815b604986a611f67d7900c42d181875e80b",
   });
   assert.equal(PINNED_BASELINE_MIGRATION_SOURCE_CLOSURE.length, 29);
   assert.deepEqual(
@@ -607,6 +619,14 @@ test("restore plan binds CA, raw safety evidence, three tools, schemas and flags
   assert.equal(
     plan.safetyBackup.structuralManifestSha256,
     SAFETY_STRUCTURAL_MANIFEST,
+  );
+  assert.equal(
+    plan.safetyBackup.portableStructuralManifestSha256,
+    SAFETY_PORTABLE_STRUCTURAL_MANIFEST,
+  );
+  assert.equal(
+    plan.postRestore.portableStructuralManifestSha256,
+    RESTORED_PORTABLE_STRUCTURAL_MANIFEST,
   );
   assert.deepEqual(plan.postgresToolchain, TOOLCHAIN_EVIDENCE);
   assert.deepEqual(plan.restore.schemas, CANDIDATE_RESTORE_SCHEMAS);
@@ -852,12 +872,31 @@ test("safety backup binds structural manifest, CA and exact official toolchain",
     SAFETY_STRUCTURAL_MANIFEST,
   );
   assert.equal(
+    evidence.backup.portableStructuralManifestSha256,
+    SAFETY_PORTABLE_STRUCTURAL_MANIFEST,
+  );
+  assert.equal(
     validateCandidateSafetyBackupEvidence(evidence, {
       operatorCommit: OPERATOR_COMMIT,
       currentProductCommit: CURRENT_PRODUCT_COMMIT,
       now: new Date("2026-08-02T09:10:00.000Z"),
     }),
     evidence,
+  );
+  const withoutPortable = structuredClone(files.safetyRawEvidence);
+  delete withoutPortable.sourcePortableStructuralManifestSha256;
+  delete withoutPortable.restoredPortableStructuralManifestSha256;
+  assert.throws(
+    () => buildSafetyEvidence(withoutPortable),
+    /portable structure/u,
+  );
+  const driftedPortable = structuredClone(files.safetyRawEvidence);
+  driftedPortable.sourcePortableStructuralManifestSha256 = `0x${"7".repeat(64)}`;
+  driftedPortable.restoredPortableStructuralManifestSha256 =
+    driftedPortable.sourcePortableStructuralManifestSha256;
+  assert.throws(
+    () => buildSafetyEvidence(driftedPortable),
+    /portable structure/u,
   );
 });
 
@@ -906,7 +945,14 @@ test("restore apply resumes postchecks without replaying pg_restore", async (t) 
   });
   assert.equal(result.executionMode, "resumed-post-restore-verification");
   assert.equal(result.runtimeLoginFence.remainsFenced, true);
-  assert.equal(result.snapshot.structuralManifestSha256, RESTORED_STRUCTURAL_MANIFEST);
+  assert.equal(
+    result.snapshot.structuralManifestSha256,
+    HOSTED_RESTORED_STRUCTURAL_MANIFEST,
+  );
+  assert.equal(
+    result.snapshot.portableStructuralManifestSha256,
+    RESTORED_PORTABLE_STRUCTURAL_MANIFEST,
+  );
   assert.equal(validateCandidateRestoreResult(result), result);
   assert.equal(stateReads, 2);
   assert.equal(manifestReads, 3);
@@ -1045,6 +1091,10 @@ test("safety recovery plan binds raw evidence, CA, tools and immutable restore s
     sha256(canonicalJson(files.safetyRawEvidence)),
   );
   assert.equal(plan.postRestore.structuralManifestSha256, SAFETY_STRUCTURAL_MANIFEST);
+  assert.equal(
+    plan.postRestore.portableStructuralManifestSha256,
+    SAFETY_PORTABLE_STRUCTURAL_MANIFEST,
+  );
   assert.deepEqual(plan.postgresToolchain, TOOLCHAIN_EVIDENCE);
   assert.deepEqual(plan.restore.schemas, CANDIDATE_RESTORE_SCHEMAS);
   assert.deepEqual(plan.restore.flags, CANDIDATE_SAFETY_RECOVERY_FLAGS);
@@ -1095,7 +1145,10 @@ test("safety recovery apply is idempotent and never opens runtime logins", async
           fences += 1;
           return loginFence();
         },
-        captureDatabaseManifest: async () => manifest(),
+        captureDatabaseManifest: async () => ({
+          ...manifest(),
+          structuralManifestSha256: `0x${"8".repeat(64)}`,
+        }),
       }, { recovery: true }),
       validateOfficialToolchain: toolchainDependency(files),
       fileCommitment: commitmentDependency(files),
@@ -1105,6 +1158,11 @@ test("safety recovery apply is idempotent and never opens runtime logins", async
     },
   });
   assert.equal(result.executionMode, "already-recovered");
+  assert.equal(result.manifest.structuralManifestSha256, `0x${"8".repeat(64)}`);
+  assert.equal(
+    result.manifest.portableStructuralManifestSha256,
+    SAFETY_PORTABLE_STRUCTURAL_MANIFEST,
+  );
   assert.equal(result.runtimeLoginFence.remainsFenced, true);
   assert.equal(fences, 1);
   assert.match(result.evidenceSha256, /^0x[0-9a-f]{64}$/u);

--- a/scripts/data-pipeline/cutover-credentials.mjs
+++ b/scripts/data-pipeline/cutover-credentials.mjs
@@ -803,6 +803,14 @@ function validateStoredEvidence(value, request) {
     value ?? {},
     "restoredStructuralManifestSha256",
   );
+  const hasSourcePortableStructuralManifest = Object.hasOwn(
+    value ?? {},
+    "sourcePortableStructuralManifestSha256",
+  );
+  const hasRestoredPortableStructuralManifest = Object.hasOwn(
+    value ?? {},
+    "restoredPortableStructuralManifestSha256",
+  );
   if (
     !isPlainRecord(value) ||
     value.kind !== "programmable-database-backup-restore-evidence" ||
@@ -825,8 +833,16 @@ function validateStoredEvidence(value, request) {
     hasSourceStructuralManifest !== hasRestoredStructuralManifest ||
     (hasSourceStructuralManifest &&
       (!SHA256.test(value.sourceStructuralManifestSha256 ?? "") ||
+        !SHA256.test(value.restoredStructuralManifestSha256 ?? ""))) ||
+    hasSourcePortableStructuralManifest !==
+      hasRestoredPortableStructuralManifest ||
+    (hasSourcePortableStructuralManifest
+      ? !SHA256.test(value.sourcePortableStructuralManifestSha256 ?? "") ||
+        value.restoredPortableStructuralManifestSha256 !==
+          value.sourcePortableStructuralManifestSha256
+      : hasSourceStructuralManifest &&
         value.restoredStructuralManifestSha256 !==
-          value.sourceStructuralManifestSha256)) ||
+          value.sourceStructuralManifestSha256) ||
     !Number.isSafeInteger(value.tableCount) ||
     value.tableCount < 0 ||
     !Number.isSafeInteger(value.rowCount) ||
@@ -1032,6 +1048,278 @@ function quoteIdentifier(value) {
   return `"${value.replaceAll('"', '""')}"`;
 }
 
+const BOOLEAN_DEFINITION_WORDS = new Set(["AND", "OR"]);
+const NON_ASSOCIATIVE_BOOLEAN_CONTEXT = new Set([
+  "BETWEEN",
+  "CASE",
+  "ELSE",
+  "END",
+  "FILTER",
+  "ORDER",
+  "OVER",
+  "SELECT",
+  "THEN",
+  "WHEN",
+  "WITHIN",
+]);
+
+function postgresDefinitionTokens(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("Postgres definition is invalid");
+  }
+  const tokens = [];
+  let offset = 0;
+  const pushQuoted = (quote) => {
+    const start = offset;
+    offset += 1;
+    while (offset < value.length) {
+      if (value[offset] === "\\") {
+        offset += Math.min(2, value.length - offset);
+        continue;
+      }
+      if (value[offset] === quote) {
+        if (value[offset + 1] === quote) {
+          offset += 2;
+          continue;
+        }
+        offset += 1;
+        tokens.push({ kind: "quoted", value: value.slice(start, offset) });
+        return;
+      }
+      offset += 1;
+    }
+    throw new Error("Postgres definition contains an unterminated quote");
+  };
+  while (offset < value.length) {
+    const character = value[offset];
+    if (/\s/u.test(character)) {
+      offset += 1;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      pushQuoted(character);
+      continue;
+    }
+    if (character === "$") {
+      const tag = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/u.exec(
+        value.slice(offset),
+      )?.[0];
+      if (tag) {
+        const end = value.indexOf(tag, offset + tag.length);
+        if (end < 0) {
+          throw new Error("Postgres definition contains an unterminated dollar quote");
+        }
+        tokens.push({
+          kind: "quoted",
+          value: value.slice(offset, end + tag.length),
+        });
+        offset = end + tag.length;
+        continue;
+      }
+    }
+    if (/[A-Za-z_]/u.test(character)) {
+      const start = offset;
+      offset += 1;
+      while (offset < value.length && /[A-Za-z0-9_$]/u.test(value[offset])) {
+        offset += 1;
+      }
+      tokens.push({ kind: "word", value: value.slice(start, offset) });
+      continue;
+    }
+    if (/[0-9]/u.test(character)) {
+      const start = offset;
+      offset += 1;
+      while (offset < value.length && /[0-9A-Fa-f_xX.eE+-]/u.test(value[offset])) {
+        if (
+          ["+", "-"].includes(value[offset]) &&
+          !["e", "E"].includes(value[offset - 1])
+        ) {
+          break;
+        }
+        offset += 1;
+      }
+      tokens.push({ kind: "number", value: value.slice(start, offset) });
+      continue;
+    }
+    if (character === "(" || character === ")") {
+      tokens.push({ kind: "parenthesis", value: character });
+      offset += 1;
+      continue;
+    }
+    if (/[,.;\[\]]/u.test(character)) {
+      tokens.push({ kind: "punctuation", value: character });
+      offset += 1;
+      continue;
+    }
+    if (/[~!@#%^&|`?+*/<>=:-]/u.test(character)) {
+      const start = offset;
+      offset += 1;
+      while (
+        offset < value.length &&
+        /[~!@#%^&|`?+*/<>=:-]/u.test(value[offset])
+      ) {
+        offset += 1;
+      }
+      tokens.push({ kind: "operator", value: value.slice(start, offset) });
+      continue;
+    }
+    tokens.push({ kind: "literal", value: character });
+    offset += 1;
+  }
+  return tokens;
+}
+
+function postgresDefinitionTree(value) {
+  const root = { kind: "group", explicit: false, children: [] };
+  const stack = [root];
+  for (const token of postgresDefinitionTokens(value)) {
+    if (token.kind !== "parenthesis") {
+      stack.at(-1).children.push(token);
+      continue;
+    }
+    if (token.value === "(") {
+      const group = { kind: "group", explicit: true, children: [] };
+      stack.at(-1).children.push(group);
+      stack.push(group);
+      continue;
+    }
+    if (stack.length === 1) {
+      throw new Error("Postgres definition has an unmatched closing parenthesis");
+    }
+    stack.pop();
+  }
+  if (stack.length !== 1) {
+    throw new Error("Postgres definition has an unmatched opening parenthesis");
+  }
+  return root;
+}
+
+function topLevelBooleanKind(group) {
+  const words = group.children
+    .filter(({ kind }) => kind === "word")
+    .map(({ value }) => value.toUpperCase());
+  if (words.some((word) => NON_ASSOCIATIVE_BOOLEAN_CONTEXT.has(word))) {
+    return null;
+  }
+  const operators = new Set(
+    words.filter((word) => BOOLEAN_DEFINITION_WORDS.has(word)),
+  );
+  return operators.size === 1 ? [...operators][0] : null;
+}
+
+function containsUnsafeSingletonSyntax(group) {
+  return group.children.some(
+    (child) =>
+      (child.kind === "punctuation" && child.value === ",") ||
+      (child.kind === "word" &&
+        ["SELECT", "TABLE", "VALUES", "WITH"].includes(
+          child.value.toUpperCase(),
+        )),
+  );
+}
+
+function booleanOperandAt(children, index, operator) {
+  const previous = children[index - 1];
+  const next = children[index + 1];
+  const boundary = (value) =>
+    value === undefined ||
+    (value.kind === "word" && value.value.toUpperCase() === operator);
+  return boundary(previous) && boundary(next);
+}
+
+function normalizePostgresDefinitionGroup(group) {
+  for (const child of group.children) {
+    if (child.kind === "group") normalizePostgresDefinitionGroup(child);
+  }
+  while (
+    group.children.length === 1 &&
+    group.children[0].kind === "group" &&
+    topLevelBooleanKind(group.children[0]) !== null &&
+    !containsUnsafeSingletonSyntax(group.children[0])
+  ) {
+    group.children = group.children[0].children;
+  }
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const operator = topLevelBooleanKind(group);
+    if (!operator) break;
+    const normalized = [];
+    for (let index = 0; index < group.children.length; index += 1) {
+      const child = group.children[index];
+      if (
+        child.kind === "group" &&
+        topLevelBooleanKind(child) === operator &&
+        booleanOperandAt(group.children, index, operator)
+      ) {
+        normalized.push(...child.children);
+        changed = true;
+      } else {
+        normalized.push(child);
+      }
+    }
+    group.children = normalized;
+  }
+  return group;
+}
+
+function serializedPostgresDefinitionNode(node) {
+  if (node.kind !== "group") return [node.kind, node.value];
+  return [
+    node.explicit ? "group" : "root",
+    ...node.children.map(serializedPostgresDefinitionNode),
+  ];
+}
+
+export function canonicalizePostgresDefinition(value) {
+  if (value === null) return null;
+  return canonicalJson(
+    serializedPostgresDefinitionNode(
+      normalizePostgresDefinitionGroup(postgresDefinitionTree(value)),
+    ),
+  );
+}
+
+function portableDefinitionRows(rows, fields) {
+  return rows.map((row) => ({
+    ...row,
+    ...Object.fromEntries(
+      fields.map((field) => [
+        field,
+        row[field] === null || row[field] === undefined
+          ? row[field]
+          : canonicalizePostgresDefinition(row[field]),
+      ]),
+    ),
+  }));
+}
+
+function rawAclRows(rows) {
+  return rows.map((row) => {
+    const raw = { ...row };
+    delete raw.grants_match_default;
+    return raw;
+  });
+}
+
+export function canonicalizePostgresAclRows(rows) {
+  const seen = new Set();
+  const canonicalRows = [];
+  for (const captured of rows) {
+    const { grants_match_default: grantsMatchDefault, ...raw } = captured;
+    const row =
+      grantsMatchDefault === true
+        ? { ...raw, grants_are_default: true, grant_text: null }
+        : raw;
+    const key = canonicalJson(row);
+    if (!seen.has(key)) {
+      seen.add(key);
+      canonicalRows.push(row);
+    }
+  }
+  return canonicalRows;
+}
+
 export async function captureDatabaseManifest(
   sql,
   { schemas: requestedSchemas = BACKUP_SCHEMAS } = {},
@@ -1200,6 +1488,9 @@ export async function captureDatabaseManifest(
         namespace.nspname as schema_name,
         pg_catalog.pg_get_userbyid(namespace.nspowner) as schema_owner,
         namespace.nspacl is null as grants_are_default,
+        namespace.nspacl is null or
+          namespace.nspacl = pg_catalog.acldefault('n', namespace.nspowner)
+          as grants_match_default,
         grant_item.grant_text
       from pg_catalog.pg_namespace as namespace
       left join lateral (
@@ -1234,6 +1525,14 @@ export async function captureDatabaseManifest(
           from pg_catalog.unnest(class.reloptions) as option_value
         ), '{}'::text[])::text as relation_options,
         class.relacl is null as grants_are_default,
+        class.relacl is null or
+          case
+            when class.relkind in ('r', 'p', 'v', 'm', 'f') then
+              class.relacl = pg_catalog.acldefault('r', class.relowner)
+            when class.relkind = 'S' then
+              class.relacl = pg_catalog.acldefault('s', class.relowner)
+            else false
+          end as grants_match_default,
         grant_item.grant_text
       from pg_catalog.pg_class as class
       join pg_catalog.pg_namespace as namespace
@@ -1739,8 +2038,8 @@ export async function captureDatabaseManifest(
   const structuralPayload = {
     schemaVersion: 2,
     schemas,
-    schemaSecurity,
-    relationSecurity,
+    schemaSecurity: rawAclRows(schemaSecurity),
+    relationSecurity: rawAclRows(relationSecurity),
     columns,
     functionDefinitions,
     views,
@@ -1755,9 +2054,24 @@ export async function captureDatabaseManifest(
     defaultPrivileges,
     sequences,
   };
+  const portableStructuralPayload = {
+    ...structuralPayload,
+    schemaVersion: 3,
+    schemaSecurity: canonicalizePostgresAclRows(schemaSecurity),
+    relationSecurity: canonicalizePostgresAclRows(relationSecurity),
+    views: portableDefinitionRows(views, ["definition"]),
+    constraints: constraints.map((row) =>
+      row.constraint_kind === "c"
+        ? portableDefinitionRows([row], ["definition"])[0]
+        : row,
+    ),
+  };
   return Object.freeze({
     manifestSha256: sha256(canonicalJson(payload)),
     structuralManifestSha256: sha256(canonicalJson(structuralPayload)),
+    portableStructuralManifestSha256: sha256(
+      canonicalJson(portableStructuralPayload),
+    ),
     tableCount: tables.length,
     rowCount: totalRows,
   });
@@ -1847,6 +2161,16 @@ async function writeEvidence(request, evidence) {
   }
 }
 
+function portableStructuralManifest(manifest) {
+  const value =
+    manifest?.portableStructuralManifestSha256 ??
+    manifest?.structuralManifestSha256;
+  if (!SHA256.test(value ?? "")) {
+    throw new Error("portable database structure manifest is invalid");
+  }
+  return value;
+}
+
 export async function createBackupAndRestoreEvidence(input) {
   const request = validateBackupRequest(input);
   request.sourceDatabaseUrl = input.sourceDatabaseUrl;
@@ -1910,6 +2234,7 @@ export async function createBackupAndRestoreEvidence(input) {
     if (
       !SHA256.test(before?.manifestSha256 ?? "") ||
       !SHA256.test(before?.structuralManifestSha256 ?? "") ||
+      !SHA256.test(portableStructuralManifest(before)) ||
       !Number.isSafeInteger(before?.tableCount) ||
       before.tableCount < 0 ||
       !Number.isSafeInteger(before?.rowCount) ||
@@ -1958,6 +2283,8 @@ export async function createBackupAndRestoreEvidence(input) {
         schemaVersion: 1,
         sourceManifestSha256: before.manifestSha256,
         sourceStructuralManifestSha256: before.structuralManifestSha256,
+        sourcePortableStructuralManifestSha256:
+          portableStructuralManifest(before),
       })}\n`;
       await createPrivateFile(request.backupPath, emptyArtifact);
       backupCreated = true;
@@ -1996,6 +2323,7 @@ export async function createBackupAndRestoreEvidence(input) {
     if (
       after?.manifestSha256 !== before.manifestSha256 ||
       after?.structuralManifestSha256 !== before.structuralManifestSha256 ||
+      portableStructuralManifest(after) !== portableStructuralManifest(before) ||
       after?.tableCount !== before.tableCount ||
       after?.rowCount !== before.rowCount
     ) {
@@ -2061,8 +2389,9 @@ export async function createBackupAndRestoreEvidence(input) {
     const restored = await captureManifest(restoreConnection.sql);
     if (
       restored?.manifestSha256 !== before.manifestSha256 ||
-      restored?.structuralManifestSha256 !==
-        before.structuralManifestSha256 ||
+      !SHA256.test(restored?.structuralManifestSha256 ?? "") ||
+      portableStructuralManifest(restored) !==
+        portableStructuralManifest(before) ||
       restored?.tableCount !== before.tableCount ||
       restored?.rowCount !== before.rowCount
     ) {
@@ -2092,6 +2421,10 @@ export async function createBackupAndRestoreEvidence(input) {
       restoredManifestSha256: restored.manifestSha256,
       sourceStructuralManifestSha256: before.structuralManifestSha256,
       restoredStructuralManifestSha256: restored.structuralManifestSha256,
+      sourcePortableStructuralManifestSha256:
+        portableStructuralManifest(before),
+      restoredPortableStructuralManifestSha256:
+        portableStructuralManifest(restored),
       tableCount: before.tableCount,
       rowCount: before.rowCount,
       postgresVersion,

--- a/scripts/data-pipeline/cutover-credentials.test.mjs
+++ b/scripts/data-pipeline/cutover-credentials.test.mjs
@@ -6,6 +6,8 @@ import test from "node:test";
 
 import {
   ROLE_SPECS,
+  canonicalizePostgresAclRows,
+  canonicalizePostgresDefinition,
   captureDatabaseManifest,
   createBackupAndRestoreEvidence,
   provisionLoginRoles,
@@ -421,6 +423,7 @@ function manifest(value = "c") {
     structuralManifestSha256: `0x${value.repeat(63)}${
       value === "f" ? "e" : "f"
     }`,
+    portableStructuralManifestSha256: `0x${"d".repeat(64)}`,
     tableCount: 27,
     rowCount: 265,
   };
@@ -527,6 +530,10 @@ test("captureDatabaseManifest preserves the legacy hash and binds structural cat
     "0x3561c613752680fd9a2faddb412267139e7c9d8d0f1995ed1b243e920c3b508a",
   );
   assert.match(baseline.structuralManifestSha256, /^0x[0-9a-f]{64}$/u);
+  assert.match(
+    baseline.portableStructuralManifestSha256,
+    /^0x[0-9a-f]{64}$/u,
+  );
   assert.equal(baseline.tableCount, 0);
   assert.equal(baseline.rowCount, 0);
 
@@ -556,6 +563,9 @@ test("captureDatabaseManifest preserves the legacy hash and binds structural cat
     "pg_policy",
     "nspacl",
     "relacl",
+    "acldefault",
+    "class.relkind in ('r', 'p', 'v', 'm', 'f')",
+    "class.relkind = 'S'",
     "attacl",
     "proacl",
     "typacl",
@@ -578,6 +588,133 @@ test("captureDatabaseManifest preserves the legacy hash and binds structural cat
     "last_value::text",
   ]) {
     assert.equal(catalogSql.includes(requiredFragment), true, requiredFragment);
+  }
+});
+
+test("portable Postgres definitions flatten only redundant same-boolean grouping", () => {
+  const hosted =
+    "CHECK ((((octet_length(value) >= 1) AND (octet_length(value) <= 192)) AND (value ~ '^[A-Z()]$'::text)))";
+  const isolated =
+    "CHECK (((octet_length(value) >= 1) AND (octet_length(value) <= 192) AND (value ~ '^[A-Z()]$'::text)))";
+  assert.equal(
+    canonicalizePostgresDefinition(hosted),
+    canonicalizePostgresDefinition(isolated),
+  );
+  assert.equal(
+    canonicalizePostgresDefinition(
+      "SELECT 1 HAVING (((count(*) >= 1) AND (count(*) <= 5)))",
+    ),
+    canonicalizePostgresDefinition(
+      "SELECT 1 HAVING ((count(*) >= 1) AND (count(*) <= 5))",
+    ),
+  );
+  assert.equal(
+    canonicalizePostgresDefinition(
+      "SELECT * FROM a JOIN b ON ((((a.id = b.id) AND (a.kind = b.kind))))",
+    ),
+    canonicalizePostgresDefinition(
+      "SELECT * FROM a JOIN b ON ((a.id = b.id) AND (a.kind = b.kind))",
+    ),
+  );
+  assert.equal(
+    canonicalizePostgresDefinition(
+      "CHECK ((((label = 'x AND (y)') AND (body = $tag$(AND)$tag$))))",
+    ),
+    canonicalizePostgresDefinition(
+      "CHECK ((label = 'x AND (y)') AND (body = $tag$(AND)$tag$))",
+    ),
+  );
+  assert.notEqual(
+    canonicalizePostgresDefinition("CHECK (((a OR b) AND c))"),
+    canonicalizePostgresDefinition("CHECK ((a OR (b AND c)))"),
+  );
+  assert.notEqual(
+    canonicalizePostgresDefinition("CHECK ((a BETWEEN b AND c) AND d)"),
+    canonicalizePostgresDefinition("CHECK (a BETWEEN b AND (c AND d))"),
+  );
+  assert.notEqual(
+    canonicalizePostgresDefinition("CHECK (a AND b)"),
+    canonicalizePostgresDefinition("CHECK (a OR b)"),
+  );
+  for (const [left, right] of [
+    ["CHECK (a = 1)", "CHECK (b = 1)"],
+    ["CHECK (a = 1)", "CHECK (a = 2)"],
+    ["CHECK (a::text = '1')", "CHECK (a::integer = 1)"],
+    ["CHECK (a >= 1)", "CHECK (a > 1)"],
+    [
+      "CHECK ((CASE WHEN a THEN b ELSE c END) AND d)",
+      "CHECK ((CASE WHEN a THEN b ELSE e END) AND d)",
+    ],
+  ]) {
+    assert.notEqual(
+      canonicalizePostgresDefinition(left),
+      canonicalizePostgresDefinition(right),
+    );
+  }
+  for (const invalid of [
+    "CHECK ((a AND b)",
+    "CHECK (a AND b))",
+    "CHECK (a = 'unterminated)",
+    "CHECK (a = $tag$unterminated)",
+  ]) {
+    assert.throws(() => canonicalizePostgresDefinition(invalid));
+  }
+});
+
+test("portable Postgres ACLs collapse only database-proven default-equivalent grants", () => {
+  const implicitDefault = [
+    {
+      schema_name: "programmable_private",
+      schema_owner: "programmable_migrator",
+      grants_are_default: true,
+      grants_match_default: true,
+      grant_text: null,
+    },
+  ];
+  const explicitDefault = [
+    {
+      schema_name: "programmable_private",
+      schema_owner: "programmable_migrator",
+      grants_are_default: false,
+      grants_match_default: true,
+      grant_text: "programmable_migrator=UC/programmable_migrator",
+    },
+  ];
+  assert.deepEqual(
+    canonicalizePostgresAclRows(explicitDefault),
+    canonicalizePostgresAclRows(implicitDefault),
+  );
+  assert.equal(
+    canonicalizePostgresAclRows([...explicitDefault, ...explicitDefault]).length,
+    1,
+  );
+
+  for (const drift of [
+    {
+      grant_text: "programmable_api_reader=U/programmable_migrator",
+    },
+    {
+      grant_text: "programmable_api_reader=U*/programmable_migrator",
+    },
+    {
+      grant_text: "programmable_migrator=UC/postgres",
+    },
+    {
+      schema_owner: "postgres",
+      grant_text: "postgres=UC/postgres",
+    },
+    { grant_text: null },
+  ]) {
+    assert.notDeepEqual(
+      canonicalizePostgresAclRows([
+        {
+          ...explicitDefault[0],
+          ...drift,
+          grants_match_default: false,
+        },
+      ]),
+      canonicalizePostgresAclRows(implicitDefault),
+    );
   }
 });
 
@@ -742,6 +879,47 @@ test("createBackupAndRestoreEvidence keeps secrets in child env and proves an is
   for (const caPath of harness.caPaths) {
     await assert.rejects(lstat(caPath), { code: "ENOENT" });
   }
+});
+
+test("createBackupAndRestoreEvidence accepts only portable-equivalent cross-build structure", async (t) => {
+  const fixture = await backupFixture();
+  t.after(() => rm(fixture.directory, { recursive: true, force: true }));
+  const source = {
+    ...manifest(),
+    structuralManifestSha256: `0x${"a".repeat(64)}`,
+    portableStructuralManifestSha256: `0x${"b".repeat(64)}`,
+  };
+  const restored = {
+    ...source,
+    structuralManifestSha256: `0x${"c".repeat(64)}`,
+  };
+  let captures = 0;
+  const harness = backupDependencies(fixture, {
+    captureDatabaseManifest: async () => {
+      captures += 1;
+      return captures < 3 ? source : restored;
+    },
+  });
+  const result = await createBackupAndRestoreEvidence({
+    ...fixture.input,
+    dependencies: harness.dependencies,
+  });
+  assert.equal(
+    result.evidence.sourceStructuralManifestSha256,
+    source.structuralManifestSha256,
+  );
+  assert.equal(
+    result.evidence.restoredStructuralManifestSha256,
+    restored.structuralManifestSha256,
+  );
+  assert.equal(
+    result.evidence.sourcePortableStructuralManifestSha256,
+    source.portableStructuralManifestSha256,
+  );
+  assert.equal(
+    result.evidence.restoredPortableStructuralManifestSha256,
+    source.portableStructuralManifestSha256,
+  );
 });
 
 test("createBackupAndRestoreEvidence records an exact empty target-schema baseline", async (t) => {


### PR DESCRIPTION
## Summary
- preserve the raw structural manifest while adding a portable cross-build manifest
- normalize only PostgreSQL-proven default ACL equivalence and redundant same-boolean grouping in CHECK/view definitions
- bind safety backup, pinned restore, rollback, and result evidence to the portable manifest

## Verification
- live Candidate versus isolated restore: data, counts, and portable structural hash exact
- pinned pre-attestation dump restored independently: portable pin reproduced
- targeted restore tests: 38/38
- PGlite database tests: 31/31
- Vitest: 1781 passed, 7 skipped
- full npm run verify passed (contracts, ESLint, typecheck, smoke/ops gates, build)