### PR TITLE
Fix runtime role posture catalog query

### DIFF
--- a/scripts/data-pipeline/candidate-restore.mjs
+++ b/scripts/data-pipeline/candidate-restore.mjs
@@ -3355,15 +3355,17 @@ function readExactRuntimeCredentials(value) {
   return values;
 }
 
-async function readRuntimeRolePosture(sql) {
+export async function readRuntimeRolePosture(sql) {
   const names = ROLE_SPECS.flatMap(({ loginRole, capabilityRole }) => [
     loginRole,
     capabilityRole,
   ]);
   const rows = await sql.unsafe(
     `
-      select rolname, rolcanlogin, rolsuper, rolcreatedb, rolcreaterole,
-             rolinherit, rolreplication, rolbypassrls, rolconnlimit, rolconfig,
+      select roles.rolname, roles.rolcanlogin, roles.rolsuper,
+             roles.rolcreatedb, roles.rolcreaterole, roles.rolinherit,
+             roles.rolreplication, roles.rolbypassrls, roles.rolconnlimit,
+             roles.rolconfig,
              auth.rolpassword is not null as has_password
         from pg_catalog.pg_roles as roles
         join pg_catalog.pg_authid as auth on auth.rolname = roles.rolname

--- a/scripts/data-pipeline/candidate-restore.pg17.test.mjs
+++ b/scripts/data-pipeline/candidate-restore.pg17.test.mjs
@@ -17,6 +17,7 @@ import {
   assertCandidateSchemaStage,
   cleanupCandidateSchemas,
   prepareSafetyRestoreClosures,
+  readRuntimeRolePosture,
 } from "./candidate-restore.mjs";
 import {
   BACKUP_SCHEMAS,
@@ -267,6 +268,9 @@ test(
       forward.structuralManifestSha256,
       "0x8073e412ca77ba6a350c11e0421444049fa8fe644d253e2432465ecec69c5f7d",
     );
+    const runtimeRolePosture = await readRuntimeRolePosture(sql);
+    assert.equal(runtimeRolePosture.rows.length, 10);
+    assert.equal(runtimeRolePosture.memberships.length, 5);
 
     const closures = await prepareSafetyRestoreClosures({
       runner: undefined,

--- a/scripts/data-pipeline/candidate-restore.test.mjs
+++ b/scripts/data-pipeline/candidate-restore.test.mjs
@@ -26,6 +26,7 @@ import {
   createCandidateSafetyBackup,
   createCandidateSafetyRecoveryPlan,
   materializeOfficialToolchain,
+  readRuntimeRolePosture,
   validateOfficialToolchain,
   validateCandidateRestoreResult,
   validateCandidateSafetyBackupEvidence,
@@ -62,6 +63,20 @@ const OPERATOR_IDENTITY = Object.freeze({
 const TOOLCHAIN_EVIDENCE = Object.freeze({
   ...OFFICIAL_POSTGRES_17_TOOLCHAIN,
   toolchainSha256: sha256(canonicalJson(OFFICIAL_POSTGRES_17_TOOLCHAIN)),
+});
+
+test("runtime role posture qualifies joined role catalog columns", async () => {
+  const queries = [];
+  const posture = await readRuntimeRolePosture({
+    unsafe: async (query) => {
+      queries.push(query);
+      return [];
+    },
+  });
+  assert.deepEqual(posture, { rows: [], memberships: [] });
+  assert.equal(queries.length, 2);
+  assert.match(queries[0], /select roles\.rolname, roles\.rolcanlogin/u);
+  assert.doesNotMatch(queries[0], /select rolname, rolcanlogin/u);
 });
 const HOSTED_RESTORED_STRUCTURAL_MANIFEST = `0x${"9".repeat(64)}`;
 const RESTORED_PORTABLE_STRUCTURAL_MANIFEST =


### PR DESCRIPTION
Fixes the fail-closed Candidate runtime-enable inspection against PostgreSQL by qualifying role catalog columns shared by pg_roles and pg_authid. Adds unit and PG17 regression coverage.\n\nVerified locally: candidate restore tests 25/25, ESLint, TypeScript, diff check, and a read-only hosted Candidate execution returning 10 runtime roles and 5 memberships. No login, credential, restore, or promotion state was changed by the diagnosis.