### PR TITLE
Bind staged runtime to release commit

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -168,7 +168,7 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          deployment_url="$(vercel deploy --prebuilt --prod --skip-domain --archive=tgz --meta githubCommitSha="$GITHUB_SHA" --token="$VERCEL_TOKEN")"
+          deployment_url="$(vercel deploy --prebuilt --prod --skip-domain --archive=tgz --meta githubCommitSha="$GITHUB_SHA" --env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA" --token="$VERCEL_TOKEN")"
           case "$deployment_url" in
             https://*) ;;
             *)

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -965,6 +965,9 @@ export function evaluateReadModelOperationsSourceContracts(
       deployWorkflow.includes("npm run contracts:official-deployments") &&
       deployWorkflow.includes("npm run contracts:slither") &&
       deployWorkflow.includes("npm run audit:prod") &&
+      deployWorkflow.includes(
+        '--meta githubCommitSha="$GITHUB_SHA" --env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA"',
+      ) &&
       deployWorkflow.indexOf("npm run perf:read-model:ops-gate") <
         deployWorkflow.indexOf("vercel build --prod"),
     "production staging reproduces the complete exact-commit release gate",

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -1277,6 +1277,9 @@ describe("read-model performance contract", () => {
       "utf8",
     );
     expect(deployWorkflow).toContain("--prod --skip-domain");
+    expect(deployWorkflow).toContain(
+      '--env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA"',
+    );
     expect(deployWorkflow).toContain("perf:read-model:capture");
     expect(deployWorkflow).toContain("actions/upload-artifact@");
     expect(deployWorkflow).toContain("npm run perf:read-model:gate");

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -160,6 +160,24 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it("binds the exact GitHub commit into the staged deployment runtime", () => {
+    const workflowPath = ".github/workflows/deploy-production.yml";
+    const unsafeWorkflow = readFileSync(
+      resolve(ROOT, workflowPath),
+      "utf8",
+    ).replace('--env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA"', "");
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-exact-release-dependency",
+    );
+  });
+
   it("rejects comment-only controls and jointly drifted manifests", () => {
     const operations = JSON.parse(
       readFileSync(resolve(ROOT, "config/read-model-operations.v1.json"), "utf8"),


### PR DESCRIPTION
## Outcome

Ensures prebuilt production staging receives the exact reviewed GitHub SHA at runtime while retaining Vercel control-plane commit metadata.

## Changes

- pass VERCEL_GIT_COMMIT_SHA through the staged vercel deploy runtime environment
- bind that requirement into the operations source contract
- add negative drift and positive workflow regression coverage

## Verified locally

- targeted Vitest: 35/35
- read-model operations gate: passed
- TypeScript typecheck: passed
- ESLint: passed

This PR remains stage-only. It does not promote production.