### PR TITLE
Defer projector rounds without full deadline

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -25,7 +25,7 @@
       },
       "runtime": {
         "path": "lib/data-pipeline/projector-runtime-config.server.ts",
-        "sha256": "f2828a8e0e20ac005511ea9cce5c3e7b349696034a2dbf445268533fbc367b9c"
+        "sha256": "78483bf9b1110b4a97b719c6bb9bf9256285729e6002deb3621a9d1987373010"
       },
       "dependencies": [
         {

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -135,7 +135,7 @@
         },
         {
           "path": "lib/data-pipeline/optimistic-market-state.server.ts",
-          "sha256": "1479af0cb925c87c86d7b30fa20a8cda6bcef326e33f32e04f3e58796a498e67"
+          "sha256": "88e55d7311c40ada819820c665fbe54247eb605373b5028346889e247dc790e3"
         },
         {
           "path": "lib/data-pipeline/optimistic-live-runtime.server.ts",

--- a/lib/data-pipeline/optimistic-market-state.server.ts
+++ b/lib/data-pipeline/optimistic-market-state.server.ts
@@ -212,7 +212,7 @@ type ProviderRead = Readonly<{
   liquidityResult: HexData;
 }>;
 
-type DeadlineContext = Readonly<{ deadlineAt: number }>;
+type DeadlineContext = { deadlineAt: number; expired: boolean };
 type RpcCallCounter = { value: number };
 
 function recordRpcCalls(counter: RpcCallCounter, count: unknown): void {
@@ -951,19 +951,23 @@ function timeoutError(): DataPipelineError {
 }
 
 function assertWithinDeadline(context: DeadlineContext): void {
-  if (Date.now() >= context.deadlineAt) throw timeoutError();
+  if (context.expired || Date.now() >= context.deadlineAt) throw timeoutError();
 }
 
-async function withinDeadline<T>(operation: Promise<T>, maximumMs: number) {
+async function withinDeadline<T>(
+  operation: Promise<T>,
+  context: DeadlineContext,
+  maximumMs: number,
+) {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
       operation,
       new Promise<never>((_resolve, reject) => {
-        timeout = setTimeout(
-          () => reject(timeoutError()),
-          maximumMs,
-        );
+        timeout = setTimeout(() => {
+          context.expired = true;
+          reject(timeoutError());
+        }, maximumMs);
       }),
     ]);
   } finally {
@@ -1166,7 +1170,10 @@ export async function readOptimisticMarketState(input: Readonly<{
   const valuation = normalizeValuation(input);
   const evidence = normalizeEvidence(input.evidence, input.providers);
   const maximumMs = deadlineMs(input.hardDeadlineMs);
-  const deadline = Object.freeze({ deadlineAt: Date.now() + maximumMs });
+  const deadline: DeadlineContext = {
+    deadlineAt: Date.now() + maximumMs,
+    expired: false,
+  };
   if (input.newLaunch) {
     if (!isVerifiedDualRpcOptimisticBlock(input.evidence)) {
       throw invalidInput("rpc", "optimistic-new-launch-evidence-origin");
@@ -1183,6 +1190,7 @@ export async function readOptimisticMarketState(input: Readonly<{
         evidence,
         deadline,
       }))) as Promise<[ProviderRead, ProviderRead]>,
+      deadline,
       maximumMs,
     );
     if (

--- a/lib/data-pipeline/projector-runtime-config.server.ts
+++ b/lib/data-pipeline/projector-runtime-config.server.ts
@@ -604,8 +604,14 @@ export async function runConfiguredProjectorCycle(
         ReturnType<typeof prepareReleaseProjectionRound>
       > | null = null;
       if (participatingReleases.length > 0) {
-        if (operationDeadline(operationsRemaining) === null) {
+        if (
+          operationDeadline(operationsRemaining) !==
+            RELEASE_PROJECTION_DEADLINE_MS
+        ) {
           stoppedForDeadline = true;
+          completedRounds += 1;
+          if (madeProgress) madeAnyProgress = true;
+          terminalSweepComplete = false;
           break;
         }
         try {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -30,7 +30,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       }),
       runtime: Object.freeze({
         path: "lib/data-pipeline/projector-runtime-config.server.ts",
-        sha256: "f2828a8e0e20ac005511ea9cce5c3e7b349696034a2dbf445268533fbc367b9c",
+        sha256: "78483bf9b1110b4a97b719c6bb9bf9256285729e6002deb3621a9d1987373010",
       }),
       dependencies: Object.freeze([
         Object.freeze({

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -140,7 +140,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
         Object.freeze({
           path: "lib/data-pipeline/optimistic-market-state.server.ts",
-          sha256: "1479af0cb925c87c86d7b30fa20a8cda6bcef326e33f32e04f3e58796a498e67",
+          sha256: "88e55d7311c40ada819820c665fbe54247eb605373b5028346889e247dc790e3",
         }),
         Object.freeze({
           path: "lib/data-pipeline/optimistic-live-runtime.server.ts",

--- a/tests/data-pipeline/projector-runtime-config.test.ts
+++ b/tests/data-pipeline/projector-runtime-config.test.ts
@@ -930,6 +930,113 @@ describe("configured projector runtime", () => {
     expect(close).toHaveBeenCalledTimes(2);
   });
 
+  it("defers a late release round before opening projection runs", async () => {
+    let now = 0;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const close = vi.fn(async () => undefined);
+    const executor = { close };
+    let ingestionCall = 0;
+    const runCycle = vi.fn(async () => {
+      ingestionCall += 1;
+      if (ingestionCall < 3) now += 5_000;
+      else now = 65_000;
+      return {
+        status: "committed" as const,
+        candidateCount: 32,
+        snapshotBlock: String(25_650_000 + ingestionCall),
+        generation: String(ingestionCall),
+      };
+    });
+    const releaseCalls = new Map<string, number>();
+    const runReleaseCycle = vi.fn(async ({ store }) => {
+      const releaseId = (store as { scope: { releaseId: string } }).scope
+        .releaseId;
+      const call = (releaseCalls.get(releaseId) ?? 0) + 1;
+      releaseCalls.set(releaseId, call);
+      return {
+        status: "committed" as const,
+        projectedCandidateCount: 32,
+        ignoredCandidateCount: 0,
+        checkpointGeneration: String(call),
+      };
+    });
+    const prepareReleaseRound = mockPrepareReleaseRound();
+    const dependencies = {
+      createExecutor: vi.fn(() => executor),
+      assertPromotedDatabase: vi.fn(async () => undefined),
+      createLeaseController: vi.fn(() => ({
+        tryAcquire: vi.fn(async () => ({
+          status: "acquired",
+          fence: {
+            holderId: "projector-runtime-test",
+            generation: "1",
+            tokenHash: bytes32("a"),
+          },
+          acquiredAt: "2026-07-31T18:00:00.000Z",
+          expiresAt: "2026-07-31T18:01:25.000Z",
+        })),
+        release: vi.fn(async () => true),
+      })),
+      createProviders: vi.fn(() => RUNTIME_PROVIDERS),
+      assertProviders: vi.fn(),
+      createEnvio: vi.fn(() => ({})),
+      createStore: vi.fn(() => ({})),
+      createReleaseStore: vi.fn(({ scope }) => ({ scope })),
+      runCycle,
+      prepareReleaseRound,
+      ...mockProjectionPhases(runReleaseCycle),
+      runReleaseCycle,
+    } as never;
+
+    try {
+      await expect(runConfiguredProjectorCycle({
+        env: environment(),
+        dependencies,
+      })).resolves.toEqual({
+        ok: true,
+        ingestion: {
+          status: "committed",
+          candidateCount: 96,
+          pageCount: 3,
+          snapshotBlock: "25650003",
+          generation: "3",
+        },
+        projections: [
+          "classic-v2",
+          "classic-v3",
+          "stock-paired-v1",
+          "stock-paired-v2",
+          "stock-paired-v3",
+        ].map((releaseId) => ({
+          releaseId,
+          status: "committed",
+          projectedCandidateCount: 64,
+          ignoredCandidateCount: 0,
+          pageCount: 2,
+          checkpointGeneration: "2",
+        })),
+        readiness: {
+          status: "progressed",
+          activationReady: false,
+          lagging: true,
+          terminalSweepComplete: false,
+          stoppedForDeadline: true,
+          completedRounds: 3,
+          snapshotBlock: "25650003",
+        },
+        deadlineMs: 75_000,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(runCycle).toHaveBeenCalledTimes(3);
+    expect(prepareReleaseRound).toHaveBeenCalledTimes(2);
+    expect(runReleaseCycle).toHaveBeenCalledTimes(10);
+    expect([...releaseCalls.values()]).toEqual([2, 2, 2, 2, 2]);
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
   it("does not report an atomic-group release as terminally swept", async () => {
     const close = vi.fn(async () => undefined);
     const executor = { close };


### PR DESCRIPTION
## Outcome

Prevents the projector from opening a release projection round when the remaining runtime cannot provide the full reviewed verification deadline to every participating release.

## Root cause

Two rounds completed successfully. A late third ingestion left about 5.2 seconds after close reserve, which was divided across five releases. All five projection runs opened, then timed out sequentially at roughly 1.04 seconds each and were reported as failures.

## Changes

- defer before prepareReleaseRound unless the full 10-second release budget is available
- preserve completed ingestion progress and report stoppedForDeadline
- add regression coverage for two successful rounds plus a late third ingestion
- update the byte-bound operations manifest and source contract

## Verified locally

- targeted Vitest: 41/41
- runtime test file: 25/25
- read-model operations gate: passed
- TypeScript typecheck: passed
- ESLint: passed
- git diff check: passed

No database migration or provider change is required.