### PR TITLE
Authenticate protected staged wake canary

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -192,6 +192,7 @@ jobs:
         if: steps.read-model-policy.outputs.wake_canary_required == 'true'
         env:
           PROGRAMMABLE_QUICKNODE_STREAM_SECRET: ${{ secrets.PROGRAMMABLE_QUICKNODE_STREAM_SECRET }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
         run: >-
           npm run perf:read-model:wake-canary --

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -118,7 +118,7 @@
       },
       "canary": {
         "path": "scripts/perf/read-model-projector-wake-canary.mjs",
-        "sha256": "5ea9c8704126fe17982515038ed75dd3eb850479a5dc8c7b092e2db076c14900"
+        "sha256": "6820b5bf29cdbf34ae7c5f1bfab55c7bccafb53a7989e09b87aad81cfa111db7"
       },
       "dependencies": [
         {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -939,27 +939,34 @@ export function evaluateReadModelOperationsSourceContracts(
   const stagedWakeGate = deployWorkflow.indexOf(
     "Gate exact staged QuickNode wake route",
   );
+  const stagedWakeGateEnd = deployWorkflow.indexOf(
+    "Attest exact staged release policy",
+  );
+  const stagedWakeGateBlock =
+    stagedWakeGate >= 0 && stagedWakeGateEnd > stagedWakeGate
+      ? deployWorkflow.slice(stagedWakeGate, stagedWakeGateEnd)
+      : "";
   check(
     "ops-quicknode-stream-stage-gate",
     packageJson?.scripts?.["perf:read-model:wake-canary"] ===
       `node ${approvedTrigger.canary.path}` &&
       wakeCanary.includes("projectorWakeCanaryArgumentsFrom") &&
       stagedWakeGate > deployWorkflow.indexOf("Resolve exact staged deployment") &&
-      stagedWakeGate < deployWorkflow.indexOf("Attest exact staged release policy") &&
-      deployWorkflow.includes(
+      stagedWakeGate < stagedWakeGateEnd &&
+      stagedWakeGateBlock.includes(
         "if: steps.read-model-policy.outputs.wake_canary_required == 'true'",
       ) &&
-      deployWorkflow.includes(
+      stagedWakeGateBlock.includes(
         "PROGRAMMABLE_QUICKNODE_STREAM_SECRET: ${{ secrets.PROGRAMMABLE_QUICKNODE_STREAM_SECRET }}",
       ) &&
-      deployWorkflow.includes(
+      stagedWakeGateBlock.includes(
         "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
       ) &&
-      deployWorkflow.includes(
+      stagedWakeGateBlock.includes(
         "STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
       ) &&
-      deployWorkflow.includes("npm run perf:read-model:wake-canary --") &&
-      deployWorkflow.includes('--target-url "$STAGED_TARGET_URL"'),
+      stagedWakeGateBlock.includes("npm run perf:read-model:wake-canary --") &&
+      stagedWakeGateBlock.includes('--target-url "$STAGED_TARGET_URL"'),
     "an active fast lane must pass the exact unaliased staged wake canary before attestation",
   );
   check(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -123,7 +123,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       }),
       canary: Object.freeze({
         path: "scripts/perf/read-model-projector-wake-canary.mjs",
-        sha256: "5ea9c8704126fe17982515038ed75dd3eb850479a5dc8c7b092e2db076c14900",
+        sha256: "6820b5bf29cdbf34ae7c5f1bfab55c7bccafb53a7989e09b87aad81cfa111db7",
       }),
       dependencies: Object.freeze([
         Object.freeze({
@@ -348,6 +348,8 @@ function eventTriggerCanaryIsFailClosed(source, trigger) {
       'export const PROJECTOR_WAKE_ROUTE = "/api/ops/projector-wake"',
     ) &&
     source.includes('"PROGRAMMABLE_QUICKNODE_STREAM_SECRET"') &&
+    source.includes('"VERCEL_AUTOMATION_BYPASS_SECRET"') &&
+    source.includes('"x-vercel-protection-bypass"') &&
     source.includes('createHmac("sha256", secret)') &&
     source.includes('id: "invalid-signature"') &&
     source.includes('id: "stale-timestamp"') &&
@@ -356,7 +358,8 @@ function eventTriggerCanaryIsFailClosed(source, trigger) {
     source.includes("status: 202") &&
     source.includes('"cache-control"') &&
     source.includes('hostname.endsWith(".vercel.app")') &&
-    !source.includes("NEXT_PUBLIC_PROGRAMMABLE_QUICKNODE_STREAM_SECRET")
+    !source.includes("NEXT_PUBLIC_PROGRAMMABLE_QUICKNODE_STREAM_SECRET") &&
+    !source.includes("NEXT_PUBLIC_VERCEL_AUTOMATION_BYPASS_SECRET")
   );
 }
 
@@ -948,6 +951,9 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       deployWorkflow.includes(
         "PROGRAMMABLE_QUICKNODE_STREAM_SECRET: ${{ secrets.PROGRAMMABLE_QUICKNODE_STREAM_SECRET }}",
+      ) &&
+      deployWorkflow.includes(
+        "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
       ) &&
       deployWorkflow.includes(
         "STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",

--- a/scripts/perf/read-model-projector-wake-canary.mjs
+++ b/scripts/perf/read-model-projector-wake-canary.mjs
@@ -5,6 +5,8 @@ import { createHash, createHmac, randomBytes } from "node:crypto";
 export const PROJECTOR_WAKE_ROUTE = "/api/ops/projector-wake";
 export const QUICKNODE_STREAM_SECRET_ENV_NAME =
   "PROGRAMMABLE_QUICKNODE_STREAM_SECRET";
+export const VERCEL_AUTOMATION_BYPASS_SECRET_ENV_NAME =
+  "VERCEL_AUTOMATION_BYPASS_SECRET";
 
 const MINIMUM_SECRET_BYTES = 32;
 const MAXIMUM_SECRET_BYTES = 1_024;
@@ -49,11 +51,34 @@ function configuredSecret(environment) {
   return secret;
 }
 
+function configuredAutomationBypassSecret(environment) {
+  const secret = environment[VERCEL_AUTOMATION_BYPASS_SECRET_ENV_NAME];
+  const length = typeof secret === "string"
+    ? Buffer.byteLength(secret, "utf8")
+    : 0;
+  if (
+    typeof secret !== "string" ||
+    length < MINIMUM_SECRET_BYTES ||
+    length > 512 ||
+    /[\r\n]/u.test(secret)
+  ) {
+    throw new Error("wake canary automation bypass is unavailable or invalid");
+  }
+  return secret;
+}
+
 function mutateSignature(signature) {
   return `${signature[0] === "0" ? "1" : "0"}${signature.slice(1)}`;
 }
 
-function signedHeaders({ body, nonce, secret, timestamp, valid }) {
+function signedHeaders({
+  automationBypassSecret,
+  body,
+  nonce,
+  secret,
+  timestamp,
+  valid,
+}) {
   const signature = createHmac("sha256", secret)
     .update(nonce, "utf8")
     .update(timestamp, "utf8")
@@ -65,6 +90,7 @@ function signedHeaders({ body, nonce, secret, timestamp, valid }) {
     "x-qn-nonce": nonce,
     "x-qn-timestamp": timestamp,
     "x-qn-signature": valid ? signature : mutateSignature(signature),
+    "x-vercel-protection-bypass": automationBypassSecret,
   });
 }
 
@@ -102,7 +128,9 @@ async function expectJsonResponse(response, expectation) {
 
 export async function runProjectorWakeCanary(input) {
   const targetOrigin = exactStagedOrigin(input.targetUrl);
-  const secret = configuredSecret(input.environment ?? process.env);
+  const environment = input.environment ?? process.env;
+  const secret = configuredSecret(environment);
+  const automationBypassSecret = configuredAutomationBypassSecret(environment);
   const fetchImpl = input.fetchImpl ?? fetch;
   const nowMs = input.nowMs ?? Date.now();
   if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
@@ -169,6 +197,7 @@ export async function runProjectorWakeCanary(input) {
         redirect: "error",
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         headers: signedHeaders({
+          automationBypassSecret,
           body,
           nonce,
           secret,

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -178,6 +178,25 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it("fails closed when the protected staged wake bypass is not bound", () => {
+    const workflowPath = ".github/workflows/deploy-production.yml";
+    const unsafeWorkflow = readFileSync(resolve(ROOT, workflowPath), "utf8")
+      .replace(
+        "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}\n",
+        "",
+      );
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-quicknode-stream-stage-gate",
+    );
+  });
+
   it("rejects comment-only controls and jointly drifted manifests", () => {
     const operations = JSON.parse(
       readFileSync(resolve(ROOT, "config/read-model-operations.v1.json"), "utf8"),

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -197,6 +197,29 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it("rejects a staged wake bypass secret relocated to another workflow step", () => {
+    const workflowPath = ".github/workflows/deploy-production.yml";
+    const secretLine =
+      "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}\n";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const unsafeWorkflow = workflow
+      .replace(secretLine, "")
+      .replace(
+        "      - name: Pull production configuration\n        env:\n",
+        `      - name: Pull production configuration\n        env:\n${secretLine}`,
+      );
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-quicknode-stream-stage-gate",
+    );
+  });
+
   it("rejects comment-only controls and jointly drifted manifests", () => {
     const operations = JSON.parse(
       readFileSync(resolve(ROOT, "config/read-model-operations.v1.json"), "utf8"),

--- a/tests/data-pipeline/read-model-projector-wake-canary.test.ts
+++ b/tests/data-pipeline/read-model-projector-wake-canary.test.ts
@@ -12,6 +12,7 @@ const {
 } = wakeCanary;
 
 const SECRET = "quicknode-stream-secret-at-least-32-bytes";
+const BYPASS_SECRET = "vercel-automation-bypass-at-least-32-bytes";
 const NOW_MS = Date.parse("2026-08-02T12:00:00.000Z");
 const TARGET = "https://programmable-stage-abc.vercel.app";
 
@@ -34,6 +35,7 @@ describe("read-model projector wake canary", () => {
       expect(init?.method).toBe("POST");
       expect(init?.redirect).toBe("error");
       const headers = new Headers(init?.headers);
+      expect(headers.get("x-vercel-protection-bypass")).toBe(BYPASS_SECRET);
       const nonce = headers.get("x-qn-nonce") ?? "";
       const timestamp = headers.get("x-qn-timestamp") ?? "";
       const signature = headers.get("x-qn-signature") ?? "";
@@ -57,7 +59,10 @@ describe("read-model projector wake canary", () => {
 
     const result = await runProjectorWakeCanary({
       targetUrl: TARGET,
-      environment: { PROGRAMMABLE_QUICKNODE_STREAM_SECRET: SECRET },
+      environment: {
+        PROGRAMMABLE_QUICKNODE_STREAM_SECRET: SECRET,
+        VERCEL_AUTOMATION_BYPASS_SECRET: BYPASS_SECRET,
+      },
       fetchImpl,
       nowMs: NOW_MS,
       nonceFactory: (id: string) => `nonce-${id}-0123456789abcdef`,
@@ -86,6 +91,7 @@ describe("read-model projector wake canary", () => {
     expect(new Set(observations.map(({ nonce }) => nonce)).size).toBe(3);
     const serialized = JSON.stringify(result);
     expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain(BYPASS_SECRET);
     for (const observation of observations) {
       expect(serialized).not.toContain(observation.nonce);
     }
@@ -101,9 +107,18 @@ describe("read-model projector wake canary", () => {
     await expect(
       runProjectorWakeCanary({
         targetUrl: "https://programmable.family",
-        environment: { PROGRAMMABLE_QUICKNODE_STREAM_SECRET: SECRET },
+        environment: {
+          PROGRAMMABLE_QUICKNODE_STREAM_SECRET: SECRET,
+          VERCEL_AUTOMATION_BYPASS_SECRET: BYPASS_SECRET,
+        },
       }),
     ).rejects.toThrow("deployment-specific Vercel HTTPS origin");
+    await expect(
+      runProjectorWakeCanary({
+        targetUrl: TARGET,
+        environment: { PROGRAMMABLE_QUICKNODE_STREAM_SECRET: SECRET },
+      }),
+    ).rejects.toThrow("automation bypass is unavailable or invalid");
   });
 
   it("fails when any exact response contract drifts", async () => {
@@ -116,7 +131,10 @@ describe("read-model projector wake canary", () => {
     await expect(
       runProjectorWakeCanary({
         targetUrl: TARGET,
-        environment: { PROGRAMMABLE_QUICKNODE_STREAM_SECRET: SECRET },
+        environment: {
+          PROGRAMMABLE_QUICKNODE_STREAM_SECRET: SECRET,
+          VERCEL_AUTOMATION_BYPASS_SECRET: BYPASS_SECRET,
+        },
         fetchImpl,
         nowMs: NOW_MS,
         nonceFactory: () => "0123456789abcdef0123456789abcdef",
@@ -134,7 +152,10 @@ describe("read-model projector wake canary", () => {
     try {
       await runProjectorWakeCanary({
         targetUrl: TARGET,
-        environment: { PROGRAMMABLE_QUICKNODE_STREAM_SECRET: SECRET },
+        environment: {
+          PROGRAMMABLE_QUICKNODE_STREAM_SECRET: SECRET,
+          VERCEL_AUTOMATION_BYPASS_SECRET: BYPASS_SECRET,
+        },
         fetchImpl,
         nowMs: NOW_MS,
         nonceFactory: () => "0123456789abcdef0123456789abcdef",


### PR DESCRIPTION
## Summary
- send the existing Vercel automation bypass header on all staged QuickNode wake canary probes
- bind the bypass to the production GitHub environment and release source contract
- fail closed when either server-side secret is absent or public-prefixed

## Validation
- `npm test -- --run tests/data-pipeline/read-model-projector-wake-canary.test.ts tests/data-pipeline/read-model-ops-contract.test.ts` (22/22)
- `npm run perf:read-model:ops-gate`
- `npm run typecheck`
- `npm run lint`

## Release note
This does not promote or deploy production. The exposed prior automation-bypass entry must be rotated and the replacement saved as the production-environment `VERCEL_AUTOMATION_BYPASS_SECRET` before dispatching the stage workflow.