### PR TITLE
fix(data-pipeline): attest final candidate backups

### DIFF
--- a/scripts/data-pipeline/candidate-restore.mjs
+++ b/scripts/data-pipeline/candidate-restore.mjs
@@ -23,6 +23,7 @@ import postgres from "postgres";
 
 import {
   BACKUP_SCHEMAS,
+  FINAL_BACKUP_SCHEMAS,
   ROLE_SPECS,
   captureDatabaseManifest,
   createBackupAndRestoreEvidence,
@@ -1047,6 +1048,7 @@ export async function createCandidateSafetyBackup(input) {
       restoreDatabaseUrl: input.restoreDatabaseUrl,
       restoreIsolationId: input.restoreIsolationId,
       restoreSslCaPem: input.restoreSslCaPem,
+      schemas: FINAL_BACKUP_SCHEMAS,
       backupPath: input.backupPath,
       evidencePath: input.backupEvidencePath,
       pgDumpBinary: toolchain.paths.pg_dump,

--- a/scripts/data-pipeline/candidate-restore.test.mjs
+++ b/scripts/data-pipeline/candidate-restore.test.mjs
@@ -32,7 +32,7 @@ import {
   validateCandidateSafetyBackupEvidence,
   validatePinnedSnapshotEvidence,
 } from "./candidate-restore.mjs";
-import { ROLE_SPECS } from "./cutover-credentials.mjs";
+import { FINAL_BACKUP_SCHEMAS, ROLE_SPECS } from "./cutover-credentials.mjs";
 import { canonicalJson, sha256 } from "./hosted-db-operator-core.mjs";
 
 const OPERATOR_COMMIT = "a".repeat(40);
@@ -979,6 +979,7 @@ test("safety backup binds structural manifest, CA and exact official toolchain",
           "postgres",
           "cli_login_postgres",
         ]);
+        assert.deepEqual(input.schemas, FINAL_BACKUP_SCHEMAS);
         assert.equal(typeof input.dependencies.runCommand, "function");
         assert.equal(typeof input.dependencies.openHostedDatabase, "function");
         return { evidence: files.safetyRawEvidence };

--- a/scripts/data-pipeline/cutover-credentials.mjs
+++ b/scripts/data-pipeline/cutover-credentials.mjs
@@ -706,6 +706,7 @@ function backupRequestPayload({
   repositoryCommit,
   source,
   restore,
+  schemas,
 }) {
   return {
     kind: "programmable-database-backup-restore-request",
@@ -714,7 +715,7 @@ function backupRequestPayload({
     repositoryCommit,
     source,
     restore,
-    schemas: BACKUP_SCHEMAS,
+    schemas,
     format: "targeted-schema-backup-v2",
   };
 }
@@ -741,6 +742,13 @@ function validateBackupRequest(input) {
     input.restoreDatabaseUrl,
     input.restoreIsolationId,
   );
+  const schemas = Object.freeze([...(input.schemas ?? BACKUP_SCHEMAS)]);
+  if (
+    canonicalJson(schemas) !== canonicalJson(BACKUP_SCHEMAS) &&
+    canonicalJson(schemas) !== canonicalJson(FINAL_BACKUP_SCHEMAS)
+  ) {
+    throw new Error("backup schema stage is invalid");
+  }
   const backupPath = validateAbsoluteOutputPath(input.backupPath, "backup path");
   const evidencePath = validateAbsoluteOutputPath(
     input.evidencePath,
@@ -754,12 +762,14 @@ function validateBackupRequest(input) {
     repositoryCommit: input.repositoryCommit,
     source: source.safeTarget,
     restore: restore.safeTarget,
+    schemas,
   });
   return {
     operationId: input.operationId,
     repositoryCommit: input.repositoryCommit,
     source,
     restore,
+    schemas,
     sslCaPem,
     restoreSslCaPem,
     backupPath,
@@ -1038,7 +1048,15 @@ function roleBootstrapSql() {
         nologin nosuperuser nocreatedb nocreaterole noinherit
         noreplication nobypassrls;`,
   ).join("\n");
-  return `do $programmable_restore_roles$ begin ${body}\nend $programmable_restore_roles$;`;
+  return `do $programmable_restore_roles$ begin ${body}\nend $programmable_restore_roles$;
+alter default privileges for role programmable_migrator
+  revoke execute on functions from public;
+alter default privileges for role programmable_migrator
+  grant execute on functions to programmable_migrator;
+alter default privileges for role programmable_migrator
+  revoke usage on types from public;
+alter default privileges for role programmable_migrator
+  grant usage on types to programmable_migrator;`;
 }
 
 function quoteIdentifier(value) {
@@ -2230,7 +2248,9 @@ export async function createBackupAndRestoreEvidence(input) {
       safeTarget: request.restore.safeTarget,
     });
     await assertRestoreEmpty(restoreConnection.sql, request.restore.safeTarget);
-    const before = await captureManifest(sourceConnection.sql);
+    const before = await captureManifest(sourceConnection.sql, {
+      schemas: request.schemas,
+    });
     if (
       !SHA256.test(before?.manifestSha256 ?? "") ||
       !SHA256.test(before?.structuralManifestSha256 ?? "") ||
@@ -2303,7 +2323,7 @@ export async function createBackupAndRestoreEvidence(input) {
         ...(request.source.username === "cli_login_postgres"
           ? ["--role", "postgres"]
           : []),
-        ...BACKUP_SCHEMAS.flatMap((schema) => ["--schema", schema]),
+        ...request.schemas.flatMap((schema) => ["--schema", schema]),
         ...commandTargetArguments(request.source.safeTarget, request.source.username),
         "--file",
         request.backupPath,
@@ -2319,7 +2339,9 @@ export async function createBackupAndRestoreEvidence(input) {
       });
       await chmod(request.backupPath, 0o600);
     }
-    const after = await captureManifest(sourceConnection.sql);
+    const after = await captureManifest(sourceConnection.sql, {
+      schemas: request.schemas,
+    });
     if (
       after?.manifestSha256 !== before.manifestSha256 ||
       after?.structuralManifestSha256 !== before.structuralManifestSha256 ||
@@ -2386,7 +2408,9 @@ export async function createBackupAndRestoreEvidence(input) {
         throw new Error("Postgres backup changed during isolated restore");
       }
     }
-    const restored = await captureManifest(restoreConnection.sql);
+    const restored = await captureManifest(restoreConnection.sql, {
+      schemas: request.schemas,
+    });
     if (
       restored?.manifestSha256 !== before.manifestSha256 ||
       !SHA256.test(restored?.structuralManifestSha256 ?? "") ||
@@ -2411,6 +2435,7 @@ export async function createBackupAndRestoreEvidence(input) {
       requestSha256: request.requestSha256,
       source: request.source.safeTarget,
       restore: request.restore.safeTarget,
+      schemas: request.schemas,
       backup: Object.freeze({
         format: backupFormat,
         sha256: backup.sha256,

--- a/scripts/data-pipeline/cutover-credentials.test.mjs
+++ b/scripts/data-pipeline/cutover-credentials.test.mjs
@@ -5,6 +5,8 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  BACKUP_SCHEMAS,
+  FINAL_BACKUP_SCHEMAS,
   ROLE_SPECS,
   canonicalizePostgresAclRows,
   canonicalizePostgresDefinition,
@@ -838,6 +840,7 @@ test("createBackupAndRestoreEvidence keeps secrets in child env and proves an is
   assert.equal(result.evidence.tableCount, 27);
   assert.equal(result.evidence.rowCount, 265);
   assert.equal(result.evidence.backup.format, "pg-custom-v1");
+  assert.deepEqual(result.evidence.schemas, BACKUP_SCHEMAS);
   assert.equal(result.evidence.postgresVersion, "PostgreSQL 17.6");
   assert.equal(harness.closeCount, 2);
   const dump = harness.calls.find(
@@ -866,6 +869,22 @@ test("createBackupAndRestoreEvidence keeps secrets in child env and proves an is
     assert.match(roleSql, new RegExp(loginRole, "u"));
     assert.match(roleSql, new RegExp(capabilityRole, "u"));
   }
+  assert.match(
+    roleSql,
+    /alter default privileges for role programmable_migrator\s+revoke execute on functions from public/iu,
+  );
+  assert.match(
+    roleSql,
+    /alter default privileges for role programmable_migrator\s+grant execute on functions to programmable_migrator/iu,
+  );
+  assert.match(
+    roleSql,
+    /alter default privileges for role programmable_migrator\s+revoke usage on types from public/iu,
+  );
+  assert.match(
+    roleSql,
+    /alter default privileges for role programmable_migrator\s+grant usage on types to programmable_migrator/iu,
+  );
   const [backupMode, evidenceMode] = await Promise.all([
     lstat(fixture.input.backupPath),
     lstat(fixture.input.evidencePath),
@@ -879,6 +898,51 @@ test("createBackupAndRestoreEvidence keeps secrets in child env and proves an is
   for (const caPath of harness.caPaths) {
     await assert.rejects(lstat(caPath), { code: "ENOENT" });
   }
+});
+
+test("createBackupAndRestoreEvidence binds and restores the final schema stage", async (t) => {
+  const fixture = await backupFixture();
+  t.after(() => rm(fixture.directory, { recursive: true, force: true }));
+  const observedSchemas = [];
+  const harness = backupDependencies(fixture, {
+    captureDatabaseManifest: async (_sql, options) => {
+      observedSchemas.push(options.schemas);
+      return manifest();
+    },
+  });
+  const result = await createBackupAndRestoreEvidence({
+    ...fixture.input,
+    schemas: FINAL_BACKUP_SCHEMAS,
+    dependencies: harness.dependencies,
+  });
+  assert.deepEqual(result.evidence.schemas, FINAL_BACKUP_SCHEMAS);
+  assert.deepEqual(observedSchemas, [
+    FINAL_BACKUP_SCHEMAS,
+    FINAL_BACKUP_SCHEMAS,
+    FINAL_BACKUP_SCHEMAS,
+  ]);
+  const dump = harness.calls.find(
+    ({ binary, args }) => binary === "pg_dump" && !args.includes("--version"),
+  );
+  assert.ok(dump);
+  assert.deepEqual(
+    dump.args.flatMap((value, index) =>
+      value === "--schema" ? [dump.args[index + 1]] : []
+    ),
+    FINAL_BACKUP_SCHEMAS,
+  );
+});
+
+test("createBackupAndRestoreEvidence rejects an unreviewed schema stage", async (t) => {
+  const fixture = await backupFixture();
+  t.after(() => rm(fixture.directory, { recursive: true, force: true }));
+  await assert.rejects(
+    createBackupAndRestoreEvidence({
+      ...fixture.input,
+      schemas: ["programmable_private"],
+    }),
+    /backup schema stage is invalid/u,
+  );
 });
 
 test("createBackupAndRestoreEvidence accepts only portable-equivalent cross-build structure", async (t) => {

--- a/scripts/data-pipeline/cutover-operator.mjs
+++ b/scripts/data-pipeline/cutover-operator.mjs
@@ -15,6 +15,8 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import {
+  BACKUP_SCHEMAS,
+  FINAL_BACKUP_SCHEMAS,
   ROLE_SPECS,
   createBackupAndRestoreEvidence,
   provisionLoginRoles,
@@ -77,7 +79,7 @@ const PRIVATE_MODE = 0o600;
 export const HELP = `Usage:
   node scripts/data-pipeline/cutover-operator.mjs roles-provision --expected-project-ref REF --output FILE
   node scripts/data-pipeline/cutover-operator.mjs roles-verify --expected-project-ref REF --pooler-host HOST --output FILE
-  node scripts/data-pipeline/cutover-operator.mjs backup-restore --expected-project-ref REF --operation-id ID --restore-isolation-id ID --backup FILE --evidence FILE
+  node scripts/data-pipeline/cutover-operator.mjs backup-restore --expected-project-ref REF --operation-id ID --restore-isolation-id ID --backup FILE --evidence FILE [--schema-stage initial|final]
   node scripts/data-pipeline/cutover-operator.mjs candidate-safety-backup --expected-project-ref REF --current-product-commit COMMIT --operation-id ID --restore-isolation-id ID --backup FILE --backup-evidence FILE --output FILE
   node scripts/data-pipeline/cutover-operator.mjs candidate-restore-plan --expected-project-ref REF --current-product-commit COMMIT --snapshot-repository-commit COMMIT --snapshot-backup FILE --snapshot-evidence FILE --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --output FILE
   node scripts/data-pipeline/cutover-operator.mjs candidate-restore-apply --expected-project-ref REF --current-product-commit COMMIT --snapshot-repository-commit COMMIT --snapshot-backup FILE --snapshot-evidence FILE --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --plan FILE --confirm-restore SHA256 --output FILE
@@ -145,6 +147,12 @@ function boundedCycles(value) {
     throw new Error("maximum cycles is invalid");
   }
   return parsed;
+}
+
+export function backupSchemas(value) {
+  if (value === undefined || value === "initial") return BACKUP_SCHEMAS;
+  if (value === "final") return FINAL_BACKUP_SCHEMAS;
+  throw new Error("backup schema stage is invalid");
 }
 
 export function credentialsFromEnvironment(environment) {
@@ -506,7 +514,7 @@ async function runCommand(command, flags, environment) {
       "--restore-isolation-id",
       "--backup",
       "--evidence",
-    ]);
+    ], ["--schema-stage"]);
     return createBackupAndRestoreEvidence({
       operationId: flags.get("--operation-id"),
       repositoryCommit: await assertCleanCheckout(),
@@ -516,6 +524,7 @@ async function runCommand(command, flags, environment) {
       restoreDatabaseUrl: environment.PROGRAMMABLE_CUTOVER_RESTORE_DATABASE_URL,
       restoreIsolationId: flags.get("--restore-isolation-id"),
       restoreSslCaPem: environment.PROGRAMMABLE_CUTOVER_RESTORE_SSL_CA_PEM,
+      schemas: backupSchemas(flags.get("--schema-stage")),
       backupPath: absoluteExternalPath(flags.get("--backup"), "backup path"),
       evidencePath: absoluteExternalPath(flags.get("--evidence"), "evidence path"),
     });

--- a/scripts/data-pipeline/cutover-operator.test.mjs
+++ b/scripts/data-pipeline/cutover-operator.test.mjs
@@ -8,12 +8,17 @@ import {
   assertAttestationMatchesIdentity,
   assertProjectorDrainEvidence,
   assertStagedGateMatchesDrain,
+  backupSchemas,
   credentialsFromEnvironment,
   evidenceCommitment,
   parseArguments,
   reserveRuntimeEnableOutput,
   runRuntimeEnableWithReservedOutput,
 } from "./cutover-operator.mjs";
+import {
+  BACKUP_SCHEMAS,
+  FINAL_BACKUP_SCHEMAS,
+} from "./cutover-credentials.mjs";
 import {
   createEnvioPromotionAttestation,
   loadEnvioCutoverIdentity,
@@ -54,6 +59,13 @@ test("operator parser rejects positional, duplicate and value-less arguments", (
     () => parseArguments(["roles-provision", "--output", "a", "--output", "b"]),
     /arguments/u,
   );
+});
+
+test("backup schema stage is exact and fail-closed", () => {
+  assert.equal(backupSchemas(), BACKUP_SCHEMAS);
+  assert.equal(backupSchemas("initial"), BACKUP_SCHEMAS);
+  assert.equal(backupSchemas("final"), FINAL_BACKUP_SCHEMAS);
+  assert.throws(() => backupSchemas("partial"), /schema stage/u);
 });
 
 test("credentials are read from five environment-only names", () => {


### PR DESCRIPTION
## Summary
- bind backup evidence to the exact reviewed initial or final schema stage
- include the wake/SLA schema in final Candidate backups and isolated restore verification
- fail closed on unreviewed schema sets

## Validation
- node --test scripts/data-pipeline/cutover-credentials.test.mjs scripts/data-pipeline/candidate-restore.test.mjs scripts/data-pipeline/cutover-operator.test.mjs (54/54)
- targeted ESLint
- git diff --check