### PR TITLE
fix(release): attest Vercel sensitive runtime metadata

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -138,6 +138,13 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
+      - name: Capture sensitive production environment metadata
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          umask 077
+          vercel env ls production --format json --token="$VERCEL_TOKEN" > "$RUNNER_TEMP/vercel-production-env-metadata.json"
+
       - name: Capture current production rollback target
         id: production-before
         env:
@@ -156,6 +163,7 @@ jobs:
         run: >-
           npm run perf:read-model:deploy-policy --
           --env-file .vercel/.env.production.local
+          --sensitive-env-metadata "$RUNNER_TEMP/vercel-production-env-metadata.json"
           --github-output "$GITHUB_OUTPUT"
 
       - name: Build production deployment
@@ -209,6 +217,7 @@ jobs:
         run: >-
           npm run perf:read-model:deploy-policy --
           --env-file .vercel/.env.production.local
+          --sensitive-env-metadata "$RUNNER_TEMP/vercel-production-env-metadata.json"
           --verified-sha "$GITHUB_SHA"
           --vercel-project-id "$VERCEL_PROJECT_ID"
           --staged-deployment-id "$STAGED_DEPLOYMENT_ID"

--- a/scripts/perf/read-model-deploy-policy.mjs
+++ b/scripts/perf/read-model-deploy-policy.mjs
@@ -104,6 +104,59 @@ function readSelectedDotenvValues(contents, selectedNames) {
   return Object.fromEntries(selectedNames.map((name) => [name, values.get(name)]));
 }
 
+export function materializeVercelSensitiveRuntimePlaceholders(
+  contents,
+  metadataContents,
+) {
+  const runtimeValues = readSelectedDotenvValues(
+    contents,
+    RUNTIME_RPC_URL_NAMES,
+  );
+  const emptyNames = RUNTIME_RPC_URL_NAMES.filter(
+    (name) => runtimeValues[name] === "",
+  );
+  if (emptyNames.length === 0) return contents;
+  let metadata;
+  try {
+    metadata = JSON.parse(metadataContents);
+  } catch {
+    throw new Error("Vercel sensitive environment metadata is invalid");
+  }
+  if (
+    metadata === null ||
+    typeof metadata !== "object" ||
+    Array.isArray(metadata) ||
+    !Array.isArray(metadata.envs)
+  ) {
+    throw new Error("Vercel sensitive environment metadata is invalid");
+  }
+  for (const name of emptyNames) {
+    const matches = metadata.envs.filter(
+      (entry) => entry !== null && typeof entry === "object" && entry.key === name,
+    );
+    if (
+      matches.length !== 1 ||
+      matches[0].type !== "sensitive" ||
+      !Array.isArray(matches[0].target) ||
+      matches[0].target.length !== 1 ||
+      matches[0].target[0] !== "production" ||
+      Object.hasOwn(matches[0], "value")
+    ) {
+      throw new Error(`${name} is not exact sensitive production metadata`);
+    }
+  }
+  const materializedNames = new Set(emptyNames);
+  return contents
+    .split(/\r?\n/u)
+    .map((line) => {
+      const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/u.exec(line);
+      return match && materializedNames.has(match[1])
+        ? `${match[1]}="[Sensitive]"`
+        : line;
+    })
+    .join("\n");
+}
+
 export function readReleaseGatedFlags(contents) {
   return readSelectedDotenvValues(contents, RELEASE_GATED_FLAG_NAMES);
 }
@@ -576,8 +629,18 @@ function argumentsFrom(argv) {
 function main() {
   const args = argumentsFrom(process.argv.slice(2));
   const expectations = readReleasePolicyExpectations(process.cwd());
+  const rawEnvironmentContents = readFileSync(
+    resolve(args["env-file"]),
+    "utf8",
+  );
+  const environmentContents = args["sensitive-env-metadata"]
+    ? materializeVercelSensitiveRuntimePlaceholders(
+        rawEnvironmentContents,
+        readFileSync(resolve(args["sensitive-env-metadata"]), "utf8"),
+      )
+    : rawEnvironmentContents;
   const result = evaluateReadModelDeployPolicy(
-    readFileSync(resolve(args["env-file"]), "utf8"),
+    environmentContents,
     process.env,
     expectations,
   );

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -943,6 +943,23 @@ export function evaluateReadModelOperationsSourceContracts(
       deployPolicy.includes("invalidServerSecretEnvironmentNames"),
     "the stream secret name is documented without a value and is fail-closed in deploy policy",
   );
+  check(
+    "ops-vercel-sensitive-runtime-metadata",
+    deployWorkflow.includes(
+      "Capture sensitive production environment metadata",
+    ) &&
+      deployWorkflow.includes(
+        'vercel env ls production --format json --token="$VERCEL_TOKEN" > "$RUNNER_TEMP/vercel-production-env-metadata.json"',
+      ) &&
+      (deployWorkflow.match(/--sensitive-env-metadata/gu) ?? []).length === 2 &&
+      deployPolicy.includes(
+        "materializeVercelSensitiveRuntimePlaceholders",
+      ) &&
+      deployPolicy.includes('matches[0].type !== "sensitive"') &&
+      deployPolicy.includes('matches[0].target[0] !== "production"') &&
+      deployPolicy.includes('Object.hasOwn(matches[0], "value")'),
+    "Vercel empty sensitive placeholders require exact value-free production metadata",
+  );
   const stagedWakeGate = deployWorkflow.indexOf(
     "Gate exact staged QuickNode wake route",
   );

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -12,6 +12,7 @@ import { runtimeProductionProviderBindingsFromUrls } from "../../scripts/perf/re
 const {
   createStagedReleaseAttestation,
   evaluateReadModelDeployPolicy,
+  materializeVercelSensitiveRuntimePlaceholders,
   PROJECTOR_WAKE_ROUTE,
   readReleasePolicyExpectations,
   validateStagedReleaseAttestation,
@@ -77,6 +78,77 @@ function environmentFile(input: {
 }
 
 describe("read-model production deploy policy", () => {
+  it("attests current Vercel empty sensitive values from exact production metadata", () => {
+    const contents = environmentFile({
+      workers: { PROGRAMMABLE_PROJECTOR_ACTIVE: "true" },
+      serverSecrets: {
+        [QUICKNODE_STREAM_SECRET_ENV_NAME]: "[sensitive]",
+      },
+    }).concat(
+      "\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL=\nPROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL=",
+    );
+    const metadata = JSON.stringify({
+      envs: [
+        {
+          key: "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+          type: "sensitive",
+          target: ["production"],
+        },
+        {
+          key: "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
+          type: "sensitive",
+          target: ["production"],
+        },
+      ],
+    });
+    const materialized = materializeVercelSensitiveRuntimePlaceholders(
+      contents,
+      metadata,
+    );
+    expect(materialized).toContain(
+      'PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL="[Sensitive]"',
+    );
+    expect(
+      evaluateReadModelDeployPolicy(materialized, COMMITMENTS, EXPECTATIONS),
+    ).toMatchObject({
+      policyReady: true,
+      commitmentsReady: true,
+      runtimeProviderBinding: "deferred-stage",
+    });
+  });
+
+  it("rejects missing, non-sensitive, preview or value-bearing Vercel metadata", () => {
+    const contents = environmentFile().concat(
+      "\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL=",
+    );
+    for (const entry of [
+      undefined,
+      {
+        key: "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+        type: "plain",
+        target: ["production"],
+      },
+      {
+        key: "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+        type: "sensitive",
+        target: ["preview"],
+      },
+      {
+        key: "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+        type: "sensitive",
+        target: ["production"],
+        value: "must-not-be-present",
+      },
+    ]) {
+      expect(() =>
+        materializeVercelSensitiveRuntimePlaceholders(
+          contents,
+          JSON.stringify({ envs: entry ? [entry] : [] }),
+        ),
+      ).toThrow(/exact sensitive production metadata/u);
+    }
+  });
+
   it("binds legacy-only to exact false indexed flags and disabled workers", () => {
     const policy = evaluateReadModelDeployPolicy(
       environmentFile({
@@ -398,6 +470,13 @@ describe("read-model production deploy policy", () => {
       "utf8",
     );
     expect(workflow).toContain("Attest exact staged release policy");
+    expect(workflow).toContain(
+      "Capture sensitive production environment metadata",
+    );
+    expect(workflow).toContain(
+      'vercel env ls production --format json --token="$VERCEL_TOKEN"',
+    );
+    expect(workflow.match(/--sensitive-env-metadata/g)).toHaveLength(2);
     expect(workflow).toContain("staged-release-attestation.json");
     expect(workflow).toContain("attestation_sha256");
     expect(workflow).toContain("Smoke legacy staged public APIs");


### PR DESCRIPTION
## Summary
- attest Vercel's current empty-string representation of Sensitive production variables from value-free JSON metadata
- keep RPC URLs Sensitive while preserving fail-closed provider commitment checks
- bind both production policy evaluations to the same exact metadata artifact

## Validation
- focused deploy-policy/performance tests: 30/30
- Typecheck
- targeted ESLint
- read-model Ops gate: 30/30
- live production metadata preflight: indexed-or-shadow, commitments ready, deferred-stage binding