### PR TITLE
fix(release): pass bypass to indexed capture

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -394,6 +394,7 @@ jobs:
         env:
           PROGRAMMABLE_PERFORMANCE_PROBE_TOKEN: ${{ secrets.PROGRAMMABLE_PERFORMANCE_PROBE_TOKEN }}
           PROGRAMMABLE_SHADOW_PROBE_TOKEN: ${{ secrets.PROGRAMMABLE_SHADOW_PROBE_TOKEN }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           PROGRAMMABLE_READ_MODEL_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
           PROGRAMMABLE_READ_MODEL_VERCEL_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}
         run: >-

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1038,6 +1038,36 @@ export function evaluateReadModelOperationsSourceContracts(
       !stagedLegacySmokeBlock.includes("console."),
     "the legacy staged API smoke uses the protected deployment bypass only inside its exact step without exposing it",
   );
+  const stagedReadModelCapture = deployWorkflow.indexOf(
+    "Capture staged read-model evidence",
+  );
+  const stagedReadModelCaptureEnd = deployWorkflow.indexOf(
+    "Preserve staged read-model evidence",
+  );
+  const stagedReadModelCaptureBlock =
+    stagedReadModelCapture >= 0 && stagedReadModelCaptureEnd > stagedReadModelCapture
+      ? deployWorkflow.slice(stagedReadModelCapture, stagedReadModelCaptureEnd)
+      : "";
+  check(
+    "ops-protected-indexed-stage-capture",
+    stagedReadModelCapture > stagedLegacySmokeEnd &&
+      stagedReadModelCaptureBlock.includes(
+        "if: steps.read-model-policy.outputs.evidence_required == 'true'",
+      ) &&
+      stagedReadModelCaptureBlock.includes(
+        "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
+      ) &&
+      stagedReadModelCaptureBlock.includes(
+        "PROGRAMMABLE_READ_MODEL_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
+      ) &&
+      stagedReadModelCaptureBlock.includes(
+        "PROGRAMMABLE_READ_MODEL_VERCEL_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}",
+      ) &&
+      !stagedReadModelCaptureBlock.includes(
+        "NEXT_PUBLIC_VERCEL_AUTOMATION_BYPASS_SECRET",
+      ),
+    "the indexed staged capture receives the protected deployment bypass only inside its exact step",
+  );
   check(
     "ops-exact-release-dependency",
     deployWorkflow.includes("needs: release-gate") &&

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -285,6 +285,37 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it("fails closed when the protected indexed staged capture bypass is missing", () => {
+    const workflowPath = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const captureStepStart = workflow.indexOf(
+      "      - name: Capture staged read-model evidence",
+    );
+    const captureStepEnd = workflow.indexOf(
+      "      - name: Preserve staged read-model evidence",
+    );
+    expect(captureStepStart).toBeGreaterThanOrEqual(0);
+    expect(captureStepEnd).toBeGreaterThan(captureStepStart);
+    const captureStep = workflow.slice(captureStepStart, captureStepEnd);
+    const secretLine =
+      "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}\n";
+    expect(captureStep).toContain(secretLine);
+    const unsafeWorkflow =
+      workflow.slice(0, captureStepStart) +
+      captureStep.replace(secretLine, "") +
+      workflow.slice(captureStepEnd);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-indexed-stage-capture",
+    );
+  });
+
   it("fails closed when the legacy staged smoke drops the bypass header", () => {
     const workflowPath = ".github/workflows/deploy-production.yml";
     const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");


### PR DESCRIPTION
## Summary
- pass the existing Vercel Automation Bypass secret only to the staged read-model capture step
- bind the exact step-local secret placement in the operations source contract
- add a fail-closed mutation test for removal of the capture-step secret

## Verification
- npm run perf:read-model:ops-gate (31/31)
- npm test -- --run tests/data-pipeline/read-model-ops-contract.test.ts tests/data-pipeline/performance-contract.test.ts (41/41)
- npm run lint
- npm run typecheck

No secret values, provider configuration, database code, migrations, or application runtime code are changed.
