### PR TITLE
fix: verify Vercel production alias directly

### DIFF
--- a/scripts/data-pipeline/cutover-http.mjs
+++ b/scripts/data-pipeline/cutover-http.mjs
@@ -187,7 +187,8 @@ export async function inspectUnexposedStagedDeployment(input) {
     throw new Error("production domain is invalid");
   }
   const lookup = input.fetchDeployment ?? fetchVercelDeployment;
-  const [candidate, production] = await Promise.all([
+  const resolveAlias = input.resolveAlias ?? resolveVercelAlias;
+  const [candidate, production, productionAlias] = await Promise.all([
     lookup({
       idOrUrl: input.deploymentId,
       token: input.token,
@@ -196,6 +197,12 @@ export async function inspectUnexposedStagedDeployment(input) {
     }),
     lookup({
       idOrUrl: productionDomain,
+      token: input.token,
+      teamId: input.teamId,
+      fetchImpl: input.fetchImpl,
+    }),
+    resolveAlias({
+      alias: productionDomain,
       token: input.token,
       teamId: input.teamId,
       fetchImpl: input.fetchImpl,
@@ -210,7 +217,7 @@ export async function inspectUnexposedStagedDeployment(input) {
     token: input.token,
     teamId: input.teamId,
     fetchImpl: input.fetchImpl,
-    resolveAlias: input.resolveAlias,
+    resolveAlias,
   });
   const projectMatches =
     candidate?.projectId === input.projectId ||
@@ -218,8 +225,8 @@ export async function inspectUnexposedStagedDeployment(input) {
   const productionProjectMatches =
     production?.projectId === input.projectId ||
     production?.project?.id === input.projectId;
-  const productionAliases = deploymentAliases(production);
-  const productionDomainAssigned = aliases.includes(productionDomain);
+  const productionDomainAssigned = productionAlias?.deploymentId === input.deploymentId;
+  const productionDomainCurrent = productionAlias?.deploymentId === production?.id;
   const schedulerExposure = candidate?.id === production?.id;
   if (
     candidate?.id !== input.deploymentId ||
@@ -234,7 +241,7 @@ export async function inspectUnexposedStagedDeployment(input) {
     production?.readyState !== "READY" ||
     production?.target !== "production" ||
     !productionProjectMatches ||
-    !productionAliases.includes(productionDomain) ||
+    !productionDomainCurrent ||
     !/^[0-9a-f]{40}$/u.test(deploymentCommit(production) ?? "")
   ) {
     throw new Error("staged deployment is exposed, aliased or not exactly bound");

--- a/scripts/data-pipeline/cutover-http.test.mjs
+++ b/scripts/data-pipeline/cutover-http.test.mjs
@@ -232,15 +232,20 @@ test("staged exposure gate accepts only the exact unaliased deployment", async (
     readyState: "READY",
     target: "production",
     projectId,
-    alias: ["programmable.family"],
+    alias: [],
     meta: { githubCommitSha: productionCommit },
   };
   const fetchDeployment = async ({ idOrUrl }) =>
     idOrUrl === DEPLOYMENT ? candidate : production;
-  const resolveAlias = async ({ alias }) =>
-    candidate.alias.includes(alias)
-      ? { alias, deploymentId: DEPLOYMENT }
+  let productionAliasDeploymentId = production.id;
+  const resolveAlias = async ({ alias }) => {
+    if (candidate.alias.includes(alias)) {
+      return { alias, deploymentId: DEPLOYMENT };
+    }
+    return alias === "programmable.family"
+      ? { alias, deploymentId: productionAliasDeploymentId }
       : undefined;
+  };
   const result = await inspectUnexposedStagedDeployment({
     targetUrl: "https://launcher-abc.vercel.app/",
     deploymentId: DEPLOYMENT,
@@ -270,7 +275,23 @@ test("staged exposure gate accepts only the exact unaliased deployment", async (
   );
 
   candidate.alias = [];
+  productionAliasDeploymentId = "dpl_11111111111111111111";
+  await assert.rejects(
+    inspectUnexposedStagedDeployment({
+      targetUrl: "https://launcher-abc.vercel.app/",
+      deploymentId: DEPLOYMENT,
+      productCommit: candidateCommit,
+      projectId,
+      token: "v".repeat(32),
+      teamId: "team_123",
+      fetchDeployment,
+      resolveAlias,
+    }),
+    /exposed, aliased or not exactly bound/u,
+  );
+
   production.id = DEPLOYMENT;
+  productionAliasDeploymentId = production.id;
   await assert.rejects(
     inspectUnexposedStagedDeployment({
       targetUrl: "https://launcher-abc.vercel.app/",


### PR DESCRIPTION
The cutover exposure gate now verifies programmable.family through the Vercel alias control-plane endpoint instead of relying on deployment alias arrays that no longer contain custom domains.

Validation:
- live control-plane probe accepts the exact unaliased 42f44a8 candidate and confirms production remains on acf3a045
- 15 focused cutover tests pass
- typecheck passes
- ESLint passes
- read-model ops gate 31/31 passes
- full Vitest: 1,839 pass; 7 unrelated local failures require Forge artifacts/submodules absent from this isolated worktree and are covered by the fresh contract Required Check
