### PR TITLE
fix(release): report staged capture rejection

### DIFF
--- a/scripts/perf/read-model-capture.mjs
+++ b/scripts/perf/read-model-capture.mjs
@@ -1122,7 +1122,19 @@ async function runtimeEvidence(input) {
       declaredLength > MAX_RUNTIME_EVIDENCE_BYTES) ||
     response.headers.get("cache-control") !== "private, no-store"
   ) {
-    throw new Error("staged runtime evidence endpoint rejected the capture");
+    const rawVercelError = response.headers.get("x-vercel-error");
+    const vercelError =
+      typeof rawVercelError === "string" &&
+      /^[A-Z0-9_]{1,64}$/u.test(rawVercelError)
+        ? rawVercelError
+        : "missing";
+    const cacheControl =
+      response.headers.get("cache-control") === "private, no-store"
+        ? "expected"
+        : "unexpected";
+    throw new Error(
+      `staged runtime evidence endpoint rejected the capture (status=${response.status}, cacheControl=${cacheControl}, declaredLength=${Number.isFinite(declaredLength) ? declaredLength : "unknown"}, vercelError=${vercelError})`,
+    );
   }
   const bytes = Buffer.from(await response.arrayBuffer());
   const completedAtMs = Date.now();

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -1,4 +1,5 @@
 import { createHmac } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import {
   mkdtempSync,
   readFileSync,
@@ -7,6 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -422,6 +424,55 @@ afterEach(() => {
 });
 
 describe("read-model performance contract", () => {
+  it("reports safe HTTP metadata when the staged runtime capture is rejected", () => {
+    const directory = mkdtempSync(join(tmpdir(), "read-model-capture-rejection-"));
+    temporaryDirectories.push(directory);
+    const fetchFixturePath = join(directory, "rejected-fetch.mjs");
+    writeFileSync(
+      fetchFixturePath,
+      `globalThis.fetch = async () => new Response(JSON.stringify({ error: "private runtime detail" }), {\n` +
+        `  status: 503,\n` +
+        `  headers: {\n` +
+        `    "cache-control": "private, no-store",\n` +
+        `    "content-type": "application/json",\n` +
+        `    "x-vercel-error": "FUNCTION_INVOCATION_FAILED",\n` +
+        `  },\n` +
+        `});\n`,
+      { mode: 0o600 },
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        resolve(process.cwd(), "scripts/perf/read-model-capture.mjs"),
+        "--target-url",
+        TARGET_URL,
+        "--deployment-id",
+        DEPLOYMENT_ID,
+        "--output-directory",
+        directory,
+        "--kind",
+        "production-canary",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_OPTIONS: `--import=${pathToFileURL(fetchFixturePath).href}`,
+          PROGRAMMABLE_PERFORMANCE_PROBE_TOKEN: "p".repeat(32),
+          PROGRAMMABLE_SHADOW_PROBE_TOKEN: "s".repeat(32),
+          VERCEL_AUTOMATION_BYPASS_SECRET: "b".repeat(32),
+        },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("status=503");
+    expect(result.stderr).toContain("vercelError=FUNCTION_INVOCATION_FAILED");
+    expect(result.stderr).not.toContain("private runtime detail");
+  });
+
   it("signs route-bound release probes without sending the server secret", () => {
     const secret = "s".repeat(32);
     const nonce = `1700000000000-${"55".repeat(32)}-7`;


### PR DESCRIPTION
## Summary
- report only safe HTTP metadata when the staged runtime capture is rejected
- preserve private response bodies and secrets
- add a real CLI regression test for the rejected runtime boundary

## Verification
- `npm test -- --run tests/data-pipeline/performance-contract.test.ts tests/data-pipeline/read-model-ops-contract.test.ts tests/data-pipeline/read-model-performance-capture-route.test.ts` (51/51)
- `npm run perf:read-model:ops-gate` (31/31)
- `npm run lint`
- `npm run typecheck`