### PR TITLE
fix(data): make candidate safety recovery exact

### DIFF
--- a/scripts/data-pipeline/candidate-restore.mjs
+++ b/scripts/data-pipeline/candidate-restore.mjs
@@ -173,13 +173,16 @@ export const CANDIDATE_SAFETY_RECOVERY_FLAGS = Object.freeze([
   "--exit-on-error",
   "--single-transaction",
   "--no-owner",
-  "--no-privileges",
 ]);
 
 const EXPECTED_ARCHIVE_SCHEMA_OWNERS = Object.freeze({
   programmable_private: "programmable_migrator",
   programmable_release_probe_private: "programmable_migrator",
   supabase_migrations: "postgres",
+});
+const EXPECTED_SAFETY_ARCHIVE_SCHEMA_OWNERS = Object.freeze({
+  ...EXPECTED_ARCHIVE_SCHEMA_OWNERS,
+  programmable_wake_private: "programmable_migrator",
 });
 const BASELINE_SECURITY_CLOSURE_URL = new URL(
   "./pinned-pre-attestation-security.sql.gz",
@@ -851,6 +854,37 @@ async function assertCandidateOperatorSession(sql, checkpoint) {
   });
 }
 
+async function withCandidateOperatorSessionHeartbeat({
+  operation,
+  heartbeat,
+  schedule = setInterval,
+  cancel = clearInterval,
+}) {
+  let pendingHeartbeat = Promise.resolve();
+  let heartbeatFailure;
+  const timer = schedule(() => {
+    pendingHeartbeat = pendingHeartbeat
+      .then(heartbeat)
+      .catch((error) => {
+        heartbeatFailure ??= error;
+      });
+  }, 15_000);
+  timer?.unref?.();
+  let operationResult;
+  let operationFailure;
+  try {
+    operationResult = await operation();
+  } catch (error) {
+    operationFailure = error;
+  } finally {
+    cancel(timer);
+  }
+  await pendingHeartbeat;
+  if (heartbeatFailure) throw heartbeatFailure;
+  if (operationFailure) throw operationFailure;
+  return operationResult;
+}
+
 const RUNTIME_LOGIN_ROLES = Object.freeze(
   ROLE_SPECS.map(({ loginRole }) => loginRole).sort(),
 );
@@ -972,6 +1006,8 @@ export async function createCandidateSafetyBackup(input) {
     "assertRuntimeLoginsFenced",
     "createBackupAndRestoreEvidence",
     "captureDatabaseManifest",
+    "scheduleHeartbeat",
+    "cancelHeartbeat",
   ]);
   const runner = dependencies.runCommand ?? defaultRunCommand;
   const inspectToolchain =
@@ -1035,36 +1071,44 @@ export async function createCandidateSafetyBackup(input) {
       await revalidateToolchain(toolchain);
       return runner(...arguments_);
     };
-    const backupResult = await createBackup({
-      operationId: input.operationId,
-      repositoryCommit: input.repositoryCommit,
-      sourceDatabaseUrl: input.databaseUrl,
-      expectedProjectRef: input.expectedProjectRef,
-      allowedSourceUsernames: Object.freeze([
-        "postgres",
-        "cli_login_postgres",
-      ]),
-      sslCaPem: input.sslCaPem,
-      restoreDatabaseUrl: input.restoreDatabaseUrl,
-      restoreIsolationId: input.restoreIsolationId,
-      restoreSslCaPem: input.restoreSslCaPem,
-      schemas: FINAL_BACKUP_SCHEMAS,
-      backupPath: input.backupPath,
-      evidencePath: input.backupEvidencePath,
-      pgDumpBinary: toolchain.paths.pg_dump,
-      pgRestoreBinary: toolchain.paths.pg_restore,
-      psqlBinary: toolchain.paths.psql,
-      toolCommitments: OFFICIAL_POSTGRES_17_TOOLCHAIN.binaries,
-      dependencies: Object.freeze({
-        runCommand: pinnedRunner,
-        openHostedDatabase: openCandidateDatabase,
+    const backupResult = await withCandidateOperatorSessionHeartbeat({
+      schedule: dependencies.scheduleHeartbeat ?? setInterval,
+      cancel: dependencies.cancelHeartbeat ?? clearInterval,
+      heartbeat: () =>
+        assertOperatorSession(connection.sql, operatorSession),
+      operation: () => createBackup({
+        operationId: input.operationId,
+        repositoryCommit: input.repositoryCommit,
+        sourceDatabaseUrl: input.databaseUrl,
+        expectedProjectRef: input.expectedProjectRef,
+        allowedSourceUsernames: Object.freeze([
+          "postgres",
+          "cli_login_postgres",
+        ]),
+        sslCaPem: input.sslCaPem,
+        restoreDatabaseUrl: input.restoreDatabaseUrl,
+        restoreIsolationId: input.restoreIsolationId,
+        restoreSslCaPem: input.restoreSslCaPem,
+        schemas: FINAL_BACKUP_SCHEMAS,
+        backupPath: input.backupPath,
+        evidencePath: input.backupEvidencePath,
+        pgDumpBinary: toolchain.paths.pg_dump,
+        pgRestoreBinary: toolchain.paths.pg_restore,
+        psqlBinary: toolchain.paths.psql,
+        toolCommitments: OFFICIAL_POSTGRES_17_TOOLCHAIN.binaries,
+        dependencies: Object.freeze({
+          runCommand: pinnedRunner,
+          openHostedDatabase: openCandidateDatabase,
+        }),
       }),
     });
     await assertOperatorSession(connection.sql, operatorSession);
     const afterCandidateState = await inspectState(connection.sql);
     drainedLeases(await inspectLeases(connection.sql));
     await inspectLoginFence(connection.sql);
-    const currentManifest = await captureManifest(connection.sql);
+    const currentManifest = await captureManifest(connection.sql, {
+      schemas: FINAL_BACKUP_SCHEMAS,
+    });
     return buildCandidateSafetyBackupEvidence({
       operatorCommit: input.repositoryCommit,
       currentProductCommit: input.currentProductCommit,
@@ -1425,13 +1469,13 @@ function postgresVersion(stdout) {
   return `PostgreSQL ${match[0]}`;
 }
 
-function archiveSchemas(list) {
+function archiveSchemas(list, expectedOwners = EXPECTED_ARCHIVE_SCHEMA_OWNERS) {
   const owners = {};
   for (const line of list.toString("utf8").split(/\r?\n/u)) {
     const match = /^\d+;\s+\d+\s+\d+\s+SCHEMA\s+-\s+(\S+)\s+(\S+)$/u.exec(line);
     if (match) owners[match[1]] = match[2];
   }
-  if (canonicalJson(owners) !== canonicalJson(EXPECTED_ARCHIVE_SCHEMA_OWNERS)) {
+  if (canonicalJson(owners) !== canonicalJson(expectedOwners)) {
     throw new Error("Candidate archive schema set is not exact");
   }
   return Object.freeze({ ...owners });
@@ -1740,19 +1784,31 @@ export async function assertCandidateSchemaStage(sql, expectedSchemas) {
   }
 }
 
-export async function cleanupCandidateSchemas(sql, closure, posture) {
+export async function cleanupCandidateSchemas(
+  sql,
+  closure,
+  posture,
+  { includePinnedBaselineCleanup = true } = {},
+) {
+  if (typeof includePinnedBaselineCleanup !== "boolean") {
+    throw new Error("Candidate restore cleanup mode is invalid");
+  }
   const statements = partitionClosure(closure, "Candidate cleanup closure");
   await assertRestoreRolePosture(sql, posture);
   await sql.begin(async (transaction) => {
     await transaction.unsafe("set local role programmable_migrator").simple();
-    await transaction.unsafe(LATER_ONLY_RESTRICT_CLEANUP_SQL).simple();
+    if (includePinnedBaselineCleanup) {
+      await transaction.unsafe(LATER_ONLY_RESTRICT_CLEANUP_SQL).simple();
+    }
     if (statements.app) await transaction.unsafe(statements.app).simple();
-    await transaction.unsafe(`
-      alter default privileges for role programmable_migrator
-        grant execute on functions to public;
-      alter default privileges for role programmable_migrator
-        grant usage on types to public;
-    `).simple();
+    if (includePinnedBaselineCleanup) {
+      await transaction.unsafe(`
+        alter default privileges for role programmable_migrator
+          grant execute on functions to public;
+        alter default privileges for role programmable_migrator
+          grant usage on types to public;
+      `).simple();
+    }
     await transaction.unsafe("set local role postgres").simple();
     if (statements.postgresOwned) {
       await transaction.unsafe(statements.postgresOwned).simple();
@@ -1767,26 +1823,46 @@ export async function applyOwnerAndSecurityClosure(
   owners,
   security,
   posture,
+  {
+    expectedSchemas = CANDIDATE_RESTORE_SCHEMAS,
+    replaySecurity = true,
+  } = {},
 ) {
+  const expected = Object.freeze([...expectedSchemas].sort());
+  if (
+    (canonicalJson(expected) !==
+      canonicalJson([...CANDIDATE_RESTORE_SCHEMAS].sort()) &&
+      canonicalJson(expected) !==
+        canonicalJson([...CANDIDATE_FINAL_SCHEMAS].sort())) ||
+    typeof replaySecurity !== "boolean"
+  ) {
+    throw new Error("Candidate owner closure mode is invalid");
+  }
   const ownerLines = owners.sql.trimEnd().split("\n");
   const objectOwners = ownerLines.filter((line) => !line.startsWith("ALTER SCHEMA "));
   const schemaOwners = ownerLines.filter((line) => line.startsWith("ALTER SCHEMA "));
-  if (schemaOwners.length !== CANDIDATE_RESTORE_SCHEMAS.length) {
+  if (schemaOwners.length !== expected.length) {
     throw new Error("Candidate schema owner closure is incomplete");
   }
-  const acl = partitionClosure(security, "Candidate security closure");
+  const migratorSchemas = expected
+    .filter((schema) => schema !== "supabase_migrations")
+    .join(", ");
+  const acl = replaySecurity
+    ? partitionClosure(security, "Candidate security closure")
+    : undefined;
   await assertRestoreRolePosture(sql, posture);
   await sql.begin(async (transaction) => {
-    await transaction.unsafe(`
-      grant create on schema programmable_private,
-        programmable_release_probe_private to programmable_migrator;
-    `).simple();
+    await transaction.unsafe(
+      `grant create on schema ${migratorSchemas} to programmable_migrator;`,
+    ).simple();
     await transaction.unsafe(`${objectOwners.join("\n")}\n`).simple();
     await transaction.unsafe(`${schemaOwners.join("\n")}\n`).simple();
-    await transaction.unsafe("set local role programmable_migrator").simple();
-    if (acl.app) await transaction.unsafe(acl.app).simple();
-    await transaction.unsafe("set local role postgres").simple();
-    if (acl.postgresOwned) await transaction.unsafe(acl.postgresOwned).simple();
+    if (replaySecurity) {
+      await transaction.unsafe("set local role programmable_migrator").simple();
+      if (acl.app) await transaction.unsafe(acl.app).simple();
+      await transaction.unsafe("set local role postgres").simple();
+      if (acl.postgresOwned) await transaction.unsafe(acl.postgresOwned).simple();
+    }
   });
   await assertRestoreRolePosture(sql, posture);
 }
@@ -2072,7 +2148,7 @@ export async function createCandidateRestorePlan(input) {
     throw new Error("Candidate backup archive listing changed");
   }
   archiveSchemas(snapshotList.stdout);
-  archiveSchemas(safetyList.stdout);
+  archiveSchemas(safetyList.stdout, EXPECTED_SAFETY_ARCHIVE_SCHEMA_OWNERS);
   validateArtifact(
     snapshot,
     await commitFile(snapshotFile.path),
@@ -2825,7 +2901,7 @@ export async function createCandidateSafetyRecoveryPlan(input) {
   if (sha256(list.stdout) !== safety.archiveListSha256) {
     throw new Error("Candidate safety archive listing changed");
   }
-  archiveSchemas(list.stdout);
+  archiveSchemas(list.stdout, EXPECTED_SAFETY_ARCHIVE_SCHEMA_OWNERS);
   const prepareClosures =
     dependencies.prepareSafetyRestoreClosures ?? prepareSafetyRestoreClosures;
   const closures = await prepareClosures({
@@ -2862,7 +2938,7 @@ export async function createCandidateSafetyRecoveryPlan(input) {
     }),
     postgresToolchain: toolchain.evidence,
     restore: Object.freeze({
-      schemas: CANDIDATE_RESTORE_SCHEMAS,
+      schemas: CANDIDATE_FINAL_SCHEMAS,
       flags: CANDIDATE_SAFETY_RECOVERY_FLAGS,
       runtimeLoginsRemainFenced: true,
     }),
@@ -2902,7 +2978,7 @@ export function validateCandidateSafetyRecoveryPlan(value) {
     canonicalJson(plan.postgresToolchain) !==
       canonicalJson(OFFICIAL_TOOLCHAIN_EVIDENCE) ||
     canonicalJson(plan.restore?.schemas) !==
-      canonicalJson(CANDIDATE_RESTORE_SCHEMAS) ||
+      canonicalJson(CANDIDATE_FINAL_SCHEMAS) ||
     canonicalJson(plan.restore?.flags) !==
       canonicalJson(CANDIDATE_SAFETY_RECOVERY_FLAGS) ||
     plan.restore?.runtimeLoginsRemainFenced !== true ||
@@ -3041,7 +3117,7 @@ export async function applyCandidateSafetyRecovery(input) {
     dependencies.prepareSafetyRestoreClosures ?? prepareSafetyRestoreClosures;
   const performCleanup =
     dependencies.cleanupCandidateSchemas ?? cleanupCandidateSchemas;
-  const applyClosures =
+  const applyOwners =
     dependencies.applyOwnerAndSecurityClosure ?? applyOwnerAndSecurityClosure;
   const assertSchemaStage =
     dependencies.assertCandidateSchemaStage ?? assertCandidateSchemaStage;
@@ -3126,10 +3202,10 @@ export async function applyCandidateSafetyRecovery(input) {
     await inspectLoginFence(connection.sql);
     let alreadyRecovered = false;
     try {
-      await assertSchemaStage(connection.sql, CANDIDATE_RESTORE_SCHEMAS);
+      await assertSchemaStage(connection.sql, CANDIDATE_FINAL_SCHEMAS);
       const [state, manifest] = await Promise.all([
         inspectState(connection.sql),
-        captureManifest(connection.sql),
+        captureManifest(connection.sql, { schemas: FINAL_BACKUP_SCHEMAS }),
       ]);
       alreadyRecovered =
         canonicalJson(
@@ -3154,7 +3230,9 @@ export async function applyCandidateSafetyRecovery(input) {
       await recheckToolchain(toolchain);
       await assertOperatorSession(connection.sql, operatorSession);
       recoveryStarted = true;
-      await performCleanup(connection.sql, closures.cleanup);
+      await performCleanup(connection.sql, closures.cleanup, undefined, {
+        includePinnedBaselineCleanup: false,
+      });
       await assertOperatorSession(connection.sql, operatorSession);
       await executeSafeTool({
         runner,
@@ -3172,18 +3250,23 @@ export async function applyCandidateSafetyRecovery(input) {
           OFFICIAL_POSTGRES_17_TOOLCHAIN.runtimeLibrariesSha256,
       });
       await assertOperatorSession(connection.sql, operatorSession);
-      await applyClosures(
+      await applyOwners(
         connection.sql,
         closures.owners,
         closures.security,
+        undefined,
+        {
+          expectedSchemas: CANDIDATE_FINAL_SCHEMAS,
+          replaySecurity: false,
+        },
       );
       await assertOperatorSession(connection.sql, operatorSession);
     }
     await inspectLoginFence(connection.sql);
-    await assertSchemaStage(connection.sql, CANDIDATE_RESTORE_SCHEMAS);
+    await assertSchemaStage(connection.sql, CANDIDATE_FINAL_SCHEMAS);
     const [state, manifest] = await Promise.all([
       inspectState(connection.sql),
-      captureManifest(connection.sql),
+      captureManifest(connection.sql, { schemas: FINAL_BACKUP_SCHEMAS }),
     ]);
     if (
       canonicalJson(
@@ -3198,7 +3281,9 @@ export async function applyCandidateSafetyRecovery(input) {
     ) {
       throw new Error("Candidate safety recovery verification failed");
     }
-    const stableManifest = await captureManifest(connection.sql);
+    const stableManifest = await captureManifest(connection.sql, {
+      schemas: FINAL_BACKUP_SCHEMAS,
+    });
     if (canonicalJson(stableManifest) !== canonicalJson(manifest)) {
       throw new Error("Candidate safety recovery manifest is not stable");
     }

--- a/scripts/data-pipeline/candidate-restore.pg17.test.mjs
+++ b/scripts/data-pipeline/candidate-restore.pg17.test.mjs
@@ -10,18 +10,16 @@ import postgres from "postgres";
 
 import {
   CANDIDATE_FINAL_SCHEMAS,
-  CANDIDATE_RESTORE_SCHEMAS,
   CANDIDATE_SAFETY_RECOVERY_FLAGS,
   PINNED_PRE_ATTESTATION_SNAPSHOT,
   applyOwnerAndSecurityClosure,
   assertCandidateSchemaStage,
   cleanupCandidateSchemas,
   prepareSafetyRestoreClosures,
-  readRuntimeRolePosture,
 } from "./candidate-restore.mjs";
 import {
-  BACKUP_SCHEMAS,
   captureDatabaseManifest,
+  FINAL_BACKUP_SCHEMAS,
 } from "./cutover-credentials.mjs";
 import {
   discoverMigrationPlan,
@@ -132,22 +130,6 @@ test(
       PINNED_PRE_ATTESTATION_SNAPSHOT.structuralManifestSha256,
     );
 
-    await runTool(config.pgDump, [
-      "--format=custom",
-      "--file",
-      safetyArchive,
-      "--host",
-      config.host,
-      "--port",
-      config.port,
-      "--username",
-      config.adminUser,
-      "--dbname",
-      database,
-      ...BACKUP_SCHEMAS.flatMap((schema) => ["--schema", schema]),
-    ]);
-    const safetyBytes = await readFile(safetyArchive);
-    const safetySha256 = sha256(safetyBytes);
     const migrationPlan = await discoverMigrationPlan({
       workspace,
       repositoryCommit: "a".repeat(40),
@@ -155,7 +137,7 @@ test(
     const pending = migrationPlan.migrations.slice(
       PINNED_PRE_ATTESTATION_SNAPSHOT.migrationSourceCount,
     );
-    assert.equal(pending.length, 10);
+    assert.equal(pending.length, 13);
     for (const migration of pending) {
       await runTool(config.psql, [
         "-X",
@@ -266,12 +248,24 @@ test(
     });
     assert.equal(
       forward.structuralManifestSha256,
-      "0x8073e412ca77ba6a350c11e0421444049fa8fe644d253e2432465ecec69c5f7d",
+      "0xc015d251ee33b075d49aa7d1a89e755df96ffd4f2748c8c22aad841afe10d2d7",
     );
-    const runtimeRolePosture = await readRuntimeRolePosture(sql);
-    assert.equal(runtimeRolePosture.rows.length, 10);
-    assert.equal(runtimeRolePosture.memberships.length, 5);
-
+    await runTool(config.pgDump, [
+      "--format=custom",
+      "--file",
+      safetyArchive,
+      "--host",
+      config.host,
+      "--port",
+      config.port,
+      "--username",
+      config.adminUser,
+      "--dbname",
+      database,
+      ...FINAL_BACKUP_SCHEMAS.flatMap((schema) => ["--schema", schema]),
+    ]);
+    const safetyBytes = await readFile(safetyArchive);
+    const safetySha256 = sha256(safetyBytes);
     const closures = await prepareSafetyRestoreClosures({
       runner: undefined,
       executeSafeTool: (input) => runTool(input.binary, input.args),
@@ -281,9 +275,12 @@ test(
       environment: Object.freeze({ LANG: "C", LC_ALL: "C" }),
       secrets: [],
     });
-    await cleanupCandidateSchemas(sql, closures.cleanup, {
-      supabaseHosted: false,
-    });
+    await cleanupCandidateSchemas(
+      sql,
+      closures.cleanup,
+      { supabaseHosted: false },
+      { includePinnedBaselineCleanup: false },
+    );
     await runTool(config.pgRestore, [
       ...CANDIDATE_SAFETY_RECOVERY_FLAGS,
       "--host",
@@ -301,11 +298,25 @@ test(
       closures.owners,
       closures.security,
       { supabaseHosted: false },
+      {
+        expectedSchemas: CANDIDATE_FINAL_SCHEMAS,
+        replaySecurity: false,
+      },
     );
-    await assertCandidateSchemaStage(sql, CANDIDATE_RESTORE_SCHEMAS);
-    const recovered = await captureDatabaseManifest(sql);
-    assert.deepEqual(recovered, baseline);
-    const recoveredAgain = await captureDatabaseManifest(sql);
+    await assertCandidateSchemaStage(sql, CANDIDATE_FINAL_SCHEMAS);
+    const recovered = await captureDatabaseManifest(sql, {
+      schemas: FINAL_BACKUP_SCHEMAS,
+    });
+    assert.equal(recovered.manifestSha256, forward.manifestSha256);
+    assert.equal(
+      recovered.portableStructuralManifestSha256,
+      forward.portableStructuralManifestSha256,
+    );
+    assert.equal(recovered.tableCount, forward.tableCount);
+    assert.equal(recovered.rowCount, forward.rowCount);
+    const recoveredAgain = await captureDatabaseManifest(sql, {
+      schemas: FINAL_BACKUP_SCHEMAS,
+    });
     assert.deepEqual(recoveredAgain, recovered);
   },
 );

--- a/scripts/data-pipeline/candidate-restore.test.mjs
+++ b/scripts/data-pipeline/candidate-restore.test.mjs
@@ -10,6 +10,7 @@ import { promisify } from "node:util";
 import {
   CANDIDATE_PROJECT_REF,
   CANDIDATE_PG_RESTRICT_KEY,
+  CANDIDATE_FINAL_SCHEMAS,
   CANDIDATE_RESTORE_FLAGS,
   CANDIDATE_RESTORE_SCHEMAS,
   CANDIDATE_SAFETY_RECOVERY_FLAGS,
@@ -48,6 +49,12 @@ const PINNED_TOC_BROTLI_BASE64 = "W1ZXMyLJ6vUKxjErwHkgUJy+DlaMbUj1bgcRpLJ+2AC1Pt
 const ARCHIVE_LIST = brotliDecompressSync(
   Buffer.from(PINNED_TOC_BROTLI_BASE64, "base64"),
 );
+const SAFETY_ARCHIVE_LIST = Buffer.concat([
+  ARCHIVE_LIST,
+  Buffer.from(
+    "25; 2615 31801 SCHEMA - programmable_wake_private programmable_migrator\n",
+  ),
+]);
 const TARGET = Object.freeze({
   projectRef: CANDIDATE_PROJECT_REF,
   host: `db.${CANDIDATE_PROJECT_REF}.supabase.co`,
@@ -323,7 +330,7 @@ function rawSafetyEvidence(archive) {
       format: "pg-custom-v1",
       sha256: sha256(archive),
       bytes: archive.byteLength,
-      archiveListSha256: sha256(ARCHIVE_LIST),
+      archiveListSha256: sha256(SAFETY_ARCHIVE_LIST),
     },
     sourceManifestSha256: current.manifestSha256,
     restoredManifestSha256: current.manifestSha256,
@@ -456,17 +463,28 @@ function safeToolDependency(calls, hook = () => {}) {
       input.args.includes("--schema-only") &&
       !input.args.includes("--no-owner")
     ) {
+      const wakeOwner =
+        path.basename(input.args.at(-1) ?? "") === "safety.dump"
+          ? "ALTER SCHEMA programmable_wake_private OWNER TO programmable_migrator;\n"
+          : "";
       return {
         stdout: Buffer.from(
           "ALTER SCHEMA programmable_private OWNER TO programmable_migrator;\n" +
             "ALTER SCHEMA programmable_release_probe_private OWNER TO programmable_migrator;\n" +
+            wakeOwner +
             "ALTER SCHEMA supabase_migrations OWNER TO postgres;\n" +
             "GRANT USAGE ON SCHEMA programmable_private TO programmable_api_reader;\n",
         ),
         stderr: Buffer.alloc(0),
       };
     }
-    return { stdout: ARCHIVE_LIST, stderr: Buffer.alloc(0) };
+    return {
+      stdout:
+        path.basename(input.args.at(-1) ?? "") === "safety.dump"
+          ? SAFETY_ARCHIVE_LIST
+          : ARCHIVE_LIST,
+      stderr: Buffer.alloc(0),
+    };
   };
 }
 
@@ -611,6 +629,9 @@ function databaseDependencies(overrides = {}) {
 }
 
 function restoreDatabaseDependencies(overrides = {}, { recovery = false } = {}) {
+  const wakeOwner = recovery
+    ? "ALTER SCHEMA programmable_wake_private OWNER TO programmable_migrator;\n"
+    : "";
   const closures = Object.freeze({
     cleanup: Object.freeze({
       sql: "DROP SCHEMA IF EXISTS programmable_private;\n",
@@ -620,8 +641,9 @@ function restoreDatabaseDependencies(overrides = {}, { recovery = false } = {}) 
       sql:
         "ALTER SCHEMA programmable_private OWNER TO programmable_migrator;\n" +
         "ALTER SCHEMA programmable_release_probe_private OWNER TO programmable_migrator;\n" +
+        wakeOwner +
         "ALTER SCHEMA supabase_migrations OWNER TO postgres;\n",
-      statementCount: 3,
+      statementCount: recovery ? 4 : 3,
     }),
     security: Object.freeze({
       sql: "GRANT USAGE ON SCHEMA programmable_private TO programmable_api_reader;\n",
@@ -933,6 +955,9 @@ test("safety backup binds structural manifest, CA and exact official toolchain",
   const files = await fixture(t);
   const events = [];
   let stateReads = 0;
+  let sessionChecks = 0;
+  let scheduledHeartbeat;
+  const heartbeatTimer = { unref: () => events.push("heartbeat-unref") };
   const evidence = await createCandidateSafetyBackup({
     repositoryCommit: OPERATOR_COMMIT,
     currentProductCommit: CURRENT_PRODUCT_COMMIT,
@@ -958,7 +983,19 @@ test("safety backup binds structural manifest, CA and exact official toolchain",
       }),
       closeHostedDatabase: async () => events.push("close"),
       acquireRestoreLock: async () => events.push("lock"),
-      assertOperatorSession: async () => {},
+      assertOperatorSession: async () => {
+        sessionChecks += 1;
+      },
+      scheduleHeartbeat: (heartbeat, interval) => {
+        assert.equal(interval, 15_000);
+        events.push("heartbeat-scheduled");
+        scheduledHeartbeat = heartbeat;
+        return heartbeatTimer;
+      },
+      cancelHeartbeat: (timer) => {
+        assert.equal(timer, heartbeatTimer);
+        events.push("heartbeat-cancelled");
+      },
       inspectCandidateDatabase: async () => {
         stateReads += 1;
         return candidateState();
@@ -971,6 +1008,8 @@ test("safety backup binds structural manifest, CA and exact official toolchain",
       assertRuntimeLoginsFenced: async () => loginFence(),
       createBackupAndRestoreEvidence: async (input) => {
         events.push("backup");
+        scheduledHeartbeat();
+        await Promise.resolve();
         assert.equal(input.pgDumpBinary, files.paths.pg_dump);
         assert.equal(input.pgRestoreBinary, files.paths.pg_restore);
         assert.equal(input.psqlBinary, files.paths.psql);
@@ -984,11 +1023,23 @@ test("safety backup binds structural manifest, CA and exact official toolchain",
         assert.equal(typeof input.dependencies.openHostedDatabase, "function");
         return { evidence: files.safetyRawEvidence };
       },
-      captureDatabaseManifest: async () => manifest(),
+      captureDatabaseManifest: async (_sql, options) => {
+        assert.deepEqual(options, { schemas: FINAL_BACKUP_SCHEMAS });
+        return manifest();
+      },
     },
   });
   assert.equal(stateReads, 2);
-  assert.deepEqual(events, ["lock", "fence", "backup", "close"]);
+  assert.equal(sessionChecks, 3);
+  assert.deepEqual(events, [
+    "lock",
+    "fence",
+    "heartbeat-scheduled",
+    "heartbeat-unref",
+    "backup",
+    "heartbeat-cancelled",
+    "close",
+  ]);
   assert.equal(evidence.caSha256, sha256(Buffer.from(CA)));
   assert.deepEqual(evidence.operatorIdentity, OPERATOR_IDENTITY);
   assert.deepEqual(evidence.postgresToolchain, TOOLCHAIN_EVIDENCE);
@@ -1023,6 +1074,70 @@ test("safety backup binds structural manifest, CA and exact official toolchain",
     () => buildSafetyEvidence(driftedPortable),
     /portable structure/u,
   );
+});
+
+test("safety backup fails closed when its operator-session heartbeat is lost", async (t) => {
+  const files = await fixture(t);
+  let scheduledHeartbeat;
+  let sessionChecks = 0;
+  let cancelled = 0;
+  let closed = 0;
+  await assert.rejects(
+    createCandidateSafetyBackup({
+      repositoryCommit: OPERATOR_COMMIT,
+      currentProductCommit: CURRENT_PRODUCT_COMMIT,
+      expectedProjectRef: CANDIDATE_PROJECT_REF,
+      databaseUrl: DATABASE_URL,
+      sslCaPem: CA,
+      operationId: "candidate-safety-heartbeat-loss",
+      restoreDatabaseUrl:
+        "postgresql://postgres:isolated@127.0.0.1:55439/programmable_restore_cutover01?sslmode=verify-full",
+      restoreIsolationId: "cutover01",
+      restoreSslCaPem: CA,
+      backupPath: files.safetyBackupPath,
+      backupEvidencePath: path.join(files.directory, "safety-heartbeat.json"),
+      pgDumpBinary: files.paths.pg_dump,
+      pgRestoreBinary: files.paths.pg_restore,
+      psqlBinary: files.paths.psql,
+      dependencies: {
+        validateOfficialToolchain: toolchainDependency(files),
+        openHostedDatabase: async () => ({
+          sql: {},
+          target: TARGET,
+          operatorIdentity: OPERATOR_IDENTITY,
+        }),
+        closeHostedDatabase: async () => {
+          closed += 1;
+        },
+        acquireRestoreLock: async () => {},
+        assertOperatorSession: async () => {
+          sessionChecks += 1;
+          if (sessionChecks === 2) throw new Error("operator session lost");
+        },
+        scheduleHeartbeat: (heartbeat) => {
+          scheduledHeartbeat = heartbeat;
+          return {};
+        },
+        cancelHeartbeat: () => {
+          cancelled += 1;
+        },
+        inspectCandidateDatabase: async () => candidateState(),
+        inspectProjectorLeaseDrain: async () => leases(),
+        fenceRuntimeLogins: async () => loginFence(),
+        assertRuntimeLoginsFenced: async () => loginFence(),
+        createBackupAndRestoreEvidence: async () => {
+          scheduledHeartbeat();
+          await Promise.resolve();
+          return { evidence: files.safetyRawEvidence };
+        },
+        captureDatabaseManifest: async () => manifest(),
+      },
+    }),
+    /Candidate safety backup failed; runtime logins may remain fenced/u,
+  );
+  assert.equal(sessionChecks, 2);
+  assert.equal(cancelled, 1);
+  assert.equal(closed, 1);
 });
 
 test("restore apply resumes postchecks without replaying pg_restore", async (t) => {
@@ -1130,7 +1245,14 @@ test("JIT restore SET ROLEs postgres and uses only the immutable restore set", a
           manifestReads += 1;
           return manifestReads === 1 ? manifest() : manifest({ restored: true });
         },
-        cleanupCandidateSchemas: async () => {
+        cleanupCandidateSchemas: async (
+          _sql,
+          _cleanup,
+          posture,
+          options,
+        ) => {
+          assert.equal(posture, undefined);
+          assert.equal(options, undefined);
           destructiveEvents.push("cleanup");
         },
         applyOwnerAndSecurityClosure: async () => {
@@ -1221,7 +1343,7 @@ test("safety recovery plan binds raw evidence, CA, tools and immutable restore s
     SAFETY_PORTABLE_STRUCTURAL_MANIFEST,
   );
   assert.deepEqual(plan.postgresToolchain, TOOLCHAIN_EVIDENCE);
-  assert.deepEqual(plan.restore.schemas, CANDIDATE_RESTORE_SCHEMAS);
+  assert.deepEqual(plan.restore.schemas, CANDIDATE_FINAL_SCHEMAS);
   assert.deepEqual(plan.restore.flags, CANDIDATE_SAFETY_RECOVERY_FLAGS);
   assert.equal(plan.restore.runtimeLoginsRemainFenced, true);
   assert.equal(calls.length, 3);
@@ -1270,10 +1392,13 @@ test("safety recovery apply is idempotent and never opens runtime logins", async
           fences += 1;
           return loginFence();
         },
-        captureDatabaseManifest: async () => ({
-          ...manifest(),
-          structuralManifestSha256: `0x${"8".repeat(64)}`,
-        }),
+        captureDatabaseManifest: async (_sql, options) => {
+          assert.deepEqual(options, { schemas: FINAL_BACKUP_SCHEMAS });
+          return {
+            ...manifest(),
+            structuralManifestSha256: `0x${"8".repeat(64)}`,
+          };
+        },
       }, { recovery: true }),
       validateOfficialToolchain: toolchainDependency(files),
       fileCommitment: commitmentDependency(files),
@@ -1293,7 +1418,7 @@ test("safety recovery apply is idempotent and never opens runtime logins", async
   assert.match(result.evidenceSha256, /^0x[0-9a-f]{64}$/u);
 });
 
-test("safety recovery orders cleanup, restore and owner/security replay", async (t) => {
+test("safety recovery orders cleanup, archive restore and exact owner replay", async (t) => {
   const files = await fixture(t);
   const plan = await createCandidateSafetyRecoveryPlan({
     repositoryCommit: OPERATOR_COMMIT,
@@ -1335,28 +1460,53 @@ test("safety recovery orders cleanup, restore and owner/security replay", async 
           stateReads += 1;
           return stateReads === 1 ? restoredState() : candidateState();
         },
-        captureDatabaseManifest: async () => {
+        captureDatabaseManifest: async (_sql, options) => {
+          assert.deepEqual(options, { schemas: FINAL_BACKUP_SCHEMAS });
           manifestReads += 1;
           return manifestReads === 1 ? manifest({ restored: true }) : manifest();
         },
-        cleanupCandidateSchemas: async () => {
+        cleanupCandidateSchemas: async (
+          _sql,
+          _cleanup,
+          posture,
+          options,
+        ) => {
+          assert.equal(posture, undefined);
+          assert.deepEqual(options, { includePinnedBaselineCleanup: false });
           destructiveEvents.push("cleanup");
         },
-        applyOwnerAndSecurityClosure: async () => {
-          destructiveEvents.push("owner-security");
+        applyOwnerAndSecurityClosure: async (
+          _sql,
+          _owners,
+          _security,
+          posture,
+          options,
+        ) => {
+          assert.equal(posture, undefined);
+          assert.deepEqual(options, {
+            expectedSchemas: CANDIDATE_FINAL_SCHEMAS,
+            replaySecurity: false,
+          });
+          destructiveEvents.push("owner");
         },
       }, { recovery: true }),
       validateOfficialToolchain: toolchainDependency(files),
       fileCommitment: commitmentDependency(files),
       revalidateToolchain: async () => {},
-      safeToolCall: async () => {
+      safeToolCall: async (input) => {
+        assert.deepEqual(
+          input.args.slice(0, CANDIDATE_SAFETY_RECOVERY_FLAGS.length),
+          CANDIDATE_SAFETY_RECOVERY_FLAGS,
+        );
+        assert.equal(input.args.includes("--no-owner"), true);
+        assert.equal(input.args.includes("--no-privileges"), false);
         destructiveEvents.push("restore");
         return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0) };
       },
     },
   });
   assert.equal(result.executionMode, "restored-from-safety-backup");
-  assert.deepEqual(destructiveEvents, ["cleanup", "restore", "owner-security"]);
+  assert.deepEqual(destructiveEvents, ["cleanup", "restore", "owner"]);
 });
 
 async function restoredResult(files) {


### PR DESCRIPTION
## Summary
- keep the candidate operator session alive during the long safety backup
- validate four-schema safety archives while preserving the three-schema pinned baseline restore
- make safety recovery preserve current ACL/default-privilege state and verify the final four-schema manifest
- update the real PostgreSQL 17 recovery fixture for all 13 post-baseline migrations

## Verification
- `node --test scripts/data-pipeline/candidate-restore.test.mjs` (26/26)
- configured PostgreSQL 17.10 `candidate-restore.pg17.test.mjs` (1/1)
- `npm run typecheck`
- `npm run lint`
- `npm run perf:read-model:ops-gate` (31/31)
- `git diff --check`