### PR TITLE
fix(read-model): restore Candidate from complete safety cleanup

### DIFF
--- a/scripts/data-pipeline/candidate-restore.mjs
+++ b/scripts/data-pipeline/candidate-restore.mjs
@@ -1788,9 +1788,18 @@ export async function cleanupCandidateSchemas(
   sql,
   closure,
   posture,
-  { includePinnedBaselineCleanup = true } = {},
+  {
+    includePinnedBaselineCleanup = true,
+    restorePinnedGlobalDefaults = includePinnedBaselineCleanup,
+    restoreHardenedGlobalDefaults = false,
+  } = {},
 ) {
-  if (typeof includePinnedBaselineCleanup !== "boolean") {
+  if (
+    typeof includePinnedBaselineCleanup !== "boolean" ||
+    typeof restorePinnedGlobalDefaults !== "boolean" ||
+    typeof restoreHardenedGlobalDefaults !== "boolean" ||
+    (restorePinnedGlobalDefaults && restoreHardenedGlobalDefaults)
+  ) {
     throw new Error("Candidate restore cleanup mode is invalid");
   }
   const statements = partitionClosure(closure, "Candidate cleanup closure");
@@ -1801,12 +1810,20 @@ export async function cleanupCandidateSchemas(
       await transaction.unsafe(LATER_ONLY_RESTRICT_CLEANUP_SQL).simple();
     }
     if (statements.app) await transaction.unsafe(statements.app).simple();
-    if (includePinnedBaselineCleanup) {
+    if (restorePinnedGlobalDefaults) {
       await transaction.unsafe(`
         alter default privileges for role programmable_migrator
           grant execute on functions to public;
         alter default privileges for role programmable_migrator
           grant usage on types to public;
+      `).simple();
+    }
+    if (restoreHardenedGlobalDefaults) {
+      await transaction.unsafe(`
+        alter default privileges for role programmable_migrator
+          revoke execute on functions from public;
+        alter default privileges for role programmable_migrator
+          revoke usage on types from public;
       `).simple();
     }
     await transaction.unsafe("set local role postgres").simple();
@@ -2065,6 +2082,7 @@ export async function createCandidateRestorePlan(input) {
     "safeToolCall",
     "schemaSqlSha256",
     "prepareRestoreClosures",
+    "prepareSafetyRestoreClosures",
   ]);
   const runner = dependencies.runCommand ?? defaultRunCommand;
   const executeSafeTool = dependencies.safeToolCall ?? safeToolCall;
@@ -2193,10 +2211,27 @@ export async function createCandidateRestorePlan(input) {
     environment: processEnvironment,
     secrets: input.secrets ?? [],
   });
+  const prepareSafetyClosures =
+    dependencies.prepareSafetyRestoreClosures ??
+    prepareSafetyRestoreClosures;
+  const safetyClosures = await prepareSafetyClosures({
+    runner,
+    executeSafeTool,
+    pgRestoreBinary: toolchain.paths.pg_restore,
+    archivePath: safetyFile.path,
+    restrictKey: safety.sha256.slice(2),
+    environment: processEnvironment,
+    secrets: input.secrets ?? [],
+  });
   validateArtifact(
     snapshot,
     await commitFile(snapshotFile.path),
     "snapshot backup",
+  );
+  validateArtifact(
+    safety,
+    await commitFile(safetyFile.path),
+    "safety backup",
   );
   const migrationSourceClosure =
     await verifyPinnedBaselineMigrationSourceClosure();
@@ -2251,6 +2286,8 @@ export async function createCandidateRestorePlan(input) {
     safetyBackup: Object.freeze({
       ...safety,
       safetyEvidenceSha256: safetyEvidence.evidenceSha256,
+      cleanClosureSha256: sha256(Buffer.from(safetyClosures.cleanup.sql)),
+      cleanClosureStatementCount: safetyClosures.cleanup.statementCount,
     }),
     postgresToolchain: toolchain.evidence,
     restore: Object.freeze({
@@ -2340,6 +2377,9 @@ export function validateCandidateRestorePlan(value) {
     !SHA256.test(plan.safetyBackup?.manifestSha256 ?? "") ||
     !SHA256.test(plan.safetyBackup?.structuralManifestSha256 ?? "") ||
     !SHA256.test(plan.safetyBackup?.portableStructuralManifestSha256 ?? "") ||
+    !SHA256.test(plan.safetyBackup?.cleanClosureSha256 ?? "") ||
+    !Number.isSafeInteger(plan.safetyBackup?.cleanClosureStatementCount) ||
+    plan.safetyBackup.cleanClosureStatementCount < 1 ||
     !Number.isSafeInteger(plan.safetyBackup?.bytes) ||
     plan.safetyBackup.bytes <= 0 ||
     canonicalJson(plan.postgresToolchain) !==
@@ -2537,6 +2577,7 @@ export async function applyCandidateRestore(input) {
     "captureDatabaseManifest",
     "migrationCount",
     "prepareRestoreClosures",
+    "prepareSafetyRestoreClosures",
     "cleanupCandidateSchemas",
     "applyOwnerAndSecurityClosure",
     "assertCandidateSchemaStage",
@@ -2565,6 +2606,9 @@ export async function applyCandidateRestore(input) {
   const readMigrationCount = dependencies.migrationCount ?? migrationCount;
   const prepareClosures =
     dependencies.prepareRestoreClosures ?? preparePinnedRestoreClosures;
+  const prepareSafetyClosures =
+    dependencies.prepareSafetyRestoreClosures ??
+    prepareSafetyRestoreClosures;
   const performCleanup =
     dependencies.cleanupCandidateSchemas ?? cleanupCandidateSchemas;
   const applyClosures =
@@ -2576,6 +2620,7 @@ export async function applyCandidateRestore(input) {
   let toolchain;
   let snapshotCopy;
   let closures;
+  let safetyCleanup;
   let restoreStarted = false;
   try {
     const inspectedToolchain = await inspectToolchain({
@@ -2619,6 +2664,29 @@ export async function applyCandidateRestore(input) {
       environment: Object.freeze({ LANG: "C", LC_ALL: "C" }),
       secrets: [password, input.databaseUrl, caPem],
     });
+    const safetyClosures = await prepareSafetyClosures({
+      runner,
+      executeSafeTool,
+      pgRestoreBinary: toolchain.paths.pg_restore,
+      archivePath: safetyFile.path,
+      restrictKey: plan.safetyBackup.sha256.slice(2),
+      environment: Object.freeze({ LANG: "C", LC_ALL: "C" }),
+      secrets: [password, input.databaseUrl, caPem],
+    });
+    if (
+      sha256(Buffer.from(safetyClosures.cleanup.sql)) !==
+        plan.safetyBackup.cleanClosureSha256 ||
+      safetyClosures.cleanup.statementCount !==
+        plan.safetyBackup.cleanClosureStatementCount
+    ) {
+      throw new Error("Candidate safety cleanup closure changed after review");
+    }
+    safetyCleanup = safetyClosures.cleanup;
+    validateArtifact(
+      plan.safetyBackup,
+      await commitFile(safetyFile.path),
+      "safety backup",
+    );
     connection = await openDatabase({
       databaseUrl: input.databaseUrl,
       expectedProjectRef: input.expectedProjectRef,
@@ -2684,7 +2752,10 @@ export async function applyCandidateRestore(input) {
       await recheckToolchain(toolchain);
       await assertOperatorSession(connection.sql, operatorSession);
       restoreStarted = true;
-      await performCleanup(connection.sql, closures.cleanup);
+      await performCleanup(connection.sql, safetyCleanup, undefined, {
+        includePinnedBaselineCleanup: false,
+        restorePinnedGlobalDefaults: true,
+      });
       await assertOperatorSession(connection.sql, operatorSession);
       await executeSafeTool({
         runner,
@@ -3235,6 +3306,7 @@ export async function applyCandidateSafetyRecovery(input) {
       recoveryStarted = true;
       await performCleanup(connection.sql, closures.cleanup, undefined, {
         includePinnedBaselineCleanup: false,
+        restoreHardenedGlobalDefaults: true,
       });
       await assertOperatorSession(connection.sql, operatorSession);
       await executeSafeTool({

--- a/scripts/data-pipeline/candidate-restore.pg17.test.mjs
+++ b/scripts/data-pipeline/candidate-restore.pg17.test.mjs
@@ -10,6 +10,8 @@ import postgres from "postgres";
 
 import {
   CANDIDATE_FINAL_SCHEMAS,
+  CANDIDATE_RESTORE_FLAGS,
+  CANDIDATE_RESTORE_SCHEMAS,
   CANDIDATE_SAFETY_RECOVERY_FLAGS,
   PINNED_PRE_ATTESTATION_SNAPSHOT,
   applyOwnerAndSecurityClosure,
@@ -76,6 +78,7 @@ test(
     const directory = await mkdtemp(
       path.join(os.tmpdir(), "programmable-candidate-pg17-it-"),
     );
+    const baselineArchive = path.join(directory, "baseline.dump");
     const safetyArchive = path.join(directory, "safety.dump");
     const admin = postgres({
       host: config.host,
@@ -129,6 +132,31 @@ test(
       baseline.structuralManifestSha256,
       PINNED_PRE_ATTESTATION_SNAPSHOT.structuralManifestSha256,
     );
+    await runTool(config.pgDump, [
+      "--format=custom",
+      "--file",
+      baselineArchive,
+      "--host",
+      config.host,
+      "--port",
+      config.port,
+      "--username",
+      config.adminUser,
+      "--dbname",
+      database,
+      ...CANDIDATE_RESTORE_SCHEMAS.flatMap((schema) => ["--schema", schema]),
+    ]);
+    const baselineBytes = await readFile(baselineArchive);
+    const baselineSha256 = sha256(baselineBytes);
+    const baselineClosures = await prepareSafetyRestoreClosures({
+      runner: undefined,
+      executeSafeTool: (input) => runTool(input.binary, input.args),
+      pgRestoreBinary: config.pgRestore,
+      archivePath: baselineArchive,
+      restrictKey: baselineSha256.slice(2),
+      environment: Object.freeze({ LANG: "C", LC_ALL: "C" }),
+      secrets: [],
+    });
 
     const migrationPlan = await discoverMigrationPlan({
       workspace,
@@ -279,7 +307,109 @@ test(
       sql,
       closures.cleanup,
       { supabaseHosted: false },
-      { includePinnedBaselineCleanup: false },
+      {
+        includePinnedBaselineCleanup: false,
+        restorePinnedGlobalDefaults: true,
+      },
+    );
+    const remainingSchemas = await sql.unsafe(`
+      select namespace.nspname
+        from pg_catalog.pg_namespace as namespace
+       where namespace.nspname = any($1::text[])
+       order by namespace.nspname
+    `, [CANDIDATE_FINAL_SCHEMAS]);
+    assert.deepEqual(remainingSchemas.map(({ nspname }) => nspname), []);
+    const restoredGlobalDefaults = await sql.unsafe(`
+      select default_acl.defaclobjtype,
+             default_acl.defaclacl::text as acl
+        from pg_catalog.pg_default_acl as default_acl
+        join pg_catalog.pg_roles as owner_role
+          on owner_role.oid = default_acl.defaclrole
+       where owner_role.rolname = 'programmable_migrator'
+         and default_acl.defaclnamespace = 0
+       order by default_acl.defaclobjtype
+    `);
+    assert.deepEqual(restoredGlobalDefaults.map((row) => ({ ...row })), []);
+    await runTool(config.pgRestore, [
+      ...CANDIDATE_RESTORE_FLAGS,
+      "--host",
+      config.host,
+      "--port",
+      config.port,
+      "--username",
+      "postgres",
+      "--dbname",
+      database,
+      baselineArchive,
+    ]);
+    await applyOwnerAndSecurityClosure(
+      sql,
+      baselineClosures.owners,
+      baselineClosures.security,
+      { supabaseHosted: false },
+    );
+    await assertCandidateSchemaStage(sql, CANDIDATE_RESTORE_SCHEMAS);
+    const pinned = await captureDatabaseManifest(sql);
+    assert.equal(pinned.manifestSha256, baseline.manifestSha256);
+    assert.equal(
+      pinned.portableStructuralManifestSha256,
+      baseline.portableStructuralManifestSha256,
+    );
+    assert.equal(pinned.tableCount, baseline.tableCount);
+    assert.equal(pinned.rowCount, baseline.rowCount);
+    await sql.unsafe(`
+      set role programmable_migrator;
+      create function programmable_private.pinned_default_acl_probe_v1()
+      returns integer language sql immutable as 'select 1';
+      create type programmable_private.pinned_default_acl_probe_type_v1
+        as enum ('one');
+      set role postgres;
+    `).simple();
+    const [pinnedFuturePrivileges] = await sql.unsafe(`
+      select
+        pg_catalog.has_function_privilege(
+          'public',
+          (
+            select procedure.oid
+              from pg_catalog.pg_proc as procedure
+              join pg_catalog.pg_namespace as namespace
+                on namespace.oid = procedure.pronamespace
+             where namespace.nspname = 'programmable_private'
+               and procedure.proname = 'pinned_default_acl_probe_v1'
+          ),
+          'EXECUTE'
+        ) as function_execute,
+        pg_catalog.has_type_privilege(
+          'public',
+          (
+            select type.oid
+              from pg_catalog.pg_type as type
+              join pg_catalog.pg_namespace as namespace
+                on namespace.oid = type.typnamespace
+             where namespace.nspname = 'programmable_private'
+               and type.typname = 'pinned_default_acl_probe_type_v1'
+          ),
+          'USAGE'
+        ) as type_usage
+    `);
+    assert.deepEqual({ ...pinnedFuturePrivileges }, {
+      function_execute: true,
+      type_usage: true,
+    });
+    await sql.unsafe(`
+      set role programmable_migrator;
+      drop type programmable_private.pinned_default_acl_probe_type_v1;
+      drop function programmable_private.pinned_default_acl_probe_v1();
+      set role postgres;
+    `).simple();
+    await cleanupCandidateSchemas(
+      sql,
+      baselineClosures.cleanup,
+      { supabaseHosted: false },
+      {
+        includePinnedBaselineCleanup: false,
+        restoreHardenedGlobalDefaults: true,
+      },
     );
     await runTool(config.pgRestore, [
       ...CANDIDATE_SAFETY_RECOVERY_FLAGS,

--- a/scripts/data-pipeline/candidate-restore.test.mjs
+++ b/scripts/data-pipeline/candidate-restore.test.mjs
@@ -531,6 +531,14 @@ async function createPlan(files, overrides = {}) {
             PINNED_PRE_ATTESTATION_SNAPSHOT.securityClosureStatementCount,
         },
       }),
+      prepareSafetyRestoreClosures: async () => ({
+        cleanup: {
+          sql: "unit safety cleanup\n",
+          statementCount: 2,
+        },
+        owners: { sql: "unit safety owners\n", statementCount: 2 },
+        security: { sql: "unit safety security\n", statementCount: 2 },
+      }),
     },
     ...overrides,
   });
@@ -650,6 +658,13 @@ function restoreDatabaseDependencies(overrides = {}, { recovery = false } = {}) 
       statementCount: 1,
     }),
   });
+  const safetyClosures = Object.freeze({
+    ...closures,
+    cleanup: Object.freeze({
+      sql: "unit safety cleanup\n",
+      statementCount: 2,
+    }),
+  });
   const dependencies = {
     ...databaseDependencies(),
     cleanupCandidateSchemas: async () => {},
@@ -657,9 +672,12 @@ function restoreDatabaseDependencies(overrides = {}, { recovery = false } = {}) 
     assertCandidateSchemaStage: async () => {},
     ...overrides,
   };
-  dependencies[
-    recovery ? "prepareSafetyRestoreClosures" : "prepareRestoreClosures"
-  ] = async () => closures;
+  if (recovery) {
+    dependencies.prepareSafetyRestoreClosures = async () => closures;
+  } else {
+    dependencies.prepareRestoreClosures = async () => closures;
+    dependencies.prepareSafetyRestoreClosures = async () => safetyClosures;
+  }
   return dependencies;
 }
 
@@ -770,6 +788,11 @@ test("restore plan binds CA, raw safety evidence, three tools, schemas and flags
     plan.safetyBackup.portableStructuralManifestSha256,
     SAFETY_PORTABLE_STRUCTURAL_MANIFEST,
   );
+  assert.equal(
+    plan.safetyBackup.cleanClosureSha256,
+    sha256(Buffer.from("unit safety cleanup\n")),
+  );
+  assert.equal(plan.safetyBackup.cleanClosureStatementCount, 2);
   assert.equal(
     plan.postRestore.portableStructuralManifestSha256,
     RESTORED_PORTABLE_STRUCTURAL_MANIFEST,
@@ -1252,12 +1275,16 @@ test("JIT restore SET ROLEs postgres and uses only the immutable restore set", a
         },
         cleanupCandidateSchemas: async (
           _sql,
-          _cleanup,
+          cleanup,
           posture,
           options,
         ) => {
+          assert.equal(cleanup.sql, "unit safety cleanup\n");
           assert.equal(posture, undefined);
-          assert.equal(options, undefined);
+          assert.deepEqual(options, {
+            includePinnedBaselineCleanup: false,
+            restorePinnedGlobalDefaults: true,
+          });
           destructiveEvents.push("cleanup");
         },
         applyOwnerAndSecurityClosure: async () => {
@@ -1482,7 +1509,10 @@ test("safety recovery orders cleanup, archive restore and exact owner replay", a
           options,
         ) => {
           assert.equal(posture, undefined);
-          assert.deepEqual(options, { includePinnedBaselineCleanup: false });
+          assert.deepEqual(options, {
+            includePinnedBaselineCleanup: false,
+            restoreHardenedGlobalDefaults: true,
+          });
           destructiveEvents.push("cleanup");
         },
         applyOwnerAndSecurityClosure: async (


### PR DESCRIPTION
## Summary
- derive the Candidate cleanup closure from the exact safety archive and bind its digest/count into the reviewed plan
- restore pinned versus hardened global default privileges explicitly across normal restore and safety recovery
- add a real PostgreSQL 17 final-to-pinned-to-final regression

## Required evidence
- candidate restore unit suite: 26/26
- PostgreSQL 17.10 integration: 1/1
- typecheck: pass
- ESLint: pass
- read-model ops gate: 31/31
- independent P0/P1 audit: pass