### PR TITLE
Allow safe reset of unbound candidate

### DIFF
--- a/docs/data-pipeline/PRODUCTION-CUTOVER-OPERATOR.md
+++ b/docs/data-pipeline/PRODUCTION-CUTOVER-OPERATOR.md
@@ -143,6 +143,12 @@ node scripts/data-pipeline/cutover-operator.mjs candidate-safety-backup \
   --output /secure/cutover/candidate-current-safety.json
 ```
 
+If an earlier reset already left the Candidate database strictly unpromoted,
+unbound and unpublished, use `--current-product-commit unbound`. The operator
+accepts that literal only when every promotion binding is null,
+`promoted=false`, and the publication count is zero. Use the same literal for
+the matching restore and recovery commands.
+
 Create a deterministic restore plan from the reviewed pre-attestation archive
 and its original backup evidence. The plan hashes the exact bytes and
 `pg_restore --list` output of both the source snapshot and the fresh safety

--- a/scripts/data-pipeline/candidate-restore.mjs
+++ b/scripts/data-pipeline/candidate-restore.mjs
@@ -437,6 +437,28 @@ function promotedCandidateState(value, currentProductCommit) {
   return state;
 }
 
+function resettableCandidateState(value, currentProductCommit) {
+  if (currentProductCommit !== null) {
+    return promotedCandidateState(value, currentProductCommit);
+  }
+  const state = candidateState(value, "current Candidate state");
+  if (
+    state.promoted !== false ||
+    state.promotedAt !== null ||
+    state.publicationCount !== 0 ||
+    state.promotionAttestationCommitment !== null ||
+    state.productCommit !== null ||
+    state.stagedDeploymentId !== null
+  ) {
+    throw new Error("current Candidate unbound fence is not exact");
+  }
+  return state;
+}
+
+function validCurrentProductCommit(value) {
+  return value === null || COMMIT.test(value ?? "");
+}
+
 function drainedLeases(value) {
   const evidence = plainObject(value, "Candidate projector lease state");
   if (
@@ -602,11 +624,11 @@ export function buildCandidateSafetyBackupEvidence(input) {
   ) {
     throw new Error("Candidate safety backup operator identity is invalid");
   }
-  const before = promotedCandidateState(
+  const before = resettableCandidateState(
     input.beforeCandidateState,
     input.currentProductCommit,
   );
-  const after = promotedCandidateState(
+  const after = resettableCandidateState(
     input.afterCandidateState,
     input.currentProductCommit,
   );
@@ -692,7 +714,7 @@ export function validateCandidateSafetyBackupEvidence(value, {
     evidence.schemaVersion !== 1 ||
     !COMMIT.test(evidence.operatorCommit ?? "") ||
     (operatorCommit !== undefined && evidence.operatorCommit !== operatorCommit) ||
-    !COMMIT.test(evidence.currentProductCommit ?? "") ||
+    !validCurrentProductCommit(evidence.currentProductCommit) ||
     (currentProductCommit !== undefined &&
       evidence.currentProductCommit !== currentProductCommit) ||
     !SHA256.test(evidence.evidenceSha256 ?? "") ||
@@ -718,7 +740,7 @@ export function validateCandidateSafetyBackupEvidence(value, {
   ) {
     throw new Error("Candidate safety backup operator identity is invalid");
   }
-  promotedCandidateState(
+  resettableCandidateState(
     evidence.currentCandidateState,
     evidence.currentProductCommit,
   );
@@ -1060,7 +1082,7 @@ export async function createCandidateSafetyBackup(input) {
       throw new Error("Candidate safety backup target changed");
     }
     const operatorSession = await acquire(connection.sql);
-    const beforeCandidateState = promotedCandidateState(
+    const beforeCandidateState = resettableCandidateState(
       await inspectState(connection.sql),
       input.currentProductCommit,
     );
@@ -2030,7 +2052,7 @@ function planPayload(value) {
 export async function createCandidateRestorePlan(input) {
   if (
     !COMMIT.test(input.repositoryCommit ?? "") ||
-    !COMMIT.test(input.currentProductCommit ?? "") ||
+    !validCurrentProductCommit(input.currentProductCommit) ||
     input.snapshotRepositoryCommit !==
       PINNED_PRE_ATTESTATION_SNAPSHOT.repositoryCommit
   ) {
@@ -2326,7 +2348,7 @@ export function validateCandidateRestorePlan(value) {
     plan.kind !== "programmable-candidate-in-place-restore-plan" ||
     plan.schemaVersion !== 1 ||
     !COMMIT.test(plan.operatorCommit ?? "") ||
-    !COMMIT.test(plan.currentProductCommit ?? "") ||
+    !validCurrentProductCommit(plan.currentProductCommit) ||
     !SHA256.test(plan.planSha256 ?? "") ||
     !SHA256.test(plan.confirmRestore ?? "") ||
     sha256(canonicalJson(planPayload(plan))) !== plan.planSha256 ||
@@ -2709,7 +2731,7 @@ export async function applyCandidateRestore(input) {
     try {
       originalStateMatches =
         canonicalJson(
-          promotedCandidateState(beforeState, plan.currentProductCommit),
+          resettableCandidateState(beforeState, plan.currentProductCommit),
         ) === canonicalJson(safetyEvidence.currentCandidateState);
     } catch {
       originalStateMatches = false;
@@ -2878,7 +2900,7 @@ function recoveryPlanPayload(value) {
 export async function createCandidateSafetyRecoveryPlan(input) {
   if (
     !COMMIT.test(input.repositoryCommit ?? "") ||
-    !COMMIT.test(input.currentProductCommit ?? "")
+    !validCurrentProductCommit(input.currentProductCommit)
   ) {
     throw new Error("Candidate safety recovery commit is invalid");
   }
@@ -3042,7 +3064,7 @@ export function validateCandidateSafetyRecoveryPlan(value) {
     plan.kind !== "programmable-candidate-safety-recovery-plan" ||
     plan.schemaVersion !== 1 ||
     !COMMIT.test(plan.operatorCommit ?? "") ||
-    !COMMIT.test(plan.currentProductCommit ?? "") ||
+    !validCurrentProductCommit(plan.currentProductCommit) ||
     !SHA256.test(plan.planSha256 ?? "") ||
     !SHA256.test(plan.confirmRecovery ?? "") ||
     sha256(canonicalJson(recoveryPlanPayload(plan))) !== plan.planSha256 ||
@@ -3097,7 +3119,7 @@ export function validateCandidateSafetyRecoveryPlan(value) {
   ) {
     throw new Error("Candidate safety recovery plan is invalid");
   }
-  promotedCandidateState(
+  resettableCandidateState(
     plan.postRestore.candidateState,
     plan.currentProductCommit,
   );
@@ -3283,7 +3305,7 @@ export async function applyCandidateSafetyRecovery(input) {
       ]);
       alreadyRecovered =
         canonicalJson(
-          promotedCandidateState(state, plan.currentProductCommit),
+          resettableCandidateState(state, plan.currentProductCommit),
         ) === canonicalJson(plan.postRestore.candidateState) &&
         manifest.manifestSha256 === plan.postRestore.manifestSha256 &&
         SHA256.test(manifest.structuralManifestSha256 ?? "") &&
@@ -3345,7 +3367,7 @@ export async function applyCandidateSafetyRecovery(input) {
     ]);
     if (
       canonicalJson(
-        promotedCandidateState(state, plan.currentProductCommit),
+        resettableCandidateState(state, plan.currentProductCommit),
       ) !== canonicalJson(plan.postRestore.candidateState) ||
       manifest.manifestSha256 !== plan.postRestore.manifestSha256 ||
       !SHA256.test(manifest.structuralManifestSha256 ?? "") ||

--- a/scripts/data-pipeline/candidate-restore.test.mjs
+++ b/scripts/data-pipeline/candidate-restore.test.mjs
@@ -365,6 +365,24 @@ function buildSafetyEvidence(rawEvidence, operatorIdentity = OPERATOR_IDENTITY) 
   });
 }
 
+function buildUnboundSafetyEvidence(rawEvidence) {
+  return buildCandidateSafetyBackupEvidence({
+    operatorCommit: OPERATOR_COMMIT,
+    currentProductCommit: null,
+    target: TARGET,
+    operatorIdentity: OPERATOR_IDENTITY,
+    beforeCandidateState: restoredState(),
+    afterCandidateState: restoredState(),
+    projectorLeases: leases(),
+    runtimeLoginFence: loginFence(),
+    caSha256: sha256(Buffer.from(CA)),
+    postgresToolchain: TOOLCHAIN_EVIDENCE,
+    backupResult: { evidence: rawEvidence },
+    currentManifest: manifest(),
+    createdAt: rawEvidence.createdAt,
+  });
+}
+
 async function fixture(t) {
   const directory = await mkdtemp(path.join(os.tmpdir(), "candidate-restore-test-"));
   t.after(() => rm(directory, { recursive: true, force: true }));
@@ -812,6 +830,54 @@ test("restore plan binds CA, raw safety evidence, three tools, schemas and flags
     assert.equal(
       call.args.includes(`--restrict-key=${CANDIDATE_PG_RESTRICT_KEY}`),
       true,
+    );
+  }
+});
+
+test("an exactly unbound Candidate can be safely backed up and reset again", async (t) => {
+  const files = await fixture(t);
+  const safetyEvidence = buildUnboundSafetyEvidence(files.safetyRawEvidence);
+  assert.equal(safetyEvidence.currentProductCommit, null);
+  assert.equal(
+    validateCandidateSafetyBackupEvidence(safetyEvidence, {
+      operatorCommit: OPERATOR_COMMIT,
+      currentProductCommit: null,
+      now: new Date("2026-08-02T09:10:00.000Z"),
+    }),
+    safetyEvidence,
+  );
+  const { plan } = await createPlan(files, {
+    currentProductCommit: null,
+    safetyEvidence,
+  });
+  assert.equal(plan.currentProductCommit, null);
+
+  for (const unsafeState of [
+    { promoted: true },
+    { promotedAt: "2026-08-02T09:00:00.000Z" },
+    { publicationCount: 1 },
+    { promotionAttestationCommitment: `0x${"c".repeat(64)}` },
+    { productCommit: CURRENT_PRODUCT_COMMIT },
+    { stagedDeploymentId: "dpl_12345678901234567890" },
+  ]) {
+    assert.throws(
+      () =>
+        buildCandidateSafetyBackupEvidence({
+          operatorCommit: OPERATOR_COMMIT,
+          currentProductCommit: null,
+          target: TARGET,
+          operatorIdentity: OPERATOR_IDENTITY,
+          beforeCandidateState: restoredState(unsafeState),
+          afterCandidateState: restoredState(unsafeState),
+          projectorLeases: leases(),
+          runtimeLoginFence: loginFence(),
+          caSha256: sha256(Buffer.from(CA)),
+          postgresToolchain: TOOLCHAIN_EVIDENCE,
+          backupResult: { evidence: files.safetyRawEvidence },
+          currentManifest: manifest(),
+          createdAt: files.safetyRawEvidence.createdAt,
+        }),
+      /unbound fence/u,
     );
   }
 });

--- a/scripts/data-pipeline/cutover-operator.mjs
+++ b/scripts/data-pipeline/cutover-operator.mjs
@@ -80,11 +80,11 @@ export const HELP = `Usage:
   node scripts/data-pipeline/cutover-operator.mjs roles-provision --expected-project-ref REF --output FILE
   node scripts/data-pipeline/cutover-operator.mjs roles-verify --expected-project-ref REF --pooler-host HOST --output FILE
   node scripts/data-pipeline/cutover-operator.mjs backup-restore --expected-project-ref REF --operation-id ID --restore-isolation-id ID --backup FILE --evidence FILE [--schema-stage initial|final]
-  node scripts/data-pipeline/cutover-operator.mjs candidate-safety-backup --expected-project-ref REF --current-product-commit COMMIT --operation-id ID --restore-isolation-id ID --backup FILE --backup-evidence FILE --output FILE
-  node scripts/data-pipeline/cutover-operator.mjs candidate-restore-plan --expected-project-ref REF --current-product-commit COMMIT --snapshot-repository-commit COMMIT --snapshot-backup FILE --snapshot-evidence FILE --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --output FILE
-  node scripts/data-pipeline/cutover-operator.mjs candidate-restore-apply --expected-project-ref REF --current-product-commit COMMIT --snapshot-repository-commit COMMIT --snapshot-backup FILE --snapshot-evidence FILE --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --plan FILE --confirm-restore SHA256 --output FILE
-  node scripts/data-pipeline/cutover-operator.mjs candidate-recovery-plan --expected-project-ref REF --current-product-commit COMMIT --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --output FILE
-  node scripts/data-pipeline/cutover-operator.mjs candidate-recovery-apply --expected-project-ref REF --current-product-commit COMMIT --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --plan FILE --confirm-recovery SHA256 --output FILE
+  node scripts/data-pipeline/cutover-operator.mjs candidate-safety-backup --expected-project-ref REF --current-product-commit COMMIT|unbound --operation-id ID --restore-isolation-id ID --backup FILE --backup-evidence FILE --output FILE
+  node scripts/data-pipeline/cutover-operator.mjs candidate-restore-plan --expected-project-ref REF --current-product-commit COMMIT|unbound --snapshot-repository-commit COMMIT --snapshot-backup FILE --snapshot-evidence FILE --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --output FILE
+  node scripts/data-pipeline/cutover-operator.mjs candidate-restore-apply --expected-project-ref REF --current-product-commit COMMIT|unbound --snapshot-repository-commit COMMIT --snapshot-backup FILE --snapshot-evidence FILE --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --plan FILE --confirm-restore SHA256 --output FILE
+  node scripts/data-pipeline/cutover-operator.mjs candidate-recovery-plan --expected-project-ref REF --current-product-commit COMMIT|unbound --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --output FILE
+  node scripts/data-pipeline/cutover-operator.mjs candidate-recovery-apply --expected-project-ref REF --current-product-commit COMMIT|unbound --safety-backup FILE --safety-backup-evidence FILE --safety-evidence FILE --plan FILE --confirm-recovery SHA256 --output FILE
   node scripts/data-pipeline/cutover-operator.mjs candidate-runtime-enable-plan --expected-project-ref REF --pooler-host HOST --restore-result FILE --output FILE
   node scripts/data-pipeline/cutover-operator.mjs candidate-runtime-enable-apply --expected-project-ref REF --pooler-host HOST --restore-result FILE --plan FILE --confirm-enable SHA256 --output FILE
   node scripts/data-pipeline/cutover-operator.mjs raw-backfill --expected-project-ref REF --backup-evidence FILE --output FILE [--maximum-cycles N]
@@ -138,6 +138,10 @@ function exactFlags(flags, required, optional = []) {
   for (const key of required) {
     if (!flags.has(key)) throw new Error(`${key} is required`);
   }
+}
+
+function currentProductCommit(value) {
+  return value === "unbound" ? null : value;
 }
 
 function boundedCycles(value) {
@@ -542,7 +546,9 @@ async function runCommand(command, flags, environment) {
     const repositoryCommit = await assertCleanCheckout();
     const result = await createCandidateSafetyBackup({
       repositoryCommit,
-      currentProductCommit: flags.get("--current-product-commit"),
+      currentProductCommit: currentProductCommit(
+        flags.get("--current-product-commit"),
+      ),
       operationId: flags.get("--operation-id"),
       expectedProjectRef: flags.get("--expected-project-ref"),
       databaseUrl: environment.PROGRAMMABLE_MIGRATOR_DATABASE_URL,
@@ -602,7 +608,9 @@ async function runCommand(command, flags, environment) {
     );
     const plan = await createCandidateRestorePlan({
       repositoryCommit,
-      currentProductCommit: flags.get("--current-product-commit"),
+      currentProductCommit: currentProductCommit(
+        flags.get("--current-product-commit"),
+      ),
       expectedProjectRef: flags.get("--expected-project-ref"),
       databaseUrl: environment.PROGRAMMABLE_MIGRATOR_DATABASE_URL,
       sslCaPem: environment.PROGRAMMABLE_POSTGRES_SSL_CA_PEM,
@@ -673,7 +681,9 @@ async function runCommand(command, flags, environment) {
     );
     const plan = await createCandidateSafetyRecoveryPlan({
       repositoryCommit,
-      currentProductCommit: flags.get("--current-product-commit"),
+      currentProductCommit: currentProductCommit(
+        flags.get("--current-product-commit"),
+      ),
       expectedProjectRef: flags.get("--expected-project-ref"),
       databaseUrl: environment.PROGRAMMABLE_MIGRATOR_DATABASE_URL,
       sslCaPem: environment.PROGRAMMABLE_POSTGRES_SSL_CA_PEM,


### PR DESCRIPTION
## What changed

- permit the Candidate restore operator to accept the explicit `unbound` state
- require the database to be unpromoted, unpublished, and free of every product/staging binding
- carry the same fail-closed state through safety backup, restore, and recovery
- document the operator literal and cover unsafe partial states

## Why

A previous safe reset left the Candidate database correctly unbound. The original operator admitted only a currently promoted product, so it could not take a fresh safety backup before rebinding an immutable RPC provider deployment.

## Impact

The Candidate can be safely reset again to the pinned pre-attestation snapshot without weakening the promotion fence. Any promotion field, product binding, staged deployment, attestation, or publication still rejects the operation.

## Validation

- `node --test scripts/data-pipeline/candidate-restore.test.mjs scripts/data-pipeline/cutover-operator.test.mjs` (36/36)
- targeted ESLint
- TypeScript typecheck
