### PR TITLE
fix: keep Explore responsive during RPC outages

### DIFF
--- a/lib/onchain/durable-model.ts
+++ b/lib/onchain/durable-model.ts
@@ -812,9 +812,7 @@ export async function readDurableExploreModel(
   deployment: ReadyOnchainDeployment,
   maxAgeMs = DEFAULT_MAX_AGE_MS,
 ): Promise<DurableExploreRead> {
-  const blobToken =
-    process.env.OPS_BLOB_READ_WRITE_TOKEN ??
-    process.env.BLOB_READ_WRITE_TOKEN;
+  const blobToken = resolveDurableExploreBlobToken();
   if (!blobToken) {
     return {
       status: "unavailable",
@@ -862,9 +860,7 @@ export async function writeDurableExploreModel(
   if (model.status !== "ready") {
     throw new Error("Only a verified ready model can be persisted");
   }
-  const blobToken =
-    process.env.OPS_BLOB_READ_WRITE_TOKEN ??
-    process.env.BLOB_READ_WRITE_TOKEN;
+  const blobToken = resolveDurableExploreBlobToken();
   if (!blobToken) {
     throw new Error("Persistent index storage is not configured");
   }
@@ -942,4 +938,11 @@ export async function writeDurableExploreModel(
     deepV3LifecycleEvidenceHash:
       deepV3Release?.lifecycleEvidenceHash ?? null,
   };
+}
+
+export function resolveDurableExploreBlobToken() {
+  return (
+    process.env.OPS_BLOB_READ_WRITE_TOKEN?.trim() ||
+    process.env.BLOB_READ_WRITE_TOKEN?.trim()
+  );
 }

--- a/lib/onchain/explore-read-source.ts
+++ b/lib/onchain/explore-read-source.ts
@@ -48,14 +48,19 @@ export async function resolveExploreReadSource(
       return enrichOrReturn(durableModel, config, dependencies);
     }
     if (durable.status === "unavailable") {
+      if (durable.reason === "stale") {
+        dependencies.warn(
+          "Durable Explore index is stale; serving the last verified snapshot",
+          {
+            reason: durable.reason,
+            ageSeconds: Math.floor(durable.ageMs / 1_000),
+          },
+        );
+        return durable.envelope.payload.model;
+      }
       dependencies.warn(
         "Durable Explore index unavailable; using live RPCs",
-        durable.reason === "stale"
-          ? {
-              reason: durable.reason,
-              ageSeconds: Math.floor(durable.ageMs / 1_000),
-            }
-          : { reason: durable.reason, detail: durable.detail },
+        { reason: durable.reason, detail: durable.detail },
       );
     }
   }

--- a/tests/onchain-durable-model.test.ts
+++ b/tests/onchain-durable-model.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { keccak256, toBytes } from "viem";
 
 import {
+  resolveDurableExploreBlobToken,
   selectFreshDurableExploreModel,
   shouldReplaceDurableSnapshot,
   validateDurableExploreEnvelope,
@@ -65,6 +66,19 @@ const model: Extract<ExploreReadModel, { status: "ready" }> = {
   launcherFeesAccruedWei: "0",
   launcherFeesAccruedEth: "0",
 };
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("durable Explore storage configuration", () => {
+  it("falls back to the shared Blob token when the ops override is empty", () => {
+    vi.stubEnv("OPS_BLOB_READ_WRITE_TOKEN", "");
+    vi.stubEnv("BLOB_READ_WRITE_TOKEN", " shared-token ");
+
+    expect(resolveDurableExploreBlobToken()).toBe("shared-token");
+  });
+});
 
 const deepRelease = {
   releaseVersion: "deep-full-range-v1",

--- a/tests/onchain-explore-read-source.test.ts
+++ b/tests/onchain-explore-read-source.test.ts
@@ -39,7 +39,7 @@ const liveModel = {
 } satisfies ExploreReadModel;
 
 describe("Explore read source", () => {
-  it("falls through a stale durable snapshot to the live RPC model", async () => {
+  it("serves a stale verified snapshot without touching live RPCs", async () => {
     const readLive = vi.fn().mockResolvedValue(liveModel);
     const enrichWithUsd = vi.fn().mockResolvedValue(liveModel);
     const warn = vi.fn();
@@ -74,11 +74,38 @@ describe("Explore read source", () => {
     });
 
     expect(result).toBe(liveModel);
+    expect(readLive).not.toHaveBeenCalled();
+    expect(enrichWithUsd).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "Durable Explore index is stale; serving the last verified snapshot",
+      { reason: "stale", ageSeconds: 901 },
+    );
+  });
+
+  it("uses live RPCs when no verified durable snapshot exists", async () => {
+    const readLive = vi.fn().mockResolvedValue(liveModel);
+    const enrichWithUsd = vi.fn().mockResolvedValue(liveModel);
+    const warn = vi.fn();
+
+    const result = await resolveExploreReadSource(config, {
+      readDurable: vi.fn().mockResolvedValue({
+        status: "unavailable",
+        reason: "missing",
+        detail: "No durable index snapshot exists",
+      }),
+      selectFreshDurable: vi.fn().mockReturnValue(null),
+      readLive,
+      enrichWithUsd,
+      warn,
+      error: vi.fn(),
+    });
+
+    expect(result).toBe(liveModel);
     expect(readLive).toHaveBeenCalledOnce();
     expect(enrichWithUsd).toHaveBeenCalledWith(liveModel, config);
     expect(warn).toHaveBeenCalledWith(
       "Durable Explore index unavailable; using live RPCs",
-      { reason: "stale", ageSeconds: 901 },
+      { reason: "missing", detail: "No durable index snapshot exists" },
     );
   });
 


### PR DESCRIPTION
## Summary
- serve the last cryptographically verified Explore snapshot when its freshness window expires
- avoid the blocking live-RPC rebuild only for the verified-stale case
- preserve live RPC fallback for missing or invalid snapshots
- accept the shared Blob token when an optional ops override is empty

## Validation
- `npm run typecheck`
- focused ESLint on changed files
- 20 focused Vitest cases across Explore source, API contract, and durable model

## Scope
Backend data-path change only. The current website design and API response shape are unchanged.