### PR TITLE
fix: retry stale Supavisor credentials once

### DIFF
--- a/scripts/data-pipeline/cutover-credentials.mjs
+++ b/scripts/data-pipeline/cutover-credentials.mjs
@@ -34,6 +34,7 @@ const ISOLATION_ID = /^[a-z0-9][a-z0-9_-]{7,31}$/u;
 const SHA256 = /^0x[0-9a-f]{64}$/u;
 const PG_TOOL_VERSION = /\b(\d+)\.(?:\d+)(?:\.\d+)?\b/u;
 const RESTORE_DATABASE_PREFIX = "programmable_restore_";
+const POOLER_CREDENTIAL_REFRESH_DELAY_MS = 250;
 export const BACKUP_SCHEMAS = Object.freeze([
   "programmable_private",
   "programmable_release_probe_private",
@@ -511,6 +512,12 @@ async function closePoolerDatabase(sql) {
   await sql.end({ timeout: 3 });
 }
 
+async function waitForPoolerCredentialRefresh() {
+  await new Promise((resolve) => {
+    setTimeout(resolve, POOLER_CREDENTIAL_REFRESH_DELAY_MS);
+  });
+}
+
 function staticSetLocalRoleSql(spec) {
   return `set local role ${spec.capabilityRole}`;
 }
@@ -564,28 +571,40 @@ export async function verifyPoolerLogins(input) {
     "closePoolerDatabase",
     "readPoolerRolePosture",
     "verifyPoolerSession",
+    "waitForPoolerCredentialRefresh",
   ]);
   const openDatabase = dependencies.openPoolerDatabase ?? openPoolerDatabase;
   const closeDatabase = dependencies.closePoolerDatabase ?? closePoolerDatabase;
   const inspectPosture =
     dependencies.readPoolerRolePosture ?? readPoolerRolePosture;
   const verifySession = dependencies.verifyPoolerSession ?? verifyPoolerSession;
+  const waitForCredentialRefresh =
+    dependencies.waitForPoolerCredentialRefresh ?? waitForPoolerCredentialRefresh;
   const roles = [];
   try {
     for (const spec of ROLE_SPECS) {
-      let connection;
-      try {
-        connection = await openDatabase({
-          target,
-          spec,
-          password: credentials.get(spec.key),
-          sslCaPem,
-          options: Object.freeze({ prepare: false }),
-        });
-        assertRolePosture(await inspectPosture(connection.sql));
-        roles.push(await verifySession(connection.sql, spec));
-      } finally {
-        if (connection?.sql) await closeDatabase(connection.sql).catch(() => {});
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        let connection;
+        let retryAfterCredentialRefresh = false;
+        try {
+          connection = await openDatabase({
+            target,
+            spec,
+            password: credentials.get(spec.key),
+            sslCaPem,
+            options: Object.freeze({ prepare: false }),
+          });
+          assertRolePosture(await inspectPosture(connection.sql));
+          roles.push(await verifySession(connection.sql, spec));
+          break;
+        } catch (error) {
+          retryAfterCredentialRefresh =
+            attempt === 0 && errorCode(error) === "28P01";
+          if (!retryAfterCredentialRefresh) throw error;
+        } finally {
+          if (connection?.sql) await closeDatabase(connection.sql).catch(() => {});
+        }
+        if (retryAfterCredentialRefresh) await waitForCredentialRefresh();
       }
     }
     if (roles.length !== ROLE_SPECS.length) {

--- a/scripts/data-pipeline/cutover-credentials.test.mjs
+++ b/scripts/data-pipeline/cutover-credentials.test.mjs
@@ -358,6 +358,146 @@ test("verifyPoolerLogins checks all five transaction-pooler identities with SET 
   }
 });
 
+test("verifyPoolerLogins retries each role once after an initial 28P01", async () => {
+  const values = credentials("refreshed_pooler");
+  const attempts = new Map();
+  const closes = [];
+  const waits = [];
+  const result = await verifyPoolerLogins({
+    expectedProjectRef: PROJECT_REF,
+    poolerHost: "aws-0-eu-central-1.pooler.supabase.com",
+    sslCaPem: CA,
+    credentials: values,
+    dependencies: {
+      openPoolerDatabase: async ({ spec }) => {
+        const attempt = (attempts.get(spec.key) ?? 0) + 1;
+        attempts.set(spec.key, attempt);
+        return { sql: { attempt, spec } };
+      },
+      closePoolerDatabase: async (sql) => {
+        closes.push(sql);
+      },
+      readPoolerRolePosture: async ({ attempt }) => {
+        if (attempt === 1) {
+          throw Object.assign(new Error("stale pooler credential"), {
+            code: "28P01",
+          });
+        }
+        return rolePosture();
+      },
+      verifyPoolerSession: async (_sql, spec) => ({
+        loginRole: spec.loginRole,
+        capabilityRole: spec.capabilityRole,
+        verified: true,
+      }),
+      waitForPoolerCredentialRefresh: async () => {
+        waits.push(true);
+      },
+    },
+  });
+
+  assert.deepEqual(
+    [...attempts.values()],
+    ROLE_SPECS.map(() => 2),
+  );
+  assert.equal(closes.length, ROLE_SPECS.length * 2);
+  assert.equal(waits.length, ROLE_SPECS.length);
+  assert.equal(result.roles.length, ROLE_SPECS.length);
+});
+
+test("verifyPoolerLogins fails immediately without retrying a non-28P01 error", async () => {
+  const values = credentials("non_auth_failure");
+  let opens = 0;
+  let closes = 0;
+  let waits = 0;
+  await assert.rejects(
+    verifyPoolerLogins({
+      expectedProjectRef: PROJECT_REF,
+      poolerHost: "aws-0-eu-central-1.pooler.supabase.com",
+      sslCaPem: CA,
+      credentials: values,
+      dependencies: {
+        openPoolerDatabase: async () => {
+          opens += 1;
+          return { sql: {} };
+        },
+        closePoolerDatabase: async () => {
+          closes += 1;
+        },
+        readPoolerRolePosture: async () => {
+          throw Object.assign(new Error("network timeout"), {
+            code: "ETIMEDOUT",
+          });
+        },
+        verifyPoolerSession: async () => {
+          throw new Error("session verification must not run");
+        },
+        waitForPoolerCredentialRefresh: async () => {
+          waits += 1;
+        },
+      },
+    }),
+    (error) => {
+      assert.equal(
+        error.message,
+        "pooler login verification failed (ETIMEDOUT)",
+      );
+      for (const secret of Object.values(values)) {
+        assert.equal(error.message.includes(secret), false);
+      }
+      return true;
+    },
+  );
+  assert.equal(opens, 1);
+  assert.equal(closes, 1);
+  assert.equal(waits, 0);
+});
+
+test("verifyPoolerLogins fails closed after the second 28P01", async () => {
+  const values = credentials("persistent_auth_failure");
+  let opens = 0;
+  let closes = 0;
+  let waits = 0;
+  await assert.rejects(
+    verifyPoolerLogins({
+      expectedProjectRef: PROJECT_REF,
+      poolerHost: "aws-0-eu-central-1.pooler.supabase.com",
+      sslCaPem: CA,
+      credentials: values,
+      dependencies: {
+        openPoolerDatabase: async () => {
+          opens += 1;
+          return { sql: {} };
+        },
+        closePoolerDatabase: async () => {
+          closes += 1;
+        },
+        readPoolerRolePosture: async () => {
+          throw Object.assign(new Error("password rejected"), {
+            code: "28P01",
+          });
+        },
+        verifyPoolerSession: async () => {
+          throw new Error("session verification must not run");
+        },
+        waitForPoolerCredentialRefresh: async () => {
+          waits += 1;
+        },
+      },
+    }),
+    (error) => {
+      assert.equal(error.message, "pooler login verification failed (28P01)");
+      for (const secret of Object.values(values)) {
+        assert.equal(error.message.includes(secret), false);
+      }
+      return true;
+    },
+  );
+  assert.equal(opens, 2);
+  assert.equal(closes, 2);
+  assert.equal(waits, 1);
+});
+
 test("verifyPoolerLogins rejects an unreviewed host and an identity mismatch", async () => {
   await assert.rejects(
     verifyPoolerLogins({


### PR DESCRIPTION
## Summary\n- retry each reviewed pooler role exactly once after an initial PostgreSQL 28P01\n- close the failed connection before the bounded refresh delay\n- preserve fail-closed behavior for a second 28P01 and every other error\n\n## Evidence\n- credential suite: 23/23\n- candidate runtime suite: 27/27\n- ESLint (2 files), node --check, diff --check: green\n- official Supavisor rotation behavior: first connection refreshes stale validation secret, second succeeds