### PR TITLE
Polish Explore, profile, create flow, and theme motion

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -25,7 +25,13 @@ import { readIndexedFeedSnapshot } from "../indexers/v1/read-indexed-feed.server
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const EXPLORE_QUERY_PARAMETERS = new Set(["limit", "page", "q", "sort"]);
+const EXPLORE_QUERY_PARAMETERS = new Set([
+  "limit",
+  "page",
+  "q",
+  "socials",
+  "sort",
+]);
 
 function hasCanonicalQueryShape(search: URLSearchParams) {
   const seen = new Set<string>();
@@ -67,6 +73,13 @@ export async function GET(request: NextRequest) {
       { status: 400, headers: { "Cache-Control": "no-store" } },
     );
   }
+  const socials = search.get("socials");
+  if (socials !== null && socials !== "yes" && socials !== "no") {
+    return NextResponse.json(
+      { error: "Unsupported socials filter" },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
 
   try {
     const options = {
@@ -74,6 +87,7 @@ export async function GET(request: NextRequest) {
       sort: parseExploreSort(search.get("sort")),
       page: integerQuery(search.get("page"), 1),
       pageSize: integerQuery(search.get("limit"), 6),
+      socials,
     } as const;
     const canonical = await coordinatePublicRouteRead({
       route: "explore-list",

--- a/app/globals.css
+++ b/app/globals.css
@@ -229,61 +229,45 @@ html[data-theme="dark"] {
   color-scheme: dark;
 }
 
-@keyframes theme-radial-reveal {
+@keyframes theme-soft-reveal {
   from {
-    clip-path: circle(
-      0 at var(--theme-reveal-x, calc(100% - 48px))
-        var(--theme-reveal-y, 34px)
-    );
+    opacity: 0;
   }
 
   to {
-    clip-path: circle(
-      var(--theme-reveal-radius, 150vmax)
-        at var(--theme-reveal-x, calc(100% - 48px))
-        var(--theme-reveal-y, 34px)
-    );
+    opacity: 1;
   }
 }
 
-@keyframes theme-radial-tint {
+@keyframes theme-soft-fade {
   from {
-    clip-path: circle(
-      0 at var(--theme-reveal-x, calc(100% - 48px))
-        var(--theme-reveal-y, 34px)
-    );
-    opacity: 0.9;
+    opacity: 1;
   }
 
   to {
-    clip-path: circle(
-      var(--theme-reveal-radius, 150vmax)
-        at var(--theme-reveal-x, calc(100% - 48px))
-        var(--theme-reveal-y, 34px)
-    );
     opacity: 0;
   }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  html[data-theme-transition="radial"]::view-transition-old(root),
-  html[data-theme-transition="radial"]::view-transition-new(root) {
+  html[data-theme-transition="soft"]::view-transition-old(root),
+  html[data-theme-transition="soft"]::view-transition-new(root) {
     animation: none;
     mix-blend-mode: normal;
   }
 
-  html[data-theme-transition="radial"]::view-transition-old(root) {
+  html[data-theme-transition="soft"]::view-transition-old(root) {
     z-index: 1;
   }
 
-  html[data-theme-transition="radial"]::view-transition-new(root) {
-    animation: theme-radial-reveal 292ms cubic-bezier(0.32, 0.72, 0, 1)
+  html[data-theme-transition="soft"]::view-transition-new(root) {
+    animation: theme-soft-reveal 380ms cubic-bezier(0.2, 0, 0, 1)
       both;
     z-index: 2;
   }
 
   html[data-theme-transition^="fallback-"] {
-    transition-duration: 292ms;
+    transition-duration: 380ms;
     transition-property:
       --body-background,
       --surface,
@@ -300,11 +284,11 @@ html[data-theme="dark"] {
       --brand-pink,
       --accent,
       --accent-strong;
-    transition-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
   }
 
   html[data-theme-transition^="fallback-"] body::after {
-    animation: theme-radial-tint 292ms cubic-bezier(0.32, 0.72, 0, 1) both;
+    animation: theme-soft-fade 380ms cubic-bezier(0.2, 0, 0, 1) both;
     content: "";
     inset: 0;
     pointer-events: none;

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -110,11 +110,7 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
   margin: 0 auto;
   max-width: 1020px;
-  transition: opacity 120ms ease-out;
-}
-
-:global(.token-section[aria-busy="true"]) .runnerGrid {
-  opacity: 0.55;
+  width: 100%;
 }
 
 .runnerCard {
@@ -125,7 +121,7 @@
   min-width: 0;
   overflow: visible;
   position: relative;
-  transition: opacity 160ms ease-out;
+  width: 100%;
 }
 
 .runnerHitArea {
@@ -146,6 +142,7 @@
   overflow: hidden;
   position: relative;
   transition: outline-color 180ms ease;
+  width: 100%;
 }
 
 :global(html[data-theme="dark"]) .runnerArt {
@@ -194,8 +191,29 @@
   -webkit-line-clamp: 2;
 }
 
-.runnerDescriptionEmpty {
+.runnerMeta {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-block-start: 7px;
+  min-height: 40px;
+  min-width: 0;
+}
+
+.runnerMarketCap {
+  color: var(--text-soft);
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.004em;
+  line-height: 1.56;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runnerMarketCapLabel {
   color: var(--muted);
+  margin-inline-end: 5px;
 }
 
 .runnerSocials {
@@ -203,8 +221,8 @@
   display: flex;
   gap: 2px;
   margin: 0;
-  margin-block-start: 7px;
-  margin-inline-start: -9px;
+  margin-inline-start: auto;
+  margin-inline-end: -9px;
   min-height: 40px;
 }
 
@@ -419,9 +437,13 @@
     font-size: 16px;
   }
 
+  .runnerMarketCap {
+    font-size: 16px;
+  }
+
   .runnerSocials {
     gap: 0;
-    margin-inline-start: -11px;
+    margin-inline-end: -11px;
     min-height: 44px;
   }
 

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -12,7 +12,10 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { type MarketCapMetric } from "@/components/animated-market-cap";
+import {
+  formatMarketCapMetric,
+  type MarketCapMetric,
+} from "@/components/animated-market-cap";
 import { XBrandIcon } from "@/components/brand-icons";
 import { EXPLORE_PREVIEW_TOKENS } from "@/components/explore-preview-data";
 import { useInterfacePreview } from "@/components/interface-preview";
@@ -39,6 +42,7 @@ type TokenCard = {
   description?: string;
   imageUrl: string;
   links: TokenLink[];
+  marketCap?: MarketCapMetric;
   usesFallbackImage: boolean;
   tokenAddress: `0x${string}`;
 };
@@ -110,14 +114,21 @@ const fallbackTokenImages = [
 const sortOptions: { id: TokenSort; label: string }[] = [
   { id: "newest", label: "Newest" },
   { id: "oldest", label: "Oldest" },
-  { id: "market-cap", label: "Highest market cap" },
-  { id: "market-cap-asc", label: "Lowest market cap" },
+  { id: "market-cap", label: "Highest Market Cap" },
+  { id: "market-cap-asc", label: "Lowest Market Cap" },
 ];
-const socialFilterOptions: { id: ExploreSocialFilter; label: string }[] = [
-  { id: "all", label: "Any" },
+const socialFilterOptions: {
+  id: Exclude<ExploreSocialFilter, "all">;
+  label: string;
+}[] = [
   { id: "yes", label: "Yes" },
   { id: "no", label: "No" },
 ];
+const tokenLinkOrder: Record<TokenLink["kind"], number> = {
+  website: 0,
+  x: 1,
+  telegram: 2,
+};
 
 export function shouldRefreshExplore(input: {
   visibilityState: DocumentVisibilityState;
@@ -267,6 +278,21 @@ type PendingExploreRequest = {
 
 const pendingExploreRequests = new Map<string, PendingExploreRequest>();
 
+async function fetchExplorePayload(
+  search: URLSearchParams,
+  signal: AbortSignal,
+) {
+  const response = await fetch(`/api/explore?${search.toString()}`, {
+    headers: { Accept: "application/json" },
+    signal,
+  });
+  const body: unknown = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(readApiError(body));
+  }
+  return parseExplorePayload(body);
+}
+
 export function loadExplorePayload(
   contentKey: string,
   search: URLSearchParams,
@@ -282,15 +308,7 @@ export function loadExplorePayload(
   }, EXPLORE_REQUEST_TIMEOUT_MS);
   const request = (async (): Promise<ExplorePayload> => {
     try {
-      const response = await fetch(`/api/explore?${search.toString()}`, {
-        headers: { Accept: "application/json" },
-        signal: controller.signal,
-      });
-      const body: unknown = await response.json().catch(() => null);
-      if (!response.ok) {
-        throw new Error(readApiError(body));
-      }
-      return parseExplorePayload(body);
+      return await fetchExplorePayload(search, controller.signal);
     } catch (error) {
       if (timedOut) {
         throw new Error("Tokens took too long to respond");
@@ -318,6 +336,26 @@ function abortExplorePayload(contentKey: string) {
   if (!pendingRequest) return;
   pendingExploreRequests.delete(contentKey);
   pendingRequest.controller.abort();
+}
+
+export function paginateTokensBySocialPresence(
+  tokens: LauncherToken[],
+  socialFilter: ExploreSocialFilter,
+  requestedPage: number,
+  pageSize = EXPLORE_TOKENS_PER_PAGE,
+) {
+  const filtered = filterTokensBySocialPresence(tokens, socialFilter);
+  const totalPages = Math.ceil(filtered.length / pageSize);
+  const page = totalPages === 0 ? 1 : Math.min(requestedPage, totalPages);
+  const offset = (page - 1) * pageSize;
+
+  return {
+    tokens: filtered.slice(offset, offset + pageSize),
+    page,
+    pageSize,
+    total: filtered.length,
+    totalPages,
+  };
 }
 
 function getFallbackTokenImage(address: string) {
@@ -430,7 +468,10 @@ function getTokenCards(tokens: LauncherToken[]): TokenCard[] {
     description: token.description?.trim() || undefined,
     imageUrl:
       token.imageUrl?.trim() || getFallbackTokenImage(token.tokenAddress),
-    links: token.links ?? [],
+    links: [...(token.links ?? [])].sort(
+      (left, right) => tokenLinkOrder[left.kind] - tokenLinkOrder[right.kind],
+    ),
+    marketCap: getMarketCap(token),
     usesFallbackImage: !token.imageUrl?.trim(),
     tokenAddress: token.tokenAddress,
   }));
@@ -473,7 +514,7 @@ export function ExploreView() {
   const [state, setState] = useState<ExploreState>({ phase: "loading" });
   const activeExploreContentKey = useRef<string | null>(null);
   const filterRef = useRef<HTMLDetailsElement>(null);
-  const contentKey = `${debouncedQuery}\u0000${sort}\u0000${currentPage}`;
+  const contentKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${currentPage}`;
   const requestKey = `${contentKey}\u0000${retryKey}\u0000${refreshKey}`;
 
   useEffect(
@@ -537,6 +578,9 @@ export function ExploreView() {
       page: String(currentPage),
       limit: String(EXPLORE_TOKENS_PER_PAGE),
     });
+    if (socialFilter !== "all") {
+      search.set("socials", socialFilter);
+    }
 
     async function loadTokens() {
       try {
@@ -571,7 +615,15 @@ export function ExploreView() {
     return () => {
       ignore = true;
     };
-  }, [contentKey, currentPage, debouncedQuery, preview, requestKey, sort]);
+  }, [
+    contentKey,
+    currentPage,
+    debouncedQuery,
+    preview,
+    requestKey,
+    socialFilter,
+    sort,
+  ]);
 
   const previewPayload = useMemo<ExplorePayload>(() => {
     const searchValue = debouncedQuery.toLowerCase();
@@ -598,15 +650,17 @@ export function ExploreView() {
       return sort === "market-cap" ? delta : -delta;
     });
 
+    const paginated = paginateTokensBySocialPresence(
+      ranked,
+      socialFilter,
+      currentPage,
+    );
+
     return {
       status: "ready",
-      tokens: ranked,
-      page: 1,
-      pageSize: EXPLORE_TOKENS_PER_PAGE,
-      total: ranked.length,
-      totalPages: ranked.length > 0 ? 1 : 0,
+      ...paginated,
     };
-  }, [debouncedQuery, sort]);
+  }, [currentPage, debouncedQuery, socialFilter, sort]);
 
   const displayState: ExploreState = preview
     ? {
@@ -619,14 +673,9 @@ export function ExploreView() {
 
   const payload =
     displayState.phase === "ready" ? displayState.payload : null;
-  const filteredTokens = useMemo(
-    () =>
-      filterTokensBySocialPresence(payload?.tokens ?? [], socialFilter),
-    [payload?.tokens, socialFilter],
-  );
   const cards = useMemo(
-    () => getTokenCards(filteredTokens),
-    [filteredTokens],
+    () => getTokenCards(payload?.tokens ?? []),
+    [payload?.tokens],
   );
   const pageCount = Math.max(1, payload?.totalPages ?? 0);
   const activePage = Math.min(payload?.page ?? currentPage, pageCount);
@@ -686,8 +735,8 @@ export function ExploreView() {
             ? "No tokens match this search"
             : "No tokens match this search and filter"
           : socialFilter === "yes"
-            ? "No tokens on this page have social links"
-            : "Every token on this page has social links";
+            ? "No tokens have social links"
+            : "No tokens without social links";
         return (
           <div className="token-empty">
             <p>{noMatchMessage}</p>
@@ -740,7 +789,9 @@ export function ExploreView() {
                       token.usesFallbackImage ? "" : `${token.name} artwork`
                     }
                     fill
-                    loading={index < 6 ? "eager" : "lazy"}
+                    loading={
+                      index < EXPLORE_TOKENS_PER_PAGE ? "eager" : "lazy"
+                    }
                     sizes="(max-width: 700px) calc(100vw - 28px), (max-width: 1040px) 46vw, 31vw"
                     unoptimized={!canOptimizeTokenImage(imageSource)}
                   />
@@ -751,40 +802,46 @@ export function ExploreView() {
                     <h3 title={token.name}>{token.name}</h3>
                   </header>
 
-                  <p
-                    className={`${styles.runnerDescription}${
-                      token.description
-                        ? ""
-                        : ` ${styles.runnerDescriptionEmpty}`
-                    }`}
-                  >
-                    {token.description ?? "No description yet."}
-                  </p>
+                  {token.description ? (
+                    <p className={styles.runnerDescription}>
+                      {token.description}
+                    </p>
+                  ) : null}
                 </div>
               </Link>
 
-              {token.links.length > 0 ? (
-                <div
-                  className={styles.runnerSocials}
-                  role="group"
-                  aria-label={`${token.name} links`}
-                >
-                  {token.links.map((link) => {
-                    const label = getTokenLinkLabel(link.kind);
-                    return (
-                      <a
-                        className={styles.runnerSocialLink}
-                        href={link.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        aria-label={`${token.name} ${label}`}
-                        title={label}
-                        key={`${link.kind}:${link.url}`}
-                      >
-                        <TokenLinkIcon kind={link.kind} />
-                      </a>
-                    );
-                  })}
+              {token.marketCap || token.links.length > 0 ? (
+                <div className={styles.runnerMeta}>
+                  {token.marketCap ? (
+                    <span className={styles.runnerMarketCap}>
+                      <span className={styles.runnerMarketCapLabel}>MC</span>
+                      {formatMarketCapMetric(token.marketCap)}
+                    </span>
+                  ) : null}
+                  {token.links.length > 0 ? (
+                    <div
+                      className={styles.runnerSocials}
+                      role="group"
+                      aria-label={`${token.name} links`}
+                    >
+                      {token.links.map((link) => {
+                        const label = getTokenLinkLabel(link.kind);
+                        return (
+                          <a
+                            className={styles.runnerSocialLink}
+                            href={link.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            aria-label={`${token.name} ${label}`}
+                            title={label}
+                            key={`${link.kind}:${link.url}`}
+                          >
+                            <TokenLinkIcon kind={link.kind} />
+                          </a>
+                        );
+                      })}
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
             </article>
@@ -874,9 +931,6 @@ export function ExploreView() {
                             onClick={() => {
                               setSort(option.id);
                               setCurrentPage(1);
-                              const filter = filterRef.current;
-                              filter?.removeAttribute("open");
-                              filter?.querySelector("summary")?.focus();
                             }}
                           >
                             <span>{option.label}</span>
@@ -909,11 +963,10 @@ export function ExploreView() {
                             type="button"
                             aria-pressed={socialFilter === option.id}
                             onClick={() => {
-                              setSocialFilter(option.id);
+                              setSocialFilter((current) =>
+                                current === option.id ? "all" : option.id,
+                              );
                               setCurrentPage(1);
-                              const filter = filterRef.current;
-                              filter?.removeAttribute("open");
-                              filter?.querySelector("summary")?.focus();
                             }}
                           >
                             <span>{option.label}</span>

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -143,8 +143,15 @@ export function LaunchModelPicker({
               priority
               unoptimized
             />
-            <span
-              className={`${launchExperience.brandMark} ${launchExperience.classicMark}`}
+            <Image
+              className={launchExperience.classicLogo}
+              src="/brand/loop/programmable-loop-mark-transparent-v1.png"
+              alt=""
+              width={1254}
+              height={1254}
+              sizes="128px"
+              priority
+              unoptimized
             />
           </span>
 
@@ -202,6 +209,11 @@ export function LaunchModelPicker({
             <span
               className={`${launchExperience.brandMark} ${launchExperience.customMark}`}
             />
+            <span className={launchExperience.customSparkles}>
+              <span />
+              <span />
+              <span />
+            </span>
           </span>
 
           <span

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -372,6 +372,8 @@
 }
 
 .formPage {
+  --launch-control-height: 52px;
+  --launch-panel-gap: 14px;
   isolation: isolate;
   min-height: calc(100svh - var(--header-height));
   padding-top: 8px;
@@ -468,7 +470,7 @@
 }
 
 .formPage :global(.classic-launch-content) {
-  padding: 24px 28px 19px;
+  padding: 26px 28px 22px;
 }
 
 .formFieldset {
@@ -499,15 +501,15 @@
 }
 
 .formPage :global(.classic-token-grid) {
-  gap: 22px;
-  grid-template-columns: 156px minmax(0, 1fr);
-  margin-top: 14px;
+  gap: 24px;
+  grid-template-columns: 148px minmax(0, 1fr);
+  margin-top: 16px;
 }
 
 .formPage :global(.classic-token-section) :global(.token-image-upload) {
   border-color: var(--control-border);
   border-radius: 17px;
-  width: 156px;
+  width: 148px;
 }
 
 .formPage :global(.token-image-upload),
@@ -530,8 +532,19 @@
   font-weight: 630;
 }
 
+.formPage :global(.classic-token-main .field),
+.formPage :global(.classic-link-fields .field) {
+  gap: 7px;
+}
+
+.formPage :global(.classic-token-main .two-column-fields),
+.formPage :global(.classic-link-fields) {
+  gap: 12px;
+}
+
 .formPage :global(.field input) {
-  min-height: 48px;
+  height: var(--launch-control-height);
+  min-height: var(--launch-control-height);
 }
 
 .formPage :global(.field textarea) {
@@ -540,7 +553,7 @@
 }
 
 .formPage :global(.classic-description-field) {
-  margin-top: 13px !important;
+  margin-top: 14px !important;
 }
 
 .formPage :global(.classic-description-field textarea) {
@@ -548,16 +561,15 @@
 }
 
 .formPage :global(.classic-link-fields) {
-  gap: 10px;
   margin-left: 0;
-  margin-top: 11px;
+  margin-top: 14px;
 }
 
 .formPage :global(.classic-fee-section),
 .formPage :global(.classic-v3-settings) {
   border-color: var(--panel-border-soft);
-  margin-top: 14px;
-  padding-top: 13px;
+  margin-top: 18px;
+  padding-top: 17px;
 }
 
 .formPage :global(.classic-fee-layout) {
@@ -578,15 +590,15 @@
 }
 
 .formPage :global(.meme-dev-buy-input) {
-  min-height: 46px;
+  min-height: var(--launch-control-height);
 }
 
 .formPage :global(.classic-launch-footer) {
   backdrop-filter: blur(18px);
   background: color-mix(in srgb, var(--glass-90) 82%, transparent);
   border-color: var(--panel-border-soft);
-  min-height: 50px;
-  padding: 0 28px;
+  min-height: 70px;
+  padding: 10px 28px;
 }
 
 .formPage :global(.classic-launch-button) {
@@ -603,13 +615,13 @@
 }
 
 .formPage :global(.classic-v3-core) {
-  gap: 12px;
+  gap: var(--launch-panel-gap);
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .formPage :global(.classic-v3-settings) {
   grid-template-columns: minmax(0, 1fr);
-  row-gap: 10px;
+  row-gap: 16px;
 }
 
 .formPage :global(.classic-v3-settings > .classic-section-heading),
@@ -645,13 +657,15 @@
   backdrop-filter: var(--control-glass-backdrop);
   background: var(--control-glass-background);
   border-color: var(--control-glass-border);
-  border-radius: 20px;
+  border-radius: 15px;
   box-shadow: inset 0 1px 0 var(--control-glass-highlight);
-  padding: 4px;
+  height: var(--launch-control-height);
+  min-height: var(--launch-control-height);
+  padding: 3px;
 }
 
 .formPage :global(.classic-v3-reward-mode button) {
-  border-radius: 16px;
+  border-radius: 11px;
   min-height: 44px;
   transition:
     background-color 160ms ease,
@@ -671,17 +685,43 @@
 .formPage :global(.classic-v3-reward-mode),
 .formPage :global(.classic-v3-initial-buy .meme-dev-buy),
 .formPage :global(.classic-v3-custody) {
-  background: transparent;
-  border: 0;
-  border-radius: 0;
-  border-top: 1px solid var(--panel-border-soft);
-  padding-inline: 0;
+  background: color-mix(in srgb, var(--glass-90) 92%, transparent);
+  border: 1px solid var(--control-border);
+  border-radius: 18px;
+  box-shadow: inset 0 1px 0 var(--control-glass-highlight);
+  padding: 15px;
+}
+
+.formPage :global(.classic-v3-fees legend),
+.formPage :global(.classic-v3-reward-mode legend) {
+  padding-inline: 5px;
+}
+
+.formPage :global(.launch-select-trigger),
+.formPage :global(.classic-v3-address-field input),
+.formPage :global(.classic-v3-split-row input),
+.formPage :global(.classic-v3-custody input) {
+  min-height: var(--launch-control-height);
 }
 
 .formPage :global(.classic-v3-initial-buy .meme-dev-buy-input button) {
   border-radius: 12px;
   min-height: 44px;
   min-width: 44px;
+}
+
+.formPage :global(.classic-v3-initial-buy) {
+  gap: var(--launch-panel-gap);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.formPage :global(.classic-v3-initial-buy .meme-dev-buy) {
+  align-content: start;
+  grid-template-columns: minmax(128px, 0.8fr) minmax(190px, 1.2fr);
+}
+
+.formPage :global(.classic-v3-custody) {
+  align-content: start;
 }
 
 .formPage :global(.deep-preset) {
@@ -753,14 +793,14 @@
 
 .formPage[data-launch-model="classic-v3"] :global(.classic-launch-content),
 .formPage[data-launch-model="deep"] :global(.classic-launch-content) {
-  padding-bottom: 10px;
-  padding-top: 14px;
+  padding-bottom: 20px;
+  padding-top: 20px;
 }
 
 .formPage[data-launch-model="classic-v3"] :global(.classic-token-grid),
 .formPage[data-launch-model="deep"] :global(.classic-token-grid) {
-  grid-template-columns: 128px minmax(0, 1fr);
-  margin-top: 10px;
+  grid-template-columns: 148px minmax(0, 1fr);
+  margin-top: 14px;
 }
 
 .formPage[data-launch-model="classic-v3"]
@@ -769,12 +809,12 @@
 .formPage[data-launch-model="deep"]
   :global(.classic-token-section)
   :global(.token-image-upload) {
-  width: 128px;
+  width: 148px;
 }
 
 .formPage[data-launch-model="classic-v3"] :global(.classic-description-field),
 .formPage[data-launch-model="deep"] :global(.classic-description-field) {
-  margin-top: 9px !important;
+  margin-top: 12px !important;
 }
 
 .formPage[data-launch-model="classic-v3"]
@@ -789,7 +829,7 @@
 .formPage[data-launch-model="classic-v3"] :global(.classic-link-fields),
 .formPage[data-launch-model="deep"] :global(.classic-link-fields) {
   margin-left: 0;
-  margin-top: 9px;
+  margin-top: 12px;
 }
 
 .formPage[data-launch-model="deep"] :global(.deep-preset) {
@@ -992,6 +1032,14 @@
     margin-left: 0;
   }
 
+  .formPage :global(.classic-v3-initial-buy) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .formPage :global(.classic-v3-initial-buy .meme-dev-buy) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .formPage[data-launch-model="classic-v3"] :global(.classic-link-fields),
   .formPage[data-launch-model="deep"] :global(.classic-link-fields) {
     margin-left: 0;
@@ -1113,6 +1161,14 @@
   .formPage :global(.classic-v3-fee-grid),
   .formPage :global(.deep-preset-stats) {
     grid-template-columns: 1fr;
+  }
+
+  .formPage :global(.classic-v3-reward-mode > div) {
+    gap: 5px;
+    grid-template-columns: minmax(0, 1fr);
+    height: auto;
+    min-height: 0;
+    padding: 5px;
   }
 
   .formPage :global(.deep-preset-stats > div),

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -119,11 +119,20 @@
   object-fit: cover;
   object-position: center;
   transform: scale(1.002);
-  transition: transform 240ms var(--ease-out);
 }
 
 .classicArt .artImage {
   filter: none;
+}
+
+.brandMark,
+.classicLogo {
+  aspect-ratio: 1;
+  inset: 50% auto auto 50%;
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: clamp(88px, 9.4vw, 128px);
+  z-index: 2;
 }
 
 .brandMark {
@@ -131,25 +140,16 @@
   -webkit-mask-position: center;
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-size: contain;
-  aspect-ratio: 1;
-  inset: 50% auto auto 50%;
   mask-image: url("/brand/loop/programmable-loop-mark-transparent-v1.png");
   mask-position: center;
   mask-repeat: no-repeat;
   mask-size: contain;
-  position: absolute;
-  transform: translate(-50%, -50%);
-  width: clamp(88px, 9.4vw, 128px);
-  z-index: 2;
 }
 
-.classicMark {
-  background: linear-gradient(
-    145deg,
-    rgb(24 27 30 / 0.98),
-    rgb(91 94 95 / 0.9)
-  );
-  filter: none;
+.classicLogo {
+  filter: drop-shadow(0 9px 22px rgb(95 54 68 / 0.13));
+  height: auto;
+  object-fit: contain;
 }
 
 .customMark {
@@ -166,6 +166,101 @@
   filter:
     drop-shadow(0 0 14px rgb(255 186 111 / 0.42))
     drop-shadow(0 12px 32px rgb(0 0 0 / 0.32));
+}
+
+.customSparkles {
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 3;
+}
+
+.customSparkles > span {
+  background: radial-gradient(
+    circle,
+    rgb(255 250 223 / 0.96) 0 13%,
+    rgb(255 225 177 / 0.54) 24%,
+    transparent 68%
+  );
+  border-radius: 50%;
+  height: 9px;
+  opacity: 0.16;
+  position: absolute;
+  transform: scale(0.78);
+  width: 9px;
+}
+
+.customSparkles > span:nth-child(1) {
+  left: 22%;
+  top: 23%;
+}
+
+.customSparkles > span:nth-child(2) {
+  right: 20%;
+  top: 31%;
+}
+
+.customSparkles > span:nth-child(3) {
+  bottom: 24%;
+  left: 32%;
+}
+
+@keyframes classic-botanical-breeze {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1.004);
+  }
+
+  28% {
+    transform: translate3d(-0.1%, 0, 0) scale(1.004);
+  }
+
+  58% {
+    transform: translate3d(0.08%, -0.08%, 0) scale(1.004);
+  }
+
+  78% {
+    transform: translate3d(0.04%, 0.05%, 0) scale(1.004);
+  }
+}
+
+@keyframes custom-star-sparkle {
+  0%,
+  72%,
+  100% {
+    opacity: 0.14;
+    transform: scale(0.78);
+  }
+
+  78% {
+    opacity: 0.68;
+    transform: scale(1.14);
+  }
+
+  84% {
+    opacity: 0.2;
+    transform: scale(0.82);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .classicArt .artImage {
+    animation: classic-botanical-breeze 9.6s steps(1, end) infinite;
+    will-change: transform;
+  }
+
+  .customSparkles > span {
+    animation: custom-star-sparkle 5.8s cubic-bezier(0.2, 0, 0, 1) infinite;
+    will-change: opacity, transform;
+  }
+
+  .customSparkles > span:nth-child(2) {
+    animation-delay: -2.1s;
+  }
+
+  .customSparkles > span:nth-child(3) {
+    animation-delay: -4.2s;
+  }
 }
 
 .modelBody.modelBody {
@@ -265,10 +360,6 @@
 
   .modelCard:hover .modelArt {
     outline-color: color-mix(in srgb, var(--text) 18%, transparent);
-  }
-
-  .modelCard:hover .artImage {
-    transform: scale(1.012);
   }
 
   .modelCard:hover .modelAction svg {
@@ -730,10 +821,6 @@
     transform: none;
   }
 
-  .modelCard[data-launch-model-available="true"]:hover .modelArt img {
-    transform: scale(1.006);
-  }
-
   .formPage :global(.launch-select-trigger:hover) {
     border-color: color-mix(in srgb, var(--accent) 34%, var(--control-border));
   }
@@ -1058,11 +1145,17 @@
 
 @media (prefers-reduced-motion: reduce) {
   .brandMark,
+  .classicLogo,
   .modelArt img,
   .modelArt,
   .modelAction svg,
   .modelCard {
     transition-duration: 0.01ms;
+  }
+
+  .classicArt .artImage,
+  .customSparkles > span {
+    animation: none;
   }
 
   .formLoadingTitle,

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -1,7 +1,7 @@
 .page {
   max-width: 1080px;
   min-height: calc(100svh - var(--header-height));
-  padding-block: clamp(34px, 5vw, 64px) 96px;
+  padding-block: clamp(28px, 4vw, 48px) 48px;
 }
 
 .hero,
@@ -252,7 +252,7 @@
 }
 
 .portfolio {
-  margin-block-start: 48px;
+  margin-block-start: 32px;
   min-width: 0;
 }
 
@@ -341,7 +341,7 @@
 }
 
 .profileWorkspace {
-  align-items: stretch;
+  align-items: start;
   display: grid;
   gap: 18px;
   grid-template-columns: minmax(0, 1fr) minmax(300px, 340px);
@@ -362,14 +362,14 @@
 .feePanel {
   display: flex;
   flex-direction: column;
-  min-height: 446px;
+  min-height: 340px;
   padding: 24px;
 }
 
 .claimablePanel {
   display: flex;
   flex-direction: column;
-  min-height: 446px;
+  min-height: 340px;
   padding: 20px;
 }
 
@@ -379,6 +379,10 @@
   display: flex;
   justify-content: space-between;
   min-width: 0;
+}
+
+.panelHeader {
+  gap: 12px;
 }
 
 .panelHeader h2,
@@ -441,12 +445,12 @@
   display: flex;
   flex-wrap: wrap;
   gap: 7px 12px;
-  margin-block-start: 30px;
+  margin-block-start: 22px;
   min-width: 0;
 }
 
 .feeSummary strong {
-  font-size: clamp(38px, 5vw, 54px);
+  font-size: clamp(34px, 4.4vw, 46px);
   font-variant-numeric: tabular-nums;
   font-weight: 590;
   letter-spacing: -0.052em;
@@ -466,10 +470,10 @@
   background: color-mix(in srgb, var(--surface-soft) 48%, transparent);
   border-radius: 20px;
   display: flex;
-  flex: 1;
+  flex: none;
   justify-content: center;
-  margin: 26px 0 0;
-  min-height: 244px;
+  margin: 20px 0 0;
+  min-height: 164px;
   min-width: 0;
   overflow: hidden;
   position: relative;
@@ -519,6 +523,39 @@
   gap: 10px;
   margin-block-start: 18px;
   min-width: 0;
+}
+
+.claimPagination {
+  align-items: center;
+  display: flex;
+  flex: none;
+  gap: 5px;
+}
+
+.claimPagination button {
+  align-items: center;
+  background: color-mix(in srgb, var(--surface-soft) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 11px;
+  color: var(--text-soft);
+  display: inline-flex;
+  font-size: 15px;
+  height: 40px;
+  justify-content: center;
+  width: 40px;
+}
+
+.claimPagination button:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.claimPagination > span {
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  min-width: 34px;
+  text-align: center;
 }
 
 .claimRow {
@@ -1297,6 +1334,63 @@
   white-space: nowrap;
 }
 
+.sessionLoading {
+  display: grid;
+  gap: 32px;
+}
+
+.sessionLoadingHero {
+  align-items: center;
+  display: grid;
+  gap: 20px;
+  grid-template-columns: 72px minmax(0, 1fr);
+  min-height: 108px;
+}
+
+.sessionLoadingAvatar,
+.sessionLoadingIdentity > span,
+.sessionLoadingWorkspace > span {
+  animation: profile-skeleton-pulse 1.6s ease-in-out infinite;
+  background: color-mix(in srgb, var(--surface-soft) 76%, transparent);
+}
+
+.sessionLoadingAvatar {
+  border-radius: 22px;
+  height: 72px;
+  width: 72px;
+}
+
+.sessionLoadingIdentity {
+  display: grid;
+  gap: 10px;
+}
+
+.sessionLoadingIdentity > span:first-child {
+  border-radius: 12px;
+  height: 42px;
+  max-width: 310px;
+  width: 52%;
+}
+
+.sessionLoadingIdentity > span:last-child {
+  border-radius: 7px;
+  height: 13px;
+  max-width: 150px;
+  width: 32%;
+}
+
+.sessionLoadingWorkspace {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 340px);
+}
+
+.sessionLoadingWorkspace > span {
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: 26px;
+  min-height: 340px;
+}
+
 .profileLoading {
   display: grid;
   gap: 24px;
@@ -1481,6 +1575,11 @@
     color: var(--text);
   }
 
+  .claimPagination button:not(:disabled):hover {
+    border-color: var(--border-strong);
+    color: var(--text);
+  }
+
   .tokenRow:hover {
     background: color-mix(in srgb, var(--glass-94) 86%, transparent);
     border-color: color-mix(in srgb, var(--border-strong) 82%, transparent);
@@ -1532,6 +1631,7 @@
 .claimIdentity:focus-visible,
 .tokenCard:focus-visible,
 .timeframeControls button:focus-visible,
+.claimPagination button:focus-visible,
 .emptyAction:focus-visible {
   outline: 2px solid var(--focus);
   outline-offset: 2px;
@@ -1555,7 +1655,8 @@
 }
 
 .tokenCard:active,
-.timeframeControls button:active {
+.timeframeControls button:active,
+.claimPagination button:not(:disabled):active {
   transform: scale(0.96);
 }
 
@@ -1640,7 +1741,8 @@
 }
 
 @media (max-width: 820px) {
-  .profileWorkspace {
+  .profileWorkspace,
+  .sessionLoadingWorkspace {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -1694,7 +1796,7 @@
   }
 
   .portfolio {
-    margin-block-start: 36px;
+    margin-block-start: 28px;
   }
 
   .feePanel,
@@ -1703,7 +1805,7 @@
   }
 
   .feePanel {
-    min-height: 420px;
+    min-height: 330px;
     padding: 20px;
   }
 
@@ -1712,7 +1814,7 @@
   }
 
   .feeChart {
-    min-height: 230px;
+    min-height: 164px;
   }
 
   .portfolioTitle h2 {
@@ -1746,6 +1848,32 @@
 }
 
 @media (max-width: 560px) {
+  .sessionLoadingHero {
+    gap: 14px;
+    grid-template-columns: 58px minmax(0, 1fr);
+    min-height: 82px;
+  }
+
+  .sessionLoadingAvatar {
+    border-radius: 17px;
+    height: 58px;
+    width: 58px;
+  }
+
+  .sessionLoadingIdentity > span:first-child {
+    height: 30px;
+    width: 68%;
+  }
+
+  .sessionLoadingIdentity > span:last-child {
+    width: 46%;
+  }
+
+  .claimPagination button {
+    height: 44px;
+    width: 44px;
+  }
+
   .hero {
     grid-template-columns: auto minmax(0, 1fr);
   }
@@ -2019,6 +2147,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .sessionLoadingAvatar,
+  .sessionLoadingIdentity > span,
+  .sessionLoadingWorkspace > span,
   .loadingHeading > span,
   .loadingArt,
   .loadingCopy > span,
@@ -2040,7 +2171,8 @@
   .retryButton,
   .emptyAction,
   .tokenCard,
-  .timeframeControls button {
+  .timeframeControls button,
+  .claimPagination button {
     transition: none;
   }
 
@@ -2055,6 +2187,7 @@
   .feePanel,
   .claimablePanel,
   .claimRow,
+  .claimPagination button,
   .tokenCard {
     background: Canvas;
   }

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -1753,8 +1753,8 @@
 
 @media (max-width: 720px) {
   .page {
-    min-height: calc(100svh - var(--header-height) - 68px);
-    padding-block: 28px 104px;
+    min-height: 0;
+    padding-block: 28px 40px;
   }
 
   .hero {
@@ -1777,8 +1777,8 @@
   }
 
   .connectCard {
-    min-height: calc(100svh - var(--header-height) - 124px);
-    padding: 42px 18px 72px;
+    min-height: 0;
+    padding: 42px 18px 36px;
   }
 
   .connectCard h1 {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -149,6 +149,15 @@ type ProfileWorkspaceSourceStatus =
   | StockPairedProfileRewards["status"];
 
 export type ProfileWorkspacePhase = "loading" | "ready" | "error";
+export type ProfileSessionView = "loading" | "connect" | "profile";
+
+export function getProfileSessionView(
+  connecting: boolean,
+  account?: string,
+): ProfileSessionView {
+  if (connecting) return "loading";
+  return account ? "profile" : "connect";
+}
 
 export function getProfileWorkspacePhase(
   statuses: readonly ProfileWorkspaceSourceStatus[],
@@ -204,40 +213,6 @@ function formatStockRewardEstimate(reward: StockPairedReward) {
     maximumFractionDigits: usd < 1 ? 3 : 2,
   }).format(usd);
   return `≈ $${formattedUsd} · ${formatEth(reward.estimatedEth)}`;
-}
-
-function formatMarketCap(token: ProfileToken) {
-  if (token.fdvUsdWad) {
-    const dollars = Number(BigInt(token.fdvUsdWad) / 10n ** 18n);
-    if (Number.isFinite(dollars)) {
-      if (dollars >= 1_000_000_000) {
-        return `$${(dollars / 1_000_000_000).toFixed(1).replace(/\.0$/, "")}B`;
-      }
-      if (dollars >= 1_000_000) {
-        return `$${(dollars / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
-      }
-      if (dollars >= 1_000) {
-        return `$${(dollars / 1_000).toFixed(1).replace(/\.0$/, "")}K`;
-      }
-      return `$${dollars.toLocaleString("en-US")}`;
-    }
-  }
-  if (token.marketCapEthWei) {
-    return formatEth(formatUnits(BigInt(token.marketCapEthWei), 18));
-  }
-  if (token.marketCapQuoteWad && token.quoteAssetSymbol) {
-    const value = Number(
-      formatUnits(BigInt(token.marketCapQuoteWad), 18),
-    );
-    if (Number.isFinite(value)) {
-      return `${new Intl.NumberFormat("en-US", {
-        notation: value >= 1_000 ? "compact" : "standard",
-        maximumFractionDigits: 2,
-        maximumSignificantDigits: 6,
-      }).format(value)} ${token.quoteAssetSymbol}`;
-    }
-  }
-  return null;
 }
 
 type WaitForTransactionOptions = {
@@ -526,6 +501,17 @@ export function clearConfirmedProfileActionStates<
   return changed ? next : states;
 }
 
+export function reflectedConfirmedProfileTransactions(
+  confirmed: ReadonlyMap<string, Hex>,
+  claimableForStateKey: (stateKey: string) => bigint | undefined,
+) {
+  return new Map(
+    [...confirmed].filter(([stateKey]) =>
+      claimableForStateKey(stateKey) === 0n,
+    ),
+  );
+}
+
 function pendingProfileTransactionStorageKey(account: string) {
   const normalizedAccount = normalizeEthereumAddress(account);
   return normalizedAccount
@@ -732,7 +718,7 @@ export function withoutClosedDeepProfileData(
 }
 
 export function ProfileView({ onchainData }: ProfileViewProps = {}) {
-  const { wallet, openWallet, sendTransaction } = useWallet();
+  const { wallet, openWallet, sendTransaction, connecting } = useWallet();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const account = wallet?.account;
   const activeAccountRef = useRef(account);
@@ -871,13 +857,23 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     void fetchCreatorProfile(account, controller.signal)
       .then((data) => {
         if (!controller.signal.aborted) {
+          const reflectedTransactions =
+            reflectedConfirmedProfileTransactions(
+              confirmedTransactions,
+              (stateKey) => {
+                const claim = data.claims.find(
+                  (entry) => entry.poolId.toLowerCase() === stateKey,
+                );
+                return claim ? BigInt(claim.claimableWei) : 0n;
+              },
+            );
           setRemoteOnchainData(data);
           setClaimActionStates((current) =>
-            clearConfirmedProfileActionStates(current, confirmedTransactions),
+            clearConfirmedProfileActionStates(current, reflectedTransactions),
           );
           consumeConfirmedProfileTransactions(
             confirmedProfileTransactionsRef.current.classic,
-            confirmedTransactions,
+            reflectedTransactions,
           );
         }
       })
@@ -905,13 +901,26 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     void fetchClassicV3ProfileRewards(account, controller.signal)
       .then((data) => {
         if (!controller.signal.aborted) {
+          const reflectedTransactions =
+            reflectedConfirmedProfileTransactions(
+              confirmedTransactions,
+              (stateKey) => {
+                if (stateKey.includes(":update-payout")) return 0n;
+                const vaultAddress = stateKey.split(":")[0];
+                const reward = data.rewards.find(
+                  (entry) =>
+                    entry.vaultAddress.toLowerCase() === vaultAddress,
+                );
+                return reward ? BigInt(reward.claimableWei) : 0n;
+              },
+            );
           setClassicV3Rewards(data);
           setClassicV3ActionStates((current) =>
-            clearConfirmedProfileActionStates(current, confirmedTransactions),
+            clearConfirmedProfileActionStates(current, reflectedTransactions),
           );
           consumeConfirmedProfileTransactions(
             confirmedProfileTransactionsRef.current["classic-v3"],
-            confirmedTransactions,
+            reflectedTransactions,
           );
         }
       })
@@ -939,13 +948,26 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     void fetchDeepProfileRewards(account, controller.signal)
       .then((data) => {
         if (!controller.signal.aborted) {
+          const reflectedTransactions =
+            reflectedConfirmedProfileTransactions(
+              confirmedTransactions,
+              (stateKey) => {
+                if (stateKey.endsWith(":update-payout")) return 0n;
+                const vaultAddress = stateKey.split(":")[0];
+                const reward = data.rewards.find(
+                  (entry) =>
+                    entry.vaultAddress.toLowerCase() === vaultAddress,
+                );
+                return reward ? BigInt(reward.claimableWei) : 0n;
+              },
+            );
           setDeepRewards(data);
           setDeepActionStates((current) =>
-            clearConfirmedProfileActionStates(current, confirmedTransactions),
+            clearConfirmedProfileActionStates(current, reflectedTransactions),
           );
           consumeConfirmedProfileTransactions(
             confirmedProfileTransactionsRef.current.deep,
-            confirmedTransactions,
+            reflectedTransactions,
           );
         }
       })
@@ -998,13 +1020,26 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     void fetchStockPairedProfileRewards(account, controller.signal)
       .then((data) => {
         if (!controller.signal.aborted) {
+          const reflectedTransactions =
+            reflectedConfirmedProfileTransactions(
+              confirmedTransactions,
+              (stateKey) => {
+                if (stateKey.endsWith(":update-payout")) return 0n;
+                const vaultAddress = stateKey.split(":")[0];
+                const reward = data.rewards.find(
+                  (entry) =>
+                    entry.vaultAddress.toLowerCase() === vaultAddress,
+                );
+                return reward ? BigInt(reward.claimableRaw) : 0n;
+              },
+            );
           setStockPairedRewards(data);
           setStockPairedActionStates((current) =>
-            clearConfirmedProfileActionStates(current, confirmedTransactions),
+            clearConfirmedProfileActionStates(current, reflectedTransactions),
           );
           consumeConfirmedProfileTransactions(
             confirmedProfileTransactionsRef.current["stock-paired"],
-            confirmedTransactions,
+            reflectedTransactions,
           );
         }
       })
@@ -1854,6 +1889,10 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
                 );
               }
               if (transactionKind === "swap") {
+                confirmedProfileTransactionsRef.current["stock-paired"].set(
+                  stateKey,
+                  transactionHash,
+                );
                 setActionState({
                   status: "confirmed",
                   message: "Claimed as ETH",
@@ -1867,6 +1906,10 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
               "The conversion needs more approval steps than expected",
             );
           }
+          confirmedProfileTransactionsRef.current["stock-paired"].set(
+            stateKey,
+            transactionHash,
+          );
           setActionState({
             status: "confirmed",
             message:
@@ -1939,7 +1982,13 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     setProfileRefresh((current) => current + 1);
   }
 
-  if (!account) {
+  const sessionView = getProfileSessionView(connecting, account);
+
+  if (sessionView === "loading") {
+    return <ProfileSessionLoadingState />;
+  }
+
+  if (sessionView === "connect" || !account) {
     return (
       <div className={`${styles.page} page-width`}>
         <section className={styles.connectCard}>
@@ -2106,6 +2155,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       </section>
 
       <ProfileAccountWorkspace
+        key={account.toLowerCase()}
         connected={Boolean(account)}
         data={scopedOnchainData}
         account={account}
@@ -2141,6 +2191,15 @@ export type ProfilePortfolioEntry = ProfileTokenReward & {
   deepV3Token?: DeepV3CreatorToken;
   launchedByWallet: boolean;
 };
+
+type ProfileActionStateCollections = {
+  claim: Record<string, ProfileClaimActionState>;
+  classicV3: Record<string, ClassicV3ActionState>;
+  deep: Record<string, DeepActionState>;
+  stockPaired: Record<string, StockPairedActionState>;
+};
+
+export const profileClaimPageSize = 5;
 
 export function groupProfileRewards(
   tokens: readonly ProfileToken[],
@@ -2455,6 +2514,153 @@ function profileEntryClaimableWei(
   );
 }
 
+function confirmedForAccount(
+  state: ProfileClaimActionState | ClassicV3ActionState | undefined,
+  account?: string,
+) {
+  return (
+    state?.status === "confirmed" &&
+    (!account || state.account.toLowerCase() === account.toLowerCase())
+  );
+}
+
+function profileEntryActionableNativeWei(
+  entry: ProfilePortfolioEntry,
+  account: string | undefined,
+  actionStates?: ProfileActionStateCollections,
+) {
+  const normalizedAccount = account?.toLowerCase();
+  const ownsReward = (beneficiary: string) =>
+    !normalizedAccount || beneficiary.toLowerCase() === normalizedAccount;
+  let total = 0n;
+
+  if (
+    entry.claim &&
+    !confirmedForAccount(
+      actionStates?.claim[entry.claim.poolId.toLowerCase()],
+      account,
+    )
+  ) {
+    total += BigInt(entry.claim.claimableWei);
+  }
+
+  for (const reward of entry.classicRewards) {
+    if (
+      ownsReward(reward.beneficiary) &&
+      !confirmedForAccount(
+        actionStates?.classicV3[
+          `${reward.vaultAddress.toLowerCase()}:claim`
+        ],
+        account,
+      )
+    ) {
+      total += BigInt(reward.claimableWei);
+    }
+  }
+
+  for (const reward of entry.deepRewards) {
+    if (
+      ownsReward(reward.beneficiary) &&
+      !confirmedForAccount(
+        actionStates?.deep[`${reward.vaultAddress.toLowerCase()}:claim`],
+        account,
+      )
+    ) {
+      total += BigInt(reward.claimableWei);
+    }
+  }
+
+  return total;
+}
+
+function profileEntryActionableStockAmounts(
+  entry: ProfilePortfolioEntry,
+  account: string | undefined,
+  actionStates?: ProfileActionStateCollections,
+) {
+  const normalizedAccount = account?.toLowerCase();
+  let raw = 0n;
+  let estimatedEthWei = 0n;
+
+  for (const reward of entry.stockPairedRewards) {
+    if (
+      normalizedAccount &&
+      reward.beneficiary.toLowerCase() !== normalizedAccount
+    ) {
+      continue;
+    }
+    const vault = reward.vaultAddress.toLowerCase();
+    if (
+      confirmedForAccount(actionStates?.stockPaired[`${vault}:claim`], account) ||
+      confirmedForAccount(
+        actionStates?.stockPaired[`${vault}:claim-as-eth`],
+        account,
+      )
+    ) {
+      continue;
+    }
+
+    raw += BigInt(reward.claimableRaw);
+    if (reward.estimatedEthRaw && /^(0|[1-9]\d*)$/.test(reward.estimatedEthRaw)) {
+      estimatedEthWei += BigInt(reward.estimatedEthRaw);
+    }
+  }
+
+  return { raw, estimatedEthWei };
+}
+
+export function sortProfileClaimableEntries(
+  entries: readonly ProfilePortfolioEntry[],
+  account?: string,
+  actionStates?: ProfileActionStateCollections,
+) {
+  return [...entries].sort((first, second) => {
+    const firstStock = profileEntryActionableStockAmounts(
+      first,
+      account,
+      actionStates,
+    );
+    const secondStock = profileEntryActionableStockAmounts(
+      second,
+      account,
+      actionStates,
+    );
+    const firstEstimatedEth =
+      profileEntryActionableNativeWei(first, account, actionStates) +
+      firstStock.estimatedEthWei;
+    const secondEstimatedEth =
+      profileEntryActionableNativeWei(second, account, actionStates) +
+      secondStock.estimatedEthWei;
+
+    if (firstEstimatedEth !== secondEstimatedEth) {
+      return firstEstimatedEth > secondEstimatedEth ? -1 : 1;
+    }
+    if (firstStock.raw !== secondStock.raw) {
+      return firstStock.raw > secondStock.raw ? -1 : 1;
+    }
+    return first.token.address.localeCompare(second.token.address);
+  });
+}
+
+export function paginateProfileClaimableEntries<T>(
+  entries: readonly T[],
+  requestedPage: number,
+  pageSize = profileClaimPageSize,
+) {
+  const safePageSize = Math.max(1, Math.floor(pageSize));
+  const totalPages = Math.max(1, Math.ceil(entries.length / safePageSize));
+  const currentPage = Math.min(
+    totalPages,
+    Math.max(1, Math.floor(requestedPage) || 1),
+  );
+  const start = (currentPage - 1) * safePageSize;
+  return {
+    currentPage,
+    totalPages,
+    items: entries.slice(start, start + safePageSize),
+  };
+}
+
 function profileEntryStockClaimableRaw(
   entry: ProfilePortfolioEntry,
   account?: string,
@@ -2490,7 +2696,9 @@ function profileEntryHasVisibleClaimState(
   if (!normalizedAccount) return false;
   const belongsToAccount = (
     state: ProfileClaimActionState | ClassicV3ActionState | undefined,
-  ) => state?.account.toLowerCase() === normalizedAccount;
+  ) =>
+    state?.account.toLowerCase() === normalizedAccount &&
+    state.status !== "confirmed";
 
   if (
     entry.claim &&
@@ -2541,6 +2749,30 @@ function profileEntryHasVisibleClaimState(
   );
 }
 
+function profileEntryHasActionableReward(
+  entry: ProfilePortfolioEntry,
+  account: string | undefined,
+  actionStates: ProfileActionStateCollections,
+) {
+  const stock = profileEntryActionableStockAmounts(
+    entry,
+    account,
+    actionStates,
+  );
+  return (
+    profileEntryActionableNativeWei(entry, account, actionStates) > 0n ||
+    stock.raw > 0n ||
+    profileEntryHasVisibleClaimState(
+      entry,
+      account,
+      actionStates.claim,
+      actionStates.classicV3,
+      actionStates.deep,
+      actionStates.stockPaired,
+    )
+  );
+}
+
 export function profileHasRewardSurface(
   entries: readonly ProfilePortfolioEntry[],
 ) {
@@ -2564,6 +2796,33 @@ export function profileRewardsForAccount<
   return rewards.filter(
     (reward) =>
       reward.beneficiary.toLowerCase() === normalizedAccount,
+  );
+}
+
+function ProfileSessionLoadingState() {
+  return (
+    <div className={`${styles.page} page-width`}>
+      <section
+        className={styles.sessionLoading}
+        aria-busy="true"
+        aria-label="Restoring wallet profile"
+      >
+        <span className={styles.visuallyHidden} role="status">
+          Restoring wallet profile
+        </span>
+        <div className={styles.sessionLoadingHero} aria-hidden="true">
+          <span className={styles.sessionLoadingAvatar} />
+          <span className={styles.sessionLoadingIdentity}>
+            <span />
+            <span />
+          </span>
+        </div>
+        <div className={styles.sessionLoadingWorkspace} aria-hidden="true">
+          <span />
+          <span />
+        </div>
+      </section>
+    </div>
   );
 }
 
@@ -2650,6 +2909,8 @@ function ProfileAccountWorkspace({
   onRetry: () => void;
   terminalErrorReady: boolean;
 }) {
+  const [claimPage, setClaimPage] = useState(1);
+
   if (!connected) {
     return (
       <section className={styles.accountState}>
@@ -2741,19 +3002,23 @@ function ProfileAccountWorkspace({
       ).length,
     0,
   );
-  const claimableEntries = entries.filter(
-    (entry) =>
-      profileEntryHasClaimableReward(entry, account) ||
-      profileEntryHasVisibleClaimState(
-        entry,
-        account,
-        claimActionStates,
-        classicV3ActionStates,
-        deepActionStates,
-        stockPairedActionStates,
-      ),
+  const actionStates: ProfileActionStateCollections = {
+    claim: claimActionStates,
+    classicV3: classicV3ActionStates,
+    deep: deepActionStates,
+    stockPaired: stockPairedActionStates,
+  };
+  const claimableEntries = sortProfileClaimableEntries(
+    entries.filter((entry) =>
+      profileEntryHasActionableReward(entry, account, actionStates),
+    ),
+    account,
+    actionStates,
   );
-  const ownedEntries = entries.filter((entry) => entry.launchedByWallet);
+  const claimPageData = paginateProfileClaimableEntries(
+    claimableEntries,
+    claimPage,
+  );
   const chainId = currentReady
     ? data.chainId
     : classicReady
@@ -2809,25 +3074,62 @@ function ProfileAccountWorkspace({
         >
           <header className={styles.panelHeader}>
             <h2 id="profile-claimable-title">Claimable</h2>
+            {claimPageData.totalPages > 1 ? (
+              <nav
+                className={styles.claimPagination}
+                aria-label="Claimable rewards pages"
+              >
+                <button
+                  type="button"
+                  aria-label="Previous claimable rewards page"
+                  disabled={claimPageData.currentPage === 1}
+                  onClick={() =>
+                    setClaimPage(Math.max(1, claimPageData.currentPage - 1))
+                  }
+                >
+                  <span aria-hidden="true">←</span>
+                </button>
+                <span aria-live="polite" aria-atomic="true">
+                  {claimPageData.currentPage} / {claimPageData.totalPages}
+                </span>
+                <button
+                  type="button"
+                  aria-label="Next claimable rewards page"
+                  disabled={
+                    claimPageData.currentPage === claimPageData.totalPages
+                  }
+                  onClick={() =>
+                    setClaimPage(
+                      Math.min(
+                        claimPageData.totalPages,
+                        claimPageData.currentPage + 1,
+                      ),
+                    )
+                  }
+                >
+                  <span aria-hidden="true">→</span>
+                </button>
+              </nav>
+            ) : null}
           </header>
 
           {claimableEntries.length ? (
             <div className={styles.claimList}>
-              {claimableEntries.map((entry) => (
+              {claimPageData.items.map((entry) => (
                 <ProfileClaimRow
-                key={entry.token.address}
-                entry={entry}
-                account={account}
-                chainId={chainId}
-                claimActionStates={claimActionStates}
-                classicV3ActionStates={classicV3ActionStates}
-                deepActionStates={deepActionStates}
-                stockPairedActionStates={stockPairedActionStates}
-                onClaim={onClaim}
-                onClassicV3Action={onClassicV3Action}
-                onDeepAction={onDeepAction}
-                onStockPairedAction={onStockPairedAction}
-              />
+                  key={entry.token.address}
+                  entry={entry}
+                  account={account}
+                  chainId={chainId}
+                  claimActionStates={claimActionStates}
+                  classicV3ActionStates={classicV3ActionStates}
+                  deepActionStates={deepActionStates}
+                  stockPairedActionStates={stockPairedActionStates}
+                  onClaim={onClaim}
+                  onClassicV3Action={onClassicV3Action}
+                  onDeepAction={onDeepAction}
+                  onStockPairedAction={onStockPairedAction}
+                />
               ))}
             </div>
           ) : (
@@ -2838,29 +3140,6 @@ function ProfileAccountWorkspace({
           )}
         </section>
       </div>
-
-      <section
-        className={styles.tokenCollection}
-        aria-labelledby="profile-tokens-title"
-      >
-        <header className={styles.panelHeader}>
-          <h2 id="profile-tokens-title">Your tokens</h2>
-        </header>
-        {ownedEntries.length ? (
-          <div className={styles.tokenGrid}>
-            {ownedEntries.map((entry) => (
-              <ProfileTokenLink key={entry.token.address} entry={entry} />
-            ))}
-          </div>
-        ) : (
-          <ProfileSectionEmpty
-            title="No tokens yet"
-            detail="Tokens created with this wallet will appear here."
-            actionHref="/launch"
-            actionLabel="Create token"
-          />
-        )}
-      </section>
     </section>
   );
 }
@@ -2928,36 +3207,6 @@ function FeeEarningsPanel({
         </figcaption>
       </figure>
     </section>
-  );
-}
-
-function ProfileTokenLink({ entry }: { entry: ProfilePortfolioEntry }) {
-  const { token } = entry;
-  const tokenImage =
-    token.imageUrl?.trim() || getFallbackTokenImage(token.address);
-  const tokenImageSource = getTokenCardImageSource(tokenImage);
-  const marketCap = formatMarketCap(token);
-
-  return (
-    <Link className={styles.tokenCard} href={token.href}>
-      <span className={styles.tokenCardArt}>
-        <Image
-          src={tokenImageSource}
-          alt=""
-          fill
-          sizes="52px"
-          unoptimized={!canOptimizeTokenImage(tokenImageSource)}
-        />
-      </span>
-      <span className={styles.tokenCardCopy}>
-        <strong>{token.name}</strong>
-        <span>${token.symbol}</span>
-      </span>
-      <span className={styles.tokenCardMetric}>
-        <small>Market cap</small>
-        <strong>{marketCap ?? "—"}</strong>
-      </span>
-    </Link>
   );
 }
 
@@ -3045,10 +3294,12 @@ function ProfileClaimRow({
   const claimState = claim
     ? claimActionStates[claim.poolId.toLowerCase()]
     : undefined;
-  const activeClaimState =
+  const scopedClaimState =
     claimState?.account.toLowerCase() === account?.toLowerCase()
       ? claimState
       : undefined;
+  const activeClaimState =
+    scopedClaimState?.status === "confirmed" ? undefined : scopedClaimState;
   const ownedClassicRewards = profileRewardsForAccount(
     classicRewards,
     account,
@@ -3058,13 +3309,15 @@ function ProfileClaimRow({
       classicV3ActionStates[
         `${reward.vaultAddress.toLowerCase()}:claim`
       ];
+    const scopedState =
+      state?.account.toLowerCase() === account?.toLowerCase()
+        ? state
+        : undefined;
+    const confirmed = scopedState?.status === "confirmed";
     return {
       reward,
-      claimable: BigInt(reward.claimableWei),
-      state:
-        state?.account.toLowerCase() === account?.toLowerCase()
-          ? state
-          : undefined,
+      claimable: confirmed ? 0n : BigInt(reward.claimableWei),
+      state: confirmed ? undefined : scopedState,
     };
   });
   const ownedDeepRewards = profileRewardsForAccount(deepRewards, account);
@@ -3073,13 +3326,15 @@ function ProfileClaimRow({
       deepActionStates[
         `${reward.vaultAddress.toLowerCase()}:claim`
       ];
+    const scopedState =
+      state?.account.toLowerCase() === account?.toLowerCase()
+        ? state
+        : undefined;
+    const confirmed = scopedState?.status === "confirmed";
     return {
       reward,
-      claimable: BigInt(reward.claimableWei),
-      state:
-        state?.account.toLowerCase() === account?.toLowerCase()
-          ? state
-          : undefined,
+      claimable: confirmed ? 0n : BigInt(reward.claimableWei),
+      state: confirmed ? undefined : scopedState,
     };
   });
   const ownedStockPairedRewards = profileRewardsForAccount(
@@ -3095,20 +3350,28 @@ function ProfileClaimRow({
       stockPairedActionStates[
         `${reward.vaultAddress.toLowerCase()}:claim-as-eth`
       ];
+    const scopedClaimState =
+      claimState?.account.toLowerCase() === account?.toLowerCase()
+        ? claimState
+        : undefined;
+    const scopedEthState =
+      ethState?.account.toLowerCase() === account?.toLowerCase()
+        ? ethState
+        : undefined;
+    const confirmed =
+      scopedClaimState?.status === "confirmed" ||
+      scopedEthState?.status === "confirmed";
     return {
       reward,
-      claimable: BigInt(reward.claimableRaw),
-      claimState:
-        claimState?.account.toLowerCase() === account?.toLowerCase()
-          ? claimState
-          : undefined,
-      ethState:
-        ethState?.account.toLowerCase() === account?.toLowerCase()
-          ? ethState
-          : undefined,
+      claimable: confirmed ? 0n : BigInt(reward.claimableRaw),
+      claimState: confirmed ? undefined : scopedClaimState,
+      ethState: confirmed ? undefined : scopedEthState,
     };
   });
-  const currentClaimable = BigInt(claim?.claimableWei ?? "0");
+  const currentClaimable =
+    scopedClaimState?.status === "confirmed"
+      ? 0n
+      : BigInt(claim?.claimableWei ?? "0");
   const classicClaimable = classicClaims.reduce(
     (total, item) => total + item.claimable,
     0n,
@@ -3404,30 +3667,5 @@ function ProfileActionState({
         </a>
       ) : null}
     </p>
-  );
-}
-
-
-function ProfileSectionEmpty({
-  title,
-  detail,
-  actionHref,
-  actionLabel,
-}: {
-  title: string;
-  detail: string;
-  actionHref?: string;
-  actionLabel?: string;
-}) {
-  return (
-    <div className={styles.emptySection}>
-      <strong>{title}</strong>
-      <p>{detail}</p>
-      {actionHref && actionLabel ? (
-        <Link className={styles.emptyAction} href={actionHref}>
-          {actionLabel}
-        </Link>
-      ) : null}
-    </div>
   );
 }

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -38,9 +38,6 @@ function clearThemeReveal(root: HTMLElement) {
     themeFallbackTimer = null;
   }
   delete root.dataset.themeTransition;
-  root.style.removeProperty("--theme-reveal-x");
-  root.style.removeProperty("--theme-reveal-y");
-  root.style.removeProperty("--theme-reveal-radius");
 }
 
 const desktopNavItems = [
@@ -124,17 +121,6 @@ function ThemeToggle() {
     }
     delete root.dataset.themeInput;
 
-    const toggleBounds = event.currentTarget.getBoundingClientRect();
-    const originX = toggleBounds.left + toggleBounds.width / 2;
-    const originY = toggleBounds.top + toggleBounds.height / 2;
-    const radius = Math.hypot(
-      Math.max(originX, window.innerWidth - originX),
-      Math.max(originY, window.innerHeight - originY),
-    );
-    root.style.setProperty("--theme-reveal-x", `${originX}px`);
-    root.style.setProperty("--theme-reveal-y", `${originY}px`);
-    root.style.setProperty("--theme-reveal-radius", `${radius}px`);
-
     const runFallbackReveal = () => {
       root.dataset.themeTransition = `fallback-${nextTheme}`;
       root.getBoundingClientRect();
@@ -143,7 +129,7 @@ function ThemeToggle() {
         if (transitionSequence === themeTransitionSequence) {
           clearThemeReveal(root);
         }
-      }, 320);
+      }, 420);
     };
 
     if (!viewTransitionDocument.startViewTransition) {
@@ -151,7 +137,7 @@ function ThemeToggle() {
       return;
     }
 
-    root.dataset.themeTransition = "radial";
+    root.dataset.themeTransition = "soft";
 
     try {
       const transition = viewTransitionDocument.startViewTransition(() => {
@@ -170,9 +156,6 @@ function ThemeToggle() {
       void transition.finished.then(finishReveal, finishReveal);
     } catch {
       clearThemeReveal(root);
-      root.style.setProperty("--theme-reveal-x", `${originX}px`);
-      root.style.setProperty("--theme-reveal-y", `${originY}px`);
-      root.style.setProperty("--theme-reveal-radius", `${radius}px`);
       runFallbackReveal();
     }
   }

--- a/lib/data-pipeline/optimistic-public-api-overlay.server.ts
+++ b/lib/data-pipeline/optimistic-public-api-overlay.server.ts
@@ -2,7 +2,10 @@ import "server-only";
 
 import { formatUnits, getAddress, isAddress, type Hex } from "viem";
 
-import { paginateExplore } from "../onchain/query";
+import {
+  paginateExplore,
+  type ExploreSocialFilter,
+} from "../onchain/query";
 import type {
   ExplorePage,
   ExploreReadModel,
@@ -524,6 +527,7 @@ export function buildOptimisticExplorePage(input: Readonly<{
     sort: ExploreSort;
     page: number;
     pageSize: number;
+    socials: ExploreSocialFilter | null;
   }>;
   snapshot: PersistedOptimisticPublicSnapshot;
   nowMs?: number;
@@ -754,6 +758,7 @@ export async function overlayExploreCanonicalResponse(input: Readonly<{
     sort: ExploreSort;
     page: number;
     pageSize: number;
+    socials: ExploreSocialFilter | null;
   }>;
   nowMs?: number;
 }>): Promise<Response> {

--- a/lib/data-pipeline/postgres-read-model.server.ts
+++ b/lib/data-pipeline/postgres-read-model.server.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import type { TokenChartRange } from "../onchain/chart";
 import type { ExploreSort } from "../onchain/types";
+import type { ExploreSocialFilter } from "../onchain/query";
 
 import type { PostgresTransaction } from "./postgres";
 import {
@@ -33,6 +34,7 @@ export type IndexedExploreReadRequest = {
   sort: ExploreSort;
   page: number;
   pageSize: number;
+  socials: ExploreSocialFilter | null;
 };
 
 export type IndexedTokenReadRequest = {

--- a/lib/data-pipeline/public-route-queries.server.ts
+++ b/lib/data-pipeline/public-route-queries.server.ts
@@ -372,13 +372,14 @@ export const postgresPublicRouteQueries: IndexedRouteSnapshotQueries =
     explore(transaction, request) {
       return readEnvelope<IndexedExploreListDataV2>({
         transaction,
-        sql: `select * from programmable_private.get_public_explore_page_v1($1, $2, $3, $4, $5)`,
+        sql: `select * from programmable_private.get_public_explore_page_v2($1, $2, $3, $4, $5, $6)`,
         values: [
           request.chainId,
           request.query,
           request.sort,
           request.page,
           request.pageSize,
+          request.socials,
         ],
         kind: "explore",
         scope: DISCOVERY_SCOPE,

--- a/lib/data-pipeline/route-adapters.server.ts
+++ b/lib/data-pipeline/route-adapters.server.ts
@@ -396,6 +396,7 @@ export type IndexedExploreCursorV2 = {
 export type IndexedExploreListDataV2 = {
   request: {
     query: string;
+    socials: "yes" | "no" | null;
     sort: ExploreSort;
     requestedPage: number;
     pageSize: number;
@@ -1608,6 +1609,13 @@ export function adaptIndexedExploreListV2(
   );
   const { request, page, tokens } = ready.data;
   if (!validExploreSort(request.sort)) fail("invalid-input", "explore-sort");
+  if (
+    request.socials !== null &&
+    request.socials !== "yes" &&
+    request.socials !== "no"
+  ) {
+    fail("invalid-input", "explore-socials");
+  }
   const requestedPage = boundedInteger(
     request.requestedPage,
     1,
@@ -1657,13 +1665,21 @@ export function adaptIndexedExploreListV2(
     : null;
   const positions = tokens.map((projection) => {
     validateRowSource(projection.source, ready.snapshot, "explore-list");
+    const hasSocials = Boolean(
+      projection.metadata?.links.some(
+        (link: IndexedProjectMetadataV2["links"][number]) =>
+          link.kind === "x" || link.kind === "telegram",
+      ),
+    );
     if (
-      normalizedQuery &&
-      !projection.name.toLowerCase().includes(normalizedQuery) &&
-      !projection.symbol.toLowerCase().includes(normalizedQuery) &&
-      !projection.tokenAddress.toLowerCase().includes(normalizedQuery)
+      (normalizedQuery &&
+        !projection.name.toLowerCase().includes(normalizedQuery) &&
+        !projection.symbol.toLowerCase().includes(normalizedQuery) &&
+        !projection.tokenAddress.toLowerCase().includes(normalizedQuery)) ||
+      (request.socials !== null &&
+        hasSocials !== (request.socials === "yes"))
     ) {
-      fail("scope-mismatch", "explore-query");
+      fail("scope-mismatch", "explore-filter");
     }
     return cursorPosition(projection, page.valuationUnit);
   });

--- a/lib/onchain/query.ts
+++ b/lib/onchain/query.ts
@@ -10,6 +10,8 @@ const DEFAULT_PAGE_SIZE = 6;
 const MAX_PAGE_SIZE = 100;
 const MAINNET_PUBLIC_EXPLORE_START_BLOCK = 25_626_490n;
 
+export type ExploreSocialFilter = "yes" | "no";
+
 export function parseExploreSort(value: string | null): ExploreSort {
   if (value === "newest") return "newest";
   if (value === "oldest") return "oldest";
@@ -65,19 +67,30 @@ export function filterAndSortTokens(
   tokens: LauncherToken[],
   query: string,
   sort: ExploreSort,
+  socials: ExploreSocialFilter | null = null,
 ) {
   const normalizedQuery = query
     .trim()
     .toLowerCase()
     .replace(/^\$/, "");
+  const socialMatches = socials
+    ? tokens.filter((token) => {
+        const hasSocials = Boolean(
+          token.links?.some(
+            (link) => link.kind === "x" || link.kind === "telegram",
+          ),
+        );
+        return hasSocials === (socials === "yes");
+      })
+    : [...tokens];
   const filtered = normalizedQuery
-    ? tokens.filter(
+    ? socialMatches.filter(
         (token) =>
           token.name.toLowerCase().includes(normalizedQuery) ||
           token.symbol.toLowerCase().includes(normalizedQuery) ||
           token.tokenAddress.toLowerCase().includes(normalizedQuery),
       )
-    : [...tokens];
+    : socialMatches;
   const marketCapSource = filtered.some(
     (token) =>
       unsignedWad(
@@ -121,6 +134,7 @@ export function paginateExplore(
     sort?: ExploreSort;
     page?: number;
     pageSize?: number;
+    socials?: ExploreSocialFilter | null;
   } = {},
 ): ExplorePage {
   const query = options.query?.trim() ?? "";
@@ -146,7 +160,12 @@ export function paginateExplore(
           );
         })
       : model.tokens;
-  const sorted = filterAndSortTokens(visibleTokens, query, sort);
+  const sorted = filterAndSortTokens(
+    visibleTokens,
+    query,
+    sort,
+    options.socials ?? null,
+  );
   const totalPages = Math.ceil(sorted.length / pageSize);
   const page = totalPages === 0 ? 1 : Math.min(requestedPage, totalPages);
   const offset = (page - 1) * pageSize;

--- a/supabase/migrations/20260803192207_explore_social_filter.sql
+++ b/supabase/migrations/20260803192207_explore_social_filter.sql
@@ -1,0 +1,373 @@
+set role programmable_migrator;
+
+create function programmable_private.public_explore_token_has_social_links_v1(
+  p_token jsonb
+)
+returns boolean
+language sql
+immutable
+strict
+security invoker
+set search_path = ''
+as $function$
+  select exists(
+    select 1
+    from pg_catalog.jsonb_array_elements(
+      coalesce(p_token #> '{metadata,links}', '[]'::jsonb)
+    ) as link(value)
+    where link.value ->> 'kind' in ('x', 'telegram')
+  )
+$function$;
+
+create function programmable_private.get_public_explore_page_v2(
+  p_chain_id bigint,
+  p_query text,
+  p_sort text,
+  p_requested_page integer,
+  p_page_size integer,
+  p_socials text
+)
+returns table (
+  http_status integer,
+  payload jsonb,
+  payload_complete boolean,
+  record_count bigint,
+  record_scopes jsonb,
+  comparison_checkpoint_block_number bigint,
+  comparison_checkpoint_block_hash bytea,
+  route_evidence jsonb
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $function$
+declare
+  route_snapshot programmable_private.public_route_snapshots_v2%rowtype;
+  normalized_query text;
+  valuation_unit text;
+  filtered_count bigint;
+  current_count bigint;
+  total_pages bigint;
+  resolved_page bigint;
+  selected_count bigint;
+  selected_tokens jsonb;
+  selected_scopes jsonb;
+  launcher_fees numeric;
+  start_cursor jsonb;
+  end_cursor jsonb;
+begin
+  perform programmable_private.assert_caller('programmable_api_reader');
+  if p_chain_id not in (1, 11155111)
+     or p_sort not in (
+       'newest', 'oldest', 'market-cap', 'market-cap-asc'
+     )
+     or p_requested_page < 1
+     or p_page_size not between 1 and 100
+     or p_query is null
+     or (p_socials is not null and p_socials not in ('yes', 'no'))
+     or pg_catalog.octet_length(p_query) > 256
+  then
+    raise exception using
+      errcode = '22023', message = 'invalid Explore page request';
+  end if;
+  normalized_query := pg_catalog.lower(
+    pg_catalog.regexp_replace(pg_catalog.btrim(p_query), '^\$', '')
+  );
+
+  select * into route_snapshot
+  from programmable_private.public_route_snapshots_v2
+  where route_key = 'explore-list'
+    and snapshot_scope = 'all-supported'
+    and chain_id = p_chain_id;
+  if not found then return; end if;
+
+  select pg_catalog.count(*) into current_count
+  from programmable_private.current_launch_projections_v1 as launch
+  join programmable_private.run_headers as run
+    on run.run_id = launch.projection_run_id
+   and run.run_kind = 'projection'
+  join lateral pg_catalog.jsonb_array_elements(
+    route_snapshot.release_pointers
+  ) as pointer(value)
+    on pointer.value ->> 'releaseVersion' = launch.release_id
+   and pointer.value ->> 'modelVersion' = launch.model_id
+   and pointer.value ->> 'sourceGroup' = run.source_group
+   and (pointer.value ->> 'epochId')::uuid = launch.epoch_id
+   and (pointer.value ->> 'pointerGeneration')::bigint =
+      launch.pointer_generation
+  where launch.chain_id = p_chain_id;
+  if current_count <> (
+    select pg_catalog.count(*)
+    from programmable_private.public_explore_list_v1
+    where chain_id = p_chain_id
+      and checkpoint_block_number =
+        route_snapshot.checkpoint_block_number
+      and checkpoint_block_hash = route_snapshot.checkpoint_block_hash
+  ) then
+    return;
+  end if;
+
+  select pg_catalog.count(*) into filtered_count
+  from programmable_private.public_explore_list_v1 as item
+  where item.chain_id = p_chain_id
+    and item.checkpoint_block_number =
+      route_snapshot.checkpoint_block_number
+    and item.checkpoint_block_hash = route_snapshot.checkpoint_block_hash
+    and (
+      normalized_query = ''
+      or pg_catalog.lower(item.token_name)
+        like '%' || normalized_query || '%'
+      or pg_catalog.lower(item.token_symbol)
+        like '%' || normalized_query || '%'
+      or pg_catalog.lower(item.token_address)
+        like '%' || normalized_query || '%'
+    )
+    and (
+      p_socials is null
+      or programmable_private.public_explore_token_has_social_links_v1(
+        item.token_projection
+      ) = (p_socials = 'yes')
+    );
+
+  if p_sort in ('market-cap', 'market-cap-asc') then
+    if filtered_count = 0 then
+      valuation_unit := 'native-wei';
+    else
+      select case
+        when pg_catalog.bool_and(market_cap_usd_wad is not null)
+          then 'usd-wad'
+        when pg_catalog.bool_and(market_cap_native_wei is not null)
+          then 'native-wei'
+      end into valuation_unit
+      from programmable_private.public_explore_list_v1 as item
+      where item.chain_id = p_chain_id
+        and item.checkpoint_block_number =
+          route_snapshot.checkpoint_block_number
+        and item.checkpoint_block_hash = route_snapshot.checkpoint_block_hash
+        and (
+          normalized_query = ''
+          or pg_catalog.lower(item.token_name)
+            like '%' || normalized_query || '%'
+          or pg_catalog.lower(item.token_symbol)
+            like '%' || normalized_query || '%'
+          or pg_catalog.lower(item.token_address)
+            like '%' || normalized_query || '%'
+        )
+        and (
+          p_socials is null
+          or programmable_private.public_explore_token_has_social_links_v1(
+            item.token_projection
+          ) = (p_socials = 'yes')
+        );
+      if valuation_unit is null then return; end if;
+    end if;
+  end if;
+
+  total_pages := pg_catalog.ceil(
+    filtered_count::numeric / p_page_size
+  )::bigint;
+  resolved_page := case
+    when total_pages = 0 then 1
+    else least(p_requested_page::bigint, total_pages)
+  end;
+
+  with candidates as (
+    select item.*,
+      case
+        when valuation_unit = 'usd-wad'
+          then item.market_cap_usd_wad::numeric
+        when valuation_unit = 'native-wei'
+          then item.market_cap_native_wei::numeric
+      end as market_cap_atomic
+    from programmable_private.public_explore_list_v1 as item
+    where item.chain_id = p_chain_id
+      and item.checkpoint_block_number =
+        route_snapshot.checkpoint_block_number
+      and item.checkpoint_block_hash = route_snapshot.checkpoint_block_hash
+      and (
+        normalized_query = ''
+        or pg_catalog.lower(item.token_name)
+          like '%' || normalized_query || '%'
+        or pg_catalog.lower(item.token_symbol)
+          like '%' || normalized_query || '%'
+        or pg_catalog.lower(item.token_address)
+          like '%' || normalized_query || '%'
+      )
+      and (
+        p_socials is null
+        or programmable_private.public_explore_token_has_social_links_v1(
+          item.token_projection
+        ) = (p_socials = 'yes')
+      )
+  ), ordered as (
+    select candidates.*,
+      pg_catalog.row_number() over (order by
+        case when p_sort = 'market-cap'
+          then market_cap_atomic end desc,
+        case when p_sort = 'market-cap-asc'
+          then market_cap_atomic end asc,
+        case when p_sort = 'oldest'
+          then launch_block_number end asc,
+        case when p_sort <> 'oldest'
+          then launch_block_number end desc,
+        case when p_sort = 'oldest'
+          then launch_transaction_index end asc,
+        case when p_sort <> 'oldest'
+          then launch_transaction_index end desc,
+        case when p_sort = 'oldest'
+          then launch_log_index end asc,
+        case when p_sort <> 'oldest'
+          then launch_log_index end desc,
+        case when p_sort = 'oldest'
+          then launch_transaction_hash end asc,
+        case when p_sort <> 'oldest'
+          then launch_transaction_hash end desc,
+        case when p_sort = 'oldest'
+          then token_address end asc,
+        case when p_sort <> 'oldest'
+          then token_address end desc
+      ) as row_ordinal
+    from candidates
+  ), selected as (
+    select * from ordered
+    where row_ordinal > (resolved_page - 1) * p_page_size
+      and row_ordinal <= resolved_page * p_page_size
+  ), selected_aggregate as (
+    select
+      pg_catalog.count(*) as selected_count,
+      coalesce(
+        pg_catalog.jsonb_agg(token_projection order by row_ordinal),
+        '[]'::jsonb
+      ) as selected_tokens
+    from selected
+  ), selected_scope as (
+    select coalesce(
+      pg_catalog.jsonb_agg(
+        pg_catalog.jsonb_build_object(
+          'model', scope.model_id,
+          'releaseVersion', scope.release_id
+        ) order by scope.release_id, scope.model_id
+      ), '[]'::jsonb
+    ) as scopes
+    from (
+      select distinct release_id, model_id from selected
+    ) as scope
+  ), cursor_rows as (
+    select
+      programmable_private.build_public_explore_cursor_v1(
+        route_snapshot.snapshot_commitment_hex,
+        normalized_query, p_sort, p_page_size, valuation_unit,
+        start_row.market_cap_atomic,
+        start_row.launch_block_number,
+        start_row.launch_transaction_index,
+        start_row.launch_log_index,
+        start_row.launch_transaction_hash,
+        start_row.token_address
+      ) as start_cursor,
+      programmable_private.build_public_explore_cursor_v1(
+        route_snapshot.snapshot_commitment_hex,
+        normalized_query, p_sort, p_page_size, valuation_unit,
+        end_row.market_cap_atomic,
+        end_row.launch_block_number,
+        end_row.launch_transaction_index,
+        end_row.launch_log_index,
+        end_row.launch_transaction_hash,
+        end_row.token_address
+      ) as end_cursor
+    from (values (true)) as singleton(value)
+    left join ordered as start_row
+      on start_row.row_ordinal = (resolved_page - 1) * p_page_size
+     and resolved_page > 1
+    left join ordered as end_row
+      on end_row.row_ordinal = least(
+        resolved_page * p_page_size, filtered_count
+      )
+  )
+  select aggregate.selected_count, aggregate.selected_tokens,
+    scope.scopes, cursors.start_cursor, cursors.end_cursor
+  into selected_count, selected_tokens, selected_scopes,
+    start_cursor, end_cursor
+  from selected_aggregate as aggregate
+  cross join selected_scope as scope
+  cross join cursor_rows as cursors;
+
+  if selected_count <> least(
+    p_page_size::bigint,
+    pg_catalog.greatest(
+      0::bigint,
+      filtered_count - ((resolved_page - 1) * p_page_size)
+    )
+  ) then return; end if;
+  if (resolved_page = 1) <> (start_cursor is null)
+     or (selected_count = 0) <> (end_cursor is null)
+  then return; end if;
+
+  select coalesce(pg_catalog.sum(
+    coalesce(item.launcher_fees_accrued_wei, '0')::numeric
+  ), 0) into launcher_fees
+  from programmable_private.public_explore_list_v1 as item
+  where item.chain_id = p_chain_id
+    and item.checkpoint_block_number =
+      route_snapshot.checkpoint_block_number
+    and item.checkpoint_block_hash = route_snapshot.checkpoint_block_hash;
+
+  http_status := 200;
+  payload := pg_catalog.jsonb_build_object(
+    'status', 'ready',
+    'snapshot', programmable_private.build_public_snapshot_identity_v2(
+      route_snapshot.snapshot_commitment_hex,
+      route_snapshot.chain_id,
+      route_snapshot.checkpoint_block_number,
+      route_snapshot.checkpoint_block_hash,
+      route_snapshot.checkpoint_confirmations,
+      route_snapshot.snapshot_captured_at,
+      route_snapshot.release_pointers
+    ),
+    'data', pg_catalog.jsonb_build_object(
+      'request', pg_catalog.jsonb_build_object(
+        'query', pg_catalog.btrim(p_query),
+        'socials', p_socials,
+        'sort', p_sort,
+        'requestedPage', p_requested_page,
+        'pageSize', p_page_size
+      ),
+      'page', pg_catalog.jsonb_build_object(
+        'resolvedPage', resolved_page,
+        'totalCount', filtered_count::text,
+        'valuationUnit', valuation_unit,
+        'startAfter', start_cursor,
+        'endAt', end_cursor
+      ),
+      'launcherFeesAccruedWei', launcher_fees::text,
+      'tokens', selected_tokens
+    )
+  );
+  payload_complete := true;
+  record_count := selected_count;
+  record_scopes := selected_scopes;
+  comparison_checkpoint_block_number :=
+    route_snapshot.checkpoint_block_number;
+  comparison_checkpoint_block_hash := route_snapshot.checkpoint_block_hash;
+  route_evidence := route_snapshot.route_evidence;
+  return next;
+end
+$function$;
+
+revoke all on function
+  programmable_private.public_explore_token_has_social_links_v1(jsonb),
+  programmable_private.get_public_explore_page_v2(
+    bigint,text,text,integer,integer,text
+  )
+from public, anon, authenticated, service_role,
+  programmable_projector, programmable_reconciler, programmable_api_reader,
+  programmable_profile_binder, programmable_profile_recovery,
+  programmable_profile_writer, programmable_maintenance;
+
+grant execute on function
+  programmable_private.get_public_explore_page_v2(
+    bigint,text,text,integer,integer,text
+  )
+to programmable_api_reader;
+
+reset role;

--- a/supabase/tests/database/023_explore_social_filter.test.sql
+++ b/supabase/tests/database/023_explore_social_filter.test.sql
@@ -1,0 +1,74 @@
+begin;
+
+select plan(7);
+
+select ok(
+  to_regprocedure(
+    'programmable_private.get_public_explore_page_v2(bigint,text,text,integer,integer,text)'
+  ) is not null,
+  'the filtered Explore reader has one explicit socials argument'
+);
+
+select ok(
+  programmable_private.public_explore_token_has_social_links_v1(
+    '{"metadata":{"links":[{"kind":"x"}]}}'::jsonb
+  ),
+  'X metadata counts as socials'
+);
+
+select ok(
+  programmable_private.public_explore_token_has_social_links_v1(
+    '{"metadata":{"links":[{"kind":"telegram"}]}}'::jsonb
+  ),
+  'Telegram metadata counts as socials'
+);
+
+select ok(
+  not programmable_private.public_explore_token_has_social_links_v1(
+    '{"metadata":{"links":[{"kind":"website"}]}}'::jsonb
+  ),
+  'a website alone does not count as socials'
+);
+
+select ok(
+  not programmable_private.public_explore_token_has_social_links_v1(
+    '{"metadata":{"links":[]}}'::jsonb
+  ),
+  'missing social links are classified as no'
+);
+
+select ok(
+  pg_catalog.has_function_privilege(
+    'programmable_api_reader',
+    'programmable_private.get_public_explore_page_v2(bigint,text,text,integer,integer,text)'::regprocedure,
+    'EXECUTE'
+  )
+  and not pg_catalog.has_function_privilege(
+    'anon',
+    'programmable_private.get_public_explore_page_v2(bigint,text,text,integer,integer,text)'::regprocedure,
+    'EXECUTE'
+  )
+  and not pg_catalog.has_function_privilege(
+    'authenticated',
+    'programmable_private.get_public_explore_page_v2(bigint,text,text,integer,integer,text)'::regprocedure,
+    'EXECUTE'
+  ),
+  'only the server-side API reader can execute the filtered reader'
+);
+
+set local role programmable_api_reader;
+
+select throws_ok(
+  $$select * from programmable_private.get_public_explore_page_v2(
+    1, '', 'newest', 1, 9, 'any'
+  )$$,
+  '22023',
+  'invalid Explore page request',
+  'the database rejects non-canonical socials values'
+);
+
+reset role;
+
+select * from finish();
+
+rollback;

--- a/tests/create-token-layout.test.ts
+++ b/tests/create-token-layout.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const launchStyles = readFileSync(
+  join(root, "components/launch-experience.module.css"),
+  "utf8",
+);
+const globalStyles = readFileSync(join(root, "app/globals.css"), "utf8");
+const launchSource = readFileSync(
+  join(root, "components/launch-builder.tsx"),
+  "utf8",
+);
+
+describe("Create Token layout", () => {
+  it("uses one shared control height for fields and launch selectors", () => {
+    expect(launchStyles).toContain("--launch-control-height: 52px");
+    expect(launchStyles).toMatch(
+      /\.formPage :global\(\.field input\)\s*\{[^}]*height:\s*var\(--launch-control-height\);[^}]*min-height:\s*var\(--launch-control-height\);/s,
+    );
+    expect(launchStyles).toMatch(
+      /:global\(\.launch-select-trigger\),[\s\S]*?:global\(\.classic-v3-custody input\)\s*\{\s*min-height:\s*var\(--launch-control-height\);/,
+    );
+  });
+
+  it("keeps fee, reward and initial-buy choices on the same panel grid", () => {
+    expect(launchStyles).toMatch(
+      /\.formPage :global\(\.classic-v3-core\)\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/s,
+    );
+    expect(launchStyles).toMatch(
+      /\.formPage :global\(\.classic-v3-initial-buy\)\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/s,
+    );
+    expect(launchStyles).toMatch(
+      /:global\(\.classic-v3-fees\),[\s\S]*?:global\(\.classic-v3-custody\)\s*\{[^}]*border-radius:\s*18px;/,
+    );
+  });
+
+  it("preserves semantic groups and a narrow one-column flow", () => {
+    expect(launchSource).toContain('<fieldset className="classic-v3-fees">');
+    expect(launchSource).toContain(
+      '<fieldset className="classic-v3-reward-mode">',
+    );
+    expect(launchSource).toContain('className="classic-v3-custody"');
+    expect(globalStyles).toMatch(
+      /@media \(max-width: 720px\)[\s\S]*?\.classic-v3-initial-buy\s*\{\s*grid-template-columns:\s*1fr;/,
+    );
+    expect(launchStyles).toMatch(
+      /@media \(max-width: 760px\)[\s\S]*?:global\(\.classic-v3-initial-buy\)\s*\{\s*grid-template-columns:\s*minmax\(0, 1fr\);/,
+    );
+    expect(launchStyles).toMatch(
+      /@media \(max-width: 760px\)[\s\S]*?:global\(\.classic-v3-initial-buy \.meme-dev-buy\)\s*\{\s*grid-template-columns:\s*minmax\(0, 1fr\);/,
+    );
+    expect(launchStyles).toMatch(
+      /@media \(max-width: 520px\)[\s\S]*?:global\(\.classic-v3-reward-mode > div\)\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\);/,
+    );
+    expect(globalStyles).toMatch(
+      /@media \(max-width: 520px\)[\s\S]*?\.classic-token-main \.two-column-fields\s*\{\s*grid-template-columns:\s*1fr;/,
+    );
+  });
+});

--- a/tests/data-pipeline/optimistic-public-api-overlay.test.ts
+++ b/tests/data-pipeline/optimistic-public-api-overlay.test.ts
@@ -250,7 +250,13 @@ describe("optimistic public API overlay", () => {
   it("merges before pagination without mixing native and USD market-cap ranks", () => {
     const page = buildOptimisticExplorePage({
       canonicalModel,
-      options: { query: "", sort: "market-cap", page: 1, pageSize: 1 },
+      options: {
+        query: "",
+        sort: "market-cap",
+        page: 1,
+        pageSize: 1,
+        socials: null,
+      },
       snapshot: persistedSnapshot(),
       nowMs: NOW,
     });
@@ -289,7 +295,13 @@ describe("optimistic public API overlay", () => {
         ...canonicalModel,
         tokens: [stock, classic],
       },
-      options: { query: "", sort: "market-cap", page: 1, pageSize: 1 },
+      options: {
+        query: "",
+        sort: "market-cap",
+        page: 1,
+        pageSize: 1,
+        socials: null,
+      },
       snapshot: persistedSnapshot(),
       nowMs: NOW,
     });
@@ -623,7 +635,13 @@ describe("optimistic public API overlay", () => {
           ethUsdQuote: undefined,
         },
       },
-      options: { query: "", sort: "market-cap", page: 1, pageSize: 2 },
+      options: {
+        query: "",
+        sort: "market-cap",
+        page: 1,
+        pageSize: 2,
+        socials: null,
+      },
       snapshot: persistedSnapshot(),
       nowMs: NOW,
     })).toBeNull();
@@ -810,7 +828,13 @@ describe("optimistic public API overlay", () => {
   it("sets no-store and exact disclosure headers only for an active overlay", () => {
     const disclosure = buildOptimisticExplorePage({
       canonicalModel,
-      options: { query: "", sort: "market-cap", page: 1, pageSize: 1 },
+      options: {
+        query: "",
+        sort: "market-cap",
+        page: 1,
+        pageSize: 1,
+        socials: null,
+      },
       snapshot: persistedSnapshot(),
       nowMs: NOW,
     })!.optimisticOverlay;

--- a/tests/data-pipeline/postgres-read-model-route-adapter.test.ts
+++ b/tests/data-pipeline/postgres-read-model-route-adapter.test.ts
@@ -65,6 +65,7 @@ function exploreEnvelope(): IndexedRouteEnvelopeV2<IndexedExploreListDataV2> {
     data: {
       request: {
         query: "",
+        socials: null,
         sort: "newest",
         requestedPage: 1,
         pageSize: 12,
@@ -124,6 +125,7 @@ describe("Postgres public route snapshot adapters", () => {
       sort: "newest" as const,
       page: 1,
       pageSize: 12,
+      socials: null,
     };
 
     const result = await adapters.explore(test.transaction, request);
@@ -196,6 +198,7 @@ describe("Postgres public route snapshot adapters", () => {
         sort: "newest",
         page: 1,
         pageSize: 12,
+        socials: null,
       }),
     ).resolves.toEqual({
       status: "not-ready",

--- a/tests/data-pipeline/public-route-queries.server.test.ts
+++ b/tests/data-pipeline/public-route-queries.server.test.ts
@@ -110,13 +110,20 @@ describe("atomic public route queries", () => {
           sort: "newest",
           page: 2,
           pageSize: 12,
+          socials: "yes",
         }),
-      functionName: "get_public_explore_page_v1",
-      values: [1, "v4", "newest", 2, 12],
+      functionName: "get_public_explore_page_v2",
+      values: [1, "v4", "newest", 2, 12, "yes"],
       kind: "explore",
       scope: DISCOVERY,
       data: {
-        request: { query: "v4", sort: "newest", requestedPage: 2, pageSize: 12 },
+        request: {
+          query: "v4",
+          socials: "yes",
+          sort: "newest",
+          requestedPage: 2,
+          pageSize: 12,
+        },
         page: {
           resolvedPage: 1,
           totalCount: "0",

--- a/tests/data-pipeline/route-adapters.test.ts
+++ b/tests/data-pipeline/route-adapters.test.ts
@@ -422,6 +422,7 @@ describe("indexed Explore list adapter v2", () => {
       ready({
         request: {
           query: "",
+          socials: "yes",
           sort: "newest",
           requestedPage: 1,
           pageSize: 5,
@@ -532,6 +533,7 @@ describe("indexed Explore list adapter v2", () => {
       ready({
         request: {
           query: "$token",
+          socials: null,
           sort: "market-cap",
           requestedPage: 2,
           pageSize: 2,
@@ -560,6 +562,7 @@ describe("indexed Explore list adapter v2", () => {
           ready({
             request: {
               query: "$token",
+              socials: null,
               sort: "market-cap",
               requestedPage: 2,
               pageSize: 2,
@@ -587,7 +590,13 @@ describe("indexed Explore list adapter v2", () => {
     const later = token("classic-v2", TOKEN_B, "explore-list", "25650002");
     const badRoute = token("classic-v2", TOKEN_B, "creator-profile", "25650000");
     const page = {
-      request: { query: "", sort: "newest" as const, requestedPage: 1, pageSize: 2 },
+      request: {
+        query: "",
+        socials: null,
+        sort: "newest" as const,
+        requestedPage: 1,
+        pageSize: 2,
+      },
       page: {
         resolvedPage: 1,
         totalCount: "2",

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -34,6 +34,7 @@ describe("Explore API query boundary", () => {
     "page=1&page=2",
     "q=token&q=other",
     "sort=newest&extra=1",
+    "socials=maybe",
   ])(
     "rejects non-canonical query shapes before any secret-backed enrichment: %s",
     async (query) => {
@@ -75,10 +76,16 @@ describe("Explore API query boundary", () => {
     mocks.enrichExplorePageWithOfficialV4Subgraph.mockResolvedValue(page);
 
     const response = await GET(
-      new NextRequest("http://localhost/api/explore?page=1&limit=10"),
+      new NextRequest(
+        "http://localhost/api/explore?page=1&limit=10&socials=yes",
+      ),
     );
 
     expect(response.status).toBe(200);
+    expect(mocks.paginateExplore).toHaveBeenCalledWith(
+      model,
+      expect.objectContaining({ socials: "yes" }),
+    );
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, s-maxage=2, stale-while-revalidate=2",
     );

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -7,6 +7,7 @@ import {
   getExplorePaginationItems,
   getMarketCap,
   loadExplorePayload,
+  paginateTokensBySocialPresence,
   preserveExplorePayloadOnRefreshFailure,
   shouldRefreshExplore,
   tokenHasSocialLinks,
@@ -95,6 +96,51 @@ describe("Explore refresh state", () => {
         (token) => token.id,
       ),
     ).toEqual(["1:test"]);
+  });
+
+  it("filters the complete result set before creating nine-token pages", () => {
+    const tokens = Array.from({ length: 22 }, (_, index) => ({
+      id: `1:${index}`,
+      name: `Token ${index}`,
+      symbol: `T${index}`,
+      tokenAddress: `0x${(index + 1).toString(16).padStart(40, "0")}`,
+      hookAddress: "0x2222222222222222222222222222222222222222",
+      poolId: `0x${(index + 1).toString(16).padStart(64, "0")}`,
+      launchedAt: "2026-07-29T00:00:00.000Z",
+      totalSwapFeeBps: 100,
+      liquidityPath: "meme" as const,
+      ...(index % 2 === 0
+        ? {
+            links: [
+              { kind: "x" as const, url: `https://x.com/token${index}` },
+            ],
+          }
+        : {}),
+    })) satisfies LauncherToken[];
+
+    expect(paginateTokensBySocialPresence(tokens, "yes", 1)).toMatchObject({
+      page: 1,
+      pageSize: 9,
+      total: 11,
+      totalPages: 2,
+      tokens: expect.arrayContaining([
+        expect.objectContaining({ id: "1:0" }),
+        expect.objectContaining({ id: "1:16" }),
+      ]),
+    });
+    expect(
+      paginateTokensBySocialPresence(tokens, "yes", 2).tokens.map(
+        (token) => token.id,
+      ),
+    ).toEqual(["1:18", "1:20"]);
+    expect(paginateTokensBySocialPresence(tokens, "no", 1)).toMatchObject({
+      total: 11,
+      totalPages: 2,
+      tokens: expect.arrayContaining([
+        expect.objectContaining({ id: "1:1" }),
+        expect.objectContaining({ id: "1:17" }),
+      ]),
+    });
   });
 
   it("refreshes only visible Explore content after the freshness interval", () => {

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -68,10 +68,11 @@ describe("interaction accessibility", () => {
     expect(css).toContain(
       'html[data-theme-input="instant"] .theme-toggle-icons svg',
     );
-    expect(css).toContain("@keyframes theme-radial-reveal");
+    expect(css).toContain("@keyframes theme-soft-reveal");
     expect(css).toMatch(
-      /theme-radial-reveal 292ms cubic-bezier\(0\.32, 0\.72, 0, 1\)/,
+      /theme-soft-reveal 380ms cubic-bezier\(0\.2, 0, 0, 1\)/,
     );
+    expect(css).toContain("@media (prefers-reduced-motion: no-preference)");
   });
 
   it("exposes the wallet actions as a native, labelled disclosure", () => {

--- a/tests/interaction-state-regressions.test.ts
+++ b/tests/interaction-state-regressions.test.ts
@@ -56,7 +56,7 @@ describe("interaction state regressions", () => {
     expect(exploreSource).not.toContain("Copy contract address");
   });
 
-  it("keeps Explore project-first and removes the repeated footer slogan", () => {
+  it("keeps Explore project-first with compact market metadata", () => {
     const exploreSource = readFileSync(
       join(root, "components/explore-view.tsx"),
       "utf8",
@@ -73,7 +73,13 @@ describe("interaction state regressions", () => {
     expect(exploreSource).not.toContain("All tokens");
     expect(exploreSource).not.toContain("V4 model");
     expect(exploreSource).not.toContain("<dt>Market cap</dt>");
-    expect(exploreSource).not.toContain("runnerMeta");
+    expect(exploreSource).toContain("runnerMeta");
+    expect(exploreSource).toContain("runnerMarketCap");
+    expect(exploreSource).not.toContain("No description yet.");
+    expect(exploreSource).not.toContain('{ id: "all", label: "Any" }');
+    expect(exploreSource).toMatch(
+      /tokenLinkOrder[\s\S]*?website:\s*0,[\s\S]*?x:\s*1,[\s\S]*?telegram:\s*2,/,
+    );
     expect(footerSource).not.toContain(
       "Launch tokens that work the way you imagine.",
     );

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+describe("launch model artwork", () => {
+  it("uses the owned botanical art and exact Programmable loop asset", () => {
+    const source = read("components/launch-entry.tsx");
+
+    expect(source).toContain(
+      'src="/brand/create/classic-botanical-v3.webp"',
+    );
+    expect(source).toContain(
+      'src="/brand/loop/programmable-loop-mark-transparent-v1.png"',
+    );
+  });
+
+  it("keeps model images stable on hover", () => {
+    const css = read("components/launch-experience.module.css");
+
+    expect(css).not.toMatch(/:hover[^{}]*\.artImage\s*\{/s);
+    expect(css).not.toMatch(/:hover[^{}]*\.modelArt img\s*\{/s);
+  });
+
+  it("limits decorative movement to opted-in, compositor-safe motion", () => {
+    const css = read("components/launch-experience.module.css");
+
+    expect(css).toContain("@media (prefers-reduced-motion: no-preference)");
+    expect(css).toContain(
+      "animation: classic-botanical-breeze 9.6s steps(1, end) infinite",
+    );
+    expect(css).toContain(
+      "animation: custom-star-sparkle 5.8s cubic-bezier(0.2, 0, 0, 1) infinite",
+    );
+    expect(css).toContain("will-change: opacity, transform");
+    expect(css).toContain("animation: none");
+  });
+});

--- a/tests/onchain-query.test.ts
+++ b/tests/onchain-query.test.ts
@@ -83,6 +83,59 @@ describe("Explore query", () => {
     ]);
   });
 
+  it("filters social presence before counting and paginating", () => {
+    const socialTokens = [
+      {
+        ...tokens[0],
+        links: [{ kind: "website" as const, url: "https://example.com" }],
+      },
+      {
+        ...tokens[1],
+        links: [{ kind: "x" as const, url: "https://x.com/example" }],
+      },
+      {
+        ...tokens[2],
+        links: [
+          { kind: "telegram" as const, url: "https://t.me/example" },
+        ],
+      },
+    ];
+    const model: ExploreReadModel = {
+      status: "ready",
+      tokens: socialTokens,
+      snapshot: {
+        chainId: 11_155_111,
+        blockNumber: "100",
+        blockHash: `0x${"44".repeat(32)}`,
+        confirmations: 12,
+      },
+      creatorClaims: [],
+      launcherFeesAccruedWei: "0",
+      launcherFeesAccruedEth: "0",
+    };
+
+    expect(
+      paginateExplore(model, {
+        page: 1,
+        pageSize: 1,
+        sort: "newest",
+        socials: "yes",
+      }),
+    ).toMatchObject({
+      total: 2,
+      totalPages: 2,
+      tokens: [expect.objectContaining({ tokenAddress: tokens[1].tokenAddress })],
+    });
+    expect(
+      paginateExplore(model, {
+        page: 1,
+        pageSize: 9,
+        sort: "newest",
+        socials: "no",
+      }).tokens.map((entry) => entry.tokenAddress),
+    ).toEqual([tokens[0].tokenAddress]);
+  });
+
   it("sorts by the fresher indexed market cap when it is available", () => {
     const refreshed = [
       {

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -7,19 +7,23 @@ import {
   actionPending,
   buildProfilePortfolio,
   clearConfirmedProfileActionStates,
+  getProfileSessionView,
   getProfileWorkspacePhase,
   groupPendingProfileTransactionStates,
   groupProfileRewards,
   parsePendingProfileTransactions,
+  paginateProfileClaimableEntries,
   profileClaimableWei,
   profileClaimActionCount,
   profileEntryHasClaimableReward,
   profileHasRewardSurface,
   profileRewardsForAccount,
   profileTransactionPollAttempts,
+  reflectedConfirmedProfileTransactions,
   preserveInterruptedTransactionStates,
   removePendingProfileTransactionRecord,
   sortProfileTokensByMarketCap,
+  sortProfileClaimableEntries,
   upsertPendingProfileTransactionRecords,
   waitForTransaction,
   withoutClosedDeepProfileData,
@@ -146,6 +150,13 @@ const deepV3Token = {
 } satisfies DeepV3CreatorToken;
 
 describe("profile workspace loading state", () => {
+  it("keeps the profile in a stable loading shell while the wallet session hydrates", () => {
+    expect(getProfileSessionView(true)).toBe("loading");
+    expect(getProfileSessionView(true, firstAddress)).toBe("loading");
+    expect(getProfileSessionView(false)).toBe("connect");
+    expect(getProfileSessionView(false, firstAddress)).toBe("profile");
+  });
+
   it("keeps a stable loading state until every pending source settles", () => {
     expect(
       getProfileWorkspacePhase(
@@ -393,6 +404,24 @@ describe("profile reward grouping", () => {
     expect(profileClaimableWei(portfolio)).toBe(
       7_000_000_000_000_000n,
     );
+  });
+
+  it("orders claimable entries by the highest current amount and paginates five at a time", () => {
+    const portfolio = buildProfilePortfolio(
+      tokens,
+      [claim],
+      [classicReward, secondClassicReward],
+    );
+    const ranked = sortProfileClaimableEntries(portfolio, firstAddress);
+
+    expect(ranked.map((entry) => entry.token.symbol)).toEqual([
+      "SECOND",
+      "FIRST",
+    ]);
+    expect(paginateProfileClaimableEntries([1, 2, 3, 4, 5, 6, 7], 1))
+      .toEqual({ currentPage: 1, totalPages: 2, items: [1, 2, 3, 4, 5] });
+    expect(paginateProfileClaimableEntries([1, 2, 3, 4, 5, 6, 7], 9))
+      .toEqual({ currentPage: 2, totalPages: 2, items: [6, 7] });
   });
 
   it("scopes claimable split rewards and actions to the connected beneficiary", () => {
@@ -685,6 +714,20 @@ describe("profile transaction status", () => {
       new Map([[firstKey, secondTransactionHash]]),
     );
     expect(hashMismatch).toBe(states);
+  });
+
+  it("keeps a confirmed action suppressed until a refreshed snapshot reports zero", () => {
+    const firstKey = `${secondAddress.toLowerCase()}:claim`;
+    const secondKey = `${thirdAddress.toLowerCase()}:claim`;
+    const reflected = reflectedConfirmedProfileTransactions(
+      new Map([
+        [firstKey, transactionHash],
+        [secondKey, secondTransactionHash],
+      ]),
+      (stateKey) => (stateKey === firstKey ? 0n : 10n),
+    );
+
+    expect([...reflected]).toEqual([[firstKey, transactionHash]]);
   });
 
   it("restores only validated pending transactions for the connected account", () => {

--- a/tests/shell-polish.test.ts
+++ b/tests/shell-polish.test.ts
@@ -36,17 +36,18 @@ describe("public shell polish", () => {
     expect(source).not.toContain("key={pathname}");
   });
 
-  it("makes the theme reveal deliberate without crossing 300ms", () => {
+  it("makes the infrequent theme change a calm, bounded crossfade", () => {
     const source = read("components/site-navigation.tsx");
     const css = read("app/globals.css");
 
     expect(source).toContain("activeThemeViewTransition?.skipTransition()");
     expect(css).toContain(
-      "theme-radial-reveal 292ms cubic-bezier(0.32, 0.72, 0, 1)",
+      "theme-soft-reveal 380ms cubic-bezier(0.2, 0, 0, 1)",
     );
     expect(css).toContain(
-      "theme-radial-tint 292ms cubic-bezier(0.32, 0.72, 0, 1)",
+      "theme-soft-fade 380ms cubic-bezier(0.2, 0, 0, 1)",
     );
+    expect(css).not.toContain("clip-path: circle(");
   });
 
   it("avoids unbounded transitions in the owned style sheets", () => {


### PR DESCRIPTION
## Summary
- make Explore filters composable and keep nine stable token cards per page
- show market cap and social links cleanly while hiding absent descriptions
- stabilize profile loading, compact analytics, and paginate claimable rewards
- align the Create Token form and refine Classic/Custom Hook artwork plus theme motion
- add the hosted Explore socials-filter migration and regression coverage

## Validation
- lint
- TypeScript typecheck
- production build
- focused interface suites: 142 passing
- profile regression suite: 25 passing
- hosted database/PGlite suite: 33/33 passing
- rendered desktop and mobile QA with console, overflow, filter, sort, hover, and theme checks
