### PR TITLE
Restore operations health with bound RPC providers

### DIFF
--- a/lib/onchain/config.ts
+++ b/lib/onchain/config.ts
@@ -57,6 +57,28 @@ function asBytes32(value: string | null | undefined): Hex | null {
     : null;
 }
 
+function firstNonEmpty(...values: Array<string | undefined>) {
+  for (const value of values) {
+    const normalized = value?.trim();
+    if (normalized) return normalized;
+  }
+  return undefined;
+}
+
+function productionPrimaryRpc() {
+  return firstNonEmpty(
+    process.env.ETHEREUM_RPC_URL,
+    process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
+  );
+}
+
+function productionSecondaryRpc() {
+  return firstNonEmpty(
+    process.env.ETHEREUM_RPC_URL_B,
+    process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
+  );
+}
+
 export function selectedDeploymentEnvironment(
   value = process.env.PROGRAMMABLE_ONCHAIN_NETWORK,
 ): DeploymentEnvironment {
@@ -99,12 +121,12 @@ function resolveOnchainDeployment(
 
   const rpcUrl =
     environment === "production"
-      ? process.env.ETHEREUM_RPC_URL ?? "https://eth.drpc.org"
+      ? productionPrimaryRpc() ?? "https://eth.drpc.org"
       : process.env.SEPOLIA_RPC_URL ?? "https://sepolia.drpc.org";
   const rpcUrlSecondary = getDistinctSecondaryRpc(
     rpcUrl,
     environment === "production"
-      ? process.env.ETHEREUM_RPC_URL_B
+      ? productionSecondaryRpc()
       : process.env.SEPOLIA_RPC_URL_B,
   );
   const common = {
@@ -204,8 +226,8 @@ export function getOperationalOnchainDeployment(
   if (
     deployment.status === "ready" &&
     deployment.environment === "production" &&
-    (!process.env.ETHEREUM_RPC_URL?.trim() ||
-      !process.env.ETHEREUM_RPC_URL_B?.trim() ||
+    (!productionPrimaryRpc() ||
+      !productionSecondaryRpc() ||
       !deployment.rpcUrlSecondary)
   ) {
     throw new Error(

--- a/tests/onchain-config.test.ts
+++ b/tests/onchain-config.test.ts
@@ -54,6 +54,25 @@ describe("onchain deployment manifest boundary", () => {
     expect(getOnchainDeployment("production").status).toBe("ready");
   });
 
+  it("uses the bound Alchemy and QuickNode RPCs when generic aliases are empty", () => {
+    vi.stubEnv("ETHEREUM_RPC_URL", "");
+    vi.stubEnv("ETHEREUM_RPC_URL_B", "");
+    vi.stubEnv(
+      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+      "https://alchemy.example",
+    );
+    vi.stubEnv(
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
+      "https://quicknode.example",
+    );
+
+    expect(getOperationalOnchainDeployment("production")).toMatchObject({
+      status: "ready",
+      rpcUrl: "https://alchemy.example",
+      rpcUrlSecondary: "https://quicknode.example",
+    });
+  });
+
   it("rejects production operations without an independent RPC", () => {
     vi.stubEnv("ETHEREUM_RPC_URL", "https://rpc-a.example");
     vi.stubEnv("ETHEREUM_RPC_URL_B", "https://rpc-a.example");
@@ -68,6 +87,8 @@ describe("onchain deployment manifest boundary", () => {
   it("rejects an implicit public fallback for production operations", () => {
     vi.stubEnv("ETHEREUM_RPC_URL", "");
     vi.stubEnv("ETHEREUM_RPC_URL_B", "https://rpc-b.example");
+    vi.stubEnv("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL", "");
+    vi.stubEnv("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL", "");
 
     expect(() =>
       getOperationalOnchainDeployment("production"),
@@ -79,6 +100,8 @@ describe("onchain deployment manifest boundary", () => {
   it("keeps public reads fail-closed when the dual-RPC environment is absent", () => {
     vi.stubEnv("ETHEREUM_RPC_URL", "");
     vi.stubEnv("ETHEREUM_RPC_URL_B", "");
+    vi.stubEnv("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL", "");
+    vi.stubEnv("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL", "");
 
     expect(getPublicOnchainDeployment("production").status).toBe(
       "not-deployed",


### PR DESCRIPTION
## Summary
- use the existing authenticated Alchemy and QuickNode production bindings when the generic Ethereum RPC aliases are empty
- keep production operations fail-closed unless two distinct RPC endpoints resolve
- cover provider fallback and absent-provider behavior

## Validation
- `npx vitest run tests/onchain-config.test.ts tests/data-pipeline/operations-health-route.test.ts tests/data-pipeline/rpc-providers.test.ts tests/action-rpc-quorum.test.ts` (37 passed)
- `npm run typecheck`
- `npm run lint`