### PR TITLE
Use durable registry for Alchemy reads

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -306,7 +306,7 @@ jobs:
                   throw new Error(`${path} returned an oversized response`);
                 }
                 if (
-                  response.headers.get("x-programmable-read-source") !== "rpc" ||
+                  response.headers.get("x-programmable-read-source") !== "blob" ||
                   response.headers.get("x-programmable-rpc-provider") !== "alchemy"
                 ) {
                   throw new Error(`${path} did not prove the Alchemy RPC source`);
@@ -375,7 +375,7 @@ jobs:
           {
             echo "## Read-model release policy"
             echo
-            echo "Alchemy-only: Explore, token detail and token list read directly through Alchemy RPC."
+            echo "Alchemy-only: Explore, token detail and token list use the verified durable registry with live Alchemy enrichment."
             echo "Every non-Alchemy public read path is disabled."
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -118,17 +118,20 @@ export async function GET(request: NextRequest) {
       socials,
     } as const;
     const model = await readAlchemyExploreModel();
+    const pricedModel = {
+      ...model,
+      tokens: await enrichTokensWithAlchemyPrices(model.tokens),
+    } satisfies ExploreReadModel;
     const useTopMarketCapView =
       options.sort === "market-cap" &&
       options.query.length === 0 &&
       options.socials === null;
     const page = useTopMarketCapView
-      ? topThenNewestPage(model, options)
-      : paginateExplore(model, options);
-    const tokens = await enrichTokensWithAlchemyPrices(page.tokens);
+      ? topThenNewestPage(pricedModel, options)
+      : paginateExplore(pricedModel, options);
 
     return NextResponse.json(
-      { ...page, tokens },
+      page,
       {
         headers: {
           "Cache-Control":
@@ -136,7 +139,7 @@ export async function GET(request: NextRequest) {
               ? "public, max-age=0, s-maxage=5, stale-while-revalidate=15"
               : "public, max-age=0, s-maxage=30",
           "X-Programmable-Price-Source": "alchemy",
-          "X-Programmable-Read-Source": "rpc",
+          "X-Programmable-Read-Source": "blob",
           "X-Programmable-Rpc-Provider": "alchemy",
         },
       },

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -41,7 +41,14 @@ export async function GET(request: NextRequest) {
     if (model.status === "ready" && !token) {
       return NextResponse.json(
         { status: model.status, token: null, snapshot: model.snapshot },
-        { status: 404, headers: { "Cache-Control": "no-store" } },
+        {
+          status: 404,
+          headers: {
+            "Cache-Control": "no-store",
+            "X-Programmable-Read-Source": "blob",
+            "X-Programmable-Rpc-Provider": "alchemy",
+          },
+        },
       );
     }
 
@@ -61,7 +68,7 @@ export async function GET(request: NextRequest) {
               ? "public, max-age=0, s-maxage=5, stale-while-revalidate=15"
               : "public, max-age=0, s-maxage=30",
           "X-Programmable-Price-Source": "alchemy",
-          "X-Programmable-Read-Source": "rpc",
+          "X-Programmable-Read-Source": "blob",
           "X-Programmable-Rpc-Provider": "alchemy",
         },
       },

--- a/app/api/indexers/v1/response.ts
+++ b/app/api/indexers/v1/response.ts
@@ -24,7 +24,7 @@ export function alchemyFeedHeaders(
     "Access-Control-Expose-Headers":
       "X-Programmable-Read-Source, X-Programmable-Rpc-Provider",
     "Cache-Control": cacheControl,
-    "X-Programmable-Read-Source": "rpc",
+    "X-Programmable-Read-Source": "blob",
     "X-Programmable-Rpc-Provider": "alchemy",
   });
 }
@@ -34,6 +34,6 @@ export const ALCHEMY_NO_STORE_HEADERS = Object.freeze({
   "Access-Control-Expose-Headers":
     "X-Programmable-Read-Source, X-Programmable-Rpc-Provider",
   "Cache-Control": "no-store",
-  "X-Programmable-Read-Source": "rpc",
+  "X-Programmable-Read-Source": "blob",
   "X-Programmable-Rpc-Provider": "alchemy",
 });

--- a/lib/alchemy/explore.server.ts
+++ b/lib/alchemy/explore.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { unstable_cache } from "next/cache";
 
 import { getOnchainDeployment } from "../onchain/config";
-import { readLiveExploreModel } from "../onchain/read-model";
+import { readExploreModel } from "../onchain/read-model";
 import type {
   ExploreReadModel,
   OnchainDeployment,
@@ -18,7 +18,7 @@ const ALCHEMY_RPC_URL_SECRET =
   /https:\/\/eth-mainnet\.g\.alchemy\.com\/v2\/[A-Za-z0-9_-]{8,256}/gu;
 const ALCHEMY_PRICE_CACHE_TTL_MS = 10_000;
 const MAX_ALCHEMY_PRICE_ADDRESSES = 20;
-const MAX_ALCHEMY_PRICE_BATCHES = 5;
+const MAX_CONCURRENT_ALCHEMY_PRICE_BATCHES = 5;
 const MAX_ALCHEMY_PRICE_AGE_MS = 5 * 60 * 1_000;
 const MAX_ALCHEMY_PRICE_CLOCK_SKEW_MS = 60 * 1_000;
 const MAX_PRICE_CACHE_ENTRIES = 100;
@@ -99,7 +99,7 @@ export function getAlchemyOnchainDeployment(): OnchainDeployment {
 }
 
 async function readAlchemyExploreModelUncached(): Promise<ExploreReadModel> {
-  return readLiveExploreModel(getAlchemyOnchainDeployment());
+  return readExploreModel(getAlchemyOnchainDeployment());
 }
 
 const readCachedAlchemyExploreModel = unstable_cache(
@@ -207,8 +207,9 @@ async function requestAlchemyPrices(addresses: readonly string[]) {
 }
 
 async function currentAlchemyPrices(addresses: readonly string[]) {
-  const unique = [...new Set(addresses.map((address) => address.toLowerCase()))]
-    .slice(0, MAX_ALCHEMY_PRICE_ADDRESSES * MAX_ALCHEMY_PRICE_BATCHES);
+  const unique = [
+    ...new Set(addresses.map((address) => address.toLowerCase())),
+  ];
   if (unique.length === 0) return new Map<string, bigint>();
 
   const key = unique.join(",");
@@ -225,7 +226,23 @@ async function currentAlchemyPrices(addresses: readonly string[]) {
         (index + 1) * MAX_ALCHEMY_PRICE_ADDRESSES,
       ),
   );
-  const value = Promise.all(batches.map(requestAlchemyPrices))
+  const value = (async () => {
+    const results: Array<ReadonlyMap<string, bigint>> = [];
+    for (
+      let offset = 0;
+      offset < batches.length;
+      offset += MAX_CONCURRENT_ALCHEMY_PRICE_BATCHES
+    ) {
+      results.push(
+        ...(await Promise.all(
+          batches
+            .slice(offset, offset + MAX_CONCURRENT_ALCHEMY_PRICE_BATCHES)
+            .map(requestAlchemyPrices),
+        )),
+      );
+    }
+    return results;
+  })()
     .then((results) => {
       const merged = new Map<string, bigint>();
       for (const result of results) {

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -61,6 +61,27 @@ export function evaluateAlchemyExploreSourceContracts(
     responsePath,
     sourceOverrides,
   );
+  const runtimePath = "lib/alchemy/explore.server.ts";
+  const runtimeSource = readSource(
+    rootDirectory,
+    runtimePath,
+    sourceOverrides,
+  );
+
+  check(
+    "alchemy-durable-registry",
+    runtimeSource.includes(
+      "return readExploreModel(getAlchemyOnchainDeployment());",
+    ) && !runtimeSource.includes("readLiveExploreModel"),
+    "the request path starts from the verified durable registry instead of rescanning launch history",
+  );
+  check(
+    "alchemy-complete-price-batching",
+    runtimeSource.includes("MAX_CONCURRENT_ALCHEMY_PRICE_BATCHES") &&
+      !runtimeSource.includes("MAX_ALCHEMY_PRICE_BATCHES") &&
+      !runtimeSource.includes(".slice(0, MAX_ALCHEMY_PRICE_ADDRESSES"),
+    "live Alchemy price enrichment covers the complete registry in bounded concurrent batches",
+  );
 
   for (const route of routeSources) {
     check(
@@ -84,15 +105,15 @@ export function evaluateAlchemyExploreSourceContracts(
       .filter(({ id }) => id !== "token-list")
       .every(
         ({ source }) =>
-          source.includes('"X-Programmable-Read-Source": "rpc"') &&
+          source.includes('"X-Programmable-Read-Source": "blob"') &&
           source.includes('"X-Programmable-Rpc-Provider": "alchemy"'),
       ) &&
-      responseSource.includes('"X-Programmable-Read-Source": "rpc"') &&
+      responseSource.includes('"X-Programmable-Read-Source": "blob"') &&
       responseSource.includes('"X-Programmable-Rpc-Provider": "alchemy"') &&
       responseSource.includes(
         '"X-Programmable-Read-Source, X-Programmable-Rpc-Provider"',
       ),
-    "Alchemy public responses expose RPC source and provider provenance",
+    "Alchemy public responses expose durable registry and live provider provenance",
   );
 
   return Object.freeze({

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1031,7 +1031,7 @@ export function evaluateReadModelOperationsSourceContracts(
         "STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
       ) &&
       stagedAlchemySmokeBlock.includes(
-        'response.headers.get("x-programmable-read-source") !== "rpc"',
+        'response.headers.get("x-programmable-read-source") !== "blob"',
       ) &&
       stagedAlchemySmokeBlock.includes(
         'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
@@ -1052,7 +1052,7 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       !stagedAlchemySmokeBlock.includes("${automationBypassSecret}") &&
       !stagedAlchemySmokeBlock.includes("console."),
-    "the Alchemy-only staged API smoke proves direct RPC provenance without indexed infrastructure or exposing its deployment bypass",
+    "the Alchemy-only staged API smoke proves durable-registry and live-provider provenance without indexed infrastructure or exposing its deployment bypass",
   );
   const stagedReadModelCapture = deployWorkflow.indexOf(
     "Capture staged read-model evidence",

--- a/tests/alchemy-explore.test.ts
+++ b/tests/alchemy-explore.test.ts
@@ -91,8 +91,8 @@ describe("Alchemy Explore price enrichment", () => {
     });
   });
 
-  it("price-enriches 100 visible tokens in five 20-address batches", async () => {
-    const tokens = Array.from({ length: 100 }, (_, index) =>
+  it("price-enriches every visible token in bounded 20-address batches", async () => {
+    const tokens = Array.from({ length: 125 }, (_, index) =>
       token(
         `0x${(index + 1).toString(16).padStart(40, "0")}` as `0x${string}`,
       ),
@@ -124,13 +124,21 @@ describe("Alchemy Explore price enrichment", () => {
 
     const enriched = await enrichTokensWithAlchemyPrices(tokens);
 
-    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock).toHaveBeenCalledTimes(7);
     const batches = fetchMock.mock.calls.map(([, init]) =>
       (JSON.parse(String(init.body)) as { addresses: unknown[] }).addresses,
     );
-    expect(batches.map((batch) => batch.length)).toEqual([20, 20, 20, 20, 20]);
-    expect(batches.flat()).toHaveLength(100);
-    expect(enriched).toHaveLength(100);
+    expect(batches.map((batch) => batch.length)).toEqual([
+      20,
+      20,
+      20,
+      20,
+      20,
+      20,
+      5,
+    ]);
+    expect(batches.flat()).toHaveLength(125);
+    expect(enriched).toHaveLength(125);
     expect(enriched.every((candidate) =>
       candidate.tokenPriceUsdWad === "2000000000000000000" &&
       candidate.fdvUsdWad ===

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -1290,7 +1290,7 @@ describe("read-model performance contract", () => {
         process.cwd(),
       );
     expect(alchemyResult.ok).toBe(true);
-    expect(alchemyResult.checks).toHaveLength(7);
+    expect(alchemyResult.checks).toHaveLength(9);
 
     const result = sourceContracts.evaluateReadModelSourceContracts(
       process.cwd(),

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -585,7 +585,7 @@ describe("read-model production deploy policy", () => {
     );
     expect(workflow).toContain("headers: alchemySmokeRequestHeaders");
     expect(workflow).toContain(
-      'response.headers.get("x-programmable-read-source") !== "rpc"',
+      'response.headers.get("x-programmable-read-source") !== "blob"',
     );
     expect(workflow).toContain(
       'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -112,7 +112,7 @@ describe("Explore API Alchemy boundary", () => {
       Array.from({ length: 10 }, (_, index) => `T${10 - index}`),
     );
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "rpc",
+      "blob",
     );
     expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
       "alchemy",
@@ -151,7 +151,7 @@ describe("Explore API Alchemy boundary", () => {
       ]),
     );
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "rpc",
+      "blob",
     );
     expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
       "alchemy",

--- a/tests/indexer-feed.test.ts
+++ b/tests/indexer-feed.test.ts
@@ -80,7 +80,7 @@ beforeEach(() => {
 });
 
 function expectAlchemyRpcHeaders(response: Response) {
-  expect(response.headers.get("x-programmable-read-source")).toBe("rpc");
+  expect(response.headers.get("x-programmable-read-source")).toBe("blob");
   expect(response.headers.get("x-programmable-rpc-provider")).toBe(
     "alchemy",
   );

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -101,7 +101,7 @@ describe("token detail Alchemy read", () => {
       indexedMarketCapUsdWad: "1250000000000000000000000",
     });
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "rpc",
+      "blob",
     );
     expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
       "alchemy",


### PR DESCRIPTION
## What changed

- start public coin reads from the existing verified durable registry instead of rescanning the full launch history on every serverless cold start
- price-enrich the complete registry through bounded 20-address Alchemy batches with at most five concurrent requests
- rank the top 20 after current Alchemy price enrichment, then append all remaining launches newest-first
- expose the honest source boundary as durable registry plus Alchemy live provider
- update the staged production smoke and source contracts to enforce that boundary

## Why

The first Alchemy-only candidate proved the direct full-history path was functionally correct but timed out after twelve 30-second cold-start attempts. The public request path must not rebuild the token registry. This follow-up keeps Alchemy as the live RPC/price provider while reusing the already verified compact registry snapshot for token identity and metadata.

## Validation

- 104 focused Vitest tests
- TypeScript typecheck
- targeted ESLint
- Alchemy source-contract smoke (9/9)
- read-model operations gate
- production Next.js build
