### PR TITLE
Keep Alchemy launch discovery current

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -340,6 +340,72 @@ jobs:
           if (!releaseToken) {
             throw new Error("staged Alchemy Explore has no token identity");
           }
+          const newest = await requestJson(
+            "/api/explore?limit=20&page=1&sort=newest",
+          );
+          if (
+            newest.status !== "ready" ||
+            !Array.isArray(newest.tokens) ||
+            newest.tokens.length < 1
+          ) {
+            throw new Error("staged Alchemy newest page is not populated");
+          }
+          for (let index = 1; index < newest.tokens.length; index += 1) {
+            const previous = newest.tokens[index - 1];
+            const current = newest.tokens[index];
+            const previousOrder = [
+              BigInt(previous.launchBlockNumber ?? "-1"),
+              BigInt(previous.launchTransactionIndex ?? -1),
+              BigInt(previous.launchLogIndex ?? -1),
+            ];
+            const currentOrder = [
+              BigInt(current.launchBlockNumber ?? "-1"),
+              BigInt(current.launchTransactionIndex ?? -1),
+              BigInt(current.launchLogIndex ?? -1),
+            ];
+            if (
+              currentOrder.some(
+                (value, offset) =>
+                  value > previousOrder[offset] &&
+                  currentOrder.slice(0, offset).every(
+                    (prefix, prefixOffset) =>
+                      prefix === previousOrder[prefixOffset],
+                  ),
+              )
+            ) {
+              throw new Error("staged Alchemy newest page is not ordered newest-first");
+            }
+          }
+          const incrementalLaunchAddress =
+            "0x468505087c2dfec4779f2d6a5f8481f03e32e905";
+          const incrementalDetail = await requestJson(
+            `/api/explore/token?address=${encodeURIComponent(incrementalLaunchAddress)}`,
+          );
+          const incrementalLaunch = incrementalDetail.token;
+          const incrementalLaunchBlock = BigInt(
+            incrementalLaunch?.launchBlockNumber ?? "-1",
+          );
+          const durableBlock = BigInt(
+            incrementalDetail.snapshot?.blockNumber ?? "-1",
+          );
+          const launchCursorBlock = BigInt(
+            incrementalDetail.launchDiscoverySnapshot?.blockNumber ?? "-1",
+          );
+          if (
+            incrementalDetail.status !== "ready" ||
+            incrementalLaunch?.tokenAddress?.toLowerCase() !==
+              incrementalLaunchAddress ||
+            launchCursorBlock < incrementalLaunchBlock ||
+            (
+              incrementalLaunch.launchDiscoverySource !==
+                "alchemy-launch-overlay" &&
+              durableBlock < incrementalLaunchBlock
+            )
+          ) {
+            throw new Error(
+              "staged Alchemy Explore did not recover the incremental launch cursor",
+            );
+          }
           const tokenList = await requestJson("/api/indexers/v1/token-list");
           if (
             !Array.isArray(tokenList.tokens) ||
@@ -365,6 +431,9 @@ jobs:
             `${JSON.stringify({
               status: "verified-alchemy-only-staged-public-apis",
               tokenAddress: releaseToken.tokenAddress,
+              incrementalLaunchAddress,
+              launchCursorBlockNumber:
+                incrementalDetail.launchDiscoverySnapshot.blockNumber,
             })}\n`,
           );
           NODE

--- a/app/api/alchemy/webhook/route.ts
+++ b/app/api/alchemy/webhook/route.ts
@@ -3,9 +3,13 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
-import { ALCHEMY_EXPLORE_CACHE_TAG } from "../../../../lib/alchemy/explore.server";
+import {
+  ALCHEMY_EXPLORE_CACHE_TAG,
+  refreshAlchemyExploreRegistry,
+} from "../../../../lib/alchemy/explore.server";
 
 export const dynamic = "force-dynamic";
+export const maxDuration = 60;
 export const runtime = "nodejs";
 
 const MAXIMUM_BODY_BYTES = 128 * 1024;
@@ -123,7 +127,12 @@ export async function POST(request: Request) {
     }
 
     parsePayload(rawBody);
-    revalidateTag(ALCHEMY_EXPLORE_CACHE_TAG, "max");
+    await refreshAlchemyExploreRegistry({
+      forcePersist: true,
+      includeLatest: false,
+      requirePersistence: true,
+    });
+    revalidateTag(ALCHEMY_EXPLORE_CACHE_TAG, { expire: 0 });
     return new NextResponse(null, {
       status: 200,
       headers: PRIVATE_NO_STORE,

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -87,6 +87,8 @@ function topThenNewestPage(
     sort: "market-cap",
     query: "",
     snapshot: model.snapshot,
+    launchDiscoverySnapshot:
+      model.status === "ready" ? model.launchDiscoverySnapshot : undefined,
     launcherFeesAccruedWei: model.launcherFeesAccruedWei,
     launcherFeesAccruedEth: model.launcherFeesAccruedEth,
   };
@@ -136,9 +138,10 @@ export async function GET(request: NextRequest) {
         headers: {
           "Cache-Control":
             page.status === "ready"
-              ? "public, max-age=0, s-maxage=5, stale-while-revalidate=15"
+              ? "public, max-age=0, s-maxage=2, stale-while-revalidate=5"
               : "public, max-age=0, s-maxage=30",
           "X-Programmable-Price-Source": "alchemy",
+          "X-Programmable-Launch-Source": "alchemy",
           "X-Programmable-Read-Source": "blob",
           "X-Programmable-Rpc-Provider": "alchemy",
         },

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -40,11 +40,17 @@ export async function GET(request: NextRequest) {
 
     if (model.status === "ready" && !token) {
       return NextResponse.json(
-        { status: model.status, token: null, snapshot: model.snapshot },
+        {
+          status: model.status,
+          token: null,
+          snapshot: model.snapshot,
+          launchDiscoverySnapshot: model.launchDiscoverySnapshot,
+        },
         {
           status: 404,
           headers: {
             "Cache-Control": "no-store",
+            "X-Programmable-Launch-Source": "alchemy",
             "X-Programmable-Read-Source": "blob",
             "X-Programmable-Rpc-Provider": "alchemy",
           },
@@ -60,14 +66,19 @@ export async function GET(request: NextRequest) {
         status: model.status,
         token: enriched,
         snapshot: model.snapshot,
+        launchDiscoverySnapshot:
+          model.status === "ready"
+            ? model.launchDiscoverySnapshot
+            : undefined,
       },
       {
         headers: {
           "Cache-Control":
             model.status === "ready"
-              ? "public, max-age=0, s-maxage=5, stale-while-revalidate=15"
+              ? "public, max-age=0, s-maxage=2, stale-while-revalidate=5"
               : "public, max-age=0, s-maxage=30",
           "X-Programmable-Price-Source": "alchemy",
+          "X-Programmable-Launch-Source": "alchemy",
           "X-Programmable-Read-Source": "blob",
           "X-Programmable-Rpc-Provider": "alchemy",
         },

--- a/app/api/indexers/v1/response.ts
+++ b/app/api/indexers/v1/response.ts
@@ -22,8 +22,9 @@ export function alchemyFeedHeaders(
   return Object.freeze({
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Expose-Headers":
-      "X-Programmable-Read-Source, X-Programmable-Rpc-Provider",
+      "X-Programmable-Launch-Source, X-Programmable-Read-Source, X-Programmable-Rpc-Provider",
     "Cache-Control": cacheControl,
+    "X-Programmable-Launch-Source": "alchemy",
     "X-Programmable-Read-Source": "blob",
     "X-Programmable-Rpc-Provider": "alchemy",
   });
@@ -32,8 +33,9 @@ export function alchemyFeedHeaders(
 export const ALCHEMY_NO_STORE_HEADERS = Object.freeze({
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Expose-Headers":
-    "X-Programmable-Read-Source, X-Programmable-Rpc-Provider",
+    "X-Programmable-Launch-Source, X-Programmable-Read-Source, X-Programmable-Rpc-Provider",
   "Cache-Control": "no-store",
+  "X-Programmable-Launch-Source": "alchemy",
   "X-Programmable-Read-Source": "blob",
   "X-Programmable-Rpc-Provider": "alchemy",
 });

--- a/app/api/indexers/v1/token-list/route.ts
+++ b/app/api/indexers/v1/token-list/route.ts
@@ -28,7 +28,7 @@ export async function GET() {
         {
           status: 503,
           headers: {
-            ...alchemyFeedHeaders("public, max-age=0, s-maxage=60"),
+            ...alchemyFeedHeaders("public, max-age=0, s-maxage=5"),
             "Retry-After": "60",
           },
         },
@@ -41,7 +41,7 @@ export async function GET() {
 
     return NextResponse.json(tokenList, {
       headers: alchemyFeedHeaders(
-        "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+        "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
       ),
     });
   } catch (error) {

--- a/lib/alchemy/explore.server.ts
+++ b/lib/alchemy/explore.server.ts
@@ -3,12 +3,20 @@ import "server-only";
 import { unstable_cache } from "next/cache";
 
 import { getOnchainDeployment } from "../onchain/config";
-import { readExploreModel } from "../onchain/read-model";
+import { readDurableExploreModel } from "../onchain/durable-model";
+import { advanceExploreLaunchDiscovery } from "../onchain/read-model";
 import type {
   ExploreReadModel,
   OnchainDeployment,
+  ReadyOnchainDeployment,
 } from "../onchain/types";
 import type { LauncherToken } from "../tokens";
+import {
+  readAlchemyLaunchRegistry,
+  writeAlchemyLaunchRegistry,
+  type AlchemyLaunchCursor,
+  type AlchemyLaunchRegistry,
+} from "./launch-registry.server";
 
 export const ALCHEMY_EXPLORE_CACHE_TAG = "alchemy-explore-v1";
 
@@ -22,6 +30,7 @@ const MAX_CONCURRENT_ALCHEMY_PRICE_BATCHES = 5;
 const MAX_ALCHEMY_PRICE_AGE_MS = 5 * 60 * 1_000;
 const MAX_ALCHEMY_PRICE_CLOCK_SKEW_MS = 60 * 1_000;
 const MAX_PRICE_CACHE_ENTRIES = 100;
+const LAUNCH_CURSOR_PERSIST_INTERVAL_BLOCKS = 64n;
 const USD_WAD = 10n ** 18n;
 
 type AlchemyPrice = Readonly<{
@@ -99,20 +108,243 @@ export function getAlchemyOnchainDeployment(): OnchainDeployment {
 }
 
 async function readAlchemyExploreModelUncached(): Promise<ExploreReadModel> {
-  return readExploreModel(getAlchemyOnchainDeployment());
+  return (
+    await refreshAlchemyExploreRegistry({
+      includeLatest: true,
+      requirePersistence: false,
+    })
+  ).model;
 }
 
 const readCachedAlchemyExploreModel = unstable_cache(
   readAlchemyExploreModelUncached,
   [ALCHEMY_EXPLORE_CACHE_TAG],
   {
-    revalidate: 15,
+    revalidate: 5,
     tags: [ALCHEMY_EXPLORE_CACHE_TAG],
   },
 );
 
 export async function readAlchemyExploreModel() {
   return readCachedAlchemyExploreModel();
+}
+
+type AlchemyRegistryRefreshOptions = Readonly<{
+  forcePersist?: boolean;
+  includeLatest?: boolean;
+  persist?: boolean;
+  requirePersistence?: boolean;
+}>;
+
+type ReadyExploreModel = Extract<ExploreReadModel, { status: "ready" }>;
+
+function durableReadyModel(
+  deployment: ReadyOnchainDeployment,
+  read: Awaited<ReturnType<typeof readDurableExploreModel>>,
+): ReadyExploreModel {
+  if (read.status !== "ready") {
+    throw new Error(
+      `Durable Alchemy registry is ${read.reason}: ${read.detail}`,
+    );
+  }
+  const model = read.envelope.payload.model;
+  if (
+    model.status !== "ready" ||
+    model.snapshot.chainId !== deployment.chainId
+  ) {
+    throw new Error("Durable Alchemy registry is not ready");
+  }
+  return model;
+}
+
+function sameLaunch(left: LauncherToken, right: LauncherToken) {
+  return (
+    left.tokenAddress.toLowerCase() === right.tokenAddress.toLowerCase() &&
+    left.launchTransactionHash?.toLowerCase() ===
+      right.launchTransactionHash?.toLowerCase() &&
+    left.launchLogIndex === right.launchLogIndex
+  );
+}
+
+function mergeLaunchOverlay(
+  base: ReadyExploreModel,
+  overlayTokens: readonly LauncherToken[],
+) {
+  const tokens = new Map(
+    base.tokens.map((token) => [token.tokenAddress.toLowerCase(), token]),
+  );
+  for (const token of overlayTokens) {
+    const key = token.tokenAddress.toLowerCase();
+    const existing = tokens.get(key);
+    if (existing && !sameLaunch(existing, token)) {
+      throw new Error(`Alchemy launch overlay conflicts for ${token.tokenAddress}`);
+    }
+    tokens.set(key, {
+      ...token,
+      launchDiscoverySource: "alchemy-launch-overlay",
+    });
+  }
+  return { ...base, tokens: [...tokens.values()] } satisfies ReadyExploreModel;
+}
+
+function overlayTokensAfterBase(
+  base: ReadyExploreModel,
+  tokens: readonly LauncherToken[],
+) {
+  const baseTokens = new Map(
+    base.tokens.map((token) => [token.tokenAddress.toLowerCase(), token]),
+  );
+  const output: LauncherToken[] = [];
+  for (const token of tokens) {
+    const existing = baseTokens.get(token.tokenAddress.toLowerCase());
+    if (existing) {
+      if (!sameLaunch(existing, token)) {
+        throw new Error(`Durable registry conflicts for ${token.tokenAddress}`);
+      }
+      continue;
+    }
+    output.push(token);
+  }
+  return output;
+}
+
+function registryTokenIdentity(registry: AlchemyLaunchRegistry) {
+  return JSON.stringify(
+    registry.tokens.map((token) => [
+      token.tokenAddress.toLowerCase(),
+      token.launchTransactionHash?.toLowerCase(),
+      token.launchLogIndex,
+    ]),
+  );
+}
+
+function persistentOverlayTokensAfterBase(
+  base: ReadyExploreModel,
+  tokens: readonly LauncherToken[],
+) {
+  return overlayTokensAfterBase(base, tokens).map((token) => {
+    const persistent = { ...token };
+    delete persistent.launchDiscoverySource;
+    return persistent;
+  });
+}
+
+async function refreshAlchemyExploreRegistryOnce(
+  options: AlchemyRegistryRefreshOptions = {},
+) {
+  const deployment = getAlchemyOnchainDeployment();
+  if (deployment.status !== "ready") {
+    throw new Error("Alchemy production deployment is not ready");
+  }
+  const durable = await readDurableExploreModel(
+    deployment,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const base = durableReadyModel(deployment, durable);
+  const initialCursor: AlchemyLaunchCursor = {
+    blockNumber: base.snapshot.blockNumber,
+    blockHash: base.snapshot.blockHash,
+  };
+  const stored = await readAlchemyLaunchRegistry(
+    deployment,
+    initialCursor,
+  );
+  const baseBlock = BigInt(base.snapshot.blockNumber);
+  const storedCursorBlock = BigInt(stored.registry.cursor.blockNumber);
+  const compactedTokens = overlayTokensAfterBase(
+    base,
+    stored.registry.tokens,
+  );
+  const cursor = storedCursorBlock >= baseBlock
+    ? stored.registry.cursor
+    : initialCursor;
+  const cursorModel: ReadyExploreModel = {
+    ...mergeLaunchOverlay(base, compactedTokens),
+    snapshot: {
+      ...base.snapshot,
+      blockNumber: cursor.blockNumber,
+      blockHash: cursor.blockHash,
+    },
+  };
+  const confirmed = await advanceExploreLaunchDiscovery(
+    deployment,
+    cursorModel,
+    "confirmed",
+  );
+  const confirmedRegistry: AlchemyLaunchRegistry = {
+    generatedAt: new Date().toISOString(),
+    repositoryCommit: stored.registry.repositoryCommit,
+    chainId: deployment.chainId,
+    cursor: {
+      blockNumber: confirmed.snapshot.blockNumber,
+      blockHash: confirmed.snapshot.blockHash,
+    },
+    tokens: persistentOverlayTokensAfterBase(base, confirmed.tokens),
+  };
+  const registryChanged =
+    registryTokenIdentity(confirmedRegistry) !==
+      registryTokenIdentity(stored.registry) ||
+    BigInt(confirmedRegistry.cursor.blockNumber) -
+      BigInt(stored.registry.cursor.blockNumber) >=
+      LAUNCH_CURSOR_PERSIST_INTERVAL_BLOCKS;
+  let persisted = false;
+  if (
+    options.persist !== false &&
+    (options.forcePersist || registryChanged)
+  ) {
+    try {
+      await writeAlchemyLaunchRegistry(
+        deployment,
+        confirmedRegistry,
+        stored.etag,
+      );
+      persisted = true;
+    } catch (error) {
+      if (options.requirePersistence) throw error;
+      console.warn("Alchemy registry persistence failed", safeAlchemyError(error));
+    }
+  }
+  const servedCursorModel = options.includeLatest === false
+    ? confirmed
+    : await advanceExploreLaunchDiscovery(deployment, confirmed, "latest");
+  const model: ReadyExploreModel = {
+    ...mergeLaunchOverlay(
+      base,
+      overlayTokensAfterBase(base, servedCursorModel.tokens),
+    ),
+    launchDiscoverySnapshot: servedCursorModel.snapshot,
+  };
+  return {
+    model,
+    baseBlockNumber: base.snapshot.blockNumber,
+    confirmedBlockNumber: confirmed.snapshot.blockNumber,
+    servedBlockNumber: servedCursorModel.snapshot.blockNumber,
+    persisted,
+    registryChanged,
+  } as const;
+}
+
+export async function refreshAlchemyExploreRegistry(
+  options: AlchemyRegistryRefreshOptions = {},
+) {
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      return await refreshAlchemyExploreRegistryOnce(options);
+    } catch (error) {
+      if (
+        attempt === 1 &&
+        error instanceof Error &&
+        (
+          error.name === "BlobPreconditionFailedError" ||
+          error.name === "AlchemyLaunchRegistryCreateConflictError"
+        )
+      ) {
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error("Alchemy registry refresh retry exhausted");
 }
 
 export function safeAlchemyError(error: unknown) {

--- a/lib/alchemy/launch-registry.server.ts
+++ b/lib/alchemy/launch-registry.server.ts
@@ -1,0 +1,226 @@
+import "server-only";
+
+import {
+  isAddress,
+  isHex,
+  keccak256,
+  toBytes,
+  type Hex,
+} from "viem";
+
+import { resolveDurableExploreBlobToken } from "../onchain/durable-model";
+import type { ReadyOnchainDeployment } from "../onchain/types";
+import type { LauncherToken } from "../tokens";
+
+const ALCHEMY_LAUNCH_REGISTRY_DIRECTORY =
+  "indexes/mainnet-classic-v2/alchemy-launch-registry-v1";
+const SCHEMA_VERSION = "programmable-alchemy-launch-registry-v1";
+const REPOSITORY_COMMIT = /^[0-9a-f]{40}$/u;
+
+export type AlchemyLaunchCursor = Readonly<{
+  blockNumber: string;
+  blockHash: Hex;
+}>;
+
+export type AlchemyLaunchRegistry = Readonly<{
+  generatedAt: string;
+  repositoryCommit: string;
+  chainId: number;
+  cursor: AlchemyLaunchCursor;
+  tokens: readonly LauncherToken[];
+}>;
+
+type AlchemyLaunchRegistryEnvelope = Readonly<{
+  schemaVersion: typeof SCHEMA_VERSION;
+  contentHash: Hex;
+  payload: AlchemyLaunchRegistry;
+}>;
+
+export type AlchemyLaunchRegistryRead = Readonly<{
+  registry: AlchemyLaunchRegistry;
+  etag: string | null;
+}>;
+
+function contentHash(payload: AlchemyLaunchRegistry) {
+  return keccak256(toBytes(JSON.stringify(payload)));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function validIntegerString(value: unknown) {
+  return typeof value === "string" && /^(?:0|[1-9]\d*)$/u.test(value);
+}
+
+function requiredRepositoryCommit(
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const value = environment.VERCEL_GIT_COMMIT_SHA?.trim().toLowerCase();
+  if (!value || !REPOSITORY_COMMIT.test(value)) {
+    throw new Error("Alchemy launch registry commit binding is unavailable");
+  }
+  return value;
+}
+
+function registryPath(repositoryCommit: string) {
+  return `${ALCHEMY_LAUNCH_REGISTRY_DIRECTORY}/${repositoryCommit}.json`;
+}
+
+function validLaunchToken(value: unknown, cursorBlock: bigint) {
+  if (!isRecord(value)) return false;
+  if (
+    !isAddress(String(value.tokenAddress ?? "")) ||
+    !isAddress(String(value.hookAddress ?? "")) ||
+    !isHex(String(value.poolId ?? ""), { strict: true }) ||
+    String(value.poolId).length !== 66 ||
+    !validIntegerString(value.launchBlockNumber) ||
+    BigInt(value.launchBlockNumber as string) > cursorBlock ||
+    !isHex(String(value.launchTransactionHash ?? ""), { strict: true }) ||
+    String(value.launchTransactionHash).length !== 66 ||
+    !Number.isSafeInteger(value.launchLogIndex) ||
+    (value.launchLogIndex as number) < 0 ||
+    typeof value.name !== "string" ||
+    typeof value.symbol !== "string" ||
+    typeof value.launchedAt !== "string" ||
+    !Number.isFinite(Date.parse(value.launchedAt))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function validateAlchemyLaunchRegistryEnvelope(
+  value: unknown,
+  deployment: ReadyOnchainDeployment,
+): AlchemyLaunchRegistry {
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== SCHEMA_VERSION ||
+    typeof value.contentHash !== "string" ||
+    !isRecord(value.payload)
+  ) {
+    throw new Error("Alchemy launch registry envelope is malformed");
+  }
+  const payload = value.payload;
+  const repositoryCommit = requiredRepositoryCommit();
+  if (
+    payload.chainId !== deployment.chainId ||
+    payload.repositoryCommit !== repositoryCommit ||
+    typeof payload.generatedAt !== "string" ||
+    !Number.isFinite(Date.parse(payload.generatedAt)) ||
+    !isRecord(payload.cursor) ||
+    !validIntegerString(payload.cursor.blockNumber) ||
+    !isHex(String(payload.cursor.blockHash ?? ""), { strict: true }) ||
+    String(payload.cursor.blockHash).length !== 66 ||
+    !Array.isArray(payload.tokens)
+  ) {
+    throw new Error("Alchemy launch registry payload is malformed");
+  }
+  const registry = payload as unknown as AlchemyLaunchRegistry;
+  if (contentHash(registry).toLowerCase() !== value.contentHash.toLowerCase()) {
+    throw new Error("Alchemy launch registry content hash is invalid");
+  }
+  const cursorBlock = BigInt(registry.cursor.blockNumber);
+  if (!registry.tokens.every((token) => validLaunchToken(token, cursorBlock))) {
+    throw new Error("Alchemy launch registry contains an invalid token");
+  }
+  const tokenKeys = registry.tokens.map((token) =>
+    token.tokenAddress.toLowerCase(),
+  );
+  const eventKeys = registry.tokens.map((token) =>
+    [
+      token.launchTransactionHash?.toLowerCase(),
+      token.launchLogIndex,
+    ].join(":"),
+  );
+  if (
+    new Set(tokenKeys).size !== tokenKeys.length ||
+    new Set(eventKeys).size !== eventKeys.length
+  ) {
+    throw new Error("Alchemy launch registry contains duplicate provenance");
+  }
+  return registry;
+}
+
+export async function readAlchemyLaunchRegistry(
+  deployment: ReadyOnchainDeployment,
+  initialCursor: AlchemyLaunchCursor,
+): Promise<AlchemyLaunchRegistryRead> {
+  const token = resolveDurableExploreBlobToken();
+  if (!token) throw new Error("Alchemy launch registry storage is not configured");
+  const repositoryCommit = requiredRepositoryCommit();
+  const { get } = await import("@vercel/blob");
+  const result = await get(registryPath(repositoryCommit), {
+    access: "private",
+    token,
+    useCache: false,
+  });
+  if (!result || result.statusCode !== 200 || !result.stream) {
+    return {
+      registry: {
+        generatedAt: new Date().toISOString(),
+        repositoryCommit,
+        chainId: deployment.chainId,
+        cursor: initialCursor,
+        tokens: [],
+      },
+      etag: null,
+    };
+  }
+  const registry = validateAlchemyLaunchRegistryEnvelope(
+    JSON.parse(await new Response(result.stream).text()),
+    deployment,
+  );
+  return { registry, etag: result.blob.etag };
+}
+
+export async function writeAlchemyLaunchRegistry(
+  deployment: ReadyOnchainDeployment,
+  registry: AlchemyLaunchRegistry,
+  expectedEtag: string | null,
+) {
+  const token = resolveDurableExploreBlobToken();
+  if (!token) throw new Error("Alchemy launch registry storage is not configured");
+  const repositoryCommit = requiredRepositoryCommit();
+  const validated = validateAlchemyLaunchRegistryEnvelope(
+    {
+      schemaVersion: SCHEMA_VERSION,
+      contentHash: contentHash(registry),
+      payload: registry,
+    },
+    deployment,
+  );
+  const envelope: AlchemyLaunchRegistryEnvelope = {
+    schemaVersion: SCHEMA_VERSION,
+    contentHash: contentHash(validated),
+    payload: validated,
+  };
+  const { get, put } = await import("@vercel/blob");
+  const path = registryPath(repositoryCommit);
+  try {
+    return await put(path, JSON.stringify(envelope), {
+      access: "private",
+      contentType: "application/json",
+      addRandomSuffix: false,
+      allowOverwrite: expectedEtag !== null,
+      cacheControlMaxAge: 60,
+      ...(expectedEtag ? { ifMatch: expectedEtag } : {}),
+      token,
+    });
+  } catch (error) {
+    if (expectedEtag === null) {
+      const existing = await get(path, {
+        access: "private",
+        token,
+        useCache: false,
+      });
+      if (existing?.statusCode === 200) {
+        const conflict = new Error("Alchemy launch registry was created concurrently");
+        conflict.name = "AlchemyLaunchRegistryCreateConflictError";
+        throw conflict;
+      }
+    }
+    throw error;
+  }
+}

--- a/lib/onchain/classic-v3-read-model.ts
+++ b/lib/onchain/classic-v3-read-model.ts
@@ -173,10 +173,14 @@ async function readEvents(
   config: ReadyOnchainDeployment,
   release: ClassicV3Release,
   toBlock: bigint,
+  fromBlockFloor: bigint,
 ) {
   const launches: LaunchRecord[] = [];
   const volumes = new Map<string, FeeVolume>();
-  let fromBlock = release.startBlock;
+  let fromBlock =
+    fromBlockFloor > release.startBlock
+      ? fromBlockFloor
+      : release.startBlock;
   let logBlockRange = config.logBlockRange;
   while (fromBlock <= toBlock) {
     const rangeEnd = minimum(
@@ -444,6 +448,7 @@ export function isClassicV3ExploreReleaseReady(
 export async function readClassicV3ExploreModel(
   config: ReadyOnchainDeployment,
   snapshotBlockNumber: string,
+  options: Readonly<{ fromBlock?: bigint }> = {},
 ): Promise<ClassicV3ExploreSlice> {
   const release = resolveClassicV3Release(config);
   if (!release || !/^(?:0|[1-9]\d*)$/.test(snapshotBlockNumber)) {
@@ -500,7 +505,14 @@ export async function readClassicV3ExploreModel(
   const eventSets = await mapInBatches(
     clients,
     RPC_PROVENANCE_BATCH_SIZE,
-    (client) => readEvents(client, config, release, toBlock),
+    (client) =>
+      readEvents(
+        client,
+        config,
+        release,
+        toBlock,
+        options.fromBlock ?? release.startBlock,
+      ),
   );
   const launcherFees = await mapInBatches(
     clients,

--- a/lib/onchain/indexer-feed.ts
+++ b/lib/onchain/indexer-feed.ts
@@ -115,6 +115,7 @@ export type ProgrammableIndexerFeed = {
   status: ExploreReadModel["status"];
   chainId: number;
   snapshot: ExploreSnapshot | null;
+  launchDiscoverySnapshot?: ExploreSnapshot;
   tokens: ProgrammableIndexerToken[];
 };
 
@@ -471,6 +472,8 @@ export function buildIndexerFeed(
     status: model.status,
     chainId,
     snapshot: model.snapshot,
+    launchDiscoverySnapshot:
+      model.status === "ready" ? model.launchDiscoverySnapshot : undefined,
     tokens: model.tokens.map((token) =>
       serializeIndexerToken(token, chainId),
     ),

--- a/lib/onchain/query.ts
+++ b/lib/onchain/query.ts
@@ -183,6 +183,8 @@ export function paginateExplore(
     sort,
     query,
     snapshot: model.snapshot,
+    launchDiscoverySnapshot:
+      model.status === "ready" ? model.launchDiscoverySnapshot : undefined,
     launcherFeesAccruedWei: model.launcherFeesAccruedWei,
     launcherFeesAccruedEth: model.launcherFeesAccruedEth,
   };

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -869,6 +869,163 @@ async function readReadyModel(
   };
 }
 
+type ReadyExploreModel = Extract<ExploreReadModel, { status: "ready" }>;
+
+function launchIdentity(token: LauncherToken) {
+  return [
+    token.tokenAddress.toLowerCase(),
+    token.launchTransactionHash?.toLowerCase() ?? "",
+    token.launchLogIndex ?? -1,
+  ].join(":");
+}
+
+function claimIdentity(
+  claim: ReadyExploreModel["creatorClaims"][number],
+) {
+  return [
+    claim.transactionHash.toLowerCase(),
+    claim.logIndex,
+  ].join(":");
+}
+
+function mergeIncrementalClassicModel(
+  base: ReadyExploreModel,
+  incremental: ReadyExploreModel,
+): ReadyExploreModel {
+  if (base.snapshot.chainId !== incremental.snapshot.chainId) {
+    throw new Error("Incremental Explore registry changed chains");
+  }
+  const tokens = new Map(
+    base.tokens.map((token) => [token.tokenAddress.toLowerCase(), token]),
+  );
+  for (const token of incremental.tokens) {
+    const key = token.tokenAddress.toLowerCase();
+    const existing = tokens.get(key);
+    if (existing && launchIdentity(existing) !== launchIdentity(token)) {
+      throw new Error(
+        `Incremental Explore registry changed launch identity for ${token.tokenAddress}`,
+      );
+    }
+    tokens.set(key, token);
+  }
+  const claims = new Map(
+    base.creatorClaims.map((claim) => [claimIdentity(claim), claim]),
+  );
+  for (const claim of incremental.creatorClaims) {
+    claims.set(claimIdentity(claim), claim);
+  }
+  return {
+    status: "ready",
+    tokens: [...tokens.values()],
+    snapshot: incremental.snapshot,
+    creatorClaims: [...claims.values()],
+    launcherFeesAccruedWei: incremental.launcherFeesAccruedWei,
+    launcherFeesAccruedEth: incremental.launcherFeesAccruedEth,
+  };
+}
+
+async function assertSnapshotIsCanonical(
+  config: ReadyOnchainDeployment,
+  snapshot: ReadyExploreModel["snapshot"],
+) {
+  if (snapshot.chainId !== config.chainId) {
+    throw new Error("Durable Explore snapshot changed chains");
+  }
+  const clients = [
+    createOnchainClient(config),
+    ...(config.rpcUrlSecondary
+      ? [createOnchainClient(config, config.rpcUrlSecondary)]
+      : []),
+  ];
+  const blocks = await mapInBatches(
+    clients,
+    RPC_PROVENANCE_BATCH_SIZE,
+    (client) =>
+      client.getBlock({ blockNumber: BigInt(snapshot.blockNumber) }),
+  );
+  if (
+    blocks.some(
+      (block) =>
+        !block.hash ||
+        block.hash.toLowerCase() !== snapshot.blockHash.toLowerCase(),
+    )
+  ) {
+    throw new Error("Durable Explore snapshot is no longer canonical");
+  }
+}
+
+export async function advanceExploreLaunchDiscovery(
+  config: ReadyOnchainDeployment,
+  base: ExploreReadModel,
+  target: "confirmed" | "latest" = "confirmed",
+): Promise<ReadyExploreModel> {
+  if (base.status !== "ready") {
+    throw new Error("Incremental Explore requires a ready durable registry");
+  }
+  if (
+    isDeepExploreReleaseReady(config) ||
+    isDeepV2ExploreReleaseReady(config) ||
+    isDeepV3ExploreReleaseReady(config)
+  ) {
+    throw new Error(
+      "Incremental Alchemy registry does not support an active Deep release",
+    );
+  }
+
+  await assertSnapshotIsCanonical(config, base.snapshot);
+  const fromBlock = BigInt(base.snapshot.blockNumber) + 1n;
+  const incrementalConfig: ReadyOnchainDeployment = {
+    ...config,
+    confirmations: target === "latest" ? 0n : config.confirmations,
+    deploymentBlock: fromBlock,
+  };
+  const incremental = await readReadyModel(incrementalConfig);
+  if (incremental.status !== "ready") {
+    throw new Error("Incremental Classic registry is not ready");
+  }
+  const incomingBlock = BigInt(incremental.snapshot.blockNumber);
+  const currentBlock = BigInt(base.snapshot.blockNumber);
+  if (incomingBlock < currentBlock) {
+    throw new Error("Incremental Explore head moved behind the durable cursor");
+  }
+  if (incomingBlock === currentBlock) {
+    if (
+      incremental.snapshot.blockHash.toLowerCase() !==
+      base.snapshot.blockHash.toLowerCase()
+    ) {
+      throw new Error("Incremental Explore head replaced the durable cursor");
+    }
+    return base;
+  }
+
+  let registry = mergeIncrementalClassicModel(base, incremental);
+  if (isClassicV3ExploreReleaseReady(config)) {
+    registry = mergeClassicV3ExploreModel(
+      registry,
+      await withReadStage("classic-v3-incremental", () =>
+        readClassicV3ExploreModel(
+          incrementalConfig,
+          incremental.snapshot.blockNumber,
+          { fromBlock },
+        ),
+      ),
+    );
+  }
+  if (isStockPairedExploreReleaseReady(config)) {
+    registry = mergeStockPairedExploreModel(
+      registry,
+      await withReadStage("stock-paired-incremental", () =>
+        readStockPairedExploreModel(
+          incrementalConfig,
+          incremental.snapshot.blockNumber,
+          { fromBlock },
+        ),
+      ),
+    );
+  }
+  return registry;
+}
+
 async function readReadyRegistryModel(
   config: ReadyOnchainDeployment,
 ): Promise<ExploreReadModel> {

--- a/lib/onchain/stock-paired-read-model.ts
+++ b/lib/onchain/stock-paired-read-model.ts
@@ -203,6 +203,7 @@ async function readEvents(
   config: ReadyOnchainDeployment,
   release: VerifiedStockPairedRelease,
   toBlock: bigint,
+  fromBlockFloor: bigint,
 ) {
   const launches: StockLaunch[] = [];
   const ethLaunches: StockEthLaunch[] = [];
@@ -210,7 +211,11 @@ async function readEvents(
   const initialBuys: StockInitialBuy[] = [];
   const volumes = new Map<string, StockVolume>();
 
-  let fromBlock = BigInt(release.startBlock);
+  const releaseStartBlock = BigInt(release.startBlock);
+  let fromBlock =
+    fromBlockFloor > releaseStartBlock
+      ? fromBlockFloor
+      : releaseStartBlock;
   let logBlockRange = config.logBlockRange;
   while (fromBlock <= toBlock) {
     const rangeEnd = minimum(
@@ -708,6 +713,7 @@ export function isStockPairedExploreReleaseReady(
 export async function readStockPairedExploreModel(
   config: ReadyOnchainDeployment,
   snapshotBlockNumber: string,
+  options: Readonly<{ fromBlock?: bigint }> = {},
 ): Promise<LauncherToken[]> {
   const releases = getConfiguredStockPairedReleases();
   if (
@@ -788,7 +794,13 @@ export async function readStockPairedExploreModel(
         clients,
         RPC_PROVENANCE_BATCH_SIZE,
         (candidate) =>
-          readEvents(candidate, config, release, toBlock),
+          readEvents(
+            candidate,
+            config,
+            release,
+            toBlock,
+            options.fromBlock ?? BigInt(release.startBlock),
+          ),
       );
       const fingerprint = eventFingerprint(eventSets[0]);
       if (

--- a/lib/onchain/types.ts
+++ b/lib/onchain/types.ts
@@ -146,6 +146,7 @@ export type ExploreReadModel =
       status: "ready";
       tokens: LauncherToken[];
       snapshot: ExploreSnapshot;
+      launchDiscoverySnapshot?: ExploreSnapshot;
       creatorClaims: CreatorClaim[];
       launcherFeesAccruedWei: string;
       launcherFeesAccruedEth: string;
@@ -167,6 +168,7 @@ export type ExplorePage = {
   sort: ExploreSort;
   query: string;
   snapshot: ExploreSnapshot | null;
+  launchDiscoverySnapshot?: ExploreSnapshot;
   launcherFeesAccruedWei: string;
   launcherFeesAccruedEth: string;
 };

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -61,6 +61,7 @@ export type LauncherToken = {
   launchTransactionHash?: `0x${string}`;
   launchTransactionIndex?: number;
   launchLogIndex?: number;
+  launchDiscoverySource?: "alchemy-launch-overlay";
   launchedAt: string;
   totalSupply?: string;
   totalSupplyRaw?: string;

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -8,19 +8,19 @@ const ROUTES = Object.freeze([
     id: "explore",
     path: "app/api/explore/route.ts",
     readyCache:
-      "public, max-age=0, s-maxage=5, stale-while-revalidate=15",
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
   }),
   Object.freeze({
     id: "token-detail",
     path: "app/api/explore/token/route.ts",
     readyCache:
-      "public, max-age=0, s-maxage=5, stale-while-revalidate=15",
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
   }),
   Object.freeze({
     id: "token-list",
     path: "app/api/indexers/v1/token-list/route.ts",
     readyCache:
-      "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
   }),
 ]);
 
@@ -61,19 +61,117 @@ export function evaluateAlchemyExploreSourceContracts(
     responsePath,
     sourceOverrides,
   );
+  const publicIndexerSource = readSource(
+    rootDirectory,
+    "app/api/indexers/v1/tokens/route.ts",
+    sourceOverrides,
+  );
+  const publicIndexerAliasSource = readSource(
+    rootDirectory,
+    "app/api/indexers/v1/token/route.ts",
+    sourceOverrides,
+  );
+  const indexerFeedSource = readSource(
+    rootDirectory,
+    "lib/onchain/indexer-feed.ts",
+    sourceOverrides,
+  );
   const runtimePath = "lib/alchemy/explore.server.ts";
   const runtimeSource = readSource(
     rootDirectory,
     runtimePath,
     sourceOverrides,
   );
+  const registrySource = readSource(
+    rootDirectory,
+    "lib/alchemy/launch-registry.server.ts",
+    sourceOverrides,
+  );
+  const onchainSource = readSource(
+    rootDirectory,
+    "lib/onchain/read-model.ts",
+    sourceOverrides,
+  );
+  const classicV3Source = readSource(
+    rootDirectory,
+    "lib/onchain/classic-v3-read-model.ts",
+    sourceOverrides,
+  );
+  const stockPairedSource = readSource(
+    rootDirectory,
+    "lib/onchain/stock-paired-read-model.ts",
+    sourceOverrides,
+  );
+  const webhookSource = readSource(
+    rootDirectory,
+    "app/api/alchemy/webhook/route.ts",
+    sourceOverrides,
+  );
+  const deployWorkflowSource = readSource(
+    rootDirectory,
+    ".github/workflows/deploy-production.yml",
+    sourceOverrides,
+  );
 
   check(
     "alchemy-durable-registry",
-    runtimeSource.includes(
-      "return readExploreModel(getAlchemyOnchainDeployment());",
-    ) && !runtimeSource.includes("readLiveExploreModel"),
-    "the request path starts from the verified durable registry instead of rescanning launch history",
+    runtimeSource.includes("readDurableExploreModel(") &&
+      runtimeSource.includes("Number.MAX_SAFE_INTEGER") &&
+      runtimeSource.includes("readAlchemyLaunchRegistry(") &&
+      runtimeSource.includes("advanceExploreLaunchDiscovery(") &&
+      !runtimeSource.includes("readExploreModel(") &&
+      !runtimeSource.includes("readLiveExploreModel"),
+    "the request path starts from the verified durable registry and advances only its separate launch overlay",
+  );
+  check(
+    "alchemy-launch-registry-cas",
+    registrySource.includes(
+      '"indexes/mainnet-classic-v2/alchemy-launch-registry-v1"',
+    ) &&
+      registrySource.includes("VERCEL_GIT_COMMIT_SHA") &&
+      registrySource.includes("payload.repositoryCommit !== repositoryCommit") &&
+      registrySource.includes("contentHash(registry)") &&
+      registrySource.includes("ifMatch: expectedEtag") &&
+      registrySource.includes("allowOverwrite: expectedEtag !== null") &&
+      registrySource.includes("AlchemyLaunchRegistryCreateConflictError") &&
+      registrySource.includes("useCache: false"),
+    "the incremental launch cursor is content-addressed and compare-and-swap protected",
+  );
+  check(
+    "alchemy-bounded-launch-advance",
+    onchainSource.includes(
+      "const fromBlock = BigInt(base.snapshot.blockNumber) + 1n;",
+    ) &&
+      onchainSource.includes("deploymentBlock: fromBlock") &&
+      classicV3Source.includes("options.fromBlock ?? release.startBlock") &&
+      stockPairedSource.includes(
+        "options.fromBlock ?? BigInt(release.startBlock)",
+      ),
+    "every active launch family reads only blocks after the committed cursor",
+  );
+  check(
+    "alchemy-request-self-refresh",
+    runtimeSource.includes("includeLatest: true") &&
+      runtimeSource.includes("requirePersistence: false") &&
+      runtimeSource.includes("revalidate: 5") &&
+      runtimeSource.includes("LAUNCH_CURSOR_PERSIST_INTERVAL_BLOCKS") &&
+      runtimeSource.includes(
+        "launchDiscoverySnapshot: servedCursorModel.snapshot",
+      ) &&
+      runtimeSource.includes(
+        'advanceExploreLaunchDiscovery(deployment, confirmed, "latest")',
+      ),
+    "public requests self-refresh to the live Alchemy head without depending on cron or webhook delivery",
+  );
+  check(
+    "alchemy-webhook-persist-before-invalidate",
+    webhookSource.indexOf("await refreshAlchemyExploreRegistry({") >= 0 &&
+      webhookSource.indexOf("await refreshAlchemyExploreRegistry({") <
+        webhookSource.indexOf("revalidateTag(ALCHEMY_EXPLORE_CACHE_TAG") &&
+      webhookSource.includes("requirePersistence: true") &&
+      webhookSource.includes("{ expire: 0 }") &&
+      webhookSource.includes("return errorResponse(503)"),
+    "an authenticated webhook persists the confirmed cursor before invalidating public caches",
   );
   check(
     "alchemy-complete-price-batching",
@@ -100,18 +198,50 @@ export function evaluateAlchemyExploreSourceContracts(
   }
 
   check(
+    "alchemy-public-indexer-runtime",
+    publicIndexerSource.includes("readAlchemyExploreModel") &&
+      publicIndexerSource.includes("alchemyFeedHeaders") &&
+      publicIndexerAliasSource.includes(
+        'import { GET as getToken } from "../tokens/route";',
+      ) &&
+      FORBIDDEN_ROUTE_BINDINGS.every(
+        (binding) =>
+          !publicIndexerSource.includes(binding) &&
+          !publicIndexerAliasSource.includes(binding),
+      ),
+    "the public indexer feed uses the same direct Alchemy launch-discovery runtime",
+  );
+  check(
+    "alchemy-discovery-snapshot-provenance",
+    indexerFeedSource.includes("launchDiscoverySnapshot?: ExploreSnapshot") &&
+      indexerFeedSource.includes("model.launchDiscoverySnapshot") &&
+      deployWorkflowSource.includes(
+        'incrementalLaunch.launchDiscoverySource !==',
+      ) &&
+      deployWorkflowSource.includes(
+        "launchCursorBlock < incrementalLaunchBlock",
+      ) &&
+      responseSource.includes(
+        '"public, max-age=0, s-maxage=2, stale-while-revalidate=2"',
+      ),
+    "Explore and public indexer payloads distinguish market-state from launch-discovery coverage",
+  );
+
+  check(
     "alchemy-explore-provenance",
     routeSources
       .filter(({ id }) => id !== "token-list")
       .every(
         ({ source }) =>
+          source.includes('"X-Programmable-Launch-Source": "alchemy"') &&
           source.includes('"X-Programmable-Read-Source": "blob"') &&
           source.includes('"X-Programmable-Rpc-Provider": "alchemy"'),
       ) &&
       responseSource.includes('"X-Programmable-Read-Source": "blob"') &&
       responseSource.includes('"X-Programmable-Rpc-Provider": "alchemy"') &&
+      responseSource.includes('"X-Programmable-Launch-Source": "alchemy"') &&
       responseSource.includes(
-        '"X-Programmable-Read-Source, X-Programmable-Rpc-Provider"',
+        '"X-Programmable-Launch-Source, X-Programmable-Read-Source, X-Programmable-Rpc-Provider"',
       ),
     "Alchemy public responses expose durable registry and live provider provenance",
   );

--- a/tests/alchemy-launch-refresh.test.ts
+++ b/tests/alchemy-launch-refresh.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({
+  unstable_cache: (reader: () => unknown) => reader,
+}));
+
+const mocks = vi.hoisted(() => ({
+  getOnchainDeployment: vi.fn(),
+  readDurableExploreModel: vi.fn(),
+  advanceExploreLaunchDiscovery: vi.fn(),
+  readAlchemyLaunchRegistry: vi.fn(),
+  writeAlchemyLaunchRegistry: vi.fn(),
+}));
+
+vi.mock("../lib/onchain/config", () => ({
+  getOnchainDeployment: mocks.getOnchainDeployment,
+}));
+vi.mock("../lib/onchain/durable-model", () => ({
+  readDurableExploreModel: mocks.readDurableExploreModel,
+}));
+vi.mock("../lib/onchain/read-model", () => ({
+  advanceExploreLaunchDiscovery: mocks.advanceExploreLaunchDiscovery,
+}));
+vi.mock("../lib/alchemy/launch-registry.server", () => ({
+  readAlchemyLaunchRegistry: mocks.readAlchemyLaunchRegistry,
+  writeAlchemyLaunchRegistry: mocks.writeAlchemyLaunchRegistry,
+}));
+
+import { refreshAlchemyExploreRegistry } from "../lib/alchemy/explore.server";
+
+const deployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: "0x1111111111111111111111111111111111111111",
+  feeHook: "0x2222222222222222222222222222222222222222",
+  launcherRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  deploymentBlock: 1n,
+  stateView: "0x3333333333333333333333333333333333333333",
+  stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/test-key-1234",
+  rpcUrlSecondary: null,
+  confirmations: 12n,
+  logBlockRange: 5_000n,
+} as const;
+
+function token(address: `0x${string}`, blockNumber: string, logIndex: number) {
+  return {
+    id: `1:${address.toLowerCase()}`,
+    name: `Token ${logIndex}`,
+    symbol: `T${logIndex}`,
+    tokenAddress: address,
+    hookAddress: "0x4444444444444444444444444444444444444444",
+    poolId: `0x${String(logIndex).padStart(64, "0")}`,
+    launchBlockNumber: blockNumber,
+    launchTransactionHash: `0x${String(logIndex + 10).padStart(64, "0")}`,
+    launchLogIndex: logIndex,
+    launchedAt: "2026-08-04T00:00:00.000Z",
+    totalSwapFeeBps: 100,
+    launchModel: "classic" as const,
+    launchModelVersion: "classic-v3" as const,
+    liquidityPath: "meme" as const,
+  };
+}
+
+function snapshot(blockNumber: string) {
+  return {
+    chainId: 1,
+    blockNumber,
+    blockHash: `0x${BigInt(blockNumber).toString(16).padStart(64, "0")}`,
+    confirmations: 12,
+  } as const;
+}
+
+const baseToken = token(
+  "0x5555555555555555555555555555555555555555",
+  "90",
+  1,
+);
+const newestToken = token(
+  "0x6666666666666666666666666666666666666666",
+  "109",
+  2,
+);
+const baseModel = {
+  status: "ready" as const,
+  tokens: [baseToken],
+  snapshot: snapshot("100"),
+  creatorClaims: [],
+  launcherFeesAccruedWei: "0",
+  launcherFeesAccruedEth: "0",
+};
+
+describe("Alchemy launch overlay refresh", () => {
+  beforeEach(() => {
+    process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL = deployment.rpcUrl;
+    process.env.VERCEL_GIT_COMMIT_SHA = "a".repeat(40);
+    Object.values(mocks).forEach((mock) => mock.mockReset());
+    mocks.getOnchainDeployment.mockReturnValue(deployment);
+    mocks.readDurableExploreModel.mockResolvedValue({
+      status: "ready",
+      envelope: { payload: { model: baseModel } },
+    });
+    mocks.readAlchemyLaunchRegistry.mockResolvedValue({
+      registry: {
+        generatedAt: "2026-08-04T00:00:00.000Z",
+        repositoryCommit: "a".repeat(40),
+        chainId: 1,
+        cursor: snapshot("100"),
+        tokens: [],
+      },
+      etag: "registry-etag",
+    });
+    mocks.writeAlchemyLaunchRegistry.mockResolvedValue({ etag: "next-etag" });
+  });
+
+  afterEach(() => {
+    delete process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL;
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+  });
+
+  it("keeps market-state and launch-discovery snapshots explicit", async () => {
+    const confirmed = {
+      ...baseModel,
+      tokens: [baseToken, newestToken],
+      snapshot: snapshot("110"),
+    };
+    const latest = { ...confirmed, snapshot: snapshot("111") };
+    mocks.advanceExploreLaunchDiscovery
+      .mockResolvedValueOnce(confirmed)
+      .mockResolvedValueOnce(latest);
+
+    const result = await refreshAlchemyExploreRegistry({ persist: false });
+
+    expect(result.model.snapshot.blockNumber).toBe("100");
+    expect(result.model.launchDiscoverySnapshot?.blockNumber).toBe("111");
+    expect(result.model.tokens.map(({ tokenAddress }) => tokenAddress)).toEqual([
+      baseToken.tokenAddress,
+      newestToken.tokenAddress,
+    ]);
+    expect(result.model.tokens[1]).toMatchObject({
+      launchDiscoverySource: "alchemy-launch-overlay",
+    });
+    expect(result).toMatchObject({
+      baseBlockNumber: "100",
+      confirmedBlockNumber: "110",
+      servedBlockNumber: "111",
+      persisted: false,
+    });
+    expect(mocks.writeAlchemyLaunchRegistry).not.toHaveBeenCalled();
+  });
+
+  it("periodically persists cursor progress even when no token launched", async () => {
+    mocks.advanceExploreLaunchDiscovery.mockResolvedValue({
+      ...baseModel,
+      snapshot: snapshot("164"),
+    });
+
+    const result = await refreshAlchemyExploreRegistry({
+      includeLatest: false,
+    });
+
+    expect(result.registryChanged).toBe(true);
+    expect(mocks.writeAlchemyLaunchRegistry).toHaveBeenCalledWith(
+      deployment,
+      expect.objectContaining({
+        cursor: expect.objectContaining({ blockNumber: "164" }),
+        tokens: [],
+      }),
+      "registry-etag",
+    );
+  });
+
+  it("persists only confirmed overlay tokens and tags only the served copy", async () => {
+    mocks.advanceExploreLaunchDiscovery.mockResolvedValue({
+      ...baseModel,
+      tokens: [baseToken, newestToken],
+      snapshot: snapshot("110"),
+    });
+
+    const result = await refreshAlchemyExploreRegistry({
+      includeLatest: false,
+    });
+
+    const persisted = mocks.writeAlchemyLaunchRegistry.mock.calls[0]?.[1];
+    expect(persisted.tokens).toHaveLength(1);
+    expect(persisted.tokens[0]).not.toHaveProperty("launchDiscoverySource");
+    expect(result.model.tokens[1]).toMatchObject({
+      launchDiscoverySource: "alchemy-launch-overlay",
+    });
+  });
+
+  it("retries an ETag conflict once but does not retry an RPC failure", async () => {
+    mocks.advanceExploreLaunchDiscovery.mockResolvedValue({
+      ...baseModel,
+      snapshot: snapshot("164"),
+    });
+    const conflict = new Error("conflict");
+    conflict.name = "BlobPreconditionFailedError";
+    mocks.writeAlchemyLaunchRegistry
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce({ etag: "winner-etag" });
+
+    await refreshAlchemyExploreRegistry({
+      includeLatest: false,
+      requirePersistence: true,
+    });
+    expect(mocks.readAlchemyLaunchRegistry).toHaveBeenCalledTimes(2);
+
+    mocks.readDurableExploreModel.mockReset();
+    mocks.readDurableExploreModel.mockRejectedValue(new Error("RPC failed"));
+    await expect(
+      refreshAlchemyExploreRegistry({ includeLatest: false }),
+    ).rejects.toThrow("RPC failed");
+    expect(mocks.readDurableExploreModel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/alchemy-launch-registry.test.ts
+++ b/tests/alchemy-launch-registry.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { keccak256, toBytes } from "viem";
+
+vi.mock("server-only", () => ({}));
+
+const blobMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  put: vi.fn(),
+}));
+
+vi.mock("@vercel/blob", () => blobMocks);
+
+import {
+  validateAlchemyLaunchRegistryEnvelope,
+  writeAlchemyLaunchRegistry,
+  type AlchemyLaunchRegistry,
+} from "../lib/alchemy/launch-registry.server";
+import type { ReadyOnchainDeployment } from "../lib/onchain/types";
+import type { LauncherToken } from "../lib/tokens";
+
+const deployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: "0x1111111111111111111111111111111111111111",
+  feeHook: "0x2222222222222222222222222222222222222222",
+  launcherRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  deploymentBlock: 100n,
+  stateView: "0x3333333333333333333333333333333333333333",
+  stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/test-key-1234",
+  rpcUrlSecondary: null,
+  confirmations: 12n,
+  logBlockRange: 5_000n,
+} satisfies ReadyOnchainDeployment;
+
+function token(input: Readonly<{ address?: `0x${string}`; block?: string; log?: number }> = {}): LauncherToken {
+  const address = input.address ??
+    "0x4444444444444444444444444444444444444444";
+  return {
+    id: `1:${address.toLowerCase()}`,
+    name: "Newest",
+    symbol: "NEW",
+    tokenAddress: address,
+    hookAddress: "0x5555555555555555555555555555555555555555",
+    poolId: `0x${"66".repeat(32)}`,
+    launchBlockNumber: input.block ?? "120",
+    launchTransactionHash: `0x${"77".repeat(32)}`,
+    launchLogIndex: input.log ?? 4,
+    launchedAt: "2026-08-04T00:00:00.000Z",
+    totalSwapFeeBps: 100,
+    launchModel: "classic",
+    launchModelVersion: "classic-v3",
+    liquidityPath: "meme",
+  };
+}
+
+function envelope(tokens: readonly LauncherToken[] = [token()]) {
+  const payload: AlchemyLaunchRegistry = {
+    generatedAt: "2026-08-04T00:01:00.000Z",
+    repositoryCommit: "a".repeat(40),
+    chainId: 1,
+    cursor: {
+      blockNumber: "130",
+      blockHash: `0x${"88".repeat(32)}`,
+    },
+    tokens,
+  };
+  return {
+    schemaVersion: "programmable-alchemy-launch-registry-v1",
+    contentHash: keccak256(toBytes(JSON.stringify(payload))),
+    payload,
+  };
+}
+
+describe("Alchemy incremental launch registry", () => {
+  beforeEach(() => {
+    process.env.OPS_BLOB_READ_WRITE_TOKEN = "blob-test-token";
+    process.env.VERCEL_GIT_COMMIT_SHA = "a".repeat(40);
+    blobMocks.get.mockReset();
+    blobMocks.put.mockReset();
+    blobMocks.put.mockResolvedValue({ etag: "next-etag" });
+  });
+
+  afterEach(() => {
+    delete process.env.OPS_BLOB_READ_WRITE_TOKEN;
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+  });
+
+  it("accepts a content-addressed registry with exact launch provenance", () => {
+    expect(
+      validateAlchemyLaunchRegistryEnvelope(envelope(), deployment),
+    ).toMatchObject({
+      chainId: 1,
+      cursor: { blockNumber: "130" },
+      tokens: [{ name: "Newest", launchBlockNumber: "120" }],
+    });
+  });
+
+  it("rejects a token beyond the committed cursor", () => {
+    expect(() =>
+      validateAlchemyLaunchRegistryEnvelope(
+        envelope([token({ block: "131" })]),
+        deployment,
+      )
+    ).toThrow("invalid token");
+  });
+
+  it("rejects duplicate launch provenance", () => {
+    expect(() =>
+      validateAlchemyLaunchRegistryEnvelope(
+        envelope([
+          token(),
+          token({
+            address: "0x9999999999999999999999999999999999999999",
+          }),
+        ]),
+        deployment,
+      )
+    ).toThrow("duplicate provenance");
+  });
+
+  it("rejects payload mutation after the content commitment", () => {
+    const candidate = envelope();
+    candidate.payload.tokens[0]!.name = "Mutated";
+
+    expect(() =>
+      validateAlchemyLaunchRegistryEnvelope(candidate, deployment)
+    ).toThrow("content hash is invalid");
+  });
+
+  it("creates atomically, then updates only through an exact ETag", async () => {
+    const registry = envelope().payload;
+
+    await writeAlchemyLaunchRegistry(deployment, registry, null);
+    expect(blobMocks.put).toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        allowOverwrite: false,
+      }),
+    );
+    expect(blobMocks.put.mock.calls.at(-1)?.[2]).not.toHaveProperty("ifMatch");
+
+    await writeAlchemyLaunchRegistry(deployment, registry, "exact-etag");
+    expect(blobMocks.put).toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        allowOverwrite: true,
+        ifMatch: "exact-etag",
+      }),
+    );
+  });
+
+  it("reports a retryable conflict when another writer wins initial creation", async () => {
+    blobMocks.put.mockRejectedValueOnce(new Error("pathname already exists"));
+    blobMocks.get.mockResolvedValueOnce({ statusCode: 200 });
+
+    await expect(
+      writeAlchemyLaunchRegistry(deployment, envelope().payload, null),
+    ).rejects.toMatchObject({
+      name: "AlchemyLaunchRegistryCreateConflictError",
+    });
+  });
+});

--- a/tests/alchemy-webhook.test.ts
+++ b/tests/alchemy-webhook.test.ts
@@ -6,11 +6,17 @@ vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
   revalidateTag: vi.fn(),
+  refreshAlchemyExploreRegistry: vi.fn(),
 }));
 
 vi.mock("next/cache", () => ({
   revalidateTag: mocks.revalidateTag,
   unstable_cache: (callback: unknown) => callback,
+}));
+
+vi.mock("../lib/alchemy/explore.server", () => ({
+  ALCHEMY_EXPLORE_CACHE_TAG: "alchemy-explore-v1",
+  refreshAlchemyExploreRegistry: mocks.refreshAlchemyExploreRegistry,
 }));
 
 import { POST } from "../app/api/alchemy/webhook/route";
@@ -42,6 +48,9 @@ function request(
 describe("Alchemy webhook route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.refreshAlchemyExploreRegistry.mockResolvedValue({
+      persisted: true,
+    });
     vi.stubEnv("ALCHEMY_WEBHOOK_SIGNING_KEY", SIGNING_KEY);
   });
 
@@ -56,10 +65,26 @@ describe("Alchemy webhook route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(mocks.refreshAlchemyExploreRegistry).toHaveBeenCalledWith({
+      forcePersist: true,
+      includeLatest: false,
+      requirePersistence: true,
+    });
     expect(mocks.revalidateTag).toHaveBeenCalledWith(
       ALCHEMY_EXPLORE_CACHE_TAG,
-      "max",
+      { expire: 0 },
     );
+  });
+
+  it("returns a retryable error without invalidating cache when persistence fails", async () => {
+    mocks.refreshAlchemyExploreRegistry.mockRejectedValueOnce(
+      new Error("Blob write failed"),
+    );
+
+    const response = await POST(request('{"event":{"block":123}}'));
+
+    expect(response.status).toBe(503);
+    expect(mocks.revalidateTag).not.toHaveBeenCalled();
   });
 
   it("rejects a signature for a normalized body", async () => {

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -569,6 +569,7 @@ describe("read-model performance contract", () => {
     ).toEqual([
       "source-cache-exploreList",
       "source-cache-tokenDetail",
+      "source-cache-tokenList",
       "source-cache-publicIndexer",
     ]);
 
@@ -1290,7 +1291,7 @@ describe("read-model performance contract", () => {
         process.cwd(),
       );
     expect(alchemyResult.ok).toBe(true);
-    expect(alchemyResult.checks).toHaveLength(9);
+    expect(alchemyResult.checks).toHaveLength(15);
 
     const result = sourceContracts.evaluateReadModelSourceContracts(
       process.cwd(),
@@ -1299,6 +1300,7 @@ describe("read-model performance contract", () => {
     const disconnectedIndexedFailures = [
       "source-cache-exploreList",
       "source-cache-tokenDetail",
+      "source-cache-tokenList",
       "source-cache-publicIndexer",
     ];
     expect(

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -121,7 +121,7 @@ describe("Explore API Alchemy boundary", () => {
       "alchemy",
     );
     expect(response.headers.get("Cache-Control")).toBe(
-      "public, max-age=0, s-maxage=5, stale-while-revalidate=15",
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
   });
 

--- a/tests/indexer-feed.test.ts
+++ b/tests/indexer-feed.test.ts
@@ -70,6 +70,12 @@ const readyModel: ExploreReadModel = {
     blockHash: `0x${"66".repeat(32)}`,
     confirmations: 12,
   },
+  launchDiscoverySnapshot: {
+    chainId: 1,
+    blockNumber: "140",
+    blockHash: `0x${"77".repeat(32)}`,
+    confirmations: 0,
+  },
   creatorClaims: [],
   launcherFeesAccruedWei: "0",
   launcherFeesAccruedEth: "0",
@@ -80,12 +86,15 @@ beforeEach(() => {
 });
 
 function expectAlchemyRpcHeaders(response: Response) {
+  expect(response.headers.get("x-programmable-launch-source")).toBe(
+    "alchemy",
+  );
   expect(response.headers.get("x-programmable-read-source")).toBe("blob");
   expect(response.headers.get("x-programmable-rpc-provider")).toBe(
     "alchemy",
   );
   expect(response.headers.get("access-control-expose-headers")).toBe(
-    "X-Programmable-Read-Source, X-Programmable-Rpc-Provider",
+    "X-Programmable-Launch-Source, X-Programmable-Read-Source, X-Programmable-Rpc-Provider",
   );
 }
 
@@ -120,6 +129,7 @@ describe("public indexer fee disclosure", () => {
       status: "ready",
       chainId: 1,
       snapshot: readyModel.snapshot,
+      launchDiscoverySnapshot: readyModel.launchDiscoverySnapshot,
       tokens: [
         {
           address: token.tokenAddress,
@@ -137,6 +147,15 @@ describe("public indexer fee disclosure", () => {
         },
       ],
     });
+    const feed = buildIndexerFeed(readyModel, 1);
+    expect(
+      feed.tokens.every(
+        (candidate) =>
+          candidate.launch.blockNumber == null ||
+          BigInt(candidate.launch.blockNumber) <=
+            BigInt(feed.launchDiscoverySnapshot!.blockNumber),
+      ),
+    ).toBe(true);
   });
 
   it("publishes the complete verified Deep V2 launch provenance", () => {
@@ -536,7 +555,7 @@ describe("public indexer fee disclosure", () => {
 
     expect(response.status).toBe(503);
     expect(response.headers.get("cache-control")).toBe(
-      "public, max-age=0, s-maxage=60",
+      "public, max-age=0, s-maxage=5",
     );
     expect(response.headers.get("retry-after")).toBe("60");
     expectAlchemyRpcHeaders(response);

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -50,6 +50,11 @@ const snapshot = {
   blockHash: `0x${"55".repeat(32)}` as const,
   confirmations: 12,
 };
+const launchDiscoverySnapshot = {
+  ...snapshot,
+  blockNumber: "25630100",
+  blockHash: `0x${"66".repeat(32)}` as const,
+};
 
 describe("token detail Alchemy read", () => {
   beforeEach(() => {
@@ -65,6 +70,7 @@ describe("token detail Alchemy read", () => {
       status: "ready",
       tokens: [canonical, token(OTHER_TOKEN_ADDRESS)],
       snapshot,
+      launchDiscoverySnapshot,
       creatorClaims: [],
       launcherFeesAccruedWei: "0",
       launcherFeesAccruedEth: "0",
@@ -75,7 +81,6 @@ describe("token detail Alchemy read", () => {
         ...canonical,
         tokenPriceUsdWad: "1250000000000000000",
         fdvUsdWad: "1250000000000000000000000",
-        indexedMarketCapUsdWad: "1250000000000000000000000",
       },
     ]);
 
@@ -98,8 +103,8 @@ describe("token detail Alchemy read", () => {
       tokenAddress: canonical.tokenAddress,
       tokenPriceUsdWad: "1250000000000000000",
       fdvUsdWad: "1250000000000000000000000",
-      indexedMarketCapUsdWad: "1250000000000000000000000",
     });
+    expect(body.launchDiscoverySnapshot).toEqual(launchDiscoverySnapshot);
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
       "blob",
     );
@@ -109,8 +114,11 @@ describe("token detail Alchemy read", () => {
     expect(response.headers.get("X-Programmable-Price-Source")).toBe(
       "alchemy",
     );
+    expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
+      "alchemy",
+    );
     expect(response.headers.get("Cache-Control")).toBe(
-      "public, max-age=0, s-maxage=5, stale-while-revalidate=15",
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
   });
 
@@ -132,6 +140,7 @@ describe("token detail Alchemy read", () => {
       status: "ready",
       tokens: [],
       snapshot,
+      launchDiscoverySnapshot,
       creatorClaims: [],
       launcherFeesAccruedWei: "0",
       launcherFeesAccruedEth: "0",
@@ -144,6 +153,9 @@ describe("token detail Alchemy read", () => {
     );
 
     expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      launchDiscoverySnapshot,
+    });
     expect(mocks.enrichTokensWithAlchemyPrices).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changed

- add a commit-bound, CAS-protected Alchemy launch registry overlay
- incrementally discover Classic V2/V3 and Stock V1/V2/V3 launches every five seconds
- keep market-state snapshots separate from launch-discovery freshness
- expose launch provenance and add a staged known-launch canary

## Why

The durable Explore snapshot stopped at block 25671377, so newer launches were missing and stale tokens appeared under Newest. Cache invalidation alone could only reload that stale snapshot.

## Validation

- 207 Vitest files passed, 1 skipped; 1880 tests passed, 7 skipped
- Typecheck passed
- ESLint passed
- Next production build passed
- read-model smoke 15/15 passed
- read-model ops gate passed
- actionlint passed
- git diff --check passed
- two independent final audits found no P0/P1 blockers