### PR TITLE
Integrate developer API into docs

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     template: "%s · Programmable Docs",
   },
   description:
-    "How Programmable project markets launch, route fees and use Uniswap v4 on Ethereum.",
+    "Developer documentation for discovering and building with Programmable launches.",
 };
 
 export default function DocsLayout({ children }: { children: ReactNode }) {

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,304 +1,170 @@
 import type { Metadata } from "next";
 
-import { DocsAddress } from "@/components/docs-address";
+import {
+  DocsLaunchInspector,
+  DocsQuickstartCommand,
+} from "@/components/docs-code-preview";
 import { DocsExternalLink } from "@/components/docs-external-link";
 import { DocsShell } from "@/components/docs-shell";
 import styles from "@/components/docs-experience.module.css";
 
 export const metadata: Metadata = {
-  title: "Docs",
+  title: "Developers",
+  description:
+    "One public interface for terminals, scanners, wallets, indexers and apps building with Programmable launches.",
   alternates: { canonical: "/docs" },
 };
 
-const classicEvidenceCommit =
-  "1fb9558af4f0248de75d5c7983f80036e32f47cb";
-const classicLauncher =
-  "0xC3bd04aAc2fb2ba58efD7Eb673E544E0B80De770";
-const classicHook =
-  "0x35Fe236EA82F7cF525c9719d7df8F49F94D720CC";
-const classicRewardVaultFactory =
-  "0xF28967f9DFaC3Ca21384b59D6D75C8106b3eab2a";
-const positionLockFactory =
-  "0x291a9ff1059d225d02B1659430804486404dB507";
-
-const platformSections = [
+const developerSections = [
   { id: "overview", label: "Overview" },
-  { id: "launching", label: "Launch flow" },
-  { id: "trading", label: "Trading and pricing" },
-  { id: "rewards", label: "Creator rewards" },
-  { id: "network", label: "Network" },
-  { id: "contracts", label: "Contracts" },
-  { id: "metadata", label: "Token metadata" },
-  { id: "releases", label: "Release evidence" },
-  { id: "risks", label: "Risks" },
+  { id: "formats", label: "Launch formats" },
+  { id: "quickstart", label: "Quickstart" },
+  { id: "rules", label: "Integration rules" },
+  { id: "resources", label: "Resources" },
 ] as const;
 
 export default function DocsPage() {
   return (
     <DocsShell
       currentPath="/docs"
-      title="Docs"
-      description="Platform reference and launch-model documentation."
-      sections={platformSections}
+      title="Build with Programmable"
+      description="One public interface for every Programmable launch. Add launches to a terminal, scanner, wallet or app without a private integration."
+      sections={developerSections}
     >
       <section id="overview">
-        <h2>Platform</h2>
+        <h2>Start from one public interface</h2>
         <p className={styles.lead}>
-          Programmable launches fixed-supply ERC-20 tokens into Uniswap v4
-          pools on Ethereum. A launch model defines the pool structure, fee
-          path, reward rules and available controls before the wallet submits
-          the transaction.
+          The Developer API lets you discover Programmable launches, verify
+          where they came from and build with their available markets. It is
+          read-only, public and does not require an API key.
         </p>
+        <div className={styles.factGrid}>
+          <div className={styles.fact}>
+            <span>Trading terminals</span>
+            <strong>List Programmable launches from one feed</strong>
+          </div>
+          <div className={styles.fact}>
+            <span>New-pair scanners</span>
+            <strong>Show the original launch time and source</strong>
+          </div>
+          <div className={styles.fact}>
+            <span>Wallets and explorers</span>
+            <strong>Identify Classic and Custom launches consistently</strong>
+          </div>
+          <div className={styles.fact}>
+            <span>Apps and agents</span>
+            <strong>Build tools around each launch&apos;s capabilities</strong>
+          </div>
+        </div>
+      </section>
+
+      <section id="formats">
+        <h2>One record, every launch</h2>
         <p>
-          Set buy and sell fees in Classic, then route creator rewards to the
-          launch wallet, another wallet or a split of up to five wallets.
+          Public labels stay simple: <strong>Classic</strong> or{" "}
+          <strong>Custom</strong>. A Custom launch can use a Uniswap pool,
+          another contract market or no market at all. Read the record instead
+          of assuming every token works the same way.
         </p>
+        <DocsLaunchInspector />
         <div className={styles.callout}>
-          <strong>Classic is the active launch model.</strong>
+          <strong>The examples share the same stable envelope.</strong>
           <p>
-            Custom Hook opens its framework and release requirements. Launch
-            configuration activates only after matching contracts and release
-            evidence are published.
+            Current live records include Classic and existing first-party
+            Custom launches. Community Custom submissions remain prelaunch
+            until the public launch flow is activated.
           </p>
         </div>
       </section>
 
-      <section id="launching">
-        <h2>From setup to a confirmed transaction</h2>
+      <section id="quickstart">
+        <h2>Fetch the launch feed</h2>
+        <p>
+          Start with the well-known document, check the current status, then
+          ingest the launch feed. The manifest supplies current deployments so
+          your product does not need hardcoded launcher addresses.
+        </p>
         <ol className={styles.steps}>
           <li>
-            <strong>Choose a model</strong>
-            <span>
-              Check its release status, fee path and model-specific risks.
-            </span>
+            <strong>Discover the interface</strong>
+            <span>Read the well-known document and current manifest.</span>
           </li>
           <li>
-            <strong>Set the token and launch terms</strong>
-            <span>
-              Add the name, ticker, image, description, project links and the
-              settings available for that model.
-            </span>
+            <strong>Ingest every page</strong>
+            <span>Store the launch ID and continue with the supplied cursor.</span>
           </li>
           <li>
-            <strong>Review the prepared transaction</strong>
+            <strong>Enable only declared support</strong>
             <span>
-              Programmable checks the configured release and validates the
-              prepared call before opening the wallet.
-            </span>
-          </li>
-          <li>
-            <strong>Confirm in the wallet</strong>
-            <span>
-              The connected wallet submits the transaction and pays Ethereum
-              gas. A confirmed receipt becomes the launch record.
+              Show charts, quotes or actions only when the market record says
+              they are available.
             </span>
           </li>
         </ol>
-        <div className={styles.callout}>
-          <strong>There is no separate Programmable launch charge.</strong>
-          <p>
-            The launch wallet pays network gas and the Initial Buy required by
-            the selected model.
-          </p>
-        </div>
+        <DocsQuickstartCommand />
       </section>
 
-      <section id="trading">
-        <h2>The recorded pool is the source of truth</h2>
-        <p>
-          Explore and token pages read the pool recorded by the verified launch
-          event. Market cap is an estimate based on confirmed pool price and
-          fixed token supply. It is not a promise that the full supply can be
-          sold at that price.
-        </p>
-        <div className={styles.factGrid}>
-          <div className={styles.fact}>
-            <span>Quotes</span>
-            <strong>Prepared against the recorded Uniswap v4 pool</strong>
-          </div>
-          <div className={styles.fact}>
-            <span>Market cap</span>
-            <strong>Confirmed pool price multiplied by fixed supply</strong>
-          </div>
-          <div className={styles.fact}>
-            <span>Price impact</span>
-            <strong>Changes with live liquidity and trade size</strong>
-          </div>
-          <div className={styles.fact}>
-            <span>External routes</span>
-            <strong>May not support the pool or its hook correctly</strong>
-          </div>
-        </div>
+      <section id="rules">
+        <h2>Four rules keep integrations future-proof</h2>
+        <ol className={styles.steps}>
+          <li>
+            <strong>Use only Classic and Custom as public categories</strong>
+            <span>Market design belongs in the record, not in new labels.</span>
+          </li>
+          <li>
+            <strong>Keep launches visible when no market exists</strong>
+            <span>No pool is a valid state, not a broken token.</span>
+          </li>
+          <li>
+            <strong>Read support before showing an action</strong>
+            <span>Discovery does not automatically authorize trading.</span>
+          </li>
+          <li>
+            <strong>Follow the manifest instead of contract addresses</strong>
+            <span>Compatible future deployments then arrive without a rebuild.</span>
+          </li>
+        </ol>
       </section>
 
-      <section id="rewards">
-        <h2>Rewards follow the launch terms</h2>
+      <section id="resources">
+        <h2>Use the full reference when you need it</h2>
         <p>
-          Classic rewards accrue in ETH. A launch can assign them to the launch
-          wallet, another wallet or a recorded split of up to five wallets. Each
-          current payout wallet claims only its own allocation and can move
-          future rewards for that allocation to a new address.
-        </p>
-        <p>
-          Moving an allocation to a new payout address does not change its
-          percentage. The disclosed CTO authority can replace future recipients
-          and split percentages after checkpointing rewards already accrued
-          under the current configuration.
-        </p>
-        <div className={styles.callout}>
-          <strong>Claiming cannot change the launch economics.</strong>
-          <p>
-            A claim pays only the caller&apos;s recorded entitlement. It cannot
-            alter fee rates, reward percentages or liquidity custody.
-          </p>
-        </div>
-      </section>
-
-      <section id="network">
-        <h2>Ethereum Mainnet</h2>
-        <p>
-          Public launches use Ethereum Mainnet and the official Uniswap v4
-          PoolManager, PositionManager, StateView, Quoter and Universal Router
-          deployments. The wallet must be connected to Ethereum before it can
-          submit a launch or trade.
-        </p>
-        <div className={styles.factGrid}>
-          <div className={styles.fact}>
-            <span>Chain ID</span>
-            <strong>1</strong>
-          </div>
-          <div className={styles.fact}>
-            <span>Gas asset</span>
-            <strong>ETH</strong>
-          </div>
-        </div>
-      </section>
-
-      <section id="contracts">
-        <h2>Active Classic deployment</h2>
-        <p>
-          These are the primary contracts behind the public Classic launcher.
-          The release manifest records the complete deployment, runtime hashes
-          and lifecycle evidence.
-        </p>
-        <div className={styles.tableWrap}>
-          <table className={styles.table}>
-            <thead>
-              <tr>
-                <th>Contract</th>
-                <th>Address</th>
-                <th>Purpose</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Classic launcher</td>
-                <td>
-                  <DocsAddress
-                    address={classicLauncher}
-                    label="Classic launcher"
-                  />
-                </td>
-                <td>Creates the token, pool and launch records.</td>
-              </tr>
-              <tr>
-                <td>Classic fee hook</td>
-                <td>
-                  <DocsAddress address={classicHook} label="Classic fee hook" />
-                </td>
-                <td>Applies the immutable buy and sell fee settings.</td>
-              </tr>
-              <tr>
-                <td>Reward vault factory</td>
-                <td>
-                  <DocsAddress
-                    address={classicRewardVaultFactory}
-                    label="Reward vault factory"
-                  />
-                </td>
-                <td>Creates the reward vault for each Classic pool.</td>
-              </tr>
-              <tr>
-                <td>Position recipient factory</td>
-                <td>
-                  <DocsAddress
-                    address={positionLockFactory}
-                    label="Position recipient factory"
-                  />
-                </td>
-                <td>Permanently holds the launch position.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      <section id="metadata">
-        <h2>Project details are public</h2>
-        <p>
-          Token metadata can include a description, image, website, X link and
-          Telegram link. Programmable uses those values on Explore and token
-          pages. External terminals control their own indexing, moderation and
-          refresh timing, so display there is not guaranteed.
-        </p>
-      </section>
-
-      <section id="releases">
-        <h2>Source and deployment must match</h2>
-        <p>
-          A model reaches the public launcher only when its deployment record,
-          runtime code and required lifecycle evidence match the application
-          release. Local tests and design documents do not make a model live.
+          The public repository contains the OpenAPI document, JSON Schemas,
+          complete examples and longer guides. This page stays intentionally
+          short.
         </p>
         <div className={styles.sourceLinks}>
           <DocsExternalLink
-            href="https://github.com/0xprogrammable/programmable"
+            href="https://developers.programmable.family/.well-known/programmable.json"
             variant="chip"
           >
-            Source repository
+            Discovery document
           </DocsExternalLink>
           <DocsExternalLink
-            href={`https://github.com/0xprogrammable/programmable/blob/${classicEvidenceCommit}/contracts/deployments/mainnet-classic-v3.json`}
+            href="https://developers.programmable.family/openapi/programmable-v1.yaml"
             variant="chip"
           >
-            Classic release record
+            OpenAPI
           </DocsExternalLink>
           <DocsExternalLink
-            href={`https://github.com/0xprogrammable/programmable/blob/${classicEvidenceCommit}/contracts/security/CLASSIC-V3.md`}
+            href="https://developers.programmable.family/schemas/v1/launch.schema.json"
             variant="chip"
           >
-            Classic security notes
+            Launch schema
           </DocsExternalLink>
           <DocsExternalLink
-            href="https://docs.uniswap.org/contracts/v4/overview"
+            href="https://developers.programmable.family/api/v1/status"
             variant="chip"
           >
-            Uniswap v4 documentation
+            Live status
+          </DocsExternalLink>
+          <DocsExternalLink
+            href="https://github.com/0xprogrammable/developers"
+            variant="chip"
+          >
+            Developer repository
           </DocsExternalLink>
         </div>
-      </section>
-
-      <section id="risks">
-        <h2>What Programmable cannot guarantee</h2>
-        <ul className={styles.contentList}>
-          <li>
-            A transaction can fail, be irreversible or cost more when network
-            conditions change.
-          </li>
-          <li>
-            Fixed supply and locked launch liquidity do not guarantee demand,
-            price stability or deep liquidity.
-          </li>
-          <li>Tokens can be volatile, illiquid or lose all value.</li>
-          <li>
-            Third-party wallets, scanners and trading terminals make their own
-            routing and display decisions.
-          </li>
-          <li>
-            Source verification and lifecycle tests are not an independent
-            audit or a guarantee that no vulnerability exists.
-          </li>
-        </ul>
       </section>
     </DocsShell>
   );

--- a/components/docs-code-preview.tsx
+++ b/components/docs-code-preview.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { Check, CircleAlert, Copy } from "lucide-react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+
+import styles from "@/components/docs-experience.module.css";
+
+type CopyState = "idle" | "copied" | "error";
+
+type LaunchSample = {
+  id: string;
+  label: string;
+  caption: string;
+  record: Record<string, unknown>;
+};
+
+const sampleToken = "0x1111111111111111111111111111111111111111";
+
+export const docsLaunchSamples: readonly LaunchSample[] = [
+  {
+    id: "classic",
+    label: "Classic",
+    caption: "Classic · live pool",
+    record: {
+      launchId: `eip155:1:${sampleToken}`,
+      category: "classic",
+      token: { address: sampleToken, symbol: "EXAMPLE" },
+      launch: { status: "live", finality: "finalized" },
+      markets: [{ kind: "uniswap-v4", status: "active" }],
+    },
+  },
+  {
+    id: "custom-pool",
+    label: "Custom pool",
+    caption: "Custom · planned pool",
+    record: {
+      launchId: `eip155:1:${sampleToken}`,
+      category: "custom",
+      token: { address: sampleToken, symbol: "EXAMPLE" },
+      launch: { status: "prelaunch", finality: null },
+      markets: [{ kind: "uniswap-v4", status: "planned" }],
+    },
+  },
+  {
+    id: "no-pool",
+    label: "No pool",
+    caption: "Custom · no registered market",
+    record: {
+      launchId: `eip155:1:${sampleToken}`,
+      category: "custom",
+      token: { address: sampleToken, symbol: "EXAMPLE" },
+      launch: { status: "prelaunch", finality: null },
+      markets: [],
+    },
+  },
+  {
+    id: "contract-market",
+    label: "Contract market",
+    caption: "Custom · contract-defined market",
+    record: {
+      launchId: `eip155:1:${sampleToken}`,
+      category: "custom",
+      token: { address: sampleToken, symbol: "EXAMPLE" },
+      launch: { status: "prelaunch", finality: null },
+      markets: [{ kind: "contract-market", status: "planned" }],
+    },
+  },
+] as const;
+
+export function getNextDocsSampleIndex(
+  currentIndex: number,
+  key: string,
+  sampleCount = docsLaunchSamples.length,
+): number {
+  if (sampleCount <= 0) return -1;
+  if (key === "Home") return 0;
+  if (key === "End") return sampleCount - 1;
+  if (key === "ArrowRight" || key === "ArrowDown") {
+    return (currentIndex + 1) % sampleCount;
+  }
+  if (key === "ArrowLeft" || key === "ArrowUp") {
+    return (currentIndex - 1 + sampleCount) % sampleCount;
+  }
+  return currentIndex;
+}
+
+export function getDocsCopyStatus(label: string, state: CopyState): string {
+  if (state === "copied") return `${label} copied`;
+  if (state === "error") return `Could not copy ${label}`;
+  return "";
+}
+
+function CopyButton({ label, text }: { label: string; text: string }) {
+  const [state, setState] = useState<CopyState>("idle");
+  const resetTimerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  async function copyText() {
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+    }
+
+    try {
+      await navigator.clipboard.writeText(text);
+      setState("copied");
+      resetTimerRef.current = window.setTimeout(() => setState("idle"), 1600);
+    } catch {
+      setState("error");
+      resetTimerRef.current = window.setTimeout(() => setState("idle"), 2400);
+    }
+
+  }
+
+  return (
+    <>
+      <button
+        aria-label={`Copy ${label}`}
+        className={styles.codeCopyButton}
+        data-state={state}
+        onClick={copyText}
+        type="button"
+      >
+        <span className={styles.codeCopyIcons} aria-hidden="true">
+          <Copy className={styles.codeCopyIdleIcon} strokeWidth={1.8} />
+          <Check className={styles.codeCopySuccessIcon} strokeWidth={2} />
+          <CircleAlert
+            className={styles.codeCopyErrorIcon}
+            strokeWidth={1.8}
+          />
+        </span>
+        <span>{state === "copied" ? "Copied" : state === "error" ? "Retry" : "Copy"}</span>
+      </button>
+      <span className="sr-only" role="status" aria-live="polite">
+        {getDocsCopyStatus(label, state)}
+      </span>
+    </>
+  );
+}
+
+export function DocsLaunchInspector() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const activeSample = docsLaunchSamples[activeIndex];
+  const code = JSON.stringify(activeSample.record, null, 2);
+
+  function moveToTab(index: number) {
+    setActiveIndex(index);
+    window.requestAnimationFrame(() => tabRefs.current[index]?.focus());
+  }
+
+  function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    const nextIndex = getNextDocsSampleIndex(activeIndex, event.key);
+    if (nextIndex === activeIndex) return;
+    event.preventDefault();
+    moveToTab(nextIndex);
+  }
+
+  return (
+    <div className={styles.launchInspector}>
+      <div className={styles.inspectorHeader}>
+        <div>
+          <span>Normalized record preview</span>
+          <strong>Same envelope, different markets</strong>
+        </div>
+        <span className={styles.sampleBadge}>Simulated</span>
+      </div>
+
+      <div
+        className={styles.sampleTabs}
+        role="tablist"
+        aria-label="Launch record examples"
+      >
+        {docsLaunchSamples.map((sample, index) => {
+          const isActive = index === activeIndex;
+          return (
+            <button
+              aria-controls="docs-launch-sample-panel"
+              aria-selected={isActive}
+              className={styles.sampleTab}
+              id={`docs-launch-sample-tab-${sample.id}`}
+              key={sample.id}
+              onClick={() => setActiveIndex(index)}
+              onKeyDown={handleTabKeyDown}
+              ref={(element) => {
+                tabRefs.current[index] = element;
+              }}
+              role="tab"
+              tabIndex={isActive ? 0 : -1}
+              type="button"
+            >
+              {sample.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        aria-labelledby={`docs-launch-sample-tab-${activeSample.id}`}
+        className={styles.codeWindow}
+        id="docs-launch-sample-panel"
+        role="tabpanel"
+        tabIndex={0}
+      >
+        <div className={styles.codeWindowBar}>
+          <span>{activeSample.caption}</span>
+          <CopyButton label={`${activeSample.label} example`} text={code} />
+        </div>
+        <pre className={styles.codePre}>
+          <code>{code}</code>
+        </pre>
+      </div>
+      <p className={styles.codeNote}>
+        Preview only. Use the complete schema and fixtures for validation.
+      </p>
+    </div>
+  );
+}
+
+const quickstartCommand =
+  "curl -fsSL https://developers.programmable.family/api/v1/launches";
+
+export function DocsQuickstartCommand() {
+  return (
+    <div className={styles.commandPanel}>
+      <div className={styles.codeWindowBar}>
+        <span className={styles.commandMethod}>GET</span>
+        <span>/api/v1/launches</span>
+        <CopyButton label="launch feed command" text={quickstartCommand} />
+      </div>
+      <pre className={styles.commandPre}>
+        <code>{quickstartCommand}</code>
+      </pre>
+    </div>
+  );
+}

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -6,89 +6,56 @@ export type DocsSearchItem = {
 
 export const docsNavigation = [
   {
-    label: "Platform",
+    label: "Developers",
     items: [
       { href: "/docs#overview", label: "Overview" },
-      { href: "/docs#launching", label: "Launch flow" },
-      { href: "/docs#trading", label: "Trading and pricing" },
-      { href: "/docs#rewards", label: "Creator rewards" },
-    ],
-  },
-  {
-    label: "Launch models",
-    items: [
-      { href: "/docs/models/classic", label: "Classic" },
-      { href: "/docs/models/custom", label: "Custom Hook" },
-    ],
-  },
-  {
-    label: "Verify",
-    items: [
-      { href: "/docs#network", label: "Network" },
-      { href: "/docs#contracts", label: "Contracts" },
-      { href: "/docs#metadata", label: "Token metadata" },
-      { href: "/docs#releases", label: "Release evidence" },
-      { href: "/docs#risks", label: "Risks" },
+      { href: "/docs#formats", label: "Launch formats" },
+      { href: "/docs#quickstart", label: "Quickstart" },
+      { href: "/docs#rules", label: "Integration rules" },
+      { href: "/docs#resources", label: "Resources" },
     ],
   },
 ] as const;
 
 export const docsSearchItems: DocsSearchItem[] = [
   {
-    title: "Overview",
-    description: "What Programmable launches and what a launch model controls.",
+    title: "Developer API overview",
+    description:
+      "One public interface for terminals, scanners, wallets and apps.",
     href: "/docs#overview",
   },
   {
-    title: "Launch flow",
-    description: "From model selection to a confirmed wallet transaction.",
-    href: "/docs#launching",
-  },
-  {
-    title: "Trading and pricing",
-    description: "Canonical pools, quotes, market cap and routing.",
-    href: "/docs#trading",
-  },
-  {
-    title: "Creator rewards",
-    description: "How model-specific rewards accrue and are claimed.",
-    href: "/docs#rewards",
-  },
-  {
-    title: "Classic",
+    title: "Launch formats",
     description:
-      "Directional swap fees, ETH creator rewards and Initial Buy custody.",
-    href: "/docs/models/classic",
+      "Classic, Custom pool, no-pool and contract-market records.",
+    href: "/docs#formats",
   },
   {
-    title: "Custom Hook",
+    title: "Quickstart",
+    description: "Discover the interface and fetch the launch feed.",
+    href: "/docs#quickstart",
+  },
+  {
+    title: "Trading terminals and scanners",
     description:
-      "Product boundary and release requirements for custom launches.",
-    href: "/docs/models/custom",
+      "List new Programmable launches and preserve their original provenance.",
+    href: "/docs#overview",
   },
   {
-    title: "Network",
-    description: "Ethereum Mainnet and the canonical Uniswap v4 dependencies.",
-    href: "/docs#network",
+    title: "Apps and agents",
+    description:
+      "Build games, dashboards and tools around declared capabilities.",
+    href: "/docs#overview",
   },
   {
-    title: "Contracts",
-    description: "Public deployment records and contract addresses.",
-    href: "/docs#contracts",
+    title: "Integration rules",
+    description:
+      "Categories, market support, no-pool launches and deployment discovery.",
+    href: "/docs#rules",
   },
   {
-    title: "Token metadata",
-    description: "Names, tickers, images, descriptions and project links.",
-    href: "/docs#metadata",
-  },
-  {
-    title: "Release evidence",
-    description: "How source, runtime and lifecycle evidence reach the app.",
-    href: "/docs#releases",
-  },
-  {
-    title: "Risks",
-    description: "Transaction, token, liquidity and integration boundaries.",
-    href: "/docs#risks",
+    title: "OpenAPI and schemas",
+    description: "Machine-readable contracts and complete integration examples.",
+    href: "/docs#resources",
   },
 ];

--- a/components/docs-experience.module.css
+++ b/components/docs-experience.module.css
@@ -27,10 +27,9 @@
 
 .heroTools {
   align-items: center;
-  display: grid;
-  gap: 12px;
-  grid-template-columns: 340px minmax(260px, 1fr);
+  display: flex;
   isolation: isolate;
+  justify-content: flex-end;
   position: sticky;
   top: calc(var(--header-height) + 12px);
   width: 100%;
@@ -51,51 +50,6 @@
   z-index: -1;
 }
 
-.guideTabs {
-  align-items: center;
-  -webkit-backdrop-filter: var(--control-glass-backdrop);
-  backdrop-filter: var(--control-glass-backdrop);
-  background: var(--control-glass-background);
-  border: 1px solid var(--control-glass-border);
-  border-radius: 18px;
-  box-shadow:
-    inset 0 1px 0 var(--control-glass-highlight),
-    0 12px 32px var(--control-glass-shadow-color);
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  padding: 4px;
-  width: 340px;
-}
-
-.guideTab {
-  align-items: center;
-  border: 1px solid transparent;
-  border-radius: 13px;
-  color: var(--muted);
-  display: inline-flex;
-  font-size: 13px;
-  font-weight: 620;
-  justify-content: center;
-  min-height: 42px;
-  padding-inline: 10px;
-  transition:
-    background-color 150ms var(--ease-out),
-    border-color 150ms var(--ease-out),
-    box-shadow 150ms var(--ease-out),
-    color 150ms var(--ease-out);
-  white-space: nowrap;
-}
-
-.guideTab[data-active="true"] {
-  background: color-mix(in srgb, var(--glass-98) 95%, transparent);
-  border-color: var(--panel-border-soft);
-  box-shadow:
-    inset 0 1px 0 var(--control-glass-highlight),
-    0 3px 10px var(--control-glass-shadow-color);
-  color: var(--text);
-}
-
-.guideTab:focus-visible,
 .navGroup a:focus-visible,
 .mobileNav summary:focus-visible {
   outline: 2px solid var(--focus);
@@ -122,6 +76,7 @@
     background-color 150ms var(--ease-out),
     border-color 150ms var(--ease-out),
     box-shadow 150ms var(--ease-out);
+  width: min(100%, 420px);
   z-index: 30;
 }
 
@@ -425,6 +380,229 @@
 .callout p {
   font-size: 15px;
   line-height: 1.58;
+}
+
+.launchInspector {
+  background: color-mix(in srgb, var(--glass-90) 92%, transparent);
+  border: 1px solid var(--panel-border-soft);
+  border-radius: 20px;
+  box-shadow:
+    inset 0 1px 0 var(--control-glass-highlight),
+    0 22px 54px var(--card-shadow-soft);
+  margin-top: 30px;
+  overflow: hidden;
+}
+
+.inspectorHeader {
+  align-items: center;
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+  padding: 18px 20px 15px;
+}
+
+.inspectorHeader > div {
+  display: grid;
+  gap: 4px;
+}
+
+.inspectorHeader > div > span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.085em;
+  text-transform: uppercase;
+}
+
+.inspectorHeader strong {
+  font-size: 16px;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.sampleBadge {
+  border: 1px solid var(--panel-border-soft);
+  border-radius: 999px;
+  color: var(--muted);
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 680;
+  padding: 5px 9px;
+}
+
+.sampleTabs {
+  border-block: 1px solid var(--panel-border-soft);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  padding: 4px;
+}
+
+.sampleTab {
+  background: transparent;
+  border: 0;
+  border-radius: 11px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 620;
+  min-height: 44px;
+  padding-inline: 8px;
+  transition:
+    background-color 140ms var(--ease-out),
+    color 140ms var(--ease-out);
+}
+
+.sampleTab[aria-selected="true"] {
+  background: var(--surface-soft);
+  color: var(--text);
+}
+
+.sampleTab:focus-visible,
+.codeWindow:focus-visible,
+.codeCopyButton:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
+.codeWindow {
+  min-width: 0;
+}
+
+.codeWindowBar {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  gap: 9px;
+  justify-content: space-between;
+  min-height: 50px;
+  padding: 7px 10px 7px 18px;
+}
+
+.codePre,
+.commandPre {
+  background: color-mix(in srgb, var(--body-background) 82%, var(--surface));
+  border-top: 1px solid var(--panel-border-soft);
+  color: var(--text-soft);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  line-height: 1.62;
+  margin: 0;
+  overflow-x: auto;
+  padding: 20px;
+  scrollbar-gutter: stable;
+  tab-size: 2;
+}
+
+.codePre {
+  min-height: 282px;
+}
+
+.codeCopyButton {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 10px;
+  color: var(--text-soft);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  gap: 7px;
+  min-height: 44px;
+  padding-inline: 10px;
+  transition:
+    background-color 140ms var(--ease-out),
+    color 140ms var(--ease-out),
+    transform 140ms var(--ease-out);
+}
+
+.codeCopyButton[data-state="copied"] {
+  color: var(--success);
+}
+
+.codeCopyButton[data-state="error"] {
+  color: var(--danger);
+}
+
+.codeCopyIcons {
+  display: grid;
+  height: 15px;
+  place-items: center;
+  position: relative;
+  width: 15px;
+}
+
+.codeCopyIcons svg {
+  grid-area: 1 / 1;
+  height: 15px;
+  transition:
+    filter 150ms ease,
+    opacity 150ms var(--ease-out),
+    transform 150ms var(--ease-out);
+  width: 15px;
+}
+
+.codeCopyIdleIcon {
+  filter: blur(0);
+  opacity: 1;
+  transform: scale(1);
+}
+
+.codeCopySuccessIcon,
+.codeCopyErrorIcon {
+  filter: blur(2px);
+  opacity: 0;
+  transform: scale(0.88);
+}
+
+.codeCopyButton[data-state="copied"] .codeCopyIdleIcon,
+.codeCopyButton[data-state="error"] .codeCopyIdleIcon {
+  filter: blur(2px);
+  opacity: 0;
+  transform: scale(0.88);
+}
+
+.codeCopyButton[data-state="copied"] .codeCopySuccessIcon,
+.codeCopyButton[data-state="error"] .codeCopyErrorIcon {
+  filter: blur(0);
+  opacity: 1;
+  transform: scale(1);
+}
+
+.codeNote {
+  border-top: 1px solid var(--panel-border-soft);
+  font-size: 12px !important;
+  line-height: 1.5 !important;
+  max-width: none !important;
+  padding: 11px 18px 13px;
+}
+
+.commandPanel {
+  background: color-mix(in srgb, var(--glass-90) 92%, transparent);
+  border: 1px solid var(--panel-border-soft);
+  border-radius: 16px;
+  box-shadow: inset 0 1px 0 var(--control-glass-highlight);
+  margin-top: 28px;
+  overflow: hidden;
+}
+
+.commandMethod {
+  background: var(--accent-soft);
+  border-radius: 7px;
+  color: var(--accent-strong);
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.06em;
+  padding: 4px 6px;
+}
+
+.commandPre {
+  min-height: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .steps {
@@ -793,7 +971,6 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .guideTab:not([data-active="true"]):hover,
   .searchResults a:hover,
   .navGroup a:hover {
     background: var(--surface-soft);
@@ -841,6 +1018,16 @@
     box-shadow:
       inset 0 1px 0 var(--control-glass-highlight),
       0 3px 10px var(--card-shadow-soft);
+  }
+
+  .sampleTab:not([aria-selected="true"]):hover,
+  .codeCopyButton:hover {
+    background: var(--surface-soft);
+    color: var(--text);
+  }
+
+  .codeCopyButton:active {
+    transform: scale(0.96);
   }
 }
 
@@ -980,15 +1167,10 @@
 
   .heroTools {
     gap: 10px;
-    grid-template-columns: minmax(0, 1fr);
   }
 
-  .guideTabs {
+  .search {
     width: 100%;
-  }
-
-  .guideTab {
-    padding-inline: 5px;
   }
 
   .search input {
@@ -1043,6 +1225,14 @@
 
   .steps {
     gap: 21px;
+  }
+
+  .sampleTabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .codePre {
+    min-height: 0;
   }
 
   .tableWrap {
@@ -1114,11 +1304,26 @@
 }
 
 @media (max-width: 430px) {
-  .guideTab {
-    font-size: 12.5px;
+  .callout {
+    padding: 16px;
   }
 
-  .callout {
+  .inspectorHeader {
+    align-items: flex-start;
+    padding: 16px;
+  }
+
+  .sampleBadge {
+    display: none;
+  }
+
+  .codeWindowBar {
+    padding-inline-start: 16px;
+  }
+
+  .codePre,
+  .commandPre {
+    font-size: 12px;
     padding: 16px;
   }
 
@@ -1143,9 +1348,11 @@
   .chapterIndicator,
   .externalLinkChip,
   .externalLinkIcon,
-  .guideTab,
+  .codeCopyButton,
+  .codeCopyIcons svg,
   .mobileNav summary svg,
   .navGroup a,
+  .sampleTab,
   .search,
   .searchResults a {
     transition: none;
@@ -1163,9 +1370,11 @@
 
 @media (forced-colors: active) {
   .addressCopyButton:focus-visible .addressCopyIcons,
-  .guideTab:focus-visible,
+  .codeCopyButton:focus-visible,
+  .codeWindow:focus-visible,
   .mobileNav summary:focus-visible,
-  .navGroup a:focus-visible {
+  .navGroup a:focus-visible,
+  .sampleTab:focus-visible {
     outline-color: Highlight;
   }
 }

--- a/components/docs-shell.tsx
+++ b/components/docs-shell.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { ReactNode } from "react";
 
 import styles from "@/components/docs-experience.module.css";
@@ -7,12 +6,6 @@ import {
   type DocsPageSection,
 } from "@/components/docs-navigation";
 import { DocsSearch } from "@/components/docs-search";
-
-const docsGuides = [
-  { href: "/docs", label: "Platform" },
-  { href: "/docs/models/classic", label: "Classic" },
-  { href: "/docs/models/custom", label: "Custom Hook" },
-] as const;
 
 export function DocsShell({
   children,
@@ -36,22 +29,6 @@ export function DocsShell({
 
       <div className={styles.mainColumn}>
         <div className={styles.heroTools} data-docs-tools>
-          <nav className={styles.guideTabs} aria-label="Documentation guides">
-            {docsGuides.map((guide) => {
-              const isActive = currentPath === guide.href;
-              return (
-                <Link
-                  key={guide.href}
-                  className={styles.guideTab}
-                  data-active={isActive ? "true" : undefined}
-                  aria-current={isActive ? "page" : undefined}
-                  href={guide.href}
-                >
-                  {guide.label}
-                </Link>
-              );
-            })}
-          </nav>
           <DocsSearch />
         </div>
 

--- a/tests/docs-classic-release.test.ts
+++ b/tests/docs-classic-release.test.ts
@@ -19,24 +19,23 @@ const legacyLauncher = "0xD240D06f8586eB799f20056054e5b527405E6bAd";
 const legacyFeeHook = "0x025a386eAa79f6067d29848FD05ccC71bEAb20CC";
 
 describe("Classic docs release binding", () => {
-  it("binds both public docs routes to the active Classic V3 contracts", () => {
+  it("keeps the hidden Classic reference bound to the active V3 contracts", () => {
     expect(classicRelease.status).toBe(
       "deployment-source-and-lifecycle-verified",
     );
     expect(classicRelease.lifecycleEvidence.releaseEligible).toBe(true);
 
-    for (const source of [docsOverview, classicDocs]) {
-      expect(source).toContain(currentLauncher);
-      expect(source).toContain(currentFeeHook);
-      expect(source).not.toContain(legacyLauncher);
-      expect(source).not.toContain(legacyFeeHook);
-      expect(source).not.toContain("mainnet-classic-v2.json");
-    }
+    expect(classicDocs).toContain(currentLauncher);
+    expect(classicDocs).toContain(currentFeeHook);
+    expect(classicDocs).not.toContain(legacyLauncher);
+    expect(classicDocs).not.toContain(legacyFeeHook);
+    expect(classicDocs).not.toContain("mainnet-classic-v2.json");
   });
 
-  it("documents configurable directional fees instead of the retired fixed-fee terms", () => {
-    expect(docsOverview).toContain("Set buy and sell fees");
-    expect(docsOverview).toContain("up to five wallets");
+  it("keeps launch-model details out of the developer overview", () => {
+    expect(docsOverview).not.toContain(currentLauncher);
+    expect(docsOverview).not.toContain(currentFeeHook);
+    expect(docsOverview).not.toContain("Set buy and sell fees");
     expect(classicDocs).toContain("Set separately from 1% to 10%");
     expect(classicDocs).toContain(
       "The 0.10% Programmable share is included.",

--- a/tests/docs-code-preview.test.ts
+++ b/tests/docs-code-preview.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  docsLaunchSamples,
+  getDocsCopyStatus,
+  getNextDocsSampleIndex,
+} from "../components/docs-code-preview";
+
+describe("Developer docs code previews", () => {
+  it("shows one Classic record and three structurally different Custom records", () => {
+    expect(docsLaunchSamples.map((sample) => sample.label)).toEqual([
+      "Classic",
+      "Custom pool",
+      "No pool",
+      "Contract market",
+    ]);
+    expect(docsLaunchSamples[0]?.record.category).toBe("classic");
+    expect(
+      docsLaunchSamples
+        .slice(1)
+        .every((sample) => sample.record.category === "custom"),
+    ).toBe(true);
+    expect(docsLaunchSamples[2]?.record.markets).toEqual([]);
+  });
+
+  it("supports the expected keyboard loop for tabs", () => {
+    expect(getNextDocsSampleIndex(0, "ArrowRight")).toBe(1);
+    expect(getNextDocsSampleIndex(3, "ArrowRight")).toBe(0);
+    expect(getNextDocsSampleIndex(0, "ArrowLeft")).toBe(3);
+    expect(getNextDocsSampleIndex(2, "Home")).toBe(0);
+    expect(getNextDocsSampleIndex(1, "End")).toBe(3);
+  });
+
+  it("announces copy success and failure without an idle message", () => {
+    expect(getDocsCopyStatus("example", "idle")).toBe("");
+    expect(getDocsCopyStatus("example", "copied")).toBe("example copied");
+    expect(getDocsCopyStatus("example", "error")).toBe(
+      "Could not copy example",
+    );
+  });
+});

--- a/tests/docs-layout-stability.test.ts
+++ b/tests/docs-layout-stability.test.ts
@@ -68,8 +68,11 @@ describe("Docs rail layout stability", () => {
     );
   });
 
-  it("uses the same current-page chapter rail for every guide", () => {
-    expect(docsPage).toContain("sections={platformSections}");
+  it("uses one concise developer guide with a current-page chapter rail", () => {
+    expect(docsPage).toContain("sections={developerSections}");
+    expect(docsPage).toContain("<DocsLaunchInspector />");
+    expect(docsShell).not.toContain("docsGuides");
+    expect(docsShell).not.toContain("Documentation guides");
     expect(docsNavigation).toContain(
       '<p className={styles.navLabel}>On this page</p>',
     );

--- a/tests/docs-navigation.test.ts
+++ b/tests/docs-navigation.test.ts
@@ -24,19 +24,19 @@ describe("Docs navigation state", () => {
   });
 
   it("uses the URL hash instead of keeping Overview active", () => {
-    expect(normalizeDocsHash("#rewards")).toBe("/docs#rewards");
+    expect(normalizeDocsHash("#formats")).toBe("/docs#formats");
     expect(
       isDocsNavigationItemActive({
-        activeHref: "/docs#rewards",
+        activeHref: "/docs#formats",
         currentPath: "/docs",
         itemHref: "/docs#overview",
       }),
     ).toBe(false);
     expect(
       isDocsNavigationItemActive({
-        activeHref: "/docs#rewards",
+        activeHref: "/docs#formats",
         currentPath: "/docs",
-        itemHref: "/docs#rewards",
+        itemHref: "/docs#formats",
       }),
     ).toBe(true);
   });
@@ -48,13 +48,13 @@ describe("Docs navigation state", () => {
 
   it("canonicalizes a duplicated topic hash", () => {
     expect(normalizeDocsHash("#overview#overview")).toBe("/docs#overview");
-    expect(normalizeDocsHash("#rewards#rewards")).toBe("/docs#rewards");
+    expect(normalizeDocsHash("#rules#rules")).toBe("/docs#rules");
   });
 
   it("resolves browser Back and Forward hashes to one deterministic scroll target", () => {
-    expect(resolveDocsLocationTarget("#rewards")).toEqual({
-      href: "/docs#rewards",
-      sectionId: "rewards",
+    expect(resolveDocsLocationTarget("#rules")).toEqual({
+      href: "/docs#rules",
+      sectionId: "rules",
       shouldScroll: true,
     });
     expect(resolveDocsLocationTarget("#unknown")).toEqual({
@@ -118,11 +118,11 @@ describe("Docs navigation state", () => {
         marker: 104,
         positions: [
           { id: "overview", top: -640 },
-          { id: "launching", top: -40 },
-          { id: "trading", top: 380 },
+          { id: "formats", top: -40 },
+          { id: "quickstart", top: 380 },
         ],
       }),
-    ).toBe("launching");
+    ).toBe("formats");
   });
 
   it("places the reading marker below whichever Docs control is fixed", () => {
@@ -173,11 +173,11 @@ describe("Docs navigation state", () => {
         marker: 844,
         positions: [
           { id: "overview", top: 120 },
-          { id: "launching", top: 760 },
-          { id: "trading", top: 1180 },
+          { id: "formats", top: 760 },
+          { id: "quickstart", top: 1180 },
         ],
       }),
-    ).toBe("launching");
+    ).toBe("formats");
   });
 
   it("selects the final section at the bottom of the page", () => {
@@ -186,12 +186,12 @@ describe("Docs navigation state", () => {
         atPageEnd: true,
         marker: 104,
         positions: [
-          { id: "metadata", top: -220 },
-          { id: "releases", top: 180 },
-          { id: "risks", top: 520 },
+          { id: "quickstart", top: -220 },
+          { id: "rules", top: 180 },
+          { id: "resources", top: 520 },
         ],
       }),
-    ).toBe("risks");
+    ).toBe("resources");
   });
 
   it("uses document position when navigation groups are out of page order", () => {
@@ -201,35 +201,37 @@ describe("Docs navigation state", () => {
         marker: 104,
         positions: [
           { id: "overview", top: -2000 },
-          { id: "risks", top: 720 },
-          { id: "network", top: -80 },
-          { id: "contracts", top: 260 },
+          { id: "resources", top: 720 },
+          { id: "formats", top: -80 },
+          { id: "quickstart", top: 260 },
         ],
       }),
-    ).toBe("network");
+    ).toBe("formats");
   });
 
   it("resolves search results from the current input", () => {
-    const launchResults = getDocsSearchResults("launch");
-    const rewardResults = getDocsSearchResults("reward");
+    const terminalResults = getDocsSearchResults("terminal");
+    const schemaResults = getDocsSearchResults("schema");
 
-    expect(launchResults.length).toBeGreaterThan(0);
-    expect(launchResults[0]?.title).toBe("Launch flow");
-    expect(rewardResults.length).toBeGreaterThan(0);
-    expect(rewardResults[0]?.title).toBe("Creator rewards");
-    expect(rewardResults).not.toEqual(launchResults);
+    expect(terminalResults.length).toBeGreaterThan(0);
+    expect(terminalResults[0]?.title).toBe("Trading terminals and scanners");
+    expect(schemaResults.length).toBeGreaterThan(0);
+    expect(schemaResults[0]?.title).toBe("OpenAPI and schemas");
+    expect(schemaResults).not.toEqual(terminalResults);
     expect(getDocsSearchResults("")).toEqual([]);
   });
 
-  it("keeps hidden models out of search and exposes Custom Hook documentation", () => {
+  it("keeps standalone model guides out of search while explaining launch formats", () => {
     const deepResults = getDocsSearchResults("deep");
     const stockResults = getDocsSearchResults("stock");
+    const classicResults = getDocsSearchResults("classic");
     const customResults = getDocsSearchResults("custom");
 
     expect(deepResults).toEqual([]);
     expect(stockResults).toEqual([]);
-    expect(customResults[0]?.title).toBe("Custom Hook");
-    expect(customResults[0]?.description).toContain("release requirements");
+    expect(classicResults[0]?.title).toBe("Launch formats");
+    expect(customResults[0]?.title).toBe("Launch formats");
+    expect(customResults[0]?.description).toContain("no-pool");
   });
 
   it("opens keyboard navigation on the first or last result", () => {


### PR DESCRIPTION
## What changed

- integrates the developer API into the existing Programmable docs experience
- temporarily removes the visible Platform, Classic, and Custom Hook guide tabs
- adds concise, copyable examples for Classic, Custom pool, No pool, and Contract market
- keeps the deeper model routes available but unlinked for later activation
- updates navigation, search data, responsive styling, and docs tests

## Why

The developer integration should live inside the main docs without overwhelming users. This keeps the entry point focused while preserving the useful interactive launch-format examples.

## Validation

- lint passed
- typecheck passed
- 1,885 active tests passed; 7 skipped
- production build passed
- desktop and mobile browser QA passed at 1440 px, 390 px, and 320 px
- keyboard navigation, copy feedback, mobile docs navigation, and console output checked
