### PR TITLE
Stream live charts and profile rewards

### DIFF
--- a/app/api/explore/profile/route.ts
+++ b/app/api/explore/profile/route.ts
@@ -2,35 +2,20 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
 import {
-  buildCreatorProfile,
-  readExploreModel,
-} from "../../../../lib/onchain";
-import {
-  coordinatePublicRouteRead,
-  PUBLIC_INDEXED_ROUTE_READS,
-  PUBLIC_DISCOVERY_ROUTE_SCOPES,
-  preparePublicRouteRequest,
-  publicSnapshotCheckpoint,
-} from "../../../../lib/data-pipeline/public-route-readiness.server";
+  getAlchemyOnchainDeployment,
+  readAlchemyExploreModel,
+  safeAlchemyError,
+} from "../../../../lib/alchemy/explore.server";
+import { readAlchemyCreatorProfile } from "../../../../lib/alchemy/profile.server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
-  const routeRequest = await preparePublicRouteRequest(
-    request.nextUrl.searchParams,
-    request.headers,
-    "creator-profile",
-  );
-  if (routeRequest.probeFailure) return routeRequest.probeFailure;
-  const search = routeRequest.searchParams;
+  const search = request.nextUrl.searchParams;
   if (
-    [...search.keys()].some(
-      (key) => key !== "account" && key !== "launch" && key !== "attempt",
-    ) ||
-    search.getAll("account").length !== 1 ||
-    search.getAll("launch").length > 1 ||
-    search.getAll("attempt").length > 1
+    [...search.keys()].some((key) => key !== "account") ||
+    search.getAll("account").length !== 1
   ) {
     return NextResponse.json(
       { error: "Unsupported query parameters" },
@@ -47,38 +32,40 @@ export async function GET(request: NextRequest) {
 
   try {
     const account = getAddress(input);
-    return await coordinatePublicRouteRead({
-      route: "creator-profile",
-      scope: PUBLIC_DISCOVERY_ROUTE_SCOPES,
-      ...(routeRequest.releaseProbe
-        ? { releaseProbe: routeRequest.releaseProbe }
-        : {}),
-      indexed: (transaction) =>
-        PUBLIC_INDEXED_ROUTE_READS.creatorProfile(transaction, {
-          chainId: 1,
-          account,
-        }),
-      async legacy() {
-        const model = await readExploreModel();
-        return {
-          source: "rpc" as const,
-          checkpoint: publicSnapshotCheckpoint(model.snapshot),
-          response: NextResponse.json(
-            buildCreatorProfile(model, account),
-            {
-              headers: {
-                "Cache-Control":
-                  model.status === "ready"
-                    ? "private, max-age=0, s-maxage=15"
-                    : "private, max-age=0, s-maxage=60",
-              },
+    const deployment = getAlchemyOnchainDeployment();
+    const model = await readAlchemyExploreModel();
+    const profile =
+      deployment.status === "ready"
+        ? await readAlchemyCreatorProfile({ account, deployment, model })
+        : {
+            status: "not-deployed" as const,
+            account,
+            tokens: [],
+            pools: [],
+            claims: [],
+            totals: {
+              claimableWei: "0",
+              claimableEth: "0",
+              generatedWei: "0",
+              generatedEth: "0",
+              claimedWei: "0",
+              claimedEth: "0",
             },
-          ),
-        };
+            snapshot: null,
+          };
+    return NextResponse.json(profile, {
+      headers: {
+        "Cache-Control": "private, max-age=0, s-maxage=15",
+        "X-Programmable-Launch-Source": "alchemy",
+        "X-Programmable-Read-Source": "rpc",
+        "X-Programmable-Rpc-Provider": "alchemy",
       },
     });
   } catch (error) {
-    console.error("Creator profile onchain read failed", error);
+    console.error(
+      "Alchemy creator profile read failed",
+      safeAlchemyError(error),
+    );
     return NextResponse.json(
       { error: "Onchain creator data is temporarily unavailable" },
       { status: 503, headers: { "Cache-Control": "no-store" } },

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -2,9 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 
 import {
   enrichTokensWithAlchemyPrices,
+  getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../lib/alchemy/explore.server";
+import { enrichTokensWithAlchemyPoolState } from "../../../lib/alchemy/live-market.server";
 import {
   filterAndSortTokens,
   paginateExplore,
@@ -12,6 +14,7 @@ import {
   visibleExploreTokens,
 } from "../../../lib/onchain/query";
 import type { ExplorePage, ExploreReadModel } from "../../../lib/onchain/types";
+import type { LauncherToken } from "../../../lib/tokens";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -24,6 +27,19 @@ const EXPLORE_QUERY_PARAMETERS = new Set([
   "sort",
 ]);
 const TOP_MARKET_CAP_LIMIT = 20;
+const NEWEST_LIVE_MARKET_LIMIT = 20;
+
+function mergeTokenUpdates(
+  tokens: readonly LauncherToken[],
+  updates: readonly LauncherToken[],
+) {
+  const byAddress = new Map(
+    updates.map((token) => [token.tokenAddress.toLowerCase(), token]),
+  );
+  return tokens.map(
+    (token) => byAddress.get(token.tokenAddress.toLowerCase()) ?? token,
+  );
+}
 
 function hasCanonicalQueryShape(search: URLSearchParams) {
   const seen = new Set<string>();
@@ -120,17 +136,60 @@ export async function GET(request: NextRequest) {
       socials,
     } as const;
     const model = await readAlchemyExploreModel();
-    const pricedModel = {
+    let pricedModel = {
       ...model,
       tokens: await enrichTokensWithAlchemyPrices(model.tokens),
     } satisfies ExploreReadModel;
+    const deployment = getAlchemyOnchainDeployment();
+    const liveSnapshot =
+      pricedModel.status === "ready"
+        ? (pricedModel.launchDiscoverySnapshot ?? pricedModel.snapshot)
+        : null;
+    if (deployment.status === "ready" && liveSnapshot) {
+      const visible = visibleExploreTokens(pricedModel);
+      const top = filterAndSortTokens(
+        [...visible],
+        "",
+        "market-cap",
+      ).slice(0, TOP_MARKET_CAP_LIMIT);
+      const newest = filterAndSortTokens(
+        [...visible],
+        "",
+        "newest",
+      ).slice(0, NEWEST_LIVE_MARKET_LIMIT);
+      const warm = [...new Map(
+        [...top, ...newest].map((token) => [
+          token.tokenAddress.toLowerCase(),
+          token,
+        ]),
+      ).values()];
+      const updates = await enrichTokensWithAlchemyPoolState({
+        deployment,
+        snapshot: liveSnapshot,
+        tokens: warm,
+      });
+      pricedModel = {
+        ...pricedModel,
+        tokens: mergeTokenUpdates(pricedModel.tokens, updates),
+      };
+    }
     const useTopMarketCapView =
       options.sort === "market-cap" &&
       options.query.length === 0 &&
       options.socials === null;
-    const page = useTopMarketCapView
+    let page = useTopMarketCapView
       ? topThenNewestPage(pricedModel, options)
       : paginateExplore(pricedModel, options);
+    if (deployment.status === "ready" && liveSnapshot && page.tokens.length) {
+      page = {
+        ...page,
+        tokens: await enrichTokensWithAlchemyPoolState({
+          deployment,
+          snapshot: liveSnapshot,
+          tokens: page.tokens,
+        }),
+      };
+    }
 
     return NextResponse.json(
       page,

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -6,6 +6,7 @@ import {
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../../../lib/alchemy/explore.server";
+import { enrichTokensWithAlchemyPoolState } from "../../../../../lib/alchemy/live-market.server";
 import {
   isTokenChartRange,
   readTokenChartSeries,
@@ -90,10 +91,18 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    const liveSnapshot = model.launchDiscoverySnapshot ?? model.snapshot;
+    const liveToken = (
+      await enrichTokensWithAlchemyPoolState({
+        deployment,
+        snapshot: liveSnapshot,
+        tokens: [token],
+      })
+    )[0] ?? token;
     const series = await readTokenChartSeries({
       deployment,
-      token,
-      snapshotBlock: BigInt(model.snapshot.blockNumber),
+      token: liveToken,
+      snapshotBlock: BigInt(liveSnapshot.blockNumber),
       ethUsdQuote: model.snapshot.ethUsdQuote,
       range: requestedRange,
     });
@@ -102,8 +111,8 @@ export async function GET(request: NextRequest) {
         ...series,
         address,
         range: requestedRange,
-        snapshotBlock: model.snapshot.blockNumber,
-        snapshotHash: model.snapshot.blockHash,
+        snapshotBlock: liveSnapshot.blockNumber,
+        snapshotHash: liveSnapshot.blockHash,
       },
       {
         headers: {

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -2,10 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
 import {
+  getAlchemyOnchainDeployment,
   enrichTokensWithAlchemyPrices,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../../lib/alchemy/explore.server";
+import { enrichTokensWithAlchemyPoolState } from "../../../../lib/alchemy/live-market.server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -58,9 +60,24 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const enriched = token
+    const priced = token
       ? (await enrichTokensWithAlchemyPrices([token]))[0] ?? token
       : null;
+    const liveSnapshot =
+      model.status === "ready"
+        ? (model.launchDiscoverySnapshot ?? model.snapshot)
+        : null;
+    const deployment = getAlchemyOnchainDeployment();
+    const enriched =
+      priced && liveSnapshot && deployment.status === "ready"
+        ? (
+            await enrichTokensWithAlchemyPoolState({
+              deployment,
+              snapshot: liveSnapshot,
+              tokens: [priced],
+            })
+          )[0] ?? priced
+        : priced;
     return NextResponse.json(
       {
         status: model.status,

--- a/app/api/profile/classic-v3/route.ts
+++ b/app/api/profile/classic-v3/route.ts
@@ -75,7 +75,9 @@ const chain = environment === "rehearsal" ? sepolia : mainnet;
 const rpcUrl =
   environment === "rehearsal"
     ? process.env.SEPOLIA_RPC_URL ?? "https://sepolia.drpc.org"
-    : process.env.ETHEREUM_RPC_URL ?? "https://eth.drpc.org";
+    : process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL ??
+      process.env.ETHEREUM_RPC_URL ??
+      "https://eth.drpc.org";
 
 function json(body: unknown, status = 200) {
   return NextResponse.json(body, {

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -518,6 +518,41 @@
   text-wrap: pretty;
 }
 
+.claimHistory {
+  display: grid;
+  gap: 7px;
+  padding: 16px;
+  position: relative;
+  width: 100%;
+}
+
+.claimHistory a {
+  align-items: center;
+  background: color-mix(in srgb, var(--glass-96) 70%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
+  border-radius: 12px;
+  color: var(--text);
+  display: flex;
+  font-size: 12px;
+  gap: 12px;
+  justify-content: space-between;
+  min-height: 32px;
+  padding: 7px 10px;
+  text-decoration: none;
+}
+
+.claimHistory span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.claimHistory time {
+  color: var(--muted);
+  flex: none;
+  font-size: 10px;
+}
+
 .claimList {
   display: grid;
   gap: 10px;

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -15,6 +15,7 @@ import {
 } from "react";
 
 import { useWallet } from "@/components/wallet-provider";
+import { useLiveDataRefresh } from "@/components/use-live-data-refresh";
 import { isConfiguredClassicV3ReleaseReady } from "@/lib/classic-v3-release";
 import { prepareAvatarImage } from "@/lib/profile/avatar";
 import {
@@ -67,6 +68,7 @@ import {
   loadingProfileData,
   UNAVAILABLE_PROFILE_DATA,
   type ProfileClaim,
+  type ProfileActivity,
   type ProfileOnchainData,
   type ProfileToken,
 } from "@/lib/profile/onchain-profile";
@@ -769,6 +771,9 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
   const [remoteOnchainData, setRemoteOnchainData] =
     useState<ProfileOnchainData>(UNAVAILABLE_PROFILE_DATA);
   const [profileRefresh, setProfileRefresh] = useState(0);
+  const liveProfileRefresh = useLiveDataRefresh({
+    enabled: Boolean(account),
+  });
   const [terminalErrorReadyKey, setTerminalErrorReadyKey] = useState("");
   const [classicV3Rewards, setClassicV3Rewards] =
     useState<ClassicV3ProfileRewards>(EMPTY_CLASSIC_V3_PROFILE);
@@ -903,18 +908,21 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       })
       .catch((caught: unknown) => {
         if (controller.signal.aborted) return;
-        setRemoteOnchainData(
-          errorProfileData(
-            account,
-            caught instanceof Error
-              ? caught.message
-              : "Onchain profile data could not be loaded",
-          ),
+        setRemoteOnchainData((current) =>
+          isProfileDataForAccount(current, account) &&
+          current.status === "ready"
+            ? current
+            : errorProfileData(
+                account,
+                caught instanceof Error
+                  ? caught.message
+                  : "Onchain profile data could not be loaded",
+              ),
         );
       });
 
     return () => controller.abort();
-  }, [account, onchainData, profileRefresh]);
+  }, [account, liveProfileRefresh, onchainData, profileRefresh]);
 
   useEffect(() => {
     if (!account || !classicV3ReleaseAvailable) return;
@@ -950,18 +958,23 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       })
       .catch((caught: unknown) => {
         if (controller.signal.aborted) return;
-        setClassicV3Rewards({
-          status: "error",
-          account,
-          rewards: [],
-          errorMessage:
-            caught instanceof Error
-              ? caught.message
-              : "Classic rewards could not be loaded",
-        });
+        setClassicV3Rewards((current) =>
+          current.status === "ready" &&
+          current.account.toLowerCase() === account.toLowerCase()
+            ? current
+            : {
+                status: "error",
+                account,
+                rewards: [],
+                errorMessage:
+                  caught instanceof Error
+                    ? caught.message
+                    : "Classic rewards could not be loaded",
+              },
+        );
       });
     return () => controller.abort();
-  }, [account, profileRefresh]);
+  }, [account, liveProfileRefresh, profileRefresh]);
 
   useEffect(() => {
     if (!account || !deepReleaseAvailable) return;
@@ -997,18 +1010,23 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       })
       .catch((caught: unknown) => {
         if (controller.signal.aborted) return;
-        setDeepRewards({
-          status: "error",
-          account,
-          rewards: [],
-          errorMessage:
-            caught instanceof Error
-              ? caught.message
-              : "Deep rewards could not be loaded",
-        });
+        setDeepRewards((current) =>
+          current.status === "ready" &&
+          current.account.toLowerCase() === account.toLowerCase()
+            ? current
+            : {
+                status: "error",
+                account,
+                rewards: [],
+                errorMessage:
+                  caught instanceof Error
+                    ? caught.message
+                    : "Deep rewards could not be loaded",
+              },
+        );
       });
     return () => controller.abort();
-  }, [account, profileRefresh]);
+  }, [account, liveProfileRefresh, profileRefresh]);
 
   useEffect(() => {
     if (!account || !deepV3ReleaseAvailable) return;
@@ -1033,7 +1051,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         });
       });
     return () => controller.abort();
-  }, [account, profileRefresh]);
+  }, [account, liveProfileRefresh, profileRefresh]);
 
   useEffect(() => {
     if (!account || !stockPairedReleaseAvailable) return;
@@ -1069,19 +1087,24 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       })
       .catch((caught: unknown) => {
         if (controller.signal.aborted) return;
-        setStockPairedRewards({
-          status: "error",
-          account,
-          chainId: 1,
-          rewards: [],
-          errorMessage:
-            caught instanceof Error
-              ? caught.message
-              : "Stock-Paired rewards could not be loaded",
-        });
+        setStockPairedRewards((current) =>
+          current.status === "ready" &&
+          current.account.toLowerCase() === account.toLowerCase()
+            ? current
+            : {
+                status: "error",
+                account,
+                chainId: 1,
+                rewards: [],
+                errorMessage:
+                  caught instanceof Error
+                    ? caught.message
+                    : "Stock-Paired rewards could not be loaded",
+              },
+        );
       });
     return () => controller.abort();
-  }, [account, profileRefresh]);
+  }, [account, liveProfileRefresh, profileRefresh]);
 
   function beginEditingProfile() {
     setUsernameDraft(savedProfile.username);
@@ -3016,6 +3039,20 @@ function ProfileAccountWorkspace({
     stockPairedReady ? stockPairedRewards.rewards : [],
   );
   const nativeClaimable = profileClaimableWei(entries, account);
+  const nativeClaimed =
+    (currentReady && data.claimedWei ? BigInt(data.claimedWei) : 0n) +
+    (classicReady
+      ? classicV3Rewards.rewards.reduce(
+          (total, reward) => total + BigInt(reward.claimedWei),
+          0n,
+        )
+      : 0n) +
+    (deepReady
+      ? deepRewards.rewards.reduce(
+          (total, reward) => total + BigInt(reward.claimedWei),
+          0n,
+        )
+      : 0n);
   const stockRewardCount = entries.reduce(
     (total, entry) =>
       total +
@@ -3087,7 +3124,9 @@ function ProfileAccountWorkspace({
       <div className={styles.profileWorkspace}>
         <FeeEarningsPanel
           nativeClaimable={nativeClaimable}
+          nativeClaimed={nativeClaimed}
           stockRewardCount={stockRewardCount}
+          activity={currentReady ? data.activity : []}
         />
 
         <section
@@ -3166,22 +3205,20 @@ function ProfileAccountWorkspace({
   );
 }
 
-type FeeEarningsTimeframe = "1H" | "1D" | "1W";
-
-const feeEarningsTimeframes: readonly FeeEarningsTimeframe[] = [
-  "1H",
-  "1D",
-  "1W",
-];
-
 function FeeEarningsPanel({
   nativeClaimable,
+  nativeClaimed,
   stockRewardCount,
+  activity,
 }: {
   nativeClaimable: bigint;
+  nativeClaimed: bigint;
   stockRewardCount: number;
+  activity: readonly ProfileActivity[];
 }) {
-  const [timeframe, setTimeframe] = useState<FeeEarningsTimeframe>("1D");
+  const claimHistory = activity
+    .filter((item) => /fees claimed/iu.test(item.label))
+    .slice(0, 4);
 
   return (
     <section
@@ -3193,40 +3230,33 @@ function FeeEarningsPanel({
           <h2 id="fee-earnings-title">Fee earnings</h2>
           <p>Claimable now</p>
         </div>
-        <div
-          className={styles.timeframeControls}
-          role="group"
-          aria-label="Fee earnings timeframe"
-        >
-          {feeEarningsTimeframes.map((value) => (
-            <button
-              key={value}
-              type="button"
-              aria-pressed={timeframe === value}
-              onClick={() => setTimeframe(value)}
-            >
-              {value}
-            </button>
-          ))}
-        </div>
       </header>
 
       <div className={styles.feeSummary}>
         <strong>{formatWei(nativeClaimable)}</strong>
+        <span>{formatWei(nativeClaimed)} claimed</span>
         {stockRewardCount > 0 ? (
-          <span>
-            + {stockRewardCount} quote{" "}
-            {stockRewardCount === 1 ? "reward" : "rewards"}
-          </span>
+          <span>+ {stockRewardCount} quote {stockRewardCount === 1 ? "reward" : "rewards"}</span>
         ) : null}
       </div>
 
       <figure className={styles.feeChart}>
         <div className={styles.chartGrid} aria-hidden="true" />
-        <figcaption className={styles.chartEmpty}>
-          <strong>History isn’t available for {timeframe}.</strong>
-          <p>Current claimable rewards are shown above.</p>
-        </figcaption>
+        {claimHistory.length ? (
+          <figcaption className={styles.claimHistory}>
+            {claimHistory.map((item) => (
+              <Link href={item.href} key={item.id}>
+                <span>{item.detail}</span>
+                <time>{item.occurredAt}</time>
+              </Link>
+            ))}
+          </figcaption>
+        ) : (
+          <figcaption className={styles.chartEmpty}>
+            <strong>No claims yet.</strong>
+            <p>New confirmed claims appear here automatically.</p>
+          </figcaption>
+        )}
       </figure>
     </section>
   );

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/components/token-trade";
 import {
   TokenPriceChart,
+  preloadTokenChart,
+  type TokenChartMarketCap,
   type TokenChartVolume,
 } from "@/components/token-price-chart";
 import { TokenCommunityChat } from "@/components/token-community-chat";
@@ -838,6 +840,8 @@ function TokenDetailContent({
   const [copied, setCopied] = useState(false);
   const [copyError, setCopyError] = useState("");
   const [chartVolume, setChartVolume] = useState<TokenChartVolume | null>(null);
+  const [chartMarketCap, setChartMarketCap] =
+    useState<TokenChartMarketCap | null>(null);
   const [tradeFlow, setTradeFlow] = useState<TradeFlow>({
     phase: "form",
   });
@@ -872,10 +876,13 @@ function TokenDetailContent({
   const metrics = useMemo(() => {
     return buildTokenDetailMetrics(
       token,
-      null,
+      chartMarketCap
+        ? (formatUsdWadAmount(chartMarketCap.marketCapUsdWad) ??
+          formatEth(chartMarketCap.marketCapEth, "amount"))
+        : null,
       buildChartVolumeMetric(chartVolume),
     );
-  }, [chartVolume, token]);
+  }, [chartMarketCap, chartVolume, token]);
 
   const explorerBase =
     chainId === 1
@@ -1168,6 +1175,7 @@ function TokenDetailContent({
               launchModel={token.launchModel}
               preview={preview}
               onVolumeChange={setChartVolume}
+              onMarketCapChange={setChartMarketCap}
             />
           </div>
 
@@ -1420,6 +1428,7 @@ export function TokenDetailView({ address }: { address: string }) {
 
     const tokenAddress = normalizedAddress;
     const controller = new AbortController();
+    void preloadTokenChart(tokenAddress, "1d");
 
     async function loadToken() {
       try {

--- a/components/token-price-chart.module.css
+++ b/components/token-price-chart.module.css
@@ -128,29 +128,18 @@
   text-align: center;
 }
 
-.loadingLine {
-  background: color-mix(in srgb, var(--border) 54%, transparent);
-  border-radius: 999px;
-  display: block;
-  height: 2px;
-  overflow: hidden;
-  position: relative;
-  width: min(360px, 72%);
-}
-
-.loadingLine::after {
-  animation: chart-loading 0.9s linear infinite;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    color-mix(in srgb, var(--accent) 58%, transparent),
-    transparent
-  );
-  content: "";
-  inset: 0;
-  position: absolute;
-  transform: translateX(-100%);
-  width: 80%;
+.waitingPlot {
+  background:
+    linear-gradient(
+      to bottom,
+      transparent 32%,
+      color-mix(in srgb, var(--border) 38%, transparent) 33%,
+      transparent 34%,
+      transparent 65%,
+      color-mix(in srgb, var(--border) 38%, transparent) 66%,
+      transparent 67%
+    );
+  opacity: 0.55;
 }
 
 @keyframes reveal-line {
@@ -172,16 +161,6 @@
 
   to {
     opacity: 1;
-  }
-}
-
-@keyframes chart-loading {
-  from {
-    transform: translateX(-100%);
-  }
-
-  to {
-    transform: translateX(225%);
   }
 }
 
@@ -248,8 +227,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .area,
-  .line,
-  .loadingLine::after {
+  .line {
     animation: none;
   }
 

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -19,14 +19,18 @@ type ChartPoint = {
   priceUsd?: string;
 };
 
-type ChartPayload = {
+export type TokenChartPayload = {
   status: "ready" | "insufficient-history" | "not-deployed";
   points: ChartPoint[];
   swapCount: number;
   volumeWei: string;
   volumeEth: string;
   volumeUsdWad?: string;
+  marketCapEthWei?: string;
+  marketCapEth?: string;
+  marketCapUsdWad?: string;
 };
+type ChartPayload = TokenChartPayload;
 
 type PlottedPoint = ChartPoint & {
   x: number;
@@ -41,7 +45,66 @@ export type TokenChartVolume = {
   volumeEth?: string;
   volumeUsdWad?: string;
 };
+export type TokenChartMarketCap = {
+  marketCapEthWei?: string;
+  marketCapEth?: string;
+  marketCapUsdWad?: string;
+};
 type ChartLaunchModel = "classic" | "adaptive" | "deep" | "stock-paired";
+
+const chartPayloadCache = new Map<
+  string,
+  Readonly<{ payload: ChartPayload; updatedAt: number }>
+>();
+const chartPayloadRequests = new Map<string, Promise<ChartPayload>>();
+const MAX_CHART_PAYLOAD_CACHE_ENTRIES = 64;
+
+function cacheChartPayload(key: string, payload: ChartPayload) {
+  chartPayloadCache.delete(key);
+  chartPayloadCache.set(key, { payload, updatedAt: Date.now() });
+  while (chartPayloadCache.size > MAX_CHART_PAYLOAD_CACHE_ENTRIES) {
+    const oldest = chartPayloadCache.keys().next().value;
+    if (oldest === undefined) return;
+    chartPayloadCache.delete(oldest);
+  }
+}
+
+async function requestTokenChartPayload(
+  tokenAddress: `0x${string}`,
+  range: ChartRange,
+) {
+  const key = `${tokenAddress.toLowerCase()}:${range}`;
+  const active = chartPayloadRequests.get(key);
+  if (active) return active;
+  const cached = chartPayloadCache.get(key);
+  if (cached && Date.now() - cached.updatedAt < 2_000) {
+    return cached.payload;
+  }
+  const request = fetch(
+    `/api/explore/token/chart?address=${encodeURIComponent(tokenAddress)}&range=${range}`,
+    { headers: { Accept: "application/json" } },
+  )
+    .then(async (response) => {
+      if (!response.ok) throw new Error("Chart request failed");
+      const payload = (await response.json()) as ChartPayload;
+      cacheChartPayload(key, payload);
+      return payload;
+    })
+    .finally(() => {
+      if (chartPayloadRequests.get(key) === request) {
+        chartPayloadRequests.delete(key);
+      }
+    });
+  chartPayloadRequests.set(key, request);
+  return request;
+}
+
+export function preloadTokenChart(
+  tokenAddress: `0x${string}`,
+  range: ChartRange = "1d",
+) {
+  return requestTokenChartPayload(tokenAddress, range).catch(() => null);
+}
 
 type SerializedChartRefresh = {
   request(): void;
@@ -178,19 +241,21 @@ export function TokenPriceChart({
   launchModel,
   preview = false,
   onVolumeChange,
+  onMarketCapChange,
 }: {
   tokenAddress: `0x${string}`;
   tokenName: string;
   launchModel?: ChartLaunchModel;
   preview?: boolean;
   onVolumeChange?: (volume: TokenChartVolume | null) => void;
+  onMarketCapChange?: (marketCap: TokenChartMarketCap | null) => void;
 }) {
   const [request, setRequest] = useState<{
     key: string;
     payload: ChartPayload | null;
     failed: boolean;
   } | null>(null);
-  const [range, setRange] = useState<ChartRange>("all");
+  const [range, setRange] = useState<ChartRange>("1d");
   const refreshTaskRef = useRef<SerializedChartRefresh | null>(null);
   const refreshKey = useLiveDataRefresh({
     enabled: launchModel !== "stock-paired" && !preview,
@@ -201,13 +266,13 @@ export function TokenPriceChart({
     () => (preview ? getExplorePreviewChart(tokenAddress, range) : null),
     [preview, range, tokenAddress],
   );
-  const payload =
+  const payload: ChartPayload | null =
     previewPayload ??
     (launchModel === "stock-paired"
       ? STOCK_PAIRED_EMPTY_CHART
       : request?.key === requestKey
         ? request.payload
-        : null);
+        : (chartPayloadCache.get(requestKey)?.payload ?? null));
   const failed =
     preview
       ? false
@@ -226,12 +291,11 @@ export function TokenPriceChart({
 
     const refreshTask = createSerializedChartRefresh(async (signal) => {
       try {
-        const response = await fetch(
-          `/api/explore/token/chart?address=${encodeURIComponent(tokenAddress)}&range=${range}`,
-          { signal },
+        const nextPayload = await requestTokenChartPayload(
+          tokenAddress,
+          range,
         );
-        if (!response.ok) throw new Error("Chart request failed");
-        const nextPayload = (await response.json()) as ChartPayload;
+        if (signal.aborted) return;
         setRequest({
           key: requestKey,
           payload: nextPayload,
@@ -341,6 +405,18 @@ export function TokenPriceChart({
     });
   }, [failed, launchModel, onVolumeChange, payload, range]);
 
+  useEffect(() => {
+    if (!payload) {
+      onMarketCapChange?.(null);
+      return;
+    }
+    onMarketCapChange?.({
+      marketCapEthWei: payload.marketCapEthWei,
+      marketCapEth: payload.marketCapEth,
+      marketCapUsdWad: payload.marketCapUsdWad,
+    });
+  }, [onMarketCapChange, payload]);
+
   if (
     !shouldRenderPriceHistory({
       loading,
@@ -402,9 +478,7 @@ export function TokenPriceChart({
       </div>
 
       {loading ? (
-        <div className={styles.placeholder} aria-hidden="true">
-          <span className={styles.loadingLine} />
-        </div>
+        <div className={`${styles.plot} ${styles.waitingPlot}`} aria-hidden="true" />
       ) : chart ? (
         <div className={styles.plot}>
           <svg

--- a/lib/alchemy/live-market.server.ts
+++ b/lib/alchemy/live-market.server.ts
@@ -1,0 +1,202 @@
+import "server-only";
+
+import {
+  createPublicClient,
+  formatUnits,
+  http,
+  type Hex,
+} from "viem";
+import { mainnet, sepolia } from "viem/chains";
+
+import { stateViewReadAbi } from "../onchain/abis";
+import {
+  marketCapNativeWadFromSqrtPriceX96,
+  nativePriceWadFromSqrtPriceX96,
+} from "../onchain/math";
+import type { ExploreSnapshot, ReadyOnchainDeployment } from "../onchain/types";
+import { usdValueFromWei } from "../onchain/usd";
+import type { LauncherToken } from "../tokens";
+
+const LIVE_POOL_STATE_TTL_MS = 5_000;
+const MAX_LIVE_POOL_STATE_ENTRIES = 256;
+
+type LivePoolState = Readonly<{
+  sqrtPriceX96: bigint;
+  tick: number;
+  protocolFeePips: number;
+  lpFeePips: number;
+  blockNumber: bigint;
+}>;
+
+const livePoolStateCache = new Map<
+  string,
+  Readonly<{
+    expiresAt: number;
+    value: Promise<LivePoolState | null>;
+  }>
+>();
+
+function currentCacheEntry(key: string) {
+  const entry = livePoolStateCache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt > Date.now()) return entry.value;
+  livePoolStateCache.delete(key);
+  return null;
+}
+
+function trimPoolStateCache() {
+  while (livePoolStateCache.size > MAX_LIVE_POOL_STATE_ENTRIES) {
+    const oldest = livePoolStateCache.keys().next().value;
+    if (oldest === undefined) return;
+    livePoolStateCache.delete(oldest);
+  }
+}
+
+function validPoolToken(token: LauncherToken) {
+  return (
+    token.launchModel !== "stock-paired" &&
+    typeof token.totalSupplyRaw === "string" &&
+    /^(?:0|[1-9]\d*)$/u.test(token.totalSupplyRaw) &&
+    typeof token.tokenDecimals === "number" &&
+    Number.isInteger(token.tokenDecimals) &&
+    token.tokenDecimals >= 0 &&
+    token.tokenDecimals <= 255 &&
+    /^0x[0-9a-f]{64}$/iu.test(token.poolId)
+  );
+}
+
+function snapshotBlock(snapshot: ExploreSnapshot) {
+  if (!/^(?:0|[1-9]\d*)$/u.test(snapshot.blockNumber)) {
+    throw new Error("Alchemy live market snapshot block is invalid");
+  }
+  return BigInt(snapshot.blockNumber);
+}
+
+function applyLivePoolState(
+  token: LauncherToken,
+  state: LivePoolState | null,
+  snapshot: ExploreSnapshot,
+) {
+  if (!state || !validPoolToken(token)) return token;
+
+  const tokenDecimals = token.tokenDecimals as number;
+  const totalSupplyRaw = BigInt(token.totalSupplyRaw as string);
+  const tokenPriceEthWei = nativePriceWadFromSqrtPriceX96(
+    state.sqrtPriceX96,
+    tokenDecimals,
+  );
+  const marketCapEthWei = marketCapNativeWadFromSqrtPriceX96(
+    totalSupplyRaw,
+    state.sqrtPriceX96,
+  );
+  const tokenPriceUsdWad = snapshot.ethUsdQuote
+    ? usdValueFromWei(
+        tokenPriceEthWei.toString(),
+        BigInt(snapshot.ethUsdQuote.answer),
+        snapshot.ethUsdQuote.decimals,
+      )
+    : undefined;
+  const marketCapUsdWad = snapshot.ethUsdQuote
+    ? usdValueFromWei(
+        marketCapEthWei.toString(),
+        BigInt(snapshot.ethUsdQuote.answer),
+        snapshot.ethUsdQuote.decimals,
+      )
+    : undefined;
+
+  return {
+    ...token,
+    tokenPriceEthWei: tokenPriceEthWei.toString(),
+    tokenPriceEth: formatUnits(tokenPriceEthWei, 18),
+    marketCapEthWei: marketCapEthWei.toString(),
+    marketCapEth: formatUnits(marketCapEthWei, 18),
+    indexedValuationBlockNumber: state.blockNumber.toString(),
+    currentTick: state.tick,
+    protocolFeePips: state.protocolFeePips,
+    lpFeePips: state.lpFeePips,
+    ...(tokenPriceUsdWad === undefined
+      ? {}
+      : { tokenPriceUsdWad: tokenPriceUsdWad.toString() }),
+    ...(marketCapUsdWad === undefined
+      ? {}
+      : { fdvUsdWad: marketCapUsdWad.toString() }),
+  } satisfies LauncherToken;
+}
+
+export async function enrichTokensWithAlchemyPoolState(input: {
+  deployment: ReadyOnchainDeployment;
+  snapshot: ExploreSnapshot;
+  tokens: readonly LauncherToken[];
+}) {
+  const eligible = input.tokens.filter(validPoolToken);
+  if (eligible.length === 0) return [...input.tokens];
+
+  const blockNumber = snapshotBlock(input.snapshot);
+  const states = new Map<string, Promise<LivePoolState | null>>();
+  const missing: LauncherToken[] = [];
+  for (const token of eligible) {
+    const key = token.poolId.toLowerCase();
+    const cached = currentCacheEntry(key);
+    if (cached) states.set(key, cached);
+    else missing.push(token);
+  }
+
+  if (missing.length > 0) {
+    const client = createPublicClient({
+      chain: input.deployment.chainId === 1 ? mainnet : sepolia,
+      transport: http(input.deployment.rpcUrl, {
+        retryCount: 2,
+        timeout: 12_000,
+      }),
+    });
+    const batch = client
+      .multicall({
+        allowFailure: true,
+        blockNumber,
+        contracts: missing.map((token) => ({
+          address: input.deployment.stateView,
+          abi: stateViewReadAbi,
+          functionName: "getSlot0" as const,
+          args: [token.poolId as Hex],
+        })),
+      })
+      .then((results) =>
+        results.map((result): LivePoolState | null => {
+          if (result.status !== "success") return null;
+          const [sqrtPriceX96, tick, protocolFeePips, lpFeePips] = result.result;
+          if (sqrtPriceX96 <= 0n) return null;
+          return {
+            sqrtPriceX96,
+            tick,
+            protocolFeePips,
+            lpFeePips,
+            blockNumber,
+          };
+        }),
+      )
+      .catch(() => missing.map(() => null));
+
+    missing.forEach((token, index) => {
+      const key = token.poolId.toLowerCase();
+      const value = batch.then((results) => results[index] ?? null);
+      livePoolStateCache.set(key, {
+        expiresAt: Date.now() + LIVE_POOL_STATE_TTL_MS,
+        value,
+      });
+      states.set(key, value);
+    });
+    trimPoolStateCache();
+  }
+
+  const resolved = await Promise.all(
+    input.tokens.map(async (token) => {
+      const state = states.get(token.poolId.toLowerCase());
+      return applyLivePoolState(
+        token,
+        state ? await state : null,
+        input.snapshot,
+      );
+    }),
+  );
+  return resolved;
+}

--- a/lib/alchemy/profile.server.ts
+++ b/lib/alchemy/profile.server.ts
@@ -1,0 +1,315 @@
+import "server-only";
+
+import {
+  createPublicClient,
+  formatUnits,
+  getAddress,
+  http,
+  type Address,
+  type Hex,
+} from "viem";
+import { mainnet, sepolia } from "viem/chains";
+
+import { buildCreatorProfile } from "../onchain/profile";
+import {
+  creatorFeeHookReadAbi,
+  creatorFeesClaimedEvent,
+} from "../onchain/abis";
+import type {
+  CreatorClaim,
+  CreatorProfile,
+  ExploreReadModel,
+  ReadyOnchainDeployment,
+} from "../onchain/types";
+import type { LauncherToken } from "../tokens";
+
+const CLAIM_LOG_BATCH_CONCURRENCY = 4;
+const MAX_PROFILE_CLAIM_CURSORS = 128;
+
+type RecentClaimReadInput = Readonly<{
+  account: Address;
+  deployment: ReadyOnchainDeployment;
+  fromBlock: bigint;
+  toBlock: bigint;
+  hookAddresses: readonly Address[];
+  tokenByPool: ReadonlyMap<string, LauncherToken>;
+}>;
+
+type RecentClaimCursor = Readonly<{
+  cursorBlock: bigint;
+  claims: readonly CreatorClaim[];
+}>;
+
+const recentClaimCursors = new Map<string, Promise<RecentClaimCursor>>();
+
+function isDirectClassicReward(token: LauncherToken) {
+  return (
+    (token.launchModel === undefined || token.launchModel === "classic") &&
+    token.launchModelVersion !== "classic-v3" &&
+    /^0x[0-9a-f]{64}$/iu.test(token.poolId)
+  );
+}
+
+function minimum(left: bigint, right: bigint) {
+  return left < right ? left : right;
+}
+
+async function scanRecentClaims(input: RecentClaimReadInput) {
+  if (
+    input.fromBlock > input.toBlock ||
+    input.hookAddresses.length === 0
+  ) {
+    return [] satisfies CreatorClaim[];
+  }
+  const client = createPublicClient({
+    chain: input.deployment.chainId === 1 ? mainnet : sepolia,
+    transport: http(input.deployment.rpcUrl, {
+      retryCount: 2,
+      timeout: 12_000,
+    }),
+  });
+  const ranges: Array<{ fromBlock: bigint; toBlock: bigint }> = [];
+  for (
+    let fromBlock = input.fromBlock;
+    fromBlock <= input.toBlock;
+    fromBlock += input.deployment.logBlockRange
+  ) {
+    ranges.push({
+      fromBlock,
+      toBlock: minimum(
+        input.toBlock,
+        fromBlock + input.deployment.logBlockRange - 1n,
+      ),
+    });
+  }
+
+  const readRange = (range: { fromBlock: bigint; toBlock: bigint }) =>
+    client.getLogs({
+      address: [...input.hookAddresses],
+      event: creatorFeesClaimedEvent,
+      args: { creator: input.account },
+      fromBlock: range.fromBlock,
+      toBlock: range.toBlock,
+      strict: true,
+    });
+  type CreatorClaimLog = Awaited<ReturnType<typeof readRange>>[number];
+  const logs: CreatorClaimLog[] = [];
+  for (
+    let offset = 0;
+    offset < ranges.length;
+    offset += CLAIM_LOG_BATCH_CONCURRENCY
+  ) {
+    const results = await Promise.all(
+      ranges
+        .slice(offset, offset + CLAIM_LOG_BATCH_CONCURRENCY)
+        .map(readRange),
+    );
+    logs.push(...results.flat());
+  }
+
+  const blockNumbers = [...new Set(
+    logs
+      .map((log) => log.blockNumber)
+      .filter((block): block is bigint => block !== null)
+      .map(String),
+  )].map(BigInt);
+  const timestamps = new Map<string, bigint>();
+  await Promise.all(
+    blockNumbers.map(async (blockNumber) => {
+      const block = await client.getBlock({ blockNumber });
+      timestamps.set(blockNumber.toString(), block.timestamp);
+    }),
+  );
+
+  return logs.flatMap((log): CreatorClaim[] => {
+    if (
+      log.removed ||
+      log.blockNumber === null ||
+      !log.transactionHash ||
+      log.transactionIndex === null ||
+      log.logIndex === null
+    ) {
+      return [];
+    }
+    const token = input.tokenByPool.get(log.args.poolId.toLowerCase());
+    if (!token) return [];
+    const timestamp = timestamps.get(log.blockNumber.toString()) ?? 0n;
+    return [{
+      poolId: log.args.poolId,
+      tokenAddress: getAddress(token.tokenAddress),
+      creatorAddress: log.args.creator,
+      recipientAddress: log.args.recipient,
+      callerAddress: log.args.caller,
+      amountWei: log.args.amount.toString(),
+      amountEth: formatUnits(log.args.amount, 18),
+      blockNumber: log.blockNumber.toString(),
+      transactionHash: log.transactionHash,
+      transactionIndex: log.transactionIndex,
+      logIndex: log.logIndex,
+      claimedAt: new Date(Number(timestamp) * 1_000).toISOString(),
+    }];
+  });
+}
+
+function recentClaimCursorKey(input: RecentClaimReadInput) {
+  return [
+    input.deployment.chainId,
+    input.account.toLowerCase(),
+    input.fromBlock.toString(),
+    ...input.hookAddresses.map((address) => address.toLowerCase()).sort(),
+  ].join(":");
+}
+
+async function readRecentClaims(input: RecentClaimReadInput) {
+  const key = recentClaimCursorKey(input);
+  const initial: RecentClaimCursor = {
+    cursorBlock: input.fromBlock - 1n,
+    claims: [],
+  };
+  const previous = recentClaimCursors.get(key) ?? Promise.resolve(initial);
+  const current = previous.then(async (cursor): Promise<RecentClaimCursor> => {
+    if (cursor.cursorBlock >= input.toBlock) return cursor;
+    const claims = await scanRecentClaims({
+      ...input,
+      fromBlock:
+        cursor.cursorBlock + 1n > input.fromBlock
+          ? cursor.cursorBlock + 1n
+          : input.fromBlock,
+    });
+    const merged = new Map(
+      [...cursor.claims, ...claims].map((claim) => [
+        `${claim.transactionHash.toLowerCase()}:${claim.logIndex}`,
+        claim,
+      ]),
+    );
+    return {
+      cursorBlock: input.toBlock,
+      claims: [...merged.values()],
+    };
+  });
+  recentClaimCursors.set(key, current);
+  current.catch(() => {
+    if (recentClaimCursors.get(key) === current) {
+      recentClaimCursors.delete(key);
+    }
+  });
+  while (recentClaimCursors.size > MAX_PROFILE_CLAIM_CURSORS) {
+    const oldest = recentClaimCursors.keys().next().value;
+    if (oldest === undefined || oldest === key) break;
+    recentClaimCursors.delete(oldest);
+  }
+  return (await current).claims;
+}
+
+export async function readAlchemyCreatorProfile(input: {
+  account: Address;
+  deployment: ReadyOnchainDeployment;
+  model: ExploreReadModel;
+}): Promise<CreatorProfile> {
+  if (input.model.status !== "ready") {
+    return buildCreatorProfile(input.model, input.account);
+  }
+
+  const normalizedAccount = input.account.toLowerCase();
+  const ownedTokens = input.model.tokens.filter(
+    (token) =>
+      token.creatorAddress?.toLowerCase() === normalizedAccount &&
+      isDirectClassicReward(token),
+  );
+  const tokenByPool = new Map(
+    ownedTokens.map((token) => [token.poolId.toLowerCase(), token]),
+  );
+  const liveSnapshot =
+    input.model.launchDiscoverySnapshot ?? input.model.snapshot;
+  const liveBlock = BigInt(liveSnapshot.blockNumber);
+  const baseBlock = BigInt(input.model.snapshot.blockNumber);
+  const client = createPublicClient({
+    chain: input.deployment.chainId === 1 ? mainnet : sepolia,
+    transport: http(input.deployment.rpcUrl, {
+      retryCount: 2,
+      timeout: 12_000,
+    }),
+  });
+
+  const [poolStates, recentClaims] = await Promise.all([
+    ownedTokens.length
+      ? client.multicall({
+          allowFailure: true,
+          blockNumber: liveBlock,
+          contracts: ownedTokens.map((token) => ({
+            address: getAddress(token.hookAddress),
+            abi: creatorFeeHookReadAbi,
+            functionName: "poolFeeConfig" as const,
+            args: [token.poolId as Hex],
+          })),
+        }).catch(() => [])
+      : Promise.resolve([]),
+    readRecentClaims({
+      account: input.account,
+      deployment: input.deployment,
+      fromBlock: baseBlock + 1n,
+      toBlock: liveBlock,
+      hookAddresses: [...new Set(
+        ownedTokens.map((token) => token.hookAddress.toLowerCase()),
+      )].map((address) => getAddress(address)),
+      tokenByPool,
+    }).catch(() => []),
+  ]);
+
+  const claims = new Map(
+    [...input.model.creatorClaims, ...recentClaims]
+      .filter(
+        (claim) =>
+          claim.creatorAddress.toLowerCase() === normalizedAccount &&
+          tokenByPool.has(claim.poolId.toLowerCase()),
+      )
+      .map((claim) => [
+        `${claim.transactionHash.toLowerCase()}:${claim.logIndex}`,
+        claim,
+      ]),
+  );
+  const claimedByPool = new Map<string, bigint>();
+  for (const claim of claims.values()) {
+    const key = claim.poolId.toLowerCase();
+    claimedByPool.set(
+      key,
+      (claimedByPool.get(key) ?? 0n) + BigInt(claim.amountWei),
+    );
+  }
+
+  const refreshed = new Map<string, LauncherToken>();
+  ownedTokens.forEach((token, index) => {
+    const result = poolStates[index];
+    if (result?.status !== "success") return;
+    const [creator, , , registered, accrued] = result.result;
+    if (!registered || creator.toLowerCase() !== normalizedAccount) return;
+    const claimed = claimedByPool.get(token.poolId.toLowerCase()) ?? 0n;
+    refreshed.set(token.tokenAddress.toLowerCase(), {
+      ...token,
+      creatorFeesAccruedWei: accrued.toString(),
+      creatorFeesAccruedEth: formatUnits(accrued, 18),
+      creatorFeesGeneratedWei: (claimed + accrued).toString(),
+      creatorFeesGeneratedEth: formatUnits(claimed + accrued, 18),
+    });
+  });
+
+  const scopedModel: ExploreReadModel = {
+    ...input.model,
+    tokens: input.model.tokens
+      .filter(
+        (token) =>
+          token.creatorAddress?.toLowerCase() !== normalizedAccount ||
+          isDirectClassicReward(token),
+      )
+      .map(
+        (token) =>
+          refreshed.get(token.tokenAddress.toLowerCase()) ?? token,
+      ),
+    creatorClaims: [...claims.values()],
+    snapshot: {
+      ...liveSnapshot,
+      ethUsdQuote: input.model.snapshot.ethUsdQuote,
+    },
+  };
+  return buildCreatorProfile(scopedModel, input.account);
+}

--- a/lib/onchain/chart.ts
+++ b/lib/onchain/chart.ts
@@ -69,6 +69,9 @@ export type TokenChartSeries = {
   volumeWei: string;
   volumeEth: string;
   volumeUsdWad?: string;
+  marketCapEthWei?: string;
+  marketCapEth?: string;
+  marketCapUsdWad?: string;
 };
 
 export function isTokenChartRange(
@@ -406,5 +409,10 @@ export async function readTokenChartSeries(input: {
     volumeWei: volumeWei.toString(),
     volumeEth: formatUnits(volumeWei, 18),
     ...(volumeUsdWad === undefined ? {} : { volumeUsdWad }),
+    ...(token.marketCapEthWei
+      ? { marketCapEthWei: token.marketCapEthWei }
+      : {}),
+    ...(token.marketCapEth ? { marketCapEth: token.marketCapEth } : {}),
+    ...(token.fdvUsdWad ? { marketCapUsdWad: token.fdvUsdWad } : {}),
   };
 }

--- a/tests/alchemy-live-market.test.ts
+++ b/tests/alchemy-live-market.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  multicall: vi.fn(),
+}));
+
+vi.mock("viem", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("viem")>();
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({ multicall: mocks.multicall })),
+  };
+});
+
+import { enrichTokensWithAlchemyPoolState } from "../lib/alchemy/live-market.server";
+import type { ReadyOnchainDeployment } from "../lib/onchain/types";
+import type { LauncherToken } from "../lib/tokens";
+
+const deployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: "0x1111111111111111111111111111111111111111",
+  feeHook: "0x2222222222222222222222222222222222222222",
+  launcherRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  deploymentBlock: 1n,
+  stateView: "0x3333333333333333333333333333333333333333",
+  stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/redacted",
+  rpcUrlSecondary: null,
+  confirmations: 12n,
+  logBlockRange: 5_000n,
+} satisfies ReadyOnchainDeployment;
+
+describe("Alchemy live pool market state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("derives current token price and market cap from StateView and reuses the five-second read", async () => {
+    mocks.multicall.mockResolvedValue([
+      {
+        status: "success",
+        result: [1n << 96n, 0, 0, 10_000],
+      },
+    ]);
+    const token = {
+      id: "1:live",
+      name: "Live",
+      symbol: "LIVE",
+      tokenAddress: "0x4444444444444444444444444444444444444444",
+      hookAddress: "0x5555555555555555555555555555555555555555",
+      poolId: `0x${"66".repeat(32)}`,
+      launchedAt: "2026-08-04T00:00:00.000Z",
+      totalSupplyRaw: (1_000n * 10n ** 18n).toString(),
+      tokenDecimals: 18,
+      launchModel: "classic",
+      totalSwapFeeBps: 100,
+      liquidityPath: "meme",
+    } satisfies LauncherToken;
+    const snapshot = {
+      chainId: 1,
+      blockNumber: "25680000",
+      blockHash: `0x${"77".repeat(32)}` as `0x${string}`,
+      confirmations: 0,
+      ethUsdQuote: {
+        feedAddress: "0x8888888888888888888888888888888888888888" as const,
+        roundId: "1",
+        answer: "300000000000",
+        decimals: 8,
+        updatedAt: "2026-08-04T00:00:00.000Z",
+      },
+    };
+
+    const first = await enrichTokensWithAlchemyPoolState({
+      deployment,
+      snapshot,
+      tokens: [token],
+    });
+    const second = await enrichTokensWithAlchemyPoolState({
+      deployment,
+      snapshot,
+      tokens: [token],
+    });
+
+    expect(first[0]).toMatchObject({
+      tokenPriceEthWei: (10n ** 18n).toString(),
+      marketCapEthWei: (1_000n * 10n ** 18n).toString(),
+      fdvUsdWad: (3_000_000n * 10n ** 18n).toString(),
+      indexedValuationBlockNumber: "25680000",
+    });
+    expect(second).toEqual(first);
+    expect(mocks.multicall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/alchemy-profile-live.test.ts
+++ b/tests/alchemy-profile-live.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getBlock: vi.fn(),
+  getLogs: vi.fn(),
+  multicall: vi.fn(),
+}));
+
+vi.mock("viem", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("viem")>();
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({
+      getBlock: mocks.getBlock,
+      getLogs: mocks.getLogs,
+      multicall: mocks.multicall,
+    })),
+  };
+});
+
+import { readAlchemyCreatorProfile } from "../lib/alchemy/profile.server";
+import type {
+  ExploreReadModel,
+  ReadyOnchainDeployment,
+} from "../lib/onchain/types";
+
+const account = "0x1111111111111111111111111111111111111111" as const;
+const poolId = `0x${"22".repeat(32)}` as const;
+const tokenAddress = "0x3333333333333333333333333333333333333333" as const;
+const hookAddress = "0x4444444444444444444444444444444444444444" as const;
+
+const deployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: "0x5555555555555555555555555555555555555555",
+  feeHook: hookAddress,
+  launcherRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  deploymentBlock: 1n,
+  stateView: "0x6666666666666666666666666666666666666666",
+  stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/redacted",
+  rpcUrlSecondary: null,
+  confirmations: 12n,
+  logBlockRange: 5_000n,
+} satisfies ReadyOnchainDeployment;
+
+const token = {
+  id: "1:classic",
+  name: "Classic",
+  symbol: "CLS",
+  tokenAddress,
+  hookAddress,
+  poolId,
+  creatorAddress: account,
+  positionRecipient: account,
+  positionTokenId: "1",
+  launchTransactionHash: `0x${"77".repeat(32)}` as const,
+  launchLogIndex: 0,
+  launchBlockNumber: "90",
+  launchedAt: "2026-08-04T00:00:00.000Z",
+  launchModel: "classic" as const,
+  totalSwapFeeBps: 100,
+  liquidityPath: "meme" as const,
+};
+
+describe("Alchemy live creator profile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("combines current claimable state with confirmed claim history", async () => {
+    mocks.multicall.mockResolvedValue([
+      {
+        status: "success",
+        result: [account, deployment.launcher, 100, true, 5n],
+      },
+    ]);
+    mocks.getLogs.mockResolvedValue([
+      {
+        removed: false,
+        blockNumber: 102n,
+        transactionHash: `0x${"88".repeat(32)}`,
+        transactionIndex: 1,
+        logIndex: 2,
+        args: {
+          poolId,
+          creator: account,
+          recipient: account,
+          caller: account,
+          amount: 10n,
+        },
+      },
+    ]);
+    mocks.getBlock.mockResolvedValue({ timestamp: 1_775_000_000n });
+    const model = {
+      status: "ready",
+      tokens: [token],
+      snapshot: {
+        chainId: 1,
+        blockNumber: "100",
+        blockHash: `0x${"99".repeat(32)}`,
+        confirmations: 12,
+      },
+      launchDiscoverySnapshot: {
+        chainId: 1,
+        blockNumber: "105",
+        blockHash: `0x${"aa".repeat(32)}`,
+        confirmations: 0,
+      },
+      creatorClaims: [],
+      launcherFeesAccruedWei: "0",
+      launcherFeesAccruedEth: "0",
+    } satisfies ExploreReadModel;
+
+    const profile = await readAlchemyCreatorProfile({
+      account,
+      deployment,
+      model,
+    });
+
+    expect(profile.snapshot?.blockNumber).toBe("105");
+    expect(profile.totals).toMatchObject({
+      claimableWei: "5",
+      claimedWei: "10",
+      generatedWei: "15",
+    });
+    expect(profile.claims).toHaveLength(1);
+    expect(profile.pools[0]).toMatchObject({
+      claimableCreatorFeesWei: "5",
+      generatedCreatorFeesWei: "15",
+    });
+  });
+});

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -8,12 +8,21 @@ import type { LauncherToken } from "../lib/tokens";
 
 const mocks = vi.hoisted(() => ({
   enrichTokensWithAlchemyPrices: vi.fn(),
+  enrichTokensWithAlchemyPoolState: vi.fn(),
+  getAlchemyOnchainDeployment: vi.fn(),
   readAlchemyExploreModel: vi.fn(),
+  safeAlchemyError: vi.fn((error) => error),
 }));
 
 vi.mock("../lib/alchemy/explore.server", () => ({
   enrichTokensWithAlchemyPrices: mocks.enrichTokensWithAlchemyPrices,
+  getAlchemyOnchainDeployment: mocks.getAlchemyOnchainDeployment,
   readAlchemyExploreModel: mocks.readAlchemyExploreModel,
+  safeAlchemyError: mocks.safeAlchemyError,
+}));
+
+vi.mock("../lib/alchemy/live-market.server", () => ({
+  enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
 }));
 
 import { GET } from "../app/api/explore/route";
@@ -64,9 +73,13 @@ describe("Explore API Alchemy boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.readAlchemyExploreModel.mockResolvedValue(readyModel());
+    mocks.getAlchemyOnchainDeployment.mockReturnValue({ status: "ready" });
     mocks.enrichTokensWithAlchemyPrices.mockImplementation(async (tokens) => [
       ...tokens,
     ]);
+    mocks.enrichTokensWithAlchemyPoolState.mockImplementation(
+      async ({ tokens }: { tokens: readonly LauncherToken[] }) => [...tokens],
+    );
   });
 
   it.each([

--- a/tests/public-route-handler-wiring.test.ts
+++ b/tests/public-route-handler-wiring.test.ts
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
-  buildCreatorProfile: vi.fn(),
   coordinatePublicRouteRead: vi.fn(),
+  getAlchemyOnchainDeployment: vi.fn(),
   preparePublicRouteRequest: vi.fn(
     async (value: URLSearchParams, headers: Headers, _route: string) => {
       void _route;
@@ -33,7 +33,9 @@ const mocks = vi.hoisted(() => ({
       };
     },
   ),
-  readExploreModel: vi.fn(),
+  readAlchemyCreatorProfile: vi.fn(),
+  readAlchemyExploreModel: vi.fn(),
+  safeAlchemyError: vi.fn((error) => error),
 }));
 
 const fixtures = vi.hoisted(() => {
@@ -60,9 +62,14 @@ vi.mock("../lib/data-pipeline/public-route-readiness.server", () => ({
   publicSnapshotCheckpoint: (value: unknown) => value ?? undefined,
 }));
 
-vi.mock("../lib/onchain", () => ({
-  buildCreatorProfile: mocks.buildCreatorProfile,
-  readExploreModel: mocks.readExploreModel,
+vi.mock("../lib/alchemy/explore.server", () => ({
+  getAlchemyOnchainDeployment: mocks.getAlchemyOnchainDeployment,
+  readAlchemyExploreModel: mocks.readAlchemyExploreModel,
+  safeAlchemyError: mocks.safeAlchemyError,
+}));
+
+vi.mock("../lib/alchemy/profile.server", () => ({
+  readAlchemyCreatorProfile: mocks.readAlchemyCreatorProfile,
 }));
 
 import { GET as creatorProfile } from "../app/api/explore/profile/route";
@@ -76,21 +83,20 @@ describe("public route coordinator wiring", () => {
     vi.clearAllMocks();
   });
 
-  it("wires creator profile through the aggregate reviewed scope", async () => {
+  it("reads creator profile directly from the current Alchemy model", async () => {
     const snapshot = {
       blockNumber: "25650000",
       blockHash: `0x${"33".repeat(32)}`,
     };
-    mocks.readExploreModel.mockResolvedValue({ status: "ready", snapshot });
-    mocks.buildCreatorProfile.mockReturnValue({
+    const model = { status: "ready", snapshot };
+    const deployment = { status: "ready", chainId: 1 };
+    mocks.readAlchemyExploreModel.mockResolvedValue(model);
+    mocks.getAlchemyOnchainDeployment.mockReturnValue(deployment);
+    mocks.readAlchemyCreatorProfile.mockResolvedValue({
       status: "ready",
       account: ACCOUNT,
       tokens: [],
     });
-    mocks.coordinatePublicRouteRead.mockImplementation(
-      async (input: { legacy: () => Promise<{ response: Response }> }) =>
-        (await input.legacy()).response,
-    );
 
     const response = await creatorProfile(
       new NextRequest(
@@ -99,14 +105,16 @@ describe("public route coordinator wiring", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.coordinatePublicRouteRead).toHaveBeenCalledWith(
-      expect.objectContaining({
-        route: "creator-profile",
-        scope: fixtures.discoveryScope,
-      }),
-    );
+    expect(mocks.readAlchemyCreatorProfile).toHaveBeenCalledWith({
+      account: ACCOUNT,
+      deployment,
+      model,
+    });
     expect(response.headers.get("Cache-Control")).toBe(
       "private, max-age=0, s-maxage=15",
+    );
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
+      "alchemy",
     );
   });
 

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -6,6 +6,7 @@ vi.mock("server-only", () => ({}));
 const mocks = vi.hoisted(() => ({
   getAlchemyOnchainDeployment: vi.fn(),
   isTokenChartRange: vi.fn(),
+  enrichTokensWithAlchemyPoolState: vi.fn(),
   readAlchemyExploreModel: vi.fn(),
   readTokenChartSeries: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
@@ -20,6 +21,10 @@ vi.mock("../lib/alchemy/explore.server", () => ({
 vi.mock("../lib/onchain/chart", () => ({
   isTokenChartRange: mocks.isTokenChartRange,
   readTokenChartSeries: mocks.readTokenChartSeries,
+}));
+
+vi.mock("../lib/alchemy/live-market.server", () => ({
+  enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
 }));
 
 import { GET } from "../app/api/explore/token/chart/route";
@@ -49,6 +54,11 @@ const snapshot = {
   confirmations: 12,
   ethUsdQuote: { answer: "350000000000", decimals: 8 },
 } as const;
+const launchDiscoverySnapshot = {
+  ...snapshot,
+  blockNumber: "25630005",
+  blockHash: `0x${"55".repeat(32)}`,
+} as const;
 
 describe("token chart Alchemy API", () => {
   beforeEach(() => {
@@ -57,10 +67,12 @@ describe("token chart Alchemy API", () => {
       ["1h", "1d", "1w", "all"].includes(range),
     );
     mocks.getAlchemyOnchainDeployment.mockReturnValue(deployment);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([token]);
     mocks.readAlchemyExploreModel.mockResolvedValue({
       status: "ready",
       tokens: [token],
       snapshot,
+      launchDiscoverySnapshot,
       creatorClaims: [],
       launcherFeesAccruedWei: "0",
       launcherFeesAccruedEth: "0",
@@ -89,7 +101,7 @@ describe("token chart Alchemy API", () => {
       expect.objectContaining({
         deployment,
         token,
-        snapshotBlock: 25_630_000n,
+        snapshotBlock: 25_630_005n,
         range: "1h",
       }),
     );

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -8,12 +8,21 @@ import type { LauncherToken } from "../lib/tokens";
 
 const mocks = vi.hoisted(() => ({
   enrichTokensWithAlchemyPrices: vi.fn(),
+  enrichTokensWithAlchemyPoolState: vi.fn(),
+  getAlchemyOnchainDeployment: vi.fn(),
   readAlchemyExploreModel: vi.fn(),
+  safeAlchemyError: vi.fn((error) => error),
 }));
 
 vi.mock("../lib/alchemy/explore.server", () => ({
   enrichTokensWithAlchemyPrices: mocks.enrichTokensWithAlchemyPrices,
+  getAlchemyOnchainDeployment: mocks.getAlchemyOnchainDeployment,
   readAlchemyExploreModel: mocks.readAlchemyExploreModel,
+  safeAlchemyError: mocks.safeAlchemyError,
+}));
+
+vi.mock("../lib/alchemy/live-market.server", () => ({
+  enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
 }));
 
 import { GET } from "../app/api/explore/token/route";
@@ -59,6 +68,10 @@ const launchDiscoverySnapshot = {
 describe("token detail Alchemy read", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getAlchemyOnchainDeployment.mockReturnValue({ status: "ready" });
+    mocks.enrichTokensWithAlchemyPoolState.mockImplementation(
+      async ({ tokens }: { tokens: readonly LauncherToken[] }) => [...tokens],
+    );
   });
 
   it("price-enriches only the canonical token from the Alchemy read model", async () => {


### PR DESCRIPTION
## What changed

- reads current Uniswap v4 pool state through the existing Alchemy RPC for top/newest lists, token detail, and charts
- starts token detail and the default 1D chart together, retains visible chart data during five-second refreshes, and removes the animated loading bar
- refreshes Classic creator claimable and claimed state from Alchemy, incrementally follows confirmed claim logs, and keeps confirmed reward history visible in Profile
- refreshes Profile sources every five seconds while retaining the last ready state during transient read failures

## Why

The chart route was pinned to the durable registry snapshot, so newly launched tokens could return empty history and stale market caps. Profile also used the legacy coordinated model and did not refresh automatically.

## Validation

- 1,884 tests passed; 7 skipped
- TypeScript passed
- ESLint passed
- production build passed
- git diff check passed