### PR TITLE
Polish live token and profile experience

### DIFF
--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -136,22 +136,23 @@
   background: var(--surface-soft);
   border: 0;
   border-radius: 20px;
-  box-shadow: 0 1px 0 color-mix(in srgb, white 28%, transparent);
-  outline: 1px solid oklch(0 0 0 / 0.1);
-  outline-offset: -1px;
+  box-shadow: none;
   overflow: hidden;
   position: relative;
-  transition: outline-color 180ms ease;
   width: 100%;
 }
 
 :global(html[data-theme="dark"]) .runnerArt {
-  outline-color: oklch(1 0 0 / 0.1);
+  background: var(--surface-soft);
 }
 
 .runnerImage {
+  display: block;
+  height: calc(100% + 2px) !important;
+  inset: -1px !important;
   object-fit: cover;
   transition: transform 220ms var(--ease-out);
+  width: calc(100% + 2px) !important;
 }
 
 .runnerBody {
@@ -299,10 +300,6 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .runnerCard:hover .runnerArt {
-    outline-color: color-mix(in srgb, var(--text) 22%, transparent);
-  }
-
   .runnerCard:hover .runnerImage {
     transform: scale(1.012);
   }

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -286,6 +286,40 @@ type PendingExploreRequest = {
 };
 
 const pendingExploreRequests = new Map<string, PendingExploreRequest>();
+const resolvedExplorePayloads = new Map<
+  string,
+  Readonly<{ payload: ExplorePayload; updatedAt: number }>
+>();
+const RESOLVED_EXPLORE_PAYLOAD_TTL_MS = 4_500;
+const MAX_RESOLVED_EXPLORE_PAYLOADS = 24;
+
+function readResolvedExplorePayload(contentKey: string) {
+  const cached = resolvedExplorePayloads.get(contentKey);
+  if (!cached) return null;
+  if (Date.now() - cached.updatedAt >= RESOLVED_EXPLORE_PAYLOAD_TTL_MS) {
+    resolvedExplorePayloads.delete(contentKey);
+    return null;
+  }
+  resolvedExplorePayloads.delete(contentKey);
+  resolvedExplorePayloads.set(contentKey, cached);
+  return cached.payload;
+}
+
+function cacheResolvedExplorePayload(
+  contentKey: string,
+  payload: ExplorePayload,
+) {
+  resolvedExplorePayloads.delete(contentKey);
+  resolvedExplorePayloads.set(contentKey, {
+    payload,
+    updatedAt: Date.now(),
+  });
+  while (resolvedExplorePayloads.size > MAX_RESOLVED_EXPLORE_PAYLOADS) {
+    const oldestKey = resolvedExplorePayloads.keys().next().value;
+    if (oldestKey === undefined) return;
+    resolvedExplorePayloads.delete(oldestKey);
+  }
+}
 
 async function fetchExplorePayload(
   search: URLSearchParams,
@@ -306,6 +340,8 @@ export function loadExplorePayload(
   contentKey: string,
   search: URLSearchParams,
 ) {
+  const resolved = readResolvedExplorePayload(contentKey);
+  if (resolved) return Promise.resolve(resolved);
   const pendingRequest = pendingExploreRequests.get(contentKey);
   if (pendingRequest) return pendingRequest.promise;
 
@@ -317,7 +353,9 @@ export function loadExplorePayload(
   }, EXPLORE_REQUEST_TIMEOUT_MS);
   const request = (async (): Promise<ExplorePayload> => {
     try {
-      return await fetchExplorePayload(search, controller.signal);
+      const payload = await fetchExplorePayload(search, controller.signal);
+      cacheResolvedExplorePayload(contentKey, payload);
+      return payload;
     } catch (error) {
       if (timedOut) {
         throw new Error("Tokens took too long to respond");
@@ -630,7 +668,6 @@ export function ExploreView() {
   const [currentPage, setCurrentPage] = useState(1);
   const [retryKey, setRetryKey] = useState(0);
   const refreshKey = useLiveDataRefresh({ enabled: !preview });
-  const [state, setState] = useState<ExploreState>({ phase: "loading" });
   const activeExploreContentKey = useRef<string | null>(null);
   const modelDatasetCache = useRef<{
     key: string;
@@ -642,6 +679,17 @@ export function ExploreView() {
   const modelDatasetKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}\u0000${refreshKey}`;
   const activeRequestContentKey =
     modelFilter === "all" ? contentKey : modelDatasetKey;
+  const [state, setState] = useState<ExploreState>(() => {
+    const cached = readResolvedExplorePayload(activeRequestContentKey);
+    return cached
+      ? {
+          phase: "ready",
+          payload: cached,
+          requestKey,
+          contentKey,
+        }
+      : { phase: "loading" };
+  });
 
   useEffect(
     () => () => {
@@ -954,9 +1002,8 @@ export function ExploreView() {
                       token.usesFallbackImage ? "" : `${token.name} artwork`
                     }
                     fill
-                    loading={
-                      index < EXPLORE_TOKENS_PER_PAGE ? "eager" : "lazy"
-                    }
+                    loading={index < 3 ? "eager" : "lazy"}
+                    priority={index < 3}
                     sizes="(max-width: 700px) calc(100vw - 28px), (max-width: 1040px) 46vw, 31vw"
                     unoptimized={!canOptimizeTokenImage(imageSource)}
                   />

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -216,6 +216,10 @@ export function LaunchModelPicker({
               <span />
               <span />
               <span />
+              <span />
+              <span />
+              <span />
+              <span />
             </span>
           </span>
 

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -76,8 +76,6 @@
   box-shadow: none;
   height: auto;
   isolation: isolate;
-  outline: 1px solid rgb(0 0 0 / 0.1);
-  outline-offset: -1px;
   overflow: hidden;
   position: relative;
 }
@@ -99,7 +97,6 @@
 
 :global(html[data-theme="dark"]) .modelArt {
   box-shadow: none;
-  outline-color: rgb(255 255 255 / 0.1);
 }
 
 .classicArt::before {
@@ -116,9 +113,13 @@
 }
 
 .artImage {
+  display: block;
+  height: calc(100% + 2px) !important;
+  inset: -1px !important;
   object-fit: cover;
   object-position: center;
   transform: scale(1.0012);
+  width: calc(100% + 2px) !important;
 }
 
 .classicArt .artImage {
@@ -184,7 +185,8 @@
     transparent 58%
   );
   height: 15px;
-  opacity: 0.11;
+  filter: drop-shadow(0 0 5px rgb(255 224 176 / 0.65));
+  opacity: 0.2;
   position: absolute;
   transform: rotate(var(--twinkle-rotation)) scale(0.72);
   width: 15px;
@@ -260,17 +262,49 @@
   width: 9px;
 }
 
+.customSparkles > span:nth-child(7) {
+  --twinkle-rotation: 21deg;
+  height: 12px;
+  left: 11%;
+  top: 58%;
+  width: 12px;
+}
+
+.customSparkles > span:nth-child(8) {
+  --twinkle-rotation: -8deg;
+  height: 8px;
+  right: 9%;
+  top: 49%;
+  width: 8px;
+}
+
+.customSparkles > span:nth-child(9) {
+  --twinkle-rotation: 12deg;
+  bottom: 9%;
+  height: 10px;
+  left: 49%;
+  width: 10px;
+}
+
+.customSparkles > span:nth-child(10) {
+  --twinkle-rotation: -22deg;
+  height: 7px;
+  right: 43%;
+  top: 8%;
+  width: 7px;
+}
+
 @keyframes custom-star-sparkle {
   0%,
   68%,
   100% {
-    opacity: 0.09;
-    transform: rotate(var(--twinkle-rotation)) scale(0.72);
+    opacity: 0.14;
+    transform: rotate(var(--twinkle-rotation)) scale(0.66);
   }
 
   76% {
-    opacity: 0.9;
-    transform: rotate(var(--twinkle-rotation)) scale(1.08);
+    opacity: 1;
+    transform: rotate(var(--twinkle-rotation)) scale(1.28);
   }
 
   82% {
@@ -326,6 +360,26 @@
   .customSparkles > span:nth-child(6) {
     animation-delay: -1.2s;
     animation-duration: 8.6s;
+  }
+
+  .customSparkles > span:nth-child(7) {
+    animation-delay: -5.8s;
+    animation-duration: 7.1s;
+  }
+
+  .customSparkles > span:nth-child(8) {
+    animation-delay: -2.9s;
+    animation-duration: 6.6s;
+  }
+
+  .customSparkles > span:nth-child(9) {
+    animation-delay: -4.1s;
+    animation-duration: 8.3s;
+  }
+
+  .customSparkles > span:nth-child(10) {
+    animation-delay: -1.8s;
+    animation-duration: 7.5s;
   }
 }
 
@@ -402,14 +456,13 @@
 }
 
 .modelAction {
-  border-top: 1px solid transparent;
   color: var(--accent-strong);
   font-size: 14px;
   font-weight: 650;
   gap: 8px;
-  margin-top: 18px;
-  min-height: 48px;
-  padding-top: 13px;
+  margin-top: 8px;
+  min-height: 40px;
+  padding-top: 2px;
   width: fit-content;
 }
 
@@ -422,10 +475,6 @@
     border-color: transparent;
     box-shadow: none;
     transform: none;
-  }
-
-  .modelCard:hover .modelArt {
-    outline-color: color-mix(in srgb, var(--text) 18%, transparent);
   }
 
   .modelCard:hover .modelAction svg {

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -466,14 +466,13 @@
 }
 
 .feeChart {
-  align-items: center;
   background: color-mix(in srgb, var(--surface-soft) 48%, transparent);
   border-radius: 20px;
-  display: flex;
+  display: grid;
   flex: none;
-  justify-content: center;
+  grid-template-rows: minmax(150px, 1fr) auto;
   margin: 20px 0 0;
-  min-height: 164px;
+  min-height: 226px;
   min-width: 0;
   overflow: hidden;
   position: relative;
@@ -495,6 +494,71 @@
   inset: 0;
   opacity: 0.48;
   position: absolute;
+}
+
+.feePlot {
+  align-self: stretch;
+  grid-column: 1;
+  grid-row: 1;
+  height: 100%;
+  min-height: 150px;
+  overflow: visible;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+
+.feeArea {
+  opacity: 0.9;
+}
+
+.feeLine {
+  fill: none;
+  stroke: var(--accent);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.feeEndPoint {
+  fill: var(--canvas);
+  stroke: var(--accent);
+  stroke-width: 2.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.feeChartTotal {
+  display: grid;
+  gap: 2px;
+  grid-column: 1;
+  grid-row: 1;
+  left: 16px;
+  pointer-events: none;
+  position: absolute;
+  top: 13px;
+  z-index: 2;
+}
+
+.feeChartTotal span,
+.chartCaption {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.feeChartTotal strong {
+  color: var(--text);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 680;
+}
+
+.chartCaption {
+  grid-column: 1;
+  grid-row: 2;
+  padding: 0 16px 14px;
+  position: relative;
+  z-index: 1;
 }
 
 .chartEmpty {
@@ -521,8 +585,11 @@
 .claimHistory {
   display: grid;
   gap: 7px;
-  padding: 16px;
+  grid-column: 1;
+  grid-row: 2;
+  padding: 0 14px 14px;
   position: relative;
+  z-index: 1;
   width: 100%;
 }
 
@@ -1142,16 +1209,6 @@
   min-width: 0;
 }
 
-.claimDialogHeader > div > span {
-  color: var(--muted);
-  display: block;
-  font-size: 10px;
-  font-weight: 680;
-  letter-spacing: 0.08em;
-  margin-block-end: 5px;
-  text-transform: uppercase;
-}
-
 .claimDialogHeader h3 {
   font-size: 22px;
   font-weight: 620;
@@ -1184,19 +1241,10 @@
   width: 44px;
 }
 
-.claimDialogIntro {
-  color: var(--muted);
-  font-size: 12px;
-  line-height: 1.5;
-  margin-block-start: 13px;
-  max-width: 350px;
-  text-wrap: pretty;
-}
-
 .claimDialogGroups {
   display: grid;
   gap: 9px;
-  margin-block-start: 17px;
+  margin-block-start: 13px;
 }
 
 .claimDialogGroup {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -2,10 +2,11 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { formatUnits, type Hex } from "viem";
+import { formatUnits, parseUnits, type Hex } from "viem";
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -92,6 +93,35 @@ const deepReleaseAvailable = false;
 const deepV3ReleaseAvailable = false;
 const stockPairedReleaseAvailable =
   isConfiguredStockPairedRewardsReady();
+const creatorProfileCache = new Map<
+  string,
+  Readonly<{ data: ProfileOnchainData; updatedAt: number }>
+>();
+const CREATOR_PROFILE_CACHE_TTL_MS = 30_000;
+const MAX_CREATOR_PROFILE_CACHE_ENTRIES = 8;
+
+function readCachedCreatorProfile(account: string) {
+  const key = account.toLowerCase();
+  const cached = creatorProfileCache.get(key);
+  if (!cached) return null;
+  if (Date.now() - cached.updatedAt >= CREATOR_PROFILE_CACHE_TTL_MS) {
+    creatorProfileCache.delete(key);
+    return null;
+  }
+  return cached.data;
+}
+
+function cacheCreatorProfile(data: ProfileOnchainData) {
+  if (!data.account || data.status !== "ready") return;
+  const key = data.account.toLowerCase();
+  creatorProfileCache.delete(key);
+  creatorProfileCache.set(key, { data, updatedAt: Date.now() });
+  while (creatorProfileCache.size > MAX_CREATOR_PROFILE_CACHE_ENTRIES) {
+    const oldestKey = creatorProfileCache.keys().next().value;
+    if (oldestKey === undefined) return;
+    creatorProfileCache.delete(oldestKey);
+  }
+}
 
 type ProfileClaimActionState = {
   account: string;
@@ -886,6 +916,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     void fetchCreatorProfile(account, controller.signal)
       .then((data) => {
         if (!controller.signal.aborted) {
+          cacheCreatorProfile(data);
           const reflectedTransactions =
             reflectedConfirmedProfileTransactions(
               confirmedTransactions,
@@ -1185,8 +1216,14 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     }
   }
 
+  const cachedOnchainData =
+    !onchainData && account ? readCachedCreatorProfile(account) : null;
+  const remoteOrCachedOnchainData =
+    account && isProfileDataForAccount(remoteOnchainData, account)
+      ? remoteOnchainData
+      : (cachedOnchainData ?? remoteOnchainData);
   const requestedOnchainData = withoutClosedDeepProfileData(
-    onchainData ?? remoteOnchainData,
+    onchainData ?? remoteOrCachedOnchainData,
   );
   const scopedOnchainData = account
     ? isProfileDataForAccount(requestedOnchainData, account)
@@ -3218,7 +3255,13 @@ function FeeEarningsPanel({
 }) {
   const claimHistory = activity
     .filter((item) => /fees claimed/iu.test(item.label))
-    .slice(0, 4);
+    .slice(0, 3);
+  const chart = buildFeeEarningsChart(
+    activity,
+    nativeClaimed,
+    nativeClaimable,
+  );
+  const gradientId = useId().replaceAll(":", "");
 
   return (
     <section
@@ -3240,17 +3283,66 @@ function FeeEarningsPanel({
         ) : null}
       </div>
 
-      <figure className={styles.feeChart}>
+      <figure
+        className={styles.feeChart}
+        aria-label={`Fee earnings history. ${formatWei(nativeClaimed + nativeClaimable)} earned in total.`}
+      >
         <div className={styles.chartGrid} aria-hidden="true" />
-        {claimHistory.length ? (
-          <figcaption className={styles.claimHistory}>
-            {claimHistory.map((item) => (
-              <Link href={item.href} key={item.id}>
-                <span>{item.detail}</span>
-                <time>{item.occurredAt}</time>
-              </Link>
-            ))}
-          </figcaption>
+        {chart ? (
+          <>
+            <svg
+              className={styles.feePlot}
+              viewBox="0 0 620 150"
+              preserveAspectRatio="none"
+              role="img"
+              aria-label={`Cumulative fee earnings ending at ${formatWei(chart.totalWei)}`}
+            >
+              <defs>
+                <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+                  <stop
+                    offset="0%"
+                    stopColor="var(--accent)"
+                    stopOpacity="0.24"
+                  />
+                  <stop
+                    offset="100%"
+                    stopColor="var(--accent)"
+                    stopOpacity="0"
+                  />
+                </linearGradient>
+              </defs>
+              <path
+                className={styles.feeArea}
+                d={chart.areaPath}
+                fill={`url(#${gradientId})`}
+              />
+              <path className={styles.feeLine} d={chart.linePath} />
+              <circle
+                className={styles.feeEndPoint}
+                cx={chart.points.at(-1)?.x}
+                cy={chart.points.at(-1)?.y}
+                r="4.5"
+              />
+            </svg>
+            <div className={styles.feeChartTotal} aria-hidden="true">
+              <span>Total earned</span>
+              <strong>{formatWei(chart.totalWei)}</strong>
+            </div>
+            {claimHistory.length ? (
+              <figcaption className={styles.claimHistory}>
+                {claimHistory.map((item) => (
+                  <Link href={item.href} key={item.id}>
+                    <span>{item.detail}</span>
+                    <time>{item.occurredAt}</time>
+                  </Link>
+                ))}
+              </figcaption>
+            ) : (
+              <figcaption className={styles.chartCaption}>
+                Current unclaimed earnings
+              </figcaption>
+            )}
+          </>
         ) : (
           <figcaption className={styles.chartEmpty}>
             <strong>No claims yet.</strong>
@@ -3260,6 +3352,81 @@ function FeeEarningsPanel({
       </figure>
     </section>
   );
+}
+
+type FeeEarningsChartPoint = {
+  x: number;
+  y: number;
+  valueWei: bigint;
+};
+
+export function parseClaimedFeeWei(detail: string) {
+  const match = detail.trim().match(/^([0-9]+(?:\.[0-9]+)?)\s+ETH\b/iu);
+  if (!match) return null;
+  try {
+    return parseUnits(match[1], 18);
+  } catch {
+    return null;
+  }
+}
+
+export function buildFeeEarningsChart(
+  activity: readonly ProfileActivity[],
+  nativeClaimed: bigint,
+  nativeClaimable: bigint,
+) {
+  const claims = activity
+    .filter((item) => /fees claimed/iu.test(item.label))
+    .map((item) => parseClaimedFeeWei(item.detail))
+    .filter((value): value is bigint => value !== null)
+    .reverse();
+  const historyTotal = claims.reduce((total, value) => total + value, 0n);
+  const startingTotal =
+    nativeClaimed > historyTotal ? nativeClaimed - historyTotal : 0n;
+  const values = [startingTotal];
+  let cumulative = startingTotal;
+  for (const claim of claims) {
+    cumulative += claim;
+    values.push(cumulative);
+  }
+
+  const totalWei = nativeClaimed + nativeClaimable;
+  if (values.at(-1) !== totalWei || values.length === 1) {
+    values.push(totalWei);
+  }
+  if (totalWei <= 0n || values.length < 2) return null;
+
+  const width = 620;
+  const height = 150;
+  const left = 8;
+  const right = width - 8;
+  const top = 12;
+  const bottom = height - 10;
+  const maximum = values.reduce(
+    (current, value) => (value > current ? value : current),
+    1n,
+  );
+  const points: FeeEarningsChartPoint[] = values.map((valueWei, index) => ({
+    valueWei,
+    x: left + (index / (values.length - 1)) * (right - left),
+    y:
+      bottom -
+      Number((valueWei * 1_000_000n) / maximum) /
+        1_000_000 *
+        (bottom - top),
+  }));
+  const linePath = points
+    .map((point, index) =>
+      `${index === 0 ? "M" : "L"}${point.x.toFixed(2)},${point.y.toFixed(2)}`,
+    )
+    .join(" ");
+
+  return {
+    areaPath: `${linePath} L${right},${height} L${left},${height} Z`,
+    linePath,
+    points,
+    totalWei,
+  };
 }
 
 function transactionHref(chainId: number | undefined, hash: Hex) {
@@ -3341,10 +3508,6 @@ function ProfileClaimDialog({
   const dialogRef = useRef<HTMLDialogElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const titleId = `${dialogId}-title`;
-  const descriptionId = `${dialogId}-description`;
-  const hasAlternativeReceiptPath = groups.some(
-    (group) => group.actions.length > 1,
-  );
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -3364,7 +3527,6 @@ function ProfileClaimDialog({
       id={dialogId}
       className={styles.claimDialog}
       aria-labelledby={titleId}
-      aria-describedby={descriptionId}
       onCancel={(event) => {
         event.preventDefault();
         onClose();
@@ -3377,7 +3539,6 @@ function ProfileClaimDialog({
       <div className={styles.claimDialogSurface}>
         <header className={styles.claimDialogHeader}>
           <div>
-            <span>Claimable rewards</span>
             <h3 id={titleId}>
               {tokenName} <small>${tokenSymbol}</small>
             </h3>
@@ -3392,12 +3553,6 @@ function ProfileClaimDialog({
             <span aria-hidden="true">×</span>
           </button>
         </header>
-
-        <p id={descriptionId} className={styles.claimDialogIntro}>
-          {hasAlternativeReceiptPath
-            ? "Choose one reward. Stock-Paired receipt choices are alternatives, not extra rewards."
-            : "Choose the reward you want to claim."}
-        </p>
 
         <div className={styles.claimDialogGroups}>
           {groups.map((group) => (

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -1177,9 +1177,8 @@ function TokenDetailContent({
               onVolumeChange={setChartVolume}
               onMarketCapChange={setChartMarketCap}
             />
+            <MetricGrid metrics={metrics} />
           </div>
-
-          <MetricGrid metrics={metrics} />
 
           {token.launchModel === "deep" &&
           token.growthTargetNativeWei &&

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -33,11 +33,10 @@
 .layout {
   align-items: start;
   display: grid;
-  gap: 16px 22px;
+  gap: 11px 22px;
   grid-template-areas:
     "identity identity"
     "chart trade"
-    "metrics trade"
     "deep community"
     "details community";
   grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
@@ -232,18 +231,18 @@
 }
 
 .marketChart {
+  display: grid;
+  gap: 9px;
   grid-area: chart;
   min-width: 0;
 }
 
 .metrics {
-  border-bottom: 1px solid var(--border);
   display: grid;
-  gap: 14px;
-  grid-area: metrics;
+  gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
   margin: 0;
-  padding: 15px 2px 17px;
+  padding: 3px 2px 8px;
 }
 
 .metric {
@@ -333,15 +332,14 @@
   gap: 0 32px;
   grid-area: details;
   grid-template-columns: minmax(180px, 0.58fr) minmax(0, 1.42fr);
-  margin-top: 28px;
+  margin-top: 18px;
 }
 
 .projectPanel {
-  border-bottom: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   min-height: 0;
-  padding: 24px 0 26px;
+  padding: 18px 0 20px;
 }
 
 .projectPanelMeta {
@@ -382,9 +380,8 @@
 }
 
 .projectFacts > div {
-  border-left: 1px solid var(--border);
   min-width: 0;
-  padding: 0 14px;
+  padding: 0 12px;
 }
 
 .projectFacts > div:first-child {
@@ -787,8 +784,6 @@
 }
 
 .tradeFacts {
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  border-top: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   margin: 13px 0 0;
@@ -805,7 +800,6 @@
 }
 
 .tradeFacts > div + div {
-  border-left: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   padding-left: 14px;
 }
 
@@ -972,7 +966,6 @@
 
 .reviewDetails > div {
   align-items: center;
-  border-bottom: 1px solid var(--border);
   display: flex;
   gap: 18px;
   justify-content: space-between;
@@ -1178,7 +1171,6 @@
     grid-template-areas:
       "identity"
       "chart"
-      "metrics"
       "trade"
       "community"
       "deep"
@@ -1276,9 +1268,9 @@
 
   .metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 16px 12px;
+    gap: 12px;
     margin-top: 0;
-    padding-block: 15px;
+    padding-block: 4px 9px;
   }
 
   .metric {
@@ -1295,7 +1287,7 @@
 
   .projectInformation {
     grid-template-columns: 1fr;
-    margin-top: 22px;
+    margin-top: 16px;
   }
 
   .projectPanelWide {
@@ -1304,7 +1296,7 @@
 
   .projectPanel {
     min-height: 0;
-    padding: 26px 0;
+    padding: 20px 0;
   }
 
   .projectFacts {
@@ -1317,7 +1309,6 @@
   }
 
   .projectFacts > div:nth-child(n + 3) {
-    border-top: 1px solid var(--border);
     margin-top: 14px;
     padding-top: 14px;
   }

--- a/components/token-price-chart.module.css
+++ b/components/token-price-chart.module.css
@@ -93,6 +93,12 @@
   width: 100%;
 }
 
+.plot:focus-visible {
+  border-radius: 12px;
+  outline: 2px solid var(--focus);
+  outline-offset: 4px;
+}
+
 .plot svg {
   overflow: visible;
 }
@@ -117,6 +123,68 @@
   stroke-linejoin: round;
   stroke-width: 2.45;
   vector-effect: non-scaling-stroke;
+}
+
+.hoverGuide {
+  stroke: color-mix(in srgb, var(--text) 28%, transparent);
+  stroke-dasharray: 3 4;
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.hoverDot {
+  fill: var(--canvas);
+  stroke: var(--accent);
+  stroke-width: 2.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.tooltip {
+  background: color-mix(in srgb, var(--glass-96) 95%, var(--canvas));
+  border: 1px solid var(--panel-border-soft);
+  border-radius: 11px;
+  box-shadow: 0 10px 28px color-mix(in srgb, black 14%, transparent);
+  display: grid;
+  gap: 2px;
+  min-width: max-content;
+  padding: 7px 9px;
+  pointer-events: none;
+  position: absolute;
+  transform: translate(-50%, calc(-100% - 11px));
+  z-index: 2;
+}
+
+.tooltip[data-horizontal-edge="start"] {
+  transform: translate(0, calc(-100% - 11px));
+}
+
+.tooltip[data-horizontal-edge="end"] {
+  transform: translate(-100%, calc(-100% - 11px));
+}
+
+.tooltip[data-vertical="below"] {
+  transform: translate(-50%, 11px);
+}
+
+.tooltip[data-horizontal-edge="start"][data-vertical="below"] {
+  transform: translate(0, 11px);
+}
+
+.tooltip[data-horizontal-edge="end"][data-vertical="below"] {
+  transform: translate(-100%, 11px);
+}
+
+.tooltip strong {
+  color: var(--text);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 680;
+}
+
+.tooltip span {
+  color: var(--muted);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
 }
 
 .placeholder {

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -6,6 +6,8 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
+  type PointerEvent,
 } from "react";
 
 import { useLiveDataRefresh } from "@/components/use-live-data-refresh";
@@ -235,6 +237,31 @@ function linePath(points: PlottedPoint[]) {
   );
 }
 
+export function nearestChartPointIndex(
+  clientX: number,
+  boundsLeft: number,
+  boundsWidth: number,
+  pointCount: number,
+) {
+  if (
+    !Number.isFinite(clientX) ||
+    !Number.isFinite(boundsLeft) ||
+    !Number.isFinite(boundsWidth) ||
+    boundsWidth <= 0 ||
+    !Number.isSafeInteger(pointCount) ||
+    pointCount < 1
+  ) {
+    return 0;
+  }
+  const pointerX =
+    ((clientX - boundsLeft) / boundsWidth) * VIEWBOX_WIDTH;
+  const normalized = Math.min(
+    1,
+    Math.max(0, (pointerX - PLOT_LEFT) / (PLOT_RIGHT - PLOT_LEFT)),
+  );
+  return Math.round(normalized * (pointCount - 1));
+}
+
 export function TokenPriceChart({
   tokenAddress,
   tokenName,
@@ -256,6 +283,9 @@ export function TokenPriceChart({
     failed: boolean;
   } | null>(null);
   const [range, setRange] = useState<ChartRange>("1d");
+  const [activePointIndex, setActivePointIndex] = useState<number | null>(
+    null,
+  );
   const refreshTaskRef = useRef<SerializedChartRefresh | null>(null);
   const refreshKey = useLiveDataRefresh({
     enabled: launchModel !== "stock-paired" && !preview,
@@ -376,6 +406,11 @@ export function TokenPriceChart({
   }, [payload]);
 
   const emptyMessage = getPriceHistoryEmptyMessage(launchModel, failed);
+  const activePoint =
+    chart && activePointIndex !== null
+      ? chart.points[Math.min(activePointIndex, chart.points.length - 1)]
+      : null;
+  const displayedPrice = activePoint?.value ?? chart?.current;
   const chartStatus =
     !payload && !failed
       ? "Loading price history"
@@ -417,6 +452,44 @@ export function TokenPriceChart({
     });
   }, [onMarketCapChange, payload]);
 
+  function inspectPointer(event: PointerEvent<HTMLDivElement>) {
+    if (!chart) return;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    setActivePointIndex(
+      nearestChartPointIndex(
+        event.clientX,
+        bounds.left,
+        bounds.width,
+        chart.points.length,
+      ),
+    );
+  }
+
+  function inspectKeyboard(event: KeyboardEvent<HTMLDivElement>) {
+    if (!chart) return;
+    const lastIndex = chart.points.length - 1;
+    const current = activePointIndex ?? lastIndex;
+    let next: number | null = null;
+
+    if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+      next = Math.max(0, current - 1);
+    } else if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+      next = Math.min(lastIndex, current + 1);
+    } else if (event.key === "Home") {
+      next = 0;
+    } else if (event.key === "End") {
+      next = lastIndex;
+    } else if (event.key === "Escape") {
+      setActivePointIndex(null);
+      return;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    setActivePointIndex(next);
+  }
+
   if (
     !shouldRenderPriceHistory({
       loading,
@@ -445,8 +518,8 @@ export function TokenPriceChart({
         <div>
           <p className={styles.eyebrow}>Price</p>
           <p className={styles.value}>
-            {chart
-              ? formatPrice(chart.current, chart.unit)
+            {chart && displayedPrice !== undefined
+              ? formatPrice(displayedPrice, chart.unit)
               : !loading || launchModel === "stock-paired"
                 ? "Unavailable"
                 : "—"}
@@ -467,6 +540,7 @@ export function TokenPriceChart({
                       ? null
                       : { range: option.value, pending: true },
                   );
+                  setActivePointIndex(null);
                   setRange(option.value);
                 }}
               >
@@ -480,7 +554,16 @@ export function TokenPriceChart({
       {loading ? (
         <div className={`${styles.plot} ${styles.waitingPlot}`} aria-hidden="true" />
       ) : chart ? (
-        <div className={styles.plot}>
+        <div
+          className={styles.plot}
+          tabIndex={0}
+          aria-label={`${tokenName} interactive price chart. Move the pointer or use arrow keys to inspect exact prices.`}
+          onBlur={() => setActivePointIndex(null)}
+          onKeyDown={inspectKeyboard}
+          onPointerEnter={inspectPointer}
+          onPointerMove={inspectPointer}
+          onPointerLeave={() => setActivePointIndex(null)}
+        >
           <svg
             viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
             preserveAspectRatio="none"
@@ -516,7 +599,50 @@ export function TokenPriceChart({
               fill={`url(#${gradientId})`}
             />
             <path className={styles.line} d={chart.path} />
+            {activePoint ? (
+              <>
+                <line
+                  className={styles.hoverGuide}
+                  x1={activePoint.x}
+                  x2={activePoint.x}
+                  y1={PLOT_TOP}
+                  y2={PLOT_BOTTOM}
+                />
+                <circle
+                  className={styles.hoverDot}
+                  cx={activePoint.x}
+                  cy={activePoint.y}
+                  r="4.5"
+                />
+              </>
+            ) : null}
           </svg>
+          {activePoint ? (
+            <div
+              className={styles.tooltip}
+              data-horizontal-edge={
+                activePointIndex === 0
+                  ? "start"
+                  : activePointIndex === chart.points.length - 1
+                    ? "end"
+                    : "middle"
+              }
+              data-vertical={activePoint.y < 44 ? "below" : "above"}
+              style={{
+                left: `${(activePoint.x / VIEWBOX_WIDTH) * 100}%`,
+                top: `${(activePoint.y / VIEWBOX_HEIGHT) * 100}%`,
+              }}
+              aria-hidden="true"
+            >
+              <strong>{formatPrice(activePoint.value, chart.unit)}</strong>
+              <span>Block {activePoint.blockNumber}</span>
+            </div>
+          ) : null}
+          <span className="sr-only" aria-live="polite" aria-atomic="true">
+            {activePoint
+              ? `${formatPrice(activePoint.value, chart.unit)}, block ${activePoint.blockNumber}`
+              : ""}
+          </span>
         </div>
       ) : (
         <div className={styles.placeholder}>

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -18,7 +18,7 @@ function collectCssFiles(directory: string): string[] {
 }
 
 describe("interaction accessibility", () => {
-  it("keeps the token chart informational instead of showing a crosshair", () => {
+  it("makes exact chart prices available to pointer and keyboard input", () => {
     const chartCss = readFileSync(
       join(root, "components/token-price-chart.module.css"),
       "utf8",
@@ -29,8 +29,30 @@ describe("interaction accessibility", () => {
     );
 
     expect(chartCss).not.toContain("cursor: crosshair");
-    expect(chartSource).not.toContain("onPointerMove");
+    expect(chartSource).toContain("onPointerMove={inspectPointer}");
+    expect(chartSource).toContain("onKeyDown={inspectKeyboard}");
+    expect(chartSource).toContain("tabIndex={0}");
     expect(chartSource).not.toContain("role=\"slider\"");
+  });
+
+  it("removes decorative token separators and image-edge outlines", () => {
+    const tokenCss = readFileSync(
+      join(root, "components/token-experience.module.css"),
+      "utf8",
+    );
+    const exploreCss = readFileSync(
+      join(root, "components/explore-experience.module.css"),
+      "utf8",
+    );
+    const launchCss = readFileSync(
+      join(root, "components/launch-experience.module.css"),
+      "utf8",
+    );
+
+    expect(tokenCss).not.toContain("border-bottom:");
+    expect(tokenCss).not.toContain("border-top:");
+    expect(exploreCss).not.toMatch(/\.runnerArt\s*\{[^}]*outline:/s);
+    expect(launchCss).not.toMatch(/\.modelArt\s*\{[^}]*outline:/s);
   });
 
   it("keeps the default arrow cursor policy across app controls", () => {

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -35,7 +35,7 @@ describe("launch model artwork", () => {
     )?.[0];
 
     expect(css).toContain("@media (prefers-reduced-motion: no-preference)");
-    expect(sparkleMarkup?.match(/<span \/>/g)).toHaveLength(6);
+    expect(sparkleMarkup?.match(/<span \/>/g)).toHaveLength(10);
     expect(css).toContain(
       "animation: classic-botanical-drift 12s steps(1, end) infinite",
     );

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -7,6 +7,7 @@ import {
   actionCanCheckStatus,
   actionLabel,
   actionPending,
+  buildFeeEarningsChart,
   buildProfilePortfolio,
   clearConfirmedProfileActionStates,
   getProfileSessionView,
@@ -15,6 +16,7 @@ import {
   groupPendingProfileTransactionStates,
   groupProfileRewards,
   parsePendingProfileTransactions,
+  parseClaimedFeeWei,
   paginateProfileClaimableEntries,
   profileClaimableWei,
   profileClaimActionCount,
@@ -50,6 +52,10 @@ const thirdAddress = getAddress(
 );
 const profileExperienceCss = readFileSync(
   new URL("../components/profile-experience.module.css", import.meta.url),
+  "utf8",
+);
+const profileViewSource = readFileSync(
+  new URL("../components/profile-view.tsx", import.meta.url),
   "utf8",
 );
 
@@ -206,6 +212,51 @@ describe("profile workspace loading state", () => {
     );
     expect(profileExperienceCss).toMatch(
       /@media \(max-width: 820px\)[\s\S]*?\.profileWorkspace/,
+    );
+  });
+});
+
+describe("fee earnings chart", () => {
+  it("builds a cumulative chart from confirmed claims and current accrual", () => {
+    const activity = [
+      {
+        id: "claim:new",
+        label: "Creator fees claimed",
+        detail: "0.3 ETH from NEW",
+        occurredAt: "Today",
+        href: "/token/new",
+      },
+      {
+        id: "claim:old",
+        label: "Creator fees claimed",
+        detail: "0.2 ETH from OLD",
+        occurredAt: "Yesterday",
+        href: "/token/old",
+      },
+    ];
+
+    expect(parseClaimedFeeWei("0.25 ETH from TEST")).toBe(
+      250_000_000_000_000_000n,
+    );
+    const chart = buildFeeEarningsChart(
+      activity,
+      500_000_000_000_000_000n,
+      100_000_000_000_000_000n,
+    );
+
+    expect(chart?.points.map((point) => point.valueWei)).toEqual([
+      0n,
+      200_000_000_000_000_000n,
+      500_000_000_000_000_000n,
+      600_000_000_000_000_000n,
+    ]);
+    expect(chart?.totalWei).toBe(600_000_000_000_000_000n);
+  });
+
+  it("keeps the claim dialog focused on the selected token and actions", () => {
+    expect(profileViewSource).not.toContain(">Claimable rewards<");
+    expect(profileViewSource).not.toContain(
+      "Choose the reward you want to claim.",
     );
   });
 });

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -26,7 +26,10 @@ describe("token detail layout", () => {
 
   it("uses a compact two-column market workspace with community on the right", () => {
     expect(detailStyles).toMatch(
-      /grid-template-areas:\s*"identity identity"\s*"chart trade"\s*"metrics trade"\s*"deep community"\s*"details community";/s,
+      /grid-template-areas:\s*"identity identity"\s*"chart trade"\s*"deep community"\s*"details community";/s,
+    );
+    expect(detailSource).toMatch(
+      /<div className=\{styles\.marketChart\}>[\s\S]*?<TokenPriceChart[\s\S]*?<MetricGrid metrics=\{metrics\} \/>[\s\S]*?<\/div>/s,
     );
     expect(detailStyles).toMatch(
       /\.communityShell\s*\{[^}]*grid-area:\s*community;[^}]*position:\s*sticky;/s,

--- a/tests/token-price-chart-refresh.test.ts
+++ b/tests/token-price-chart-refresh.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createSerializedChartRefresh } from "../components/token-price-chart";
+import {
+  createSerializedChartRefresh,
+  nearestChartPointIndex,
+} from "../components/token-price-chart";
+
+describe("token price chart inspection", () => {
+  it("maps the pointer to the nearest plotted price point", () => {
+    expect(nearestChartPointIndex(100, 100, 600, 7)).toBe(0);
+    expect(nearestChartPointIndex(400, 100, 600, 7)).toBe(3);
+    expect(nearestChartPointIndex(700, 100, 600, 7)).toBe(6);
+    expect(nearestChartPointIndex(10_000, 100, 600, 7)).toBe(6);
+  });
+});
 
 describe("token price chart refresh", () => {
   afterEach(() => {


### PR DESCRIPTION
## What changed

- make token price charts inspectable by pointer and keyboard with exact price and block values
- move market metrics directly below the chart and remove decorative detail dividers
- remove Explore and launch-art edge seams and strengthen the Custom Hook sparkle treatment
- replace the profile fee-history placeholder with a cumulative earnings chart and simplify the claim dialog
- add bounded short-lived Explore and profile caches while preserving five-second live refreshes

## Why

Token pages did not expose exact historical prices, detail spacing was fragmented, image outlines produced visible white seams, and Profile/Explore revisits unnecessarily returned to loading states.

## Validation

- ESLint
- TypeScript
- production build
- 72 focused UI and state regression tests
- rendered desktop and mobile QA for Explore, token detail, chart hover, and launch-model selection
- browser console inspection