### PR TITLE
Polish earnings, docs, and Explore data

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -13,7 +13,11 @@ import {
   parseExploreSort,
   visibleExploreTokens,
 } from "../../../lib/onchain/query";
-import type { ExplorePage, ExploreReadModel } from "../../../lib/onchain/types";
+import type {
+  ExplorePage,
+  ExploreReadModel,
+  ExploreSnapshot,
+} from "../../../lib/onchain/types";
 import type { LauncherToken } from "../../../lib/tokens";
 
 export const dynamic = "force-dynamic";
@@ -28,6 +32,19 @@ const EXPLORE_QUERY_PARAMETERS = new Set([
 ]);
 const TOP_MARKET_CAP_LIMIT = 20;
 const NEWEST_LIVE_MARKET_LIMIT = 20;
+
+export function inheritExploreEthUsdQuote(
+  liveSnapshot: ExploreSnapshot,
+  referenceSnapshot: ExploreSnapshot,
+): ExploreSnapshot {
+  if (liveSnapshot.ethUsdQuote || !referenceSnapshot.ethUsdQuote) {
+    return liveSnapshot;
+  }
+  return {
+    ...liveSnapshot,
+    ethUsdQuote: referenceSnapshot.ethUsdQuote,
+  };
+}
 
 function mergeTokenUpdates(
   tokens: readonly LauncherToken[],
@@ -143,7 +160,10 @@ export async function GET(request: NextRequest) {
     const deployment = getAlchemyOnchainDeployment();
     const liveSnapshot =
       pricedModel.status === "ready"
-        ? (pricedModel.launchDiscoverySnapshot ?? pricedModel.snapshot)
+        ? inheritExploreEthUsdQuote(
+            pricedModel.launchDiscoverySnapshot ?? pricedModel.snapshot,
+            pricedModel.snapshot,
+          )
         : null;
     if (deployment.status === "ready" && liveSnapshot) {
       const visible = visibleExploreTokens(pricedModel);

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -4,6 +4,22 @@ export type DocsSearchItem = {
   title: string;
 };
 
+export const docsCategories = [
+  {
+    label: "Classic",
+    status: "coming-soon",
+  },
+  {
+    label: "Custom Hook",
+    status: "coming-soon",
+  },
+  {
+    href: "/docs",
+    label: "Developers",
+    status: "available",
+  },
+] as const;
+
 export const docsNavigation = [
   {
     label: "Developers",

--- a/components/docs-experience.module.css
+++ b/components/docs-experience.module.css
@@ -50,6 +50,59 @@
   z-index: -1;
 }
 
+.docsCategories {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 34px;
+  max-width: 760px;
+}
+
+.docsCategory {
+  border: 1px solid var(--panel-border-soft);
+  border-radius: 14px;
+  display: grid;
+  gap: 3px;
+  min-height: 68px;
+  padding: 13px 15px;
+}
+
+.docsCategory strong {
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.docsCategory span {
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.docsCategoryActive {
+  background: var(--docs-link-soft);
+  border-color: color-mix(
+    in srgb,
+    var(--docs-link) 24%,
+    var(--panel-border-soft)
+  );
+  outline: 0;
+  transition:
+    background-color 140ms var(--ease-out),
+    border-color 140ms var(--ease-out),
+    transform 140ms var(--ease-out);
+}
+
+.docsCategoryActive:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.docsCategoryUnavailable {
+  background: color-mix(in srgb, var(--surface-soft) 46%, transparent);
+}
+
 .navGroup a:focus-visible,
 .mobileNav summary:focus-visible {
   outline: 2px solid var(--focus);
@@ -971,6 +1024,19 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
+  .docsCategoryActive:hover {
+    background: color-mix(
+      in srgb,
+      var(--docs-link-soft) 86%,
+      var(--surface-soft)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--docs-link) 38%,
+      var(--panel-border-soft)
+    );
+  }
+
   .searchResults a:hover,
   .navGroup a:hover {
     background: var(--surface-soft);
@@ -1167,6 +1233,24 @@
 
   .heroTools {
     gap: 10px;
+  }
+
+  .docsCategories {
+    gap: 6px;
+    margin-top: 24px;
+  }
+
+  .docsCategory {
+    min-height: 64px;
+    padding: 11px 10px;
+  }
+
+  .docsCategory strong {
+    font-size: 12px;
+  }
+
+  .docsCategory span {
+    font-size: 10px;
   }
 
   .search {

--- a/components/docs-shell.tsx
+++ b/components/docs-shell.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from "react";
+import Link from "next/link";
 
+import { docsCategories } from "@/components/docs-data";
 import styles from "@/components/docs-experience.module.css";
 import {
   DocsNavigation,
@@ -31,6 +33,34 @@ export function DocsShell({
         <div className={styles.heroTools} data-docs-tools>
           <DocsSearch />
         </div>
+
+        <nav
+          aria-label="Documentation categories"
+          className={styles.docsCategories}
+        >
+          {docsCategories.map((category) =>
+            category.status === "available" ? (
+              <Link
+                aria-current="page"
+                className={`${styles.docsCategory} ${styles.docsCategoryActive}`}
+                href={category.href}
+                key={category.label}
+              >
+                <strong>{category.label}</strong>
+                <span>Integrations</span>
+              </Link>
+            ) : (
+              <span
+                aria-disabled="true"
+                className={`${styles.docsCategory} ${styles.docsCategoryUnavailable}`}
+                key={category.label}
+              >
+                <strong>{category.label}</strong>
+                <span>Available soon</span>
+              </span>
+            ),
+          )}
+        </nav>
 
         <header className={styles.hero} data-docs-hero>
           <h1>{title}</h1>

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -108,7 +108,7 @@
   display: grid;
   gap: clamp(42px, 4vw, 54px) clamp(18px, 2vw, 24px);
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin: 0 auto;
+  margin: clamp(16px, 2svh, 24px) auto 0;
   max-width: 1020px;
   width: 100%;
 }
@@ -410,6 +410,7 @@
   .runnerGrid {
     gap: 56px;
     grid-template-columns: 1fr;
+    margin-top: 0;
   }
 
   .runnerCard {

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -470,9 +470,9 @@
   border-radius: 20px;
   display: grid;
   flex: none;
-  grid-template-rows: minmax(150px, 1fr) auto;
+  grid-template-rows: minmax(172px, 1fr);
   margin: 20px 0 0;
-  min-height: 226px;
+  min-height: 180px;
   min-width: 0;
   overflow: hidden;
   position: relative;
@@ -508,6 +508,21 @@
   z-index: 1;
 }
 
+.feeChartInteraction {
+  cursor: crosshair;
+  grid-column: 1;
+  grid-row: 1;
+  min-height: 172px;
+  outline: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.feeChartInteraction:focus-visible {
+  border-radius: 20px;
+  box-shadow: inset 0 0 0 2px var(--focus);
+}
+
 .feeArea {
   opacity: 0.9;
 }
@@ -521,10 +536,18 @@
   vector-effect: non-scaling-stroke;
 }
 
-.feeEndPoint {
+.feeActivePoint {
   fill: var(--canvas);
   stroke: var(--accent);
   stroke-width: 2.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.feeCursor {
+  opacity: 0.42;
+  stroke: var(--accent);
+  stroke-dasharray: 3 4;
+  stroke-width: 1;
   vector-effect: non-scaling-stroke;
 }
 
@@ -540,8 +563,7 @@
   z-index: 2;
 }
 
-.feeChartTotal span,
-.chartCaption {
+.feeChartTotal span {
   color: var(--muted);
   font-size: 10px;
 }
@@ -551,14 +573,6 @@
   font-size: 13px;
   font-variant-numeric: tabular-nums;
   font-weight: 680;
-}
-
-.chartCaption {
-  grid-column: 1;
-  grid-row: 2;
-  padding: 0 16px 14px;
-  position: relative;
-  z-index: 1;
 }
 
 .chartEmpty {
@@ -580,44 +594,6 @@
   line-height: 1.5;
   margin-block-start: 6px;
   text-wrap: pretty;
-}
-
-.claimHistory {
-  display: grid;
-  gap: 7px;
-  grid-column: 1;
-  grid-row: 2;
-  padding: 0 14px 14px;
-  position: relative;
-  z-index: 1;
-  width: 100%;
-}
-
-.claimHistory a {
-  align-items: center;
-  background: color-mix(in srgb, var(--glass-96) 70%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
-  border-radius: 12px;
-  color: var(--text);
-  display: flex;
-  font-size: 12px;
-  gap: 12px;
-  justify-content: space-between;
-  min-height: 32px;
-  padding: 7px 10px;
-  text-decoration: none;
-}
-
-.claimHistory span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.claimHistory time {
-  color: var(--muted);
-  flex: none;
-  font-size: 10px;
 }
 
 .claimList {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -13,6 +13,8 @@ import {
   useSyncExternalStore,
   type ChangeEvent,
   type FormEvent,
+  type KeyboardEvent,
+  type PointerEvent,
 } from "react";
 
 import { useWallet } from "@/components/wallet-provider";
@@ -3253,15 +3255,68 @@ function FeeEarningsPanel({
   stockRewardCount: number;
   activity: readonly ProfileActivity[];
 }) {
-  const claimHistory = activity
-    .filter((item) => /fees claimed/iu.test(item.label))
-    .slice(0, 3);
-  const chart = buildFeeEarningsChart(
-    activity,
-    nativeClaimed,
-    nativeClaimable,
+  const [timeframe, setTimeframe] = useState<FeeEarningsRange>("all");
+  const chart = useMemo(
+    () =>
+      buildFeeEarningsChart(activity, nativeClaimed, nativeClaimable, {
+        range: timeframe,
+      }),
+    [activity, nativeClaimable, nativeClaimed, timeframe],
   );
+  const [activePointIndex, setActivePointIndex] = useState(-1);
   const gradientId = useId().replaceAll(":", "");
+  const resolvedActivePointIndex = chart
+    ? activePointIndex >= 0 && activePointIndex < chart.points.length
+      ? activePointIndex
+      : chart.points.length - 1
+    : -1;
+  const activePoint = chart
+    ? chart.points[resolvedActivePointIndex]
+    : undefined;
+
+  function resetActivePoint() {
+    setActivePointIndex(-1);
+  }
+
+  function selectPointFromPointer(event: PointerEvent<HTMLDivElement>) {
+    if (!chart) return;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    if (bounds.width <= 0) return;
+    const pointerX = Math.min(
+      620,
+      Math.max(0, ((event.clientX - bounds.left) / bounds.width) * 620),
+    );
+    const nearestIndex = chart.points.reduce(
+      (nearest, point, index) =>
+        Math.abs(point.x - pointerX) <
+        Math.abs(chart.points[nearest].x - pointerX)
+          ? index
+          : nearest,
+      0,
+    );
+    setActivePointIndex(nearestIndex);
+  }
+
+  function handleChartKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (!chart) return;
+    let nextIndex = resolvedActivePointIndex;
+    if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+      nextIndex = Math.max(0, resolvedActivePointIndex - 1);
+    } else if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+      nextIndex = Math.min(
+        chart.points.length - 1,
+        resolvedActivePointIndex + 1,
+      );
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = chart.points.length - 1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    setActivePointIndex(nextIndex);
+  }
 
   return (
     <section
@@ -3272,6 +3327,22 @@ function FeeEarningsPanel({
         <div>
           <h2 id="fee-earnings-title">Fee earnings</h2>
           <p>Claimable now</p>
+        </div>
+        <div className={styles.timeframeControls} aria-label="Earnings period">
+          {feeEarningsRanges.map((range) => (
+            <button
+              aria-label={`Show earnings for ${range.description}`}
+              aria-pressed={timeframe === range.value}
+              key={range.value}
+              onClick={() => {
+                setActivePointIndex(-1);
+                setTimeframe(range.value);
+              }}
+              type="button"
+            >
+              {range.label}
+            </button>
+          ))}
         </div>
       </header>
 
@@ -3285,63 +3356,74 @@ function FeeEarningsPanel({
 
       <figure
         className={styles.feeChart}
-        aria-label={`Fee earnings history. ${formatWei(nativeClaimed + nativeClaimable)} earned in total.`}
+        aria-label={`Fee earnings for ${feeEarningsRangeLabel(timeframe)}.`}
       >
         <div className={styles.chartGrid} aria-hidden="true" />
-        {chart ? (
+        {chart && activePoint ? (
           <>
-            <svg
-              className={styles.feePlot}
-              viewBox="0 0 620 150"
-              preserveAspectRatio="none"
-              role="img"
-              aria-label={`Cumulative fee earnings ending at ${formatWei(chart.totalWei)}`}
+            <div
+              aria-label="Fee earnings timeline"
+              aria-orientation="horizontal"
+              aria-valuemax={chart.points.length - 1}
+              aria-valuemin={0}
+              aria-valuenow={resolvedActivePointIndex}
+              aria-valuetext={`${formatWei(activePoint.valueWei)} at ${formatFeeChartMoment(activePoint.timestampMs, chart.nowMs)}`}
+              className={styles.feeChartInteraction}
+              onBlur={resetActivePoint}
+              onKeyDown={handleChartKeyDown}
+              onPointerDown={(event) => event.currentTarget.focus()}
+              onPointerLeave={resetActivePoint}
+              onPointerMove={selectPointFromPointer}
+              role="slider"
+              tabIndex={0}
             >
-              <defs>
-                <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
-                  <stop
-                    offset="0%"
-                    stopColor="var(--accent)"
-                    stopOpacity="0.24"
-                  />
-                  <stop
-                    offset="100%"
-                    stopColor="var(--accent)"
-                    stopOpacity="0"
-                  />
-                </linearGradient>
-              </defs>
-              <path
-                className={styles.feeArea}
-                d={chart.areaPath}
-                fill={`url(#${gradientId})`}
-              />
-              <path className={styles.feeLine} d={chart.linePath} />
-              <circle
-                className={styles.feeEndPoint}
-                cx={chart.points.at(-1)?.x}
-                cy={chart.points.at(-1)?.y}
-                r="4.5"
-              />
-            </svg>
-            <div className={styles.feeChartTotal} aria-hidden="true">
-              <span>Total earned</span>
-              <strong>{formatWei(chart.totalWei)}</strong>
+              <svg
+                aria-hidden="true"
+                className={styles.feePlot}
+                viewBox="0 0 620 150"
+                preserveAspectRatio="none"
+              >
+                <defs>
+                  <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+                    <stop
+                      offset="0%"
+                      stopColor="var(--accent)"
+                      stopOpacity="0.24"
+                    />
+                    <stop
+                      offset="100%"
+                      stopColor="var(--accent)"
+                      stopOpacity="0"
+                    />
+                  </linearGradient>
+                </defs>
+                <path
+                  className={styles.feeArea}
+                  d={chart.areaPath}
+                  fill={`url(#${gradientId})`}
+                />
+                <path className={styles.feeLine} d={chart.linePath} />
+                <line
+                  className={styles.feeCursor}
+                  x1={activePoint.x}
+                  x2={activePoint.x}
+                  y1="10"
+                  y2="140"
+                />
+                <circle
+                  className={styles.feeActivePoint}
+                  cx={activePoint.x}
+                  cy={activePoint.y}
+                  r="4.5"
+                />
+              </svg>
             </div>
-            {claimHistory.length ? (
-              <figcaption className={styles.claimHistory}>
-                {claimHistory.map((item) => (
-                  <Link href={item.href} key={item.id}>
-                    <span>{item.detail}</span>
-                    <time>{item.occurredAt}</time>
-                  </Link>
-                ))}
-              </figcaption>
-            ) : (
-              <figcaption className={styles.chartCaption}>
-                Current unclaimed earnings
-              </figcaption>
-            )}
+            <div className={styles.feeChartTotal} aria-hidden="true">
+              <span>
+                Total earned · {formatFeeChartMoment(activePoint.timestampMs, chart.nowMs)}
+              </span>
+              <strong>{formatWei(activePoint.valueWei)}</strong>
+            </div>
           </>
         ) : (
           <figcaption className={styles.chartEmpty}>
@@ -3357,8 +3439,43 @@ function FeeEarningsPanel({
 type FeeEarningsChartPoint = {
   x: number;
   y: number;
+  timestampMs: number;
   valueWei: bigint;
 };
+
+export type FeeEarningsRange = "1h" | "1d" | "1w" | "all";
+
+const feeEarningsRanges: ReadonlyArray<{
+  description: string;
+  label: string;
+  value: FeeEarningsRange;
+}> = [
+  { description: "the last hour", label: "1H", value: "1h" },
+  { description: "the last day", label: "1D", value: "1d" },
+  { description: "the last week", label: "1W", value: "1w" },
+  { description: "all time", label: "ALL", value: "all" },
+];
+
+const feeEarningsRangeMs: Record<Exclude<FeeEarningsRange, "all">, number> = {
+  "1h": 60 * 60 * 1_000,
+  "1d": 24 * 60 * 60 * 1_000,
+  "1w": 7 * 24 * 60 * 60 * 1_000,
+};
+
+function feeEarningsRangeLabel(range: FeeEarningsRange) {
+  return feeEarningsRanges.find((candidate) => candidate.value === range)
+    ?.description ?? "all time";
+}
+
+function formatFeeChartMoment(timestampMs: number, nowMs: number) {
+  if (Math.abs(nowMs - timestampMs) < 1_000) return "Now";
+  return new Intl.DateTimeFormat("en", {
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "short",
+  }).format(timestampMs);
+}
 
 export function parseClaimedFeeWei(detail: string) {
   const match = detail.trim().match(/^([0-9]+(?:\.[0-9]+)?)\s+ETH\b/iu);
@@ -3374,26 +3491,58 @@ export function buildFeeEarningsChart(
   activity: readonly ProfileActivity[],
   nativeClaimed: bigint,
   nativeClaimable: bigint,
+  options: Readonly<{
+    nowMs?: number;
+    range?: FeeEarningsRange;
+  }> = {},
 ) {
-  const claims = activity
+  const nowMs = options.nowMs ?? Date.now();
+  const range = options.range ?? "all";
+  const rawClaims = activity
     .filter((item) => /fees claimed/iu.test(item.label))
-    .map((item) => parseClaimedFeeWei(item.detail))
-    .filter((value): value is bigint => value !== null)
-    .reverse();
-  const historyTotal = claims.reduce((total, value) => total + value, 0n);
+    .flatMap((item) => {
+      const valueWei = parseClaimedFeeWei(item.detail);
+      if (valueWei === null) return [];
+      const parsedTimestamp = Date.parse(
+        item.occurredAtIso ?? item.occurredAt,
+      );
+      return [{
+        timestampMs: Number.isFinite(parsedTimestamp) ? parsedTimestamp : null,
+        valueWei,
+      }];
+    });
+  const claims = rawClaims
+    .map((claim, index) => ({
+      ...claim,
+      timestampMs:
+        claim.timestampMs ?? nowMs - (index + 1) * 24 * 60 * 60 * 1_000,
+    }))
+    .sort((first, second) => first.timestampMs - second.timestampMs);
+  const historyTotal = claims.reduce(
+    (total, claim) => total + claim.valueWei,
+    0n,
+  );
+  const rangeStartMs =
+    range === "all"
+      ? (claims[0]?.timestampMs ?? nowMs - 24 * 60 * 60 * 1_000)
+      : nowMs - feeEarningsRangeMs[range];
+  const visibleClaims =
+    range === "all"
+      ? claims
+      : claims.filter((claim) => claim.timestampMs >= rangeStartMs);
   const startingTotal =
-    nativeClaimed > historyTotal ? nativeClaimed - historyTotal : 0n;
-  const values = [startingTotal];
+    range === "all" && nativeClaimed > historyTotal
+      ? nativeClaimed - historyTotal
+      : 0n;
+  const values = [{ timestampMs: rangeStartMs, valueWei: startingTotal }];
   let cumulative = startingTotal;
-  for (const claim of claims) {
-    cumulative += claim;
-    values.push(cumulative);
+  for (const claim of visibleClaims) {
+    cumulative += claim.valueWei;
+    values.push({ timestampMs: claim.timestampMs, valueWei: cumulative });
   }
 
-  const totalWei = nativeClaimed + nativeClaimable;
-  if (values.at(-1) !== totalWei || values.length === 1) {
-    values.push(totalWei);
-  }
+  const totalWei = cumulative + nativeClaimable;
+  values.push({ timestampMs: nowMs, valueWei: totalWei });
   if (totalWei <= 0n || values.length < 2) return null;
 
   const width = 620;
@@ -3403,18 +3552,26 @@ export function buildFeeEarningsChart(
   const top = 12;
   const bottom = height - 10;
   const maximum = values.reduce(
-    (current, value) => (value > current ? value : current),
+    (current, value) => (value.valueWei > current ? value.valueWei : current),
     1n,
   );
-  const points: FeeEarningsChartPoint[] = values.map((valueWei, index) => ({
-    valueWei,
-    x: left + (index / (values.length - 1)) * (right - left),
-    y:
-      bottom -
-      Number((valueWei * 1_000_000n) / maximum) /
-        1_000_000 *
-        (bottom - top),
-  }));
+  const timeSpanMs = Math.max(1, nowMs - rangeStartMs);
+  const points: FeeEarningsChartPoint[] = values.map(
+    ({ timestampMs, valueWei }) => ({
+      timestampMs,
+      valueWei,
+      x:
+        left +
+        ((Math.min(nowMs, Math.max(rangeStartMs, timestampMs)) - rangeStartMs) /
+          timeSpanMs) *
+          (right - left),
+      y:
+        bottom -
+        Number((valueWei * 1_000_000n) / maximum) /
+          1_000_000 *
+          (bottom - top),
+    }),
+  );
   const linePath = points
     .map((point, index) =>
       `${index === 0 ? "M" : "L"}${point.x.toFixed(2)},${point.y.toFixed(2)}`,
@@ -3424,6 +3581,7 @@ export function buildFeeEarningsChart(
   return {
     areaPath: `${linePath} L${right},${height} L${left},${height} Z`,
     linePath,
+    nowMs,
     points,
     totalWei,
   };

--- a/lib/profile/onchain-profile.ts
+++ b/lib/profile/onchain-profile.ts
@@ -52,6 +52,7 @@ export type ProfileActivity = {
   label: string;
   detail: string;
   occurredAt: string;
+  occurredAtIso?: string;
   href: string;
 };
 
@@ -705,6 +706,7 @@ export function mapCreatorProfileResponse(
         label: "Token launched",
         detail: `${token.name} (${token.symbol})`,
         occurredAt: formatActivityDate(token.launchedAt),
+        occurredAtIso: token.launchedAt,
         href: token.href,
       } satisfies ProfileActivity,
     })),
@@ -723,6 +725,7 @@ export function mapCreatorProfileResponse(
           label: "Creator fees claimed",
           detail: `${formatUnits(BigInt(claim.amountWei), 18)} ETH from ${token.symbol}`,
           occurredAt: formatActivityDate(claim.claimedAt),
+          occurredAtIso: claim.claimedAt,
           href: token.href,
         } satisfies ProfileActivity,
       };

--- a/tests/docs-layout-stability.test.ts
+++ b/tests/docs-layout-stability.test.ts
@@ -73,6 +73,9 @@ describe("Docs rail layout stability", () => {
     expect(docsPage).toContain("<DocsLaunchInspector />");
     expect(docsShell).not.toContain("docsGuides");
     expect(docsShell).not.toContain("Documentation guides");
+    expect(docsShell).toContain('aria-label="Documentation categories"');
+    expect(docsShell).toContain("Available soon");
+    expect(docsShell).toContain("Integrations");
     expect(docsNavigation).toContain(
       '<p className={styles.navLabel}>On this page</p>',
     );

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -25,7 +25,7 @@ vi.mock("../lib/alchemy/live-market.server", () => ({
   enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
 }));
 
-import { GET } from "../app/api/explore/route";
+import { GET, inheritExploreEthUsdQuote } from "../app/api/explore/route";
 
 const HOOK_ADDRESS =
   "0x3333333333333333333333333333333333333333" as const;
@@ -80,6 +80,36 @@ describe("Explore API Alchemy boundary", () => {
     mocks.enrichTokensWithAlchemyPoolState.mockImplementation(
       async ({ tokens }: { tokens: readonly LauncherToken[] }) => [...tokens],
     );
+  });
+
+  it("inherits the durable ETH/USD quote for newest live market values", () => {
+    const ethUsdQuote = {
+      feedAddress: "0x1111111111111111111111111111111111111111" as const,
+      roundId: "12",
+      answer: "350000000000",
+      decimals: 8,
+      updatedAt: "2026-08-04T10:00:00.000Z",
+    };
+    const launchSnapshot = {
+      ...snapshot,
+      blockNumber: "25630001",
+    };
+
+    expect(
+      inheritExploreEthUsdQuote(launchSnapshot, {
+        ...snapshot,
+        ethUsdQuote,
+      }),
+    ).toEqual({
+      ...launchSnapshot,
+      ethUsdQuote,
+    });
+    expect(
+      inheritExploreEthUsdQuote(
+        { ...launchSnapshot, ethUsdQuote },
+        snapshot,
+      ),
+    ).toEqual({ ...launchSnapshot, ethUsdQuote });
   });
 
   it.each([

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -224,6 +224,7 @@ describe("fee earnings chart", () => {
         label: "Creator fees claimed",
         detail: "0.3 ETH from NEW",
         occurredAt: "Today",
+        occurredAtIso: "2026-08-04T11:30:00.000Z",
         href: "/token/new",
       },
       {
@@ -231,6 +232,7 @@ describe("fee earnings chart", () => {
         label: "Creator fees claimed",
         detail: "0.2 ETH from OLD",
         occurredAt: "Yesterday",
+        occurredAtIso: "2026-08-03T11:30:00.000Z",
         href: "/token/old",
       },
     ];
@@ -251,6 +253,46 @@ describe("fee earnings chart", () => {
       600_000_000_000_000_000n,
     ]);
     expect(chart?.totalWei).toBe(600_000_000_000_000_000n);
+  });
+
+  it("changes the earned total with the selected period", () => {
+    const nowMs = Date.parse("2026-08-04T12:00:00.000Z");
+    const activity = [
+      {
+        id: "claim:recent",
+        label: "Creator fees claimed",
+        detail: "0.1 ETH from NOW",
+        occurredAt: "Today",
+        occurredAtIso: "2026-08-04T11:30:00.000Z",
+        href: "/token/now",
+      },
+      {
+        id: "claim:old",
+        label: "Creator fees claimed",
+        detail: "0.4 ETH from OLD",
+        occurredAt: "Last week",
+        occurredAtIso: "2026-07-24T12:00:00.000Z",
+        href: "/token/old",
+      },
+    ];
+
+    const hourly = buildFeeEarningsChart(
+      activity,
+      500_000_000_000_000_000n,
+      50_000_000_000_000_000n,
+      { nowMs, range: "1h" },
+    );
+    const allTime = buildFeeEarningsChart(
+      activity,
+      500_000_000_000_000_000n,
+      50_000_000_000_000_000n,
+      { nowMs, range: "all" },
+    );
+
+    expect(hourly?.totalWei).toBe(150_000_000_000_000_000n);
+    expect(allTime?.totalWei).toBe(550_000_000_000_000_000n);
+    expect(profileViewSource).toContain('role="slider"');
+    expect(profileViewSource).not.toContain("styles.claimHistory");
   });
 
   it("keeps the claim dialog focused on the selected token and actions", () => {


### PR DESCRIPTION
## What changed

- add `1H`, `1D`, `1W`, and `ALL` ranges to Fee Earnings
- update the displayed total from pointer or keyboard chart inspection
- remove the claim-history rows below the earnings chart
- restore the Classic, Custom Hook, and Developers documentation categories while marking the first two as available soon
- inherit the durable ETH/USD quote for Newest live market values so cards render compact USD market caps
- move the desktop Explore grid slightly lower

## Why

The profile chart did not support time-scoped inspection, the developer-only Docs page no longer exposed the intended category structure, and the Newest live snapshot could omit the ETH/USD quote even though the durable snapshot already had it.

## Validation

- `npm run build`
- `npm run typecheck`
- scoped ESLint on the changed TypeScript files
- 83 focused Profile, Docs, Explore, and market-cap tests
- rendered desktop QA at 1440x900
- rendered mobile QA at 390x844

The full repository test command also reached 1886 passing tests; seven unrelated contract verifier tests require missing `contracts/out` artifacts and the `contracts/lib/v4-core` submodule in this isolated UI worktree.
