### PR TITLE
Polish Explore and rebuild developer docs

### DIFF
--- a/app/docs/developers/page.tsx
+++ b/app/docs/developers/page.tsx
@@ -2,19 +2,17 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import {
   ArrowUpRight,
-  Bot,
-  Braces,
   CircleDot,
   Database,
   FileJson,
   Layers3,
   ShieldCheck,
-  Terminal,
   Workflow,
 } from "lucide-react";
 
 import {
   DeveloperAgentPrompt,
+  DeveloperDocsActions,
   DeveloperDocsWorkbench,
 } from "@/components/developer-docs-workbench";
 import styles from "@/components/developer-docs.module.css";
@@ -149,37 +147,19 @@ export default function DeveloperDocsPage() {
   return (
     <DocsShell
       currentPath="/docs/developers"
-      description="Fetch launches, track new tokens, and add Programmable data to a terminal, scanner, wallet, indexer, app, or agent. The public v1 API is read-only and needs no API key."
+      description="Integrate the public Programmable launch feed into terminals, wallets, scanners, indexers, apps, and agents. Read-only REST, no API key."
       heroAside={<DeveloperDocsWorkbench />}
-      heroMeta={
-        <>
-          <div className={styles.integrationMeta} aria-label="API summary">
-            <span>Public REST</span>
-            <span>No API key</span>
-            <span>Ethereum mainnet</span>
-            <span>v1 JSON</span>
-          </div>
-          <div className={styles.endpointBar}>
-            <span>Base URL</span>
-            <code>developers.programmable.family</code>
-            <span className={styles.endpointLive}>
-              <i aria-hidden="true" />
-              Live
-            </span>
-          </div>
-        </>
-      }
+      heroMeta={<DeveloperDocsActions />}
       kicker="Docs / Developers"
       sections={developerSections}
-      title="Developer integrations"
+      title="Developer documentation"
     >
       <section id="response">
         <div className={styles.sectionIntro}>
-          <span className={styles.sectionKicker}>Understand the payload</span>
-          <h2>Store identity once. Add features only when supported.</h2>
+          <h2>Response model</h2>
           <p>
-            Every record keeps the same trusted core. Open a group to see what
-            it means and which values your integration should preserve.
+            Preserve the trusted core of every launch. Open a group to inspect
+            its fields and the rules your integration must keep.
           </p>
         </div>
 
@@ -232,11 +212,10 @@ export default function DeveloperDocsPage() {
 
       <section id="sync">
         <div className={styles.sectionIntro}>
-          <span className={styles.sectionKicker}>Keep the feed current</span>
-          <h2>Backfill once, then poll from a durable checkpoint</h2>
+          <h2>Backfill and live updates</h2>
           <p>
-            The two cursors do different jobs. Treat them as opaque strings and
-            never advance your durable checkpoint before every page is stored.
+            Complete one snapshot, store it, then poll from a durable
+            checkpoint. Treat every cursor as opaque.
           </p>
         </div>
 
@@ -310,19 +289,16 @@ export default function DeveloperDocsPage() {
 
       <section id="rendering">
         <div className={styles.sectionIntro}>
-          <span className={styles.sectionKicker}>Ship safe defaults</span>
-          <h2>Discovery is universal. Market features are explicit.</h2>
+          <h2>Rendering rules</h2>
           <p>
-            Keep every recognized launch visible. Then enable price, chart,
-            quote, simulation, or execution only when that market declares
-            verified support.
+            Keep recognized launches visible. Enable price, chart, quote,
+            simulation, or execution only when a market declares support.
           </p>
         </div>
 
         <div className={styles.renderingRules}>
           <article>
             <CircleDot aria-hidden="true" size={20} strokeWidth={1.8} />
-            <span>Always show</span>
             <h3>Identity and provenance</h3>
             <p>
               Chain, contract address, launch ID, category, onchain timestamp,
@@ -331,7 +307,6 @@ export default function DeveloperDocsPage() {
           </article>
           <article>
             <Layers3 aria-hidden="true" size={20} strokeWidth={1.8} />
-            <span>Read before rendering</span>
             <h3>Markets and capabilities</h3>
             <p>
               Accept zero, one, or several markets. Keep unfamiliar types
@@ -340,7 +315,6 @@ export default function DeveloperDocsPage() {
           </article>
           <article>
             <ShieldCheck aria-hidden="true" size={20} strokeWidth={1.8} />
-            <span>Never guess</span>
             <h3>Price, volume, or actions</h3>
             <p>
               Null is not zero. No market is not an error. Discovery never
@@ -362,46 +336,21 @@ export default function DeveloperDocsPage() {
 
       <section id="agents">
         <div className={styles.sectionIntro}>
-          <span className={styles.sectionKicker}>Agent-ready by default</span>
-          <h2>Give an AI agent structured context, not a screenshot</h2>
+          <h2>AI agent integration</h2>
           <p>
-            The human page, Markdown export, compact index, full integration
-            context, OpenAPI contract, and JSON Schemas all point to the same
-            current public interface.
+            Give an agent Markdown, OpenAPI, and schemas instead of a
+            screenshot. Every machine-readable surface points to the same
+            public interface.
           </p>
         </div>
 
         <DeveloperAgentPrompt />
 
-        <div className={styles.agentSurfaces}>
-          <div>
-            <Bot aria-hidden="true" size={19} strokeWidth={1.8} />
-            <span>
-              <strong>Discover</strong>
-              <code>/llms.txt</code>
-            </span>
-          </div>
-          <div>
-            <FileJson aria-hidden="true" size={19} strokeWidth={1.8} />
-            <span>
-              <strong>Read</strong>
-              <code>/docs/developers.md</code>
-            </span>
-          </div>
-          <div>
-            <Braces aria-hidden="true" size={19} strokeWidth={1.8} />
-            <span>
-              <strong>Generate</strong>
-              <code>OpenAPI + Schemas</code>
-            </span>
-          </div>
-        </div>
       </section>
 
       <section id="reference">
         <div className={styles.sectionIntro}>
-          <span className={styles.sectionKicker}>Public v1 reference</span>
-          <h2>Every endpoint you need</h2>
+          <h2>API reference</h2>
           <p>
             Successful responses are JSON. Errors use the published problem
             schema. Honor cache headers, ETags, retry timing, and feed status.
@@ -472,19 +421,6 @@ export default function DeveloperDocsPage() {
           </ExternalResource>
         </div>
 
-        <div className={styles.docsBoundary}>
-          <Terminal aria-hidden="true" size={20} strokeWidth={1.8} />
-          <div>
-            <strong>
-              Classic and Custom Hook product guides are not published yet.
-            </strong>
-            <p>
-              This page covers only the public developer integration contract.
-              The other Docs categories stay marked Available soon until their
-              product documentation is ready.
-            </p>
-          </div>
-        </div>
       </section>
     </DocsShell>
   );

--- a/components/developer-docs-workbench.tsx
+++ b/components/developer-docs-workbench.tsx
@@ -5,6 +5,7 @@ import {
   CircleAlert,
   Copy,
   ExternalLink,
+  FileText,
   LoaderCircle,
   Play,
   Sparkles,
@@ -326,14 +327,7 @@ export function DeveloperDocsWorkbench() {
   return (
     <div className={styles.workbench} data-request-state={requestState}>
       <div className={styles.workbenchTopbar}>
-        <div>
-          <span className={styles.windowDots} aria-hidden="true">
-            <i />
-            <i />
-            <i />
-          </span>
-          <span className={styles.workbenchLabel}>Live API</span>
-        </div>
+        <span className={styles.workbenchLabel}>Quickstart</span>
         <a
           className={styles.openApiLink}
           href={`${apiOrigin}/openapi/programmable-v1.yaml`}
@@ -436,14 +430,73 @@ export function DeveloperDocsWorkbench() {
   );
 }
 
+export function DeveloperDocsActions() {
+  const [state, setState] = useState<CopyState>("idle");
+  const resetTimer = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current !== null) window.clearTimeout(resetTimer.current);
+    },
+    [],
+  );
+
+  async function copyMarkdown() {
+    if (resetTimer.current !== null) window.clearTimeout(resetTimer.current);
+    try {
+      const response = await fetch("/docs/developers.md");
+      if (!response.ok) throw new Error(`Markdown returned ${response.status}`);
+      await navigator.clipboard.writeText(await response.text());
+      setState("copied");
+      resetTimer.current = window.setTimeout(() => setState("idle"), 1800);
+    } catch {
+      setState("error");
+      resetTimer.current = window.setTimeout(() => setState("idle"), 2400);
+    }
+  }
+
+  return (
+    <div className={styles.docsActions}>
+      <button data-state={state} onClick={copyMarkdown} type="button">
+        {state === "copied" ? (
+          <Check aria-hidden="true" size={16} strokeWidth={2.1} />
+        ) : state === "error" ? (
+          <CircleAlert aria-hidden="true" size={16} strokeWidth={1.9} />
+        ) : (
+          <FileText aria-hidden="true" size={16} strokeWidth={1.8} />
+        )}
+        <span>
+          {state === "copied"
+            ? "Copied"
+            : state === "error"
+              ? "Retry"
+              : "Copy Markdown"}
+        </span>
+      </button>
+      <a
+        href={`${apiOrigin}/openapi/programmable-v1.yaml`}
+        rel="noreferrer"
+        target="_blank"
+      >
+        OpenAPI
+        <ExternalLink aria-hidden="true" size={15} strokeWidth={1.8} />
+      </a>
+      <span className="sr-only" role="status" aria-live="polite">
+        {state === "copied"
+          ? "Developer documentation Markdown copied"
+          : state === "error"
+            ? "Unable to copy developer documentation Markdown"
+            : ""}
+      </span>
+    </div>
+  );
+}
+
 export function DeveloperAgentPrompt() {
   return (
     <div className={styles.agentPrompt}>
       <div className={styles.agentPromptHeader}>
-        <div>
-          <span className={styles.agentPromptEyebrow}>Agent handoff</span>
-          <strong>Give any coding agent the same source of truth</strong>
-        </div>
+        <strong>Give any coding agent the same source of truth</strong>
         <CopyAction
           label="Copy agent prompt"
           text={agentPrompt}

--- a/components/developer-docs.module.css
+++ b/components/developer-docs.module.css
@@ -1,133 +1,83 @@
 :global([data-docs-shell]) {
-  --dev-accent: #a83f64;
-  --dev-accent-soft: rgba(168, 63, 100, 0.08);
-  --dev-live: #1f765d;
-  --dev-live-soft: rgba(31, 118, 93, 0.09);
-  --dev-code: #0b0d10;
-  --dev-code-raised: #111419;
-  --dev-code-border: rgba(239, 243, 247, 0.12);
-  --dev-code-text: #eef1f4;
-  --dev-code-muted: #9aa3ad;
+  --dev-accent: #315775;
+  --dev-accent-soft: rgba(49, 87, 117, 0.09);
+  --dev-live: #23735c;
+  --dev-live-soft: rgba(35, 115, 92, 0.1);
+  --dev-code: #111317;
+  --dev-code-raised: #171a1f;
+  --dev-code-border: rgba(244, 247, 250, 0.12);
+  --dev-code-text: #f4f6f8;
+  --dev-code-muted: #aab2bc;
   --dev-rule: color-mix(in srgb, var(--text) 12%, transparent);
 }
 
 :global(html[data-theme="dark"] [data-docs-shell]) {
-  --dev-accent: #e087a6;
-  --dev-accent-soft: rgba(224, 135, 166, 0.1);
-  --dev-live: #70cdb0;
-  --dev-live-soft: rgba(112, 205, 176, 0.1);
-  --dev-rule: color-mix(in srgb, var(--text) 14%, transparent);
+  --dev-accent: #92bad5;
+  --dev-accent-soft: rgba(146, 186, 213, 0.12);
+  --dev-live: #76ceb2;
+  --dev-live-soft: rgba(118, 206, 178, 0.11);
+  --dev-rule: color-mix(in srgb, var(--text) 15%, transparent);
 }
 
-.quickstartSection {
-  position: relative;
-}
-
-.integrationMeta {
+.docsActions {
   align-items: center;
-  color: var(--text-soft);
-  display: grid;
-  font-size: 12px;
-  font-weight: 590;
-  gap: 7px 12px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  line-height: 1.4;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
 }
 
-.integrationMeta > span {
+.docsActions button,
+.docsActions a {
   align-items: center;
-  display: inline-flex;
-  white-space: nowrap;
-}
-
-.integrationMeta > span::before {
-  background: var(--dev-accent);
-  content: "";
-  height: 1px;
-  margin-right: 7px;
-  opacity: 0.65;
-  width: 8px;
-}
-
-.endpointBar {
-  align-items: center;
-  border-block: 1px solid var(--dev-rule);
-  display: grid;
-  gap: 10px;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  margin-top: 18px;
-  min-height: 45px;
-  padding-block: 8px;
-}
-
-.endpointBar > span:first-child {
-  color: var(--muted);
-  font-size: 9.5px;
-  font-weight: 760;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.endpointBar code {
+  background: var(--surface-raised);
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
   color: var(--text);
-  font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
-  font-size: 11px;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.endpointLive {
-  align-items: center;
-  color: var(--dev-live);
   display: inline-flex;
-  font-size: 10.5px;
-  font-weight: 700;
-  gap: 6px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 640;
+  gap: 7px;
+  justify-content: center;
+  min-height: 40px;
+  padding-inline: 13px;
+  text-decoration: none;
+  transition:
+    background-color 140ms var(--ease-out),
+    border-color 140ms var(--ease-out),
+    color 140ms var(--ease-out),
+    transform 120ms var(--ease-out);
 }
 
-.endpointLive i,
-.responseStatusDot {
-  background: currentColor;
-  border-radius: 50%;
-  height: 6px;
-  width: 6px;
+.docsActions button[data-state="copied"] {
+  color: var(--dev-live);
 }
 
-.endpointLive i {
-  box-shadow: 0 0 0 3px var(--dev-live-soft);
+.docsActions button[data-state="error"] {
+  color: var(--danger);
 }
 
 .sectionIntro {
   display: grid;
-  margin-bottom: 25px;
-  max-width: 700px;
-}
-
-.sectionKicker {
-  color: var(--dev-accent);
-  font-size: 10px;
-  font-weight: 760;
-  letter-spacing: 0.11em;
-  margin-bottom: 10px;
-  text-transform: uppercase;
+  margin-bottom: 28px;
+  max-width: 720px;
 }
 
 .sectionIntro h2 {
-  max-width: 25ch !important;
+  max-width: none !important;
 }
 
 .sectionIntro > p {
-  margin-top: 13px !important;
-  max-width: 61ch !important;
+  margin-top: 12px !important;
+  max-width: 66ch !important;
 }
 
 .workbench {
   background: var(--dev-code);
   border: 1px solid var(--dev-code-border);
-  border-radius: 14px;
-  box-shadow: 0 18px 48px rgba(4, 7, 10, 0.18);
+  border-radius: 16px;
+  box-shadow: 0 20px 54px rgba(4, 7, 10, 0.16);
   color: var(--dev-code-text);
   overflow: hidden;
   position: relative;
@@ -138,75 +88,36 @@
   border-bottom: 1px solid var(--dev-code-border);
   display: flex;
   justify-content: space-between;
-  min-height: 43px;
-  padding-inline: 13px 9px;
-}
-
-.workbenchTopbar > div,
-.workbenchTopbar > a {
-  align-items: center;
-  display: flex;
-}
-
-.workbenchTopbar > div {
-  gap: 9px;
-}
-
-.windowDots {
-  display: flex;
-  gap: 4px;
-}
-
-.windowDots i {
-  background: #3a4048;
-  border-radius: 50%;
-  height: 5px;
-  width: 5px;
-}
-
-.windowDots i:first-child {
-  background: var(--dev-accent);
+  min-height: 48px;
+  padding-inline: 16px 10px;
 }
 
 .workbenchLabel {
-  color: #c8ced5;
-  font-size: 9.5px;
-  font-weight: 760;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  color: #dce1e6;
+  font-size: 12px;
+  font-weight: 680;
 }
 
 .openApiLink {
-  border-radius: 6px;
-  color: #a5aeb8;
-  font-size: 10px;
-  font-weight: 630;
-  gap: 5px;
-  min-height: 30px;
-  padding-inline: 8px;
+  align-items: center;
+  border-radius: 8px;
+  color: #aeb6bf;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 620;
+  gap: 6px;
+  min-height: 34px;
+  padding-inline: 10px;
   text-decoration: none;
   transition:
-    background-color 140ms var(--ease-out),
-    color 140ms var(--ease-out);
-}
-
-.openApiLink:focus-visible,
-.languageTabs button:focus-visible,
-.copyButton:focus-visible,
-.runButton:focus-visible,
-.promptCopyButton:focus-visible,
-.agentPromptLinks a:focus-visible,
-.resourceLink:focus-visible,
-.endpointList a:focus-visible,
-.responseGroup summary:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 2px;
+    background-color 130ms var(--ease-out),
+    color 130ms var(--ease-out);
 }
 
 .workbenchGrid {
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(190px, 0.92fr);
-  min-height: 306px;
+  grid-template-columns: minmax(0, 1.12fr) minmax(260px, 0.88fr);
+  min-height: 344px;
 }
 
 .codePane,
@@ -224,9 +135,10 @@
   background: var(--dev-code-raised);
   border-bottom: 1px solid var(--dev-code-border);
   display: flex;
+  gap: 8px;
   justify-content: space-between;
-  min-height: 43px;
-  padding-inline: 9px;
+  min-height: 48px;
+  padding-inline: 10px;
 }
 
 .languageTabs {
@@ -238,13 +150,13 @@
 .languageTabs button {
   background: transparent;
   border: 0;
-  border-radius: 6px;
-  color: #838d98;
+  border-radius: 7px;
+  color: #8e98a3;
   font: inherit;
-  font-size: 9.5px;
-  font-weight: 650;
-  min-height: 32px;
-  padding-inline: 7px;
+  font-size: 12px;
+  font-weight: 620;
+  min-height: 36px;
+  padding-inline: 10px;
   position: relative;
   transition:
     background-color 120ms var(--ease-out),
@@ -253,15 +165,15 @@
 
 .languageTabs button[aria-selected="true"] {
   background: rgba(255, 255, 255, 0.07);
-  color: #f4f6f8;
+  color: #f5f7f9;
 }
 
 .languageTabs button[aria-selected="true"]::after {
   background: var(--dev-accent);
-  bottom: -6px;
+  bottom: -7px;
   content: "";
   height: 2px;
-  inset-inline: 8px;
+  inset-inline: 10px;
   position: absolute;
 }
 
@@ -277,14 +189,13 @@
 
 .copyButton {
   background: transparent;
-  border-radius: 6px;
-  color: #98a2ad;
-  font-size: 9.5px;
-  font-weight: 650;
-  gap: 5px;
-  min-height: 32px;
-  min-width: 60px;
-  padding-inline: 7px;
+  border-radius: 7px;
+  color: #a7b0ba;
+  font-size: 12px;
+  font-weight: 630;
+  gap: 6px;
+  min-height: 36px;
+  padding-inline: 9px;
   transition:
     background-color 120ms var(--ease-out),
     color 120ms var(--ease-out),
@@ -292,11 +203,11 @@
 }
 
 .copyButton[data-state="copied"] {
-  color: #79ceb3;
+  color: #7ad0b4;
 }
 
 .copyButton[data-state="error"] {
-  color: #eb9ba3;
+  color: #ee9aa5;
 }
 
 .copyIcon {
@@ -306,21 +217,17 @@
 }
 
 .codePanel {
-  min-height: 262px;
+  min-height: 296px;
   outline: 0;
-  padding: 16px 15px 18px;
-}
-
-.codePanel:focus-visible {
-  box-shadow: inset 0 0 0 2px var(--focus);
+  padding: 20px 18px 22px;
 }
 
 .filename {
-  color: #68727d;
+  color: #78828d;
   display: block;
   font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
-  font-size: 9px;
-  margin-bottom: 11px;
+  font-size: 11px;
+  margin-bottom: 14px;
 }
 
 .codePanel pre,
@@ -328,38 +235,34 @@
 .agentPromptCode {
   margin: 0;
   overflow: auto;
-  scrollbar-color: rgba(170, 184, 199, 0.26) transparent;
+  scrollbar-color: rgba(170, 184, 199, 0.28) transparent;
 }
 
 .codePanel code,
 .responseBody code,
 .agentPromptCode code {
   font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
-  font-size: 10.5px;
-  line-height: 1.66;
+  font-size: 12px;
+  line-height: 1.7;
   tab-size: 2;
 }
 
 .codePanel code {
-  color: #dce2e8;
+  color: #e0e5ea;
   white-space: pre;
 }
 
 .responsePane {
-  background: #0d1014;
-}
-
-.responseHeader {
-  gap: 7px;
+  background: #0e1014;
 }
 
 .responseHeader > div {
   align-items: center;
-  color: #929ca7;
+  color: #a6afb9;
   display: flex;
-  font-size: 9.5px;
-  font-weight: 630;
-  gap: 6px;
+  font-size: 12px;
+  font-weight: 610;
+  gap: 7px;
   min-width: 0;
 }
 
@@ -370,11 +273,15 @@
 }
 
 .responseStatusDot {
-  color: #5f6872;
+  background: currentColor;
+  border-radius: 50%;
+  color: #66707b;
   flex: 0 0 auto;
+  height: 7px;
   transition:
     background-color 150ms var(--ease-out),
     box-shadow 150ms var(--ease-out);
+  width: 7px;
 }
 
 .workbench[data-request-state="success"] .responseStatusDot {
@@ -388,20 +295,20 @@
 }
 
 .workbench[data-request-state="loading"] .responseStatusDot {
-  color: #aeb8c4;
+  color: #b5bec8;
   box-shadow: 0 0 0 3px rgba(174, 184, 196, 0.1);
 }
 
 .runButton {
   background: #f2f4f6;
-  border-radius: 7px;
+  border-radius: 8px;
   color: #111419;
   flex: 0 0 auto;
-  font-size: 9.5px;
-  font-weight: 740;
-  gap: 5px;
-  min-height: 32px;
-  padding-inline: 8px;
+  font-size: 12px;
+  font-weight: 720;
+  gap: 6px;
+  min-height: 36px;
+  padding-inline: 10px;
   transition:
     background-color 120ms var(--ease-out),
     opacity 120ms var(--ease-out),
@@ -413,10 +320,20 @@
   opacity: 0.68;
 }
 
-.runButton:active:not(:disabled),
-.promptCopyButton:active,
-.copyButton:active {
-  transform: scale(0.96);
+.responseBody {
+  min-height: 296px;
+  padding: 20px 18px;
+}
+
+.responseBody pre {
+  max-height: 260px;
+  min-height: 100%;
+}
+
+.responseBody code {
+  color: #b5bec8;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .loadingIcon {
@@ -429,50 +346,6 @@
   }
 }
 
-.responseBody {
-  min-height: 262px;
-  padding: 16px 14px;
-}
-
-.responseBody pre {
-  max-height: 230px;
-  min-height: 100%;
-}
-
-.responseBody code {
-  color: #aeb7c1;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.firstSuccess {
-  align-items: flex-start;
-  border-left: 2px solid var(--dev-live);
-  color: var(--dev-live);
-  display: flex;
-  gap: 11px;
-  margin-top: 18px;
-  padding: 3px 0 3px 14px;
-}
-
-.firstSuccess svg {
-  flex: 0 0 auto;
-}
-
-.firstSuccess strong {
-  color: var(--text);
-  display: block;
-  font-size: 13.5px;
-  font-weight: 690;
-}
-
-.firstSuccess p {
-  color: var(--text-soft) !important;
-  font-size: 13px !important;
-  line-height: 1.55 !important;
-  margin-top: 3px !important;
-}
-
 .responseMap {
   border-block: 1px solid var(--dev-rule);
   display: grid;
@@ -482,9 +355,9 @@
   align-items: center;
   border-bottom: 1px solid var(--dev-rule);
   display: flex;
-  gap: 11px;
-  min-height: 58px;
-  padding: 10px 4px;
+  gap: 12px;
+  min-height: 64px;
+  padding: 12px 4px;
 }
 
 .responseRoot svg {
@@ -494,18 +367,18 @@
 .responseRoot > span,
 .responseGroup summary > span:nth-child(2) {
   display: grid;
-  gap: 1px;
+  gap: 2px;
 }
 
 .responseRoot strong {
   color: var(--text);
-  font-size: 13.5px;
+  font-size: 14px;
 }
 
 .responseRoot small,
 .responseGroup small {
   color: var(--muted);
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.45;
 }
 
@@ -522,34 +395,30 @@
 }
 
 .responseGroup[open] {
-  background: color-mix(in srgb, var(--surface-soft) 58%, transparent);
+  background: color-mix(in srgb, var(--surface-soft) 55%, transparent);
 }
 
 .responseGroup summary {
   align-items: center;
   display: grid;
-  gap: 11px;
+  gap: 12px;
   grid-template-columns: auto minmax(0, 1fr) auto;
   list-style: none;
-  min-height: 54px;
-  padding: 9px 4px;
+  min-height: 58px;
+  padding: 10px 4px;
 }
 
 .responseGroup summary::-webkit-details-marker {
   display: none;
 }
 
-.responseGroup summary:focus-visible {
-  outline-offset: -2px;
-}
-
 .responseGroupDot {
   background: var(--dev-accent);
   border-radius: 50%;
-  height: 5px;
+  height: 6px;
   margin-inline: 4px 2px;
-  opacity: 0.58;
-  width: 5px;
+  opacity: 0.6;
+  width: 6px;
 }
 
 .responseGroup[open] .responseGroupDot {
@@ -559,7 +428,7 @@
 .responseGroup summary code {
   color: var(--text);
   font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 650;
 }
 
@@ -567,12 +436,11 @@
   align-items: center;
   color: var(--muted);
   display: inline-flex;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 15px;
-  height: 28px;
+  font-size: 17px;
+  height: 32px;
   justify-content: center;
   transition: transform 160ms var(--ease-out);
-  width: 28px;
+  width: 32px;
 }
 
 .responseGroup[open] .responseChevron {
@@ -581,13 +449,13 @@
 
 .responseGroupBody {
   display: grid;
-  gap: 9px;
-  padding: 0 36px 16px;
+  gap: 10px;
+  padding: 0 42px 18px;
 }
 
 .responseGroupBody p {
   color: var(--text-soft) !important;
-  font-size: 13px !important;
+  font-size: 14px !important;
   line-height: 1.58 !important;
   margin: 0 !important;
   max-width: 66ch !important;
@@ -596,18 +464,19 @@
 .responseGroupBody code {
   color: var(--dev-accent);
   font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
-  font-size: 10.5px;
+  font-size: 11.5px;
   line-height: 1.55;
 }
 
 .identityRule {
   align-items: center;
-  border-left: 2px solid var(--dev-accent);
+  background: var(--dev-accent-soft);
+  border-radius: 12px;
   display: grid;
   gap: 12px;
   grid-template-columns: auto 1fr;
-  margin-top: 17px;
-  padding: 5px 0 5px 14px;
+  margin-top: 18px;
+  padding: 14px 16px;
 }
 
 .identityRule > svg {
@@ -618,22 +487,28 @@
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 7px 12px;
+  gap: 7px 14px;
 }
 
 .identityRule span {
-  color: var(--muted);
-  font-size: 10px;
-  font-weight: 740;
-  letter-spacing: 0.09em;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 680;
   margin-right: auto;
-  text-transform: uppercase;
+}
+
+.identityRule code,
+.syncSteps code,
+.cursorComparison code,
+.stateLegend code,
+.endpointList code,
+.httpStates code {
+  font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
 }
 
 .identityRule code {
   color: var(--text-soft);
-  font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
-  font-size: 10.5px;
+  font-size: 11.5px;
 }
 
 .syncSteps {
@@ -644,76 +519,70 @@
 }
 
 .syncSteps li {
-  border-top: 1px solid var(--dev-rule);
+  border-bottom: 1px solid var(--dev-rule);
   display: grid;
   gap: 14px;
-  grid-template-columns: 32px minmax(0, 1fr);
-  padding: 17px 4px;
+  grid-template-columns: 30px minmax(0, 1fr);
+  padding: 19px 4px;
 }
 
-.syncSteps li:last-child {
-  border-bottom: 1px solid var(--dev-rule);
+.syncSteps li:first-child {
+  border-top: 1px solid var(--dev-rule);
 }
 
 .stepNumber {
   color: var(--dev-accent);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
+  font-size: 13px;
   font-variant-numeric: tabular-nums;
   font-weight: 720;
-  padding-top: 3px;
-}
-
-.stepNumber::before {
-  content: "0";
+  padding-top: 2px;
 }
 
 .syncSteps li > div {
   display: grid;
-  gap: 5px;
+  gap: 6px;
 }
 
 .syncSteps strong {
   color: var(--text);
-  font-size: 14px;
-  font-weight: 680;
+  font-size: 15px;
+  font-weight: 670;
 }
 
 .syncSteps p {
   color: var(--text-soft) !important;
-  font-size: 13px !important;
-  line-height: 1.56 !important;
+  font-size: 14px !important;
+  line-height: 1.58 !important;
   margin: 0 !important;
 }
 
 .syncSteps li > div > code {
   color: var(--dev-accent);
-  font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
-  font-size: 10.5px;
-  margin-top: 2px;
+  font-size: 11.5px;
+  margin-top: 3px;
   overflow-wrap: anywhere;
 }
 
 .syncSteps p code {
   color: var(--text);
-  font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
   font-size: 0.92em;
 }
 
 .cursorComparison {
   align-items: center;
-  border-block: 1px solid var(--dev-rule);
+  background: color-mix(in srgb, var(--surface-soft) 70%, transparent);
+  border-radius: 12px;
   display: grid;
   gap: 14px;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-  margin-top: 16px;
-  padding: 13px 4px;
+  margin-top: 18px;
+  padding: 15px 16px;
 }
 
 .cursorComparison > div {
   align-items: center;
   display: flex;
-  gap: 9px;
+  gap: 10px;
 }
 
 .cursorComparison svg {
@@ -722,18 +591,18 @@
 
 .cursorComparison > div > span {
   display: grid;
-  gap: 1px;
+  gap: 2px;
 }
 
 .cursorComparison strong {
   color: var(--text);
   font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
+  font-size: 12px;
 }
 
 .cursorComparison small {
   color: var(--muted);
-  font-size: 10.5px;
+  font-size: 12px;
 }
 
 .cursorArrow {
@@ -742,48 +611,28 @@
 
 .renderingRules {
   display: grid;
+  gap: 30px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .renderingRules article {
-  border-left: 1px solid var(--dev-rule);
   min-width: 0;
-  padding: 2px 22px 0;
-}
-
-.renderingRules article:first-child {
-  border-left: 0;
-  padding-left: 0;
-}
-
-.renderingRules article:last-child {
-  padding-right: 0;
 }
 
 .renderingRules article svg {
   color: var(--dev-accent);
-}
-
-.renderingRules article > span {
-  color: var(--muted);
-  display: block;
-  font-size: 9.5px;
-  font-weight: 740;
-  letter-spacing: 0.09em;
-  margin-top: 16px;
-  text-transform: uppercase;
+  margin-bottom: 14px;
 }
 
 .renderingRules h3 {
   font-size: 17px !important;
-  margin-top: 6px;
 }
 
 .renderingRules p {
   color: var(--text-soft) !important;
-  font-size: 12.5px !important;
-  line-height: 1.56 !important;
-  margin-top: 8px !important;
+  font-size: 14px !important;
+  line-height: 1.58 !important;
+  margin-top: 9px !important;
 }
 
 .stateLegend {
@@ -791,31 +640,28 @@
   border-top: 1px solid var(--dev-rule);
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 15px;
-  margin-top: 22px;
-  padding-top: 13px;
+  gap: 8px 16px;
+  margin-top: 26px;
+  padding-top: 16px;
 }
 
 .stateLegend > span {
-  color: var(--muted);
-  font-size: 9.5px;
-  font-weight: 740;
-  letter-spacing: 0.09em;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 650;
   margin-right: 2px;
-  text-transform: uppercase;
 }
 
 .stateLegend code {
   color: var(--text-soft);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
+  font-size: 11.5px;
 }
 
 .agentPrompt {
   background: var(--dev-code);
   border: 1px solid var(--dev-code-border);
-  border-radius: 14px;
-  box-shadow: 0 16px 42px rgba(4, 7, 10, 0.15);
+  border-radius: 15px;
+  box-shadow: 0 18px 46px rgba(4, 7, 10, 0.14);
   color: var(--dev-code-text);
   overflow: hidden;
 }
@@ -824,40 +670,28 @@
   align-items: center;
   border-bottom: 1px solid var(--dev-code-border);
   display: flex;
+  gap: 16px;
   justify-content: space-between;
-  min-height: 64px;
-  padding: 11px 12px 11px 16px;
-}
-
-.agentPromptHeader > div {
-  display: grid;
-  gap: 3px;
-}
-
-.agentPromptEyebrow {
-  color: #d47a9a;
-  font-size: 9px;
-  font-weight: 760;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  min-height: 62px;
+  padding: 11px 12px 11px 18px;
 }
 
 .agentPromptHeader strong {
-  color: #edf1f4;
-  font-size: 13px;
-  font-weight: 670;
+  color: #f0f3f5;
+  font-size: 14px;
+  font-weight: 660;
 }
 
 .promptCopyButton {
   background: #f1f3f5;
-  border-radius: 7px;
+  border-radius: 8px;
   color: #111419;
   flex: 0 0 auto;
-  font-size: 10px;
-  font-weight: 730;
+  font-size: 12px;
+  font-weight: 710;
   gap: 6px;
-  min-height: 35px;
-  padding-inline: 10px;
+  min-height: 38px;
+  padding-inline: 11px;
   transition:
     background-color 120ms var(--ease-out),
     color 120ms var(--ease-out),
@@ -875,10 +709,10 @@
 }
 
 .agentPromptCode {
-  color: #b5bec8;
+  color: #bac2cb;
   display: block;
-  max-height: 300px;
-  padding: 17px 18px 20px;
+  max-height: 330px;
+  padding: 19px 20px 22px;
   white-space: pre-wrap;
 }
 
@@ -887,69 +721,24 @@
   border-top: 1px solid var(--dev-code-border);
   display: flex;
   flex-wrap: wrap;
-  gap: 2px;
-  padding: 7px 9px;
+  gap: 3px;
+  padding: 8px 10px;
 }
 
 .agentPromptLinks a {
   align-items: center;
-  border-radius: 6px;
-  color: #9da7b1;
+  border-radius: 7px;
+  color: #aab3bd;
   display: inline-flex;
-  font-size: 10px;
-  font-weight: 630;
-  gap: 5px;
-  min-height: 32px;
-  padding-inline: 8px;
+  font-size: 12px;
+  font-weight: 620;
+  gap: 6px;
+  min-height: 36px;
+  padding-inline: 9px;
   text-decoration: none;
   transition:
     background-color 120ms var(--ease-out),
     color 120ms var(--ease-out);
-}
-
-.agentSurfaces {
-  border-block: 1px solid var(--dev-rule);
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: 15px;
-}
-
-.agentSurfaces > div {
-  align-items: center;
-  border-left: 1px solid var(--dev-rule);
-  display: flex;
-  gap: 9px;
-  min-width: 0;
-  padding: 12px;
-}
-
-.agentSurfaces > div:first-child {
-  border-left: 0;
-}
-
-.agentSurfaces svg {
-  color: var(--dev-accent);
-  flex: 0 0 auto;
-}
-
-.agentSurfaces span {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
-}
-
-.agentSurfaces strong {
-  color: var(--text);
-  font-size: 11.5px;
-}
-
-.agentSurfaces code {
-  color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 9.5px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .endpointList {
@@ -961,10 +750,10 @@
   align-items: center;
   color: inherit;
   display: grid;
-  gap: 11px;
-  grid-template-columns: 36px minmax(210px, 0.9fr) minmax(230px, 1.1fr) auto;
-  min-height: 68px;
-  padding: 10px 4px;
+  gap: 13px;
+  grid-template-columns: 40px minmax(220px, 0.95fr) minmax(240px, 1.05fr) auto;
+  min-height: 76px;
+  padding: 12px 5px;
   text-decoration: none;
   transition:
     background-color 130ms var(--ease-out),
@@ -978,30 +767,29 @@
 .method {
   color: var(--dev-live);
   font-family: var(--font-plex-mono), monospace;
-  font-size: 9px;
-  font-weight: 780;
+  font-size: 10.5px;
+  font-weight: 760;
 }
 
 .endpointList > a > code {
   color: var(--text);
-  font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
-  font-size: 10.5px;
+  font-size: 12px;
   overflow-wrap: anywhere;
 }
 
 .endpointDescription {
   display: grid;
-  gap: 2px;
+  gap: 3px;
 }
 
 .endpointDescription strong {
   color: var(--text);
-  font-size: 12px;
+  font-size: 13.5px;
 }
 
 .endpointDescription small {
   color: var(--muted);
-  font-size: 10.5px;
+  font-size: 12px;
   line-height: 1.45;
 }
 
@@ -1013,22 +801,21 @@
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px 18px;
-  margin-top: 14px;
+  gap: 9px 20px;
+  margin-top: 16px;
 }
 
 .httpStates span {
   align-items: center;
   color: var(--text-soft);
   display: inline-flex;
-  font-size: 10.5px;
-  gap: 5px;
+  font-size: 12px;
+  gap: 6px;
 }
 
 .httpStates code {
   color: var(--dev-accent);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 720;
 }
 
@@ -1036,7 +823,7 @@
   border-top: 1px solid var(--dev-rule);
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-top: 22px;
+  margin-top: 28px;
 }
 
 .resourceLink {
@@ -1045,8 +832,8 @@
   color: inherit;
   display: flex;
   justify-content: space-between;
-  min-height: 67px;
-  padding: 11px 5px;
+  min-height: 74px;
+  padding: 13px 6px;
   text-decoration: none;
   transition:
     background-color 130ms var(--ease-out),
@@ -1054,27 +841,27 @@
 }
 
 .resourceLink:nth-child(odd) {
-  padding-right: 16px;
+  padding-right: 18px;
 }
 
 .resourceLink:nth-child(even) {
   border-left: 1px solid var(--dev-rule);
-  padding-left: 16px;
+  padding-left: 18px;
 }
 
 .resourceLink > span {
   display: grid;
-  gap: 2px;
+  gap: 3px;
 }
 
 .resourceLink strong {
   color: var(--text);
-  font-size: 12.5px;
+  font-size: 13.5px;
 }
 
 .resourceLink small {
   color: var(--muted);
-  font-size: 10.5px;
+  font-size: 12px;
 }
 
 .resourceLink svg {
@@ -1082,44 +869,51 @@
   flex: 0 0 auto;
 }
 
-.docsBoundary {
-  align-items: flex-start;
-  border-left: 2px solid var(--muted);
-  color: var(--muted);
-  display: flex;
-  gap: 11px;
-  margin-top: 18px;
-  padding: 4px 0 4px 14px;
+.docsActions button:focus-visible,
+.docsActions a:focus-visible,
+.openApiLink:focus-visible,
+.languageTabs button:focus-visible,
+.copyButton:focus-visible,
+.runButton:focus-visible,
+.promptCopyButton:focus-visible,
+.agentPromptLinks a:focus-visible,
+.resourceLink:focus-visible,
+.endpointList a:focus-visible,
+.responseGroup summary:focus-visible,
+.codePanel:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
 }
 
-.docsBoundary svg {
-  flex: 0 0 auto;
-  margin-top: 1px;
+.codePanel:focus-visible,
+.responseGroup summary:focus-visible {
+  outline-offset: -2px;
 }
 
-.docsBoundary strong {
-  color: var(--text);
-  display: block;
-  font-size: 12.5px;
-}
-
-.docsBoundary p {
-  color: var(--text-soft) !important;
-  font-size: 12px !important;
-  line-height: 1.55 !important;
-  margin-top: 4px !important;
+.runButton:active:not(:disabled),
+.promptCopyButton:active,
+.copyButton:active,
+.docsActions button:active,
+.docsActions a:active {
+  transform: scale(0.96);
 }
 
 @media (hover: hover) and (pointer: fine) {
+  .docsActions button:hover,
+  .docsActions a:hover {
+    background: var(--surface-soft);
+    border-color: color-mix(in srgb, var(--dev-accent) 28%, var(--panel-border));
+  }
+
   .openApiLink:hover,
   .copyButton:hover,
   .agentPromptLinks a:hover {
     background: rgba(255, 255, 255, 0.07);
-    color: #f0f3f6;
+    color: #f2f5f7;
   }
 
   .languageTabs button:hover {
-    color: #dce2e8;
+    color: #e1e6eb;
   }
 
   .runButton:hover:not(:disabled),
@@ -1130,7 +924,7 @@
   .responseGroup:hover,
   .endpointList a:hover,
   .resourceLink:hover {
-    background: color-mix(in srgb, var(--surface-soft) 55%, transparent);
+    background: color-mix(in srgb, var(--surface-soft) 52%, transparent);
   }
 
   .resourceLink:hover svg,
@@ -1151,26 +945,24 @@
 
   .codePanel,
   .responseBody {
-    min-height: 220px;
+    min-height: 230px;
   }
 
   .responseBody pre {
-    max-height: 220px;
+    max-height: 230px;
   }
 
   .renderingRules {
+    gap: 0;
     grid-template-columns: 1fr;
   }
 
-  .renderingRules article,
-  .renderingRules article:first-child,
-  .renderingRules article:last-child {
-    border-left: 0;
+  .renderingRules article {
     border-top: 1px solid var(--dev-rule);
     display: grid;
-    gap: 0 13px;
+    gap: 0 14px;
     grid-template-columns: auto 1fr;
-    padding: 16px 2px;
+    padding: 18px 2px;
   }
 
   .renderingRules article:last-child {
@@ -1178,29 +970,12 @@
   }
 
   .renderingRules article > svg {
-    grid-row: 1 / span 3;
-  }
-
-  .renderingRules article > span {
-    margin-top: 0;
-  }
-
-  .agentSurfaces {
-    grid-template-columns: 1fr;
-  }
-
-  .agentSurfaces > div,
-  .agentSurfaces > div:first-child {
-    border-left: 0;
-    border-top: 1px solid var(--dev-rule);
-  }
-
-  .agentSurfaces > div:first-child {
-    border-top: 0;
+    grid-row: 1 / span 2;
+    margin: 1px 0 0;
   }
 
   .endpointList a {
-    grid-template-columns: 36px minmax(0, 1fr) auto;
+    grid-template-columns: 40px minmax(0, 1fr) auto;
   }
 
   .endpointDescription {
@@ -1209,58 +984,29 @@
 }
 
 @media (max-width: 620px) {
-  .integrationMeta {
-    display: grid;
-    gap: 7px 12px;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .docsActions {
+    justify-content: flex-start;
+    width: 100%;
   }
 
-  .integrationMeta > span {
-    font-size: 11.5px;
-  }
-
-  .endpointBar {
-    gap: 4px 10px;
-    grid-template-columns: minmax(0, 1fr) auto;
-    margin-top: 15px;
-    padding-block: 9px;
-  }
-
-  .endpointBar > span:first-child {
-    grid-column: 1;
-  }
-
-  .endpointBar code {
-    grid-column: 1 / -1;
-    grid-row: 2;
-  }
-
-  .endpointLive {
-    grid-column: 2;
-    grid-row: 1;
+  .docsActions button,
+  .docsActions a {
+    flex: 1 1 140px;
+    min-height: 44px;
   }
 
   .workbench {
-    border-radius: 12px;
+    border-radius: 13px;
   }
 
   .workbenchTopbar {
-    min-height: 41px;
-    padding-inline: 11px 7px;
-  }
-
-  .windowDots {
-    display: none;
-  }
-
-  .workbenchTopbar > div {
-    gap: 0;
+    min-height: 46px;
+    padding-inline: 13px 7px;
   }
 
   .codePaneHeader,
   .responseHeader {
-    gap: 6px;
-    min-height: 49px;
+    min-height: 52px;
     padding-block: 5px;
   }
 
@@ -1270,38 +1016,36 @@
 
   .languageTabs button {
     flex: 0 0 auto;
-    min-height: 36px;
+    min-height: 40px;
   }
 
   .copyButton,
   .runButton {
-    min-height: 36px;
-  }
-
-  .copyButton {
-    min-width: 36px;
+    min-height: 40px;
   }
 
   .copyButton > span:last-child {
-    display: none;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
   }
 
   .codePanel,
   .responseBody {
-    min-height: 190px;
-    padding: 14px;
+    min-height: 210px;
+    padding: 16px;
   }
 
   .responseBody pre {
-    max-height: 190px;
-  }
-
-  .responseBranches {
-    margin: 0;
+    max-height: 210px;
   }
 
   .responseGroupBody {
-    padding-left: 30px;
+    padding-inline: 34px 12px;
   }
 
   .identityRule {
@@ -1326,28 +1070,23 @@
   }
 
   .agentPromptHeader {
-    align-items: flex-start;
+    align-items: stretch;
     display: grid;
-    gap: 11px;
   }
 
   .promptCopyButton {
-    min-height: 40px;
+    min-height: 44px;
     width: 100%;
   }
 
   .agentPromptCode {
-    max-height: 320px;
-    padding: 15px;
+    max-height: 340px;
+    padding: 17px;
   }
 
   .endpointList a {
-    gap: 7px;
-    padding-block: 13px;
-  }
-
-  .endpointList > a > code {
-    font-size: 10px;
+    gap: 8px;
+    padding-block: 14px;
   }
 
   .httpStates {
@@ -1362,18 +1101,25 @@
   .resourceLink:nth-child(odd),
   .resourceLink:nth-child(even) {
     border-left: 0;
-    padding-inline: 4px;
+    padding-inline: 5px;
   }
 }
 
 @media (max-width: 360px) {
-  .integrationMeta {
-    grid-template-columns: 1fr;
+  .docsActions {
+    gap: 6px;
+  }
+
+  .docsActions button,
+  .docsActions a {
+    font-size: 12px;
+    padding-inline: 9px;
+    white-space: nowrap;
   }
 
   .languageTabs button {
-    font-size: 9px;
-    padding-inline: 6px;
+    font-size: 11px;
+    padding-inline: 8px;
   }
 
   .httpStates {
@@ -1387,6 +1133,8 @@
     opacity: 0.72;
   }
 
+  .docsActions button,
+  .docsActions a,
   .responseStatusDot,
   .responseChevron,
   .resourceLink,

--- a/components/docs-experience.module.css
+++ b/components/docs-experience.module.css
@@ -1,9 +1,9 @@
 .page {
-  --docs-content-width: 900px;
-  --docs-layout-gap: clamp(36px, 4vw, 56px);
+  --docs-content-width: 860px;
+  --docs-layout-gap: clamp(36px, 4vw, 48px);
   --docs-link: #075fca;
   --docs-link-soft: rgba(7, 95, 202, 0.075);
-  --docs-rail-width: 208px;
+  --docs-rail-width: 240px;
   align-items: start;
   display: grid;
   gap: var(--docs-layout-gap);
@@ -11,7 +11,7 @@
     var(--docs-rail-width)
     minmax(0, var(--docs-content-width));
   justify-content: center;
-  padding-block: 24px 104px;
+  padding-block: 36px 112px;
 }
 
 :global(html[data-theme="dark"]) .page {
@@ -25,45 +25,51 @@
   width: 100%;
 }
 
-.heroTools {
-  align-items: center;
-  display: flex;
-  isolation: isolate;
-  justify-content: flex-end;
-  position: sticky;
-  top: calc(var(--header-height) + 12px);
-  width: 100%;
-  z-index: 43;
+.sidebarBrand {
+  display: grid;
+  gap: 1px;
+  margin-bottom: 2px;
+  padding: 3px 10px 8px;
+  text-decoration: none;
 }
 
-.heroTools::before {
-  background: linear-gradient(
-    180deg,
-    var(--body-background) 0%,
-    color-mix(in srgb, var(--body-background) 94%, transparent) 74%,
-    transparent 100%
-  );
-  content: "";
-  inset: -12px -16px -18px;
-  pointer-events: none;
-  position: absolute;
-  z-index: -1;
+.sidebarBrand span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 540;
+  line-height: 1.35;
+}
+
+.sidebarBrand strong {
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 670;
+  letter-spacing: -0.015em;
+  line-height: 1.35;
+}
+
+.sidebarSearch,
+.sidebarSearch .search {
+  width: 100%;
 }
 
 .docsCategories {
+  border-bottom: 1px solid var(--panel-border-soft);
   display: grid;
-  gap: 6px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: 22px;
-  max-width: 600px;
+  gap: 2px;
+  grid-template-columns: minmax(0, 1fr);
+  margin: 4px 0 14px;
+  padding-bottom: 14px;
 }
 
 .docsCategory {
+  align-items: center;
   border: 1px solid transparent;
-  border-radius: 9px;
-  display: grid;
-  gap: 1px;
-  min-height: 46px;
+  border-radius: 8px;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+  min-height: 40px;
   padding: 7px 10px;
   position: relative;
   transition:
@@ -74,14 +80,14 @@
 
 .docsCategory strong {
   color: var(--text);
-  font-size: 12.5px;
-  font-weight: 660;
+  font-size: 13.5px;
+  font-weight: 620;
   line-height: 1.25;
 }
 
 .docsCategory span {
   color: var(--muted);
-  font-size: 10.5px;
+  font-size: 11.5px;
   line-height: 1.3;
 }
 
@@ -98,7 +104,7 @@
 
 .docsCategoryUnavailable {
   color: var(--muted);
-  opacity: 0.58;
+  opacity: 0.62;
 }
 
 .docsCategoryUnavailable::after {
@@ -234,16 +240,20 @@
 }
 
 .hero {
-  margin-top: clamp(38px, 5svh, 52px);
+  margin-top: 0;
   max-width: var(--docs-content-width);
   scroll-margin-top: 148px;
 }
 
 .hero[data-has-aside="true"] {
+  display: block;
+}
+
+.heroHeader {
   align-items: start;
   display: grid;
-  gap: clamp(28px, 3.4vw, 42px);
-  grid-template-columns: minmax(280px, 0.76fr) minmax(0, 1.24fr);
+  gap: 28px;
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .heroCopy,
@@ -251,45 +261,47 @@
   min-width: 0;
 }
 
-.heroKicker {
-  color: #a83f64 !important;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10.5px !important;
-  font-weight: 720;
-  letter-spacing: 0.11em;
-  line-height: 1.3 !important;
-  margin: 0 0 13px !important;
-  max-width: none !important;
-  text-transform: uppercase;
+.heroAside {
+  margin-top: 36px;
+  width: 100%;
 }
 
-:global(html[data-theme="dark"]) .heroKicker {
-  color: #e087a6 !important;
+.heroKicker {
+  color: var(--muted) !important;
+  font-size: 13px !important;
+  font-weight: 570;
+  letter-spacing: 0;
+  line-height: 1.4 !important;
+  margin: 0 0 14px !important;
+  max-width: none !important;
+  text-transform: none;
 }
 
 .hero h1 {
-  font-size: clamp(44px, 4.5vw, 56px);
+  font-size: clamp(46px, 5vw, 60px);
   font-weight: 640;
   letter-spacing: -0.045em;
-  line-height: 1;
+  line-height: 1.02;
   text-wrap: balance;
 }
 
 .heroCopy > p {
   color: var(--text-soft);
-  font-size: 15.5px;
-  line-height: 1.58;
+  font-size: 17px;
+  line-height: 1.6;
   margin-top: 16px;
-  max-width: 46ch;
+  max-width: 66ch;
   text-wrap: pretty;
 }
 
 .heroMeta {
-  margin-top: 26px;
+  margin-top: 0;
 }
 
 .sidebar {
   align-self: start;
+  display: grid;
+  gap: 10px;
   grid-column: 1;
   inline-size: var(--docs-rail-width);
   position: sticky;
@@ -304,7 +316,7 @@
 
 .desktopNav {
   display: grid;
-  max-height: calc(100svh - var(--header-height) - 44px);
+  max-height: calc(100svh - var(--header-height) - 250px);
   overflow-y: auto;
   padding: 5px 10px 18px 0;
   scrollbar-gutter: stable;
@@ -341,11 +353,11 @@
 
 .navLabel {
   color: var(--dim);
-  font-size: 10.5px;
-  font-weight: 720;
-  letter-spacing: 0.1em;
+  font-size: 12px;
+  font-weight: 620;
+  letter-spacing: 0.015em;
   padding-inline: 11px 8px;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .navGroup ul {
@@ -361,7 +373,7 @@
   border-radius: 7px;
   color: var(--text-soft);
   display: flex;
-  font-size: 13.5px;
+  font-size: 14px;
   font-weight: 510;
   line-height: 1.35;
   min-height: 36px;
@@ -382,7 +394,7 @@
 }
 
 .layout {
-  margin-top: clamp(60px, 7svh, 76px);
+  margin-top: clamp(68px, 8svh, 84px);
   max-width: var(--docs-content-width);
   width: 100%;
 }
@@ -400,7 +412,7 @@
 }
 
 .content h2 {
-  font-size: clamp(28px, 2.7vw, 34px);
+  font-size: clamp(30px, 3vw, 36px);
   font-weight: 650;
   letter-spacing: -0.032em;
   line-height: 1.12;
@@ -423,7 +435,7 @@
 
 .content p {
   color: var(--text-soft);
-  font-size: 15.5px;
+  font-size: 16px;
   letter-spacing: 0;
   line-height: 1.62;
   max-width: 65ch;
@@ -1123,7 +1135,7 @@
 @media (max-width: 960px) {
   .page {
     display: block;
-    padding-block: 88px 112px;
+    padding-block: 144px 112px;
   }
 
   .mainColumn {
@@ -1131,6 +1143,7 @@
   }
 
   .sidebar {
+    gap: 8px;
     inline-size: auto;
     inset-inline: 24px;
     isolation: isolate;
@@ -1156,6 +1169,16 @@
   .desktopNav,
   .chapterIndicator {
     display: none;
+  }
+
+  .sidebarBrand,
+  .docsCategories {
+    display: none;
+  }
+
+  .sidebarSearch {
+    position: sticky;
+    top: 0;
   }
 
   .mobileNav {
@@ -1228,25 +1251,18 @@
     padding: 12px;
   }
 
-  .heroTools {
-    position: static;
-  }
-
-  .heroTools::before {
-    display: none;
-  }
-
   .hero {
-    margin-top: 44px;
+    margin-top: 28px;
   }
 
-  .hero[data-has-aside="true"] {
-    gap: 34px;
+  .heroHeader {
+    gap: 24px;
     grid-template-columns: minmax(0, 1fr);
   }
 
   .heroAside {
-    max-width: 720px;
+    margin-top: 30px;
+    max-width: none;
   }
 
   .layout {
@@ -1256,33 +1272,11 @@
 
 @media (max-width: 700px) {
   .page {
-    padding-block: 82px 112px;
+    padding-block: 140px 112px;
   }
 
   .sidebar {
     inset-inline: 14px;
-  }
-
-  .heroTools {
-    gap: 10px;
-  }
-
-  .docsCategories {
-    gap: 6px;
-    margin-top: 18px;
-  }
-
-  .docsCategory {
-    min-height: 46px;
-    padding: 7px 8px;
-  }
-
-  .docsCategory strong {
-    font-size: 12px;
-  }
-
-  .docsCategory span {
-    font-size: 10px;
   }
 
   .search {
@@ -1294,7 +1288,7 @@
   }
 
   .hero {
-    margin-top: 34px;
+    margin-top: 24px;
   }
 
   .hero h1 {
@@ -1302,13 +1296,13 @@
   }
 
   .heroCopy > p {
-    font-size: 15.5px;
-    line-height: 1.58;
+    font-size: 16px;
+    line-height: 1.6;
     margin-top: 14px;
   }
 
   .heroMeta {
-    margin-top: 22px;
+    margin-top: 0;
   }
 
   .layout {

--- a/components/docs-navigation.tsx
+++ b/components/docs-navigation.tsx
@@ -631,7 +631,7 @@ export function DocsNavigation({
                   : undefined
               }
             />
-            <p className={styles.navLabel}>On this page</p>
+            <p className={styles.navLabel}>Contents</p>
             <ul>
               {sections.map((section) => {
                 const href = `${currentPath}#${section.id}`;

--- a/components/docs-shell.tsx
+++ b/components/docs-shell.tsx
@@ -31,11 +31,12 @@ export function DocsShell({
   return (
     <div className={`${styles.page} page-width`} data-docs-shell>
       <aside className={styles.sidebar} data-docs-sidebar>
-        <DocsNavigation currentPath={currentPath} sections={sections} />
-      </aside>
+        <Link className={styles.sidebarBrand} href="/docs/developers">
+          <span>Programmable</span>
+          <strong>Developer docs</strong>
+        </Link>
 
-      <div className={styles.mainColumn}>
-        <div className={styles.heroTools} data-docs-tools>
+        <div className={styles.sidebarSearch} data-docs-tools>
           <DocsSearch />
         </div>
 
@@ -56,7 +57,7 @@ export function DocsShell({
                   key={category.label}
                 >
                   <strong>{category.label}</strong>
-                  <span>Integrations</span>
+                  <span>Public API</span>
                 </Link>
               );
             }
@@ -68,25 +69,29 @@ export function DocsShell({
                 key={category.label}
               >
                 <strong>{category.label}</strong>
-                <span>Available soon</span>
+                <span>Soon</span>
               </span>
             );
           })}
         </nav>
 
+        <DocsNavigation currentPath={currentPath} sections={sections} />
+      </aside>
+
+      <div className={styles.mainColumn}>
         <header
           className={styles.hero}
           data-docs-hero
           data-has-aside={heroAside ? "true" : undefined}
           id={heroAside ? "quickstart" : undefined}
         >
-          <div className={styles.heroCopy}>
-            {kicker ? <p className={styles.heroKicker}>{kicker}</p> : null}
-            <h1>{title}</h1>
-            <p>{description}</p>
-            {heroMeta ? (
-              <div className={styles.heroMeta}>{heroMeta}</div>
-            ) : null}
+          <div className={styles.heroHeader}>
+            <div className={styles.heroCopy}>
+              {kicker ? <p className={styles.heroKicker}>{kicker}</p> : null}
+              <h1>{title}</h1>
+              <p>{description}</p>
+            </div>
+            {heroMeta ? <div className={styles.heroMeta}>{heroMeta}</div> : null}
           </div>
           {heroAside ? (
             <div className={styles.heroAside}>{heroAside}</div>

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1,27 +1,17 @@
 .page {
-  --explore-pink: #a83f64;
-  --explore-pink-strong: #873149;
+  --explore-pink: var(--accent);
+  --explore-pink-strong: var(--accent-strong);
   --explore-pink-soft: color-mix(
     in srgb,
     var(--explore-pink) 9%,
     transparent
   );
-  --accent: var(--explore-pink);
-  --accent-strong: var(--explore-pink-strong);
-  --accent-soft: var(--explore-pink-soft);
-  --brand-pink: var(--explore-pink);
-  --focus: var(--explore-pink);
   display: block;
   height: auto;
   min-height: calc(100svh - var(--header-height));
   min-width: 0;
   overflow: visible;
   padding-bottom: 0;
-}
-
-:global(html[data-theme="dark"]) .page {
-  --explore-pink: #e087a6;
-  --explore-pink-strong: #f0a7be;
 }
 
 .pageHeading {
@@ -36,17 +26,6 @@
   position: relative;
   text-align: center;
   width: 100%;
-}
-
-.pageKicker {
-  color: var(--explore-pink);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.12em;
-  line-height: 1;
-  margin: 0 0 14px;
-  text-transform: uppercase;
 }
 
 .pageHeading h1 {
@@ -227,43 +206,6 @@
   width: 18px;
 }
 
-.indexRail {
-  align-items: baseline;
-  display: flex;
-  gap: 24px;
-  justify-content: space-between;
-  margin: 0 auto;
-  max-width: 1020px;
-  min-height: 20px;
-  min-width: 0;
-  padding-inline: 2px;
-  width: 100%;
-}
-
-.resultCount,
-.sortReadout {
-  color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-  line-height: 1.45;
-  margin: 0;
-}
-
-.sortReadout {
-  min-width: 0;
-  overflow: hidden;
-  text-align: end;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.sortReadout span {
-  color: var(--explore-pink);
-  margin-inline-end: 8px;
-  text-transform: uppercase;
-}
-
 .runnerGrid {
   align-items: stretch;
   display: grid;
@@ -337,20 +279,7 @@
 .runnerHeading {
   align-items: baseline;
   display: flex;
-  gap: 9px;
   min-width: 0;
-}
-
-.runnerIndex {
-  color: var(--explore-pink);
-  flex: none;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
-  font-variant-numeric: tabular-nums;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  line-height: 1;
-  transform: translateY(-2px);
 }
 
 .runnerHeading h3 {
@@ -358,7 +287,7 @@
   font-size: clamp(22px, 1.75vw, 26px);
   font-weight: 585;
   letter-spacing: -0.032em;
-  line-height: 1.03;
+  line-height: 1.15;
   margin: 0;
   min-width: 0;
   overflow: hidden;
@@ -406,7 +335,7 @@
 }
 
 .runnerMarketCapLabel {
-  color: var(--explore-pink);
+  color: var(--muted);
   font-size: 10px;
   letter-spacing: 0.08em;
 }
@@ -646,10 +575,6 @@
     padding: 22px 0 18px;
   }
 
-  .pageKicker {
-    margin-bottom: 10px;
-  }
-
   .pageHeading h1 {
     font-size: clamp(31px, 9vw, 38px);
     letter-spacing: -0.035em;
@@ -754,15 +679,6 @@
 
   .runnersIntro :global(.token-toolbar) {
     gap: 8px;
-  }
-
-  .indexRail {
-    gap: 12px;
-  }
-
-  .resultCount,
-  .sortReadout {
-    font-size: 10px;
   }
 
   .runnerHitArea {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -963,8 +963,6 @@ export function ExploreView() {
   const pageCount = Math.max(1, payload?.totalPages ?? 0);
   const activePage = Math.min(payload?.page ?? currentPage, pageCount);
   const paginationItems = getExplorePaginationItems(activePage, pageCount);
-  const activeSortLabel =
-    sortOptions.find((option) => option.id === sort)?.label ?? "Newest";
   const resultLabel = resultRangeLabel(payload);
   const busy =
     !preview &&
@@ -1067,11 +1065,6 @@ export function ExploreView() {
         {cards.map((token, index) => {
           const href = `/token/${token.tokenAddress}`;
           const imageSource = getTokenCardImageSource(token.imageUrl);
-          const rank =
-            (activePage - 1) *
-              (payload?.pageSize ?? EXPLORE_TOKENS_PER_PAGE) +
-            index +
-            1;
           const marketCapLabel = token.marketCap
             ? formatMarketCapMetric(token.marketCap)
             : null;
@@ -1101,9 +1094,6 @@ export function ExploreView() {
 
                 <div className={styles.runnerBody}>
                   <header className={styles.runnerHeading}>
-                    <span className={styles.runnerIndex} aria-hidden="true">
-                      {String(rank).padStart(2, "0")}
-                    </span>
                     <h3 title={token.name}>{token.name}</h3>
                   </header>
 
@@ -1163,7 +1153,6 @@ export function ExploreView() {
     <>
       <div className={`${styles.page} explore-page page-width`}>
         <header className={styles.pageHeading}>
-          <p className={styles.pageKicker}>Explore</p>
           <h1>Launch tokens that work the way you imagine.</h1>
         </header>
 
@@ -1409,20 +1398,14 @@ export function ExploreView() {
           </div>
 
           {hasPublicTokens ? (
-            <div className={styles.indexRail}>
-              <p
-                className={styles.resultCount}
-                role="status"
-                aria-live="polite"
-                aria-atomic="true"
-              >
-                {resultLabel}
-              </p>
-              <p className={styles.sortReadout}>
-                <span>Sort</span>
-                {activeSortLabel}
-              </p>
-            </div>
+            <p
+              className="sr-only"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {resultLabel}
+            </p>
           ) : null}
 
           {displayState.phase === "ready" &&

--- a/components/token-community-chat.module.css
+++ b/components/token-community-chat.module.css
@@ -151,12 +151,12 @@
   border-radius: 11px;
   color: var(--token-accent-ink, var(--accent-ink));
   display: inline-flex;
-  font-size: 12px;
+  font-size: 11.5px;
   font-weight: 680;
-  gap: 7px;
+  gap: 5px;
   height: 44px;
   justify-content: center;
-  padding: 0 13px;
+  padding: 0 10px;
   transition:
     filter 140ms ease,
     transform 140ms var(--ease-out);

--- a/components/token-community-chat.tsx
+++ b/components/token-community-chat.tsx
@@ -278,8 +278,8 @@ export function TokenCommunityChat({
           onChange={(event) => setDraft(event.target.value)}
         />
         <button type="submit" disabled={!draft.trim()}>
-          <Send aria-hidden="true" size={17} />
-          <span>Send message</span>
+          <Send aria-hidden="true" size={15} />
+          <span>Send</span>
         </button>
       </form>
       <p className={styles.storageError} role="status" aria-live="polite">

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -1350,46 +1350,39 @@ function TokenDetailContent({
             </dl>
           </section>
 
-          <section className={styles.projectPanel}>
-            <header className={styles.projectPanelHeading}>
-              <h2>Team</h2>
-            </header>
-            {creatorAddress ? (
-              <>
-                <div className={styles.creatorRecord}>
-                  <span className={styles.creatorMark} aria-hidden="true">
-                    {token.name.trim().charAt(0).toUpperCase() || "P"}
-                  </span>
-                  <div>
-                    <strong>
-                      {previewProject?.teamName ?? "Creator wallet"}
-                    </strong>
-                    {explorerBase ? (
-                      <a
-                        href={`${explorerBase}/address/${creatorAddress}`}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        <code>{formatProjectAddress(creatorAddress)}</code>
-                        <ArrowUpRight aria-hidden="true" size={13} />
-                      </a>
-                    ) : (
+          {creatorAddress ? (
+            <section className={styles.projectPanel}>
+              <header className={styles.projectPanelHeading}>
+                <h2>Team</h2>
+              </header>
+              <div className={styles.creatorRecord}>
+                <span className={styles.creatorMark} aria-hidden="true">
+                  {token.name.trim().charAt(0).toUpperCase() || "P"}
+                </span>
+                <div>
+                  <strong>{previewProject?.teamName ?? "Creator wallet"}</strong>
+                  {explorerBase ? (
+                    <a
+                      href={`${explorerBase}/address/${creatorAddress}`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
                       <code>{formatProjectAddress(creatorAddress)}</code>
-                    )}
-                  </div>
+                      <ArrowUpRight aria-hidden="true" size={13} />
+                    </a>
+                  ) : (
+                    <code>{formatProjectAddress(creatorAddress)}</code>
+                  )}
                 </div>
+              </div>
+              {previewProject ? (
                 <p className={styles.projectNote}>
-                  {previewProject
-                    ? `${previewProject.contributors} contributors · ${previewProject.teamSummary}`
-                    : "No team profile provided."}
+                  {previewProject.contributors} contributors ·{" "}
+                  {previewProject.teamSummary}
                 </p>
-              </>
-            ) : (
-              <p className={styles.projectEmpty}>
-                No team information provided.
-              </p>
-            )}
-          </section>
+              ) : null}
+            </section>
+          ) : null}
         </div>
       </div>
       {copyError ? (

--- a/tests/developer-docs-experience.test.ts
+++ b/tests/developer-docs-experience.test.ts
@@ -79,15 +79,15 @@ describe("Developer documentation experience", () => {
     expect(nextLanguageIndex(1, "End", 3)).toBe(2);
   });
 
-  it("collapses the workbench and integration metadata for narrow screens", () => {
+  it("collapses the workbench and keeps document actions usable on narrow screens", () => {
     expect(developerDocsCss).toMatch(
       /@media \(max-width: 820px\)[\s\S]*?\.workbenchGrid\s*\{[^}]*grid-template-columns:\s*1fr;/,
     );
     expect(developerDocsCss).toMatch(
-      /@media \(max-width: 620px\)[\s\S]*?\.integrationMeta\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*repeat\(2,/,
+      /@media \(max-width: 620px\)[\s\S]*?\.docsActions\s*\{[^}]*justify-content:\s*flex-start;[^}]*width:\s*100%;/,
     );
     expect(developerDocsCss).toMatch(
-      /@media \(max-width: 360px\)[\s\S]*?\.integrationMeta\s*\{[^}]*grid-template-columns:\s*1fr;/,
+      /@media \(max-width: 620px\)[\s\S]*?\.docsActions button,\s*\.docsActions a\s*\{[^}]*flex:\s*1 1 140px;[^}]*min-height:\s*44px;/,
     );
   });
 
@@ -131,8 +131,8 @@ describe("Developer documentation experience", () => {
   });
 
   it("keeps unpublished product docs visibly separate", () => {
-    expect(developerPage).toContain(
-      "Classic and Custom Hook product guides are not published yet.",
-    );
+    expect(developerPage).not.toContain("Classic and Custom Hook product guides");
+    expect(workbench).toContain('fetch("/docs/developers.md")');
+    expect(workbench).toContain("Copy Markdown");
   });
 });

--- a/tests/docs-layout-stability.test.ts
+++ b/tests/docs-layout-stability.test.ts
@@ -25,7 +25,7 @@ const interfaceCss = readFileSync(join(root, "app/interface.css"), "utf8");
 describe("Docs rail layout stability", () => {
   it("keeps the desktop rail sticky beside one bounded reading column", () => {
     expect(docsCss).toMatch(
-      /\.page\s*\{[^}]*--docs-content-width:\s*900px;[^}]*--docs-rail-width:\s*208px;/s,
+      /\.page\s*\{[^}]*--docs-content-width:\s*860px;[^}]*--docs-rail-width:\s*240px;/s,
     );
     expect(docsCss).toMatch(
       /\.page\s*\{[^}]*grid-template-columns:[^}]*var\(--docs-rail-width\)[^}]*minmax\(0,\s*var\(--docs-content-width\)\);/s,
@@ -38,13 +38,14 @@ describe("Docs rail layout stability", () => {
     );
   });
 
-  it("keeps the desktop tools available without pinning them on mobile", () => {
+  it("keeps search in the persistent rail and includes it in mobile offsets", () => {
     expect(docsShell).toContain("data-docs-tools");
+    expect(docsShell).toContain("styles.sidebarSearch");
     expect(docsCss).toMatch(
-      /\.heroTools\s*\{[^}]*position:\s*sticky;[^}]*top:\s*calc\(var\(--header-height\) \+ 12px\);/s,
+      /\.sidebarSearch,\s*\.sidebarSearch \.search\s*\{[^}]*width:\s*100%;/s,
     );
     expect(docsCss).toMatch(
-      /@media \(max-width:\s*960px\)[\s\S]*?\.heroTools\s*\{[^}]*position:\s*static;/s,
+      /@media \(max-width:\s*960px\)[\s\S]*?\.sidebarSearch\s*\{[^}]*position:\s*sticky;[^}]*top:\s*0;/s,
     );
   });
 
@@ -79,10 +80,10 @@ describe("Docs rail layout stability", () => {
     expect(docsShell).not.toContain("docsGuides");
     expect(docsShell).not.toContain("Documentation guides");
     expect(docsShell).toContain('aria-label="Documentation categories"');
-    expect(docsShell).toContain("Available soon");
-    expect(docsShell).toContain("Integrations");
+    expect(docsShell).toContain("Public API");
+    expect(docsShell).toContain("Soon");
     expect(docsNavigation).toContain(
-      '<p className={styles.navLabel}>On this page</p>',
+      '<p className={styles.navLabel}>Contents</p>',
     );
     expect(docsNavigation).toContain(
       "const navigationGroups = sections.length === 0 ? docsNavigation : [];",

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -47,5 +47,14 @@ describe("Explore UI contract", () => {
     expect(styles).not.toMatch(
       /\.runnerSocials\s*\{[^}]*margin-inline-start:\s*auto;/s,
     );
+    expect(source).not.toContain("styles.runnerIndex");
+    expect(source).not.toContain("styles.sortReadout");
+    expect(source).not.toContain("styles.pageKicker");
+    expect(styles).not.toContain(".runnerIndex");
+    expect(styles).not.toContain(".sortReadout");
+    expect(styles).not.toContain("#a83f64");
+    expect(styles).toMatch(
+      /\.runnerHeading h3\s*\{[^}]*line-height:\s*1\.15;/s,
+    );
   });
 });

--- a/tests/token-community-chat.test.ts
+++ b/tests/token-community-chat.test.ts
@@ -64,7 +64,8 @@ describe("token community room storage", () => {
     expect(source).toContain("useWallet()");
     expect(source).toContain("currentAvatarDataUrl");
     expect(source).toContain('placeholder="Write message"');
-    expect(source).toContain("<span>Send message</span>");
+    expect(source).toContain("<span>Send</span>");
+    expect(source).not.toContain("<span>Send message</span>");
     expect(source).not.toMatch(/Local Room|Room Notice/i);
     expect(source).not.toMatch(/Messages sync across tabs/i);
     expect(source).not.toMatch(/Message Programmable/i);

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -112,4 +112,10 @@ describe("token detail layout", () => {
     expect(detailSource).toContain("<EthereumMark />");
     expect(detailSource).toContain('aria-label="Token metadata"');
   });
+
+  it("omits empty team-profile filler copy", () => {
+    expect(detailSource).not.toContain("No team profile provided.");
+    expect(detailSource).not.toContain("No team information provided.");
+    expect(detailSource).toContain("{previewProject ? (");
+  });
 });


### PR DESCRIPTION
## Summary
- remove Explore ranking and sort/result chrome, restore neutral accents, and prevent token-name descender clipping
- tighten the community send action and omit empty team-profile filler
- rebuild Developer Docs around a persistent technical rail, full-width executable quickstart, Markdown/OpenAPI actions, clearer hierarchy, and responsive agent-ready reference content

## Validation
- focused UI contracts: 26/26
- ESLint: passed
- TypeScript: passed
- Next.js production build: passed
- browser QA: desktop, 390px, 320px, 200% reflow, interactions, console
- full Vitest run: 1,912 passed; 7 contract-release fixtures require bootstrapped submodules/build artifacts absent from this isolated UI worktree