### PR TITLE
Fix delegated revenue submission

### DIFF
--- a/lib/protocol-revenue/keeper-v2.server.ts
+++ b/lib/protocol-revenue/keeper-v2.server.ts
@@ -2,7 +2,6 @@ import "server-only";
 
 import { DelegationManager } from "@metamask/delegation-abis";
 import {
-  erc7710WalletActions,
   getNativeTokenPeriodTransferEnforcerAvailableAmount,
 } from "@metamask/smart-accounts-kit/actions";
 import { getSmartAccountsEnvironment } from "@metamask/smart-accounts-kit";
@@ -14,7 +13,6 @@ import {
 } from "@metamask/smart-accounts-kit/utils";
 import {
   createPublicClient,
-  createWalletClient,
   encodeFunctionData,
   getAddress,
   http,
@@ -704,46 +702,32 @@ export async function runConfiguredProtocolRevenueKeeperV2(
   }
 
   let transactionHash: Hex;
+  let submissionStage: "sign" | "broadcast" | "hash" = "sign";
   try {
-    if (action === "transfer") {
-      const walletClient = createWalletClient({
-        account,
-        chain: mainnet,
-        transport: http(privateEndpoint, { retryCount: 1, timeout: 12_000 }),
-      }).extend(erc7710WalletActions());
-      transactionHash = await walletClient.sendTransactionWithDelegation({
-        account,
-        chain: mainnet,
-        to: configuration.vault,
-        value: decision.amount,
-        data: "0x",
-        permissionContext: configuration.permissionContext,
-        delegationManager: configuration.delegationManager,
-        gas: economics.gasLimit,
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        nonce: latestNonce,
-      });
-    } else {
-      const serializedTransaction = await account.signTransaction({
-        chainId: mainnet.id,
-        data: transaction.data,
-        gas: economics.gasLimit,
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        nonce: latestNonce,
-        to: transaction.to,
-        type: "eip1559",
-        value: 0n,
-      });
-      transactionHash = await privateClient.sendRawTransaction({
-        serializedTransaction,
-      });
-      if (transactionHash.toLowerCase() !== keccak256(serializedTransaction)) {
-        throw new Error();
-      }
+    const serializedTransaction = await account.signTransaction({
+      chainId: mainnet.id,
+      data: transaction.data,
+      gas: economics.gasLimit,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+      nonce: latestNonce,
+      to: transaction.to,
+      type: "eip1559",
+      value: transaction.value,
+    });
+    submissionStage = "broadcast";
+    transactionHash = await privateClient.sendRawTransaction({
+      serializedTransaction,
+    });
+    submissionStage = "hash";
+    if (transactionHash.toLowerCase() !== keccak256(serializedTransaction)) {
+      throw new Error();
     }
   } catch {
+    console.error("Programmable protocol revenue submission rejected", {
+      action,
+      stage: submissionStage,
+    });
     throw new ProtocolRevenueKeeperV2Error("submission_failed");
   }
 

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -30,7 +30,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       }),
       runtime: Object.freeze({
         path: "lib/protocol-revenue/keeper-v2.server.ts",
-        sha256: "582b6f1fd78c5863b70a34977e5baa142f56310f0b92458ad4440954ab769f9d",
+        sha256: "f2dd4c49e2a9746398e205e0e70c1cdc4cd94ce0fb0191e230fb6076e9b43eb2",
       }),
       policy: Object.freeze({
         path: "lib/protocol-revenue/keeper-policy.ts",


### PR DESCRIPTION
## What changed

- submit the already encoded DelegationManager redemption as a locally signed EIP-1559 transaction
- use the same private raw-transaction path for transfer, claim and processing actions
- record only the failed submission stage if the private broadcast is rejected
- update the reviewed operations source binding

## Why

The first bounded canary passed its onchain simulation but the SDK wallet submission failed before a transaction was broadcast. No funds moved and the keeper nonce remained zero. The direct path now signs the exact transaction that passed simulation instead of asking the SDK wallet action to rebuild and submit it.

## Checks

- protocol revenue policy and runtime tests
- operations source gate
- ESLint
- TypeScript
- production build
- MEV Blocker call and gas-estimation check for the exact redemption payload
