### PR TITLE
Classify private relay failures safely

### DIFF
--- a/lib/protocol-revenue/keeper-v2.server.ts
+++ b/lib/protocol-revenue/keeper-v2.server.ts
@@ -399,6 +399,66 @@ function mevEndpoint(keeper: Address) {
   return endpoint.toString();
 }
 
+type SubmissionRejectionCategory =
+  | "fee_rejected"
+  | "insufficient_funds"
+  | "method_unsupported"
+  | "nonce_conflict"
+  | "provider_rejected"
+  | "simulation_rejected"
+  | "transport_failed"
+  | "unknown";
+
+function submissionErrorText(error: unknown) {
+  const fragments: string[] = [];
+  let current = error;
+  for (let depth = 0; depth < 6 && current; depth += 1) {
+    if (current instanceof Error) {
+      fragments.push(current.name, current.message);
+      current = "cause" in current ? current.cause : undefined;
+      continue;
+    }
+    if (typeof current === "object") {
+      const candidate = current as Readonly<Record<string, unknown>>;
+      for (const key of ["name", "message", "details", "shortMessage"]) {
+        if (typeof candidate[key] === "string") fragments.push(candidate[key]);
+      }
+      current = candidate.cause;
+      continue;
+    }
+    break;
+  }
+  return fragments.join(" ").toLowerCase();
+}
+
+export function classifyProtocolRevenueSubmissionError(
+  error: unknown,
+): SubmissionRejectionCategory {
+  const message = submissionErrorText(error);
+  if (/insufficient funds|insufficient balance/u.test(message)) {
+    return "insufficient_funds";
+  }
+  if (/nonce too low|nonce too high|already known|replacement transaction/u.test(message)) {
+    return "nonce_conflict";
+  }
+  if (/max fee per gas|priority fee|underpriced|fee cap|base fee/u.test(message)) {
+    return "fee_rejected";
+  }
+  if (/method not found|method .* not (?:exist|available|supported)/u.test(message)) {
+    return "method_unsupported";
+  }
+  if (/simulation|revert|execution reverted/u.test(message)) {
+    return "simulation_rejected";
+  }
+  if (/fetch failed|network|timeout|timed out|socket|connection/u.test(message)) {
+    return "transport_failed";
+  }
+  if (/rejected|denied|invalid transaction|rpc request/u.test(message)) {
+    return "provider_rejected";
+  }
+  return "unknown";
+}
+
 function maximum(values: readonly bigint[]) {
   return values.reduce((current, value) => value > current ? value : current);
 }
@@ -723,10 +783,11 @@ export async function runConfiguredProtocolRevenueKeeperV2(
     if (transactionHash.toLowerCase() !== keccak256(serializedTransaction)) {
       throw new Error();
     }
-  } catch {
+  } catch (error) {
     console.error("Programmable protocol revenue submission rejected", {
       action,
       stage: submissionStage,
+      category: classifyProtocolRevenueSubmissionError(error),
     });
     throw new ProtocolRevenueKeeperV2Error("submission_failed");
   }

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -30,7 +30,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       }),
       runtime: Object.freeze({
         path: "lib/protocol-revenue/keeper-v2.server.ts",
-        sha256: "f2dd4c49e2a9746398e205e0e70c1cdc4cd94ce0fb0191e230fb6076e9b43eb2",
+        sha256: "959985f6f93ed922342cb14b71aca9a49e2438fb2b80a56a9d10bd8397e0513e",
       }),
       policy: Object.freeze({
         path: "lib/protocol-revenue/keeper-policy.ts",

--- a/tests/protocol-revenue-keeper-runtime.test.ts
+++ b/tests/protocol-revenue-keeper-runtime.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import {
+  classifyProtocolRevenueSubmissionError,
   ProtocolRevenueKeeperV2Error,
   runConfiguredProtocolRevenueKeeperV2,
   safeProtocolRevenueKeeperV2Error,
@@ -58,5 +59,23 @@ describe("protocol revenue keeper runtime boundary", () => {
         new Error("private key and provider URL must never escape"),
       ),
     ).toEqual({ code: "unexpected_failure", retryable: true });
+  });
+
+  it("classifies private relay failures without returning provider text", () => {
+    expect(
+      classifyProtocolRevenueSubmissionError(
+        new Error("max fee per gas less than block base fee: secret payload"),
+      ),
+    ).toBe("fee_rejected");
+    expect(
+      classifyProtocolRevenueSubmissionError(
+        new Error("nonce too low: raw transaction must stay private"),
+      ),
+    ).toBe("nonce_conflict");
+    expect(
+      classifyProtocolRevenueSubmissionError(
+        new Error("unexpected provider response with sensitive details"),
+      ),
+    ).toBe("unknown");
   });
 });


### PR DESCRIPTION
Adds a finite, non-sensitive failure category to private relay rejection logs. Provider messages, signed payloads and key material are never emitted.

Checks:
- protocol revenue runtime tests
- TypeScript
- ESLint