### PR TITLE
Claim revenue before daily settlement

### DIFF
--- a/lib/protocol-revenue/keeper-policy.ts
+++ b/lib/protocol-revenue/keeper-policy.ts
@@ -36,6 +36,13 @@ export function evaluateProtocolRevenueV2Action(input: Readonly<{
     return { status: "process", revenue: input.pendingRevenue };
   }
 
+  if (
+    input.claimReady &&
+    input.claimAccruedRevenue >= input.claimMinimumRevenue
+  ) {
+    return { status: "claim", accruedRevenue: input.claimAccruedRevenue };
+  }
+
   const transferable = [
     input.rewardWalletBalance,
     input.permissionAvailable,
@@ -43,12 +50,6 @@ export function evaluateProtocolRevenueV2Action(input: Readonly<{
   ].reduce((current, value) => value < current ? value : current);
   if (transferable >= input.vaultMinimumRevenue) {
     return { status: "transfer", amount: transferable };
-  }
-  if (
-    input.claimReady &&
-    input.claimAccruedRevenue >= input.claimMinimumRevenue
-  ) {
-    return { status: "claim", accruedRevenue: input.claimAccruedRevenue };
   }
   if (
     input.rewardWalletBalance >= input.vaultMinimumRevenue &&

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -34,7 +34,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       }),
       policy: Object.freeze({
         path: "lib/protocol-revenue/keeper-policy.ts",
-        sha256: "4b4e0b56265743a102d4f1a9be271dfb8f13014f89e3ac1fba53ae3d8aa2d7bd",
+        sha256: "ca242872b95141f042656199b39ae4a1636ccdaf5585a97a7eae28a6549f8ab0",
       }),
     }),
   ]),

--- a/tests/protocol-revenue-keeper-policy.test.ts
+++ b/tests/protocol-revenue-keeper-policy.test.ts
@@ -9,7 +9,7 @@ import {
 const DELEGATION_HASH = `0x${"11".repeat(32)}`;
 
 describe("protocol revenue keeper policy", () => {
-  it("processes, transfers, then claims in fail-closed priority order", () => {
+  it("processes, claims, then transfers in fail-closed priority order", () => {
     const base = {
       finalizedTimestamp: 2_000n,
       pendingRevenue: 0n,
@@ -37,6 +37,14 @@ describe("protocol revenue keeper policy", () => {
     expect(
       evaluateProtocolRevenueV2Action({
         ...base,
+        claimReady: true,
+        claimAccruedRevenue: 200n,
+      }),
+    ).toEqual({ status: "claim", accruedRevenue: 200n });
+    expect(
+      evaluateProtocolRevenueV2Action({
+        ...base,
+        rewardWalletBalance: 900n,
         claimReady: true,
         claimAccruedRevenue: 200n,
       }),


### PR DESCRIPTION
Claims accrued Classic revenue before transferring the reward wallet balance into the daily settlement vault. An already funded vault is still processed first to avoid stranding a previous cycle.

Checks:
- protocol revenue policy and runtime tests
- operations source gate
- TypeScript
- ESLint