### PR TITLE
Isolate protocol revenue RPC quorum

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,10 @@ PROTOCOL_REVENUE_EXECUTOR_CODE_HASH=
 # Never use the reward, treasury or deployment-wallet key here.
 PROTOCOL_REVENUE_KEEPER_PRIVATE_KEY=
 PROTOCOL_REVENUE_KEEPER_MAX_GAS_PRICE_GWEI=5
+# Optional dedicated Mainnet quorum overrides. When unset, revenue execution
+# uses independent dRPC and PublicNode endpoints instead of shared trade RPCs.
+PROTOCOL_REVENUE_RPC_URL_A=
+PROTOCOL_REVENUE_RPC_URL_B=
 # 250 ensures the fixed 0.5% keeper allocation covers the buffered maximum gas
 # cost before a cycle can be submitted.
 PROTOCOL_REVENUE_KEEPER_MIN_REVENUE_GAS_MULTIPLIER=250

--- a/contracts/security/PROTOCOL-REVENUE-V2.md
+++ b/contracts/security/PROTOCOL-REVENUE-V2.md
@@ -3,9 +3,11 @@
 ## Status
 
 The immutable Coordinator and Vault are deployed on Ethereum Mainnet and match their submitted creation and runtime
-bytecode in Sourcify. The bounded ERC-7715 permission has been granted and stored outside the repository. Automation
-remains disabled. No revenue has moved through this system yet, so deployment and source verification must not be
-described as a successful production lifecycle.
+bytecode in Sourcify. The bounded ERC-7715 permission has been granted and stored outside the repository. The first
+Mainnet claim canary succeeded in transaction
+[`0xa84ae391934b6ca9c30ca0de4bcb00a99e0ef14cbacd3d14aa7579751bd39484`](https://etherscan.io/tx/0xa84ae391934b6ca9c30ca0de4bcb00a99e0ef14cbacd3d14aa7579751bd39484),
+claiming `0.785086332824991480 ETH` to the immutable revenue wallet. The transfer and process canaries remain pending,
+and automation remains disabled until both receipts and balance changes match the fixed policy.
 
 The automated claim scope is intentionally limited to Classic V1 and Classic V2. Classic V3, Deep and quote-asset
 hooks still require the revenue wallet as caller and remain manual.
@@ -64,6 +66,11 @@ output, `0.1 ETH` chunks and 32 chunks maximum. Any failed check reverts the com
 
 The runtime also has a server-side transfer ceiling bounded by the signed `5 ETH` daily permission. Releases can use a
 smaller ceiling for a first-cycle canary without changing or expanding the wallet grant.
+
+Revenue execution uses its own independent RPC quorum rather than inheriting user-facing trade RPC configuration.
+The default pair is dRPC and PublicNode, with both endpoint URLs kept non-enumerable at runtime. A failed simulation
+records only the provider vendor and a finite error category; credentials and provider response text never enter logs
+or API responses.
 
 ## Required release gates
 

--- a/lib/protocol-revenue/keeper-v2.server.ts
+++ b/lib/protocol-revenue/keeper-v2.server.ts
@@ -30,7 +30,7 @@ import {
 import { privateKeyToAccount } from "viem/accounts";
 import { mainnet } from "viem/chains";
 
-import { tradeActionRpcProviders } from "../server/action-rpc-quorum.server";
+import { protocolRevenueRpcProviders } from "../server/action-rpc-quorum.server";
 import {
   evaluateProtocolRevenueEconomics,
   evaluateProtocolRevenueV2Action,
@@ -514,7 +514,7 @@ export async function runConfiguredProtocolRevenueKeeperV2(
   const configuration = configuredKeeper(env);
   if (!configuration) return { status: "disabled" };
 
-  const providers = tradeActionRpcProviders(1, env);
+  const providers = protocolRevenueRpcProviders(env);
   const clients = [
     client(providers[0].endpoint),
     client(providers[1].endpoint),
@@ -719,18 +719,33 @@ export async function runConfiguredProtocolRevenueKeeperV2(
         economicRevenue: decision.accruedRevenue,
       };
 
-  try {
-    await Promise.all(
-      clients.map((current) =>
-        current.call({
+  const simulationOutcomes = await Promise.all(
+    clients.map(async (current, index) => {
+      try {
+        await current.call({
           account: account.address,
           to: transaction.to,
           data: transaction.data,
           value: transaction.value,
-        }),
-      ),
-    );
-  } catch {
+        });
+        return {
+          provider: providers[index]!.vendorGroup,
+          status: "success",
+        } as const;
+      } catch (error) {
+        return {
+          provider: providers[index]!.vendorGroup,
+          status: "failed",
+          category: classifyProtocolRevenueSubmissionError(error),
+        } as const;
+      }
+    }),
+  );
+  if (simulationOutcomes.some((outcome) => outcome.status === "failed")) {
+    console.error("Programmable protocol revenue simulation rejected", {
+      action,
+      outcomes: simulationOutcomes,
+    });
     throw new ProtocolRevenueKeeperV2Error("simulation_failed");
   }
 

--- a/lib/server/action-rpc-quorum.server.ts
+++ b/lib/server/action-rpc-quorum.server.ts
@@ -308,6 +308,28 @@ export function tradeActionRpcProviders(
   });
 }
 
+/**
+ * Keeps protocol-revenue execution isolated from the RPCs used by user-facing
+ * trade preparation. The selected defaults are independently operated and
+ * have both been verified against the live ERC-7715 delegation path.
+ */
+export function protocolRevenueRpcProviders(
+  env: Environment = process.env,
+) {
+  const primary =
+    env.PROTOCOL_REVENUE_RPC_URL_A ?? "https://eth.drpc.org";
+  const secondary =
+    env.PROTOCOL_REVENUE_RPC_URL_B ??
+    "https://ethereum-rpc.publicnode.com";
+  return createActionRpcQuorum({
+    chainId: 1,
+    primary,
+    secondary,
+    fallbacks: ["https://rpc.mevblocker.io"],
+    maximumProviders: 2,
+  });
+}
+
 export function creatorClaimRpcProviders(
   deployment: Readonly<{
     chainId: number;

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -30,8 +30,14 @@ const APPROVED_OPERATIONS = Object.freeze({
       }),
       runtime: Object.freeze({
         path: "lib/protocol-revenue/keeper-v2.server.ts",
-        sha256: "a40cea5a06ae3def870b61b35b359fdb05f02f587072956f8f84b58d319f27c7",
+        sha256: "da027cf1f0a565715f921130604df968c63e78907b5829fc548a7619639c0e51",
       }),
+      dependencies: Object.freeze([
+        Object.freeze({
+          path: "lib/server/action-rpc-quorum.server.ts",
+          sha256: "712d4df420068c20e3456606d87062203b89b4674a363109244175d113b2a413",
+        }),
+      ]),
       policy: Object.freeze({
         path: "lib/protocol-revenue/keeper-policy.ts",
         sha256: "ca242872b95141f042656199b39ae4a1636ccdaf5585a97a7eae28a6549f8ab0",
@@ -669,6 +675,9 @@ export function evaluateReadModelOperationsSourceContracts(
       `ops-${approvedCron.id}-source-digests`,
       sourceBindingMatches(source, approvedCron.route, expectedSha256Overrides) &&
         sourceBindingMatches(source, approvedCron.runtime, expectedSha256Overrides) &&
+        (approvedCron.dependencies ?? []).every((binding) =>
+          sourceBindingMatches(source, binding, expectedSha256Overrides)
+        ) &&
         sourceBindingMatches(source, approvedCron.policy, expectedSha256Overrides),
       `${approvedCron.id} route, runtime and policy match reviewed bytes`,
     );

--- a/tests/action-rpc-quorum.test.ts
+++ b/tests/action-rpc-quorum.test.ts
@@ -7,6 +7,7 @@ import {
   classicV3ActionRpcProviders,
   createActionRpcQuorum,
   creatorClaimRpcProviders,
+  protocolRevenueRpcProviders,
   stockPairedActionRpcProviders,
   tradeActionRpcProviders,
 } from "../lib/server/action-rpc-quorum.server";
@@ -151,6 +152,44 @@ describe("action-route RPC quorums", () => {
         tradeActionRpcProviders(1, {
           ETHEREUM_RPC_URL: ALCHEMY_MAINNET_A,
           ETHEREUM_RPC_URL_B: ALCHEMY_MAINNET_B,
+        }),
+      "alchemy-key-two",
+    );
+  });
+
+  it("isolates protocol revenue from shared trade RPC configuration", () => {
+    const providers = protocolRevenueRpcProviders({
+      ETHEREUM_RPC_URL: ALCHEMY_MAINNET_A,
+      ETHEREUM_RPC_URL_B: QUICKNODE_MAINNET,
+    });
+
+    expectIndependent(providers);
+    expect(providers.map((provider) => provider.vendorGroup)).toEqual([
+      "drpc",
+      "publicnode",
+    ]);
+    expect(providers.map((provider) => provider.endpoint)).toEqual([
+      "https://eth.drpc.org/",
+      "https://ethereum-rpc.publicnode.com/",
+    ]);
+  });
+
+  it("accepts only independent protocol-revenue provider overrides", () => {
+    const providers = protocolRevenueRpcProviders({
+      PROTOCOL_REVENUE_RPC_URL_A: ALCHEMY_MAINNET_A,
+      PROTOCOL_REVENUE_RPC_URL_B: QUICKNODE_MAINNET,
+    });
+    expectIndependent(providers);
+    expect(providers.map((provider) => provider.vendorGroup)).toEqual([
+      "alchemy",
+      "quicknode",
+    ]);
+
+    expectSafeFailure(
+      () =>
+        protocolRevenueRpcProviders({
+          PROTOCOL_REVENUE_RPC_URL_A: ALCHEMY_MAINNET_A,
+          PROTOCOL_REVENUE_RPC_URL_B: ALCHEMY_MAINNET_B,
         }),
       "alchemy-key-two",
     );


### PR DESCRIPTION
## What changed

- isolate protocol-revenue simulations from shared trading RPC configuration
- require two independent Ethereum providers before submitting delegated transfers
- record finite, secret-free provider diagnostics
- bind the new runtime dependency into the operations source contract

## Verification

- `npm run verify`
- 1,931 tests passed; 7 skipped
- production build passed
- operations source contract passed

## Runtime state

Automation remains disabled. This change will be released disabled, then validated with one capped transfer canary before processing is attempted.