### PR TITLE
Add safe builder intake feedback fallback

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -1,0 +1,215 @@
+name: Verify hook builder intake feedback
+
+# Non-authoritative default-branch fallback. GitHub requires a
+# pull_request_target workflow to exist on the repository's default branch.
+# This workflow runs only validator code from the default branch, treats the
+# pull-request base and candidate as inert Git data, and can report preflight
+# feedback. It never approves a pull request or issues an admission receipt,
+# launch grant, entitlement, or permit.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hook-builder-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  public-intake:
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
+      GIT_LFS_SKIP_SMUDGE: "1"
+      GIT_TERMINAL_PROMPT: "0"
+
+    steps:
+      - name: Checkout exact default-branch validator
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          fetch-depth: 1
+          lfs: false
+          submodules: false
+
+      - name: Checkout exact pull-request base as inert data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          persist-credentials: false
+          fetch-depth: 1
+          lfs: false
+          submodules: false
+
+      - name: Prove trusted and base revisions are exact
+        shell: bash
+        env:
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          test "$(git -C "$GITHUB_WORKSPACE/trusted" rev-parse HEAD)" = "$EXPECTED_WORKFLOW_SHA"
+          test "$(git -C "$GITHUB_WORKSPACE/base" rev-parse HEAD)" = "$EXPECTED_BASE_SHA"
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.14.0
+
+      - name: Fetch exact candidate merge as blobless data
+        id: candidate_fetch
+        shell: bash
+        env:
+          CANDIDATE_READ_TOKEN: ${{ github.token }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$SERVER_URL" != "https://github.com" ]]; then
+            echo "::error::The central repository identity is outside the supported GitHub origin."
+            exit 1
+          fi
+
+          fetch_report="$(timeout --signal=KILL 90s node \
+            "$GITHUB_WORKSPACE/trusted/scripts/verify-public-hook-application.mjs" \
+            --fetch-candidate \
+            --repository "${{ github.repository }}" \
+            --pull-request-number "${{ github.event.pull_request.number }}" \
+            --base-root "$GITHUB_WORKSPACE/base" \
+            --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
+            --expected-base-commit "${{ github.event.pull_request.base.sha }}" \
+            --expected-candidate-commit "${{ github.event.pull_request.head.sha }}")"
+          merge_commit="$(node -e '
+            const report = JSON.parse(process.argv[1]);
+            if (report.result !== "exact-blobless-candidate-fetched" || !/^[a-f0-9]{40}$/.test(report.mergeCommit)) process.exit(1);
+            process.stdout.write(report.mergeCommit);
+          ' "$fetch_report")"
+          echo "merge_commit=$merge_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Classify candidate data with trusted default-branch code
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          validator="$GITHUB_WORKSPACE/trusted/scripts/verify-public-hook-application.mjs"
+          if [[ ! -f "$validator" ]]; then
+            echo "::error::The default branch does not contain the trusted public-intake classifier."
+            exit 1
+          fi
+          mode="$(timeout --signal=KILL 30s node "$validator" --classify \
+            --base-root "$GITHUB_WORKSPACE/base" \
+            --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
+            --expected-base-commit "${{ github.event.pull_request.base.sha }}" \
+            --expected-candidate-commit "${{ github.event.pull_request.head.sha }}" \
+            --expected-merge-commit "${{ steps.candidate_fetch.outputs.merge_commit }}")"
+          case "$mode" in
+            application|builder-maintenance|no-op) ;;
+            *)
+              echo "::error::The trusted classifier returned an unsupported mode."
+              exit 1
+              ;;
+          esac
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+      - name: Preflight and hydrate only bounded application blobs
+        if: steps.classify.outputs.mode == 'application'
+        shell: bash
+        env:
+          CANDIDATE_READ_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          timeout --signal=KILL 90s node \
+            "$GITHUB_WORKSPACE/trusted/scripts/verify-public-hook-application.mjs" \
+            --hydrate-candidate \
+            --repository "${{ github.repository }}" \
+            --pull-request-number "${{ github.event.pull_request.number }}" \
+            --base-root "$GITHUB_WORKSPACE/base" \
+            --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
+            --expected-base-commit "${{ github.event.pull_request.base.sha }}" \
+            --expected-candidate-commit "${{ github.event.pull_request.head.sha }}" \
+            --expected-merge-commit "${{ steps.candidate_fetch.outputs.merge_commit }}"
+
+      - name: Remove candidate fetch credential
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          candidate="$GITHUB_WORKSPACE/candidate.git"
+          if [[ ! -f "$candidate/config" ]]; then
+            exit 0
+          fi
+          git -C "$candidate" config --local --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+          if git -C "$candidate" config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null; then
+            echo "::error::Candidate object-store credentials were not fully removed."
+            exit 1
+          fi
+
+      - name: Verify closed public application package
+        if: steps.classify.outputs.mode == 'application'
+        shell: bash
+        # Do not pass github.token/GITHUB_TOKEN to the source resolver. GitHub
+        # documents GITHUB_TOKEN as limited to this workflow repository, so it
+        # is not a reliable credential for arbitrary public builder repos:
+        # https://docs.github.com/en/actions/concepts/security/github_token
+        env:
+          GH_TOKEN: ""
+          GITHUB_TOKEN: ""
+          GIT_NO_LAZY_FETCH: "1"
+        run: |
+          set -euo pipefail
+
+          timeout --signal=KILL 120s node \
+            "$GITHUB_WORKSPACE/trusted/scripts/verify-public-hook-application.mjs" \
+            --pull-request-number "${{ github.event.pull_request.number }}" \
+            --base-root "$GITHUB_WORKSPACE/base" \
+            --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
+            --expected-base-commit "${{ github.event.pull_request.base.sha }}" \
+            --expected-builder-login "${{ github.event.pull_request.user.login }}" \
+            --expected-builder-user-id "${{ github.event.pull_request.user.id }}" \
+            --expected-candidate-commit "${{ github.event.pull_request.head.sha }}" \
+            --expected-merge-commit "${{ steps.candidate_fetch.outputs.merge_commit }}"
+
+      - name: Defer executable builder-maintenance checks to read-only pull-request CI
+        if: steps.classify.outputs.mode == 'builder-maintenance'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Builder-maintenance paths are closed by the trusted base classifier."
+          echo "No maintenance blob is hydrated or parsed under pull_request_target."
+          echo "Candidate validators, generators, tests, workflows, and scripts run only in ordinary read-only pull-request CI."
+
+      - name: Preserve legacy pull-request compatibility
+        if: steps.classify.outputs.mode == 'no-op'
+        shell: bash
+        run: echo "No builder-beta intake content changed; existing model CI remains authoritative."
+
+      - name: State feedback-only authority boundary
+        if: always()
+        shell: bash
+        run: |
+          echo "This default-branch fallback provides preflight feedback only."
+          echo "Only the separately installed Programmable GitHub App may issue an admission decision or launch authority."

--- a/scripts/verify-public-hook-application-core.mjs
+++ b/scripts/verify-public-hook-application-core.mjs
@@ -1,0 +1,3635 @@
+import childProcess from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { TextDecoder } from "node:util";
+import {
+  createGitHubPublicFetchTransportV1,
+  GITHUB_PUBLIC_SOURCE_CONTRACT_V1,
+  GitHubPublicSourceError,
+  isCanonicalGitHubRepositoryPathV1,
+  resolveGitHubPublicSourceV1,
+  validateGitHubPublicSourceRequestV1
+} from "../skills/programmable-v4-hook-builder/scripts/github-public-source-core.mjs";
+import {
+  createAnonymousGitHubExactObjectResolverV1,
+  GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1
+} from "../skills/programmable-v4-hook-builder/scripts/github-exact-object-resolver.mjs";
+import { findUnsupportedPublicClaims } from "../skills/programmable-v4-hook-builder/scripts/public-claims-core.mjs";
+import {
+  AUTONOMOUS_ADMISSION_FILES,
+  AUTONOMOUS_ADMISSION_FILE_LIMITS,
+  validateAutonomousApplicationManifest,
+  validateAutonomousLaunchSpecification
+} from "../skills/programmable-v4-hook-builder/scripts/autonomous-admission-contract.mjs";
+import { AUTONOMOUS_APPLICATION_INPUT_DISCLAIMER } from "../skills/programmable-v4-hook-builder/scripts/application-input-contract.mjs";
+
+export const VALIDATOR_VERSION = "2.0.0";
+export const PUBLIC_APPLICATION_SCHEMA_ID = "https://schemas.programmable.family/autonomous-approval/v1/application-manifest.schema.json";
+export const PUBLIC_BETA_DISCLAIMER = AUTONOMOUS_APPLICATION_INPUT_DISCLAIMER;
+export const PUBLIC_INTAKE_STATES = Object.freeze(["prelaunch", "open", "paused-new", "paused-all"]);
+export const MAXIMUM_MAINTAINED_LEGACY_PACKAGES = 32;
+export const MAINTAINED_LEGACY_PACKAGE_TIMEOUT_MS = 120_000;
+
+const APPLICATION_FILE = "application.json";
+const INTAKE_STATUS_PATH = "docs/builder/intake-status.json";
+const MAXIMUM_INTAKE_STATUS_BYTES = 32 * 1024;
+const MAXIMUM_CONTINUING_PULL_REQUESTS = 32;
+const MAXIMUM_CONTINUATION_COMPANIONS = 15;
+const APPLICATION_FILES = AUTONOMOUS_ADMISSION_FILES;
+export const PUBLIC_APPLICATION_FILES = APPLICATION_FILES;
+export const GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1 = Object.freeze({
+  maximumProviderRequests: 60,
+  maximumSourceRequests: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.anonymousRestRequests,
+  maximumTransportRetries: 12,
+  minimumIntervalMs: 125,
+  maximumRetryDelayMs: 1_000,
+  timeoutMs: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.maximumTimeoutMs
+});
+const maximumAnonymousSchedulingDelayMs =
+  ((GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumProviderRequests - 1)
+    * GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.minimumIntervalMs)
+  + (GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumTransportRetries
+    * GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumRetryDelayMs);
+if (
+  GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumSourceRequests
+    + GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumTransportRetries
+    > GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumProviderRequests
+  || maximumAnonymousSchedulingDelayMs >= GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.timeoutMs
+) {
+  throw new Error("trusted anonymous GitHub request, pacing, retry, and timeout budgets are inconsistent");
+}
+const GITHUB_PUBLIC_TRANSPORT_DEFAULTS = Object.freeze({
+  maximumRetryBodyBytes: 16 * 1024,
+  maximumRetryDelayMs: GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumRetryDelayMs,
+  minimumIntervalMs: GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.minimumIntervalMs,
+  transientRetryDelayMs: 250
+});
+const REVIEW_FILES = Object.freeze([
+  "PROPOSAL.md",
+  "TEST_PLAN.md",
+  "THREAT_MODEL.md",
+  "compatibility-report.json",
+  "evidence-index.json"
+]);
+const BUILDER_MAINTENANCE_PREFIXES = Object.freeze([
+  "docs/builder/",
+  "evals/",
+  "plugins/marketplace/",
+  "scripts/evals/",
+  "scripts/test/schema-validator/",
+  "skills/programmable-v4-hook-builder/"
+]);
+const BUILDER_MAINTENANCE_FILES = new Set([
+  ".github/CODEOWNERS",
+  ".github/PULL_REQUEST_TEMPLATE.md",
+  ".github/workflows/verify-hook-builder.yml",
+  ".github/workflows/verify.yml",
+  "BUILDER_PROGRAM.md",
+  "CONTRIBUTING.md",
+  "README.md",
+  "SUPPORT.md",
+  "docs/README.md",
+  "scripts/check-documentation-links.mjs",
+  "scripts/test/check-documentation-links.test.mjs",
+  "scripts/verify-public-hook-application-core.mjs",
+  "scripts/verify-public-hook-application.mjs",
+  "submissions/README.md",
+  "skills/README.md"
+]);
+const SHARED_BUILDER_DOCUMENTATION_FILES = new Set([
+  "README.md",
+  "SUPPORT.md",
+  "docs/README.md",
+  "scripts/check-documentation-links.mjs",
+  "scripts/test/check-documentation-links.test.mjs"
+]);
+const APPLICATION_PATH_PATTERN = /^submissions\/([a-z0-9]+(?:-[a-z0-9]+)*)\/([^/]+)$/;
+const SHA1_PATTERN = /^[a-f0-9]{40}$/;
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const OPAQUE_ID_PATTERN = /^[1-9][0-9]{0,63}$/;
+const SAFE_CODE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+const APPLICATION_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const EVIDENCE_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const FINDING_CODE_PATTERN = /^[A-Z][A-Z0-9_]{2,79}$/;
+const GITHUB_LOGIN_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const FORBIDDEN_JSON_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+const CONTROL_OR_BIDI_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f\u00ad\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/u;
+const TRUSTED_GIT_TIMEOUT_MS = 30_000;
+const CANDIDATE_PREFLIGHT_API_RESPONSE_BYTES = 4 * 1024 * 1024;
+const CANDIDATE_PREFLIGHT_FILES_PER_PAGE = 100;
+const HYDRATION_API_RESPONSE_BYTES = 1 * 1024 * 1024;
+const HYDRATION_ADDITIONAL_REPOSITORY_BYTES = 4 * 1024 * 1024;
+const HYDRATION_FILE_SIZE_BYTES = 2 * 1024 * 1024;
+const HYDRATION_OUTPUT_BYTES = 64 * 1024;
+const HYDRATION_POLL_MS = 25;
+const HYDRATION_KILL_GRACE_MS = 250;
+const HYDRATION_MAXIMUM_ENTRIES = 65_536;
+const CANDIDATE_GIT_ADDRESS_SPACE_BYTES = 512 * 1024 * 1024;
+const CANDIDATE_GIT_CPU_SECONDS = 20;
+const CANDIDATE_FETCH_FILE_SIZE_BYTES = 32 * 1024 * 1024;
+const CANDIDATE_FETCH_REPOSITORY_BYTES = 64 * 1024 * 1024;
+const GITHUB_REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
+const PULL_REQUEST_NUMBER_PATTERN = /^[1-9][0-9]{0,19}$/u;
+
+const DEFAULT_LIMITS = Object.freeze({
+  maximumChangedFiles: 256,
+  maximumGitEntries: 200_000,
+  maximumGitTreeBytes: 64 * 1024 * 1024,
+  maximumFindings: 128,
+  maximumEvidence: 128,
+  maximumEvidenceBlobBytes: 8 * 1024 * 1024,
+  maximumEvidenceResolutionBytes: 32 * 1024 * 1024,
+  maximumEvidenceRequests: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.anonymousRestRequests,
+  maximumEvidenceTreeEntries: 200_000,
+  maximumJsonDepth: 16,
+  maximumJsonNodes: 20_000,
+  maximumPackageBytes: 768 * 1024,
+  maximumFileBytes: AUTONOMOUS_ADMISSION_FILE_LIMITS,
+});
+
+export class PublicIntakeError extends Error {
+  constructor(code, message, { kind = "candidate" } = {}) {
+    super(message);
+    this.name = "PublicIntakeError";
+    this.code = code;
+    this.kind = kind;
+  }
+}
+
+function reject(code, message) {
+  throw new PublicIntakeError(code, message, { kind: "candidate" });
+}
+
+function systemBlocked(code, message) {
+  throw new PublicIntakeError(code, message, { kind: "system" });
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!isPlainObject(value)) return value;
+  return Object.fromEntries(Object.keys(value).sort(compareUtf8).map((key) => [key, sortJson(value[key])]));
+}
+
+export function classifyPublicIntakePullRequest({
+  baseRoot,
+  candidateRoot,
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  expectedMergeCommit,
+  limits: limitOverrides = {}
+}) {
+  const limits = mergeLimits(limitOverrides);
+  const comparison = compareGitRevisions({
+    baseRoot,
+    candidateRoot,
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    expectedMergeCommit,
+    limits
+  });
+  const { changes } = comparison;
+
+  if (changes.length === 0) return { mode: "no-op", ...comparison };
+
+  const submissionChanges = changes.filter((change) => change.path.startsWith("submissions/"));
+  const applicationDirectoryChanges = submissionChanges.filter((change) => change.path !== "submissions/README.md");
+  if (applicationDirectoryChanges.length > 0) {
+    rejectUnsafeChangedEntries(changes);
+    if (changes.every((change) => isAllowlistedApplicationPath(change.path))) {
+      return { mode: "application", ...comparison };
+    }
+    reject(
+      "CHANGED_PATH_NOT_ALLOWED",
+      "A pull request that touches submissions/ must contain only one closed seven-file autonomous application package."
+    );
+  }
+
+  const maintenanceChanges = changes.filter((change) => (
+    isBuilderMaintenancePath(change.path)
+    && !SHARED_BUILDER_DOCUMENTATION_FILES.has(change.path)
+  ));
+  if (maintenanceChanges.length === 0) return { mode: "no-op", ...comparison };
+
+  rejectUnsafeChangedEntries(changes);
+  if (changes.every((change) => isBuilderMaintenancePath(change.path))) {
+    return { mode: "builder-maintenance", ...comparison };
+  }
+
+  reject(
+    "CHANGED_PATH_NOT_ALLOWED",
+    "A builder-maintenance pull request may change only first-party builder infrastructure and documentation."
+  );
+}
+
+/**
+ * Read the intake switch from the trusted base revision before any candidate
+ * Git objects are fetched. Closed states inspect only bounded GitHub PR
+ * metadata so maintenance and legacy PRs can continue without letting an
+ * application consume Git pack/decompression capacity.
+ */
+export async function preflightPublicApplicationCandidateFetch({
+  baseRoot,
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  repository,
+  pullRequestNumber,
+  readToken,
+  limits: limitOverrides = {}
+}, dependencies = {}) {
+  validateHydrationAuthority({ repository, readToken });
+  validateCandidateHeadIdentity({ pullRequestNumber, expectedBaseCommit, expectedCandidateCommit });
+  const limits = mergeLimits(limitOverrides);
+  const base = inspectGitRevision(baseRoot, expectedBaseCommit, limits);
+  const intakeStatus = readTrustedIntakeStatus(base);
+  if (intakeStatus.state === "open") {
+    return {
+      schemaVersion: 1,
+      result: "candidate-fetch-allowed",
+      intakeState: intakeStatus.state,
+      modeHint: "unclassified"
+    };
+  }
+
+  const changedFiles = await resolveCentralPullRequestChangedFiles({
+    repository,
+    pullRequestNumber,
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    readToken,
+    maximumChangedFiles: limits.maximumChangedFiles,
+    fetchImplementation: dependencies.fetchImplementation ?? globalThis.fetch,
+    timeoutMs: dependencies.timeoutMs ?? TRUSTED_GIT_TIMEOUT_MS
+  });
+  const changedPaths = [];
+  for (const file of changedFiles) {
+    changedPaths.push(file.path);
+    if (file.previousPath !== null) changedPaths.push(file.previousPath);
+  }
+  const uniquePaths = [...new Set(changedPaths)].sort(compareUtf8);
+  const applicationPaths = uniquePaths.filter(
+    (entryPath) => entryPath.startsWith("submissions/") && entryPath !== "submissions/README.md"
+  );
+  if (applicationPaths.length === 0) {
+    return {
+      schemaVersion: 1,
+      result: "candidate-fetch-allowed",
+      intakeState: intakeStatus.state,
+      modeHint: "non-application"
+    };
+  }
+
+  if (intakeStatus.state === "prelaunch" || intakeStatus.state === "paused-all") {
+    enforceTrustedIntakeStatus({ intakeStatus, isUpdate: false, pullRequestNumber, applicationId: null });
+  }
+
+  const applicationIds = new Set();
+  for (const entryPath of applicationPaths) {
+    const match = APPLICATION_PATH_PATTERN.exec(entryPath);
+    if (!match || !APPLICATION_FILES.includes(match[2])) {
+      reject(
+        "CHANGED_PATH_NOT_ALLOWED",
+        "A paused-new pull request may fetch candidate data only for one existing closed application package."
+      );
+    }
+    applicationIds.add(match[1]);
+  }
+  if (
+    applicationIds.size !== 1
+    || uniquePaths.some((entryPath) => !isAllowlistedApplicationPath(entryPath))
+    || changedFiles.some((file) => file.status === "removed" && applicationPaths.includes(file.path))
+  ) {
+    reject(
+      "CHANGED_PATH_NOT_ALLOWED",
+      "A paused-new pull request may fetch candidate data only for one existing closed application package."
+    );
+  }
+  const [applicationId] = applicationIds;
+  const isUpdate = classifyTrustedBaseApplication(base, applicationId);
+  const continuation = enforceTrustedIntakeStatus({
+    intakeStatus,
+    isUpdate,
+    pullRequestNumber,
+    applicationId
+  });
+  if (!isUpdate) assertNewApplicationChangedFileSet({ changedFiles, applicationId });
+  return {
+    schemaVersion: 1,
+    result: "candidate-fetch-allowed",
+    intakeState: intakeStatus.state,
+    modeHint: isUpdate ? "application-update" : "application-continuation",
+    pullRequestNumber,
+    continuationAuthorized: continuation !== null
+  };
+}
+
+/**
+ * Fetch the base repository's exact PR merge ref into a newly-created bare,
+ * blobless object store under hard per-file and aggregate storage bounds.
+ */
+export async function fetchPublicApplicationCandidate({
+  baseRoot,
+  candidateRoot,
+  repository,
+  pullRequestNumber,
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  readToken
+}, dependencies = {}) {
+  validateHydrationAuthority({ repository, readToken });
+  validateCandidateHeadIdentity({ pullRequestNumber, expectedBaseCommit, expectedCandidateCommit });
+  await preflightPublicApplicationCandidateFetch({
+    baseRoot,
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    repository,
+    pullRequestNumber,
+    readToken
+  }, {
+    fetchImplementation: dependencies.fetchImplementation,
+    timeoutMs: dependencies.metadataTimeoutMs
+  });
+  const gitDirectory = validateNewCandidateDirectory(candidateRoot);
+  const remoteUrl = dependencies.remoteUrlForTests ?? `https://github.com/${repository}.git`;
+  if (typeof remoteUrl !== "string" || remoteUrl.length < 1 || /[\u0000\r\n]/u.test(remoteUrl)) {
+    systemBlocked("CANDIDATE_FETCH_REMOTE_INVALID", "The central candidate remote is malformed.");
+  }
+  const gitExecutable = dependencies.gitExecutable ?? "git";
+  let complete = false;
+  try {
+    const init = childProcess.spawnSync(
+      gitExecutable,
+      [
+        "-c", "init.templateDir=",
+        "-c", "core.hooksPath=/dev/null",
+        "init", "--quiet", "--bare", "--object-format=sha1", gitDirectory
+      ],
+      {
+        encoding: "utf8",
+        shell: false,
+        timeout: TRUSTED_GIT_TIMEOUT_MS,
+        killSignal: "SIGKILL",
+        env: trustedGitEnvironment()
+      }
+    );
+    if (init.status !== 0) {
+      systemBlocked("CANDIDATE_FETCH_INIT_FAILED", "The bounded candidate object store could not be initialized.");
+    }
+    writeCandidateGitConfig(gitDirectory, remoteUrl, readToken);
+
+    const runFetch = dependencies.runFetch ?? runBoundedHydrationGitProcess;
+    const result = await runFetch({
+      gitExecutable,
+      gitDirectory,
+      args: [
+        "fetch",
+        "--force",
+        "--no-tags",
+        "--no-write-fetch-head",
+        "--no-recurse-submodules",
+        "--depth=1",
+        "--filter=blob:none",
+        "origin",
+        `+refs/pull/${pullRequestNumber}/merge:refs/heads/candidate-merge`
+      ],
+      timeoutMs: dependencies.fetchTimeoutMs ?? TRUSTED_GIT_TIMEOUT_MS,
+      maximumOutputBytes: HYDRATION_OUTPUT_BYTES,
+      maximumFileSizeBytes: dependencies.maximumFileSizeBytes ?? CANDIDATE_FETCH_FILE_SIZE_BYTES,
+      maximumRepositoryBytes: dependencies.maximumRepositoryBytes ?? CANDIDATE_FETCH_REPOSITORY_BYTES,
+      maximumAddressSpaceBytes: dependencies.maximumAddressSpaceBytes ?? CANDIDATE_GIT_ADDRESS_SPACE_BYTES,
+      maximumCpuSeconds: dependencies.maximumCpuSeconds ?? CANDIDATE_GIT_CPU_SECONDS,
+      allowFileProtocol: dependencies.allowFileProtocolForTests === true
+    });
+    if (
+      !isBoundedGitProcessResult(result)
+      || result.timedOut
+      || result.outputExceeded
+      || result.repositoryBytesExceeded
+      || result.fileSizeExceeded
+      || result.addressSpaceExceeded
+      || result.cpuExceeded
+      || result.status !== 0
+    ) {
+      systemBlocked("CANDIDATE_FETCH_BOUNDED_FAILURE", "The exact blobless PR merge exceeded trusted fetch bounds or was unavailable.");
+    }
+    runGit(gitDirectory, ["symbolic-ref", "HEAD", "refs/heads/candidate-merge"], 1024);
+    const { mergeCommit: observedMergeCommit } = inspectExactPullRequestMergeIdentity(gitDirectory, {
+      expectedBaseCommit,
+      expectedCandidateCommit
+    });
+    complete = true;
+    return {
+      schemaVersion: 1,
+      result: "exact-blobless-candidate-fetched",
+      mergeCommit: observedMergeCommit
+    };
+  } finally {
+    if (!complete && fs.lstatSync(gitDirectory, { throwIfNoEntry: false }) !== undefined) {
+      removeCandidateDirectory(gitDirectory);
+    }
+  }
+}
+
+/**
+ * Hydrate only the already-classified seven-file application package. GitHub's
+ * exact tree metadata is checked before any candidate blob is requested, and
+ * the bounded Git process is prevented from lazily fetching anything else.
+ */
+export async function hydratePublicApplicationCandidate({
+  baseRoot,
+  candidateRoot,
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  expectedMergeCommit,
+  pullRequestNumber,
+  repository,
+  readToken,
+  limits: limitOverrides = {}
+}, dependencies = {}) {
+  const limits = mergeLimits(limitOverrides);
+  validateHydrationAuthority({ repository, readToken });
+  validateCandidateFetchIdentity({
+    pullRequestNumber,
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    expectedMergeCommit
+  });
+  const classified = classifyPublicIntakePullRequest({
+    baseRoot,
+    candidateRoot,
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    expectedMergeCommit,
+    limits
+  });
+  const plan = planApplicationHydration(classified, limits);
+  const intakeStatus = readTrustedIntakeStatus(classified.base);
+  const isUpdate = classifyTrustedBaseApplication(classified.base, plan.applicationId);
+  const continuation = enforceTrustedIntakeStatus({
+    intakeStatus,
+    isUpdate,
+    pullRequestNumber,
+    applicationId: plan.applicationId
+  });
+  const gitDirectory = path.resolve(candidateRoot ?? "");
+  requireHydrationRemote(
+    gitDirectory,
+    dependencies.remoteUrlForTests ?? `https://github.com/${repository}.git`
+  );
+  const packageTreeObjectId = readPackageTreeObjectId(gitDirectory, plan.packageDirectory);
+  const metadata = await resolveCandidateTreeMetadata({
+    repository,
+    readToken,
+    packageTreeObjectId,
+    fetchImplementation: dependencies.fetchImplementation ?? globalThis.fetch,
+    timeoutMs: dependencies.metadataTimeoutMs ?? TRUSTED_GIT_TIMEOUT_MS
+  });
+  const boundedMetadata = enforceHydrationMetadata(plan, metadata, limits);
+
+  const baselineBytes = measureHydrationDirectory(gitDirectory);
+  const maximumAdditionalRepositoryBytes = dependencies.maximumAdditionalRepositoryBytes
+    ?? HYDRATION_ADDITIONAL_REPOSITORY_BYTES;
+  const maximumFileSizeBytes = dependencies.maximumFileSizeBytes ?? HYDRATION_FILE_SIZE_BYTES;
+  validateHydrationProcessLimits(maximumAdditionalRepositoryBytes, maximumFileSizeBytes);
+  if (baselineBytes > Number.MAX_SAFE_INTEGER - maximumAdditionalRepositoryBytes) {
+    systemBlocked("HYDRATION_STORAGE_INVALID", "Candidate object-store size could not be bounded safely.");
+  }
+
+  const sparsePath = path.join(gitDirectory, "info", "sparse-checkout");
+  const sparseBytes = Buffer.from(`${plan.entries.map((entry) => `/${entry.path}`).join("\n")}\n`, "utf8");
+  let operationFailed = false;
+  try {
+    fs.mkdirSync(path.dirname(sparsePath), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(sparsePath, sparseBytes, { mode: 0o600, flag: "w" });
+    runHydrationConfig(gitDirectory, ["core.sparseCheckout", "true"]);
+    runHydrationConfig(gitDirectory, ["core.sparseCheckoutCone", "false"]);
+    const result = await runBoundedHydrationGitProcess({
+      gitExecutable: dependencies.gitExecutable ?? "git",
+      gitDirectory,
+      args: ["backfill", "--sparse"],
+      timeoutMs: dependencies.backfillTimeoutMs ?? TRUSTED_GIT_TIMEOUT_MS,
+      maximumOutputBytes: HYDRATION_OUTPUT_BYTES,
+      maximumFileSizeBytes,
+      maximumRepositoryBytes: baselineBytes + maximumAdditionalRepositoryBytes,
+      maximumAddressSpaceBytes: CANDIDATE_GIT_ADDRESS_SPACE_BYTES,
+      maximumCpuSeconds: CANDIDATE_GIT_CPU_SECONDS,
+      allowFileProtocol: dependencies.allowFileProtocolForTests === true
+    });
+    if (result.timedOut) {
+      systemBlocked("HYDRATION_TIMEOUT", "Bounded candidate blob hydration exceeded its trusted timeout.");
+    }
+    if (
+      result.outputExceeded
+      || result.repositoryBytesExceeded
+      || result.fileSizeExceeded
+      || result.addressSpaceExceeded
+      || result.cpuExceeded
+      || result.status !== 0
+    ) {
+      systemBlocked("HYDRATION_BOUNDED_FETCH_FAILED", "Git could not hydrate the bounded application blobs within trusted resource limits.");
+    }
+    verifyHydratedObjects(gitDirectory, plan, boundedMetadata, limits);
+  } catch (error) {
+    operationFailed = true;
+    throw error;
+  } finally {
+    try {
+      fs.rmSync(sparsePath, { force: true });
+      runHydrationConfig(gitDirectory, ["--unset", "core.sparseCheckout"], { allowMissing: true });
+      runHydrationConfig(gitDirectory, ["--unset", "core.sparseCheckoutCone"], { allowMissing: true });
+    } catch (cleanupError) {
+      if (!operationFailed) {
+        systemBlocked("HYDRATION_CLEANUP_FAILED", "Trusted sparse hydration state could not be removed.");
+      }
+    }
+  }
+
+  const applicationEntry = plan.entries.find((entry) => path.posix.basename(entry.path) === APPLICATION_FILE);
+  const applicationBytes = readGitBlob(
+    path.resolve(candidateRoot ?? ""),
+    applicationEntry,
+    limits.maximumFileBytes[APPLICATION_FILE]
+  );
+  const application = parseCanonicalJson(applicationBytes, APPLICATION_FILE, limits, { trailingNewline: false });
+  try {
+    validateAutonomousApplicationManifest(application, { requireImmutableSourceHints: true });
+  } catch {
+    reject("APPLICATION_MANIFEST_INVALID", "application.json does not satisfy the autonomous service manifest contract.");
+  }
+  if (application.applicationId !== plan.applicationId) {
+    reject("APPLICATION_ID_PATH_MISMATCH", "The manifest application id must equal its submissions directory.");
+  }
+  enforceTrustedContinuationSourceIdentity({ continuation, application });
+
+  return {
+    schemaVersion: 1,
+    result: "bounded-application-blobs-hydrated",
+    intakeState: intakeStatus.state,
+    applicationId: plan.applicationId,
+    pullRequestNumber,
+    continuationAuthorized: continuation !== null,
+    fileCount: plan.entries.length,
+    totalBytes: boundedMetadata.totalBytes
+  };
+}
+
+function validateHydrationAuthority({ repository, readToken }) {
+  if (typeof repository !== "string" || !GITHUB_REPOSITORY_PATTERN.test(repository) || repository.length > 202) {
+    systemBlocked("HYDRATION_REPOSITORY_INVALID", "The central GitHub repository identity is malformed.");
+  }
+  if (
+    typeof readToken !== "string"
+    || readToken.length < 1
+    || readToken.length > 4096
+    || /[\u0000-\u001f\u007f-\u009f]/u.test(readToken)
+  ) {
+    systemBlocked("HYDRATION_CREDENTIAL_INVALID", "The central read credential is missing or malformed.");
+  }
+}
+
+function validateCandidateFetchIdentity({
+  pullRequestNumber,
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  expectedMergeCommit
+}) {
+  validateCandidateHeadIdentity({ pullRequestNumber, expectedBaseCommit, expectedCandidateCommit });
+  if (!SHA1_PATTERN.test(expectedMergeCommit ?? "")) {
+    systemBlocked("CANDIDATE_FETCH_ID_INVALID", "The expected pull-request merge commit is missing or malformed.");
+  }
+}
+
+function validateCandidateHeadIdentity({ pullRequestNumber, expectedBaseCommit, expectedCandidateCommit }) {
+  if (typeof pullRequestNumber !== "string" || !PULL_REQUEST_NUMBER_PATTERN.test(pullRequestNumber)) {
+    systemBlocked("CANDIDATE_FETCH_ID_INVALID", "The pull-request number is missing or malformed.");
+  }
+  for (const [label, objectId] of [
+    ["base", expectedBaseCommit],
+    ["head", expectedCandidateCommit]
+  ]) {
+    if (!SHA1_PATTERN.test(objectId ?? "")) {
+      systemBlocked("CANDIDATE_FETCH_ID_INVALID", `The expected pull-request ${label} commit is missing or malformed.`);
+    }
+  }
+}
+
+async function resolveCentralPullRequestChangedFiles({
+  repository,
+  pullRequestNumber,
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  readToken,
+  maximumChangedFiles,
+  fetchImplementation,
+  timeoutMs
+}) {
+  if (typeof fetchImplementation !== "function") {
+    systemBlocked("CANDIDATE_PREFLIGHT_UNAVAILABLE", "The trusted GitHub pull-request metadata transport is unavailable.");
+  }
+  if (
+    !Number.isInteger(timeoutMs)
+    || timeoutMs < 1
+    || timeoutMs > TRUSTED_GIT_TIMEOUT_MS
+    || !Number.isInteger(maximumChangedFiles)
+    || maximumChangedFiles < 1
+    || maximumChangedFiles > 1_000
+  ) {
+    systemBlocked("CANDIDATE_PREFLIGHT_INVALID", "The trusted pull-request metadata limits are invalid.");
+  }
+  const apiOrigin = GITHUB_PUBLIC_SOURCE_CONTRACT_V1.apiOrigin;
+  const deadline = performance.now() + timeoutMs;
+  const pullRequestUrl = `${apiOrigin}/repos/${repository}/pulls/${pullRequestNumber}`;
+  const pullRequest = await requestCentralCandidateJson({
+    url: pullRequestUrl,
+    readToken,
+    fetchImplementation,
+    deadline
+  });
+  if (
+    !isPlainObject(pullRequest)
+    || String(pullRequest.number) !== pullRequestNumber
+    || pullRequest.state !== "open"
+    || pullRequest.base?.sha !== expectedBaseCommit
+    || pullRequest.head?.sha !== expectedCandidateCommit
+    || typeof pullRequest.base?.repo?.full_name !== "string"
+    || pullRequest.base.repo.full_name.toLowerCase() !== repository.toLowerCase()
+    || !Number.isInteger(pullRequest.changed_files)
+    || pullRequest.changed_files < 0
+  ) {
+    systemBlocked("CANDIDATE_PREFLIGHT_ID_MISMATCH", "GitHub pull-request metadata did not match the immutable workflow event.");
+  }
+  if (pullRequest.changed_files > maximumChangedFiles) {
+    reject("TOO_MANY_CHANGED_FILES", "The pull request exceeds the trusted changed-file limit before candidate fetch.");
+  }
+
+  const records = [];
+  const pages = Math.ceil(pullRequest.changed_files / CANDIDATE_PREFLIGHT_FILES_PER_PAGE);
+  for (let page = 1; page <= pages; page += 1) {
+    const url = `${pullRequestUrl}/files?per_page=${CANDIDATE_PREFLIGHT_FILES_PER_PAGE}&page=${page}`;
+    const document = await requestCentralCandidateJson({
+      url,
+      readToken,
+      fetchImplementation,
+      deadline
+    });
+    const expectedRecords = Math.min(
+      CANDIDATE_PREFLIGHT_FILES_PER_PAGE,
+      pullRequest.changed_files - records.length
+    );
+    if (!Array.isArray(document) || document.length !== expectedRecords) {
+      systemBlocked("CANDIDATE_PREFLIGHT_INVALID", "GitHub returned an incomplete bounded pull-request file list.");
+    }
+    records.push(...document);
+  }
+  if (records.length !== pullRequest.changed_files) {
+    systemBlocked("CANDIDATE_PREFLIGHT_INVALID", "GitHub pull-request file metadata did not match its declared count.");
+  }
+
+  const supportedStatuses = new Set(["added", "removed", "modified", "renamed", "copied", "changed", "unchanged"]);
+  const observedPaths = new Set();
+  return records.map((record) => {
+    if (
+      !isPlainObject(record)
+      || typeof record.filename !== "string"
+      || !supportedStatuses.has(record.status)
+      || (record.status === "renamed") !== (typeof record.previous_filename === "string")
+    ) {
+      systemBlocked("CANDIDATE_PREFLIGHT_INVALID", "GitHub returned malformed pull-request file metadata.");
+    }
+    validateGitPath(record.filename);
+    if (observedPaths.has(record.filename)) {
+      systemBlocked("CANDIDATE_PREFLIGHT_INVALID", "GitHub returned a duplicate pull-request path.");
+    }
+    observedPaths.add(record.filename);
+    let previousPath = null;
+    if (record.status === "renamed") {
+      validateGitPath(record.previous_filename);
+      previousPath = record.previous_filename;
+    }
+    return { path: record.filename, previousPath, status: record.status };
+  });
+}
+
+async function requestCentralCandidateJson({ url, readToken, fetchImplementation, deadline }) {
+  const remaining = Math.floor(deadline - performance.now());
+  if (remaining < 1) {
+    systemBlocked("CANDIDATE_PREFLIGHT_TIMEOUT", "Trusted pull-request metadata resolution exceeded its total deadline.");
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), remaining);
+  timeout.unref?.();
+  let response;
+  try {
+    response = await fetchImplementation(url, {
+      method: "GET",
+      redirect: "error",
+      signal: controller.signal,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${readToken}`,
+        "User-Agent": "programmable-public-intake-prefetch-v1",
+        "X-GitHub-Api-Version": GITHUB_PUBLIC_SOURCE_CONTRACT_V1.githubApiVersion
+      }
+    });
+  } catch {
+    systemBlocked("CANDIDATE_PREFLIGHT_UNAVAILABLE", "GitHub pull-request metadata was unavailable before candidate fetch.");
+  } finally {
+    clearTimeout(timeout);
+  }
+  if (
+    !response
+    || response.status !== 200
+    || response.redirected === true
+    || (typeof response.url === "string" && response.url !== "" && response.url !== url)
+  ) {
+    systemBlocked("CANDIDATE_PREFLIGHT_UNAVAILABLE", "GitHub did not return exact same-origin pull-request metadata.");
+  }
+  const declaredLength = response.headers?.get?.("content-length");
+  if (declaredLength !== null && declaredLength !== undefined) {
+    if (
+      !/^(?:0|[1-9][0-9]*)$/u.test(declaredLength)
+      || Number(declaredLength) > CANDIDATE_PREFLIGHT_API_RESPONSE_BYTES
+    ) {
+      systemBlocked("CANDIDATE_PREFLIGHT_TOO_LARGE", "GitHub pull-request metadata exceeded its trusted response bound.");
+    }
+  }
+  const bytes = await readBoundedHydrationResponse(response, CANDIDATE_PREFLIGHT_API_RESPONSE_BYTES);
+  try {
+    return JSON.parse(UTF8_DECODER.decode(bytes));
+  } catch {
+    systemBlocked("CANDIDATE_PREFLIGHT_INVALID", "GitHub pull-request metadata was not valid bounded UTF-8 JSON.");
+  }
+}
+
+function validateNewCandidateDirectory(candidateRoot) {
+  if (typeof candidateRoot !== "string" || candidateRoot.length < 1 || /[\u0000\r\n]/u.test(candidateRoot)) {
+    systemBlocked("CANDIDATE_FETCH_PATH_INVALID", "The candidate object-store path is malformed.");
+  }
+  const resolved = path.resolve(candidateRoot);
+  const parent = path.dirname(resolved);
+  if (
+    path.basename(resolved) !== "candidate.git"
+    || !fs.statSync(parent, { throwIfNoEntry: false })?.isDirectory()
+    || fs.lstatSync(resolved, { throwIfNoEntry: false }) !== undefined
+  ) {
+    systemBlocked("CANDIDATE_FETCH_PATH_INVALID", "The candidate object store must be a new candidate.git directory.");
+  }
+  return resolved;
+}
+
+function writeCandidateGitConfig(gitDirectory, remoteUrl, readToken) {
+  const basicAuth = Buffer.from(`x-access-token:${readToken}`, "utf8").toString("base64");
+  const config = [
+    "[core]",
+    "\trepositoryformatversion = 0",
+    "\tfilemode = true",
+    "\tbare = true",
+    "\thooksPath = /dev/null",
+    "\tattributesFile = /dev/null",
+    "[protocol]",
+    "\tallow = never",
+    "\tversion = 2",
+    "[protocol \"https\"]",
+    "\tallow = always",
+    "[http]",
+    "\tfollowRedirects = false",
+    "[http \"https://github.com/\"]",
+    `\textraheader = AUTHORIZATION: basic ${basicAuth}`,
+    "[fetch]",
+    "\trecurseSubmodules = false",
+    "\tfsckObjects = true",
+    "[transfer]",
+    "\tfsckObjects = true",
+    "[maintenance]",
+    "\tauto = false",
+    "[gc]",
+    "\tauto = 0",
+    "[remote \"origin\"]",
+    `\turl = ${remoteUrl}`,
+    "\tpromisor = true",
+    "\tpartialclonefilter = blob:none",
+    ""
+  ].join("\n");
+  fs.writeFileSync(path.join(gitDirectory, "config"), config, { encoding: "utf8", mode: 0o600, flag: "w" });
+}
+
+function isBoundedGitProcessResult(value) {
+  return isPlainObject(value)
+    && Number.isInteger(value.status)
+    && typeof value.timedOut === "boolean"
+    && typeof value.outputExceeded === "boolean"
+    && typeof value.repositoryBytesExceeded === "boolean"
+    && typeof value.fileSizeExceeded === "boolean"
+    && typeof value.addressSpaceExceeded === "boolean"
+    && typeof value.cpuExceeded === "boolean";
+}
+
+function removeCandidateDirectory(gitDirectory) {
+  const resolved = path.resolve(gitDirectory);
+  if (path.basename(resolved) !== "candidate.git" || path.dirname(resolved) === resolved) {
+    systemBlocked("CANDIDATE_FETCH_CLEANUP_FAILED", "The failed candidate object-store cleanup target changed identity.");
+  }
+  try {
+    fs.rmSync(resolved, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 });
+  } catch {
+    systemBlocked("CANDIDATE_FETCH_CLEANUP_FAILED", "The failed candidate object store and its credential could not be removed.");
+  }
+}
+
+function planApplicationHydration(classified, limits) {
+  if (classified.mode !== "application") {
+    reject("APPLICATION_CHANGE_REQUIRED", "Only a closed public application package may hydrate candidate blobs.");
+  }
+  const applicationIds = new Set();
+  for (const change of classified.changes) {
+    if (change.status === "deleted") {
+      reject("APPLICATION_FILE_DELETED", "Public application files cannot be deleted through the intake workflow.");
+    }
+    const match = APPLICATION_PATH_PATTERN.exec(change.path);
+    if (!match) reject("APPLICATION_PATH_INVALID", "An application path is outside the closed package layout.");
+    applicationIds.add(match[1]);
+  }
+  if (applicationIds.size !== 1) {
+    reject("APPLICATION_COUNT_INVALID", "A public application pull request must add or update exactly one application id.");
+  }
+  const [applicationId] = applicationIds;
+  const packageDirectory = `submissions/${applicationId}`;
+  const packagePrefix = `${packageDirectory}/`;
+  const entries = [...classified.candidate.entries.values()]
+    .filter((entry) => entry.path.startsWith(packagePrefix))
+    .sort((left, right) => compareUtf8(left.path, right.path));
+  const expectedPaths = APPLICATION_FILES.map((fileName) => `${packagePrefix}${fileName}`).sort(compareUtf8);
+  if (!arraysEqual(entries.map((entry) => entry.path), expectedPaths)) {
+    reject(
+      "APPLICATION_PACKAGE_NOT_CLOSED",
+      "The application directory must contain exactly the seven allowlisted autonomous admission files."
+    );
+  }
+  for (const entry of entries) {
+    assertRegularBlob(entry);
+    const maximumBytes = limits.maximumFileBytes[path.posix.basename(entry.path)];
+    if (!Number.isInteger(maximumBytes)) {
+      systemBlocked("FILE_LIMIT_MISSING", "The trusted validator has no size policy for an allowlisted package file.");
+    }
+  }
+  return { applicationId, packageDirectory, entries };
+}
+
+function readPackageTreeObjectId(gitDirectory, packageDirectory) {
+  const objectId = runGitText(
+    gitDirectory,
+    ["rev-parse", "--verify", `HEAD:${packageDirectory}`],
+    128
+  ).trim();
+  if (!SHA1_PATTERN.test(objectId)) {
+    systemBlocked("HYDRATION_TREE_INVALID", "The closed application directory did not resolve to an exact Git tree.");
+  }
+  const objectType = runGitText(gitDirectory, ["cat-file", "-t", objectId], 32).trim();
+  if (objectType !== "tree") {
+    systemBlocked("HYDRATION_TREE_INVALID", "The closed application directory was not a Git tree.");
+  }
+  return objectId;
+}
+
+function requireHydrationRemote(gitDirectory, expectedRemoteUrl) {
+  if (typeof expectedRemoteUrl !== "string" || expectedRemoteUrl.length < 1 || /[\u0000\r\n]/u.test(expectedRemoteUrl)) {
+    systemBlocked("HYDRATION_REMOTE_INVALID", "The trusted candidate remote identity is malformed.");
+  }
+  const remoteNames = runGitText(gitDirectory, ["remote"], 1024).trim().split("\n").filter(Boolean);
+  const observedRemoteUrl = runGitText(
+    gitDirectory,
+    ["config", "--local", "--get", "remote.origin.url"],
+    4096
+  ).trim();
+  if (remoteNames.length !== 1 || remoteNames[0] !== "origin" || observedRemoteUrl !== expectedRemoteUrl) {
+    systemBlocked("HYDRATION_REMOTE_INVALID", "The candidate object store is not bound to the central GitHub repository.");
+  }
+}
+
+async function resolveCandidateTreeMetadata({
+  repository,
+  readToken,
+  packageTreeObjectId,
+  fetchImplementation,
+  timeoutMs
+}) {
+  if (typeof fetchImplementation !== "function") {
+    systemBlocked("HYDRATION_METADATA_UNAVAILABLE", "The trusted GitHub metadata transport is unavailable.");
+  }
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > TRUSTED_GIT_TIMEOUT_MS) {
+    systemBlocked("HYDRATION_TIMEOUT_INVALID", "The trusted metadata timeout is outside its closed bound.");
+  }
+  const requestUrl = `https://api.github.com/repos/${repository}/git/trees/${packageTreeObjectId}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  timeout.unref?.();
+  let response;
+  try {
+    response = await fetchImplementation(requestUrl, {
+      method: "GET",
+      redirect: "error",
+      signal: controller.signal,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${readToken}`,
+        "User-Agent": "programmable-public-intake-hydrator-v1",
+        "X-GitHub-Api-Version": "2026-03-10"
+      }
+    });
+  } catch {
+    systemBlocked("HYDRATION_METADATA_UNAVAILABLE", "GitHub tree-size metadata was unavailable before candidate hydration.");
+  } finally {
+    clearTimeout(timeout);
+  }
+  if (
+    !response
+    || response.status !== 200
+    || response.redirected === true
+    || (typeof response.url === "string" && response.url !== "" && response.url !== requestUrl)
+  ) {
+    systemBlocked("HYDRATION_METADATA_UNAVAILABLE", "GitHub did not return exact same-origin tree-size metadata.");
+  }
+  const declaredLength = response.headers?.get?.("content-length");
+  if (declaredLength !== null && declaredLength !== undefined) {
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(declaredLength) || Number(declaredLength) > HYDRATION_API_RESPONSE_BYTES) {
+      systemBlocked("HYDRATION_METADATA_TOO_LARGE", "GitHub tree-size metadata exceeded its trusted response bound.");
+    }
+  }
+  const bytes = await readBoundedHydrationResponse(response, HYDRATION_API_RESPONSE_BYTES);
+  let parsed;
+  try {
+    parsed = JSON.parse(UTF8_DECODER.decode(bytes));
+  } catch {
+    systemBlocked("HYDRATION_METADATA_INVALID", "GitHub tree-size metadata was not valid bounded UTF-8 JSON.");
+  }
+  return { requestUrl, packageTreeObjectId, parsed };
+}
+
+async function readBoundedHydrationResponse(response, maximumBytes) {
+  if (response.body?.getReader) {
+    const reader = response.body.getReader();
+    const chunks = [];
+    let total = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const bytes = Buffer.from(value);
+        total += bytes.length;
+        if (total > maximumBytes) {
+          await reader.cancel().catch(() => {});
+          systemBlocked("HYDRATION_METADATA_TOO_LARGE", "GitHub tree-size metadata exceeded its trusted response bound.");
+        }
+        chunks.push(bytes);
+      }
+    } finally {
+      reader.releaseLock?.();
+    }
+    return Buffer.concat(chunks, total);
+  }
+  if (typeof response.arrayBuffer !== "function") {
+    systemBlocked("HYDRATION_METADATA_INVALID", "GitHub tree-size metadata had no readable response body.");
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.length > maximumBytes) {
+    systemBlocked("HYDRATION_METADATA_TOO_LARGE", "GitHub tree-size metadata exceeded its trusted response bound.");
+  }
+  return bytes;
+}
+
+function enforceHydrationMetadata(plan, metadata, limits) {
+  const document = metadata.parsed;
+  if (
+    !isPlainObject(document)
+    || document.sha !== metadata.packageTreeObjectId
+    || document.truncated !== false
+    || !Array.isArray(document.tree)
+    || document.tree.length !== plan.entries.length
+  ) {
+    systemBlocked("HYDRATION_METADATA_INVALID", "GitHub tree-size metadata did not match the exact closed package tree.");
+  }
+  const expected = new Map(plan.entries.map((entry) => [path.posix.basename(entry.path), entry]));
+  const observed = new Set();
+  let totalBytes = 0;
+  for (const record of document.tree) {
+    if (!isPlainObject(record) || typeof record.path !== "string" || observed.has(record.path)) {
+      systemBlocked("HYDRATION_METADATA_INVALID", "GitHub tree-size metadata contained an invalid or duplicate entry.");
+    }
+    observed.add(record.path);
+    const entry = expected.get(record.path);
+    if (
+      !entry
+      || record.mode !== entry.mode
+      || record.type !== entry.type
+      || record.sha !== entry.oid
+      || !Number.isSafeInteger(record.size)
+      || record.size < 0
+    ) {
+      systemBlocked("HYDRATION_METADATA_MISMATCH", "GitHub tree-size metadata did not match the fetched exact Git tree.");
+    }
+    const maximumBytes = limits.maximumFileBytes[record.path];
+    if (record.size > maximumBytes) {
+      reject("APPLICATION_FILE_TOO_LARGE", "An application package file exceeds its trusted byte limit before hydration.");
+    }
+    totalBytes += record.size;
+    if (totalBytes > limits.maximumPackageBytes) {
+      reject("APPLICATION_PACKAGE_TOO_LARGE", "The application review package exceeds its trusted byte limit before hydration.");
+    }
+  }
+  return {
+    entries: new Map(document.tree.map((record) => [record.sha, { path: record.path, size: record.size }])),
+    totalBytes
+  };
+}
+
+function validateHydrationProcessLimits(maximumAdditionalRepositoryBytes, maximumFileSizeBytes) {
+  for (const [label, value, maximum] of [
+    ["additional repository", maximumAdditionalRepositoryBytes, HYDRATION_ADDITIONAL_REPOSITORY_BYTES],
+    ["file size", maximumFileSizeBytes, HYDRATION_FILE_SIZE_BYTES]
+  ]) {
+    if (!Number.isInteger(value) || value < 512 || value > maximum) {
+      systemBlocked("HYDRATION_LIMIT_INVALID", `The trusted ${label} hydration limit is invalid.`);
+    }
+  }
+}
+
+function runHydrationConfig(gitDirectory, configArgs, { allowMissing = false } = {}) {
+  const result = childProcess.spawnSync(
+    "git",
+    [
+      "-c", "credential.helper=",
+      "-c", "core.hooksPath=/dev/null",
+      "-C", gitDirectory,
+      "config", "--local",
+      ...configArgs
+    ],
+    {
+      encoding: "utf8",
+      shell: false,
+      timeout: TRUSTED_GIT_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+      env: trustedGitEnvironment()
+    }
+  );
+  if (result.status === 0 || (allowMissing && result.status === 5)) return;
+  systemBlocked("HYDRATION_CONFIG_FAILED", "Trusted sparse hydration configuration failed.");
+}
+
+function verifyHydratedObjects(gitDirectory, plan, metadata, limits) {
+  let totalBytes = 0;
+  for (const entry of plan.entries) {
+    const type = runGitText(gitDirectory, ["cat-file", "-t", entry.oid], 32).trim();
+    const sizeText = runGitText(gitDirectory, ["cat-file", "-s", entry.oid], 128).trim();
+    if (type !== "blob" || !/^(?:0|[1-9][0-9]*)$/u.test(sizeText)) {
+      systemBlocked("HYDRATION_OBJECT_INVALID", "A bounded application blob was unavailable after sparse hydration.");
+    }
+    const size = Number(sizeText);
+    const expected = metadata.entries.get(entry.oid);
+    if (!Number.isSafeInteger(size) || expected?.size !== size || size > limits.maximumFileBytes[expected.path]) {
+      systemBlocked("HYDRATION_OBJECT_MISMATCH", "A hydrated blob did not match preflighted GitHub size metadata.");
+    }
+    totalBytes += size;
+  }
+  if (totalBytes !== metadata.totalBytes || totalBytes > limits.maximumPackageBytes) {
+    systemBlocked("HYDRATION_OBJECT_MISMATCH", "Hydrated application bytes did not match the bounded package metadata.");
+  }
+}
+
+export async function runBoundedHydrationGitProcess({
+  gitExecutable = "git",
+  gitDirectory,
+  args,
+  timeoutMs,
+  maximumOutputBytes,
+  maximumFileSizeBytes,
+  maximumRepositoryBytes,
+  maximumAddressSpaceBytes = CANDIDATE_GIT_ADDRESS_SPACE_BYTES,
+  maximumCpuSeconds = CANDIDATE_GIT_CPU_SECONDS,
+  allowFileProtocol = false
+}) {
+  if (process.platform !== "darwin" && process.platform !== "linux") {
+    systemBlocked("HYDRATION_PLATFORM_UNSUPPORTED", "Bounded Git hydration supports macOS and Linux only.");
+  }
+  const safeArgs = [
+    "-c", "credential.helper=",
+    "-c", "credential.interactive=never",
+    "-c", "core.hooksPath=/dev/null",
+    "-c", "core.attributesFile=/dev/null",
+    "-c", "core.fsmonitor=false",
+    "-c", "core.untrackedCache=false",
+    "-c", "protocol.allow=never",
+    "-c", "protocol.version=2",
+    "-c", "protocol.https.allow=always",
+    "-c", `protocol.file.allow=${allowFileProtocol ? "always" : "never"}`,
+    "-c", "protocol.ext.allow=never",
+    "-c", "protocol.ssh.allow=never",
+    "-c", "http.followRedirects=false",
+    "-c", "submodule.recurse=false",
+    "-c", "fetch.recurseSubmodules=false",
+    "-c", "fetch.fsckObjects=true",
+    "-c", "transfer.fsckObjects=true",
+    "-c", "core.deltaBaseCacheLimit=16m",
+    "-c", "core.packedGitWindowSize=16m",
+    "-c", "core.packedGitLimit=64m",
+    "-c", "pack.deltaCacheLimit=16m",
+    "-c", "pack.windowMemory=32m",
+    "-c", "pack.threads=1",
+    "-c", "index.threads=1",
+    "-c", "maintenance.auto=false",
+    "-c", "gc.auto=0",
+    "-C", gitDirectory,
+    ...args
+  ];
+  // Bash defines ulimit -f in 1024-byte increments on the supported runners.
+  const fileLimitBlocks = Math.floor(maximumFileSizeBytes / 1024);
+  const addressSpaceLimitKilobytes = process.platform === "linux"
+    ? Math.floor(maximumAddressSpaceBytes / 1024)
+    : 0;
+  if (
+    typeof gitExecutable !== "string"
+    || gitExecutable.length < 1
+    || /[\u0000\r\n]/u.test(gitExecutable)
+    || !Array.isArray(args)
+    || !Number.isInteger(timeoutMs)
+    || timeoutMs < 1
+    || timeoutMs > TRUSTED_GIT_TIMEOUT_MS
+    || !Number.isInteger(maximumOutputBytes)
+    || maximumOutputBytes < 1
+    || !Number.isInteger(maximumRepositoryBytes)
+    || maximumRepositoryBytes < 1
+    || !Number.isInteger(maximumAddressSpaceBytes)
+    || maximumAddressSpaceBytes < 64 * 1024 * 1024
+    || maximumAddressSpaceBytes > CANDIDATE_GIT_ADDRESS_SPACE_BYTES
+    || !Number.isInteger(maximumCpuSeconds)
+    || maximumCpuSeconds < 1
+    || maximumCpuSeconds > CANDIDATE_GIT_CPU_SECONDS
+    || fileLimitBlocks < 1
+  ) {
+    systemBlocked("HYDRATION_PROCESS_INVALID", "Bounded Git hydration received invalid trusted process options.");
+  }
+  return new Promise((resolve, rejectPromise) => {
+    // GitHub's production runner is Linux: RLIMIT_AS bounds decompression and
+    // delta resolution even when a tiny pack expands far beyond its disk size.
+    // Darwin does not implement a settable RLIMIT_AS, so local macOS tests keep
+    // the file/CPU/repository/output/wall-clock limits while Linux adds RLIMIT_AS.
+    const launcher = [
+      'ulimit -f "$1" || exit 125',
+      'ulimit -t "$2" || exit 125',
+      'if [[ "$3" != "0" ]]; then ulimit -v "$3" || exit 125; fi',
+      'shift 3',
+      'exec "$@"'
+    ].join("; ");
+    let child;
+    try {
+      child = childProcess.spawn(
+        "/bin/bash",
+        [
+          "--noprofile", "--norc", "-c", launcher, "bounded-git",
+          String(fileLimitBlocks),
+          String(maximumCpuSeconds),
+          String(addressSpaceLimitKilobytes),
+          gitExecutable,
+          ...safeArgs
+        ],
+        {
+          detached: true,
+          env: hydrationGitEnvironment(),
+          shell: false,
+          stdio: ["ignore", "pipe", "pipe"]
+        }
+      );
+    } catch (error) {
+      rejectPromise(error);
+      return;
+    }
+
+    const stdout = [];
+    const stderr = [];
+    let outputBytes = 0;
+    let outputExceeded = false;
+    let repositoryBytesExceeded = false;
+    let timedOut = false;
+    let terminated = false;
+    let settled = false;
+    let forceKillTimer = null;
+
+    const killGroup = (signal) => {
+      if (!Number.isInteger(child.pid)) return;
+      try {
+        process.kill(-child.pid, signal);
+      } catch (error) {
+        if (error?.code !== "ESRCH") child.kill(signal);
+      }
+    };
+    const terminate = () => {
+      if (terminated) return;
+      terminated = true;
+      killGroup("SIGTERM");
+      forceKillTimer = setTimeout(() => killGroup("SIGKILL"), HYDRATION_KILL_GRACE_MS);
+      forceKillTimer.unref?.();
+    };
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      terminate();
+    }, timeoutMs);
+    timeout.unref?.();
+    const sizePoll = setInterval(() => {
+      if (settled || repositoryBytesExceeded) return;
+      try {
+        if (measureHydrationDirectory(gitDirectory) > maximumRepositoryBytes) {
+          repositoryBytesExceeded = true;
+          terminate();
+        }
+      } catch {
+        repositoryBytesExceeded = true;
+        terminate();
+      }
+    }, HYDRATION_POLL_MS);
+    sizePoll.unref?.();
+
+    const collect = (target) => (chunk) => {
+      if (outputExceeded) return;
+      const bytes = Buffer.from(chunk);
+      outputBytes += bytes.length;
+      if (outputBytes > maximumOutputBytes) {
+        outputExceeded = true;
+        terminate();
+        return;
+      }
+      target.push(bytes);
+    };
+    child.stdout.on("data", collect(stdout));
+    child.stderr.on("data", collect(stderr));
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      clearInterval(sizePoll);
+      killGroup("SIGKILL");
+      if (forceKillTimer !== null) clearTimeout(forceKillTimer);
+      rejectPromise(error);
+    });
+    child.on("close", (status, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      clearInterval(sizePoll);
+      // A successful leader must not be allowed to leave a detached helper
+      // alive after the bounded operation has finished.
+      killGroup("SIGKILL");
+      if (forceKillTimer !== null) clearTimeout(forceKillTimer);
+      try {
+        if (measureHydrationDirectory(gitDirectory) > maximumRepositoryBytes) repositoryBytesExceeded = true;
+      } catch {
+        repositoryBytesExceeded = true;
+      }
+      const stderrBytes = Buffer.concat(stderr);
+      const stderrText = stderrBytes.toString("utf8");
+      resolve({
+        status: Number.isInteger(status) ? status : 1,
+        signal,
+        stdout: Buffer.concat(stdout),
+        stderr: stderrBytes,
+        timedOut,
+        outputExceeded,
+        repositoryBytesExceeded,
+        fileSizeExceeded: signal === "SIGXFSZ"
+          || status === 153
+          || /File size limit exceeded/iu.test(stderrText),
+        addressSpaceExceeded: /(?:out of memory|cannot allocate memory|memory exhausted|failed to allocate memory)/iu.test(stderrText),
+        cpuExceeded: signal === "SIGXCPU" || status === 152
+      });
+    });
+  });
+}
+
+function hydrationGitEnvironment() {
+  const environment = Object.create(null);
+  for (const name of ["PATH", "TMPDIR", "TMP", "TEMP"]) {
+    if (typeof process.env[name] === "string") environment[name] = process.env[name];
+  }
+  environment.LANG = "C";
+  environment.LC_ALL = "C";
+  environment.LC_CTYPE = "C";
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = "/dev/null";
+  environment.GIT_TERMINAL_PROMPT = "0";
+  environment.GIT_OPTIONAL_LOCKS = "0";
+  environment.GIT_LFS_SKIP_SMUDGE = "1";
+  environment.GIT_NO_REPLACE_OBJECTS = "1";
+  environment.GIT_LITERAL_PATHSPECS = "1";
+  environment.GIT_PROTOCOL_FROM_USER = "0";
+  environment.GIT_PAGER = "cat";
+  environment.GCM_INTERACTIVE = "Never";
+  return environment;
+}
+
+function measureHydrationDirectory(directory) {
+  const root = path.resolve(directory ?? "");
+  if (!fs.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    systemBlocked("HYDRATION_STORAGE_INVALID", "The candidate object store is missing.");
+  }
+  const pending = [root];
+  let entries = 0;
+  let totalBytes = 0;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      entries += 1;
+      if (entries > HYDRATION_MAXIMUM_ENTRIES) {
+        systemBlocked("HYDRATION_STORAGE_INVALID", "The candidate object store exceeds its trusted entry bound.");
+      }
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      } else {
+        const status = fs.lstatSync(entryPath);
+        if (status.isFile() || status.isSymbolicLink()) totalBytes += status.size;
+      }
+      if (!Number.isSafeInteger(totalBytes)) {
+        systemBlocked("HYDRATION_STORAGE_INVALID", "The candidate object-store size could not be represented safely.");
+      }
+    }
+  }
+  return totalBytes;
+}
+
+export async function verifyPublicHookApplication({
+  baseRoot,
+  candidateRoot,
+  expectedBaseCommit,
+  pullRequestNumber,
+  expectedBuilderLogin,
+  expectedBuilderUserId,
+  expectedCandidateCommit,
+  expectedMergeCommit,
+  resolveSource: _deprecatedResolveSource,
+  resolveEvidence: _deprecatedResolveEvidence,
+  limits: limitOverrides = {}
+}) {
+  const limits = mergeLimits(limitOverrides);
+  validateCandidateFetchIdentity({
+    pullRequestNumber,
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    expectedMergeCommit
+  });
+  const classified = classifyPublicIntakePullRequest({
+    baseRoot,
+    candidateRoot,
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    expectedMergeCommit,
+    limits
+  });
+  if (classified.mode !== "application") {
+    reject("APPLICATION_CHANGE_REQUIRED", "This validator accepts exactly one closed public application package.");
+  }
+
+  const changedApplicationIds = new Set();
+  for (const change of classified.changes) {
+    if (change.status === "deleted") {
+      reject("APPLICATION_FILE_DELETED", "Public application files cannot be deleted through the intake workflow.");
+    }
+    const match = APPLICATION_PATH_PATTERN.exec(change.path);
+    if (!match) reject("APPLICATION_PATH_INVALID", "An application path is outside the closed package layout.");
+    changedApplicationIds.add(match[1]);
+  }
+  if (changedApplicationIds.size !== 1) {
+    reject("APPLICATION_COUNT_INVALID", "A public application pull request must add or update exactly one application id.");
+  }
+  const [applicationId] = changedApplicationIds;
+  const packagePrefix = `submissions/${applicationId}/`;
+  const isUpdate = classifyTrustedBaseApplication(classified.base, applicationId);
+  const intakeStatus = readTrustedIntakeStatus(classified.base);
+  const continuation = enforceTrustedIntakeStatus({
+    intakeStatus,
+    isUpdate,
+    pullRequestNumber,
+    applicationId
+  });
+
+  // Source resolution and approval are intentionally not duplicated here. This
+  // repository-local gate proves only that the inert seven-file envelope is
+  // canonical and attributable to the authenticated pull-request author. The
+  // autonomous admission service independently resolves every numeric
+  // repository id, full commit, tree and file before it can decide anything.
+  const normalizedBuilderLogin = normalizeExpectedBuilderLogin(expectedBuilderLogin);
+  const normalizedBuilderUserId = normalizeExpectedBuilderUserId(expectedBuilderUserId);
+  const candidatePackageEntries = [...classified.candidate.entries.values()]
+    .filter((entry) => entry.path.startsWith(packagePrefix))
+    .sort((left, right) => compareUtf8(left.path, right.path));
+  const expectedPaths = APPLICATION_FILES.map((fileName) => `${packagePrefix}${fileName}`).sort(compareUtf8);
+  const observedPaths = candidatePackageEntries.map((entry) => entry.path);
+  if (!arraysEqual(observedPaths, expectedPaths)) {
+    reject(
+      "APPLICATION_PACKAGE_NOT_CLOSED",
+      "The application directory must contain exactly the seven allowlisted autonomous-admission files."
+    );
+  }
+  for (const entry of candidatePackageEntries) assertRegularBlob(entry);
+
+  const packageFiles = new Map();
+  let packageBytes = 0;
+  for (const entry of candidatePackageEntries) {
+    const fileName = path.posix.basename(entry.path);
+    const maximumBytes = limits.maximumFileBytes[fileName];
+    if (!Number.isInteger(maximumBytes)) {
+      systemBlocked("FILE_LIMIT_MISSING", "The trusted validator has no size policy for an allowlisted package file.");
+    }
+    const bytes = readGitBlob(classified.candidate.root, entry, maximumBytes);
+    packageFiles.set(fileName, bytes);
+    packageBytes += bytes.length;
+  }
+  if (packageBytes > limits.maximumPackageBytes) {
+    reject("APPLICATION_PACKAGE_TOO_LARGE", "The application review package exceeds the trusted byte limit.");
+  }
+
+  const { application, launch, compatibility, evidenceIndex } = validatePublicApplicationPackageFiles({
+    applicationId,
+    packageFiles,
+    limits
+  });
+  enforceTrustedContinuationIdentity({
+    continuation,
+    application,
+    authenticatedBuilderUserId: normalizedBuilderUserId
+  });
+  validateRevisionChange({ application, applicationId, packagePrefix, classified, limits });
+  const sourceHints = autonomousSourceHintProjection(application);
+
+  return {
+    schemaVersion: 1,
+    validatorVersion: VALIDATOR_VERSION,
+    result: "valid-public-application-package",
+    mode: "application",
+    intakeState: intakeStatus.state,
+    applicationId,
+    applicationRevision: application.applicationRevision,
+    pullRequestNumber,
+    continuationAuthorized: continuation !== null,
+    builderIdentity: {
+      authentication: "github-pull-request-author",
+      immutableGitHubUserId: normalizedBuilderUserId,
+      authenticatedLogin: expectedBuilderLogin,
+      normalizedLogin: normalizedBuilderLogin,
+      provesSourceRepositoryOwnership: false
+    },
+    baseCommit: classified.base.commit,
+    candidateCommit: classified.candidate.commit,
+    mergeCommit: classified.candidate.mergeCommit,
+    authority: "preflight-only",
+    serviceResolutionRequired: true,
+    sourceHints,
+    launchSha256: `sha256:${crypto.createHash("sha256").update(packageFiles.get("launch.json")).digest("hex")}`,
+    evidenceAttestation: evidenceIndex.attestation,
+    compatibilityResult: compatibility.result
+  };
+}
+
+function readTrustedIntakeStatus(base) {
+  const entry = base.entries.get(INTAKE_STATUS_PATH);
+  if (!entry) {
+    systemBlocked(
+      "INTAKE_STATUS_MISSING",
+      `The trusted base revision does not contain ${INTAKE_STATUS_PATH}.`
+    );
+  }
+  if (entry.mode !== "100644" || entry.type !== "blob" || !SHA1_PATTERN.test(entry.oid)) {
+    systemBlocked(
+      "INTAKE_STATUS_INVALID",
+      `The trusted base revision's ${INTAKE_STATUS_PATH} must be a non-executable regular Git blob.`
+    );
+  }
+
+  const declaredSizeText = runGitText(base.root, ["cat-file", "-s", entry.oid], 128).trim();
+  if (!/^(?:0|[1-9][0-9]*)$/u.test(declaredSizeText)) {
+    systemBlocked("INTAKE_STATUS_INVALID", "Git returned an invalid trusted intake-status size.");
+  }
+  const declaredSize = Number(declaredSizeText);
+  if (!Number.isSafeInteger(declaredSize) || declaredSize > MAXIMUM_INTAKE_STATUS_BYTES) {
+    systemBlocked("INTAKE_STATUS_INVALID", "The trusted intake-status file exceeds its closed byte limit.");
+  }
+  const bytes = runGit(base.root, ["cat-file", "blob", entry.oid], MAXIMUM_INTAKE_STATUS_BYTES + 1);
+  if (bytes.length !== declaredSize) {
+    systemBlocked("INTAKE_STATUS_INVALID", "Trusted intake-status bytes do not match their declared Git blob size.");
+  }
+
+  let source;
+  try {
+    source = UTF8_DECODER.decode(bytes);
+  } catch {
+    systemBlocked("INTAKE_STATUS_INVALID", "The trusted intake-status file is not valid UTF-8.");
+  }
+  if (CONTROL_OR_BIDI_PATTERN.test(source) || source.includes("\r")) {
+    systemBlocked("INTAKE_STATUS_INVALID", "The trusted intake-status file contains unsupported text controls.");
+  }
+
+  let status;
+  try {
+    status = JSON.parse(source);
+  } catch {
+    systemBlocked("INTAKE_STATUS_INVALID", "The trusted intake-status file is not valid JSON.");
+  }
+  if (
+    !isPlainObject(status)
+    || !arraysEqual(
+      Object.keys(status).sort(compareUtf8),
+      ["continuingPullRequests", "schemaVersion", "state"]
+    )
+    || status.schemaVersion !== 2
+    || !PUBLIC_INTAKE_STATES.includes(status.state)
+    || !Array.isArray(status.continuingPullRequests)
+    || status.continuingPullRequests.length > MAXIMUM_CONTINUING_PULL_REQUESTS
+    || source !== `${canonicalJson(status)}\n`
+  ) {
+    systemBlocked(
+      "INTAKE_STATUS_INVALID",
+      "The trusted intake-status file must be closed canonical JSON with schemaVersion 2, a supported state, and a bounded continuation list."
+    );
+  }
+  const continuingPullRequests = validateTrustedContinuations(status.continuingPullRequests);
+  if (status.state !== "paused-new" && continuingPullRequests.length !== 0) {
+    systemBlocked(
+      "INTAKE_STATUS_INVALID",
+      "Trusted pull-request continuations may be nonempty only while new application ids are paused."
+    );
+  }
+  return Object.freeze({
+    schemaVersion: status.schemaVersion,
+    state: status.state,
+    continuingPullRequests
+  });
+}
+
+function validateTrustedContinuations(records) {
+  const result = [];
+  const pullRequestNumbers = new Set();
+  const applicationIds = new Set();
+  let previous = null;
+  for (const record of records) {
+    if (
+      !isPlainObject(record)
+      || !arraysEqual(Object.keys(record).sort(compareUtf8), [
+        "applicationId",
+        "builderGitHubUserId",
+        "companionNumericRepositoryIds",
+        "primaryNumericRepositoryId",
+        "pullRequestNumber"
+      ])
+      || typeof record.applicationId !== "string"
+      || !APPLICATION_ID_PATTERN.test(record.applicationId)
+      || record.applicationId.length > 80
+      || typeof record.builderGitHubUserId !== "string"
+      || !OPAQUE_ID_PATTERN.test(record.builderGitHubUserId)
+      || typeof record.primaryNumericRepositoryId !== "string"
+      || !OPAQUE_ID_PATTERN.test(record.primaryNumericRepositoryId)
+      || typeof record.pullRequestNumber !== "string"
+      || !PULL_REQUEST_NUMBER_PATTERN.test(record.pullRequestNumber)
+      || !Array.isArray(record.companionNumericRepositoryIds)
+      || record.companionNumericRepositoryIds.length > MAXIMUM_CONTINUATION_COMPANIONS
+    ) {
+      systemBlocked("INTAKE_STATUS_INVALID", "A trusted pull-request continuation record is malformed.");
+    }
+    const companions = record.companionNumericRepositoryIds;
+    for (let index = 0; index < companions.length; index += 1) {
+      if (
+        typeof companions[index] !== "string"
+        || !OPAQUE_ID_PATTERN.test(companions[index])
+        || (index > 0 && compareUtf8(companions[index - 1], companions[index]) >= 0)
+        || companions[index] === record.primaryNumericRepositoryId
+      ) {
+        systemBlocked(
+          "INTAKE_STATUS_INVALID",
+          "Trusted continuation companion repository ids must be unique canonical decimal strings in source-contract order."
+        );
+      }
+    }
+    if (
+      pullRequestNumbers.has(record.pullRequestNumber)
+      || applicationIds.has(record.applicationId)
+      || (previous !== null && compareContinuations(previous, record) >= 0)
+    ) {
+      systemBlocked(
+        "INTAKE_STATUS_INVALID",
+        "Trusted pull-request continuations must be uniquely bound and sorted by pull-request number and application id."
+      );
+    }
+    pullRequestNumbers.add(record.pullRequestNumber);
+    applicationIds.add(record.applicationId);
+    previous = record;
+    result.push(Object.freeze({
+      applicationId: record.applicationId,
+      builderGitHubUserId: record.builderGitHubUserId,
+      companionNumericRepositoryIds: Object.freeze([...companions]),
+      primaryNumericRepositoryId: record.primaryNumericRepositoryId,
+      pullRequestNumber: record.pullRequestNumber
+    }));
+  }
+  return Object.freeze(result);
+}
+
+function enforceTrustedIntakeStatus({ intakeStatus, isUpdate, pullRequestNumber, applicationId }) {
+  if (intakeStatus?.state === "open") return null;
+  if (intakeStatus?.state === "paused-new" && isUpdate) return null;
+  if (intakeStatus?.state === "paused-new" && !isUpdate) {
+    const continuation = intakeStatus.continuingPullRequests.find((record) => (
+      record.pullRequestNumber === pullRequestNumber && record.applicationId === applicationId
+    ));
+    if (continuation) return continuation;
+  }
+  if (intakeStatus?.state === "prelaunch") {
+    systemBlocked("INTAKE_PRELAUNCH", "Custom Launch applications are not open yet.");
+  }
+  if (intakeStatus?.state === "paused-new") {
+    systemBlocked(
+      "INTAKE_PAUSED_NEW",
+      "Custom Launch intake is paused for new application ids except exact trusted pull-request continuations."
+    );
+  }
+  if (intakeStatus?.state === "paused-all") {
+    systemBlocked("INTAKE_PAUSED_ALL", "Custom Launch intake is temporarily paused for all application changes.");
+  }
+  systemBlocked("INTAKE_STATUS_INVALID", "The trusted intake state could not be enforced.");
+}
+
+function enforceTrustedContinuationSourceIdentity({ continuation, application }) {
+  if (continuation === null) return;
+  const primary = autonomousPrimarySourceHint(application);
+  const companionIds = application.githubSources
+    .filter(({ sourceId }) => sourceId !== application.primarySourceId)
+    .sort((left, right) => compareUtf8(left.sourceId, right.sourceId))
+    .map(({ repositoryIdHint }) => repositoryIdHint);
+  if (
+    application.applicationId !== continuation.applicationId
+    || primary.repositoryIdHint !== continuation.primaryNumericRepositoryId
+    || !arraysEqual(companionIds, continuation.companionNumericRepositoryIds)
+  ) {
+    reject(
+      "INTAKE_CONTINUATION_IDENTITY_MISMATCH",
+      "The paused-new continuation changed its trusted builder or repository lineage."
+    );
+  }
+}
+
+function enforceTrustedContinuationIdentity({ continuation, application, authenticatedBuilderUserId }) {
+  enforceTrustedContinuationSourceIdentity({ continuation, application });
+  if (continuation !== null && authenticatedBuilderUserId !== continuation.builderGitHubUserId) {
+    reject(
+      "INTAKE_CONTINUATION_IDENTITY_MISMATCH",
+      "The paused-new continuation changed its trusted builder or repository lineage."
+    );
+  }
+}
+
+function compareContinuations(left, right) {
+  const pullRequestOrder = compareDecimalStrings(left.pullRequestNumber, right.pullRequestNumber);
+  return pullRequestOrder === 0 ? compareUtf8(left.applicationId, right.applicationId) : pullRequestOrder;
+}
+
+function compareDecimalStrings(left, right) {
+  if (left.length !== right.length) return left.length - right.length;
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function normalizeExpectedBuilderLogin(value) {
+  if (typeof value !== "string" || value.length > 39 || !GITHUB_LOGIN_PATTERN.test(value)) {
+    systemBlocked(
+      "EXPECTED_BUILDER_LOGIN_INVALID",
+      "The trusted GitHub pull-request author login is missing or malformed."
+    );
+  }
+  return value.toLowerCase();
+}
+
+function normalizeExpectedBuilderUserId(value) {
+  if (typeof value !== "string" || !OPAQUE_ID_PATTERN.test(value)) {
+    systemBlocked(
+      "EXPECTED_BUILDER_ID_INVALID",
+      "The trusted GitHub pull-request author id is missing or malformed."
+    );
+  }
+  return value;
+}
+
+export function validatePublicApplicationPackageFiles({ applicationId, packageFiles, limits: limitOverrides = {} }) {
+  const limits = mergeLimits(limitOverrides);
+  if (
+    !(packageFiles instanceof Map)
+    || !arraysEqual([...packageFiles.keys()].sort(compareUtf8), [...APPLICATION_FILES].sort(compareUtf8))
+  ) {
+    reject("APPLICATION_PACKAGE_NOT_CLOSED", "The pure package validator requires exactly the seven frozen application files.");
+  }
+  let packageBytes = 0;
+  for (const [fileName, bytes] of packageFiles) {
+    if (!Buffer.isBuffer(bytes)) systemBlocked("PACKAGE_BYTES_INVALID", "The pure package validator requires Buffer values.");
+    if (bytes.length > limits.maximumFileBytes[fileName]) reject("APPLICATION_FILE_TOO_LARGE", "An application package file exceeds its trusted byte limit.");
+    packageBytes += bytes.length;
+  }
+  if (packageBytes > limits.maximumPackageBytes) {
+    reject("APPLICATION_PACKAGE_TOO_LARGE", "The application review package exceeds the trusted byte limit.");
+  }
+  const application = parseCanonicalJson(packageFiles.get(APPLICATION_FILE), APPLICATION_FILE, limits, { trailingNewline: false });
+  try {
+    validateAutonomousApplicationManifest(application, { requireImmutableSourceHints: true });
+  } catch {
+    reject("APPLICATION_MANIFEST_INVALID", "application.json does not satisfy the autonomous service manifest contract.");
+  }
+  if (application.applicationId !== applicationId) reject("APPLICATION_ID_PATH_MISMATCH", "The manifest application id must equal its submissions directory.");
+  const launch = parseCanonicalJson(packageFiles.get("launch.json"), "launch.json", limits, {
+    trailingNewline: false,
+    allowedForbiddenKeys: new Set(["constructor"])
+  });
+  try {
+    validateAutonomousLaunchSpecification(launch);
+  } catch {
+    reject("LAUNCH_SPECIFICATION_INVALID", "launch.json does not satisfy the autonomous compiler contract.");
+  }
+  if (launch.applicationId !== application.applicationId) reject("LAUNCH_APPLICATION_MISMATCH", "launch.json and application.json identify different applications.");
+  const compatibility = parseCanonicalJson(
+    packageFiles.get("compatibility-report.json"),
+    "compatibility-report.json",
+    limits
+  );
+  const evidenceIndex = parseCanonicalJson(packageFiles.get("evidence-index.json"), "evidence-index.json", limits);
+  const primary = autonomousPrimarySourceProjection(application, compatibility);
+  const internalApplication = autonomousInternalApplicationProjection(application, primary);
+  const evidenceIds = validateEvidenceIndex(evidenceIndex, internalApplication, limits);
+  validateCompatibilityReport(compatibility, internalApplication, evidenceIndex, evidenceIds, limits);
+  const markdownSources = new Map([
+    ["PROPOSAL.md", validateMarkdown(packageFiles.get("PROPOSAL.md"), "PROPOSAL.md", "# Proposal")],
+    ["THREAT_MODEL.md", validateMarkdown(packageFiles.get("THREAT_MODEL.md"), "THREAT_MODEL.md", "# Threat model")],
+    ["TEST_PLAN.md", validateMarkdown(packageFiles.get("TEST_PLAN.md"), "TEST_PLAN.md", "# Test plan")]
+  ]);
+  validatePublicClaims({ application: internalApplication, compatibility, evidenceIndex, markdownSources });
+  return { application, launch, compatibility, evidenceIndex };
+}
+
+export function inspectMaintainedSubmissions({
+  repositoryRoot,
+  maximumLegacyPackages = MAXIMUM_MAINTAINED_LEGACY_PACKAGES
+}) {
+  if (typeof repositoryRoot !== "string" || repositoryRoot.length === 0) {
+    systemBlocked(
+      "MAINTAINED_REPOSITORY_ROOT_INVALID",
+      "Maintained submission verification requires an explicit repository root."
+    );
+  }
+  if (!Number.isInteger(maximumLegacyPackages) || maximumLegacyPackages < 0) {
+    systemBlocked(
+      "MAINTAINED_LEGACY_LIMIT_INVALID",
+      "The maintained legacy-package limit must be a non-negative integer."
+    );
+  }
+
+  const resolvedRepositoryRoot = path.resolve(repositoryRoot);
+  const submissionRoot = path.join(resolvedRepositoryRoot, "submissions");
+  const rootStatus = lstatIfPresent(submissionRoot);
+  if (!rootStatus || rootStatus.isSymbolicLink() || !rootStatus.isDirectory()) {
+    systemBlocked(
+      "MAINTAINED_SUBMISSIONS_ROOT_INVALID",
+      "The trusted revision must contain a regular submissions directory."
+    );
+  }
+
+  const applications = [];
+  const legacyPackages = [];
+  const entries = fs.readdirSync(submissionRoot, { withFileTypes: true })
+    .sort((left, right) => compareUtf8(left.name, right.name));
+
+  for (const entry of entries) {
+    const entryPath = path.join(submissionRoot, entry.name);
+    if (entry.name === "README.md") {
+      const readmeStatus = lstatIfPresent(entryPath);
+      if (!readmeStatus || readmeStatus.isSymbolicLink() || !readmeStatus.isFile()) {
+        systemBlocked(
+          "MAINTAINED_SUBMISSION_ENTRY_INVALID",
+          "submissions/README.md must be a regular file."
+        );
+      }
+      continue;
+    }
+    if (entry.isSymbolicLink() || !entry.isDirectory()) {
+      systemBlocked(
+        "MAINTAINED_SUBMISSION_ENTRY_INVALID",
+        `Unexpected maintained intake entry submissions/${entry.name}; only package directories and README.md are allowed.`
+      );
+    }
+
+    const applicationManifest = path.join(entryPath, APPLICATION_FILE);
+    const manifestStatus = lstatIfPresent(applicationManifest);
+    if (!manifestStatus) {
+      legacyPackages.push({ name: entry.name, path: entryPath });
+      continue;
+    }
+    if (manifestStatus.isSymbolicLink() || !manifestStatus.isFile()) {
+      systemBlocked(
+        "MAINTAINED_APPLICATION_FILE_INVALID",
+        `Maintained application ${entry.name} has a non-regular application.json.`
+      );
+    }
+    assertClosedMaintainedApplication(entryPath, entry.name);
+    applications.push({ name: entry.name, path: entryPath });
+  }
+
+  if (legacyPackages.length > maximumLegacyPackages) {
+    systemBlocked(
+      "MAINTAINED_LEGACY_PACKAGE_LIMIT_EXCEEDED",
+      `Maintained intake contains ${legacyPackages.length} legacy packages; the trusted validation limit is ${maximumLegacyPackages}.`
+    );
+  }
+
+  return {
+    repositoryRoot: resolvedRepositoryRoot,
+    submissionRoot,
+    applications,
+    legacyPackages
+  };
+}
+
+export async function verifyMaintainedSubmissions({
+  repositoryRoot,
+  maximumLegacyPackages = MAXIMUM_MAINTAINED_LEGACY_PACKAGES,
+  validateLegacyPackage
+}) {
+  if (typeof validateLegacyPackage !== "function") {
+    systemBlocked(
+      "MAINTAINED_LEGACY_VALIDATOR_UNAVAILABLE",
+      "Maintained submission verification requires the trusted legacy-package validator."
+    );
+  }
+  const inventory = inspectMaintainedSubmissions({ repositoryRoot, maximumLegacyPackages });
+  for (const legacyPackage of inventory.legacyPackages) {
+    await validateLegacyPackage({
+      repositoryRoot: inventory.repositoryRoot,
+      packageName: legacyPackage.name,
+      packageRoot: legacyPackage.path
+    });
+  }
+  return {
+    schemaVersion: 1,
+    result: "valid-maintained-submissions",
+    applicationCount: inventory.applications.length,
+    legacyPackageCount: inventory.legacyPackages.length,
+    validatedLegacyPackages: inventory.legacyPackages.map((entry) => entry.name)
+  };
+}
+
+function assertClosedMaintainedApplication(packageRoot, applicationId) {
+  const entries = fs.readdirSync(packageRoot, { withFileTypes: true })
+    .sort((left, right) => compareUtf8(left.name, right.name));
+  const observedNames = entries.map((entry) => entry.name);
+  const expectedNames = [...APPLICATION_FILES].sort(compareUtf8);
+  if (!arraysEqual(observedNames, expectedNames)) {
+    systemBlocked(
+      "MAINTAINED_APPLICATION_PACKAGE_NOT_CLOSED",
+      `Maintained application ${applicationId} must contain exactly the seven autonomous application files.`
+    );
+  }
+  for (const entry of entries) {
+    const fileStatus = lstatIfPresent(path.join(packageRoot, entry.name));
+    if (!fileStatus || fileStatus.isSymbolicLink() || !fileStatus.isFile()) {
+      systemBlocked(
+        "MAINTAINED_APPLICATION_FILE_INVALID",
+        `Maintained application ${applicationId} contains a non-regular package file.`
+      );
+    }
+  }
+}
+
+function lstatIfPresent(target) {
+  try {
+    return fs.lstatSync(target);
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function mergeLimits(overrides) {
+  if (!isPlainObject(overrides)) systemBlocked("LIMITS_INVALID", "Trusted validator limits must be an object.");
+  return {
+    ...DEFAULT_LIMITS,
+    ...overrides,
+    maximumFileBytes: {
+      ...DEFAULT_LIMITS.maximumFileBytes,
+      ...(isPlainObject(overrides.maximumFileBytes) ? overrides.maximumFileBytes : {})
+    }
+  };
+}
+
+function compareGitRevisions({
+  baseRoot,
+  candidateRoot,
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  expectedMergeCommit,
+  limits
+}) {
+  const base = inspectGitRevision(baseRoot, expectedBaseCommit, limits);
+  const candidate = inspectPullRequestMergeRevision(candidateRoot, {
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    expectedMergeCommit,
+    limits
+  });
+  const allPaths = [...new Set([...base.entries.keys(), ...candidate.entries.keys()])].sort(compareUtf8);
+  const changes = [];
+  for (const entryPath of allPaths) {
+    const before = base.entries.get(entryPath) ?? null;
+    const after = candidate.entries.get(entryPath) ?? null;
+    if (before && after && before.mode === after.mode && before.type === after.type && before.oid === after.oid) continue;
+    changes.push({
+      path: entryPath,
+      status: before === null ? "added" : after === null ? "deleted" : "modified",
+      before,
+      after
+    });
+  }
+  if (changes.length > limits.maximumChangedFiles) {
+    reject("TOO_MANY_CHANGED_FILES", "The pull request exceeds the trusted changed-file limit.");
+  }
+  return { base, candidate, changes };
+}
+
+function inspectPullRequestMergeRevision(rootInput, {
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  expectedMergeCommit,
+  limits
+}) {
+  const { root, mergeCommit } = inspectExactPullRequestMergeIdentity(rootInput, {
+    expectedBaseCommit,
+    expectedCandidateCommit,
+    expectedMergeCommit
+  });
+  const output = runGit(root, ["ls-tree", "-rz", "--full-tree", "HEAD"], limits.maximumGitTreeBytes);
+  const entries = parseGitTree(output, limits);
+  return {
+    root,
+    commit: expectedCandidateCommit,
+    mergeCommit,
+    entries
+  };
+}
+
+/**
+ * Bind the fetched GitHub-owned refs/pull/N/merge object directly to the exact
+ * workflow base and head. GitHub API version 2026-03-10 intentionally omits
+ * merge_commit_sha, so the immutable Git object and its ordered parents are
+ * the source of truth instead of mutable or removed REST response metadata.
+ */
+function inspectExactPullRequestMergeIdentity(rootInput, {
+  expectedBaseCommit,
+  expectedCandidateCommit,
+  expectedMergeCommit = null
+}) {
+  for (const [label, commit] of [
+    ["base", expectedBaseCommit],
+    ["candidate", expectedCandidateCommit]
+  ]) {
+    if (!SHA1_PATTERN.test(commit ?? "")) {
+      systemBlocked("EXPECTED_COMMIT_INVALID", `The workflow did not provide an exact lowercase ${label} commit id.`);
+    }
+  }
+  if (expectedMergeCommit !== null && !SHA1_PATTERN.test(expectedMergeCommit ?? "")) {
+    systemBlocked("EXPECTED_COMMIT_INVALID", "The workflow did not provide an exact lowercase merge commit id.");
+  }
+
+  const root = resolveGitRoot(rootInput);
+  const mergeCommit = runGitText(root, ["rev-parse", "HEAD^{commit}"], 1024).trim();
+  if (!SHA1_PATTERN.test(mergeCommit)) {
+    systemBlocked("PR_MERGE_COMMIT_MALFORMED", "GitHub's PR merge ref did not resolve to one exact SHA-1 commit id.");
+  }
+  if (expectedMergeCommit !== null && mergeCommit !== expectedMergeCommit) {
+    systemBlocked("CHECKOUT_COMMIT_MISMATCH", "The candidate-data checkout does not match GitHub's immutable PR merge commit.");
+  }
+
+  const commitObject = runGitText(root, ["cat-file", "-p", `${mergeCommit}^{commit}`], 1024 * 1024);
+  const headerEnd = commitObject.indexOf("\n\n");
+  if (headerEnd === -1) {
+    systemBlocked("PR_MERGE_COMMIT_MALFORMED", "GitHub's PR merge commit has no canonical commit header boundary.");
+  }
+  const headerLines = commitObject.slice(0, headerEnd).split("\n");
+  const treeLines = headerLines.filter((line) => line.startsWith("tree "));
+  const parentLines = headerLines.filter((line) => line.startsWith("parent "));
+  if (
+    treeLines.length !== 1
+    || !/^tree [a-f0-9]{40}$/u.test(treeLines[0])
+    || parentLines.length !== 2
+    || parentLines.some((line) => !/^parent [a-f0-9]{40}$/u.test(line))
+  ) {
+    systemBlocked("PR_MERGE_PARENT_CONTRACT_INVALID", "GitHub's PR merge commit does not have one tree and exactly two canonical parents.");
+  }
+  const parents = parentLines.map((line) => line.slice("parent ".length));
+  if (parents[0] !== expectedBaseCommit || parents[1] !== expectedCandidateCommit) {
+    systemBlocked("PR_MERGE_PARENT_MISMATCH", "GitHub's PR merge parents do not match the event's exact base and head commits.");
+  }
+  return { root, mergeCommit };
+}
+
+function inspectGitRevision(rootInput, expectedCommit, limits) {
+  const root = resolveGitRoot(rootInput);
+  if (!SHA1_PATTERN.test(expectedCommit ?? "")) {
+    systemBlocked("EXPECTED_COMMIT_INVALID", "The workflow did not provide an exact lowercase 40-hex commit id.");
+  }
+  const commit = runGitText(root, ["rev-parse", "HEAD^{commit}"], 1024).trim();
+  if (commit !== expectedCommit) {
+    systemBlocked("CHECKOUT_COMMIT_MISMATCH", "A checkout does not match the immutable commit supplied by GitHub.");
+  }
+  const output = runGit(root, ["ls-tree", "-rz", "--full-tree", "HEAD"], limits.maximumGitTreeBytes);
+  const entries = parseGitTree(output, limits);
+  return { root, commit, entries };
+}
+
+function resolveGitRoot(rootInput) {
+  const root = path.resolve(rootInput ?? "");
+  if (!rootInput || !fs.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    systemBlocked("GIT_ROOT_INVALID", "A trusted checkout root is missing or is not a directory.");
+  }
+  return root;
+}
+
+function parseGitTree(output, limits) {
+  const entries = new Map();
+  let offset = 0;
+  while (offset < output.length) {
+    const terminator = output.indexOf(0, offset);
+    if (terminator === -1) systemBlocked("GIT_TREE_MALFORMED", "The trusted Git tree output is not NUL terminated.");
+    const recordBytes = output.subarray(offset, terminator);
+    offset = terminator + 1;
+    if (recordBytes.length === 0) continue;
+    let record;
+    try {
+      record = UTF8_DECODER.decode(recordBytes);
+    } catch {
+      reject("GIT_PATH_NOT_UTF8", "A changed Git path is not valid UTF-8.");
+    }
+    const match = /^(\d{6}) (blob|commit|tree) ([a-f0-9]{40})\t(.+)$/.exec(record);
+    if (!match) systemBlocked("GIT_TREE_MALFORMED", "The trusted Git tree output contains an invalid record.");
+    const [, mode, type, oid, entryPath] = match;
+    validateGitPath(entryPath);
+    if (entries.has(entryPath)) systemBlocked("GIT_TREE_DUPLICATE_PATH", "The Git tree contains a duplicate path.");
+    entries.set(entryPath, { mode, type, oid, path: entryPath });
+    if (entries.size > limits.maximumGitEntries) {
+      reject("GIT_TREE_TOO_LARGE", "The candidate tree exceeds the trusted entry limit.");
+    }
+  }
+  return entries;
+}
+
+function validateGitPath(entryPath) {
+  if (!isCanonicalGitHubRepositoryPathV1(entryPath)) {
+    reject("GIT_PATH_UNSAFE", "A changed Git path is outside the safe canonical path subset.");
+  }
+}
+
+function rejectUnsafeChangedEntries(changes) {
+  for (const change of changes) {
+    if (change.after && (change.after.mode === "120000" || change.after.type === "commit" || change.after.mode === "160000")) {
+      reject("LINKED_CONTENT_FORBIDDEN", "Candidate symlinks and submodules are forbidden in trusted intake paths.");
+    }
+    if (change.after && (change.after.mode !== "100644" || change.after.type !== "blob")) {
+      reject("FILE_MODE_FORBIDDEN", "Changed intake files must be non-executable regular Git blobs.");
+    }
+  }
+}
+
+function isAllowlistedApplicationPath(entryPath) {
+  const match = APPLICATION_PATH_PATTERN.exec(entryPath);
+  return Boolean(match && APPLICATION_FILES.includes(match[2]));
+}
+
+function classifyTrustedBaseApplication(base, applicationId) {
+  const packagePrefix = `submissions/${applicationId}/`;
+  const entries = [...base.entries.values()]
+    .filter((entry) => entry.path.startsWith(packagePrefix))
+    .sort((left, right) => compareUtf8(left.path, right.path));
+  if (entries.length === 0) return false;
+  const expectedPaths = APPLICATION_FILES
+    .map((fileName) => `${packagePrefix}${fileName}`)
+    .sort(compareUtf8);
+  if (!arraysEqual(entries.map(({ path: entryPath }) => entryPath), expectedPaths)) {
+    systemBlocked(
+      "INTAKE_BASE_APPLICATION_INVALID",
+      "The trusted base contains an incomplete or non-closed public application package."
+    );
+  }
+  for (const entry of entries) {
+    if (entry.mode !== "100644" || entry.type !== "blob" || !SHA1_PATTERN.test(entry.oid)) {
+      systemBlocked(
+        "INTAKE_BASE_APPLICATION_INVALID",
+        "The trusted base application package contains a non-regular entry."
+      );
+    }
+  }
+  return true;
+}
+
+function assertNewApplicationChangedFileSet({ changedFiles, applicationId }) {
+  const expectedPaths = APPLICATION_FILES
+    .map((fileName) => `submissions/${applicationId}/${fileName}`)
+    .sort(compareUtf8);
+  const observedPaths = changedFiles.map(({ path: entryPath }) => entryPath).sort(compareUtf8);
+  if (
+    !arraysEqual(observedPaths, expectedPaths)
+    || changedFiles.some(({ status, previousPath }) => status !== "added" || previousPath !== null)
+  ) {
+    reject(
+      "CHANGED_PATH_NOT_ALLOWED",
+      "A paused-new continuation must add exactly the seven frozen files for its trusted application id."
+    );
+  }
+}
+
+function isBuilderMaintenancePath(entryPath) {
+  return BUILDER_MAINTENANCE_FILES.has(entryPath)
+    || BUILDER_MAINTENANCE_PREFIXES.some((prefix) => entryPath.startsWith(prefix))
+    || /^scripts\/test\/verify-public-hook-application(?:-[a-z0-9-]+)?\.test\.mjs$/u.test(entryPath);
+}
+
+function assertRegularBlob(entry) {
+  if (!entry || entry.mode !== "100644" || entry.type !== "blob" || !SHA1_PATTERN.test(entry.oid)) {
+    reject("APPLICATION_FILE_NOT_REGULAR", "Every application package entry must be a non-executable regular Git blob.");
+  }
+}
+
+function readGitBlob(root, entry, maximumBytes) {
+  assertRegularBlob(entry);
+  const declaredSizeText = runGitText(root, ["cat-file", "-s", entry.oid], 128).trim();
+  if (!/^(?:0|[1-9][0-9]*)$/.test(declaredSizeText)) {
+    systemBlocked("GIT_BLOB_SIZE_INVALID", "Git returned an invalid blob size.");
+  }
+  const declaredSize = Number(declaredSizeText);
+  if (!Number.isSafeInteger(declaredSize) || declaredSize > maximumBytes) {
+    reject("APPLICATION_FILE_TOO_LARGE", "An application package file exceeds its trusted byte limit.");
+  }
+  const bytes = runGit(root, ["cat-file", "blob", entry.oid], maximumBytes + 1);
+  if (bytes.length !== declaredSize) systemBlocked("GIT_BLOB_SIZE_MISMATCH", "Git blob bytes do not match their declared size.");
+  return bytes;
+}
+
+function parseCanonicalJson(
+  bytes,
+  documentName,
+  limits,
+  { trailingNewline = true, allowedForbiddenKeys = new Set() } = {}
+) {
+  let source;
+  try {
+    source = UTF8_DECODER.decode(bytes);
+  } catch {
+    reject("JSON_UTF8_INVALID", `${documentName} is not valid UTF-8.`);
+  }
+  if (CONTROL_OR_BIDI_PATTERN.test(source) || source.includes("\r")) {
+    reject("JSON_TEXT_UNSAFE", `${documentName} contains unsupported control, bidi, or carriage-return characters.`);
+  }
+  let value;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    reject("JSON_PARSE_FAILED", `${documentName} is not valid JSON.`);
+  }
+  validateJsonTree(value, limits, allowedForbiddenKeys);
+  if (source !== `${canonicalJson(value)}${trailingNewline ? "\n" : ""}`) {
+    reject("JSON_NOT_CANONICAL", `${documentName} must use its exact sorted compact canonical JSON encoding.`);
+  }
+  return value;
+}
+
+function validateJsonTree(root, limits, allowedForbiddenKeys = new Set()) {
+  let nodes = 0;
+  const visit = (value, depth) => {
+    nodes += 1;
+    if (nodes > limits.maximumJsonNodes) reject("JSON_NODE_LIMIT", "A JSON document exceeds the trusted node limit.");
+    if (depth > limits.maximumJsonDepth) reject("JSON_DEPTH_LIMIT", "A JSON document exceeds the trusted depth limit.");
+    if (typeof value === "string") {
+      if (CONTROL_OR_BIDI_PATTERN.test(value)) reject("JSON_STRING_UNSAFE", "A JSON string contains unsafe control or bidi characters.");
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((entry) => visit(entry, depth + 1));
+      return;
+    }
+    if (value === null || typeof value === "boolean" || typeof value === "number") return;
+    if (!isPlainObject(value)) reject("JSON_VALUE_UNSUPPORTED", "A JSON document contains an unsupported value type.");
+    for (const [key, entry] of Object.entries(value)) {
+      if (FORBIDDEN_JSON_KEYS.has(key) && !allowedForbiddenKeys.has(key)) {
+        reject("JSON_KEY_FORBIDDEN", "A JSON document contains a prototype-sensitive key.");
+      }
+      visit(entry, depth + 1);
+    }
+  };
+  visit(root, 0);
+}
+
+function validateApplicationManifest(application, expectedApplicationId, limits) {
+  expectClosedObject(application, [
+    "applicationId",
+    "applicationRevision",
+    "builder",
+    "declarations",
+    "reviewPackage",
+    "schemaVersion",
+    "source",
+    "stage",
+    "summary",
+    "title"
+  ], "application.json");
+  expectInteger(application.schemaVersion, 1, 1, "application.schemaVersion");
+  expectPattern(application.applicationId, APPLICATION_ID_PATTERN, 80, "application.applicationId");
+  if (application.applicationId !== expectedApplicationId) {
+    reject("APPLICATION_ID_PATH_MISMATCH", "The manifest application id must equal its submissions directory.");
+  }
+  expectInteger(application.applicationRevision, 1, 1_000_000, "application.applicationRevision");
+  if (!new Set(["proposal", "prototype"]).has(application.stage)) {
+    reject("APPLICATION_STAGE_INVALID", "An application stage must be proposal or prototype.");
+  }
+  expectText(application.title, 3, 120, "application.title");
+  expectText(application.summary, 20, 1_000, "application.summary");
+
+  expectClosedObject(application.builder, ["contact", "githubLogin", "githubUserId"], "application.builder");
+  expectPattern(application.builder.githubUserId, OPAQUE_ID_PATTERN, 64, "application.builder.githubUserId");
+  expectPattern(application.builder.githubLogin, GITHUB_LOGIN_PATTERN, 39, "application.builder.githubLogin");
+  if (application.builder.contact !== null) validatePublicHttpsUrl(application.builder.contact, "application.builder.contact");
+
+  expectClosedObject(application.declarations, [
+    "noApprovalClaim",
+    "noSecretsDeclared",
+    "noUniswapEndorsementClaim",
+    "publicInformationAcknowledged"
+  ], "application.declarations");
+  for (const value of Object.values(application.declarations)) {
+    if (value !== true) reject("APPLICATION_DECLARATION_REQUIRED", "Every Custom Launch application declaration must be explicitly true.");
+  }
+
+  validateApplicationSource(application.source);
+
+  if (!Array.isArray(application.reviewPackage) || application.reviewPackage.length !== REVIEW_FILES.length) {
+    reject("REVIEW_PACKAGE_INDEX_INVALID", "The manifest must index every review file exactly once.");
+  }
+  application.reviewPackage.forEach((record, index) => {
+    expectClosedObject(record, ["byteLength", "path", "sha256"], `reviewPackage[${index}]`);
+    if (record.path !== REVIEW_FILES[index]) reject("REVIEW_PACKAGE_ORDER_INVALID", "Review package records must use the canonical path order.");
+    expectPattern(record.sha256, SHA256_PATTERN, 71, "reviewPackage.sha256");
+    expectInteger(record.byteLength, 1, limits.maximumFileBytes[record.path], "reviewPackage.byteLength");
+  });
+}
+
+function autonomousPrimarySourceProjection(application, compatibility) {
+  const primary = application.githubSources.find((entry) => entry.sourceId === application.primarySourceId);
+  if (primary === undefined) reject("APPLICATION_PRIMARY_SOURCE_UNKNOWN", "application.json primarySourceId is unresolved.");
+  expectClosedObject(compatibility?.source, ["numericRepositoryId", "revisionObjectId", "treeObjectId"], "compatibility.source");
+  if (
+    compatibility.source.numericRepositoryId !== primary.repositoryIdHint
+    || compatibility.source.revisionObjectId !== primary.requestedRevisionHint
+    || !SHA1_PATTERN.test(compatibility.source.treeObjectId ?? "")
+  ) {
+    reject("REVIEW_SOURCE_BINDING_MISMATCH", "Compatibility evidence is not bound to the exact primary source hint.");
+  }
+  return {
+    repositoryUri: `https://github.com/${primary.ownerHint.toLowerCase()}/${primary.repositoryHint.toLowerCase()}`,
+    numericRepositoryId: primary.repositoryIdHint,
+    revisionObjectId: primary.requestedRevisionHint,
+    treeObjectId: compatibility.source.treeObjectId,
+    sourcePaths: [],
+    contractPaths: [],
+    githubActionsRunIds: []
+  };
+}
+
+function autonomousInternalApplicationProjection(application, primary) {
+  return {
+    ...application,
+    title: application.project.title,
+    summary: application.project.summary,
+    stage: "proposal",
+    source: { schemaVersion: "1.0.0", primary, companions: [] },
+    autonomousPrimaryHint: autonomousPrimarySourceHint(application)
+  };
+}
+
+function validateEvidenceIndex(index, application, limits) {
+  expectClosedObject(index, ["applicationId", "attestation", "evidence", "schemaVersion", "source"], "evidence-index.json");
+  expectInteger(index.schemaVersion, 1, 1, "evidenceIndex.schemaVersion");
+  if (index.applicationId !== application.applicationId) reject("EVIDENCE_APPLICATION_MISMATCH", "The evidence index is bound to another application id.");
+  if (index.attestation !== "builder-declared-untrusted") reject("EVIDENCE_ATTESTATION_INVALID", "Builder evidence must remain explicitly untrusted.");
+  validateSourceProjection(index.source, application.source.primary, "evidenceIndex.source");
+  if (!Array.isArray(index.evidence) || index.evidence.length < 1 || index.evidence.length > limits.maximumEvidence) {
+    reject("EVIDENCE_COUNT_INVALID", "The evidence index must contain at least one record and stay within the trusted record limit.");
+  }
+  const ids = new Set();
+  const urls = new Set();
+  const allowedKinds = new Set(["build", "unit", "fuzz", "invariant", "static-analysis", "fork", "ui", "manual-review", "other"]);
+  const allowedStatuses = new Set(["passed", "failed", "blocked", "not-run"]);
+  let previousId = null;
+  index.evidence.forEach((record, recordIndex) => {
+    expectClosedObject(record, ["id", "kind", "scope", "sha256", "status", "url"], `evidence[${recordIndex}]`);
+    expectPattern(record.id, EVIDENCE_ID_PATTERN, 80, "evidence.id");
+    if (ids.has(record.id)) reject("EVIDENCE_ID_DUPLICATE", "Evidence ids must be unique.");
+    if (urls.has(record.url)) reject("EVIDENCE_TARGET_DUPLICATE", "Each immutable evidence target may be declared only once.");
+    if (previousId !== null && compareUtf8(previousId, record.id) >= 0) reject("EVIDENCE_ORDER_INVALID", "Evidence records must be sorted by id.");
+    ids.add(record.id);
+    urls.add(record.url);
+    previousId = record.id;
+    if (!allowedKinds.has(record.kind)) reject("EVIDENCE_KIND_INVALID", "An evidence record has an unsupported kind.");
+    if (!allowedStatuses.has(record.status)) reject("EVIDENCE_STATUS_INVALID", "An evidence record has an unsupported status.");
+    expectText(record.scope, 12, 500, "evidence.scope");
+    const evidenceLocation = validateApplicationEvidenceUrl(record.url, application);
+    if (evidenceLocation === "blob" && record.sha256 === null) {
+      reject("EVIDENCE_BLOB_HASH_REQUIRED", "Evidence bound to a source blob must declare its SHA-256 digest.");
+    }
+    if (evidenceLocation === "actions" && record.sha256 !== null) {
+      reject("EVIDENCE_ACTION_HASH_INVALID", "A GitHub Actions run page is not immutable content and must use a null SHA-256 field.");
+    }
+    if (record.sha256 !== null) expectPattern(record.sha256, SHA256_PATTERN, 71, "evidence.sha256");
+  });
+  return ids;
+}
+
+function validateCompatibilityReport(report, application, evidenceIndex, evidenceIds, limits) {
+  expectClosedObject(report, ["applicationId", "disclaimer", "findings", "result", "schemaVersion", "source"], "compatibility-report.json");
+  expectInteger(report.schemaVersion, 1, 1, "compatibility.schemaVersion");
+  if (report.applicationId !== application.applicationId) reject("COMPATIBILITY_APPLICATION_MISMATCH", "The compatibility report is bound to another application id.");
+  validateSourceProjection(report.source, application.source.primary, "compatibility.source");
+  const allowedResults = new Set(["prototype-ready", "changes-required", "architecture-review-required", "tooling-blocked"]);
+  if (!allowedResults.has(report.result)) reject("COMPATIBILITY_RESULT_INVALID", "The compatibility report cannot claim approval, safety, or launch status.");
+  if (report.disclaimer !== PUBLIC_BETA_DISCLAIMER) reject("COMPATIBILITY_DISCLAIMER_INVALID", "The required autonomous-admission disclaimer is missing or changed.");
+  if (!Array.isArray(report.findings) || report.findings.length > limits.maximumFindings) {
+    reject("FINDING_COUNT_INVALID", "The compatibility report exceeds the trusted finding limit.");
+  }
+  const findingKeys = new Set();
+  let previousKey = null;
+  report.findings.forEach((finding, index) => {
+    expectClosedObject(finding, ["code", "evidenceIds", "path", "remediation", "severity", "summary"], `findings[${index}]`);
+    expectPattern(finding.code, FINDING_CODE_PATTERN, 80, "finding.code");
+    if (!new Set(["informational", "warning", "blocker", "hard"]).has(finding.severity)) {
+      reject("FINDING_SEVERITY_INVALID", "A finding has an unsupported severity.");
+    }
+    validateFindingPath(finding.path);
+    expectText(finding.summary, 12, 800, "finding.summary");
+    expectText(finding.remediation, 12, 800, "finding.remediation");
+    validateSortedUniqueStrings(finding.evidenceIds, 0, 32, "finding.evidenceIds", (value) => {
+      expectPattern(value, EVIDENCE_ID_PATTERN, 80, "finding.evidenceId");
+      if (!evidenceIds.has(value)) reject("FINDING_EVIDENCE_UNKNOWN", "A finding references an unknown evidence id.");
+    });
+    const key = `${finding.code}\u0000${finding.path}`;
+    if (findingKeys.has(key)) reject("FINDING_DUPLICATE", "Finding code and path pairs must be unique.");
+    if (previousKey !== null && compareUtf8(previousKey, key) >= 0) reject("FINDING_ORDER_INVALID", "Findings must be sorted by code and path.");
+    findingKeys.add(key);
+    previousKey = key;
+  });
+
+  if (application.stage === "proposal" && report.result === "prototype-ready") {
+    reject("COMPATIBILITY_STAGE_MISMATCH", "A proposal-stage application cannot claim prototype-ready compatibility.");
+  }
+  const evidenceStatuses = new Set(evidenceIndex.evidence.map((record) => record.status));
+  const findingSeverities = new Set(report.findings.map((finding) => finding.severity));
+  const hasActionableFinding = ["warning", "blocker", "hard"].some((severity) => findingSeverities.has(severity));
+  if (
+    report.result === "prototype-ready"
+    && (evidenceIndex.evidence.some((record) => record.status !== "passed") || hasActionableFinding)
+  ) {
+    reject(
+      "COMPATIBILITY_EVIDENCE_MISMATCH",
+      "Prototype-ready compatibility requires passed evidence and no warning, blocker, or hard finding."
+    );
+  }
+  if (
+    report.result === "prototype-ready"
+    && !evidenceIndex.evidence.some((record) =>
+      record.status === "passed"
+      && validateApplicationEvidenceUrl(record.url, application) === "actions"
+    )
+  ) {
+    reject(
+      "COMPATIBILITY_EVIDENCE_MISMATCH",
+      "Prototype-ready compatibility requires a declared successful GitHub Actions run for the exact source revision."
+    );
+  }
+  if (report.result === "changes-required" && !evidenceStatuses.has("failed") && !hasActionableFinding) {
+    reject(
+      "COMPATIBILITY_EVIDENCE_MISMATCH",
+      "Changes-required compatibility needs failed evidence or an actionable finding."
+    );
+  }
+  if (
+    report.result === "tooling-blocked"
+    && !evidenceStatuses.has("blocked")
+    && !evidenceStatuses.has("not-run")
+  ) {
+    reject(
+      "COMPATIBILITY_EVIDENCE_MISMATCH",
+      "Tooling-blocked compatibility needs blocked or not-run evidence."
+    );
+  }
+  // The inert seven-file record does not let this repository-local preflight
+  // reconstruct or authenticate the exact external review target.
+  // the exact review target and every bound source/evidence blob digest.
+  if (report.result === "prototype-ready") {
+    reject(
+      "PROTOTYPE_READY_REQUIRES_TRUSTED_REVIEW_TARGET",
+      "Public prototype-ready requires trusted-base reconstruction of the exact review target and source/evidence blob digests; submit this revision for architecture or changes review until that gate is available."
+    );
+  }
+}
+
+function validateSourceProjection(source, primary, label) {
+  expectClosedObject(source, ["numericRepositoryId", "revisionObjectId", "treeObjectId"], label);
+  if (
+    source.numericRepositoryId !== primary.numericRepositoryId
+    || source.revisionObjectId !== primary.revisionObjectId
+    || source.treeObjectId !== primary.treeObjectId
+  ) {
+    reject("REVIEW_SOURCE_BINDING_MISMATCH", "Review JSON is not bound to the exact primary source revision.");
+  }
+}
+
+function validateReviewPackageHashes(application, files) {
+  for (const record of application.reviewPackage) {
+    const bytes = files.get(record.path);
+    if (!bytes) systemBlocked("REVIEW_FILE_MISSING", "An indexed review file is unavailable to the trusted validator.");
+    const digest = `sha256:${crypto.createHash("sha256").update(bytes).digest("hex")}`;
+    if (record.byteLength !== bytes.length || record.sha256 !== digest) {
+      reject("REVIEW_FILE_BINDING_MISMATCH", "A review file does not match its manifest byte length and SHA-256 digest.");
+    }
+  }
+}
+
+function validateMarkdown(bytes, documentName, requiredHeading) {
+  let source;
+  try {
+    source = UTF8_DECODER.decode(bytes);
+  } catch {
+    reject("MARKDOWN_UTF8_INVALID", `${documentName} is not valid UTF-8.`);
+  }
+  if (!source.endsWith("\n") || source.includes("\r") || source.includes("\t") || CONTROL_OR_BIDI_PATTERN.test(source)) {
+    reject("MARKDOWN_TEXT_UNSAFE", `${documentName} must be LF-delimited UTF-8 without tabs, controls, or bidi overrides.`);
+  }
+  if (source.split("\n", 1)[0] !== requiredHeading) {
+    reject("MARKDOWN_HEADING_INVALID", `${documentName} is missing its exact first-level heading.`);
+  }
+  const body = source.slice(requiredHeading.length + 1).trim();
+  if (body.length < 40) {
+    reject("MARKDOWN_CONTENT_INCOMPLETE", `${documentName} must contain a substantive review body after its heading.`);
+  }
+  if (/<[!/?A-Za-z]/u.test(source) || /&(?:#x?[0-9A-Fa-f]+|[A-Za-z][A-Za-z0-9]+);/u.test(source)) {
+    reject("MARKDOWN_ACTIVE_CONTENT", `${documentName} contains raw markup, autolinks, or encoded active content.`);
+  }
+  if (
+    /!\[[^\]]*\]\s*(?:\([^)]*\)|\[[^\]]*\])/su.test(source)
+    || /(?:javascript|data|file|vbscript)\s*:/iu.test(source)
+  ) {
+    reject("MARKDOWN_EMBEDDED_CONTENT", `${documentName} contains an image or unsafe URI scheme.`);
+  }
+  return source;
+}
+
+function validatePublicClaims({ application, compatibility, evidenceIndex, markdownSources }) {
+  const documents = [
+    ["application.json", [application.title, application.summary]],
+    [
+      "compatibility-report.json",
+      compatibility.findings.flatMap((finding) => [finding.summary, finding.remediation])
+    ],
+    ["evidence-index.json", evidenceIndex.evidence.map((record) => record.scope)],
+    ...[...markdownSources].map(([documentName, source]) => [documentName, [source]])
+  ];
+  for (const [documentName, strings] of documents) {
+    for (const value of strings) {
+      if (findUnsupportedPublicClaims(value).length > 0) {
+        reject(
+          "UNSUPPORTED_PUBLIC_CLAIM",
+          `${documentName} contains an unsupported approval, audit, safety, deployment, launch, or availability claim.`
+        );
+      }
+    }
+  }
+}
+
+function validateRevisionChange({ application, applicationId, packagePrefix, classified, limits }) {
+  const manifestPath = `${packagePrefix}${APPLICATION_FILE}`;
+  const baseEntry = classified.base.entries.get(manifestPath);
+  if (!baseEntry) {
+    if (application.applicationRevision !== 1) {
+      reject("NEW_APPLICATION_REVISION_INVALID", "A new public application must begin at revision 1.");
+    }
+    return;
+  }
+  assertRegularBlob(baseEntry);
+  const prior = parseCanonicalJson(
+    readGitBlob(classified.base.root, baseEntry, limits.maximumFileBytes[APPLICATION_FILE]),
+    `base:${manifestPath}`,
+    limits,
+    { trailingNewline: false }
+  );
+  try {
+    validateAutonomousApplicationManifest(prior, { requireImmutableSourceHints: true });
+  } catch {
+    reject(
+      "PRIOR_APPLICATION_SCHEMA_UNSUPPORTED",
+      "An autonomous application update requires a canonical autonomous application.json on the trusted base."
+    );
+  }
+  if (prior.applicationId !== applicationId) {
+    reject("APPLICATION_ID_PATH_MISMATCH", "The trusted base application id must equal its submissions directory.");
+  }
+  if (application.applicationRevision !== prior.applicationRevision + 1) {
+    reject("APPLICATION_REVISION_NOT_INCREMENTED", "An updated application must increment its revision by exactly one.");
+  }
+  if (application.primarySourceId !== prior.primarySourceId) {
+    reject("PRIMARY_SOURCE_LINEAGE_CHANGED", "An application update cannot replace its primary source id.");
+  }
+  const priorSources = new Map(prior.githubSources.map((source) => [source.sourceId, source]));
+  const nextSources = new Map(application.githubSources.map((source) => [source.sourceId, source]));
+  if (!arraysEqual([...priorSources.keys()].sort(compareUtf8), [...nextSources.keys()].sort(compareUtf8))) {
+    reject("SOURCE_TOPOLOGY_CHANGED", "An application update cannot add, remove, or rename source lineages.");
+  }
+  let sourceRevisionChanged = false;
+  for (const [sourceId, priorSource] of priorSources) {
+    const nextSource = nextSources.get(sourceId);
+    if (
+      priorSource.repositoryIdHint !== nextSource.repositoryIdHint
+      || priorSource.ownerHint.toLowerCase() !== nextSource.ownerHint.toLowerCase()
+      || priorSource.repositoryHint.toLowerCase() !== nextSource.repositoryHint.toLowerCase()
+    ) {
+      reject("SOURCE_LINEAGE_CHANGED", "An application update cannot replace an immutable GitHub repository lineage.");
+    }
+    if (priorSource.requestedRevisionHint !== nextSource.requestedRevisionHint) sourceRevisionChanged = true;
+  }
+  const priorPrimary = autonomousPrimarySourceHint(prior);
+  const nextPrimary = autonomousPrimarySourceHint(application);
+  if (priorPrimary.repositoryIdHint !== nextPrimary.repositoryIdHint) {
+    reject("PRIMARY_SOURCE_LINEAGE_CHANGED", "An application update cannot replace its primary public repository lineage.");
+  }
+  if (!sourceRevisionChanged) {
+    reject("SOURCE_REVISION_UNCHANGED", "An application update must request at least one new full source commit.");
+  }
+  for (const requiredChangedFile of ["launch.json", "compatibility-report.json", "evidence-index.json"]) {
+    const changed = classified.changes.find((entry) => entry.path === `${packagePrefix}${requiredChangedFile}`);
+    if (!changed || changed.status !== "modified") {
+      reject("REVIEW_EVIDENCE_NOT_REGENERATED", "A source revision update must regenerate compatibility and evidence JSON.");
+    }
+  }
+}
+
+function autonomousPrimarySourceHint(application) {
+  const primary = application.githubSources.find(({ sourceId }) => sourceId === application.primarySourceId);
+  if (primary === undefined) reject("APPLICATION_PRIMARY_SOURCE_UNKNOWN", "application.json primarySourceId is unresolved.");
+  return primary;
+}
+
+function autonomousSourceHintProjection(application) {
+  return application.githubSources
+    .map((source) => ({
+      sourceId: source.sourceId,
+      role: source.sourceId === application.primarySourceId ? "primary" : "companion",
+      ownerHint: source.ownerHint,
+      repositoryHint: source.repositoryHint,
+      repositoryIdHint: source.repositoryIdHint,
+      requestedRevisionHint: source.requestedRevisionHint
+    }))
+    .sort((left, right) => compareUtf8(left.sourceId, right.sourceId));
+}
+
+function sameSourceAuthority(left, right) {
+  const leftProjection = sourceAuthorityProjection(left);
+  const rightProjection = sourceAuthorityProjection(right);
+  return JSON.stringify(leftProjection) === JSON.stringify(rightProjection);
+}
+
+/**
+ * One application-scoped resolver session shares the anonymous REST transport
+ * and retains only exact primary-source blobs that the evidence index already
+ * names. Source validation therefore pays for each REST control-plane object
+ * once, while evidence reuses the same inert Git bytes without another REST
+ * tree walk or another anonymous smart-Git fetch.
+ */
+export function createTrustedPublicApplicationResolutionSessionV1(
+  { primary, evidence },
+  {
+    exactObjectResolver = createAnonymousGitHubExactObjectResolverV1(),
+    transport = createTrustedGitHubActionsPublicTransportV1()
+  } = {}
+) {
+  if (!isPlainObject(primary) || !Array.isArray(evidence)) {
+    systemBlocked("EVIDENCE_RESOLUTION_INPUT_INVALID", "Trusted resolution session received malformed inputs.");
+  }
+  if (typeof exactObjectResolver !== "function" || typeof transport !== "function") {
+    systemBlocked("RESOLVER_UNAVAILABLE", "The trusted application resolution session is unavailable.");
+  }
+  const retainedPaths = new Set(evidence.map((record) => evidenceBlobPath(record.url, primary)));
+  const sharedExactObjectResolver = createRetainedExactObjectResolverV1(exactObjectResolver, {
+    repositoryUri: primary.repositoryUri,
+    revisionObjectId: primary.revisionObjectId,
+    treeObjectId: primary.treeObjectId,
+    retainedPaths
+  });
+  return Object.freeze({
+    resolveSource(request) {
+      return resolvePublicGitHubSource(request, { exactObjectResolver: sharedExactObjectResolver, transport });
+    },
+    resolveEvidence(request) {
+      return resolvePublicApplicationEvidence(request, { exactObjectResolver: sharedExactObjectResolver });
+    }
+  });
+}
+
+function createRetainedExactObjectResolverV1(delegate, authority) {
+  const retainedRecords = new Map();
+  return async (request) => {
+    if (sameExactObjectAuthority(request, authority)) {
+      const cached = new Map();
+      let cachedBytes = 0;
+      for (const filePath of request.paths) {
+        const record = retainedRecords.get(filePath);
+        if (record === undefined) break;
+        cachedBytes += record.bytes.length;
+        if (record.bytes.length > request.maximumFileBytes || cachedBytes > request.maximumTotalBytes) break;
+        cached.set(filePath, cloneExactObjectRecord(record));
+      }
+      if (cached.size === request.paths.length) return { records: cached };
+    }
+
+    const result = await delegate(request);
+    const records = result instanceof Map ? result : result?.records;
+    if (sameExactObjectAuthority(request, authority) && records instanceof Map) {
+      for (const filePath of authority.retainedPaths) {
+        const record = records.get(filePath);
+        if (isEvidenceExactObjectRecord(record)) {
+          retainedRecords.set(filePath, cloneExactObjectRecord(record));
+        }
+      }
+    }
+    return result;
+  };
+}
+
+function sameExactObjectAuthority(request, authority) {
+  return request?.repositoryUri === authority.repositoryUri
+    && request?.revisionObjectId === authority.revisionObjectId
+    && request?.treeObjectId === authority.treeObjectId;
+}
+
+function cloneExactObjectRecord(record) {
+  return {
+    bytes: Buffer.from(record.bytes),
+    mode: record.mode,
+    objectId: record.objectId
+  };
+}
+
+export async function resolvePublicGitHubSource(request, options = {}) {
+  const usesDefaultTrustedTransport = options.transport === undefined;
+  const resolverOptions = {
+    timeoutMs: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.maximumTimeoutMs,
+    ...options
+  };
+  if (resolverOptions.transport === undefined) {
+    resolverOptions.transport = createTrustedGitHubActionsPublicTransportV1();
+  }
+  if (resolverOptions.exactObjectResolver === undefined && usesDefaultTrustedTransport) {
+    resolverOptions.exactObjectResolver = createAnonymousGitHubExactObjectResolverV1();
+  }
+  return resolveGitHubPublicSourceV1(request, resolverOptions);
+}
+
+export async function resolvePublicApplicationEvidence({ primary, evidence, limits: limitOverrides = {} }, options = {}) {
+  if (!isPlainObject(primary) || !Array.isArray(evidence)) {
+    systemBlocked("EVIDENCE_RESOLUTION_INPUT_INVALID", "Trusted evidence resolution received malformed inputs.");
+  }
+  const limits = mergeLimits(limitOverrides);
+  const timeoutMs = options.timeoutMs ?? GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.maximumTimeoutMs;
+  if (
+    !Number.isSafeInteger(timeoutMs)
+    || timeoutMs < GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.minimumTimeoutMs
+    || timeoutMs > GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.maximumTimeoutMs
+  ) {
+    systemBlocked("EVIDENCE_RESOLUTION_OPTIONS_INVALID", "Trusted evidence resolution received an invalid timeout.");
+  }
+  const usesDefaultTransport = options.transport === undefined;
+  const exactObjectResolver = options.exactObjectResolver === undefined
+    ? (usesDefaultTransport ? createAnonymousGitHubExactObjectResolverV1() : null)
+    : options.exactObjectResolver;
+  if (exactObjectResolver !== null && typeof exactObjectResolver !== "function") {
+    systemBlocked("EVIDENCE_RESOLVER_UNAVAILABLE", "The trusted exact evidence resolver is unavailable.");
+  }
+  if (exactObjectResolver !== null) {
+    return resolveEvidenceWithExactObjectResolver({
+      primary,
+      evidence,
+      limits,
+      timeoutMs,
+      exactObjectResolver
+    });
+  }
+
+  const transport = options.transport ?? createTrustedGitHubActionsPublicTransportV1();
+  if (typeof transport !== "function") {
+    systemBlocked("EVIDENCE_RESOLVER_UNAVAILABLE", "The trusted public-evidence transport is unavailable.");
+  }
+  const repository = new URL(primary.repositoryUri);
+  const [owner, repositoryName] = repository.pathname.slice(1).split("/");
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(new Error("evidence resolution timed out")), timeoutMs);
+  const state = {
+    controller,
+    limits,
+    owner,
+    repositoryName,
+    requests: 0,
+    responseBytes: 0,
+    transport,
+    recursiveTree: null,
+    blobCache: new Map()
+  };
+  try {
+    const observations = [];
+    for (const record of evidence) {
+      const sourcePath = evidenceBlobPath(record.url, primary);
+      const resolved = await resolveEvidenceBlob(sourcePath, primary.treeObjectId, state);
+      observations.push({
+        id: record.id,
+        path: sourcePath,
+        blobObjectId: resolved.blobObjectId,
+        bytes: resolved.bytes
+      });
+    }
+    return observations;
+  } catch (error) {
+    if (controller.signal.aborted) {
+      systemBlocked("GITHUB_TIMEOUT", "Trusted evidence resolution exceeded its deadline.");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function resolveEvidenceWithExactObjectResolver({
+  primary,
+  evidence,
+  limits,
+  timeoutMs,
+  exactObjectResolver
+}) {
+  const paths = evidence.map((record) => evidenceBlobPath(record.url, primary));
+  let result;
+  try {
+    result = await exactObjectResolver(Object.freeze({
+      repositoryUri: primary.repositoryUri,
+      revisionObjectId: primary.revisionObjectId,
+      treeObjectId: primary.treeObjectId,
+      paths: Object.freeze([...paths].sort(compareUtf8)),
+      timeoutMs,
+      maximumFileBytes: Math.min(
+        limits.maximumEvidenceBlobBytes,
+        GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumFileBytes
+      ),
+      maximumTotalBytes: Math.min(
+        limits.maximumEvidenceResolutionBytes,
+        GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTotalBytes
+      )
+    }));
+  } catch (error) {
+    if (error instanceof GitHubPublicSourceError && error.code === "GITHUB_DECLARED_PATH_NOT_FOUND") {
+      reject("EVIDENCE_BLOB_UNAVAILABLE", "The declared evidence path is not a regular blob in the exact source tree.");
+    }
+    if (error instanceof GitHubPublicSourceError && error.code === "GITHUB_RESPONSE_TOO_LARGE") {
+      reject("EVIDENCE_RESPONSE_LIMIT", "Declared evidence exceeds the trusted inert-content limit.");
+    }
+    throw error;
+  }
+
+  const records = result instanceof Map ? result : result?.records;
+  if (!(records instanceof Map) || records.size !== paths.length) {
+    systemBlocked("EVIDENCE_OBSERVATION_INVALID", "The trusted exact evidence resolver returned an invalid path set.");
+  }
+  const expectedPaths = new Set(paths);
+  for (const filePath of records.keys()) {
+    if (!expectedPaths.has(filePath)) {
+      systemBlocked("EVIDENCE_OBSERVATION_INVALID", "The trusted exact evidence resolver returned an undeclared path.");
+    }
+  }
+
+  return evidence.map((record, index) => {
+    const filePath = paths[index];
+    const exactRecord = records.get(filePath);
+    if (!isEvidenceExactObjectRecord(exactRecord)) {
+      reject("EVIDENCE_BLOB_UNAVAILABLE", "The declared evidence path is not a regular blob in the exact source tree.");
+    }
+    const bytes = Buffer.from(exactRecord.bytes);
+    if (bytes.length > limits.maximumEvidenceBlobBytes) {
+      reject("EVIDENCE_BLOB_UNAVAILABLE", "The declared evidence blob exceeds the trusted byte limit.");
+    }
+    const observedObjectId = crypto.createHash("sha1")
+      .update(Buffer.from(`blob ${bytes.length}\0`, "utf8"))
+      .update(bytes)
+      .digest("hex");
+    if (observedObjectId !== exactRecord.objectId) {
+      systemBlocked("EVIDENCE_BLOB_INVALID", "Exact evidence bytes did not match their Git blob object id.");
+    }
+    return {
+      id: record.id,
+      path: filePath,
+      blobObjectId: exactRecord.objectId,
+      bytes
+    };
+  });
+}
+
+function isEvidenceExactObjectRecord(value) {
+  if (!isPlainObject(value)) return false;
+  const keys = Object.keys(value).sort(compareUtf8);
+  return arraysEqual(keys, ["bytes", "mode", "objectId"])
+    && (value.mode === "100644" || value.mode === "100755")
+    && SHA1_PATTERN.test(value.objectId ?? "")
+    && value.bytes instanceof Uint8Array;
+}
+
+async function resolveEvidenceBlob(sourcePath, rootTreeObjectId, state) {
+  const entries = await loadEvidenceRecursiveTree(rootTreeObjectId, state);
+  const entry = entries.get(sourcePath);
+  if (entry?.type !== "blob") {
+    reject("EVIDENCE_BLOB_UNAVAILABLE", "The declared evidence path is not a blob in the exact source tree.");
+  }
+  const blobObjectId = entry.sha;
+  const bytes = await loadEvidenceBlob(blobObjectId, state);
+  return { blobObjectId, bytes };
+}
+
+async function loadEvidenceRecursiveTree(treeObjectId, state) {
+  if (state.recursiveTree !== null) return state.recursiveTree;
+  const tree = await requestEvidenceGitHubJson(
+    `/repos/${state.owner}/${state.repositoryName}/git/trees/${treeObjectId}?recursive=1`,
+    8 * 1024 * 1024,
+    state
+  );
+  if (tree.sha !== treeObjectId || tree.truncated !== false || !Array.isArray(tree.tree)) {
+    systemBlocked("EVIDENCE_TREE_INVALID", "GitHub could not provide a complete exact tree for REST evidence fallback.");
+  }
+  if (tree.tree.length > state.limits.maximumEvidenceTreeEntries) {
+    reject("EVIDENCE_TREE_TOO_LARGE", "An evidence tree exceeds the trusted entry limit.");
+  }
+  const entries = new Map();
+  for (const entry of tree.tree) {
+    if (
+      !isPlainObject(entry)
+      || typeof entry.path !== "string"
+      || entry.path.length === 0
+      || !isCanonicalGitHubRepositoryPathV1(entry.path)
+      || !new Set(["blob", "tree", "commit"]).has(entry.type)
+      || !SHA1_PATTERN.test(entry.sha ?? "")
+    ) {
+      systemBlocked("EVIDENCE_TREE_INVALID", "GitHub returned a malformed direct tree entry.");
+    }
+    if (entries.has(entry.path)) {
+      systemBlocked("EVIDENCE_TREE_INVALID", "GitHub returned duplicate direct tree entries.");
+    }
+    entries.set(entry.path, { type: entry.type, sha: entry.sha });
+  }
+  state.recursiveTree = entries;
+  return entries;
+}
+
+async function loadEvidenceBlob(blobObjectId, state) {
+  if (state.blobCache.has(blobObjectId)) return state.blobCache.get(blobObjectId);
+  const blob = await requestEvidenceGitHubJson(
+    `/repos/${state.owner}/${state.repositoryName}/git/blobs/${blobObjectId}`,
+    Math.min(state.limits.maximumEvidenceResolutionBytes, 12 * 1024 * 1024),
+    state
+  );
+  if (
+    blob.sha !== blobObjectId
+    || blob.encoding !== "base64"
+    || typeof blob.content !== "string"
+    || !Number.isSafeInteger(blob.size)
+    || blob.size < 0
+    || blob.size > state.limits.maximumEvidenceBlobBytes
+  ) {
+    reject("EVIDENCE_BLOB_UNAVAILABLE", "GitHub did not return a bounded base64 blob for the declared evidence path.");
+  }
+  const encoded = blob.content.replace(/\n/gu, "");
+  if (
+    /[^A-Za-z0-9+/=\n]/u.test(blob.content)
+    || encoded.length % 4 !== 0
+    || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(encoded)
+  ) {
+    systemBlocked("EVIDENCE_BLOB_INVALID", "GitHub returned malformed base64 evidence content.");
+  }
+  const bytes = Buffer.from(encoded, "base64");
+  if (bytes.length !== blob.size || bytes.toString("base64") !== encoded) {
+    systemBlocked("EVIDENCE_BLOB_INVALID", "GitHub evidence bytes did not match their declared base64 size.");
+  }
+  const gitObjectId = crypto.createHash("sha1")
+    .update(Buffer.from(`blob ${bytes.length}\0`, "utf8"))
+    .update(bytes)
+    .digest("hex");
+  if (gitObjectId !== blobObjectId) {
+    systemBlocked("EVIDENCE_BLOB_INVALID", "GitHub evidence bytes did not match their exact Git blob object id.");
+  }
+  state.blobCache.set(blobObjectId, bytes);
+  return bytes;
+}
+
+async function requestEvidenceGitHubJson(apiPath, maximumResponseBytes, state) {
+  state.requests += 1;
+  if (state.requests > state.limits.maximumEvidenceRequests) {
+    systemBlocked(
+      "EVIDENCE_REQUEST_LIMIT",
+      "The bounded REST evidence fallback exhausted its tooling request budget."
+    );
+  }
+  const url = `https://api.github.com${apiPath}`;
+  let response;
+  try {
+    response = await state.transport({
+      url,
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": GITHUB_PUBLIC_SOURCE_CONTRACT_V1.userAgent,
+        "X-GitHub-Api-Version": GITHUB_PUBLIC_SOURCE_CONTRACT_V1.githubApiVersion
+      },
+      redirect: "error",
+      signal: state.controller.signal,
+      maxResponseBytes: maximumResponseBytes
+    });
+  } catch (error) {
+    if (error instanceof GitHubPublicSourceError || error instanceof PublicIntakeError) throw error;
+    systemBlocked("GITHUB_NETWORK_ERROR", "GitHub evidence resolution failed at the transport boundary.");
+  }
+  if (!isPlainObject(response) || response.redirected === true || response.responseUrl !== url) {
+    systemBlocked("GITHUB_PROTOCOL_ERROR", "GitHub evidence resolution received an invalid or redirected response.");
+  }
+  if (response.status !== 200) {
+    if (response.status === 404 || response.status === 422) {
+      reject("EVIDENCE_BLOB_UNAVAILABLE", "The declared evidence blob is unavailable from the exact source tree.");
+    }
+    if (response.status === 403 || response.status === 429) {
+      systemBlocked("GITHUB_RATE_LIMITED", "GitHub rate-limited trusted evidence resolution.");
+    }
+    if (Number.isInteger(response.status) && response.status >= 500) {
+      systemBlocked("GITHUB_UNAVAILABLE", "GitHub was unavailable during trusted evidence resolution.");
+    }
+    systemBlocked("GITHUB_UPSTREAM_REJECTED", "GitHub rejected trusted evidence resolution.");
+  }
+  let bytes;
+  if (typeof response.body === "string") bytes = Buffer.from(response.body, "utf8");
+  else if (response.body instanceof Uint8Array) bytes = Buffer.from(response.body);
+  else if (response.body instanceof ArrayBuffer) bytes = Buffer.from(response.body);
+  else systemBlocked("GITHUB_PROTOCOL_ERROR", "GitHub evidence response bytes were malformed.");
+  if (bytes.length > maximumResponseBytes) {
+    systemBlocked("GITHUB_RESPONSE_TOO_LARGE", "A GitHub evidence response exceeded its trusted byte limit.");
+  }
+  state.responseBytes += bytes.length;
+  if (state.responseBytes > state.limits.maximumEvidenceResolutionBytes) {
+    reject("EVIDENCE_RESPONSE_LIMIT", "Evidence resolution exceeded the trusted aggregate response limit.");
+  }
+  let source;
+  try {
+    source = UTF8_DECODER.decode(bytes);
+  } catch {
+    systemBlocked("GITHUB_PROTOCOL_ERROR", "GitHub evidence JSON was not valid UTF-8.");
+  }
+  let value;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    systemBlocked("GITHUB_PROTOCOL_ERROR", "GitHub evidence response was not valid JSON.");
+  }
+  if (!isPlainObject(value)) {
+    systemBlocked("GITHUB_PROTOCOL_ERROR", "GitHub evidence response was not a JSON object.");
+  }
+  return value;
+}
+
+/**
+ * Anonymous, bounded transport for the trusted pull_request_target validator.
+ *
+ * GitHub documents GITHUB_TOKEN as an installation token whose authority is
+ * limited to the workflow repository. It therefore is not a reliable
+ * credential for arbitrary external public builder repositories and must not
+ * be added here. The underlying public transport pins api.github.com, GET,
+ * redirect rejection, fixed public headers, abort signals, and response byte
+ * limits. This wrapper only adds serial pacing and one tightly bounded retry.
+ */
+export function createTrustedGitHubActionsPublicTransportV1({
+  fetchImplementation = globalThis.fetch,
+  maximumRetryBodyBytes = GITHUB_PUBLIC_TRANSPORT_DEFAULTS.maximumRetryBodyBytes,
+  maximumRetryDelayMs = GITHUB_PUBLIC_TRANSPORT_DEFAULTS.maximumRetryDelayMs,
+  minimumIntervalMs = GITHUB_PUBLIC_TRANSPORT_DEFAULTS.minimumIntervalMs,
+  now = () => Date.now(),
+  sleep = abortableDelay,
+  transientRetryDelayMs = GITHUB_PUBLIC_TRANSPORT_DEFAULTS.transientRetryDelayMs
+} = {}) {
+  for (const [label, value, maximum] of [
+    ["maximumRetryBodyBytes", maximumRetryBodyBytes, 64 * 1024],
+    ["maximumRetryDelayMs", maximumRetryDelayMs, 5_000],
+    ["minimumIntervalMs", minimumIntervalMs, 1_000],
+    ["transientRetryDelayMs", transientRetryDelayMs, 5_000]
+  ]) {
+    if (!Number.isSafeInteger(value) || value < 0 || value > maximum) {
+      throw new GitHubPublicSourceError("INVALID_OPTIONS", `${label} is outside the trusted transport bounds`);
+    }
+  }
+  if (typeof now !== "function" || typeof sleep !== "function") {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "trusted transport clocks must be functions");
+  }
+  const maximumConfiguredDelayMs =
+    ((GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumProviderRequests - 1) * minimumIntervalMs)
+    + (GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumTransportRetries * maximumRetryDelayMs);
+  if (maximumConfiguredDelayMs >= GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.timeoutMs) {
+    throw new GitHubPublicSourceError(
+      "INVALID_OPTIONS",
+      "trusted transport pacing and retry delays do not fit the resolver deadline"
+    );
+  }
+
+  const publicTransport = createGitHubPublicFetchTransportV1(fetchImplementation);
+  let earliestNextRequestMs = 0;
+  let physicalRequestsRemaining = GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumProviderRequests;
+  let retriesRemaining = GITHUB_ANONYMOUS_RESOLUTION_BUDGET_V1.maximumTransportRetries;
+  let schedulingTail = Promise.resolve();
+
+  return async function trustedGitHubActionsPublicTransport(request) {
+    let response = await performPublicRequest(request);
+    const retryDelayMs = selectTrustedRetryDelay(response, {
+      maximumRetryBodyBytes,
+      maximumRetryDelayMs,
+      transientRetryDelayMs
+    });
+    if (retryDelayMs === null || retriesRemaining <= 0) return response;
+
+    retriesRemaining -= 1;
+    await sleep(retryDelayMs, request.signal);
+    response = await performPublicRequest(request);
+    return response;
+  };
+
+  async function performPublicRequest(request) {
+    let releaseSlot;
+    const predecessor = schedulingTail;
+    schedulingTail = new Promise((resolve) => { releaseSlot = resolve; });
+    await predecessor;
+    let responsePromise;
+    try {
+      if (request?.signal?.aborted) throw request.signal.reason ?? new Error("request aborted");
+      const currentMs = now();
+      const waitMs = Math.max(0, earliestNextRequestMs - currentMs);
+      if (waitMs > 0) await sleep(waitMs, request?.signal);
+      earliestNextRequestMs = Math.max(currentMs + waitMs, now()) + minimumIntervalMs;
+      if (physicalRequestsRemaining <= 0) {
+        throw new GitHubPublicSourceError(
+          "GITHUB_RATE_LIMITED",
+          "The trusted anonymous GitHub REST request budget was exhausted",
+          { retryable: true }
+        );
+      }
+      physicalRequestsRemaining -= 1;
+      // Invoke fetch while this start slot is still held; release immediately
+      // afterwards so response bodies may be in flight concurrently.
+      responsePromise = publicTransport(request);
+    } finally {
+      releaseSlot();
+    }
+    return responsePromise;
+  }
+}
+
+function selectTrustedRetryDelay(response, {
+  maximumRetryBodyBytes,
+  maximumRetryDelayMs,
+  transientRetryDelayMs
+}) {
+  const bodyBytes = responseBodyByteLength(response?.body);
+  if (bodyBytes === null || bodyBytes > maximumRetryBodyBytes) return null;
+
+  if (new Set([502, 503, 504]).has(response.status)) {
+    return transientRetryDelayMs <= maximumRetryDelayMs ? transientRetryDelayMs : null;
+  }
+  if (response.status !== 403 && response.status !== 429) return null;
+
+  const remaining = transportHeader(response.headers, "x-ratelimit-remaining");
+  if (remaining === "0") return null;
+  const retryAfter = transportHeader(response.headers, "retry-after");
+  if (typeof retryAfter !== "string" || !/^(?:0|[1-9][0-9]{0,2})$/u.test(retryAfter)) return null;
+  const retryDelayMs = Number(retryAfter) * 1_000;
+  return retryDelayMs <= maximumRetryDelayMs ? retryDelayMs : null;
+}
+
+function responseBodyByteLength(body) {
+  if (typeof body === "string") return Buffer.byteLength(body, "utf8");
+  if (body instanceof Uint8Array) return body.byteLength;
+  if (body instanceof ArrayBuffer) return body.byteLength;
+  return null;
+}
+
+function transportHeader(headers, name) {
+  if (headers === null || headers === undefined) return null;
+  if (typeof headers.get === "function") return headers.get(name);
+  if (!isPlainObject(headers)) return null;
+  const match = Object.entries(headers).find(([key]) => key.toLowerCase() === name);
+  return match?.[1] ?? null;
+}
+
+function abortableDelay(milliseconds, signal) {
+  if (signal?.aborted) return Promise.reject(signal.reason ?? new Error("request aborted"));
+  return new Promise((resolve, rejectDelay) => {
+    const timeout = setTimeout(finish, milliseconds);
+    signal?.addEventListener("abort", abort, { once: true });
+    function finish() {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }
+    function abort() {
+      clearTimeout(timeout);
+      rejectDelay(signal.reason ?? new Error("request aborted"));
+    }
+  });
+}
+
+function validateApplicationSource(source) {
+  let normalized;
+  try {
+    normalized = validateGitHubPublicSourceRequestV1(source);
+  } catch (error) {
+    if (error instanceof GitHubPublicSourceError) {
+      reject("SOURCE_CONTRACT_INVALID", "application.source does not satisfy GitHubPublicSourceContractV1.");
+    }
+    throw error;
+  }
+
+  const requestedRepositories = [source.primary, ...source.companions];
+  const normalizedRepositories = [normalized.primary, ...normalized.companions];
+  for (let index = 0; index < requestedRepositories.length; index += 1) {
+    const requested = requestedRepositories[index];
+    const canonical = normalizedRepositories[index];
+    if (
+      requested.numericRepositoryId !== canonical.numericRepositoryId
+      || requested.repositoryUri !== canonical.repositoryUri
+      || !arraysEqual(requested.sourcePaths ?? [], canonical.sourcePaths)
+      || !arraysEqual(requested.contractPaths ?? [], canonical.contractPaths)
+      || !arraysEqual(requested.githubActionsRunIds ?? [], canonical.githubActionsRunIds)
+    ) {
+      reject("SOURCE_CONTRACT_ORDER_INVALID", "application.source arrays and companions must use the contract's unsigned UTF-8 order.");
+    }
+  }
+}
+
+function translateSourceResolutionError(error) {
+  if (error instanceof PublicIntakeError) throw error;
+  if (!(error instanceof GitHubPublicSourceError)) {
+    systemBlocked("SOURCE_RESOLUTION_FAILED", "The trusted GitHubPublicSourceContractV1 resolver failed unexpectedly.");
+  }
+  if (
+    error.code === "GITHUB_UPSTREAM_REJECTED"
+    && error.message.startsWith("Exact Git object tooling is unavailable:")
+  ) {
+    systemBlocked("TOOLING_BLOCKED", "The trusted runner cannot safely resolve exact public Git objects.");
+  }
+  const candidateCodes = new Set([
+    "GITHUB_ACTIONS_RUN_MISMATCH",
+    "GITHUB_ACTIONS_RUN_NOT_REACHABLE",
+    "GITHUB_ACTIONS_WORKFLOW_NOT_IN_TREE",
+    "GITHUB_COMMIT_MISMATCH",
+    "GITHUB_COMMIT_NOT_REACHABLE",
+    "GITHUB_DECLARED_PATH_NOT_FOUND",
+    "GITHUB_PUBLIC_REPOSITORY_UNAVAILABLE",
+    "GITHUB_REDIRECT_REJECTED",
+    "GITHUB_REPOSITORY_ID_MISMATCH",
+    "GITHUB_REPOSITORY_LOCATOR_MISMATCH",
+    "GITHUB_TREE_MISMATCH",
+    "GITHUB_TREE_NOT_REACHABLE",
+    "INVALID_REQUEST"
+  ]);
+  if (candidateCodes.has(error.code)) {
+    reject(error.code, "The declared public GitHub source did not resolve to its exact frozen authority.");
+  }
+  systemBlocked(error.code, "The trusted GitHubPublicSourceContractV1 resolver could not complete.");
+}
+
+function translateEvidenceResolutionError(error) {
+  if (error instanceof PublicIntakeError) throw error;
+  if (error instanceof GitHubPublicSourceError) translateSourceResolutionError(error);
+  systemBlocked("EVIDENCE_RESOLUTION_FAILED", "The trusted public-evidence resolver failed unexpectedly.");
+}
+
+function validateSourceObservation(request, observation) {
+  if (
+    !isPlainObject(observation)
+    || observation.schemaVersion !== GITHUB_PUBLIC_SOURCE_CONTRACT_V1.schemaVersion
+    || observation.kind !== GITHUB_PUBLIC_SOURCE_CONTRACT_V1.kind
+    || observation.canonicalProviderOrigin !== GITHUB_PUBLIC_SOURCE_CONTRACT_V1.canonicalProviderOrigin
+    || observation.githubApiVersion !== GITHUB_PUBLIC_SOURCE_CONTRACT_V1.githubApiVersion
+    || !Array.isArray(observation.companions)
+  ) {
+    systemBlocked("SOURCE_OBSERVATION_INVALID", "The trusted resolver returned an invalid GitHubPublicSourceContractV1 observation.");
+  }
+  const expected = [request.primary, ...request.companions];
+  const observed = [observation.primary, ...observation.companions];
+  if (expected.length !== observed.length) {
+    systemBlocked("SOURCE_OBSERVATION_INVALID", "The trusted resolver returned the wrong number of source observations.");
+  }
+  expected.forEach((binding, index) => validateRepositoryObservation(binding, observed[index], index === 0 ? "primary" : "companion"));
+}
+
+function validateRepositoryObservation(binding, observation, expectedRole) {
+  if (!isPlainObject(observation) || !isPlainObject(observation.authority) || !isPlainObject(observation.display)) {
+    systemBlocked("SOURCE_OBSERVATION_INVALID", "The trusted resolver returned a malformed repository observation.");
+  }
+  if (observation.role !== expectedRole) systemBlocked("SOURCE_OBSERVATION_INVALID", "The trusted resolver returned an invalid repository role.");
+  if (observation.visibility !== "public") reject("GITHUB_PUBLIC_REPOSITORY_UNAVAILABLE", "Every Custom Launch source repository in the public intake path must resolve as public.");
+  if (observation.display.repositoryUri !== binding.repositoryUri) reject("GITHUB_REPOSITORY_LOCATOR_MISMATCH", "GitHub resolved a different canonical repository URI.");
+  if (observation.authority.numericRepositoryId !== binding.numericRepositoryId) reject("GITHUB_REPOSITORY_ID_MISMATCH", "GitHub resolved a different numeric repository id.");
+  if (observation.authority.revisionObjectId !== binding.revisionObjectId) reject("GITHUB_COMMIT_MISMATCH", "GitHub did not resolve the declared source revision.");
+  if (observation.authority.treeObjectId !== binding.treeObjectId) reject("GITHUB_TREE_MISMATCH", "GitHub resolved a different root tree for the declared revision.");
+  if (
+    !arraysEqual(observation.sourcePaths ?? [], binding.sourcePaths ?? [])
+    || !arraysEqual(observation.contractPaths ?? [], binding.contractPaths ?? [])
+    || !Array.isArray(observation.githubActionsEvidence)
+    || observation.githubActionsEvidence.length !== (binding.githubActionsRunIds ?? []).length
+  ) {
+    systemBlocked("SOURCE_OBSERVATION_INVALID", "The trusted resolver returned incomplete path or Actions observations.");
+  }
+  observation.githubActionsEvidence.forEach((entry, index) => {
+    validateActionsObservation(entry, binding, binding.githubActionsRunIds[index]);
+  });
+}
+
+function validateActionsObservation(observation, binding, expectedRunId) {
+  if (
+    !isPlainObject(observation)
+    || !OPAQUE_ID_PATTERN.test(observation.runId ?? "")
+    || !OPAQUE_ID_PATTERN.test(observation.runAttempt ?? "")
+    || !OPAQUE_ID_PATTERN.test(observation.workflowId ?? "")
+    || typeof observation.workflowPath !== "string"
+    || !SAFE_CODE_PATTERN.test(observation.event ?? "")
+    || !SAFE_CODE_PATTERN.test(observation.status ?? "")
+    || (observation.conclusion !== null && !SAFE_CODE_PATTERN.test(observation.conclusion ?? ""))
+  ) {
+    systemBlocked("SOURCE_OBSERVATION_INVALID", "The trusted resolver returned a malformed GitHub Actions observation.");
+  }
+  try {
+    validateSourcePath(observation.workflowPath);
+  } catch (error) {
+    if (error instanceof PublicIntakeError) {
+      systemBlocked("SOURCE_OBSERVATION_INVALID", "The trusted resolver returned an unsafe GitHub Actions workflow path.");
+    }
+    throw error;
+  }
+  if (
+    !observation.workflowPath.startsWith(".github/workflows/")
+    || !/\.ya?ml$/u.test(observation.workflowPath)
+  ) {
+    systemBlocked("SOURCE_OBSERVATION_INVALID", "The trusted resolver returned an invalid GitHub Actions workflow path.");
+  }
+  const expectedUrl = `${binding.repositoryUri}/actions/runs/${expectedRunId}`;
+  if (
+    observation.runId !== expectedRunId
+    || observation.headRevision !== binding.revisionObjectId
+    || observation.headTree !== binding.treeObjectId
+    || observation.htmlUrl !== expectedUrl
+  ) {
+    reject("GITHUB_ACTIONS_RUN_MISMATCH", "GitHub Actions evidence did not match its exact run, attempt, commit, tree, or repository.");
+  }
+}
+
+function validateEvidenceObservations({
+  application,
+  compatibility,
+  evidenceIndex,
+  sourceObservation,
+  blobObservations
+}) {
+  if (!Array.isArray(blobObservations)) {
+    systemBlocked("EVIDENCE_OBSERVATION_INVALID", "The trusted evidence resolver returned a malformed observation list.");
+  }
+  const primary = application.source.primary;
+  const expectedBlobs = evidenceIndex.evidence.filter((record) =>
+    validateGitHubEvidenceUrl(record.url, "evidence.url", primary) === "blob"
+  );
+  if (blobObservations.length !== expectedBlobs.length) {
+    systemBlocked("EVIDENCE_OBSERVATION_INVALID", "The trusted evidence resolver returned the wrong number of blob observations.");
+  }
+  const blobBindings = new Map();
+  expectedBlobs.forEach((record, index) => {
+    const observation = blobObservations[index];
+    const expectedPath = evidenceBlobPath(record.url, primary);
+    if (
+      !isPlainObject(observation)
+      || observation.id !== record.id
+      || observation.path !== expectedPath
+      || !SHA1_PATTERN.test(observation.blobObjectId ?? "")
+      || !Buffer.isBuffer(observation.bytes)
+    ) {
+      systemBlocked("EVIDENCE_OBSERVATION_INVALID", "The trusted evidence resolver returned a malformed blob observation.");
+    }
+    const gitObjectId = crypto.createHash("sha1")
+      .update(Buffer.from(`blob ${observation.bytes.length}\0`, "utf8"))
+      .update(observation.bytes)
+      .digest("hex");
+    if (gitObjectId !== observation.blobObjectId) {
+      systemBlocked("EVIDENCE_OBSERVATION_INVALID", "Resolved evidence bytes do not match their immutable Git blob object id.");
+    }
+    const digest = `sha256:${crypto.createHash("sha256").update(observation.bytes).digest("hex")}`;
+    if (digest !== record.sha256) {
+      reject("EVIDENCE_BLOB_DIGEST_MISMATCH", "Resolved GitHub evidence bytes do not match the declared SHA-256 digest.");
+    }
+    blobBindings.set(record.id, {
+      id: record.id,
+      kind: record.kind,
+      declaredStatus: record.status,
+      statusAuthority: "builder-declared-untrusted",
+      identityAuthority: "github-observed",
+      location: "blob",
+      path: expectedPath,
+      blobObjectId: observation.blobObjectId,
+      sha256: digest
+    });
+  });
+
+  const actionObservations = new Map(
+    sourceObservation.primary.githubActionsEvidence.map((observation) => [observation.runId, observation])
+  );
+  const actionBindings = new Map();
+  for (const record of evidenceIndex.evidence) {
+    if (validateGitHubEvidenceUrl(record.url, "evidence.url", primary) !== "actions") continue;
+    const runId = record.url.slice(record.url.lastIndexOf("/") + 1);
+    const observation = actionObservations.get(runId);
+    if (!observation) {
+      systemBlocked("EVIDENCE_OBSERVATION_INVALID", "The trusted source resolver omitted a declared GitHub Actions run.");
+    }
+    validateActionEvidenceStatus(record.status, observation.status, observation.conclusion);
+    actionBindings.set(record.id, {
+      id: record.id,
+      kind: record.kind,
+      declaredStatus: record.status,
+      statusAuthority: "github-observed",
+      identityAuthority: "github-observed",
+      location: "github-actions",
+      runId: observation.runId,
+      runAttempt: observation.runAttempt,
+      workflowId: observation.workflowId,
+      workflowPath: observation.workflowPath,
+      headRevision: observation.headRevision,
+      headTree: observation.headTree,
+      event: observation.event,
+      status: observation.status,
+      conclusion: observation.conclusion,
+      htmlUrl: observation.htmlUrl
+    });
+  }
+  if (compatibility.result === "prototype-ready" && actionBindings.size === 0) {
+    reject(
+      "COMPATIBILITY_EVIDENCE_MISMATCH",
+      "Prototype-ready compatibility requires an exact successful GitHub Actions observation."
+    );
+  }
+  return evidenceIndex.evidence.map((record) => blobBindings.get(record.id) ?? actionBindings.get(record.id));
+}
+
+function validateActionEvidenceStatus(declaredStatus, status, conclusion) {
+  const nonCompletedStatuses = new Set(["queued", "in_progress", "pending", "requested", "waiting"]);
+  const failedConclusions = new Set(["failure", "startup_failure", "timed_out"]);
+  const blockedConclusions = new Set(["action_required", "cancelled", "stale"]);
+  let matches = false;
+  if (declaredStatus === "passed") matches = status === "completed" && conclusion === "success";
+  else if (declaredStatus === "failed") matches = status === "completed" && failedConclusions.has(conclusion);
+  else if (declaredStatus === "blocked") {
+    matches = (nonCompletedStatuses.has(status) && conclusion === null)
+      || (status === "completed" && blockedConclusions.has(conclusion));
+  } else if (declaredStatus === "not-run") {
+    matches = status === "completed" && conclusion === "skipped";
+  }
+  if (!matches) {
+    reject(
+      "EVIDENCE_ACTION_STATUS_MISMATCH",
+      "A builder-declared GitHub Actions evidence status does not match the exact run attempt outcome."
+    );
+  }
+}
+
+function sourceAuthorityProjection(source) {
+  const project = (repository) => ({
+    repositoryUri: repository.repositoryUri,
+    numericRepositoryId: repository.numericRepositoryId,
+    revisionObjectId: repository.revisionObjectId,
+    treeObjectId: repository.treeObjectId
+  });
+  return {
+    schemaVersion: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.schemaVersion,
+    primary: project(source.primary),
+    companions: source.companions.map(project)
+  };
+}
+
+function validateSourcePath(value) {
+  if (!isCanonicalGitHubRepositoryPathV1(value)) {
+    reject("SOURCE_PATH_INVALID", "A declared source path is outside the safe canonical path subset.");
+  }
+}
+
+function validateFindingPath(value) {
+  if (value === "$" || (typeof value === "string" && value.startsWith("$.") && value.length <= 240 && !CONTROL_OR_BIDI_PATTERN.test(value))) return;
+  if (typeof value === "string") {
+    try {
+      validateSourcePath(value);
+      return;
+    } catch (error) {
+      if (!(error instanceof PublicIntakeError)) throw error;
+    }
+  }
+  reject("FINDING_PATH_INVALID", "A finding path is neither a canonical JSON path nor a safe source path.");
+}
+
+function validateSortedUniqueStrings(value, minimum, maximum, label, validateEntry) {
+  if (!Array.isArray(value) || value.length < minimum || value.length > maximum) {
+    reject("ARRAY_LENGTH_INVALID", `${label} has an invalid item count.`);
+  }
+  let previous = null;
+  for (const entry of value) {
+    validateEntry(entry);
+    if (previous !== null && compareUtf8(previous, entry) >= 0) reject("ARRAY_ORDER_INVALID", `${label} must be sorted and unique.`);
+    previous = entry;
+  }
+}
+
+function expectClosedObject(value, expectedKeys, label) {
+  if (!isPlainObject(value)) reject("OBJECT_REQUIRED", `${label} must be an object.`);
+  const observed = Object.keys(value).sort(compareUtf8);
+  const expected = [...expectedKeys].sort(compareUtf8);
+  if (!arraysEqual(observed, expected)) reject("OBJECT_NOT_CLOSED", `${label} has missing or unsupported properties.`);
+}
+
+function expectInteger(value, minimum, maximum, label) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) reject("INTEGER_INVALID", `${label} is outside its integer bounds.`);
+}
+
+function expectPattern(value, pattern, maximumLength, label) {
+  if (typeof value !== "string" || value.length > maximumLength || !pattern.test(value)) reject("STRING_PATTERN_INVALID", `${label} has an invalid canonical format.`);
+}
+
+function expectText(value, minimumLength, maximumLength, label) {
+  if (
+    typeof value !== "string"
+    || value.length < minimumLength
+    || value.length > maximumLength
+    || value.trim() !== value
+    || CONTROL_OR_BIDI_PATTERN.test(value)
+  ) {
+    reject("TEXT_INVALID", `${label} is empty, oversized, padded, or contains unsafe characters.`);
+  }
+}
+
+function validatePublicHttpsUrl(value, label) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    reject("URL_INVALID", `${label} is not a valid public HTTPS URL.`);
+  }
+  if (value.length > 500 || parsed.protocol !== "https:" || parsed.username || parsed.password || parsed.hash) {
+    reject("URL_INVALID", `${label} must be a credential-free public HTTPS URL without a fragment.`);
+  }
+}
+
+function validateApplicationEvidenceUrl(value, application) {
+  if (application.autonomousPrimaryHint === undefined) {
+    return validateGitHubEvidenceUrl(value, "evidence.url", application.source.primary);
+  }
+  validatePublicHttpsUrl(value, "evidence.url");
+  const parsed = new URL(value);
+  const primary = application.autonomousPrimaryHint;
+  const repositoryPath = `/${primary.ownerHint}/${primary.repositoryHint}`;
+  if (
+    parsed.hostname !== "github.com"
+    || parsed.port !== ""
+    || parsed.search !== ""
+    || !parsed.pathname.startsWith(`${repositoryPath}/`)
+  ) {
+    reject(
+      "EVIDENCE_URL_SOURCE_MISMATCH",
+      "Evidence must remain inside the hinted primary GitHub repository."
+    );
+  }
+  const blobPrefix = `${repositoryPath}/blob/${primary.requestedRevisionHint}/`;
+  if (parsed.pathname.startsWith(blobPrefix)) {
+    const encodedPath = parsed.pathname.slice(blobPrefix.length);
+    let decodedPath;
+    try {
+      decodedPath = decodeURIComponent(encodedPath);
+    } catch {
+      reject("EVIDENCE_URL_SOURCE_MISMATCH", "Evidence contains a malformed GitHub blob path.");
+    }
+    if (
+      decodedPath.length === 0
+      || decodedPath.startsWith("/")
+      || decodedPath.includes("\\")
+      || decodedPath.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+    ) {
+      reject("EVIDENCE_URL_SOURCE_MISMATCH", "Evidence contains a noncanonical GitHub blob path.");
+    }
+    return "blob";
+  }
+  if (new RegExp(`^${escapeRegExp(repositoryPath)}/actions/runs/[1-9][0-9]*$`, "u").test(parsed.pathname)) {
+    return "actions";
+  }
+  reject(
+    "EVIDENCE_URL_SOURCE_MISMATCH",
+    "Evidence must be a primary-repository blob at the full requested commit or a GitHub Actions run."
+  );
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function validateGitHubEvidenceUrl(value, label, primary) {
+  validatePublicHttpsUrl(value, label);
+  const blobUrls = new Set((primary.sourcePaths ?? []).map((sourcePath) =>
+    `${primary.repositoryUri}/blob/${primary.revisionObjectId}/${encodeGitHubPath(sourcePath)}`
+  ));
+  if (blobUrls.has(value)) return "blob";
+  const actionUrls = new Set((primary.githubActionsRunIds ?? []).map((runId) =>
+    `${primary.repositoryUri}/actions/runs/${runId}`
+  ));
+  if (actionUrls.has(value)) return "actions";
+  reject(
+    "EVIDENCE_URL_SOURCE_MISMATCH",
+    "Evidence must be an exact primary-repository blob at the declared commit or a declared GitHub Actions run."
+  );
+}
+
+function evidenceBlobPath(value, primary) {
+  for (const sourcePath of primary.sourcePaths ?? []) {
+    if (value === `${primary.repositoryUri}/blob/${primary.revisionObjectId}/${encodeGitHubPath(sourcePath)}`) {
+      return sourcePath;
+    }
+  }
+  systemBlocked("EVIDENCE_RESOLUTION_INPUT_INVALID", "Trusted blob evidence was not bound to a declared source path.");
+}
+
+function encodeGitHubPath(value) {
+  return value.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function compareUtf8(left, right) {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}
+
+function arraysEqual(left, right) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function runGitText(root, args, maximumBytes) {
+  return UTF8_DECODER.decode(runGit(root, args, maximumBytes));
+}
+
+function runGit(root, args, maximumBytes) {
+  const result = childProcess.spawnSync(
+    "git",
+    [
+      "-c", "core.hooksPath=/dev/null",
+      "-c", "credential.helper=",
+      "-C", root,
+      ...args
+    ],
+    {
+      encoding: null,
+      shell: false,
+      maxBuffer: maximumBytes,
+      timeout: TRUSTED_GIT_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+      env: trustedGitEnvironment()
+    }
+  );
+  if (result.error || result.status !== 0 || !Buffer.isBuffer(result.stdout)) {
+    systemBlocked("GIT_COMMAND_FAILED", "A fixed trusted Git inspection command failed.");
+  }
+  return result.stdout;
+}
+
+function trustedGitEnvironment() {
+  const environment = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !/^(?:GIT_|SSH_)/u.test(key))
+  );
+  return {
+    ...environment,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_NO_LAZY_FETCH: "1",
+    GIT_NO_REPLACE_OBJECTS: "1",
+    GIT_OPTIONAL_LOCKS: "0",
+    GIT_TERMINAL_PROMPT: "0"
+  };
+}

--- a/scripts/verify-public-hook-application.mjs
+++ b/scripts/verify-public-hook-application.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import {
+  classifyPublicIntakePullRequest,
+  fetchPublicApplicationCandidate,
+  hydratePublicApplicationCandidate,
+  MAINTAINED_LEGACY_PACKAGE_TIMEOUT_MS,
+  PublicIntakeError,
+  verifyMaintainedSubmissions,
+  verifyPublicHookApplication
+} from "./verify-public-hook-application-core.mjs";
+
+const usage = `Usage:
+  verify-public-hook-application.mjs --classify --base-root <path> --candidate-root <path> --expected-base-commit <sha> --expected-candidate-commit <sha> --expected-merge-commit <sha>
+  verify-public-hook-application.mjs --pull-request-number <number> --base-root <path> --candidate-root <path> --expected-base-commit <sha> --expected-candidate-commit <sha> --expected-merge-commit <sha> --expected-builder-login <login> --expected-builder-user-id <decimal-id>
+  verify-public-hook-application.mjs --fetch-candidate --repository <owner/repository> --pull-request-number <number> --base-root <path> --candidate-root <path> --expected-base-commit <sha> --expected-candidate-commit <sha>
+  verify-public-hook-application.mjs --hydrate-candidate --repository <owner/repository> --pull-request-number <number> --base-root <path> --candidate-root <path> --expected-base-commit <sha> --expected-candidate-commit <sha> --expected-merge-commit <sha>
+  verify-public-hook-application.mjs --verify-maintained --repository-root <path>
+
+Inspect one pull request with trusted base code. Candidate Git objects are treated only as data.
+
+Options:
+  --classify                    Print application, builder-maintenance, or no-op without network access
+  --fetch-candidate             Fetch and identify the exact base-repository PR merge in bounded blobless storage
+  --hydrate-candidate           Preflight sizes and hydrate only the closed seven-file candidate package
+  --repository <owner/name>     Authenticated central GitHub repository for candidate tree metadata
+  --pull-request-number <n>     Exact central pull-request number for fetch, hydration, and final application verification
+  --verify-maintained           Inspect all closed applications and validate bounded legacy packages
+  --repository-root <path>      Trusted post-merge repository root for maintained verification
+  --base-root <path>            Trusted base-revision checkout
+  --candidate-root <path>       GitHub PR merge checkout treated as untrusted data
+  --expected-base-commit <sha>  Exact lowercase base commit supplied by GitHub
+  --expected-candidate-commit <sha> Exact lowercase head commit supplied by GitHub
+  --expected-merge-commit <sha> Exact lowercase PR merge commit supplied by GitHub
+  --expected-builder-login <login> Authenticated pull-request author; required for application verification
+  --expected-builder-user-id <decimal-id> Immutable authenticated pull-request author id; required for application verification
+  --help                        Show this help
+`;
+
+let options;
+try {
+  options = parseArguments(process.argv.slice(2));
+} catch (error) {
+  emitFailure(error);
+  process.exitCode = 2;
+  options = null;
+}
+
+if (options?.help) {
+  process.stdout.write(usage);
+} else if (options) {
+  try {
+    if (options.verifyMaintained) {
+      const report = await verifyMaintainedSubmissions({
+        repositoryRoot: options.repositoryRoot,
+        validateLegacyPackage: runLegacyPackageValidator
+      });
+      process.stdout.write(`${JSON.stringify(report)}\n`);
+    } else if (options.fetchCandidate) {
+      const report = await fetchPublicApplicationCandidate({
+        baseRoot: options.baseRoot,
+        candidateRoot: options.candidateRoot,
+        repository: options.repository,
+        pullRequestNumber: options.pullRequestNumber,
+        expectedBaseCommit: options.expectedBaseCommit,
+        expectedCandidateCommit: options.expectedCandidateCommit,
+        readToken: process.env.CANDIDATE_READ_TOKEN
+      });
+      process.stdout.write(`${JSON.stringify(report)}\n`);
+    } else if (options.hydrateCandidate) {
+      const report = await hydratePublicApplicationCandidate({
+        baseRoot: options.baseRoot,
+        candidateRoot: options.candidateRoot,
+        expectedBaseCommit: options.expectedBaseCommit,
+        expectedCandidateCommit: options.expectedCandidateCommit,
+        expectedMergeCommit: options.expectedMergeCommit,
+        pullRequestNumber: options.pullRequestNumber,
+        repository: options.repository,
+        readToken: process.env.CANDIDATE_READ_TOKEN
+      });
+      process.stdout.write(`${JSON.stringify(report)}\n`);
+    } else {
+      const input = {
+        baseRoot: options.baseRoot,
+        candidateRoot: options.candidateRoot,
+        expectedBaseCommit: options.expectedBaseCommit,
+        pullRequestNumber: options.pullRequestNumber,
+        expectedBuilderLogin: options.expectedBuilderLogin,
+        expectedBuilderUserId: options.expectedBuilderUserId,
+        expectedCandidateCommit: options.expectedCandidateCommit,
+        expectedMergeCommit: options.expectedMergeCommit
+      };
+      if (options.classify) {
+        const result = classifyPublicIntakePullRequest(input);
+        process.stdout.write(`${result.mode}\n`);
+      } else {
+        const report = await verifyPublicHookApplication(input);
+        process.stdout.write(`${JSON.stringify(report)}\n`);
+      }
+    }
+  } catch (error) {
+    emitFailure(error);
+    process.exitCode = error instanceof PublicIntakeError && error.kind === "candidate" ? 1 : 2;
+  }
+}
+
+function parseArguments(args) {
+  const parsed = {
+    classify: false,
+    fetchCandidate: false,
+    hydrateCandidate: false,
+    verifyMaintained: false,
+    help: false,
+    repositoryRoot: null,
+    repository: null,
+    pullRequestNumber: null,
+    baseRoot: null,
+    candidateRoot: null,
+    expectedBaseCommit: null,
+    expectedBuilderLogin: null,
+    expectedBuilderUserId: null,
+    expectedCandidateCommit: null,
+    expectedMergeCommit: null
+  };
+  const valueOptions = new Map([
+    ["--repository-root", "repositoryRoot"],
+    ["--repository", "repository"],
+    ["--pull-request-number", "pullRequestNumber"],
+    ["--base-root", "baseRoot"],
+    ["--candidate-root", "candidateRoot"],
+    ["--expected-base-commit", "expectedBaseCommit"],
+    ["--expected-builder-login", "expectedBuilderLogin"],
+    ["--expected-builder-user-id", "expectedBuilderUserId"],
+    ["--expected-candidate-commit", "expectedCandidateCommit"],
+    ["--expected-merge-commit", "expectedMergeCommit"]
+  ]);
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--help") {
+      parsed.help = true;
+      continue;
+    }
+    if (argument === "--classify") {
+      parsed.classify = true;
+      continue;
+    }
+    if (argument === "--fetch-candidate") {
+      parsed.fetchCandidate = true;
+      continue;
+    }
+    if (argument === "--hydrate-candidate") {
+      parsed.hydrateCandidate = true;
+      continue;
+    }
+    if (argument === "--verify-maintained") {
+      parsed.verifyMaintained = true;
+      continue;
+    }
+    const key = valueOptions.get(argument);
+    if (!key) throw new PublicIntakeError("CLI_ARGUMENT_INVALID", "The trusted validator received an unsupported CLI argument.", { kind: "system" });
+    if (parsed[key] !== null) throw new PublicIntakeError("CLI_ARGUMENT_DUPLICATE", "A trusted validator CLI option was repeated.", { kind: "system" });
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) throw new PublicIntakeError("CLI_VALUE_MISSING", "A trusted validator CLI option is missing its value.", { kind: "system" });
+    parsed[key] = value;
+    index += 1;
+  }
+  if (!parsed.help) {
+    if ([parsed.classify, parsed.fetchCandidate, parsed.hydrateCandidate, parsed.verifyMaintained].filter(Boolean).length > 1) {
+      throw new PublicIntakeError("CLI_MODE_INVALID", "Trusted validator modes cannot be combined.", { kind: "system" });
+    }
+    if (parsed.verifyMaintained) {
+      if (parsed.repositoryRoot === null) {
+        throw new PublicIntakeError("CLI_ARGUMENT_MISSING", "Maintained verification requires the trusted repository root.", { kind: "system" });
+      }
+      for (const key of ["repository", "pullRequestNumber", "baseRoot", "candidateRoot", "expectedBaseCommit", "expectedBuilderLogin", "expectedBuilderUserId", "expectedCandidateCommit", "expectedMergeCommit"]) {
+        if (parsed[key] !== null) {
+          throw new PublicIntakeError("CLI_ARGUMENT_INVALID", "Pull-request options cannot be combined with maintained verification.", { kind: "system" });
+        }
+      }
+    } else if (parsed.fetchCandidate) {
+      for (const key of ["repository", "pullRequestNumber", "baseRoot", "candidateRoot", "expectedBaseCommit", "expectedCandidateCommit"]) {
+        if (parsed[key] === null) throw new PublicIntakeError("CLI_ARGUMENT_MISSING", "Candidate fetch is missing a required trusted option.", { kind: "system" });
+      }
+      for (const key of ["repositoryRoot", "expectedBuilderLogin", "expectedBuilderUserId", "expectedMergeCommit"]) {
+        if (parsed[key] !== null) throw new PublicIntakeError("CLI_ARGUMENT_INVALID", "Candidate fetch received an unrelated validator option.", { kind: "system" });
+      }
+    } else {
+      if (parsed.repositoryRoot !== null) {
+        throw new PublicIntakeError("CLI_ARGUMENT_INVALID", "--repository-root is available only for maintained verification.", { kind: "system" });
+      }
+      for (const key of ["baseRoot", "candidateRoot", "expectedBaseCommit", "expectedCandidateCommit", "expectedMergeCommit"]) {
+        if (parsed[key] === null) throw new PublicIntakeError("CLI_ARGUMENT_MISSING", "The trusted validator is missing a required CLI option.", { kind: "system" });
+      }
+      if (parsed.classify && parsed.pullRequestNumber !== null) {
+        throw new PublicIntakeError("CLI_ARGUMENT_INVALID", "Classification does not accept a pull-request number.", { kind: "system" });
+      }
+      if (!parsed.classify && parsed.pullRequestNumber === null) {
+        throw new PublicIntakeError("CLI_ARGUMENT_MISSING", "Hydration and application verification require the exact pull-request number.", { kind: "system" });
+      }
+      if (parsed.hydrateCandidate && parsed.repository === null) {
+        throw new PublicIntakeError("CLI_ARGUMENT_MISSING", "Candidate hydration requires the central GitHub repository identity.", { kind: "system" });
+      }
+      if (!parsed.hydrateCandidate && parsed.repository !== null) {
+        throw new PublicIntakeError("CLI_ARGUMENT_INVALID", "--repository is available only for candidate hydration.", { kind: "system" });
+      }
+      if (parsed.hydrateCandidate && (parsed.expectedBuilderLogin !== null || parsed.expectedBuilderUserId !== null)) {
+        throw new PublicIntakeError("CLI_ARGUMENT_INVALID", "Candidate hydration does not accept a builder identity.", { kind: "system" });
+      }
+      if (
+        !parsed.classify
+        && !parsed.hydrateCandidate
+        && (parsed.expectedBuilderLogin === null || parsed.expectedBuilderUserId === null)
+      ) {
+        throw new PublicIntakeError("CLI_ARGUMENT_MISSING", "Application verification requires the authenticated pull-request author login and immutable user id.", { kind: "system" });
+      }
+    }
+  }
+  return parsed;
+}
+
+function runLegacyPackageValidator({ repositoryRoot, packageName, packageRoot }) {
+  const validator = path.join(
+    repositoryRoot,
+    "skills",
+    "programmable-v4-hook-builder",
+    "scripts",
+    "verify-package.mjs"
+  );
+  let validatorStatus;
+  try {
+    validatorStatus = fs.lstatSync(validator);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new PublicIntakeError(
+        "MAINTAINED_LEGACY_VALIDATOR_UNAVAILABLE",
+        "The trusted revision does not contain the legacy-package validator.",
+        { kind: "system" }
+      );
+    }
+    throw error;
+  }
+  if (validatorStatus.isSymbolicLink() || !validatorStatus.isFile()) {
+    throw new PublicIntakeError(
+      "MAINTAINED_LEGACY_VALIDATOR_UNAVAILABLE",
+      "The trusted legacy-package validator must be a regular file.",
+      { kind: "system" }
+    );
+  }
+
+  process.stderr.write(`Validating maintained legacy package ${packageName}.\n`);
+  const result = childProcess.spawnSync(
+    process.execPath,
+    [validator, "--repository-root", repositoryRoot, packageRoot],
+    {
+      cwd: repositoryRoot,
+      shell: false,
+      stdio: ["ignore", "inherit", "inherit"],
+      timeout: MAINTAINED_LEGACY_PACKAGE_TIMEOUT_MS,
+      killSignal: "SIGKILL"
+    }
+  );
+  if (result.error) {
+    const timedOut = result.error.code === "ETIMEDOUT";
+    throw new PublicIntakeError(
+      timedOut ? "MAINTAINED_LEGACY_VALIDATION_TIMEOUT" : "MAINTAINED_LEGACY_VALIDATION_FAILED",
+      timedOut
+        ? `Legacy package ${packageName} exceeded its trusted validation timeout.`
+        : `Legacy package ${packageName} could not be validated.`,
+      { kind: "system" }
+    );
+  }
+  if (result.status !== 0) {
+    throw new PublicIntakeError(
+      "MAINTAINED_LEGACY_PACKAGE_INVALID",
+      `Legacy package ${packageName} failed trusted package validation.`,
+      { kind: "system" }
+    );
+  }
+}
+
+function emitFailure(error) {
+  const known = error instanceof PublicIntakeError;
+  const payload = {
+    schemaVersion: 1,
+    result: known && error.kind === "candidate" ? "invalid-public-application-package" : "system-blocked",
+    code: known ? error.code : "UNEXPECTED_VALIDATOR_FAILURE",
+    message: known ? error.message : "The trusted validator failed unexpectedly."
+  };
+  process.stderr.write(`${JSON.stringify(payload)}\n`);
+}

--- a/skills/programmable-v4-hook-builder/scripts/application-input-contract.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/application-input-contract.mjs
@@ -1,0 +1,2 @@
+export const AUTONOMOUS_APPLICATION_INPUT_DISCLAIMER =
+  "Builder-declared untrusted application input; only the autonomous admission service may approve the exact revision. Not an audit, deployment, Uniswap endorsement, or launch.";

--- a/skills/programmable-v4-hook-builder/scripts/autonomous-admission-contract.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/autonomous-admission-contract.mjs
@@ -1,0 +1,1103 @@
+import crypto from "node:crypto";
+import { TextDecoder } from "node:util";
+import { canonicalJson } from "./submission-core.mjs";
+import { CliFailure } from "./cli-runtime.mjs";
+
+export const AUTONOMOUS_APPLICATION_SCHEMA_VERSION = "1.0.0";
+export const AUTONOMOUS_LAUNCH_SCHEMA_VERSION = "programmable.launch-specification.v1";
+export const AUTONOMOUS_ACTIVE_LAUNCH_COMPILER_PROFILE = Object.freeze({
+  profileId: "programmable:solidity-solc-0.8.26-v1",
+  profileVersion: "v1",
+  language: "solidity",
+  family: "solc",
+  version: "0.8.26"
+});
+export const AUTONOMOUS_ADMISSION_FILES = Object.freeze([
+  "application.json",
+  "launch.json",
+  "PROPOSAL.md",
+  "TEST_PLAN.md",
+  "THREAT_MODEL.md",
+  "compatibility-report.json",
+  "evidence-index.json"
+]);
+
+export const AUTONOMOUS_ADMISSION_FILE_LIMITS = Object.freeze({
+  "application.json": 64 * 1024,
+  "launch.json": 256 * 1024,
+  "PROPOSAL.md": 64 * 1024,
+  "TEST_PLAN.md": 64 * 1024,
+  "THREAT_MODEL.md": 64 * 1024,
+  "compatibility-report.json": 160 * 1024,
+  "evidence-index.json": 160 * 1024
+});
+
+const decoder = new TextDecoder("utf-8", { fatal: true });
+const APPLICATION_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const LOCAL_ID_PATTERN = /^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$/u;
+const LAUNCH_LOCAL_ID_PATTERN = /^[A-Za-z][A-Za-z0-9]*(?:[._:@/+~-][A-Za-z0-9]+)*$/u;
+const KIND_PATTERN = /^[A-Za-z][A-Za-z0-9]*(?:[._:@/+~-][A-Za-z0-9]+)*$/u;
+const GITHUB_URI_PATTERN = /^https:\/\/github\.com\/([a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?)\/((?!\.{1,2}$)(?!.*\.git$)(?=[a-z0-9._-]*[a-z0-9])[a-z0-9._-]{1,100})$/u;
+const OPAQUE_DECIMAL_PATTERN = /^[1-9][0-9]{0,63}$/u;
+const UINT256_DECIMAL_PATTERN = /^(?:0|[1-9][0-9]{0,77})$/u;
+const UINT256_MAXIMUM = (1n << 256n) - 1n;
+const COMMIT_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const ADDRESS_PATTERN = /^0x[0-9a-f]{40}$/u;
+const SOURCE_PATH_PATTERN = /^(?!\/)(?!.*(?:^|\/)\.{1,2}(?:\/|$))(?!.*\/\/)(?!.*\\)[A-Za-z0-9_@+./-]+\.sol$/u;
+const REPOSITORY_PATH_PATTERN = /^(?!\/)(?!.*(?:^|\/)\.{1,2}(?:\/|$))(?!.*(?:^|\/)\.git(?:\/|$))(?!.*\\)(?!.*\/\/)(?!.*\/$)[^\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]+$/u;
+const SPDX_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9.+-]{1,79}$/u;
+const CONTROL_OR_BIDI_PATTERN = /[\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]/u;
+const MUTABLE_URL_PATTERN = /(?:\b(?:https?|ftp|ssh|git):\/\/|\b(?:javascript|file):|\bdata:[^\s])/iu;
+const SECRET_KEY_PATTERN = /^(?:api[-_]?key|api[-_]?token|authorization|bearer[-_]?token|credential|credentials|mnemonic|password|private[-_]?key|secret|secret[-_]?key|seed[-_]?phrase)$/iu;
+const SECRET_VALUE_PATTERNS = Object.freeze([
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/u,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/u,
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/u,
+  /\bAKIA[0-9A-Z]{16}\b/u,
+  /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/u,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/u
+]);
+
+export function primarySourceId() {
+  return "source:primary";
+}
+
+export function companionSourceId(index) {
+  if (!Number.isInteger(index) || index < 0 || index > 14) invalid("companion source index is invalid");
+  return `source:companion-${index + 1}`;
+}
+
+export function buildAutonomousApplicationManifest({
+  submission,
+  source,
+  applicationRevision,
+  launchSpecification
+}) {
+  const applicationId = submission?.model?.id;
+  if (!APPLICATION_ID_PATTERN.test(applicationId ?? "") || applicationId.length > 80) {
+    invalid("submission model id cannot identify an autonomous application");
+  }
+  if (!Number.isInteger(applicationRevision) || applicationRevision < 1 || applicationRevision > 1_000_000) {
+    invalid("application revision is outside the autonomous application contract");
+  }
+  const repositories = normalizeSourceRepositories(source);
+  const sourceIds = new Set(repositories.map((entry) => entry.sourceId));
+  const chainRequest = {
+    requestId: "chain:launch",
+    namespaceHint: launchSpecification.chain.namespace,
+    referenceHint: launchSpecification.chain.reference,
+    profileHint: launchSpecification.chain.profileId
+  };
+  const components = launchSpecification.components.map((component) => {
+    for (const sourceId of component.sourceIds) {
+      if (!sourceIds.has(sourceId)) invalid(`launch component ${component.componentId} references unknown source ${sourceId}`);
+    }
+    return {
+      componentId: component.componentId,
+      kindHint: component.kind,
+      summary: componentSummary(component),
+      sourceIds: [...component.sourceIds],
+      chainRequestIds: [chainRequest.requestId],
+      visibilityHint: component.sourceIds.length > 0 ? "public-source" : "external-service",
+      reviewRelevanceHint: "unknown"
+    };
+  }).sort((left, right) => compareUtf8(left.componentId, right.componentId));
+  if (components.length === 0) invalid("at least one launch component is required");
+  const componentIds = components.map((component) => component.componentId);
+  const manifest = {
+    schemaVersion: AUTONOMOUS_APPLICATION_SCHEMA_VERSION,
+    applicationId,
+    applicationRevision,
+    project: {
+      title: normalizedPlainText(submission?.model?.name, 3, 120, "project title"),
+      summary: normalizedPlainText(submission?.model?.summary, 20, 4_000, "project summary")
+    },
+    primarySourceId: primarySourceId(),
+    githubSources: repositories.map(({
+      sourceId,
+      ownerHint,
+      repositoryHint,
+      repositoryIdHint,
+      requestedRevisionHint,
+      purposeHint,
+      executionRoots,
+      rightsDeclaration
+    }) => ({
+      sourceId,
+      ownerHint,
+      repositoryHint,
+      repositoryIdHint,
+      requestedRevisionHint,
+      visibilityHint: "public",
+      purposeHint,
+      executionRoots,
+      rightsDeclaration
+    })).sort((left, right) => compareUtf8(left.sourceId, right.sourceId)),
+    chainProfileRequests: [chainRequest],
+    components,
+    capabilityHints: [{
+      capabilityId: "capability:project",
+      kindHint: "project.source-defined",
+      summary: normalizedPlainText(
+        submission?.model?.userOutcome ?? submission?.model?.summary,
+        1,
+        4_000,
+        "project capability summary"
+      ),
+      componentIds,
+      chainRequestIds: [chainRequest.requestId],
+      movesUserValueHint: null,
+      controlsUserValueHint: null
+    }]
+  };
+  validateAutonomousApplicationManifest(manifest, { requireImmutableSourceHints: true });
+  return deepFreeze(manifest);
+}
+
+export function deriveAutonomousLaunchSpecification({ submission, source, headFiles }) {
+  const launchPlanPath = submission?.implementation?.specificationPath;
+  if (typeof launchPlanPath !== "string" || !launchPlanPath.endsWith(".json")) {
+    invalid("implementation.specificationPath must identify one committed data-only launch plan JSON file");
+  }
+  if (!(headFiles instanceof Map)) invalid("exact HEAD file bytes are unavailable");
+  const bytes = headFiles.get(launchPlanPath);
+  if (!Buffer.isBuffer(bytes)) invalid(`${launchPlanPath} is not bound to the exact project HEAD`);
+  let sourceText;
+  let launchSpecification;
+  try {
+    sourceText = decoder.decode(bytes);
+    launchSpecification = JSON.parse(sourceText);
+  } catch {
+    invalid(`${launchPlanPath} must be valid UTF-8 JSON`);
+  }
+  validateAutonomousLaunchSpecification(launchSpecification);
+  if (launchSpecification.applicationId !== submission?.model?.id) {
+    invalid("launch plan applicationId must equal submission.model.id");
+  }
+  if (
+    launchSpecification.compiler.version !== submission?.target?.solidityVersion
+    || launchSpecification.chain.namespace !== "eip155"
+    || launchSpecification.chain.reference !== String(submission?.target?.chainId)
+  ) {
+    invalid("launch plan compiler and chain must match the reviewed submission target");
+  }
+  const repositories = normalizeSourceRepositories(source);
+  const repositoryBySourceId = new Map(repositories.map((entry) => [entry.sourceId, entry]));
+  const sourceRequestById = new Map([
+    [primarySourceId(), source.primary],
+    ...source.companions.map((entry) => [entry.sourceId, entry])
+  ]);
+  for (const target of launchSpecification.targets) {
+    const repository = repositoryBySourceId.get(target.sourceId);
+    const sourceRequest = sourceRequestById.get(target.sourceId);
+    if (repository === undefined || sourceRequest === undefined) {
+      invalid(`launch target ${target.targetId} references unknown source ${target.sourceId}`);
+    }
+    const declaredPaths = new Set([...sourceRequest.sourcePaths, ...sourceRequest.contractPaths]);
+    if (!declaredPaths.has(target.sourceUnitName)) {
+      invalid(`launch target ${target.targetId} sourceUnitName is not declared in ${target.sourceId}`);
+    }
+    if (target.sourceId === primarySourceId()) {
+      const sourceBytes = headFiles.get(target.sourceUnitName);
+      if (!Buffer.isBuffer(sourceBytes)) {
+        invalid(`launch target ${target.targetId} source bytes are not bound to the exact primary HEAD`);
+      }
+      const observed = digest(sourceBytes);
+      if (target.sourceSha256 !== observed) {
+        invalid(`launch target ${target.targetId} sourceSha256 does not match ${target.sourceUnitName}`);
+      }
+    }
+  }
+  return deepFreeze(launchSpecification);
+}
+
+export function validateAutonomousApplicationManifest(value, { requireImmutableSourceHints = false } = {}) {
+  assertExactObject(value, [
+    "applicationId",
+    "applicationRevision",
+    "capabilityHints",
+    "chainProfileRequests",
+    "components",
+    "githubSources",
+    "primarySourceId",
+    "project",
+    "schemaVersion"
+  ], "application.json");
+  if (
+    value.schemaVersion !== AUTONOMOUS_APPLICATION_SCHEMA_VERSION
+    || !APPLICATION_ID_PATTERN.test(value.applicationId ?? "")
+    || value.applicationId.length > 80
+    || !Number.isInteger(value.applicationRevision)
+    || value.applicationRevision < 1
+    || value.applicationRevision > 1_000_000
+  ) invalid("application.json identity or revision is invalid");
+  assertExactObject(value.project, ["summary", "title"], "application project");
+  normalizedPlainText(value.project.title, 3, 120, "project title");
+  normalizedPlainText(value.project.summary, 20, 4_000, "project summary");
+  if (!LOCAL_ID_PATTERN.test(value.primarySourceId ?? "")) invalid("primarySourceId is invalid");
+  if (!Array.isArray(value.githubSources) || value.githubSources.length < 1 || value.githubSources.length > 16) {
+    invalid("githubSources must contain one primary source and at most fifteen companions");
+  }
+  const sourceIds = new Set();
+  for (const sourceHint of value.githubSources) {
+    assertExactObject(
+      sourceHint,
+      [
+        "executionRoots",
+        "ownerHint",
+        "purposeHint",
+        "repositoryHint",
+        "repositoryIdHint",
+        "requestedRevisionHint",
+        "rightsDeclaration",
+        "sourceId",
+        "visibilityHint"
+      ],
+      "GitHub source hint"
+    );
+    if (
+      !LOCAL_ID_PATTERN.test(sourceHint.sourceId ?? "")
+      || sourceIds.has(sourceHint.sourceId)
+      || !OPAQUE_DECIMAL_PATTERN.test(sourceHint.repositoryIdHint ?? "")
+      || !KIND_PATTERN.test(sourceHint.purposeHint ?? "")
+      || sourceHint.visibilityHint !== "public"
+      || !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/u.test(sourceHint.ownerHint ?? "")
+      || !/^(?!\.{1,2}$)(?!.*\.git$)(?=.*[A-Za-z0-9])[A-Za-z0-9._-]{1,100}$/u.test(sourceHint.repositoryHint ?? "")
+      || (requireImmutableSourceHints && !COMMIT_PATTERN.test(sourceHint.requestedRevisionHint ?? ""))
+    ) invalid("application.json contains a noncanonical GitHub source hint");
+    const executionRoots = validateExecutionRoots(sourceHint.executionRoots, `source ${sourceHint.sourceId} executionRoots`);
+    validateRightsDeclaration(sourceHint.rightsDeclaration, `source ${sourceHint.sourceId} rightsDeclaration`, executionRoots);
+    sourceIds.add(sourceHint.sourceId);
+  }
+  if (!sourceIds.has(value.primarySourceId)) invalid("primarySourceId must identify exactly one GitHub source");
+  validateOpenWorldGraph(value, sourceIds);
+  assertSafeDataTree(value, { forbidUrls: true });
+  return value;
+}
+
+export function validateAutonomousLaunchSpecification(value) {
+  assertExactObject(value, [
+    "applicationId",
+    "chain",
+    "compiler",
+    "components",
+    "declaredIdentities",
+    "edges",
+    "externalOnchainDependencies",
+    "extensions",
+    "internalChildDeployments",
+    "language",
+    "launcher",
+    "releaseModules",
+    "rootComponentId",
+    "rootTargetId",
+    "schemaVersion",
+    "targets"
+  ], "launch.json");
+  if (
+    value.schemaVersion !== AUTONOMOUS_LAUNCH_SCHEMA_VERSION
+    || !APPLICATION_ID_PATTERN.test(value.applicationId ?? "")
+    || value.language !== AUTONOMOUS_ACTIVE_LAUNCH_COMPILER_PROFILE.language
+  ) invalid("launch.json identity, schema, or language is invalid");
+  assertExactObject(value.compiler, ["family", "profileId", "settings", "version"], "launch compiler");
+  if (
+    value.compiler.profileId !== AUTONOMOUS_ACTIVE_LAUNCH_COMPILER_PROFILE.profileId
+    || value.compiler.family !== AUTONOMOUS_ACTIVE_LAUNCH_COMPILER_PROFILE.family
+    || value.compiler.version !== AUTONOMOUS_ACTIVE_LAUNCH_COMPILER_PROFILE.version
+  ) {
+    invalid("launch compiler must use the active V1 Solidity solc 0.8.26 profile");
+  }
+  if (!isPlainObject(value.compiler.settings)) invalid("launch compiler settings must be a data-only object");
+  assertExactObject(value.chain, ["namespace", "profileId", "reference"], "launch chain");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._~-]{0,63}$/u.test(value.chain.namespace ?? "") || !/^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u.test(value.chain.reference ?? "") || !LAUNCH_LOCAL_ID_PATTERN.test(value.chain.profileId ?? "")) {
+    invalid("launch chain identity is invalid");
+  }
+  const chainNamespace = `${value.chain.namespace}:${value.chain.reference}`;
+  assertExactObject(value.launcher, ["route"], "launch launcher");
+  assertExactObject(value.launcher.route, ["adapterId", "kind"], "launcher route");
+  if (!KIND_PATTERN.test(value.launcher.route.kind ?? "") || !KIND_PATTERN.test(value.launcher.route.adapterId ?? "")) {
+    invalid("launcher route is invalid");
+  }
+  if (!Array.isArray(value.targets) || value.targets.length < 1 || value.targets.length > 64) invalid("launch targets are invalid");
+  if (!Array.isArray(value.components) || value.components.length < 1 || value.components.length > 256) invalid("launch components are invalid");
+  if (
+    !Array.isArray(value.edges)
+    || value.edges.length > 1_024
+    || !Array.isArray(value.externalOnchainDependencies)
+    || value.externalOnchainDependencies.length > 256
+    || !Array.isArray(value.internalChildDeployments)
+    || value.internalChildDeployments.length > 256
+    || !Array.isArray(value.releaseModules)
+    || value.releaseModules.length > 256
+    || !Array.isArray(value.declaredIdentities)
+    || value.declaredIdentities.length > 4_096
+    || !isPlainObject(value.extensions)
+  ) invalid("launch graph is invalid");
+  const targetIds = sortedUnique(value.targets.map((target) => target?.targetId), "launch targets");
+  const componentIds = sortedUnique(value.components.map((component) => component?.componentId), "launch components");
+  const componentSet = new Set(componentIds);
+  const targetSet = new Set(targetIds);
+  const rootTarget = value.targets.find((target) => target?.targetId === value.rootTargetId);
+  const rootComponent = value.components.find((component) => component?.componentId === value.rootComponentId);
+  if (
+    rootTarget === undefined
+    || rootComponent === undefined
+    || rootTarget.componentId !== rootComponent.componentId
+    || rootComponent.targetIds?.filter((targetId) => targetId === rootTarget.targetId).length !== 1
+  ) invalid("rootTargetId and rootComponentId must bind exactly one deployable onchain target");
+  const sourceIdsByComponent = new Map();
+  const constructorDependencies = new Map();
+  const externalDependencySet = validateExternalOnchainDependencies(value.externalOnchainDependencies);
+  const internalChildSet = validateInternalChildDeployments(value.internalChildDeployments);
+  const declaredIdentitySet = validateDeclaredIdentities(value.declaredIdentities, chainNamespace);
+  const releaseModuleSelectionSet = validateReleaseModuleSelections(value.releaseModules);
+  const releaseModuleLocatorUse = new Map();
+  for (const component of value.components) {
+    assertExactObject(component, ["attributes", "componentId", "kind", "sourceIds", "targetIds"], "launch component");
+    if (!LAUNCH_LOCAL_ID_PATTERN.test(component.componentId ?? "") || !KIND_PATTERN.test(component.kind ?? "") || !isPlainObject(component.attributes)) {
+      invalid("launch component is invalid");
+    }
+    const sourceIds = sortedUnique(component.sourceIds, `component ${component.componentId} sources`);
+    const boundTargets = sortedUnique(component.targetIds, `component ${component.componentId} targets`);
+    for (const targetId of boundTargets) if (!targetSet.has(targetId)) invalid(`component ${component.componentId} references unknown target ${targetId}`);
+    sourceIdsByComponent.set(component.componentId, new Set(sourceIds));
+  }
+  for (const target of value.targets) {
+    assertExactObject(target, [
+      "componentId", "constructor", "contractName", "declaredHookPermissions", "deploymentMode",
+      "deploymentValueWei", "initializer", "initializerValueWei", "libraries", "saltStrategy", "sourceId",
+      "sourceSha256", "sourceUnitName", "targetId"
+    ], "launch target");
+    if (
+      !LAUNCH_LOCAL_ID_PATTERN.test(target.targetId ?? "")
+      || !componentSet.has(target.componentId)
+      || !LAUNCH_LOCAL_ID_PATTERN.test(target.sourceId ?? "")
+      || !sourceIdsByComponent.get(target.componentId)?.has(target.sourceId)
+      || !SOURCE_PATH_PATTERN.test(target.sourceUnitName ?? "")
+      || !SHA256_PATTERN.test(target.sourceSha256 ?? "")
+      || !/^[A-Za-z_$][A-Za-z0-9_$]{0,127}$/u.test(target.contractName ?? "")
+      || !KIND_PATTERN.test(target.deploymentMode ?? "")
+      || ![null, "compiler-deterministic-v1"].includes(target.saltStrategy)
+      || !Array.isArray(target.libraries)
+      || target.libraries.length > 128
+    ) invalid("launch target is invalid");
+    if (target.declaredHookPermissions !== null) {
+      const supportedHookPermissions = new Set([
+        "beforeInitialize", "afterInitialize", "beforeAddLiquidity", "afterAddLiquidity",
+        "beforeRemoveLiquidity", "afterRemoveLiquidity", "beforeSwap", "afterSwap", "beforeDonate", "afterDonate",
+        "beforeSwapReturnDelta", "afterSwapReturnDelta", "afterAddLiquidityReturnDelta",
+        "afterRemoveLiquidityReturnDelta"
+      ]);
+      const permissions = sortedUnique(
+        target.declaredHookPermissions,
+        `target ${target.targetId} declaredHookPermissions`
+      );
+      if (permissions.length > 14 || permissions.some((permission) => !supportedHookPermissions.has(permission))) {
+        invalid("launch target declaredHookPermissions are invalid");
+      }
+    }
+    validateUint256Decimal(target.deploymentValueWei, "launch deploymentValueWei");
+    validateUint256Decimal(target.initializerValueWei, "launch initializerValueWei");
+    assertExactObject(target.constructor, ["abiEncodedArguments", "addressLocators"], "launch constructor");
+    if (!/^0x(?:[0-9a-f]{2})*$/u.test(target.constructor.abiEncodedArguments ?? "")) invalid("constructor arguments are invalid");
+    const constructorLocators = validateAddressLocators({
+      locators: target.constructor.addressLocators,
+      hexadecimalBytes: target.constructor.abiEncodedArguments,
+      targetSet,
+      releaseModuleSelectionSet,
+      externalDependencySet,
+      internalChildSet,
+      declaredIdentitySet,
+      routeAdapterId: value.launcher.route.adapterId,
+      label: `target ${target.targetId} constructor address locators`
+    });
+    if (constructorLocators.some((locator) => locator.kind === "target" && locator.targetId === target.targetId)) {
+      invalid(`target ${target.targetId} constructor cannot embed its own deterministic address`);
+    }
+    constructorDependencies.set(
+      target.targetId,
+      constructorLocators.filter(({ kind }) => kind === "target").map(({ targetId }) => targetId)
+    );
+    recordReleaseModuleLocatorUse(releaseModuleLocatorUse, constructorLocators, target.targetId, "constructor");
+    if (target.initializer !== null) {
+      assertExactObject(target.initializer, ["addressLocators", "calldata"], "launch initializer");
+      if (!/^0x(?:[0-9a-f]{2})*$/u.test(target.initializer.calldata ?? "")) invalid("initializer calldata is invalid");
+      validateAddressLocators({
+        locators: target.initializer.addressLocators,
+        hexadecimalBytes: target.initializer.calldata,
+        targetSet,
+        releaseModuleSelectionSet,
+        externalDependencySet,
+        internalChildSet,
+        declaredIdentitySet,
+        routeAdapterId: value.launcher.route.adapterId,
+        label: `target ${target.targetId} initializer address locators`
+      });
+      recordReleaseModuleLocatorUse(releaseModuleLocatorUse, target.initializer.addressLocators, target.targetId, "initializer");
+    } else if (target.initializerValueWei !== "0") {
+      invalid("a nonzero initializerValueWei requires a nonempty initializer calldata");
+    }
+    if (target.initializerValueWei !== "0" && target.initializer?.calldata === "0x") {
+      invalid("a nonzero initializerValueWei requires a nonempty initializer calldata");
+    }
+    const libraryKeys = [];
+    for (const library of target.libraries) {
+      assertExactObject(library, ["binding", "libraryName", "sourceUnitName"], "launch library");
+      if (!SOURCE_PATH_PATTERN.test(library.sourceUnitName ?? "") || !/^[A-Za-z_$][A-Za-z0-9_$]{0,127}$/u.test(library.libraryName ?? "")) invalid("launch library is invalid");
+      validateLibraryBinding(library.binding, targetSet, externalDependencySet);
+      libraryKeys.push(`${library.sourceUnitName}\0${library.libraryName}`);
+    }
+    sortedUnique(libraryKeys, `target ${target.targetId} libraries`);
+  }
+  assertAcyclicConstructorDependencies(constructorDependencies);
+  validateReleaseModuleRoutes(value.releaseModules, value.targets, releaseModuleLocatorUse);
+  const edgeIds = [];
+  for (const edge of value.edges) {
+    assertExactObject(edge, ["attributes", "edgeId", "fromComponentId", "kind", "toComponentId"], "launch edge");
+    if (!LAUNCH_LOCAL_ID_PATTERN.test(edge.edgeId ?? "") || !KIND_PATTERN.test(edge.kind ?? "") || !componentSet.has(edge.fromComponentId) || !componentSet.has(edge.toComponentId) || !isPlainObject(edge.attributes)) {
+      invalid("launch edge is invalid");
+    }
+    edgeIds.push(edge.edgeId);
+  }
+  sortedUnique(edgeIds, "launch edges");
+  assertSafeDataTree(value, { forbidUrls: false });
+  return value;
+}
+
+function validateExternalOnchainDependencies(dependencies) {
+  const ids = sortedUnique(dependencies.map((dependency) => dependency?.dependencyId), "external onchain dependencies");
+  for (const dependency of dependencies) {
+    assertExactObject(dependency, ["dependencyId"], "external onchain dependency reference");
+    if (!LAUNCH_LOCAL_ID_PATTERN.test(dependency.dependencyId ?? "")) {
+      invalid("external onchain dependency reference is invalid");
+    }
+  }
+  return new Set(ids);
+}
+
+function validateInternalChildDeployments(children) {
+  const ids = sortedUnique(children.map((child) => child?.childId), "internal child deployments");
+  for (const child of children) {
+    assertExactObject(child, ["childId"], "internal child deployment reference");
+    if (!LAUNCH_LOCAL_ID_PATTERN.test(child.childId ?? "")) invalid("internal child deployment reference is invalid");
+  }
+  return new Set(ids);
+}
+
+function validateReleaseModuleSelections(selections) {
+  const ids = sortedUnique(selections.map((selection) => selection?.selectionId), "release module selections");
+  for (const selection of selections) {
+    assertExactObject(selection, ["intent", "moduleId", "selectionId"], "release module selection");
+    if (!LAUNCH_LOCAL_ID_PATTERN.test(selection.selectionId ?? "") || !LAUNCH_LOCAL_ID_PATTERN.test(selection.moduleId ?? "")) {
+      invalid("release module selection is invalid");
+    }
+    assertExactObject(
+      selection.intent,
+      ["authorizedRouteComponentId", "authorizedRouteTargetId", "kind"],
+      "release module intent"
+    );
+    if (
+      !KIND_PATTERN.test(selection.intent.kind ?? "")
+      || !LAUNCH_LOCAL_ID_PATTERN.test(selection.intent.authorizedRouteTargetId ?? "")
+      || !LAUNCH_LOCAL_ID_PATTERN.test(selection.intent.authorizedRouteComponentId ?? "")
+    ) invalid("release module intent is invalid");
+  }
+  return new Set(ids);
+}
+
+function validateDeclaredIdentities(identities, chainNamespace) {
+  const ids = sortedUnique(identities.map((identity) => identity?.identityId), "declared identities");
+  for (const declared of identities) {
+    assertExactObject(declared, ["identity", "identityId", "role"], "declared identity");
+    if (!LAUNCH_LOCAL_ID_PATTERN.test(declared.identityId ?? "") || !KIND_PATTERN.test(declared.role ?? "")) {
+      invalid("declared identity is invalid");
+    }
+    validateIdentity(declared.identity, chainNamespace, "declared identity value");
+  }
+  return new Set(ids);
+}
+
+function validateLibraryBinding(binding, targetSet, externalDependencySet) {
+  if (binding?.kind === "target") {
+    assertExactObject(binding, ["kind", "targetId"], "launch library binding");
+    if (!targetSet.has(binding.targetId)) invalid("launch library target binding is unknown");
+    return;
+  }
+  if (binding?.kind === "external-onchain-dependency") {
+    assertExactObject(binding, ["dependencyId", "kind"], "launch library binding");
+    if (!externalDependencySet.has(binding.dependencyId)) invalid("launch library dependency binding is unknown");
+    return;
+  }
+  invalid("launch library binding is invalid");
+}
+
+function recordReleaseModuleLocatorUse(uses, locators, targetId, phase) {
+  for (const locator of locators) {
+    if (locator.kind !== "release-module-selection") continue;
+    uses.set(locator.selectionId, [...(uses.get(locator.selectionId) ?? []), { targetId, phase }]);
+  }
+}
+
+function validateReleaseModuleRoutes(selections, targets, locatorUses) {
+  const routeKeys = [];
+  for (const selection of selections) {
+    const routeTarget = targets.find(({ targetId }) => targetId === selection.intent.authorizedRouteTargetId);
+    if (routeTarget === undefined || routeTarget.componentId !== selection.intent.authorizedRouteComponentId) {
+      invalid("release module intent must bind one exact route target and component");
+    }
+    const uses = locatorUses.get(selection.selectionId) ?? [];
+    if (uses.length !== 1 || uses[0].phase !== "constructor" || uses[0].targetId !== routeTarget.targetId) {
+      invalid("release module must be injected exactly once into its authorized route constructor");
+    }
+    routeKeys.push(`${selection.moduleId}\0${routeTarget.targetId}`);
+  }
+  if (new Set(routeKeys).size !== routeKeys.length) invalid("one release module cannot be selected twice for the same route");
+}
+
+export function canonicalApplicationBytes(value) {
+  validateAutonomousApplicationManifest(value, { requireImmutableSourceHints: true });
+  return Buffer.from(canonicalJson(value), "utf8");
+}
+
+export function canonicalLaunchBytes(value) {
+  validateAutonomousLaunchSpecification(value);
+  return Buffer.from(canonicalJson(value), "utf8");
+}
+
+export function autonomousAdmissionContractDescriptor({ applicationSchemaSha256, launchSchemaSha256 }) {
+  if (!SHA256_PATTERN.test(applicationSchemaSha256 ?? "") || !SHA256_PATTERN.test(launchSchemaSha256 ?? "")) {
+    invalid("schema digests are invalid");
+  }
+  const descriptor = {
+    schemaVersion: "programmable.autonomous-admission-skill-contract.v1",
+    applicationSchemaSha256,
+    launchSchemaSha256,
+    fileOrder: [...AUTONOMOUS_ADMISSION_FILES],
+    canonicalJson: {
+      application: "rfc8785-compatible-no-trailing-newline",
+      launch: "rfc8785-compatible-no-trailing-newline"
+    },
+    activeLaunchCompilerProfile: AUTONOMOUS_ACTIVE_LAUNCH_COMPILER_PROFILE,
+    sourceAuthority: {
+      primarySourceId: primarySourceId(),
+      companionSourceIdPattern: "source:companion-{one-based-index}",
+      numericRepositoryIdRequired: true,
+      fullCommitRequired: true,
+      treeDerivedByService: true
+    }
+  };
+  return deepFreeze({ ...descriptor, contractSha256: digest(Buffer.from(canonicalJson(descriptor), "utf8")) });
+}
+
+function normalizeSourceRepositories(source) {
+  if (!isPlainObject(source) || !isPlainObject(source.primary) || !Array.isArray(source.companions) || source.companions.length > 15) {
+    invalid("resolved GitHub source topology is invalid");
+  }
+  const orderedCompanions = [...source.companions].sort((left, right) => compareCompanionSourceIds(left.sourceId, right.sourceId));
+  const repositories = [source.primary, ...orderedCompanions];
+  return repositories.map((repository, index) => {
+    const match = GITHUB_URI_PATTERN.exec(repository.repositoryUri ?? "");
+    if (
+      match === null
+      || !OPAQUE_DECIMAL_PATTERN.test(repository.numericRepositoryId ?? "")
+      || !COMMIT_PATTERN.test(repository.revisionObjectId ?? "")
+    ) invalid("resolved GitHub source lacks canonical owner, repository, numeric id, or full commit");
+    const executionRoots = validateExecutionRoots(repository.executionRoots, `source ${index + 1} executionRoots`);
+    const rightsDeclaration = validateRightsDeclaration(repository.rightsDeclaration, `source ${index + 1} rightsDeclaration`, executionRoots);
+    const sourceId = index === 0 ? primarySourceId() : repository.sourceId;
+    if (index > 0 && sourceId !== companionSourceId(index - 1)) {
+      invalid("companion source ids must be explicit, unique, and contiguous from source:companion-1");
+    }
+    return {
+      sourceId,
+      ownerHint: match[1],
+      repositoryHint: match[2],
+      repositoryIdHint: repository.numericRepositoryId,
+      requestedRevisionHint: repository.revisionObjectId,
+      purposeHint: index === 0 ? "project.primary" : "project.companion",
+      executionRoots,
+      rightsDeclaration
+    };
+  });
+}
+
+export function bindAutonomousSourceDeclarations({ source, sourceTopology }) {
+  if (!isPlainObject(sourceTopology)) {
+    pending(
+      "SOURCE_TOPOLOGY_REQUIRED",
+      "We need an explicit source partition and deployment-rights declaration before launch; this is not a safety finding."
+    );
+  }
+  assertExactObject(sourceTopology, ["companions", "primary"], "sourceTopology");
+  assertExactObject(sourceTopology.primary, ["executionRoots", "rightsDeclaration"], "sourceTopology.primary");
+  if (!Array.isArray(sourceTopology.companions) || sourceTopology.companions.length > 15) {
+    invalid("sourceTopology.companions must contain at most fifteen source declarations");
+  }
+  const primaryExecutionRoots = validateExecutionRoots(
+    sourceTopology.primary.executionRoots,
+    "sourceTopology.primary.executionRoots"
+  );
+  const primary = {
+    ...source.primary,
+    executionRoots: primaryExecutionRoots,
+    rightsDeclaration: validateRightsDeclaration(
+      sourceTopology.primary.rightsDeclaration,
+      "sourceTopology.primary.rightsDeclaration",
+      primaryExecutionRoots
+    )
+  };
+  const declarations = new Map();
+  for (const declaration of sourceTopology.companions) {
+    assertExactObject(
+      declaration,
+      ["executionRoots", "repositoryUri", "revisionObjectId", "rightsDeclaration", "sourceId"],
+      "sourceTopology companion"
+    );
+    const match = GITHUB_URI_PATTERN.exec(declaration.repositoryUri ?? "");
+    if (
+      match === null
+      || !COMMIT_PATTERN.test(declaration.revisionObjectId ?? "")
+      || !/^source:companion-[1-9][0-9]{0,2}$/u.test(declaration.sourceId ?? "")
+    ) {
+      invalid("a sourceTopology companion lacks a canonical GitHub repository or full commit");
+    }
+    const key = `${declaration.repositoryUri.toLowerCase()}\0${declaration.revisionObjectId}`;
+    if (declarations.has(key)) invalid("sourceTopology companion declarations must be unique");
+    const executionRoots = validateExecutionRoots(declaration.executionRoots, "sourceTopology companion executionRoots");
+    declarations.set(key, {
+      sourceId: declaration.sourceId,
+      executionRoots,
+      rightsDeclaration: validateRightsDeclaration(
+        declaration.rightsDeclaration,
+        "sourceTopology companion rightsDeclaration",
+        executionRoots
+      )
+    });
+  }
+  const companions = source.companions.map((repository) => {
+    const key = `${repository.repositoryUri.toLowerCase()}\0${repository.revisionObjectId}`;
+    const declaration = declarations.get(key);
+    if (declaration === undefined) {
+      pending(
+        "SOURCE_TOPOLOGY_MISMATCH",
+        "We need one explicit source partition and deployment-rights declaration for every resolved companion before launch; this is not a safety finding."
+      );
+    }
+    declarations.delete(key);
+    return { ...repository, ...declaration };
+  }).sort((left, right) => compareCompanionSourceIds(left.sourceId, right.sourceId));
+  if (declarations.size !== 0 || companions.length !== sourceTopology.companions.length) {
+    pending(
+      "SOURCE_TOPOLOGY_MISMATCH",
+      "The declared and resolved companion source sets differ; update the pinned source list before launch."
+    );
+  }
+  return deepFreeze({ ...source, primary, companions });
+}
+
+export function companionDescriptorsFromSourceTopology(sourceTopology) {
+  if (!isPlainObject(sourceTopology)) {
+    pending(
+      "SOURCE_TOPOLOGY_REQUIRED",
+      "We need an explicit source partition and deployment-rights declaration before launch; this is not a safety finding."
+    );
+  }
+  assertExactObject(sourceTopology, ["companions", "primary"], "sourceTopology");
+  assertExactObject(sourceTopology.primary, ["executionRoots", "rightsDeclaration"], "sourceTopology.primary");
+  const primaryExecutionRoots = validateExecutionRoots(
+    sourceTopology.primary.executionRoots,
+    "sourceTopology.primary.executionRoots"
+  );
+  validateRightsDeclaration(
+    sourceTopology.primary.rightsDeclaration,
+    "sourceTopology.primary.rightsDeclaration",
+    primaryExecutionRoots
+  );
+  if (!Array.isArray(sourceTopology.companions) || sourceTopology.companions.length > 15) {
+    invalid("sourceTopology.companions must contain at most fifteen source declarations");
+  }
+  const descriptors = sourceTopology.companions.map((source) => {
+    assertExactObject(
+      source,
+      ["executionRoots", "repositoryUri", "revisionObjectId", "rightsDeclaration", "sourceId"],
+      "sourceTopology companion"
+    );
+    if (
+      GITHUB_URI_PATTERN.exec(source.repositoryUri ?? "") === null
+      || !COMMIT_PATTERN.test(source.revisionObjectId ?? "")
+      || !/^source:companion-[1-9][0-9]{0,2}$/u.test(source.sourceId ?? "")
+    ) {
+      invalid("a sourceTopology companion lacks a canonical GitHub repository or full commit");
+    }
+    const executionRoots = validateExecutionRoots(source.executionRoots, "sourceTopology companion executionRoots");
+    validateRightsDeclaration(source.rightsDeclaration, "sourceTopology companion rightsDeclaration", executionRoots);
+    return {
+      repositoryUri: source.repositoryUri,
+      revisionObjectId: source.revisionObjectId,
+      sourcePaths: [],
+      contractPaths: []
+    };
+  });
+  const sourceIds = sourceTopology.companions.map(({ sourceId }) => sourceId).sort(compareCompanionSourceIds);
+  for (let index = 0; index < sourceIds.length; index += 1) {
+    if (sourceIds[index] !== companionSourceId(index)) {
+      invalid("sourceTopology companion source ids must be unique and contiguous from source:companion-1");
+    }
+  }
+  return descriptors;
+}
+
+function validateExecutionRoots(value, label) {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 32) {
+    pending("SOURCE_PARTITION_REQUIRED", `We need 1 to 32 explicit ${label}; this is not a safety finding.`);
+  }
+  const roots = value.map((entry) => {
+    if (
+      typeof entry !== "string"
+      || entry !== entry.normalize("NFC")
+      || Buffer.byteLength(entry, "utf8") > 256
+      || (entry !== "." && !REPOSITORY_PATH_PATTERN.test(entry))
+    ) invalid(`${label} contains a noncanonical repository path`);
+    return entry;
+  }).sort(compareUtf8);
+  if (new Set(roots).size !== roots.length || (roots.includes(".") && roots.length !== 1)) {
+    invalid(`${label} must be unique, non-overlapping, and use repository root only by itself`);
+  }
+  for (let index = 0; index < roots.length; index += 1) {
+    for (let prior = 0; prior < index; prior += 1) {
+      if (roots[index].startsWith(`${roots[prior]}/`) || roots[prior].startsWith(`${roots[index]}/`)) {
+        invalid(`${label} must not contain ancestor and descendant roots`);
+      }
+    }
+  }
+  return Object.freeze(roots);
+}
+
+function validateRightsDeclaration(value, label, executionRoots) {
+  if (!isPlainObject(value)) {
+    pending("SOURCE_RIGHTS_DECLARATION_REQUIRED", "We need proof of deployment rights before launch; this is not a contract-safety finding.");
+  }
+  assertExactObject(value, ["authorizationGrantId", "basis", "licenseBindings"], label);
+  const basis = value.basis;
+  const licenseBindings = value.licenseBindings;
+  const authorizationGrantId = value.authorizationGrantId;
+  const valid = (
+    basis === "applicant-original"
+      ? Array.isArray(licenseBindings) && licenseBindings.length === 0 && authorizationGrantId === null
+      : basis === "spdx-license"
+        ? Array.isArray(licenseBindings) && licenseBindings.length >= 1 && licenseBindings.length <= 16 && authorizationGrantId === null
+        : basis === "controller-authorization"
+          ? Array.isArray(licenseBindings) && licenseBindings.length === 0 && LOCAL_ID_PATTERN.test(authorizationGrantId ?? "")
+          : false
+  );
+  if (!valid) invalid(`${label} fields do not match the declared rights basis`);
+  const normalizedBindings = [];
+  const governedRoots = [];
+  const licensePaths = new Set();
+  for (const binding of licenseBindings) {
+    assertExactObject(binding, ["licensePath", "pathRoots", "spdxId"], `${label} license binding`);
+    if (!SPDX_ID_PATTERN.test(binding.spdxId ?? "")) invalid(`${label} contains an invalid SPDX id`);
+    if (
+      typeof binding.licensePath !== "string"
+      || binding.licensePath === "."
+      || binding.licensePath !== binding.licensePath.normalize("NFC")
+      || Buffer.byteLength(binding.licensePath, "utf8") > 256
+      || !REPOSITORY_PATH_PATTERN.test(binding.licensePath)
+      || licensePaths.has(binding.licensePath)
+    ) invalid(`${label} license paths must be unique canonical file paths`);
+    licensePaths.add(binding.licensePath);
+    const pathRoots = validateExecutionRoots(binding.pathRoots, `${label} license pathRoots`);
+    for (const root of pathRoots) {
+      if (!executionRoots.some((executionRoot) => (
+        executionRoot === "." || root === executionRoot || root.startsWith(`${executionRoot}/`)
+      ))) invalid(`${label} license pathRoots must stay inside executionRoots`);
+      for (const prior of governedRoots) {
+        if (root === prior || root.startsWith(`${prior}/`) || prior.startsWith(`${root}/`)) {
+          invalid(`${label} license pathRoots must be globally non-overlapping`);
+        }
+      }
+      governedRoots.push(root);
+    }
+    normalizedBindings.push({ spdxId: binding.spdxId, licensePath: binding.licensePath, pathRoots });
+  }
+  if (governedRoots.length > 64) invalid(`${label} exceeds sixty-four governed path roots`);
+  normalizedBindings.sort((left, right) => (
+    compareUtf8(left.spdxId, right.spdxId) || compareUtf8(left.licensePath, right.licensePath)
+  ));
+  return deepFreeze({ basis, licenseBindings: normalizedBindings, authorizationGrantId });
+}
+
+function validateOpenWorldGraph(value, sourceIds) {
+  if (!Array.isArray(value.chainProfileRequests) || value.chainProfileRequests.length > 32) invalid("chainProfileRequests is invalid");
+  const chainIds = new Set();
+  for (const chain of value.chainProfileRequests) {
+    assertExactObject(chain, ["namespaceHint", "profileHint", "referenceHint", "requestId"], "chain profile request");
+    if (!LOCAL_ID_PATTERN.test(chain.requestId ?? "") || chainIds.has(chain.requestId) || !KIND_PATTERN.test(chain.profileHint ?? "")) invalid("chain profile request is invalid");
+    chainIds.add(chain.requestId);
+  }
+  if (!Array.isArray(value.components) || value.components.length < 1 || value.components.length > 256) invalid("application components are invalid");
+  const componentIds = new Set();
+  for (const component of value.components) {
+    assertExactObject(component, ["chainRequestIds", "componentId", "kindHint", "reviewRelevanceHint", "sourceIds", "summary", "visibilityHint"], "application component");
+    if (!LOCAL_ID_PATTERN.test(component.componentId ?? "") || componentIds.has(component.componentId) || !KIND_PATTERN.test(component.kindHint ?? "")) invalid("application component is invalid");
+    normalizedPlainText(component.summary, 1, 4_000, "component summary");
+    assertReferenceSet(component.sourceIds, sourceIds, "component sourceIds");
+    assertReferenceSet(component.chainRequestIds, chainIds, "component chainRequestIds");
+    if (!new Set(["public-source", "private-source", "external-service", "opaque", "not-applicable"]).has(component.visibilityHint) || !new Set(["value-or-authority", "noncritical", "unknown"]).has(component.reviewRelevanceHint)) invalid("application component policy hint is invalid");
+    componentIds.add(component.componentId);
+  }
+  if (!Array.isArray(value.capabilityHints) || value.capabilityHints.length < 1 || value.capabilityHints.length > 256) invalid("capabilityHints is invalid");
+  const capabilityIds = new Set();
+  for (const capability of value.capabilityHints) {
+    assertExactObject(capability, ["capabilityId", "chainRequestIds", "componentIds", "controlsUserValueHint", "kindHint", "movesUserValueHint", "summary"], "capability hint");
+    if (!LOCAL_ID_PATTERN.test(capability.capabilityId ?? "") || capabilityIds.has(capability.capabilityId) || !KIND_PATTERN.test(capability.kindHint ?? "")) invalid("capability hint is invalid");
+    normalizedPlainText(capability.summary, 1, 4_000, "capability summary");
+    assertReferenceSet(capability.componentIds, componentIds, "capability componentIds", { requireOne: true });
+    assertReferenceSet(capability.chainRequestIds, chainIds, "capability chainRequestIds");
+    if (![true, false, null].includes(capability.movesUserValueHint) || ![true, false, null].includes(capability.controlsUserValueHint)) invalid("capability value hints are invalid");
+    capabilityIds.add(capability.capabilityId);
+  }
+}
+
+function assertReferenceSet(values, known, label, { requireOne = false } = {}) {
+  if (!Array.isArray(values) || values.length > 32 || (requireOne && values.length === 0)) invalid(`${label} is invalid`);
+  const seen = new Set();
+  for (const value of values) {
+    if (!LOCAL_ID_PATTERN.test(value ?? "") || !known.has(value) || seen.has(value)) invalid(`${label} contains an unknown or duplicate id`);
+    seen.add(value);
+  }
+}
+
+function validateIdentity(identity, expectedNamespace, label) {
+  assertExactObject(identity, ["namespace", "value"], label);
+  if (
+    identity.namespace !== expectedNamespace
+    || typeof identity.value !== "string"
+    || identity.value.length < 1
+    || identity.value.length > 512
+    || (identity.value.startsWith("0x") && !/^0x(?:[0-9a-f]{2})+$/u.test(identity.value))
+    || (/^eip155:[0-9]+$/u.test(identity.namespace) && !ADDRESS_PATTERN.test(identity.value))
+  ) invalid(`${label} is not a canonical selected-chain identity`);
+}
+
+function validateUint256Decimal(value, label) {
+  if (!UINT256_DECIMAL_PATTERN.test(value ?? "") || BigInt(value) > UINT256_MAXIMUM) {
+    invalid(`${label} must be a canonical uint256 decimal string`);
+  }
+}
+
+function validateAddressLocators({
+  locators,
+  hexadecimalBytes,
+  targetSet,
+  releaseModuleSelectionSet,
+  externalDependencySet,
+  internalChildSet,
+  declaredIdentitySet,
+  routeAdapterId,
+  label
+}) {
+  if (!Array.isArray(locators) || locators.length > 128) invalid(`${label} must be a bounded array`);
+  const byteLength = (hexadecimalBytes.length - 2) / 2;
+  let previous = null;
+  for (const locator of locators) {
+    const reference = validateAddressLocatorReference({
+      locator,
+      targetSet,
+      releaseModuleSelectionSet,
+      externalDependencySet,
+      internalChildSet,
+      declaredIdentitySet,
+      routeAdapterId,
+      label
+    });
+    const width = locator.encoding === "abi-address-word"
+      ? 32
+      : locator.encoding === "packed-address-20"
+        ? 20
+        : null;
+    if (
+      width === null
+      || !Number.isSafeInteger(locator.byteOffset)
+      || locator.byteOffset < 0
+      || locator.byteOffset > 1_048_576
+      || locator.byteOffset + width > byteLength
+    ) invalid(`${label} contains an invalid reference, offset, or encoding`);
+    const locatorKey = [locator.byteOffset, reference, locator.kind, locator.encoding];
+    if (previous !== null) {
+      const order = compareAddressLocatorKeys(previous.key, locatorKey);
+      if (order >= 0) invalid(`${label} must be unique and canonically sorted`);
+      if (locator.byteOffset < previous.end) invalid(`${label} contains overlapping address placeholders`);
+    }
+    const start = 2 + locator.byteOffset * 2;
+    const placeholder = hexadecimalBytes.slice(start, start + width * 2);
+    if (!/^0+$/u.test(placeholder)) invalid(`${label} must point at an all-zero placeholder of the declared width`);
+    previous = { key: locatorKey, end: locator.byteOffset + width };
+  }
+  return locators;
+}
+
+function compareAddressLocatorKeys(left, right) {
+  const offsetOrder = left[0] - right[0];
+  if (offsetOrder !== 0) return offsetOrder;
+  const referenceOrder = compareUtf8(left[1], right[1]);
+  if (referenceOrder !== 0) return referenceOrder;
+  const kindOrder = compareUtf8(left[2], right[2]);
+  return kindOrder !== 0 ? kindOrder : compareUtf8(left[3], right[3]);
+}
+
+function validateAddressLocatorReference({
+  locator,
+  targetSet,
+  releaseModuleSelectionSet,
+  externalDependencySet,
+  internalChildSet,
+  declaredIdentitySet,
+  routeAdapterId,
+  label
+}) {
+  if (locator?.kind === "target") {
+    assertExactObject(locator, ["byteOffset", "encoding", "kind", "targetId"], label);
+    if (!targetSet.has(locator.targetId)) invalid(`${label} references an unknown target`);
+    return locator.targetId;
+  }
+  if (locator?.kind === "release-module-selection") {
+    assertExactObject(locator, ["byteOffset", "encoding", "kind", "selectionId"], label);
+    if (!releaseModuleSelectionSet.has(locator.selectionId)) invalid(`${label} references an unknown release module selection`);
+    return locator.selectionId;
+  }
+  if (locator?.kind === "external-onchain-dependency") {
+    assertExactObject(locator, ["byteOffset", "dependencyId", "encoding", "kind"], label);
+    if (!externalDependencySet.has(locator.dependencyId)) invalid(`${label} references an unknown external dependency`);
+    return locator.dependencyId;
+  }
+  if (locator?.kind === "launch-session-wallet") {
+    assertExactObject(locator, ["byteOffset", "encoding", "kind"], label);
+    return "launch-session-wallet";
+  }
+  if (locator?.kind === "internal-child") {
+    assertExactObject(locator, ["byteOffset", "childId", "encoding", "kind"], label);
+    if (!internalChildSet.has(locator.childId)) invalid(`${label} references an unknown internal child`);
+    return locator.childId;
+  }
+  if (locator?.kind === "declared-identity") {
+    assertExactObject(locator, ["byteOffset", "encoding", "identityId", "kind"], label);
+    if (!declaredIdentitySet.has(locator.identityId)) invalid(`${label} references an unknown declared identity`);
+    return locator.identityId;
+  }
+  if (locator?.kind === "release-launch-adapter") {
+    assertExactObject(locator, ["adapterId", "byteOffset", "encoding", "kind"], label);
+    if (locator.adapterId !== routeAdapterId) invalid(`${label} references a different launch adapter`);
+    return locator.adapterId;
+  }
+  invalid(`${label} contains an unsupported address locator kind`);
+}
+
+function assertAcyclicConstructorDependencies(dependencies) {
+  const state = new Map();
+  const visit = (targetId) => {
+    const current = state.get(targetId) ?? 0;
+    if (current === 1) invalid("constructor address locators contain a dependency cycle; move at least one cyclic reference to initializer calldata");
+    if (current === 2) return;
+    state.set(targetId, 1);
+    for (const dependency of dependencies.get(targetId) ?? []) visit(dependency);
+    state.set(targetId, 2);
+  };
+  for (const targetId of dependencies.keys()) visit(targetId);
+}
+
+function componentSummary(component) {
+  const candidate = typeof component.attributes?.summary === "string"
+    ? component.attributes.summary
+    : `${component.kind} component declared by the exact source-defined launch graph.`;
+  return normalizedPlainText(candidate, 1, 4_000, `component ${component.componentId} summary`);
+}
+
+function normalizedPlainText(value, minimum, maximum, label) {
+  if (typeof value !== "string" || value.normalize("NFC") !== value || CONTROL_OR_BIDI_PATTERN.test(value) || MUTABLE_URL_PATTERN.test(value)) {
+    invalid(`${label} must be bounded plain text without mutable URLs`);
+  }
+  const normalized = value.trim().replace(/\s+/gu, " ");
+  if (normalized.length < minimum || normalized.length > maximum) invalid(`${label} length is invalid`);
+  return normalized;
+}
+
+function sortedUnique(values, label) {
+  if (!Array.isArray(values)) invalid(`${label} must be an array`);
+  const sorted = [...values].sort(compareUtf8);
+  if (sorted.some((value, index) => typeof value !== "string" || value !== values[index] || (index > 0 && value === sorted[index - 1]))) {
+    invalid(`${label} must be unique and UTF-8 sorted`);
+  }
+  return sorted;
+}
+
+function assertSafeDataTree(value, { forbidUrls }) {
+  let nodes = 0;
+  const visit = (current, path) => {
+    nodes += 1;
+    if (nodes > 65_536) invalid("admission data exceeds its bounded node limit");
+    if (typeof current === "number" && !Number.isSafeInteger(current)) invalid(`${path} contains an unsafe number`);
+    if (typeof current === "string") {
+      if (current.normalize("NFC") !== current || CONTROL_OR_BIDI_PATTERN.test(current) || (forbidUrls && MUTABLE_URL_PATTERN.test(current)) || SECRET_VALUE_PATTERNS.some((pattern) => pattern.test(current))) invalid(`${path} contains unsafe public text`);
+      return;
+    }
+    if (Array.isArray(current)) {
+      current.forEach((entry, index) => visit(entry, `${path}/${index}`));
+      return;
+    }
+    if (!isPlainObject(current)) return;
+    for (const [key, child] of Object.entries(current)) {
+      if (SECRET_KEY_PATTERN.test(key)) invalid(`${path}/${key} is a forbidden credential field`);
+      visit(child, `${path}/${key}`);
+    }
+  };
+  visit(value, "");
+}
+
+function assertExactObject(value, keys, label) {
+  if (!isPlainObject(value) || !arraysEqual(Object.keys(value).sort(compareUtf8), [...keys].sort(compareUtf8))) {
+    invalid(`${label} must use its exact closed field set`);
+  }
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function arraysEqual(left, right) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function compareUtf8(left, right) {
+  return Buffer.compare(Buffer.from(String(left), "utf8"), Buffer.from(String(right), "utf8"));
+}
+
+function compareCompanionSourceIds(left, right) {
+  const leftIndex = Number(String(left).slice("source:companion-".length));
+  const rightIndex = Number(String(right).slice("source:companion-".length));
+  return leftIndex - rightIndex;
+}
+
+function digest(bytes) {
+  return `sha256:${crypto.createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function deepFreeze(value) {
+  if (Array.isArray(value)) value.forEach(deepFreeze);
+  else if (isPlainObject(value)) Object.values(value).forEach(deepFreeze);
+  return Object.freeze(value);
+}
+
+function invalid(message) {
+  throw new CliFailure("AUTONOMOUS_ADMISSION_INVALID", message, { exitCode: 1 });
+}
+
+function pending(code, message) {
+  throw new CliFailure(code, message, {
+    exitCode: 1,
+    details: { classification: "analysis_pending", safetyFinding: false }
+  });
+}

--- a/skills/programmable-v4-hook-builder/scripts/cli-runtime.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/cli-runtime.mjs
@@ -1,0 +1,134 @@
+import childProcess from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { canonicalJson } from "./submission-core.mjs";
+
+export const CLI_SCHEMA_VERSION = "1.0.0";
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const MAX_CHILD_OUTPUT_BYTES = 32_000_000;
+const MAX_CHILD_RUNTIME_MS = 120_000;
+
+export class CliFailure extends Error {
+  constructor(code, message, { exitCode = 2, details = null } = {}) {
+    super(sanitizeMessage(message));
+    this.name = "CliFailure";
+    this.code = code;
+    this.exitCode = exitCode;
+    this.details = details;
+  }
+}
+
+export function emitSuccess(command, result) {
+  process.stdout.write(`${canonicalJson({
+    schemaVersion: CLI_SCHEMA_VERSION,
+    command,
+    ok: true,
+    result
+  })}\n`);
+}
+
+export function emitFailure(command, error) {
+  const failure = normalizeFailure(error);
+  const payload = {
+    schemaVersion: CLI_SCHEMA_VERSION,
+    command,
+    ok: false,
+    error: {
+      code: failure.code,
+      message: failure.message
+    }
+  };
+  if (failure.details !== null) payload.error.details = failure.details;
+  process.stdout.write(`${canonicalJson(payload)}\n`);
+  return failure.exitCode;
+}
+
+export function normalizeFailure(error) {
+  if (error instanceof CliFailure) return error;
+  return new CliFailure("INTERNAL_ERROR", "the command failed without a safe diagnostic", {
+    exitCode: 2
+  });
+}
+
+export function runBundledCommand(script, args, { cwd, failureCode = "COMMAND_FAILED" } = {}) {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*\.mjs$/.test(script)) {
+    throw new CliFailure("INTERNAL_ERROR", "invalid bundled command identity");
+  }
+  const result = childProcess.spawnSync(
+    process.execPath,
+    [path.join(scriptDirectory, script), ...args],
+    {
+      cwd,
+      encoding: "utf8",
+      shell: false,
+      env: safeChildEnvironment(),
+      timeout: MAX_CHILD_RUNTIME_MS,
+      maxBuffer: MAX_CHILD_OUTPUT_BYTES
+    }
+  );
+  if (result.error) {
+    throw new CliFailure(failureCode, `cannot execute ${script}: ${result.error.message}`);
+  }
+  const parsed = parseJsonOutput(result.stdout);
+  if (result.status !== 0) {
+    const diagnostic = sanitizeMessage(result.stderr) || `${script} exited with status ${result.status}`;
+    throw new CliFailure(failureCode, diagnostic, {
+      exitCode: result.status === 1 ? 1 : 2,
+      details: parsed
+    });
+  }
+  return { parsed, stdout: result.stdout.trim() };
+}
+
+export function requireJsonResult(commandResult, command) {
+  if (commandResult.parsed === null) {
+    throw new CliFailure("INVALID_COMMAND_OUTPUT", `${command} did not return valid JSON`);
+  }
+  return commandResult.parsed;
+}
+
+export function sanitizeMessage(value) {
+  return String(value ?? "")
+    .replace(/\u001b\[[0-?]*[ -/]*[@-~]/gu, "")
+    .replace(/[\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim()
+    .slice(0, 1_000);
+}
+
+function parseJsonOutput(output) {
+  const source = String(output ?? "").trim();
+  if (source.length === 0) return null;
+  try {
+    return JSON.parse(source);
+  } catch {
+    return null;
+  }
+}
+
+function safeChildEnvironment() {
+  const environment = { ...process.env };
+  for (const name of Object.keys(environment)) {
+    if (/^(?:GIT|SSH)_/iu.test(name) || ["NODE_OPTIONS", "NODE_PATH"].includes(name.toUpperCase())) {
+      delete environment[name];
+    }
+  }
+  const nullDevice = process.platform === "win32" ? "NUL" : "/dev/null";
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = nullDevice;
+  environment.GIT_CONFIG_COUNT = "3";
+  environment.GIT_CONFIG_KEY_0 = "core.fsmonitor";
+  environment.GIT_CONFIG_VALUE_0 = "false";
+  environment.GIT_CONFIG_KEY_1 = "core.hooksPath";
+  environment.GIT_CONFIG_VALUE_1 = nullDevice;
+  environment.GIT_CONFIG_KEY_2 = "core.untrackedCache";
+  environment.GIT_CONFIG_VALUE_2 = "false";
+  environment.GIT_TERMINAL_PROMPT = "0";
+  environment.GIT_OPTIONAL_LOCKS = "0";
+  environment.GIT_LITERAL_PATHSPECS = "1";
+  environment.GIT_LFS_SKIP_SMUDGE = "1";
+  environment.GIT_NO_REPLACE_OBJECTS = "1";
+  environment.GIT_PAGER = "cat";
+  return environment;
+}

--- a/skills/programmable-v4-hook-builder/scripts/github-exact-object-resolver.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/github-exact-object-resolver.mjs
@@ -1,0 +1,1087 @@
+import childProcess from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { TextDecoder } from "node:util";
+
+import {
+  GITHUB_PUBLIC_SOURCE_CONTRACT_V1,
+  GitHubPublicSourceError
+} from "./github-public-source-core.mjs";
+import {
+  isCanonicalReviewTargetPath,
+  isGitLfsPointer,
+  REVIEW_TARGET_CONTRACT_V1
+} from "./review-target-contract.mjs";
+
+export const GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1 = Object.freeze({
+  name: "GitHubPublicGitObjectResolverV1",
+  minimumGitVersion: "2.49.0",
+  maximumFiles: REVIEW_TARGET_CONTRACT_V1.maximumFiles,
+  maximumFileBytes: REVIEW_TARGET_CONTRACT_V1.maximumFileBytes,
+  maximumTotalBytes: REVIEW_TARGET_CONTRACT_V1.maximumTotalBytes,
+  maximumPathDepth: REVIEW_TARGET_CONTRACT_V1.maximumPathDepth,
+  maximumTemporaryRepositoryBytes: 67_108_864,
+  maximumTemporaryFileBytes: 67_108_864,
+  maximumAddressSpaceBytes: 536_870_912,
+  maximumCpuSeconds: 20,
+  minimumTimeoutMs: 1,
+  maximumTimeoutMs: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.maximumTimeoutMs
+});
+
+const REQUEST_KEYS = new Set([
+  "repositoryUri",
+  "revisionObjectId",
+  "treeObjectId",
+  "paths",
+  "timeoutMs",
+  "maximumFileBytes",
+  "maximumTotalBytes"
+]);
+const LOWER_HEX_40 = /^[0-9a-f]{40}$/u;
+const GITHUB_OWNER = /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/u;
+const GITHUB_REPOSITORY = /^[a-z0-9._-]{1,100}$/u;
+const REGULAR_BLOB_MODES = new Set(["100644", "100755"]);
+const STRICT_UTF8 = new TextDecoder("utf-8", { fatal: true });
+const TEMPORARY_PREFIX = "programmable-github-objects-";
+const SMALL_COMMAND_OUTPUT_BYTES = 65_536;
+const COMMIT_OUTPUT_BYTES = 1_048_576;
+const TREE_LIST_OUTPUT_BYTES = 1_048_576;
+const BATCH_PROTOCOL_OVERHEAD_BYTES = 1_048_576;
+const KILL_GRACE_MS = 250;
+const TEMPORARY_SIZE_POLL_MS = 25;
+const MAXIMUM_TEMPORARY_ENTRIES = 65_536;
+const SAFE_GIT_CONFIG = Object.freeze([
+  "-c", "credential.helper=",
+  "-c", "credential.interactive=never",
+  "-c", "core.hooksPath=/dev/null",
+  "-c", "core.attributesFile=/dev/null",
+  "-c", "core.fsmonitor=false",
+  "-c", "core.untrackedCache=false",
+  "-c", "protocol.allow=never",
+  "-c", "protocol.version=2",
+  "-c", "protocol.https.allow=always",
+  "-c", "protocol.file.allow=never",
+  "-c", "protocol.ext.allow=never",
+  "-c", "protocol.ssh.allow=never",
+  "-c", "http.followRedirects=false",
+  "-c", "submodule.recurse=false",
+  "-c", "fetch.recurseSubmodules=false",
+  "-c", "fetch.fsckObjects=true",
+  "-c", "transfer.fsckObjects=true",
+  "-c", "core.deltaBaseCacheLimit=16m",
+  "-c", "core.packedGitWindowSize=16m",
+  "-c", "core.packedGitLimit=64m",
+  "-c", "pack.deltaCacheLimit=16m",
+  "-c", "pack.windowMemory=32m",
+  "-c", "pack.threads=1",
+  "-c", "index.threads=1",
+  "-c", "maintenance.auto=false",
+  "-c", "gc.auto=0"
+]);
+
+class GitCommandExecutionError extends Error {
+  constructor(reason, message, options = {}) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "GitCommandExecutionError";
+    this.reason = reason;
+  }
+}
+
+/**
+ * Creates an anonymous exact-object resolver. Factory options are trusted
+ * process dependencies; repository content and every resolver request remain
+ * untrusted data.
+ */
+export function createAnonymousGitHubExactObjectResolverV1(options = {}) {
+  assertFactoryOptions(options);
+  const runGit = options.runGit ?? runBoundedExactGitProcessV1;
+  const gitExecutable = options.gitExecutable ?? "git";
+  const temporaryDirectoryRoot = path.resolve(options.temporaryDirectoryRoot ?? os.tmpdir());
+  const platform = options.platform ?? process.platform;
+
+  return async function resolveAnonymousGitHubExactObjectsV1(input) {
+    const request = validateRequest(input);
+    if (platform !== "darwin" && platform !== "linux") {
+      throw toolingBlocked("this resolver supports macOS and Linux only");
+    }
+
+    const state = {
+      deadline: performance.now() + request.timeoutMs,
+      gitExecutable,
+      runGit
+    };
+    let temporaryDirectory = null;
+    let operationFailed = false;
+
+    try {
+      await requireBackfillCapability(state);
+      temporaryDirectory = await fs.promises.mkdtemp(path.join(temporaryDirectoryRoot, TEMPORARY_PREFIX));
+      const gitDirectory = path.join(temporaryDirectory, "repository.git");
+      await initializeBareRepository(state, gitDirectory, request.repositoryUri);
+      await fetchExactCommit(state, gitDirectory, request.revisionObjectId);
+      await validateCommitAndTree(state, gitDirectory, request.revisionObjectId, request.treeObjectId);
+
+      if (request.paths.length === 0) {
+        return { records: new Map() };
+      }
+
+      const treeRecords = await resolveTreeRecords(state, gitDirectory, request.treeObjectId, request.paths);
+      await writeSparseSelection(gitDirectory, request.paths);
+      await backfillSparseBlobs(state, gitDirectory);
+      const objectSizes = await readObjectSizes(state, gitDirectory, treeRecords);
+      enforceContentLimits(request, treeRecords, objectSizes);
+      const objectBytes = await readBlobObjects(
+        state,
+        gitDirectory,
+        treeRecords,
+        request.maximumTotalBytes
+      );
+      return { records: buildResultRecords(treeRecords, objectSizes, objectBytes) };
+    } catch (error) {
+      operationFailed = true;
+      throw normalizeResolverError(error);
+    } finally {
+      if (temporaryDirectory !== null) {
+        try {
+          await removeExactTemporaryDirectory(temporaryDirectory, temporaryDirectoryRoot);
+        } catch (error) {
+          if (!operationFailed) {
+            throw toolingBlocked("temporary repository cleanup failed", error);
+          }
+        }
+      }
+    }
+  };
+}
+
+function validateRequest(input) {
+  if (!isPlainObject(input)) invalidRequest("exact-object request must be an object");
+  const keys = Object.keys(input);
+  if (keys.length !== REQUEST_KEYS.size || keys.some((key) => !REQUEST_KEYS.has(key))) {
+    invalidRequest("exact-object request fields did not match the closed contract");
+  }
+
+  const repositoryUri = normalizeRepositoryUri(input.repositoryUri);
+  if (!LOWER_HEX_40.test(input.revisionObjectId ?? "")) {
+    invalidRequest("revisionObjectId must be a lowercase 40-hex Git object id");
+  }
+  if (!LOWER_HEX_40.test(input.treeObjectId ?? "")) {
+    invalidRequest("treeObjectId must be a lowercase 40-hex Git object id");
+  }
+  if (!Array.isArray(input.paths) || input.paths.length > GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumFiles) {
+    invalidRequest("paths must be an array within the file-count limit");
+  }
+  const paths = [...input.paths];
+  if (paths.some((entry) => !isCanonicalReviewTargetPath(entry))) {
+    invalidRequest("every path must satisfy the canonical review-target path contract");
+  }
+  if (new Set(paths).size !== paths.length) {
+    invalidRequest("paths must not contain duplicates");
+  }
+  paths.sort(compareUtf8);
+
+  const timeoutMs = boundedPositiveInteger(
+    input.timeoutMs,
+    GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTimeoutMs,
+    "timeoutMs"
+  );
+  const maximumFileBytes = boundedPositiveInteger(
+    input.maximumFileBytes,
+    GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumFileBytes,
+    "maximumFileBytes"
+  );
+  const maximumTotalBytes = boundedPositiveInteger(
+    input.maximumTotalBytes,
+    GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTotalBytes,
+    "maximumTotalBytes"
+  );
+  if (maximumFileBytes > maximumTotalBytes) {
+    invalidRequest("maximumFileBytes cannot exceed maximumTotalBytes");
+  }
+
+  return Object.freeze({
+    repositoryUri,
+    revisionObjectId: input.revisionObjectId,
+    treeObjectId: input.treeObjectId,
+    paths: Object.freeze(paths),
+    timeoutMs,
+    maximumFileBytes,
+    maximumTotalBytes
+  });
+}
+
+function normalizeRepositoryUri(value) {
+  if (typeof value !== "string" || /[\u0000-\u001f\u007f-\u009f]/u.test(value)) {
+    invalidRequest("repositoryUri must be a canonical public github.com URL");
+  }
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    invalidRequest("repositoryUri must be a canonical public github.com URL");
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (
+    parsed.protocol !== "https:"
+    || parsed.hostname !== "github.com"
+    || parsed.port !== ""
+    || parsed.username !== ""
+    || parsed.password !== ""
+    || parsed.search !== ""
+    || parsed.hash !== ""
+    || segments.length !== 2
+    || !GITHUB_OWNER.test(segments[0])
+    || !GITHUB_REPOSITORY.test(segments[1])
+    || segments[1].endsWith(".git")
+    || value !== `https://github.com/${segments[0]}/${segments[1]}`
+  ) {
+    invalidRequest("repositoryUri must be a canonical lowercase https://github.com/owner/repository URL");
+  }
+  return value;
+}
+
+async function requireBackfillCapability(state) {
+  const versionResult = await invokeGit(state, ["--version"], {
+    maximumOutputBytes: SMALL_COMMAND_OUTPUT_BYTES,
+    phase: "capability"
+  });
+  if (versionResult.status !== 0) {
+    throw toolingBlocked(`Git ${GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.minimumGitVersion} or newer is required`);
+  }
+  const version = parseGitVersion(versionResult.stdout);
+  if (
+    version === null
+    || compareNumericVersion(version, GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.minimumGitVersion) < 0
+  ) {
+    throw toolingBlocked(`Git ${GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.minimumGitVersion} or newer is required`);
+  }
+  const result = await invokeGit(state, ["backfill", "-h"], {
+    acceptedStatuses: null,
+    maximumOutputBytes: SMALL_COMMAND_OUTPUT_BYTES,
+    phase: "capability"
+  });
+  const output = Buffer.concat([result.stdout, result.stderr]).toString("utf8");
+  if (!/(?:^|\n)usage: git backfill(?: |\n)/u.test(output)) {
+    throw toolingBlocked("git backfill --sparse is required");
+  }
+}
+
+function parseGitVersion(output) {
+  let source;
+  try {
+    source = STRICT_UTF8.decode(output);
+  } catch {
+    return null;
+  }
+  const match = /^git version ([0-9]+\.[0-9]+\.[0-9]+)(?:[^0-9.]|$)/u.exec(source.trim());
+  return match?.[1] ?? null;
+}
+
+function compareNumericVersion(left, right) {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return leftParts[index] - rightParts[index];
+  }
+  return 0;
+}
+
+async function initializeBareRepository(state, gitDirectory, repositoryUri) {
+  const init = await invokeGit(state, ["init", "--quiet", "--bare", "--object-format=sha1", gitDirectory], {
+    maximumOutputBytes: SMALL_COMMAND_OUTPUT_BYTES,
+    phase: "init"
+  });
+  requireSuccess(init, "cannot initialize the isolated bare repository");
+
+  const remoteUrl = `${repositoryUri}.git`;
+  const config = [
+    "[core]",
+    "\trepositoryformatversion = 0",
+    "\tfilemode = true",
+    "\tbare = true",
+    "\thooksPath = /dev/null",
+    "\tattributesFile = /dev/null",
+    "\tsparseCheckout = true",
+    "\tsparseCheckoutCone = false",
+    "[credential]",
+    "\thelper =",
+    "\tinteractive = never",
+    "[protocol]",
+    "\tallow = never",
+    "\tversion = 2",
+    "[protocol \"https\"]",
+    "\tallow = always",
+    "[http]",
+    "\tfollowRedirects = false",
+    "[fetch]",
+    "\trecurseSubmodules = false",
+    "\tfsckObjects = true",
+    "[transfer]",
+    "\tfsckObjects = true",
+    "[maintenance]",
+    "\tauto = false",
+    "[gc]",
+    "\tauto = 0",
+    "[remote \"origin\"]",
+    `\turl = ${remoteUrl}`,
+    "\tpromisor = true",
+    "\tpartialclonefilter = blob:none",
+    ""
+  ].join("\n");
+  try {
+    await fs.promises.mkdir(path.join(gitDirectory, "info"), { recursive: true, mode: 0o700 });
+    await fs.promises.writeFile(path.join(gitDirectory, "config"), config, { encoding: "utf8", mode: 0o600 });
+  } catch (error) {
+    throw toolingBlocked("cannot configure the isolated bare repository", error);
+  }
+}
+
+async function fetchExactCommit(state, gitDirectory, revisionObjectId) {
+  const result = await invokeRepositoryGit(state, gitDirectory, [
+    "fetch",
+    "--quiet",
+    "--no-tags",
+    "--no-write-fetch-head",
+    "--no-recurse-submodules",
+    "--depth=1",
+    "--filter=blob:none",
+    "origin",
+    revisionObjectId
+  ], {
+    maximumOutputBytes: SMALL_COMMAND_OUTPUT_BYTES,
+    phase: "fetch",
+    monitoredDirectory: gitDirectory
+  });
+  if (result.status !== 0) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_UNAVAILABLE",
+      "GitHub anonymous smart HTTP was unavailable while reading the REST-verified exact commit",
+      { retryable: true }
+    );
+  }
+  try {
+    await fs.promises.writeFile(path.join(gitDirectory, "HEAD"), `${revisionObjectId}\n`, {
+      encoding: "ascii",
+      mode: 0o600
+    });
+  } catch (error) {
+    throw toolingBlocked("cannot bind HEAD to the exact fetched commit", error);
+  }
+}
+
+async function validateCommitAndTree(state, gitDirectory, revisionObjectId, treeObjectId) {
+  const commitResult = await invokeRepositoryGit(state, gitDirectory, ["cat-file", "--batch"], {
+    input: Buffer.from(`${revisionObjectId}\n`, "ascii"),
+    maximumOutputBytes: COMMIT_OUTPUT_BYTES,
+    phase: "commit",
+    disableLazyFetch: true
+  });
+  requireSuccess(commitResult, "cannot read the exact fetched commit object");
+  const commitObjects = parseBatchObjects(commitResult.stdout, [revisionObjectId]);
+  const commit = commitObjects.get(revisionObjectId);
+  if (commit?.type !== "commit") {
+    throw new GitHubPublicSourceError("GITHUB_COMMIT_MISMATCH", "the requested revision was not an exact commit object");
+  }
+  verifyGitObjectId("commit", commit.bytes, revisionObjectId, "GITHUB_COMMIT_MISMATCH");
+  const firstLineEnd = commit.bytes.indexOf(0x0a);
+  const firstLine = firstLineEnd === -1 ? "" : commit.bytes.subarray(0, firstLineEnd).toString("ascii");
+  if (firstLine !== `tree ${treeObjectId}`) {
+    throw new GitHubPublicSourceError("GITHUB_TREE_MISMATCH", "the exact commit did not bind the expected root tree");
+  }
+
+  const treeResult = await invokeRepositoryGit(state, gitDirectory, [
+    "cat-file",
+    "--batch-check=%(objectname) %(objecttype) %(objectsize)"
+  ], {
+    input: Buffer.from(`${treeObjectId}\n`, "ascii"),
+    maximumOutputBytes: SMALL_COMMAND_OUTPUT_BYTES,
+    phase: "tree",
+    disableLazyFetch: true
+  });
+  requireSuccess(treeResult, "cannot inspect the expected root tree object");
+  const headers = parseBatchCheck(treeResult.stdout, [treeObjectId]);
+  if (headers.get(treeObjectId)?.type !== "tree") {
+    throw new GitHubPublicSourceError("GITHUB_TREE_NOT_REACHABLE", "the expected root tree object was unavailable");
+  }
+}
+
+async function resolveTreeRecords(state, gitDirectory, treeObjectId, requestedPaths) {
+  const result = await invokeRepositoryGit(state, gitDirectory, [
+    "ls-tree",
+    "-z",
+    "--full-tree",
+    treeObjectId,
+    "--",
+    ...requestedPaths
+  ], {
+    maximumOutputBytes: TREE_LIST_OUTPUT_BYTES,
+    phase: "tree-paths",
+    disableLazyFetch: true
+  });
+  requireSuccess(result, "cannot resolve declared paths in the exact root tree");
+  return parseTreeRecords(result.stdout, requestedPaths);
+}
+
+async function writeSparseSelection(gitDirectory, paths) {
+  const contents = `${paths.map((entry) => `/${escapeSparsePattern(entry)}`).join("\n")}\n`;
+  try {
+    await fs.promises.writeFile(path.join(gitDirectory, "info", "sparse-checkout"), contents, {
+      encoding: "utf8",
+      mode: 0o600
+    });
+  } catch (error) {
+    throw toolingBlocked("cannot create the literal sparse object selection", error);
+  }
+}
+
+async function backfillSparseBlobs(state, gitDirectory) {
+  const result = await invokeRepositoryGit(state, gitDirectory, ["backfill", "--sparse"], {
+    maximumOutputBytes: SMALL_COMMAND_OUTPUT_BYTES,
+    phase: "backfill",
+    monitoredDirectory: gitDirectory
+  });
+  if (result.status !== 0) {
+    const output = Buffer.concat([result.stdout, result.stderr]).toString("utf8");
+    if (/not a git command|unknown (?:command|option)|usage: git backfill/iu.test(output)) {
+      throw toolingBlocked("git backfill --sparse is required");
+    }
+    throw new GitHubPublicSourceError(
+      "GITHUB_UPSTREAM_REJECTED",
+      "GitHub did not provide the declared blobs through anonymous sparse backfill",
+      { retryable: true }
+    );
+  }
+}
+
+async function readObjectSizes(state, gitDirectory, treeRecords) {
+  const objectIds = uniqueObjectIds(treeRecords);
+  const result = await invokeRepositoryGit(state, gitDirectory, [
+    "cat-file",
+    "--batch-check=%(objectname) %(objecttype) %(objectsize)"
+  ], {
+    input: Buffer.from(`${objectIds.join("\n")}\n`, "ascii"),
+    maximumOutputBytes: SMALL_COMMAND_OUTPUT_BYTES,
+    phase: "blob-sizes",
+    disableLazyFetch: true
+  });
+  requireSuccess(result, "cannot inspect the backfilled blob objects");
+  return parseBatchCheck(result.stdout, objectIds);
+}
+
+function enforceContentLimits(request, treeRecords, objectSizes) {
+  let totalBytes = 0;
+  for (const record of treeRecords.values()) {
+    const header = objectSizes.get(record.objectId);
+    if (header?.type !== "blob") {
+      throw new GitHubPublicSourceError(
+        "GITHUB_DECLARED_PATH_NOT_FOUND",
+        "A declared source blob was unavailable after sparse backfill"
+      );
+    }
+    if (header.size > request.maximumFileBytes) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_RESPONSE_TOO_LARGE",
+        "A declared source blob exceeds the bounded inert-content limit"
+      );
+    }
+    totalBytes += header.size;
+    if (totalBytes > request.maximumTotalBytes) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_RESPONSE_TOO_LARGE",
+        "Declared source blobs exceed the aggregate inert-content limit"
+      );
+    }
+  }
+}
+
+async function readBlobObjects(state, gitDirectory, treeRecords, maximumTotalBytes) {
+  const objectIds = uniqueObjectIds(treeRecords);
+  const result = await invokeRepositoryGit(state, gitDirectory, ["cat-file", "--batch"], {
+    input: Buffer.from(`${objectIds.join("\n")}\n`, "ascii"),
+    maximumOutputBytes: maximumTotalBytes + BATCH_PROTOCOL_OVERHEAD_BYTES,
+    phase: "blobs",
+    disableLazyFetch: true
+  });
+  requireSuccess(result, "cannot read the backfilled blob objects");
+  const objects = parseBatchObjects(result.stdout, objectIds);
+  for (const [objectId, object] of objects) {
+    if (object.type !== "blob") {
+      throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "a declared Git object was not a blob");
+    }
+    verifyGitObjectId("blob", object.bytes, objectId, "GITHUB_PROTOCOL_ERROR");
+    if (isGitLfsPointer(object.bytes)) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_DECLARED_PATH_NOT_FOUND",
+        "A declared source path is a Git LFS pointer, not source bytes"
+      );
+    }
+  }
+  return objects;
+}
+
+function buildResultRecords(treeRecords, objectSizes, objectBytes) {
+  const records = new Map();
+  for (const [filePath, treeRecord] of treeRecords) {
+    const bytes = objectBytes.get(treeRecord.objectId)?.bytes;
+    const expectedSize = objectSizes.get(treeRecord.objectId)?.size;
+    if (!(bytes instanceof Buffer) || bytes.length !== expectedSize) {
+      throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "Git blob bytes did not match declared object metadata");
+    }
+    records.set(filePath, {
+      mode: treeRecord.mode,
+      objectId: treeRecord.objectId,
+      bytes: Buffer.from(bytes)
+    });
+  }
+  return records;
+}
+
+function parseTreeRecords(output, requestedPaths) {
+  const requested = new Set(requestedPaths);
+  const records = new Map();
+  const entries = splitNulRecords(output);
+  for (const entry of entries) {
+    const tab = entry.indexOf(0x09);
+    if (tab < 0) protocolError("Git tree output did not contain a path separator");
+    const header = entry.subarray(0, tab).toString("ascii");
+    const match = header.match(/^([0-7]{6}) ([a-z]+) ([0-9a-f]{40})$/u);
+    if (!match) protocolError("Git tree output contained invalid object metadata");
+    let filePath;
+    try {
+      filePath = STRICT_UTF8.decode(entry.subarray(tab + 1));
+    } catch (error) {
+      throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "Git tree output contained a non-UTF-8 path", {
+        cause: error
+      });
+    }
+    if (!requested.has(filePath) || records.has(filePath)) {
+      protocolError("Git tree output did not match the exact declared paths");
+    }
+    if (match[2] !== "blob" || !REGULAR_BLOB_MODES.has(match[1])) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_DECLARED_PATH_NOT_FOUND",
+        "A declared source path was not found as a regular blob in the exact tree"
+      );
+    }
+    records.set(filePath, { mode: match[1], objectId: match[3] });
+  }
+  if (records.size !== requested.size) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_DECLARED_PATH_NOT_FOUND",
+      "A declared source path was not found as a regular blob in the exact tree"
+    );
+  }
+  return new Map([...records].sort(([left], [right]) => compareUtf8(left, right)));
+}
+
+function parseBatchCheck(output, requestedObjectIds) {
+  let text;
+  try {
+    text = STRICT_UTF8.decode(output);
+  } catch (error) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "Git object metadata was not valid UTF-8", {
+      cause: error
+    });
+  }
+  const lines = text.endsWith("\n") ? text.slice(0, -1).split("\n") : [];
+  if (lines.length !== requestedObjectIds.length) {
+    protocolError("Git object metadata count did not match the request");
+  }
+  const records = new Map();
+  for (let index = 0; index < lines.length; index += 1) {
+    const objectId = requestedObjectIds[index];
+    const match = lines[index].match(/^([0-9a-f]{40}) ([a-z]+) (0|[1-9][0-9]*)$/u);
+    if (!match || match[1] !== objectId) {
+      protocolError("Git object metadata did not match the exact requested object");
+    }
+    const size = Number(match[3]);
+    if (!Number.isSafeInteger(size)) protocolError("Git object size was outside the supported integer range");
+    records.set(objectId, { type: match[2], size });
+  }
+  return records;
+}
+
+function parseBatchObjects(output, requestedObjectIds) {
+  const records = new Map();
+  let cursor = 0;
+  for (const requestedObjectId of requestedObjectIds) {
+    const headerEnd = output.indexOf(0x0a, cursor);
+    if (headerEnd < cursor || headerEnd - cursor > 256) {
+      protocolError("Git batch output contained an invalid object header");
+    }
+    const header = output.subarray(cursor, headerEnd).toString("ascii");
+    const match = header.match(/^([0-9a-f]{40}) ([a-z]+) (0|[1-9][0-9]*)$/u);
+    if (!match || match[1] !== requestedObjectId) {
+      protocolError("Git batch output did not match the exact requested object");
+    }
+    const size = Number(match[3]);
+    if (!Number.isSafeInteger(size)) protocolError("Git object size was outside the supported integer range");
+    const bodyStart = headerEnd + 1;
+    const bodyEnd = bodyStart + size;
+    if (bodyEnd >= output.length || output[bodyEnd] !== 0x0a) {
+      protocolError("Git batch output contained truncated object bytes");
+    }
+    records.set(requestedObjectId, {
+      type: match[2],
+      bytes: Buffer.from(output.subarray(bodyStart, bodyEnd))
+    });
+    cursor = bodyEnd + 1;
+  }
+  if (cursor !== output.length) protocolError("Git batch output contained unexpected trailing bytes");
+  return records;
+}
+
+function splitNulRecords(output) {
+  if (output.length === 0) return [];
+  if (output.at(-1) !== 0) protocolError("Git tree output was not NUL terminated");
+  const records = [];
+  let start = 0;
+  for (let index = 0; index < output.length; index += 1) {
+    if (output[index] !== 0) continue;
+    if (index === start) protocolError("Git tree output contained an empty record");
+    records.push(output.subarray(start, index));
+    start = index + 1;
+  }
+  return records;
+}
+
+function escapeSparsePattern(value) {
+  return value.replace(/[\\!#*?\[\] ]/gu, (character) => `\\${character}`);
+}
+
+function uniqueObjectIds(treeRecords) {
+  return [...new Set([...treeRecords.values()].map((entry) => entry.objectId))].sort();
+}
+
+function verifyGitObjectId(type, bytes, expectedObjectId, errorCode) {
+  const observedObjectId = createHash("sha1")
+    .update(`${type} ${bytes.length}\0`, "utf8")
+    .update(bytes)
+    .digest("hex");
+  if (observedObjectId !== expectedObjectId) {
+    throw new GitHubPublicSourceError(errorCode, `Git ${type} bytes did not match the exact object id`);
+  }
+}
+
+async function invokeRepositoryGit(state, gitDirectory, args, options) {
+  return invokeGit(state, ["-C", gitDirectory, ...args], options);
+}
+
+async function invokeGit(state, args, options) {
+  const remainingMs = Math.floor(state.deadline - performance.now());
+  if (remainingMs < 1) {
+    throw new GitHubPublicSourceError("GITHUB_TIMEOUT", "anonymous Git object resolution exceeded its deadline", {
+      retryable: true
+    });
+  }
+  let result;
+  try {
+    result = await state.runGit({
+      gitExecutable: state.gitExecutable,
+      args: [...SAFE_GIT_CONFIG, ...args],
+      cwd: null,
+      env: safeGitEnvironment(options.disableLazyFetch === true),
+      input: options.input ?? null,
+      timeoutMs: remainingMs,
+      maximumOutputBytes: options.maximumOutputBytes,
+      monitoredDirectory: options.monitoredDirectory ?? null,
+      maximumTemporaryBytes: GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTemporaryRepositoryBytes,
+      maximumFileSizeBytes: GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTemporaryFileBytes,
+      maximumAddressSpaceBytes: GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumAddressSpaceBytes,
+      maximumCpuSeconds: GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumCpuSeconds
+    });
+  } catch (error) {
+    throw toolingBlocked(`cannot execute git during ${options.phase}`, error);
+  }
+  if (!isGitResult(result)) {
+    throw toolingBlocked(`git returned an invalid process result during ${options.phase}`);
+  }
+  if (result.timedOut) {
+    throw new GitHubPublicSourceError("GITHUB_TIMEOUT", "anonymous Git object resolution exceeded its deadline", {
+      retryable: true
+    });
+  }
+  if (result.outputExceeded) {
+    throw new GitHubPublicSourceError("GITHUB_RESPONSE_TOO_LARGE", "Git process output exceeded its byte limit");
+  }
+  if (result.temporaryBytesExceeded) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_RESPONSE_TOO_LARGE",
+      "Git temporary object storage exceeded its byte limit"
+    );
+  }
+  if (result.fileSizeExceeded || result.addressSpaceExceeded || result.cpuExceeded) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_RESPONSE_TOO_LARGE",
+      "Git object resolution exceeded its bounded process resources"
+    );
+  }
+  if (options.monitoredDirectory !== undefined) {
+    let temporaryBytes;
+    try {
+      temporaryBytes = measureDirectoryBytes(options.monitoredDirectory);
+    } catch (error) {
+      throw toolingBlocked(`cannot measure temporary Git storage during ${options.phase}`, error);
+    }
+    if (temporaryBytes > GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTemporaryRepositoryBytes) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_RESPONSE_TOO_LARGE",
+        "Git temporary object storage exceeded its byte limit"
+      );
+    }
+  }
+  if (options.acceptedStatuses === null || (options.acceptedStatuses ?? [0]).includes(result.status)) return result;
+  return result;
+}
+
+function requireSuccess(result, message) {
+  if (result.status !== 0) throw toolingBlocked(message);
+}
+
+function safeGitEnvironment(disableLazyFetch) {
+  const environment = Object.create(null);
+  for (const name of ["PATH", "TMPDIR", "TMP", "TEMP"]) {
+    if (typeof process.env[name] === "string") environment[name] = process.env[name];
+  }
+  environment.LANG = "C";
+  environment.LC_ALL = "C";
+  environment.LC_CTYPE = "C";
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = "/dev/null";
+  environment.GIT_TERMINAL_PROMPT = "0";
+  environment.GIT_OPTIONAL_LOCKS = "0";
+  environment.GIT_LFS_SKIP_SMUDGE = "1";
+  environment.GIT_NO_REPLACE_OBJECTS = "1";
+  environment.GIT_LITERAL_PATHSPECS = "1";
+  environment.GIT_PROTOCOL_FROM_USER = "0";
+  environment.GIT_PAGER = "cat";
+  environment.GCM_INTERACTIVE = "Never";
+  if (disableLazyFetch) environment.GIT_NO_LAZY_FETCH = "1";
+  return environment;
+}
+
+export async function runBoundedExactGitProcessV1({
+  gitExecutable,
+  args,
+  cwd,
+  env,
+  input,
+  timeoutMs,
+  maximumOutputBytes,
+  monitoredDirectory,
+  maximumTemporaryBytes,
+  maximumFileSizeBytes = GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTemporaryFileBytes,
+  maximumAddressSpaceBytes = GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumAddressSpaceBytes,
+  maximumCpuSeconds = GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumCpuSeconds
+}) {
+  if (process.platform !== "darwin" && process.platform !== "linux") {
+    throw new GitCommandExecutionError("platform", "bounded Git execution supports macOS and Linux only");
+  }
+  const fileLimitBlocks = Math.floor(maximumFileSizeBytes / 1024);
+  const addressSpaceLimitKilobytes = process.platform === "linux"
+    ? Math.floor(maximumAddressSpaceBytes / 1024)
+    : 0;
+  if (
+    typeof gitExecutable !== "string"
+    || gitExecutable.length < 1
+    || /[\u0000\r\n]/u.test(gitExecutable)
+    || !Array.isArray(args)
+    || args.some((entry) => typeof entry !== "string" || /\u0000/u.test(entry))
+    || (cwd !== null && cwd !== undefined && (typeof cwd !== "string" || cwd.length < 1 || /\u0000/u.test(cwd)))
+    || !isPlainObject(env)
+    || (input !== null && !(input instanceof Uint8Array))
+    || !Number.isInteger(timeoutMs)
+    || timeoutMs < GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.minimumTimeoutMs
+    || timeoutMs > GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTimeoutMs
+    || !Number.isInteger(maximumOutputBytes)
+    || maximumOutputBytes < 1
+    || !Number.isInteger(maximumTemporaryBytes)
+    || maximumTemporaryBytes < 1
+    || maximumTemporaryBytes > GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTemporaryRepositoryBytes
+    || !Number.isInteger(maximumFileSizeBytes)
+    || maximumFileSizeBytes < 1024
+    || maximumFileSizeBytes > GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumTemporaryFileBytes
+    || !Number.isInteger(maximumAddressSpaceBytes)
+    || maximumAddressSpaceBytes < 64 * 1024 * 1024
+    || maximumAddressSpaceBytes > GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumAddressSpaceBytes
+    || !Number.isInteger(maximumCpuSeconds)
+    || maximumCpuSeconds < 1
+    || maximumCpuSeconds > GITHUB_PUBLIC_GIT_OBJECT_RESOLVER_V1.maximumCpuSeconds
+    || fileLimitBlocks < 1
+    || (monitoredDirectory !== null
+      && (typeof monitoredDirectory !== "string" || monitoredDirectory.length < 1 || /\u0000/u.test(monitoredDirectory)))
+  ) {
+    throw new GitCommandExecutionError("options", "bounded Git execution received invalid trusted process options");
+  }
+
+  return new Promise((resolve, reject) => {
+    // GitHub's production runner is Linux. RLIMIT_AS constrains pack expansion
+    // there; macOS has no settable RLIMIT_AS, but retains the inherited file,
+    // CPU, output, storage and wall-clock limits. Positional parameters keep
+    // every Git argument out of shell evaluation.
+    const launcher = [
+      'ulimit -f "$1" || exit 125',
+      'ulimit -t "$2" || exit 125',
+      'if [[ "$3" != "0" ]]; then ulimit -v "$3" || exit 125; fi',
+      'shift 3',
+      'exec "$@"'
+    ].join("; ");
+    let child;
+    try {
+      child = childProcess.spawn("/bin/bash", [
+        "--noprofile",
+        "--norc",
+        "-c",
+        launcher,
+        "bounded-exact-git",
+        String(fileLimitBlocks),
+        String(maximumCpuSeconds),
+        String(addressSpaceLimitKilobytes),
+        gitExecutable,
+        ...args
+      ], {
+        cwd: cwd ?? undefined,
+        detached: true,
+        env,
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true
+      });
+    } catch (error) {
+      reject(new GitCommandExecutionError("spawn", "cannot spawn git", { cause: error }));
+      return;
+    }
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    let outputBytes = 0;
+    let outputExceeded = false;
+    let temporaryBytesExceeded = false;
+    let timedOut = false;
+    let terminated = false;
+    let settled = false;
+    let forceKillTimer = null;
+
+    const killGroup = (signal) => {
+      if (!Number.isInteger(child.pid)) return;
+      try {
+        process.kill(-child.pid, signal);
+      } catch (error) {
+        if (error?.code === "ESRCH") return;
+        try {
+          child.kill(signal);
+        } catch {
+          // The process may have exited between the group and direct kill.
+        }
+      }
+    };
+    const terminate = () => {
+      if (terminated) return;
+      terminated = true;
+      killGroup("SIGTERM");
+      forceKillTimer = setTimeout(() => killGroup("SIGKILL"), KILL_GRACE_MS);
+      forceKillTimer.unref?.();
+    };
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      terminate();
+    }, timeoutMs);
+    timeout.unref?.();
+    const sizePoll = monitoredDirectory === null ? null : setInterval(() => {
+      if (temporaryBytesExceeded || settled) return;
+      try {
+        if (measureDirectoryBytes(monitoredDirectory) > maximumTemporaryBytes) {
+          temporaryBytesExceeded = true;
+          terminate();
+        }
+      } catch {
+        temporaryBytesExceeded = true;
+        terminate();
+      }
+    }, TEMPORARY_SIZE_POLL_MS);
+    sizePoll?.unref?.();
+
+    const collect = (target) => (chunk) => {
+      if (outputExceeded) return;
+      const bytes = Buffer.from(chunk);
+      outputBytes += bytes.length;
+      if (outputBytes > maximumOutputBytes) {
+        outputExceeded = true;
+        terminate();
+        return;
+      }
+      target.push(bytes);
+    };
+    child.stdout.on("data", collect(stdoutChunks));
+    child.stderr.on("data", collect(stderrChunks));
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (sizePoll !== null) clearInterval(sizePoll);
+      killGroup("SIGKILL");
+      if (forceKillTimer !== null) clearTimeout(forceKillTimer);
+      reject(new GitCommandExecutionError("spawn", "git process failed", { cause: error }));
+    });
+    child.on("close", (status, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (sizePoll !== null) clearInterval(sizePoll);
+      // A leader that exits successfully must not leave git-remote, index-pack
+      // or another helper alive outside the bounded operation.
+      killGroup("SIGKILL");
+      if (forceKillTimer !== null) clearTimeout(forceKillTimer);
+      if (monitoredDirectory !== null) {
+        try {
+          if (measureDirectoryBytes(monitoredDirectory) > maximumTemporaryBytes) {
+            temporaryBytesExceeded = true;
+          }
+        } catch {
+          temporaryBytesExceeded = true;
+        }
+      }
+      const stderr = Buffer.concat(stderrChunks);
+      const stderrText = stderr.toString("utf8");
+      const fileSizeExceeded = signal === "SIGXFSZ"
+        || status === 153
+        || /File size limit exceeded/iu.test(stderrText);
+      const addressSpaceExceeded = /(?:out of memory|cannot allocate memory|memory exhausted|failed to allocate memory|bad_alloc)/iu
+        .test(stderrText);
+      // Bash applies the same soft and hard RLIMIT_CPU value. Linux may report
+      // that hard-limit termination as SIGKILL instead of SIGXCPU. Only treat
+      // an otherwise unexplained SIGKILL as a resource kill: every SIGKILL
+      // initiated by our timeout/output/storage/input handling follows terminate().
+      const cpuExceeded = signal === "SIGXCPU"
+        || status === 152
+        || (signal === "SIGKILL" && !terminated && !fileSizeExceeded && !addressSpaceExceeded);
+      resolve({
+        status: Number.isInteger(status) ? status : 1,
+        signal,
+        stdout: Buffer.concat(stdoutChunks),
+        stderr,
+        timedOut,
+        outputExceeded,
+        temporaryBytesExceeded,
+        fileSizeExceeded,
+        addressSpaceExceeded,
+        cpuExceeded
+      });
+    });
+
+    child.stdin.on("error", (error) => {
+      if (error?.code !== "EPIPE" && !settled) terminate();
+    });
+    if (input === null) child.stdin.end();
+    else child.stdin.end(input);
+  });
+}
+
+async function removeExactTemporaryDirectory(directory, expectedParent) {
+  const resolvedDirectory = path.resolve(directory);
+  if (
+    path.dirname(resolvedDirectory) !== expectedParent
+    || !path.basename(resolvedDirectory).startsWith(TEMPORARY_PREFIX)
+  ) {
+    throw new Error("temporary directory identity changed");
+  }
+  await fs.promises.rm(resolvedDirectory, {
+    recursive: true,
+    force: true,
+    maxRetries: 3,
+    retryDelay: 20
+  });
+}
+
+function normalizeResolverError(error) {
+  if (error instanceof GitHubPublicSourceError) return error;
+  if (error instanceof GitCommandExecutionError) return toolingBlocked("git command execution failed", error);
+  return toolingBlocked("exact Git object resolution failed locally", error);
+}
+
+function measureDirectoryBytes(directory) {
+  const pending = [directory];
+  let entries = 0;
+  let totalBytes = 0;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      entries += 1;
+      if (entries > MAXIMUM_TEMPORARY_ENTRIES) return Number.POSITIVE_INFINITY;
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      } else if (entry.isFile()) {
+        totalBytes += fs.statSync(entryPath).size;
+      }
+    }
+  }
+  return totalBytes;
+}
+
+function toolingBlocked(detail, cause = undefined) {
+  return new GitHubPublicSourceError(
+    "GITHUB_UPSTREAM_REJECTED",
+    `Exact Git object tooling is unavailable: ${detail}`,
+    cause === undefined ? {} : { cause }
+  );
+}
+
+function protocolError(message) {
+  throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", message);
+}
+
+function invalidRequest(message) {
+  throw new GitHubPublicSourceError("INVALID_REQUEST", message);
+}
+
+function boundedPositiveInteger(value, maximum, name) {
+  if (!Number.isInteger(value) || value < 1 || value > maximum) {
+    invalidRequest(`${name} must be a positive integer within the supported bound`);
+  }
+  return value;
+}
+
+function assertFactoryOptions(options) {
+  if (!isPlainObject(options)) throw new TypeError("resolver factory options must be an object");
+  const allowed = new Set(["gitExecutable", "platform", "runGit", "temporaryDirectoryRoot"]);
+  if (Object.keys(options).some((key) => !allowed.has(key))) {
+    throw new TypeError("resolver factory options contained an unsupported field");
+  }
+  if (
+    (options.gitExecutable !== undefined
+      && (typeof options.gitExecutable !== "string" || options.gitExecutable.length === 0 || /[\u0000\r\n]/u.test(options.gitExecutable)))
+    || (options.runGit !== undefined && typeof options.runGit !== "function")
+    || (options.platform !== undefined
+      && (typeof options.platform !== "string" || options.platform.length === 0 || /[\u0000\r\n]/u.test(options.platform)))
+    || (options.temporaryDirectoryRoot !== undefined
+      && (typeof options.temporaryDirectoryRoot !== "string" || !path.isAbsolute(options.temporaryDirectoryRoot)))
+  ) {
+    throw new TypeError("resolver factory options were invalid");
+  }
+}
+
+function isGitResult(value) {
+  return isPlainObject(value)
+    && Number.isInteger(value.status)
+    && value.stdout instanceof Uint8Array
+    && value.stderr instanceof Uint8Array
+    && typeof value.timedOut === "boolean"
+    && typeof value.outputExceeded === "boolean"
+    && typeof value.temporaryBytesExceeded === "boolean"
+    && typeof value.fileSizeExceeded === "boolean"
+    && typeof value.addressSpaceExceeded === "boolean"
+    && typeof value.cpuExceeded === "boolean";
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
+}
+
+function compareUtf8(left, right) {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}

--- a/skills/programmable-v4-hook-builder/scripts/github-public-source-core.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/github-public-source-core.mjs
@@ -1,0 +1,1653 @@
+import { createHash } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { TextDecoder, TextEncoder } from "node:util";
+import {
+  isCanonicalReviewTargetPath,
+  isGitLfsPointer,
+  REVIEW_TARGET_CONTRACT_V1
+} from "./review-target-contract.mjs";
+
+export const GITHUB_PUBLIC_SOURCE_CONTRACT_V1 = Object.freeze({
+  name: "GitHubPublicSourceContractV1",
+  schemaVersion: "1.0.0",
+  kind: "github-public-source",
+  canonicalProviderOrigin: "https://github.com",
+  apiOrigin: "https://api.github.com",
+  githubApiVersion: "2026-03-10",
+  userAgent: "programmable-github-public-source-v1",
+  limits: Object.freeze({
+    companions: 15,
+    pathsPerKind: REVIEW_TARGET_CONTRACT_V1.maximumFiles,
+    pathsTotal: REVIEW_TARGET_CONTRACT_V1.maximumFiles,
+    actionsRunsPerRepository: 16,
+    pathBytes: REVIEW_TARGET_CONTRACT_V1.maximumPathBytes,
+    opaqueIdDigits: 64,
+    defaultTimeoutMs: 10_000,
+    minimumTimeoutMs: 10,
+    maximumTimeoutMs: 30_000,
+    anonymousRestRequests: 48,
+    reviewFileBytes: REVIEW_TARGET_CONTRACT_V1.maximumFileBytes,
+    reviewTotalBytes: REVIEW_TARGET_CONTRACT_V1.maximumTotalBytes,
+    defaultTotalResponseBytes: 16_777_216,
+    minimumTotalResponseBytes: 1_024,
+    maximumTotalResponseBytes: 67_108_864,
+  }),
+});
+
+export const GITHUB_PUBLIC_SOURCE_ERROR_CODES_V1 = Object.freeze([
+  "GITHUB_ACTIONS_RUN_MISMATCH",
+  "GITHUB_ACTIONS_RUN_NOT_REACHABLE",
+  "GITHUB_ACTIONS_WORKFLOW_NOT_IN_TREE",
+  "GITHUB_COMMIT_MISMATCH",
+  "GITHUB_COMMIT_NOT_REACHABLE",
+  "GITHUB_DECLARED_PATH_NOT_FOUND",
+  "GITHUB_NETWORK_ERROR",
+  "GITHUB_PROTOCOL_ERROR",
+  "GITHUB_PUBLIC_REPOSITORY_UNAVAILABLE",
+  "GITHUB_RATE_LIMITED",
+  "GITHUB_REDIRECT_REJECTED",
+  "GITHUB_REPOSITORY_ID_MISMATCH",
+  "GITHUB_REPOSITORY_LOCATOR_MISMATCH",
+  "GITHUB_RESPONSE_TOO_LARGE",
+  "GITHUB_TIMEOUT",
+  "GITHUB_TREE_MISMATCH",
+  "GITHUB_TREE_NOT_REACHABLE",
+  "GITHUB_TREE_TRUNCATED",
+  "GITHUB_UNAVAILABLE",
+  "GITHUB_UPSTREAM_REJECTED",
+  "INVALID_OPTIONS",
+  "INVALID_REQUEST",
+]);
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true });
+const lowerHex40 = /^[0-9a-f]{40}$/;
+const opaqueDecimal = /^[1-9][0-9]{0,63}$/;
+const ownerPattern = /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/;
+const repositoryPattern = /^[a-z0-9._-]{1,100}$/;
+const safeCodePattern = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+const allowedRequestKeys = new Set(["schemaVersion", "primary", "companions"]);
+const allowedRepositoryKeys = new Set([
+  "repositoryUri",
+  "numericRepositoryId",
+  "revisionObjectId",
+  "treeObjectId",
+  "sourcePaths",
+  "contractPaths",
+  "githubActionsRunIds",
+]);
+const allowedOptionKeys = new Set([
+  "transport",
+  "timeoutMs",
+  "maxResponseBytes",
+  "localBlobBytes",
+  "exactObjectResolver",
+]);
+const errorCodeSet = new Set(GITHUB_PUBLIC_SOURCE_ERROR_CODES_V1);
+const maximumJsonDepth = 128;
+const maximumJsonNodes = 2_000_000;
+const maximumJsonNumberCharacters = 128;
+// Sixteen repositories need the full 48-request anonymous budget even without
+// Actions evidence. Three-wide deterministic batches keep the deadline bounded
+// without creating an unbounded request fan-out.
+const maximumConcurrentRepositories = 3;
+// A GitHub recursive tree response is bounded at roughly 7 MB. Two tree slots
+// preserve the resolver's aggregate byte limit while other repositories wait.
+const maximumConcurrentTreeRequests = 2;
+const maximumTreeResponseBytes = 8_388_608;
+const maximumOtherResponseBytes = 1_048_576;
+// GitHub's JSON blob envelope base64-expands the canonical two-megabyte
+// review-file ceiling. Production uses the batched exact-object resolver, but
+// the bounded REST fallback still needs room for one valid canonical blob.
+const maximumBlobResponseBytes = 3_000_000;
+const maximumDeclaredBlobBytes = REVIEW_TARGET_CONTRACT_V1.maximumFileBytes;
+const maximumDeclaredAggregateBytes = REVIEW_TARGET_CONTRACT_V1.maximumTotalBytes;
+const maximumGitHubRequests = GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.anonymousRestRequests;
+// The fallback follows only declared paths. These independent caps prevent a
+// malicious or unusually broad tree from turning path validation into a crawl.
+const maximumTreeWalkRequestsPerRepository =
+  REVIEW_TARGET_CONTRACT_V1.maximumFiles * REVIEW_TARGET_CONTRACT_V1.maximumPathDepth;
+const maximumTreeWalkDepth = REVIEW_TARGET_CONTRACT_V1.maximumPathDepth;
+
+class LosslessJsonNumber {
+  constructor(source) {
+    this.source = source;
+    Object.freeze(this);
+  }
+}
+
+export class GitHubPublicSourceError extends Error {
+  constructor(code, message, options = {}) {
+    if (!errorCodeSet.has(code)) {
+      throw new TypeError("unsupported GitHub public source error code");
+    }
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "GitHubPublicSourceError";
+    this.code = code;
+    this.retryable = options.retryable === true;
+    this.status = options.status ?? null;
+    this.retryAfterSeconds = options.retryAfterSeconds ?? null;
+  }
+
+  toJSON() {
+    return {
+      schemaVersion: "1.0.0",
+      error: this.code,
+      message: this.message,
+      retryable: this.retryable,
+      status: this.status,
+      retryAfterSeconds: this.retryAfterSeconds,
+    };
+  }
+}
+
+export function validateGitHubPublicSourceRequestV1(input) {
+  assertPlainObject(input, "INVALID_REQUEST", "request must be an object");
+  assertExactKeys(input, allowedRequestKeys, "INVALID_REQUEST");
+  if (input.schemaVersion !== GITHUB_PUBLIC_SOURCE_CONTRACT_V1.schemaVersion) {
+    invalidRequest("request schemaVersion is unsupported");
+  }
+
+  const primary = normalizeRepositoryRequest(input.primary);
+  if (!Array.isArray(input.companions)) {
+    invalidRequest("companions must be an array");
+  }
+  if (input.companions.length > GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.companions) {
+    invalidRequest("too many companion repositories");
+  }
+
+  const companions = input.companions.map(normalizeRepositoryRequest);
+  companions.sort(compareRepositoryRequests);
+
+  const repositoryIds = new Set([primary.numericRepositoryId]);
+  const repositoryUris = new Set([primary.repositoryUri]);
+  for (const companion of companions) {
+    if (repositoryIds.has(companion.numericRepositoryId)) {
+      invalidRequest("repository identities must be unique");
+    }
+    if (repositoryUris.has(companion.repositoryUri)) {
+      invalidRequest("repository locators must be unique");
+    }
+    repositoryIds.add(companion.numericRepositoryId);
+    repositoryUris.add(companion.repositoryUri);
+  }
+
+  const repositories = [primary, ...companions];
+  const minimumApiRequests = (repositories.length * 3)
+    + repositories.reduce((total, repository) => total + repository.githubActionsRunIds.length, 0);
+  if (minimumApiRequests > maximumGitHubRequests) {
+    invalidRequest("repository and GitHub Actions breadth exceeds the anonymous request budget");
+  }
+
+  return deepFreeze({
+    schemaVersion: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.schemaVersion,
+    primary,
+    companions,
+  });
+}
+
+export function isCanonicalGitHubRepositoryPathV1(value) {
+  return isCanonicalReviewTargetPath(value);
+}
+
+export async function resolveGitHubPublicSourceV1(input, options = {}) {
+  const request = validateGitHubPublicSourceRequestV1(input);
+  const resolverOptions = normalizeOptions(options, request);
+  const state = {
+    deadline: performance.now() + resolverOptions.timeoutMs,
+    requestsRemaining: maximumGitHubRequests,
+    responseBytesRemaining: resolverOptions.maxResponseBytes,
+    treeRequestSemaphore: createBoundedSemaphore(maximumConcurrentTreeRequests),
+    transport: resolverOptions.transport,
+    localBlobBytes: resolverOptions.localBlobBytes,
+    exactObjectResolver: resolverOptions.exactObjectResolver,
+  };
+
+  const repositories = [
+    { request: request.primary, role: "primary" },
+    ...request.companions.map((companion) => ({ request: companion, role: "companion" })),
+  ];
+  const resolvedRepositories = await resolveRepositoryBatches(repositories, state);
+  const [primary, ...companions] = resolvedRepositories;
+
+  return deepFreeze({
+    schemaVersion: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.schemaVersion,
+    kind: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.kind,
+    canonicalProviderOrigin: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.canonicalProviderOrigin,
+    githubApiVersion: GITHUB_PUBLIC_SOURCE_CONTRACT_V1.githubApiVersion,
+    primary,
+    companions,
+  });
+}
+
+async function resolveRepositoryBatches(repositories, state) {
+  const resolved = new Array(repositories.length);
+  for (let offset = 0; offset < repositories.length; offset += maximumConcurrentRepositories) {
+    const batch = repositories.slice(offset, offset + maximumConcurrentRepositories);
+    const settled = await Promise.allSettled(
+      batch.map(({ request, role }) => resolveRepository(request, role, state)),
+    );
+    // Inspect in canonical request order so simultaneous failures do not make
+    // the resolver's observable result depend on network completion order.
+    for (let index = 0; index < settled.length; index += 1) {
+      const outcome = settled[index];
+      if (outcome.status === "rejected") throw outcome.reason;
+      resolved[offset + index] = outcome.value;
+    }
+  }
+  return resolved;
+}
+
+export function serializeGitHubPublicSourceV1(value) {
+  return stableStringify(value);
+}
+
+export function createGitHubPublicFetchTransportV1(fetchImplementation = globalThis.fetch, options = {}) {
+  if (typeof fetchImplementation !== "function") {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "fetch implementation must be a function");
+  }
+  if (
+    options === null
+    || typeof options !== "object"
+    || Array.isArray(options)
+    || Object.keys(options).some((key) => key !== "allowPublicUserLookups")
+    || (options.allowPublicUserLookups !== undefined && typeof options.allowPublicUserLookups !== "boolean")
+  ) {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "public GitHub transport options are invalid");
+  }
+  const allowPublicUserLookups = options.allowPublicUserLookups === true;
+
+  return async function githubPublicFetchTransport(request) {
+    assertPublicFetchRequest(request, allowPublicUserLookups);
+    const response = await fetchImplementation(request.url, {
+      method: "GET",
+      headers: request.headers,
+      redirect: "error",
+      signal: request.signal,
+    });
+
+    if (response.redirected) {
+      throw new GitHubPublicSourceError("GITHUB_REDIRECT_REJECTED", "GitHub redirect was rejected");
+    }
+
+    const contentLength = normalizeContentLength(response.headers?.get?.("content-length"));
+    if (contentLength !== null && contentLength > request.maxResponseBytes) {
+      throw new GitHubPublicSourceError("GITHUB_RESPONSE_TOO_LARGE", "GitHub response exceeded the byte limit");
+    }
+
+    const body = await readBoundedResponseBody(response, request.maxResponseBytes);
+    return {
+      status: response.status,
+      headers: {
+        "content-type": response.headers?.get?.("content-type") ?? null,
+        "retry-after": response.headers?.get?.("retry-after") ?? null,
+        "x-ratelimit-remaining": response.headers?.get?.("x-ratelimit-remaining") ?? null,
+      },
+      body,
+      redirected: response.redirected,
+      responseUrl: response.url,
+    };
+  };
+}
+
+async function resolveRepository(repositoryRequest, role, state) {
+  const { owner, repository } = parseCanonicalRepositoryUri(repositoryRequest.repositoryUri);
+  const repositoryPrefix = `/repos/${owner}/${repository}`;
+  const metadata = await requestGitHubJson(`${repositoryPrefix}`, "repository", state);
+  validateRepositoryMetadata(metadata, repositoryRequest, owner, repository);
+
+  const commit = await requestGitHubJson(
+    `${repositoryPrefix}/git/commits/${repositoryRequest.revisionObjectId}`,
+    "commit",
+    state,
+  );
+  validateCommit(commit, repositoryRequest, owner, repository);
+
+  const githubActionsEvidence = [];
+  for (const runId of repositoryRequest.githubActionsRunIds) {
+    const run = await requestGitHubJson(`${repositoryPrefix}/actions/runs/${runId}`, "actions-run", state);
+    githubActionsEvidence.push(validateActionsRun(run, repositoryRequest, owner, repository, runId));
+  }
+
+  const declaredPaths = [
+    ...repositoryRequest.sourcePaths,
+    ...repositoryRequest.contractPaths,
+    ...githubActionsEvidence.map((entry) => entry.workflowPath),
+  ];
+  // When remote bytes are required, the exact-object resolver already proves
+  // every declared path against the REST-verified commit and root tree. A
+  // recursive REST tree would repeat that walk. Complete local bytes instead
+  // need REST metadata for their path, mode, object-id, and size comparison.
+  const hasCompleteLocalBytes = declaredPaths.length > 0 && declaredPaths.every(
+    (filePath) => state.localBlobBytes.has(`${repositoryPrefix}\0${filePath}`),
+  );
+  const recursive = declaredPaths.length > 0
+    && (state.exactObjectResolver === null || hasCompleteLocalBytes);
+  const tree = await requestGitHubJson(
+    `${repositoryPrefix}/git/trees/${repositoryRequest.treeObjectId}${recursive ? "?recursive=1" : ""}`,
+    "tree",
+    state,
+  );
+  await validateTree(tree, repositoryPrefix, repositoryRequest, githubActionsEvidence, state, { recursive });
+
+  const defaultBranch = normalizeDisplayText(metadata.default_branch, 255, "repository default branch");
+  return deepFreeze({
+    role,
+    authority: {
+      numericRepositoryId: repositoryRequest.numericRepositoryId,
+      revisionObjectId: repositoryRequest.revisionObjectId,
+      treeObjectId: repositoryRequest.treeObjectId,
+    },
+    display: {
+      repositoryUri: repositoryRequest.repositoryUri,
+      owner,
+      repository,
+      defaultBranch,
+    },
+    visibility: "public",
+    sourcePaths: repositoryRequest.sourcePaths,
+    contractPaths: repositoryRequest.contractPaths,
+    githubActionsEvidence,
+  });
+}
+
+function normalizeRepositoryRequest(input) {
+  assertPlainObject(input, "INVALID_REQUEST", "repository request must be an object");
+  assertExactKeys(input, allowedRepositoryKeys, "INVALID_REQUEST");
+  const parsedUri = parseCanonicalRepositoryUri(input.repositoryUri);
+  const numericRepositoryId = normalizeOpaqueId(input.numericRepositoryId, "repository id", "INVALID_REQUEST");
+  const revisionObjectId = normalizeGitObjectId(input.revisionObjectId, "revision", "INVALID_REQUEST");
+  const treeObjectId = normalizeGitObjectId(input.treeObjectId, "tree", "INVALID_REQUEST");
+
+  const sourcePaths = normalizeUniqueArray(
+    input.sourcePaths ?? [],
+    GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.pathsPerKind,
+    normalizeRepositoryPath,
+    "source paths",
+  );
+  const contractPaths = normalizeUniqueArray(
+    input.contractPaths ?? [],
+    GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.pathsPerKind,
+    normalizeRepositoryPath,
+    "contract paths",
+  );
+  const githubActionsRunIds = normalizeUniqueArray(
+    input.githubActionsRunIds ?? [],
+    GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.actionsRunsPerRepository,
+    (value) => normalizeOpaqueId(value, "GitHub Actions run id", "INVALID_REQUEST"),
+    "GitHub Actions run ids",
+  );
+
+  const allDeclaredPaths = [...sourcePaths, ...contractPaths].sort(compareUtf8);
+  if (allDeclaredPaths.length > GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.pathsTotal) {
+    invalidRequest("declared paths exceed the total contract limit");
+  }
+  assertNoDuplicateSortedValues(allDeclaredPaths, "declared paths");
+
+  return deepFreeze({
+    repositoryUri: `https://github.com/${parsedUri.owner}/${parsedUri.repository}`,
+    numericRepositoryId,
+    revisionObjectId,
+    treeObjectId,
+    sourcePaths,
+    contractPaths,
+    githubActionsRunIds,
+  });
+}
+
+function normalizeOptions(options, request) {
+  assertPlainObject(options, "INVALID_OPTIONS", "resolver options must be an object");
+  assertExactKeys(options, allowedOptionKeys, "INVALID_OPTIONS");
+  const timeoutMs = options.timeoutMs ?? GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.defaultTimeoutMs;
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs < GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.minimumTimeoutMs ||
+    timeoutMs > GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.maximumTimeoutMs
+  ) {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "timeoutMs is outside the contract bounds");
+  }
+
+  const maxResponseBytes =
+    options.maxResponseBytes ?? GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.defaultTotalResponseBytes;
+  if (
+    !Number.isSafeInteger(maxResponseBytes) ||
+    maxResponseBytes < GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.minimumTotalResponseBytes ||
+    maxResponseBytes > GITHUB_PUBLIC_SOURCE_CONTRACT_V1.limits.maximumTotalResponseBytes
+  ) {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "maxResponseBytes is outside the contract bounds");
+  }
+
+  const transport = options.transport ?? createGitHubPublicFetchTransportV1();
+  if (typeof transport !== "function") {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "transport must be a function");
+  }
+  const exactObjectResolver = options.exactObjectResolver ?? null;
+  if (exactObjectResolver !== null && typeof exactObjectResolver !== "function") {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "exactObjectResolver must be a function");
+  }
+  const localBlobBytes = normalizeLocalBlobBytes(options.localBlobBytes, request);
+  return { timeoutMs, maxResponseBytes, transport, localBlobBytes, exactObjectResolver };
+}
+
+function normalizeLocalBlobBytes(input, request) {
+  if (input === undefined) return new Map();
+  if (!(input instanceof Map)) {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "local blob bytes must be a repository Map");
+  }
+
+  const repositories = new Map(
+    [request.primary, ...request.companions].map((repository) => [repository.repositoryUri, repository])
+  );
+  const normalized = new Map();
+  let aggregateBytes = 0;
+  for (const [repositoryUri, files] of input) {
+    const repository = repositories.get(repositoryUri);
+    if (repository === undefined || !(files instanceof Map)) {
+      throw new GitHubPublicSourceError("INVALID_OPTIONS", "local blob bytes referenced an undeclared repository");
+    }
+    const declaredPaths = new Set([...repository.sourcePaths, ...repository.contractPaths]);
+    for (const [filePath, value] of files) {
+      if (!declaredPaths.has(filePath) || !(value instanceof Uint8Array)) {
+        throw new GitHubPublicSourceError("INVALID_OPTIONS", "local blob bytes referenced an undeclared path");
+      }
+      const bytes = Buffer.from(value);
+      if (bytes.length > maximumDeclaredBlobBytes) {
+        throw new GitHubPublicSourceError("INVALID_OPTIONS", "local blob bytes exceeded the per-file limit");
+      }
+      aggregateBytes += bytes.length;
+      if (aggregateBytes > maximumDeclaredAggregateBytes) {
+        throw new GitHubPublicSourceError("INVALID_OPTIONS", "local blob bytes exceeded the aggregate limit");
+      }
+      const parsed = parseCanonicalRepositoryUri(repositoryUri);
+      normalized.set(`/repos/${parsed.owner}/${parsed.repository}\0${filePath}`, bytes);
+    }
+  }
+  return normalized;
+}
+
+async function requestGitHubJson(pathAndQuery, resourceKind, state) {
+  const url = `${GITHUB_PUBLIC_SOURCE_CONTRACT_V1.apiOrigin}${pathAndQuery}`;
+  assertCanonicalApiUrl(url);
+  if (state.requestsRemaining <= 0) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_UPSTREAM_REJECTED",
+      "GitHub public source request budget was exhausted; reduce companion or declared-path breadth"
+    );
+  }
+  state.requestsRemaining -= 1;
+  const releaseTreeSlot = resourceKind === "tree" ? await state.treeRequestSemaphore.acquire() : null;
+  let reservedResponseBytes = 0;
+  try {
+    const remainingMs = state.deadline - performance.now();
+    if (remainingMs <= 0) {
+      throw new GitHubPublicSourceError("GITHUB_TIMEOUT", "GitHub resolution timed out", { retryable: true });
+    }
+    reservedResponseBytes = reserveResponseBytes(resourceKind, state);
+
+    const controller = new AbortController();
+    let timeoutHandle;
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        controller.abort();
+        reject(new GitHubPublicSourceError("GITHUB_TIMEOUT", "GitHub resolution timed out", { retryable: true }));
+      }, remainingMs);
+    });
+
+    let response;
+    try {
+      response = await Promise.race([
+        Promise.resolve(
+          state.transport({
+            method: "GET",
+            url,
+            headers: Object.freeze({
+              Accept: "application/vnd.github+json",
+              "User-Agent": GITHUB_PUBLIC_SOURCE_CONTRACT_V1.userAgent,
+              "X-GitHub-Api-Version": GITHUB_PUBLIC_SOURCE_CONTRACT_V1.githubApiVersion,
+            }),
+            redirect: "error",
+            signal: controller.signal,
+            maxResponseBytes: reservedResponseBytes,
+          }),
+        ),
+        timeoutPromise,
+      ]);
+    } catch (error) {
+      if (error instanceof GitHubPublicSourceError) throw error;
+      throw new GitHubPublicSourceError("GITHUB_NETWORK_ERROR", "GitHub request failed", {
+        retryable: true,
+        cause: error,
+      });
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+
+    const normalized = normalizeTransportResponse(response, url);
+    if (normalized.body.byteLength > reservedResponseBytes) {
+      reservedResponseBytes = 0;
+      throw new GitHubPublicSourceError(
+        "GITHUB_RESPONSE_TOO_LARGE",
+        "GitHub responses exceeded the total byte limit",
+      );
+    }
+    state.responseBytesRemaining += reservedResponseBytes - normalized.body.byteLength;
+    reservedResponseBytes = 0;
+
+    const status = normalized.status;
+    const retryAfterSeconds = normalizeRetryAfter(normalized.headers["retry-after"]);
+    if (status >= 300 && status < 400) {
+      throw new GitHubPublicSourceError("GITHUB_REDIRECT_REJECTED", "GitHub redirect was rejected", { status });
+    }
+    if (status === 429 || status === 403) {
+      throw new GitHubPublicSourceError("GITHUB_RATE_LIMITED", "GitHub public API rate limit was reached", {
+        retryable: true,
+        status,
+        retryAfterSeconds,
+      });
+    }
+    if (status === 404) {
+      const codeByResource = {
+        repository: "GITHUB_PUBLIC_REPOSITORY_UNAVAILABLE",
+        commit: "GITHUB_COMMIT_NOT_REACHABLE",
+        tree: "GITHUB_TREE_NOT_REACHABLE",
+        blob: "GITHUB_DECLARED_PATH_NOT_FOUND",
+        "actions-run": "GITHUB_ACTIONS_RUN_NOT_REACHABLE",
+      };
+      throw new GitHubPublicSourceError(codeByResource[resourceKind], githubUnavailableMessage(resourceKind), {
+        status,
+      });
+    }
+    if (status >= 500) {
+      throw new GitHubPublicSourceError("GITHUB_UNAVAILABLE", "GitHub public API is unavailable", {
+        retryable: true,
+        status,
+        retryAfterSeconds,
+      });
+    }
+    if (status < 200 || status >= 300) {
+      throw new GitHubPublicSourceError("GITHUB_UPSTREAM_REJECTED", "GitHub public API rejected the request", {
+        status,
+      });
+    }
+
+    try {
+      const text = decoder.decode(normalized.body);
+      const parsed = parseBoundedLosslessJson(text);
+      assertPlainObject(parsed, "GITHUB_PROTOCOL_ERROR", "GitHub response must be a JSON object");
+      return parsed;
+    } catch (error) {
+      if (error instanceof GitHubPublicSourceError) throw error;
+      throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub returned invalid JSON", { cause: error });
+    }
+  } finally {
+    if (reservedResponseBytes > 0) state.responseBytesRemaining += reservedResponseBytes;
+    releaseTreeSlot?.();
+  }
+}
+
+function reserveResponseBytes(resourceKind, state) {
+  if (state.responseBytesRemaining <= 0) {
+    throw new GitHubPublicSourceError("GITHUB_RESPONSE_TOO_LARGE", "GitHub responses exceeded the total byte limit");
+  }
+  const perResponseLimit = resourceKind === "tree"
+    ? maximumTreeResponseBytes
+    : resourceKind === "blob"
+      ? maximumBlobResponseBytes
+      : maximumOtherResponseBytes;
+  const reserved = Math.min(perResponseLimit, state.responseBytesRemaining);
+  state.responseBytesRemaining -= reserved;
+  return reserved;
+}
+
+function createBoundedSemaphore(limit) {
+  let active = 0;
+  const waiters = [];
+
+  return Object.freeze({
+    acquire() {
+      return new Promise((resolve) => {
+        const grant = () => {
+          active += 1;
+          let released = false;
+          resolve(() => {
+            if (released) return;
+            released = true;
+            active -= 1;
+            waiters.shift()?.();
+          });
+        };
+        if (active < limit) grant();
+        else waiters.push(grant);
+      });
+    },
+  });
+}
+
+function validateRepositoryMetadata(metadata, request, owner, repository) {
+  const observedId = normalizeOpaqueId(metadata.id, "repository id", "GITHUB_PROTOCOL_ERROR", true);
+  if (observedId !== request.numericRepositoryId) {
+    throw new GitHubPublicSourceError("GITHUB_REPOSITORY_ID_MISMATCH", "GitHub repository identity did not match");
+  }
+  if (metadata.private !== false || metadata.visibility !== "public") {
+    throw new GitHubPublicSourceError(
+      "GITHUB_PUBLIC_REPOSITORY_UNAVAILABLE",
+      "GitHub public repository is unavailable",
+      { status: 404 },
+    );
+  }
+  if (typeof metadata.full_name !== "string" || metadata.full_name.toLowerCase() !== `${owner}/${repository}`) {
+    throw new GitHubPublicSourceError("GITHUB_REPOSITORY_LOCATOR_MISMATCH", "GitHub repository locator did not match");
+  }
+  validateRepositoryHtmlUrl(metadata.html_url, owner, repository);
+  normalizeDisplayText(metadata.default_branch, 255, "repository default branch");
+}
+
+function validateCommit(commit, request, owner, repository) {
+  const observedCommit = normalizeGitObjectId(commit.sha, "commit", "GITHUB_PROTOCOL_ERROR");
+  if (observedCommit !== request.revisionObjectId) {
+    throw new GitHubPublicSourceError("GITHUB_COMMIT_MISMATCH", "GitHub commit did not match the requested revision");
+  }
+  assertPlainObject(commit.tree, "GITHUB_PROTOCOL_ERROR", "GitHub commit tree must be an object");
+  const observedTree = normalizeGitObjectId(commit.tree.sha, "commit tree", "GITHUB_PROTOCOL_ERROR");
+  if (observedTree !== request.treeObjectId) {
+    throw new GitHubPublicSourceError("GITHUB_TREE_MISMATCH", "GitHub commit tree did not match the expected tree");
+  }
+  if (commit.html_url !== undefined) {
+    validateCommitHtmlUrl(commit.html_url, owner, repository, request.revisionObjectId);
+  }
+}
+
+async function validateTree(tree, repositoryPrefix, request, actionsEvidence, state, { recursive }) {
+  const hasDeclaredPaths =
+    request.sourcePaths.length > 0 || request.contractPaths.length > 0 || actionsEvidence.length > 0;
+  const entries = indexTreeResponse(tree, request.treeObjectId, recursive ? "recursive" : "direct", {
+    allowTruncated: recursive && hasDeclaredPaths,
+  });
+
+  if (hasDeclaredPaths && state.exactObjectResolver !== null && !recursive) {
+    await validateDeclaredPathsWithExactObjectResolver({
+      repositoryPrefix,
+      request,
+      actionsEvidence,
+      state,
+      // A direct root-tree response establishes the REST control-plane object
+      // but cannot describe nested paths. The exact Git resolver supplies the
+      // path, mode, object-id, size, and byte proof in one bounded batch.
+      expectedEntries: null,
+    });
+    return;
+  }
+
+  if (entries !== null) {
+    await validateIndexedDeclaredPaths(entries, repositoryPrefix, request, actionsEvidence, state);
+    return;
+  }
+
+  if (state.exactObjectResolver !== null) {
+    await validateDeclaredPathsWithExactObjectResolver({
+      repositoryPrefix,
+      request,
+      actionsEvidence,
+      state,
+      expectedEntries: null,
+    });
+    return;
+  }
+
+  // Never infer absence or presence from GitHub's partial recursive response.
+  // Re-open the exact root object non-recursively and traverse only declared
+  // paths by content-addressed tree SHA. Declared blobs are read only as
+  // bounded inert bytes to reject symlinks, gitlinks and Git LFS pointers.
+  await validateDeclaredPathsByTreeWalk(repositoryPrefix, request, actionsEvidence, state);
+}
+
+function indexTreeResponse(tree, expectedTreeObjectId, mode, options = {}) {
+  const observedTree = normalizeGitObjectId(tree.sha, "tree", "GITHUB_PROTOCOL_ERROR");
+  if (observedTree !== expectedTreeObjectId) {
+    throw new GitHubPublicSourceError("GITHUB_TREE_MISMATCH", "GitHub tree response did not match the expected tree");
+  }
+  if (tree.truncated !== false && tree.truncated !== true) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub tree truncation state was invalid");
+  }
+  if (!Array.isArray(tree.tree)) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub tree entries must be an array");
+  }
+  if (tree.truncated) {
+    if (options.allowTruncated === true) return null;
+    throw new GitHubPublicSourceError("GITHUB_TREE_TRUNCATED", "GitHub tree response was truncated");
+  }
+
+  const entries = new Map();
+  for (const entry of tree.tree) {
+    assertPlainObject(entry, "GITHUB_PROTOCOL_ERROR", "GitHub tree entry must be an object");
+    let path;
+    try {
+      path = normalizeRepositoryPath(entry.path);
+    } catch (error) {
+      throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub tree contained an invalid path", {
+        cause: error,
+      });
+    }
+    if (mode === "direct" && path.includes("/")) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_PROTOCOL_ERROR",
+        "GitHub non-recursive tree contained a nested path",
+      );
+    }
+    if (entries.has(path)) {
+      throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub tree contained a duplicate path");
+    }
+    if (entry.type !== "blob" && entry.type !== "tree" && entry.type !== "commit") {
+      throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub tree contained an invalid entry type");
+    }
+    const sha = normalizeGitObjectId(entry.sha, "tree entry", "GITHUB_PROTOCOL_ERROR");
+    const entryMode = normalizeTreeEntryMode(entry.mode, entry.type);
+    const size = entry.type === "blob" ? normalizeTreeBlobSize(entry.size) : null;
+    entries.set(path, { type: entry.type, sha, mode: entryMode, size });
+  }
+  return entries;
+}
+
+async function validateIndexedDeclaredPaths(entries, repositoryPrefix, request, actionsEvidence, state) {
+  const requirements = declaredPathRequirements(request, actionsEvidence);
+  let aggregateBytes = 0;
+  for (const requirement of requirements) {
+    const entry = entries.get(requirement.path);
+    if (!isRegularBlob(entry)) throwMissingDeclaredPath(requirement.kind);
+    aggregateBytes = addDeclaredBytesToAggregate(aggregateBytes, entry.size);
+  }
+  if (state.exactObjectResolver !== null) {
+    await validateDeclaredPathsWithExactObjectResolver({
+      repositoryPrefix,
+      request,
+      actionsEvidence,
+      state,
+      expectedEntries: entries,
+    });
+    return;
+  }
+  const blobCache = new Map();
+  for (const requirement of requirements) {
+    await validateDeclaredBlob(
+      repositoryPrefix,
+      requirement.path,
+      entries.get(requirement.path),
+      state,
+      blobCache,
+      requirement.kind,
+    );
+  }
+}
+
+function declaredPathRequirements(request, actionsEvidence) {
+  const requirementsByPath = new Map();
+  for (const path of [...request.sourcePaths, ...request.contractPaths]) {
+    requirementsByPath.set(path, { path, kind: "declared" });
+  }
+  for (const evidence of actionsEvidence) {
+    if (!requirementsByPath.has(evidence.workflowPath)) {
+      requirementsByPath.set(evidence.workflowPath, { path: evidence.workflowPath, kind: "workflow" });
+    }
+  }
+  return [...requirementsByPath.values()].sort(
+    (left, right) => compareUtf8(left.path, right.path) || compareUtf8(left.kind, right.kind),
+  );
+}
+
+async function validateDeclaredPathsWithExactObjectResolver({
+  repositoryPrefix,
+  request,
+  actionsEvidence,
+  state,
+  expectedEntries,
+}) {
+  const requirements = declaredPathRequirements(request, actionsEvidence);
+  const unresolved = [];
+  let aggregateBytes = 0;
+
+  if (expectedEntries !== null) {
+    for (const requirement of requirements) {
+      const entry = expectedEntries.get(requirement.path);
+      if (!isRegularBlob(entry)) throwMissingDeclaredPath(requirement.kind);
+      const localBytes = state.localBlobBytes.get(`${repositoryPrefix}\0${requirement.path}`);
+      if (localBytes === undefined) {
+        unresolved.push(requirement);
+        continue;
+      }
+      aggregateBytes = addDeclaredBytesToAggregate(aggregateBytes, localBytes.length);
+      validateDeclaredBlobBytes(entry, localBytes, requirement.kind);
+    }
+  } else {
+    unresolved.push(...requirements);
+  }
+
+  if (unresolved.length === 0) return;
+  const remainingMs = Math.floor(state.deadline - performance.now());
+  if (remainingMs <= 0) {
+    throw new GitHubPublicSourceError("GITHUB_TIMEOUT", "GitHub exact-object resolution timed out", {
+      retryable: true,
+    });
+  }
+
+  let resolved;
+  try {
+    resolved = await state.exactObjectResolver(Object.freeze({
+      repositoryUri: request.repositoryUri,
+      revisionObjectId: request.revisionObjectId,
+      treeObjectId: request.treeObjectId,
+      paths: Object.freeze(unresolved.map(({ path }) => path)),
+      timeoutMs: remainingMs,
+      maximumFileBytes: maximumDeclaredBlobBytes,
+      maximumTotalBytes: maximumDeclaredAggregateBytes - aggregateBytes,
+    }));
+  } catch (error) {
+    if (error instanceof GitHubPublicSourceError) throw error;
+    throw new GitHubPublicSourceError(
+      "GITHUB_PROTOCOL_ERROR",
+      "The trusted exact Git object resolver failed unexpectedly",
+      { cause: error },
+    );
+  }
+
+  const records = resolved instanceof Map ? resolved : resolved?.records;
+  if (!(records instanceof Map) || records.size !== unresolved.length) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_PROTOCOL_ERROR",
+      "The trusted exact Git object resolver returned an invalid path set",
+    );
+  }
+  const unresolvedPaths = new Set(unresolved.map(({ path }) => path));
+  for (const path of records.keys()) {
+    if (!unresolvedPaths.has(path)) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_PROTOCOL_ERROR",
+        "The trusted exact Git object resolver returned an undeclared path",
+      );
+    }
+  }
+
+  for (const requirement of unresolved) {
+    const record = records.get(requirement.path);
+    if (!isPlainExactObjectRecord(record)) throwMissingDeclaredPath(requirement.kind);
+    const bytes = Buffer.from(record.bytes);
+    aggregateBytes = addDeclaredBytesToAggregate(aggregateBytes, bytes.length);
+    const resolvedEntry = {
+      type: "blob",
+      mode: record.mode,
+      sha: record.objectId,
+      size: bytes.length,
+    };
+    if (!isRegularBlob(resolvedEntry)) throwMissingDeclaredPath(requirement.kind);
+    const expected = expectedEntries?.get(requirement.path) ?? null;
+    if (
+      expected !== null
+      && (
+        expected.type !== resolvedEntry.type
+        || expected.mode !== resolvedEntry.mode
+        || expected.sha !== resolvedEntry.sha
+        || expected.size !== resolvedEntry.size
+      )
+    ) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_PROTOCOL_ERROR",
+        "The exact Git object did not match GitHub tree metadata",
+      );
+    }
+    validateDeclaredBlobBytes(resolvedEntry, bytes, requirement.kind);
+  }
+}
+
+function isPlainExactObjectRecord(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const keys = Object.keys(value).sort();
+  return keys.length === 3
+    && keys[0] === "bytes"
+    && keys[1] === "mode"
+    && keys[2] === "objectId"
+    && (value.mode === "100644" || value.mode === "100755")
+    && lowerHex40.test(value.objectId)
+    && value.bytes instanceof Uint8Array;
+}
+
+function addDeclaredBytesToAggregate(current, additional) {
+  if (!Number.isSafeInteger(additional) || additional < 0 || additional > maximumDeclaredBlobBytes) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_RESPONSE_TOO_LARGE",
+      "A declared source blob exceeds the canonical review limit",
+    );
+  }
+  const next = current + additional;
+  if (next > maximumDeclaredAggregateBytes) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_RESPONSE_TOO_LARGE",
+      "Declared source blobs exceed the canonical aggregate review limit",
+    );
+  }
+  return next;
+}
+
+async function validateDeclaredPathsByTreeWalk(repositoryPrefix, request, actionsEvidence, state) {
+  const treeCache = new Map();
+  const blobCache = new Map();
+  const walkBudget = { requestsRemaining: maximumTreeWalkRequestsPerRepository };
+  const requirements = declaredPathRequirements(request, actionsEvidence);
+  let aggregateBytes = 0;
+
+  const loadTree = async (treeObjectId) => {
+    const cached = treeCache.get(treeObjectId);
+    if (cached !== undefined) return cached;
+    if (walkBudget.requestsRemaining <= 0) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_TREE_TRUNCATED",
+        "GitHub tree could not be resolved within the bounded walk request limit",
+      );
+    }
+    walkBudget.requestsRemaining -= 1;
+    const response = await requestGitHubJson(
+      `${repositoryPrefix}/git/trees/${treeObjectId}`,
+      "tree",
+      state,
+    );
+    const indexed = indexTreeResponse(response, treeObjectId, "direct");
+    treeCache.set(treeObjectId, indexed);
+    return indexed;
+  };
+
+  for (const requirement of requirements) {
+    const parts = requirement.path.split("/");
+    if (parts.length > maximumTreeWalkDepth) {
+      throw new GitHubPublicSourceError(
+        "GITHUB_TREE_TRUNCATED",
+        "GitHub tree could not be resolved within the bounded walk depth",
+      );
+    }
+    let currentTreeObjectId = request.treeObjectId;
+    for (let index = 0; index < parts.length; index += 1) {
+      const entries = await loadTree(currentTreeObjectId);
+      const entry = entries.get(parts[index]);
+      const isLeaf = index === parts.length - 1;
+      if (isLeaf) {
+        if (!isRegularBlob(entry)) throwMissingDeclaredPath(requirement.kind);
+        aggregateBytes = addDeclaredBytesToAggregate(aggregateBytes, entry.size);
+        await validateDeclaredBlob(repositoryPrefix, requirement.path, entry, state, blobCache, requirement.kind);
+      } else {
+        if (entry?.type !== "tree" || entry.mode !== "040000") throwMissingDeclaredPath(requirement.kind);
+        currentTreeObjectId = entry.sha;
+      }
+    }
+  }
+}
+
+function isRegularBlob(entry) {
+  return entry?.type === "blob" && (entry.mode === "100644" || entry.mode === "100755");
+}
+
+async function validateDeclaredBlob(repositoryPrefix, filePath, entry, state, cache, kind) {
+  const localBytes = state.localBlobBytes.get(`${repositoryPrefix}\0${filePath}`);
+  if (localBytes !== undefined) {
+    validateDeclaredBlobBytes(entry, localBytes, kind);
+    cache.set(entry.sha, entry.size);
+    return;
+  }
+  const cached = cache.get(entry.sha);
+  if (cached !== undefined) {
+    if (cached !== entry.size) throwMissingDeclaredPath(kind);
+    return;
+  }
+  if (entry.size > maximumDeclaredBlobBytes) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_RESPONSE_TOO_LARGE",
+      "A declared source blob exceeds the bounded inert-content limit"
+    );
+  }
+  const response = await requestGitHubJson(`${repositoryPrefix}/git/blobs/${entry.sha}`, "blob", state);
+  const observedSha = normalizeGitObjectId(response.sha, "blob", "GITHUB_PROTOCOL_ERROR");
+  const observedSize = normalizeTreeBlobSize(response.size);
+  if (observedSha !== entry.sha || observedSize !== entry.size || response.encoding !== "base64") {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub declared blob metadata did not match the tree");
+  }
+  if (typeof response.content !== "string" || /[^A-Za-z0-9+/=\n]/u.test(response.content)) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub declared blob content encoding was invalid");
+  }
+  const compactBase64 = response.content.replaceAll("\n", "");
+  if (compactBase64.length % 4 !== 0) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub declared blob content encoding was invalid");
+  }
+  const bytes = Buffer.from(compactBase64, "base64");
+  if (bytes.toString("base64") !== compactBase64 || bytes.length !== entry.size) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub declared blob bytes did not match metadata");
+  }
+  validateDeclaredBlobBytes(entry, bytes, kind);
+  cache.set(entry.sha, entry.size);
+}
+
+function validateDeclaredBlobBytes(entry, bytes, kind) {
+  if (bytes.length > maximumDeclaredBlobBytes) {
+    throw new GitHubPublicSourceError(
+      "GITHUB_RESPONSE_TOO_LARGE",
+      "A declared source blob exceeds the canonical review limit",
+    );
+  }
+  if (bytes.length !== entry.size) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub declared blob bytes did not match metadata");
+  }
+  const gitObjectSha = createHash("sha1")
+    .update(`blob ${bytes.length}\0`, "utf8")
+    .update(bytes)
+    .digest("hex");
+  if (gitObjectSha !== entry.sha) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub declared blob bytes did not match its object id");
+  }
+  if (isGitLfsPointer(bytes)) {
+    throwMissingDeclaredPath(kind, "A declared source path is a Git LFS pointer, not source bytes");
+  }
+}
+
+function throwMissingDeclaredPath(kind, detail = null) {
+  if (kind === "workflow") {
+    throw new GitHubPublicSourceError(
+      "GITHUB_ACTIONS_WORKFLOW_NOT_IN_TREE",
+      detail ?? "GitHub Actions workflow was not found as a regular blob in the exact tree",
+    );
+  }
+  throw new GitHubPublicSourceError(
+    "GITHUB_DECLARED_PATH_NOT_FOUND",
+    detail ?? "A declared source path was not found as a regular blob in the exact tree"
+  );
+}
+
+function validateActionsRun(run, request, owner, repository, expectedRunId) {
+  const runId = normalizeOpaqueId(run.id, "GitHub Actions run id", "GITHUB_PROTOCOL_ERROR", true);
+  if (runId !== expectedRunId) {
+    throw new GitHubPublicSourceError("GITHUB_ACTIONS_RUN_MISMATCH", "GitHub Actions run id did not match");
+  }
+  assertPlainObject(run.repository, "GITHUB_PROTOCOL_ERROR", "GitHub Actions repository must be an object");
+  const repositoryId = normalizeOpaqueId(run.repository.id, "repository id", "GITHUB_PROTOCOL_ERROR", true);
+  if (repositoryId !== request.numericRepositoryId) {
+    throw new GitHubPublicSourceError("GITHUB_ACTIONS_RUN_MISMATCH", "GitHub Actions repository did not match");
+  }
+  const headRevision = normalizeGitObjectId(run.head_sha, "GitHub Actions head commit", "GITHUB_PROTOCOL_ERROR");
+  if (headRevision !== request.revisionObjectId) {
+    throw new GitHubPublicSourceError("GITHUB_ACTIONS_RUN_MISMATCH", "GitHub Actions head commit did not match");
+  }
+  assertPlainObject(run.head_commit, "GITHUB_PROTOCOL_ERROR", "GitHub Actions head commit must be an object");
+  const headCommitId = normalizeGitObjectId(run.head_commit.id, "GitHub Actions head commit", "GITHUB_PROTOCOL_ERROR");
+  const headTree = normalizeGitObjectId(run.head_commit.tree_id, "GitHub Actions head tree", "GITHUB_PROTOCOL_ERROR");
+  if (headCommitId !== request.revisionObjectId || headTree !== request.treeObjectId) {
+    throw new GitHubPublicSourceError("GITHUB_ACTIONS_RUN_MISMATCH", "GitHub Actions source identity did not match");
+  }
+
+  const workflowPath = normalizeWorkflowPath(run.path);
+  const workflowId = normalizeOpaqueId(
+    run.workflow_id,
+    "GitHub Actions workflow id",
+    "GITHUB_PROTOCOL_ERROR",
+    true,
+  );
+  const runAttempt = normalizeOpaqueId(
+    run.run_attempt,
+    "GitHub Actions run attempt",
+    "GITHUB_PROTOCOL_ERROR",
+    true,
+  );
+  const event = normalizeSafeCode(run.event, "GitHub Actions event");
+  const status = normalizeSafeCode(run.status, "GitHub Actions status");
+  const conclusion = run.conclusion === null ? null : normalizeSafeCode(run.conclusion, "GitHub Actions conclusion");
+  validateActionsHtmlUrl(run.html_url, owner, repository, runId);
+
+  return deepFreeze({
+    runId,
+    runAttempt,
+    workflowId,
+    workflowPath,
+    headRevision,
+    headTree,
+    event,
+    status,
+    conclusion,
+    htmlUrl: `https://github.com/${owner}/${repository}/actions/runs/${runId}`,
+  });
+}
+
+function normalizeTransportResponse(response, expectedUrl) {
+  assertPlainObject(response, "GITHUB_PROTOCOL_ERROR", "transport response must be an object");
+  if (!Number.isInteger(response.status) || response.status < 100 || response.status > 599) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "transport status was invalid");
+  }
+  if (response.redirected === true) {
+    throw new GitHubPublicSourceError("GITHUB_REDIRECT_REJECTED", "GitHub redirect was rejected", {
+      status: response.status,
+    });
+  }
+  if (response.responseUrl !== undefined && response.responseUrl !== "" && response.responseUrl !== expectedUrl) {
+    throw new GitHubPublicSourceError("GITHUB_REDIRECT_REJECTED", "GitHub response URL changed");
+  }
+
+  let body;
+  if (typeof response.body === "string") {
+    body = encoder.encode(response.body);
+  } else if (response.body instanceof Uint8Array) {
+    body = response.body;
+  } else if (response.body instanceof ArrayBuffer) {
+    body = new Uint8Array(response.body);
+  } else {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "transport body must be bytes or text");
+  }
+
+  return {
+    status: response.status,
+    headers: normalizeHeaders(response.headers),
+    body,
+  };
+}
+
+function normalizeHeaders(headers) {
+  if (headers === undefined || headers === null) return Object.create(null);
+  const output = Object.create(null);
+  if (typeof headers.get === "function") {
+    for (const name of ["retry-after", "x-ratelimit-remaining", "content-type"]) {
+      output[name] = headers.get(name);
+    }
+    return output;
+  }
+  assertPlainObject(headers, "GITHUB_PROTOCOL_ERROR", "transport headers must be an object");
+  for (const [name, value] of Object.entries(headers)) {
+    output[name.toLowerCase()] = normalizeTransportHeaderValue(value);
+  }
+  return output;
+}
+
+async function readBoundedResponseBody(response, maxBytes) {
+  if (response.body?.getReader) {
+    const reader = response.body.getReader();
+    const chunks = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // The size violation remains authoritative even if a hostile stream rejects cancellation.
+        }
+        throw new GitHubPublicSourceError("GITHUB_RESPONSE_TOO_LARGE", "GitHub response exceeded the byte limit");
+      }
+      chunks.push(value);
+    }
+    const output = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      output.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return output;
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength > maxBytes) {
+    throw new GitHubPublicSourceError("GITHUB_RESPONSE_TOO_LARGE", "GitHub response exceeded the byte limit");
+  }
+  return bytes;
+}
+
+function parseCanonicalRepositoryUri(value) {
+  if (typeof value !== "string") invalidRequest("repositoryUri must be a canonical GitHub URL");
+  const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+)$/.exec(value);
+  if (!match) invalidRequest("repositoryUri must be a canonical GitHub URL");
+  const [, owner, repository] = match;
+  if (
+    !ownerPattern.test(owner) ||
+    owner.includes("--") ||
+    !repositoryPattern.test(repository) ||
+    !/[a-z0-9]/.test(repository) ||
+    repository === "." ||
+    repository === ".." ||
+    repository.endsWith(".git")
+  ) {
+    invalidRequest("repositoryUri must use canonical lowercase GitHub owner and repository names");
+  }
+  const canonical = `https://github.com/${owner}/${repository}`;
+  if (value !== canonical) invalidRequest("repositoryUri must be canonical and lowercase");
+  return { owner, repository };
+}
+
+function assertPublicFetchRequest(request, allowPublicUserLookups) {
+  assertPlainObject(request, "INVALID_OPTIONS", "public GitHub transport request must be an object");
+  assertCanonicalApiUrl(request.url, allowPublicUserLookups);
+  if (request.method !== "GET" || request.redirect !== "error") {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "public GitHub transport is read-only and redirect-free");
+  }
+  if (!Number.isSafeInteger(request.maxResponseBytes) || request.maxResponseBytes < 1) {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "public GitHub transport requires a byte limit");
+  }
+  assertPlainObject(request.headers, "INVALID_OPTIONS", "public GitHub transport headers must be an object");
+  const headerNames = Object.keys(request.headers).sort(compareUtf8);
+  const expectedNames = ["Accept", "User-Agent", "X-GitHub-Api-Version"].sort(compareUtf8);
+  if (
+    headerNames.length !== expectedNames.length ||
+    headerNames.some((name, index) => name !== expectedNames[index]) ||
+    request.headers.Accept !== "application/vnd.github+json" ||
+    request.headers["User-Agent"] !== GITHUB_PUBLIC_SOURCE_CONTRACT_V1.userAgent ||
+    request.headers["X-GitHub-Api-Version"] !== GITHUB_PUBLIC_SOURCE_CONTRACT_V1.githubApiVersion
+  ) {
+    throw new GitHubPublicSourceError("INVALID_OPTIONS", "public GitHub transport accepts only pinned public headers");
+  }
+}
+
+function validateRepositoryHtmlUrl(value, expectedOwner, expectedRepository) {
+  if (typeof value !== "string") {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub repository URL was invalid");
+  }
+  let url;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub repository URL was invalid", { cause: error });
+  }
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (
+    url.protocol !== "https:" ||
+    url.hostname.toLowerCase() !== "github.com" ||
+    url.hostname !== "github.com" ||
+    url.port !== "" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    parts.length !== 2 ||
+    parts[0].toLowerCase() !== expectedOwner ||
+    parts[1].toLowerCase() !== expectedRepository
+  ) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub repository URL was invalid");
+  }
+}
+
+function validateCommitHtmlUrl(value, owner, repository, commit) {
+  validateStructuredGitHubUrl(value, [owner, repository, "commit", commit], "GitHub commit URL was invalid");
+}
+
+function validateActionsHtmlUrl(value, owner, repository, runId) {
+  validateStructuredGitHubUrl(
+    value,
+    [owner, repository, "actions", "runs", runId],
+    "GitHub Actions URL was invalid",
+  );
+}
+
+function validateStructuredGitHubUrl(value, expectedParts, message) {
+  if (typeof value !== "string") {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", message);
+  }
+  let url;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", message, { cause: error });
+  }
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "github.com" ||
+    url.port !== "" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    parts.length !== expectedParts.length ||
+    parts.some((part, index) =>
+      index < 2 ? part.toLowerCase() !== expectedParts[index] : part !== expectedParts[index],
+    )
+  ) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", message);
+  }
+}
+
+function assertCanonicalApiUrl(value, allowPublicUserLookups) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub API URL was invalid", { cause: error });
+  }
+  const repositoryPath = url.pathname.startsWith("/repos/");
+  const publicUserPath = /^\/users\/[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/u.test(url.pathname);
+  if (
+    url.origin !== GITHUB_PUBLIC_SOURCE_CONTRACT_V1.apiOrigin ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.hash !== "" ||
+    (!repositoryPath && !(allowPublicUserLookups && publicUserPath)) ||
+    (publicUserPath && url.search !== "") ||
+    (repositoryPath && url.search !== "" && url.search !== "?recursive=1")
+  ) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub API URL escaped the public source contract");
+  }
+}
+
+function normalizeWorkflowPath(value) {
+  if (typeof value !== "string") {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub Actions workflow path was invalid");
+  }
+  const separator = value.lastIndexOf("@");
+  const candidate = separator === -1 ? value : value.slice(0, separator);
+  let path;
+  try {
+    path = normalizeRepositoryPath(candidate);
+  } catch (error) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub Actions workflow path was invalid", {
+      cause: error,
+    });
+  }
+  if (!path.startsWith(".github/workflows/") || !/\.ya?ml$/.test(path)) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub Actions workflow path was invalid");
+  }
+  return path;
+}
+
+function normalizeRepositoryPath(value) {
+  if (!isCanonicalReviewTargetPath(value)) invalidRequest("repository path is not canonical");
+  return value;
+}
+
+function isWellFormedUnicode(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function normalizeUniqueArray(value, limit, normalizer, label) {
+  if (!Array.isArray(value)) invalidRequest(`${label} must be an array`);
+  if (value.length > limit) invalidRequest(`${label} exceed the contract limit`);
+  const normalized = value.map(normalizer).sort(compareUtf8);
+  assertNoDuplicateSortedValues(normalized, label);
+  return deepFreeze(normalized);
+}
+
+function assertNoDuplicateSortedValues(values, label) {
+  for (let index = 1; index < values.length; index += 1) {
+    if (values[index - 1] === values[index]) invalidRequest(`${label} must be unique`);
+  }
+}
+
+function normalizeOpaqueId(value, label, errorCode, requireLosslessJsonNumber = false) {
+  let normalized;
+  if (requireLosslessJsonNumber && value instanceof LosslessJsonNumber) {
+    normalized = value.source;
+  } else if (!requireLosslessJsonNumber && typeof value === "string") {
+    normalized = value;
+  } else {
+    throw new GitHubPublicSourceError(errorCode, `${label} must be a canonical opaque decimal string`);
+  }
+  if (!opaqueDecimal.test(normalized)) {
+    throw new GitHubPublicSourceError(errorCode, `${label} must be a canonical opaque decimal string`);
+  }
+  return normalized;
+}
+
+export function parseBoundedLosslessJson(source) {
+  if (typeof source !== "string") throw new SyntaxError("JSON source must be text");
+  let cursor = 0;
+  let nodes = 0;
+  const numberPattern = /-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?/y;
+
+  const value = parseValue(0);
+  skipWhitespace();
+  if (cursor !== source.length) throw new SyntaxError("JSON contains trailing data");
+  return value;
+
+  function parseValue(depth) {
+    if (depth > maximumJsonDepth) throw new SyntaxError("JSON nesting exceeds the limit");
+    consumeNode();
+    skipWhitespace();
+    const character = source[cursor];
+    if (character === "{") return parseObject(depth);
+    if (character === "[") return parseArray(depth);
+    if (character === '"') return parseString();
+    if (character === "t" && source.startsWith("true", cursor)) {
+      cursor += 4;
+      return true;
+    }
+    if (character === "f" && source.startsWith("false", cursor)) {
+      cursor += 5;
+      return false;
+    }
+    if (character === "n" && source.startsWith("null", cursor)) {
+      cursor += 4;
+      return null;
+    }
+    if (character === "-" || (character >= "0" && character <= "9")) return parseNumber();
+    throw new SyntaxError("JSON value is invalid");
+  }
+
+  function parseObject(depth) {
+    cursor += 1;
+    const output = Object.create(null);
+    const keys = new Set();
+    skipWhitespace();
+    if (source[cursor] === "}") {
+      cursor += 1;
+      return output;
+    }
+    while (cursor < source.length) {
+      skipWhitespace();
+      if (source[cursor] !== '"') throw new SyntaxError("JSON object key is invalid");
+      consumeNode();
+      const key = parseString();
+      if (keys.has(key)) throw new SyntaxError("JSON object contains a duplicate key");
+      keys.add(key);
+      skipWhitespace();
+      if (source[cursor] !== ":") throw new SyntaxError("JSON object separator is invalid");
+      cursor += 1;
+      output[key] = parseValue(depth + 1);
+      skipWhitespace();
+      if (source[cursor] === "}") {
+        cursor += 1;
+        return output;
+      }
+      if (source[cursor] !== ",") throw new SyntaxError("JSON object delimiter is invalid");
+      cursor += 1;
+    }
+    throw new SyntaxError("JSON object is unterminated");
+  }
+
+  function parseArray(depth) {
+    cursor += 1;
+    const output = [];
+    skipWhitespace();
+    if (source[cursor] === "]") {
+      cursor += 1;
+      return output;
+    }
+    while (cursor < source.length) {
+      output.push(parseValue(depth + 1));
+      skipWhitespace();
+      if (source[cursor] === "]") {
+        cursor += 1;
+        return output;
+      }
+      if (source[cursor] !== ",") throw new SyntaxError("JSON array delimiter is invalid");
+      cursor += 1;
+    }
+    throw new SyntaxError("JSON array is unterminated");
+  }
+
+  function parseString() {
+    const start = cursor;
+    cursor += 1;
+    while (cursor < source.length) {
+      const code = source.charCodeAt(cursor);
+      if (code === 0x22) {
+        cursor += 1;
+        // Only an isolated quoted token reaches JSON.parse; numeric tokens never do.
+        return JSON.parse(source.slice(start, cursor));
+      }
+      if (code === 0x5c) {
+        cursor += 2;
+        continue;
+      }
+      if (code <= 0x1f) throw new SyntaxError("JSON string contains a control character");
+      cursor += 1;
+    }
+    throw new SyntaxError("JSON string is unterminated");
+  }
+
+  function parseNumber() {
+    numberPattern.lastIndex = cursor;
+    const match = numberPattern.exec(source);
+    if (match === null) throw new SyntaxError("JSON number is invalid");
+    if (match[0].length > maximumJsonNumberCharacters) throw new SyntaxError("JSON number exceeds the limit");
+    cursor = numberPattern.lastIndex;
+    return new LosslessJsonNumber(match[0]);
+  }
+
+  function skipWhitespace() {
+    while (
+      source[cursor] === " " ||
+      source[cursor] === "\t" ||
+      source[cursor] === "\n" ||
+      source[cursor] === "\r"
+    ) {
+      cursor += 1;
+    }
+  }
+
+  function consumeNode() {
+    nodes += 1;
+    if (nodes > maximumJsonNodes) throw new SyntaxError("JSON node count exceeds the limit");
+  }
+}
+
+function normalizeGitObjectId(value, label, errorCode) {
+  if (typeof value !== "string" || !lowerHex40.test(value)) {
+    throw new GitHubPublicSourceError(errorCode, `${label} must be an exact lowercase 40-hex Git object id`);
+  }
+  return value;
+}
+
+function normalizeTreeEntryMode(value, type) {
+  const allowedByType = {
+    blob: new Set(["100644", "100755", "120000"]),
+    tree: new Set(["040000"]),
+    commit: new Set(["160000"]),
+  };
+  if (typeof value !== "string" || !allowedByType[type]?.has(value)) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub tree entry mode did not match its type");
+  }
+  return value;
+}
+
+function normalizeTreeBlobSize(value) {
+  if (!(value instanceof LosslessJsonNumber) || !/^(?:0|[1-9][0-9]*)$/u.test(value.source)) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub blob size was invalid");
+  }
+  const size = BigInt(value.source);
+  if (size > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", "GitHub blob size exceeded the supported range");
+  }
+  return Number(size);
+}
+
+function normalizeDisplayText(value, maximumBytes, label) {
+  if (
+    typeof value !== "string" ||
+    encoder.encode(value).byteLength < 1 ||
+    encoder.encode(value).byteLength > maximumBytes ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", `${label} was invalid`);
+  }
+  return value;
+}
+
+function normalizeSafeCode(value, label) {
+  if (typeof value !== "string" || !safeCodePattern.test(value)) {
+    throw new GitHubPublicSourceError("GITHUB_PROTOCOL_ERROR", `${label} was invalid`);
+  }
+  return value;
+}
+
+function normalizeContentLength(value) {
+  if (value === null || value === undefined || value === "") return null;
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) return null;
+  const number = Number(value);
+  return Number.isSafeInteger(number) ? number : null;
+}
+
+function normalizeRetryAfter(value) {
+  if (typeof value !== "string" || !/^(0|[1-9][0-9]{0,4})$/.test(value)) return null;
+  const seconds = Number(value);
+  return seconds <= 86_400 ? String(seconds) : null;
+}
+
+function normalizeTransportHeaderValue(value) {
+  if (value === null || value === undefined) return null;
+  return typeof value === "string" ? value : String(value);
+}
+
+function compareRepositoryRequests(left, right) {
+  return compareUtf8(left.numericRepositoryId, right.numericRepositoryId);
+}
+
+function compareUtf8(left, right) {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("non-finite numbers are not canonical JSON");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (typeof value !== "object") throw new TypeError("value is not canonical JSON");
+  const keys = Object.keys(value).sort(compareUtf8);
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+function deepFreeze(value) {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const nested of Object.values(value)) deepFreeze(nested);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function assertPlainObject(value, code, message) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new GitHubPublicSourceError(code, message);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new GitHubPublicSourceError(code, message);
+  }
+}
+
+function assertExactKeys(value, allowed, code) {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      throw new GitHubPublicSourceError(code, "object contains an unsupported field");
+    }
+  }
+}
+
+function invalidRequest(message) {
+  throw new GitHubPublicSourceError("INVALID_REQUEST", message);
+}
+
+function githubUnavailableMessage(resourceKind) {
+  if (resourceKind === "repository") return "GitHub public repository is unavailable";
+  if (resourceKind === "commit") return "GitHub commit is not reachable from the public repository";
+  if (resourceKind === "tree") return "GitHub tree is not reachable from the public repository";
+  if (resourceKind === "blob") return "GitHub declared blob is not reachable from the public repository";
+  return "GitHub Actions run is not reachable from the public repository";
+}

--- a/skills/programmable-v4-hook-builder/scripts/official-launchpad-core.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/official-launchpad-core.mjs
@@ -1,0 +1,479 @@
+const addressPattern = /^0x[a-fA-F0-9]{40}$/;
+const commitPattern = /^[a-f0-9]{40}$/i;
+const sha256Pattern = /^[a-f0-9]{64}$/i;
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+const requiredSourceIds = new Set([
+  "uniswap-deployments-feed",
+  "cca-repository-readme",
+  "liquidity-launcher-repository-readme",
+  "uerc20-factory-repository-readme",
+  "cca-repository-changelog",
+  "cca-v2.1-factory-source",
+  "liquidity-launcher-v3.0-source",
+  "lbp-strategy-v3.1-source",
+  "uerc20-factory-v2.0-source",
+  "usuperc20-factory-v2.0-source",
+  "liquidity-launchpad-docs-overview",
+  "liquidity-launchpad-docs-deployments",
+  "v4-docs-deployments",
+  "universal-router-mainnet-deployments",
+  "universal-router-base-deployments",
+  "universal-router-unichain-deployments",
+  "universal-router-sepolia-deployments"
+]);
+
+const requiredComponentReleases = new Map([
+  ["ContinuousClearingAuctionFactory", {
+    version: "v2.1.0",
+    commit: "7d7602d257733315434570f2a0c2f94f1c7b207a"
+  }],
+  ["LiquidityLauncher", {
+    version: "v3.0.0",
+    commit: "3a3103543f50a13a0ae52a253bb98a925d72146f"
+  }],
+  ["LBPStrategy", {
+    version: "v3.1.0",
+    commit: "873cbb23c5019a795193c5ad561edff2f78ba5a3"
+  }],
+  ["UERC20Factory", {
+    version: "v2.0.0",
+    commit: "de5bacd215f6aae50e524297c18fcf78b69b6312"
+  }],
+  ["USUPERC20Factory", {
+    version: "v2.0.0",
+    commit: "de5bacd215f6aae50e524297c18fcf78b69b6312"
+  }]
+]);
+
+const conflictedUniversalRouterRecordIds = new Set([
+  "universal-router-universalrouter-ethereum",
+  "universal-router-universalrouter-unichain",
+  "universal-router-universalrouter-sepolia"
+]);
+
+const requiredProfiles = new Map([
+  ["official-cca-lbp-new-token-ethereum", { chain: "Ethereum", chainId: 1 }],
+  ["official-cca-lbp-new-token-base", { chain: "Base", chainId: 8453 }],
+  ["official-cca-lbp-new-token-unichain", { chain: "Unichain", chainId: 130 }],
+  ["official-cca-lbp-new-token-sepolia", { chain: "Sepolia", chainId: 11155111 }]
+]);
+
+const requiredProfileSlots = [
+  "tokenFactory",
+  "auctionFactory",
+  "liquidityLauncher",
+  "liquidityStrategy",
+  "poolManager",
+  "positionManager",
+  "universalRouter",
+  "permit2"
+];
+
+const expectedProfileContracts = {
+  tokenFactory: new Set(["UERC20Factory", "USUPERC20Factory"]),
+  auctionFactory: new Set(["ContinuousClearingAuctionFactory"]),
+  liquidityLauncher: new Set(["LiquidityLauncher"]),
+  liquidityStrategy: new Set(["LBPStrategy"]),
+  poolManager: new Set(["PoolManager"]),
+  positionManager: new Set(["PositionManager"]),
+  universalRouter: new Set(["UniversalRouter"]),
+  permit2: new Set(["Permit2"])
+};
+
+export const staleCcaV11Address = "0xCCccCcCAE7503Cac057829BF2811De42E16e0bD5";
+
+export class OfficialLaunchpadReferenceError extends Error {}
+
+export function validateOfficialLaunchpadReference(reference) {
+  assertObject(reference, "reference");
+  if (reference.schemaVersion !== 1) fail("reference.schemaVersion must be 1");
+  if (reference.referenceKind !== "official-uniswap-launchpad-deployment-reference") {
+    fail("reference.referenceKind is unsupported");
+  }
+  if (!datePattern.test(reference.snapshotDate ?? "")) {
+    fail("reference.snapshotDate must use YYYY-MM-DD");
+  }
+  validateAuthorityPolicy(reference.authorityPolicy);
+
+  if (!Array.isArray(reference.sources)) fail("reference.sources must be an array");
+  const sourcesById = new Map();
+  for (const [index, source] of reference.sources.entries()) {
+    validateSource(source, `reference.sources[${index}]`);
+    if (sourcesById.has(source.id)) fail(`duplicate source id ${source.id}`);
+    sourcesById.set(source.id, source);
+  }
+  for (const sourceId of requiredSourceIds) {
+    if (!sourcesById.has(sourceId)) fail(`missing required official source ${sourceId}`);
+  }
+
+  validateDocumentedConflicts(reference.documentedConflicts, sourcesById);
+  validateForbiddenDefaults(reference.forbiddenDefaults);
+
+  if (!Array.isArray(reference.records) || reference.records.length === 0) {
+    fail("reference.records must be a non-empty array");
+  }
+  const recordsById = new Map();
+  const componentVersions = new Map();
+  for (const [index, record] of reference.records.entries()) {
+    validateRecord(record, `reference.records[${index}]`, sourcesById);
+    if (recordsById.has(record.id)) fail(`duplicate deployment record id ${record.id}`);
+    if (record.address.toLowerCase() === staleCcaV11Address.toLowerCase()) {
+      fail(`stale CCA v1.1 address is forbidden in active record ${record.id}`);
+    }
+    recordsById.set(record.id, record);
+    if (!componentVersions.has(record.contract)) componentVersions.set(record.contract, new Set());
+    componentVersions.get(record.contract).add(record.version);
+  }
+  for (const [contract, release] of requiredComponentReleases) {
+    if (!componentVersions.get(contract)?.has(release.version)) {
+      fail(`missing required ${contract} ${release.version} deployment record`);
+    }
+  }
+  for (const contract of ["PoolManager", "PositionManager", "UniversalRouter", "Permit2"]) {
+    if (!componentVersions.has(contract)) fail(`missing required ${contract} deployment record`);
+  }
+
+  if (!Array.isArray(reference.profiles) || reference.profiles.length === 0) {
+    fail("reference.profiles must be a non-empty array");
+  }
+  const profilesById = new Map();
+  for (const [index, profile] of reference.profiles.entries()) {
+    validateProfile(profile, `reference.profiles[${index}]`, recordsById);
+    if (profilesById.has(profile.id)) fail(`duplicate launch profile id ${profile.id}`);
+    profilesById.set(profile.id, profile);
+  }
+  for (const [profileId, expected] of requiredProfiles) {
+    const profile = profilesById.get(profileId);
+    if (!profile) fail(`missing required launch profile ${profileId}`);
+    if (profile.chain !== expected.chain || profile.chainId !== expected.chainId) {
+      fail(`${profileId} must target ${expected.chain} (${expected.chainId})`);
+    }
+  }
+
+  return { sourcesById, recordsById, profilesById };
+}
+
+export function resolveOfficialLaunchProfile(reference, profileId, options = {}) {
+  const validated = validateOfficialLaunchpadReference(reference);
+  assertObject(options, "options");
+  if (Object.keys(options).length > 0) {
+    fail("prompt-supplied deployment addresses are forbidden; select a committed profile id");
+  }
+  if (typeof profileId !== "string" || profileId.length === 0) fail("profileId must be a non-empty string");
+  const profile = validated.profilesById.get(profileId);
+  if (!profile) fail(`unknown official launch profile ${profileId}`);
+
+  const records = {};
+  for (const slot of requiredProfileSlots) {
+    const record = validated.recordsById.get(profile.records[slot]);
+    records[slot] = Object.freeze({
+      ...record,
+      authoritySourceIds: Object.freeze([...record.authoritySourceIds])
+    });
+  }
+  const hasSourceConflict = Object.values(records)
+    .some((record) => record.sourceResolutionStatus === "official-feed-ref-conflicted");
+  return Object.freeze({
+    id: profile.id,
+    chain: profile.chain,
+    chainId: profile.chainId,
+    status: profile.status,
+    sourceConflictStatus: hasSourceConflict ? "blocked-official-source-conflict" : "no-recorded-source-conflict",
+    runtimeVerificationStatus: "unverified",
+    executionStatus: hasSourceConflict
+      ? "blocked-official-source-conflict"
+      : "blocked-pending-runtime-and-interface-verification",
+    records: Object.freeze(records)
+  });
+}
+
+export function compareOfficialDeploymentRecords(reference, observedRecords) {
+  const { recordsById } = validateOfficialLaunchpadReference(reference);
+  if (!Array.isArray(observedRecords)) fail("observed deployment records must be an array");
+  const observedById = new Map();
+  for (const [index, observed] of observedRecords.entries()) {
+    assertObject(observed, `observedRecords[${index}]`);
+    if (typeof observed.id !== "string" || observed.id.length === 0) {
+      fail(`observedRecords[${index}].id must be a non-empty string`);
+    }
+    if (observedById.has(observed.id)) fail(`duplicate observed deployment record ${observed.id}`);
+    observedById.set(observed.id, observed);
+  }
+
+  const fields = [
+    "protocol",
+    "contract",
+    "chain",
+    "chainId",
+    "address",
+    "tier",
+    "sourceRepo",
+    "sourceRef",
+    "sourceCodeUrl",
+    "env",
+    "status"
+  ];
+  const findings = [];
+  for (const record of recordsById.values()) {
+    const observed = observedById.get(record.feedRecordId);
+    if (!observed) {
+      findings.push({
+        code: "official-deployment-record-missing",
+        recordId: record.id,
+        expected: "present",
+        actual: "missing"
+      });
+      continue;
+    }
+    for (const field of fields) {
+      if (record[field] === observed[field]) continue;
+      findings.push({
+        code: `official-deployment-${toKebabCase(field)}-drift`,
+        recordId: record.id,
+        field,
+        expected: record[field],
+        actual: observed[field] ?? null
+      });
+    }
+  }
+  findings.sort((left, right) => left.recordId.localeCompare(right.recordId)
+    || left.code.localeCompare(right.code)
+    || (left.field ?? "").localeCompare(right.field ?? ""));
+  return findings;
+}
+
+function validateAuthorityPolicy(policy) {
+  assertObject(policy, "reference.authorityPolicy");
+  const expected = {
+    promptSuppliedAddresses: "reject",
+    recordSelection: "committed-id-only",
+    unknownChainOrComponent: "block",
+    driftDecision: "block",
+    offlineVerification: "committed-reference-only",
+    runtimeVerification: "required-before-execution",
+    sourceVerification: "required-before-release-claim"
+  };
+  for (const [key, value] of Object.entries(expected)) {
+    if (policy[key] !== value) fail(`reference.authorityPolicy.${key} must be ${value}`);
+  }
+}
+
+function validateSource(source, location) {
+  assertObject(source, location);
+  nonEmptyString(source.id, `${location}.id`);
+  const kinds = new Set(["official-deployment-feed", "official-repository", "official-documentation"]);
+  if (!kinds.has(source.authorityKind)) fail(`${location}.authorityKind is unsupported`);
+
+  if (source.authorityKind === "official-deployment-feed") {
+    if (source.url !== "https://developers.uniswap.org/deployments.json") {
+      fail(`${location}.url must be the official Uniswap deployments feed`);
+    }
+    exactDigest(source.contentSha256, sha256Pattern, `${location}.contentSha256`, "SHA-256 digest");
+    nonEmptyString(source.generatedAt, `${location}.generatedAt`);
+    assertObject(source.source, `${location}.source`);
+    validateOfficialRepository(source.source.repository, `${location}.source.repository`);
+    exactDigest(source.source.commit, commitPattern, `${location}.source.commit`, "Git commit");
+    return;
+  }
+
+  validateOfficialRepository(source.repository, `${location}.repository`);
+  exactDigest(source.commit, commitPattern, `${location}.commit`, "Git commit");
+  validateRelativePath(source.path, `${location}.path`);
+  exactDigest(source.contentSha256, sha256Pattern, `${location}.contentSha256`, "SHA-256 digest");
+  const repositoryName = new URL(source.repository).pathname.replace(/\.git$/i, "").split("/").filter(Boolean)[1];
+  const expectedUrl = `https://raw.githubusercontent.com/Uniswap/${repositoryName}/${source.commit}/${source.path}`;
+  if (source.immutableUrl !== expectedUrl) fail(`${location}.immutableUrl does not match its repository, commit and path`);
+}
+
+function validateForbiddenDefaults(forbiddenDefaults) {
+  if (!Array.isArray(forbiddenDefaults) || forbiddenDefaults.length === 0) {
+    fail("reference.forbiddenDefaults must be a non-empty array");
+  }
+  const stale = forbiddenDefaults.find((entry) => entry?.address?.toLowerCase?.() === staleCcaV11Address.toLowerCase());
+  if (!stale) fail("reference.forbiddenDefaults must reject the CCA v1.1 deployment");
+  if (stale.contract !== "ContinuousClearingAuctionFactory" || stale.version !== "v1.1.0") {
+    fail("the stale CCA default must identify ContinuousClearingAuctionFactory v1.1.0");
+  }
+  if (stale.replacementContract !== "ContinuousClearingAuctionFactory" || stale.replacementVersion !== "v2.1.0") {
+    fail("the stale CCA default must point to ContinuousClearingAuctionFactory v2.1.0");
+  }
+  if (stale.releaseCommit !== "8508f332c3daf330b189290b335fd9da4e95f3f0") {
+    fail("the stale CCA default must retain its pinned v1.1 deployment commit");
+  }
+  if (stale.replacementAddress !== "0x000000001F26a0044BaA66024e7b6599c61963F8") {
+    fail("the stale CCA default must point to the pinned v2.1 deployment address");
+  }
+  if (stale.decision !== "reject") fail("the stale CCA default decision must be reject");
+}
+
+function validateDocumentedConflicts(conflicts, sourcesById) {
+  if (!Array.isArray(conflicts)) fail("reference.documentedConflicts must be an array");
+  const byId = new Map();
+  for (const [index, conflict] of conflicts.entries()) {
+    const location = `reference.documentedConflicts[${index}]`;
+    assertObject(conflict, location);
+    nonEmptyString(conflict.id, `${location}.id`);
+    if (byId.has(conflict.id)) fail(`duplicate documented conflict ${conflict.id}`);
+    for (const key of ["sourceId", "documentationSourceId"]) {
+      if (!Object.hasOwn(conflict, key)) continue;
+      if (!sourcesById.has(conflict[key])) fail(`${location}.${key} references unknown source ${conflict[key]}`);
+    }
+    for (const sourceId of conflict.preferredEvidence ?? []) {
+      if (!sourcesById.has(sourceId)) fail(`${location}.preferredEvidence references unknown source ${sourceId}`);
+    }
+    for (const [comparisonIndex, comparison] of (conflict.comparisons ?? []).entries()) {
+      if (!sourcesById.has(comparison.repositorySourceId)) {
+        fail(`${location}.comparisons[${comparisonIndex}].repositorySourceId references an unknown source`);
+      }
+    }
+    byId.set(conflict.id, conflict);
+  }
+  for (const requiredId of [
+    "cca-readme-changelog-latest-label-disagreement",
+    "launchpad-docs-behind-feed-and-release-readmes",
+    "universal-router-generic-record-disagreement"
+  ]) {
+    if (!byId.has(requiredId)) fail(`missing documented official-source conflict ${requiredId}`);
+  }
+}
+
+function validateRecord(record, location, sourcesById) {
+  assertObject(record, location);
+  for (const field of ["id", "feedRecordId", "protocol", "contract", "version", "chain", "tier", "sourceRepo", "sourceRef", "sourceCodeUrl", "env", "status", "sourceResolutionStatus", "runtimeVerification"]) {
+    nonEmptyString(record[field], `${location}.${field}`);
+  }
+  if (record.id !== record.feedRecordId) fail(`${location}.feedRecordId must equal its official feed record id`);
+  if (!Number.isSafeInteger(record.chainId) || record.chainId <= 0) fail(`${location}.chainId must be a positive integer`);
+  if (!addressPattern.test(record.address ?? "")) fail(`${location}.address must be an exact EVM address`);
+  if (record.status !== "active") fail(`${location}.status must be active`);
+  if (!new Set(["mainnet", "testnet"]).has(record.env)) fail(`${location}.env is unsupported`);
+  if (!new Set(["labs-launched", "labs-supported"]).has(record.tier)) fail(`${location}.tier is unsupported`);
+  validateOfficialRepository(record.sourceRepo, `${location}.sourceRepo`);
+  validateOfficialCodeUrl(record.sourceCodeUrl, `${location}.sourceCodeUrl`);
+  if (record.runtimeVerification !== "required-before-execution") {
+    fail(`${location}.runtimeVerification must be required-before-execution`);
+  }
+  if (!Array.isArray(record.authoritySourceIds) || !record.authoritySourceIds.includes("uniswap-deployments-feed")) {
+    fail(`${location}.authoritySourceIds must include uniswap-deployments-feed`);
+  }
+  for (const sourceId of record.authoritySourceIds) {
+    if (!sourcesById.has(sourceId)) fail(`${location}.authoritySourceIds contains unknown source ${sourceId}`);
+  }
+
+  const expectedRelease = requiredComponentReleases.get(record.contract);
+  if (expectedRelease && record.version !== expectedRelease.version) {
+    fail(`${location}.version must be ${expectedRelease.version} for ${record.contract}`);
+  }
+  if (expectedRelease) {
+    exactDigest(record.releaseCommit, commitPattern, `${location}.releaseCommit`, "Git commit");
+    if (record.releaseCommit.toLowerCase() !== expectedRelease.commit) {
+      fail(`${location}.releaseCommit must be the pinned ${record.contract} ${expectedRelease.version} deployment commit`);
+    }
+    validateOfficialCodeUrl(record.immutableSourceCodeUrl, `${location}.immutableSourceCodeUrl`);
+    if (!new URL(record.immutableSourceCodeUrl).pathname.includes(`/${record.releaseCommit}/`)) {
+      fail(`${location}.immutableSourceCodeUrl must contain its exact releaseCommit`);
+    }
+    if (record.sourceResolutionStatus !== "release-commit-pinned") {
+      fail(`${location}.sourceResolutionStatus must be release-commit-pinned`);
+    }
+  } else {
+    if (record.releaseCommit !== null) fail(`${location}.releaseCommit must be null until the feed ref is resolved`);
+    if (record.immutableSourceCodeUrl !== null) {
+      fail(`${location}.immutableSourceCodeUrl must be null until the feed ref is resolved`);
+    }
+    const expectedResolution = conflictedUniversalRouterRecordIds.has(record.id)
+      ? "official-feed-ref-conflicted"
+      : "official-feed-ref-unresolved";
+    if (record.sourceResolutionStatus !== expectedResolution) {
+      fail(`${location}.sourceResolutionStatus must be ${expectedResolution}`);
+    }
+  }
+}
+
+function validateProfile(profile, location, recordsById) {
+  assertObject(profile, location);
+  nonEmptyString(profile.id, `${location}.id`);
+  nonEmptyString(profile.chain, `${location}.chain`);
+  if (!Number.isSafeInteger(profile.chainId) || profile.chainId <= 0) fail(`${location}.chainId must be a positive integer`);
+  assertObject(profile.records, `${location}.records`);
+  const keys = Object.keys(profile.records).sort();
+  if (keys.length !== requiredProfileSlots.length || keys.some((key, index) => key !== [...requiredProfileSlots].sort()[index])) {
+    fail(`${location}.records must contain exactly ${requiredProfileSlots.join(", ")}`);
+  }
+  let hasSourceConflict = false;
+  for (const slot of requiredProfileSlots) {
+    const recordId = profile.records[slot];
+    nonEmptyString(recordId, `${location}.records.${slot}`);
+    const record = recordsById.get(recordId);
+    if (!record) fail(`${location}.records.${slot} references unknown record ${recordId}`);
+    if (record.chainId !== profile.chainId || record.chain !== profile.chain) {
+      fail(`${location}.records.${slot} is not on ${profile.chain} (${profile.chainId})`);
+    }
+    if (!expectedProfileContracts[slot].has(record.contract)) {
+      fail(`${location}.records.${slot} references ${record.contract}, not ${[...expectedProfileContracts[slot]].join(" or ")}`);
+    }
+    if (record.sourceResolutionStatus === "official-feed-ref-conflicted") hasSourceConflict = true;
+  }
+  const expectedStatus = hasSourceConflict
+    ? "reference-conflicted-runtime-unverified"
+    : "reference-ready-runtime-unverified";
+  if (profile.status !== expectedStatus) {
+    fail(`${location}.status must be ${expectedStatus}`);
+  }
+}
+
+function validateOfficialRepository(value, location) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    fail(`${location} must be an official Uniswap GitHub repository URL`);
+  }
+  const parts = url.pathname.replace(/\/+$/, "").split("/").filter(Boolean);
+  if (url.protocol !== "https:" || url.hostname !== "github.com" || url.username || url.password || url.search || url.hash
+    || parts.length !== 2 || parts[0] !== "Uniswap") {
+    fail(`${location} must be an official Uniswap GitHub repository URL`);
+  }
+}
+
+function validateOfficialCodeUrl(value, location) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    fail(`${location} must be an official Uniswap GitHub source URL`);
+  }
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (url.protocol !== "https:" || url.hostname !== "github.com" || url.username || url.password || url.search || url.hash
+    || parts.length < 5 || parts[0] !== "Uniswap" || parts[2] !== "blob") {
+    fail(`${location} must be an official Uniswap GitHub source URL`);
+  }
+}
+
+function validateRelativePath(value, location) {
+  nonEmptyString(value, location);
+  if (value.startsWith("/") || value.includes("\\") || value.split("/").includes("..")) {
+    fail(`${location} must be a safe repository-relative path`);
+  }
+}
+
+function exactDigest(value, pattern, location, label) {
+  if (typeof value !== "string" || !pattern.test(value)) fail(`${location} must be an exact ${label}`);
+}
+
+function nonEmptyString(value, location) {
+  if (typeof value !== "string" || value.length === 0) fail(`${location} must be a non-empty string`);
+}
+
+function assertObject(value, location) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${location} must be an object`);
+}
+
+function toKebabCase(value) {
+  return value.replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`);
+}
+
+function fail(message) {
+  throw new OfficialLaunchpadReferenceError(message);
+}

--- a/skills/programmable-v4-hook-builder/scripts/package-dependency-contract.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/package-dependency-contract.mjs
@@ -1,0 +1,133 @@
+const CONTROL_OR_BIDI_PATTERN = /[\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]/u;
+const COMMIT_PATTERN = /^[0-9a-fA-F]{40}$/u;
+
+export const NPM_PACKAGE_NAME_PATTERN_SOURCE = "^(?:@(?!\\.{1,2}/)[a-z0-9._~-]+/(?!\\.{1,2}$)[a-z0-9._~-]+|[a-z0-9~-][a-z0-9._~-]*)$";
+export const EXACT_PACKAGE_VERSION_PATTERN_SOURCE = "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$";
+export const SHA512_INTEGRITY_PATTERN_SOURCE = "^sha512-[A-Za-z0-9+/]+={0,2}$";
+export const OFFICIAL_UNISWAP_SDK_REPOSITORY = "https://github.com/Uniswap/sdks.git";
+export const EXTERNAL_PACKAGE_SOURCE_CLASS = "external-package-local";
+export const EXTERNAL_PACKAGE_EVIDENCE_STATE = "builder-declared-local-package-bytes";
+export const OFFICIAL_UNISWAP_SDK_PACKAGES = Object.freeze([
+  "@uniswap/permit2-sdk",
+  "@uniswap/router-sdk",
+  "@uniswap/sdk-core",
+  "@uniswap/universal-router-sdk",
+  "@uniswap/v4-sdk"
+]);
+const officialUniswapSdkPackages = new Set(OFFICIAL_UNISWAP_SDK_PACKAGES);
+
+const npmPackageNamePattern = new RegExp(NPM_PACKAGE_NAME_PATTERN_SOURCE, "u");
+const exactPackageVersionPattern = new RegExp(EXACT_PACKAGE_VERSION_PATTERN_SOURCE, "u");
+const sha512IntegrityPattern = new RegExp(SHA512_INTEGRITY_PATTERN_SOURCE, "u");
+
+export function isCanonicalNpmPackageName(value) {
+  if (!(typeof value === "string"
+    && value.length > 0
+    && Buffer.byteLength(value, "utf8") <= 214
+    && value.normalize("NFC") === value
+    && npmPackageNamePattern.test(value))) return false;
+  const segments = value.startsWith("@") ? value.slice(1).split("/") : [value];
+  return segments.every((segment) => segment !== "." && segment !== "..");
+}
+
+export function isExactPackageDependency(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (!isCanonicalNpmPackageName(value.packageName)) return false;
+  if (typeof value.version !== "string" || !exactPackageVersionPattern.test(value.version)) return false;
+  if (typeof value.integrity !== "string" || !sha512IntegrityPattern.test(value.integrity)) return false;
+
+  const repositoryIsNull = value.repository === null;
+  const revisionIsNull = value.revision === null;
+  if (repositoryIsNull !== revisionIsNull) return false;
+  if (!repositoryIsNull) {
+    if (!isCanonicalHttpsRepository(value.repository) || !COMMIT_PATTERN.test(value.revision ?? "")) return false;
+  }
+
+  return !isOfficialUniswapSdkPackage(value.packageName)
+    || (value.repository === OFFICIAL_UNISWAP_SDK_REPOSITORY && COMMIT_PATTERN.test(value.revision ?? ""));
+}
+
+export function isOfficialUniswapSdkPackage(packageName) {
+  return officialUniswapSdkPackages.has(packageName);
+}
+
+export function isExactDeclaredPackageSpecifier(specifier, packageName) {
+  if (typeof specifier !== "string" || !isCanonicalNpmPackageName(packageName)) return false;
+  if (specifier === packageName) return true;
+  if (!specifier.startsWith(`${packageName}/`)) return false;
+  const subpath = specifier.slice(packageName.length + 1);
+  if (
+    subpath.length === 0
+    || subpath.includes("\\")
+    || subpath.includes("?")
+    || subpath.includes("#")
+    || subpath.includes("%")
+    || CONTROL_OR_BIDI_PATTERN.test(subpath)
+  ) return false;
+  return subpath.split("/").every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
+}
+
+export function packageRootPath(packageName) {
+  if (!isCanonicalNpmPackageName(packageName)) return null;
+  return `node_modules/${packageName}`;
+}
+
+export function isExactPackageFilePath(repositoryPath, packageName) {
+  const root = packageRootPath(packageName);
+  if (root === null || typeof repositoryPath !== "string" || !repositoryPath.startsWith(`${root}/`)) return false;
+  const subpath = repositoryPath.slice(root.length + 1);
+  return subpath.split("/").every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
+}
+
+export function buildExternalPackageBinding(dependency) {
+  if (!isExactPackageDependency(dependency)) throw new Error("external package dependency is not exactly bound");
+  return {
+    packageName: dependency.packageName,
+    version: dependency.version,
+    integrity: dependency.integrity,
+    repository: dependency.repository,
+    revision: dependency.revision,
+    evidenceState: EXTERNAL_PACKAGE_EVIDENCE_STATE,
+    integrityVerified: false,
+    centralSourceVerified: false
+  };
+}
+
+export function isExternalPackageReviewRecord(record) {
+  if (
+    !record
+    || typeof record !== "object"
+    || record.sourceClass !== EXTERNAL_PACKAGE_SOURCE_CLASS
+    || record.kind !== "solidity-package-dependency-import"
+    || !record.packageDependency
+    || record.packageDependency.evidenceState !== EXTERNAL_PACKAGE_EVIDENCE_STATE
+    || record.packageDependency.integrityVerified !== false
+    || record.packageDependency.centralSourceVerified !== false
+  ) return false;
+  const dependency = {
+    packageName: record.packageDependency.packageName,
+    version: record.packageDependency.version,
+    integrity: record.packageDependency.integrity,
+    repository: record.packageDependency.repository,
+    revision: record.packageDependency.revision
+  };
+  return isExactPackageDependency(dependency)
+    && isExactPackageFilePath(record.path, dependency.packageName);
+}
+
+function isCanonicalHttpsRepository(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 2_048 || CONTROL_OR_BIDI_PATTERN.test(value)) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:"
+      && url.hostname.length > 0
+      && url.username === ""
+      && url.password === ""
+      && url.search === ""
+      && url.hash === "";
+  } catch {
+    return false;
+  }
+}

--- a/skills/programmable-v4-hook-builder/scripts/public-claims-core.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/public-claims-core.mjs
@@ -1,0 +1,160 @@
+const submittedArtifact = String.raw`(?:application|builder|code|contract|evidence|model|project|release|report|skill|submission|token|hook|platform|launch(?:pad|\s+model)?)`;
+const selfReference = String.raw`(?:this|our|my|the\s+(?:submitted|proposed))`;
+const stateVerb = String.raw`(?:was|is|has\s+been|became|remains)`;
+const endorsementVerb = String.raw`(?:verified|approved|certified|endorsed|reviewed)`;
+const endorsementNoun = String.raw`(?:verification|approval|certification|endorsement|official\s+status)`;
+const confusableCharacters = new Map(Object.entries({
+  "\u0391": "A", "\u0392": "B", "\u0395": "E", "\u0397": "H", "\u0399": "I", "\u039a": "K", "\u039c": "M", "\u039d": "N", "\u039f": "O", "\u03a1": "P", "\u03a4": "T", "\u03a5": "Y", "\u03a7": "X",
+  "\u03b1": "a", "\u03b2": "b", "\u03b5": "e", "\u03b9": "i", "\u03ba": "k", "\u03bd": "v", "\u03bf": "o", "\u03c1": "p", "\u03c4": "t", "\u03c5": "y", "\u03c7": "x",
+  "\u0410": "A", "\u0412": "B", "\u0415": "E", "\u0406": "I", "\u041a": "K", "\u041c": "M", "\u041d": "H", "\u041e": "O", "\u0420": "P", "\u0421": "C", "\u0422": "T", "\u0425": "X", "\u0405": "S", "\u042c": "b",
+  "\u0430": "a", "\u0435": "e", "\u0456": "i", "\u0458": "j", "\u043e": "o", "\u0440": "p", "\u0441": "c", "\u0445": "x", "\u0443": "y", "\u044c": "b"
+}));
+
+function providerEndorsementPatterns(provider) {
+  return [
+    new RegExp(String.raw`\b${selfReference}\s+(?:${submittedArtifact}\s+)?${stateVerb}\s+(?:officially\s+)?${endorsementVerb}\s+by\s+${provider}\b`, "i"),
+    new RegExp(String.raw`\bofficially\s+${endorsementVerb}\s+by\s+${provider}\b`, "i"),
+    new RegExp(String.raw`\b${provider}\s+(?:(?:has|have|had)\s+)?(?:officially\s+)?${endorsementVerb}\s+(?:this|the|our|my|an?|the\s+submitted|the\s+proposed)\s+(?:(?:submitted|proposed)\s+)?${submittedArtifact}\b`, "i"),
+    new RegExp(String.raw`\b${selfReference}\s+(?:${submittedArtifact}\s+)?${stateVerb}\s+(?:an?\s+)?official\s+${provider}\s+${submittedArtifact}\b`, "i"),
+    new RegExp(String.raw`\b${selfReference}\s+(?:${submittedArtifact}\s+)?${stateVerb}\s+(?:an?\s+)?${provider}[- ]${endorsementVerb}(?:\s+${submittedArtifact})?\b`, "i"),
+    new RegExp(String.raw`\b${selfReference}\s+${submittedArtifact}\s+(?:has|received|carries|claims)\s+(?:an?\s+)?${provider}\s+${endorsementNoun}\b`, "i"),
+    new RegExp(String.raw`\b(?:officially\s+)?${endorsementVerb}\s+by\s+${provider}\b`, "i"),
+    new RegExp(String.raw`\b(?:an?\s+)?(?:official\s+${provider}|${provider}[- ]${endorsementVerb})\s+${submittedArtifact}\b`, "i"),
+    new RegExp(String.raw`\b${provider}\s+${endorsementNoun}\s+(?:was\s+|has\s+been\s+)?(?:received|granted|obtained)\b`, "i"),
+    new RegExp(String.raw`\b${provider}\s+(?:recommends?|validated|recognizes?)\s+(?:this|the|our|my)\s+${submittedArtifact}\b`, "i"),
+    new RegExp(String.raw`\b(?:this|the|our|my)\s+${submittedArtifact}\s+${stateVerb}\s+officially\s+recognized\s+by\s+${provider}\b`, "i")
+  ];
+}
+
+function providerNegations(provider) {
+  return [
+    new RegExp(String.raw`\b(?:this\s+)?(?:${submittedArtifact})?\s*(?:was|is|has\s+been)?\s*not\s+(?:verified|approved|certified|official|endorsed|reviewed)\s+by\s+${provider}\b`, "gi"),
+    new RegExp(String.raw`\b${provider}\s+(?:did|does|has|was|is)\s+not\s+(?:verify|approve|certify|endorse|review)(?:\s+or\s+(?:verify|approve|certify|endorse|review))*\b`, "gi"),
+    new RegExp(String.raw`\bno\s+${provider}\s+(?:verification|approval|certification|endorsement|official\s+status)\s+(?:is|was|has\s+been)?\s*(?:claimed|granted|obtained|performed)?\b`, "gi"),
+    new RegExp(String.raw`\b(?:does|do)\s+not\s+(?:constitute|imply)\s+${provider}\s+(?:verification|approval|certification|endorsement|official\s+status)\b`, "gi")
+  ];
+}
+
+const providerRules = [
+  {
+    label: "OpenZeppelin audit, review or certification",
+    forbidden: /\b(?:openzeppelin.{0,80}(?:audit|review|certif)|(?:audit|review|certif).{0,80}openzeppelin)\b/i,
+    allowed: [
+      /\b(?:this\s+)?(?:model|code|release|project|hook)?\s*(?:was|is|has\s+been)?\s*not\s+(?:audited|reviewed|certified)\s+by\s+openzeppelin\b/gi,
+      /\bopenzeppelin\s+(?:did|does|has|was|is)\s+not\s+(?:audit|review|certify)(?:\s+or\s+(?:audit|review|certify))*\b/gi,
+      /\bno\s+openzeppelin\s+(?:audit|review|certification)\s+(?:is|was|has\s+been)\s+(?:claimed|performed|completed)\b/gi
+    ]
+  },
+  {
+    label: "Uniswap verification, approval, certification or official status",
+    forbidden: providerEndorsementPatterns("uniswap"),
+    allowed: providerNegations("uniswap")
+  },
+  {
+    label: "Programmable verification, approval, certification or official status",
+    forbidden: providerEndorsementPatterns("programmable"),
+    allowed: providerNegations("programmable")
+  },
+  {
+    label: "Independent audit or certification",
+    forbidden: [
+      new RegExp(String.raw`\b${selfReference}\s+(?:${submittedArtifact}\s+)?${stateVerb}\s+(?:fully\s+|independently\s+|professionally\s+)?(?:audited|security[- ]reviewed|certified)\b`, "i"),
+      new RegExp(String.raw`\b(?:the\s+)?${submittedArtifact}\s+${stateVerb}\s+(?:fully\s+|independently\s+|professionally\s+)?(?:audited|security[- ]reviewed|certified)\b`, "i"),
+      /\b(?:independently|professionally|fully)\s+(?:audited|security[- ]reviewed|certified)\b/i,
+      /\b(?:audited|security[- ]reviewed|certified)\s+by\s+[A-Za-z0-9][A-Za-z0-9 .&_-]{1,80}\b/i,
+      /\b(?:security\s+)?audit\s+(?:was\s+|is\s+|has\s+been\s+)?(?:passed|complete|completed|finished)\b/i,
+      /\bpassed\s+(?:an?\s+)?(?:(?:independent|professional|security)\s+)*(?:security\s+)?audit\b/i,
+      /\bpassed\s+(?:an?\s+)?(?:trail\s+of\s+bits\s+|independent\s+|professional\s+)?(?:security\s+)?review\b/i,
+      new RegExp(String.raw`\b(?:audited|certified)\s+${submittedArtifact}\b`, "i")
+    ],
+    allowed: [
+      /\b(?:this\s+)?(?:application|builder|code|model|project|release|report|skill|submission|token|hook|platform)?\s*(?:was|is|has\s+been)?\s*not\s+(?:yet\s+)?(?:audited|security[- ]reviewed|certified)\b/gi,
+      /\bno\s+(?:independent\s+|professional\s+|security\s+)?(?:audit|certification|security\s+review)\s+(?:is|was|has\s+been)?\s*(?:claimed|performed|completed|available)?\b/gi,
+      /\b(?:does|do)\s+not\s+(?:constitute|imply)\s+(?:an?\s+)?(?:audit|certification|security\s+review)\b/gi,
+      /\bnot\s+an?\s+(?:audit|certification|security\s+review)\b/gi,
+      /\b(?:audit|certification|security\s+review)\s+(?:status\s*:\s*)?(?:blocked|not[- ]run|failed)\b/gi
+    ]
+  },
+  {
+    label: "Safety, rug-free or risk-free status",
+    forbidden: [
+      new RegExp(String.raw`\b${selfReference}\s+(?:${submittedArtifact}\s+)?${stateVerb}\s+(?:guaranteed\s+|provably\s+|fully\s+)?(?:safe|secure|risk[- ]free|rug[- ]free|unruggable)\b`, "i"),
+      new RegExp(String.raw`\b(?:the\s+)?${submittedArtifact}\s+${stateVerb}\s+(?:guaranteed\s+|provably\s+|fully\s+)?(?:safe|secure|risk[- ]free|rug[- ]free|rug[- ]?proof|unruggable)\b`, "i"),
+      /\b(?:rug[- ]free|unruggable|risk[- ]free)\b/i,
+      /\brug[- ]?proof\b/i,
+      /\b(?:cannot|can\s+never)\s+be\s+rugged\b/i,
+      /\b(?:cannot|can\s+never)\s+rug(?:\s+(?:users?|holders?))?\b/i,
+      /\b(?:there\s+is\s+)?no\s+way\s+to\s+rug(?:\s+(?:users?|holders?))?\b/i,
+      /\bimmune\s+to\s+rug(?:\s+pulls?)?\b/i,
+      /\b(?:impossible|not\s+possible)\s+to\s+rug\b/i,
+      /\b(?:zero|no)\s+(?:rug|security|loss)\s+risk\b/i,
+      /\b(?:100\s*%|completely|guaranteed|provably)\s+(?:safe|secure)\b/i,
+      /\b(?:this|the|our|my)\s+(?:contract|code|hook|project)\s+(?:has|contains)\s+no\s+(?:known\s+)?vulnerabilit(?:y|ies)\b/i
+    ],
+    allowed: [
+      /\b(?:is|are|was|were|remains?)\s+not\s+(?:safe|secure|risk[- ]free|rug[- ]free|rug[- ]?proof|unruggable)\b/gi,
+      /\b(?:not|never)\s+(?:claim|claimed|claims|guarantee|guaranteed|described\s+as|called)\s+(?:to\s+be\s+|that\s+(?:it|this)\s+is\s+)?(?:safe|secure|risk[- ]free|rug[- ]free|unruggable)\b/gi,
+      /\bno\s+(?:claim|guarantee)\s+(?:of|that)\s+(?:safety|security|[^.;\n]{0,40}(?:safe|secure|risk[- ]free|rug[- ]free|unruggable))\b/gi,
+      /\b(?:does|do)\s+not\s+(?:make|mean|imply|prove)\s+(?:it|this|the\s+(?:application|builder|code|model|project|release|skill|submission|token|hook|platform))\s+(?:safe|secure|risk[- ]free|rug[- ]free|unruggable)\b/gi,
+      /\b(?:do|does)\s+not\s+(?:call|label|describe|market|present)\s+(?:it|this|(?:this|the|our|my)\s+(?:application|builder|code|contract|model|project|release|skill|submission|token|hook|platform))\s+(?:as\s+)?(?:safe|secure|risk[- ]free|rug[- ]free|rug[- ]?proof|unruggable)\b/gi,
+      /\b(?:do|does)\s+not\s+(?:promise|claim|guarantee)\s+(?:an?\s+)?(?:safe|secure|risk[- ]free|rug[- ]free|rug[- ]?proof|unruggable)(?:\s+design)?\b/gi,
+      /\b(?:the\s+)?(?:term|word)\s+["']?(?:risk[- ]free|rug[- ]free|rug[- ]?proof|unruggable)["']?\s+(?:is\s+)?(?:forbidden|prohibited|not\s+allowed)\b/gi,
+      /\b(?:a|the)\s+malicious\s+[^.;\n]{0,80}\s+(?:could|may|might)\s+(?:falsely\s+)?(?:call|label|describe|market|present)\s+(?:it|this|the\s+(?:application|code|contract|project|token|hook))\s+(?:as\s+)?(?:safe|secure|risk[- ]free|rug[- ]free|rug[- ]?proof|unruggable)\b/gi
+    ]
+  },
+  {
+    label: "Deployment, launch or availability",
+    forbidden: [
+      new RegExp(String.raw`\b${selfReference}\s+(?:${submittedArtifact}\s+)?${stateVerb}\s+(?:already\s+|now\s+|publicly\s+|production[- ]?)?(?:deployed|launched|live|available)\b`, "i"),
+      new RegExp(String.raw`\b(?:the\s+)?${submittedArtifact}\s+${stateVerb}\s+(?:already\s+|now\s+|publicly\s+|production[- ]?)?(?:deployed|launched|live|available)\b`, "i"),
+      new RegExp(String.raw`\b(?:this|our|my|the\s+(?:submitted|proposed))\s+${submittedArtifact}\s+(?:has\s+)?(?:launched|gone\s+live)\b`, "i"),
+      new RegExp(String.raw`\b(?:the\s+)?(?:submitted|proposed)\s+${submittedArtifact}\s+(?:is\s+)?available\s+(?:now|today|for\s+use)\b`, "i"),
+      new RegExp(String.raw`\b(?:the\s+)?${submittedArtifact}\s+(?:was\s+|is\s+|has\s+been\s+)?(?:deployed|launched|live|available)\s+(?:on|to|now|today|for\s+use)\b`, "i"),
+      /\b(?:already\s+|now\s+)?live\s+on\s+(?:mainnet|production)\b/i,
+      /\b(?:now|publicly)\s+available\b/i,
+      /\bavailable\s+(?:now|today|for\s+use)\b/i,
+      /\bproduction[- ]ready\b/i,
+      /\bmainnet[- ]ready\b/i,
+      new RegExp(String.raw`\b(?:this|the|our|my)\s+(?:contract|code|hook|project|token)\s+${stateVerb}\s+active\s+on\s+(?:ethereum\s+)?mainnet\b`, "i"),
+      /\b(?:you\s+can|users?\s+can)\s+trade\s+(?:it|this|the\s+(?:hook|project|token))\s+now\b/i
+    ],
+    allowed: [
+      new RegExp(String.raw`\b(?:this|our|my|the\s+(?:submitted|proposed))\s+(?:${submittedArtifact}\s+)?(?:was|is|has\s+been|remains)\s+not\s+(?:yet\s+)?(?:deployed|launched|live|available)\b`, "gi"),
+      /\bno\s+(?:deployment|launch|availability)\s+(?:is|was|has\s+been)?\s*(?:claimed|performed|completed)?\b/gi,
+      /\b(?:does|do)\s+not\s+(?:constitute|imply|prove)\s+(?:a\s+)?(?:deployment|launch|availability)\b/gi,
+      /\bnot\s+(?:an?\s+)?(?:deployment|launch|availability)\b/gi,
+      /\b(?:deployment|launch|availability)\s+(?:status\s*:\s*)?(?:blocked|not[- ]run|failed)\b/gi,
+      /\bnot\s+(?:yet\s+|now\s+)?(?:live\s+on\s+(?:mainnet|production)|publicly\s+available|production[- ]ready)\b/gi
+    ]
+  }
+];
+
+export function findUnsupportedPublicClaims(text) {
+  if (typeof text !== "string" || text.length === 0) return [];
+  const findings = [];
+  const normalized = text
+    .normalize("NFKC")
+    .replace(/[\u0391-\u03c7\u0405\u0406\u0410-\u0458]/gu, (character) => confusableCharacters.get(character) ?? character)
+    .replace(/\[([^\]\n]{0,1000})\]\([^\n)]{0,1000}\)/gu, "$1")
+    .replace(/\[([^\]\n]{0,1000})\]\[[^\]\n]{0,1000}\]/gu, "$1")
+    .replace(/\\([\\`*_{}\[\]()#+.!~-])/gu, "$1")
+    .replace(/[*_~`]/gu, "")
+    .replace(/[\u00ad\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/gu, "")
+    .replace(/[’‘]/gu, "'")
+    .replace(/[‐‑‒–—]/gu, "-");
+  const segments = normalized.replace(/\s+/gu, " ").split(/[.!?;]+/).map((segment) => segment.trim()).filter(Boolean);
+
+  for (const segment of segments) {
+    for (const rule of providerRules) {
+      let remainder = segment;
+      for (const allowed of rule.allowed) remainder = remainder.replace(allowed, " ");
+      const forbiddenPatterns = Array.isArray(rule.forbidden) ? rule.forbidden : [rule.forbidden];
+      if (forbiddenPatterns.some((pattern) => pattern.test(remainder)) && !findings.includes(rule.label)) findings.push(rule.label);
+    }
+  }
+  if (findings.some((finding) => finding !== "Independent audit or certification" && /(?:audit|certification)/u.test(finding))) {
+    const genericAuditIndex = findings.indexOf("Independent audit or certification");
+    if (genericAuditIndex !== -1) findings.splice(genericAuditIndex, 1);
+  }
+  return findings;
+}

--- a/skills/programmable-v4-hook-builder/scripts/review-target-contract.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/review-target-contract.mjs
@@ -1,0 +1,177 @@
+const CONTROL_OR_BIDI_PATTERN = /[\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]/u;
+const ENCODED_SEPARATOR_PATTERN = /%2f|%5c/iu;
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[a-z]:\//iu;
+const SOLIDITY_SOURCE_EXTENSION = /\.sol$/iu;
+
+export const REVIEW_TARGET_CONTRACT_V1 = Object.freeze({
+  maximumFiles: 512,
+  maximumFileBytes: 2_000_000,
+  maximumTotalBytes: 20_000_000,
+  maximumPathDepth: 24,
+  maximumPathBytes: 1_024,
+  maximumImportResolutions: 8_192,
+  maximumClosureDiagnostics: 512,
+  maximumClosureDiagnosticDetailBytes: 500
+});
+
+export const REVIEW_TARGET_CLOSURE_METHOD_V1 =
+  "declared-bytes-and-resolved-solidity-and-javascript-imports-v9";
+
+export const REVIEW_TARGET_CLOSURE_DIAGNOSTIC_CODES = Object.freeze([
+  "COMPANION_CLOSURE_REVIEW_REQUIRED",
+  "DECLARED_FILE_SEMANTIC_CLOSURE_UNAVAILABLE",
+  "JAVASCRIPT_ALIAS_RESOLUTION_UNPROVEN",
+  "JAVASCRIPT_DYNAMIC_IMPORT_UNPROVEN",
+  "JAVASCRIPT_IMPORT_META_GLOB_UNPROVEN",
+  "JAVASCRIPT_PACKAGE_DEPENDENCY_UNBOUND",
+  "JAVASCRIPT_RUNTIME_LOADER_UNPROVEN",
+  "JAVASCRIPT_SYNTAX_CLOSURE_UNPROVEN",
+  "SOLIDITY_BUILD_PROFILE_REVIEW_REQUIRED",
+  "SOLIDITY_IMPORT_RESOLUTION_UNPROVEN"
+]);
+
+const closureDiagnosticCodes = new Set(REVIEW_TARGET_CLOSURE_DIAGNOSTIC_CODES);
+
+export function isCanonicalReviewTargetPath(value) {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || Buffer.byteLength(value, "utf8") > REVIEW_TARGET_CONTRACT_V1.maximumPathBytes
+    || value.normalize("NFC") !== value
+    || hasUnpairedSurrogate(value)
+    || value.startsWith("/")
+    || WINDOWS_ABSOLUTE_PATH_PATTERN.test(value)
+    || value.endsWith("/")
+    || value.includes("\\")
+    || CONTROL_OR_BIDI_PATTERN.test(value)
+    || ENCODED_SEPARATOR_PATTERN.test(value)
+  ) {
+    return false;
+  }
+  const segments = value.split("/");
+  return segments.length <= REVIEW_TARGET_CONTRACT_V1.maximumPathDepth
+    && segments.every((segment) => (
+      segment.length > 0
+      && segment !== "."
+      && segment !== ".."
+      && segment.toLowerCase() !== ".git"
+    ));
+}
+
+export function isClosedReviewTargetClosure(value) {
+  if (!isPlainObject(value) || !hasExactKeys(value, ["diagnostics", "status"])) return false;
+  if (!new Set(["complete", "incomplete"]).has(value.status)) return false;
+  if (
+    !Array.isArray(value.diagnostics)
+    || value.diagnostics.length > REVIEW_TARGET_CONTRACT_V1.maximumClosureDiagnostics
+    || (value.status === "complete") !== (value.diagnostics.length === 0)
+  ) return false;
+
+  let previousKey = null;
+  for (const diagnostic of value.diagnostics) {
+    if (!isPlainObject(diagnostic) || !hasExactKeys(diagnostic, ["code", "detail", "path"])) return false;
+    if (!closureDiagnosticCodes.has(diagnostic.code)) return false;
+    if (!isCanonicalReviewTargetPath(diagnostic.path)) return false;
+    if (
+      typeof diagnostic.detail !== "string"
+      || diagnostic.detail.length === 0
+      || Buffer.byteLength(diagnostic.detail, "utf8") > REVIEW_TARGET_CONTRACT_V1.maximumClosureDiagnosticDetailBytes
+      || diagnostic.detail.normalize("NFC") !== diagnostic.detail
+      || hasUnpairedSurrogate(diagnostic.detail)
+      || CONTROL_OR_BIDI_PATTERN.test(diagnostic.detail)
+    ) return false;
+    const key = `${diagnostic.code}\0${diagnostic.path}\0${diagnostic.detail}`;
+    if (previousKey !== null && compareUtf8(previousKey, key) >= 0) return false;
+    previousKey = key;
+  }
+  return true;
+}
+
+export function declaredSourceAndTestPaths(submission) {
+  const implementation = submission?.implementation ?? {};
+  const customExecution = submission?.hook?.customExecution ?? {};
+  const integration = submission?.integration ?? {};
+  const routing = integration.routingAndDiscoverability ?? {};
+  const reconstruction = integration.dataReconstruction ?? {};
+  const handoff = integration.platformHandoff ?? {};
+  const paths = [
+    ...arrayValues(implementation.sourcePaths),
+    ...arrayValues(implementation.testPaths),
+    ...arrayValues(customExecution.moduleSourcePaths),
+    ...arrayValues(integration.appSourcePaths),
+    ...arrayValues(integration.integrationTestPaths),
+    ...arrayValues(routing.sourcePaths),
+    ...arrayValues(routing.testPaths),
+    ...arrayValues(reconstruction.sourcePaths),
+    ...arrayValues(reconstruction.testPaths),
+    handoff.websiteRegistryPath,
+    ...arrayValues(handoff.uiSourcePaths),
+    ...arrayValues(handoff.apiSourcePaths),
+    ...arrayValues(handoff.indexerSourcePaths),
+    ...arrayValues(handoff.testPaths),
+    ...arrayValues(submission?.capabilityExtensions).flatMap((extension) => [
+      ...arrayValues(extension?.sourcePaths),
+      ...arrayValues(extension?.testPaths)
+    ])
+  ].filter((entry) => typeof entry === "string" && entry.length > 0);
+  return [...new Set(paths)].sort(compareUtf8);
+}
+
+export function declaredSoliditySourceAndTestPaths(submission) {
+  return declaredSourceAndTestPaths(submission).filter((entry) => SOLIDITY_SOURCE_EXTENSION.test(entry));
+}
+
+export function isSourceOrTestReviewKind(kind) {
+  return kind === "source-entry"
+    || kind === "test-entry"
+    || kind === "app-integration-source"
+    || kind === "app-integration-test"
+    || kind === "routing-integration-source"
+    || kind === "routing-integration-test"
+    || kind === "data-reconstruction-source"
+    || kind === "data-reconstruction-test"
+    || kind === "platform-handoff-registry"
+    || kind === "platform-handoff-ui-source"
+    || kind === "platform-handoff-api-source"
+    || kind === "platform-handoff-indexer-source"
+    || kind === "platform-handoff-test"
+    || kind === "custom-execution-module-source"
+    || kind?.startsWith("capability-source:")
+    || kind?.startsWith("capability-test:")
+    || kind?.startsWith("solidity-")
+    || kind?.startsWith("javascript-");
+}
+
+export function isGitLfsPointer(contents) {
+  if (!(contents instanceof Uint8Array) || contents.byteLength < 42 || contents.byteLength > 4_096) {
+    return false;
+  }
+  const prefix = Buffer.from(contents).subarray(0, 128).toString("utf8");
+  return /^(?:\uFEFF)?version https:\/\/git-lfs\.github\.com\/spec\/v1(?:\r?\n|$)/u.test(prefix);
+}
+
+function hasUnpairedSurrogate(value) {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint >= 0xd800 && codePoint <= 0xdfff) return true;
+  }
+  return false;
+}
+
+function arrayValues(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function compareUtf8(left, right) {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, expected) {
+  const keys = Object.keys(value).sort(compareUtf8);
+  return keys.length === expected.length
+    && keys.every((key, index) => key === expected[index]);
+}

--- a/skills/programmable-v4-hook-builder/scripts/submission-core.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/submission-core.mjs
@@ -1,0 +1,3012 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveOfficialLaunchProfile } from "./official-launchpad-core.mjs";
+import {
+  EXACT_PACKAGE_VERSION_PATTERN_SOURCE,
+  isOfficialUniswapSdkPackage,
+  NPM_PACKAGE_NAME_PATTERN_SOURCE,
+  OFFICIAL_UNISWAP_SDK_REPOSITORY,
+  SHA512_INTEGRITY_PATTERN_SOURCE
+} from "./package-dependency-contract.mjs";
+import {
+  declaredSoliditySourceAndTestPaths,
+  isCanonicalReviewTargetPath
+} from "./review-target-contract.mjs";
+
+export const REPORT_VERSION = 2;
+export const STANDARD_VERSION = "1.1.0";
+export const PROGRAMMABLE_LAUNCH_CHAIN_ID = 1;
+export const PROGRAMMABLE_PLATFORM_FEE_PPM = 1_000;
+export const PROGRAMMABLE_PLATFORM_FEE_RECIPIENT = "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c";
+const UINT256_MAX = (1n << 256n) - 1n;
+export const KNOWN_EVM_NETWORKS = Object.freeze({
+  1: "ethereum",
+  130: "unichain",
+  8453: "base",
+  11155111: "sepolia"
+});
+
+export const PERMISSION_BITS = Object.freeze({
+  beforeInitialize: 0x2000,
+  afterInitialize: 0x1000,
+  beforeAddLiquidity: 0x0800,
+  afterAddLiquidity: 0x0400,
+  beforeRemoveLiquidity: 0x0200,
+  afterRemoveLiquidity: 0x0100,
+  beforeSwap: 0x0080,
+  afterSwap: 0x0040,
+  beforeDonate: 0x0020,
+  afterDonate: 0x0010,
+  beforeSwapReturnDelta: 0x0008,
+  afterSwapReturnDelta: 0x0004,
+  afterAddLiquidityReturnDelta: 0x0002,
+  afterRemoveLiquidityReturnDelta: 0x0001
+});
+
+export const RISK_DIMENSION_MAX = Object.freeze({
+  complexity: 5,
+  customMath: 5,
+  externalDependencies: 3,
+  externalLiquidity: 3,
+  valueAtRisk: 5,
+  teamMaturity: 3,
+  upgradeability: 3,
+  autonomy: 3,
+  priceImpact: 3
+});
+
+const severityOrder = Object.freeze({ hard: 0, blocker: 1, warning: 2 });
+const placeholderPattern = /\b(?:unresolved|unknown|tbd|todo|to be determined|not decided)\b/i;
+const soliditySourceExtension = /\.sol$/i;
+const javascriptSourceExtension = /\.(?:[cm]?[jt]sx?)$/i;
+const declarativeReviewExtension = /\.(?:json|md|txt|ya?ml)$/i;
+const knownModelCategories = new Set([
+  "permissionless-token",
+  "permissioned-asset",
+  "market-structure",
+  "liquidity-management",
+  "distribution",
+  "oracle-linked",
+  "privacy"
+]);
+const includedSwapClientRoutingModes = new Set(["programmable-app", "custom-reviewed"]);
+const noIncludedSwapClientRoutingModes = new Set(["uniswap-interface-api", "uniswapx-filler", "not-planned"]);
+const validatorModulePath = fileURLToPath(import.meta.url);
+const skillRoot = path.resolve(path.dirname(validatorModulePath), "..");
+const deploymentSnapshotPath = path.resolve(skillRoot, "references", "deployment-snapshot.json");
+const officialLaunchpadReferencePath = path.resolve(skillRoot, "references", "official-launchpad-deployments.json");
+const MAX_SCHEMA_DEPTH = 64;
+const MAX_SCHEMA_NODES = 8192;
+const MAX_REFERENCE_DEPTH = 64;
+const MAX_INSTANCE_DEPTH = 64;
+const MAX_INSTANCE_NODES = 32768;
+const MAX_VALIDATION_STEPS = 131072;
+const MAX_SCHEMA_FINDINGS = 128;
+const MAX_PATTERN_LENGTH = 256;
+const MAX_PATTERN_INPUT_LENGTH = 4096;
+const structuralSchemaFinding = Symbol("structuralSchemaFinding");
+
+export function hasIncludedSwapClient(submission) {
+  return includedSwapClientRoutingModes.has(
+    submission?.integration?.routingAndDiscoverability?.routingMode
+  );
+}
+const approvedSchemaPatterns = new Set([
+  "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+  "^[1-9][0-9]{0,77}$",
+  "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$",
+  "^0x[a-fA-F0-9]{40}$",
+  "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+  "^[a-z][a-z0-9-]*$",
+  "^[A-Za-z][A-Za-z0-9._:-]{2,127}$",
+  "^[0-9]+$",
+  "^0x[a-fA-F0-9]{64}$",
+  "^[a-fA-F0-9]{40}$",
+  NPM_PACKAGE_NAME_PATTERN_SOURCE,
+  EXACT_PACKAGE_VERSION_PATTERN_SOURCE,
+  SHA512_INTEGRITY_PATTERN_SOURCE,
+  "^[-a-z0-9]{3,8}$",
+  "^[-_a-zA-Z0-9]{1,32}$"
+]);
+const policyBundlePaths = [
+  "SKILL.md",
+  "THIRD_PARTY_NOTICES.md",
+  "references/compatibility-standard.md",
+  "references/intake-playbook.md",
+  "references/load-graph.json",
+  "references/official-launchpad-deployments.json",
+  "references/official-model-patterns.md",
+  "references/output-contract.md",
+  "references/platform-fee-composition.md",
+  "references/routing-and-discovery.md",
+  "references/scenario-matrix.md",
+  "references/security-and-evidence.md",
+  "references/submission-workflow.md",
+  "references/upstream-sources.json",
+  "references/upstream-sources.md",
+  "references/workflow.md",
+  "scripts/application-input-contract.mjs",
+  "scripts/official-launchpad-core.mjs",
+  "scripts/package-dependency-contract.mjs"
+].map((relativePath) => path.resolve(skillRoot, relativePath));
+
+export function canonicalJson(value) {
+  return JSON.stringify(sortValue(value));
+}
+
+export function submissionHash(submission) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(submission)).digest("hex")}`;
+}
+
+export function permissionMask(permissions) {
+  if (!isObject(permissions)) return null;
+
+  let mask = 0;
+  for (const [name, bit] of Object.entries(PERMISSION_BITS)) {
+    if (typeof permissions[name] !== "boolean") return null;
+    if (permissions[name]) mask |= bit;
+  }
+  return `0x${mask.toString(16).padStart(4, "0")}`;
+}
+
+export function validateAgainstSchema(value, schema) {
+  const findings = [];
+  let findingsCapped = false;
+
+  function add(code, path, message, { structural = false } = {}) {
+    if (findingsCapped) return;
+    if (findings.length >= MAX_SCHEMA_FINDINGS - 1) {
+      const finding = {
+        severity: "blocker",
+        code: "SCHEMA_FINDING_LIMIT",
+        path: "$",
+        message: `Schema validation stopped after ${MAX_SCHEMA_FINDINGS - 1} findings.`,
+        remediation: "Fix the reported structural errors before running compatibility review again."
+      };
+      Object.defineProperty(finding, structuralSchemaFinding, { value: true });
+      findings.push(finding);
+      findingsCapped = true;
+      return;
+    }
+    const finding = {
+      severity: "blocker",
+      code,
+      path,
+      message,
+      remediation: "Make the submission match submission.schema.json before compatibility review."
+    };
+    if (structural) Object.defineProperty(finding, structuralSchemaFinding, { value: true });
+    findings.push(finding);
+  }
+
+  const addStructural = (code, path, message) => add(code, path, message, { structural: true });
+  const schemaInspection = inspectSchemaDefinition(schema, addStructural);
+  if (!schemaInspection.valid) return findings;
+  if (!inspectInstance(value, addStructural) || findingsCapped) return findings;
+
+  let validationSteps = 0;
+  function check(node, rule, path) {
+    if (findingsCapped) return;
+    validationSteps += 1;
+    if (validationSteps > MAX_VALIDATION_STEPS) {
+      addStructural("SCHEMA_VALIDATION_STEP_LIMIT", path, `Schema validation exceeded ${MAX_VALIDATION_STEPS} deterministic steps.`);
+      return;
+    }
+    if (!isObject(rule)) {
+      addStructural("SCHEMA_RULE_INVALID", path, "Schema rules must be JSON objects.");
+      return;
+    }
+    if (!schemaRuleShapeIsValid(rule)) {
+      addStructural("SCHEMA_KEYWORD_INVALID", path, "Schema structure keywords must use the supported JSON shapes.");
+      return;
+    }
+    if (rule.$ref) {
+      const target = resolveLocalReference(schema, rule.$ref);
+      if (!target) {
+        addStructural("SCHEMA_REFERENCE_INVALID", path, `Schema reference ${rule.$ref} could not be resolved.`);
+        return;
+      }
+      check(node, target, path);
+      return;
+    }
+
+    if ("const" in rule && !sameValue(node, rule.const)) {
+      add("SCHEMA_CONST", path, `Expected ${JSON.stringify(rule.const)}.`);
+      return;
+    }
+    if (Array.isArray(rule.enum) && !rule.enum.some((entry) => sameValue(node, entry))) {
+      add("SCHEMA_ENUM", path, `Value is not one of the allowed options.`);
+      return;
+    }
+
+    const allowedTypes = Array.isArray(rule.type) ? rule.type : rule.type ? [rule.type] : [];
+    if (allowedTypes.length > 0 && !allowedTypes.some((type) => matchesType(node, type))) {
+      add("SCHEMA_TYPE", path, `Expected ${allowedTypes.join(" or ")}.`, {
+        structural: path === "$" || allowedTypes.some((type) => type === "object" || type === "array")
+      });
+      return;
+    }
+
+    if (typeof node === "string") {
+      if (rule.minLength !== undefined && node.length < rule.minLength) add("SCHEMA_MIN_LENGTH", path, `Text must be at least ${rule.minLength} characters.`);
+      if (rule.maxLength !== undefined && node.length > rule.maxLength) add("SCHEMA_MAX_LENGTH", path, `Text must be at most ${rule.maxLength} characters.`);
+      if (rule.pattern) {
+        if (node.length > MAX_PATTERN_INPUT_LENGTH) {
+          addStructural("SCHEMA_PATTERN_INPUT_LIMIT", path, `Pattern validation accepts at most ${MAX_PATTERN_INPUT_LENGTH} characters.`);
+        } else if (!schemaInspection.patterns.get(rule).test(node)) {
+          add("SCHEMA_PATTERN", path, "Text does not match the required format.");
+        }
+      }
+      if (rule.format === "uri") {
+        try {
+          const url = new URL(node);
+          if (url.protocol !== "https:") add("SCHEMA_URI", path, "Public source and evidence links must use HTTPS.");
+        } catch {
+          add("SCHEMA_URI", path, "Expected an absolute URI.");
+        }
+      }
+    }
+
+    if (typeof node === "number") {
+      if (rule.minimum !== undefined && node < rule.minimum) add("SCHEMA_MINIMUM", path, `Value must be at least ${rule.minimum}.`);
+      if (rule.maximum !== undefined && node > rule.maximum) add("SCHEMA_MAXIMUM", path, `Value must be at most ${rule.maximum}.`);
+    }
+
+    if (Array.isArray(node)) {
+      if (rule.minItems !== undefined && node.length < rule.minItems) add("SCHEMA_MIN_ITEMS", path, `Expected at least ${rule.minItems} items.`);
+      if (rule.maxItems !== undefined && node.length > rule.maxItems) add("SCHEMA_MAX_ITEMS", path, `Expected at most ${rule.maxItems} items.`);
+      if (rule.uniqueItems && new Set(node.map(canonicalJson)).size !== node.length) add("SCHEMA_UNIQUE_ITEMS", path, "Array items must be unique.");
+      if (rule.items) node.forEach((entry, index) => check(entry, rule.items, `${path}[${index}]`));
+    }
+
+    if (isObject(node)) {
+      const properties = rule.properties ?? {};
+      for (const required of rule.required ?? []) {
+        if (!Object.hasOwn(node, required)) {
+          add("SCHEMA_REQUIRED", `${path}.${required}`, "Required field is missing.", {
+            structural: path === "$"
+          });
+        }
+      }
+      if (rule.additionalProperties === false) {
+        for (const key of Object.keys(node)) {
+          if (findingsCapped) break;
+          if (!Object.hasOwn(properties, key)) add("SCHEMA_ADDITIONAL_PROPERTY", `${path}.${key}`, "Unexpected field.", { structural: true });
+        }
+      }
+      for (const [key, childRule] of Object.entries(properties)) {
+        if (findingsCapped) break;
+        if (Object.hasOwn(node, key)) check(node[key], childRule, `${path}.${key}`);
+      }
+    }
+  }
+
+  check(value, schema, "$");
+  return findings;
+}
+
+export function analyzeSubmission(submission, { schema } = {}) {
+  const findings = schema ? validateAgainstSchema(submission, schema) : [];
+  const gates = new Map();
+  const packagesMissingSourceProvenance = [];
+
+  function add(severity, code, path, message, remediation) {
+    findings.push({ severity, code, path, message, remediation });
+  }
+
+  function gate(id, stage, reason) {
+    if (!gates.has(id)) gates.set(id, { id, stage, reason });
+  }
+
+  if (findings.some((finding) => schemaFindingStopsSemanticReview(finding))) {
+    return buildReport(submission, findings, gates, null, [], null, null, schema);
+  }
+
+  if (!isObject(submission)) {
+    add("hard", "SUBMISSION_NOT_OBJECT", "$", "The submission root must be an object.", "Start from the supplied submission template.");
+    return buildReport(submission, findings, gates, null, [], null, null, schema);
+  }
+
+  if (submission.standardVersion !== STANDARD_VERSION) {
+    add("blocker", "STANDARD_VERSION_MISMATCH", "$.standardVersion", `Expected standard version ${STANDARD_VERSION}.`, "Regenerate from the current template and review every changed field.");
+  }
+
+  const stage = submission.stage;
+  const intakeModel = objectAt(submission, "model");
+  const intakeArchitecture = objectAt(submission, "launchArchitecture");
+  const intakeCapabilities = objectAt(submission, "capabilities");
+  const hasResolvedCapabilityUsage = Object.values(intakeCapabilities).some((profile) => (
+    isObject(profile) && profile.used !== null && profile.used !== undefined
+  ));
+  const hasExplicitSecuritySignal = [
+    "usesTxOrigin",
+    "userControlledDelegatecall",
+    "arbitraryExecution",
+    "unboundedCriticalLoop",
+    "ignoredCallResults",
+    "hiddenControls",
+    "assumesOnchainSecrecy",
+    "bypassesHookAddressValidation"
+  ].some((field) => submission.security?.[field] === true)
+    || submission.security?.signatureScheme?.used === true;
+  const hasDeclaredDependencies = (submission.dependencies?.onchain?.length ?? 0) > 0
+    || (submission.dependencies?.offchain?.length ?? 0) > 0;
+  const hasExplicitReviewSignal = hasResolvedCapabilityUsage
+    || hasExplicitSecuritySignal
+    || hasDeclaredDependencies
+    || (submission.authorities?.length ?? 0) > 0
+    || (submission.valueFlows?.length ?? 0) > 0
+    || (submission.risk?.featureTriggers?.length ?? 0) > 0;
+  const pristineIdeaDraft = stage === "proposal"
+    && !resolvedText(intakeArchitecture.routeKind)
+    && (submission.implementation?.sourcePaths?.length ?? 0) === 0
+    && (submission.implementation?.testPaths?.length ?? 0) === 0
+    && submission.pool?.used === null
+    && submission.hook?.used === null
+    && !hasExplicitReviewSignal;
+  if (pristineIdeaDraft) {
+    if (!resolvedText(intakeModel.userOutcome)) {
+      add(
+        "blocker",
+        "INTAKE_USER_OUTCOME_REQUIRED",
+        "$.model.userOutcome",
+        "The idea draft has not yet stated the concrete user outcome.",
+        "Describe what a user can do and what should happen, in plain language; the agent will derive the route, assets, chain and implementation choices afterward."
+      );
+    } else {
+      add(
+        "blocker",
+        "LAUNCH_ARCHITECTURE_ROUTE_UNRESOLVED",
+        "$.launchArchitecture.routeKind",
+        "The user outcome is known, but no execution or value-flow route has been derived yet.",
+        "Let the agent map actors and value flows, then record the confirmed economic route without assuming a pool, market, chain or token-supply model."
+      );
+    }
+    return buildReport(submission, findings, gates, null, [], null, null, schema);
+  }
+  const declaredImplementationSourcePaths = Array.isArray(submission.implementation?.sourcePaths)
+    ? submission.implementation.sourcePaths
+    : [];
+  const declaredImplementationSoliditySourcePaths = declaredImplementationSourcePaths.filter((entry) => (
+    typeof entry === "string" && soliditySourceExtension.test(entry)
+  ));
+  const declaredSoliditySourcePaths = declaredSoliditySourceAndTestPaths(submission);
+  const customHookDeclared = submission.hook?.used === true;
+  const solidityBuildRequired = customHookDeclared || declaredSoliditySourcePaths.length > 0;
+  const toolingReviewPaths = new Set();
+
+  function validateDeclaredPath(entry, findingPath, role) {
+    if (!isSafeRepositoryPath(entry)) {
+      add(
+        "blocker",
+        "DECLARED_REPOSITORY_PATH_UNSAFE",
+        findingPath,
+        `The declared ${role} path is not a normalized repository-relative path.`,
+        "Use a bounded repository-relative path without parent traversal, absolute roots, backslashes or control characters."
+      );
+      return;
+    }
+    if (
+      !soliditySourceExtension.test(entry)
+      && !javascriptSourceExtension.test(entry)
+      && !declarativeReviewExtension.test(entry)
+    ) {
+      const key = `${role}\0${entry}`;
+      if (!toolingReviewPaths.has(key)) {
+        toolingReviewPaths.add(key);
+        add(
+          "warning",
+          "DECLARED_FILE_TOOLING_REVIEW_REQUIRED",
+          findingPath,
+          `${entry} is bound as exact bytes, but the current deterministic validator has no semantic dependency-closure scanner for this ${role} file type.`,
+          "Keep the file in the exact review target and add a release-bound language-specific scanner or semantic analyzer before candidate approval."
+        );
+      }
+      gate(
+        "declared-file-tooling-or-autonomous-analysis",
+        "candidate",
+        "At least one declared project file is byte-bound but needs a release-bound language-specific scanner or bounded autonomous semantic analyzer."
+      );
+    }
+  }
+
+  const declaredArchitecture = isObject(submission.launchArchitecture)
+    ? submission.launchArchitecture
+    : null;
+  const architectureDeclared = resolvedText(declaredArchitecture?.routeKind);
+  const usesUniswapV4 = architectureDeclared ? declaredArchitecture.usesUniswapV4 : true;
+  const settledFlow = architectureDeclared ? declaredArchitecture.settledFlow : true;
+  if (architectureDeclared) {
+    if (typeof usesUniswapV4 !== "boolean") add("blocker", "LAUNCH_ARCHITECTURE_V4_USAGE_UNRESOLVED", "$.launchArchitecture.usesUniswapV4", "The route does not say whether any execution target uses Uniswap v4.", "Derive this from the confirmed architecture; do not ask the builder for protocol jargon.");
+    if (typeof settledFlow !== "boolean") add("blocker", "LAUNCH_ARCHITECTURE_SETTLED_FLOW_UNRESOLVED", "$.launchArchitecture.settledFlow", "The route does not say whether it contains a swap, sale, fill, auction or other settled volume path.", "Map the complete route and mark settledFlow true exactly when value is exchanged through a priced execution path.");
+    requireDetailedText(declaredArchitecture.targetSummary, "$.launchArchitecture.targetSummary", "LAUNCH_TARGET_SUMMARY_INCOMPLETE", add);
+    const platformFee = objectAt(declaredArchitecture, "platformFee");
+    if (settledFlow === true) {
+      if (platformFee.applicability !== "required") add("blocker", "PLATFORM_FEE_REQUIRED_FOR_SETTLED_FLOW", "$.launchArchitecture.platformFee.applicability", "Every settled swap, sale, auction, fill or priced-volume path must enforce the immutable Programmable fee.", "Set applicability required and generate route-specific additive 1000 ppm enforcement.");
+      if (platformFee.ratePpm !== PROGRAMMABLE_PLATFORM_FEE_PPM) add("blocker", "PLATFORM_FEE_RATE_INVALID", "$.launchArchitecture.platformFee.ratePpm", "The Programmable platform fee must be exactly 1000 ppm.", "Use the immutable 1000 ppm rate independently of creator and LP economics.");
+      if (platformFee.recipient?.toLowerCase() !== PROGRAMMABLE_PLATFORM_FEE_RECIPIENT.toLowerCase()) add("blocker", "PLATFORM_FEE_RECIPIENT_INVALID", "$.launchArchitecture.platformFee.recipient", "The platform fee recipient is not the immutable Programmable treasury.", `Bind the exact treasury ${PROGRAMMABLE_PLATFORM_FEE_RECIPIENT}.`);
+      for (const field of ["basis", "enforcementPath", "claimOwner", "bypassAnalysis", "rounding"]) {
+        requireDetailedText(platformFee[field], `$.launchArchitecture.platformFee.${field}`, "PLATFORM_FEE_ROUTE_INCOMPLETE", add);
+      }
+      if (platformFee.notApplicableReason !== null) add("blocker", "PLATFORM_FEE_APPLICABILITY_CONFLICT", "$.launchArchitecture.platformFee.notApplicableReason", "A required platform fee cannot also be marked not applicable.", "Set notApplicableReason to null.");
+      if (usesUniswapV4 === true && !/fee\s*vault|feevault/iu.test(platformFee.claimOwner ?? "")) {
+        add("blocker", "V4_PLATFORM_FEE_VAULT_UNBOUND", "$.launchArchitecture.platformFee.claimOwner", "A v4 route must bind treasury claims to a separate immutable platform FeeVault rather than relying on inheritable hook ownership.", "Name the immutable FeeVault claim owner and prove that custom hook inheritance cannot redirect or bypass it.");
+      }
+      gate("route-specific-platform-fee-bypass-tests", "prototype", "Every reachable settled route must preserve additive 1000 ppm platform fees under split, alternate-entry, rounding and custom-accounting paths.");
+    } else if (settledFlow === false) {
+      if (platformFee.applicability !== "not-applicable") add("blocker", "PLATFORM_FEE_NA_PROOF_REQUIRED", "$.launchArchitecture.platformFee.applicability", "A route with no settled flow must explicitly prove that the volume fee is not applicable.", "Set not-applicable only after proving there is no reachable swap, sale, fill, auction or priced settlement path.");
+      requireDetailedText(platformFee.notApplicableReason, "$.launchArchitecture.platformFee.notApplicableReason", "PLATFORM_FEE_NA_REASON_INCOMPLETE", add);
+      for (const field of ["ratePpm", "recipient", "basis", "enforcementPath", "claimOwner", "bypassAnalysis", "rounding"]) {
+        if (platformFee[field] !== null) add("blocker", "PLATFORM_FEE_NA_FIELD_CONFLICT", `$.launchArchitecture.platformFee.${field}`, "A not-applicable fee declaration retains an active fee field.", "Clear active fee fields or mark the settled flow and complete route-specific enforcement.");
+      }
+    }
+  }
+
+  const model = objectAt(submission, "model");
+  for (const field of ["id", "name", "summary", "userOutcome"]) {
+    requireResolvedText(model[field], `$.model.${field}`, "MODEL_FIELD_UNRESOLVED", add);
+  }
+  if (usesUniswapV4 === true) requireResolvedText(model.whyV4, "$.model.whyV4", "MODEL_FIELD_UNRESOLVED", add);
+  else if (architectureDeclared && model.whyV4 !== null) add("blocker", "NON_V4_ROUTE_WHY_V4_CONFLICT", "$.model.whyV4", "A route without Uniswap v4 retains a whyV4 claim.", "Set whyV4 to null and explain the actual route in launchArchitecture.targetSummary.");
+  if (resolvedText(model.category) && (!knownModelCategories.has(model.category) || model.category === "other")) {
+    add(
+      "warning",
+      "NOVEL_PROJECT_CATEGORY_REQUIRES_ARCHITECTURE_REVIEW",
+      "$.model.category",
+      `Project category ${model.category} is not a closed launch-type decision and enters automated architecture-evidence analysis of its declared behavior.`,
+      "Keep the category and describe the actors, value flows, authorities, failures and integration surfaces; do not force the project into an unrelated known profile."
+    );
+    gate("novel-project-architecture-evidence", "candidate", "The project uses a novel category that the autonomous service must analyze by behavior rather than reject by label.");
+  }
+
+  const target = objectAt(submission, "target");
+  const targetChainId = canonicalEvmChainId(target.chainId);
+  const targetChainIsValid = targetChainId !== null;
+  if (
+    targetChainId === null
+    && typeof target.chainId === "string"
+    && /^[1-9][0-9]{0,77}$/u.test(target.chainId)
+  ) {
+    add(
+      "blocker",
+      "CHAIN_ID_UINT256_RANGE_INVALID",
+      "$.target.chainId",
+      "The canonical EVM chain id exceeds the reviewed unsigned-256-bit range.",
+      "Use the exact positive canonical chain id from the target chain's signed profile."
+    );
+  }
+  const expectedNetwork = targetChainIsValid ? KNOWN_EVM_NETWORKS[targetChainId] ?? null : null;
+  if (expectedNetwork && target.network !== expectedNetwork) {
+    add(
+      "blocker",
+      "CHAIN_NETWORK_MISMATCH",
+      "$.target.network",
+      `Chain ${target.chainId} must use network ${expectedNetwork}.`,
+      "Keep the canonical network slug and numeric chain id bound to the same deployment set."
+    );
+  }
+  if (targetChainIsValid && !expectedNetwork) {
+    add(
+      "warning",
+      "TARGET_CHAIN_REQUIRES_ARCHITECTURE_REVIEW",
+      "$.target.chainId",
+      `Chain ${target.chainId} is application-eligible, but this standard has no committed chain profile for it.`,
+      usesUniswapV4 === true
+        ? "Keep the canonical network slug and add exact v4 deployments, Cancun and EIP-1153 support, PoolManager, router, Permit2, runtime, source and pinned-fork evidence."
+        : "Keep the canonical network slug and add the exact route-specific runtime, settlement, deployment, source, finality and pinned-fork evidence."
+    );
+    gate(
+      "target-chain-architecture-review",
+      "candidate",
+      "The target chain has no committed Programmable chain profile; the autonomous admission service must verify its canonical identity and the declared route-specific runtime and integration evidence."
+    );
+  }
+  if (targetChainIsValid && targetChainId !== String(PROGRAMMABLE_LAUNCH_CHAIN_ID)) {
+    add(
+      "warning",
+      "PROGRAMMABLE_PLATFORM_CHAIN_NOT_CURRENTLY_INTEGRATED",
+      "$.target.chainId",
+      `Chain ${target.chainId} is eligible for public application review, but the current Programmable launch runtime is integrated only with Ethereum Mainnet (chain 1).`,
+      "Continue the application without making a launch claim; a separately authorized chain integration and signed release must pass before Programmable can launch this project on the target chain."
+    );
+    gate(
+      "programmable-platform-target-chain-integration",
+      "release",
+      "The project may be analyzed, but Programmable launch availability remains blocked until the production release authority integrates and activates the exact target chain."
+    );
+  }
+  if (solidityBuildRequired && !resolvedText(target.solidityVersion)) add("blocker", "COMPILER_UNPINNED", "$.target.solidityVersion", "The declared Solidity source has no pinned compiler.", "Set one exact compiler version from a tested dependency baseline.");
+  if (solidityBuildRequired && !resolvedText(target.evmVersion)) {
+    add("blocker", "EVM_TARGET_INVALID", "$.target.evmVersion", "Declared Solidity source has no exact EVM target.", "Bind the exact EVM target from the selected compiler profile.");
+  } else if (usesUniswapV4 === true && resolvedText(target.evmVersion) && target.evmVersion !== "cancun") {
+    add("blocker", "EVM_TARGET_INVALID", "$.target.evmVersion", "The selected Uniswap v4 route depends on Cancun semantics, including transient storage.", "Use the exact Cancun compiler/EVM profile or change the route before implementation.");
+  } else if (usesUniswapV4 === false && resolvedText(target.evmVersion) && target.evmVersion !== "cancun") {
+    add(
+      "warning",
+      "NON_V4_EVM_PROFILE_REQUIRES_RELEASE_INTEGRATION",
+      "$.target.evmVersion",
+      `The non-v4 design pins EVM target ${target.evmVersion}; application review remains open, but the current launch compiler profile does not yet prove that target.`,
+      "Keep the exact route-specific EVM target. The release authority must add and sign the matching compiler/runtime profile or produce a semantics-preserving reviewed port."
+    );
+    gate("route-specific-evm-compiler-profile", "release", "A non-v4 EVM target outside the active compiler profile requires an exact signed compiler/runtime profile before launch.");
+  }
+  if (solidityBuildRequired && !target.dependencyBaseline) add("blocker", "DEPENDENCY_BASELINE_MISSING", "$.target.dependencyBaseline", "Declared Solidity source has no dependency baseline.", "Use the Programmable-tested baseline or document and review a model-specific baseline.");
+  if (target.dependencyBaseline === "model-specific-pinned") {
+    gate("model-specific-dependency-reproduction", "candidate", "A builder-pinned compiler and dependency closure remains untrusted until the autonomous service reproduces the exact lock and source graph.");
+    gate("model-specific-architecture-evidence", "candidate", "A model-specific baseline changes the architecture and trust assumptions outside the Programmable-tested acceleration path and needs machine-bound evidence.");
+  }
+  if (target.dependencyBaseline === "model-specific-reviewed") {
+    add(
+      "blocker",
+      "MODEL_SPECIFIC_REVIEWED_BASELINE_SELF_ATTESTED",
+      "$.target.dependencyBaseline",
+      "An applicant cannot self-assign a model-specific reviewed dependency baseline.",
+      "Use model-specific-pinned with an exact dependency lock. A later signed release registry may bind an independently verified baseline."
+    );
+  }
+  if (resolvedText(target.officialLaunchProfileId)) {
+    if (architectureDeclared && usesUniswapV4 === false) add("blocker", "NON_V4_OFFICIAL_LAUNCH_PROFILE_CONFLICT", "$.target.officialLaunchProfileId", "A non-v4 route retains an official v4 Launchpad profile.", "Set officialLaunchProfileId to null and bind the actual route in launchArchitecture and launch.json.");
+    try {
+      const reference = JSON.parse(fs.readFileSync(officialLaunchpadReferencePath, "utf8"));
+      const profile = resolveOfficialLaunchProfile(reference, target.officialLaunchProfileId);
+      if (String(profile.chainId) !== targetChainId) {
+        add(
+          "blocker",
+          "OFFICIAL_LAUNCH_PROFILE_CHAIN_MISMATCH",
+          "$.target.officialLaunchProfileId",
+          `Official launch profile ${profile.id} targets chain ${profile.chainId}, not submission chain ${target.chainId}.`,
+          "Select the exact committed profile for target.chainId; never override profile deployment addresses in the submission."
+        );
+      }
+      gate("official-launch-profile-runtime-and-interface-verification", "release", "An official launch profile reference is not proof that its current runtime, interfaces, immutables or source configuration were verified.");
+      if (profile.sourceConflictStatus === "blocked-official-source-conflict") {
+        gate("official-launch-profile-source-conflict-resolution", "release", "The committed official sources disagree on at least one selected deployment record and execution remains blocked until the conflict is resolved.");
+      }
+    } catch (error) {
+      add(
+        "blocker",
+        "OFFICIAL_LAUNCH_PROFILE_INVALID",
+        "$.target.officialLaunchProfileId",
+        `The selected official launch profile cannot be resolved from the committed reference: ${error.message}`,
+        "Select an exact profile id from references/official-launchpad-deployments.json and rerun the current skill; do not supply deployment addresses manually."
+      );
+    }
+  }
+
+  const assets = Array.isArray(submission.assets) ? submission.assets : [];
+  const assetIds = new Set();
+  const assetAddresses = new Set();
+  for (const [index, asset] of assets.entries()) {
+    if (!isObject(asset)) continue;
+    if (assetIds.has(asset.id)) add("blocker", "ASSET_ID_DUPLICATE", `$.assets[${index}].id`, "Asset identifiers must be unique.", "Give each distinct currency or claim a stable identifier.");
+    assetIds.add(asset.id);
+    if (asset.address) {
+      const normalizedAddress = asset.address.toLowerCase();
+      if (assetAddresses.has(normalizedAddress)) add("blocker", "ASSET_ADDRESS_DUPLICATE", `$.assets[${index}].address`, "Two declared asset identities resolve to the same non-native address.", "Use one asset record per exact currency address and reference that stable id from the PoolKey.");
+      assetAddresses.add(normalizedAddress);
+    }
+    if (!Number.isInteger(asset.decimals) || asset.decimals < 0 || asset.decimals > 255 || !asset.decimalsSource) add("blocker", "ASSET_DECIMALS_UNRESOLVED", `$.assets[${index}]`, "Asset decimals and their source must be exact.", "Record the exact decimals and whether they come from native ETH rules, source code, an onchain observation or issuer documentation.");
+    if (!asset.supplyPolicy) add("blocker", "ASSET_SUPPLY_POLICY_UNRESOLVED", `$.assets[${index}].supplyPolicy`, "The asset supply policy is unresolved.", "Declare whether supply is native, fixed at creation, externally managed or mintable under reviewed authority.");
+    if (asset.origin === "native-eth" && (asset.address !== null || asset.decimals !== 18 || asset.decimalsSource !== "native-eth-protocol" || asset.supplyPolicy !== "native" || asset.initialSupply !== null)) add("blocker", "NATIVE_ETH_IDENTITY_INVALID", `$.assets[${index}]`, "Native ETH must use the zero-address representation, 18 decimals, native supply and no token supply field.", "Use address null, decimals 18, decimalsSource native-eth-protocol, supplyPolicy native and initialSupply null.");
+    if (asset.origin === "new-fixed-supply" && (asset.supplyPolicy !== "fixed-at-creation" || !/^[0-9]+$/.test(asset.initialSupply ?? "") || asset.initialSupply === "0")) add("blocker", "FIXED_SUPPLY_UNRESOLVED", `$.assets[${index}]`, "A new fixed-supply token needs one exact nonzero base-unit supply.", "Set supplyPolicy fixed-at-creation and initialSupply to a nonzero integer string in base units.");
+    if (asset.origin === "new-fixed-supply" && /^[0-9]+$/.test(asset.initialSupply ?? "") && BigInt(asset.initialSupply) > (2n ** 256n - 1n)) add("blocker", "FIXED_SUPPLY_UINT256_OVERFLOW", `$.assets[${index}].initialSupply`, "The declared fixed supply does not fit uint256.", "Choose a base-unit supply from 1 through 2^256 minus 1.");
+    if (asset.origin === "new-fixed-supply" && ((asset.controls?.length ?? 0) !== 0 || (asset.behaviors ?? []).some((behavior) => ["pausable", "blacklistable", "confiscatable", "upgradeable"].includes(behavior)))) add("blocker", "FIXED_SUPPLY_CONTROL_CONFLICT", `$.assets[${index}]`, "A new fixed-supply launch token cannot retain issuer or upgrade controls under this profile.", "Remove mint, pause, blacklist, confiscation and upgrade powers, or select a separately reviewed managed-asset profile.");
+    if (["existing-erc20", "vault-share", "permissioned-adapter", "external-wrapper"].includes(asset.origin) && !asset.address) add("blocker", "EXISTING_ASSET_ADDRESS_MISSING", `$.assets[${index}].address`, "An existing or wrapped asset is not identified by an exact chain address.", "Record the exact address for the selected chain before automated architecture-evidence analysis.");
+    if (!Array.isArray(asset.behaviors) || asset.behaviors.length === 0 || asset.behaviors.includes("unknown")) {
+      add("blocker", "ASSET_BEHAVIOR_UNKNOWN", `$.assets[${index}].behaviors`, "Token behavior is unresolved.", "Classify transfer fees, rebasing, callbacks, controls, upgrades, permit behavior and vault semantics.");
+    }
+    if ((asset.behaviors?.length ?? 0) > 1 && asset.behaviors.includes("standard")) add("blocker", "ASSET_STANDARD_BEHAVIOR_CONFLICT", `$.assets[${index}].behaviors`, "Standard behavior cannot be combined with a non-standard token behavior.", "Use standard by itself or list only the exact exceptional behaviors.");
+    const exotic = (asset.behaviors ?? []).filter((behavior) => ["fee-on-transfer", "rebasing", "callback-on-transfer", "pausable", "blacklistable", "confiscatable", "upgradeable"].includes(behavior));
+    if (exotic.length > 0) {
+      add("warning", "ASSET_SPECIAL_BEHAVIOR", `$.assets[${index}].behaviors`, `Special token behavior declared: ${exotic.join(", ")}.`, "Add asset-specific accounting, reentrancy, liveness and authority tests or exclude the asset.");
+      gate("adversarial-token-tests", "prototype", "Non-standard token behavior is declared.");
+    }
+    const settlementSensitive = (asset.behaviors ?? []).filter((behavior) => ["fee-on-transfer", "rebasing", "callback-on-transfer"].includes(behavior));
+    if (settlementSensitive.length > 0 && (!["permissioned-adapter", "external-wrapper"].includes(asset.origin) || submission.hook?.customAccounting?.used !== true || submission.capabilities?.externalCalls?.used !== true)) add("blocker", "NON_STANDARD_TOKEN_ADAPTER_MISSING", `$.assets[${index}]`, "A settlement-sensitive token behavior is declared without an explicit reviewed adapter and accounting path.", "Use a reviewed adapter or wrapper, enable custom accounting and external-call policies, and add requested-versus-received, reentrancy and solvency tests.");
+  }
+
+  if (assets.filter((asset) => asset?.role === "launched").length !== 1) add("blocker", "LAUNCHED_ASSET_COUNT_INVALID", "$.assets", "A launch project needs exactly one canonical launched asset identity.", "Identify one launched asset; other assets are route-specific quote, share, reward, collateral, or auxiliary assets.");
+  const quoteAssetCount = assets.filter((asset) => asset?.role === "quote").length;
+  if (usesUniswapV4 === true && quoteAssetCount !== 1) add("blocker", "QUOTE_ASSET_COUNT_INVALID", "$.assets", "A declared canonical v4 PoolKey needs exactly one quote asset beside the launched asset.", "Identify the exact quote asset used by the canonical PoolKey.");
+  else if (architectureDeclared && settledFlow === true && quoteAssetCount < 1) add("blocker", "SETTLED_ROUTE_QUOTE_ASSET_MISSING", "$.assets", "The settled route has no declared counter-asset or quote asset.", "Declare every asset used by contract pricing, an AMM, auction, fill, or other settled route.");
+  const lifecycle = objectAt(submission, "launchLifecycle");
+  const mandatoryLifecycle = new Set(["tokenCreation"]);
+  const routeHasLiquidityVenue = usesUniswapV4 === true || /(?:amm|liquidity)/iu.test(declaredArchitecture?.routeKind ?? "");
+  if (routeHasLiquidityVenue) {
+    mandatoryLifecycle.add("poolInitialization");
+    mandatoryLifecycle.add("liquidityFormation");
+  }
+  if (settledFlow === true) {
+    mandatoryLifecycle.add("trading");
+    mandatoryLifecycle.add("feesAndClaims");
+  }
+  for (const phaseName of ["tokenCreation", "poolInitialization", "liquidityFormation", "initialTransaction", "trading", "feesAndClaims", "dependencyFailure", "retirement"]) {
+    const phase = objectAt(lifecycle, phaseName);
+    const basePath = `$.launchLifecycle.${phaseName}`;
+    if (typeof phase.applicable !== "boolean") add("blocker", "LIFECYCLE_PHASE_UNRESOLVED", `${basePath}.applicable`, `The ${phaseName} lifecycle phase is unresolved.`, "State whether the phase applies, then define its actor, value movement, custody, failure and event behavior.");
+    if (mandatoryLifecycle.has(phaseName) && phase.applicable !== true) add("blocker", "ROUTE_LIFECYCLE_PHASE_MISSING", `${basePath}.applicable`, `The declared ${declaredArchitecture?.routeKind ?? "legacy-v4"} route requires the ${phaseName} phase.`, "Map this phase to the exact route-specific actor, value movement, custody, failure, and event behavior.");
+    if (phase.applicable === true) {
+      for (const field of ["actor", "valueFlow", "custody", "failure", "event"]) requireDetailedText(phase[field], `${basePath}.${field}`, "LIFECYCLE_PHASE_INCOMPLETE", add);
+      if (phase.notApplicableReason !== null) add("blocker", "LIFECYCLE_NOT_APPLICABLE_CONFLICT", `${basePath}.notApplicableReason`, "An applicable lifecycle phase cannot also carry a not-applicable reason.", "Set notApplicableReason to null.");
+    } else if (phase.applicable === false) {
+      requireDetailedText(phase.notApplicableReason, `${basePath}.notApplicableReason`, "LIFECYCLE_EXCLUSION_UNEXPLAINED", add);
+      for (const field of ["actor", "valueFlow", "custody", "failure", "event"]) if (phase[field] !== null) add("blocker", "LIFECYCLE_EXCLUSION_CONFLICT", `${basePath}.${field}`, "A non-applicable lifecycle phase must not define active behavior.", "Set active phase fields to null or mark the phase applicable and complete it.");
+    }
+  }
+  if (model.category === "permissionless-token") {
+    for (const [index, asset] of assets.entries()) {
+      if (asset?.role !== "launched") continue;
+      const forbidden = (asset.behaviors ?? []).filter((behavior) => ["pausable", "blacklistable", "confiscatable", "upgradeable"].includes(behavior));
+      if (forbidden.length > 0 || (asset.controls?.length ?? 0) > 0) {
+        add("hard", "PERMISSIONLESS_TOKEN_HAS_ISSUER_CONTROLS", `$.assets[${index}]`, "A permissionless launch is declared with issuer controls on the launched token.", "Remove the controls or classify and present the design as a permissioned asset model.");
+      }
+    }
+  }
+
+  const pool = objectAt(submission, "pool");
+  const lpFee = objectAt(pool, "lpFee");
+  const poolUsed = pool.used === undefined ? true : pool.used;
+  if (typeof poolUsed !== "boolean") add("blocker", "V4_POOL_USAGE_UNRESOLVED", "$.pool.used", "The architecture does not say whether a canonical Uniswap v4 PoolKey exists.", "Derive pool.used from launchArchitecture.usesUniswapV4.");
+  if (usesUniswapV4 === true && poolUsed !== true) add("blocker", "V4_ARCHITECTURE_POOL_MISSING", "$.pool.used", "The architecture declares Uniswap v4 but disables its canonical PoolKey record.", "Set pool.used true and bind the exact PoolKey fields.");
+  if (architectureDeclared && usesUniswapV4 === false && poolUsed !== false) add("blocker", "NON_V4_ARCHITECTURE_POOL_CONFLICT", "$.pool.used", "The route declares no Uniswap v4 target but retains an active v4 PoolKey.", "Set pool.used false and clear the v4-only pool fields; describe custom pricing or AMM state in route-specific source and lifecycle records.");
+  if (poolUsed === true) {
+  if (!resolvedText(pool.currency0) || !assetIds.has(pool.currency0)) add("blocker", "CURRENCY0_UNRESOLVED", "$.pool.currency0", "currency0 does not resolve to a declared asset.", "Use a declared asset id after applying canonical currency ordering.");
+  if (!resolvedText(pool.currency1) || !assetIds.has(pool.currency1)) add("blocker", "CURRENCY1_UNRESOLVED", "$.pool.currency1", "currency1 does not resolve to a declared asset.", "Use a declared asset id after applying canonical currency ordering.");
+  if (pool.currency0 && pool.currency0 === pool.currency1) add("hard", "POOL_CURRENCIES_IDENTICAL", "$.pool", "A pool cannot contain the same currency on both sides.", "Choose two distinct currencies.");
+  requireResolvedText(pool.orderingRule, "$.pool.orderingRule", "POOL_ORDERING_UNRESOLVED", add);
+  if (!Number.isInteger(pool.tickSpacing)) add("blocker", "TICK_SPACING_UNRESOLVED", "$.pool.tickSpacing", "Tick spacing is unresolved.", "Set the exact tick spacing and prove it matches the fee model.");
+  if (typeof pool.canonical !== "boolean") add("blocker", "CANONICAL_POOL_POLICY_UNRESOLVED", "$.pool.canonical", "The canonical-pool policy is unresolved.", "Declare whether the launched pool is canonical and disclose the behavior of alternative pools.");
+  requireResolvedText(pool.alternativePools, "$.pool.alternativePools", "ALTERNATIVE_POOL_POLICY_UNRESOLVED", add);
+  if (lpFee.classification !== "lp-fee") add("blocker", "LP_FEE_CLASSIFICATION_INVALID", "$.pool.lpFee.classification", "The PoolKey fee must be classified as an LP fee.", "Put hook-owned charges in hook.feeMechanism and token transfer taxes in the asset behavior profile.");
+  if (!lpFee.mode) add("blocker", "LP_FEE_MODE_UNRESOLVED", "$.pool.lpFee.mode", "The LP fee mode is unresolved.", "Choose a static or dynamic LP fee and distinguish it from hook-owned revenue.");
+  if (lpFee.mode === "static" && !Number.isInteger(lpFee.hundredthsOfBip)) add("blocker", "STATIC_LP_FEE_UNRESOLVED", "$.pool.lpFee.hundredthsOfBip", "The static LP fee is unresolved.", "Set the exact fee in hundredths of a basis point.");
+  if (lpFee.mode === "static") {
+    for (const field of ["initialHundredthsOfBip", "initializationPath", "applicationMode", "overrideFlagPolicy", "persistentUpdateActor", "rateLimit", "updatePath", "minimum", "maximum", "inputMetric", "referenceAsset", "measurementUnit", "observationMode", "observationWindow", "curve", "updateCadence", "liquidityDecreaseBehavior", "manipulationResistance", "failureRule"]) if (lpFee[field] !== null) add("blocker", "STATIC_LP_FEE_DYNAMIC_FIELD", `$.pool.lpFee.${field}`, "A static LP fee cannot carry dynamic-fee configuration.", "Set every dynamic-only field to null or select dynamic mode and complete its update model.");
+    if ((lpFee.persistentUpdateCallSites?.length ?? 0) !== 0) add("blocker", "STATIC_LP_FEE_DYNAMIC_FIELD", "$.pool.lpFee.persistentUpdateCallSites", "A static LP fee cannot declare persistent update call sites.", "Use an empty array or select dynamic mode.");
+  }
+  if (lpFee.recipient !== "pool-liquidity-providers") add("blocker", "LP_FEE_RECIPIENT_INVALID", "$.pool.lpFee.recipient", "The pool LP fee accrues to the pool's liquidity providers; it is not creator-owned hook revenue.", "Use pool-liquidity-providers and model any separate hook-owned charge explicitly.");
+  if (lpFee.mode === "dynamic") {
+    if (lpFee.hundredthsOfBip !== null) add("blocker", "DYNAMIC_LP_FEE_STATIC_FIELD", "$.pool.lpFee.hundredthsOfBip", "A dynamic LP fee cannot also declare the static PoolKey fee field.", "Set hundredthsOfBip to null and use initialHundredthsOfBip plus the explicit update path.");
+    for (const field of ["initialHundredthsOfBip", "initializationPath", "applicationMode", "updatePath", "minimum", "maximum", "inputMetric", "referenceAsset", "measurementUnit", "observationMode", "observationWindow", "curve", "updateCadence", "liquidityDecreaseBehavior", "manipulationResistance", "failureRule"]) {
+      if (lpFee[field] === null || lpFee[field] === undefined || (typeof lpFee[field] === "string" && !resolvedText(lpFee[field]))) {
+        add("blocker", "DYNAMIC_LP_FEE_UNRESOLVED", `$.pool.lpFee.${field}`, "The dynamic LP fee bounds or update rule are unresolved.", "Define immutable bounds, update authority, rate limits and failure behavior.");
+      }
+    }
+    for (const field of ["updatePath", "inputMetric", "observationWindow", "curve", "updateCadence", "liquidityDecreaseBehavior", "manipulationResistance", "failureRule"]) requireDetailedText(lpFee[field], `$.pool.lpFee.${field}`, "DYNAMIC_LP_FEE_POLICY_TOO_VAGUE", add);
+    if (["before-swap-override", "hybrid"].includes(lpFee.applicationMode)) {
+      if (submission.hook?.permissions?.beforeSwap !== true) add("blocker", "DYNAMIC_LP_FEE_APPLICATION_PERMISSION_MISMATCH", "$.hook.permissions.beforeSwap", "A per-swap dynamic fee override requires beforeSwap permission.", "Enable beforeSwap or choose persistent-update and remove override behavior.");
+      requireDetailedText(lpFee.overrideFlagPolicy, "$.pool.lpFee.overrideFlagPolicy", "DYNAMIC_LP_FEE_OVERRIDE_POLICY_MISSING", add);
+    } else if (lpFee.overrideFlagPolicy !== null) add("blocker", "DYNAMIC_LP_FEE_APPLICATION_CONFLICT", "$.pool.lpFee.overrideFlagPolicy", "A persistent-update-only model cannot declare a beforeSwap override policy.", "Set overrideFlagPolicy to null or select a mode that uses beforeSwap overrides.");
+    if (["persistent-update", "hybrid"].includes(lpFee.applicationMode)) {
+      requireDetailedText(lpFee.persistentUpdateActor, "$.pool.lpFee.persistentUpdateActor", "DYNAMIC_LP_FEE_UPDATER_MISSING", add);
+      requireNonEmptyArray(lpFee.persistentUpdateCallSites, "$.pool.lpFee.persistentUpdateCallSites", "DYNAMIC_LP_FEE_CALL_SITES_MISSING", "List each exact hook method or callback that calls updateDynamicLPFee.", add);
+      requireDetailedText(lpFee.rateLimit, "$.pool.lpFee.rateLimit", "DYNAMIC_LP_FEE_RATE_LIMIT_MISSING", add);
+      for (const callSite of lpFee.persistentUpdateCallSites ?? []) if (["afterInitialize", "beforeSwap", "afterSwap"].includes(callSite) && submission.hook?.permissions?.[callSite] !== true) add("blocker", "DYNAMIC_LP_FEE_CALL_SITE_PERMISSION_MISMATCH", "$.pool.lpFee.persistentUpdateCallSites", `Persistent update call site ${callSite} is declared while its callback permission is disabled.`, "Enable the required callback and add its callback policy, or remove the call site.");
+    } else if (lpFee.persistentUpdateActor !== null || lpFee.rateLimit !== null || (lpFee.persistentUpdateCallSites?.length ?? 0) !== 0) add("blocker", "DYNAMIC_LP_FEE_APPLICATION_CONFLICT", "$.pool.lpFee", "A beforeSwap-only override cannot declare a persistent update actor, call site or rate limit.", "Remove persistent-update fields or select hybrid or persistent-update.");
+    if (lpFee.initializationPath === "afterInitialize-updateDynamicLPFee" && submission.hook?.permissions?.afterInitialize !== true) add("blocker", "DYNAMIC_LP_FEE_INITIALIZATION_PERMISSION_MISSING", "$.hook.permissions.afterInitialize", "The selected initial dynamic-fee path needs afterInitialize permission.", "Enable afterInitialize and test the exact updateDynamicLPFee call, or select and prove another explicit initialization path.");
+    if (Number.isInteger(lpFee.minimum) && Number.isInteger(lpFee.maximum) && Number.isInteger(lpFee.initialHundredthsOfBip) && (lpFee.minimum > lpFee.maximum || lpFee.initialHundredthsOfBip < lpFee.minimum || lpFee.initialHundredthsOfBip > lpFee.maximum)) add("blocker", "DYNAMIC_LP_FEE_BOUNDS_INVALID", "$.pool.lpFee", "The initial dynamic fee must lie inside ordered immutable bounds.", "Choose minimum <= initial <= maximum and test both endpoints.");
+    if (lpFee.observationMode === "instantaneous" && /liquid|depth|tvl|market cap/i.test(lpFee.inputMetric ?? "")) {
+      add("blocker", "INSTANTANEOUS_DEPTH_METRIC", "$.pool.lpFee.observationMode", "An instantaneous liquidity or depth metric is manipulable by same-block liquidity changes.", "Use a bounded delayed or time-weighted observation and specify same-block manipulation tests, or provide a separately reviewed invariant that removes the manipulation path.");
+    }
+    gate("dynamic-fee-properties", "prototype", "The pool uses a dynamic LP fee.");
+    gate("dynamic-fee-manipulation-tests", "prototype", "The dynamic LP fee depends on a measured input.");
+  }
+  } else if (poolUsed === false) {
+    for (const field of ["currency0", "currency1", "orderingRule", "tickSpacing", "canonical", "alternativePools"]) {
+      if (pool[field] !== null) add("blocker", "INACTIVE_V4_POOL_FIELD", `$.pool.${field}`, "A route without a v4 pool retains an active PoolKey field.", "Clear every v4-only pool field or declare the v4 target explicitly.");
+    }
+    for (const [field, value] of Object.entries(lpFee)) {
+      const inactive = Array.isArray(value) ? value.length === 0 : value === null;
+      if (!inactive) add("blocker", "INACTIVE_V4_LP_FEE_FIELD", `$.pool.lpFee.${field}`, "A route without a v4 pool retains LP-fee configuration.", "Clear every LP-fee field; route-specific platform and creator economics belong in their actual settlement path.");
+    }
+  }
+
+  const hook = objectAt(submission, "hook");
+  const hookUsed = hook.used;
+  if (typeof hookUsed !== "boolean") add("blocker", "HOOK_USAGE_UNRESOLVED", "$.hook.used", "The launch route does not state whether a declared v4 PoolKey uses a custom hook.", "Derive hook.used from the route; use false when no v4 pool exists.");
+  if (architectureDeclared && usesUniswapV4 === false && hookUsed !== false) add("blocker", "NON_V4_ARCHITECTURE_HOOK_CONFLICT", "$.hook.used", "A route without Uniswap v4 retains an active or unresolved v4 hook.", "Set hook.used false and clear v4-only callback configuration.");
+  if (hookUsed !== false) {
+    requireResolvedText(hook.base, "$.hook.base", "HOOK_BASE_UNRESOLVED", add);
+    if (typeof hook.upgradeable !== "boolean") add("blocker", "HOOK_UPGRADEABILITY_UNRESOLVED", "$.hook.upgradeable", "The hook's own upgradeability is unresolved.", "State whether the hook implementation is immutable; document any upgrade authority separately from token or dependency controls.");
+    if (typeof hook.sharedAcrossPools !== "boolean") add("blocker", "POOL_SHARING_UNRESOLVED", "$.hook.sharedAcrossPools", "The hook instance sharing policy is unresolved.", "Prefer one hook per pool or specify and prove per-pool isolation.");
+    requireResolvedText(hook.poolNamespace, "$.hook.poolNamespace", "POOL_NAMESPACE_UNRESOLVED", add);
+  }
+  const poolAdmission = objectAt(hook, "poolAdmission");
+  if (hookUsed !== false) {
+    for (const field of ["enforcement", "factoryOrRegistry", "alternativePoolBehavior", "rejectionRule"]) {
+      requireDetailedText(poolAdmission[field], `$.hook.poolAdmission.${field}`, "POOL_ADMISSION_INCOMPLETE", add);
+    }
+  }
+
+  const permissions = objectAt(hook, "permissions");
+  const computedMask = permissionMask(permissions);
+  const mask = hookUsed === false ? null : computedMask;
+  if (computedMask === null) add("blocker", "HOOK_PERMISSIONS_UNRESOLVED", "$.hook.permissions", "All 14 hook permission bits must be explicit booleans.", "Derive the minimum permissions from final behavior before mining an address.");
+  const permissionPairs = [
+    ["beforeSwapReturnDelta", "beforeSwap"],
+    ["afterSwapReturnDelta", "afterSwap"],
+    ["afterAddLiquidityReturnDelta", "afterAddLiquidity"],
+    ["afterRemoveLiquidityReturnDelta", "afterRemoveLiquidity"]
+  ];
+  if (hookUsed !== false) {
+    for (const [returnBit, parentBit] of permissionPairs) {
+      if (permissions[returnBit] === true && permissions[parentBit] !== true) {
+        add("blocker", "RETURN_DELTA_PARENT_PERMISSION_MISSING", `$.hook.permissions.${returnBit}`, `${returnBit} requires ${parentBit}.`, `Enable ${parentBit} or remove the return-delta permission.`);
+      }
+    }
+  }
+  if (poolUsed === true && hookUsed === true && mask === "0x0000" && lpFee.mode !== "dynamic") add("blocker", "ZERO_PERMISSION_STATIC_HOOK_INVALID", "$.hook.permissions", "A nonzero static-fee hook address with no permission bits fails Uniswap v4 hook-address validation.", "Enable only the callbacks the model actually needs, use a dynamic-fee hook, or remove the hook and use an ordinary pool.");
+  if (hookUsed === false) validateNoCustomHookRoute({ hook, poolAdmission, permissions, computedMask, lpFee, target, poolActive: poolUsed === true, add });
+
+  const callbackPolicies = Array.isArray(hook.callbackPolicies) ? hook.callbackPolicies : [];
+  const callbackPolicyNames = new Set();
+  const callbackNames = ["beforeInitialize", "afterInitialize", "beforeAddLiquidity", "afterAddLiquidity", "beforeRemoveLiquidity", "afterRemoveLiquidity", "beforeSwap", "afterSwap", "beforeDonate", "afterDonate"];
+  if (hookUsed !== false) {
+    for (const [index, policy] of callbackPolicies.entries()) {
+      const basePath = `$.hook.callbackPolicies[${index}]`;
+      if (callbackPolicyNames.has(policy?.callback)) add("blocker", "CALLBACK_POLICY_DUPLICATE", `${basePath}.callback`, "An enabled callback may have only one policy record.", "Merge the rationale, revert behavior, exit impact and noSelfCall behavior into one record.");
+      callbackPolicyNames.add(policy?.callback);
+      if (permissions[policy?.callback] !== true) add("blocker", "CALLBACK_POLICY_DISABLED_PERMISSION", `${basePath}.callback`, "A policy is declared for a callback whose permission bit is disabled.", "Enable the callback only if required, or remove the policy.");
+      for (const field of ["necessity", "allowedReverts", "userExitImpact", "noSelfCallImpact"]) requireDetailedText(policy?.[field], `${basePath}.${field}`, "CALLBACK_POLICY_INCOMPLETE", add);
+    }
+    for (const callback of callbackNames) {
+      if (permissions[callback] === true && !callbackPolicyNames.has(callback)) add("blocker", "CALLBACK_POLICY_MISSING", `$.hook.permissions.${callback}`, `Enabled callback ${callback} has no structured necessity and liveness policy.`, "Add one callbackPolicies record and explain why the callback is necessary, when it may revert, how exits behave and what noSelfCall suppresses.");
+    }
+  }
+
+  const hookData = objectAt(hook, "hookData");
+  if (hookUsed !== false) {
+    if (typeof hookData.used !== "boolean") add("blocker", "HOOK_DATA_USAGE_UNRESOLVED", "$.hook.hookData.used", "hookData usage is unresolved.", "State whether hookData is ignored or define its exact ABI and authentication.");
+    if (hookData.used === true) {
+      for (const field of ["schema", "identitySource", "callbackSenderRule", "validation"]) requireResolvedText(hookData[field], `$.hook.hookData.${field}`, "HOOK_DATA_CONTRACT_INCOMPLETE", add);
+      const allowedIdentitySources = ["none", "router-only", "trusted-router-decoded-user", "signature-bound-actor", "proof-bound-actor"];
+      if (!allowedIdentitySources.includes(hookData.identitySource)) add("blocker", "HOOK_DATA_SENDER_IS_NOT_USER", "$.hook.hookData.identitySource", "Neither callback msg.sender nor the sender argument proves an end-user wallet.", "Use router-only, a trusted router-decoded actor, a signature-bound actor, a proof-bound actor, or no identity.");
+      if (hookData.identitySource === "signature-bound-actor" && submission.security?.signatureScheme?.used !== true) add("blocker", "HOOK_DATA_SIGNATURE_PROFILE_MISSING", "$.security.signatureScheme", "The declared hookData identity depends on a signature but the signature profile is disabled.", "Enable and complete the signature replay and domain-binding profile.");
+      if (hookData.identitySource === "proof-bound-actor" && submission.capabilities?.proof?.used !== true) add("blocker", "HOOK_DATA_PROOF_PROFILE_MISSING", "$.capabilities.proof", "The declared hookData identity depends on a proof but the proof profile is disabled.", "Enable and complete the proof domain, replay and verifier profile.");
+      if (["router-only", "trusted-router-decoded-user"].includes(hookData.identitySource)) {
+        if (hookData.callbackSenderRule !== "pool-manager-callback-and-exact-router-binding") add("blocker", "HOOK_DATA_ROUTER_SENDER_RULE_MISSING", "$.hook.hookData.callbackSenderRule", "Router-derived hookData is not bound to both the PoolManager callback and one exact trusted router.", "Authenticate PoolManager at the callback and bind the decoded router identity to one deployment record.");
+        if (!resolvedText(hookData.trustedRouterDeploymentRecordId) || !(submission.dependencies?.onchain ?? []).some((dependency) => dependency?.deploymentRecordId === hookData.trustedRouterDeploymentRecordId)) add("blocker", "HOOK_DATA_TRUSTED_ROUTER_UNBOUND", "$.hook.hookData.trustedRouterDeploymentRecordId", "The hookData trust model does not resolve to an exact declared onchain router dependency.", "Use one deploymentRecordId present in dependencies.onchain and verify its chain address and runtime evidence.");
+      } else if (hookData.trustedRouterDeploymentRecordId !== null) add("blocker", "HOOK_DATA_ROUTER_BINDING_CONFLICT", "$.hook.hookData.trustedRouterDeploymentRecordId", "This identity mode does not use a trusted router deployment binding.", "Set the router deployment record to null or choose a router-derived identity mode.");
+    } else if (hookData.used === false && (hookData.schema !== null || hookData.identitySource !== null || hookData.trustedRouterDeploymentRecordId !== null || hookData.callbackSenderRule !== null || hookData.validation !== null)) {
+      add("blocker", "HOOK_DATA_DISABLED_CONFLICT", "$.hook.hookData", "Disabled hookData cannot retain schema, identity or router trust configuration.", "Set every hookData field except used to null.");
+    }
+  }
+
+  const customExecution = objectAt(hook, "customExecution");
+  const customExecutionProfiles = new Set([
+    "none",
+    "same-address-effect-proven",
+    "isolated-external-module-v1"
+  ]);
+  const customExecutionFlags = [
+    "usesInlineAssembly",
+    "usesDelegatecall",
+    "writesArbitraryStorage",
+    "storageHeavy"
+  ];
+  const customExecutionModulePaths = Array.isArray(customExecution.moduleSourcePaths)
+    ? customExecution.moduleSourcePaths
+    : [];
+  const customExecutionEffectPaths = Array.isArray(customExecution.effectProofPaths)
+    ? customExecution.effectProofPaths
+    : [];
+  const isolatedCallbacks = Array.isArray(customExecution.isolatedCallbacks)
+    ? customExecution.isolatedCallbacks
+    : [];
+  if (hookUsed === false) {
+    if (customExecution.profile !== "none") {
+      add("blocker", "INACTIVE_HOOK_CUSTOM_EXECUTION_PROFILE", "$.hook.customExecution.profile", "A route without a custom v4 hook retains an active or unresolved custom-execution profile.", "Use profile none and clear every custom module and effect-proof path.");
+    }
+    if (isolatedCallbacks.length !== 0 || customExecutionModulePaths.length !== 0 || customExecutionEffectPaths.length !== 0) {
+      add("blocker", "INACTIVE_HOOK_CUSTOM_EXECUTION_PATH", "$.hook.customExecution", "A route without a custom v4 hook retains custom module, callback or effect-proof paths.", "Use empty arrays for isolatedCallbacks, moduleSourcePaths and effectProofPaths.");
+    }
+    for (const flag of customExecutionFlags) {
+      if (customExecution[flag] !== false) add("blocker", "INACTIVE_HOOK_CUSTOM_EXECUTION_FLAG", `$.hook.customExecution.${flag}`, "A route without a custom v4 hook retains unresolved or active low-level-code flags.", "Set every custom-execution behavior flag to false.");
+    }
+  } else if (!customExecutionProfiles.has(customExecution.profile)) {
+    add("blocker", "CUSTOM_EXECUTION_PROFILE_UNRESOLVED", "$.hook.customExecution.profile", "The hook does not select an exact custom-execution isolation profile.", "Use none for the frozen zero-custom adapter, same-address-effect-proven for compiler-laid-out state with exact effect proof, or isolated-external-module-v1 for delegatecall or unbounded/arbitrary raw-storage logic.");
+  } else {
+    for (const flag of customExecutionFlags) {
+      if (typeof customExecution[flag] !== "boolean") add("blocker", "CUSTOM_EXECUTION_FLAG_UNRESOLVED", `$.hook.customExecution.${flag}`, "A custom-execution behavior flag is unresolved.", "Inspect the exact source and record whether it uses inline assembly, delegatecall, arbitrary storage writes or storage-heavy logic.");
+    }
+    if (customExecution.profile === "none") {
+      if (
+        customExecutionFlags.some((flag) => customExecution[flag] === true)
+        || isolatedCallbacks.length !== 0
+        || customExecutionModulePaths.length !== 0
+        || customExecutionEffectPaths.length !== 0
+      ) {
+        add("blocker", "CUSTOM_EXECUTION_NONE_CONFLICT", "$.hook.customExecution", "The zero-custom profile retains custom code capabilities or evidence paths.", "Use empty paths and false behavior flags, or select the matching custom execution profile.");
+      }
+    } else {
+      requireDetailedText(customExecution.selectionReason, "$.hook.customExecution.selectionReason", "CUSTOM_EXECUTION_SELECTION_REASON_INCOMPLETE", add);
+    }
+    if (customExecution.profile === "same-address-effect-proven") {
+      if (isolatedCallbacks.length !== 0 || customExecutionModulePaths.length !== 0) {
+        add("blocker", "SAME_ADDRESS_CUSTOM_MODULE_CONFLICT", "$.hook.customExecution", "A same-address profile cannot also declare isolated callbacks or external custom-module sources.", "Clear isolatedCallbacks and moduleSourcePaths, or select isolated-external-module-v1.");
+      }
+      if (
+        customExecution.usesDelegatecall === true
+        || customExecution.writesArbitraryStorage === true
+      ) {
+        add("blocker", "CUSTOM_EXECUTION_ISOLATION_REQUIRED", "$.hook.customExecution.profile", "Delegatecall or unbounded/arbitrary raw-storage logic cannot share the release hook and fee-vault storage boundary.", "Select isolated-external-module-v1; keep the low-level state and execution in the external module and compose it only through the typed release interface.");
+      }
+      if (stage === "prototype" && customExecution.storageHeavy === true && customExecutionEffectPaths.length === 0) {
+        add("blocker", "STORAGE_HEAVY_EFFECT_PROOF_MISSING", "$.hook.customExecution.effectProofPaths", "A storage-heavy same-address prototype has no exact compiler storage-layout and reachable-effect evidence.", "Bind the compiler storage layout, callback reachability and bounded state-effect proof paths for the exact source revision; ordinary mappings and compiler-laid-out state do not require isolation by themselves.");
+      }
+      gate("same-address-storage-effect-proof", "candidate", "Same-address custom logic requires exact compiler storage layout, reachable-call and state-effect proof before admission.");
+    }
+    if (customExecution.profile === "isolated-external-module-v1") {
+      if (isolatedCallbacks.length !== 1 || isolatedCallbacks[0] !== "afterSwap") {
+        add("blocker", "ISOLATED_CUSTOM_CALLBACK_PROFILE_UNSUPPORTED", "$.hook.customExecution.isolatedCallbacks", "The current isolated external module profile supports exactly the afterSwap custom-delta extension.", "Use isolatedCallbacks [\"afterSwap\"] or keep the application pending until a release-bound profile exists for the required callback.");
+      }
+      if (permissions.afterSwap !== true || permissions.afterSwapReturnDelta !== true) {
+        add("blocker", "ISOLATED_CUSTOM_AFTER_SWAP_PERMISSION_MISSING", "$.hook.permissions", "The isolated afterSwap custom-delta profile requires both afterSwap and afterSwapReturnDelta.", "Enable the exact parent and return-delta permissions or choose a profile that matches the actual behavior.");
+      }
+      if (stage === "prototype" && customExecutionModulePaths.length === 0) {
+        add("blocker", "ISOLATED_CUSTOM_MODULE_SOURCE_MISSING", "$.hook.customExecution.moduleSourcePaths", "The prototype selects external custom execution but declares no module source.", "Add the generated typed custom-module source and every implementation file that can affect its result or state.");
+      }
+      gate("isolated-custom-module-interface-and-reentrancy-tests", "prototype", "The typed external custom module must prove caller binding, return bounds, revert atomicity, claim authorization and cross-contract reentrancy behavior.");
+      gate("isolated-custom-module-effect-replay", "candidate", "The autonomous service must replay the external module's exact compiler, call graph, storage effects and custom-delta bounds without granting it release hook or fee-vault storage authority.");
+    }
+  }
+
+  const fee = objectAt(hook, "feeMechanism");
+  if (hookUsed !== false && typeof fee.used !== "boolean") add("blocker", "HOOK_FEE_USAGE_UNRESOLVED", "$.hook.feeMechanism.used", "Hook-owned fee usage is unresolved.", "Distinguish LP fees from hook-owned fees before implementation.");
+  if (hookUsed !== false && fee.used === false && fee.classification !== "none") add("blocker", "HOOK_FEE_CLASSIFICATION_CONFLICT", "$.hook.feeMechanism.classification", "A disabled fee mechanism must be classified as none.", "Set classification to none or fully define the fee mechanism.");
+  if (hookUsed !== false && fee.used === false && (
+    fee.chargedCurrency !== null || fee.maximumHundredthsOfBip !== null || fee.collectionPath !== null || fee.collectionValueFlowId !== null || fee.collectionEvent !== null ||
+    fee.ownership !== null || fee.claimPolicy !== null || (fee.liabilityKeyDimensions?.length ?? 0) !== 0 || (fee.recipients?.length ?? 0) !== 0 ||
+    Object.values(fee.swapQuadrants ?? {}).some((quadrant) => quadrant !== null)
+  )) add("blocker", "HOOK_FEE_DISABLED_COLLECTION_CONFLICT", "$.hook.feeMechanism", "A disabled hook fee cannot retain economics, collection, recipient or liability configuration.", "Keep classification none, all scalar fields null, all four quadrants null and recipient and liability arrays empty.");
+  if (hookUsed !== false && fee.used === true) {
+    if (fee.classification === "lp-fee") add("blocker", "LP_FEE_IN_HOOK_CHARGE", "$.hook.feeMechanism.classification", "An LP fee belongs in pool.lpFee; this section is for a separately owned hook charge.", "Set hook fee usage to false for an LP-fee-only model, or classify and define the separate hook-owned charge.");
+    if (!fee.classification || fee.classification === "none") add("blocker", "HOOK_FEE_CLASSIFICATION_UNRESOLVED", "$.hook.feeMechanism.classification", "The fee is not classified as an LP fee, hook-owned fee or both.", "Choose the exact fee class and do not infer creator revenue from an LP fee primitive.");
+    for (const field of ["chargedCurrency", "ownership", "claimPolicy"]) requireResolvedText(fee[field], `$.hook.feeMechanism.${field}`, "HOOK_FEE_ACCOUNTING_INCOMPLETE", add);
+    if (!Number.isInteger(fee.maximumHundredthsOfBip)) add("blocker", "HOOK_FEE_CAP_UNRESOLVED", "$.hook.feeMechanism.maximumHundredthsOfBip", "The hook fee cap is unresolved.", "Set an immutable product-level maximum.");
+    if (!Array.isArray(fee.recipients) || fee.recipients.length === 0) add("blocker", "HOOK_FEE_RECIPIENTS_UNRESOLVED", "$.hook.feeMechanism.recipients", "Fee recipients are unresolved.", "Declare every recipient, allocation and redirection authority.");
+    const shareTotal = (fee.recipients ?? []).reduce((total, recipient) => total + (Number.isInteger(recipient?.sharePpm) ? recipient.sharePpm : 0), 0);
+    if (shareTotal !== 1000000) add("blocker", "HOOK_FEE_RECIPIENT_SHARES_INVALID", "$.hook.feeMechanism.recipients", "Hook-fee recipient shares must sum to exactly 1,000,000 parts per million.", "Assign every unit of hook-owned revenue to a declared recipient.");
+    const recipientRoles = new Set();
+    for (const [index, recipient] of (fee.recipients ?? []).entries()) {
+      const recipientPath = `$.hook.feeMechanism.recipients[${index}]`;
+      if (recipientRoles.has(recipient?.role)) add("blocker", "HOOK_FEE_RECIPIENT_DUPLICATE", `$.hook.feeMechanism.recipients[${index}].role`, "Recipient roles must be unique within one immutable split.", "Combine duplicate roles or use distinct explicit role names.");
+      recipientRoles.add(recipient?.role);
+      if (recipient?.addressSource === "fixed-address" && (!recipient.address || recipient.binding !== "exact-address")) add("blocker", "HOOK_FEE_FIXED_RECIPIENT_UNBOUND", recipientPath, "A fixed recipient is not bound to an exact Ethereum address.", "Provide the exact address and use binding exact-address.");
+      if (recipient?.addressSource === "launch-wallet" && (recipient.address !== null || recipient.binding !== "launch-transaction-sender")) add("blocker", "HOOK_FEE_LAUNCH_RECIPIENT_INVALID", recipientPath, "A launch-wallet recipient must derive from the authenticated launch transaction sender, not a supplied address.", "Use address null and binding launch-transaction-sender.");
+      if (recipient?.addressSource === "beneficiary-supplied" && (recipient.address !== null || recipient.binding !== "beneficiary-at-launch")) add("blocker", "HOOK_FEE_BENEFICIARY_RECIPIENT_INVALID", recipientPath, "A beneficiary-supplied recipient must be validated and recorded during the launch, not hard-coded in the model.", "Use address null and binding beneficiary-at-launch, then prove nonzero-address validation in the launch lifecycle.");
+      if (recipient?.addressSource === "derived-contract" && (recipient.address !== null || recipient.binding !== "immutable-derived-contract")) add("blocker", "HOOK_FEE_DERIVED_RECIPIENT_INVALID", recipientPath, "A derived recipient must bind to an immutable deployment derivation, not a mutable supplied address.", "Use address null and binding immutable-derived-contract and document the derivation in the launch lifecycle.");
+      if (recipient?.addressSource === "derived-contract") requireDetailedText(recipient.derivationRule, `${recipientPath}.derivationRule`, "HOOK_FEE_DERIVED_RECIPIENT_UNBOUND", add);
+      else if (recipient?.derivationRule !== null) add("blocker", "HOOK_FEE_RECIPIENT_DERIVATION_CONFLICT", `${recipientPath}.derivationRule`, "Only a derived-contract recipient may declare a contract derivation rule.", "Set derivationRule to null or select derived-contract and bind its immutable deployment derivation.");
+      if (recipient?.address?.toLowerCase() === "0x0000000000000000000000000000000000000000") add("blocker", "HOOK_FEE_ZERO_RECIPIENT", `${recipientPath}.address`, "A concrete fee recipient cannot be the zero address.", "Use one exact nonzero Ethereum address.");
+      if (recipient?.mutable === true) {
+        if (recipient.mutationController !== "current-beneficiary-only" || recipient.newAddressValidation !== "nonzero-ethereum-address") add("blocker", "HOOK_FEE_RECIPIENT_MUTATION_UNSAFE", recipientPath, "A mutable payout destination must be changeable only by its current beneficiary and must reject an invalid new address.", "Use current-beneficiary-only control and nonzero Ethereum-address validation; do not add an administrator redirect.");
+        requireDetailedText(recipient.mutationEvent, `${recipientPath}.mutationEvent`, "HOOK_FEE_RECIPIENT_MUTATION_EVENT_MISSING", add);
+      } else if (recipient?.mutationController !== "none" || recipient?.newAddressValidation !== "none" || recipient?.mutationEvent !== null) add("blocker", "HOOK_FEE_IMMUTABLE_RECIPIENT_CONFLICT", recipientPath, "An immutable recipient cannot declare a mutation controller, validation path or mutation event.", "Use none, none and null for immutable recipients.");
+    }
+    if (!fee.collectionPath) add("blocker", "HOOK_FEE_COLLECTION_PATH_MISSING", "$.hook.feeMechanism.collectionPath", "Hook-owned economics are declared without an executable PoolManager collection path.", "Choose a beforeSwap or afterSwap return-delta path and complete the corresponding accounting policy.");
+    if (fee.collectionPath === "before-swap-return-delta" && (permissions.beforeSwap !== true || permissions.beforeSwapReturnDelta !== true || hook.returnDeltaAccounting?.used !== true)) add("blocker", "HOOK_FEE_COLLECTION_PATH_MISMATCH", "$.hook.feeMechanism.collectionPath", "The selected beforeSwap fee path is not enabled in permissions and return-delta accounting.", "Enable beforeSwap and beforeSwapReturnDelta and complete all supported component policies.");
+    if (fee.collectionPath === "after-swap-return-delta" && (permissions.afterSwap !== true || permissions.afterSwapReturnDelta !== true || hook.postReturnDeltaAccounting?.afterSwap?.used !== true)) add("blocker", "HOOK_FEE_COLLECTION_PATH_MISMATCH", "$.hook.feeMechanism.collectionPath", "The selected afterSwap fee path is not enabled in permissions and post-return accounting.", "Enable afterSwap and afterSwapReturnDelta and complete the afterSwap component policy.");
+    if (hook.customAccounting?.used !== true) add("blocker", "HOOK_FEE_CUSTOM_ACCOUNTING_MISSING", "$.hook.customAccounting.used", "A hook-owned swap charge creates PoolManager deltas and liabilities but custom accounting is disabled.", "Define backing, conservation, settlement, liability keys and withdrawals for the fee path.");
+    const feeFlow = (submission.valueFlows ?? []).find((flow) => flow?.id === fee.collectionValueFlowId);
+    if (!feeFlow) add("blocker", "HOOK_FEE_VALUE_FLOW_MISSING", "$.hook.feeMechanism.collectionValueFlowId", "The hook fee does not reference one exact value-flow record.", "Add a fee collection value flow and reference its stable id.");
+    for (const dimension of ["poolId", "currency", "beneficiary"]) if (!(fee.liabilityKeyDimensions ?? []).includes(dimension)) add("blocker", "HOOK_FEE_LIABILITY_KEY_INCOMPLETE", "$.hook.feeMechanism.liabilityKeyDimensions", `Hook-fee liabilities omit ${dimension}.`, "Key every accrued claim by PoolId, currency and beneficiary so balances cannot be redirected or cross-netted.");
+    requireDetailedText(fee.collectionEvent, "$.hook.feeMechanism.collectionEvent", "HOOK_FEE_COLLECTION_EVENT_MISSING", add);
+    const quadrants = objectAt(fee, "swapQuadrants");
+    for (const field of ["zeroForOneExactInput", "zeroForOneExactOutput", "oneForZeroExactInput", "oneForZeroExactOutput"]) {
+      const quadrant = quadrants[field];
+      if (!isObject(quadrant)) add("blocker", "HOOK_FEE_QUADRANT_UNRESOLVED", `$.hook.feeMechanism.swapQuadrants.${field}`, "The fee currency and amount basis for this swap quadrant are unresolved.", "Declare currency, basis, formula, rounding and a maximum for every supported quadrant.");
+      else {
+        requireDetailedText(quadrant.formula, `$.hook.feeMechanism.swapQuadrants.${field}.formula`, "HOOK_FEE_FORMULA_INCOMPLETE", add);
+        if (!Number.isInteger(quadrant.maximumHundredthsOfBip) || quadrant.maximumHundredthsOfBip > fee.maximumHundredthsOfBip) add("blocker", "HOOK_FEE_QUADRANT_CAP_INVALID", `$.hook.feeMechanism.swapQuadrants.${field}.maximumHundredthsOfBip`, "A quadrant fee cap cannot exceed the model-wide immutable cap.", "Lower the quadrant cap or correct the global cap.");
+        const zeroForOne = field.startsWith("zeroForOne");
+        const exactInput = field.endsWith("ExactInput");
+        const inputCurrency = zeroForOne ? "currency0" : "currency1";
+        const outputCurrency = zeroForOne ? "currency1" : "currency0";
+        const expectedCurrency = quadrant.basis === "gross-input" ? inputCurrency : quadrant.basis === "gross-output" ? outputCurrency : quadrant.basis === "unspecified-amount" ? (exactInput ? outputCurrency : inputCurrency) : null;
+        if (expectedCurrency && quadrant.currency !== expectedCurrency) add("blocker", "HOOK_FEE_BASIS_CURRENCY_MISMATCH", `$.hook.feeMechanism.swapQuadrants.${field}`, "The charged currency does not match the declared amount basis and swap quadrant.", `Use ${expectedCurrency} for ${quadrant.basis} in ${field}.`);
+        if (quadrant.basis === "custom-reviewed") gate("custom-hook-fee-basis-replay", "candidate", "A hook fee uses a custom amount basis that the autonomous service must replay.");
+      }
+    }
+    if (fee.maximumHundredthsOfBip === 1000000 && (submission.integration?.swapModes ?? []).some((mode) => mode.endsWith("exactOutput"))) add("blocker", "FULL_HOOK_FEE_EXACT_OUTPUT_UNSUPPORTED", "$.hook.feeMechanism.maximumHundredthsOfBip", "A 100% hook-owned charge has no finite gross-up for exact-output execution.", "Cap it below 100% or remove and reject exact-output modes.");
+    gate("fee-four-quadrant-tests", "prototype", "The model charges or changes fees during swaps.");
+  }
+
+  const customAccounting = objectAt(hook, "customAccounting");
+  if (hookUsed !== false && typeof customAccounting.used !== "boolean") add("blocker", "CUSTOM_ACCOUNTING_USAGE_UNRESOLVED", "$.hook.customAccounting.used", "Custom accounting usage is unresolved.", "State whether the hook changes PoolManager deltas or settles value itself.");
+  if (hookUsed !== false && customAccounting.used === true) {
+    for (const field of ["backingSource", "conservationEquation", "settlement", "partialFillBehavior", "liabilityNamespace", "duplicateCurrencyPolicy", "failureIsolation", "withdrawalOrdering"]) requireDetailedText(customAccounting[field], `$.hook.customAccounting.${field}`, "CUSTOM_ACCOUNTING_INCOMPLETE", add);
+    if (!Array.isArray(customAccounting.liabilityKeyDimensions)) add("blocker", "LIABILITY_KEY_DIMENSIONS_UNRESOLVED", "$.hook.customAccounting.liabilityKeyDimensions", "Custom-accounting liability keys are not structurally declared.", "List the exact dimensions used in every liability key.");
+    if (typeof customAccounting.crossPoolNetting !== "boolean") add("blocker", "CROSS_POOL_NETTING_UNRESOLVED", "$.hook.customAccounting.crossPoolNetting", "Cross-pool netting must be explicit.", "Default to false and prove PoolId-scoped liabilities.");
+    gate("delta-conservation-invariants", "prototype", "The hook uses custom accounting.");
+    gate("custom-accounting-conservation-replay", "candidate", "The hook uses custom accounting that requires machine-replayed conservation evidence.");
+    if (hook.sharedAcrossPools === true) {
+      if (customAccounting.crossPoolNetting !== false) add("blocker", "SHARED_ACCOUNTING_NETTING", "$.hook.customAccounting.crossPoolNetting", "Shared custom accounting cannot net liabilities across pools by default.", "Set crossPoolNetting to false and prove PoolId-scoped liabilities, duplicate-currency handling and failure isolation.");
+      for (const dimension of ["poolId", "currency", "beneficiary"]) if (!(customAccounting.liabilityKeyDimensions ?? []).includes(dimension)) add("blocker", "SHARED_ACCOUNTING_KEY_INCOMPLETE", "$.hook.customAccounting.liabilityKeyDimensions", `Shared custom accounting omits ${dimension} from the liability key.`, "Key liabilities by PoolId, currency and beneficiary; an aggregate token balance is not pool isolation.");
+      if (customAccounting.crossPoolNetting === false) add("warning", "SHARED_CUSTOM_ACCOUNTING", "$.hook.sharedAcrossPools", "Shared custom accounting carries correlated exposure even with PoolId-scoped liabilities.", "Prefer one hook instance per pool and retain cross-pool solvency invariants if sharing is required.");
+      gate("cross-pool-solvency-invariants", "prototype", "Custom accounting is shared across pools.");
+    }
+  }
+
+  const returnDeltaAccounting = objectAt(hook, "returnDeltaAccounting");
+  const beforeSwapReturnDelta = permissions.beforeSwapReturnDelta === true;
+  const anyReturnDelta = ["beforeSwapReturnDelta", "afterSwapReturnDelta", "afterAddLiquidityReturnDelta", "afterRemoveLiquidityReturnDelta"].some((name) => permissions[name] === true);
+  if (hookUsed !== false && typeof returnDeltaAccounting.used !== "boolean") add("blocker", "RETURN_DELTA_USAGE_UNRESOLVED", "$.hook.returnDeltaAccounting.used", "Return-delta accounting usage is unresolved.", "Match this field to the enabled return-delta permission bits.");
+  if (hookUsed !== false && returnDeltaAccounting.used !== beforeSwapReturnDelta) add("blocker", "RETURN_DELTA_USAGE_MISMATCH", "$.hook.returnDeltaAccounting.used", "The before-swap return-delta policy does not match beforeSwapReturnDelta.", "Enable this policy exactly when beforeSwapReturnDelta is enabled; use the post-action policies for other return-delta permissions.");
+  if (hookUsed !== false && returnDeltaAccounting.used === true) {
+    const expectedQuadrants = {
+      zeroForOneExactInput: ["currency0", "currency1", "negative-exact-input", "zeroForOne-exactInput"],
+      zeroForOneExactOutput: ["currency1", "currency0", "positive-exact-output", "zeroForOne-exactOutput"],
+      oneForZeroExactInput: ["currency1", "currency0", "negative-exact-input", "oneForZero-exactInput"],
+      oneForZeroExactOutput: ["currency0", "currency1", "positive-exact-output", "oneForZero-exactOutput"]
+    };
+    const quadrants = objectAt(returnDeltaAccounting, "quadrants");
+    for (const [name, [specified, unspecified, sign, swapMode]] of Object.entries(expectedQuadrants)) {
+      const quadrant = objectAt(quadrants, name);
+      if (typeof quadrant.supported !== "boolean") add("blocker", "RETURN_DELTA_QUADRANT_UNRESOLVED", `$.hook.returnDeltaAccounting.quadrants.${name}.supported`, "Quadrant support must be explicit.", "State whether this path executes or reverts.");
+      if (quadrant.specifiedCurrency !== specified || quadrant.unspecifiedCurrency !== unspecified || quadrant.amountSign !== sign) {
+        add("blocker", "RETURN_DELTA_CURRENCY_MAPPING_INVALID", `$.hook.returnDeltaAccounting.quadrants.${name}`, "Specified currency, unspecified currency or amount sign does not match Uniswap v4 swap semantics.", `Use specified=${specified}, unspecified=${unspecified}, amountSign=${sign}.`);
+      }
+      if (quadrant.supported !== submission.integration?.swapModes?.includes(swapMode)) {
+        add("blocker", "RETURN_DELTA_SWAP_MODE_MISMATCH", `$.hook.returnDeltaAccounting.quadrants.${name}.supported`, "Quadrant support disagrees with integration.swapModes.", "Keep router/UI support and hook accounting on the same four-quadrant matrix.");
+      }
+      if (quadrant.supported === true) {
+        for (const field of ["rounding", "partialFillRule", "slippageInvariant", "failureRule"]) requireDetailedText(quadrant[field], `$.hook.returnDeltaAccounting.quadrants.${name}.${field}`, "RETURN_DELTA_QUADRANT_INCOMPLETE", add);
+        validateDeltaComponentPolicy(quadrant.specifiedComponent, `$.hook.returnDeltaAccounting.quadrants.${name}.specifiedComponent`, "specified", add);
+        validateDeltaComponentPolicy(quadrant.unspecifiedComponent, `$.hook.returnDeltaAccounting.quadrants.${name}.unspecifiedComponent`, "unspecified", add);
+        if (quadrant.residualAmmEquation !== "amountSpecified-plus-specifiedDelta") add("blocker", "RETURN_DELTA_RESIDUAL_EQUATION_INVALID", `$.hook.returnDeltaAccounting.quadrants.${name}.residualAmmEquation`, "The residual AMM amount does not match the core equation.", "Use amountSpecified-plus-specifiedDelta and prove its signed bounds.");
+        if (quadrant.finalCallerDeltaEquation !== "pool-manager-swap-delta-minus-hook-delta") add("blocker", "RETURN_DELTA_CALLER_EQUATION_INVALID", `$.hook.returnDeltaAccounting.quadrants.${name}.finalCallerDeltaEquation`, "The final caller delta does not match core accounting.", "Use pool-manager-swap-delta-minus-hook-delta and bind router slippage to the final result.");
+        if (!["forbidden", "allowed-reviewed"].includes(quadrant.zeroAmmLeg)) add("blocker", "ZERO_AMM_POLICY_UNRESOLVED", `$.hook.returnDeltaAccounting.quadrants.${name}.zeroAmmLeg`, "A supported quadrant must forbid a zero AMM leg or use the separately reviewed custom-curve path.", "Choose forbidden or allowed-reviewed and keep the full-consumption declaration consistent.");
+        if (quadrant.zeroAmmLeg === "forbidden" && quadrant.specifiedDeltaCanConsumeEntireAmount !== false) add("blocker", "ZERO_AMM_POLICY_CONTRADICTION", `$.hook.returnDeltaAccounting.quadrants.${name}.specifiedDeltaCanConsumeEntireAmount`, "The policy forbids a zero AMM leg but still allows the hook delta to consume the complete specified amount.", "Set this to false and enforce a nonzero residual bound, or choose the separately reviewed zero-AMM path.");
+        if (quadrant.zeroAmmLeg === "allowed-reviewed" && quadrant.specifiedDeltaCanConsumeEntireAmount !== true) add("blocker", "ZERO_AMM_POLICY_CONTRADICTION", `$.hook.returnDeltaAccounting.quadrants.${name}.specifiedDeltaCanConsumeEntireAmount`, "The reviewed zero-AMM policy and full-consumption declaration disagree.", "Keep the structured declarations consistent and supply the custom-curve review path.");
+        if (quadrant.zeroAmmLeg === "allowed-reviewed" && submission.capabilities?.customCurve?.used !== true) add("blocker", "ZERO_AMM_CUSTOM_CURVE_PROFILE_MISSING", `$.hook.returnDeltaAccounting.quadrants.${name}.zeroAmmLeg`, "A zero-AMM custom leg is enabled without the custom-curve invariant profile.", "Enable and complete capabilities.customCurve, differential tests and autonomous mathematical-invariant replay.");
+      } else if (quadrant.supported === false && (quadrant.zeroAmmLeg !== "not-applicable" || quadrant.specifiedComponent !== null || quadrant.unspecifiedComponent !== null)) {
+        add("blocker", "UNSUPPORTED_QUADRANT_POLICY_CONFLICT", `$.hook.returnDeltaAccounting.quadrants.${name}`, "An unsupported quadrant must not declare an AMM-leg or settlement path.", "Use zeroAmmLeg not-applicable, no settlement actions, and reject the mode in the router and UI.");
+      }
+    }
+    requireDetailedText(returnDeltaAccounting.executionEvent, "$.hook.returnDeltaAccounting.executionEvent", "RETURN_DELTA_EVENT_MISSING", add);
+    gate("return-delta-execution-event", "prototype", "Core Swap events do not fully describe the custom leg.");
+  }
+
+  const postPolicies = objectAt(hook, "postReturnDeltaAccounting");
+  for (const [policyName, permissionName, expectedShape] of [
+    ["afterSwap", "afterSwapReturnDelta", "unspecified-currency-int128"],
+    ["afterAddLiquidity", "afterAddLiquidityReturnDelta", "currency0-and-currency1-balance-delta"],
+    ["afterRemoveLiquidity", "afterRemoveLiquidityReturnDelta", "currency0-and-currency1-balance-delta"]
+  ]) {
+    const policy = objectAt(postPolicies, policyName);
+    const enabled = permissions[permissionName] === true;
+    const basePath = `$.hook.postReturnDeltaAccounting.${policyName}`;
+    if (hookUsed === false) continue;
+    if (typeof policy.used !== "boolean") add("blocker", "POST_RETURN_DELTA_USAGE_UNRESOLVED", `${basePath}.used`, `${policyName} return-delta usage is unresolved.`, `Match this policy to ${permissionName}.`);
+    if (policy.used !== enabled) add("blocker", "POST_RETURN_DELTA_USAGE_MISMATCH", `${basePath}.used`, `${policyName} policy does not match ${permissionName}.`, "Enable the policy and permission together or disable both.");
+    if (policy.used === true) {
+      if (policy.returnedDeltaShape !== expectedShape) add("blocker", "POST_RETURN_DELTA_SHAPE_INVALID", `${basePath}.returnedDeltaShape`, `${policyName} uses the wrong core return-delta shape.`, `Use ${expectedShape}.`);
+      if (policy.positiveMeaning !== "hook-credit-caller-debit" || policy.negativeMeaning !== "hook-debt-caller-credit") add("blocker", "POST_RETURN_DELTA_SIGN_INVALID", basePath, "Positive and negative return-delta meanings do not match core accounting.", "Declare the hook-credit/caller-debit and hook-debt/caller-credit mapping.");
+      if (policy.callerDeltaEquation !== "protocol-delta-minus-hook-delta") add("blocker", "POST_RETURN_DELTA_CALLER_EQUATION_INVALID", `${basePath}.callerDeltaEquation`, "The caller-delta equation does not match core accounting.", "Use protocol-delta-minus-hook-delta.");
+      for (const field of ["backingSource", "bounds", "rounding", "slippageOrMinimums", "failureRule", "executionEvent"]) requireDetailedText(policy[field], `${basePath}.${field}`, "POST_RETURN_DELTA_POLICY_INCOMPLETE", add);
+      const componentPolicies = objectAt(policy, "componentPolicies");
+      if (policyName === "afterSwap") {
+        validateDeltaComponentPolicy(componentPolicies.unspecified, `${basePath}.componentPolicies.unspecified`, "unspecified", add);
+        if (componentPolicies.currency0 !== null || componentPolicies.currency1 !== null) add("blocker", "POST_RETURN_DELTA_COMPONENT_CONFLICT", `${basePath}.componentPolicies`, "afterSwap returns one unspecified-currency scalar, not independent currency0 and currency1 components.", "Define only the unspecified component policy.");
+      } else {
+        validateDeltaComponentPolicy(componentPolicies.currency0, `${basePath}.componentPolicies.currency0`, "currency0", add);
+        validateDeltaComponentPolicy(componentPolicies.currency1, `${basePath}.componentPolicies.currency1`, "currency1", add);
+        if (componentPolicies.unspecified !== null) add("blocker", "POST_RETURN_DELTA_COMPONENT_CONFLICT", `${basePath}.componentPolicies.unspecified`, "Liquidity callbacks return a BalanceDelta with currency0 and currency1 components, not an unspecified swap currency.", "Set unspecified to null and define both currency components.");
+      }
+      gate(`${policyName.replace(/[A-Z]/g, (value) => `-${value.toLowerCase()}`)}-return-delta-invariants`, "prototype", `${permissionName} is enabled.`);
+    }
+  }
+
+  if (hookUsed !== false && anyReturnDelta && customAccounting.used !== true) add("blocker", "RETURN_DELTA_WITHOUT_ACCOUNTING_MODEL", "$.hook.customAccounting", "A return-delta permission is enabled without an explicit custom-accounting model.", "Define backing, conservation, settlement, caller deltas and partial-fill or liquidity-minimum behavior for that permission.");
+
+  const claims = objectAt(hook, "erc6909Claims");
+  if (hookUsed !== false && typeof claims.used !== "boolean") add("blocker", "ERC6909_USAGE_UNRESOLVED", "$.hook.erc6909Claims.used", "ERC-6909 claim usage is unresolved.", "State whether the hook mints, burns, transfers or redeems PoolManager claims.");
+  if (hookUsed !== false && claims.used === true) {
+    for (const field of ["owner", "operatorPolicy", "mintFlow", "burnFlow", "takeSettleFlow", "liabilityKeys", "transferPolicy", "redemption", "roundingDust", "aggregateSolvencyEquation"]) requireDetailedText(claims[field], `$.hook.erc6909Claims.${field}`, "ERC6909_POLICY_INCOMPLETE", add);
+    if (claims.currencyIdDerivation !== "currency-address-uint160" || claims.claimBalanceScope !== "claim-owner-and-currency" || claims.poolIdIncludedInClaimId !== false) add("blocker", "ERC6909_ID_IS_NOT_POOLID", "$.hook.erc6909Claims", "PoolManager claim ids derive from the currency address and claim balances aggregate by owner and currency, not PoolId.", "Use the fixed currency-address rule and keep PoolId only in a separate internal liability ledger.");
+    for (const dimension of ["poolId", "currency", "beneficiary"]) if (!(claims.liabilityKeyDimensions ?? []).includes(dimension)) add("blocker", "ERC6909_LIABILITY_KEY_INCOMPLETE", "$.hook.erc6909Claims.liabilityKeyDimensions", `ERC-6909 liabilities omit ${dimension}.`, "Key the internal ledger by PoolId, currency and beneficiary even though the PoolManager claim balance is aggregated.");
+    if (claims.crossPoolNetting !== false) add("blocker", "ERC6909_CROSS_POOL_NETTING", "$.hook.erc6909Claims.crossPoolNetting", "PoolManager claim ids identify currency, not PoolId, so shared balances cannot be treated as pool-isolated.", "Set crossPoolNetting to false and maintain a separate PoolId and beneficiary liability ledger.");
+    gate("erc6909-liability-solvency-invariants", "prototype", "The model uses PoolManager ERC-6909 claims.");
+  }
+  const claimActions = collectOperationNames(hook);
+  if (hookUsed !== false && (claimActions.has("mint-claim") || claimActions.has("burn-claim")) && claims.used !== true) add("blocker", "ERC6909_ACTION_PROFILE_MISSING", "$.hook.erc6909Claims.used", "Settlement actions use PoolManager ERC-6909 claims while the claim ownership and solvency profile is disabled.", "Enable and complete the ERC-6909 profile or remove every mint-claim and burn-claim action.");
+
+  const nestedActions = objectAt(hook, "nestedActions");
+  if (hookUsed !== false && typeof nestedActions.used !== "boolean") add("blocker", "NESTED_ACTION_USAGE_UNRESOLVED", "$.hook.nestedActions.used", "Nested PoolManager or router action usage is unresolved.", "State whether callbacks initiate any direct or router-mediated action.");
+  if (hookUsed !== false && nestedActions.used === true) {
+    if (typeof nestedActions.directPoolManagerCalls !== "boolean" || typeof nestedActions.routerCalls !== "boolean") add("blocker", "NESTED_ACTION_PATH_UNRESOLVED", "$.hook.nestedActions", "Direct PoolManager and router-mediated nested paths must be distinguished.", "Declare each path and its callback behavior.");
+    if (!Array.isArray(nestedActions.allowedActions) || nestedActions.allowedActions.length === 0) add("blocker", "NESTED_ACTIONS_UNRESOLVED", "$.hook.nestedActions.allowedActions", "Allowed nested actions are unresolved.", "List the exact PoolManager actions and pools.");
+    if (nestedActions.directPoolManagerCalls !== true && nestedActions.routerCalls !== true) add("blocker", "NESTED_ACTION_PATH_MISSING", "$.hook.nestedActions", "Nested actions are enabled without a direct or router-mediated call path.", "Enable at least one exact path or set nestedActions.used to false.");
+    if (nestedActions.directPoolManagerCalls === true && nestedActions.directCallbackBehavior !== "self-call-hook-callbacks-skipped") add("blocker", "DIRECT_NESTED_CALLBACK_MODEL_INVALID", "$.hook.nestedActions.directCallbackBehavior", "Direct hook-to-PoolManager actions skip callbacks to the same hook.", "Use the fixed self-call callback behavior and test state ordering around the skipped callback.");
+    if (nestedActions.routerCalls === true && nestedActions.routerCallbackBehavior !== "hook-callbacks-can-reenter") add("blocker", "ROUTER_NESTED_CALLBACK_MODEL_INVALID", "$.hook.nestedActions.routerCallbackBehavior", "Router-mediated nested actions can re-enter the hook.", "Use the fixed router re-entry behavior and prove depth, state ordering and failure atomicity.");
+    for (const field of ["samePoolPolicy", "crossPoolPolicy", "callbackSuppression", "stateCommitOrder", "transientDeltaOwner", "syncInterleaving", "slippageAggregation", "failureAtomicity"]) requireDetailedText(nestedActions[field], `$.hook.nestedActions.${field}`, "NESTED_ACTION_POLICY_INCOMPLETE", add);
+    if (!Number.isInteger(nestedActions.maximumDepth)) add("blocker", "NESTED_ACTION_DEPTH_UNRESOLVED", "$.hook.nestedActions.maximumDepth", "Nested action depth is unbounded or unresolved.", "Set and enforce a small maximum depth.");
+    gate("nested-action-reentrancy-tests", "prototype", "The hook initiates nested actions.");
+  } else if (hookUsed !== false && nestedActions.used === false) {
+    if (nestedActions.directPoolManagerCalls !== false || nestedActions.routerCalls !== false || (nestedActions.allowedActions?.length ?? 0) !== 0) add("blocker", "NESTED_ACTION_DISABLED_CONFLICT", "$.hook.nestedActions", "Nested actions are disabled but call paths or allowed actions remain declared.", "Set both call paths to false and allowedActions to an empty array, or fully enable and specify nested actions.");
+  }
+
+  if (hookUsed !== false && permissions.beforeSwapReturnDelta === true) {
+    add("warning", "BEFORE_SWAP_RETURN_DELTA_CRITICAL", "$.hook.permissions.beforeSwapReturnDelta", "beforeSwapReturnDelta can bypass concentrated-liquidity swap math and create a no-op swap.", "Prove all four swap quadrants, backing, partial fills, slippage and zero-sum settlement with deterministic replay and bounded semantic analysis.");
+    gate("before-swap-delta-four-quadrant-proof", "prototype", "beforeSwapReturnDelta is enabled.");
+    gate("high-obligation-economic-security-replay", "candidate", "beforeSwapReturnDelta is enabled and requires deterministic economic and security replay.");
+  }
+
+  const valueFlows = Array.isArray(submission.valueFlows) ? submission.valueFlows : [];
+  if (valueFlows.length === 0) add("blocker", "VALUE_FLOW_MISSING", "$.valueFlows", "No value flow is documented.", "Trace every asset through initialize, liquidity, swap, fee, claim and failure paths.");
+  const valueFlowIds = new Set();
+  for (const [index, flow] of valueFlows.entries()) {
+    for (const field of ["id", "action", "asset", "from", "to", "amountRule", "settlement", "failure"]) {
+      requireResolvedText(flow?.[field], `$.valueFlows[${index}].${field}`, "VALUE_FLOW_UNRESOLVED", add);
+    }
+    if (valueFlowIds.has(flow?.id)) add("blocker", "VALUE_FLOW_ID_DUPLICATE", `$.valueFlows[${index}].id`, "Value-flow identifiers must be unique.", "Use one stable id for each distinct lifecycle value path.");
+    valueFlowIds.add(flow?.id);
+  }
+
+  const authorities = Array.isArray(submission.authorities) ? submission.authorities : [];
+  for (const [index, authority] of authorities.entries()) {
+    requireResolvedText(authority?.controller, `$.authorities[${index}].controller`, "AUTHORITY_CONTROLLER_UNRESOLVED", add);
+    if (typeof authority?.mutable !== "boolean") add("blocker", "AUTHORITY_MUTABILITY_UNRESOLVED", `$.authorities[${index}].mutable`, "Authority mutability is unresolved.", "Declare whether the controller or its capabilities can change.");
+    requireResolvedText(authority?.userExitImpact, `$.authorities[${index}].userExitImpact`, "AUTHORITY_EXIT_IMPACT_UNRESOLVED", add);
+    const capabilities = (authority?.capabilities ?? []).join(" ").toLowerCase();
+    if (/(upgrade|confiscat|blacklist|freeze|pause|redirect|rescue|mint)/.test(capabilities)) gate("privileged-authority-capability-proof", "candidate", "A privileged capability can affect users, balances or behavior and requires exact machine-bound authority evidence.");
+  }
+
+  const dependencyIds = new Set();
+  const dependenciesById = new Map();
+  const onchainAddressKeys = new Set();
+  for (const location of ["onchain", "offchain"]) {
+    const dependencies = submission.dependencies?.[location] ?? [];
+    for (const [index, dependency] of dependencies.entries()) {
+      const basePath = `$.dependencies.${location}[${index}]`;
+      for (const field of ["id", "name", "kind", "license", "trust", "failure", "fallback"]) requireResolvedText(dependency?.[field], `${basePath}.${field}`, "DEPENDENCY_INCOMPLETE", add);
+      if (dependencyIds.has(dependency?.id)) add("blocker", "DEPENDENCY_ID_DUPLICATE", `${basePath}.id`, "Dependency identifiers must be unique across onchain and offchain records.", "Give each exact source or deployment one stable id.");
+      dependencyIds.add(dependency?.id);
+      if (resolvedText(dependency?.id)) dependenciesById.set(dependency.id, dependency);
+      if (location === "onchain" && dependency?.chainAddress) {
+        const addressKey = `${target.chainId}:${dependency.chainAddress.toLowerCase()}`;
+        if (onchainAddressKeys.has(addressKey)) add("blocker", "DEPENDENCY_ADDRESS_DUPLICATE", `${basePath}.chainAddress`, "Two dependency records claim the same chain address.", "Use one canonical record per chain and address and reference it by id.");
+        onchainAddressKeys.add(addressKey);
+      }
+      if (!resolvedText(dependency?.repository) && !resolvedText(dependency?.chainAddress)) add("blocker", "DEPENDENCY_SOURCE_UNRESOLVED", basePath, "A dependency has neither an exact source repository nor chain address.", "Record the authoritative source and exact deployed identity where applicable.");
+      if (dependency?.repository && !resolvedText(dependency?.revision) && !resolvedText(dependency?.packageVersion)) add("blocker", "DEPENDENCY_UNPINNED", basePath, "A source dependency is not pinned to a commit or exact package version.", "Pin an exact revision and preserve lockfile provenance.");
+      if (location === "onchain" && submission.stage === "prototype") {
+        if (!dependency?.sourceProvenance) add("blocker", "ONCHAIN_SOURCE_PROVENANCE_MISSING", `${basePath}.sourceProvenance`, "An onchain dependency has no exact source-provenance mode.", "Use pinned-source or verified-explorer-source with exact source and runtime evidence; bytecode-only exceptions require a signed independent authority record.");
+        if (["pinned-source", "verified-explorer-source"].includes(dependency?.sourceProvenance) && (!resolvedText(dependency?.repository) || (!resolvedText(dependency?.revision) && !resolvedText(dependency?.packageVersion)) || !resolvedText(dependency?.runtimeHash))) add("blocker", "ONCHAIN_SOURCE_IDENTITY_INCOMPLETE", basePath, "Address identity is not source identity; the onchain dependency lacks a pinned source and runtime tuple.", "Record the exact repository and revision or package, plus deployed runtime hash and structured observation evidence.");
+        if (dependency?.sourceProvenance === "maintainer-bytecode-exception") add("blocker", "BYTECODE_EXCEPTION_REQUIRES_MAINTAINER", `${basePath}.sourceProvenance`, "An applicant cannot self-approve an immutable bytecode-only exception.", "Use reproducible pinned source or a signed exception issued outside applicant control.");
+      }
+      if (location === "onchain" && submission.stage === "prototype" && /^https:\/\/github\.com\/uniswap\/(?:v4-core|v4-periphery|permit2|universal-router)(?:\.git)?\/?$/i.test(dependency?.repository ?? "") && !resolvedText(dependency?.deploymentRecordId)) {
+        add("blocker", "OFFICIAL_DEPLOYMENT_RECORD_MISSING", `${basePath}.deploymentRecordId`, "An official Uniswap onchain dependency is not bound to the committed deployment registry.", "Resolve one exact active record and preserve its trust tier, record id, address, chain and independent runtime evidence; a runtime-unverified reference is not a Programmable-tested deployment.");
+      }
+      if (location === "onchain" && submission.stage === "prototype" && !resolvedText(dependency?.deploymentEvidencePath)) add("blocker", "DEPLOYMENT_EVIDENCE_PATH_MISSING", `${basePath}.deploymentEvidencePath`, "An onchain prototype dependency has no structured runtime and source observation record.", "Add a repository-relative deployment evidence record; the autonomous admission service must reproduce it before release.");
+      gate("dependency-failure-tests", "prototype", "The model has external dependencies.");
+    }
+  }
+
+  const operations = objectAt(submission, "operations");
+  for (const kind of ["keeper", "oracle"]) {
+    const operation = objectAt(operations, kind);
+    if (typeof operation.required !== "boolean") add("blocker", "OPERATION_USAGE_UNRESOLVED", `$.operations.${kind}.required`, `${kind} usage is unresolved.`, `State whether a ${kind} is required.`);
+    if (operation.required === true) {
+      for (const field of ["actor", "action", "cadence", "authentication", "funding", "failure", "fallback"]) requireResolvedText(operation[field], `$.operations.${kind}.${field}`, "OPERATION_INCOMPLETE", add);
+      gate(`${kind}-liveness-tests`, "prototype", `The model requires a ${kind}.`);
+      gate(`${kind}-monitoring`, "candidate", `The model requires a ${kind}.`);
+    }
+  }
+  requireResolvedText(operations.monitoring, "$.operations.monitoring", "MONITORING_PLAN_UNRESOLVED", add);
+  requireResolvedText(operations.incidentResponse, "$.operations.incidentResponse", "INCIDENT_PLAN_UNRESOLVED", add);
+
+  const integration = objectAt(submission, "integration");
+  const routing = objectAt(integration, "routingAndDiscoverability");
+  const includedSwapClient = usesUniswapV4 === true && hasIncludedSwapClient(submission);
+  const noIncludedSwapClient = noIncludedSwapClientRoutingModes.has(routing.routingMode);
+  if (!routing.routingMode) add("blocker", "ROUTING_MODE_UNRESOLVED", "$.integration.routingAndDiscoverability.routingMode", "The submission does not identify which application or routing path will execute swaps.", "Choose the Uniswap interface and API, a UniswapX filler, the Programmable application, a separately reviewed custom path or no planned route.");
+  if (noIncludedSwapClient) {
+    const actionProfile = objectAt(integration, "routerActionProfile");
+    const inactiveClientFields = [
+      ["$.integration.routerGeneration", integration.routerGeneration === null],
+      ["$.integration.routerDependencyId", integration.routerDependencyId === null],
+      ["$.integration.permit2DependencyId", integration.permit2DependencyId === null],
+      ["$.integration.stateViewDependencyId", integration.stateViewDependencyId === null],
+      ["$.integration.quoterDependencyId", integration.quoterDependencyId === null],
+      ["$.integration.routerActionProfile.routerVersionExplicit", actionProfile.routerVersionExplicit === null],
+      ["$.integration.routerActionProfile.universalRouterCommand", actionProfile.universalRouterCommand === null],
+      ["$.integration.routerActionProfile.v4Actions", (actionProfile.v4Actions?.length ?? 0) === 0],
+      ["$.integration.routerActionProfile.settlementMode", actionProfile.settlementMode === null],
+      ["$.integration.routerActionProfile.permit2Mode", actionProfile.permit2Mode === null],
+      ["$.integration.routerActionProfile.finalSwapDeltaValidated", actionProfile.finalSwapDeltaValidated === null],
+      ["$.integration.appSourcePaths", (integration.appSourcePaths?.length ?? 0) === 0],
+      ["$.integration.integrationTestPaths", (integration.integrationTestPaths?.length ?? 0) === 0],
+      ["$.integration.quoteExecutionParity", integration.quoteExecutionParity === null],
+      ["$.integration.routingAndDiscoverability.sourcePaths", (routing.sourcePaths?.length ?? 0) === 0],
+      ["$.integration.routingAndDiscoverability.testPaths", (routing.testPaths?.length ?? 0) === 0]
+    ];
+    for (const [findingPath, inactive] of inactiveClientFields) {
+      if (!inactive) {
+        add(
+          "blocker",
+          "SWAP_CLIENT_MODE_CONFLICT",
+          findingPath,
+          `Routing mode ${routing.routingMode} declares no included swap client, but an included-client field remains active.`,
+          "Clear the included-client binding or select programmable-app/custom-reviewed and complete every included-client gate."
+        );
+      }
+    }
+  }
+  if (includedSwapClient && !integration.routerGeneration) add("blocker", "ROUTER_GENERATION_UNRESOLVED", "$.integration.routerGeneration", "The included swap client has no exact Universal Router generation.", "Resolve the exact router generation and deployed address from the official deployment feed.");
+  const routerDependency = (submission.dependencies?.onchain ?? []).find((dependency) => dependency?.id === integration.routerDependencyId);
+  if (stage === "prototype" && includedSwapClient && !routerDependency) add("blocker", "ROUTER_DEPENDENCY_UNBOUND", "$.integration.routerDependencyId", "The included swap client router generation does not resolve to one exact onchain dependency id.", "Reference one dependencies.onchain id with exact deployment and runtime evidence.");
+  if (settledFlow === true && (!Array.isArray(integration.swapModes) || integration.swapModes.length === 0)) add("blocker", "SWAP_MODES_UNRESOLVED", "$.integration.swapModes", "No supported settled-route direction or exactness mode is declared.", "Declare every supported and rejected direction/exactness path for the actual route.");
+  if (settledFlow === true) {
+    for (const field of ["partialFills", "slippage", "deadline", "stateReads"]) requireResolvedText(integration[field], `$.integration.${field}`, "INTEGRATION_CONTRACT_INCOMPLETE", add);
+    if (usesUniswapV4 === true) requireResolvedText(integration.permit2, "$.integration.permit2", "INTEGRATION_CONTRACT_INCOMPLETE", add);
+  } else if (settledFlow === false) {
+    if ((integration.swapModes?.length ?? 0) !== 0) add("blocker", "NO_SETTLED_FLOW_SWAP_MODE_CONFLICT", "$.integration.swapModes", "A route with no settled flow retains active swap modes.", "Use an empty swapModes array or mark and fully define the settled route.");
+    for (const field of ["partialFills", "slippage", "deadline", "permit2", "stateReads", "quoteExecutionParity"]) {
+      if (integration[field] !== null) add("blocker", "NO_SETTLED_FLOW_INTEGRATION_CONFLICT", `$.integration.${field}`, "A route with no settled flow retains active trade integration data.", "Clear trade-only integration fields or mark the settled flow and complete its evidence.");
+    }
+  }
+  if (!Array.isArray(integration.events) || integration.events.length === 0) add("blocker", "EVENT_CONTRACT_MISSING", "$.integration.events", "No indexable lifecycle events are declared.", "Declare events that reconstruct launches, configuration, fees, claims and operational state.");
+  if (settledFlow === true && (integration.swapModes?.length ?? 0) < 4) add("warning", "PARTIAL_SWAP_MODE_SUPPORT", "$.integration.swapModes", "The model does not declare all four directional/exactness paths.", "Gate unsupported paths explicitly in the route and UI and test the expected rejection behavior.");
+  if (stage === "prototype") {
+    const packageDependencies = Array.isArray(integration.sdkDependencies) ? integration.sdkDependencies : [];
+    if (packageDependencies.length > 0) {
+      gate(
+        "package-dependency-lock-and-closure-verification",
+        "prototype",
+        "Every declared package requires attributable verification that its exact version and sha512 integrity match the installed lock entry and the dependency closure used by the reviewed build."
+      );
+    }
+    const packageNames = new Set();
+    for (const [index, dependency] of packageDependencies.entries()) {
+      const dependencyPath = `$.integration.sdkDependencies[${index}]`;
+      if (packageNames.has(dependency?.packageName)) add("blocker", "PACKAGE_DEPENDENCY_DUPLICATE", `${dependencyPath}.packageName`, "One package dependency is declared more than once.", "Keep one exact version and integrity record per package.");
+      packageNames.add(dependency?.packageName);
+      for (const field of ["packageName", "version", "integrity"]) requireResolvedText(dependency?.[field], `${dependencyPath}.${field}`, "PACKAGE_DEPENDENCY_INCOMPLETE", add);
+
+      const repositoryIsNull = dependency?.repository === null;
+      const revisionIsNull = dependency?.revision === null;
+      if (repositoryIsNull !== revisionIsNull) {
+        add(
+          "blocker",
+          "PACKAGE_SOURCE_PROVENANCE_INCOMPLETE",
+          dependencyPath,
+          "A package source repository and revision must either both be exact or both be null.",
+          "Record one HTTPS source repository with its exact 40-character commit, or set both fields to null and retain the exact package version and integrity."
+        );
+      } else if (repositoryIsNull && !isOfficialUniswapSdkPackage(dependency?.packageName)) {
+        packagesMissingSourceProvenance.push(dependency?.packageName);
+        add(
+          "warning",
+          "PACKAGE_SOURCE_PROVENANCE_MISSING",
+          dependencyPath,
+          "The exact registry package is bound by version and sha512 integrity, but its source repository is not declared.",
+          "Add a matching HTTPS source repository and exact commit when available; otherwise keep this limitation explicit for attributable dependency review."
+        );
+      }
+
+      if (
+        isOfficialUniswapSdkPackage(dependency?.packageName)
+        && (dependency?.repository !== OFFICIAL_UNISWAP_SDK_REPOSITORY || revisionIsNull)
+      ) {
+        add(
+          "blocker",
+          "UNISWAP_PACKAGE_SOURCE_UNTRUSTED",
+          `${dependencyPath}.repository`,
+          "An official @uniswap SDK package must bind to the official monorepo source and its exact release commit.",
+          `Use ${OFFICIAL_UNISWAP_SDK_REPOSITORY} and the package release gitHead represented by revision.`
+        );
+      }
+    }
+    if (includedSwapClient) {
+      for (const [field, label] of [["permit2DependencyId", "Permit2"], ["stateViewDependencyId", "StateView"], ["quoterDependencyId", "V4Quoter"]]) {
+        const dependency = dependenciesById.get(integration[field]);
+        if (!dependency || !(submission.dependencies?.onchain ?? []).includes(dependency)) add("blocker", "INTEGRATION_DEPENDENCY_UNBOUND", `$.integration.${field}`, `${label} does not resolve to one exact onchain dependency record.`, `Reference the exact ${label} dependencies.onchain id with source, deployment and runtime evidence.`);
+      }
+      for (const packageName of ["@uniswap/v4-sdk", "@uniswap/universal-router-sdk", "@uniswap/sdk-core"]) if (!packageNames.has(packageName)) add("blocker", "PACKAGE_DEPENDENCY_MISSING", "$.integration.sdkDependencies", `The included swap client does not lock ${packageName}.`, "Record its exact package version, integrity and official release source revision from the application lockfile.");
+
+      const actionProfile = objectAt(integration, "routerActionProfile");
+      if (actionProfile.routerVersionExplicit !== true) add("blocker", "ROUTER_VERSION_IMPLICIT", "$.integration.routerActionProfile.routerVersionExplicit", "The SDK router generation may silently fall back when it is not passed explicitly.", "Pass and record the exact Universal Router generation for quoting and execution.");
+      if (!actionProfile.universalRouterCommand) add("blocker", "ROUTER_COMMAND_UNRESOLVED", "$.integration.routerActionProfile.universalRouterCommand", "The Universal Router command carrying the v4 plan is unresolved.", "Use V4_SWAP for the official router path or select the separately reviewed custom-router path.");
+      requireNonEmptyArray(actionProfile.v4Actions, "$.integration.routerActionProfile.v4Actions", "V4_ACTION_PLAN_MISSING", "List the exact v4 planner actions encoded for every supported route.", add);
+      if (!(actionProfile.v4Actions ?? []).some((action) => /SWAP/i.test(action))) add("blocker", "V4_SWAP_ACTION_MISSING", "$.integration.routerActionProfile.v4Actions", "The declared v4 plan has no swap action.", "List the exact swap and settlement actions used by the application encoder.");
+      requireDetailedText(actionProfile.settlementMode, "$.integration.routerActionProfile.settlementMode", "ROUTER_SETTLEMENT_PROFILE_MISSING", add);
+      if (!actionProfile.permit2Mode) add("blocker", "PERMIT2_MODE_UNRESOLVED", "$.integration.routerActionProfile.permit2Mode", "Permit2 or native settlement mode is unresolved.", "Choose the exact allowance, signature, mixed or native-only transfer path and test it.");
+      if (actionProfile.finalSwapDeltaValidated !== true) add("blocker", "FINAL_SWAP_DELTA_NOT_VALIDATED", "$.integration.routerActionProfile.finalSwapDeltaValidated", "The application does not commit to enforcing user bounds against the final PoolManager swap delta.", "Validate final input/output after hook deltas and all route legs, not only an intermediate quote.");
+      for (const [field, role] of [["appSourcePaths", "application source"], ["integrationTestPaths", "integration test"]]) {
+        const paths = integration[field];
+        if (!Array.isArray(paths) || paths.length === 0) add("blocker", "INTEGRATION_PATHS_MISSING", `$.integration.${field}`, "The prototype does not bind its included swap client or executable integration tests.", "List repository-relative application source and tests that encode, quote and execute every supported route.");
+        for (const [index, entry] of (paths ?? []).entries()) validateDeclaredPath(entry, `$.integration.${field}[${index}]`, role);
+      }
+      requireDetailedText(integration.quoteExecutionParity, "$.integration.quoteExecutionParity", "QUOTE_EXECUTION_PARITY_MISSING", add);
+      gate("sdk-lock-router-action-and-quote-parity-tests", "prototype", "The included swap client must bind exact SDK artifacts and prove quote-to-execution parity for every supported route.");
+    }
+  }
+  if (usesUniswapV4 === true && includedSwapClient && integration.routerGeneration === "custom-reviewed") {
+    const customRouter = routerDependency;
+    if (!customRouter || !resolvedText(customRouter.repository) || !resolvedText(customRouter.revision) || !resolvedText(customRouter.runtimeHash)) add("blocker", "CUSTOM_ROUTER_PROVENANCE_MISSING", "$.integration.routerGeneration", "A custom router selection needs an exact custom-router source, revision, runtime and deployment record.", "Add the reviewed router dependency or select an official explicit generation.");
+    gate("custom-router-auth-and-settlement-replay", "candidate", "A custom router changes actor identity, hookData, settlement and slippage assumptions that the autonomous service must replay.");
+  }
+  const exactOutputSupported = (integration.swapModes ?? []).some((mode) => mode.endsWith("exactOutput"));
+  const maximumLpFee = poolUsed === true ? (lpFee.mode === "static" ? lpFee.hundredthsOfBip : lpFee.maximum) : null;
+  if (poolUsed === true && maximumLpFee === 1000000 && exactOutputSupported) add("blocker", "FULL_LP_FEE_EXACT_OUTPUT_UNSUPPORTED", "$.integration.swapModes", "A 100% LP fee makes exact-output swaps impossible in Uniswap v4.", "Cap the LP fee below 100% or remove and explicitly reject both exact-output modes.");
+
+  const allowlistTriggers = objectAt(routing, "allowlistTriggers");
+  if (hookUsed === false) {
+    for (const field of ["usesDeltaFlag", "addressStartsWith91", "targetsMajorPair", "permissionedPool"]) {
+      if (allowlistTriggers[field] !== false) {
+        add("blocker", "NO_CUSTOM_HOOK_ROUTING_TRIGGER_CONFLICT", `$.integration.routingAndDiscoverability.allowlistTriggers.${field}`, "A no-custom-hook PoolKey cannot retain a hook-routing review trigger.", `Set ${field} to false for the ordinary no-custom-hook route.`);
+      }
+    }
+    if (routing.hookRegistryStatus !== "not-applicable") {
+      add("blocker", "NO_CUSTOM_HOOK_REGISTRY_CONFLICT", "$.integration.routingAndDiscoverability.hookRegistryStatus", "A no-custom-hook PoolKey has no custom hook to submit to a registry.", "Use hookRegistryStatus not-applicable.");
+    }
+    if (routing.customHookDataRequired !== false) {
+      add("blocker", "NO_CUSTOM_HOOK_ROUTING_DATA_CONFLICT", "$.integration.routingAndDiscoverability.customHookDataRequired", "A no-custom-hook route cannot require custom hookData.", "Set customHookDataRequired to false and use the standard router input path.");
+    }
+  }
+  const permissionedAssetProfile = objectAt(objectAt(submission, "capabilities"), "permissionedAsset");
+  const routingPermissionedExpected = permissionedAssetProfile.officialUniswapPermissionedPool === true;
+  const expectedRoutingTriggers = {
+    usesDeltaFlag: anyReturnDelta,
+    permissionedPool: routingPermissionedExpected
+  };
+  for (const [field, expected] of Object.entries(expectedRoutingTriggers)) {
+    if (typeof allowlistTriggers[field] !== "boolean") {
+      add("blocker", "ROUTING_ALLOWLIST_TRIGGER_UNRESOLVED", `$.integration.routingAndDiscoverability.allowlistTriggers.${field}`, "A routing allowlist trigger is unresolved.", "Inspect the hook permissions and pool profile, then record the exact boolean.");
+    } else if (allowlistTriggers[field] !== expected) {
+      add("blocker", "ROUTING_ALLOWLIST_TRIGGER_MISMATCH", `$.integration.routingAndDiscoverability.allowlistTriggers.${field}`, "The declared routing allowlist trigger does not match the submission.", `Set ${field} to ${expected}.`);
+    }
+  }
+  for (const field of ["addressStartsWith91", "targetsMajorPair"]) {
+    if (stage === "prototype" && typeof allowlistTriggers[field] !== "boolean") {
+      add("blocker", "ROUTING_ALLOWLIST_TRIGGER_UNRESOLVED", `$.integration.routingAndDiscoverability.allowlistTriggers.${field}`, "A published Uniswap routing allowlist trigger is unresolved for the prototype.", "Record the mined hook-address prefix and intended token pair after bytecode, CREATE2 inputs and assets are fixed.");
+    }
+  }
+  const publishedAllowlistTrigger = hookUsed === true && (
+    anyReturnDelta ||
+    allowlistTriggers.addressStartsWith91 === true ||
+    allowlistTriggers.targetsMajorPair === true ||
+    routingPermissionedExpected
+  );
+  const activeAllowlistStatuses = new Set(["required-not-submitted", "submitted-unverified"]);
+  const targetsUniswapRouting = routing.routingMode === "uniswap-interface-api";
+  if (targetsUniswapRouting && publishedAllowlistTrigger && !activeAllowlistStatuses.has(routing.uniswapRoutingStatus)) {
+    add("blocker", "UNISWAP_ROUTING_ALLOWLIST_REQUIRED", "$.integration.routingAndDiscoverability.uniswapRoutingStatus", "The hook meets a published routing-review trigger, but the submission does not retain an external allowlist step.", "Use required-not-submitted or submitted-unverified; only Uniswap Labs can decide routing eligibility.");
+  }
+  if (targetsUniswapRouting && !publishedAllowlistTrigger && routing.uniswapRoutingStatus !== "not-required-by-published-triggers") {
+    add("blocker", "UNISWAP_ROUTING_STATUS_MISMATCH", "$.integration.routingAndDiscoverability.uniswapRoutingStatus", "No published routing-review trigger is declared, so this status must not imply an external review or approval.", "Use not-required-by-published-triggers without claiming that the pool is routed or available.");
+  }
+  if (!targetsUniswapRouting && routing.uniswapRoutingStatus !== "not-applicable") {
+    add("blocker", "UNISWAP_ROUTING_STATUS_MISMATCH", "$.integration.routingAndDiscoverability.uniswapRoutingStatus", "A route outside the Uniswap interface and API cannot carry an active Uniswap hook-routing status.", "Use not-applicable; record application, filler or custom-route review separately without implying Uniswap routing.");
+  }
+  if (!routing.hookRegistryStatus) add("blocker", "HOOK_REGISTRY_STATUS_UNRESOLVED", "$.integration.routingAndDiscoverability.hookRegistryStatus", "The public hook registry status is unresolved.", "Record not-submitted, submitted-unverified, listed-unverified or not-applicable; registry listing is not routing approval.");
+  if (typeof routing.customHookDataRequired !== "boolean") add("blocker", "ROUTING_HOOK_DATA_REQUIREMENT_UNRESOLVED", "$.integration.routingAndDiscoverability.customHookDataRequired", "The route does not state whether every swap needs model-specific hookData.", "Inspect every supported route and record the exact requirement.");
+  if (typeof routing.standardRouterCompatible !== "boolean") add("blocker", "STANDARD_ROUTER_COMPATIBILITY_UNRESOLVED", "$.integration.routingAndDiscoverability.standardRouterCompatible", "Compatibility with the selected standard router path is unresolved.", "Bind the exact router generation and state whether it can encode every required input.");
+  if (hookData.used === false && routing.customHookDataRequired === true) add("blocker", "ROUTING_HOOK_DATA_DECLARATION_MISMATCH", "$.integration.routingAndDiscoverability.customHookDataRequired", "The routing profile requires custom hookData while the hook contract profile says hookData is unused.", "Keep both declarations consistent and test the exact encoded bytes.");
+  if (routing.customHookDataRequired === true && routing.routingMode === "uniswap-interface-api") {
+    add("blocker", "UNISWAP_ROUTING_CUSTOM_HOOK_DATA_UNSUPPORTED", "$.integration.routingAndDiscoverability.customHookDataRequired", "Uniswap's published routing policy does not approve hooks that require custom data inputs.", "Make the custom data optional with a safe default, or use and review an application-controlled or filler route without claiming standard Uniswap routing.");
+  }
+  const upgradeableRoutingExpected = hook.upgradeable === true;
+  if (upgradeableRoutingExpected && routing.routingMode === "uniswap-interface-api") {
+    add("blocker", "UNISWAP_ROUTING_UPGRADEABLE_HOOK_UNSUPPORTED", "$.integration.routingAndDiscoverability.routingMode", "Uniswap's published hook-routing policy does not approve upgradeable hooks.", "Use an immutable hook for the standard Uniswap routing target, or remove that target and disclose the exact upgrade authority for a separately reviewed application route.");
+  }
+  if (routing.customHookDataRequired === true && routing.standardRouterCompatible === true) {
+    add("blocker", "STANDARD_ROUTER_CUSTOM_HOOK_DATA_CONFLICT", "$.integration.routingAndDiscoverability.standardRouterCompatible", "A route that requires model-specific hookData cannot also claim generic standard-router compatibility.", "Set standardRouterCompatible to false and bind the application-controlled encoder and tests.");
+  }
+  if (routing.routingMode === "uniswap-interface-api" && routing.standardRouterCompatible !== true) add("blocker", "UNISWAP_STANDARD_ROUTE_INCOMPATIBLE", "$.integration.routingAndDiscoverability.standardRouterCompatible", "The selected Uniswap interface and API path is not compatible with the declared hook inputs.", "Remove the standard routing target or redesign the hook so the published routing path can execute every supported swap.");
+  if (routing.standardRouterCompatible === true && integration.routerGeneration === "custom-reviewed") add("blocker", "STANDARD_ROUTER_GENERATION_CONFLICT", "$.integration.routerGeneration", "A custom router cannot be described as the standard Universal Router path.", "Select one exact official generation or set standardRouterCompatible to false.");
+
+  const permissionedRouting = objectAt(routing, "permissionedRouting");
+  if (permissionedAssetProfile.used === true && typeof permissionedAssetProfile.officialUniswapPermissionedPool !== "boolean") {
+    add("blocker", "PERMISSIONED_POOL_ARCHITECTURE_UNRESOLVED", "$.capabilities.permissionedAsset.officialUniswapPermissionedPool", "The submission does not distinguish a controlled asset in a standard v4 pool from Uniswap's Permissioned Pool architecture.", "Set the field to true only when the pool uses Permissions Adapter, PermissionedHooks and the permissioned Position Manager architecture.");
+  }
+  if (permissionedAssetProfile.used !== true && permissionedAssetProfile.officialUniswapPermissionedPool === true) {
+    add("blocker", "PERMISSIONED_POOL_ARCHITECTURE_PROFILE_MISMATCH", "$.capabilities.permissionedAsset.officialUniswapPermissionedPool", "The submission selects the official Permissioned Pool architecture without enabling and completing the permissioned asset profile.", "Enable the permissioned asset profile and document the issuer, adapter, hooks, position manager and eligibility rules.");
+  }
+  if (permissionedRouting.required !== routingPermissionedExpected) {
+    add("blocker", "PERMISSIONED_ROUTING_PROFILE_MISMATCH", "$.integration.routingAndDiscoverability.permissionedRouting.required", "The permissioned routing profile does not match the token and pool design.", `Set required to ${routingPermissionedExpected} and ${routingPermissionedExpected ? "complete the adapter route" : "clear the inactive fields"}.`);
+  }
+  if (routingPermissionedExpected) {
+    if (target.dependencyBaseline === "model-specific-pinned") {
+      gate("permissioned-pool-release-baseline-binding", "candidate", "A builder-pinned Permissioned Pool dependency graph cannot become trusted until the signed release registry binds one coherently machine-verified baseline.");
+      if (stage === "prototype") {
+        add("blocker", "PERMISSIONED_POOL_BASELINE_UNREVIEWED", "$.target.dependencyBaseline", "The Permissioned Pool prototype uses a builder-pinned baseline that no signed release registry has independently bound.", "Keep the application at proposal and complete the exact dependency lock; a later signed baseline must bind the adapter, hooks, Position Manager, router and deployment graph.");
+      }
+    } else if (target.dependencyBaseline !== "model-specific-reviewed") {
+      add("blocker", "PERMISSIONED_POOL_BASELINE_UNREVIEWED", "$.target.dependencyBaseline", "The general Programmable-tested dependency baseline does not include Uniswap's Permissioned Pool architecture.", "Use model-specific-pinned for analysis; only a signed independently verified registry record may later assign model-specific-reviewed.");
+    }
+    if (permissionedRouting.minimumRouterGeneration !== "V2_2_0" || (includedSwapClient && integration.routerGeneration !== "V2_2_0")) {
+      add("blocker", "PERMISSIONED_ROUTER_GENERATION_INCOMPATIBLE", "$.integration.routingAndDiscoverability.permissionedRouting.minimumRouterGeneration", "Permissioned pool swaps require Universal Router 2.2.0 or a later compatible generation; this standard currently pins 2.2.0.", includedSwapClient ? "Select V2_2_0, bind its exact deployment record and test adapter wrapping and unwrapping." : "Keep minimumRouterGeneration at V2_2_0 for the external client; do not add builder-owned router bindings unless the project includes that client.");
+    }
+    if (permissionedRouting.adapterCurrencyUsed !== true) add("blocker", "PERMISSIONED_ADAPTER_CURRENCY_MISSING", "$.integration.routingAndDiscoverability.permissionedRouting.adapterCurrencyUsed", "The PoolKey and settlement path do not commit to the verified Permissions Adapter currency.", "Use the adapter currency, not the underlying permissioned token, throughout PoolKey, settlement and quoting.");
+    requireDetailedText(permissionedRouting.allowedWrapperBindings, "$.integration.routingAndDiscoverability.permissionedRouting.allowedWrapperBindings", "PERMISSIONED_WRAPPER_BINDINGS_MISSING", add);
+    requireDetailedText(permissionedRouting.positionManagerBinding, "$.integration.routingAndDiscoverability.permissionedRouting.positionManagerBinding", "PERMISSIONED_POSITION_MANAGER_BINDING_MISSING", add);
+    if (permissionedRouting.routingAllowlistRequiredPerChain !== true) add("blocker", "PERMISSIONED_ROUTING_ALLOWLIST_MISSING", "$.integration.routingAndDiscoverability.permissionedRouting.routingAllowlistRequiredPerChain", "Permissioned pools require a separate Uniswap routing allowlist step on every network.", "Keep the external per-chain allowlist gate true and do not infer approval from adapter verification.");
+    if (routing.standardRouterCompatible !== true || routing.customHookDataRequired === true) add("blocker", "PERMISSIONED_ROUTING_INCOMPATIBLE", "$.integration.routingAndDiscoverability", "The permissioned pool cannot execute through the required adapter-aware standard route.", "Use Universal Router 2.2.0, approved wrapper bindings and no model-specific hookData requirement.");
+    gate("permissioned-router-wrapper-and-quote-tests", "prototype", "The pool uses a permissioned asset adapter.");
+    gate("permissioned-pool-routing-allowlist", "external", "Uniswap controls permissioned-pool routing eligibility per chain.");
+  } else if (permissionedRouting.required === false && (
+    permissionedRouting.minimumRouterGeneration !== null ||
+    permissionedRouting.adapterCurrencyUsed !== null ||
+    permissionedRouting.allowedWrapperBindings !== null ||
+    permissionedRouting.positionManagerBinding !== null ||
+    permissionedRouting.routingAllowlistRequiredPerChain !== null
+  )) {
+    add("blocker", "PERMISSIONED_ROUTING_DISABLED_CONFLICT", "$.integration.routingAndDiscoverability.permissionedRouting", "The permissioned routing profile is disabled but still contains adapter or allowlist configuration.", "Set every field except required to null or enable and complete the permissioned asset profile.");
+  }
+  if (targetsUniswapRouting && publishedAllowlistTrigger) gate("uniswap-hook-routing-provider-policy", "external", "Published Uniswap routing criteria apply; only the provider controls its hook or pool support.");
+
+  const routingPathRules = [
+    ["sourcePaths", "routing source"],
+    ["testPaths", "routing test"]
+  ];
+  for (const [field, role] of routingPathRules) {
+    const entries = routing[field];
+    if (stage === "prototype" && includedSwapClient && (!Array.isArray(entries) || entries.length === 0)) add("blocker", "ROUTING_PATHS_MISSING", `$.integration.routingAndDiscoverability.${field}`, "The included swap client does not bind the route encoder or its executable tests.", "List repository-relative routing source and test files for every supported swap mode.");
+    for (const [index, entry] of (entries ?? []).entries()) validateDeclaredPath(entry, `$.integration.routingAndDiscoverability.${field}[${index}]`, role);
+  }
+
+  const dataReconstruction = objectAt(integration, "dataReconstruction");
+  const reserveReconstruction = objectAt(dataReconstruction, "reserveReconstruction");
+  const reserveReconstructionExpected =
+    customAccounting.used === true ||
+    claims.used === true ||
+    submission.capabilities?.externalLiquidity?.used === true;
+  const platformIndexerDeclared = (integration.platformHandoff?.indexerSourcePaths?.length ?? 0) > 0;
+  const dataReconstructionApplicable = dataReconstruction.mode !== "not-applicable";
+  if (!dataReconstruction.mode) {
+    add("blocker", "DATA_RECONSTRUCTION_MODE_UNRESOLVED", "$.integration.dataReconstruction.mode", "The submission does not say whether it includes a reconstructing data surface.", "Choose events-only, events-with-confirmed-reads or not-applicable after inspecting the actual project surfaces and accounting requirements.");
+  } else if (!dataReconstructionApplicable) {
+    for (const field of [
+      "eventCoverage",
+      "cursor",
+      "startBlockPolicy",
+      "finalityDepth",
+      "reorgPolicy",
+      "backfillPolicy",
+      "checkpointPolicy",
+      "freshnessTargetSeconds",
+      "staleAfterSeconds",
+      "freshnessMeasurement",
+      "reconciliation"
+    ]) {
+      if (dataReconstruction[field] !== null) add("blocker", "DATA_RECONSTRUCTION_NOT_APPLICABLE_CONFLICT", `$.integration.dataReconstruction.${field}`, "Data reconstruction is not applicable, but an active indexer field remains configured.", "Set every inactive data-reconstruction field to null, keep source and test paths empty and disable reserve reconstruction.");
+    }
+    for (const field of ["sourcePaths", "testPaths"]) {
+      if ((dataReconstruction[field]?.length ?? 0) !== 0) add("blocker", "DATA_RECONSTRUCTION_NOT_APPLICABLE_CONFLICT", `$.integration.dataReconstruction.${field}`, "Data reconstruction is not applicable, but indexer source or test paths remain declared.", "Use an empty array or select an active data-reconstruction mode and complete its evidence.");
+    }
+    if (reserveReconstruction.used !== false || hasConfiguredValue(reserveReconstruction, new Set(["used"]))) {
+      add("blocker", "DATA_RECONSTRUCTION_NOT_APPLICABLE_CONFLICT", "$.integration.dataReconstruction.reserveReconstruction", "Data reconstruction is not applicable, but reserve-reconstruction fields remain active.", "Set used to false and clear every reserve-reconstruction field, or select an active data mode and complete the solvency evidence.");
+    }
+    if (reserveReconstructionExpected || platformIndexerDeclared) {
+      add("blocker", "DATA_RECONSTRUCTION_REQUIRED_BY_PROJECT", "$.integration.dataReconstruction.mode", "The project declares custom accounting, claims, external liquidity or an indexer surface, so data reconstruction cannot be not-applicable.", "Choose events-only or events-with-confirmed-reads and bind the exact indexer, recovery and reconciliation evidence required by the declared surface.");
+    }
+  } else {
+    requireDetailedText(dataReconstruction.eventCoverage, "$.integration.dataReconstruction.eventCoverage", "DATA_EVENT_COVERAGE_MISSING", add);
+    if (dataReconstruction.cursor !== "block-number-transaction-index-log-index") add("blocker", "DATA_CURSOR_INVALID", "$.integration.dataReconstruction.cursor", "The indexer cursor does not preserve deterministic EVM log order.", "Order by block number, transaction index and log index, and keep the block hash in each checkpoint.");
+    requireDetailedText(dataReconstruction.startBlockPolicy, "$.integration.dataReconstruction.startBlockPolicy", "DATA_START_BLOCK_POLICY_MISSING", add);
+    if (!Number.isInteger(dataReconstruction.finalityDepth) || dataReconstruction.finalityDepth < 1) add("blocker", "DATA_FINALITY_POLICY_MISSING", "$.integration.dataReconstruction.finalityDepth", "The indexer has no positive finality depth.", "Set a chain-specific confirmation depth and test shallow and deeper reorganizations.");
+    if (!resolvedText(dataReconstruction.reorgPolicy) || dataReconstruction.reorgPolicy.trim().length < 12) add("blocker", "DATA_REORG_POLICY_MISSING", "$.integration.dataReconstruction.reorgPolicy", "The indexer does not say how orphaned logs and derived rows are rolled back.", "Store checkpoint block hashes, find the last canonical ancestor, remove orphaned state and replay deterministically.");
+    if (!resolvedText(dataReconstruction.backfillPolicy) || dataReconstruction.backfillPolicy.trim().length < 12) add("blocker", "DATA_BACKFILL_POLICY_MISSING", "$.integration.dataReconstruction.backfillPolicy", "The indexer does not define complete historical replay from deployment.", "Bind exact start blocks, bounded ranges, retry behavior and a no-skip cursor.");
+    requireDetailedText(dataReconstruction.checkpointPolicy, "$.integration.dataReconstruction.checkpointPolicy", "DATA_CHECKPOINT_POLICY_MISSING", add);
+    if (
+      !Number.isInteger(dataReconstruction.freshnessTargetSeconds) ||
+      !Number.isInteger(dataReconstruction.staleAfterSeconds) ||
+      dataReconstruction.freshnessTargetSeconds < 1 ||
+      dataReconstruction.staleAfterSeconds < dataReconstruction.freshnessTargetSeconds ||
+      !resolvedText(dataReconstruction.freshnessMeasurement) ||
+      dataReconstruction.freshnessMeasurement.trim().length < 12
+    ) {
+      add("blocker", "DATA_FRESHNESS_POLICY_MISSING", "$.integration.dataReconstruction", "The data contract has no coherent freshness target, stale threshold and measurement rule.", "Set positive target and stale thresholds, keep staleAfterSeconds at or above the target and expose lag from finalized chain state.");
+    }
+    requireDetailedText(dataReconstruction.reconciliation, "$.integration.dataReconstruction.reconciliation", "DATA_RECONCILIATION_POLICY_MISSING", add);
+
+    if (reserveReconstruction.used !== reserveReconstructionExpected) {
+      add("blocker", "RESERVE_RECONSTRUCTION_REQUIRED", "$.integration.dataReconstruction.reserveReconstruction.used", "The indexer reserve profile does not match the hook-held balances, PoolManager claims or custom liabilities in this design.", `Set used to ${reserveReconstructionExpected} and ${reserveReconstructionExpected ? "reconstruct gross balances, attributed liabilities and solvency" : "clear inactive reserve fields"}.`);
+    }
+    if (reserveReconstruction.used === true) {
+      requireNonEmptyArray(reserveReconstruction.balanceSources, "$.integration.dataReconstruction.reserveReconstruction.balanceSources", "RESERVE_BALANCE_SOURCES_MISSING", "List the exact hook balances and PoolManager claim or credit sources observed at one confirmed block.", add);
+      requireNonEmptyArray(reserveReconstruction.liabilitySources, "$.integration.dataReconstruction.reserveReconstruction.liabilitySources", "RESERVE_LIABILITY_SOURCES_MISSING", "List the exact events and contract reads that reconstruct beneficiary liabilities.", add);
+      for (const dimension of ["poolId", "currency", "beneficiary"]) if (!(reserveReconstruction.attributionKeys ?? []).includes(dimension)) add("blocker", "RESERVE_ATTRIBUTION_KEY_INCOMPLETE", "$.integration.dataReconstruction.reserveReconstruction.attributionKeys", `Reserve attribution omits ${dimension}.`, "Keep hook-held assets and liabilities isolated by PoolId, currency and beneficiary.");
+      requireDetailedText(reserveReconstruction.solvencyEquation, "$.integration.dataReconstruction.reserveReconstruction.solvencyEquation", "RESERVE_SOLVENCY_EQUATION_MISSING", add);
+      if (reserveReconstruction.poolLiquidityTreatment !== "excluded-from-hook-reserves") add("blocker", "POOL_LIQUIDITY_COUNTED_AS_HOOK_RESERVE", "$.integration.dataReconstruction.reserveReconstruction.poolLiquidityTreatment", "Canonical pool liquidity is not a hook-owned reserve and cannot back hook liabilities.", "Exclude PoolManager pool liquidity; count only balances or claims legally and operationally attributable to the hook liability.");
+      requireDetailedText(reserveReconstruction.donationAndDustPolicy, "$.integration.dataReconstruction.reserveReconstruction.donationAndDustPolicy", "RESERVE_DONATION_POLICY_MISSING", add);
+      requireDetailedText(reserveReconstruction.reconciliation, "$.integration.dataReconstruction.reserveReconstruction.reconciliation", "RESERVE_RECONCILIATION_MISSING", add);
+      gate("reserve-reconstruction-and-solvency-tests", "prototype", "The hook holds balances, claims or custom-accounting liabilities.");
+    } else if (reserveReconstruction.used === false && hasConfiguredValue(reserveReconstruction, new Set(["used"]))) {
+      add("blocker", "RESERVE_RECONSTRUCTION_DISABLED_CONFLICT", "$.integration.dataReconstruction.reserveReconstruction", "Reserve reconstruction is disabled but reserve sources or accounting rules remain configured.", "Clear every inactive field or enable and complete reserve reconstruction.");
+    }
+
+    for (const [field, role] of [
+      ["sourcePaths", "data reconstruction source"],
+      ["testPaths", "data reconstruction test"]
+    ]) {
+      const entries = dataReconstruction[field];
+      if (stage === "prototype" && (!Array.isArray(entries) || entries.length === 0)) add("blocker", "DATA_RECONSTRUCTION_PATHS_MISSING", `$.integration.dataReconstruction.${field}`, "The prototype does not bind its indexer implementation and recovery tests.", "List repository-relative indexer source and executable reorg, backfill, freshness and reconciliation tests.");
+      for (const [index, entry] of (entries ?? []).entries()) validateDeclaredPath(entry, `$.integration.dataReconstruction.${field}[${index}]`, role);
+    }
+    gate("event-reorg-backfill-freshness-tests", "prototype", "Public model state must be reproducible from events and confirmed reads.");
+  }
+
+  const platformHandoff = objectAt(integration, "platformHandoff");
+  if (typeof platformHandoff.intended !== "boolean") add("blocker", "PLATFORM_HANDOFF_INTENT_UNRESOLVED", "$.integration.platformHandoff.intended", "The submission does not say whether it is intended for Programmable integration.", "Set intended explicitly; product paths remain separately authorized until the exact revision is admitted and integrated.");
+  if (!platformHandoff.reviewStatus) add("blocker", "PLATFORM_REVIEW_STATUS_UNRESOLVED", "$.integration.platformHandoff.reviewStatus", "The legacy-named independent-review status is unresolved.", "Use not-requested or pending-maintainer-review; applicant input cannot record its own approval.");
+  if (platformHandoff.maintainerReviewRequired !== true) add("blocker", "PLATFORM_MAINTAINER_REVIEW_REQUIRED", "$.integration.platformHandoff.maintainerReviewRequired", "The legacy compatibility field does not preserve an independent admission decision.", "Set maintainerReviewRequired to true; the field name is retained for compatibility and grants no human or machine authority.");
+  if (platformHandoff.selfApproval === true) add("hard", "PLATFORM_SELF_APPROVAL_FORBIDDEN", "$.integration.platformHandoff.selfApproval", "An applicant cannot approve its own registry or product integration.", "Set selfApproval to false; the autonomous admission service decides admission and production integration remains separately authorized.");
+  else if (platformHandoff.selfApproval !== false) add("blocker", "PLATFORM_SELF_APPROVAL_UNRESOLVED", "$.integration.platformHandoff.selfApproval", "The handoff must explicitly deny self-approval.", "Set selfApproval to false.");
+  if (platformHandoff.availabilityClaimed === true) add("hard", "PLATFORM_AVAILABILITY_CLAIM_FORBIDDEN", "$.integration.platformHandoff.availabilityClaimed", "A proposal or prototype cannot claim that a model is publicly available.", "Set availabilityClaimed to false; availability needs separate deployment, lifecycle, monitoring and production release evidence.");
+  else if (platformHandoff.availabilityClaimed !== false) add("blocker", "PLATFORM_AVAILABILITY_CLAIM_UNRESOLVED", "$.integration.platformHandoff.availabilityClaimed", "The handoff must explicitly avoid a public availability claim.", "Set availabilityClaimed to false.");
+  requireDetailedText(platformHandoff.handoffNotes, "$.integration.platformHandoff.handoffNotes", "PLATFORM_HANDOFF_NOTES_MISSING", add);
+  if (stage === "prototype" && platformHandoff.intended !== true) add("blocker", "PROTOTYPE_PLATFORM_HANDOFF_MISSING", "$.integration.platformHandoff.intended", "A prototype submission does not bind the Programmable integration handoff.", "Set intended to true and describe the intended product surfaces in handoffNotes; repository paths remain untrusted proposals until independent admission and separate integration.");
+
+  const platformPathRules = [
+    ["websiteRegistryPath", platformHandoff.websiteRegistryPath ? [platformHandoff.websiteRegistryPath] : [], "website registry"],
+    ["uiSourcePaths", platformHandoff.uiSourcePaths ?? [], "user-interface source"],
+    ["apiSourcePaths", platformHandoff.apiSourcePaths ?? [], "API source"],
+    ["indexerSourcePaths", platformHandoff.indexerSourcePaths ?? [], "indexer source"],
+    ["testPaths", platformHandoff.testPaths ?? [], "platform integration test"]
+  ];
+  for (const [field, entries, role] of platformPathRules) {
+    for (const [index, entry] of entries.entries()) validateDeclaredPath(entry, `$.integration.platformHandoff.${field}${field === "websiteRegistryPath" ? "" : `[${index}]`}`, role);
+  }
+  if (platformHandoff.intended === true) {
+    gate("programmable-registry-finality-projection", "candidate", "Registry publication requires the separately authorized production projection after finalized launch evidence.");
+    if (includedSwapClient || (platformHandoff.uiSourcePaths?.length ?? 0) > 0) gate("programmable-ui-launch-contract-evidence", "candidate", "The proposed user-interface integration requires machine-bound launch-contract evidence and a separately authorized product release.");
+    if ((platformHandoff.apiSourcePaths?.length ?? 0) > 0) gate("programmable-api-launch-contract-evidence", "candidate", "The proposed API integration requires machine-bound launch-contract evidence and a separately authorized product release.");
+    if (dataReconstructionApplicable || (platformHandoff.indexerSourcePaths?.length ?? 0) > 0) gate("programmable-indexer-finality-projection", "candidate", "The proposed indexer integration requires finalized launch evidence and a separately authorized production projection.");
+    if (
+      includedSwapClient ||
+      dataReconstructionApplicable ||
+      (platformHandoff.testPaths?.length ?? 0) > 0
+    ) gate("programmable-cross-surface-integration-replay", "candidate", "The autonomous service must bind and replay cross-surface test evidence before admission; production integration remains separately authorized.");
+  }
+
+  const capabilityProfiles = objectAt(submission, "capabilities");
+  for (const name of ["externalCalls", "permissionedAsset", "oracle", "keeper", "proof", "crossChain", "externalLiquidity", "asyncSwap", "customCurve"]) {
+    const profile = objectAt(capabilityProfiles, name);
+    if (typeof profile.used !== "boolean") {
+      add("blocker", "CAPABILITY_USAGE_UNRESOLVED", `$.capabilities.${name}.used`, `Usage of the ${name} capability is unresolved.`, "Set used to true or false after inspecting the design and complete the policy when it is true.");
+    }
+  }
+
+  const capabilityExtensions = Array.isArray(submission.capabilityExtensions) ? submission.capabilityExtensions : [];
+  const capabilityExtensionIds = new Set();
+  for (const [index, extension] of capabilityExtensions.entries()) {
+    const extensionPath = `$.capabilityExtensions[${index}]`;
+    if (capabilityExtensionIds.has(extension?.capabilityId)) {
+      add("blocker", "CAPABILITY_EXTENSION_DUPLICATE", `${extensionPath}.capabilityId`, "Capability extension identifiers must be unique.", "Merge duplicate declarations under one stable capabilityId.");
+    }
+    capabilityExtensionIds.add(extension?.capabilityId);
+    for (const [field, role] of [
+      ["sourcePaths", "capability extension source"],
+      ["testPaths", "capability extension test"],
+      ["evidencePaths", "capability extension evidence"]
+    ]) {
+      for (const [pathIndex, entry] of (extension?.[field] ?? []).entries()) {
+        validateDeclaredPath(entry, `${extensionPath}.${field}[${pathIndex}]`, role);
+      }
+    }
+    if (extension?.schemaPath !== null && extension?.schemaPath !== undefined) {
+      validateDeclaredPath(extension.schemaPath, `${extensionPath}.schemaPath`, "capability extension schema");
+    }
+    add(
+      "warning",
+      "CAPABILITY_EXTENSION_REQUIRES_ARCHITECTURE_REVIEW",
+      extensionPath,
+      `Novel capability ${extension?.capabilityId ?? "without an id"} is preserved for automated architecture-evidence analysis rather than forced into the current catalog.`,
+      "Machine-analyze its declared interactions, trust boundary, failure mode, schema and exact source/evidence bytes before defining adapters or approval requirements."
+    );
+    gate("novel-capability-architecture-evidence", "candidate", "At least one capability extension is outside the current acceleration catalog and needs automated architecture evidence.");
+  }
+
+  const externalCalls = objectAt(capabilityProfiles, "externalCalls");
+  if (externalCalls.used === true) {
+    requireNonEmptyArray(externalCalls.targets, "$.capabilities.externalCalls.targets", "EXTERNAL_CALL_TARGETS_MISSING", "List every exact target or target registry.", add);
+    requireNonEmptyArray(externalCalls.callSites, "$.capabilities.externalCalls.callSites", "EXTERNAL_CALL_SITES_MISSING", "List every callback and lifecycle action that performs an external call.", add);
+    for (const field of ["reentrancyPolicy", "stateDriftPolicy", "returnValuePolicy", "failureAtomicity"]) requireDetailedText(externalCalls[field], `$.capabilities.externalCalls.${field}`, "EXTERNAL_CALL_POLICY_INCOMPLETE", add);
+    gate("external-call-reentrancy-and-failure-tests", "prototype", "The declared model makes external calls.");
+  }
+
+  const permissionedAsset = objectAt(capabilityProfiles, "permissionedAsset");
+  const permissionedExpected = model.category === "permissioned-asset" || assets.some((asset) => asset?.origin === "permissioned-adapter" || (asset?.controls?.length ?? 0) > 0 || (asset?.behaviors ?? []).some((behavior) => ["pausable", "blacklistable", "confiscatable"].includes(behavior)));
+  requireCapabilityMatch(permissionedAsset.used, permissionedExpected, "permissionedAsset", "PERMISSIONED_ASSET_PROFILE_MISMATCH", add);
+  if (permissionedAsset.used === true) {
+    for (const field of ["issuer", "jurisdiction", "underlyingClaim", "custodian", "adapter", "hooks", "positionManager", "swapEligibility", "liquidityEligibility", "positionTransferability", "pauseFreezeUnwind", "redemption", "routingLimitations"]) requireDetailedText(permissionedAsset[field], `$.capabilities.permissionedAsset.${field}`, "PERMISSIONED_ASSET_PROFILE_INCOMPLETE", add);
+    requireNonEmptyArray(permissionedAsset.legalDocuments, "$.capabilities.permissionedAsset.legalDocuments", "PERMISSIONED_ASSET_LEGAL_DOCUMENTS_MISSING", "Link the exact issuer and legal documents; token pairing is not ownership of an underlying asset.", add);
+    gate("permissioned-asset-legal-and-trust-disclosure", "candidate", "The model depends on issuer controls, legal claims or permission adapters whose exact external documents and trust boundaries must be disclosed.");
+  }
+
+  const oracle = objectAt(capabilityProfiles, "oracle");
+  const oracleDependencyText = [...(submission.dependencies?.onchain ?? []), ...(submission.dependencies?.offchain ?? [])].map((dependency) => `${dependency?.name ?? ""} ${dependency?.kind ?? ""}`).join(" ");
+  const oracleExpected = operations.oracle?.required === true || model.category === "oracle-linked" || /\b(?:oracle|price feed|chainlink|pyth)\b/i.test(`${model.summary ?? ""} ${model.whyV4 ?? ""} ${oracleDependencyText}`);
+  requireCapabilityMatch(oracle.used, oracleExpected, "oracle", "ORACLE_PROFILE_MISMATCH", add);
+  if (oracle.used === true) {
+    for (const field of ["source", "value", "deployment", "runtimeHash", "decimals", "heartbeatSeconds", "maxAgeSeconds", "observationType", "windowSeconds", "minimumAnswer", "maximumAnswer", "maximumDeviation", "roundChecks", "manipulationResistance", "governance", "fallback", "maxFallbackAgeSeconds", "failureRule"]) requirePresent(oracle[field], `$.capabilities.oracle.${field}`, "ORACLE_POLICY_INCOMPLETE", "Define the exact feed, bounds, freshness, manipulation, governance and bounded failure behavior.", add);
+    if (Number.isInteger(oracle.heartbeatSeconds) && Number.isInteger(oracle.maxAgeSeconds) && oracle.maxAgeSeconds < oracle.heartbeatSeconds) add("blocker", "ORACLE_MAX_AGE_BELOW_HEARTBEAT", "$.capabilities.oracle.maxAgeSeconds", "The accepted oracle age is shorter than its declared heartbeat.", "Use coherent freshness bounds and test delayed and stale rounds.");
+    if (oracle.fallback === "last-good-bounded" && (!Number.isInteger(oracle.maxFallbackAgeSeconds) || oracle.maxFallbackAgeSeconds <= 0)) add("blocker", "ORACLE_FALLBACK_UNBOUNDED", "$.capabilities.oracle.maxFallbackAgeSeconds", "A last-good fallback needs a finite maximum age.", "Set a finite fallback horizon and revert or enter a static safe mode afterward.");
+    gate("oracle-freshness-manipulation-and-failure-tests", "prototype", "The model consumes an oracle.");
+    gate("oracle-deployment-governance-evidence", "candidate", "The model consumes an oracle whose exact deployment, runtime and governance evidence must be machine-verified.");
+  }
+
+  const keeper = objectAt(capabilityProfiles, "keeper");
+  const keeperExpected = operations.keeper?.required === true;
+  requireCapabilityMatch(keeper.used, keeperExpected, "keeper", "KEEPER_PROFILE_MISMATCH", add);
+  if (keeper.used === true) {
+    for (const field of ["executionMode", "minIntervalSeconds", "maxDelaySeconds", "permissionlessFallbackAfterSeconds", "idempotencyKey", "duplicateBehavior", "lastProcessedState", "boundedWork", "maxItems", "retryPolicy", "zeroWorkBehavior", "fundingSource", "minimumGasRunway", "alertThreshold", "maximumGas", "failureImpact", "userExitIndependent", "poolBinding", "slippage", "deadline", "mevPolicy"]) requirePresent(keeper[field], `$.capabilities.keeper.${field}`, "KEEPER_POLICY_INCOMPLETE", "Define liveness, idempotency, bounded work, funding, fallback, slippage, deadline and failure semantics.", add);
+    if (keeper.executionMode === "operator-with-permissionless-fallback" && (!Number.isInteger(keeper.permissionlessFallbackAfterSeconds) || keeper.permissionlessFallbackAfterSeconds <= 0)) add("blocker", "KEEPER_FALLBACK_UNRESOLVED", "$.capabilities.keeper.permissionlessFallbackAfterSeconds", "The permissionless keeper fallback needs a finite activation delay.", "Set the delay and test duplicate execution at the boundary.");
+    if (keeper.userExitIndependent !== true) add("blocker", "KEEPER_CAN_BLOCK_EXIT", "$.capabilities.keeper.userExitIndependent", "A keeper outage must not trap user funds or block the defined exit path.", "Make exit independent of keeper liveness or redesign the custody model.");
+    gate("keeper-idempotency-liveness-and-gas-tests", "prototype", "The model requires autonomous or scheduled execution.");
+    gate("keeper-monitoring-and-fallback-proof", "candidate", "The model requires autonomous or scheduled execution.");
+  }
+
+  const proof = objectAt(capabilityProfiles, "proof");
+  const proofText = `${model.summary ?? ""} ${model.whyV4 ?? ""} ${(submission.dependencies?.onchain ?? []).map((dependency) => `${dependency.name ?? ""} ${dependency.kind ?? ""}`).join(" ")}`;
+  const proofExpected = model.category === "privacy" || /\b(?:zero[- ]knowledge|zkp?|zk[- ]snark|zk[- ]stark|snark|stark|verifier|nullifier|cryptographic proof)\b/i.test(proofText);
+  requireCapabilityMatch(proof.used, proofExpected, "proof", "PROOF_PROFILE_MISMATCH", add);
+  if (proof.used === true) {
+    for (const field of ["proofSystem", "circuitRevision", "verifyingKeyHash", "verifierAddress", "runtimeHash", "setupType", "setupProvenance", "replayMode", "nullifierScope", "nullifierDerivation", "nullifierStorage", "atomicSpentCheck", "resetPolicy", "maximumProofBytes", "maximumVerificationGas", "verifierAuthority", "failureRule", "privacyClaim", "metadataLeakage"]) requirePresent(proof[field], `$.capabilities.proof.${field}`, "PROOF_POLICY_INCOMPLETE", "Define the exact circuit, verifier, setup, domain, replay, gas, failure and privacy model.", add);
+    requireNonEmptyArray(proof.publicInputs, "$.capabilities.proof.publicInputs", "PROOF_PUBLIC_INPUTS_MISSING", "List and bind every public input.", add);
+    const bindings = objectAt(proof, "domainBindings");
+    for (const field of ["chainId", "verifyingContract", "modelVersion", "pool", "action", "actorOrRecipient", "amountBounds", "epochOrDeadline"]) {
+      if (bindings[field] !== true) add("blocker", "PROOF_DOMAIN_BINDING_INCOMPLETE", `$.capabilities.proof.domainBindings.${field}`, "The proof is not bound to this execution domain and action.", "Bind the field in the circuit or prove a separately reviewed equivalent replay boundary.");
+    }
+    if (proof.replayMode === "single-use" && proof.atomicSpentCheck !== true) add("blocker", "PROOF_NULLIFIER_NOT_ATOMIC", "$.capabilities.proof.atomicSpentCheck", "A single-use proof needs an atomic spent check and state update.", "Check and consume the nullifier in the same transaction before value is released.");
+    gate("proof-domain-replay-and-verifier-tests", "prototype", "The model verifies cryptographic proofs.");
+    gate("circuit-and-privacy-proof-analysis", "candidate", "The model verifies cryptographic proofs whose circuit, domain, verifier and privacy claims require bounded machine analysis.");
+  }
+
+  const crossChain = objectAt(capabilityProfiles, "crossChain");
+  const dependencyText = [...(submission.dependencies?.onchain ?? []), ...(submission.dependencies?.offchain ?? [])].map((dependency) => `${dependency.name ?? ""} ${dependency.kind ?? ""} ${dependency.trust ?? ""}`).join(" ");
+  const crossChainDeclared = (submission.risk?.featureTriggers ?? [])
+    .some((trigger) => /\bcross[- ]chain\b/i.test(trigger));
+  const crossChainConfigured = Object.entries(crossChain)
+    .some(([field, value]) => field !== "used" && hasResolvedPolicyValue(value));
+  const crossChainExpected =
+    crossChainDeclared ||
+    crossChainConfigured ||
+    /\b(?:bridge|cross[- ]chain|cross[- ]domain|message relay|wormhole|vaa|layerzero|endpointv2|hyperlane|axelar|ccip)\b/i
+      .test(`${model.summary ?? ""} ${model.whyV4 ?? ""} ${dependencyText}`);
+  requireCapabilityMatch(crossChain.used, crossChainExpected, "crossChain", "CROSS_CHAIN_PROFILE_MISMATCH", add);
+  if (crossChain.used === true) {
+    const crossChainPath = "$.capabilities.crossChain";
+    const source = objectAt(crossChain, "source");
+    const sourceNetwork = objectAt(source, "network");
+    const sourceSender = objectAt(source, "authenticatedSender");
+    const destination = objectAt(crossChain, "destination");
+    const message = objectAt(crossChain, "message");
+    const domainBindings = objectAt(message, "domainBindings");
+    const finality = objectAt(crossChain, "finality");
+    const ordering = objectAt(crossChain, "ordering");
+    const staleness = objectAt(crossChain, "staleness");
+    const fallback = objectAt(crossChain, "fallback");
+    const quarantine = objectAt(crossChain, "quarantine");
+
+    requirePresent(crossChain.bridgeDependencyId, `${crossChainPath}.bridgeDependencyId`, "CROSS_CHAIN_POLICY_INCOMPLETE", "Reference the exact pinned destination bridge dependency.", add);
+
+    for (const field of ["namespace", "reference"]) {
+      requirePresent(sourceNetwork[field], `${crossChainPath}.source.network.${field}`, "CROSS_CHAIN_SOURCE_POLICY_INCOMPLETE", "Bind the source network with one canonical namespace and reference.", add);
+    }
+    for (const field of ["encoding", "value"]) {
+      requirePresent(sourceSender[field], `${crossChainPath}.source.authenticatedSender.${field}`, "CROSS_CHAIN_SOURCE_POLICY_INCOMPLETE", "Bind the exact authenticated source sender and its canonical encoding.", add);
+    }
+    requirePresent(source.domain, `${crossChainPath}.source.domain`, "CROSS_CHAIN_SOURCE_POLICY_INCOMPLETE", "Bind the exact bridge source domain identifier.", add);
+    if (
+      sourceNetwork.namespace === "eip155" &&
+      resolvedText(sourceNetwork.reference) &&
+      !/^[1-9][0-9]*$/.test(sourceNetwork.reference)
+    ) {
+      add("blocker", "CROSS_CHAIN_SOURCE_NETWORK_INVALID", `${crossChainPath}.source.network.reference`, "An eip155 source reference must be a canonical positive decimal chain id.", "Use the exact EIP-155 chain id without signs, prefixes or leading zeroes.");
+    }
+    const senderEncodingPatterns = {
+      "evm-address": /^0x[a-fA-F0-9]{40}$/,
+      bytes32: /^0x[a-fA-F0-9]{64}$/,
+      base58: /^[1-9A-HJ-NP-Za-km-z]{3,128}$/,
+      bech32: /^[a-z0-9]{8,200}$/,
+      "bridge-native": /^\S{3,200}$/u
+    };
+    if (
+      resolvedText(sourceSender.encoding) &&
+      resolvedText(sourceSender.value) &&
+      !senderEncodingPatterns[sourceSender.encoding]?.test(sourceSender.value)
+    ) {
+      add("blocker", "CROSS_CHAIN_SOURCE_SENDER_ENCODING_INVALID", `${crossChainPath}.source.authenticatedSender.value`, "The authenticated source sender does not match its declared encoding.", "Use the bridge-authenticated sender in its exact canonical encoding.");
+    }
+    if (sourceSender.encoding === "bridge-native") {
+      if (!resolvedText(sourceSender.canonicalizationRule) || sourceSender.canonicalizationRule.trim().length < 12) {
+        add("blocker", "CROSS_CHAIN_SOURCE_CANONICALIZATION_MISSING", `${crossChainPath}.source.authenticatedSender.canonicalizationRule`, "A bridge-native sender identifier has no exact canonicalization and derivation rule.", "Define the bridge version, decoded fields, byte order, normalization and collision-free encoded form.");
+      }
+      gate("custom-cross-chain-source-identity-replay", "candidate", "The model uses a bridge-native source identity encoding that requires exact replay.");
+    } else if (resolvedText(sourceSender.canonicalizationRule)) {
+      add("blocker", "CROSS_CHAIN_SOURCE_CANONICALIZATION_CONFLICT", `${crossChainPath}.source.authenticatedSender.canonicalizationRule`, "A canonical sender encoding declares an unrelated custom normalization rule.", "Leave the custom rule null or select bridge-native and document the exact derivation.");
+    }
+
+    for (const field of ["chainId", "receiver", "receiverDependencyId", "authenticatedBridgeCaller"]) {
+      requirePresent(destination[field], `${crossChainPath}.destination.${field}`, "CROSS_CHAIN_DESTINATION_POLICY_INCOMPLETE", "Bind the exact destination chain, domain, receiver and authenticated bridge caller.", add);
+    }
+    requirePresent(destination.domain, `${crossChainPath}.destination.domain`, "CROSS_CHAIN_DESTINATION_POLICY_INCOMPLETE", "Bind the exact bridge destination domain identifier.", add);
+
+    const allDependencies = [
+      ...(submission.dependencies?.onchain ?? []),
+      ...(submission.dependencies?.offchain ?? [])
+    ];
+    const validatePinnedCrossChainDependency = ({
+      dependencyId,
+      dependencyPath,
+      expectedAddress,
+      expectedAddressPath,
+      unboundCode,
+      notOnchainCode,
+      unpinnedCode,
+      addressMismatchCode,
+      role
+    }) => {
+      if (!resolvedText(dependencyId)) return;
+      const matchingDependencies = allDependencies.filter((dependency) => dependency?.id === dependencyId);
+      const matchingOnchainDependencies = (submission.dependencies?.onchain ?? []).filter((dependency) => dependency?.id === dependencyId);
+      if (matchingDependencies.length !== 1) {
+        add("blocker", unboundCode, dependencyPath, `The ${role} dependency id must resolve to exactly one declared dependency.`, "Reference one unique dependency id and remove duplicate records.");
+        return;
+      }
+      if (matchingOnchainDependencies.length !== 1) {
+        add("blocker", notOnchainCode, dependencyPath, `The referenced ${role} record is not an onchain deployment.`, `Declare the exact ${role} contract in dependencies.onchain with pinned source and runtime evidence.`);
+        return;
+      }
+      const dependency = matchingOnchainDependencies[0];
+      const sourcePinned =
+        ["pinned-source", "verified-explorer-source"].includes(dependency.sourceProvenance) &&
+        resolvedText(dependency.repository) &&
+        resolvedText(dependency.revision);
+      const deploymentPinned =
+        resolvedText(dependency.chainAddress) &&
+        resolvedText(dependency.runtimeHash);
+      if (!sourcePinned || !deploymentPinned) {
+        add("blocker", unpinnedCode, dependencyPath, `The ${role} dependency lacks one immutable source commit and deployed runtime identity.`, "Pin the exact source commit, destination address and runtime hash.");
+      }
+      if (
+        resolvedText(dependency.chainAddress) &&
+        resolvedText(expectedAddress) &&
+        dependency.chainAddress.toLowerCase() !== expectedAddress.toLowerCase()
+      ) {
+        add("blocker", addressMismatchCode, expectedAddressPath, `The declared ${role} address differs from its pinned onchain dependency.`, `Use the exact ${role} address from the reviewed deployment record.`);
+      }
+    };
+
+    validatePinnedCrossChainDependency({
+      dependencyId: crossChain.bridgeDependencyId,
+      dependencyPath: `${crossChainPath}.bridgeDependencyId`,
+      expectedAddress: destination.authenticatedBridgeCaller,
+      expectedAddressPath: `${crossChainPath}.destination.authenticatedBridgeCaller`,
+      unboundCode: "CROSS_CHAIN_BRIDGE_DEPENDENCY_UNBOUND",
+      notOnchainCode: "CROSS_CHAIN_BRIDGE_DEPENDENCY_NOT_ONCHAIN",
+      unpinnedCode: "CROSS_CHAIN_BRIDGE_DEPENDENCY_UNPINNED",
+      addressMismatchCode: "CROSS_CHAIN_BRIDGE_CALLER_MISMATCH",
+      role: "authenticated bridge caller"
+    });
+    validatePinnedCrossChainDependency({
+      dependencyId: destination.receiverDependencyId,
+      dependencyPath: `${crossChainPath}.destination.receiverDependencyId`,
+      expectedAddress: destination.receiver,
+      expectedAddressPath: `${crossChainPath}.destination.receiver`,
+      unboundCode: "CROSS_CHAIN_RECEIVER_DEPENDENCY_UNBOUND",
+      notOnchainCode: "CROSS_CHAIN_RECEIVER_DEPENDENCY_NOT_ONCHAIN",
+      unpinnedCode: "CROSS_CHAIN_RECEIVER_DEPENDENCY_UNPINNED",
+      addressMismatchCode: "CROSS_CHAIN_RECEIVER_UNBOUND",
+      role: "destination receiver"
+    });
+
+    if (
+      sourceNetwork.namespace === "eip155" &&
+      resolvedText(sourceNetwork.reference) &&
+      Number.isInteger(destination.chainId) &&
+      sourceNetwork.reference === String(destination.chainId)
+    ) {
+      add("blocker", "CROSS_CHAIN_SOURCE_DESTINATION_CONFLICT", `${crossChainPath}.source.network`, "The source network and destination chain are identical.", "Bind the actual remote source network and the local Ethereum destination.");
+    }
+    if (
+      Number.isInteger(destination.chainId) &&
+      targetChainId !== null &&
+      String(destination.chainId) !== targetChainId
+    ) {
+      add("blocker", "CROSS_CHAIN_DESTINATION_CHAIN_MISMATCH", `${crossChainPath}.destination.chainId`, "The cross-chain destination differs from the launch target chain.", "Use the exact target chain id as the destination.");
+    }
+    for (const [field, value] of [
+      ["destination.receiver", destination.receiver],
+      ["destination.authenticatedBridgeCaller", destination.authenticatedBridgeCaller]
+    ]) {
+      if (/^0x0{40}$/i.test(value ?? "")) {
+        add("blocker", "CROSS_CHAIN_ZERO_ADDRESS", `${crossChainPath}.${field}`, "A cross-chain authentication address cannot be the zero address.", "Bind the exact nonzero source sender, receiver or bridge caller.");
+      }
+    }
+    if (
+      ["evm-address", "bytes32"].includes(sourceSender.encoding) &&
+      /^0x0+$/i.test(sourceSender.value ?? "")
+    ) {
+      add("blocker", "CROSS_CHAIN_ZERO_ADDRESS", `${crossChainPath}.source.authenticatedSender.value`, "The authenticated source sender cannot be an all-zero identifier.", "Bind the exact nonzero source sender supplied by the reviewed bridge.");
+    }
+
+    for (const field of ["identifierDerivation", "nonceDerivation", "payloadHashRule", "idempotencyKeyRule", "idempotencyStorage"]) {
+      requireDetailedText(message[field], `${crossChainPath}.message.${field}`, "CROSS_CHAIN_MESSAGE_POLICY_INCOMPLETE", add);
+    }
+    for (const field of ["nonceScope", "duplicateBehavior"]) {
+      requirePresent(message[field], `${crossChainPath}.message.${field}`, "CROSS_CHAIN_MESSAGE_POLICY_INCOMPLETE", "Define the exact nonce scope and duplicate-message behavior.", add);
+    }
+    if (message.nonceScope === "custom-reviewed") {
+      if (!resolvedText(message.customNonceRule) || message.customNonceRule.trim().length < 12) {
+        add("blocker", "CROSS_CHAIN_CUSTOM_NONCE_RULE_MISSING", `${crossChainPath}.message.customNonceRule`, "The custom nonce scope has no exact derivation and collision boundary.", "Define the canonical nonce inputs, encoding, scope, reset behavior and collision resistance.");
+      }
+      gate("custom-cross-chain-nonce-replay", "candidate", "The model uses a custom cross-chain nonce scope that requires exact replay.");
+    } else if (resolvedText(message.customNonceRule)) {
+      add("blocker", "CROSS_CHAIN_CUSTOM_NONCE_RULE_CONFLICT", `${crossChainPath}.message.customNonceRule`, "A standard nonce scope declares a custom nonce rule.", "Leave the custom rule null or select custom-reviewed and request the dedicated review.");
+    }
+    if (message.atomicConsumption !== true) {
+      add("blocker", "CROSS_CHAIN_REPLAY_NOT_ATOMIC", `${crossChainPath}.message.atomicConsumption`, "The message idempotency key is not checked and consumed atomically with the destination action.", "Check and consume the exact key before any value or external call can be committed.");
+    }
+    for (const field of [
+      "bridgeDependencyId",
+      "sourceNetwork",
+      "sourceDomain",
+      "sourceSender",
+      "destinationChainId",
+      "destinationDomain",
+      "receiver",
+      "receiverDependencyId",
+      "modelId",
+      "poolId",
+      "action",
+      "payloadHash",
+      "timestampOrExpiry",
+      "messageId",
+      "nonce"
+    ]) {
+      if (domainBindings[field] !== true) {
+        add("blocker", "CROSS_CHAIN_DOMAIN_BINDING_INCOMPLETE", `${crossChainPath}.message.domainBindings.${field}`, "The message is not bound to every identity, execution domain and payload component required for replay safety.", "Authenticate and hash this field into the accepted message or idempotency boundary.");
+      }
+    }
+
+    for (const field of ["mode", "minimumSourceConfirmations", "challengePeriodSeconds", "reorgBehavior"]) {
+      requirePresent(finality[field], `${crossChainPath}.finality.${field}`, "CROSS_CHAIN_FINALITY_POLICY_INCOMPLETE", "Define the source-finality threshold, challenge window and reorg behavior.", add);
+    }
+    requireDetailedText(finality.attestationRule, `${crossChainPath}.finality.attestationRule`, "CROSS_CHAIN_FINALITY_POLICY_INCOMPLETE", add);
+    if (finality.mode === "source-finalized" && (!Number.isInteger(finality.minimumSourceConfirmations) || finality.minimumSourceConfirmations < 1)) {
+      add("blocker", "CROSS_CHAIN_FINALITY_CONFIRMATIONS_INVALID", `${crossChainPath}.finality.minimumSourceConfirmations`, "A source-finalized route needs a positive confirmation threshold.", "Set the reviewed source-chain confirmation threshold and test a reorg below it.");
+    }
+    if (finality.mode === "optimistic-challenge-window" && (!Number.isInteger(finality.challengePeriodSeconds) || finality.challengePeriodSeconds < 1)) {
+      add("blocker", "CROSS_CHAIN_FINALITY_WINDOW_INVALID", `${crossChainPath}.finality.challengePeriodSeconds`, "An optimistic route needs a positive challenge period before execution.", "Set the reviewed challenge period and reject messages until it ends.");
+    }
+    if (finality.mode === "custom-reviewed") {
+      if (!resolvedText(finality.customFinalityRule) || finality.customFinalityRule.trim().length < 12) {
+        add("blocker", "CROSS_CHAIN_CUSTOM_FINALITY_RULE_MISSING", `${crossChainPath}.finality.customFinalityRule`, "The custom finality mode has no exact acceptance and reorg rule.", "Define the authenticated evidence, acceptance threshold, wait period, reorg boundary and failure behavior.");
+      }
+      gate("custom-cross-chain-finality-replay", "candidate", "The model uses a custom source-finality rule that requires exact replay.");
+    } else if (resolvedText(finality.customFinalityRule)) {
+      add("blocker", "CROSS_CHAIN_CUSTOM_FINALITY_RULE_CONFLICT", `${crossChainPath}.finality.customFinalityRule`, "A standard finality mode declares a custom finality rule.", "Leave the custom rule null or select custom-reviewed and request the dedicated review.");
+    }
+
+    for (const field of ["mode", "outOfOrderBehavior", "maximumPendingMessages"]) {
+      requirePresent(ordering[field], `${crossChainPath}.ordering.${field}`, "CROSS_CHAIN_ORDERING_POLICY_INCOMPLETE", "Define message ordering, the sequence key and bounded out-of-order behavior.", add);
+    }
+    requireDetailedText(ordering.sequenceKey, `${crossChainPath}.ordering.sequenceKey`, "CROSS_CHAIN_ORDERING_POLICY_INCOMPLETE", add);
+    if (ordering.mode === "unordered-idempotent" && ordering.outOfOrderBehavior === "queue-bounded") {
+      add("blocker", "CROSS_CHAIN_ORDERING_MODE_CONFLICT", `${crossChainPath}.ordering`, "An unordered idempotent route declares a queue for out-of-order delivery.", "Use ignore-after-authentication for unordered idempotent delivery or select a sequential mode with the bounded queue.");
+    }
+    if (ordering.outOfOrderBehavior === "queue-bounded") {
+      for (const field of ["queueOverflowBehavior", "pendingMessageExpirySeconds"]) {
+        requirePresent(ordering[field], `${crossChainPath}.ordering.${field}`, "CROSS_CHAIN_ORDERING_POLICY_INCOMPLETE", "Define bounded queue overflow and expiry behavior.", add);
+      }
+      for (const field of ["cleanupRule", "releaseRule"]) {
+        requireDetailedText(ordering[field], `${crossChainPath}.ordering.${field}`, "CROSS_CHAIN_ORDERING_POLICY_INCOMPLETE", add);
+      }
+      if (!Number.isInteger(ordering.maximumPendingMessages) || ordering.maximumPendingMessages < 1) {
+        add("blocker", "CROSS_CHAIN_ORDERING_BOUND_INVALID", `${crossChainPath}.ordering.maximumPendingMessages`, "An out-of-order queue needs a positive finite item bound.", "Set a finite queue bound and test overflow without partial execution.");
+      }
+      if (!Number.isInteger(ordering.pendingMessageExpirySeconds) || ordering.pendingMessageExpirySeconds < 1) {
+        add("blocker", "CROSS_CHAIN_ORDERING_EXPIRY_INVALID", `${crossChainPath}.ordering.pendingMessageExpirySeconds`, "Queued messages do not have a positive finite expiry.", "Set a finite positive expiry and test cleanup, overflow and late-release behavior.");
+      }
+      gate("cross-chain-bounded-queue-state-machine-tests", "prototype", "The model stores out-of-order cross-chain messages.");
+    } else if (ordering.maximumPendingMessages !== 0) {
+      add("blocker", "CROSS_CHAIN_ORDERING_BOUND_CONFLICT", `${crossChainPath}.ordering.maximumPendingMessages`, "A route without a queue declares pending message capacity.", "Set the value to zero or select the bounded queue behavior.");
+    } else if (
+      ordering.queueOverflowBehavior !== null ||
+      ordering.pendingMessageExpirySeconds !== 0 ||
+      resolvedText(ordering.cleanupRule) ||
+      resolvedText(ordering.releaseRule)
+    ) {
+      add("blocker", "CROSS_CHAIN_ORDERING_QUEUE_POLICY_CONFLICT", `${crossChainPath}.ordering`, "A route without an out-of-order queue declares queue lifecycle behavior.", "Clear the queue fields or select queue-bounded and complete its state machine.");
+    }
+
+    for (const field of ["timestampSource", "maximumMessageAgeSeconds", "maximumFutureSkewSeconds", "staleMessageBehavior"]) {
+      requirePresent(staleness[field], `${crossChainPath}.staleness.${field}`, "CROSS_CHAIN_STALENESS_POLICY_INCOMPLETE", "Define the authenticated timestamp, maximum age, clock skew and stale-message behavior.", add);
+    }
+    if (staleness.timestampSource === "custom-reviewed") {
+      if (!resolvedText(staleness.customTimestampRule) || staleness.customTimestampRule.trim().length < 12) {
+        add("blocker", "CROSS_CHAIN_CUSTOM_TIMESTAMP_RULE_MISSING", `${crossChainPath}.staleness.customTimestampRule`, "The custom timestamp source has no exact authenticated derivation and comparison rule.", "Define the timestamp origin, authentication, units, normalization, skew comparison and expiry calculation.");
+      }
+      gate("custom-cross-chain-timestamp-replay", "candidate", "The model uses a custom cross-chain timestamp source that requires exact replay.");
+    } else if (resolvedText(staleness.customTimestampRule)) {
+      add("blocker", "CROSS_CHAIN_CUSTOM_TIMESTAMP_RULE_CONFLICT", `${crossChainPath}.staleness.customTimestampRule`, "A standard timestamp source declares a custom derivation rule.", "Leave the custom rule null or select custom-reviewed and request the dedicated review.");
+    }
+    if (!Number.isInteger(staleness.maximumMessageAgeSeconds) || staleness.maximumMessageAgeSeconds < 1) {
+      add("blocker", "CROSS_CHAIN_STALENESS_BOUND_INVALID", `${crossChainPath}.staleness.maximumMessageAgeSeconds`, "The accepted message age is not positively bounded.", "Set a finite positive age and reject or quarantine older messages.");
+    }
+
+    requirePresent(crossChain.failureBehavior, `${crossChainPath}.failureBehavior`, "CROSS_CHAIN_FAILURE_POLICY_INCOMPLETE", "Choose atomic revert or quarantine without execution.", add);
+    requireDetailedText(crossChain.failureRule, `${crossChainPath}.failureRule`, "CROSS_CHAIN_FAILURE_POLICY_INCOMPLETE", add);
+    for (const field of ["mode", "authority"]) {
+      requirePresent(fallback[field], `${crossChainPath}.fallback.${field}`, "CROSS_CHAIN_FALLBACK_POLICY_INCOMPLETE", "Define a fail-closed fallback mode and its exact authority.", add);
+    }
+    requireDetailedText(fallback.rule, `${crossChainPath}.fallback.rule`, "CROSS_CHAIN_FALLBACK_POLICY_INCOMPLETE", add);
+    if (fallback.mode === "none-fail-closed" && fallback.authority !== "none") {
+      add("blocker", "CROSS_CHAIN_FALLBACK_AUTHORITY_CONFLICT", `${crossChainPath}.fallback.authority`, "A route with no fallback names an authority.", "Use authority none or select a fallback mode with one declared authority role.");
+    }
+    if (
+      ["pause-cross-chain-path", "manual-reconciliation-no-execution"].includes(fallback.mode) &&
+      resolvedText(fallback.authority) &&
+      !authorities.some((authority) => authority?.role === fallback.authority)
+    ) {
+      add("blocker", "CROSS_CHAIN_FALLBACK_AUTHORITY_UNBOUND", `${crossChainPath}.fallback.authority`, "The fallback authority does not resolve to one declared authority role.", "Reference an exact authorities[].role and disclose its controller, capabilities, mutability and exit impact.");
+    }
+
+    const quarantineExpected =
+      crossChain.failureBehavior === "quarantine-no-execution" ||
+      staleness.staleMessageBehavior === "quarantine-no-execution" ||
+      finality.reorgBehavior === "pause-and-reconcile-without-execution" ||
+      fallback.mode === "manual-reconciliation-no-execution";
+    if (typeof quarantine.used !== "boolean") {
+      add("blocker", "CROSS_CHAIN_QUARANTINE_USAGE_UNRESOLVED", `${crossChainPath}.quarantine.used`, "Quarantine usage is unresolved for a cross-chain prototype.", `Set used to ${quarantineExpected} and complete or clear the bounded quarantine state machine.`);
+    }
+    requireCapabilityMatch(quarantine.used, quarantineExpected, "crossChain.quarantine", "CROSS_CHAIN_QUARANTINE_PROFILE_MISMATCH", add);
+    if (quarantine.used === true) {
+      for (const field of ["maximumEntries", "entryExpirySeconds", "overflowBehavior", "releaseMode", "releaseAuthority"]) {
+        requirePresent(quarantine[field], `${crossChainPath}.quarantine.${field}`, "CROSS_CHAIN_QUARANTINE_POLICY_INCOMPLETE", "Define bounded storage, expiry, overflow, cleanup and release behavior.", add);
+      }
+      for (const field of ["storageRule", "cleanupRule", "releaseRule"]) {
+        requireDetailedText(quarantine[field], `${crossChainPath}.quarantine.${field}`, "CROSS_CHAIN_QUARANTINE_POLICY_INCOMPLETE", add);
+      }
+      if (!Number.isInteger(quarantine.maximumEntries) || quarantine.maximumEntries < 1) {
+        add("blocker", "CROSS_CHAIN_QUARANTINE_BOUND_INVALID", `${crossChainPath}.quarantine.maximumEntries`, "The quarantine store has no positive finite entry bound.", "Set a finite item bound and test overflow without execution or eviction of live entries.");
+      }
+      if (!Number.isInteger(quarantine.entryExpirySeconds) || quarantine.entryExpirySeconds < 1) {
+        add("blocker", "CROSS_CHAIN_QUARANTINE_EXPIRY_INVALID", `${crossChainPath}.quarantine.entryExpirySeconds`, "Quarantined entries do not have a positive finite expiry.", "Set a finite expiry and define deterministic permissionless cleanup.");
+      }
+      if (quarantine.atomicRelease !== true) {
+        add("blocker", "CROSS_CHAIN_QUARANTINE_RELEASE_NOT_ATOMIC", `${crossChainPath}.quarantine.atomicRelease`, "A quarantined entry can be released without atomically consuming its stored state.", "Consume or finalize the exact entry in the same transaction before retry, discard or reconciliation.");
+      }
+      const specialReleaseAuthorities = new Set([
+        "permissionless-after-revalidation",
+        "permissionless-expiry-cleanup"
+      ]);
+      const permissionlessAuthorityByMode = {
+        "revalidate-and-retry": "permissionless-after-revalidation",
+        "discard-only": "permissionless-expiry-cleanup"
+      };
+      if (
+        specialReleaseAuthorities.has(quarantine.releaseAuthority) &&
+        permissionlessAuthorityByMode[quarantine.releaseMode] !== quarantine.releaseAuthority
+      ) {
+        add("blocker", "CROSS_CHAIN_QUARANTINE_RELEASE_AUTHORITY_CONFLICT", `${crossChainPath}.quarantine.releaseAuthority`, "The permissionless quarantine authority does not match the declared release mode.", "Use permissionless-after-revalidation only for retry, permissionless-expiry-cleanup only for discard, or a declared authority role.");
+      }
+      if (
+        resolvedText(quarantine.releaseAuthority) &&
+        !specialReleaseAuthorities.has(quarantine.releaseAuthority) &&
+        !authorities.some((authority) => authority?.role === quarantine.releaseAuthority)
+      ) {
+        add("blocker", "CROSS_CHAIN_QUARANTINE_RELEASE_AUTHORITY_UNBOUND", `${crossChainPath}.quarantine.releaseAuthority`, "The quarantine release authority is neither a bounded permissionless path nor a declared authority role.", "Use a reviewed permissionless release mode or reference an exact authorities[].role.");
+      }
+      if (
+        quarantine.releaseMode === "manual-reconciliation-no-execution" &&
+        !authorities.some((authority) => authority?.role === quarantine.releaseAuthority)
+      ) {
+        add("blocker", "CROSS_CHAIN_QUARANTINE_MANUAL_AUTHORITY_UNBOUND", `${crossChainPath}.quarantine.releaseAuthority`, "Manual reconciliation does not resolve to one declared authority role.", "Reference an exact authorities[].role and keep the path unable to execute or redirect the message payload.");
+      }
+      gate("cross-chain-quarantine-state-machine-tests", "prototype", "The model stores cross-chain messages that cannot execute immediately.");
+    }
+
+    gate("cross-chain-replay-finality-and-failure-tests", "prototype", "The model consumes cross-domain state or messages.");
+    gate("bridge-cross-domain-replay", "candidate", "The model consumes cross-domain state or messages that require authenticated replay and finality evidence.");
+  }
+
+  const externalLiquidity = objectAt(capabilityProfiles, "externalLiquidity");
+  const externalLiquidityExpected = (submission.risk?.dimensions?.externalLiquidity ?? 0) > 0 || assets.some((asset) => ["vault-share", "external-wrapper"].includes(asset?.origin)) || /\b(?:vault|external liquidity|hook-held liquidity|inventory|collateral)\b/i.test(`${model.summary ?? ""} ${customAccounting.backingSource ?? ""}`);
+  requireCapabilityMatch(externalLiquidity.used, externalLiquidityExpected, "externalLiquidity", "EXTERNAL_LIQUIDITY_PROFILE_MISMATCH", add);
+  if (externalLiquidity.used === true) {
+    for (const field of ["custody", "ownership", "shareAccounting", "solvencyEquation", "lossAllocation", "donationPolicy", "exitPath", "dependencyFailure"]) requireDetailedText(externalLiquidity[field], `$.capabilities.externalLiquidity.${field}`, "EXTERNAL_LIQUIDITY_POLICY_INCOMPLETE", add);
+    gate("external-liquidity-solvency-and-exit-invariants", "prototype", "The model holds or depends on liquidity outside the canonical pool accounting.");
+    gate("custody-solvency-replay", "candidate", "The model holds or depends on external liquidity that requires machine-replayed custody and solvency evidence.");
+  }
+
+  const asyncSwap = objectAt(capabilityProfiles, "asyncSwap");
+  const asyncExpected = /\b(?:async|asynchronous|queued swap|deferred fill|order queue)\b/i.test(`${model.summary ?? ""} ${model.whyV4 ?? ""}`);
+  requireCapabilityMatch(asyncSwap.used, asyncExpected, "asyncSwap", "ASYNC_SWAP_PROFILE_MISMATCH", add);
+  if (asyncSwap.used === true) {
+    for (const field of ["supportedExactness", "custody", "fillRule", "partialFillRule", "cancellation", "expiry", "refund", "queueBound", "liveness", "failureRule"]) requirePresent(asyncSwap[field], `$.capabilities.asyncSwap.${field}`, "ASYNC_SWAP_POLICY_INCOMPLETE", "Define custody, fills, cancellation, bounded queues, expiry, refunds and failure behavior.", add);
+    gate("async-custody-fill-and-liveness-invariants", "prototype", "The model defers swap execution or settlement.");
+    gate("async-accounting-liveness-replay", "candidate", "The model defers swap execution or settlement and requires machine-replayed accounting and liveness evidence.");
+  }
+
+  const customCurve = objectAt(capabilityProfiles, "customCurve");
+  const customCurveExpected = /\b(?:custom curve|constant sum|bonding curve|weighted curve|custom pricing)\b/i.test(`${model.summary ?? ""} ${model.whyV4 ?? ""}`);
+  requireCapabilityMatch(customCurve.used, customCurveExpected, "customCurve", "CUSTOM_CURVE_PROFILE_MISMATCH", add);
+  if (customCurve.used === true) {
+    for (const field of ["invariant", "domain", "rounding", "monotonicity", "discontinuities", "inverse", "differentialReference", "failureRule"]) requireDetailedText(customCurve[field], `$.capabilities.customCurve.${field}`, "CUSTOM_CURVE_POLICY_INCOMPLETE", add);
+    gate("custom-curve-differential-and-invariant-tests", "prototype", "The model changes pricing math.");
+    gate("mathematical-invariant-replay", "candidate", "The model changes pricing math and requires deterministic invariant and differential replay.");
+  }
+
+  const security = objectAt(submission, "security");
+  const hardSecurity = {
+    usesTxOrigin: ["TX_ORIGIN_AUTHORIZATION", "tx.origin authorization is forbidden."],
+    userControlledDelegatecall: ["USER_CONTROLLED_DELEGATECALL", "User-controlled delegatecall is forbidden."],
+    arbitraryExecution: ["ARBITRARY_PROTOCOL_EXECUTION", "Arbitrary target and calldata execution with protocol authority is forbidden."],
+    unboundedCriticalLoop: ["UNBOUNDED_CRITICAL_LOOP", "Unbounded storage-dependent work on a callback or exit path is forbidden."],
+    ignoredCallResults: ["IGNORED_CALL_RESULT", "Ignored low-level or token-transfer results are forbidden."],
+    hiddenControls: ["HIDDEN_CONTROLS", "Undisclosed control or payout behavior is forbidden."],
+    assumesOnchainSecrecy: ["ONCHAIN_SECRECY_ASSUMPTION", "Onchain data cannot be treated as secret."],
+    bypassesHookAddressValidation: ["HOOK_ADDRESS_VALIDATION_BYPASS", "Production hooks may not bypass BaseHook address and permission validation."]
+  };
+  for (const [field, [code, message]] of Object.entries(hardSecurity)) {
+    if (security[field] === true) add("hard", code, `$.security.${field}`, message, "Remove the behavior or redesign the model with an explicit, reviewable mechanism.");
+    else if (security[field] !== false) add("blocker", "SECURITY_ASSERTION_UNRESOLVED", `$.security.${field}`, "This security assertion must be explicitly true or false.", "Inspect the design and source before answering.");
+  }
+  const signature = objectAt(security, "signatureScheme");
+  if (typeof signature.used !== "boolean") add("blocker", "SIGNATURE_USAGE_UNRESOLVED", "$.security.signatureScheme.used", "Signature usage is unresolved.", "State whether offchain signatures authorize any action.");
+  if (signature.used === true) {
+    if (!signature.standard) add("blocker", "SIGNATURE_STANDARD_UNRESOLVED", "$.security.signatureScheme.standard", "The signature standard is unresolved.", "Use a reviewed EIP-712 domain or document an equivalent reviewed scheme.");
+    for (const field of ["nonce", "deadline", "chain", "verifyingContract", "action", "parameters"]) {
+      if (signature[field] !== true) add("blocker", "SIGNATURE_BINDING_INCOMPLETE", `$.security.signatureScheme.${field}`, "The signature does not explicitly bind this security property.", "Bind nonce, deadline, chain, verifying contract, action and parameters.");
+    }
+    if (signature.erc1271 === false) {
+      add(
+        "warning",
+        "EOA_SIGNER_KEY_OPERATIONS_REVIEW_REQUIRED",
+        "$.security.signatureScheme.erc1271",
+        "The declared signature model intentionally accepts only a fixed EOA signer and does not support ERC-1271 contract-wallet validation.",
+        "Review signer provenance, custody, environment isolation, rotation and revocation, key-loss recovery, low-s enforcement and incident response before candidate approval."
+      );
+      gate(
+        "eoa-signer-key-operations-evidence",
+        "candidate",
+        "The declared signature model uses a fixed EOA signer, so key provenance, custody, rotation, revocation, recovery and incident response require review."
+      );
+    } else if (signature.erc1271 !== true) {
+      add(
+        "blocker",
+        "SIGNATURE_BINDING_INCOMPLETE",
+        "$.security.signatureScheme.erc1271",
+        "The signature model does not explicitly choose fixed-EOA or ERC-1271 contract-wallet behavior.",
+        "Set erc1271 to false only for an intentionally fixed EOA signer, or true when ERC-1271 contract-wallet validation is supported."
+      );
+    }
+    gate("signature-replay-and-wallet-tests", "prototype", "The model uses signatures.");
+  }
+
+  const implementation = objectAt(submission, "implementation");
+  for (const [field, entries] of Object.entries({
+    sourcePaths: implementation.sourcePaths ?? [],
+    testPaths: implementation.testPaths ?? [],
+    compilerBuildInfoPaths: implementation.compilerBuildInfoPaths ?? [],
+    specificationPath: implementation.specificationPath ? [implementation.specificationPath] : [],
+    testEvidencePath: implementation.testEvidencePath ? [implementation.testEvidencePath] : [],
+    dependencyLockPath: implementation.dependencyLockPath ? [implementation.dependencyLockPath] : [],
+    gateStatusPath: implementation.gateStatusPath ? [implementation.gateStatusPath] : [],
+    reviewTargetPath: implementation.reviewTargetPath ? [implementation.reviewTargetPath] : []
+  })) {
+    for (const [index, entry] of entries.entries()) {
+      if (!isSafeRepositoryPath(entry)) {
+        add("blocker", "IMPLEMENTATION_PATH_UNSAFE", `$.implementation.${field}${field.endsWith("Paths") ? `[${index}]` : ""}`, "Implementation paths must be repository-relative and cannot traverse parent directories.", "Use a normalized path inside the repository.");
+      }
+    }
+  }
+  if (stage === "prototype") {
+    if (!Array.isArray(implementation.sourcePaths) || implementation.sourcePaths.length === 0) add("blocker", "SOURCE_PATHS_MISSING", "$.implementation.sourcePaths", "A prototype must identify its source files.", "List repository-relative contract and integration source paths.");
+    if (!Array.isArray(implementation.testPaths) || implementation.testPaths.length === 0) add("blocker", "TEST_PATHS_MISSING", "$.implementation.testPaths", "A prototype must identify its tests.", "List repository-relative unit, fuzz, invariant and integration tests.");
+    if (solidityBuildRequired && (!Array.isArray(implementation.compilerBuildInfoPaths) || implementation.compilerBuildInfoPaths.length !== 1)) add("blocker", "COMPILER_BUILD_INFO_PATHS_MISSING", "$.implementation.compilerBuildInfoPaths", "A prototype with declared Solidity source must bind exactly one compiler build-info artifact.", "List the one repository-relative Foundry build-info JSON file whose compiler input and settings produced the reviewed bytecode.");
+    if (!solidityBuildRequired && (implementation.compilerBuildInfoPaths?.length ?? 0) !== 0) add("blocker", "COMPILER_BUILD_INFO_WITHOUT_SOLIDITY", "$.implementation.compilerBuildInfoPaths", "Compiler build-info is declared even though the project declares no Solidity source.", "Use an empty compilerBuildInfoPaths array for the official no-custom-hook route, or declare and bind the actual Solidity source.");
+    if (customHookDeclared && declaredImplementationSoliditySourcePaths.length === 0) add("blocker", "SOLIDITY_SOURCE_MISSING", "$.implementation.sourcePaths", "A custom-hook prototype has no declared Solidity implementation source.", "List every .sol hook implementation file so the package verifier can bind and scan the complete import closure.");
+    for (const [index, entry] of (implementation.sourcePaths ?? []).entries()) validateDeclaredPath(entry, `$.implementation.sourcePaths[${index}]`, "implementation source");
+    for (const [index, entry] of (implementation.testPaths ?? []).entries()) validateDeclaredPath(entry, `$.implementation.testPaths[${index}]`, "implementation test");
+    for (const [index, entry] of (implementation.compilerBuildInfoPaths ?? []).entries()) {
+      validateDeclaredPath(entry, `$.implementation.compilerBuildInfoPaths[${index}]`, "compiler build-info");
+      if (!/\.json$/i.test(entry)) add("blocker", "COMPILER_BUILD_INFO_PATH_TYPE_INVALID", `$.implementation.compilerBuildInfoPaths[${index}]`, "A declared Solidity compiler build-info artifact must be JSON.", "Use the exact repository-relative Foundry build-info JSON path.");
+    }
+    requireResolvedText(implementation.specificationPath, "$.implementation.specificationPath", "SPECIFICATION_PATH_MISSING", add);
+    requireResolvedText(implementation.testEvidencePath, "$.implementation.testEvidencePath", "TEST_EVIDENCE_PATH_MISSING", add);
+    if (solidityBuildRequired) requireResolvedText(implementation.dependencyLockPath, "$.implementation.dependencyLockPath", "DEPENDENCY_LOCK_PATH_MISSING", add);
+    requireResolvedText(implementation.gateStatusPath, "$.implementation.gateStatusPath", "GATE_STATUS_PATH_MISSING", add);
+    requireResolvedText(implementation.reviewTargetPath, "$.implementation.reviewTargetPath", "REVIEW_TARGET_PATH_MISSING", add);
+    if ((submission.dependencies?.onchain?.length ?? 0) === 0) add("blocker", "PROTOCOL_DEPENDENCIES_MISSING", "$.dependencies.onchain", "A prototype must record its exact Uniswap and contract-library dependency closure.", "List the exact source and deployed dependencies and bind them through the dependency lock.");
+
+    const boundSourcePaths = new Set(implementation.sourcePaths ?? []);
+    const boundTestPaths = new Set(implementation.testPaths ?? []);
+    for (const [index, entry] of customExecutionModulePaths.entries()) {
+      validateDeclaredPath(entry, `$.hook.customExecution.moduleSourcePaths[${index}]`, "custom execution module source");
+      if (!boundSourcePaths.has(entry)) add("blocker", "CUSTOM_EXECUTION_MODULE_SOURCE_NOT_BOUND", `$.hook.customExecution.moduleSourcePaths[${index}]`, "A custom execution module source is outside implementation.sourcePaths.", `Add ${entry} to implementation.sourcePaths so its exact bytes, imports and compiler output enter the review target.`);
+    }
+    for (const [index, entry] of customExecutionEffectPaths.entries()) {
+      validateDeclaredPath(entry, `$.hook.customExecution.effectProofPaths[${index}]`, "custom execution effect proof");
+    }
+    for (const [field, entries, boundPaths, code, label] of [
+      ["routingAndDiscoverability.sourcePaths", routing.sourcePaths ?? [], boundSourcePaths, "ROUTING_SOURCE_NOT_BOUND", "routing source"],
+      ["routingAndDiscoverability.testPaths", routing.testPaths ?? [], boundTestPaths, "ROUTING_TEST_NOT_BOUND", "routing test"],
+      ["dataReconstruction.sourcePaths", dataReconstruction.sourcePaths ?? [], boundSourcePaths, "DATA_SOURCE_NOT_BOUND", "indexer source"],
+      ["dataReconstruction.testPaths", dataReconstruction.testPaths ?? [], boundTestPaths, "DATA_TEST_NOT_BOUND", "indexer recovery test"]
+    ]) {
+      for (const [index, entry] of entries.entries()) {
+        if (!boundPaths.has(entry)) add("blocker", code, `$.integration.${field}[${index}]`, `The ${label} path is not part of the prototype implementation manifest.`, `Add ${entry} to the matching implementation source or test paths so package verification binds the exact file.`);
+      }
+    }
+    for (const [index, extension] of capabilityExtensions.entries()) {
+      for (const [field, boundPaths, code, label] of [
+        ["sourcePaths", boundSourcePaths, "CAPABILITY_EXTENSION_SOURCE_NOT_BOUND", "capability extension source"],
+        ["testPaths", boundTestPaths, "CAPABILITY_EXTENSION_TEST_NOT_BOUND", "capability extension test"]
+      ]) {
+        for (const [pathIndex, entry] of (extension?.[field] ?? []).entries()) {
+          if (!boundPaths.has(entry)) add("blocker", code, `$.capabilityExtensions[${index}].${field}[${pathIndex}]`, `The ${label} path is not part of the implementation manifest.`, `Add ${entry} to implementation.${field} so the exact bytes enter the review target.`);
+        }
+      }
+    }
+  }
+
+  const builder = objectAt(submission, "builder");
+  if (stage === "prototype") {
+    for (const field of ["github", "contact", "licenseDeclaration"]) requireResolvedText(builder[field], `$.builder.${field}`, "PROTOTYPE_IDENTITY_INCOMPLETE", add);
+  } else {
+    for (const field of ["github", "contact", "licenseDeclaration"]) {
+      if (!resolvedText(builder[field])) add("warning", "BUILDER_FIELD_PENDING", `$.builder.${field}`, "This builder field may remain open during proposal work but is required before authenticated admission.", "Complete it in a prototype before requesting independent admission.");
+    }
+  }
+
+  const unresolved = Array.isArray(submission.unresolved) ? submission.unresolved : [];
+  for (const [index, item] of unresolved.entries()) {
+    add("blocker", "UNRESOLVED_DECISION", `$.unresolved[${index}]`, item, "Resolve the decision, update the locked design and rerun preflight.");
+  }
+
+  const derivedTriggers = deriveFeatureTriggers(submission);
+  const risk = analyzeRisk(submission.risk, derivedTriggers, add);
+  if (packagesMissingSourceProvenance.length > 0) {
+    gate(
+      "package-source-provenance-analysis",
+      "candidate",
+      `Exact registry artifacts without declared source provenance require attributable dependency review: ${packagesMissingSourceProvenance.join(", ")}.`
+    );
+    if (risk.effectiveTier === "high") {
+      gate(
+        "package-source-provenance-architecture-evidence",
+        "candidate",
+        "High-risk projects must resolve the trust boundary and review method for package dependencies whose source provenance is unavailable."
+      );
+    }
+  }
+  if (risk.effectiveTier) gate("autonomous-security-evidence-replay", "candidate", "Every model needs autonomous security evidence and replay scaled to its capability and value risk before selection.");
+  if (risk.effectiveTier === "high") {
+    gate("high-risk-finalized-security-replay", "release", "High-risk models need a fresh finalized-state security replay before a production release decision.");
+    gate("production-anomaly-monitoring", "release", "High-risk models need live accounting, callback and authority anomaly monitoring.");
+  }
+  if (submission.risk?.dimensions?.valueAtRisk === 5) gate("tvl5-economic-solvency-replay", "candidate", "The maximum value-at-risk score needs dedicated economic and solvency replay regardless of aggregate tier.");
+
+  for (const trigger of derivedTriggers) {
+    if (trigger === "permissioned-asset") {
+      gate("permissioned-asset-trust-and-legal-disclosure", "candidate", "The model uses permissioned assets or issuer controls and must disclose exact external trust and legal documents without implying a legal opinion.");
+    }
+    if (["custom-math", "custom-accounting", "return-delta", "hook-held-liquidity", "price-impact"].includes(trigger)) {
+      gate("high-obligation-economic-security-replay", "candidate", `Feature trigger: ${trigger}.`);
+    }
+    if (trigger === "upgradeable") gate("upgrade-storage-authority-replay", "candidate", "The model is upgradeable and requires storage-layout and authority replay.");
+    if (trigger === "autonomous") gate("autonomous-state-transition-invariants", "prototype", "The model changes behavior autonomously.");
+  }
+
+  gate("format-build-size-warnings", "prototype", "Every prototype must pass its declared language build and size checks without unexplained warnings.");
+  if (solidityBuildRequired) gate("unit-integration-fuzz-invariant-tests", "prototype", "Declared Solidity behavior needs lifecycle and property evidence.");
+  if (hookUsed === true) {
+    gate("callback-authentication-and-permission-mask", "prototype", "Every hook must authenticate PoolManager and match its mined address permissions.");
+    gate("callback-selector-return-length-and-self-call-tests", "prototype", "Every enabled callback must return the exact selector and ABI length and account for noSelfCall suppression.");
+  }
+  if (permissions.afterAddLiquidity === true || permissions.afterRemoveLiquidity === true) gate("fees-accrued-jit-liquidity-manipulation-tests", "prototype", "Liquidity callbacks expose feesAccrued and may be sensitive to just-in-time liquidity ordering.");
+  if (permissions.beforeRemoveLiquidity === true || permissions.afterRemoveLiquidity === true) gate("liquidity-exit-liveness-invariants", "prototype", "Remove-liquidity callbacks can block LP exits and need failure, malformed-data, depleted-custody and gas-bound liveness tests.");
+  if (solidityBuildRequired) gate("static-analysis", "prototype", "Declared Solidity source needs static findings with dispositions.");
+  gate("pinned-fork-and-current-head-smoke", "candidate", "Every candidate must prove compatibility with exact deployments and current chain state.");
+  gate("autonomous-admission-analysis", "candidate", "The autonomous admission service must replay the authenticated source, rights, compiler, policy and bounded semantic evidence before approving the exact revision.");
+  gate("runtime-source-config-verification", "release", "Deployment claims require runtime, source and configuration evidence.");
+  gate("monitoring-and-lifecycle-evidence", "release", "Availability requires operational evidence after deployment.");
+  gate("external-routing-provider-policy", "external", "Routing or listing is controlled by each external provider and is not part of technical admission.");
+
+  return buildReport(submission, findings, gates, mask, derivedTriggers, risk.score, risk, schema);
+}
+
+function validateNoCustomHookRoute({ hook, poolAdmission, permissions, computedMask, lpFee, target, poolActive, add }) {
+  if (poolActive && !resolvedText(target.officialLaunchProfileId)) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_OFFICIAL_LAUNCH_PROFILE_MISSING",
+      "$.target.officialLaunchProfileId",
+      "The ordinary no-custom-hook route is not bound to an exact committed official launch profile.",
+      "Set officialLaunchProfileId to the current committed profile for target.chainId; never supply deployment addresses in the submission."
+    );
+  }
+  if (poolActive && lpFee.mode === "dynamic") {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_DYNAMIC_FEE_CONFLICT",
+      "$.pool.lpFee.mode",
+      "A dynamic v4 LP fee requires hook behavior, but this launch declares no custom hook.",
+      "Use a static LP fee for the no-custom-hook route or set hook.used to true and fully define the dynamic-fee hook."
+    );
+  }
+
+  if ([hook.base, hook.upgradeable, hook.sharedAcrossPools, hook.poolNamespace].some((value) => value !== null)) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_IDENTITY_CONFLICT",
+      "$.hook",
+      "The no-custom-hook route retains a hook implementation, upgrade or pool-sharing identity.",
+      "Set base, upgradeable, sharedAcrossPools and poolNamespace to null when hook.used is false."
+    );
+  }
+  if (["enforcement", "factoryOrRegistry", "alternativePoolBehavior", "rejectionRule"].some((field) => poolAdmission[field] !== null)) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_ADMISSION_CONFLICT",
+      "$.hook.poolAdmission",
+      "The no-custom-hook route retains custom hook pool-admission behavior.",
+      "Set every poolAdmission field to null when hook.used is false."
+    );
+  }
+
+  if (computedMask !== "0x0000" || Object.values(permissions).some((enabled) => enabled !== false)) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_PERMISSION_CONFLICT",
+      "$.hook.permissions",
+      "The no-custom-hook route must explicitly disable all 14 hook permissions.",
+      "Set every permission to false; an ordinary PoolKey has no callback permission mask."
+    );
+  }
+  if (!Array.isArray(hook.callbackPolicies) || hook.callbackPolicies.length !== 0) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_CALLBACK_CONFLICT",
+      "$.hook.callbackPolicies",
+      "The no-custom-hook route retains custom callback policy records.",
+      "Use an empty callbackPolicies array when hook.used is false."
+    );
+  }
+
+  if (hook.hookData?.used !== false || hasConfiguredValue(hook.hookData, new Set(["used"]))) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_DATA_CONFLICT",
+      "$.hook.hookData",
+      "The no-custom-hook route cannot encode or authenticate custom hookData.",
+      "Set hookData.used to false and every other hookData field to null."
+    );
+  }
+  if (
+    hook.feeMechanism?.used !== false ||
+    hook.feeMechanism?.classification !== "none" ||
+    hasConfiguredValue(hook.feeMechanism, new Set(["used", "classification"]))
+  ) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_FEE_CONFLICT",
+      "$.hook.feeMechanism",
+      "The no-custom-hook route cannot retain a hook-owned fee or collection path.",
+      "Disable the hook fee, classify it as none and clear every collection, recipient and liability field."
+    );
+  }
+  if (hook.customAccounting?.used !== false || hasConfiguredValue(hook.customAccounting, new Set(["used"]))) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_ACCOUNTING_CONFLICT",
+      "$.hook.customAccounting",
+      "The no-custom-hook route cannot retain custom PoolManager accounting.",
+      "Set customAccounting.used to false and clear every backing, settlement and liability field."
+    );
+  }
+  if (hook.returnDeltaAccounting?.used !== false || hasConfiguredValue(hook.returnDeltaAccounting, new Set(["used"]))) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_RETURN_DELTA_CONFLICT",
+      "$.hook.returnDeltaAccounting",
+      "The no-custom-hook route cannot retain beforeSwap return-delta behavior.",
+      "Set returnDeltaAccounting.used to false and clear every quadrant and event field."
+    );
+  }
+
+  const postPolicies = hook.postReturnDeltaAccounting;
+  if (
+    !isObject(postPolicies) ||
+    Object.values(postPolicies).some((profile) => profile?.used !== false || hasConfiguredValue(profile, new Set(["used"])))
+  ) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_POST_RETURN_DELTA_CONFLICT",
+      "$.hook.postReturnDeltaAccounting",
+      "The no-custom-hook route cannot retain post-action return-delta behavior.",
+      "Set every post-return policy to used false and clear all accounting fields."
+    );
+  }
+  if (hook.erc6909Claims?.used !== false || hasConfiguredValue(hook.erc6909Claims, new Set(["used"]))) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_CLAIMS_CONFLICT",
+      "$.hook.erc6909Claims",
+      "The no-custom-hook route cannot retain hook-owned PoolManager claim behavior.",
+      "Set erc6909Claims.used to false and clear every claim and liability field."
+    );
+  }
+
+  const nestedActions = hook.nestedActions;
+  if (
+    nestedActions?.used !== false ||
+    nestedActions?.directPoolManagerCalls !== false ||
+    nestedActions?.routerCalls !== false ||
+    (nestedActions?.allowedActions?.length ?? 0) !== 0 ||
+    hasConfiguredValue(nestedActions, new Set(["used", "directPoolManagerCalls", "routerCalls", "allowedActions"]))
+  ) {
+    add(
+      "blocker",
+      "NO_CUSTOM_HOOK_NESTED_ACTION_CONFLICT",
+      "$.hook.nestedActions",
+      "The no-custom-hook route cannot retain nested actions initiated by a hook callback.",
+      "Disable both nested call paths, use an empty allowedActions array and clear every nested-action policy."
+    );
+  }
+}
+
+function hasConfiguredValue(value, ignoredKeys = new Set()) {
+  if (value === null || value === false || value === undefined) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (!isObject(value)) return true;
+  return Object.entries(value).some(([key, child]) => !ignoredKeys.has(key) && hasConfiguredValue(child));
+}
+
+function analyzeRisk(riskInput, derivedTriggers, add) {
+  const risk = isObject(riskInput) ? riskInput : {};
+  const dimensions = isObject(risk.dimensions) ? risk.dimensions : {};
+  let complete = true;
+  let score = 0;
+  const rationales = isObject(risk.rationales) ? risk.rationales : {};
+  for (const [name, maximum] of Object.entries(RISK_DIMENSION_MAX)) {
+    const value = dimensions[name];
+    if (!Number.isInteger(value) || value < 0 || value > maximum) {
+      complete = false;
+      add("blocker", "RISK_DIMENSION_UNRESOLVED", `$.risk.dimensions.${name}`, `Risk dimension ${name} must be an integer from 0 to ${maximum}.`, "Score the design conservatively using the pinned Uniswap Foundation rubric.");
+    } else {
+      score += value;
+    }
+    requireDetailedText(rationales[name], `$.risk.rationales.${name}`, "RISK_RATIONALE_MISSING", add);
+  }
+  const triggerSet = new Set(derivedTriggers);
+  const floors = {
+    complexity: derivedTriggers.some((trigger) => ["custom-math", "custom-accounting", "return-delta", "oracle", "autonomous", "proof", "cross-chain", "external-liquidity", "async-swap", "custom-curve"].includes(trigger)) ? 2 : 1,
+    customMath: triggerSet.has("custom-math") || triggerSet.has("custom-curve") ? 1 : 0,
+    externalDependencies: derivedTriggers.some((trigger) => ["external-calls", "oracle", "proof", "cross-chain"].includes(trigger)) ? 1 : 0,
+    externalLiquidity: triggerSet.has("external-liquidity") || triggerSet.has("hook-held-liquidity") ? 1 : 0,
+    upgradeability: triggerSet.has("upgradeable") ? 1 : 0,
+    autonomy: triggerSet.has("autonomous") ? 1 : 0,
+    priceImpact: triggerSet.has("price-impact") || triggerSet.has("return-delta") || triggerSet.has("custom-curve") ? 1 : 0
+  };
+  for (const [name, floor] of Object.entries(floors)) if (Number.isInteger(dimensions[name]) && dimensions[name] < floor) add("blocker", "RISK_DIMENSION_BELOW_FEATURE_FLOOR", `$.risk.dimensions.${name}`, `Risk dimension ${name} is below the minimum implied by the declared capabilities.`, `Use at least ${floor} and explain the specific exposure in risk.rationales.${name}.`);
+  const baseTier = complete ? tierForScore(score) : null;
+  const critical = new Set(["custom-math", "custom-accounting", "return-delta", "hook-held-liquidity", "oracle", "autonomous", "price-impact", "upgradeable", "permissioned-asset", "proof", "cross-chain", "external-liquidity", "async-swap", "custom-curve"]);
+  const effectiveTier = complete && derivedTriggers.some((trigger) => critical.has(trigger)) ? "high" : baseTier;
+  if (complete && risk.declaredTotal !== score) add("blocker", "RISK_TOTAL_MISMATCH", "$.risk.declaredTotal", `Declared total ${risk.declaredTotal} does not match derived total ${score}.`, "Update the total from the nine dimension values.");
+  if (complete && risk.declaredTier !== effectiveTier) add("blocker", "RISK_TIER_MISMATCH", "$.risk.declaredTier", `Declared tier ${risk.declaredTier} does not match effective tier ${effectiveTier}.`, "Use the numeric tier and raise it when a critical feature trigger applies.");
+  const declaredTriggers = new Set(Array.isArray(risk.featureTriggers) ? risk.featureTriggers : []);
+  for (const trigger of derivedTriggers) {
+    if (!declaredTriggers.has(trigger)) add("blocker", "RISK_TRIGGER_MISSING", "$.risk.featureTriggers", `Derived feature trigger ${trigger} is not declared.`, "Add the trigger and its capability-specific security work.");
+  }
+  return { score: complete ? score : null, baseTier, effectiveTier };
+}
+
+function deriveFeatureTriggers(submission) {
+  const triggers = new Set();
+  const dimensions = submission.risk?.dimensions ?? {};
+  const permissions = submission.hook?.permissions ?? {};
+  const behaviors = (submission.assets ?? []).flatMap((asset) => asset.behaviors ?? []);
+  const capabilities = (submission.authorities ?? []).flatMap((authority) => authority.capabilities ?? []).join(" ").toLowerCase();
+  if ((dimensions.customMath ?? 0) > 0 || /curve|twamm|logarith|exponent|weighted|piecewise/.test(submission.model?.summary?.toLowerCase() ?? "")) triggers.add("custom-math");
+  if (submission.hook?.customAccounting?.used === true) triggers.add("custom-accounting");
+  if (["beforeSwapReturnDelta", "afterSwapReturnDelta", "afterAddLiquidityReturnDelta", "afterRemoveLiquidityReturnDelta"].some((name) => permissions[name] === true)) triggers.add("return-delta");
+  if ((dimensions.externalLiquidity ?? 0) > 0 || /hold|custod|liquidity|rehypothecat/.test(submission.hook?.customAccounting?.backingSource?.toLowerCase() ?? "")) triggers.add("hook-held-liquidity");
+  if (submission.operations?.oracle?.required === true) triggers.add("oracle");
+  if (submission.operations?.keeper?.required === true || (dimensions.autonomy ?? 0) > 0) triggers.add("autonomous");
+  if ((dimensions.priceImpact ?? 0) > 0 || permissions.beforeSwapReturnDelta === true || permissions.afterSwapReturnDelta === true || submission.hook?.feeMechanism?.used === true) triggers.add("price-impact");
+  if ((dimensions.upgradeability ?? 0) > 0 || behaviors.includes("upgradeable") || /upgrade/.test(capabilities)) triggers.add("upgradeable");
+  if (submission.model?.category === "permissioned-asset" || behaviors.some((behavior) => ["pausable", "blacklistable", "confiscatable"].includes(behavior))) triggers.add("permissioned-asset");
+  const capabilityProfiles = submission.capabilities ?? {};
+  if (capabilityProfiles.externalCalls?.used === true) triggers.add("external-calls");
+  if (capabilityProfiles.oracle?.used === true) triggers.add("oracle");
+  if (capabilityProfiles.keeper?.used === true) triggers.add("autonomous");
+  if (capabilityProfiles.proof?.used === true) triggers.add("proof");
+  if (capabilityProfiles.crossChain?.used === true) triggers.add("cross-chain");
+  if (capabilityProfiles.externalLiquidity?.used === true) triggers.add("external-liquidity");
+  if (capabilityProfiles.asyncSwap?.used === true) triggers.add("async-swap");
+  if (capabilityProfiles.customCurve?.used === true) triggers.add("custom-curve");
+  if (behaviors.some((behavior) => ["fee-on-transfer", "rebasing", "callback-on-transfer"].includes(behavior))) triggers.add("non-standard-token");
+  return [...triggers].sort();
+}
+
+function tierForScore(score) {
+  if (score <= 6) return "low";
+  if (score <= 17) return "medium";
+  return "high";
+}
+
+function buildReport(submission, findingsInput, gates, mask, triggers, score, risk, schema) {
+  const findings = deduplicate(findingsInput).sort((left, right) =>
+    severityOrder[left.severity] - severityOrder[right.severity] ||
+    left.code.localeCompare(right.code) ||
+    left.path.localeCompare(right.path)
+  );
+  const decision = findings.some((finding) => finding.severity === "hard")
+    ? "UNSUPPORTED"
+    : findings.some((finding) => finding.severity === "blocker")
+      ? "REDESIGN_REQUIRED"
+      : "PROTOTYPE_READY";
+  return {
+    reportVersion: REPORT_VERSION,
+    standardVersion: STANDARD_VERSION,
+    submissionHash: submissionHash(submission),
+    toolchain: {
+      validatorSha256: hashFile(validatorModulePath),
+      schemaSha256: isObject(schema) ? `sha256:${crypto.createHash("sha256").update(canonicalJson(schema)).digest("hex")}` : null,
+      deploymentSnapshotSha256: fs.existsSync(deploymentSnapshotPath) ? hashFile(deploymentSnapshotPath) : null,
+      officialDeploymentReferenceSha256: fs.existsSync(officialLaunchpadReferencePath) ? hashFile(officialLaunchpadReferencePath) : null,
+      policyBundleSha256: hashBundle(policyBundlePaths)
+    },
+    decision,
+    hookPermissionMask: mask,
+    risk: {
+      score,
+      baseTier: risk?.baseTier ?? null,
+      effectiveTier: risk?.effectiveTier ?? null,
+      featureTriggers: triggers
+    },
+    findings,
+    requiredGates: [...gates.values()].sort((left, right) => left.stage.localeCompare(right.stage) || left.id.localeCompare(right.id)),
+    disclaimer: "This is a structural and rule-based compatibility preflight. Free-text claims are untrusted input and still require bounded autonomous semantic analysis. PROTOTYPE_READY means only that an isolated prototype may begin; it is not acceptance, an audit, a safety guarantee, deployment evidence, routing approval or proof of availability."
+  };
+}
+
+function hashFile(target) {
+  return `sha256:${crypto.createHash("sha256").update(fs.readFileSync(target)).digest("hex")}`;
+}
+
+function hashBundle(targets) {
+  if (targets.some((target) => !fs.existsSync(target))) return null;
+  const hash = crypto.createHash("sha256");
+  for (const target of targets) {
+    const relativePath = path.relative(skillRoot, target).split(path.sep).join("/");
+    hash.update(relativePath);
+    hash.update("\0");
+    const bytes = fs.readFileSync(target);
+    hash.update(relativePath === "SKILL.md" ? normalizeSkillPolicyBytes(bytes) : bytes);
+    hash.update("\0");
+  }
+  return `sha256:${hash.digest("hex")}`;
+}
+
+function normalizeSkillPolicyBytes(bytes) {
+  let source;
+  try {
+    source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return bytes;
+  }
+
+  const document = source.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/u);
+  if (!document) return bytes;
+
+  const rootFields = new Map();
+  const metadataFields = new Map();
+  let insideMetadata = false;
+  let sawMetadata = false;
+
+  for (const line of document[1].split("\n")) {
+    if (line.startsWith("    ")) {
+      if (!insideMetadata) return bytes;
+      const child = line.match(/^ {4}([a-z][a-z0-9-]*): (.+)$/u);
+      if (!child || metadataFields.has(child[1])) return bytes;
+      metadataFields.set(child[1], child[2]);
+      continue;
+    }
+
+    const field = line.match(/^([a-z][a-z0-9-]*):(?: (.+))?$/u);
+    if (!field) return bytes;
+    const [, key, value] = field;
+    insideMetadata = key === "metadata";
+
+    if (insideMetadata) {
+      if (sawMetadata || value !== undefined) return bytes;
+      sawMetadata = true;
+      continue;
+    }
+
+    if (!["name", "description", "license"].includes(key) || rootFields.has(key) || value === undefined) return bytes;
+    rootFields.set(key, value);
+  }
+
+  if (!rootFields.has("name") || !rootFields.has("description")) return bytes;
+  if (sawMetadata && !isExactInstallerProvenance(metadataFields, rootFields.get("name"))) return bytes;
+
+  const canonicalFrontmatter = [
+    "---",
+    `name: ${rootFields.get("name")}`,
+    `description: ${rootFields.get("description")}`,
+    ...(rootFields.has("license") ? [`license: ${rootFields.get("license")}`] : []),
+    "---"
+  ].join("\n");
+  const body = document[2].startsWith("\n") ? document[2].slice(1) : document[2];
+  return Buffer.from(`${canonicalFrontmatter}\n\n${body}`, "utf8");
+}
+
+function isExactInstallerProvenance(metadataFields, declaredName) {
+  const keys = [...metadataFields.keys()].sort();
+  const values = new Map();
+  for (const [key, source] of metadataFields) {
+    const parsed = parseCanonicalProvenanceScalar(source);
+    if (!parsed.ok) return false;
+    values.set(key, parsed.value);
+  }
+
+  if (keys.length === 1 && keys[0] === "local-path") {
+    const localPath = values.get("local-path");
+    return isBoundedProvenanceValue(localPath, 4096)
+      && (path.posix.isAbsolute(localPath) || path.win32.isAbsolute(localPath));
+  }
+
+  const required = ["github-path", "github-ref", "github-repo", "github-tree-sha"];
+  const allowed = [...required, "github-pinned"].sort();
+  if (!keys.every((key) => allowed.includes(key)) || !required.every((key) => keys.includes(key))) return false;
+  if (![...values].every(([key, value]) => isBoundedProvenanceValue(value, key === "github-path" ? 1024 : 2048))) return false;
+
+  const githubPath = values.get("github-path");
+  const pathSegments = githubPath.split("/");
+  if (
+    githubPath.startsWith("/")
+    || githubPath.endsWith("/")
+    || githubPath.includes("\\")
+    || pathSegments.some((segment) => segment === "" || segment === "." || segment === "..")
+    || pathSegments.at(-1) !== declaredName
+  ) return false;
+
+  return isSupportedGitHubRepositoryUrl(values.get("github-repo"))
+    && isSafeGitReference(values.get("github-ref"))
+    && (!values.has("github-pinned") || isSafeGitReference(values.get("github-pinned")))
+    && /^[0-9a-f]{40}$/u.test(values.get("github-tree-sha"));
+}
+
+export function parseCanonicalProvenanceScalar(source) {
+  if (source.startsWith('"')) {
+    try {
+      const value = JSON.parse(source);
+      if (typeof value !== "string") return { ok: false, error: "requires a string value" };
+      if (value.length === 0) return { ok: false, error: "requires a non-empty string value" };
+      return { ok: true, value };
+    } catch {
+      return { ok: false, error: "contains an invalid double-quoted string" };
+    }
+  }
+  if (source.startsWith("'")) {
+    if (!source.endsWith("'") || source.length < 2) {
+      return { ok: false, error: "contains an invalid single-quoted string" };
+    }
+    const inner = source.slice(1, -1);
+    let value = "";
+    for (let index = 0; index < inner.length; index += 1) {
+      if (inner[index] !== "'") {
+        value += inner[index];
+      } else if (inner[index + 1] === "'") {
+        value += "'";
+        index += 1;
+      } else {
+        return { ok: false, error: "contains an invalid single-quoted string" };
+      }
+    }
+    if (value.length === 0) return { ok: false, error: "requires a non-empty string value" };
+    return { ok: true, value };
+  }
+  if (
+    source.length === 0
+    || source !== source.trim()
+    || /^(?:null|true|false|yes|no|on|off|~)$/iu.test(source)
+    || /^(?:[!&*|>@`]|[-?:]\s)/u.test(source)
+    || /[\[\]{}]/u.test(source)
+    || /(?:^|\s)#/u.test(source)
+    || /:\s|:$/u.test(source)
+  ) return { ok: false, error: "contains a non-canonical plain string" };
+  return { ok: true, value: source };
+}
+
+function isBoundedProvenanceValue(value, maximumBytes) {
+  return Buffer.byteLength(value, "utf8") <= maximumBytes
+    && !/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/u.test(value)
+    && ![...value].some((character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint >= 0xd800 && codePoint <= 0xdfff;
+    });
+}
+
+export function isSupportedGitHubRepositoryUrl(value) {
+  try {
+    const parsed = new URL(value);
+    const hostname = parsed.hostname.toLowerCase();
+    const supportedHost = hostname === "github.com"
+      || /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.ghe\.com$/u.test(hostname);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    return supportedHost
+      && parsed.href === value
+      && parsed.protocol === "https:"
+      && parsed.username === ""
+      && parsed.password === ""
+      && parsed.port === ""
+      && parsed.search === ""
+      && parsed.hash === ""
+      && !parsed.pathname.endsWith("/")
+      && segments.length === 2
+      && /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?$/u.test(segments[0])
+      && /^[A-Za-z0-9._-]{1,100}$/u.test(segments[1]);
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeGitReference(value) {
+  if (
+    value === "@"
+    || value.startsWith("/")
+    || value.endsWith("/")
+    || value.endsWith(".")
+    || value.includes("..")
+    || value.includes("//")
+    || value.includes("@{")
+    || /[\u0000-\u0020\u007f~^:?*[\\\u202a-\u202e\u2066-\u2069]/u.test(value)
+  ) return false;
+  return value.split("/").every((segment) => segment !== "" && !segment.startsWith(".") && !segment.endsWith(".lock"));
+}
+
+function requireResolvedText(value, path, code, add) {
+  if (!resolvedText(value)) add("blocker", code, path, "Required design text is missing or contains a placeholder.", "Replace the placeholder with a specific, testable statement.");
+}
+
+function requireDetailedText(value, path, code, add) {
+  if (!resolvedText(value) || value.trim().length < 12) add("blocker", code, path, "Required design text is missing, vague or contains a placeholder.", "Replace it with a specific, testable statement of at least one complete phrase.");
+}
+
+function validateDeltaComponentPolicy(policy, path, currency, add) {
+  if (!isObject(policy)) {
+    add("blocker", "RETURN_DELTA_COMPONENT_POLICY_MISSING", path, `The ${currency} return-delta component has no signed range and cancellation policy.`, "Declare zero-only, positive-only, negative-only or signed-bounded behavior and its exact settlement actions.");
+    return;
+  }
+  const positiveActions = policy.positiveSettlementActions ?? [];
+  const negativeActions = policy.negativeSettlementActions ?? [];
+  if (policy.mode === "zero-only") {
+    if (policy.formula !== null || policy.minimum !== "0" || policy.maximum !== "0" || policy.minimumSign !== "zero" || policy.maximumSign !== "zero" || positiveActions.length !== 0 || negativeActions.length !== 0) add("blocker", "RETURN_DELTA_ZERO_COMPONENT_CONFLICT", path, "A zero-only component must have exact zero bounds and no settlement path.", "Use formula null, exact zero bounds, zero sign declarations and empty action arrays.");
+    return;
+  }
+  for (const field of ["formula", "minimum", "maximum"]) requireDetailedText(policy[field], `${path}.${field}`, "RETURN_DELTA_COMPONENT_RANGE_INCOMPLETE", add);
+  const permittedSigns = {
+    "positive-only": { minimum: ["zero", "positive"], maximum: ["positive"] },
+    "negative-only": { minimum: ["negative"], maximum: ["negative", "zero"] },
+    "signed-bounded": { minimum: ["negative", "zero"], maximum: ["zero", "positive"] }
+  }[policy.mode];
+  if (!permittedSigns?.minimum.includes(policy.minimumSign) || !permittedSigns?.maximum.includes(policy.maximumSign)) add("blocker", "RETURN_DELTA_COMPONENT_SIGN_RANGE_INVALID", path, "The structured bound signs contradict the selected return-delta component mode.", "Use a nonnegative range for positive-only, a nonpositive range for negative-only, or an ordered negative-to-positive range for signed-bounded.");
+  if (policy.mode === "signed-bounded" && policy.minimumSign === "zero" && policy.maximumSign === "zero") add("blocker", "RETURN_DELTA_COMPONENT_SIGN_RANGE_INVALID", path, "A signed-bounded component cannot collapse to an exact zero range.", "Use zero-only, or declare at least one reachable negative or positive bound.");
+  if (["positive-only", "signed-bounded"].includes(policy.mode)) validateSettlementActions(positiveActions, `${path}.positiveSettlementActions`, add, { expectedEffect: "negative", allowedCurrencies: [currency] });
+  else if (positiveActions.length !== 0) add("blocker", "RETURN_DELTA_COMPONENT_SIGN_CONFLICT", `${path}.positiveSettlementActions`, "This component cannot be positive but declares a positive cancellation path.", "Remove the actions or select a mode that permits positive values.");
+  if (["negative-only", "signed-bounded"].includes(policy.mode)) validateSettlementActions(negativeActions, `${path}.negativeSettlementActions`, add, { expectedEffect: "positive", allowedCurrencies: [currency] });
+  else if (negativeActions.length !== 0) add("blocker", "RETURN_DELTA_COMPONENT_SIGN_CONFLICT", `${path}.negativeSettlementActions`, "This component cannot be negative but declares a negative cancellation path.", "Remove the actions or select a mode that permits negative values.");
+}
+
+export function validateSettlementActions(actions, path, add, { expectedEffect = null, allowedCurrencies = null } = {}) {
+  if (!Array.isArray(actions) || actions.length === 0) {
+    add("blocker", "RETURN_DELTA_SETTLEMENT_MISSING", path, "No action creates the opposing hook delta required before unlock ends.", "List the exact PoolManager accounting actions, actors, currencies, delta owners and completion deadlines.");
+    return;
+  }
+  const ordered = [...actions].sort((left, right) => (left?.order ?? 0) - (right?.order ?? 0));
+  const seenOrders = new Set();
+  let hasAccountingAction = false;
+  let hasExpectedEffect = expectedEffect === null;
+  const operationEffects = {
+    sync: "none",
+    "transfer-to-pool-manager": "none",
+    settle: "positive",
+    "settle-for": "positive",
+    take: "negative",
+    "mint-claim": "negative",
+    "burn-claim": "positive",
+    "clear-reviewed-dust": "negative",
+    "internal-ledger-update": "none"
+  };
+  for (const [index, action] of ordered.entries()) {
+    const actionPath = `${path}[${index}]`;
+    if (!Number.isInteger(action?.order) || action.order !== index + 1 || seenOrders.has(action.order)) add("blocker", "SETTLEMENT_ACTION_ORDER_INVALID", `${actionPath}.order`, "Settlement actions need unique contiguous order values beginning at one.", "Renumber the exact execution sequence without gaps or duplicates.");
+    seenOrders.add(action?.order);
+    if (!resolvedText(action?.amountRule) || action.amountRule.trim().length < 12) add("blocker", "SETTLEMENT_ACTION_AMOUNT_UNRESOLVED", `${actionPath}.amountRule`, "The accounting action has no testable amount rule.", "Bind the amount to an actual returned delta, balance, request or bounded formula.");
+    if (allowedCurrencies && !allowedCurrencies.includes(action?.currency)) add("blocker", "SETTLEMENT_ACTION_CURRENCY_INVALID", `${actionPath}.currency`, "The settlement action uses a currency component that this callback cannot return.", `Use only ${allowedCurrencies.join(" or ")} for this return-delta path.`);
+    const requiredEffect = operationEffects[action?.operation];
+    if (requiredEffect && action?.deltaEffect !== requiredEffect) add("blocker", "SETTLEMENT_ACTION_EFFECT_INVALID", `${actionPath}.deltaEffect`, `${action?.operation} has a fixed PoolManager delta direction.`, `Use deltaEffect ${requiredEffect} and reconcile it with the returned hook delta.`);
+    if (expectedEffect && action?.deltaEffect === expectedEffect && ["take", "mint-claim", "burn-claim", "settle", "settle-for"].includes(action?.operation)) hasExpectedEffect = true;
+    if (action?.deltaOwner !== "hook") add("blocker", "RETURN_DELTA_OWNER_INVALID", `${actionPath}.deltaOwner`, "A hook return delta must be cancelled against the hook's own PoolManager delta.", "Set deltaOwner to hook; model value recipients separately through the action counterparty and internal liabilities.");
+    if (action?.actor === "hook" && action?.operation !== "settle-for" && action?.deltaOwner !== "hook") add("blocker", "HOOK_ACTION_OWNER_INVALID", `${actionPath}.deltaOwner`, "A direct hook accounting action changes the hook's own delta.", "Use hook as the delta owner or specify a valid settle-for recipient.");
+    if (["sync", "internal-ledger-update"].includes(action?.operation) && action?.counterparty !== "not-applicable") add("blocker", "SETTLEMENT_COUNTERPARTY_INVALID", `${actionPath}.counterparty`, "This action has no transfer recipient or source address.", "Use not-applicable for the counterparty.");
+    if (["transfer-to-pool-manager", "settle"].includes(action?.operation) && action?.counterparty !== "PoolManager") add("blocker", "SETTLEMENT_COUNTERPARTY_INVALID", `${actionPath}.counterparty`, "This action transfers value to or accounts value at PoolManager.", "Use PoolManager as counterparty.");
+    if (["take", "mint-claim", "burn-claim", "settle-for"].includes(action?.operation) && action?.counterparty === "not-applicable") add("blocker", "SETTLEMENT_COUNTERPARTY_MISSING", `${actionPath}.counterparty`, "This action changes custody or another account and needs an exact bound counterparty.", "Bind the recipient, claim owner, burn source or settle-for recipient to a declared actor or beneficiary.");
+    if (action?.operation === "settle" && action?.actor !== action?.deltaOwner) add("blocker", "SETTLE_ACTOR_OWNER_MISMATCH", actionPath, "PoolManager settle credits the caller, so the actor must be the delta owner being settled.", "Use the same actor and deltaOwner or use settle-for with an exact owner-bound recipient.");
+    if (action?.operation === "settle-for" && action?.counterparty !== action?.deltaOwner) add("blocker", "SETTLE_FOR_RECIPIENT_OWNER_MISMATCH", actionPath, "PoolManager settleFor credits its recipient; a different counterparty leaves the declared delta owner's debt uncancelled.", "Set counterparty to the exact deltaOwner whose returned delta is being cancelled.");
+    if (["beneficiary", "other-declared"].includes(action?.counterparty) && !resolvedText(action?.authorizationRule)) add("blocker", "SETTLEMENT_AUTHORIZATION_MISSING", `${actionPath}.authorizationRule`, "A beneficiary or other declared counterparty needs an explicit identity and authorization binding.", "Describe how the exact address is selected and why the actor may move value for it.");
+    if (action?.operation === "burn-claim" && !resolvedText(action?.authorizationRule)) add("blocker", "ERC6909_BURN_AUTHORIZATION_MISSING", `${actionPath}.authorizationRule`, "Burning a PoolManager claim requires an explicit owner or operator authorization rule.", "Bind the burn to the exact claim owner and approved operator policy.");
+    if (action?.assetKind === "native" && action?.operation === "transfer-to-pool-manager") add("blocker", "NATIVE_SETTLEMENT_TRANSFER_INVALID", actionPath, "Native ETH settlement is measured from settle or settleFor msg.value, not a preceding standalone transfer.", "Use sync followed directly by settle or settle-for and bind the exact msg.value.");
+    if (action?.assetKind === "native" && ["settle", "settle-for"].includes(action?.operation) && !resolvedText(action?.msgValueRule)) add("blocker", "NATIVE_SETTLEMENT_VALUE_MISSING", `${actionPath}.msgValueRule`, "Native settlement needs an exact msg.value rule.", "Bind msg.value to the precise native debt settled for the declared delta owner.");
+    if (action?.assetKind === "erc20" && action?.msgValueRule !== null) add("blocker", "ERC20_SETTLEMENT_MSG_VALUE_CONFLICT", `${actionPath}.msgValueRule`, "ERC-20 settlement must not claim native msg.value.", "Set msgValueRule to null and use sync, token transfer and settle.");
+    if (action?.operation === "clear-reviewed-dust") add("blocker", "RETURN_DELTA_CLEAR_USED", `${actionPath}.operation`, "PoolManager clear irreversibly abandons exact positive credit and cannot settle a return delta.", "Use take, mint, burn, settle or settleFor; isolate dust disposal outside the return-delta path.");
+    if (["take", "mint-claim", "burn-claim", "settle", "settle-for"].includes(action?.operation)) hasAccountingAction = true;
+    if (action?.completionDeadline === "after-hook-return-before-unlock-end") {
+      if (!["router", "caller"].includes(action?.actor)) add("blocker", "POST_CALLBACK_SETTLEMENT_ACTOR_INVALID", `${actionPath}.actor`, "The hook cannot execute an action after its callback has returned.", "Use an authenticated outer router or caller and prove the exact unlock sequence, or create the opposing delta inside the callback.");
+      if (!["sync", "transfer-to-pool-manager", "settle-for"].includes(action?.operation)) add("blocker", "POST_CALLBACK_SETTLEMENT_OPERATION_INVALID", `${actionPath}.operation`, "This operation cannot safely be delegated to the outer unlock caller after the hook returns.", "Use sync, transfer-to-pool-manager and settle-for for a declared hook debt; credits must be consumed by the hook before returning.");
+      if (action?.deltaOwner !== "hook" && action?.deltaOwner !== "other-declared") add("blocker", "POST_CALLBACK_SETTLEMENT_OWNER_INVALID", `${actionPath}.deltaOwner`, "Post-callback settleFor must identify the hook or another exact declared delta owner.", "Bind the recipient of settleFor to the return-delta owner.");
+    }
+    if (["take", "mint-claim", "burn-claim"].includes(action?.operation) && (action?.actor !== "hook" || action?.completionDeadline !== "before-hook-return")) add("blocker", "HOOK_ACCOUNTING_ACTION_TIMING_INVALID", actionPath, "Hook-owned take, mint or burn accounting must execute by the hook before its callback returns.", "Move the action inside the callback and preserve its exact currency and amount.");
+    if (["settle", "settle-for"].includes(action?.operation)) {
+      const prior = ordered.slice(0, index);
+      const syncIndex = prior.findLastIndex((candidate) => candidate.operation === "sync" && candidate.currency === action.currency && candidate.assetKind === action.assetKind && candidate.actor === action.actor && candidate.completionDeadline === action.completionDeadline);
+      const transferIndex = prior.findLastIndex((candidate) => candidate.operation === "transfer-to-pool-manager" && candidate.currency === action.currency && candidate.assetKind === action.assetKind && candidate.actor === action.actor && candidate.completionDeadline === action.completionDeadline);
+      if (action.assetKind === "erc20" && (syncIndex < 0 || transferIndex !== syncIndex + 1 || index !== transferIndex + 1)) add("blocker", "ERC20_SETTLEMENT_SEQUENCE_INVALID", actionPath, "ERC-20 settlement needs an uninterrupted sync, token transfer to PoolManager and settle or settle-for sequence for one actor and currency.", "Put the three operations next to each other and do not interleave an action that can overwrite the synced reserve checkpoint.");
+      if (action.assetKind === "native" && (syncIndex < 0 || index !== syncIndex + 1 || transferIndex >= syncIndex)) add("blocker", "NATIVE_SETTLEMENT_SEQUENCE_INVALID", actionPath, "Native settlement needs sync followed directly by settle or settle-for with exact msg.value and no standalone transfer.", "Use one uninterrupted native sync and settlement pair.");
+    }
+  }
+  if (!hasAccountingAction) add("blocker", "RETURN_DELTA_OPPOSING_DELTA_MISSING", path, "The action list does not create or settle the opposing hook delta.", "Include an exact take, mint-claim, burn-claim, settle or settle-for accounting action.");
+  if (!hasExpectedEffect) add("blocker", "RETURN_DELTA_CANCELLATION_DIRECTION_MISSING", path, "The action list does not create the PoolManager delta direction needed to cancel this returned hook delta.", `Include at least one accounting action with deltaEffect ${expectedEffect}.`);
+}
+
+function requirePresent(value, path, code, remediation, add) {
+  const present = typeof value === "string" ? resolvedText(value) : value !== null && value !== undefined;
+  if (!present) add("blocker", code, path, "A required capability field is unresolved.", remediation);
+}
+
+function requireNonEmptyArray(value, path, code, remediation, add) {
+  if (!Array.isArray(value) || value.length === 0 || value.some((entry) => !resolvedText(entry))) add("blocker", code, path, "A required capability list is empty or unresolved.", remediation);
+}
+
+function requireCapabilityMatch(actual, expected, name, code, add) {
+  if (typeof actual === "boolean" && actual !== expected) add("blocker", code, `$.capabilities.${name}.used`, `The ${name} capability declaration does not match the rest of the design.`, `Set used to ${expected} and complete the corresponding structured policy.`);
+}
+
+function schemaRuleShapeIsValid(rule) {
+  if (Object.hasOwn(rule, "required") && (!Array.isArray(rule.required) || rule.required.some((entry) => typeof entry !== "string"))) return false;
+  if (Object.hasOwn(rule, "properties") && !isObject(rule.properties)) return false;
+  if (Object.hasOwn(rule, "items") && !isObject(rule.items)) return false;
+  if (Object.hasOwn(rule, "$ref") && typeof rule.$ref !== "string") return false;
+  if (Object.hasOwn(rule, "pattern") && typeof rule.pattern !== "string") return false;
+  return true;
+}
+
+function inspectSchemaDefinition(schema, add) {
+  const patterns = new WeakMap();
+  if (!isObject(schema)) {
+    add("SCHEMA_DEFINITION_TYPE", "$", "The schema root must be a JSON object.");
+    return { valid: false, patterns };
+  }
+
+  const seen = new WeakSet();
+  const active = new WeakSet();
+  const rulePaths = new WeakMap();
+  const referenceRules = [];
+  const stack = [{ node: schema, path: "$", depth: 0, leaving: false }];
+  let nodes = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current.leaving) {
+      active.delete(current.node);
+      continue;
+    }
+    if (current.depth > MAX_SCHEMA_DEPTH) {
+      add("SCHEMA_DEPTH_LIMIT", current.path, `The schema exceeds the maximum depth of ${MAX_SCHEMA_DEPTH}.`);
+      return { valid: false, patterns };
+    }
+    nodes += 1;
+    if (nodes > MAX_SCHEMA_NODES) {
+      add("SCHEMA_NODE_LIMIT", current.path, `The schema exceeds the maximum of ${MAX_SCHEMA_NODES} JSON values.`);
+      return { valid: false, patterns };
+    }
+    if (!current.node || typeof current.node !== "object") continue;
+    if (active.has(current.node)) {
+      add("SCHEMA_OBJECT_CYCLE", current.path, "The schema contains a direct object cycle.");
+      return { valid: false, patterns };
+    }
+    if (seen.has(current.node)) continue;
+
+    seen.add(current.node);
+    active.add(current.node);
+    stack.push({ ...current, leaving: true });
+    if (isObject(current.node)) {
+      rulePaths.set(current.node, current.path);
+      if (Object.hasOwn(current.node, "$ref") && typeof current.node.$ref === "string") {
+        if (!resolveLocalReference(schema, current.node.$ref)) {
+          add("SCHEMA_REFERENCE_INVALID", current.path, "Schema references must resolve to a local JSON object.");
+          return { valid: false, patterns };
+        }
+        referenceRules.push(current.node);
+      }
+      if (Object.hasOwn(current.node, "pattern") && typeof current.node.pattern === "string") {
+        const compiled = compileRestrictedPattern(current.node.pattern);
+        if (!compiled.ok) {
+          add(compiled.code, `${current.path}.pattern`, compiled.message);
+          return { valid: false, patterns };
+        }
+        patterns.set(current.node, compiled.pattern);
+      }
+    }
+
+    const entries = boundedEntries(current.node, MAX_SCHEMA_NODES);
+    if (!entries) {
+      add("SCHEMA_NODE_LIMIT", current.path, `The schema exceeds the maximum of ${MAX_SCHEMA_NODES} JSON values.`);
+      return { valid: false, patterns };
+    }
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const [key, child] = entries[index];
+      stack.push({
+        node: child,
+        path: Array.isArray(current.node) ? `${current.path}[${key}]` : `${current.path}.${key}`,
+        depth: current.depth + 1,
+        leaving: false
+      });
+    }
+  }
+
+  const referenceResult = inspectReferenceGraph(schema, referenceRules, rulePaths);
+  if (!referenceResult.ok) {
+    add(referenceResult.code, referenceResult.path, referenceResult.message);
+    return { valid: false, patterns };
+  }
+  return { valid: true, patterns };
+}
+
+function inspectReferenceGraph(schema, referenceRules, rulePaths) {
+  const state = new WeakMap();
+  const maximumReferenceDepth = new WeakMap();
+
+  function visit(rule) {
+    if (state.get(rule) === 1) {
+      return {
+        ok: false,
+        code: "SCHEMA_REFERENCE_CYCLE",
+        path: rulePaths.get(rule) ?? "$",
+        message: "The schema contains a recursive local reference cycle."
+      };
+    }
+    if (state.get(rule) === 2) return { ok: true, depth: maximumReferenceDepth.get(rule) ?? 0 };
+
+    state.set(rule, 1);
+    let depth = 0;
+    for (const child of schemaEvaluationChildren(schema, rule)) {
+      const result = visit(child.rule);
+      if (!result.ok) return result;
+      depth = Math.max(depth, child.referenceIncrement + result.depth);
+      if (depth > MAX_REFERENCE_DEPTH) {
+        return {
+          ok: false,
+          code: "SCHEMA_REFERENCE_DEPTH_LIMIT",
+          path: rulePaths.get(rule) ?? "$",
+          message: `A schema reference chain exceeds ${MAX_REFERENCE_DEPTH} hops.`
+        };
+      }
+    }
+    state.set(rule, 2);
+    maximumReferenceDepth.set(rule, depth);
+    return { ok: true, depth };
+  }
+
+  for (const referenceRule of referenceRules) {
+    const result = visit(referenceRule);
+    if (!result.ok) return result;
+  }
+  return { ok: true };
+}
+
+function schemaEvaluationChildren(schema, rule) {
+  if (typeof rule.$ref === "string") {
+    const target = resolveLocalReference(schema, rule.$ref);
+    return target ? [{ rule: target, referenceIncrement: 1 }] : [];
+  }
+
+  const children = [];
+  if (isObject(rule.items)) children.push({ rule: rule.items, referenceIncrement: 0 });
+  if (isObject(rule.properties)) {
+    for (const child of Object.values(rule.properties)) {
+      if (isObject(child)) children.push({ rule: child, referenceIncrement: 0 });
+    }
+  }
+  return children;
+}
+
+function resolveLocalReference(schema, reference) {
+  if (typeof reference !== "string" || !reference.startsWith("#/")) return null;
+  let current = schema;
+  for (const rawSegment of reference.slice(2).split("/")) {
+    const segment = rawSegment.replaceAll("~1", "/").replaceAll("~0", "~");
+    if (!current || typeof current !== "object" || !Object.hasOwn(current, segment)) return null;
+    current = current[segment];
+  }
+  return isObject(current) ? current : null;
+}
+
+function inspectInstance(value, add) {
+  const seen = new WeakSet();
+  const active = new WeakSet();
+  const stack = [{ node: value, path: "$", depth: 0, leaving: false }];
+  let nodes = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current.leaving) {
+      active.delete(current.node);
+      continue;
+    }
+    if (current.depth > MAX_INSTANCE_DEPTH) {
+      add("SCHEMA_INSTANCE_DEPTH_LIMIT", current.path, `The submission exceeds the maximum depth of ${MAX_INSTANCE_DEPTH}.`);
+      return false;
+    }
+    nodes += 1;
+    if (nodes > MAX_INSTANCE_NODES) {
+      add("SCHEMA_INSTANCE_NODE_LIMIT", current.path, `The submission exceeds the maximum of ${MAX_INSTANCE_NODES} values.`);
+      return false;
+    }
+    if (!current.node || typeof current.node !== "object") continue;
+    if (active.has(current.node)) {
+      add("SCHEMA_INSTANCE_CYCLE", current.path, "The submission contains an object cycle and cannot be validated as JSON.");
+      return false;
+    }
+    if (seen.has(current.node)) continue;
+
+    seen.add(current.node);
+    active.add(current.node);
+    stack.push({ ...current, leaving: true });
+    const entries = boundedEntries(current.node, MAX_INSTANCE_NODES);
+    if (!entries) {
+      add("SCHEMA_INSTANCE_NODE_LIMIT", current.path, `The submission exceeds the maximum of ${MAX_INSTANCE_NODES} values.`);
+      return false;
+    }
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const [key, child] = entries[index];
+      stack.push({
+        node: child,
+        path: Array.isArray(current.node) ? `${current.path}[${key}]` : `${current.path}.${key}`,
+        depth: current.depth + 1,
+        leaving: false
+      });
+    }
+  }
+  return true;
+}
+
+function boundedEntries(value, maximum) {
+  if (Array.isArray(value)) {
+    if (value.length > maximum) return null;
+    return value.map((entry, index) => [index, entry]);
+  }
+  const entries = [];
+  for (const key in value) {
+    if (!Object.hasOwn(value, key)) continue;
+    entries.push([key, value[key]]);
+    if (entries.length > maximum) return null;
+  }
+  return entries;
+}
+
+function compileRestrictedPattern(pattern) {
+  if (typeof pattern !== "string") {
+    return {
+      ok: false,
+      code: "SCHEMA_PATTERN_INVALID",
+      message: "Schema patterns must be strings."
+    };
+  }
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    return {
+      ok: false,
+      code: "SCHEMA_PATTERN_LIMIT",
+      message: `Schema patterns may contain at most ${MAX_PATTERN_LENGTH} characters.`
+    };
+  }
+
+  let compiled;
+  try {
+    compiled = new RegExp(pattern);
+  } catch {
+    return {
+      ok: false,
+      code: "SCHEMA_PATTERN_INVALID",
+      message: "The schema pattern is not a valid JavaScript regular expression."
+    };
+  }
+  if (!approvedSchemaPatterns.has(pattern)) {
+    return {
+      ok: false,
+      code: "SCHEMA_PATTERN_UNSAFE",
+      message: "The schema pattern is not in the validator's reviewed pattern set."
+    };
+  }
+  return { ok: true, pattern: compiled };
+}
+
+function schemaFindingStopsSemanticReview(finding) {
+  return finding?.[structuralSchemaFinding] === true;
+}
+
+function canonicalEvmChainId(value) {
+  if (Number.isSafeInteger(value) && value > 0) return String(value);
+  if (typeof value !== "string" || !/^[1-9][0-9]{0,77}$/u.test(value)) return null;
+  try {
+    return BigInt(value) <= UINT256_MAX ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolvedText(value) {
+  return typeof value === "string" && value.trim().length > 0 && !placeholderPattern.test(value);
+}
+
+function hasResolvedPolicyValue(value) {
+  if (typeof value === "string") return resolvedText(value);
+  if (typeof value === "number" || typeof value === "boolean") return true;
+  if (Array.isArray(value)) return value.some((entry) => hasResolvedPolicyValue(entry));
+  if (isObject(value)) return Object.values(value).some((entry) => hasResolvedPolicyValue(entry));
+  return false;
+}
+
+function isSafeRepositoryPath(value) {
+  return isCanonicalReviewTargetPath(value);
+}
+
+function objectAt(parent, key) {
+  return isObject(parent?.[key]) ? parent[key] : {};
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function collectOperationNames(value, result = new Set()) {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectOperationNames(entry, result);
+  } else if (isObject(value)) {
+    if (typeof value.operation === "string") result.add(value.operation);
+    for (const entry of Object.values(value)) collectOperationNames(entry, result);
+  }
+  return result;
+}
+
+function matchesType(value, type) {
+  if (type === "null") return value === null;
+  if (type === "array") return Array.isArray(value);
+  if (type === "object") return isObject(value);
+  if (type === "integer") return Number.isInteger(value);
+  return typeof value === type;
+}
+
+function sameValue(left, right) {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+function sortValue(value) {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (!isObject(value)) return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, sortValue(value[key])]));
+}
+
+function deduplicate(findings) {
+  const seen = new Set();
+  return findings.filter((finding) => {
+    const key = `${finding.severity}:${finding.code}:${finding.path}:${finding.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}


### PR DESCRIPTION
Adds the reviewed, read-only default-branch feedback fallback for builder submissions. It runs only trusted validator code, treats candidate data as inert Git objects, and cannot issue approval, grants, entitlements, or launch permits.\n\nValidation: actionlint; workflow authority contract; exact import closure; 336/338 relevant tests passing with 2 platform-only skips; syntax/import/CLI smoke checks.\n\nNo website or UI files are changed.