### PR TITLE
Simplify landing navigation and tighten app topbar

### DIFF
--- a/app/interface.css
+++ b/app/interface.css
@@ -521,10 +521,6 @@ html[data-theme="dark"] .app-frame::before {
   padding-inline: 6px;
 }
 
-.site-header--landing .header-inner {
-  max-width: 720px;
-}
-
 .header-brand {
   gap: 0;
   min-width: 0;
@@ -616,6 +612,26 @@ html[data-theme="dark"] .app-frame::before {
   border-radius: var(--radius-control);
   height: 38px;
   min-height: 38px;
+}
+
+@media (min-width: 801px) {
+  .header-inner {
+    column-gap: 4px;
+    grid-template-columns: auto auto auto;
+    justify-content: center;
+    max-width: calc(100vw - 24px);
+    width: max-content;
+  }
+
+  .header-brand,
+  .desktop-nav,
+  .header-actions {
+    justify-self: auto;
+  }
+
+  .header-actions {
+    gap: 4px;
+  }
 }
 
 .theme-toggle {
@@ -1081,27 +1097,18 @@ html[data-theme="dark"] .app-frame::before {
   }
 
   .header-inner {
+    column-gap: 4px;
+    grid-template-columns: auto auto;
     height: 52px;
+    justify-content: center;
+    max-width: calc(100vw - 20px);
+    padding-inline: 6px;
+    width: max-content;
   }
 
-  .site-header--landing .header-inner {
-    column-gap: 2px;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
-
-  .site-header--landing .desktop-nav {
-    display: flex;
-    grid-column: 2;
-  }
-
-  .site-header--landing .desktop-nav a {
-    font-size: 13px;
-    min-height: 36px;
-    padding-inline: 9px;
-  }
-
-  .site-header--landing .header-actions {
-    grid-column: 3;
+  .header-brand,
+  .header-actions {
+    justify-self: auto;
   }
 
   .mobile-nav {

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -83,13 +83,66 @@
 }
 
 .primaryAction:active,
-.secondaryAction:active {
-  transform: scale(0.98);
+.secondaryAction:active,
+.socialLink:active,
+.docsLink:active {
+  transform: scale(0.96);
 }
 
-:global(.site-header--landing) {
-  position: fixed;
-  width: 100%;
+.supportingLinks {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.socialLinks {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
+.socialLink,
+.docsLink {
+  align-items: center;
+  color: rgba(255, 253, 249, 0.66);
+  display: inline-flex;
+  justify-content: center;
+  transition:
+    color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    opacity 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.socialLink {
+  height: 44px;
+  width: 44px;
+}
+
+.socialLink svg,
+.socialLogo {
+  display: block;
+  height: 20px;
+  width: 20px;
+}
+
+.socialLogo {
+  filter: grayscale(1) brightness(1.18);
+  opacity: 0.82;
+}
+
+.docsLink {
+  font-size: 14px;
+  font-weight: 560;
+  min-height: 44px;
+  padding-inline: 12px;
+}
+
+.socialLink:focus-visible,
+.docsLink:focus-visible {
+  outline: 2px solid #fffdf9;
+  outline-offset: 2px;
 }
 
 :global(.app-frame:has(.landing-page-root) > main) {
@@ -102,6 +155,16 @@
     background: var(--liquid-glass-control-background-hover);
     border-color: rgba(255, 253, 249, 0.3);
     transform: translateY(-2px);
+  }
+
+  .socialLink:hover,
+  .docsLink:hover {
+    color: #fffdf9;
+    transform: translateY(-1px);
+  }
+
+  .socialLink:hover .socialLogo {
+    opacity: 1;
   }
 }
 
@@ -147,22 +210,15 @@
   }
 }
 
-@media (max-width: 600px) {
-  :global(.site-header--landing .header-socials) {
-    display: flex;
-  }
-
-  :global(.site-header--landing .header-social-link) {
-    height: 42px;
-    width: 42px;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .primaryAction,
-  .secondaryAction {
+  .secondaryAction,
+  .socialLink,
+  .docsLink {
     transition:
       background-color 160ms ease,
-      border-color 160ms ease;
+      border-color 160ms ease,
+      color 160ms ease,
+      opacity 160ms ease;
   }
 }

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -1,5 +1,10 @@
+import Image from "next/image";
 import Link from "next/link";
 
+import {
+  GitHubBrandIcon,
+  XBrandIcon,
+} from "@/components/brand-icons";
 import styles from "@/components/landing-page.module.css";
 
 export function LandingPage() {
@@ -25,6 +30,47 @@ export function LandingPage() {
               Explore Tokens
             </Link>
           </div>
+          <nav className={styles.supportingLinks} aria-label="Programmable links">
+            <div className={styles.socialLinks}>
+              <a
+                className={styles.socialLink}
+                href="https://x.com/0xProgrammable"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Programmable on X"
+              >
+                <XBrandIcon />
+              </a>
+              <a
+                className={styles.socialLink}
+                href="https://github.com/0xprogrammable"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Programmable on GitHub"
+              >
+                <GitHubBrandIcon />
+              </a>
+              <a
+                className={styles.socialLink}
+                href="https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Programmable on Dexscreener"
+              >
+                <Image
+                  className={styles.socialLogo}
+                  src="/brand/platforms/dexscreener-mark-white.png"
+                  alt=""
+                  width={256}
+                  height={256}
+                  sizes="20px"
+                />
+              </a>
+            </div>
+            <Link className={styles.docsLink} href="/docs/developers">
+              Docs
+            </Link>
+          </nav>
         </div>
       </section>
     </article>

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -22,10 +22,6 @@ const desktopNavItems = [
   { href: "/profile", label: "Profile", icon: UserRound },
 ];
 
-const landingNavItems = desktopNavItems.filter(
-  (item) => item.href === "/launch" || item.href === "/docs/developers",
-);
-
 const mobileNavItems = desktopNavItems;
 
 function isCurrent(pathname: string, href: string) {
@@ -34,13 +30,11 @@ function isCurrent(pathname: string, href: string) {
 
 export function SiteHeader() {
   const pathname = usePathname();
-  const isLandingPage = pathname === "/";
-  const visibleNavItems = isLandingPage ? landingNavItems : desktopNavItems;
+
+  if (pathname === "/") return null;
 
   return (
-    <header
-      className={`site-header${isLandingPage ? " site-header--landing" : ""}`}
-    >
+    <header className="site-header">
       <div className="header-inner liquid-glass-surface liquid-glass-distortion">
         <div className="header-brand">
           <Link className="wordmark" href="/" aria-label="Programmable home">
@@ -57,7 +51,7 @@ export function SiteHeader() {
         </div>
 
         <nav className="desktop-nav" aria-label="Primary navigation">
-          {visibleNavItems.map((item) => (
+          {desktopNavItems.map((item) => (
             <Link
               key={item.href}
               className={isCurrent(pathname, item.href) ? "active" : undefined}
@@ -106,7 +100,7 @@ export function SiteHeader() {
               />
             </a>
           </div>
-          {!isLandingPage ? <WalletButton compact /> : null}
+          <WalletButton compact />
         </div>
       </div>
     </header>

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -134,9 +134,13 @@ describe("interaction accessibility", () => {
     );
   });
 
-  it("keeps the landing header wallet-free while retaining its market links", () => {
+  it("removes landing chrome while keeping its supporting links accessible", () => {
     const source = readFileSync(
       join(root, "components/site-navigation.tsx"),
+      "utf8",
+    );
+    const landing = readFileSync(
+      join(root, "components/landing-page.tsx"),
       "utf8",
     );
     const css = readFileSync(
@@ -144,10 +148,15 @@ describe("interaction accessibility", () => {
       "utf8",
     );
 
-    expect(source).toContain("{!isLandingPage ? <WalletButton compact /> : null}");
+    expect(source).toContain('if (pathname === "/") return null;');
+    expect(landing).toContain('aria-label="Programmable links"');
+    expect(landing).toContain('aria-label="Programmable on X"');
+    expect(landing).toContain('aria-label="Programmable on GitHub"');
+    expect(landing).toContain('aria-label="Programmable on Dexscreener"');
     expect(css).toMatch(
-      /@media \(max-width: 600px\)[\s\S]*?site-header--landing \.header-socials[\s\S]*?display:\s*flex/,
+      /\.socialLink\s*\{[^}]*height:\s*44px;[^}]*width:\s*44px;/s,
     );
+    expect(css).toMatch(/\.docsLink\s*\{[^}]*min-height:\s*44px;/s);
   });
 
   it("keeps all four primary routes semantic and reflow-safe in mobile navigation", () => {

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -23,6 +23,7 @@ describe("landing page contract", () => {
   it("uses responsive static atmosphere layers without a video", () => {
     const landing = read("components/landing-page.tsx");
     const backdrop = read("components/atmosphere-backdrop.tsx");
+    const navigation = read("components/site-navigation.tsx");
 
     expect(backdrop).toContain(
       "/brand/atmosphere/night-sky-desktop-v1.avif",
@@ -43,6 +44,12 @@ describe("landing page contract", () => {
     expect(landing).toContain('href="/explore"');
     expect(landing).toContain("Create a Token");
     expect(landing).toContain("Explore Tokens");
+    expect(landing).toContain('aria-label="Programmable links"');
+    expect(landing).toContain('aria-label="Programmable on X"');
+    expect(landing).toContain('aria-label="Programmable on GitHub"');
+    expect(landing).toContain('aria-label="Programmable on Dexscreener"');
+    expect(landing).toContain('href="/docs/developers"');
+    expect(navigation).toContain('if (pathname === "/") return null;');
     expect(landing).not.toContain("LandingBackdrop");
     expect(backdrop).not.toContain("<video");
     expect(landing).not.toContain("Built on Uniswap v4");

--- a/tests/topbar-hero-polish.test.ts
+++ b/tests/topbar-hero-polish.test.ts
@@ -35,32 +35,33 @@ describe("topbar and Explore hero polish", () => {
     );
   });
 
-  it("keeps one glass topbar and exposes the verified market link", () => {
+  it("keeps app navigation compact and moves landing links below the hero actions", () => {
     const navigation = read("components/site-navigation.tsx");
+    const landing = read("components/landing-page.tsx");
     const landingCss = read("components/landing-page.module.css");
+    const interfaceCss = read("app/interface.css");
 
-    expect(navigation).toContain(
+    expect(landing).toContain(
       "https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0",
     );
-    expect(navigation).toContain(
+    expect(landing).toContain(
       'src="/brand/platforms/dexscreener-mark-white.png"',
     );
-    expect(navigation).toContain('aria-label="Programmable on Dexscreener"');
+    expect(landing).toContain('aria-label="Programmable on X"');
+    expect(landing).toContain('aria-label="Programmable on GitHub"');
+    expect(landing).toContain('aria-label="Programmable on Dexscreener"');
+    expect(landing).toContain('href="/docs/developers"');
     expect(navigation).not.toContain("ThemeToggle");
-    expect(navigation).toContain(
-      "{!isLandingPage ? <WalletButton compact /> : null}",
+    expect(navigation).toContain('if (pathname === "/") return null;');
+    expect(navigation).toContain("<WalletButton compact />");
+    expect(interfaceCss).toMatch(
+      /@media \(min-width: 801px\)[\s\S]*?\.header-inner\s*\{[^}]*grid-template-columns:\s*auto auto auto;[^}]*justify-content:\s*center;[^}]*width:\s*max-content;/s,
     );
-    expect(navigation).toContain("const landingNavItems");
-    expect(navigation).toContain('item.href === "/launch"');
-    expect(navigation).toContain('item.href === "/docs/developers"');
+    expect(interfaceCss).toMatch(
+      /@media \(max-width: 800px\)[\s\S]*?\.header-inner\s*\{[^}]*grid-template-columns:\s*auto auto;[^}]*justify-content:\s*center;[^}]*width:\s*max-content;/s,
+    );
     expect(landingCss).toMatch(
-      /:global\(\.site-header--landing\)\s*\{[^}]*position:\s*fixed;[^}]*width:\s*100%;/s,
-    );
-    expect(landingCss).not.toContain(
-      ":global(.site-header--landing .header-inner)",
-    );
-    expect(landingCss).not.toMatch(
-      /site-header--landing \.header-socials[\s\S]*?display:\s*none/u,
+      /\.socialLink\s*\{[^}]*height:\s*44px;[^}]*width:\s*44px;/s,
     );
   });
 


### PR DESCRIPTION
## Summary
- remove the topbar from the landing page
- place X, GitHub, DexScreener and Docs below the primary landing actions
- shrink and center the app topbar on desktop and mobile

## Validation
- 28 focused UI tests
- TypeScript
- targeted ESLint
- production build
- desktop and mobile browser QA