### PR TITLE
Enlarge landing support links

### DIFF
--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -123,8 +123,8 @@
 .socialLink svg,
 .socialLogo {
   display: block;
-  height: 20px;
-  width: 20px;
+  height: 30px;
+  width: 30px;
 }
 
 .socialLogo {
@@ -133,7 +133,7 @@
 }
 
 .docsLink {
-  font-size: 14px;
+  font-size: 20px;
   font-weight: 560;
   min-height: 44px;
   padding-inline: 12px;

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -63,7 +63,7 @@ export function LandingPage() {
                   alt=""
                   width={256}
                   height={256}
-                  sizes="20px"
+                  sizes="30px"
                 />
               </a>
             </div>

--- a/tests/topbar-hero-polish.test.ts
+++ b/tests/topbar-hero-polish.test.ts
@@ -63,6 +63,12 @@ describe("topbar and Explore hero polish", () => {
     expect(landingCss).toMatch(
       /\.socialLink\s*\{[^}]*height:\s*44px;[^}]*width:\s*44px;/s,
     );
+    expect(landingCss).toMatch(
+      /\.socialLink svg,\s*\.socialLogo\s*\{[^}]*height:\s*30px;[^}]*width:\s*30px;/s,
+    );
+    expect(landingCss).toMatch(
+      /\.docsLink\s*\{[^}]*font-size:\s*20px;/s,
+    );
   });
 
   it("centers the Explore headline and only forces one line on wide screens", () => {


### PR DESCRIPTION
## Summary
- enlarge the three landing social icons from 20px to 30px
- enlarge the landing Docs link from 14px to 20px
- retain 44px minimum interactive hit areas

## Validation
- `npm test -- --run tests/topbar-hero-polish.test.ts`
- `npm run typecheck`
- `npx eslint components/landing-page.tsx tests/topbar-hero-polish.test.ts`
- `npm run build`
- desktop and 390px mobile browser QA with no overflow or console errors