### PR TITLE
Refine landing headline and brand mark

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ const plexMono = IBM_Plex_Mono({
 
 const siteUrl = new URL("https://programmable.family");
 const siteDescription =
-  "Launch tokens that work the way you imagine.";
+  "Launch tokens that behave exactly how you imagine.";
 const socialImageUrl = new URL(
   "/og/programmable-loop-og-1200x630.png",
   siteUrl,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { LandingPage } from "@/components/landing-page";
 
 export const metadata: Metadata = {
   title: "Programmable",
-  description: "Launch what you imagine on Ethereum with Programmable.",
+  description: "Launch tokens that behave exactly how you imagine.",
 };
 
 export default function HomePage() {

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -6,6 +6,33 @@
   position: relative;
 }
 
+.brandLink {
+  align-items: center;
+  border-radius: 16px;
+  display: inline-flex;
+  height: 56px;
+  justify-content: center;
+  left: max(24px, env(safe-area-inset-left));
+  position: absolute;
+  top: max(24px, env(safe-area-inset-top));
+  transition:
+    opacity 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  width: 48px;
+  z-index: 2;
+}
+
+.brandLogo {
+  display: block;
+  height: 44px;
+  width: auto;
+}
+
+.brandLink:focus-visible {
+  outline: 3px solid #fffdf9;
+  outline-offset: 4px;
+}
+
 .hero {
   align-items: center;
   display: flex;
@@ -84,6 +111,7 @@
 
 .primaryAction:active,
 .secondaryAction:active,
+.brandLink:active,
 .socialLink:active,
 .docsLink:active {
   transform: scale(0.96);
@@ -150,6 +178,11 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
+  .brandLink:hover {
+    opacity: 0.84;
+    transform: translateY(-1px);
+  }
+
   .primaryAction:hover,
   .secondaryAction:hover {
     background: var(--liquid-glass-control-background-hover);
@@ -190,6 +223,17 @@
 }
 
 @media (max-width: 460px) {
+  .brandLink {
+    height: 48px;
+    left: max(16px, env(safe-area-inset-left));
+    top: max(16px, env(safe-area-inset-top));
+    width: 40px;
+  }
+
+  .brandLogo {
+    height: 38px;
+  }
+
   .hero {
     padding-inline: 16px;
   }
@@ -213,6 +257,7 @@
 @media (prefers-reduced-motion: reduce) {
   .primaryAction,
   .secondaryAction,
+  .brandLink,
   .socialLink,
   .docsLink {
     transition:

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -13,9 +13,26 @@ export function LandingPage() {
       className={`${styles.page} landing-page-root`}
       aria-labelledby="landing-title"
     >
+      <Link
+        className={styles.brandLink}
+        href="/"
+        aria-label="Programmable home"
+      >
+        <Image
+          className={styles.brandLogo}
+          src="/brand/loop/programmable-loop-mark-header.png"
+          alt=""
+          width={146}
+          height={192}
+          sizes="44px"
+          priority
+        />
+      </Link>
       <section className={styles.hero}>
         <div className={styles.content}>
-          <h1 id="landing-title">Launch what you imagine</h1>
+          <h1 id="landing-title">
+            Launch tokens that behave exactly how you imagine
+          </h1>
           <div className={styles.actions} aria-label="Get started">
             <Link
               className={`${styles.primaryAction} liquid-glass-control liquid-glass-distortion`}

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -42,6 +42,13 @@ describe("landing page contract", () => {
     expect(backdrop).toContain('fetchPriority="high"');
     expect(landing).toContain('href="/launch"');
     expect(landing).toContain('href="/explore"');
+    expect(landing).toContain(
+      "Launch tokens that behave exactly how you imagine",
+    );
+    expect(landing).toContain('aria-label="Programmable home"');
+    expect(landing).toContain(
+      'src="/brand/loop/programmable-loop-mark-header.png"',
+    );
     expect(landing).toContain("Create a Token");
     expect(landing).toContain("Explore Tokens");
     expect(landing).toContain('aria-label="Programmable links"');


### PR DESCRIPTION
## Summary
- change the landing headline to Launch tokens that behave exactly how you imagine
- add the canonical Programmable loop mark at the top left of the landing page
- keep landing metadata aligned with the new message

## Validation
- 8 focused tests passed
- TypeScript passed
- targeted ESLint passed
- production build passed
- desktop and mobile browser QA passed without console errors or overflow