### PR TITLE
Shorten landing headline

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,8 +19,7 @@ const plexMono = IBM_Plex_Mono({
 });
 
 const siteUrl = new URL("https://programmable.family");
-const siteDescription =
-  "Launch tokens that behave exactly how you imagine.";
+const siteDescription = "Tokens that behave how you imagine.";
 const socialImageUrl = new URL(
   "/og/programmable-loop-og-1200x630.png",
   siteUrl,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { LandingPage } from "@/components/landing-page";
 
 export const metadata: Metadata = {
   title: "Programmable",
-  description: "Launch tokens that behave exactly how you imagine.",
+  description: "Tokens that behave how you imagine.",
 };
 
 export default function HomePage() {

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -62,6 +62,11 @@
   text-wrap: balance;
 }
 
+.content h1 span {
+  display: block;
+  white-space: nowrap;
+}
+
 .actions {
   align-items: center;
   display: flex;
@@ -239,7 +244,7 @@
   }
 
   .content h1 {
-    font-size: clamp(48px, 14.8vw, 64px);
+    font-size: clamp(36px, 11vw, 48px);
   }
 
   .actions {

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -30,9 +30,7 @@ export function LandingPage() {
       </Link>
       <section className={styles.hero}>
         <div className={styles.content}>
-          <h1 id="landing-title">
-            Launch tokens that behave exactly how you imagine
-          </h1>
+          <h1 id="landing-title">Tokens that behave how you imagine</h1>
           <div className={styles.actions} aria-label="Get started">
             <Link
               className={`${styles.primaryAction} liquid-glass-control liquid-glass-distortion`}

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -30,7 +30,13 @@ export function LandingPage() {
       </Link>
       <section className={styles.hero}>
         <div className={styles.content}>
-          <h1 id="landing-title">Tokens that behave how you imagine</h1>
+          <h1
+            id="landing-title"
+            aria-label="Tokens that behave how you imagine"
+          >
+            <span aria-hidden="true">Tokens that behave</span>
+            <span aria-hidden="true">how you imagine</span>
+          </h1>
           <div className={styles.actions} aria-label="Get started">
             <Link
               className={`${styles.primaryAction} liquid-glass-control liquid-glass-distortion`}

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -42,9 +42,7 @@ describe("landing page contract", () => {
     expect(backdrop).toContain('fetchPriority="high"');
     expect(landing).toContain('href="/launch"');
     expect(landing).toContain('href="/explore"');
-    expect(landing).toContain(
-      "Launch tokens that behave exactly how you imagine",
-    );
+    expect(landing).toContain("Tokens that behave how you imagine");
     expect(landing).toContain('aria-label="Programmable home"');
     expect(landing).toContain(
       'src="/brand/loop/programmable-loop-mark-header.png"',

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -22,6 +22,7 @@ describe("landing page contract", () => {
 
   it("uses responsive static atmosphere layers without a video", () => {
     const landing = read("components/landing-page.tsx");
+    const styles = read("components/landing-page.module.css");
     const backdrop = read("components/atmosphere-backdrop.tsx");
     const navigation = read("components/site-navigation.tsx");
 
@@ -42,7 +43,12 @@ describe("landing page contract", () => {
     expect(backdrop).toContain('fetchPriority="high"');
     expect(landing).toContain('href="/launch"');
     expect(landing).toContain('href="/explore"');
-    expect(landing).toContain("Tokens that behave how you imagine");
+    expect(landing).toContain(
+      'aria-label="Tokens that behave how you imagine"',
+    );
+    expect(landing).toContain(">Tokens that behave</span>");
+    expect(landing).toContain(">how you imagine</span>");
+    expect(styles).toContain("white-space: nowrap");
     expect(landing).toContain('aria-label="Programmable home"');
     expect(landing).toContain(
       'src="/brand/loop/programmable-loop-mark-header.png"',


### PR DESCRIPTION
## Summary
- shorten the landing headline to `Tokens that behave how you imagine`
- keep page and social metadata aligned with the visible copy
- update the landing contract assertion

## Validation
- 8/8 focused landing and branding tests
- TypeScript
- targeted ESLint
- production build
- desktop and mobile browser QA with no horizontal overflow or console errors