### PR TITLE
Keep protocol revenue claims on daily cadence

### DIFF
--- a/lib/protocol-revenue/keeper-policy.ts
+++ b/lib/protocol-revenue/keeper-policy.ts
@@ -29,10 +29,10 @@ export function evaluateProtocolRevenueV2Action(input: Readonly<{
   if (input.pendingNonce !== input.latestNonce) {
     return { status: "pending_transaction" };
   }
-  if (input.pendingRevenue >= input.vaultMinimumRevenue) {
-    if (input.finalizedTimestamp < input.vaultNextRunAt) {
-      return { status: "not_due", nextRunAt: input.vaultNextRunAt };
-    }
+  if (
+    input.pendingRevenue >= input.vaultMinimumRevenue &&
+    input.finalizedTimestamp >= input.vaultNextRunAt
+  ) {
     return { status: "process", revenue: input.pendingRevenue };
   }
 
@@ -41,6 +41,10 @@ export function evaluateProtocolRevenueV2Action(input: Readonly<{
     input.claimAccruedRevenue >= input.claimMinimumRevenue
   ) {
     return { status: "claim", accruedRevenue: input.claimAccruedRevenue };
+  }
+
+  if (input.pendingRevenue >= input.vaultMinimumRevenue) {
+    return { status: "not_due", nextRunAt: input.vaultNextRunAt };
   }
 
   const transferable = [

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -40,7 +40,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       ]),
       policy: Object.freeze({
         path: "lib/protocol-revenue/keeper-policy.ts",
-        sha256: "ca242872b95141f042656199b39ae4a1636ccdaf5585a97a7eae28a6549f8ab0",
+        sha256: "b515502c8ef81b99a3ba8d7867c76e6aeb346d2c9f2b50da4c0407fb54c46090",
       }),
     }),
   ]),

--- a/tests/protocol-revenue-keeper-policy.test.ts
+++ b/tests/protocol-revenue-keeper-policy.test.ts
@@ -51,7 +51,7 @@ describe("protocol revenue keeper policy", () => {
     ).toEqual({ status: "claim", accruedRevenue: 200n });
   });
 
-  it("never stacks transactions and waits for cadence or permission recovery", () => {
+  it("keeps the daily claim cadence independent from a waiting vault cycle", () => {
     const base = {
       finalizedTimestamp: 2_000n,
       pendingRevenue: 200n,
@@ -67,9 +67,15 @@ describe("protocol revenue keeper policy", () => {
       pendingNonce: 7,
     } as const;
     expect(evaluateProtocolRevenueV2Action(base)).toEqual({
-      status: "not_due",
-      nextRunAt: 2_100n,
+      status: "claim",
+      accruedRevenue: 300n,
     });
+    expect(
+      evaluateProtocolRevenueV2Action({
+        ...base,
+        claimReady: false,
+      }),
+    ).toEqual({ status: "not_due", nextRunAt: 2_100n });
     expect(
       evaluateProtocolRevenueV2Action({
         ...base,


### PR DESCRIPTION
Claims now remain eligible on their own 24-hour cadence even when revenue is already waiting for the vault processing window.

The vault still processes first whenever it is due. Transactions remain serialized, and waiting vault revenue still blocks additional transfers.

Checks:
- protocol revenue policy, runtime and route tests
- TypeScript
- ESLint
- operations source binding