### PR TITLE
Add public analytics short link

### DIFF
--- a/app/analytics/route.ts
+++ b/app/analytics/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+const DUNE_ANALYTICS_URL =
+  "https://dune.com/0xprogrammable6098/programmable-analytics";
+
+export function GET() {
+  return NextResponse.redirect(DUNE_ANALYTICS_URL);
+}

--- a/tests/analytics-redirect.test.ts
+++ b/tests/analytics-redirect.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { GET } from "@/app/analytics/route";
+
+describe("analytics short link", () => {
+  it("redirects to the canonical public Dune dashboard", () => {
+    const response = GET();
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://dune.com/0xprogrammable6098/programmable-analytics",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `/analytics` as the stable Programmable-owned entry point for public analytics
- redirect to the canonical public Dune dashboard
- cover the redirect target and status with a focused test

## Validation
- `npm test -- tests/analytics-redirect.test.ts`
- `npm run typecheck`
- `npx eslint app/analytics/route.ts tests/analytics-redirect.test.ts`