### PR TITLE
Add Analytics to the site footer

### DIFF
--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -12,6 +12,10 @@ const productLinks = [
 
 const resourceLinks = [
   {
+    href: "/analytics",
+    label: "Analytics",
+  },
+  {
     href: "https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0",
     label: "Token",
     external: true,
@@ -77,13 +81,13 @@ export function SiteFooter() {
           <ul>
             {resourceLinks.map((link) => (
               <li key={link.href}>
-                <a
-                  href={link.href}
-                  target={link.external ? "_blank" : undefined}
-                  rel={link.external ? "noreferrer" : undefined}
-                >
-                  {link.label}
-                </a>
+                {link.external ? (
+                  <a href={link.href} target="_blank" rel="noreferrer">
+                    {link.label}
+                  </a>
+                ) : (
+                  <Link href={link.href}>{link.label}</Link>
+                )}
               </li>
             ))}
           </ul>

--- a/tests/site-footer.test.ts
+++ b/tests/site-footer.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const footerSource = readFileSync(
+  new URL("../components/site-footer.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("Site footer", () => {
+  it("links the public analytics shortcut from Resources", () => {
+    expect(footerSource).toContain('href: "/analytics"');
+    expect(footerSource).toContain('label: "Analytics"');
+  });
+});


### PR DESCRIPTION
## Summary
- add the public Analytics shortcut under Resources in the existing footer
- keep the landing page and primary navigation unchanged
- preserve external-link behavior for the remaining resource links

## Validation
- `npm test -- --run tests/site-footer.test.ts`
- `npx eslint components/site-footer.tsx tests/site-footer.test.ts`
- `npm run typecheck`