### PR TITLE
Align revenue claims with daily buybacks

### DIFF
--- a/docs/operations/protocol-revenue-v1.md
+++ b/docs/operations/protocol-revenue-v1.md
@@ -1,4 +1,4 @@
-# Protocol revenue V1 operations
+# Protocol revenue operations
 
 ## Production boundary
 
@@ -14,24 +14,29 @@ the disposable keeper bound immutably to the executor. It holds gas only.
 
 ## Runtime behavior
 
-Vercel checks the route every 15 minutes. The contracts allow at most one successful cycle every 24 hours. A cycle is
-submitted only when all of the following hold:
+Vercel checks the route every minute. The keeper aligns the daily claim with the vault's immutable 24-hour processing
+window: it claims in the final five minutes before the vault is due, transfers the exact unprocessed claim total, and
+processes the complete pending amount as soon as the vault permits it. A transaction is submitted only when all of the
+following hold:
 
 - the signed delegation is active;
-- two RPC vendors agree on one recent finalized block and every critical binding;
+- two RPC vendors agree on a two-confirmation state block, one recent finalized price observation and every critical
+  binding;
 - no keeper transaction is pending;
-- the cycle is due and supported hook revenue meets the minimum;
+- coordinator `totalClaimed` minus vault `totalRevenueDeposited` exactly matches the amount transferred;
+- the complete transfer fits the wallet balance, signed daily permission and vault capacity;
+- the claim or processing window is due and supported hook revenue meets the minimum;
 - both public simulations pass;
 - the gas price, gas estimate, keeper balance and revenue-to-gas ratio pass their bounds;
 - the fixed 0.5% keeper allocation covers the buffered maximum gas cost.
 
-The raw transaction is sent only through MEV Blocker's private no-revert boost endpoint. Onchain tick, output, chunk,
+The raw transaction is sent only through Flashbots' private fast endpoint. Onchain tick, output, chunk,
 capacity and cooldown checks remain authoritative. A failed check leaves the claim, Treasury transfer and buyback
 unchanged and the next Cron invocation tries again.
 
 ## Safe statuses
 
-`disabled`, `delegation_missing`, `not_due`, `below_minimum`, `gas_price_too_high`, `gas_estimate_too_high`,
+`disabled`, `delegation_missing`, `not_due`, `below_minimum`, `accounting_mismatch`, `gas_price_too_high`, `gas_estimate_too_high`,
 `uneconomic` and `keeper_balance_low` are fail-closed no-op states. `submitted` includes the raw transaction hash.
 `pending_transaction` prevents nonce reuse while a prior private transaction is unresolved. A `503` means the runtime
 could not prove a safe execution and submitted nothing.
@@ -48,6 +53,6 @@ Treasury balance delta, `$V4` delivery and unchanged main-pool binding.
 
 ## Extension rule
 
-V1 claims native ETH fees from the four pinned shared hooks named in the security specification. A future hook or a
-non-native fee asset is not discovered automatically. Supporting it requires a new reviewed executor/enforcer source
-binding, tests, source verification and delegation update before activation.
+The current coordinator claims native ETH fees from the pinned Classic V1 and Classic V2 hooks. A future hook or a
+non-native fee asset is not discovered automatically. Supporting it requires a reviewed source binding, tests,
+source verification and, where the hook restricts claims to the revenue wallet, a narrowly scoped delegation update.

--- a/lib/protocol-revenue/keeper-policy.ts
+++ b/lib/protocol-revenue/keeper-policy.ts
@@ -2,6 +2,7 @@ export const PROTOCOL_REVENUE_GAS_LIMIT_BUFFER_BPS = 12_500n;
 export const PROTOCOL_REVENUE_KEEPER_BALANCE_HEADROOM = 2n;
 export const PROTOCOL_REVENUE_MIN_GAS_MULTIPLIER = 250n;
 export const PROTOCOL_REVENUE_MAX_EXECUTION_GAS = 15_000_000n;
+export const PROTOCOL_REVENUE_CLAIM_LEAD_TIME = 5n * 60n;
 
 export type ProtocolRevenueV2ActionDecision =
   | Readonly<{ status: "pending_transaction" }>
@@ -9,14 +10,18 @@ export type ProtocolRevenueV2ActionDecision =
   | Readonly<{ status: "transfer"; amount: bigint }>
   | Readonly<{ status: "claim"; accruedRevenue: bigint }>
   | Readonly<{ status: "not_due"; nextRunAt: bigint }>
+  | Readonly<{ status: "accounting_mismatch" }>
   | Readonly<{ status: "permission_exhausted" }>
   | Readonly<{ status: "below_minimum"; minimumRevenue: bigint }>;
 
 export function evaluateProtocolRevenueV2Action(input: Readonly<{
-  finalizedTimestamp: bigint;
+  stateTimestamp: bigint;
   pendingRevenue: bigint;
   vaultNextRunAt: bigint;
   vaultMinimumRevenue: bigint;
+  vaultMaximumRevenue: bigint;
+  coordinatorTotalClaimed: bigint;
+  vaultTotalRevenueDeposited: bigint;
   rewardWalletBalance: bigint;
   permissionAvailable: bigint;
   maximumTransfer: bigint;
@@ -29,16 +34,38 @@ export function evaluateProtocolRevenueV2Action(input: Readonly<{
   if (input.pendingNonce !== input.latestNonce) {
     return { status: "pending_transaction" };
   }
+  if (input.vaultTotalRevenueDeposited > input.coordinatorTotalClaimed) {
+    return { status: "accounting_mismatch" };
+  }
+  const untransferredClaims =
+    input.coordinatorTotalClaimed - input.vaultTotalRevenueDeposited;
   if (
     input.pendingRevenue >= input.vaultMinimumRevenue &&
-    input.finalizedTimestamp >= input.vaultNextRunAt
+    input.stateTimestamp >= input.vaultNextRunAt
   ) {
     return { status: "process", revenue: input.pendingRevenue };
   }
 
+  if (untransferredClaims >= input.vaultMinimumRevenue) {
+    const remainingVaultCapacity = input.pendingRevenue < input.vaultMaximumRevenue
+      ? input.vaultMaximumRevenue - input.pendingRevenue
+      : 0n;
+    if (
+      input.rewardWalletBalance < untransferredClaims ||
+      input.permissionAvailable < untransferredClaims ||
+      input.maximumTransfer < untransferredClaims ||
+      remainingVaultCapacity < untransferredClaims
+    ) {
+      return { status: "permission_exhausted" };
+    }
+    return { status: "transfer", amount: untransferredClaims };
+  }
+
   if (
     input.claimReady &&
-    input.claimAccruedRevenue >= input.claimMinimumRevenue
+    input.claimAccruedRevenue >= input.claimMinimumRevenue &&
+    input.stateTimestamp + PROTOCOL_REVENUE_CLAIM_LEAD_TIME >=
+      input.vaultNextRunAt
   ) {
     return { status: "claim", accruedRevenue: input.claimAccruedRevenue };
   }
@@ -47,19 +74,11 @@ export function evaluateProtocolRevenueV2Action(input: Readonly<{
     return { status: "not_due", nextRunAt: input.vaultNextRunAt };
   }
 
-  const transferable = [
-    input.rewardWalletBalance,
-    input.permissionAvailable,
-    input.maximumTransfer,
-  ].reduce((current, value) => value < current ? value : current);
-  if (transferable >= input.vaultMinimumRevenue) {
-    return { status: "transfer", amount: transferable };
-  }
-  if (
-    input.rewardWalletBalance >= input.vaultMinimumRevenue &&
-    input.permissionAvailable < input.vaultMinimumRevenue
-  ) {
-    return { status: "permission_exhausted" };
+  if (input.claimReady && input.claimAccruedRevenue >= input.claimMinimumRevenue) {
+    const claimAt = input.vaultNextRunAt > PROTOCOL_REVENUE_CLAIM_LEAD_TIME
+      ? input.vaultNextRunAt - PROTOCOL_REVENUE_CLAIM_LEAD_TIME
+      : 0n;
+    return { status: "not_due", nextRunAt: claimAt };
   }
   return {
     status: "below_minimum",

--- a/lib/protocol-revenue/keeper-v2.server.ts
+++ b/lib/protocol-revenue/keeper-v2.server.ts
@@ -63,6 +63,7 @@ const COORDINATOR_ABI = parseAbi([
   "function CLASSIC_V2_HOOK() view returns (address)",
   "function MIN_ACCRUED_REVENUE() view returns (uint256)",
   "function accruedRevenue() view returns (uint256)",
+  "function totalClaimed() view returns (uint256)",
   "function ready() view returns (bool)",
   "function nextClaimAt() view returns (uint256)",
   "function claim() returns (uint256)",
@@ -80,6 +81,7 @@ const VAULT_ABI = parseAbi([
   "function MIN_NEW_REVENUE() view returns (uint256)",
   "function MAX_OBSERVATION_AGE() view returns (uint64)",
   "function pendingRevenue() view returns (uint256)",
+  "function totalRevenueDeposited() view returns (uint256)",
   "function nextRunAt() view returns (uint256)",
   "function currentMainPoolTick() view returns (int24)",
   "function process(uint64 observedAt,int24 referenceTick)",
@@ -105,6 +107,7 @@ export type ProtocolRevenueKeeperV2Result =
         | "not_due"
         | "below_minimum"
         | "pending_transaction"
+        | "accounting_mismatch"
         | "permission_exhausted"
         | "gas_price_too_high"
         | "gas_estimate_too_high"
@@ -294,6 +297,38 @@ async function finalizedObservation(
   const blockNumber = heads[0].number < heads[1].number
     ? heads[0].number
     : heads[1].number;
+  const blocks = await Promise.all(
+    clients.map((current) => current.getBlock({ blockNumber })),
+  );
+  if (
+    !blocks[0].hash ||
+    !blocks[1].hash ||
+    blocks[0].hash.toLowerCase() !== blocks[1].hash.toLowerCase() ||
+    blocks[0].timestamp !== blocks[1].timestamp
+  ) {
+    throw new ProtocolRevenueKeeperV2Error("rpc_quorum_failed");
+  }
+  return { blockNumber, timestamp: blocks[0].timestamp } as const;
+}
+
+async function confirmedObservation(
+  clients: readonly [PublicClient, PublicClient],
+) {
+  let heads;
+  try {
+    heads = await Promise.all(
+      clients.map((current) => current.getBlock({ blockTag: "latest" })),
+    );
+  } catch {
+    throw new ProtocolRevenueKeeperV2Error("rpc_quorum_failed");
+  }
+  const lowestHead = heads[0].number < heads[1].number
+    ? heads[0].number
+    : heads[1].number;
+  if (lowestHead < 2n) {
+    throw new ProtocolRevenueKeeperV2Error("rpc_quorum_failed");
+  }
+  const blockNumber = lowestHead - 2n;
   const blocks = await Promise.all(
     clients.map((current) => current.getBlock({ blockNumber })),
   );
@@ -519,18 +554,21 @@ export async function runConfiguredProtocolRevenueKeeperV2(
     client(providers[0].endpoint),
     client(providers[1].endpoint),
   ] as const;
-  const observation = await finalizedObservation(clients);
+  const [stateObservation, priceObservation] = await Promise.all([
+    confirmedObservation(clients),
+    finalizedObservation(clients),
+  ]);
   await Promise.all([
     assertCodeBinding({
       clients,
       address: configuration.coordinator,
-      blockNumber: observation.blockNumber,
+      blockNumber: stateObservation.blockNumber,
       expectedCodeHash: configuration.coordinatorCodeHash,
     }),
     assertCodeBinding({
       clients,
       address: configuration.vault,
-      blockNumber: observation.blockNumber,
+      blockNumber: stateObservation.blockNumber,
       expectedCodeHash: configuration.vaultCodeHash,
     }),
   ]);
@@ -547,6 +585,7 @@ export async function runConfiguredProtocolRevenueKeeperV2(
     coordinatorRevenueAuthority,
     claimMinimumRevenue,
     claimAccruedRevenue,
+    coordinatorTotalClaimed,
     claimReady,
     vaultKeeper,
     vaultRevenueAuthority,
@@ -560,31 +599,39 @@ export async function runConfiguredProtocolRevenueKeeperV2(
     vaultMinimumRevenue,
     maximumObservationAge,
     pendingRevenue,
+    vaultTotalRevenueDeposited,
     vaultNextRunAt,
-    referenceTick,
     rewardWalletBalance,
   ] = await Promise.all([
-    readContractAgreement<Address>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "keeper", blockNumber: observation.blockNumber }),
-    readContractAgreement<Address>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "REVENUE_AUTHORITY", blockNumber: observation.blockNumber }),
-    readContractAgreement<bigint>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "MIN_ACCRUED_REVENUE", blockNumber: observation.blockNumber }),
-    readContractAgreement<bigint>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "accruedRevenue", blockNumber: observation.blockNumber }),
-    readContractAgreement<boolean>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "ready", blockNumber: observation.blockNumber }),
-    readContractAgreement<Address>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "keeper", blockNumber: observation.blockNumber }),
-    readContractAgreement<Address>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "REVENUE_AUTHORITY", blockNumber: observation.blockNumber }),
-    readContractAgreement<Address>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "TREASURY", blockNumber: observation.blockNumber }),
-    readContractAgreement<Address>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "V4_TOKEN", blockNumber: observation.blockNumber }),
-    readContractAgreement<number>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "TREASURY_SHARE_BPS", blockNumber: observation.blockNumber }),
-    readContractAgreement<number>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "BUY_SHARE_BPS", blockNumber: observation.blockNumber }),
-    readContractAgreement<number>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "KEEPER_GAS_SHARE_BPS", blockNumber: observation.blockNumber }),
-    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "CYCLE_INTERVAL", blockNumber: observation.blockNumber }),
-    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "MAX_DAILY_REVENUE", blockNumber: observation.blockNumber }),
-    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "MIN_NEW_REVENUE", blockNumber: observation.blockNumber }),
-    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "MAX_OBSERVATION_AGE", blockNumber: observation.blockNumber }),
-    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "pendingRevenue", blockNumber: observation.blockNumber }),
-    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "nextRunAt", blockNumber: observation.blockNumber }),
-    readContractAgreement<number>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "currentMainPoolTick", blockNumber: observation.blockNumber }),
-    agreed(clients, (current) => current.getBalance({ address: REVENUE_AUTHORITY, blockNumber: observation.blockNumber })),
+    readContractAgreement<Address>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "keeper", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<Address>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "REVENUE_AUTHORITY", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "MIN_ACCRUED_REVENUE", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "accruedRevenue", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "totalClaimed", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<boolean>({ clients, address: configuration.coordinator, abi: COORDINATOR_ABI, functionName: "ready", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<Address>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "keeper", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<Address>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "REVENUE_AUTHORITY", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<Address>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "TREASURY", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<Address>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "V4_TOKEN", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<number>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "TREASURY_SHARE_BPS", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<number>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "BUY_SHARE_BPS", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<number>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "KEEPER_GAS_SHARE_BPS", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "CYCLE_INTERVAL", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "MAX_DAILY_REVENUE", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "MIN_NEW_REVENUE", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "MAX_OBSERVATION_AGE", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "pendingRevenue", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "totalRevenueDeposited", blockNumber: stateObservation.blockNumber }),
+    readContractAgreement<bigint>({ clients, address: configuration.vault, abi: VAULT_ABI, functionName: "nextRunAt", blockNumber: stateObservation.blockNumber }),
+    agreed(clients, (current) => current.getBalance({ address: REVENUE_AUTHORITY, blockNumber: stateObservation.blockNumber })),
   ]);
+  const referenceTick = await readContractAgreement<number>({
+    clients,
+    address: configuration.vault,
+    abi: VAULT_ABI,
+    functionName: "currentMainPoolTick",
+    blockNumber: priceObservation.blockNumber,
+  });
   if (
     getAddress(coordinatorKeeper) !== account.address ||
     getAddress(vaultKeeper) !== account.address ||
@@ -604,9 +651,11 @@ export async function runConfiguredProtocolRevenueKeeperV2(
 
   const wallClock = BigInt(Math.floor(Date.now() / 1_000));
   if (
-    observation.timestamp > wallClock ||
-    wallClock - observation.timestamp > maximumObservationAge - 120n ||
-    observation.timestamp > maxUint64
+    stateObservation.timestamp > wallClock ||
+    wallClock - stateObservation.timestamp > 180n ||
+    priceObservation.timestamp > wallClock ||
+    wallClock - priceObservation.timestamp > maximumObservationAge - 120n ||
+    priceObservation.timestamp > maxUint64
   ) {
     throw new ProtocolRevenueKeeperV2Error("observation_stale");
   }
@@ -654,10 +703,13 @@ export async function runConfiguredProtocolRevenueKeeperV2(
   }
 
   const decision = evaluateProtocolRevenueV2Action({
-    finalizedTimestamp: observation.timestamp,
+    stateTimestamp: stateObservation.timestamp,
     pendingRevenue,
     vaultNextRunAt,
     vaultMinimumRevenue,
+    vaultMaximumRevenue: maximumDailyRevenue,
+    coordinatorTotalClaimed,
+    vaultTotalRevenueDeposited,
     rewardWalletBalance,
     permissionAvailable,
     maximumTransfer: configuration.maximumTransfer < maximumDailyRevenue
@@ -676,9 +728,13 @@ export async function runConfiguredProtocolRevenueKeeperV2(
   ) {
     return {
       status: decision.status,
-      finalizedBlockNumber: observation.blockNumber.toString(),
+      finalizedBlockNumber: priceObservation.blockNumber.toString(),
       availableRevenue: (
-        pendingRevenue + rewardWalletBalance + claimAccruedRevenue
+        pendingRevenue +
+        (coordinatorTotalClaimed >= vaultTotalRevenueDeposited
+          ? coordinatorTotalClaimed - vaultTotalRevenueDeposited
+          : 0n) +
+        claimAccruedRevenue
       ).toString(),
       ...(decision.status === "not_due"
         ? { nextRunAt: decision.nextRunAt.toString() }
@@ -693,7 +749,7 @@ export async function runConfiguredProtocolRevenueKeeperV2(
         data: encodeFunctionData({
           abi: VAULT_ABI,
           functionName: "process",
-          args: [observation.timestamp, referenceTick],
+          args: [priceObservation.timestamp, referenceTick],
         }),
         value: 0n,
         economicRevenue: decision.revenue,
@@ -765,7 +821,7 @@ export async function runConfiguredProtocolRevenueKeeperV2(
         ),
       ),
       Promise.all(clients.map((current) => current.estimateFeesPerGas())),
-      agreed(clients, (current) => current.getBalance({ address: account.address, blockNumber: observation.blockNumber })),
+      agreed(clients, (current) => current.getBalance({ address: account.address, blockNumber: stateObservation.blockNumber })),
     ]);
   } catch {
     throw new ProtocolRevenueKeeperV2Error("rpc_quorum_failed");
@@ -791,7 +847,7 @@ export async function runConfiguredProtocolRevenueKeeperV2(
   if (economics.status !== "ready") {
     return {
       status: economics.status,
-      finalizedBlockNumber: observation.blockNumber.toString(),
+      finalizedBlockNumber: priceObservation.blockNumber.toString(),
       availableRevenue: transaction.economicRevenue.toString(),
     };
   }
@@ -831,7 +887,7 @@ export async function runConfiguredProtocolRevenueKeeperV2(
     status: "submitted",
     action,
     transactionHash,
-    finalizedBlockNumber: observation.blockNumber.toString(),
+    finalizedBlockNumber: priceObservation.blockNumber.toString(),
     availableRevenue: transaction.economicRevenue.toString(),
     maximumGasCost: economics.maximumGasCost.toString(),
     keeperFunding: economics.keeperFunding.toString(),

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -22,7 +22,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     Object.freeze({
       id: "protocol-revenue",
       path: "/api/ops/protocol-revenue",
-      schedule: "*/15 * * * *",
+      schedule: "* * * * *",
       activationEnvironment: "PROTOCOL_REVENUE_AUTOMATION_ENABLED",
       route: Object.freeze({
         path: "app/api/ops/protocol-revenue/route.ts",
@@ -30,7 +30,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       }),
       runtime: Object.freeze({
         path: "lib/protocol-revenue/keeper-v2.server.ts",
-        sha256: "da027cf1f0a565715f921130604df968c63e78907b5829fc548a7619639c0e51",
+        sha256: "8a0b48fcc3cf3034c4be422cc6e9f35f5c7c224c2c45589b34b5798a3fd5a0d8",
       }),
       dependencies: Object.freeze([
         Object.freeze({
@@ -40,7 +40,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       ]),
       policy: Object.freeze({
         path: "lib/protocol-revenue/keeper-policy.ts",
-        sha256: "b515502c8ef81b99a3ba8d7867c76e6aeb346d2c9f2b50da4c0407fb54c46090",
+        sha256: "bb39f651c11e49173e5b07e42edd2bfa4a1c0e78e5b0345a47b338751e451787",
       }),
     }),
   ]),

--- a/tests/protocol-revenue-keeper-policy.test.ts
+++ b/tests/protocol-revenue-keeper-policy.test.ts
@@ -9,12 +9,15 @@ import {
 const DELEGATION_HASH = `0x${"11".repeat(32)}`;
 
 describe("protocol revenue keeper policy", () => {
-  it("processes, claims, then transfers in fail-closed priority order", () => {
+  it("processes due revenue before any other action", () => {
     const base = {
-      finalizedTimestamp: 2_000n,
+      stateTimestamp: 2_000n,
       pendingRevenue: 0n,
       vaultNextRunAt: 1_900n,
       vaultMinimumRevenue: 100n,
+      vaultMaximumRevenue: 1_000n,
+      coordinatorTotalClaimed: 0n,
+      vaultTotalRevenueDeposited: 0n,
       rewardWalletBalance: 0n,
       permissionAvailable: 1_000n,
       maximumTransfer: 500n,
@@ -28,38 +31,56 @@ describe("protocol revenue keeper policy", () => {
     expect(
       evaluateProtocolRevenueV2Action({ ...base, pendingRevenue: 300n }),
     ).toEqual({ status: "process", revenue: 300n });
-    expect(
-      evaluateProtocolRevenueV2Action({
-        ...base,
-        rewardWalletBalance: 900n,
-      }),
-    ).toEqual({ status: "transfer", amount: 500n });
-    expect(
-      evaluateProtocolRevenueV2Action({
-        ...base,
-        claimReady: true,
-        claimAccruedRevenue: 200n,
-      }),
-    ).toEqual({ status: "claim", accruedRevenue: 200n });
-    expect(
-      evaluateProtocolRevenueV2Action({
-        ...base,
-        rewardWalletBalance: 900n,
-        claimReady: true,
-        claimAccruedRevenue: 200n,
-      }),
-    ).toEqual({ status: "claim", accruedRevenue: 200n });
   });
 
-  it("keeps the daily claim cadence independent from a waiting vault cycle", () => {
+  it("transfers the complete unprocessed claim instead of the wallet balance", () => {
     const base = {
-      finalizedTimestamp: 2_000n,
+      stateTimestamp: 2_000n,
       pendingRevenue: 200n,
       vaultNextRunAt: 2_100n,
       vaultMinimumRevenue: 100n,
+      vaultMaximumRevenue: 2_000n,
+      coordinatorTotalClaimed: 1_000n,
+      vaultTotalRevenueDeposited: 300n,
+      rewardWalletBalance: 1_500n,
+      permissionAvailable: 1_500n,
+      maximumTransfer: 1_500n,
+      claimReady: false,
+      claimAccruedRevenue: 0n,
+      claimMinimumRevenue: 100n,
+      latestNonce: 7,
+      pendingNonce: 7,
+    } as const;
+
+    expect(
+      evaluateProtocolRevenueV2Action(base),
+    ).toEqual({ status: "transfer", amount: 700n });
+    expect(
+      evaluateProtocolRevenueV2Action({
+        ...base,
+        rewardWalletBalance: 699n,
+      }),
+    ).toEqual({ status: "permission_exhausted" });
+    expect(
+      evaluateProtocolRevenueV2Action({
+        ...base,
+        vaultTotalRevenueDeposited: 1_001n,
+      }),
+    ).toEqual({ status: "accounting_mismatch" });
+  });
+
+  it("claims only inside the five-minute window before the vault cycle", () => {
+    const base = {
+      stateTimestamp: 2_000n,
+      pendingRevenue: 0n,
+      vaultNextRunAt: 2_500n,
+      vaultMinimumRevenue: 100n,
+      vaultMaximumRevenue: 2_000n,
+      coordinatorTotalClaimed: 1_000n,
+      vaultTotalRevenueDeposited: 1_000n,
       rewardWalletBalance: 500n,
-      permissionAvailable: 0n,
-      maximumTransfer: 500n,
+      permissionAvailable: 1_000n,
+      maximumTransfer: 1_000n,
       claimReady: true,
       claimAccruedRevenue: 300n,
       claimMinimumRevenue: 100n,
@@ -67,6 +88,13 @@ describe("protocol revenue keeper policy", () => {
       pendingNonce: 7,
     } as const;
     expect(evaluateProtocolRevenueV2Action(base)).toEqual({
+      status: "not_due",
+      nextRunAt: 2_200n,
+    });
+    expect(evaluateProtocolRevenueV2Action({
+      ...base,
+      stateTimestamp: 2_200n,
+    })).toEqual({
       status: "claim",
       accruedRevenue: 300n,
     });
@@ -75,23 +103,33 @@ describe("protocol revenue keeper policy", () => {
         ...base,
         claimReady: false,
       }),
-    ).toEqual({ status: "not_due", nextRunAt: 2_100n });
-    expect(
-      evaluateProtocolRevenueV2Action({
-        ...base,
-        pendingRevenue: 0n,
-      }),
-    ).toEqual({ status: "claim", accruedRevenue: 300n });
-    expect(
-      evaluateProtocolRevenueV2Action({
-        ...base,
-        pendingRevenue: 0n,
-        claimReady: false,
-      }),
-    ).toEqual({ status: "permission_exhausted" });
+    ).toEqual({ status: "below_minimum", minimumRevenue: 100n });
     expect(
       evaluateProtocolRevenueV2Action({ ...base, pendingNonce: 8 }),
     ).toEqual({ status: "pending_transaction" });
+  });
+
+  it("catches up the exact live untransferred claim balance", () => {
+    expect(evaluateProtocolRevenueV2Action({
+      stateTimestamp: 1_785_973_700n,
+      pendingRevenue: 100_000_000_000_000_000n,
+      vaultNextRunAt: 1_786_020_347n,
+      vaultMinimumRevenue: 1_000_000_000_000_000n,
+      vaultMaximumRevenue: 5_000_000_000_000_000_000n,
+      coordinatorTotalClaimed: 1_051_686_789_475_590_097n,
+      vaultTotalRevenueDeposited: 300_000_000_000_000_000n,
+      rewardWalletBalance: 830_100_252_895_636_119n,
+      permissionAvailable: 4_700_000_000_000_000_000n,
+      maximumTransfer: 5_000_000_000_000_000_000n,
+      claimReady: false,
+      claimAccruedRevenue: 0n,
+      claimMinimumRevenue: 1_000_000_000_000_000n,
+      latestNonce: 7,
+      pendingNonce: 7,
+    })).toEqual({
+      status: "transfer",
+      amount: 751_686_789_475_590_097n,
+    });
   });
 
   it("requires a live delegation, due cadence, minimum revenue and clear nonce", () => {

--- a/vercel.json
+++ b/vercel.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "/api/ops/protocol-revenue",
-      "schedule": "*/15 * * * *"
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- transfer the exact unprocessed claimed revenue instead of a fixed chunk
- align daily claims to the final five minutes before the buyback window
- check the keeper every minute while retaining dual-RPC state confirmation and finalized price observations
- fail closed on accounting mismatches or any incomplete transfer capacity

## Verification

- `npm run verify`
- 1,944 tests passed; 7 skipped
- production build passed
- operations source and schedule bindings passed