### PR TITLE
Clarify Custom launch search copy

### DIFF
--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -53,7 +53,7 @@ export const docsSearchItems: DocsSearchItem[] = [
   {
     title: "Launch provider integration",
     description:
-      "Register Basebit and future provider templates through authenticated atomic provenance.",
+      "Register approved external hook launches through authenticated atomic provenance in the Custom Registry.",
     href: "/docs/developers#providers",
   },
   {

--- a/tests/developer-docs-experience.test.ts
+++ b/tests/developer-docs-experience.test.ts
@@ -23,6 +23,7 @@ const docsSearch = readFileSync(
   join(root, "components/docs-search.tsx"),
   "utf8",
 );
+const docsData = readFileSync(join(root, "components/docs-data.ts"), "utf8");
 const workbench = readFileSync(
   join(root, "components/developer-docs-workbench.tsx"),
   "utf8",
@@ -44,6 +45,9 @@ describe("Developer documentation experience", () => {
 
   it("keeps search result keys unique when several terms point to one section", () => {
     expect(docsSearch).toContain("key={`${item.href}:${item.title}`}");
+    expect(docsData).toContain("approved external hook launches");
+    expect(docsData).toContain("Custom Registry");
+    expect(docsData).not.toContain("Basebit");
   });
 
   it("provides copy-ready examples and machine-readable entry points", () => {


### PR DESCRIPTION
## Summary
- remove the provider-specific Basebit reference from the public docs search
- describe the canonical Custom Registry path for approved external hook launches
- add a regression assertion for provider-neutral search copy

## Validation
- `npm test -- --run tests/developer-docs-experience.test.ts` (10/10)
- `npx prettier --check components/docs-data.ts tests/developer-docs-experience.test.ts`
- `git diff --check`