### PR TITLE
Redesign shared surfaces with liquid glass

### DIFF
--- a/app/interface.css
+++ b/app/interface.css
@@ -10,31 +10,42 @@
   --radius-control: 18px;
   --radius-control-inner: 14px;
   --radius-panel: 28px;
-  --liquid-glass-surface-background: rgba(8, 18, 40, 0.34);
-  --liquid-glass-surface-background-strong: rgba(8, 18, 40, 0.52);
-  --liquid-glass-inner-background: rgba(255, 255, 255, 0.055);
-  --liquid-glass-control-background: rgba(255, 255, 255, 0.07);
-  --liquid-glass-control-background-hover: rgba(255, 255, 255, 0.12);
-  --liquid-glass-border: rgba(255, 255, 255, 0.16);
-  --liquid-glass-border-strong: rgba(255, 255, 255, 0.22);
-  --liquid-glass-highlight: rgba(255, 255, 255, 0.1);
-  --liquid-glass-backdrop: blur(18px) saturate(1.34);
+  --liquid-glass-surface-background: oklch(0.185 0.028 264 / 0.72);
+  --liquid-glass-surface-background-strong: oklch(0.17 0.024 264 / 0.86);
+  --liquid-glass-inner-background: oklch(0.94 0.008 85 / 0.055);
+  --liquid-glass-control-background: oklch(0.94 0.008 85 / 0.074);
+  --liquid-glass-control-background-hover: oklch(0.94 0.008 85 / 0.12);
+  --liquid-glass-border: oklch(0.95 0.008 85 / 0.105);
+  --liquid-glass-border-strong: oklch(0.96 0.007 85 / 0.17);
+  --liquid-glass-highlight: oklch(0.98 0.006 85 / 0.14);
+  --liquid-glass-backdrop: blur(22px) saturate(1.08);
   --liquid-glass-shadow:
-    inset 0 0 6px -3px rgba(255, 255, 255, 0.7),
-    inset 0 0 88px rgba(99, 133, 196, 0.035),
-    0 18px 48px rgba(1, 5, 20, 0.2);
-  --navigation-glass-background: rgba(5, 11, 30, 0.42);
-  --navigation-glass-background-hover: rgba(18, 33, 60, 0.68);
-  --navigation-glass-border: rgba(255, 253, 249, 0.18);
-  --navigation-glass-highlight: rgba(255, 255, 255, 0.08);
+    inset 0 1px 0 oklch(0.99 0.004 85 / 0.13),
+    inset 0 -1px 0 oklch(0.08 0.018 264 / 0.42),
+    0 0 0 1px oklch(0.08 0.02 264 / 0.18),
+    0 12px 28px oklch(0.07 0.022 264 / 0.2),
+    0 30px 70px oklch(0.07 0.022 264 / 0.12);
+  --liquid-glass-control-shadow:
+    inset 0 1px 0 oklch(0.99 0.004 85 / 0.12),
+    inset 0 -1px 0 oklch(0.08 0.018 264 / 0.28),
+    0 0 0 1px oklch(0.08 0.02 264 / 0.14),
+    0 8px 20px oklch(0.07 0.022 264 / 0.16);
+  --liquid-glass-inner-shadow:
+    inset 0 1px 0 oklch(0.99 0.004 85 / 0.07),
+    0 0 0 1px oklch(0.08 0.02 264 / 0.12);
+  --navigation-glass-background: oklch(0.16 0.025 264 / 0.8);
+  --navigation-glass-background-hover: oklch(0.24 0.027 264 / 0.74);
+  --navigation-glass-border: oklch(0.95 0.008 85 / 0.11);
+  --navigation-glass-highlight: oklch(0.99 0.004 85 / 0.13);
   --navigation-glass-ink: #fffdf9;
   --navigation-glass-ink-muted: rgba(255, 253, 249, 0.68);
   --navigation-glass-accent: rgba(255, 255, 255, 0.085);
   --navigation-glass-backdrop: var(--liquid-glass-backdrop);
   --navigation-glass-shadow:
     inset 0 1px 0 var(--navigation-glass-highlight),
-    inset 0 0 80px rgba(116, 151, 213, 0.04),
-    0 18px 48px rgba(1, 5, 20, 0.2);
+    inset 0 -1px 0 oklch(0.08 0.018 264 / 0.36),
+    0 0 0 1px oklch(0.08 0.02 264 / 0.16),
+    0 12px 30px oklch(0.07 0.022 264 / 0.2);
   --control-glass-background: var(--liquid-glass-control-background);
   --control-glass-background-strong: var(--liquid-glass-surface-background-strong);
   --control-glass-background-hover: var(--liquid-glass-control-background-hover);
@@ -73,9 +84,9 @@ html[data-theme="light"] {
 
 html[data-theme="dark"] {
   --canvas: rgba(5, 11, 30, 0.2);
-  --surface: rgba(9, 18, 38, 0.68);
-  --surface-raised: rgba(15, 28, 50, 0.72);
-  --surface-soft: rgba(24, 40, 66, 0.58);
+  --surface: var(--liquid-glass-surface-background);
+  --surface-raised: var(--liquid-glass-surface-background-strong);
+  --surface-soft: var(--liquid-glass-inner-background);
   --text: #f7f1ea;
   --text-soft: #d5cec6;
   --muted: #aaa39b;
@@ -111,6 +122,7 @@ html {
 
 body {
   background: #050b1c;
+  font-feature-settings: "kern" 1, "liga" 1;
   font-kerning: normal;
   font-synthesis: style;
   letter-spacing: -0.006em;
@@ -217,11 +229,14 @@ html[data-theme="dark"] .app-frame::before {
   backdrop-filter: var(--control-glass-backdrop);
   background: var(--liquid-glass-control-background);
   border-color: var(--liquid-glass-border);
-  box-shadow:
-    inset 0 0 5px -3px rgba(255, 255, 255, 0.72),
-    0 9px 26px rgba(1, 5, 20, 0.16);
+  box-shadow: var(--liquid-glass-control-shadow);
 }
 
+.liquid-glass-popover {
+  position: absolute;
+}
+
+.liquid-glass-surface::after,
 .liquid-glass-distortion::after {
   -webkit-backdrop-filter: var(--liquid-glass-backdrop);
   -webkit-filter: url("#glass-distortion");
@@ -233,6 +248,16 @@ html[data-theme="dark"] .app-frame::before {
   pointer-events: none;
   position: absolute;
   z-index: -1;
+}
+
+/* Keep the refractive layer behind content and disable it where browsers
+ * cannot render the SVG displacement cleanly. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .liquid-glass-surface::after,
+  .liquid-glass-distortion::after {
+    -webkit-filter: none;
+    filter: none;
+  }
 }
 
 /* Persistent night atmosphere */
@@ -657,10 +682,7 @@ html[data-theme="dark"] .app-frame::before {
   backdrop-filter: var(--control-glass-backdrop);
   background: var(--control-glass-background);
   border-color: var(--control-glass-border);
-  box-shadow:
-    inset 0 1px 0 var(--control-glass-highlight),
-    inset 0 0 44px color-mix(in srgb, var(--brand-pink) 2.5%, transparent),
-    0 9px 26px var(--control-glass-shadow-color);
+  box-shadow: var(--liquid-glass-control-shadow);
 }
 
 .header-actions .wallet-button {
@@ -668,9 +690,7 @@ html[data-theme="dark"] .app-frame::before {
   backdrop-filter: var(--control-glass-backdrop);
   background: var(--liquid-glass-control-background);
   border-color: var(--liquid-glass-border);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 8px 22px rgba(1, 5, 20, 0.16);
+  box-shadow: var(--liquid-glass-control-shadow);
   color: var(--navigation-glass-ink);
 }
 
@@ -701,10 +721,7 @@ html[data-theme="dark"] .app-frame::before {
   background: var(--accent-glass-background);
   border: 1px solid var(--accent-glass-border);
   color: var(--brand-pink-ink);
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, white 22%, transparent),
-    inset 0 0 42px color-mix(in srgb, white 4%, transparent),
-    0 8px 22px color-mix(in srgb, var(--brand-pink-action) 18%, transparent);
+  box-shadow: var(--liquid-glass-control-shadow);
 }
 
 .wallet-button,
@@ -776,9 +793,7 @@ html[data-theme="dark"] .app-frame::before {
 .token-search,
 .token-filter summary,
 .token-pagination {
-  box-shadow:
-    0 1px 0 color-mix(in srgb, white 6%, transparent),
-    0 8px 24px var(--card-shadow-soft);
+  box-shadow: var(--liquid-glass-control-shadow);
 }
 
 .token-search {
@@ -866,15 +881,12 @@ html[data-theme="dark"] .app-frame::before {
 .token-card,
 .token-card:nth-child(10):last-child {
   animation: interface-card-fade 130ms ease-out both;
-  background:
-    linear-gradient(
-      165deg,
-      color-mix(in srgb, var(--glass-96) 96%, transparent),
-      color-mix(in srgb, var(--glass-82) 88%, transparent)
-    );
-  border-color: var(--panel-border-soft);
+  -webkit-backdrop-filter: var(--liquid-glass-backdrop);
+  backdrop-filter: var(--liquid-glass-backdrop);
+  background: var(--liquid-glass-surface-background);
+  border-color: var(--liquid-glass-border);
   border-radius: 20px;
-  box-shadow: var(--shadow-resting);
+  box-shadow: var(--liquid-glass-shadow);
 }
 
 @keyframes interface-card-fade {
@@ -931,13 +943,17 @@ html[data-theme="dark"] .app-frame::before {
 }
 
 .token-card-market-cap strong {
-  font-size: 13px;
-  letter-spacing: -0.03em;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 13.5px;
+  font-weight: 600;
+  letter-spacing: -0.018em;
 }
 
 .token-card-market-cap span {
+  font-family: var(--font-instrument), Arial, sans-serif;
   font-size: 12px;
-  letter-spacing: 0.04em;
+  font-weight: 540;
+  letter-spacing: 0;
 }
 
 .token-card-footer {
@@ -984,8 +1000,8 @@ html[data-theme="dark"] .app-frame::before {
 }
 
 .launch-model-card {
-  border-color: var(--panel-border-soft);
-  box-shadow: var(--shadow-resting);
+  border-color: var(--liquid-glass-border);
+  box-shadow: var(--liquid-glass-shadow);
 }
 
 .launch-model-art {

--- a/components/docs-experience.module.css
+++ b/components/docs-experience.module.css
@@ -1188,6 +1188,7 @@
   .sidebarSearch {
     position: sticky;
     top: 0;
+    z-index: 2;
   }
 
   .mobileNav {
@@ -1201,6 +1202,8 @@
       0 12px 30px var(--control-glass-shadow-color);
     display: block;
     overflow: hidden;
+    position: relative;
+    z-index: 1;
   }
 
   .mobileNav summary {

--- a/components/docs-search.tsx
+++ b/components/docs-search.tsx
@@ -303,7 +303,7 @@ export function DocsSearch() {
       </span>
       {isOpen && normalizedQuery ? (
         <div
-          className={`${styles.searchResults} liquid-glass-surface liquid-glass-distortion`}
+          className={`${styles.searchResults} liquid-glass-surface liquid-glass-distortion liquid-glass-popover`}
           id={listboxId}
           role="listbox"
           aria-label="Documentation search results"

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -189,13 +189,13 @@
 
 .filterLabel {
   color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.08em;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 620;
+  letter-spacing: -0.005em;
   line-height: 1.2;
   margin: 8px 11px 5px;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .activeFilterCount {
@@ -204,8 +204,8 @@
   border-radius: 5px;
   color: var(--explore-pink-strong);
   display: inline-flex;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
   height: 18px;
   justify-content: center;
@@ -227,9 +227,7 @@
   background: var(--liquid-glass-surface-background);
   border: 1px solid var(--liquid-glass-border);
   border-radius: 24px;
-  box-shadow:
-    inset 0 0 5px -3px rgba(255, 255, 255, 0.64),
-    0 16px 40px rgba(1, 5, 20, 0.17);
+  box-shadow: var(--liquid-glass-shadow);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -333,11 +331,12 @@
   color: var(--text);
   display: inline-flex;
   flex: none;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 13.5px;
   font-variant-numeric: tabular-nums;
-  gap: 7px;
-  letter-spacing: -0.01em;
+  font-weight: 585;
+  gap: 5px;
+  letter-spacing: -0.018em;
   line-height: 1.35;
   max-width: calc(100% - 2px);
   overflow: hidden;
@@ -347,8 +346,9 @@
 
 .runnerMarketCapLabel {
   color: var(--muted);
-  font-size: 10.5px;
-  letter-spacing: 0.08em;
+  font-size: 12px;
+  font-weight: 540;
+  letter-spacing: 0;
 }
 
 .runnerMarketCapValue {
@@ -549,7 +549,7 @@
 
 :global(html[data-theme="dark"]) .runnerCard,
 :global(html[data-theme="dark"]) .emptyState {
-  box-shadow: none;
+  box-shadow: var(--liquid-glass-shadow);
 }
 
 @media (max-width: 900px) {
@@ -612,13 +612,32 @@
   }
 
   .runnersIntro :global(.token-toolbar) {
+    align-items: start;
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .runnersIntro :global(.token-search) {
+    align-self: start;
+    height: 44px;
     max-width: none;
     width: 100%;
+  }
+
+  .runnersIntro :global(.token-filter) {
+    align-self: start;
+    width: 100px;
+  }
+
+  .runnersIntro :global(.token-filter summary) {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .runnersIntro .filterMenu {
+    inset-inline: auto 0;
+    min-width: 0;
+    width: 232px;
   }
 
   .runnersIntro :global(.token-search input) {
@@ -690,6 +709,10 @@
 
   .runnersIntro :global(.token-toolbar) {
     gap: 8px;
+  }
+
+  .runnersIntro :global(.token-filter) {
+    width: 44px;
   }
 
   .runnerHitArea {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1231,7 +1231,7 @@ export function ExploreView() {
                     </summary>
                     <div
                       id="explore-filter-panel"
-                      className={`token-filter-menu ${styles.filterMenu} liquid-glass-surface liquid-glass-distortion`}
+                      className={`token-filter-menu ${styles.filterMenu} liquid-glass-surface liquid-glass-distortion liquid-glass-popover`}
                       role="group"
                       aria-label="Filter and sort tokens"
                     >

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -387,8 +387,9 @@
   border-color: var(--panel-border);
   border-radius: 12px;
   color: var(--text-soft);
-  font-size: 10px;
-  letter-spacing: 0.015em;
+  font-size: 12px;
+  font-weight: 560;
+  letter-spacing: -0.005em;
   padding: 6px 8px;
 }
 
@@ -417,7 +418,8 @@
   border-left: 1px solid var(--panel-border-soft);
   color: var(--muted);
   display: flex;
-  font-size: 10.5px;
+  font-size: 12px;
+  font-weight: 540;
   line-height: 1.35;
   min-height: 32px;
   padding: 0 12px;
@@ -728,7 +730,7 @@
 
 .formPage :global(.classic-link-disclosure summary small) {
   color: var(--muted);
-  font-size: 10.5px;
+  font-size: 12px;
   font-weight: 540;
 }
 

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -209,9 +209,7 @@
   backdrop-filter: var(--control-glass-backdrop);
   background: var(--accent-glass-background);
   border-color: var(--accent-glass-border);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    0 9px 26px var(--control-glass-shadow-color);
+  box-shadow: var(--liquid-glass-control-shadow);
   color: var(--text);
 }
 
@@ -335,6 +333,7 @@
   background: var(--profile-subtle);
   border: 1px solid color-mix(in srgb, var(--liquid-glass-border) 72%, transparent);
   border-radius: 17px;
+  box-shadow: var(--liquid-glass-inner-shadow);
   display: flex;
   flex-direction: column;
   min-height: 500px;
@@ -362,8 +361,9 @@
 
 .panelStatus {
   color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 9px;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 540;
   line-height: 1.3;
   margin-inline-start: auto;
   overflow-wrap: anywhere;
@@ -388,6 +388,7 @@
   background: var(--profile-subtle);
   border: 1px solid var(--profile-line);
   border-radius: 14px;
+  box-shadow: var(--liquid-glass-inner-shadow);
   gap: 2px;
   padding: 3px;
 }
@@ -397,8 +398,8 @@
   border: 0;
   border-radius: 11px;
   color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
   height: 40px;
@@ -429,21 +430,21 @@
 
 .feeSummaryLabel {
   color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.045em;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 560;
+  letter-spacing: -0.005em;
   line-height: 1.3;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .feeSummary > strong {
   color: var(--text);
-  font-family: var(--font-plex-mono), monospace;
+  font-family: var(--font-instrument), Arial, sans-serif;
   font-size: clamp(38px, 4vw, 52px);
   font-variant-numeric: tabular-nums;
-  font-weight: 500;
-  letter-spacing: -0.06em;
+  font-weight: 560;
+  letter-spacing: -0.05em;
   line-height: 0.98;
   margin-block-start: 8px;
   overflow-wrap: anywhere;
@@ -467,7 +468,7 @@
 
 .feeBreakdown b {
   color: var(--text-soft);
-  font-family: var(--font-plex-mono), monospace;
+  font-family: var(--font-instrument), Arial, sans-serif;
   font-variant-numeric: tabular-nums;
   font-weight: 500;
 }
@@ -548,8 +549,8 @@
   align-items: center;
   color: var(--muted);
   display: flex;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
   grid-column: 1;
   grid-row: 2;
@@ -691,9 +692,9 @@
 
 .claimCopy span {
   color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
-  font-weight: 500;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 540;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -708,7 +709,7 @@
 .claimAmount > span,
 .claimAmount small {
   color: var(--muted);
-  font-size: 10px;
+  font-size: 11px;
   line-height: 1.25;
 }
 
@@ -724,8 +725,8 @@
 }
 
 .claimAmount strong {
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 13px;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
   line-height: 1.3;
@@ -864,11 +865,11 @@
 
 .claimDialogHeader > div > span {
   color: var(--profile-pink);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 620;
+  letter-spacing: -0.005em;
+  text-transform: none;
 }
 
 .claimDialogHeader h3 {
@@ -889,9 +890,9 @@
 
 .claimDialogHeader p small {
   color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
-  font-weight: 500;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 11px;
+  font-weight: 540;
   white-space: nowrap;
 }
 
@@ -928,7 +929,7 @@
 
 .claimDialogGroup > header span {
   color: var(--muted);
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 620;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -937,8 +938,8 @@
 
 .claimDialogGroup > header strong {
   flex: none;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
 }

--- a/components/site-footer.module.css
+++ b/components/site-footer.module.css
@@ -52,9 +52,9 @@
 
 .copyright {
   color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10.5px;
-  letter-spacing: 0.02em;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
+  letter-spacing: -0.005em;
   line-height: 1.5;
   margin: 0;
 }
@@ -75,13 +75,13 @@
 
 .label {
   color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 620;
+  letter-spacing: -0.005em;
   line-height: 1.5;
   margin: 0;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .column ul {

--- a/components/token-community-chat.module.css
+++ b/components/token-community-chat.module.css
@@ -118,7 +118,7 @@
   background: var(--liquid-glass-inner-background);
   border: 1px solid var(--liquid-glass-border);
   border-radius: 17px;
-  box-shadow: none;
+  box-shadow: var(--liquid-glass-inner-shadow);
   display: grid;
   gap: 7px;
   grid-template-columns: 36px minmax(0, 1fr) auto;
@@ -154,7 +154,7 @@
   background: var(--accent-glass-background);
   border: 1px solid var(--accent-glass-border);
   border-radius: 11px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  box-shadow: var(--liquid-glass-control-shadow);
   color: var(--text);
   display: inline-flex;
   font-size: 11.5px;

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -144,8 +144,8 @@
   display: inline-flex;
   flex: none;
   font-family: var(--font-plex-mono), monospace;
-  font-size: 9px;
-  font-weight: 700;
+  font-size: 11px;
+  font-weight: 650;
   gap: 4px;
   height: auto;
   justify-content: center;
@@ -165,9 +165,7 @@
   background: var(--control-glass-background);
   border: 1px solid var(--control-glass-border);
   border-radius: var(--radius-control);
-  box-shadow:
-    inset 0 1px 0 var(--control-glass-highlight),
-    0 8px 24px var(--control-glass-shadow-color);
+  box-shadow: var(--liquid-glass-control-shadow);
   color: var(--text-soft);
   display: inline-flex;
   min-height: 44px;
@@ -275,17 +273,21 @@
 
 .metric dt {
   color: var(--muted);
-  font-size: 10px;
-  line-height: 1.2;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 540;
+  letter-spacing: -0.005em;
+  line-height: 1.3;
 }
 
 .metric dd {
   color: var(--text);
-  font-size: clamp(16px, 1.55vw, 19px);
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: clamp(17px, 1.55vw, 20px);
   font-variant-numeric: tabular-nums;
-  font-weight: 610;
-  letter-spacing: -0.022em;
-  margin: 3px 0 0;
+  font-weight: 620;
+  letter-spacing: -0.028em;
+  margin: 4px 0 0;
   overflow-wrap: anywhere;
 }
 
@@ -614,7 +616,7 @@
   background: var(--liquid-glass-inner-background);
   border: 1px solid var(--liquid-glass-border);
   border-radius: 16px;
-  box-shadow: none;
+  box-shadow: var(--liquid-glass-inner-shadow);
   display: grid;
   gap: 4px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -665,6 +667,7 @@
   background: var(--liquid-glass-inner-background);
   border: 1px solid var(--liquid-glass-border);
   border-radius: 17px;
+  box-shadow: var(--liquid-glass-inner-shadow);
   margin-top: 12px;
   min-height: 116px;
   padding: 10px 14px 9px;
@@ -832,6 +835,7 @@
   background: var(--liquid-glass-control-background);
   border: 1px solid var(--liquid-glass-border);
   border-radius: 15px;
+  box-shadow: var(--liquid-glass-inner-shadow);
   display: inline-flex;
   min-height: 38px;
   overflow: hidden;
@@ -922,9 +926,7 @@
   backdrop-filter: var(--control-glass-backdrop);
   background: var(--accent-glass-background);
   border: 1px solid var(--accent-glass-border);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    0 9px 26px var(--control-glass-shadow-color);
+  box-shadow: var(--liquid-glass-control-shadow);
   color: var(--text);
   width: 100%;
 }
@@ -940,7 +942,7 @@
 .secondaryAction {
   background: var(--liquid-glass-control-background);
   border: 1px solid var(--liquid-glass-border);
-  box-shadow: none;
+  box-shadow: var(--liquid-glass-control-shadow);
   color: var(--text);
 }
 

--- a/components/token-price-chart.module.css
+++ b/components/token-price-chart.module.css
@@ -24,9 +24,10 @@
 
 .eyebrow {
   color: var(--muted);
-  font-size: 11px;
-  font-weight: 620;
-  letter-spacing: 0.015em;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 560;
+  letter-spacing: -0.005em;
   margin: 0 0 4px;
 }
 
@@ -45,7 +46,7 @@
   background: var(--liquid-glass-inner-background);
   border: 1px solid var(--liquid-glass-border);
   border-radius: 14px;
-  box-shadow: none;
+  box-shadow: var(--liquid-glass-inner-shadow);
   display: flex;
   gap: 2px;
   padding: 3px;
@@ -56,8 +57,9 @@
   border: 0;
   border-radius: 11px;
   color: var(--muted);
-  font-size: 10px;
-  font-weight: 700;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 11px;
+  font-weight: 650;
   height: 38px;
   letter-spacing: 0.025em;
   min-width: 40px;
@@ -148,7 +150,7 @@
   background: var(--liquid-glass-surface-background-strong);
   border: 1px solid var(--liquid-glass-border);
   border-radius: 11px;
-  box-shadow: 0 10px 28px color-mix(in srgb, black 14%, transparent);
+  box-shadow: var(--liquid-glass-control-shadow);
   display: grid;
   gap: 2px;
   max-width: calc(100% - 16px);
@@ -166,14 +168,14 @@
 
 .tooltip strong {
   color: var(--text);
-  font-size: 11px;
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
   font-weight: 680;
 }
 
 .tooltip span {
   color: var(--muted);
-  font-size: 9px;
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary
- unify navigation, cards, panels, filters, inputs, charts and footer under one restrained liquid-glass material system
- replace non-semantic miniature monospace labels with Instrument Sans while retaining mono for code and addresses
- fix mobile Explore filter sizing/positioning and Docs search-result stacking

## Validation
- npm run typecheck
- npm run lint (0 errors; existing warnings only)
- npx vitest run tests/interaction-accessibility.test.ts tests/explore-ui-contract.test.ts tests/explore-view-state.test.ts tests/docs-layout-stability.test.ts tests/docs-navigation.test.ts tests/token-detail-layout.test.ts tests/token-price-chart-refresh.test.ts tests/profile-view.test.ts (95/95)
- npm run build
- rendered QA at 1440x900, 390x844, and 320x760