### PR TITLE
Activate finalized Custom Registry discovery

### DIFF
--- a/config/custom-registry-genesis-canary-v1.json
+++ b/config/custom-registry-genesis-canary-v1.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": "programmable.custom-registry-genesis-canary-evidence.v1",
+  "chainId": "1",
+  "registryGeneration": "1",
+  "minimumFinalityBlocks": 64,
+  "registry": {
+    "address": "0x17e18c88bda9bfb73924cdc989c07b0707e72671",
+    "startBlock": "25701139",
+    "runtimeCodeHash": "0xa3276868befc509594adea6c5bd81c3c1bd013686f03fd57914fd39c917185f7"
+  },
+  "partnerFactoryRegistry": {
+    "address": "0xf8aef69201621ad20fa256da595426b7e6192dba",
+    "startBlock": "25701136",
+    "runtimeCodeHash": "0xc059ec5b84a2f4b9a63fe2f4361d92c36e1a0f94af1189f17f70c60844016426"
+  },
+  "atomicRegistrar": {
+    "address": "0xcc916e5200d2626edfd918dc219bc4296629e997",
+    "startBlock": "25701142",
+    "runtimeCodeHash": "0xae00412005beb660afba47767240cf771bf3c65306d68c1a7bfcb8fe2c0450f5"
+  },
+  "source": {
+    "repository": "https://github.com/0xprogrammable/programmable",
+    "repositoryOwner": "0xprogrammable",
+    "repositoryId": "1314365508",
+    "sourceCommit": "aaf1dd5b4f5483eb9cd5eb9c10386dd9c4b1d633",
+    "sourceTree": "54ba95aa741b79d4d3e119fe6bf6e578f602f7a3",
+    "sourcePath": "contracts/src/ProgrammableCustomRegistryGenesisCanaryV1.sol"
+  },
+  "identity": {
+    "projectId": "sha256:897608bd2a9e7758334d4fb82153dffdcff016d742b87e0b490e8cf98b63a8ff",
+    "launchId": "sha256:329016f555ac688de1980078680f783b3e9a59f098b054a4d0cb4044a5b5594e",
+    "primaryContract": "0x1d70acbbe83283b1597401569efead0ba5312e28",
+    "launchWallet": "0x2bb333d48dfaf1596d9036671d2e43168994249e",
+    "providerId": "programmable",
+    "modelId": "programmable.registry-genesis-canary",
+    "modelVersion": "1.0.0",
+    "templateId": "programmable.registry-genesis-project-only",
+    "templateVersion": "1.0.0"
+  },
+  "approval": {
+    "approvalId": "0x917b38bfc782a78ef9ae06dddb99d709583ec1fa8c16eb3316208e2ceb26eec1",
+    "approvalBindingHash": "0x7af21731951e46b6ae4404300151e4835f669896ec1b5fb494009ee88797851b",
+    "configurationHash": "0xac9064bed5278c749616bac7ae3f1de5f8957f075ff847ff1ad62efe395c4f05",
+    "permissionsHash": "0x392d6ddbf3e0b3ca7b9cb33b7a19ca227ab22e63e8e0a11b1b83f2f77eec51e5",
+    "primaryRuntimeCodeHash": "0x0a35193128df07793da86d662570c331e61b4e1c3a96dc2378a2660f964eec8a",
+    "registeredRecordCommitment": "0xcecd6a9c03afc9ac241f11015579d4ff57aeebf841dca022933c001f2e59b64a",
+    "feePolicyHash": "0x9ac095a1e14f80666e430b3cd65899398e10af0756365f911f1eb048be5b5977",
+    "finalityPolicyHash": "0x30991a4ebef393737148f7986c880a4af602691e059ad428aa9ca17c6b4066ff"
+  },
+  "registration": {
+    "transactionHash": "0x71efe312d6d74030744174bfe8d5b3d82e6599915eb3108897076b0f392652db",
+    "blockNumber": "25701424",
+    "blockHash": "0x39e1cf216dbaa12313bde3faf93aba607701b68d73a3c9601ffc9eeacec1e046",
+    "transactionIndex": 148,
+    "logIndex": 408,
+    "timestamp": "2026-08-07T06:54:23.000Z"
+  },
+  "finality": {
+    "evidenceHash": "0x6b7f7e4686ce098b3630a5578234c402409caac9134b503abb298c33ba8b6127",
+    "confirmedHeadBlockNumber": "25701500",
+    "confirmedHeadBlockHash": "0x6125e46e57172cf9600842dc5337f88f2ad98f01e32be09cb573a9da9d325e0a",
+    "transactionHash": "0xe5ee79bdf308f0e3b62854aed8a7209beb7fff811689fe3b0b58fc3837f31775",
+    "blockNumber": "25701504",
+    "blockHash": "0x47f276751d8b02fb58a1f99edabd25a91f716d6c2d01ac1250a69b0a8a3b48c4",
+    "transactionIndex": 378,
+    "logIndex": 482,
+    "timestamp": "2026-08-07T07:10:23.000Z"
+  }
+}

--- a/indexer/config.yaml
+++ b/indexer/config.yaml
@@ -100,6 +100,27 @@ contracts:
     events:
       - event: "PayoutAddressUpdated(address indexed beneficiary, address indexed previousPayoutAddress, address indexed newPayoutAddress)"
       - event: "BeneficiaryFeesClaimed(address indexed beneficiary, address indexed payoutAddress, address indexed quoteAsset, uint256 amount, uint256 beneficiaryTotalClaimed, uint256 vaultTotalReceived)"
+  - name: CustomRegistryV1
+    events:
+      - event: "CustomLaunchApprovalAuthorizedV1(bytes32 indexed approvalId, bytes32 indexed launchId, bytes32 indexed approvalBindingHash, bytes32 registrationBindingHash, uint64 transitionSequence, uint64 validAfterBlock, uint64 expiresAtBlock, bytes32 evidenceHash)"
+      - event: "CustomLaunchRegisteredV1(bytes32 indexed launchId, bytes32 indexed projectId, address indexed primaryContract, uint64 registrationSequence, uint256 chainId, uint64 registryGeneration, bytes32 approvalId, bytes32 deploymentId, address launchWallet, bytes32 identityHash, bytes32 registeredRecordCommitment, uint64 observedAtBlock)"
+      - event: "CustomLaunchProvenanceBoundV1(bytes32 indexed launchId, bytes32 indexed repositoryId, bytes32 indexed commitId, bytes32 sourceCommitment, bytes32 buildCommitment, bytes32 artifactSetHash, bytes32 deploymentConfigurationHash, bytes32 deploymentSetHash, bytes32 runtimeCodeSetHash, bytes32 primaryRuntimeCodeHash)"
+      - event: "CustomLaunchReviewBoundV1(bytes32 indexed launchId, bytes32 indexed approvalBindingHash, bytes32 indexed securityReviewHash, bytes32 reviewPolicyHash, bytes32 reviewResultId, bytes32 reviewDeploymentBindingHash, bytes32 feePolicyHash, bytes32 finalityPolicyHash)"
+      - event: "CustomLaunchAttributionBoundV1(bytes32 indexed launchId, bytes32 indexed modelId, bytes32 indexed templateId, bytes32 modelVersion, bytes32 templateVersion, bytes32 providerId, bytes32 builderAttributionHash, bytes32 originHash, bytes32 assetSetHash, bytes32 marketSetHash, bytes32 marketPathId, bytes32 configurationHash, bytes32 permissionsHash, bytes32 capabilitySetHash)"
+      - event: "CustomLaunchFeePolicyBoundV1(bytes32 indexed launchId, bytes32 indexed feePolicyHash, bytes32 indexed providerId, uint8 kind, uint16 totalFeeBps, uint16 nativeCustomFeeBps, uint16 partnerShareBps, uint16 programmableShareBps, address partnerRecipient, address programmableRecipient)"
+      - event: "CustomLaunchFeeScopeBoundV1(bytes32 indexed launchId, bytes32 indexed feePolicyHash, bytes32 indexed publicPolicyBindingHash, bytes32 modelId, bytes32 modelVersion, bytes32 templateId, bytes32 templateVersion, bytes32 marketPathId)"
+      - event: "CustomLaunchFeeEvidenceBoundV1(bytes32 indexed launchId, bytes32 indexed feePolicyHash, bytes32 indexed verificationEvidenceHash, address currency, bytes32 chargeModeId, bytes32 basisId, bytes32 roundingId, bytes32 partnerAccrualId, bytes32 programmableAccrualId, bytes32 claimIsolationEvidenceHash, bytes32 accountingSafetyEvidenceHash)"
+      - event: "CustomLaunchFinalizedV1(bytes32 indexed launchId, bytes32 indexed observedTransactionHash, bytes32 indexed finalityEvidenceHash, uint64 transitionSequence, uint64 observedBlockNumber, bytes32 observedBlockHash, uint32 observedTransactionIndex, uint32 observedLogIndex, uint64 confirmedHeadBlockNumber, bytes32 confirmedHeadBlockHash, bytes32 finalityPolicyHash, uint64 finalizedAtBlock, uint64 finalizedAtTimestamp)"
+      - event: "CustomLaunchRecordCorrectedV1(bytes32 indexed launchId, uint64 indexed revision, bytes32 indexed correctedRecordHash, uint64 transitionSequence, bytes32 previousRecordHash, bytes32 reasonCode, bytes32 evidenceHash)"
+      - event: "CustomLaunchRevokedV1(bytes32 indexed launchId, bytes32 indexed reasonCode, bytes32 indexed evidenceHash, uint64 transitionSequence, uint64 latestRecordRevision, bytes32 latestRecordHash, uint64 revokedAtBlock, uint64 revokedAtTimestamp)"
+  - name: CustomPartnerFactoryRegistryV1
+    events:
+      - event: "CustomPartnerFactoryAuthorizedV1(bytes32 indexed configurationHash, bytes32 indexed providerId, address indexed factory, bytes32 modelId, bytes32 modelVersion, bytes32 templateId, bytes32 templateVersion, uint64 validAfterBlock, uint64 expiresAtBlock, bytes32 evidenceHash)"
+      - event: "CustomPartnerFactorySourceBoundV1(bytes32 indexed configurationHash, bytes32 indexed modelRepositoryId, bytes32 indexed modelSourceCommitId, bytes32 factorySourceRepositoryId, bytes32 factorySourceCommitId, bytes32 factoryRuntimeCodeHash, bytes32 launchRuntimeCodeSetHash, bytes32 permissionsHash, bytes32 feePolicyHash)"
+      - event: "CustomPartnerFactoryRevokedV1(bytes32 indexed configurationHash, bytes32 indexed providerId, address indexed factory, bytes32 reasonCode, bytes32 evidenceHash)"
+  - name: CustomAtomicRegistrarV1
+    events:
+      - event: "AtomicCustomLaunchExecutedV1(bytes32 indexed launchId, address indexed primaryContract, bytes32 indexed salt, bytes32 creationCodeHash, bytes32 initializationResultHash)"
 chains:
   - id: 1
     start_block: 25624130
@@ -141,3 +162,9 @@ chains:
         address: "0x0573879f72d8ee8b0e5a4ec5e8bcdb2fcab9e51c"
       - name: StockV3EthCoordinator
         address: "0xddc3abbab0df7f1189310a4f70e7e365796b74e2"
+      - name: CustomRegistryV1
+        address: "0x17e18c88bda9bfb73924cdc989c07b0707e72671"
+      - name: CustomPartnerFactoryRegistryV1
+        address: "0xf8aef69201621ad20fa256da595426b7e6192dba"
+      - name: CustomAtomicRegistrarV1
+        address: "0xcc916e5200d2626edfd918dc219bc4296629e997"

--- a/indexer/scripts/release-candidate.mjs
+++ b/indexer/scripts/release-candidate.mjs
@@ -41,6 +41,9 @@ const EXPECTED_CONTRACTS = Object.freeze([
   "ClassicV3RewardVault",
   "ClassicV3RewardVaultFactory",
   "ClassicV3VestingWalletFactory",
+  "CustomAtomicRegistrarV1",
+  "CustomPartnerFactoryRegistryV1",
+  "CustomRegistryV1",
   "StockV1EthCoordinator",
   "StockV1Hook",
   "StockV1Launcher",
@@ -299,7 +302,7 @@ function exactNames(label, names) {
     new Set(sorted).size !== sorted.length ||
     sorted.some((name, index) => name !== EXPECTED_CONTRACTS[index])
   ) {
-    throw new Error(`${label} must be the exact reviewed 19-contract scope`);
+    throw new Error(`${label} must be the exact reviewed contract scope`);
   }
 }
 

--- a/indexer/src/EventHandlers.ts
+++ b/indexer/src/EventHandlers.ts
@@ -2021,3 +2021,124 @@ indexer.onEvent(
   { contract: "StockV2V3RewardVault", event: "BeneficiaryFeesClaimed" },
   handleEvent,
 );
+
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchApprovalAuthorizedV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchRegisteredV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchProvenanceBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchReviewBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchAttributionBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchFeePolicyBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchFeeScopeBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchFeeEvidenceBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchFinalizedV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchRecordCorrectedV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchRevokedV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomPartnerFactoryRegistryV1",
+    event: "CustomPartnerFactoryAuthorizedV1",
+    where: eventBlockFilter("CustomPartnerFactoryRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomPartnerFactoryRegistryV1",
+    event: "CustomPartnerFactorySourceBoundV1",
+    where: eventBlockFilter("CustomPartnerFactoryRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomPartnerFactoryRegistryV1",
+    event: "CustomPartnerFactoryRevokedV1",
+    where: eventBlockFilter("CustomPartnerFactoryRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomAtomicRegistrarV1",
+    event: "AtomicCustomLaunchExecutedV1",
+    where: eventBlockFilter("CustomAtomicRegistrarV1"),
+  },
+  handleEvent,
+);

--- a/indexer/src/lib/release-map.ts
+++ b/indexer/src/lib/release-map.ts
@@ -90,6 +90,21 @@ export const SOURCE_REGISTRY = [
     address: "0xddc3abbab0df7f1189310a4f70e7e365796b74e2",
     startBlock: 25_642_745,
   },
+  {
+    contractName: "CustomRegistryV1",
+    address: "0x17e18c88bda9bfb73924cdc989c07b0707e72671",
+    startBlock: 25_701_139,
+  },
+  {
+    contractName: "CustomPartnerFactoryRegistryV1",
+    address: "0xf8aef69201621ad20fa256da595426b7e6192dba",
+    startBlock: 25_701_136,
+  },
+  {
+    contractName: "CustomAtomicRegistrarV1",
+    address: "0xcc916e5200d2626edfd918dc219bc4296629e997",
+    startBlock: 25_701_142,
+  },
 ] as const satisfies readonly SourceRegistryEntry[];
 
 export function staticReleaseForContract(
@@ -109,6 +124,9 @@ export function staticReleaseForContract(
   }
   if (STOCK_V3_CONTRACTS.has(contractName)) {
     return { model: "stock-paired", releaseVersion: "stock-paired-v3" };
+  }
+  if (CUSTOM_REGISTRY_V1_CONTRACTS.has(contractName)) {
+    return { model: "custom", releaseVersion: "custom-registry-v1" };
   }
   return undefined;
 }
@@ -159,4 +177,9 @@ const STOCK_V2_CONTRACTS = new Set([
 const STOCK_V3_CONTRACTS = new Set([
   "StockV3Launcher",
   "StockV3EthCoordinator",
+]);
+const CUSTOM_REGISTRY_V1_CONTRACTS = new Set([
+  "CustomRegistryV1",
+  "CustomPartnerFactoryRegistryV1",
+  "CustomAtomicRegistrarV1",
 ]);

--- a/indexer/test/release-candidate.test.ts
+++ b/indexer/test/release-candidate.test.ts
@@ -214,16 +214,16 @@ describe("Envio release candidate identity", () => {
       deployment: `production-${SOURCE_COMMIT.slice(0, 7)}`,
       sourceCommit: SOURCE_COMMIT,
       configSha256:
-        "0x378e3a799c762cb31107792c7123f5f90b54b5826884c398995e7465176fe1c2",
+        "0x133099a107e8d9c91aea1f0e811dbcc179fae8cf35919e612df7139deab3ee6a",
       schemaSha256:
         "0xdf3d65e033e96d7ebbe62b6f114b6a30f10c8944e5c6fca6b020c3130bb738c0",
       handlerSha256:
-        "0x9f68d05cc8907f1c422cb2584b338ed42375eb4b6033cbec1338d00577267491",
+        "0xa14f0d3bd93d8be1b329467786b40dd465ce71751298fb04a6b97886a1a781fe",
       sourceRegistrySha256:
-        "0x55e7a7c7cd0e419a6be0f9c784990f5048b9845e46e329939025c3fab405565a",
+        "0x7bad14df06e48c8fb0a439bd17b26c2949c475a7c5b58507e5f8514bf92d605a",
       eventSetSha256:
-        "0x7481d6fa986d706e46b9834e40574dd84f21be80b041d35e7d47dbfa59d69243",
-      eventCount: 51,
+        "0xe5a88608068d4c84582cc63de55cbf386fa7f36b201722a39164eb4af61de95f",
+      eventCount: 66,
     });
   });
 

--- a/indexer/test/replay.test.ts
+++ b/indexer/test/replay.test.ts
@@ -414,6 +414,16 @@ describe("checked-in manifest fixtures", () => {
     }>(
       "contracts/deployments/mainnet-stock-paired-v3.json",
     );
+    const customRegistry = readJson<{
+      contracts: Array<{ name: string; address: string; blockNumber: string }>;
+    }>("contracts/deployments/mainnet-custom-registry-v1.json");
+    const customContract = (name: string) => {
+      const contract = customRegistry.contracts.find((entry) => entry.name === name);
+      if (contract === undefined) {
+        throw new Error(`Missing ${name} in the Custom Registry deployment evidence`);
+      }
+      return contract;
+    };
 
     const expected = [
       ["ClassicV2Hook", classicV2.addresses.feeHook, classicV2.transactions.feeHook.blockNumber],
@@ -432,6 +442,9 @@ describe("checked-in manifest fixtures", () => {
       ["StockV2V3RewardVaultFactory", stockV2.addresses.feeSplitVaultFactory, stockV2.startBlock],
       ["StockV3Launcher", stockV3.addresses.launcher, stockV3.startBlock],
       ["StockV3EthCoordinator", stockV3.addresses.ethLaunchCoordinator, stockV3.startBlock],
+      ["CustomRegistryV1", customContract("ProgrammableCustomRegistryV1").address, customContract("ProgrammableCustomRegistryV1").blockNumber],
+      ["CustomPartnerFactoryRegistryV1", customContract("ProgrammableCustomPartnerFactoryRegistryV1").address, customContract("ProgrammableCustomPartnerFactoryRegistryV1").blockNumber],
+      ["CustomAtomicRegistrarV1", customContract("ProgrammableCustomAtomicRegistrarV1").address, customContract("ProgrammableCustomAtomicRegistrarV1").blockNumber],
     ].map(([contractName, address, startBlock]) => ({
       contractName: String(contractName),
       address: String(address).toLowerCase(),

--- a/lib/data-pipeline/event-manifest.ts
+++ b/lib/data-pipeline/event-manifest.ts
@@ -127,6 +127,22 @@ export const PROGRAMMABLE_EVENT_SIGNATURES = {
   ],
 } as const satisfies Readonly<Record<string, readonly string[]>>;
 
+/**
+ * Events consumed by the legacy Classic/Stock read-model projector.
+ *
+ * Custom Registry events have their own projection path and are still part of
+ * PROGRAMMABLE_EVENT_SIGNATURES for strict provider decoding. Keeping this
+ * subset explicit prevents a Registry ABI addition from silently becoming a
+ * Classic/Stock projector rule.
+ */
+export const PROJECTOR_EVENT_SIGNATURES = Object.freeze(
+  Object.fromEntries(
+    Object.entries(PROGRAMMABLE_EVENT_SIGNATURES).filter(
+      ([contractName]) => !contractName.startsWith("Custom"),
+    ),
+  ),
+) as Readonly<Record<string, readonly string[]>>;
+
 type CanonicalValue =
   | null
   | boolean

--- a/lib/data-pipeline/event-manifest.ts
+++ b/lib/data-pipeline/event-manifest.ts
@@ -52,6 +52,27 @@ export const PROGRAMMABLE_EVENT_SIGNATURES = {
     "PayoutWalletChanged(bytes32 indexed poolId, uint256 indexed allocationIndex, address indexed previousPayoutWallet, address newPayoutWallet, uint16 shareBps, uint64 configurationEpoch, bytes32 activeConfigurationHash, uint256 effectiveTotalCreatorFeesReceived)",
     "CtoRewardConfigurationActivated(bytes32 indexed poolId, bytes32 indexed approvalReference, uint64 indexed configurationEpoch, bytes32 previousConfigurationHash, bytes32 newConfigurationHash, address[] beneficiaries, uint16[] sharesBps, uint256 effectiveTotalCreatorFeesReceived)",
   ],
+  CustomRegistryV1: [
+    "CustomLaunchApprovalAuthorizedV1(bytes32 indexed approvalId, bytes32 indexed launchId, bytes32 indexed approvalBindingHash, bytes32 registrationBindingHash, uint64 transitionSequence, uint64 validAfterBlock, uint64 expiresAtBlock, bytes32 evidenceHash)",
+    "CustomLaunchRegisteredV1(bytes32 indexed launchId, bytes32 indexed projectId, address indexed primaryContract, uint64 registrationSequence, uint256 chainId, uint64 registryGeneration, bytes32 approvalId, bytes32 deploymentId, address launchWallet, bytes32 identityHash, bytes32 registeredRecordCommitment, uint64 observedAtBlock)",
+    "CustomLaunchProvenanceBoundV1(bytes32 indexed launchId, bytes32 indexed repositoryId, bytes32 indexed commitId, bytes32 sourceCommitment, bytes32 buildCommitment, bytes32 artifactSetHash, bytes32 deploymentConfigurationHash, bytes32 deploymentSetHash, bytes32 runtimeCodeSetHash, bytes32 primaryRuntimeCodeHash)",
+    "CustomLaunchReviewBoundV1(bytes32 indexed launchId, bytes32 indexed approvalBindingHash, bytes32 indexed securityReviewHash, bytes32 reviewPolicyHash, bytes32 reviewResultId, bytes32 reviewDeploymentBindingHash, bytes32 feePolicyHash, bytes32 finalityPolicyHash)",
+    "CustomLaunchAttributionBoundV1(bytes32 indexed launchId, bytes32 indexed modelId, bytes32 indexed templateId, bytes32 modelVersion, bytes32 templateVersion, bytes32 providerId, bytes32 builderAttributionHash, bytes32 originHash, bytes32 assetSetHash, bytes32 marketSetHash, bytes32 marketPathId, bytes32 configurationHash, bytes32 permissionsHash, bytes32 capabilitySetHash)",
+    "CustomLaunchFeePolicyBoundV1(bytes32 indexed launchId, bytes32 indexed feePolicyHash, bytes32 indexed providerId, uint8 kind, uint16 totalFeeBps, uint16 nativeCustomFeeBps, uint16 partnerShareBps, uint16 programmableShareBps, address partnerRecipient, address programmableRecipient)",
+    "CustomLaunchFeeScopeBoundV1(bytes32 indexed launchId, bytes32 indexed feePolicyHash, bytes32 indexed publicPolicyBindingHash, bytes32 modelId, bytes32 modelVersion, bytes32 templateId, bytes32 templateVersion, bytes32 marketPathId)",
+    "CustomLaunchFeeEvidenceBoundV1(bytes32 indexed launchId, bytes32 indexed feePolicyHash, bytes32 indexed verificationEvidenceHash, address currency, bytes32 chargeModeId, bytes32 basisId, bytes32 roundingId, bytes32 partnerAccrualId, bytes32 programmableAccrualId, bytes32 claimIsolationEvidenceHash, bytes32 accountingSafetyEvidenceHash)",
+    "CustomLaunchFinalizedV1(bytes32 indexed launchId, bytes32 indexed observedTransactionHash, bytes32 indexed finalityEvidenceHash, uint64 transitionSequence, uint64 observedBlockNumber, bytes32 observedBlockHash, uint32 observedTransactionIndex, uint32 observedLogIndex, uint64 confirmedHeadBlockNumber, bytes32 confirmedHeadBlockHash, bytes32 finalityPolicyHash, uint64 finalizedAtBlock, uint64 finalizedAtTimestamp)",
+    "CustomLaunchRecordCorrectedV1(bytes32 indexed launchId, uint64 indexed revision, bytes32 indexed correctedRecordHash, uint64 transitionSequence, bytes32 previousRecordHash, bytes32 reasonCode, bytes32 evidenceHash)",
+    "CustomLaunchRevokedV1(bytes32 indexed launchId, bytes32 indexed reasonCode, bytes32 indexed evidenceHash, uint64 transitionSequence, uint64 latestRecordRevision, bytes32 latestRecordHash, uint64 revokedAtBlock, uint64 revokedAtTimestamp)",
+  ],
+  CustomPartnerFactoryRegistryV1: [
+    "CustomPartnerFactoryAuthorizedV1(bytes32 indexed configurationHash, bytes32 indexed providerId, address indexed factory, bytes32 modelId, bytes32 modelVersion, bytes32 templateId, bytes32 templateVersion, uint64 validAfterBlock, uint64 expiresAtBlock, bytes32 evidenceHash)",
+    "CustomPartnerFactorySourceBoundV1(bytes32 indexed configurationHash, bytes32 indexed modelRepositoryId, bytes32 indexed modelSourceCommitId, bytes32 factorySourceRepositoryId, bytes32 factorySourceCommitId, bytes32 factoryRuntimeCodeHash, bytes32 launchRuntimeCodeSetHash, bytes32 permissionsHash, bytes32 feePolicyHash)",
+    "CustomPartnerFactoryRevokedV1(bytes32 indexed configurationHash, bytes32 indexed providerId, address indexed factory, bytes32 reasonCode, bytes32 evidenceHash)",
+  ],
+  CustomAtomicRegistrarV1: [
+    "AtomicCustomLaunchExecutedV1(bytes32 indexed launchId, address indexed primaryContract, bytes32 indexed salt, bytes32 creationCodeHash, bytes32 initializationResultHash)",
+  ],
   StockV1Launcher: [
     "StockPairedTokenLaunched(address indexed deployer, address indexed token, address indexed quoteAsset, bytes32 poolId, address rewardVault, address positionRecipient, uint256 positionTokenId, bytes32 launchHash)",
     "StockPairedLiquidityConfigured(address indexed token, address indexed quoteAsset, uint256 totalSupply, uint256 tokenLiquidityAmount, uint256 lockedTokenDust, int24 initialTick, int24 tickLower, int24 tickUpper, uint24 lpFeePips, bytes32 launchHash)",

--- a/lib/data-pipeline/projector-fold.ts
+++ b/lib/data-pipeline/projector-fold.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import type { DualRpcCandidateEvidence } from "./dual-rpc";
 import type { EnvioCandidate } from "./envio";
-import { PROGRAMMABLE_EVENT_SIGNATURES } from "./event-manifest";
+import { PROJECTOR_EVENT_SIGNATURES } from "./event-manifest";
 import { getDataPipelineReleaseBinding } from "./release-binding.server";
 
 type HexAddress = `0x${string}`;
@@ -1030,7 +1030,7 @@ function validateFactInvariants(fact: ProjectorEventFact) {
 }
 
 export function projectorFoldManifestCoverage() {
-  const manifest = Object.entries(PROGRAMMABLE_EVENT_SIGNATURES)
+  const manifest = Object.entries(PROJECTOR_EVENT_SIGNATURES)
     .flatMap(([contractName, signatures]) =>
       signatures.map((signature) => {
         const eventName = /^([A-Za-z][A-Za-z0-9]*)\(/u.exec(signature)?.[1];

--- a/lib/server/custom-launch/explore-directory-v1.ts
+++ b/lib/server/custom-launch/explore-directory-v1.ts
@@ -10,6 +10,8 @@ import type {
 } from "../../tokens";
 import { getProductionWebsiteProjectionTargetV1 } from "../projection-target/website-target";
 import { isCustomLaunchRegistryPublicReadEnabled } from "./public-readiness";
+import { withGenesisCanaryRegistryCustomStoreV1 } from
+  "./genesis-canary-public-v1";
 import type { VerifiedRegistryCustomLaunchPublicV1 } from
   "./registry-public-store-v1";
 
@@ -124,7 +126,9 @@ export async function readProductionCustomExploreDirectoryV1(
   if (!isCustomLaunchRegistryPublicReadEnabled()) return Object.freeze([]);
   const target = getProductionWebsiteProjectionTargetV1();
   await target.assertProductionReadiness();
-  const records = await target.registryCustomPublicStore
+  const records = await withGenesisCanaryRegistryCustomStoreV1(
+    target.registryCustomPublicStore,
+  )
     .findVerifiedRegistryCustomLaunchesPublic({ signal });
   return Object.freeze(records.map(customLaunchProjectToExploreEntryV1));
 }

--- a/lib/server/custom-launch/genesis-canary-public-v1.ts
+++ b/lib/server/custom-launch/genesis-canary-public-v1.ts
@@ -1,0 +1,419 @@
+import "server-only";
+
+import evidence from "../../../config/custom-registry-genesis-canary-v1.json";
+import type { AuthenticatedCustomLaunchProjectV2 } from "../../custom-launch/contract-v2";
+import type { JsonValue } from "../projection-target/canonical-json";
+import {
+  canonicalSha256,
+  type Sha256Digest,
+} from "../projection-target/hashing";
+import { parseAuthenticatedCustomLaunchProjectV2 } from
+  "../projection-target/postgres-store";
+import {
+  parseRegistryCustomLaunchPublicRecordV1,
+  type RegistryCustomLaunchPublicReadStoreV1,
+  type VerifiedRegistryCustomLaunchPublicV1,
+} from "./registry-public-store-v1";
+
+function bindingHash(domain: string, value: unknown): Sha256Digest {
+  return canonicalSha256(domain, value as JsonValue);
+}
+
+const launchingWallet = Object.freeze({
+  namespace: `eip155:${evidence.chainId}`,
+  value: evidence.identity.launchWallet,
+});
+const authorityInventoryPreimage = Object.freeze({
+  schemaVersion: "programmable.post-launch-authority-inventory.v1" as const,
+  launchingWallet,
+  addressBindings: Object.freeze([]),
+  declaredIdentityBindings: Object.freeze([]),
+  postLaunchAuthorities: Object.freeze([]),
+  confirmation: Object.freeze({
+    mode: "artifact-bound-launching-wallet-intent" as const,
+    confirmingIdentity: launchingWallet,
+    userVisibleDisclosureRequired: true as const,
+  }),
+  postLaunchActionPolicy: "declared-onchain-authority-only" as const,
+  githubAuthority: "provenance-only-never-post-launch-authority" as const,
+});
+const postLaunchAuthorityInventoryHash = bindingHash(
+  "programmable.post-launch-authority-inventory.v1",
+  authorityInventoryPreimage,
+);
+const postLaunchAuthorityInventory = Object.freeze({
+  ...authorityInventoryPreimage,
+  postLaunchAuthorityInventoryHash,
+});
+const discoverableAssets = Object.freeze([]);
+const assetIdentitySetHash = bindingHash(
+  "programmable.discoverable-launch-asset-set-hash.v2",
+  {
+    schemaVersion: "programmable.discoverable-launch-asset-set.v2",
+    advertisesToken: false,
+    assets: discoverableAssets,
+  },
+);
+const discoverableMarkets = Object.freeze([]);
+const marketSetHash = bindingHash(
+  "programmable.discoverable-launch-market-set-hash.v2",
+  {
+    schemaVersion: "programmable.discoverable-launch-market-set.v2",
+    assetIdentitySetHash,
+    markets: discoverableMarkets,
+  },
+);
+const chainProfileHash = bindingHash(
+  "programmable.custom-registry-chain-profile-reference.v1",
+  {
+    chainId: evidence.chainId,
+    finalityPolicyHash: evidence.approval.finalityPolicyHash,
+    minimumFinalityBlocks: evidence.minimumFinalityBlocks,
+  },
+);
+const feeAssessmentHash = bindingHash(
+  "programmable.custom-registry-genesis-canary-fee-assessment.v1",
+  {
+    launchId: evidence.identity.launchId,
+    feePolicyHash: evidence.approval.feePolicyHash,
+    marketSetHash,
+    qualifyingMarketCount: 0,
+  },
+);
+const feePolicy = Object.freeze({
+  schemaVersion: "programmable.custom-launch-fee-policy.v1" as const,
+  providerId: evidence.identity.providerId,
+  modelId: evidence.identity.modelId,
+  templateId: evidence.identity.templateId,
+  semanticVersion: evidence.identity.modelVersion,
+  feeMode: "no-qualifying-market" as const,
+  marketPathId: null,
+  totalRatePpm: 0,
+  totalRateBps: 0,
+  chargeMode: "none" as const,
+  normalProgrammableTenBpsApplied: false,
+  legs: Object.freeze([]),
+});
+const feeObligationPreimage = Object.freeze({
+  schemaVersion: "programmable.launch-fee-obligation.v3" as const,
+  feeAssessmentHash,
+  chainId: evidence.chainId,
+  chainProfileId: "ethereum-mainnet",
+  chainProfileHash,
+  policy: feePolicy,
+  qualifyingFlowBasis: null,
+  qualifyingFlowBasisBindingHash: null,
+  feeBasis: null,
+  enforcementRouteId: null,
+  enforcementRouteBindingHash: null,
+  enforcementModuleId: null,
+  enforcementModuleBindingHash: null,
+  claimSemantics: "not-applicable" as const,
+});
+const feeObligationHash = bindingHash(
+  "programmable.launch-fee-obligation.v3",
+  feeObligationPreimage,
+);
+const feeAssessmentObligationBindingHash = bindingHash(
+  "programmable.launch-fee-assessment-obligation-binding.v3",
+  {
+    schemaVersion: "programmable.launch-fee-assessment-obligation-binding.v3",
+    feeAssessmentHash,
+    feeObligationHash,
+  },
+);
+const feeObligation = Object.freeze({
+  ...feeObligationPreimage,
+  feeObligationHash,
+  feeAssessmentObligationBindingHash,
+});
+const registryPublicationBindingHash = bindingHash(
+  "programmable.custom-registry-genesis-canary-publication.v1",
+  evidence,
+);
+const registryAdapterBindingHash = bindingHash(
+  "programmable.custom-registry-genesis-canary-adapter.v1",
+  {
+    registry: evidence.registry,
+    eventSet: "sha256:8df340512445931e96838244207940ce9ca631b48c905bda78d5f4f5bcee1c0a",
+  },
+);
+const projectionRuntimeBindingHash = bindingHash(
+  "programmable.custom-registry-genesis-canary-projection-runtime.v1",
+  {
+    sourceCommit: evidence.source.sourceCommit,
+    sourceTree: evidence.source.sourceTree,
+    sourcePath: "lib/server/custom-launch/genesis-canary-public-v1.ts",
+  },
+);
+const registryObservationDigest = bindingHash(
+  "programmable.custom-registry-genesis-canary-observation.v1",
+  {
+    registration: evidence.registration,
+    finality: evidence.finality,
+  },
+);
+const registryTargetBindingHash = bindingHash(
+  "programmable.custom-registry-genesis-canary-target.v1",
+  {
+    chainId: evidence.chainId,
+    registryAddress: evidence.registry.address,
+    registryStartBlock: evidence.registry.startBlock,
+  },
+);
+
+const project = parseAuthenticatedCustomLaunchProjectV2({
+  schemaVersion: "programmable.custom-launch-website-record.v2",
+  platformId: "programmable",
+  origin: "programmable",
+  category: "custom",
+  launchFamily: "custom",
+  modelId: evidence.identity.modelId,
+  sourceKind: "browser-wallet-report",
+  sourceRecordBindingHash: bindingHash(
+    "programmable.custom-registry-genesis-canary-source-record.v1",
+    {
+      registeredRecordCommitment: evidence.approval.registeredRecordCommitment,
+      registration: evidence.registration,
+    },
+  ),
+  finalizedLaunchBindingHash: bindingHash(
+    "programmable.custom-registry-genesis-canary-finalized-launch.v1",
+    {
+      launchId: evidence.identity.launchId,
+      finality: evidence.finality,
+    },
+  ),
+  status: "launched",
+  action: "view_live_launch",
+  projectId: evidence.identity.projectId,
+  launchId: evidence.identity.launchId,
+  githubPrincipalHash: bindingHash(
+    "programmable.custom-registry-genesis-canary-github-principal.v1",
+    {
+      repositoryOwner: evidence.source.repositoryOwner,
+      repositoryId: evidence.source.repositoryId,
+    },
+  ),
+  chainId: evidence.chainId,
+  chainProfileId: "ethereum-mainnet",
+  chainProfileHash,
+  launchIdentity: {
+    namespace: `eip155:${evidence.chainId}`,
+    value: evidence.identity.primaryContract,
+  },
+  launchingWallet,
+  postLaunchAuthorityInventory,
+  postLaunchAuthorityInventoryHash,
+  launchTransactionId: evidence.registration.transactionHash,
+  launchRouteId: "registry-genesis-canary-v1",
+  executionMode: "atomic-deploy-and-register",
+  advertisesToken: false,
+  discoverableAssets,
+  assetIdentitySetHash,
+  discoverableMarkets,
+  marketSetHash,
+  feeAssessmentHash,
+  feeObligationHash,
+  feeAssessmentObligationBindingHash,
+  feeObligation,
+  registryPublicationBindingHash,
+  registryAdapterBindingHash,
+  projectionRuntimeBindingHash,
+  registryObservationDigest,
+  registryTargetBindingHash,
+  presentationVersion: null,
+  presentationBindingHash: null,
+  presentation: null,
+  websiteProjectionGeneration: evidence.registryGeneration,
+  launchedAt: evidence.registration.timestamp,
+  finalizedAt: evidence.finality.timestamp,
+});
+
+const publicRecord = parseRegistryCustomLaunchPublicRecordV1({
+  schemaVersion: "programmable.registry-custom-launch-public-record.v1",
+  projectId: evidence.identity.projectId,
+  launchId: evidence.identity.launchId,
+  registry: {
+    chainId: evidence.chainId,
+    registryAddress: evidence.registry.address,
+    startBlock: evidence.registry.startBlock,
+  },
+  event: {
+    transactionHash: evidence.registration.transactionHash,
+    blockHash: evidence.registration.blockHash,
+    blockNumber: evidence.registration.blockNumber,
+    transactionIndex: evidence.registration.transactionIndex,
+    logIndex: evidence.registration.logIndex,
+  },
+  finality: {
+    observedHeadBlockNumber: evidence.finality.confirmedHeadBlockNumber,
+    observedHeadBlockHash: evidence.finality.confirmedHeadBlockHash,
+    requiredConfirmations: evidence.minimumFinalityBlocks,
+    policyBindingHash: bindingHash(
+      "programmable.custom-registry-finality-policy-reference.v1",
+      { finalityPolicyHash: evidence.approval.finalityPolicyHash },
+    ),
+    evidenceBindingHash: bindingHash(
+      "programmable.custom-registry-finality-evidence-reference.v1",
+      {
+        evidenceHash: evidence.finality.evidenceHash,
+        finalizationTransactionHash: evidence.finality.transactionHash,
+      },
+    ),
+  },
+  configurationHash: evidence.approval.configurationHash,
+  provider: {
+    providerId: evidence.identity.providerId,
+    modelId: evidence.identity.modelId,
+    modelVersion: evidence.identity.modelVersion,
+    marketPath: null,
+  },
+  github: {
+    repositoryOwner: evidence.source.repositoryOwner,
+    repositoryId: evidence.source.repositoryId,
+    commitObjectId: evidence.source.sourceCommit,
+    treeObjectId: evidence.source.sourceTree,
+  },
+  approval: {
+    approvalId: evidence.approval.approvalId,
+    approvalBindingHash: bindingHash(
+      "programmable.custom-registry-approval-reference.v1",
+      {
+        approvalId: evidence.approval.approvalId,
+        approvalBindingHash: evidence.approval.approvalBindingHash,
+      },
+    ),
+    launchPlanPath: evidence.source.sourcePath,
+    launchPlanBindingHash: bindingHash(
+      "programmable.custom-registry-genesis-canary-launch-plan.v1",
+      {
+        sourceCommit: evidence.source.sourceCommit,
+        sourceTree: evidence.source.sourceTree,
+        sourcePath: evidence.source.sourcePath,
+        configurationHash: evidence.approval.configurationHash,
+        permissionsHash: evidence.approval.permissionsHash,
+        primaryRuntimeCodeHash: evidence.approval.primaryRuntimeCodeHash,
+      },
+    ),
+  },
+  runtime: {
+    launchRouteId: project.launchRouteId,
+    executionMode: project.executionMode,
+    registryAdapterBindingHash,
+    projectionRuntimeBindingHash,
+    registryTargetBindingHash,
+  },
+  fee: {
+    feeAssessmentHash,
+    feeObligationHash,
+    feeAssessmentObligationBindingHash,
+    obligation: feeObligation,
+  },
+  roles: {
+    launchingWallet,
+    postLaunchAuthorityInventoryHash,
+    postLaunchAuthorityInventory,
+  },
+  project,
+});
+
+export const GENESIS_CANARY_VERIFIED_REGISTRY_CUSTOM_LAUNCH_V1:
+Readonly<VerifiedRegistryCustomLaunchPublicV1> = Object.freeze({
+  schemaVersion: "programmable.verified-registry-custom-launch-public.v1",
+  sourceLane: "registry.custom-launched",
+  lifecycle: Object.freeze({
+    generation: "3",
+    state: "finalized",
+    bindingHash: bindingHash(
+      "programmable.custom-registry-genesis-canary-lifecycle.v1",
+      evidence.finality,
+    ),
+    observedAt: evidence.finality.timestamp,
+  }),
+  record: publicRecord,
+});
+
+function mergeVerified(
+  records: readonly Readonly<VerifiedRegistryCustomLaunchPublicV1>[],
+): readonly Readonly<VerifiedRegistryCustomLaunchPublicV1>[] {
+  return Object.freeze([
+    GENESIS_CANARY_VERIFIED_REGISTRY_CUSTOM_LAUNCH_V1,
+    ...records.filter(({ record }) => record.projectId !== evidence.identity.projectId),
+  ].sort((left, right) =>
+    right.record.project.finalizedAt.localeCompare(left.record.project.finalizedAt)));
+}
+
+function mergeProjects(
+  projects: readonly Readonly<AuthenticatedCustomLaunchProjectV2>[],
+): readonly Readonly<AuthenticatedCustomLaunchProjectV2>[] {
+  return Object.freeze([
+    project,
+    ...projects.filter((candidate) => candidate.projectId !== evidence.identity.projectId),
+  ].sort((left, right) => right.finalizedAt.localeCompare(left.finalizedAt)));
+}
+
+const wrappedStores = new WeakMap<object, RegistryCustomLaunchPublicReadStoreV1>();
+
+export function withGenesisCanaryRegistryCustomStoreV1(
+  base: RegistryCustomLaunchPublicReadStoreV1,
+): RegistryCustomLaunchPublicReadStoreV1 {
+  const existing = wrappedStores.get(base as object);
+  if (existing !== undefined) return existing;
+  const store: RegistryCustomLaunchPublicReadStoreV1 = Object.freeze({
+    sourceLane: "registry.custom-launched" as const,
+    async findFinalizedCustomLaunchByProjectId(
+      input: Parameters<RegistryCustomLaunchPublicReadStoreV1[
+        "findFinalizedCustomLaunchByProjectId"
+      ]>[0],
+    ) {
+      input.signal.throwIfAborted();
+      if (input.projectId === project.projectId) return project;
+      return base.findFinalizedCustomLaunchByProjectId(input);
+    },
+    async findFinalizedCustomLaunchesPublic(
+      input: Parameters<RegistryCustomLaunchPublicReadStoreV1[
+        "findFinalizedCustomLaunchesPublic"
+      ]>[0],
+    ) {
+      input.signal.throwIfAborted();
+      return mergeProjects(await base.findFinalizedCustomLaunchesPublic(input));
+    },
+    async findFinalizedCustomLaunchesByWallet(
+      input: Parameters<RegistryCustomLaunchPublicReadStoreV1[
+        "findFinalizedCustomLaunchesByWallet"
+      ]>[0],
+    ) {
+      input.signal.throwIfAborted();
+      const projects = await base.findFinalizedCustomLaunchesByWallet(input);
+      return input.namespace === launchingWallet.namespace
+        && input.value.toLowerCase() === launchingWallet.value.toLowerCase()
+        ? mergeProjects(projects)
+        : Object.freeze(projects.filter((candidate) =>
+            candidate.projectId !== project.projectId));
+    },
+    async findVerifiedRegistryCustomLaunchByProjectId(
+      input: Parameters<RegistryCustomLaunchPublicReadStoreV1[
+        "findVerifiedRegistryCustomLaunchByProjectId"
+      ]>[0],
+    ) {
+      input.signal.throwIfAborted();
+      if (input.projectId === publicRecord.projectId) {
+        return GENESIS_CANARY_VERIFIED_REGISTRY_CUSTOM_LAUNCH_V1;
+      }
+      return base.findVerifiedRegistryCustomLaunchByProjectId(input);
+    },
+    async findVerifiedRegistryCustomLaunchesPublic(
+      input: Parameters<RegistryCustomLaunchPublicReadStoreV1[
+        "findVerifiedRegistryCustomLaunchesPublic"
+      ]>[0],
+    ) {
+      input.signal.throwIfAborted();
+      return mergeVerified(
+        await base.findVerifiedRegistryCustomLaunchesPublic(input),
+      );
+    },
+  });
+  wrappedStores.set(base as object, store);
+  return store;
+}

--- a/lib/server/custom-launch/project-read-v2.ts
+++ b/lib/server/custom-launch/project-read-v2.ts
@@ -6,6 +6,8 @@ import type {
 } from "./registry-public-store-v1";
 import { getProductionWebsiteProjectionTargetV1 } from "../projection-target/website-target";
 import { isCustomLaunchRegistryPublicReadEnabled } from "./public-readiness";
+import { withGenesisCanaryRegistryCustomStoreV1 } from
+  "./genesis-canary-public-v1";
 
 const DIGEST = /^sha256:[0-9a-f]{64}$/u;
 
@@ -81,7 +83,9 @@ async function production() {
   const target = getProductionWebsiteProjectionTargetV1();
   await target.assertProductionReadiness();
   productionHandlers ??= createCustomLaunchProjectReadHandlersV2({
-    store: target.registryCustomPublicStore,
+    store: withGenesisCanaryRegistryCustomStoreV1(
+      target.registryCustomPublicStore,
+    ),
   });
   return productionHandlers;
 }

--- a/lib/server/custom-launch/public-readiness.ts
+++ b/lib/server/custom-launch/public-readiness.ts
@@ -52,7 +52,7 @@ export function isCustomLaunchPublicEnabled(
 export function isCustomLaunchRegistryPublicReadEnabled(
   environment: Readonly<Record<string, string | undefined>> = process.env,
 ): boolean {
-  return environment.PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED === "true";
+  return environment.PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED === "true";
 }
 
 export function configuredLaunchPermitSignersV2(

--- a/lib/server/custom-launch/registry-manifest-v1.ts
+++ b/lib/server/custom-launch/registry-manifest-v1.ts
@@ -125,7 +125,7 @@ export function resolveCustomRegistryPublicManifestV1(
       status: "live",
       chainId: "1",
       caip2: "eip155:1",
-      publicSubmissionsEnabled: true,
+      publicSubmissionsEnabled: false,
       generation,
       startBlock,
       contracts: Object.freeze(contracts),

--- a/lib/server/custom-launch/registry-public-read-v1.ts
+++ b/lib/server/custom-launch/registry-public-read-v1.ts
@@ -5,6 +5,8 @@ import type { Sha256Digest } from "../projection-target/hashing";
 import { getProductionWebsiteProjectionTargetV1 } from
   "../projection-target/website-target";
 import { isCustomLaunchRegistryPublicReadEnabled } from "./public-readiness";
+import { withGenesisCanaryRegistryCustomStoreV1 } from
+  "./genesis-canary-public-v1";
 import type { RegistryCustomLaunchPublicReadStoreV1 } from
   "./registry-public-store-v1";
 
@@ -66,7 +68,9 @@ async function production() {
   const target = getProductionWebsiteProjectionTargetV1();
   await target.assertProductionReadiness();
   productionHandlers ??= createRegistryCustomLaunchPublicReadHandlersV1({
-    store: target.registryCustomPublicStore,
+    store: withGenesisCanaryRegistryCustomStoreV1(
+      target.registryCustomPublicStore,
+    ),
   });
   return productionHandlers;
 }

--- a/lib/server/projection-target/postgres-store.ts
+++ b/lib/server/projection-target/postgres-store.ts
@@ -1020,6 +1020,15 @@ function parseCustomLaunchProject(
   const launchedAt = canonicalInstant(record.launchedAt, "custom launch time");
   const finalizedAt = canonicalInstant(record.finalizedAt, "custom finality time");
   const presentation = validatedLaunchPresentationV1(record);
+  const launchingWalletAuthorityCount =
+    postLaunchAuthorityInventory.postLaunchAuthorities.filter(({ source }) =>
+      source.kind === "launching-wallet").length;
+  const isAuthoritylessProjectMarker = record.advertisesToken === false
+    && discoverableAssets.length === 0
+    && discoverableMarkets.length === 0
+    && postLaunchAuthorityInventory.addressBindings.length === 0
+    && postLaunchAuthorityInventory.declaredIdentityBindings.length === 0
+    && postLaunchAuthorityInventory.postLaunchAuthorities.length === 0;
   if (
     readback.schemaVersion !== "programmable.custom-launch-projection-readback.v2"
     || readback.projectionKind !== "website.custom-launched"
@@ -1044,8 +1053,9 @@ function parseCustomLaunchProject(
       !== launchingWallet.value
     || postLaunchAuthorityInventory.postLaunchAuthorityInventoryHash
       !== postLaunchAuthorityInventoryHash
-    || postLaunchAuthorityInventory.postLaunchAuthorities.filter(({ source }) =>
-      source.kind === "launching-wallet").length !== 1
+    || (isAuthoritylessProjectMarker
+      ? launchingWalletAuthorityCount !== 0
+      : launchingWalletAuthorityCount !== 1)
     || postLaunchAuthorityInventory.postLaunchAuthorities.some(
       ({ identity: authorityIdentity, source }) =>
       source.kind === "launching-wallet"

--- a/scripts/serve-custom-registry-genesis-canary.mjs
+++ b/scripts/serve-custom-registry-genesis-canary.mjs
@@ -516,11 +516,21 @@ async function finalizationTransaction(plan, registeredLog) {
   const observedBlock = BigInt(registeredLog.blockNumber);
   if (lowestHead <= observedBlock + BigInt(MINIMUM_FINALITY_BLOCKS)) return null;
   const confirmedHead = lowestHead - 1n;
-  const confirmedBlock = await reconciled("eth_getBlockByNumber", [
-    `0x${confirmedHead.toString(16)}`,
-    false,
-  ]);
-  if (confirmedBlock?.hash === undefined) fail("Confirmed head block is unavailable");
+  const confirmedBlocks = await Promise.all(RPC_ENDPOINTS.map((endpoint) => rpc(
+    endpoint,
+    "eth_getBlockByNumber",
+    [`0x${confirmedHead.toString(16)}`, false],
+  )));
+  const confirmedBlock = confirmedBlocks[0];
+  if (confirmedBlock?.hash === undefined || confirmedBlock?.number === undefined) {
+    fail("Confirmed head block is unavailable");
+  }
+  const confirmedIdentity = `${confirmedBlock.number}:${confirmedBlock.hash}`.toLowerCase();
+  if (confirmedBlocks.some((block) =>
+    `${block?.number ?? ""}:${block?.hash ?? ""}`.toLowerCase() !== confirmedIdentity
+  )) {
+    fail("Independent Ethereum Mainnet RPCs disagree on the confirmed head block identity");
+  }
   const finalityEvidence = {
     chainId: "1",
     registry: REGISTRY,

--- a/tests/custom-launch-public-readiness.test.ts
+++ b/tests/custom-launch-public-readiness.test.ts
@@ -75,11 +75,11 @@ describe("Custom launch public readiness", () => {
 
   it("separates finalized Registry reads from launch-write service readiness", () => {
     expect(isCustomLaunchRegistryPublicReadEnabled({
-      PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED: "true",
+      PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED: "true",
     })).toBe(true);
     expect(isCustomLaunchRegistryPublicReadEnabled({
       ...configured,
-      PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED: "false",
+      PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED: "false",
     })).toBe(false);
   });
 

--- a/tests/custom-registry-genesis-public-v1.test.ts
+++ b/tests/custom-registry-genesis-public-v1.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  GENESIS_CANARY_VERIFIED_REGISTRY_CUSTOM_LAUNCH_V1,
+  withGenesisCanaryRegistryCustomStoreV1,
+} from "../lib/server/custom-launch/genesis-canary-public-v1";
+import { customLaunchProjectToExploreEntryV1 } from
+  "../lib/server/custom-launch/explore-directory-v1";
+import {
+  parseRegistryCustomLaunchPublicRecordV1,
+  type RegistryCustomLaunchPublicReadStoreV1,
+} from "../lib/server/custom-launch/registry-public-store-v1";
+
+const emptyStore: RegistryCustomLaunchPublicReadStoreV1 = Object.freeze({
+  sourceLane: "registry.custom-launched" as const,
+  async findFinalizedCustomLaunchByProjectId() {
+    return null;
+  },
+  async findFinalizedCustomLaunchesPublic() {
+    return Object.freeze([]);
+  },
+  async findFinalizedCustomLaunchesByWallet() {
+    return Object.freeze([]);
+  },
+  async findVerifiedRegistryCustomLaunchByProjectId() {
+    return null;
+  },
+  async findVerifiedRegistryCustomLaunchesPublic() {
+    return Object.freeze([]);
+  },
+});
+
+describe("finalized Custom Registry genesis canary", () => {
+  it("publishes the exact authorityless, marketless Mainnet Registry record", async () => {
+    const verified = GENESIS_CANARY_VERIFIED_REGISTRY_CUSTOM_LAUNCH_V1;
+    const store = withGenesisCanaryRegistryCustomStoreV1(emptyStore);
+    const signal = new AbortController().signal;
+
+    expect(verified.record).toMatchObject({
+      projectId: "sha256:897608bd2a9e7758334d4fb82153dffdcff016d742b87e0b490e8cf98b63a8ff",
+      launchId: "sha256:329016f555ac688de1980078680f783b3e9a59f098b054a4d0cb4044a5b5594e",
+      configurationHash: "0xac9064bed5278c749616bac7ae3f1de5f8957f075ff847ff1ad62efe395c4f05",
+      registry: {
+        chainId: "1",
+        registryAddress: "0x17e18c88bda9bfb73924cdc989c07b0707e72671",
+        startBlock: "25701139",
+      },
+      event: {
+        transactionHash: "0x71efe312d6d74030744174bfe8d5b3d82e6599915eb3108897076b0f392652db",
+        blockNumber: "25701424",
+        transactionIndex: 148,
+        logIndex: 408,
+      },
+      provider: {
+        providerId: "programmable",
+        modelId: "programmable.registry-genesis-canary",
+        modelVersion: "1.0.0",
+        marketPath: null,
+      },
+      project: {
+        advertisesToken: false,
+        discoverableAssets: [],
+        discoverableMarkets: [],
+        launchIdentity: {
+          namespace: "eip155:1",
+          value: "0x1d70acbbe83283b1597401569efead0ba5312e28",
+        },
+        postLaunchAuthorityInventory: {
+          addressBindings: [],
+          declaredIdentityBindings: [],
+          postLaunchAuthorities: [],
+        },
+        feeObligation: {
+          policy: {
+            providerId: "programmable",
+            feeMode: "no-qualifying-market",
+            totalRateBps: 0,
+            normalProgrammableTenBpsApplied: false,
+          },
+        },
+      },
+    });
+    await expect(store.findVerifiedRegistryCustomLaunchesPublic({ signal }))
+      .resolves.toEqual([verified]);
+    await expect(store.findFinalizedCustomLaunchesByWallet({
+      namespace: "eip155:1",
+      value: "0x2bb333d48dfaf1596d9036671d2e43168994249e",
+      signal,
+    })).resolves.toEqual([verified.record.project]);
+    expect(customLaunchProjectToExploreEntryV1(verified)).toMatchObject({
+      exploreKind: "custom-project",
+      name: "programmable.registry-genesis-canary",
+      markets: [],
+      customProjectId: verified.record.projectId,
+      customLaunchId: verified.record.launchId,
+    });
+  });
+
+  it("rejects substituted configuration and incomplete finality", () => {
+    const record = GENESIS_CANARY_VERIFIED_REGISTRY_CUSTOM_LAUNCH_V1.record;
+    expect(() => parseRegistryCustomLaunchPublicRecordV1({
+      ...record,
+      configurationHash: "0x1234",
+    })).toThrow("configuration hash is invalid");
+    expect(() => parseRegistryCustomLaunchPublicRecordV1({
+      ...record,
+      finality: {
+        ...record.finality,
+        observedHeadBlockNumber: record.event.blockNumber,
+      },
+    })).toThrow("public bindings are inconsistent");
+  });
+});

--- a/tests/custom-registry-public-manifest-v1.test.ts
+++ b/tests/custom-registry-public-manifest-v1.test.ts
@@ -104,7 +104,7 @@ describe("Custom Registry V1 public manifest", () => {
       status: "live",
       chainId: "1",
       caip2: "eip155:1",
-      publicSubmissionsEnabled: true,
+      publicSubmissionsEnabled: false,
       generation: "ethereum-mainnet-v1",
       startBlock: "23456789",
       contracts: {


### PR DESCRIPTION
## Summary
- publish the finalized Ethereum Custom Registry generation and immutable genesis canary
- expose the finalized Custom launch in Registry, project/profile and Explore read paths while keeping public submissions disabled
- add Registry, partner-factory and atomic-registrar sources/events to the Envio indexer
- keep Custom events out of the legacy Classic/Stock projector rule set while retaining strict ABI decoding
- bind the 66-event indexer identity and dual-RPC finality evidence

## Validation
- `npm run typecheck`
- `npm test` — 2,127 passed, 7 skipped
- `npm --prefix indexer test` — 81 passed
- targeted Custom Registry tests — 17 passed
- indexer codegen/typecheck passed

## Release boundary
- Registry discovery becomes live only when `PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED=true`
- general Custom write/intake remains disabled
- no AEON approval or partner factory is published by this change