### PR TITLE
fix(custom-registry): separate public read readiness

### DIFF
--- a/lib/server/custom-launch/registry-public-read-v1.ts
+++ b/lib/server/custom-launch/registry-public-read-v1.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { canonicalizeJson } from "../projection-target/canonical-json";
 import type { Sha256Digest } from "../projection-target/hashing";
-import { getProductionWebsiteProjectionTargetV1 } from
+import { getProductionWebsiteRegistryCustomPublicReadTargetV1 } from
   "../projection-target/website-target";
 import { isCustomLaunchRegistryPublicReadEnabled } from "./public-readiness";
 import { withGenesisCanaryRegistryCustomStoreV1 } from
@@ -65,11 +65,11 @@ let productionHandlers:
 ReturnType<typeof createRegistryCustomLaunchPublicReadHandlersV1> | null = null;
 
 async function production() {
-  const target = getProductionWebsiteProjectionTargetV1();
+  const target = getProductionWebsiteRegistryCustomPublicReadTargetV1();
   await target.assertProductionReadiness();
   productionHandlers ??= createRegistryCustomLaunchPublicReadHandlersV1({
     store: withGenesisCanaryRegistryCustomStoreV1(
-      target.registryCustomPublicStore,
+      target.store,
     ),
   });
   return productionHandlers;

--- a/lib/server/custom-launch/registry-public-read-v1.ts
+++ b/lib/server/custom-launch/registry-public-read-v1.ts
@@ -65,14 +65,43 @@ let productionHandlers:
 ReturnType<typeof createRegistryCustomLaunchPublicReadHandlersV1> | null = null;
 
 async function production() {
-  const target = getProductionWebsiteRegistryCustomPublicReadTargetV1();
-  await target.assertProductionReadiness();
+  let target: ReturnType<
+    typeof getProductionWebsiteRegistryCustomPublicReadTargetV1
+  >;
+  try {
+    target = getProductionWebsiteRegistryCustomPublicReadTargetV1();
+  } catch (error) {
+    logProductionReadFailure("construction", error);
+    throw error;
+  }
+  try {
+    await target.assertProductionReadiness();
+  } catch (error) {
+    logProductionReadFailure("attestation", error);
+    throw error;
+  }
   productionHandlers ??= createRegistryCustomLaunchPublicReadHandlersV1({
     store: withGenesisCanaryRegistryCustomStoreV1(
       target.store,
     ),
   });
   return productionHandlers;
+}
+
+function logProductionReadFailure(
+  stage: "construction" | "attestation",
+  error: unknown,
+): void {
+  const code = error !== null && typeof error === "object"
+    && "code" in error && typeof error.code === "string"
+    && /^[A-Za-z0-9_-]{1,64}$/u.test(error.code)
+      ? error.code
+      : error instanceof TypeError ? "type_error" : "unknown";
+  console.error(JSON.stringify({
+    event: "registry_custom_public_read_dependency_failed",
+    stage,
+    code,
+  }));
 }
 
 export async function handleProductionRegistryCustomLaunchFeedV1(

--- a/lib/server/projection-target/website-target.ts
+++ b/lib/server/projection-target/website-target.ts
@@ -36,6 +36,11 @@ export interface WebsiteProjectionTargetV1 {
   readonly assertProductionReadiness: () => Promise<void>;
 }
 
+export interface WebsiteRegistryCustomPublicReadTargetV1 {
+  readonly store: PostgresRegistryCustomLaunchPublicStoreV1;
+  readonly assertProductionReadiness: () => Promise<void>;
+}
+
 export interface ProjectionTargetSecurityAttestationRowV1
 extends Record<string, unknown> {
   runtime_role: string;
@@ -79,6 +84,31 @@ export interface VerifiedPostgresTlsConfigurationV1 {
 }
 
 let productionTarget: WebsiteProjectionTargetV1 | null = null;
+let productionRegistryCustomPublicReadTarget:
+WebsiteRegistryCustomPublicReadTargetV1 | null = null;
+
+export function getProductionWebsiteRegistryCustomPublicReadTargetV1():
+WebsiteRegistryCustomPublicReadTargetV1 {
+  if (productionRegistryCustomPublicReadTarget !== null) {
+    return productionRegistryCustomPublicReadTarget;
+  }
+  const expectedDatabaseRole = environmentId(
+    "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE",
+  );
+  const pool = createProductionProjectionTargetPostgresPoolV1(
+    environmentValue("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL"),
+    environmentPem(
+      "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM",
+      "CERTIFICATE",
+    ),
+    expectedDatabaseRole,
+  );
+  productionRegistryCustomPublicReadTarget = Object.freeze({
+    store: new PostgresRegistryCustomLaunchPublicStoreV1(pool),
+    assertProductionReadiness: () => pool.assertProductionReadiness(),
+  });
+  return productionRegistryCustomPublicReadTarget;
+}
 
 export function getProductionWebsiteProjectionTargetV1(): WebsiteProjectionTargetV1 {
   if (productionTarget !== null) return productionTarget;


### PR DESCRIPTION
Keeps the public Registry feed fail-closed on the dedicated TLS and least-privilege database attestation, while removing unrelated approval-workload signing configuration from the public-read construction path. The authenticated projection write target remains unchanged and still requires its full frozen workload identity.\n\nProduction dependency prepared separately: dedicated login role, ordered migrations 0001-0003, seven exact RLS policies, forced RLS, provider-role exclusion, and bounded grants.\n\nValidation: targeted projection/genesis suites (27 passed); npm run typecheck; npm run lint (0 errors, 11 pre-existing warnings).