### PR TITLE
fix(custom-registry): bind Supabase pooler login

### DIFF
--- a/lib/server/custom-launch/explore-directory-v1.ts
+++ b/lib/server/custom-launch/explore-directory-v1.ts
@@ -8,7 +8,8 @@ import type {
   CustomProjectExploreEntry,
   TokenLink,
 } from "../../tokens";
-import { getProductionWebsiteProjectionTargetV1 } from "../projection-target/website-target";
+import { getProductionWebsiteRegistryCustomPublicReadTargetV1 } from
+  "../projection-target/website-target";
 import { isCustomLaunchRegistryPublicReadEnabled } from "./public-readiness";
 import { withGenesisCanaryRegistryCustomStoreV1 } from
   "./genesis-canary-public-v1";
@@ -124,10 +125,10 @@ export async function readProductionCustomExploreDirectoryV1(
   signal: AbortSignal,
 ): Promise<readonly CustomProjectExploreEntry[]> {
   if (!isCustomLaunchRegistryPublicReadEnabled()) return Object.freeze([]);
-  const target = getProductionWebsiteProjectionTargetV1();
+  const target = getProductionWebsiteRegistryCustomPublicReadTargetV1();
   await target.assertProductionReadiness();
   const records = await withGenesisCanaryRegistryCustomStoreV1(
-    target.registryCustomPublicStore,
+    target.store,
   )
     .findVerifiedRegistryCustomLaunchesPublic({ signal });
   return Object.freeze(records.map(customLaunchProjectToExploreEntryV1));

--- a/lib/server/custom-launch/project-read-v2.ts
+++ b/lib/server/custom-launch/project-read-v2.ts
@@ -4,7 +4,8 @@ import { canonicalizeJson } from "../projection-target/canonical-json";
 import type {
   RegistryCustomLaunchPublicReadStoreV1,
 } from "./registry-public-store-v1";
-import { getProductionWebsiteProjectionTargetV1 } from "../projection-target/website-target";
+import { getProductionWebsiteRegistryCustomPublicReadTargetV1 } from
+  "../projection-target/website-target";
 import { isCustomLaunchRegistryPublicReadEnabled } from "./public-readiness";
 import { withGenesisCanaryRegistryCustomStoreV1 } from
   "./genesis-canary-public-v1";
@@ -80,11 +81,11 @@ export function createCustomLaunchProjectReadHandlersV2(input: Readonly<{
 let productionHandlers: ReturnType<typeof createCustomLaunchProjectReadHandlersV2> | null = null;
 
 async function production() {
-  const target = getProductionWebsiteProjectionTargetV1();
+  const target = getProductionWebsiteRegistryCustomPublicReadTargetV1();
   await target.assertProductionReadiness();
   productionHandlers ??= createCustomLaunchProjectReadHandlersV2({
     store: withGenesisCanaryRegistryCustomStoreV1(
-      target.registryCustomPublicStore,
+      target.store,
     ),
   });
   return productionHandlers;

--- a/lib/server/custom-launch/registry-public-read-v1.ts
+++ b/lib/server/custom-launch/registry-public-read-v1.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { canonicalizeJson } from "../projection-target/canonical-json";
 import type { Sha256Digest } from "../projection-target/hashing";
-import { getProductionWebsiteProjectionTargetV1 } from
+import { getProductionWebsiteRegistryCustomPublicReadTargetV1 } from
   "../projection-target/website-target";
 import { isCustomLaunchRegistryPublicReadEnabled } from "./public-readiness";
 import { withGenesisCanaryRegistryCustomStoreV1 } from
@@ -65,11 +65,11 @@ let productionHandlers:
 ReturnType<typeof createRegistryCustomLaunchPublicReadHandlersV1> | null = null;
 
 async function production() {
-  const target = getProductionWebsiteProjectionTargetV1();
+  const target = getProductionWebsiteRegistryCustomPublicReadTargetV1();
   await target.assertProductionReadiness();
   productionHandlers ??= createRegistryCustomLaunchPublicReadHandlersV1({
     store: withGenesisCanaryRegistryCustomStoreV1(
-      target.registryCustomPublicStore,
+      target.store,
     ),
   });
   return productionHandlers;

--- a/lib/server/custom-launch/registry-public-read-v1.ts
+++ b/lib/server/custom-launch/registry-public-read-v1.ts
@@ -65,14 +65,43 @@ let productionHandlers:
 ReturnType<typeof createRegistryCustomLaunchPublicReadHandlersV1> | null = null;
 
 async function production() {
-  const target = getProductionWebsiteRegistryCustomPublicReadTargetV1();
-  await target.assertProductionReadiness();
+  let target: ReturnType<
+    typeof getProductionWebsiteRegistryCustomPublicReadTargetV1
+  >;
+  try {
+    target = getProductionWebsiteRegistryCustomPublicReadTargetV1();
+  } catch (error) {
+    logProductionReadFailure("construction", error);
+    throw error;
+  }
+  try {
+    await target.assertProductionReadiness();
+  } catch (error) {
+    logProductionReadFailure("attestation", error);
+    throw error;
+  }
   productionHandlers ??= createRegistryCustomLaunchPublicReadHandlersV1({
     store: withGenesisCanaryRegistryCustomStoreV1(
       target.store,
     ),
   });
   return productionHandlers;
+}
+
+function logProductionReadFailure(
+  stage: "construction" | "attestation",
+  error: unknown,
+): void {
+  const code = error !== null && typeof error === "object"
+    && "code" in error && typeof error.code === "string"
+    && /^[A-Za-z0-9_-]{1,64}$/u.test(error.code)
+      ? error.code
+      : error instanceof TypeError ? "type_error" : "unknown";
+  console.error(JSON.stringify({
+    event: "registry_custom_public_read_dependency_failed",
+    stage,
+    code,
+  }));
 }
 
 export async function handleProductionRegistryCustomLaunchFeedV1(

--- a/lib/server/projection-target/website-target.ts
+++ b/lib/server/projection-target/website-target.ts
@@ -28,6 +28,8 @@ import {
 
 const DIGEST = /^sha256:[0-9a-f]{64}$/u;
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/+~-]{0,255}$/u;
+const SUPABASE_POOLER_HOST = /^aws-[0-9]+-[a-z0-9-]+\.pooler\.supabase\.com$/u;
+const SUPABASE_PROJECT_REF = /^[a-z]{20}$/u;
 
 export interface WebsiteProjectionTargetV1 {
   readonly handler: ProjectionTargetReferenceHandlerV1;
@@ -246,15 +248,7 @@ export function createProductionProjectionTargetPostgresPoolV1(
   if (!SAFE_ID.test(expectedRuntimeRole)) {
     throw new TypeError("website projection database role is invalid");
   }
-  let loginRole: string;
-  try {
-    loginRole = decodeURIComponent(new URL(tls.connectionString).username);
-  } catch {
-    throw new TypeError("website projection database login role is invalid");
-  }
-  if (loginRole !== expectedRuntimeRole) {
-    throw new TypeError("website projection database login role is invalid");
-  }
+  assertProductionDatabaseLoginRoleV1(tls.connectionString, expectedRuntimeRole);
   const pool = new Pool({
     connectionString: tls.connectionString,
     ssl: {
@@ -272,6 +266,28 @@ export function createProductionProjectionTargetPostgresPoolV1(
     // Route-level operations surface a bounded 503 without credential or URL data.
   });
   return new NodePostgresProjectionTargetPoolV1(pool, expectedRuntimeRole);
+}
+
+export function assertProductionDatabaseLoginRoleV1(
+  connectionString: string,
+  expectedRuntimeRole: string,
+): void {
+  let url: URL;
+  let loginRole: string;
+  try {
+    url = new URL(connectionString);
+    loginRole = decodeURIComponent(url.username);
+  } catch {
+    throw new TypeError("website projection database login role is invalid");
+  }
+  if (loginRole === expectedRuntimeRole) return;
+  const projectRef = loginRole.slice(expectedRuntimeRole.length + 1);
+  if (
+    !loginRole.startsWith(`${expectedRuntimeRole}.`)
+    || !SUPABASE_PROJECT_REF.test(projectRef)
+    || !SUPABASE_POOLER_HOST.test(url.hostname.toLowerCase())
+    || (url.port !== "5432" && url.port !== "6543")
+  ) throw new TypeError("website projection database login role is invalid");
 }
 
 export function verifiedPostgresTlsConfigurationV1(

--- a/lib/server/projection-target/website-target.ts
+++ b/lib/server/projection-target/website-target.ts
@@ -36,6 +36,11 @@ export interface WebsiteProjectionTargetV1 {
   readonly assertProductionReadiness: () => Promise<void>;
 }
 
+export interface WebsiteRegistryCustomPublicReadTargetV1 {
+  readonly store: PostgresRegistryCustomLaunchPublicStoreV1;
+  readonly assertProductionReadiness: () => Promise<void>;
+}
+
 export interface ProjectionTargetSecurityAttestationRowV1
 extends Record<string, unknown> {
   runtime_role: string;
@@ -79,6 +84,31 @@ export interface VerifiedPostgresTlsConfigurationV1 {
 }
 
 let productionTarget: WebsiteProjectionTargetV1 | null = null;
+let productionRegistryCustomPublicReadTarget:
+WebsiteRegistryCustomPublicReadTargetV1 | null = null;
+
+export function getProductionWebsiteRegistryCustomPublicReadTargetV1():
+WebsiteRegistryCustomPublicReadTargetV1 {
+  if (productionRegistryCustomPublicReadTarget !== null) {
+    return productionRegistryCustomPublicReadTarget;
+  }
+  const expectedDatabaseRole = environmentId(
+    "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE",
+  );
+  const pool = createProductionProjectionTargetPostgresPoolV1(
+    environmentValue("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL"),
+    environmentPem(
+      "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM",
+      "CERTIFICATE",
+    ),
+    expectedDatabaseRole,
+  );
+  productionRegistryCustomPublicReadTarget = Object.freeze({
+    store: new PostgresRegistryCustomLaunchPublicStoreV1(pool),
+    assertProductionReadiness: () => pool.assertProductionReadiness(),
+  });
+  return productionRegistryCustomPublicReadTarget;
+}
 
 export function getProductionWebsiteProjectionTargetV1(): WebsiteProjectionTargetV1 {
   if (productionTarget !== null) return productionTarget;

--- a/tests/website-projection-target.test.ts
+++ b/tests/website-projection-target.test.ts
@@ -46,6 +46,7 @@ import type {
 import {
   createWebsiteProjectionTargetV1,
   assertProjectionTargetSecurityAttestationV1,
+  assertProductionDatabaseLoginRoleV1,
   verifiedPostgresTlsConfigurationV1,
   type ProjectionTargetSecurityAttestationRowV1,
 } from "../lib/server/projection-target/website-target";
@@ -1384,6 +1385,28 @@ describe("Website projection target", () => {
       "postgresql://runtime:secret@db.example.com/postgres",
       "not-a-certificate",
     )).toThrow("database CA is invalid");
+  });
+
+  it("accepts only the exact runtime role or its verified Supabase pooler routing identity", () => {
+    expect(() => assertProductionDatabaseLoginRoleV1(
+      "postgresql://programmable_website_projection_runtime:secret@db.example.com:5432/postgres",
+      "programmable_website_projection_runtime",
+    )).not.toThrow();
+    expect(() => assertProductionDatabaseLoginRoleV1(
+      "postgresql://programmable_website_projection_runtime.mnnvlrqwhfoppogslsje:secret@aws-0-eu-central-1.pooler.supabase.com:6543/postgres",
+      "programmable_website_projection_runtime",
+    )).not.toThrow();
+    for (const connectionString of [
+      "postgresql://unexpected_runtime:secret@db.example.com:5432/postgres",
+      "postgresql://programmable_website_projection_runtime.mnnvlrqwhfoppogslsje:secret@db.example.com:6543/postgres",
+      "postgresql://programmable_website_projection_runtime.invalid:secret@aws-0-eu-central-1.pooler.supabase.com:6543/postgres",
+      "postgresql://programmable_website_projection_runtime.mnnvlrqwhfoppogslsje:secret@aws-0-eu-central-1.pooler.supabase.com:9999/postgres",
+    ]) {
+      expect(() => assertProductionDatabaseLoginRoleV1(
+        connectionString,
+        "programmable_website_projection_runtime",
+      )).toThrow("database login role is invalid");
+    }
   });
 
   it("fails the production attestation for every weakened TLS, RLS, or role axis", () => {


### PR DESCRIPTION
## Summary
- preserve exact website runtime-role binding for direct PostgreSQL connections
- allow only the official Supabase transaction/session pooler username form for the same role and a 20-character project reference
- reject wrong roles, non-Supabase hosts, malformed project refs, and non-database ports

## Validation
- ESLint
- 28 targeted tests
- TypeScript typecheck

The live database attestation still requires current_user and session_user to equal programmable_website_projection_runtime, TLS, forced RLS, and exact grants.