### PR TITLE
Make programmable.market the canonical website origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Programmable is an interface for launching tokens whose market behavior is defined by Uniswap v4 hooks.
 
-[programmable.family](https://programmable.family) · [X](https://x.com/0xProgrammable)
+[programmable.market](https://programmable.market) · [X](https://x.com/0xProgrammable)
 
 ## Launch models
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,7 @@ const plexMono = IBM_Plex_Mono({
   weight: ["400", "500", "600"],
 });
 
-const siteUrl = new URL("https://programmable.family");
+const siteUrl = new URL("https://programmable.market");
 const siteDescription = "Tokens that behave how you imagine.";
 const socialImageUrl = new URL(
   "/og/programmable-loop-og-1200x630.png",

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+const SITE_ORIGIN = "https://programmable.market";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/", "/analytics"],
+    },
+    sitemap: `${SITE_ORIGIN}/sitemap.xml`,
+    host: SITE_ORIGIN,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from "next";
+
+const SITE_ORIGIN = "https://programmable.market";
+
+const PUBLIC_ROUTES = [
+  "",
+  "/explore",
+  "/launch",
+  "/docs",
+  "/docs/developers",
+  "/docs/models/classic",
+  "/docs/models/custom",
+  "/docs/models/stock-paired",
+  "/profile",
+] as const;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return PUBLIC_ROUTES.map((route) => ({
+    url: `${SITE_ORIGIN}${route}`,
+  }));
+}

--- a/components/developer-docs-workbench.tsx
+++ b/components/developer-docs-workbench.tsx
@@ -112,7 +112,7 @@ export function buildDeveloperAgentPrompt(
   "Integrate the active Programmable launch feed into this project.",
   "",
   "Read these sources first:",
-  "1. https://programmable.family/docs/developers.md",
+  "1. https://programmable.market/docs/developers.md",
   `2. ${PROGRAMMABLE_WELL_KNOWN_URL}`,
   `3. ${PROGRAMMABLE_OPENAPI_URL}`,
   `4. ${PROGRAMMABLE_DEVELOPER_REPOSITORY}/blob/main/docs/guides/terminals-and-scanners.md`,

--- a/components/explore-preview-data.ts
+++ b/components/explore-preview-data.ts
@@ -13,7 +13,7 @@ export type ExplorePreviewProject = {
 };
 
 const PROJECT_LINKS = [
-  { kind: "website" as const, url: "https://programmable.family" },
+  { kind: "website" as const, url: "https://programmable.market" },
   { kind: "x" as const, url: "https://x.com/0xProgrammable" },
   { kind: "telegram" as const, url: "https://t.me/programmable" },
 ];
@@ -359,7 +359,7 @@ export const EXPLORE_PREVIEW_CUSTOM_PROJECT: CustomProjectExploreEntry = {
   symbol: "SIGNAL",
   description: "A reviewed Custom Hook launch with explicit post-launch authority.",
   imageUrl: "/brand/projects/common-ground-v1.webp",
-  links: [{ kind: "website", url: "https://programmable.family" }],
+  links: [{ kind: "website", url: "https://programmable.market" }],
   launchedAt: "2026-08-06T12:00:00.000Z",
   finalizedAt: "2026-08-06T12:02:00.000Z",
   chainId: "1",

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,16 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.programmable.market" }],
+        destination: "https://programmable.market/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/tests/programmable-market-domain.test.ts
+++ b/tests/programmable-market-domain.test.ts
@@ -1,0 +1,45 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import nextConfig from "../next.config";
+import robots from "../app/robots";
+import sitemap from "../app/sitemap";
+
+describe("programmable.market website origin", () => {
+  it("publishes the new canonical origin in website metadata", async () => {
+    const layoutSource = await readFile(
+      new URL("../app/layout.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(layoutSource).toContain(
+      'const siteUrl = new URL("https://programmable.market")',
+    );
+    expect(layoutSource).not.toContain(
+      'const siteUrl = new URL("https://programmable.family")',
+    );
+  });
+
+  it("publishes robots and sitemap on the canonical origin", () => {
+    expect(robots()).toMatchObject({
+      host: "https://programmable.market",
+      sitemap: "https://programmable.market/sitemap.xml",
+    });
+    expect(sitemap()).not.toHaveLength(0);
+    expect(
+      sitemap().every(({ url }) => url.startsWith("https://programmable.market")),
+    ).toBe(true);
+  });
+
+  it("redirects only the new www host to the apex", async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toEqual([
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.programmable.market" }],
+        destination: "https://programmable.market/:path*",
+        permanent: true,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- make `https://programmable.market` the website metadata and public self-link origin
- redirect only `www.programmable.market` to the apex
- add canonical `robots.txt` and `sitemap.xml`
- retain `programmable.family` and `developers.programmable.family` as compatibility origins

## Validation

- `npm run lint` (0 errors; 11 pre-existing warnings)
- `npm run typecheck`
- `npx vitest run tests/programmable-market-domain.test.ts tests/developer-docs-contract-parity.test.ts tests/explore-interface-preview.test.ts tests/custom-launch-public-surface-parity.test.ts` (15/15)
- `npm run build`
- live alias verified against production deployment `dpl_F7UkugKDhkXqKm82v6qDjyxujCcX`

## Compatibility

No `.family` redirect is introduced in this PR. Existing API callbacks, origin-scoped browser state, and Developer API clients continue to work unchanged.