### PR TITLE
Accept Vercel built-in deployment commit metadata

### DIFF
--- a/scripts/perf/read-model-live-verifier.mjs
+++ b/scripts/perf/read-model-live-verifier.mjs
@@ -22,6 +22,7 @@ async function boundedFetch(fetchImpl, url, init, timeoutMs = 10_000) {
 function deploymentCommit(deployment) {
   const candidates = [
     deployment?.meta?.githubCommitSha,
+    deployment?.meta?.gitCommitSha,
     deployment?.gitSource?.sha,
     deployment?.github?.commitSha,
   ];

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -712,4 +712,36 @@ describe("post-promotion route verification", () => {
       }),
     ).rejects.toThrow("automatic production-domain assignment");
   });
+
+  it("accepts Vercel built-in Git commit metadata for the rollback binding", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      if (url.hostname === "api.vercel.com") {
+        return Response.json({
+          id: DEPLOYMENT_ID,
+          url: "programmable-tested.vercel.app",
+          readyState: "READY",
+          projectId: PROJECT_ID,
+          meta: { gitCommitSha: GIT_HEAD },
+        });
+      }
+      return base(input);
+    };
+
+    await expect(
+      resolveProductionBinding({
+        targetUrl: "https://programmable.family",
+        token: "vercel-test-token",
+        teamId: "team_programmable_test",
+        projectId: PROJECT_ID,
+        fetchImpl,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        deploymentId: DEPLOYMENT_ID,
+        gitHead: GIT_HEAD,
+      }),
+    );
+  });
 });


### PR DESCRIPTION
Fix the production rollback binding for standard Vercel deployments.

Vercel exposes the current live commit as `meta.gitCommitSha`; staged releases additionally set `meta.githubCommitSha`. The verifier now accepts either exact 40-character commit field while retaining the same deployment, project, READY-state, and rejection checks.

Validation:
- focused read-model operations tests: 23 passed
- live rollback binding resolves current deployment and exact production SHA
- operations source contract: passed
- typecheck: passed
- lint: 0 errors (11 pre-existing warnings)