### PR TITLE
Accept hybrid registry read source in production smoke

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -480,8 +480,11 @@ jobs:
                 if (Buffer.byteLength(text, "utf8") > 2 * 1024 * 1024) {
                   throw new Error(`${path} returned an oversized response`);
                 }
+                const readSource = response.headers.get(
+                  "x-programmable-read-source",
+                );
                 if (
-                  response.headers.get("x-programmable-read-source") !== "blob" ||
+                  !["blob", "blob+postgres"].includes(readSource ?? "") ||
                   response.headers.get("x-programmable-rpc-provider") !== "alchemy"
                 ) {
                   throw new Error(`${path} did not prove the Alchemy RPC source`);

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1089,7 +1089,7 @@ export function evaluateReadModelOperationsSourceContracts(
         "STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
       ) &&
       stagedAlchemySmokeBlock.includes(
-        'response.headers.get("x-programmable-read-source") !== "blob"',
+        '!["blob", "blob+postgres"].includes(readSource ?? "")',
       ) &&
       stagedAlchemySmokeBlock.includes(
         'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
@@ -1102,7 +1102,7 @@ export function evaluateReadModelOperationsSourceContracts(
       (stagedAlchemySmokeBlock.match(/\bfetch\(/gu) ?? []).length === 1 &&
       !stagedAlchemySmokeBlock.includes("/api/ops/health") &&
       !stagedAlchemySmokeBlock.includes("/api/explore/profile") &&
-      !/(?:postgres|database|projector|quicknode|envio|real-block|sla)/iu.test(
+      !/(?:database|projector|quicknode|envio|real-block|sla)/iu.test(
         stagedAlchemySmokeBlock,
       ) &&
       !stagedAlchemySmokeBlock.includes(

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -585,7 +585,7 @@ describe("read-model production deploy policy", () => {
     );
     expect(workflow).toContain("headers: alchemySmokeRequestHeaders");
     expect(workflow).toContain(
-      'response.headers.get("x-programmable-read-source") !== "blob"',
+      '!["blob", "blob+postgres"].includes(readSource ?? "")',
     );
     expect(workflow).toContain(
       'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
@@ -599,7 +599,7 @@ describe("read-model production deploy policy", () => {
     expect(alchemySmoke).not.toContain("/api/ops/health");
     expect(alchemySmoke).not.toContain("/api/explore/profile");
     expect(alchemySmoke).not.toMatch(
-      /(?:postgres|database|projector|quicknode|envio|real-block|sla)/iu,
+      /(?:database|projector|quicknode|envio|real-block|sla)/iu,
     );
     expect(workflow).toContain("Reverify staged candidate binding");
     expect(workflow).toContain("Record staged candidate handoff");


### PR DESCRIPTION
Update the staged Alchemy API smoke for the live Registry read architecture.

The production and staged responses both prove `x-programmable-rpc-provider: alchemy`, while the read source is now `blob+postgres` after the Registry cutover. The smoke accepts only the two known exact read-source values (`blob` and `blob+postgres`) and keeps every provider, payload, ordering, token-list, and detail assertion unchanged.

Validation:
- real staged candidate returned `blob+postgres` + `alchemy` and a bounded 20-token ready page
- operations source contract: passed
- focused policy/operations tests: 37 passed
- typecheck: passed
- lint: 0 errors (11 pre-existing warnings)