### PR TITLE
Fix mixed Classic and Custom launch ordering

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -518,30 +518,124 @@ jobs:
           if (!releaseToken) {
             throw new Error("staged Alchemy Explore has no token identity");
           }
+          const newestPageSize = 100;
           const newest = await requestJson(
-            "/api/explore?limit=20&page=1&sort=newest",
+            `/api/explore?limit=${newestPageSize}&page=1&sort=newest`,
           );
+          const newestTotal = Number(newest.total);
+          const newestTotalPages = Number(newest.totalPages);
           if (
             newest.status !== "ready" ||
             !Array.isArray(newest.tokens) ||
-            newest.tokens.length < 1
+            newest.tokens.length < 1 ||
+            newest.page !== 1 ||
+            newest.pageSize !== newestPageSize ||
+            !Number.isSafeInteger(newestTotal) ||
+            newestTotal < 1 ||
+            newestTotal > 10_000 ||
+            !Number.isSafeInteger(newestTotalPages) ||
+            newestTotalPages < 1 ||
+            newestTotalPages > 100 ||
+            newestTotalPages !== Math.ceil(newestTotal / newestPageSize)
           ) {
             throw new Error("staged Alchemy newest page is not populated");
           }
-          for (let index = 1; index < newest.tokens.length; index += 1) {
-            const previous = newest.tokens[index - 1];
-            const current = newest.tokens[index];
-            const previousOrder = [
-              BigInt(previous.launchBlockNumber ?? "-1"),
-              BigInt(previous.launchTransactionIndex ?? -1),
-              BigInt(previous.launchLogIndex ?? -1),
-            ];
-            const currentOrder = [
-              BigInt(current.launchBlockNumber ?? "-1"),
-              BigInt(current.launchTransactionIndex ?? -1),
-              BigInt(current.launchLogIndex ?? -1),
-            ];
+          const newestTokens = [];
+          const seenNewestIds = new Set();
+          for (let pageNumber = 1; pageNumber <= newestTotalPages; pageNumber += 1) {
+            const page = pageNumber === 1
+              ? newest
+              : await requestJson(
+                  `/api/explore?limit=${newestPageSize}&page=${pageNumber}&sort=newest`,
+                );
             if (
+              page.status !== "ready" ||
+              page.page !== pageNumber ||
+              page.pageSize !== newestPageSize ||
+              page.total !== newestTotal ||
+              page.totalPages !== newestTotalPages ||
+              !Array.isArray(page.tokens) ||
+              page.tokens.length < 1
+            ) {
+              throw new Error("staged Alchemy newest pagination is not stable");
+            }
+            for (const entry of page.tokens) {
+              if (typeof entry?.id !== "string" || seenNewestIds.has(entry.id)) {
+                throw new Error("staged Alchemy newest pagination is not unique");
+              }
+              seenNewestIds.add(entry.id);
+              newestTokens.push(entry);
+            }
+          }
+          if (newestTokens.length !== newestTotal) {
+            throw new Error("staged Alchemy newest pagination is incomplete");
+          }
+          const newestChainId = String(newest.snapshot?.chainId ?? "");
+          if (!/^(?:0|[1-9][0-9]*)$/.test(newestChainId)) {
+            throw new Error("staged Alchemy newest snapshot has no canonical chain");
+          }
+          const launchChainId = (entry) => {
+            const value = entry.exploreKind === "token"
+              ? String(entry.id).split(":", 1)[0]
+              : entry.exploreKind === "custom-project"
+                ? String(entry.chainId ?? "")
+                : "";
+            if (!/^(?:0|[1-9][0-9]*)$/.test(value)) {
+              throw new Error("staged Alchemy newest entry has no canonical chain");
+            }
+            return value;
+          };
+          const launchOrder = (entry) => {
+            const coordinates = entry.exploreKind === "token"
+              ? [
+                  entry.launchBlockNumber,
+                  entry.launchTransactionIndex,
+                  entry.launchLogIndex,
+                ]
+              : entry.exploreKind === "custom-project" &&
+                  entry.launchCategoryProvenance?.category === "custom"
+                ? [
+                    entry.launchCategoryProvenance.blockNumber,
+                    entry.launchCategoryProvenance.transactionIndex,
+                    entry.launchCategoryProvenance.logIndex,
+                  ]
+                : null;
+            if (coordinates === null || coordinates.length !== 3) {
+              throw new Error(
+                "staged Alchemy newest entry has no canonical launch order",
+              );
+            }
+            return coordinates.map((value) => {
+              const normalized = String(value ?? "");
+              if (!/^(?:0|[1-9][0-9]*)$/.test(normalized)) {
+                throw new Error(
+                  "staged Alchemy newest entry has no canonical launch order",
+                );
+              }
+              return BigInt(normalized);
+            });
+          };
+          const launchTime = (entry) => {
+            const value = Date.parse(entry.launchedAt ?? "");
+            if (!Number.isFinite(value)) {
+              throw new Error("staged Alchemy newest entry has no canonical time");
+            }
+            return value;
+          };
+          for (const entry of newestTokens) {
+            if (launchChainId(entry) !== newestChainId) {
+              throw new Error("staged Alchemy newest entry is on another chain");
+            }
+            launchOrder(entry);
+            launchTime(entry);
+          }
+          for (let index = 1; index < newestTokens.length; index += 1) {
+            const previous = newestTokens[index - 1];
+            const current = newestTokens[index];
+            const previousOrder = launchOrder(previous);
+            const currentOrder = launchOrder(current);
+            if (
+              launchTime(current) > launchTime(previous) ||
               currentOrder.some(
                 (value, offset) =>
                   value > previousOrder[offset] &&
@@ -553,6 +647,23 @@ jobs:
             ) {
               throw new Error("staged Alchemy newest page is not ordered newest-first");
             }
+          }
+          const oldest = await requestJson(
+            `/api/explore?limit=${newestPageSize}&page=1&sort=oldest`,
+          );
+          const expectedOldestIds = newestTokens
+            .slice(-newestPageSize)
+            .reverse()
+            .map((entry) => entry.id);
+          if (
+            oldest.status !== "ready" ||
+            oldest.total !== newestTotal ||
+            oldest.totalPages !== newestTotalPages ||
+            !Array.isArray(oldest.tokens) ||
+            oldest.tokens.map((entry) => entry.id).join("\n") !==
+              expectedOldestIds.join("\n")
+          ) {
+            throw new Error("staged Alchemy oldest page is not ordered oldest-first");
           }
           const incrementalLaunchAddress =
             "0x468505087c2dfec4779f2d6a5f8481f03e32e905";

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -97,9 +97,77 @@ function entryLaunchTime(entry: ExploreEntry): number {
   return Number.isFinite(value) ? value : 0;
 }
 
+function nonNegativeInteger(value: unknown): bigint | null {
+  const normalized = String(value ?? "");
+  return /^(?:0|[1-9][0-9]*)$/u.test(normalized)
+    ? BigInt(normalized)
+    : null;
+}
+
+function entryChainId(entry: ExploreEntry): string | null {
+  if (entry.exploreKind === "custom-project") return entry.chainId;
+  const [chainId] = entry.id.split(":", 1);
+  return /^\d+$/u.test(chainId ?? "") ? chainId : null;
+}
+
+function entryLaunchOrder(
+  entry: ExploreEntry,
+): readonly [bigint, bigint, bigint] | null {
+  const values = entry.exploreKind === "token"
+    ? [
+        entry.launchBlockNumber,
+        entry.launchTransactionIndex,
+        entry.launchLogIndex,
+      ]
+    : entry.launchCategoryProvenance.source === "registry.custom-launched"
+      ? [
+          entry.launchCategoryProvenance.blockNumber,
+          entry.launchCategoryProvenance.transactionIndex,
+          entry.launchCategoryProvenance.logIndex,
+        ]
+      : null;
+  if (values === null) return null;
+  const coordinates = values.map(nonNegativeInteger);
+  return coordinates.every((value): value is bigint => value !== null)
+    ? [coordinates[0], coordinates[1], coordinates[2]]
+    : null;
+}
+
+function compareCanonicalLaunchOrder(
+  first: ExploreEntry,
+  second: ExploreEntry,
+): number {
+  const firstChainId = entryChainId(first);
+  const secondChainId = entryChainId(second);
+  const firstOrder = entryLaunchOrder(first);
+  const secondOrder = entryLaunchOrder(second);
+  if (
+    firstChainId === null ||
+    firstChainId !== secondChainId ||
+    firstOrder === null ||
+    secondOrder === null
+  ) {
+    return 0;
+  }
+  for (let index = 0; index < firstOrder.length; index += 1) {
+    if (firstOrder[index] === secondOrder[index]) continue;
+    return firstOrder[index] > secondOrder[index] ? -1 : 1;
+  }
+  return 0;
+}
+
 function compareNewestEntries(first: ExploreEntry, second: ExploreEntry): number {
   const time = entryLaunchTime(second) - entryLaunchTime(first);
-  return time === 0 ? first.id.localeCompare(second.id) : time;
+  if (time !== 0) return time;
+  const firstChainId = entryChainId(first);
+  const secondChainId = entryChainId(second);
+  if (firstChainId !== secondChainId) {
+    if (firstChainId === null) return 1;
+    if (secondChainId === null) return -1;
+    return BigInt(firstChainId) < BigInt(secondChainId) ? -1 : 1;
+  }
+  const canonicalOrder = compareCanonicalLaunchOrder(first, second);
+  return canonicalOrder === 0 ? first.id.localeCompare(second.id) : canonicalOrder;
 }
 
 function sortExploreEntries(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1097,6 +1097,27 @@ export function evaluateReadModelOperationsSourceContracts(
       stagedAlchemySmokeBlock.includes(
         '"/api/explore?limit=20&page=1&sort=market-cap"',
       ) &&
+      stagedAlchemySmokeBlock.includes(
+        "entry.launchCategoryProvenance.blockNumber",
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        "entry.launchCategoryProvenance.transactionIndex",
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        "entry.launchCategoryProvenance.logIndex",
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        "staged Alchemy newest entry has no canonical launch order",
+      ) &&
+      stagedAlchemySmokeBlock.includes("coordinates === null") &&
+      stagedAlchemySmokeBlock.includes("const newestPageSize = 100") &&
+      stagedAlchemySmokeBlock.includes("seenNewestIds") &&
+      stagedAlchemySmokeBlock.includes("newestTokens.length !== newestTotal") &&
+      stagedAlchemySmokeBlock.includes("launchChainId(entry) !== newestChainId") &&
+      stagedAlchemySmokeBlock.includes("sort=oldest") &&
+      stagedAlchemySmokeBlock.includes(
+        "staged Alchemy oldest page is not ordered oldest-first",
+      ) &&
       stagedAlchemySmokeBlock.includes('"/api/indexers/v1/token-list"') &&
       stagedAlchemySmokeBlock.includes("/api/explore/token?address=") &&
       (stagedAlchemySmokeBlock.match(/\bfetch\(/gu) ?? []).length === 1 &&

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -590,6 +590,23 @@ describe("read-model production deploy policy", () => {
     expect(workflow).toContain(
       'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
     );
+    expect(workflow).toContain("entry.launchCategoryProvenance.blockNumber");
+    expect(workflow).toContain(
+      "entry.launchCategoryProvenance.transactionIndex",
+    );
+    expect(workflow).toContain("entry.launchCategoryProvenance.logIndex");
+    expect(workflow).toContain(
+      "staged Alchemy newest entry has no canonical launch order",
+    );
+    expect(workflow).toContain("coordinates === null");
+    expect(workflow).toContain("const newestPageSize = 100");
+    expect(workflow).toContain("seenNewestIds");
+    expect(workflow).toContain("newestTokens.length !== newestTotal");
+    expect(workflow).toContain("launchChainId(entry) !== newestChainId");
+    expect(workflow).toContain("sort=oldest");
+    expect(workflow).toContain(
+      "staged Alchemy oldest page is not ordered oldest-first",
+    );
     expect(workflow).toContain('"/api/indexers/v1/token-list"');
     expect(workflow).toContain("/api/explore/token?address=");
     const alchemySmoke = workflow.slice(

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import type { ExploreReadModel } from "../lib/onchain/types";
-import type { LauncherToken } from "../lib/tokens";
+import type { ExploreEntry, LauncherToken } from "../lib/tokens";
 
 const mocks = vi.hoisted(() => ({
   enrichTokensWithAlchemyPrices: vi.fn(),
@@ -25,7 +25,11 @@ vi.mock("../lib/alchemy/live-market.server", () => ({
   enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
 }));
 
-import { GET, inheritExploreEthUsdQuote } from "../app/api/explore/route";
+import {
+  GET,
+  inheritExploreEthUsdQuote,
+  paginateExploreEntriesV1,
+} from "../app/api/explore/route";
 
 const HOOK_ADDRESS =
   "0x3333333333333333333333333333333333333333" as const;
@@ -69,6 +73,53 @@ function readyModel(): ExploreReadModel {
   };
 }
 
+function orderedEntry(input: Readonly<{
+  id: string;
+  kind: "token" | "custom-project";
+  block: string;
+  transaction: number;
+  log: number;
+  chainId?: string;
+  launchedAt?: string;
+}>): ExploreEntry {
+  const base = {
+    exploreKind: input.kind,
+    id: input.id,
+    name: input.id,
+    symbol: input.id,
+    launchedAt: input.launchedAt ?? "2026-08-07T00:00:00.000Z",
+    links: [],
+  };
+  if (input.kind === "token") {
+    return {
+      ...base,
+      launchBlockNumber: input.block,
+      launchTransactionIndex: input.transaction,
+      launchLogIndex: input.log,
+      launchCategoryProvenance: {
+        schemaVersion: "programmable.explore-launch-category-provenance.v1",
+        category: "classic",
+        source: "canonical-launch-read-model",
+        recordId: input.id,
+        modelId: "classic",
+        modelVersion: "classic-v3",
+      },
+    } as unknown as ExploreEntry;
+  }
+  return {
+    ...base,
+    chainId: input.chainId ?? "1",
+    launchCategoryProvenance: {
+      schemaVersion: "programmable.explore-launch-category-provenance.v1",
+      category: "custom",
+      source: "registry.custom-launched",
+      blockNumber: input.block,
+      transactionIndex: input.transaction,
+      logIndex: input.log,
+    },
+  } as unknown as ExploreEntry;
+}
+
 describe("Explore API Alchemy boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -110,6 +161,126 @@ describe("Explore API Alchemy boundary", () => {
         snapshot,
       ),
     ).toEqual({ ...launchSnapshot, ethUsdQuote });
+  });
+
+  it("orders mixed Classic and Custom launches by canonical chain position", () => {
+    const entries = [
+      orderedEntry({
+        id: "1:classic-log-8",
+        kind: "token",
+        block: "101",
+        transaction: 5,
+        log: 8,
+      }),
+      orderedEntry({
+        id: "custom:older-block",
+        kind: "custom-project",
+        block: "100",
+        transaction: 9,
+        log: 9,
+      }),
+      orderedEntry({
+        id: "custom:log-9",
+        kind: "custom-project",
+        block: "101",
+        transaction: 5,
+        log: 9,
+      }),
+      orderedEntry({
+        id: "1:newest-block",
+        kind: "token",
+        block: "102",
+        transaction: 0,
+        log: 0,
+      }),
+      orderedEntry({
+        id: "1:transaction-6",
+        kind: "token",
+        block: "101",
+        transaction: 6,
+        log: 0,
+      }),
+    ];
+    const paginate = (sort: "newest" | "oldest") =>
+      paginateExploreEntriesV1(entries, {
+        page: 1,
+        pageSize: entries.length,
+        query: "",
+        socials: null,
+        sort,
+        topThenNewest: false,
+      }).tokens.map(({ id }) => id);
+
+    const newest = [
+      "1:newest-block",
+      "1:transaction-6",
+      "custom:log-9",
+      "1:classic-log-8",
+      "custom:older-block",
+    ];
+    expect(paginate("newest")).toEqual(newest);
+    expect(paginate("oldest")).toEqual([...newest].reverse());
+  });
+
+  it("keeps mixed-chain ordering total and independent of input order", () => {
+    const entries = [
+      orderedEntry({
+        id: "2:newer-time",
+        kind: "token",
+        block: "1",
+        transaction: 0,
+        log: 0,
+        launchedAt: "2026-08-07T01:00:00.000Z",
+      }),
+      orderedEntry({
+        id: "1:block-7",
+        kind: "token",
+        block: "7",
+        transaction: 0,
+        log: 0,
+      }),
+      orderedEntry({
+        id: "custom:chain-1-block-6",
+        kind: "custom-project",
+        block: "6",
+        transaction: 0,
+        log: 0,
+        chainId: "1",
+      }),
+      orderedEntry({
+        id: "custom:chain-2-block-999",
+        kind: "custom-project",
+        block: "999",
+        transaction: 0,
+        log: 0,
+        chainId: "2",
+      }),
+    ];
+    const expected = [
+      "2:newer-time",
+      "1:block-7",
+      "custom:chain-1-block-6",
+      "custom:chain-2-block-999",
+    ];
+    const permutations = [
+      entries,
+      [...entries].reverse(),
+      [entries[2], entries[0], entries[3], entries[1]],
+      [entries[3], entries[1], entries[0], entries[2]],
+    ];
+
+    for (const candidates of permutations) {
+      expect(
+        paginateExploreEntriesV1(candidates, {
+          page: 1,
+          pageSize: candidates.length,
+          query: "",
+          socials: null,
+          sort: "newest",
+          topThenNewest: false,
+        }).tokens.map(({ id }) => id),
+      ).toEqual(expected);
+    }
   });
 
   it.each([


### PR DESCRIPTION
Fixes the production staging gate discovered during the programmable.market release.\n\nThe previous gate read only Classic launch coordinates, so a valid Custom registry launch was treated as missing and the deployment was rejected. This change adds one deterministic ordering contract for Classic and Custom launches, scans the complete bounded catalog, validates newest and oldest order, and fails closed on malformed or drifting pages.\n\nIt also fixes same-block transaction and log ordering that timestamp-only sorting could misorder.\n\nValidation:\n- 50 focused tests passed\n- Typecheck passed\n- Targeted lint passed\n- Read-model operations gate passed\n- Independent release review found no blocking issues