### PR TITLE
Fix Privy wallet login and branding

### DIFF
--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -290,7 +290,7 @@ const privyConfig = {
   appearance: {
     theme: "light",
     accentColor: "#465a6f",
-    logo: "/icon-512.png",
+    logo: "/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png",
     landingHeader: "Connect to Programmable",
     loginMessage: "Use a wallet or email to continue",
     showWalletLoginFirst: true,

--- a/tests/branding-assets.test.ts
+++ b/tests/branding-assets.test.ts
@@ -82,6 +82,15 @@ describe("Programmable branding assets", () => {
     );
   });
 
+  it("uses the current Warm Ivory loop mark in the Privy login modal", () => {
+    const walletProvider = read("components/wallet-provider.tsx");
+
+    expect(walletProvider).toContain(
+      'logo: "/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"',
+    );
+    expect(walletProvider).not.toContain('logo: "/icon-512.png"');
+  });
+
   it("binds metadata to the cache-busted, tightly framed favicon set", () => {
     const layout = read("app/layout.tsx");
 


### PR DESCRIPTION
## What changed

- allow the current Programmable loop mark to appear in the Privy login modal
- keep the old generic app icon out of the wallet login surface

## Live configuration repair

Privy allowed origins now include both `https://programmable.market` and `https://www.programmable.market`. The embedded-wallet iframe CSP was rechecked live and now includes both origins.

## Verification

- `npx vitest run tests/branding-assets.test.ts tests/wallet-state.test.ts`
- `npm run typecheck`
- `npx eslint components/wallet-provider.tsx tests/branding-assets.test.ts`
- `npm run build`