### PR TITLE
[codex] add graph launch stamp canary

### DIFF
--- a/contracts/spec/programmable-graph-mainnet-canary-v1.json
+++ b/contracts/spec/programmable-graph-mainnet-canary-v1.json
@@ -1,0 +1,196 @@
+{
+  "schemaVersion": "programmable-graph-mainnet-canary-v1",
+  "status": "LOCAL_AND_EPHEMERAL_MAINNET_FORK_VALIDATED_NOT_DEPLOYED",
+  "purpose": "Low-value, honestly tradable Mainnet canary for the exact Programmable Stamp Router Graph route.",
+  "claims": {
+    "productionDeployed": false,
+    "mainnetTransactionSent": false,
+    "independentlyAudited": false,
+    "liquidityLocked": false,
+    "fairLaunch": false,
+    "economicSafety": false
+  },
+  "source": {
+    "baseCommit": "bc43a26b4d1142c5934e871355fac7a909c81754",
+    "solidity": "0.8.26",
+    "optimizerRuns": 1000,
+    "files": [
+      {
+        "path": "src/ProgrammableCanaryTokenV1.sol",
+        "sha256": "7a77f7c52745323402115722ddc115c7e26b5917d584ce93346d3c220e85f095",
+        "creationCodeBytesBeforeConstructorArgs": 3656,
+        "runtimeCodeBytesBeforeImmutableSubstitution": 2130,
+        "reuse": "new-minimal-fixed-supply-token"
+      },
+      {
+        "path": "src/ProgrammableCanaryLiquidityInitializerV1.sol",
+        "sha256": "98bc33dacb5ab6039905921bbf8217514334bc127af54886643e591d5b999d5e",
+        "creationCodeBytesBeforeConstructorArgs": 15983,
+        "runtimeCodeBytesBeforeImmutableSubstitution": 14825,
+        "reuse": "new-one-shot-graph-initializer-over-reviewed-position-planner-actions"
+      },
+      {
+        "path": "src/PlatformFeeHookV1.sol",
+        "sha256": "dfe33c41d1e0bcabfdca29e16e3885a22fa61479beaacbb5ba5cd1ab7e536eec",
+        "gitBlob": "fea5e2eb53c6ade79b0af2d7f695ec62549ad6b3",
+        "creationCodeBytesBeforeConstructorArgs": 9473,
+        "runtimeCodeBytesBeforeImmutableSubstitution": 7986,
+        "reuse": "unchanged-existing-hook"
+      }
+    ]
+  },
+  "mainnetBindings": {
+    "chainId": 1,
+    "graphFactory": {
+      "address": "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
+      "runtimeCodeHash": "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8"
+    },
+    "poolManager": {
+      "address": "0x000000000004444c5dc75cB358380D2e3dE08A90",
+      "runtimeCodeHash": "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293"
+    },
+    "positionManager": {
+      "address": "0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e",
+      "runtimeCodeHash": "0x77e36c08b19959a30dde46dec9abe6208e371ff2f56884a56fe1e1a53615528b"
+    },
+    "permit2": {
+      "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      "canaryTokenApprovalUsed": false,
+      "reason": "The reviewed DirectLiquidityLauncherV1 pattern pre-transfers the exact token budget to PositionManager, so the canary creates no persistent Permit2 allowance."
+    },
+    "stampRouter": {
+      "address": null,
+      "requiredBeforeFinalManifest": true,
+      "mustEqualGraphAuthorizedLauncher": true,
+      "mustBindExactDeploymentSet": true,
+      "componentEncoding": "the exact three Graph deployments, unique and strictly numerically address-sorted; Graph target order remains initializer, token, hook"
+    }
+  },
+  "token": {
+    "name": "Programmable Mainnet Canary",
+    "symbol": "PCAN",
+    "decimals": 18,
+    "totalSupply": "1000000000000000000000000",
+    "initialRecipient": "predicted-initializer-address",
+    "launchWallet": null,
+    "admin": null,
+    "ownerRole": null,
+    "upgradeability": false,
+    "pause": false,
+    "blacklist": false,
+    "transferTax": false,
+    "additionalMint": false
+  },
+  "pool": {
+    "currency0": "0x0000000000000000000000000000000000000000",
+    "currency1": "predicted-token-address",
+    "lpFeePips": 3000,
+    "lpFeeBps": 30,
+    "tickSpacing": 60,
+    "initialTick": 207240,
+    "approximateInitialRawTokenPerNative": "999698077.713835",
+    "position": {
+      "kind": "full-range",
+      "tickLower": -887220,
+      "tickUpper": 887220,
+      "nftRecipient": null,
+      "locked": false,
+      "removableByNftOwner": true
+    },
+    "reviewedBudgets": {
+      "nativeWei": "1000000000000000",
+      "tokenWei": "1000000000000000000000000",
+      "unusedNativeRecipient": "launchWallet",
+      "unusedTokenRecipient": "launchWallet"
+    }
+  },
+  "programmableFee": {
+    "recipient": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+    "feePips": 1000,
+    "denominator": 1000000,
+    "feeBps": 10,
+    "rounding": "floor",
+    "basis": {
+      "exactInput": "output-currency-amount",
+      "exactOutput": "input-currency-amount"
+    },
+    "settlement": "PoolManager ERC6909 claims accrue only to the immutable hook; permissionless redemption sends all claims directly to the immutable recipient.",
+    "beforeSwapReturnDelta": false,
+    "hookAddressPermissionMask": "0x3fff",
+    "requiredHookAddressFlags": "0x2044",
+    "permissions": [
+      "beforeInitialize",
+      "afterSwap",
+      "afterSwapReturnDelta"
+    ]
+  },
+  "graph": {
+    "routeNamespace": "0xa93f0eb8b0e018d494b55cbf9b15d30252a8378059f010c51beeb8deb16136ae",
+    "routeNonce": null,
+    "topologyHash": "0x69437db25128cb7c3b73a64ed7336d4238d3cf238be98b3d2758f3098a8fbd66",
+    "graphCommitment": null,
+    "totalValueWei": "1000000000000000",
+    "atomicity": "Graph Factory deploys all raw CREATE2 targets first, then calls the initializer; any failure reverts deployment, pool initialization, and LP mint.",
+    "targetOrder": [
+      {
+        "index": 0,
+        "id": "programmable-canary-initializer-v1",
+        "targetIdHash": "0x68e386adabfc4d8f9283fc52d3f0c22cfdabdb19e4a3adf1d20bfcb47fb63800",
+        "applicantSalt": "0xf6aae3ef91bc644c49f31ecc338b6267c6457cbdf849a53920c855c6719699a4",
+        "deploymentValueWei": "0",
+        "initializerValueWei": "1000000000000000",
+        "expectedDeployment": null,
+        "expectedRuntimeCodeHash": null
+      },
+      {
+        "index": 1,
+        "id": "programmable-canary-token-v1",
+        "targetIdHash": "0x54fd63b67b7ebaa0a8c88812b3a17d45540cda31c3b76d0571378c28bca744d7",
+        "applicantSalt": "0x6a66987554fde0a46e3ac02292906d35e64f341e52d5be16374d329e034a3afd",
+        "deploymentValueWei": "0",
+        "initializerValueWei": "0",
+        "expectedDeployment": null,
+        "expectedRuntimeCodeHash": null
+      },
+      {
+        "index": 2,
+        "id": "programmable-canary-hook-v1",
+        "targetIdHash": "0x5413f5d6a0da5fdfda480e87e3084541ec6efb63c151cbd9b7a2dc1098a23315",
+        "applicantSalt": null,
+        "applicantSaltRule": "Mine offchain only after stampRouter address and routeNonce are frozen; predicted address low 14 bits must equal 0x2044.",
+        "deploymentValueWei": "0",
+        "initializerValueWei": "0",
+        "expectedDeployment": null,
+        "expectedRuntimeCodeHash": null
+      }
+    ],
+    "constructorDependencyOrder": [
+      "initializer depends only on frozen Mainnet infrastructure, explicit Graph Factory, launchWallet, and LP NFT recipient",
+      "token embeds the predicted initializer address",
+      "hook embeds predicted initializer and token addresses",
+      "initializer calldata embeds predicted token and hook addresses plus a finite deadline"
+    ],
+    "initializerCaller": "explicit-graph-factory-address",
+    "factoryCallerIdentityUsedAsOwner": false
+  },
+  "custody": {
+    "initializerResidualNative": "must-equal-zero",
+    "initializerPrefundedNative": "every pre-existing or forced native residual is sent only to the signed immutable launchWallet after LP creation; a failed refund reverts the entire Graph",
+    "initializerResidualToken": "must-equal-zero",
+    "positionManagerNativeAfter": "must-equal-zero",
+    "positionManagerPreexistingForcedNative": "cannot change fixed LP liquidity; the reviewed SETTLE plus TAKE_PAIR plan routes any such surplus to launchWallet instead of retaining it",
+    "positionManagerTokenBeforeAndAfter": "must-equal-zero-for-this-token",
+    "lpNft": "minted-directly-to-explicit-recipient",
+    "dust": "PositionManager TAKE_PAIR sends both currencies directly to launchWallet",
+    "platformFees": "redeemable-only-to-immutable-platform-recipient"
+  },
+  "finalizationRequired": [
+    "Freeze the deployed Stamp Router address and use it as GraphAuthorization.authorizedLauncher.",
+    "Freeze one nonzero launchWallet and one nonzero LP NFT recipient; equality is allowed only if explicitly chosen.",
+    "Freeze a fresh routeNonce and a finite execution deadline.",
+    "Materialize exact constructor arguments and initializer calldata, then mine the hook applicantSalt offchain.",
+    "Recompute all three predicted deployments, init-code hashes, runtime-code hashes, graphCommitment, Router exact deployment set, and permit fields.",
+    "Run the identical final payload on a current Mainnet fork and recheck infrastructure runtime hashes immediately before any signing.",
+    "Do not claim live until an authorized Mainnet transaction is finalized and independently observed."
+  ]
+}

--- a/contracts/src/ProgrammableCanaryLiquidityInitializerV1.sol
+++ b/contracts/src/ProgrammableCanaryLiquidityInitializerV1.sol
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { ReentrancyGuardTransient } from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+import { PositionPlanner } from "@uniswap/liquidity-launcher/src/libraries/PositionPlanner.sol";
+import {
+    CurrencyAmounts,
+    Plan,
+    Position,
+    PositionDefinition
+} from "@uniswap/liquidity-launcher/src/types/PositionPlannerTypes.sol";
+import { IPoolManager } from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import { Hooks } from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import { TickMath } from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import { Currency } from "@uniswap/v4-core/src/types/Currency.sol";
+import { PoolId, PoolIdLibrary } from "@uniswap/v4-core/src/types/PoolId.sol";
+import { PoolKey } from "@uniswap/v4-core/src/types/PoolKey.sol";
+import { IPositionManager } from "@uniswap/v4-periphery/src/interfaces/IPositionManager.sol";
+
+import { PlatformFeeHookV1 } from "./PlatformFeeHookV1.sol";
+import { ProgrammableCanaryTokenV1 } from "./ProgrammableCanaryTokenV1.sol";
+
+/// @title ProgrammableCanaryLiquidityInitializerV1
+/// @notice One-shot Graph target that opens the reviewed canary pool and mints its owner-controlled full-range LP NFT.
+/// @dev The Graph factory is an explicit immutable caller, never inferred from constructor `msg.sender`. The
+/// initializer reuses the official PositionPlanner/PositionManager action path already exercised by
+/// DirectLiquidityLauncherV1.
+///      The PositionManager receives the exact token/native budgets, mints the NFT directly to `lpRecipient`, and its
+///      TAKE_PAIR actions send every unused token/native unit directly to `launchWallet`. This contract retains
+/// nothing. Any native balance prefunded to the predicted CREATE2 address is refunded only to the same immutable
+/// `launchWallet` after LP creation; refund failure or a nonzero post-refund balance reverts the complete Graph.
+contract ProgrammableCanaryLiquidityInitializerV1 is ReentrancyGuardTransient {
+    using PoolIdLibrary for PoolKey;
+    using SafeERC20 for IERC20;
+
+    uint256 public constant TOKEN_LIQUIDITY_BUDGET = 1_000_000 ether;
+    uint256 public constant NATIVE_LIQUIDITY_BUDGET = 0.001 ether;
+    int24 public constant INITIAL_TICK = 207_240;
+    uint24 public constant LP_FEE_PIPS = 3000;
+    int24 public constant TICK_SPACING = 60;
+    uint24 public constant PLATFORM_FEE_PIPS = 1000;
+    address public constant PLATFORM_FEE_RECIPIENT = 0x4957f49620AFf3Adbbe8195a4f633E49cc93376c;
+
+    uint160 public constant ALL_HOOK_MASK = (1 << 14) - 1;
+    uint160 public constant REQUIRED_HOOK_FLAGS =
+        uint160(Hooks.BEFORE_INITIALIZE_FLAG | Hooks.AFTER_SWAP_FLAG | Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG);
+
+    bytes32 private constant FIELD_ALLOCATION = keccak256("allocation");
+    bytes32 private constant FIELD_CODE = keccak256("code");
+    bytes32 private constant FIELD_CURRENCIES = keccak256("currencies");
+    bytes32 private constant FIELD_FEE_RECIPIENT = keccak256("fee-recipient");
+    bytes32 private constant FIELD_FEES = keccak256("fees");
+    bytes32 private constant FIELD_INITIALIZER = keccak256("initializer");
+    bytes32 private constant FIELD_PERMISSIONS = keccak256("permissions");
+    bytes32 private constant FIELD_POOL_ID = keccak256("pool-id");
+    bytes32 private constant FIELD_POOL_MANAGER = keccak256("pool-manager");
+    bytes32 private constant FIELD_SUPPLY = keccak256("supply");
+    bytes32 private constant FIELD_WALLET = keccak256("wallet");
+
+    IPoolManager public immutable poolManager;
+    IPositionManager public immutable positionManager;
+    address public immutable graphFactory;
+    address public immutable launchWallet;
+    address public immutable lpRecipient;
+    bytes32 public immutable configurationHash;
+
+    bool public initialized;
+    address public token;
+    address public hook;
+    bytes32 public poolId;
+    uint256 public positionTokenId;
+    uint256 public nativeLiquidityAmount;
+    uint256 public tokenLiquidityAmount;
+
+    error AlreadyInitialized();
+    error DeadlineExpired(uint256 timestamp, uint256 deadline);
+    error DependencyPoolManagerMismatch(address expected, address actual);
+    error InvalidDependency(address dependency);
+    error InvalidHook(address hook, bytes32 field);
+    error InvalidInitialTick(int24 expected, int24 actual);
+    error InvalidPosition(uint256 count, uint256 nativeAmount, uint256 tokenAmount);
+    error InvalidPositionOwner(address expected, address actual);
+    error InvalidRemainder(uint256 nativeAmount, uint256 tokenAmount);
+    error InvalidToken(address token, bytes32 field);
+    error InvalidValue(uint256 expected, uint256 actual);
+    error PositionManagerBalanceNotEmpty(uint256 nativeBalance, uint256 tokenBalance);
+    error ResidualCustody(uint256 nativeBalance, uint256 tokenBalance);
+    error UnauthorizedInitializer(address caller, address expected);
+    error ZeroAddress();
+
+    event ProgrammableCanaryLiquidityInitializedV1(
+        address indexed launchWallet,
+        address indexed token,
+        address indexed hook,
+        bytes32 poolId,
+        address lpRecipient,
+        uint256 positionTokenId,
+        uint256 nativeLiquidityAmount,
+        uint256 tokenLiquidityAmount,
+        uint256 nativeLiquidityBudget,
+        uint256 tokenLiquidityBudget,
+        int24 initialTick
+    );
+
+    constructor(
+        IPoolManager poolManager_,
+        IPositionManager positionManager_,
+        address graphFactory_,
+        address launchWallet_,
+        address lpRecipient_
+    ) {
+        if (graphFactory_ == address(0) || launchWallet_ == address(0) || lpRecipient_ == address(0)) {
+            revert ZeroAddress();
+        }
+        if (address(poolManager_).code.length == 0) revert InvalidDependency(address(poolManager_));
+        if (address(positionManager_).code.length == 0) revert InvalidDependency(address(positionManager_));
+        if (graphFactory_.code.length == 0) revert InvalidDependency(graphFactory_);
+
+        address positionManagerPoolManager = address(positionManager_.poolManager());
+        if (positionManagerPoolManager != address(poolManager_)) {
+            revert DependencyPoolManagerMismatch(address(poolManager_), positionManagerPoolManager);
+        }
+
+        poolManager = poolManager_;
+        positionManager = positionManager_;
+        graphFactory = graphFactory_;
+        launchWallet = launchWallet_;
+        lpRecipient = lpRecipient_;
+        bytes32 dependencyHash = keccak256(
+            abi.encode(
+                address(poolManager_),
+                address(positionManager_),
+                graphFactory_,
+                launchWallet_,
+                lpRecipient_,
+                PLATFORM_FEE_RECIPIENT
+            )
+        );
+        bytes32 economicsHash = keccak256(
+            abi.encode(
+                TOKEN_LIQUIDITY_BUDGET,
+                NATIVE_LIQUIDITY_BUDGET,
+                INITIAL_TICK,
+                LP_FEE_PIPS,
+                TICK_SPACING,
+                PLATFORM_FEE_PIPS,
+                REQUIRED_HOOK_FLAGS
+            )
+        );
+        configurationHash = keccak256(abi.encode(block.chainid, address(this), dependencyHash, economicsHash));
+    }
+
+    /// @notice Initializes exactly one reviewed canary token/hook pair and mints its full-range LP NFT atomically.
+    /// @param token_ Exact Graph-deployed fixed-supply token.
+    /// @param hook_ Exact Graph-deployed 10 bps PlatformFeeHookV1.
+    /// @param deadline PositionManager deadline, also committed inside the Graph target initializer calldata.
+    function initialize(ProgrammableCanaryTokenV1 token_, PlatformFeeHookV1 hook_, uint256 deadline)
+        external
+        payable
+        nonReentrant
+    {
+        if (msg.sender != graphFactory) revert UnauthorizedInitializer(msg.sender, graphFactory);
+        if (initialized) revert AlreadyInitialized();
+        if (msg.value != NATIVE_LIQUIDITY_BUDGET) {
+            revert InvalidValue(NATIVE_LIQUIDITY_BUDGET, msg.value);
+        }
+        // The deadline is committed in the Graph payload; timestamp slack can only expire, never broaden, that permit.
+        // forge-lint: disable-next-line(block-timestamp)
+        if (block.timestamp > deadline) revert DeadlineExpired(block.timestamp, deadline);
+
+        _validateToken(token_);
+        PoolKey memory key = _validateHook(token_, hook_);
+        _requireEmptyPositionManagerTokenBalance(token_);
+
+        uint160 initialSqrtPriceX96 = TickMath.getSqrtPriceAtTick(INITIAL_TICK);
+        (Plan memory plan, Position memory position) = _buildFullRangePlan(key, initialSqrtPriceX96);
+        uint256 nextPositionTokenId = positionManager.nextTokenId();
+
+        // Effects precede the PoolManager/PositionManager interactions. Every downstream failure reverts atomically.
+        initialized = true;
+        token = address(token_);
+        hook = address(hook_);
+        poolId = PoolId.unwrap(key.toId());
+        positionTokenId = nextPositionTokenId;
+        nativeLiquidityAmount = position.amount0;
+        tokenLiquidityAmount = position.amount1;
+
+        int24 actualTick = poolManager.initialize(key, initialSqrtPriceX96);
+        if (actualTick != INITIAL_TICK) revert InvalidInitialTick(INITIAL_TICK, actualTick);
+
+        IERC20(address(token_)).safeTransfer(address(positionManager), TOKEN_LIQUIDITY_BUDGET);
+        positionManager.modifyLiquidities{ value: NATIVE_LIQUIDITY_BUDGET }(
+            abi.encode(plan.actions, plan.params), deadline
+        );
+
+        address actualOwner = IERC721(address(positionManager)).ownerOf(positionTokenId);
+        if (actualOwner != lpRecipient) revert InvalidPositionOwner(lpRecipient, actualOwner);
+
+        _requireEmptyPositionManagerBalance(token_);
+        uint256 nativeResidual = address(this).balance;
+        if (nativeResidual != 0) Address.sendValue(payable(launchWallet), nativeResidual);
+        uint256 tokenBalance = IERC20(address(token_)).balanceOf(address(this));
+        if (address(this).balance != 0 || tokenBalance != 0) {
+            revert ResidualCustody(address(this).balance, tokenBalance);
+        }
+
+        _emitInitialized(token_, hook_);
+    }
+
+    function reviewedPoolKey(address token_, address hook_) public pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(0)),
+            currency1: Currency.wrap(token_),
+            fee: LP_FEE_PIPS,
+            tickSpacing: TICK_SPACING,
+            hooks: PlatformFeeHookV1(hook_)
+        });
+    }
+
+    function _emitInitialized(ProgrammableCanaryTokenV1 token_, PlatformFeeHookV1 hook_) private {
+        emit ProgrammableCanaryLiquidityInitializedV1(
+            launchWallet,
+            address(token_),
+            address(hook_),
+            poolId,
+            lpRecipient,
+            positionTokenId,
+            nativeLiquidityAmount,
+            tokenLiquidityAmount,
+            NATIVE_LIQUIDITY_BUDGET,
+            TOKEN_LIQUIDITY_BUDGET,
+            INITIAL_TICK
+        );
+    }
+
+    function _buildFullRangePlan(PoolKey memory key, uint160 initialSqrtPriceX96)
+        private
+        view
+        returns (Plan memory plan, Position memory position)
+    {
+        PositionDefinition[] memory definitions = new PositionDefinition[](0);
+        CurrencyAmounts memory available =
+            CurrencyAmounts({ amount0: NATIVE_LIQUIDITY_BUDGET, amount1: TOKEN_LIQUIDITY_BUDGET });
+        (Position[] memory positions, CurrencyAmounts memory remaining) =
+            PositionPlanner.resolve(definitions, initialSqrtPriceX96, TICK_SPACING, available, lpRecipient);
+        if (
+            positions.length != 1 || positions[0].amount0 == 0 || positions[0].amount1 == 0
+                || positions[0].amount0 > NATIVE_LIQUIDITY_BUDGET || positions[0].amount1 > TOKEN_LIQUIDITY_BUDGET
+        ) {
+            uint256 nativeAmount = positions.length == 0 ? 0 : positions[0].amount0;
+            uint256 tokenAmount = positions.length == 0 ? 0 : positions[0].amount1;
+            revert InvalidPosition(positions.length, nativeAmount, tokenAmount);
+        }
+        position = positions[0];
+        if (
+            remaining.amount0 != NATIVE_LIQUIDITY_BUDGET - position.amount0
+                || remaining.amount1 != TOKEN_LIQUIDITY_BUDGET - position.amount1
+        ) revert InvalidRemainder(remaining.amount0, remaining.amount1);
+        plan = PositionPlanner.toPlan(positions, key, launchWallet);
+    }
+
+    function _validateToken(ProgrammableCanaryTokenV1 token_) private view {
+        if (address(token_).code.length == 0) revert InvalidToken(address(token_), FIELD_CODE);
+        if (token_.totalSupply() != TOKEN_LIQUIDITY_BUDGET) {
+            revert InvalidToken(address(token_), FIELD_SUPPLY);
+        }
+        if (token_.launchWallet() != launchWallet) revert InvalidToken(address(token_), FIELD_WALLET);
+        if (token_.liquidityInitializer() != address(this)) {
+            revert InvalidToken(address(token_), FIELD_INITIALIZER);
+        }
+        if (token_.balanceOf(address(this)) != TOKEN_LIQUIDITY_BUDGET) {
+            revert InvalidToken(address(token_), FIELD_ALLOCATION);
+        }
+    }
+
+    function _requireEmptyPositionManagerTokenBalance(ProgrammableCanaryTokenV1 token_) private view {
+        uint256 tokenBalance = token_.balanceOf(address(positionManager));
+        if (tokenBalance != 0) {
+            revert PositionManagerBalanceNotEmpty(address(positionManager).balance, tokenBalance);
+        }
+    }
+
+    function _requireEmptyPositionManagerBalance(ProgrammableCanaryTokenV1 token_) private view {
+        uint256 tokenBalance = token_.balanceOf(address(positionManager));
+        if (address(positionManager).balance != 0 || tokenBalance != 0) {
+            revert PositionManagerBalanceNotEmpty(address(positionManager).balance, tokenBalance);
+        }
+    }
+
+    function _validateHook(ProgrammableCanaryTokenV1 token_, PlatformFeeHookV1 hook_)
+        private
+        view
+        returns (PoolKey memory key)
+    {
+        if (address(hook_).code.length == 0) revert InvalidHook(address(hook_), FIELD_CODE);
+        if ((uint160(address(hook_)) & ALL_HOOK_MASK) != REQUIRED_HOOK_FLAGS) {
+            revert InvalidHook(address(hook_), FIELD_PERMISSIONS);
+        }
+        if (address(hook_.poolManager()) != address(poolManager)) {
+            revert InvalidHook(address(hook_), FIELD_POOL_MANAGER);
+        }
+        if (hook_.authorized() != address(this)) revert InvalidHook(address(hook_), FIELD_INITIALIZER);
+        if (hook_.feeRecipient() != PLATFORM_FEE_RECIPIENT) {
+            revert InvalidHook(address(hook_), FIELD_FEE_RECIPIENT);
+        }
+        if (hook_.currency0() != address(0) || hook_.currency1() != address(token_)) {
+            revert InvalidHook(address(hook_), FIELD_CURRENCIES);
+        }
+        if (
+            hook_.LP_FEE_PIPS() != LP_FEE_PIPS || hook_.TICK_SPACING() != TICK_SPACING
+                || hook_.PLATFORM_FEE_PIPS() != PLATFORM_FEE_PIPS
+        ) revert InvalidHook(address(hook_), FIELD_FEES);
+
+        key = reviewedPoolKey(address(token_), address(hook_));
+        if (hook_.poolId() != PoolId.unwrap(key.toId())) revert InvalidHook(address(hook_), FIELD_POOL_ID);
+    }
+}

--- a/contracts/src/ProgrammableCanaryTokenV1.sol
+++ b/contracts/src/ProgrammableCanaryTokenV1.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title ProgrammableCanaryTokenV1
+/// @notice Fixed-supply, non-upgradeable ERC-20 used only for the first low-value stamped Mainnet canary.
+/// @dev The complete supply is minted once to the explicitly configured liquidity initializer. The initializer
+///      atomically places the reviewed budget into Uniswap v4 and returns any token dust to `launchWallet`.
+///      There is no owner, administrator, pause, blacklist, tax, proxy, or second mint path.
+contract ProgrammableCanaryTokenV1 is ERC20 {
+    uint256 public constant TOTAL_SUPPLY = 1_000_000 ether;
+    uint256 public constant MAX_NAME_BYTES = 48;
+    uint256 public constant MAX_SYMBOL_BYTES = 12;
+
+    address public immutable launchWallet;
+    address public immutable liquidityInitializer;
+    bytes32 public immutable configurationHash;
+
+    error EmptyName();
+    error EmptySymbol();
+    error NameTooLong(uint256 actual, uint256 maximum);
+    error SymbolTooLong(uint256 actual, uint256 maximum);
+    error ZeroAddress();
+
+    constructor(string memory name_, string memory symbol_, address launchWallet_, address liquidityInitializer_)
+        ERC20(name_, symbol_)
+    {
+        uint256 nameLength = bytes(name_).length;
+        uint256 symbolLength = bytes(symbol_).length;
+        if (nameLength == 0) revert EmptyName();
+        if (symbolLength == 0) revert EmptySymbol();
+        if (nameLength > MAX_NAME_BYTES) revert NameTooLong(nameLength, MAX_NAME_BYTES);
+        if (symbolLength > MAX_SYMBOL_BYTES) revert SymbolTooLong(symbolLength, MAX_SYMBOL_BYTES);
+        if (launchWallet_ == address(0) || liquidityInitializer_ == address(0)) revert ZeroAddress();
+
+        launchWallet = launchWallet_;
+        liquidityInitializer = liquidityInitializer_;
+        configurationHash = keccak256(
+            abi.encode(
+                block.chainid,
+                address(this),
+                keccak256(bytes(name_)),
+                keccak256(bytes(symbol_)),
+                TOTAL_SUPPLY,
+                launchWallet_,
+                liquidityInitializer_
+            )
+        );
+
+        _mint(liquidityInitializer_, TOTAL_SUPPLY);
+    }
+}

--- a/contracts/test/ProgrammableGraphCanaryV1.t.sol
+++ b/contracts/test/ProgrammableGraphCanaryV1.t.sol
@@ -1,0 +1,952 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { PositionPlanner } from "@uniswap/liquidity-launcher/src/libraries/PositionPlanner.sol";
+import {
+    CurrencyAmounts,
+    Plan,
+    Position,
+    PositionDefinition
+} from "@uniswap/liquidity-launcher/src/types/PositionPlannerTypes.sol";
+import { IPoolManager } from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import { FullMath } from "@uniswap/v4-core/src/libraries/FullMath.sol";
+import { Hooks } from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import { StateLibrary } from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import { TickMath } from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import { PoolSwapTest } from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
+import { BalanceDelta } from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import { Currency } from "@uniswap/v4-core/src/types/Currency.sol";
+import { PoolKey } from "@uniswap/v4-core/src/types/PoolKey.sol";
+import { SwapParams } from "@uniswap/v4-core/src/types/PoolOperation.sol";
+import { Deployers } from "@uniswap/v4-core/test/utils/Deployers.sol";
+import { PositionManager } from "@uniswap/v4-periphery/src/PositionManager.sol";
+import { IPositionDescriptor } from "@uniswap/v4-periphery/src/interfaces/IPositionDescriptor.sol";
+import { IPositionManager } from "@uniswap/v4-periphery/src/interfaces/IPositionManager.sol";
+import { IWETH9 } from "@uniswap/v4-periphery/src/interfaces/external/IWETH9.sol";
+import { IAllowanceTransfer } from "permit2/src/interfaces/IAllowanceTransfer.sol";
+
+import { PlatformFeeHookV1 } from "../src/PlatformFeeHookV1.sol";
+import { ProgrammableCanaryLiquidityInitializerV1 } from "../src/ProgrammableCanaryLiquidityInitializerV1.sol";
+import { ProgrammableCanaryTokenV1 } from "../src/ProgrammableCanaryTokenV1.sol";
+
+interface IProgrammableCreate2GraphDeployerV1 {
+    struct GraphAuthorization {
+        bytes32 routeNamespace;
+        bytes32 routeNonce;
+        bytes32 topologyHash;
+        bytes32 graphCommitment;
+        address authorizedLauncher;
+        uint256 totalValue;
+    }
+
+    struct Target {
+        bytes32 targetIdHash;
+        bytes32 applicantSalt;
+        uint256 deploymentValue;
+        uint256 initializerValue;
+        bytes initCode;
+        bytes initializerCalldata;
+    }
+
+    function deployGraph(GraphAuthorization calldata authorization, Target[] calldata targets)
+        external
+        payable
+        returns (
+            address[] memory deployments,
+            bytes32[] memory runtimeCodeHashes,
+            bytes[] memory runtimeCodes,
+            bytes32 graphDeploymentHash
+        );
+
+    function computeGraphCommitment(GraphAuthorization calldata authorization, Target[] calldata targets)
+        external
+        view
+        returns (bytes32 commitment, uint256 targetValueSum);
+
+    function effectiveTargetSalt(GraphAuthorization calldata authorization, bytes32 targetIdHash, bytes32 applicantSalt)
+        external
+        view
+        returns (bytes32);
+
+    function predictTarget(GraphAuthorization calldata authorization, Target calldata target)
+        external
+        view
+        returns (address);
+}
+
+/// @dev Test-only reproduction of the deployed V1 factory's deploy-all-then-initialize caller semantics and hashes.
+contract LocalProgrammableCreate2GraphDeployerV1 is IProgrammableCreate2GraphDeployerV1 {
+    bytes32 internal constant GRAPH_TARGET_COMMITMENT_TYPEHASH = keccak256(
+        "ProgrammableCreate2GraphTargetCommitmentV1(uint256 targetIndex,bytes32 targetIdHash,bytes32 applicantSalt,uint256 deploymentValue,uint256 initializerValue,bytes32 initCodeHash,bytes32 initializerCalldataHash)"
+    );
+    bytes32 internal constant GRAPH_COMMITMENT_TYPEHASH = keccak256(
+        "ProgrammableCreate2GraphCommitmentV1(uint256 chainId,address factory,bytes32 routeNamespace,bytes32 routeNonce,bytes32 topologyHash,address authorizedLauncher,uint256 totalValue,bytes32 targetCommitmentsHash)"
+    );
+    bytes32 internal constant TARGET_SALT_TYPEHASH = keccak256(
+        "ProgrammableCreate2GraphTargetSaltV1(uint256 chainId,address factory,bytes32 routeNamespace,bytes32 routeNonce,bytes32 targetIdHash,bytes32 applicantSalt,address authorizedLauncher)"
+    );
+    bytes32 internal constant GRAPH_AUTHORIZATION_KEY_TYPEHASH = keccak256(
+        "ProgrammableCreate2GraphAuthorizationKeyV1(uint256 chainId,address factory,bytes32 routeNamespace,bytes32 routeNonce,address authorizedLauncher)"
+    );
+    bytes32 internal constant GRAPH_DEPLOYMENT_ACCUMULATOR_TYPEHASH = keccak256(
+        "ProgrammableCreate2GraphDeploymentAccumulatorV1(bytes32 previous,uint256 targetIndex,bytes32 targetIdHash,address deployment,bytes32 effectiveSalt,bytes32 initCodeHash,bytes32 initializerCalldataHash,bytes32 runtimeCodeHash,uint256 deploymentValue,uint256 initializerValue)"
+    );
+
+    struct GraphExecution {
+        address[] deployments;
+        bytes32[] salts;
+        bytes32[] initCodeHashes;
+        bytes32[] initializerCalldataHashes;
+        bytes32[] runtimeCodeHashes;
+        bytes[] runtimeCodes;
+    }
+
+    mapping(bytes32 authorizationKey => bool consumed) public consumedGraphAuthorization;
+
+    error InvalidGraph();
+    error InitializerFailed(uint256 index, bytes reason);
+
+    function deployGraph(GraphAuthorization calldata authorization, Target[] calldata targets)
+        external
+        payable
+        override
+        returns (
+            address[] memory deployments,
+            bytes32[] memory runtimeCodeHashes,
+            bytes[] memory runtimeCodes,
+            bytes32 graphDeploymentHash
+        )
+    {
+        if (targets.length == 0 || targets.length > 16 || msg.sender != authorization.authorizedLauncher) {
+            revert InvalidGraph();
+        }
+        if (msg.value != authorization.totalValue) revert InvalidGraph();
+        (bytes32 commitment, uint256 targetValueSum) = _computeGraphCommitment(authorization, targets);
+        if (commitment != authorization.graphCommitment || targetValueSum != authorization.totalValue) {
+            revert InvalidGraph();
+        }
+        bytes32 authorizationKey = keccak256(
+            abi.encode(
+                GRAPH_AUTHORIZATION_KEY_TYPEHASH,
+                block.chainid,
+                address(this),
+                authorization.routeNamespace,
+                authorization.routeNonce,
+                authorization.authorizedLauncher
+            )
+        );
+        if (consumedGraphAuthorization[authorizationKey]) revert InvalidGraph();
+        consumedGraphAuthorization[authorizationKey] = true;
+
+        uint256 length = targets.length;
+        GraphExecution memory execution = GraphExecution({
+            deployments: new address[](length),
+            salts: new bytes32[](length),
+            initCodeHashes: new bytes32[](length),
+            initializerCalldataHashes: new bytes32[](length),
+            runtimeCodeHashes: new bytes32[](length),
+            runtimeCodes: new bytes[](length)
+        });
+
+        _deriveTargets(authorization, targets, execution);
+        _deployTargets(targets, execution);
+        _initializeTargets(targets, execution.deployments);
+        graphDeploymentHash = _observeTargets(authorization, targets, execution);
+        deployments = execution.deployments;
+        runtimeCodeHashes = execution.runtimeCodeHashes;
+        runtimeCodes = execution.runtimeCodes;
+    }
+
+    function computeGraphCommitment(GraphAuthorization calldata authorization, Target[] calldata targets)
+        external
+        view
+        override
+        returns (bytes32 commitment, uint256 targetValueSum)
+    {
+        return _computeGraphCommitment(authorization, targets);
+    }
+
+    function effectiveTargetSalt(GraphAuthorization calldata authorization, bytes32 targetIdHash, bytes32 applicantSalt)
+        external
+        view
+        override
+        returns (bytes32)
+    {
+        return _effectiveTargetSalt(authorization, targetIdHash, applicantSalt);
+    }
+
+    function predictTarget(GraphAuthorization calldata authorization, Target calldata target)
+        external
+        view
+        override
+        returns (address)
+    {
+        return _computeAddress(
+            _effectiveTargetSalt(authorization, target.targetIdHash, target.applicantSalt), keccak256(target.initCode)
+        );
+    }
+
+    function _computeGraphCommitment(GraphAuthorization calldata authorization, Target[] calldata targets)
+        private
+        view
+        returns (bytes32 commitment, uint256 targetValueSum)
+    {
+        bytes32[] memory targetCommitments = new bytes32[](targets.length);
+        for (uint256 index; index < targets.length; ++index) {
+            Target calldata target = targets[index];
+            targetValueSum += target.deploymentValue + target.initializerValue;
+            targetCommitments[index] = keccak256(
+                abi.encode(
+                    GRAPH_TARGET_COMMITMENT_TYPEHASH,
+                    index,
+                    target.targetIdHash,
+                    target.applicantSalt,
+                    target.deploymentValue,
+                    target.initializerValue,
+                    keccak256(target.initCode),
+                    keccak256(target.initializerCalldata)
+                )
+            );
+        }
+        commitment = keccak256(
+            abi.encode(
+                GRAPH_COMMITMENT_TYPEHASH,
+                block.chainid,
+                address(this),
+                authorization.routeNamespace,
+                authorization.routeNonce,
+                authorization.topologyHash,
+                authorization.authorizedLauncher,
+                authorization.totalValue,
+                keccak256(abi.encode(targetCommitments))
+            )
+        );
+    }
+
+    function _deriveTargets(
+        GraphAuthorization calldata authorization,
+        Target[] calldata targets,
+        GraphExecution memory execution
+    ) private view {
+        for (uint256 index; index < targets.length; ++index) {
+            Target calldata target = targets[index];
+            if (target.targetIdHash == bytes32(0) || target.initCode.length == 0) revert InvalidGraph();
+            execution.salts[index] = _effectiveTargetSalt(authorization, target.targetIdHash, target.applicantSalt);
+            execution.initCodeHashes[index] = keccak256(target.initCode);
+            execution.initializerCalldataHashes[index] = keccak256(target.initializerCalldata);
+            execution.deployments[index] = _computeAddress(execution.salts[index], execution.initCodeHashes[index]);
+            if (execution.deployments[index].code.length != 0) revert InvalidGraph();
+        }
+    }
+
+    function _deployTargets(Target[] calldata targets, GraphExecution memory execution) private {
+        for (uint256 index; index < targets.length; ++index) {
+            bytes memory creationCode = targets[index].initCode;
+            address deployed;
+            bytes32 salt = execution.salts[index];
+            uint256 value = targets[index].deploymentValue;
+            assembly ("memory-safe") {
+                deployed := create2(value, add(creationCode, 0x20), mload(creationCode), salt)
+            }
+            if (deployed != execution.deployments[index]) revert InvalidGraph();
+        }
+    }
+
+    function _initializeTargets(Target[] calldata targets, address[] memory deployments) private {
+        for (uint256 index; index < targets.length; ++index) {
+            if (targets[index].initializerCalldata.length == 0) continue;
+            (bool success, bytes memory reason) =
+                deployments[index].call{ value: targets[index].initializerValue }(targets[index].initializerCalldata);
+            if (!success) revert InitializerFailed(index, reason);
+        }
+    }
+
+    function _observeTargets(
+        GraphAuthorization calldata authorization,
+        Target[] calldata targets,
+        GraphExecution memory execution
+    ) private view returns (bytes32 accumulator) {
+        accumulator = authorization.graphCommitment;
+        for (uint256 index; index < targets.length; ++index) {
+            execution.runtimeCodes[index] = execution.deployments[index].code;
+            execution.runtimeCodeHashes[index] = keccak256(execution.runtimeCodes[index]);
+            accumulator = _accumulateTarget(accumulator, index, targets[index], execution);
+        }
+    }
+
+    function _accumulateTarget(bytes32 previous, uint256 index, Target calldata target, GraphExecution memory execution)
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                GRAPH_DEPLOYMENT_ACCUMULATOR_TYPEHASH,
+                previous,
+                index,
+                target.targetIdHash,
+                execution.deployments[index],
+                execution.salts[index],
+                execution.initCodeHashes[index],
+                execution.initializerCalldataHashes[index],
+                execution.runtimeCodeHashes[index],
+                target.deploymentValue,
+                target.initializerValue
+            )
+        );
+    }
+
+    function _effectiveTargetSalt(
+        GraphAuthorization calldata authorization,
+        bytes32 targetIdHash,
+        bytes32 applicantSalt
+    ) private view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                TARGET_SALT_TYPEHASH,
+                block.chainid,
+                address(this),
+                authorization.routeNamespace,
+                authorization.routeNonce,
+                targetIdHash,
+                applicantSalt,
+                authorization.authorizedLauncher
+            )
+        );
+    }
+
+    function _computeAddress(bytes32 salt, bytes32 initCodeHash) private view returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, initCodeHash)))));
+    }
+}
+
+contract ProgrammableCanaryReferenceToken is ERC20 {
+    constructor(address recipient) ERC20("Programmable Canary Reference", "PCR") {
+        _mint(recipient, 1_000_000 ether);
+    }
+}
+
+contract ProgrammableCanaryReentrantLaunchWallet {
+    uint256 public receivedAmount;
+    address public lastSender;
+    bool public reentrySucceeded;
+    bytes4 public reentryRevertSelector;
+
+    receive() external payable {
+        receivedAmount += msg.value;
+        lastSender = msg.sender;
+        (bool success, bytes memory reason) = msg.sender
+            .call(
+                abi.encodeCall(
+                    ProgrammableCanaryLiquidityInitializerV1.initialize,
+                    (ProgrammableCanaryTokenV1(address(0)), PlatformFeeHookV1(address(0)), 0)
+                )
+            );
+        reentrySucceeded = success;
+        if (reason.length >= 4) {
+            bytes4 selector;
+            assembly ("memory-safe") {
+                selector := mload(add(reason, 0x20))
+            }
+            reentryRevertSelector = selector;
+        }
+    }
+}
+
+contract ProgrammableCanaryRejectingLaunchWallet {
+    bytes4 private constant LAUNCH_WALLET_SELECTOR = bytes4(keccak256("launchWallet()"));
+
+    error NativeRefundRejected();
+
+    receive() external payable {
+        (bool success, bytes memory result) = msg.sender.staticcall(abi.encodeWithSelector(LAUNCH_WALLET_SELECTOR));
+        if (success && result.length >= 32 && abi.decode(result, (address)) == address(this)) {
+            revert NativeRefundRejected();
+        }
+    }
+}
+
+abstract contract ProgrammableGraphCanaryFixtureV1 is Deployers {
+    using SafeCast for uint256;
+    using StateLibrary for IPoolManager;
+
+    uint256 internal constant FEE_DENOMINATOR = 1_000_000;
+    uint256 internal constant MAX_HOOK_SALT_ATTEMPTS = 500_000;
+    uint256 internal constant CANARY_TOKEN_LIQUIDITY_BUDGET = 1_000_000 ether;
+    uint256 internal constant CANARY_NATIVE_LIQUIDITY_BUDGET = 0.001 ether;
+    uint160 internal constant CANARY_ALL_HOOK_MASK = (1 << 14) - 1;
+    uint160 internal constant CANARY_REQUIRED_HOOK_FLAGS =
+        uint160(Hooks.BEFORE_INITIALIZE_FLAG | Hooks.AFTER_SWAP_FLAG | Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG);
+    address internal constant CANARY_PLATFORM_FEE_RECIPIENT = 0x4957f49620AFf3Adbbe8195a4f633E49cc93376c;
+
+    IPositionManager internal positionManager;
+    IProgrammableCreate2GraphDeployerV1 internal graphFactory;
+    ProgrammableCanaryLiquidityInitializerV1 internal initializer;
+    ProgrammableCanaryTokenV1 internal token;
+    PlatformFeeHookV1 internal hook;
+    PoolKey internal hookKey;
+
+    address internal launchWallet;
+    address internal lpRecipient;
+    address internal initializerPrefunder;
+    uint256 internal graphDeployGasUsed;
+
+    PoolSwapTest.TestSettings internal settings =
+        PoolSwapTest.TestSettings({ takeClaims: false, settleUsingBurn: false });
+
+    function _launchCanary() internal {
+        _launchCanaryWithConfiguration(
+            makeAddr("programmableCanaryLaunchWallet"), makeAddr("programmableCanaryLpRecipient"), 0
+        );
+    }
+
+    function _launchCanaryWithInitializerPrefund(uint256 initializerPrefund) internal {
+        _launchCanaryWithConfiguration(
+            makeAddr("programmableCanaryLaunchWallet"), makeAddr("programmableCanaryLpRecipient"), initializerPrefund
+        );
+    }
+
+    function _launchCanaryWithConfiguration(address launchWallet_, address lpRecipient_, uint256 initializerPrefund)
+        internal
+    {
+        launchWallet = launchWallet_;
+        lpRecipient = lpRecipient_;
+        vm.deal(address(this), 100 ether);
+
+        IProgrammableCreate2GraphDeployerV1.GraphAuthorization memory authorization =
+            IProgrammableCreate2GraphDeployerV1.GraphAuthorization({
+                routeNamespace: keccak256("programmable.mainnet-canary.v1"),
+                routeNonce: keccak256(abi.encode(address(this), block.number, "canary-1")),
+                topologyHash: keccak256("initializer,token,hook;initializer(token,hook)"),
+                graphCommitment: bytes32(0),
+                authorizedLauncher: address(this),
+                totalValue: CANARY_NATIVE_LIQUIDITY_BUDGET
+            });
+        IProgrammableCreate2GraphDeployerV1.Target[] memory targets =
+            new IProgrammableCreate2GraphDeployerV1.Target[](3);
+
+        targets[0] = IProgrammableCreate2GraphDeployerV1.Target({
+            targetIdHash: keccak256("programmable-canary-initializer-v1"),
+            applicantSalt: keccak256("programmable-canary-initializer-salt-v1"),
+            deploymentValue: 0,
+            initializerValue: CANARY_NATIVE_LIQUIDITY_BUDGET,
+            initCode: abi.encodePacked(
+                type(ProgrammableCanaryLiquidityInitializerV1).creationCode,
+                abi.encode(manager, positionManager, address(graphFactory), launchWallet, lpRecipient)
+            ),
+            initializerCalldata: bytes("")
+        });
+        address predictedInitializer = graphFactory.predictTarget(authorization, targets[0]);
+        if (initializerPrefund != 0) {
+            initializerPrefunder = makeAddr("programmableCanaryInitializerPrefunder");
+            vm.deal(initializerPrefunder, initializerPrefund);
+            vm.prank(initializerPrefunder);
+            (bool success,) = payable(predictedInitializer).call{ value: initializerPrefund }("");
+            assertTrue(success);
+            assertEq(predictedInitializer.balance, initializerPrefund);
+        }
+
+        targets[1] = IProgrammableCreate2GraphDeployerV1.Target({
+            targetIdHash: keccak256("programmable-canary-token-v1"),
+            applicantSalt: keccak256("programmable-canary-token-salt-v1"),
+            deploymentValue: 0,
+            initializerValue: 0,
+            initCode: abi.encodePacked(
+                type(ProgrammableCanaryTokenV1).creationCode,
+                abi.encode("Programmable Mainnet Canary", "PCAN", launchWallet, predictedInitializer)
+            ),
+            initializerCalldata: bytes("")
+        });
+        address predictedToken = graphFactory.predictTarget(authorization, targets[1]);
+
+        targets[2] = IProgrammableCreate2GraphDeployerV1.Target({
+            targetIdHash: keccak256("programmable-canary-hook-v1"),
+            applicantSalt: bytes32(0),
+            deploymentValue: 0,
+            initializerValue: 0,
+            initCode: abi.encodePacked(
+                type(PlatformFeeHookV1).creationCode,
+                abi.encode(
+                    manager,
+                    predictedInitializer,
+                    CANARY_PLATFORM_FEE_RECIPIENT,
+                    Currency.wrap(address(0)),
+                    Currency.wrap(predictedToken)
+                )
+            ),
+            initializerCalldata: bytes("")
+        });
+        address predictedHook = _mineHookTarget(authorization, targets[2]);
+
+        uint256 deadline = block.timestamp + 1 days;
+        targets[0].initializerCalldata = abi.encodeCall(
+            ProgrammableCanaryLiquidityInitializerV1.initialize,
+            (ProgrammableCanaryTokenV1(predictedToken), PlatformFeeHookV1(predictedHook), deadline)
+        );
+        uint256 valueSum;
+        (authorization.graphCommitment, valueSum) = graphFactory.computeGraphCommitment(authorization, targets);
+        assertEq(valueSum, authorization.totalValue);
+
+        uint256 graphDeployGasBefore = gasleft();
+        (
+            address[] memory deployments,
+            bytes32[] memory runtimeCodeHashes,
+            bytes[] memory runtimeCodes,
+            bytes32 graphDeploymentHash
+        ) = graphFactory.deployGraph{ value: authorization.totalValue }(authorization, targets);
+        graphDeployGasUsed = graphDeployGasBefore - gasleft();
+
+        assertEq(deployments.length, 3);
+        assertEq(deployments[0], predictedInitializer);
+        assertEq(deployments[1], predictedToken);
+        assertEq(deployments[2], predictedHook);
+        assertTrue(graphDeploymentHash != bytes32(0));
+        for (uint256 index; index < deployments.length; ++index) {
+            assertGt(runtimeCodes[index].length, 0);
+            assertEq(runtimeCodeHashes[index], deployments[index].codehash);
+            assertEq(runtimeCodeHashes[index], keccak256(runtimeCodes[index]));
+        }
+
+        initializer = ProgrammableCanaryLiquidityInitializerV1(payable(predictedInitializer));
+        token = ProgrammableCanaryTokenV1(predictedToken);
+        hook = PlatformFeeHookV1(predictedHook);
+        hookKey = hook.poolKey();
+    }
+
+    function _mineHookTarget(
+        IProgrammableCreate2GraphDeployerV1.GraphAuthorization memory authorization,
+        IProgrammableCreate2GraphDeployerV1.Target memory target
+    ) private returns (address predictedHook) {
+        // Salt mining is an offchain manifest-construction step, not part of the Mainnet transaction.
+        vm.pauseGasMetering();
+        uint160 requiredFlags = CANARY_REQUIRED_HOOK_FLAGS;
+        uint160 mask = CANARY_ALL_HOOK_MASK;
+        for (uint256 attempt; attempt < MAX_HOOK_SALT_ATTEMPTS; ++attempt) {
+            target.applicantSalt = bytes32(attempt);
+            predictedHook = graphFactory.predictTarget(authorization, target);
+            if ((uint160(predictedHook) & mask) == requiredFlags) {
+                vm.resumeGasMetering();
+                return predictedHook;
+            }
+        }
+        vm.resumeGasMetering();
+        revert("hook salt not found");
+    }
+}
+
+contract ProgrammableGraphCanaryV1Test is ProgrammableGraphCanaryFixtureV1 {
+    ProgrammableCanaryReferenceToken internal referenceToken;
+    PoolKey internal referenceKey;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        positionManager = IPositionManager(
+            address(
+                new PositionManager(
+                    manager,
+                    IAllowanceTransfer(address(0)),
+                    uint256(0),
+                    IPositionDescriptor(address(0)),
+                    IWETH9(address(0))
+                )
+            )
+        );
+        graphFactory = new LocalProgrammableCreate2GraphDeployerV1();
+        _launchCanary();
+    }
+
+    function test_graphLaunchIsTradableAndLeavesNoAmbiguousCustody() public view {
+        assertTrue(initializer.initialized());
+        assertEq(initializer.graphFactory(), address(graphFactory));
+        assertEq(initializer.launchWallet(), launchWallet);
+        assertEq(initializer.lpRecipient(), lpRecipient);
+        assertEq(initializer.token(), address(token));
+        assertEq(initializer.hook(), address(hook));
+        assertEq(token.launchWallet(), launchWallet);
+        assertEq(token.liquidityInitializer(), address(initializer));
+        assertEq(token.totalSupply(), initializer.TOKEN_LIQUIDITY_BUDGET());
+
+        assertEq(token.balanceOf(address(initializer)), 0);
+        assertEq(address(initializer).balance, 0);
+        assertEq(token.balanceOf(address(positionManager)), 0);
+        assertEq(address(positionManager).balance, 0);
+        assertEq(token.balanceOf(address(manager)), initializer.tokenLiquidityAmount());
+        assertEq(address(manager).balance, initializer.nativeLiquidityAmount());
+        assertEq(
+            token.balanceOf(launchWallet), initializer.TOKEN_LIQUIDITY_BUDGET() - initializer.tokenLiquidityAmount()
+        );
+        assertEq(launchWallet.balance, initializer.NATIVE_LIQUIDITY_BUDGET() - initializer.nativeLiquidityAmount());
+        assertEq(IERC721(address(positionManager)).ownerOf(initializer.positionTokenId()), lpRecipient);
+        assertGt(positionManager.getPositionLiquidity(initializer.positionTokenId()), 0);
+        assertGt(initializer.nativeLiquidityAmount(), 0);
+        assertGt(initializer.tokenLiquidityAmount(), 0);
+
+        (uint160 sqrtPriceX96, int24 tick,,) = StateLibrary.getSlot0(manager, hookKey.toId());
+        assertEq(sqrtPriceX96, TickMath.getSqrtPriceAtTick(initializer.INITIAL_TICK()));
+        assertEq(tick, initializer.INITIAL_TICK());
+        assertEq(initializer.poolId(), hook.poolId());
+    }
+
+    function test_hookPermissionsAndExactOutputBasisAreExplicit() public view {
+        Hooks.Permissions memory permissions = hook.getHookPermissions();
+        assertTrue(permissions.beforeInitialize);
+        assertTrue(permissions.afterSwap);
+        assertTrue(permissions.afterSwapReturnDelta);
+        assertFalse(permissions.beforeSwap);
+        assertFalse(permissions.beforeSwapReturnDelta);
+        assertEq(hook.PLATFORM_FEE_PIPS(), 1000);
+        assertEq(hook.feeRecipient(), initializer.PLATFORM_FEE_RECIPIENT());
+        assertEq(hook.authorized(), address(initializer));
+        assertEq(uint160(address(hook)) & initializer.ALL_HOOK_MASK(), initializer.REQUIRED_HOOK_FLAGS());
+    }
+
+    function test_exactInputNativeToTokenChargesTenBpsOnTokenOutput() public {
+        _assertFeeSettlement(true, true);
+    }
+
+    function test_exactOutputNativeToTokenChargesTenBpsOnNativeInput() public {
+        _assertFeeSettlement(true, false);
+    }
+
+    function test_exactInputTokenToNativeChargesTenBpsOnNativeOutput() public {
+        _assertFeeSettlement(false, true);
+    }
+
+    function test_exactOutputTokenToNativeChargesTenBpsOnTokenInput() public {
+        _assertFeeSettlement(false, false);
+    }
+
+    function test_rejectsReplayThroughTheSameGraphAuthorization() public {
+        uint256 nativeBudget = initializer.NATIVE_LIQUIDITY_BUDGET();
+        vm.deal(address(graphFactory), nativeBudget);
+        vm.expectRevert(ProgrammableCanaryLiquidityInitializerV1.AlreadyInitialized.selector);
+        vm.prank(address(graphFactory));
+        initializer.initialize{ value: nativeBudget }(token, hook, block.timestamp + 1 days);
+    }
+
+    function test_rejectsCallerOtherThanExplicitGraphFactoryBeforeInspectingTargets() public {
+        ProgrammableCanaryLiquidityInitializerV1 freshInitializer = _newUninitializedInitializer();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableCanaryLiquidityInitializerV1.UnauthorizedInitializer.selector,
+                address(this),
+                address(graphFactory)
+            )
+        );
+        freshInitializer.initialize(ProgrammableCanaryTokenV1(address(0)), PlatformFeeHookV1(address(0)), 0);
+    }
+
+    function test_rejectsAnyInitializerValueOtherThanExactReviewedBudget() public {
+        ProgrammableCanaryLiquidityInitializerV1 freshInitializer = _newUninitializedInitializer();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableCanaryLiquidityInitializerV1.InvalidValue.selector,
+                freshInitializer.NATIVE_LIQUIDITY_BUDGET(),
+                0
+            )
+        );
+        vm.prank(address(graphFactory));
+        freshInitializer.initialize(ProgrammableCanaryTokenV1(address(0)), PlatformFeeHookV1(address(0)), 0);
+    }
+
+    function test_rejectsExpiredCommittedDeadlineBeforeInspectingTargets() public {
+        ProgrammableCanaryLiquidityInitializerV1 freshInitializer = _newUninitializedInitializer();
+        uint256 nativeBudget = freshInitializer.NATIVE_LIQUIDITY_BUDGET();
+        vm.warp(2);
+        vm.deal(address(graphFactory), nativeBudget);
+        vm.expectRevert(abi.encodeWithSelector(ProgrammableCanaryLiquidityInitializerV1.DeadlineExpired.selector, 2, 1));
+        vm.prank(address(graphFactory));
+        freshInitializer.initialize{ value: nativeBudget }(
+            ProgrammableCanaryTokenV1(address(0)), PlatformFeeHookV1(address(0)), 1
+        );
+    }
+
+    function test_preexistingForcedNativeCannotChangeLiquidityOrBecomeResidualCustody() public {
+        uint256 priorLaunchWalletBalance = launchWallet.balance;
+        uint256 forcedNative = 123 wei;
+        vm.deal(address(positionManager), forcedNative);
+        vm.roll(block.number + 1);
+
+        _launchCanary();
+
+        assertEq(address(positionManager).balance, 0);
+        assertEq(
+            launchWallet.balance,
+            priorLaunchWalletBalance + forcedNative + initializer.NATIVE_LIQUIDITY_BUDGET()
+                - initializer.nativeLiquidityAmount()
+        );
+        assertEq(address(manager).balance, initializer.nativeLiquidityAmount() * 2);
+    }
+
+    function test_create2PrefundedInitializerStillLaunchesAndRefundsOnlySignedWallet() public {
+        uint256 priorLaunchWalletBalance = launchWallet.balance;
+        uint256 poolManagerNativeBefore = address(manager).balance;
+        uint256 graphFactoryNativeBefore = address(graphFactory).balance;
+        uint256 initializerPrefund = 1 wei;
+        vm.roll(block.number + 1);
+
+        _launchCanaryWithInitializerPrefund(initializerPrefund);
+
+        assertEq(initializerPrefunder.balance, 0);
+        assertEq(address(initializer).balance, 0);
+        assertEq(address(positionManager).balance, 0);
+        assertEq(address(graphFactory).balance, graphFactoryNativeBefore);
+        assertEq(address(manager).balance - poolManagerNativeBefore, initializer.nativeLiquidityAmount());
+        assertEq(
+            launchWallet.balance,
+            priorLaunchWalletBalance + initializerPrefund + initializer.NATIVE_LIQUIDITY_BUDGET()
+                - initializer.nativeLiquidityAmount()
+        );
+        assertEq(lpRecipient.balance, 0);
+    }
+
+    function test_signedLaunchWalletCallbackCannotReenterInitializerRefund() public {
+        ProgrammableCanaryReentrantLaunchWallet reentrantWallet = new ProgrammableCanaryReentrantLaunchWallet();
+        address reentrantLpRecipient = makeAddr("programmableCanaryReentrantLpRecipient");
+        uint256 initializerPrefund = 1 wei;
+        vm.roll(block.number + 1);
+
+        _launchCanaryWithConfiguration(address(reentrantWallet), reentrantLpRecipient, initializerPrefund);
+
+        assertEq(address(initializer).balance, 0);
+        assertEq(reentrantWallet.lastSender(), address(initializer));
+        assertFalse(reentrantWallet.reentrySucceeded());
+        assertEq(reentrantWallet.reentryRevertSelector(), bytes4(keccak256("ReentrancyGuardReentrantCall()")));
+        assertEq(
+            reentrantWallet.receivedAmount(),
+            initializerPrefund + initializer.NATIVE_LIQUIDITY_BUDGET() - initializer.nativeLiquidityAmount()
+        );
+        assertEq(IERC721(address(positionManager)).ownerOf(initializer.positionTokenId()), reentrantLpRecipient);
+    }
+
+    function test_rejectedInitializerPrefundRefundFailsClosedAndRollsBackGraph() public {
+        ProgrammableCanaryRejectingLaunchWallet rejectingWallet = new ProgrammableCanaryRejectingLaunchWallet();
+        address rejectingLpRecipient = makeAddr("programmableCanaryRejectingLpRecipient");
+        uint256 nextTokenIdBefore = positionManager.nextTokenId();
+        uint256 poolManagerNativeBefore = address(manager).balance;
+        uint256 graphFactoryNativeBefore = address(graphFactory).balance;
+        vm.roll(block.number + 1);
+
+        bool reverted;
+        try this.launchCanaryForFailClosedTest(address(rejectingWallet), rejectingLpRecipient, 1 wei) {
+            fail();
+        } catch (bytes memory reason) {
+            reverted = true;
+            assertEq(bytes4(reason), LocalProgrammableCreate2GraphDeployerV1.InitializerFailed.selector);
+        }
+
+        assertTrue(reverted);
+        assertEq(address(rejectingWallet).balance, 0);
+        assertEq(positionManager.nextTokenId(), nextTokenIdBefore);
+        assertEq(address(manager).balance, poolManagerNativeBefore);
+        assertEq(address(graphFactory).balance, graphFactoryNativeBefore);
+    }
+
+    function launchCanaryForFailClosedTest(address launchWallet_, address lpRecipient_, uint256 initializerPrefund)
+        external
+    {
+        require(msg.sender == address(this));
+        _launchCanaryWithConfiguration(launchWallet_, lpRecipient_, initializerPrefund);
+    }
+
+    function _newUninitializedInitializer()
+        private
+        returns (ProgrammableCanaryLiquidityInitializerV1 freshInitializer)
+    {
+        freshInitializer = new ProgrammableCanaryLiquidityInitializerV1(
+            manager, positionManager, address(graphFactory), launchWallet, lpRecipient
+        );
+    }
+
+    function _assertFeeSettlement(bool zeroForOne, bool exactInput) private {
+        _seedReferencePool();
+        address trader = makeAddr("programmableCanaryTrader");
+        vm.deal(trader, 10 ether);
+
+        if (!zeroForOne) _primeTraderForSell(trader);
+
+        uint256 amount;
+        if (zeroForOne && exactInput) amount = 10 gwei;
+        if (zeroForOne && !exactInput) amount = 1 ether;
+        if (!zeroForOne && exactInput) amount = 1 ether;
+        if (!zeroForOne && !exactInput) amount = 1 gwei;
+        int256 signedAmount = SafeCast.toInt256(amount);
+        int256 amountSpecified = exactInput ? -signedAmount : signedAmount;
+        SwapParams memory params = SwapParams({
+            zeroForOne: zeroForOne,
+            amountSpecified: amountSpecified,
+            sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+        });
+
+        bool feeInCurrency1 = exactInput == zeroForOne;
+        Currency feeCurrency = feeInCurrency1 ? hookKey.currency1 : hookKey.currency0;
+        uint256 claimsBefore = manager.balanceOf(address(hook), feeCurrency.toId());
+
+        BalanceDelta hookDelta = _swapAs(trader, hookKey, params);
+        BalanceDelta referenceDelta = _swapReferenceAs(trader, params);
+        hookDelta;
+
+        int128 referenceUnspecified = feeInCurrency1 ? referenceDelta.amount1() : referenceDelta.amount0();
+        uint256 absoluteUnspecified =
+            referenceUnspecified < 0 ? uint256(-int256(referenceUnspecified)) : uint256(int256(referenceUnspecified));
+        uint256 expectedFee = FullMath.mulDiv(absoluteUnspecified, hook.PLATFORM_FEE_PIPS(), FEE_DENOMINATOR);
+        uint256 actualFee = manager.balanceOf(address(hook), feeCurrency.toId()) - claimsBefore;
+        assertEq(actualFee, expectedFee);
+        assertGt(actualFee, 0);
+
+        uint256 recipientBefore = feeCurrency.balanceOf(initializer.PLATFORM_FEE_RECIPIENT());
+        vm.prank(makeAddr("permissionlessCanaryFeeCollector"));
+        hook.handleHookFees(new Currency[](0));
+        assertEq(
+            feeCurrency.balanceOf(initializer.PLATFORM_FEE_RECIPIENT()), recipientBefore + claimsBefore + actualFee
+        );
+    }
+
+    function _seedReferencePool() private {
+        if (address(referenceToken) != address(0)) return;
+        referenceToken = new ProgrammableCanaryReferenceToken(address(this));
+        referenceKey = PoolKey({
+            currency0: Currency.wrap(address(0)),
+            currency1: Currency.wrap(address(referenceToken)),
+            fee: initializer.LP_FEE_PIPS(),
+            tickSpacing: initializer.TICK_SPACING(),
+            hooks: PlatformFeeHookV1(address(0))
+        });
+        uint160 initialSqrtPriceX96 = TickMath.getSqrtPriceAtTick(initializer.INITIAL_TICK());
+        manager.initialize(referenceKey, initialSqrtPriceX96);
+
+        PositionDefinition[] memory definitions = new PositionDefinition[](0);
+        CurrencyAmounts memory available = CurrencyAmounts({
+            amount0: initializer.NATIVE_LIQUIDITY_BUDGET(), amount1: initializer.TOKEN_LIQUIDITY_BUDGET()
+        });
+        (Position[] memory positions,) = PositionPlanner.resolve(
+            definitions, initialSqrtPriceX96, initializer.TICK_SPACING(), available, address(this)
+        );
+        assertEq(positions.length, 1);
+        Plan memory plan = PositionPlanner.toPlan(positions, referenceKey, address(this));
+        referenceToken.transfer(address(positionManager), initializer.TOKEN_LIQUIDITY_BUDGET());
+        positionManager.modifyLiquidities{ value: initializer.NATIVE_LIQUIDITY_BUDGET() }(
+            abi.encode(plan.actions, plan.params), block.timestamp + 1 days
+        );
+    }
+
+    function _primeTraderForSell(address trader) private {
+        SwapParams memory buy = SwapParams({
+            zeroForOne: true, amountSpecified: -int256(100 gwei), sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1
+        });
+        _swapAs(trader, hookKey, buy);
+        _swapReferenceAs(trader, buy);
+    }
+
+    function _swapAs(address trader, PoolKey memory key, SwapParams memory params)
+        private
+        returns (BalanceDelta delta)
+    {
+        vm.startPrank(trader);
+        IERC20(Currency.unwrap(key.currency1)).approve(address(swapRouter), type(uint256).max);
+        uint256 value = params.zeroForOne ? 1 ether : 0;
+        delta = swapRouter.swap{ value: value }(key, params, settings, "");
+        vm.stopPrank();
+    }
+
+    function _swapReferenceAs(address trader, SwapParams memory params) private returns (BalanceDelta delta) {
+        vm.startPrank(trader);
+        referenceToken.approve(address(swapRouter), type(uint256).max);
+        uint256 value = params.zeroForOne ? 1 ether : 0;
+        delta = swapRouter.swap{ value: value }(referenceKey, params, settings, "");
+        vm.stopPrank();
+    }
+}
+
+contract ProgrammableCanaryTokenV1FuzzTest is Test {
+    function testFuzz_entireFixedSupplyGoesOnlyToExplicitInitializer(address wallet, address liquidityInitializer)
+        public
+    {
+        vm.assume(wallet != address(0));
+        vm.assume(liquidityInitializer != address(0));
+        ProgrammableCanaryTokenV1 token =
+            new ProgrammableCanaryTokenV1("Programmable Canary", "PCAN", wallet, liquidityInitializer);
+        assertEq(token.totalSupply(), token.TOTAL_SUPPLY());
+        assertEq(token.balanceOf(liquidityInitializer), token.TOTAL_SUPPLY());
+        if (wallet != liquidityInitializer) assertEq(token.balanceOf(wallet), 0);
+        assertEq(token.launchWallet(), wallet);
+        assertEq(token.liquidityInitializer(), liquidityInitializer);
+    }
+}
+
+contract ProgrammableGraphCanaryV1MainnetForkTest is ProgrammableGraphCanaryFixtureV1 {
+    address internal constant MAINNET_POOL_MANAGER = 0x000000000004444c5dc75cB358380D2e3dE08A90;
+    address internal constant MAINNET_POSITION_MANAGER = 0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e;
+    address internal constant MAINNET_GRAPH_FACTORY = 0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887;
+    bytes32 internal constant POOL_MANAGER_RUNTIME_HASH =
+        0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293;
+    bytes32 internal constant POSITION_MANAGER_RUNTIME_HASH =
+        0x77e36c08b19959a30dde46dec9abe6208e371ff2f56884a56fe1e1a53615528b;
+    bytes32 internal constant GRAPH_FACTORY_RUNTIME_HASH =
+        0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8;
+
+    function test_mainnetForkDeploysTheExactTradableGraphThroughTheLiveFactory() public {
+        string memory rpcUrl = vm.envOr("MAINNET_RPC_URL", string(""));
+        if (bytes(rpcUrl).length == 0) {
+            vm.skip(true);
+            return;
+        }
+        vm.createSelectFork(rpcUrl);
+
+        assertEq(MAINNET_POOL_MANAGER.codehash, POOL_MANAGER_RUNTIME_HASH);
+        assertEq(MAINNET_POSITION_MANAGER.codehash, POSITION_MANAGER_RUNTIME_HASH);
+        assertEq(MAINNET_GRAPH_FACTORY.codehash, GRAPH_FACTORY_RUNTIME_HASH);
+
+        manager = IPoolManager(MAINNET_POOL_MANAGER);
+        positionManager = IPositionManager(MAINNET_POSITION_MANAGER);
+        graphFactory = IProgrammableCreate2GraphDeployerV1(MAINNET_GRAPH_FACTORY);
+        swapRouter = new PoolSwapTest(manager);
+        uint256 poolManagerNativeBefore = MAINNET_POOL_MANAGER.balance;
+        uint256 graphFactoryNativeBefore = MAINNET_GRAPH_FACTORY.balance;
+        uint256 initializerPrefund = 1 wei;
+        _launchCanaryWithInitializerPrefund(initializerPrefund);
+        emit log_named_uint("Live Graph deploy plus LP call gas", graphDeployGasUsed);
+
+        assertEq(IERC721(MAINNET_POSITION_MANAGER).ownerOf(initializer.positionTokenId()), lpRecipient);
+        assertGt(positionManager.getPositionLiquidity(initializer.positionTokenId()), 0);
+        assertEq(MAINNET_POOL_MANAGER.balance - poolManagerNativeBefore, initializer.nativeLiquidityAmount());
+        assertEq(MAINNET_GRAPH_FACTORY.balance, graphFactoryNativeBefore);
+        assertEq(token.balanceOf(MAINNET_POOL_MANAGER), initializer.tokenLiquidityAmount());
+        assertEq(
+            token.balanceOf(launchWallet), initializer.TOKEN_LIQUIDITY_BUDGET() - initializer.tokenLiquidityAmount()
+        );
+        assertEq(
+            launchWallet.balance,
+            initializerPrefund + initializer.NATIVE_LIQUIDITY_BUDGET() - initializer.nativeLiquidityAmount()
+        );
+        assertEq(initializerPrefunder.balance, 0);
+        assertEq(token.balanceOf(address(initializer)), 0);
+        assertEq(address(initializer).balance, 0);
+        assertEq(hook.feeRecipient(), initializer.PLATFORM_FEE_RECIPIENT());
+        assertEq(uint160(address(hook)) & initializer.ALL_HOOK_MASK(), initializer.REQUIRED_HOOK_FLAGS());
+
+        address trader = makeAddr("programmableCanaryMainnetForkTrader");
+        vm.deal(trader, 1 ether);
+        Currency feeCurrency = hookKey.currency1;
+        uint256 feeClaimsBefore = manager.balanceOf(address(hook), feeCurrency.toId());
+        uint256 recipientBalanceBefore = token.balanceOf(initializer.PLATFORM_FEE_RECIPIENT());
+        SwapParams memory params = SwapParams({
+            zeroForOne: true, amountSpecified: -int256(10 gwei), sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1
+        });
+        vm.prank(trader);
+        BalanceDelta delta = swapRouter.swap{ value: 10 gwei }(hookKey, params, settings, "");
+        assertEq(delta.amount0(), -int128(int256(10 gwei)));
+        assertGt(delta.amount1(), 0);
+        uint256 collectedFee = manager.balanceOf(address(hook), feeCurrency.toId()) - feeClaimsBefore;
+        assertGt(collectedFee, 0);
+
+        vm.prank(makeAddr("permissionlessMainnetForkFeeCollector"));
+        hook.handleHookFees(new Currency[](0));
+        assertEq(token.balanceOf(initializer.PLATFORM_FEE_RECIPIENT()), recipientBalanceBefore + collectedFee);
+    }
+}


### PR DESCRIPTION
## What changed

- adds a fixed-supply `ProgrammableCanaryTokenV1`
- adds a one-shot Graph-compatible Uniswap v4 liquidity initializer
- adds the frozen Mainnet canary manifest and focused unit, fuzz, invariant, prefund, rollback, reentrancy, swap, and fee tests

## Why

This is the smallest low-value Mainnet canary for the new atomic Programmable launch-stamp Router. It proves that an arbitrary custom Graph launch can deploy a token, initialize a v4 pool, mint liquidity, execute a real swap, and expose the Programmable origin stamp without relying on the legacy Registry/indexer path.

## Safety boundary

- fixed 1,000,000-token supply; no admin, proxy, pause, tax, or second mint
- exact 0.001 ETH launch value
- 10 bps immutable Programmable hook fee
- CREATE2 native prefunds are returned only to the signed launch wallet
- rejecting refunds and reentrancy roll the complete Graph back
- low-value canary only; no audit, fair-launch, locked-liquidity, or economic-safety claim

## Validation

- Canary suite: 15/15, including 1,000 fuzz runs
- Hook/unit/fuzz/invariants: 19/19, including 3 x 16,384 invariant calls
- current Mainnet-fork Graph deploy + LP + real swap + fee redemption: 1/1
- independent re-audit: no P0-P3 findings
- Slither: no actionable Medium/High findings in the new contracts
- `forge fmt`, JSON validation, and whitespace checks pass

The manifest intentionally leaves Router address, nonce, mined salt, final target addresses, and runtime hashes pending until the separately reviewed Router is deployed and finalized.
