### PR TITLE
Add launch stamp developer documentation

### DIFF
--- a/app/docs/launch-stamps/page.tsx
+++ b/app/docs/launch-stamps/page.tsx
@@ -1,0 +1,240 @@
+import type { Metadata } from "next";
+
+import docsStyles from "@/components/docs-experience.module.css";
+import {
+  LAUNCH_STAMP_RUNTIME_HASH_DEFINITION,
+  PROGRAMMABLE_LAUNCH_STAMP_MANIFEST,
+} from "@/components/launch-stamp-docs-contract";
+import styles from "@/components/launch-stamp-docs.module.css";
+import { DocsShell } from "@/components/docs-shell";
+
+export const metadata: Metadata = {
+  title: "Launch stamps · Programmable",
+  description:
+    "Verify provenance for future Programmable Classic and Custom launches through the canonical Launch Stamp Router.",
+  alternates: { canonical: "/docs/launch-stamps" },
+};
+
+const sections = [
+  { id: "trust-root", label: "Trust root" },
+  { id: "algorithm", label: "Verification algorithm" },
+  { id: "record", label: "Returned record" },
+  { id: "boundary", label: "Trust boundary" },
+  { id: "integration", label: "Integration seam" },
+] as const;
+
+const conceptualVerifier = [
+  "input := token OR (PoolManager, poolId)",
+  "",
+  "step 1  resolve input with the canonical Router → launchId",
+  "        if no launchId is returned → NOT_STAMPED",
+  "",
+  "step 2  read launchStamp at launchId from the same Router",
+  "        if no record is returned → NOT_STAMPED",
+  "",
+  "return launchStamp",
+].join("\n");
+
+const router = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter;
+
+const manifestFields = [
+  ["version", router.version],
+  ["generation", router.generation],
+  ["address", router.address],
+  ["startBlock", router.startBlock],
+  ["runtimeCodeHash", router.runtimeCodeHash],
+  ["authority", router.authority],
+  ["abi", router.abi],
+] as const;
+
+function PrelaunchTrustRoot() {
+  return (
+    <section
+      aria-labelledby="trust-root-heading"
+      className={styles.trustRoot}
+      data-launch-stamp-docs
+    >
+      <div className={styles.trustRootHeader}>
+        <div>
+          <p>Canonical trust root</p>
+          <h2 id="trust-root-heading">Launch Stamp Router</h2>
+        </div>
+        <span className={styles.status}>Status: {router.status}</span>
+      </div>
+
+      <dl className={styles.manifest}>
+        {manifestFields.map(([field, value]) => (
+          <div key={field}>
+            <dt>{field}</dt>
+            <dd>{value ?? "null"}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <p className={styles.hashDefinition}>
+        <code>runtimeCodeHash</code> means {LAUNCH_STAMP_RUNTIME_HASH_DEFINITION}{" "}
+        No address, ABI, authority, start block, or runtime binding is published
+        before the final Router deployment is verified.
+      </p>
+    </section>
+  );
+}
+
+export default function LaunchStampDocsPage() {
+  return (
+    <DocsShell
+      currentPath="/docs/launch-stamps"
+      description="For launches created after Router activation, resolve a token or Uniswap v4 market and read its launch stamp from one canonical contract. The result establishes Programmable provenance only."
+      heroAside={<PrelaunchTrustRoot />}
+      heroId="trust-root"
+      kicker="Developer provenance"
+      sections={sections}
+      title="Verify future launches at one trust root."
+    >
+      <section id="algorithm">
+        <h2>Use one verification algorithm</h2>
+        <p className={docsStyles.lead}>
+          Recognition has two steps. Resolve the launch identifier from either
+          the token or the Uniswap v4 market identity, then read the launch
+          stamp at that identifier from the same Router.
+        </p>
+
+        <ol
+          aria-label="Launch stamp verification flow"
+          className={styles.algorithmTrace}
+        >
+          <li className={styles.traceNode}>
+            <span>Recognition input</span>
+            <strong>token or (PoolManager, poolId)</strong>
+          </li>
+          <li className={styles.traceNode}>
+            <span>Step 1</span>
+            <strong>launchId</strong>
+          </li>
+          <li className={styles.traceNode}>
+            <span>Step 2</span>
+            <strong>launchStamp record</strong>
+          </li>
+        </ol>
+
+        <div className={styles.concept}>
+          <div className={styles.conceptHeader}>
+            <span className={styles.conceptLabel}>Conceptual pseudocode</span>
+            <span>Not executable calldata</span>
+          </div>
+          <pre aria-label="Conceptual launch stamp verifier pseudocode">
+            {conceptualVerifier}
+          </pre>
+        </div>
+
+        <p className={styles.scopeLine}>
+          A missing record means Programmable provenance is not established. It
+          is not a claim that the token, pool, or project is unsafe.
+        </p>
+      </section>
+
+      <section id="record">
+        <h2>Keep record semantics separate</h2>
+        <p>
+          The final ABI will define the encoded tuple. Until that artifact is
+          frozen, consumers should bind only to these stable interpretation
+          rules and keep decoding behind an injected ABI adapter.
+        </p>
+
+        <dl className={styles.recordList}>
+          <div>
+            <dt>Identity</dt>
+            <dd>
+              <code>launchId</code> is the key used to read the stamp. Do not
+              replace it with a name, ticker, creator label, or hook address.
+            </dd>
+          </div>
+          <div>
+            <dt>Recognition</dt>
+            <dd>
+              Accept either a token address or the pair{" "}
+              <code>(PoolManager, poolId)</code>. These are two inputs to the
+              same Router algorithm, not separate trust systems.
+            </dd>
+          </div>
+          <div>
+            <dt>Launch kind</dt>
+            <dd>
+              Read <code>LaunchKindV1.CustomGraph</code> or{" "}
+              <code>LaunchKindV1.Classic</code> as returned metadata. Do not
+              choose a trust root or verification path from the kind.
+            </dd>
+          </div>
+          <div>
+            <dt>Hook</dt>
+            <dd>
+              A returned hook is descriptive metadata. It is not a universal
+              lookup key because more than one launch can use the same hook.
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section id="boundary">
+        <h2>A stamp proves provenance, and only provenance</h2>
+        <p>
+          A valid record says that the canonical Router recognizes the launch
+          under the returned identity. Keep every other product or risk decision
+          outside this result.
+        </p>
+
+        <dl className={styles.boundaryList}>
+          <div>
+            <dt>It establishes</dt>
+            <dd>
+              Programmable origin for the returned future Classic or Custom
+              launch record on the configured chain.
+            </dd>
+          </div>
+          <div>
+            <dt>It does not establish</dt>
+            <dd>
+              Safety, tradability, liquidity, audit coverage, review status,
+              approval, endorsement, or permission to launch.
+            </dd>
+          </div>
+          <div>
+            <dt>It does not require</dt>
+            <dd>
+              A Registry, indexer, Supabase project, Programmable API, or
+              application server. Read the Router directly through an Ethereum
+              provider.
+            </dd>
+          </div>
+          <div>
+            <dt>It excludes</dt>
+            <dd>
+              Historical launches created before Router activation. Do not
+              backfill them or infer stamps from legacy contracts and events.
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className={styles.finalSection} id="integration">
+        <h2>Inject the final binding</h2>
+        <p>
+          Keep the Router address, ABI, start block, runtime hash, authority,
+          and selector encoding in one versioned binding. Application logic
+          should receive that binding rather than hardcode provisional names or
+          calldata.
+        </p>
+
+        <div className={styles.implementationRule}>
+          <strong>Prelaunch rule</strong>
+          <p>
+            While any required binding field above is <code>null</code>, do not
+            issue Router reads and do not present any launch as stamped. Replace
+            the conceptual pseudocode only after the final artifact and
+            deployment evidence are published together.
+          </p>
+        </div>
+      </section>
+    </DocsShell>
+  );
+}

--- a/app/docs/launch-stamps/page.tsx
+++ b/app/docs/launch-stamps/page.tsx
@@ -25,7 +25,7 @@ const sections = [
   { id: "abi", label: "Frozen ABI" },
   { id: "record", label: "Returned record" },
   { id: "boundary", label: "Trust boundary" },
-  { id: "integration", label: "Integration seam" },
+  { id: "integration", label: "Deployment state" },
 ] as const;
 
 const abiBoundVerifier = [
@@ -44,6 +44,8 @@ const abiBoundVerifier = [
 ].join("\n");
 
 const router = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter;
+const deployment = router.deploymentEvidence;
+const observedBindings = deployment.observedBindings;
 const artifact = PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT;
 const abi = PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI;
 
@@ -57,6 +59,35 @@ const manifestFields = [
   ["abi", router.abi],
 ] as const;
 
+const deploymentEvidenceFields = [
+  ["verificationStatus", deployment.verificationStatus],
+  ["address", deployment.address],
+  ["deploymentTransactionHash", deployment.deploymentTransactionHash],
+  ["deploymentBlockNumber", deployment.deploymentBlockNumber],
+  ["deploymentBlockHash", deployment.deploymentBlockHash],
+  ["finalizedBlockNumber", deployment.finalizedBlockNumber],
+  ["finalizedBlockHash", deployment.finalizedBlockHash],
+  ["finalityDepth", deployment.finalityDepth],
+  ["runtimeCodeBytes", deployment.runtimeCodeBytes],
+  ["runtimeCodeKeccak256", deployment.runtimeCodeKeccak256],
+  ["runtimeCodeSha256", deployment.runtimeCodeSha256],
+  ["getterBundleSha256", deployment.getterBundleSha256],
+  ["evidenceSha256", deployment.evidenceSha256],
+] as const;
+
+const observedBindingFields = [
+  ["chainId", observedBindings.chainId],
+  ["permitAuthority", observedBindings.permitAuthority],
+  [
+    "permitAuthorityRuntimeCodeHash",
+    observedBindings.permitAuthorityRuntimeCodeHash,
+  ],
+  ["graphFactory", observedBindings.graphFactory],
+  ["graphFactoryRuntimeCodeHash", observedBindings.graphFactoryRuntimeCodeHash],
+  ["poolManager", observedBindings.poolManager],
+  ["poolManagerRuntimeCodeHash", observedBindings.poolManagerRuntimeCodeHash],
+] as const;
+
 function PrelaunchTrustRoot() {
   return (
     <section
@@ -66,7 +97,7 @@ function PrelaunchTrustRoot() {
     >
       <div className={styles.trustRootHeader}>
         <div>
-          <p>Canonical trust root</p>
+          <p>Canonical activation binding</p>
           <h2 id="trust-root-heading">Launch Stamp Router</h2>
         </div>
         <span className={styles.status}>Status: {router.status}</span>
@@ -83,9 +114,9 @@ function PrelaunchTrustRoot() {
 
       <p className={styles.hashDefinition}>
         <code>runtimeCodeHash</code> means {LAUNCH_STAMP_RUNTIME_HASH_DEFINITION}{" "}
-        The ABI is frozen to the source artifact documented below. No address,
-        authority, start block, or runtime binding is published before the
-        final Router deployment is verified.
+        The activation tuple above stays null while the canary is pending. The
+        finalized deployment evidence published below identifies the deployed
+        Router candidate, but does not activate terminal classification.
       </p>
     </section>
   );
@@ -131,7 +162,7 @@ export default function LaunchStampDocsPage() {
         <div className={styles.concept}>
           <div className={styles.conceptHeader}>
             <span className={styles.conceptLabel}>ABI-bound read sequence</span>
-            <span>Unavailable while address is null</span>
+            <span>Unavailable while status is prelaunch</span>
           </div>
           <pre aria-label="Launch stamp verifier pseudocode using the frozen ABI">
             {abiBoundVerifier}
@@ -150,8 +181,8 @@ export default function LaunchStampDocsPage() {
         <h2>Bind to the frozen Router ABI</h2>
         <p>
           The signatures and selectors below come from the final Router source
-          artifact. They fix the call encoding, but they do not activate an
-          address or make the Router live.
+          artifact. They fix the call encoding, but they do not activate the
+          Router or make terminal classification live.
         </p>
 
         <dl className={styles.artifactBinding}>
@@ -340,22 +371,42 @@ export default function LaunchStampDocsPage() {
       </section>
 
       <section className={styles.finalSection} id="integration">
-        <h2>Inject the verified deployment binding</h2>
+        <h2>Separate deployment evidence from activation</h2>
         <p>
-          Keep the frozen ABI and selector map together with the eventual
-          Router address, start block, runtime hash, and authority in one
-          versioned binding. Application logic should receive that binding
-          rather than copy addresses or rebuild calldata locally.
+          The Router candidate below is finalized and its runtime and immutable
+          getters were verified at the stated finalized block. These values are
+          deployment evidence only. The activation binding remains prelaunch
+          until the canary is complete.
         </p>
 
+        <h3 className={styles.subheading}>Finalized deployment evidence</h3>
+        <dl className={styles.artifactBinding}>
+          {deploymentEvidenceFields.map(([field, value]) => (
+            <div key={field}>
+              <dt>{field}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
+
+        <h3 className={styles.subheading}>Observed immutable getters</h3>
+        <dl className={styles.artifactBinding}>
+          {observedBindingFields.map(([field, value]) => (
+            <div key={field}>
+              <dt>{field}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
+
         <div className={styles.implementationRule}>
-          <strong>Prelaunch rule</strong>
+          <strong>Activation rule</strong>
           <p>
-            The ABI and tuple layout are final. The deployment is not. While
-            the address, runtime code hash, start block, or authority remains{" "}
-            <code>null</code>, do not issue Router reads and do not present any
-            launch as stamped. Enable the frozen read sequence only after those
-            fields are published and independently verified together.
+            While <code>status</code> is <code>prelaunch</code>, do not issue
+            Router reads and do not present any launch as stamped. Enable the
+            frozen read sequence only after the canary is complete and the
+            address, runtime code hash, start block, and authority are published
+            together in the live activation binding.
           </p>
         </div>
       </section>

--- a/app/docs/launch-stamps/page.tsx
+++ b/app/docs/launch-stamps/page.tsx
@@ -3,7 +3,11 @@ import type { Metadata } from "next";
 import docsStyles from "@/components/docs-experience.module.css";
 import {
   LAUNCH_STAMP_RUNTIME_HASH_DEFINITION,
+  LAUNCH_KIND_V1,
   PROGRAMMABLE_LAUNCH_STAMP_MANIFEST,
+  PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI,
+  PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT,
+  STAMP_RECORD_V1_FIELDS,
 } from "@/components/launch-stamp-docs-contract";
 import styles from "@/components/launch-stamp-docs.module.css";
 import { DocsShell } from "@/components/docs-shell";
@@ -18,24 +22,30 @@ export const metadata: Metadata = {
 const sections = [
   { id: "trust-root", label: "Trust root" },
   { id: "algorithm", label: "Verification algorithm" },
+  { id: "abi", label: "Frozen ABI" },
   { id: "record", label: "Returned record" },
   { id: "boundary", label: "Trust boundary" },
   { id: "integration", label: "Integration seam" },
 ] as const;
 
-const conceptualVerifier = [
+const abiBoundVerifier = [
   "input := token OR (PoolManager, poolId)",
   "",
-  "step 1  resolve input with the canonical Router → launchId",
-  "        if no launchId is returned → NOT_STAMPED",
+  "step 1  launchId := input is token",
+  "          ? launchIdByToken(token)",
+  "          : launchIdByPool(PoolManager, poolId)",
+  "        if launchId == bytes32(0) → NOT_STAMPED",
   "",
-  "step 2  read launchStamp at launchId from the same Router",
-  "        if no record is returned → NOT_STAMPED",
+  "step 2  record := launchStamp(launchId)",
+  "        if record.stampHash == bytes32(0) → INDETERMINATE",
+  "        if identity or kind is inconsistent → INDETERMINATE",
   "",
-  "return launchStamp",
+  "return STAMPED(record)",
 ].join("\n");
 
 const router = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter;
+const artifact = PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT;
+const abi = PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI;
 
 const manifestFields = [
   ["version", router.version],
@@ -73,8 +83,9 @@ function PrelaunchTrustRoot() {
 
       <p className={styles.hashDefinition}>
         <code>runtimeCodeHash</code> means {LAUNCH_STAMP_RUNTIME_HASH_DEFINITION}{" "}
-        No address, ABI, authority, start block, or runtime binding is published
-        before the final Router deployment is verified.
+        The ABI is frozen to the source artifact documented below. No address,
+        authority, start block, or runtime binding is published before the
+        final Router deployment is verified.
       </p>
     </section>
   );
@@ -119,27 +130,137 @@ export default function LaunchStampDocsPage() {
 
         <div className={styles.concept}>
           <div className={styles.conceptHeader}>
-            <span className={styles.conceptLabel}>Conceptual pseudocode</span>
-            <span>Not executable calldata</span>
+            <span className={styles.conceptLabel}>ABI-bound read sequence</span>
+            <span>Unavailable while address is null</span>
           </div>
-          <pre aria-label="Conceptual launch stamp verifier pseudocode">
-            {conceptualVerifier}
+          <pre aria-label="Launch stamp verifier pseudocode using the frozen ABI">
+            {abiBoundVerifier}
           </pre>
         </div>
 
         <p className={styles.scopeLine}>
-          A missing record means Programmable provenance is not established. It
-          is not a claim that the token, pool, or project is unsafe.
+          A successful zero lookup is <code>NOT_STAMPED</code>. A failed call or
+          inconsistent nonzero record is <code>INDETERMINATE</code>, not a
+          provenance result and not a claim that the token, pool, or project is
+          unsafe.
+        </p>
+      </section>
+
+      <section id="abi">
+        <h2>Bind to the frozen Router ABI</h2>
+        <p>
+          The signatures and selectors below come from the final Router source
+          artifact. They fix the call encoding, but they do not activate an
+          address or make the Router live.
+        </p>
+
+        <dl className={styles.artifactBinding}>
+          <div>
+            <dt>Contract</dt>
+            <dd>{artifact.contractName}</dd>
+          </div>
+          <div>
+            <dt>Source commit</dt>
+            <dd>{artifact.sourceCommit}</dd>
+          </div>
+          <div>
+            <dt>Source tree</dt>
+            <dd>{artifact.sourceTree}</dd>
+          </div>
+          <div>
+            <dt>Forge artifact</dt>
+            <dd>{artifact.artifactPath}</dd>
+          </div>
+        </dl>
+
+        <h3 className={styles.subheading}>Primary verification reads</h3>
+        <dl className={styles.abiList}>
+          {abi.primaryReads.map((entry) => (
+            <div key={entry.signature}>
+              <dt>{entry.label}</dt>
+              <dd>
+                <code>{entry.signature}</code>
+                <span>
+                  selector <code>{entry.selector}</code> · returns{" "}
+                  <code>{entry.returns}</code>
+                </span>
+              </dd>
+            </div>
+          ))}
+        </dl>
+
+        <h3 className={styles.subheading}>Exclusive-component reads</h3>
+        <dl className={styles.abiList}>
+          {abi.componentReads.map((entry) => (
+            <div key={entry.signature}>
+              <dt>{entry.label}</dt>
+              <dd>
+                <code>{entry.signature}</code>
+                <span>
+                  selector <code>{entry.selector}</code> · returns{" "}
+                  <code>{entry.returns}</code>
+                </span>
+              </dd>
+            </div>
+          ))}
+        </dl>
+
+        <p className={styles.scopeLine}>
+          <code>stampProof(address)</code> returns the component&apos;s exclusive
+          assignment and the corresponding record hash. A Classic hook is
+          shared infrastructure, so its component proof is intentionally{" "}
+          <code>(bytes32(0), bytes32(0))</code> even when its launch is stamped.
+          There is no universal hook getter.
+        </p>
+
+        <h3 className={styles.subheading}>Atomic write selector</h3>
+        <div className={styles.atomicSignature}>
+          <code>{abi.market.signature}</code>
+          <span>
+            selector <code>{abi.market.selector}</code> · payable · returns{" "}
+            <code>{abi.market.returns}</code>
+          </span>
+        </div>
+        <p className={styles.detailLine}>
+          This is the sole market-bearing state-changing selector. Verification
+          uses the read calls above and does not require a permit service,
+          Registry, or application server.
         </p>
       </section>
 
       <section id="record">
-        <h2>Keep record semantics separate</h2>
+        <h2>Decode the frozen record in order</h2>
         <p>
-          The final ABI will define the encoded tuple. Until that artifact is
-          frozen, consumers should bind only to these stable interpretation
-          rules and keep decoding behind an injected ABI adapter.
+          <code>launchStamp(bytes32)</code> returns{" "}
+          <code>StampRecordV1</code> with these fourteen fields in this exact
+          order. Decode the tuple with the frozen ABI rather than a locally
+          reconstructed type.
         </p>
+
+        <div className={styles.recordLayout}>
+          <div>
+            <span>StampRecordV1</span>
+            <span>ABI tuple order</span>
+          </div>
+          <ol aria-label="StampRecordV1 fields in ABI order">
+            {STAMP_RECORD_V1_FIELDS.map(([type, name]) => (
+              <li key={name}>
+                <code>{type}</code> <strong>{name}</strong>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        <dl className={styles.kindMap}>
+          {LAUNCH_KIND_V1.map((kind) => (
+            <div key={kind.name}>
+              <dt>
+                <code>{kind.value}</code> · {kind.name}
+              </dt>
+              <dd>{kind.publicLabel ?? "Not a valid stamped record kind"}</dd>
+            </div>
+          ))}
+        </dl>
 
         <dl className={styles.recordList}>
           <div>
@@ -160,16 +281,18 @@ export default function LaunchStampDocsPage() {
           <div>
             <dt>Launch kind</dt>
             <dd>
-              Read <code>LaunchKindV1.CustomGraph</code> or{" "}
-              <code>LaunchKindV1.Classic</code> as returned metadata. Do not
-              choose a trust root or verification path from the kind.
+              Map <code>LaunchKindV1.CustomGraph</code> (<code>1</code>) to
+              Programmable Custom and <code>LaunchKindV1.Classic</code> ({" "}
+              <code>2</code>) to Programmable Classic. Kind is returned
+              metadata; it never selects another trust root.
             </dd>
           </div>
           <div>
             <dt>Hook</dt>
             <dd>
-              A returned hook is descriptive metadata. It is not a universal
-              lookup key because more than one launch can use the same hook.
+              <code>record.hook</code> is descriptive metadata. The Classic
+              hook is shared by multiple launches, so it is never a universal
+              lookup or classification key.
             </dd>
           </div>
         </dl>
@@ -217,21 +340,22 @@ export default function LaunchStampDocsPage() {
       </section>
 
       <section className={styles.finalSection} id="integration">
-        <h2>Inject the final binding</h2>
+        <h2>Inject the verified deployment binding</h2>
         <p>
-          Keep the Router address, ABI, start block, runtime hash, authority,
-          and selector encoding in one versioned binding. Application logic
-          should receive that binding rather than hardcode provisional names or
-          calldata.
+          Keep the frozen ABI and selector map together with the eventual
+          Router address, start block, runtime hash, and authority in one
+          versioned binding. Application logic should receive that binding
+          rather than copy addresses or rebuild calldata locally.
         </p>
 
         <div className={styles.implementationRule}>
           <strong>Prelaunch rule</strong>
           <p>
-            While any required binding field above is <code>null</code>, do not
-            issue Router reads and do not present any launch as stamped. Replace
-            the conceptual pseudocode only after the final artifact and
-            deployment evidence are published together.
+            The ABI and tuple layout are final. The deployment is not. While
+            the address, runtime code hash, start block, or authority remains{" "}
+            <code>null</code>, do not issue Router reads and do not present any
+            launch as stamped. Enable the frozen read sequence only after those
+            fields are published and independently verified together.
           </p>
         </div>
       </section>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,6 +8,7 @@ const PUBLIC_ROUTES = [
   "/launch",
   "/docs",
   "/docs/developers",
+  "/docs/launch-stamps",
   "/docs/models/classic",
   "/docs/models/custom",
   "/docs/models/stock-paired",

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -16,6 +16,7 @@ export const docsCategories = [
   {
     href: "/docs/developers",
     label: "Developers",
+    relatedPaths: ["/docs/launch-stamps"],
     status: "available",
   },
 ] as const;
@@ -25,6 +26,7 @@ export const docsNavigation = [
     label: "Developers",
     items: [
       { href: "/docs/developers#paths", label: "Start here" },
+      { href: "/docs/launch-stamps", label: "Launch stamps" },
       { href: "/docs/developers#quickstart", label: "Quickstart" },
       { href: "/docs/developers#identity", label: "Launch identity" },
       { href: "/docs/developers#providers", label: "Custom Registry" },
@@ -39,6 +41,12 @@ export const docsNavigation = [
 ] as const;
 
 export const docsSearchItems: DocsSearchItem[] = [
+  {
+    title: "Launch stamps",
+    description:
+      "Verify future Classic and Custom provenance through one canonical Router lookup.",
+    href: "/docs/launch-stamps",
+  },
   {
     title: "Terminal contract",
     description:

--- a/components/docs-shell.tsx
+++ b/components/docs-shell.tsx
@@ -48,7 +48,9 @@ export function DocsShell({
         >
           {docsCategories.map((category) => {
             if (category.status === "available") {
-              const active = currentPath === category.href;
+              const active =
+                currentPath === category.href ||
+                category.relatedPaths.some((path) => path === currentPath);
               return (
                 <Link
                   aria-current={active ? "page" : undefined}

--- a/components/launch-stamp-docs-contract.ts
+++ b/components/launch-stamp-docs-contract.ts
@@ -1,3 +1,61 @@
+export const PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT = {
+  contractName: "ProgrammableLaunchStampRouterV1",
+  sourceCommit: "0a7134bbb912222639627fb9078df2f8dd3a6c38",
+  sourceTree: "24ffb0c6b04af7993254560b4f03608de8f52231",
+  artifactPath:
+    "out/ProgrammableLaunchStampRouterV1.sol/ProgrammableLaunchStampRouterV1.json",
+} as const;
+
+export const PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI = {
+  market: {
+    label: "Sole market-bearing write",
+    signature:
+      "launchAndStampV1((uint256,address,address,uint8,bytes32,bytes32,bytes32,bytes32,uint64,uint64,uint256),(bytes32,address,bytes32,(address,address,uint24,int24,address),bytes32,(uint8,address,bytes32,uint8,uint8)[]),bytes,bytes)",
+    selector: "0xe5f6b8cd",
+    returns: "bytes32 stampHash",
+  },
+  primaryReads: [
+    {
+      label: "Token to launch ID",
+      signature: "launchIdByToken(address)",
+      selector: "0x1dad847c",
+      returns: "bytes32 launchId",
+    },
+    {
+      label: "Market to launch ID",
+      signature: "launchIdByPool(address,bytes32)",
+      selector: "0x361df6f3",
+      returns: "bytes32 launchId",
+    },
+    {
+      label: "Launch ID to record",
+      signature: "launchStamp(bytes32)",
+      selector: "0x4c9e4764",
+      returns: "StampRecordV1",
+    },
+  ],
+  componentReads: [
+    {
+      label: "Exclusive-component proof",
+      signature: "stampProof(address)",
+      selector: "0x174b9f9d",
+      returns: "(bytes32 launchId, bytes32 stampHash)",
+    },
+    {
+      label: "Exclusive-component lookup",
+      signature: "launchIdByComponent(address)",
+      selector: "0x58c5e373",
+      returns: "bytes32 launchId",
+    },
+    {
+      label: "Recorded component runtime",
+      signature: "componentRuntimeCodeHash(address)",
+      selector: "0xc892d353",
+      returns: "bytes32 runtimeCodeHash",
+    },
+  ],
+} as const;
+
 export const PROGRAMMABLE_LAUNCH_STAMP_MANIFEST = {
   launchStampRouter: {
     version: "1",
@@ -7,9 +65,32 @@ export const PROGRAMMABLE_LAUNCH_STAMP_MANIFEST = {
     startBlock: null,
     runtimeCodeHash: null,
     authority: null,
-    abi: null,
+    abi: "frozen",
   },
 } as const;
+
+export const LAUNCH_KIND_V1 = [
+  { value: 0, name: "Invalid", publicLabel: null },
+  { value: 1, name: "CustomGraph", publicLabel: "Programmable Custom" },
+  { value: 2, name: "Classic", publicLabel: "Programmable Classic" },
+] as const;
+
+export const STAMP_RECORD_V1_FIELDS = [
+  ["uint8", "kind"],
+  ["address", "launchWallet"],
+  ["address", "token"],
+  ["address", "hook"],
+  ["address", "poolManager"],
+  ["bytes32", "poolId"],
+  ["bytes32", "poolKeyHash"],
+  ["bytes32", "componentSetHash"],
+  ["bytes32", "routePayloadHash"],
+  ["address", "routeLauncher"],
+  ["bytes32", "routeLauncherRuntimeCodeHash"],
+  ["bytes32", "expectedResultHash"],
+  ["bytes32", "permitDigest"],
+  ["bytes32", "stampHash"],
+] as const;
 
 export const LAUNCH_STAMP_RUNTIME_HASH_DEFINITION =
   "EVM Keccak-256 of the deployed runtime bytecode, encoded as a 0x-prefixed bytes32 value.";

--- a/components/launch-stamp-docs-contract.ts
+++ b/components/launch-stamp-docs-contract.ts
@@ -66,6 +66,40 @@ export const PROGRAMMABLE_LAUNCH_STAMP_MANIFEST = {
     runtimeCodeHash: null,
     authority: null,
     abi: "frozen",
+    deploymentEvidence: {
+      verificationStatus: "finalized-verified",
+      address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+      deploymentTransactionHash:
+        "0x3bc086661555c10040feb3fceb23d33003e22ca033e65cfae72592119ee8d486",
+      deploymentBlockNumber: "25717612",
+      deploymentBlockHash:
+        "0x8e4512193217c2171624657717d32dbfe9896455e553cadc192fbfe32d3278bc",
+      finalizedBlockNumber: "25717634",
+      finalizedBlockHash:
+        "0x4177a280cd7e43da181bf1d73900eb2431c26d5fe933a5ed0e583370064cbd6e",
+      finalityDepth: 22,
+      runtimeCodeBytes: 23013,
+      runtimeCodeKeccak256:
+        "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+      runtimeCodeSha256:
+        "sha256:0b0e89074bff270bd5bf80ca9642f748dca1857d1ab643cbce65f4f663937ec7",
+      observedBindings: {
+        chainId: 1,
+        permitAuthority: "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
+        permitAuthorityRuntimeCodeHash:
+          "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c",
+        graphFactory: "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
+        graphFactoryRuntimeCodeHash:
+          "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8",
+        poolManager: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+        poolManagerRuntimeCodeHash:
+          "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293",
+      },
+      getterBundleSha256:
+        "sha256:6e6e8a93193bbe2f79f98594a1af32c27bae0746f8297dd13592d9608e2feb20",
+      evidenceSha256:
+        "sha256:f9786ebfb74c96a3c225567ad324f0fbecfd8520b8d8addec85ba58cd67e19ff",
+    },
   },
 } as const;
 

--- a/components/launch-stamp-docs-contract.ts
+++ b/components/launch-stamp-docs-contract.ts
@@ -1,0 +1,15 @@
+export const PROGRAMMABLE_LAUNCH_STAMP_MANIFEST = {
+  launchStampRouter: {
+    version: "1",
+    generation: "1",
+    status: "prelaunch",
+    address: null,
+    startBlock: null,
+    runtimeCodeHash: null,
+    authority: null,
+    abi: null,
+  },
+} as const;
+
+export const LAUNCH_STAMP_RUNTIME_HASH_DEFINITION =
+  "EVM Keccak-256 of the deployed runtime bytecode, encoded as a 0x-prefixed bytes32 value.";

--- a/components/launch-stamp-docs.module.css
+++ b/components/launch-stamp-docs.module.css
@@ -203,6 +203,11 @@
   padding-block: 14px;
 }
 
+.artifactBinding dt {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .artifactBinding dd {
   color: var(--text-soft);
   font-family: var(--font-plex-mono), monospace;

--- a/components/launch-stamp-docs.module.css
+++ b/components/launch-stamp-docs.module.css
@@ -17,6 +17,8 @@
 
 .trustRootHeader p,
 .conceptLabel,
+.artifactBinding dt,
+.abiList dt,
 .recordList dt,
 .boundaryList dt {
   color: var(--muted);
@@ -186,6 +188,188 @@
   white-space: pre-wrap;
 }
 
+.artifactBinding {
+  border-top: 1px solid var(--panel-border);
+  display: grid;
+  margin-top: 28px;
+  max-width: 820px;
+}
+
+.artifactBinding > div {
+  border-bottom: 1px solid var(--panel-border-soft);
+  display: grid;
+  gap: 28px;
+  grid-template-columns: minmax(145px, 0.34fr) minmax(0, 1fr);
+  padding-block: 14px;
+}
+
+.artifactBinding dd {
+  color: var(--text-soft);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.subheading {
+  font-size: 17px;
+  font-weight: 650;
+  letter-spacing: -0.014em;
+  line-height: 1.4;
+  margin-top: 34px;
+}
+
+.abiList {
+  border-top: 1px solid var(--panel-border);
+  display: grid;
+  margin-top: 14px;
+  max-width: 820px;
+}
+
+.abiList > div {
+  border-bottom: 1px solid var(--panel-border-soft);
+  display: grid;
+  gap: 28px;
+  grid-template-columns: minmax(145px, 0.34fr) minmax(0, 1fr);
+  padding-block: 16px;
+}
+
+.abiList dd {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  min-width: 0;
+}
+
+.abiList dd > code,
+.atomicSignature > code {
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.abiList dd span,
+.atomicSignature span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.atomicSignature {
+  border-block: 1px solid var(--panel-border);
+  display: grid;
+  gap: 9px;
+  margin-top: 14px;
+  max-width: 820px;
+  padding-block: 18px;
+}
+
+.detailLine {
+  color: var(--text-soft) !important;
+  font-size: 14px !important;
+  line-height: 1.6 !important;
+  margin-top: 14px !important;
+  max-width: 72ch !important;
+}
+
+.recordLayout {
+  border: 1px solid var(--panel-border);
+  margin-top: 28px;
+  max-width: 820px;
+}
+
+.recordLayout > div {
+  align-items: center;
+  border-bottom: 1px solid var(--panel-border-soft);
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  min-height: 48px;
+  padding: 8px 16px;
+}
+
+.recordLayout > div span:first-child {
+  color: var(--text);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.recordLayout > div span:last-child {
+  color: var(--dim);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.recordLayout ol {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  list-style-position: inside;
+  margin: 0;
+  padding: 12px 16px;
+}
+
+.recordLayout li {
+  border-bottom: 1px solid var(--panel-border-soft);
+  color: var(--dim);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 8px 6px 8px 0;
+}
+
+.recordLayout li:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.recordLayout li code {
+  color: var(--muted);
+}
+
+.recordLayout li strong {
+  color: var(--text-soft);
+  font-weight: 500;
+}
+
+.kindMap {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 20px;
+  max-width: 820px;
+}
+
+.kindMap > div {
+  border-inline-start: 1px solid var(--panel-border-soft);
+  display: grid;
+  gap: 5px;
+  padding: 2px 14px;
+}
+
+.kindMap > div:first-child {
+  border-inline-start: 0;
+  padding-inline-start: 0;
+}
+
+.kindMap dt {
+  color: var(--text);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.kindMap dd {
+  color: var(--text-soft);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
+}
+
 .recordList,
 .boundaryList {
   border-top: 1px solid var(--panel-border);
@@ -245,6 +429,24 @@
     scroll-padding-bottom: calc(88px + env(safe-area-inset-bottom));
   }
 
+  :global(body:has([data-launch-stamp-docs]) .site-header),
+  :global(body:has([data-launch-stamp-docs]) [data-docs-sidebar]) {
+    background: var(--body-background);
+  }
+
+  :global(body:has([data-launch-stamp-docs]) .site-header::before),
+  :global(body:has([data-launch-stamp-docs]) [data-docs-sidebar]::before) {
+    background: var(--body-background) !important;
+  }
+
+  :global(body:has([data-launch-stamp-docs]) .site-header::before) {
+    inset-block-end: -8px;
+  }
+
+  :global(body:has([data-launch-stamp-docs]) [data-docs-sidebar]::before) {
+    inset: -8px -14px -18px;
+  }
+
   .trustRootHeader {
     align-items: start;
     display: grid;
@@ -277,6 +479,11 @@
   .trustRoot,
   .algorithmTrace,
   .concept,
+  .artifactBinding,
+  .abiList,
+  .atomicSignature,
+  .recordLayout,
+  .kindMap,
   .recordList,
   .boundaryList,
   .implementationRule {
@@ -305,9 +512,31 @@
   }
 
   .recordList > div,
-  .boundaryList > div {
+  .boundaryList > div,
+  .artifactBinding > div,
+  .abiList > div {
     gap: 7px;
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .recordLayout ol,
+  .kindMap {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .recordLayout li:nth-last-child(2) {
+    border-bottom: 1px solid var(--panel-border-soft);
+  }
+
+  .kindMap > div,
+  .kindMap > div:first-child {
+    border-inline-start: 0;
+    border-top: 1px solid var(--panel-border-soft);
+    padding: 11px 0;
+  }
+
+  .kindMap > div:first-child {
+    border-top: 0;
   }
 
   .finalSection {

--- a/components/launch-stamp-docs.module.css
+++ b/components/launch-stamp-docs.module.css
@@ -1,0 +1,348 @@
+.trustRoot {
+  border-block: 1px solid var(--panel-border);
+  padding-block: 20px 18px;
+}
+
+.trustRootHeader {
+  align-items: end;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+}
+
+.trustRootHeader > div {
+  display: grid;
+  gap: 4px;
+}
+
+.trustRootHeader p,
+.conceptLabel,
+.recordList dt,
+.boundaryList dt {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 680;
+  letter-spacing: 0.055em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.trustRootHeader h2 {
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.018em;
+  line-height: 1.3;
+}
+
+.status {
+  align-items: center;
+  color: var(--text-soft);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  gap: 8px;
+  line-height: 1.4;
+}
+
+.status::before {
+  background: var(--warning);
+  border-radius: 50%;
+  content: "";
+  height: 7px;
+  width: 7px;
+}
+
+.manifest {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 20px;
+}
+
+.manifest > div {
+  border-inline-start: 1px solid var(--panel-border-soft);
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  padding: 2px 14px 4px;
+}
+
+.manifest > div:nth-child(4n + 1) {
+  border-inline-start: 0;
+  padding-inline-start: 0;
+}
+
+.manifest dt {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.manifest dd {
+  color: var(--text);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.hashDefinition {
+  color: var(--muted) !important;
+  font-size: 13px !important;
+  line-height: 1.55 !important;
+  margin-top: 16px !important;
+  max-width: 72ch !important;
+}
+
+.scopeLine {
+  border-inline-start: 2px solid var(--accent-strong);
+  color: var(--text) !important;
+  font-size: 16px !important;
+  line-height: 1.6 !important;
+  margin-top: 26px !important;
+  max-width: 68ch !important;
+  padding-inline-start: 17px;
+}
+
+.algorithmTrace {
+  align-items: stretch;
+  display: grid;
+  gap: 48px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  list-style: none;
+  margin-top: 30px;
+  max-width: 820px;
+  padding: 0;
+}
+
+.traceNode {
+  border-block: 1px solid var(--panel-border);
+  display: grid;
+  gap: 7px;
+  min-height: 104px;
+  padding: 17px 4px;
+  position: relative;
+}
+
+.traceNode:not(:last-child)::after {
+  color: var(--dim);
+  content: "→";
+  font-size: 18px;
+  inset-inline-end: -34px;
+  line-height: 1;
+  position: absolute;
+  top: calc(50% - 9px);
+}
+
+.traceNode span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.traceNode strong {
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.concept {
+  background: color-mix(in srgb, var(--body-background) 84%, var(--surface));
+  border: 1px solid var(--panel-border);
+  margin-top: 28px;
+  max-width: 820px;
+}
+
+.conceptHeader {
+  align-items: center;
+  border-bottom: 1px solid var(--panel-border-soft);
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  min-height: 48px;
+  padding: 8px 16px;
+}
+
+.conceptHeader span:last-child {
+  color: var(--dim);
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: end;
+}
+
+.concept pre {
+  color: var(--text-soft);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  line-height: 1.72;
+  margin: 0;
+  overflow-wrap: anywhere;
+  padding: 20px;
+  white-space: pre-wrap;
+}
+
+.recordList,
+.boundaryList {
+  border-top: 1px solid var(--panel-border);
+  display: grid;
+  margin-top: 28px;
+  max-width: 820px;
+}
+
+.recordList > div,
+.boundaryList > div {
+  border-bottom: 1px solid var(--panel-border-soft);
+  display: grid;
+  gap: 28px;
+  grid-template-columns: minmax(145px, 0.34fr) minmax(0, 1fr);
+  padding-block: 16px;
+}
+
+.recordList dd,
+.boundaryList dd {
+  color: var(--text-soft);
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 62ch;
+}
+
+.recordList code,
+.boundaryList code {
+  color: var(--text);
+  font-size: 0.92em;
+  overflow-wrap: anywhere;
+}
+
+.implementationRule {
+  border-block: 1px solid var(--panel-border);
+  display: grid;
+  gap: 6px;
+  margin-top: 26px;
+  max-width: 820px;
+  padding-block: 18px;
+}
+
+.implementationRule strong {
+  font-size: 15px;
+  font-weight: 660;
+  line-height: 1.5;
+}
+
+.implementationRule p {
+  font-size: 15px !important;
+  line-height: 1.6 !important;
+  max-width: 68ch !important;
+}
+
+@media (max-width: 700px) {
+  :global(html:has([data-launch-stamp-docs])) {
+    scroll-padding-bottom: calc(88px + env(safe-area-inset-bottom));
+  }
+
+  .trustRootHeader {
+    align-items: start;
+    display: grid;
+    gap: 12px;
+  }
+
+  .manifest {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .manifest > div {
+    border-top: 1px solid var(--panel-border-soft);
+    padding-block: 12px;
+  }
+
+  .manifest > div:nth-child(odd) {
+    border-inline-start: 0;
+    padding-inline-start: 0;
+  }
+
+  .manifest > div:nth-child(-n + 2) {
+    border-top: 0;
+  }
+
+  .algorithmTrace {
+    gap: 38px;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .trustRoot,
+  .algorithmTrace,
+  .concept,
+  .recordList,
+  .boundaryList,
+  .implementationRule {
+    background: color-mix(in srgb, var(--body-background) 92%, transparent);
+    box-shadow: 0 0 22px 12px
+      color-mix(in srgb, var(--body-background) 76%, transparent);
+    margin-inline: -8px;
+    padding-inline: 8px;
+  }
+
+  .concept {
+    background: color-mix(in srgb, var(--body-background) 97%, var(--surface));
+  }
+
+  .traceNode {
+    min-height: 0;
+    padding-block: 15px;
+  }
+
+  .traceNode:not(:last-child)::after {
+    bottom: -29px;
+    content: "↓";
+    inset-inline-end: auto;
+    inset-inline-start: 2px;
+    top: auto;
+  }
+
+  .recordList > div,
+  .boundaryList > div {
+    gap: 7px;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .finalSection {
+    padding-bottom: calc(88px + env(safe-area-inset-bottom));
+  }
+}
+
+@media (max-width: 360px) {
+  .manifest {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .manifest > div,
+  .manifest > div:nth-child(-n + 2) {
+    border-inline-start: 0;
+    border-top: 1px solid var(--panel-border-soft);
+    padding: 11px 0;
+  }
+
+  .manifest > div:first-child {
+    border-top: 0;
+  }
+
+  .conceptHeader {
+    align-items: flex-start;
+    display: grid;
+    gap: 3px;
+  }
+
+  .conceptHeader span:last-child {
+    text-align: start;
+  }
+
+  .concept pre {
+    font-size: 12px;
+    padding: 16px;
+  }
+}

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -168,6 +168,7 @@ export function buildDeveloperDocsMarkdown(
   "",
   "## Canonical resources",
   "",
+  "- [Launch Stamp Router reference](https://programmable.market/docs/launch-stamps) — direct provenance lookup for future Classic and Custom launches; the binding remains prelaunch until every deployment field is published.",
   `- [GitHub developer repository](${PROGRAMMABLE_DEVELOPER_REPOSITORY}) — canonical guides, schemas, fixtures, clients, compatibility and security policy.`,
   `- [Live discovery](${PROGRAMMABLE_WELL_KNOWN_URL}) — active API version, chains and canonical URLs.`,
   `- [Active OpenAPI](${PROGRAMMABLE_OPENAPI_URL}) — v${PROGRAMMABLE_ACTIVE_API_VERSION} HTTP contract.`,

--- a/tests/launch-stamp-docs.test.ts
+++ b/tests/launch-stamp-docs.test.ts
@@ -22,7 +22,7 @@ const sitemap = read("app/sitemap.ts");
 const markdown = read("lib/developer-docs-content.ts");
 
 describe("Launch Stamp developer documentation", () => {
-  it("binds the frozen ABI artifact while keeping deployment data prelaunch", () => {
+  it("keeps activation prelaunch while publishing exact finalized deployment evidence", () => {
     expect(PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT).toEqual({
       contractName: "ProgrammableLaunchStampRouterV1",
       sourceCommit: "0a7134bbb912222639627fb9078df2f8dd3a6c38",
@@ -40,12 +40,47 @@ describe("Launch Stamp developer documentation", () => {
         runtimeCodeHash: null,
         authority: null,
         abi: "frozen",
+        deploymentEvidence: {
+          verificationStatus: "finalized-verified",
+          address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+          deploymentTransactionHash:
+            "0x3bc086661555c10040feb3fceb23d33003e22ca033e65cfae72592119ee8d486",
+          deploymentBlockNumber: "25717612",
+          deploymentBlockHash:
+            "0x8e4512193217c2171624657717d32dbfe9896455e553cadc192fbfe32d3278bc",
+          finalizedBlockNumber: "25717634",
+          finalizedBlockHash:
+            "0x4177a280cd7e43da181bf1d73900eb2431c26d5fe933a5ed0e583370064cbd6e",
+          finalityDepth: 22,
+          runtimeCodeBytes: 23013,
+          runtimeCodeKeccak256:
+            "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+          runtimeCodeSha256:
+            "sha256:0b0e89074bff270bd5bf80ca9642f748dca1857d1ab643cbce65f4f663937ec7",
+          observedBindings: {
+            chainId: 1,
+            permitAuthority: "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
+            permitAuthorityRuntimeCodeHash:
+              "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c",
+            graphFactory: "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
+            graphFactoryRuntimeCodeHash:
+              "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8",
+            poolManager: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+            poolManagerRuntimeCodeHash:
+              "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293",
+          },
+          getterBundleSha256:
+            "sha256:6e6e8a93193bbe2f79f98594a1af32c27bae0746f8297dd13592d9608e2feb20",
+          evidenceSha256:
+            "sha256:f9786ebfb74c96a3c225567ad324f0fbecfd8520b8d8addec85ba58cd67e19ff",
+        },
       },
     });
     expect(LAUNCH_STAMP_RUNTIME_HASH_DEFINITION).toContain(
       "EVM Keccak-256 of the deployed runtime bytecode",
     );
-    expect(page).not.toMatch(/0x[a-fA-F0-9]{40}/);
+    expect(PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter.address).toBeNull();
+    expect(page).toContain("does not activate terminal classification");
   });
 
   it("publishes the artifact-exact terminal signatures and selectors", () => {
@@ -108,7 +143,7 @@ describe("Launch Stamp developer documentation", () => {
     );
     expect(page).toContain('"step 2  record := launchStamp(launchId)"');
     expect(page).toContain("ABI-bound read sequence");
-    expect(page).toContain("Unavailable while address is null");
+    expect(page).toContain("Unavailable while status is prelaunch");
   });
 
   it("documents stampProof as exclusive-component corroboration, never a hook route", () => {
@@ -155,8 +190,8 @@ describe("Launch Stamp developer documentation", () => {
     expect(page).toContain(
       "A Registry, indexer, Supabase project, Programmable API, or",
     );
-    expect(page).toContain("The ABI and tuple layout are final");
-    expect(page).toContain("The deployment is not");
+    expect(page).toContain("deployment evidence only");
+    expect(page).toContain("until the canary is complete");
   });
 
   it("adds one discoverable route to the existing Docs navigation", () => {

--- a/tests/launch-stamp-docs.test.ts
+++ b/tests/launch-stamp-docs.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  LAUNCH_STAMP_RUNTIME_HASH_DEFINITION,
+  PROGRAMMABLE_LAUNCH_STAMP_MANIFEST,
+} from "../components/launch-stamp-docs-contract";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+const page = read("app/docs/launch-stamps/page.tsx");
+const styles = read("components/launch-stamp-docs.module.css");
+const docsData = read("components/docs-data.ts");
+const docsShell = read("components/docs-shell.tsx");
+const sitemap = read("app/sitemap.ts");
+const markdown = read("lib/developer-docs-content.ts");
+
+describe("Launch Stamp developer documentation", () => {
+  it("publishes one explicit prelaunch Router binding without placeholders", () => {
+    expect(PROGRAMMABLE_LAUNCH_STAMP_MANIFEST).toEqual({
+      launchStampRouter: {
+        version: "1",
+        generation: "1",
+        status: "prelaunch",
+        address: null,
+        startBlock: null,
+        runtimeCodeHash: null,
+        authority: null,
+        abi: null,
+      },
+    });
+    expect(LAUNCH_STAMP_RUNTIME_HASH_DEFINITION).toContain(
+      "EVM Keccak-256 of the deployed runtime bytecode",
+    );
+    expect(page).not.toMatch(/0x[a-fA-F0-9]{40}/);
+  });
+
+  it("uses one recognition algorithm for token and Uniswap v4 pool identity", () => {
+    expect(page).toContain("token or (PoolManager, poolId)");
+    expect(page).toContain(
+      '"step 1  resolve input with the canonical Router → launchId"',
+    );
+    expect(page).toContain(
+      '"step 2  read launchStamp at launchId from the same Router"',
+    );
+    expect(page).toContain("Not executable calldata");
+    expect(page).not.toContain("functionName");
+    expect(page).not.toContain("hook → launchId");
+  });
+
+  it("limits stamps to future Classic and Custom provenance", () => {
+    expect(page).toContain("LaunchKindV1.CustomGraph");
+    expect(page).toContain("LaunchKindV1.Classic");
+    expect(page).toContain("Historical launches created before Router activation");
+    expect(page).toContain(
+      "Safety, tradability, liquidity, audit coverage, review status",
+    );
+    expect(page).toContain(
+      "A Registry, indexer, Supabase project, Programmable API, or",
+    );
+  });
+
+  it("adds one discoverable route to the existing Docs navigation", () => {
+    expect(docsData).toContain(
+      '{ href: "/docs/launch-stamps", label: "Launch stamps" }',
+    );
+    expect(docsData).toContain('relatedPaths: ["/docs/launch-stamps"]');
+    expect(docsShell).toContain(
+      "category.relatedPaths.some((path) => path === currentPath)",
+    );
+    expect(page).toContain('currentPath="/docs/launch-stamps"');
+    expect(page).toContain(
+      'alternates: { canonical: "/docs/launch-stamps" }',
+    );
+    expect(sitemap).toContain('"/docs/launch-stamps"');
+    expect(markdown).toContain(
+      "[Launch Stamp Router reference](https://programmable.market/docs/launch-stamps)",
+    );
+  });
+
+  it("keeps the page semantic, keyboard-visible, and reflow-safe", () => {
+    expect(page).toContain('aria-labelledby="trust-root-heading"');
+    expect(page).toContain("<dl className={styles.manifest}>");
+    expect(page).toContain('aria-label="Launch stamp verification flow"');
+    expect(page).toContain("<ol");
+    expect(page).not.toContain('role="img"');
+    expect(styles).toContain("@media (max-width: 700px)");
+    expect(styles).toContain("@media (max-width: 360px)");
+    expect(styles).toContain("env(safe-area-inset-bottom)");
+    expect(styles).toContain("var(--body-background) 92%");
+    expect(styles).not.toContain("transition: all");
+    expect(styles).not.toMatch(/\n\s+width:\s*\d{3,}px/);
+  });
+});

--- a/tests/launch-stamp-docs.test.ts
+++ b/tests/launch-stamp-docs.test.ts
@@ -4,8 +4,12 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  LAUNCH_KIND_V1,
   LAUNCH_STAMP_RUNTIME_HASH_DEFINITION,
   PROGRAMMABLE_LAUNCH_STAMP_MANIFEST,
+  PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI,
+  PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT,
+  STAMP_RECORD_V1_FIELDS,
 } from "../components/launch-stamp-docs-contract";
 
 const root = process.cwd();
@@ -18,7 +22,14 @@ const sitemap = read("app/sitemap.ts");
 const markdown = read("lib/developer-docs-content.ts");
 
 describe("Launch Stamp developer documentation", () => {
-  it("publishes one explicit prelaunch Router binding without placeholders", () => {
+  it("binds the frozen ABI artifact while keeping deployment data prelaunch", () => {
+    expect(PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT).toEqual({
+      contractName: "ProgrammableLaunchStampRouterV1",
+      sourceCommit: "0a7134bbb912222639627fb9078df2f8dd3a6c38",
+      sourceTree: "24ffb0c6b04af7993254560b4f03608de8f52231",
+      artifactPath:
+        "out/ProgrammableLaunchStampRouterV1.sol/ProgrammableLaunchStampRouterV1.json",
+    });
     expect(PROGRAMMABLE_LAUNCH_STAMP_MANIFEST).toEqual({
       launchStampRouter: {
         version: "1",
@@ -28,7 +39,7 @@ describe("Launch Stamp developer documentation", () => {
         startBlock: null,
         runtimeCodeHash: null,
         authority: null,
-        abi: null,
+        abi: "frozen",
       },
     });
     expect(LAUNCH_STAMP_RUNTIME_HASH_DEFINITION).toContain(
@@ -37,22 +48,106 @@ describe("Launch Stamp developer documentation", () => {
     expect(page).not.toMatch(/0x[a-fA-F0-9]{40}/);
   });
 
-  it("uses one recognition algorithm for token and Uniswap v4 pool identity", () => {
+  it("publishes the artifact-exact terminal signatures and selectors", () => {
+    expect(PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI).toEqual({
+      market: {
+        label: "Sole market-bearing write",
+        signature:
+          "launchAndStampV1((uint256,address,address,uint8,bytes32,bytes32,bytes32,bytes32,uint64,uint64,uint256),(bytes32,address,bytes32,(address,address,uint24,int24,address),bytes32,(uint8,address,bytes32,uint8,uint8)[]),bytes,bytes)",
+        selector: "0xe5f6b8cd",
+        returns: "bytes32 stampHash",
+      },
+      primaryReads: [
+        {
+          label: "Token to launch ID",
+          signature: "launchIdByToken(address)",
+          selector: "0x1dad847c",
+          returns: "bytes32 launchId",
+        },
+        {
+          label: "Market to launch ID",
+          signature: "launchIdByPool(address,bytes32)",
+          selector: "0x361df6f3",
+          returns: "bytes32 launchId",
+        },
+        {
+          label: "Launch ID to record",
+          signature: "launchStamp(bytes32)",
+          selector: "0x4c9e4764",
+          returns: "StampRecordV1",
+        },
+      ],
+      componentReads: [
+        {
+          label: "Exclusive-component proof",
+          signature: "stampProof(address)",
+          selector: "0x174b9f9d",
+          returns: "(bytes32 launchId, bytes32 stampHash)",
+        },
+        {
+          label: "Exclusive-component lookup",
+          signature: "launchIdByComponent(address)",
+          selector: "0x58c5e373",
+          returns: "bytes32 launchId",
+        },
+        {
+          label: "Recorded component runtime",
+          signature: "componentRuntimeCodeHash(address)",
+          selector: "0xc892d353",
+          returns: "bytes32 runtimeCodeHash",
+        },
+      ],
+    });
+  });
+
+  it("uses token or PoolManager and poolId as the universal recognition inputs", () => {
     expect(page).toContain("token or (PoolManager, poolId)");
+    expect(page).toContain('"          ? launchIdByToken(token)"');
     expect(page).toContain(
-      '"step 1  resolve input with the canonical Router → launchId"',
+      '"          : launchIdByPool(PoolManager, poolId)"',
     );
-    expect(page).toContain(
-      '"step 2  read launchStamp at launchId from the same Router"',
+    expect(page).toContain('"step 2  record := launchStamp(launchId)"');
+    expect(page).toContain("ABI-bound read sequence");
+    expect(page).toContain("Unavailable while address is null");
+  });
+
+  it("documents stampProof as exclusive-component corroboration, never a hook route", () => {
+    expect(page).toContain("stampProof(address)");
+    expect(page).toContain("A Classic hook is");
+    expect(page).toContain("There is no universal hook getter");
+    expect(JSON.stringify(PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI)).not.toContain(
+      "launchIdByHook",
     );
-    expect(page).toContain("Not executable calldata");
-    expect(page).not.toContain("functionName");
     expect(page).not.toContain("hook → launchId");
   });
 
-  it("limits stamps to future Classic and Custom provenance", () => {
+  it("freezes StampRecordV1 tuple order and LaunchKindV1 encoding", () => {
+    expect(STAMP_RECORD_V1_FIELDS).toEqual([
+      ["uint8", "kind"],
+      ["address", "launchWallet"],
+      ["address", "token"],
+      ["address", "hook"],
+      ["address", "poolManager"],
+      ["bytes32", "poolId"],
+      ["bytes32", "poolKeyHash"],
+      ["bytes32", "componentSetHash"],
+      ["bytes32", "routePayloadHash"],
+      ["address", "routeLauncher"],
+      ["bytes32", "routeLauncherRuntimeCodeHash"],
+      ["bytes32", "expectedResultHash"],
+      ["bytes32", "permitDigest"],
+      ["bytes32", "stampHash"],
+    ]);
+    expect(LAUNCH_KIND_V1).toEqual([
+      { value: 0, name: "Invalid", publicLabel: null },
+      { value: 1, name: "CustomGraph", publicLabel: "Programmable Custom" },
+      { value: 2, name: "Classic", publicLabel: "Programmable Classic" },
+    ]);
     expect(page).toContain("LaunchKindV1.CustomGraph");
     expect(page).toContain("LaunchKindV1.Classic");
+  });
+
+  it("limits stamps to future Classic and Custom provenance", () => {
     expect(page).toContain("Historical launches created before Router activation");
     expect(page).toContain(
       "Safety, tradability, liquidity, audit coverage, review status",
@@ -60,6 +155,8 @@ describe("Launch Stamp developer documentation", () => {
     expect(page).toContain(
       "A Registry, indexer, Supabase project, Programmable API, or",
     );
+    expect(page).toContain("The ABI and tuple layout are final");
+    expect(page).toContain("The deployment is not");
   });
 
   it("adds one discoverable route to the existing Docs navigation", () => {
@@ -80,10 +177,13 @@ describe("Launch Stamp developer documentation", () => {
     );
   });
 
-  it("keeps the page semantic, keyboard-visible, and reflow-safe", () => {
+  it("keeps the expanded reference semantic and reflow-safe", () => {
     expect(page).toContain('aria-labelledby="trust-root-heading"');
     expect(page).toContain("<dl className={styles.manifest}>");
     expect(page).toContain('aria-label="Launch stamp verification flow"');
+    expect(page).toContain(
+      'aria-label="StampRecordV1 fields in ABI order"',
+    );
     expect(page).toContain("<ol");
     expect(page).not.toContain('role="img"');
     expect(styles).toContain("@media (max-width: 700px)");


### PR DESCRIPTION
## Summary

- add `/docs/launch-stamps` as a concise implementation reference for terminals and other data consumers
- bind the page to the frozen Router ABI, selectors, events, `StampRecordV1` layout, and `stampProof`
- explain token and `(PoolManager, PoolId)` recognition for future Classic and Custom launches
- keep Router address, authority, runtime hash, and start block explicitly null while prelaunch

## Scope

The page documents origin verification only. It does not present the stamp as an audit, safety, liquidity, sellability, tradability, approval, or endorsement signal. Historical launches are not backfilled, and the shared Classic hook is not a universal classifier.

## Validation

- TypeScript: pass
- focused tests: 46/46
- lint: 0 errors; 11 unchanged warnings in unrelated legacy scripts
- production build: pass; `/docs/launch-stamps` generated statically
- rendered QA: 1440px, 390px, 320px, and 200% equivalent with no overflow
- keyboard, focus, reduced-motion, console, and HTTP checks: pass
- independent final claims review: 0 Critical / 0 High

No deployment, domain change, or production activation is included.
