### PR TITLE
docs: activate launch stamp router

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -52,3 +52,13 @@ regexes = [
   '''(?i)0x7987f03462200b3d8a072e02c89a8a41dcb124ee''',
   '''(?i)0x4fe466386aeebe507f6bcfc58e046a0632e4687699fa5bd28c4b7ec6333141ad''',
 ]
+
+[[allowlists]]
+description = "Launch stamp docs pin the public PCAN canary token address"
+condition = "AND"
+regexTarget = "match"
+paths = [
+  '''components/launch-stamp-docs-contract\.ts''',
+  '''tests/launch-stamp-docs\.test\.ts''',
+]
+regexes = ['''(?i)0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce''']

--- a/app/docs/launch-stamps/page.tsx
+++ b/app/docs/launch-stamps/page.tsx
@@ -5,6 +5,7 @@ import {
   LAUNCH_STAMP_RUNTIME_HASH_DEFINITION,
   LAUNCH_KIND_V1,
   PROGRAMMABLE_LAUNCH_STAMP_MANIFEST,
+  PROGRAMMABLE_LAUNCH_STAMP_RESOURCES,
   PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI,
   PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT,
   STAMP_RECORD_V1_FIELDS,
@@ -23,13 +24,18 @@ const sections = [
   { id: "trust-root", label: "Trust root" },
   { id: "algorithm", label: "Verification algorithm" },
   { id: "abi", label: "Frozen ABI" },
+  { id: "indexing", label: "Terminal indexing" },
   { id: "record", label: "Returned record" },
   { id: "boundary", label: "Trust boundary" },
-  { id: "integration", label: "Deployment state" },
+  { id: "integration", label: "Live deployment" },
 ] as const;
 
 const abiBoundVerifier = [
   "input := token OR (PoolManager, poolId)",
+  "",
+  "preflight  resolve one finalized canonical block",
+  "           require chainId, block range, Router runtime,",
+  "           and immutable bindings to match the manifest",
   "",
   "step 1  launchId := input is token",
   "          ? launchIdByToken(token)",
@@ -44,19 +50,35 @@ const abiBoundVerifier = [
 ].join("\n");
 
 const router = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter;
+const chainId = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.chainId;
 const deployment = router.deploymentEvidence;
-const observedBindings = deployment.observedBindings;
+const bindings = router.bindings;
+const canary = router.canaryEvidence;
 const artifact = PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT;
 const abi = PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI;
+const events = Object.values(router.events);
+
+const terminalLogFilter = JSON.stringify(
+  {
+    address: router.address,
+    fromBlock: "0x1886b6c",
+    toBlock: "finalized",
+    topics: [events.map((event) => event.topic0)],
+  },
+  null,
+  2,
+);
 
 const manifestFields = [
+  ["chainId", chainId],
   ["version", router.version],
   ["generation", router.generation],
   ["address", router.address],
   ["startBlock", router.startBlock],
+  ["endBlock", router.endBlock],
   ["runtimeCodeHash", router.runtimeCodeHash],
-  ["authority", router.authority],
-  ["abi", router.abi],
+  ["finalityConfirmations", router.finalityConfirmations],
+  ["abiSha256", router.abiSha256],
 ] as const;
 
 const deploymentEvidenceFields = [
@@ -75,20 +97,51 @@ const deploymentEvidenceFields = [
   ["evidenceSha256", deployment.evidenceSha256],
 ] as const;
 
-const observedBindingFields = [
-  ["chainId", observedBindings.chainId],
-  ["permitAuthority", observedBindings.permitAuthority],
-  [
-    "permitAuthorityRuntimeCodeHash",
-    observedBindings.permitAuthorityRuntimeCodeHash,
-  ],
-  ["graphFactory", observedBindings.graphFactory],
-  ["graphFactoryRuntimeCodeHash", observedBindings.graphFactoryRuntimeCodeHash],
-  ["poolManager", observedBindings.poolManager],
-  ["poolManagerRuntimeCodeHash", observedBindings.poolManagerRuntimeCodeHash],
+const activationBindingFields = [
+  ["permitAuthority", bindings.permitAuthority],
+  ["permitAuthorityRuntimeCodeHash", bindings.permitAuthorityRuntimeCodeHash],
+  ["graphFactory", bindings.graphFactory],
+  ["graphFactoryRuntimeCodeHash", bindings.graphFactoryRuntimeCodeHash],
+  ["poolManager", bindings.poolManager],
+  ["poolManagerRuntimeCodeHash", bindings.poolManagerRuntimeCodeHash],
 ] as const;
 
-function PrelaunchTrustRoot() {
+const canaryIdentityFields = [
+  ["finality", canary.finality],
+  [
+    "customGraphOnchainCanary",
+    String(canary.routeCoverage.customGraphOnchainCanary),
+  ],
+  ["classicOnchainCanary", String(canary.routeCoverage.classicOnchainCanary)],
+  ["transactionHash", canary.transactionHash],
+  ["blockNumber", canary.blockNumber],
+  ["blockHash", canary.blockHash],
+  ["launchId", canary.launchId],
+  ["stampHash", canary.stampHash],
+  ["launchKind", canary.launchKind],
+  ["sourceRepository", canary.source.sourceRepository],
+  ["sourceCommit", canary.source.sourceCommit],
+  ["commitSubject", canary.source.commitSubject],
+  ["evidenceFileSha256", canary.evidenceFileSha256],
+  ["evidenceLineSha256", canary.evidenceLineSha256],
+] as const;
+
+const canaryObservationFields = [
+  ["initializer", canary.components.initializer],
+  ["token", canary.components.token],
+  ["hook", canary.components.hook],
+  ["poolManager", canary.pool.poolManager],
+  ["poolId", canary.pool.poolId],
+  ["activeLiquidity", canary.pool.activeLiquidity],
+  ["positionManager", canary.lpPosition.positionManager],
+  ["lpNftTokenId", canary.lpPosition.tokenId],
+  ["lpNftOwner", canary.lpPosition.owner],
+  ["platformFeePips", canary.platformFee.feePips],
+  ["platformFeeRecipient", canary.platformFee.recipient],
+  ["tokenTotalSupply", canary.tokenTotalSupply],
+] as const;
+
+function LiveTrustRoot() {
   return (
     <section
       aria-labelledby="trust-root-heading"
@@ -113,10 +166,12 @@ function PrelaunchTrustRoot() {
       </dl>
 
       <p className={styles.hashDefinition}>
-        <code>runtimeCodeHash</code> means {LAUNCH_STAMP_RUNTIME_HASH_DEFINITION}{" "}
-        The activation tuple above stays null while the canary is pending. The
-        finalized deployment evidence published below identifies the deployed
-        Router candidate, but does not activate terminal classification.
+        <code>runtimeCodeHash</code> means{" "}
+        {LAUNCH_STAMP_RUNTIME_HASH_DEFINITION} The live tuple above activates
+        direct verification for Router stamps at or after{" "}
+        <code>startBlock</code>. A terminal must still validate the Router
+        runtime and immutable bindings at the same canonical block as each
+        lookup.
       </p>
     </section>
   );
@@ -126,8 +181,8 @@ export default function LaunchStampDocsPage() {
   return (
     <DocsShell
       currentPath="/docs/launch-stamps"
-      description="For launches created after Router activation, resolve a token or Uniswap v4 market and read its launch stamp from one canonical contract. The result establishes Programmable provenance only."
-      heroAside={<PrelaunchTrustRoot />}
+      description="For launches stamped through the live Router, resolve a token or Uniswap v4 market and read its record from one canonical contract. The result establishes Programmable provenance only."
+      heroAside={<LiveTrustRoot />}
       heroId="trust-root"
       kicker="Developer provenance"
       sections={sections}
@@ -162,7 +217,7 @@ export default function LaunchStampDocsPage() {
         <div className={styles.concept}>
           <div className={styles.conceptHeader}>
             <span className={styles.conceptLabel}>ABI-bound read sequence</span>
-            <span>Unavailable while status is prelaunch</span>
+            <span>Live on Ethereum · finalized reads</span>
           </div>
           <pre aria-label="Launch stamp verifier pseudocode using the frozen ABI">
             {abiBoundVerifier}
@@ -181,8 +236,8 @@ export default function LaunchStampDocsPage() {
         <h2>Bind to the frozen Router ABI</h2>
         <p>
           The signatures and selectors below come from the final Router source
-          artifact. They fix the call encoding, but they do not activate the
-          Router or make terminal classification live.
+          artifact. They fix the call encoding. Bind them to the live address,
+          runtime code hash, and immutable getters before classifying a result.
         </p>
 
         <dl className={styles.artifactBinding}>
@@ -202,6 +257,45 @@ export default function LaunchStampDocsPage() {
             <dt>Forge artifact</dt>
             <dd>{artifact.artifactPath}</dd>
           </div>
+          <div>
+            <dt>Published ABI</dt>
+            <dd>
+              <a href={router.abiUrl}>{router.abiUrl}</a>
+            </dd>
+          </div>
+          <div>
+            <dt>ABI file SHA-256</dt>
+            <dd>{router.abiSha256}</dd>
+          </div>
+          <div>
+            <dt>GitHub ABI source</dt>
+            <dd>
+              <a href={PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.abiGithubUrl}>
+                Exact published file
+              </a>
+            </dd>
+          </div>
+        </dl>
+
+        <p className={styles.detailLine}>
+          Hash the exact downloaded ABI file bytes. Do not normalize or
+          reserialize the JSON before comparing its SHA-256 digest.
+        </p>
+
+        <h3 className={styles.subheading}>Trust-root reads</h3>
+        <dl className={styles.abiList}>
+          {abi.bindingReads.map((entry) => (
+            <div key={entry.signature}>
+              <dt>{entry.label}</dt>
+              <dd>
+                <code>{entry.signature}</code>
+                <span>
+                  selector <code>{entry.selector}</code> · returns{" "}
+                  <code>{entry.returns}</code>
+                </span>
+              </dd>
+            </div>
+          ))}
         </dl>
 
         <h3 className={styles.subheading}>Primary verification reads</h3>
@@ -237,11 +331,34 @@ export default function LaunchStampDocsPage() {
         </dl>
 
         <p className={styles.scopeLine}>
-          <code>stampProof(address)</code> returns the component&apos;s exclusive
-          assignment and the corresponding record hash. A Classic hook is
-          shared infrastructure, so its component proof is intentionally{" "}
+          <code>stampProof(address)</code> returns the component&apos;s
+          exclusive assignment and the corresponding record hash. A Classic hook
+          is shared infrastructure, so its component proof is intentionally{" "}
           <code>(bytes32(0), bytes32(0))</code> even when its launch is stamped.
           There is no universal hook getter.
+        </p>
+
+        <h3 className={styles.subheading}>Discovery events</h3>
+        <dl className={styles.abiList}>
+          {events.map((event) => (
+            <div key={event.topic0}>
+              <dt>{event.name}</dt>
+              <dd>
+                <code>{event.signature}</code>
+                <span>
+                  topic0 <code>{event.topic0}</code>
+                </span>
+                <span>
+                  indexed: <code>{event.indexedInputs.join(", ")}</code>
+                </span>
+              </dd>
+            </div>
+          ))}
+        </dl>
+        <p className={styles.detailLine}>
+          A matching topic is only a discovery candidate. Accept it only when
+          the emitter is the exact Router address on chain <code>1</code>, then
+          reproduce the record with canonical getter reads.
         </p>
 
         <h3 className={styles.subheading}>Atomic write selector</h3>
@@ -259,13 +376,185 @@ export default function LaunchStampDocsPage() {
         </p>
       </section>
 
+      <section id="indexing">
+        <h2>Backfill once, then follow finalized logs</h2>
+        <p className={docsStyles.lead}>
+          Terminals can discover every future Router stamp with one Ethereum log
+          stream. The filter is exact; the log is only an index candidate until
+          the point verifier reproduces it. Require{" "}
+          <code>eth_chainId == 0x1</code> before issuing this standard JSON-RPC
+          filter.
+        </p>
+
+        <div className={styles.concept}>
+          <div className={styles.conceptHeader}>
+            <span className={styles.conceptLabel}>eth_getLogs filter</span>
+            <span>Ethereum · canonical Router only</span>
+          </div>
+          <pre aria-label="Launch stamp Router event filter">
+            {terminalLogFilter}
+          </pre>
+        </div>
+
+        <dl className={styles.recordList}>
+          <div>
+            <dt>1 · Bind</dt>
+            <dd>
+              Verify chain, Router address, runtime, ABI URL and SHA-256,
+              topics, getters, immutable bindings, block range, and finality
+              policy before accepting any log.
+            </dd>
+          </div>
+          <div>
+            <dt>2 · Backfill</dt>
+            <dd>
+              Scan <code>eth_getLogs</code> in bounded chunks from block{" "}
+              <code>{router.startBlock}</code> to a finalized boundary. Respect{" "}
+              <code>endBlock</code> if a future manifest retires this Router.
+            </dd>
+          </div>
+          <div>
+            <dt>3 · Persist and dedupe</dt>
+            <dd>
+              Retain block number and hash, transaction hash and index, and log
+              index. Use those coordinates as the idempotency key so an overlap
+              can be replayed without duplicate classifications.
+            </dd>
+          </div>
+          <div>
+            <dt>4 · Verify candidates</dt>
+            <dd>
+              Decode each log by its matched signature and correlate the three
+              event types by <code>launchId</code>. Only{" "}
+              <code>ProgrammableLaunchStampedV1</code> supplies token and hook,
+              plus the non-indexed PoolManager, poolId, and stampHash. Read the
+              record at the same canonical block and classify only from{" "}
+              <code>record.kind</code>.
+            </dd>
+          </div>
+          <div>
+            <dt>5 · Checkpoint</dt>
+            <dd>
+              Advance a durable checkpoint only through the finalized boundary.
+              Explicit block-number reads require at least{" "}
+              <code>{router.finalityConfirmations}</code> confirmations.
+            </dd>
+          </div>
+          <div>
+            <dt>6 · Replay overlap</dt>
+            <dd>
+              Re-read an overlap window on every run. Deduplicate identical
+              coordinates and apply corrections idempotently before moving the
+              checkpoint.
+            </dd>
+          </div>
+          <div>
+            <dt>7 · Handle reorgs</dt>
+            <dd>
+              Prefer EIP-1898 reads with <code>requireCanonical: true</code>. If
+              a stored block hash changes, orphan the affected observations,
+              rewind to the last common finalized checkpoint, and replay.
+            </dd>
+          </div>
+          <div>
+            <dt>8 · Hand off to live</dt>
+            <dd>
+              After backfill reaches finality, poll or subscribe from the
+              overlapping checkpoint. Reconcile every notification through the
+              same log and getter checks before advancing, leaving no
+              backfill-to-live gap.
+            </dd>
+          </div>
+        </dl>
+
+        <h3 className={styles.subheading}>Verify each supported identity</h3>
+        <dl className={styles.boundaryList}>
+          <div>
+            <dt>Token</dt>
+            <dd>
+              Require <code>launchIdByToken(token)</code>,{" "}
+              <code>record.token == token</code>, and{" "}
+              <code>stampProof(token) == (launchId, record.stampHash)</code>.
+            </dd>
+          </div>
+          <div>
+            <dt>v4 pool</dt>
+            <dd>
+              Require <code>launchIdByPool(PoolManager, poolId)</code> and exact
+              equality with <code>record.poolManager</code> and{" "}
+              <code>record.poolId</code>. PoolManager must equal the published
+              immutable binding.
+            </dd>
+          </div>
+          <div>
+            <dt>Exclusive component</dt>
+            <dd>
+              Require <code>launchIdByComponent(component)</code>, matching{" "}
+              <code>stampProof(component)</code>, and equality between{" "}
+              <code>componentRuntimeCodeHash(component)</code> and the component
+              runtime read at the same block.
+            </dd>
+          </div>
+        </dl>
+
+        <p className={styles.scopeLine}>
+          Token and pool are the interoperable terminal inputs. A Custom hook
+          may also be an exclusive component; the shared Classic hook never
+          identifies a launch. Zero means not stamped only after a successful
+          canonical call. RPC or consistency failures remain indeterminate.
+        </p>
+
+        <h3 className={styles.subheading}>Canonical integration resources</h3>
+        <dl className={styles.artifactBinding}>
+          <div>
+            <dt>Discovery</dt>
+            <dd>
+              <a href={PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.discoveryUrl}>
+                {PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.discoveryUrl}
+              </a>
+            </dd>
+          </div>
+          <div>
+            <dt>Router reference</dt>
+            <dd>
+              <a href={PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.referenceUrl}>
+                Full verification contract
+              </a>
+            </dd>
+          </div>
+          <div>
+            <dt>Terminal guide</dt>
+            <dd>
+              <a href={PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.terminalGuideUrl}>
+                Backfill, live-follow, and reorg policy
+              </a>
+            </dd>
+          </div>
+          <div>
+            <dt>JSON-RPC verifier</dt>
+            <dd>
+              <a href={PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.jsonRpcVerifierUrl}>
+                Dependency-light implementation
+              </a>
+            </dd>
+          </div>
+          <div>
+            <dt>viem verifier</dt>
+            <dd>
+              <a href={PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.viemVerifierUrl}>
+                TypeScript implementation
+              </a>
+            </dd>
+          </div>
+        </dl>
+      </section>
+
       <section id="record">
         <h2>Decode the frozen record in order</h2>
         <p>
-          <code>launchStamp(bytes32)</code> returns{" "}
-          <code>StampRecordV1</code> with these fourteen fields in this exact
-          order. Decode the tuple with the frozen ABI rather than a locally
-          reconstructed type.
+          <code>launchStamp(bytes32)</code> returns <code>StampRecordV1</code>{" "}
+          with these fourteen fields in this exact order. Decode the tuple with
+          the frozen ABI rather than a locally reconstructed type.
         </p>
 
         <div className={styles.recordLayout}>
@@ -321,9 +610,9 @@ export default function LaunchStampDocsPage() {
           <div>
             <dt>Hook</dt>
             <dd>
-              <code>record.hook</code> is descriptive metadata. The Classic
-              hook is shared by multiple launches, so it is never a universal
-              lookup or classification key.
+              <code>record.hook</code> is descriptive metadata. The Classic hook
+              is shared by multiple launches, so it is never a universal lookup
+              or classification key.
             </dd>
           </div>
         </dl>
@@ -341,15 +630,29 @@ export default function LaunchStampDocsPage() {
           <div>
             <dt>It establishes</dt>
             <dd>
-              Programmable origin for the returned future Classic or Custom
-              launch record on the configured chain.
+              Canonical Router route and origin for the returned Classic or
+              Custom launch record at or after <code>startBlock</code>. It does
+              not claim that every recorded component was newly created; shared
+              Classic infrastructure can be recorded by reference.
+            </dd>
+          </div>
+          <div>
+            <dt>Atomic v4 pool check</dt>
+            <dd>
+              For the exact recorded pool, the Router requires{" "}
+              <code>slot0.sqrtPriceX96 == 0</code> immediately before its
+              authorized launch call and <code>slot0.sqrtPriceX96 != 0</code>{" "}
+              immediately after it, then writes the stamp in the same
+              transaction. This establishes initialization during that atomic
+              launch, not current pool state or liquidity.
             </dd>
           </div>
           <div>
             <dt>It does not establish</dt>
             <dd>
-              Safety, tradability, liquidity, audit coverage, review status,
-              approval, endorsement, or permission to launch.
+              Safety, tradability, current pool state, current liquidity, audit
+              coverage, review status, approval, endorsement, or permission to
+              launch.
             </dd>
           </div>
           <div>
@@ -365,18 +668,39 @@ export default function LaunchStampDocsPage() {
             <dd>
               Historical launches created before Router activation. Do not
               backfill them or infer stamps from legacy contracts and events.
+              Direct Classic Factory, Graph Factory, or Single Factory calls
+              outside the canonical Router do not create Router provenance.
+            </dd>
+          </div>
+          <div>
+            <dt>Third-party support</dt>
+            <dd>
+              A stamp does not automatically list a coin in GMGN, Axiom, FOMO,
+              or any other terminal. Each consumer decides whether and how to
+              integrate this public verification contract. Generic pool or token
+              discovery in a third-party API is not Router stamp integration and
+              must not be presented as Programmable provenance. GMGN market
+              numbers are not canonical onchain stamp evidence; read current
+              pool state separately through PoolManager or StateView.
+            </dd>
+          </div>
+          <div>
+            <dt>Launch operations</dt>
+            <dd>
+              The public GitHub approval → permit → wallet self-service flow is
+              not live. This reference activates read-only provenance detection,
+              not public launch authorization.
             </dd>
           </div>
         </dl>
       </section>
 
       <section className={styles.finalSection} id="integration">
-        <h2>Separate deployment evidence from activation</h2>
+        <h2>Bind to the live Router</h2>
         <p>
-          The Router candidate below is finalized and its runtime and immutable
-          getters were verified at the stated finalized block. These values are
-          deployment evidence only. The activation binding remains prelaunch
-          until the canary is complete.
+          The activation tuple is live on Ethereum. The deployment evidence
+          identifies the exact Router runtime, and the immutable bindings below
+          must match at the canonical block used for every lookup.
         </p>
 
         <h3 className={styles.subheading}>Finalized deployment evidence</h3>
@@ -388,10 +712,17 @@ export default function LaunchStampDocsPage() {
             </div>
           ))}
         </dl>
+        <p className={styles.detailLine}>
+          <code>finalized-verified</code> describes the deployment receipt,
+          runtime, and immutable getter evidence. It is not an Explorer source
+          publication status. The SHA-256 values are supplied handoff digests;
+          this Website repository did not independently download and recompute
+          their source evidence files.
+        </p>
 
-        <h3 className={styles.subheading}>Observed immutable getters</h3>
+        <h3 className={styles.subheading}>Live immutable bindings</h3>
         <dl className={styles.artifactBinding}>
-          {observedBindingFields.map(([field, value]) => (
+          {activationBindingFields.map(([field, value]) => (
             <div key={field}>
               <dt>{field}</dt>
               <dd>{value}</dd>
@@ -399,14 +730,65 @@ export default function LaunchStampDocsPage() {
           ))}
         </dl>
 
+        <h3 className={styles.subheading}>
+          Finalized CustomGraph canary (PCAN vector)
+        </h3>
+        <p>
+          The PCAN point-in-time test vector covers the CustomGraph route.
+          <code>PCAN</code> is the human-readable token symbol, not another
+          canary, launch, or trust identifier. There is no separate Classic
+          onchain canary claim. Future Classic stamps use the same live Router
+          ABI and become verifiable when their records exist.
+        </p>
+        <dl className={styles.artifactBinding}>
+          {canaryIdentityFields.map(([field, value]) => (
+            <div key={field}>
+              <dt>{field}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
+        <p className={styles.detailLine}>
+          Canary source commit <code>{canary.source.sourceCommit}</code> is
+          separate from Router artifact source commit{" "}
+          <code>{artifact.sourceCommit}</code> and does not replace it. The
+          canary SHA-256 fields are supplied handoff digests; this Website
+          repository did not independently download or recompute their evidence
+          files and does not host them.
+        </p>
+
+        <h3 className={styles.subheading}>Canary observations</h3>
+        <dl className={styles.artifactBinding}>
+          {canaryObservationFields.map(([field, value]) => (
+            <div key={field}>
+              <dt>{field}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
+
+        <h3 className={styles.subheading}>Canary component proofs</h3>
+        <dl className={`${styles.abiList} ${styles.proofList}`}>
+          {canary.stampProofs.map((proof) => (
+            <div key={proof.component}>
+              <dt>{proof.component}</dt>
+              <dd>
+                <code>{proof.launchId}</code>
+                <span>
+                  stampHash <code>{proof.stampHash}</code>
+                </span>
+              </dd>
+            </div>
+          ))}
+        </dl>
+
         <div className={styles.implementationRule}>
-          <strong>Activation rule</strong>
+          <strong>Classification rule</strong>
           <p>
-            While <code>status</code> is <code>prelaunch</code>, do not issue
-            Router reads and do not present any launch as stamped. Enable the
-            frozen read sequence only after the canary is complete and the
-            address, runtime code hash, start block, and authority are published
-            together in the live activation binding.
+            Resolve one finalized canonical block, enforce the published block
+            range, and validate the Router runtime and immutable bindings. Only
+            a consistent nonzero record is stamped. A canonical zero lookup is
+            not stamped; a failed call or mismatch is indeterminate.
           </p>
         </div>
       </section>

--- a/components/launch-stamp-docs-contract.ts
+++ b/components/launch-stamp-docs-contract.ts
@@ -6,7 +6,70 @@ export const PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT = {
     "out/ProgrammableLaunchStampRouterV1.sol/ProgrammableLaunchStampRouterV1.json",
 } as const;
 
+export const PROGRAMMABLE_LAUNCH_STAMP_RESOURCES = {
+  discoveryUrl:
+    "https://developers.programmable.family/.well-known/programmable.json",
+  abiUrl:
+    "https://developers.programmable.family/abis/ethereum/programmable-launch-stamp-router-v1.json",
+  abiGithubUrl:
+    "https://raw.githubusercontent.com/0xprogrammable/developers/main/abis/ethereum/programmable-launch-stamp-router-v1.json",
+  abiSha256:
+    "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
+  referenceUrl:
+    "https://github.com/0xprogrammable/developers/blob/main/docs/reference/launch-stamp.md",
+  terminalGuideUrl:
+    "https://github.com/0xprogrammable/developers/blob/main/docs/guides/terminals-and-scanners.md",
+  jsonRpcVerifierUrl:
+    "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp.mjs",
+  viemVerifierUrl:
+    "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp-viem.ts",
+} as const;
+
 export const PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI = {
+  bindingReads: [
+    {
+      label: "Router chain ID",
+      signature: "CHAIN_ID()",
+      selector: "0x85e1f4d0",
+      returns: "uint256 chainId",
+    },
+    {
+      label: "Permit authority",
+      signature: "PERMIT_AUTHORITY()",
+      selector: "0xc3a3d03c",
+      returns: "address permitAuthority",
+    },
+    {
+      label: "Permit authority runtime",
+      signature: "PERMIT_AUTHORITY_RUNTIME_CODE_HASH()",
+      selector: "0xa497c61c",
+      returns: "bytes32 runtimeCodeHash",
+    },
+    {
+      label: "Graph Factory",
+      signature: "GRAPH_FACTORY()",
+      selector: "0x1cc9e5ce",
+      returns: "address graphFactory",
+    },
+    {
+      label: "Graph Factory runtime",
+      signature: "GRAPH_FACTORY_RUNTIME_CODE_HASH()",
+      selector: "0x92989a00",
+      returns: "bytes32 runtimeCodeHash",
+    },
+    {
+      label: "PoolManager",
+      signature: "POOL_MANAGER()",
+      selector: "0x62308e85",
+      returns: "address poolManager",
+    },
+    {
+      label: "PoolManager runtime",
+      signature: "POOL_MANAGER_RUNTIME_CODE_HASH()",
+      selector: "0x38d831c4",
+      returns: "bytes32 runtimeCodeHash",
+    },
+  ],
   market: {
     label: "Sole market-bearing write",
     signature:
@@ -57,15 +120,56 @@ export const PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI = {
 } as const;
 
 export const PROGRAMMABLE_LAUNCH_STAMP_MANIFEST = {
+  chainId: 1,
   launchStampRouter: {
     version: "1",
     generation: "1",
-    status: "prelaunch",
-    address: null,
-    startBlock: null,
-    runtimeCodeHash: null,
-    authority: null,
-    abi: "frozen",
+    status: "live",
+    address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+    startBlock: "25717612",
+    endBlock: null,
+    runtimeCodeHash:
+      "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+    finalityConfirmations: 64,
+    abiUrl: PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.abiUrl,
+    abiSha256: PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.abiSha256,
+    bindings: {
+      permitAuthority: "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
+      permitAuthorityRuntimeCodeHash:
+        "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c",
+      graphFactory: "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
+      graphFactoryRuntimeCodeHash:
+        "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8",
+      poolManager: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+      poolManagerRuntimeCodeHash:
+        "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293",
+    },
+    events: {
+      launchStamped: {
+        name: "ProgrammableLaunchStampedV1",
+        signature:
+          "ProgrammableLaunchStampedV1(bytes32,address,address,address,bytes32,bytes32)",
+        topic0:
+          "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2",
+        indexedInputs: ["launchId", "token", "hook"],
+      },
+      launchRouteStamped: {
+        name: "ProgrammableLaunchRouteStampedV1",
+        signature:
+          "ProgrammableLaunchRouteStampedV1(bytes32,uint8,bytes32,bytes32,bytes32)",
+        topic0:
+          "0x45e7cc355b63ca67d6278a0d8d23470ce2a0741a9c60283d7dee712df7a877a5",
+        indexedInputs: ["launchId", "kind", "routePayloadHash"],
+      },
+      componentStamped: {
+        name: "ProgrammableComponentStampedV1",
+        signature:
+          "ProgrammableComponentStampedV1(bytes32,address,uint8,bytes32)",
+        topic0:
+          "0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b",
+        indexedInputs: ["launchId", "component", "kind"],
+      },
+    },
     deploymentEvidence: {
       verificationStatus: "finalized-verified",
       address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
@@ -99,6 +203,76 @@ export const PROGRAMMABLE_LAUNCH_STAMP_MANIFEST = {
         "sha256:6e6e8a93193bbe2f79f98594a1af32c27bae0746f8297dd13592d9608e2feb20",
       evidenceSha256:
         "sha256:f9786ebfb74c96a3c225567ad324f0fbecfd8520b8d8addec85ba58cd67e19ff",
+    },
+    canaryEvidence: {
+      finality: "finalized",
+      routeCoverage: {
+        customGraphOnchainCanary: true,
+        classicOnchainCanary: false,
+      },
+      source: {
+        sourceRepository: "https://github.com/0xprogrammable/programmable",
+        sourceCommit: "b3cfed41bb841ae8d6188dbb815eddb5e1440218",
+        commitSubject: "Add graph launch stamp canary",
+      },
+      transactionHash:
+        "0xc07b4e70233534a1d4f435ffc9a636ed5f542f4aedcde35052c58224f378b612",
+      blockNumber: "25717953",
+      blockHash:
+        "0x97827b6586f0dca00e44801acc529c3961b4c693988dfc9f4b2bb4c3d94632ba",
+      launchId:
+        "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+      stampHash:
+        "0x06cb71b38d9b8b1dd1ffcdb00f31c774be36f5473979c3831d5fd0c96cdaa579",
+      launchKind: 1,
+      components: {
+        initializer: "0x87B108848B444bC44A01734D62C7be4a2fA64983",
+        token: "0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE",
+        hook: "0xEBa46f25DfF528141dE5317109Acb5A989296044",
+      },
+      pool: {
+        poolManager: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+        poolId:
+          "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229",
+        activeLiquidity: "31618002430832353916",
+      },
+      lpPosition: {
+        positionManager: "0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e",
+        tokenId: "367610",
+        owner: "0x2Bb333d48DFAF1596D9036671d2E43168994249E",
+      },
+      platformFee: {
+        feePips: 1000,
+        recipient: "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+      },
+      tokenTotalSupply: "1000000000000000000000000",
+      stampProofs: [
+        {
+          component: "0x87B108848B444bC44A01734D62C7be4a2fA64983",
+          launchId:
+            "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+          stampHash:
+            "0x06cb71b38d9b8b1dd1ffcdb00f31c774be36f5473979c3831d5fd0c96cdaa579",
+        },
+        {
+          component: "0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE",
+          launchId:
+            "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+          stampHash:
+            "0x06cb71b38d9b8b1dd1ffcdb00f31c774be36f5473979c3831d5fd0c96cdaa579",
+        },
+        {
+          component: "0xEBa46f25DfF528141dE5317109Acb5A989296044",
+          launchId:
+            "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+          stampHash:
+            "0x06cb71b38d9b8b1dd1ffcdb00f31c774be36f5473979c3831d5fd0c96cdaa579",
+        },
+      ],
+      evidenceFileSha256:
+        "sha256:1325d1333b6df9545cb87048e2b8d1c57a63af5b6790c329c0e95157a0d16d2c",
+      evidenceLineSha256:
+        "sha256:615a20b31f454afb020a8fa83653c7685328e3f12ad58d3ac11ddab2d02968b5",
     },
   },
 } as const;

--- a/components/launch-stamp-docs.module.css
+++ b/components/launch-stamp-docs.module.css
@@ -262,6 +262,20 @@
   line-height: 1.55;
 }
 
+.proofList dd > code,
+.proofList dd span {
+  max-width: 100%;
+  min-width: 0;
+  width: 100%;
+}
+
+.proofList dd > code,
+.proofList dd span,
+.proofList dd span code {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .atomicSignature {
   border-block: 1px solid var(--panel-border);
   display: grid;
@@ -430,6 +444,11 @@
 }
 
 @media (max-width: 700px) {
+  :global(html:has([data-launch-stamp-docs])),
+  :global(body:has([data-launch-stamp-docs])) {
+    overflow-x: clip;
+  }
+
   :global(html:has([data-launch-stamp-docs])) {
     scroll-padding-bottom: calc(88px + env(safe-area-inset-bottom));
   }

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -168,7 +168,7 @@ export function buildDeveloperDocsMarkdown(
   "",
   "## Canonical resources",
   "",
-  "- [Launch Stamp Router reference](https://programmable.market/docs/launch-stamps) — direct provenance lookup for future Classic and Custom launches; the binding remains prelaunch until every deployment field is published.",
+  "- [Launch Stamp Router reference](https://programmable.market/docs/launch-stamps) — live Ethereum Router binding for direct, future-only Classic and Custom provenance verification.",
   `- [GitHub developer repository](${PROGRAMMABLE_DEVELOPER_REPOSITORY}) — canonical guides, schemas, fixtures, clients, compatibility and security policy.`,
   `- [Live discovery](${PROGRAMMABLE_WELL_KNOWN_URL}) — active API version, chains and canonical URLs.`,
   `- [Active OpenAPI](${PROGRAMMABLE_OPENAPI_URL}) — v${PROGRAMMABLE_ACTIVE_API_VERSION} HTTP contract.`,

--- a/tests/launch-stamp-docs.test.ts
+++ b/tests/launch-stamp-docs.test.ts
@@ -7,6 +7,7 @@ import {
   LAUNCH_KIND_V1,
   LAUNCH_STAMP_RUNTIME_HASH_DEFINITION,
   PROGRAMMABLE_LAUNCH_STAMP_MANIFEST,
+  PROGRAMMABLE_LAUNCH_STAMP_RESOURCES,
   PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI,
   PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT,
   STAMP_RECORD_V1_FIELDS,
@@ -22,7 +23,7 @@ const sitemap = read("app/sitemap.ts");
 const markdown = read("lib/developer-docs-content.ts");
 
 describe("Launch Stamp developer documentation", () => {
-  it("keeps activation prelaunch while publishing exact finalized deployment evidence", () => {
+  it("publishes the exact live Router activation and finalized evidence", () => {
     expect(PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ARTIFACT).toEqual({
       contractName: "ProgrammableLaunchStampRouterV1",
       sourceCommit: "0a7134bbb912222639627fb9078df2f8dd3a6c38",
@@ -31,15 +32,58 @@ describe("Launch Stamp developer documentation", () => {
         "out/ProgrammableLaunchStampRouterV1.sol/ProgrammableLaunchStampRouterV1.json",
     });
     expect(PROGRAMMABLE_LAUNCH_STAMP_MANIFEST).toEqual({
+      chainId: 1,
       launchStampRouter: {
         version: "1",
         generation: "1",
-        status: "prelaunch",
-        address: null,
-        startBlock: null,
-        runtimeCodeHash: null,
-        authority: null,
-        abi: "frozen",
+        status: "live",
+        address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+        startBlock: "25717612",
+        endBlock: null,
+        runtimeCodeHash:
+          "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+        finalityConfirmations: 64,
+        abiUrl:
+          "https://developers.programmable.family/abis/ethereum/programmable-launch-stamp-router-v1.json",
+        abiSha256:
+          "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
+        bindings: {
+          permitAuthority: "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
+          permitAuthorityRuntimeCodeHash:
+            "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c",
+          graphFactory: "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
+          graphFactoryRuntimeCodeHash:
+            "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8",
+          poolManager: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+          poolManagerRuntimeCodeHash:
+            "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293",
+        },
+        events: {
+          launchStamped: {
+            name: "ProgrammableLaunchStampedV1",
+            signature:
+              "ProgrammableLaunchStampedV1(bytes32,address,address,address,bytes32,bytes32)",
+            topic0:
+              "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2",
+            indexedInputs: ["launchId", "token", "hook"],
+          },
+          launchRouteStamped: {
+            name: "ProgrammableLaunchRouteStampedV1",
+            signature:
+              "ProgrammableLaunchRouteStampedV1(bytes32,uint8,bytes32,bytes32,bytes32)",
+            topic0:
+              "0x45e7cc355b63ca67d6278a0d8d23470ce2a0741a9c60283d7dee712df7a877a5",
+            indexedInputs: ["launchId", "kind", "routePayloadHash"],
+          },
+          componentStamped: {
+            name: "ProgrammableComponentStampedV1",
+            signature:
+              "ProgrammableComponentStampedV1(bytes32,address,uint8,bytes32)",
+            topic0:
+              "0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b",
+            indexedInputs: ["launchId", "component", "kind"],
+          },
+        },
         deploymentEvidence: {
           verificationStatus: "finalized-verified",
           address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
@@ -74,17 +118,207 @@ describe("Launch Stamp developer documentation", () => {
           evidenceSha256:
             "sha256:f9786ebfb74c96a3c225567ad324f0fbecfd8520b8d8addec85ba58cd67e19ff",
         },
+        canaryEvidence: {
+          finality: "finalized",
+          routeCoverage: {
+            customGraphOnchainCanary: true,
+            classicOnchainCanary: false,
+          },
+          source: {
+            sourceRepository: "https://github.com/0xprogrammable/programmable",
+            sourceCommit: "b3cfed41bb841ae8d6188dbb815eddb5e1440218",
+            commitSubject: "Add graph launch stamp canary",
+          },
+          transactionHash:
+            "0xc07b4e70233534a1d4f435ffc9a636ed5f542f4aedcde35052c58224f378b612",
+          blockNumber: "25717953",
+          blockHash:
+            "0x97827b6586f0dca00e44801acc529c3961b4c693988dfc9f4b2bb4c3d94632ba",
+          launchId:
+            "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+          stampHash:
+            "0x06cb71b38d9b8b1dd1ffcdb00f31c774be36f5473979c3831d5fd0c96cdaa579",
+          launchKind: 1,
+          components: {
+            initializer: "0x87B108848B444bC44A01734D62C7be4a2fA64983",
+            token: "0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE",
+            hook: "0xEBa46f25DfF528141dE5317109Acb5A989296044",
+          },
+          pool: {
+            poolManager: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+            poolId:
+              "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229",
+            activeLiquidity: "31618002430832353916",
+          },
+          lpPosition: {
+            positionManager: "0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e",
+            tokenId: "367610",
+            owner: "0x2Bb333d48DFAF1596D9036671d2E43168994249E",
+          },
+          platformFee: {
+            feePips: 1000,
+            recipient: "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+          },
+          tokenTotalSupply: "1000000000000000000000000",
+          stampProofs: [
+            {
+              component: "0x87B108848B444bC44A01734D62C7be4a2fA64983",
+              launchId:
+                "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+              stampHash:
+                "0x06cb71b38d9b8b1dd1ffcdb00f31c774be36f5473979c3831d5fd0c96cdaa579",
+            },
+            {
+              component: "0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE",
+              launchId:
+                "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+              stampHash:
+                "0x06cb71b38d9b8b1dd1ffcdb00f31c774be36f5473979c3831d5fd0c96cdaa579",
+            },
+            {
+              component: "0xEBa46f25DfF528141dE5317109Acb5A989296044",
+              launchId:
+                "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+              stampHash:
+                "0x06cb71b38d9b8b1dd1ffcdb00f31c774be36f5473979c3831d5fd0c96cdaa579",
+            },
+          ],
+          evidenceFileSha256:
+            "sha256:1325d1333b6df9545cb87048e2b8d1c57a63af5b6790c329c0e95157a0d16d2c",
+          evidenceLineSha256:
+            "sha256:615a20b31f454afb020a8fa83653c7685328e3f12ad58d3ac11ddab2d02968b5",
+        },
       },
     });
     expect(LAUNCH_STAMP_RUNTIME_HASH_DEFINITION).toContain(
       "EVM Keccak-256 of the deployed runtime bytecode",
     );
-    expect(PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter.address).toBeNull();
-    expect(page).toContain("does not activate terminal classification");
+    const router = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter;
+    expect(PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.chainId).toBe(
+      router.deploymentEvidence.observedBindings.chainId,
+    );
+    expect(router.address).toBe(router.deploymentEvidence.address);
+    expect(router.startBlock).toBe(
+      router.deploymentEvidence.deploymentBlockNumber,
+    );
+    expect(router.runtimeCodeHash).toBe(
+      router.deploymentEvidence.runtimeCodeKeccak256,
+    );
+    expect(router.bindings).toEqual({
+      permitAuthority:
+        router.deploymentEvidence.observedBindings.permitAuthority,
+      permitAuthorityRuntimeCodeHash:
+        router.deploymentEvidence.observedBindings
+          .permitAuthorityRuntimeCodeHash,
+      graphFactory: router.deploymentEvidence.observedBindings.graphFactory,
+      graphFactoryRuntimeCodeHash:
+        router.deploymentEvidence.observedBindings.graphFactoryRuntimeCodeHash,
+      poolManager: router.deploymentEvidence.observedBindings.poolManager,
+      poolManagerRuntimeCodeHash:
+        router.deploymentEvidence.observedBindings.poolManagerRuntimeCodeHash,
+    });
+    expect(page).toContain("same canonical block as");
+  });
+
+  it("publishes the exact terminal discovery and follow contract", () => {
+    expect(PROGRAMMABLE_LAUNCH_STAMP_RESOURCES).toEqual({
+      discoveryUrl:
+        "https://developers.programmable.family/.well-known/programmable.json",
+      abiUrl:
+        "https://developers.programmable.family/abis/ethereum/programmable-launch-stamp-router-v1.json",
+      abiGithubUrl:
+        "https://raw.githubusercontent.com/0xprogrammable/developers/main/abis/ethereum/programmable-launch-stamp-router-v1.json",
+      abiSha256:
+        "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
+      referenceUrl:
+        "https://github.com/0xprogrammable/developers/blob/main/docs/reference/launch-stamp.md",
+      terminalGuideUrl:
+        "https://github.com/0xprogrammable/developers/blob/main/docs/guides/terminals-and-scanners.md",
+      jsonRpcVerifierUrl:
+        "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp.mjs",
+      viemVerifierUrl:
+        "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp-viem.ts",
+    });
+    expect(page).toContain("eth_getLogs filter");
+    expect(page).toContain("eth_chainId == 0x1");
+    expect(page).toContain('fromBlock: "0x1886b6c"');
+    expect(page).not.toContain("chainId,\n    address: router.address");
+    expect(page).toContain("Backfill once, then follow finalized logs");
+    expect(page).toContain("1 · Bind");
+    expect(page).toContain("3 · Persist and dedupe");
+    expect(page).toContain("coordinates as the idempotency key");
+    expect(page).toContain("6 · Replay overlap");
+    expect(page).toContain("8 · Hand off to live");
+    expect(page).toContain("overlapping checkpoint");
+    expect(page).toContain("backfill-to-live gap");
+    expect(page).toContain("requireCanonical: true");
+    expect(page).toContain("last common finalized checkpoint");
+    expect(page).toContain("classify only from");
+    expect(page).toContain("record.kind");
+    expect(page).toContain("Decode each log by its matched signature");
+    expect(page).toContain("correlate the three");
+    expect(page).toContain("ProgrammableLaunchStampedV1");
+    expect(page).toContain("non-indexed PoolManager, poolId, and stampHash");
+    const eventContract = JSON.stringify(
+      PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter.events,
+    );
+    expect(eventContract).toContain(
+      "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2",
+    );
+    expect(eventContract).toContain(
+      "0x45e7cc355b63ca67d6278a0d8d23470ce2a0741a9c60283d7dee712df7a877a5",
+    );
+    expect(eventContract).toContain(
+      "0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b",
+    );
   });
 
   it("publishes the artifact-exact terminal signatures and selectors", () => {
     expect(PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI).toEqual({
+      bindingReads: [
+        {
+          label: "Router chain ID",
+          signature: "CHAIN_ID()",
+          selector: "0x85e1f4d0",
+          returns: "uint256 chainId",
+        },
+        {
+          label: "Permit authority",
+          signature: "PERMIT_AUTHORITY()",
+          selector: "0xc3a3d03c",
+          returns: "address permitAuthority",
+        },
+        {
+          label: "Permit authority runtime",
+          signature: "PERMIT_AUTHORITY_RUNTIME_CODE_HASH()",
+          selector: "0xa497c61c",
+          returns: "bytes32 runtimeCodeHash",
+        },
+        {
+          label: "Graph Factory",
+          signature: "GRAPH_FACTORY()",
+          selector: "0x1cc9e5ce",
+          returns: "address graphFactory",
+        },
+        {
+          label: "Graph Factory runtime",
+          signature: "GRAPH_FACTORY_RUNTIME_CODE_HASH()",
+          selector: "0x92989a00",
+          returns: "bytes32 runtimeCodeHash",
+        },
+        {
+          label: "PoolManager",
+          signature: "POOL_MANAGER()",
+          selector: "0x62308e85",
+          returns: "address poolManager",
+        },
+        {
+          label: "PoolManager runtime",
+          signature: "POOL_MANAGER_RUNTIME_CODE_HASH()",
+          selector: "0x38d831c4",
+          returns: "bytes32 runtimeCodeHash",
+        },
+      ],
       market: {
         label: "Sole market-bearing write",
         signature:
@@ -138,21 +372,26 @@ describe("Launch Stamp developer documentation", () => {
   it("uses token or PoolManager and poolId as the universal recognition inputs", () => {
     expect(page).toContain("token or (PoolManager, poolId)");
     expect(page).toContain('"          ? launchIdByToken(token)"');
-    expect(page).toContain(
-      '"          : launchIdByPool(PoolManager, poolId)"',
-    );
+    expect(page).toContain('"          : launchIdByPool(PoolManager, poolId)"');
     expect(page).toContain('"step 2  record := launchStamp(launchId)"');
     expect(page).toContain("ABI-bound read sequence");
-    expect(page).toContain("Unavailable while status is prelaunch");
+    expect(page).toContain("Live on Ethereum · finalized reads");
+    expect(page).toContain("resolve one finalized canonical block");
+    expect(page).toContain("immutable bindings to match the manifest");
+    expect(page).toContain("launchIdByToken(token)");
+    expect(page).toContain("launchIdByPool(PoolManager, poolId)");
+    expect(page).toContain("launchIdByComponent(component)");
+    expect(page).toContain("stampProof(component)");
+    expect(page).toContain("componentRuntimeCodeHash(component)");
   });
 
   it("documents stampProof as exclusive-component corroboration, never a hook route", () => {
     expect(page).toContain("stampProof(address)");
-    expect(page).toContain("A Classic hook is");
+    expect(page).toMatch(/A Classic hook\s+is shared/);
     expect(page).toContain("There is no universal hook getter");
-    expect(JSON.stringify(PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI)).not.toContain(
-      "launchIdByHook",
-    );
+    expect(
+      JSON.stringify(PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI),
+    ).not.toContain("launchIdByHook");
     expect(page).not.toContain("hook → launchId");
   });
 
@@ -183,15 +422,52 @@ describe("Launch Stamp developer documentation", () => {
   });
 
   it("limits stamps to future Classic and Custom provenance", () => {
-    expect(page).toContain("Historical launches created before Router activation");
     expect(page).toContain(
-      "Safety, tradability, liquidity, audit coverage, review status",
+      "Historical launches created before Router activation",
+    );
+    expect(page).toMatch(
+      /Safety, tradability, current pool state, current liquidity, audit\s+coverage, review status/,
     );
     expect(page).toContain(
       "A Registry, indexer, Supabase project, Programmable API, or",
     );
-    expect(page).toContain("deployment evidence only");
-    expect(page).toContain("until the canary is complete");
+    expect(page).toContain(
+      "PCAN point-in-time test vector covers the CustomGraph route",
+    );
+    expect(page).toContain("There is no");
+    expect(page).toMatch(/separate Classic\s+onchain canary claim/);
+    expect(page).toMatch(
+      /Future Classic stamps use\s+the same live Router\s+ABI/,
+    );
+    expect(page).toMatch(
+      /Direct Classic Factory, Graph Factory, or Single Factory\s+calls/,
+    );
+    expect(page).toMatch(
+      /does not automatically list a coin in GMGN, Axiom, FOMO/,
+    );
+    expect(page).toMatch(
+      /Generic pool or token\s+discovery in a third-party API is not Router stamp integration/,
+    );
+    expect(page).toMatch(
+      /GMGN market\s+numbers are not canonical onchain stamp evidence/,
+    );
+    expect(page).toMatch(
+      /read current\s+pool state separately through PoolManager or StateView/,
+    );
+    expect(page).toContain("slot0.sqrtPriceX96 == 0");
+    expect(page).toContain("slot0.sqrtPriceX96 != 0");
+    expect(page).toMatch(/not current pool state or liquidity/);
+    expect(page).toMatch(
+      /does\s+not claim that every recorded component was newly/,
+    );
+    expect(page).toContain("not an Explorer source");
+    expect(page).toContain("supplied handoff digests");
+    expect(page).toMatch(/PCAN.*human-readable token symbol/s);
+    expect(page).toContain("does not replace it");
+    expect(page).toMatch(
+      /The public GitHub approval → permit → wallet self-service flow is\s+not live/,
+    );
+    expect(page).not.toContain("Classic onchain canary passed");
   });
 
   it("adds one discoverable route to the existing Docs navigation", () => {
@@ -203,12 +479,16 @@ describe("Launch Stamp developer documentation", () => {
       "category.relatedPaths.some((path) => path === currentPath)",
     );
     expect(page).toContain('currentPath="/docs/launch-stamps"');
-    expect(page).toContain(
-      'alternates: { canonical: "/docs/launch-stamps" }',
-    );
+    expect(page).toContain('alternates: { canonical: "/docs/launch-stamps" }');
     expect(sitemap).toContain('"/docs/launch-stamps"');
     expect(markdown).toContain(
       "[Launch Stamp Router reference](https://programmable.market/docs/launch-stamps)",
+    );
+    expect(markdown).toContain(
+      "live Ethereum Router binding for direct, future-only Classic and Custom provenance verification",
+    );
+    expect(markdown).not.toContain(
+      "the binding remains prelaunch until every deployment field is published",
     );
   });
 
@@ -216,9 +496,7 @@ describe("Launch Stamp developer documentation", () => {
     expect(page).toContain('aria-labelledby="trust-root-heading"');
     expect(page).toContain("<dl className={styles.manifest}>");
     expect(page).toContain('aria-label="Launch stamp verification flow"');
-    expect(page).toContain(
-      'aria-label="StampRecordV1 fields in ABI order"',
-    );
+    expect(page).toContain('aria-label="StampRecordV1 fields in ABI order"');
     expect(page).toContain("<ol");
     expect(page).not.toContain('role="img"');
     expect(styles).toContain("@media (max-width: 700px)");


### PR DESCRIPTION
## Summary
- bind the public launch-stamp docs to the finalized Ethereum Router and immutable runtime bindings
- publish the exact ABI, event, getter, backfill/live-follow, reorg, and verifier contract for terminal integrators
- publish finalized deployment evidence and the CustomGraph PCAN canary while keeping Classic-canary, safety, tradability, automatic-listing, and self-service boundaries explicit
- expose the live, future-only activation on the canonical developer resource

## Validation
- focused launch-stamp tests: 9/9
- full tests: 2,182 passed, 7 skipped; 242 files passed, 1 skipped
- typecheck: pass
- lint: pass (0 errors; 11 pre-existing warnings)
- production build: pass
- rendered QA: 1440px, 390px, 320px, and 200% reflow; keyboard focus, overflow, images, console checked
- canonical ABI: HTTP 200 and exact published SHA-256

No server, indexer, Supabase dependency, historical backfill, safety claim, or automatic terminal adoption is introduced.