### PR TITLE
Add canonical launch-stamp discovery surfaces

### DIFF
--- a/app/api/explore/profile/claim/route.ts
+++ b/app/api/explore/profile/claim/route.ts
@@ -237,8 +237,12 @@ async function legacyClaimToken(
   ];
   if (
     token.launchModel !== "classic" ||
+    token.launchStampProvenance !== undefined ||
     token.hookAddress.toLowerCase() !== deployment.feeHook.toLowerCase() ||
     !token.creatorAddress ||
+    typeof token.totalSwapFeeBps !== "number" ||
+    !Number.isSafeInteger(token.totalSwapFeeBps) ||
+    token.totalSwapFeeBps < 0 ||
     canonicalClaimPoolId(
       getAddress(token.tokenAddress),
       getAddress(token.hookAddress),

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -7,6 +7,7 @@ import {
   safeAlchemyError,
 } from "../../../lib/alchemy/explore.server";
 import { enrichTokensWithAlchemyPoolState } from "../../../lib/alchemy/live-market.server";
+import { suppressRouterBoundCustomProjectDuplicates } from "../../../lib/alchemy/router-custom-collision";
 import { canonicalTokenExploreEntryV1 } from "../../../lib/explore-entry-v1";
 import {
   filterAndSortTokens,
@@ -300,10 +301,14 @@ export async function GET(request: NextRequest) {
       pageSize: integerQuery(search.get("limit"), 9),
       socials,
     } as const;
-    const [model, customProjects] = await Promise.all([
+    const [model, customProjectRecords] = await Promise.all([
       readAlchemyExploreModel(),
       readProductionCustomExploreDirectoryV1(request.signal),
     ]);
+    const customProjects = suppressRouterBoundCustomProjectDuplicates(
+      model.tokens,
+      customProjectRecords,
+    );
     let pricedModel = {
       ...model,
       tokens: await enrichTokensWithAlchemyPrices(model.tokens),

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -8,6 +8,7 @@ import {
   safeAlchemyError,
 } from "../../../../lib/alchemy/explore.server";
 import { enrichTokensWithAlchemyPoolState } from "../../../../lib/alchemy/live-market.server";
+import { suppressRouterBoundCustomProjectDuplicates } from "../../../../lib/alchemy/router-custom-collision";
 import { canonicalTokenExploreEntryV1 } from "../../../../lib/explore-entry-v1";
 import { readProductionCustomExploreDirectoryV1 } from "../../../../lib/server/custom-launch/explore-directory-v1";
 
@@ -36,13 +37,17 @@ export async function GET(request: NextRequest) {
 
   try {
     const address = getAddress(input);
-    const [model, customProjects] = await Promise.all([
+    const [model, customProjectRecords] = await Promise.all([
       readAlchemyExploreModel(),
       readProductionCustomExploreDirectoryV1(request.signal),
     ]);
     const token = model.tokens.find(
       (candidate) =>
         candidate.tokenAddress.toLowerCase() === address.toLowerCase(),
+    );
+    const customProjects = suppressRouterBoundCustomProjectDuplicates(
+      model.tokens,
+      customProjectRecords,
     );
     const customProject = customProjects.find(
       (candidate) => candidate.tokenAddress?.toLowerCase() === address.toLowerCase(),

--- a/app/api/indexers/v1/token-list/route.ts
+++ b/app/api/indexers/v1/token-list/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { buildUniswapTokenList } from "../../../../../lib/onchain/indexer-feed";
+import { buildUniswapTokenListResult } from "../../../../../lib/onchain/indexer-feed";
 import {
   getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
@@ -13,6 +13,30 @@ import {
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+const TOKEN_LIST_OMITTED_COUNT_HEADER =
+  "X-Programmable-Omitted-Token-Count";
+const TOKEN_LIST_OMISSION_REASON_HEADER =
+  "X-Programmable-Omission-Reason";
+
+function tokenListHeaders(
+  cacheControl: string,
+  omissions: ReturnType<typeof buildUniswapTokenListResult>["omissions"],
+) {
+  const headers = alchemyFeedHeaders(cacheControl);
+  return {
+    ...headers,
+    "Access-Control-Expose-Headers": [
+      headers["Access-Control-Expose-Headers"],
+      TOKEN_LIST_OMITTED_COUNT_HEADER,
+      TOKEN_LIST_OMISSION_REASON_HEADER,
+    ].join(", "),
+    [TOKEN_LIST_OMITTED_COUNT_HEADER]: String(omissions.count),
+    ...(omissions.reason
+      ? { [TOKEN_LIST_OMISSION_REASON_HEADER]: omissions.reason }
+      : {}),
+  };
+}
 
 export async function GET() {
   try {
@@ -34,14 +58,34 @@ export async function GET() {
         },
       );
     }
-    const tokenList = buildUniswapTokenList(
+    const result = buildUniswapTokenListResult(
       model,
       deployment.chainId,
     );
+    if (result.tokenList === null) {
+      return NextResponse.json(
+        {
+          status: model.status,
+          error:
+            "The token list is unavailable until a token has verified decimals",
+        },
+        {
+          status: 503,
+          headers: {
+            ...tokenListHeaders(
+              "public, max-age=0, s-maxage=5",
+              result.omissions,
+            ),
+            "Retry-After": "60",
+          },
+        },
+      );
+    }
 
-    return NextResponse.json(tokenList, {
-      headers: alchemyFeedHeaders(
+    return NextResponse.json(result.tokenList, {
+      headers: tokenListHeaders(
         "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
+        result.omissions,
       ),
     });
   } catch (error) {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -34,7 +34,9 @@ import {
   getTokenCardImageSource,
 } from "@/lib/token-image";
 import {
+  isLaunchStampProvenanceV1,
   type ExploreEntry,
+  type ExploreLaunchCategoryProvenance,
   type LauncherToken,
   type TokenLink,
 } from "@/lib/tokens";
@@ -269,10 +271,62 @@ function parseLauncherToken(value: unknown): LauncherToken | null {
     !isTokenAddress(value.hookAddress) ||
     !isBytes32(value.poolId) ||
     typeof value.launchedAt !== "string" ||
-    typeof value.totalSwapFeeBps !== "number" ||
-    !Number.isSafeInteger(value.totalSwapFeeBps) ||
-    value.totalSwapFeeBps < 0 ||
-    value.liquidityPath !== "meme"
+    (value.totalSwapFeeBps !== null &&
+      (typeof value.totalSwapFeeBps !== "number" ||
+        !Number.isSafeInteger(value.totalSwapFeeBps) ||
+        value.totalSwapFeeBps < 0)) ||
+    (value.liquidityPath !== "meme" &&
+      value.liquidityPath !== "programmable-v4")
+  ) {
+    return null;
+  }
+
+  const stamp = value.launchStampProvenance;
+  if (
+    stamp !== undefined &&
+    (!isTokenAddress(value.creatorAddress) ||
+      !isBytes32(value.launchTransactionHash) ||
+      typeof value.launchBlockNumber !== "string" ||
+      !/^[1-9][0-9]*$/u.test(value.launchBlockNumber) ||
+      !Number.isSafeInteger(value.launchTransactionIndex) ||
+      Number(value.launchTransactionIndex) < 0 ||
+      !Number.isSafeInteger(value.launchLogIndex) ||
+      Number(value.launchLogIndex) < 0 ||
+      !isLaunchStampProvenanceV1(stamp, {
+        tokenAddress: value.tokenAddress,
+        hookAddress: value.hookAddress,
+        poolId: value.poolId,
+        launchWallet: value.creatorAddress,
+        transactionHash: value.launchTransactionHash,
+        blockNumber: value.launchBlockNumber,
+        transactionIndex: Number(value.launchTransactionIndex),
+        launchLogIndex: Number(value.launchLogIndex),
+      }))
+  ) {
+    return null;
+  }
+  const stamped = stamp !== undefined;
+  const unknownStampedFees = stamped && value.totalSwapFeeBps === null;
+  if (
+    stamped
+      ? value.launchModel !==
+          (stamp.kind === "custom-graph" ? "custom-graph" : "classic") ||
+        value.launchModelVersion !== "programmable-launch-stamp-router-v1" ||
+        value.liquidityPath !== "programmable-v4" ||
+        !unknownStampedFees ||
+        (unknownStampedFees &&
+          (value.buyHookFeeBps !== undefined ||
+            value.sellHookFeeBps !== undefined ||
+            value.creatorFeeBps !== undefined ||
+            value.buyCreatorFeeBps !== undefined ||
+            value.sellCreatorFeeBps !== undefined ||
+            value.growthFeeBps !== undefined ||
+            value.programmableFeeBps !== undefined ||
+            value.launcherFeeBps !== undefined ||
+            value.transferTaxBps !== undefined))
+      : value.launchModel === "custom-graph" ||
+        value.totalSwapFeeBps === null ||
+        value.liquidityPath !== "meme"
   ) {
     return null;
   }
@@ -295,16 +349,31 @@ function parseLauncherToken(value: unknown): LauncherToken | null {
 function parseLaunchCategoryProvenance(
   value: unknown,
   category: "classic" | "custom",
-) {
+): ExploreLaunchCategoryProvenance | null {
   if (!isRecord(value)
     || value.schemaVersion !== "programmable.explore-launch-category-provenance.v1"
     || value.category !== category) return null;
+  if (value.source === "canonical-launch-stamp-router") {
+    return isBytes32(value.launchId) &&
+      isBytes32(value.stampHash) &&
+      isTokenAddress(value.routerAddress) &&
+      isBytes32(value.transactionHash) &&
+      isBytes32(value.blockHash) &&
+      typeof value.blockNumber === "string" &&
+      /^[1-9][0-9]*$/u.test(value.blockNumber) &&
+      Number.isSafeInteger(value.transactionIndex) &&
+      Number(value.transactionIndex) >= 0 &&
+      Number.isSafeInteger(value.logIndex) &&
+      Number(value.logIndex) >= 0
+      ? value as unknown as ExploreLaunchCategoryProvenance
+      : null;
+  }
   if (category === "classic") {
     return value.source === "canonical-launch-read-model"
       && typeof value.recordId === "string"
       && (typeof value.modelId === "string" || value.modelId === null)
       && (typeof value.modelVersion === "string" || value.modelVersion === null)
-      ? value
+      ? value as unknown as ExploreLaunchCategoryProvenance
       : null;
   }
   const baseValid = isSha256(value.projectId)
@@ -312,7 +381,9 @@ function parseLaunchCategoryProvenance(
     && isSha256(value.sourceRecordBindingHash)
     && isSha256(value.finalizedLaunchBindingHash);
   if (!baseValid) return null;
-  if (value.source === "interface-preview") return value;
+  if (value.source === "interface-preview") {
+    return value as unknown as ExploreLaunchCategoryProvenance;
+  }
   return value.source === "registry.custom-launched"
     && isTokenAddress(value.registryAddress)
     && typeof value.registryStartBlock === "string"
@@ -326,7 +397,7 @@ function parseLaunchCategoryProvenance(
     && Number.isSafeInteger(value.logIndex)
     && Number(value.logIndex) >= 0
     && isBytes32(value.configurationHash)
-    ? value : null;
+    ? value as unknown as ExploreLaunchCategoryProvenance : null;
 }
 
 function isSha256(value: unknown): value is `sha256:${string}` {
@@ -395,6 +466,12 @@ function parseCustomExploreMarkets(value: unknown, chainId: string) {
 }
 
 function parseCustomExploreEntry(value: unknown): ExploreEntry | null {
+  const categoryProvenance = isRecord(value)
+    ? parseLaunchCategoryProvenance(
+        value.launchCategoryProvenance,
+        "custom",
+      )
+    : null;
   if (!isRecord(value)
     || value.exploreKind !== "custom-project"
     || typeof value.id !== "string"
@@ -421,10 +498,8 @@ function parseCustomExploreEntry(value: unknown): ExploreEntry | null {
     || !Array.isArray(value.postLaunchAuthorityInventory.postLaunchAuthorities)
     || !Array.isArray(value.markets)
     || !Array.isArray(value.links)
-    || parseLaunchCategoryProvenance(
-      value.launchCategoryProvenance,
-      "custom",
-    ) === null
+    || categoryProvenance === null
+    || categoryProvenance.source === "canonical-launch-stamp-router"
   ) return null;
   const links = value.links.map(parseTokenLink);
   if (links.some((link) => link === null)) return null;
@@ -478,12 +553,42 @@ function parseExploreEntry(value: unknown): ExploreEntry | null {
     return parseCustomExploreEntry(value);
   }
   const token = parseLauncherToken(value);
+  const expectedCategory = token?.launchStampProvenance?.kind === "custom-graph"
+    ? "custom"
+    : "classic";
+  const categoryProvenance = isRecord(value)
+    ? parseLaunchCategoryProvenance(
+        value.launchCategoryProvenance,
+        expectedCategory,
+      )
+    : null;
   if (!token || !isRecord(value)
     || value.exploreKind !== "token"
-    || parseLaunchCategoryProvenance(
-      value.launchCategoryProvenance,
-      "classic",
-    ) === null) return null;
+    || categoryProvenance === null) return null;
+  const stamp = token.launchStampProvenance;
+  if (stamp) {
+    if (
+      categoryProvenance.source !==
+        "canonical-launch-stamp-router" ||
+      categoryProvenance.launchId.toLowerCase() !==
+        stamp.launchId.toLowerCase() ||
+      categoryProvenance.stampHash.toLowerCase() !==
+        stamp.stampHash.toLowerCase() ||
+      categoryProvenance.routerAddress.toLowerCase() !==
+        stamp.routerAddress.toLowerCase() ||
+      categoryProvenance.transactionHash.toLowerCase() !==
+        stamp.transactionHash.toLowerCase() ||
+      categoryProvenance.blockHash.toLowerCase() !==
+        stamp.blockHash.toLowerCase() ||
+      categoryProvenance.blockNumber !== stamp.blockNumber ||
+      categoryProvenance.transactionIndex !== stamp.transactionIndex ||
+      categoryProvenance.logIndex !== stamp.launchLogIndex
+    ) {
+      return null;
+    }
+  } else if (categoryProvenance.source === "canonical-launch-stamp-router") {
+    return null;
+  }
   return {
     ...token,
     exploreKind: "token",

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -967,11 +967,21 @@ export function filterTokensBySocialPresence<
   );
 }
 
+export function exploreTokenCardDescription(token: ExploreEntry) {
+  const description = token.description?.trim();
+  if (description) return description;
+
+  return token.exploreKind === "token" &&
+      isLaunchStampProvenanceV1(token.launchStampProvenance)
+    ? "Canonical Router stamp. v4 pool initialized."
+    : undefined;
+}
+
 export function getTokenCards(tokens: ExploreEntry[]): TokenCard[] {
   return tokens.map((token) => ({
     id: token.id,
     name: token.name,
-    description: token.description?.trim() || undefined,
+    description: exploreTokenCardDescription(token),
     imageUrl:
       token.imageUrl?.trim() || getFallbackTokenImage(
         token.tokenAddress ?? token.id,

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -1574,6 +1574,16 @@
     min-height: 340px;
   }
 
+  .claimablePanelEmpty {
+    min-height: 0;
+  }
+
+  .claimablePanelEmpty .claimEmpty {
+    flex: none;
+    min-height: 0;
+    padding-block: 28px 12px;
+  }
+
   .feeChart {
     min-height: 190px;
   }

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -453,6 +453,113 @@
   padding: 10px;
 }
 
+.launchesPanel {
+  background: var(--profile-panel);
+  border: 1px solid var(--profile-line);
+  border-radius: 20px;
+  box-shadow: var(--liquid-glass-shadow);
+  margin-block-end: 10px;
+  padding: 15px 16px 16px;
+}
+
+.launchesHeader {
+  align-items: end;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.launchesHeader h2 {
+  font-size: 18px;
+  font-weight: 640;
+  letter-spacing: -0.026em;
+  line-height: 1.1;
+  margin: 0;
+}
+
+.launchesHeader p,
+.launchesHeader > span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.launchesHeader p {
+  margin: 4px 0 0;
+}
+
+.launchesHeader > span {
+  flex: none;
+}
+
+.launchList {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
+  margin-block-start: 12px;
+}
+
+.launchRow {
+  align-items: center;
+  background: var(--profile-subtle);
+  border: 1px solid color-mix(in srgb, var(--profile-line) 72%, transparent);
+  border-radius: 15px;
+  color: var(--text);
+  display: grid;
+  gap: 11px;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
+  min-height: 64px;
+  padding: 9px 11px 9px 9px;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    transform 120ms var(--ease-out);
+}
+
+.launchMark {
+  background: var(--liquid-glass-control-background-hover);
+  border-radius: 11px;
+  height: 44px;
+  overflow: hidden;
+  position: relative;
+  width: 44px;
+}
+
+.launchMark img {
+  object-fit: cover;
+}
+
+.launchIdentity,
+.launchStatus {
+  display: grid;
+  min-width: 0;
+}
+
+.launchIdentity strong {
+  font-size: 14px;
+  font-weight: 650;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launchIdentity small,
+.launchStatus small {
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.launchStatus {
+  justify-items: end;
+  text-align: end;
+}
+
+.launchStatus strong {
+  font-size: 12px;
+  font-weight: 650;
+}
+
 .feePanel,
 .claimablePanel,
 .loadingPanel {
@@ -1382,6 +1489,11 @@
   outline-offset: 2px;
 }
 
+.launchRow:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
 .feeChartInteraction:focus-visible {
   border-radius: 10px;
 }
@@ -1512,6 +1624,11 @@
   .sessionLoadingWorkspace {
     border-radius: 20px;
     padding: 6px;
+  }
+
+  .launchesPanel {
+    border-radius: 18px;
+    padding: 14px;
   }
 
   .feePanel {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -3567,7 +3567,6 @@ export function ProfileRouterLaunches({
             <Link
               className={styles.launchRow}
               href={token.href}
-              aria-label={`Open ${token.name}`}
               key={token.address}
             >
               <span className={styles.launchMark} aria-hidden="true">

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -3844,7 +3844,9 @@ function ProfileAccountWorkspace({
         />
 
         <section
-          className={styles.claimablePanel}
+          className={`${styles.claimablePanel} ${
+            claimableEntries.length ? "" : styles.claimablePanelEmpty
+          }`}
           aria-labelledby="profile-claimable-title"
         >
           <header className={styles.panelHeader}>

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -3043,6 +3043,16 @@ export function buildProfilePortfolio(
   );
 }
 
+export function profileRouterLaunchEntries(
+  entries: readonly ProfilePortfolioEntry[],
+) {
+  return entries.filter(
+    (entry) =>
+      entry.launchedByWallet &&
+      entry.token.launchProvenance === "canonical-router",
+  );
+}
+
 export function profileClaimableWei(
   entries: readonly ProfilePortfolioEntry[],
   account?: string,
@@ -3523,6 +3533,68 @@ function ProfileLoadingState() {
   );
 }
 
+export function ProfileRouterLaunches({
+  entries,
+}: {
+  entries: readonly ProfilePortfolioEntry[];
+}) {
+  if (!entries.length) return null;
+
+  return (
+    <section
+      className={styles.launchesPanel}
+      aria-labelledby="profile-launches-title"
+    >
+      <header className={styles.launchesHeader}>
+        <div>
+          <h2 id="profile-launches-title">Launches</h2>
+          <p>Canonical Router records from this wallet.</p>
+        </div>
+        <span>
+          {entries.length} {entries.length === 1 ? "launch" : "launches"}
+        </span>
+      </header>
+
+      <div className={styles.launchList}>
+        {entries.map(({ token }) => {
+          const tokenImage =
+            token.imageUrl?.trim() || getFallbackTokenImage(token.address);
+          const tokenImageSource = getTokenCardImageSource(tokenImage);
+          const category =
+            token.launchModel === "custom-graph" ? "Custom" : "Classic";
+
+          return (
+            <Link
+              className={styles.launchRow}
+              href={token.href}
+              aria-label={`Open ${token.name}`}
+              key={token.address}
+            >
+              <span className={styles.launchMark} aria-hidden="true">
+                <Image
+                  src={tokenImageSource}
+                  alt=""
+                  fill
+                  sizes="44px"
+                  unoptimized={!canOptimizeTokenImage(tokenImageSource)}
+                />
+              </span>
+              <span className={styles.launchIdentity}>
+                <strong>{token.name}</strong>
+                <small>${token.symbol}</small>
+              </span>
+              <span className={styles.launchStatus}>
+                <strong>{category}</strong>
+                <small>Router record</small>
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 function ProfileAccountWorkspace({
   connected,
   data,
@@ -3714,6 +3786,7 @@ function ProfileAccountWorkspace({
     claimableEntries,
     claimPage,
   );
+  const routerLaunchEntries = profileRouterLaunchEntries(entries);
   const chainId = currentReady
     ? data.chainId
     : classicReady
@@ -3756,6 +3829,8 @@ function ProfileAccountWorkspace({
           </button>
         </div>
       ) : null}
+
+      <ProfileRouterLaunches entries={routerLaunchEntries} />
 
       <div
         className={`${styles.profileWorkspace} liquid-glass-surface`}

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/lib/token-image";
 import { validatePreparedTradeResponse } from "@/lib/trade/client";
 import {
+  isLaunchStampProvenanceV1,
   type CustomProjectExploreEntry,
   type LauncherToken,
   type TokenLink,
@@ -329,8 +330,6 @@ function parseLauncherToken(value: unknown): LauncherToken | null {
     !isRecord(value.launchCategoryProvenance) ||
     value.launchCategoryProvenance.schemaVersion !==
       "programmable.explore-launch-category-provenance.v1" ||
-    value.launchCategoryProvenance.category !== "classic" ||
-    value.launchCategoryProvenance.source !== "canonical-launch-read-model" ||
     typeof value.id !== "string" ||
     typeof value.name !== "string" ||
     typeof value.symbol !== "string" ||
@@ -338,10 +337,84 @@ function parseLauncherToken(value: unknown): LauncherToken | null {
     !isTokenAddress(value.hookAddress) ||
     !isBytes32(value.poolId) ||
     typeof value.launchedAt !== "string" ||
-    typeof value.totalSwapFeeBps !== "number" ||
-    !Number.isSafeInteger(value.totalSwapFeeBps) ||
-    value.totalSwapFeeBps < 0 ||
-    value.liquidityPath !== "meme"
+    (value.totalSwapFeeBps !== null &&
+      (typeof value.totalSwapFeeBps !== "number" ||
+        !Number.isSafeInteger(value.totalSwapFeeBps) ||
+        value.totalSwapFeeBps < 0)) ||
+    (value.liquidityPath !== "meme" &&
+      value.liquidityPath !== "programmable-v4")
+  ) {
+    return null;
+  }
+
+  const stamp = value.launchStampProvenance;
+  if (
+    stamp !== undefined &&
+    (!isTokenAddress(value.creatorAddress) ||
+      !isBytes32(value.launchTransactionHash) ||
+      typeof value.launchBlockNumber !== "string" ||
+      !/^[1-9][0-9]*$/u.test(value.launchBlockNumber) ||
+      !Number.isSafeInteger(value.launchTransactionIndex) ||
+      Number(value.launchTransactionIndex) < 0 ||
+      !Number.isSafeInteger(value.launchLogIndex) ||
+      Number(value.launchLogIndex) < 0 ||
+      !isLaunchStampProvenanceV1(stamp, {
+        tokenAddress: value.tokenAddress,
+        hookAddress: value.hookAddress,
+        poolId: value.poolId,
+        launchWallet: value.creatorAddress,
+        transactionHash: value.launchTransactionHash,
+        blockNumber: value.launchBlockNumber,
+        transactionIndex: Number(value.launchTransactionIndex),
+        launchLogIndex: Number(value.launchLogIndex),
+      }))
+  ) {
+    return null;
+  }
+  const provenance = value.launchCategoryProvenance;
+  if (stamp) {
+    const unknownStampedFees = value.totalSwapFeeBps === null;
+    if (
+      value.launchModel !==
+        (stamp.kind === "custom-graph" ? "custom-graph" : "classic") ||
+      value.launchModelVersion !== "programmable-launch-stamp-router-v1" ||
+      value.liquidityPath !== "programmable-v4" ||
+      !unknownStampedFees ||
+      (unknownStampedFees &&
+        (value.buyHookFeeBps !== undefined ||
+          value.sellHookFeeBps !== undefined ||
+          value.creatorFeeBps !== undefined ||
+          value.buyCreatorFeeBps !== undefined ||
+          value.sellCreatorFeeBps !== undefined ||
+          value.growthFeeBps !== undefined ||
+          value.programmableFeeBps !== undefined ||
+          value.launcherFeeBps !== undefined ||
+          value.transferTaxBps !== undefined)) ||
+      provenance.category !==
+        (stamp.kind === "custom-graph" ? "custom" : "classic") ||
+      provenance.source !== "canonical-launch-stamp-router" ||
+      !isBytes32(provenance.launchId) ||
+      !isBytes32(provenance.stampHash) ||
+      !isTokenAddress(provenance.routerAddress) ||
+      !isBytes32(provenance.transactionHash) ||
+      !isBytes32(provenance.blockHash) ||
+      provenance.launchId.toLowerCase() !== stamp.launchId.toLowerCase() ||
+      provenance.stampHash.toLowerCase() !== stamp.stampHash.toLowerCase() ||
+      provenance.routerAddress.toLowerCase() !==
+        stamp.routerAddress.toLowerCase() ||
+      provenance.transactionHash.toLowerCase() !==
+        stamp.transactionHash.toLowerCase() ||
+      provenance.blockHash.toLowerCase() !== stamp.blockHash.toLowerCase() ||
+      provenance.blockNumber !== stamp.blockNumber ||
+      provenance.transactionIndex !== stamp.transactionIndex ||
+      provenance.logIndex !== stamp.launchLogIndex
+    ) return null;
+  } else if (
+    value.launchModel === "custom-graph" ||
+    value.totalSwapFeeBps === null ||
+    value.liquidityPath !== "meme" ||
+    provenance.category !== "classic" ||
+    provenance.source !== "canonical-launch-read-model"
   ) {
     return null;
   }
@@ -560,6 +633,13 @@ export function parseDetailPayload(value: unknown): DetailPayload {
     }
     snapshot = { chainId: Number(value.snapshot.chainId) };
   }
+  if (
+    token?.launchStampProvenance &&
+    snapshot &&
+    token.launchStampProvenance.chainId !== snapshot.chainId
+  ) {
+    throw new Error("The launch stamp does not match the snapshot network");
+  }
 
   return { status: value.status, token, customProject, snapshot };
 }
@@ -702,7 +782,7 @@ export function formatStockPairedGrossVolume(token: LauncherToken) {
   return formatUsdWadAmount(volumeUsdWad.toString()) ?? quoteUnitVolume;
 }
 
-function formatSwapFee(value: number | undefined) {
+function formatSwapFee(value: number | null | undefined) {
   if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
     return null;
   }
@@ -773,8 +853,22 @@ export function buildTokenDetailMetrics(
       : null,
     {
       label: "Category",
-      value: "Classic",
+      value:
+        token.launchStampProvenance?.kind === "custom-graph"
+          ? "Custom"
+          : "Classic",
     },
+    token.launchStampProvenance !== undefined && token.currentTick !== undefined
+      ? {
+          label: "Pool state",
+          value:
+            token.activeLiquidity !== undefined &&
+            /^(?:0|[1-9]\d*)$/u.test(token.activeLiquidity) &&
+            BigInt(token.activeLiquidity) > 0n
+              ? "Initialized · active liquidity"
+              : "Initialized",
+        }
+      : null,
     volumeOverride ??
       (officialVolumeUsd !== null ||
       token.grossVolumeEth ||
@@ -829,6 +923,15 @@ export function buildTokenDetailMetrics(
   return values.filter(
     (metric): metric is TokenMetric =>
       metric !== null && metric.value.length > 0,
+  );
+}
+
+export function canUseClassicTokenTrade(token: LauncherToken) {
+  return (
+    token.launchStampProvenance === undefined &&
+    token.launchModel !== "custom-graph" &&
+    token.liquidityPath === "meme" &&
+    typeof token.totalSwapFeeBps === "number"
   );
 }
 
@@ -940,26 +1043,75 @@ function VerifiedLaunchRecord({
         timeZone: "UTC",
       }).format(new Date(token.launchedAt))
     : token.launchedAt;
+  const stamp = token.launchStampProvenance;
+  const category = stamp?.kind === "custom-graph" ? "Custom" : "Classic";
 
   return (
     <details className={styles.launchRecord}>
       <summary>
-        <span>Verified launch record</span>
-        <small>Onchain provenance</small>
+        <span>{stamp ? "Launch stamp provenance" : "Onchain launch record"}</span>
+        <small>{stamp ? "Canonical Router record" : "Onchain provenance"}</small>
       </summary>
       <dl>
         <div>
           <dt>Category</dt>
-          <dd>Classic</dd>
+          <dd>{category}</dd>
         </div>
         <div>
           <dt>Model</dt>
-          <dd>{token.launchModelVersion ?? token.launchModel ?? "classic"}</dd>
+          <dd>{token.launchModel ?? "classic"}</dd>
         </div>
         <div>
           <dt>Launched</dt>
           <dd><time dateTime={token.launchedAt}>{launchedAt} UTC</time></dd>
         </div>
+        {stamp ? (
+          <>
+            <div>
+              <dt>Launch ID</dt>
+              <dd><code>{stamp.launchId}</code></dd>
+            </div>
+            <div>
+              <dt>Stamp hash</dt>
+              <dd><code>{stamp.stampHash}</code></dd>
+            </div>
+            <div>
+              <dt>Router</dt>
+              <dd>
+                {explorerBase ? (
+                  <a href={`${explorerBase}/address/${stamp.routerAddress}`} target="_blank" rel="noreferrer">
+                    <code>{stamp.routerAddress}</code>
+                  </a>
+                ) : (
+                  <code>{stamp.routerAddress}</code>
+                )}
+              </dd>
+            </div>
+            <div>
+              <dt>Pool manager</dt>
+              <dd>
+                {explorerBase ? (
+                  <a href={`${explorerBase}/address/${stamp.poolManagerAddress}`} target="_blank" rel="noreferrer">
+                    <code>{stamp.poolManagerAddress}</code>
+                  </a>
+                ) : (
+                  <code>{stamp.poolManagerAddress}</code>
+                )}
+              </dd>
+            </div>
+            <div>
+              <dt>Launch block</dt>
+              <dd><code>{stamp.blockNumber}</code></dd>
+            </div>
+            <div>
+              <dt>Finality observed</dt>
+              <dd>
+                <code>{stamp.finalizedAtBlockNumber}</code>
+                {` (${stamp.finalityConfirmations} confirmations)`}
+              </dd>
+            </div>
+          </>
+        ) : null}
         {token.creatorAddress ? (
           <div>
             <dt>Creator</dt>
@@ -1173,6 +1325,15 @@ function TokenDetailContent({
     token.tokenDecimals <= 255
       ? token.tokenDecimals
       : 18;
+  const isRouterStamped = token.launchStampProvenance !== undefined;
+  const canUseClassicTrade = canUseClassicTokenTrade(token);
+  const classicTradeLaunchModel = token.launchModel === "custom-graph"
+    ? undefined
+    : token.launchModel;
+  const defaultSwapFeeBps = token.totalSwapFeeBps;
+  const classicSwapFeeBps = typeof defaultSwapFeeBps === "number"
+    ? defaultSwapFeeBps
+    : null;
 
   useEffect(
     () => () => {
@@ -1229,6 +1390,9 @@ function TokenDetailContent({
   }
 
   async function prepareNextTrade(source: PreparedTokenTrade) {
+    if (!canUseClassicTrade) {
+      throw new Error("Trading is not enabled for this pool");
+    }
     if (!wallet) {
       throw new Error("Connect an Ethereum wallet before continuing");
     }
@@ -1263,7 +1427,7 @@ function TokenDetailContent({
       token: getAddress(token.tokenAddress),
       hook: getAddress(token.hookAddress),
       poolId: token.poolId,
-      launchModel: token.launchModel,
+      launchModel: classicTradeLaunchModel,
       quoteAsset: token.quoteAssetAddress
         ? getAddress(token.quoteAssetAddress)
         : undefined,
@@ -1311,6 +1475,9 @@ function TokenDetailContent({
   }
 
   async function submitPreparedTrade(prepared: PreparedTokenTrade) {
+    if (!canUseClassicTrade) {
+      throw new Error("Trading is not enabled for this pool");
+    }
     if (!wallet) {
       throw new Error("Connect an Ethereum wallet before continuing");
     }
@@ -1330,7 +1497,7 @@ function TokenDetailContent({
       token: getAddress(token.tokenAddress),
       hook: getAddress(token.hookAddress),
       poolId: token.poolId,
-      launchModel: token.launchModel,
+      launchModel: classicTradeLaunchModel,
       quoteAsset: token.quoteAssetAddress
         ? getAddress(token.quoteAssetAddress)
         : undefined,
@@ -1480,21 +1647,23 @@ function TokenDetailContent({
           </div>
 
           <div className={styles.marketChart}>
-            <TokenPriceChart
-              tokenAddress={token.tokenAddress}
-              tokenName={token.name}
-              launchModel={token.launchModel}
-              preview={preview}
-              marketCapEthWei={
-                token.indexedMarketCapEthWei ?? token.marketCapEthWei
-              }
-              marketCapEth={token.indexedMarketCapEth ?? token.marketCapEth}
-              marketCapUsdWad={
-                token.indexedMarketCapUsdWad ?? token.fdvUsdWad
-              }
-              onVolumeChange={setChartVolume}
-              onMarketCapChange={setChartMarketCap}
-            />
+            {isRouterStamped ? null : (
+              <TokenPriceChart
+                tokenAddress={token.tokenAddress}
+                tokenName={token.name}
+                launchModel={classicTradeLaunchModel}
+                preview={preview}
+                marketCapEthWei={
+                  token.indexedMarketCapEthWei ?? token.marketCapEthWei
+                }
+                marketCapEth={token.indexedMarketCapEth ?? token.marketCapEth}
+                marketCapUsdWad={
+                  token.indexedMarketCapUsdWad ?? token.fdvUsdWad
+                }
+                onVolumeChange={setChartVolume}
+                onMarketCapChange={setChartMarketCap}
+              />
+            )}
             <MetricGrid metrics={metrics} />
             <VerifiedLaunchRecord
               token={token}
@@ -1507,7 +1676,18 @@ function TokenDetailContent({
           className={`${styles.tradeShell} liquid-glass-surface`}
           aria-label={`${token.name} trade`}
         >
-          {preview ? (
+          {isRouterStamped ? (
+            <div className={styles.submitted} role="status">
+              <strong>Router launch</strong>
+              <p>
+                Trading is not enabled in this interface for this PoolKey.
+              </p>
+            </div>
+          ) : !canUseClassicTrade || classicSwapFeeBps === null ? (
+            <div className={styles.submitted} role="status">
+              <p>Trading is unavailable because the fee policy is unknown</p>
+            </div>
+          ) : preview ? (
             <PreviewTokenTrade token={token} />
           ) : chainId !== 1 && chainId !== 11_155_111 ? (
             <div className={styles.submitted} role="status">
@@ -1524,7 +1704,7 @@ function TokenDetailContent({
               tokenDecimals={tokenDecimals}
               tokenPriceEth={token.tokenPriceEth}
               tokenPriceUsdWad={token.tokenPriceUsdWad}
-              launchModel={token.launchModel}
+              launchModel={classicTradeLaunchModel}
               quoteAsset={
                 token.quoteAssetAddress
                   ? getAddress(token.quoteAssetAddress)
@@ -1532,8 +1712,8 @@ function TokenDetailContent({
               }
               quoteAssetSymbol={token.quoteAssetSymbol}
               tokenPriceQuote={token.tokenPriceQuote}
-              buySwapFeeBps={token.buyHookFeeBps ?? token.totalSwapFeeBps}
-              sellSwapFeeBps={token.sellHookFeeBps ?? token.totalSwapFeeBps}
+              buySwapFeeBps={token.buyHookFeeBps ?? classicSwapFeeBps}
+              sellSwapFeeBps={token.sellHookFeeBps ?? classicSwapFeeBps}
               readBalances={readTokenBalances}
               onConnect={openWallet}
               onPrepared={submitPreparedTrade}
@@ -1544,11 +1724,11 @@ function TokenDetailContent({
               symbol={token.symbol}
               tokenDecimals={tokenDecimals}
               tokenPriceEth={token.tokenPriceEth}
-              launchModel={token.launchModel}
+              launchModel={classicTradeLaunchModel}
               totalSwapFeeBps={
                 tradeFlow.prepared.side === "buy"
-                  ? (token.buyHookFeeBps ?? token.totalSwapFeeBps)
-                  : (token.sellHookFeeBps ?? token.totalSwapFeeBps)
+                  ? (token.buyHookFeeBps ?? classicSwapFeeBps)
+                  : (token.sellHookFeeBps ?? classicSwapFeeBps)
               }
               pending={tradeFlow.submitting}
               error={tradeFlow.error}

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -1673,14 +1673,21 @@ function TokenDetailContent({
         </section>
 
         <aside
-          className={`${styles.tradeShell} liquid-glass-surface`}
-          aria-label={`${token.name} trade`}
+          className={`${styles.tradeShell} ${
+            isRouterStamped ? styles.routerNoticeShell : ""
+          } liquid-glass-surface`}
+          aria-label={
+            isRouterStamped
+              ? `${token.name} market availability`
+              : `${token.name} trade`
+          }
         >
           {isRouterStamped ? (
-            <div className={styles.submitted} role="status">
+            <div className={styles.routerNotice} role="status">
               <strong>Router launch</strong>
               <p>
-                Trading is not enabled in this interface for this PoolKey.
+                This page shows launch data only. Trading is not enabled here
+                for this PoolKey.
               </p>
             </div>
           ) : !canUseClassicTrade || classicSwapFeeBps === null ? (

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -919,6 +919,33 @@
   width: 100%;
 }
 
+.routerNoticeShell {
+  min-height: 0;
+  padding: 20px;
+  position: static;
+}
+
+.routerNotice {
+  display: grid;
+  gap: 6px;
+}
+
+.routerNotice strong {
+  color: var(--text);
+  font-size: 18px;
+  font-weight: 630;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+.routerNotice p {
+  color: var(--text-soft);
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 0;
+  max-width: 48ch;
+}
+
 .tradeForm,
 .review,
 .submitted {

--- a/lib/alchemy/explore.server.ts
+++ b/lib/alchemy/explore.server.ts
@@ -11,6 +11,7 @@ import type {
   ReadyOnchainDeployment,
 } from "../onchain/types";
 import type { LauncherToken } from "../tokens";
+import { advanceLaunchStampRouterSlice } from "./launch-stamp.server";
 import {
   readAlchemyLaunchRegistry,
   writeAlchemyLaunchRegistry,
@@ -166,6 +167,49 @@ function sameLaunch(left: LauncherToken, right: LauncherToken) {
   );
 }
 
+function sameHex(left: string | undefined, right: string | undefined) {
+  return left?.toLowerCase() === right?.toLowerCase();
+}
+
+function sameLaunchStampBinding(left: LauncherToken, right: LauncherToken) {
+  const leftStamp = left.launchStampProvenance;
+  const rightStamp = right.launchStampProvenance;
+  if (leftStamp && rightStamp) {
+    return (
+      sameHex(leftStamp.launchId, rightStamp.launchId) &&
+      sameHex(leftStamp.stampHash, rightStamp.stampHash) &&
+      sameHex(leftStamp.routerAddress, rightStamp.routerAddress)
+    );
+  }
+  return (
+    sameHex(left.launchTransactionHash, right.launchTransactionHash) &&
+    sameHex(left.poolId, right.poolId) &&
+    sameHex(left.hookAddress, right.hookAddress)
+  );
+}
+
+function mergeDefinedToken(
+  existing: LauncherToken,
+  stamped: LauncherToken,
+): LauncherToken {
+  if (stamped.launchStampProvenance) {
+    return {
+      ...stamped,
+      launchDiscoverySource:
+        stamped.launchDiscoverySource ??
+        existing.launchDiscoverySource ??
+        "alchemy-launch-overlay",
+    };
+  }
+  const merged = { ...existing } as LauncherToken & Record<string, unknown>;
+  for (const [key, value] of Object.entries(stamped)) {
+    if (value !== undefined && (value !== null || merged[key] === undefined)) {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
 function mergeLaunchOverlay(
   base: ReadyExploreModel,
   overlayTokens: readonly LauncherToken[],
@@ -183,6 +227,34 @@ function mergeLaunchOverlay(
       ...token,
       launchDiscoverySource: "alchemy-launch-overlay",
     });
+  }
+  return { ...base, tokens: [...tokens.values()] } satisfies ReadyExploreModel;
+}
+
+function mergeLaunchStampRouterOverlay(
+  base: ReadyExploreModel,
+  routerTokens: readonly LauncherToken[],
+) {
+  const tokens = new Map(
+    base.tokens.map((token) => [token.tokenAddress.toLowerCase(), token]),
+  );
+  for (const token of routerTokens) {
+    const key = token.tokenAddress.toLowerCase();
+    const existing = tokens.get(key);
+    if (existing && !sameLaunchStampBinding(existing, token)) {
+      throw new Error(
+        `Alchemy launch stamp Router overlay conflicts for ${token.tokenAddress}`,
+      );
+    }
+    tokens.set(
+      key,
+      existing
+        ? mergeDefinedToken(existing, token)
+        : {
+            ...token,
+            launchDiscoverySource: "alchemy-launch-overlay",
+          },
+    );
   }
   return { ...base, tokens: [...tokens.values()] } satisfies ReadyExploreModel;
 }
@@ -209,12 +281,35 @@ function overlayTokensAfterBase(
 }
 
 function registryTokenIdentity(registry: AlchemyLaunchRegistry) {
-  return JSON.stringify(
-    registry.tokens.map((token) => [
+  return JSON.stringify({
+    classic: registry.tokens.map((token) => [
       token.tokenAddress.toLowerCase(),
       token.launchTransactionHash?.toLowerCase(),
       token.launchLogIndex,
     ]),
+    router: registry.launchStampRouter.tokens.map((token) => [
+      token.tokenAddress.toLowerCase(),
+      token.launchStampProvenance?.launchId.toLowerCase(),
+      token.launchStampProvenance?.stampHash.toLowerCase(),
+      token.launchTransactionHash?.toLowerCase(),
+      token.launchLogIndex,
+    ]),
+  });
+}
+
+function cursorRequiresPersistence(
+  next: AlchemyLaunchCursor,
+  previous: AlchemyLaunchCursor,
+) {
+  const nextBlock = BigInt(next.blockNumber);
+  const previousBlock = BigInt(previous.blockNumber);
+  return (
+    nextBlock < previousBlock ||
+    nextBlock - previousBlock >= LAUNCH_CURSOR_PERSIST_INTERVAL_BLOCKS ||
+    (
+      nextBlock === previousBlock &&
+      next.blockHash.toLowerCase() !== previous.blockHash.toLowerCase()
+    )
   );
 }
 
@@ -227,6 +322,18 @@ function persistentOverlayTokensAfterBase(
     delete persistent.launchDiscoverySource;
     return persistent;
   });
+}
+
+function withoutRouterTokenDuplicates(
+  classicTokens: readonly LauncherToken[],
+  routerTokens: readonly LauncherToken[],
+) {
+  const routerTokenKeys = new Set(
+    routerTokens.map((token) => token.tokenAddress.toLowerCase()),
+  );
+  return classicTokens.filter(
+    (token) => !routerTokenKeys.has(token.tokenAddress.toLowerCase()),
+  );
 }
 
 async function refreshAlchemyExploreRegistryOnce(
@@ -271,6 +378,13 @@ async function refreshAlchemyExploreRegistryOnce(
     cursorModel,
     "confirmed",
   );
+  const routerAdvance = await advanceLaunchStampRouterSlice(
+    deployment,
+    {
+      cursor: stored.registry.launchStampRouter.cursor,
+      tokens: stored.registry.launchStampRouter.tokens,
+    },
+  );
   const confirmedRegistry: AlchemyLaunchRegistry = {
     generatedAt: new Date().toISOString(),
     repositoryCommit: stored.registry.repositoryCommit,
@@ -279,14 +393,27 @@ async function refreshAlchemyExploreRegistryOnce(
       blockNumber: confirmed.snapshot.blockNumber,
       blockHash: confirmed.snapshot.blockHash,
     },
-    tokens: persistentOverlayTokensAfterBase(base, confirmed.tokens),
+    tokens: withoutRouterTokenDuplicates(
+      persistentOverlayTokensAfterBase(base, confirmed.tokens),
+      routerAdvance.slice.tokens,
+    ),
+    launchStampRouter: {
+      ...stored.registry.launchStampRouter,
+      cursor: routerAdvance.slice.cursor,
+      tokens: routerAdvance.slice.tokens,
+    },
   };
   const registryChanged =
     registryTokenIdentity(confirmedRegistry) !==
       registryTokenIdentity(stored.registry) ||
-    BigInt(confirmedRegistry.cursor.blockNumber) -
-      BigInt(stored.registry.cursor.blockNumber) >=
-      LAUNCH_CURSOR_PERSIST_INTERVAL_BLOCKS;
+    cursorRequiresPersistence(
+      confirmedRegistry.cursor,
+      stored.registry.cursor,
+    ) ||
+    cursorRequiresPersistence(
+      confirmedRegistry.launchStampRouter.cursor,
+      stored.registry.launchStampRouter.cursor,
+    ) || routerAdvance.rebuiltAfterReorg;
   let persisted = false;
   if (
     options.persist !== false &&
@@ -307,18 +434,24 @@ async function refreshAlchemyExploreRegistryOnce(
   const servedCursorModel = options.includeLatest === false
     ? confirmed
     : await advanceExploreLaunchDiscovery(deployment, confirmed, "latest");
-  const model: ReadyExploreModel = {
+  const classicModel: ReadyExploreModel = {
     ...mergeLaunchOverlay(
       base,
       overlayTokensAfterBase(base, servedCursorModel.tokens),
     ),
     launchDiscoverySnapshot: servedCursorModel.snapshot,
   };
+  const model = mergeLaunchStampRouterOverlay(
+    classicModel,
+    confirmedRegistry.launchStampRouter.tokens,
+  );
   return {
     model,
     baseBlockNumber: base.snapshot.blockNumber,
     confirmedBlockNumber: confirmed.snapshot.blockNumber,
     servedBlockNumber: servedCursorModel.snapshot.blockNumber,
+    launchStampRouterBlockNumber:
+      confirmedRegistry.launchStampRouter.cursor.blockNumber,
     persisted,
     registryChanged,
   } as const;

--- a/lib/alchemy/launch-registry.server.ts
+++ b/lib/alchemy/launch-registry.server.ts
@@ -10,16 +10,45 @@ import {
 
 import { resolveDurableExploreBlobToken } from "../onchain/durable-model";
 import type { ReadyOnchainDeployment } from "../onchain/types";
-import type { LauncherToken } from "../tokens";
+import {
+  CANONICAL_LAUNCH_STAMP_V1,
+  isLaunchStampProvenanceV1,
+  type LauncherToken,
+} from "../tokens";
 
 const ALCHEMY_LAUNCH_REGISTRY_DIRECTORY =
   "indexes/mainnet-classic-v2/alchemy-launch-registry-v1";
-const SCHEMA_VERSION = "programmable-alchemy-launch-registry-v1";
+const LEGACY_SCHEMA_VERSION = "programmable-alchemy-launch-registry-v1";
+const SCHEMA_VERSION = "programmable-alchemy-launch-registry-v2";
+const ROUTER_SLICE_SCHEMA_VERSION =
+  "programmable-launch-stamp-router-registry-v1";
 const REPOSITORY_COMMIT = /^[0-9a-f]{40}$/u;
+
+export const LAUNCH_STAMP_ROUTER_BINDING = Object.freeze({
+  chainId: CANONICAL_LAUNCH_STAMP_V1.chainId,
+  routerAddress: CANONICAL_LAUNCH_STAMP_V1.routerAddress,
+  routerRuntimeCodeHash: CANONICAL_LAUNCH_STAMP_V1.routerRuntimeCodeHash,
+  poolManagerAddress: CANONICAL_LAUNCH_STAMP_V1.poolManagerAddress,
+  startBlock: CANONICAL_LAUNCH_STAMP_V1.routerStartBlock,
+  finalityConfirmations: CANONICAL_LAUNCH_STAMP_V1.finalityConfirmations,
+} as const);
+
+export const LAUNCH_STAMP_ROUTER_INITIAL_CURSOR = Object.freeze({
+  blockNumber: "25717611",
+  blockHash:
+    "0x2d42bd6f5cea0a09b7a76c5ca51569ac69e677cef0498b12730d6f1f7a979a5e",
+} as const satisfies AlchemyLaunchCursor);
 
 export type AlchemyLaunchCursor = Readonly<{
   blockNumber: string;
   blockHash: Hex;
+}>;
+
+export type AlchemyLaunchStampRouterRegistry = Readonly<{
+  schemaVersion: typeof ROUTER_SLICE_SCHEMA_VERSION;
+  binding: typeof LAUNCH_STAMP_ROUTER_BINDING;
+  cursor: AlchemyLaunchCursor;
+  tokens: readonly LauncherToken[];
 }>;
 
 export type AlchemyLaunchRegistry = Readonly<{
@@ -28,12 +57,13 @@ export type AlchemyLaunchRegistry = Readonly<{
   chainId: number;
   cursor: AlchemyLaunchCursor;
   tokens: readonly LauncherToken[];
+  launchStampRouter: AlchemyLaunchStampRouterRegistry;
 }>;
 
 type AlchemyLaunchRegistryEnvelope = Readonly<{
-  schemaVersion: typeof SCHEMA_VERSION;
+  schemaVersion: typeof LEGACY_SCHEMA_VERSION | typeof SCHEMA_VERSION;
   contentHash: Hex;
-  payload: AlchemyLaunchRegistry;
+  payload: unknown;
 }>;
 
 export type AlchemyLaunchRegistryRead = Readonly<{
@@ -90,57 +120,385 @@ function validLaunchToken(value: unknown, cursorBlock: bigint) {
   return true;
 }
 
-export function validateAlchemyLaunchRegistryEnvelope(
+function sameHex(left: unknown, right: string) {
+  return typeof left === "string" && left.toLowerCase() === right.toLowerCase();
+}
+
+function validBytes32(value: unknown) {
+  return (
+    typeof value === "string" &&
+    isHex(value, { strict: true }) &&
+    value.length === 66
+  );
+}
+
+function validSafeNonNegativeInteger(value: unknown) {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function validProof(
   value: unknown,
-  deployment: ReadyOnchainDeployment,
-): AlchemyLaunchRegistry {
+  launchId: string,
+  stampHash: string,
+) {
+  return (
+    isRecord(value) &&
+    sameHex(value.launchId, launchId) &&
+    sameHex(value.stampHash, stampHash)
+  );
+}
+
+function validLaunchStampToken(value: unknown, cursorBlock: bigint) {
+  if (!validLaunchToken(value, cursorBlock) || !isRecord(value)) return false;
+  const provenance = value.launchStampProvenance;
+  if (!isRecord(provenance)) return false;
   if (
-    !isRecord(value) ||
-    value.schemaVersion !== SCHEMA_VERSION ||
-    typeof value.contentHash !== "string" ||
-    !isRecord(value.payload)
+    !isLaunchStampProvenanceV1(provenance, {
+      chainId: LAUNCH_STAMP_ROUTER_BINDING.chainId,
+      tokenAddress: value.tokenAddress as `0x${string}`,
+      hookAddress: value.hookAddress as `0x${string}`,
+      poolId: value.poolId as `0x${string}`,
+      launchWallet: value.creatorAddress as `0x${string}` | undefined,
+      transactionHash: value.launchTransactionHash as `0x${string}`,
+      blockNumber: value.launchBlockNumber as string,
+      transactionIndex: value.launchTransactionIndex as number,
+      launchLogIndex: value.launchLogIndex as number,
+    })
   ) {
-    throw new Error("Alchemy launch registry envelope is malformed");
+    return false;
   }
-  const payload = value.payload;
+  const launchId = String(provenance.launchId ?? "");
+  const stampHash = String(provenance.stampHash ?? "");
+  if (
+    provenance.schemaVersion !== "programmable.launch-stamp-provenance.v1" ||
+    provenance.chainId !== LAUNCH_STAMP_ROUTER_BINDING.chainId ||
+    !sameHex(
+      provenance.routerAddress,
+      LAUNCH_STAMP_ROUTER_BINDING.routerAddress,
+    ) ||
+    !sameHex(
+      provenance.routerRuntimeCodeHash,
+      LAUNCH_STAMP_ROUTER_BINDING.routerRuntimeCodeHash,
+    ) ||
+    provenance.routerStartBlock !== LAUNCH_STAMP_ROUTER_BINDING.startBlock ||
+    provenance.finalityConfirmations !==
+      LAUNCH_STAMP_ROUTER_BINDING.finalityConfirmations ||
+    (provenance.kind !== "custom-graph" && provenance.kind !== "classic") ||
+    !isHex(launchId, { strict: true }) ||
+    launchId.length !== 66 ||
+    !isHex(stampHash, { strict: true }) ||
+    stampHash.length !== 66 ||
+    !isAddress(String(provenance.launchWallet ?? "")) ||
+    !sameHex(provenance.launchWallet, String(value.creatorAddress)) ||
+    !sameHex(provenance.transactionHash, String(value.launchTransactionHash)) ||
+    provenance.blockNumber !== value.launchBlockNumber ||
+    !validBytes32(provenance.blockHash) ||
+    !validSafeNonNegativeInteger(provenance.transactionIndex) ||
+    provenance.transactionIndex !== value.launchTransactionIndex ||
+    !validSafeNonNegativeInteger(provenance.routeLogIndex) ||
+    provenance.launchLogIndex !== value.launchLogIndex ||
+    (provenance.routeLogIndex as number) >=
+      (provenance.launchLogIndex as number) ||
+    !validIntegerString(provenance.finalizedAtBlockNumber) ||
+    !validBytes32(provenance.finalizedAtBlockHash) ||
+    BigInt(provenance.finalizedAtBlockNumber as string) <
+      BigInt(provenance.blockNumber as string) +
+        BigInt(LAUNCH_STAMP_ROUTER_BINDING.finalityConfirmations) ||
+    !sameHex(provenance.poolId, String(value.poolId)) ||
+    !isAddress(String(provenance.poolManagerAddress ?? "")) ||
+    !sameHex(
+      provenance.poolManagerAddress,
+      LAUNCH_STAMP_ROUTER_BINDING.poolManagerAddress,
+    ) ||
+    !isRecord(provenance.poolKey) ||
+    !isAddress(String(provenance.poolKey.currency0 ?? "")) ||
+    !isAddress(String(provenance.poolKey.currency1 ?? "")) ||
+    !isAddress(String(provenance.poolKey.hooks ?? "")) ||
+    !sameHex(provenance.poolKey.hooks, String(value.hookAddress)) ||
+    !validSafeNonNegativeInteger(provenance.poolKey.fee) ||
+    (
+      (provenance.poolKey.fee as number) !== 0x80_00_00 &&
+      (provenance.poolKey.fee as number) > 1_000_000
+    ) ||
+    !Number.isSafeInteger(provenance.poolKey.tickSpacing) ||
+    (provenance.poolKey.tickSpacing as number) < 1 ||
+    (provenance.poolKey.tickSpacing as number) > 32_767 ||
+    !validBytes32(provenance.poolKeyHash) ||
+    !validBytes32(provenance.componentSetHash) ||
+    !validBytes32(provenance.routePayloadHash) ||
+    !isAddress(String(provenance.routeLauncherAddress ?? "")) ||
+    !validBytes32(provenance.routeLauncherRuntimeCodeHash) ||
+    !validBytes32(provenance.expectedResultHash) ||
+    !validBytes32(provenance.permitDigest) ||
+    !Array.isArray(provenance.components) ||
+    provenance.components.length < 2 ||
+    !isRecord(provenance.tokenProof) ||
+    !sameHex(provenance.tokenProof.tokenAddress, String(value.tokenAddress)) ||
+    !validProof(provenance.tokenProof, launchId, stampHash) ||
+    !isRecord(provenance.poolProof) ||
+    !sameHex(
+      provenance.poolProof.poolManagerAddress,
+      String(provenance.poolManagerAddress),
+    ) ||
+    !sameHex(provenance.poolProof.poolId, String(value.poolId)) ||
+    !validProof(provenance.poolProof, launchId, stampHash)
+  ) {
+    return false;
+  }
+  if (
+    BigInt(String(provenance.poolKey.currency0)) >=
+      BigInt(String(provenance.poolKey.currency1)) ||
+    value.liquidityPath !== "programmable-v4" ||
+    value.launchModelVersion !== "programmable-launch-stamp-router-v1" ||
+    value.totalSwapFeeBps !== null ||
+    value.positionRecipient !== undefined ||
+    value.positionTokenId !== undefined ||
+    value.buyHookFeeBps !== undefined ||
+    value.sellHookFeeBps !== undefined ||
+    value.creatorFeeBps !== undefined ||
+    value.buyCreatorFeeBps !== undefined ||
+    value.sellCreatorFeeBps !== undefined ||
+    value.growthFeeBps !== undefined ||
+    value.programmableFeeBps !== undefined ||
+    value.launcherFeeBps !== undefined ||
+    value.transferTaxBps !== undefined ||
+    (
+      provenance.kind === "custom-graph" &&
+      value.launchModel !== "custom-graph"
+    ) ||
+    (provenance.kind === "classic" && value.launchModel !== "classic")
+  ) {
+    return false;
+  }
+  const componentLogIndexes = new Set<number>();
+  const componentAddresses = new Set<string>();
+  for (const component of provenance.components) {
+    if (
+      !isRecord(component) ||
+      !isAddress(String(component.address ?? "")) ||
+      (
+        component.kind !== "token" &&
+        component.kind !== "hook" &&
+        component.kind !== "other"
+      ) ||
+      (
+        component.scope !== "exclusive" &&
+        component.scope !== "shared-infrastructure"
+      ) ||
+      !validBytes32(component.runtimeCodeHash) ||
+      !validSafeNonNegativeInteger(component.logIndex) ||
+      (component.logIndex as number) >= (provenance.routeLogIndex as number) ||
+      componentLogIndexes.has(component.logIndex as number) ||
+      componentAddresses.has(String(component.address).toLowerCase()) ||
+      (
+        component.scope === "exclusive"
+          ? !validProof(component.exclusiveProof, launchId, stampHash)
+          : component.exclusiveProof !== null
+      )
+    ) {
+      return false;
+    }
+    componentLogIndexes.add(component.logIndex as number);
+    componentAddresses.add(String(component.address).toLowerCase());
+  }
+  const tokenComponent = provenance.components.find(
+    (component) =>
+      isRecord(component) &&
+      component.kind === "token" &&
+      component.scope === "exclusive" &&
+      sameHex(component.address, String(value.tokenAddress)) &&
+      validProof(component.exclusiveProof, launchId, stampHash),
+  );
+  const hookComponent = provenance.components.find(
+    (component) =>
+      isRecord(component) &&
+      component.kind === "hook" &&
+      sameHex(component.address, String(value.hookAddress)) &&
+      (
+        provenance.kind === "classic"
+          ? component.scope === "shared-infrastructure" &&
+            component.exclusiveProof === null
+          : component.scope === "exclusive" &&
+            validProof(component.exclusiveProof, launchId, stampHash)
+      ),
+  );
+  return Boolean(
+    tokenComponent &&
+    hookComponent &&
+    provenance.components.filter(
+      (component) => isRecord(component) && component.kind === "token",
+    ).length === 1 &&
+    provenance.components.filter(
+      (component) => isRecord(component) && component.kind === "hook",
+    ).length === 1
+  );
+}
+
+function initialLaunchStampRouterRegistry(): AlchemyLaunchStampRouterRegistry {
+  return {
+    schemaVersion: ROUTER_SLICE_SCHEMA_VERSION,
+    binding: LAUNCH_STAMP_ROUTER_BINDING,
+    cursor: LAUNCH_STAMP_ROUTER_INITIAL_CURSOR,
+    tokens: [],
+  };
+}
+
+function validateCursor(value: unknown) {
+  return (
+    isRecord(value) &&
+    validIntegerString(value.blockNumber) &&
+    isHex(String(value.blockHash ?? ""), { strict: true }) &&
+    String(value.blockHash).length === 66
+  );
+}
+
+function validateClassicPayload(
+  payload: Record<string, unknown>,
+  deployment: ReadyOnchainDeployment,
+) {
   const repositoryCommit = requiredRepositoryCommit();
   if (
     payload.chainId !== deployment.chainId ||
     payload.repositoryCommit !== repositoryCommit ||
     typeof payload.generatedAt !== "string" ||
     !Number.isFinite(Date.parse(payload.generatedAt)) ||
-    !isRecord(payload.cursor) ||
-    !validIntegerString(payload.cursor.blockNumber) ||
-    !isHex(String(payload.cursor.blockHash ?? ""), { strict: true }) ||
-    String(payload.cursor.blockHash).length !== 66 ||
+    !validateCursor(payload.cursor) ||
     !Array.isArray(payload.tokens)
   ) {
     throw new Error("Alchemy launch registry payload is malformed");
   }
-  const registry = payload as unknown as AlchemyLaunchRegistry;
-  if (contentHash(registry).toLowerCase() !== value.contentHash.toLowerCase()) {
-    throw new Error("Alchemy launch registry content hash is invalid");
-  }
-  const cursorBlock = BigInt(registry.cursor.blockNumber);
-  if (!registry.tokens.every((token) => validLaunchToken(token, cursorBlock))) {
+  const cursor = payload.cursor as AlchemyLaunchCursor;
+  const cursorBlock = BigInt(cursor.blockNumber);
+  if (
+    !payload.tokens.every(
+      (token) =>
+        validLaunchToken(token, cursorBlock) &&
+        isRecord(token) &&
+        token.launchStampProvenance === undefined,
+    )
+  ) {
     throw new Error("Alchemy launch registry contains an invalid token");
   }
-  const tokenKeys = registry.tokens.map((token) =>
-    token.tokenAddress.toLowerCase(),
+  const tokenKeys = payload.tokens.map((token) =>
+    String((token as LauncherToken).tokenAddress).toLowerCase(),
   );
-  const eventKeys = registry.tokens.map((token) =>
-    [
-      token.launchTransactionHash?.toLowerCase(),
-      token.launchLogIndex,
-    ].join(":"),
-  );
+  const eventKeys = payload.tokens.map((token) => {
+    const launch = token as LauncherToken;
+    return [
+      launch.launchTransactionHash?.toLowerCase(),
+      launch.launchLogIndex,
+    ].join(":");
+  });
   if (
     new Set(tokenKeys).size !== tokenKeys.length ||
     new Set(eventKeys).size !== eventKeys.length
   ) {
     throw new Error("Alchemy launch registry contains duplicate provenance");
   }
-  return registry;
+}
+
+function validateRouterSlice(value: unknown): AlchemyLaunchStampRouterRegistry {
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== ROUTER_SLICE_SCHEMA_VERSION ||
+    !isRecord(value.binding) ||
+    value.binding.chainId !== LAUNCH_STAMP_ROUTER_BINDING.chainId ||
+    !sameHex(value.binding.routerAddress, LAUNCH_STAMP_ROUTER_BINDING.routerAddress) ||
+    !sameHex(
+      value.binding.routerRuntimeCodeHash,
+      LAUNCH_STAMP_ROUTER_BINDING.routerRuntimeCodeHash,
+    ) ||
+    !sameHex(
+      value.binding.poolManagerAddress,
+      LAUNCH_STAMP_ROUTER_BINDING.poolManagerAddress,
+    ) ||
+    value.binding.startBlock !== LAUNCH_STAMP_ROUTER_BINDING.startBlock ||
+    value.binding.finalityConfirmations !==
+      LAUNCH_STAMP_ROUTER_BINDING.finalityConfirmations ||
+    !validateCursor(value.cursor) ||
+    !Array.isArray(value.tokens)
+  ) {
+    throw new Error("Alchemy launch stamp Router registry is malformed");
+  }
+  const cursor = value.cursor as AlchemyLaunchCursor;
+  const cursorBlock = BigInt(cursor.blockNumber);
+  if (
+    cursorBlock < BigInt(LAUNCH_STAMP_ROUTER_INITIAL_CURSOR.blockNumber) ||
+    !value.tokens.every((token) => validLaunchStampToken(token, cursorBlock))
+  ) {
+    throw new Error("Alchemy launch stamp Router registry contains an invalid token");
+  }
+  const tokenKeys = value.tokens.map((token) =>
+    String((token as LauncherToken).tokenAddress).toLowerCase(),
+  );
+  const launchKeys = value.tokens.map((token) =>
+    String((token as LauncherToken & { launchStampProvenance: { launchId: string } })
+      .launchStampProvenance.launchId).toLowerCase(),
+  );
+  const poolKeys = value.tokens.map((token) =>
+    String((token as LauncherToken).poolId).toLowerCase(),
+  );
+  const eventKeys = value.tokens.map((token) => {
+    const launch = token as LauncherToken;
+    return `${launch.launchTransactionHash?.toLowerCase()}:${launch.launchLogIndex}`;
+  });
+  if (
+    new Set(tokenKeys).size !== tokenKeys.length ||
+    new Set(launchKeys).size !== launchKeys.length ||
+    new Set(poolKeys).size !== poolKeys.length ||
+    new Set(eventKeys).size !== eventKeys.length
+  ) {
+    throw new Error("Alchemy launch stamp Router registry contains duplicate provenance");
+  }
+  return value as unknown as AlchemyLaunchStampRouterRegistry;
+}
+
+export function validateAlchemyLaunchRegistryEnvelope(
+  value: unknown,
+  deployment: ReadyOnchainDeployment,
+): AlchemyLaunchRegistry {
+  if (
+    !isRecord(value) ||
+    (
+      value.schemaVersion !== LEGACY_SCHEMA_VERSION &&
+      value.schemaVersion !== SCHEMA_VERSION
+    ) ||
+    typeof value.contentHash !== "string" ||
+    !isRecord(value.payload)
+  ) {
+    throw new Error("Alchemy launch registry envelope is malformed");
+  }
+  const payload = value.payload;
+  if (
+    keccak256(toBytes(JSON.stringify(payload))).toLowerCase() !==
+      value.contentHash.toLowerCase()
+  ) {
+    throw new Error("Alchemy launch registry content hash is invalid");
+  }
+  validateClassicPayload(payload, deployment);
+  if (value.schemaVersion === LEGACY_SCHEMA_VERSION) {
+    return {
+      ...(payload as unknown as Omit<AlchemyLaunchRegistry, "launchStampRouter">),
+      launchStampRouter: initialLaunchStampRouterRegistry(),
+    };
+  }
+  const launchStampRouter = validateRouterSlice(payload.launchStampRouter);
+  const classicTokenKeys = new Set(
+    (payload.tokens as readonly LauncherToken[]).map((token) =>
+      token.tokenAddress.toLowerCase(),
+    ),
+  );
+  if (
+    launchStampRouter.tokens.some((token) =>
+      classicTokenKeys.has(token.tokenAddress.toLowerCase()),
+    )
+  ) {
+    throw new Error("Alchemy launch registry slices contain duplicate tokens");
+  }
+  return {
+    ...(payload as unknown as AlchemyLaunchRegistry),
+    launchStampRouter,
+  };
 }
 
 export async function readAlchemyLaunchRegistry(
@@ -164,6 +522,7 @@ export async function readAlchemyLaunchRegistry(
         chainId: deployment.chainId,
         cursor: initialCursor,
         tokens: [],
+        launchStampRouter: initialLaunchStampRouterRegistry(),
       },
       etag: null,
     };

--- a/lib/alchemy/launch-stamp.server.ts
+++ b/lib/alchemy/launch-stamp.server.ts
@@ -1,0 +1,1311 @@
+import "server-only";
+
+import {
+  createPublicClient,
+  decodeEventLog,
+  formatUnits,
+  getAddress,
+  http,
+  isAddressEqual,
+  keccak256,
+  parseAbi,
+  parseAbiItem,
+  type Address,
+  type Hex,
+  type Log,
+  type PublicClient,
+  type TransactionReceipt,
+} from "viem";
+import { mainnet } from "viem/chains";
+
+import {
+  characterLength,
+  hasUnsafeDisplayCharacters,
+  isValidTokenSymbol,
+  MAX_SOCIAL_EXTRA_DATA_BYTES,
+  MAX_TOKEN_DESCRIPTION_BYTES,
+  MAX_TOKEN_NAME_BYTES,
+  MAX_TOKEN_NAME_CHARACTERS,
+  MAX_TOKEN_SYMBOL_BYTES,
+  utf8ByteLength,
+} from "../metadata-policy";
+import { stateViewReadAbi, uerc20ReadAbi } from "../onchain/abis";
+import {
+  buildTokenLinks,
+  decodeSocialMetadata,
+  sanitizeImageUrl,
+  sanitizeWebsiteUrl,
+} from "../onchain/metadata";
+import type { ReadyOnchainDeployment } from "../onchain/types";
+import type {
+  LauncherToken,
+  LaunchStampProvenanceV1,
+} from "../tokens";
+import { computeOfficialV4PoolId } from "../uniswap/liquidity-launcher-sdk";
+
+export const LAUNCH_STAMP_ROUTER_ADDRESS = getAddress(
+  "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+);
+export const LAUNCH_STAMP_ROUTER_START_BLOCK = 25_717_612n;
+export const LAUNCH_STAMP_ROUTER_RUNTIME_CODE_HASH =
+  "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546" as const;
+export const LAUNCH_STAMP_POOL_MANAGER_ADDRESS = getAddress(
+  "0x000000000004444c5dc75cB358380D2e3dE08A90",
+);
+export const LAUNCH_STAMP_POOL_MANAGER_RUNTIME_CODE_HASH =
+  "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293" as const;
+export const LAUNCH_STAMP_FINALITY_CONFIRMATIONS = 64n;
+/** Direct-call evidence only. Discovery and hydration never require tx.to/input. */
+export const LAUNCH_STAMP_DIRECT_CALL_SELECTOR = "0xe5f6b8cd" as const;
+export const LAUNCH_STAMP_ROUTER_INITIAL_CURSOR = Object.freeze({
+  blockNumber: (LAUNCH_STAMP_ROUTER_START_BLOCK - 1n).toString(),
+  blockHash:
+    "0x2d42bd6f5cea0a09b7a76c5ca51569ac69e677cef0498b12730d6f1f7a979a5e" as Hex,
+});
+
+export const LAUNCH_STAMP_COMPONENT_TOPIC =
+  "0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b" as const;
+export const LAUNCH_STAMP_ROUTE_TOPIC =
+  "0x45e7cc355b63ca67d6278a0d8d23470ce2a0741a9c60283d7dee712df7a877a5" as const;
+export const LAUNCH_STAMP_LAUNCH_TOPIC =
+  "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2" as const;
+export const POOL_MANAGER_INITIALIZE_TOPIC =
+  "0xdd466e674ea557f56295e2d0218a125ea4b4f0f6f3307b95f85e6110838d6438" as const;
+
+const ZERO_HASH = `0x${"00".repeat(32)}` as Hex;
+const INITIAL_LOG_CHUNK = 5_000n;
+const MINIMUM_LOG_CHUNK = 100n;
+const MAXIMUM_CATCH_UP_BLOCKS = 50_000n;
+const MAXIMUM_ANCHORS_PER_ADVANCE = 512;
+const HYDRATION_CONCURRENCY = 3;
+const COMPONENT_CONCURRENCY = 4;
+
+export const launchStampComponentEvent = parseAbiItem(
+  "event ProgrammableComponentStampedV1(bytes32 indexed launchId,address indexed component,uint8 indexed kind,bytes32 runtimeCodeHash)",
+);
+export const launchStampRouteEvent = parseAbiItem(
+  "event ProgrammableLaunchRouteStampedV1(bytes32 indexed launchId,uint8 indexed kind,bytes32 indexed routePayloadHash,bytes32 expectedResultHash,bytes32 permitDigest)",
+);
+export const launchStampLaunchEvent = parseAbiItem(
+  "event ProgrammableLaunchStampedV1(bytes32 indexed launchId,address indexed token,address indexed hook,address poolManager,bytes32 poolId,bytes32 stampHash)",
+);
+export const poolManagerInitializeEvent = parseAbiItem(
+  "event Initialize(bytes32 indexed id,address indexed currency0,address indexed currency1,uint24 fee,int24 tickSpacing,address hooks,uint160 sqrtPriceX96,int24 tick)",
+);
+
+export const launchStampRouterReadAbi = parseAbi([
+  "function CHAIN_ID() view returns (uint256)",
+  "function POOL_MANAGER() view returns (address)",
+  "function launchStamp(bytes32 launchId) view returns ((uint8 kind,address launchWallet,address token,address hook,address poolManager,bytes32 poolId,bytes32 poolKeyHash,bytes32 componentSetHash,bytes32 routePayloadHash,address routeLauncher,bytes32 routeLauncherRuntimeCodeHash,bytes32 expectedResultHash,bytes32 permitDigest,bytes32 stampHash) record)",
+  "function launchIdByToken(address token) view returns (bytes32 launchId)",
+  "function launchIdByPool(address poolManager,bytes32 poolId) view returns (bytes32 launchId)",
+  "function launchIdByComponent(address component) view returns (bytes32 launchId)",
+  "function componentRuntimeCodeHash(address component) view returns (bytes32 runtimeCodeHash)",
+  "function stampProof(address component) view returns (bytes32 launchId,bytes32 stampHash)",
+  "function computePoolKeyHash((address currency0,address currency1,uint24 fee,int24 tickSpacing,address hooks) poolKey) pure returns (bytes32)",
+]);
+
+export type LaunchStampReaderClient = PublicClient;
+
+export type LaunchStampRouterCursor = Readonly<{
+  blockNumber: string;
+  blockHash: Hex;
+}>;
+
+export type LaunchStampRouterSlice = Readonly<{
+  cursor: LaunchStampRouterCursor;
+  tokens: readonly LauncherToken[];
+}>;
+
+export type LaunchStampAnchor = Readonly<{
+  launchId: Hex;
+  token: Address;
+  hook: Address;
+  poolManager: Address;
+  poolId: Hex;
+  stampHash: Hex;
+  blockNumber: bigint;
+  blockHash: Hex;
+  transactionHash: Hex;
+  transactionIndex: number;
+  logIndex: number;
+}>;
+
+export type LaunchStampPoolKey = Readonly<{
+  currency0: Address;
+  currency1: Address;
+  fee: number;
+  tickSpacing: number;
+  hooks: Address;
+}>;
+
+export type ParsedLaunchStampComponent = Readonly<{
+  launchId: Hex;
+  component: Address;
+  kind: 0 | 1 | 2;
+  runtimeCodeHash: Hex;
+  logIndex: number;
+}>;
+
+export type ParsedLaunchStampRoute = Readonly<{
+  launchId: Hex;
+  kind: 1 | 2;
+  routePayloadHash: Hex;
+  expectedResultHash: Hex;
+  permitDigest: Hex;
+  logIndex: number;
+}>;
+
+export type ParsedLaunchStampReceipt = Readonly<{
+  components: readonly ParsedLaunchStampComponent[];
+  route: ParsedLaunchStampRoute;
+  poolKey: LaunchStampPoolKey;
+  initializeLogIndex: number;
+}>;
+
+export type HydratedLaunchStamp = Readonly<{
+  token: LauncherToken;
+  launchStampProvenance: LaunchStampProvenanceV1;
+}>;
+
+export type AdvanceLaunchStampRouterResult = Readonly<{
+  slice: LaunchStampRouterSlice;
+  scannedFromBlock: string | null;
+  scannedToBlock: string;
+  discovered: number;
+  hydrated: number;
+  boundedByDensity: boolean;
+  rebuiltAfterReorg: boolean;
+}>;
+
+export type LaunchStampReaderOptions = Readonly<{
+  client?: LaunchStampReaderClient;
+}>;
+
+type StampRecord = Readonly<{
+  kind: number;
+  launchWallet: Address;
+  token: Address;
+  hook: Address;
+  poolManager: Address;
+  poolId: Hex;
+  poolKeyHash: Hex;
+  componentSetHash: Hex;
+  routePayloadHash: Hex;
+  routeLauncher: Address;
+  routeLauncherRuntimeCodeHash: Hex;
+  expectedResultHash: Hex;
+  permitDigest: Hex;
+  stampHash: Hex;
+}>;
+
+export type LaunchStampCanonicalBlock = Readonly<{
+  number: bigint;
+  hash: Hex;
+  timestamp: bigint;
+}>;
+
+export class LaunchStampReaderError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "LaunchStampReaderError";
+  }
+}
+
+function fail(message: string): never {
+  throw new LaunchStampReaderError(message);
+}
+
+function sameHex(left: string, right: string) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function requireHex(value: Hex | null | undefined, label: string): Hex {
+  if (!value || !/^0x[0-9a-f]{64}$/iu.test(value)) {
+    fail(`${label} is unavailable`);
+  }
+  return value;
+}
+
+function requireLogIndex(value: number | null | undefined, label: string) {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    fail(`${label} is unavailable`);
+  }
+  return value as number;
+}
+
+function requireCanonicalDeployment(deployment: ReadyOnchainDeployment) {
+  if (deployment.chainId !== 1) {
+    fail("Launch Stamp Router discovery is restricted to Ethereum mainnet");
+  }
+}
+
+function createReaderClient(deployment: ReadyOnchainDeployment) {
+  requireCanonicalDeployment(deployment);
+  return createPublicClient({
+    chain: mainnet,
+    transport: http(deployment.rpcUrl, {
+      retryCount: 2,
+      timeout: 12_000,
+    }),
+  });
+}
+
+async function canonicalBlock(
+  client: LaunchStampReaderClient,
+  blockNumber: bigint,
+): Promise<LaunchStampCanonicalBlock> {
+  const block = await client.getBlock({ blockNumber });
+  if (block.number !== blockNumber) fail("RPC returned the wrong block number");
+  return {
+    number: blockNumber,
+    hash: requireHex(block.hash, `Block ${blockNumber} hash`),
+    timestamp: block.timestamp,
+  };
+}
+
+async function assertRuntimeCodeHash(
+  client: LaunchStampReaderClient,
+  address: Address,
+  expected: Hex,
+  blockNumber: bigint,
+  label: string,
+) {
+  const code = await client.getCode({ address, blockNumber });
+  if (!code || code === "0x" || !sameHex(keccak256(code), expected)) {
+    fail(`${label} runtime code hash mismatch`);
+  }
+}
+
+async function mapWithConcurrency<Input, Output>(
+  values: readonly Input[],
+  concurrency: number,
+  mapper: (value: Input, index: number) => Promise<Output>,
+) {
+  const results = new Array<Output>(values.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(Math.max(1, concurrency), values.length) },
+    async () => {
+      while (nextIndex < values.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await mapper(values[index] as Input, index);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function anchorFromLog(log: Log): LaunchStampAnchor {
+  if (
+    !log.blockNumber ||
+    !log.blockHash ||
+    !log.transactionHash ||
+    !isAddressEqual(log.address, LAUNCH_STAMP_ROUTER_ADDRESS)
+  ) {
+    fail("Launch Stamp discovery returned incomplete provenance");
+  }
+  const decoded = decodeEventLog({
+    abi: [launchStampLaunchEvent],
+    data: log.data,
+    topics: log.topics,
+    strict: true,
+  });
+  const args = decoded.args;
+  if (!isAddressEqual(args.poolManager, LAUNCH_STAMP_POOL_MANAGER_ADDRESS)) {
+    fail("Launch Stamp event used a non-canonical PoolManager");
+  }
+  return {
+    launchId: args.launchId,
+    token: getAddress(args.token),
+    hook: getAddress(args.hook),
+    poolManager: getAddress(args.poolManager),
+    poolId: args.poolId,
+    stampHash: args.stampHash,
+    blockNumber: log.blockNumber,
+    blockHash: log.blockHash,
+    transactionHash: log.transactionHash,
+    transactionIndex: requireLogIndex(
+      log.transactionIndex,
+      "Launch Stamp transaction index",
+    ),
+    logIndex: requireLogIndex(log.logIndex, "Launch Stamp log index"),
+  };
+}
+
+export async function scanLaunchStampAnchors(
+  client: LaunchStampReaderClient,
+  input: Readonly<{
+    fromBlock: bigint;
+    toBlock: bigint;
+    latestBlock?: bigint;
+  }>,
+) {
+  if (input.fromBlock < LAUNCH_STAMP_ROUTER_START_BLOCK) {
+    fail("Launch Stamp scan begins before the canonical Router deployment");
+  }
+  const latestBlock = input.latestBlock ?? (await client.getBlockNumber());
+  const highestFinalized = latestBlock - LAUNCH_STAMP_FINALITY_CONFIRMATIONS;
+  if (input.toBlock > highestFinalized) {
+    fail("Launch Stamp scan includes a block without 64 confirmations");
+  }
+  if (input.fromBlock > input.toBlock) return [] as LaunchStampAnchor[];
+
+  const anchors: LaunchStampAnchor[] = [];
+  let cursor = input.fromBlock;
+  let chunkSize = INITIAL_LOG_CHUNK;
+  while (cursor <= input.toBlock) {
+    const end = cursor + chunkSize - 1n < input.toBlock
+      ? cursor + chunkSize - 1n
+      : input.toBlock;
+    try {
+      const logs = await client.getLogs({
+        address: LAUNCH_STAMP_ROUTER_ADDRESS,
+        event: launchStampLaunchEvent,
+        fromBlock: cursor,
+        toBlock: end,
+        strict: true,
+      });
+      anchors.push(...logs.map((log) => anchorFromLog(log)));
+      cursor = end + 1n;
+    } catch (error) {
+      const attempted = end - cursor + 1n;
+      if (attempted <= MINIMUM_LOG_CHUNK) {
+        throw new LaunchStampReaderError(
+          `Launch Stamp log scan failed at the minimum ${MINIMUM_LOG_CHUNK}-block window`,
+          { cause: error },
+        );
+      }
+      chunkSize = attempted / 2n;
+      if (chunkSize < MINIMUM_LOG_CHUNK) chunkSize = MINIMUM_LOG_CHUNK;
+    }
+  }
+
+  anchors.sort((left, right) =>
+    left.blockNumber === right.blockNumber
+      ? left.transactionIndex === right.transactionIndex
+        ? left.logIndex - right.logIndex
+        : left.transactionIndex - right.transactionIndex
+      : left.blockNumber < right.blockNumber ? -1 : 1
+  );
+  const identities = new Set<string>();
+  for (const anchor of anchors) {
+    const identity = `${anchor.transactionHash.toLowerCase()}:${anchor.logIndex}`;
+    if (identities.has(identity)) fail("Duplicate Launch Stamp discovery anchor");
+    identities.add(identity);
+  }
+  return anchors;
+}
+
+function componentFromLog(log: Log): ParsedLaunchStampComponent {
+  const decoded = decodeEventLog({
+    abi: [launchStampComponentEvent],
+    data: log.data,
+    topics: log.topics,
+    strict: true,
+  });
+  const kind = Number(decoded.args.kind);
+  if (kind !== 0 && kind !== 1 && kind !== 2) {
+    fail("Launch Stamp component kind is invalid");
+  }
+  return {
+    launchId: decoded.args.launchId,
+    component: getAddress(decoded.args.component),
+    kind,
+    runtimeCodeHash: decoded.args.runtimeCodeHash,
+    logIndex: requireLogIndex(log.logIndex, "Component log index"),
+  };
+}
+
+function routeFromLog(log: Log): ParsedLaunchStampRoute {
+  const decoded = decodeEventLog({
+    abi: [launchStampRouteEvent],
+    data: log.data,
+    topics: log.topics,
+    strict: true,
+  });
+  const kind = Number(decoded.args.kind);
+  if (kind !== 1 && kind !== 2) fail("Launch Stamp route kind is invalid");
+  return {
+    launchId: decoded.args.launchId,
+    kind,
+    routePayloadHash: decoded.args.routePayloadHash,
+    expectedResultHash: decoded.args.expectedResultHash,
+    permitDigest: decoded.args.permitDigest,
+    logIndex: requireLogIndex(log.logIndex, "Route log index"),
+  };
+}
+
+function parseRouterRun(run: readonly Log[]) {
+  if (
+    run.length < 4 ||
+    run.length > 18 ||
+    !sameHex(run.at(-2)?.topics[0] ?? "", LAUNCH_STAMP_ROUTE_TOPIC) ||
+    !sameHex(run.at(-1)?.topics[0] ?? "", LAUNCH_STAMP_LAUNCH_TOPIC) ||
+    run.slice(0, -2).some((log) =>
+      !sameHex(log.topics[0] ?? "", LAUNCH_STAMP_COMPONENT_TOPIC)
+    )
+  ) {
+    fail("Router logs are not a contiguous Component -> Route -> Launch group");
+  }
+  for (let index = 1; index < run.length; index += 1) {
+    if (
+      requireLogIndex(run[index]?.logIndex, "Router log index") !==
+      requireLogIndex(run[index - 1]?.logIndex, "Router log index") + 1
+    ) {
+      fail("Router stamp logs are not contiguous");
+    }
+  }
+  const components = run.slice(0, -2).map(componentFromLog);
+  if (components.length < 2 || components.length > 16) {
+    fail("Launch Stamp component count is outside the Router bound");
+  }
+  const route = routeFromLog(run.at(-2) as Log);
+  const launchLog = run.at(-1) as Log;
+  const launch = anchorFromLog(launchLog);
+  if (
+    !sameHex(route.launchId, launch.launchId) ||
+    components.some((component) => !sameHex(component.launchId, launch.launchId))
+  ) {
+    fail("Router stamp group contains mixed launch identities");
+  }
+  return { components, route, launch, launchLog };
+}
+
+export function parseLaunchStampReceipt(
+  anchor: LaunchStampAnchor,
+  receipt: TransactionReceipt,
+): ParsedLaunchStampReceipt {
+  if (
+    receipt.status !== "success" ||
+    !sameHex(receipt.transactionHash, anchor.transactionHash) ||
+    receipt.blockNumber !== anchor.blockNumber ||
+    receipt.transactionIndex !== anchor.transactionIndex ||
+    !sameHex(requireHex(receipt.blockHash, "Receipt block hash"), anchor.blockHash)
+  ) {
+    fail("Launch Stamp receipt provenance mismatch");
+  }
+
+  const ordered = [...receipt.logs].sort(
+    (left, right) =>
+      requireLogIndex(left.logIndex, "Receipt log index") -
+      requireLogIndex(right.logIndex, "Receipt log index"),
+  );
+  const runs: Log[][] = [];
+  let current: Log[] = [];
+  for (const log of ordered) {
+    if (isAddressEqual(log.address, LAUNCH_STAMP_ROUTER_ADDRESS)) {
+      const previous = current.at(-1);
+      if (
+        previous &&
+        requireLogIndex(log.logIndex, "Router log index") !==
+          requireLogIndex(previous.logIndex, "Router log index") + 1
+      ) {
+        runs.push(current);
+        current = [];
+      }
+      current.push(log);
+    } else if (current.length > 0) {
+      runs.push(current);
+      current = [];
+    }
+  }
+  if (current.length > 0) runs.push(current);
+  const groups = runs.map(parseRouterRun);
+  const matches = groups.filter(({ launch }) =>
+    launch.logIndex === anchor.logIndex &&
+    sameHex(launch.launchId, anchor.launchId)
+  );
+  if (matches.length !== 1) fail("Launch Stamp anchor has no unique receipt group");
+  const group = matches[0];
+  if (
+    !sameHex(group.launch.token, anchor.token) ||
+    !sameHex(group.launch.hook, anchor.hook) ||
+    !sameHex(group.launch.poolManager, anchor.poolManager) ||
+    !sameHex(group.launch.poolId, anchor.poolId) ||
+    !sameHex(group.launch.stampHash, anchor.stampHash) ||
+    group.launch.transactionIndex !== anchor.transactionIndex
+  ) {
+    fail("Launch Stamp anchor arguments differ from its receipt");
+  }
+
+  const matchingInitializes = ordered.filter((log) =>
+    isAddressEqual(log.address, LAUNCH_STAMP_POOL_MANAGER_ADDRESS) &&
+    sameHex(log.topics[0] ?? "", POOL_MANAGER_INITIALIZE_TOPIC) &&
+    requireLogIndex(log.logIndex, "Initialize log index") <
+      (group.components[0]?.logIndex ?? 0) &&
+    sameHex(log.topics[1] ?? "", anchor.poolId)
+  );
+  if (matchingInitializes.length !== 1) {
+    fail("Launch Stamp receipt must contain exactly one prior pool initialization");
+  }
+  const initialize = matchingInitializes[0] as Log;
+  const decoded = decodeEventLog({
+    abi: [poolManagerInitializeEvent],
+    data: initialize.data,
+    topics: initialize.topics,
+    strict: true,
+  });
+  const poolKey = {
+    currency0: getAddress(decoded.args.currency0),
+    currency1: getAddress(decoded.args.currency1),
+    fee: Number(decoded.args.fee),
+    tickSpacing: Number(decoded.args.tickSpacing),
+    hooks: getAddress(decoded.args.hooks),
+  } satisfies LaunchStampPoolKey;
+  if (
+    !sameHex(decoded.args.id, anchor.poolId) ||
+    !isAddressEqual(poolKey.hooks, anchor.hook) ||
+    !sameHex(computeOfficialV4PoolId(poolKey), anchor.poolId)
+  ) {
+    fail("Pool initialization does not reconstruct the stamped PoolKey");
+  }
+  return {
+    components: group.components,
+    route: group.route,
+    poolKey,
+    initializeLogIndex: requireLogIndex(
+      initialize.logIndex,
+      "Initialize log index",
+    ),
+  };
+}
+
+async function readRouterState(
+  client: LaunchStampReaderClient,
+  anchor: LaunchStampAnchor,
+  poolKey: LaunchStampPoolKey,
+) {
+  const blockNumber = anchor.blockNumber;
+  const [chainId, poolManager, record, tokenLaunchId, poolLaunchId, tokenProof,
+    computedPoolKeyHash] = await Promise.all([
+    client.readContract({
+      address: LAUNCH_STAMP_ROUTER_ADDRESS,
+      abi: launchStampRouterReadAbi,
+      functionName: "CHAIN_ID",
+      blockNumber,
+    }),
+    client.readContract({
+      address: LAUNCH_STAMP_ROUTER_ADDRESS,
+      abi: launchStampRouterReadAbi,
+      functionName: "POOL_MANAGER",
+      blockNumber,
+    }),
+    client.readContract({
+      address: LAUNCH_STAMP_ROUTER_ADDRESS,
+      abi: launchStampRouterReadAbi,
+      functionName: "launchStamp",
+      args: [anchor.launchId],
+      blockNumber,
+    }),
+    client.readContract({
+      address: LAUNCH_STAMP_ROUTER_ADDRESS,
+      abi: launchStampRouterReadAbi,
+      functionName: "launchIdByToken",
+      args: [anchor.token],
+      blockNumber,
+    }),
+    client.readContract({
+      address: LAUNCH_STAMP_ROUTER_ADDRESS,
+      abi: launchStampRouterReadAbi,
+      functionName: "launchIdByPool",
+      args: [LAUNCH_STAMP_POOL_MANAGER_ADDRESS, anchor.poolId],
+      blockNumber,
+    }),
+    client.readContract({
+      address: LAUNCH_STAMP_ROUTER_ADDRESS,
+      abi: launchStampRouterReadAbi,
+      functionName: "stampProof",
+      args: [anchor.token],
+      blockNumber,
+    }),
+    client.readContract({
+      address: LAUNCH_STAMP_ROUTER_ADDRESS,
+      abi: launchStampRouterReadAbi,
+      functionName: "computePoolKeyHash",
+      args: [poolKey],
+      blockNumber,
+    }),
+  ]);
+  return {
+    chainId,
+    poolManager,
+    record: record as StampRecord,
+    tokenLaunchId,
+    poolLaunchId,
+    tokenProof,
+    computedPoolKeyHash,
+  };
+}
+
+function validateRouterState(
+  anchor: LaunchStampAnchor,
+  parsed: ParsedLaunchStampReceipt,
+  state: Awaited<ReturnType<typeof readRouterState>>,
+) {
+  const record = state.record;
+  if (
+    state.chainId !== 1n ||
+    !isAddressEqual(state.poolManager, LAUNCH_STAMP_POOL_MANAGER_ADDRESS) ||
+    !sameHex(state.tokenLaunchId, anchor.launchId) ||
+    !sameHex(state.poolLaunchId, anchor.launchId) ||
+    !sameHex(state.tokenProof[0], anchor.launchId) ||
+    !sameHex(state.tokenProof[1], anchor.stampHash) ||
+    !sameHex(state.computedPoolKeyHash, record.poolKeyHash) ||
+    record.kind !== parsed.route.kind ||
+    !isAddressEqual(record.token, anchor.token) ||
+    !isAddressEqual(record.hook, anchor.hook) ||
+    !isAddressEqual(record.poolManager, LAUNCH_STAMP_POOL_MANAGER_ADDRESS) ||
+    !sameHex(record.poolId, anchor.poolId) ||
+    !sameHex(record.routePayloadHash, parsed.route.routePayloadHash) ||
+    !sameHex(record.expectedResultHash, parsed.route.expectedResultHash) ||
+    !sameHex(record.permitDigest, parsed.route.permitDigest) ||
+    !sameHex(record.stampHash, anchor.stampHash) ||
+    record.componentSetHash === ZERO_HASH ||
+    record.poolKeyHash === ZERO_HASH ||
+    record.routeLauncherRuntimeCodeHash === ZERO_HASH ||
+    record.launchWallet === "0x0000000000000000000000000000000000000000" ||
+    record.routeLauncher === "0x0000000000000000000000000000000000000000"
+  ) {
+    fail("Launch Stamp Router getter bundle does not match the receipt");
+  }
+  return record;
+}
+
+async function verifyComponents(
+  client: LaunchStampReaderClient,
+  anchor: LaunchStampAnchor,
+  parsed: ParsedLaunchStampReceipt,
+  kind: "custom-graph" | "classic",
+) {
+  const addresses = new Set<string>();
+  let tokenSeen = false;
+  let hookSeen = false;
+  const components = await mapWithConcurrency(
+    parsed.components,
+    COMPONENT_CONCURRENCY,
+    async (component): Promise<LaunchStampProvenanceV1["components"][number]> => {
+      const key = component.component.toLowerCase();
+      if (addresses.has(key)) fail("Launch Stamp contains duplicate components");
+      addresses.add(key);
+      const componentKind = component.kind === 1
+        ? "token"
+        : component.kind === 2 ? "hook" : "other";
+      const sharedHook = kind === "classic" &&
+        componentKind === "hook" &&
+        isAddressEqual(component.component, anchor.hook);
+      const scope = sharedHook ? "shared-infrastructure" : "exclusive";
+      if (componentKind === "token" && isAddressEqual(component.component, anchor.token)) {
+        tokenSeen = true;
+      }
+      if (componentKind === "hook" && isAddressEqual(component.component, anchor.hook)) {
+        hookSeen = true;
+      }
+      await assertRuntimeCodeHash(
+        client,
+        component.component,
+        component.runtimeCodeHash,
+        anchor.blockNumber,
+        `Component ${component.component}`,
+      );
+      if (sharedHook) {
+        const priorExclusiveLaunchId = await client.readContract({
+          address: LAUNCH_STAMP_ROUTER_ADDRESS,
+          abi: launchStampRouterReadAbi,
+          functionName: "launchIdByComponent",
+          args: [component.component],
+          blockNumber: anchor.blockNumber,
+        });
+        if (!sameHex(priorExclusiveLaunchId, ZERO_HASH)) {
+          fail("Classic shared hook is already bound as an exclusive component");
+        }
+        return {
+          address: component.component,
+          kind: componentKind,
+          scope,
+          runtimeCodeHash: component.runtimeCodeHash,
+          logIndex: component.logIndex,
+          exclusiveProof: null,
+        };
+      }
+      const [launchId, runtimeCodeHash, proof] = await Promise.all([
+        client.readContract({
+          address: LAUNCH_STAMP_ROUTER_ADDRESS,
+          abi: launchStampRouterReadAbi,
+          functionName: "launchIdByComponent",
+          args: [component.component],
+          blockNumber: anchor.blockNumber,
+        }),
+        client.readContract({
+          address: LAUNCH_STAMP_ROUTER_ADDRESS,
+          abi: launchStampRouterReadAbi,
+          functionName: "componentRuntimeCodeHash",
+          args: [component.component],
+          blockNumber: anchor.blockNumber,
+        }),
+        client.readContract({
+          address: LAUNCH_STAMP_ROUTER_ADDRESS,
+          abi: launchStampRouterReadAbi,
+          functionName: "stampProof",
+          args: [component.component],
+          blockNumber: anchor.blockNumber,
+        }),
+      ]);
+      if (
+        !sameHex(launchId, anchor.launchId) ||
+        !sameHex(runtimeCodeHash, component.runtimeCodeHash) ||
+        !sameHex(proof[0], anchor.launchId) ||
+        !sameHex(proof[1], anchor.stampHash)
+      ) {
+        fail(`Exclusive component proof mismatch for ${component.component}`);
+      }
+      return {
+        address: component.component,
+        kind: componentKind,
+        scope,
+        runtimeCodeHash: component.runtimeCodeHash,
+        logIndex: component.logIndex,
+        exclusiveProof: {
+          launchId: proof[0],
+          stampHash: proof[1],
+        },
+      };
+    },
+  );
+  if (!tokenSeen || !hookSeen) {
+    fail("Launch Stamp is missing its canonical token or hook component");
+  }
+  return components;
+}
+
+async function optionalRead<T>(reader: () => Promise<T>): Promise<T | null> {
+  try {
+    return await reader();
+  } catch {
+    return null;
+  }
+}
+
+function normalizedDisplayText(value: unknown) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized && !hasUnsafeDisplayCharacters(normalized)
+    ? normalized
+    : null;
+}
+
+function normalizedTokenName(value: unknown) {
+  const normalized = normalizedDisplayText(value);
+  return normalized &&
+      characterLength(normalized) <= MAX_TOKEN_NAME_CHARACTERS &&
+      utf8ByteLength(normalized) <= MAX_TOKEN_NAME_BYTES
+    ? normalized
+    : null;
+}
+
+function normalizedTokenSymbol(value: unknown) {
+  const normalized = normalizedDisplayText(value);
+  return normalized &&
+      utf8ByteLength(normalized) <= MAX_TOKEN_SYMBOL_BYTES &&
+      isValidTokenSymbol(normalized)
+    ? normalized
+    : null;
+}
+
+function normalizedDescription(value: unknown) {
+  const normalized = normalizedDisplayText(value);
+  return normalized && utf8ByteLength(normalized) <= MAX_TOKEN_DESCRIPTION_BYTES
+    ? normalized
+    : null;
+}
+
+function metadataField(
+  value: unknown,
+  index: number,
+  key: "description" | "website" | "image" | "extraData",
+) {
+  if (Array.isArray(value)) return value[index];
+  if (typeof value !== "object" || value === null) return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function normalizedSocialExtraData(value: unknown): Hex | null {
+  if (
+    typeof value !== "string" ||
+    value.length > 2 + MAX_SOCIAL_EXTRA_DATA_BYTES * 2 ||
+    !/^0x(?:[0-9a-f]{2})+$/iu.test(value)
+  ) {
+    return null;
+  }
+  const extraData = value as Hex;
+  return decodeSocialMetadata(extraData) ? extraData : null;
+}
+
+function addressSymbolFallback(address: Address) {
+  return `A${address.slice(-9)}`.toUpperCase();
+}
+
+function optionalBigInt(value: unknown) {
+  try {
+    const normalized = BigInt(value as bigint);
+    return normalized >= 0n ? normalized : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readTokenAndPoolState(
+  client: LaunchStampReaderClient,
+  deployment: ReadyOnchainDeployment,
+  anchor: LaunchStampAnchor,
+  blockNumber: bigint,
+) {
+  const [name, symbol, decimals, totalSupply, metadata, slot0, liquidity] =
+    await Promise.all([
+      optionalRead(() => client.readContract({
+        address: anchor.token,
+        abi: uerc20ReadAbi,
+        functionName: "name",
+        blockNumber,
+      })),
+      optionalRead(() => client.readContract({
+        address: anchor.token,
+        abi: uerc20ReadAbi,
+        functionName: "symbol",
+        blockNumber,
+      })),
+      optionalRead(() => client.readContract({
+        address: anchor.token,
+        abi: uerc20ReadAbi,
+        functionName: "decimals",
+        blockNumber,
+      })),
+      optionalRead(() => client.readContract({
+        address: anchor.token,
+        abi: uerc20ReadAbi,
+        functionName: "totalSupply",
+        blockNumber,
+      })),
+      optionalRead(() => client.readContract({
+        address: anchor.token,
+        abi: uerc20ReadAbi,
+        functionName: "metadata",
+        blockNumber,
+      })),
+      client.readContract({
+        address: deployment.stateView,
+        abi: stateViewReadAbi,
+        functionName: "getSlot0",
+        args: [anchor.poolId],
+        blockNumber,
+      }),
+      client.readContract({
+        address: deployment.stateView,
+        abi: stateViewReadAbi,
+        functionName: "getLiquidity",
+        args: [anchor.poolId],
+        blockNumber,
+      }),
+  ]);
+  if (slot0[0] === 0n) fail("Stamped pool is not initialized in StateView");
+  const normalizedName = normalizedTokenName(name) ??
+    `Token ${anchor.token.slice(0, 8)}…${anchor.token.slice(-4)}`;
+  const normalizedSymbol = normalizedTokenSymbol(symbol) ??
+    addressSymbolFallback(anchor.token);
+  const parsedDecimals = decimals === null ? null : Number(decimals);
+  const normalizedDecimals = parsedDecimals !== null &&
+      Number.isSafeInteger(parsedDecimals) &&
+      parsedDecimals >= 0 &&
+      parsedDecimals <= 255
+    ? parsedDecimals
+    : null;
+  const normalizedSupply = totalSupply === null ? null : optionalBigInt(totalSupply);
+  const description = normalizedDescription(
+    metadataField(metadata, 0, "description"),
+  );
+  const website = sanitizeWebsiteUrl(metadataField(metadata, 1, "website"));
+  const imageUrl = sanitizeImageUrl(metadataField(metadata, 2, "image"));
+  const metadataExtraData = normalizedSocialExtraData(
+    metadataField(metadata, 3, "extraData"),
+  );
+  const links = buildTokenLinks(website, metadataExtraData ?? "0x");
+  return {
+    name: normalizedName,
+    symbol: normalizedSymbol,
+    description,
+    imageUrl,
+    links: links.length > 0 ? links : undefined,
+    metadataExtraData,
+    decimals: normalizedDecimals,
+    totalSupplyRaw: normalizedSupply?.toString(),
+    totalSupply: normalizedSupply === null || normalizedDecimals === null
+      ? undefined
+      : formatUnits(normalizedSupply, normalizedDecimals),
+    currentTick: Number(slot0[1]),
+    protocolFeePips: Number(slot0[2]),
+    lpFeePips: Number(slot0[3]),
+    activeLiquidity: liquidity.toString(),
+  };
+}
+
+export async function hydrateLaunchStampAnchor(
+  deployment: ReadyOnchainDeployment,
+  anchor: LaunchStampAnchor,
+  options: LaunchStampReaderOptions & Readonly<{
+    latestBlock?: LaunchStampCanonicalBlock;
+    stateBlock?: LaunchStampCanonicalBlock;
+    receipt?: TransactionReceipt;
+  }> = {},
+): Promise<HydratedLaunchStamp> {
+  requireCanonicalDeployment(deployment);
+  if (
+    anchor.blockNumber < LAUNCH_STAMP_ROUTER_START_BLOCK ||
+    !isAddressEqual(anchor.poolManager, LAUNCH_STAMP_POOL_MANAGER_ADDRESS)
+  ) {
+    fail("Launch Stamp anchor is outside the canonical Router binding");
+  }
+  const client = options.client ?? createReaderClient(deployment);
+  const chainId = await client.getChainId();
+  if (chainId !== 1) fail("Launch Stamp RPC is not Ethereum mainnet");
+  const latestNumber = options.latestBlock?.number ?? (await client.getBlockNumber());
+  if (latestNumber < anchor.blockNumber + LAUNCH_STAMP_FINALITY_CONFIRMATIONS) {
+    fail("Launch Stamp anchor does not have 64 confirmations");
+  }
+  const latestBlock = options.latestBlock ?? await canonicalBlock(client, latestNumber);
+  if (latestBlock.number !== latestNumber) fail("Latest block proof mismatch");
+  const stateBlock = options.stateBlock ?? await canonicalBlock(
+    client,
+    latestNumber - LAUNCH_STAMP_FINALITY_CONFIRMATIONS,
+  );
+  if (
+    stateBlock.number > latestNumber - LAUNCH_STAMP_FINALITY_CONFIRMATIONS ||
+    stateBlock.number < anchor.blockNumber
+  ) {
+    fail("Launch Stamp state block is outside the finalized scan boundary");
+  }
+  const receipt = options.receipt ?? await client.getTransactionReceipt({
+    hash: anchor.transactionHash,
+  });
+  const parsed = parseLaunchStampReceipt(anchor, receipt);
+  const launchBlock = await canonicalBlock(client, anchor.blockNumber);
+  if (!sameHex(launchBlock.hash, anchor.blockHash)) {
+    fail("Launch Stamp anchor block is no longer canonical");
+  }
+  await Promise.all([
+    assertRuntimeCodeHash(
+      client,
+      LAUNCH_STAMP_ROUTER_ADDRESS,
+      LAUNCH_STAMP_ROUTER_RUNTIME_CODE_HASH,
+      anchor.blockNumber,
+      "Launch Stamp Router",
+    ),
+    assertRuntimeCodeHash(
+      client,
+      LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+      LAUNCH_STAMP_POOL_MANAGER_RUNTIME_CODE_HASH,
+      anchor.blockNumber,
+      "PoolManager",
+    ),
+    assertRuntimeCodeHash(
+      client,
+      deployment.stateView,
+      deployment.stateViewRuntimeCodeHash,
+      stateBlock.number,
+      "StateView",
+    ),
+  ]);
+  const state = await readRouterState(client, anchor, parsed.poolKey);
+  const record = validateRouterState(anchor, parsed, state);
+  const kind = parsed.route.kind === 1 ? "custom-graph" : "classic";
+  const components = await verifyComponents(client, anchor, parsed, kind);
+  await assertRuntimeCodeHash(
+    client,
+    record.routeLauncher,
+    record.routeLauncherRuntimeCodeHash,
+    anchor.blockNumber,
+    "Launch route launcher",
+  );
+  const tokenAndPool = await readTokenAndPoolState(
+    client,
+    deployment,
+    anchor,
+    stateBlock.number,
+  );
+  const provenance: LaunchStampProvenanceV1 = {
+    schemaVersion: "programmable.launch-stamp-provenance.v1",
+    chainId: 1,
+    routerAddress: LAUNCH_STAMP_ROUTER_ADDRESS,
+    routerRuntimeCodeHash: LAUNCH_STAMP_ROUTER_RUNTIME_CODE_HASH,
+    routerStartBlock: LAUNCH_STAMP_ROUTER_START_BLOCK.toString(),
+    finalityConfirmations: Number(LAUNCH_STAMP_FINALITY_CONFIRMATIONS),
+    kind,
+    launchId: anchor.launchId,
+    stampHash: anchor.stampHash,
+    launchWallet: record.launchWallet,
+    transactionHash: anchor.transactionHash,
+    blockNumber: anchor.blockNumber.toString(),
+    blockHash: anchor.blockHash,
+    transactionIndex: anchor.transactionIndex,
+    routeLogIndex: parsed.route.logIndex,
+    launchLogIndex: anchor.logIndex,
+    finalizedAtBlockNumber: latestBlock.number.toString(),
+    finalizedAtBlockHash: latestBlock.hash,
+    poolManagerAddress: LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+    poolId: anchor.poolId,
+    poolKey: parsed.poolKey,
+    poolKeyHash: record.poolKeyHash,
+    componentSetHash: record.componentSetHash,
+    routePayloadHash: record.routePayloadHash,
+    routeLauncherAddress: record.routeLauncher,
+    routeLauncherRuntimeCodeHash: record.routeLauncherRuntimeCodeHash,
+    expectedResultHash: record.expectedResultHash,
+    permitDigest: record.permitDigest,
+    components,
+    tokenProof: {
+      tokenAddress: anchor.token,
+      launchId: anchor.launchId,
+      stampHash: anchor.stampHash,
+    },
+    poolProof: {
+      poolManagerAddress: LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+      poolId: anchor.poolId,
+      launchId: anchor.launchId,
+      stampHash: anchor.stampHash,
+    },
+  };
+  const token: LauncherToken = {
+    id: `1:${anchor.token.toLowerCase()}`,
+    name: tokenAndPool.name,
+    symbol: tokenAndPool.symbol,
+    ...(tokenAndPool.description ? { description: tokenAndPool.description } : {}),
+    ...(tokenAndPool.imageUrl ? { imageUrl: tokenAndPool.imageUrl } : {}),
+    ...(tokenAndPool.links ? { links: tokenAndPool.links } : {}),
+    tokenAddress: anchor.token,
+    hookAddress: anchor.hook,
+    poolId: anchor.poolId,
+    creatorAddress: record.launchWallet,
+    launchBlockNumber: anchor.blockNumber.toString(),
+    launchTransactionHash: anchor.transactionHash,
+    launchTransactionIndex: anchor.transactionIndex,
+    launchLogIndex: anchor.logIndex,
+    launchedAt: new Date(Number(launchBlock.timestamp) * 1_000).toISOString(),
+    ...(tokenAndPool.totalSupply ? { totalSupply: tokenAndPool.totalSupply } : {}),
+    ...(tokenAndPool.totalSupplyRaw
+      ? { totalSupplyRaw: tokenAndPool.totalSupplyRaw }
+      : {}),
+    ...(tokenAndPool.decimals === null
+      ? {}
+      : { tokenDecimals: tokenAndPool.decimals }),
+    activeLiquidity: tokenAndPool.activeLiquidity,
+    currentTick: tokenAndPool.currentTick,
+    protocolFeePips: tokenAndPool.protocolFeePips,
+    lpFeePips: tokenAndPool.lpFeePips,
+    totalSwapFeeBps: null,
+    launchModel: kind === "custom-graph" ? "custom-graph" : "classic",
+    launchModelVersion: "programmable-launch-stamp-router-v1",
+    liquidityPath: "programmable-v4",
+    ...(tokenAndPool.metadataExtraData
+      ? { metadataExtraData: tokenAndPool.metadataExtraData }
+      : {}),
+    launchStampProvenance: provenance,
+  };
+  return { token, launchStampProvenance: provenance };
+}
+
+function validateSliceCursor(cursor: LaunchStampRouterCursor) {
+  if (!/^(?:0|[1-9]\d*)$/u.test(cursor.blockNumber)) {
+    fail("Launch Stamp Router cursor block is invalid");
+  }
+  const number = BigInt(cursor.blockNumber);
+  if (number < LAUNCH_STAMP_ROUTER_START_BLOCK - 1n) {
+    fail("Launch Stamp Router cursor predates its canonical anchor");
+  }
+  if (
+    number === LAUNCH_STAMP_ROUTER_START_BLOCK - 1n &&
+    !sameHex(cursor.blockHash, LAUNCH_STAMP_ROUTER_INITIAL_CURSOR.blockHash)
+  ) {
+    fail("Launch Stamp Router initial cursor hash mismatch");
+  }
+  return number;
+}
+
+export function createInitialLaunchStampRouterSlice(): LaunchStampRouterSlice {
+  return {
+    cursor: LAUNCH_STAMP_ROUTER_INITIAL_CURSOR,
+    tokens: [],
+  };
+}
+
+export async function advanceLaunchStampRouterSlice(
+  deployment: ReadyOnchainDeployment,
+  slice: LaunchStampRouterSlice,
+  options: LaunchStampReaderOptions = {},
+): Promise<AdvanceLaunchStampRouterResult> {
+  requireCanonicalDeployment(deployment);
+  const client = options.client ?? createReaderClient(deployment);
+  if ((await client.getChainId()) !== 1) {
+    fail("Launch Stamp RPC is not Ethereum mainnet");
+  }
+  let workingSlice = slice;
+  let cursorNumber = validateSliceCursor(workingSlice.cursor);
+  let cursorBlock = await canonicalBlock(client, cursorNumber);
+  let rebuiltAfterReorg = false;
+  if (!sameHex(cursorBlock.hash, slice.cursor.blockHash)) {
+    if (cursorNumber === LAUNCH_STAMP_ROUTER_START_BLOCK - 1n) {
+      fail("Launch Stamp Router initial cursor is no longer canonical");
+    }
+    workingSlice = createInitialLaunchStampRouterSlice();
+    cursorNumber = LAUNCH_STAMP_ROUTER_START_BLOCK - 1n;
+    cursorBlock = await canonicalBlock(client, cursorNumber);
+    if (!sameHex(cursorBlock.hash, LAUNCH_STAMP_ROUTER_INITIAL_CURSOR.blockHash)) {
+      fail("Launch Stamp Router canonical rebuild anchor mismatch");
+    }
+    rebuiltAfterReorg = true;
+  }
+  const latestNumber = await client.getBlockNumber();
+  if (latestNumber < LAUNCH_STAMP_FINALITY_CONFIRMATIONS) {
+    fail("Ethereum head is below the Launch Stamp finality depth");
+  }
+  const latestBlock = await canonicalBlock(client, latestNumber);
+  const highestSafeNumber = latestNumber - LAUNCH_STAMP_FINALITY_CONFIRMATIONS;
+  if (highestSafeNumber < LAUNCH_STAMP_ROUTER_START_BLOCK - 1n) {
+    fail("Ethereum head does not finalize the canonical Router deployment");
+  }
+  if (cursorNumber > highestSafeNumber) {
+    fail("Launch Stamp Router cursor is ahead of the 64-confirmation boundary");
+  }
+  let targetNumber = cursorNumber + MAXIMUM_CATCH_UP_BLOCKS < highestSafeNumber
+    ? cursorNumber + MAXIMUM_CATCH_UP_BLOCKS
+    : highestSafeNumber;
+  let targetBlock = await canonicalBlock(client, targetNumber);
+  await Promise.all([
+    assertRuntimeCodeHash(
+      client,
+      LAUNCH_STAMP_ROUTER_ADDRESS,
+      LAUNCH_STAMP_ROUTER_RUNTIME_CODE_HASH,
+      targetNumber,
+      "Launch Stamp Router",
+    ),
+    assertRuntimeCodeHash(
+      client,
+      LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+      LAUNCH_STAMP_POOL_MANAGER_RUNTIME_CODE_HASH,
+      targetNumber,
+      "PoolManager",
+    ),
+  ]);
+  const fromBlock = cursorNumber + 1n;
+  if (fromBlock > targetNumber) {
+    return {
+      slice: workingSlice,
+      scannedFromBlock: null,
+      scannedToBlock: targetNumber.toString(),
+      discovered: 0,
+      hydrated: 0,
+      boundedByDensity: false,
+      rebuiltAfterReorg,
+    };
+  }
+  let anchors = await scanLaunchStampAnchors(client, {
+    fromBlock,
+    toBlock: targetNumber,
+    latestBlock: latestNumber,
+  });
+  let boundedByDensity = false;
+  if (anchors.length > MAXIMUM_ANCHORS_PER_ADVANCE) {
+    const firstDeferredBlock = anchors[MAXIMUM_ANCHORS_PER_ADVANCE]?.blockNumber;
+    if (firstDeferredBlock === undefined || firstDeferredBlock <= fromBlock) {
+      fail("A single block exceeds the bounded Launch Stamp hydration limit");
+    }
+    targetNumber = firstDeferredBlock - 1n;
+    targetBlock = await canonicalBlock(client, targetNumber);
+    anchors = anchors.filter((anchor) => anchor.blockNumber <= targetNumber);
+    if (anchors.length > MAXIMUM_ANCHORS_PER_ADVANCE) {
+      fail("Launch Stamp density could not be reduced at a block boundary");
+    }
+    boundedByDensity = true;
+  }
+  const receiptHashes = [...new Set(
+    anchors.map((anchor) => anchor.transactionHash.toLowerCase()),
+  )] as Hex[];
+  const receipts = new Map<string, TransactionReceipt>();
+  await mapWithConcurrency(
+    receiptHashes,
+    COMPONENT_CONCURRENCY,
+    async (hash) => {
+      const receipt = await client.getTransactionReceipt({ hash });
+      receipts.set(hash.toLowerCase(), receipt);
+    },
+  );
+  const hydrated = await mapWithConcurrency(
+    anchors,
+    HYDRATION_CONCURRENCY,
+    (anchor) => hydrateLaunchStampAnchor(deployment, anchor, {
+      client,
+      latestBlock,
+      stateBlock: targetBlock,
+      receipt: receipts.get(anchor.transactionHash.toLowerCase()),
+    }),
+  );
+  const tokenAddresses = new Set<string>();
+  const launchIds = new Set<string>();
+  const poolIds = new Set<string>();
+  const eventIds = new Set<string>();
+  for (const token of workingSlice.tokens) {
+    const provenance = token.launchStampProvenance;
+    if (!provenance) fail("Launch Stamp Router slice contains an unstamped token");
+    const tokenKey = token.tokenAddress.toLowerCase();
+    const launchKey = provenance.launchId.toLowerCase();
+    const poolKey = `${provenance.poolManagerAddress.toLowerCase()}:${provenance.poolId.toLowerCase()}`;
+    const eventKey = `${provenance.transactionHash.toLowerCase()}:${provenance.launchLogIndex}`;
+    if (
+      tokenAddresses.has(tokenKey) ||
+      launchIds.has(launchKey) ||
+      poolIds.has(poolKey) ||
+      eventIds.has(eventKey)
+    ) {
+      fail("Launch Stamp Router slice contains duplicate provenance");
+    }
+    tokenAddresses.add(tokenKey);
+    launchIds.add(launchKey);
+    poolIds.add(poolKey);
+    eventIds.add(eventKey);
+  }
+  const newTokens: LauncherToken[] = [];
+  for (const result of hydrated) {
+    const tokenKey = result.token.tokenAddress.toLowerCase();
+    const launchKey = result.launchStampProvenance.launchId.toLowerCase();
+    const poolKey = `${result.launchStampProvenance.poolManagerAddress.toLowerCase()}:${result.launchStampProvenance.poolId.toLowerCase()}`;
+    const eventKey = `${result.launchStampProvenance.transactionHash.toLowerCase()}:${result.launchStampProvenance.launchLogIndex}`;
+    if (
+      tokenAddresses.has(tokenKey) ||
+      launchIds.has(launchKey) ||
+      poolIds.has(poolKey) ||
+      eventIds.has(eventKey)
+    ) {
+      fail("Launch Stamp Router advancement conflicts with persisted provenance");
+    }
+    tokenAddresses.add(tokenKey);
+    launchIds.add(launchKey);
+    poolIds.add(poolKey);
+    eventIds.add(eventKey);
+    newTokens.push(result.token);
+  }
+  return {
+    slice: {
+      cursor: {
+        blockNumber: targetNumber.toString(),
+        blockHash: targetBlock.hash,
+      },
+      tokens: [...workingSlice.tokens, ...newTokens],
+    },
+    scannedFromBlock: fromBlock.toString(),
+    scannedToBlock: targetNumber.toString(),
+    discovered: anchors.length,
+    hydrated: hydrated.length,
+    boundedByDensity,
+    rebuiltAfterReorg,
+  };
+}

--- a/lib/alchemy/live-market.server.ts
+++ b/lib/alchemy/live-market.server.ts
@@ -15,7 +15,10 @@ import {
 } from "../onchain/math";
 import type { ExploreSnapshot, ReadyOnchainDeployment } from "../onchain/types";
 import { usdValueFromWei } from "../onchain/usd";
-import type { LauncherToken } from "../tokens";
+import {
+  isLaunchStampProvenanceV1,
+  type LauncherToken,
+} from "../tokens";
 
 const LIVE_POOL_STATE_TTL_MS = 5_000;
 const MAX_LIVE_POOL_STATE_ENTRIES = 256;
@@ -25,6 +28,7 @@ type LivePoolState = Readonly<{
   tick: number;
   protocolFeePips: number;
   lpFeePips: number;
+  activeLiquidity: bigint;
   blockNumber: bigint;
 }>;
 
@@ -52,17 +56,80 @@ function trimPoolStateCache() {
   }
 }
 
-function validPoolToken(token: LauncherToken) {
+const NATIVE_CURRENCY = "0x0000000000000000000000000000000000000000";
+
+function validLaunchStampForToken(token: LauncherToken) {
+  const stamp = token.launchStampProvenance;
+  if (!stamp) return false;
+  if (
+    !token.creatorAddress ||
+    !token.launchTransactionHash ||
+    !token.launchBlockNumber ||
+    token.launchTransactionIndex === undefined ||
+    token.launchLogIndex === undefined
+  ) return false;
+
+  return isLaunchStampProvenanceV1(stamp, {
+    tokenAddress: token.tokenAddress,
+    hookAddress: token.hookAddress,
+    poolId: token.poolId,
+    launchWallet: token.creatorAddress,
+    transactionHash: token.launchTransactionHash,
+    blockNumber: token.launchBlockNumber,
+    transactionIndex: token.launchTransactionIndex,
+    launchLogIndex: token.launchLogIndex,
+  });
+}
+
+function hasNativeTokenPriceOrientation(token: LauncherToken) {
+  const stamp = token.launchStampProvenance;
+  if (stamp) {
+    return validLaunchStampForToken(token) &&
+      stamp.poolKey.currency0.toLowerCase() === NATIVE_CURRENCY &&
+      stamp.poolKey.currency1.toLowerCase() === token.tokenAddress.toLowerCase();
+  }
+
+  // Existing canonical read models are native/token pools. A Custom Graph is
+  // never allowed to inherit that assumption without its complete PoolKey.
+  return token.launchModel !== "custom-graph";
+}
+
+function validPoolStateToken(token: LauncherToken) {
+  if (!/^0x[0-9a-f]{64}$/iu.test(token.poolId)) return false;
+  if (token.launchStampProvenance) return validLaunchStampForToken(token);
+  return token.launchModel !== "stock-paired" &&
+    token.launchModel !== "custom-graph";
+}
+
+function validValuationToken(token: LauncherToken) {
   return (
-    token.launchModel !== "stock-paired" &&
+    hasNativeTokenPriceOrientation(token) &&
     typeof token.totalSupplyRaw === "string" &&
     /^(?:0|[1-9]\d*)$/u.test(token.totalSupplyRaw) &&
     typeof token.tokenDecimals === "number" &&
     Number.isInteger(token.tokenDecimals) &&
     token.tokenDecimals >= 0 &&
-    token.tokenDecimals <= 255 &&
-    /^0x[0-9a-f]{64}$/iu.test(token.poolId)
+    token.tokenDecimals <= 255
   );
+}
+
+function withoutNativeValuation(token: LauncherToken): LauncherToken {
+  const withoutValuation = { ...token };
+  delete withoutValuation.tokenPriceEth;
+  delete withoutValuation.tokenPriceEthWei;
+  delete withoutValuation.tokenPriceUsdWad;
+  delete withoutValuation.tokenPriceQuote;
+  delete withoutValuation.tokenPriceQuoteWad;
+  delete withoutValuation.marketCapEth;
+  delete withoutValuation.marketCapEthWei;
+  delete withoutValuation.marketCapQuote;
+  delete withoutValuation.marketCapQuoteWad;
+  delete withoutValuation.indexedMarketCapEth;
+  delete withoutValuation.indexedMarketCapEthWei;
+  delete withoutValuation.indexedMarketCapUsdWad;
+  delete withoutValuation.indexedValuationBlockNumber;
+  delete withoutValuation.fdvUsdWad;
+  return withoutValuation;
 }
 
 function snapshotBlock(snapshot: ExploreSnapshot) {
@@ -72,12 +139,40 @@ function snapshotBlock(snapshot: ExploreSnapshot) {
   return BigInt(snapshot.blockNumber);
 }
 
+function poolStateCacheKey(input: {
+  deployment: ReadyOnchainDeployment;
+  blockNumber: bigint;
+  poolId: string;
+}) {
+  return [
+    input.deployment.chainId,
+    input.deployment.stateView.toLowerCase(),
+    input.blockNumber.toString(),
+    input.poolId.toLowerCase(),
+  ].join(":");
+}
+
 function applyLivePoolState(
   token: LauncherToken,
   state: LivePoolState | null,
   snapshot: ExploreSnapshot,
 ) {
-  if (!state || !validPoolToken(token)) return token;
+  if (!state || !validPoolStateToken(token)) {
+    return token;
+  }
+
+  const currentState = {
+    ...(token.launchStampProvenance
+      ? withoutNativeValuation(token)
+      : token),
+    currentTick: state.tick,
+    activeLiquidity: state.activeLiquidity.toString(),
+    protocolFeePips: state.protocolFeePips,
+    lpFeePips: state.lpFeePips,
+  } satisfies LauncherToken;
+  if (state.activeLiquidity <= 0n || !validValuationToken(token)) {
+    return withoutNativeValuation(currentState);
+  }
 
   const tokenDecimals = token.tokenDecimals as number;
   const totalSupplyRaw = BigInt(token.totalSupplyRaw as string);
@@ -105,15 +200,12 @@ function applyLivePoolState(
     : undefined;
 
   return {
-    ...token,
+    ...currentState,
     tokenPriceEthWei: tokenPriceEthWei.toString(),
     tokenPriceEth: formatUnits(tokenPriceEthWei, 18),
     marketCapEthWei: marketCapEthWei.toString(),
     marketCapEth: formatUnits(marketCapEthWei, 18),
     indexedValuationBlockNumber: state.blockNumber.toString(),
-    currentTick: state.tick,
-    protocolFeePips: state.protocolFeePips,
-    lpFeePips: state.lpFeePips,
     ...(tokenPriceUsdWad === undefined
       ? {}
       : { tokenPriceUsdWad: tokenPriceUsdWad.toString() }),
@@ -128,16 +220,21 @@ export async function enrichTokensWithAlchemyPoolState(input: {
   snapshot: ExploreSnapshot;
   tokens: readonly LauncherToken[];
 }) {
-  const eligible = input.tokens.filter(validPoolToken);
+  const eligible = input.tokens.filter(validPoolStateToken);
   if (eligible.length === 0) return [...input.tokens];
 
   const blockNumber = snapshotBlock(input.snapshot);
   const states = new Map<string, Promise<LivePoolState | null>>();
   const missing: LauncherToken[] = [];
   for (const token of eligible) {
-    const key = token.poolId.toLowerCase();
-    const cached = currentCacheEntry(key);
-    if (cached) states.set(key, cached);
+    const poolId = token.poolId.toLowerCase();
+    const cacheKey = poolStateCacheKey({
+      deployment: input.deployment,
+      blockNumber,
+      poolId,
+    });
+    const cached = currentCacheEntry(cacheKey);
+    if (cached) states.set(poolId, cached);
     else missing.push(token);
   }
 
@@ -149,8 +246,8 @@ export async function enrichTokensWithAlchemyPoolState(input: {
         timeout: 12_000,
       }),
     });
-    const batch = client
-      .multicall({
+    const batch = Promise.all([
+      client.multicall({
         allowFailure: true,
         blockNumber,
         contracts: missing.map((token) => ({
@@ -159,17 +256,36 @@ export async function enrichTokensWithAlchemyPoolState(input: {
           functionName: "getSlot0" as const,
           args: [token.poolId as Hex],
         })),
-      })
-      .then((results) =>
-        results.map((result): LivePoolState | null => {
-          if (result.status !== "success") return null;
-          const [sqrtPriceX96, tick, protocolFeePips, lpFeePips] = result.result;
+      }),
+      client.multicall({
+        allowFailure: true,
+        blockNumber,
+        contracts: missing.map((token) => ({
+          address: input.deployment.stateView,
+          abi: stateViewReadAbi,
+          functionName: "getLiquidity" as const,
+          args: [token.poolId as Hex],
+        })),
+      }),
+    ])
+      .then(([slot0Results, liquidityResults]) =>
+        missing.map((_, index): LivePoolState | null => {
+          const slot0 = slot0Results[index];
+          const liquidity = liquidityResults[index];
+          if (
+            slot0?.status !== "success" ||
+            liquidity?.status !== "success"
+          ) {
+            return null;
+          }
+          const [sqrtPriceX96, tick, protocolFeePips, lpFeePips] = slot0.result;
           if (sqrtPriceX96 <= 0n) return null;
           return {
             sqrtPriceX96,
             tick,
             protocolFeePips,
             lpFeePips,
+            activeLiquidity: liquidity.result,
             blockNumber,
           };
         }),
@@ -177,13 +293,18 @@ export async function enrichTokensWithAlchemyPoolState(input: {
       .catch(() => missing.map(() => null));
 
     missing.forEach((token, index) => {
-      const key = token.poolId.toLowerCase();
+      const poolId = token.poolId.toLowerCase();
+      const cacheKey = poolStateCacheKey({
+        deployment: input.deployment,
+        blockNumber,
+        poolId,
+      });
       const value = batch.then((results) => results[index] ?? null);
-      livePoolStateCache.set(key, {
+      livePoolStateCache.set(cacheKey, {
         expiresAt: Date.now() + LIVE_POOL_STATE_TTL_MS,
         value,
       });
-      states.set(key, value);
+      states.set(poolId, value);
     });
     trimPoolStateCache();
   }

--- a/lib/alchemy/profile.server.ts
+++ b/lib/alchemy/profile.server.ts
@@ -42,11 +42,34 @@ type RecentClaimCursor = Readonly<{
 
 const recentClaimCursors = new Map<string, Promise<RecentClaimCursor>>();
 
-function isDirectClassicReward(token: LauncherToken) {
+function isUnsignedInteger(value: unknown): value is string {
+  return typeof value === "string" && /^(0|[1-9]\d*)$/u.test(value);
+}
+
+function isBytes32(value: unknown): value is Hex {
+  return typeof value === "string" && /^0x[0-9a-f]{64}$/iu.test(value);
+}
+
+function isVerifiedLegacyDirectReward(
+  token: LauncherToken,
+  deployment: ReadyOnchainDeployment,
+) {
   return (
-    (token.launchModel === undefined || token.launchModel === "classic") &&
-    token.launchModelVersion !== "classic-v3" &&
-    /^0x[0-9a-f]{64}$/iu.test(token.poolId)
+    token.launchStampProvenance === undefined &&
+    token.launchModel === "classic" &&
+    token.liquidityPath === "meme" &&
+    token.hookAddress.toLowerCase() === deployment.feeHook.toLowerCase() &&
+    isBytes32(token.poolId) &&
+    isBytes32(token.launchHash) &&
+    isBytes32(token.launchTransactionHash) &&
+    typeof token.positionRecipient === "string" &&
+    /^0x[0-9a-f]{40}$/iu.test(token.positionRecipient) &&
+    isUnsignedInteger(token.positionTokenId) &&
+    typeof token.totalSwapFeeBps === "number" &&
+    Number.isSafeInteger(token.totalSwapFeeBps) &&
+    token.totalSwapFeeBps >= 0 &&
+    isUnsignedInteger(token.creatorFeesAccruedWei) &&
+    isUnsignedInteger(token.creatorFeesGeneratedWei)
   );
 }
 
@@ -207,18 +230,21 @@ export async function readAlchemyCreatorProfile(input: {
   model: ExploreReadModel;
 }): Promise<CreatorProfile> {
   if (input.model.status !== "ready") {
-    return buildCreatorProfile(input.model, input.account);
+    return buildCreatorProfile(input.model, input.account, new Set());
   }
 
   const normalizedAccount = input.account.toLowerCase();
   const ownedTokens = input.model.tokens.filter(
     (token) =>
-      token.creatorAddress?.toLowerCase() === normalizedAccount &&
-      isDirectClassicReward(token),
+      token.creatorAddress?.toLowerCase() === normalizedAccount,
+  );
+  const directRewardTokens = ownedTokens.filter((token) =>
+    isVerifiedLegacyDirectReward(token, input.deployment),
   );
   const tokenByPool = new Map(
-    ownedTokens.map((token) => [token.poolId.toLowerCase(), token]),
+    directRewardTokens.map((token) => [token.poolId.toLowerCase(), token]),
   );
+  const directRewardPoolIds = new Set(tokenByPool.keys());
   const liveSnapshot =
     input.model.launchDiscoverySnapshot ?? input.model.snapshot;
   const liveBlock = BigInt(liveSnapshot.blockNumber);
@@ -232,11 +258,11 @@ export async function readAlchemyCreatorProfile(input: {
   });
 
   const [poolStates, recentClaims] = await Promise.all([
-    ownedTokens.length
+    directRewardTokens.length
       ? client.multicall({
           allowFailure: true,
           blockNumber: liveBlock,
-          contracts: ownedTokens.map((token) => ({
+          contracts: directRewardTokens.map((token) => ({
             address: getAddress(token.hookAddress),
             abi: creatorFeeHookReadAbi,
             functionName: "poolFeeConfig" as const,
@@ -250,7 +276,7 @@ export async function readAlchemyCreatorProfile(input: {
       fromBlock: baseBlock + 1n,
       toBlock: liveBlock,
       hookAddresses: [...new Set(
-        ownedTokens.map((token) => token.hookAddress.toLowerCase()),
+        directRewardTokens.map((token) => token.hookAddress.toLowerCase()),
       )].map((address) => getAddress(address)),
       tokenByPool,
     }).catch(() => []),
@@ -278,7 +304,7 @@ export async function readAlchemyCreatorProfile(input: {
   }
 
   const refreshed = new Map<string, LauncherToken>();
-  ownedTokens.forEach((token, index) => {
+  directRewardTokens.forEach((token, index) => {
     const result = poolStates[index];
     if (result?.status !== "success") return;
     const [creator, , , registered, accrued] = result.result;
@@ -296,11 +322,6 @@ export async function readAlchemyCreatorProfile(input: {
   const scopedModel: ExploreReadModel = {
     ...input.model,
     tokens: input.model.tokens
-      .filter(
-        (token) =>
-          token.creatorAddress?.toLowerCase() !== normalizedAccount ||
-          isDirectClassicReward(token),
-      )
       .map(
         (token) =>
           refreshed.get(token.tokenAddress.toLowerCase()) ?? token,
@@ -311,5 +332,9 @@ export async function readAlchemyCreatorProfile(input: {
       ethUsdQuote: input.model.snapshot.ethUsdQuote,
     },
   };
-  return buildCreatorProfile(scopedModel, input.account);
+  return buildCreatorProfile(
+    scopedModel,
+    input.account,
+    directRewardPoolIds,
+  );
 }

--- a/lib/alchemy/router-custom-collision.ts
+++ b/lib/alchemy/router-custom-collision.ts
@@ -1,0 +1,66 @@
+import {
+  isLaunchStampProvenanceV1,
+  type CustomProjectExploreEntry,
+  type LauncherToken,
+} from "../tokens";
+
+function matchingRouterToken(
+  project: CustomProjectExploreEntry,
+  tokens: readonly LauncherToken[],
+) {
+  if (!project.tokenAddress) return null;
+  return tokens.find(
+    (token) => {
+      const stamp = token.launchStampProvenance;
+      return (
+        stamp?.kind === "custom-graph" &&
+        isLaunchStampProvenanceV1(stamp, {
+          chainId: Number(project.chainId),
+          tokenAddress: token.tokenAddress,
+          hookAddress: token.hookAddress,
+          poolId: token.poolId,
+          launchWallet: token.creatorAddress,
+          transactionHash: token.launchTransactionHash,
+          blockNumber: token.launchBlockNumber,
+          transactionIndex: token.launchTransactionIndex,
+          launchLogIndex: token.launchLogIndex,
+        }) &&
+        token.tokenAddress.toLowerCase() ===
+          project.tokenAddress?.toLowerCase()
+      );
+    },
+  ) ?? null;
+}
+
+function projectContainsPool(
+  project: CustomProjectExploreEntry,
+  poolId: string,
+) {
+  const marketPools = [...new Set(
+    project.markets.flatMap((market) =>
+      market.poolId ? [market.poolId.toLowerCase()] : [],
+    ),
+  )];
+  return marketPools.length === 1 && marketPools[0] === poolId.toLowerCase();
+}
+
+/**
+ * A canonical Router stamp wins over the older project directory only when
+ * both sources identify the exact same token and pool. Any partial collision
+ * remains fail-closed instead of silently changing launch provenance.
+ */
+export function suppressRouterBoundCustomProjectDuplicates(
+  tokens: readonly LauncherToken[],
+  projects: readonly CustomProjectExploreEntry[],
+) {
+  return projects.filter((project) => {
+    const token = matchingRouterToken(project, tokens);
+    if (!token) return true;
+    if (!projectContainsPool(project, token.poolId)) {
+      throw new Error(
+        "Canonical Router and custom directory disagree on token pool binding",
+      );
+    }
+    return false;
+  });
+}

--- a/lib/data-pipeline/optimistic-read-overlay.server.ts
+++ b/lib/data-pipeline/optimistic-read-overlay.server.ts
@@ -361,6 +361,7 @@ function validateLaunch(
     launchTransactionHash !== base.event.transactionHash ||
     launchBlockNumber !== base.evidence.blockNumber ||
     !Number.isFinite(Date.parse(row.token.launchedAt)) ||
+    typeof row.token.totalSwapFeeBps !== "number" ||
     !Number.isInteger(row.token.totalSwapFeeBps) ||
     row.token.totalSwapFeeBps < 0 ||
     row.token.totalSwapFeeBps > 10_000 ||

--- a/lib/data-pipeline/route-adapters.server.ts
+++ b/lib/data-pipeline/route-adapters.server.ts
@@ -1938,9 +1938,14 @@ export function adaptIndexedCreatorProfileV2(
       if (left.logIndex !== right.logIndex) return right.logIndex - left.logIndex;
       return right.transactionHash.localeCompare(left.transactionHash);
     });
-  const pools = tokens
-    .filter((entry) => entry.launchModel !== "stock-paired")
-    .map((entry) => ({
+  const pools = tokens.flatMap((entry) => {
+    if (
+      entry.launchModel === "stock-paired" ||
+      typeof entry.totalSwapFeeBps !== "number"
+    ) {
+      return [];
+    }
+    return [{
       tokenAddress: entry.tokenAddress,
       name: entry.name,
       symbol: entry.symbol,
@@ -1951,7 +1956,8 @@ export function adaptIndexedCreatorProfileV2(
       claimableCreatorFeesEth: entry.creatorFeesAccruedEth ?? "0",
       generatedCreatorFeesWei: entry.creatorFeesGeneratedWei ?? "0",
       generatedCreatorFeesEth: entry.creatorFeesGeneratedEth ?? "0",
-    }));
+    }];
+  });
   const claimable = pools.reduce(
     (total, pool) => total + BigInt(pool.claimableCreatorFeesWei),
     0n,

--- a/lib/explore-entry-v1.ts
+++ b/lib/explore-entry-v1.ts
@@ -1,8 +1,101 @@
-import type { CanonicalTokenExploreEntry, LauncherToken } from "./tokens";
+import {
+  isLaunchStampProvenanceV1,
+  type CanonicalTokenExploreEntry,
+  type LauncherToken,
+} from "./tokens";
 
 export function canonicalTokenExploreEntryV1(
   token: LauncherToken,
 ): CanonicalTokenExploreEntry {
+  const stamp = token.launchStampProvenance;
+  if (
+    stamp !== undefined &&
+    (!token.creatorAddress ||
+      !token.launchTransactionHash ||
+      !token.launchBlockNumber ||
+      token.launchTransactionIndex === undefined ||
+      token.launchLogIndex === undefined)
+  ) {
+    throw new Error(`Token ${token.tokenAddress} has incomplete launch coordinates`);
+  }
+  if (
+    stamp !== undefined &&
+    !isLaunchStampProvenanceV1(stamp, {
+      tokenAddress: token.tokenAddress,
+      hookAddress: token.hookAddress,
+      poolId: token.poolId,
+      launchWallet: token.creatorAddress,
+      transactionHash: token.launchTransactionHash,
+      blockNumber: token.launchBlockNumber,
+      transactionIndex: token.launchTransactionIndex,
+      launchLogIndex: token.launchLogIndex,
+    })
+  ) {
+    throw new Error(`Token ${token.tokenAddress} has invalid launch stamp provenance`);
+  }
+
+  if (token.launchModel === "custom-graph") {
+    if (
+      !stamp ||
+      stamp.kind !== "custom-graph" ||
+      token.launchModelVersion !== "programmable-launch-stamp-router-v1" ||
+      token.totalSwapFeeBps !== null ||
+      token.liquidityPath !== "programmable-v4"
+    ) {
+      throw new Error(
+        `Token ${token.tokenAddress} is missing canonical Custom Graph provenance`,
+      );
+    }
+  }
+
+  if (stamp) {
+    const unknownStampedFees = token.totalSwapFeeBps === null;
+    if (
+      token.launchModel !==
+        (stamp.kind === "custom-graph" ? "custom-graph" : "classic") ||
+      token.launchModelVersion !== "programmable-launch-stamp-router-v1" ||
+      token.liquidityPath !== "programmable-v4" ||
+      !unknownStampedFees ||
+      (unknownStampedFees &&
+        (token.buyHookFeeBps !== undefined ||
+          token.sellHookFeeBps !== undefined ||
+          token.creatorFeeBps !== undefined ||
+          token.buyCreatorFeeBps !== undefined ||
+          token.sellCreatorFeeBps !== undefined ||
+          token.growthFeeBps !== undefined ||
+          token.programmableFeeBps !== undefined ||
+          token.launcherFeeBps !== undefined ||
+          token.transferTaxBps !== undefined))
+    ) {
+      throw new Error(`Token ${token.tokenAddress} has a mismatched launch stamp kind`);
+    }
+    return {
+      ...token,
+      exploreKind: "token",
+      launchCategoryProvenance: {
+        schemaVersion: "programmable.explore-launch-category-provenance.v1",
+        category: stamp.kind === "custom-graph" ? "custom" : "classic",
+        source: "canonical-launch-stamp-router",
+        launchId: stamp.launchId,
+        stampHash: stamp.stampHash,
+        routerAddress: stamp.routerAddress,
+        transactionHash: stamp.transactionHash,
+        blockHash: stamp.blockHash,
+        blockNumber: stamp.blockNumber,
+        transactionIndex: stamp.transactionIndex,
+        logIndex: stamp.launchLogIndex,
+      },
+    };
+  }
+
+  if (
+    token.launchModel === "custom-graph" ||
+    token.totalSwapFeeBps === null ||
+    token.liquidityPath !== "meme"
+  ) {
+    throw new Error(`Token ${token.tokenAddress} has no canonical launch stamp`);
+  }
+
   return {
     ...token,
     exploreKind: "token",

--- a/lib/onchain/indexer-feed.ts
+++ b/lib/onchain/indexer-feed.ts
@@ -1,4 +1,9 @@
-import type { LauncherToken, TokenLinkKind } from "../tokens";
+import {
+  isLaunchStampProvenanceV1,
+  type LaunchStampProvenanceV1,
+  type LauncherToken,
+  type TokenLinkKind,
+} from "../tokens";
 import type { ExploreReadModel, ExploreSnapshot } from "./types";
 
 type IndexerLinks = Partial<Record<TokenLinkKind, string>>;
@@ -9,7 +14,7 @@ export type ProgrammableIndexerToken = {
   address: LauncherToken["tokenAddress"];
   name: string;
   symbol: string;
-  decimals: number;
+  decimals: number | null;
   description: string | null;
   imageUrl: string | null;
   links: IndexerLinks;
@@ -22,6 +27,8 @@ export type ProgrammableIndexerToken = {
     quoteAssetSymbol: LauncherToken["quoteAssetSymbol"] | null;
     quoteAssetName: LauncherToken["quoteAssetName"] | null;
     quoteIsCurrency0: LauncherToken["quoteIsCurrency0"] | null;
+    poolManagerAddress: `0x${string}` | null;
+    poolKey: LaunchStampProvenanceV1["poolKey"] | null;
     positionRecipient: LauncherToken["positionRecipient"] | null;
     positionTokenId: LauncherToken["positionTokenId"] | null;
     tokenLiquidityAmountRaw:
@@ -32,20 +39,21 @@ export type ProgrammableIndexerToken = {
       | null;
   };
   fees: {
-    model: "uniswap-v4-custom-accounting";
-    currency: string;
+    status: "verified" | "unknown";
+    model: "uniswap-v4-custom-accounting" | "unknown";
+    currency: string | null;
     currencyAddress: `0x${string}` | null;
-    buyHookFeeBps: number;
-    sellHookFeeBps: number;
+    buyHookFeeBps: number | null;
+    sellHookFeeBps: number | null;
     creatorFeeBps: number | null;
     buyCreatorFeeBps: number | null;
     sellCreatorFeeBps: number | null;
     growthFeeBps: number | null;
-    programmableFeeBps: number;
-    launcherFeeBps: number;
-    transferTaxBps: number;
-    lpFeePips: number;
-    launcherFeeIncludedInHookFee: true;
+    programmableFeeBps: number | null;
+    launcherFeeBps: number | null;
+    transferTaxBps: number | null;
+    lpFeePips: number | null;
+    launcherFeeIncludedInHookFee: true | null;
   };
   launch: {
     /**
@@ -55,6 +63,7 @@ export type ProgrammableIndexerToken = {
     model: string;
     modelId: NonNullable<LauncherToken["launchModel"]>;
     modelVersion: string | null;
+    category: "classic" | "custom";
     deepReleaseVersion:
       | "deep-full-range-v1"
       | "deep-full-range-v2"
@@ -66,6 +75,7 @@ export type ProgrammableIndexerToken = {
     transactionHash: LauncherToken["launchTransactionHash"] | null;
     blockNumber: LauncherToken["launchBlockNumber"] | null;
     launchedAt: string;
+    launchStampProvenance: LauncherToken["launchStampProvenance"] | null;
   };
   liquidityGrowth:
     | {
@@ -131,7 +141,9 @@ function launchIdentity(token: LauncherToken) {
     token.launchModel === "deep"
       ? token.deepReleaseVersion ?? null
       : token.launchModel === "stock-paired" ||
-          token.launchModelVersion === "classic-v3"
+          token.launchModel === "custom-graph" ||
+          token.launchModelVersion === "classic-v3" ||
+          token.launchModelVersion === "programmable-launch-stamp-router-v1"
         ? token.launchModelVersion ?? null
         : null;
 
@@ -270,6 +282,74 @@ export function serializeIndexerToken(
   const isDeepV1 = token.deepReleaseVersion === "deep-full-range-v1";
   const isDeepV2 = token.deepReleaseVersion === "deep-full-range-v2";
   const isDeepV3 = token.deepReleaseVersion === "deep-full-range-v3";
+  const isCustomGraph = token.launchModel === "custom-graph";
+  const launchStampProvenance = token.launchStampProvenance;
+  const isStamped = launchStampProvenance !== undefined;
+  if (
+    isStamped &&
+    (!token.creatorAddress ||
+      !token.launchTransactionHash ||
+      !token.launchBlockNumber ||
+      token.launchTransactionIndex === undefined ||
+      token.launchLogIndex === undefined ||
+      !isLaunchStampProvenanceV1(launchStampProvenance, {
+        chainId,
+        tokenAddress: token.tokenAddress,
+        hookAddress: token.hookAddress,
+        poolId: token.poolId,
+        launchWallet: token.creatorAddress,
+        transactionHash: token.launchTransactionHash,
+        blockNumber: token.launchBlockNumber,
+        transactionIndex: token.launchTransactionIndex,
+        launchLogIndex: token.launchLogIndex,
+      }))
+  ) {
+    throw new Error(`Token ${token.tokenAddress} has invalid launch stamp provenance`);
+  }
+  const stampedTokenDecimals =
+    Number.isSafeInteger(token.tokenDecimals) &&
+    (token.tokenDecimals as number) >= 0 &&
+    (token.tokenDecimals as number) <= 255
+      ? (token.tokenDecimals as number)
+      : null;
+  if (
+    isStamped &&
+    (token.launchModel !==
+        (launchStampProvenance.kind === "custom-graph"
+          ? "custom-graph"
+          : "classic") ||
+      token.launchModelVersion !== "programmable-launch-stamp-router-v1" ||
+      token.liquidityPath !== "programmable-v4" ||
+      token.totalSwapFeeBps !== null)
+  ) {
+    throw new Error(
+      `Token ${token.tokenAddress} has a mismatched launch stamp disclosure`,
+    );
+  }
+  if (
+    isCustomGraph && !isStamped
+  ) {
+    throw new Error(
+      `Token ${token.tokenAddress} is missing canonical Custom Graph disclosure`,
+    );
+  }
+  const hasUnknownFees = isStamped;
+  if (
+    hasUnknownFees &&
+    (token.buyHookFeeBps !== undefined ||
+      token.sellHookFeeBps !== undefined ||
+      token.creatorFeeBps !== undefined ||
+      token.buyCreatorFeeBps !== undefined ||
+      token.sellCreatorFeeBps !== undefined ||
+      token.growthFeeBps !== undefined ||
+      token.programmableFeeBps !== undefined ||
+      token.launcherFeeBps !== undefined ||
+      token.transferTaxBps !== undefined)
+  ) {
+    throw new Error(
+      `Token ${token.tokenAddress} has invented Router fee disclosure`,
+    );
+  }
   if (
     (token.launchModel === "deep" &&
       !isDeepV1 &&
@@ -313,33 +393,37 @@ export function serializeIndexerToken(
     );
   }
   if (
-    buyHookFeeBps === undefined ||
-    sellHookFeeBps === undefined ||
-    launcherFeeBps === undefined ||
-    transferTaxBps === undefined ||
-    programmableFeeBps === undefined ||
-    (!isDeepV3 &&
-      (buyCreatorFeeBps === null ||
-        sellCreatorFeeBps === null)) ||
-    (isDeepV3 && growthFeeBps === null)
+    (!hasUnknownFees && buyHookFeeBps === undefined) ||
+    (!hasUnknownFees && sellHookFeeBps === undefined) ||
+    (!hasUnknownFees && launcherFeeBps === undefined) ||
+    (!hasUnknownFees && transferTaxBps === undefined) ||
+    (!hasUnknownFees && programmableFeeBps === undefined) ||
+    (!hasUnknownFees &&
+      !isDeepV3 &&
+      (buyCreatorFeeBps === null || sellCreatorFeeBps === null)) ||
+    (!hasUnknownFees && isDeepV3 && growthFeeBps === null) ||
+    (!isStamped && token.totalSwapFeeBps === null)
   ) {
     throw new Error(
       `Token ${token.tokenAddress} is missing onchain fee disclosure`,
     );
   }
   if (
-    (isDeepV3
-      ? growthFeeBps! + programmableFeeBps !== buyHookFeeBps ||
-        growthFeeBps! + programmableFeeBps !== sellHookFeeBps ||
-        launcherFeeBps !== programmableFeeBps ||
-        ![undefined, 0].includes(token.creatorFeeBps) ||
-        ![undefined, 0].includes(token.buyCreatorFeeBps) ||
-        ![undefined, 0].includes(token.sellCreatorFeeBps)
-      : (buyCreatorFeeBps as number) + launcherFeeBps !==
-          buyHookFeeBps ||
-        (sellCreatorFeeBps as number) + launcherFeeBps !==
-          sellHookFeeBps) ||
-    transferTaxBps !== 0
+    !hasUnknownFees &&
+    (
+      (isDeepV3
+        ? growthFeeBps! + programmableFeeBps! !== buyHookFeeBps ||
+          growthFeeBps! + programmableFeeBps! !== sellHookFeeBps ||
+          launcherFeeBps !== programmableFeeBps ||
+          ![undefined, 0].includes(token.creatorFeeBps ?? undefined) ||
+          ![undefined, 0].includes(token.buyCreatorFeeBps) ||
+          ![undefined, 0].includes(token.sellCreatorFeeBps)
+        : (buyCreatorFeeBps as number) + launcherFeeBps! !==
+            buyHookFeeBps ||
+          (sellCreatorFeeBps as number) + launcherFeeBps! !==
+            sellHookFeeBps) ||
+      transferTaxBps !== 0
+    )
   ) {
     throw new Error(`Token ${token.tokenAddress} has an invalid fee disclosure`);
   }
@@ -406,7 +490,9 @@ export function serializeIndexerToken(
     address: token.tokenAddress,
     name: token.name,
     symbol: token.symbol,
-    decimals: token.tokenDecimals ?? 18,
+    decimals: isStamped
+      ? stampedTokenDecimals
+      : token.tokenDecimals ?? 18,
     description: token.description ?? null,
     imageUrl: token.imageUrl ?? null,
     links: indexerLinks(token),
@@ -419,35 +505,45 @@ export function serializeIndexerToken(
       quoteAssetSymbol,
       quoteAssetName,
       quoteIsCurrency0,
-      positionRecipient: token.positionRecipient ?? null,
-      positionTokenId: token.positionTokenId ?? null,
+      poolManagerAddress: launchStampProvenance?.poolManagerAddress ?? null,
+      poolKey: launchStampProvenance?.poolKey ?? null,
+      positionRecipient: isStamped
+        ? null
+        : token.positionRecipient ?? null,
+      positionTokenId: isStamped ? null : token.positionTokenId ?? null,
       tokenLiquidityAmountRaw:
         token.tokenLiquidityAmountRaw ?? null,
       lockedTokenDustRaw: token.lockedTokenDustRaw ?? null,
     },
     fees: {
-      model: "uniswap-v4-custom-accounting",
-      currency: quoteAssetSymbol ?? "ETH",
-      currencyAddress: quoteAssetAddress,
-      buyHookFeeBps,
-      sellHookFeeBps,
+      status: hasUnknownFees ? "unknown" : "verified",
+      model: hasUnknownFees ? "unknown" : "uniswap-v4-custom-accounting",
+      currency: hasUnknownFees ? null : quoteAssetSymbol ?? "ETH",
+      currencyAddress: hasUnknownFees ? null : quoteAssetAddress,
+      buyHookFeeBps: hasUnknownFees ? null : buyHookFeeBps!,
+      sellHookFeeBps: hasUnknownFees ? null : sellHookFeeBps!,
       creatorFeeBps:
+        !hasUnknownFees &&
         buyCreatorFeeBps !== null &&
         sellCreatorFeeBps !== null &&
         buyCreatorFeeBps === sellCreatorFeeBps
           ? buyCreatorFeeBps
           : null,
-      buyCreatorFeeBps,
-      sellCreatorFeeBps,
-      growthFeeBps,
-      programmableFeeBps,
-      launcherFeeBps,
-      transferTaxBps,
-      lpFeePips: token.lpFeePips ?? 0,
-      launcherFeeIncludedInHookFee: true,
+      buyCreatorFeeBps: hasUnknownFees ? null : buyCreatorFeeBps,
+      sellCreatorFeeBps: hasUnknownFees ? null : sellCreatorFeeBps,
+      growthFeeBps: hasUnknownFees ? null : growthFeeBps,
+      programmableFeeBps: hasUnknownFees ? null : programmableFeeBps!,
+      launcherFeeBps: hasUnknownFees ? null : launcherFeeBps!,
+      transferTaxBps: hasUnknownFees ? null : transferTaxBps!,
+      lpFeePips: hasUnknownFees ? null : token.lpFeePips ?? 0,
+      launcherFeeIncludedInHookFee: hasUnknownFees ? null : true,
     },
     launch: {
       ...launch,
+      category:
+        launchStampProvenance?.kind === "custom-graph"
+          ? "custom"
+          : "classic",
       deepReleaseVersion:
         token.launchModel === "deep"
           ? token.deepReleaseVersion!
@@ -458,6 +554,7 @@ export function serializeIndexerToken(
       transactionHash: token.launchTransactionHash ?? null,
       blockNumber: token.launchBlockNumber ?? null,
       launchedAt: token.launchedAt,
+      launchStampProvenance: launchStampProvenance ?? null,
     },
     liquidityGrowth: serializeLiquidityGrowth(token, isDeepV3),
   };
@@ -494,7 +591,10 @@ export function findIndexerToken(
   return token ? serializeIndexerToken(token, chainId) : null;
 }
 
-export function buildUniswapTokenList(
+export const UNISWAP_TOKEN_LIST_OMISSION_REASON =
+  "missing-valid-decimals" as const;
+
+export function buildUniswapTokenListResult(
   model: ExploreReadModel,
   chainId: number,
   generatedAt = new Date(),
@@ -505,23 +605,16 @@ export function buildUniswapTokenList(
     );
   }
 
-  return {
-    name: "Programmable",
-    timestamp: generatedAt.toISOString(),
-    version: {
-      major: 1,
-      minor: model.tokens.length,
-      patch: 0,
-    },
-    keywords: ["programmable", "uniswap v4"],
-    tokens: model.tokens.map((token) => {
-      const serialized = serializeIndexerToken(token, chainId);
-      return {
+  const tokens = model.tokens.flatMap((token) => {
+    const serialized = serializeIndexerToken(token, chainId);
+    if (serialized.decimals === null) return [];
+    return [
+      {
         chainId,
         address: token.tokenAddress,
         name: token.name,
         symbol: token.symbol,
-        decimals: token.tokenDecimals ?? 18,
+        decimals: serialized.decimals,
         ...(token.imageUrl ? { logoURI: token.imageUrl } : {}),
         extensions: {
           programmable: {
@@ -534,9 +627,14 @@ export function buildUniswapTokenList(
                 ? "v4-deep-liquidity"
                 : token.launchModel === "stock-paired"
                   ? "v4-stock-paired"
-                  : "v4-custom-accounting",
+                  : token.launchModel === "custom-graph"
+                    ? "v4-programmable-custom-graph"
+                    : "v4-custom-accounting",
             launchModel: serialized.launch.modelId,
             launchModelVersion: serialized.launch.modelVersion,
+            launchCategory: serialized.launch.category,
+            launchStampProvenance:
+              serialized.launch.launchStampProvenance,
             poolId: token.poolId,
             quoteAssetAddress:
               serialized.canonicalPool.quoteAssetAddress,
@@ -545,8 +643,9 @@ export function buildUniswapTokenList(
             quoteAssetName: serialized.canonicalPool.quoteAssetName,
             quoteIsCurrency0:
               serialized.canonicalPool.quoteIsCurrency0,
-            positionRecipient: token.positionRecipient ?? null,
-            positionTokenId: token.positionTokenId ?? null,
+            positionRecipient:
+              serialized.canonicalPool.positionRecipient,
+            positionTokenId: serialized.canonicalPool.positionTokenId,
             tokenLiquidityAmountRaw:
               token.tokenLiquidityAmountRaw ?? null,
             lockedTokenDustRaw: token.lockedTokenDustRaw ?? null,
@@ -557,11 +656,52 @@ export function buildUniswapTokenList(
             sellCreatorFeeBps: serialized.fees.sellCreatorFeeBps,
             launcherFeeBps: serialized.fees.launcherFeeBps,
             transferTaxBps: serialized.fees.transferTaxBps,
-            feeIncluded: true,
+            feeStatus: serialized.fees.status,
+            feeIncluded:
+              serialized.fees.launcherFeeIncludedInHookFee,
             liquidityGrowth: serialized.liquidityGrowth,
           },
         },
-      };
-    }),
+      },
+    ];
+  });
+  const omittedTokenCount = model.tokens.length - tokens.length;
+
+  return {
+    tokenList:
+      tokens.length === 0
+        ? null
+        : {
+            name: "Programmable",
+            timestamp: generatedAt.toISOString(),
+            version: {
+              major: 1,
+              minor: model.tokens.length,
+              patch: 0,
+            },
+            keywords: ["programmable", "uniswap v4"],
+            tokens,
+          },
+    omissions: {
+      count: omittedTokenCount,
+      reason:
+        omittedTokenCount === 0
+          ? null
+          : UNISWAP_TOKEN_LIST_OMISSION_REASON,
+    },
   };
+}
+
+export function buildUniswapTokenList(
+  model: ExploreReadModel,
+  chainId: number,
+  generatedAt = new Date(),
+) {
+  const result = buildUniswapTokenListResult(model, chainId, generatedAt);
+  if (result.tokenList === null) {
+    throw new Error(
+      "A token list cannot be published without a token with valid decimals",
+    );
+  }
+  return result.tokenList;
 }

--- a/lib/onchain/profile.ts
+++ b/lib/onchain/profile.ts
@@ -9,14 +9,28 @@ function sumStringValues(values: string[]) {
 export function buildCreatorProfile(
   model: ExploreReadModel,
   account: Address,
+  directRewardPoolIds: ReadonlySet<string> = new Set(),
 ): CreatorProfile {
   const normalizedAccount = account.toLowerCase();
   const tokens = model.tokens.filter(
     (token) =>
       token.creatorAddress?.toLowerCase() === normalizedAccount,
   );
+  const rewardTokens = tokens.flatMap((token) => {
+    const totalSwapFeeBps = token.totalSwapFeeBps;
+    if (
+      !directRewardPoolIds.has(token.poolId.toLowerCase()) ||
+      token.launchModel !== "classic" ||
+      typeof totalSwapFeeBps !== "number" ||
+      !Number.isSafeInteger(totalSwapFeeBps) ||
+      totalSwapFeeBps < 0
+    ) {
+      return [];
+    }
+    return [{ token, totalSwapFeeBps }];
+  });
   const tokenPools = new Set(
-    tokens.map((token) => token.poolId.toLowerCase()),
+    rewardTokens.map(({ token }) => token.poolId.toLowerCase()),
   );
   const claims = model.creatorClaims
     .filter(
@@ -35,26 +49,18 @@ export function buildCreatorProfile(
       }
       return second.logIndex - first.logIndex;
     });
-  const pools = tokens
-    .filter((token) => token.launchModel !== "stock-paired")
-    .map((token) => ({
+  const pools = rewardTokens.map(({ token, totalSwapFeeBps }) => ({
     tokenAddress: token.tokenAddress,
     name: token.name,
     symbol: token.symbol,
     poolId: token.poolId,
-    totalSwapFeeBps: token.totalSwapFeeBps,
-    launchModel:
-      token.launchModel === "stock-paired"
-        ? "classic"
-        : token.launchModel ?? "classic",
-    ...(token.adaptiveCurveHash
-      ? { adaptiveCurveHash: token.adaptiveCurveHash }
-      : {}),
+    totalSwapFeeBps,
+    launchModel: "classic" as const,
     claimableCreatorFeesWei: token.creatorFeesAccruedWei ?? "0",
     claimableCreatorFeesEth: token.creatorFeesAccruedEth ?? "0",
     generatedCreatorFeesWei: token.creatorFeesGeneratedWei ?? "0",
     generatedCreatorFeesEth: token.creatorFeesGeneratedEth ?? "0",
-    }));
+  }));
   const claimable = sumStringValues(
     pools.map((pool) => pool.claimableCreatorFeesWei),
   );

--- a/lib/profile/onchain-profile.ts
+++ b/lib/profile/onchain-profile.ts
@@ -7,6 +7,11 @@ import {
   type Hex,
 } from "viem";
 
+import {
+  isLaunchStampProvenanceV1,
+  type LaunchStampProvenanceV1,
+} from "../tokens";
+
 export type ProfileDataStatus =
   "unavailable" | "not-deployed" | "loading" | "ready" | "error";
 
@@ -21,7 +26,12 @@ export type ProfileToken = {
   fdvUsdWad?: string;
   marketCapQuoteWad?: string;
   quoteAssetSymbol?: string;
-  launchModel?: "classic" | "adaptive" | "deep" | "stock-paired";
+  launchModel?:
+    | "classic"
+    | "adaptive"
+    | "deep"
+    | "stock-paired"
+    | "custom-graph";
 };
 
 export type ProfilePosition = {
@@ -75,11 +85,12 @@ type ParsedProfileToken = ProfileToken & {
   poolId: Hex;
   hookAddress: Address;
   creatorAddress: Address;
-  positionRecipient: Address;
-  positionTokenId: string;
+  positionRecipient?: Address;
+  positionTokenId?: string;
   launchTransactionHash: Hex;
   launchLogIndex: number;
-  totalSwapFeeBps: number;
+  totalSwapFeeBps?: number;
+  launchStampProvenance?: LaunchStampProvenanceV1;
 };
 
 type ParsedProfilePool = {
@@ -155,6 +166,20 @@ function readAddress(
 ) {
   const value = readString(record, key, label);
   if (!isAddress(value)) {
+    throw new ProfileResponseError(`Invalid ${label}`);
+  }
+
+  return getAddress(value);
+}
+
+function readOptionalAddress(
+  record: Record<string, unknown>,
+  key: string,
+  label: string,
+) {
+  const value = record[key];
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string" || !isAddress(value)) {
     throw new ProfileResponseError(`Invalid ${label}`);
   }
 
@@ -239,6 +264,37 @@ function readSafeInteger(
   return value;
 }
 
+function readOptionalSafeInteger(
+  record: Record<string, unknown>,
+  key: string,
+  label: string,
+) {
+  const value = record[key];
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new ProfileResponseError(`Invalid ${label}`);
+  }
+
+  return value;
+}
+
+function readLaunchStampProvenance(
+  record: Record<string, unknown>,
+  expected: Readonly<{
+    tokenAddress: Address;
+    hookAddress: Address;
+    poolId: Hex;
+  }>,
+) {
+  const value = record.launchStampProvenance;
+  if (value === undefined || value === null) return undefined;
+  if (!isLaunchStampProvenanceV1(value, expected)) {
+    throw new ProfileResponseError("Invalid launch stamp provenance");
+  }
+
+  return value;
+}
+
 function readTimestamp(
   record: Record<string, unknown>,
   key: string,
@@ -313,6 +369,8 @@ function parseToken(
       "Profile response contains a token for another creator",
     );
   }
+  const poolId = readHex(token, "poolId", "pool id", 32);
+  const hookAddress = readAddress(token, "hookAddress", "token hook address");
   const imageUrl = readOptionalHttpsUrl(token, "imageUrl", "token image");
   const marketCapEthWei = readOptionalIntegerString(
     token,
@@ -338,9 +396,71 @@ function parseToken(
     token.launchModel === "adaptive" ||
     token.launchModel === "classic" ||
     token.launchModel === "deep" ||
-    token.launchModel === "stock-paired"
+    token.launchModel === "stock-paired" ||
+    token.launchModel === "custom-graph"
       ? token.launchModel
       : undefined;
+  const launchStampProvenance = readLaunchStampProvenance(token, {
+    tokenAddress: address,
+    hookAddress,
+    poolId,
+  });
+  if (
+    (launchStampProvenance?.kind === "custom-graph" &&
+      launchModel !== "custom-graph") ||
+    (launchStampProvenance?.kind === "classic" && launchModel !== "classic")
+  ) {
+    throw new ProfileResponseError(
+      "Profile token model does not match its launch stamp",
+    );
+  }
+  const positionRecipient = readOptionalAddress(
+    token,
+    "positionRecipient",
+    "position recipient",
+  );
+  const positionTokenId = readOptionalIntegerString(
+    token,
+    "positionTokenId",
+    "position token id",
+  );
+  if ((positionRecipient === undefined) !== (positionTokenId === undefined)) {
+    throw new ProfileResponseError(
+      "Profile token contains an incomplete position proof",
+    );
+  }
+  const totalSwapFeeBps = readOptionalSafeInteger(
+    token,
+    "totalSwapFeeBps",
+    "token swap fee",
+  );
+  const launchTransactionHash = readHex(
+    token,
+    "launchTransactionHash",
+    "launch transaction hash",
+    32,
+  );
+  const launchLogIndex = readSafeInteger(
+    token,
+    "launchLogIndex",
+    "launch log index",
+  );
+  if (
+    launchStampProvenance &&
+    (!sameAddress(launchStampProvenance.launchWallet, creatorAddress) ||
+      launchStampProvenance.transactionHash.toLowerCase() !==
+        launchTransactionHash.toLowerCase() ||
+      launchStampProvenance.launchLogIndex !== launchLogIndex ||
+      readIntegerString(
+        token,
+        "launchBlockNumber",
+        "launch block number",
+      ) !== launchStampProvenance.blockNumber)
+  ) {
+    throw new ProfileResponseError(
+      "Profile token does not match its launch stamp",
+    );
+  }
 
   return {
     address,
@@ -354,35 +474,16 @@ function parseToken(
     ...(marketCapQuoteWad ? { marketCapQuoteWad } : {}),
     ...(quoteAssetSymbol ? { quoteAssetSymbol } : {}),
     ...(launchModel ? { launchModel } : {}),
-    poolId: readHex(token, "poolId", "pool id", 32),
-    hookAddress: readAddress(token, "hookAddress", "token hook address"),
+    poolId,
+    hookAddress,
     creatorAddress,
-    positionRecipient: readAddress(
-      token,
-      "positionRecipient",
-      "position recipient",
-    ),
-    positionTokenId: readIntegerString(
-      token,
-      "positionTokenId",
-      "position token id",
-    ),
-    launchTransactionHash: readHex(
-      token,
-      "launchTransactionHash",
-      "launch transaction hash",
-      32,
-    ),
-    launchLogIndex: readSafeInteger(
-      token,
-      "launchLogIndex",
-      "launch log index",
-    ),
-    totalSwapFeeBps: readSafeInteger(
-      token,
-      "totalSwapFeeBps",
-      "token swap fee",
-    ),
+    ...(positionRecipient && positionTokenId
+      ? { positionRecipient, positionTokenId }
+      : {}),
+    launchTransactionHash,
+    launchLogIndex,
+    ...(totalSwapFeeBps === undefined ? {} : { totalSwapFeeBps }),
+    ...(launchStampProvenance ? { launchStampProvenance } : {}),
   };
 }
 
@@ -530,6 +631,7 @@ export function mapCreatorProfileResponse(
     if (
       pool.name !== token.name ||
       pool.symbol !== token.symbol ||
+      token.totalSwapFeeBps === undefined ||
       pool.totalSwapFeeBps !== token.totalSwapFeeBps
     ) {
       throw new ProfileResponseError(
@@ -540,7 +642,11 @@ export function mapCreatorProfileResponse(
 
   for (const pool of pools) {
     const token = tokenByPool.get(pool.poolId.toLowerCase());
-    if (!token || !sameAddress(token.address, pool.tokenAddress)) {
+    if (
+      !token ||
+      token.launchStampProvenance !== undefined ||
+      !sameAddress(token.address, pool.tokenAddress)
+    ) {
       throw new ProfileResponseError(
         "Profile pool does not match a verified token",
       );
@@ -549,7 +655,13 @@ export function mapCreatorProfileResponse(
 
   for (const claim of claimEvents) {
     const token = tokenByPool.get(claim.poolId.toLowerCase());
-    if (!token || !sameAddress(token.address, claim.tokenAddress)) {
+    const pool = poolByPoolId.get(claim.poolId.toLowerCase());
+    if (
+      !token ||
+      !pool ||
+      token.launchStampProvenance !== undefined ||
+      !sameAddress(token.address, claim.tokenAddress)
+    ) {
       throw new ProfileResponseError(
         "Creator claim does not match a verified token",
       );
@@ -638,6 +750,17 @@ export function mapCreatorProfileResponse(
   readIntegerString(snapshot, "blockNumber", "snapshot block number");
   readHex(snapshot, "blockHash", "snapshot block hash", 32);
   readSafeInteger(snapshot, "confirmations", "snapshot confirmations");
+  if (
+    tokens.some(
+      (token) =>
+        token.launchStampProvenance !== undefined &&
+        token.launchStampProvenance.chainId !== chainId,
+    )
+  ) {
+    throw new ProfileResponseError(
+      "Profile launch stamp does not match the snapshot chain",
+    );
+  }
 
   const profileTokens: ProfileToken[] = tokens.map(
     ({
@@ -666,16 +789,25 @@ export function mapCreatorProfileResponse(
       ...(launchModel ? { launchModel } : {}),
     }),
   );
-  const positions: ProfilePosition[] = tokens.map((token) => ({
-    id: token.poolId,
-    tokenAddress: token.address,
-    tokenName: token.name,
-    tokenSymbol: token.symbol,
-    positionRecipient: token.positionRecipient,
-    positionTokenId: token.positionTokenId,
-    lockStatus: "permanently-locked",
-    href: token.href,
-  }));
+  const positions: ProfilePosition[] = tokens.flatMap((token) => {
+    if (
+      token.launchStampProvenance !== undefined ||
+      !token.positionRecipient ||
+      token.positionTokenId === undefined
+    ) {
+      return [];
+    }
+    return [{
+      id: token.poolId,
+      tokenAddress: token.address,
+      tokenName: token.name,
+      tokenSymbol: token.symbol,
+      positionRecipient: token.positionRecipient,
+      positionTokenId: token.positionTokenId,
+      lockStatus: "permanently-locked" as const,
+      href: token.href,
+    }];
+  });
   const claims: ProfileClaim[] = pools
     .filter((pool) => BigInt(pool.claimableWei) > 0n)
     .map((pool) => {

--- a/lib/profile/onchain-profile.ts
+++ b/lib/profile/onchain-profile.ts
@@ -32,6 +32,7 @@ export type ProfileToken = {
     | "deep"
     | "stock-paired"
     | "custom-graph";
+  launchProvenance?: "canonical-router";
 };
 
 export type ProfilePosition = {
@@ -775,6 +776,7 @@ export function mapCreatorProfileResponse(
       marketCapQuoteWad,
       quoteAssetSymbol,
       launchModel,
+      launchStampProvenance,
     }) => ({
       address,
       name,
@@ -787,6 +789,9 @@ export function mapCreatorProfileResponse(
       ...(marketCapQuoteWad ? { marketCapQuoteWad } : {}),
       ...(quoteAssetSymbol ? { quoteAssetSymbol } : {}),
       ...(launchModel ? { launchModel } : {}),
+      ...(launchStampProvenance
+        ? { launchProvenance: "canonical-router" as const }
+        : {}),
     }),
   );
   const positions: ProfilePosition[] = tokens.flatMap((token) => {

--- a/lib/profile/portfolio-history.ts
+++ b/lib/profile/portfolio-history.ts
@@ -18,7 +18,8 @@ type PortfolioHistoryLaunchModel =
   | "classic"
   | "adaptive"
   | "deep"
-  | "stock-paired";
+  | "stock-paired"
+  | "custom-graph";
 
 export type PortfolioHistoryTokenPoint = {
   tokenAddress: Address;

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -7,6 +7,304 @@ export type TokenLink = {
 
 export type TokenTone = "rose" | "violet" | "mint" | "amber" | "sky" | "peach";
 
+export type LaunchStampProvenanceV1 = Readonly<{
+  schemaVersion: "programmable.launch-stamp-provenance.v1";
+  chainId: number;
+  routerAddress: `0x${string}`;
+  routerRuntimeCodeHash: `0x${string}`;
+  routerStartBlock: string;
+  finalityConfirmations: number;
+  kind: "custom-graph" | "classic";
+  launchId: `0x${string}`;
+  stampHash: `0x${string}`;
+  launchWallet: `0x${string}`;
+  transactionHash: `0x${string}`;
+  blockNumber: string;
+  blockHash: `0x${string}`;
+  transactionIndex: number;
+  routeLogIndex: number;
+  launchLogIndex: number;
+  finalizedAtBlockNumber: string;
+  finalizedAtBlockHash: `0x${string}`;
+  poolManagerAddress: `0x${string}`;
+  poolId: `0x${string}`;
+  poolKey: Readonly<{
+    currency0: `0x${string}`;
+    currency1: `0x${string}`;
+    fee: number;
+    tickSpacing: number;
+    hooks: `0x${string}`;
+  }>;
+  poolKeyHash: `0x${string}`;
+  componentSetHash: `0x${string}`;
+  routePayloadHash: `0x${string}`;
+  routeLauncherAddress: `0x${string}`;
+  routeLauncherRuntimeCodeHash: `0x${string}`;
+  expectedResultHash: `0x${string}`;
+  permitDigest: `0x${string}`;
+  components: readonly Readonly<{
+    address: `0x${string}`;
+    kind: "token" | "hook" | "other";
+    scope: "exclusive" | "shared-infrastructure";
+    runtimeCodeHash: `0x${string}`;
+    logIndex: number;
+    exclusiveProof: Readonly<{
+      launchId: `0x${string}`;
+      stampHash: `0x${string}`;
+    }> | null;
+  }>[];
+  tokenProof: Readonly<{
+    tokenAddress: `0x${string}`;
+    launchId: `0x${string}`;
+    stampHash: `0x${string}`;
+  }>;
+  poolProof: Readonly<{
+    poolManagerAddress: `0x${string}`;
+    poolId: `0x${string}`;
+    launchId: `0x${string}`;
+    stampHash: `0x${string}`;
+  }>;
+}>;
+
+export const CANONICAL_LAUNCH_STAMP_V1 = Object.freeze({
+  chainId: 1,
+  routerAddress: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+  routerRuntimeCodeHash:
+    "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+  routerStartBlock: "25717612",
+  finalityConfirmations: 64,
+  poolManagerAddress: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+} as const);
+
+type LaunchStampExpectedIdentity = Readonly<{
+  chainId?: number;
+  tokenAddress?: `0x${string}`;
+  hookAddress?: `0x${string}`;
+  poolId?: `0x${string}`;
+  launchWallet?: `0x${string}`;
+  transactionHash?: `0x${string}`;
+  blockNumber?: string;
+  transactionIndex?: number;
+  launchLogIndex?: number;
+}>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAddress(value: unknown): value is `0x${string}` {
+  return typeof value === "string" && /^0x[0-9a-f]{40}$/iu.test(value);
+}
+
+function isBytes32(value: unknown): value is `0x${string}` {
+  return typeof value === "string" && /^0x[0-9a-f]{64}$/iu.test(value);
+}
+
+function isNonZeroBytes32(value: unknown): value is `0x${string}` {
+  return isBytes32(value) && BigInt(value) !== 0n;
+}
+
+function isNonZeroAddress(value: unknown): value is `0x${string}` {
+  return isAddress(value) && BigInt(value) !== 0n;
+}
+
+function areCanonicalCurrencies(value: unknown): value is Readonly<{
+  currency0: `0x${string}`;
+  currency1: `0x${string}`;
+  fee: unknown;
+  tickSpacing: unknown;
+  hooks: unknown;
+}> {
+  return isRecord(value) &&
+    isAddress(value.currency0) &&
+    isAddress(value.currency1) &&
+    BigInt(value.currency0) < BigInt(value.currency1);
+}
+
+function isUnsignedDecimal(value: unknown): value is string {
+  return typeof value === "string" && /^(?:0|[1-9]\d*)$/u.test(value);
+}
+
+function sameHex(left: unknown, right: unknown) {
+  return typeof left === "string" &&
+    typeof right === "string" &&
+    left.toLowerCase() === right.toLowerCase();
+}
+
+/**
+ * Validates the complete, finalized Router proof carried through the public
+ * Website and indexer surfaces. PoolId recomputation and onchain getter checks
+ * remain server-side responsibilities; this guard prevents a partial or
+ * category-mismatched proof from being rendered as canonical provenance.
+ */
+export function isLaunchStampProvenanceV1(
+  value: unknown,
+  expected: LaunchStampExpectedIdentity = {},
+): value is LaunchStampProvenanceV1 {
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== "programmable.launch-stamp-provenance.v1" ||
+    !Number.isSafeInteger(value.chainId) ||
+    value.chainId !== CANONICAL_LAUNCH_STAMP_V1.chainId ||
+    !isAddress(value.routerAddress) ||
+    !sameHex(
+      value.routerAddress,
+      CANONICAL_LAUNCH_STAMP_V1.routerAddress,
+    ) ||
+    !isBytes32(value.routerRuntimeCodeHash) ||
+    !sameHex(
+      value.routerRuntimeCodeHash,
+      CANONICAL_LAUNCH_STAMP_V1.routerRuntimeCodeHash,
+    ) ||
+    !isUnsignedDecimal(value.routerStartBlock) ||
+    value.routerStartBlock !== CANONICAL_LAUNCH_STAMP_V1.routerStartBlock ||
+    !Number.isSafeInteger(value.finalityConfirmations) ||
+    value.finalityConfirmations !==
+      CANONICAL_LAUNCH_STAMP_V1.finalityConfirmations ||
+    (value.kind !== "custom-graph" && value.kind !== "classic") ||
+    !isBytes32(value.launchId) ||
+    !isBytes32(value.stampHash) ||
+    !isNonZeroAddress(value.launchWallet) ||
+    !isBytes32(value.transactionHash) ||
+    !isUnsignedDecimal(value.blockNumber) ||
+    !isBytes32(value.blockHash) ||
+    !Number.isSafeInteger(value.transactionIndex) ||
+    Number(value.transactionIndex) < 0 ||
+    !Number.isSafeInteger(value.routeLogIndex) ||
+    Number(value.routeLogIndex) < 0 ||
+    !Number.isSafeInteger(value.launchLogIndex) ||
+    Number(value.launchLogIndex) !== Number(value.routeLogIndex) + 1 ||
+    !isUnsignedDecimal(value.finalizedAtBlockNumber) ||
+    !isBytes32(value.finalizedAtBlockHash) ||
+    !isAddress(value.poolManagerAddress) ||
+    !sameHex(
+      value.poolManagerAddress,
+      CANONICAL_LAUNCH_STAMP_V1.poolManagerAddress,
+    ) ||
+    !isBytes32(value.poolId) ||
+    !areCanonicalCurrencies(value.poolKey) ||
+    !Number.isSafeInteger(value.poolKey.fee) ||
+    Number(value.poolKey.fee) < 0 ||
+    (Number(value.poolKey.fee) !== 0x80_00_00 &&
+      Number(value.poolKey.fee) > 1_000_000) ||
+    !Number.isSafeInteger(value.poolKey.tickSpacing) ||
+    Number(value.poolKey.tickSpacing) < 1 ||
+    Number(value.poolKey.tickSpacing) > 32_767 ||
+    !isAddress(value.poolKey.hooks) ||
+    !isNonZeroBytes32(value.poolKeyHash) ||
+    !isNonZeroBytes32(value.componentSetHash) ||
+    !isBytes32(value.routePayloadHash) ||
+    !isNonZeroAddress(value.routeLauncherAddress) ||
+    !isNonZeroBytes32(value.routeLauncherRuntimeCodeHash) ||
+    !isBytes32(value.expectedResultHash) ||
+    !isBytes32(value.permitDigest) ||
+    !Array.isArray(value.components) ||
+    value.components.length < 2 ||
+    value.components.length > 16 ||
+    !isRecord(value.tokenProof) ||
+    !isNonZeroAddress(value.tokenProof.tokenAddress) ||
+    !sameHex(value.tokenProof.launchId, value.launchId) ||
+    !sameHex(value.tokenProof.stampHash, value.stampHash) ||
+    !isRecord(value.poolProof) ||
+    !sameHex(value.poolProof.poolManagerAddress, value.poolManagerAddress) ||
+    !sameHex(value.poolProof.poolId, value.poolId) ||
+    !sameHex(value.poolProof.launchId, value.launchId) ||
+    !sameHex(value.poolProof.stampHash, value.stampHash)
+  ) {
+    return false;
+  }
+
+  if (
+    BigInt(value.blockNumber) < BigInt(value.routerStartBlock) ||
+    BigInt(value.finalizedAtBlockNumber) <
+      BigInt(value.blockNumber) + BigInt(value.finalityConfirmations) ||
+    (expected.chainId !== undefined && value.chainId !== expected.chainId) ||
+    (expected.tokenAddress !== undefined &&
+      !sameHex(value.tokenProof.tokenAddress, expected.tokenAddress)) ||
+    (expected.hookAddress !== undefined &&
+      !sameHex(value.poolKey.hooks, expected.hookAddress)) ||
+    (expected.poolId !== undefined && !sameHex(value.poolId, expected.poolId))
+    || (expected.launchWallet !== undefined &&
+      !sameHex(value.launchWallet, expected.launchWallet))
+    || (expected.transactionHash !== undefined &&
+      !sameHex(value.transactionHash, expected.transactionHash))
+    || (expected.blockNumber !== undefined &&
+      value.blockNumber !== expected.blockNumber)
+    || (expected.transactionIndex !== undefined &&
+      value.transactionIndex !== expected.transactionIndex)
+    || (expected.launchLogIndex !== undefined &&
+      value.launchLogIndex !== expected.launchLogIndex)
+  ) {
+    return false;
+  }
+
+  const seenComponents = new Set<string>();
+  const seenComponentLogIndexes = new Set<number>();
+  let previousComponentLogIndex: number | null = null;
+  let tokenComponentCount = 0;
+  let hookComponentCount = 0;
+  for (const component of value.components) {
+    if (
+      !isRecord(component) ||
+      !isAddress(component.address) ||
+      (component.kind !== "token" &&
+        component.kind !== "hook" &&
+        component.kind !== "other") ||
+      (component.scope !== "exclusive" &&
+        component.scope !== "shared-infrastructure") ||
+      !isNonZeroBytes32(component.runtimeCodeHash) ||
+      !Number.isSafeInteger(component.logIndex) ||
+      Number(component.logIndex) < 0 ||
+      Number(component.logIndex) >= Number(value.routeLogIndex)
+    ) {
+      return false;
+    }
+    const componentAddress = component.address.toLowerCase();
+    if (seenComponents.has(componentAddress)) return false;
+    seenComponents.add(componentAddress);
+    const componentLogIndex = Number(component.logIndex);
+    if (seenComponentLogIndexes.has(componentLogIndex)) return false;
+    if (
+      previousComponentLogIndex !== null &&
+      componentLogIndex !== previousComponentLogIndex + 1
+    ) return false;
+    seenComponentLogIndexes.add(componentLogIndex);
+    previousComponentLogIndex = componentLogIndex;
+
+    if (component.scope === "exclusive") {
+      if (
+        !isRecord(component.exclusiveProof) ||
+        !sameHex(component.exclusiveProof.launchId, value.launchId) ||
+        !sameHex(component.exclusiveProof.stampHash, value.stampHash)
+      ) {
+        return false;
+      }
+    } else if (component.exclusiveProof !== null) {
+      return false;
+    }
+
+    if (
+      component.kind === "token" &&
+      sameHex(component.address, value.tokenProof.tokenAddress) &&
+      component.scope === "exclusive"
+    ) {
+      tokenComponentCount += 1;
+    }
+    if (
+      component.kind === "hook" &&
+      sameHex(component.address, value.poolKey.hooks) &&
+      component.scope ===
+        (value.kind === "custom-graph" ? "exclusive" : "shared-infrastructure")
+    ) {
+      hookComponentCount += 1;
+    }
+  }
+
+  return tokenComponentCount === 1 &&
+    hookComponentCount === 1 &&
+    previousComponentLogIndex === Number(value.routeLogIndex) - 1;
+}
+
 export type ExploreLaunchCategoryProvenance =
   | Readonly<{
       schemaVersion: "programmable.explore-launch-category-provenance.v1";
@@ -15,6 +313,19 @@ export type ExploreLaunchCategoryProvenance =
       recordId: string;
       modelId: string | null;
       modelVersion: string | null;
+    }>
+  | Readonly<{
+      schemaVersion: "programmable.explore-launch-category-provenance.v1";
+      category: "classic" | "custom";
+      source: "canonical-launch-stamp-router";
+      launchId: `0x${string}`;
+      stampHash: `0x${string}`;
+      routerAddress: `0x${string}`;
+      transactionHash: `0x${string}`;
+      blockHash: `0x${string}`;
+      blockNumber: string;
+      transactionIndex: number;
+      logIndex: number;
     }>
   | Readonly<{
       schemaVersion: "programmable.explore-launch-category-provenance.v1";
@@ -160,13 +471,19 @@ export type LauncherToken = {
   programmableFeeBps?: number;
   launcherFeeBps?: number;
   transferTaxBps?: number;
-  totalSwapFeeBps: number;
-  launchModel?: "classic" | "adaptive" | "deep" | "stock-paired";
+  totalSwapFeeBps: number | null;
+  launchModel?:
+    | "classic"
+    | "adaptive"
+    | "deep"
+    | "stock-paired"
+    | "custom-graph";
   launchModelVersion?:
     | "classic-v3"
     | "stock-paired-v1"
     | "stock-paired-v2"
-    | "stock-paired-v3";
+    | "stock-paired-v3"
+    | "programmable-launch-stamp-router-v1";
   deepReleaseVersion?:
     "deep-full-range-v1" | "deep-full-range-v2" | "deep-full-range-v3";
   adaptiveCurveHash?: `0x${string}`;
@@ -204,6 +521,7 @@ export type LauncherToken = {
   automationGuaranteed?: false;
   deepV2Provenance?: DeepV2IndexedLaunchProvenance;
   deepV3Provenance?: DeepV3IndexedLaunchProvenance;
+  launchStampProvenance?: LaunchStampProvenanceV1;
   uniswapV4Pool?: {
     source: "official-uniswap-v4-subgraph";
     indexedBlockNumber: string;
@@ -216,16 +534,21 @@ export type LauncherToken = {
     tick?: number;
     feeTierPips: string;
   };
-  liquidityPath: "meme";
+  liquidityPath: "meme" | "programmable-v4";
   metadataExtraData?: `0x${string}`;
 };
 
 export type CanonicalTokenExploreEntry = LauncherToken & Readonly<{
   exploreKind: "token";
-  launchCategoryProvenance: Extract<
-    ExploreLaunchCategoryProvenance,
-    { category: "classic" }
-  >;
+  launchCategoryProvenance:
+    | Extract<
+        ExploreLaunchCategoryProvenance,
+        { category: "classic" }
+      >
+    | Extract<
+        ExploreLaunchCategoryProvenance,
+        { source: "canonical-launch-stamp-router" }
+      >;
 }>;
 
 export type CustomProjectExploreEntry = Readonly<{

--- a/tests/alchemy-launch-refresh.test.ts
+++ b/tests/alchemy-launch-refresh.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   getOnchainDeployment: vi.fn(),
   readDurableExploreModel: vi.fn(),
   advanceExploreLaunchDiscovery: vi.fn(),
+  advanceLaunchStampRouterSlice: vi.fn(),
   readAlchemyLaunchRegistry: vi.fn(),
   writeAlchemyLaunchRegistry: vi.fn(),
 }));
@@ -22,12 +23,18 @@ vi.mock("../lib/onchain/durable-model", () => ({
 vi.mock("../lib/onchain/read-model", () => ({
   advanceExploreLaunchDiscovery: mocks.advanceExploreLaunchDiscovery,
 }));
+vi.mock("../lib/alchemy/launch-stamp.server", () => ({
+  advanceLaunchStampRouterSlice: mocks.advanceLaunchStampRouterSlice,
+}));
 vi.mock("../lib/alchemy/launch-registry.server", () => ({
   readAlchemyLaunchRegistry: mocks.readAlchemyLaunchRegistry,
   writeAlchemyLaunchRegistry: mocks.writeAlchemyLaunchRegistry,
 }));
 
 import { refreshAlchemyExploreRegistry } from "../lib/alchemy/explore.server";
+import { canonicalTokenExploreEntryV1 } from "../lib/explore-entry-v1";
+import type { LauncherToken } from "../lib/tokens";
+import { stampedClassicToken } from "./launch-stamp-surface-fixture";
 
 const deployment = {
   environment: "production",
@@ -111,10 +118,37 @@ describe("Alchemy launch overlay refresh", () => {
         chainId: 1,
         cursor: snapshot("100"),
         tokens: [],
+        launchStampRouter: {
+          schemaVersion: "programmable-launch-stamp-router-registry-v1",
+          binding: {
+            chainId: 1,
+            routerAddress: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+            routerRuntimeCodeHash:
+              "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+            startBlock: "25717612",
+            finalityConfirmations: 64,
+          },
+          cursor: {
+            blockNumber: "25717611",
+            blockHash:
+              "0x2d42bd6f5cea0a09b7a76c5ca51569ac69e677cef0498b12730d6f1f7a979a5e",
+          },
+          tokens: [],
+        },
       },
       etag: "registry-etag",
     });
     mocks.writeAlchemyLaunchRegistry.mockResolvedValue({ etag: "next-etag" });
+    mocks.advanceLaunchStampRouterSlice.mockImplementation(
+      async (_deployment, slice) => ({
+        slice,
+        scannedFromBlock: null,
+        scannedToBlock: null,
+        discovered: 0,
+        hydrated: 0,
+        rebuiltAfterReorg: false,
+      }),
+    );
   });
 
   afterEach(() => {
@@ -191,6 +225,214 @@ describe("Alchemy launch overlay refresh", () => {
     expect(result.model.tokens[1]).toMatchObject({
       launchDiscoverySource: "alchemy-launch-overlay",
     });
+  });
+
+  it("advances and persists the independent finalized Router cursor exactly once", async () => {
+    mocks.advanceExploreLaunchDiscovery
+      .mockResolvedValueOnce({ ...baseModel, snapshot: snapshot("110") })
+      .mockResolvedValueOnce({ ...baseModel, snapshot: snapshot("111") });
+    mocks.advanceLaunchStampRouterSlice.mockImplementationOnce(
+      async (_deployment, slice) => ({
+        slice: {
+          ...slice,
+          cursor: {
+            blockNumber: "25717680",
+            blockHash: `0x${"ab".repeat(32)}`,
+          },
+        },
+        scannedFromBlock: "25717612",
+        scannedToBlock: "25717680",
+        discovered: 0,
+        hydrated: 0,
+        rebuiltAfterReorg: false,
+      }),
+    );
+
+    const result = await refreshAlchemyExploreRegistry();
+
+    expect(mocks.advanceLaunchStampRouterSlice).toHaveBeenCalledTimes(1);
+    expect(mocks.advanceLaunchStampRouterSlice).toHaveBeenCalledWith(
+      deployment,
+      expect.objectContaining({
+        cursor: expect.objectContaining({ blockNumber: "25717611" }),
+      }),
+    );
+    expect(mocks.advanceExploreLaunchDiscovery).toHaveBeenCalledTimes(2);
+    expect(mocks.writeAlchemyLaunchRegistry).toHaveBeenCalledWith(
+      deployment,
+      expect.objectContaining({
+        launchStampRouter: expect.objectContaining({
+          cursor: expect.objectContaining({ blockNumber: "25717680" }),
+        }),
+      }),
+      "registry-etag",
+    );
+    expect(result.launchStampRouterBlockNumber).toBe("25717680");
+  });
+
+  it("persists a Router cursor hash replacement even without block progress", async () => {
+    const stored = await mocks.readAlchemyLaunchRegistry();
+    mocks.readAlchemyLaunchRegistry.mockResolvedValue({
+      ...stored,
+      registry: {
+        ...stored.registry,
+        launchStampRouter: {
+          ...stored.registry.launchStampRouter,
+          cursor: {
+            blockNumber: "25717680",
+            blockHash: `0x${"aa".repeat(32)}`,
+          },
+        },
+      },
+    });
+    mocks.advanceExploreLaunchDiscovery.mockResolvedValue({
+      ...baseModel,
+      snapshot: snapshot("100"),
+    });
+    mocks.advanceLaunchStampRouterSlice.mockImplementationOnce(
+      async (_deployment, slice) => ({
+        slice: {
+          ...slice,
+          cursor: {
+            ...slice.cursor,
+            blockHash: `0x${"bb".repeat(32)}`,
+          },
+        },
+        scannedFromBlock: "25717612",
+        scannedToBlock: "25717680",
+        discovered: 0,
+        hydrated: 0,
+        rebuiltAfterReorg: false,
+      }),
+    );
+
+    const result = await refreshAlchemyExploreRegistry({
+      includeLatest: false,
+    });
+
+    expect(result.registryChanged).toBe(true);
+    expect(mocks.writeAlchemyLaunchRegistry).toHaveBeenCalledWith(
+      deployment,
+      expect.objectContaining({
+        launchStampRouter: expect.objectContaining({
+          cursor: expect.objectContaining({
+            blockNumber: "25717680",
+            blockHash: `0x${"bb".repeat(32)}`,
+          }),
+        }),
+      }),
+      "registry-etag",
+    );
+  });
+
+  it("persists a Router-only reorg rebuild even below the cursor interval", async () => {
+    const stored = await mocks.readAlchemyLaunchRegistry();
+    mocks.readAlchemyLaunchRegistry.mockResolvedValue({
+      ...stored,
+      registry: {
+        ...stored.registry,
+        launchStampRouter: {
+          ...stored.registry.launchStampRouter,
+          cursor: {
+            blockNumber: "25717680",
+            blockHash: `0x${"aa".repeat(32)}`,
+          },
+        },
+      },
+    });
+    mocks.advanceExploreLaunchDiscovery.mockResolvedValue({
+      ...baseModel,
+      snapshot: snapshot("100"),
+    });
+    mocks.advanceLaunchStampRouterSlice.mockImplementationOnce(
+      async (_deployment, slice) => ({
+        slice: {
+          ...slice,
+          cursor: {
+            blockNumber: "25717690",
+            blockHash: `0x${"bb".repeat(32)}`,
+          },
+        },
+        scannedFromBlock: "25717612",
+        scannedToBlock: "25717690",
+        discovered: 0,
+        hydrated: 0,
+        rebuiltAfterReorg: true,
+      }),
+    );
+
+    const result = await refreshAlchemyExploreRegistry({
+      includeLatest: false,
+    });
+
+    expect(result.registryChanged).toBe(true);
+    expect(mocks.writeAlchemyLaunchRegistry).toHaveBeenCalledWith(
+      deployment,
+      expect.objectContaining({
+        launchStampRouter: expect.objectContaining({
+          cursor: expect.objectContaining({ blockNumber: "25717690" }),
+        }),
+      }),
+      "registry-etag",
+    );
+  });
+
+  it("keeps a stamped Classic authoritative over the legacy Classic overlay", async () => {
+    const unstampedClassic: LauncherToken = { ...stampedClassicToken };
+    delete unstampedClassic.launchStampProvenance;
+    const legacyClassic = {
+      ...unstampedClassic,
+      launchModelVersion: "classic-v3",
+      liquidityPath: "meme",
+      totalSwapFeeBps: 100,
+      buyHookFeeBps: 100,
+      sellHookFeeBps: 100,
+      creatorFeeBps: 90,
+      launcherFeeBps: 10,
+      positionRecipient:
+        "0x7777777777777777777777777777777777777777",
+      positionTokenId: "42",
+    } as const;
+    const classicModel = {
+      ...baseModel,
+      tokens: [baseToken, legacyClassic],
+      snapshot: snapshot("110"),
+    };
+    mocks.advanceExploreLaunchDiscovery.mockResolvedValue(classicModel);
+    mocks.advanceLaunchStampRouterSlice.mockResolvedValueOnce({
+      slice: {
+        cursor: {
+          blockNumber: "25718017",
+          blockHash: `0x${"cd".repeat(32)}`,
+        },
+        tokens: [stampedClassicToken],
+      },
+      scannedFromBlock: "25717612",
+      scannedToBlock: "25718017",
+      discovered: 1,
+      hydrated: 1,
+      rebuiltAfterReorg: false,
+    });
+
+    const result = await refreshAlchemyExploreRegistry({
+      includeLatest: false,
+      persist: false,
+    });
+    const stamped = result.model.tokens.find(
+      ({ tokenAddress }) =>
+        tokenAddress.toLowerCase() ===
+        stampedClassicToken.tokenAddress.toLowerCase(),
+    );
+
+    expect(stamped).toMatchObject({
+      launchModel: "classic",
+      launchModelVersion: "programmable-launch-stamp-router-v1",
+      liquidityPath: "programmable-v4",
+      totalSwapFeeBps: null,
+    });
+    expect(stamped).not.toHaveProperty("buyHookFeeBps");
+    expect(stamped).not.toHaveProperty("positionRecipient");
+    expect(() => canonicalTokenExploreEntryV1(stamped!)).not.toThrow();
   });
 
   it("retries an ETag conflict once but does not retry an RPC failure", async () => {

--- a/tests/alchemy-launch-registry.test.ts
+++ b/tests/alchemy-launch-registry.test.ts
@@ -11,6 +11,8 @@ const blobMocks = vi.hoisted(() => ({
 vi.mock("@vercel/blob", () => blobMocks);
 
 import {
+  LAUNCH_STAMP_ROUTER_BINDING,
+  LAUNCH_STAMP_ROUTER_INITIAL_CURSOR,
   validateAlchemyLaunchRegistryEnvelope,
   writeAlchemyLaunchRegistry,
   type AlchemyLaunchRegistry,
@@ -57,8 +59,165 @@ function token(input: Readonly<{ address?: `0x${string}`; block?: string; log?: 
   };
 }
 
-function envelope(tokens: readonly LauncherToken[] = [token()]) {
-  const payload: AlchemyLaunchRegistry = {
+function routerToken(
+  input: Readonly<{
+    address?: `0x${string}`;
+    launchId?: `0x${string}`;
+    poolId?: `0x${string}`;
+    transactionHash?: `0x${string}`;
+  }> = {},
+): LauncherToken {
+  const address = input.address ??
+    "0x9444444444444444444444444444444444444444";
+  const hookAddress = "0x9555555555555555555555555555555555555555";
+  const launchId = input.launchId ?? `0x${"91".repeat(32)}`;
+  const stampHash = `0x${"92".repeat(32)}` as const;
+  const poolId = input.poolId ?? `0x${"93".repeat(32)}`;
+  const transactionHash = input.transactionHash ?? `0x${"94".repeat(32)}`;
+  return {
+    id: `1:${address.toLowerCase()}`,
+    name: "Stamped",
+    symbol: "STAMP",
+    tokenAddress: address,
+    hookAddress,
+    poolId,
+    creatorAddress: "0x9666666666666666666666666666666666666666",
+    launchBlockNumber: "25717620",
+    launchTransactionHash: transactionHash,
+    launchTransactionIndex: 2,
+    launchLogIndex: 9,
+    launchedAt: "2026-08-09T00:00:00.000Z",
+    totalSwapFeeBps: null,
+    launchModel: "custom-graph",
+    launchModelVersion: "programmable-launch-stamp-router-v1",
+    liquidityPath: "programmable-v4",
+    launchStampProvenance: {
+      schemaVersion: "programmable.launch-stamp-provenance.v1",
+      chainId: LAUNCH_STAMP_ROUTER_BINDING.chainId,
+      routerAddress: LAUNCH_STAMP_ROUTER_BINDING.routerAddress,
+      routerRuntimeCodeHash:
+        LAUNCH_STAMP_ROUTER_BINDING.routerRuntimeCodeHash,
+      routerStartBlock: LAUNCH_STAMP_ROUTER_BINDING.startBlock,
+      finalityConfirmations:
+        LAUNCH_STAMP_ROUTER_BINDING.finalityConfirmations,
+      kind: "custom-graph",
+      launchId,
+      stampHash,
+      launchWallet: "0x9666666666666666666666666666666666666666",
+      transactionHash,
+      blockNumber: "25717620",
+      blockHash: `0x${"95".repeat(32)}`,
+      transactionIndex: 2,
+      routeLogIndex: 8,
+      launchLogIndex: 9,
+      finalizedAtBlockNumber: "25717684",
+      finalizedAtBlockHash: `0x${"96".repeat(32)}`,
+      poolManagerAddress: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+      poolId,
+      poolKey: {
+        currency0: "0x0000000000000000000000000000000000000000",
+        currency1: address,
+        fee: 3_000,
+        tickSpacing: 60,
+        hooks: hookAddress,
+      },
+      poolKeyHash: `0x${"97".repeat(32)}`,
+      componentSetHash: `0x${"98".repeat(32)}`,
+      routePayloadHash: `0x${"99".repeat(32)}`,
+      routeLauncherAddress: "0x9777777777777777777777777777777777777777",
+      routeLauncherRuntimeCodeHash: `0x${"a1".repeat(32)}`,
+      expectedResultHash: `0x${"a2".repeat(32)}`,
+      permitDigest: `0x${"a3".repeat(32)}`,
+      components: [
+        {
+          address,
+          kind: "token",
+          scope: "exclusive",
+          runtimeCodeHash: `0x${"a4".repeat(32)}`,
+          logIndex: 6,
+          exclusiveProof: { launchId, stampHash },
+        },
+        {
+          address: hookAddress,
+          kind: "hook",
+          scope: "exclusive",
+          runtimeCodeHash: `0x${"a5".repeat(32)}`,
+          logIndex: 7,
+          exclusiveProof: { launchId, stampHash },
+        },
+      ],
+      tokenProof: { tokenAddress: address, launchId, stampHash },
+      poolProof: {
+        poolManagerAddress: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+        poolId,
+        launchId,
+        stampHash,
+      },
+    },
+  };
+}
+
+function routerClassicToken(): LauncherToken {
+  const custom = routerToken();
+  const provenance = custom.launchStampProvenance!;
+  return {
+    ...custom,
+    launchModel: "classic",
+    launchStampProvenance: {
+      ...provenance,
+      kind: "classic",
+      components: provenance.components.map((component) =>
+        component.kind === "hook"
+          ? {
+              ...component,
+              scope: "shared-infrastructure" as const,
+              exclusiveProof: null,
+            }
+          : component
+      ),
+    },
+  };
+}
+
+function payload(
+  tokens: readonly LauncherToken[] = [token()],
+  routerTokens: readonly LauncherToken[] = [routerToken()],
+): AlchemyLaunchRegistry {
+  return {
+    generatedAt: "2026-08-04T00:01:00.000Z",
+    repositoryCommit: "a".repeat(40),
+    chainId: 1,
+    cursor: {
+      blockNumber: "130",
+      blockHash: `0x${"88".repeat(32)}`,
+    },
+    tokens,
+    launchStampRouter: {
+      schemaVersion: "programmable-launch-stamp-router-registry-v1",
+      binding: LAUNCH_STAMP_ROUTER_BINDING,
+      cursor: {
+        blockNumber: "25717680",
+        blockHash: `0x${"89".repeat(32)}`,
+      },
+      tokens: routerTokens,
+    },
+  };
+}
+
+function envelope(
+  tokens: readonly LauncherToken[] = [token()],
+  routerTokens: readonly LauncherToken[] = [routerToken()],
+) {
+  const registry = payload(tokens, routerTokens);
+  return {
+    schemaVersion: "programmable-alchemy-launch-registry-v2",
+    contentHash: keccak256(toBytes(JSON.stringify(registry))),
+    payload: registry,
+  };
+}
+
+function legacyEnvelope(tokens: readonly LauncherToken[] = [token()]) {
+  const registry = {
     generatedAt: "2026-08-04T00:01:00.000Z",
     repositoryCommit: "a".repeat(40),
     chainId: 1,
@@ -70,8 +229,8 @@ function envelope(tokens: readonly LauncherToken[] = [token()]) {
   };
   return {
     schemaVersion: "programmable-alchemy-launch-registry-v1",
-    contentHash: keccak256(toBytes(JSON.stringify(payload))),
-    payload,
+    contentHash: keccak256(toBytes(JSON.stringify(registry))),
+    payload: registry,
   };
 }
 
@@ -96,13 +255,38 @@ describe("Alchemy incremental launch registry", () => {
       chainId: 1,
       cursor: { blockNumber: "130" },
       tokens: [{ name: "Newest", launchBlockNumber: "120" }],
+      launchStampRouter: {
+        cursor: { blockNumber: "25717680" },
+        tokens: [{ name: "Stamped" }],
+      },
     });
+  });
+
+  it("migrates a v1 payload to the independent Router start cursor", () => {
+    expect(
+      validateAlchemyLaunchRegistryEnvelope(legacyEnvelope(), deployment),
+    ).toMatchObject({
+      cursor: { blockNumber: "130" },
+      launchStampRouter: {
+        cursor: LAUNCH_STAMP_ROUTER_INITIAL_CURSOR,
+        tokens: [],
+      },
+    });
+  });
+
+  it("never accepts stamped records through the legacy Classic cursor", () => {
+    expect(() =>
+      validateAlchemyLaunchRegistryEnvelope(
+        legacyEnvelope([{ ...routerToken(), launchBlockNumber: "120" }]),
+        deployment,
+      )
+    ).toThrow("invalid token");
   });
 
   it("rejects a token beyond the committed cursor", () => {
     expect(() =>
       validateAlchemyLaunchRegistryEnvelope(
-        envelope([token({ block: "131" })]),
+        envelope([token({ block: "131" })], []),
         deployment,
       )
     ).toThrow("invalid token");
@@ -116,10 +300,79 @@ describe("Alchemy incremental launch registry", () => {
           token({
             address: "0x9999999999999999999999999999999999999999",
           }),
+        ], []),
+        deployment,
+      )
+    ).toThrow("duplicate provenance");
+  });
+
+  it("rejects duplicate Router launch, pool, token, or event provenance", () => {
+    expect(() =>
+      validateAlchemyLaunchRegistryEnvelope(
+        envelope([], [
+          routerToken(),
+          routerToken({
+            address: "0x9888888888888888888888888888888888888888",
+          }),
         ]),
         deployment,
       )
     ).toThrow("duplicate provenance");
+  });
+
+  it("rejects the same token across the Classic and Router slices", () => {
+    const classic = token();
+    expect(() =>
+      validateAlchemyLaunchRegistryEnvelope(
+        envelope([classic], [
+          routerToken({ address: classic.tokenAddress }),
+        ]),
+        deployment,
+      )
+    ).toThrow("slices contain duplicate tokens");
+  });
+
+  it("rejects Router tokens that drift from the canonical binding", () => {
+    const valid = payload([], [routerToken()]);
+    const drifted = {
+      ...valid,
+      launchStampRouter: {
+        ...valid.launchStampRouter,
+        binding: {
+          ...LAUNCH_STAMP_ROUTER_BINDING,
+          finalityConfirmations: 12,
+        },
+      },
+    };
+    const candidate = {
+      schemaVersion: "programmable-alchemy-launch-registry-v2",
+      contentHash: keccak256(toBytes(JSON.stringify(drifted))),
+      payload: drifted,
+    };
+    expect(() =>
+      validateAlchemyLaunchRegistryEnvelope(candidate, deployment)
+    ).toThrow("Router registry is malformed");
+  });
+
+  it.each([
+    ["legacy model version", { launchModelVersion: "classic-v3" }],
+    ["invented total fee", { totalSwapFeeBps: 100 }],
+    ["invented hook fee", { buyHookFeeBps: 100 }],
+    [
+      "invented position",
+      {
+        positionRecipient:
+          "0x9777777777777777777777777777777777777777",
+        positionTokenId: "42",
+      },
+    ],
+  ] as const)("rejects stamped Classic with %s", (_label, mutation) => {
+    expect(() =>
+      validateAlchemyLaunchRegistryEnvelope(
+        envelope([], [{ ...routerClassicToken(), ...mutation }]),
+        deployment,
+      )
+    ).toThrow("invalid token");
   });
 
   it("rejects payload mutation after the content commitment", () => {

--- a/tests/alchemy-launch-stamp.test.ts
+++ b/tests/alchemy-launch-stamp.test.ts
@@ -1,0 +1,961 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const runtimeHashOverrides = vi.hoisted(() =>
+  new Map<string, `0x${string}`>()
+);
+
+vi.mock("viem", async () => {
+  const actual = await vi.importActual<typeof import("viem")>("viem");
+  return {
+    ...actual,
+    keccak256: (value: `0x${string}` | Uint8Array) => {
+      if (typeof value === "string") {
+        const override = runtimeHashOverrides.get(value.toLowerCase());
+        if (override) return override;
+      }
+      return actual.keccak256(value);
+    },
+  };
+});
+
+import {
+  encodeAbiParameters,
+  encodeEventTopics,
+  getAddress,
+  parseAbiParameters,
+  type Address,
+  type Hex,
+  type Log,
+  type TransactionReceipt,
+} from "viem";
+
+import {
+  advanceLaunchStampRouterSlice,
+  createInitialLaunchStampRouterSlice,
+  hydrateLaunchStampAnchor,
+  LAUNCH_STAMP_DIRECT_CALL_SELECTOR,
+  LAUNCH_STAMP_FINALITY_CONFIRMATIONS,
+  LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+  LAUNCH_STAMP_POOL_MANAGER_RUNTIME_CODE_HASH,
+  LAUNCH_STAMP_ROUTER_ADDRESS,
+  LAUNCH_STAMP_ROUTER_INITIAL_CURSOR,
+  LAUNCH_STAMP_ROUTER_RUNTIME_CODE_HASH,
+  LAUNCH_STAMP_ROUTER_START_BLOCK,
+  launchStampComponentEvent,
+  launchStampLaunchEvent,
+  launchStampRouteEvent,
+  parseLaunchStampReceipt,
+  poolManagerInitializeEvent,
+  scanLaunchStampAnchors,
+  type LaunchStampAnchor,
+  type LaunchStampReaderClient,
+} from "../lib/alchemy/launch-stamp.server";
+import type { ReadyOnchainDeployment } from "../lib/onchain/types";
+import type { LauncherToken } from "../lib/tokens";
+import { computeOfficialV4PoolId } from "../lib/uniswap/liquidity-launcher-sdk";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const STATE_VIEW = getAddress("0x3333333333333333333333333333333333333333");
+const STATE_VIEW_HASH = hex32(0x33);
+const ROUTER_CODE = "0x600001" as Hex;
+const POOL_MANAGER_CODE = "0x600002" as Hex;
+const STATE_VIEW_CODE = "0x600003" as Hex;
+
+const deployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: getAddress("0x1111111111111111111111111111111111111111"),
+  feeHook: getAddress("0x2222222222222222222222222222222222222222"),
+  launcherRuntimeCodeHash: hex32(0x11),
+  feeHookRuntimeCodeHash: hex32(0x22),
+  deploymentBlock: 1n,
+  stateView: STATE_VIEW,
+  stateViewRuntimeCodeHash: STATE_VIEW_HASH,
+  rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/redacted",
+  rpcUrlSecondary: null,
+  confirmations: 12n,
+  logBlockRange: 5_000n,
+} satisfies ReadyOnchainDeployment;
+
+function hex32(seed: number): Hex {
+  return `0x${seed.toString(16).padStart(64, "0")}`;
+}
+
+function address(seed: number): Address {
+  return getAddress(`0x${seed.toString(16).padStart(40, "0")}`);
+}
+
+function marker(seed: number): Hex {
+  return `0x60${seed.toString(16).padStart(8, "0")}`;
+}
+
+function exactTopics(
+  topics: readonly (Hex | readonly Hex[] | null)[],
+): readonly Hex[] {
+  return topics.map((topic) => {
+    if (typeof topic !== "string") {
+      throw new Error("Test fixture did not encode an exact event topic");
+    }
+    return topic;
+  });
+}
+
+function rawLog(input: Readonly<{
+  address: Address;
+  topics: readonly Hex[];
+  data: Hex;
+  blockNumber: bigint;
+  blockHash: Hex;
+  transactionHash: Hex;
+  transactionIndex: number;
+  logIndex: number;
+}>): Log {
+  return {
+    ...input,
+    topics: input.topics,
+    removed: false,
+  } as Log;
+}
+
+type Fixture = ReturnType<typeof fixture>;
+
+function fixture(input: Readonly<{
+  seed: number;
+  kind?: 1 | 2;
+  blockNumber?: bigint;
+  blockHash?: Hex;
+  transactionHash?: Hex;
+  transactionIndex?: number;
+  firstLogIndex?: number;
+  hook?: Address;
+  hookRuntimeCodeHash?: Hex;
+  hookCode?: Hex;
+}> ) {
+  const seed = input.seed;
+  const token = address(0x1000 + seed * 10);
+  const hook = input.hook ?? address(0x1001 + seed * 10);
+  const routeLauncher = address(0x1002 + seed * 10);
+  const poolKey = {
+    currency0: getAddress(ZERO_ADDRESS),
+    currency1: token,
+    fee: 3_000,
+    tickSpacing: 60,
+    hooks: hook,
+  } as const;
+  const poolId = computeOfficialV4PoolId(poolKey);
+  const blockNumber = input.blockNumber ??
+    LAUNCH_STAMP_ROUTER_START_BLOCK + BigInt(seed);
+  const blockHash = input.blockHash ?? hex32(0x100 + seed);
+  const transactionHash = input.transactionHash ?? hex32(0x200 + seed);
+  const transactionIndex = input.transactionIndex ?? 1;
+  const first = input.firstLogIndex ?? 1;
+  const launchId = hex32(0x300 + seed);
+  const stampHash = hex32(0x400 + seed);
+  const tokenRuntimeCodeHash = hex32(0x500 + seed);
+  const hookRuntimeCodeHash = input.hookRuntimeCodeHash ?? hex32(0x600 + seed);
+  const routeRuntimeCodeHash = hex32(0x700 + seed);
+  const routePayloadHash = hex32(0x800 + seed);
+  const expectedResultHash = hex32(0x900 + seed);
+  const permitDigest = hex32(0xa00 + seed);
+  const poolKeyHash = hex32(0xb00 + seed);
+  const componentSetHash = hex32(0xc00 + seed);
+  const kind = input.kind ?? 1;
+
+  const initialize = rawLog({
+    address: LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+    topics: exactTopics(encodeEventTopics({
+      abi: [poolManagerInitializeEvent],
+      eventName: "Initialize",
+      args: { id: poolId, currency0: poolKey.currency0, currency1: token },
+    })),
+    data: encodeAbiParameters(
+      parseAbiParameters("uint24 fee,int24 tickSpacing,address hooks,uint160 sqrtPriceX96,int24 tick"),
+      [poolKey.fee, poolKey.tickSpacing, hook, 2n ** 96n, 0],
+    ),
+    blockNumber,
+    blockHash,
+    transactionHash,
+    transactionIndex,
+    logIndex: first,
+  });
+  const component = (
+    componentAddress: Address,
+    componentKind: 1 | 2,
+    runtimeCodeHash: Hex,
+    logIndex: number,
+  ) => rawLog({
+    address: LAUNCH_STAMP_ROUTER_ADDRESS,
+    topics: exactTopics(encodeEventTopics({
+      abi: [launchStampComponentEvent],
+      eventName: "ProgrammableComponentStampedV1",
+      args: { launchId, component: componentAddress, kind: componentKind },
+    })),
+    data: encodeAbiParameters(
+      parseAbiParameters("bytes32 runtimeCodeHash"),
+      [runtimeCodeHash],
+    ),
+    blockNumber,
+    blockHash,
+    transactionHash,
+    transactionIndex,
+    logIndex,
+  });
+  const route = rawLog({
+    address: LAUNCH_STAMP_ROUTER_ADDRESS,
+    topics: exactTopics(encodeEventTopics({
+      abi: [launchStampRouteEvent],
+      eventName: "ProgrammableLaunchRouteStampedV1",
+      args: { launchId, kind, routePayloadHash },
+    })),
+    data: encodeAbiParameters(
+      parseAbiParameters("bytes32 expectedResultHash,bytes32 permitDigest"),
+      [expectedResultHash, permitDigest],
+    ),
+    blockNumber,
+    blockHash,
+    transactionHash,
+    transactionIndex,
+    logIndex: first + 3,
+  });
+  const launch = rawLog({
+    address: LAUNCH_STAMP_ROUTER_ADDRESS,
+    topics: exactTopics(encodeEventTopics({
+      abi: [launchStampLaunchEvent],
+      eventName: "ProgrammableLaunchStampedV1",
+      args: { launchId, token, hook },
+    })),
+    data: encodeAbiParameters(
+      parseAbiParameters("address poolManager,bytes32 poolId,bytes32 stampHash"),
+      [LAUNCH_STAMP_POOL_MANAGER_ADDRESS, poolId, stampHash],
+    ),
+    blockNumber,
+    blockHash,
+    transactionHash,
+    transactionIndex,
+    logIndex: first + 4,
+  });
+  const logs = [
+    initialize,
+    component(token, 1, tokenRuntimeCodeHash, first + 1),
+    component(hook, 2, hookRuntimeCodeHash, first + 2),
+    route,
+    launch,
+  ];
+  const anchor: LaunchStampAnchor = {
+    launchId,
+    token,
+    hook,
+    poolManager: LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+    poolId,
+    stampHash,
+    blockNumber,
+    blockHash,
+    transactionHash,
+    transactionIndex,
+    logIndex: first + 4,
+  };
+  return {
+    anchor,
+    logs,
+    kind,
+    poolKey,
+    routeLauncher,
+    routeRuntimeCodeHash,
+    routePayloadHash,
+    expectedResultHash,
+    permitDigest,
+    poolKeyHash,
+    componentSetHash,
+    tokenRuntimeCodeHash,
+    hookRuntimeCodeHash,
+    tokenCode: marker(0x100 + seed),
+    hookCode: input.hookCode ?? marker(0x200 + seed),
+    routeCode: marker(0x300 + seed),
+    record: {
+      kind,
+      launchWallet: address(0x9000 + seed),
+      token,
+      hook,
+      poolManager: LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+      poolId,
+      poolKeyHash,
+      componentSetHash,
+      routePayloadHash,
+      routeLauncher,
+      routeLauncherRuntimeCodeHash: routeRuntimeCodeHash,
+      expectedResultHash,
+      permitDigest,
+      stampHash,
+    },
+  };
+}
+
+function receiptFor(fixtures: readonly Fixture[]): TransactionReceipt {
+  const first = fixtures[0] as Fixture;
+  return {
+    blockHash: first.anchor.blockHash,
+    blockNumber: first.anchor.blockNumber,
+    contractAddress: null,
+    cumulativeGasUsed: 1n,
+    effectiveGasPrice: 1n,
+    from: address(0xf001),
+    gasUsed: 1n,
+    logs: fixtures.flatMap(({ logs }) => logs),
+    logsBloom: `0x${"00".repeat(256)}`,
+    status: "success",
+    to: address(0xf002),
+    transactionHash: first.anchor.transactionHash,
+    transactionIndex: first.anchor.transactionIndex,
+    type: "eip1559",
+  } as unknown as TransactionReceipt;
+}
+
+function clientFor(
+  fixtures: readonly Fixture[],
+  options: Readonly<{
+    latestBlock?: bigint;
+    metadataFailures?: ReadonlySet<string>;
+    unsafeMetadata?: ReadonlySet<string>;
+    wrongProofAddress?: Address;
+    wrongPoolKeyHash?: boolean;
+    wrongRuntimeAddress?: Address;
+    cursorCanonicalHash?: Hex;
+    sharedHookExclusiveCollision?: boolean;
+  }> = {},
+) {
+  runtimeHashOverrides.clear();
+  runtimeHashOverrides.set(ROUTER_CODE, LAUNCH_STAMP_ROUTER_RUNTIME_CODE_HASH);
+  runtimeHashOverrides.set(
+    POOL_MANAGER_CODE,
+    LAUNCH_STAMP_POOL_MANAGER_RUNTIME_CODE_HASH,
+  );
+  runtimeHashOverrides.set(STATE_VIEW_CODE, STATE_VIEW_HASH);
+  const codeByAddress = new Map<string, Hex>([
+    [LAUNCH_STAMP_ROUTER_ADDRESS.toLowerCase(), ROUTER_CODE],
+    [LAUNCH_STAMP_POOL_MANAGER_ADDRESS.toLowerCase(), POOL_MANAGER_CODE],
+    [STATE_VIEW.toLowerCase(), STATE_VIEW_CODE],
+  ]);
+  for (const item of fixtures) {
+    codeByAddress.set(item.anchor.token.toLowerCase(), item.tokenCode);
+    codeByAddress.set(item.anchor.hook.toLowerCase(), item.hookCode);
+    codeByAddress.set(item.routeLauncher.toLowerCase(), item.routeCode);
+    runtimeHashOverrides.set(item.tokenCode, item.tokenRuntimeCodeHash);
+    runtimeHashOverrides.set(item.hookCode, item.hookRuntimeCodeHash);
+    runtimeHashOverrides.set(item.routeCode, item.routeRuntimeCodeHash);
+  }
+  const latestBlock = options.latestBlock ??
+    Math.max(...fixtures.map(({ anchor }) => Number(anchor.blockNumber))) + 100;
+  const latest = BigInt(latestBlock);
+  const receiptCalls = vi.fn();
+  const readCalls: Array<Readonly<{
+    address: Address;
+    functionName: string;
+    blockNumber?: bigint;
+    args?: readonly unknown[];
+  }>> = [];
+  const findByToken = (token: Address) => fixtures.find((item) =>
+    item.anchor.token.toLowerCase() === token.toLowerCase()
+  );
+  const findByPool = (poolId: Hex) => fixtures.find((item) =>
+    item.anchor.poolId.toLowerCase() === poolId.toLowerCase()
+  );
+  const findByLaunch = (launchId: Hex) => fixtures.find((item) =>
+    item.anchor.launchId.toLowerCase() === launchId.toLowerCase()
+  );
+  const findByComponent = (component: Address) => fixtures.find((item) =>
+    item.anchor.token.toLowerCase() === component.toLowerCase() ||
+    item.anchor.hook.toLowerCase() === component.toLowerCase()
+  );
+  const client = {
+    getChainId: vi.fn(async () => 1),
+    getBlockNumber: vi.fn(async () => latest),
+    getBlock: vi.fn(async ({ blockNumber }: { blockNumber: bigint }) => {
+      const fixtureAtBlock = fixtures.find((item) =>
+        item.anchor.blockNumber === blockNumber
+      );
+      const hash = blockNumber === LAUNCH_STAMP_ROUTER_START_BLOCK - 1n
+        ? LAUNCH_STAMP_ROUTER_INITIAL_CURSOR.blockHash
+        : options.cursorCanonicalHash &&
+            blockNumber === LAUNCH_STAMP_ROUTER_START_BLOCK + 5n
+          ? options.cursorCanonicalHash
+          : fixtureAtBlock?.anchor.blockHash ?? hex32(Number(blockNumber % 10_000n) + 0xd00);
+      return { number: blockNumber, hash, timestamp: 1_786_284_000n + blockNumber };
+    }),
+    getLogs: vi.fn(async ({ fromBlock, toBlock }: {
+      fromBlock: bigint;
+      toBlock: bigint;
+    }) => fixtures.flatMap((item) =>
+      item.anchor.blockNumber >= fromBlock && item.anchor.blockNumber <= toBlock
+        ? [item.logs.at(-1) as Log]
+        : []
+    )),
+    getTransactionReceipt: vi.fn(async ({ hash }: { hash: Hex }) => {
+      receiptCalls(hash);
+      const matches = fixtures.filter((item) =>
+        item.anchor.transactionHash.toLowerCase() === hash.toLowerCase()
+      );
+      if (matches.length === 0) throw new Error("receipt unavailable");
+      return receiptFor(matches);
+    }),
+    getCode: vi.fn(async ({ address: account }: { address: Address }) => {
+      if (
+        options.wrongRuntimeAddress &&
+        account.toLowerCase() === options.wrongRuntimeAddress.toLowerCase()
+      ) return "0x6000" as Hex;
+      return codeByAddress.get(account.toLowerCase()) ?? "0x";
+    }),
+    readContract: vi.fn(async (input: {
+      address: Address;
+      functionName: string;
+      blockNumber?: bigint;
+      args?: readonly unknown[];
+    }) => {
+      readCalls.push(input);
+      const argument = input.args?.[0];
+      if (input.address.toLowerCase() === LAUNCH_STAMP_ROUTER_ADDRESS.toLowerCase()) {
+        if (input.functionName === "CHAIN_ID") return 1n;
+        if (input.functionName === "POOL_MANAGER") return LAUNCH_STAMP_POOL_MANAGER_ADDRESS;
+        if (input.functionName === "launchStamp") {
+          return findByLaunch(argument as Hex)?.record;
+        }
+        if (input.functionName === "launchIdByToken") {
+          return findByToken(argument as Address)?.anchor.launchId;
+        }
+        if (input.functionName === "launchIdByPool") {
+          return findByPool(input.args?.[1] as Hex)?.anchor.launchId;
+        }
+        if (input.functionName === "computePoolKeyHash") {
+          const key = argument as { currency0: Address; currency1: Address };
+          const item = fixtures.find((candidate) =>
+            candidate.anchor.token.toLowerCase() === key.currency0.toLowerCase() ||
+            candidate.anchor.token.toLowerCase() === key.currency1.toLowerCase()
+          );
+          return options.wrongPoolKeyHash ? hex32(0xdead) : item?.poolKeyHash;
+        }
+        if (input.functionName === "launchIdByComponent") {
+          const item = findByComponent(argument as Address);
+          if (
+            item?.kind === 2 &&
+            item.anchor.hook.toLowerCase() === String(argument).toLowerCase()
+          ) {
+            return options.sharedHookExclusiveCollision
+              ? hex32(0xeeee)
+              : hex32(0);
+          }
+          return item?.anchor.launchId ?? hex32(0);
+        }
+        if (input.functionName === "componentRuntimeCodeHash") {
+          const item = findByComponent(argument as Address);
+          return item?.anchor.token.toLowerCase() === String(argument).toLowerCase()
+            ? item.tokenRuntimeCodeHash
+            : item?.hookRuntimeCodeHash ?? hex32(0);
+        }
+        if (input.functionName === "stampProof") {
+          const item = findByComponent(argument as Address);
+          if (
+            options.wrongProofAddress &&
+            String(argument).toLowerCase() === options.wrongProofAddress.toLowerCase()
+          ) return [hex32(0xdead), hex32(0xbeef)] as const;
+          return item
+            ? [item.anchor.launchId, item.anchor.stampHash] as const
+            : [hex32(0), hex32(0)] as const;
+        }
+      }
+      if (input.address.toLowerCase() === STATE_VIEW.toLowerCase()) {
+        if (input.functionName === "getSlot0") return [2n ** 96n, 0, 0, 3_000] as const;
+        if (input.functionName === "getLiquidity") return 123n;
+      }
+      const tokenFixture = findByToken(input.address);
+      if (tokenFixture) {
+        if (options.metadataFailures?.has(input.address.toLowerCase())) {
+          throw new Error("optional metadata unavailable");
+        }
+        const unsafeMetadata = options.unsafeMetadata?.has(
+          input.address.toLowerCase(),
+        );
+        if (unsafeMetadata && input.functionName === "name") {
+          return `Unsafe\u0000${"N".repeat(100)}`;
+        }
+        if (unsafeMetadata && input.functionName === "symbol") {
+          return `bad\u200b${"S".repeat(20)}`;
+        }
+        if (input.functionName === "name") return `Token ${tokenFixture.anchor.token.slice(-4)}`;
+        if (input.functionName === "symbol") return `T${tokenFixture.anchor.token.slice(-3)}`;
+        if (input.functionName === "decimals") return 18;
+        if (input.functionName === "totalSupply") return 1_000_000n * 10n ** 18n;
+        if (input.functionName === "metadata") {
+          if (unsafeMetadata) {
+            return [
+              `Unsafe\u0000${"D".repeat(400)}`,
+              `https://example.com/${"w".repeat(2_100)}`,
+              "javascript:alert(1)",
+              `0x${"61".repeat(1_201)}`,
+            ] as const;
+          }
+          return {
+            description: "",
+            website: "",
+            image: "",
+            extraData: "0x",
+          };
+        }
+      }
+      throw new Error(`Unexpected read ${input.functionName}`);
+    }),
+  };
+  return {
+    client: client as unknown as LaunchStampReaderClient,
+    receiptCalls,
+    readCalls,
+  };
+}
+
+const PCAN = {
+  transactionHash:
+    "0xc07b4e70233534a1d4f435ffc9a636ed5f542f4aedcde35052c58224f378b612" as Hex,
+  blockNumber: 25_717_953n,
+  blockHash:
+    "0x97827b6586f0dca00e44801acc529c3961b4c693988dfc9f4b2bb4c3d94632ba" as Hex,
+  launchId:
+    "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92" as Hex,
+  stampHash:
+    "0x06cb71b38d9b8b1dd1ffcdb00f31c774be36f5473979c3831d5fd0c96cdaa579" as Hex,
+  token: getAddress("0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE"),
+  hook: getAddress("0xEBa46f25DfF528141dE5317109Acb5A989296044"),
+  poolId:
+    "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229" as Hex,
+};
+
+describe("canonical Launch Stamp Router reader", () => {
+  it("parses the exact direct PCAN event vector without making direct-call shape a trust requirement", () => {
+    const vector = fixture({
+      seed: 90,
+      blockNumber: PCAN.blockNumber,
+      blockHash: PCAN.blockHash,
+      transactionHash: PCAN.transactionHash,
+      transactionIndex: 0,
+      firstLogIndex: 1,
+    });
+    const poolKey = {
+      currency0: getAddress(ZERO_ADDRESS),
+      currency1: PCAN.token,
+      fee: 3_000,
+      tickSpacing: 60,
+      hooks: PCAN.hook,
+    } as const;
+    const components = [
+      [getAddress("0x87B108848B444bC44A01734D62C7be4a2fA64983"), 0,
+        "0x271793d9c3b904cb1e83b1c6db33be85282bae8ebed554937977826638228a94"],
+      [PCAN.token, 1,
+        "0xa72b5518fc9ed183450af8b394834fc78c0971b15cab121cfcaf61aa8af2c5e2"],
+      [PCAN.hook, 2,
+        "0xd59d31add7a3b206972725889dbb726782c0fbd82514710cf2d645749dc3fa25"],
+    ] as const;
+    const base = 12;
+    const componentLogs = components.map(([account, kind, runtime], index) =>
+      rawLog({
+        address: LAUNCH_STAMP_ROUTER_ADDRESS,
+        topics: exactTopics(encodeEventTopics({
+          abi: [launchStampComponentEvent],
+          eventName: "ProgrammableComponentStampedV1",
+          args: { launchId: PCAN.launchId, component: account, kind },
+        })),
+        data: encodeAbiParameters(parseAbiParameters("bytes32"), [runtime]),
+        blockNumber: PCAN.blockNumber,
+        blockHash: PCAN.blockHash,
+        transactionHash: PCAN.transactionHash,
+        transactionIndex: 0,
+        logIndex: base + index,
+      })
+    );
+    const route = rawLog({
+      ...vector.logs[3] as Log,
+      topics: exactTopics(encodeEventTopics({
+        abi: [launchStampRouteEvent],
+        eventName: "ProgrammableLaunchRouteStampedV1",
+        args: {
+          launchId: PCAN.launchId,
+          kind: 1,
+          routePayloadHash:
+            "0x05d20f81020b0fd4a0a5b157e11453210ab73d5615d13bbccef3f023afdb2aa5",
+        },
+      })),
+      data: encodeAbiParameters(parseAbiParameters("bytes32,bytes32"), [
+        "0xda3fa225b1d597ad76665c0b9e894fe429b5cc89e44de855c567fe361fde0809",
+        "0x0f97e3f202181d379805c775db656c36e2cfb77aa0ec56b0daabe0a6c5e84563",
+      ]),
+      blockNumber: PCAN.blockNumber,
+      blockHash: PCAN.blockHash,
+      transactionHash: PCAN.transactionHash,
+      transactionIndex: 0,
+      logIndex: 15,
+    });
+    const launch = rawLog({
+      ...vector.logs[4] as Log,
+      topics: exactTopics(encodeEventTopics({
+        abi: [launchStampLaunchEvent],
+        eventName: "ProgrammableLaunchStampedV1",
+        args: { launchId: PCAN.launchId, token: PCAN.token, hook: PCAN.hook },
+      })),
+      data: encodeAbiParameters(parseAbiParameters("address,bytes32,bytes32"), [
+        LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+        PCAN.poolId,
+        PCAN.stampHash,
+      ]),
+      blockNumber: PCAN.blockNumber,
+      blockHash: PCAN.blockHash,
+      transactionHash: PCAN.transactionHash,
+      transactionIndex: 0,
+      logIndex: 16,
+    });
+    const initialize = rawLog({
+      address: LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+      topics: exactTopics(encodeEventTopics({
+        abi: [poolManagerInitializeEvent],
+        eventName: "Initialize",
+        args: {
+          id: PCAN.poolId,
+          currency0: poolKey.currency0,
+          currency1: poolKey.currency1,
+        },
+      })),
+      data: encodeAbiParameters(parseAbiParameters("uint24,int24,address,uint160,int24"), [
+        3_000,
+        60,
+        PCAN.hook,
+        0x7b82009f4e993a8fab74db060d9fn,
+        207_240,
+      ]),
+      blockNumber: PCAN.blockNumber,
+      blockHash: PCAN.blockHash,
+      transactionHash: PCAN.transactionHash,
+      transactionIndex: 0,
+      logIndex: 1,
+    });
+    const anchor: LaunchStampAnchor = {
+      launchId: PCAN.launchId,
+      token: PCAN.token,
+      hook: PCAN.hook,
+      poolManager: LAUNCH_STAMP_POOL_MANAGER_ADDRESS,
+      poolId: PCAN.poolId,
+      stampHash: PCAN.stampHash,
+      blockNumber: PCAN.blockNumber,
+      blockHash: PCAN.blockHash,
+      transactionHash: PCAN.transactionHash,
+      transactionIndex: 0,
+      logIndex: 16,
+    };
+    const parsed = parseLaunchStampReceipt(
+      anchor,
+      receiptFor([{ ...vector, anchor, logs: [initialize, ...componentLogs, route, launch] }]),
+    );
+    expect(LAUNCH_STAMP_DIRECT_CALL_SELECTOR).toBe("0xe5f6b8cd");
+    expect(parsed).toMatchObject({
+      poolKey,
+      route: { kind: 1, logIndex: 15 },
+      components: [{ logIndex: 12 }, { logIndex: 13 }, { logIndex: 14 }],
+    });
+  });
+
+  it("hydrates an internally called launch without reading tx.to or top-level calldata, at finalized state only", async () => {
+    const item = fixture({ seed: 1 });
+    const latest = item.anchor.blockNumber + 100n;
+    const { client, readCalls } = clientFor([item], { latestBlock: latest });
+    expect("getTransaction" in (client as object)).toBe(false);
+
+    const result = await hydrateLaunchStampAnchor(deployment, item.anchor, { client });
+
+    expect(result.token).toMatchObject({
+      tokenAddress: item.anchor.token,
+      launchModel: "custom-graph",
+      liquidityPath: "programmable-v4",
+      activeLiquidity: "123",
+      totalSwapFeeBps: null,
+    });
+    expect(result.launchStampProvenance.finalizedAtBlockNumber).toBe(
+      latest.toString(),
+    );
+    const mutableReads = readCalls.filter((call) =>
+      call.address.toLowerCase() === STATE_VIEW.toLowerCase() ||
+      call.address.toLowerCase() === item.anchor.token.toLowerCase()
+    );
+    expect(new Set(mutableReads.map(({ blockNumber }) => blockNumber))).toEqual(
+      new Set([latest - LAUNCH_STAMP_FINALITY_CONFIRMATIONS]),
+    );
+  });
+
+  it("does not require an exclusive hook proof for kind 2 Classic", async () => {
+    const item = fixture({ seed: 2, kind: 2 });
+    const { client, readCalls } = clientFor([item]);
+    const result = await hydrateLaunchStampAnchor(deployment, item.anchor, { client });
+    expect(result.token).toMatchObject({
+      launchModel: "classic",
+      liquidityPath: "programmable-v4",
+      totalSwapFeeBps: null,
+    });
+    expect(result.launchStampProvenance.components.at(-1)).toMatchObject({
+      address: item.anchor.hook,
+      scope: "shared-infrastructure",
+      exclusiveProof: null,
+    });
+    expect(readCalls.some((call) =>
+      call.functionName === "stampProof" &&
+      String(call.args?.[0]).toLowerCase() === item.anchor.hook.toLowerCase()
+    )).toBe(false);
+  });
+
+  it("rejects a prior exclusive hook binding but permits repeated Classic shared-hook use", async () => {
+    const sharedHook = address(0x7777);
+    const sharedHookHash = hex32(0x7777);
+    const sharedHookCode = marker(0x7777);
+    const first = fixture({
+      seed: 20,
+      kind: 2,
+      hook: sharedHook,
+      hookRuntimeCodeHash: sharedHookHash,
+      hookCode: sharedHookCode,
+    });
+    const second = fixture({
+      seed: 21,
+      kind: 2,
+      hook: sharedHook,
+      hookRuntimeCodeHash: sharedHookHash,
+      hookCode: sharedHookCode,
+    });
+    const normal = clientFor([first, second]);
+    await expect(hydrateLaunchStampAnchor(deployment, first.anchor, {
+      client: normal.client,
+    })).resolves.toBeDefined();
+    await expect(hydrateLaunchStampAnchor(deployment, second.anchor, {
+      client: normal.client,
+    })).resolves.toBeDefined();
+
+    const collision = clientFor([first], {
+      sharedHookExclusiveCollision: true,
+    });
+    await expect(hydrateLaunchStampAnchor(deployment, first.anchor, {
+      client: collision.client,
+    })).rejects.toThrow("already bound as an exclusive component");
+  });
+
+  it("rejects reordered stamp logs, missing Initialize, and transaction-index drift", () => {
+    const item = fixture({ seed: 3 });
+    const receipt = receiptFor([item]);
+    const reordered = {
+      ...receipt,
+      logs: receipt.logs.map((log) =>
+        log.logIndex === 3 ? { ...log, logIndex: 4 } :
+          log.logIndex === 4 ? { ...log, logIndex: 3 } : log
+      ),
+    } as TransactionReceipt;
+    expect(() => parseLaunchStampReceipt(item.anchor, reordered)).toThrow(
+      "Component -> Route -> Launch",
+    );
+    expect(() => parseLaunchStampReceipt(item.anchor, {
+      ...receipt,
+      logs: receipt.logs.slice(1),
+    } as TransactionReceipt)).toThrow("exactly one prior pool initialization");
+    expect(() => parseLaunchStampReceipt(item.anchor, {
+      ...receipt,
+      transactionIndex: item.anchor.transactionIndex + 1,
+    } as TransactionReceipt)).toThrow("receipt provenance mismatch");
+    expect(() => parseLaunchStampReceipt(item.anchor, {
+      ...receipt,
+      status: "reverted",
+    } as TransactionReceipt)).toThrow("receipt provenance mismatch");
+    expect(() => parseLaunchStampReceipt(item.anchor, {
+      ...receipt,
+      logs: receipt.logs.map((log) =>
+        log.logIndex === item.anchor.logIndex
+          ? { ...log, transactionIndex: item.anchor.transactionIndex + 1 }
+          : log
+      ),
+    } as TransactionReceipt)).toThrow("anchor arguments differ");
+  });
+
+  it.each([
+    ["exclusive proof", (item: Fixture) => ({ wrongProofAddress: item.anchor.hook })],
+    ["component runtime", (item: Fixture) => ({ wrongRuntimeAddress: item.anchor.token })],
+    ["Router runtime", () => ({ wrongRuntimeAddress: LAUNCH_STAMP_ROUTER_ADDRESS })],
+    ["PoolKey hash", () => ({ wrongPoolKeyHash: true })],
+  ])("fails closed on a wrong %s", async (_label, option) => {
+    const item = fixture({ seed: 4 });
+    const { client } = clientFor([item], option(item));
+    await expect(
+      hydrateLaunchStampAnchor(deployment, item.anchor, { client }),
+    ).rejects.toThrow();
+  });
+
+  it("excludes anchors below 64 confirmations", async () => {
+    const item = fixture({ seed: 5 });
+    const { client } = clientFor([item], {
+      latestBlock: item.anchor.blockNumber + 63n,
+    });
+    await expect(
+      hydrateLaunchStampAnchor(deployment, item.anchor, { client }),
+    ).rejects.toThrow("does not have 64 confirmations");
+    await expect(scanLaunchStampAnchors(client, {
+      fromBlock: item.anchor.blockNumber,
+      toBlock: item.anchor.blockNumber,
+      latestBlock: item.anchor.blockNumber + 63n,
+    })).rejects.toThrow("without 64 confirmations");
+  });
+
+  it("halves 5000-block getLogs windows and retains the reduced successful size", async () => {
+    const widths: bigint[] = [];
+    const fromBlock = LAUNCH_STAMP_ROUTER_START_BLOCK;
+    const toBlock = fromBlock + 5_999n;
+    const client = {
+      getLogs: vi.fn(async ({ fromBlock: from, toBlock: to }: {
+        fromBlock: bigint;
+        toBlock: bigint;
+      }) => {
+        const width = to - from + 1n;
+        widths.push(width);
+        if (width > 625n) throw new Error("provider range limit");
+        return [];
+      }),
+    } as unknown as LaunchStampReaderClient;
+    await scanLaunchStampAnchors(client, {
+      fromBlock,
+      toBlock,
+      latestBlock: toBlock + LAUNCH_STAMP_FINALITY_CONFIRMATIONS,
+    });
+    expect(widths.slice(0, 5)).toEqual([5_000n, 2_500n, 1_250n, 625n, 625n]);
+    expect(widths.filter((width) => width === 5_000n)).toHaveLength(1);
+  });
+
+  it("rebuilds only the Router slice from the immutable anchor after a cursor reorg", async () => {
+    const canonicalCursorHash = hex32(0xf00);
+    const latest = LAUNCH_STAMP_ROUTER_START_BLOCK + 100n;
+    const { client } = clientFor([], {
+      latestBlock: latest,
+      cursorCanonicalHash: canonicalCursorHash,
+    });
+    const result = await advanceLaunchStampRouterSlice(deployment, {
+      cursor: {
+        blockNumber: (LAUNCH_STAMP_ROUTER_START_BLOCK + 5n).toString(),
+        blockHash: hex32(0xbad),
+      },
+      tokens: [{ tokenAddress: address(0xdead) } as LauncherToken],
+    }, { client });
+    expect(result.rebuiltAfterReorg).toBe(true);
+    expect(result.slice.tokens).toEqual([]);
+    expect(result.scannedFromBlock).toBe(LAUNCH_STAMP_ROUTER_START_BLOCK.toString());
+    expect(result.slice.cursor.blockNumber).toBe(
+      (latest - LAUNCH_STAMP_FINALITY_CONFIRMATIONS).toString(),
+    );
+  });
+
+  it("fetches a shared receipt once and lets poisoned optional metadata fall back without pinning later launches", async () => {
+    const sharedTx = hex32(0xf10);
+    const sharedBlock = LAUNCH_STAMP_ROUTER_START_BLOCK + 20n;
+    const sharedHash = hex32(0xf11);
+    const first = fixture({
+      seed: 6,
+      blockNumber: sharedBlock,
+      blockHash: sharedHash,
+      transactionHash: sharedTx,
+      firstLogIndex: 1,
+    });
+    const second = fixture({
+      seed: 7,
+      blockNumber: sharedBlock,
+      blockHash: sharedHash,
+      transactionHash: sharedTx,
+      firstLogIndex: 6,
+    });
+    const { client, receiptCalls } = clientFor([first, second], {
+      latestBlock: sharedBlock + 100n,
+      metadataFailures: new Set([first.anchor.token.toLowerCase()]),
+    });
+    const result = await advanceLaunchStampRouterSlice(
+      deployment,
+      createInitialLaunchStampRouterSlice(),
+      { client },
+    );
+    expect(receiptCalls).toHaveBeenCalledTimes(1);
+    expect(result.slice.tokens).toHaveLength(2);
+    expect(result.slice.tokens[0]).toMatchObject({
+      name: expect.stringContaining(first.anchor.token.slice(0, 8)),
+    });
+    expect(result.slice.tokens[0]).not.toHaveProperty("tokenDecimals");
+    expect(result.slice.tokens[1]?.tokenAddress).toBe(second.anchor.token);
+  });
+
+  it("bounds unsafe and oversized UERC20 metadata without dropping it or later stamps", async () => {
+    const first = fixture({ seed: 22 });
+    const second = fixture({ seed: 23 });
+    const { client } = clientFor([first, second], {
+      latestBlock: second.anchor.blockNumber + 100n,
+      unsafeMetadata: new Set([first.anchor.token.toLowerCase()]),
+    });
+    const result = await advanceLaunchStampRouterSlice(
+      deployment,
+      createInitialLaunchStampRouterSlice(),
+      { client },
+    );
+    const poisoned = result.slice.tokens.find((token) =>
+      token.tokenAddress.toLowerCase() === first.anchor.token.toLowerCase()
+    );
+    expect(result.slice.tokens).toHaveLength(2);
+    expect(poisoned).toMatchObject({
+      name: expect.stringContaining(first.anchor.token.slice(0, 8)),
+      symbol: `A${first.anchor.token.slice(-9)}`.toUpperCase(),
+      launchStampProvenance: {
+        launchId: first.anchor.launchId,
+        stampHash: first.anchor.stampHash,
+      },
+    });
+    expect(poisoned).not.toHaveProperty("description");
+    expect(poisoned).not.toHaveProperty("imageUrl");
+    expect(poisoned).not.toHaveProperty("links");
+    expect(poisoned).not.toHaveProperty("metadataExtraData");
+    expect(JSON.stringify(poisoned).length).toBeLessThan(10_000);
+    expect(result.slice.tokens.some((token) =>
+      token.tokenAddress.toLowerCase() === second.anchor.token.toLowerCase()
+    )).toBe(true);
+  });
+
+  it("bounds each catch-up invocation to 50,000 blocks", async () => {
+    const latest = LAUNCH_STAMP_ROUTER_START_BLOCK + 100_000n;
+    const { client } = clientFor([], { latestBlock: latest });
+    const result = await advanceLaunchStampRouterSlice(
+      deployment,
+      createInitialLaunchStampRouterSlice(),
+      { client },
+    );
+    expect(result.slice.cursor.blockNumber).toBe(
+      (LAUNCH_STAMP_ROUTER_START_BLOCK - 1n + 50_000n).toString(),
+    );
+  });
+
+  it("moves the cursor only to a canonical prefix when launch density exceeds the hydration bound", async () => {
+    const denseBlock = LAUNCH_STAMP_ROUTER_START_BLOCK + 1n;
+    const item = fixture({ seed: 8, blockNumber: denseBlock });
+    const base = item.logs.at(-1) as Log;
+    const logs = Array.from({ length: 513 }, (_, index) => ({
+      ...base,
+      transactionHash: hex32(0x2000 + index),
+      logIndex: index,
+    }));
+    const { client } = clientFor([], {
+      latestBlock: LAUNCH_STAMP_ROUTER_START_BLOCK + 100n,
+    });
+    client.getLogs = vi.fn(async () => logs) as typeof client.getLogs;
+    const result = await advanceLaunchStampRouterSlice(
+      deployment,
+      createInitialLaunchStampRouterSlice(),
+      { client },
+    );
+    expect(result.boundedByDensity).toBe(true);
+    expect(result.slice.cursor.blockNumber).toBe(
+      LAUNCH_STAMP_ROUTER_START_BLOCK.toString(),
+    );
+    expect(result.slice.tokens).toEqual([]);
+  });
+});

--- a/tests/alchemy-live-market.test.ts
+++ b/tests/alchemy-live-market.test.ts
@@ -17,6 +17,10 @@ vi.mock("viem", async (importOriginal) => {
 import { enrichTokensWithAlchemyPoolState } from "../lib/alchemy/live-market.server";
 import type { ReadyOnchainDeployment } from "../lib/onchain/types";
 import type { LauncherToken } from "../lib/tokens";
+import {
+  customGraphToken,
+  stampedClassicToken,
+} from "./launch-stamp-surface-fixture";
 
 const deployment = {
   environment: "production",
@@ -42,10 +46,15 @@ describe("Alchemy live pool market state", () => {
   });
 
   it("derives current token price and market cap from StateView and reuses the five-second read", async () => {
-    mocks.multicall.mockResolvedValue([
+    mocks.multicall.mockResolvedValueOnce([
       {
         status: "success",
         result: [1n << 96n, 0, 0, 10_000],
+      },
+    ]).mockResolvedValueOnce([
+      {
+        status: "success",
+        result: 1_000_000n,
       },
     ]);
     const token = {
@@ -92,8 +101,175 @@ describe("Alchemy live pool market state", () => {
       marketCapEthWei: (1_000n * 10n ** 18n).toString(),
       fdvUsdWad: (3_000_000n * 10n ** 18n).toString(),
       indexedValuationBlockNumber: "25680000",
+      activeLiquidity: "1000000",
     });
     expect(second).toEqual(first);
-    expect(mocks.multicall).toHaveBeenCalledTimes(1);
+    expect(mocks.multicall).toHaveBeenCalledTimes(2);
+    expect(mocks.multicall.mock.calls.every(
+      ([request]) => request.blockNumber === 25_680_000n,
+    )).toBe(true);
+  });
+
+  it("reads every valid stamped PoolId at one block and separates state from valuation", async () => {
+    const nonNativePoolId = `0x${"aa".repeat(32)}` as const;
+    const zeroLiquidityPoolId = `0x${"bb".repeat(32)}` as const;
+    const staleValuation = {
+      tokenPriceEth: "999",
+      tokenPriceEthWei: "999",
+      tokenPriceUsdWad: "999",
+      tokenPriceQuote: "999",
+      tokenPriceQuoteWad: "999",
+      marketCapEth: "999",
+      marketCapEthWei: "999",
+      marketCapQuote: "999",
+      marketCapQuoteWad: "999",
+      indexedMarketCapEth: "999",
+      indexedMarketCapEthWei: "999",
+      indexedMarketCapUsdWad: "999",
+      indexedValuationBlockNumber: "1",
+      fdvUsdWad: "999",
+    } as const;
+    const nonNativeClassic = {
+      ...stampedClassicToken,
+      ...staleValuation,
+      poolId: nonNativePoolId,
+      launchStampProvenance: {
+        ...stampedClassicToken.launchStampProvenance,
+        poolId: nonNativePoolId,
+        poolKey: {
+          ...stampedClassicToken.launchStampProvenance.poolKey,
+          currency0: "0x0101010101010101010101010101010101010101",
+        },
+        poolProof: {
+          ...stampedClassicToken.launchStampProvenance.poolProof,
+          poolId: nonNativePoolId,
+        },
+      },
+    } satisfies LauncherToken;
+    const zeroLiquidityCustom = {
+      ...customGraphToken,
+      ...staleValuation,
+      poolId: zeroLiquidityPoolId,
+      launchStampProvenance: {
+        ...customGraphToken.launchStampProvenance,
+        poolId: zeroLiquidityPoolId,
+        poolProof: {
+          ...customGraphToken.launchStampProvenance.poolProof,
+          poolId: zeroLiquidityPoolId,
+        },
+      },
+    } satisfies LauncherToken;
+    const stampedTokens = [
+      customGraphToken,
+      nonNativeClassic,
+      zeroLiquidityCustom,
+    ];
+    const samePoolIneligible = {
+      id: "1:same-pool-ineligible",
+      name: "Stock paired collision",
+      symbol: "COLLIDE",
+      tokenAddress: customGraphToken.tokenAddress,
+      hookAddress: customGraphToken.hookAddress,
+      poolId: customGraphToken.poolId,
+      launchedAt: customGraphToken.launchedAt,
+      totalSupplyRaw: customGraphToken.totalSupplyRaw,
+      tokenDecimals: customGraphToken.tokenDecimals,
+      totalSwapFeeBps: 100,
+      launchModel: "stock-paired",
+      launchModelVersion: "stock-paired-v3",
+      liquidityPath: "meme",
+    } as const satisfies LauncherToken;
+    mocks.multicall.mockResolvedValueOnce([
+      { status: "success", result: [1n << 96n, 10, 11, 12] },
+      { status: "success", result: [1n << 96n, 20, 21, 22] },
+      { status: "success", result: [1n << 96n, 30, 31, 32] },
+    ]).mockResolvedValueOnce([
+      { status: "success", result: 1_000_000n },
+      { status: "success", result: 2_000_000n },
+      { status: "success", result: 0n },
+    ]);
+    const snapshot = {
+      chainId: 1,
+      blockNumber: "25680001",
+      blockHash: `0x${"88".repeat(32)}` as `0x${string}`,
+      confirmations: 0,
+      ethUsdQuote: {
+        feedAddress: "0x8888888888888888888888888888888888888888" as const,
+        roundId: "1",
+        answer: "300000000000",
+        decimals: 8,
+        updatedAt: "2026-08-09T12:00:00.000Z",
+      },
+    };
+
+    const enriched = await enrichTokensWithAlchemyPoolState({
+      deployment,
+      snapshot,
+      tokens: [...stampedTokens, samePoolIneligible],
+    });
+
+    expect(mocks.multicall).toHaveBeenCalledTimes(2);
+    const [slot0Request] = mocks.multicall.mock.calls[0];
+    const [liquidityRequest] = mocks.multicall.mock.calls[1];
+    expect(slot0Request).toMatchObject({
+      blockNumber: 25_680_001n,
+      contracts: stampedTokens.map((candidate) => ({
+        functionName: "getSlot0",
+        args: [candidate.poolId],
+      })),
+    });
+    expect(liquidityRequest).toMatchObject({
+      blockNumber: 25_680_001n,
+      contracts: stampedTokens.map((candidate) => ({
+        functionName: "getLiquidity",
+        args: [candidate.poolId],
+      })),
+    });
+
+    expect(enriched[0]).toMatchObject({
+      currentTick: 10,
+      activeLiquidity: "1000000",
+      protocolFeePips: 11,
+      lpFeePips: 12,
+      tokenPriceEthWei: (10n ** 18n).toString(),
+      marketCapEthWei: (1_000n * 10n ** 18n).toString(),
+      fdvUsdWad: (3_000_000n * 10n ** 18n).toString(),
+      indexedValuationBlockNumber: "25680001",
+    });
+    expect(enriched[1]).toMatchObject({
+      currentTick: 20,
+      activeLiquidity: "2000000",
+      protocolFeePips: 21,
+      lpFeePips: 22,
+    });
+    expect(enriched[1]).not.toHaveProperty("indexedValuationBlockNumber");
+    expect(enriched[1]).not.toHaveProperty("tokenPriceEthWei");
+    expect(enriched[1]).not.toHaveProperty("marketCapEthWei");
+    expect(enriched[1]).not.toHaveProperty("fdvUsdWad");
+    expect(enriched[1]).not.toHaveProperty("indexedMarketCapEth");
+    expect(enriched[1]).not.toHaveProperty("indexedMarketCapEthWei");
+    expect(enriched[1]).not.toHaveProperty("indexedMarketCapUsdWad");
+    for (const field of Object.keys(staleValuation)) {
+      expect(enriched[1]).not.toHaveProperty(field);
+    }
+    expect(enriched[2]).toMatchObject({
+      currentTick: 30,
+      activeLiquidity: "0",
+      protocolFeePips: 31,
+      lpFeePips: 32,
+    });
+    expect(enriched[2]).not.toHaveProperty("indexedValuationBlockNumber");
+    expect(enriched[2]).not.toHaveProperty("tokenPriceEthWei");
+    expect(enriched[2]).not.toHaveProperty("marketCapEthWei");
+    expect(enriched[2]).not.toHaveProperty("fdvUsdWad");
+    expect(enriched[2]).not.toHaveProperty("indexedMarketCapEth");
+    expect(enriched[2]).not.toHaveProperty("indexedMarketCapEthWei");
+    expect(enriched[2]).not.toHaveProperty("indexedMarketCapUsdWad");
+    for (const field of Object.keys(staleValuation)) {
+      expect(enriched[2]).not.toHaveProperty(field);
+    }
+    expect(enriched[3]).toEqual(samePoolIneligible);
+    expect(enriched[3]).not.toHaveProperty("currentTick");
+    expect(enriched[3]).not.toHaveProperty("activeLiquidity");
   });
 });

--- a/tests/alchemy-profile-live.test.ts
+++ b/tests/alchemy-profile-live.test.ts
@@ -25,6 +25,7 @@ import type {
   ExploreReadModel,
   ReadyOnchainDeployment,
 } from "../lib/onchain/types";
+import type { LauncherToken } from "../lib/tokens";
 
 const account = "0x1111111111111111111111111111111111111111" as const;
 const poolId = `0x${"22".repeat(32)}` as const;
@@ -59,14 +60,109 @@ const token = {
   creatorAddress: account,
   positionRecipient: account,
   positionTokenId: "1",
+  launchHash: `0x${"66".repeat(32)}` as const,
   launchTransactionHash: `0x${"77".repeat(32)}` as const,
   launchLogIndex: 0,
   launchBlockNumber: "90",
   launchedAt: "2026-08-04T00:00:00.000Z",
   launchModel: "classic" as const,
   totalSwapFeeBps: 100,
+  creatorFeesAccruedWei: "0",
+  creatorFeesGeneratedWei: "0",
   liquidityPath: "meme" as const,
-};
+} satisfies LauncherToken;
+
+function customGraphProvenance() {
+  const launchId = `0x${"aa".repeat(32)}` as const;
+  const stampHash = `0x${"ab".repeat(32)}` as const;
+  const poolManagerAddress =
+    "0x000000000004444c5dc75cB358380D2e3dE08A90" as const;
+  return {
+    schemaVersion: "programmable.launch-stamp-provenance.v1",
+    chainId: 1,
+    routerAddress: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+    routerRuntimeCodeHash:
+      "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+    routerStartBlock: "25717612",
+    finalityConfirmations: 64,
+    kind: "custom-graph",
+    launchId,
+    stampHash,
+    launchWallet: account,
+    transactionHash: `0x${"ad".repeat(32)}`,
+    blockNumber: "25717620",
+    blockHash: `0x${"ae".repeat(32)}`,
+    transactionIndex: 2,
+    routeLogIndex: 8,
+    launchLogIndex: 9,
+    finalizedAtBlockNumber: "25717684",
+    finalizedAtBlockHash: `0x${"af".repeat(32)}`,
+    poolManagerAddress,
+    poolId: `0x${"99".repeat(32)}`,
+    poolKey: {
+      currency0: "0x0000000000000000000000000000000000000000",
+      currency1: "0x7777777777777777777777777777777777777777",
+      fee: 3_000,
+      tickSpacing: 60,
+      hooks: "0x8888888888888888888888888888888888888888",
+    },
+    poolKeyHash: `0x${"b1".repeat(32)}`,
+    componentSetHash: `0x${"b2".repeat(32)}`,
+    routePayloadHash: `0x${"b3".repeat(32)}`,
+    routeLauncherAddress:
+      "0x9999999999999999999999999999999999999999",
+    routeLauncherRuntimeCodeHash: `0x${"b4".repeat(32)}`,
+    expectedResultHash: `0x${"b5".repeat(32)}`,
+    permitDigest: `0x${"b6".repeat(32)}`,
+    components: [
+      {
+        address: "0x7777777777777777777777777777777777777777",
+        kind: "token",
+        scope: "exclusive",
+        runtimeCodeHash: `0x${"b7".repeat(32)}`,
+        logIndex: 6,
+        exclusiveProof: { launchId, stampHash },
+      },
+      {
+        address: "0x8888888888888888888888888888888888888888",
+        kind: "hook",
+        scope: "exclusive",
+        runtimeCodeHash: `0x${"b8".repeat(32)}`,
+        logIndex: 7,
+        exclusiveProof: { launchId, stampHash },
+      },
+    ],
+    tokenProof: {
+      tokenAddress: "0x7777777777777777777777777777777777777777",
+      launchId,
+      stampHash,
+    },
+    poolProof: {
+      poolManagerAddress,
+      poolId: `0x${"99".repeat(32)}`,
+      launchId,
+      stampHash,
+    },
+  } as const;
+}
+
+const customGraphToken = {
+  id: "1:custom-graph",
+  name: "Stamped graph",
+  symbol: "GRAPH",
+  tokenAddress: "0x7777777777777777777777777777777777777777",
+  hookAddress: "0x8888888888888888888888888888888888888888",
+  poolId: `0x${"99".repeat(32)}`,
+  creatorAddress: account,
+  launchBlockNumber: "25717620",
+  launchTransactionHash: `0x${"ad".repeat(32)}`,
+  launchLogIndex: 9,
+  launchedAt: "2026-08-09T00:00:00.000Z",
+  launchModel: "custom-graph",
+  totalSwapFeeBps: null,
+  launchStampProvenance: customGraphProvenance(),
+  liquidityPath: "programmable-v4",
+} satisfies LauncherToken;
 
 describe("Alchemy live creator profile", () => {
   beforeEach(() => {
@@ -134,5 +230,47 @@ describe("Alchemy live creator profile", () => {
       claimableCreatorFeesWei: "5",
       generatedCreatorFeesWei: "15",
     });
+    expect(mocks.multicall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contracts: [expect.objectContaining({ address: hookAddress })],
+      }),
+    );
+  });
+
+  it("keeps a stamped CustomGraph launch visible without querying its hook or inventing rewards", async () => {
+    mocks.getLogs.mockResolvedValue([]);
+    const model = {
+      status: "ready",
+      tokens: [customGraphToken],
+      snapshot: {
+        chainId: 1,
+        blockNumber: "100",
+        blockHash: `0x${"99".repeat(32)}`,
+        confirmations: 12,
+      },
+      creatorClaims: [],
+      launcherFeesAccruedWei: "0",
+      launcherFeesAccruedEth: "0",
+    } satisfies ExploreReadModel;
+
+    const profile = await readAlchemyCreatorProfile({
+      account,
+      deployment,
+      model,
+    });
+
+    expect(profile.tokens.map((entry) => entry.symbol)).toEqual(["GRAPH"]);
+    expect(profile.pools).toEqual([]);
+    expect(profile.claims).toEqual([]);
+    expect(profile.totals).toEqual({
+      claimableWei: "0",
+      claimableEth: "0",
+      generatedWei: "0",
+      generatedEth: "0",
+      claimedWei: "0",
+      claimedEth: "0",
+    });
+    expect(mocks.multicall).not.toHaveBeenCalled();
+    expect(mocks.getLogs).not.toHaveBeenCalled();
   });
 });

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -5,6 +5,7 @@ vi.mock("server-only", () => ({}));
 
 import type { ExploreReadModel } from "../lib/onchain/types";
 import type { ExploreEntry, LauncherToken } from "../lib/tokens";
+import { customGraphToken } from "./launch-stamp-surface-fixture";
 
 const mocks = vi.hoisted(() => ({
   enrichTokensWithAlchemyPrices: vi.fn(),
@@ -337,6 +338,38 @@ describe("Explore API Alchemy boundary", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
+  });
+
+  it("serves a finalized Router Custom Graph as a canonical Custom token", async () => {
+    mocks.readAlchemyExploreModel.mockResolvedValue({
+      ...readyModel(),
+      tokens: [customGraphToken],
+    });
+    mocks.enrichTokensWithAlchemyPrices.mockImplementation(async (tokens) => [
+      ...tokens,
+    ]);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/explore?sort=newest"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.tokens).toHaveLength(1);
+    expect(body.tokens[0]).toMatchObject({
+      exploreKind: "token",
+      tokenAddress: customGraphToken.tokenAddress,
+      launchModel: "custom-graph",
+      totalSwapFeeBps: null,
+      liquidityPath: "programmable-v4",
+      launchCategoryProvenance: {
+        category: "custom",
+        source: "canonical-launch-stamp-router",
+        launchId: customGraphToken.launchStampProvenance.launchId,
+        stampHash: customGraphToken.launchStampProvenance.stampHash,
+      },
+      launchStampProvenance: customGraphToken.launchStampProvenance,
+    });
   });
 
   it.each([

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -485,6 +485,40 @@ describe("Explore refresh state", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects Router provenance on a custom project without a complete stamp", async () => {
+    const project = customEntry(91);
+    const forged = {
+      ...project,
+      launchCategoryProvenance: {
+        schemaVersion: "programmable.explore-launch-category-provenance.v1",
+        category: "custom",
+        source: "canonical-launch-stamp-router",
+        launchId: `0x${"11".repeat(32)}`,
+        stampHash: `0x${"22".repeat(32)}`,
+        routerAddress: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+        transactionHash: `0x${"33".repeat(32)}`,
+        blockHash: `0x${"44".repeat(32)}`,
+        blockNumber: "25717612",
+        transactionIndex: 1,
+        logIndex: 2,
+      },
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        ...payload,
+        tokens: [forged],
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(loadExplorePayload(
+      "forged-custom-project-router-source",
+      new URLSearchParams(),
+    )).rejects.toThrow("invalid token record");
+  });
+
   it("stops a stalled Explore request after twelve seconds", async () => {
     vi.useFakeTimers();
     vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {

--- a/tests/indexer-feed.test.ts
+++ b/tests/indexer-feed.test.ts
@@ -22,11 +22,16 @@ import { GET as getIndexerTokens } from "../app/api/indexers/v1/tokens/route";
 import {
   buildIndexerFeed,
   buildUniswapTokenList,
+  buildUniswapTokenListResult,
   findIndexerToken,
   serializeIndexerToken,
 } from "../lib/onchain/indexer-feed";
 import type { ExploreReadModel } from "../lib/onchain/types";
 import type { LauncherToken } from "../lib/tokens";
+import {
+  customGraphToken,
+  stampedClassicToken,
+} from "./launch-stamp-surface-fixture";
 
 const token: LauncherToken = {
   id: "test",
@@ -93,8 +98,39 @@ function expectAlchemyRpcHeaders(response: Response) {
   expect(response.headers.get("x-programmable-rpc-provider")).toBe(
     "alchemy",
   );
-  expect(response.headers.get("access-control-expose-headers")).toBe(
-    "X-Programmable-Launch-Source, X-Programmable-Read-Source, X-Programmable-Rpc-Provider",
+  expect(
+    response.headers
+      .get("access-control-expose-headers")
+      ?.split(", "),
+  ).toEqual(
+    expect.arrayContaining([
+      "X-Programmable-Launch-Source",
+      "X-Programmable-Read-Source",
+      "X-Programmable-Rpc-Provider",
+    ]),
+  );
+}
+
+function expectTokenListOmissions(
+  response: Response,
+  count: number,
+  reason: string | null,
+) {
+  expect(response.headers.get("x-programmable-omitted-token-count")).toBe(
+    String(count),
+  );
+  expect(response.headers.get("x-programmable-omission-reason")).toBe(
+    reason,
+  );
+  expect(
+    response.headers
+      .get("access-control-expose-headers")
+      ?.split(", "),
+  ).toEqual(
+    expect.arrayContaining([
+      "X-Programmable-Omitted-Token-Count",
+      "X-Programmable-Omission-Reason",
+    ]),
   );
 }
 
@@ -103,6 +139,7 @@ describe("public indexer fee disclosure", () => {
     const result = serializeIndexerToken(token, 1);
 
     expect(result.fees).toEqual({
+      status: "verified",
       model: "uniswap-v4-custom-accounting",
       currency: "ETH",
       currencyAddress: null,
@@ -308,6 +345,7 @@ describe("public indexer fee disclosure", () => {
           creatorFeeBps: 90,
           launcherFeeBps: 10,
           transferTaxBps: 0,
+          feeStatus: "verified",
           feeIncluded: true,
         },
       },
@@ -333,6 +371,118 @@ describe("public indexer fee disclosure", () => {
     expect(() =>
       serializeIndexerToken({ ...token, creatorFeeBps: 89 }, 1),
     ).toThrow("invalid fee disclosure");
+  });
+
+  it.each([
+    ["Custom", customGraphToken, "custom"],
+    ["stamped Classic", stampedClassicToken, "classic"],
+  ] as const)(
+    "publishes %s Router provenance without inventing unknown fees",
+    (_, stampedToken, category) => {
+      const withLegacyPositionIdentity = {
+        ...stampedToken,
+        positionRecipient:
+          "0x7777777777777777777777777777777777777777",
+        positionTokenId: "42",
+      } satisfies LauncherToken;
+      const result = serializeIndexerToken(withLegacyPositionIdentity, 1);
+
+      expect(result.fees).toEqual({
+        status: "unknown",
+        model: "unknown",
+        currency: null,
+        currencyAddress: null,
+        buyHookFeeBps: null,
+        sellHookFeeBps: null,
+        creatorFeeBps: null,
+        buyCreatorFeeBps: null,
+        sellCreatorFeeBps: null,
+        growthFeeBps: null,
+        programmableFeeBps: null,
+        launcherFeeBps: null,
+        transferTaxBps: null,
+        lpFeePips: null,
+        launcherFeeIncludedInHookFee: null,
+      });
+      expect(result.canonicalPool).toMatchObject({
+        poolId: stampedToken.poolId,
+        hookAddress: stampedToken.hookAddress,
+        poolManagerAddress:
+          stampedToken.launchStampProvenance.poolManagerAddress,
+        poolKey: stampedToken.launchStampProvenance.poolKey,
+        positionRecipient: null,
+        positionTokenId: null,
+      });
+      expect(result.launch).toMatchObject({
+        modelId: stampedToken.launchModel,
+        modelVersion: "programmable-launch-stamp-router-v1",
+        category,
+      });
+      expect(result.launch.launchStampProvenance).toEqual(
+        stampedToken.launchStampProvenance,
+      );
+    },
+  );
+
+  it.each([
+    ["Custom", customGraphToken],
+    ["stamped Classic", stampedClassicToken],
+  ] as const)("rejects invented %s Router fee fields", (_, stampedToken) => {
+    expect(() =>
+      serializeIndexerToken({
+        ...stampedToken,
+        buyHookFeeBps: 0,
+      }, 1),
+    ).toThrow("invented Router fee disclosure");
+    expect(() =>
+      serializeIndexerToken({
+        ...stampedToken,
+        totalSwapFeeBps: 100,
+      }, 1),
+    ).toThrow("mismatched launch stamp disclosure");
+  });
+
+  it("preserves a stamped token with unknown decimals outside the standard token list", () => {
+    const withoutDecimals: LauncherToken = { ...customGraphToken };
+    delete withoutDecimals.tokenDecimals;
+    const poisonedModel = {
+      ...readyModel,
+      tokens: [withoutDecimals, token],
+    } satisfies ExploreReadModel;
+
+    expect(serializeIndexerToken(withoutDecimals, 1)).toMatchObject({
+      address: withoutDecimals.tokenAddress,
+      decimals: null,
+      launch: {
+        launchStampProvenance: withoutDecimals.launchStampProvenance,
+      },
+    });
+    expect(buildIndexerFeed(poisonedModel, 1).tokens[0]).toMatchObject({
+      address: withoutDecimals.tokenAddress,
+      decimals: null,
+      launch: {
+        launchStampProvenance: withoutDecimals.launchStampProvenance,
+      },
+    });
+    expect(findIndexerToken(
+      poisonedModel,
+      1,
+      withoutDecimals.tokenAddress,
+    )).toMatchObject({
+      decimals: null,
+      launch: {
+        launchStampProvenance: withoutDecimals.launchStampProvenance,
+      },
+    });
+    const result = buildUniswapTokenListResult(poisonedModel, 1);
+    expect(result.omissions).toEqual({
+      count: 1,
+      reason: "missing-valid-decimals",
+    });
+    expect(result.tokenList).not.toHaveProperty("omissions");
+    expect(result.tokenList?.tokens.map(
+      (candidate) => candidate.address,
+    )).toEqual([token.tokenAddress]);
   });
 
   it("discloses Stock-Paired identity, quote asset and pool ordering", () => {
@@ -487,6 +637,148 @@ describe("public indexer fee disclosure", () => {
       address: token.tokenAddress,
       name: token.name,
       symbol: token.symbol,
+    });
+  });
+
+  it("serves finalized Router provenance through direct lookup and token-list routes", async () => {
+    const stampedModel = {
+      ...readyModel,
+      tokens: [customGraphToken],
+    } satisfies ExploreReadModel;
+    routeMocks.readAlchemyExploreModel.mockResolvedValue(stampedModel);
+
+    const direct = await getIndexerTokens(
+      new Request(
+        `https://programmable.family/api/indexers/v1/tokens?address=${customGraphToken.tokenAddress}`,
+      ),
+    );
+    const directBody = await direct.json();
+
+    expect(direct.status).toBe(200);
+    expect(directBody).toMatchObject({
+      address: customGraphToken.tokenAddress,
+      fees: {
+        status: "unknown",
+        buyHookFeeBps: null,
+        sellHookFeeBps: null,
+        creatorFeeBps: null,
+        launcherFeeBps: null,
+      },
+      canonicalPool: {
+        poolId: customGraphToken.poolId,
+        poolManagerAddress:
+          customGraphToken.launchStampProvenance.poolManagerAddress,
+        positionRecipient: null,
+        positionTokenId: null,
+      },
+      launch: {
+        category: "custom",
+        modelId: "custom-graph",
+        launchStampProvenance: customGraphToken.launchStampProvenance,
+      },
+    });
+
+    routeMocks.readAlchemyExploreModel.mockResolvedValue(stampedModel);
+    const tokenList = await getTokenList();
+    const tokenListBody = await tokenList.json();
+
+    expect(tokenList.status).toBe(200);
+    expect(tokenListBody.tokens).toHaveLength(1);
+    expect(tokenListBody.tokens[0]).toMatchObject({
+      address: customGraphToken.tokenAddress,
+      extensions: {
+        programmable: {
+          launchModel: "custom-graph",
+          feeStatus: "unknown",
+          buyFeeBps: null,
+          sellFeeBps: null,
+          creatorFeeBps: null,
+          launcherFeeBps: null,
+          positionRecipient: null,
+          positionTokenId: null,
+          launchStampProvenance: customGraphToken.launchStampProvenance,
+        },
+      },
+    });
+  });
+
+  it("keeps poisoned Router metadata in programmable feeds and omits only that token from the standard list", async () => {
+    const withoutDecimals: LauncherToken = { ...customGraphToken };
+    delete withoutDecimals.tokenDecimals;
+    const poisonedModel = {
+      ...readyModel,
+      tokens: [withoutDecimals, token],
+    } satisfies ExploreReadModel;
+    routeMocks.readAlchemyExploreModel.mockResolvedValue(poisonedModel);
+
+    const direct = await getIndexerTokens(
+      new Request(
+        `https://programmable.family/api/indexers/v1/tokens?address=${withoutDecimals.tokenAddress}`,
+      ),
+    );
+    expect(direct.status).toBe(200);
+    expect(await direct.json()).toMatchObject({
+      address: withoutDecimals.tokenAddress,
+      decimals: null,
+      launch: {
+        launchStampProvenance: withoutDecimals.launchStampProvenance,
+      },
+    });
+
+    const full = await getIndexerTokens(
+      new Request("https://programmable.family/api/indexers/v1/tokens"),
+    );
+    expect(full.status).toBe(200);
+    expect(await full.json()).toMatchObject({
+      tokens: [
+        {
+          address: withoutDecimals.tokenAddress,
+          decimals: null,
+          launch: {
+            launchStampProvenance:
+              withoutDecimals.launchStampProvenance,
+          },
+        },
+        {
+          address: token.tokenAddress,
+          decimals: token.tokenDecimals,
+        },
+      ],
+    });
+
+    const tokenList = await getTokenList();
+    expect(tokenList.status).toBe(200);
+    expectTokenListOmissions(
+      tokenList,
+      1,
+      "missing-valid-decimals",
+    );
+    expect((await tokenList.json()).tokens.map(
+      (candidate: { address: string }) => candidate.address,
+    )).toEqual([token.tokenAddress]);
+  });
+
+  it("fails closed instead of serving a schema-invalid list when every token lacks decimals", async () => {
+    const withoutDecimals: LauncherToken = { ...customGraphToken };
+    delete withoutDecimals.tokenDecimals;
+    routeMocks.readAlchemyExploreModel.mockResolvedValue({
+      ...readyModel,
+      tokens: [withoutDecimals],
+    } satisfies ExploreReadModel);
+
+    const response = await getTokenList();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBe("60");
+    expectTokenListOmissions(
+      response,
+      1,
+      "missing-valid-decimals",
+    );
+    expect(await response.json()).toEqual({
+      status: "ready",
+      error:
+        "The token list is unavailable until a token has verified decimals",
     });
   });
 

--- a/tests/launch-stamp-surface-fixture.ts
+++ b/tests/launch-stamp-surface-fixture.ts
@@ -1,0 +1,167 @@
+import type {
+  CanonicalTokenExploreEntry,
+  LaunchStampProvenanceV1,
+  LauncherToken,
+} from "../lib/tokens";
+
+export const STAMP_TOKEN =
+  "0x1111111111111111111111111111111111111111" as const;
+export const STAMP_HOOK =
+  "0x2222222222222222222222222222222222222222" as const;
+export const STAMP_POOL_ID = `0x${"33".repeat(32)}` as const;
+export const STAMP_LAUNCH_ID = `0x${"44".repeat(32)}` as const;
+export const STAMP_HASH = `0x${"55".repeat(32)}` as const;
+
+export const launchStampProvenance = {
+  schemaVersion: "programmable.launch-stamp-provenance.v1",
+  chainId: 1,
+  routerAddress: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+  routerRuntimeCodeHash:
+    "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+  routerStartBlock: "25717612",
+  finalityConfirmations: 64,
+  kind: "custom-graph",
+  launchId: STAMP_LAUNCH_ID,
+  stampHash: STAMP_HASH,
+  launchWallet: "0x4444444444444444444444444444444444444444",
+  transactionHash: `0x${"66".repeat(32)}`,
+  blockNumber: "25717953",
+  blockHash: `0x${"77".repeat(32)}`,
+  transactionIndex: 2,
+  routeLogIndex: 3,
+  launchLogIndex: 4,
+  finalizedAtBlockNumber: "25718017",
+  finalizedAtBlockHash: `0x${"88".repeat(32)}`,
+  poolManagerAddress: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+  poolId: STAMP_POOL_ID,
+  poolKey: {
+    currency0: "0x0000000000000000000000000000000000000000",
+    currency1: STAMP_TOKEN,
+    fee: 3_000,
+    tickSpacing: 60,
+    hooks: STAMP_HOOK,
+  },
+  poolKeyHash: `0x${"99".repeat(32)}`,
+  componentSetHash: `0x${"aa".repeat(32)}`,
+  routePayloadHash: `0x${"bb".repeat(32)}`,
+  routeLauncherAddress: "0x5555555555555555555555555555555555555555",
+  routeLauncherRuntimeCodeHash: `0x${"cc".repeat(32)}`,
+  expectedResultHash: `0x${"dd".repeat(32)}`,
+  permitDigest: `0x${"ee".repeat(32)}`,
+  components: [
+    {
+      address: STAMP_TOKEN,
+      kind: "token",
+      scope: "exclusive",
+      runtimeCodeHash: `0x${"12".repeat(32)}`,
+      logIndex: 1,
+      exclusiveProof: {
+        launchId: STAMP_LAUNCH_ID,
+        stampHash: STAMP_HASH,
+      },
+    },
+    {
+      address: STAMP_HOOK,
+      kind: "hook",
+      scope: "exclusive",
+      runtimeCodeHash: `0x${"23".repeat(32)}`,
+      logIndex: 2,
+      exclusiveProof: {
+        launchId: STAMP_LAUNCH_ID,
+        stampHash: STAMP_HASH,
+      },
+    },
+  ],
+  tokenProof: {
+    tokenAddress: STAMP_TOKEN,
+    launchId: STAMP_LAUNCH_ID,
+    stampHash: STAMP_HASH,
+  },
+  poolProof: {
+    poolManagerAddress: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+    poolId: STAMP_POOL_ID,
+    launchId: STAMP_LAUNCH_ID,
+    stampHash: STAMP_HASH,
+  },
+} as const satisfies LaunchStampProvenanceV1;
+
+export const customGraphToken = {
+  id: `1:${STAMP_TOKEN.toLowerCase()}`,
+  name: "Custom Graph",
+  symbol: "GRAPH",
+  tokenAddress: STAMP_TOKEN,
+  hookAddress: STAMP_HOOK,
+  poolId: STAMP_POOL_ID,
+  creatorAddress: launchStampProvenance.launchWallet,
+  launchBlockNumber: launchStampProvenance.blockNumber,
+  launchTransactionHash: launchStampProvenance.transactionHash,
+  launchTransactionIndex: launchStampProvenance.transactionIndex,
+  launchLogIndex: launchStampProvenance.launchLogIndex,
+  launchedAt: "2026-08-09T12:00:00.000Z",
+  totalSupplyRaw: (1_000n * 10n ** 18n).toString(),
+  tokenDecimals: 18,
+  currentTick: 0,
+  activeLiquidity: "1000000",
+  totalSwapFeeBps: null,
+  launchModel: "custom-graph",
+  launchModelVersion: "programmable-launch-stamp-router-v1",
+  launchStampProvenance,
+  liquidityPath: "programmable-v4",
+} as const satisfies LauncherToken;
+
+export const customGraphExploreEntry = {
+  ...customGraphToken,
+  exploreKind: "token",
+  launchCategoryProvenance: {
+    schemaVersion: "programmable.explore-launch-category-provenance.v1",
+    category: "custom",
+    source: "canonical-launch-stamp-router",
+    launchId: launchStampProvenance.launchId,
+    stampHash: launchStampProvenance.stampHash,
+    routerAddress: launchStampProvenance.routerAddress,
+    transactionHash: launchStampProvenance.transactionHash,
+    blockHash: launchStampProvenance.blockHash,
+    blockNumber: launchStampProvenance.blockNumber,
+    transactionIndex: launchStampProvenance.transactionIndex,
+    logIndex: launchStampProvenance.launchLogIndex,
+  },
+} as const satisfies CanonicalTokenExploreEntry;
+
+export const classicLaunchStampProvenance = {
+  ...launchStampProvenance,
+  kind: "classic",
+  components: [
+    launchStampProvenance.components[0],
+    {
+      ...launchStampProvenance.components[1],
+      scope: "shared-infrastructure",
+      exclusiveProof: null,
+    },
+  ],
+} as const satisfies LaunchStampProvenanceV1;
+
+export const stampedClassicToken = {
+  ...customGraphToken,
+  name: "Stamped Classic",
+  symbol: "CLASSIC",
+  launchModel: "classic",
+  launchStampProvenance: classicLaunchStampProvenance,
+} as const satisfies LauncherToken;
+
+export const stampedClassicExploreEntry = {
+  ...stampedClassicToken,
+  exploreKind: "token",
+  launchCategoryProvenance: {
+    schemaVersion: "programmable.explore-launch-category-provenance.v1",
+    category: "classic",
+    source: "canonical-launch-stamp-router",
+    launchId: classicLaunchStampProvenance.launchId,
+    stampHash: classicLaunchStampProvenance.stampHash,
+    routerAddress: classicLaunchStampProvenance.routerAddress,
+    transactionHash: classicLaunchStampProvenance.transactionHash,
+    blockHash: classicLaunchStampProvenance.blockHash,
+    blockNumber: classicLaunchStampProvenance.blockNumber,
+    transactionIndex: classicLaunchStampProvenance.transactionIndex,
+    logIndex: classicLaunchStampProvenance.launchLogIndex,
+  },
+} as const satisfies CanonicalTokenExploreEntry;

--- a/tests/launch-stamp-surfaces.test.ts
+++ b/tests/launch-stamp-surfaces.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  canUseClassicTokenTrade,
+  parseDetailPayload,
+} from "../components/token-detail-view";
+import {
+  getTokenCards,
+  loadExplorePayload,
+  tokenLaunchModelGroup,
+} from "../components/explore-view";
+import { canonicalTokenExploreEntryV1 } from "../lib/explore-entry-v1";
+import {
+  isLaunchStampProvenanceV1,
+  type LauncherToken,
+} from "../lib/tokens";
+import {
+  classicLaunchStampProvenance,
+  customGraphExploreEntry,
+  customGraphToken,
+  launchStampProvenance,
+  stampedClassicExploreEntry,
+  stampedClassicToken,
+} from "./launch-stamp-surface-fixture";
+
+const legacyClassicToken = {
+  id: "1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  name: "Legacy Classic",
+  symbol: "LEGACY",
+  tokenAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  hookAddress: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  poolId: `0x${"cc".repeat(32)}`,
+  launchedAt: "2026-08-08T12:00:00.000Z",
+  totalSwapFeeBps: 100,
+  launchModel: "classic",
+  launchModelVersion: "classic-v3",
+  liquidityPath: "meme",
+} as const satisfies LauncherToken;
+
+function detailPayload(
+  token: unknown,
+  chainId = 1,
+) {
+  return {
+    status: "ready",
+    token,
+    customProject: null,
+    snapshot: { chainId },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("canonical Router stamp surfaces", () => {
+  it("classifies a valid Custom Graph from the canonical stamp kind", () => {
+    const entry = canonicalTokenExploreEntryV1(customGraphToken);
+
+    expect(entry.launchCategoryProvenance).toMatchObject({
+      category: "custom",
+      source: "canonical-launch-stamp-router",
+      launchId: customGraphToken.launchStampProvenance.launchId,
+      stampHash: customGraphToken.launchStampProvenance.stampHash,
+    });
+  });
+
+  it("classifies a valid stamped Classic without falling back to the legacy source", () => {
+    const entry = canonicalTokenExploreEntryV1(stampedClassicToken);
+
+    expect(entry.launchCategoryProvenance).toMatchObject({
+      category: "classic",
+      source: "canonical-launch-stamp-router",
+      launchId: stampedClassicToken.launchStampProvenance.launchId,
+      stampHash: stampedClassicToken.launchStampProvenance.stampHash,
+    });
+  });
+
+  it("preserves the existing unstamped Classic read-model provenance", () => {
+    const entry = canonicalTokenExploreEntryV1(legacyClassicToken);
+
+    expect(entry.launchCategoryProvenance).toEqual({
+      schemaVersion: "programmable.explore-launch-category-provenance.v1",
+      category: "classic",
+      source: "canonical-launch-read-model",
+      recordId: legacyClassicToken.id,
+      modelId: "classic",
+      modelVersion: "classic-v3",
+    });
+  });
+
+  it("rejects launch-model and stamp-kind mismatches in both directions", () => {
+    expect(() =>
+      canonicalTokenExploreEntryV1({
+        ...customGraphToken,
+        launchStampProvenance: classicLaunchStampProvenance,
+      }),
+    ).toThrow(/provenance|stamp kind/iu);
+
+    expect(() =>
+      canonicalTokenExploreEntryV1({
+        ...stampedClassicToken,
+        launchStampProvenance: customGraphToken.launchStampProvenance,
+      }),
+    ).toThrow(/provenance|stamp kind/iu);
+  });
+
+  it("binds the public proof to the Mainnet trust root and Router limits", () => {
+    expect(isLaunchStampProvenanceV1(launchStampProvenance)).toBe(true);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      routerRuntimeCodeHash: `0x${"00".repeat(32)}`,
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      poolKey: { ...launchStampProvenance.poolKey, fee: 0x80_00_01 },
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      components: launchStampProvenance.components.slice(0, 1),
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      finalizedAtBlockNumber: "25718016",
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      blockNumber: "25717611",
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      poolKeyHash: `0x${"00".repeat(32)}`,
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      routeLauncherRuntimeCodeHash: `0x${"00".repeat(32)}`,
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      components: launchStampProvenance.components.map((component) => ({
+        ...component,
+        runtimeCodeHash: `0x${"00".repeat(32)}` as `0x${string}`,
+      })),
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      launchLogIndex: launchStampProvenance.launchLogIndex + 1,
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      components: [...launchStampProvenance.components].reverse(),
+    })).toBe(false);
+    expect(isLaunchStampProvenanceV1({
+      ...launchStampProvenance,
+      components: [
+        { ...launchStampProvenance.components[0], logIndex: 0 },
+        launchStampProvenance.components[1],
+      ],
+    })).toBe(false);
+  });
+
+  it("rejects any Router fee claim without a separate capability", () => {
+    expect(() => canonicalTokenExploreEntryV1({
+      ...stampedClassicToken,
+      totalSwapFeeBps: 100,
+    })).toThrow(/stamp/iu);
+    expect(() => parseDetailPayload(detailPayload({
+      ...stampedClassicExploreEntry,
+      totalSwapFeeBps: 100,
+    }))).toThrow(/invalid token/iu);
+  });
+
+  it("accepts complete Custom Graph and stamped Classic detail records", () => {
+    const custom = parseDetailPayload(detailPayload(customGraphExploreEntry));
+    const classic = parseDetailPayload(detailPayload(stampedClassicExploreEntry));
+
+    expect(custom.token).toMatchObject({
+      launchModel: "custom-graph",
+      launchStampProvenance: { kind: "custom-graph", chainId: 1 },
+    });
+    expect(classic.token).toMatchObject({
+      launchModel: "classic",
+      launchStampProvenance: { kind: "classic", chainId: 1 },
+    });
+  });
+
+  it("parses and labels both Router categories from the stamp", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "ready",
+        tokens: [customGraphExploreEntry, stampedClassicExploreEntry],
+        page: 1,
+        pageSize: 9,
+        total: 2,
+        totalPages: 1,
+      }),
+    }));
+
+    const payload = await loadExplorePayload(
+      `router-stamp-${Date.now()}`,
+      new URLSearchParams(),
+    );
+
+    expect(payload.tokens.map(tokenLaunchModelGroup)).toEqual([
+      "custom-hook",
+      "classic",
+    ]);
+    expect(getTokenCards(payload.tokens).map((card) => card.launchCategory))
+      .toEqual(["Custom", "Classic"]);
+    expect(payload.tokens[0]).toMatchObject({
+      launchStampProvenance: { kind: "custom-graph" },
+    });
+  });
+
+  it("rejects a stamped detail record on snapshot-chain drift", () => {
+    expect(() =>
+      parseDetailPayload(detailPayload(customGraphExploreEntry, 10)),
+    ).toThrow(/snapshot|invalid token/iu);
+  });
+
+  it("rejects category and canonical provenance tampering", () => {
+    expect(() =>
+      parseDetailPayload(detailPayload({
+        ...customGraphExploreEntry,
+        launchCategoryProvenance: {
+          ...customGraphExploreEntry.launchCategoryProvenance,
+          category: "classic",
+        },
+      })),
+    ).toThrow(/invalid token/iu);
+
+    expect(() =>
+      parseDetailPayload(detailPayload({
+        ...stampedClassicExploreEntry,
+        launchStampProvenance: {
+          ...stampedClassicExploreEntry.launchStampProvenance,
+          routerAddress: "0x9999999999999999999999999999999999999999",
+        },
+      })),
+    ).toThrow(/invalid token/iu);
+  });
+
+  it("never enables legacy Classic trade for a stamped token", () => {
+    expect(canUseClassicTokenTrade(customGraphToken)).toBe(false);
+    expect(canUseClassicTokenTrade(stampedClassicToken)).toBe(false);
+    expect(canUseClassicTokenTrade({
+      ...stampedClassicToken,
+      totalSwapFeeBps: 100,
+      liquidityPath: "meme",
+    })).toBe(false);
+    expect(canUseClassicTokenTrade(legacyClassicToken)).toBe(true);
+  });
+});

--- a/tests/launch-stamp-surfaces.test.ts
+++ b/tests/launch-stamp-surfaces.test.ts
@@ -213,6 +213,37 @@ describe("canonical Router stamp surfaces", () => {
     });
   });
 
+  it("fills missing Router card copy without inventing market data", () => {
+    const authoredDescription = "An authored token description.";
+    const cards = getTokenCards([
+      customGraphExploreEntry,
+      stampedClassicExploreEntry,
+      {
+        ...customGraphExploreEntry,
+        id: `${customGraphExploreEntry.id}:authored`,
+        description: authoredDescription,
+      },
+      canonicalTokenExploreEntryV1(legacyClassicToken),
+    ]);
+
+    expect(cards[0]).toMatchObject({
+      launchCategory: "Custom",
+      description:
+        "Canonical Router stamp. v4 pool initialized.",
+      marketCap: undefined,
+      marketStatus: undefined,
+    });
+    expect(cards[1]).toMatchObject({
+      launchCategory: "Classic",
+      description:
+        "Canonical Router stamp. v4 pool initialized.",
+      marketCap: undefined,
+      marketStatus: undefined,
+    });
+    expect(cards[2]?.description).toBe(authoredDescription);
+    expect(cards[3]?.description).toBeUndefined();
+  });
+
   it("rejects a stamped detail record on snapshot-chain drift", () => {
     expect(() =>
       parseDetailPayload(detailPayload(customGraphExploreEntry, 10)),

--- a/tests/onchain-profile.test.ts
+++ b/tests/onchain-profile.test.ts
@@ -27,7 +27,23 @@ describe("creator profile projection", () => {
           creatorFeesGeneratedWei: "500000000000000000",
           creatorFeesGeneratedEth: "0.5",
           totalSwapFeeBps: 100,
+          launchModel: "classic",
           liquidityPath: "meme",
+        },
+        {
+          id: "1:custom-graph",
+          name: "Stamped graph",
+          symbol: "GRAPH",
+          tokenAddress:
+            "0x7777777777777777777777777777777777777777",
+          hookAddress:
+            "0x8888888888888888888888888888888888888888",
+          poolId: `0x${"99".repeat(32)}`,
+          creatorAddress: creator,
+          launchedAt: "2026-07-28T00:00:00.000Z",
+          totalSwapFeeBps: null,
+          launchModel: "custom-graph",
+          liquidityPath: "programmable-v4",
         },
       ],
       creatorClaims: [
@@ -56,8 +72,17 @@ describe("creator profile projection", () => {
       launcherFeesAccruedEth: "0",
     };
 
-    const profile = buildCreatorProfile(model, creator);
-    expect(profile.tokens).toHaveLength(1);
+    const profile = buildCreatorProfile(
+      model,
+      creator,
+      new Set([poolId.toLowerCase()]),
+    );
+    expect(profile.tokens).toHaveLength(2);
+    expect(profile.tokens.map((token) => token.symbol)).toEqual([
+      "PRG",
+      "GRAPH",
+    ]);
+    expect(profile.pools).toHaveLength(1);
     expect(profile.claims).toHaveLength(1);
     expect(profile.totals).toEqual({
       claimableWei: "200000000000000000",

--- a/tests/profile-client.test.ts
+++ b/tests/profile-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { encodeFunctionData, parseAbi } from "viem";
+import { encodeFunctionData, getAddress, parseAbi } from "viem";
 
 import {
   prepareCreatorClaim,
@@ -30,9 +30,96 @@ const stockHookAddress =
 const stockPoolId = `0x${"ee".repeat(32)}` as `0x${string}`;
 const stockLaunchTransactionHash =
   `0x${"ff".repeat(32)}` as `0x${string}`;
+const stampedTokenAddress =
+  "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const stampedHookAddress =
+  "0xabababababababababababababababababababab";
+const stampedPoolId = `0x${"12".repeat(32)}` as `0x${string}`;
+const stampedLaunchTransactionHash =
+  `0x${"13".repeat(32)}` as `0x${string}`;
 const claimCreatorFeesAbi = parseAbi([
   "function claimCreatorFees(bytes32 poolId) returns (uint256 amount)",
 ]);
+
+function launchStampProvenance(input: Readonly<{
+  kind: "custom-graph" | "classic";
+  tokenAddress: `0x${string}`;
+  hookAddress: `0x${string}`;
+  poolId: `0x${string}`;
+  transactionHash: `0x${string}`;
+}>) {
+  const launchId = `0x${"15".repeat(32)}` as const;
+  const stampHash = `0x${"16".repeat(32)}` as const;
+  const poolManagerAddress =
+    "0x000000000004444c5dc75cB358380D2e3dE08A90" as const;
+  return {
+    schemaVersion: "programmable.launch-stamp-provenance.v1",
+    chainId: 1,
+    routerAddress: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+    routerRuntimeCodeHash:
+      "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+    routerStartBlock: "25717612",
+    finalityConfirmations: 64,
+    kind: input.kind,
+    launchId,
+    stampHash,
+    launchWallet: account,
+    transactionHash: input.transactionHash,
+    blockNumber: "25717620",
+    blockHash: `0x${"18".repeat(32)}`,
+    transactionIndex: 2,
+    routeLogIndex: 8,
+    launchLogIndex: 9,
+    finalizedAtBlockNumber: "25717684",
+    finalizedAtBlockHash: `0x${"19".repeat(32)}`,
+    poolManagerAddress,
+    poolId: input.poolId,
+    poolKey: {
+      currency0: "0x0000000000000000000000000000000000000000",
+      currency1: input.tokenAddress,
+      fee: 3_000,
+      tickSpacing: 60,
+      hooks: input.hookAddress,
+    },
+    poolKeyHash: `0x${"20".repeat(32)}`,
+    componentSetHash: `0x${"21".repeat(32)}`,
+    routePayloadHash: `0x${"22".repeat(32)}`,
+    routeLauncherAddress:
+      "0x1717171717171717171717171717171717171717",
+    routeLauncherRuntimeCodeHash: `0x${"23".repeat(32)}`,
+    expectedResultHash: `0x${"24".repeat(32)}`,
+    permitDigest: `0x${"25".repeat(32)}`,
+    components: [
+      {
+        address: input.tokenAddress,
+        kind: "token",
+        scope: "exclusive",
+        runtimeCodeHash: `0x${"26".repeat(32)}`,
+        logIndex: 6,
+        exclusiveProof: { launchId, stampHash },
+      },
+      {
+        address: input.hookAddress,
+        kind: "hook",
+        scope:
+          input.kind === "custom-graph"
+            ? "exclusive"
+            : "shared-infrastructure",
+        runtimeCodeHash: `0x${"27".repeat(32)}`,
+        logIndex: 7,
+        exclusiveProof:
+          input.kind === "custom-graph" ? { launchId, stampHash } : null,
+      },
+    ],
+    tokenProof: { tokenAddress: input.tokenAddress, launchId, stampHash },
+    poolProof: {
+      poolManagerAddress,
+      poolId: input.poolId,
+      launchId,
+      stampHash,
+    },
+  } as const;
+}
 
 function profileResponse() {
   return {
@@ -248,6 +335,81 @@ describe("profile API client", () => {
     expect(profile.positions).toHaveLength(2);
   });
 
+  it("keeps stamped launches visible without inferring fees or permanent positions", () => {
+    const response = profileResponse();
+    const customGraphToken = {
+      id: "1:stamped-custom-graph",
+      name: "Stamped graph",
+      symbol: "GRAPH",
+      tokenAddress: stampedTokenAddress,
+      hookAddress: stampedHookAddress,
+      poolId: stampedPoolId,
+      creatorAddress: account,
+      launchTransactionHash: stampedLaunchTransactionHash,
+      launchLogIndex: 9,
+      launchBlockNumber: "25717620",
+      launchedAt: "2026-07-28T12:00:00.000Z",
+      totalSwapFeeBps: null,
+      launchModel: "custom-graph",
+      liquidityPath: "programmable-v4",
+      launchStampProvenance: launchStampProvenance({
+        kind: "custom-graph",
+        tokenAddress: stampedTokenAddress,
+        hookAddress: stampedHookAddress,
+        poolId: stampedPoolId,
+        transactionHash: stampedLaunchTransactionHash,
+      }),
+    } as const;
+    const routerClassicToken = {
+      ...customGraphToken,
+      id: "1:stamped-classic",
+      name: "Stamped Classic",
+      symbol: "STAMP",
+      tokenAddress:
+        "0xacacacacacacacacacacacacacacacacacacacac",
+      poolId: `0x${"14".repeat(32)}`,
+      positionRecipient,
+      positionTokenId: "77",
+      totalSwapFeeBps: 100,
+      launchModel: "classic",
+      launchStampProvenance: launchStampProvenance({
+        kind: "classic",
+        tokenAddress:
+          "0xacacacacacacacacacacacacacacacacacacacac",
+        hookAddress: stampedHookAddress,
+        poolId: `0x${"14".repeat(32)}`,
+        transactionHash: stampedLaunchTransactionHash,
+      }),
+    } as const;
+
+    const profile = mapCreatorProfileResponse(
+      {
+        ...response,
+        tokens: [
+          ...response.tokens,
+          customGraphToken,
+          routerClassicToken,
+        ],
+      },
+      account,
+    );
+
+    expect(profile.tokens.map((token) => token.symbol)).toEqual([
+      "PRG",
+      "GRAPH",
+      "STAMP",
+    ]);
+    expect(profile.tokens[1]).toMatchObject({
+      address: getAddress(stampedTokenAddress),
+      launchModel: "custom-graph",
+    });
+    expect(profile.positions).toHaveLength(1);
+    expect(profile.positions[0]?.tokenAddress).toBe(tokenAddress);
+    expect(profile.claims).toHaveLength(1);
+    expect(profile.claimableWei).toBe("200000000000000000");
+    expect(profile.claimedWei).toBe("300000000000000000");
+  });
+
   it("keeps the undeployed state explicit and rejects fabricated records", () => {
     const undeployed = {
       status: "not-deployed",
@@ -298,6 +460,18 @@ describe("profile API client", () => {
         "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       ),
     ).toThrow("does not match the connected wallet");
+
+    const partialStamp = profileResponse();
+    partialStamp.tokens[0] = {
+      ...partialStamp.tokens[0],
+      launchStampProvenance: {
+        schemaVersion: "programmable.launch-stamp-provenance.v1",
+        kind: "custom-graph",
+      },
+    } as (typeof partialStamp.tokens)[number];
+    expect(() => mapCreatorProfileResponse(partialStamp, account)).toThrow(
+      "Invalid launch stamp provenance",
+    );
   });
 
   it("loads the account-keyed endpoint without browser caching", async () => {

--- a/tests/profile-client.test.ts
+++ b/tests/profile-client.test.ts
@@ -402,12 +402,72 @@ describe("profile API client", () => {
     expect(profile.tokens[1]).toMatchObject({
       address: getAddress(stampedTokenAddress),
       launchModel: "custom-graph",
+      launchProvenance: "canonical-router",
     });
     expect(profile.positions).toHaveLength(1);
     expect(profile.positions[0]?.tokenAddress).toBe(tokenAddress);
     expect(profile.claims).toHaveLength(1);
     expect(profile.claimableWei).toBe("200000000000000000");
     expect(profile.claimedWei).toBe("300000000000000000");
+  });
+
+  it("returns a connected launchWallet Router token with no reward or position state", () => {
+    const response = profileResponse();
+    const customGraphToken = {
+      id: "1:stamped-custom-graph-only",
+      name: "Custom Graph",
+      symbol: "GRAPH",
+      tokenAddress: stampedTokenAddress,
+      hookAddress: stampedHookAddress,
+      poolId: stampedPoolId,
+      creatorAddress: account,
+      launchTransactionHash: stampedLaunchTransactionHash,
+      launchLogIndex: 9,
+      launchBlockNumber: "25717620",
+      launchedAt: "2026-07-28T12:00:00.000Z",
+      totalSwapFeeBps: null,
+      launchModel: "custom-graph",
+      liquidityPath: "programmable-v4",
+      launchStampProvenance: launchStampProvenance({
+        kind: "custom-graph",
+        tokenAddress: stampedTokenAddress,
+        hookAddress: stampedHookAddress,
+        poolId: stampedPoolId,
+        transactionHash: stampedLaunchTransactionHash,
+      }),
+    } as const;
+    const profile = mapCreatorProfileResponse(
+      {
+        ...response,
+        tokens: [customGraphToken],
+        pools: [],
+        claims: [],
+        totals: {
+          claimableWei: "0",
+          claimableEth: "0",
+          generatedWei: "0",
+          generatedEth: "0",
+          claimedWei: "0",
+          claimedEth: "0",
+        },
+      },
+      account,
+    );
+
+    expect(profile.account).toBe(getAddress(account));
+    expect(profile.tokens).toEqual([
+      expect.objectContaining({
+        address: getAddress(stampedTokenAddress),
+        name: "Custom Graph",
+        symbol: "GRAPH",
+        launchModel: "custom-graph",
+        launchProvenance: "canonical-router",
+      }),
+    ]);
+    expect(profile.positions).toEqual([]);
+    expect(profile.claims).toEqual([]);
+    expect(profile.claimableWei).toBe("0");
+    expect(profile.claimedWei).toBe("0");
   });
 
   it("keeps the undeployed state explicit and rejects fabricated records", () => {

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { getAddress } from "viem";
 
@@ -22,6 +24,8 @@ import {
   profileClaimActionCount,
   profileEntryHasClaimableReward,
   profileHasRewardSurface,
+  profileRouterLaunchEntries,
+  ProfileRouterLaunches,
   profileRewardsForAccount,
   profileTransactionPollAttempts,
   reflectedConfirmedProfileTransactions,
@@ -758,6 +762,7 @@ describe("profile reward grouping", () => {
       name: "Stamped graph",
       symbol: "GRAPH",
       launchModel: "custom-graph",
+      launchProvenance: "canonical-router",
     } satisfies ProfileToken;
     const portfolio = buildProfilePortfolio(
       [customGraphToken],
@@ -777,6 +782,56 @@ describe("profile reward grouping", () => {
     ]);
     expect(profileClaimableWei(portfolio, firstAddress)).toBe(0n);
     expect(profileHasRewardSurface(portfolio)).toBe(false);
+  });
+
+  it("lists a connected launchWallet Router token independently of rewards", () => {
+    const routerCustom = {
+      ...tokens[0],
+      name: "Custom Graph",
+      symbol: "GRAPH",
+      launchModel: "custom-graph",
+      launchProvenance: "canonical-router",
+    } satisfies ProfileToken;
+    const legacy = {
+      ...tokens[1],
+      launchModel: "classic",
+    } satisfies ProfileToken;
+    const portfolio = buildProfilePortfolio(
+      [routerCustom, legacy],
+      [],
+      [],
+    );
+
+    expect(profileRouterLaunchEntries(portfolio)).toEqual([
+      expect.objectContaining({
+        token: routerCustom,
+        launchedByWallet: true,
+        claim: undefined,
+        classicRewards: [],
+        deepRewards: [],
+        stockPairedRewards: [],
+      }),
+    ]);
+    expect(profileHasRewardSurface(profileRouterLaunchEntries(portfolio)))
+      .toBe(false);
+    expect(profileViewSource).toContain("Canonical Router records from this wallet.");
+    expect(profileViewSource).toContain("Router record");
+
+    const html = renderToStaticMarkup(
+      createElement(ProfileRouterLaunches, {
+        entries: profileRouterLaunchEntries(portfolio),
+      }),
+    );
+    expect(html).toContain("Launches");
+    expect(html).toContain("Canonical Router records from this wallet.");
+    expect(html).toContain("Custom Graph");
+    expect(html).toContain("$GRAPH");
+    expect(html).toContain(`href="/token/${routerCustom.address}"`);
+    expect(html).toContain("Custom");
+    expect(html).toContain("Router record");
+    expect(html).not.toMatch(/>\s*Claim\s*</i);
+    expect(html).not.toContain("permanently locked");
+    expect(html).not.toContain("positionTokenId");
   });
 });
 

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -816,6 +816,12 @@ describe("profile reward grouping", () => {
       .toBe(false);
     expect(profileViewSource).toContain("Canonical Router records from this wallet.");
     expect(profileViewSource).toContain("Router record");
+    expect(profileViewSource).toContain(
+      'claimableEntries.length ? "" : styles.claimablePanelEmpty',
+    );
+    expect(profileExperienceCss).toMatch(
+      /@media \(max-width: 820px\)[\s\S]*\.claimablePanelEmpty\s*\{[^}]*min-height:\s*0;[\s\S]*\.claimablePanelEmpty \.claimEmpty\s*\{[^}]*min-height:\s*0;/,
+    );
 
     const html = renderToStaticMarkup(
       createElement(ProfileRouterLaunches, {

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -751,6 +751,33 @@ describe("profile reward grouping", () => {
     expect(profileClaimableWei(portfolio, firstAddress)).toBe(0n);
     expect(profileHasRewardSurface(portfolio)).toBe(false);
   });
+
+  it("shows a stamped CustomGraph token without inventing a reward surface", () => {
+    const customGraphToken = {
+      ...tokens[0],
+      name: "Stamped graph",
+      symbol: "GRAPH",
+      launchModel: "custom-graph",
+    } satisfies ProfileToken;
+    const portfolio = buildProfilePortfolio(
+      [customGraphToken],
+      [],
+      [],
+    );
+
+    expect(portfolio).toEqual([
+      expect.objectContaining({
+        token: customGraphToken,
+        launchedByWallet: true,
+        claim: undefined,
+        classicRewards: [],
+        deepRewards: [],
+        stockPairedRewards: [],
+      }),
+    ]);
+    expect(profileClaimableWei(portfolio, firstAddress)).toBe(0n);
+    expect(profileHasRewardSurface(portfolio)).toBe(false);
+  });
 });
 
 describe("profile transaction status", () => {

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -835,6 +835,7 @@ describe("profile reward grouping", () => {
     expect(html).toContain(`href="/token/${routerCustom.address}"`);
     expect(html).toContain("Custom");
     expect(html).toContain("Router record");
+    expect(html).not.toContain('aria-label="Open Custom Graph"');
     expect(html).not.toMatch(/>\s*Claim\s*</i);
     expect(html).not.toContain("permanently locked");
     expect(html).not.toContain("positionTokenId");

--- a/tests/router-custom-collision.test.ts
+++ b/tests/router-custom-collision.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { suppressRouterBoundCustomProjectDuplicates } from
+  "../lib/alchemy/router-custom-collision";
+import type {
+  CustomProjectExploreEntry,
+  LauncherToken,
+} from "../lib/tokens";
+import {
+  customGraphToken,
+  STAMP_POOL_ID,
+  STAMP_TOKEN,
+} from "./launch-stamp-surface-fixture";
+
+const tokenAddress = STAMP_TOKEN;
+const poolId = STAMP_POOL_ID;
+
+function token(stamped = true) {
+  if (stamped) return customGraphToken;
+  const legacy = { ...customGraphToken } as LauncherToken;
+  delete legacy.launchStampProvenance;
+  return legacy;
+}
+
+function project(boundPoolId: `0x${string}`) {
+  return {
+    chainId: "1",
+    tokenAddress,
+    markets: [{ poolId: boundPoolId }],
+  } as unknown as CustomProjectExploreEntry;
+}
+
+describe("Router and custom-directory collision policy", () => {
+  it("lets the canonical Router record win only for the exact token and pool", () => {
+    expect(
+      suppressRouterBoundCustomProjectDuplicates(
+        [token()],
+        [project(poolId)],
+      ),
+    ).toEqual([]);
+  });
+
+  it("fails closed when the same token is bound to a different pool", () => {
+    expect(() =>
+      suppressRouterBoundCustomProjectDuplicates(
+        [token()],
+        [project(`0x${"34".repeat(32)}`)],
+      )
+    ).toThrow("disagree on token pool binding");
+  });
+
+  it("does not suppress collisions for an unstamped legacy token", () => {
+    const candidate = project(poolId);
+    expect(
+      suppressRouterBoundCustomProjectDuplicates(
+        [token(false)],
+        [candidate],
+      ),
+    ).toEqual([candidate]);
+  });
+
+  it("does not relabel a Router Classic launch as a custom project", () => {
+    const customStamp = customGraphToken.launchStampProvenance;
+    const classic = {
+      ...customGraphToken,
+      launchModel: "classic",
+      launchStampProvenance: {
+        ...customStamp,
+        kind: "classic",
+        components: customStamp.components.map((component) =>
+          component.kind === "hook"
+            ? {
+                ...component,
+                scope: "shared-infrastructure" as const,
+                exclusiveProof: null,
+              }
+            : component,
+        ),
+      },
+    } satisfies LauncherToken;
+    const candidate = project(poolId);
+    expect(
+      suppressRouterBoundCustomProjectDuplicates([classic], [candidate]),
+    ).toEqual([candidate]);
+  });
+});

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -5,6 +5,7 @@ vi.mock("server-only", () => ({}));
 
 import type { ExploreReadModel } from "../lib/onchain/types";
 import type { LauncherToken } from "../lib/tokens";
+import { customGraphToken } from "./launch-stamp-surface-fixture";
 
 const mocks = vi.hoisted(() => ({
   enrichTokensWithAlchemyPrices: vi.fn(),
@@ -133,6 +134,44 @@ describe("token detail Alchemy read", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
+  });
+
+  it("serves Router provenance for a finalized Custom Graph without Classic fields", async () => {
+    const model = {
+      status: "ready",
+      tokens: [customGraphToken],
+      snapshot,
+      launchDiscoverySnapshot,
+      creatorClaims: [],
+      launcherFeesAccruedWei: "0",
+      launcherFeesAccruedEth: "0",
+    } satisfies ExploreReadModel;
+    mocks.readAlchemyExploreModel.mockResolvedValue(model);
+    mocks.enrichTokensWithAlchemyPrices.mockResolvedValue([customGraphToken]);
+
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/explore/token?address=${customGraphToken.tokenAddress}`,
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.customProject).toBeNull();
+    expect(body.token).toMatchObject({
+      tokenAddress: customGraphToken.tokenAddress,
+      launchModel: "custom-graph",
+      totalSwapFeeBps: null,
+      launchCategoryProvenance: {
+        category: "custom",
+        source: "canonical-launch-stamp-router",
+        launchId: customGraphToken.launchStampProvenance.launchId,
+        stampHash: customGraphToken.launchStampProvenance.stampHash,
+      },
+      launchStampProvenance: customGraphToken.launchStampProvenance,
+    });
+    expect(body.token.positionRecipient).toBeUndefined();
+    expect(body.token.positionTokenId).toBeUndefined();
   });
 
   it.each([

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -75,6 +75,24 @@ describe("token detail layout", () => {
     );
   });
 
+  it("uses a compact read-only Router notice without shrinking live trade forms", () => {
+    expect(detailSource).toContain(
+      'isRouterStamped ? styles.routerNoticeShell : ""',
+    );
+    expect(detailSource).toContain('className={styles.routerNotice} role="status"');
+    expect(detailSource).toContain("market availability");
+    expect(detailSource).toContain("This page shows launch data only.");
+    expect(detailStyles).toMatch(
+      /\.tradeShell\s*\{[^}]*min-height:\s*390px;/s,
+    );
+    expect(detailStyles).toMatch(
+      /\.routerNoticeShell\s*\{[^}]*min-height:\s*0;[^}]*position:\s*static;/s,
+    );
+    expect(detailStyles).toMatch(
+      /\.routerNotice\s*\{[^}]*display:\s*grid;[^}]*gap:\s*6px;/s,
+    );
+  });
+
   it("keeps the mobile visual order aligned with DOM and keyboard order", () => {
     const contentSource = detailSource.slice(
       detailSource.indexOf("function TokenDetailContent"),


### PR DESCRIPTION
## What changed

- discovers finalized `ProgrammableLaunchStampRouterV1` launches through the existing Alchemy read path
- persists an independent Router cursor in the existing Blob registry with 64-confirmation finality and Router-only reorg rebuilds
- verifies the canonical Router runtime, event sequence, PoolManager initialization, PoolId/key hash, launch getters and component proofs
- exposes CustomGraph and Router Classic provenance across Explore, token detail, indexer feeds/token list and creator profiles
- keeps Router launches read-only unless separate route-specific trade, reward or position evidence exists
- preserves existing Classic results and collision handling without adding Supabase, a new server or a second persistent indexer

## Safety boundaries

- Safe and contract-wallet internal Router calls are supported; discovery does not assume the Router is the top-level transaction target
- CustomGraph fees, positions, rewards and trade capability are never fabricated
- optional ERC-20 presentation metadata cannot hide a valid stamp or pin later launches
- standard token-list output omits only tokens without valid decimals; the programmable feed keeps exact provenance with decimals explicitly unknown

## Validation

- `npm run contracts:bootstrap` — PASS
- `npm run contracts:build` — PASS, 465 Solidity files compiled
- `npm test` — PASS, node verifier 3/3 and Vitest 245 files / 2,239 tests passed; 7 explicitly skipped, 0 failed
- `npm run typecheck` — PASS
- `npm run lint` — PASS, 0 errors (11 existing warnings)
- `npm run contracts:token-list:schema` — PASS against pinned Uniswap schema commit `01705f94a307270b6c0fe5f55c7e66f7b92373cc`
- `npm run build` — PASS
- rendered QA — PASS at desktop, 390 px, 320 px and 200%; keyboard focus/search verified, no horizontal overflow, and no CustomGraph trade/claim/permanent-lock actions
- independent final audit — 0 Critical / 0 High / 0 Medium on `b9be6c9da358aa6f8c3f74bcb4ab3d00cdaa9a96`
