### PR TITLE
Fix launch stamp source hash wrapping

### DIFF
--- a/components/launch-stamp-docs.module.css
+++ b/components/launch-stamp-docs.module.css
@@ -308,6 +308,11 @@
   max-width: 72ch !important;
 }
 
+.detailLine code {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .recordLayout {
   border: 1px solid var(--panel-border);
   margin-top: 28px;

--- a/tests/launch-stamp-docs.test.ts
+++ b/tests/launch-stamp-docs.test.ts
@@ -513,6 +513,9 @@ describe("Launch Stamp developer documentation", () => {
     expect(styles).toMatch(
       /\.abiList dd > span,\s*\.abiList dd > span code\s*\{[^}]*max-width:\s*100%;[^}]*min-width:\s*0;[^}]*overflow-wrap:\s*anywhere;[^}]*word-break:\s*break-word;/s,
     );
+    expect(styles).toMatch(
+      /\.detailLine code\s*\{[^}]*overflow-wrap:\s*anywhere;[^}]*word-break:\s*break-word;/s,
+    );
     expect(styles).not.toContain("transition: all");
     expect(styles).not.toMatch(/\n\s+width:\s*\d{3,}px/);
   });


### PR DESCRIPTION
## What changed

- allow inline code values in launch-stamp detail lines to wrap at narrow widths
- add a focused regression assertion for the wrapping rule

## Why

The two 40-character source commit hashes in the finalized PCAN section exceeded the 292px content column at 320px and were visually clipped. Global horizontal scrolling stayed disabled, so the final characters were not visible.

## Impact

Both hashes now remain fully readable at 320px. No documentation copy, Router bindings, reader logic, security behavior, or deployment code changed.

## Validation

- focused Vitest: 9/9
- TypeScript typecheck
- production build
- focused ESLint and diff check
- rendered production build at 1440, 720 reflow, 390, and 320 CSS pixels
- no horizontal overflow and no console warnings or errors
- both source hashes fully contained; 320px wraps to two lines