### PR TITLE
Fix sensitive env release validation

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -171,24 +171,33 @@ jobs:
           --production-mode "$CUSTOM_LAUNCH_PRODUCTION_MODE"
           --github-output "$GITHUB_OUTPUT"
 
-      - name: Resolve manual Applicant launch policy
-        id: manual-applicant-policy
-        env:
-          MANUAL_APPLICANT_LAUNCH_ENABLEMENT_REQUESTED: ${{ inputs.manual_applicant_launch_enablement }}
-          MANUAL_APPLICANT_LAUNCH_PROTECTED_MODE: ${{ vars.PROGRAMMABLE_MANUAL_APPLICANT_LAUNCH_MODE }}
-        run: >-
-          node scripts/resolve-manual-applicant-launch-policy.mjs
-          --env-file .vercel/.env.production.local
-          --requested "$MANUAL_APPLICANT_LAUNCH_ENABLEMENT_REQUESTED"
-          --protected-mode "$MANUAL_APPLICANT_LAUNCH_PROTECTED_MODE"
-          --github-output "$GITHUB_OUTPUT"
-
       - name: Capture sensitive production environment metadata
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           umask 077
           vercel env ls production --format json --token="$VERCEL_TOKEN" > "$RUNNER_TEMP/vercel-production-env-metadata.json"
+          node scripts/bind-vercel-sensitive-production-metadata.mjs \
+            --metadata-file "$RUNNER_TEMP/vercel-production-env-metadata.json" \
+            --vercel-project-id "$VERCEL_PROJECT_ID"
+
+      - name: Resolve manual Applicant launch policy
+        id: manual-applicant-policy
+        env:
+          MANUAL_APPLICANT_LAUNCH_ENABLEMENT_REQUESTED: ${{ inputs.manual_applicant_launch_enablement }}
+          MANUAL_APPLICANT_LAUNCH_PROTECTED_MODE: ${{ vars.PROGRAMMABLE_MANUAL_APPLICANT_LAUNCH_MODE }}
+          PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}
+          PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}
+        run: >-
+          node scripts/resolve-manual-applicant-launch-policy.mjs
+          --env-file .vercel/.env.production.local
+          --manual-sensitive-metadata "$RUNNER_TEMP/vercel-production-env-metadata.json"
+          --vercel-project-id "$VERCEL_PROJECT_ID"
+          --alchemy-endpoint-commitment "$PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT"
+          --quicknode-endpoint-commitment "$PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT"
+          --requested "$MANUAL_APPLICANT_LAUNCH_ENABLEMENT_REQUESTED"
+          --protected-mode "$MANUAL_APPLICANT_LAUNCH_PROTECTED_MODE"
+          --github-output "$GITHUB_OUTPUT"
 
       - name: Capture current production rollback target
         id: production-before
@@ -322,8 +331,10 @@ jobs:
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}
+          PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}
         run: |
-          deployment_url="$(vercel deploy --prebuilt --prod --skip-domain --archive=tgz --meta githubCommitSha="$GITHUB_SHA" --env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA" --env PROGRAMMABLE_RELEASE_COMMIT_SHA="$GITHUB_SHA" --token="$VERCEL_TOKEN")"
+          deployment_url="$(vercel deploy --prebuilt --prod --skip-domain --archive=tgz --meta githubCommitSha="$GITHUB_SHA" --env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA" --env PROGRAMMABLE_RELEASE_COMMIT_SHA="$GITHUB_SHA" --env PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT="$PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT" --env PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT="$PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT" --token="$VERCEL_TOKEN")"
           case "$deployment_url" in
             https://*) ;;
             *)
@@ -444,6 +455,15 @@ jobs:
           curl --fail --silent --show-error \
             --retry 12 --retry-all-errors --retry-delay 5 \
             --max-time 30 "$DEPLOYMENT_URL/" > /dev/null
+
+      - name: Verify staged manual Applicant runtime
+        if: steps.manual-applicant-policy.outputs.enabled == 'true'
+        env:
+          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: >-
+          node scripts/verify-manual-applicant-staged-runtime.mjs
+          --target-url "$STAGED_TARGET_URL"
 
       - name: Smoke staged Alchemy Explore APIs
         if: steps.read-model-policy.outputs.mode == 'alchemy-only'

--- a/lib/server/custom-launch/manual-router-config-v1.ts
+++ b/lib/server/custom-launch/manual-router-config-v1.ts
@@ -1,5 +1,8 @@
 import "server-only";
 
+import { rpcProviderCommitment } from
+  "@/lib/data-pipeline/rpc-provider-commitments";
+
 const ALCHEMY_PRODUCTION_HOST = "eth-mainnet.g.alchemy.com";
 const QUICKNODE_PRODUCTION_HOST = /^(?:[a-z0-9-]+\.)+quiknode\.pro$/u;
 
@@ -42,6 +45,23 @@ export function resolveManualRouterStrictRpcConfigurationV1(
   ) {
     throw new TypeError("manual Router RPC providers are not independent");
   }
+  const alchemyCommitment = requiredCommitmentEnvironment(
+    environment,
+    "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT",
+  );
+  const quickNodeCommitment = requiredCommitmentEnvironment(
+    environment,
+    "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+  );
+  if (alchemyCommitment === quickNodeCommitment) {
+    throw new TypeError("manual Router RPC commitments are not independent");
+  }
+  if (rpcProviderCommitment("endpoint", alchemy.href) !== alchemyCommitment) {
+    throw new TypeError("manual Router Alchemy endpoint commitment mismatch");
+  }
+  if (rpcProviderCommitment("endpoint", quickNode.href) !== quickNodeCommitment) {
+    throw new TypeError("manual Router QuickNode endpoint commitment mismatch");
+  }
   return Object.freeze({
     alchemyUrl: alchemy.href,
     quickNodeUrl: quickNode.href,
@@ -61,6 +81,7 @@ export function assertManualRouterProductionConfigurationV1(
   ] as const) {
     requiredEnvironment(environment, name);
   }
+  requiredCronSecretEnvironment(environment);
   resolveManualRouterStrictRpcConfigurationV1(environment);
 }
 
@@ -82,6 +103,30 @@ function requiredRpcEnvironment(
     throw new TypeError(`${name} is not configured`);
   }
   return value;
+}
+
+function requiredCronSecretEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+): string {
+  const value = environment.CRON_SECRET;
+  const byteLength = typeof value === "string"
+    ? Buffer.byteLength(value, "utf8")
+    : 0;
+  if (typeof value !== "string" || byteLength < 32 || byteLength > 1_024) {
+    throw new TypeError("CRON_SECRET is not configured");
+  }
+  return value;
+}
+
+function requiredCommitmentEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+  name: string,
+): `0x${string}` {
+  const value = environment[name];
+  if (typeof value !== "string" || !/^0x[0-9a-f]{64}$/u.test(value)) {
+    throw new TypeError(`${name} is not configured`);
+  }
+  return value as `0x${string}`;
 }
 
 function strictProviderUrl(

--- a/scripts/bind-vercel-sensitive-production-metadata.mjs
+++ b/scripts/bind-vercel-sensitive-production-metadata.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import { readFile, rename, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+export const VERCEL_SENSITIVE_PRODUCTION_METADATA_SCHEMA =
+  "programmable.vercel-sensitive-production-metadata.v1";
+
+export function bindVercelSensitiveProductionMetadata({
+  metadata,
+  vercelProjectId,
+}) {
+  if (!/^prj_[A-Za-z0-9]{8,128}$/u.test(vercelProjectId ?? "")) {
+    throw new Error("Vercel project ID is invalid");
+  }
+  if (
+    metadata === null
+    || typeof metadata !== "object"
+    || Array.isArray(metadata)
+    || Object.keys(metadata).sort().join("\0") !== "envs"
+    || !Array.isArray(metadata.envs)
+  ) {
+    throw new Error("Vercel environment metadata is invalid");
+  }
+  for (const entry of metadata.envs) {
+    if (
+      entry === null
+      || typeof entry !== "object"
+      || Array.isArray(entry)
+      || Object.hasOwn(entry, "value")
+    ) {
+      throw new Error("Vercel environment metadata must not contain values");
+    }
+  }
+  return Object.freeze({
+    schemaVersion: VERCEL_SENSITIVE_PRODUCTION_METADATA_SCHEMA,
+    vercelProjectId,
+    target: "production",
+    envs: metadata.envs,
+  });
+}
+
+function argumentsFrom(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || !value || value.startsWith("--")) {
+      throw new Error("arguments must be --name value pairs");
+    }
+    result[name.slice(2)] = value;
+  }
+  for (const name of ["metadata-file", "vercel-project-id"]) {
+    if (!result[name]) throw new Error(`--${name} is required`);
+  }
+  return result;
+}
+
+async function main(argv) {
+  const args = argumentsFrom(argv);
+  const source = JSON.parse(await readFile(args["metadata-file"], "utf8"));
+  const bound = bindVercelSensitiveProductionMetadata({
+    metadata: source,
+    vercelProjectId: args["vercel-project-id"],
+  });
+  const replacement = `${args["metadata-file"]}.bound`;
+  await writeFile(replacement, `${JSON.stringify(bound)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  await rename(replacement, args["metadata-file"]);
+  process.stdout.write(`${JSON.stringify({
+    status: "bound",
+    schemaVersion: bound.schemaVersion,
+    target: bound.target,
+  })}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "metadata binding failed"}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/resolve-manual-applicant-launch-policy.mjs
+++ b/scripts/resolve-manual-applicant-launch-policy.mjs
@@ -3,6 +3,9 @@
 import { appendFile, readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
+import { VERCEL_SENSITIVE_PRODUCTION_METADATA_SCHEMA } from
+  "./bind-vercel-sensitive-production-metadata.mjs";
+
 export const MANUAL_APPLICANT_LAUNCH_FLAG =
   "PROGRAMMABLE_MANUAL_APPLICANT_LAUNCH_ENABLED";
 export const MANUAL_APPLICANT_SERVER_ENVIRONMENT = Object.freeze([
@@ -13,6 +16,14 @@ export const MANUAL_APPLICANT_SERVER_ENVIRONMENT = Object.freeze([
   "OPS_BLOB_READ_WRITE_TOKEN",
   "CRON_SECRET",
 ]);
+export const MANUAL_APPLICANT_SENSITIVE_SERVER_ENVIRONMENT = Object.freeze([
+  "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+  "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
+  "PRIVY_APP_SECRET",
+  "OPS_BLOB_READ_WRITE_TOKEN",
+  "CRON_SECRET",
+]);
+const HEX_BYTES32 = /^0x[0-9a-f]{64}$/u;
 
 export function readManualApplicantLaunchFlag(envSource) {
   const matches = [];
@@ -49,6 +60,9 @@ export function resolveManualApplicantLaunchPolicy({
   requested,
   productionEnvSource,
   protectedMode,
+  sensitiveMetadataSource,
+  expectedVercelProjectId,
+  endpointCommitments,
 }) {
   const dispatchEnabled = exactBoolean(
     requested,
@@ -74,33 +88,38 @@ export function resolveManualApplicantLaunchPolicy({
     );
   }
   if (configuredEnabled) {
-    assertManualApplicantServerEnvironment(productionEnvSource);
+    assertManualApplicantServerEnvironment(productionEnvSource, {
+      sensitiveMetadataSource,
+      expectedVercelProjectId,
+      endpointCommitments,
+    });
   }
   return Object.freeze({ enabled: configuredEnabled });
 }
 
-export function assertManualApplicantServerEnvironment(envSource) {
+export function assertManualApplicantServerEnvironment(
+  envSource,
+  {
+    sensitiveMetadataSource,
+    expectedVercelProjectId,
+    endpointCommitments,
+  } = {},
+) {
   const values = new Map(MANUAL_APPLICANT_SERVER_ENVIRONMENT.map((name) =>
     [name, readExactEnvironmentValue(envSource, name)]));
-  const alchemy = strictRpcUrl(
-    values.get("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL"),
-    "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
-    (hostname) => hostname === "eth-mainnet.g.alchemy.com",
-  );
-  const quickNode = strictRpcUrl(
-    values.get("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL"),
-    "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
-    (hostname) => /^(?:[a-z0-9-]+\.)+quiknode\.pro$/u.test(hostname),
-  );
-  if (
-    alchemy.href === quickNode.href
-    || alchemy.hostname === quickNode.hostname
-    || alchemy.hostname.split(".").slice(-2).join(".")
-      === quickNode.hostname.split(".").slice(-2).join(".")
-  ) throw new Error("manual Applicant RPC providers are not independent");
-  if (values.get("CRON_SECRET").length < 32) {
-    throw new Error("manual Applicant CRON_SECRET is too short");
+  for (const name of MANUAL_APPLICANT_SENSITIVE_SERVER_ENVIRONMENT) {
+    if (values.get(name) !== "") {
+      throw new Error(`manual Applicant ${name} custody was downgraded`);
+    }
   }
+  if (values.get("NEXT_PUBLIC_PRIVY_APP_ID") === "") {
+    throw new Error("manual Applicant NEXT_PUBLIC_PRIVY_APP_ID is not configured");
+  }
+  assertExactSensitiveProductionMetadata({
+    source: sensitiveMetadataSource,
+    expectedVercelProjectId,
+  });
+  assertEndpointCommitments(endpointCommitments);
   return Object.freeze(Object.fromEntries(
     [...values.keys()].map((name) => [name, "configured"]),
   ));
@@ -121,33 +140,66 @@ function readExactEnvironmentValue(source, name) {
       || (raw.startsWith("'") && raw.endsWith("'")))
     ? raw.slice(1, -1)
     : raw;
-  if (!value || /[\r\n\u0000]/u.test(value)) {
+  if (/[\r\n\u0000]/u.test(value)) {
     throw new Error(`manual Applicant ${name} is not configured`);
   }
   return value;
 }
 
-function strictRpcUrl(value, name, acceptsHostname) {
-  let url;
-  if (value.length > 2_048 || value !== value.trim()) {
-    throw new Error(`manual Applicant ${name} is not a valid URL`);
-  }
+function assertExactSensitiveProductionMetadata({
+  source,
+  expectedVercelProjectId,
+}) {
+  if (
+    typeof expectedVercelProjectId !== "string"
+    || !/^prj_[A-Za-z0-9]{8,128}$/u.test(expectedVercelProjectId)
+  ) throw new Error("manual Applicant Vercel project binding is invalid");
+  let metadata;
   try {
-    url = new URL(value);
+    metadata = JSON.parse(source);
   } catch {
-    throw new Error(`manual Applicant ${name} is not a valid URL`);
+    throw new Error("manual Applicant sensitive production metadata is invalid");
   }
   if (
-    url.protocol !== "https:"
-    || url.username !== ""
-    || url.password !== ""
-    || url.search !== ""
-    || url.hash !== ""
-    || url.port !== ""
-    || url.pathname === "/"
-    || !acceptsHostname(url.hostname.toLowerCase())
-  ) throw new Error(`manual Applicant ${name} is not its strict provider`);
-  return url;
+    metadata === null
+    || typeof metadata !== "object"
+    || Array.isArray(metadata)
+    || Object.keys(metadata).sort().join("\0")
+      !== "envs\0schemaVersion\0target\0vercelProjectId"
+    || metadata.schemaVersion
+      !== VERCEL_SENSITIVE_PRODUCTION_METADATA_SCHEMA
+    || metadata.vercelProjectId !== expectedVercelProjectId
+    || metadata.target !== "production"
+    || !Array.isArray(metadata.envs)
+  ) throw new Error("manual Applicant sensitive production metadata is invalid");
+  for (const name of MANUAL_APPLICANT_SENSITIVE_SERVER_ENVIRONMENT) {
+    const matches = metadata.envs.filter(
+      (entry) => entry !== null && typeof entry === "object" && entry.key === name,
+    );
+    if (
+      matches.length !== 1
+      || matches[0].type !== "sensitive"
+      || !Array.isArray(matches[0].target)
+      || matches[0].target.length !== 1
+      || matches[0].target[0] !== "production"
+      || Object.hasOwn(matches[0], "value")
+    ) throw new Error(`manual Applicant ${name} is not exact sensitive production metadata`);
+  }
+}
+
+function assertEndpointCommitments(value) {
+  const alchemy = value?.alchemy;
+  const quickNode = value?.quickNode;
+  if (!HEX_BYTES32.test(alchemy ?? "")) {
+    throw new Error("manual Applicant Alchemy endpoint commitment is invalid");
+  }
+  if (!HEX_BYTES32.test(quickNode ?? "")) {
+    throw new Error("manual Applicant QuickNode endpoint commitment is invalid");
+  }
+  if (alchemy === quickNode) {
+    throw new Error("manual Applicant endpoint commitments are not independent");
+  }
+  return Object.freeze({ alchemy, quickNode });
 }
 
 function exactBoolean(value, label) {
@@ -167,7 +219,14 @@ function argumentsFrom(argv) {
     result[name.slice(2)] = value;
   }
   for (const name of [
-    "env-file", "requested", "protected-mode", "github-output",
+    "env-file",
+    "manual-sensitive-metadata",
+    "vercel-project-id",
+    "alchemy-endpoint-commitment",
+    "quicknode-endpoint-commitment",
+    "requested",
+    "protected-mode",
+    "github-output",
   ]) {
     if (!result[name]) throw new Error(`--${name} is required`);
   }
@@ -180,6 +239,15 @@ async function main(argv) {
     requested: args.requested,
     productionEnvSource: await readFile(args["env-file"], "utf8"),
     protectedMode: args["protected-mode"],
+    sensitiveMetadataSource: await readFile(
+      args["manual-sensitive-metadata"],
+      "utf8",
+    ),
+    expectedVercelProjectId: args["vercel-project-id"],
+    endpointCommitments: {
+      alchemy: args["alchemy-endpoint-commitment"],
+      quickNode: args["quicknode-endpoint-commitment"],
+    },
   });
   await appendFile(
     args["github-output"],

--- a/scripts/test/manual-applicant-launch-policy.test.mjs
+++ b/scripts/test/manual-applicant-launch-policy.test.mjs
@@ -1,23 +1,52 @@
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import assert from "node:assert/strict";
+import { keccak256, toBytes } from "viem";
 
+import {
+  bindVercelSensitiveProductionMetadata,
+} from "../bind-vercel-sensitive-production-metadata.mjs";
 import {
   assertManualApplicantServerEnvironment,
   readManualApplicantLaunchFlag,
   resolveManualApplicantLaunchPolicy,
 } from "../resolve-manual-applicant-launch-policy.mjs";
+import { verifyManualApplicantStagedRuntime } from
+  "../verify-manual-applicant-staged-runtime.mjs";
+
+const ALCHEMY_URL = "https://eth-mainnet.g.alchemy.com/v2/key";
+const QUICKNODE_URL = "https://example.quiknode.pro/key";
+const VERCEL_PROJECT_ID = "prj_12345678";
+const ENDPOINT_DOMAIN = "programmable:data-pipeline:rpc-endpoint:v1\0";
+const endpointCommitments = Object.freeze({
+  alchemy: keccak256(toBytes(`${ENDPOINT_DOMAIN}${ALCHEMY_URL}`)),
+  quickNode: keccak256(toBytes(`${ENDPOINT_DOMAIN}${QUICKNODE_URL}`)),
+});
+const SENSITIVE_NAMES = Object.freeze([
+  "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+  "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
+  "PRIVY_APP_SECRET",
+  "OPS_BLOB_READ_WRITE_TOKEN",
+  "CRON_SECRET",
+]);
 
 const enabledEnvironment = [
   "PROGRAMMABLE_MANUAL_APPLICANT_LAUNCH_ENABLED=true",
-  "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/key",
-  "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL=https://example.quiknode.pro/key",
+  `PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL=${ALCHEMY_URL}`,
+  `PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL=${QUICKNODE_URL}`,
   "NEXT_PUBLIC_PRIVY_APP_ID=privy-app",
   "PRIVY_APP_SECRET=privy-secret",
   "OPS_BLOB_READ_WRITE_TOKEN=blob-token",
   `CRON_SECRET=${"c".repeat(32)}`,
   "",
 ].join("\n");
+
+const pulledSensitiveEnvironment = sensitivePulledEnvironment();
+const policyEvidence = Object.freeze({
+  endpointCommitments,
+  expectedVercelProjectId: VERCEL_PROJECT_ID,
+  sensitiveMetadataSource: JSON.stringify(boundSensitiveMetadata()),
+});
 
 test("manual Applicant flag is default-off and exact", () => {
   assert.equal(readManualApplicantLaunchFlag(""), false);
@@ -34,27 +63,39 @@ test("manual Applicant flag is default-off and exact", () => {
 });
 
 test("manual Applicant policy requires dispatch, Vercel and protected mode parity", () => {
-  const source = enabledEnvironment;
+  const source = pulledSensitiveEnvironment;
   assert.deepEqual(resolveManualApplicantLaunchPolicy({
     requested: true,
     productionEnvSource: source,
     protectedMode: "enabled",
+    ...policyEvidence,
   }), { enabled: true });
   assert.throws(() => resolveManualApplicantLaunchPolicy({
     requested: false,
     productionEnvSource: source,
     protectedMode: "enabled",
+    ...policyEvidence,
   }), /dispatch request/u);
   assert.throws(() => resolveManualApplicantLaunchPolicy({
     requested: true,
     productionEnvSource: source,
     protectedMode: "disabled",
+    ...policyEvidence,
   }), /protected mode/u);
+  assert.deepEqual(resolveManualApplicantLaunchPolicy({
+    requested: false,
+    productionEnvSource:
+      "PROGRAMMABLE_MANUAL_APPLICANT_LAUNCH_ENABLED=false\n",
+    protectedMode: "disabled",
+  }), { enabled: false });
 });
 
 test("enabled policy binds only the strict server environment contract", () => {
   assert.deepEqual(
-    Object.keys(assertManualApplicantServerEnvironment(enabledEnvironment)).sort(),
+    Object.keys(assertManualApplicantServerEnvironment(
+      pulledSensitiveEnvironment,
+      policyEvidence,
+    )).sort(),
     [
       "CRON_SECRET",
       "NEXT_PUBLIC_PRIVY_APP_ID",
@@ -65,61 +106,187 @@ test("enabled policy binds only the strict server environment contract", () => {
     ].sort(),
   );
   assert.throws(() => assertManualApplicantServerEnvironment(
-    enabledEnvironment.replace(/^PRIVY_APP_SECRET=.*\n/mu, ""),
-  ), /PRIVY_APP_SECRET/u);
+    pulledSensitiveEnvironment.replace(/^NEXT_PUBLIC_PRIVY_APP_ID=.*\n/mu, ""),
+    policyEvidence,
+  ), /NEXT_PUBLIC_PRIVY_APP_ID/u);
   assert.throws(() => assertManualApplicantServerEnvironment(
-    enabledEnvironment.replace(
-      "https://eth-mainnet.g.alchemy.com/v2/key",
-      "https://example.quiknode.pro/key",
-    ),
-  ), /strict provider/u);
-  assert.throws(() => assertManualApplicantServerEnvironment([
-    "ETHEREUM_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/key",
-    "ETHEREUM_RPC_URL_B=https://example.quiknode.pro/key",
-    "NEXT_PUBLIC_PRIVY_APP_ID=privy-app",
-    "PRIVY_APP_SECRET=privy-secret",
-    "OPS_BLOB_READ_WRITE_TOKEN=blob-token",
-    `CRON_SECRET=${"c".repeat(32)}`,
-  ].join("\n")), /PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL/u);
-
-  const invalidAlchemy = [
-    "http://eth-mainnet.g.alchemy.com/v2/key",
-    "https://foo.alchemy.com/v2/key",
-    "https://eth-mainnet.g.alchemy.com/",
-    "https://eth-mainnet.g.alchemy.com:8443/v2/key",
-    "https://user@eth-mainnet.g.alchemy.com/v2/key",
-    "https://eth-mainnet.g.alchemy.com/v2/key?query=true",
-    " https://eth-mainnet.g.alchemy.com/v2/key",
-    `https://eth-mainnet.g.alchemy.com/${"x".repeat(2_049)}`,
-  ];
-  for (const value of invalidAlchemy) {
+    pulledSensitiveEnvironment.replace(/^PRIVY_APP_SECRET=.*\n/mu, ""),
+    policyEvidence,
+  ), /must occur exactly once/u);
+  for (const name of SENSITIVE_NAMES) {
     assert.throws(() => assertManualApplicantServerEnvironment(
-      replaceEnvironmentValue(
-        enabledEnvironment,
-        "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
-        value,
-      ),
-    ));
+      replaceEnvironmentValue(pulledSensitiveEnvironment, name, "readable"),
+      policyEvidence,
+    ), /custody was downgraded/u);
+  }
+});
+
+test("sensitive production metadata is project-bound and value-free", () => {
+  const raw = rawSensitiveMetadata();
+  const bound = bindVercelSensitiveProductionMetadata({
+    metadata: raw,
+    vercelProjectId: VERCEL_PROJECT_ID,
+  });
+  assert.equal(bound.vercelProjectId, VERCEL_PROJECT_ID);
+  assert.equal(bound.target, "production");
+  assert.equal(bound.envs.length, 5);
+  assert.throws(() => bindVercelSensitiveProductionMetadata({
+    metadata: { envs: [{ key: "CRON_SECRET", value: null }] },
+    vercelProjectId: VERCEL_PROJECT_ID,
+  }), /must not contain values/u);
+  assert.throws(() => bindVercelSensitiveProductionMetadata({
+    metadata: { envs: [{ key: "CRON_SECRET", value: "must-not-exist" }] },
+    vercelProjectId: VERCEL_PROJECT_ID,
+  }), /must not contain values/u);
+  assert.throws(() => bindVercelSensitiveProductionMetadata({
+    metadata: raw,
+    vercelProjectId: "wrong-project",
+  }), /project ID/u);
+});
+
+test("enabled policy accepts only exact sensitive production placeholders", () => {
+  const productionEnvSource = pulledSensitiveEnvironment;
+  const metadata = boundSensitiveMetadata();
+  const evidence = {
+    endpointCommitments,
+    expectedVercelProjectId: VERCEL_PROJECT_ID,
+    sensitiveMetadataSource: JSON.stringify(metadata),
+  };
+  assert.deepEqual(resolveManualApplicantLaunchPolicy({
+    requested: true,
+    productionEnvSource,
+    protectedMode: "enabled",
+    ...evidence,
+  }), { enabled: true });
+
+  for (const name of SENSITIVE_NAMES) {
+    const index = metadata.envs.findIndex((entry) => entry.key === name);
+    const missing = clone(metadata);
+    missing.envs.splice(index, 1);
+    assertMetadataRejected(productionEnvSource, evidence, missing, /exact sensitive/u);
+
+    const duplicate = clone(metadata);
+    duplicate.envs.push(clone(duplicate.envs[index]));
+    assertMetadataRejected(productionEnvSource, evidence, duplicate, /exact sensitive/u);
+
+    for (const mutation of [
+      (entry) => { entry.target = ["preview"]; },
+      (entry) => { entry.target = ["production", "preview"]; },
+      (entry) => { entry.type = "encrypted"; },
+      (entry) => { entry.value = null; },
+      (entry) => { entry.value = "must-not-exist"; },
+    ]) {
+      const changed = clone(metadata);
+      mutation(changed.envs[index]);
+      assertMetadataRejected(
+        productionEnvSource,
+        evidence,
+        changed,
+        /exact sensitive/u,
+      );
+    }
   }
 
-  const invalidQuickNode = [
-    "https://quiknode.pro/key",
-    "https://example.quicknode.com/key",
-    "https://example.quiknode.pro/",
-    "https://example.quiknode.pro:8443/key",
-    "https://user:pass@example.quiknode.pro/key",
-    "https://example.quiknode.pro/key#fragment",
-    "https://example.quiknode.pro/key ",
-  ];
-  for (const value of invalidQuickNode) {
-    assert.throws(() => assertManualApplicantServerEnvironment(
-      replaceEnvironmentValue(
-        enabledEnvironment,
-        "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
-        value,
-      ),
-    ));
-  }
+  assert.throws(() => assertManualApplicantServerEnvironment(
+    productionEnvSource,
+    {
+      endpointCommitments,
+      expectedVercelProjectId: VERCEL_PROJECT_ID,
+    },
+  ), /metadata is invalid/u);
+  assert.throws(() => assertManualApplicantServerEnvironment(
+    productionEnvSource,
+    {
+      ...evidence,
+      expectedVercelProjectId: "prj_other1234",
+    },
+  ), /metadata is invalid/u);
+});
+
+test("enabled policy requires exact independent protected commitments", () => {
+  assert.throws(() => assertManualApplicantServerEnvironment(
+    pulledSensitiveEnvironment,
+    {
+      ...policyEvidence,
+      endpointCommitments: {
+        ...endpointCommitments,
+        alchemy: "invalid",
+      },
+    },
+  ), /Alchemy endpoint commitment is invalid/u);
+  assert.throws(() => assertManualApplicantServerEnvironment(
+    pulledSensitiveEnvironment,
+    {
+      ...policyEvidence,
+      endpointCommitments: {
+        alchemy: endpointCommitments.alchemy,
+        quickNode: endpointCommitments.alchemy,
+      },
+    },
+  ), /not independent/u);
+  assert.throws(() => assertManualApplicantServerEnvironment(
+    pulledSensitiveEnvironment,
+    {
+      ...policyEvidence,
+      endpointCommitments: { alchemy: endpointCommitments.alchemy },
+    },
+  ), /QuickNode endpoint commitment is invalid/u);
+});
+
+test("staged runtime preflight accepts only the typed client error", async () => {
+  let request;
+  const result = await verifyManualApplicantStagedRuntime({
+    targetUrl: "https://candidate.example.vercel.app/",
+    bypassSecret: "b".repeat(32),
+    attempts: 1,
+    retryDelayMs: 0,
+    async fetchImpl(url, init) {
+      request = { url: String(url), init };
+      return new Response(JSON.stringify({
+        schemaVersion: "programmable.manual-router-website-error.v1",
+        code: "invalid_request",
+        message: "invalid_request",
+        retryable: false,
+      }), {
+        status: 400,
+        headers: {
+          "cache-control": "no-store, max-age=0",
+          "content-type": "application/json; charset=utf-8",
+        },
+      });
+    },
+  });
+  assert.deepEqual(result, {
+    status: "verified",
+    route: "/api/custom-launch/manual/submissions",
+    httpStatus: 400,
+    code: "invalid_request",
+  });
+  assert.equal(request.url,
+    "https://candidate.example.vercel.app/api/custom-launch/manual/submissions");
+  assert.equal(request.init.body, "{}");
+  assert.equal(new Headers(request.init.headers).has("authorization"), false);
+
+  await assert.rejects(() => verifyManualApplicantStagedRuntime({
+    targetUrl: "https://candidate.example.vercel.app/",
+    bypassSecret: "b".repeat(32),
+    attempts: 1,
+    retryDelayMs: 0,
+    async fetchImpl() {
+      return new Response(JSON.stringify({
+        schemaVersion: "programmable.manual-router-website-error.v1",
+        code: "storage_unavailable",
+        message: "storage_unavailable",
+        retryable: true,
+      }), {
+        status: 503,
+        headers: {
+          "cache-control": "no-store, max-age=0",
+          "content-type": "application/json; charset=utf-8",
+        },
+      });
+    },
+  }), /preflight failed/u);
 });
 
 test("production workflow keeps manual Applicant policy independent of legacy Custom", async () => {
@@ -131,6 +298,25 @@ test("production workflow keeps manual Applicant policy independent of legacy Cu
   assert.match(workflow, /Resolve manual Applicant launch policy/u);
   assert.match(workflow, /PROGRAMMABLE_MANUAL_APPLICANT_LAUNCH_MODE/u);
   assert.match(workflow, /resolve-manual-applicant-launch-policy\.mjs/u);
+  assert.match(workflow, /bind-vercel-sensitive-production-metadata\.mjs/u);
+  assert.match(workflow, /--manual-sensitive-metadata/u);
+  assert.match(workflow, /--alchemy-endpoint-commitment/u);
+  assert.match(workflow, /--quicknode-endpoint-commitment/u);
+  assert.match(workflow, /verify-manual-applicant-staged-runtime\.mjs/u);
+  assert.ok(
+    workflow.indexOf("Capture sensitive production environment metadata")
+      < workflow.indexOf("Resolve manual Applicant launch policy"),
+  );
+  assert.equal(
+    (workflow.match(/--env PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT=/gu)
+      ?? []).length,
+    1,
+  );
+  assert.equal(
+    (workflow.match(/--env PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT=/gu)
+      ?? []).length,
+    1,
+  );
 });
 
 function replaceEnvironmentValue(source, name, value) {
@@ -138,4 +324,50 @@ function replaceEnvironmentValue(source, name, value) {
     new RegExp(`^${name}=.*$`, "mu"),
     `${name}=${value}`,
   );
+}
+
+function rawSensitiveMetadata() {
+  return {
+    envs: [
+      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
+      "PRIVY_APP_SECRET",
+      "OPS_BLOB_READ_WRITE_TOKEN",
+      "CRON_SECRET",
+    ].map((key) => ({ key, type: "sensitive", target: ["production"] })),
+  };
+}
+
+function boundSensitiveMetadata() {
+  return bindVercelSensitiveProductionMetadata({
+    metadata: rawSensitiveMetadata(),
+    vercelProjectId: VERCEL_PROJECT_ID,
+  });
+}
+
+function sensitivePulledEnvironment() {
+  return [
+    "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+    "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
+    "PRIVY_APP_SECRET",
+    "OPS_BLOB_READ_WRITE_TOKEN",
+    "CRON_SECRET",
+  ].reduce(
+    (source, name) => replaceEnvironmentValue(source, name, '""'),
+    enabledEnvironment,
+  );
+}
+
+function assertMetadataRejected(productionEnvSource, evidence, metadata, match) {
+  assert.throws(() => assertManualApplicantServerEnvironment(
+    productionEnvSource,
+    {
+      ...evidence,
+      sensitiveMetadataSource: JSON.stringify(metadata),
+    },
+  ), match);
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
 }

--- a/scripts/verify-manual-applicant-staged-runtime.mjs
+++ b/scripts/verify-manual-applicant-staged-runtime.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+const ROUTE = "/api/custom-launch/manual/submissions";
+
+export async function verifyManualApplicantStagedRuntime({
+  targetUrl,
+  bypassSecret,
+  fetchImpl = fetch,
+  attempts = 12,
+  retryDelayMs = 5_000,
+}) {
+  const origin = new URL(targetUrl);
+  if (
+    origin.protocol !== "https:"
+    || !origin.hostname.endsWith(".vercel.app")
+    || origin.pathname !== "/"
+    || origin.search !== ""
+    || origin.hash !== ""
+  ) throw new Error("manual Applicant stage target is not an exact Vercel origin");
+  const bypassLength = Buffer.byteLength(bypassSecret ?? "", "utf8");
+  if (
+    typeof bypassSecret !== "string"
+    || bypassLength < 32
+    || bypassLength > 512
+    || /[\r\n]/u.test(bypassSecret)
+  ) throw new Error("manual Applicant stage bypass is unavailable");
+  if (!Number.isSafeInteger(attempts) || attempts < 1 || attempts > 12) {
+    throw new Error("manual Applicant stage attempts are invalid");
+  }
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(new URL(ROUTE, origin), {
+        method: "POST",
+        redirect: "error",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "x-vercel-protection-bypass": bypassSecret,
+        },
+        body: "{}",
+        signal: AbortSignal.timeout(30_000),
+      });
+      const responseText = await response.text();
+      if (Buffer.byteLength(responseText, "utf8") > 4_096) {
+        throw new Error("manual Applicant stage response is oversized");
+      }
+      let body;
+      try {
+        body = JSON.parse(responseText);
+      } catch {
+        throw new Error("manual Applicant stage response is not JSON");
+      }
+      if (
+        response.status !== 400
+        || response.headers.get("content-type")
+          !== "application/json; charset=utf-8"
+        || !response.headers.get("cache-control")?.startsWith("no-store")
+        || body === null
+        || typeof body !== "object"
+        || Array.isArray(body)
+        || Object.keys(body).sort().join("\0")
+          !== "code\0message\0retryable\0schemaVersion"
+        || body.schemaVersion !== "programmable.manual-router-website-error.v1"
+        || body.code !== "invalid_request"
+        || body.message !== "invalid_request"
+        || body.retryable !== false
+      ) throw new Error("manual Applicant staged authority preflight failed");
+      return Object.freeze({
+        status: "verified",
+        route: ROUTE,
+        httpStatus: response.status,
+        code: body.code,
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts && retryDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+    }
+  }
+  throw lastError ?? new Error("manual Applicant staged authority preflight failed");
+}
+
+function argumentsFrom(argv) {
+  if (
+    argv.length !== 2
+    || argv[0] !== "--target-url"
+    || !argv[1]
+    || argv[1].startsWith("--")
+  ) throw new Error("--target-url is required");
+  return Object.freeze({ targetUrl: argv[1] });
+}
+
+async function main(argv) {
+  const args = argumentsFrom(argv);
+  const result = await verifyManualApplicantStagedRuntime({
+    targetUrl: args.targetUrl,
+    bypassSecret: process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "manual Applicant stage failed"}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -60,6 +60,8 @@ import {
 } from "../lib/server/custom-launch/manual-router-state-v1";
 import { canonicalSha256 } from
   "../lib/server/projection-target/hashing";
+import { rpcProviderCommitment } from
+  "../lib/data-pipeline/rpc-provider-commitments";
 
 const WALLET = "0x1111111111111111111111111111111111111111" as const;
 const OTHER_WALLET = "0x2222222222222222222222222222222222222222" as const;
@@ -367,15 +369,20 @@ describe("manual Applicant browser durability", () => {
 });
 
 describe("manual Applicant production configuration", () => {
+  const alchemyUrl = "https://eth-mainnet.g.alchemy.com/v2/test-key";
+  const quickNodeUrl = "https://example.quiknode.pro/test-key";
   const valid = {
     PROGRAMMABLE_MANUAL_APPLICANT_LAUNCH_ENABLED: "true",
-    PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL:
-      "https://eth-mainnet.g.alchemy.com/v2/test-key",
-    PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL:
-      "https://example.quiknode.pro/test-key",
+    PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL: alchemyUrl,
+    PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL: quickNodeUrl,
+    PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT:
+      rpcProviderCommitment("endpoint", alchemyUrl),
+    PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT:
+      rpcProviderCommitment("endpoint", quickNodeUrl),
     NEXT_PUBLIC_PRIVY_APP_ID: "privy-app",
     PRIVY_APP_SECRET: "privy-secret",
     OPS_BLOB_READ_WRITE_TOKEN: "blob-token",
+    CRON_SECRET: "c".repeat(32),
   };
 
   it("returns the typed default-off response before constructing production clients", async () => {
@@ -384,6 +391,7 @@ describe("manual Applicant production configuration", () => {
     vi.stubEnv("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL", "");
     vi.stubEnv("OPS_BLOB_READ_WRITE_TOKEN", "");
     vi.stubEnv("PRIVY_APP_SECRET", "");
+    vi.stubEnv("CRON_SECRET", "");
     try {
       const response = await handleProductionManualRouterWebsiteRouteV1(
         new Request("https://programmable.com/api/custom-launch/manual/submissions", {
@@ -472,6 +480,35 @@ describe("manual Applicant production configuration", () => {
         PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL: quickNodeUrl,
       })).toThrow();
     }
+  });
+
+  it("binds runtime RPCs to protected commitments and validates cron bytes", () => {
+    expect(() => resolveManualRouterStrictRpcConfigurationV1({
+      ...valid,
+      PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT:
+        `0x${"1".repeat(64)}`,
+    })).toThrow("Alchemy endpoint commitment mismatch");
+    expect(() => resolveManualRouterStrictRpcConfigurationV1({
+      ...valid,
+      PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT:
+        valid.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT,
+    })).toThrow("commitments are not independent");
+    expect(() => assertManualRouterProductionConfigurationV1({
+      ...valid,
+      CRON_SECRET: "c".repeat(31),
+    })).toThrow("CRON_SECRET");
+    expect(() => assertManualRouterProductionConfigurationV1({
+      ...valid,
+      CRON_SECRET: "c".repeat(1_025),
+    })).toThrow("CRON_SECRET");
+    expect(() => assertManualRouterProductionConfigurationV1({
+      ...valid,
+      CRON_SECRET: "é".repeat(16),
+    })).not.toThrow();
+    expect(() => assertManualRouterProductionConfigurationV1({
+      ...valid,
+      CRON_SECRET: "é".repeat(513),
+    })).toThrow("CRON_SECRET");
   });
 });
 


### PR DESCRIPTION
## What changed

- bind Vercel's value-free sensitive Production metadata to the exact project before resolving manual Applicant enablement
- reject readable/downgraded custody for all five private runtime variables and validate protected RPC commitments
- validate the real staged runtime, including RPC provider bindings and `CRON_SECRET`, through the exact typed 400 canary

## Why

Vercel intentionally omits values for `sensitive` variables during `vercel pull`. The previous enabled release policy interpreted those empty placeholders as missing configuration and stopped before build. This keeps the variables sensitive while proving metadata custody and exercising the real runtime after deployment.

## Safety

- default-off behavior is unchanged
- no secret values are read into logs or GitHub outputs
- any missing, duplicate, wrong-target, wrong-type, value-bearing, or downgraded sensitive entry fails closed
- INDEXER, data-pipeline, Ops routes, cron schedules, and `vercel.json` are unchanged

## Validation

- manual Applicant policy: 8/8
- manual Applicant foundations: 22/22
- adversarial sensitive metadata matrix: 43/43 rejected as expected
- TypeScript, scoped ESLint, Actionlint, operations source contract, and Next production build: PASS
- Gitleaks 8.30.1 exact commit scan: PASS
- independent frozen-commit review: PASS
