### PR TITLE
Simplify the Custom Hook launch entry

### DIFF
--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -142,7 +142,6 @@ export function LaunchExperience({
   if (!selectedModel) {
     return (
       <LaunchModelPicker
-        customLaunchPublicEnabled={customLaunchPublicEnabled}
         manualApplicantLaunchEnabled={manualApplicantLaunchEnabled}
         manualApplicantButtonRef={manualApplicantButtonRef}
         onChoose={chooseModel}
@@ -181,21 +180,16 @@ export function LaunchExperience({
 }
 
 export function LaunchModelPicker({
-  customLaunchPublicEnabled = false,
   manualApplicantLaunchEnabled = false,
   manualApplicantButtonRef,
   onChoose,
 }: {
-  customLaunchPublicEnabled?: boolean;
   manualApplicantLaunchEnabled?: boolean;
   manualApplicantButtonRef?: RefObject<HTMLButtonElement | null>;
-  onChoose: (model: LaunchModel | "custom" | "manual-applicant") => void;
+  onChoose: (model: LaunchModel | "manual-applicant") => void;
 }) {
   const preloadAvailableForm = () => {
     void loadLaunchForm();
-  };
-  const preloadCustomLaunch = () => {
-    void loadCustomLaunch();
   };
   const preloadManualApplicantLaunch = () => {
     void loadManualApplicantLaunch();
@@ -255,7 +249,7 @@ export function LaunchModelPicker({
                 className={`launch-model-card-heading ${launchExperience.modelHeading}`}
               >
                 <strong id="launch-model-manual-applicant-title">
-                  Approved launch
+                  Custom Hook
                 </strong>
                 <small data-status="ready">Ready</small>
               </span>
@@ -269,7 +263,7 @@ export function LaunchModelPicker({
               <span
                 className={`launch-model-action ${launchExperience.modelAction}`}
               >
-                Open applicant launch
+                Open Custom Hook launch
                 <ArrowRight aria-hidden="true" size={16} />
               </span>
             </span>
@@ -337,86 +331,6 @@ export function LaunchModelPicker({
                 className={`launch-model-action ${launchExperience.modelAction}`}
               >
                 Create a Classic coin
-                <ArrowRight aria-hidden="true" size={16} />
-              </span>
-            ) : null}
-          </span>
-        </button>
-
-        <button
-          className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
-          data-launch-model-option="custom"
-          data-launch-model-available={customLaunchPublicEnabled}
-          data-launch-model-launchable={customLaunchPublicEnabled}
-          type="button"
-          disabled={!customLaunchPublicEnabled}
-          aria-labelledby="launch-model-custom-title"
-          aria-describedby="launch-model-custom-description"
-          onPointerEnter={customLaunchPublicEnabled ? preloadCustomLaunch : undefined}
-          onFocus={customLaunchPublicEnabled ? preloadCustomLaunch : undefined}
-          onClick={() => onChoose("custom")}
-        >
-          <span
-            className={`launch-model-art ${launchExperience.modelArt} ${launchExperience.customArt}`}
-            aria-hidden="true"
-          >
-            <Image
-              className={launchExperience.artImage}
-              src="/brand/create/custom-galaxy-v3.webp"
-              alt=""
-              fill
-              loading="lazy"
-              fetchPriority="low"
-              sizes="(max-width: 760px) calc(100vw - 32px), (max-width: 1280px) calc((100vw - 96px) / 4), 260px"
-            />
-            <Image
-              className={`${launchExperience.classicLogo} ${launchExperience.customLogo}`}
-              src="/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"
-              alt=""
-              width={1536}
-              height={1536}
-              sizes="128px"
-              loading="lazy"
-              fetchPriority="low"
-            />
-            <span className={launchExperience.customSparkles}>
-              <span />
-              <span />
-              <span />
-              <span />
-              <span />
-              <span />
-              <span />
-              <span />
-              <span />
-              <span />
-            </span>
-          </span>
-
-          <span
-            className={`launch-model-card-body ${launchExperience.modelBody}`}
-          >
-            <span
-              className={`launch-model-card-heading ${launchExperience.modelHeading}`}
-            >
-              <strong id="launch-model-custom-title">Custom Hook</strong>
-              {!customLaunchPublicEnabled ? (
-                <small data-status="pending">Coming soon</small>
-              ) : null}
-            </span>
-            <span
-              className={`launch-model-description ${launchExperience.modelDescription}`}
-              id="launch-model-custom-description"
-            >
-              Review the framework for token-specific Uniswap v4 hook logic,
-              including permissions, fee behavior, liquidity rules, and the
-              evidence required for release.
-            </span>
-            {customLaunchPublicEnabled ? (
-              <span
-                className={`launch-model-action ${launchExperience.modelAction}`}
-              >
-                Build or resume
                 <ArrowRight aria-hidden="true" size={16} />
               </span>
             ) : null}

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -158,10 +158,10 @@ describe("unreleased launch model gating", () => {
     ).toEqual([-1, -1, 0, -1, -1, -1]);
   });
 
-  it("opens the gated Custom launcher and shows upcoming partner models", () => {
+  it("opens the approved Custom Hook launcher without the legacy Custom card", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
-        customLaunchPublicEnabled: true,
+        manualApplicantLaunchEnabled: true,
         onChoose: () => undefined,
       }),
     );
@@ -177,18 +177,19 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain(
       'id="launch-model-classic-title">Classic</strong>',
     );
-    expect(html).toContain('data-launch-model-option="custom"');
+    expect(html).toContain('data-launch-model-option="manual-applicant"');
     const customCard = html.match(
-      /<button[^>]*data-launch-model-option="custom"[^>]*>/,
+      /<button[^>]*data-launch-model-option="manual-applicant"[^>]*>/,
     )?.[0];
     expect(customCard).toContain('data-launch-model-launchable="true"');
     expect(html).toContain(
-      'id="launch-model-custom-title">Custom Hook</strong>',
+      'id="launch-model-manual-applicant-title">Custom Hook</strong>',
     );
     expect(html).toContain("Create a Classic coin");
-    expect(html).toContain("Build or resume");
-    expect(html).not.toContain("Create a Custom Hook");
-    expect(html).toContain("evidence required for release");
+    expect(html).toContain("Open Custom Hook launch");
+    expect(html).not.toContain('data-launch-model-option="custom"');
+    expect(html).not.toContain("Build or resume");
+    expect(html).not.toContain("Coming soon");
     expect(html).toContain('data-launch-model-option="aeon"');
     const aeonCard = html.match(
       /<a[^>]*href="https:\/\/x\.com\/aeonframework"[^>]*>/,
@@ -234,18 +235,15 @@ describe("unreleased launch model gating", () => {
     expect(html).not.toContain("Liquidity Growth");
   });
 
-  it("fails the Custom Hook launcher closed until the server gate is enabled", () => {
+  it("does not render the removed legacy Custom Hook card", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
         onChoose: () => undefined,
       }),
     );
-    const customCard = html.match(
-      /<button[^>]*data-launch-model-option="custom"[^>]*>/,
-    )?.[0];
-    expect(customCard).toContain('data-launch-model-launchable="false"');
-    expect(customCard).toContain("disabled");
-    expect(html).toContain("Coming soon");
+    expect(html).not.toContain('data-launch-model-option="custom"');
+    expect(html).not.toContain('id="launch-model-custom-title"');
+    expect(html).not.toContain("Coming soon");
     expect(html).not.toContain("Build or resume");
   });
 

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -50,14 +50,14 @@ describe("launch model artwork", () => {
     expect(source).toContain(
       'aria-describedby="launch-model-classic-description"',
     );
-    expect(source).toContain('onClick={() => onChoose("custom")}');
-    expect(source).toContain("disabled={!customLaunchPublicEnabled}");
+    expect(source).toContain('onClick={() => onChoose("manual-applicant")}');
     expect(source).toContain(
-      'aria-labelledby="launch-model-custom-title"',
+      'aria-labelledby="launch-model-manual-applicant-title"',
     );
     expect(source).toContain(
-      'aria-describedby="launch-model-custom-description"',
+      'aria-describedby="launch-model-manual-applicant-description"',
     );
+    expect(source).not.toContain('data-launch-model-option="custom"');
     expect(source).toContain('href="https://x.com/aeonframework"');
     expect(source).toContain(
       'aria-labelledby="launch-model-aeon-title"',
@@ -81,27 +81,19 @@ describe("launch model artwork", () => {
   });
 
   it("keeps decorative movement subtle and compositor-safe", () => {
-    const source = read("components/launch-entry.tsx");
     const css = read("components/launch-experience.module.css");
-    const sparkleMarkup = source.match(
-      /<span className=\{launchExperience\.customSparkles\}>[\s\S]*?<\/span>/,
-    )?.[0];
     const classicDrift = css.match(
       /@keyframes classic-botanical-drift[\s\S]*?(?=\n}\n\n@media)/,
     )?.[0];
 
     expect(css).toContain("@media (prefers-reduced-motion: no-preference)");
-    expect(sparkleMarkup?.match(/<span \/>/g)).toHaveLength(10);
     expect(css).toContain(
       "animation: classic-botanical-drift 12s steps(1, end) infinite",
     );
     expect(css).toContain("translate3d(0.06%, -0.03%, 0) scale(1.0012)");
     expect(classicDrift).not.toContain("filter:");
-    expect(css).toContain(
-      "animation: custom-star-sparkle 6.4s cubic-bezier(0.2, 0, 0, 1) infinite",
-    );
     expect(css).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.classicArt \.artImage,[\s\S]*?\.customSparkles > span\s*\{\s*animation:\s*none;/,
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.classicArt \.artImage[\s\S]*?animation:\s*none;/,
     );
   });
 });

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -993,17 +993,20 @@ describe("manual Applicant browser contract", () => {
 
   it("adds the Applicant entry only behind its separate flag and exposes no upload fallback", () => {
     const disabled = renderToStaticMarkup(createElement(LaunchModelPicker, {
-      customLaunchPublicEnabled: false,
       manualApplicantLaunchEnabled: false,
       onChoose: () => undefined,
     }));
     const enabled = renderToStaticMarkup(createElement(LaunchModelPicker, {
-      customLaunchPublicEnabled: false,
       manualApplicantLaunchEnabled: true,
       onChoose: () => undefined,
     }));
     expect(disabled).not.toContain('data-launch-model-option="manual-applicant"');
     expect(enabled).toContain('data-launch-model-option="manual-applicant"');
+    expect(enabled).toContain(
+      'id="launch-model-manual-applicant-title">Custom Hook</strong>',
+    );
+    expect(enabled).toContain("Open Custom Hook launch");
+    expect(enabled).not.toContain('data-launch-model-option="custom"');
 
     const component = readFileSync(
       join(process.cwd(), "components/manual-applicant-launch.tsx"),


### PR DESCRIPTION
## What changed

- Rename the approved Applicant launch card to `Custom Hook`
- Remove the obsolete disabled Custom Hook card from the Create picker
- Keep the approved Hookbuilder submission flow as the single Custom Hook entry

## Why

The two cards described the same product path and made the active approved-launch flow look separate from Custom Hooks.

## Validation

- Focused Vitest: 49/49 passing
- TypeScript: passing
- Scoped ESLint: 0 errors
- Production build: passing
- Rendered picker QA: exactly one Custom Hook card, legacy option absent, click/back flow passing, no horizontal overflow