### PR TITLE
fix: normalize manual applicant authentication failures

### DIFF
--- a/lib/server/custom-launch/manual-router-auth-v1.ts
+++ b/lib/server/custom-launch/manual-router-auth-v1.ts
@@ -100,7 +100,12 @@ export function createManualRouterApplicantAuthenticatorFromBoundaryV1(
           principal.privyUserId,
         );
       } catch (error) {
-        if (error instanceof GitHubPrincipalAuthenticationErrorV1) throw error;
+        if (error instanceof GitHubPrincipalAuthenticationErrorV1) {
+          throw new ManualRouterApplicantAuthenticationErrorV1(
+            error.status,
+            "applicant_authentication_required",
+          );
+        }
         throw new ManualRouterApplicantAuthenticationErrorV1(
           401,
           "applicant_authentication_required",

--- a/scripts/test/manual-applicant-launch-policy.test.mjs
+++ b/scripts/test/manual-applicant-launch-policy.test.mjs
@@ -233,22 +233,26 @@ test("enabled policy requires exact independent protected commitments", () => {
   ), /QuickNode endpoint commitment is invalid/u);
 });
 
-test("staged runtime preflight accepts only the typed client error", async () => {
-  let request;
+test("staged runtime preflight requires typed parse and authentication errors", async () => {
+  const requests = [];
   const result = await verifyManualApplicantStagedRuntime({
     targetUrl: "https://candidate.example.vercel.app/",
     bypassSecret: "b".repeat(32),
     attempts: 1,
     retryDelayMs: 0,
     async fetchImpl(url, init) {
-      request = { url: String(url), init };
+      requests.push({ url: String(url), init });
+      const authentication = init.body !== "{}";
+      const code = authentication
+        ? "applicant_authentication_required"
+        : "invalid_request";
       return new Response(JSON.stringify({
         schemaVersion: "programmable.manual-router-website-error.v1",
-        code: "invalid_request",
-        message: "invalid_request",
+        code,
+        message: code,
         retryable: false,
       }), {
-        status: 400,
+        status: authentication ? 401 : 400,
         headers: {
           "cache-control": "no-store, max-age=0",
           "content-type": "application/json; charset=utf-8",
@@ -261,11 +265,20 @@ test("staged runtime preflight accepts only the typed client error", async () =>
     route: "/api/custom-launch/manual/submissions",
     httpStatus: 400,
     code: "invalid_request",
+    authenticationHttpStatus: 401,
+    authenticationCode: "applicant_authentication_required",
   });
-  assert.equal(request.url,
-    "https://candidate.example.vercel.app/api/custom-launch/manual/submissions");
-  assert.equal(request.init.body, "{}");
-  assert.equal(new Headers(request.init.headers).has("authorization"), false);
+  assert.equal(requests.length, 2);
+  for (const request of requests) {
+    assert.equal(request.url,
+      "https://candidate.example.vercel.app/api/custom-launch/manual/submissions");
+    assert.equal(new Headers(request.init.headers).has("authorization"), false);
+  }
+  assert.equal(requests[0].init.body, "{}");
+  assert.deepEqual(JSON.parse(requests[1].init.body), {
+    schemaVersion: "programmable.manual-router-applicant-list-request.v1",
+    launchWallet: "0x1111111111111111111111111111111111111111",
+  });
 
   await assert.rejects(() => verifyManualApplicantStagedRuntime({
     targetUrl: "https://candidate.example.vercel.app/",

--- a/scripts/verify-manual-applicant-staged-runtime.mjs
+++ b/scripts/verify-manual-applicant-staged-runtime.mjs
@@ -3,6 +3,10 @@
 import { pathToFileURL } from "node:url";
 
 const ROUTE = "/api/custom-launch/manual/submissions";
+const AUTHENTICATION_PROBE = Object.freeze({
+  schemaVersion: "programmable.manual-router-applicant-list-request.v1",
+  launchWallet: "0x1111111111111111111111111111111111111111",
+});
 
 export async function verifyManualApplicantStagedRuntime({
   targetUrl,
@@ -32,47 +36,26 @@ export async function verifyManualApplicantStagedRuntime({
   let lastError;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      const response = await fetchImpl(new URL(ROUTE, origin), {
-        method: "POST",
-        redirect: "error",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "x-vercel-protection-bypass": bypassSecret,
-        },
-        body: "{}",
-        signal: AbortSignal.timeout(30_000),
-      });
-      const responseText = await response.text();
-      if (Buffer.byteLength(responseText, "utf8") > 4_096) {
-        throw new Error("manual Applicant stage response is oversized");
-      }
-      let body;
-      try {
-        body = JSON.parse(responseText);
-      } catch {
-        throw new Error("manual Applicant stage response is not JSON");
-      }
-      if (
-        response.status !== 400
-        || response.headers.get("content-type")
-          !== "application/json; charset=utf-8"
-        || !response.headers.get("cache-control")?.startsWith("no-store")
-        || body === null
-        || typeof body !== "object"
-        || Array.isArray(body)
-        || Object.keys(body).sort().join("\0")
-          !== "code\0message\0retryable\0schemaVersion"
-        || body.schemaVersion !== "programmable.manual-router-website-error.v1"
-        || body.code !== "invalid_request"
-        || body.message !== "invalid_request"
-        || body.retryable !== false
-      ) throw new Error("manual Applicant staged authority preflight failed");
+      const invalid = await postProbe(fetchImpl, origin, bypassSecret, "{}");
+      assertTypedError(invalid, 400, "invalid_request");
+      const unauthenticated = await postProbe(
+        fetchImpl,
+        origin,
+        bypassSecret,
+        JSON.stringify(AUTHENTICATION_PROBE),
+      );
+      assertTypedError(
+        unauthenticated,
+        401,
+        "applicant_authentication_required",
+      );
       return Object.freeze({
         status: "verified",
         route: ROUTE,
-        httpStatus: response.status,
-        code: body.code,
+        httpStatus: invalid.response.status,
+        code: invalid.body.code,
+        authenticationHttpStatus: unauthenticated.response.status,
+        authenticationCode: unauthenticated.body.code,
       });
     } catch (error) {
       lastError = error;
@@ -82,6 +65,49 @@ export async function verifyManualApplicantStagedRuntime({
     }
   }
   throw lastError ?? new Error("manual Applicant staged authority preflight failed");
+}
+
+async function postProbe(fetchImpl, origin, bypassSecret, body) {
+  const response = await fetchImpl(new URL(ROUTE, origin), {
+    method: "POST",
+    redirect: "error",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "x-vercel-protection-bypass": bypassSecret,
+    },
+    body,
+    signal: AbortSignal.timeout(30_000),
+  });
+  const responseText = await response.text();
+  if (Buffer.byteLength(responseText, "utf8") > 4_096) {
+    throw new Error("manual Applicant stage response is oversized");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(responseText);
+  } catch {
+    throw new Error("manual Applicant stage response is not JSON");
+  }
+  return Object.freeze({ response, body: parsed });
+}
+
+function assertTypedError(observed, status, code) {
+  const { response, body } = observed;
+  if (
+    response.status !== status
+    || response.headers.get("content-type") !== "application/json; charset=utf-8"
+    || !response.headers.get("cache-control")?.startsWith("no-store")
+    || body === null
+    || typeof body !== "object"
+    || Array.isArray(body)
+    || Object.keys(body).sort().join("\0")
+      !== "code\0message\0retryable\0schemaVersion"
+    || body.schemaVersion !== "programmable.manual-router-website-error.v1"
+    || body.code !== code
+    || body.message !== code
+    || body.retryable !== false
+  ) throw new Error("manual Applicant staged authority preflight failed");
 }
 
 function argumentsFrom(argv) {

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -40,7 +40,10 @@ import {
   isManualRouterApplicantLaunchEnabledV1,
   resolveManualRouterStrictRpcConfigurationV1,
 } from "../lib/server/custom-launch/manual-router-config-v1";
-import { handleProductionManualRouterWebsiteRouteV1 } from
+import {
+  handleManualRouterWebsiteRouteV1,
+  handleProductionManualRouterWebsiteRouteV1,
+} from
   "../lib/server/custom-launch/manual-router-routes-v1";
 import {
   assertManualRouterUsableSendWindowV1,
@@ -60,6 +63,8 @@ import {
 } from "../lib/server/custom-launch/manual-router-state-v1";
 import { canonicalSha256 } from
   "../lib/server/projection-target/hashing";
+import { GitHubPrincipalAuthenticationErrorV1 } from
+  "../lib/server/projection-target/github-entitlement";
 import { rpcProviderCommitment } from
   "../lib/data-pipeline/rpc-provider-commitments";
 
@@ -555,6 +560,56 @@ describe("manual Applicant Privy identity", () => {
       new Request("https://programmable.market/api"),
       WALLET,
     )).rejects.toThrow("github_subject_mismatch");
+  });
+
+  it("returns an Applicant authentication error instead of a storage failure", async () => {
+    vi.stubEnv("PROGRAMMABLE_MANUAL_APPLICANT_LAUNCH_ENABLED", "true");
+    const authenticator = createManualRouterApplicantAuthenticatorFromBoundaryV1({
+      githubAuthenticator: {
+        async authenticate() {
+          throw new GitHubPrincipalAuthenticationErrorV1(401, "session_required");
+        },
+      },
+      currentUserBoundary: {
+        async getCurrentUser() {
+          throw new TypeError("current user must not be read");
+        },
+      },
+    });
+    try {
+      const response = await handleManualRouterWebsiteRouteV1(
+        new Request(
+          "https://programmable.market/api/custom-launch/manual/submissions",
+          {
+            method: "POST",
+            headers: {
+              accept: "application/json",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              schemaVersion:
+                "programmable.manual-router-applicant-list-request.v1",
+              launchWallet: WALLET,
+            }),
+          },
+        ),
+        "submissions",
+        {
+          authenticator,
+          service: {} as never,
+          finalityService: {} as never,
+        },
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toMatchObject({
+        schemaVersion: "programmable.manual-router-website-error.v1",
+        code: "applicant_authentication_required",
+        retryable: false,
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });
 


### PR DESCRIPTION
Closes the live manual Applicant lane failure mode where a schema-valid unauthenticated request fell through as `503 storage_unavailable`.\n\n- maps the shared GitHub principal authentication error into the manual-router typed 401/403 envelope\n- adds a schema-valid credential-free stage regression requiring exact 401/no-store behavior\n\nFocused gates: foundations 23/23, policy 8/8, typecheck and production build green.