### PR TITLE
Fix manual Applicant staged runtime canary

### DIFF
--- a/scripts/test/manual-applicant-launch-policy.test.mjs
+++ b/scripts/test/manual-applicant-launch-policy.test.mjs
@@ -245,7 +245,7 @@ test("staged runtime preflight requires typed parse, authentication, and accepta
       const acceptance = String(url).endsWith("/route-acceptance");
       const authentication = !acceptance && init.body !== "{}";
       const code = acceptance
-        ? "session_required"
+        ? "applicant_authentication_required"
         : authentication
           ? "applicant_authentication_required"
           : "invalid_request";
@@ -271,7 +271,7 @@ test("staged runtime preflight requires typed parse, authentication, and accepta
     authenticationHttpStatus: 401,
     authenticationCode: "applicant_authentication_required",
     acceptanceHttpStatus: 401,
-    acceptanceCode: "session_required",
+    acceptanceCode: "applicant_authentication_required",
   });
   assert.equal(requests.length, 3);
   assert.equal(requests[0].url,

--- a/scripts/verify-manual-applicant-staged-runtime.mjs
+++ b/scripts/verify-manual-applicant-staged-runtime.mjs
@@ -23,7 +23,7 @@ const CHECKS = Object.freeze([
   Object.freeze({
     route: "/api/custom-launch/manual/route-acceptance",
     status: 401,
-    code: "session_required",
+    code: "applicant_authentication_required",
     body: "{}",
   }),
 ]);


### PR DESCRIPTION
Align the staged route-acceptance probe with the production authenticator contract. The runtime intentionally maps unauthenticated GitHub sessions to `applicant_authentication_required`; the canary incorrectly expected `session_required`, causing the otherwise READY c5b597 deployment to fail its post-build gate.

Validation:
- `node --test scripts/test/manual-applicant-launch-policy.test.mjs` (8/8)
- scoped ESLint
- `git diff --check`

No runtime, API, UI, indexer, contract, or environment behavior changes.