### PR TITLE
Add fail-closed Router V2 Website authority port

### DIFF
--- a/lib/server/custom-launch/manual-router-authority-v1.ts
+++ b/lib/server/custom-launch/manual-router-authority-v1.ts
@@ -32,6 +32,10 @@ import {
   type ManualRouterVerifiedPublishV1,
   type ManualRouterWebsiteAuthorityV1,
 } from "@/lib/server/custom-launch/manual-router-service-v1";
+import {
+  createManualRouterWebsiteAuthorityDispatchV2,
+  createProductionManualRouterWebsiteAuthorityV2,
+} from "@/lib/server/custom-launch/manual-router-authority-v2";
 
 export type ProductionManualRouterAuthorityV1 = Readonly<{
   composition: PortableManualRouterCompositionV1;
@@ -94,7 +98,7 @@ ProductionManualRouterAuthorityV1 {
     // secret. The Applicant identity path is separately bound through Privy.
     githubReadToken: null,
   });
-  const website: ManualRouterWebsiteAuthorityV1 = Object.freeze({
+  const legacyWebsite: ManualRouterWebsiteAuthorityV1 = Object.freeze({
     assertCompleteSignedArtifact(raw: unknown) {
       const artifact = assertPortableManualRouterCompleteSignedArtifactV1(raw);
       return artifact as unknown as ManualRouterCompleteSignedArtifactViewV1;
@@ -153,6 +157,10 @@ ProductionManualRouterAuthorityV1 {
         ...input,
       });
     },
+  });
+  const website = createManualRouterWebsiteAuthorityDispatchV2({
+    v1: legacyWebsite,
+    loadV2: createProductionManualRouterWebsiteAuthorityV2,
   });
   const finality = new RouterLaunchFinalityVerifierV1({ rpc: composition.rpc });
   const finalityAuthority = createProductionManualRouterFinalityAuthorityV1({

--- a/lib/server/custom-launch/manual-router-authority-v2.ts
+++ b/lib/server/custom-launch/manual-router-authority-v2.ts
@@ -2,6 +2,10 @@ import "server-only";
 
 import { getAddress, isAddress } from "viem";
 
+import * as portableManualRouterAuthorityV2 from
+  // @ts-expect-error -- generated, hash-bound ESM has no handwritten types.
+  "@/lib/vendor/manual-router-authority-v2/manual-router-portable.v2.mjs";
+
 import {
   getActiveManualRouterProductionBindingV2,
   type ActiveManualRouterProductionBindingV2,
@@ -14,6 +18,116 @@ import type {
 } from "@/lib/server/custom-launch/manual-router-artifact-v2";
 import { assertManualRouterApplicantSubjectV1 } from
   "@/lib/server/custom-launch/manual-router-state-v1";
+import type {
+  ManualRouterWebsiteAuthorityV1,
+} from "@/lib/server/custom-launch/manual-router-service-v1";
+
+export const PORTABLE_MANUAL_ROUTER_WEBSITE_AUTHORITY_FACTORY_V2 =
+  "createPortableManualRouterWebsiteAuthorityV2" as const;
+
+export type ManualRouterWebsiteAuthorityV2 = Omit<
+  ManualRouterWebsiteAuthorityV1,
+  "assertV2AcceptanceCurrent" | "assertV2ReadyCurrentness"
+> & Readonly<{
+  assertV2AcceptanceCurrent: NonNullable<
+    ManualRouterWebsiteAuthorityV1["assertV2AcceptanceCurrent"]
+  >;
+  assertV2ReadyCurrentness: NonNullable<
+    ManualRouterWebsiteAuthorityV1["assertV2ReadyCurrentness"]
+  >;
+}>;
+
+export type PortableManualRouterWebsiteAuthorityFactoryV2 = (
+  input: Readonly<{
+    binding: ActiveManualRouterProductionBindingV2;
+    env: Readonly<Record<string, string | undefined>>;
+    fetch: typeof fetch;
+  }>,
+) => ManualRouterWebsiteAuthorityV2;
+
+/**
+ * Loads the one portable Authority-owned Website facade. The frozen b180aca
+ * bundle intentionally does not export this surface, so production remains
+ * fail-closed until a later immutable Authority release adds it and the
+ * Website vendor/binding hashes are rebound together.
+ */
+export function createProductionManualRouterWebsiteAuthorityV2():
+ManualRouterWebsiteAuthorityV2 {
+  const binding = getActiveManualRouterProductionBindingV2();
+  const factory = portableWebsiteAuthorityFactoryV2(
+    portableManualRouterAuthorityV2,
+  );
+  return assertManualRouterWebsiteAuthorityV2(factory({
+    binding,
+    env: process.env,
+    fetch,
+  }));
+}
+
+/** Exact schema dispatch with no V1/V2 fallback. */
+export function createManualRouterWebsiteAuthorityDispatchV2(input: Readonly<{
+  v1: ManualRouterWebsiteAuthorityV1;
+  loadV2: () => ManualRouterWebsiteAuthorityV2;
+}>): ManualRouterWebsiteAuthorityV1 {
+  if (
+    input.v1 === null
+    || typeof input.v1 !== "object"
+    || typeof input.loadV2 !== "function"
+  ) throw new TypeError("manual Router authority dispatch is invalid");
+  let v2: ManualRouterWebsiteAuthorityV2 | null = null;
+  const loadV2 = (): ManualRouterWebsiteAuthorityV2 => {
+    v2 ??= input.loadV2();
+    return v2;
+  };
+  return Object.freeze({
+    assertCompleteSignedArtifact(raw: unknown) {
+      return artifactVersionV2(raw, "manual Router signed artifact")
+          === "programmable.manual-router-complete-signed-artifact.v2"
+        ? loadV2().assertCompleteSignedArtifact(raw)
+        : input.v1.assertCompleteSignedArtifact(raw);
+    },
+    async verifySignedPublish(request: Parameters<
+      ManualRouterWebsiteAuthorityV1["verifySignedPublish"]
+    >[0]) {
+      return publishArtifactVersionV2(request.request)
+          === "programmable.manual-router-complete-signed-artifact.v2"
+        ? await loadV2().verifySignedPublish(request)
+        : await input.v1.verifySignedPublish(request);
+    },
+    async readChainClock() {
+      // Chain time is route-independent. Keeping the existing production
+      // source preserves V1 behavior; the V2 facade must independently bind
+      // its own dual-RPC observations during currentness/preflight.
+      return await input.v1.readChainClock();
+    },
+    async assertV2AcceptanceCurrent(value: Parameters<NonNullable<
+      ManualRouterWebsiteAuthorityV1["assertV2AcceptanceCurrent"]
+    >>[0]) {
+      return await loadV2().assertV2AcceptanceCurrent(value);
+    },
+    async assertV2ReadyCurrentness(value: Parameters<NonNullable<
+      ManualRouterWebsiteAuthorityV1["assertV2ReadyCurrentness"]
+    >>[0]) {
+      return await loadV2().assertV2ReadyCurrentness(value);
+    },
+    async observeExactTransaction(value: Parameters<
+      ManualRouterWebsiteAuthorityV1["observeExactTransaction"]
+    >[0]) {
+      return artifactVersionV2(value.artifact, "manual Router transaction artifact")
+          === "programmable.manual-router-complete-signed-artifact.v2"
+        ? await loadV2().observeExactTransaction(value)
+        : await input.v1.observeExactTransaction(value);
+    },
+    async resolveReissueState(value: Parameters<
+      ManualRouterWebsiteAuthorityV1["resolveReissueState"]
+    >[0]) {
+      return reissueArtifactVersionV2(value.request)
+          === "programmable.manual-router-complete-signed-artifact.v2"
+        ? await loadV2().resolveReissueState(value)
+        : await input.v1.resolveReissueState(value);
+    },
+  });
+}
 
 /**
  * This is the Website's final fail-closed boundary after the portable
@@ -21,12 +135,10 @@ import { assertManualRouterApplicantSubjectV1 } from
  * absent from the production binding.
  */
 export function assertProductionManualRouterCompleteSignedArtifactV2(
-  _raw: unknown,
+  raw: unknown,
 ): ManualRouterCompleteSignedArtifactViewV2 {
-  getActiveManualRouterProductionBindingV2();
-  throw new TypeError(
-    "portable manual Router V2 Authority vendor is not installed",
-  );
+  return createProductionManualRouterWebsiteAuthorityV2()
+    .assertCompleteSignedArtifact(raw) as ManualRouterCompleteSignedArtifactViewV2;
 }
 
 /**
@@ -319,6 +431,85 @@ function exactObject(
     || strings.length !== expected.length
     || strings.some((key, index) => key !== expected[index])
   ) throw invalid(`${label} contains unexpected fields`);
+  return raw as Record<string, unknown>;
+}
+
+function portableWebsiteAuthorityFactoryV2(
+  namespace: object,
+): PortableManualRouterWebsiteAuthorityFactoryV2 {
+  const factory = (namespace as Record<string, unknown>)[
+    PORTABLE_MANUAL_ROUTER_WEBSITE_AUTHORITY_FACTORY_V2
+  ];
+  if (typeof factory !== "function") {
+    throw new TypeError(
+      "portable manual Router V2 Website Authority facade is not installed",
+    );
+  }
+  return factory as PortableManualRouterWebsiteAuthorityFactoryV2;
+}
+
+function assertManualRouterWebsiteAuthorityV2(
+  raw: unknown,
+): ManualRouterWebsiteAuthorityV2 {
+  if (
+    raw === null
+    || typeof raw !== "object"
+    || Array.isArray(raw)
+    || !Object.isFrozen(raw)
+  ) {
+    throw invalid("portable manual Router V2 Website Authority is invalid");
+  }
+  const authority = raw as Record<string, unknown>;
+  for (const method of [
+    "assertCompleteSignedArtifact", "assertV2AcceptanceCurrent",
+    "assertV2ReadyCurrentness", "observeExactTransaction", "readChainClock",
+    "resolveReissueState", "verifySignedPublish",
+  ] as const) {
+    if (typeof authority[method] !== "function") {
+      throw invalid("portable manual Router V2 Website Authority is incomplete");
+    }
+  }
+  return raw as ManualRouterWebsiteAuthorityV2;
+}
+
+function publishArtifactVersionV2(raw: unknown): ManualRouterArtifactVersionV2 {
+  const request = recordV2(raw, "manual Router signed publish request");
+  return artifactVersionV2(
+    request.signedArtifact,
+    "manual Router signed publish artifact",
+  );
+}
+
+function reissueArtifactVersionV2(raw: unknown): ManualRouterArtifactVersionV2 {
+  const request = recordV2(raw, "manual Router reissue request");
+  return artifactVersionV2(
+    request.previousSignedArtifact,
+    "manual Router previous signed artifact",
+  );
+}
+
+type ManualRouterArtifactVersionV2 =
+  | "programmable.manual-router-complete-signed-artifact.v1"
+  | "programmable.manual-router-complete-signed-artifact.v2";
+
+function artifactVersionV2(
+  raw: unknown,
+  label: string,
+): ManualRouterArtifactVersionV2 {
+  const artifact = recordV2(raw, label);
+  if (
+    artifact.schemaVersion
+      !== "programmable.manual-router-complete-signed-artifact.v1"
+    && artifact.schemaVersion
+      !== "programmable.manual-router-complete-signed-artifact.v2"
+  ) throw invalid(`${label} schema is unsupported`);
+  return artifact.schemaVersion;
+}
+
+function recordV2(raw: unknown, label: string): Record<string, unknown> {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid(`${label} is invalid`);
+  }
   return raw as Record<string, unknown>;
 }
 

--- a/tests/manual-router-v2-authority-dispatch.test.ts
+++ b/tests/manual-router-v2-authority-dispatch.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createManualRouterWebsiteAuthorityDispatchV2,
+  type ManualRouterWebsiteAuthorityV2,
+} from "../lib/server/custom-launch/manual-router-authority-v2";
+import type {
+  ManualRouterWebsiteAuthorityV1,
+} from "../lib/server/custom-launch/manual-router-service-v1";
+
+const V1_ARTIFACT = Object.freeze({
+  schemaVersion: "programmable.manual-router-complete-signed-artifact.v1",
+});
+const V2_ARTIFACT = Object.freeze({
+  schemaVersion: "programmable.manual-router-complete-signed-artifact.v2",
+});
+
+describe("manual Router production authority version dispatch", () => {
+  it("keeps every V1 operation on the existing authority", async () => {
+    const { authority: v1, calls: v1Calls } = fakeAuthority("v1");
+    const { authority: v2, calls: v2Calls } = fakeAuthority("v2");
+    const loadV2 = vi.fn(() => v2 as ManualRouterWebsiteAuthorityV2);
+    const dispatch = createManualRouterWebsiteAuthorityDispatchV2({
+      v1,
+      loadV2,
+    });
+
+    expect(dispatch.assertCompleteSignedArtifact(V1_ARTIFACT))
+      .toBe(V1_ARTIFACT);
+    await dispatch.verifySignedPublish(verificationInput(V1_ARTIFACT));
+    await dispatch.observeExactTransaction({
+      artifact: V1_ARTIFACT,
+    } as never);
+    await dispatch.resolveReissueState({
+      request: { previousSignedArtifact: V1_ARTIFACT },
+    } as never);
+    await dispatch.readChainClock();
+
+    expect(v1Calls).toEqual([
+      "assert", "publish", "transaction", "reissue", "clock",
+    ]);
+    expect(v2Calls).toEqual([]);
+    expect(loadV2).not.toHaveBeenCalled();
+  });
+
+  it("routes every V2 operation to the portable facade without V1 fallback", async () => {
+    const { authority: v1, calls: v1Calls } = fakeAuthority("v1");
+    const { authority: v2, calls: v2Calls } = fakeAuthority("v2");
+    const loadV2 = vi.fn(() => v2 as ManualRouterWebsiteAuthorityV2);
+    const dispatch = createManualRouterWebsiteAuthorityDispatchV2({
+      v1,
+      loadV2,
+    });
+
+    expect(dispatch.assertCompleteSignedArtifact(V2_ARTIFACT))
+      .toBe(V2_ARTIFACT);
+    await dispatch.verifySignedPublish(verificationInput(V2_ARTIFACT));
+    await dispatch.observeExactTransaction({
+      artifact: V2_ARTIFACT,
+    } as never);
+    await dispatch.resolveReissueState({
+      request: { previousSignedArtifact: V2_ARTIFACT },
+    } as never);
+    await dispatch.assertV2AcceptanceCurrent?.({} as never);
+    await dispatch.assertV2ReadyCurrentness?.({} as never);
+
+    expect(v1Calls).toEqual([]);
+    expect(v2Calls).toEqual([
+      "assert", "publish", "transaction", "reissue", "acceptance",
+      "currentness",
+    ]);
+    expect(loadV2).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unknown schemas before either authority can inspect them", async () => {
+    const { authority: v1, calls: v1Calls } = fakeAuthority("v1");
+    const { authority: v2, calls: v2Calls } = fakeAuthority("v2");
+    const loadV2 = vi.fn(() => v2 as ManualRouterWebsiteAuthorityV2);
+    const dispatch = createManualRouterWebsiteAuthorityDispatchV2({
+      v1,
+      loadV2,
+    });
+    const unknown = { schemaVersion: "programmable.unknown.v99" };
+
+    expect(() => dispatch.assertCompleteSignedArtifact(unknown))
+      .toThrow("schema is unsupported");
+    await expect(dispatch.verifySignedPublish(verificationInput(unknown)))
+      .rejects.toThrow("schema is unsupported");
+    await expect(dispatch.observeExactTransaction({
+      artifact: unknown,
+    } as never)).rejects.toThrow("schema is unsupported");
+    await expect(dispatch.resolveReissueState({
+      request: { previousSignedArtifact: unknown },
+    } as never)).rejects.toThrow("schema is unsupported");
+
+    expect(v1Calls).toEqual([]);
+    expect(v2Calls).toEqual([]);
+    expect(loadV2).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to V1 when the V2 facade is unavailable", async () => {
+    const { authority: v1, calls: v1Calls } = fakeAuthority("v1");
+    const dispatch = createManualRouterWebsiteAuthorityDispatchV2({
+      v1,
+      loadV2() {
+        throw new TypeError("portable V2 facade unavailable");
+      },
+    });
+
+    expect(() => dispatch.assertCompleteSignedArtifact(V2_ARTIFACT))
+      .toThrow("portable V2 facade unavailable");
+    await expect(dispatch.verifySignedPublish(verificationInput(V2_ARTIFACT)))
+      .rejects.toThrow("portable V2 facade unavailable");
+    expect(v1Calls).toEqual([]);
+  });
+});
+
+function fakeAuthority(label: "v1" | "v2") {
+  const calls: string[] = [];
+  const authority = {
+    assertCompleteSignedArtifact(raw: unknown) {
+      calls.push("assert");
+      return raw;
+    },
+    async verifySignedPublish() {
+      calls.push("publish");
+      return {};
+    },
+    async readChainClock() {
+      calls.push("clock");
+      return {
+        minimumTimestamp: "1",
+        maximumTimestamp: "1",
+        commonFinalizedTimestamp: "1",
+        commonFinalizedBlockNumber: "1",
+        commonFinalizedBlockHash: `0x${"11".repeat(32)}`,
+      };
+    },
+    async assertV2AcceptanceCurrent() {
+      calls.push("acceptance");
+    },
+    async assertV2ReadyCurrentness() {
+      calls.push("currentness");
+      return {};
+    },
+    async observeExactTransaction() {
+      calls.push("transaction");
+    },
+    async resolveReissueState() {
+      calls.push("reissue");
+      return {};
+    },
+  };
+  return {
+    authority: authority as unknown as ManualRouterWebsiteAuthorityV1,
+    calls,
+    label,
+  };
+}
+
+function verificationInput(signedArtifact: unknown) {
+  return {
+    request: { signedArtifact },
+    currentApplicantIndex: null,
+    currentApplicantPointers: [],
+  };
+}


### PR DESCRIPTION
## Outcome

Adds the smallest ready-but-inactive Website integration port for a future frozen Router V2 portable Authority facade.

- dispatches complete-artifact parse, publish, reissue, transaction observation, acceptance currentness, and Ready currentness/preflight by exact artifact schema
- preserves the existing V1 authority and chain-clock path
- rejects unknown schemas and never falls back from V2 to V1
- loads and caches one immutable portable V2 facade only after the full production binding is active
- keeps the local projection helper out of the production HTTP/publish boundary

The currently vendored exact `b180aca` disabled bundle does not export `createPortableManualRouterWebsiteAuthorityV2`, so V2 remains fail-closed. `active=false`, `activationAllowed=false`, null deployment/revenue evidence, V2 finality, and route-acceptance closure are unchanged release blockers.

No UI, INDEXER, Explore, Profile, data-pipeline, activation, staging, deployment, signature, or transaction change is included.

## Validation

- `npm run typecheck`
- focused Vitest: 5 files, 52 tests passed
- final authority/state/service Vitest: 3 files, 12 tests passed
- `npm run release:manual-applicant:policy:test`: 8 passed
- `npm run release:manual-applicant:vendor:test`: 4 passed
- `npm run release:manual-applicant:vendor:verify`
- path-scoped ESLint
- clean `npm run build`
- `git diff --check`
