### PR TITLE
Add fail-closed Hookemon applicant flow codecs

### DIFF
--- a/components/manual-applicant-launch.module.css
+++ b/components/manual-applicant-launch.module.css
@@ -328,6 +328,20 @@
   font-family: var(--font-plex-mono), monospace;
 }
 
+.hookemonSequence {
+  color: var(--text-soft);
+  display: grid;
+  font-size: 12px;
+  gap: 8px;
+  line-height: 1.45;
+  margin: 18px 0 0;
+  padding-inline-start: 24px;
+}
+
+.hookemonSequence li {
+  padding-inline-start: 4px;
+}
+
 .confirmationTitle {
   align-items: center;
   color: var(--accent-strong);

--- a/components/manual-applicant-launch.tsx
+++ b/components/manual-applicant-launch.tsx
@@ -28,6 +28,9 @@ import { useWallet } from "@/components/wallet-provider";
 import { getActiveManualRouterProductionBindingV2 } from
   "@/lib/custom-launch/manual-router-bindings-v2";
 import {
+  isExactHookemonApplicantGithubLoginV1,
+} from "@/lib/custom-launch/hookemon-applicant-presentation-v1";
+import {
   type ManualRouterApplicantListResponseV1,
   type ManualRouterPersistedAttemptV1,
   type ManualRouterResolveResponseV1,
@@ -172,15 +175,23 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
   const launchLockRef = useRef(false);
   const finalityLockRef = useRef(false);
   const exactShardsApplicant = isExactShardsGithubLogin(githubUsername);
-  const routeCapabilityUnavailable = exactShardsApplicant
+  const exactHookemonApplicant =
+    isExactHookemonApplicantGithubLoginV1(githubUsername);
+  const shardsRouteCapabilityUnavailable = exactShardsApplicant
     && NESTED_FACTORY_ACTIVATION === null;
+  // The Website must not infer an executable Hookemon action from source
+  // metadata. This stays hard-disabled until one immutable mixed-provenance
+  // profile, Facade and Authority release are bound together.
+  const hookemonRouteCapabilityUnavailable = exactHookemonApplicant;
   const routeAcceptanceRequired = exactShardsApplicant
     && NESTED_FACTORY_ACTIVATION !== null;
-  const routeAccepted = !exactShardsApplicant
-    || (
-      NESTED_FACTORY_ACTIVATION !== null
-      && routeAcceptance?.state === "accepted"
-    );
+  const routeAccepted = exactHookemonApplicant
+    ? false
+    : !exactShardsApplicant
+      || (
+        NESTED_FACTORY_ACTIVATION !== null
+        && routeAcceptance?.state === "accepted"
+      );
 
   const getSession = useCallback(async (): Promise<ManualRouterWebsiteSessionV1> => {
     const [accessToken, identityToken] = await Promise.all([
@@ -442,7 +453,6 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     authenticated,
     getSession,
     githubConnected,
-    routeAcceptanceRequired,
     exactShardsApplicant,
     selectedSubjectHash,
     routeAccepted,
@@ -850,9 +860,14 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     }),
   );
   const trustSteps = useMemo(() => [
+    ...(exactHookemonApplicant ? [{
+      label: "Completed-graph adoption",
+      detail: "Exact profile and Authority release required",
+      complete: false,
+    }] : []),
     ...(exactShardsApplicant ? [{
       label: "Exact route acceptance",
-      detail: routeCapabilityUnavailable
+      detail: shardsRouteCapabilityUnavailable
         ? "Route capability unavailable"
         : routeAcceptance?.state === "accepted"
           ? "nested-factory@1.0.0 accepted"
@@ -889,8 +904,8 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     githubUsername,
     resolved,
     routeAcceptance?.state,
-    routeAcceptanceRequired,
-    routeCapabilityUnavailable,
+    shardsRouteCapabilityUnavailable,
+    exactHookemonApplicant,
     exactShardsApplicant,
     routeAccepted,
     selected,
@@ -903,20 +918,33 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
           <ArrowLeft aria-hidden="true" size={15} />
           Back
         </button>
-        <span className={styles.betaLabel}>Approved applicants</span>
+        <span className={styles.betaLabel}>
+          {exactHookemonApplicant ? "Hookbuilder applicant" : "Approved applicants"}
+        </span>
       </header>
 
       <section className={styles.hero} aria-labelledby="applicant-launch-title">
         <div className={styles.heroCopy}>
           <span className={styles.kicker}>Applicant launch</span>
           <h1 id="applicant-launch-title" ref={titleRef} tabIndex={-1}>
-            Launch your approved coin
+            {exactHookemonApplicant
+              ? "Prepare the Hookemon launch"
+              : "Launch your approved coin"}
           </h1>
-          <p>
-            Sign in with the GitHub account from your submission and connect its
-            exact wallet. Your approved launch loads automatically. You pay gas
-            and send one transaction directly to the canonical Router.
-          </p>
+          {exactHookemonApplicant ? (
+            <p>
+              Hookemon requires three ordered wallet confirmations: the exact
+              USDC approval, the nonce-bound contract creation, then canonical
+              completed-graph adoption. Every step remains unavailable until
+              its fresh plan and chain checks are verified.
+            </p>
+          ) : (
+            <p>
+              Sign in with the GitHub account from your submission and connect its
+              exact wallet. Your approved launch loads automatically. You pay gas
+              and send one transaction directly to the canonical Router.
+            </p>
+          )}
         </div>
         <ol className={styles.trustRail} aria-label="Launch authorization">
           {trustSteps.map((step) => (
@@ -959,11 +987,35 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
             />
           ) : null}
 
-          {routeCapabilityUnavailable ? (
+          {shardsRouteCapabilityUnavailable ? (
             <p className={styles.nonceNote} role="status">
               The exact Shards route is not available yet. Wallet connection and
               launch stay disabled until its audited production binding is current.
             </p>
+          ) : null}
+
+          {hookemonRouteCapabilityUnavailable ? (
+            <section
+              className={styles.submission}
+              aria-labelledby="hookemon-launch-sequence-heading"
+            >
+              <div>
+                <span>Required order</span>
+                <strong id="hookemon-launch-sequence-heading">
+                  Hookemon completed-graph adoption
+                </strong>
+              </div>
+              <ol className={styles.hookemonSequence}>
+                <li>Approve the exact plan-bound USDC amount at nonce N</li>
+                <li>Create the exact AtomicLauncher at nonce N + 1</li>
+                <li>Adopt and stamp only after finalized graph verification</li>
+              </ol>
+              <p className={styles.nonceNote} role="status">
+                Wallet actions stay disabled until the exact Hookemon profile,
+                fresh chain checks, valid runtime status and Authority release
+                are current. Programmable never requests a private key.
+              </p>
+            </section>
           ) : null}
 
           <div className={styles.identityGrid}>
@@ -1189,22 +1241,44 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
 
         <aside className={styles.safetyPanel} aria-labelledby="safety-heading">
           <ShieldCheck aria-hidden="true" size={23} />
-          <h2 id="safety-heading">One wallet action</h2>
-          <p>
-            Your wallet sends one transaction to the verified Ethereum Router.
-            Programmable never needs your private key or an operator secret in
-            this browser.
-          </p>
-          <ul>
-            <li>Your wallet pays gas</li>
-            <li>The pending nonce is diagnostic only</li>
-            <li>Do not retry an uncertain wallet send</li>
-            <li>Never speed up or replace a submitted beta transaction</li>
-            <li>Public indexing starts after finality</li>
-          </ul>
+          <h2 id="safety-heading">
+            {exactHookemonApplicant ? "Three exact confirmations" : "One wallet action"}
+          </h2>
+          {exactHookemonApplicant ? (
+            <>
+              <p>
+                The Website guides approval, contract creation and adoption in
+                order. It never requests your private key or an operator secret.
+              </p>
+              <ul>
+                <li>Approval and CREATE use consecutive bound nonces</li>
+                <li>Any drift invalidates the complete plan</li>
+                <li>Adoption opens only after CREATE finality</li>
+                <li>Do not retry an uncertain wallet send</li>
+                <li>Public indexing starts after adoption finality</li>
+              </ul>
+            </>
+          ) : (
+            <>
+              <p>
+                Your wallet sends one transaction to the verified Ethereum Router.
+                Programmable never needs your private key or an operator secret in
+                this browser.
+              </p>
+              <ul>
+                <li>Your wallet pays gas</li>
+                <li>The pending nonce is diagnostic only</li>
+                <li>Do not retry an uncertain wallet send</li>
+                <li>Never speed up or replace a submitted beta transaction</li>
+                <li>Public indexing starts after finality</li>
+              </ul>
+            </>
+          )}
           <Link
             className={styles.githubLink}
-            href="https://github.com/0xprogrammable/hookbuilder/tree/279dd2fc2ea8c488943ca4e60ca889cb00bab40e/submissions/requests"
+            href={exactHookemonApplicant
+              ? "https://github.com/0xprogrammable/hookbuilder/pull/10"
+              : "https://github.com/0xprogrammable/hookbuilder/tree/279dd2fc2ea8c488943ca4e60ca889cb00bab40e/submissions/requests"}
             target="_blank"
             rel="noreferrer"
           >

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -38,11 +38,16 @@ import { mainnet, sepolia } from "viem/chains";
 import { bytesToHex, hexToBytes, type Hex } from "viem";
 
 import type {
+  HookemonApplicantFlowBindingV1,
   HookemonBrowserWalletActionV1,
 } from "@/lib/custom-launch/hookemon-applicant-contract-v1";
 import {
   HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
+  revalidateHookemonBrowserWalletActionForSendV1,
 } from "@/lib/custom-launch/hookemon-applicant-contract-v1";
+import {
+  verifyHookemonActionIdentifierAuthorityForSendV1,
+} from "@/lib/custom-launch/hookemon-action-identifier-verifier-v1";
 import { parseLocalProfile } from "@/lib/profile/local-profile";
 import {
   buildEip1193TransactionRequest,
@@ -100,6 +105,7 @@ type WalletContextValue = {
   }>) => Promise<Hex>;
   sendHookemonBrowserWalletAction: (
     action: HookemonBrowserWalletActionV1,
+    binding: HookemonApplicantFlowBindingV1,
   ) => Promise<Hex>;
   sendTransaction: (transaction: PreparedTransaction) => Promise<Hex>;
   readNativeBalance: () => Promise<WalletNativeBalance>;
@@ -384,17 +390,24 @@ export type HookemonEip1193TransactionV1 = Readonly<{
  */
 export function buildHookemonEip1193TransactionV1(
   action: HookemonBrowserWalletActionV1,
+  binding: HookemonApplicantFlowBindingV1,
   connectedAccount: `0x${string}`,
+  currentEpochSeconds: string,
 ): HookemonEip1193TransactionV1 {
-  const transaction = action.transaction;
-  const executableAction = action.actionIndex === 0
-    ? action.actionKind === "ERC20_APPROVAL"
-      && action.currentness.kind === "PRE_APPROVAL"
-    : action.actionIndex === 1
-      && action.actionKind === "EOA_CREATE"
-      && action.currentness.kind === "PRE_CREATE";
+  const validatedAction = revalidateHookemonBrowserWalletActionForSendV1(
+    action,
+    binding,
+    currentEpochSeconds,
+  );
+  const transaction = validatedAction.transaction;
+  const executableAction = validatedAction.actionIndex === 0
+    ? validatedAction.actionKind === "ERC20_APPROVAL"
+      && validatedAction.currentness.kind === "PRE_APPROVAL"
+    : validatedAction.actionIndex === 1
+      && validatedAction.actionKind === "EOA_CREATE"
+      && validatedAction.currentness.kind === "PRE_CREATE";
   if (
-    action.schemaVersion !== HOOKEMON_BROWSER_ACTION_SCHEMA_V1
+    validatedAction.schemaVersion !== HOOKEMON_BROWSER_ACTION_SCHEMA_V1
     || !executableAction
     || transaction.chainId !== "0x1"
     || transaction.method !== "eth_sendTransaction"
@@ -403,10 +416,11 @@ export function buildHookemonEip1193TransactionV1(
     throw new Error("The Hookemon wallet action is not executable");
   }
   if (
-    action.currentness.observedPendingNonce !== transaction.nonce
-    || (action.actionIndex === 0 && transaction.to === null)
-    || (action.actionIndex === 1 && transaction.to !== null)
+    validatedAction.currentness.observedPendingNonce !== transaction.nonce
+    || (validatedAction.actionIndex === 0 && transaction.to === null)
+    || (validatedAction.actionIndex === 1 && transaction.to !== null)
   ) throw new Error("The Hookemon wallet action nonce or target drifted");
+  verifyHookemonActionIdentifierAuthorityForSendV1(validatedAction, binding);
   const common = {
     from: transaction.from,
     nonce: transaction.nonce,
@@ -1024,6 +1038,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
 
   const sendHookemonBrowserWalletAction = useCallback(async (
     action: HookemonBrowserWalletActionV1,
+    binding: HookemonApplicantFlowBindingV1,
   ) => {
     if (!connectedWallet || !wallet) {
       throw new Error("Connect an Ethereum wallet before continuing");
@@ -1033,7 +1048,9 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
     }
     const transaction = buildHookemonEip1193TransactionV1(
       action,
+      binding,
       wallet.account,
+      Math.floor(Date.now() / 1_000).toString(),
     );
     const isEmbeddedWallet =
       connectedWallet.walletClientType === "privy" ||
@@ -1054,13 +1071,21 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
         params: [wallet.account, "pending"],
       });
       assertHookemonPendingNonceV1(pendingNonce, transaction.nonce);
+      const currentTransaction = buildHookemonEip1193TransactionV1(
+        action,
+        binding,
+        wallet.account,
+        Math.floor(Date.now() / 1_000).toString(),
+      );
       if (isEmbeddedWallet) {
         const result = await sendPrivyTransaction({
-          ...(transaction.to === undefined ? {} : { to: transaction.to }),
-          data: transaction.data,
+          ...(currentTransaction.to === undefined
+            ? {}
+            : { to: currentTransaction.to }),
+          data: currentTransaction.data,
           value: 0n,
-          nonce: BigInt(transaction.nonce),
-          gasLimit: BigInt(transaction.gas),
+          nonce: BigInt(currentTransaction.nonce),
+          gasLimit: BigInt(currentTransaction.gas),
           chainId: 1,
         }, {
           address: wallet.account,
@@ -1080,7 +1105,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       }
       const hash = await provider.request({
         method: "eth_sendTransaction",
-        params: [transaction],
+        params: [currentTransaction],
       });
       return parseSubmittedTransactionHash(hash);
     } catch (caught) {

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -37,6 +37,12 @@ import {
 import { mainnet, sepolia } from "viem/chains";
 import { bytesToHex, hexToBytes, type Hex } from "viem";
 
+import type {
+  HookemonBrowserWalletActionV1,
+} from "@/lib/custom-launch/hookemon-applicant-contract-v1";
+import {
+  HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
+} from "@/lib/custom-launch/hookemon-applicant-contract-v1";
 import { parseLocalProfile } from "@/lib/profile/local-profile";
 import {
   buildEip1193TransactionRequest,
@@ -92,6 +98,9 @@ type WalletContextValue = {
     data: `0x${string}`;
     value: `0x${string}`;
   }>) => Promise<Hex>;
+  sendHookemonBrowserWalletAction: (
+    action: HookemonBrowserWalletActionV1,
+  ) => Promise<Hex>;
   sendTransaction: (transaction: PreparedTransaction) => Promise<Hex>;
   readNativeBalance: () => Promise<WalletNativeBalance>;
   readTradeBalances: (token: `0x${string}`) => Promise<WalletTradeBalances>;
@@ -358,6 +367,67 @@ export async function assertExternalWalletAuthorityCurrent(input: Readonly<{
   ) {
     throw new Error("The active wallet account changed. Review the launch and try again");
   }
+}
+
+export type HookemonEip1193TransactionV1 = Readonly<{
+  from: `0x${string}`;
+  to?: `0x${string}`;
+  nonce: `0x${string}`;
+  gas: `0x${string}`;
+  data: `0x${string}`;
+  value: "0x0";
+}>;
+
+/**
+ * Isolated from the existing Router V1/V2 sender: Hookemon must bind an exact
+ * nonce and must omit `to` only for the normal-CREATE step.
+ */
+export function buildHookemonEip1193TransactionV1(
+  action: HookemonBrowserWalletActionV1,
+  connectedAccount: `0x${string}`,
+): HookemonEip1193TransactionV1 {
+  const transaction = action.transaction;
+  const executableAction = action.actionIndex === 0
+    ? action.actionKind === "ERC20_APPROVAL"
+      && action.currentness.kind === "PRE_APPROVAL"
+    : action.actionIndex === 1
+      && action.actionKind === "EOA_CREATE"
+      && action.currentness.kind === "PRE_CREATE";
+  if (
+    action.schemaVersion !== HOOKEMON_BROWSER_ACTION_SCHEMA_V1
+    || !executableAction
+    || transaction.chainId !== "0x1"
+    || transaction.method !== "eth_sendTransaction"
+    || transaction.from.toLowerCase() !== connectedAccount.toLowerCase()
+  ) {
+    throw new Error("The Hookemon wallet action is not executable");
+  }
+  if (
+    action.currentness.observedPendingNonce !== transaction.nonce
+    || (action.actionIndex === 0 && transaction.to === null)
+    || (action.actionIndex === 1 && transaction.to !== null)
+  ) throw new Error("The Hookemon wallet action nonce or target drifted");
+  const common = {
+    from: transaction.from,
+    nonce: transaction.nonce,
+    gas: transaction.gas,
+    data: transaction.data,
+    value: transaction.value,
+  } as const;
+  return transaction.to === null
+    ? Object.freeze(common)
+    : Object.freeze({ ...common, to: transaction.to });
+}
+
+export function assertHookemonPendingNonceV1(
+  observed: unknown,
+  expected: `0x${string}`,
+): void {
+  if (
+    typeof observed !== "string"
+    || !/^0x(?:0|[1-9a-f][0-9a-f]*)$/u.test(observed)
+    || observed !== expected
+  ) throw new Error("The Hookemon wallet nonce changed. Refresh the exact plan");
 }
 
 function decodeBase64Url(value: string): Uint8Array {
@@ -952,6 +1022,72 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
     }
   }, [connectedWallet, sendPrivyTransaction, wallet]);
 
+  const sendHookemonBrowserWalletAction = useCallback(async (
+    action: HookemonBrowserWalletActionV1,
+  ) => {
+    if (!connectedWallet || !wallet) {
+      throw new Error("Connect an Ethereum wallet before continuing");
+    }
+    if (appChain.id !== 1) {
+      throw new Error("The Hookemon launch is available only on Ethereum");
+    }
+    const transaction = buildHookemonEip1193TransactionV1(
+      action,
+      wallet.account,
+    );
+    const isEmbeddedWallet =
+      connectedWallet.walletClientType === "privy" ||
+      connectedWallet.walletClientType === "privy-v2";
+    try {
+      if (wallet.chainId !== "0x1") {
+        await connectedWallet.switchChain(1);
+      }
+      const provider = await connectedWallet.getEthereumProvider();
+      await assertExternalWalletAuthorityCurrent({
+        expectedAccount: wallet.account,
+        expectedChainId: "0x1",
+        networkName: "Ethereum",
+        request: (method) => provider.request({ method }),
+      });
+      const pendingNonce = await provider.request({
+        method: "eth_getTransactionCount",
+        params: [wallet.account, "pending"],
+      });
+      assertHookemonPendingNonceV1(pendingNonce, transaction.nonce);
+      if (isEmbeddedWallet) {
+        const result = await sendPrivyTransaction({
+          ...(transaction.to === undefined ? {} : { to: transaction.to }),
+          data: transaction.data,
+          value: 0n,
+          nonce: BigInt(transaction.nonce),
+          gasLimit: BigInt(transaction.gas),
+          chainId: 1,
+        }, {
+          address: wallet.account,
+          uiOptions: action.actionIndex === 0
+            ? {
+                description: "Approve the exact Hookemon USDC funding",
+                buttonText: "Approve USDC",
+                successHeader: "Approval submitted",
+              }
+            : {
+                description: "Create the exact Hookemon AtomicLauncher",
+                buttonText: "Create launcher",
+                successHeader: "Launcher submitted",
+              },
+        });
+        return parseSubmittedTransactionHash(result.hash);
+      }
+      const hash = await provider.request({
+        method: "eth_sendTransaction",
+        params: [transaction],
+      });
+      return parseSubmittedTransactionHash(hash);
+    } catch (caught) {
+      throw new Error(getWalletTransactionErrorMessage(caught));
+    }
+  }, [connectedWallet, sendPrivyTransaction, wallet]);
+
   const readTradeBalances = useCallback(
     async (token: `0x${string}`) => {
       if (!connectedWallet || !wallet) {
@@ -1054,6 +1190,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       setUsername,
       signLaunchMessage,
       sendBrowserWalletAction,
+      sendHookemonBrowserWalletAction,
       sendTransaction,
       readNativeBalance,
       readTradeBalances,
@@ -1074,6 +1211,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       readNativeBalance,
       readTradeBalances,
       sendBrowserWalletAction,
+      sendHookemonBrowserWalletAction,
       sendTransaction,
       signLaunchMessage,
       providerSettled,
@@ -1137,6 +1275,9 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
         throw new Error("Wallet sign-in is unavailable");
       },
       sendBrowserWalletAction: async () => {
+        throw new Error("Wallet sign-in is unavailable");
+      },
+      sendHookemonBrowserWalletAction: async () => {
         throw new Error("Wallet sign-in is unavailable");
       },
       sendTransaction: async () => {

--- a/lib/custom-launch/artifacts/hookemon-applicant-authority-browser.v1.schema.json
+++ b/lib/custom-launch/artifacts/hookemon-applicant-authority-browser.v1.schema.json
@@ -1,0 +1,358 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:programmable:hookemon-applicant-authority-browser:1.0.0",
+  "title": "Programmable Hookemon applicant Authority/browser state V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "bindingHash",
+    "blocker",
+    "finalizedActions",
+    "pendingAction",
+    "planHash",
+    "profileKey",
+    "readyAction",
+    "schemaVersion",
+    "state",
+    "stateVersion",
+    "subjectHash"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "programmable.hookemon-applicant-flow-state-response.v1"
+    },
+    "bindingHash": { "$ref": "#/$defs/sha256" },
+    "subjectHash": { "$ref": "#/$defs/sha256" },
+    "planHash": { "$ref": "#/$defs/bytes32" },
+    "profileKey": { "$ref": "#/$defs/bytes32" },
+    "stateVersion": { "$ref": "#/$defs/uint" },
+    "state": {
+      "enum": [
+        "PLAN_ACCEPTANCE_REQUIRED",
+        "APPROVAL_READY",
+        "APPROVAL_SUBMITTED",
+        "CREATE_READY",
+        "CREATE_SUBMITTED",
+        "GRAPH_CURRENTNESS_PENDING",
+        "ADOPTION_READY",
+        "ADOPTION_SUBMITTED",
+        "FINALIZED",
+        "BLOCKED"
+      ]
+    },
+    "finalizedActions": {
+      "type": "array",
+      "maxItems": 3,
+      "items": { "$ref": "#/$defs/actionFinality" }
+    },
+    "pendingAction": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/reportedAction" }
+      ]
+    },
+    "readyAction": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/browserAction" }
+      ]
+    },
+    "blocker": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/blocker" }
+      ]
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "bytes32": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{64}$"
+    },
+    "address": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{40}$"
+    },
+    "uint": {
+      "type": "string",
+      "pattern": "^(?:0|[1-9][0-9]*)$"
+    },
+    "rpcQuantity": {
+      "type": "string",
+      "pattern": "^0x(?:0|[1-9a-f][0-9a-f]*)$"
+    },
+    "evenHex": {
+      "type": "string",
+      "pattern": "^0x(?:[0-9a-f]{2})*$"
+    },
+    "actionIndex": {
+      "type": "integer",
+      "enum": [0, 1, 2]
+    },
+    "actionKind": {
+      "enum": [
+        "ERC20_APPROVAL",
+        "EOA_CREATE",
+        "COMPLETED_GRAPH_ADOPTION"
+      ]
+    },
+    "currentness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "completedGraphHash",
+        "currentPoolStateHash",
+        "evidenceHash",
+        "kind",
+        "observedBlockHash",
+        "observedBlockNumber",
+        "observedPendingNonce",
+        "previousFinalityEvidenceHash",
+        "runtimeStatusHash",
+        "schemaVersion"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.hookemon-action-currentness.v1"
+        },
+        "kind": {
+          "enum": ["PRE_APPROVAL", "PRE_CREATE", "PRE_ADOPTION"]
+        },
+        "observedBlockNumber": { "$ref": "#/$defs/uint" },
+        "observedBlockHash": { "$ref": "#/$defs/bytes32" },
+        "observedPendingNonce": { "$ref": "#/$defs/rpcQuantity" },
+        "evidenceHash": { "$ref": "#/$defs/sha256" },
+        "previousFinalityEvidenceHash": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/sha256" }
+          ]
+        },
+        "completedGraphHash": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/bytes32" }
+          ]
+        },
+        "currentPoolStateHash": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/bytes32" }
+          ]
+        },
+        "runtimeStatusHash": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/sha256" }
+          ]
+        }
+      }
+    },
+    "transaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "chainId",
+        "data",
+        "from",
+        "gas",
+        "method",
+        "nonce",
+        "to",
+        "value"
+      ],
+      "properties": {
+        "method": { "const": "eth_sendTransaction" },
+        "chainId": { "const": "0x1" },
+        "from": { "$ref": "#/$defs/address" },
+        "to": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/address" }
+          ]
+        },
+        "nonce": { "$ref": "#/$defs/rpcQuantity" },
+        "gas": { "$ref": "#/$defs/rpcQuantity" },
+        "data": { "$ref": "#/$defs/evenHex" },
+        "value": { "const": "0x0" }
+      }
+    },
+    "browserAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actionHash",
+        "actionIndex",
+        "actionKind",
+        "bindingHash",
+        "currentness",
+        "dataHash",
+        "expiresAtEpochSeconds",
+        "permitDigest",
+        "previousFinalityEvidenceHash",
+        "schemaVersion",
+        "selectorHash",
+        "stateVersion",
+        "transaction",
+        "validAfterEpochSeconds"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.hookemon-browser-wallet-action.v1"
+        },
+        "bindingHash": { "$ref": "#/$defs/sha256" },
+        "stateVersion": { "$ref": "#/$defs/uint" },
+        "actionIndex": { "$ref": "#/$defs/actionIndex" },
+        "actionKind": { "$ref": "#/$defs/actionKind" },
+        "selectorHash": { "$ref": "#/$defs/sha256" },
+        "actionHash": { "$ref": "#/$defs/sha256" },
+        "dataHash": { "$ref": "#/$defs/bytes32" },
+        "previousFinalityEvidenceHash": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/sha256" }
+          ]
+        },
+        "permitDigest": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/bytes32" }
+          ]
+        },
+        "validAfterEpochSeconds": { "$ref": "#/$defs/uint" },
+        "expiresAtEpochSeconds": { "$ref": "#/$defs/uint" },
+        "currentness": { "$ref": "#/$defs/currentness" },
+        "transaction": { "$ref": "#/$defs/transaction" }
+      }
+    },
+    "actionFinality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actionHash",
+        "actionIndex",
+        "actionKind",
+        "blockHash",
+        "blockNumber",
+        "confirmations",
+        "finalityEvidenceHash",
+        "receiptEvidenceHash",
+        "resultHash",
+        "schemaVersion",
+        "selectorHash",
+        "transactionHash"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.hookemon-action-finality.v1"
+        },
+        "actionIndex": { "$ref": "#/$defs/actionIndex" },
+        "actionKind": { "$ref": "#/$defs/actionKind" },
+        "selectorHash": { "$ref": "#/$defs/sha256" },
+        "actionHash": { "$ref": "#/$defs/sha256" },
+        "transactionHash": { "$ref": "#/$defs/bytes32" },
+        "blockNumber": { "$ref": "#/$defs/uint" },
+        "blockHash": { "$ref": "#/$defs/bytes32" },
+        "confirmations": { "type": "integer", "minimum": 1 },
+        "receiptEvidenceHash": { "$ref": "#/$defs/sha256" },
+        "finalityEvidenceHash": { "$ref": "#/$defs/sha256" },
+        "resultHash": { "$ref": "#/$defs/bytes32" }
+      }
+    },
+    "reportedAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actionHash",
+        "actionIndex",
+        "actionKind",
+        "reportedAtEpochSeconds",
+        "schemaVersion",
+        "selectorHash",
+        "transactionHash"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.hookemon-reported-action.v1"
+        },
+        "actionIndex": { "$ref": "#/$defs/actionIndex" },
+        "actionKind": { "$ref": "#/$defs/actionKind" },
+        "selectorHash": { "$ref": "#/$defs/sha256" },
+        "actionHash": { "$ref": "#/$defs/sha256" },
+        "transactionHash": { "$ref": "#/$defs/bytes32" },
+        "reportedAtEpochSeconds": { "$ref": "#/$defs/uint" }
+      }
+    },
+    "blocker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "owner", "retryable"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]{2,63}$"
+        },
+        "owner": {
+          "enum": ["platform", "applicant", "provider", "funding"]
+        },
+        "retryable": { "type": "boolean" }
+      }
+    },
+    "transactionReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actionHash",
+        "actionIndex",
+        "actionKind",
+        "bindingHash",
+        "schemaVersion",
+        "selectorHash",
+        "stateVersion",
+        "transactionHash"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.hookemon-applicant-transaction-report.v1"
+        },
+        "bindingHash": { "$ref": "#/$defs/sha256" },
+        "stateVersion": { "$ref": "#/$defs/uint" },
+        "actionIndex": { "$ref": "#/$defs/actionIndex" },
+        "actionKind": { "$ref": "#/$defs/actionKind" },
+        "selectorHash": { "$ref": "#/$defs/sha256" },
+        "actionHash": { "$ref": "#/$defs/sha256" },
+        "transactionHash": { "$ref": "#/$defs/bytes32" }
+      }
+    },
+    "finalityRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actionHash",
+        "actionIndex",
+        "actionKind",
+        "bindingHash",
+        "schemaVersion",
+        "selectorHash",
+        "stateVersion",
+        "transactionHash"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.hookemon-applicant-finality-request.v1"
+        },
+        "bindingHash": { "$ref": "#/$defs/sha256" },
+        "stateVersion": { "$ref": "#/$defs/uint" },
+        "actionIndex": { "$ref": "#/$defs/actionIndex" },
+        "actionKind": { "$ref": "#/$defs/actionKind" },
+        "selectorHash": { "$ref": "#/$defs/sha256" },
+        "actionHash": { "$ref": "#/$defs/sha256" },
+        "transactionHash": { "$ref": "#/$defs/bytes32" }
+      }
+    }
+  }
+}

--- a/lib/custom-launch/hookemon-action-identifier-verifier-v1.ts
+++ b/lib/custom-launch/hookemon-action-identifier-verifier-v1.ts
@@ -1,0 +1,14 @@
+/**
+ * Browser send authority for actionHash/selectorHash is intentionally absent.
+ * Replace this stub only with the exact frozen Facade formula or signature
+ * over the binding, full transaction envelope (including gas), currentness and
+ * action fields; structural SHA-256 strings are not execution authority.
+ */
+export function verifyHookemonActionIdentifierAuthorityForSendV1(
+  action: unknown,
+  binding: unknown,
+): void {
+  void action;
+  void binding;
+  throw new TypeError("Hookemon action identifier authority is unavailable");
+}

--- a/lib/custom-launch/hookemon-adoption-verifier-v22.ts
+++ b/lib/custom-launch/hookemon-adoption-verifier-v22.ts
@@ -1,0 +1,45 @@
+import { keccak256, type Hex } from "viem";
+
+export interface HookemonAdoptionCalldataEnvelopeV22 {
+  readonly calldata: Hex;
+  readonly expectedSelector: Hex;
+  readonly expectedCalldataHash: Hex;
+}
+
+export interface HookemonAdoptionReencodingCheckV22
+  extends HookemonAdoptionCalldataEnvelopeV22 {
+  readonly reencodedCalldata: Hex;
+}
+
+/**
+ * Final guard for the future frozen decoder. Passing this guard alone is not
+ * adoption authority: the decoder must first recompute every V2.2 binding.
+ */
+export function assertHookemonAdoptionByteExactReencodingV22(
+  input: HookemonAdoptionReencodingCheckV22,
+): void {
+  if (
+    !/^0x(?:[0-9a-f]{2})+$/u.test(input.calldata)
+    || !/^0x[0-9a-f]{8}$/u.test(input.expectedSelector)
+    || !/^0x[0-9a-f]{64}$/u.test(input.expectedCalldataHash)
+    || !input.calldata.startsWith(input.expectedSelector)
+    || keccak256(input.calldata) !== input.expectedCalldataHash
+    || input.reencodedCalldata !== input.calldata
+  ) {
+    throw new TypeError(
+      "Hookemon V2.2 adoption calldata is not a byte-exact deterministic re-encoding",
+    );
+  }
+}
+
+/**
+ * This is the only browser entry point for adoption calldata. It deliberately
+ * cannot succeed until the exact frozen V2.2 ABI and hash formulas replace
+ * this stub with a decoder, full recomputation and byte-exact re-encoding.
+ */
+export function verifyHookemonAdoptionCalldataV22(
+  input: HookemonAdoptionCalldataEnvelopeV22,
+): never {
+  void input;
+  throw new TypeError("Hookemon V2.2 adoption decoder is unavailable");
+}

--- a/lib/custom-launch/hookemon-applicant-browser-state-v1.ts
+++ b/lib/custom-launch/hookemon-applicant-browser-state-v1.ts
@@ -1,0 +1,389 @@
+import {
+  type HookemonAddressV1,
+  type HookemonApplicantFlowBindingV1,
+  type HookemonApplicantFlowStateV1,
+  type HookemonBrowserWalletActionV1,
+  type HookemonBytes32V1,
+  type HookemonSha256V1,
+} from "@/lib/custom-launch/hookemon-applicant-contract-v1";
+
+export const HOOKEMON_ATTEMPT_STORAGE_PREFIX_V1 =
+  "programmable:hookemon-browser-attempt:v1" as const;
+
+export interface HookemonBrowserAttemptV1 {
+  readonly schemaVersion: "programmable.hookemon-browser-attempt.v1";
+  readonly bindingHash: HookemonSha256V1;
+  readonly subjectHash: HookemonSha256V1;
+  readonly planHash: HookemonBytes32V1;
+  readonly stateVersion: string;
+  readonly actionIndex: 0 | 1 | 2;
+  readonly actionKind:
+    | "ERC20_APPROVAL"
+    | "EOA_CREATE"
+    | "COMPLETED_GRAPH_ADOPTION";
+  readonly selectorHash: HookemonSha256V1;
+  readonly actionHash: HookemonSha256V1;
+  readonly currentnessEvidenceHash: HookemonSha256V1;
+  readonly dataHash: HookemonBytes32V1;
+  readonly from: HookemonAddressV1;
+  readonly to: HookemonAddressV1 | null;
+  readonly nonce: `0x${string}`;
+  readonly createdAt: string;
+  readonly transactionHash: HookemonBytes32V1 | null;
+  readonly phase: "wallet-prompt-opened" | "submitted" | "reported";
+}
+
+export type HookemonBrowserAttemptReadV1 =
+  | Readonly<{ kind: "none" }>
+  | Readonly<{ kind: "valid"; attempt: HookemonBrowserAttemptV1 }>
+  | Readonly<{ kind: "corrupt"; raw: string | null }>;
+
+export type HookemonAttemptReconciliationV1 = Readonly<{
+  active: HookemonBrowserAttemptV1 | null;
+  archive: HookemonBrowserAttemptV1 | null;
+  archiveReason: "server-finalized" | null;
+  recoveryRequired: boolean;
+}>;
+
+export function hookemonAttemptStorageKeyV1(
+  bindingHash: HookemonSha256V1,
+  actionIndex: 0 | 1 | 2,
+): string {
+  return `${HOOKEMON_ATTEMPT_STORAGE_PREFIX_V1}:${bindingHash}:${actionIndex}`;
+}
+
+export function createHookemonBrowserAttemptV1(input: Readonly<{
+  action: HookemonBrowserWalletActionV1;
+  binding: HookemonApplicantFlowBindingV1;
+  createdAt: string;
+}>): HookemonBrowserAttemptV1 {
+  const action = input.action;
+  if (
+    action.bindingHash !== input.binding.bindingHash
+    || action.transaction.from !== input.binding.launchWallet
+  ) throw new TypeError("Hookemon browser attempt binding is invalid");
+  return deepFreeze({
+    schemaVersion: "programmable.hookemon-browser-attempt.v1",
+    bindingHash: input.binding.bindingHash,
+    subjectHash: input.binding.subjectHash,
+    planHash: input.binding.planHash,
+    stateVersion: action.stateVersion,
+    actionIndex: action.actionIndex,
+    actionKind: action.actionKind,
+    selectorHash: action.selectorHash,
+    actionHash: action.actionHash,
+    currentnessEvidenceHash: action.currentness.evidenceHash,
+    dataHash: action.dataHash,
+    from: action.transaction.from,
+    to: action.transaction.to,
+    nonce: action.transaction.nonce,
+    createdAt: isoDate(input.createdAt),
+    transactionHash: null,
+    phase: "wallet-prompt-opened",
+  });
+}
+
+export function markHookemonBrowserAttemptSubmittedV1(
+  attempt: HookemonBrowserAttemptV1,
+  transactionHash: HookemonBytes32V1,
+): HookemonBrowserAttemptV1 {
+  if (
+    attempt.phase !== "wallet-prompt-opened"
+    || attempt.transactionHash !== null
+  ) throw new TypeError("Hookemon browser attempt is already submitted");
+  return deepFreeze({
+    ...attempt,
+    transactionHash: bytes32(transactionHash),
+    phase: "submitted" as const,
+  });
+}
+
+export function markHookemonBrowserAttemptReportedV1(
+  attempt: HookemonBrowserAttemptV1,
+): HookemonBrowserAttemptV1 {
+  if (attempt.phase !== "submitted" || attempt.transactionHash === null) {
+    throw new TypeError("Hookemon browser attempt has no submitted transaction");
+  }
+  return deepFreeze({ ...attempt, phase: "reported" as const });
+}
+
+export function parseHookemonBrowserAttemptStorageV1(
+  raw: string | null,
+  binding: HookemonApplicantFlowBindingV1,
+): HookemonBrowserAttemptReadV1 {
+  if (raw === null) return Object.freeze({ kind: "none" });
+  try {
+    const attempt = parseAttempt(JSON.parse(raw), binding);
+    return Object.freeze({ kind: "valid", attempt });
+  } catch {
+    return Object.freeze({ kind: "corrupt", raw });
+  }
+}
+
+export function hookemonFreshActionMatchesCachedV1(input: Readonly<{
+  cached: HookemonBrowserWalletActionV1;
+  fresh: HookemonApplicantFlowStateV1;
+}>): input is Readonly<{
+  cached: HookemonBrowserWalletActionV1;
+  fresh: HookemonApplicantFlowStateV1 & Readonly<{
+    readyAction: HookemonBrowserWalletActionV1;
+  }>;
+}> {
+  const fresh = input.fresh.readyAction;
+  const cached = input.cached;
+  if (fresh === null) return false;
+  return fresh.bindingHash === cached.bindingHash
+    && fresh.stateVersion === cached.stateVersion
+    && fresh.actionIndex === cached.actionIndex
+    && fresh.actionKind === cached.actionKind
+    && fresh.selectorHash === cached.selectorHash
+    && fresh.actionHash === cached.actionHash
+    && fresh.dataHash === cached.dataHash
+    && fresh.previousFinalityEvidenceHash
+      === cached.previousFinalityEvidenceHash
+    && fresh.permitDigest === cached.permitDigest
+    && fresh.validAfterEpochSeconds === cached.validAfterEpochSeconds
+    && fresh.expiresAtEpochSeconds === cached.expiresAtEpochSeconds
+    && fresh.currentness.evidenceHash === cached.currentness.evidenceHash
+    && fresh.currentness.observedBlockNumber
+      === cached.currentness.observedBlockNumber
+    && fresh.currentness.observedBlockHash === cached.currentness.observedBlockHash
+    && fresh.currentness.observedPendingNonce
+      === cached.currentness.observedPendingNonce
+    && fresh.transaction.method === cached.transaction.method
+    && fresh.transaction.chainId === cached.transaction.chainId
+    && fresh.transaction.from === cached.transaction.from
+    && fresh.transaction.to === cached.transaction.to
+    && fresh.transaction.nonce === cached.transaction.nonce
+    && fresh.transaction.gas === cached.transaction.gas
+    && fresh.transaction.data === cached.transaction.data
+    && fresh.transaction.value === cached.transaction.value;
+}
+
+export function hookemonBlocksNewSendV1(input: Readonly<{
+  attempts: readonly HookemonBrowserAttemptReadV1[];
+}>): boolean {
+  return input.attempts.some(({ kind }) => kind !== "none");
+}
+
+export function hookemonCanClearUncertainNoSendV1(input: Readonly<{
+  attempt: HookemonBrowserAttemptV1;
+  readyAction: HookemonBrowserWalletActionV1;
+}>): boolean {
+  return input.attempt.phase === "wallet-prompt-opened"
+    && input.attempt.transactionHash === null
+    && attemptMatchesAction(input.attempt, input.readyAction);
+}
+
+/**
+ * A local attempt is never cleared merely because the server advanced. Only
+ * exact matching finality archives it; every other divergence requires manual
+ * recovery so the Website cannot accidentally send the next action twice.
+ */
+export function reconcileHookemonBrowserAttemptV1(input: Readonly<{
+  attempt: HookemonBrowserAttemptV1 | null;
+  serverState: HookemonApplicantFlowStateV1;
+}>): HookemonAttemptReconciliationV1 {
+  const attempt = input.attempt;
+  if (attempt === null) return deepFreeze({
+    active: null,
+    archive: null,
+    archiveReason: null,
+    recoveryRequired: false,
+  });
+  const finalized = input.serverState.finalizedActions.find(
+    ({ actionIndex }) => actionIndex === attempt.actionIndex,
+  );
+  if (
+    finalized !== undefined
+    && attempt.transactionHash !== null
+    && finalized.selectorHash === attempt.selectorHash
+    && finalized.actionHash === attempt.actionHash
+    && finalized.transactionHash === attempt.transactionHash
+  ) return deepFreeze({
+    active: null,
+    archive: attempt,
+    archiveReason: "server-finalized",
+    recoveryRequired: false,
+  });
+  const pending = input.serverState.pendingAction;
+  if (
+    pending !== null
+    && attempt.transactionHash !== null
+    && pending.actionIndex === attempt.actionIndex
+    && pending.selectorHash === attempt.selectorHash
+    && pending.actionHash === attempt.actionHash
+    && pending.transactionHash === attempt.transactionHash
+  ) return deepFreeze({
+    active: attempt,
+    archive: null,
+    archiveReason: null,
+    recoveryRequired: false,
+  });
+  return deepFreeze({
+    active: attempt,
+    archive: null,
+    archiveReason: null,
+    recoveryRequired: true,
+  });
+}
+
+function parseAttempt(
+  raw: unknown,
+  binding: HookemonApplicantFlowBindingV1,
+): HookemonBrowserAttemptV1 {
+  const value = exactObject(raw, [
+    "actionHash", "actionIndex", "actionKind", "bindingHash", "createdAt",
+    "currentnessEvidenceHash", "dataHash", "from", "nonce", "phase",
+    "planHash", "schemaVersion", "selectorHash", "stateVersion",
+    "subjectHash", "to", "transactionHash",
+  ]);
+  const actionIndex = index(value.actionIndex);
+  const actionKind = kind(value.actionKind);
+  const transactionHash = value.transactionHash === null
+    ? null
+    : bytes32(value.transactionHash);
+  if (
+    value.schemaVersion !== "programmable.hookemon-browser-attempt.v1"
+    || value.bindingHash !== binding.bindingHash
+    || value.subjectHash !== binding.subjectHash
+    || value.planHash !== binding.planHash
+    || actionKind !== [
+      "ERC20_APPROVAL",
+      "EOA_CREATE",
+      "COMPLETED_GRAPH_ADOPTION",
+    ][actionIndex]
+    || (
+      value.phase !== "wallet-prompt-opened"
+      && value.phase !== "submitted"
+      && value.phase !== "reported"
+    )
+    || (value.phase === "wallet-prompt-opened") !== (transactionHash === null)
+  ) throw new TypeError("Hookemon browser attempt is invalid");
+  const from = address(value.from);
+  if (from !== binding.launchWallet) {
+    throw new TypeError("Hookemon browser attempt wallet drifted");
+  }
+  return deepFreeze({
+    schemaVersion: "programmable.hookemon-browser-attempt.v1",
+    bindingHash: binding.bindingHash,
+    subjectHash: binding.subjectHash,
+    planHash: binding.planHash,
+    stateVersion: uint(value.stateVersion),
+    actionIndex,
+    actionKind,
+    selectorHash: sha256(value.selectorHash),
+    actionHash: sha256(value.actionHash),
+    currentnessEvidenceHash: sha256(value.currentnessEvidenceHash),
+    dataHash: bytes32(value.dataHash),
+    from,
+    to: value.to === null ? null : address(value.to),
+    nonce: quantity(value.nonce),
+    createdAt: isoDate(value.createdAt),
+    transactionHash,
+    phase: value.phase,
+  });
+}
+
+function attemptMatchesAction(
+  attempt: HookemonBrowserAttemptV1,
+  action: HookemonBrowserWalletActionV1,
+): boolean {
+  return attempt.bindingHash === action.bindingHash
+    && attempt.stateVersion === action.stateVersion
+    && attempt.actionIndex === action.actionIndex
+    && attempt.actionKind === action.actionKind
+    && attempt.selectorHash === action.selectorHash
+    && attempt.actionHash === action.actionHash
+    && attempt.currentnessEvidenceHash === action.currentness.evidenceHash
+    && attempt.dataHash === action.dataHash
+    && attempt.from === action.transaction.from
+    && attempt.to === action.transaction.to
+    && attempt.nonce === action.transaction.nonce;
+}
+
+function exactObject(raw: unknown, keys: readonly string[]): Record<string, unknown> {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new TypeError("Hookemon browser attempt is not an object");
+  }
+  const actual = Reflect.ownKeys(raw);
+  const strings = actual.filter((key): key is string => typeof key === "string")
+    .sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== strings.length
+    || strings.length !== expected.length
+    || strings.some((key, position) => key !== expected[position])
+  ) throw new TypeError("Hookemon browser attempt has unexpected fields");
+  return raw as Record<string, unknown>;
+}
+
+function sha256(value: unknown): HookemonSha256V1 {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw new TypeError("Hookemon browser attempt SHA-256 is invalid");
+  }
+  return value as HookemonSha256V1;
+}
+
+function bytes32(value: unknown): HookemonBytes32V1 {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/u.test(value)) {
+    throw new TypeError("Hookemon browser attempt bytes32 is invalid");
+  }
+  return value.toLowerCase() as HookemonBytes32V1;
+}
+
+function address(value: unknown): HookemonAddressV1 {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{40}$/u.test(value)) {
+    throw new TypeError("Hookemon browser attempt address is invalid");
+  }
+  return value as HookemonAddressV1;
+}
+
+function uint(value: unknown): string {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    throw new TypeError("Hookemon browser attempt integer is invalid");
+  }
+  return value;
+}
+
+function quantity(value: unknown): `0x${string}` {
+  if (typeof value !== "string" || !/^0x(?:0|[1-9a-f][0-9a-f]*)$/u.test(value)) {
+    throw new TypeError("Hookemon browser attempt nonce is invalid");
+  }
+  return value as `0x${string}`;
+}
+
+function isoDate(value: unknown): string {
+  if (
+    typeof value !== "string"
+    || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u.test(value)
+    || Number.isNaN(Date.parse(value))
+  ) throw new TypeError("Hookemon browser attempt timestamp is invalid");
+  return value;
+}
+
+function index(value: unknown): 0 | 1 | 2 {
+  if (value !== 0 && value !== 1 && value !== 2) {
+    throw new TypeError("Hookemon browser attempt index is invalid");
+  }
+  return value;
+}
+
+function kind(value: unknown): HookemonBrowserAttemptV1["actionKind"] {
+  if (
+    value !== "ERC20_APPROVAL"
+    && value !== "EOA_CREATE"
+    && value !== "COMPLETED_GRAPH_ADOPTION"
+  ) throw new TypeError("Hookemon browser attempt kind is invalid");
+  return value;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(nested);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/custom-launch/hookemon-applicant-contract-v1.ts
+++ b/lib/custom-launch/hookemon-applicant-contract-v1.ts
@@ -1,0 +1,717 @@
+import {
+  getAddress,
+  isAddress,
+  keccak256,
+} from "viem";
+
+export const HOOKEMON_FLOW_STATE_SCHEMA_V1 =
+  "programmable.hookemon-applicant-flow-state-response.v1" as const;
+export const HOOKEMON_BROWSER_ACTION_SCHEMA_V1 =
+  "programmable.hookemon-browser-wallet-action.v1" as const;
+export const HOOKEMON_TRANSACTION_REPORT_SCHEMA_V1 =
+  "programmable.hookemon-applicant-transaction-report.v1" as const;
+export const HOOKEMON_FINALITY_REQUEST_SCHEMA_V1 =
+  "programmable.hookemon-applicant-finality-request.v1" as const;
+
+export const HOOKEMON_MAINNET_USDC =
+  "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const;
+export const HOOKEMON_APPROVE_SELECTOR = "0x095ea7b3" as const;
+
+export type HookemonSha256V1 = `sha256:${string}`;
+export type HookemonBytes32V1 = `0x${string}`;
+export type HookemonAddressV1 = `0x${string}`;
+export type HookemonActionKindV1 =
+  | "ERC20_APPROVAL"
+  | "EOA_CREATE"
+  | "COMPLETED_GRAPH_ADOPTION";
+
+export interface HookemonApplicantFlowBindingV1 {
+  readonly bindingHash: HookemonSha256V1;
+  readonly subjectHash: HookemonSha256V1;
+  readonly profileKey: HookemonBytes32V1;
+  readonly profileSchemaHash: HookemonBytes32V1;
+  readonly planHash: HookemonBytes32V1;
+  readonly sourceCommit: string;
+  readonly sourceTree: string;
+  readonly launchWallet: HookemonAddressV1;
+  readonly launcher: HookemonAddressV1;
+  readonly launcherInitCodeHash: HookemonBytes32V1;
+  readonly fundingUsdc: string;
+  readonly approvalNonce: string;
+  readonly launcherNonce: string;
+  readonly adoptionTarget: HookemonAddressV1;
+  readonly adoptionSelector: `0x${string}`;
+  readonly requiredConfirmations: number;
+}
+
+export interface HookemonActionCurrentnessV1 {
+  readonly schemaVersion: "programmable.hookemon-action-currentness.v1";
+  readonly kind: "PRE_APPROVAL" | "PRE_CREATE" | "PRE_ADOPTION";
+  readonly observedBlockNumber: string;
+  readonly observedBlockHash: HookemonBytes32V1;
+  readonly observedPendingNonce: `0x${string}`;
+  readonly evidenceHash: HookemonSha256V1;
+  readonly previousFinalityEvidenceHash: HookemonSha256V1 | null;
+  readonly completedGraphHash: HookemonBytes32V1 | null;
+  readonly currentPoolStateHash: HookemonBytes32V1 | null;
+  readonly runtimeStatusHash: HookemonSha256V1 | null;
+}
+
+export interface HookemonBrowserWalletActionV1 {
+  readonly schemaVersion: typeof HOOKEMON_BROWSER_ACTION_SCHEMA_V1;
+  readonly bindingHash: HookemonSha256V1;
+  readonly stateVersion: string;
+  readonly actionIndex: 0 | 1 | 2;
+  readonly actionKind: HookemonActionKindV1;
+  readonly selectorHash: HookemonSha256V1;
+  readonly actionHash: HookemonSha256V1;
+  readonly dataHash: HookemonBytes32V1;
+  readonly previousFinalityEvidenceHash: HookemonSha256V1 | null;
+  readonly permitDigest: HookemonBytes32V1 | null;
+  readonly validAfterEpochSeconds: string;
+  readonly expiresAtEpochSeconds: string;
+  readonly currentness: HookemonActionCurrentnessV1;
+  readonly transaction: Readonly<{
+    method: "eth_sendTransaction";
+    chainId: "0x1";
+    from: HookemonAddressV1;
+    to: HookemonAddressV1 | null;
+    nonce: `0x${string}`;
+    gas: `0x${string}`;
+    data: `0x${string}`;
+    value: "0x0";
+  }>;
+}
+
+export interface HookemonFinalizedActionV1 {
+  readonly schemaVersion: "programmable.hookemon-action-finality.v1";
+  readonly actionIndex: 0 | 1 | 2;
+  readonly actionKind: HookemonActionKindV1;
+  readonly selectorHash: HookemonSha256V1;
+  readonly actionHash: HookemonSha256V1;
+  readonly transactionHash: HookemonBytes32V1;
+  readonly blockNumber: string;
+  readonly blockHash: HookemonBytes32V1;
+  readonly confirmations: number;
+  readonly receiptEvidenceHash: HookemonSha256V1;
+  readonly finalityEvidenceHash: HookemonSha256V1;
+  readonly resultHash: HookemonBytes32V1;
+}
+
+export interface HookemonReportedActionV1 {
+  readonly schemaVersion: "programmable.hookemon-reported-action.v1";
+  readonly actionIndex: 0 | 1 | 2;
+  readonly actionKind: HookemonActionKindV1;
+  readonly selectorHash: HookemonSha256V1;
+  readonly actionHash: HookemonSha256V1;
+  readonly transactionHash: HookemonBytes32V1;
+  readonly reportedAtEpochSeconds: string;
+}
+
+export type HookemonFlowStateNameV1 =
+  | "PLAN_ACCEPTANCE_REQUIRED"
+  | "APPROVAL_READY"
+  | "APPROVAL_SUBMITTED"
+  | "CREATE_READY"
+  | "CREATE_SUBMITTED"
+  | "GRAPH_CURRENTNESS_PENDING"
+  | "ADOPTION_READY"
+  | "ADOPTION_SUBMITTED"
+  | "FINALIZED"
+  | "BLOCKED";
+
+export interface HookemonApplicantFlowStateV1 {
+  readonly schemaVersion: typeof HOOKEMON_FLOW_STATE_SCHEMA_V1;
+  readonly bindingHash: HookemonSha256V1;
+  readonly subjectHash: HookemonSha256V1;
+  readonly planHash: HookemonBytes32V1;
+  readonly profileKey: HookemonBytes32V1;
+  readonly stateVersion: string;
+  readonly state: HookemonFlowStateNameV1;
+  readonly finalizedActions: readonly HookemonFinalizedActionV1[];
+  readonly pendingAction: HookemonReportedActionV1 | null;
+  readonly readyAction: HookemonBrowserWalletActionV1 | null;
+  readonly blocker: Readonly<{
+    code: string;
+    owner: "platform" | "applicant" | "provider" | "funding";
+    retryable: boolean;
+  }> | null;
+}
+
+const ACTION_KINDS = Object.freeze([
+  "ERC20_APPROVAL",
+  "EOA_CREATE",
+  "COMPLETED_GRAPH_ADOPTION",
+] as const);
+const CURRENTNESS_KINDS = Object.freeze([
+  "PRE_APPROVAL",
+  "PRE_CREATE",
+  "PRE_ADOPTION",
+] as const);
+
+export function assertHookemonApplicantFlowBindingV1(
+  raw: HookemonApplicantFlowBindingV1,
+): HookemonApplicantFlowBindingV1 {
+  const value = exactObject(raw, [
+    "adoptionSelector", "adoptionTarget", "approvalNonce", "bindingHash",
+    "fundingUsdc", "launchWallet", "launcher", "launcherInitCodeHash",
+    "launcherNonce", "planHash", "profileKey", "profileSchemaHash",
+    "requiredConfirmations", "sourceCommit", "sourceTree", "subjectHash",
+  ], "Hookemon flow binding");
+  const approvalNonce = uint(value.approvalNonce);
+  const launcherNonce = uint(value.launcherNonce);
+  const requiredConfirmations = safePositiveInteger(
+    value.requiredConfirmations,
+    "Hookemon finality depth",
+  );
+  if (
+    BigInt(launcherNonce) !== BigInt(approvalNonce) + 1n
+    || requiredConfirmations > 10_000
+  ) throw invalid("Hookemon flow nonce or finality binding is invalid");
+  return deepFreeze({
+    bindingHash: sha256(value.bindingHash),
+    subjectHash: sha256(value.subjectHash),
+    profileKey: bytes32(value.profileKey),
+    profileSchemaHash: bytes32(value.profileSchemaHash),
+    planHash: bytes32(value.planHash),
+    sourceCommit: gitSha(value.sourceCommit),
+    sourceTree: gitSha(value.sourceTree),
+    launchWallet: address(value.launchWallet),
+    launcher: address(value.launcher),
+    launcherInitCodeHash: bytes32(value.launcherInitCodeHash),
+    fundingUsdc: positiveUint(value.fundingUsdc),
+    approvalNonce,
+    launcherNonce,
+    adoptionTarget: address(value.adoptionTarget),
+    adoptionSelector: selector(value.adoptionSelector),
+    requiredConfirmations,
+  });
+}
+
+export function parseHookemonApplicantFlowStateV1(
+  raw: unknown,
+  expectedBinding: HookemonApplicantFlowBindingV1,
+  currentEpochSeconds: string,
+): HookemonApplicantFlowStateV1 {
+  const binding = assertHookemonApplicantFlowBindingV1(expectedBinding);
+  const value = exactObject(raw, [
+    "bindingHash", "blocker", "finalizedActions", "pendingAction",
+    "planHash", "profileKey", "readyAction", "schemaVersion", "state",
+    "stateVersion", "subjectHash",
+  ], "Hookemon flow state");
+  if (
+    value.schemaVersion !== HOOKEMON_FLOW_STATE_SCHEMA_V1
+    || value.bindingHash !== binding.bindingHash
+    || value.subjectHash !== binding.subjectHash
+    || value.planHash !== binding.planHash
+    || value.profileKey !== binding.profileKey
+  ) throw invalid("Hookemon flow state binding is invalid");
+  const state = flowState(value.state);
+  const stateVersion = uint(value.stateVersion);
+  if (!Array.isArray(value.finalizedActions)) {
+    throw invalid("Hookemon finalized actions are invalid");
+  }
+  const finalizedActions = value.finalizedActions.map((entry, index) =>
+    parseFinalizedAction(entry, index, binding));
+  const pendingAction = value.pendingAction === null
+    ? null
+    : parseReportedAction(value.pendingAction, binding);
+  const readyAction = value.readyAction === null
+    ? null
+    : parseHookemonBrowserWalletActionV1(
+        value.readyAction,
+        binding,
+        currentEpochSeconds,
+      );
+  const blocker = value.blocker === null ? null : parseBlocker(value.blocker);
+  assertStateShape({
+    state,
+    finalizedActions,
+    pendingAction,
+    readyAction,
+    blocker,
+  });
+  if (
+    readyAction !== null
+    && (
+      readyAction.stateVersion !== stateVersion
+      || readyAction.previousFinalityEvidenceHash
+        !== (finalizedActions.at(-1)?.finalityEvidenceHash ?? null)
+    )
+  ) throw invalid("Hookemon ready action selector is stale");
+  return deepFreeze({
+    schemaVersion: HOOKEMON_FLOW_STATE_SCHEMA_V1,
+    bindingHash: binding.bindingHash,
+    subjectHash: binding.subjectHash,
+    planHash: binding.planHash,
+    profileKey: binding.profileKey,
+    stateVersion,
+    state,
+    finalizedActions,
+    pendingAction,
+    readyAction,
+    blocker,
+  });
+}
+
+export function parseHookemonBrowserWalletActionV1(
+  raw: unknown,
+  expectedBinding: HookemonApplicantFlowBindingV1,
+  currentEpochSeconds: string,
+): HookemonBrowserWalletActionV1 {
+  const binding = assertHookemonApplicantFlowBindingV1(expectedBinding);
+  const value = exactObject(raw, [
+    "actionHash", "actionIndex", "actionKind", "bindingHash", "currentness",
+    "dataHash", "expiresAtEpochSeconds", "permitDigest",
+    "previousFinalityEvidenceHash", "schemaVersion", "selectorHash",
+    "stateVersion", "transaction", "validAfterEpochSeconds",
+  ], "Hookemon browser action");
+  if (
+    value.schemaVersion !== HOOKEMON_BROWSER_ACTION_SCHEMA_V1
+    || value.bindingHash !== binding.bindingHash
+  ) throw invalid("Hookemon browser action binding is invalid");
+  const actionIndex = actionIndexValue(value.actionIndex);
+  const actionKind = actionKindValue(value.actionKind);
+  if (ACTION_KINDS[actionIndex] !== actionKind) {
+    throw invalid("Hookemon browser action order is invalid");
+  }
+  const validAfterEpochSeconds = uint(value.validAfterEpochSeconds);
+  const expiresAtEpochSeconds = uint(value.expiresAtEpochSeconds);
+  const now = BigInt(uint(currentEpochSeconds));
+  if (
+    BigInt(validAfterEpochSeconds) > now
+    || now >= BigInt(expiresAtEpochSeconds)
+    || BigInt(expiresAtEpochSeconds) - BigInt(validAfterEpochSeconds) > 3_600n
+  ) throw invalid("Hookemon browser action is not current");
+  const previousFinalityEvidenceHash = nullableSha256(
+    value.previousFinalityEvidenceHash,
+  );
+  const permitDigest = nullableBytes32(value.permitDigest);
+  const currentness = parseCurrentness(value.currentness, actionIndex);
+  if (
+    currentness.previousFinalityEvidenceHash !== previousFinalityEvidenceHash
+    || (actionIndex === 0 && previousFinalityEvidenceHash !== null)
+    || (actionIndex > 0 && previousFinalityEvidenceHash === null)
+    || (actionIndex === 2) !== (permitDigest !== null)
+  ) throw invalid("Hookemon browser action predecessor or permit is invalid");
+  const transaction = parseTransaction(value.transaction, actionIndex, binding);
+  if (currentness.observedPendingNonce !== transaction.nonce) {
+    throw invalid("Hookemon browser action nonce is not current");
+  }
+  const dataHash = bytes32(value.dataHash);
+  if (keccak256(transaction.data) !== dataHash) {
+    throw invalid("Hookemon browser action data hash is invalid");
+  }
+  if (actionIndex === 1 && dataHash !== binding.launcherInitCodeHash) {
+    throw invalid("Hookemon launcher init code drifted");
+  }
+  // V2.2 adoption has a nested permit, plan, stamp request, 23-component
+  // graph, edge vector and signature. A target, selector and data hash are not
+  // sufficient browser authority. Keep this step unavailable until the exact
+  // frozen ABI decoder recomputes every binding and byte-for-byte re-encodes
+  // the calldata in this client bundle.
+  if (actionIndex === 2) {
+    throw invalid("Hookemon V2.2 adoption decoder is unavailable");
+  }
+  return deepFreeze({
+    schemaVersion: HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
+    bindingHash: binding.bindingHash,
+    stateVersion: uint(value.stateVersion),
+    actionIndex,
+    actionKind,
+    selectorHash: sha256(value.selectorHash),
+    actionHash: sha256(value.actionHash),
+    dataHash,
+    previousFinalityEvidenceHash,
+    permitDigest,
+    validAfterEpochSeconds,
+    expiresAtEpochSeconds,
+    currentness,
+    transaction,
+  });
+}
+
+export function createHookemonTransactionReportV1(
+  action: HookemonBrowserWalletActionV1,
+  transactionHash: HookemonBytes32V1,
+) {
+  return deepFreeze({
+    schemaVersion: HOOKEMON_TRANSACTION_REPORT_SCHEMA_V1,
+    bindingHash: action.bindingHash,
+    stateVersion: action.stateVersion,
+    actionIndex: action.actionIndex,
+    actionKind: action.actionKind,
+    selectorHash: action.selectorHash,
+    actionHash: action.actionHash,
+    transactionHash: bytes32(transactionHash),
+  });
+}
+
+export function createHookemonFinalityRequestV1(
+  action: HookemonBrowserWalletActionV1,
+  transactionHash: HookemonBytes32V1,
+) {
+  return deepFreeze({
+    ...createHookemonTransactionReportV1(action, transactionHash),
+    schemaVersion: HOOKEMON_FINALITY_REQUEST_SCHEMA_V1,
+  });
+}
+
+function parseTransaction(
+  raw: unknown,
+  actionIndex: 0 | 1 | 2,
+  binding: HookemonApplicantFlowBindingV1,
+): HookemonBrowserWalletActionV1["transaction"] {
+  const value = exactObject(raw, [
+    "chainId", "data", "from", "gas", "method", "nonce", "to", "value",
+  ], "Hookemon transaction");
+  const from = address(value.from);
+  const to = value.to === null ? null : address(value.to);
+  const nonce = rpcQuantity(value.nonce);
+  const gas = rpcQuantity(value.gas);
+  const data = evenHex(value.data, actionIndex === 1);
+  if (
+    value.method !== "eth_sendTransaction"
+    || value.chainId !== "0x1"
+    || from !== binding.launchWallet
+    || value.value !== "0x0"
+    || BigInt(gas) === 0n
+    || BigInt(gas) > 16_777_216n
+  ) throw invalid("Hookemon transaction envelope is invalid");
+  if (actionIndex === 0) {
+    assertApprovalData(data, binding);
+    if (to !== getAddress(HOOKEMON_MAINNET_USDC)
+      || BigInt(nonce) !== BigInt(binding.approvalNonce)) {
+      throw invalid("Hookemon approval transaction is invalid");
+    }
+  } else if (actionIndex === 1) {
+    if (to !== null || BigInt(nonce) !== BigInt(binding.launcherNonce)) {
+      throw invalid("Hookemon CREATE transaction is invalid");
+    }
+  } else if (
+    to !== binding.adoptionTarget
+    || !data.startsWith(binding.adoptionSelector)
+  ) throw invalid("Hookemon adoption transaction is invalid");
+  return deepFreeze({
+    method: "eth_sendTransaction",
+    chainId: "0x1",
+    from,
+    to,
+    nonce,
+    gas,
+    data,
+    value: "0x0",
+  });
+}
+
+function assertApprovalData(
+  data: `0x${string}`,
+  binding: HookemonApplicantFlowBindingV1,
+): void {
+  if (data.length !== 138 || !data.startsWith(HOOKEMON_APPROVE_SELECTOR)) {
+    throw invalid("Hookemon approval calldata is invalid");
+  }
+  const spenderWord = data.slice(10, 74);
+  const amountWord = data.slice(74, 138);
+  const spender = address(`0x${spenderWord.slice(24)}`);
+  if (
+    spender !== binding.launcher
+    || BigInt(`0x${amountWord}`) !== BigInt(binding.fundingUsdc)
+  ) throw invalid("Hookemon approval spender or amount is invalid");
+}
+
+function parseCurrentness(
+  raw: unknown,
+  actionIndex: 0 | 1 | 2,
+): HookemonActionCurrentnessV1 {
+  const value = exactObject(raw, [
+    "completedGraphHash", "currentPoolStateHash", "evidenceHash", "kind",
+    "observedBlockHash", "observedBlockNumber", "observedPendingNonce",
+    "previousFinalityEvidenceHash", "runtimeStatusHash", "schemaVersion",
+  ], "Hookemon action currentness");
+  if (
+    value.schemaVersion !== "programmable.hookemon-action-currentness.v1"
+    || value.kind !== CURRENTNESS_KINDS[actionIndex]
+  ) throw invalid("Hookemon currentness kind is invalid");
+  const previousFinalityEvidenceHash = nullableSha256(
+    value.previousFinalityEvidenceHash,
+  );
+  const completedGraphHash = nullableBytes32(value.completedGraphHash);
+  const currentPoolStateHash = nullableBytes32(value.currentPoolStateHash);
+  const runtimeStatusHash = nullableSha256(value.runtimeStatusHash);
+  if (
+    actionIndex < 2
+      ? completedGraphHash !== null
+        || currentPoolStateHash !== null
+        || runtimeStatusHash !== null
+      : completedGraphHash === null
+        || currentPoolStateHash === null
+        || runtimeStatusHash === null
+  ) throw invalid("Hookemon currentness evidence is incomplete");
+  return deepFreeze({
+    schemaVersion: "programmable.hookemon-action-currentness.v1",
+    kind: CURRENTNESS_KINDS[actionIndex],
+    observedBlockNumber: uint(value.observedBlockNumber),
+    observedBlockHash: bytes32(value.observedBlockHash),
+    observedPendingNonce: rpcQuantity(value.observedPendingNonce),
+    evidenceHash: sha256(value.evidenceHash),
+    previousFinalityEvidenceHash,
+    completedGraphHash,
+    currentPoolStateHash,
+    runtimeStatusHash,
+  });
+}
+
+function parseFinalizedAction(
+  raw: unknown,
+  expectedIndex: number,
+  binding: HookemonApplicantFlowBindingV1,
+): HookemonFinalizedActionV1 {
+  const value = exactObject(raw, [
+    "actionHash", "actionIndex", "actionKind", "blockHash", "blockNumber",
+    "confirmations", "finalityEvidenceHash", "receiptEvidenceHash",
+    "resultHash", "schemaVersion", "selectorHash", "transactionHash",
+  ], "Hookemon action finality");
+  const actionIndex = actionIndexValue(value.actionIndex);
+  const actionKind = actionKindValue(value.actionKind);
+  const confirmations = safePositiveInteger(
+    value.confirmations,
+    "Hookemon action confirmations",
+  );
+  if (
+    value.schemaVersion !== "programmable.hookemon-action-finality.v1"
+    || actionIndex !== expectedIndex
+    || actionKind !== ACTION_KINDS[actionIndex]
+    || confirmations < binding.requiredConfirmations
+  ) throw invalid("Hookemon action finality is invalid");
+  return deepFreeze({
+    schemaVersion: "programmable.hookemon-action-finality.v1",
+    actionIndex,
+    actionKind,
+    selectorHash: sha256(value.selectorHash),
+    actionHash: sha256(value.actionHash),
+    transactionHash: bytes32(value.transactionHash),
+    blockNumber: uint(value.blockNumber),
+    blockHash: bytes32(value.blockHash),
+    confirmations,
+    receiptEvidenceHash: sha256(value.receiptEvidenceHash),
+    finalityEvidenceHash: sha256(value.finalityEvidenceHash),
+    resultHash: bytes32(value.resultHash),
+  });
+}
+
+function parseReportedAction(
+  raw: unknown,
+  binding: HookemonApplicantFlowBindingV1,
+): HookemonReportedActionV1 {
+  const value = exactObject(raw, [
+    "actionHash", "actionIndex", "actionKind", "reportedAtEpochSeconds",
+    "schemaVersion", "selectorHash", "transactionHash",
+  ], "Hookemon reported action");
+  void binding;
+  const actionIndex = actionIndexValue(value.actionIndex);
+  const actionKind = actionKindValue(value.actionKind);
+  if (
+    value.schemaVersion !== "programmable.hookemon-reported-action.v1"
+    || actionKind !== ACTION_KINDS[actionIndex]
+  ) throw invalid("Hookemon reported action is invalid");
+  return deepFreeze({
+    schemaVersion: "programmable.hookemon-reported-action.v1",
+    actionIndex,
+    actionKind,
+    selectorHash: sha256(value.selectorHash),
+    actionHash: sha256(value.actionHash),
+    transactionHash: bytes32(value.transactionHash),
+    reportedAtEpochSeconds: uint(value.reportedAtEpochSeconds),
+  });
+}
+
+function parseBlocker(raw: unknown): NonNullable<HookemonApplicantFlowStateV1["blocker"]> {
+  const value = exactObject(raw, ["code", "owner", "retryable"], "Hookemon blocker");
+  if (
+    typeof value.code !== "string"
+    || !/^[a-z][a-z0-9_]{2,63}$/u.test(value.code)
+    || !["platform", "applicant", "provider", "funding"].includes(
+      String(value.owner),
+    )
+    || typeof value.retryable !== "boolean"
+  ) throw invalid("Hookemon blocker is invalid");
+  return deepFreeze({
+    code: value.code,
+    owner: value.owner as "platform" | "applicant" | "provider" | "funding",
+    retryable: value.retryable,
+  });
+}
+
+function assertStateShape(input: Readonly<{
+  state: HookemonFlowStateNameV1;
+  finalizedActions: readonly HookemonFinalizedActionV1[];
+  pendingAction: HookemonReportedActionV1 | null;
+  readyAction: HookemonBrowserWalletActionV1 | null;
+  blocker: HookemonApplicantFlowStateV1["blocker"];
+}>): void {
+  const count = input.finalizedActions.length;
+  const expected: readonly [
+    number,
+    number | null,
+    number | null,
+    boolean,
+  ] = input.state === "PLAN_ACCEPTANCE_REQUIRED" ? [0, null, null, false]
+    : input.state === "APPROVAL_READY" ? [0, null, 0, false]
+      : input.state === "APPROVAL_SUBMITTED" ? [0, 0, null, false]
+        : input.state === "CREATE_READY" ? [1, null, 1, false]
+          : input.state === "CREATE_SUBMITTED" ? [1, 1, null, false]
+            : input.state === "GRAPH_CURRENTNESS_PENDING"
+              ? [2, null, null, false]
+              : input.state === "ADOPTION_READY" ? [2, null, 2, false]
+                : input.state === "ADOPTION_SUBMITTED"
+                  ? [2, 2, null, false]
+                  : input.state === "FINALIZED" ? [3, null, null, false]
+                    : [count, null, null, true];
+  if (
+    count !== expected[0]
+    || (input.pendingAction?.actionIndex ?? null) !== expected[1]
+    || (input.readyAction?.actionIndex ?? null) !== expected[2]
+    || (input.blocker !== null) !== expected[3]
+  ) throw invalid("Hookemon flow state has competing dispositions");
+}
+
+function flowState(value: unknown): HookemonFlowStateNameV1 {
+  const states: readonly HookemonFlowStateNameV1[] = [
+    "PLAN_ACCEPTANCE_REQUIRED", "APPROVAL_READY", "APPROVAL_SUBMITTED",
+    "CREATE_READY", "CREATE_SUBMITTED", "GRAPH_CURRENTNESS_PENDING",
+    "ADOPTION_READY", "ADOPTION_SUBMITTED", "FINALIZED", "BLOCKED",
+  ];
+  if (!states.includes(value as HookemonFlowStateNameV1)) {
+    throw invalid("Hookemon flow state is invalid");
+  }
+  return value as HookemonFlowStateNameV1;
+}
+
+function actionIndexValue(value: unknown): 0 | 1 | 2 {
+  if (value !== 0 && value !== 1 && value !== 2) {
+    throw invalid("Hookemon action index is invalid");
+  }
+  return value;
+}
+
+function actionKindValue(value: unknown): HookemonActionKindV1 {
+  if (!ACTION_KINDS.includes(value as HookemonActionKindV1)) {
+    throw invalid("Hookemon action kind is invalid");
+  }
+  return value as HookemonActionKindV1;
+}
+
+function exactObject(
+  raw: unknown,
+  expectedKeys: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid(`${label} is invalid`);
+  }
+  const keys = Reflect.ownKeys(raw);
+  const strings = keys.filter((key): key is string => typeof key === "string")
+    .sort();
+  const expected = [...expectedKeys].sort();
+  if (
+    keys.length !== strings.length
+    || strings.length !== expected.length
+    || strings.some((key, index) => key !== expected[index])
+  ) throw invalid(`${label} has unexpected fields`);
+  return raw as Record<string, unknown>;
+}
+
+function address(value: unknown): HookemonAddressV1 {
+  if (typeof value !== "string" || !isAddress(value, { strict: true })) {
+    throw invalid("Hookemon address is invalid");
+  }
+  return getAddress(value);
+}
+
+function bytes32(value: unknown): HookemonBytes32V1 {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/u.test(value)) {
+    throw invalid("Hookemon bytes32 is invalid");
+  }
+  return value.toLowerCase() as HookemonBytes32V1;
+}
+
+function nullableBytes32(value: unknown): HookemonBytes32V1 | null {
+  return value === null ? null : bytes32(value);
+}
+
+function sha256(value: unknown): HookemonSha256V1 {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw invalid("Hookemon SHA-256 is invalid");
+  }
+  return value as HookemonSha256V1;
+}
+
+function nullableSha256(value: unknown): HookemonSha256V1 | null {
+  return value === null ? null : sha256(value);
+}
+
+function uint(value: unknown): string {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    throw invalid("Hookemon unsigned integer is invalid");
+  }
+  return value;
+}
+
+function positiveUint(value: unknown): string {
+  const parsed = uint(value);
+  if (BigInt(parsed) === 0n) throw invalid("Hookemon amount is invalid");
+  return parsed;
+}
+
+function safePositiveInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 1) {
+    throw invalid(`${label} is invalid`);
+  }
+  return Number(value);
+}
+
+function rpcQuantity(value: unknown): `0x${string}` {
+  if (
+    typeof value !== "string"
+    || !/^0x(?:0|[1-9a-f][0-9a-f]*)$/u.test(value)
+  ) throw invalid("Hookemon RPC quantity is invalid");
+  return value as `0x${string}`;
+}
+
+function evenHex(value: unknown, nonEmpty = false): `0x${string}` {
+  if (
+    typeof value !== "string"
+    || !/^0x(?:[0-9a-f]{2})*$/u.test(value)
+    || (nonEmpty && value === "0x")
+  ) throw invalid("Hookemon transaction data is invalid");
+  return value as `0x${string}`;
+}
+
+function selector(value: unknown): `0x${string}` {
+  if (typeof value !== "string" || !/^0x[0-9a-f]{8}$/u.test(value)) {
+    throw invalid("Hookemon adoption selector is invalid");
+  }
+  return value as `0x${string}`;
+}
+
+function gitSha(value: unknown): string {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/u.test(value)) {
+    throw invalid("Hookemon source revision is invalid");
+  }
+  return value;
+}
+
+function invalid(message: string): TypeError {
+  return new TypeError(message);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(nested);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/custom-launch/hookemon-applicant-contract-v1.ts
+++ b/lib/custom-launch/hookemon-applicant-contract-v1.ts
@@ -1,5 +1,6 @@
 import {
   getAddress,
+  getCreateAddress,
   isAddress,
   keccak256,
 } from "viem";
@@ -152,6 +153,7 @@ const CURRENTNESS_KINDS = Object.freeze([
   "PRE_CREATE",
   "PRE_ADOPTION",
 ] as const);
+const VALIDATED_BROWSER_ACTIONS_V1 = new WeakSet<HookemonBrowserWalletActionV1>();
 
 export function assertHookemonApplicantFlowBindingV1(
   raw: HookemonApplicantFlowBindingV1,
@@ -164,12 +166,18 @@ export function assertHookemonApplicantFlowBindingV1(
   ], "Hookemon flow binding");
   const approvalNonce = uint(value.approvalNonce);
   const launcherNonce = uint(value.launcherNonce);
+  const launchWallet = address(value.launchWallet);
+  const launcher = address(value.launcher);
   const requiredConfirmations = safePositiveInteger(
     value.requiredConfirmations,
     "Hookemon finality depth",
   );
   if (
     BigInt(launcherNonce) !== BigInt(approvalNonce) + 1n
+    || launcher !== getCreateAddress({
+      from: launchWallet,
+      nonce: BigInt(launcherNonce),
+    })
     || requiredConfirmations > 10_000
   ) throw invalid("Hookemon flow nonce or finality binding is invalid");
   return deepFreeze({
@@ -180,8 +188,8 @@ export function assertHookemonApplicantFlowBindingV1(
     planHash: bytes32(value.planHash),
     sourceCommit: gitSha(value.sourceCommit),
     sourceTree: gitSha(value.sourceTree),
-    launchWallet: address(value.launchWallet),
-    launcher: address(value.launcher),
+    launchWallet,
+    launcher,
     launcherInitCodeHash: bytes32(value.launcherInitCodeHash),
     fundingUsdc: positiveUint(value.fundingUsdc),
     approvalNonce,
@@ -316,7 +324,7 @@ export function parseHookemonBrowserWalletActionV1(
       expectedCalldataHash: dataHash,
     });
   }
-  return deepFreeze({
+  const parsed = deepFreeze({
     schemaVersion: HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
     bindingHash: binding.bindingHash,
     stateVersion: uint(value.stateVersion),
@@ -332,6 +340,23 @@ export function parseHookemonBrowserWalletActionV1(
     currentness,
     transaction,
   });
+  VALIDATED_BROWSER_ACTIONS_V1.add(parsed);
+  return parsed;
+}
+
+export function revalidateHookemonBrowserWalletActionForSendV1(
+  action: HookemonBrowserWalletActionV1,
+  expectedBinding: HookemonApplicantFlowBindingV1,
+  currentEpochSeconds: string,
+): HookemonBrowserWalletActionV1 {
+  if (!VALIDATED_BROWSER_ACTIONS_V1.has(action)) {
+    throw invalid("Hookemon browser action was not runtime-validated");
+  }
+  return parseHookemonBrowserWalletActionV1(
+    action,
+    expectedBinding,
+    currentEpochSeconds,
+  );
 }
 
 export function createHookemonTransactionReportV1(
@@ -411,16 +436,16 @@ function assertApprovalData(
   data: `0x${string}`,
   binding: HookemonApplicantFlowBindingV1,
 ): void {
-  if (data.length !== 138 || !data.startsWith(HOOKEMON_APPROVE_SELECTOR)) {
+  const amount = BigInt(binding.fundingUsdc);
+  if (amount >= 1n << 256n) {
+    throw invalid("Hookemon approval amount is invalid");
+  }
+  const canonicalData = `${HOOKEMON_APPROVE_SELECTOR}${binding.launcher
+    .slice(2).toLowerCase().padStart(64, "0")}${amount
+    .toString(16).padStart(64, "0")}`;
+  if (data !== canonicalData) {
     throw invalid("Hookemon approval calldata is invalid");
   }
-  const spenderWord = data.slice(10, 74);
-  const amountWord = data.slice(74, 138);
-  const spender = address(`0x${spenderWord.slice(24)}`);
-  if (
-    spender !== binding.launcher
-    || BigInt(`0x${amountWord}`) !== BigInt(binding.fundingUsdc)
-  ) throw invalid("Hookemon approval spender or amount is invalid");
 }
 
 function parseCurrentness(

--- a/lib/custom-launch/hookemon-applicant-contract-v1.ts
+++ b/lib/custom-launch/hookemon-applicant-contract-v1.ts
@@ -4,6 +4,10 @@ import {
   keccak256,
 } from "viem";
 
+import {
+  verifyHookemonAdoptionCalldataV22,
+} from "./hookemon-adoption-verifier-v22";
+
 export const HOOKEMON_FLOW_STATE_SCHEMA_V1 =
   "programmable.hookemon-applicant-flow-state-response.v1" as const;
 export const HOOKEMON_BROWSER_ACTION_SCHEMA_V1 =
@@ -305,13 +309,12 @@ export function parseHookemonBrowserWalletActionV1(
   if (actionIndex === 1 && dataHash !== binding.launcherInitCodeHash) {
     throw invalid("Hookemon launcher init code drifted");
   }
-  // V2.2 adoption has a nested permit, plan, stamp request, 23-component
-  // graph, edge vector and signature. A target, selector and data hash are not
-  // sufficient browser authority. Keep this step unavailable until the exact
-  // frozen ABI decoder recomputes every binding and byte-for-byte re-encodes
-  // the calldata in this client bundle.
   if (actionIndex === 2) {
-    throw invalid("Hookemon V2.2 adoption decoder is unavailable");
+    verifyHookemonAdoptionCalldataV22({
+      calldata: transaction.data,
+      expectedSelector: binding.adoptionSelector,
+      expectedCalldataHash: dataHash,
+    });
   }
   return deepFreeze({
     schemaVersion: HOOKEMON_BROWSER_ACTION_SCHEMA_V1,

--- a/lib/custom-launch/hookemon-applicant-presentation-v1.ts
+++ b/lib/custom-launch/hookemon-applicant-presentation-v1.ts
@@ -1,0 +1,29 @@
+export const HOOKEMON_APPLICANT_IDENTITY_V1 = Object.freeze({
+  githubLogin: "hookemonv4",
+  githubUserId: "312745360",
+  githubNodeId: "U_kgDOEqQdkA",
+  repository: "hookemonv4/hookemon",
+  repositoryId: "1324982531",
+  requestPath: "submissions/requests/1324982531-hookemon.json",
+  submissionSchemaId: "urn:programmable:applicant-submission:1.1.0",
+  submissionSchemaVersion: "1.1.0",
+  launchWallet: "0x5E9a7A24DCCC81cddd10b8a555300E227533c89f",
+  sourceCommit: "23336e60ae5859dbb0ae9c0db3399af4ef4af8e8",
+  sourceTree: "7624bde3bb09f654e77881880c419e356ed85c29",
+} as const);
+
+export const HOOKEMON_APPLICANT_ACTION_ORDER_V1 = Object.freeze([
+  "ERC20_APPROVAL",
+  "EOA_CREATE",
+  "COMPLETED_GRAPH_ADOPTION",
+] as const);
+
+/**
+ * Presentation routing only. Server authority must independently bind the
+ * immutable numeric GitHub identity, repository, source, wallet and profile.
+ */
+export function isExactHookemonApplicantGithubLoginV1(
+  login: string | null,
+): boolean {
+  return login?.toLowerCase() === HOOKEMON_APPLICANT_IDENTITY_V1.githubLogin;
+}

--- a/lib/custom-launch/hookemon-authority-envelope-v1.ts
+++ b/lib/custom-launch/hookemon-authority-envelope-v1.ts
@@ -530,7 +530,13 @@ function ed25519SignatureBytes(value: `ed25519:${string}`): Uint8Array {
     throw invalid("Hookemon Ed25519 signature encoding is invalid");
   }
   const bytes = Uint8Array.from(decoded, (character) => character.charCodeAt(0));
-  if (bytes.length !== 64) throw invalid("Hookemon Ed25519 signature length is invalid");
+  const canonical = btoa(String.fromCharCode(...bytes))
+    .replace(/\+/gu, "-")
+    .replace(/\//gu, "_")
+    .replace(/=+$/u, "");
+  if (bytes.length !== 64 || canonical !== encoded) {
+    throw invalid("Hookemon Ed25519 signature length or encoding is invalid");
+  }
   return bytes;
 }
 

--- a/lib/custom-launch/hookemon-authority-envelope-v1.ts
+++ b/lib/custom-launch/hookemon-authority-envelope-v1.ts
@@ -1,0 +1,559 @@
+import { bytesToHex, sha256 as rawSha256, stringToBytes } from "viem";
+
+export const HOOKEMON_ACTION_SELECTOR_SCHEMA_V1 =
+  "programmable.hookemon-action-selector.v1" as const;
+export const HOOKEMON_BROWSER_ACTION_SCHEMA_V1 =
+  "programmable.hookemon-browser-wallet-action.v1" as const;
+export const HOOKEMON_ACTION_AUTHORITY_ENVELOPE_SCHEMA_V1 =
+  "programmable.hookemon-action-authority-envelope.v1" as const;
+export const HOOKEMON_ACTION_AUTHORITY_SIGNING_DOMAIN_V1 =
+  "programmable.hookemon-action-authority-envelope-signing.v1" as const;
+
+export type HookemonEnvelopeSha256V1 = `sha256:${string}`;
+export type HookemonEnvelopeBytes32V1 = `0x${string}`;
+export type HookemonEnvelopeActionKindV1 =
+  | "ERC20_APPROVAL"
+  | "EOA_CREATE"
+  | "COMPLETED_GRAPH_ADOPTION";
+
+export interface HookemonActionSelectorCoreV1 {
+  readonly schemaVersion: typeof HOOKEMON_ACTION_SELECTOR_SCHEMA_V1;
+  readonly bindingHash: HookemonEnvelopeSha256V1;
+  readonly stateVersion: string;
+  readonly actionIndex: 0 | 1 | 2;
+  readonly actionKind: HookemonEnvelopeActionKindV1;
+  readonly previousFinalityEvidenceHash: HookemonEnvelopeSha256V1 | null;
+  readonly permitDigest: HookemonEnvelopeBytes32V1 | null;
+  readonly validAfterEpochSeconds: string;
+  readonly expiresAtEpochSeconds: string;
+  readonly currentnessEvidenceHash: HookemonEnvelopeSha256V1;
+}
+
+export interface HookemonAuthorityBrowserActionCoreV1 {
+  readonly schemaVersion: typeof HOOKEMON_BROWSER_ACTION_SCHEMA_V1;
+  readonly bindingHash: HookemonEnvelopeSha256V1;
+  readonly stateVersion: string;
+  readonly actionIndex: 0 | 1 | 2;
+  readonly actionKind: HookemonEnvelopeActionKindV1;
+  readonly selectorHash: HookemonEnvelopeSha256V1;
+  readonly dataHash: HookemonEnvelopeBytes32V1;
+  readonly previousFinalityEvidenceHash: HookemonEnvelopeSha256V1 | null;
+  readonly permitDigest: HookemonEnvelopeBytes32V1 | null;
+  readonly validAfterEpochSeconds: string;
+  readonly expiresAtEpochSeconds: string;
+  readonly currentness: Readonly<Record<string, unknown>>;
+  readonly transaction: Readonly<Record<string, unknown>>;
+}
+
+export interface HookemonAuthorityBrowserActionV1
+  extends HookemonAuthorityBrowserActionCoreV1 {
+  readonly actionHash: HookemonEnvelopeSha256V1;
+}
+
+export interface HookemonActionAuthorityEnvelopeCoreV1 {
+  readonly schemaVersion: typeof HOOKEMON_ACTION_AUTHORITY_ENVELOPE_SCHEMA_V1;
+  readonly bindingHash: HookemonEnvelopeSha256V1;
+  readonly releaseHeadHash: HookemonEnvelopeSha256V1;
+  readonly revocationEpoch: string;
+  readonly selectorHash: HookemonEnvelopeSha256V1;
+  readonly actionHash: HookemonEnvelopeSha256V1;
+  readonly authorityKeyId: string;
+  readonly signatureAlgorithm: "ed25519";
+}
+
+export interface HookemonActionAuthorityEnvelopeV1
+  extends HookemonActionAuthorityEnvelopeCoreV1 {
+  readonly envelopeHash: HookemonEnvelopeSha256V1;
+  readonly signature: `ed25519:${string}`;
+}
+
+export interface HookemonActionAuthorityExpectedReleaseV1 {
+  readonly bindingHash: HookemonEnvelopeSha256V1;
+  readonly releaseHeadHash: HookemonEnvelopeSha256V1;
+  readonly revocationEpoch: string;
+  readonly authorityKeyId: string;
+}
+
+export function canonicalizeHookemonAuthorityJsonV1(value: unknown): string {
+  return canonicalizeValue(value, new WeakSet<object>(), 0);
+}
+
+export function canonicalHookemonAuthoritySha256V1(
+  domain: string,
+  value: unknown,
+): HookemonEnvelopeSha256V1 {
+  if (!/^programmable\.[a-z0-9.-]+\.v[1-9][0-9]*$/u.test(domain)) {
+    throw invalid("Hookemon hash domain is invalid");
+  }
+  const digest = rawSha256(bytesToHex(concatBytes(
+    stringToBytes(domain),
+    Uint8Array.of(0),
+    stringToBytes(canonicalizeHookemonAuthorityJsonV1(value)),
+  )));
+  return `sha256:${digest.slice(2)}`;
+}
+
+export function computeHookemonActionSelectorHashV1(
+  raw: Omit<HookemonActionSelectorCoreV1, "schemaVersion"> & Readonly<{
+    schemaVersion?: typeof HOOKEMON_ACTION_SELECTOR_SCHEMA_V1;
+  }>,
+): HookemonEnvelopeSha256V1 {
+  const core = assertSelectorCore({
+    ...raw,
+    schemaVersion: raw.schemaVersion ?? HOOKEMON_ACTION_SELECTOR_SCHEMA_V1,
+  });
+  return canonicalHookemonAuthoritySha256V1(core.schemaVersion, core);
+}
+
+export function computeHookemonAuthorityActionHashV1(
+  raw: HookemonAuthorityBrowserActionCoreV1,
+): HookemonEnvelopeSha256V1 {
+  const core = assertActionCore(raw);
+  return canonicalHookemonAuthoritySha256V1(core.schemaVersion, core);
+}
+
+export function computeHookemonActionAuthorityEnvelopeHashV1(
+  raw: HookemonActionAuthorityEnvelopeCoreV1,
+): HookemonEnvelopeSha256V1 {
+  const core = assertEnvelopeCore(raw);
+  return canonicalHookemonAuthoritySha256V1(core.schemaVersion, core);
+}
+
+export function hookemonActionAuthoritySigningBytesV1(
+  raw: HookemonActionAuthorityEnvelopeCoreV1 & Readonly<{
+    envelopeHash: HookemonEnvelopeSha256V1;
+  }>,
+): Uint8Array {
+  const value = exactObject(raw, [
+    "actionHash", "authorityKeyId", "bindingHash", "envelopeHash",
+    "releaseHeadHash", "revocationEpoch", "schemaVersion", "selectorHash",
+    "signatureAlgorithm",
+  ], "Hookemon signing envelope");
+  const { envelopeHash: rawEnvelopeHash, ...rawCore } = value;
+  const core = assertEnvelopeCore(rawCore);
+  const envelopeHash = sha256(rawEnvelopeHash);
+  if (envelopeHash !== computeHookemonActionAuthorityEnvelopeHashV1(core)) {
+    throw invalid("Hookemon action envelope hash drifted");
+  }
+  return concatBytes(
+    stringToBytes(HOOKEMON_ACTION_AUTHORITY_SIGNING_DOMAIN_V1),
+    Uint8Array.of(0),
+    stringToBytes(canonicalizeHookemonAuthorityJsonV1({
+      ...core,
+      envelopeHash,
+    })),
+  );
+}
+
+export async function verifyHookemonActionAuthorityEnvelopeV1(input: Readonly<{
+  action: unknown;
+  envelope: unknown;
+  expectedRelease: HookemonActionAuthorityExpectedReleaseV1;
+  verifySignature: (request: Readonly<{
+    keyId: string;
+    signingBytes: Uint8Array;
+    signature: Uint8Array;
+  }>) => boolean | Promise<boolean>;
+}>): Promise<Readonly<{
+  action: HookemonAuthorityBrowserActionV1;
+  envelope: HookemonActionAuthorityEnvelopeV1;
+}>> {
+  const action = assertAuthorityBrowserAction(input.action);
+  const currentnessEvidenceHash = sha256(
+    action.currentness.currentnessEvidenceHash,
+  );
+  const expectedSelectorHash = computeHookemonActionSelectorHashV1({
+    bindingHash: action.bindingHash,
+    stateVersion: action.stateVersion,
+    actionIndex: action.actionIndex,
+    actionKind: action.actionKind,
+    previousFinalityEvidenceHash: action.previousFinalityEvidenceHash,
+    permitDigest: action.permitDigest,
+    validAfterEpochSeconds: action.validAfterEpochSeconds,
+    expiresAtEpochSeconds: action.expiresAtEpochSeconds,
+    currentnessEvidenceHash,
+  });
+  const { actionHash, ...actionCore } = action;
+  if (
+    action.selectorHash !== expectedSelectorHash
+    || actionHash !== computeHookemonAuthorityActionHashV1(actionCore)
+  ) throw invalid("Hookemon browser action identifiers drifted");
+
+  const expectedRelease = assertExpectedRelease(input.expectedRelease);
+  const envelope = assertEnvelope(input.envelope);
+  const { envelopeHash, signature, ...envelopeCore } = envelope;
+  if (
+    envelope.bindingHash !== expectedRelease.bindingHash
+    || envelope.releaseHeadHash !== expectedRelease.releaseHeadHash
+    || envelope.revocationEpoch !== expectedRelease.revocationEpoch
+    || envelope.authorityKeyId !== expectedRelease.authorityKeyId
+    || envelope.bindingHash !== action.bindingHash
+    || envelope.selectorHash !== action.selectorHash
+    || envelope.actionHash !== action.actionHash
+    || envelopeHash !== computeHookemonActionAuthorityEnvelopeHashV1(envelopeCore)
+  ) throw invalid("Hookemon action authority envelope left the exact release");
+  const verified = await input.verifySignature({
+    keyId: envelope.authorityKeyId,
+    signingBytes: hookemonActionAuthoritySigningBytesV1({
+      ...envelopeCore,
+      envelopeHash,
+    }),
+    signature: ed25519SignatureBytes(signature),
+  });
+  if (!verified) throw invalid("Hookemon action authority signature is invalid");
+  return deepFreeze({ action, envelope });
+}
+
+function assertAuthorityBrowserAction(
+  raw: unknown,
+): HookemonAuthorityBrowserActionV1 {
+  const value = exactObject(raw, [
+    "actionHash", "actionIndex", "actionKind", "bindingHash", "currentness",
+    "dataHash", "expiresAtEpochSeconds", "permitDigest",
+    "previousFinalityEvidenceHash", "schemaVersion", "selectorHash",
+    "stateVersion", "transaction", "validAfterEpochSeconds",
+  ], "Hookemon authority browser action");
+  const { actionHash: rawActionHash, ...rawCore } = value;
+  const actionHash = sha256(rawActionHash);
+  const core = assertActionCore(rawCore);
+  return deepFreeze({ ...core, actionHash });
+}
+
+function assertActionCore(raw: unknown): HookemonAuthorityBrowserActionCoreV1 {
+  const value = exactObject(raw, [
+    "actionIndex", "actionKind", "bindingHash", "currentness", "dataHash",
+    "expiresAtEpochSeconds", "permitDigest", "previousFinalityEvidenceHash",
+    "schemaVersion", "selectorHash", "stateVersion", "transaction",
+    "validAfterEpochSeconds",
+  ], "Hookemon authority action core");
+  if (value.schemaVersion !== HOOKEMON_BROWSER_ACTION_SCHEMA_V1) {
+    throw invalid("Hookemon browser action schema is invalid");
+  }
+  const actionIndex = index(value.actionIndex);
+  const actionKind = kind(value.actionKind);
+  if (["ERC20_APPROVAL", "EOA_CREATE", "COMPLETED_GRAPH_ADOPTION"][actionIndex]
+    !== actionKind) throw invalid("Hookemon browser action order is invalid");
+  const currentness = plainRecord(value.currentness, "Hookemon currentness");
+  const transaction = plainRecord(value.transaction, "Hookemon transaction");
+  // Canonicalization here rejects accessors, symbols, cycles and non-JSON data
+  // before any object can participate in an authority hash.
+  canonicalizeHookemonAuthorityJsonV1(currentness);
+  canonicalizeHookemonAuthorityJsonV1(transaction);
+  return deepFreeze({
+    schemaVersion: HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
+    bindingHash: sha256(value.bindingHash),
+    stateVersion: uint(value.stateVersion),
+    actionIndex,
+    actionKind,
+    selectorHash: sha256(value.selectorHash),
+    dataHash: bytes32(value.dataHash),
+    previousFinalityEvidenceHash: nullableSha256(value.previousFinalityEvidenceHash),
+    permitDigest: nullableBytes32(value.permitDigest),
+    validAfterEpochSeconds: uint(value.validAfterEpochSeconds),
+    expiresAtEpochSeconds: uint(value.expiresAtEpochSeconds),
+    currentness,
+    transaction,
+  });
+}
+
+function assertSelectorCore(raw: unknown): HookemonActionSelectorCoreV1 {
+  const value = exactObject(raw, [
+    "actionIndex", "actionKind", "bindingHash", "currentnessEvidenceHash",
+    "expiresAtEpochSeconds", "permitDigest", "previousFinalityEvidenceHash",
+    "schemaVersion", "stateVersion", "validAfterEpochSeconds",
+  ], "Hookemon action selector core");
+  if (value.schemaVersion !== HOOKEMON_ACTION_SELECTOR_SCHEMA_V1) {
+    throw invalid("Hookemon action selector schema is invalid");
+  }
+  const actionIndex = index(value.actionIndex);
+  const actionKind = kind(value.actionKind);
+  if (["ERC20_APPROVAL", "EOA_CREATE", "COMPLETED_GRAPH_ADOPTION"][actionIndex]
+    !== actionKind) throw invalid("Hookemon action selector order is invalid");
+  return deepFreeze({
+    schemaVersion: HOOKEMON_ACTION_SELECTOR_SCHEMA_V1,
+    bindingHash: sha256(value.bindingHash),
+    stateVersion: uint(value.stateVersion),
+    actionIndex,
+    actionKind,
+    previousFinalityEvidenceHash: nullableSha256(value.previousFinalityEvidenceHash),
+    permitDigest: nullableBytes32(value.permitDigest),
+    validAfterEpochSeconds: uint(value.validAfterEpochSeconds),
+    expiresAtEpochSeconds: uint(value.expiresAtEpochSeconds),
+    currentnessEvidenceHash: sha256(value.currentnessEvidenceHash),
+  });
+}
+
+function assertEnvelope(raw: unknown): HookemonActionAuthorityEnvelopeV1 {
+  const value = exactObject(raw, [
+    "actionHash", "authorityKeyId", "bindingHash", "envelopeHash",
+    "releaseHeadHash", "revocationEpoch", "schemaVersion", "selectorHash",
+    "signature", "signatureAlgorithm",
+  ], "Hookemon action authority envelope");
+  const {
+    envelopeHash: rawEnvelopeHash,
+    signature: rawSignature,
+    ...rawCore
+  } = value;
+  const core = assertEnvelopeCore(rawCore);
+  const signature = ed25519Signature(rawSignature);
+  return deepFreeze({
+    ...core,
+    envelopeHash: sha256(rawEnvelopeHash),
+    signature,
+  });
+}
+
+function assertEnvelopeCore(raw: unknown): HookemonActionAuthorityEnvelopeCoreV1 {
+  const value = exactObject(raw, [
+    "actionHash", "authorityKeyId", "bindingHash", "releaseHeadHash",
+    "revocationEpoch", "schemaVersion", "selectorHash", "signatureAlgorithm",
+  ], "Hookemon action authority envelope core");
+  if (
+    value.schemaVersion !== HOOKEMON_ACTION_AUTHORITY_ENVELOPE_SCHEMA_V1
+    || value.signatureAlgorithm !== "ed25519"
+  ) throw invalid("Hookemon action authority envelope schema is invalid");
+  return deepFreeze({
+    schemaVersion: HOOKEMON_ACTION_AUTHORITY_ENVELOPE_SCHEMA_V1,
+    bindingHash: sha256(value.bindingHash),
+    releaseHeadHash: sha256(value.releaseHeadHash),
+    revocationEpoch: uint(value.revocationEpoch),
+    selectorHash: sha256(value.selectorHash),
+    actionHash: sha256(value.actionHash),
+    authorityKeyId: identifier(value.authorityKeyId),
+    signatureAlgorithm: "ed25519",
+  });
+}
+
+function assertExpectedRelease(
+  raw: unknown,
+): HookemonActionAuthorityExpectedReleaseV1 {
+  const value = exactObject(raw, [
+    "authorityKeyId", "bindingHash", "releaseHeadHash", "revocationEpoch",
+  ], "Hookemon action authority expected release");
+  return deepFreeze({
+    bindingHash: sha256(value.bindingHash),
+    releaseHeadHash: sha256(value.releaseHeadHash),
+    revocationEpoch: uint(value.revocationEpoch),
+    authorityKeyId: identifier(value.authorityKeyId),
+  });
+}
+
+function canonicalizeValue(
+  value: unknown,
+  active: WeakSet<object>,
+  depth: number,
+): string {
+  if (depth > 128) throw invalid("Hookemon canonical JSON is too deep");
+  if (value === null) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "string") {
+    assertUnicodeScalarString(value);
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw invalid("Hookemon canonical JSON number is invalid");
+    return JSON.stringify(value);
+  }
+  if (typeof value !== "object") {
+    throw invalid(`Hookemon canonical JSON does not support ${typeof value}`);
+  }
+  if (active.has(value)) throw invalid("Hookemon canonical JSON is cyclic");
+  active.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const ownKeys = Reflect.ownKeys(value);
+      if (ownKeys.some((key) => typeof key !== "string"
+        || (key !== "length" && !/^(?:0|[1-9][0-9]*)$/u.test(key)))) {
+        throw invalid("Hookemon canonical JSON array has custom properties");
+      }
+      const elements: string[] = [];
+      for (let position = 0; position < value.length; position += 1) {
+        if (!Object.hasOwn(value, position)) {
+          throw invalid("Hookemon canonical JSON array is sparse");
+        }
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(position));
+        if (
+          descriptor === undefined
+          || descriptor.get !== undefined
+          || descriptor.set !== undefined
+          || !("value" in descriptor)
+          || descriptor.enumerable !== true
+        ) throw invalid("Hookemon canonical JSON array element is invalid");
+        elements.push(canonicalizeValue(descriptor.value, active, depth + 1));
+      }
+      return `[${elements.join(",")}]`;
+    }
+    const prototype = Object.getPrototypeOf(value) as object | null;
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw invalid("Hookemon canonical JSON object prototype is invalid");
+    }
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.some((key) => typeof key === "symbol")) {
+      throw invalid("Hookemon canonical JSON object has symbols");
+    }
+    const keys = ownKeys as string[];
+    const descriptors = new Map<string, PropertyDescriptor>();
+    for (const key of keys) {
+      assertUnicodeScalarString(key);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (
+        descriptor === undefined
+        || !descriptor.enumerable
+        || descriptor.get !== undefined
+        || descriptor.set !== undefined
+        || !("value" in descriptor)
+      ) throw invalid("Hookemon canonical JSON property is invalid");
+      descriptors.set(key, descriptor);
+    }
+    keys.sort();
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${
+      canonicalizeValue(descriptors.get(key)!.value, active, depth + 1)
+    }`).join(",")}}`;
+  } finally {
+    active.delete(value);
+  }
+}
+
+function assertUnicodeScalarString(value: string): void {
+  for (let position = 0; position < value.length; position += 1) {
+    const code = value.charCodeAt(position);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(position + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw invalid("Hookemon canonical JSON has a lone high surrogate");
+      }
+      position += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      throw invalid("Hookemon canonical JSON has a lone low surrogate");
+    }
+  }
+}
+
+function exactObject(
+  raw: unknown,
+  expectedKeys: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  const value = plainRecord(raw, label);
+  const keys = Reflect.ownKeys(value);
+  const strings = keys.filter((key): key is string => typeof key === "string")
+    .sort();
+  const expected = [...expectedKeys].sort();
+  if (
+    keys.length !== strings.length
+    || strings.length !== expected.length
+    || strings.some((key, position) => key !== expected[position])
+  ) throw invalid(`${label} has unexpected fields`);
+  return value;
+}
+
+function plainRecord(raw: unknown, label: string): Record<string, unknown> {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid(`${label} is invalid`);
+  }
+  const prototype = Object.getPrototypeOf(raw) as object | null;
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw invalid(`${label} has an invalid prototype`);
+  }
+  return raw as Record<string, unknown>;
+}
+
+function index(value: unknown): 0 | 1 | 2 {
+  if (value !== 0 && value !== 1 && value !== 2) {
+    throw invalid("Hookemon action index is invalid");
+  }
+  return value;
+}
+
+function kind(value: unknown): HookemonEnvelopeActionKindV1 {
+  if (![
+    "ERC20_APPROVAL", "EOA_CREATE", "COMPLETED_GRAPH_ADOPTION",
+  ].includes(String(value))) throw invalid("Hookemon action kind is invalid");
+  return value as HookemonEnvelopeActionKindV1;
+}
+
+function bytes32(value: unknown): HookemonEnvelopeBytes32V1 {
+  if (typeof value !== "string" || !/^0x[0-9a-f]{64}$/u.test(value)) {
+    throw invalid("Hookemon authority bytes32 is invalid");
+  }
+  return value as HookemonEnvelopeBytes32V1;
+}
+
+function nullableBytes32(value: unknown): HookemonEnvelopeBytes32V1 | null {
+  return value === null ? null : bytes32(value);
+}
+
+function sha256(value: unknown): HookemonEnvelopeSha256V1 {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw invalid("Hookemon authority SHA-256 is invalid");
+  }
+  return value as HookemonEnvelopeSha256V1;
+}
+
+function nullableSha256(value: unknown): HookemonEnvelopeSha256V1 | null {
+  return value === null ? null : sha256(value);
+}
+
+function uint(value: unknown): string {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(value)
+    || BigInt(value) >= 1n << 64n) {
+    throw invalid("Hookemon authority uint64 is invalid");
+  }
+  return value;
+}
+
+function identifier(value: unknown): string {
+  if (
+    typeof value !== "string"
+    || value.length < 1
+    || value.length > 256
+    || !/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/u.test(value)
+  ) throw invalid("Hookemon authority key id is invalid");
+  return value;
+}
+
+function ed25519Signature(value: unknown): `ed25519:${string}` {
+  if (typeof value !== "string" || !/^ed25519:[A-Za-z0-9_-]{86}$/u.test(value)) {
+    throw invalid("Hookemon Ed25519 signature encoding is invalid");
+  }
+  ed25519SignatureBytes(value as `ed25519:${string}`);
+  return value as `ed25519:${string}`;
+}
+
+function ed25519SignatureBytes(value: `ed25519:${string}`): Uint8Array {
+  const encoded = value.slice("ed25519:".length);
+  const base64 = encoded.replace(/-/gu, "+").replace(/_/gu, "/") + "==";
+  let decoded: string;
+  try {
+    decoded = atob(base64);
+  } catch {
+    throw invalid("Hookemon Ed25519 signature encoding is invalid");
+  }
+  const bytes = Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+  if (bytes.length !== 64) throw invalid("Hookemon Ed25519 signature length is invalid");
+  return bytes;
+}
+
+function concatBytes(...parts: readonly Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(parts.reduce((sum, part) => sum + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}
+
+function invalid(message: string): TypeError {
+  return new TypeError(message);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(nested);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/custom-launch/hookemon-permit-envelope-v1.ts
+++ b/lib/custom-launch/hookemon-permit-envelope-v1.ts
@@ -1,0 +1,412 @@
+import {
+  concatHex,
+  encodeAbiParameters,
+  keccak256,
+  stringToHex,
+  type Hex,
+} from "viem";
+
+export const HOOKEMON_PERMIT_ENVELOPE_TYPE_V1 =
+  "HookemonPermitEnvelopeV1(bytes32 envelopeTypeHash,uint256 chainId,address router,address launchWallet,bytes32 profileKey,bytes32 architectureIdHash,bytes32 sourceLaunchPlanHash,bytes32 adoptionPlanHash,bytes32 architectureResultHash,bytes32 currentArchitectureStateHash,bytes32 stampRequestHash,bytes32 nonce,uint64 validAfter,uint64 deadline,uint256 value,bytes32 r,bytes32 s,uint8 v)" as const;
+export const HOOKEMON_PERMIT_ENVELOPE_TYPE_HASH_V1 =
+  "0x76aee0e3ca5251fb636fbe95fc3c44609c3fa524a51d0054aab916ec752319d0" as const;
+export const HOOKEMON_PERMIT_ENVELOPE_BYTES_V1 = 576 as const;
+
+export const HOOKEMON_LAUNCH_PERMIT_TYPE_V1 =
+  "LaunchPermitV1(uint256 chainId,address router,address launchWallet,bytes32 profileKey,bytes32 architectureIdHash,bytes32 sourceLaunchPlanHash,bytes32 adoptionPlanHash,bytes32 architectureResultHash,bytes32 currentArchitectureStateHash,bytes32 stampRequestHash,bytes32 nonce,uint64 validAfter,uint64 deadline,uint256 value)" as const;
+export const HOOKEMON_LAUNCH_PERMIT_TYPE_HASH_V1 =
+  "0x9bbf58469f9b0d79df750050233f3adb8e1c7f52e505a731334edd22f0025226" as const;
+export const HOOKEMON_ADOPTION_EIP712_NAME_V1 =
+  "ProgrammableHookemonAdoptionRouter" as const;
+export const HOOKEMON_ADOPTION_EIP712_VERSION_V1 = "1.0.0" as const;
+
+const EIP712_DOMAIN_TYPE_V1 =
+  "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
+const SECP256K1_ORDER =
+  0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141n;
+const SECP256K1_HALF_ORDER =
+  0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0n;
+
+export type HookemonPermitAddressV1 = `0x${string}`;
+export type HookemonPermitBytes32V1 = `0x${string}`;
+
+export interface HookemonLaunchPermitV1 {
+  readonly chainId: "1";
+  readonly router: HookemonPermitAddressV1;
+  readonly launchWallet: HookemonPermitAddressV1;
+  readonly profileKey: HookemonPermitBytes32V1;
+  readonly architectureIdHash: HookemonPermitBytes32V1;
+  readonly sourceLaunchPlanHash: HookemonPermitBytes32V1;
+  readonly adoptionPlanHash: HookemonPermitBytes32V1;
+  readonly architectureResultHash: HookemonPermitBytes32V1;
+  readonly currentArchitectureStateHash: HookemonPermitBytes32V1;
+  readonly stampRequestHash: HookemonPermitBytes32V1;
+  readonly nonce: HookemonPermitBytes32V1;
+  readonly validAfter: string;
+  readonly deadline: string;
+  readonly value: "0";
+}
+
+export interface HookemonPermitSignatureV1 {
+  readonly r: HookemonPermitBytes32V1;
+  readonly s: HookemonPermitBytes32V1;
+  readonly v: 27 | 28;
+}
+
+export interface HookemonPermitEnvelopeExpectedReleaseV1 {
+  readonly router: HookemonPermitAddressV1;
+  readonly launchWallet: HookemonPermitAddressV1;
+  readonly profileKey: HookemonPermitBytes32V1;
+  readonly architectureIdHash: HookemonPermitBytes32V1;
+  readonly sourceLaunchPlanHash: HookemonPermitBytes32V1;
+  readonly adoptionPlanHash: HookemonPermitBytes32V1;
+  readonly architectureResultHash: HookemonPermitBytes32V1;
+  readonly currentArchitectureStateHash: HookemonPermitBytes32V1;
+  readonly stampRequestHash: HookemonPermitBytes32V1;
+  readonly nonce: HookemonPermitBytes32V1;
+  readonly permitDigest: HookemonPermitBytes32V1;
+  readonly validAfterEpochSeconds: string;
+  readonly expiresAtEpochSeconds: string;
+}
+
+export interface HookemonDecodedPermitEnvelopeV1 {
+  readonly permit: HookemonLaunchPermitV1;
+  readonly signature: HookemonPermitSignatureV1;
+  readonly permitDigest: HookemonPermitBytes32V1;
+  readonly envelopeHash: HookemonPermitBytes32V1;
+}
+
+const PERMIT_ENVELOPE_ABI = [
+  { type: "bytes32" },
+  { type: "uint256" },
+  { type: "address" },
+  { type: "address" },
+  { type: "bytes32" },
+  { type: "bytes32" },
+  { type: "bytes32" },
+  { type: "bytes32" },
+  { type: "bytes32" },
+  { type: "bytes32" },
+  { type: "bytes32" },
+  { type: "bytes32" },
+  { type: "uint64" },
+  { type: "uint64" },
+  { type: "uint256" },
+  { type: "bytes32" },
+  { type: "bytes32" },
+  { type: "uint8" },
+] as const;
+
+export function assertHookemonPermitEnvelopeTypeHashesV1(): void {
+  if (
+    keccak256(stringToHex(HOOKEMON_PERMIT_ENVELOPE_TYPE_V1))
+      !== HOOKEMON_PERMIT_ENVELOPE_TYPE_HASH_V1
+    || keccak256(stringToHex(HOOKEMON_LAUNCH_PERMIT_TYPE_V1))
+      !== HOOKEMON_LAUNCH_PERMIT_TYPE_HASH_V1
+  ) throw invalid("Hookemon permit type hash drifted");
+}
+
+export function assertHookemonLaunchPermitV1(
+  raw: unknown,
+): HookemonLaunchPermitV1 {
+  const value = exactObject(raw, [
+    "adoptionPlanHash", "architectureIdHash", "architectureResultHash",
+    "chainId", "currentArchitectureStateHash", "deadline", "launchWallet",
+    "nonce", "profileKey", "router", "sourceLaunchPlanHash",
+    "stampRequestHash", "validAfter", "value",
+  ], "Hookemon launch permit");
+  const permit = deepFreeze({
+    chainId: uint(value.chainId, 256) as "1",
+    router: address(value.router),
+    launchWallet: address(value.launchWallet),
+    profileKey: bytes32(value.profileKey),
+    architectureIdHash: bytes32(value.architectureIdHash),
+    sourceLaunchPlanHash: bytes32(value.sourceLaunchPlanHash),
+    adoptionPlanHash: bytes32(value.adoptionPlanHash),
+    architectureResultHash: bytes32(value.architectureResultHash),
+    currentArchitectureStateHash: bytes32(value.currentArchitectureStateHash),
+    stampRequestHash: bytes32(value.stampRequestHash),
+    nonce: bytes32(value.nonce),
+    validAfter: uint(value.validAfter, 64),
+    deadline: uint(value.deadline, 64),
+    value: uint(value.value, 256) as "0",
+  });
+  if (
+    permit.chainId !== "1"
+    || permit.value !== "0"
+    || BigInt(permit.validAfter) > BigInt(permit.deadline)
+    || BigInt(permit.deadline) - BigInt(permit.validAfter) > 3_600n
+  ) throw invalid("Hookemon permit is outside the Mainnet zero-value policy");
+  return permit;
+}
+
+export function assertHookemonPermitSignatureV1(
+  raw: unknown,
+): HookemonPermitSignatureV1 {
+  const value = exactObject(raw, ["r", "s", "v"], "Hookemon permit signature");
+  const r = bytes32(value.r);
+  const s = bytes32(value.s);
+  const rNumber = BigInt(r);
+  const sNumber = BigInt(s);
+  if (
+    rNumber === 0n
+    || rNumber >= SECP256K1_ORDER
+    || sNumber === 0n
+    || sNumber > SECP256K1_HALF_ORDER
+    || (value.v !== 27 && value.v !== 28)
+  ) throw invalid("Hookemon permit signature is non-canonical");
+  return Object.freeze({ r, s, v: value.v });
+}
+
+export function computeHookemonPermitDigestV1(
+  raw: HookemonLaunchPermitV1,
+): HookemonPermitBytes32V1 {
+  const permit = assertHookemonLaunchPermitV1(raw);
+  assertHookemonPermitEnvelopeTypeHashesV1();
+  const domainSeparator = keccak256(encodeAbiParameters(
+    [
+      { type: "bytes32" }, { type: "bytes32" }, { type: "bytes32" },
+      { type: "uint256" }, { type: "address" },
+    ],
+    [
+      keccak256(stringToHex(EIP712_DOMAIN_TYPE_V1)),
+      keccak256(stringToHex(HOOKEMON_ADOPTION_EIP712_NAME_V1)),
+      keccak256(stringToHex(HOOKEMON_ADOPTION_EIP712_VERSION_V1)),
+      1n,
+      permit.router,
+    ],
+  ));
+  const structHash = keccak256(encodeAbiParameters(
+    [
+      { type: "bytes32" }, { type: "uint256" }, { type: "address" },
+      { type: "address" }, { type: "bytes32" }, { type: "bytes32" },
+      { type: "bytes32" }, { type: "bytes32" }, { type: "bytes32" },
+      { type: "bytes32" }, { type: "bytes32" }, { type: "bytes32" },
+      { type: "uint64" }, { type: "uint64" }, { type: "uint256" },
+    ],
+    [
+      HOOKEMON_LAUNCH_PERMIT_TYPE_HASH_V1,
+      1n,
+      permit.router,
+      permit.launchWallet,
+      permit.profileKey,
+      permit.architectureIdHash,
+      permit.sourceLaunchPlanHash,
+      permit.adoptionPlanHash,
+      permit.architectureResultHash,
+      permit.currentArchitectureStateHash,
+      permit.stampRequestHash,
+      permit.nonce,
+      BigInt(permit.validAfter),
+      BigInt(permit.deadline),
+      0n,
+    ],
+  ));
+  return keccak256(concatHex(["0x1901", domainSeparator, structHash]));
+}
+
+export function encodeHookemonPermitEnvelopeV1(
+  rawPermit: HookemonLaunchPermitV1,
+  rawSignature: HookemonPermitSignatureV1,
+): Hex {
+  const permit = assertHookemonLaunchPermitV1(rawPermit);
+  const signature = assertHookemonPermitSignatureV1(rawSignature);
+  assertHookemonPermitEnvelopeTypeHashesV1();
+  const encoded = encodeAbiParameters(PERMIT_ENVELOPE_ABI, [
+    HOOKEMON_PERMIT_ENVELOPE_TYPE_HASH_V1,
+    1n,
+    permit.router,
+    permit.launchWallet,
+    permit.profileKey,
+    permit.architectureIdHash,
+    permit.sourceLaunchPlanHash,
+    permit.adoptionPlanHash,
+    permit.architectureResultHash,
+    permit.currentArchitectureStateHash,
+    permit.stampRequestHash,
+    permit.nonce,
+    BigInt(permit.validAfter),
+    BigInt(permit.deadline),
+    0n,
+    signature.r,
+    signature.s,
+    signature.v,
+  ]);
+  if ((encoded.length - 2) / 2 !== HOOKEMON_PERMIT_ENVELOPE_BYTES_V1) {
+    throw invalid("Hookemon permit envelope has the wrong byte length");
+  }
+  return encoded;
+}
+
+export function decodeHookemonPermitEnvelopeV1(
+  raw: unknown,
+): HookemonDecodedPermitEnvelopeV1 {
+  if (
+    typeof raw !== "string"
+    || !/^0x[0-9a-f]+$/u.test(raw)
+    || (raw.length - 2) / 2 !== HOOKEMON_PERMIT_ENVELOPE_BYTES_V1
+  ) throw invalid("Hookemon permit envelope encoding is invalid");
+  const words = Array.from({ length: 18 }, (_, index) =>
+    `0x${raw.slice(2 + index * 64, 2 + (index + 1) * 64)}` as const);
+  if (words[0] !== HOOKEMON_PERMIT_ENVELOPE_TYPE_HASH_V1) {
+    throw invalid("Hookemon permit envelope tag drifted");
+  }
+  const permit = assertHookemonLaunchPermitV1({
+    chainId: uintFromWord(words[1]!, 256),
+    router: addressFromWord(words[2]!),
+    launchWallet: addressFromWord(words[3]!),
+    profileKey: words[4],
+    architectureIdHash: words[5],
+    sourceLaunchPlanHash: words[6],
+    adoptionPlanHash: words[7],
+    architectureResultHash: words[8],
+    currentArchitectureStateHash: words[9],
+    stampRequestHash: words[10],
+    nonce: words[11],
+    validAfter: uintFromWord(words[12]!, 64),
+    deadline: uintFromWord(words[13]!, 64),
+    value: uintFromWord(words[14]!, 256),
+  });
+  const signature = assertHookemonPermitSignatureV1({
+    r: words[15],
+    s: words[16],
+    v: Number(BigInt(words[17]!)),
+  });
+  const canonical = encodeHookemonPermitEnvelopeV1(permit, signature);
+  if (canonical !== raw) {
+    throw invalid("Hookemon permit envelope is not canonical ABI encoding");
+  }
+  return deepFreeze({
+    permit,
+    signature,
+    permitDigest: computeHookemonPermitDigestV1(permit),
+    envelopeHash: keccak256(canonical),
+  });
+}
+
+export function assertHookemonPermitEnvelopeReleaseV1(input: Readonly<{
+  envelope: unknown;
+  expected: HookemonPermitEnvelopeExpectedReleaseV1;
+  currentEpochSeconds: string;
+}>): HookemonDecodedPermitEnvelopeV1 {
+  const decoded = decodeHookemonPermitEnvelopeV1(input.envelope);
+  const expected = assertExpectedRelease(input.expected);
+  const now = BigInt(uint(input.currentEpochSeconds, 64));
+  const permit = decoded.permit;
+  if (
+    decoded.permitDigest !== expected.permitDigest
+    || permit.router !== expected.router
+    || permit.launchWallet !== expected.launchWallet
+    || permit.profileKey !== expected.profileKey
+    || permit.architectureIdHash !== expected.architectureIdHash
+    || permit.sourceLaunchPlanHash !== expected.sourceLaunchPlanHash
+    || permit.adoptionPlanHash !== expected.adoptionPlanHash
+    || permit.architectureResultHash !== expected.architectureResultHash
+    || permit.currentArchitectureStateHash !== expected.currentArchitectureStateHash
+    || permit.stampRequestHash !== expected.stampRequestHash
+    || permit.nonce !== expected.nonce
+    || permit.validAfter !== expected.validAfterEpochSeconds
+    || permit.deadline !== expected.expiresAtEpochSeconds
+    || BigInt(permit.validAfter) > now
+    || now >= BigInt(permit.deadline)
+  ) throw invalid("Hookemon permit envelope left the exact current release");
+  return decoded;
+}
+
+function assertExpectedRelease(
+  raw: unknown,
+): HookemonPermitEnvelopeExpectedReleaseV1 {
+  const value = exactObject(raw, [
+    "adoptionPlanHash", "architectureIdHash", "architectureResultHash",
+    "currentArchitectureStateHash", "expiresAtEpochSeconds", "launchWallet",
+    "nonce", "permitDigest", "profileKey", "router", "sourceLaunchPlanHash",
+    "stampRequestHash", "validAfterEpochSeconds",
+  ], "Hookemon expected permit release");
+  return deepFreeze({
+    router: address(value.router),
+    launchWallet: address(value.launchWallet),
+    profileKey: bytes32(value.profileKey),
+    architectureIdHash: bytes32(value.architectureIdHash),
+    sourceLaunchPlanHash: bytes32(value.sourceLaunchPlanHash),
+    adoptionPlanHash: bytes32(value.adoptionPlanHash),
+    architectureResultHash: bytes32(value.architectureResultHash),
+    currentArchitectureStateHash: bytes32(value.currentArchitectureStateHash),
+    stampRequestHash: bytes32(value.stampRequestHash),
+    nonce: bytes32(value.nonce),
+    permitDigest: bytes32(value.permitDigest),
+    validAfterEpochSeconds: uint(value.validAfterEpochSeconds, 64),
+    expiresAtEpochSeconds: uint(value.expiresAtEpochSeconds, 64),
+  });
+}
+
+function exactObject(
+  raw: unknown,
+  expectedKeys: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid(`${label} is invalid`);
+  }
+  const keys = Reflect.ownKeys(raw);
+  const strings = keys.filter((key): key is string => typeof key === "string")
+    .sort();
+  const expected = [...expectedKeys].sort();
+  if (
+    keys.length !== strings.length
+    || strings.length !== expected.length
+    || strings.some((key, index) => key !== expected[index])
+  ) throw invalid(`${label} has unexpected fields`);
+  return raw as Record<string, unknown>;
+}
+
+function address(value: unknown): HookemonPermitAddressV1 {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{40}$/u.test(value)) {
+    throw invalid("Hookemon permit address is invalid");
+  }
+  return value.toLowerCase() as HookemonPermitAddressV1;
+}
+
+function addressFromWord(word: Hex): HookemonPermitAddressV1 {
+  if (!/^0x0{24}[0-9a-f]{40}$/u.test(word)) {
+    throw invalid("Hookemon permit address word is non-canonical");
+  }
+  return address(`0x${word.slice(-40)}`);
+}
+
+function bytes32(value: unknown): HookemonPermitBytes32V1 {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/u.test(value)) {
+    throw invalid("Hookemon permit bytes32 is invalid");
+  }
+  return value.toLowerCase() as HookemonPermitBytes32V1;
+}
+
+function uint(value: unknown, bits: number): string {
+  if (
+    typeof value !== "string"
+    || !/^(?:0|[1-9][0-9]*)$/u.test(value)
+    || BigInt(value) >= 1n << BigInt(bits)
+  ) throw invalid(`Hookemon permit uint${bits} is invalid`);
+  return value;
+}
+
+function uintFromWord(word: Hex, bits: number): string {
+  const value = BigInt(word);
+  if (value >= 1n << BigInt(bits)) {
+    throw invalid(`Hookemon permit uint${bits} word overflowed`);
+  }
+  return value.toString(10);
+}
+
+function invalid(message: string): TypeError {
+  return new TypeError(message);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(nested);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/tests/hookemon-applicant-browser-state.test.ts
+++ b/tests/hookemon-applicant-browser-state.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getCreateAddress } from "viem";
 
 import {
   createHookemonBrowserAttemptV1,
@@ -21,6 +22,7 @@ const sha = (byte: number) =>
   `sha256:${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
 const bytes32 = (byte: number) =>
   `0x${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+const launchWallet = "0x1111111111111111111111111111111111111111" as const;
 
 const binding = Object.freeze({
   bindingHash: sha(1),
@@ -30,8 +32,8 @@ const binding = Object.freeze({
   planHash: bytes32(5),
   sourceCommit: "11".repeat(20),
   sourceTree: "22".repeat(20),
-  launchWallet: "0x1111111111111111111111111111111111111111",
-  launcher: "0x2222222222222222222222222222222222222222",
+  launchWallet,
+  launcher: getCreateAddress({ from: launchWallet, nonce: 8n }),
   launcherInitCodeHash: bytes32(6),
   fundingUsdc: "1000000",
   approvalNonce: "7",

--- a/tests/hookemon-applicant-browser-state.test.ts
+++ b/tests/hookemon-applicant-browser-state.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createHookemonBrowserAttemptV1,
+  hookemonAttemptStorageKeyV1,
+  hookemonBlocksNewSendV1,
+  hookemonCanClearUncertainNoSendV1,
+  hookemonFreshActionMatchesCachedV1,
+  markHookemonBrowserAttemptReportedV1,
+  markHookemonBrowserAttemptSubmittedV1,
+  parseHookemonBrowserAttemptStorageV1,
+  reconcileHookemonBrowserAttemptV1,
+} from "../lib/custom-launch/hookemon-applicant-browser-state-v1";
+import type {
+  HookemonApplicantFlowBindingV1,
+  HookemonApplicantFlowStateV1,
+  HookemonBrowserWalletActionV1,
+} from "../lib/custom-launch/hookemon-applicant-contract-v1";
+
+const sha = (byte: number) =>
+  `sha256:${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+const bytes32 = (byte: number) =>
+  `0x${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+
+const binding = Object.freeze({
+  bindingHash: sha(1),
+  subjectHash: sha(2),
+  profileKey: bytes32(3),
+  profileSchemaHash: bytes32(4),
+  planHash: bytes32(5),
+  sourceCommit: "11".repeat(20),
+  sourceTree: "22".repeat(20),
+  launchWallet: "0x1111111111111111111111111111111111111111",
+  launcher: "0x2222222222222222222222222222222222222222",
+  launcherInitCodeHash: bytes32(6),
+  fundingUsdc: "1000000",
+  approvalNonce: "7",
+  launcherNonce: "8",
+  adoptionTarget: "0x3333333333333333333333333333333333333333",
+  adoptionSelector: "0x12345678",
+  requiredConfirmations: 64,
+} as const satisfies HookemonApplicantFlowBindingV1);
+
+const action = Object.freeze({
+  schemaVersion: "programmable.hookemon-browser-wallet-action.v1",
+  bindingHash: binding.bindingHash,
+  stateVersion: "10",
+  actionIndex: 1,
+  actionKind: "EOA_CREATE",
+  selectorHash: sha(10),
+  actionHash: sha(11),
+  dataHash: bytes32(12),
+  previousFinalityEvidenceHash: sha(13),
+  permitDigest: null,
+  validAfterEpochSeconds: "900",
+  expiresAtEpochSeconds: "1200",
+  currentness: {
+    schemaVersion: "programmable.hookemon-action-currentness.v1",
+    kind: "PRE_CREATE",
+    observedBlockNumber: "23000000",
+    observedBlockHash: bytes32(14),
+    observedPendingNonce: "0x8",
+    evidenceHash: sha(15),
+    previousFinalityEvidenceHash: sha(13),
+    completedGraphHash: null,
+    currentPoolStateHash: null,
+    runtimeStatusHash: null,
+  },
+  transaction: {
+    method: "eth_sendTransaction",
+    chainId: "0x1",
+    from: binding.launchWallet,
+    to: null,
+    nonce: "0x8",
+    gas: "0x100000",
+    data: "0x60006000",
+    value: "0x0",
+  },
+} as const satisfies HookemonBrowserWalletActionV1);
+
+describe("Hookemon per-action durable browser state", () => {
+  it("uses a distinct storage slot for every exact action", () => {
+    expect(hookemonAttemptStorageKeyV1(binding.bindingHash, 0)).not.toBe(
+      hookemonAttemptStorageKeyV1(binding.bindingHash, 1),
+    );
+    expect(hookemonAttemptStorageKeyV1(binding.bindingHash, 2)).toContain(
+      `${binding.bindingHash}:2`,
+    );
+  });
+
+  it("persists before prompt, then records the hash before reporting", () => {
+    const opened = createHookemonBrowserAttemptV1({
+      action,
+      binding,
+      createdAt: "2026-08-10T16:00:00.000Z",
+    });
+    expect(opened).toMatchObject({
+      actionIndex: 1,
+      actionKind: "EOA_CREATE",
+      nonce: "0x8",
+      to: null,
+      phase: "wallet-prompt-opened",
+      transactionHash: null,
+    });
+    const parsed = parseHookemonBrowserAttemptStorageV1(
+      JSON.stringify(opened),
+      binding,
+    );
+    expect(parsed.kind).toBe("valid");
+
+    const submitted = markHookemonBrowserAttemptSubmittedV1(
+      opened,
+      bytes32(20),
+    );
+    expect(submitted.phase).toBe("submitted");
+    expect(submitted.transactionHash).toBe(bytes32(20));
+    expect(markHookemonBrowserAttemptReportedV1(submitted).phase)
+      .toBe("reported");
+  });
+
+  it("blocks the next action for valid or corrupt unresolved storage", () => {
+    const opened = createHookemonBrowserAttemptV1({
+      action,
+      binding,
+      createdAt: "2026-08-10T16:00:00.000Z",
+    });
+    expect(hookemonBlocksNewSendV1({ attempts: [
+      { kind: "none" },
+      { kind: "valid", attempt: opened },
+      { kind: "none" },
+    ] })).toBe(true);
+    expect(hookemonBlocksNewSendV1({ attempts: [
+      { kind: "none" },
+      { kind: "corrupt", raw: "{" },
+      { kind: "none" },
+    ] })).toBe(true);
+  });
+
+  it("requires a byte-equal fresh resolve before opening the wallet", () => {
+    const state = serverState({ readyAction: action });
+    expect(hookemonFreshActionMatchesCachedV1({ cached: action, fresh: state }))
+      .toBe(true);
+    const drifted = structuredClone(state) as MutableState;
+    if (drifted.readyAction === null) throw new Error("fixture drift");
+    drifted.readyAction.transaction.gas = "0x100001";
+    expect(hookemonFreshActionMatchesCachedV1({
+      cached: action,
+      fresh: drifted,
+    })).toBe(false);
+  });
+
+  it("archives only exact server finality and otherwise requires recovery", () => {
+    const opened = createHookemonBrowserAttemptV1({
+      action,
+      binding,
+      createdAt: "2026-08-10T16:00:00.000Z",
+    });
+    const submitted = markHookemonBrowserAttemptSubmittedV1(
+      opened,
+      bytes32(20),
+    );
+    const pending = serverState({
+      state: "CREATE_SUBMITTED",
+      pendingAction: {
+        schemaVersion: "programmable.hookemon-reported-action.v1",
+        actionIndex: 1,
+        actionKind: "EOA_CREATE",
+        selectorHash: action.selectorHash,
+        actionHash: action.actionHash,
+        transactionHash: bytes32(20),
+        reportedAtEpochSeconds: "1000",
+      },
+    });
+    expect(reconcileHookemonBrowserAttemptV1({
+      attempt: submitted,
+      serverState: pending,
+    })).toMatchObject({ recoveryRequired: false, active: submitted });
+
+    const finalized = serverState({
+      state: "GRAPH_CURRENTNESS_PENDING",
+      finalizedActions: [approvalFinality(), {
+        schemaVersion: "programmable.hookemon-action-finality.v1",
+        actionIndex: 1,
+        actionKind: "EOA_CREATE",
+        selectorHash: action.selectorHash,
+        actionHash: action.actionHash,
+        transactionHash: bytes32(20),
+        blockNumber: "23000001",
+        blockHash: bytes32(30),
+        confirmations: 64,
+        receiptEvidenceHash: sha(31),
+        finalityEvidenceHash: sha(32),
+        resultHash: bytes32(33),
+      }],
+    });
+    expect(reconcileHookemonBrowserAttemptV1({
+      attempt: submitted,
+      serverState: finalized,
+    })).toMatchObject({
+      recoveryRequired: false,
+      active: null,
+      archiveReason: "server-finalized",
+    });
+
+    const wrongHash = structuredClone(finalized) as MutableState;
+    wrongHash.finalizedActions[1]!.transactionHash = bytes32(99);
+    expect(reconcileHookemonBrowserAttemptV1({
+      attempt: submitted,
+      serverState: wrongHash,
+    }).recoveryRequired).toBe(true);
+  });
+
+  it("allows a no-send clear only for the exact still-ready prompt", () => {
+    const opened = createHookemonBrowserAttemptV1({
+      action,
+      binding,
+      createdAt: "2026-08-10T16:00:00.000Z",
+    });
+    expect(hookemonCanClearUncertainNoSendV1({
+      attempt: opened,
+      readyAction: action,
+    })).toBe(true);
+    const submitted = markHookemonBrowserAttemptSubmittedV1(
+      opened,
+      bytes32(20),
+    );
+    expect(hookemonCanClearUncertainNoSendV1({
+      attempt: submitted,
+      readyAction: action,
+    })).toBe(false);
+  });
+});
+
+function serverState(overrides: Partial<MutableState> = {}): HookemonApplicantFlowStateV1 {
+  return {
+    schemaVersion: "programmable.hookemon-applicant-flow-state-response.v1",
+    bindingHash: binding.bindingHash,
+    subjectHash: binding.subjectHash,
+    planHash: binding.planHash,
+    profileKey: binding.profileKey,
+    stateVersion: "10",
+    state: "CREATE_READY",
+    finalizedActions: [approvalFinality()],
+    pendingAction: null,
+    readyAction: action,
+    blocker: null,
+    ...overrides,
+  };
+}
+
+function approvalFinality() {
+  return {
+    schemaVersion: "programmable.hookemon-action-finality.v1",
+    actionIndex: 0,
+    actionKind: "ERC20_APPROVAL",
+    selectorHash: sha(40),
+    actionHash: sha(41),
+    transactionHash: bytes32(42),
+    blockNumber: "23000000",
+    blockHash: bytes32(43),
+    confirmations: 64,
+    receiptEvidenceHash: sha(44),
+    finalityEvidenceHash: sha(45),
+    resultHash: bytes32(46),
+  } as const;
+}
+
+type DeepMutable<T> = T extends readonly (infer Item)[]
+  ? DeepMutable<Item>[]
+  : T extends object
+    ? { -readonly [Key in keyof T]: DeepMutable<T[Key]> }
+    : T;
+
+type MutableState = DeepMutable<HookemonApplicantFlowStateV1>;

--- a/tests/hookemon-applicant-contract.test.ts
+++ b/tests/hookemon-applicant-contract.test.ts
@@ -1,0 +1,360 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import Ajv2020 from "ajv/dist/2020";
+import { describe, expect, it } from "vitest";
+import { getAddress, keccak256 } from "viem";
+
+import {
+  createHookemonFinalityRequestV1,
+  createHookemonTransactionReportV1,
+  HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
+  HOOKEMON_FLOW_STATE_SCHEMA_V1,
+  parseHookemonApplicantFlowStateV1,
+  parseHookemonBrowserWalletActionV1,
+  type HookemonApplicantFlowBindingV1,
+  type HookemonBrowserWalletActionV1,
+} from "../lib/custom-launch/hookemon-applicant-contract-v1";
+
+const sha = (byte: number) =>
+  `sha256:${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+const bytes32 = (byte: number) =>
+  `0x${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+const address = (byte: number) => getAddress(
+  `0x${byte.toString(16).padStart(2, "0").repeat(20)}`,
+);
+
+const launcher = address(0x22);
+const fundingUsdc = "123456789";
+const approvalData = `0x095ea7b3${launcher.slice(2).toLowerCase().padStart(64, "0")}${
+  BigInt(fundingUsdc).toString(16).padStart(64, "0")
+}` as const;
+const createData = "0x600060005560016000f3" as const;
+const adoptionSelector = "0x12345678" as const;
+const adoptionData = `${adoptionSelector}${"ab".repeat(96)}` as const;
+
+const binding = Object.freeze({
+  bindingHash: sha(1),
+  subjectHash: sha(2),
+  profileKey: bytes32(3),
+  profileSchemaHash: bytes32(4),
+  planHash: bytes32(5),
+  sourceCommit: "11".repeat(20),
+  sourceTree: "22".repeat(20),
+  launchWallet: address(0x11),
+  launcher,
+  launcherInitCodeHash: keccak256(createData),
+  fundingUsdc,
+  approvalNonce: "7",
+  launcherNonce: "8",
+  adoptionTarget: address(0x33),
+  adoptionSelector,
+  requiredConfirmations: 64,
+} as const satisfies HookemonApplicantFlowBindingV1);
+
+describe("Hookemon Applicant Authority/browser contract", () => {
+  it("freezes one strict Authority/browser JSON Schema", () => {
+    const source = readFileSync(join(
+      process.cwd(),
+      "lib/custom-launch/artifacts/hookemon-applicant-authority-browser.v1.schema.json",
+    ), "utf8");
+    const schema = JSON.parse(source) as Record<string, unknown>;
+    const validate = new Ajv2020({ strict: true }).compile(schema);
+    expect(schema.$id).toBe(
+      "urn:programmable:hookemon-applicant-authority-browser:1.0.0",
+    );
+    expect(validate(state("CREATE_READY"))).toBe(true);
+    const extra = { ...state("CREATE_READY"), opaqueCalldata: "0x1234" };
+    expect(validate(extra)).toBe(false);
+  });
+
+  it("accepts only the exact approval -> CREATE action shapes", () => {
+    const approval = parseHookemonBrowserWalletActionV1(
+      action(0),
+      binding,
+      "1000",
+    );
+    expect(approval.transaction).toMatchObject({
+      to: getAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+      nonce: "0x7",
+      value: "0x0",
+    });
+
+    const create = parseHookemonBrowserWalletActionV1(
+      action(1),
+      binding,
+      "1000",
+    );
+    expect(create.transaction).toMatchObject({
+      to: null,
+      nonce: "0x8",
+      data: createData,
+    });
+
+  });
+
+  it("keeps adoption unavailable until the exact V2.2 decoder is frozen", () => {
+    expect(() => parseHookemonBrowserWalletActionV1(
+      action(2),
+      binding,
+      "1000",
+    )).toThrow(/V2\.2 adoption decoder is unavailable/u);
+  });
+
+  it("rejects route substitution, CREATE-to-call conversion and nonce drift", () => {
+    const wrongApproval = structuredClone(action(0));
+    wrongApproval.transaction.data = `0x095ea7b3${address(0x99)
+      .slice(2).toLowerCase().padStart(64, "0")}${
+      BigInt(fundingUsdc).toString(16).padStart(64, "0")
+    }`;
+    wrongApproval.dataHash = keccak256(wrongApproval.transaction.data);
+    expect(() => parseHookemonBrowserWalletActionV1(
+      wrongApproval,
+      binding,
+      "1000",
+    )).toThrow(/spender or amount/u);
+
+    const createCall = structuredClone(action(1));
+    createCall.transaction.to = address(0x77);
+    expect(() => parseHookemonBrowserWalletActionV1(
+      createCall,
+      binding,
+      "1000",
+    )).toThrow(/CREATE transaction/u);
+
+    const driftedNonce = structuredClone(action(1));
+    driftedNonce.transaction.nonce = "0x9";
+    driftedNonce.currentness.observedPendingNonce = "0x9";
+    expect(() => parseHookemonBrowserWalletActionV1(
+      driftedNonce,
+      binding,
+      "1000",
+    )).toThrow(/CREATE transaction/u);
+
+    const staleObservation = structuredClone(action(2));
+    staleObservation.currentness.observedPendingNonce = "0x62";
+    expect(() => parseHookemonBrowserWalletActionV1(
+      staleObservation,
+      binding,
+      "1000",
+    )).toThrow(/nonce is not current/u);
+  });
+
+  it("requires fresh runtime and completed-graph evidence only for adoption", () => {
+    const missingRuntime = structuredClone(action(2));
+    missingRuntime.currentness.runtimeStatusHash = null;
+    expect(() => parseHookemonBrowserWalletActionV1(
+      missingRuntime,
+      binding,
+      "1000",
+    )).toThrow(/currentness evidence is incomplete/u);
+
+    const prematureGraph = structuredClone(action(0));
+    prematureGraph.currentness.completedGraphHash = bytes32(20);
+    expect(() => parseHookemonBrowserWalletActionV1(
+      prematureGraph,
+      binding,
+      "1000",
+    )).toThrow(/currentness evidence is incomplete/u);
+
+    expect(() => parseHookemonBrowserWalletActionV1(
+      action(2),
+      binding,
+      "4600",
+    )).toThrow(/not current/u);
+  });
+
+  it("accepts exactly one disposition for every sequence state", () => {
+    const approvalReady = parseHookemonApplicantFlowStateV1(
+      state("APPROVAL_READY"),
+      binding,
+      "1000",
+    );
+    expect(approvalReady.readyAction?.actionKind).toBe("ERC20_APPROVAL");
+    expect(Object.isFrozen(approvalReady)).toBe(true);
+
+    const createReady = parseHookemonApplicantFlowStateV1(
+      state("CREATE_READY"),
+      binding,
+      "1000",
+    );
+    expect(createReady.finalizedActions).toHaveLength(1);
+    expect(createReady.readyAction?.actionKind).toBe("EOA_CREATE");
+
+    const graphPending = parseHookemonApplicantFlowStateV1(
+      state("GRAPH_CURRENTNESS_PENDING"),
+      binding,
+      "1000",
+    );
+    expect(graphPending.finalizedActions).toHaveLength(2);
+    expect(graphPending.readyAction).toBeNull();
+    expect(() => parseHookemonApplicantFlowStateV1(
+      state("ADOPTION_READY"),
+      binding,
+      "1000",
+    )).toThrow(/V2\.2 adoption decoder is unavailable/u);
+
+    const competing = state("CREATE_READY");
+    competing.pendingAction = reported(1);
+    expect(() => parseHookemonApplicantFlowStateV1(
+      competing,
+      binding,
+      "1000",
+    )).toThrow(/competing dispositions/u);
+  });
+
+  it("binds report and finality requests to the exact action selector", () => {
+    const parsed = parseHookemonBrowserWalletActionV1(
+      action(1),
+      binding,
+      "1000",
+    );
+    const report = createHookemonTransactionReportV1(parsed, bytes32(80));
+    expect(report).toMatchObject({
+      schemaVersion: "programmable.hookemon-applicant-transaction-report.v1",
+      bindingHash: binding.bindingHash,
+      actionIndex: 1,
+      actionKind: "EOA_CREATE",
+      selectorHash: parsed.selectorHash,
+      actionHash: parsed.actionHash,
+      transactionHash: bytes32(80),
+    });
+    expect(createHookemonFinalityRequestV1(parsed, bytes32(80)))
+      .toMatchObject({
+        schemaVersion: "programmable.hookemon-applicant-finality-request.v1",
+        selectorHash: parsed.selectorHash,
+      });
+  });
+});
+
+function action(index: 0 | 1 | 2): MutableAction {
+  const data = index === 0 ? approvalData : index === 1 ? createData : adoptionData;
+  const previousFinalityEvidenceHash = index === 0 ? null : sha(40 + index);
+  return {
+    schemaVersion: HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
+    bindingHash: binding.bindingHash,
+    stateVersion: String(index + 10),
+    actionIndex: index,
+    actionKind: [
+      "ERC20_APPROVAL",
+      "EOA_CREATE",
+      "COMPLETED_GRAPH_ADOPTION",
+    ][index] as MutableAction["actionKind"],
+    selectorHash: sha(10 + index),
+    actionHash: sha(20 + index),
+    dataHash: keccak256(data),
+    previousFinalityEvidenceHash,
+    permitDigest: index === 2 ? bytes32(30) : null,
+    validAfterEpochSeconds: "900",
+    expiresAtEpochSeconds: "1200",
+    currentness: {
+      schemaVersion: "programmable.hookemon-action-currentness.v1",
+      kind: ["PRE_APPROVAL", "PRE_CREATE", "PRE_ADOPTION"][index] as
+        MutableAction["currentness"]["kind"],
+      observedBlockNumber: "23000000",
+      observedBlockHash: bytes32(31),
+      observedPendingNonce: index === 0 ? "0x7" : index === 1 ? "0x8" : "0x63",
+      evidenceHash: sha(32 + index),
+      previousFinalityEvidenceHash,
+      completedGraphHash: index === 2 ? bytes32(20) : null,
+      currentPoolStateHash: index === 2 ? bytes32(21) : null,
+      runtimeStatusHash: index === 2 ? sha(22) : null,
+    },
+    transaction: {
+      method: "eth_sendTransaction",
+      chainId: "0x1",
+      from: binding.launchWallet,
+      to: index === 0
+        ? getAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+        : index === 1 ? null : binding.adoptionTarget,
+      nonce: index === 0 ? "0x7" : index === 1 ? "0x8" : "0x63",
+      gas: index === 0 ? "0x10000" : "0x100000",
+      data,
+      value: "0x0",
+    },
+  };
+}
+
+function finalized(index: 0 | 1 | 2) {
+  return {
+    schemaVersion: "programmable.hookemon-action-finality.v1",
+    actionIndex: index,
+    actionKind: [
+      "ERC20_APPROVAL",
+      "EOA_CREATE",
+      "COMPLETED_GRAPH_ADOPTION",
+    ][index],
+    selectorHash: sha(10 + index),
+    actionHash: sha(20 + index),
+    transactionHash: bytes32(50 + index),
+    blockNumber: String(23_000_000 + index),
+    blockHash: bytes32(60 + index),
+    confirmations: 64,
+    receiptEvidenceHash: sha(70 + index),
+    finalityEvidenceHash: sha(41 + index),
+    resultHash: bytes32(75 + index),
+  };
+}
+
+function reported(index: 0 | 1 | 2) {
+  return {
+    schemaVersion: "programmable.hookemon-reported-action.v1",
+    actionIndex: index,
+    actionKind: [
+      "ERC20_APPROVAL",
+      "EOA_CREATE",
+      "COMPLETED_GRAPH_ADOPTION",
+    ][index],
+    selectorHash: sha(10 + index),
+    actionHash: sha(20 + index),
+    transactionHash: bytes32(50 + index),
+    reportedAtEpochSeconds: "1000",
+  };
+}
+
+function state(name: string) {
+  const finalizedCount = name.startsWith("CREATE") ? 1
+    : name === "GRAPH_CURRENTNESS_PENDING" || name.startsWith("ADOPTION")
+      ? 2
+      : name === "FINALIZED" ? 3 : 0;
+  const readyIndex = name === "APPROVAL_READY" ? 0
+    : name === "CREATE_READY" ? 1
+      : name === "ADOPTION_READY" ? 2 : null;
+  const pendingIndex = name === "APPROVAL_SUBMITTED" ? 0
+    : name === "CREATE_SUBMITTED" ? 1
+      : name === "ADOPTION_SUBMITTED" ? 2 : null;
+  const ready = readyIndex === null ? null : action(readyIndex);
+  if (readyIndex === 1 && ready !== null) {
+    ready.previousFinalityEvidenceHash = sha(41);
+    ready.currentness.previousFinalityEvidenceHash = sha(41);
+  } else if (readyIndex === 2 && ready !== null) {
+    ready.previousFinalityEvidenceHash = sha(42);
+    ready.currentness.previousFinalityEvidenceHash = sha(42);
+  }
+  return {
+    schemaVersion: HOOKEMON_FLOW_STATE_SCHEMA_V1,
+    bindingHash: binding.bindingHash,
+    subjectHash: binding.subjectHash,
+    planHash: binding.planHash,
+    profileKey: binding.profileKey,
+    stateVersion: ready?.stateVersion ?? "20",
+    state: name,
+    finalizedActions: Array.from(
+      { length: finalizedCount },
+      (_, index) => finalized(index as 0 | 1 | 2),
+    ),
+    pendingAction: pendingIndex === null ? null : reported(pendingIndex),
+    readyAction: ready,
+    blocker: name === "BLOCKED"
+      ? { code: "authority_release_pending", owner: "platform", retryable: false }
+      : null,
+  };
+}
+
+type DeepMutable<T> = T extends readonly (infer Item)[]
+  ? DeepMutable<Item>[]
+  : T extends object
+    ? { -readonly [Key in keyof T]: DeepMutable<T[Key]> }
+    : T;
+
+type MutableAction = DeepMutable<HookemonBrowserWalletActionV1>;

--- a/tests/hookemon-applicant-contract.test.ts
+++ b/tests/hookemon-applicant-contract.test.ts
@@ -3,12 +3,13 @@ import { join } from "node:path";
 
 import Ajv2020 from "ajv/dist/2020";
 import { describe, expect, it } from "vitest";
-import { getAddress, keccak256 } from "viem";
+import { getAddress, getCreateAddress, keccak256 } from "viem";
 
 import {
   assertHookemonAdoptionByteExactReencodingV22,
 } from "../lib/custom-launch/hookemon-adoption-verifier-v22";
 import {
+  assertHookemonApplicantFlowBindingV1,
   createHookemonFinalityRequestV1,
   createHookemonTransactionReportV1,
   HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
@@ -27,7 +28,8 @@ const address = (byte: number) => getAddress(
   `0x${byte.toString(16).padStart(2, "0").repeat(20)}`,
 );
 
-const launcher = address(0x22);
+const launchWallet = address(0x11);
+const launcher = getCreateAddress({ from: launchWallet, nonce: 8n });
 const fundingUsdc = "123456789";
 const approvalData = `0x095ea7b3${launcher.slice(2).toLowerCase().padStart(64, "0")}${
   BigInt(fundingUsdc).toString(16).padStart(64, "0")
@@ -44,7 +46,7 @@ const binding = Object.freeze({
   planHash: bytes32(5),
   sourceCommit: "11".repeat(20),
   sourceTree: "22".repeat(20),
-  launchWallet: address(0x11),
+  launchWallet,
   launcher,
   launcherInitCodeHash: keccak256(createData),
   fundingUsdc,
@@ -96,6 +98,16 @@ describe("Hookemon Applicant Authority/browser contract", () => {
 
   });
 
+  it("derives the normal-CREATE launcher from wallet and launcher nonce", () => {
+    expect(assertHookemonApplicantFlowBindingV1(binding).launcher).toBe(
+      getCreateAddress({ from: launchWallet, nonce: 8n }),
+    );
+    expect(() => assertHookemonApplicantFlowBindingV1({
+      ...binding,
+      launcher: address(0x22),
+    })).toThrow(/nonce or finality binding is invalid/u);
+  });
+
   it("keeps adoption unavailable until the exact V2.2 decoder is frozen", () => {
     expect(() => parseHookemonBrowserWalletActionV1(
       action(2),
@@ -128,7 +140,7 @@ describe("Hookemon Applicant Authority/browser contract", () => {
     })).toThrow(/byte-exact deterministic re-encoding/u);
   });
 
-  it("rejects route substitution, CREATE-to-call conversion and nonce drift", () => {
+  it("rejects noncanonical approval, CREATE-to-call conversion and nonce drift", () => {
     const wrongApproval = structuredClone(action(0));
     wrongApproval.transaction.data = `0x095ea7b3${address(0x99)
       .slice(2).toLowerCase().padStart(64, "0")}${
@@ -139,7 +151,48 @@ describe("Hookemon Applicant Authority/browser contract", () => {
       wrongApproval,
       binding,
       "1000",
-    )).toThrow(/spender or amount/u);
+    )).toThrow(/approval calldata is invalid/u);
+
+    const wrongAmount = structuredClone(action(0));
+    wrongAmount.transaction.data = `0x095ea7b3${launcher.slice(2)
+      .toLowerCase().padStart(64, "0")}${
+      (BigInt(fundingUsdc) + 1n).toString(16).padStart(64, "0")
+    }`;
+    wrongAmount.dataHash = keccak256(wrongAmount.transaction.data);
+    expect(() => parseHookemonBrowserWalletActionV1(
+      wrongAmount,
+      binding,
+      "1000",
+    )).toThrow(/approval calldata is invalid/u);
+
+    const dirtySpenderPadding = structuredClone(action(0));
+    dirtySpenderPadding.transaction.data = `0x095ea7b3${"01".repeat(12)}${
+      launcher.slice(2).toLowerCase()
+    }${BigInt(fundingUsdc).toString(16).padStart(64, "0")}`;
+    dirtySpenderPadding.dataHash = keccak256(
+      dirtySpenderPadding.transaction.data,
+    );
+    expect(() => parseHookemonBrowserWalletActionV1(
+      dirtySpenderPadding,
+      binding,
+      "1000",
+    )).toThrow(/approval calldata is invalid/u);
+
+    const wrongUsdcTarget = structuredClone(action(0));
+    wrongUsdcTarget.transaction.to = address(0x99);
+    expect(() => parseHookemonBrowserWalletActionV1(
+      wrongUsdcTarget,
+      binding,
+      "1000",
+    )).toThrow(/approval transaction is invalid/u);
+
+    const nonzeroValue = structuredClone(action(0));
+    nonzeroValue.transaction.value = "0x1" as "0x0";
+    expect(() => parseHookemonBrowserWalletActionV1(
+      nonzeroValue,
+      binding,
+      "1000",
+    )).toThrow(/transaction envelope is invalid/u);
 
     const createCall = structuredClone(action(1));
     createCall.transaction.to = address(0x77);
@@ -157,6 +210,23 @@ describe("Hookemon Applicant Authority/browser contract", () => {
       binding,
       "1000",
     )).toThrow(/CREATE transaction/u);
+
+    const alteredInitcode = structuredClone(action(1));
+    alteredInitcode.transaction.data = "0x6001";
+    alteredInitcode.dataHash = keccak256(alteredInitcode.transaction.data);
+    expect(() => parseHookemonBrowserWalletActionV1(
+      alteredInitcode,
+      binding,
+      "1000",
+    )).toThrow(/launcher init code drifted/u);
+
+    const alteredDataHash = structuredClone(action(1));
+    alteredDataHash.dataHash = bytes32(0xee);
+    expect(() => parseHookemonBrowserWalletActionV1(
+      alteredDataHash,
+      binding,
+      "1000",
+    )).toThrow(/data hash is invalid/u);
 
     const staleObservation = structuredClone(action(2));
     staleObservation.currentness.observedPendingNonce = "0x62";

--- a/tests/hookemon-applicant-contract.test.ts
+++ b/tests/hookemon-applicant-contract.test.ts
@@ -6,6 +6,9 @@ import { describe, expect, it } from "vitest";
 import { getAddress, keccak256 } from "viem";
 
 import {
+  assertHookemonAdoptionByteExactReencodingV22,
+} from "../lib/custom-launch/hookemon-adoption-verifier-v22";
+import {
   createHookemonFinalityRequestV1,
   createHookemonTransactionReportV1,
   HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
@@ -99,6 +102,30 @@ describe("Hookemon Applicant Authority/browser contract", () => {
       binding,
       "1000",
     )).toThrow(/V2\.2 adoption decoder is unavailable/u);
+  });
+
+  it("reserves a byte-exact final guard for the frozen V2.2 recomputation", () => {
+    const expectedCalldataHash = keccak256(adoptionData);
+    expect(() => assertHookemonAdoptionByteExactReencodingV22({
+      calldata: adoptionData,
+      expectedSelector: adoptionSelector,
+      expectedCalldataHash,
+      reencodedCalldata: adoptionData,
+    })).not.toThrow();
+
+    const sameSelectorTamper = `${adoptionSelector}${"ac".repeat(96)}` as const;
+    expect(() => assertHookemonAdoptionByteExactReencodingV22({
+      calldata: adoptionData,
+      expectedSelector: adoptionSelector,
+      expectedCalldataHash,
+      reencodedCalldata: sameSelectorTamper,
+    })).toThrow(/byte-exact deterministic re-encoding/u);
+    expect(() => assertHookemonAdoptionByteExactReencodingV22({
+      calldata: sameSelectorTamper,
+      expectedSelector: adoptionSelector,
+      expectedCalldataHash,
+      reencodedCalldata: sameSelectorTamper,
+    })).toThrow(/byte-exact deterministic re-encoding/u);
   });
 
   it("rejects route substitution, CREATE-to-call conversion and nonce drift", () => {

--- a/tests/hookemon-applicant-presentation.test.ts
+++ b/tests/hookemon-applicant-presentation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HOOKEMON_APPLICANT_ACTION_ORDER_V1,
+  HOOKEMON_APPLICANT_IDENTITY_V1,
+  isExactHookemonApplicantGithubLoginV1,
+} from "../lib/custom-launch/hookemon-applicant-presentation-v1";
+
+describe("Hookemon Applicant presentation identity", () => {
+  it("binds the exact public request and source identity", () => {
+    expect(HOOKEMON_APPLICANT_IDENTITY_V1).toEqual({
+      githubLogin: "hookemonv4",
+      githubUserId: "312745360",
+      githubNodeId: "U_kgDOEqQdkA",
+      repository: "hookemonv4/hookemon",
+      repositoryId: "1324982531",
+      requestPath: "submissions/requests/1324982531-hookemon.json",
+      submissionSchemaId: "urn:programmable:applicant-submission:1.1.0",
+      submissionSchemaVersion: "1.1.0",
+      launchWallet: "0x5E9a7A24DCCC81cddd10b8a555300E227533c89f",
+      sourceCommit: "23336e60ae5859dbb0ae9c0db3399af4ef4af8e8",
+      sourceTree: "7624bde3bb09f654e77881880c419e356ed85c29",
+    });
+    expect(Object.isFrozen(HOOKEMON_APPLICANT_IDENTITY_V1)).toBe(true);
+  });
+
+  it("keeps the three wallet confirmations in their only safe order", () => {
+    expect(HOOKEMON_APPLICANT_ACTION_ORDER_V1).toEqual([
+      "ERC20_APPROVAL",
+      "EOA_CREATE",
+      "COMPLETED_GRAPH_ADOPTION",
+    ]);
+    expect(Object.isFrozen(HOOKEMON_APPLICANT_ACTION_ORDER_V1)).toBe(true);
+  });
+
+  it("uses the login only for presentation routing", () => {
+    expect(isExactHookemonApplicantGithubLoginV1("hookemonv4")).toBe(true);
+    expect(isExactHookemonApplicantGithubLoginV1("HookemonV4")).toBe(true);
+    expect(isExactHookemonApplicantGithubLoginV1("jesse-stahl")).toBe(false);
+    expect(isExactHookemonApplicantGithubLoginV1(null)).toBe(false);
+  });
+});

--- a/tests/hookemon-authority-envelope.test.ts
+++ b/tests/hookemon-authority-envelope.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  HOOKEMON_ACTION_AUTHORITY_ENVELOPE_SCHEMA_V1,
+  HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
+  canonicalHookemonAuthoritySha256V1,
+  canonicalizeHookemonAuthorityJsonV1,
+  computeHookemonActionAuthorityEnvelopeHashV1,
+  computeHookemonActionSelectorHashV1,
+  computeHookemonAuthorityActionHashV1,
+  hookemonActionAuthoritySigningBytesV1,
+  verifyHookemonActionAuthorityEnvelopeV1,
+  type HookemonActionAuthorityEnvelopeCoreV1,
+  type HookemonAuthorityBrowserActionCoreV1,
+} from "../lib/custom-launch/hookemon-authority-envelope-v1";
+
+const sha = (byte: number) =>
+  `sha256:${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+const bytes32 = (byte: number) =>
+  `0x${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+
+const bindingHash = sha(0x11);
+const releaseHeadHash = sha(0x12);
+const currentnessEvidenceHash = sha(0x13);
+const authorityKeyId = "hookemon-action-authority-2026-08";
+const signature = `ed25519:${"A".repeat(86)}` as const;
+
+const actionCoreBase = Object.freeze({
+  schemaVersion: HOOKEMON_BROWSER_ACTION_SCHEMA_V1,
+  bindingHash,
+  stateVersion: "7",
+  actionIndex: 0,
+  actionKind: "ERC20_APPROVAL",
+  dataHash: bytes32(0x21),
+  previousFinalityEvidenceHash: null,
+  permitDigest: null,
+  validAfterEpochSeconds: "1723300000",
+  expiresAtEpochSeconds: "1723301800",
+  currentness: Object.freeze({
+    schemaVersion: "programmable.hookemon-dual-rpc-currentness.v1",
+    currentnessEvidenceHash,
+    observations: Object.freeze([
+      Object.freeze({ providerIdentityHash: sha(0x31), pendingNonce: "0x8" }),
+      Object.freeze({ providerIdentityHash: sha(0x32), pendingNonce: "0x8" }),
+    ]),
+  }),
+  transaction: Object.freeze({
+    method: "eth_sendTransaction",
+    chainId: "0x1",
+    from: "0x5e9a7a24dccc81cddd10b8a555300e227533c89f",
+    to: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    nonce: "0x8",
+    gas: "0x15f90",
+    data: "0x095ea7b3",
+    value: "0x0",
+  }),
+} as const);
+
+function authorityFixture() {
+  const selectorHash = computeHookemonActionSelectorHashV1({
+    bindingHash: actionCoreBase.bindingHash,
+    stateVersion: actionCoreBase.stateVersion,
+    actionIndex: actionCoreBase.actionIndex,
+    actionKind: actionCoreBase.actionKind,
+    previousFinalityEvidenceHash: actionCoreBase.previousFinalityEvidenceHash,
+    permitDigest: actionCoreBase.permitDigest,
+    validAfterEpochSeconds: actionCoreBase.validAfterEpochSeconds,
+    expiresAtEpochSeconds: actionCoreBase.expiresAtEpochSeconds,
+    currentnessEvidenceHash,
+  });
+  const actionCore: HookemonAuthorityBrowserActionCoreV1 = Object.freeze({
+    ...actionCoreBase,
+    selectorHash,
+  });
+  const action = Object.freeze({
+    ...actionCore,
+    actionHash: computeHookemonAuthorityActionHashV1(actionCore),
+  });
+  const envelopeCore: HookemonActionAuthorityEnvelopeCoreV1 = Object.freeze({
+    schemaVersion: HOOKEMON_ACTION_AUTHORITY_ENVELOPE_SCHEMA_V1,
+    bindingHash,
+    releaseHeadHash,
+    revocationEpoch: "2",
+    selectorHash: action.selectorHash,
+    actionHash: action.actionHash,
+    authorityKeyId,
+    signatureAlgorithm: "ed25519",
+  });
+  const envelope = Object.freeze({
+    ...envelopeCore,
+    envelopeHash: computeHookemonActionAuthorityEnvelopeHashV1(envelopeCore),
+    signature,
+  });
+  const expectedRelease = Object.freeze({
+    bindingHash,
+    releaseHeadHash,
+    revocationEpoch: "2",
+    authorityKeyId,
+  });
+  return { action, envelope, envelopeCore, expectedRelease };
+}
+
+describe("Hookemon browser Authority envelope", () => {
+  it("uses deterministic JCS domain-separated hashes", () => {
+    expect(canonicalizeHookemonAuthorityJsonV1({ z: 1, a: [true, null] }))
+      .toBe('{"a":[true,null],"z":1}');
+    expect(canonicalHookemonAuthoritySha256V1(
+      "programmable.hookemon-action-selector.v1",
+      { z: 1, a: [true, null] },
+    )).toBe(
+      "sha256:659507239a465c86f48d72fdf5ee558872fd91c9ba6daf60240d43a18be6ef86",
+    );
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => canonicalizeHookemonAuthorityJsonV1(cyclic)).toThrow(/cyclic/u);
+    expect(() => canonicalizeHookemonAuthorityJsonV1("\ud800"))
+      .toThrow(/lone high surrogate/u);
+    expect(() => canonicalizeHookemonAuthorityJsonV1({ value: undefined }))
+      .toThrow(/does not support undefined/u);
+  });
+
+  it("recomputes selector, full action, envelope and exact signing bytes", async () => {
+    const fixture = authorityFixture();
+    expect(fixture.action.selectorHash).toBe(
+      "sha256:2cf4ad9ff274d61d3b0cbb6c4bae4f8ebf6d9eac591dc4697a89fab5eb118416",
+    );
+    expect(fixture.action.actionHash).toBe(
+      "sha256:44a334672604fb0cb8c95c75051c8f5843a4327adf1128f4edd6586caf752e8a",
+    );
+    expect(fixture.envelope.envelopeHash).toBe(
+      "sha256:b6a546d1b73b0d582865198d89eaa6e729f05bf20ff53cd7c971a00c97b38305",
+    );
+    const verifySignature = vi.fn((request: Readonly<{
+      keyId: string;
+      signingBytes: Uint8Array;
+      signature: Uint8Array;
+    }>) => {
+      void request;
+      return true;
+    });
+    const verified = await verifyHookemonActionAuthorityEnvelopeV1({
+      action: fixture.action,
+      envelope: fixture.envelope,
+      expectedRelease: fixture.expectedRelease,
+      verifySignature,
+    });
+    expect(verified).toEqual({
+      action: fixture.action,
+      envelope: fixture.envelope,
+    });
+    expect(verifySignature).toHaveBeenCalledOnce();
+    const request = verifySignature.mock.calls[0]![0];
+    expect(request.keyId).toBe(authorityKeyId);
+    expect(request.signature).toHaveLength(64);
+    expect(request.signingBytes).toEqual(
+      hookemonActionAuthoritySigningBytesV1({
+        ...fixture.envelopeCore,
+        envelopeHash: fixture.envelope.envelopeHash,
+      }),
+    );
+    expect(new TextDecoder().decode(request.signingBytes)).toContain(
+      "programmable.hookemon-action-authority-envelope-signing.v1\u0000",
+    );
+  });
+
+  it("rejects relabeling, transaction/currentness drift and release drift", async () => {
+    const fixture = authorityFixture();
+    const verifySignature = vi.fn(() => true);
+    const mutations: unknown[] = [
+      { ...fixture.action, actionKind: "EOA_CREATE" },
+      { ...fixture.action, actionIndex: 1 },
+      {
+        ...fixture.action,
+        transaction: { ...fixture.action.transaction, to: bytes32(0x44) },
+      },
+      {
+        ...fixture.action,
+        currentness: {
+          ...fixture.action.currentness,
+          currentnessEvidenceHash: sha(0x45),
+        },
+      },
+      { ...fixture.action, selectorHash: sha(0x46) },
+      { ...fixture.action, actionHash: sha(0x47) },
+    ];
+    for (const action of mutations) {
+      await expect(verifyHookemonActionAuthorityEnvelopeV1({
+        action,
+        envelope: fixture.envelope,
+        expectedRelease: fixture.expectedRelease,
+        verifySignature,
+      })).rejects.toThrow();
+    }
+    for (const [field, value] of Object.entries({
+      bindingHash: sha(0x51),
+      releaseHeadHash: sha(0x52),
+      revocationEpoch: "3",
+      authorityKeyId: "different-key",
+    })) {
+      await expect(verifyHookemonActionAuthorityEnvelopeV1({
+        action: fixture.action,
+        envelope: fixture.envelope,
+        expectedRelease: { ...fixture.expectedRelease, [field]: value },
+        verifySignature,
+      }), field).rejects.toThrow(/exact release/u);
+    }
+    await expect(verifyHookemonActionAuthorityEnvelopeV1({
+      action: fixture.action,
+      envelope: fixture.envelope,
+      expectedRelease: fixture.expectedRelease,
+      verifySignature: () => false,
+    })).rejects.toThrow(/signature is invalid/u);
+  });
+
+  it("rejects free envelope hashes, padded signatures and unexpected fields", async () => {
+    const fixture = authorityFixture();
+    const verifySignature = () => true;
+    await expect(verifyHookemonActionAuthorityEnvelopeV1({
+      action: fixture.action,
+      envelope: { ...fixture.envelope, envelopeHash: sha(0x61) },
+      expectedRelease: fixture.expectedRelease,
+      verifySignature,
+    })).rejects.toThrow(/exact release/u);
+    await expect(verifyHookemonActionAuthorityEnvelopeV1({
+      action: fixture.action,
+      envelope: { ...fixture.envelope, signature: `${signature}=` },
+      expectedRelease: fixture.expectedRelease,
+      verifySignature,
+    })).rejects.toThrow(/signature encoding/u);
+    await expect(verifyHookemonActionAuthorityEnvelopeV1({
+      action: { ...fixture.action, opaque: "accepted" },
+      envelope: fixture.envelope,
+      expectedRelease: fixture.expectedRelease,
+      verifySignature,
+    })).rejects.toThrow(/unexpected fields/u);
+  });
+});

--- a/tests/hookemon-authority-envelope.test.ts
+++ b/tests/hookemon-authority-envelope.test.ts
@@ -228,6 +228,15 @@ describe("Hookemon browser Authority envelope", () => {
       verifySignature,
     })).rejects.toThrow(/signature encoding/u);
     await expect(verifyHookemonActionAuthorityEnvelopeV1({
+      action: fixture.action,
+      envelope: {
+        ...fixture.envelope,
+        signature: `${signature.slice(0, -1)}B`,
+      },
+      expectedRelease: fixture.expectedRelease,
+      verifySignature,
+    })).rejects.toThrow(/signature length or encoding/u);
+    await expect(verifyHookemonActionAuthorityEnvelopeV1({
       action: { ...fixture.action, opaque: "accepted" },
       envelope: fixture.envelope,
       expectedRelease: fixture.expectedRelease,

--- a/tests/hookemon-permit-envelope.test.ts
+++ b/tests/hookemon-permit-envelope.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HOOKEMON_LAUNCH_PERMIT_TYPE_HASH_V1,
+  HOOKEMON_PERMIT_ENVELOPE_BYTES_V1,
+  HOOKEMON_PERMIT_ENVELOPE_TYPE_HASH_V1,
+  assertHookemonLaunchPermitV1,
+  assertHookemonPermitEnvelopeReleaseV1,
+  assertHookemonPermitEnvelopeTypeHashesV1,
+  computeHookemonPermitDigestV1,
+  decodeHookemonPermitEnvelopeV1,
+  encodeHookemonPermitEnvelopeV1,
+  type HookemonLaunchPermitV1,
+  type HookemonPermitEnvelopeExpectedReleaseV1,
+  type HookemonPermitSignatureV1,
+} from "../lib/custom-launch/hookemon-permit-envelope-v1";
+
+const bytes32 = (byte: number) =>
+  `0x${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+
+const permit = Object.freeze({
+  chainId: "1",
+  router: "0x1111111111111111111111111111111111111111",
+  launchWallet: "0x5e9a7a24dccc81cddd10b8a555300e227533c89f",
+  profileKey: bytes32(0x22),
+  architectureIdHash: bytes32(0x33),
+  sourceLaunchPlanHash: bytes32(0x44),
+  adoptionPlanHash: bytes32(0x55),
+  architectureResultHash: bytes32(0x66),
+  currentArchitectureStateHash: bytes32(0x77),
+  stampRequestHash: bytes32(0x88),
+  nonce: bytes32(0x99),
+  validAfter: "1723300000",
+  deadline: "1723301800",
+  value: "0",
+} as const satisfies HookemonLaunchPermitV1);
+
+const signature = Object.freeze({
+  r: bytes32(0x11),
+  s: bytes32(0x22),
+  v: 27,
+} as const satisfies HookemonPermitSignatureV1);
+
+describe("Hookemon typed permit envelope", () => {
+  it("pins the two type hashes and exact static 576-byte encoding", () => {
+    expect(() => assertHookemonPermitEnvelopeTypeHashesV1()).not.toThrow();
+    expect(HOOKEMON_PERMIT_ENVELOPE_TYPE_HASH_V1).toBe(
+      "0x76aee0e3ca5251fb636fbe95fc3c44609c3fa524a51d0054aab916ec752319d0",
+    );
+    expect(HOOKEMON_LAUNCH_PERMIT_TYPE_HASH_V1).toBe(
+      "0x9bbf58469f9b0d79df750050233f3adb8e1c7f52e505a731334edd22f0025226",
+    );
+    const envelope = encodeHookemonPermitEnvelopeV1(permit, signature);
+    expect((envelope.length - 2) / 2).toBe(HOOKEMON_PERMIT_ENVELOPE_BYTES_V1);
+    expect(envelope.slice(0, 66)).toBe(HOOKEMON_PERMIT_ENVELOPE_TYPE_HASH_V1);
+    expect(computeHookemonPermitDigestV1(permit)).toBe(
+      "0x14b306e4d9837eb980aff1e379e687feb5659ed8a994454788b4101b83bac4e1",
+    );
+    expect(decodeHookemonPermitEnvelopeV1(envelope)).toEqual({
+      permit,
+      signature,
+      permitDigest: computeHookemonPermitDigestV1(permit),
+      envelopeHash: expect.stringMatching(/^0x[0-9a-f]{64}$/u),
+    });
+  });
+
+  it("recomputes the EIP-712 digest and binds every release field and time", () => {
+    const envelope = encodeHookemonPermitEnvelopeV1(permit, signature);
+    const expected = expectedRelease(permit);
+    expect(assertHookemonPermitEnvelopeReleaseV1({
+      envelope,
+      expected,
+      currentEpochSeconds: "1723300000",
+    }).permitDigest).toBe(expected.permitDigest);
+
+    for (const [field, value] of Object.entries({
+      router: "0x2222222222222222222222222222222222222222",
+      launchWallet: "0x3333333333333333333333333333333333333333",
+      profileKey: bytes32(0xa1),
+      architectureIdHash: bytes32(0xa2),
+      sourceLaunchPlanHash: bytes32(0xa3),
+      adoptionPlanHash: bytes32(0xa4),
+      architectureResultHash: bytes32(0xa5),
+      currentArchitectureStateHash: bytes32(0xa6),
+      stampRequestHash: bytes32(0xa7),
+      nonce: bytes32(0xa8),
+      permitDigest: bytes32(0xa9),
+      validAfterEpochSeconds: "1723300001",
+      expiresAtEpochSeconds: "1723301799",
+    })) {
+      expect(() => assertHookemonPermitEnvelopeReleaseV1({
+        envelope,
+        expected: { ...expected, [field]: value },
+        currentEpochSeconds: "1723300000",
+      }), field).toThrow(/exact current release/u);
+    }
+    expect(() => assertHookemonPermitEnvelopeReleaseV1({
+      envelope,
+      expected,
+      currentEpochSeconds: "1723299999",
+    })).toThrow(/exact current release/u);
+    expect(() => assertHookemonPermitEnvelopeReleaseV1({
+      envelope,
+      expected,
+      currentEpochSeconds: permit.deadline,
+    })).toThrow(/exact current release/u);
+  });
+
+  it("rejects noncanonical ABI words, tags, signatures and windows", () => {
+    const envelope = encodeHookemonPermitEnvelopeV1(permit, signature);
+    const replaceWord = (index: number, word: string) =>
+      `${envelope.slice(0, 2 + index * 64)}${word}${
+        envelope.slice(2 + (index + 1) * 64)
+      }`;
+    expect(() => decodeHookemonPermitEnvelopeV1(
+      replaceWord(0, bytes32(0xaa).slice(2)),
+    )).toThrow(/tag drifted/u);
+    expect(() => decodeHookemonPermitEnvelopeV1(
+      replaceWord(2, `${"01".repeat(12)}${permit.router.slice(2)}`),
+    )).toThrow(/address word is non-canonical/u);
+    expect(() => decodeHookemonPermitEnvelopeV1(
+      replaceWord(12, "01".padEnd(64, "0")),
+    )).toThrow(/uint64 word overflowed/u);
+    expect(() => decodeHookemonPermitEnvelopeV1(envelope.toUpperCase()))
+      .toThrow(/encoding is invalid/u);
+    expect(() => encodeHookemonPermitEnvelopeV1(permit, {
+      ...signature,
+      r: `0x${"f".repeat(64)}`,
+    })).toThrow(/non-canonical/u);
+    expect(() => encodeHookemonPermitEnvelopeV1(permit, {
+      ...signature,
+      s: `0x${"f".repeat(64)}`,
+    })).toThrow(/non-canonical/u);
+    expect(() => encodeHookemonPermitEnvelopeV1(permit, {
+      ...signature,
+      v: 29 as 27,
+    })).toThrow(/non-canonical/u);
+    expect(() => assertHookemonLaunchPermitV1({
+      ...permit,
+      deadline: (BigInt(permit.validAfter) + 3_601n).toString(),
+    })).toThrow(/Mainnet zero-value policy/u);
+  });
+});
+
+function expectedRelease(
+  value: HookemonLaunchPermitV1,
+): HookemonPermitEnvelopeExpectedReleaseV1 {
+  return Object.freeze({
+    router: value.router,
+    launchWallet: value.launchWallet,
+    profileKey: value.profileKey,
+    architectureIdHash: value.architectureIdHash,
+    sourceLaunchPlanHash: value.sourceLaunchPlanHash,
+    adoptionPlanHash: value.adoptionPlanHash,
+    architectureResultHash: value.architectureResultHash,
+    currentArchitectureStateHash: value.currentArchitectureStateHash,
+    stampRequestHash: value.stampRequestHash,
+    nonce: value.nonce,
+    permitDigest: computeHookemonPermitDigestV1(value),
+    validAfterEpochSeconds: value.validAfter,
+    expiresAtEpochSeconds: value.deadline,
+  });
+}

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -1059,7 +1059,7 @@ describe("inactive Shards nested-factory Router V2 browser contract", () => {
     expect(component).toContain("nestedFactoryRoute={isManualRouterResolveV2");
     expect(component).toContain('const SHARDS_GITHUB_LOGIN = "jesse-stahl"');
     expect(component).toContain(
-      "const routeCapabilityUnavailable = exactShardsApplicant",
+      "const shardsRouteCapabilityUnavailable = exactShardsApplicant",
     );
     expect(component).toContain(
       "requireExactShardsRoute: exactShardsApplicant",

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -1,7 +1,25 @@
 import { describe, expect, it, vi } from "vitest";
 import * as walletProvider from "../components/wallet-provider";
+import type {
+  HookemonBrowserWalletActionV1,
+} from "../lib/custom-launch/hookemon-applicant-contract-v1";
 
 type WalletProviderContract = {
+  assertHookemonPendingNonceV1: (
+    observed: unknown,
+    expected: `0x${string}`,
+  ) => void;
+  buildHookemonEip1193TransactionV1: (
+    action: HookemonBrowserWalletActionV1,
+    connectedAccount: `0x${string}`,
+  ) => Readonly<{
+    from: `0x${string}`;
+    to?: `0x${string}`;
+    nonce: `0x${string}`;
+    gas: `0x${string}`;
+    data: `0x${string}`;
+    value: "0x0";
+  }>;
   assertExternalWalletAuthorityCurrent: (input: Readonly<{
     expectedAccount: `0x${string}`;
     expectedChainId: string;
@@ -56,6 +74,66 @@ type WalletProviderContract = {
 const subject = walletProvider as unknown as WalletProviderContract;
 
 describe("wallet recovery state", () => {
+  it("builds exact-nonce Hookemon approval and null-to CREATE requests in isolation", () => {
+    const account = `0x${"1".repeat(40)}` as const;
+    const approval = subject.buildHookemonEip1193TransactionV1(
+      hookemonAction(0),
+      account,
+    );
+    expect(approval).toMatchObject({
+      from: account,
+      to: `0x${"2".repeat(40)}`,
+      nonce: "0x7",
+      gas: "0x10000",
+      value: "0x0",
+    });
+
+    const create = subject.buildHookemonEip1193TransactionV1(
+      hookemonAction(1),
+      account,
+    );
+    expect(create).toMatchObject({
+      from: account,
+      nonce: "0x8",
+      gas: "0x10000",
+      value: "0x0",
+    });
+    expect(Object.hasOwn(create, "to")).toBe(false);
+  });
+
+  it("keeps adoption disabled and rejects any pending-nonce drift", () => {
+    const account = `0x${"1".repeat(40)}` as const;
+    expect(() => subject.buildHookemonEip1193TransactionV1(
+      hookemonAction(2),
+      account,
+    )).toThrow(/not executable/u);
+    expect(() => subject.buildHookemonEip1193TransactionV1(
+      hookemonAction(0),
+      `0x${"9".repeat(40)}`,
+    )).toThrow(/not executable/u);
+    expect(() => subject.assertHookemonPendingNonceV1("0x8", "0x8"))
+      .not.toThrow();
+    expect(() => subject.assertHookemonPendingNonceV1("0x9", "0x8"))
+      .toThrow(/nonce changed/u);
+    expect(() => subject.assertHookemonPendingNonceV1("0x08", "0x8"))
+      .toThrow(/nonce changed/u);
+  });
+
+  it("rejects Hookemon action-kind and currentness substitutions", () => {
+    const account = `0x${"1".repeat(40)}` as const;
+    expect(() => subject.buildHookemonEip1193TransactionV1({
+      ...hookemonAction(0),
+      actionKind: "EOA_CREATE",
+    }, account)).toThrow(/not executable/u);
+    expect(() => subject.buildHookemonEip1193TransactionV1({
+      ...hookemonAction(1),
+      currentness: {
+        ...hookemonAction(1).currentness,
+        kind: "PRE_APPROVAL",
+      },
+    }, account)).toThrow(/not executable/u);
+  });
+
   it("fails closed when an external provider mutates chain before a wallet action", async () => {
     const request = vi.fn(async (method: "eth_chainId" | "eth_accounts") =>
       method === "eth_chainId"
@@ -357,3 +435,57 @@ describe("wallet recovery state", () => {
     expect(subject.selectConnectedWallet([older, newer])).toBe(newer);
   });
 });
+
+function hookemonAction(
+  actionIndex: 0 | 1 | 2,
+): HookemonBrowserWalletActionV1 {
+  const actionKind = [
+    "ERC20_APPROVAL",
+    "EOA_CREATE",
+    "COMPLETED_GRAPH_ADOPTION",
+  ][actionIndex] as HookemonBrowserWalletActionV1["actionKind"];
+  const nonce = actionIndex === 0 ? "0x7" : actionIndex === 1 ? "0x8" : "0x9";
+  return {
+    schemaVersion: "programmable.hookemon-browser-wallet-action.v1",
+    bindingHash: `sha256:${"1".repeat(64)}`,
+    stateVersion: "1",
+    actionIndex,
+    actionKind,
+    selectorHash: `sha256:${"2".repeat(64)}`,
+    actionHash: `sha256:${"3".repeat(64)}`,
+    dataHash: `0x${"4".repeat(64)}`,
+    previousFinalityEvidenceHash: actionIndex === 0
+      ? null
+      : `sha256:${"5".repeat(64)}`,
+    permitDigest: actionIndex === 2 ? `0x${"6".repeat(64)}` : null,
+    validAfterEpochSeconds: "1",
+    expiresAtEpochSeconds: "2",
+    currentness: {
+      schemaVersion: "programmable.hookemon-action-currentness.v1",
+      kind: ["PRE_APPROVAL", "PRE_CREATE", "PRE_ADOPTION"][actionIndex] as
+        HookemonBrowserWalletActionV1["currentness"]["kind"],
+      observedBlockNumber: "1",
+      observedBlockHash: `0x${"7".repeat(64)}`,
+      observedPendingNonce: nonce,
+      evidenceHash: `sha256:${"8".repeat(64)}`,
+      previousFinalityEvidenceHash: actionIndex === 0
+        ? null
+        : `sha256:${"5".repeat(64)}`,
+      completedGraphHash: actionIndex === 2 ? `0x${"9".repeat(64)}` : null,
+      currentPoolStateHash: actionIndex === 2 ? `0x${"a".repeat(64)}` : null,
+      runtimeStatusHash: actionIndex === 2
+        ? `sha256:${"b".repeat(64)}`
+        : null,
+    },
+    transaction: {
+      method: "eth_sendTransaction",
+      chainId: "0x1",
+      from: `0x${"1".repeat(40)}`,
+      to: actionIndex === 1 ? null : `0x${"2".repeat(40)}`,
+      nonce,
+      gas: "0x10000",
+      data: "0x6000",
+      value: "0x0",
+    },
+  };
+}

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+import { getCreateAddress, keccak256 } from "viem";
 import * as walletProvider from "../components/wallet-provider";
-import type {
-  HookemonBrowserWalletActionV1,
+import {
+  HOOKEMON_APPROVE_SELECTOR,
+  HOOKEMON_MAINNET_USDC,
+  parseHookemonBrowserWalletActionV1,
+  type HookemonApplicantFlowBindingV1,
+  type HookemonBrowserWalletActionV1,
 } from "../lib/custom-launch/hookemon-applicant-contract-v1";
 
 type WalletProviderContract = {
@@ -11,7 +16,9 @@ type WalletProviderContract = {
   ) => void;
   buildHookemonEip1193TransactionV1: (
     action: HookemonBrowserWalletActionV1,
+    binding: HookemonApplicantFlowBindingV1,
     connectedAccount: `0x${string}`,
+    currentEpochSeconds: string,
   ) => Readonly<{
     from: `0x${string}`;
     to?: `0x${string}`;
@@ -74,42 +81,64 @@ type WalletProviderContract = {
 const subject = walletProvider as unknown as WalletProviderContract;
 
 describe("wallet recovery state", () => {
-  it("builds exact-nonce Hookemon approval and null-to CREATE requests in isolation", () => {
-    const account = `0x${"1".repeat(40)}` as const;
-    const approval = subject.buildHookemonEip1193TransactionV1(
-      hookemonAction(0),
-      account,
-    );
-    expect(approval).toMatchObject({
-      from: account,
-      to: `0x${"2".repeat(40)}`,
-      nonce: "0x7",
-      gas: "0x10000",
-      value: "0x0",
-    });
-
-    const create = subject.buildHookemonEip1193TransactionV1(
-      hookemonAction(1),
-      account,
-    );
-    expect(create).toMatchObject({
-      from: account,
-      nonce: "0x8",
-      gas: "0x10000",
-      value: "0x0",
-    });
-    expect(Object.hasOwn(create, "to")).toBe(false);
+  it("holds approval and CREATE until exact identifier authority is frozen", () => {
+    for (const actionIndex of [0, 1] as const) {
+      const action = validatedHookemonAction(actionIndex);
+      expect(() => subject.buildHookemonEip1193TransactionV1(
+        action,
+        hookemonBinding,
+        hookemonBinding.launchWallet,
+        "1000",
+      )).toThrow(/identifier authority is unavailable/u);
+    }
   });
 
-  it("keeps adoption disabled and rejects any pending-nonce drift", () => {
-    const account = `0x${"1".repeat(40)}` as const;
+  it("does not promote structurally valid gas, identifiers or currentness to send authority", () => {
+    const candidates = [
+      forgeRawHookemonAction(0, {
+        transaction: { gas: "0x10001" },
+      }),
+      forgeRawHookemonAction(0, {
+        actionHash: hookemonSha(0xd1),
+      }),
+      forgeRawHookemonAction(0, {
+        selectorHash: hookemonSha(0xd2),
+      }),
+      forgeRawHookemonAction(0, {
+        currentness: {
+          observedBlockNumber: "2",
+          observedBlockHash: hookemonBytes32(0xd3),
+          evidenceHash: hookemonSha(0xd4),
+        },
+      }),
+    ];
+    for (const candidate of candidates) {
+      const parsed = parseHookemonBrowserWalletActionV1(
+        candidate,
+        hookemonBinding,
+        "1000",
+      );
+      expect(() => subject.buildHookemonEip1193TransactionV1(
+        parsed,
+        hookemonBinding,
+        hookemonBinding.launchWallet,
+        "1000",
+      )).toThrow(/identifier authority is unavailable/u);
+    }
+  });
+
+  it("keeps unvalidated actions, adoption and pending-nonce drift disabled", () => {
     expect(() => subject.buildHookemonEip1193TransactionV1(
-      hookemonAction(2),
-      account,
-    )).toThrow(/not executable/u);
+      rawHookemonAction(2),
+      hookemonBinding,
+      hookemonBinding.launchWallet,
+      "1000",
+    )).toThrow(/not runtime-validated/u);
     expect(() => subject.buildHookemonEip1193TransactionV1(
-      hookemonAction(0),
+      validatedHookemonAction(0),
+      hookemonBinding,
       `0x${"9".repeat(40)}`,
+      "1000",
     )).toThrow(/not executable/u);
     expect(() => subject.assertHookemonPendingNonceV1("0x8", "0x8"))
       .not.toThrow();
@@ -120,18 +149,89 @@ describe("wallet recovery state", () => {
   });
 
   it("rejects Hookemon action-kind and currentness substitutions", () => {
-    const account = `0x${"1".repeat(40)}` as const;
     expect(() => subject.buildHookemonEip1193TransactionV1({
-      ...hookemonAction(0),
+      ...validatedHookemonAction(0),
       actionKind: "EOA_CREATE",
-    }, account)).toThrow(/not executable/u);
+    }, hookemonBinding, hookemonBinding.launchWallet, "1000"))
+      .toThrow(/not runtime-validated/u);
     expect(() => subject.buildHookemonEip1193TransactionV1({
-      ...hookemonAction(1),
+      ...validatedHookemonAction(1),
       currentness: {
-        ...hookemonAction(1).currentness,
+        ...validatedHookemonAction(1).currentness,
         kind: "PRE_APPROVAL",
       },
-    }, account)).toThrow(/not executable/u);
+    }, hookemonBinding, hookemonBinding.launchWallet, "1000"))
+      .toThrow(/not runtime-validated/u);
+  });
+
+  it("fuzzes tx/currentness drift, relabeling and expiry before send", () => {
+    const approval = validatedHookemonAction(0);
+    const create = validatedHookemonAction(1);
+    const transactionMutations = [
+      { method: "eth_signTransaction" },
+      { chainId: "0xaa36a7" },
+      { from: `0x${"9".repeat(40)}` },
+      { to: `0x${"9".repeat(40)}` },
+      { data: "0x6001" },
+      { data: approval.transaction.data, value: "0x1" },
+      { gas: "0x10001" },
+      { nonce: "0x8" },
+    ] as const;
+    for (const mutation of transactionMutations) {
+      expect(() => subject.buildHookemonEip1193TransactionV1(
+        forgeHookemonAction(approval, { transaction: mutation }),
+        hookemonBinding,
+        hookemonBinding.launchWallet,
+        "1000",
+      )).toThrow(/not runtime-validated/u);
+    }
+    const currentnessMutations = [
+      { kind: "PRE_APPROVAL" },
+      { observedBlockNumber: "2" },
+      { observedBlockHash: hookemonBytes32(0xe1) },
+      { observedPendingNonce: "0x9" },
+      { evidenceHash: hookemonSha(0xe2) },
+      { previousFinalityEvidenceHash: hookemonSha(0xe3) },
+      { completedGraphHash: hookemonBytes32(0xe4) },
+      { currentPoolStateHash: hookemonBytes32(0xe5) },
+      { runtimeStatusHash: hookemonSha(0xe6) },
+    ] as const;
+    for (const mutation of currentnessMutations) {
+      expect(() => subject.buildHookemonEip1193TransactionV1(
+        forgeHookemonAction(create, { currentness: mutation }),
+        hookemonBinding,
+        hookemonBinding.launchWallet,
+        "1000",
+      )).toThrow(/not runtime-validated/u);
+    }
+    const relabeledActions = [
+      { ...approval, actionIndex: 1 as const },
+      { ...approval, actionKind: "EOA_CREATE" as const },
+      { ...approval, selectorHash: hookemonSha(0xe7) },
+      { ...approval, actionHash: hookemonSha(0xe8) },
+      { ...approval, bindingHash: hookemonSha(0xe9) },
+      { ...approval, dataHash: hookemonBytes32(0xea) },
+    ] as const;
+    for (const relabeled of relabeledActions) {
+      expect(() => subject.buildHookemonEip1193TransactionV1(
+        relabeled,
+        hookemonBinding,
+        hookemonBinding.launchWallet,
+        "1000",
+      )).toThrow(/not runtime-validated/u);
+    }
+    expect(() => subject.buildHookemonEip1193TransactionV1(
+      approval,
+      hookemonBinding,
+      hookemonBinding.launchWallet,
+      "1200",
+    )).toThrow(/not current/u);
+    expect(() => subject.buildHookemonEip1193TransactionV1(
+      approval,
+      hookemonBinding,
+      hookemonBinding.launchWallet,
+      "899",
+    )).toThrow(/not current/u);
   });
 
   it("fails closed when an external provider mutates chain before a wallet action", async () => {
@@ -436,7 +536,40 @@ describe("wallet recovery state", () => {
   });
 });
 
-function hookemonAction(
+const hookemonSha = (byte: number) =>
+  `sha256:${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+const hookemonBytes32 = (byte: number) =>
+  `0x${byte.toString(16).padStart(2, "0").repeat(32)}` as const;
+const hookemonLaunchWallet = `0x${"1".repeat(40)}` as const;
+const hookemonLauncher = getCreateAddress({
+  from: hookemonLaunchWallet,
+  nonce: 8n,
+});
+const hookemonFundingUsdc = "1000000";
+const hookemonApprovalData = `${HOOKEMON_APPROVE_SELECTOR}${
+  hookemonLauncher.slice(2).toLowerCase().padStart(64, "0")
+}${BigInt(hookemonFundingUsdc).toString(16).padStart(64, "0")}` as const;
+const hookemonCreateData = "0x600060005560016000f3" as const;
+const hookemonBinding = Object.freeze({
+  bindingHash: hookemonSha(1),
+  subjectHash: hookemonSha(2),
+  profileKey: hookemonBytes32(3),
+  profileSchemaHash: hookemonBytes32(4),
+  planHash: hookemonBytes32(5),
+  sourceCommit: "11".repeat(20),
+  sourceTree: "22".repeat(20),
+  launchWallet: hookemonLaunchWallet,
+  launcher: hookemonLauncher,
+  launcherInitCodeHash: keccak256(hookemonCreateData),
+  fundingUsdc: hookemonFundingUsdc,
+  approvalNonce: "7",
+  launcherNonce: "8",
+  adoptionTarget: `0x${"3".repeat(40)}`,
+  adoptionSelector: "0x12345678",
+  requiredConfirmations: 64,
+} as const satisfies HookemonApplicantFlowBindingV1);
+
+function rawHookemonAction(
   actionIndex: 0 | 1 | 2,
 ): HookemonBrowserWalletActionV1 {
   const actionKind = [
@@ -445,47 +578,111 @@ function hookemonAction(
     "COMPLETED_GRAPH_ADOPTION",
   ][actionIndex] as HookemonBrowserWalletActionV1["actionKind"];
   const nonce = actionIndex === 0 ? "0x7" : actionIndex === 1 ? "0x8" : "0x9";
+  const data = actionIndex === 0
+    ? hookemonApprovalData
+    : actionIndex === 1
+      ? hookemonCreateData
+      : `${hookemonBinding.adoptionSelector}${"00".repeat(32)}` as const;
   return {
     schemaVersion: "programmable.hookemon-browser-wallet-action.v1",
-    bindingHash: `sha256:${"1".repeat(64)}`,
+    bindingHash: hookemonBinding.bindingHash,
     stateVersion: "1",
     actionIndex,
     actionKind,
-    selectorHash: `sha256:${"2".repeat(64)}`,
-    actionHash: `sha256:${"3".repeat(64)}`,
-    dataHash: `0x${"4".repeat(64)}`,
+    selectorHash: hookemonSha(6),
+    actionHash: hookemonSha(7),
+    dataHash: keccak256(data),
     previousFinalityEvidenceHash: actionIndex === 0
       ? null
-      : `sha256:${"5".repeat(64)}`,
-    permitDigest: actionIndex === 2 ? `0x${"6".repeat(64)}` : null,
-    validAfterEpochSeconds: "1",
-    expiresAtEpochSeconds: "2",
+      : hookemonSha(8),
+    permitDigest: actionIndex === 2 ? hookemonBytes32(9) : null,
+    validAfterEpochSeconds: "900",
+    expiresAtEpochSeconds: "1200",
     currentness: {
       schemaVersion: "programmable.hookemon-action-currentness.v1",
       kind: ["PRE_APPROVAL", "PRE_CREATE", "PRE_ADOPTION"][actionIndex] as
         HookemonBrowserWalletActionV1["currentness"]["kind"],
       observedBlockNumber: "1",
-      observedBlockHash: `0x${"7".repeat(64)}`,
+      observedBlockHash: hookemonBytes32(10),
       observedPendingNonce: nonce,
-      evidenceHash: `sha256:${"8".repeat(64)}`,
+      evidenceHash: hookemonSha(11),
       previousFinalityEvidenceHash: actionIndex === 0
         ? null
-        : `sha256:${"5".repeat(64)}`,
-      completedGraphHash: actionIndex === 2 ? `0x${"9".repeat(64)}` : null,
-      currentPoolStateHash: actionIndex === 2 ? `0x${"a".repeat(64)}` : null,
+        : hookemonSha(8),
+      completedGraphHash: actionIndex === 2 ? hookemonBytes32(12) : null,
+      currentPoolStateHash: actionIndex === 2 ? hookemonBytes32(13) : null,
       runtimeStatusHash: actionIndex === 2
-        ? `sha256:${"b".repeat(64)}`
+        ? hookemonSha(14)
         : null,
     },
     transaction: {
       method: "eth_sendTransaction",
       chainId: "0x1",
-      from: `0x${"1".repeat(40)}`,
-      to: actionIndex === 1 ? null : `0x${"2".repeat(40)}`,
+      from: hookemonBinding.launchWallet,
+      to: actionIndex === 0
+        ? HOOKEMON_MAINNET_USDC
+        : actionIndex === 1
+          ? null
+          : hookemonBinding.adoptionTarget,
       nonce,
       gas: "0x10000",
-      data: "0x6000",
+      data,
       value: "0x0",
     },
   };
+}
+
+function validatedHookemonAction(
+  actionIndex: 0 | 1,
+): HookemonBrowserWalletActionV1 {
+  return parseHookemonBrowserWalletActionV1(
+    rawHookemonAction(actionIndex),
+    hookemonBinding,
+    "1000",
+  );
+}
+
+function forgeHookemonAction(
+  action: HookemonBrowserWalletActionV1,
+  patch: Readonly<{
+    transaction?: Readonly<Record<string, unknown>>;
+    currentness?: Readonly<Record<string, unknown>>;
+  }>,
+): HookemonBrowserWalletActionV1 {
+  return {
+    ...action,
+    ...(patch.transaction === undefined ? {} : {
+      transaction: { ...action.transaction, ...patch.transaction },
+    }),
+    ...(patch.currentness === undefined ? {} : {
+      currentness: { ...action.currentness, ...patch.currentness },
+    }),
+  } as unknown as HookemonBrowserWalletActionV1;
+}
+
+function forgeRawHookemonAction(
+  actionIndex: 0 | 1,
+  patch: Readonly<{
+    actionHash?: HookemonBrowserWalletActionV1["actionHash"];
+    selectorHash?: HookemonBrowserWalletActionV1["selectorHash"];
+    transaction?: Readonly<Record<string, unknown>>;
+    currentness?: Readonly<Record<string, unknown>>;
+  }>,
+): HookemonBrowserWalletActionV1 {
+  const action = rawHookemonAction(actionIndex);
+  return {
+    ...action,
+    ...(patch.actionHash === undefined ? {} : {
+      actionHash: patch.actionHash,
+    }),
+    ...(patch.selectorHash === undefined ? {} : {
+      selectorHash: patch.selectorHash,
+    }),
+    ...(patch.transaction === undefined ? {} : {
+      transaction: { ...action.transaction, ...patch.transaction },
+    }),
+    ...(patch.currentness === undefined ? {} : {
+      currentness: { ...action.currentness, ...patch.currentness },
+    }),
+  } as HookemonBrowserWalletActionV1;
 }


### PR DESCRIPTION
## Summary

- adds the Hookemon-specific three-step applicant flow contract while keeping execution fail closed
- pins the exact 576-byte typed permit envelope and EIP-712 digest with canonical ABI and secp256k1 checks
- recomputes domain-separated action selector, action and Ed25519 authority-envelope hashes in browser-safe code
- preserves existing Shards, Classic and indexer behavior

## Safety boundary

- all Hookemon wallet sends remain disabled because the action-authority verifier and adoption decoder intentionally fail closed
- no Facade endpoint, active authority key, Kernel deployment or production identity is substituted
- no deployment or onchain action is included

## Focused gate

`npm exec vitest run tests/hookemon-applicant-browser-state.test.ts tests/hookemon-applicant-contract.test.ts tests/hookemon-applicant-presentation.test.ts tests/hookemon-authority-envelope.test.ts tests/hookemon-permit-envelope.test.ts tests/wallet-state.test.ts`

Result: 6/6 test files and 46/46 tests passed on head `7766946f568ef5ebb5b40c12ad3b3e3caa69f898`.