### PR TITLE
Require fresh Privy Applicant session before protected launch requests

### DIFF
--- a/app/api/custom-launch/manual/signed-artifacts/route.ts
+++ b/app/api/custom-launch/manual/signed-artifacts/route.ts
@@ -2,7 +2,7 @@ import { handleProductionManualRouterWebsiteRouteV1 } from
   "@/lib/server/custom-launch/manual-router-routes-v1";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 60;
+export const maxDuration = 300;
 export const runtime = "nodejs";
 
 export function POST(request: Request) {

--- a/components/manual-applicant-launch.tsx
+++ b/components/manual-applicant-launch.tsx
@@ -69,6 +69,8 @@ import {
   manualRouterDirectoryForApplicantV2,
   manualRouterFreshReadyMatchesCachedV1,
   manualRouterFreshReadyMatchesCachedV2,
+  manualRouterIsExactShardsV1ApplicantDirectory,
+  manualRouterResolveForApplicantV2,
   manualRouterRouteFactsV2,
   manualRouterTransactionContextV1,
   manualRouterTransactionContextV2,
@@ -128,10 +130,45 @@ type ManualRouterTransaction = Readonly<{
       lane: "v2";
       routeBindingHash: ManualRouterSha256V1;
     }>
-);
+  );
+
+export function manualRouterApplicantDiscoveryReady(input: Readonly<{
+  authReady: boolean;
+  authenticated: boolean;
+  githubConnected: boolean;
+  walletConnected: boolean;
+  routeDiscoveryAllowed: boolean;
+}>): boolean {
+  return input.authReady
+    && input.authenticated
+    && input.githubConnected
+    && input.walletConnected
+    && input.routeDiscoveryAllowed;
+}
+
+export async function acquireManualRouterWebsiteSessionV1(input: Readonly<{
+  getAccessToken: () => Promise<string | null>;
+  getIdentityToken: () => Promise<string | null>;
+}>): Promise<ManualRouterWebsiteSessionV1> {
+  let accessToken = await input.getAccessToken();
+  const identityToken = await input.getIdentityToken();
+  if (!accessToken && identityToken) {
+    accessToken = await input.getAccessToken();
+  }
+  if (!accessToken || !identityToken) {
+    throw new ManualRouterWebsiteRequestErrorV1(
+      401,
+      "applicant_authentication_required",
+      "Sign in with your approved GitHub account",
+      false,
+    );
+  }
+  return { accessToken, identityToken };
+}
 
 export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
   const {
+    authReady,
     authenticated,
     connectGithub,
     getAccessToken,
@@ -177,41 +214,43 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
   const exactShardsApplicant = isExactShardsGithubLogin(githubUsername);
   const exactHookemonApplicant =
     isExactHookemonApplicantGithubLoginV1(githubUsername);
+  const exactShardsV1Compatibility = exactShardsApplicant
+    && NESTED_FACTORY_ACTIVATION === null
+    && directory !== null
+    && manualRouterIsExactShardsV1ApplicantDirectory(directory);
   const shardsRouteCapabilityUnavailable = exactShardsApplicant
-    && NESTED_FACTORY_ACTIVATION === null;
+    && NESTED_FACTORY_ACTIVATION === null
+    && directory !== null
+    && !exactShardsV1Compatibility;
   // The Website must not infer an executable Hookemon action from source
   // metadata. This stays hard-disabled until one immutable mixed-provenance
   // profile, Facade and Authority release are bound together.
   const hookemonRouteCapabilityUnavailable = exactHookemonApplicant;
   const routeAcceptanceRequired = exactShardsApplicant
     && NESTED_FACTORY_ACTIVATION !== null;
+  const routeDiscoveryAllowed = !exactShardsApplicant
+    || NESTED_FACTORY_ACTIVATION === null
+    || routeAcceptance?.state === "accepted";
   const routeAccepted = exactHookemonApplicant
     ? false
     : !exactShardsApplicant
+      || exactShardsV1Compatibility
       || (
         NESTED_FACTORY_ACTIVATION !== null
         && routeAcceptance?.state === "accepted"
       );
 
   const getSession = useCallback(async (): Promise<ManualRouterWebsiteSessionV1> => {
-    const [accessToken, identityToken] = await Promise.all([
-      getAccessToken(),
-      getIdentityToken(),
-    ]);
-    if (!accessToken || !identityToken) {
-      throw new ManualRouterWebsiteRequestErrorV1(
-        401,
-        "applicant_authentication_required",
-        "Sign in with your approved GitHub account",
-        false,
-      );
-    }
-    return { accessToken, identityToken };
+    return acquireManualRouterWebsiteSessionV1({
+      getAccessToken,
+      getIdentityToken,
+    });
   }, [getAccessToken, getIdentityToken]);
 
   const loadRouteAcceptance = useCallback(async () => {
     if (
       NESTED_FACTORY_ACTIVATION === null
+      || !authReady
       || !authenticated
       || !githubConnected
       || !isExactShardsGithubLogin(githubUsername)
@@ -241,18 +280,19 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
       }
       if (!controller.signal.aborted) setLoadingAcceptance(false);
     }
-  }, [authenticated, getSession, githubConnected, githubUsername]);
+  }, [authReady, authenticated, getSession, githubConnected, githubUsername]);
 
   useEffect(() => {
     if (
       NESTED_FACTORY_ACTIVATION === null
+      || !authReady
       || !authenticated
       || !githubConnected
       || !isExactShardsGithubLogin(githubUsername)
     ) return;
     const kickoff = window.setTimeout(() => void loadRouteAcceptance(), 0);
     return () => window.clearTimeout(kickoff);
-  }, [authenticated, githubConnected, githubUsername, loadRouteAcceptance]);
+  }, [authReady, authenticated, githubConnected, githubUsername, loadRouteAcceptance]);
 
   const acceptReviewedRoute = useCallback(async () => {
     if (
@@ -286,7 +326,13 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     quiet?: boolean;
     preferredSubjectHash?: ManualRouterSha256V1 | "";
   }>) => {
-    if (!authenticated || !githubConnected || !wallet || !routeAccepted) return;
+    if (!wallet || !manualRouterApplicantDiscoveryReady({
+      authReady,
+      authenticated,
+      githubConnected,
+      walletConnected: true,
+      routeDiscoveryAllowed,
+    })) return;
     loadAbortRef.current?.abort();
     const controller = new AbortController();
     loadAbortRef.current = controller;
@@ -325,9 +371,14 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
           subjectHash: chosenSubjectHash,
           signal: controller.signal,
         } as const;
-        const nextResolved = isNestedFactorySubmissionV2(chosenSubmission)
+        const rawResolved = isNestedFactorySubmissionV2(chosenSubmission)
           ? await resolveManualRouterApplicantSubmissionV2(resolveRequest)
           : await resolveManualRouterApplicantSubmissionV1(resolveRequest);
+        const nextResolved = manualRouterResolveForApplicantV2({
+          directory: next,
+          resolved: rawResolved,
+          requireExactShardsRoute: exactShardsApplicant,
+        });
         if (controller.signal.aborted || sequence !== loadSequenceRef.current) return;
         setResolved(nextResolved);
         const stored = isManualRouterResolveV2(nextResolved)
@@ -450,17 +501,24 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
       }
     }
   }, [
+    authReady,
     authenticated,
     getSession,
     githubConnected,
     exactShardsApplicant,
     selectedSubjectHash,
-    routeAccepted,
+    routeDiscoveryAllowed,
     wallet,
   ]);
 
   useEffect(() => {
-    if (!authenticated || !githubConnected || !wallet || !routeAccepted) {
+    if (!manualRouterApplicantDiscoveryReady({
+      authReady,
+      authenticated,
+      githubConnected,
+      walletConnected: wallet !== null,
+      routeDiscoveryAllowed,
+    })) {
       loadAbortRef.current?.abort();
       return;
     }
@@ -473,7 +531,14 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
       window.clearTimeout(kickoff);
       window.clearInterval(interval);
     };
-  }, [authenticated, githubConnected, loadDirectory, routeAccepted, wallet]);
+  }, [
+    authReady,
+    authenticated,
+    githubConnected,
+    loadDirectory,
+    routeDiscoveryAllowed,
+    wallet,
+  ]);
 
   useEffect(() => () => {
     loadAbortRef.current?.abort();
@@ -865,7 +930,7 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
       detail: "Exact profile and Authority release required",
       complete: false,
     }] : []),
-    ...(exactShardsApplicant ? [{
+    ...(routeAcceptanceRequired ? [{
       label: "Exact route acceptance",
       detail: shardsRouteCapabilityUnavailable
         ? "Route capability unavailable"
@@ -906,7 +971,7 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     routeAcceptance?.state,
     shardsRouteCapabilityUnavailable,
     exactHookemonApplicant,
-    exactShardsApplicant,
+    routeAcceptanceRequired,
     routeAccepted,
     selected,
   ]);
@@ -1044,7 +1109,7 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
               {!wallet ? (
                 <button
                   type="button"
-                  disabled={!githubConnected || !routeAccepted}
+                  disabled={!githubConnected || !routeDiscoveryAllowed}
                   onClick={openWallet}>Connect wallet</button>
               ) : null}
             </div>

--- a/components/manual-applicant-launch.tsx
+++ b/components/manual-applicant-launch.tsx
@@ -127,10 +127,45 @@ type ManualRouterTransaction = Readonly<{
       lane: "v2";
       routeBindingHash: ManualRouterSha256V1;
     }>
-);
+  );
+
+export function manualRouterApplicantDiscoveryReady(input: Readonly<{
+  authReady: boolean;
+  authenticated: boolean;
+  githubConnected: boolean;
+  walletConnected: boolean;
+  routeDiscoveryAllowed: boolean;
+}>): boolean {
+  return input.authReady
+    && input.authenticated
+    && input.githubConnected
+    && input.walletConnected
+    && input.routeDiscoveryAllowed;
+}
+
+export async function acquireManualRouterWebsiteSessionV1(input: Readonly<{
+  getAccessToken: () => Promise<string | null>;
+  getIdentityToken: () => Promise<string | null>;
+}>): Promise<ManualRouterWebsiteSessionV1> {
+  let accessToken = await input.getAccessToken();
+  const identityToken = await input.getIdentityToken();
+  if (!accessToken && identityToken) {
+    accessToken = await input.getAccessToken();
+  }
+  if (!accessToken || !identityToken) {
+    throw new ManualRouterWebsiteRequestErrorV1(
+      401,
+      "applicant_authentication_required",
+      "Sign in with your approved GitHub account",
+      false,
+    );
+  }
+  return { accessToken, identityToken };
+}
 
 export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
   const {
+    authReady,
     authenticated,
     connectGithub,
     getAccessToken,
@@ -195,24 +230,16 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     );
 
   const getSession = useCallback(async (): Promise<ManualRouterWebsiteSessionV1> => {
-    const [accessToken, identityToken] = await Promise.all([
-      getAccessToken(),
-      getIdentityToken(),
-    ]);
-    if (!accessToken || !identityToken) {
-      throw new ManualRouterWebsiteRequestErrorV1(
-        401,
-        "applicant_authentication_required",
-        "Sign in with your approved GitHub account",
-        false,
-      );
-    }
-    return { accessToken, identityToken };
+    return acquireManualRouterWebsiteSessionV1({
+      getAccessToken,
+      getIdentityToken,
+    });
   }, [getAccessToken, getIdentityToken]);
 
   const loadRouteAcceptance = useCallback(async () => {
     if (
       NESTED_FACTORY_ACTIVATION === null
+      || !authReady
       || !authenticated
       || !githubConnected
       || !isExactShardsGithubLogin(githubUsername)
@@ -242,18 +269,19 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
       }
       if (!controller.signal.aborted) setLoadingAcceptance(false);
     }
-  }, [authenticated, getSession, githubConnected, githubUsername]);
+  }, [authReady, authenticated, getSession, githubConnected, githubUsername]);
 
   useEffect(() => {
     if (
       NESTED_FACTORY_ACTIVATION === null
+      || !authReady
       || !authenticated
       || !githubConnected
       || !isExactShardsGithubLogin(githubUsername)
     ) return;
     const kickoff = window.setTimeout(() => void loadRouteAcceptance(), 0);
     return () => window.clearTimeout(kickoff);
-  }, [authenticated, githubConnected, githubUsername, loadRouteAcceptance]);
+  }, [authReady, authenticated, githubConnected, githubUsername, loadRouteAcceptance]);
 
   const acceptReviewedRoute = useCallback(async () => {
     if (
@@ -287,12 +315,13 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     quiet?: boolean;
     preferredSubjectHash?: ManualRouterSha256V1 | "";
   }>) => {
-    if (
-      !authenticated
-      || !githubConnected
-      || !wallet
-      || !routeDiscoveryAllowed
-    ) return;
+    if (!wallet || !manualRouterApplicantDiscoveryReady({
+      authReady,
+      authenticated,
+      githubConnected,
+      walletConnected: true,
+      routeDiscoveryAllowed,
+    })) return;
     loadAbortRef.current?.abort();
     const controller = new AbortController();
     loadAbortRef.current = controller;
@@ -461,6 +490,7 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
       }
     }
   }, [
+    authReady,
     authenticated,
     getSession,
     githubConnected,
@@ -471,7 +501,13 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
   ]);
 
   useEffect(() => {
-    if (!authenticated || !githubConnected || !wallet || !routeDiscoveryAllowed) {
+    if (!manualRouterApplicantDiscoveryReady({
+      authReady,
+      authenticated,
+      githubConnected,
+      walletConnected: wallet !== null,
+      routeDiscoveryAllowed,
+    })) {
       loadAbortRef.current?.abort();
       return;
     }
@@ -485,6 +521,7 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
       window.clearInterval(interval);
     };
   }, [
+    authReady,
     authenticated,
     githubConnected,
     loadDirectory,

--- a/components/manual-applicant-launch.tsx
+++ b/components/manual-applicant-launch.tsx
@@ -24,10 +24,15 @@ import { getAddress } from "viem";
 
 import { GitHubBrandIcon } from "@/components/brand-icons";
 import styles from "@/components/manual-applicant-launch.module.css";
-import { useWallet } from "@/components/wallet-provider";
+import {
+  useWallet,
+  type WalletApplicantIdentityRequirementV1,
+  type WalletApplicantSessionV1,
+} from "@/components/wallet-provider";
 import { getActiveManualRouterProductionBindingV2 } from
   "@/lib/custom-launch/manual-router-bindings-v2";
 import {
+  HOOKEMON_APPLICANT_IDENTITY_V1,
   isExactHookemonApplicantGithubLoginV1,
 } from "@/lib/custom-launch/hookemon-applicant-presentation-v1";
 import {
@@ -69,6 +74,7 @@ import {
   manualRouterDirectoryForApplicantV2,
   manualRouterFreshReadyMatchesCachedV1,
   manualRouterFreshReadyMatchesCachedV2,
+  MANUAL_ROUTER_EXACT_SHARDS_V1_BROWSER_BINDING,
   manualRouterIsExactShardsV1ApplicantDirectory,
   manualRouterResolveForApplicantV2,
   manualRouterRouteFactsV2,
@@ -88,6 +94,18 @@ const LIST_REFRESH_MS = 30_000;
 // Presentation routing only. The server re-observes and authorizes the numeric
 // GitHub identity before it returns or records any Shards acceptance state.
 const SHARDS_GITHUB_LOGIN = "jesse-stahl";
+const SHARDS_APPLICANT_IDENTITY_REQUIREMENT_V1 = Object.freeze({
+  githubUserId:
+    MANUAL_ROUTER_EXACT_SHARDS_V1_BROWSER_BINDING.authenticatedGitHubUserId,
+  githubLogin: SHARDS_GITHUB_LOGIN,
+  launchWallet:
+    MANUAL_ROUTER_EXACT_SHARDS_V1_BROWSER_BINDING.linkedLaunchWallet,
+}) satisfies WalletApplicantIdentityRequirementV1;
+const HOOKEMON_APPLICANT_IDENTITY_REQUIREMENT_V1 = Object.freeze({
+  githubUserId: HOOKEMON_APPLICANT_IDENTITY_V1.githubUserId,
+  githubLogin: HOOKEMON_APPLICANT_IDENTITY_V1.githubLogin,
+  launchWallet: HOOKEMON_APPLICANT_IDENTITY_V1.launchWallet,
+}) satisfies WalletApplicantIdentityRequirementV1;
 const ATTEMPT_STORAGE_PREFIX = "programmable:manual-router-browser-attempt:v1";
 const ATTEMPT_STORAGE_PREFIX_V2 =
   "programmable:manual-router-browser-attempt:v2";
@@ -146,16 +164,23 @@ export function manualRouterApplicantDiscoveryReady(input: Readonly<{
     && input.routeDiscoveryAllowed;
 }
 
-export async function acquireManualRouterWebsiteSessionV1(input: Readonly<{
-  getAccessToken: () => Promise<string | null>;
-  getIdentityToken: () => Promise<string | null>;
-}>): Promise<ManualRouterWebsiteSessionV1> {
-  let accessToken = await input.getAccessToken();
-  const identityToken = await input.getIdentityToken();
-  if (!accessToken && identityToken) {
-    accessToken = await input.getAccessToken();
+export function applicantIdentityRequirementForLoginV1(
+  login: string | null,
+): WalletApplicantIdentityRequirementV1 | undefined {
+  if (isExactShardsGithubLogin(login)) {
+    return SHARDS_APPLICANT_IDENTITY_REQUIREMENT_V1;
   }
-  if (!accessToken || !identityToken) {
+  if (isExactHookemonApplicantGithubLoginV1(login)) {
+    return HOOKEMON_APPLICANT_IDENTITY_REQUIREMENT_V1;
+  }
+  return undefined;
+}
+
+export async function acquireManualRouterWebsiteSessionV1(input: Readonly<{
+  refreshApplicantSession: () => Promise<WalletApplicantSessionV1 | null>;
+}>): Promise<ManualRouterWebsiteSessionV1> {
+  const session = await input.refreshApplicantSession();
+  if (!session) {
     throw new ManualRouterWebsiteRequestErrorV1(
       401,
       "applicant_authentication_required",
@@ -163,7 +188,18 @@ export async function acquireManualRouterWebsiteSessionV1(input: Readonly<{
       false,
     );
   }
-  return { accessToken, identityToken };
+  return {
+    accessToken: session.accessToken,
+    identityToken: session.identityToken,
+  };
+}
+
+export async function runManualRouterRequestWithFreshSessionV1<T>(
+  getSession: () => Promise<ManualRouterWebsiteSessionV1>,
+  request: (session: ManualRouterWebsiteSessionV1) => Promise<T>,
+): Promise<T> {
+  const session = await getSession();
+  return await request(session);
 }
 
 export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
@@ -171,11 +207,10 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     authReady,
     authenticated,
     connectGithub,
-    getAccessToken,
-    getIdentityToken,
     githubConnected,
     githubUsername,
     openWallet,
+    refreshApplicantSession,
     sendBrowserWalletAction,
     wallet,
   } = useWallet();
@@ -239,13 +274,15 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
         NESTED_FACTORY_ACTIVATION !== null
         && routeAcceptance?.state === "accepted"
       );
+  const applicantIdentityRequirement =
+    applicantIdentityRequirementForLoginV1(githubUsername);
 
   const getSession = useCallback(async (): Promise<ManualRouterWebsiteSessionV1> => {
     return acquireManualRouterWebsiteSessionV1({
-      getAccessToken,
-      getIdentityToken,
+      refreshApplicantSession: () =>
+        refreshApplicantSession(applicantIdentityRequirement),
     });
-  }, [getAccessToken, getIdentityToken]);
+  }, [applicantIdentityRequirement, refreshApplicantSession]);
 
   const loadRouteAcceptance = useCallback(async () => {
     if (
@@ -341,14 +378,19 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     setError("");
     setErrorCode("");
     try {
-      const request = {
-        session: await getSession(),
-        launchWallet: wallet.account,
-        signal: controller.signal,
-      } as const;
-      const directoryResponse = NESTED_FACTORY_ACTIVATION === null
-        ? await listManualRouterApplicantSubmissionsV1(request)
-        : await listManualRouterApplicantSubmissionsVersionedV2(request);
+      const directoryResponse = await runManualRouterRequestWithFreshSessionV1(
+        getSession,
+        async (session) => {
+          const request = {
+            session,
+            launchWallet: wallet.account,
+            signal: controller.signal,
+          } as const;
+          return NESTED_FACTORY_ACTIVATION === null
+            ? await listManualRouterApplicantSubmissionsV1(request)
+            : await listManualRouterApplicantSubmissionsVersionedV2(request);
+        },
+      );
       const next = manualRouterDirectoryForApplicantV2({
         directory: directoryResponse,
         requireExactShardsRoute: exactShardsApplicant,
@@ -365,15 +407,20 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
         subjectHash === chosen) ?? null;
       if (chosenSubmission !== null) {
         const chosenSubjectHash = chosenSubmission.subjectHash;
-        const resolveRequest = {
-          session: await getSession(),
-          launchWallet: next.linkedLaunchWallet,
-          subjectHash: chosenSubjectHash,
-          signal: controller.signal,
-        } as const;
-        const rawResolved = isNestedFactorySubmissionV2(chosenSubmission)
-          ? await resolveManualRouterApplicantSubmissionV2(resolveRequest)
-          : await resolveManualRouterApplicantSubmissionV1(resolveRequest);
+        const rawResolved = await runManualRouterRequestWithFreshSessionV1(
+          getSession,
+          async (session) => {
+            const resolveRequest = {
+              session,
+              launchWallet: next.linkedLaunchWallet,
+              subjectHash: chosenSubjectHash,
+              signal: controller.signal,
+            } as const;
+            return isNestedFactorySubmissionV2(chosenSubmission)
+              ? await resolveManualRouterApplicantSubmissionV2(resolveRequest)
+              : await resolveManualRouterApplicantSubmissionV1(resolveRequest);
+          },
+        );
         const nextResolved = manualRouterResolveForApplicantV2({
           directory: next,
           resolved: rawResolved,

--- a/components/manual-applicant-launch.tsx
+++ b/components/manual-applicant-launch.tsx
@@ -66,6 +66,8 @@ import {
   manualRouterDirectoryForApplicantV2,
   manualRouterFreshReadyMatchesCachedV1,
   manualRouterFreshReadyMatchesCachedV2,
+  manualRouterIsExactShardsV1ApplicantDirectory,
+  manualRouterResolveForApplicantV2,
   manualRouterRouteFactsV2,
   manualRouterTransactionContextV1,
   manualRouterTransactionContextV2,
@@ -172,11 +174,21 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
   const launchLockRef = useRef(false);
   const finalityLockRef = useRef(false);
   const exactShardsApplicant = isExactShardsGithubLogin(githubUsername);
+  const exactShardsV1Compatibility = exactShardsApplicant
+    && NESTED_FACTORY_ACTIVATION === null
+    && directory !== null
+    && manualRouterIsExactShardsV1ApplicantDirectory(directory);
   const routeCapabilityUnavailable = exactShardsApplicant
-    && NESTED_FACTORY_ACTIVATION === null;
+    && NESTED_FACTORY_ACTIVATION === null
+    && directory !== null
+    && !exactShardsV1Compatibility;
   const routeAcceptanceRequired = exactShardsApplicant
     && NESTED_FACTORY_ACTIVATION !== null;
+  const routeDiscoveryAllowed = !exactShardsApplicant
+    || NESTED_FACTORY_ACTIVATION === null
+    || routeAcceptance?.state === "accepted";
   const routeAccepted = !exactShardsApplicant
+    || exactShardsV1Compatibility
     || (
       NESTED_FACTORY_ACTIVATION !== null
       && routeAcceptance?.state === "accepted"
@@ -275,7 +287,12 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     quiet?: boolean;
     preferredSubjectHash?: ManualRouterSha256V1 | "";
   }>) => {
-    if (!authenticated || !githubConnected || !wallet || !routeAccepted) return;
+    if (
+      !authenticated
+      || !githubConnected
+      || !wallet
+      || !routeDiscoveryAllowed
+    ) return;
     loadAbortRef.current?.abort();
     const controller = new AbortController();
     loadAbortRef.current = controller;
@@ -314,9 +331,14 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
           subjectHash: chosenSubjectHash,
           signal: controller.signal,
         } as const;
-        const nextResolved = isNestedFactorySubmissionV2(chosenSubmission)
+        const rawResolved = isNestedFactorySubmissionV2(chosenSubmission)
           ? await resolveManualRouterApplicantSubmissionV2(resolveRequest)
           : await resolveManualRouterApplicantSubmissionV1(resolveRequest);
+        const nextResolved = manualRouterResolveForApplicantV2({
+          directory: next,
+          resolved: rawResolved,
+          requireExactShardsRoute: exactShardsApplicant,
+        });
         if (controller.signal.aborted || sequence !== loadSequenceRef.current) return;
         setResolved(nextResolved);
         const stored = isManualRouterResolveV2(nextResolved)
@@ -442,15 +464,14 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     authenticated,
     getSession,
     githubConnected,
-    routeAcceptanceRequired,
     exactShardsApplicant,
     selectedSubjectHash,
-    routeAccepted,
+    routeDiscoveryAllowed,
     wallet,
   ]);
 
   useEffect(() => {
-    if (!authenticated || !githubConnected || !wallet || !routeAccepted) {
+    if (!authenticated || !githubConnected || !wallet || !routeDiscoveryAllowed) {
       loadAbortRef.current?.abort();
       return;
     }
@@ -463,7 +484,13 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
       window.clearTimeout(kickoff);
       window.clearInterval(interval);
     };
-  }, [authenticated, githubConnected, loadDirectory, routeAccepted, wallet]);
+  }, [
+    authenticated,
+    githubConnected,
+    loadDirectory,
+    routeDiscoveryAllowed,
+    wallet,
+  ]);
 
   useEffect(() => () => {
     loadAbortRef.current?.abort();
@@ -850,7 +877,7 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     }),
   );
   const trustSteps = useMemo(() => [
-    ...(exactShardsApplicant ? [{
+    ...(routeAcceptanceRequired ? [{
       label: "Exact route acceptance",
       detail: routeCapabilityUnavailable
         ? "Route capability unavailable"
@@ -891,7 +918,6 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     routeAcceptance?.state,
     routeAcceptanceRequired,
     routeCapabilityUnavailable,
-    exactShardsApplicant,
     routeAccepted,
     selected,
   ]);
@@ -992,7 +1018,7 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
               {!wallet ? (
                 <button
                   type="button"
-                  disabled={!githubConnected || !routeAccepted}
+                  disabled={!githubConnected || !routeDiscoveryAllowed}
                   onClick={openWallet}>Connect wallet</button>
               ) : null}
             </div>

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import {
+  getIdentityToken as getPrivyIdentityToken,
   PrivyProvider,
   useIdentityToken,
   useLinkAccount,
@@ -81,6 +82,7 @@ type WalletContextValue = {
   wallet: WalletState | null;
   username: string;
   avatarDataUrl: string;
+  authReady: boolean;
   authenticated: boolean;
   hasSession: boolean;
   connecting: boolean;
@@ -137,6 +139,21 @@ export function isWalletProviderSettled(
   authenticated: boolean,
 ) {
   return privyReady && (!authenticated || walletsReady);
+}
+
+export async function resolveWalletIdentityToken(input: Readonly<{
+  authenticated: boolean;
+  cachedIdentityToken: string | null;
+  loadIdentityToken: () => Promise<string | null>;
+}>): Promise<string | null> {
+  if (!input.authenticated) return null;
+  if (input.cachedIdentityToken !== null) return input.cachedIdentityToken;
+
+  try {
+    return await input.loadIdentityToken();
+  } catch {
+    return null;
+  }
 }
 
 export function getWalletProfileStorageKey(account: string) {
@@ -661,6 +678,14 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
   );
   const hasSession = activeAuthenticated;
   const sessionAction = getWalletSessionAction(ready, activeAuthenticated);
+  const getCurrentIdentityToken = useCallback(
+    () => resolveWalletIdentityToken({
+      authenticated: activeAuthenticated,
+      cachedIdentityToken: identityToken,
+      loadIdentityToken: getPrivyIdentityToken,
+    }),
+    [activeAuthenticated, identityToken],
+  );
 
   const profileValue = useSyncExternalStore(
     subscribeToProfiles,
@@ -1201,6 +1226,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       wallet,
       username,
       avatarDataUrl,
+      authReady: ready,
       authenticated: activeAuthenticated,
       hasSession,
       connecting: !providerSettled && !providerTimedOut,
@@ -1208,7 +1234,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       openWallet,
       disconnect,
       getAccessToken,
-      getIdentityToken: async () => identityToken,
+      getIdentityToken: getCurrentIdentityToken,
       githubConnected,
       githubUsername,
       connectGithub,
@@ -1227,14 +1253,15 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       disconnect,
       disconnecting,
       getAccessToken,
+      getCurrentIdentityToken,
       githubConnected,
       githubUsername,
       hasSession,
-      identityToken,
       openWallet,
       providerTimedOut,
       readNativeBalance,
       readTradeBalances,
+      ready,
       sendBrowserWalletAction,
       sendHookemonBrowserWalletAction,
       sendTransaction,
@@ -1284,6 +1311,7 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
       wallet: null,
       username: "",
       avatarDataUrl: "",
+      authReady: false,
       authenticated: false,
       hasSession: false,
       connecting: false,

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import {
+  getIdentityToken as getPrivyIdentityToken,
   PrivyProvider,
   useIdentityToken,
   useLinkAccount,
@@ -70,6 +71,7 @@ type WalletContextValue = {
   wallet: WalletState | null;
   username: string;
   avatarDataUrl: string;
+  authReady: boolean;
   authenticated: boolean;
   hasSession: boolean;
   connecting: boolean;
@@ -122,6 +124,21 @@ export function isWalletProviderSettled(
   authenticated: boolean,
 ) {
   return privyReady && (!authenticated || walletsReady);
+}
+
+export async function resolveWalletIdentityToken(input: Readonly<{
+  authenticated: boolean;
+  cachedIdentityToken: string | null;
+  loadIdentityToken: () => Promise<string | null>;
+}>): Promise<string | null> {
+  if (!input.authenticated) return null;
+  if (input.cachedIdentityToken !== null) return input.cachedIdentityToken;
+
+  try {
+    return await input.loadIdentityToken();
+  } catch {
+    return null;
+  }
 }
 
 export function getWalletProfileStorageKey(account: string) {
@@ -577,6 +594,14 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
   );
   const hasSession = activeAuthenticated;
   const sessionAction = getWalletSessionAction(ready, activeAuthenticated);
+  const getCurrentIdentityToken = useCallback(
+    () => resolveWalletIdentityToken({
+      authenticated: activeAuthenticated,
+      cachedIdentityToken: identityToken,
+      loadIdentityToken: getPrivyIdentityToken,
+    }),
+    [activeAuthenticated, identityToken],
+  );
 
   const profileValue = useSyncExternalStore(
     subscribeToProfiles,
@@ -1040,6 +1065,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       wallet,
       username,
       avatarDataUrl,
+      authReady: ready,
       authenticated: activeAuthenticated,
       hasSession,
       connecting: !providerSettled && !providerTimedOut,
@@ -1047,7 +1073,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       openWallet,
       disconnect,
       getAccessToken,
-      getIdentityToken: async () => identityToken,
+      getIdentityToken: getCurrentIdentityToken,
       githubConnected,
       githubUsername,
       connectGithub,
@@ -1065,14 +1091,15 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       disconnect,
       disconnecting,
       getAccessToken,
+      getCurrentIdentityToken,
       githubConnected,
       githubUsername,
       hasSession,
-      identityToken,
       openWallet,
       providerTimedOut,
       readNativeBalance,
       readTradeBalances,
+      ready,
       sendBrowserWalletAction,
       sendTransaction,
       signLaunchMessage,
@@ -1121,6 +1148,7 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
       wallet: null,
       username: "",
       avatarDataUrl: "",
+      authReady: false,
       authenticated: false,
       hasSession: false,
       connecting: false,

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -11,6 +11,7 @@ import {
   usePrivy,
   useSendTransaction as usePrivySendTransaction,
   useSignMessage as usePrivySignMessage,
+  useUser,
   useWallets,
   type PrivyClientConfig,
 } from "@privy-io/react-auth";
@@ -78,6 +79,21 @@ export type WalletNativeBalance = {
   gasPriceWei: bigint;
 };
 
+export type WalletApplicantIdentityRequirementV1 = Readonly<{
+  githubUserId: string;
+  githubLogin: string;
+  launchWallet: `0x${string}`;
+}>;
+
+export type WalletApplicantSessionV1 = Readonly<{
+  accessToken: string;
+  identityToken: string;
+  privyUserId: string;
+  githubUserId: string;
+  githubLogin: string;
+  launchWallet: `0x${string}`;
+}>;
+
 type WalletContextValue = {
   wallet: WalletState | null;
   username: string;
@@ -93,6 +109,9 @@ type WalletContextValue = {
   }) => Promise<boolean>;
   getAccessToken: () => Promise<string | null>;
   getIdentityToken: () => Promise<string | null>;
+  refreshApplicantSession: (
+    requirement?: WalletApplicantIdentityRequirementV1,
+  ) => Promise<WalletApplicantSessionV1 | null>;
   githubConnected: boolean;
   githubUsername: string;
   connectGithub: () => void;
@@ -154,6 +173,130 @@ export async function resolveWalletIdentityToken(input: Readonly<{
   } catch {
     return null;
   }
+}
+
+type RefreshableApplicantUserV1 = Readonly<{
+  id: string;
+  github?: Readonly<{
+    subject: string;
+    username: string | null;
+  }>;
+  linkedAccounts: readonly Readonly<{
+    type: string;
+    subject?: string;
+    username?: string | null;
+    address?: string;
+    chainType?: string;
+  }>[];
+}>;
+
+type ApplicantAuthoritySnapshotV1 = Readonly<{
+  privyUserId: string | null;
+  githubUserId: string | null;
+  githubLogin: string | null;
+  walletAddress: string | null;
+}>;
+
+export async function refreshWalletApplicantSessionV1(input: Readonly<{
+  authenticated: boolean;
+  readCurrentAuthority: () => ApplicantAuthoritySnapshotV1;
+  refreshUser: () => Promise<RefreshableApplicantUserV1 | null | undefined>;
+  getAccessToken: () => Promise<string | null>;
+  getIdentityToken: () => Promise<string | null>;
+  requirement?: WalletApplicantIdentityRequirementV1;
+}>): Promise<WalletApplicantSessionV1 | null> {
+  if (!input.authenticated) return null;
+  const initial = input.readCurrentAuthority();
+  if (
+    typeof initial.privyUserId !== "string"
+    || initial.privyUserId.length === 0
+    || typeof initial.githubUserId !== "string"
+    || initial.githubUserId.length === 0
+    || typeof initial.githubLogin !== "string"
+    || initial.githubLogin.length === 0
+    || typeof initial.walletAddress !== "string"
+    || !isEthereumAddress(initial.walletAddress)
+  ) return null;
+
+  try {
+    const refreshedUser = await input.refreshUser();
+    if (
+      refreshedUser === null
+      || typeof refreshedUser !== "object"
+      || refreshedUser.id !== initial.privyUserId
+      || !Array.isArray(refreshedUser.linkedAccounts)
+    ) return null;
+    if (!authoritySnapshotMatches(initial, input.readCurrentAuthority())) {
+      return null;
+    }
+
+    const github = refreshedUser.github;
+    const githubAccounts = refreshedUser.linkedAccounts.filter(
+      (account) => account.type === "github_oauth",
+    );
+    if (
+      !github
+      || typeof github.subject !== "string"
+      || github.subject.length === 0
+      || typeof github.username !== "string"
+      || github.username.length === 0
+      || github.subject !== initial.githubUserId
+      || github.username.toLowerCase() !== initial.githubLogin.toLowerCase()
+      || githubAccounts.length !== 1
+      || !githubAccounts.some((account) =>
+        account.subject === github.subject
+        && account.username?.toLowerCase() === github.username!.toLowerCase()
+      )
+    ) return null;
+
+    const launchWallet = initial.walletAddress.toLowerCase() as `0x${string}`;
+    if (refreshedUser.linkedAccounts.filter((account) =>
+      account.type === "wallet"
+      && account.chainType === "ethereum"
+      && typeof account.address === "string"
+      && account.address.toLowerCase() === launchWallet
+    ).length !== 1) return null;
+    if (
+      input.requirement
+      && (
+        github.subject !== input.requirement.githubUserId
+        || github.username.toLowerCase()
+          !== input.requirement.githubLogin.toLowerCase()
+        || launchWallet !== input.requirement.launchWallet.toLowerCase()
+      )
+    ) return null;
+
+    const accessToken = await input.getAccessToken();
+    const identityToken = await input.getIdentityToken();
+    if (
+      typeof accessToken !== "string"
+      || accessToken.length === 0
+      || typeof identityToken !== "string"
+      || identityToken.length === 0
+      || !authoritySnapshotMatches(initial, input.readCurrentAuthority())
+    ) return null;
+    return Object.freeze({
+      accessToken,
+      identityToken,
+      privyUserId: refreshedUser.id,
+      githubUserId: github.subject,
+      githubLogin: github.username,
+      launchWallet,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function authoritySnapshotMatches(
+  expected: ApplicantAuthoritySnapshotV1,
+  current: ApplicantAuthoritySnapshotV1,
+): boolean {
+  return current.privyUserId === expected.privyUserId
+    && current.githubUserId === expected.githubUserId
+    && current.githubLogin?.toLowerCase() === expected.githubLogin?.toLowerCase()
+    && current.walletAddress?.toLowerCase()
+      === expected.walletAddress?.toLowerCase();
 }
 
 export function getWalletProfileStorageKey(account: string) {
@@ -590,6 +733,7 @@ function ConfiguredWalletProvider({
 
 function PrivyWalletBridge({ children }: { children: ReactNode }) {
   const { authenticated, getAccessToken, logout, ready, user } = usePrivy();
+  const { refreshUser } = useUser();
   const { identityToken } = useIdentityToken();
   const { sendTransaction: sendPrivyTransaction } = usePrivySendTransaction();
   const { signMessage: signPrivyMessage } = usePrivySignMessage();
@@ -685,6 +829,32 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       loadIdentityToken: getPrivyIdentityToken,
     }),
     [activeAuthenticated, identityToken],
+  );
+  const applicantAuthorityRef = useRef<ApplicantAuthoritySnapshotV1>({
+    privyUserId: user?.id ?? null,
+    githubUserId: user?.github?.subject ?? null,
+    githubLogin: user?.github?.username ?? null,
+    walletAddress: wallet?.account ?? null,
+  });
+  useEffect(() => {
+    applicantAuthorityRef.current = {
+      privyUserId: user?.id ?? null,
+      githubUserId: user?.github?.subject ?? null,
+      githubLogin: user?.github?.username ?? null,
+      walletAddress: wallet?.account ?? null,
+    };
+  }, [user?.github?.subject, user?.github?.username, user?.id, wallet?.account]);
+  const refreshApplicantSession = useCallback(
+    (requirement?: WalletApplicantIdentityRequirementV1) =>
+      refreshWalletApplicantSessionV1({
+        authenticated: activeAuthenticated && ready,
+        readCurrentAuthority: () => applicantAuthorityRef.current,
+        refreshUser,
+        getAccessToken,
+        getIdentityToken: getPrivyIdentityToken,
+        requirement,
+      }),
+    [activeAuthenticated, getAccessToken, ready, refreshUser],
   );
 
   const profileValue = useSyncExternalStore(
@@ -1235,6 +1405,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       disconnect,
       getAccessToken,
       getIdentityToken: getCurrentIdentityToken,
+      refreshApplicantSession,
       githubConnected,
       githubUsername,
       connectGithub,
@@ -1262,6 +1433,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       readNativeBalance,
       readTradeBalances,
       ready,
+      refreshApplicantSession,
       sendBrowserWalletAction,
       sendHookemonBrowserWalletAction,
       sendTransaction,
@@ -1320,6 +1492,7 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
       disconnect: async () => false,
       getAccessToken: async () => null,
       getIdentityToken: async () => null,
+      refreshApplicantSession: async () => null,
       githubConnected: false,
       githubUsername: "",
       connectGithub: () => setDialogOpen(true),

--- a/lib/custom-launch/manual-router-browser-state-v1.ts
+++ b/lib/custom-launch/manual-router-browser-state-v1.ts
@@ -23,15 +23,54 @@ export type ManualRouterApplicantDirectoryAnyV2 =
   | ManualRouterApplicantListResponseV1
   | ManualRouterApplicantListResponseV2;
 
+export const MANUAL_ROUTER_EXACT_SHARDS_V1_BROWSER_BINDING = Object.freeze({
+  authenticatedGitHubUserId: "155705664",
+  linkedLaunchWallet: "0xceebb3a6543cebeb2ed66963897a0abea52a50cc",
+  subjectHash:
+    "sha256:c818b79c99277b878b2e0be70f1479fa8a864f111fbe0579bf9e2b8cf95524ee",
+  pullRequestNumber: 6,
+  headSha: "1aa5017154d227e639cfe6256f39bf3916352124",
+  treeSha: "48149d436bf222c440980e1fc31a71899b833af7",
+  approvalBindingHash:
+    "sha256:a036d02141ae96c178691ceb9aac9390260e4caf71acb37fe427c0803bdc0b03",
+  routeNonce:
+    "0xfcd4ff3393a669e5bb9f21a97f9adaad624bcfad67c9ef3763ec5e4488d6df9f",
+} as const);
+
+export function manualRouterIsExactShardsV1ApplicantDirectory(
+  directory: ManualRouterApplicantDirectoryAnyV2,
+): directory is ManualRouterApplicantListResponseV1 {
+  if (
+    directory.schemaVersion
+      !== "programmable.manual-router-applicant-list-response.v1"
+    || directory.submissions.length !== 1
+  ) return false;
+  const exact = MANUAL_ROUTER_EXACT_SHARDS_V1_BROWSER_BINDING;
+  const submission = directory.submissions[0]!;
+  return directory.authenticatedGitHubUserId
+      === exact.authenticatedGitHubUserId
+    && directory.linkedLaunchWallet.toLowerCase()
+      === exact.linkedLaunchWallet
+    && submission.subjectHash === exact.subjectHash
+    && submission.pullRequestNumber === exact.pullRequestNumber
+    && submission.headSha === exact.headSha
+    && submission.treeSha === exact.treeSha
+    && submission.approvalBindingHash === exact.approvalBindingHash
+    && submission.routeNonce === exact.routeNonce;
+}
+
 export function manualRouterDirectoryForApplicantV2(input: Readonly<{
   directory: ManualRouterApplicantDirectoryAnyV2;
   requireExactShardsRoute: boolean;
 }>): ManualRouterApplicantDirectoryAnyV2 {
   if (!input.requireExactShardsRoute) return input.directory;
+  if (manualRouterIsExactShardsV1ApplicantDirectory(input.directory)) {
+    return input.directory;
+  }
   if (
     input.directory.schemaVersion
       !== "programmable.manual-router-applicant-list-response.v2"
-  ) throw new TypeError("exact Shards Router V2 submission is unavailable");
+  ) throw new TypeError("exact Shards Router submission is unavailable");
   const submissions = input.directory.submissions.filter(
     (submission): submission is ManualRouterNestedFactorySubmissionSummaryV2 =>
       submission.artifactSchemaVersion
@@ -44,6 +83,35 @@ export function manualRouterDirectoryForApplicantV2(input: Readonly<{
     ...input.directory,
     submissions: Object.freeze(submissions),
   });
+}
+
+export function manualRouterResolveForApplicantV2(input: Readonly<{
+  directory: ManualRouterApplicantDirectoryAnyV2;
+  resolved: ManualRouterResolveResponseV1 | ManualRouterResolveResponseV2;
+  requireExactShardsRoute: boolean;
+}>): ManualRouterResolveResponseV1 | ManualRouterResolveResponseV2 {
+  if (!input.requireExactShardsRoute) return input.resolved;
+  const directory = manualRouterDirectoryForApplicantV2(input);
+  if (directory.schemaVersion
+    !== "programmable.manual-router-applicant-list-response.v1") {
+    if (input.resolved.schemaVersion
+      === "programmable.manual-router-applicant-resolve-response.v1") {
+      throw new TypeError("exact Shards Router V2 submission is unavailable");
+    }
+    return input.resolved;
+  }
+  if (input.resolved.schemaVersion
+    !== "programmable.manual-router-applicant-resolve-response.v1") {
+    throw new TypeError("exact Shards Router V1 submission is unavailable");
+  }
+  const submission = directory.submissions[0]!;
+  if (
+    input.resolved.subjectHash !== submission.subjectHash
+    || input.resolved.pointerHash !== submission.pointerHash
+    || input.resolved.approvalBindingHash !== submission.approvalBindingHash
+    || input.resolved.routeNonce !== submission.routeNonce
+  ) throw new TypeError("exact Shards Router V1 resolution is unavailable");
+  return input.resolved;
 }
 
 export type ManualRouterPersistedAttemptReadV1 =

--- a/lib/server/custom-launch/manual-router-authority-v1.ts
+++ b/lib/server/custom-launch/manual-router-authority-v1.ts
@@ -28,9 +28,17 @@ import {
   type ManualRouterFinalityAuthorityV1,
 } from "@/lib/server/custom-launch/manual-router-finality-v1";
 import {
+  SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_ENV_V1,
+  SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_ENV_V1,
+  SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1,
+  createShardsManualRouterAlchemyBearerFetchV1,
   createShardsManualRouterPublishFetchV1,
   isExactShardsManualRouterPublishRequestV1,
 } from "@/lib/server/custom-launch/manual-router-shards-publish-transport-v1";
+import {
+  manualRouterIsExactShardsV1ArtifactV1,
+  manualRouterIsExactShardsV1PointerV1,
+} from "@/lib/server/custom-launch/manual-router-shards-v1-compat-v1";
 import {
   ManualRouterTransactionNotObservedErrorV1,
   type ManualRouterCompleteSignedArtifactViewV1,
@@ -99,15 +107,31 @@ ProductionManualRouterAuthorityV1 {
     // secret. The Applicant identity path is separately bound through Privy.
     githubReadToken: null,
   });
-  const shardsPublishComposition =
-    createPortableManualRouterPublishAuthorityFromEnvV1({
-      env: process.env,
-      fetch: createShardsManualRouterPublishFetchV1({
-        fetch,
-        quickNodeUrl: process.env[MANUAL_ROUTER_QUICKNODE_RPC_ENV_V1],
+  let shardsComposition: PortableManualRouterCompositionV1 | null = null;
+  const exactShardsComposition = (): PortableManualRouterCompositionV1 => {
+    if (shardsComposition !== null) return shardsComposition;
+    const quickNodeFetch = createShardsManualRouterPublishFetchV1({
+      fetch,
+      quickNodeUrl: process.env[MANUAL_ROUTER_QUICKNODE_RPC_ENV_V1],
+    });
+    const alchemyBearerFetch = createShardsManualRouterAlchemyBearerFetchV1({
+      fetch: quickNodeFetch,
+      apiKey: process.env[SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_ENV_V1],
+      apiKeyCommitment:
+        process.env[SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_ENV_V1],
+    });
+    shardsComposition = createPortableManualRouterPublishAuthorityFromEnvV1({
+      env: Object.freeze({
+        [MANUAL_ROUTER_ALCHEMY_RPC_ENV_V1]:
+          SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1,
+        [MANUAL_ROUTER_QUICKNODE_RPC_ENV_V1]:
+          process.env[MANUAL_ROUTER_QUICKNODE_RPC_ENV_V1],
       }),
+      fetch: alchemyBearerFetch,
       githubReadToken: null,
     });
+    return shardsComposition;
+  };
   const website: ManualRouterWebsiteAuthorityV1 = Object.freeze({
     assertCompleteSignedArtifact(raw: unknown) {
       const artifact = assertPortableManualRouterCompleteSignedArtifactV1(raw);
@@ -119,18 +143,28 @@ ProductionManualRouterAuthorityV1 {
       const verifiedRequest = assertPortableManualRouterSignedPublishRequestV1(
         input.request,
       );
+      const exactShards = isExactShardsManualRouterPublishRequestV1(
+        verifiedRequest,
+      ) && manualRouterIsExactShardsV1ArtifactV1(
+        verifiedRequest.signedArtifact as never,
+      );
       return await verifyPortableManualRouterSignedPublishV1({
         ...input,
-        composition: isExactShardsManualRouterPublishRequestV1(verifiedRequest)
-          ? shardsPublishComposition
+        composition: exactShards
+          ? exactShardsComposition()
           : composition,
         request: verifiedRequest,
       }) as unknown as ManualRouterVerifiedPublishV1;
     },
-    async readChainClock(): Promise<ManualRouterChainClockV1> {
+    async readChainClock(
+      selector: Parameters<ManualRouterWebsiteAuthorityV1["readChainClock"]>[0],
+    ): Promise<ManualRouterChainClockV1> {
+      const selected = selectorUsesExactShardsV1(selector)
+        ? exactShardsComposition()
+        : composition;
       const [clock, finalized] = await Promise.all([
-        composition.rpc.observeChainClock(),
-        composition.rpc.collectCommonFinalizedAnchor(),
+        selected.rpc.observeChainClock(),
+        selected.rpc.collectCommonFinalizedAnchor(),
       ]);
       if (BigInt(finalized.timestamp) > BigInt(clock.minimumTimestamp)) {
         throw new TypeError("portable manual Router finality clock is invalid");
@@ -144,10 +178,14 @@ ProductionManualRouterAuthorityV1 {
       });
     },
     async observeExactTransaction({
+      artifact,
       prepared,
       transactionHash,
     }: Parameters<ManualRouterWebsiteAuthorityV1["observeExactTransaction"]>[0]) {
-      const observed = await composition.rpc.readConsensus(
+      const selected = manualRouterIsExactShardsV1ArtifactV1(artifact as never)
+        ? exactShardsComposition()
+        : composition;
+      const observed = await selected.rpc.readConsensus(
         "eth_getTransactionByHash",
         [transactionHash],
       );
@@ -168,16 +206,43 @@ ProductionManualRouterAuthorityV1 {
     async resolveReissueState(input: Parameters<
       ManualRouterWebsiteAuthorityV1["resolveReissueState"]
     >[0]) {
+      const selected = manualRouterIsExactShardsV1ArtifactV1(
+        input.artifact as never,
+      )
+        ? exactShardsComposition()
+        : composition;
       return await resolvePortableManualRouterReissueStateV1({
-        composition,
-        ...input,
+        composition: selected,
+        request: input.request,
+        currentApplicantIndex: input.currentApplicantIndex,
+        currentApplicantPointers: input.currentApplicantPointers,
+        currentStatus: input.currentStatus,
       });
     },
   });
   const finality = new RouterLaunchFinalityVerifierV1({ rpc: composition.rpc });
-  const finalityAuthority = createProductionManualRouterFinalityAuthorityV1({
+  const genericFinalityAuthority = createProductionManualRouterFinalityAuthorityV1({
     finality,
     rpc: composition.rpc,
+  });
+  let shardsFinalityAuthority: ManualRouterFinalityAuthorityV1 | null = null;
+  const exactShardsFinalityAuthority = (): ManualRouterFinalityAuthorityV1 => {
+    if (shardsFinalityAuthority !== null) return shardsFinalityAuthority;
+    const selected = exactShardsComposition();
+    shardsFinalityAuthority = createProductionManualRouterFinalityAuthorityV1({
+      finality: new RouterLaunchFinalityVerifierV1({ rpc: selected.rpc }),
+      rpc: selected.rpc,
+    });
+    return shardsFinalityAuthority;
+  };
+  const finalityAuthority: ManualRouterFinalityAuthorityV1 = Object.freeze({
+    async finalize(
+      input: Parameters<ManualRouterFinalityAuthorityV1["finalize"]>[0],
+    ) {
+      return (manualRouterIsExactShardsV1ArtifactV1(input.artifact as never)
+        ? exactShardsFinalityAuthority()
+        : genericFinalityAuthority).finalize(input);
+    },
   });
   return Object.freeze({
     composition,
@@ -185,6 +250,18 @@ ProductionManualRouterAuthorityV1 {
     finality,
     finalityAuthority,
   });
+}
+
+function selectorUsesExactShardsV1(
+  selector: Parameters<ManualRouterWebsiteAuthorityV1["readChainClock"]>[0],
+): boolean {
+  return (
+    selector?.artifact !== undefined
+      && manualRouterIsExactShardsV1ArtifactV1(selector.artifact as never)
+  ) || (
+    selector?.pointer !== undefined
+      && manualRouterIsExactShardsV1PointerV1(selector.pointer as never)
+  );
 }
 
 const PORTABLE_FINALITY_OBSERVATION_UNAVAILABLE_MESSAGES = new Set([

--- a/lib/server/custom-launch/manual-router-authority-v1.ts
+++ b/lib/server/custom-launch/manual-router-authority-v1.ts
@@ -8,6 +8,7 @@ import {
   RouterLaunchFinalityVerifierV1,
   RouterLaunchTransactionRevertedError,
   assertPortableManualRouterCompleteSignedArtifactV1,
+  assertPortableManualRouterSignedPublishRequestV1,
   createPortableManualRouterPublishAuthorityFromEnvV1,
   resolvePortableManualRouterReissueStateV1,
   verifyPortableManualRouterSignedPublishV1,
@@ -26,6 +27,10 @@ import type { ManualRouterChainClockV1 } from
 import {
   type ManualRouterFinalityAuthorityV1,
 } from "@/lib/server/custom-launch/manual-router-finality-v1";
+import {
+  createShardsManualRouterPublishFetchV1,
+  isExactShardsManualRouterPublishRequestV1,
+} from "@/lib/server/custom-launch/manual-router-shards-publish-transport-v1";
 import {
   ManualRouterTransactionNotObservedErrorV1,
   type ManualRouterCompleteSignedArtifactViewV1,
@@ -94,6 +99,15 @@ ProductionManualRouterAuthorityV1 {
     // secret. The Applicant identity path is separately bound through Privy.
     githubReadToken: null,
   });
+  const shardsPublishComposition =
+    createPortableManualRouterPublishAuthorityFromEnvV1({
+      env: process.env,
+      fetch: createShardsManualRouterPublishFetchV1({
+        fetch,
+        quickNodeUrl: process.env[MANUAL_ROUTER_QUICKNODE_RPC_ENV_V1],
+      }),
+      githubReadToken: null,
+    });
   const website: ManualRouterWebsiteAuthorityV1 = Object.freeze({
     assertCompleteSignedArtifact(raw: unknown) {
       const artifact = assertPortableManualRouterCompleteSignedArtifactV1(raw);
@@ -102,9 +116,15 @@ ProductionManualRouterAuthorityV1 {
     async verifySignedPublish(input: Parameters<
       ManualRouterWebsiteAuthorityV1["verifySignedPublish"]
     >[0]) {
+      const verifiedRequest = assertPortableManualRouterSignedPublishRequestV1(
+        input.request,
+      );
       return await verifyPortableManualRouterSignedPublishV1({
-        composition,
         ...input,
+        composition: isExactShardsManualRouterPublishRequestV1(verifiedRequest)
+          ? shardsPublishComposition
+          : composition,
+        request: verifiedRequest,
       }) as unknown as ManualRouterVerifiedPublishV1;
     },
     async readChainClock(): Promise<ManualRouterChainClockV1> {

--- a/lib/server/custom-launch/manual-router-authority-v1.ts
+++ b/lib/server/custom-launch/manual-router-authority-v1.ts
@@ -8,6 +8,7 @@ import {
   RouterLaunchFinalityVerifierV1,
   RouterLaunchTransactionRevertedError,
   assertPortableManualRouterCompleteSignedArtifactV1,
+  assertPortableManualRouterSignedPublishRequestV1,
   createPortableManualRouterPublishAuthorityFromEnvV1,
   resolvePortableManualRouterReissueStateV1,
   verifyPortableManualRouterSignedPublishV1,
@@ -26,6 +27,18 @@ import type { ManualRouterChainClockV1 } from
 import {
   type ManualRouterFinalityAuthorityV1,
 } from "@/lib/server/custom-launch/manual-router-finality-v1";
+import {
+  SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_ENV_V1,
+  SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_ENV_V1,
+  SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1,
+  createShardsManualRouterAlchemyBearerFetchV1,
+  createShardsManualRouterPublishFetchV1,
+  isExactShardsManualRouterPublishRequestV1,
+} from "@/lib/server/custom-launch/manual-router-shards-publish-transport-v1";
+import {
+  manualRouterIsExactShardsV1ArtifactV1,
+  manualRouterIsExactShardsV1PointerV1,
+} from "@/lib/server/custom-launch/manual-router-shards-v1-compat-v1";
 import {
   ManualRouterTransactionNotObservedErrorV1,
   type ManualRouterCompleteSignedArtifactViewV1,
@@ -98,6 +111,31 @@ ProductionManualRouterAuthorityV1 {
     // secret. The Applicant identity path is separately bound through Privy.
     githubReadToken: null,
   });
+  let shardsComposition: PortableManualRouterCompositionV1 | null = null;
+  const exactShardsComposition = (): PortableManualRouterCompositionV1 => {
+    if (shardsComposition !== null) return shardsComposition;
+    const quickNodeFetch = createShardsManualRouterPublishFetchV1({
+      fetch,
+      quickNodeUrl: process.env[MANUAL_ROUTER_QUICKNODE_RPC_ENV_V1],
+    });
+    const alchemyBearerFetch = createShardsManualRouterAlchemyBearerFetchV1({
+      fetch: quickNodeFetch,
+      apiKey: process.env[SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_ENV_V1],
+      apiKeyCommitment:
+        process.env[SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_ENV_V1],
+    });
+    shardsComposition = createPortableManualRouterPublishAuthorityFromEnvV1({
+      env: Object.freeze({
+        [MANUAL_ROUTER_ALCHEMY_RPC_ENV_V1]:
+          SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1,
+        [MANUAL_ROUTER_QUICKNODE_RPC_ENV_V1]:
+          process.env[MANUAL_ROUTER_QUICKNODE_RPC_ENV_V1],
+      }),
+      fetch: alchemyBearerFetch,
+      githubReadToken: null,
+    });
+    return shardsComposition;
+  };
   const legacyWebsite: ManualRouterWebsiteAuthorityV1 = Object.freeze({
     assertCompleteSignedArtifact(raw: unknown) {
       const artifact = assertPortableManualRouterCompleteSignedArtifactV1(raw);
@@ -106,15 +144,31 @@ ProductionManualRouterAuthorityV1 {
     async verifySignedPublish(input: Parameters<
       ManualRouterWebsiteAuthorityV1["verifySignedPublish"]
     >[0]) {
+      const verifiedRequest = assertPortableManualRouterSignedPublishRequestV1(
+        input.request,
+      );
+      const exactShards = isExactShardsManualRouterPublishRequestV1(
+        verifiedRequest,
+      ) && manualRouterIsExactShardsV1ArtifactV1(
+        verifiedRequest.signedArtifact as never,
+      );
       return await verifyPortableManualRouterSignedPublishV1({
-        composition,
         ...input,
+        composition: exactShards
+          ? exactShardsComposition()
+          : composition,
+        request: verifiedRequest,
       }) as unknown as ManualRouterVerifiedPublishV1;
     },
-    async readChainClock(): Promise<ManualRouterChainClockV1> {
+    async readChainClock(
+      selector: Parameters<ManualRouterWebsiteAuthorityV1["readChainClock"]>[0],
+    ): Promise<ManualRouterChainClockV1> {
+      const selected = selectorUsesExactShardsV1(selector)
+        ? exactShardsComposition()
+        : composition;
       const [clock, finalized] = await Promise.all([
-        composition.rpc.observeChainClock(),
-        composition.rpc.collectCommonFinalizedAnchor(),
+        selected.rpc.observeChainClock(),
+        selected.rpc.collectCommonFinalizedAnchor(),
       ]);
       if (BigInt(finalized.timestamp) > BigInt(clock.minimumTimestamp)) {
         throw new TypeError("portable manual Router finality clock is invalid");
@@ -128,10 +182,14 @@ ProductionManualRouterAuthorityV1 {
       });
     },
     async observeExactTransaction({
+      artifact,
       prepared,
       transactionHash,
     }: Parameters<ManualRouterWebsiteAuthorityV1["observeExactTransaction"]>[0]) {
-      const observed = await composition.rpc.readConsensus(
+      const selected = manualRouterIsExactShardsV1ArtifactV1(artifact as never)
+        ? exactShardsComposition()
+        : composition;
+      const observed = await selected.rpc.readConsensus(
         "eth_getTransactionByHash",
         [transactionHash],
       );
@@ -152,9 +210,17 @@ ProductionManualRouterAuthorityV1 {
     async resolveReissueState(input: Parameters<
       ManualRouterWebsiteAuthorityV1["resolveReissueState"]
     >[0]) {
+      const selected = manualRouterIsExactShardsV1ArtifactV1(
+        input.artifact as never,
+      )
+        ? exactShardsComposition()
+        : composition;
       return await resolvePortableManualRouterReissueStateV1({
-        composition,
-        ...input,
+        composition: selected,
+        request: input.request,
+        currentApplicantIndex: input.currentApplicantIndex,
+        currentApplicantPointers: input.currentApplicantPointers,
+        currentStatus: input.currentStatus,
       });
     },
   });
@@ -163,9 +229,28 @@ ProductionManualRouterAuthorityV1 {
     loadV2: createProductionManualRouterWebsiteAuthorityV2,
   });
   const finality = new RouterLaunchFinalityVerifierV1({ rpc: composition.rpc });
-  const finalityAuthority = createProductionManualRouterFinalityAuthorityV1({
+  const genericFinalityAuthority = createProductionManualRouterFinalityAuthorityV1({
     finality,
     rpc: composition.rpc,
+  });
+  let shardsFinalityAuthority: ManualRouterFinalityAuthorityV1 | null = null;
+  const exactShardsFinalityAuthority = (): ManualRouterFinalityAuthorityV1 => {
+    if (shardsFinalityAuthority !== null) return shardsFinalityAuthority;
+    const selected = exactShardsComposition();
+    shardsFinalityAuthority = createProductionManualRouterFinalityAuthorityV1({
+      finality: new RouterLaunchFinalityVerifierV1({ rpc: selected.rpc }),
+      rpc: selected.rpc,
+    });
+    return shardsFinalityAuthority;
+  };
+  const finalityAuthority: ManualRouterFinalityAuthorityV1 = Object.freeze({
+    async finalize(
+      input: Parameters<ManualRouterFinalityAuthorityV1["finalize"]>[0],
+    ) {
+      return (manualRouterIsExactShardsV1ArtifactV1(input.artifact as never)
+        ? exactShardsFinalityAuthority()
+        : genericFinalityAuthority).finalize(input);
+    },
   });
   return Object.freeze({
     composition,
@@ -173,6 +258,18 @@ ProductionManualRouterAuthorityV1 {
     finality,
     finalityAuthority,
   });
+}
+
+function selectorUsesExactShardsV1(
+  selector: Parameters<ManualRouterWebsiteAuthorityV1["readChainClock"]>[0],
+): boolean {
+  return (
+    selector?.artifact !== undefined
+      && manualRouterIsExactShardsV1ArtifactV1(selector.artifact as never)
+  ) || (
+    selector?.pointer !== undefined
+      && manualRouterIsExactShardsV1PointerV1(selector.pointer as never)
+  );
 }
 
 const PORTABLE_FINALITY_OBSERVATION_UNAVAILABLE_MESSAGES = new Set([

--- a/lib/server/custom-launch/manual-router-authority-v2.ts
+++ b/lib/server/custom-launch/manual-router-authority-v2.ts
@@ -94,11 +94,13 @@ export function createManualRouterWebsiteAuthorityDispatchV2(input: Readonly<{
         ? await loadV2().verifySignedPublish(request)
         : await input.v1.verifySignedPublish(request);
     },
-    async readChainClock() {
+    async readChainClock(selector: Parameters<
+      ManualRouterWebsiteAuthorityV1["readChainClock"]
+    >[0]) {
       // Chain time is route-independent. Keeping the existing production
       // source preserves V1 behavior; the V2 facade must independently bind
       // its own dual-RPC observations during currentness/preflight.
-      return await input.v1.readChainClock();
+      return await input.v1.readChainClock(selector);
     },
     async assertV2AcceptanceCurrent(value: Parameters<NonNullable<
       ManualRouterWebsiteAuthorityV1["assertV2AcceptanceCurrent"]
@@ -121,7 +123,13 @@ export function createManualRouterWebsiteAuthorityDispatchV2(input: Readonly<{
     async resolveReissueState(value: Parameters<
       ManualRouterWebsiteAuthorityV1["resolveReissueState"]
     >[0]) {
-      return reissueArtifactVersionV2(value.request)
+      const version = value.artifact === undefined
+        ? reissueArtifactVersionV2(value.request)
+        : artifactVersionV2(
+            value.artifact,
+            "manual Router previous signed artifact",
+          );
+      return version
           === "programmable.manual-router-complete-signed-artifact.v2"
         ? await loadV2().resolveReissueState(value)
         : await input.v1.resolveReissueState(value);

--- a/lib/server/custom-launch/manual-router-finality-v1.ts
+++ b/lib/server/custom-launch/manual-router-finality-v1.ts
@@ -160,7 +160,7 @@ export class ManualRouterFinalityServiceV1 {
       );
     }
     const clock = await this.dependencies.website.dependencies.authority
-      .readChainClock();
+      .readChainClock({ artifact });
     const nextPointer = advanceFinalityPointer({
       pointer,
       updatedAtEpochSeconds: clock.maximumTimestamp,

--- a/lib/server/custom-launch/manual-router-head-v1.ts
+++ b/lib/server/custom-launch/manual-router-head-v1.ts
@@ -24,9 +24,12 @@ export async function readManualRouterApplicantHeadV1(input: Readonly<{
   store: ManualRouterPrivateBlobStoreV1;
   approvedGitHubUserId: string;
   approvedLaunchWallet: `0x${string}`;
+  useCompareAndSwapEtag?: boolean;
 }>): Promise<ManualRouterApplicantHeadV1> {
   const path = manualRouterApplicantIndexPathV1(input);
-  const storedIndex = await input.store.read(path);
+  const storedIndex = input.useCompareAndSwapEtag === true
+    ? await input.store.readForCompareAndSwap(path)
+    : await input.store.read(path);
   if (storedIndex === null) {
     return Object.freeze({ path, etag: null, index: null, pointers: [] });
   }

--- a/lib/server/custom-launch/manual-router-service-v1.ts
+++ b/lib/server/custom-launch/manual-router-service-v1.ts
@@ -42,10 +42,17 @@ import {
 import {
   commitManualRouterApplicantHeadTransitionV1,
 } from "@/lib/server/custom-launch/manual-router-transition-v1";
+import {
+  MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1,
+  manualRouterClaimsShardsV1ArtifactV1,
+  manualRouterClaimsShardsV1PointerV1,
+  manualRouterIsExactShardsV1ArtifactV1,
+  manualRouterIsExactShardsV1PointerV1,
+} from "@/lib/server/custom-launch/manual-router-shards-v1-compat-v1";
 
 type EvmAddress = `0x${string}`;
 type EvmBytes32 = `0x${string}`;
-const SHARDS_GITHUB_USER_ID = "155705664";
+const MAXIMUM_SHARDS_V1_POINTER_LINEAGE_DEPTH = 64;
 
 export type ManualRouterCompleteSignedArtifactViewV1 = Readonly<{
   schemaVersion: "programmable.manual-router-complete-signed-artifact.v1";
@@ -176,12 +183,13 @@ export class ManualRouterWebsiteServiceV1 {
     } catch {
       throw invalidArtifact();
     }
-    assertNoLegacyShardsArtifact(artifact);
+    assertShardsV1ArtifactCompatibility(artifact);
     const principal = artifactPrincipal(artifact);
     const head = await readManualRouterApplicantHeadV1({
       store: this.dependencies.store,
       ...principal,
     });
+    await this.#assertShardsV1CurrentHead(artifact, head);
     let verified: ManualRouterVerifiedPublishV1;
     let checkedArtifact: ManualRouterCompleteSignedArtifactViewAnyV2;
     try {
@@ -196,7 +204,7 @@ export class ManualRouterWebsiteServiceV1 {
     } catch {
       throw invalidArtifact();
     }
-    assertNoLegacyShardsArtifact(checkedArtifact);
+    assertShardsV1ArtifactCompatibility(checkedArtifact);
     if (canonicalizeJson(artifact) !== canonicalizeJson(checkedArtifact)) {
       throw invalidArtifact();
     }
@@ -204,6 +212,12 @@ export class ManualRouterWebsiteServiceV1 {
     const pointer = assertManualRouterApplicantPointerAnyV2(
       verified.nextPointer,
     );
+    await this.#assertShardsV1PublishTransition({
+      artifact,
+      pointer,
+      head,
+      idempotent: verified.idempotent,
+    });
     if (
       pointer.state !== "signed-permit-available"
       || pointer.signedArtifactHash !== artifact.signedArtifactHash
@@ -257,11 +271,12 @@ export class ManualRouterWebsiteServiceV1 {
     } catch {
       throw invalidArtifact();
     }
-    assertNoLegacyShardsArtifact(artifact);
+    assertShardsV1ArtifactCompatibility(artifact);
     const head = await readManualRouterApplicantHeadV1({
       store: this.dependencies.store,
       ...artifactPrincipal(artifact),
     });
+    await this.#assertShardsV1CurrentHead(artifact, head);
     const matching = head.pointers.find((pointer) =>
       pointer.subject.subjectHash
         === artifact.preparationArtifact.subject.subjectHash);
@@ -311,11 +326,8 @@ export class ManualRouterWebsiteServiceV1 {
       approvedLaunchWallet: principal.launchWallet,
     });
     const clock = await this.dependencies.authority.readChainClock();
-    if (
-      principal.githubUserId === SHARDS_GITHUB_USER_ID
-      && head.pointers.some((pointer) => pointer.schemaVersion
-        === "programmable.manual-router-applicant-pointer.v1")
-    ) throw routeCapabilityDisabled();
+    await Promise.all(head.pointers.map((pointer) =>
+      this.#assertShardsV1PointerLineage(pointer)));
     await Promise.all(head.pointers.map(async (pointer) => {
       if (
         pointer.schemaVersion
@@ -360,6 +372,7 @@ export class ManualRouterWebsiteServiceV1 {
       approvedLaunchWallet: principal.launchWallet,
     });
     const pointer = currentPointer(head, principal.subjectHash);
+    await this.#assertShardsV1PointerLineage(pointer);
     const clock = await this.dependencies.authority.readChainClock();
     const status = manualRouterApplicantStatusAnyV2(pointer, clock);
     const common = resolveCommon(pointer);
@@ -496,7 +509,7 @@ export class ManualRouterWebsiteServiceV1 {
   async readPointerArtifact(
     pointer: ManualRouterApplicantPointerAnyV2,
   ): Promise<ManualRouterCompleteSignedArtifactViewAnyV2> {
-    assertNoLegacyShardsPointer(pointer);
+    assertShardsV1PointerCompatibility(pointer);
     const stored = await this.dependencies.store.read(manualRouterContentPathV1(
       "signed-artifacts",
       pointer.signedArtifactHash,
@@ -510,6 +523,7 @@ export class ManualRouterWebsiteServiceV1 {
     } catch {
       throw invalidArtifact();
     }
+    assertShardsV1ArtifactCompatibility(artifact);
     if (
       artifact.signedArtifactHash !== pointer.signedArtifactHash
       || artifact.descriptor.descriptorHash !== pointer.signedDescriptorHash
@@ -522,7 +536,133 @@ export class ManualRouterWebsiteServiceV1 {
         !== pointer.subject.approvedLaunchWallet.toLowerCase()
       || !pointerBindsArtifact(pointer, artifact)
     ) throw invalidArtifact();
+    await this.#assertShardsV1PointerLineage(pointer, artifact);
     return artifact;
+  }
+
+  async #assertShardsV1CurrentHead(
+    artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
+    head: ManualRouterApplicantHeadV1,
+  ): Promise<void> {
+    if (!manualRouterClaimsShardsV1ArtifactV1(artifact)) return;
+    assertShardsV1ArtifactCompatibility(artifact);
+    const matches = head.pointers.filter((pointer) =>
+      pointer.subject.subjectHash
+        === artifact.preparationArtifact.subject.subjectHash);
+    if (matches.length !== 1) throw routeCapabilityDisabled();
+    await this.#assertShardsV1PointerLineage(matches[0]!);
+  }
+
+  async #assertShardsV1PublishTransition(input: Readonly<{
+    artifact: ManualRouterCompleteSignedArtifactViewAnyV2;
+    pointer: ManualRouterApplicantPointerAnyV2;
+    head: ManualRouterApplicantHeadV1;
+    idempotent: boolean;
+  }>): Promise<void> {
+    const claimsArtifact = manualRouterClaimsShardsV1ArtifactV1(input.artifact);
+    const claimsPointer = manualRouterClaimsShardsV1PointerV1(input.pointer);
+    if (!claimsArtifact && !claimsPointer) return;
+    assertShardsV1ArtifactCompatibility(input.artifact);
+    assertShardsV1PointerCompatibility(input.pointer);
+    const current = input.head.pointers.filter((pointer) =>
+      pointer.subject.subjectHash === input.pointer.subject.subjectHash);
+    if (current.length !== 1) throw routeCapabilityDisabled();
+    await this.#assertShardsV1PointerLineage(current[0]!);
+    if (
+      input.pointer.signedArtifactHash !== input.artifact.signedArtifactHash
+      || input.pointer.subject.subjectHash
+        !== input.artifact.preparationArtifact.subject.subjectHash
+      || input.pointer.schemaVersion
+        !== "programmable.manual-router-applicant-pointer.v1"
+      || !shardsV1PointerBindsArtifact(input.pointer, input.artifact)
+    ) throw routeCapabilityDisabled();
+    if (input.pointer.pointerHash === current[0]!.pointerHash) {
+      if (!input.idempotent) throw routeCapabilityDisabled();
+      return;
+    }
+    if (
+      input.idempotent
+      || input.pointer.state !== "signed-permit-available"
+      || input.pointer.previousPointerHash !== current[0]!.pointerHash
+      || input.pointer.signedArtifactHash === current[0]!.signedArtifactHash
+      || input.artifact.descriptor.reissueOf
+        !== current[0]!.signatureRequestHash
+    ) throw routeCapabilityDisabled();
+  }
+
+  async #assertShardsV1PointerLineage(
+    pointer: ManualRouterApplicantPointerAnyV2,
+    currentArtifact?: ManualRouterCompleteSignedArtifactViewAnyV2,
+  ): Promise<void> {
+    if (!manualRouterClaimsShardsV1PointerV1(pointer)) return;
+    assertShardsV1PointerCompatibility(pointer);
+    let current = pointer;
+    let suppliedArtifact = currentArtifact;
+    const seen = new Set<Sha256Digest>();
+    for (
+      let depth = 0;
+      depth < MAXIMUM_SHARDS_V1_POINTER_LINEAGE_DEPTH;
+      depth += 1
+    ) {
+      if (current.schemaVersion
+        !== "programmable.manual-router-applicant-pointer.v1") {
+        throw routeCapabilityDisabled();
+      }
+      assertShardsV1PointerCompatibility(current);
+      if (seen.has(current.pointerHash)) throw routeCapabilityDisabled();
+      seen.add(current.pointerHash);
+      const artifact = suppliedArtifact ?? await this.#readShardsV1Artifact(current);
+      suppliedArtifact = undefined;
+      assertShardsV1ArtifactCompatibility(artifact);
+      if (!shardsV1PointerBindsArtifact(current, artifact)) {
+        throw routeCapabilityDisabled();
+      }
+      if (current.pointerHash
+        === MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1.rootPointerHash) {
+        if (
+          current.previousPointerHash !== null
+          || current.signedArtifactHash
+            !== MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1.rootSignedArtifactHash
+          || artifact.descriptor.reissueOf !== null
+        ) throw routeCapabilityDisabled();
+        return;
+      }
+      if (current.previousPointerHash === null) throw routeCapabilityDisabled();
+      const childPointer = current;
+      const expectedPreviousPointerHash = current.previousPointerHash;
+      const previous = await this.dependencies.store.read(
+        manualRouterContentPathV1("pointer-history", expectedPreviousPointerHash),
+      );
+      if (previous === null) throw routeCapabilityDisabled();
+      try {
+        current = assertManualRouterApplicantPointerV1(previous.value);
+      } catch {
+        throw routeCapabilityDisabled();
+      }
+      if (current.pointerHash !== expectedPreviousPointerHash) {
+        throw routeCapabilityDisabled();
+      }
+      if (
+        childPointer.signedArtifactHash !== current.signedArtifactHash
+        && artifact.descriptor.reissueOf !== current.signatureRequestHash
+      ) throw routeCapabilityDisabled();
+    }
+    throw routeCapabilityDisabled();
+  }
+
+  async #readShardsV1Artifact(
+    pointer: ManualRouterApplicantPointerV1,
+  ): Promise<ManualRouterCompleteSignedArtifactViewAnyV2> {
+    const stored = await this.dependencies.store.read(manualRouterContentPathV1(
+      "signed-artifacts",
+      pointer.signedArtifactHash,
+    ));
+    if (stored === null) throw routeCapabilityDisabled();
+    try {
+      return this.dependencies.authority.assertCompleteSignedArtifact(stored.value);
+    } catch {
+      throw routeCapabilityDisabled();
+    }
   }
 
   async #assertV2AcceptanceCurrent(
@@ -616,23 +756,42 @@ function artifactPrincipal(
   });
 }
 
-function assertNoLegacyShardsArtifact(
+function assertShardsV1ArtifactCompatibility(
   artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
 ): void {
   if (
-    artifact.schemaVersion === "programmable.manual-router-complete-signed-artifact.v1"
-    && artifact.preparationArtifact.subject.approvedGitHubUserId
-      === SHARDS_GITHUB_USER_ID
+    manualRouterClaimsShardsV1ArtifactV1(artifact)
+    && !manualRouterIsExactShardsV1ArtifactV1(artifact)
   ) throw routeCapabilityDisabled();
 }
 
-function assertNoLegacyShardsPointer(
+function assertShardsV1PointerCompatibility(
   pointer: ManualRouterApplicantPointerAnyV2,
 ): void {
   if (
-    pointer.schemaVersion === "programmable.manual-router-applicant-pointer.v1"
-    && pointer.subject.approvedGitHubUserId === SHARDS_GITHUB_USER_ID
+    manualRouterClaimsShardsV1PointerV1(pointer)
+    && !manualRouterIsExactShardsV1PointerV1(pointer)
   ) throw routeCapabilityDisabled();
+}
+
+function shardsV1PointerBindsArtifact(
+  pointer: ManualRouterApplicantPointerV1,
+  artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
+): boolean {
+  return artifact.schemaVersion
+      === "programmable.manual-router-complete-signed-artifact.v1"
+    && pointer.signedArtifactHash === artifact.signedArtifactHash
+    && pointer.signedDescriptorHash === artifact.descriptor.descriptorHash
+    && pointer.signatureRequestHash === artifact.descriptor.signatureRequestHash
+    && pointer.preparationArtifactHash
+      === artifact.preparationArtifact.preparationArtifactHash
+    && pointer.subject.subjectHash
+      === artifact.preparationArtifact.subject.subjectHash
+    && pointer.subject.approvedLaunchWallet
+      === artifact.prepared.launchWallet.toLowerCase()
+    && pointer.headSha === artifact.preparationArtifact.approvalClaim.headSha
+    && pointer.treeSha === artifact.preparationArtifact.approvalClaim.treeSha
+    && pointer.routeNonce === artifact.descriptor.routeNonce;
 }
 
 function signedPublishImmutableWrites(

--- a/lib/server/custom-launch/manual-router-service-v1.ts
+++ b/lib/server/custom-launch/manual-router-service-v1.ts
@@ -42,10 +42,17 @@ import {
 import {
   commitManualRouterApplicantHeadTransitionV1,
 } from "@/lib/server/custom-launch/manual-router-transition-v1";
+import {
+  MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1,
+  manualRouterClaimsShardsV1ArtifactV1,
+  manualRouterClaimsShardsV1PointerV1,
+  manualRouterIsExactShardsV1ArtifactV1,
+  manualRouterIsExactShardsV1PointerV1,
+} from "@/lib/server/custom-launch/manual-router-shards-v1-compat-v1";
 
 type EvmAddress = `0x${string}`;
 type EvmBytes32 = `0x${string}`;
-const SHARDS_GITHUB_USER_ID = "155705664";
+const MAXIMUM_SHARDS_V1_POINTER_LINEAGE_DEPTH = 64;
 
 export type ManualRouterCompleteSignedArtifactViewV1 = Readonly<{
   schemaVersion: "programmable.manual-router-complete-signed-artifact.v1";
@@ -114,7 +121,10 @@ export interface ManualRouterWebsiteAuthorityV1 {
     currentApplicantIndex: ManualRouterApplicantIndexAnyV2 | null;
     currentApplicantPointers: readonly ManualRouterApplicantPointerAnyV2[];
   }>): Promise<ManualRouterVerifiedPublishV1>;
-  readChainClock(): Promise<ManualRouterChainClockV1>;
+  readChainClock(selector?: Readonly<{
+    artifact?: ManualRouterCompleteSignedArtifactViewAnyV2;
+    pointer?: ManualRouterApplicantPointerAnyV2;
+  }>): Promise<ManualRouterChainClockV1>;
   assertV2AcceptanceCurrent?(input: Readonly<{
     artifact: ManualRouterCompleteSignedArtifactViewV2;
     acceptanceHead: ManualRouterApplicantAcceptanceHeadV1;
@@ -134,6 +144,7 @@ export interface ManualRouterWebsiteAuthorityV1 {
     transactionHash: EvmBytes32;
   }>): Promise<void>;
   resolveReissueState(input: Readonly<{
+    artifact: ManualRouterCompleteSignedArtifactViewAnyV2;
     request: unknown;
     currentApplicantIndex: ManualRouterApplicantIndexAnyV2 | null;
     currentApplicantPointers: readonly ManualRouterApplicantPointerAnyV2[];
@@ -176,12 +187,13 @@ export class ManualRouterWebsiteServiceV1 {
     } catch {
       throw invalidArtifact();
     }
-    assertNoLegacyShardsArtifact(artifact);
+    assertShardsV1ArtifactCompatibility(artifact);
     const principal = artifactPrincipal(artifact);
     const head = await readManualRouterApplicantHeadV1({
       store: this.dependencies.store,
       ...principal,
     });
+    await this.#assertShardsV1CurrentHead(artifact, head);
     let verified: ManualRouterVerifiedPublishV1;
     let checkedArtifact: ManualRouterCompleteSignedArtifactViewAnyV2;
     try {
@@ -196,7 +208,7 @@ export class ManualRouterWebsiteServiceV1 {
     } catch {
       throw invalidArtifact();
     }
-    assertNoLegacyShardsArtifact(checkedArtifact);
+    assertShardsV1ArtifactCompatibility(checkedArtifact);
     if (canonicalizeJson(artifact) !== canonicalizeJson(checkedArtifact)) {
       throw invalidArtifact();
     }
@@ -204,6 +216,12 @@ export class ManualRouterWebsiteServiceV1 {
     const pointer = assertManualRouterApplicantPointerAnyV2(
       verified.nextPointer,
     );
+    await this.#assertShardsV1PublishTransition({
+      artifact,
+      pointer,
+      head,
+      idempotent: verified.idempotent,
+    });
     if (
       pointer.state !== "signed-permit-available"
       || pointer.signedArtifactHash !== artifact.signedArtifactHash
@@ -230,6 +248,12 @@ export class ManualRouterWebsiteServiceV1 {
       // Different signed posts never converge implicitly. The losing request
       // must reload and prove the winner as its exact predecessor.
       acceptConcurrentExactTarget: false,
+      ...(manualRouterIsExactShardsV1ArtifactV1(artifact)
+        ? {
+            refreshHeadAfterImmutableWrites: () =>
+              this.#refreshExactShardsV1PublishHead(artifact, head),
+          }
+        : {}),
     });
     return Object.freeze({
       schemaVersion: pointer.schemaVersion
@@ -257,18 +281,20 @@ export class ManualRouterWebsiteServiceV1 {
     } catch {
       throw invalidArtifact();
     }
-    assertNoLegacyShardsArtifact(artifact);
+    assertShardsV1ArtifactCompatibility(artifact);
     const head = await readManualRouterApplicantHeadV1({
       store: this.dependencies.store,
       ...artifactPrincipal(artifact),
     });
+    await this.#assertShardsV1CurrentHead(artifact, head);
     const matching = head.pointers.find((pointer) =>
       pointer.subject.subjectHash
         === artifact.preparationArtifact.subject.subjectHash);
-    const clock = await this.dependencies.authority.readChainClock();
+    const clock = await this.dependencies.authority.readChainClock({ artifact });
     let resolved: Readonly<Record<string, unknown>>;
     try {
       resolved = await this.dependencies.authority.resolveReissueState({
+        artifact,
         request,
         currentApplicantIndex: head.index,
         currentApplicantPointers: head.pointers,
@@ -310,12 +336,11 @@ export class ManualRouterWebsiteServiceV1 {
       approvedGitHubUserId: principal.githubUserId,
       approvedLaunchWallet: principal.launchWallet,
     });
-    const clock = await this.dependencies.authority.readChainClock();
-    if (
-      principal.githubUserId === SHARDS_GITHUB_USER_ID
-      && head.pointers.some((pointer) => pointer.schemaVersion
-        === "programmable.manual-router-applicant-pointer.v1")
-    ) throw routeCapabilityDisabled();
+    await Promise.all(head.pointers.map((pointer) =>
+      this.#assertShardsV1PointerLineage(pointer)));
+    const clock = await this.dependencies.authority.readChainClock({
+      ...(head.pointers.length === 1 ? { pointer: head.pointers[0] } : {}),
+    });
     await Promise.all(head.pointers.map(async (pointer) => {
       if (
         pointer.schemaVersion
@@ -360,7 +385,8 @@ export class ManualRouterWebsiteServiceV1 {
       approvedLaunchWallet: principal.launchWallet,
     });
     const pointer = currentPointer(head, principal.subjectHash);
-    const clock = await this.dependencies.authority.readChainClock();
+    await this.#assertShardsV1PointerLineage(pointer);
+    const clock = await this.dependencies.authority.readChainClock({ pointer });
     const status = manualRouterApplicantStatusAnyV2(pointer, clock);
     const common = resolveCommon(pointer);
     if (status === "ready" || status === "permit-not-yet-valid") {
@@ -475,7 +501,7 @@ export class ManualRouterWebsiteServiceV1 {
         false,
       );
     }
-    const clock = await this.dependencies.authority.readChainClock();
+    const clock = await this.dependencies.authority.readChainClock({ artifact });
     const nextPointer = advanceSubmittedPointer(
       pointer,
       clock.maximumTimestamp,
@@ -496,7 +522,7 @@ export class ManualRouterWebsiteServiceV1 {
   async readPointerArtifact(
     pointer: ManualRouterApplicantPointerAnyV2,
   ): Promise<ManualRouterCompleteSignedArtifactViewAnyV2> {
-    assertNoLegacyShardsPointer(pointer);
+    assertShardsV1PointerCompatibility(pointer);
     const stored = await this.dependencies.store.read(manualRouterContentPathV1(
       "signed-artifacts",
       pointer.signedArtifactHash,
@@ -510,6 +536,7 @@ export class ManualRouterWebsiteServiceV1 {
     } catch {
       throw invalidArtifact();
     }
+    assertShardsV1ArtifactCompatibility(artifact);
     if (
       artifact.signedArtifactHash !== pointer.signedArtifactHash
       || artifact.descriptor.descriptorHash !== pointer.signedDescriptorHash
@@ -522,7 +549,155 @@ export class ManualRouterWebsiteServiceV1 {
         !== pointer.subject.approvedLaunchWallet.toLowerCase()
       || !pointerBindsArtifact(pointer, artifact)
     ) throw invalidArtifact();
+    await this.#assertShardsV1PointerLineage(pointer, artifact);
     return artifact;
+  }
+
+  async #assertShardsV1CurrentHead(
+    artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
+    head: ManualRouterApplicantHeadV1,
+  ): Promise<void> {
+    if (!manualRouterClaimsShardsV1ArtifactV1(artifact)) return;
+    assertShardsV1ArtifactCompatibility(artifact);
+    const matches = head.pointers.filter((pointer) =>
+      pointer.subject.subjectHash
+        === artifact.preparationArtifact.subject.subjectHash);
+    if (matches.length !== 1) throw routeCapabilityDisabled();
+    await this.#assertShardsV1PointerLineage(matches[0]!);
+  }
+
+  async #refreshExactShardsV1PublishHead(
+    artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
+    verifiedHead: ManualRouterApplicantHeadV1,
+  ): Promise<ManualRouterApplicantHeadV1> {
+    const refreshed = await readManualRouterApplicantHeadV1({
+      store: this.dependencies.store,
+      ...artifactPrincipal(artifact),
+      useCompareAndSwapEtag: true,
+    });
+    if (
+      refreshed.path !== verifiedHead.path
+      || canonicalizeJson(refreshed.index) !== canonicalizeJson(verifiedHead.index)
+      || canonicalizeJson(refreshed.pointers)
+        !== canonicalizeJson(verifiedHead.pointers)
+    ) throw conflict();
+    if (
+      refreshed.etag === null
+      || !/^"[0-9a-f]{32}"$/u.test(refreshed.etag)
+    ) throw conflict();
+    return refreshed;
+  }
+
+  async #assertShardsV1PublishTransition(input: Readonly<{
+    artifact: ManualRouterCompleteSignedArtifactViewAnyV2;
+    pointer: ManualRouterApplicantPointerAnyV2;
+    head: ManualRouterApplicantHeadV1;
+    idempotent: boolean;
+  }>): Promise<void> {
+    const claimsArtifact = manualRouterClaimsShardsV1ArtifactV1(input.artifact);
+    const claimsPointer = manualRouterClaimsShardsV1PointerV1(input.pointer);
+    if (!claimsArtifact && !claimsPointer) return;
+    assertShardsV1ArtifactCompatibility(input.artifact);
+    assertShardsV1PointerCompatibility(input.pointer);
+    const current = input.head.pointers.filter((pointer) =>
+      pointer.subject.subjectHash === input.pointer.subject.subjectHash);
+    if (current.length !== 1) throw routeCapabilityDisabled();
+    await this.#assertShardsV1PointerLineage(current[0]!);
+    if (
+      input.pointer.signedArtifactHash !== input.artifact.signedArtifactHash
+      || input.pointer.subject.subjectHash
+        !== input.artifact.preparationArtifact.subject.subjectHash
+      || input.pointer.schemaVersion
+        !== "programmable.manual-router-applicant-pointer.v1"
+      || !shardsV1PointerBindsArtifact(input.pointer, input.artifact)
+    ) throw routeCapabilityDisabled();
+    if (input.pointer.pointerHash === current[0]!.pointerHash) {
+      if (!input.idempotent) throw routeCapabilityDisabled();
+      return;
+    }
+    if (
+      input.idempotent
+      || input.pointer.state !== "signed-permit-available"
+      || input.pointer.previousPointerHash !== current[0]!.pointerHash
+      || input.pointer.signedArtifactHash === current[0]!.signedArtifactHash
+      || input.artifact.descriptor.reissueOf
+        !== current[0]!.signatureRequestHash
+    ) throw routeCapabilityDisabled();
+  }
+
+  async #assertShardsV1PointerLineage(
+    pointer: ManualRouterApplicantPointerAnyV2,
+    currentArtifact?: ManualRouterCompleteSignedArtifactViewAnyV2,
+  ): Promise<void> {
+    if (!manualRouterClaimsShardsV1PointerV1(pointer)) return;
+    assertShardsV1PointerCompatibility(pointer);
+    let current = pointer;
+    let suppliedArtifact = currentArtifact;
+    const seen = new Set<Sha256Digest>();
+    for (
+      let depth = 0;
+      depth < MAXIMUM_SHARDS_V1_POINTER_LINEAGE_DEPTH;
+      depth += 1
+    ) {
+      if (current.schemaVersion
+        !== "programmable.manual-router-applicant-pointer.v1") {
+        throw routeCapabilityDisabled();
+      }
+      assertShardsV1PointerCompatibility(current);
+      if (seen.has(current.pointerHash)) throw routeCapabilityDisabled();
+      seen.add(current.pointerHash);
+      const artifact = suppliedArtifact ?? await this.#readShardsV1Artifact(current);
+      suppliedArtifact = undefined;
+      assertShardsV1ArtifactCompatibility(artifact);
+      if (!shardsV1PointerBindsArtifact(current, artifact)) {
+        throw routeCapabilityDisabled();
+      }
+      if (current.pointerHash
+        === MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1.rootPointerHash) {
+        if (
+          current.previousPointerHash !== null
+          || current.signedArtifactHash
+            !== MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1.rootSignedArtifactHash
+          || artifact.descriptor.reissueOf !== null
+        ) throw routeCapabilityDisabled();
+        return;
+      }
+      if (current.previousPointerHash === null) throw routeCapabilityDisabled();
+      const childPointer = current;
+      const expectedPreviousPointerHash = current.previousPointerHash;
+      const previous = await this.dependencies.store.read(
+        manualRouterContentPathV1("pointer-history", expectedPreviousPointerHash),
+      );
+      if (previous === null) throw routeCapabilityDisabled();
+      try {
+        current = assertManualRouterApplicantPointerV1(previous.value);
+      } catch {
+        throw routeCapabilityDisabled();
+      }
+      if (current.pointerHash !== expectedPreviousPointerHash) {
+        throw routeCapabilityDisabled();
+      }
+      if (
+        childPointer.signedArtifactHash !== current.signedArtifactHash
+        && artifact.descriptor.reissueOf !== current.signatureRequestHash
+      ) throw routeCapabilityDisabled();
+    }
+    throw routeCapabilityDisabled();
+  }
+
+  async #readShardsV1Artifact(
+    pointer: ManualRouterApplicantPointerV1,
+  ): Promise<ManualRouterCompleteSignedArtifactViewAnyV2> {
+    const stored = await this.dependencies.store.read(manualRouterContentPathV1(
+      "signed-artifacts",
+      pointer.signedArtifactHash,
+    ));
+    if (stored === null) throw routeCapabilityDisabled();
+    try {
+      return this.dependencies.authority.assertCompleteSignedArtifact(stored.value);
+    } catch {
+      throw routeCapabilityDisabled();
+    }
   }
 
   async #assertV2AcceptanceCurrent(
@@ -616,23 +791,42 @@ function artifactPrincipal(
   });
 }
 
-function assertNoLegacyShardsArtifact(
+function assertShardsV1ArtifactCompatibility(
   artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
 ): void {
   if (
-    artifact.schemaVersion === "programmable.manual-router-complete-signed-artifact.v1"
-    && artifact.preparationArtifact.subject.approvedGitHubUserId
-      === SHARDS_GITHUB_USER_ID
+    manualRouterClaimsShardsV1ArtifactV1(artifact)
+    && !manualRouterIsExactShardsV1ArtifactV1(artifact)
   ) throw routeCapabilityDisabled();
 }
 
-function assertNoLegacyShardsPointer(
+function assertShardsV1PointerCompatibility(
   pointer: ManualRouterApplicantPointerAnyV2,
 ): void {
   if (
-    pointer.schemaVersion === "programmable.manual-router-applicant-pointer.v1"
-    && pointer.subject.approvedGitHubUserId === SHARDS_GITHUB_USER_ID
+    manualRouterClaimsShardsV1PointerV1(pointer)
+    && !manualRouterIsExactShardsV1PointerV1(pointer)
   ) throw routeCapabilityDisabled();
+}
+
+function shardsV1PointerBindsArtifact(
+  pointer: ManualRouterApplicantPointerV1,
+  artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
+): boolean {
+  return artifact.schemaVersion
+      === "programmable.manual-router-complete-signed-artifact.v1"
+    && pointer.signedArtifactHash === artifact.signedArtifactHash
+    && pointer.signedDescriptorHash === artifact.descriptor.descriptorHash
+    && pointer.signatureRequestHash === artifact.descriptor.signatureRequestHash
+    && pointer.preparationArtifactHash
+      === artifact.preparationArtifact.preparationArtifactHash
+    && pointer.subject.subjectHash
+      === artifact.preparationArtifact.subject.subjectHash
+    && pointer.subject.approvedLaunchWallet
+      === artifact.prepared.launchWallet.toLowerCase()
+    && pointer.headSha === artifact.preparationArtifact.approvalClaim.headSha
+    && pointer.treeSha === artifact.preparationArtifact.approvalClaim.treeSha
+    && pointer.routeNonce === artifact.descriptor.routeNonce;
 }
 
 function signedPublishImmutableWrites(

--- a/lib/server/custom-launch/manual-router-service-v1.ts
+++ b/lib/server/custom-launch/manual-router-service-v1.ts
@@ -573,6 +573,7 @@ export class ManualRouterWebsiteServiceV1 {
     const refreshed = await readManualRouterApplicantHeadV1({
       store: this.dependencies.store,
       ...artifactPrincipal(artifact),
+      useCompareAndSwapEtag: true,
     });
     if (
       refreshed.path !== verifiedHead.path
@@ -580,11 +581,11 @@ export class ManualRouterWebsiteServiceV1 {
       || canonicalizeJson(refreshed.pointers)
         !== canonicalizeJson(verifiedHead.pointers)
     ) throw conflict();
-    if (refreshed.etag === null) throw conflict();
-    return Object.freeze({
-      ...refreshed,
-      etag: strongExactShardsBlobEtag(refreshed.etag),
-    });
+    if (
+      refreshed.etag === null
+      || !/^"[0-9a-f]{32}"$/u.test(refreshed.etag)
+    ) throw conflict();
+    return refreshed;
   }
 
   async #assertShardsV1PublishTransition(input: Readonly<{
@@ -1244,10 +1245,4 @@ function routeCapabilityDisabled(): ManualRouterServiceErrorV1 {
 
 function conflict(): ManualRouterServiceErrorV1 {
   return new ManualRouterServiceErrorV1(409, "state_conflict", false);
-}
-
-function strongExactShardsBlobEtag(value: string): string {
-  if (/^"[0-9a-f]{32}"$/u.test(value)) return value;
-  if (/^W\/"[0-9a-f]{32}"$/u.test(value)) return value.slice(2);
-  throw conflict();
 }

--- a/lib/server/custom-launch/manual-router-service-v1.ts
+++ b/lib/server/custom-launch/manual-router-service-v1.ts
@@ -239,19 +239,21 @@ export class ManualRouterWebsiteServiceV1 {
       expected.idempotent !== verified.idempotent
       || canonicalizeJson(expected.index) !== canonicalizeJson(index)
     ) throw invalidArtifact();
-    const commitHead = await this.#refreshExactShardsV1PublishHead(
-      artifact,
-      head,
-    );
     const transition = await commitManualRouterApplicantHeadTransitionV1({
       store: this.dependencies.store,
-      head: commitHead,
+      head,
       nextPointer: pointer,
       nextIndex: index,
       immutableWrites: signedPublishImmutableWrites(artifact, pointer, index),
       // Different signed posts never converge implicitly. The losing request
       // must reload and prove the winner as its exact predecessor.
       acceptConcurrentExactTarget: false,
+      ...(manualRouterIsExactShardsV1ArtifactV1(artifact)
+        ? {
+            refreshHeadAfterImmutableWrites: () =>
+              this.#refreshExactShardsV1PublishHead(artifact, head),
+          }
+        : {}),
     });
     return Object.freeze({
       schemaVersion: pointer.schemaVersion
@@ -568,7 +570,6 @@ export class ManualRouterWebsiteServiceV1 {
     artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
     verifiedHead: ManualRouterApplicantHeadV1,
   ): Promise<ManualRouterApplicantHeadV1> {
-    if (!manualRouterIsExactShardsV1ArtifactV1(artifact)) return verifiedHead;
     const refreshed = await readManualRouterApplicantHeadV1({
       store: this.dependencies.store,
       ...artifactPrincipal(artifact),
@@ -579,7 +580,11 @@ export class ManualRouterWebsiteServiceV1 {
       || canonicalizeJson(refreshed.pointers)
         !== canonicalizeJson(verifiedHead.pointers)
     ) throw conflict();
-    return refreshed;
+    if (refreshed.etag === null) throw conflict();
+    return Object.freeze({
+      ...refreshed,
+      etag: strongExactShardsBlobEtag(refreshed.etag),
+    });
   }
 
   async #assertShardsV1PublishTransition(input: Readonly<{
@@ -1239,4 +1244,10 @@ function routeCapabilityDisabled(): ManualRouterServiceErrorV1 {
 
 function conflict(): ManualRouterServiceErrorV1 {
   return new ManualRouterServiceErrorV1(409, "state_conflict", false);
+}
+
+function strongExactShardsBlobEtag(value: string): string {
+  if (/^"[0-9a-f]{32}"$/u.test(value)) return value;
+  if (/^W\/"[0-9a-f]{32}"$/u.test(value)) return value.slice(2);
+  throw conflict();
 }

--- a/lib/server/custom-launch/manual-router-service-v1.ts
+++ b/lib/server/custom-launch/manual-router-service-v1.ts
@@ -121,7 +121,10 @@ export interface ManualRouterWebsiteAuthorityV1 {
     currentApplicantIndex: ManualRouterApplicantIndexAnyV2 | null;
     currentApplicantPointers: readonly ManualRouterApplicantPointerAnyV2[];
   }>): Promise<ManualRouterVerifiedPublishV1>;
-  readChainClock(): Promise<ManualRouterChainClockV1>;
+  readChainClock(selector?: Readonly<{
+    artifact?: ManualRouterCompleteSignedArtifactViewAnyV2;
+    pointer?: ManualRouterApplicantPointerAnyV2;
+  }>): Promise<ManualRouterChainClockV1>;
   assertV2AcceptanceCurrent?(input: Readonly<{
     artifact: ManualRouterCompleteSignedArtifactViewV2;
     acceptanceHead: ManualRouterApplicantAcceptanceHeadV1;
@@ -141,6 +144,7 @@ export interface ManualRouterWebsiteAuthorityV1 {
     transactionHash: EvmBytes32;
   }>): Promise<void>;
   resolveReissueState(input: Readonly<{
+    artifact: ManualRouterCompleteSignedArtifactViewAnyV2;
     request: unknown;
     currentApplicantIndex: ManualRouterApplicantIndexAnyV2 | null;
     currentApplicantPointers: readonly ManualRouterApplicantPointerAnyV2[];
@@ -280,10 +284,11 @@ export class ManualRouterWebsiteServiceV1 {
     const matching = head.pointers.find((pointer) =>
       pointer.subject.subjectHash
         === artifact.preparationArtifact.subject.subjectHash);
-    const clock = await this.dependencies.authority.readChainClock();
+    const clock = await this.dependencies.authority.readChainClock({ artifact });
     let resolved: Readonly<Record<string, unknown>>;
     try {
       resolved = await this.dependencies.authority.resolveReissueState({
+        artifact,
         request,
         currentApplicantIndex: head.index,
         currentApplicantPointers: head.pointers,
@@ -325,9 +330,11 @@ export class ManualRouterWebsiteServiceV1 {
       approvedGitHubUserId: principal.githubUserId,
       approvedLaunchWallet: principal.launchWallet,
     });
-    const clock = await this.dependencies.authority.readChainClock();
     await Promise.all(head.pointers.map((pointer) =>
       this.#assertShardsV1PointerLineage(pointer)));
+    const clock = await this.dependencies.authority.readChainClock({
+      ...(head.pointers.length === 1 ? { pointer: head.pointers[0] } : {}),
+    });
     await Promise.all(head.pointers.map(async (pointer) => {
       if (
         pointer.schemaVersion
@@ -373,7 +380,7 @@ export class ManualRouterWebsiteServiceV1 {
     });
     const pointer = currentPointer(head, principal.subjectHash);
     await this.#assertShardsV1PointerLineage(pointer);
-    const clock = await this.dependencies.authority.readChainClock();
+    const clock = await this.dependencies.authority.readChainClock({ pointer });
     const status = manualRouterApplicantStatusAnyV2(pointer, clock);
     const common = resolveCommon(pointer);
     if (status === "ready" || status === "permit-not-yet-valid") {
@@ -488,7 +495,7 @@ export class ManualRouterWebsiteServiceV1 {
         false,
       );
     }
-    const clock = await this.dependencies.authority.readChainClock();
+    const clock = await this.dependencies.authority.readChainClock({ artifact });
     const nextPointer = advanceSubmittedPointer(
       pointer,
       clock.maximumTimestamp,

--- a/lib/server/custom-launch/manual-router-service-v1.ts
+++ b/lib/server/custom-launch/manual-router-service-v1.ts
@@ -239,9 +239,13 @@ export class ManualRouterWebsiteServiceV1 {
       expected.idempotent !== verified.idempotent
       || canonicalizeJson(expected.index) !== canonicalizeJson(index)
     ) throw invalidArtifact();
+    const commitHead = await this.#refreshExactShardsV1PublishHead(
+      artifact,
+      head,
+    );
     const transition = await commitManualRouterApplicantHeadTransitionV1({
       store: this.dependencies.store,
-      head,
+      head: commitHead,
       nextPointer: pointer,
       nextIndex: index,
       immutableWrites: signedPublishImmutableWrites(artifact, pointer, index),
@@ -558,6 +562,24 @@ export class ManualRouterWebsiteServiceV1 {
         === artifact.preparationArtifact.subject.subjectHash);
     if (matches.length !== 1) throw routeCapabilityDisabled();
     await this.#assertShardsV1PointerLineage(matches[0]!);
+  }
+
+  async #refreshExactShardsV1PublishHead(
+    artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
+    verifiedHead: ManualRouterApplicantHeadV1,
+  ): Promise<ManualRouterApplicantHeadV1> {
+    if (!manualRouterIsExactShardsV1ArtifactV1(artifact)) return verifiedHead;
+    const refreshed = await readManualRouterApplicantHeadV1({
+      store: this.dependencies.store,
+      ...artifactPrincipal(artifact),
+    });
+    if (
+      refreshed.path !== verifiedHead.path
+      || canonicalizeJson(refreshed.index) !== canonicalizeJson(verifiedHead.index)
+      || canonicalizeJson(refreshed.pointers)
+        !== canonicalizeJson(verifiedHead.pointers)
+    ) throw conflict();
+    return refreshed;
   }
 
   async #assertShardsV1PublishTransition(input: Readonly<{

--- a/lib/server/custom-launch/manual-router-shards-publish-transport-v1.ts
+++ b/lib/server/custom-launch/manual-router-shards-publish-transport-v1.ts
@@ -1,7 +1,17 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
+
 export const SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1 =
   "sha256:1d7c191dc3e16ba9967be76622b76269b6ac1673637212fab41594ff1665394a";
+export const SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1 =
+  "https://eth-mainnet.g.alchemy.com/v2";
+export const SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_ENV_V1 =
+  "PROGRAMMABLE_SHARDS_REISSUE_ALCHEMY_MAINNET_RPC_API_KEY";
+export const SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_ENV_V1 =
+  "PROGRAMMABLE_SHARDS_REISSUE_ALCHEMY_MAINNET_RPC_API_KEY_COMMITMENT";
+export const SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_V1 =
+  "sha256:5419a7a33826708ccae3c7e29aca5e6bab25e6bc5e52a14c22141c4d0cc7ec87";
 
 const QUICKNODE_MINIMUM_FETCH_GAP_MILLISECONDS_V1 = 1_000;
 const QUICKNODE_429_RETRY_DELAYS_MILLISECONDS_V1 = Object.freeze([
@@ -13,6 +23,59 @@ type PublishTransportClockV1 = Readonly<{
   nowMilliseconds(): number;
   wait(milliseconds: number): Promise<void>;
 }>;
+
+export function createShardsManualRouterAlchemyBearerFetchV1(input: Readonly<{
+  fetch: typeof fetch;
+  apiKey: string | undefined;
+  apiKeyCommitment: string | undefined;
+}>): typeof fetch {
+  return createShardsManualRouterAlchemyBearerFetchForBindingV1({
+    ...input,
+    expectedApiKeyCommitment:
+      SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_V1,
+  });
+}
+
+export function createShardsManualRouterAlchemyBearerFetchForBindingV1(
+  input: Readonly<{
+    fetch: typeof fetch;
+    apiKey: string | undefined;
+    apiKeyCommitment: string | undefined;
+    expectedApiKeyCommitment: `sha256:${string}`;
+  }>,
+): typeof fetch {
+  const apiKey = strictAlchemyApiKey(input.apiKey);
+  const expected = strictSha256(
+    input.expectedApiKeyCommitment,
+    "expected Shards Alchemy access-key commitment",
+  );
+  const configured = strictSha256(
+    input.apiKeyCommitment,
+    "Shards Alchemy access-key commitment",
+  );
+  const observed = shardsManualRouterAlchemyApiKeyCommitmentV1(apiKey);
+  if (configured !== expected || observed !== expected) {
+    throw new TypeError("Shards Alchemy access-key commitment is invalid");
+  }
+  return (requestInput, requestInit) => {
+    if (requestUrl(requestInput) !== SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1) {
+      return input.fetch(requestInput, requestInit);
+    }
+    const request = new Request(requestInput, requestInit);
+    if (request.headers.has("authorization")) {
+      throw new TypeError("Shards Alchemy authorization is ambiguous");
+    }
+    const headers = new Headers(request.headers);
+    headers.set("authorization", `Bearer ${apiKey}`);
+    return input.fetch(new Request(request, { headers }));
+  };
+}
+
+export function shardsManualRouterAlchemyApiKeyCommitmentV1(
+  apiKey: string,
+): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(apiKey, "utf8").digest("hex")}`;
+}
 
 export function createShardsManualRouterPublishFetchV1(input: Readonly<{
   fetch: typeof fetch;
@@ -82,6 +145,25 @@ function strictQuickNodeUrl(value: string | undefined): string {
     )
   ) throw new TypeError("Shards QuickNode transport is not strictly bound");
   return parsed.href;
+}
+
+function strictAlchemyApiKey(value: string | undefined): string {
+  if (
+    typeof value !== "string"
+    || value.length < 16
+    || value.length > 512
+    || value !== value.trim()
+    || !value.startsWith("alcht_")
+    || !/^alcht_[A-Za-z0-9_-]+$/u.test(value)
+  ) throw new TypeError("Shards Alchemy access key is invalid");
+  return value;
+}
+
+function strictSha256(value: string | undefined, label: string): `sha256:${string}` {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as `sha256:${string}`;
 }
 
 function requestUrl(input: RequestInfo | URL): string {

--- a/lib/server/custom-launch/manual-router-shards-publish-transport-v1.ts
+++ b/lib/server/custom-launch/manual-router-shards-publish-transport-v1.ts
@@ -1,0 +1,179 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+
+export const SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1 =
+  "sha256:1d7c191dc3e16ba9967be76622b76269b6ac1673637212fab41594ff1665394a";
+export const SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1 =
+  "https://eth-mainnet.g.alchemy.com/v2";
+export const SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_ENV_V1 =
+  "PROGRAMMABLE_SHARDS_REISSUE_ALCHEMY_MAINNET_RPC_API_KEY";
+export const SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_ENV_V1 =
+  "PROGRAMMABLE_SHARDS_REISSUE_ALCHEMY_MAINNET_RPC_API_KEY_COMMITMENT";
+export const SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_V1 =
+  "sha256:5419a7a33826708ccae3c7e29aca5e6bab25e6bc5e52a14c22141c4d0cc7ec87";
+
+const QUICKNODE_MINIMUM_FETCH_GAP_MILLISECONDS_V1 = 1_000;
+const QUICKNODE_429_RETRY_DELAYS_MILLISECONDS_V1 = Object.freeze([
+  1_000,
+  2_000,
+] as const);
+
+type PublishTransportClockV1 = Readonly<{
+  nowMilliseconds(): number;
+  wait(milliseconds: number): Promise<void>;
+}>;
+
+export function createShardsManualRouterAlchemyBearerFetchV1(input: Readonly<{
+  fetch: typeof fetch;
+  apiKey: string | undefined;
+  apiKeyCommitment: string | undefined;
+}>): typeof fetch {
+  return createShardsManualRouterAlchemyBearerFetchForBindingV1({
+    ...input,
+    expectedApiKeyCommitment:
+      SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_V1,
+  });
+}
+
+export function createShardsManualRouterAlchemyBearerFetchForBindingV1(
+  input: Readonly<{
+    fetch: typeof fetch;
+    apiKey: string | undefined;
+    apiKeyCommitment: string | undefined;
+    expectedApiKeyCommitment: `sha256:${string}`;
+  }>,
+): typeof fetch {
+  const apiKey = strictAlchemyApiKey(input.apiKey);
+  const expected = strictSha256(
+    input.expectedApiKeyCommitment,
+    "expected Shards Alchemy access-key commitment",
+  );
+  const configured = strictSha256(
+    input.apiKeyCommitment,
+    "Shards Alchemy access-key commitment",
+  );
+  const observed = shardsManualRouterAlchemyApiKeyCommitmentV1(apiKey);
+  if (configured !== expected || observed !== expected) {
+    throw new TypeError("Shards Alchemy access-key commitment is invalid");
+  }
+  return (requestInput, requestInit) => {
+    if (requestUrl(requestInput) !== SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1) {
+      return input.fetch(requestInput, requestInit);
+    }
+    const request = new Request(requestInput, requestInit);
+    if (request.headers.has("authorization")) {
+      throw new TypeError("Shards Alchemy authorization is ambiguous");
+    }
+    const headers = new Headers(request.headers);
+    headers.set("authorization", `Bearer ${apiKey}`);
+    return input.fetch(new Request(request, { headers }));
+  };
+}
+
+export function shardsManualRouterAlchemyApiKeyCommitmentV1(
+  apiKey: string,
+): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(apiKey, "utf8").digest("hex")}`;
+}
+
+export function createShardsManualRouterPublishFetchV1(input: Readonly<{
+  fetch: typeof fetch;
+  quickNodeUrl: string | undefined;
+  clock?: PublishTransportClockV1;
+}>): typeof fetch {
+  const quickNodeUrl = strictQuickNodeUrl(input.quickNodeUrl);
+  const clock = input.clock ?? Object.freeze({
+    nowMilliseconds: () => Date.now(),
+    wait: async (milliseconds: number) => {
+      await new Promise<void>((resolveDelay) =>
+        setTimeout(resolveDelay, milliseconds));
+    },
+  });
+  let tail: Promise<void> = Promise.resolve();
+  let lastFetchStartMilliseconds = 0;
+
+  return (requestInput, requestInit) => {
+    if (requestUrl(requestInput) !== quickNodeUrl) {
+      return input.fetch(requestInput, requestInit);
+    }
+    const request = new Request(requestInput, requestInit);
+    const run = tail.then(async () => {
+      for (let attempt = 0; ; attempt += 1) {
+        const earliest = lastFetchStartMilliseconds
+          + QUICKNODE_MINIMUM_FETCH_GAP_MILLISECONDS_V1;
+        const gap = Math.max(0, earliest - clock.nowMilliseconds());
+        if (gap > 0) await clock.wait(gap);
+        lastFetchStartMilliseconds = clock.nowMilliseconds();
+        const response = await input.fetch(request.clone());
+        const retryDelay = response.status === 429
+          ? QUICKNODE_429_RETRY_DELAYS_MILLISECONDS_V1[attempt]
+          : undefined;
+        if (retryDelay === undefined) return response;
+        await clock.wait(retryDelay);
+      }
+    });
+    tail = run.then(() => undefined, () => undefined);
+    return run;
+  };
+}
+
+export function isExactShardsManualRouterPublishRequestV1(
+  verifiedRequest: Readonly<Record<string, unknown>>,
+): boolean {
+  const artifact = record(verifiedRequest.signedArtifact, "signed artifact");
+  const prepared = record(artifact.prepared, "prepared launch");
+  return prepared.compileInputHash
+    === SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1;
+}
+
+function strictQuickNodeUrl(value: string | undefined): string {
+  if (typeof value !== "string" || value.length === 0 || value !== value.trim()) {
+    throw new TypeError("Shards QuickNode transport is not configured");
+  }
+  const parsed = new URL(value);
+  if (
+    parsed.protocol !== "https:"
+    || parsed.username.length !== 0
+    || parsed.password.length !== 0
+    || parsed.port.length !== 0
+    || parsed.search.length !== 0
+    || parsed.hash.length !== 0
+    || parsed.pathname === "/"
+    || !/^(?:[a-z0-9-]+\.)+quiknode\.pro$/u.test(
+      parsed.hostname.toLowerCase(),
+    )
+  ) throw new TypeError("Shards QuickNode transport is not strictly bound");
+  return parsed.href;
+}
+
+function strictAlchemyApiKey(value: string | undefined): string {
+  if (
+    typeof value !== "string"
+    || value.length < 16
+    || value.length > 512
+    || value !== value.trim()
+    || !value.startsWith("alcht_")
+    || !/^alcht_[A-Za-z0-9_-]+$/u.test(value)
+  ) throw new TypeError("Shards Alchemy access key is invalid");
+  return value;
+}
+
+function strictSha256(value: string | undefined, label: string): `sha256:${string}` {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as `sha256:${string}`;
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (input instanceof Request) return input.url;
+  return new URL(input.toString()).href;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`verified Shards ${label} is invalid`);
+  }
+  return value as Record<string, unknown>;
+}

--- a/lib/server/custom-launch/manual-router-shards-publish-transport-v1.ts
+++ b/lib/server/custom-launch/manual-router-shards-publish-transport-v1.ts
@@ -1,0 +1,97 @@
+import "server-only";
+
+export const SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1 =
+  "sha256:1d7c191dc3e16ba9967be76622b76269b6ac1673637212fab41594ff1665394a";
+
+const QUICKNODE_MINIMUM_FETCH_GAP_MILLISECONDS_V1 = 1_000;
+const QUICKNODE_429_RETRY_DELAYS_MILLISECONDS_V1 = Object.freeze([
+  1_000,
+  2_000,
+] as const);
+
+type PublishTransportClockV1 = Readonly<{
+  nowMilliseconds(): number;
+  wait(milliseconds: number): Promise<void>;
+}>;
+
+export function createShardsManualRouterPublishFetchV1(input: Readonly<{
+  fetch: typeof fetch;
+  quickNodeUrl: string | undefined;
+  clock?: PublishTransportClockV1;
+}>): typeof fetch {
+  const quickNodeUrl = strictQuickNodeUrl(input.quickNodeUrl);
+  const clock = input.clock ?? Object.freeze({
+    nowMilliseconds: () => Date.now(),
+    wait: async (milliseconds: number) => {
+      await new Promise<void>((resolveDelay) =>
+        setTimeout(resolveDelay, milliseconds));
+    },
+  });
+  let tail: Promise<void> = Promise.resolve();
+  let lastFetchStartMilliseconds = 0;
+
+  return (requestInput, requestInit) => {
+    if (requestUrl(requestInput) !== quickNodeUrl) {
+      return input.fetch(requestInput, requestInit);
+    }
+    const request = new Request(requestInput, requestInit);
+    const run = tail.then(async () => {
+      for (let attempt = 0; ; attempt += 1) {
+        const earliest = lastFetchStartMilliseconds
+          + QUICKNODE_MINIMUM_FETCH_GAP_MILLISECONDS_V1;
+        const gap = Math.max(0, earliest - clock.nowMilliseconds());
+        if (gap > 0) await clock.wait(gap);
+        lastFetchStartMilliseconds = clock.nowMilliseconds();
+        const response = await input.fetch(request.clone());
+        const retryDelay = response.status === 429
+          ? QUICKNODE_429_RETRY_DELAYS_MILLISECONDS_V1[attempt]
+          : undefined;
+        if (retryDelay === undefined) return response;
+        await clock.wait(retryDelay);
+      }
+    });
+    tail = run.then(() => undefined, () => undefined);
+    return run;
+  };
+}
+
+export function isExactShardsManualRouterPublishRequestV1(
+  verifiedRequest: Readonly<Record<string, unknown>>,
+): boolean {
+  const artifact = record(verifiedRequest.signedArtifact, "signed artifact");
+  const prepared = record(artifact.prepared, "prepared launch");
+  return prepared.compileInputHash
+    === SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1;
+}
+
+function strictQuickNodeUrl(value: string | undefined): string {
+  if (typeof value !== "string" || value.length === 0 || value !== value.trim()) {
+    throw new TypeError("Shards QuickNode transport is not configured");
+  }
+  const parsed = new URL(value);
+  if (
+    parsed.protocol !== "https:"
+    || parsed.username.length !== 0
+    || parsed.password.length !== 0
+    || parsed.port.length !== 0
+    || parsed.search.length !== 0
+    || parsed.hash.length !== 0
+    || parsed.pathname === "/"
+    || !/^(?:[a-z0-9-]+\.)+quiknode\.pro$/u.test(
+      parsed.hostname.toLowerCase(),
+    )
+  ) throw new TypeError("Shards QuickNode transport is not strictly bound");
+  return parsed.href;
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (input instanceof Request) return input.url;
+  return new URL(input.toString()).href;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`verified Shards ${label} is invalid`);
+  }
+  return value as Record<string, unknown>;
+}

--- a/lib/server/custom-launch/manual-router-shards-v1-compat-v1.ts
+++ b/lib/server/custom-launch/manual-router-shards-v1-compat-v1.ts
@@ -1,0 +1,252 @@
+import "server-only";
+
+import type {
+  ManualRouterCompleteSignedArtifactViewAnyV2,
+} from "@/lib/server/custom-launch/manual-router-service-v1";
+import type {
+  ManualRouterApplicantPointerAnyV2,
+} from "@/lib/server/custom-launch/manual-router-state-v2";
+
+type UnknownRecord = Readonly<Record<string, unknown>>;
+
+export const MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1 = Object.freeze({
+  approvedGitHubUserId: "155705664",
+  approvedLaunchWallet: "0xceebb3a6543cebeb2ed66963897a0abea52a50cc",
+  repositoryId: "1320085947",
+  headRepositoryId: "1329074393",
+  sourceRepositoryId: "1329073878",
+  sourceRepositoryUrl: "https://github.com/jesse-stahl/shards-v1",
+  sourceCommitSha: "91b38f3de64d96cac7e29f127c004f128fc1da59",
+  sourceTreeSha: "92d6def8609e829487adea66c13901734e43c8c7",
+  applicantGitHubLogin: "jesse-stahl",
+  pullRequestNumber: 6,
+  subjectHash:
+    "sha256:c818b79c99277b878b2e0be70f1479fa8a864f111fbe0579bf9e2b8cf95524ee",
+  headSha: "1aa5017154d227e639cfe6256f39bf3916352124",
+  treeSha: "48149d436bf222c440980e1fc31a71899b833af7",
+  approvalBindingHash:
+    "sha256:a036d02141ae96c178691ceb9aac9390260e4caf71acb37fe427c0803bdc0b03",
+  compileInputHash:
+    "sha256:1d7c191dc3e16ba9967be76622b76269b6ac1673637212fab41594ff1665394a",
+  planHash:
+    "sha256:fe2a675dda7460d93d5c5cce562fdbf98b13b362fef79918ad8122539d3db864",
+  applicationId: "shards-v1",
+  applicationManifestSha256:
+    "sha256:e069926d380e56bee001dd7cfeda591db56164b1acf7478b478dd62a6e119ec2",
+  sourceRevisionBindingHash:
+    "sha256:01e34d7212326bf2e7ac5e446b127a5f994c335dc0126501fe73954cffe2f008",
+  compilerProfileBindingHash:
+    "sha256:c47c175cf867633adae778c507264b79a6c366f0a425eadba13e625c6a0977f7",
+  compilerEvidenceDigest:
+    "sha256:f128b69f184a5f79c79badc7b59669548d9bd11d63253088d126377ea2aed98a",
+  routeNonce:
+    "0xfcd4ff3393a669e5bb9f21a97f9adaad624bcfad67c9ef3763ec5e4488d6df9f",
+  rootPointerHash:
+    "sha256:40d807312362e9edec84a26581620e809d9f16e6d62ac1b2a87bd0138b2fb30c",
+  rootSignedArtifactHash:
+    "sha256:93d2e1fe8cd5d20a043ba93dd0f5e45ccd3b91abd8e335bd511e39aa287e3aa5",
+  approvalRevision: Object.freeze({
+    schemaVersion: "programmable.router-approval-revision.v2",
+    approvalId:
+      "0xbf5df8e728d6a7ab6fa513ccc1fef8d5ee8ffabd3bbc24085a7867ee66651cfc",
+    approvalVersion: "2",
+    authorizedPrincipalHash:
+      "0x8691c76e94073ea9f97cd02d03a893b81d5b1af841da909c29206dae82aecc5e",
+    configurationHash:
+      "0x4ff6f93e65be0388696bdc1d8f5c1729111b7c2d581e337693cc3b7466637c31",
+    evidenceDigest:
+      "0x83af1e346c417c28a6f9b2e72ded1421d605795da40de28557c5ff2dfaeb2283",
+    headSha: "0x1aa5017154d227e639cfe6256f39bf3916352124",
+    policyHash:
+      "0xa70e57eba9d86a3ec068d36ddd023b5a4021d3ee0a158ee3239ca26a9edc28ef",
+    repositoryId: "1320085947",
+    reviewArtifactHash:
+      "0x6ee28349e1353e714b33eb6d2f9eefd75f1e98880a27d7b2f5f8094dac6d14c5",
+    treeSha: "0x48149d436bf222c440980e1fc31a71899b833af7",
+  }),
+} as const);
+
+export function manualRouterClaimsShardsV1ArtifactV1(
+  artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
+): boolean {
+  if (artifact.schemaVersion
+    !== "programmable.manual-router-complete-signed-artifact.v1") return false;
+  const preparation = record(artifact.preparationArtifact);
+  const subject = record(preparation?.subject);
+  const approvalClaim = record(preparation?.approvalClaim);
+  const reviewed = record(preparation?.reviewedCompileInput);
+  const compilation = record(preparation?.compilation);
+  const signatureRequest = record(preparation?.signatureRequest);
+  const verifiedApproval = record(signatureRequest?.approval);
+  const exact = MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1;
+  return subject?.approvedGitHubUserId === exact.approvedGitHubUserId
+    || subject?.subjectHash === exact.subjectHash
+    || reviewed?.applicationId === exact.applicationId
+    || reviewed?.compileInputHash === exact.compileInputHash
+    || reviewed?.sourceRevisionBindingHash === exact.sourceRevisionBindingHash
+    || approvalClaim?.compileInputHash === exact.compileInputHash
+    || compilation?.compileInputHash === exact.compileInputHash
+    || verifiedApproval?.sourceCommitSha === exact.sourceCommitSha;
+}
+
+export function manualRouterIsExactShardsV1ArtifactV1(
+  artifact: ManualRouterCompleteSignedArtifactViewAnyV2,
+): boolean {
+  if (artifact.schemaVersion
+    !== "programmable.manual-router-complete-signed-artifact.v1") return false;
+  const preparation = record(artifact.preparationArtifact);
+  const subject = record(preparation?.subject);
+  const approvalClaim = record(preparation?.approvalClaim);
+  const reviewed = record(preparation?.reviewedCompileInput);
+  const compilation = record(preparation?.compilation);
+  const descriptor = record(artifact.descriptor);
+  const signatureRequest = record(preparation?.signatureRequest);
+  const verifiedApproval = record(signatureRequest?.approval);
+  const verifiedClaim = record(verifiedApproval?.claim);
+  const submissionMetadata = record(reviewed?.submissionMetadata);
+  const submissionSource = record(submissionMetadata?.source);
+  const submissionApplicant = record(submissionMetadata?.applicant);
+  const exact = MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1;
+  return subject?.schemaVersion
+      === "programmable.manual-router-applicant-subject.v1"
+    && preparation?.schemaVersion
+      === "programmable.manual-router-authority-preparation-artifact.v1"
+    && subject.repositoryId === exact.repositoryId
+    && subject.pullRequestNumber === exact.pullRequestNumber
+    && subject.approvedGitHubUserId === exact.approvedGitHubUserId
+    && normalizedAddress(subject.approvedLaunchWallet)
+      === exact.approvedLaunchWallet
+    && subject.subjectHash === exact.subjectHash
+    && exactApprovalClaim(approvalClaim)
+    && exactApprovalClaim(verifiedClaim)
+    && exactApprovalRevision(record(approvalClaim?.approvalRevision))
+    && exactApprovalRevision(record(verifiedClaim?.approvalRevision))
+    && approvalClaim?.schemaVersion
+      === "programmable.github-router-launch-approval-claim.v3"
+    && reviewed?.applicationId === exact.applicationId
+    && reviewed.schemaVersion
+      === "programmable.stored-router-custom-graph-reviewed-compile-input.v1"
+    && reviewed.applicationManifestSha256
+      === exact.applicationManifestSha256
+    && reviewed.sourceRevisionBindingHash
+      === exact.sourceRevisionBindingHash
+    && reviewed.compilerProfileBindingHash
+      === exact.compilerProfileBindingHash
+    && reviewed.compileInputHash === exact.compileInputHash
+    && reviewed.compilerEvidenceDigest === exact.compilerEvidenceDigest
+    && submissionSource?.repositoryId === exact.sourceRepositoryId
+    && submissionSource.repositoryUrl === exact.sourceRepositoryUrl
+    && submissionSource.commitSha === exact.sourceCommitSha
+    && submissionSource.treeSha === exact.sourceTreeSha
+    && submissionApplicant?.githubLogin === exact.applicantGitHubLogin
+    && normalizedAddress(submissionApplicant.launchWallet)
+      === exact.approvedLaunchWallet
+    && compilation?.compileInputHash === exact.compileInputHash
+    && compilation.schemaVersion
+      === "programmable.router-custom-graph-compilation.v1"
+    && compilation.planHash === exact.planHash
+    && compilation.production === true
+    && descriptor?.schemaVersion
+      === "programmable.manual-router-signed-artifact-descriptor.v1"
+    && descriptor.approvalBindingHash === exact.approvalBindingHash
+    && descriptor.subjectHash === exact.subjectHash
+    && descriptor.preparationArtifactHash
+      === preparation?.preparationArtifactHash
+    && descriptor.signatureRequestHash === signatureRequest?.requestHash
+    && descriptor.routeNonce === exact.routeNonce
+    && signatureRequest?.schemaVersion
+      === "programmable.manual-github-router-signature-request.v1"
+    && signatureRequest.compileInputHash === exact.compileInputHash
+    && signatureRequest.planHash === exact.planHash
+    && verifiedApproval?.schemaVersion
+      === "programmable.verified-github-router-launch-approval.v6"
+    && verifiedApproval.approvalBindingHash === exact.approvalBindingHash
+    && verifiedApproval.pullRequestAuthorGitHubLogin
+      === exact.applicantGitHubLogin
+    && verifiedApproval.pullRequestAuthorGitHubUserId
+      === exact.approvedGitHubUserId
+    && verifiedApproval.pullRequestHeadRepositoryUrl
+      === "https://github.com/jesse-stahl/hookbuilder"
+    && verifiedApproval.pullRequestState === "merged"
+    && verifiedApproval.sourceRepositoryId === exact.sourceRepositoryId
+    && verifiedApproval.sourceRepositoryUrl === exact.sourceRepositoryUrl
+    && verifiedApproval.sourceCommitSha === exact.sourceCommitSha
+    && verifiedApproval.sourceTreeSha === exact.sourceTreeSha;
+}
+
+export function manualRouterClaimsShardsV1PointerV1(
+  pointer: ManualRouterApplicantPointerAnyV2,
+): boolean {
+  if (pointer.schemaVersion
+    !== "programmable.manual-router-applicant-pointer.v1") return false;
+  const exact = MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1;
+  return pointer.subject.approvedGitHubUserId === exact.approvedGitHubUserId
+    || pointer.subject.subjectHash === exact.subjectHash
+    || pointer.approvalBindingHash === exact.approvalBindingHash
+    || pointer.routeNonce === exact.routeNonce
+    || (
+      pointer.headSha === exact.headSha
+      && pointer.treeSha === exact.treeSha
+    );
+}
+
+export function manualRouterIsExactShardsV1PointerV1(
+  pointer: ManualRouterApplicantPointerAnyV2,
+): boolean {
+  if (pointer.schemaVersion
+    !== "programmable.manual-router-applicant-pointer.v1") return false;
+  const exact = MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1;
+  return pointer.subject.schemaVersion
+      === "programmable.manual-router-applicant-subject.v1"
+    && pointer.subject.repositoryId === exact.repositoryId
+    && pointer.subject.pullRequestNumber === exact.pullRequestNumber
+    && pointer.subject.approvedGitHubUserId === exact.approvedGitHubUserId
+    && normalizedAddress(pointer.subject.approvedLaunchWallet)
+      === exact.approvedLaunchWallet
+    && pointer.subject.subjectHash === exact.subjectHash
+    && pointer.approvalBindingHash === exact.approvalBindingHash
+    && pointer.headSha === exact.headSha
+    && pointer.treeSha === exact.treeSha
+    && pointer.routeNonce === exact.routeNonce;
+}
+
+function record(value: unknown): UnknownRecord | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as UnknownRecord
+    : null;
+}
+
+function normalizedAddress(value: unknown): string | null {
+  return typeof value === "string" && /^0x[0-9a-fA-F]{40}$/u.test(value)
+    ? value.toLowerCase()
+    : null;
+}
+
+function exactApprovalClaim(value: UnknownRecord | null): boolean {
+  const exact = MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1;
+  return value?.repositoryId === exact.repositoryId
+    && value.headRepositoryId === exact.headRepositoryId
+    && value.pullRequestNumber === exact.pullRequestNumber
+    && value.approvedGitHubUserId === exact.approvedGitHubUserId
+    && normalizedAddress(value.approvedLaunchWallet)
+      === exact.approvedLaunchWallet
+    && value.headSha === exact.headSha
+    && value.treeSha === exact.treeSha
+    && value.compileInputHash === exact.compileInputHash
+    && value.planHash === exact.planHash;
+}
+
+function exactApprovalRevision(value: UnknownRecord | null): boolean {
+  const expected = MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1.approvalRevision;
+  return value?.schemaVersion === expected.schemaVersion
+    && value.approvalId === expected.approvalId
+    && value.approvalVersion === expected.approvalVersion
+    && value.authorizedPrincipalHash === expected.authorizedPrincipalHash
+    && value.configurationHash === expected.configurationHash
+    && value.evidenceDigest === expected.evidenceDigest
+    && value.headSha === expected.headSha
+    && value.policyHash === expected.policyHash
+    && value.repositoryId === expected.repositoryId
+    && value.reviewArtifactHash === expected.reviewArtifactHash
+    && value.treeSha === expected.treeSha;
+}

--- a/lib/server/custom-launch/manual-router-store-v1.ts
+++ b/lib/server/custom-launch/manual-router-store-v1.ts
@@ -3,6 +3,7 @@ import "server-only";
 import {
   BlobPreconditionFailedError,
   get,
+  head,
   list as listBlobs,
   put,
 } from "@vercel/blob";
@@ -29,6 +30,7 @@ export interface ManualRouterPrivateBlobBoundaryV1 {
     etag: string | null;
     body: string | null;
   }> | null>;
+  head?(path: string): Promise<Readonly<{ etag: string }>>;
   put(
     path: string,
     body: string,
@@ -82,6 +84,27 @@ export class ManualRouterPrivateBlobStoreV1 {
       serialized: result.body,
       etag: result.etag,
     });
+  }
+
+  async readForCompareAndSwap(
+    path: string,
+  ): Promise<ManualRouterPrivateBlobReadV1> {
+    const checkedPath = manualRouterBlobPath(path);
+    if (typeof this.boundary.head !== "function") {
+      throw new TypeError("manual Router Blob CAS metadata is unavailable");
+    }
+    const before = await this.boundary.head(checkedPath);
+    const read = await this.read(checkedPath);
+    const after = await this.boundary.head(checkedPath);
+    if (
+      read === null
+      || before.etag !== after.etag
+      || typeof after.etag !== "string"
+      || after.etag.length < 1
+      || after.etag.length > 1_024
+      || /[\r\n\u0000]/u.test(after.etag)
+    ) throw new ManualRouterBlobCasConflictV1(checkedPath);
+    return Object.freeze({ ...read, etag: after.etag });
   }
 
   async putImmutable(
@@ -191,6 +214,10 @@ ManualRouterPrivateBlobStoreV1 {
           ? null
           : await new Response(result.stream).text(),
       });
+    },
+    async head(path: string) {
+      const result = await head(path, { token });
+      return Object.freeze({ etag: result.etag });
     },
     async put(
       path: string,

--- a/lib/server/custom-launch/manual-router-transition-v1.ts
+++ b/lib/server/custom-launch/manual-router-transition-v1.ts
@@ -49,6 +49,7 @@ export async function commitManualRouterApplicantHeadTransitionV1(
     nextIndex: ManualRouterApplicantIndexAnyV2;
     immutableWrites: readonly ManualRouterImmutableWriteV1[];
     acceptConcurrentExactTarget: boolean;
+    refreshHeadAfterImmutableWrites?: () => Promise<ManualRouterApplicantHeadV1>;
   }>,
 ): Promise<ManualRouterHeadTransitionResultV1> {
   const pointer = assertManualRouterApplicantPointerAnyV2(input.nextPointer);
@@ -79,8 +80,14 @@ export async function commitManualRouterApplicantHeadTransitionV1(
       concurrentConvergence: false,
     });
   }
+  const commitHead = input.refreshHeadAfterImmutableWrites === undefined
+    ? input.head
+    : assertSemanticallyIdenticalHead(
+        input.head,
+        await input.refreshHeadAfterImmutableWrites(),
+      );
   try {
-    await input.store.compareAndSwap(input.head.path, input.head.etag, index);
+    await input.store.compareAndSwap(commitHead.path, commitHead.etag, index);
     return Object.freeze({
       index,
       pointer,
@@ -111,6 +118,19 @@ export async function commitManualRouterApplicantHeadTransitionV1(
       concurrentConvergence: true,
     });
   }
+}
+
+function assertSemanticallyIdenticalHead(
+  verified: ManualRouterApplicantHeadV1,
+  refreshed: ManualRouterApplicantHeadV1,
+): ManualRouterApplicantHeadV1 {
+  if (
+    refreshed.path !== verified.path
+    || canonicalizeJson(refreshed.index) !== canonicalizeJson(verified.index)
+    || canonicalizeJson(refreshed.pointers)
+      !== canonicalizeJson(verified.pointers)
+  ) throw new ManualRouterBlobCasConflictV1(verified.path);
+  return refreshed;
 }
 
 function replaceCurrentPointer(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -67,7 +67,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
         Object.freeze({
           path: "lib/server/custom-launch/manual-router-finality-v1.ts",
-          sha256: "be7a0fe1c482a734b0c5605c88bf82e7eb547cd3d57ada7695634fdd23b26ed8",
+          sha256: "f653ee2ea386740d4536445a86397ef527aa828d6e7f91f3741082d1b1f9833d",
         }),
         Object.freeze({
           path: "lib/server/custom-launch/manual-router-production-v1.ts",
@@ -75,11 +75,11 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
         Object.freeze({
           path: "lib/server/custom-launch/manual-router-service-v1.ts",
-          sha256: "36ba5a141b30a204d0e2493e8d382f366b070eef4547fe69c12935e63d619fcd",
+          sha256: "97a99851bc8eb0c60ad43d6548931da6faafb4f17f7857cdd31fd6767fe64412",
         }),
         Object.freeze({
           path: "lib/server/custom-launch/manual-router-store-v1.ts",
-          sha256: "5462e4413798e8fa2804c4727ccd6c9355aa9860eeb0a345ad167b01f0eb4162",
+          sha256: "24a464017173af3bda97d6fc7d143dec27453a25315424a8348cbca2ad8acd66",
         }),
       ]),
       policy: Object.freeze({

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -11,7 +11,9 @@ vi.mock("server-only", () => ({}));
 import { LaunchModelPicker } from "../components/launch-entry";
 import {
   acquireManualRouterWebsiteSessionV1,
+  applicantIdentityRequirementForLoginV1,
   manualRouterApplicantDiscoveryReady,
+  runManualRouterRequestWithFreshSessionV1,
 } from "../components/manual-applicant-launch";
 import {
   MANUAL_ROUTER_PRODUCTION_BINDING_V1,
@@ -104,6 +106,20 @@ const WALLET = "0x1111111111111111111111111111111111111111" as const;
 const OTHER_WALLET = "0x2222222222222222222222222222222222222222" as const;
 
 describe("manual Applicant Privy hydration", () => {
+  it("binds refreshed sessions to the exact Shards and Hookemon identities", () => {
+    expect(applicantIdentityRequirementForLoginV1("jesse-stahl")).toEqual({
+      githubUserId: "155705664",
+      githubLogin: "jesse-stahl",
+      launchWallet: "0xceebb3a6543cebeb2ed66963897a0abea52a50cc",
+    });
+    expect(applicantIdentityRequirementForLoginV1("hookemonv4")).toEqual({
+      githubUserId: "312745360",
+      githubLogin: "hookemonv4",
+      launchWallet: "0x5E9a7A24DCCC81cddd10b8a555300E227533c89f",
+    });
+    expect(applicantIdentityRequirementForLoginV1("other-applicant"))
+      .toBeUndefined();
+  });
   it("does not start discovery before Privy is ready and starts once on the ready transition", () => {
     const listAndResolve = vi.fn();
     const runDiscovery = (authReady: boolean) => {
@@ -131,38 +147,81 @@ describe("manual Applicant Privy hydration", () => {
     expect(component).toContain("authReady,\n    authenticated,\n    githubConnected,\n    loadDirectory");
   });
 
-  it("reacquires access once after identity hydration and never retries a request", async () => {
-    const events: string[] = [];
-    let accessCall = 0;
+  it("requires one refreshed Applicant session and never retries a request", async () => {
+    const refreshApplicantSession = vi.fn(async () => ({
+      accessToken: "access-token",
+      identityToken: "identity-token",
+      privyUserId: "did:privy:approved",
+      githubUserId: "155705664",
+      githubLogin: "jesse-stahl",
+      launchWallet: `0x${"a".repeat(40)}` as const,
+    }));
     const session = await acquireManualRouterWebsiteSessionV1({
-      getAccessToken: async () => {
-        accessCall += 1;
-        events.push(`access-${accessCall}`);
-        return accessCall === 1 ? null : "access-token";
-      },
-      getIdentityToken: async () => {
-        events.push("identity");
-        return "identity-token";
-      },
+      refreshApplicantSession,
     });
 
     expect(session).toEqual({
       accessToken: "access-token",
       identityToken: "identity-token",
     });
-    expect(events).toEqual(["access-1", "identity", "access-2"]);
+    expect(refreshApplicantSession).toHaveBeenCalledTimes(1);
+    const component = readFileSync(
+      join(process.cwd(), "components/manual-applicant-launch.tsx"),
+      "utf8",
+    );
+    expect(component).not.toContain("getAccessToken");
+    expect(component).not.toContain("getIdentityToken");
   });
 
   it("keeps unresolved dual-token hydration closed before any request", async () => {
     const request = vi.fn();
     await expect(acquireManualRouterWebsiteSessionV1({
-      getAccessToken: async () => null,
-      getIdentityToken: async () => null,
+      refreshApplicantSession: async () => null,
     })).rejects.toMatchObject({
       status: 401,
       code: "applicant_authentication_required",
     });
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("refreshes independently before list and resolve without replaying either request", async () => {
+    const events: string[] = [];
+    let refreshCount = 0;
+    const getSession = vi.fn(async () => {
+      refreshCount += 1;
+      events.push(`refresh-${refreshCount}`);
+      return {
+        accessToken: `access-${refreshCount}`,
+        identityToken: `identity-${refreshCount}`,
+      };
+    });
+
+    await runManualRouterRequestWithFreshSessionV1(getSession, async () => {
+      events.push("list");
+    });
+    await runManualRouterRequestWithFreshSessionV1(getSession, async () => {
+      events.push("resolve");
+    });
+
+    expect(events).toEqual(["refresh-1", "list", "refresh-2", "resolve"]);
+    expect(getSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not invoke resolve when its dedicated refresh fails", async () => {
+    const getSession = vi.fn()
+      .mockResolvedValueOnce({
+        accessToken: "list-access",
+        identityToken: "list-identity",
+      })
+      .mockRejectedValueOnce(new Error("refresh failed"));
+    const list = vi.fn(async () => undefined);
+    const resolve = vi.fn(async () => undefined);
+
+    await runManualRouterRequestWithFreshSessionV1(getSession, list);
+    await expect(runManualRouterRequestWithFreshSessionV1(getSession, resolve))
+      .rejects.toThrow("refresh failed");
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(resolve).not.toHaveBeenCalled();
   });
 });
 const SUBJECT = `sha256:${"11".repeat(32)}` as const;

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -10,6 +10,10 @@ vi.mock("server-only", () => ({}));
 
 import { LaunchModelPicker } from "../components/launch-entry";
 import {
+  acquireManualRouterWebsiteSessionV1,
+  manualRouterApplicantDiscoveryReady,
+} from "../components/manual-applicant-launch";
+import {
   MANUAL_ROUTER_PRODUCTION_BINDING_V1,
   assertManualRouterProductionBindingV1,
 } from "../lib/custom-launch/manual-router-bindings-v1";
@@ -39,11 +43,14 @@ import {
   type ManualRouterResolveResponseV2,
 } from "../lib/custom-launch/manual-router-contract-v2";
 import {
+  MANUAL_ROUTER_EXACT_SHARDS_V1_BROWSER_BINDING,
   manualRouterBlocksNewSendV1,
   manualRouterCanClearUncertainNoSendV1,
   manualRouterDirectoryForApplicantV2,
   manualRouterFreshReadyMatchesCachedV1,
   manualRouterFreshReadyMatchesCachedV2,
+  manualRouterIsExactShardsV1ApplicantDirectory,
+  manualRouterResolveForApplicantV2,
   manualRouterRouteFactsV2,
   manualRouterTransactionContextV1,
   parseManualRouterPersistedAttemptStorageV1,
@@ -95,6 +102,69 @@ import { rpcProviderCommitment } from
 
 const WALLET = "0x1111111111111111111111111111111111111111" as const;
 const OTHER_WALLET = "0x2222222222222222222222222222222222222222" as const;
+
+describe("manual Applicant Privy hydration", () => {
+  it("does not start discovery before Privy is ready and starts once on the ready transition", () => {
+    const listAndResolve = vi.fn();
+    const runDiscovery = (authReady: boolean) => {
+      if (manualRouterApplicantDiscoveryReady({
+        authReady,
+        authenticated: true,
+        githubConnected: true,
+        walletConnected: true,
+        routeDiscoveryAllowed: true,
+      })) listAndResolve();
+    };
+
+    runDiscovery(false);
+    expect(listAndResolve).not.toHaveBeenCalled();
+    runDiscovery(true);
+    expect(listAndResolve).toHaveBeenCalledTimes(1);
+
+    const component = readFileSync(
+      join(process.cwd(), "components/manual-applicant-launch.tsx"),
+      "utf8",
+    );
+    expect(component.match(/manualRouterApplicantDiscoveryReady\(\{/gu))
+      .toHaveLength(2);
+    expect(component).toContain("NESTED_FACTORY_ACTIVATION === null\n      || !authReady");
+    expect(component).toContain("authReady,\n    authenticated,\n    githubConnected,\n    loadDirectory");
+  });
+
+  it("reacquires access once after identity hydration and never retries a request", async () => {
+    const events: string[] = [];
+    let accessCall = 0;
+    const session = await acquireManualRouterWebsiteSessionV1({
+      getAccessToken: async () => {
+        accessCall += 1;
+        events.push(`access-${accessCall}`);
+        return accessCall === 1 ? null : "access-token";
+      },
+      getIdentityToken: async () => {
+        events.push("identity");
+        return "identity-token";
+      },
+    });
+
+    expect(session).toEqual({
+      accessToken: "access-token",
+      identityToken: "identity-token",
+    });
+    expect(events).toEqual(["access-1", "identity", "access-2"]);
+  });
+
+  it("keeps unresolved dual-token hydration closed before any request", async () => {
+    const request = vi.fn();
+    await expect(acquireManualRouterWebsiteSessionV1({
+      getAccessToken: async () => null,
+      getIdentityToken: async () => null,
+    })).rejects.toMatchObject({
+      status: 401,
+      code: "applicant_authentication_required",
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+});
 const SUBJECT = `sha256:${"11".repeat(32)}` as const;
 const POINTER = `sha256:${"22".repeat(32)}` as const;
 const APPROVAL = `sha256:${"33".repeat(32)}` as const;
@@ -746,7 +816,7 @@ describe("inactive Shards nested-factory Router V2 browser contract", () => {
     }
   });
 
-  it("never substitutes a legacy pointer into the accepted Jesse route", () => {
+  it("admits only the exact Shards V1 directory or the exact V2 route", () => {
     const legacy = {
       schemaVersion: "programmable.manual-router-applicant-list-response.v1",
       authenticatedGitHubUserId: "123456789",
@@ -773,7 +843,89 @@ describe("inactive Shards nested-factory Router V2 browser contract", () => {
     expect(() => manualRouterDirectoryForApplicantV2({
       directory: legacy,
       requireExactShardsRoute: true,
-    })).toThrow("exact Shards Router V2 submission is unavailable");
+    })).toThrow("exact Shards Router submission is unavailable");
+
+    const binding = MANUAL_ROUTER_EXACT_SHARDS_V1_BROWSER_BINDING;
+    const exactV1 = {
+      schemaVersion: "programmable.manual-router-applicant-list-response.v1",
+      authenticatedGitHubUserId: binding.authenticatedGitHubUserId,
+      linkedLaunchWallet: binding.linkedLaunchWallet,
+      submissions: [{
+        subjectHash: binding.subjectHash,
+        pointerHash: POINTER,
+        pullRequestNumber: binding.pullRequestNumber,
+        headSha: binding.headSha,
+        treeSha: binding.treeSha,
+        approvalBindingHash: binding.approvalBindingHash,
+        routeNonce: binding.routeNonce,
+        status: "ready" as const,
+        deadline: "1786387607",
+        submittedTransactionHash: null,
+        failedTransactionEvidenceHash: null,
+      }],
+      applicantIndexHash: APPROVAL,
+    } satisfies ManualRouterApplicantListResponseV1;
+    expect(manualRouterIsExactShardsV1ApplicantDirectory(exactV1)).toBe(true);
+    expect(manualRouterDirectoryForApplicantV2({
+      directory: exactV1,
+      requireExactShardsRoute: true,
+    })).toBe(exactV1);
+
+    const exactResolved = {
+      schemaVersion: "programmable.manual-router-applicant-resolve-response.v1",
+      subjectHash: binding.subjectHash,
+      pointerHash: POINTER,
+      approvalBindingHash: binding.approvalBindingHash,
+      routeNonce: binding.routeNonce,
+      status: "finalized" as const,
+      transactionHash: LAUNCH_ID,
+      proofHash: APPROVAL,
+    } satisfies ManualRouterResolveResponseV1;
+    expect(manualRouterResolveForApplicantV2({
+      directory: exactV1,
+      resolved: exactResolved,
+      requireExactShardsRoute: true,
+    })).toBe(exactResolved);
+    for (const nearMiss of [
+      { ...exactV1, authenticatedGitHubUserId: "155705665" },
+      { ...exactV1, linkedLaunchWallet: WALLET },
+      { ...exactV1, submissions: [] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], subjectHash: SUBJECT,
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], pullRequestNumber: 7,
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], headSha: "b".repeat(40),
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], treeSha: "c".repeat(40),
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], approvalBindingHash: APPROVAL,
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], routeNonce: ROUTE_NONCE,
+      }] },
+    ] satisfies ManualRouterApplicantListResponseV1[]) {
+      expect(manualRouterIsExactShardsV1ApplicantDirectory(nearMiss)).toBe(false);
+      expect(() => manualRouterDirectoryForApplicantV2({
+        directory: nearMiss,
+        requireExactShardsRoute: true,
+      })).toThrow("exact Shards Router submission is unavailable");
+    }
+    for (const resolvedNearMiss of [
+      { ...exactResolved, pointerHash: `sha256:${"23".repeat(32)}` as const },
+      { ...exactResolved, approvalBindingHash: APPROVAL },
+      { ...exactResolved, routeNonce: ROUTE_NONCE },
+    ] satisfies ManualRouterResolveResponseV1[]) {
+      expect(() => manualRouterResolveForApplicantV2({
+        directory: exactV1,
+        resolved: resolvedNearMiss,
+        requireExactShardsRoute: true,
+      })).toThrow("exact Shards Router V1 resolution is unavailable");
+    }
 
     const mixed = {
       schemaVersion: "programmable.manual-router-applicant-list-response.v2",
@@ -1065,8 +1217,11 @@ describe("inactive Shards nested-factory Router V2 browser contract", () => {
       "requireExactShardsRoute: exactShardsApplicant",
     );
     expect(component).toContain(
-      "disabled={!githubConnected || !routeAccepted}",
+      "disabled={!githubConnected || !routeDiscoveryAllowed}",
     );
+    expect(component).toContain("manualRouterResolveForApplicantV2");
+    expect(component).toContain("exactShardsV1Compatibility");
+    expect(component).toContain("...(routeAcceptanceRequired ? [{");
     expect(component).toContain("The exact Shards route is not available yet");
     expect(component).toContain("isNestedFactorySubmissionV2(chosenSubmission)");
     expect(component).toContain("Reviewed deployment order");

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -39,11 +39,14 @@ import {
   type ManualRouterResolveResponseV2,
 } from "../lib/custom-launch/manual-router-contract-v2";
 import {
+  MANUAL_ROUTER_EXACT_SHARDS_V1_BROWSER_BINDING,
   manualRouterBlocksNewSendV1,
   manualRouterCanClearUncertainNoSendV1,
   manualRouterDirectoryForApplicantV2,
   manualRouterFreshReadyMatchesCachedV1,
   manualRouterFreshReadyMatchesCachedV2,
+  manualRouterIsExactShardsV1ApplicantDirectory,
+  manualRouterResolveForApplicantV2,
   manualRouterRouteFactsV2,
   manualRouterTransactionContextV1,
   parseManualRouterPersistedAttemptStorageV1,
@@ -746,7 +749,7 @@ describe("inactive Shards nested-factory Router V2 browser contract", () => {
     }
   });
 
-  it("never substitutes a legacy pointer into the accepted Jesse route", () => {
+  it("admits only the exact Shards V1 directory or the exact V2 route", () => {
     const legacy = {
       schemaVersion: "programmable.manual-router-applicant-list-response.v1",
       authenticatedGitHubUserId: "123456789",
@@ -773,7 +776,89 @@ describe("inactive Shards nested-factory Router V2 browser contract", () => {
     expect(() => manualRouterDirectoryForApplicantV2({
       directory: legacy,
       requireExactShardsRoute: true,
-    })).toThrow("exact Shards Router V2 submission is unavailable");
+    })).toThrow("exact Shards Router submission is unavailable");
+
+    const binding = MANUAL_ROUTER_EXACT_SHARDS_V1_BROWSER_BINDING;
+    const exactV1 = {
+      schemaVersion: "programmable.manual-router-applicant-list-response.v1",
+      authenticatedGitHubUserId: binding.authenticatedGitHubUserId,
+      linkedLaunchWallet: binding.linkedLaunchWallet,
+      submissions: [{
+        subjectHash: binding.subjectHash,
+        pointerHash: POINTER,
+        pullRequestNumber: binding.pullRequestNumber,
+        headSha: binding.headSha,
+        treeSha: binding.treeSha,
+        approvalBindingHash: binding.approvalBindingHash,
+        routeNonce: binding.routeNonce,
+        status: "ready" as const,
+        deadline: "1786387607",
+        submittedTransactionHash: null,
+        failedTransactionEvidenceHash: null,
+      }],
+      applicantIndexHash: APPROVAL,
+    } satisfies ManualRouterApplicantListResponseV1;
+    expect(manualRouterIsExactShardsV1ApplicantDirectory(exactV1)).toBe(true);
+    expect(manualRouterDirectoryForApplicantV2({
+      directory: exactV1,
+      requireExactShardsRoute: true,
+    })).toBe(exactV1);
+
+    const exactResolved = {
+      schemaVersion: "programmable.manual-router-applicant-resolve-response.v1",
+      subjectHash: binding.subjectHash,
+      pointerHash: POINTER,
+      approvalBindingHash: binding.approvalBindingHash,
+      routeNonce: binding.routeNonce,
+      status: "finalized" as const,
+      transactionHash: LAUNCH_ID,
+      proofHash: APPROVAL,
+    } satisfies ManualRouterResolveResponseV1;
+    expect(manualRouterResolveForApplicantV2({
+      directory: exactV1,
+      resolved: exactResolved,
+      requireExactShardsRoute: true,
+    })).toBe(exactResolved);
+    for (const nearMiss of [
+      { ...exactV1, authenticatedGitHubUserId: "155705665" },
+      { ...exactV1, linkedLaunchWallet: WALLET },
+      { ...exactV1, submissions: [] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], subjectHash: SUBJECT,
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], pullRequestNumber: 7,
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], headSha: "b".repeat(40),
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], treeSha: "c".repeat(40),
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], approvalBindingHash: APPROVAL,
+      }] },
+      { ...exactV1, submissions: [{
+        ...exactV1.submissions[0], routeNonce: ROUTE_NONCE,
+      }] },
+    ] satisfies ManualRouterApplicantListResponseV1[]) {
+      expect(manualRouterIsExactShardsV1ApplicantDirectory(nearMiss)).toBe(false);
+      expect(() => manualRouterDirectoryForApplicantV2({
+        directory: nearMiss,
+        requireExactShardsRoute: true,
+      })).toThrow("exact Shards Router submission is unavailable");
+    }
+    for (const resolvedNearMiss of [
+      { ...exactResolved, pointerHash: `sha256:${"23".repeat(32)}` as const },
+      { ...exactResolved, approvalBindingHash: APPROVAL },
+      { ...exactResolved, routeNonce: ROUTE_NONCE },
+    ] satisfies ManualRouterResolveResponseV1[]) {
+      expect(() => manualRouterResolveForApplicantV2({
+        directory: exactV1,
+        resolved: resolvedNearMiss,
+        requireExactShardsRoute: true,
+      })).toThrow("exact Shards Router V1 resolution is unavailable");
+    }
 
     const mixed = {
       schemaVersion: "programmable.manual-router-applicant-list-response.v2",
@@ -1065,8 +1150,11 @@ describe("inactive Shards nested-factory Router V2 browser contract", () => {
       "requireExactShardsRoute: exactShardsApplicant",
     );
     expect(component).toContain(
-      "disabled={!githubConnected || !routeAccepted}",
+      "disabled={!githubConnected || !routeDiscoveryAllowed}",
     );
+    expect(component).toContain("manualRouterResolveForApplicantV2");
+    expect(component).toContain("exactShardsV1Compatibility");
+    expect(component).toContain("...(routeAcceptanceRequired ? [{");
     expect(component).toContain("The exact Shards route is not available yet");
     expect(component).toContain("isNestedFactorySubmissionV2(chosenSubmission)");
     expect(component).toContain("Reviewed deployment order");

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -10,6 +10,10 @@ vi.mock("server-only", () => ({}));
 
 import { LaunchModelPicker } from "../components/launch-entry";
 import {
+  acquireManualRouterWebsiteSessionV1,
+  manualRouterApplicantDiscoveryReady,
+} from "../components/manual-applicant-launch";
+import {
   MANUAL_ROUTER_PRODUCTION_BINDING_V1,
   assertManualRouterProductionBindingV1,
 } from "../lib/custom-launch/manual-router-bindings-v1";
@@ -98,6 +102,69 @@ import { rpcProviderCommitment } from
 
 const WALLET = "0x1111111111111111111111111111111111111111" as const;
 const OTHER_WALLET = "0x2222222222222222222222222222222222222222" as const;
+
+describe("manual Applicant Privy hydration", () => {
+  it("does not start discovery before Privy is ready and starts once on the ready transition", () => {
+    const listAndResolve = vi.fn();
+    const runDiscovery = (authReady: boolean) => {
+      if (manualRouterApplicantDiscoveryReady({
+        authReady,
+        authenticated: true,
+        githubConnected: true,
+        walletConnected: true,
+        routeDiscoveryAllowed: true,
+      })) listAndResolve();
+    };
+
+    runDiscovery(false);
+    expect(listAndResolve).not.toHaveBeenCalled();
+    runDiscovery(true);
+    expect(listAndResolve).toHaveBeenCalledTimes(1);
+
+    const component = readFileSync(
+      join(process.cwd(), "components/manual-applicant-launch.tsx"),
+      "utf8",
+    );
+    expect(component.match(/manualRouterApplicantDiscoveryReady\(\{/gu))
+      .toHaveLength(2);
+    expect(component).toContain("NESTED_FACTORY_ACTIVATION === null\n      || !authReady");
+    expect(component).toContain("authReady,\n    authenticated,\n    githubConnected,\n    loadDirectory");
+  });
+
+  it("reacquires access once after identity hydration and never retries a request", async () => {
+    const events: string[] = [];
+    let accessCall = 0;
+    const session = await acquireManualRouterWebsiteSessionV1({
+      getAccessToken: async () => {
+        accessCall += 1;
+        events.push(`access-${accessCall}`);
+        return accessCall === 1 ? null : "access-token";
+      },
+      getIdentityToken: async () => {
+        events.push("identity");
+        return "identity-token";
+      },
+    });
+
+    expect(session).toEqual({
+      accessToken: "access-token",
+      identityToken: "identity-token",
+    });
+    expect(events).toEqual(["access-1", "identity", "access-2"]);
+  });
+
+  it("keeps unresolved dual-token hydration closed before any request", async () => {
+    const request = vi.fn();
+    await expect(acquireManualRouterWebsiteSessionV1({
+      getAccessToken: async () => null,
+      getIdentityToken: async () => null,
+    })).rejects.toMatchObject({
+      status: 401,
+      code: "applicant_authentication_required",
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+});
 const SUBJECT = `sha256:${"11".repeat(32)}` as const;
 const POINTER = `sha256:${"22".repeat(32)}` as const;
 const APPROVAL = `sha256:${"33".repeat(32)}` as const;

--- a/tests/manual-router-shards-authority-routing.test.ts
+++ b/tests/manual-router-shards-authority-routing.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const routing = vi.hoisted(() => ({
+  bearerConstructions: 0,
+  quickNodeConstructions: 0,
+  factoryRoutes: [] as string[],
+  clockRoutes: [] as string[],
+  publishRoutes: [] as string[],
+  reissueRoutes: [] as string[],
+  transactionRoutes: [] as string[],
+  finalityRoutes: [] as string[],
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("../lib/server/custom-launch/manual-router-config-v1", async (load) => {
+  const actual = await load<typeof import(
+    "../lib/server/custom-launch/manual-router-config-v1"
+  )>();
+  return { ...actual, assertManualRouterProductionConfigurationV1: () => {} };
+});
+
+vi.mock(
+  "../lib/server/custom-launch/manual-router-shards-v1-compat-v1",
+  async (load) => {
+    const actual = await load<typeof import(
+      "../lib/server/custom-launch/manual-router-shards-v1-compat-v1"
+    )>();
+    return {
+      ...actual,
+      manualRouterIsExactShardsV1ArtifactV1: (value: { routeTest?: string }) =>
+        value?.routeTest === "exact-shards-v1",
+      manualRouterIsExactShardsV1PointerV1: (value: { routeTest?: string }) =>
+        value?.routeTest === "exact-shards-v1",
+    };
+  },
+);
+
+vi.mock(
+  "../lib/server/custom-launch/manual-router-shards-publish-transport-v1",
+  async (load) => {
+    const actual = await load<typeof import(
+      "../lib/server/custom-launch/manual-router-shards-publish-transport-v1"
+    )>();
+    return {
+      ...actual,
+      createShardsManualRouterAlchemyBearerFetchV1(input: { fetch: typeof fetch }) {
+        routing.bearerConstructions += 1;
+        return input.fetch;
+      },
+      createShardsManualRouterPublishFetchV1(input: { fetch: typeof fetch }) {
+        routing.quickNodeConstructions += 1;
+        return input.fetch;
+      },
+      isExactShardsManualRouterPublishRequestV1(request: {
+        signedArtifact?: { routeTest?: string };
+      }) {
+        return request.signedArtifact?.routeTest === "exact-shards-v1";
+      },
+    };
+  },
+);
+
+vi.mock(
+  "../lib/vendor/manual-router-authority-v1/manual-router-portable.v1.mjs",
+  async (load) => {
+    const actual = await load<Record<string, unknown>>();
+    class RoutedFinalityVerifier {
+      readonly rpc: { routeTest: string };
+      constructor(input: { rpc: { routeTest: string } }) {
+        this.rpc = input.rpc;
+      }
+      async finalize() {
+        routing.finalityRoutes.push(this.rpc.routeTest);
+        return { proofHash: `sha256:${"11".repeat(32)}` };
+      }
+    }
+    return {
+      ...actual,
+      assertPortableManualRouterSignedPublishRequestV1: (raw: unknown) => raw,
+      createPortableManualRouterPublishAuthorityFromEnvV1(input: {
+        env: Record<string, string | undefined>;
+      }) {
+        const routeTest = input.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL
+          === "https://eth-mainnet.g.alchemy.com/v2"
+          ? "exact-shards-v1"
+          : "generic";
+        routing.factoryRoutes.push(routeTest);
+        return Object.freeze({
+          github: Object.freeze({}),
+          rpc: Object.freeze({
+            routeTest,
+            async observeChainClock() {
+              routing.clockRoutes.push(routeTest);
+              return { minimumTimestamp: "100", maximumTimestamp: "101" };
+            },
+            async collectCommonFinalizedAnchor() {
+              return {
+                blockNumber: "0x64",
+                blockHash: `0x${"22".repeat(32)}`,
+                timestamp: "99",
+              };
+            },
+            async readConsensus(method: string) {
+              if (method === "eth_getTransactionByHash") {
+                routing.transactionRoutes.push(routeTest);
+              }
+              return null;
+            },
+          }),
+        });
+      },
+      async verifyPortableManualRouterSignedPublishV1(input: {
+        composition: { rpc: { routeTest: string } };
+        request: unknown;
+      }) {
+        routing.publishRoutes.push(input.composition.rpc.routeTest);
+        return {
+          request: input.request,
+          nextPointer: {},
+          nextApplicantIndex: {},
+          idempotent: false,
+        };
+      },
+      async resolvePortableManualRouterReissueStateV1(input: {
+        composition: { rpc: { routeTest: string } };
+      }) {
+        routing.reissueRoutes.push(input.composition.rpc.routeTest);
+        return {
+          schemaVersion:
+            "programmable.manual-router-operator-reissue-state-response.v1",
+          disposition: "stale",
+          code: "stale_previous_artifact",
+        };
+      },
+      RouterLaunchFinalityVerifierV1: RoutedFinalityVerifier,
+    };
+  },
+);
+
+import {
+  createProductionManualRouterAuthorityV1,
+} from "../lib/server/custom-launch/manual-router-authority-v1";
+
+const exact = Object.freeze({
+  schemaVersion: "programmable.manual-router-complete-signed-artifact.v1",
+  routeTest: "exact-shards-v1",
+});
+const nearMiss = Object.freeze({
+  schemaVersion: "programmable.manual-router-complete-signed-artifact.v1",
+  routeTest: "near-miss-shards-v1",
+});
+const genericV1 = Object.freeze({
+  schemaVersion: "programmable.manual-router-complete-signed-artifact.v1",
+  routeTest: "generic-v1",
+});
+
+describe("exact Shards authority composition routing", () => {
+  beforeEach(() => {
+    for (const key of [
+      "factoryRoutes", "clockRoutes", "publishRoutes", "reissueRoutes",
+      "transactionRoutes", "finalityRoutes",
+    ] as const) routing[key].length = 0;
+    routing.bearerConstructions = 0;
+    routing.quickNodeConstructions = 0;
+  });
+
+  it("routes all six exact V1 authority paths through the Bearer composition", async () => {
+    const candidate = createProductionManualRouterAuthorityV1();
+
+    // list and resolve both select the already lineage-validated exact pointer.
+    await candidate.website.readChainClock({ pointer: exact as never });
+    await candidate.website.readChainClock({ pointer: exact as never });
+    await candidate.website.resolveReissueState({
+      artifact: exact as never,
+      request: {},
+      currentApplicantIndex: null,
+      currentApplicantPointers: [],
+      currentStatus: "reissue-required",
+    });
+    await candidate.website.verifySignedPublish({
+      request: { signedArtifact: exact },
+      currentApplicantIndex: null,
+      currentApplicantPointers: [],
+    });
+    await expect(candidate.website.observeExactTransaction({
+      artifact: exact as never,
+      prepared: {} as never,
+      transactionHash: `0x${"33".repeat(32)}`,
+    })).rejects.toThrow("transaction_not_observed");
+    await candidate.finalityAuthority.finalize({
+      artifact: exact as never,
+      prepared: { preparationHash: `sha256:${"44".repeat(32)}` } as never,
+      transactionHash: `0x${"55".repeat(32)}`,
+      deadline: "200",
+    });
+
+    expect(routing.factoryRoutes).toEqual(["generic", "exact-shards-v1"]);
+    expect(routing.bearerConstructions).toBe(1);
+    expect(routing.quickNodeConstructions).toBe(1);
+    expect(routing.clockRoutes).toEqual([
+      "exact-shards-v1", "exact-shards-v1",
+    ]);
+    expect(routing.reissueRoutes).toEqual(["exact-shards-v1"]);
+    expect(routing.publishRoutes).toEqual(["exact-shards-v1"]);
+    expect(routing.transactionRoutes).toEqual(["exact-shards-v1"]);
+    expect(routing.finalityRoutes).toEqual(["exact-shards-v1"]);
+  });
+
+  it("never constructs Bearer authority for near-miss Shards or generic V1", async () => {
+    const candidate = createProductionManualRouterAuthorityV1();
+    await candidate.website.readChainClock({ pointer: nearMiss as never });
+    await candidate.website.readChainClock({ pointer: genericV1 as never });
+    await candidate.website.resolveReissueState({
+      artifact: nearMiss as never,
+      request: {},
+      currentApplicantIndex: null,
+      currentApplicantPointers: [],
+      currentStatus: "reissue-required",
+    });
+    await candidate.website.verifySignedPublish({
+      request: { signedArtifact: genericV1 },
+      currentApplicantIndex: null,
+      currentApplicantPointers: [],
+    });
+
+    expect(routing.factoryRoutes).toEqual(["generic"]);
+    expect(routing.bearerConstructions).toBe(0);
+    expect(routing.quickNodeConstructions).toBe(0);
+    expect(routing.clockRoutes).toEqual(["generic", "generic"]);
+    expect(routing.reissueRoutes).toEqual(["generic"]);
+    expect(routing.publishRoutes).toEqual(["generic"]);
+  });
+});

--- a/tests/manual-router-shards-authority-routing.test.ts
+++ b/tests/manual-router-shards-authority-routing.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const routing = vi.hoisted(() => ({
+  bearerConstructions: 0,
+  quickNodeConstructions: 0,
+  factoryRoutes: [] as string[],
+  clockRoutes: [] as string[],
+  publishRoutes: [] as string[],
+  reissueRoutes: [] as string[],
+  transactionRoutes: [] as string[],
+  finalityRoutes: [] as string[],
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("../lib/server/custom-launch/manual-router-config-v1", async (load) => {
+  const actual = await load<typeof import(
+    "../lib/server/custom-launch/manual-router-config-v1"
+  )>();
+  return { ...actual, assertManualRouterProductionConfigurationV1: () => {} };
+});
+
+vi.mock(
+  "../lib/server/custom-launch/manual-router-shards-v1-compat-v1",
+  async (load) => {
+    const actual = await load<typeof import(
+      "../lib/server/custom-launch/manual-router-shards-v1-compat-v1"
+    )>();
+    return {
+      ...actual,
+      manualRouterIsExactShardsV1ArtifactV1: (value: { routeTest?: string }) =>
+        value?.routeTest === "exact-shards-v1",
+      manualRouterIsExactShardsV1PointerV1: (value: { routeTest?: string }) =>
+        value?.routeTest === "exact-shards-v1",
+    };
+  },
+);
+
+vi.mock(
+  "../lib/server/custom-launch/manual-router-shards-publish-transport-v1",
+  async (load) => {
+    const actual = await load<typeof import(
+      "../lib/server/custom-launch/manual-router-shards-publish-transport-v1"
+    )>();
+    return {
+      ...actual,
+      createShardsManualRouterAlchemyBearerFetchV1(input: { fetch: typeof fetch }) {
+        routing.bearerConstructions += 1;
+        return input.fetch;
+      },
+      createShardsManualRouterPublishFetchV1(input: { fetch: typeof fetch }) {
+        routing.quickNodeConstructions += 1;
+        return input.fetch;
+      },
+      isExactShardsManualRouterPublishRequestV1(request: {
+        signedArtifact?: { routeTest?: string };
+      }) {
+        return request.signedArtifact?.routeTest === "exact-shards-v1";
+      },
+    };
+  },
+);
+
+vi.mock(
+  "../lib/vendor/manual-router-authority-v1/manual-router-portable.v1.mjs",
+  async (load) => {
+    const actual = await load<Record<string, unknown>>();
+    class RoutedFinalityVerifier {
+      readonly rpc: { routeTest: string };
+      constructor(input: { rpc: { routeTest: string } }) {
+        this.rpc = input.rpc;
+      }
+      async finalize() {
+        routing.finalityRoutes.push(this.rpc.routeTest);
+        return { proofHash: `sha256:${"11".repeat(32)}` };
+      }
+    }
+    return {
+      ...actual,
+      assertPortableManualRouterSignedPublishRequestV1: (raw: unknown) => raw,
+      createPortableManualRouterPublishAuthorityFromEnvV1(input: {
+        env: Record<string, string | undefined>;
+      }) {
+        const routeTest = input.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL
+          === "https://eth-mainnet.g.alchemy.com/v2"
+          ? "exact-shards-v1"
+          : "generic";
+        routing.factoryRoutes.push(routeTest);
+        return Object.freeze({
+          github: Object.freeze({}),
+          rpc: Object.freeze({
+            routeTest,
+            async observeChainClock() {
+              routing.clockRoutes.push(routeTest);
+              return { minimumTimestamp: "100", maximumTimestamp: "101" };
+            },
+            async collectCommonFinalizedAnchor() {
+              return {
+                blockNumber: "0x64",
+                blockHash: `0x${"22".repeat(32)}`,
+                timestamp: "99",
+              };
+            },
+            async readConsensus(method: string) {
+              if (method === "eth_getTransactionByHash") {
+                routing.transactionRoutes.push(routeTest);
+              }
+              return null;
+            },
+          }),
+        });
+      },
+      async verifyPortableManualRouterSignedPublishV1(input: {
+        composition: { rpc: { routeTest: string } };
+        request: unknown;
+      }) {
+        routing.publishRoutes.push(input.composition.rpc.routeTest);
+        return {
+          request: input.request,
+          nextPointer: {},
+          nextApplicantIndex: {},
+          idempotent: false,
+        };
+      },
+      async resolvePortableManualRouterReissueStateV1(input: {
+        composition: { rpc: { routeTest: string } };
+      }) {
+        routing.reissueRoutes.push(input.composition.rpc.routeTest);
+        return {
+          schemaVersion:
+            "programmable.manual-router-operator-reissue-state-response.v1",
+          disposition: "stale",
+          code: "stale_previous_artifact",
+        };
+      },
+      RouterLaunchFinalityVerifierV1: RoutedFinalityVerifier,
+    };
+  },
+);
+
+import {
+  createProductionManualRouterAuthorityV1,
+} from "../lib/server/custom-launch/manual-router-authority-v1";
+
+const exact = Object.freeze({ routeTest: "exact-shards-v1" });
+const nearMiss = Object.freeze({ routeTest: "near-miss-shards-v1" });
+const genericV2 = Object.freeze({ routeTest: "generic-v2" });
+
+describe("exact Shards authority composition routing", () => {
+  beforeEach(() => {
+    for (const key of [
+      "factoryRoutes", "clockRoutes", "publishRoutes", "reissueRoutes",
+      "transactionRoutes", "finalityRoutes",
+    ] as const) routing[key].length = 0;
+    routing.bearerConstructions = 0;
+    routing.quickNodeConstructions = 0;
+  });
+
+  it("routes all six exact V1 authority paths through the Bearer composition", async () => {
+    const candidate = createProductionManualRouterAuthorityV1();
+
+    // list and resolve both select the already lineage-validated exact pointer.
+    await candidate.website.readChainClock({ pointer: exact as never });
+    await candidate.website.readChainClock({ pointer: exact as never });
+    await candidate.website.resolveReissueState({
+      artifact: exact as never,
+      request: {},
+      currentApplicantIndex: null,
+      currentApplicantPointers: [],
+      currentStatus: "reissue-required",
+    });
+    await candidate.website.verifySignedPublish({
+      request: { signedArtifact: exact },
+      currentApplicantIndex: null,
+      currentApplicantPointers: [],
+    });
+    await expect(candidate.website.observeExactTransaction({
+      artifact: exact as never,
+      prepared: {} as never,
+      transactionHash: `0x${"33".repeat(32)}`,
+    })).rejects.toThrow("transaction_not_observed");
+    await candidate.finalityAuthority.finalize({
+      artifact: exact as never,
+      prepared: { preparationHash: `sha256:${"44".repeat(32)}` } as never,
+      transactionHash: `0x${"55".repeat(32)}`,
+      deadline: "200",
+    });
+
+    expect(routing.factoryRoutes).toEqual(["generic", "exact-shards-v1"]);
+    expect(routing.bearerConstructions).toBe(1);
+    expect(routing.quickNodeConstructions).toBe(1);
+    expect(routing.clockRoutes).toEqual([
+      "exact-shards-v1", "exact-shards-v1",
+    ]);
+    expect(routing.reissueRoutes).toEqual(["exact-shards-v1"]);
+    expect(routing.publishRoutes).toEqual(["exact-shards-v1"]);
+    expect(routing.transactionRoutes).toEqual(["exact-shards-v1"]);
+    expect(routing.finalityRoutes).toEqual(["exact-shards-v1"]);
+  });
+
+  it("never constructs Bearer authority for near-miss Shards or generic V2", async () => {
+    const candidate = createProductionManualRouterAuthorityV1();
+    await candidate.website.readChainClock({ pointer: nearMiss as never });
+    await candidate.website.readChainClock({ pointer: genericV2 as never });
+    await candidate.website.resolveReissueState({
+      artifact: nearMiss as never,
+      request: {},
+      currentApplicantIndex: null,
+      currentApplicantPointers: [],
+      currentStatus: "reissue-required",
+    });
+    await candidate.website.verifySignedPublish({
+      request: { signedArtifact: genericV2 },
+      currentApplicantIndex: null,
+      currentApplicantPointers: [],
+    });
+
+    expect(routing.factoryRoutes).toEqual(["generic"]);
+    expect(routing.bearerConstructions).toBe(0);
+    expect(routing.quickNodeConstructions).toBe(0);
+    expect(routing.clockRoutes).toEqual(["generic", "generic"]);
+    expect(routing.reissueRoutes).toEqual(["generic"]);
+    expect(routing.publishRoutes).toEqual(["generic"]);
+  });
+});

--- a/tests/manual-router-shards-publish-transport.test.ts
+++ b/tests/manual-router-shards-publish-transport.test.ts
@@ -1,0 +1,161 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1,
+  createShardsManualRouterPublishFetchV1,
+  isExactShardsManualRouterPublishRequestV1,
+} from "../lib/server/custom-launch/manual-router-shards-publish-transport-v1";
+
+const QUICKNODE =
+  "https://programmable.ethereum.quiknode.pro/exact-shards-test-key/";
+const ALCHEMY = "https://eth-mainnet.g.alchemy.com/v2/test-key";
+
+describe("Shards manual Router publish transport", () => {
+  it("pins the signed-artifact route above the serialized provider budget", async () => {
+    const route = await readFile(new URL(
+      "../app/api/custom-launch/manual/signed-artifacts/route.ts",
+      import.meta.url,
+    ), "utf8");
+
+    expect(route).toContain("export const maxDuration = 300;");
+  });
+
+  it("retries only exact QuickNode HTTP 429 responses with the frozen delays", async () => {
+    let now = 10_000;
+    const waits: number[] = [];
+    const responses = [429, 429, 200];
+    const delegate = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: responses.shift() }));
+    const transport = createShardsManualRouterPublishFetchV1({
+      fetch: delegate,
+      quickNodeUrl: QUICKNODE,
+      clock: {
+        nowMilliseconds: () => now,
+        async wait(milliseconds) {
+          waits.push(milliseconds);
+          now += milliseconds;
+        },
+      },
+    });
+
+    await expect(transport(QUICKNODE, { method: "POST", body: "{}" }))
+      .resolves.toMatchObject({ status: 200 });
+    expect(delegate).toHaveBeenCalledTimes(3);
+    expect(waits).toEqual([1_000, 2_000]);
+  });
+
+  it("returns the final QuickNode 429 after the bounded attempts", async () => {
+    let now = 20_000;
+    const waits: number[] = [];
+    const delegate = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: 429 }));
+    const transport = createShardsManualRouterPublishFetchV1({
+      fetch: delegate,
+      quickNodeUrl: QUICKNODE,
+      clock: {
+        nowMilliseconds: () => now,
+        async wait(milliseconds) {
+          waits.push(milliseconds);
+          now += milliseconds;
+        },
+      },
+    });
+
+    await expect(transport(QUICKNODE)).resolves.toMatchObject({ status: 429 });
+    expect(delegate).toHaveBeenCalledTimes(3);
+    expect(waits).toEqual([1_000, 2_000]);
+  });
+
+  it("does not retry exceptions or non-QuickNode traffic", async () => {
+    const failure = new TypeError("transport failed");
+    const quickNodeDelegate = vi.fn<typeof fetch>().mockRejectedValue(failure);
+    const quickNodeTransport = createShardsManualRouterPublishFetchV1({
+      fetch: quickNodeDelegate,
+      quickNodeUrl: QUICKNODE,
+    });
+    await expect(quickNodeTransport(QUICKNODE)).rejects.toBe(failure);
+    expect(quickNodeDelegate).toHaveBeenCalledTimes(1);
+
+    const input = new Request(ALCHEMY, { method: "POST", body: "{}" });
+    const init = { headers: { "x-test": "unchanged" } };
+    const genericDelegate = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: 429 }));
+    const genericTransport = createShardsManualRouterPublishFetchV1({
+      fetch: genericDelegate,
+      quickNodeUrl: QUICKNODE,
+    });
+    await expect(genericTransport(input, init)).resolves.toMatchObject({
+      status: 429,
+    });
+    const lookalikeQuickNodeUrl = `${QUICKNODE}different-path`;
+    await expect(genericTransport(lookalikeQuickNodeUrl)).resolves.toMatchObject({
+      status: 429,
+    });
+    expect(genericDelegate).toHaveBeenCalledTimes(2);
+    expect(genericDelegate).toHaveBeenCalledWith(input, init);
+    expect(genericDelegate).toHaveBeenCalledWith(
+      lookalikeQuickNodeUrl,
+      undefined,
+    );
+  });
+
+  it("serializes exact QuickNode traffic with a one-second start gap", async () => {
+    let now = 30_000;
+    let active = 0;
+    let maximumActive = 0;
+    let releaseFirst: (() => void) | undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let call = 0;
+    const delegate = vi.fn<typeof fetch>(async () => {
+      call += 1;
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      if (call === 1) await firstBlocked;
+      active -= 1;
+      return new Response(null, { status: 200 });
+    });
+    const waits: number[] = [];
+    const transport = createShardsManualRouterPublishFetchV1({
+      fetch: delegate,
+      quickNodeUrl: QUICKNODE,
+      clock: {
+        nowMilliseconds: () => now,
+        async wait(milliseconds) {
+          waits.push(milliseconds);
+          now += milliseconds;
+        },
+      },
+    });
+
+    const first = transport(QUICKNODE);
+    await vi.waitFor(() => expect(delegate).toHaveBeenCalledTimes(1));
+    const second = transport(QUICKNODE);
+    await Promise.resolve();
+    expect(delegate).toHaveBeenCalledTimes(1);
+    releaseFirst?.();
+    await Promise.all([first, second]);
+
+    expect(maximumActive).toBe(1);
+    expect(delegate).toHaveBeenCalledTimes(2);
+    expect(waits).toEqual([1_000]);
+  });
+
+  it("selects the transport only from the verified exact Shards hash", () => {
+    expect(isExactShardsManualRouterPublishRequestV1({
+      signedArtifact: { prepared: {
+        compileInputHash: SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1,
+      } },
+    })).toBe(true);
+    expect(isExactShardsManualRouterPublishRequestV1({
+      signedArtifact: { prepared: {
+        compileInputHash: `sha256:${"0".repeat(64)}`,
+      } },
+    })).toBe(false);
+  });
+});

--- a/tests/manual-router-shards-publish-transport.test.ts
+++ b/tests/manual-router-shards-publish-transport.test.ts
@@ -1,0 +1,308 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_V1,
+  SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1,
+  SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1,
+  createShardsManualRouterAlchemyBearerFetchForBindingV1,
+  createShardsManualRouterAlchemyBearerFetchV1,
+  createShardsManualRouterPublishFetchV1,
+  isExactShardsManualRouterPublishRequestV1,
+  shardsManualRouterAlchemyApiKeyCommitmentV1,
+} from "../lib/server/custom-launch/manual-router-shards-publish-transport-v1";
+
+const QUICKNODE =
+  "https://programmable.ethereum.quiknode.pro/exact-shards-test-key/";
+const ALCHEMY = "https://eth-mainnet.g.alchemy.com/v2/test-key";
+
+describe("Shards manual Router publish transport", () => {
+  it("injects one committed Bearer key only on the fixed Alchemy endpoint", async () => {
+    const key = "alcht_synthetic_access_key_for_focused_test";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    const delegate = vi.fn<typeof fetch>(async (input) => {
+      const request = new Request(input);
+      expect(request.url).toBe(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1);
+      expect(request.headers.get("authorization")).toBe(`Bearer ${key}`);
+      expect(request.headers.get("content-type")).toBe("application/json");
+      return new Response(null, { status: 200 });
+    });
+    const transport = createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch: delegate,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    });
+
+    await expect(transport(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    })).resolves.toMatchObject({ status: 200 });
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed on key drift without leaking key bytes", () => {
+    const key = "alcht_synthetic_access_key_that_must_not_leak";
+    let observed: unknown;
+    try {
+      createShardsManualRouterAlchemyBearerFetchV1({
+        fetch,
+        apiKey: key,
+        apiKeyCommitment:
+          shardsManualRouterAlchemyApiKeyCommitmentV1(key),
+      });
+    } catch (error) {
+      observed = error;
+    }
+    expect(observed).toBeInstanceOf(TypeError);
+    expect(String(observed)).not.toContain(key);
+    expect(SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_V1)
+      .toBe("sha256:5419a7a33826708ccae3c7e29aca5e6bab25e6bc5e52a14c22141c4d0cc7ec87");
+  });
+
+  it("rejects a committed key outside the audited alcht_ family", () => {
+    const key = "not_alcht_but_otherwise_well_formed_key";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    expect(() => createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    })).toThrow("access key is invalid");
+  });
+
+  it("does not retry Alchemy 401 or alter nonexact provider traffic", async () => {
+    const key = "alcht_synthetic_access_key_for_pass_through";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    const delegate = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: 401 }));
+    const transport = createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch: delegate,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    });
+
+    await expect(transport(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1))
+      .resolves.toMatchObject({ status: 401 });
+    const request = new Request(ALCHEMY, { method: "POST", body: "{}" });
+    const init = { headers: { "x-pass-through": "exact" } };
+    await expect(transport(request, init)).resolves.toMatchObject({ status: 401 });
+    expect(delegate).toHaveBeenCalledTimes(2);
+    expect(delegate).toHaveBeenLastCalledWith(request, init);
+  });
+
+  it("rejects caller-supplied authorization on the exact endpoint", () => {
+    const key = "alcht_synthetic_access_key_for_ambiguity";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    const delegate = vi.fn<typeof fetch>();
+    const transport = createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch: delegate,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    });
+
+    expect(() => transport(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1, {
+      headers: { authorization: "Bearer competing" },
+    })).toThrow("authorization is ambiguous");
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it("composes exact Alchemy Bearer auth with QuickNode FIFO/429 handling", async () => {
+    const key = "alcht_synthetic_combined_transport_key";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    let now = 50_000;
+    const waits: number[] = [];
+    let quickNodeAttempts = 0;
+    const delegate = vi.fn<typeof fetch>(async (input) => {
+      const request = new Request(input);
+      if (request.url === QUICKNODE) {
+        quickNodeAttempts += 1;
+        expect(request.headers.has("authorization")).toBe(false);
+        return new Response(null, {
+          status: quickNodeAttempts === 1 ? 429 : 200,
+        });
+      }
+      if (request.url === SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1) {
+        expect(request.headers.get("authorization")).toBe(`Bearer ${key}`);
+        return new Response(null, { status: 200 });
+      }
+      expect(request.headers.has("authorization")).toBe(false);
+      return new Response(null, { status: 401 });
+    });
+    const quickNode = createShardsManualRouterPublishFetchV1({
+      fetch: delegate,
+      quickNodeUrl: QUICKNODE,
+      clock: {
+        nowMilliseconds: () => now,
+        async wait(milliseconds) {
+          waits.push(milliseconds);
+          now += milliseconds;
+        },
+      },
+    });
+    const combined = createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch: quickNode,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    });
+
+    await expect(combined(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1))
+      .resolves.toMatchObject({ status: 200 });
+    await expect(combined(QUICKNODE)).resolves.toMatchObject({ status: 200 });
+    await expect(combined(`${SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1}/lookalike`))
+      .resolves.toMatchObject({ status: 401 });
+    expect(quickNodeAttempts).toBe(2);
+    expect(waits).toEqual([1_000]);
+  });
+
+  it("pins the signed-artifact route above the serialized provider budget", async () => {
+    const route = await readFile(new URL(
+      "../app/api/custom-launch/manual/signed-artifacts/route.ts",
+      import.meta.url,
+    ), "utf8");
+
+    expect(route).toContain("export const maxDuration = 300;");
+  });
+
+  it("retries only exact QuickNode HTTP 429 responses with the frozen delays", async () => {
+    let now = 10_000;
+    const waits: number[] = [];
+    const responses = [429, 429, 200];
+    const delegate = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: responses.shift() }));
+    const transport = createShardsManualRouterPublishFetchV1({
+      fetch: delegate,
+      quickNodeUrl: QUICKNODE,
+      clock: {
+        nowMilliseconds: () => now,
+        async wait(milliseconds) {
+          waits.push(milliseconds);
+          now += milliseconds;
+        },
+      },
+    });
+
+    await expect(transport(QUICKNODE, { method: "POST", body: "{}" }))
+      .resolves.toMatchObject({ status: 200 });
+    expect(delegate).toHaveBeenCalledTimes(3);
+    expect(waits).toEqual([1_000, 2_000]);
+  });
+
+  it("returns the final QuickNode 429 after the bounded attempts", async () => {
+    let now = 20_000;
+    const waits: number[] = [];
+    const delegate = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: 429 }));
+    const transport = createShardsManualRouterPublishFetchV1({
+      fetch: delegate,
+      quickNodeUrl: QUICKNODE,
+      clock: {
+        nowMilliseconds: () => now,
+        async wait(milliseconds) {
+          waits.push(milliseconds);
+          now += milliseconds;
+        },
+      },
+    });
+
+    await expect(transport(QUICKNODE)).resolves.toMatchObject({ status: 429 });
+    expect(delegate).toHaveBeenCalledTimes(3);
+    expect(waits).toEqual([1_000, 2_000]);
+  });
+
+  it("does not retry exceptions or non-QuickNode traffic", async () => {
+    const failure = new TypeError("transport failed");
+    const quickNodeDelegate = vi.fn<typeof fetch>().mockRejectedValue(failure);
+    const quickNodeTransport = createShardsManualRouterPublishFetchV1({
+      fetch: quickNodeDelegate,
+      quickNodeUrl: QUICKNODE,
+    });
+    await expect(quickNodeTransport(QUICKNODE)).rejects.toBe(failure);
+    expect(quickNodeDelegate).toHaveBeenCalledTimes(1);
+
+    const input = new Request(ALCHEMY, { method: "POST", body: "{}" });
+    const init = { headers: { "x-test": "unchanged" } };
+    const genericDelegate = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: 429 }));
+    const genericTransport = createShardsManualRouterPublishFetchV1({
+      fetch: genericDelegate,
+      quickNodeUrl: QUICKNODE,
+    });
+    await expect(genericTransport(input, init)).resolves.toMatchObject({
+      status: 429,
+    });
+    const lookalikeQuickNodeUrl = `${QUICKNODE}different-path`;
+    await expect(genericTransport(lookalikeQuickNodeUrl)).resolves.toMatchObject({
+      status: 429,
+    });
+    expect(genericDelegate).toHaveBeenCalledTimes(2);
+    expect(genericDelegate).toHaveBeenCalledWith(input, init);
+    expect(genericDelegate).toHaveBeenCalledWith(
+      lookalikeQuickNodeUrl,
+      undefined,
+    );
+  });
+
+  it("serializes exact QuickNode traffic with a one-second start gap", async () => {
+    let now = 30_000;
+    let active = 0;
+    let maximumActive = 0;
+    let releaseFirst: (() => void) | undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let call = 0;
+    const delegate = vi.fn<typeof fetch>(async () => {
+      call += 1;
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      if (call === 1) await firstBlocked;
+      active -= 1;
+      return new Response(null, { status: 200 });
+    });
+    const waits: number[] = [];
+    const transport = createShardsManualRouterPublishFetchV1({
+      fetch: delegate,
+      quickNodeUrl: QUICKNODE,
+      clock: {
+        nowMilliseconds: () => now,
+        async wait(milliseconds) {
+          waits.push(milliseconds);
+          now += milliseconds;
+        },
+      },
+    });
+
+    const first = transport(QUICKNODE);
+    await vi.waitFor(() => expect(delegate).toHaveBeenCalledTimes(1));
+    const second = transport(QUICKNODE);
+    await Promise.resolve();
+    expect(delegate).toHaveBeenCalledTimes(1);
+    releaseFirst?.();
+    await Promise.all([first, second]);
+
+    expect(maximumActive).toBe(1);
+    expect(delegate).toHaveBeenCalledTimes(2);
+    expect(waits).toEqual([1_000]);
+  });
+
+  it("selects the transport only from the verified exact Shards hash", () => {
+    expect(isExactShardsManualRouterPublishRequestV1({
+      signedArtifact: { prepared: {
+        compileInputHash: SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1,
+      } },
+    })).toBe(true);
+    expect(isExactShardsManualRouterPublishRequestV1({
+      signedArtifact: { prepared: {
+        compileInputHash: `sha256:${"0".repeat(64)}`,
+      } },
+    })).toBe(false);
+  });
+});

--- a/tests/manual-router-shards-publish-transport.test.ts
+++ b/tests/manual-router-shards-publish-transport.test.ts
@@ -5,9 +5,14 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import {
+  SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_V1,
+  SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1,
   SHARDS_MANUAL_ROUTER_COMPILE_INPUT_HASH_V1,
+  createShardsManualRouterAlchemyBearerFetchForBindingV1,
+  createShardsManualRouterAlchemyBearerFetchV1,
   createShardsManualRouterPublishFetchV1,
   isExactShardsManualRouterPublishRequestV1,
+  shardsManualRouterAlchemyApiKeyCommitmentV1,
 } from "../lib/server/custom-launch/manual-router-shards-publish-transport-v1";
 
 const QUICKNODE =
@@ -15,6 +20,148 @@ const QUICKNODE =
 const ALCHEMY = "https://eth-mainnet.g.alchemy.com/v2/test-key";
 
 describe("Shards manual Router publish transport", () => {
+  it("injects one committed Bearer key only on the fixed Alchemy endpoint", async () => {
+    const key = "alcht_synthetic_access_key_for_focused_test";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    const delegate = vi.fn<typeof fetch>(async (input) => {
+      const request = new Request(input);
+      expect(request.url).toBe(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1);
+      expect(request.headers.get("authorization")).toBe(`Bearer ${key}`);
+      expect(request.headers.get("content-type")).toBe("application/json");
+      return new Response(null, { status: 200 });
+    });
+    const transport = createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch: delegate,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    });
+
+    await expect(transport(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    })).resolves.toMatchObject({ status: 200 });
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed on key drift without leaking key bytes", () => {
+    const key = "alcht_synthetic_access_key_that_must_not_leak";
+    let observed: unknown;
+    try {
+      createShardsManualRouterAlchemyBearerFetchV1({
+        fetch,
+        apiKey: key,
+        apiKeyCommitment:
+          shardsManualRouterAlchemyApiKeyCommitmentV1(key),
+      });
+    } catch (error) {
+      observed = error;
+    }
+    expect(observed).toBeInstanceOf(TypeError);
+    expect(String(observed)).not.toContain(key);
+    expect(SHARDS_MANUAL_ROUTER_ALCHEMY_API_KEY_COMMITMENT_V1)
+      .toBe("sha256:5419a7a33826708ccae3c7e29aca5e6bab25e6bc5e52a14c22141c4d0cc7ec87");
+  });
+
+  it("rejects a committed key outside the audited alcht_ family", () => {
+    const key = "not_alcht_but_otherwise_well_formed_key";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    expect(() => createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    })).toThrow("access key is invalid");
+  });
+
+  it("does not retry Alchemy 401 or alter nonexact provider traffic", async () => {
+    const key = "alcht_synthetic_access_key_for_pass_through";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    const delegate = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: 401 }));
+    const transport = createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch: delegate,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    });
+
+    await expect(transport(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1))
+      .resolves.toMatchObject({ status: 401 });
+    const request = new Request(ALCHEMY, { method: "POST", body: "{}" });
+    const init = { headers: { "x-pass-through": "exact" } };
+    await expect(transport(request, init)).resolves.toMatchObject({ status: 401 });
+    expect(delegate).toHaveBeenCalledTimes(2);
+    expect(delegate).toHaveBeenLastCalledWith(request, init);
+  });
+
+  it("rejects caller-supplied authorization on the exact endpoint", () => {
+    const key = "alcht_synthetic_access_key_for_ambiguity";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    const delegate = vi.fn<typeof fetch>();
+    const transport = createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch: delegate,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    });
+
+    expect(() => transport(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1, {
+      headers: { authorization: "Bearer competing" },
+    })).toThrow("authorization is ambiguous");
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it("composes exact Alchemy Bearer auth with QuickNode FIFO/429 handling", async () => {
+    const key = "alcht_synthetic_combined_transport_key";
+    const commitment = shardsManualRouterAlchemyApiKeyCommitmentV1(key);
+    let now = 50_000;
+    const waits: number[] = [];
+    let quickNodeAttempts = 0;
+    const delegate = vi.fn<typeof fetch>(async (input) => {
+      const request = new Request(input);
+      if (request.url === QUICKNODE) {
+        quickNodeAttempts += 1;
+        expect(request.headers.has("authorization")).toBe(false);
+        return new Response(null, {
+          status: quickNodeAttempts === 1 ? 429 : 200,
+        });
+      }
+      if (request.url === SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1) {
+        expect(request.headers.get("authorization")).toBe(`Bearer ${key}`);
+        return new Response(null, { status: 200 });
+      }
+      expect(request.headers.has("authorization")).toBe(false);
+      return new Response(null, { status: 401 });
+    });
+    const quickNode = createShardsManualRouterPublishFetchV1({
+      fetch: delegate,
+      quickNodeUrl: QUICKNODE,
+      clock: {
+        nowMilliseconds: () => now,
+        async wait(milliseconds) {
+          waits.push(milliseconds);
+          now += milliseconds;
+        },
+      },
+    });
+    const combined = createShardsManualRouterAlchemyBearerFetchForBindingV1({
+      fetch: quickNode,
+      apiKey: key,
+      apiKeyCommitment: commitment,
+      expectedApiKeyCommitment: commitment,
+    });
+
+    await expect(combined(SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1))
+      .resolves.toMatchObject({ status: 200 });
+    await expect(combined(QUICKNODE)).resolves.toMatchObject({ status: 200 });
+    await expect(combined(`${SHARDS_MANUAL_ROUTER_ALCHEMY_ENDPOINT_V1}/lookalike`))
+      .resolves.toMatchObject({ status: 401 });
+    expect(quickNodeAttempts).toBe(2);
+    expect(waits).toEqual([1_000]);
+  });
+
   it("pins the signed-artifact route above the serialized provider budget", async () => {
     const route = await readFile(new URL(
       "../app/api/custom-launch/manual/signed-artifacts/route.ts",

--- a/tests/manual-router-shards-v1-compat.test.ts
+++ b/tests/manual-router-shards-v1-compat.test.ts
@@ -251,6 +251,86 @@ describe("exact Shards Router V1 Website service bridge", () => {
     });
   });
 
+  it("refreshes an unchanged exact Shards head ETag after verification", async () => {
+    const { store, values } = memoryStore();
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const indexPath = manualRouterApplicantIndexPathV1({
+      approvedGitHubUserId: EXACT.approvedGitHubUserId,
+      approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    });
+    const baseAuthority = shardsAuthority();
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: Object.freeze({
+        ...baseAuthority,
+        async verifySignedPublish(input: Parameters<
+          ManualRouterWebsiteAuthorityV1["verifySignedPublish"]
+        >[0]) {
+          const verified = await baseAuthority.verifySignedPublish(input);
+          const current = values.get(indexPath)!;
+          values.set(indexPath, { ...current, etag: "etag-external-same-head" });
+          return verified;
+        },
+      }),
+    });
+    const successor = shardsArtifact("successor");
+
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: successor,
+    })).resolves.toMatchObject({
+      state: "signed-permit-available",
+      signedArtifactHash: successor.signedArtifactHash,
+      idempotent: false,
+    });
+  });
+
+  it("rejects semantic exact Shards head drift after verification", async () => {
+    const { store } = memoryStore();
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const indexPath = manualRouterApplicantIndexPathV1({
+      approvedGitHubUserId: EXACT.approvedGitHubUserId,
+      approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    });
+    const baseAuthority = shardsAuthority();
+    const successor = shardsArtifact("successor");
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: Object.freeze({
+        ...baseAuthority,
+        async verifySignedPublish(input: Parameters<
+          ManualRouterWebsiteAuthorityV1["verifySignedPublish"]
+        >[0]) {
+          const verified = await baseAuthority.verifySignedPublish(input);
+          const nextPointer = verified.nextPointer as ManualRouterApplicantPointerV1;
+          const nextIndex = verified.nextApplicantIndex as ManualRouterApplicantIndexV1;
+          await store.putImmutable(
+            manualRouterContentPathV1("signed-artifacts", successor.signedArtifactHash),
+            successor,
+          );
+          await store.putImmutable(
+            manualRouterContentPathV1("pointer-history", nextPointer.pointerHash),
+            nextPointer,
+          );
+          const current = await store.read(indexPath);
+          await store.compareAndSwap(indexPath, current!.etag, nextIndex);
+          return verified;
+        },
+      }),
+    });
+
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: successor,
+    })).rejects.toMatchObject({
+      status: 409,
+      code: "state_conflict",
+      retryable: false,
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+  });
+
   it("blocks every path for an exact-looking V1 head outside pointer40d8 lineage", async () => {
     const { store, values } = memoryStore();
     const orphanArtifact = shardsArtifact("successor");

--- a/tests/manual-router-shards-v1-compat.test.ts
+++ b/tests/manual-router-shards-v1-compat.test.ts
@@ -1,0 +1,775 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1,
+  manualRouterClaimsShardsV1ArtifactV1,
+  manualRouterClaimsShardsV1PointerV1,
+  manualRouterIsExactShardsV1ArtifactV1,
+  manualRouterIsExactShardsV1PointerV1,
+} from "../lib/server/custom-launch/manual-router-shards-v1-compat-v1";
+import {
+  createManualRouterApplicantIndexV1,
+  createManualRouterSignedPointerV1,
+  type ManualRouterApplicantIndexV1,
+  type ManualRouterApplicantPointerV1,
+} from "../lib/server/custom-launch/manual-router-state-v1";
+import {
+  ManualRouterServiceErrorV1,
+  ManualRouterWebsiteServiceV1,
+  type ManualRouterCompleteSignedArtifactViewV1,
+  type ManualRouterWebsiteAuthorityV1,
+} from "../lib/server/custom-launch/manual-router-service-v1";
+import {
+  ManualRouterPrivateBlobStoreV1,
+  manualRouterApplicantIndexPathV1,
+  manualRouterContentPathV1,
+} from "../lib/server/custom-launch/manual-router-store-v1";
+import type { Sha256Digest } from
+  "../lib/server/projection-target/hashing";
+
+const EXACT = MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1;
+const ROOT_POINTER = Object.freeze({
+  schemaVersion: "programmable.manual-router-applicant-pointer.v1" as const,
+  subject: Object.freeze({
+    schemaVersion: "programmable.manual-router-applicant-subject.v1" as const,
+    repositoryId: "1320085947" as const,
+    pullRequestNumber: EXACT.pullRequestNumber,
+    approvedGitHubUserId: EXACT.approvedGitHubUserId,
+    approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    subjectHash: EXACT.subjectHash,
+  }),
+  state: "signed-permit-available" as const,
+  approvalBindingHash: EXACT.approvalBindingHash,
+  headSha: EXACT.headSha,
+  treeSha: EXACT.treeSha,
+  routeNonce: EXACT.routeNonce,
+  preparationArtifactHash:
+    "sha256:820bd4e0bde3acb35152678ab63c97350ca36b11d923a4e9dccb5a78451076f2",
+  signatureRequestHash:
+    "sha256:487707d489f6c4928d1665cae734aeaffcc818140c045077a45b5786fb1d2c40",
+  signedDescriptorHash:
+    "sha256:3f85b32256882bb02e5d3286c0366e1c2fb8e0376de455e35805d3b01e5d976e",
+  signedArtifactHash: EXACT.rootSignedArtifactHash,
+  validAfter: "1786373204",
+  deadline: "1786375919",
+  submittedTransactionHash: null,
+  failedTransactionEvidenceHash: null,
+  finalizedProofHash: null,
+  previousPointerHash: null,
+  updatedAtEpochSeconds: "1786375463",
+  pointerHash: EXACT.rootPointerHash,
+} satisfies ManualRouterApplicantPointerV1);
+
+const ROOT_INDEX = Object.freeze({
+  schemaVersion: "programmable.manual-router-applicant-index.v1" as const,
+  approvedGitHubUserId: EXACT.approvedGitHubUserId,
+  approvedLaunchWallet: EXACT.approvedLaunchWallet,
+  entries: Object.freeze([Object.freeze({
+    subjectHash: EXACT.subjectHash,
+    pointerHash: EXACT.rootPointerHash,
+    pullRequestNumber: EXACT.pullRequestNumber,
+    approvalBindingHash: EXACT.approvalBindingHash,
+    headSha: EXACT.headSha,
+    treeSha: EXACT.treeSha,
+    routeNonce: EXACT.routeNonce,
+    state: "signed-permit-available" as const,
+    signedArtifactHash: EXACT.rootSignedArtifactHash,
+    validAfter: ROOT_POINTER.validAfter,
+    deadline: ROOT_POINTER.deadline,
+    submittedTransactionHash: null,
+    failedTransactionEvidenceHash: null,
+  })]),
+  previousIndexHash: null,
+  indexHash:
+    "sha256:5beb2166983f0530bde7249343a4887704657b8b076bed8736ffef821ddce230",
+} satisfies ManualRouterApplicantIndexV1);
+
+describe("exact Shards Router V1 compatibility identity", () => {
+  it("accepts only the frozen Applicant, source, compile, plan, and route tuple", () => {
+    const exact = shardsArtifact("root");
+    expect(manualRouterClaimsShardsV1ArtifactV1(exact)).toBe(true);
+    expect(manualRouterIsExactShardsV1ArtifactV1(exact)).toBe(true);
+
+    const mutations: readonly [readonly string[], unknown][] = [
+      [["preparationArtifact", "subject", "approvedGitHubUserId"], "155705665"],
+      [["preparationArtifact", "subject", "approvedLaunchWallet"],
+        "0xdeebb3a6543cebeb2ed66963897a0abea52a50cc"],
+      [["preparationArtifact", "subject", "pullRequestNumber"], 7],
+      [["preparationArtifact", "subject", "subjectHash"], digest("01")],
+      [["preparationArtifact", "approvalClaim", "headRepositoryId"], "1329074394"],
+      [["preparationArtifact", "approvalClaim", "headSha"], "2".repeat(40)],
+      [["preparationArtifact", "approvalClaim", "treeSha"], "3".repeat(40)],
+      [["preparationArtifact", "approvalClaim", "compileInputHash"], digest("02")],
+      [["preparationArtifact", "approvalClaim", "planHash"], digest("03")],
+      [["preparationArtifact", "reviewedCompileInput", "applicationId"], "other"],
+      [["preparationArtifact", "reviewedCompileInput", "applicationManifestSha256"],
+        digest("04")],
+      [["preparationArtifact", "reviewedCompileInput", "sourceRevisionBindingHash"],
+        digest("05")],
+      [["preparationArtifact", "reviewedCompileInput", "compilerProfileBindingHash"],
+        digest("06")],
+      [["preparationArtifact", "reviewedCompileInput", "compileInputHash"],
+        digest("07")],
+      [["preparationArtifact", "compilation", "compileInputHash"], digest("08")],
+      [["preparationArtifact", "compilation", "planHash"], digest("09")],
+      [["preparationArtifact", "compilation", "production"], false],
+      [["descriptor", "approvalBindingHash"], digest("0a")],
+      [["descriptor", "subjectHash"], digest("0b")],
+      [["descriptor", "routeNonce"], `0x${"11".repeat(32)}`],
+      [["preparationArtifact", "signatureRequest", "approval", "approvalBindingHash"],
+        digest("0c")],
+      [["preparationArtifact", "signatureRequest", "approval", "sourceRepositoryId"],
+        "1329073879"],
+      [["preparationArtifact", "signatureRequest", "approval", "sourceCommitSha"],
+        "4".repeat(40)],
+      [["preparationArtifact", "signatureRequest", "approval", "sourceTreeSha"],
+        "5".repeat(40)],
+      [["preparationArtifact", "signatureRequest", "approval", "claim", "planHash"],
+        digest("0d")],
+      [["preparationArtifact", "approvalClaim", "approvalRevision", "reviewArtifactHash"],
+        `0x${"13".repeat(32)}`],
+      [["preparationArtifact", "reviewedCompileInput", "submissionMetadata", "source", "repositoryId"],
+        "1329073879"],
+      [["preparationArtifact", "reviewedCompileInput", "submissionMetadata", "source", "commitSha"],
+        "6".repeat(40)],
+      [["preparationArtifact", "reviewedCompileInput", "submissionMetadata", "source", "treeSha"],
+        "7".repeat(40)],
+    ];
+    for (const [path, value] of mutations) {
+      const candidate = mutate(exact, path, value);
+      expect(
+        manualRouterClaimsShardsV1ArtifactV1(candidate),
+        path.join("."),
+      ).toBe(true);
+      expect(
+        manualRouterIsExactShardsV1ArtifactV1(candidate),
+        path.join("."),
+      ).toBe(false);
+    }
+  });
+
+  it("accepts only exact static pointer bindings before checking lineage", () => {
+    expect(manualRouterClaimsShardsV1PointerV1(ROOT_POINTER)).toBe(true);
+    expect(manualRouterIsExactShardsV1PointerV1(ROOT_POINTER)).toBe(true);
+    const mutations: readonly [readonly string[], unknown][] = [
+      [["subject", "approvedGitHubUserId"], "155705665"],
+      [["subject", "approvedLaunchWallet"],
+        "0xdeebb3a6543cebeb2ed66963897a0abea52a50cc"],
+      [["subject", "pullRequestNumber"], 7],
+      [["subject", "subjectHash"], digest("10")],
+      [["approvalBindingHash"], digest("11")],
+      [["headSha"], "2".repeat(40)],
+      [["treeSha"], "3".repeat(40)],
+      [["routeNonce"], `0x${"12".repeat(32)}`],
+    ];
+    for (const [path, value] of mutations) {
+      const candidate = mutate(ROOT_POINTER, path, value);
+      expect(
+        manualRouterClaimsShardsV1PointerV1(candidate),
+        path.join("."),
+      ).toBe(true);
+      expect(
+        manualRouterIsExactShardsV1PointerV1(candidate),
+        path.join("."),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("exact Shards Router V1 Website service bridge", () => {
+  it("serves the exact root and publishes only its CAS successor", async () => {
+    const { store } = memoryStore();
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+
+    await expect(service.listApplicantSubmissions({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+    })).resolves.toMatchObject({
+      schemaVersion: "programmable.manual-router-applicant-list-response.v1",
+      submissions: [{
+        subjectHash: EXACT.subjectHash,
+        pointerHash: EXACT.rootPointerHash,
+        status: "reissue-required",
+      }],
+    });
+    await expect(service.resolveApplicantSubmission({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+      subjectHash: EXACT.subjectHash,
+    })).resolves.toMatchObject({
+      schemaVersion: "programmable.manual-router-applicant-resolve-response.v1",
+      status: "reissue-required",
+      pointerHash: EXACT.rootPointerHash,
+    });
+    await expect(service.resolveOperatorReissueState({
+      schemaVersion: "programmable.manual-router-operator-reissue-state-request.v1",
+      previousSignedArtifact: shardsArtifact("root"),
+    })).resolves.toMatchObject({
+      disposition: "current",
+      status: "reissue-required",
+      currentPointer: { pointerHash: EXACT.rootPointerHash },
+    });
+
+    const successor = shardsArtifact("successor");
+    const wrongPredecessor = mutate(
+      successor,
+      ["descriptor", "reissueOf"],
+      digest("14"),
+    );
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: wrongPredecessor,
+    })).rejects.toMatchObject({
+      status: 503,
+      code: "route_capability_disabled",
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+    const published = await service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: successor,
+    });
+    expect(published).toMatchObject({
+      state: "signed-permit-available",
+      signedArtifactHash: successor.signedArtifactHash,
+      idempotent: false,
+    });
+    await expect(service.listApplicantSubmissions({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+    })).resolves.toMatchObject({
+      submissions: [{
+        pointerHash: published.pointerHash,
+        status: "ready",
+      }],
+    });
+  });
+
+  it("refreshes an unchanged exact Shards head ETag after verification", async () => {
+    const indexPath = manualRouterApplicantIndexPathV1({
+      approvedGitHubUserId: EXACT.approvedGitHubUserId,
+      approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    });
+    let immutableWrites = 0;
+    let rotateDuringImmutableWrites = false;
+    const { store } = memoryStore({
+      weakReadEtags: true,
+      beforePut(path, options, values) {
+        if (
+          rotateDuringImmutableWrites
+          && !options.allowOverwrite
+          && path !== indexPath
+          && ++immutableWrites === 3
+        ) {
+          const current = values.get(indexPath)!;
+          values.set(indexPath, { ...current, etag: `"${"f".repeat(32)}"` });
+        }
+      },
+    });
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+    const successor = shardsArtifact("successor");
+    rotateDuringImmutableWrites = true;
+
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: successor,
+    })).resolves.toMatchObject({
+      state: "signed-permit-available",
+      signedArtifactHash: successor.signedArtifactHash,
+      idempotent: false,
+    });
+  });
+
+  it("rejects semantic exact Shards head drift after verification", async () => {
+    const indexPath = manualRouterApplicantIndexPathV1({
+      approvedGitHubUserId: EXACT.approvedGitHubUserId,
+      approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    });
+    let immutableWrites = 0;
+    let driftDuringImmutableWrites: (() => Promise<void>) | null = null;
+    const { store } = memoryStore({
+      weakReadEtags: true,
+      async beforePut(path, options) {
+        if (
+          driftDuringImmutableWrites !== null
+          && !options.allowOverwrite
+          && path !== indexPath
+          && ++immutableWrites === 3
+        ) await driftDuringImmutableWrites();
+      },
+    });
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const successor = shardsArtifact("successor");
+    const nextPointer = pointerForArtifact(successor, EXACT.rootPointerHash);
+    const nextIndex = createManualRouterApplicantIndexV1({
+      previousIndex: ROOT_INDEX,
+      previousPointers: [ROOT_POINTER],
+      nextPointer,
+    }).index;
+    await store.putImmutable(
+      manualRouterContentPathV1("signed-artifacts", successor.signedArtifactHash),
+      successor,
+    );
+    await store.putImmutable(
+      manualRouterContentPathV1("pointer-history", nextPointer.pointerHash),
+      nextPointer,
+    );
+    driftDuringImmutableWrites = async () => {
+      const current = await store.read(indexPath);
+      await store.compareAndSwap(indexPath, current!.etag.slice(2), nextIndex);
+    };
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: successor,
+    })).rejects.toMatchObject({
+      status: 409,
+      code: "state_conflict",
+      retryable: false,
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+  });
+
+  it.each([
+    'W/"short"',
+    `W/"${"A".repeat(32)}"`,
+    `w/"${"a".repeat(32)}"`,
+    `"${"A".repeat(32)}"`,
+  ])("rejects a noncanonical exact Shards CAS ETag: %s", async (headEtag) => {
+    const { store } = memoryStore({ headEtag: () => headEtag });
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: shardsArtifact("successor"),
+    })).rejects.toMatchObject({
+      status: 409,
+      code: "state_conflict",
+      retryable: false,
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+  });
+
+  it("blocks every path for an exact-looking V1 head outside pointer40d8 lineage", async () => {
+    const { store, values } = memoryStore();
+    const orphanArtifact = shardsArtifact("successor");
+    const orphanPointer = pointerForArtifact(orphanArtifact, null);
+    const orphanIndex = createManualRouterApplicantIndexV1({
+      previousIndex: null,
+      previousPointers: [],
+      nextPointer: orphanPointer,
+    }).index;
+    await seedHead(store, orphanPointer, orphanIndex, orphanArtifact);
+    const before = new Map(values);
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+    const expected = {
+      status: 503,
+      code: "route_capability_disabled",
+    } satisfies Partial<ManualRouterServiceErrorV1>;
+    await expect(service.listApplicantSubmissions({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+    })).rejects.toMatchObject(expected);
+    await expect(service.resolveApplicantSubmission({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+      subjectHash: EXACT.subjectHash,
+    })).rejects.toMatchObject(expected);
+    await expect(service.resolveOperatorReissueState({
+      schemaVersion: "programmable.manual-router-operator-reissue-state-request.v1",
+      previousSignedArtifact: orphanArtifact,
+    })).rejects.toMatchObject(expected);
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: orphanPointer.pointerHash,
+      signedArtifact: shardsArtifact("next"),
+    })).rejects.toMatchObject(expected);
+    expect(values).toEqual(before);
+  });
+
+  it("rejects a stored successor whose reissueOf skips the predecessor request", async () => {
+    const { store } = memoryStore();
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const malformed = mutate(
+      shardsArtifact("successor"),
+      ["descriptor", "reissueOf"],
+      digest("15"),
+    );
+    const pointer = pointerForArtifact(malformed, EXACT.rootPointerHash);
+    const nextIndex = createManualRouterApplicantIndexV1({
+      previousIndex: ROOT_INDEX,
+      previousPointers: [ROOT_POINTER],
+      nextPointer: pointer,
+    }).index;
+    await store.putImmutable(
+      manualRouterContentPathV1("signed-artifacts", pointer.signedArtifactHash),
+      malformed,
+    );
+    await store.putImmutable(
+      manualRouterContentPathV1("pointer-history", pointer.pointerHash),
+      pointer,
+    );
+    const indexPath = manualRouterApplicantIndexPathV1({
+      approvedGitHubUserId: EXACT.approvedGitHubUserId,
+      approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    });
+    const current = await store.read(indexPath);
+    await store.compareAndSwap(indexPath, current!.etag, nextIndex);
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+    await expect(service.listApplicantSubmissions({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+    })).rejects.toMatchObject({
+      status: 503,
+      code: "route_capability_disabled",
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+  });
+
+  it("requires the pointer40d8 root artifact to have no predecessor", async () => {
+    const { store } = memoryStore();
+    const malformedRoot = mutate(
+      shardsArtifact("root"),
+      ["descriptor", "reissueOf"],
+      ROOT_POINTER.signatureRequestHash,
+    );
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, malformedRoot);
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+    await expect(service.resolveApplicantSubmission({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+      subjectHash: EXACT.subjectHash,
+    })).rejects.toMatchObject({
+      status: 503,
+      code: "route_capability_disabled",
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+  });
+});
+
+function shardsArtifact(
+  revision: "root" | "successor" | "next",
+): ManualRouterCompleteSignedArtifactViewV1 {
+  const sequence = revision === "root" ? "aa" : revision === "successor" ? "bb" : "cc";
+  const root = revision === "root";
+  const preparationArtifactHash = root
+    ? ROOT_POINTER.preparationArtifactHash
+    : digest(`${sequence}04`);
+  const signatureRequestHash = root
+    ? ROOT_POINTER.signatureRequestHash
+    : digest(`${sequence}02`);
+  const claim = Object.freeze({
+    schemaVersion: "programmable.github-router-launch-approval-claim.v3",
+    repositoryId: EXACT.repositoryId,
+    headRepositoryId: EXACT.headRepositoryId,
+    pullRequestNumber: EXACT.pullRequestNumber,
+    approvedGitHubUserId: EXACT.approvedGitHubUserId,
+    approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    headSha: EXACT.headSha,
+    treeSha: EXACT.treeSha,
+    compileInputHash: EXACT.compileInputHash,
+    planHash: EXACT.planHash,
+    approvalRevision: EXACT.approvalRevision,
+  });
+  return Object.freeze({
+    schemaVersion: "programmable.manual-router-complete-signed-artifact.v1",
+    signedArtifactHash: root ? EXACT.rootSignedArtifactHash : digest(sequence),
+    descriptor: Object.freeze({
+      schemaVersion: "programmable.manual-router-signed-artifact-descriptor.v1",
+      approvalBindingHash: EXACT.approvalBindingHash,
+      subjectHash: EXACT.subjectHash,
+      preparationArtifactHash,
+      descriptorHash: root ? ROOT_POINTER.signedDescriptorHash : digest(`${sequence}01`),
+      signatureRequestHash,
+      envelopeHash: digest(`${sequence}03`),
+      routeNonce: EXACT.routeNonce,
+      validAfter: root ? ROOT_POINTER.validAfter : "2000000000",
+      deadline: root ? ROOT_POINTER.deadline : "2000001000",
+      reissueOf: root ? null : ROOT_POINTER.signatureRequestHash,
+    }),
+    preparationArtifact: Object.freeze({
+      schemaVersion: "programmable.manual-router-authority-preparation-artifact.v1",
+      preparationArtifactHash,
+      subject: ROOT_POINTER.subject,
+      approvalClaim: claim,
+      reviewedCompileInput: Object.freeze({
+        schemaVersion:
+          "programmable.stored-router-custom-graph-reviewed-compile-input.v1",
+        applicationId: EXACT.applicationId,
+        applicationManifestSha256: EXACT.applicationManifestSha256,
+        sourceRevisionBindingHash: EXACT.sourceRevisionBindingHash,
+        compilerProfileBindingHash: EXACT.compilerProfileBindingHash,
+        compilerEvidenceDigest: EXACT.compilerEvidenceDigest,
+        compileInputHash: EXACT.compileInputHash,
+        submissionMetadata: Object.freeze({
+          applicant: Object.freeze({
+            githubLogin: EXACT.applicantGitHubLogin,
+            launchWallet: EXACT.approvedLaunchWallet,
+          }),
+          source: Object.freeze({
+            repositoryId: EXACT.sourceRepositoryId,
+            repositoryUrl: EXACT.sourceRepositoryUrl,
+            commitSha: EXACT.sourceCommitSha,
+            treeSha: EXACT.sourceTreeSha,
+          }),
+        }),
+      }),
+      compilation: Object.freeze({
+        schemaVersion: "programmable.router-custom-graph-compilation.v1",
+        compileInputHash: EXACT.compileInputHash,
+        planHash: EXACT.planHash,
+        production: true,
+      }),
+      signatureRequest: Object.freeze({
+        schemaVersion: "programmable.manual-github-router-signature-request.v1",
+        requestHash: signatureRequestHash,
+        compileInputHash: EXACT.compileInputHash,
+        planHash: EXACT.planHash,
+        approval: Object.freeze({
+          schemaVersion: "programmable.verified-github-router-launch-approval.v6",
+          approvalBindingHash: EXACT.approvalBindingHash,
+          claim,
+          pullRequestAuthorGitHubLogin: EXACT.applicantGitHubLogin,
+          pullRequestAuthorGitHubUserId: EXACT.approvedGitHubUserId,
+          pullRequestHeadRepositoryUrl:
+            "https://github.com/jesse-stahl/hookbuilder",
+          pullRequestState: "merged",
+          sourceRepositoryId: EXACT.sourceRepositoryId,
+          sourceRepositoryUrl: EXACT.sourceRepositoryUrl,
+          sourceCommitSha: EXACT.sourceCommitSha,
+          sourceTreeSha: EXACT.sourceTreeSha,
+          verifiedAtEpochSeconds: "2000000000",
+        }),
+      }),
+    }),
+    prepared: Object.freeze({
+      preparationHash: digest(`${sequence}05`),
+      launchWallet: EXACT.approvedLaunchWallet,
+      expectedLaunchId: `0x${"11".repeat(32)}` as const,
+      expectedPoolId: `0x${"22".repeat(32)}` as const,
+      expectedComponents: Object.freeze([]),
+      browserAction: Object.freeze({
+        params: Object.freeze([Object.freeze({
+          from: EXACT.approvedLaunchWallet,
+          to: "0x3cc7c9A9AB12c36658968Cf4A3e10fCf9f10eF0a" as const,
+          data: "0x1234" as const,
+          value: "0x0" as const,
+        })]) as unknown as ManualRouterCompleteSignedArtifactViewV1["prepared"]["browserAction"]["params"],
+      }),
+    }),
+  }) as unknown as ManualRouterCompleteSignedArtifactViewV1;
+}
+
+function pointerForArtifact(
+  artifact: ManualRouterCompleteSignedArtifactViewV1,
+  previousPointerHash: Sha256Digest | null,
+): ManualRouterApplicantPointerV1 {
+  return createManualRouterSignedPointerV1({
+    artifact: {
+      subject: ROOT_POINTER.subject,
+      approvalBindingHash: EXACT.approvalBindingHash,
+      headSha: EXACT.headSha,
+      treeSha: EXACT.treeSha,
+      routeNonce: EXACT.routeNonce,
+      preparationArtifactHash:
+        artifact.preparationArtifact.preparationArtifactHash,
+      signatureRequestHash: artifact.descriptor.signatureRequestHash,
+      descriptorHash: artifact.descriptor.descriptorHash,
+      signedArtifactHash: artifact.signedArtifactHash,
+      validAfter: artifact.descriptor.validAfter,
+      deadline: artifact.descriptor.deadline,
+      reissueOf: artifact.descriptor.reissueOf,
+    },
+    previousPointerHash,
+    updatedAtEpochSeconds: "2000000001",
+  });
+}
+
+function shardsAuthority(): ManualRouterWebsiteAuthorityV1 {
+  return Object.freeze({
+    assertCompleteSignedArtifact(raw: unknown) {
+      return raw as ManualRouterCompleteSignedArtifactViewV1;
+    },
+    async verifySignedPublish(input: Parameters<
+      ManualRouterWebsiteAuthorityV1["verifySignedPublish"]
+    >[0]) {
+      const request = input.request as Readonly<{
+        expectedPreviousPointerHash: Sha256Digest | null;
+        signedArtifact: ManualRouterCompleteSignedArtifactViewV1;
+      }>;
+      const pointer = pointerForArtifact(
+        request.signedArtifact,
+        request.expectedPreviousPointerHash,
+      );
+      const next = createManualRouterApplicantIndexV1({
+        previousIndex: input.currentApplicantIndex as ManualRouterApplicantIndexV1,
+        previousPointers: input.currentApplicantPointers as
+          readonly ManualRouterApplicantPointerV1[],
+        nextPointer: pointer,
+      });
+      return Object.freeze({
+        request,
+        nextPointer: pointer,
+        nextApplicantIndex: next.index,
+        idempotent: next.idempotent,
+      });
+    },
+    async readChainClock() {
+      return Object.freeze({
+        minimumTimestamp: "2000000001",
+        maximumTimestamp: "2000000001",
+        commonFinalizedTimestamp: "2000000000",
+        commonFinalizedBlockNumber: "1",
+        commonFinalizedBlockHash: `0x${"ab".repeat(32)}` as const,
+      });
+    },
+    async observeExactTransaction() {},
+    async resolveReissueState(input: Parameters<
+      ManualRouterWebsiteAuthorityV1["resolveReissueState"]
+    >[0]) {
+      const request = input.request as Readonly<{
+        previousSignedArtifact: ManualRouterCompleteSignedArtifactViewV1;
+      }>;
+      const current = input.currentApplicantPointers.find((pointer) =>
+        pointer.subject.subjectHash
+          === request.previousSignedArtifact.preparationArtifact.subject.subjectHash);
+      if (current?.signedArtifactHash
+        !== request.previousSignedArtifact.signedArtifactHash) {
+        return Object.freeze({
+          schemaVersion: "programmable.manual-router-operator-reissue-state-response.v1",
+          disposition: "stale",
+          code: "stale_previous_artifact",
+        });
+      }
+      return Object.freeze({
+        schemaVersion: "programmable.manual-router-operator-reissue-state-response.v1",
+        disposition: "current",
+        status: input.currentStatus,
+        currentPointer: current,
+        currentApplicantIndex: input.currentApplicantIndex,
+      });
+    },
+  });
+}
+
+async function seedHead(
+  store: ManualRouterPrivateBlobStoreV1,
+  pointer: ManualRouterApplicantPointerV1,
+  index: ManualRouterApplicantIndexV1,
+  artifact: ManualRouterCompleteSignedArtifactViewV1,
+): Promise<void> {
+  await store.putImmutable(
+    manualRouterContentPathV1("signed-artifacts", pointer.signedArtifactHash),
+    artifact,
+  );
+  await store.putImmutable(
+    manualRouterContentPathV1("pointer-history", pointer.pointerHash),
+    pointer,
+  );
+  await store.compareAndSwap(manualRouterApplicantIndexPathV1({
+    approvedGitHubUserId: EXACT.approvedGitHubUserId,
+    approvedLaunchWallet: EXACT.approvedLaunchWallet,
+  }), null, index);
+}
+
+function digest(seed: string): Sha256Digest {
+  return `sha256:${seed.padEnd(64, seed.slice(-1)).slice(0, 64)}` as Sha256Digest;
+}
+
+function mutate<T>(source: T, path: readonly string[], value: unknown): T {
+  const cloned = structuredClone(source) as Record<string, unknown>;
+  let cursor = cloned;
+  for (const key of path.slice(0, -1)) {
+    cursor = cursor[key] as Record<string, unknown>;
+  }
+  cursor[path.at(-1)!] = value;
+  return cloned as T;
+}
+
+function memoryStore(hooks: Readonly<{
+  weakReadEtags?: boolean;
+  readEtag?: (strongEtag: string) => string;
+  headEtag?: (strongEtag: string) => string;
+  beforePut?: (
+    path: string,
+    options: Readonly<{ allowOverwrite: boolean; ifMatch?: string }>,
+    values: Map<string, { body: string; etag: string }>,
+  ) => void | Promise<void>;
+}> = {}) {
+  const values = new Map<string, { body: string; etag: string }>();
+  let version = 0;
+  return {
+    values,
+    store: new ManualRouterPrivateBlobStoreV1({
+      async get(path) {
+        const value = values.get(path);
+        return value
+          ? {
+              statusCode: 200,
+              etag: hooks.readEtag?.(value.etag)
+                ?? (hooks.weakReadEtags ? `W/${value.etag}` : value.etag),
+              body: value.body,
+            }
+          : { statusCode: 404, etag: null, body: null };
+      },
+      async head(path) {
+        const value = values.get(path);
+        if (!value) throw new TypeError("missing Blob metadata");
+        return { etag: hooks.headEtag?.(value.etag) ?? value.etag };
+      },
+      async put(path, body, options) {
+        await hooks.beforePut?.(path, options, values);
+        const current = values.get(path);
+        if (
+          (!options.allowOverwrite && current)
+          || (options.ifMatch !== undefined && current?.etag !== options.ifMatch)
+        ) {
+          const error = new Error("conflict");
+          error.name = "BlobPreconditionFailedError";
+          throw error;
+        }
+        version += 1;
+        const etag = `"${version.toString(16).padStart(32, "0")}"`;
+        values.set(path, { body, etag });
+        return { etag };
+      },
+      async list({ prefix }) {
+        return {
+          paths: [...values.keys()].filter((path) => path.startsWith(prefix)),
+          cursor: null,
+          hasMore: false,
+        };
+      },
+      isPreconditionFailure(error) {
+        return error instanceof Error
+          && error.name === "BlobPreconditionFailedError";
+      },
+    }),
+  };
+}

--- a/tests/manual-router-shards-v1-compat.test.ts
+++ b/tests/manual-router-shards-v1-compat.test.ts
@@ -252,28 +252,33 @@ describe("exact Shards Router V1 Website service bridge", () => {
   });
 
   it("refreshes an unchanged exact Shards head ETag after verification", async () => {
-    const { store, values } = memoryStore();
-    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
     const indexPath = manualRouterApplicantIndexPathV1({
       approvedGitHubUserId: EXACT.approvedGitHubUserId,
       approvedLaunchWallet: EXACT.approvedLaunchWallet,
     });
-    const baseAuthority = shardsAuthority();
+    let immutableWrites = 0;
+    let rotateDuringImmutableWrites = false;
+    const { store } = memoryStore({
+      weakReadEtags: true,
+      beforePut(path, options, values) {
+        if (
+          rotateDuringImmutableWrites
+          && !options.allowOverwrite
+          && path !== indexPath
+          && ++immutableWrites === 3
+        ) {
+          const current = values.get(indexPath)!;
+          values.set(indexPath, { ...current, etag: `"${"f".repeat(32)}"` });
+        }
+      },
+    });
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
     const service = new ManualRouterWebsiteServiceV1({
       store,
-      authority: Object.freeze({
-        ...baseAuthority,
-        async verifySignedPublish(input: Parameters<
-          ManualRouterWebsiteAuthorityV1["verifySignedPublish"]
-        >[0]) {
-          const verified = await baseAuthority.verifySignedPublish(input);
-          const current = values.get(indexPath)!;
-          values.set(indexPath, { ...current, etag: "etag-external-same-head" });
-          return verified;
-        },
-      }),
+      authority: shardsAuthority(),
     });
     const successor = shardsArtifact("successor");
+    rotateDuringImmutableWrites = true;
 
     await expect(service.publishSignedArtifact({
       schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
@@ -287,43 +292,76 @@ describe("exact Shards Router V1 Website service bridge", () => {
   });
 
   it("rejects semantic exact Shards head drift after verification", async () => {
-    const { store } = memoryStore();
-    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
     const indexPath = manualRouterApplicantIndexPathV1({
       approvedGitHubUserId: EXACT.approvedGitHubUserId,
       approvedLaunchWallet: EXACT.approvedLaunchWallet,
     });
-    const baseAuthority = shardsAuthority();
+    let immutableWrites = 0;
+    let driftDuringImmutableWrites: (() => Promise<void>) | null = null;
+    const { store } = memoryStore({
+      weakReadEtags: true,
+      async beforePut(path, options) {
+        if (
+          driftDuringImmutableWrites !== null
+          && !options.allowOverwrite
+          && path !== indexPath
+          && ++immutableWrites === 3
+        ) await driftDuringImmutableWrites();
+      },
+    });
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
     const successor = shardsArtifact("successor");
+    const nextPointer = pointerForArtifact(successor, EXACT.rootPointerHash);
+    const nextIndex = createManualRouterApplicantIndexV1({
+      previousIndex: ROOT_INDEX,
+      previousPointers: [ROOT_POINTER],
+      nextPointer,
+    }).index;
+    await store.putImmutable(
+      manualRouterContentPathV1("signed-artifacts", successor.signedArtifactHash),
+      successor,
+    );
+    await store.putImmutable(
+      manualRouterContentPathV1("pointer-history", nextPointer.pointerHash),
+      nextPointer,
+    );
+    driftDuringImmutableWrites = async () => {
+      const current = await store.read(indexPath);
+      await store.compareAndSwap(indexPath, current!.etag.slice(2), nextIndex);
+    };
     const service = new ManualRouterWebsiteServiceV1({
       store,
-      authority: Object.freeze({
-        ...baseAuthority,
-        async verifySignedPublish(input: Parameters<
-          ManualRouterWebsiteAuthorityV1["verifySignedPublish"]
-        >[0]) {
-          const verified = await baseAuthority.verifySignedPublish(input);
-          const nextPointer = verified.nextPointer as ManualRouterApplicantPointerV1;
-          const nextIndex = verified.nextApplicantIndex as ManualRouterApplicantIndexV1;
-          await store.putImmutable(
-            manualRouterContentPathV1("signed-artifacts", successor.signedArtifactHash),
-            successor,
-          );
-          await store.putImmutable(
-            manualRouterContentPathV1("pointer-history", nextPointer.pointerHash),
-            nextPointer,
-          );
-          const current = await store.read(indexPath);
-          await store.compareAndSwap(indexPath, current!.etag, nextIndex);
-          return verified;
-        },
-      }),
+      authority: shardsAuthority(),
     });
 
     await expect(service.publishSignedArtifact({
       schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
       expectedPreviousPointerHash: EXACT.rootPointerHash,
       signedArtifact: successor,
+    })).rejects.toMatchObject({
+      status: 409,
+      code: "state_conflict",
+      retryable: false,
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+  });
+
+  it.each([
+    'W/"short"',
+    `W/"${"A".repeat(32)}"`,
+    `w/"${"a".repeat(32)}"`,
+    `"${"A".repeat(32)}"`,
+  ])("rejects a noncanonical exact Shards CAS ETag: %s", async (readEtag) => {
+    const { store } = memoryStore({ readEtag: () => readEtag });
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: shardsArtifact("successor"),
     })).rejects.toMatchObject({
       status: 409,
       code: "state_conflict",
@@ -674,7 +712,15 @@ function mutate<T>(source: T, path: readonly string[], value: unknown): T {
   return cloned as T;
 }
 
-function memoryStore() {
+function memoryStore(hooks: Readonly<{
+  weakReadEtags?: boolean;
+  readEtag?: (strongEtag: string) => string;
+  beforePut?: (
+    path: string,
+    options: Readonly<{ allowOverwrite: boolean; ifMatch?: string }>,
+    values: Map<string, { body: string; etag: string }>,
+  ) => void | Promise<void>;
+}> = {}) {
   const values = new Map<string, { body: string; etag: string }>();
   let version = 0;
   return {
@@ -683,10 +729,16 @@ function memoryStore() {
       async get(path) {
         const value = values.get(path);
         return value
-          ? { statusCode: 200, etag: value.etag, body: value.body }
+          ? {
+              statusCode: 200,
+              etag: hooks.readEtag?.(value.etag)
+                ?? (hooks.weakReadEtags ? `W/${value.etag}` : value.etag),
+              body: value.body,
+            }
           : { statusCode: 404, etag: null, body: null };
       },
       async put(path, body, options) {
+        await hooks.beforePut?.(path, options, values);
         const current = values.get(path);
         if (
           (!options.allowOverwrite && current)
@@ -697,7 +749,7 @@ function memoryStore() {
           throw error;
         }
         version += 1;
-        const etag = `etag-${version}`;
+        const etag = `"${version.toString(16).padStart(32, "0")}"`;
         values.set(path, { body, etag });
         return { etag };
       },

--- a/tests/manual-router-shards-v1-compat.test.ts
+++ b/tests/manual-router-shards-v1-compat.test.ts
@@ -1,0 +1,637 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1,
+  manualRouterClaimsShardsV1ArtifactV1,
+  manualRouterClaimsShardsV1PointerV1,
+  manualRouterIsExactShardsV1ArtifactV1,
+  manualRouterIsExactShardsV1PointerV1,
+} from "../lib/server/custom-launch/manual-router-shards-v1-compat-v1";
+import {
+  createManualRouterApplicantIndexV1,
+  createManualRouterSignedPointerV1,
+  type ManualRouterApplicantIndexV1,
+  type ManualRouterApplicantPointerV1,
+} from "../lib/server/custom-launch/manual-router-state-v1";
+import {
+  ManualRouterServiceErrorV1,
+  ManualRouterWebsiteServiceV1,
+  type ManualRouterCompleteSignedArtifactViewV1,
+  type ManualRouterWebsiteAuthorityV1,
+} from "../lib/server/custom-launch/manual-router-service-v1";
+import {
+  ManualRouterPrivateBlobStoreV1,
+  manualRouterApplicantIndexPathV1,
+  manualRouterContentPathV1,
+} from "../lib/server/custom-launch/manual-router-store-v1";
+import type { Sha256Digest } from
+  "../lib/server/projection-target/hashing";
+
+const EXACT = MANUAL_ROUTER_SHARDS_V1_COMPATIBILITY_V1;
+const ROOT_POINTER = Object.freeze({
+  schemaVersion: "programmable.manual-router-applicant-pointer.v1" as const,
+  subject: Object.freeze({
+    schemaVersion: "programmable.manual-router-applicant-subject.v1" as const,
+    repositoryId: "1320085947" as const,
+    pullRequestNumber: EXACT.pullRequestNumber,
+    approvedGitHubUserId: EXACT.approvedGitHubUserId,
+    approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    subjectHash: EXACT.subjectHash,
+  }),
+  state: "signed-permit-available" as const,
+  approvalBindingHash: EXACT.approvalBindingHash,
+  headSha: EXACT.headSha,
+  treeSha: EXACT.treeSha,
+  routeNonce: EXACT.routeNonce,
+  preparationArtifactHash:
+    "sha256:820bd4e0bde3acb35152678ab63c97350ca36b11d923a4e9dccb5a78451076f2",
+  signatureRequestHash:
+    "sha256:487707d489f6c4928d1665cae734aeaffcc818140c045077a45b5786fb1d2c40",
+  signedDescriptorHash:
+    "sha256:3f85b32256882bb02e5d3286c0366e1c2fb8e0376de455e35805d3b01e5d976e",
+  signedArtifactHash: EXACT.rootSignedArtifactHash,
+  validAfter: "1786373204",
+  deadline: "1786375919",
+  submittedTransactionHash: null,
+  failedTransactionEvidenceHash: null,
+  finalizedProofHash: null,
+  previousPointerHash: null,
+  updatedAtEpochSeconds: "1786375463",
+  pointerHash: EXACT.rootPointerHash,
+} satisfies ManualRouterApplicantPointerV1);
+
+const ROOT_INDEX = Object.freeze({
+  schemaVersion: "programmable.manual-router-applicant-index.v1" as const,
+  approvedGitHubUserId: EXACT.approvedGitHubUserId,
+  approvedLaunchWallet: EXACT.approvedLaunchWallet,
+  entries: Object.freeze([Object.freeze({
+    subjectHash: EXACT.subjectHash,
+    pointerHash: EXACT.rootPointerHash,
+    pullRequestNumber: EXACT.pullRequestNumber,
+    approvalBindingHash: EXACT.approvalBindingHash,
+    headSha: EXACT.headSha,
+    treeSha: EXACT.treeSha,
+    routeNonce: EXACT.routeNonce,
+    state: "signed-permit-available" as const,
+    signedArtifactHash: EXACT.rootSignedArtifactHash,
+    validAfter: ROOT_POINTER.validAfter,
+    deadline: ROOT_POINTER.deadline,
+    submittedTransactionHash: null,
+    failedTransactionEvidenceHash: null,
+  })]),
+  previousIndexHash: null,
+  indexHash:
+    "sha256:5beb2166983f0530bde7249343a4887704657b8b076bed8736ffef821ddce230",
+} satisfies ManualRouterApplicantIndexV1);
+
+describe("exact Shards Router V1 compatibility identity", () => {
+  it("accepts only the frozen Applicant, source, compile, plan, and route tuple", () => {
+    const exact = shardsArtifact("root");
+    expect(manualRouterClaimsShardsV1ArtifactV1(exact)).toBe(true);
+    expect(manualRouterIsExactShardsV1ArtifactV1(exact)).toBe(true);
+
+    const mutations: readonly [readonly string[], unknown][] = [
+      [["preparationArtifact", "subject", "approvedGitHubUserId"], "155705665"],
+      [["preparationArtifact", "subject", "approvedLaunchWallet"],
+        "0xdeebb3a6543cebeb2ed66963897a0abea52a50cc"],
+      [["preparationArtifact", "subject", "pullRequestNumber"], 7],
+      [["preparationArtifact", "subject", "subjectHash"], digest("01")],
+      [["preparationArtifact", "approvalClaim", "headRepositoryId"], "1329074394"],
+      [["preparationArtifact", "approvalClaim", "headSha"], "2".repeat(40)],
+      [["preparationArtifact", "approvalClaim", "treeSha"], "3".repeat(40)],
+      [["preparationArtifact", "approvalClaim", "compileInputHash"], digest("02")],
+      [["preparationArtifact", "approvalClaim", "planHash"], digest("03")],
+      [["preparationArtifact", "reviewedCompileInput", "applicationId"], "other"],
+      [["preparationArtifact", "reviewedCompileInput", "applicationManifestSha256"],
+        digest("04")],
+      [["preparationArtifact", "reviewedCompileInput", "sourceRevisionBindingHash"],
+        digest("05")],
+      [["preparationArtifact", "reviewedCompileInput", "compilerProfileBindingHash"],
+        digest("06")],
+      [["preparationArtifact", "reviewedCompileInput", "compileInputHash"],
+        digest("07")],
+      [["preparationArtifact", "compilation", "compileInputHash"], digest("08")],
+      [["preparationArtifact", "compilation", "planHash"], digest("09")],
+      [["preparationArtifact", "compilation", "production"], false],
+      [["descriptor", "approvalBindingHash"], digest("0a")],
+      [["descriptor", "subjectHash"], digest("0b")],
+      [["descriptor", "routeNonce"], `0x${"11".repeat(32)}`],
+      [["preparationArtifact", "signatureRequest", "approval", "approvalBindingHash"],
+        digest("0c")],
+      [["preparationArtifact", "signatureRequest", "approval", "sourceRepositoryId"],
+        "1329073879"],
+      [["preparationArtifact", "signatureRequest", "approval", "sourceCommitSha"],
+        "4".repeat(40)],
+      [["preparationArtifact", "signatureRequest", "approval", "sourceTreeSha"],
+        "5".repeat(40)],
+      [["preparationArtifact", "signatureRequest", "approval", "claim", "planHash"],
+        digest("0d")],
+      [["preparationArtifact", "approvalClaim", "approvalRevision", "reviewArtifactHash"],
+        `0x${"13".repeat(32)}`],
+      [["preparationArtifact", "reviewedCompileInput", "submissionMetadata", "source", "repositoryId"],
+        "1329073879"],
+      [["preparationArtifact", "reviewedCompileInput", "submissionMetadata", "source", "commitSha"],
+        "6".repeat(40)],
+      [["preparationArtifact", "reviewedCompileInput", "submissionMetadata", "source", "treeSha"],
+        "7".repeat(40)],
+    ];
+    for (const [path, value] of mutations) {
+      const candidate = mutate(exact, path, value);
+      expect(
+        manualRouterClaimsShardsV1ArtifactV1(candidate),
+        path.join("."),
+      ).toBe(true);
+      expect(
+        manualRouterIsExactShardsV1ArtifactV1(candidate),
+        path.join("."),
+      ).toBe(false);
+    }
+  });
+
+  it("accepts only exact static pointer bindings before checking lineage", () => {
+    expect(manualRouterClaimsShardsV1PointerV1(ROOT_POINTER)).toBe(true);
+    expect(manualRouterIsExactShardsV1PointerV1(ROOT_POINTER)).toBe(true);
+    const mutations: readonly [readonly string[], unknown][] = [
+      [["subject", "approvedGitHubUserId"], "155705665"],
+      [["subject", "approvedLaunchWallet"],
+        "0xdeebb3a6543cebeb2ed66963897a0abea52a50cc"],
+      [["subject", "pullRequestNumber"], 7],
+      [["subject", "subjectHash"], digest("10")],
+      [["approvalBindingHash"], digest("11")],
+      [["headSha"], "2".repeat(40)],
+      [["treeSha"], "3".repeat(40)],
+      [["routeNonce"], `0x${"12".repeat(32)}`],
+    ];
+    for (const [path, value] of mutations) {
+      const candidate = mutate(ROOT_POINTER, path, value);
+      expect(
+        manualRouterClaimsShardsV1PointerV1(candidate),
+        path.join("."),
+      ).toBe(true);
+      expect(
+        manualRouterIsExactShardsV1PointerV1(candidate),
+        path.join("."),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("exact Shards Router V1 Website service bridge", () => {
+  it("serves the exact root and publishes only its CAS successor", async () => {
+    const { store } = memoryStore();
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+
+    await expect(service.listApplicantSubmissions({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+    })).resolves.toMatchObject({
+      schemaVersion: "programmable.manual-router-applicant-list-response.v1",
+      submissions: [{
+        subjectHash: EXACT.subjectHash,
+        pointerHash: EXACT.rootPointerHash,
+        status: "reissue-required",
+      }],
+    });
+    await expect(service.resolveApplicantSubmission({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+      subjectHash: EXACT.subjectHash,
+    })).resolves.toMatchObject({
+      schemaVersion: "programmable.manual-router-applicant-resolve-response.v1",
+      status: "reissue-required",
+      pointerHash: EXACT.rootPointerHash,
+    });
+    await expect(service.resolveOperatorReissueState({
+      schemaVersion: "programmable.manual-router-operator-reissue-state-request.v1",
+      previousSignedArtifact: shardsArtifact("root"),
+    })).resolves.toMatchObject({
+      disposition: "current",
+      status: "reissue-required",
+      currentPointer: { pointerHash: EXACT.rootPointerHash },
+    });
+
+    const successor = shardsArtifact("successor");
+    const wrongPredecessor = mutate(
+      successor,
+      ["descriptor", "reissueOf"],
+      digest("14"),
+    );
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: wrongPredecessor,
+    })).rejects.toMatchObject({
+      status: 503,
+      code: "route_capability_disabled",
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+    const published = await service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: EXACT.rootPointerHash,
+      signedArtifact: successor,
+    });
+    expect(published).toMatchObject({
+      state: "signed-permit-available",
+      signedArtifactHash: successor.signedArtifactHash,
+      idempotent: false,
+    });
+    await expect(service.listApplicantSubmissions({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+    })).resolves.toMatchObject({
+      submissions: [{
+        pointerHash: published.pointerHash,
+        status: "ready",
+      }],
+    });
+  });
+
+  it("blocks every path for an exact-looking V1 head outside pointer40d8 lineage", async () => {
+    const { store, values } = memoryStore();
+    const orphanArtifact = shardsArtifact("successor");
+    const orphanPointer = pointerForArtifact(orphanArtifact, null);
+    const orphanIndex = createManualRouterApplicantIndexV1({
+      previousIndex: null,
+      previousPointers: [],
+      nextPointer: orphanPointer,
+    }).index;
+    await seedHead(store, orphanPointer, orphanIndex, orphanArtifact);
+    const before = new Map(values);
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+    const expected = {
+      status: 503,
+      code: "route_capability_disabled",
+    } satisfies Partial<ManualRouterServiceErrorV1>;
+    await expect(service.listApplicantSubmissions({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+    })).rejects.toMatchObject(expected);
+    await expect(service.resolveApplicantSubmission({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+      subjectHash: EXACT.subjectHash,
+    })).rejects.toMatchObject(expected);
+    await expect(service.resolveOperatorReissueState({
+      schemaVersion: "programmable.manual-router-operator-reissue-state-request.v1",
+      previousSignedArtifact: orphanArtifact,
+    })).rejects.toMatchObject(expected);
+    await expect(service.publishSignedArtifact({
+      schemaVersion: "programmable.manual-router-signed-artifact-publish-request.v1",
+      expectedPreviousPointerHash: orphanPointer.pointerHash,
+      signedArtifact: shardsArtifact("next"),
+    })).rejects.toMatchObject(expected);
+    expect(values).toEqual(before);
+  });
+
+  it("rejects a stored successor whose reissueOf skips the predecessor request", async () => {
+    const { store } = memoryStore();
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
+    const malformed = mutate(
+      shardsArtifact("successor"),
+      ["descriptor", "reissueOf"],
+      digest("15"),
+    );
+    const pointer = pointerForArtifact(malformed, EXACT.rootPointerHash);
+    const nextIndex = createManualRouterApplicantIndexV1({
+      previousIndex: ROOT_INDEX,
+      previousPointers: [ROOT_POINTER],
+      nextPointer: pointer,
+    }).index;
+    await store.putImmutable(
+      manualRouterContentPathV1("signed-artifacts", pointer.signedArtifactHash),
+      malformed,
+    );
+    await store.putImmutable(
+      manualRouterContentPathV1("pointer-history", pointer.pointerHash),
+      pointer,
+    );
+    const indexPath = manualRouterApplicantIndexPathV1({
+      approvedGitHubUserId: EXACT.approvedGitHubUserId,
+      approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    });
+    const current = await store.read(indexPath);
+    await store.compareAndSwap(indexPath, current!.etag, nextIndex);
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+    await expect(service.listApplicantSubmissions({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+    })).rejects.toMatchObject({
+      status: 503,
+      code: "route_capability_disabled",
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+  });
+
+  it("requires the pointer40d8 root artifact to have no predecessor", async () => {
+    const { store } = memoryStore();
+    const malformedRoot = mutate(
+      shardsArtifact("root"),
+      ["descriptor", "reissueOf"],
+      ROOT_POINTER.signatureRequestHash,
+    );
+    await seedHead(store, ROOT_POINTER, ROOT_INDEX, malformedRoot);
+    const service = new ManualRouterWebsiteServiceV1({
+      store,
+      authority: shardsAuthority(),
+    });
+    await expect(service.resolveApplicantSubmission({
+      githubUserId: EXACT.approvedGitHubUserId,
+      launchWallet: EXACT.approvedLaunchWallet,
+      subjectHash: EXACT.subjectHash,
+    })).rejects.toMatchObject({
+      status: 503,
+      code: "route_capability_disabled",
+    } satisfies Partial<ManualRouterServiceErrorV1>);
+  });
+});
+
+function shardsArtifact(
+  revision: "root" | "successor" | "next",
+): ManualRouterCompleteSignedArtifactViewV1 {
+  const sequence = revision === "root" ? "aa" : revision === "successor" ? "bb" : "cc";
+  const root = revision === "root";
+  const preparationArtifactHash = root
+    ? ROOT_POINTER.preparationArtifactHash
+    : digest(`${sequence}04`);
+  const signatureRequestHash = root
+    ? ROOT_POINTER.signatureRequestHash
+    : digest(`${sequence}02`);
+  const claim = Object.freeze({
+    schemaVersion: "programmable.github-router-launch-approval-claim.v3",
+    repositoryId: EXACT.repositoryId,
+    headRepositoryId: EXACT.headRepositoryId,
+    pullRequestNumber: EXACT.pullRequestNumber,
+    approvedGitHubUserId: EXACT.approvedGitHubUserId,
+    approvedLaunchWallet: EXACT.approvedLaunchWallet,
+    headSha: EXACT.headSha,
+    treeSha: EXACT.treeSha,
+    compileInputHash: EXACT.compileInputHash,
+    planHash: EXACT.planHash,
+    approvalRevision: EXACT.approvalRevision,
+  });
+  return Object.freeze({
+    schemaVersion: "programmable.manual-router-complete-signed-artifact.v1",
+    signedArtifactHash: root ? EXACT.rootSignedArtifactHash : digest(sequence),
+    descriptor: Object.freeze({
+      schemaVersion: "programmable.manual-router-signed-artifact-descriptor.v1",
+      approvalBindingHash: EXACT.approvalBindingHash,
+      subjectHash: EXACT.subjectHash,
+      preparationArtifactHash,
+      descriptorHash: root ? ROOT_POINTER.signedDescriptorHash : digest(`${sequence}01`),
+      signatureRequestHash,
+      envelopeHash: digest(`${sequence}03`),
+      routeNonce: EXACT.routeNonce,
+      validAfter: root ? ROOT_POINTER.validAfter : "2000000000",
+      deadline: root ? ROOT_POINTER.deadline : "2000001000",
+      reissueOf: root ? null : ROOT_POINTER.signatureRequestHash,
+    }),
+    preparationArtifact: Object.freeze({
+      schemaVersion: "programmable.manual-router-authority-preparation-artifact.v1",
+      preparationArtifactHash,
+      subject: ROOT_POINTER.subject,
+      approvalClaim: claim,
+      reviewedCompileInput: Object.freeze({
+        schemaVersion:
+          "programmable.stored-router-custom-graph-reviewed-compile-input.v1",
+        applicationId: EXACT.applicationId,
+        applicationManifestSha256: EXACT.applicationManifestSha256,
+        sourceRevisionBindingHash: EXACT.sourceRevisionBindingHash,
+        compilerProfileBindingHash: EXACT.compilerProfileBindingHash,
+        compilerEvidenceDigest: EXACT.compilerEvidenceDigest,
+        compileInputHash: EXACT.compileInputHash,
+        submissionMetadata: Object.freeze({
+          applicant: Object.freeze({
+            githubLogin: EXACT.applicantGitHubLogin,
+            launchWallet: EXACT.approvedLaunchWallet,
+          }),
+          source: Object.freeze({
+            repositoryId: EXACT.sourceRepositoryId,
+            repositoryUrl: EXACT.sourceRepositoryUrl,
+            commitSha: EXACT.sourceCommitSha,
+            treeSha: EXACT.sourceTreeSha,
+          }),
+        }),
+      }),
+      compilation: Object.freeze({
+        schemaVersion: "programmable.router-custom-graph-compilation.v1",
+        compileInputHash: EXACT.compileInputHash,
+        planHash: EXACT.planHash,
+        production: true,
+      }),
+      signatureRequest: Object.freeze({
+        schemaVersion: "programmable.manual-github-router-signature-request.v1",
+        requestHash: signatureRequestHash,
+        compileInputHash: EXACT.compileInputHash,
+        planHash: EXACT.planHash,
+        approval: Object.freeze({
+          schemaVersion: "programmable.verified-github-router-launch-approval.v6",
+          approvalBindingHash: EXACT.approvalBindingHash,
+          claim,
+          pullRequestAuthorGitHubLogin: EXACT.applicantGitHubLogin,
+          pullRequestAuthorGitHubUserId: EXACT.approvedGitHubUserId,
+          pullRequestHeadRepositoryUrl:
+            "https://github.com/jesse-stahl/hookbuilder",
+          pullRequestState: "merged",
+          sourceRepositoryId: EXACT.sourceRepositoryId,
+          sourceRepositoryUrl: EXACT.sourceRepositoryUrl,
+          sourceCommitSha: EXACT.sourceCommitSha,
+          sourceTreeSha: EXACT.sourceTreeSha,
+          verifiedAtEpochSeconds: "2000000000",
+        }),
+      }),
+    }),
+    prepared: Object.freeze({
+      preparationHash: digest(`${sequence}05`),
+      launchWallet: EXACT.approvedLaunchWallet,
+      expectedLaunchId: `0x${"11".repeat(32)}` as const,
+      expectedPoolId: `0x${"22".repeat(32)}` as const,
+      expectedComponents: Object.freeze([]),
+      browserAction: Object.freeze({
+        params: Object.freeze([Object.freeze({
+          from: EXACT.approvedLaunchWallet,
+          to: "0x3cc7c9A9AB12c36658968Cf4A3e10fCf9f10eF0a" as const,
+          data: "0x1234" as const,
+          value: "0x0" as const,
+        })]) as unknown as ManualRouterCompleteSignedArtifactViewV1["prepared"]["browserAction"]["params"],
+      }),
+    }),
+  }) as unknown as ManualRouterCompleteSignedArtifactViewV1;
+}
+
+function pointerForArtifact(
+  artifact: ManualRouterCompleteSignedArtifactViewV1,
+  previousPointerHash: Sha256Digest | null,
+): ManualRouterApplicantPointerV1 {
+  return createManualRouterSignedPointerV1({
+    artifact: {
+      subject: ROOT_POINTER.subject,
+      approvalBindingHash: EXACT.approvalBindingHash,
+      headSha: EXACT.headSha,
+      treeSha: EXACT.treeSha,
+      routeNonce: EXACT.routeNonce,
+      preparationArtifactHash:
+        artifact.preparationArtifact.preparationArtifactHash,
+      signatureRequestHash: artifact.descriptor.signatureRequestHash,
+      descriptorHash: artifact.descriptor.descriptorHash,
+      signedArtifactHash: artifact.signedArtifactHash,
+      validAfter: artifact.descriptor.validAfter,
+      deadline: artifact.descriptor.deadline,
+      reissueOf: artifact.descriptor.reissueOf,
+    },
+    previousPointerHash,
+    updatedAtEpochSeconds: "2000000001",
+  });
+}
+
+function shardsAuthority(): ManualRouterWebsiteAuthorityV1 {
+  return Object.freeze({
+    assertCompleteSignedArtifact(raw: unknown) {
+      return raw as ManualRouterCompleteSignedArtifactViewV1;
+    },
+    async verifySignedPublish(input: Parameters<
+      ManualRouterWebsiteAuthorityV1["verifySignedPublish"]
+    >[0]) {
+      const request = input.request as Readonly<{
+        expectedPreviousPointerHash: Sha256Digest | null;
+        signedArtifact: ManualRouterCompleteSignedArtifactViewV1;
+      }>;
+      const pointer = pointerForArtifact(
+        request.signedArtifact,
+        request.expectedPreviousPointerHash,
+      );
+      const next = createManualRouterApplicantIndexV1({
+        previousIndex: input.currentApplicantIndex as ManualRouterApplicantIndexV1,
+        previousPointers: input.currentApplicantPointers as
+          readonly ManualRouterApplicantPointerV1[],
+        nextPointer: pointer,
+      });
+      return Object.freeze({
+        request,
+        nextPointer: pointer,
+        nextApplicantIndex: next.index,
+        idempotent: next.idempotent,
+      });
+    },
+    async readChainClock() {
+      return Object.freeze({
+        minimumTimestamp: "2000000001",
+        maximumTimestamp: "2000000001",
+        commonFinalizedTimestamp: "2000000000",
+        commonFinalizedBlockNumber: "1",
+        commonFinalizedBlockHash: `0x${"ab".repeat(32)}` as const,
+      });
+    },
+    async observeExactTransaction() {},
+    async resolveReissueState(input: Parameters<
+      ManualRouterWebsiteAuthorityV1["resolveReissueState"]
+    >[0]) {
+      const request = input.request as Readonly<{
+        previousSignedArtifact: ManualRouterCompleteSignedArtifactViewV1;
+      }>;
+      const current = input.currentApplicantPointers.find((pointer) =>
+        pointer.subject.subjectHash
+          === request.previousSignedArtifact.preparationArtifact.subject.subjectHash);
+      if (current?.signedArtifactHash
+        !== request.previousSignedArtifact.signedArtifactHash) {
+        return Object.freeze({
+          schemaVersion: "programmable.manual-router-operator-reissue-state-response.v1",
+          disposition: "stale",
+          code: "stale_previous_artifact",
+        });
+      }
+      return Object.freeze({
+        schemaVersion: "programmable.manual-router-operator-reissue-state-response.v1",
+        disposition: "current",
+        status: input.currentStatus,
+        currentPointer: current,
+        currentApplicantIndex: input.currentApplicantIndex,
+      });
+    },
+  });
+}
+
+async function seedHead(
+  store: ManualRouterPrivateBlobStoreV1,
+  pointer: ManualRouterApplicantPointerV1,
+  index: ManualRouterApplicantIndexV1,
+  artifact: ManualRouterCompleteSignedArtifactViewV1,
+): Promise<void> {
+  await store.putImmutable(
+    manualRouterContentPathV1("signed-artifacts", pointer.signedArtifactHash),
+    artifact,
+  );
+  await store.putImmutable(
+    manualRouterContentPathV1("pointer-history", pointer.pointerHash),
+    pointer,
+  );
+  await store.compareAndSwap(manualRouterApplicantIndexPathV1({
+    approvedGitHubUserId: EXACT.approvedGitHubUserId,
+    approvedLaunchWallet: EXACT.approvedLaunchWallet,
+  }), null, index);
+}
+
+function digest(seed: string): Sha256Digest {
+  return `sha256:${seed.padEnd(64, seed.slice(-1)).slice(0, 64)}` as Sha256Digest;
+}
+
+function mutate<T>(source: T, path: readonly string[], value: unknown): T {
+  const cloned = structuredClone(source) as Record<string, unknown>;
+  let cursor = cloned;
+  for (const key of path.slice(0, -1)) {
+    cursor = cursor[key] as Record<string, unknown>;
+  }
+  cursor[path.at(-1)!] = value;
+  return cloned as T;
+}
+
+function memoryStore() {
+  const values = new Map<string, { body: string; etag: string }>();
+  let version = 0;
+  return {
+    values,
+    store: new ManualRouterPrivateBlobStoreV1({
+      async get(path) {
+        const value = values.get(path);
+        return value
+          ? { statusCode: 200, etag: value.etag, body: value.body }
+          : { statusCode: 404, etag: null, body: null };
+      },
+      async put(path, body, options) {
+        const current = values.get(path);
+        if (
+          (!options.allowOverwrite && current)
+          || (options.ifMatch !== undefined && current?.etag !== options.ifMatch)
+        ) {
+          const error = new Error("conflict");
+          error.name = "BlobPreconditionFailedError";
+          throw error;
+        }
+        version += 1;
+        const etag = `etag-${version}`;
+        values.set(path, { body, etag });
+        return { etag };
+      },
+      async list({ prefix }) {
+        return {
+          paths: [...values.keys()].filter((path) => path.startsWith(prefix)),
+          cursor: null,
+          hasMore: false,
+        };
+      },
+      isPreconditionFailure(error) {
+        return error instanceof Error
+          && error.name === "BlobPreconditionFailedError";
+      },
+    }),
+  };
+}

--- a/tests/manual-router-shards-v1-compat.test.ts
+++ b/tests/manual-router-shards-v1-compat.test.ts
@@ -350,8 +350,8 @@ describe("exact Shards Router V1 Website service bridge", () => {
     `W/"${"A".repeat(32)}"`,
     `w/"${"a".repeat(32)}"`,
     `"${"A".repeat(32)}"`,
-  ])("rejects a noncanonical exact Shards CAS ETag: %s", async (readEtag) => {
-    const { store } = memoryStore({ readEtag: () => readEtag });
+  ])("rejects a noncanonical exact Shards CAS ETag: %s", async (headEtag) => {
+    const { store } = memoryStore({ headEtag: () => headEtag });
     await seedHead(store, ROOT_POINTER, ROOT_INDEX, shardsArtifact("root"));
     const service = new ManualRouterWebsiteServiceV1({
       store,
@@ -715,6 +715,7 @@ function mutate<T>(source: T, path: readonly string[], value: unknown): T {
 function memoryStore(hooks: Readonly<{
   weakReadEtags?: boolean;
   readEtag?: (strongEtag: string) => string;
+  headEtag?: (strongEtag: string) => string;
   beforePut?: (
     path: string,
     options: Readonly<{ allowOverwrite: boolean; ifMatch?: string }>,
@@ -736,6 +737,11 @@ function memoryStore(hooks: Readonly<{
               body: value.body,
             }
           : { statusCode: 404, etag: null, body: null };
+      },
+      async head(path) {
+        const value = values.get(path);
+        if (!value) throw new TypeError("missing Blob metadata");
+        return { etag: hooks.headEtag?.(value.etag) ?? value.etag };
       },
       async put(path, body, options) {
         await hooks.beforePut?.(path, options, values);

--- a/tests/manual-router-v2-authority-dispatch.test.ts
+++ b/tests/manual-router-v2-authority-dispatch.test.ts
@@ -19,7 +19,11 @@ const V2_ARTIFACT = Object.freeze({
 
 describe("manual Router production authority version dispatch", () => {
   it("keeps every V1 operation on the existing authority", async () => {
-    const { authority: v1, calls: v1Calls } = fakeAuthority("v1");
+    const {
+      authority: v1,
+      calls: v1Calls,
+      selectors: v1Selectors,
+    } = fakeAuthority("v1");
     const { authority: v2, calls: v2Calls } = fakeAuthority("v2");
     const loadV2 = vi.fn(() => v2 as ManualRouterWebsiteAuthorityV2);
     const dispatch = createManualRouterWebsiteAuthorityDispatchV2({
@@ -36,13 +40,15 @@ describe("manual Router production authority version dispatch", () => {
     await dispatch.resolveReissueState({
       request: { previousSignedArtifact: V1_ARTIFACT },
     } as never);
-    await dispatch.readChainClock();
+    const clockSelector = { pointer: { routeTest: "v1" } } as never;
+    await dispatch.readChainClock(clockSelector);
 
     expect(v1Calls).toEqual([
       "assert", "publish", "transaction", "reissue", "clock",
     ]);
     expect(v2Calls).toEqual([]);
     expect(loadV2).not.toHaveBeenCalled();
+    expect(v1Selectors).toEqual([clockSelector]);
   });
 
   it("routes every V2 operation to the portable facade without V1 fallback", async () => {
@@ -119,6 +125,7 @@ describe("manual Router production authority version dispatch", () => {
 
 function fakeAuthority(label: "v1" | "v2") {
   const calls: string[] = [];
+  const selectors: unknown[] = [];
   const authority = {
     assertCompleteSignedArtifact(raw: unknown) {
       calls.push("assert");
@@ -128,8 +135,9 @@ function fakeAuthority(label: "v1" | "v2") {
       calls.push("publish");
       return {};
     },
-    async readChainClock() {
+    async readChainClock(selector?: unknown) {
       calls.push("clock");
+      selectors.push(selector);
       return {
         minimumTimestamp: "1",
         maximumTimestamp: "1",
@@ -157,6 +165,7 @@ function fakeAuthority(label: "v1" | "v2") {
     authority: authority as unknown as ManualRouterWebsiteAuthorityV1,
     calls,
     label,
+    selectors,
   };
 }
 

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 import { getCreateAddress, keccak256 } from "viem";
 import * as walletProvider from "../components/wallet-provider";
@@ -84,6 +87,73 @@ type WalletProviderContract = {
 };
 
 const subject = walletProvider as unknown as WalletProviderContract;
+
+const APPLICANT_PRIVY_USER_ID = "did:privy:approved";
+const APPLICANT_GITHUB_USER_ID = "155705664";
+const APPLICANT_GITHUB_LOGIN = "jesse-stahl";
+const APPLICANT_WALLET =
+  "0xceebb3a6543cebeb2ed66963897a0abea52a50cc" as const;
+const OTHER_WALLET = `0x${"b".repeat(40)}` as const;
+const applicantRequirement = Object.freeze({
+  githubUserId: APPLICANT_GITHUB_USER_ID,
+  githubLogin: APPLICANT_GITHUB_LOGIN,
+  launchWallet: APPLICANT_WALLET,
+});
+
+type ApplicantLinkedAccountFixture = {
+  type: string;
+  subject?: string;
+  username?: string | null;
+  address?: string;
+  chainType?: string;
+};
+
+function applicantAuthority(overrides?: Partial<{
+  privyUserId: string | null;
+  githubUserId: string | null;
+  githubLogin: string | null;
+  walletAddress: string | null;
+}>) {
+  return {
+    privyUserId: APPLICANT_PRIVY_USER_ID,
+    githubUserId: APPLICANT_GITHUB_USER_ID,
+    githubLogin: APPLICANT_GITHUB_LOGIN,
+    walletAddress: APPLICANT_WALLET,
+    ...overrides,
+  };
+}
+
+function applicantUser(overrides?: Partial<{
+  id: string;
+  githubUserId: string;
+  githubLogin: string;
+  wallet: `0x${string}`;
+}>) {
+  const id = overrides?.id ?? APPLICANT_PRIVY_USER_ID;
+  const githubUserId = overrides?.githubUserId ?? APPLICANT_GITHUB_USER_ID;
+  const githubLogin = overrides?.githubLogin ?? APPLICANT_GITHUB_LOGIN;
+  const wallet = overrides?.wallet ?? APPLICANT_WALLET;
+  const linkedAccounts: ApplicantLinkedAccountFixture[] = [
+    {
+      type: "github_oauth",
+      subject: githubUserId,
+      username: githubLogin,
+    },
+    {
+      type: "wallet",
+      chainType: "ethereum",
+      address: wallet,
+    },
+  ];
+  return {
+    id,
+    github: {
+      subject: githubUserId,
+      username: githubLogin,
+    },
+    linkedAccounts,
+  };
+}
 
 describe("wallet recovery state", () => {
   it("holds approval and CREATE until exact identifier authority is frozen", () => {
@@ -285,6 +355,228 @@ describe("wallet recovery state", () => {
       loadIdentityToken,
     })).resolves.toBe("hook-identity-token");
     expect(loadIdentityToken).not.toHaveBeenCalled();
+  });
+
+  it("pins Privy 3.35.2 refreshUser to updateUserAndIdToken before Applicant tokens", () => {
+    const packageRoot = join(
+      process.cwd(),
+      "node_modules/@privy-io/react-auth",
+    );
+    const packageJson = JSON.parse(readFileSync(
+      join(packageRoot, "package.json"),
+      "utf8",
+    )) as { version?: unknown };
+    const dts = readFileSync(join(packageRoot, "dist/dts/index.d.ts"), "utf8");
+    const cjsIndex = readFileSync(join(packageRoot, "dist/cjs/index.js"), "utf8");
+    const implementationFile = cjsIndex.match(/require\("\.\/(index-[^"]+\.js)"\)/u)?.[1];
+    expect(packageJson.version).toBe("3.35.2");
+    expect(dts).toContain("refreshUser: () => Promise<User>");
+    expect(implementationFile).toBeTypeOf("string");
+    const implementation = readFileSync(
+      join(packageRoot, "dist/cjs", implementationFile!),
+      "utf8",
+    );
+    expect(implementation).toContain("updateUserAndIdToken");
+    const provider = readFileSync(
+      join(process.cwd(), "components/wallet-provider.tsx"),
+      "utf8",
+    );
+    expect(provider).toContain("const { refreshUser } = useUser();");
+    expect(provider).toContain("getIdentityToken: getPrivyIdentityToken");
+  });
+
+  it("does not refresh or acquire tokens before authentication is current", async () => {
+    const refreshUser = vi.fn(async () => applicantUser());
+    const getAccessToken = vi.fn(async () => "unexpected-access");
+    const getIdentityToken = vi.fn(async () => "unexpected-identity");
+    await expect(walletProvider.refreshWalletApplicantSessionV1({
+      authenticated: false,
+      readCurrentAuthority: applicantAuthority,
+      refreshUser,
+      getAccessToken,
+      getIdentityToken,
+      requirement: applicantRequirement,
+    })).resolves.toBeNull();
+    expect(refreshUser).not.toHaveBeenCalled();
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(getIdentityToken).not.toHaveBeenCalled();
+  });
+
+  it("refreshes user before tokens and binds the exact GitHub identity and linked wallet", async () => {
+    const events: string[] = [];
+    const authority = applicantAuthority();
+    const session = await walletProvider.refreshWalletApplicantSessionV1({
+      authenticated: true,
+      readCurrentAuthority: () => authority,
+      refreshUser: async () => {
+        events.push("refresh-user");
+        return applicantUser();
+      },
+      getAccessToken: async () => {
+        events.push("access-token");
+        return "access-token";
+      },
+      getIdentityToken: async () => {
+        events.push("identity-token");
+        return "identity-token";
+      },
+      requirement: applicantRequirement,
+    });
+
+    expect(events).toEqual([
+      "refresh-user",
+      "access-token",
+      "identity-token",
+    ]);
+    expect(session).toEqual({
+      accessToken: "access-token",
+      identityToken: "identity-token",
+      privyUserId: APPLICANT_PRIVY_USER_ID,
+      githubUserId: APPLICANT_GITHUB_USER_ID,
+      githubLogin: APPLICANT_GITHUB_LOGIN,
+      launchWallet: APPLICANT_WALLET,
+    });
+  });
+
+  it("rejects missing refresh results and refresh failures before token acquisition", async () => {
+    for (const refreshUser of [
+      async () => undefined,
+      async () => null,
+      async () => { throw new Error("refresh failed"); },
+    ]) {
+      const getAccessToken = vi.fn(async () => "unexpected-access");
+      const getIdentityToken = vi.fn(async () => "unexpected-identity");
+      await expect(walletProvider.refreshWalletApplicantSessionV1({
+        authenticated: true,
+        readCurrentAuthority: applicantAuthority,
+        refreshUser,
+        getAccessToken,
+        getIdentityToken,
+        requirement: applicantRequirement,
+      })).resolves.toBeNull();
+      expect(getAccessToken).not.toHaveBeenCalled();
+      expect(getIdentityToken).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects wrong or missing identity and wallet data before token acquisition", async () => {
+    const candidates = [
+      { id: APPLICANT_PRIVY_USER_ID, linkedAccounts: [] },
+      applicantUser({ id: "did:privy:other" }),
+      applicantUser({ githubUserId: "1" }),
+      applicantUser({ githubLogin: "other-user" }),
+      applicantUser({ wallet: OTHER_WALLET }),
+    ];
+    for (const refreshedUser of candidates) {
+      const getAccessToken = vi.fn(async () => "unexpected-access");
+      const getIdentityToken = vi.fn(async () => "unexpected-identity");
+      await expect(walletProvider.refreshWalletApplicantSessionV1({
+        authenticated: true,
+        readCurrentAuthority: applicantAuthority,
+        refreshUser: async () => refreshedUser,
+        getAccessToken,
+        getIdentityToken,
+        requirement: applicantRequirement,
+      })).resolves.toBeNull();
+      expect(getAccessToken).not.toHaveBeenCalled();
+      expect(getIdentityToken).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects a same-DID GitHub switch even without an exact lane requirement", async () => {
+    const getAccessToken = vi.fn(async () => "unexpected-access");
+    const getIdentityToken = vi.fn(async () => "unexpected-identity");
+    await expect(walletProvider.refreshWalletApplicantSessionV1({
+      authenticated: true,
+      readCurrentAuthority: applicantAuthority,
+      refreshUser: async () => applicantUser({
+        githubUserId: "999",
+        githubLogin: "other-user",
+      }),
+      getAccessToken,
+      getIdentityToken,
+    })).resolves.toBeNull();
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(getIdentityToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects ambiguous GitHub linkage and account reload drift before any request", async () => {
+    const ambiguous = applicantUser();
+    ambiguous.linkedAccounts.push({
+      type: "github_oauth",
+      subject: "999",
+      username: "other-user",
+    });
+    const getAccessToken = vi.fn(async () => "unexpected-access");
+    const getIdentityToken = vi.fn(async () => "unexpected-identity");
+    await expect(walletProvider.refreshWalletApplicantSessionV1({
+      authenticated: true,
+      readCurrentAuthority: applicantAuthority,
+      refreshUser: async () => ambiguous,
+      getAccessToken,
+      getIdentityToken,
+      requirement: applicantRequirement,
+    })).resolves.toBeNull();
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(getIdentityToken).not.toHaveBeenCalled();
+
+    let readCount = 0;
+    await expect(walletProvider.refreshWalletApplicantSessionV1({
+      authenticated: true,
+      readCurrentAuthority: () => {
+        readCount += 1;
+        return readCount === 1
+          ? applicantAuthority()
+          : applicantAuthority({ walletAddress: OTHER_WALLET });
+      },
+      refreshUser: async () => applicantUser(),
+      getAccessToken,
+      getIdentityToken,
+      requirement: applicantRequirement,
+    })).resolves.toBeNull();
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(getIdentityToken).not.toHaveBeenCalled();
+  });
+
+  it("acquires each token once after refresh and rejects either null without retry", async () => {
+    for (const tokens of [
+      { access: null, identity: "identity-token" },
+      { access: "access-token", identity: null },
+    ] as const) {
+      const getAccessToken = vi.fn(async () => tokens.access);
+      const getIdentityToken = vi.fn(async () => tokens.identity);
+      await expect(walletProvider.refreshWalletApplicantSessionV1({
+        authenticated: true,
+        readCurrentAuthority: applicantAuthority,
+        refreshUser: async () => applicantUser(),
+        getAccessToken,
+        getIdentityToken,
+        requirement: applicantRequirement,
+      })).resolves.toBeNull();
+      expect(getAccessToken).toHaveBeenCalledTimes(1);
+      expect(getIdentityToken).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("rejects account drift detected only after token acquisition", async () => {
+    let readCount = 0;
+    const getAccessToken = vi.fn(async () => "access-token");
+    const getIdentityToken = vi.fn(async () => "identity-token");
+    await expect(walletProvider.refreshWalletApplicantSessionV1({
+      authenticated: true,
+      readCurrentAuthority: () => {
+        readCount += 1;
+        return readCount < 3
+          ? applicantAuthority()
+          : applicantAuthority({ githubLogin: "other-user" });
+      },
+      refreshUser: async () => applicantUser(),
+      getAccessToken,
+      getIdentityToken,
+      requirement: applicantRequirement,
+    })).resolves.toBeNull();
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(getIdentityToken).toHaveBeenCalledTimes(1);
   });
 
   it("fails closed when an external provider mutates chain before a wallet action", async () => {

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -42,6 +42,11 @@ type WalletProviderContract = {
     walletsReady: boolean,
     authenticated: boolean,
   ) => boolean;
+  resolveWalletIdentityToken: (input: Readonly<{
+    authenticated: boolean;
+    cachedIdentityToken: string | null;
+    loadIdentityToken: () => Promise<string | null>;
+  }>) => Promise<string | null>;
   selectAuthenticatedWallet: <T extends {
     address: string;
     connectedAt: number;
@@ -232,6 +237,54 @@ describe("wallet recovery state", () => {
       hookemonBinding.launchWallet,
       "899",
     )).toThrow(/not current/u);
+  });
+
+  it("refreshes an authenticated Privy identity token when hook hydration is still null", async () => {
+    const loadIdentityToken = vi.fn(async () => "fresh-identity-token");
+
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: true,
+      cachedIdentityToken: null,
+      loadIdentityToken,
+    })).resolves.toBe("fresh-identity-token");
+    expect(loadIdentityToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retrieve an identity token for an unauthenticated session", async () => {
+    const loadIdentityToken = vi.fn(async () => "unexpected-token");
+
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: false,
+      cachedIdentityToken: null,
+      loadIdentityToken,
+    })).resolves.toBeNull();
+    expect(loadIdentityToken).not.toHaveBeenCalled();
+  });
+
+  it("keeps identity-token retrieval failures fail closed", async () => {
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: true,
+      cachedIdentityToken: null,
+      loadIdentityToken: async () => null,
+    })).resolves.toBeNull();
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: true,
+      cachedIdentityToken: null,
+      loadIdentityToken: async () => {
+        throw new Error("Privy unavailable");
+      },
+    })).resolves.toBeNull();
+  });
+
+  it("uses the Privy hook token without reading browser storage or refreshing", async () => {
+    const loadIdentityToken = vi.fn(async () => "unexpected-token");
+
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: true,
+      cachedIdentityToken: "hook-identity-token",
+      loadIdentityToken,
+    })).resolves.toBe("hook-identity-token");
+    expect(loadIdentityToken).not.toHaveBeenCalled();
   });
 
   it("fails closed when an external provider mutates chain before a wallet action", async () => {

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -17,6 +17,11 @@ type WalletProviderContract = {
     walletsReady: boolean,
     authenticated: boolean,
   ) => boolean;
+  resolveWalletIdentityToken: (input: Readonly<{
+    authenticated: boolean;
+    cachedIdentityToken: string | null;
+    loadIdentityToken: () => Promise<string | null>;
+  }>) => Promise<string | null>;
   selectAuthenticatedWallet: <T extends {
     address: string;
     connectedAt: number;
@@ -56,6 +61,54 @@ type WalletProviderContract = {
 const subject = walletProvider as unknown as WalletProviderContract;
 
 describe("wallet recovery state", () => {
+  it("refreshes an authenticated Privy identity token when hook hydration is still null", async () => {
+    const loadIdentityToken = vi.fn(async () => "fresh-identity-token");
+
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: true,
+      cachedIdentityToken: null,
+      loadIdentityToken,
+    })).resolves.toBe("fresh-identity-token");
+    expect(loadIdentityToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retrieve an identity token for an unauthenticated session", async () => {
+    const loadIdentityToken = vi.fn(async () => "unexpected-token");
+
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: false,
+      cachedIdentityToken: null,
+      loadIdentityToken,
+    })).resolves.toBeNull();
+    expect(loadIdentityToken).not.toHaveBeenCalled();
+  });
+
+  it("keeps identity-token retrieval failures fail closed", async () => {
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: true,
+      cachedIdentityToken: null,
+      loadIdentityToken: async () => null,
+    })).resolves.toBeNull();
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: true,
+      cachedIdentityToken: null,
+      loadIdentityToken: async () => {
+        throw new Error("Privy unavailable");
+      },
+    })).resolves.toBeNull();
+  });
+
+  it("uses the Privy hook token without reading browser storage or refreshing", async () => {
+    const loadIdentityToken = vi.fn(async () => "unexpected-token");
+
+    await expect(subject.resolveWalletIdentityToken({
+      authenticated: true,
+      cachedIdentityToken: "hook-identity-token",
+      loadIdentityToken,
+    })).resolves.toBe("hook-identity-token");
+    expect(loadIdentityToken).not.toHaveBeenCalled();
+  });
+
   it("fails closed when an external provider mutates chain before a wallet action", async () => {
     const request = vi.fn(async (method: "eth_chainId" | "eth_accounts") =>
       method === "eth_chainId"


### PR DESCRIPTION
## Summary\n- merges the exact live Shards launch lane with current `production` Hookemon history\n- adds a mandatory Privy `useUser().refreshUser()` Applicant session refresh before protected LIST, RESOLVE, and permit-bound requests\n- validates the refreshed Privy DID, exact GitHub account, and linked Ethereum launch wallet before reacquiring access and identity tokens\n- fails closed on missing, stale, ambiguous, changed, or failed authentication state without retrying an API request or wallet action\n\n## Immutable topology\n- integration merge: `702a43fa96cbfba2fe8682ec71696124ac342284`\n- parents: `d027e4f78d8f5f233584db67981de730986d41d0` then `26b053d7672cdc4277d8ce5f5b2bcc1423566dd7`\n- refresh commit: `e967b2ee105b99536dcb06b14990000bfbab5448`\n- tree: `3309a6f4019203ff5ce1322835ed56f5e4d71e8c`\n\n## Verification\n- combined focused Shards + Hookemon + authentication suite: 128/128 passed\n- cold TypeScript check passed\n- scoped ESLint and diff check passed\n- local Next production build passed\n\nNo launch permit was generated or signed for this change. No transaction was submitted.