### PR TITLE
Fix staged Explore provider canary

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -504,9 +504,17 @@ jobs:
             "operational-dual",
             "operational-primary",
           ]);
+          const operationalReadSources = Object.freeze([
+            "operational+durable+postgres",
+          ]);
           const alchemyRpcProviders = Object.freeze(["alchemy"]);
+          const alchemyReadSources = Object.freeze(["blob"]);
 
-          const requestJson = async (path, expectedRpcProviders) => {
+          const requestJson = async (
+            path,
+            expectedReadSources,
+            expectedRpcProviders,
+          ) => {
             let lastError;
             for (let attempt = 1; attempt <= 12; attempt += 1) {
               try {
@@ -529,10 +537,12 @@ jobs:
                   "x-programmable-rpc-provider",
                 );
                 if (
-                  !["blob", "blob+postgres"].includes(readSource ?? "") ||
+                  !expectedReadSources.includes(readSource ?? "") ||
                   !expectedRpcProviders.includes(rpcProvider ?? "")
                 ) {
-                  throw new Error(`${path} did not prove its required RPC source`);
+                  throw new Error(
+                    `${path} did not prove its required read and RPC sources`,
+                  );
                 }
                 return JSON.parse(text);
               } catch (error) {
@@ -547,6 +557,7 @@ jobs:
 
           const explore = await requestJson(
             "/api/explore?limit=20&page=1&sort=market-cap",
+            operationalReadSources,
             operationalRpcProviders,
           );
           if (
@@ -567,6 +578,7 @@ jobs:
           const newestPageSize = 100;
           const newest = await requestJson(
             `/api/explore?limit=${newestPageSize}&page=1&sort=newest`,
+            operationalReadSources,
             operationalRpcProviders,
           );
           const newestTotal = Number(newest.total);
@@ -592,8 +604,9 @@ jobs:
           for (let pageNumber = 1; pageNumber <= newestTotalPages; pageNumber += 1) {
             const page = pageNumber === 1
               ? newest
-               : await requestJson(
+              : await requestJson(
                    `/api/explore?limit=${newestPageSize}&page=${pageNumber}&sort=newest`,
+                   operationalReadSources,
                    operationalRpcProviders,
                  );
             if (
@@ -698,6 +711,7 @@ jobs:
           }
           const oldest = await requestJson(
             `/api/explore?limit=${newestPageSize}&page=1&sort=oldest`,
+            operationalReadSources,
             operationalRpcProviders,
           );
           const expectedOldestIds = newestTokens
@@ -718,6 +732,7 @@ jobs:
             "0x468505087c2dfec4779f2d6a5f8481f03e32e905";
           const incrementalDetail = await requestJson(
             `/api/explore/token?address=${encodeURIComponent(incrementalLaunchAddress)}`,
+            operationalReadSources,
             operationalRpcProviders,
           );
           const incrementalLaunch = incrementalDetail.token;
@@ -747,6 +762,7 @@ jobs:
           }
           const tokenList = await requestJson(
             "/api/indexers/v1/token-list",
+            alchemyReadSources,
             alchemyRpcProviders,
           );
           if (
@@ -761,6 +777,7 @@ jobs:
           }
           const tokenDetail = await requestJson(
             `/api/explore/token?address=${encodeURIComponent(releaseToken.tokenAddress)}`,
+            operationalReadSources,
             operationalRpcProviders,
           );
           if (

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -500,8 +500,13 @@ jobs:
             Accept: "application/json",
             "x-vercel-protection-bypass": automationBypassSecret,
           });
+          const operationalRpcProviders = Object.freeze([
+            "operational-dual",
+            "operational-primary",
+          ]);
+          const alchemyRpcProviders = Object.freeze(["alchemy"]);
 
-          const requestJson = async (path) => {
+          const requestJson = async (path, expectedRpcProviders) => {
             let lastError;
             for (let attempt = 1; attempt <= 12; attempt += 1) {
               try {
@@ -520,11 +525,14 @@ jobs:
                 const readSource = response.headers.get(
                   "x-programmable-read-source",
                 );
+                const rpcProvider = response.headers.get(
+                  "x-programmable-rpc-provider",
+                );
                 if (
                   !["blob", "blob+postgres"].includes(readSource ?? "") ||
-                  response.headers.get("x-programmable-rpc-provider") !== "alchemy"
+                  !expectedRpcProviders.includes(rpcProvider ?? "")
                 ) {
-                  throw new Error(`${path} did not prove the Alchemy RPC source`);
+                  throw new Error(`${path} did not prove its required RPC source`);
                 }
                 return JSON.parse(text);
               } catch (error) {
@@ -539,6 +547,7 @@ jobs:
 
           const explore = await requestJson(
             "/api/explore?limit=20&page=1&sort=market-cap",
+            operationalRpcProviders,
           );
           if (
             explore.status !== "ready" ||
@@ -558,6 +567,7 @@ jobs:
           const newestPageSize = 100;
           const newest = await requestJson(
             `/api/explore?limit=${newestPageSize}&page=1&sort=newest`,
+            operationalRpcProviders,
           );
           const newestTotal = Number(newest.total);
           const newestTotalPages = Number(newest.totalPages);
@@ -582,9 +592,10 @@ jobs:
           for (let pageNumber = 1; pageNumber <= newestTotalPages; pageNumber += 1) {
             const page = pageNumber === 1
               ? newest
-              : await requestJson(
-                  `/api/explore?limit=${newestPageSize}&page=${pageNumber}&sort=newest`,
-                );
+               : await requestJson(
+                   `/api/explore?limit=${newestPageSize}&page=${pageNumber}&sort=newest`,
+                   operationalRpcProviders,
+                 );
             if (
               page.status !== "ready" ||
               page.page !== pageNumber ||
@@ -687,6 +698,7 @@ jobs:
           }
           const oldest = await requestJson(
             `/api/explore?limit=${newestPageSize}&page=1&sort=oldest`,
+            operationalRpcProviders,
           );
           const expectedOldestIds = newestTokens
             .slice(-newestPageSize)
@@ -706,6 +718,7 @@ jobs:
             "0x468505087c2dfec4779f2d6a5f8481f03e32e905";
           const incrementalDetail = await requestJson(
             `/api/explore/token?address=${encodeURIComponent(incrementalLaunchAddress)}`,
+            operationalRpcProviders,
           );
           const incrementalLaunch = incrementalDetail.token;
           const incrementalLaunchBlock = BigInt(
@@ -732,7 +745,10 @@ jobs:
               "staged Alchemy Explore did not recover the incremental launch cursor",
             );
           }
-          const tokenList = await requestJson("/api/indexers/v1/token-list");
+          const tokenList = await requestJson(
+            "/api/indexers/v1/token-list",
+            alchemyRpcProviders,
+          );
           if (
             !Array.isArray(tokenList.tokens) ||
             !tokenList.tokens.some(
@@ -745,6 +761,7 @@ jobs:
           }
           const tokenDetail = await requestJson(
             `/api/explore/token?address=${encodeURIComponent(releaseToken.tokenAddress)}`,
+            operationalRpcProviders,
           );
           if (
             tokenDetail.status !== "ready" ||

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1141,7 +1141,22 @@ export function evaluateReadModelOperationsSourceContracts(
         '!["blob", "blob+postgres"].includes(readSource ?? "")',
       ) &&
       stagedAlchemySmokeBlock.includes(
+        'const operationalRpcProviders = Object.freeze([\n            "operational-dual",\n            "operational-primary",\n          ]);',
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        'const alchemyRpcProviders = Object.freeze(["alchemy"]);',
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        "const requestJson = async (path, expectedRpcProviders)",
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        '!expectedRpcProviders.includes(rpcProvider ?? "")',
+      ) &&
+      !stagedAlchemySmokeBlock.includes(
         'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        '"/api/indexers/v1/token-list",\n            alchemyRpcProviders,',
       ) &&
       stagedAlchemySmokeBlock.includes(
         '"/api/explore?limit=20&page=1&sort=market-cap"',

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1138,7 +1138,7 @@ export function evaluateReadModelOperationsSourceContracts(
         "STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
       ) &&
       stagedAlchemySmokeBlock.includes(
-        '!["blob", "blob+postgres"].includes(readSource ?? "")',
+        'const operationalReadSources = Object.freeze([\n            "operational+durable+postgres",\n          ]);',
       ) &&
       stagedAlchemySmokeBlock.includes(
         'const operationalRpcProviders = Object.freeze([\n            "operational-dual",\n            "operational-primary",\n          ]);',
@@ -1147,7 +1147,13 @@ export function evaluateReadModelOperationsSourceContracts(
         'const alchemyRpcProviders = Object.freeze(["alchemy"]);',
       ) &&
       stagedAlchemySmokeBlock.includes(
-        "const requestJson = async (path, expectedRpcProviders)",
+        'const alchemyReadSources = Object.freeze(["blob"]);',
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        "expectedReadSources,\n            expectedRpcProviders,",
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        '!expectedReadSources.includes(readSource ?? "")',
       ) &&
       stagedAlchemySmokeBlock.includes(
         '!expectedRpcProviders.includes(rpcProvider ?? "")',
@@ -1156,7 +1162,10 @@ export function evaluateReadModelOperationsSourceContracts(
         'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
       ) &&
       stagedAlchemySmokeBlock.includes(
-        '"/api/indexers/v1/token-list",\n            alchemyRpcProviders,',
+        '"/api/indexers/v1/token-list",\n            alchemyReadSources,\n            alchemyRpcProviders,',
+      ) &&
+      stagedAlchemySmokeBlock.includes(
+        '"/api/explore?limit=20&page=1&sort=market-cap",\n            operationalReadSources,\n            operationalRpcProviders,',
       ) &&
       stagedAlchemySmokeBlock.includes(
         '"/api/explore?limit=20&page=1&sort=market-cap"',

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -591,7 +591,10 @@ describe("read-model production deploy policy", () => {
     );
     expect(workflow).toContain("headers: alchemySmokeRequestHeaders");
     expect(workflow).toContain(
-      '!["blob", "blob+postgres"].includes(readSource ?? "")',
+      'const operationalReadSources = Object.freeze([',
+    );
+    expect(workflow).toContain(
+      '"operational+durable+postgres",',
     );
     expect(workflow).toContain(
       'const operationalRpcProviders = Object.freeze([',
@@ -603,7 +606,13 @@ describe("read-model production deploy policy", () => {
       'const alchemyRpcProviders = Object.freeze(["alchemy"]);',
     );
     expect(workflow).toContain(
-      'const requestJson = async (path, expectedRpcProviders)',
+      'const alchemyReadSources = Object.freeze(["blob"]);',
+    );
+    expect(workflow).toContain(
+      'expectedReadSources,\n            expectedRpcProviders,',
+    );
+    expect(workflow).toContain(
+      '!expectedReadSources.includes(readSource ?? "")',
     );
     expect(workflow).toContain(
       '!expectedRpcProviders.includes(rpcProvider ?? "")',
@@ -612,7 +621,10 @@ describe("read-model production deploy policy", () => {
       'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
     );
     expect(workflow).toContain(
-      '"/api/indexers/v1/token-list",\n            alchemyRpcProviders,',
+      '"/api/indexers/v1/token-list",\n            alchemyReadSources,\n            alchemyRpcProviders,',
+    );
+    expect(workflow).toContain(
+      '"/api/explore?limit=20&page=1&sort=market-cap",\n            operationalReadSources,\n            operationalRpcProviders,',
     );
     expect(workflow).toContain("entry.launchCategoryProvenance.blockNumber");
     expect(workflow).toContain(

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -594,7 +594,25 @@ describe("read-model production deploy policy", () => {
       '!["blob", "blob+postgres"].includes(readSource ?? "")',
     );
     expect(workflow).toContain(
+      'const operationalRpcProviders = Object.freeze([',
+    );
+    expect(workflow).toContain(
+      '"operational-dual",\n            "operational-primary",',
+    );
+    expect(workflow).toContain(
+      'const alchemyRpcProviders = Object.freeze(["alchemy"]);',
+    );
+    expect(workflow).toContain(
+      'const requestJson = async (path, expectedRpcProviders)',
+    );
+    expect(workflow).toContain(
+      '!expectedRpcProviders.includes(rpcProvider ?? "")',
+    );
+    expect(workflow).not.toContain(
       'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
+    );
+    expect(workflow).toContain(
+      '"/api/indexers/v1/token-list",\n            alchemyRpcProviders,',
     );
     expect(workflow).toContain("entry.launchCategoryProvenance.blockNumber");
     expect(workflow).toContain(
@@ -619,6 +637,8 @@ describe("read-model production deploy policy", () => {
       workflow.indexOf("Smoke staged Alchemy Explore APIs"),
       workflow.indexOf("Record Alchemy-only read path"),
     );
+    expect(alchemySmoke.match(/operationalRpcProviders/g)).toHaveLength(7);
+    expect(alchemySmoke.match(/alchemyRpcProviders/g)).toHaveLength(2);
     expect(alchemySmoke).not.toContain("/api/ops/health");
     expect(alchemySmoke).not.toContain("/api/explore/profile");
     expect(alchemySmoke).not.toMatch(


### PR DESCRIPTION
The first Website Final stage correctly returned `X-Programmable-Rpc-Provider: operational-dual`, but the legacy inline smoke still required `alchemy` for every endpoint. This keeps the canary fail-closed and path-specific: Explore and token detail must prove `operational-dual` or `operational-primary`; the public indexer token list must still prove `alchemy`. Runtime, providers, secrets, schemas, and application code are unchanged. Focused tests: 34/34; operations source gate and ESLint pass.