### PR TITLE
Keep health available on verified read fallback

### DIFF
--- a/app/api/ops/health/route.ts
+++ b/app/api/ops/health/route.ts
@@ -13,6 +13,27 @@ export const runtime = "nodejs";
 
 const MAX_INDEX_AGE_MS = 15 * 60 * 1_000;
 
+type IndexedHealthRead = Readonly<{
+  health: Awaited<ReturnType<typeof readIndexedReadModelHealth>>;
+  status: "available" | "disabled" | "unavailable";
+}>;
+
+async function readIndexedHealth(): Promise<IndexedHealthRead> {
+  try {
+    const health = await readIndexedReadModelHealth();
+    return {
+      health,
+      status: health ? "available" : "disabled",
+    };
+  } catch (error) {
+    console.error("Programmable indexed read-model health is unavailable", {
+      errorName:
+        error instanceof Error ? error.name : "UnknownIndexedHealthError",
+    });
+    return { health: null, status: "unavailable" };
+  }
+}
+
 function unhealthyRpcResponse(
   rpc: OperationalRpcHealth,
   startedAt: number,
@@ -39,7 +60,8 @@ function unhealthyRpcResponse(
 export async function GET() {
   const startedAt = Date.now();
   try {
-    const indexed = await readIndexedReadModelHealth();
+    const indexedRead = await readIndexedHealth();
+    const indexed = indexedRead.health;
     const deployment = getOperationalOnchainDeployment("production");
     if (deployment.status !== "ready") {
       throw new Error(
@@ -65,6 +87,8 @@ export async function GET() {
           status: "healthy",
           chainId: indexed.chainId,
           index: indexed.index,
+          indexSource: "indexed",
+          indexedReadModel: { status: indexedRead.status },
           rpc,
           checkedAt: new Date().toISOString(),
         },
@@ -97,6 +121,8 @@ export async function GET() {
             index.envelope.payload.model.snapshot.blockNumber,
           tokenCount: index.envelope.payload.model.tokens.length,
         },
+        indexSource: "durable",
+        indexedReadModel: { status: indexedRead.status },
         rpc,
         checkedAt: new Date().toISOString(),
       },

--- a/tests/data-pipeline/operations-health-route.test.ts
+++ b/tests/data-pipeline/operations-health-route.test.ts
@@ -90,6 +90,8 @@ describe("operations health route", () => {
     expect(body).toMatchObject({
       status: "healthy",
       chainId: 1,
+      indexSource: "durable",
+      indexedReadModel: { status: "disabled" },
       index: {
         ageSeconds: 5,
         blockNumber: "25600000",
@@ -125,6 +127,8 @@ describe("operations health route", () => {
     expect(body).toMatchObject({
       status: "healthy",
       chainId: 1,
+      indexSource: "indexed",
+      indexedReadModel: { status: "available" },
       index: {
         ageSeconds: 4,
         blockNumber: "25600010",
@@ -279,23 +283,58 @@ describe("operations health route", () => {
     expect(mocks.readDurableExploreModel).not.toHaveBeenCalled();
   });
 
-  it("fails closed without details when indexed health validation fails", async () => {
+  it("uses the verified durable path when indexed health is unavailable", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     mocks.readIndexedReadModelHealth.mockRejectedValue(
       new Error("private database detail"),
     );
+    mocks.getOperationalOnchainDeployment.mockReturnValue({
+      status: "ready",
+      chainId: 1,
+    });
+    mocks.readDurableExploreModel.mockResolvedValue({
+      status: "ready",
+      ageMs: 5_500,
+      envelope: {
+        payload: {
+          model: {
+            snapshot: { blockNumber: "25600000" },
+            tokens: [{}, {}],
+          },
+        },
+      },
+    });
+    mocks.readOperationalRpcHealth.mockResolvedValue(rpcHealth());
 
     const response = await GET();
     const body = await response.json();
 
-    expect(response.status).toBe(503);
-    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=0, s-maxage=30",
+    );
     expect(body).toMatchObject({
-      status: "unhealthy",
+      status: "healthy",
+      chainId: 1,
+      indexSource: "durable",
+      indexedReadModel: { status: "unavailable" },
+      index: {
+        ageSeconds: 5,
+        blockNumber: "25600000",
+        tokenCount: 2,
+      },
+      rpc: {
+        status: "healthy",
+        quorum: { status: "verified" },
+      },
     });
     expect(JSON.stringify(body)).not.toContain(
       "private database detail",
     );
-    expect(mocks.getOperationalOnchainDeployment).not.toHaveBeenCalled();
+    expect(mocks.getOperationalOnchainDeployment).toHaveBeenCalledWith(
+      "production",
+    );
+    expect(mocks.readDurableExploreModel).toHaveBeenCalledOnce();
+    expect(mocks.readOperationalRpcHealth).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Outcome

- keep `/api/ops/health` available when the indexed read model is unavailable but the validated durable model and operational dual-RPC path are healthy
- expose `indexSource` and the indexed read-model status explicitly instead of collapsing the active serving path into a generic 503
- continue to fail closed when the durable model or operational RPC path is unavailable or inconsistent

## Evidence

- exact staged predecessor: Explore sorted correctly, Classic Rewards returned `200 ready`, but health returned generic 503 before reaching RPC health
- 3 focused files / 29 tests
- scoped ESLint, TypeScript, and diff-check
- no provider key, account, indexer-core, contract, Router, or Authority change
