### PR TITLE
Fix live valuations, claims, and Hookathon

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -54,6 +54,13 @@ regexes = [
 ]
 
 [[allowlists]]
+description = "Live market golden sample pins the public Programmable token address"
+condition = "AND"
+regexTarget = "match"
+paths = ['''tests/alchemy-live-market\.test\.ts''']
+regexes = ['''(?i)0x7987f03462200b3d8a072e02c89a8a41dcb124ee''']
+
+[[allowlists]]
 description = "Launch stamp docs pin the public PCAN canary token address"
 condition = "AND"
 regexTarget = "match"

--- a/app/api/explore/profile/claim/route.ts
+++ b/app/api/explore/profile/claim/route.ts
@@ -28,10 +28,13 @@ import {
 } from "../../../../../lib/data-pipeline/action-lookup";
 import { indexedLaunchLookupEnabled } from "../../../../../lib/data-pipeline/route-activation.server";
 import {
+  ActionRpcQuorumError,
+  creatorClaimRpcProviders,
+} from "../../../../../lib/server/action-rpc-quorum.server";
+import {
   errorChainIncludesData,
   safeServerErrorSummary,
 } from "../../../../../lib/server/safe-error";
-import { creatorClaimRpcProviders } from "../../../../../lib/server/action-rpc-quorum.server";
 import { computeOfficialV4PoolId } from "../../../../../lib/uniswap/liquidity-launcher-sdk";
 
 export const dynamic = "force-dynamic";
@@ -40,6 +43,8 @@ export const runtime = "nodejs";
 const MAX_REQUEST_BYTES = 2_048;
 const NO_FEES_TO_CLAIM_SELECTOR = "0x846d8c5c";
 const NATIVE_ETH = "0x0000000000000000000000000000000000000000" as Address;
+const CLAIM_RPC_UNAVAILABLE_MESSAGE =
+  "Creator claim reads are temporarily unavailable. Try again";
 
 type CreatorClaimTokenIdentity = Readonly<{
   tokenAddress: Address;
@@ -86,29 +91,207 @@ function claimClient(
   });
 }
 
-async function sharedVerifiedBlock(clients: readonly PublicClient[]) {
-  if (clients.length !== 2) {
-    throw new CreatorClaimUnavailableError(
-      "rpc-unavailable",
-      "Creator claims require two independent Ethereum RPCs",
-    );
-  }
-  const heads = await Promise.all(clients.map((client) => client.getBlockNumber()));
-  const blockNumber = minimum(heads[0]!, heads[1]!);
-  const blocks = await Promise.all(
-    clients.map((client) => client.getBlock({ blockNumber })),
+function claimRpcUnavailable() {
+  return new CreatorClaimUnavailableError(
+    "rpc-unavailable",
+    CLAIM_RPC_UNAVAILABLE_MESSAGE,
   );
-  if (
-    !blocks[0]?.hash ||
-    !blocks[1]?.hash ||
-    blocks[0].hash.toLowerCase() !== blocks[1].hash.toLowerCase()
-  ) {
+}
+
+async function sharedVerifiedBlock(clients: readonly PublicClient[]) {
+  if (clients.length < 2) {
+    throw claimRpcUnavailable();
+  }
+
+  const headResults = await Promise.allSettled(
+    clients.map((client) => client.getBlockNumber()),
+  );
+  const available = headResults.flatMap((result, index) =>
+    result.status === "fulfilled"
+      ? [{ client: clients[index]!, head: result.value }]
+      : [],
+  );
+  if (available.length < 2) {
+    throw claimRpcUnavailable();
+  }
+
+  const descendingHeads = available
+    .map(({ head }) => head)
+    .sort((left, right) => (left > right ? -1 : left < right ? 1 : 0));
+  const candidateBlocks = [...new Set(descendingHeads.slice(1).map(String))]
+    .map((value) => BigInt(value))
+    .sort((left, right) => (left > right ? -1 : left < right ? 1 : 0));
+  let sawBlockDisagreement = false;
+
+  for (const blockNumber of candidateBlocks) {
+    const eligible = available.filter(({ head }) => head >= blockNumber);
+    const blockResults = await Promise.allSettled(
+      eligible.map(async ({ client }) => ({
+        client,
+        block: await client.getBlock({ blockNumber }),
+      })),
+    );
+    const groups = new Map<
+      string,
+      { blockHash: Hex; clients: PublicClient[] }
+    >();
+    for (const result of blockResults) {
+      if (result.status !== "fulfilled" || !result.value.block.hash) continue;
+      const blockHash = result.value.block.hash as Hex;
+      const key = blockHash.toLowerCase();
+      const group = groups.get(key) ?? { blockHash, clients: [] };
+      group.clients.push(result.value.client);
+      groups.set(key, group);
+    }
+    const agreeing = [...groups.values()].sort(
+      (left, right) => right.clients.length - left.clients.length,
+    )[0];
+    if (agreeing && agreeing.clients.length >= 2) {
+      return {
+        blockNumber,
+        blockHash: agreeing.blockHash,
+        clients: agreeing.clients,
+      };
+    }
+    if (groups.size > 1) sawBlockDisagreement = true;
+  }
+
+  if (sawBlockDisagreement) {
     throw new CreatorClaimUnavailableError(
       "rpc-disagreement",
       "Independent Ethereum RPCs disagree on the current claim state",
     );
   }
-  return { blockNumber, blockHash: blocks[0].hash };
+  throw claimRpcUnavailable();
+}
+
+async function sharedCurrentClaimState(input: {
+  clients: readonly PublicClient[];
+  deployment: Extract<ReturnType<typeof getOnchainDeployment>, { status: "ready" }>;
+  token: CreatorClaimTokenIdentity;
+  blockNumber: bigint;
+}) {
+  const results = await Promise.allSettled(
+    input.clients.map(async (client) => ({
+      client,
+      state: await readCurrentClaimState({
+        client,
+        deployment: input.deployment,
+        token: input.token,
+        blockNumber: input.blockNumber,
+      }),
+    })),
+  );
+  const groups = new Map<
+    string,
+    { claimable: bigint; clients: PublicClient[] }
+  >();
+  for (const result of results) {
+    if (result.status !== "fulfilled") continue;
+    const key = result.value.state.claimable.toString();
+    const group = groups.get(key) ?? {
+      claimable: result.value.state.claimable,
+      clients: [],
+    };
+    group.clients.push(result.value.client);
+    groups.set(key, group);
+  }
+  const agreeing = [...groups.values()].sort(
+    (left, right) => right.clients.length - left.clients.length,
+  )[0];
+  if (agreeing && agreeing.clients.length >= 2) return agreeing;
+  if (groups.size > 1) {
+    throw new CreatorClaimUnavailableError(
+      "rpc-disagreement",
+      "Independent Ethereum RPCs disagree on the current claim balance",
+    );
+  }
+
+  const deterministicFailures = new Map<
+    string,
+    CreatorClaimUnavailableError[]
+  >();
+  for (const result of results) {
+    if (
+      result.status !== "rejected" ||
+      !(result.reason instanceof CreatorClaimUnavailableError) ||
+      (result.reason.code !== "runtime-mismatch" &&
+        result.reason.code !== "identity-mismatch")
+    ) {
+      continue;
+    }
+    const failures = deterministicFailures.get(result.reason.code) ?? [];
+    failures.push(result.reason);
+    deterministicFailures.set(result.reason.code, failures);
+  }
+  const verifiedFailure = [...deterministicFailures.values()].find(
+    (failures) => failures.length >= 2,
+  )?.[0];
+  if (verifiedFailure) throw verifiedFailure;
+  throw claimRpcUnavailable();
+}
+
+function revertFingerprint(error: unknown) {
+  const summary = safeServerErrorSummary(error);
+  const selector = summary.chain.find((entry) => entry.dataSelector)
+    ?.dataSelector;
+  if (selector) return `data:${selector}`;
+  const reverted = summary.chain.find(
+    (entry) =>
+      entry.name === "ContractFunctionRevertedError" ||
+      entry.message?.toLowerCase().includes("execution reverted"),
+  );
+  return reverted
+    ? `revert:${reverted.message?.toLowerCase() ?? reverted.name}`
+    : null;
+}
+
+async function simulateCreatorClaim(input: {
+  clients: readonly PublicClient[];
+  transaction: {
+    account: Address;
+    to: Address;
+    data: Hex;
+    value: bigint;
+  };
+  blockNumber: bigint;
+}) {
+  const results = await Promise.allSettled(
+    input.clients.map(async (client) => {
+      await client.call({ ...input.transaction, blockNumber: input.blockNumber });
+      const [estimatedGas, gasPrice, accountBalance] = await Promise.all([
+        client.estimateGas({
+          ...input.transaction,
+          blockNumber: input.blockNumber,
+        }),
+        client.getGasPrice(),
+        client.getBalance({
+          address: input.transaction.account,
+          blockNumber: input.blockNumber,
+        }),
+      ]);
+      return { estimatedGas, gasPrice, accountBalance };
+    }),
+  );
+  const simulations = results.flatMap((result) =>
+    result.status === "fulfilled" ? [result.value] : [],
+  );
+  if (simulations.length >= 2) return simulations;
+
+  const failures = new Map<string, unknown[]>();
+  for (const result of results) {
+    if (result.status !== "rejected") continue;
+    const fingerprint = revertFingerprint(result.reason);
+    if (!fingerprint) continue;
+    const matching = failures.get(fingerprint) ?? [];
+    matching.push(result.reason);
+    failures.set(fingerprint, matching);
+  }
+  const verifiedFailure = [...failures.values()].find(
+    (matching) => matching.length >= 2,
+  )?.[0];
+  if (verifiedFailure) throw verifiedFailure;
+  throw claimRpcUnavailable();
 }
 
 async function readCurrentClaimState(input: {
@@ -381,23 +564,13 @@ export async function POST(request: NextRequest) {
       claimClient(deployment, provider.endpoint),
     );
     const snapshot = await sharedVerifiedBlock(clients);
-    const states = await Promise.all(
-      clients.map((client) =>
-        readCurrentClaimState({
-          client,
-          deployment,
-          token,
-          blockNumber: snapshot.blockNumber,
-        }),
-      ),
-    );
-    if (states[0]!.claimable !== states[1]!.claimable) {
-      throw new CreatorClaimUnavailableError(
-        "rpc-disagreement",
-        "Independent Ethereum RPCs disagree on the current claim balance",
-      );
-    }
-    const claimable = states[0]!.claimable;
+    const state = await sharedCurrentClaimState({
+      clients: snapshot.clients,
+      deployment,
+      token,
+      blockNumber: snapshot.blockNumber,
+    });
+    const claimable = state.claimable;
     if (claimable <= 0n) {
       throw new CreatorClaimUnavailableError(
         "nothing-to-claim",
@@ -410,23 +583,17 @@ export async function POST(request: NextRequest) {
       args: [claimRequest.poolId],
     });
     const value = 0n;
-    const simulations = await Promise.all(
-      clients.map(async (client) => {
-        const transaction = {
-          account: claimRequest.account,
-          to: deployment.feeHook,
-          data,
-          value,
-        };
-        await client.call(transaction);
-        const [estimatedGas, gasPrice, accountBalance] = await Promise.all([
-          client.estimateGas(transaction),
-          client.getGasPrice(),
-          client.getBalance({ address: claimRequest.account }),
-        ]);
-        return { estimatedGas, gasPrice, accountBalance };
-      }),
-    );
+    const transaction = {
+      account: claimRequest.account,
+      to: deployment.feeHook,
+      data,
+      value,
+    };
+    const simulations = await simulateCreatorClaim({
+      clients: state.clients,
+      transaction,
+      blockNumber: snapshot.blockNumber,
+    });
     const intent = {
       account: claimRequest.account,
       poolId: claimRequest.poolId,
@@ -483,14 +650,24 @@ export async function POST(request: NextRequest) {
         400,
       );
     }
-    if (error instanceof CreatorClaimUnavailableError) {
+    if (
+      error instanceof CreatorClaimUnavailableError ||
+      error instanceof ActionRpcQuorumError
+    ) {
+      const unavailable =
+        error instanceof ActionRpcQuorumError
+          ? claimRpcUnavailable()
+          : error;
+      const retryable =
+        unavailable.code === "rpc-unavailable" ||
+        unavailable.code === "rpc-disagreement";
       return json(
         blockedResponse(
-          error.code === "not-deployed" ? "not-deployed" : "blocked",
-          error.code,
-          error.message,
+          unavailable.code === "not-deployed" ? "not-deployed" : "blocked",
+          unavailable.code,
+          unavailable.message,
         ),
-        409,
+        retryable ? 503 : 409,
       );
     }
     if (

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import {
-  enrichTokensWithAlchemyPrices,
   getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../lib/alchemy/explore.server";
-import { enrichTokensWithAlchemyPoolState } from "../../../lib/alchemy/live-market.server";
+import {
+  enrichTokensWithAlchemyPoolState,
+  readVerifiedOperationalMarketSnapshot,
+  withSameBlockEthUsdQuote,
+  withoutUnboundEthUsdQuote,
+} from "../../../lib/alchemy/live-market.server";
 import { suppressRouterBoundCustomProjectDuplicates } from "../../../lib/alchemy/router-custom-collision";
 import {
   createExploreConsumerSource,
@@ -33,7 +37,6 @@ import {
 } from "../../../lib/onchain/query";
 import type {
   ExploreReadModel,
-  ExploreSnapshot,
   ExploreSort,
 } from "../../../lib/onchain/types";
 import { readProductionCustomExploreDirectoryV1 } from "../../../lib/server/custom-launch/explore-directory-v1";
@@ -109,19 +112,6 @@ async function settleExploreSource<T>(
   } catch (error) {
     return { source: null, error };
   }
-}
-
-export function inheritExploreEthUsdQuote(
-  liveSnapshot: ExploreSnapshot,
-  referenceSnapshot: ExploreSnapshot,
-): ExploreSnapshot {
-  if (liveSnapshot.ethUsdQuote || !referenceSnapshot.ethUsdQuote) {
-    return liveSnapshot;
-  }
-  return {
-    ...liveSnapshot,
-    ethUsdQuote: referenceSnapshot.ethUsdQuote,
-  };
 }
 
 function mergeTokenUpdates(
@@ -393,6 +383,12 @@ export async function GET(request: NextRequest) {
       pageSize: integerQuery(search.get("limit"), 9),
       socials,
     } as const;
+    let deployment: ReturnType<typeof getAlchemyOnchainDeployment> | null = null;
+    try {
+      deployment = getAlchemyOnchainDeployment();
+    } catch {
+      // Provider readiness is independent from canonical launch identity.
+    }
     const canonicalRead = settleExploreSource(
       readCanonicalExploreSource({
         primary: readPrimaryExploreModel,
@@ -404,10 +400,19 @@ export async function GET(request: NextRequest) {
         primary: () => readProductionCustomExploreDirectoryV1(request.signal),
       }),
     );
-    const [canonicalAttempt, customAttempt, referenceHead] = await Promise.all([
+    const operationalSnapshotRead = deployment?.status === "ready"
+      ? readVerifiedOperationalMarketSnapshot(deployment)
+      : Promise.resolve(null);
+    const [
+      canonicalAttempt,
+      customAttempt,
+      referenceHead,
+      operationalSnapshot,
+    ] = await Promise.all([
       canonicalRead,
       customRead,
       readExploreReferenceHeadWithinRouteBudget(),
+      operationalSnapshotRead,
     ]);
     if (canonicalAttempt.source === null && customAttempt.source === null) {
       throw canonicalAttempt.error ?? customAttempt.error;
@@ -416,41 +421,21 @@ export async function GET(request: NextRequest) {
     const canonicalSource = canonicalAttempt.source;
     const customSource = customAttempt.source;
     let pricedModel = canonicalSource?.value ?? null;
-    let priceApiApplied = false;
-    if (pricedModel && canonicalSource?.status === "current") {
-      try {
-        const previousTokens = pricedModel.tokens;
-        const enrichedTokens = await enrichTokensWithAlchemyPrices(
-          previousTokens,
-        );
-        priceApiApplied = enrichedTokens.some((token, index) =>
-          token.tokenPriceUsdWad !== previousTokens[index]?.tokenPriceUsdWad ||
-          token.fdvUsdWad !== previousTokens[index]?.fdvUsdWad
-        );
-        pricedModel = {
-          ...pricedModel,
-          tokens: enrichedTokens,
-        } satisfies ExploreReadModel;
-      } catch {
-        // The canonical launch identities remain valid without price enrichment.
-      }
-    }
 
-    let deployment: ReturnType<typeof getAlchemyOnchainDeployment> | null = null;
-    if (canonicalSource?.status === "current") {
+    let liveSnapshot = operationalSnapshot;
+    if (deployment?.status === "ready" && liveSnapshot) {
       try {
-        deployment = getAlchemyOnchainDeployment();
+        liveSnapshot = await withSameBlockEthUsdQuote({
+          deployment,
+          snapshot: liveSnapshot,
+        });
       } catch {
-        // Deployment/provider unavailability must not remove launch identities.
+        // USD conversion is fail-closed. Current StateView values can still be
+        // exposed in ETH, but an older durable quote is never carried forward.
+        liveSnapshot = withoutUnboundEthUsdQuote(liveSnapshot);
       }
     }
-    const liveSnapshot =
-      pricedModel?.status === "ready"
-        ? inheritExploreEthUsdQuote(
-            pricedModel.launchDiscoverySnapshot ?? pricedModel.snapshot,
-            pricedModel.snapshot,
-          )
-        : null;
+    let livePoolStateApplied = false;
     if (deployment?.status === "ready" && liveSnapshot && pricedModel) {
       const visible = visibleExploreTokens(pricedModel);
       const top = filterAndSortTokens(
@@ -463,8 +448,12 @@ export async function GET(request: NextRequest) {
         "",
         "newest",
       ).slice(0, NEWEST_LIVE_MARKET_LIMIT);
+      const warmCandidates =
+        options.sort === "market-cap" || options.sort === "market-cap-asc"
+          ? visible
+          : [...top, ...newest];
       const warm = [...new Map(
-        [...top, ...newest].map((token) => [
+        warmCandidates.map((token) => [
           token.tokenAddress.toLowerCase(),
           token,
         ]),
@@ -474,6 +463,23 @@ export async function GET(request: NextRequest) {
           deployment,
           snapshot: liveSnapshot,
           tokens: warm,
+        });
+        const previousByAddress = new Map(pricedModel.tokens.map((token) => [
+          token.tokenAddress.toLowerCase(),
+          token,
+        ]));
+        livePoolStateApplied = updates.some((token) => {
+          const previous = previousByAddress.get(
+            token.tokenAddress.toLowerCase(),
+          );
+          return token.indexedValuationBlockNumber ===
+              liveSnapshot?.blockNumber &&
+            (
+              previous?.indexedValuationBlockNumber !==
+                token.indexedValuationBlockNumber ||
+              previous?.marketCapEthWei !== token.marketCapEthWei ||
+              previous?.fdvUsdWad !== token.fdvUsdWad
+            );
         });
         pricedModel = {
           ...pricedModel,
@@ -496,10 +502,13 @@ export async function GET(request: NextRequest) {
     const referenceBlock = greatestBlockNumber(
       identityAsOfBlock,
       referenceHead?.blockNumber,
+      operationalSnapshot?.blockNumber,
     );
     const valuationContext = {
       referenceBlock,
-      forceStale: canonicalSource?.status === "last-known-good",
+      forceStale:
+        canonicalSource?.status === "last-known-good" ||
+        operationalSnapshot === null,
     } as const;
     const classicEntries = pricedModel
       ? visibleExploreTokens(pricedModel)
@@ -514,6 +523,11 @@ export async function GET(request: NextRequest) {
       ...valuedCustomProjects,
     ]) as ValuedExploreEntry[];
     assertNoExploreCategoryCollision(entries);
+    const livePriceSource = livePoolStateApplied
+      ? liveSnapshot?.ethUsdQuote
+        ? "state-view+chainlink"
+        : "state-view"
+      : "read-model";
     const useTopValuationView =
       options.sort === "market-cap" &&
       options.query.length === 0 &&
@@ -639,8 +653,7 @@ export async function GET(request: NextRequest) {
             : {}),
           ...(pricedModel
             ? {
-                "X-Programmable-Price-Source":
-                  priceApiApplied ? "alchemy" : "read-model",
+                "X-Programmable-Price-Source": livePriceSource,
               }
             : {}),
           ...sourceHeaders,

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -6,7 +6,12 @@ import {
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../../../lib/alchemy/explore.server";
-import { enrichTokensWithAlchemyPoolState } from "../../../../../lib/alchemy/live-market.server";
+import {
+  enrichTokensWithAlchemyPoolState,
+  readVerifiedOperationalMarketSnapshot,
+  withSameBlockEthUsdQuote,
+  withoutUnboundEthUsdQuote,
+} from "../../../../../lib/alchemy/live-market.server";
 import {
   assertTokenChartSupported,
   isTokenChartRange,
@@ -76,8 +81,30 @@ export async function GET(request: NextRequest) {
   try {
     const address = getAddress(input);
     const deployment = getAlchemyOnchainDeployment();
-    const model = await readAlchemyExploreModel();
-    if (deployment.status !== "ready" || model.status !== "ready") {
+    if (deployment.status !== "ready") {
+      return NextResponse.json(
+        {
+          status: "unavailable",
+          address,
+          error: "Onchain chart data is temporarily unavailable",
+          dataQuality: unavailableDataQuality("source-unavailable"),
+        },
+        {
+          status: 503,
+          headers: {
+            "Cache-Control": "no-store",
+            "Retry-After": "5",
+            "X-Programmable-Data-Quality": "unavailable",
+            "X-Programmable-Read-Source": "rpc",
+          },
+        },
+      );
+    }
+    const [model, operationalSnapshot] = await Promise.all([
+      readAlchemyExploreModel(),
+      readVerifiedOperationalMarketSnapshot(deployment),
+    ]);
+    if (model.status !== "ready") {
       return NextResponse.json(
         {
           status: "unavailable",
@@ -120,7 +147,39 @@ export async function GET(request: NextRequest) {
 
     assertTokenChartSupported(token);
 
-    const liveSnapshot = model.launchDiscoverySnapshot ?? model.snapshot;
+    // A lagging launch-discovery snapshot is useful for canonical identity,
+    // but it is never market-currentness authority. Returning unavailable here
+    // lets the client preserve its last verified chart instead of appending a
+    // stale model point as though it were the current price.
+    if (operationalSnapshot === null) {
+      return NextResponse.json(
+        {
+          status: "unavailable",
+          address,
+          error: "Onchain chart data is temporarily unavailable",
+          dataQuality: unavailableDataQuality("source-unavailable"),
+        },
+        {
+          status: 503,
+          headers: {
+            "Cache-Control": "no-store",
+            "Retry-After": "5",
+            "X-Programmable-Data-Quality": "unavailable",
+            "X-Programmable-Read-Source": "rpc",
+          },
+        },
+      );
+    }
+
+    let liveSnapshot = operationalSnapshot;
+    try {
+      liveSnapshot = await withSameBlockEthUsdQuote({
+        deployment,
+        snapshot: liveSnapshot,
+      });
+    } catch {
+      liveSnapshot = withoutUnboundEthUsdQuote(liveSnapshot);
+    }
     const liveToken = (
       await enrichTokensWithAlchemyPoolState({
         deployment,
@@ -132,7 +191,7 @@ export async function GET(request: NextRequest) {
       deployment,
       token: liveToken,
       snapshotBlock: BigInt(liveSnapshot.blockNumber),
-      ethUsdQuote: model.snapshot.ethUsdQuote,
+      ethUsdQuote: liveSnapshot.ethUsdQuote,
       range: requestedRange,
     });
     const { freshness, ...publicSeries } = series;

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -3,11 +3,15 @@ import { getAddress, isAddress } from "viem";
 
 import {
   getAlchemyOnchainDeployment,
-  enrichTokensWithAlchemyPrices,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../../lib/alchemy/explore.server";
-import { enrichTokensWithAlchemyPoolState } from "../../../../lib/alchemy/live-market.server";
+import {
+  enrichTokensWithAlchemyPoolState,
+  readVerifiedOperationalMarketSnapshot,
+  withSameBlockEthUsdQuote,
+  withoutUnboundEthUsdQuote,
+} from "../../../../lib/alchemy/live-market.server";
 import { suppressRouterBoundCustomProjectDuplicates } from "../../../../lib/alchemy/router-custom-collision";
 import {
   createExploreConsumerSource,
@@ -106,7 +110,21 @@ export async function GET(request: NextRequest) {
 
   try {
     const address = getAddress(input);
-    const [canonicalAttempt, customAttempt, referenceHead] = await Promise.all([
+    let deployment: ReturnType<typeof getAlchemyOnchainDeployment> | null = null;
+    try {
+      deployment = getAlchemyOnchainDeployment();
+    } catch {
+      // Provider readiness is independent from canonical launch identity.
+    }
+    const operationalSnapshotRead = deployment?.status === "ready"
+      ? readVerifiedOperationalMarketSnapshot(deployment)
+      : Promise.resolve(null);
+    const [
+      canonicalAttempt,
+      customAttempt,
+      referenceHead,
+      operationalSnapshot,
+    ] = await Promise.all([
       settleTokenSource(readCanonicalTokenSource({
         primary: readPrimaryTokenModel,
         fallback: readDurableTokenFallback,
@@ -115,6 +133,7 @@ export async function GET(request: NextRequest) {
         primary: () => readProductionCustomExploreDirectoryV1(request.signal),
       })),
       readExploreReferenceHeadWithinRouteBudget(),
+      operationalSnapshotRead,
     ]);
     if (canonicalAttempt.source === null && customAttempt.source === null) {
       throw canonicalAttempt.error ?? customAttempt.error;
@@ -184,53 +203,44 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    let priced = token;
-    let priceApiApplied = false;
-    if (priced && canonicalSource?.status === "current") {
+    let liveSnapshot = operationalSnapshot;
+    if (liveSnapshot && deployment?.status === "ready") {
       try {
-        const previous = priced;
-        priced = (await enrichTokensWithAlchemyPrices([priced]))[0] ?? priced;
-        priceApiApplied =
-          priced.tokenPriceUsdWad !== previous.tokenPriceUsdWad ||
-          priced.fdvUsdWad !== previous.fdvUsdWad;
+        liveSnapshot = await withSameBlockEthUsdQuote({
+          deployment,
+          snapshot: liveSnapshot,
+        });
       } catch {
-        // Keep the canonical token when price enrichment is unavailable.
+        liveSnapshot = withoutUnboundEthUsdQuote(liveSnapshot);
       }
     }
-    const liveSnapshot =
-      model?.status === "ready"
-        ? (model.launchDiscoverySnapshot ?? model.snapshot)
-        : null;
-    let deployment: ReturnType<typeof getAlchemyOnchainDeployment> | null = null;
-    if (canonicalSource?.status === "current") {
-      try {
-        deployment = getAlchemyOnchainDeployment();
-      } catch {
-        // Provider readiness is independent from canonical launch identity.
-      }
-    }
-    let enriched = priced;
-    if (priced && liveSnapshot && deployment?.status === "ready") {
+    let enriched = token;
+    if (token && liveSnapshot && deployment?.status === "ready") {
       try {
         enriched = (
           await enrichTokensWithAlchemyPoolState({
             deployment,
             snapshot: liveSnapshot,
-            tokens: [priced],
+            tokens: [token],
           })
-        )[0] ?? priced;
+        )[0] ?? token;
       } catch {
         // Preserve the identity and older valuation with explicit freshness.
       }
     }
-    const identityAsOfBlock = liveSnapshot?.blockNumber ?? null;
+    const identityAsOfBlock = model?.status === "ready"
+      ? (model.launchDiscoverySnapshot ?? model.snapshot).blockNumber
+      : null;
     const referenceBlock = greatestBlockNumber(
       identityAsOfBlock,
       referenceHead?.blockNumber,
+      operationalSnapshot?.blockNumber,
     );
     const valuationContext = {
       referenceBlock,
-      forceStale: canonicalSource?.status === "last-known-good",
+      forceStale:
+        canonicalSource?.status === "last-known-good" ||
+        operationalSnapshot === null,
     } as const;
     const valuedToken = enriched
       ? withExploreValuation(
@@ -258,6 +268,14 @@ export async function GET(request: NextRequest) {
     const publicValuedToken = valuedToken
       ? publicExploreEntryV1(valuedToken)
       : null;
+    const livePriceSource =
+      valuedToken?.valuation.status === "available" &&
+        valuedToken.valuation.freshness === "current" &&
+        valuedToken.valuation.asOfBlock === liveSnapshot?.blockNumber
+        ? valuedToken.valuation.currency === "usd"
+          ? "state-view+chainlink"
+          : "state-view"
+        : "read-model";
     const rpcProvider = exploreRpcProviderHeader(deployment);
     const status = "ready" as const;
     return NextResponse.json(
@@ -284,8 +302,7 @@ export async function GET(request: NextRequest) {
           "X-Programmable-Valuation-Metric": "fdv",
           ...(valuedToken
             ? {
-                "X-Programmable-Price-Source":
-                  priceApiApplied ? "alchemy" : "read-model",
+                "X-Programmable-Price-Source": livePriceSource,
               }
             : {}),
           ...sourceHeaders,

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -57,7 +57,7 @@ type TokenCard = {
   imageUrl: string;
   links: readonly TokenLink[];
   valuation?: MarketCapMetric;
-  marketStatus?: "No market" | "Unavailable";
+  marketStatus?: "No market" | "Last verified" | "Unavailable";
   usesFallbackImage: boolean;
   tokenAddress?: `0x${string}`;
   launchCategory: "Classic" | "Custom";
@@ -65,7 +65,7 @@ type TokenCard = {
 
 export function exploreMarketStatusLabel(
   entry: ExploreEntry | ValuedExploreEntry,
-): "No market" | "Unavailable" | undefined {
+): "No market" | "Last verified" | "Unavailable" | undefined {
   if (entry.exploreKind === "custom-project" && entry.markets.length === 0) {
     return "No market";
   }
@@ -73,7 +73,10 @@ export function exploreMarketStatusLabel(
   const valuation = isExploreValuation(explicit)
     ? explicit
     : exploreValuation(entry);
-  return valuation.status === "unavailable" ? "Unavailable" : undefined;
+  if (valuation.status === "unavailable") return "Unavailable";
+  if (valuation.freshness === "stale") return "Last verified";
+  if (valuation.freshness === "unknown") return "Unavailable";
+  return undefined;
 }
 
 type TokenSort = "newest" | "oldest" | "market-cap" | "market-cap-asc";
@@ -912,7 +915,10 @@ export function getExploreValuationMetric(
   token: ExploreEntry | ValuedExploreEntry,
 ): MarketCapMetric | undefined {
   const valuation = valuationForEntry(token);
-  if (valuation.status !== "available") return undefined;
+  if (
+    valuation.status !== "available" ||
+    valuation.freshness !== "current"
+  ) return undefined;
   const value = Number(BigInt(valuation.valueWad)) / 1e18;
   if (!Number.isFinite(value) || value <= 0) return undefined;
   if (valuation.currency === "usd") return { kind: "usd", value };

--- a/components/hookathon-countdown.module.css
+++ b/components/hookathon-countdown.module.css
@@ -56,26 +56,12 @@
   text-wrap: balance;
 }
 
-.deadline {
-  align-items: baseline;
-  color: var(--brand-ivory-muted);
-  display: flex;
-  flex-wrap: wrap;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-  gap: 4px;
-  line-height: 16px;
-  margin: 12px 0 0;
-  justify-content: center;
-}
-
 .actions {
   align-items: center;
   display: flex;
   gap: 16px;
   justify-content: center;
-  margin-top: 20px;
+  margin-top: 24px;
 }
 
 .secondaryAction,
@@ -100,7 +86,6 @@
   background: var(--brand-ivory);
   border: 1px solid var(--brand-ivory);
   color: #010103;
-  gap: 8px;
   min-width: 184px;
   text-decoration: none;
 }
@@ -144,10 +129,6 @@
 }
 
 @media (max-width: 420px) {
-  .deadline {
-    column-gap: 8px;
-  }
-
   .timer {
     gap: 12px;
     grid-template-columns: repeat(4, minmax(42px, 1fr));

--- a/components/hookathon-countdown.tsx
+++ b/components/hookathon-countdown.tsx
@@ -10,7 +10,6 @@ import {
 
 export type HookathonCountdownProps = Readonly<{
   deadlineIso: string;
-  deadlineDisplay: string;
   hookbuilderUrl: string;
   initialNowMs: number;
 }>;
@@ -34,7 +33,6 @@ function paddedUnit(value: number) {
 
 export function HookathonCountdown({
   deadlineIso,
-  deadlineDisplay,
   hookbuilderUrl,
   initialNowMs,
 }: HookathonCountdownProps) {
@@ -114,12 +112,9 @@ export function HookathonCountdown({
       </div>
 
       <p className="sr-only">
-        Submissions close on {deadlineDisplay} in Europe/Zurich.
-      </p>
-      <p className={styles.deadline}>
-        <time dateTime={deadlineIso}>{deadlineDisplay}</time>
-        <span aria-hidden="true"> · </span>
-        <span>Europe/Zurich</span>
+        {countdown.ended
+          ? "Submissions closed"
+          : `${countdown.days} days, ${countdown.hours} hours, ${countdown.minutes} minutes and ${countdown.seconds} seconds remaining`}
       </p>
 
       <div className={styles.actions}>
@@ -135,7 +130,6 @@ export function HookathonCountdown({
             target="_blank"
           >
             Open Hookbuilder
-            <span aria-hidden="true">↗</span>
           </a>
         )}
       </div>

--- a/components/hookathon-page.module.css
+++ b/components/hookathon-page.module.css
@@ -9,7 +9,7 @@
 .shell {
   margin: 0 auto;
   max-width: var(--page-width);
-  padding: 20px 32px 28px;
+  padding: 8px 32px 16px;
   width: 100%;
 }
 
@@ -19,49 +19,51 @@
   flex-direction: column;
   gap: 20px;
   justify-content: center;
-  min-height: 250px;
-  padding: 18px 0 30px;
+  min-height: 300px;
+  padding: 28px 0 32px;
   text-align: center;
 }
 
 .hero h1 {
-  font-size: clamp(64px, 6.7vw, 96px);
+  font-size: clamp(64px, 6vw, 88px);
   font-weight: 520;
-  letter-spacing: -0.065em;
-  line-height: 0.9;
+  letter-spacing: -0.06em;
+  line-height: 1;
   margin: 0;
   text-wrap: balance;
 }
 
 .prizes,
-.entry,
-.conditions {
+.eligibility,
+.judging {
+  align-items: center;
   border-top: 1px solid var(--panel-border-soft);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
 }
 
 .prizes {
-  align-items: center;
-  display: grid;
-  gap: 48px;
-  grid-template-columns: minmax(260px, 0.72fr) minmax(480px, 1.28fr);
-  min-height: 112px;
+  gap: 16px;
+  min-height: 124px;
   padding: 20px 0;
 }
 
 .prizeLead {
   align-items: baseline;
   display: flex;
-  gap: 24px;
+  gap: 20px;
+  justify-content: center;
 }
 
 .prizeLead h2,
-.entry > h2,
 .eligibility h2,
 .judging h2 {
   color: var(--brand-ivory-muted);
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 560;
-  line-height: 20px;
+  line-height: 24px;
   margin: 0;
 }
 
@@ -76,17 +78,18 @@
 }
 
 .prizeSplit {
-  display: grid;
-  gap: 24px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: flex;
+  gap: 32px;
+  justify-content: center;
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
 .prizeSplit li {
-  display: grid;
-  gap: 4px;
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
 }
 
 .prizeSplit span {
@@ -97,159 +100,88 @@
 
 .prizeSplit strong {
   font-family: var(--font-plex-mono), monospace;
-  font-size: 24px;
+  font-size: 20px;
   font-variant-numeric: tabular-nums;
   font-weight: 500;
-  letter-spacing: -0.035em;
-  line-height: 32px;
+  letter-spacing: -0.03em;
+  line-height: 28px;
 }
 
-.entry {
-  display: grid;
-  gap: 48px;
-  grid-template-columns: minmax(150px, 0.3fr) minmax(0, 1.7fr);
-  min-height: 188px;
-  padding: 24px 0 28px;
+.eligibility {
+  gap: 8px;
+  min-height: 124px;
+  padding: 20px 0;
 }
 
-.entry > h2 {
-  padding-top: 4px;
-}
-
-.steps {
-  display: grid;
-  gap: 32px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.steps li {
-  align-items: flex-start;
-  display: grid;
-  gap: 16px;
-  grid-template-columns: 28px minmax(0, 1fr);
-}
-
-.stepNumber {
-  align-items: center;
-  border: 1px solid var(--panel-border);
-  border-radius: 50%;
-  color: var(--brand-ivory-soft);
-  display: inline-flex;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
-  height: 28px;
-  justify-content: center;
-  line-height: 1;
-  width: 28px;
-}
-
-.steps h3 {
-  font-size: 24px;
-  font-weight: 560;
-  letter-spacing: -0.035em;
-  line-height: 32px;
-  margin: 0;
-}
-
-.steps p,
 .eligibility p,
 .judging p {
   color: var(--brand-ivory-soft);
-  font-size: 14px;
-  line-height: 20px;
-  margin: 8px 0 0;
+  font-size: 18px;
+  line-height: 28px;
+  margin: 0;
   text-wrap: pretty;
 }
 
-.conditions {
-  display: grid;
-  gap: 64px;
-  grid-template-columns: minmax(0, 1.35fr) minmax(380px, 0.65fr);
-  min-height: 132px;
-  padding: 22px 0 12px;
-}
-
-.eligibility,
-.judging {
-  min-width: 0;
-}
-
 .eligibility p {
-  max-width: 84ch;
+  max-width: 900px;
+}
+
+.eligibility a {
+  color: var(--brand-ivory);
+  font-weight: 560;
+  text-decoration-color: var(--brand-ivory-muted);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.eligibility a:focus-visible {
+  border-radius: 4px;
+  outline: 2px solid var(--brand-ivory);
+  outline-offset: 4px;
+}
+
+.judging {
+  gap: 8px;
+  min-height: 136px;
+  padding: 20px 0 24px;
 }
 
 .judging ul {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px 24px;
+  gap: 16px 40px;
+  justify-content: center;
   list-style: none;
-  margin: 10px 0 0;
+  margin: 0;
   padding: 0;
 }
 
 .judging li {
   color: var(--brand-ivory);
-  font-size: 18px;
+  font-size: 24px;
   font-weight: 560;
-  letter-spacing: -0.02em;
-  line-height: 28px;
+  letter-spacing: -0.03em;
+  line-height: 32px;
 }
 
 .judging p {
-  max-width: 52ch;
+  max-width: 680px;
 }
 
-@media (max-width: 1100px) {
-  .steps {
-    gap: 24px;
-  }
-
-  .conditions {
-    gap: 40px;
-    grid-template-columns: minmax(0, 1.2fr) minmax(340px, 0.8fr);
-  }
-}
-
-@media (max-width: 960px) {
-  .shell {
-    padding-top: 12px;
-  }
-
-  .hero {
-    gap: 20px;
-    padding-top: 8px;
-  }
-
-  .hero h1 {
-    font-size: 68px;
-  }
-
-  .prizes {
-    gap: 32px;
-    grid-template-columns: minmax(240px, 0.7fr) minmax(0, 1.3fr);
-  }
-
-  .entry {
-    gap: 32px;
-    grid-template-columns: 128px minmax(0, 1fr);
-  }
-
-  .conditions {
-    grid-template-columns: minmax(0, 1fr) minmax(300px, 0.8fr);
+@media (hover: hover) and (pointer: fine) {
+  .eligibility a:hover {
+    color: var(--accent-hover);
   }
 }
 
 @media (max-width: 720px) {
   .shell {
-    padding: 8px 20px calc(32px + env(safe-area-inset-bottom));
+    padding: 0 20px calc(104px + env(safe-area-inset-bottom));
   }
 
   .hero {
-    min-height: 0;
-    padding: 12px 0 28px;
+    min-height: 288px;
+    padding: 32px 0;
   }
 
   .hero h1 {
@@ -257,66 +189,59 @@
   }
 
   .prizes,
-  .entry,
-  .conditions {
-    grid-template-columns: 1fr;
+  .eligibility,
+  .judging {
+    min-height: 0;
   }
 
   .prizes {
     gap: 20px;
-    padding: 24px 0 28px;
+    padding: 28px 0 32px;
   }
 
   .prizeLead {
-    align-items: flex-end;
-    justify-content: space-between;
+    align-items: center;
+    flex-direction: column;
+    gap: 4px;
   }
 
   .prizeLead p {
-    font-size: 36px;
+    font-size: 40px;
   }
 
   .prizeSplit {
-    gap: 16px;
+    gap: 20px;
   }
 
-  .prizeSplit strong {
-    font-size: 20px;
-    line-height: 28px;
+  .prizeSplit li {
+    align-items: center;
+    flex-direction: column;
+    gap: 0;
   }
 
-  .entry {
-    gap: 24px;
-    padding: 24px 0 28px;
-  }
-
-  .entry > h2 {
-    padding-top: 0;
-  }
-
-  .steps {
-    gap: 24px;
-    grid-template-columns: 1fr;
-  }
-
-  .steps li {
-    gap: 16px;
-  }
-
-  .conditions {
-    gap: 28px;
-    padding: 24px 0 12px;
+  .eligibility {
+    gap: 12px;
+    padding: 28px 0 32px;
   }
 
   .eligibility p,
-  .judging p,
-  .steps p {
-    font-size: 16px;
-    line-height: 24px;
+  .judging p {
+    font-size: 18px;
+    line-height: 28px;
+  }
+
+  .judging {
+    gap: 12px;
+    padding: 28px 0 32px;
   }
 
   .judging ul {
-    gap: 8px 20px;
+    gap: 8px 24px;
+  }
+
+  .judging li {
+    font-size: 20px;
+    line-height: 28px;
   }
 }
 
@@ -325,13 +250,22 @@
     padding-inline: 16px;
   }
 
-  .prizeLead {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 8px;
+  .prizeSplit {
+    gap: 14px;
   }
 
-  .prizeSplit {
-    gap: 8px;
+  .prizeSplit strong {
+    font-size: 18px;
+  }
+
+  .judging ul {
+    align-items: center;
+    flex-direction: column;
+  }
+}
+
+@media (forced-colors: active) {
+  .eligibility a {
+    color: LinkText;
   }
 }

--- a/components/hookathon-page.tsx
+++ b/components/hookathon-page.tsx
@@ -1,7 +1,6 @@
 import { HookathonCountdown } from "@/components/hookathon-countdown";
 import styles from "@/components/hookathon-page.module.css";
 import { hookathonConfig } from "@/lib/hookathon/config";
-import { formatHookathonDeadline } from "@/lib/hookathon/time";
 
 const usdFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -14,11 +13,6 @@ export type HookathonPageProps = Readonly<{
 }>;
 
 export function HookathonPage({ initialNowMs }: HookathonPageProps) {
-  const deadlineDisplay = formatHookathonDeadline(
-    hookathonConfig.deadlineIso,
-    hookathonConfig.timeZone,
-  );
-
   return (
     <article
       className={`${styles.page} hookathon-root`}
@@ -28,7 +22,6 @@ export function HookathonPage({ initialNowMs }: HookathonPageProps) {
         <header className={styles.hero}>
           <h1 id="hookathon-title">{hookathonConfig.name}</h1>
           <HookathonCountdown
-            deadlineDisplay={deadlineDisplay}
             deadlineIso={hookathonConfig.deadlineIso}
             hookbuilderUrl={hookathonConfig.hookbuilderUrl}
             initialNowMs={initialNowMs}
@@ -50,45 +43,36 @@ export function HookathonPage({ initialNowMs }: HookathonPageProps) {
           </ol>
         </section>
 
-        <section className={styles.entry} aria-labelledby="hookathon-entry">
-          <h2 id="hookathon-entry">How to enter</h2>
-          <ol className={styles.steps}>
-            {hookathonConfig.entrySteps.map((step) => (
-              <li key={step.id}>
-                <span className={styles.stepNumber} aria-hidden="true">
-                  {step.number}
-                </span>
-                <div>
-                  <h3>{step.title}</h3>
-                  <p>{step.description}</p>
-                </div>
-              </li>
-            ))}
-          </ol>
+        <section
+          className={styles.eligibility}
+          aria-labelledby="hookathon-eligibility"
+        >
+          <h2 id="hookathon-eligibility">Eligibility</h2>
+          <p>
+            {hookathonConfig.eligibility.beforeSubmissionLink}{" "}
+            <a
+              href={hookathonConfig.submissionUrl}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {hookathonConfig.eligibility.submissionLinkLabel}
+            </a>
+            {hookathonConfig.eligibility.afterSubmissionLink}
+          </p>
         </section>
 
-        <div className={styles.conditions}>
-          <section
-            className={styles.eligibility}
-            aria-labelledby="hookathon-eligibility"
-          >
-            <h2 id="hookathon-eligibility">Eligibility</h2>
-            <p>{hookathonConfig.eligibility.description}</p>
-          </section>
-
-          <section
-            className={styles.judging}
-            aria-labelledby="hookathon-judging"
-          >
-            <h2 id="hookathon-judging">Judging</h2>
-            <ul aria-label="Judging criteria">
-              {hookathonConfig.judging.criteria.map((criterion) => (
-                <li key={criterion}>{criterion}</li>
-              ))}
-            </ul>
-            <p>{hookathonConfig.judging.description}</p>
-          </section>
-        </div>
+        <section
+          className={styles.judging}
+          aria-labelledby="hookathon-judging"
+        >
+          <h2 id="hookathon-judging">Judging</h2>
+          <ul aria-label="Judging criteria">
+            {hookathonConfig.judging.criteria.map((criterion) => (
+              <li key={criterion}>{criterion}</li>
+            ))}
+          </ul>
+          <p>{hookathonConfig.judging.description}</p>
+        </section>
       </div>
     </article>
   );

--- a/lib/alchemy/live-market.server.ts
+++ b/lib/alchemy/live-market.server.ts
@@ -4,6 +4,7 @@ import {
   createPublicClient,
   formatUnits,
   http,
+  parseAbi,
   type Hex,
 } from "viem";
 import { mainnet, sepolia } from "viem/chains";
@@ -14,8 +15,13 @@ import {
   nativePriceWadFromSqrtPriceX96,
 } from "../onchain/math";
 import { withOperationalRpcFailover } from "../onchain/operational-rpc-failover.server";
+import { readOperationalRpcHealth } from "../onchain/rpc-health";
 import type { ExploreSnapshot, ReadyOnchainDeployment } from "../onchain/types";
-import { usdValueFromWei } from "../onchain/usd";
+import {
+  assertValidEthUsdSnapshot,
+  ETH_USD_FEED_ADDRESS,
+  usdValueFromWei,
+} from "../onchain/usd";
 import {
   isLaunchStampProvenanceV1,
   type LauncherToken,
@@ -58,6 +64,10 @@ function trimPoolStateCache() {
 }
 
 const NATIVE_CURRENCY = "0x0000000000000000000000000000000000000000";
+const ethUsdReadAbi = parseAbi([
+  "function decimals() view returns (uint8)",
+  "function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)",
+]);
 
 function validLaunchStampForToken(token: LauncherToken) {
   const stamp = token.launchStampProvenance;
@@ -138,6 +148,108 @@ function snapshotBlock(snapshot: ExploreSnapshot) {
     throw new Error("Alchemy live market snapshot block is invalid");
   }
   return BigInt(snapshot.blockNumber);
+}
+
+/**
+ * A launch-discovery snapshot may be newer than the durable market snapshot.
+ * Never carry the durable ETH/USD quote across that block boundary: doing so
+ * combines a current pool ratio with an older FX observation and produces a
+ * plausible but incorrect USD FDV.
+ */
+export function withoutUnboundEthUsdQuote(
+  snapshot: ExploreSnapshot,
+): ExploreSnapshot {
+  const withoutQuote = { ...snapshot };
+  delete withoutQuote.ethUsdQuote;
+  return withoutQuote;
+}
+
+/**
+ * Resolves the market read target from the two configured operational RPCs,
+ * not from the potentially lagging launch-discovery model. Only a fresh
+ * confirmed block with matching hashes from both providers can be labelled as
+ * current market data.
+ */
+export async function readVerifiedOperationalMarketSnapshot(
+  deployment: ReadyOnchainDeployment,
+): Promise<ExploreSnapshot | null> {
+  const health = await readOperationalRpcHealth(deployment);
+  if (
+    health.status !== "healthy" ||
+    health.read.status !== "available" ||
+    health.quorum.status !== "verified" ||
+    health.confirmedBlock === null
+  ) return null;
+
+  return {
+    chainId: deployment.chainId,
+    blockNumber: health.confirmedBlock.number,
+    blockHash: health.confirmedBlock.hash,
+    confirmations: Number(deployment.confirmations),
+  };
+}
+
+/**
+ * Reads Chainlink at the exact pool-state block and verifies the provider's
+ * block hash before the quote can be used. Capacity/transport failures use the
+ * fixed operational secondary through the same bounded failover policy as
+ * StateView reads.
+ */
+export async function withSameBlockEthUsdQuote(input: {
+  deployment: ReadyOnchainDeployment;
+  snapshot: ExploreSnapshot;
+}): Promise<ExploreSnapshot> {
+  const snapshot = withoutUnboundEthUsdQuote(input.snapshot);
+  if (input.deployment.chainId !== 1) return snapshot;
+  const blockNumber = snapshotBlock(snapshot);
+  const quote = await withOperationalRpcFailover(
+    input.deployment,
+    async (rpcDeployment) => {
+      const client = createPublicClient({
+        chain: mainnet,
+        transport: http(rpcDeployment.rpcUrl, {
+          retryCount: 1,
+          timeout: 12_000,
+        }),
+      });
+      const [decimals, roundData, block] = await Promise.all([
+        client.readContract({
+          address: ETH_USD_FEED_ADDRESS,
+          abi: ethUsdReadAbi,
+          functionName: "decimals",
+          blockNumber,
+        }),
+        client.readContract({
+          address: ETH_USD_FEED_ADDRESS,
+          abi: ethUsdReadAbi,
+          functionName: "latestRoundData",
+          blockNumber,
+        }),
+        client.getBlock({ blockNumber }),
+      ]);
+      const [roundId, answer, , updatedAt] = roundData;
+      assertValidEthUsdSnapshot({
+        expectedBlockHash: snapshot.blockHash,
+        actualBlockHash: block.hash,
+        blockTimestamp: block.timestamp,
+        roundId,
+        answer,
+        updatedAt,
+      });
+      return { roundId, answer, decimals, updatedAt };
+    },
+  );
+
+  return {
+    ...snapshot,
+    ethUsdQuote: {
+      feedAddress: ETH_USD_FEED_ADDRESS,
+      roundId: quote.roundId.toString(),
+      answer: quote.answer.toString(),
+      decimals: quote.decimals,
+      updatedAt: quote.updatedAt.toString(),
+    },
+  };
 }
 
 function poolStateCacheKey(input: {

--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -140,9 +140,11 @@ function valuationFreshness(
   Extract<ExploreValuation, { status: "available" }>,
   "freshness" | "asOfBlock" | "lagBlocks"
 > | null {
-  if (!asOfBlock) {
-    return { freshness: forceStale ? "stale" : "unknown" };
-  }
+  // A numeric valuation without block provenance cannot be reconciled with
+  // the launch/read snapshot. Treat it as unavailable instead of publishing a
+  // plausible but unprovable USD value (for example an offchain price API
+  // response with no onchain observation block).
+  if (!asOfBlock) return null;
   const asOf = blockNumber(asOfBlock);
   const reference = blockNumber(referenceBlock);
   if (asOf === null || (reference !== null && asOf > reference)) return null;
@@ -290,7 +292,8 @@ export function publicExploreEntryV1(
 export function valuationSortValue(entry: ExploreEntry): bigint | null {
   const value = (entry as Partial<ValuedExploreEntry>).valuation;
   return value?.status === "available" &&
-    value.currency === "usd"
+    value.currency === "usd" &&
+    value.freshness === "current"
     ? positiveUint256(value.valueWad)
     : null;
 }

--- a/lib/hookathon/config.ts
+++ b/lib/hookathon/config.ts
@@ -1,10 +1,3 @@
-export type HookathonEntryStep = Readonly<{
-  id: "build" | "submit" | "launch";
-  number: 1 | 2 | 3;
-  title: "Build" | "Submit" | "Launch";
-  description: string;
-}>;
-
 export type HookathonPrize = Readonly<{
   place: "1st" | "2nd" | "3rd";
   amountUsd: number;
@@ -17,13 +10,14 @@ export type HookathonConfig = Readonly<{
   timeZone: "Europe/Zurich";
   totalPrizeUsd: number;
   prizes: readonly HookathonPrize[];
-  builderPrompt: string;
   hookbuilderUrl: "https://github.com/0xprogrammable/hookbuilder";
-  entrySteps: readonly HookathonEntryStep[];
+  submissionUrl: "https://github.com/0xprogrammable/submit-launch";
   eligibility: Readonly<{
     participation: "Anyone can enter";
     teamSize: "No team size limit";
-    description: string;
+    beforeSubmissionLink: string;
+    submissionLinkLabel: "Submit Launch";
+    afterSubmissionLink: string;
   }>;
   judging: Readonly<{
     criteria: readonly ["Originality", "Usefulness", "Execution"];
@@ -31,13 +25,10 @@ export type HookathonConfig = Readonly<{
   }>;
 }>;
 
-export const HOOKATHON_BUILDER_PROMPT =
-  "Use the Programmable v4 Hook Builder to turn this idea into a complete, review-ready Hookathon project: [DESCRIBE YOUR IDEA]. Build the contracts, tests and required evidence, preserve the core idea, prepare the Hookbuilder pull request, and ask me only for decisions that materially change the project.";
-
 export const hookathonConfig = {
   name: "Hookathon",
-  confirmationIso: "2026-08-10T19:40:20+02:00",
-  deadlineIso: "2026-08-14T17:40:20Z",
+  confirmationIso: "2026-08-11T10:09:29+02:00",
+  deadlineIso: "2026-08-15T08:09:29Z",
   timeZone: "Europe/Zurich",
   totalPrizeUsd: 10_000,
   prizes: [
@@ -45,34 +36,16 @@ export const hookathonConfig = {
     { place: "2nd", amountUsd: 3_000 },
     { place: "3rd", amountUsd: 2_000 },
   ],
-  builderPrompt: HOOKATHON_BUILDER_PROMPT,
   hookbuilderUrl: "https://github.com/0xprogrammable/hookbuilder",
-  entrySteps: [
-    {
-      id: "build",
-      number: 1,
-      title: "Build",
-      description: "Copy the provided prompt into Codex and describe the idea.",
-    },
-    {
-      id: "submit",
-      number: 2,
-      title: "Submit",
-      description: "Open the generated Applicant pull request in Hookbuilder.",
-    },
-    {
-      id: "launch",
-      number: 3,
-      title: "Launch",
-      description:
-        "After approval, launch the exact project on Programmable before the timer ends.",
-    },
-  ],
+  submissionUrl: "https://github.com/0xprogrammable/submit-launch",
   eligibility: {
     participation: "Anyone can enter",
     teamSize: "No team size limit",
-    description:
-      "Anyone can enter, with no team size limit. A valid entry is a hook-powered token or hook project with an X account and project website, submitted through Hookbuilder, approved, and launched as the exact project on Programmable before the countdown ends. A pull request alone does not qualify.",
+    beforeSubmissionLink:
+      "Anyone can enter, with no team size limit. Build a hook-powered token or hook project with an X account and project website. Apply through",
+    submissionLinkLabel: "Submit Launch",
+    afterSubmissionLink:
+      ", get approved and launch on Programmable before the countdown ends.",
   },
   judging: {
     criteria: ["Originality", "Usefulness", "Execution"],

--- a/lib/server/action-rpc-quorum.server.ts
+++ b/lib/server/action-rpc-quorum.server.ts
@@ -355,7 +355,7 @@ export function creatorClaimRpcProviders(
             "https://ethereum-sepolia-rpc.publicnode.com",
             "https://rpc.sepolia.org",
           ],
-    maximumProviders: 2,
+    maximumProviders: 4,
   });
 }
 

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -35,7 +35,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       dependencies: Object.freeze([
         Object.freeze({
           path: "lib/server/action-rpc-quorum.server.ts",
-          sha256: "712d4df420068c20e3456606d87062203b89b4674a363109244175d113b2a413",
+          sha256: "0cb84ff2a409980e84383699f73bfc1941dfe328f39e94d8e3658cc4aa4ed6f3",
         }),
       ]),
       policy: Object.freeze({

--- a/tests/action-rpc-quorum.test.ts
+++ b/tests/action-rpc-quorum.test.ts
@@ -202,7 +202,12 @@ describe("action-route RPC quorums", () => {
       rpcUrlSecondary: QUICKNODE_MAINNET,
     });
     expectIndependent(providers);
-    expect(providers).toHaveLength(2);
+    expect(providers.map((provider) => provider.vendorGroup)).toEqual([
+      "drpc",
+      "quicknode",
+      "publicnode",
+      "mevblocker",
+    ]);
 
     expectSafeFailure(
       () =>

--- a/tests/alchemy-live-market.test.ts
+++ b/tests/alchemy-live-market.test.ts
@@ -3,18 +3,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
+  getBlock: vi.fn(),
   multicall: vi.fn(),
+  readContract: vi.fn(),
 }));
 
 vi.mock("viem", async (importOriginal) => {
   const actual = await importOriginal<typeof import("viem")>();
   return {
     ...actual,
-    createPublicClient: vi.fn(() => ({ multicall: mocks.multicall })),
+    createPublicClient: vi.fn(() => ({
+      getBlock: mocks.getBlock,
+      multicall: mocks.multicall,
+      readContract: mocks.readContract,
+    })),
   };
 });
 
-import { enrichTokensWithAlchemyPoolState } from "../lib/alchemy/live-market.server";
+import {
+  enrichTokensWithAlchemyPoolState,
+  withSameBlockEthUsdQuote,
+  withoutUnboundEthUsdQuote,
+} from "../lib/alchemy/live-market.server";
 import { exploreValuation } from "../lib/explore-financial-data";
 import type { ReadyOnchainDeployment } from "../lib/onchain/types";
 import type { LauncherToken } from "../lib/tokens";
@@ -44,6 +54,70 @@ const deployment = {
 describe("Alchemy live pool market state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("replaces an older ETH/USD quote with a verified same-block quote", async () => {
+    const blockHash = `0x${"77".repeat(32)}` as const;
+    mocks.readContract
+      .mockResolvedValueOnce(8)
+      .mockResolvedValueOnce([
+        12n,
+        300_000_000_000n,
+        0n,
+        1_786_400_000n,
+        12n,
+      ]);
+    mocks.getBlock.mockResolvedValue({
+      hash: blockHash,
+      timestamp: 1_786_400_100n,
+    });
+
+    const snapshot = await withSameBlockEthUsdQuote({
+      deployment,
+      snapshot: {
+        chainId: 1,
+        blockNumber: "25680000",
+        blockHash,
+        confirmations: 0,
+        ethUsdQuote: {
+          feedAddress: "0x8888888888888888888888888888888888888888",
+          roundId: "1",
+          answer: "1",
+          decimals: 8,
+          updatedAt: "1",
+        },
+      },
+    });
+
+    expect(snapshot.ethUsdQuote).toEqual({
+      feedAddress: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+      roundId: "12",
+      answer: "300000000000",
+      decimals: 8,
+      updatedAt: "1786400000",
+    });
+    expect(mocks.readContract.mock.calls.every(
+      ([request]) => request.blockNumber === 25_680_000n,
+    )).toBe(true);
+    expect(mocks.getBlock).toHaveBeenCalledWith({
+      blockNumber: 25_680_000n,
+    });
+  });
+
+  it("removes a quote that is not bound to the live snapshot", () => {
+    expect(withoutUnboundEthUsdQuote({
+      chainId: 1,
+      blockNumber: "25680000",
+      blockHash: `0x${"77".repeat(32)}`,
+      confirmations: 0,
+      ethUsdQuote: {
+        feedAddress: "0x8888888888888888888888888888888888888888",
+        roundId: "1",
+        answer: "1",
+        decimals: 8,
+        updatedAt: "1",
+      },
+    })).not.toHaveProperty("ethUsdQuote");
   });
 
   it("derives current token price and market cap from StateView and reuses the five-second read", async () => {
@@ -126,6 +200,62 @@ describe("Alchemy live pool market state", () => {
     expect(mocks.multicall.mock.calls.every(
       ([request]) => request.blockNumber === 25_680_000n,
     )).toBe(true);
+  });
+
+  it("matches the public Programmable V4 StateView and Chainlink golden sample", async () => {
+    mocks.multicall.mockResolvedValueOnce([
+      {
+        status: "success",
+        result: [71_024_877_262_306_743_364_511_803_610_105n, 135_975, 0, 0],
+      },
+    ]).mockResolvedValueOnce([
+      {
+        status: "success",
+        result: 41_873_636_805_959_591_033_727n,
+      },
+    ]);
+    const token = {
+      id: "1:0x7987f03462200b3d8a072e02c89a8a41dcb124ee",
+      name: "Programmable",
+      symbol: "V4",
+      tokenAddress: "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
+      hookAddress: "0x025a386eAa79f6067d29848FD05ccC71bEAb20CC",
+      poolId: "0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0",
+      launchedAt: "2026-07-27T22:12:23.000Z",
+      totalSupplyRaw: "1000000000000000000000000000",
+      tokenDecimals: 18,
+      activeLiquidity: "41873636805959591033727",
+      launchModel: "classic",
+      totalSwapFeeBps: 100,
+      liquidityPath: "meme",
+    } satisfies LauncherToken;
+
+    const [enriched] = await enrichTokensWithAlchemyPoolState({
+      deployment,
+      snapshot: {
+        chainId: 1,
+        blockNumber: "25730555",
+        blockHash: "0x88e3bc3a2ffed82bf413cd16c2bad04d8e5482306b55398ceb791285ff5248b1",
+        confirmations: 0,
+        ethUsdQuote: {
+          feedAddress: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+          roundId: "129127208515966893693",
+          answer: "187594280000",
+          decimals: 8,
+          updatedAt: "1786435217",
+        },
+      },
+      tokens: [token],
+    });
+
+    expect(enriched).toMatchObject({
+      currentTick: 135_975,
+      tokenPriceEthWei: "1244337483530",
+      marketCapEthWei: "1244337483530407886719",
+      tokenPriceUsdWad: "2334305942998222",
+      fdvUsdWad: "2334305942998987256153723",
+      indexedValuationBlockNumber: "25730555",
+    });
   });
 
   it("reads every valid stamped PoolId at one block and separates state from valuation", async () => {

--- a/tests/creator-claim-action-activation.test.ts
+++ b/tests/creator-claim-action-activation.test.ts
@@ -145,6 +145,12 @@ function rpcClient(estimatedGas: bigint, gasPrice: bigint, balance: bigint) {
   };
 }
 
+function unavailableRpcClient(message = "provider capacity unavailable") {
+  return {
+    getBlockNumber: vi.fn().mockRejectedValue(new Error(message)),
+  };
+}
+
 vi.mock("../lib/data-pipeline/route-activation.server", () => ({
   indexedLaunchLookupEnabled: () => mocks.indexedEnabled,
 }));
@@ -197,10 +203,14 @@ describe("creator claim action identity activation", () => {
     const clients = [
       rpcClient(100_000n, 2_000_000_000n, 10n ** 18n),
       rpcClient(110_000n, 3_000_000_000n, 9n * 10n ** 17n),
+      rpcClient(100_000n, 2_000_000_000n, 10n ** 18n),
+      rpcClient(110_000n, 3_000_000_000n, 9n * 10n ** 17n),
     ];
     mocks.createPublicClient
       .mockImplementationOnce(() => clients[0])
-      .mockImplementationOnce(() => clients[1]);
+      .mockImplementationOnce(() => clients[1])
+      .mockImplementationOnce(() => clients[2])
+      .mockImplementationOnce(() => clients[3]);
   });
 
   it.each([true, false])(
@@ -221,11 +231,60 @@ describe("creator claim action identity activation", () => {
           accountBalanceWei: "900000000000000000",
         },
       });
-      expect(mocks.createPublicClient).toHaveBeenCalledTimes(2);
+      expect(mocks.createPublicClient).toHaveBeenCalledTimes(4);
       expect(mocks.lookup).toHaveBeenCalledTimes(indexedEnabled ? 1 : 0);
       expect(mocks.readLegacy).toHaveBeenCalledTimes(indexedEnabled ? 0 : 1);
     },
   );
+
+  it("uses two agreeing fixed fallback providers when both configured providers are unavailable", async () => {
+    const clients = [
+      unavailableRpcClient("monthly capacity exceeded"),
+      unavailableRpcClient("secondary transport unavailable"),
+      rpcClient(105_000n, 2_500_000_000n, 8n * 10n ** 17n),
+      rpcClient(108_000n, 2_700_000_000n, 7n * 10n ** 17n),
+    ];
+    mocks.createPublicClient.mockReset();
+    for (const client of clients) {
+      mocks.createPublicClient.mockImplementationOnce(() => client);
+    }
+
+    const response = await POST(request());
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      status: "ready",
+      claim: { account: creator, tokenAddress: token, poolId },
+      gas: {
+        estimatedGas: "108000",
+        gasPriceWei: "2700000000",
+        accountBalanceWei: "700000000000000000",
+      },
+    });
+  });
+
+  it("returns a retryable typed error when fewer than two providers can be verified", async () => {
+    mocks.createPublicClient.mockReset();
+    for (let index = 0; index < 4; index += 1) {
+      mocks.createPublicClient.mockImplementationOnce(() =>
+        unavailableRpcClient(),
+      );
+    }
+
+    const response = await POST(request());
+    const payload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(payload).toMatchObject({
+      status: "blocked",
+      error: {
+        code: "rpc-unavailable",
+        message: "Creator claim reads are temporarily unavailable. Try again",
+      },
+    });
+    expect(JSON.stringify(payload)).not.toContain("capacity");
+  });
 
   it.each([true, false])(
     "fails closed before simulation for same-provider aliases with indexed lookup %s",
@@ -237,7 +296,10 @@ describe("creator claim action identity activation", () => {
       const response = await POST(request());
       const serialized = JSON.stringify(await response.json());
 
-      expect(response.status).toBe(502);
+      expect(response.status).toBe(503);
+      expect(JSON.parse(serialized)).toMatchObject({
+        error: { code: "rpc-unavailable" },
+      });
       expect(mocks.createPublicClient).not.toHaveBeenCalled();
       expect(serialized).not.toContain("alchemy-claim-key");
       expect(serialized).not.toContain("second-claim-secret");

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -8,8 +8,9 @@ import type { ExploreEntry, LauncherToken } from "../lib/tokens";
 import { customGraphToken } from "./launch-stamp-surface-fixture";
 
 const mocks = vi.hoisted(() => ({
-  enrichTokensWithAlchemyPrices: vi.fn(),
   enrichTokensWithAlchemyPoolState: vi.fn(),
+  readVerifiedOperationalMarketSnapshot: vi.fn(),
+  withSameBlockEthUsdQuote: vi.fn(),
   getAlchemyOnchainDeployment: vi.fn(),
   readAlchemyExploreModel: vi.fn(),
   readProductionCustomExploreDirectoryV1: vi.fn(),
@@ -20,7 +21,6 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/alchemy/explore.server", () => ({
-  enrichTokensWithAlchemyPrices: mocks.enrichTokensWithAlchemyPrices,
   getAlchemyOnchainDeployment: mocks.getAlchemyOnchainDeployment,
   readAlchemyExploreModel: mocks.readAlchemyExploreModel,
   safeAlchemyError: mocks.safeAlchemyError,
@@ -28,6 +28,17 @@ vi.mock("../lib/alchemy/explore.server", () => ({
 
 vi.mock("../lib/alchemy/live-market.server", () => ({
   enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
+  readVerifiedOperationalMarketSnapshot:
+    mocks.readVerifiedOperationalMarketSnapshot,
+  withSameBlockEthUsdQuote: mocks.withSameBlockEthUsdQuote,
+  withoutUnboundEthUsdQuote: (snapshot: {
+    ethUsdQuote?: unknown;
+    [key: string]: unknown;
+  }) => {
+    const withoutQuote = { ...snapshot };
+    delete withoutQuote.ethUsdQuote;
+    return withoutQuote;
+  },
 }));
 
 vi.mock("../lib/server/custom-launch/explore-directory-v1", () => ({
@@ -51,7 +62,6 @@ vi.mock("../lib/onchain/durable-model", () => ({
 import {
   dedupeExploreEntriesV1,
   GET,
-  inheritExploreEthUsdQuote,
   paginateExploreEntriesV1,
 } from "../app/api/explore/route";
 
@@ -164,42 +174,13 @@ describe("Explore API Alchemy boundary", () => {
       status: "ready",
       rpcUrlSecondary: "https://secondary.example",
     });
-    mocks.enrichTokensWithAlchemyPrices.mockImplementation(async (tokens) => [
-      ...tokens,
-    ]);
+    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(snapshot);
+    mocks.withSameBlockEthUsdQuote.mockImplementation(
+      async ({ snapshot: value }) => value,
+    );
     mocks.enrichTokensWithAlchemyPoolState.mockImplementation(
       async ({ tokens }: { tokens: readonly LauncherToken[] }) => [...tokens],
     );
-  });
-
-  it("inherits the durable ETH/USD quote for newest live market values", () => {
-    const ethUsdQuote = {
-      feedAddress: "0x1111111111111111111111111111111111111111" as const,
-      roundId: "12",
-      answer: "350000000000",
-      decimals: 8,
-      updatedAt: "2026-08-04T10:00:00.000Z",
-    };
-    const launchSnapshot = {
-      ...snapshot,
-      blockNumber: "25630001",
-    };
-
-    expect(
-      inheritExploreEthUsdQuote(launchSnapshot, {
-        ...snapshot,
-        ethUsdQuote,
-      }),
-    ).toEqual({
-      ...launchSnapshot,
-      ethUsdQuote,
-    });
-    expect(
-      inheritExploreEthUsdQuote(
-        { ...launchSnapshot, ethUsdQuote },
-        snapshot,
-      ),
-    ).toEqual({ ...launchSnapshot, ethUsdQuote });
   });
 
   it("orders mixed Classic and Custom launches by canonical chain position", () => {
@@ -322,7 +303,7 @@ describe("Explore API Alchemy boundary", () => {
     }
   });
 
-  it("ranks all USD FDV and uses newest order only for other currencies", () => {
+  it("ranks only current USD FDV and uses newest order for stale or other currencies", () => {
     const valued = (
       entry: ExploreEntry,
       valuation: Readonly<{
@@ -387,9 +368,9 @@ describe("Explore API Alchemy boundary", () => {
       }).tokens.map(({ id }) => id);
 
     expect(paginate("market-cap")).toEqual([
-      "1:stale-usd",
       "1:usd-high",
       "1:usd-low",
+      "1:stale-usd",
       "1:eth",
       "1:quote",
     ]);
@@ -433,7 +414,6 @@ describe("Explore API Alchemy boundary", () => {
 
     expect(response.status).toBe(400);
     expect(mocks.readAlchemyExploreModel).not.toHaveBeenCalled();
-    expect(mocks.enrichTokensWithAlchemyPrices).not.toHaveBeenCalled();
   });
 
   it("fails closed when the canonical source and durable fallback are unavailable", async () => {
@@ -575,15 +555,87 @@ describe("Explore API Alchemy boundary", () => {
     );
   });
 
+  it("binds current FDV to the verified operational block instead of the lagging model snapshot", async () => {
+    const staleModelSnapshot = {
+      ...snapshot,
+      blockNumber: "25628000",
+      blockHash: `0x${"88".repeat(32)}` as const,
+    };
+    const operationalSnapshot = {
+      ...snapshot,
+      blockNumber: "25632000",
+      blockHash: `0x${"99".repeat(32)}` as const,
+    };
+    mocks.readAlchemyExploreModel.mockResolvedValue({
+      ...readyModel(),
+      snapshot: staleModelSnapshot,
+      launchDiscoverySnapshot: staleModelSnapshot,
+    });
+    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
+      operationalSnapshot,
+    );
+    mocks.readExploreReferenceHeadWithinRouteBudget.mockResolvedValue({
+      blockNumber: operationalSnapshot.blockNumber,
+      blockHash: operationalSnapshot.blockHash,
+      indexedAt: "2026-08-10T18:00:00.000Z",
+      finality: "confirmed",
+    });
+    mocks.enrichTokensWithAlchemyPoolState.mockImplementation(
+      async ({ snapshot: readSnapshot, tokens }: {
+        snapshot: typeof operationalSnapshot;
+        tokens: readonly LauncherToken[];
+      }) => tokens.map((candidate) => {
+        const identity = { ...candidate };
+        delete identity.indexedMarketCapUsdWad;
+        delete identity.indexedMarketCapEthWei;
+        delete identity.indexedMarketCapEth;
+        delete identity.marketCapEthWei;
+        delete identity.marketCapEth;
+        return {
+          ...identity,
+          indexedValuationBlockNumber: readSnapshot.blockNumber,
+          fdvUsdWad: String(BigInt(candidate.symbol.slice(1)) * 10n ** 20n),
+        };
+      }),
+    );
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/explore?sort=market-cap&page=1&limit=100",
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mocks.withSameBlockEthUsdQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshot: operationalSnapshot }),
+    );
+    expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshot: operationalSnapshot }),
+    );
+    expect(body.tokens[0].valuation).toMatchObject({
+      status: "available",
+      freshness: "current",
+      asOfBlock: operationalSnapshot.blockNumber,
+      lagBlocks: "0",
+    });
+    expect(body.dataQuality).toMatchObject({
+      launchIdentity: {
+        asOfBlock: staleModelSnapshot.blockNumber,
+        referenceBlock: operationalSnapshot.blockNumber,
+      },
+      valuation: {
+        status: "current",
+        asOfBlock: operationalSnapshot.blockNumber,
+      },
+    });
+  });
+
   it("serves a finalized Router Custom Graph as a canonical Custom token", async () => {
     mocks.readAlchemyExploreModel.mockResolvedValue({
       ...readyModel(),
       tokens: [customGraphToken],
     });
-    mocks.enrichTokensWithAlchemyPrices.mockImplementation(async (tokens) => [
-      ...tokens,
-    ]);
-
     const response = await GET(
       new NextRequest("http://localhost/api/explore?sort=newest"),
     );
@@ -631,9 +683,6 @@ describe("Explore API Alchemy boundary", () => {
   });
 
   it("keeps canonical launches visible with honest stale valuation quality during enrichment failure", async () => {
-    mocks.enrichTokensWithAlchemyPrices.mockRejectedValue(
-      new Error("provider unavailable"),
-    );
     mocks.enrichTokensWithAlchemyPoolState.mockRejectedValue(
       new Error("provider unavailable"),
     );
@@ -696,7 +745,9 @@ describe("Explore API Alchemy boundary", () => {
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
       "durable+registry.custom-launched",
     );
-    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBeNull();
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
+      "operational-dual",
+    );
   });
 
   it.each([
@@ -719,11 +770,6 @@ describe("Explore API Alchemy boundary", () => {
       totalPages: 3,
     });
     expect(body.tokens).toHaveLength(10);
-    expect(mocks.enrichTokensWithAlchemyPrices).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ tokenAddress: body.tokens[0].tokenAddress }),
-      ]),
-    );
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
       "operational+durable+postgres",
     );

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -77,6 +77,7 @@ describe("Explore financial-data semantics", () => {
     [{ activeLiquidity: "0" }, "liquidity-unavailable"],
     [{ fdvUsdWad: "NaN" }, "price-unavailable"],
     [{ fdvUsdWad: "0" }, "price-unavailable"],
+    [{ indexedValuationBlockNumber: undefined }, "inconsistent-snapshot"],
   ] as const)("fails unavailable for unsafe inputs %o", (overrides, reason) => {
     expect(exploreValuation(goldenToken(overrides))).toEqual({
       status: "unavailable",
@@ -94,7 +95,7 @@ describe("Explore financial-data semantics", () => {
     });
   });
 
-  it("sorts every safely parsed USD FDV while keeping freshness separate", () => {
+  it("sorts only reconciled current USD FDV", () => {
     const valued = (overrides: Partial<LauncherToken>, referenceBlock: string) =>
       withExploreValuation(
         canonicalTokenExploreEntryV1(goldenToken(overrides)),
@@ -118,12 +119,8 @@ describe("Explore financial-data semantics", () => {
     expect(valuationSortValue(currentUsd)).toBe(
       2_779_462_110_000_000_000_000_000n,
     );
-    expect(valuationSortValue(staleUsd)).toBe(
-      2_779_462_110_000_000_000_000_000n,
-    );
-    expect(valuationSortValue(unknownUsd)).toBe(
-      2_779_462_110_000_000_000_000_000n,
-    );
+    expect(valuationSortValue(staleUsd)).toBeNull();
+    expect(valuationSortValue(unknownUsd)).toBeNull();
     expect(valuationSortValue(currentEth)).toBeNull();
     expect(valuationSortValue(currentQuote)).toBeNull();
   });

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -416,7 +416,19 @@ describe("Explore refresh state", () => {
       liquidityPath: "meme",
     } satisfies LauncherToken;
 
-    expect(getExploreValuationMetric(classicEntry(token))).toEqual({
+    expect(getExploreValuationMetric({
+      ...classicEntry(token),
+      valuation: {
+        status: "available",
+        metric: "fdv",
+        supplyBasis: "total",
+        currency: "usd",
+        valueWad: "125000000000000000000",
+        freshness: "current",
+        asOfBlock: "25730000",
+        lagBlocks: "0",
+      },
+    })).toEqual({
       kind: "usd",
       value: 125,
     });

--- a/tests/hookathon-config.test.ts
+++ b/tests/hookathon-config.test.ts
@@ -1,20 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  HOOKATHON_BUILDER_PROMPT,
-  hookathonConfig,
-} from "@/lib/hookathon/config";
+import { hookathonConfig } from "@/lib/hookathon/config";
 
 describe("Hookathon configuration", () => {
-  it("binds the exact owner-confirmed identity and three-day window", () => {
+  it("binds the exact owner-reset four-day window", () => {
     const confirmation = Date.parse(hookathonConfig.confirmationIso);
     const deadline = Date.parse(hookathonConfig.deadlineIso);
 
     expect(hookathonConfig.name).toBe("Hookathon");
     expect(hookathonConfig.confirmationIso).toBe(
-      "2026-08-10T19:40:20+02:00",
+      "2026-08-11T10:09:29+02:00",
     );
-    expect(hookathonConfig.deadlineIso).toBe("2026-08-14T17:40:20Z");
+    expect(hookathonConfig.deadlineIso).toBe("2026-08-15T08:09:29Z");
     expect(hookathonConfig.timeZone).toBe("Europe/Zurich");
     expect(deadline - confirmation).toBe(4 * 24 * 60 * 60 * 1_000);
   });
@@ -34,56 +31,34 @@ describe("Hookathon configuration", () => {
     ).toBe(hookathonConfig.totalPrizeUsd);
   });
 
-  it("keeps exactly three truthful entry steps and the canonical builder target", () => {
-    expect(
-      hookathonConfig.entrySteps.map(({ number, title, description }) => ({
-        number,
-        title,
-        description,
-      })),
-    ).toEqual([
-      {
-        number: 1,
-        title: "Build",
-        description: "Copy the provided prompt into Codex and describe the idea.",
-      },
-      {
-        number: 2,
-        title: "Submit",
-        description: "Open the generated Applicant pull request in Hookbuilder.",
-      },
-      {
-        number: 3,
-        title: "Launch",
-        description:
-          "After approval, launch the exact project on Programmable before the timer ends.",
-      },
-    ]);
+  it("binds the builder action and application repository separately", () => {
     expect(hookathonConfig.hookbuilderUrl).toBe(
       "https://github.com/0xprogrammable/hookbuilder",
     );
-  });
-
-  it("preserves the exact starter prompt and editable idea marker", () => {
-    expect(hookathonConfig.builderPrompt).toBe(HOOKATHON_BUILDER_PROMPT);
-    expect(HOOKATHON_BUILDER_PROMPT).toBe(
-      "Use the Programmable v4 Hook Builder to turn this idea into a complete, review-ready Hookathon project: [DESCRIBE YOUR IDEA]. Build the contracts, tests and required evidence, preserve the core idea, prepare the Hookbuilder pull request, and ask me only for decisions that materially change the project.",
+    expect(hookathonConfig.submissionUrl).toBe(
+      "https://github.com/0xprogrammable/submit-launch",
     );
+    expect(hookathonConfig).not.toHaveProperty("builderPrompt");
+    expect(hookathonConfig).not.toHaveProperty("entrySteps");
   });
 
   it("contains only the confirmed eligibility and judging conditions", () => {
     expect(hookathonConfig.eligibility.participation).toBe("Anyone can enter");
     expect(hookathonConfig.eligibility.teamSize).toBe("No team size limit");
-    expect(hookathonConfig.eligibility.description).toContain(
+    expect(hookathonConfig.eligibility.beforeSubmissionLink).toContain(
       "hook-powered token or hook project",
     );
-    expect(hookathonConfig.eligibility.description).toContain("X account");
-    expect(hookathonConfig.eligibility.description).toContain("project website");
-    expect(hookathonConfig.eligibility.description).toContain(
-      "submitted through Hookbuilder, approved, and launched as the exact project on Programmable before the countdown ends",
+    expect(hookathonConfig.eligibility.beforeSubmissionLink).toContain(
+      "X account",
     );
-    expect(hookathonConfig.eligibility.description).toContain(
-      "A pull request alone does not qualify",
+    expect(hookathonConfig.eligibility.beforeSubmissionLink).toContain(
+      "project website",
+    );
+    expect(hookathonConfig.eligibility.submissionLinkLabel).toBe(
+      "Submit Launch",
+    );
+    expect(hookathonConfig.eligibility.afterSubmissionLink).toBe(
+      ", get approved and launch on Programmable before the countdown ends.",
     );
     expect(hookathonConfig.judging.criteria).toEqual([
       "Originality",

--- a/tests/hookathon-countdown.test.ts
+++ b/tests/hookathon-countdown.test.ts
@@ -104,7 +104,7 @@ describe("Hookathon countdown", () => {
         hookathonConfig.deadlineIso,
         hookathonConfig.timeZone,
       ),
-    ).toBe("14 Aug 2026, 19:40:20 CEST");
+    ).toBe("15 Aug 2026, 10:09:29 CEST");
   });
 
   it("rejects invalid clock inputs instead of inventing a countdown", () => {

--- a/tests/hookathon-surface.test.ts
+++ b/tests/hookathon-surface.test.ts
@@ -30,14 +30,15 @@ describe("Hookathon surface", () => {
     expect(html).toContain("$5,000");
     expect(html).toContain("$3,000");
     expect(html).toContain("$2,000");
-    expect(html).toContain(">Build<");
-    expect(html).toContain(">Submit<");
-    expect(html).toContain(">Launch<");
     expect(html).toContain(">Originality<");
     expect(html).toContain(">Usefulness<");
     expect(html).toContain(">Execution<");
     expect(html).toContain("Anyone can enter, with no team size limit");
-    expect(html).toContain("A pull request alone does not qualify");
+    expect(html).not.toContain("How to enter");
+    expect(html).toContain(
+      'href="https://github.com/0xprogrammable/submit-launch"',
+    );
+    expect(html).toContain(">Submit Launch</a>");
   });
 
   it("uses one accessible Hookbuilder action without announcing every second", () => {
@@ -46,12 +47,16 @@ describe("Hookathon surface", () => {
     expect(html).not.toContain("Copy builder prompt");
     expect(html).toContain('href="https://github.com/0xprogrammable/hookbuilder"');
     expect(html).toContain("Open Hookbuilder");
+    expect(html).not.toContain("↗");
     expect(html).toContain('aria-hidden="true"');
     expect(html).toContain('role="status" aria-live="polite"');
     expect(html).not.toContain('role="timer"');
     expect(html).not.toContain('aria-live="assertive"');
+    expect(html).not.toContain("Submissions close on");
+    expect(html).not.toContain("Europe/Zurich");
+    expect(html).not.toContain("<time");
     expect(html).toContain(
-      '<time dateTime="2026-08-14T17:40:20Z">14 Aug 2026, 19:40:20 CEST</time>',
+      "4 days, 0 hours, 0 minutes and 0 seconds remaining",
     );
   });
 

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -23,6 +23,8 @@ const mocks = vi.hoisted(() => {
     getAlchemyOnchainDeployment: vi.fn(),
     isTokenChartRange: vi.fn(),
     enrichTokensWithAlchemyPoolState: vi.fn(),
+    readVerifiedOperationalMarketSnapshot: vi.fn(),
+    withSameBlockEthUsdQuote: vi.fn(),
     readAlchemyExploreModel: vi.fn(),
     readTokenChartSeries: vi.fn(),
     safeAlchemyError: vi.fn((error) => error),
@@ -47,6 +49,17 @@ vi.mock("../lib/onchain/chart", () => ({
 
 vi.mock("../lib/alchemy/live-market.server", () => ({
   enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
+  readVerifiedOperationalMarketSnapshot:
+    mocks.readVerifiedOperationalMarketSnapshot,
+  withSameBlockEthUsdQuote: mocks.withSameBlockEthUsdQuote,
+  withoutUnboundEthUsdQuote: (snapshot: {
+    ethUsdQuote?: unknown;
+    [key: string]: unknown;
+  }) => {
+    const withoutQuote = { ...snapshot };
+    delete withoutQuote.ethUsdQuote;
+    return withoutQuote;
+  },
 }));
 
 import { GET } from "../app/api/explore/token/chart/route";
@@ -89,6 +102,9 @@ describe("token chart Alchemy API", () => {
       ["1h", "1d", "1w", "all"].includes(range),
     );
     mocks.getAlchemyOnchainDeployment.mockReturnValue(deployment);
+    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
+      launchDiscoverySnapshot,
+    );
     mocks.assertTokenChartSupported.mockImplementation((candidate) => {
       if (candidate.launchModel === "custom-graph") {
         throw new mocks.TokenChartUnavailableError(
@@ -97,6 +113,18 @@ describe("token chart Alchemy API", () => {
       }
     });
     mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([token]);
+    mocks.withSameBlockEthUsdQuote.mockImplementation(
+      async ({ snapshot: value }) => ({
+        ...value,
+        ethUsdQuote: {
+          feedAddress: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+          roundId: "12",
+          answer: "350000000000",
+          decimals: 8,
+          updatedAt: "1786400000",
+        },
+      }),
+    );
     mocks.readAlchemyExploreModel.mockResolvedValue({
       status: "ready",
       tokens: [token],
@@ -154,6 +182,10 @@ describe("token chart Alchemy API", () => {
         deployment,
         token,
         snapshotBlock: 25_630_005n,
+        ethUsdQuote: expect.objectContaining({
+          roundId: "12",
+          answer: "350000000000",
+        }),
         range: "1h",
       }),
     );
@@ -205,6 +237,93 @@ describe("token chart Alchemy API", () => {
     expect(response.headers.get("X-Programmable-Valuation-Metric")).toBe(
       "fdv",
     );
+  });
+
+  it("reads price history through the verified operational block instead of the stale model snapshot", async () => {
+    const operationalSnapshot = {
+      ...launchDiscoverySnapshot,
+      blockNumber: "25632000",
+      blockHash: `0x${"99".repeat(32)}` as const,
+    };
+    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
+      operationalSnapshot,
+    );
+    mocks.readTokenChartSeries.mockResolvedValue({
+      status: "ready",
+      points: [
+        { blockNumber: "25631999", priceEth: "0.49", priceUsd: "1715" },
+        { blockNumber: operationalSnapshot.blockNumber, priceEth: "0.5", priceUsd: "1750" },
+      ],
+      swapCount: 2,
+      volumeWei: "1",
+      volumeEth: "0.000000000000000001",
+      freshness: {
+        history: {
+          status: "current",
+          throughBlock: operationalSnapshot.blockNumber,
+        },
+        price: {
+          status: "current",
+          asOfBlock: operationalSnapshot.blockNumber,
+          lagBlocks: "0",
+        },
+        valuation: {
+          status: "current",
+          metric: "fdv",
+          asOfBlock: operationalSnapshot.blockNumber,
+          lagBlocks: "0",
+        },
+      },
+    });
+
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mocks.withSameBlockEthUsdQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshot: operationalSnapshot }),
+    );
+    expect(mocks.readTokenChartSeries).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshotBlock: 25_632_000n }),
+    );
+    expect(body.dataQuality).toMatchObject({
+      status: "current",
+      asOfBlock: operationalSnapshot.blockNumber,
+      blockHash: operationalSnapshot.blockHash,
+      history: { throughBlock: operationalSnapshot.blockNumber },
+      price: { asOfBlock: operationalSnapshot.blockNumber },
+      valuation: { asOfBlock: operationalSnapshot.blockNumber },
+    });
+    expect(body.snapshotBlock).toBe(operationalSnapshot.blockNumber);
+  });
+
+  it("fails closed and leaves the client to preserve its last verified chart without operational quorum", async () => {
+    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(null);
+
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body).toMatchObject({
+      status: "unavailable",
+      dataQuality: {
+        status: "unavailable",
+        reason: "source-unavailable",
+      },
+    });
+    expect(body).not.toHaveProperty("snapshotBlock");
+    expect(mocks.withSameBlockEthUsdQuote).not.toHaveBeenCalled();
+    expect(mocks.enrichTokensWithAlchemyPoolState).not.toHaveBeenCalled();
+    expect(mocks.readTokenChartSeries).not.toHaveBeenCalled();
   });
 
   it("returns partial freshness without caching an older price as current", async () => {

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -8,8 +8,9 @@ import type { LauncherToken } from "../lib/tokens";
 import { customGraphToken } from "./launch-stamp-surface-fixture";
 
 const mocks = vi.hoisted(() => ({
-  enrichTokensWithAlchemyPrices: vi.fn(),
   enrichTokensWithAlchemyPoolState: vi.fn(),
+  readVerifiedOperationalMarketSnapshot: vi.fn(),
+  withSameBlockEthUsdQuote: vi.fn(),
   getAlchemyOnchainDeployment: vi.fn(),
   readAlchemyExploreModel: vi.fn(),
   readProductionCustomExploreDirectoryV1: vi.fn(),
@@ -20,7 +21,6 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/alchemy/explore.server", () => ({
-  enrichTokensWithAlchemyPrices: mocks.enrichTokensWithAlchemyPrices,
   getAlchemyOnchainDeployment: mocks.getAlchemyOnchainDeployment,
   readAlchemyExploreModel: mocks.readAlchemyExploreModel,
   safeAlchemyError: mocks.safeAlchemyError,
@@ -28,6 +28,17 @@ vi.mock("../lib/alchemy/explore.server", () => ({
 
 vi.mock("../lib/alchemy/live-market.server", () => ({
   enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
+  readVerifiedOperationalMarketSnapshot:
+    mocks.readVerifiedOperationalMarketSnapshot,
+  withSameBlockEthUsdQuote: mocks.withSameBlockEthUsdQuote,
+  withoutUnboundEthUsdQuote: (snapshot: {
+    ethUsdQuote?: unknown;
+    [key: string]: unknown;
+  }) => {
+    const withoutQuote = { ...snapshot };
+    delete withoutQuote.ethUsdQuote;
+    return withoutQuote;
+  },
 }));
 
 vi.mock("../lib/server/custom-launch/explore-directory-v1", () => ({
@@ -103,6 +114,12 @@ describe("token detail Alchemy read", () => {
       indexedAt: "2026-08-10T17:55:45.000Z",
       finality: "confirmed",
     });
+    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
+      launchDiscoverySnapshot,
+    );
+    mocks.withSameBlockEthUsdQuote.mockImplementation(
+      async ({ snapshot: value }) => value,
+    );
     mocks.enrichTokensWithAlchemyPoolState.mockImplementation(
       async ({ tokens }: { tokens: readonly LauncherToken[] }) =>
         tokens.map((candidate) => ({
@@ -114,7 +131,7 @@ describe("token detail Alchemy read", () => {
     );
   });
 
-  it("price-enriches only the canonical token from the Alchemy read model", async () => {
+  it("refreshes only the canonical token from current StateView data", async () => {
     const canonical = token(TOKEN_ADDRESS, {
       totalSupplyRaw: "1000000000000000000000000",
       tokenDecimals: 18,
@@ -135,13 +152,6 @@ describe("token detail Alchemy read", () => {
       launcherFeesAccruedEth: "0",
     } satisfies ExploreReadModel;
     mocks.readAlchemyExploreModel.mockResolvedValue(model);
-    mocks.enrichTokensWithAlchemyPrices.mockResolvedValue([
-      {
-        ...canonical,
-        tokenPriceUsdWad: "1250000000000000000",
-        fdvUsdWad: "1250000000000000000000000",
-      },
-    ]);
 
     const response = await GET(
       new NextRequest(
@@ -152,15 +162,14 @@ describe("token detail Alchemy read", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.readAlchemyExploreModel).toHaveBeenCalledTimes(1);
-    expect(mocks.enrichTokensWithAlchemyPrices).toHaveBeenCalledWith([
-      canonical,
-    ]);
+    expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalledWith(
+      expect.objectContaining({ tokens: [canonical] }),
+    );
     expect(body.token).toMatchObject({
       id: canonical.id,
       name: canonical.name,
       symbol: canonical.symbol,
       tokenAddress: canonical.tokenAddress,
-      tokenPriceUsdWad: "1250000000000000000",
       fdvUsdWad: "1250000000000000000000000",
       valuation: {
         status: "available",
@@ -201,7 +210,7 @@ describe("token detail Alchemy read", () => {
       "operational-dual",
     );
     expect(response.headers.get("X-Programmable-Price-Source")).toBe(
-      "alchemy",
+      "state-view+chainlink",
     );
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
       "operational+durable+registry.custom-launched",
@@ -212,6 +221,76 @@ describe("token detail Alchemy read", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
+  });
+
+  it("reports detail FDV at the verified operational block, not the stale launch snapshot", async () => {
+    const canonical = token(TOKEN_ADDRESS, {
+      totalSupplyRaw: "1000000000000000000000000",
+      tokenDecimals: 18,
+      activeLiquidity: "1",
+      indexedMarketCapUsdWad: "1620000000000000000000000",
+      indexedValuationBlockNumber: snapshot.blockNumber,
+    });
+    const operationalSnapshot = {
+      ...launchDiscoverySnapshot,
+      blockNumber: "25632000",
+      blockHash: `0x${"99".repeat(32)}` as const,
+    };
+    mocks.readAlchemyExploreModel.mockResolvedValue({
+      status: "ready",
+      tokens: [canonical],
+      snapshot,
+      launchDiscoverySnapshot,
+      creatorClaims: [],
+      launcherFeesAccruedWei: "0",
+      launcherFeesAccruedEth: "0",
+    } satisfies ExploreReadModel);
+    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
+      operationalSnapshot,
+    );
+    mocks.readExploreReferenceHeadWithinRouteBudget.mockResolvedValue({
+      blockNumber: operationalSnapshot.blockNumber,
+      blockHash: operationalSnapshot.blockHash,
+      indexedAt: "2026-08-10T18:00:00.000Z",
+      finality: "confirmed",
+    });
+    mocks.enrichTokensWithAlchemyPoolState.mockImplementation(
+      async ({ snapshot: readSnapshot }) => [{
+        ...canonical,
+        indexedMarketCapUsdWad: undefined,
+        indexedValuationBlockNumber: readSnapshot.blockNumber,
+        fdvUsdWad: "2334305942998987256153723",
+      }],
+    );
+
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/explore/token?address=${TOKEN_ADDRESS}`,
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mocks.withSameBlockEthUsdQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshot: operationalSnapshot }),
+    );
+    expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshot: operationalSnapshot }),
+    );
+    expect(body.token).toMatchObject({
+      fdvUsdWad: "2334305942998987256153723",
+      valuation: {
+        status: "available",
+        freshness: "current",
+        asOfBlock: operationalSnapshot.blockNumber,
+        lagBlocks: "0",
+      },
+    });
+    expect(body.dataQuality.valuation).toMatchObject({
+      status: "current",
+      asOfBlock: operationalSnapshot.blockNumber,
+    });
+    expect(body.launchDiscoverySnapshot).toEqual(launchDiscoverySnapshot);
   });
 
   it("serves Router provenance for a finalized Custom Graph without Classic fields", async () => {
@@ -225,7 +304,6 @@ describe("token detail Alchemy read", () => {
       launcherFeesAccruedEth: "0",
     } satisfies ExploreReadModel;
     mocks.readAlchemyExploreModel.mockResolvedValue(model);
-    mocks.enrichTokensWithAlchemyPrices.mockResolvedValue([customGraphToken]);
 
     const response = await GET(
       new NextRequest(
@@ -262,7 +340,6 @@ describe("token detail Alchemy read", () => {
 
     expect(response.status).toBe(400);
     expect(mocks.readAlchemyExploreModel).not.toHaveBeenCalled();
-    expect(mocks.enrichTokensWithAlchemyPrices).not.toHaveBeenCalled();
   });
 
   it("returns a canonical 404 without price enrichment", async () => {
@@ -292,7 +369,6 @@ describe("token detail Alchemy read", () => {
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
       "operational+durable+postgres",
     );
-    expect(mocks.enrichTokensWithAlchemyPrices).not.toHaveBeenCalled();
   });
 
   it("retains canonical identity and reports unavailable FDV when enrichment fails", async () => {
@@ -309,9 +385,6 @@ describe("token detail Alchemy read", () => {
       launcherFeesAccruedWei: "0",
       launcherFeesAccruedEth: "0",
     } satisfies ExploreReadModel);
-    mocks.enrichTokensWithAlchemyPrices.mockRejectedValue(
-      new Error("price unavailable"),
-    );
     mocks.enrichTokensWithAlchemyPoolState.mockRejectedValue(
       new Error("pool unavailable"),
     );

--- a/tests/token-detail-view.test.ts
+++ b/tests/token-detail-view.test.ts
@@ -22,6 +22,7 @@ const token = {
   tokenPriceEth: "0.002",
   tokenPriceUsdWad: parseEther("6").toString(),
   fdvUsdWad: parseEther("168560").toString(),
+  indexedValuationBlockNumber: "25630000",
   totalSupplyRaw: parseEther("1000000").toString(),
   tokenDecimals: 18,
   activeLiquidity: "1",


### PR DESCRIPTION
## Outcome\n\n- binds Explore list, token detail, and chart valuation to one fresh dual-RPC confirmed block with same-block Chainlink conversion\n- preserves canonical coins while refusing stale or unknown FDV as current/rankable\n- fixes creator-claim simulation with a fixed, two-provider failover quorum\n- simplifies and recenters Hookathon, resets the exact four-day countdown, and links Submit Launch\n\n## Validation\n\n- 12 focused files, 129 tests passed\n- scoped ESLint passed\n- TypeScript passed\n- performance source contract passed\n- desktop 1440, mobile 390, 320 reflow, keyboard focus, and 200% reflow checked\n- no provider/account/key or contract changes