### PR TITLE
Prefer operational RPC pair for public reads

### DIFF
--- a/lib/onchain/config.ts
+++ b/lib/onchain/config.ts
@@ -67,15 +67,15 @@ function firstNonEmpty(...values: Array<string | undefined>) {
 
 function productionPrimaryRpc() {
   return firstNonEmpty(
-    process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
     process.env.ETHEREUM_RPC_URL,
+    process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
   );
 }
 
 function productionSecondaryRpc() {
   return firstNonEmpty(
-    process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
     process.env.ETHEREUM_RPC_URL_B,
+    process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
   );
 }
 

--- a/tests/onchain-config.test.ts
+++ b/tests/onchain-config.test.ts
@@ -73,9 +73,9 @@ describe("onchain deployment manifest boundary", () => {
     });
   });
 
-  it("prefers the provider-specific production bindings over legacy aliases", () => {
-    vi.stubEnv("ETHEREUM_RPC_URL", "https://legacy-primary.example");
-    vi.stubEnv("ETHEREUM_RPC_URL_B", "https://legacy-secondary.example");
+  it("prefers the operational dual-RPC bindings over provider-specific feeds", () => {
+    vi.stubEnv("ETHEREUM_RPC_URL", "https://operational-primary.example");
+    vi.stubEnv("ETHEREUM_RPC_URL_B", "https://operational-secondary.example");
     vi.stubEnv(
       "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
       "https://alchemy.example",
@@ -87,8 +87,8 @@ describe("onchain deployment manifest boundary", () => {
 
     expect(getOperationalOnchainDeployment("production")).toMatchObject({
       status: "ready",
-      rpcUrl: "https://alchemy.example",
-      rpcUrlSecondary: "https://quicknode.example",
+      rpcUrl: "https://operational-primary.example",
+      rpcUrlSecondary: "https://operational-secondary.example",
     });
   });
 


### PR DESCRIPTION
Stage evidence on production SHA 11ef825 showed current launch identities but `OperationalRpcUnavailableError` on the provider-specific Alchemy/QuickNode read pair, so verified FDV stayed unavailable. This minimal change prioritizes the existing fixed operational `ETHEREUM_RPC_URL`/`ETHEREUM_RPC_URL_B` pair for Website reads while retaining the provider-specific pair as configuration fallback. No endpoint value, secret, account, contract, or launch behavior changes.\n\nFocused proof: 6 files / 66 tests, TypeScript, scoped ESLint, and diff-check pass. Stage/public data canary remains required before promotion.