### PR TITLE
Fix Website read RPC quorum

### DIFF
--- a/app/api/ops/health/route.ts
+++ b/app/api/ops/health/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import {
-  getOperationalOnchainDeployment,
+  getWebsiteReadOnchainDeployment,
   readDurableExploreModel,
   readOperationalRpcHealth,
   type OperationalRpcHealth,
@@ -62,7 +62,7 @@ export async function GET() {
   try {
     const indexedRead = await readIndexedHealth();
     const indexed = indexedRead.health;
-    const deployment = getOperationalOnchainDeployment("production");
+    const deployment = getWebsiteReadOnchainDeployment("production");
     if (deployment.status !== "ready") {
       throw new Error(
         "The verified production release is not operationally eligible",

--- a/app/api/ops/index-v2/route.ts
+++ b/app/api/ops/index-v2/route.ts
@@ -3,7 +3,7 @@ import { timingSafeEqual } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 
 import {
-  getOperationalOnchainDeployment,
+  getWebsiteReadOnchainDeployment,
   readLiveExploreModel,
   writeDurableExploreModel,
 } from "../../../../lib/onchain";
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
 
   const startedAt = Date.now();
   try {
-    const deployment = getOperationalOnchainDeployment("production");
+    const deployment = getWebsiteReadOnchainDeployment("production");
     if (deployment.status !== "ready") {
       throw new Error(
         "The verified production release is not operationally eligible",

--- a/app/api/profile/classic-v3/route.ts
+++ b/app/api/profile/classic-v3/route.ts
@@ -32,7 +32,7 @@ import {
 } from "@/lib/data-pipeline/action-lookup";
 import { indexedLaunchLookupEnabled } from "@/lib/data-pipeline/route-activation.server";
 import { uerc20ReadAbi } from "@/lib/onchain/abis";
-import { getOperationalOnchainDeployment } from "@/lib/onchain/config";
+import { getWebsiteReadOnchainDeployment } from "@/lib/onchain/config";
 import {
   safeOperationalRpcError,
   isOperationalRpcFailoverEligible,
@@ -660,7 +660,7 @@ async function readRewards(account: Address) {
     };
   }
   try {
-    const deployment = getOperationalOnchainDeployment(environment);
+    const deployment = getWebsiteReadOnchainDeployment(environment);
     return await withOperationalRpcFailover(deployment, (rpcDeployment) =>
       readRewardsFromClient(account, createClient(rpcDeployment.rpcUrl))
     );
@@ -757,7 +757,7 @@ async function readLaunchByTransaction(
   if (!isClassicV3ReleaseVerified(manifest, releaseManifest, chain.id)) {
     return { status: "not-deployed" as const, launch: null };
   }
-  const deployment = getOperationalOnchainDeployment(environment);
+  const deployment = getWebsiteReadOnchainDeployment(environment);
   return withOperationalRpcFailover(deployment, (rpcDeployment) =>
     readLaunchByTransactionFromClient(
       account,

--- a/app/api/profile/stock-paired/route.ts
+++ b/app/api/profile/stock-paired/route.ts
@@ -15,7 +15,7 @@ import {
 import { mainnet } from "viem/chains";
 
 import {
-  getOnchainDeployment,
+  getWebsiteReadOnchainDeployment,
   readExploreModel,
   type ExploreReadModel,
 } from "@/lib/onchain";
@@ -509,7 +509,7 @@ async function readRewardsWithClients(
       rpcClients: [] as PublicClient[],
     };
   }
-  const deployment = getOnchainDeployment("production");
+  const deployment = getWebsiteReadOnchainDeployment("production");
   const model = await readExploreModel(deployment);
   if (model.status !== "ready") {
     throw new Error("The verified launch registry is unavailable");
@@ -845,7 +845,7 @@ export async function POST(request: NextRequest) {
       registry = actionTokenAsExploreModel(indexedReward.token);
     } else {
       registry = await readExploreModel(
-        getOnchainDeployment("production"),
+        getWebsiteReadOnchainDeployment("production"),
       );
       if (registry.status !== "ready") {
         return json({ error: "Stock-Paired rewards are not deployed" }, 409);

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -5,7 +5,7 @@
     "schedule": "*/5 * * * *",
     "retainedUntil": "indexed-read-cutover",
     "route": "app/api/ops/index-v2/route.ts",
-    "sha256": "9638ec482ff66c5f3b1377c60b946e6348fb895769b6f8596fca2dc8cfbac535",
+    "sha256": "38593eaa836e88400311e8a585079a6a81fa84f115d93a72a6ac0fefa01cef43",
     "closedAlias": {
       "path": "/api/ops/index",
       "route": "app/api/ops/index/route.ts",

--- a/lib/alchemy/explore.server.ts
+++ b/lib/alchemy/explore.server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { unstable_cache } from "next/cache";
 
-import { getOperationalOnchainDeployment } from "../onchain/config";
+import { getWebsiteReadOnchainDeployment } from "../onchain/config";
 import {
   safeOperationalRpcError,
   withOperationalRpcFailover,
@@ -102,7 +102,7 @@ function alchemyApiKey(environment: NodeJS.ProcessEnv = process.env) {
 }
 
 export function getAlchemyOnchainDeployment(): OnchainDeployment {
-  return getOperationalOnchainDeployment("production");
+  return getWebsiteReadOnchainDeployment("production");
 }
 
 async function readAlchemyExploreModelUncached(): Promise<ExploreReadModel> {

--- a/lib/onchain/config.ts
+++ b/lib/onchain/config.ts
@@ -79,6 +79,10 @@ function productionSecondaryRpc() {
   );
 }
 
+const WEBSITE_MAINNET_RPC_PRIMARY =
+  "https://ethereum-rpc.publicnode.com";
+const WEBSITE_MAINNET_RPC_SECONDARY = "https://rpc.mevblocker.io";
+
 export function selectedDeploymentEnvironment(
   value = process.env.PROGRAMMABLE_ONCHAIN_NETWORK,
 ): DeploymentEnvironment {
@@ -235,6 +239,19 @@ export function getOperationalOnchainDeployment(
     );
   }
   return deployment;
+}
+
+export function getWebsiteReadOnchainDeployment(
+  environment = selectedDeploymentEnvironment(),
+): OnchainDeployment {
+  const deployment = getOperationalOnchainDeployment(environment);
+  if (deployment.environment !== "production") return deployment;
+
+  return {
+    ...deployment,
+    rpcUrl: WEBSITE_MAINNET_RPC_PRIMARY,
+    rpcUrlSecondary: WEBSITE_MAINNET_RPC_SECONDARY,
+  };
 }
 
 export function getPublicOnchainDeployment(

--- a/lib/onchain/config.ts
+++ b/lib/onchain/config.ts
@@ -244,7 +244,7 @@ export function getOperationalOnchainDeployment(
 export function getWebsiteReadOnchainDeployment(
   environment = selectedDeploymentEnvironment(),
 ): OnchainDeployment {
-  const deployment = getOperationalOnchainDeployment(environment);
+  const deployment = resolveOnchainDeployment(environment, true);
   if (deployment.environment !== "production") return deployment;
 
   return {

--- a/lib/onchain/index.ts
+++ b/lib/onchain/index.ts
@@ -2,6 +2,7 @@ export {
   getOnchainDeployment,
   getOperationalOnchainDeployment,
   getPublicOnchainDeployment,
+  getWebsiteReadOnchainDeployment,
 } from "./config";
 export {
   readExploreModel,

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -10,7 +10,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     schedule: "*/5 * * * *",
     retainedUntil: "indexed-read-cutover",
     route: "app/api/ops/index-v2/route.ts",
-    sha256: "9638ec482ff66c5f3b1377c60b946e6348fb895769b6f8596fca2dc8cfbac535",
+    sha256: "38593eaa836e88400311e8a585079a6a81fa84f115d93a72a6ac0fefa01cef43",
     closedAlias: Object.freeze({
       path: "/api/ops/index",
       route: "app/api/ops/index/route.ts",

--- a/tests/alchemy-launch-refresh.test.ts
+++ b/tests/alchemy-launch-refresh.test.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/onchain/config", () => ({
-  getOperationalOnchainDeployment: mocks.getOperationalOnchainDeployment,
+  getWebsiteReadOnchainDeployment: mocks.getOperationalOnchainDeployment,
 }));
 vi.mock("../lib/onchain/durable-model", () => ({
   readDurableExploreModel: mocks.readDurableExploreModel,

--- a/tests/alchemy-operational-deployment.test.ts
+++ b/tests/alchemy-operational-deployment.test.ts
@@ -7,10 +7,12 @@ vi.mock("next/cache", () => ({
 
 const mocks = vi.hoisted(() => ({
   getOperationalOnchainDeployment: vi.fn(),
+  getWebsiteReadOnchainDeployment: vi.fn(),
 }));
 
 vi.mock("../lib/onchain/config", () => ({
   getOperationalOnchainDeployment: mocks.getOperationalOnchainDeployment,
+  getWebsiteReadOnchainDeployment: mocks.getWebsiteReadOnchainDeployment,
 }));
 
 import { getAlchemyOnchainDeployment } from "../lib/alchemy/explore.server";
@@ -35,12 +37,13 @@ const operational = {
 } satisfies ReadyOnchainDeployment;
 
 describe("Alchemy-named website consumer deployment", () => {
-  it("retains the validated operational primary and fixed secondary", () => {
-    mocks.getOperationalOnchainDeployment.mockReturnValue(operational);
+  it("uses the fixed independent Website read quorum", () => {
+    mocks.getWebsiteReadOnchainDeployment.mockReturnValue(operational);
 
     expect(getAlchemyOnchainDeployment()).toBe(operational);
-    expect(mocks.getOperationalOnchainDeployment).toHaveBeenCalledWith(
+    expect(mocks.getWebsiteReadOnchainDeployment).toHaveBeenCalledWith(
       "production",
     );
+    expect(mocks.getOperationalOnchainDeployment).not.toHaveBeenCalled();
   });
 });

--- a/tests/data-pipeline/legacy-index-ops-route.test.ts
+++ b/tests/data-pipeline/legacy-index-ops-route.test.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../lib/onchain", () => ({
-  getOperationalOnchainDeployment: mocks.getOperationalOnchainDeployment,
+  getWebsiteReadOnchainDeployment: mocks.getOperationalOnchainDeployment,
   readLiveExploreModel: mocks.readLiveExploreModel,
   writeDurableExploreModel: mocks.writeDurableExploreModel,
 }));

--- a/tests/data-pipeline/operations-health-route.test.ts
+++ b/tests/data-pipeline/operations-health-route.test.ts
@@ -12,7 +12,7 @@ vi.mock("../../lib/data-pipeline/read-model-health.server", () => ({
 }));
 
 vi.mock("../../lib/onchain", () => ({
-  getOperationalOnchainDeployment: mocks.getOperationalOnchainDeployment,
+  getWebsiteReadOnchainDeployment: mocks.getOperationalOnchainDeployment,
   readDurableExploreModel: mocks.readDurableExploreModel,
   readOperationalRpcHealth: mocks.readOperationalRpcHealth,
 }));

--- a/tests/onchain-config.test.ts
+++ b/tests/onchain-config.test.ts
@@ -120,11 +120,11 @@ describe("onchain deployment manifest boundary", () => {
     ).toThrow(
       "Production operations require two distinct authenticated RPC URLs",
     );
-    expect(() =>
-      getWebsiteReadOnchainDeployment("production"),
-    ).toThrow(
-      "Production operations require two distinct authenticated RPC URLs",
-    );
+    expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
+      status: "ready",
+      rpcUrl: "https://ethereum-rpc.publicnode.com",
+      rpcUrlSecondary: "https://rpc.mevblocker.io",
+    });
   });
 
   it("rejects an implicit public fallback for production operations", () => {
@@ -138,6 +138,11 @@ describe("onchain deployment manifest boundary", () => {
     ).toThrow(
       "Production operations require two distinct authenticated RPC URLs",
     );
+    expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
+      status: "ready",
+      rpcUrl: "https://ethereum-rpc.publicnode.com",
+      rpcUrlSecondary: "https://rpc.mevblocker.io",
+    });
   });
 
   it("keeps public reads fail-closed when the dual-RPC environment is absent", () => {

--- a/tests/onchain-config.test.ts
+++ b/tests/onchain-config.test.ts
@@ -4,6 +4,7 @@ import {
   getOnchainDeployment,
   getOperationalOnchainDeployment,
   getPublicOnchainDeployment,
+  getWebsiteReadOnchainDeployment,
 } from "../lib/onchain/config";
 
 describe("onchain deployment manifest boundary", () => {
@@ -92,12 +93,35 @@ describe("onchain deployment manifest boundary", () => {
     });
   });
 
+  it("uses the fixed independent Website read quorum without changing the operational bindings", () => {
+    vi.stubEnv("ETHEREUM_RPC_URL", "https://operational-primary.example");
+    vi.stubEnv(
+      "ETHEREUM_RPC_URL_B",
+      "https://operational-secondary.example",
+    );
+
+    expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
+      status: "ready",
+      rpcUrl: "https://ethereum-rpc.publicnode.com",
+      rpcUrlSecondary: "https://rpc.mevblocker.io",
+    });
+    expect(getOperationalOnchainDeployment("production")).toMatchObject({
+      rpcUrl: "https://operational-primary.example",
+      rpcUrlSecondary: "https://operational-secondary.example",
+    });
+  });
+
   it("rejects production operations without an independent RPC", () => {
     vi.stubEnv("ETHEREUM_RPC_URL", "https://rpc-a.example");
     vi.stubEnv("ETHEREUM_RPC_URL_B", "https://rpc-a.example");
 
     expect(() =>
       getOperationalOnchainDeployment("production"),
+    ).toThrow(
+      "Production operations require two distinct authenticated RPC URLs",
+    );
+    expect(() =>
+      getWebsiteReadOnchainDeployment("production"),
     ).toThrow(
       "Production operations require two distinct authenticated RPC URLs",
     );

--- a/tests/stock-paired-action-activation.test.ts
+++ b/tests/stock-paired-action-activation.test.ts
@@ -209,7 +209,10 @@ vi.mock("../lib/onchain", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/onchain")>();
   return {
     ...actual,
-    getOnchainDeployment: () => ({ status: "ready", chainId: 1 }),
+    getWebsiteReadOnchainDeployment: () => ({
+      status: "ready",
+      chainId: 1,
+    }),
     readExploreModel: mocks.readLegacy,
   };
 });


### PR DESCRIPTION
## Outcome
- binds Explore, token charts, Health, durable refresh, and Classic Rewards to the fixed independent Website read quorum
- preserves the operational deployment gate and fixed one-secondary failover
- makes no provider account, key, contract, or launch-flow change

## Proof
- 89 focused tests passed
- TypeScript and scoped ESLint passed
- both fixed readers agreed on the current head and confirmed block hash
- Stage API/data/claim canary follows protected CI before promotion