### PR TITLE
Fix chart archive failover and degraded health

### DIFF
--- a/app/api/ops/health/route.ts
+++ b/app/api/ops/health/route.ts
@@ -104,11 +104,36 @@ export async function GET() {
       readDurableExploreModel(deployment, MAX_INDEX_AGE_MS),
       readOperationalRpcHealth(deployment),
     ]);
-    if (index.status !== "ready") {
-      throw new Error(`Durable index ${index.reason}: ${index.detail}`);
-    }
     if (rpc.status === "unhealthy") {
       return unhealthyRpcResponse(rpc, startedAt);
+    }
+    if (rpc.chainId !== deployment.chainId) {
+      throw new Error("Durable read-model chain binding is unavailable");
+    }
+    if (index.status !== "ready") {
+      if (index.reason === "stale") {
+        const model = index.envelope.payload.model;
+        return NextResponse.json(
+          {
+            status: "degraded",
+            chainId: rpc.chainId,
+            index: {
+              status: "stale",
+              ageSeconds: Math.floor(index.ageMs / 1_000),
+              blockNumber: model.snapshot.blockNumber,
+              tokenCount: model.tokens.length,
+            },
+            indexSource: "durable",
+            indexedReadModel: { status: indexedRead.status },
+            rpc,
+            checkedAt: new Date().toISOString(),
+          },
+          {
+            headers: { "Cache-Control": "no-store" },
+          },
+        );
+      }
+      throw new Error(`Durable index ${index.reason}: ${index.detail}`);
     }
 
     return NextResponse.json(

--- a/lib/onchain/operational-rpc-failover.server.ts
+++ b/lib/onchain/operational-rpc-failover.server.ts
@@ -11,6 +11,8 @@ import type { OnchainDeployment } from "./types";
 
 const CAPACITY_MESSAGE =
   /(?:monthly[_\s-]*capacity[_\s-]*(?:exceeded|reached)|capacity[_\s-]*(?:exceeded|reached)|rate[_\s-]*limit(?:ed)?|too many requests)/iu;
+const ARCHIVE_LIMITATION_MESSAGE =
+  /archive requests require a personal token/iu;
 
 function errorChain(error: unknown) {
   const chain: unknown[] = [];
@@ -34,6 +36,15 @@ function rpcCapacityMessage(error: RpcRequestError) {
     error.cause instanceof Error ? error.cause.message : undefined,
   ].filter((value): value is string => Boolean(value));
   return details.some((value) => CAPACITY_MESSAGE.test(value));
+}
+
+function rpcArchiveLimitationMessage(error: RpcRequestError) {
+  const details = [
+    error.details,
+    typeof error.data === "string" ? error.data : undefined,
+    error.cause instanceof Error ? error.cause.message : undefined,
+  ].filter((value): value is string => Boolean(value));
+  return details.some((value) => ARCHIVE_LIMITATION_MESSAGE.test(value));
 }
 
 /**
@@ -63,7 +74,8 @@ export function isOperationalRpcFailoverEligible(error: unknown) {
       return (
         candidate.code === 429 ||
         candidate.code === -32_005 ||
-        rpcCapacityMessage(candidate)
+        rpcCapacityMessage(candidate) ||
+        rpcArchiveLimitationMessage(candidate)
       );
     }
     return false;

--- a/tests/data-pipeline/operations-health-route.test.ts
+++ b/tests/data-pipeline/operations-health-route.test.ts
@@ -65,7 +65,10 @@ describe("operations health route", () => {
 
   it("preserves the complete legacy health behavior in legacy-only mode", async () => {
     mocks.readIndexedReadModelHealth.mockResolvedValue(null);
-    mocks.getOperationalOnchainDeployment.mockReturnValue({ status: "ready" });
+    mocks.getOperationalOnchainDeployment.mockReturnValue({
+      status: "ready",
+      chainId: 1,
+    });
     mocks.readDurableExploreModel.mockResolvedValue({
       status: "ready",
       ageMs: 5_500,
@@ -336,5 +339,78 @@ describe("operations health route", () => {
     );
     expect(mocks.readDurableExploreModel).toHaveBeenCalledOnce();
     expect(mocks.readOperationalRpcHealth).toHaveBeenCalledOnce();
+  });
+
+  it("reports a stale durable index as degraded while verified RPC reads stay available", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.readIndexedReadModelHealth.mockResolvedValue(null);
+    mocks.getOperationalOnchainDeployment.mockReturnValue({
+      status: "ready",
+      chainId: 1,
+    });
+    mocks.readDurableExploreModel.mockResolvedValue({
+      status: "unavailable",
+      reason: "stale",
+      detail: "private stale-index detail",
+      ageMs: 7_200_000,
+      envelope: {
+        payload: {
+          model: {
+            snapshot: { blockNumber: "25600000" },
+            tokens: [{}, {}],
+          },
+        },
+      },
+    });
+    mocks.readOperationalRpcHealth.mockResolvedValue(rpcHealth());
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(body).toMatchObject({
+      status: "degraded",
+      chainId: 1,
+      indexSource: "durable",
+      indexedReadModel: { status: "disabled" },
+      index: {
+        status: "stale",
+        ageSeconds: 7_200,
+        blockNumber: "25600000",
+        tokenCount: 2,
+      },
+      rpc: {
+        status: "healthy",
+        quorum: { status: "verified" },
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain("private stale-index detail");
+  });
+
+  it("remains fail-closed when the durable identity index is missing", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.readIndexedReadModelHealth.mockResolvedValue(null);
+    mocks.getOperationalOnchainDeployment.mockReturnValue({
+      status: "ready",
+      chainId: 1,
+    });
+    mocks.readDurableExploreModel.mockResolvedValue({
+      status: "unavailable",
+      reason: "missing",
+      detail: "private missing-index detail",
+    });
+    mocks.readOperationalRpcHealth.mockResolvedValue(rpcHealth());
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(body).toEqual({
+      status: "unhealthy",
+      checkedAt: expect.any(String),
+    });
+    expect(JSON.stringify(body)).not.toContain("private missing-index detail");
   });
 });

--- a/tests/operational-rpc-failover.test.ts
+++ b/tests/operational-rpc-failover.test.ts
@@ -102,9 +102,32 @@ describe("operational RPC failover", () => {
     ).toBe(true);
   });
 
+  it("uses the fixed secondary after an exact archive-read limitation", async () => {
+    const calls: string[] = [];
+    const read = vi.fn(async (candidate: ReadyOnchainDeployment) => {
+      calls.push(candidate.rpcUrl);
+      if (candidate.rpcUrl === deployment.rpcUrl) {
+        throw rpcFailure(
+          "Archive requests require a personal token. Get one at: https://provider.example",
+          -32602,
+        );
+      }
+      return "secondary-archive-ready";
+    });
+
+    await expect(
+      withOperationalRpcFailover(deployment, read),
+    ).resolves.toBe("secondary-archive-ready");
+    expect(calls).toEqual([
+      deployment.rpcUrl,
+      deployment.rpcUrlSecondary,
+    ]);
+  });
+
   it.each([
     httpFailure(400),
     rpcFailure("execution reverted"),
+    rpcFailure("Invalid parameters were provided", -32602),
     new Error("Pool identity mismatch"),
   ])("does not rotate providers for a non-transport read error", async (error) => {
     const read = vi.fn(async () => {


### PR DESCRIPTION
## Outcome
- fail over exact public archive-read limitations to the fixed secondary RPC
- report a stale durable identity index as degraded while verified RPC reads remain available
- keep missing/invalid identity data and RPC integrity failures fail-closed

## Verification
- 20 focused failover/health tests
- 59 impacted chart/RPC/config tests
- TypeScript and scoped ESLint
- operations source-contract gate
- direct Stage proof: current USD FDV and creator claim simulation ready; no transaction submitted