### PR TITLE
Fix chart identity fallback

### DIFF
--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -20,6 +20,12 @@ import {
   TokenChartUnavailableError,
   type TokenChartFreshness,
 } from "../../../../../lib/onchain/chart";
+import { readDurableExploreModel } from "../../../../../lib/onchain/durable-model";
+import type {
+  ExploreReadModel,
+  ReadyOnchainDeployment,
+} from "../../../../../lib/onchain/types";
+import type { LauncherToken } from "../../../../../lib/tokens";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -46,6 +52,61 @@ function unavailableDataQuality(
     status: "unavailable" as const,
     reason,
   };
+}
+
+type ReadyExploreModel = Extract<ExploreReadModel, { status: "ready" }>;
+
+async function readChartIdentityModel(
+  deployment: ReadyOnchainDeployment,
+): Promise<Readonly<{
+  model: ReadyExploreModel;
+  readSource: "rpc" | "durable+rpc";
+}>> {
+  let primaryError: unknown;
+  try {
+    const model = await readAlchemyExploreModel();
+    if (
+      model.status === "ready" &&
+      model.snapshot.chainId === deployment.chainId
+    ) {
+      return { model, readSource: "rpc" };
+    }
+    primaryError = new Error("Live chart identity is unavailable");
+  } catch (error) {
+    primaryError = error;
+  }
+
+  try {
+    const durable = await readDurableExploreModel(
+      deployment,
+      Number.MAX_SAFE_INTEGER,
+    );
+    if (durable.status === "ready") {
+      const model = durable.envelope.payload.model;
+      if (
+        model.status === "ready" &&
+        model.snapshot.chainId === deployment.chainId
+      ) {
+        return { model, readSource: "durable+rpc" };
+      }
+    }
+  } catch {
+    // The original live-read failure is the useful sanitized telemetry cause.
+  }
+
+  throw primaryError ?? new Error("Chart identity is unavailable");
+}
+
+function chartIdentityToken(
+  token: LauncherToken,
+  readSource: "rpc" | "durable+rpc",
+): LauncherToken {
+  if (readSource === "rpc") return token;
+  const identityOnly = { ...token };
+  // An old aggregate is not current chart history. Reconstruct volume from
+  // exact logs when the canonical identity came from the durable snapshot.
+  delete identityOnly.grossVolumeWei;
+  return identityOnly;
 }
 
 export async function GET(request: NextRequest) {
@@ -100,16 +161,22 @@ export async function GET(request: NextRequest) {
         },
       );
     }
-    const [model, operationalSnapshot] = await Promise.all([
-      readAlchemyExploreModel(),
+    const [identityRead, operationalSnapshot] = await Promise.all([
+      readChartIdentityModel(deployment),
       readVerifiedOperationalMarketSnapshot(deployment),
     ]);
-    if (model.status !== "ready") {
+    const { model, readSource } = identityRead;
+
+    const token = model.tokens.find(
+      (candidate) =>
+        candidate.tokenAddress.toLowerCase() === address.toLowerCase(),
+    );
+    if (!token && readSource === "durable+rpc") {
       return NextResponse.json(
         {
           status: "unavailable",
           address,
-          error: "Onchain chart data is temporarily unavailable",
+          error: "Token identity is temporarily unavailable",
           dataQuality: unavailableDataQuality("source-unavailable"),
         },
         {
@@ -118,16 +185,11 @@ export async function GET(request: NextRequest) {
             "Cache-Control": "no-store",
             "Retry-After": "5",
             "X-Programmable-Data-Quality": "unavailable",
-            "X-Programmable-Read-Source": "rpc",
+            "X-Programmable-Read-Source": readSource,
           },
         },
       );
     }
-
-    const token = model.tokens.find(
-      (candidate) =>
-        candidate.tokenAddress.toLowerCase() === address.toLowerCase(),
-    );
     if (!token) {
       return NextResponse.json(
         {
@@ -139,13 +201,14 @@ export async function GET(request: NextRequest) {
           status: 404,
           headers: {
             "Cache-Control": "no-store",
-            "X-Programmable-Read-Source": "rpc",
+            "X-Programmable-Read-Source": readSource,
           },
         },
       );
     }
 
-    assertTokenChartSupported(token);
+    const tokenForChart = chartIdentityToken(token, readSource);
+    assertTokenChartSupported(tokenForChart);
 
     // A lagging launch-discovery snapshot is useful for canonical identity,
     // but it is never market-currentness authority. Returning unavailable here
@@ -165,7 +228,7 @@ export async function GET(request: NextRequest) {
             "Cache-Control": "no-store",
             "Retry-After": "5",
             "X-Programmable-Data-Quality": "unavailable",
-            "X-Programmable-Read-Source": "rpc",
+            "X-Programmable-Read-Source": readSource,
           },
         },
       );
@@ -184,9 +247,9 @@ export async function GET(request: NextRequest) {
       await enrichTokensWithAlchemyPoolState({
         deployment,
         snapshot: liveSnapshot,
-        tokens: [token],
+        tokens: [tokenForChart],
       })
-    )[0] ?? token;
+    )[0] ?? tokenForChart;
     const series = await readTokenChartSeries({
       deployment,
       token: liveToken,
@@ -226,7 +289,7 @@ export async function GET(request: NextRequest) {
               : "no-store",
           "X-Programmable-Data-Quality": qualityStatus,
           "X-Programmable-Valuation-Metric": "fdv",
-          "X-Programmable-Read-Source": "rpc",
+          "X-Programmable-Read-Source": readSource,
         },
       },
     );

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => {
     readVerifiedOperationalMarketSnapshot: vi.fn(),
     withSameBlockEthUsdQuote: vi.fn(),
     readAlchemyExploreModel: vi.fn(),
+    readDurableExploreModel: vi.fn(),
     readTokenChartSeries: vi.fn(),
     safeAlchemyError: vi.fn((error) => error),
     TokenChartIntegrityError,
@@ -45,6 +46,10 @@ vi.mock("../lib/onchain/chart", () => ({
   readTokenChartSeries: mocks.readTokenChartSeries,
   TokenChartIntegrityError: mocks.TokenChartIntegrityError,
   TokenChartUnavailableError: mocks.TokenChartUnavailableError,
+}));
+
+vi.mock("../lib/onchain/durable-model", () => ({
+  readDurableExploreModel: mocks.readDurableExploreModel,
 }));
 
 vi.mock("../lib/alchemy/live-market.server", () => ({
@@ -133,6 +138,11 @@ describe("token chart Alchemy API", () => {
       creatorClaims: [],
       launcherFeesAccruedWei: "0",
       launcherFeesAccruedEth: "0",
+    });
+    mocks.readDurableExploreModel.mockResolvedValue({
+      status: "unavailable",
+      reason: "missing",
+      detail: "No durable index snapshot exists",
     });
     mocks.readTokenChartSeries.mockResolvedValue({
       status: "ready",
@@ -299,6 +309,86 @@ describe("token chart Alchemy API", () => {
       valuation: { asOfBlock: operationalSnapshot.blockNumber },
     });
     expect(body.snapshotBlock).toBe(operationalSnapshot.blockNumber);
+  });
+
+  it("uses a verified durable identity snapshot when the live registry refresh is unavailable", async () => {
+    mocks.readAlchemyExploreModel.mockRejectedValue(
+      new Error("Operational RPCs are unavailable"),
+    );
+    mocks.readDurableExploreModel.mockResolvedValue({
+      status: "ready",
+      ageMs: 60_000,
+      envelope: {
+        payload: {
+          model: {
+            status: "ready",
+            tokens: [{ ...token, grossVolumeWei: "1000000000000000000" }],
+            snapshot,
+            launchDiscoverySnapshot,
+            creatorClaims: [],
+            launcherFeesAccruedWei: "0",
+            launcherFeesAccruedEth: "0",
+          },
+        },
+      },
+    });
+
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Programmable-Read-Source")).toBe(
+      "durable+rpc",
+    );
+    expect(mocks.readDurableExploreModel).toHaveBeenCalledWith(
+      deployment,
+      Number.MAX_SAFE_INTEGER,
+    );
+    expect(mocks.readTokenChartSeries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining(token),
+        snapshotBlock: BigInt(launchDiscoverySnapshot.blockNumber),
+      }),
+    );
+    expect(
+      mocks.readTokenChartSeries.mock.calls.at(-1)?.[0]?.token,
+    ).not.toHaveProperty("grossVolumeWei");
+    expect(body).toMatchObject({
+      status: "ready",
+      snapshotBlock: launchDiscoverySnapshot.blockNumber,
+      dataQuality: {
+        status: "current",
+        asOfBlock: launchDiscoverySnapshot.blockNumber,
+      },
+    });
+  });
+
+  it("fails closed when neither live nor durable identity is verified", async () => {
+    mocks.readAlchemyExploreModel.mockRejectedValue(
+      new Error("Operational RPCs are unavailable"),
+    );
+
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body).toMatchObject({
+      status: "unavailable",
+      dataQuality: {
+        status: "unavailable",
+        reason: "source-unavailable",
+      },
+    });
+    expect(mocks.readTokenChartSeries).not.toHaveBeenCalled();
   });
 
   it("fails closed and leaves the client to preserve its last verified chart without operational quorum", async () => {


### PR DESCRIPTION
## Outcome
- keep verified durable token identity available when the live registry refresh fails
- retain current price, FDV and chart authority on the verified dual-RPC block
- reconstruct chart volume instead of presenting a stale durable aggregate
- fail closed when neither live nor durable identity is verified

## Focused verification
- 4 chart suites / 51 tests passed
- TypeScript passed
- scoped ESLint passed
- diff check passed