### PR TITLE
Stabilize Website read quorum and chart history

### DIFF
--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -20,6 +20,7 @@ import {
   TokenChartUnavailableError,
   type TokenChartFreshness,
 } from "../../../../../lib/onchain/chart";
+import { getWebsiteChartOnchainDeployment } from "../../../../../lib/onchain/config";
 import { readDurableExploreModel } from "../../../../../lib/onchain/durable-model";
 import type {
   ExploreReadModel,
@@ -142,7 +143,12 @@ export async function GET(request: NextRequest) {
   try {
     const address = getAddress(input);
     const deployment = getAlchemyOnchainDeployment();
-    if (deployment.status !== "ready") {
+    const chartDeployment = getWebsiteChartOnchainDeployment("production");
+    if (
+      deployment.status !== "ready" ||
+      chartDeployment.status !== "ready" ||
+      chartDeployment.chainId !== deployment.chainId
+    ) {
       return NextResponse.json(
         {
           status: "unavailable",
@@ -251,7 +257,7 @@ export async function GET(request: NextRequest) {
       })
     )[0] ?? tokenForChart;
     const series = await readTokenChartSeries({
-      deployment,
+      deployment: chartDeployment,
       token: liveToken,
       snapshotBlock: BigInt(liveSnapshot.blockNumber),
       ethUsdQuote: liveSnapshot.ethUsdQuote,

--- a/lib/onchain/chart.ts
+++ b/lib/onchain/chart.ts
@@ -28,6 +28,7 @@ import type { ReadyOnchainDeployment } from "./types";
 import { usdValueFromWei } from "./usd";
 
 const MAXIMUM_CHART_POINTS = 80;
+const CHART_LOG_RANGE_CONCURRENCY = 4;
 const CHART_RANGE_SECONDS = {
   "1h": 60n * 60n,
   "1d": 24n * 60n * 60n,
@@ -421,54 +422,74 @@ async function readTokenChartSeriesFromRpc(input: {
   const shouldReadFeeVolume = indexedAllTimeVolume === undefined;
   const feeVolumeEvent = feeVolumeEventForToken(token, deployment.chainId);
 
+  const ranges: Array<Readonly<{ fromBlock: bigint; toBlock: bigint }>> = [];
   for (
     let fromBlock = rangeStartBlock;
     fromBlock <= snapshotBlock;
     fromBlock += deployment.logBlockRange
   ) {
-    const toBlock = minimum(
-      snapshotBlock,
-      fromBlock + deployment.logBlockRange - 1n,
-    );
-    const [logs, feeLogs] = await Promise.all([
-      client.getLogs({
-        address: poolManagerAddress(deployment.chainId),
-        event: poolManagerSwapEvent,
-        args: { id: token.poolId as Hex },
-        fromBlock,
-        toBlock,
-        strict: true,
-      }),
-      shouldReadFeeVolume
-        ? client.getLogs({
-            address: getAddress(token.hookAddress),
-            event: feeVolumeEvent,
-            args: { poolId: token.poolId as Hex },
-            fromBlock,
-            toBlock,
-            strict: true,
-          })
-        : Promise.resolve([]),
-    ]);
+    ranges.push({
+      fromBlock,
+      toBlock: minimum(
+        snapshotBlock,
+        fromBlock + deployment.logBlockRange - 1n,
+      ),
+    });
+  }
 
-    for (const log of logs) {
-      if (log.removed || log.blockNumber === null) continue;
-      rawPoints.push({
-        blockNumber: log.blockNumber,
-        logIndex: log.logIndex,
-        sqrtPriceX96: log.args.sqrtPriceX96,
-      });
-    }
-    for (const log of feeLogs) {
-      if (log.removed) continue;
-      const args = log.args;
-      if (
-        args &&
-        typeof args === "object" &&
-        "grossNativeAmount" in args &&
-        typeof args.grossNativeAmount === "bigint"
-      ) {
-        volumeWei += args.grossNativeAmount;
+  for (
+    let offset = 0;
+    offset < ranges.length;
+    offset += CHART_LOG_RANGE_CONCURRENCY
+  ) {
+    const batch = await Promise.all(
+      ranges
+        .slice(offset, offset + CHART_LOG_RANGE_CONCURRENCY)
+        .map(async ({ fromBlock, toBlock }) => {
+          const [logs, feeLogs] = await Promise.all([
+            client.getLogs({
+              address: poolManagerAddress(deployment.chainId),
+              event: poolManagerSwapEvent,
+              args: { id: token.poolId as Hex },
+              fromBlock,
+              toBlock,
+              strict: true,
+            }),
+            shouldReadFeeVolume
+              ? client.getLogs({
+                  address: getAddress(token.hookAddress),
+                  event: feeVolumeEvent,
+                  args: { poolId: token.poolId as Hex },
+                  fromBlock,
+                  toBlock,
+                  strict: true,
+                })
+              : Promise.resolve([]),
+          ]);
+          return { logs, feeLogs };
+        }),
+    );
+
+    for (const { logs, feeLogs } of batch) {
+      for (const log of logs) {
+        if (log.removed || log.blockNumber === null) continue;
+        rawPoints.push({
+          blockNumber: log.blockNumber,
+          logIndex: log.logIndex,
+          sqrtPriceX96: log.args.sqrtPriceX96,
+        });
+      }
+      for (const log of feeLogs) {
+        if (log.removed) continue;
+        const args = log.args;
+        if (
+          args &&
+          typeof args === "object" &&
+          "grossNativeAmount" in args &&
+          typeof args.grossNativeAmount === "bigint"
+        ) {
+          volumeWei += args.grossNativeAmount;
+        }
       }
     }
   }

--- a/lib/onchain/config.ts
+++ b/lib/onchain/config.ts
@@ -81,7 +81,8 @@ function productionSecondaryRpc() {
 
 const WEBSITE_MAINNET_RPC_PRIMARY =
   "https://ethereum-rpc.publicnode.com";
-const WEBSITE_MAINNET_RPC_SECONDARY = "https://rpc.mevblocker.io";
+const WEBSITE_MAINNET_RPC_SECONDARY = "https://eth.drpc.org";
+const WEBSITE_MAINNET_CHART_RPC_SECONDARY = "https://rpc.mevblocker.io";
 
 export function selectedDeploymentEnvironment(
   value = process.env.PROGRAMMABLE_ONCHAIN_NETWORK,
@@ -251,6 +252,23 @@ export function getWebsiteReadOnchainDeployment(
     ...deployment,
     rpcUrl: WEBSITE_MAINNET_RPC_PRIMARY,
     rpcUrlSecondary: WEBSITE_MAINNET_RPC_SECONDARY,
+  };
+}
+
+/**
+ * Historical log reads need one fixed archive-capable fallback. Current
+ * Website reads use the independently verified PublicNode + dRPC pair above;
+ * charts keep MEV Blocker as their narrow, fixed archive secondary.
+ */
+export function getWebsiteChartOnchainDeployment(
+  environment = selectedDeploymentEnvironment(),
+): OnchainDeployment {
+  const deployment = getWebsiteReadOnchainDeployment(environment);
+  if (deployment.environment !== "production") return deployment;
+
+  return {
+    ...deployment,
+    rpcUrlSecondary: WEBSITE_MAINNET_CHART_RPC_SECONDARY,
   };
 }
 

--- a/lib/onchain/index.ts
+++ b/lib/onchain/index.ts
@@ -2,6 +2,7 @@ export {
   getOnchainDeployment,
   getOperationalOnchainDeployment,
   getPublicOnchainDeployment,
+  getWebsiteChartOnchainDeployment,
   getWebsiteReadOnchainDeployment,
 } from "./config";
 export {

--- a/tests/onchain-chart-failover.test.ts
+++ b/tests/onchain-chart-failover.test.ts
@@ -128,6 +128,42 @@ describe("token chart operational RPC failover", () => {
     expect(secondaryClient.getLogs).toHaveBeenCalledTimes(2);
   });
 
+  it("reads disjoint chart ranges in bounded parallel batches", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const releases: Array<() => void> = [];
+    const getLogs = vi.fn().mockImplementation(() =>
+      new Promise<readonly []>((resolve) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        releases.push(() => {
+          inFlight -= 1;
+          resolve([]);
+        });
+      })
+    );
+    mocks.clients.set(primary, client(getLogs));
+
+    const read = readTokenChartSeries({
+      deployment: { ...deployment, logBlockRange: 10n },
+      token,
+      snapshotBlock: 149n,
+    });
+
+    await vi.waitFor(() => expect(getLogs).toHaveBeenCalledTimes(8));
+    expect(maxInFlight).toBe(8);
+    releases.splice(0).forEach((release) => release());
+
+    await vi.waitFor(() => expect(getLogs).toHaveBeenCalledTimes(10));
+    expect(maxInFlight).toBe(8);
+    releases.splice(0).forEach((release) => release());
+
+    await expect(read).resolves.toMatchObject({
+      status: "partial",
+      points: [],
+    });
+  });
+
   it("stays honestly unavailable when both configured RPCs fail", async () => {
     mocks.clients.set(
       primary,

--- a/tests/onchain-config.test.ts
+++ b/tests/onchain-config.test.ts
@@ -4,6 +4,7 @@ import {
   getOnchainDeployment,
   getOperationalOnchainDeployment,
   getPublicOnchainDeployment,
+  getWebsiteChartOnchainDeployment,
   getWebsiteReadOnchainDeployment,
 } from "../lib/onchain/config";
 
@@ -103,6 +104,11 @@ describe("onchain deployment manifest boundary", () => {
     expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
       status: "ready",
       rpcUrl: "https://ethereum-rpc.publicnode.com",
+      rpcUrlSecondary: "https://eth.drpc.org",
+    });
+    expect(getWebsiteChartOnchainDeployment("production")).toMatchObject({
+      status: "ready",
+      rpcUrl: "https://ethereum-rpc.publicnode.com",
       rpcUrlSecondary: "https://rpc.mevblocker.io",
     });
     expect(getOperationalOnchainDeployment("production")).toMatchObject({
@@ -123,7 +129,7 @@ describe("onchain deployment manifest boundary", () => {
     expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
       status: "ready",
       rpcUrl: "https://ethereum-rpc.publicnode.com",
-      rpcUrlSecondary: "https://rpc.mevblocker.io",
+      rpcUrlSecondary: "https://eth.drpc.org",
     });
   });
 
@@ -141,7 +147,7 @@ describe("onchain deployment manifest boundary", () => {
     expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
       status: "ready",
       rpcUrl: "https://ethereum-rpc.publicnode.com",
-      rpcUrlSecondary: "https://rpc.mevblocker.io",
+      rpcUrlSecondary: "https://eth.drpc.org",
     });
   });
 

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => {
   return {
     assertTokenChartSupported: vi.fn(),
     getAlchemyOnchainDeployment: vi.fn(),
+    getWebsiteChartOnchainDeployment: vi.fn(),
     isTokenChartRange: vi.fn(),
     enrichTokensWithAlchemyPoolState: vi.fn(),
     readVerifiedOperationalMarketSnapshot: vi.fn(),
@@ -46,6 +47,11 @@ vi.mock("../lib/onchain/chart", () => ({
   readTokenChartSeries: mocks.readTokenChartSeries,
   TokenChartIntegrityError: mocks.TokenChartIntegrityError,
   TokenChartUnavailableError: mocks.TokenChartUnavailableError,
+}));
+
+vi.mock("../lib/onchain/config", () => ({
+  getWebsiteChartOnchainDeployment:
+    mocks.getWebsiteChartOnchainDeployment,
 }));
 
 vi.mock("../lib/onchain/durable-model", () => ({
@@ -86,6 +92,11 @@ const deployment = {
   chainId: 1,
   rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/redacted",
 } as const;
+const chartDeployment = {
+  ...deployment,
+  rpcUrl: "https://ethereum-rpc.publicnode.com",
+  rpcUrlSecondary: "https://rpc.mevblocker.io",
+} as const;
 
 const snapshot = {
   chainId: 1,
@@ -107,6 +118,9 @@ describe("token chart Alchemy API", () => {
       ["1h", "1d", "1w", "all"].includes(range),
     );
     mocks.getAlchemyOnchainDeployment.mockReturnValue(deployment);
+    mocks.getWebsiteChartOnchainDeployment.mockReturnValue(
+      chartDeployment,
+    );
     mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
       launchDiscoverySnapshot,
     );
@@ -189,7 +203,7 @@ describe("token chart Alchemy API", () => {
     expect(mocks.getAlchemyOnchainDeployment).toHaveBeenCalledTimes(1);
     expect(mocks.readTokenChartSeries).toHaveBeenCalledWith(
       expect.objectContaining({
-        deployment,
+        deployment: chartDeployment,
         token,
         snapshotBlock: 25_630_005n,
         ethUsdQuote: expect.objectContaining({


### PR DESCRIPTION
## Outcome
- use the validated PublicNode + dRPC pair for current Website health, price, and FDV quorum reads
- keep the fixed archive-capable chart failover separate from current-value authority
- read disjoint chart log ranges in bounded parallel batches so long histories do not serialize every RPC chunk

## Evidence
- 5 focused files / 63 tests passed
- TypeScript passed
- scoped ESLint passed
- operations source-contract gate passed
- three consecutive live PublicNode + dRPC probes agreed on head, confirmed block, and block hash
- no provider account, key, secret, contract, Router, or Authority change

Target: `production`. The current public release remains functional while this reliability follow-up passes protected CI.