### PR TITLE
Use Bitquery for verified market data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,10 @@ UNISWAP_API_KEY=
 UNISWAP_V4_SUBGRAPH_URL=https://gateway.thegraph.com/api/subgraphs/id/DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G
 UNISWAP_V4_SUBGRAPH_API_KEY=
 
+# Required server-only access for Programmable market snapshots, OHLCV
+# backfill, and live Uniswap v4 PoolId streams. Never expose via NEXT_PUBLIC_.
+BITQUERY_OAUTH_TOKEN=
+
 # Server-only realtime read-model providers. Keep every indexed route disabled
 # until the migrated database, full backfill, parity, reorg and fallback gates
 # have passed. The Envio endpoint is public by design; Postgres and Graph

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -471,6 +471,9 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           node --input-type=module <<'NODE'
+          const { verifyBitqueryGoldenMarketParityV1 } = await import(
+            "./scripts/perf/bitquery-golden-market-parity.mjs"
+          );
           const origin = new URL(process.env.STAGED_TARGET_URL);
           if (
             origin.protocol !== "https:" ||
@@ -503,11 +506,17 @@ jobs:
             readSources: Object.freeze(["operational+durable+postgres"]),
             rpcProviders: null,
             marketSources: Object.freeze(["bitquery"]),
+            dataQualities: Object.freeze(["complete", "partial", "stale"]),
           });
           const bitqueryChartContract = Object.freeze({
             readSources: null,
             rpcProviders: null,
             marketSources: Object.freeze(["bitquery"]),
+            dataQualities: Object.freeze([
+              "ready",
+              "insufficient-history",
+              "partial",
+            ]),
           });
           const unavailableValuationReasons = new Set([
             "no-market",
@@ -542,6 +551,9 @@ jobs:
           const currentMarketTime = (value) =>
             validMarketTime(value) &&
             Date.now() - Date.parse(value) <= 6 * 60_000;
+          const boundedStaleMarketTime = (value) =>
+            validMarketTime(value) &&
+            Date.now() - Date.parse(value) <= 24 * 60 * 60_000;
 
           const requestJson = async (path, contract) => {
             let lastError;
@@ -574,10 +586,14 @@ jobs:
                 const marketAsOf = response.headers.get(
                   "x-programmable-market-as-of",
                 );
+                const dataQuality = response.headers.get(
+                  "x-programmable-data-quality",
+                );
                 if (
                   !headerMatches(readSource, contract.readSources) ||
                   !headerMatches(rpcProvider, contract.rpcProviders) ||
                   !headerMatches(marketSource, contract.marketSources) ||
+                  !headerMatches(dataQuality, contract.dataQualities) ||
                   (contract.priceSources !== undefined &&
                     !headerMatches(priceSource, contract.priceSources))
                 ) {
@@ -586,8 +602,17 @@ jobs:
                   );
                 }
                 const body = JSON.parse(text);
+                const expectedDataQuality = body?.dataQuality?.status ?? body?.status;
+                if (dataQuality !== expectedDataQuality) {
+                  throw new Error(`${path} has inconsistent data-quality provenance`);
+                }
                 Object.defineProperty(body, "__marketHeaders", {
-                  value: Object.freeze({ marketAsOf, marketSource, priceSource }),
+                  value: Object.freeze({
+                    dataQuality,
+                    marketAsOf,
+                    marketSource,
+                    priceSource,
+                  }),
                   enumerable: false,
                 });
                 return body;
@@ -658,6 +683,9 @@ jobs:
             }
             availableFdvCount += 1;
             if (valuation.freshness === "stale") {
+              if (!boundedStaleMarketTime(valuation.asOfTime)) {
+                throw new Error("staged Bitquery Explore stale FDV is too old");
+              }
               staleFdvCount += 1;
               sawNonCurrentFdv = true;
               if (token?.fdvUsdWad !== undefined) {
@@ -704,14 +732,30 @@ jobs:
           }
           const exploreMarketAsOf =
             explore.dataQuality?.valuation?.asOfTime ?? null;
+          const valuationQuality = explore.dataQuality?.valuation;
           if (
+            explore.dataQuality?.schemaVersion !==
+              "programmable.explore-data-quality.v1" ||
+            explore.__marketHeaders?.dataQuality !== explore.dataQuality.status ||
+            !["complete", "partial", "stale"].includes(
+              explore.dataQuality.status,
+            ) ||
+            valuationQuality?.metric !== "fdv" ||
+            !Number.isSafeInteger(valuationQuality.available) ||
+            !Number.isSafeInteger(valuationQuality.unavailable) ||
+            valuationQuality.available + valuationQuality.unavailable !==
+              explore.total ||
+            !Number.isSafeInteger(valuationQuality.stale) ||
+            valuationQuality.stale > valuationQuality.available ||
+            valuationQuality.unknown !== 0 ||
             ![null, "bitquery"].includes(
               explore.__marketHeaders?.priceSource ?? null,
             ) ||
             (currentFdvCount > 0 &&
               explore.__marketHeaders?.priceSource !== "bitquery") ||
             explore.__marketHeaders?.marketAsOf !== exploreMarketAsOf ||
-            (exploreMarketAsOf !== null && !validMarketTime(exploreMarketAsOf))
+            (exploreMarketAsOf !== null &&
+              !boundedStaleMarketTime(exploreMarketAsOf))
           ) {
             throw new Error(
               "staged Bitquery Explore has inconsistent market provenance",
@@ -925,6 +969,8 @@ jobs:
                 currentFdvToken.valuation.asOfTime ||
               currentFdvDetail.token.fdvUsdWad !==
                 currentFdvToken.fdvUsdWad ||
+              currentFdvDetail.__marketHeaders?.marketAsOf !==
+                currentFdvDetail.token.valuation.asOfTime ||
               currentFdvDetail.__marketHeaders?.priceSource !== "bitquery"
             ) {
               throw new Error(
@@ -975,6 +1021,14 @@ jobs:
             goldenMarket?.schemaVersion !== "programmable.market-data.v1" ||
             goldenMarket?.source !== "bitquery" ||
             goldenMarket?.primaryPoolId !== goldenPoolId ||
+            !currentMarketTime(goldenMarket?.generatedAt) ||
+            goldenDetail.dataQuality?.schemaVersion !==
+              "programmable.explore-data-quality.v1" ||
+            goldenDetail.__marketHeaders?.dataQuality !==
+              goldenDetail.dataQuality.status ||
+            !["complete", "partial", "stale"].includes(
+              goldenDetail.dataQuality.status,
+            ) ||
             !["current", "stale"].includes(goldenMarket?.status) ||
             !["current", "stale"].includes(goldenPool?.status) ||
             goldenValuation?.status !== "available" ||
@@ -985,6 +1039,8 @@ jobs:
             !validMarketTime(goldenValuation.asOfTime) ||
             (goldenValuation.freshness === "current" &&
               !currentMarketTime(goldenValuation.asOfTime)) ||
+            (goldenValuation.freshness === "stale" &&
+              !boundedStaleMarketTime(goldenValuation.asOfTime)) ||
             goldenPool?.valuation?.metric !== "fdv" ||
             goldenPool?.valuation?.marketCapUsdWad !== undefined ||
             expectedGoldenFdv === null ||
@@ -995,6 +1051,7 @@ jobs:
             goldenExploreToken.valuation.valueWad !== goldenValuation.valueWad ||
             goldenExploreToken.valuation.freshness !== goldenValuation.freshness ||
             goldenExploreToken.valuation.asOfTime !== goldenValuation.asOfTime ||
+            goldenDetail.__marketHeaders?.marketAsOf !== goldenValuation.asOfTime ||
             (goldenValuation.freshness === "current"
               ? goldenDetail.__marketHeaders?.priceSource !== "bitquery"
               : goldenDetail.__marketHeaders?.priceSource !== null) ||
@@ -1006,6 +1063,9 @@ jobs:
           ) {
             throw new Error("staged PCAN market valuation is not Bitquery-bound");
           }
+          const goldenParity = await verifyBitqueryGoldenMarketParityV1({
+            token: goldenDetail.token,
+          });
           const goldenChart = await requestJson(
             `/api/explore/token/chart?address=${goldenTokenAddress}&range=all`,
             bitqueryChartContract,
@@ -1013,6 +1073,7 @@ jobs:
           if (
             goldenChart.schemaVersion !== "programmable.market-chart.v1" ||
             goldenChart.source !== "bitquery" ||
+            !currentMarketTime(goldenChart.generatedAt) ||
             goldenChart.address?.toLowerCase() !== goldenTokenAddress ||
             goldenChart.identity?.poolId !== goldenPoolId ||
             !["ready", "insufficient-history", "partial"].includes(
@@ -1025,8 +1086,11 @@ jobs:
             !["current", "stale"].includes(goldenChart.valuation?.freshness) ||
             (goldenChart.valuation?.freshness === "current" &&
               !currentMarketTime(goldenChart.valuation?.asOfTime)) ||
+            (goldenChart.valuation?.freshness === "stale" &&
+              !boundedStaleMarketTime(goldenChart.valuation?.asOfTime)) ||
             goldenChart.asOfTime !== goldenChart.points.at(-1)?.time ||
             goldenChart.__marketHeaders?.marketAsOf !== goldenChart.asOfTime ||
+            goldenChart.__marketHeaders?.dataQuality !== goldenChart.status ||
             goldenChart.__marketHeaders?.priceSource !== "bitquery" ||
             !validMarketTime(goldenChart.asOfTime)
           ) {
@@ -1056,12 +1120,30 @@ jobs:
             previousChartTime = time;
             previousChartBlock = block;
           }
+          const historicalPaidPathVerified =
+            goldenParity.schemaVersion ===
+              "programmable.bitquery-golden-market-parity.v1" &&
+            goldenParity.tokenAddress === goldenTokenAddress &&
+            goldenParity.poolId === goldenPoolId &&
+            goldenParity.confirmations >= 12 &&
+            goldenChart.points.length >= 1 &&
+            currentMarketTime(goldenChart.generatedAt) &&
+            goldenChart.__marketHeaders?.dataQuality === goldenChart.status &&
+            goldenChart.__marketHeaders?.marketSource === "bitquery" &&
+            goldenChart.__marketHeaders?.priceSource === "bitquery";
+          if (currentFdvCount < 1 && !historicalPaidPathVerified) {
+            throw new Error(
+              "staged Bitquery market path has no current or independently verified history",
+            );
+          }
           process.stdout.write(
             `${JSON.stringify({
               status: "verified-bitquery-staged-market-apis",
               tokenAddress: releaseToken.tokenAddress,
               goldenTokenAddress,
               goldenPoolId,
+              goldenParity,
+              historicalPaidPathVerified,
               currentFdvCount,
               availableFdvCount,
               staleFdvCount,

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -465,8 +465,7 @@ jobs:
           node scripts/verify-manual-applicant-staged-runtime.mjs
           --target-url "$STAGED_TARGET_URL"
 
-      - name: Smoke staged Alchemy Explore APIs
-        if: steps.read-model-policy.outputs.mode == 'alchemy-only'
+      - name: Smoke staged Bitquery market APIs
         env:
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -480,7 +479,7 @@ jobs:
             origin.search ||
             origin.hash
           ) {
-            throw new Error("Alchemy smoke target is not an exact Vercel origin");
+            throw new Error("Bitquery smoke target is not an exact Vercel origin");
           }
           const automationBypassSecret =
             process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
@@ -494,33 +493,63 @@ jobs:
             automationBypassSecretLength > 512 ||
             /[\r\n]/.test(automationBypassSecret)
           ) {
-            throw new Error("Alchemy smoke automation bypass is unavailable");
+            throw new Error("Bitquery smoke automation bypass is unavailable");
           }
-          const alchemySmokeRequestHeaders = Object.freeze({
+          const bitquerySmokeRequestHeaders = Object.freeze({
             Accept: "application/json",
             "x-vercel-protection-bypass": automationBypassSecret,
           });
-          const operationalRpcProviders = Object.freeze([
-            "operational-dual",
-            "operational-primary",
+          const bitqueryMarketContract = Object.freeze({
+            readSources: Object.freeze(["operational+durable+postgres"]),
+            rpcProviders: null,
+            marketSources: Object.freeze(["bitquery"]),
+          });
+          const bitqueryChartContract = Object.freeze({
+            readSources: null,
+            rpcProviders: null,
+            marketSources: Object.freeze(["bitquery"]),
+          });
+          const unavailableValuationReasons = new Set([
+            "no-market",
+            "supply-unavailable",
+            "liquidity-unavailable",
+            "price-unavailable",
+            "inconsistent-snapshot",
+            "waiting-for-first-trade",
+            "source-unavailable",
           ]);
-          const operationalReadSources = Object.freeze([
-            "operational+durable+postgres",
-          ]);
-          const alchemyRpcProviders = Object.freeze(["alchemy"]);
-          const alchemyReadSources = Object.freeze(["blob"]);
 
-          const requestJson = async (
-            path,
-            expectedReadSources,
-            expectedRpcProviders,
-          ) => {
+          const headerMatches = (value, expected) =>
+            expected === null
+              ? value === null
+              : expected.includes(value ?? "");
+          const positiveInteger = (value) =>
+            typeof value === "string" && /^[1-9][0-9]*$/.test(value);
+          const positiveDecimalToWad = (value) => {
+            const match = /^(0|[1-9][0-9]*)(?:\.([0-9]+))?$/.exec(
+              String(value ?? ""),
+            );
+            if (!match) return null;
+            const wad = BigInt(match[1]) * 10n ** 18n +
+              BigInt((match[2] ?? "").slice(0, 18).padEnd(18, "0") || "0");
+            return wad > 0n ? wad : null;
+          };
+          const validMarketTime = (value) => {
+            const parsed = Date.parse(value ?? "");
+            return Number.isFinite(parsed) &&
+              parsed <= Date.now() + 60_000;
+          };
+          const currentMarketTime = (value) =>
+            validMarketTime(value) &&
+            Date.now() - Date.parse(value) <= 6 * 60_000;
+
+          const requestJson = async (path, contract) => {
             let lastError;
             for (let attempt = 1; attempt <= 12; attempt += 1) {
               try {
                 const response = await fetch(new URL(path, origin), {
                   redirect: "error",
-                  headers: alchemySmokeRequestHeaders,
+                  headers: bitquerySmokeRequestHeaders,
                   signal: AbortSignal.timeout(30_000),
                 });
                 const text = await response.text();
@@ -536,15 +565,32 @@ jobs:
                 const rpcProvider = response.headers.get(
                   "x-programmable-rpc-provider",
                 );
+                const marketSource = response.headers.get(
+                  "x-programmable-market-source",
+                );
+                const priceSource = response.headers.get(
+                  "x-programmable-price-source",
+                );
+                const marketAsOf = response.headers.get(
+                  "x-programmable-market-as-of",
+                );
                 if (
-                  !expectedReadSources.includes(readSource ?? "") ||
-                  !expectedRpcProviders.includes(rpcProvider ?? "")
+                  !headerMatches(readSource, contract.readSources) ||
+                  !headerMatches(rpcProvider, contract.rpcProviders) ||
+                  !headerMatches(marketSource, contract.marketSources) ||
+                  (contract.priceSources !== undefined &&
+                    !headerMatches(priceSource, contract.priceSources))
                 ) {
                   throw new Error(
-                    `${path} did not prove its required read and RPC sources`,
+                    `${path} did not prove its required identity and market sources`,
                   );
                 }
-                return JSON.parse(text);
+                const body = JSON.parse(text);
+                Object.defineProperty(body, "__marketHeaders", {
+                  value: Object.freeze({ marketAsOf, marketSource, priceSource }),
+                  enumerable: false,
+                });
+                return body;
               } catch (error) {
                 lastError = error;
                 if (attempt < 12) {
@@ -557,8 +603,7 @@ jobs:
 
           const explore = await requestJson(
             "/api/explore?limit=20&page=1&sort=market-cap",
-            operationalReadSources,
-            operationalRpcProviders,
+            bitqueryMarketContract,
           );
           if (
             explore.status !== "ready" ||
@@ -566,20 +611,116 @@ jobs:
             explore.tokens.length < 1 ||
             explore.tokens.length > 20
           ) {
-            throw new Error("staged Alchemy Explore is not a populated bounded page");
+            throw new Error("staged Bitquery Explore is not a populated bounded page");
           }
           const releaseToken = explore.tokens.find(
             (token) =>
               /^0x[0-9a-fA-F]{40}$/.test(token?.tokenAddress ?? ""),
           );
           if (!releaseToken) {
-            throw new Error("staged Alchemy Explore has no token identity");
+            throw new Error("staged Bitquery Explore has no token identity");
+          }
+          let previousCurrentFdv = null;
+          let currentFdvCount = 0;
+          let availableFdvCount = 0;
+          let staleFdvCount = 0;
+          let waitingForFirstTradeCount = 0;
+          let sawNonCurrentFdv = false;
+          let currentFdvToken = null;
+          for (const token of explore.tokens) {
+            const valuation = token?.valuation;
+            if (valuation?.status === "unavailable") {
+              if (!unavailableValuationReasons.has(valuation.reason)) {
+                throw new Error("staged Bitquery Explore has an untyped unavailable valuation");
+              }
+              if (valuation.reason === "waiting-for-first-trade") {
+                waitingForFirstTradeCount += 1;
+              }
+              sawNonCurrentFdv = true;
+              if (token?.fdvUsdWad !== undefined) {
+                throw new Error(
+                  "staged Bitquery Explore exposed stale or unavailable FDV as current",
+                );
+              }
+              continue;
+            }
+            if (
+              valuation?.status !== "available" ||
+              valuation.metric !== "fdv" ||
+              valuation.supplyBasis !== "total" ||
+              valuation.currency !== "usd" ||
+              !["current", "stale"].includes(valuation.freshness) ||
+              valuation.source !== "bitquery" ||
+              !positiveInteger(valuation.valueWad) ||
+              !validMarketTime(valuation.asOfTime)
+            ) {
+              throw new Error("staged Bitquery Explore has an invalid typed FDV");
+            }
+            availableFdvCount += 1;
+            if (valuation.freshness === "stale") {
+              staleFdvCount += 1;
+              sawNonCurrentFdv = true;
+              if (token?.fdvUsdWad !== undefined) {
+                throw new Error(
+                  "staged Bitquery Explore exposed stale or unavailable FDV as current",
+                );
+              }
+              continue;
+            }
+            if (token.fdvUsdWad !== valuation.valueWad) {
+              throw new Error("staged Bitquery Explore did not expose its current FDV");
+            }
+            if (!currentMarketTime(valuation.asOfTime)) {
+              throw new Error("staged Bitquery Explore mislabeled stale FDV as current");
+            }
+            if (sawNonCurrentFdv) {
+              throw new Error(
+                "staged Bitquery Highest FDV placed current data after stale data",
+              );
+            }
+            const value = BigInt(valuation.valueWad);
+            if (previousCurrentFdv !== null && value > previousCurrentFdv) {
+              throw new Error(
+                "staged Bitquery Highest FDV is not monotonically descending",
+              );
+            }
+            const primary = token.marketData?.pools?.find(
+              (pool) => pool.identity?.poolId === token.marketData?.primaryPoolId,
+            );
+            if (
+              !primary ||
+              primary.status !== "current" ||
+              primary.liquidity?.freshness !== "current" ||
+              !positiveInteger(primary.liquidity?.valueUsdWad) ||
+              primary.valuation?.asOfTime !== valuation.asOfTime
+            ) {
+              throw new Error(
+                "staged Bitquery current FDV lacks current trade and liquidity evidence",
+              );
+            }
+            previousCurrentFdv = value;
+            currentFdvCount += 1;
+            currentFdvToken ??= token;
+          }
+          const exploreMarketAsOf =
+            explore.dataQuality?.valuation?.asOfTime ?? null;
+          if (
+            ![null, "bitquery"].includes(
+              explore.__marketHeaders?.priceSource ?? null,
+            ) ||
+            (currentFdvCount > 0 &&
+              explore.__marketHeaders?.priceSource !== "bitquery") ||
+            explore.__marketHeaders?.marketAsOf !== exploreMarketAsOf ||
+            (exploreMarketAsOf !== null && !validMarketTime(exploreMarketAsOf))
+          ) {
+            throw new Error(
+              "staged Bitquery Explore has inconsistent market provenance",
+            );
           }
           const newestPageSize = 100;
           const newest = await requestJson(
             `/api/explore?limit=${newestPageSize}&page=1&sort=newest`,
-            operationalReadSources,
-            operationalRpcProviders,
+            bitqueryMarketContract,
           );
           const newestTotal = Number(newest.total);
           const newestTotalPages = Number(newest.totalPages);
@@ -597,7 +738,7 @@ jobs:
             newestTotalPages > 100 ||
             newestTotalPages !== Math.ceil(newestTotal / newestPageSize)
           ) {
-            throw new Error("staged Alchemy newest page is not populated");
+            throw new Error("staged Bitquery newest page is not populated");
           }
           const newestTokens = [];
           const seenNewestIds = new Set();
@@ -606,8 +747,7 @@ jobs:
               ? newest
               : await requestJson(
                    `/api/explore?limit=${newestPageSize}&page=${pageNumber}&sort=newest`,
-                   operationalReadSources,
-                   operationalRpcProviders,
+                   bitqueryMarketContract,
                  );
             if (
               page.status !== "ready" ||
@@ -618,22 +758,22 @@ jobs:
               !Array.isArray(page.tokens) ||
               page.tokens.length < 1
             ) {
-              throw new Error("staged Alchemy newest pagination is not stable");
+              throw new Error("staged Bitquery newest pagination is not stable");
             }
             for (const entry of page.tokens) {
               if (typeof entry?.id !== "string" || seenNewestIds.has(entry.id)) {
-                throw new Error("staged Alchemy newest pagination is not unique");
+                throw new Error("staged Bitquery newest pagination is not unique");
               }
               seenNewestIds.add(entry.id);
               newestTokens.push(entry);
             }
           }
           if (newestTokens.length !== newestTotal) {
-            throw new Error("staged Alchemy newest pagination is incomplete");
+            throw new Error("staged Bitquery newest pagination is incomplete");
           }
           const newestChainId = String(newest.snapshot?.chainId ?? "");
           if (!/^(?:0|[1-9][0-9]*)$/.test(newestChainId)) {
-            throw new Error("staged Alchemy newest snapshot has no canonical chain");
+            throw new Error("staged Bitquery newest snapshot has no canonical chain");
           }
           const launchChainId = (entry) => {
             const value = entry.exploreKind === "token"
@@ -642,7 +782,7 @@ jobs:
                 ? String(entry.chainId ?? "")
                 : "";
             if (!/^(?:0|[1-9][0-9]*)$/.test(value)) {
-              throw new Error("staged Alchemy newest entry has no canonical chain");
+              throw new Error("staged Bitquery newest entry has no canonical chain");
             }
             return value;
           };
@@ -663,14 +803,14 @@ jobs:
                 : null;
             if (coordinates === null || coordinates.length !== 3) {
               throw new Error(
-                "staged Alchemy newest entry has no canonical launch order",
+                "staged Bitquery newest entry has no canonical launch order",
               );
             }
             return coordinates.map((value) => {
               const normalized = String(value ?? "");
               if (!/^(?:0|[1-9][0-9]*)$/.test(normalized)) {
                 throw new Error(
-                  "staged Alchemy newest entry has no canonical launch order",
+                  "staged Bitquery newest entry has no canonical launch order",
                 );
               }
               return BigInt(normalized);
@@ -679,13 +819,13 @@ jobs:
           const launchTime = (entry) => {
             const value = Date.parse(entry.launchedAt ?? "");
             if (!Number.isFinite(value)) {
-              throw new Error("staged Alchemy newest entry has no canonical time");
+              throw new Error("staged Bitquery newest entry has no canonical time");
             }
             return value;
           };
           for (const entry of newestTokens) {
             if (launchChainId(entry) !== newestChainId) {
-              throw new Error("staged Alchemy newest entry is on another chain");
+              throw new Error("staged Bitquery newest entry is on another chain");
             }
             launchOrder(entry);
             launchTime(entry);
@@ -706,13 +846,12 @@ jobs:
                   ),
               )
             ) {
-              throw new Error("staged Alchemy newest page is not ordered newest-first");
+              throw new Error("staged Bitquery newest page is not ordered newest-first");
             }
           }
           const oldest = await requestJson(
             `/api/explore?limit=${newestPageSize}&page=1&sort=oldest`,
-            operationalReadSources,
-            operationalRpcProviders,
+            bitqueryMarketContract,
           );
           const expectedOldestIds = newestTokens
             .slice(-newestPageSize)
@@ -726,14 +865,13 @@ jobs:
             oldest.tokens.map((entry) => entry.id).join("\n") !==
               expectedOldestIds.join("\n")
           ) {
-            throw new Error("staged Alchemy oldest page is not ordered oldest-first");
+            throw new Error("staged Bitquery oldest page is not ordered oldest-first");
           }
           const incrementalLaunchAddress =
             "0x468505087c2dfec4779f2d6a5f8481f03e32e905";
           const incrementalDetail = await requestJson(
             `/api/explore/token?address=${encodeURIComponent(incrementalLaunchAddress)}`,
-            operationalReadSources,
-            operationalRpcProviders,
+            bitqueryMarketContract,
           );
           const incrementalLaunch = incrementalDetail.token;
           const incrementalLaunchBlock = BigInt(
@@ -757,40 +895,177 @@ jobs:
             )
           ) {
             throw new Error(
-              "staged Alchemy Explore did not recover the incremental launch cursor",
+              "staged Bitquery Explore did not recover the incremental launch cursor",
             );
-          }
-          const tokenList = await requestJson(
-            "/api/indexers/v1/token-list",
-            alchemyReadSources,
-            alchemyRpcProviders,
-          );
-          if (
-            !Array.isArray(tokenList.tokens) ||
-            !tokenList.tokens.some(
-              (token) =>
-                String(token?.address ?? token?.tokenAddress ?? "").toLowerCase() ===
-                releaseToken.tokenAddress.toLowerCase(),
-            )
-          ) {
-            throw new Error("staged Alchemy token list does not contain the Explore token");
           }
           const tokenDetail = await requestJson(
             `/api/explore/token?address=${encodeURIComponent(releaseToken.tokenAddress)}`,
-            operationalReadSources,
-            operationalRpcProviders,
+            bitqueryMarketContract,
           );
           if (
             tokenDetail.status !== "ready" ||
             tokenDetail.token?.tokenAddress?.toLowerCase() !==
               releaseToken.tokenAddress.toLowerCase()
           ) {
-            throw new Error("staged Alchemy token lookup did not resolve the Explore token");
+            throw new Error("staged Bitquery token lookup did not resolve the Explore token");
+          }
+          if (currentFdvToken !== null) {
+            const currentFdvDetail = await requestJson(
+              `/api/explore/token?address=${encodeURIComponent(currentFdvToken.tokenAddress)}`,
+              bitqueryMarketContract,
+            );
+            if (
+              currentFdvDetail.token?.valuation?.status !== "available" ||
+              currentFdvDetail.token.valuation.metric !== "fdv" ||
+              currentFdvDetail.token.valuation.supplyBasis !== "total" ||
+              currentFdvDetail.token.valuation.freshness !== "current" ||
+              currentFdvDetail.token.valuation.valueWad !==
+                currentFdvToken.valuation.valueWad ||
+              currentFdvDetail.token.valuation.asOfTime !==
+                currentFdvToken.valuation.asOfTime ||
+              currentFdvDetail.token.fdvUsdWad !==
+                currentFdvToken.fdvUsdWad ||
+              currentFdvDetail.__marketHeaders?.priceSource !== "bitquery"
+            ) {
+              throw new Error(
+                "staged Bitquery current Explore and detail FDV are not identical",
+              );
+            }
+          }
+          const goldenTokenAddress =
+            "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
+          const goldenPoolId =
+            "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+          const goldenExplore = await requestJson(
+            `/api/explore?limit=20&page=1&q=${goldenTokenAddress}&sort=market-cap`,
+            bitqueryMarketContract,
+          );
+          const goldenExploreToken = goldenExplore.tokens?.find(
+            (token) => token?.tokenAddress?.toLowerCase() === goldenTokenAddress,
+          );
+          if (goldenExplore.status !== "ready" || !goldenExploreToken) {
+            throw new Error("staged Explore did not retain the canonical PCAN identity");
+          }
+          const goldenDetail = await requestJson(
+            `/api/explore/token?address=${goldenTokenAddress}`,
+            bitqueryMarketContract,
+          );
+          const goldenMarket = goldenDetail.token?.marketData;
+          const goldenPool = goldenMarket?.pools?.find(
+            (pool) => pool.identity?.poolId === goldenPoolId,
+          );
+          const goldenPrice = positiveInteger(
+              goldenPool?.latestTrade?.priceUsdWad,
+            )
+            ? BigInt(goldenPool.latestTrade.priceUsdWad)
+            : null;
+          const goldenSupply = positiveDecimalToWad(
+            goldenDetail.token?.valuation?.status === "available"
+              ? goldenPool?.valuation?.totalSupply
+              : null,
+          );
+          const expectedGoldenFdv = goldenPrice !== null && goldenSupply !== null
+            ? (goldenPrice * goldenSupply) / 10n ** 18n
+            : null;
+          const goldenValuation = goldenDetail.token?.valuation;
+          if (
+            goldenDetail.status !== "ready" ||
+            goldenDetail.token?.tokenAddress?.toLowerCase() !==
+              goldenTokenAddress ||
+            goldenMarket?.schemaVersion !== "programmable.market-data.v1" ||
+            goldenMarket?.source !== "bitquery" ||
+            goldenMarket?.primaryPoolId !== goldenPoolId ||
+            !["current", "stale"].includes(goldenMarket?.status) ||
+            !["current", "stale"].includes(goldenPool?.status) ||
+            goldenValuation?.status !== "available" ||
+            goldenValuation.source !== "bitquery" ||
+            goldenValuation.metric !== "fdv" ||
+            goldenValuation.supplyBasis !== "total" ||
+            !["current", "stale"].includes(goldenValuation.freshness) ||
+            !validMarketTime(goldenValuation.asOfTime) ||
+            (goldenValuation.freshness === "current" &&
+              !currentMarketTime(goldenValuation.asOfTime)) ||
+            goldenPool?.valuation?.metric !== "fdv" ||
+            goldenPool?.valuation?.marketCapUsdWad !== undefined ||
+            expectedGoldenFdv === null ||
+            expectedGoldenFdv <= 0n ||
+            goldenPool?.valuation?.fdvUsdWad !== expectedGoldenFdv.toString() ||
+            goldenValuation.valueWad !== expectedGoldenFdv.toString() ||
+            goldenExploreToken.valuation?.status !== "available" ||
+            goldenExploreToken.valuation.valueWad !== goldenValuation.valueWad ||
+            goldenExploreToken.valuation.freshness !== goldenValuation.freshness ||
+            goldenExploreToken.valuation.asOfTime !== goldenValuation.asOfTime ||
+            (goldenValuation.freshness === "current"
+              ? goldenDetail.__marketHeaders?.priceSource !== "bitquery"
+              : goldenDetail.__marketHeaders?.priceSource !== null) ||
+            (goldenValuation.freshness === "current"
+              ? goldenDetail.token.fdvUsdWad !== goldenValuation.valueWad ||
+                goldenExploreToken.fdvUsdWad !== goldenValuation.valueWad
+              : goldenDetail.token.fdvUsdWad !== undefined ||
+                goldenExploreToken.fdvUsdWad !== undefined)
+          ) {
+            throw new Error("staged PCAN market valuation is not Bitquery-bound");
+          }
+          const goldenChart = await requestJson(
+            `/api/explore/token/chart?address=${goldenTokenAddress}&range=all`,
+            bitqueryChartContract,
+          );
+          if (
+            goldenChart.schemaVersion !== "programmable.market-chart.v1" ||
+            goldenChart.source !== "bitquery" ||
+            goldenChart.address?.toLowerCase() !== goldenTokenAddress ||
+            goldenChart.identity?.poolId !== goldenPoolId ||
+            !["ready", "insufficient-history", "partial"].includes(
+              goldenChart.status,
+            ) ||
+            !Array.isArray(goldenChart.points) ||
+            goldenChart.points.length < 1 ||
+            goldenChart.valuation?.metric !== "fdv" ||
+            goldenChart.valuation?.supplyBasis !== "total" ||
+            !["current", "stale"].includes(goldenChart.valuation?.freshness) ||
+            (goldenChart.valuation?.freshness === "current" &&
+              !currentMarketTime(goldenChart.valuation?.asOfTime)) ||
+            goldenChart.asOfTime !== goldenChart.points.at(-1)?.time ||
+            goldenChart.__marketHeaders?.marketAsOf !== goldenChart.asOfTime ||
+            goldenChart.__marketHeaders?.priceSource !== "bitquery" ||
+            !validMarketTime(goldenChart.asOfTime)
+          ) {
+            throw new Error("staged PCAN price history is not Bitquery-bound");
+          }
+          let previousChartTime = null;
+          let previousChartBlock = null;
+          for (const point of goldenChart.points) {
+            const time = Date.parse(point?.time ?? "");
+            const block = positiveInteger(point?.blockNumber)
+              ? BigInt(point.blockNumber)
+              : null;
+            const price = point?.priceUsd ?? point?.priceQuote;
+            const numericPrice = Number(price);
+            if (
+              !Number.isFinite(time) ||
+              block === null ||
+              !Number.isFinite(numericPrice) ||
+              numericPrice <= 0 ||
+              (previousChartTime !== null && time <= previousChartTime) ||
+              (previousChartBlock !== null && block < previousChartBlock)
+            ) {
+              throw new Error(
+                "staged PCAN chart is not a strictly ordered positive history",
+              );
+            }
+            previousChartTime = time;
+            previousChartBlock = block;
           }
           process.stdout.write(
             `${JSON.stringify({
-              status: "verified-alchemy-only-staged-public-apis",
+              status: "verified-bitquery-staged-market-apis",
               tokenAddress: releaseToken.tokenAddress,
+              goldenTokenAddress,
+              goldenPoolId,
+              currentFdvCount,
+              availableFdvCount,
+              staleFdvCount,
+              waitingForFirstTradeCount,
               incrementalLaunchAddress,
               launchCursorBlockNumber:
                 incrementalDetail.launchDiscoverySnapshot.blockNumber,
@@ -798,14 +1073,14 @@ jobs:
           );
           NODE
 
-      - name: Record Alchemy-only read path
+      - name: Record registry identity and Bitquery market path
         if: steps.read-model-policy.outputs.mode == 'alchemy-only'
         run: |
           {
             echo "## Read-model release policy"
             echo
-            echo "Alchemy-only: Explore, token detail and token list use the verified durable registry with live Alchemy enrichment."
-            echo "Every non-Alchemy public read path is disabled."
+            echo "Router and Registry remain the launch-identity authority."
+            echo "Explore, token detail and charts use verified Bitquery market data; token identities do not disappear when market data is unavailable."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Capture staged read-model evidence

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1073,6 +1073,7 @@ jobs:
           if (
             goldenChart.schemaVersion !== "programmable.market-chart.v1" ||
             goldenChart.source !== "bitquery" ||
+            goldenChart.readStatus !== "live" ||
             !currentMarketTime(goldenChart.generatedAt) ||
             goldenChart.address?.toLowerCase() !== goldenTokenAddress ||
             goldenChart.identity?.poolId !== goldenPoolId ||
@@ -1127,6 +1128,7 @@ jobs:
             goldenParity.poolId === goldenPoolId &&
             goldenParity.confirmations >= 12 &&
             goldenChart.points.length >= 1 &&
+            goldenChart.readStatus === "live" &&
             currentMarketTime(goldenChart.generatedAt) &&
             goldenChart.__marketHeaders?.dataQuality === goldenChart.status &&
             goldenChart.__marketHeaders?.marketSource === "bitquery" &&

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -71,6 +71,38 @@ paths = [
 regexes = ['''(?i)0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce''']
 
 [[allowlists]]
+description = "Bitquery market parity pins the public PCAN golden token address"
+condition = "AND"
+regexTarget = "match"
+paths = [
+  '''scripts/perf/bitquery-golden-market-parity\.mjs''',
+  '''scripts/perf/read-model-post-promotion\.mjs''',
+  '''tests/bitquery-market-data\.test\.ts''',
+  '''tests/data-pipeline/read-model-ops-contract\.test\.ts''',
+]
+regexes = ['''(?i)0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce''']
+
+[[allowlists]]
+description = "Bitquery parity pins public Uniswap StateView and Chainlink feed addresses"
+condition = "AND"
+regexTarget = "match"
+paths = [
+  '''scripts/perf/bitquery-golden-market-parity\.mjs''',
+  '''tests/data-pipeline/read-model-ops-contract\.test\.ts''',
+]
+regexes = [
+  '''(?i)0x7ffe42c4a5deea5b0fec41c94c136cf115597227''',
+  '''(?i)0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419''',
+]
+
+[[allowlists]]
+description = "Bitquery tests pin a public Classic token fixture address"
+condition = "AND"
+regexTarget = "match"
+paths = ['''tests/bitquery-market-data\.test\.ts''']
+regexes = ['''(?i)0x3f2a426365e7a438a7f9f758766cff419d207d51''']
+
+[[allowlists]]
 description = "Manual Router vendor artifacts contain public bytes32 runtime and pool-key hashes"
 condition = "AND"
 regexTarget = "match"

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -1,22 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import {
-  getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../lib/alchemy/explore.server";
-import {
-  enrichTokensWithAlchemyPoolState,
-  readVerifiedOperationalMarketSnapshot,
-  withSameBlockEthUsdQuote,
-  withoutUnboundEthUsdQuote,
-} from "../../../lib/alchemy/live-market.server";
 import { suppressRouterBoundCustomProjectDuplicates } from "../../../lib/alchemy/router-custom-collision";
 import {
   createExploreConsumerSource,
   exploreLaunchSourceHeader,
   exploreReadSourceHeader,
-  exploreRpcProviderHeader,
   type ExploreConsumerSource,
 } from "../../../lib/explore-consumer.server";
 import { canonicalTokenExploreEntryV1 } from "../../../lib/explore-entry-v1";
@@ -24,14 +16,19 @@ import {
   buildExploreDataQuality,
   publicExploreEntryV1,
   valuationSortValue,
-  withExploreValuation,
+  withBitqueryMarketData,
   type ValuedExploreEntry,
 } from "../../../lib/explore-financial-data";
+import { readBitqueryTokenMarketDataV1 } from
+  "../../../lib/market-data/bitquery.server";
+import { exploreEntriesMarketIdentitiesV1 } from
+  "../../../lib/market-data/explore-market-identities";
+import type { TokenMarketDataV1 } from
+  "../../../lib/market-data/market-data-v1";
 import { readExploreReferenceHeadWithinRouteBudget } from "../../../lib/explore-reference-head.server";
 import { getOnchainDeployment } from "../../../lib/onchain/config";
 import { readDurableExploreModel } from "../../../lib/onchain/durable-model";
 import {
-  filterAndSortTokens,
   parseExploreSort,
   visibleExploreTokens,
 } from "../../../lib/onchain/query";
@@ -41,10 +38,8 @@ import type {
 } from "../../../lib/onchain/types";
 import { readProductionCustomExploreDirectoryV1 } from "../../../lib/server/custom-launch/explore-directory-v1";
 import type {
-  CanonicalTokenExploreEntry,
   CustomProjectExploreEntry,
   ExploreEntry,
-  LauncherToken,
 } from "../../../lib/tokens";
 
 export const dynamic = "force-dynamic";
@@ -58,7 +53,6 @@ const EXPLORE_QUERY_PARAMETERS = new Set([
   "sort",
 ]);
 const TOP_VALUATION_LIMIT = 20;
-const NEWEST_LIVE_MARKET_LIMIT = 20;
 const readCanonicalExploreSource = createExploreConsumerSource<ExploreReadModel>({});
 const readCustomExploreSource = createExploreConsumerSource<
   readonly CustomProjectExploreEntry[]
@@ -112,18 +106,6 @@ async function settleExploreSource<T>(
   } catch (error) {
     return { source: null, error };
   }
-}
-
-function mergeTokenUpdates(
-  tokens: readonly LauncherToken[],
-  updates: readonly LauncherToken[],
-) {
-  const byAddress = new Map(
-    updates.map((token) => [token.tokenAddress.toLowerCase(), token]),
-  );
-  return tokens.map(
-    (token) => byAddress.get(token.tokenAddress.toLowerCase()) ?? token,
-  );
 }
 
 function hasCanonicalQueryShape(search: URLSearchParams) {
@@ -313,6 +295,38 @@ export function dedupeExploreEntriesV1(
   return output;
 }
 
+function valueExploreEntriesWithMarketData(
+  entries: readonly ExploreEntry[],
+  marketByToken: ReadonlyMap<string, TokenMarketDataV1>,
+): ValuedExploreEntry[] {
+  return entries.map((entry) => {
+    const address = entry.tokenAddress?.toLowerCase();
+    const marketData = address ? marketByToken.get(address) : undefined;
+    if (marketData) return withBitqueryMarketData(entry, marketData);
+    return {
+      ...entry,
+      valuation: {
+        status: "unavailable" as const,
+        reason:
+          entry.exploreKind === "custom-project" && entry.markets.length === 0
+            ? "no-market" as const
+            : "source-unavailable" as const,
+      },
+    };
+  });
+}
+
+function hasVerifiedBitqueryPrice(entries: readonly ValuedExploreEntry[]): boolean {
+  return entries.some((entry) => {
+    const primary = entry.marketData?.pools.find(
+      (pool) => pool.identity.poolId === entry.marketData?.primaryPoolId,
+    );
+    return primary?.status === "current" &&
+      (primary.latestTrade?.priceUsdWad !== undefined ||
+        primary.latestTrade?.priceQuoteWad !== undefined);
+  });
+}
+
 function paginateEntries(
   ordered: readonly ExploreEntry[],
   input: Readonly<{ page: number; pageSize: number }>,
@@ -383,12 +397,6 @@ export async function GET(request: NextRequest) {
       pageSize: integerQuery(search.get("limit"), 9),
       socials,
     } as const;
-    let deployment: ReturnType<typeof getAlchemyOnchainDeployment> | null = null;
-    try {
-      deployment = getAlchemyOnchainDeployment();
-    } catch {
-      // Provider readiness is independent from canonical launch identity.
-    }
     const canonicalRead = settleExploreSource(
       readCanonicalExploreSource({
         primary: readPrimaryExploreModel,
@@ -400,19 +408,14 @@ export async function GET(request: NextRequest) {
         primary: () => readProductionCustomExploreDirectoryV1(request.signal),
       }),
     );
-    const operationalSnapshotRead = deployment?.status === "ready"
-      ? readVerifiedOperationalMarketSnapshot(deployment)
-      : Promise.resolve(null);
     const [
       canonicalAttempt,
       customAttempt,
       referenceHead,
-      operationalSnapshot,
     ] = await Promise.all([
       canonicalRead,
       customRead,
       readExploreReferenceHeadWithinRouteBudget(),
-      operationalSnapshotRead,
     ]);
     if (canonicalAttempt.source === null && customAttempt.source === null) {
       throw canonicalAttempt.error ?? customAttempt.error;
@@ -420,114 +423,35 @@ export async function GET(request: NextRequest) {
 
     const canonicalSource = canonicalAttempt.source;
     const customSource = customAttempt.source;
-    let pricedModel = canonicalSource?.value ?? null;
-
-    let liveSnapshot = operationalSnapshot;
-    if (deployment?.status === "ready" && liveSnapshot) {
-      try {
-        liveSnapshot = await withSameBlockEthUsdQuote({
-          deployment,
-          snapshot: liveSnapshot,
-        });
-      } catch {
-        // USD conversion is fail-closed. Current StateView values can still be
-        // exposed in ETH, but an older durable quote is never carried forward.
-        liveSnapshot = withoutUnboundEthUsdQuote(liveSnapshot);
-      }
-    }
-    let livePoolStateApplied = false;
-    if (deployment?.status === "ready" && liveSnapshot && pricedModel) {
-      const visible = visibleExploreTokens(pricedModel);
-      const top = filterAndSortTokens(
-        [...visible],
-        "",
-        "market-cap",
-      ).slice(0, TOP_VALUATION_LIMIT);
-      const newest = filterAndSortTokens(
-        [...visible],
-        "",
-        "newest",
-      ).slice(0, NEWEST_LIVE_MARKET_LIMIT);
-      const warmCandidates =
-        options.sort === "market-cap" || options.sort === "market-cap-asc"
-          ? visible
-          : [...top, ...newest];
-      const warm = [...new Map(
-        warmCandidates.map((token) => [
-          token.tokenAddress.toLowerCase(),
-          token,
-        ]),
-      ).values()];
-      try {
-        const updates = await enrichTokensWithAlchemyPoolState({
-          deployment,
-          snapshot: liveSnapshot,
-          tokens: warm,
-        });
-        const previousByAddress = new Map(pricedModel.tokens.map((token) => [
-          token.tokenAddress.toLowerCase(),
-          token,
-        ]));
-        livePoolStateApplied = updates.some((token) => {
-          const previous = previousByAddress.get(
-            token.tokenAddress.toLowerCase(),
-          );
-          return token.indexedValuationBlockNumber ===
-              liveSnapshot?.blockNumber &&
-            (
-              previous?.indexedValuationBlockNumber !==
-                token.indexedValuationBlockNumber ||
-              previous?.marketCapEthWei !== token.marketCapEthWei ||
-              previous?.fdvUsdWad !== token.fdvUsdWad
-            );
-        });
-        pricedModel = {
-          ...pricedModel,
-          tokens: mergeTokenUpdates(pricedModel.tokens, updates),
-        };
-      } catch {
-        // Keep the canonical model and mark its valuations below as partial.
-      }
-    }
-
-    const modelTokens = pricedModel?.tokens ?? [];
+    const identityModel = canonicalSource?.value ?? null;
+    const modelTokens = identityModel?.tokens ?? [];
     const customProjects = suppressRouterBoundCustomProjectDuplicates(
       modelTokens,
       customSource?.value ?? [],
     );
     const identityAsOfBlock =
-      pricedModel?.status === "ready"
-        ? (pricedModel.launchDiscoverySnapshot ?? pricedModel.snapshot).blockNumber
+      identityModel?.status === "ready"
+        ? (identityModel.launchDiscoverySnapshot ?? identityModel.snapshot).blockNumber
         : null;
     const referenceBlock = greatestBlockNumber(
       identityAsOfBlock,
       referenceHead?.blockNumber,
-      operationalSnapshot?.blockNumber,
     );
-    const valuationContext = {
-      referenceBlock,
-      forceStale:
-        canonicalSource?.status === "last-known-good" ||
-        operationalSnapshot === null,
-    } as const;
-    const classicEntries = pricedModel
-      ? visibleExploreTokens(pricedModel)
-          .map(canonicalTokenExploreEntryV1)
-          .map((entry) => withExploreValuation(entry, valuationContext))
-      : [];
-    const valuedCustomProjects = customProjects.map((entry) =>
-      withExploreValuation(entry, valuationContext)
+    const identityEntries = dedupeExploreEntriesV1([
+      ...(identityModel
+        ? visibleExploreTokens(identityModel).map(canonicalTokenExploreEntryV1)
+        : []),
+      ...customProjects,
+    ]);
+    const marketByToken = await readBitqueryTokenMarketDataV1(
+      exploreEntriesMarketIdentitiesV1(identityEntries),
+      { signal: request.signal },
     );
-    const entries = dedupeExploreEntriesV1([
-      ...classicEntries,
-      ...valuedCustomProjects,
-    ]) as ValuedExploreEntry[];
+    const entries = valueExploreEntriesWithMarketData(
+      identityEntries,
+      marketByToken,
+    );
     assertNoExploreCategoryCollision(entries);
-    const livePriceSource = livePoolStateApplied
-      ? liveSnapshot?.ethUsdQuote
-        ? "state-view+chainlink"
-        : "state-view"
-      : "read-model";
     const useTopValuationView =
       options.sort === "market-cap" &&
       options.query.length === 0 &&
@@ -536,34 +460,7 @@ export async function GET(request: NextRequest) {
       ...options,
       topThenNewest: useTopValuationView,
     });
-    let pageEntries = paginated.tokens as ValuedExploreEntry[];
-    const pageClassic = pageEntries.filter(
-      (
-        entry,
-      ): entry is ValuedExploreEntry<CanonicalTokenExploreEntry> =>
-        entry.exploreKind === "token",
-    );
-    if (deployment?.status === "ready" && liveSnapshot && pageClassic.length) {
-      try {
-        const updates = await enrichTokensWithAlchemyPoolState({
-          deployment,
-          snapshot: liveSnapshot,
-          tokens: pageClassic,
-        });
-        const updatedByAddress = new Map(updates.map((token) => [
-          token.tokenAddress.toLowerCase(),
-          withExploreValuation(
-            canonicalTokenExploreEntryV1(token),
-            valuationContext,
-          ),
-        ]));
-        pageEntries = pageEntries.map((entry) => entry.exploreKind === "token"
-          ? updatedByAddress.get(entry.tokenAddress.toLowerCase()) ?? entry
-          : entry);
-      } catch {
-        // Page-level refresh is best effort; last-known values remain visible.
-      }
-    }
+    const pageEntries = paginated.tokens as ValuedExploreEntry[];
 
     const sourceAges = [canonicalSource?.ageMs, customSource?.ageMs].filter(
       (value): value is number => value !== undefined,
@@ -587,8 +484,6 @@ export async function GET(request: NextRequest) {
         custom: customSource,
       }),
     };
-    const rpcProvider = exploreRpcProviderHeader(deployment);
-
     if (canonicalSource === null && entries.length === 0) {
       return NextResponse.json(
         {
@@ -603,7 +498,7 @@ export async function GET(request: NextRequest) {
             "Cache-Control": "no-store",
             "Retry-After": "5",
             "X-Programmable-Data-Quality": dataQuality.status,
-            "X-Programmable-Valuation-Metric": "fdv",
+            "X-Programmable-Market-Source": "bitquery",
             ...sourceHeaders,
           },
         },
@@ -611,24 +506,24 @@ export async function GET(request: NextRequest) {
     }
 
     const page = {
-      status: pricedModel?.status === "ready" || entries.length > 0
+      status: identityModel?.status === "ready" || entries.length > 0
         ? "ready" as const
-        : pricedModel?.status ?? "not-deployed" as const,
+        : identityModel?.status ?? "not-deployed" as const,
       ...paginated,
       tokens: pageEntries.map(publicExploreEntryV1),
       sort: options.sort,
       query: options.query,
       sortMetric: "fdv" as const,
       dataQuality,
-      snapshot: pricedModel?.snapshot ?? null,
+      snapshot: identityModel?.snapshot ?? null,
       launchDiscoverySnapshot:
-        pricedModel?.status === "ready"
-          ? pricedModel.launchDiscoverySnapshot
+        identityModel?.status === "ready"
+          ? identityModel.launchDiscoverySnapshot
           : undefined,
-      ...(pricedModel
+      ...(identityModel
         ? {
-            launcherFeesAccruedWei: pricedModel.launcherFeesAccruedWei,
-            launcherFeesAccruedEth: pricedModel.launcherFeesAccruedEth,
+            launcherFeesAccruedWei: identityModel.launcherFeesAccruedWei,
+            launcherFeesAccruedEth: identityModel.launcherFeesAccruedEth,
           }
         : {}),
     };
@@ -644,22 +539,17 @@ export async function GET(request: NextRequest) {
               ? "public, max-age=0, s-maxage=2, stale-while-revalidate=5"
               : "public, max-age=0, s-maxage=30",
           "X-Programmable-Data-Quality": dataQuality.status,
-          "X-Programmable-Valuation-Metric": "fdv",
-          ...(dataQuality.valuation.asOfBlock
+          "X-Programmable-Market-Source": "bitquery",
+          ...(dataQuality.valuation.asOfTime
             ? {
-                "X-Programmable-Valuation-Block":
-                  dataQuality.valuation.asOfBlock,
+                "X-Programmable-Market-As-Of":
+                  dataQuality.valuation.asOfTime,
               }
             : {}),
-          ...(pricedModel
-            ? {
-                "X-Programmable-Price-Source": livePriceSource,
-              }
+          ...(hasVerifiedBitqueryPrice(entries)
+            ? { "X-Programmable-Price-Source": "bitquery" }
             : {}),
           ...sourceHeaders,
-          ...(rpcProvider === null
-            ? {}
-            : { "X-Programmable-Rpc-Provider": rpcProvider }),
         },
       },
     );

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -2,112 +2,80 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
 import {
-  getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../../../lib/alchemy/explore.server";
+import { suppressRouterBoundCustomProjectDuplicates } from
+  "../../../../../lib/alchemy/router-custom-collision";
 import {
-  enrichTokensWithAlchemyPoolState,
-  readVerifiedOperationalMarketSnapshot,
-  withSameBlockEthUsdQuote,
-  withoutUnboundEthUsdQuote,
-} from "../../../../../lib/alchemy/live-market.server";
+  createExploreConsumerSource,
+  type ExploreConsumerSource,
+} from "../../../../../lib/explore-consumer.server";
+import { canonicalTokenExploreEntryV1 } from
+  "../../../../../lib/explore-entry-v1";
+import { withBitqueryMarketData } from
+  "../../../../../lib/explore-financial-data";
 import {
-  assertTokenChartSupported,
-  isTokenChartRange,
-  readTokenChartSeries,
-  TokenChartIntegrityError,
-  TokenChartUnavailableError,
-  type TokenChartFreshness,
-} from "../../../../../lib/onchain/chart";
-import { getWebsiteChartOnchainDeployment } from "../../../../../lib/onchain/config";
-import { readDurableExploreModel } from "../../../../../lib/onchain/durable-model";
+  readBitqueryMarketChartV1,
+  readBitqueryTokenMarketDataV1,
+} from "../../../../../lib/market-data/bitquery.server";
+import { exploreEntryMarketIdentitiesV1 } from
+  "../../../../../lib/market-data/explore-market-identities";
+import type { MarketChartV1 } from
+  "../../../../../lib/market-data/market-data-v1";
+import { PROGRAMMABLE_MARKET_CHART_ERROR_SCHEMA_VERSION } from
+  "../../../../../lib/market-data/market-data-v1";
+import { getOnchainDeployment } from "../../../../../lib/onchain/config";
+import { readDurableExploreModel } from
+  "../../../../../lib/onchain/durable-model";
+import { isTokenChartRange } from "../../../../../lib/onchain/chart";
+import type { ExploreReadModel } from "../../../../../lib/onchain/types";
+import { readProductionCustomExploreDirectoryV1 } from
+  "../../../../../lib/server/custom-launch/explore-directory-v1";
 import type {
-  ExploreReadModel,
-  ReadyOnchainDeployment,
-} from "../../../../../lib/onchain/types";
-import type { LauncherToken } from "../../../../../lib/tokens";
+  CustomProjectExploreEntry,
+  ExploreEntry,
+} from "../../../../../lib/tokens";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const TOKEN_CHART_DATA_QUALITY_SCHEMA_VERSION =
-  "programmable.explore-chart-data-quality.v1" as const;
+const readCanonicalChartSource = createExploreConsumerSource<ExploreReadModel>({});
+const readCustomChartSource = createExploreConsumerSource<
+  readonly CustomProjectExploreEntry[]
+>({});
 
-function chartDataQualityStatus(freshness: TokenChartFreshness) {
-  return freshness.history.status === "current" &&
-    freshness.price.status === "current" &&
-    freshness.valuation.status === "current"
-    ? "current" as const
-    : "partial" as const;
-}
-
-function unavailableDataQuality(
-  reason:
-    | "integrity"
-    | "source-unavailable"
-    | "unsupported-pool-orientation",
-) {
-  return {
-    schemaVersion: TOKEN_CHART_DATA_QUALITY_SCHEMA_VERSION,
-    status: "unavailable" as const,
-    reason,
-  };
-}
-
-type ReadyExploreModel = Extract<ExploreReadModel, { status: "ready" }>;
-
-async function readChartIdentityModel(
-  deployment: ReadyOnchainDeployment,
-): Promise<Readonly<{
-  model: ReadyExploreModel;
-  readSource: "rpc" | "durable+rpc";
-}>> {
-  let primaryError: unknown;
-  try {
-    const model = await readAlchemyExploreModel();
-    if (
-      model.status === "ready" &&
-      model.snapshot.chainId === deployment.chainId
-    ) {
-      return { model, readSource: "rpc" };
-    }
-    primaryError = new Error("Live chart identity is unavailable");
-  } catch (error) {
-    primaryError = error;
+async function readPrimaryChartModel() {
+  const model = await readAlchemyExploreModel();
+  if (model.status !== "ready") {
+    throw new Error("Primary Explore model is unavailable");
   }
+  return model;
+}
 
+async function readDurableChartFallback() {
+  const deployment = getOnchainDeployment("production");
+  if (deployment.status !== "ready") {
+    throw new Error("Production Explore deployment is not ready");
+  }
+  const read = await readDurableExploreModel(
+    deployment,
+    Number.MAX_SAFE_INTEGER,
+  );
+  if (read.status !== "ready") {
+    throw new Error(`Durable Explore fallback is ${read.reason}`);
+  }
+  return { value: read.envelope.payload.model, ageMs: read.ageMs };
+}
+
+async function settleSource<T>(
+  read: Promise<ExploreConsumerSource<T>>,
+): Promise<ExploreConsumerSource<T> | null> {
   try {
-    const durable = await readDurableExploreModel(
-      deployment,
-      Number.MAX_SAFE_INTEGER,
-    );
-    if (durable.status === "ready") {
-      const model = durable.envelope.payload.model;
-      if (
-        model.status === "ready" &&
-        model.snapshot.chainId === deployment.chainId
-      ) {
-        return { model, readSource: "durable+rpc" };
-      }
-    }
+    return await read;
   } catch {
-    // The original live-read failure is the useful sanitized telemetry cause.
+    return null;
   }
-
-  throw primaryError ?? new Error("Chart identity is unavailable");
-}
-
-function chartIdentityToken(
-  token: LauncherToken,
-  readSource: "rpc" | "durable+rpc",
-): LauncherToken {
-  if (readSource === "rpc") return token;
-  const identityOnly = { ...token };
-  // An old aggregate is not current chart history. Reconstruct volume from
-  // exact logs when the canonical identity came from the durable snapshot.
-  delete identityOnly.grossVolumeWei;
-  return identityOnly;
 }
 
 export async function GET(request: NextRequest) {
@@ -125,15 +93,14 @@ export async function GET(request: NextRequest) {
     );
   }
   const input = search.get("address")?.trim();
-  const requestedRange =
-    search.get("range")?.trim().toLowerCase() ?? "all";
+  const range = search.get("range")?.trim().toLowerCase() ?? "all";
   if (!input || !isAddress(input)) {
     return NextResponse.json(
       { error: "Enter a valid Ethereum token address" },
       { status: 400, headers: { "Cache-Control": "no-store" } },
     );
   }
-  if (!isTokenChartRange(requestedRange)) {
+  if (!isTokenChartRange(range)) {
     return NextResponse.json(
       { error: "Choose a supported chart range" },
       { status: 400, headers: { "Cache-Control": "no-store" } },
@@ -142,196 +109,168 @@ export async function GET(request: NextRequest) {
 
   try {
     const address = getAddress(input);
-    const deployment = getAlchemyOnchainDeployment();
-    const chartDeployment = getWebsiteChartOnchainDeployment("production");
-    if (
-      deployment.status !== "ready" ||
-      chartDeployment.status !== "ready" ||
-      chartDeployment.chainId !== deployment.chainId
-    ) {
-      return NextResponse.json(
-        {
-          status: "unavailable",
-          address,
-          error: "Onchain chart data is temporarily unavailable",
-          dataQuality: unavailableDataQuality("source-unavailable"),
-        },
-        {
-          status: 503,
-          headers: {
-            "Cache-Control": "no-store",
-            "Retry-After": "5",
-            "X-Programmable-Data-Quality": "unavailable",
-            "X-Programmable-Read-Source": "rpc",
-          },
-        },
-      );
-    }
-    const [identityRead, operationalSnapshot] = await Promise.all([
-      readChartIdentityModel(deployment),
-      readVerifiedOperationalMarketSnapshot(deployment),
+    const [canonicalSource, customSource] = await Promise.all([
+      settleSource(readCanonicalChartSource({
+        primary: readPrimaryChartModel,
+        fallback: readDurableChartFallback,
+      })),
+      settleSource(readCustomChartSource({
+        primary: () => readProductionCustomExploreDirectoryV1(request.signal),
+      })),
     ]);
-    const { model, readSource } = identityRead;
-
-    const token = model.tokens.find(
-      (candidate) =>
-        candidate.tokenAddress.toLowerCase() === address.toLowerCase(),
+    if (canonicalSource === null && customSource === null) {
+      return unavailable(
+        address,
+        range,
+        "identity-unavailable",
+        "Token identity is temporarily unavailable",
+      );
+    }
+    const model = canonicalSource?.value ?? null;
+    const token = model?.tokens.find(
+      (candidate) => candidate.tokenAddress.toLowerCase() === address.toLowerCase(),
     );
-    if (!token && readSource === "durable+rpc") {
-      return NextResponse.json(
-        {
-          status: "unavailable",
-          address,
-          error: "Token identity is temporarily unavailable",
-          dataQuality: unavailableDataQuality("source-unavailable"),
-        },
-        {
-          status: 503,
-          headers: {
-            "Cache-Control": "no-store",
-            "Retry-After": "5",
-            "X-Programmable-Data-Quality": "unavailable",
-            "X-Programmable-Read-Source": readSource,
-          },
-        },
+    const customProjects = suppressRouterBoundCustomProjectDuplicates(
+      model?.tokens ?? [],
+      customSource?.value ?? [],
+    );
+    const customProject = customProjects.find(
+      (candidate) => candidate.tokenAddress?.toLowerCase() === address.toLowerCase(),
+    );
+    if (token && customProject) {
+      throw new Error("Canonical token chart sources disagree on launch category");
+    }
+    const entry: ExploreEntry | null = token
+      ? canonicalTokenExploreEntryV1(token)
+      : customProject ?? null;
+    if (!entry) {
+      if (
+        canonicalSource?.status === "current" &&
+        customSource?.status === "current"
+      ) {
+        return NextResponse.json(
+          { error: "Token not found" },
+          { status: 404, headers: { "Cache-Control": "no-store" } },
+        );
+      }
+      return unavailable(
+        address,
+        range,
+        "identity-unavailable",
+        "Token identity is temporarily unavailable",
       );
     }
-    if (!token) {
-      return NextResponse.json(
-        {
-          error: "Token not found",
-          snapshotBlock: model.snapshot.blockNumber,
-          snapshotHash: model.snapshot.blockHash,
-        },
-        {
-          status: 404,
-          headers: {
-            "Cache-Control": "no-store",
-            "X-Programmable-Read-Source": readSource,
-          },
-        },
+    const identities = exploreEntryMarketIdentitiesV1(entry);
+    if (identities.length === 0) {
+      return unavailable(
+        address,
+        range,
+        "market-data-unavailable",
+        "Price history is unavailable for this market",
       );
     }
-
-    const tokenForChart = chartIdentityToken(token, readSource);
-    assertTokenChartSupported(tokenForChart);
-
-    // A lagging launch-discovery snapshot is useful for canonical identity,
-    // but it is never market-currentness authority. Returning unavailable here
-    // lets the client preserve its last verified chart instead of appending a
-    // stale model point as though it were the current price.
-    if (operationalSnapshot === null) {
-      return NextResponse.json(
-        {
-          status: "unavailable",
-          address,
-          error: "Onchain chart data is temporarily unavailable",
-          dataQuality: unavailableDataQuality("source-unavailable"),
-        },
-        {
-          status: 503,
-          headers: {
-            "Cache-Control": "no-store",
-            "Retry-After": "5",
-            "X-Programmable-Data-Quality": "unavailable",
-            "X-Programmable-Read-Source": readSource,
-          },
-        },
-      );
-    }
-
-    let liveSnapshot = operationalSnapshot;
-    try {
-      liveSnapshot = await withSameBlockEthUsdQuote({
-        deployment,
-        snapshot: liveSnapshot,
-      });
-    } catch {
-      liveSnapshot = withoutUnboundEthUsdQuote(liveSnapshot);
-    }
-    const liveToken = (
-      await enrichTokensWithAlchemyPoolState({
-        deployment,
-        snapshot: liveSnapshot,
-        tokens: [tokenForChart],
-      })
-    )[0] ?? tokenForChart;
-    const series = await readTokenChartSeries({
-      deployment: chartDeployment,
-      token: liveToken,
-      snapshotBlock: BigInt(liveSnapshot.blockNumber),
-      ethUsdQuote: liveSnapshot.ethUsdQuote,
-      range: requestedRange,
+    const marketByToken = await readBitqueryTokenMarketDataV1(identities, {
+      signal: request.signal,
     });
-    const { freshness, ...publicSeries } = series;
-    const qualityStatus = series.status === "partial"
-      ? "partial" as const
-      : chartDataQualityStatus(freshness);
+    const marketDataRead = marketByToken.get(address.toLowerCase());
+    const marketData = marketDataRead
+      ? withBitqueryMarketData(entry, marketDataRead).marketData
+      : undefined;
+    const identity = identities.find(
+      (candidate) => candidate.poolId === marketData?.primaryPoolId,
+    ) ?? identities[0];
+    const primaryMarket = marketData?.pools.find(
+      (candidate) => candidate.identity.poolId === identity.poolId,
+    );
+    const chart = await readBitqueryMarketChartV1({
+      identity,
+      range,
+      ...(primaryMarket ? { valuation: primaryMarket.valuation } : {}),
+      signal: request.signal,
+    });
+    if (chart.status === "unavailable") {
+      return unavailable(
+        address,
+        range,
+        "market-data-unavailable",
+        "Price history is temporarily unavailable",
+        chart,
+      );
+    }
+
+    const fdvUsdWad = chart.valuation.status === "available"
+      ? chart.valuation.fdvUsdWad
+      : undefined;
+    const hasVerifiedPrice = chart.points.some(
+      (point) => point.priceUsd !== undefined || point.priceQuote !== undefined,
+    );
     return NextResponse.json(
       {
-        ...publicSeries,
+        ...chart,
         address,
-        range: requestedRange,
-        valuationMetric: "fdv",
-        dataQuality: {
-          schemaVersion: TOKEN_CHART_DATA_QUALITY_SCHEMA_VERSION,
-          status: qualityStatus,
-          asOfBlock: liveSnapshot.blockNumber,
-          blockHash: liveSnapshot.blockHash,
-          finality:
-            liveSnapshot.confirmations > 0 ? "confirmed" : "latest",
-          history: freshness.history,
-          price: freshness.price,
-          valuation: freshness.valuation,
-        },
-        snapshotBlock: liveSnapshot.blockNumber,
-        snapshotHash: liveSnapshot.blockHash,
+        ...(fdvUsdWad ? { fdvUsdWad } : {}),
+        valuationMetric: chart.valuation.status === "available"
+          ? chart.valuation.metric
+          : null,
       },
       {
         headers: {
           "Cache-Control":
-            qualityStatus === "current"
-              ? "public, max-age=0, s-maxage=2, stale-while-revalidate=2"
+            chart.status === "ready" &&
+                chart.valuation.status === "available" &&
+                chart.valuation.freshness === "current"
+              ? "public, max-age=0, s-maxage=2, stale-while-revalidate=5"
               : "no-store",
-          "X-Programmable-Data-Quality": qualityStatus,
-          "X-Programmable-Valuation-Metric": "fdv",
-          "X-Programmable-Read-Source": readSource,
+          "X-Programmable-Data-Quality": chart.status,
+          "X-Programmable-Market-Source": "bitquery",
+          ...(hasVerifiedPrice
+            ? { "X-Programmable-Price-Source": "bitquery" }
+            : {}),
+          ...(chart.asOfTime
+            ? { "X-Programmable-Market-As-Of": chart.asOfTime }
+            : {}),
         },
       },
     );
   } catch (error) {
-    const integrityFailure = error instanceof TokenChartIntegrityError;
-    const unsupportedPool = error instanceof TokenChartUnavailableError;
-    if (!unsupportedPool) {
-      console.error(
-        "Token chart read failed",
-        safeAlchemyError(error),
-      );
-    }
-    return NextResponse.json(
-      {
-        status: "unavailable",
-        error: unsupportedPool
-          ? "Price history is unavailable for this pool"
-          : "Onchain chart data is temporarily unavailable",
-        dataQuality: unavailableDataQuality(
-          integrityFailure
-            ? "integrity"
-            : unsupportedPool
-              ? error.reason
-              : "source-unavailable",
-        ),
-      },
-      {
-        status: 503,
-        headers: {
-          "Cache-Control": "no-store",
-          ...(integrityFailure || unsupportedPool
-            ? {}
-            : { "Retry-After": "5" }),
-          "X-Programmable-Data-Quality": "unavailable",
-        },
-      },
+    console.error("Token chart read failed", safeAlchemyError(error));
+    return unavailable(
+      getAddress(input),
+      range,
+      "market-data-unavailable",
+      "Price history is temporarily unavailable",
     );
   }
+}
+
+function unavailable(
+  address: `0x${string}`,
+  range: MarketChartV1["range"],
+  reason: "identity-unavailable" | "market-data-unavailable",
+  error: string,
+  chart?: MarketChartV1,
+) {
+  return NextResponse.json(
+    chart
+      ? { ...chart, address, error }
+      : {
+          schemaVersion: PROGRAMMABLE_MARKET_CHART_ERROR_SCHEMA_VERSION,
+          source: "bitquery",
+          status: "unavailable",
+          generatedAt: new Date().toISOString(),
+          address,
+          range,
+          reason,
+          error,
+        },
+    {
+      status: 503,
+      headers: {
+        "Cache-Control": "no-store",
+        "Retry-After": "5",
+        "X-Programmable-Data-Quality": "unavailable",
+        "X-Programmable-Market-Source": "bitquery",
+      },
+    },
+  );
 }

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -2,31 +2,29 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
 import {
-  getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../../lib/alchemy/explore.server";
-import {
-  enrichTokensWithAlchemyPoolState,
-  readVerifiedOperationalMarketSnapshot,
-  withSameBlockEthUsdQuote,
-  withoutUnboundEthUsdQuote,
-} from "../../../../lib/alchemy/live-market.server";
 import { suppressRouterBoundCustomProjectDuplicates } from "../../../../lib/alchemy/router-custom-collision";
 import {
   createExploreConsumerSource,
   exploreLaunchSourceHeader,
   exploreReadSourceHeader,
-  exploreRpcProviderHeader,
   type ExploreConsumerSource,
 } from "../../../../lib/explore-consumer.server";
 import { canonicalTokenExploreEntryV1 } from "../../../../lib/explore-entry-v1";
 import {
   buildExploreDataQuality,
   publicExploreEntryV1,
-  withExploreValuation,
+  withBitqueryMarketData,
   type ValuedExploreEntry,
 } from "../../../../lib/explore-financial-data";
+import { readBitqueryTokenMarketDataV1 } from
+  "../../../../lib/market-data/bitquery.server";
+import { exploreEntryMarketIdentitiesV1 } from
+  "../../../../lib/market-data/explore-market-identities";
+import type { TokenMarketDataV1 } from
+  "../../../../lib/market-data/market-data-v1";
 import { readExploreReferenceHeadWithinRouteBudget } from "../../../../lib/explore-reference-head.server";
 import { getOnchainDeployment } from "../../../../lib/onchain/config";
 import { readDurableExploreModel } from "../../../../lib/onchain/durable-model";
@@ -110,20 +108,10 @@ export async function GET(request: NextRequest) {
 
   try {
     const address = getAddress(input);
-    let deployment: ReturnType<typeof getAlchemyOnchainDeployment> | null = null;
-    try {
-      deployment = getAlchemyOnchainDeployment();
-    } catch {
-      // Provider readiness is independent from canonical launch identity.
-    }
-    const operationalSnapshotRead = deployment?.status === "ready"
-      ? readVerifiedOperationalMarketSnapshot(deployment)
-      : Promise.resolve(null);
     const [
       canonicalAttempt,
       customAttempt,
       referenceHead,
-      operationalSnapshot,
     ] = await Promise.all([
       settleTokenSource(readCanonicalTokenSource({
         primary: readPrimaryTokenModel,
@@ -133,7 +121,6 @@ export async function GET(request: NextRequest) {
         primary: () => readProductionCustomExploreDirectoryV1(request.signal),
       })),
       readExploreReferenceHeadWithinRouteBudget(),
-      operationalSnapshotRead,
     ]);
     if (canonicalAttempt.source === null && customAttempt.source === null) {
       throw canonicalAttempt.error ?? customAttempt.error;
@@ -203,53 +190,51 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    let liveSnapshot = operationalSnapshot;
-    if (liveSnapshot && deployment?.status === "ready") {
-      try {
-        liveSnapshot = await withSameBlockEthUsdQuote({
-          deployment,
-          snapshot: liveSnapshot,
-        });
-      } catch {
-        liveSnapshot = withoutUnboundEthUsdQuote(liveSnapshot);
-      }
-    }
-    let enriched = token;
-    if (token && liveSnapshot && deployment?.status === "ready") {
-      try {
-        enriched = (
-          await enrichTokensWithAlchemyPoolState({
-            deployment,
-            snapshot: liveSnapshot,
-            tokens: [token],
-          })
-        )[0] ?? token;
-      } catch {
-        // Preserve the identity and older valuation with explicit freshness.
-      }
-    }
     const identityAsOfBlock = model?.status === "ready"
       ? (model.launchDiscoverySnapshot ?? model.snapshot).blockNumber
       : null;
     const referenceBlock = greatestBlockNumber(
       identityAsOfBlock,
       referenceHead?.blockNumber,
-      operationalSnapshot?.blockNumber,
     );
-    const valuationContext = {
-      referenceBlock,
-      forceStale:
-        canonicalSource?.status === "last-known-good" ||
-        operationalSnapshot === null,
-    } as const;
-    const valuedToken = enriched
-      ? withExploreValuation(
-          canonicalTokenExploreEntryV1(enriched),
-          valuationContext,
+    const identityEntry = token
+      ? canonicalTokenExploreEntryV1(token)
+      : customProject ?? null;
+    const marketByToken = identityEntry
+      ? await readBitqueryTokenMarketDataV1(
+          exploreEntryMarketIdentitiesV1(identityEntry),
+          { signal: request.signal },
         )
+      : new Map<string, TokenMarketDataV1>();
+    const marketData = identityEntry?.tokenAddress
+      ? marketByToken.get(identityEntry.tokenAddress.toLowerCase())
+      : undefined;
+    const primaryMarket = marketData?.pools.find(
+      (pool) => pool.identity.poolId === marketData.primaryPoolId,
+    );
+    const hasVerifiedPrice = primaryMarket?.status === "current" &&
+      (primaryMarket.latestTrade?.priceUsdWad !== undefined ||
+        primaryMarket.latestTrade?.priceQuoteWad !== undefined);
+    const valuedEntry: ValuedExploreEntry | null = identityEntry
+      ? marketData
+        ? withBitqueryMarketData(identityEntry, marketData)
+        : {
+            ...identityEntry,
+            valuation: {
+              status: "unavailable",
+              reason:
+                identityEntry.exploreKind === "custom-project" &&
+                    identityEntry.markets.length === 0
+                  ? "no-market"
+                  : "source-unavailable",
+            },
+          }
       : null;
-    const valuedCustomProject = customProject
-      ? withExploreValuation(customProject, valuationContext)
+    const valuedToken = valuedEntry?.exploreKind === "token"
+      ? valuedEntry
+      : null;
+    const valuedCustomProject = valuedEntry?.exploreKind === "custom-project"
+      ? valuedEntry
       : null;
     const qualityEntries = [valuedToken, valuedCustomProject].filter(
       (entry): entry is ValuedExploreEntry => entry !== null,
@@ -268,21 +253,15 @@ export async function GET(request: NextRequest) {
     const publicValuedToken = valuedToken
       ? publicExploreEntryV1(valuedToken)
       : null;
-    const livePriceSource =
-      valuedToken?.valuation.status === "available" &&
-        valuedToken.valuation.freshness === "current" &&
-        valuedToken.valuation.asOfBlock === liveSnapshot?.blockNumber
-        ? valuedToken.valuation.currency === "usd"
-          ? "state-view+chainlink"
-          : "state-view"
-        : "read-model";
-    const rpcProvider = exploreRpcProviderHeader(deployment);
+    const publicValuedCustomProject = valuedCustomProject
+      ? publicExploreEntryV1(valuedCustomProject)
+      : null;
     const status = "ready" as const;
     return NextResponse.json(
       {
         status,
         token: publicValuedToken,
-        customProject: valuedCustomProject,
+        customProject: publicValuedCustomProject,
         dataQuality,
         snapshot: model?.snapshot ?? null,
         launchDiscoverySnapshot:
@@ -299,16 +278,17 @@ export async function GET(request: NextRequest) {
               ? "public, max-age=0, s-maxage=2, stale-while-revalidate=5"
               : "public, max-age=0, s-maxage=30",
           "X-Programmable-Data-Quality": dataQuality.status,
-          "X-Programmable-Valuation-Metric": "fdv",
-          ...(valuedToken
+          "X-Programmable-Market-Source": "bitquery",
+          ...(dataQuality.valuation.asOfTime
             ? {
-                "X-Programmable-Price-Source": livePriceSource,
+                "X-Programmable-Market-As-Of":
+                  dataQuality.valuation.asOfTime,
               }
             : {}),
+          ...(hasVerifiedPrice
+            ? { "X-Programmable-Price-Source": "bitquery" }
+            : {}),
           ...sourceHeaders,
-          ...(rpcProvider === null
-            ? {}
-            : { "X-Programmable-Rpc-Provider": rpcProvider }),
         },
       },
     );

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -38,6 +38,10 @@ import {
   type ValuedExploreEntry,
 } from "@/lib/explore-financial-data";
 import {
+  isTokenMarketDataV1,
+  marketDataStatusLabel,
+} from "@/lib/market-data/market-data-v1";
+import {
   canOptimizeTokenImage,
   getTokenCardImageSource,
 } from "@/lib/token-image";
@@ -57,7 +61,13 @@ type TokenCard = {
   imageUrl: string;
   links: readonly TokenLink[];
   valuation?: MarketCapMetric;
-  marketStatus?: "No market" | "Last verified" | "Unavailable";
+  valuationMetric?: "Market cap" | "FDV";
+  marketStatus?:
+    | "No market"
+    | "Waiting for first trade"
+    | "Last verified"
+    | "Limited market data"
+    | "Unavailable";
   usesFallbackImage: boolean;
   tokenAddress?: `0x${string}`;
   launchCategory: "Classic" | "Custom";
@@ -65,7 +75,17 @@ type TokenCard = {
 
 export function exploreMarketStatusLabel(
   entry: ExploreEntry | ValuedExploreEntry,
-): "No market" | "Last verified" | "Unavailable" | undefined {
+):
+  | "No market"
+  | "Waiting for first trade"
+  | "Last verified"
+  | "Limited market data"
+  | "Unavailable"
+  | undefined {
+  const marketData = (entry as Partial<ValuedExploreEntry>).marketData;
+  if (marketData && isTokenMarketDataV1(marketData)) {
+    return marketDataStatusLabel(marketData);
+  }
   if (entry.exploreKind === "custom-project" && entry.markets.length === 0) {
     return "No market";
   }
@@ -572,7 +592,18 @@ function parseExploreEntry(value: unknown): ValuedExploreEntry | null {
       : isRecord(value) && isExploreValuation(value.valuation)
         ? value.valuation
         : null;
-    return valuation === null ? null : { ...entry, valuation };
+    const marketData = isRecord(value) && value.marketData !== undefined
+      ? isTokenMarketDataV1(value.marketData)
+        ? value.marketData
+        : null
+      : undefined;
+    return valuation === null || marketData === null
+      ? null
+      : {
+          ...entry,
+          valuation,
+          ...(marketData === undefined ? {} : { marketData }),
+        };
   };
   if (isRecord(value) && value.exploreKind === "custom-project") {
     const entry = parseCustomExploreEntry(value);
@@ -993,7 +1024,9 @@ export function exploreTokenCardDescription(token: ExploreEntry) {
 export function getTokenCards(
   tokens: Array<ExploreEntry | ValuedExploreEntry>,
 ): TokenCard[] {
-  return tokens.map((token) => ({
+  return tokens.map((token) => {
+    const valuation = valuationForEntry(token);
+    return ({
     id: token.id,
     name: token.name,
     description: exploreTokenCardDescription(token),
@@ -1005,6 +1038,12 @@ export function getTokenCards(
       (left, right) => tokenLinkOrder[left.kind] - tokenLinkOrder[right.kind],
     ),
     valuation: getExploreValuationMetric(token),
+    ...(valuation.status === "available"
+      ? {
+          valuationMetric:
+            valuation.metric === "market-cap" ? "Market cap" as const : "FDV" as const,
+        }
+      : {}),
     marketStatus: exploreMarketStatusLabel(token),
     usesFallbackImage: !token.imageUrl?.trim(),
     ...(token.tokenAddress === undefined
@@ -1014,7 +1053,8 @@ export function getTokenCards(
       token.launchCategoryProvenance.category === "classic"
         ? "Classic"
         : "Custom",
-  }));
+    });
+  });
 }
 
 function getTokenLinkLabel(kind: TokenLink["kind"]) {
@@ -1517,13 +1557,13 @@ export function ExploreView() {
                 {valuationLabel ? (
                   <span className={styles.runnerMarketCap}>
                     <span className="sr-only">
-                      {"Fully diluted valuation: "}
+                      {`${token.valuationMetric ?? "Valuation"}: `}
                     </span>
                     <span
                       className={styles.runnerMarketCapLabel}
                       aria-hidden="true"
                     >
-                      FDV
+                      {token.valuationMetric ?? "Value"}
                     </span>
                     <span className={styles.runnerMarketCapValue}>
                       {valuationLabel}

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -18,7 +18,6 @@ import {
 } from "viem";
 
 import {
-  calculateEthVolumeUsdValue,
   PreparedTradeReview,
   TokenTrade,
   type PreparedTokenTrade,
@@ -46,6 +45,10 @@ import {
   type ExploreValuation,
 } from "@/lib/explore-financial-data";
 import {
+  isTokenMarketDataV1,
+  type TokenMarketDataV1,
+} from "@/lib/market-data/market-data-v1";
+import {
   canOptimizeTokenImage,
   getTokenCardImageSource,
 } from "@/lib/token-image";
@@ -60,12 +63,20 @@ import {
 import type { PostLaunchAuthorityInventoryV1 } from "@/lib/custom-launch/contract-v2";
 import styles from "./token-experience.module.css";
 
-type DetailToken = LauncherToken & Readonly<{ valuation: ExploreValuation }>;
+type DetailToken = LauncherToken & Readonly<{
+  valuation: ExploreValuation;
+  marketData?: TokenMarketDataV1;
+}>;
+
+type DetailCustomProject = CustomProjectExploreEntry & Readonly<{
+  valuation?: ExploreValuation;
+  marketData?: TokenMarketDataV1;
+}>;
 
 type DetailPayload = {
   status: "ready" | "not-deployed";
   token: DetailToken | null;
-  customProject: CustomProjectExploreEntry | null;
+  customProject: DetailCustomProject | null;
   snapshot: { chainId: number } | null;
 };
 
@@ -82,7 +93,7 @@ type DetailState =
     }
   | {
       phase: "custom-ready";
-      project: CustomProjectExploreEntry;
+      project: DetailCustomProject;
       chainId: number;
       requestKey: string;
     };
@@ -450,10 +461,21 @@ function parseLauncherToken(value: unknown): DetailToken | null {
     : isExploreValuation(value.valuation)
       ? value.valuation
       : null;
-  return valuation === null ? null : { ...token, valuation };
+  const marketData = value.marketData === undefined
+    ? undefined
+    : isTokenMarketDataV1(value.marketData)
+      ? value.marketData
+      : null;
+  return valuation === null || marketData === null
+    ? null
+    : {
+        ...token,
+        valuation,
+        ...(marketData === undefined ? {} : { marketData }),
+      };
 }
 
-function parseCustomProject(value: unknown): CustomProjectExploreEntry | null {
+function parseCustomProject(value: unknown): DetailCustomProject | null {
   if (!isRecord(value)
     || value.exploreKind !== "custom-project"
     || typeof value.id !== "string"
@@ -576,6 +598,17 @@ function parseCustomProject(value: unknown): CustomProjectExploreEntry | null {
         : { tradeCapability: capability as CustomMarket["tradeCapability"] }),
     });
   }
+  const valuation = value.valuation === undefined
+    ? undefined
+    : isExploreValuation(value.valuation)
+      ? value.valuation
+      : null;
+  const marketData = value.marketData === undefined
+    ? undefined
+    : isTokenMarketDataV1(value.marketData)
+      ? value.marketData
+      : null;
+  if (valuation === null || marketData === null) return null;
   return {
     exploreKind: "custom-project",
     id: value.id,
@@ -605,6 +638,8 @@ function parseCustomProject(value: unknown): CustomProjectExploreEntry | null {
       ? { tokenDecimals: value.tokenDecimals }
       : {}),
     launchCategoryProvenance: value.launchCategoryProvenance as CustomProjectExploreEntry["launchCategoryProvenance"],
+    ...(valuation === undefined ? {} : { valuation }),
+    ...(marketData === undefined ? {} : { marketData }),
   };
 }
 
@@ -818,30 +853,29 @@ export function buildChartVolumeMetric(
 }
 
 export function buildTokenDetailMetrics(
-  token: LauncherToken,
+  token: LauncherToken & Readonly<{
+    valuation?: ExploreValuation;
+    marketData?: TokenMarketDataV1;
+  }>,
   fdvOverride?: string | null,
   volumeOverride?: TokenMetric,
 ): TokenMetric[] {
-  const fallbackVolumeUsd = calculateEthVolumeUsdValue({
-    grossVolumeEth: token.grossVolumeEth,
-    tokenPriceEth: token.tokenPriceEth,
-    tokenPriceUsdWad: token.tokenPriceUsdWad,
-  });
-  const officialVolumeUsd = formatUsdWadAmount(
-    token.uniswapV4Pool?.volumeUsdWad,
+  const primaryMarket = token.marketData?.pools.find(
+    (pool) => pool.identity.poolId === token.marketData?.primaryPoolId,
   );
-  const officialLiquidityUsd = formatUsdWadAmount(
-    token.uniswapV4Pool?.tvlUsdWad,
-  );
-  const stockPairedVolume =
-    token.launchModel === "stock-paired"
-      ? formatStockPairedGrossVolume(token)
-      : null;
+  const marketVolumeUsd = formatUsdWadAmount(primaryMarket?.volume24hUsdWad);
+  const marketLiquidityUsd = primaryMarket?.liquidity?.freshness === "current"
+    ? formatUsdWadAmount(primaryMarket.liquidity.valueUsdWad)
+    : null;
   const explicitValuation = (token as { valuation?: unknown }).valuation;
   const valuation = isExploreValuation(explicitValuation)
     ? explicitValuation
     : exploreValuation(token);
-  const safeFdvOverride = fdvOverride?.trim() ? fdvOverride : null;
+  const safeFdvOverride = valuation.status === "available" &&
+      valuation.metric === "fdv" &&
+      fdvOverride?.trim()
+    ? fdvOverride
+    : null;
   const formattedFdv = valuation.status === "available"
     ? safeFdvOverride ?? (
         valuation.currency === "usd"
@@ -856,7 +890,14 @@ export function buildTokenDetailMetrics(
     : null;
   const values: Array<TokenMetric | null> = [
     {
-      label: "FDV",
+      label:
+        valuation.status === "available" && valuation.freshness === "stale"
+          ? valuation.metric === "market-cap"
+            ? "Last verified market cap"
+            : "Last verified FDV"
+          : valuation.status === "available" && valuation.metric === "market-cap"
+            ? "Market cap"
+            : "FDV",
       value: formattedFdv ?? "Unavailable",
     },
     {
@@ -877,29 +918,16 @@ export function buildTokenDetailMetrics(
               : "Initialized",
         }
       : null,
-    volumeOverride ??
-      (officialVolumeUsd !== null ||
-      token.grossVolumeEth ||
-      token.grossVolumeQuote
-        ? {
-            label: "Volume",
-            value:
-              token.launchModel === "stock-paired"
-                ? (stockPairedVolume ?? "")
-                : (officialVolumeUsd ??
-                  formatUsdAmount(fallbackVolumeUsd) ??
-                  formatEth(token.grossVolumeEth, "amount") ??
-                  formatQuoteAmount(
-                    token.grossVolumeQuote,
-                    token.quoteAssetSymbol,
-                  ) ??
-                  ""),
-          }
-        : null),
-    officialLiquidityUsd !== null
+    volumeOverride ?? (marketVolumeUsd !== null
       ? {
-          label: "Liquidity now",
-          value: officialLiquidityUsd,
+          label: "24h volume",
+          value: marketVolumeUsd,
+        }
+      : null),
+    marketLiquidityUsd !== null
+      ? {
+          label: "Liquidity",
+          value: marketLiquidityUsd,
         }
       : null,
     token.buyHookFeeBps !== undefined &&
@@ -1519,16 +1547,14 @@ function TokenDetailContent({
           </div>
 
           <div className={styles.marketChart}>
-            {isRouterStamped ? null : (
-              <TokenPriceChart
-                tokenAddress={token.tokenAddress}
-                tokenName={token.name}
-                launchModel={classicTradeLaunchModel}
-                preview={preview}
-                onVolumeChange={setChartVolume}
-                onFdvChange={setChartFdv}
-              />
-            )}
+            <TokenPriceChart
+              tokenAddress={token.tokenAddress}
+              tokenName={token.name}
+              launchModel={classicTradeLaunchModel}
+              preview={preview}
+              onVolumeChange={setChartVolume}
+              onFdvChange={setChartFdv}
+            />
             <MetricGrid metrics={metrics} />
           </div>
         </section>
@@ -1718,11 +1744,60 @@ function customMarketStatus(project: CustomProjectExploreEntry): string {
     : status.charAt(0).toUpperCase() + status.slice(1);
 }
 
+function customMarketMetrics(project: DetailCustomProject): TokenMetric[] {
+  const primary = project.marketData?.pools.find(
+    (pool) => pool.identity.poolId === project.marketData?.primaryPoolId,
+  );
+  const valuation = project.valuation;
+  const valuationValue = valuation?.status === "available"
+    ? valuation.currency === "usd"
+      ? formatUsd(valuation.valueWad, "amount")
+      : valuation.currency === "eth"
+        ? formatEth(formatUnits(BigInt(valuation.valueWad), 18), "amount")
+        : formatQuoteAmount(
+            formatUnits(BigInt(valuation.valueWad), 18),
+            valuation.quoteSymbol,
+          )
+    : null;
+  const marketStatus = project.marketData?.status === "waiting-for-first-trade"
+    ? "Waiting for first trade"
+    : project.marketData?.status === "stale"
+      ? "Last verified"
+      : project.marketData?.status === "current"
+        ? "Current"
+        : project.marketData?.status === "partial"
+          ? "Limited"
+          : "Unavailable";
+  return [
+    {
+      label:
+        valuation?.status === "available" && valuation.metric === "market-cap"
+          ? "Market cap"
+          : "FDV",
+      value: valuationValue ?? "Unavailable",
+    },
+    { label: "Market data", value: marketStatus },
+    ...(primary?.volume24hUsdWad
+      ? [{
+          label: "24h volume",
+          value: formatUsdWadAmount(primary.volume24hUsdWad) ?? "Unavailable",
+        }]
+      : []),
+    ...(primary?.liquidity?.freshness === "current"
+      ? [{
+          label: "Liquidity",
+          value: formatUsdWadAmount(primary.liquidity.valueUsdWad) ??
+            "Unavailable",
+        }]
+      : []),
+  ];
+}
+
 function CustomProjectDetailContent({
   project,
   chainId,
 }: {
-  project: CustomProjectExploreEntry;
+  project: DetailCustomProject;
   chainId: number;
 }) {
   const {
@@ -1739,6 +1814,7 @@ function CustomProjectDetailContent({
     || getFallbackTokenImage(project.tokenAddress ?? project.customProjectId);
   const imageSource = getTokenCardImageSource(imageUrl);
   const authorities = project.postLaunchAuthorityInventory.postLaunchAuthorities;
+  const metrics = customMarketMetrics(project);
 
   useEffect(() => () => {
     if (copyResetTimer.current !== null) window.clearTimeout(copyResetTimer.current);
@@ -1827,6 +1903,19 @@ function CustomProjectDetailContent({
             ) : null}
           </div>
         </section>
+
+        {project.tokenAddress ? (
+          <section
+            className={styles.marketChart}
+            aria-label={`${project.name} market data`}
+          >
+            <TokenPriceChart
+              tokenAddress={project.tokenAddress}
+              tokenName={project.name}
+            />
+            <MetricGrid metrics={metrics} />
+          </section>
+        ) : null}
 
         <section className={styles.customMarketPanel} aria-labelledby="custom-market-heading">
           <div className={styles.customPanelHeading}>

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -1249,7 +1249,8 @@ function TokenDetailContent({
       token,
       chartFdv
         ? (formatUsdWadAmount(chartFdv.fdvUsdWad) ??
-          formatEth(chartFdv.fdvEth, "amount"))
+          formatEth(chartFdv.fdvEth, "amount") ??
+          "Unavailable")
         : null,
       buildChartVolumeMetric(chartVolume),
     );

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -12,13 +12,20 @@ import {
 
 import { useLiveDataRefresh } from "@/components/use-live-data-refresh";
 import { getExplorePreviewChart } from "@/components/explore-preview-data";
+import {
+  isMarketChartV1,
+  type MarketChartV1,
+} from "@/lib/market-data/market-data-v1";
 
 import styles from "./token-price-chart.module.css";
 
 export type TokenChartPoint = {
   blockNumber: string;
-  priceEth: string;
+  time?: string;
+  priceEth?: string;
   priceUsd?: string;
+  priceQuote?: string;
+  quoteSymbol?: string;
 };
 
 export type TokenChartDataQuality = Readonly<{
@@ -50,17 +57,22 @@ export type TokenChartDataQuality = Readonly<{
 }>;
 
 export type TokenChartPayload = {
-  status: "ready" | "insufficient-history" | "partial";
+  status:
+    | "ready"
+    | "insufficient-history"
+    | "partial"
+    | "waiting-for-first-trade";
   points: TokenChartPoint[];
   swapCount: number;
-  volumeWei: string;
-  volumeEth: string;
+  volumeWei?: string;
+  volumeEth?: string;
   volumeUsdWad?: string;
   fdvEthWei?: string;
   fdvEth?: string;
   fdvUsdWad?: string;
-  valuationMetric?: "fdv";
+  valuationMetric?: "market-cap" | "fdv";
   dataQuality?: TokenChartDataQuality;
+  marketData?: MarketChartV1;
 };
 type ChartPayload = TokenChartPayload;
 type ChartRequestState = {
@@ -162,22 +174,33 @@ export function getChartFdvAtPoint(
     };
   }
 
+  const ethPrice = comparableChartPricePair(
+    inspectedPoint,
+    latestPoint,
+    "eth",
+  );
+  const usdPrice = comparableChartPricePair(
+    inspectedPoint,
+    latestPoint,
+    "usd",
+  );
+
   const fdvEthWei = scaleIntegerByPriceRatio(
     payload.fdvEthWei,
-    inspectedPoint.priceEth,
-    latestPoint.priceEth,
+    ethPrice?.inspected,
+    ethPrice?.latest,
   );
   const fdvEth = fdvEthWei
     ? formatFixedInteger(BigInt(fdvEthWei), 18)
     : scaleDecimalByPriceRatio(
         payload.fdvEth,
-        inspectedPoint.priceEth,
-        latestPoint.priceEth,
+        ethPrice?.inspected,
+        ethPrice?.latest,
       );
   const fdvUsdWad = scaleIntegerByPriceRatio(
     payload.fdvUsdWad,
-    inspectedPoint.priceEth,
-    latestPoint.priceEth,
+    usdPrice?.inspected,
+    usdPrice?.latest,
   );
 
   return {
@@ -185,6 +208,26 @@ export function getChartFdvAtPoint(
     fdvEth: fdvEth ?? payload.fdvEth,
     fdvUsdWad: fdvUsdWad ?? payload.fdvUsdWad,
   };
+}
+
+function comparableChartPricePair(
+  inspected: TokenChartPoint,
+  latest: TokenChartPoint,
+  preferred: "usd" | "eth",
+): Readonly<{ inspected: string; latest: string }> | null {
+  const candidates = preferred === "usd"
+    ? [[inspected.priceUsd, latest.priceUsd],
+      [inspected.priceEth, latest.priceEth],
+      [inspected.priceQuote, latest.priceQuote]]
+    : [[inspected.priceEth, latest.priceEth],
+      [inspected.priceQuote, latest.priceQuote],
+      [inspected.priceUsd, latest.priceUsd]];
+  for (const [inspectedPrice, latestPrice] of candidates) {
+    if (inspectedPrice && latestPrice) {
+      return { inspected: inspectedPrice, latest: latestPrice };
+    }
+  }
+  return null;
 }
 type ChartLaunchModel = "classic" | "adaptive" | "deep" | "stock-paired";
 
@@ -209,7 +252,8 @@ export function isAuthoritativeChartPayloadStatus(status: unknown) {
   return (
     status === "ready" ||
     status === "insufficient-history" ||
-    status === "partial"
+    status === "partial" ||
+    status === "waiting-for-first-trade"
   );
 }
 
@@ -340,7 +384,9 @@ function hasValidChartCardinality(
     ? pointCount >= 2
     : status === "insufficient-history"
       ? pointCount === 1
-      : status === "partial" && pointCount >= 1;
+      : status === "partial"
+        ? pointCount >= 1
+        : status === "waiting-for-first-trade" && pointCount === 0;
 }
 
 function hasValidChartPointBlocks(
@@ -364,6 +410,10 @@ function hasValidChartPointBlocks(
 }
 
 function withoutNonCurrentFdv(payload: ChartPayload): ChartPayload {
+  if (
+    payload.marketData?.valuation.status === "available" &&
+    payload.marketData.valuation.freshness === "current"
+  ) return payload;
   if (payload.dataQuality?.valuation.status === "current") return payload;
   const sanitized = { ...payload };
   delete sanitized.fdvEthWei;
@@ -375,6 +425,23 @@ function withoutNonCurrentFdv(payload: ChartPayload): ChartPayload {
 export function parseAuthoritativeChartPayload(
   value: unknown,
 ): ChartPayload | null {
+  if (isMarketChartV1(value)) {
+    if (value.status === "unavailable") return null;
+    const fdvUsdWad = value.valuation.status === "available"
+      ? value.valuation.fdvUsdWad
+      : undefined;
+    return withoutNonCurrentFdv({
+      status: value.status,
+      points: [...value.points],
+      swapCount: value.swapCount,
+      ...(value.volumeUsdWad ? { volumeUsdWad: value.volumeUsdWad } : {}),
+      ...(fdvUsdWad ? { fdvUsdWad } : {}),
+      ...(value.valuation.status === "available"
+        ? { valuationMetric: value.valuation.metric }
+        : {}),
+      marketData: value,
+    });
+  }
   if (!isRecord(value)) return null;
   if (
     "marketCapEthWei" in value ||
@@ -403,9 +470,15 @@ export function parseAuthoritativeChartPayload(
       (point) =>
         isRecord(point) &&
         isCanonicalUnsignedIntegerString(point.blockNumber) &&
-        isPositiveDecimalString(point.priceEth) &&
+        (point.priceEth === undefined ||
+          isPositiveDecimalString(point.priceEth)) &&
         (point.priceUsd === undefined ||
-          isPositiveDecimalString(point.priceUsd)),
+          isPositiveDecimalString(point.priceUsd)) &&
+        (point.priceQuote === undefined ||
+          isPositiveDecimalString(point.priceQuote)) &&
+        (isPositiveDecimalString(point.priceUsd) ||
+          isPositiveDecimalString(point.priceEth) ||
+          isPositiveDecimalString(point.priceQuote)),
     )
   ) {
     return null;
@@ -561,10 +634,12 @@ const STOCK_PAIRED_EMPTY_CHART: ChartPayload = {
 export function getPriceHistoryEmptyMessage(
   launchModel: ChartLaunchModel | undefined,
   failed: boolean,
+  waitingForFirstTrade = false,
 ) {
   if (launchModel === "stock-paired") {
     return STOCK_PAIRED_HISTORY_MESSAGE;
   }
+  if (waitingForFirstTrade) return "Waiting for first trade";
   return failed
     ? "Price history is temporarily unavailable"
     : "Price history appears after confirmed trades";
@@ -599,7 +674,7 @@ const PLOT_RIGHT = VIEWBOX_WIDTH - 7;
 const PLOT_TOP = 9;
 const PLOT_BOTTOM = VIEWBOX_HEIGHT - 9;
 
-function formatPrice(value: number, unit: "USD" | "ETH") {
+function formatPrice(value: number, unit: string) {
   if (!Number.isFinite(value) || value < 0) return "Unavailable";
   if (unit === "USD") {
     if (value >= 1) {
@@ -617,7 +692,21 @@ function formatPrice(value: number, unit: "USD" | "ETH") {
   return `${value.toLocaleString("en-US", {
     maximumSignificantDigits: 8,
     useGrouping: false,
-  })} ETH`;
+  })} ${unit}`;
+}
+
+function chartPointContext(point: TokenChartPoint): string {
+  if (point.time && Number.isFinite(Date.parse(point.time))) {
+    return new Intl.DateTimeFormat("en", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "UTC",
+      timeZoneName: "short",
+    }).format(new Date(point.time));
+  }
+  return `Block ${point.blockNumber}`;
 }
 
 function linePath(points: PlottedPoint[]) {
@@ -638,11 +727,29 @@ export function createChartGeometry(points: readonly TokenChartPoint[]) {
   const usesUsd = points.every(
     (point) => point.priceUsd && Number(point.priceUsd) > 0,
   );
-  const unit = usesUsd ? "USD" : "ETH";
+  const usesEth = !usesUsd && points.every(
+    (point) => point.priceEth && Number(point.priceEth) > 0,
+  );
+  const quoteSymbols = new Set(
+    points.map((point) => point.quoteSymbol?.trim()).filter(Boolean),
+  );
+  const unit = usesUsd
+    ? "USD"
+    : usesEth
+      ? "ETH"
+      : quoteSymbols.size === 1
+        ? [...quoteSymbols][0] as string
+        : "quote";
   const validPoints = points
     .map((point) => ({
       ...point,
-      value: Number(usesUsd ? point.priceUsd : point.priceEth),
+      value: Number(
+        usesUsd
+          ? point.priceUsd
+          : usesEth
+            ? point.priceEth
+            : point.priceQuote,
+      ),
     }))
     .filter((point) => Number.isFinite(point.value) && point.value > 0);
   if (validPoints.length === 0) return null;
@@ -838,9 +945,16 @@ export function TokenPriceChart({
     return payload ? createChartGeometry(payload.points) : null;
   }, [payload]);
   const hasLimitedHistory =
-    payload?.status === "partial" && payload.dataQuality?.price.status === "stale";
+    payload?.status === "partial" && (
+      payload.marketData !== undefined ||
+      payload.dataQuality?.price.status === "stale"
+    );
 
-  const emptyMessage = getPriceHistoryEmptyMessage(launchModel, failed);
+  const emptyMessage = getPriceHistoryEmptyMessage(
+    launchModel,
+    failed,
+    payload?.status === "waiting-for-first-trade",
+  );
   const activePoint =
     chart && activePointIndex !== null
       ? chart.points[Math.min(activePointIndex, chart.points.length - 1)]
@@ -1088,7 +1202,7 @@ export function TokenPriceChart({
                 aria-hidden="true"
               >
                 <strong>{formatPrice(activePoint.value, chart.unit)}</strong>
-                <span>Block {activePoint.blockNumber}</span>
+                <span>{chartPointContext(activePoint)}</span>
               </div>
             </>
           ) : null}
@@ -1100,7 +1214,7 @@ export function TokenPriceChart({
             aria-atomic="true"
           >
             {activePoint
-              ? `${formatPrice(activePoint.value, chart.unit)}, block ${activePoint.blockNumber}`
+              ? `${formatPrice(activePoint.value, chart.unit)}, ${chartPointContext(activePoint)}`
               : ""}
           </span>
         </div>

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -174,15 +174,10 @@ export function getChartFdvAtPoint(
     };
   }
 
-  const ethPrice = comparableChartPricePair(
-    inspectedPoint,
-    latestPoint,
-    "eth",
-  );
-  const usdPrice = comparableChartPricePair(
-    inspectedPoint,
-    latestPoint,
-    "usd",
+  const ethPrice = exactEthChartPricePair(inspectedPoint, latestPoint);
+  const usdPrice = exactChartPricePair(
+    inspectedPoint.priceUsd,
+    latestPoint.priceUsd,
   );
 
   const fdvEthWei = scaleIntegerByPriceRatio(
@@ -204,28 +199,34 @@ export function getChartFdvAtPoint(
   );
 
   return {
-    fdvEthWei: fdvEthWei ?? payload.fdvEthWei,
-    fdvEth: fdvEth ?? payload.fdvEth,
-    fdvUsdWad: fdvUsdWad ?? payload.fdvUsdWad,
+    ...(fdvEthWei === undefined ? {} : { fdvEthWei }),
+    ...(fdvEth === undefined ? {} : { fdvEth }),
+    ...(fdvUsdWad === undefined ? {} : { fdvUsdWad }),
   };
 }
 
-function comparableChartPricePair(
+function exactChartPricePair(
+  inspected: string | undefined,
+  latest: string | undefined,
+): Readonly<{ inspected: string; latest: string }> | null {
+  return inspected && latest ? { inspected, latest } : null;
+}
+
+function exactEthChartPricePair(
   inspected: TokenChartPoint,
   latest: TokenChartPoint,
-  preferred: "usd" | "eth",
 ): Readonly<{ inspected: string; latest: string }> | null {
-  const candidates = preferred === "usd"
-    ? [[inspected.priceUsd, latest.priceUsd],
-      [inspected.priceEth, latest.priceEth],
-      [inspected.priceQuote, latest.priceQuote]]
-    : [[inspected.priceEth, latest.priceEth],
-      [inspected.priceQuote, latest.priceQuote],
-      [inspected.priceUsd, latest.priceUsd]];
-  for (const [inspectedPrice, latestPrice] of candidates) {
-    if (inspectedPrice && latestPrice) {
-      return { inspected: inspectedPrice, latest: latestPrice };
-    }
+  const direct = exactChartPricePair(inspected.priceEth, latest.priceEth);
+  if (direct) return direct;
+  const inspectedQuote = inspected.quoteSymbol?.trim().toUpperCase();
+  const latestQuote = latest.quoteSymbol?.trim().toUpperCase();
+  if (
+    inspectedQuote &&
+    latestQuote &&
+    ["ETH", "WETH"].includes(inspectedQuote) &&
+    ["ETH", "WETH"].includes(latestQuote)
+  ) {
+    return exactChartPricePair(inspected.priceQuote, latest.priceQuote);
   }
   return null;
 }

--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -621,13 +621,21 @@ export function buildExploreDataQuality(input: Readonly<{
   const stale = available.filter((value) => value.freshness === "stale");
   const unknown = available.filter((value) => value.freshness === "unknown");
   const unavailable = valuations.length - available.length;
+  const incompleteMarketData = input.entries.filter((entry) => {
+    const marketData = entry.marketData;
+    if (!marketData) return false;
+    const primary = marketData.pools.find(
+      (pool) => pool.identity.poolId === marketData.primaryPoolId,
+    );
+    return marketData.status !== "current" || primary?.quality !== "complete";
+  }).length;
   const metrics = new Set(available.map((value) => value.metric));
   const valuationStatus =
     available.length === 0
       ? "unavailable" as const
       : stale.length > 0
         ? "stale" as const
-        : unavailable > 0 || unknown.length > 0
+        : unavailable > 0 || unknown.length > 0 || incompleteMarketData > 0
           ? "partial" as const
           : "current" as const;
   const identityAsOf = blockNumber(input.identityAsOfBlock);

--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -4,6 +4,15 @@ import type {
   ExploreEntry,
   LauncherToken,
 } from "./tokens";
+import {
+  MARKET_DATA_CURRENT_MAX_AGE_MS,
+  MARKET_DATA_MAXIMUM_RAW_INDEXED_PRICE_DEVIATION_BPS,
+  MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD,
+  MARKET_DATA_USD_PRICE_SOURCE,
+  isTokenMarketDataV1,
+  type MarketPoolDataV1,
+  type TokenMarketDataV1,
+} from "./market-data/market-data-v1";
 
 export const EXPLORE_DATA_QUALITY_SCHEMA_VERSION =
   "programmable.explore-data-quality.v1" as const;
@@ -11,16 +20,19 @@ export const EXPLORE_VALUATION_MAX_LAG_BLOCKS = 64n;
 
 const UINT_256_MAX = (1n << 256n) - 1n;
 const WAD = 10n ** 18n;
+const MAXIMUM_MARKET_FUTURE_SKEW_MS = 60_000;
 
 export type ExploreValuation =
   | Readonly<{
       status: "available";
-      metric: "fdv";
-      supplyBasis: "total";
+      metric: "market-cap" | "fdv";
+      supplyBasis: "circulating" | "total";
       currency: "usd" | "eth" | "quote";
       valueWad: string;
       quoteSymbol?: string;
       freshness: "current" | "stale" | "unknown";
+      source?: "bitquery";
+      asOfTime?: string;
       asOfBlock?: string;
       lagBlocks?: string;
     }>
@@ -31,11 +43,16 @@ export type ExploreValuation =
         | "supply-unavailable"
         | "liquidity-unavailable"
         | "price-unavailable"
-        | "inconsistent-snapshot";
+        | "inconsistent-snapshot"
+        | "waiting-for-first-trade"
+        | "source-unavailable";
     }>;
 
 export type ValuedExploreEntry<T extends ExploreEntry = ExploreEntry> =
-  T & Readonly<{ valuation: ExploreValuation }>;
+  T & Readonly<{
+    valuation: ExploreValuation;
+    marketData?: TokenMarketDataV1;
+  }>;
 
 const LEGACY_MARKET_CAP_FIELDS = [
   "marketCapEth",
@@ -45,6 +62,20 @@ const LEGACY_MARKET_CAP_FIELDS = [
   "indexedMarketCapUsdWad",
   "marketCapQuote",
   "marketCapQuoteWad",
+] as const;
+
+const LEGACY_EXTERNAL_MARKET_FIELDS = [
+  "tokenPriceEth",
+  "tokenPriceEthWei",
+  "tokenPriceUsdWad",
+  "tokenPriceQuote",
+  "tokenPriceQuoteWad",
+  "grossVolumeEth",
+  "grossVolumeWei",
+  "grossVolumeQuote",
+  "grossVolumeQuoteRaw",
+  "swapCount",
+  "uniswapV4Pool",
 ] as const;
 
 type LegacyMarketCapField = typeof LEGACY_MARKET_CAP_FIELDS[number];
@@ -74,12 +105,13 @@ export type ExploreDataQuality = Readonly<{
   }>;
   valuation: Readonly<{
     status: "current" | "partial" | "stale" | "unavailable";
-    metric: "fdv";
+    metric: "market-cap" | "fdv" | "mixed";
     available: number;
     unavailable: number;
     stale: number;
     unknown: number;
     asOfBlock: string | null;
+    asOfTime: string | null;
   }>;
 }>;
 
@@ -266,6 +298,199 @@ export function withExploreValuation<T extends ExploreEntry>(
   return { ...entry, valuation: exploreValuation(entry, context) };
 }
 
+export function withBitqueryMarketData<T extends ExploreEntry>(
+  entry: T,
+  marketData: TokenMarketDataV1,
+): ValuedExploreEntry<T> {
+  const reconciledMarketData = reconcileBitqueryValuations(entry, marketData);
+  const primary = reconciledMarketData.pools.find(
+    (pool) => pool.identity.poolId === reconciledMarketData.primaryPoolId,
+  );
+  const marketValuation = primary?.valuation;
+  const valuation: ExploreValuation =
+    marketValuation?.status === "available"
+      ? {
+          status: "available",
+          metric: marketValuation.metric,
+          supplyBasis: marketValuation.supplyBasis,
+          currency: "usd",
+          valueWad: marketValuation.valueUsdWad,
+          freshness: marketValuation.freshness,
+          source: "bitquery",
+          asOfTime: marketValuation.asOfTime,
+        }
+      : {
+          status: "unavailable",
+          reason:
+            marketValuation?.reason === "waiting-for-first-trade"
+              ? "waiting-for-first-trade"
+              : marketValuation?.reason === "source-unavailable"
+                ? "source-unavailable"
+                : marketValuation?.reason === "price-unavailable"
+                  ? "price-unavailable"
+                  : marketValuation?.reason === "supply-unavailable"
+                    ? "supply-unavailable"
+                    : "inconsistent-snapshot",
+        };
+  return { ...entry, valuation, marketData: reconciledMarketData };
+}
+
+function reconcileBitqueryValuations<T extends ExploreEntry>(
+  entry: T,
+  marketData: TokenMarketDataV1,
+): TokenMarketDataV1 {
+  // Bitquery owns the market price, but Router/Registry owns the token
+  // identity and canonical fixed supply. Its third-party circulating-supply
+  // estimate is never promoted to Market cap. A numeric FDV is current only
+  // when the exact v4 pool also has a current, positive liquidity snapshot.
+  const canonicalSupply = canonicalTotalSupply(entry);
+  const pools = marketData.pools.map((pool): MarketPoolDataV1 => {
+    const price = positiveUint256(pool.latestTrade?.priceUsdWad);
+    const rawPrice = positiveUint256(pool.latestTrade?.rawPriceUsdWad);
+    const liquidity = positiveUint256(pool.liquidity?.valueUsdWad);
+    if (canonicalSupply === null) {
+      return {
+        ...pool,
+        quality: "partial",
+        valuation: { status: "unavailable", reason: "supply-unavailable" },
+      };
+    }
+    if (price === null) {
+      return {
+        ...pool,
+        quality: "partial",
+        valuation: { status: "unavailable", reason: "price-unavailable" },
+      };
+    }
+    if (
+      pool.latestTrade?.priceUsdSource !== MARKET_DATA_USD_PRICE_SOURCE ||
+      !pool.latestTrade.priceUsdAsOfTime ||
+      rawPrice === null ||
+      !usdPricesWithinConfidence(rawPrice, price)
+    ) {
+      return {
+        ...pool,
+        quality: "partial",
+        valuation: {
+          status: "unavailable",
+          reason: "inconsistent-market-data",
+        },
+      };
+    }
+    if (
+      !pool.liquidity ||
+      liquidity === null ||
+      liquidity < BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD)
+    ) {
+      return {
+        ...pool,
+        quality: "partial",
+        valuation: {
+          status: "unavailable",
+          reason: "inconsistent-market-data",
+        },
+      };
+    }
+    const supplyWad = decimalToWad(canonicalSupply);
+    if (supplyWad === null) {
+      return {
+        ...pool,
+        quality: "partial",
+        valuation: { status: "unavailable", reason: "supply-unavailable" },
+      };
+    }
+    const fdv = (price * supplyWad) / WAD;
+    if (fdv <= 0n || fdv > UINT_256_MAX) {
+      return {
+        ...pool,
+        quality: "partial",
+        valuation: {
+          status: "unavailable",
+          reason: "inconsistent-market-data",
+        },
+      };
+    }
+    const tradeTime = Date.parse(pool.latestTrade?.time ?? "");
+    const priceTime = Date.parse(pool.latestTrade.priceUsdAsOfTime);
+    const liquidityTime = Date.parse(pool.liquidity.asOfTime);
+    const generatedTime = Date.parse(marketData.generatedAt);
+    if (
+      !Number.isFinite(tradeTime) ||
+      !Number.isFinite(priceTime) ||
+      !Number.isFinite(liquidityTime) ||
+      !Number.isFinite(generatedTime) ||
+      Math.abs(tradeTime - priceTime) > MARKET_DATA_CURRENT_MAX_AGE_MS ||
+      tradeTime > generatedTime + MAXIMUM_MARKET_FUTURE_SKEW_MS ||
+      priceTime > generatedTime + MAXIMUM_MARKET_FUTURE_SKEW_MS ||
+      liquidityTime > generatedTime + MAXIMUM_MARKET_FUTURE_SKEW_MS
+    ) {
+      return {
+        ...pool,
+        quality: "partial",
+        valuation: {
+          status: "unavailable",
+          reason: "inconsistent-market-data",
+        },
+      };
+    }
+    const asOfTime = new Date(
+      Math.min(tradeTime, priceTime, liquidityTime),
+    ).toISOString();
+    const evidenceIsCurrent = [tradeTime, priceTime, liquidityTime].every(
+      (time) => generatedTime - time <= MARKET_DATA_CURRENT_MAX_AGE_MS,
+    );
+    const freshness = pool.status === "current" &&
+        pool.liquidity.freshness === "current" &&
+        evidenceIsCurrent
+      ? "current" as const
+      : "stale" as const;
+    return {
+      ...pool,
+      quality: freshness === "current" && pool.quality === "complete"
+        ? "complete"
+        : "partial",
+      valuation: {
+        status: "available",
+        metric: "fdv",
+        supplyBasis: "total",
+        valueUsdWad: fdv.toString(),
+        fdvUsdWad: fdv.toString(),
+        totalSupply: canonicalSupply,
+        asOfTime,
+        freshness,
+      },
+    };
+  });
+  return { ...marketData, pools };
+}
+
+function usdPricesWithinConfidence(rawPrice: bigint, indexedPrice: bigint): boolean {
+  if (rawPrice <= 0n || indexedPrice <= 0n) return false;
+  const difference = rawPrice > indexedPrice
+    ? rawPrice - indexedPrice
+    : indexedPrice - rawPrice;
+  return difference * 10_000n <=
+    indexedPrice * BigInt(MARKET_DATA_MAXIMUM_RAW_INDEXED_PRICE_DEVIATION_BPS);
+}
+
+function canonicalTotalSupply(entry: ExploreEntry): string | null {
+  if (entry.exploreKind !== "token") return null;
+  const raw = positiveUint256(entry.totalSupplyRaw);
+  const decimals = entry.tokenDecimals;
+  if (
+    raw === null ||
+    typeof decimals !== "number" ||
+    !Number.isInteger(decimals) ||
+    decimals < 0 ||
+    decimals > 255
+  ) return null;
+  const digits = raw.toString().padStart(decimals + 1, "0");
+  if (decimals === 0) return digits;
+  const whole = digits.slice(0, -decimals);
+  const fraction = digits.slice(-decimals).replace(/0+$/u, "");
+  return fraction ? `${whole}.${fraction}` : whole;
+}
+
 /**
  * Removes legacy total-supply values whose names imply circulating market
  * cap. Public consumers receive the typed FDV valuation and, for USD values,
@@ -278,20 +503,74 @@ export function publicExploreEntryV1(
 
   const output = { ...entry } as Record<string, unknown>;
   for (const field of LEGACY_MARKET_CAP_FIELDS) delete output[field];
-  if (
+  for (const field of LEGACY_EXTERNAL_MARKET_FIELDS) delete output[field];
+  const primaryMarket = entry.marketData?.pools.find(
+    (pool) => pool.identity.poolId === entry.marketData?.primaryPoolId,
+  );
+  const bitqueryFdv = primaryMarket?.valuation.status === "available"
+      && primaryMarket.valuation.freshness === "current"
+    ? primaryMarket.valuation.fdvUsdWad
+    : undefined;
+  if (bitqueryFdv !== undefined) {
+    output.fdvUsdWad = bitqueryFdv;
+  } else if (
     entry.valuation.status === "available" &&
-    entry.valuation.currency === "usd"
+    entry.valuation.metric === "fdv" &&
+    entry.valuation.currency === "usd" &&
+    entry.valuation.freshness === "current"
   ) {
     output.fdvUsdWad = entry.valuation.valueWad;
   } else {
     delete output.fdvUsdWad;
   }
+  const latestTrade = primaryMarket?.status === "current"
+    ? primaryMarket.latestTrade
+    : undefined;
+  if (
+    latestTrade?.priceUsdWad &&
+    latestTrade.priceUsdSource === MARKET_DATA_USD_PRICE_SOURCE &&
+    primaryMarket?.valuation.status === "available" &&
+    primaryMarket.valuation.freshness === "current"
+  ) {
+    output.tokenPriceUsdWad = latestTrade.priceUsdWad;
+  }
+  if (latestTrade?.priceQuoteWad) {
+    output.tokenPriceQuoteWad = latestTrade.priceQuoteWad;
+    output.tokenPriceQuote = wadToDecimal(BigInt(latestTrade.priceQuoteWad));
+    if (latestTrade.quoteSymbol) output.quoteAssetSymbol = latestTrade.quoteSymbol;
+    if (latestTrade.quoteAddress) output.quoteAssetAddress = latestTrade.quoteAddress;
+    if (["ETH", "WETH"].includes(latestTrade.quoteSymbol?.toUpperCase() ?? "")) {
+      output.tokenPriceEthWei = latestTrade.priceQuoteWad;
+      output.tokenPriceEth = wadToDecimal(BigInt(latestTrade.priceQuoteWad));
+    }
+  }
   return output as PublicCanonicalExploreEntry;
+}
+
+function wadToDecimal(value: bigint): string {
+  const raw = value.toString().padStart(19, "0");
+  const whole = raw.slice(0, -18);
+  const fraction = raw.slice(-18).replace(/0+$/u, "");
+  return fraction ? `${whole}.${fraction}` : whole;
 }
 
 export function valuationSortValue(entry: ExploreEntry): bigint | null {
   const value = (entry as Partial<ValuedExploreEntry>).valuation;
+  const marketData = (entry as Partial<ValuedExploreEntry>).marketData;
+  if (marketData && isTokenMarketDataV1(marketData)) {
+    const primary = marketData.pools.find(
+      (pool) => pool.identity.poolId === marketData.primaryPoolId,
+    );
+    const fdv = primary?.valuation.status === "available"
+        && primary.valuation.metric === "fdv"
+        && primary.valuation.supplyBasis === "total"
+        && primary.valuation.freshness === "current"
+      ? primary.valuation.fdvUsdWad
+      : undefined;
+    return positiveUint256(fdv);
+  }
   return value?.status === "available" &&
+    value.metric === "fdv" &&
     value.currency === "usd" &&
     value.freshness === "current"
     ? positiveUint256(value.valueWad)
@@ -311,6 +590,21 @@ function latestAvailableValuationBlock(
   return latest?.toString() ?? null;
 }
 
+function latestAvailableValuationTime(
+  entries: readonly ValuedExploreEntry[],
+): string | null {
+  let latest: number | null = null;
+  for (const entry of entries) {
+    const valuation = entry.valuation;
+    if (valuation.status !== "available" || !valuation.asOfTime) continue;
+    const parsed = Date.parse(valuation.asOfTime);
+    if (Number.isFinite(parsed) && (latest === null || parsed > latest)) {
+      latest = parsed;
+    }
+  }
+  return latest === null ? null : new Date(latest).toISOString();
+}
+
 export function buildExploreDataQuality(input: Readonly<{
   entries: readonly ValuedExploreEntry[];
   generatedAt?: string;
@@ -320,15 +614,14 @@ export function buildExploreDataQuality(input: Readonly<{
   referenceBlock: string | null;
   identityAgeMs?: number | null;
 }>): ExploreDataQuality {
-  const tokenValuations = input.entries.flatMap((entry) =>
-    entry.exploreKind === "token" ? [entry.valuation] : [],
-  );
-  const available = tokenValuations.filter(
+  const valuations = input.entries.map((entry) => entry.valuation);
+  const available = valuations.filter(
     (value) => value.status === "available",
   );
   const stale = available.filter((value) => value.freshness === "stale");
   const unknown = available.filter((value) => value.freshness === "unknown");
-  const unavailable = tokenValuations.length - available.length;
+  const unavailable = valuations.length - available.length;
+  const metrics = new Set(available.map((value) => value.metric));
   const valuationStatus =
     available.length === 0
       ? "unavailable" as const
@@ -377,12 +670,18 @@ export function buildExploreDataQuality(input: Readonly<{
     },
     valuation: {
       status: valuationStatus,
-      metric: "fdv",
+      metric:
+        metrics.size > 1
+          ? "mixed"
+          : metrics.has("market-cap")
+            ? "market-cap"
+            : "fdv",
       available: available.length,
       unavailable,
       stale: stale.length,
       unknown: unknown.length,
       asOfBlock: latestAvailableValuationBlock(input.entries),
+      asOfTime: latestAvailableValuationTime(input.entries),
     },
   };
 }
@@ -397,17 +696,26 @@ export function isExploreValuation(value: unknown): value is ExploreValuation {
       "liquidity-unavailable",
       "price-unavailable",
       "inconsistent-snapshot",
+      "waiting-for-first-trade",
+      "source-unavailable",
     ].includes(String(candidate.reason));
   }
   return candidate.status === "available" &&
-    candidate.metric === "fdv" &&
-    candidate.supplyBasis === "total" &&
+    ["market-cap", "fdv"].includes(String(candidate.metric)) &&
+    ["circulating", "total"].includes(String(candidate.supplyBasis)) &&
+    (candidate.metric !== "market-cap" ||
+      candidate.supplyBasis === "circulating") &&
+    (candidate.metric !== "fdv" || candidate.supplyBasis === "total") &&
     ["usd", "eth", "quote"].includes(String(candidate.currency)) &&
     positiveUint256(candidate.valueWad) !== null &&
     ["current", "stale", "unknown"].includes(String(candidate.freshness)) &&
     (candidate.currency !== "quote" ||
       (typeof candidate.quoteSymbol === "string" &&
         candidate.quoteSymbol.trim().length > 0)) &&
+    (candidate.source === undefined || candidate.source === "bitquery") &&
+    (candidate.asOfTime === undefined ||
+      (typeof candidate.asOfTime === "string" &&
+        Number.isFinite(Date.parse(candidate.asOfTime)))) &&
     (candidate.asOfBlock === undefined ||
       blockNumber(candidate.asOfBlock) !== null) &&
     (candidate.lagBlocks === undefined || uint256(candidate.lagBlocks) !== null);
@@ -456,7 +764,9 @@ export function isExploreDataQuality(
     ["current", "partial", "stale", "unavailable"].includes(
       String(valuationRecord.status),
     ) &&
-    valuationRecord.metric === "fdv" &&
+    ["market-cap", "fdv", "mixed"].includes(
+      String(valuationRecord.metric),
+    ) &&
     ["available", "unavailable", "stale", "unknown"].every(
       (key) =>
         typeof valuationRecord[key] === "number" &&
@@ -464,5 +774,8 @@ export function isExploreDataQuality(
         Number(valuationRecord[key]) >= 0,
     ) &&
     (valuationRecord.asOfBlock === null ||
-      blockNumber(valuationRecord.asOfBlock) !== null);
+      blockNumber(valuationRecord.asOfBlock) !== null) &&
+    (valuationRecord.asOfTime === null ||
+      (typeof valuationRecord.asOfTime === "string" &&
+        Number.isFinite(Date.parse(valuationRecord.asOfTime))));
 }

--- a/lib/market-data/bitquery-stream.server.ts
+++ b/lib/market-data/bitquery-stream.server.ts
@@ -212,7 +212,7 @@ export const BITQUERY_MARKET_STREAM_QUERY = `
           Buy { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
           Sell { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
         }
-        Transaction { Hash }
+        Transaction { Hash Index }
       }
       DEXPoolEvents(
         where: {

--- a/lib/market-data/bitquery-stream.server.ts
+++ b/lib/market-data/bitquery-stream.server.ts
@@ -1,0 +1,310 @@
+import "server-only";
+
+import {
+  BITQUERY_OAUTH_TOKEN_ENVIRONMENT_VARIABLE,
+  ingestBitqueryMarketStreamPayloadV1,
+  safeBitqueryMarketDataError,
+  BitqueryMarketDataError,
+} from "./bitquery.server";
+import type {
+  MarketDataIdentityV1,
+  MarketPoolDataV1,
+} from "./market-data-v1";
+
+export const BITQUERY_WEBSOCKET_ENDPOINT =
+  "wss://streaming.bitquery.io/graphql" as const;
+
+const SUBSCRIPTION_ID = "programmable-market-stream";
+const INITIAL_RETRY_DELAY_MS = 1_000;
+const MAXIMUM_RETRY_DELAY_MS = 30_000;
+const STREAM_SILENCE_TIMEOUT_MS = 45_000;
+const MAXIMUM_STREAM_MESSAGE_BYTES = 1_000_000;
+const MAXIMUM_STREAM_POOL_COUNT = 1_000;
+
+type WebSocketConstructor = new (
+  url: string | URL,
+  protocols?: string | string[],
+) => WebSocket;
+
+export type BitqueryMarketStreamEventV1 = Readonly<{
+  identity: MarketDataIdentityV1;
+  market: MarketPoolDataV1;
+}>;
+
+export type BitqueryMarketStreamV1 = Readonly<{
+  start(): void;
+  stop(): void;
+}>;
+
+export function createBitqueryMarketStreamV1(input: Readonly<{
+  identities: readonly MarketDataIdentityV1[];
+  onData: (event: BitqueryMarketStreamEventV1) => void;
+  onStatus?: (status: "connecting" | "connected" | "retrying" | "stopped") => void;
+  onError?: (error: Readonly<{ name: string; category: string }>) => void;
+  token?: string;
+  WebSocketImpl?: WebSocketConstructor;
+}>): BitqueryMarketStreamV1 {
+  const configuredToken = (input.token ??
+    process.env[BITQUERY_OAUTH_TOKEN_ENVIRONMENT_VARIABLE])?.trim();
+  if (!configuredToken || configuredToken.length < 16) {
+    throw new BitqueryMarketDataError("configuration");
+  }
+  const token: string = configuredToken;
+  const WebSocketImpl = input.WebSocketImpl ?? globalThis.WebSocket;
+  if (!WebSocketImpl) throw new BitqueryMarketDataError("configuration");
+  const identities = canonicalIdentities(input.identities);
+  const identityByPoolId = new Map(
+    identities.map((identity) => [identity.poolId, identity]),
+  );
+  let socket: WebSocket | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let silenceTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = true;
+  let retryDelay = INITIAL_RETRY_DELAY_MS;
+
+  function report(error: unknown) {
+    input.onError?.(safeBitqueryMarketDataError(error));
+  }
+
+  function scheduleRetry() {
+    if (stopped || retryTimer !== null) return;
+    input.onStatus?.("retrying");
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      connect();
+    }, retryDelay);
+    retryDelay = Math.min(retryDelay * 2, MAXIMUM_RETRY_DELAY_MS);
+  }
+
+  function armSilenceTimer(active: WebSocket) {
+    if (silenceTimer !== null) clearTimeout(silenceTimer);
+    silenceTimer = setTimeout(() => {
+      silenceTimer = null;
+      if (!stopped && socket === active) {
+        active.close(4000, "stream timeout");
+      }
+    }, STREAM_SILENCE_TIMEOUT_MS);
+  }
+
+  function connect() {
+    if (stopped || socket !== null) return;
+    input.onStatus?.("connecting");
+    // Bitquery requires its OAuth token in the WebSocket URL. This URL remains
+    // server-only and is never passed to telemetry or to an error callback.
+    const url = `${BITQUERY_WEBSOCKET_ENDPOINT}?token=${encodeURIComponent(token)}`;
+    let next: WebSocket;
+    try {
+      next = new WebSocketImpl(url, "graphql-ws");
+    } catch {
+      report(new BitqueryMarketDataError("transport"));
+      scheduleRetry();
+      return;
+    }
+    socket = next;
+
+    next.addEventListener("open", () => {
+      if (stopped || socket !== next) return;
+      armSilenceTimer(next);
+      next.send(JSON.stringify({ type: "connection_init", payload: {} }));
+    });
+    next.addEventListener("message", (event) => {
+      if (stopped || socket !== next) return;
+      try {
+        armSilenceTimer(next);
+        const raw = String(event.data);
+        if (new TextEncoder().encode(raw).byteLength > MAXIMUM_STREAM_MESSAGE_BYTES) {
+          throw new BitqueryMarketDataError("response");
+        }
+        const message: unknown = JSON.parse(raw);
+        const value = record(message);
+        if (!value) throw new BitqueryMarketDataError("response");
+        if (value.type === "connection_ack") {
+          retryDelay = INITIAL_RETRY_DELAY_MS;
+          input.onStatus?.("connected");
+          next.send(JSON.stringify({
+            id: SUBSCRIPTION_ID,
+            type: "start",
+            payload: {
+              query: BITQUERY_MARKET_STREAM_QUERY,
+              variables: { poolIds: identities.map((identity) => identity.poolId) },
+            },
+          }));
+          return;
+        }
+        if (value.type === "ka") return;
+        if (value.type === "data" && value.id === SUBSCRIPTION_ID) {
+          const payload = record(value.payload);
+          const data = record(payload?.data);
+          if (!data) throw new BitqueryMarketDataError("response");
+          for (const [poolId, identity] of identityByPoolId) {
+            const payloadForPool = streamPayloadForPool(data, poolId);
+            if (payloadForPool === null) continue;
+            const market = ingestBitqueryMarketStreamPayloadV1({
+              identity,
+              payload: payloadForPool,
+            });
+            if (market) input.onData({ identity, market });
+          }
+          return;
+        }
+        if (value.type === "error") {
+          throw new BitqueryMarketDataError("response");
+        }
+      } catch (error) {
+        report(error);
+      }
+    });
+    next.addEventListener("error", () => {
+      report(new BitqueryMarketDataError("transport"));
+    });
+    next.addEventListener("close", () => {
+      if (silenceTimer !== null) {
+        clearTimeout(silenceTimer);
+        silenceTimer = null;
+      }
+      if (socket === next) socket = null;
+      scheduleRetry();
+    });
+  }
+
+  return {
+    start() {
+      if (!stopped) return;
+      stopped = false;
+      retryDelay = INITIAL_RETRY_DELAY_MS;
+      connect();
+    },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      if (silenceTimer !== null) {
+        clearTimeout(silenceTimer);
+        silenceTimer = null;
+      }
+      const active = socket;
+      socket = null;
+      active?.close(1000, "stream stopped");
+      input.onStatus?.("stopped");
+    },
+  };
+}
+
+export const BITQUERY_MARKET_STREAM_QUERY = `
+  subscription ProgrammablePoolMarketStream($poolIds: [String!]!) {
+    EVM(network: eth) {
+      DEXTrades(
+        where: {
+          TransactionStatus: { Success: true }
+          Trade: {
+            Dex: { ProtocolName: { is: "uniswap_v4" } }
+            PoolId: { in: $poolIds }
+          }
+        }
+      ) {
+        Block { Number Time }
+        Log { Index }
+        Trade {
+          PoolId
+          Buy { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
+          Sell { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
+        }
+        Transaction { Hash }
+      }
+      DEXPoolEvents(
+        where: {
+          TransactionStatus: { Success: true }
+          PoolEvent: {
+            Dex: { ProtocolName: { is: "uniswap_v4" } }
+            Pool: { PoolId: { in: $poolIds } }
+          }
+        }
+      ) {
+        Block { Number Time }
+        PoolEvent {
+          Pool { PoolId }
+          Liquidity { AmountCurrencyAInUSD AmountCurrencyBInUSD }
+        }
+        Transaction { Hash }
+      }
+    }
+  }
+`;
+
+function canonicalIdentities(
+  values: readonly MarketDataIdentityV1[],
+): readonly MarketDataIdentityV1[] {
+  if (values.length === 0 || values.length > MAXIMUM_STREAM_POOL_COUNT) {
+    throw new BitqueryMarketDataError("configuration");
+  }
+  const byPool = new Map<string, MarketDataIdentityV1>();
+  for (const value of values) {
+    const identity = canonicalIdentity(value);
+    const existing = byPool.get(identity.poolId);
+    if (existing && existing.tokenAddress !== identity.tokenAddress) {
+      throw new BitqueryMarketDataError("integrity");
+    }
+    byPool.set(identity.poolId, identity);
+  }
+  return [...byPool.values()].sort((first, second) =>
+    first.poolId.localeCompare(second.poolId)
+  );
+}
+
+function streamPayloadForPool(
+  data: Record<string, unknown>,
+  poolId: string,
+): Record<string, unknown> | null {
+  const evm = record(data.EVM);
+  if (!evm) throw new BitqueryMarketDataError("response");
+  const trades = array(evm.DEXTrades).filter((row) =>
+    nestedPoolId(row, "Trade") === poolId
+  );
+  const liquidity = array(evm.DEXPoolEvents).filter((row) =>
+    nestedPoolId(row, "PoolEvent") === poolId
+  );
+  return trades.length === 0 && liquidity.length === 0
+    ? null
+    : { EVM: { DEXTrades: trades, DEXPoolEvents: liquidity } };
+}
+
+function nestedPoolId(value: unknown, kind: "Trade" | "PoolEvent"): string | null {
+  const row = record(value);
+  const parent = record(row?.[kind]);
+  const valuePoolId = kind === "Trade"
+    ? parent?.PoolId
+    : record(parent?.Pool)?.PoolId;
+  if (typeof valuePoolId !== "string") return null;
+  const normalized = valuePoolId.toLowerCase();
+  return /^0x[0-9a-f]{64}$/u.test(normalized) ? normalized : null;
+}
+
+function canonicalIdentity(identity: MarketDataIdentityV1): MarketDataIdentityV1 {
+  const tokenAddress = identity.tokenAddress.toLowerCase();
+  const poolId = identity.poolId.toLowerCase();
+  if (
+    identity.chainId !== "1" ||
+    identity.protocol !== "uniswap_v4" ||
+    !/^0x[0-9a-f]{40}$/u.test(tokenAddress) ||
+    !/^0x[0-9a-f]{64}$/u.test(poolId)
+  ) throw new BitqueryMarketDataError("integrity");
+  return {
+    chainId: "1",
+    tokenAddress: tokenAddress as `0x${string}`,
+    poolId: poolId as `0x${string}`,
+    protocol: "uniswap_v4",
+  };
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function array(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -733,11 +733,15 @@ function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
       $pools: [String!]!
       $tokenAddresses: [String!]!
     ) {
-      EVM(network: eth) {
+      EVM(network: eth, dataset: combined) {
         latestTrades: DEXTrades(
           limit: { count: ${rowLimit} }
           limitBy: { by: Trade_PoolId, count: 1 }
-          orderBy: { descending: Block_Time }
+          orderBy: [
+            { descending: Block_Number }
+            { descending: Transaction_Index }
+            { descending: Log_Index }
+          ]
           where: {
             TransactionStatus: { Success: true }
             Trade: {
@@ -749,7 +753,11 @@ function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
         latestLiquidity: DEXPoolEvents(
           limit: { count: ${rowLimit} }
           limitBy: { by: PoolEvent_Pool_PoolId, count: 1 }
-          orderBy: { descending: Block_Time }
+          orderBy: [
+            { descending: Block_Number }
+            { descending: Transaction_Index }
+            { descending: Log_Index }
+          ]
           where: {
             TransactionStatus: { Success: true }
             PoolEvent: {
@@ -798,12 +806,16 @@ function marketChartQuery(
   const blockFilter = withSince
     ? "Block: { Time: { since: $since } }"
     : "";
-  const dataset = range === "all" ? ", dataset: combined" : "";
+  const dataset = range === "1h" ? "" : ", dataset: combined";
   return `query ProgrammableMarketChart(${definitions}) {
     EVM(network: eth${dataset}) {
       DEXTrades(
         limit: { count: ${MAXIMUM_CHART_TRADES} }
-        orderBy: { descending: Block_Time }
+        orderBy: [
+          { descending: Block_Number }
+          { descending: Transaction_Index }
+          { descending: Log_Index }
+        ]
         where: {
           TransactionStatus: { Success: true }
           ${blockFilter}
@@ -830,7 +842,7 @@ function tradeSelection() {
       Buy { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
       Sell { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
     }
-    Transaction { Hash }
+    Transaction { Hash Index }
   `;
 }
 
@@ -879,6 +891,7 @@ function parseTrade(
   const trade = record(row?.Trade);
   const transaction = record(row?.Transaction);
   const transactionHash = canonicalTransactionHash(transaction?.Hash);
+  const transactionIndex = nonNegativeSafeInteger(transaction?.Index);
   if (
     !row ||
     !block ||
@@ -888,6 +901,7 @@ function parseTrade(
     canonicalBytes32(trade.PoolId) !== identity.poolId ||
     !canonicalUnsignedInteger(block.Number) ||
     nonNegativeSafeInteger(log.Index) === null ||
+    transactionIndex === null ||
     transactionHash === null
   ) return null;
   const time = isoTime(block.Time);
@@ -912,6 +926,7 @@ function parseTrade(
   if (rawPriceUsdWad === null && priceQuoteWad === null) return null;
   return {
     transactionHash,
+    transactionIndex,
     logIndex: Number(log.Index),
     blockNumber: String(block.Number),
     time,
@@ -1319,11 +1334,17 @@ function cachedOrUnavailable(
   if (!cached || now.getTime() - cached.storedAt > MARKET_CACHE_MAX_AGE_MS) {
     return unavailablePool(identity, "source-unavailable");
   }
+  if (cached.value.status === "waiting-for-first-trade") {
+    return {
+      ...cached.value,
+      status: "unavailable",
+      quality: "partial",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    };
+  }
   return {
     ...cached.value,
-    status: cached.value.status === "waiting-for-first-trade"
-      ? "waiting-for-first-trade"
-      : "stale",
+    status: "stale",
     quality: "partial",
     valuation: cached.value.valuation.status === "available"
       ? { ...cached.value.valuation, freshness: "stale" }
@@ -1339,11 +1360,17 @@ function cachedChartOrUnavailable(
 ): MarketChartV1 {
   const cached = chartCache.get(key);
   if (cached && now.getTime() - cached.storedAt <= CHART_CACHE_MAX_AGE_MS) {
+    if (cached.value.points.length === 0) {
+      return {
+        ...cached.value,
+        status: "unavailable",
+        generatedAt: now.toISOString(),
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+      };
+    }
     return {
       ...cached.value,
-      status: cached.value.points.length === 0
-        ? "waiting-for-first-trade"
-        : "partial",
+      status: "partial",
       generatedAt: now.toISOString(),
       valuation: cached.value.valuation.status === "available"
         ? { ...cached.value.valuation, freshness: "stale" }
@@ -1379,12 +1406,14 @@ function canonicalTrades(trades: readonly MarketTradeV1[]): MarketTradeV1[] {
   const sorted = [...trades].sort((first, second) => {
     const block = BigInt(first.blockNumber) - BigInt(second.blockNumber);
     if (block !== 0n) return block < 0n ? -1 : 1;
-    const time = Date.parse(first.time) - Date.parse(second.time);
-    if (time !== 0) return time;
-    const transaction = first.transactionHash.localeCompare(
-      second.transactionHash,
-    );
-    return transaction !== 0 ? transaction : first.logIndex - second.logIndex;
+    const firstTransaction = first.transactionIndex ?? -1;
+    const secondTransaction = second.transactionIndex ?? -1;
+    const transaction = firstTransaction - secondTransaction;
+    if (transaction !== 0) return transaction;
+    const log = first.logIndex - second.logIndex;
+    return log !== 0
+      ? log
+      : first.transactionHash.localeCompare(second.transactionHash);
   });
   const byKey = new Map<string, MarketTradeV1>();
   for (const trade of sorted) {

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -1,0 +1,1646 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+
+import {
+  MARKET_DATA_CURRENT_MAX_AGE_MS,
+  MARKET_DATA_MAXIMUM_RAW_INDEXED_PRICE_DEVIATION_BPS,
+  MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD,
+  MARKET_DATA_USD_PRICE_SOURCE,
+  PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION,
+  PROGRAMMABLE_MARKET_DATA_SCHEMA_VERSION,
+  isMarketChartV1,
+  selectPrimaryMarketPoolV1,
+  type MarketChartPointV1,
+  type MarketChartV1,
+  type MarketDataIdentityV1,
+  type MarketLiquidityV1,
+  type MarketOhlcV1,
+  type MarketPoolDataV1,
+  type MarketTradeV1,
+  type MarketValuationV1,
+  type TokenMarketDataV1,
+} from "./market-data-v1";
+
+export const BITQUERY_OAUTH_TOKEN_ENVIRONMENT_VARIABLE =
+  "BITQUERY_OAUTH_TOKEN" as const;
+export const BITQUERY_HTTP_ENDPOINT =
+  "https://streaming.bitquery.io/graphql" as const;
+
+const REQUEST_TIMEOUT_MS = 8_000;
+const MAXIMUM_RESPONSE_BYTES = 1_500_000;
+const MARKET_BATCH_SIZE = 100;
+const MARKET_BATCH_CONCURRENCY = 2;
+const MARKET_CACHE_CURRENT_MAX_AGE_MS = 2_000;
+const MARKET_CACHE_MAX_AGE_MS = 15 * 60 * 1_000;
+const DURABLE_MARKET_CACHE_SECONDS = 5 * 60;
+const CHART_CACHE_MAX_AGE_MS = 2 * 60 * 1_000;
+const MAXIMUM_CHART_TRADES = 2_000;
+const MAXIMUM_CHART_POINTS = 80;
+const SUPPLY_PRICE_MAXIMUM_DISTANCE_MS = 24 * 60 * 60 * 1_000;
+const INDEXED_PRICE_MAXIMUM_DISTANCE_MS = MARKET_DATA_CURRENT_MAX_AGE_MS;
+const MAXIMUM_FUTURE_SKEW_MS = 60_000;
+
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const BYTES32 = /^0x[0-9a-f]{64}$/u;
+const TRANSACTION_HASH = /^0x[0-9a-f]{64}$/u;
+const CANONICAL_UNSIGNED_INTEGER = /^(?:0|[1-9][0-9]*)$/u;
+
+type FetchImplementation = typeof fetch;
+
+type GraphqlResponse = Readonly<{
+  data: Record<string, unknown>;
+  partial: boolean;
+}>;
+
+type BitqueryReaderOptions = Readonly<{
+  fetchImpl?: FetchImplementation;
+  token?: string | null;
+  now?: Date;
+  signal?: AbortSignal;
+}>;
+
+type MarketCacheEntry = Readonly<{
+  storedAt: number;
+  value: MarketPoolDataV1;
+}>;
+
+type ChartCacheEntry = Readonly<{
+  storedAt: number;
+  value: MarketChartV1;
+}>;
+
+const marketCache = new Map<string, MarketCacheEntry>();
+const chartCache = new Map<string, ChartCacheEntry>();
+
+export class BitqueryMarketDataError extends Error {
+  override name = "BitqueryMarketDataError";
+
+  constructor(
+    readonly category:
+      | "configuration"
+      | "transport"
+      | "response"
+      | "integrity",
+  ) {
+    super("Market data is temporarily unavailable");
+  }
+}
+
+export function safeBitqueryMarketDataError(error: unknown): Readonly<{
+  name: string;
+  category: string;
+}> {
+  return error instanceof BitqueryMarketDataError
+    ? { name: error.name, category: error.category }
+    : { name: "MarketDataError", category: "unexpected" };
+}
+
+export function bitqueryMarketDataConfigured(
+  token = process.env[BITQUERY_OAUTH_TOKEN_ENVIRONMENT_VARIABLE],
+): boolean {
+  return typeof token === "string" && token.trim().length >= 16;
+}
+
+export async function readBitqueryTokenMarketDataV1(
+  identities: readonly MarketDataIdentityV1[],
+  options: BitqueryReaderOptions = {},
+): Promise<ReadonlyMap<string, TokenMarketDataV1>> {
+  const now = options.now ?? new Date();
+  const unique = canonicalMarketIdentities(identities);
+  if (unique.length === 0) return new Map();
+  if (
+    process.env.NODE_ENV !== "test" &&
+    options.fetchImpl === undefined &&
+    options.token === undefined &&
+    options.now === undefined
+  ) {
+    const entries = await readDurablyCachedBitqueryMarketData(
+      JSON.stringify(unique),
+    );
+    return ageCachedTokenMarketData(new Map(entries), now);
+  }
+  return readBitqueryTokenMarketDataUncachedV1(unique, options, now);
+}
+
+async function readBitqueryTokenMarketDataUncachedV1(
+  unique: readonly MarketDataIdentityV1[],
+  options: BitqueryReaderOptions,
+  now: Date,
+): Promise<ReadonlyMap<string, TokenMarketDataV1>> {
+  const token = resolveToken(options.token);
+  const pools = new Map<string, MarketPoolDataV1>();
+
+  if (token === null) {
+    for (const identity of unique) {
+      pools.set(identity.poolId, cachedOrUnavailable(identity, now));
+    }
+    return groupTokenMarketData(unique, pools, now);
+  }
+
+  const pending = unique.filter((identity) => {
+    const cached = marketCache.get(marketCacheKey(identity));
+    if (
+      cached &&
+      now.getTime() - cached.storedAt <= MARKET_CACHE_CURRENT_MAX_AGE_MS
+    ) {
+      pools.set(identity.poolId, cached.value);
+      return false;
+    }
+    return true;
+  });
+  const batches: MarketDataIdentityV1[][] = [];
+  for (let offset = 0; offset < pending.length; offset += MARKET_BATCH_SIZE) {
+    batches.push(pending.slice(offset, offset + MARKET_BATCH_SIZE));
+  }
+  await mapWithConcurrency(batches, MARKET_BATCH_CONCURRENCY, async (batch) => {
+    try {
+      const result = await readMarketBatch(batch, {
+        ...options,
+        token,
+        now,
+      });
+      for (const value of result) {
+        const resolved = value.status === "unavailable"
+          ? cachedOrUnavailable(value.identity, now)
+          : value;
+        pools.set(value.identity.poolId, resolved);
+        if (resolved.status !== "unavailable") {
+          marketCache.set(marketCacheKey(value.identity), {
+            storedAt: now.getTime(),
+            value: resolved,
+          });
+        }
+      }
+    } catch {
+      for (const identity of batch) {
+        pools.set(identity.poolId, cachedOrUnavailable(identity, now));
+      }
+    }
+  });
+
+  return groupTokenMarketData(unique, pools, now);
+}
+
+const readDurablyCachedBitqueryMarketData = unstable_cache(
+  async (serializedIdentities: string) => {
+    const parsed: unknown = JSON.parse(serializedIdentities);
+    if (!Array.isArray(parsed)) throw new BitqueryMarketDataError("integrity");
+    const identities = canonicalMarketIdentities(
+      parsed as MarketDataIdentityV1[],
+    );
+    const now = new Date();
+    const values = await readBitqueryTokenMarketDataUncachedV1(
+      identities,
+      {},
+      now,
+    );
+    return [...values.entries()] as Array<[string, TokenMarketDataV1]>;
+  },
+  ["programmable-bitquery-market-data-v1"],
+  { revalidate: DURABLE_MARKET_CACHE_SECONDS },
+);
+
+function ageCachedTokenMarketData(
+  values: ReadonlyMap<string, TokenMarketDataV1>,
+  now: Date,
+): ReadonlyMap<string, TokenMarketDataV1> {
+  const output = new Map<string, TokenMarketDataV1>();
+  for (const [address, value] of values) {
+    const pools = value.pools.map((pool): MarketPoolDataV1 => {
+      const tradeAge = pool.asOfTime
+        ? now.getTime() - Date.parse(pool.asOfTime)
+        : null;
+      const stale = tradeAge !== null && tradeAge > MARKET_DATA_CURRENT_MAX_AGE_MS;
+      const valuation = pool.valuation.status === "available"
+        ? {
+            ...pool.valuation,
+            freshness:
+              now.getTime() - Date.parse(pool.valuation.asOfTime) >
+                  MARKET_DATA_CURRENT_MAX_AGE_MS
+                ? "stale" as const
+                : "current" as const,
+          }
+        : pool.valuation;
+      const liquidity = pool.liquidity
+        ? {
+            ...pool.liquidity,
+            freshness:
+              now.getTime() - Date.parse(pool.liquidity.asOfTime) >
+                  MARKET_DATA_CURRENT_MAX_AGE_MS
+                ? "stale" as const
+                : "current" as const,
+          }
+        : undefined;
+      return {
+        ...pool,
+        status: pool.status === "current" && stale ? "stale" : pool.status,
+        quality:
+          pool.quality === "complete" &&
+              (stale ||
+                (valuation.status === "available" &&
+                  valuation.freshness === "stale") ||
+                liquidity?.freshness === "stale")
+            ? "partial"
+            : pool.quality,
+        valuation,
+        ...(liquidity ? { liquidity } : {}),
+      };
+    });
+    const primary = selectPrimaryMarketPoolV1(pools);
+    const status = primary === null || primary.status === "unavailable"
+      ? "unavailable" as const
+      : primary.status === "waiting-for-first-trade"
+        ? "waiting-for-first-trade" as const
+        : primary.status === "stale"
+          ? "stale" as const
+          : pools.some((pool) => pool.quality !== "complete")
+            ? "partial" as const
+            : "current" as const;
+    output.set(address, {
+      ...value,
+      generatedAt: now.toISOString(),
+      status,
+      pools,
+    });
+  }
+  return output;
+}
+
+async function mapWithConcurrency<T>(
+  values: readonly T[],
+  concurrency: number,
+  run: (value: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  await Promise.all(Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (cursor < values.length) {
+        const index = cursor;
+        cursor += 1;
+        await run(values[index]);
+      }
+    },
+  ));
+}
+
+export async function readBitqueryMarketChartV1(input: Readonly<{
+  identity: MarketDataIdentityV1;
+  range: "1h" | "1d" | "1w" | "all";
+  valuation?: MarketValuationV1;
+}> & BitqueryReaderOptions): Promise<MarketChartV1> {
+  const now = input.now ?? new Date();
+  const identity = canonicalMarketIdentities([input.identity])[0];
+  if (!identity) throw new BitqueryMarketDataError("integrity");
+  const cacheKey = `${marketCacheKey(identity)}:${input.range}`;
+  const token = resolveToken(input.token);
+  if (token === null) {
+    return cachedChartOrUnavailable(identity, input.range, cacheKey, now);
+  }
+
+  const since = chartRangeStart(input.range, now);
+  const query = marketChartQuery(input.range, since !== null);
+  const variables: Record<string, unknown> = {
+    poolId: identity.poolId,
+    tokenAddress: identity.tokenAddress,
+    ...(since === null ? {} : { since: since.toISOString() }),
+  };
+
+  try {
+    const response = await executeBitqueryGraphql(query, variables, {
+      ...input,
+      token,
+    });
+    const evm = record(response.data.EVM);
+    const trading = record(response.data.Trading);
+    if (evm === null || trading === null) {
+      throw new BitqueryMarketDataError("response");
+    }
+    const rows = array(evm?.DEXTrades);
+    const indexedPrice = parseTokenPriceObservation(
+      array(trading?.Tokens)[0],
+      identity,
+    );
+    const parsed = rows.flatMap((row) => {
+      const trade = parseTrade(row, identity);
+      return trade === null ? [] : [trade];
+    });
+    const trades = canonicalTrades(parsed);
+    const supply = parseSupply(array(trading?.Tokens)[0], identity);
+
+    if (rows.length !== parsed.length) {
+      throw new BitqueryMarketDataError("integrity");
+    }
+    if (trades.length === 0) {
+      if (response.partial) throw new BitqueryMarketDataError("response");
+      const waiting: MarketChartV1 = {
+        schemaVersion: PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION,
+        source: "bitquery",
+        status: "waiting-for-first-trade",
+        generatedAt: now.toISOString(),
+        identity,
+        range: input.range,
+        points: [],
+        swapCount: 0,
+        valuation: {
+          status: "unavailable",
+          reason: "waiting-for-first-trade",
+        },
+        truncated: false,
+      };
+      chartCache.set(cacheKey, { storedAt: now.getTime(), value: waiting });
+      return waiting;
+    }
+
+    const truncated = rows.length >= MAXIMUM_CHART_TRADES;
+    const points = chartPoints(trades, input.range);
+    const latest = trades.at(-1) as MarketTradeV1;
+    const latestForValuation = enrichTradeWithIndexedUsd(
+      latest,
+      indexedPrice,
+      now,
+    );
+    const valuation = input.valuation ?? valuationFrom(
+      latestForValuation,
+      supply,
+      now,
+    );
+    const volumeComplete = trades.every(
+      (trade) => trade.amountUsdWad !== undefined,
+    );
+    const volume = volumeComplete
+      ? sumPositiveIntegers(trades.map((trade) => trade.amountUsdWad))
+      : null;
+    const quotePriceComplete = trades.every(
+      (trade) =>
+        trade.priceQuoteWad !== undefined && trade.quoteSymbol !== undefined,
+    );
+    const partial = truncated || response.partial || !quotePriceComplete;
+    const status = partial
+      ? "partial" as const
+      : points.length === 1
+        ? "insufficient-history" as const
+        : "ready" as const;
+    const chart: MarketChartV1 = {
+      schemaVersion: PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION,
+      source: "bitquery",
+      status,
+      generatedAt: now.toISOString(),
+      identity,
+      range: input.range,
+      points,
+      swapCount: trades.length,
+      ...(volume === null ? {} : { volumeUsdWad: volume.toString() }),
+      valuation,
+      asOfTime: latest.time,
+      truncated,
+    };
+    if (!isMarketChartV1(chart)) {
+      throw new BitqueryMarketDataError("integrity");
+    }
+    chartCache.set(cacheKey, { storedAt: now.getTime(), value: chart });
+    return chart;
+  } catch {
+    return cachedChartOrUnavailable(identity, input.range, cacheKey, now);
+  }
+}
+
+export function clearBitqueryMarketDataCachesForTests(): void {
+  marketCache.clear();
+  chartCache.clear();
+}
+
+export function ingestBitqueryMarketStreamPayloadV1(input: Readonly<{
+  identity: MarketDataIdentityV1;
+  payload: Record<string, unknown>;
+  now?: Date;
+}>): MarketPoolDataV1 | null {
+  const now = input.now ?? new Date();
+  const identity = canonicalMarketIdentities([input.identity])[0];
+  if (!identity) throw new BitqueryMarketDataError("integrity");
+  const evm = record(input.payload.EVM);
+  if (evm === null) throw new BitqueryMarketDataError("response");
+  const tradeRows = array(evm.DEXTrades);
+  const liquidityRows = array(evm.DEXPoolEvents);
+  const parsedTrades = tradeRows.flatMap((row) => {
+    const trade = parseTrade(row, identity);
+    return trade === null ? [] : [trade];
+  });
+  if (parsedTrades.length !== tradeRows.length) {
+    throw new BitqueryMarketDataError("integrity");
+  }
+  const parsedLiquidity = liquidityRows.flatMap((row) => {
+    const liquidity = parseLiquidity(row, identity, now);
+    return liquidity === null ? [] : [liquidity];
+  });
+  if (parsedLiquidity.length !== liquidityRows.length) {
+    throw new BitqueryMarketDataError("integrity");
+  }
+  const latestTrade = canonicalTrades(parsedTrades).at(-1) ?? null;
+  const latestLiquidity = parsedLiquidity.sort((first, second) => {
+    const left = BigInt(first.asOfBlock);
+    const right = BigInt(second.asOfBlock);
+    return left === right ? 0 : left < right ? -1 : 1;
+  }).at(-1) ?? null;
+  const existing = marketCache.get(marketCacheKey(identity))?.value;
+  if (latestTrade === null) {
+    if (latestLiquidity === null) return null;
+    if (!existing) return unavailablePool(identity, "source-unavailable");
+    const value: MarketPoolDataV1 = {
+      ...existing,
+      liquidity: latestLiquidity,
+      quality: "partial",
+    };
+    marketCache.set(marketCacheKey(identity), {
+      storedAt: now.getTime(),
+      value,
+    });
+    return value;
+  }
+  const value = marketPoolData({
+    identity,
+    latestTrade,
+    tradeObserved: true,
+    liquidity: latestLiquidity ?? existing?.liquidity ?? null,
+    stats: {
+      ...(existing?.volume24hUsdWad
+        ? { volumeUsdWad: existing.volume24hUsdWad }
+        : {}),
+      ...(existing?.tradeCount24h !== undefined
+        ? { tradeCount: existing.tradeCount24h }
+        : {}),
+    },
+    supply: supplyFromValuation(existing?.valuation),
+    now,
+    partialResponse: true,
+  });
+  marketCache.set(marketCacheKey(identity), {
+    storedAt: now.getTime(),
+    value,
+  });
+  return value;
+}
+
+async function readMarketBatch(
+  identities: readonly MarketDataIdentityV1[],
+  options: BitqueryReaderOptions & Readonly<{ token: string; now: Date }>,
+): Promise<readonly MarketPoolDataV1[]> {
+  const { query, variables } = marketBatchQuery(identities);
+  const response = await executeBitqueryGraphql(query, variables, options);
+  const evm = record(response.data.EVM);
+  const trading = record(response.data.Trading);
+  if (evm === null || trading === null) {
+    throw new BitqueryMarketDataError("response");
+  }
+
+  const tradesByPool = indexUniqueRows(
+    array(evm.latestTrades),
+    tradeRowPoolId,
+  );
+  const liquidityByPool = indexUniqueRows(
+    array(evm.latestLiquidity),
+    liquidityRowPoolId,
+  );
+  const statsByMarket = indexUniqueRows(
+    array(evm.stats),
+    (row) => {
+      const trade = record(record(row)?.Trade);
+      const poolId = canonicalBytes32(trade?.PoolId);
+      const address = canonicalCurrencyAddress(
+        record(trade?.Currency)?.SmartContract,
+      );
+      return poolId && address ? marketStatsKey(poolId, address) : null;
+    },
+  );
+  const supplyByToken = indexUniqueRows(
+    array(trading.tokenSupplies),
+    (row) => canonicalAddress(record(record(row)?.Token)?.Address),
+  );
+  const parsed = identities.map((identity) => {
+    const latestTradeRow = tradesByPool.get(identity.poolId);
+    const latestTradeRows = latestTradeRow === undefined
+      ? []
+      : [latestTradeRow];
+    const tokenRow = supplyByToken.get(identity.tokenAddress);
+    const parsedTrade = parseTrade(latestTradeRows[0], identity);
+    const latestTrade = parsedTrade === null
+      ? null
+      : enrichTradeWithIndexedUsd(
+          parsedTrade,
+          parseTokenPriceObservation(tokenRow, identity),
+          options.now,
+        );
+    return {
+      identity,
+      latestTradeRows,
+      latestTrade,
+      liquidityRow: liquidityByPool.get(identity.poolId),
+      stats: parseStats(statsByMarket.get(
+        marketStatsKey(identity.poolId, identity.tokenAddress),
+      )),
+      supply: parseSupply(tokenRow, identity),
+    };
+  });
+
+  return parsed.map((value) => {
+    const liquidity = parseLiquidity(
+      value.liquidityRow,
+      value.identity,
+      options.now,
+      value.latestTrade,
+    );
+    return marketPoolData({
+      identity: value.identity,
+      latestTrade: value.latestTrade,
+      tradeObserved: value.latestTradeRows.length > 0,
+      liquidity,
+      stats: value.stats,
+      supply: value.supply,
+      now: options.now,
+      partialResponse: response.partial,
+    });
+  });
+}
+
+type TokenPriceObservation = Readonly<{
+  time: string;
+  priceUsdWad: string;
+}>;
+
+function parseTokenPriceObservation(
+  value: unknown,
+  identity: MarketDataIdentityV1,
+): TokenPriceObservation | null {
+  const row = record(value);
+  const token = record(row?.Token);
+  const block = record(row?.Block);
+  const price = record(row?.Price);
+  const ohlc = record(price?.Ohlc);
+  const id = nonEmptyString(token?.Id)?.toLowerCase();
+  if (
+    canonicalAddress(token?.Address) !== identity.tokenAddress ||
+    (id !== `eth:${identity.tokenAddress}` &&
+      id !== `bid:eth:${identity.tokenAddress}`) ||
+    price?.IsQuotedInUsd !== true
+  ) return null;
+  const time = isoTime(block?.Time);
+  const priceUsdWad = decimalToWad(ohlc?.Close);
+  return time === null || priceUsdWad === null
+    ? null
+    : { time, priceUsdWad: priceUsdWad.toString() };
+}
+
+function enrichTradeWithIndexedUsd(
+  trade: MarketTradeV1,
+  indexed: TokenPriceObservation | null,
+  now: Date,
+): MarketTradeV1 {
+  const indexedTime = indexed === null ? Number.NaN : Date.parse(indexed.time);
+  const tradeTime = Date.parse(trade.time);
+  const rawPrice = trade.rawPriceUsdWad === undefined
+    ? null
+    : BigInt(trade.rawPriceUsdWad);
+  const indexedPrice = indexed === null ? null : BigInt(indexed.priceUsdWad);
+  if (
+    indexed === null ||
+    rawPrice === null ||
+    indexedPrice === null ||
+    !Number.isFinite(indexedTime) ||
+    !Number.isFinite(tradeTime) ||
+    indexedTime > now.getTime() + MAXIMUM_FUTURE_SKEW_MS ||
+    Math.abs(indexedTime - tradeTime) > INDEXED_PRICE_MAXIMUM_DISTANCE_MS ||
+    !usdPricesWithinConfidence(rawPrice, indexedPrice)
+  ) return trade;
+  const amountUsdWad = trade.tokenAmount
+    ? multiplyWadByDecimal(indexedPrice, trade.tokenAmount)
+    : null;
+  return {
+    ...trade,
+    priceUsdWad: indexed.priceUsdWad,
+    priceUsdAsOfTime: indexed.time,
+    priceUsdSource: MARKET_DATA_USD_PRICE_SOURCE,
+    ...(amountUsdWad === null ? {} : { amountUsdWad: amountUsdWad.toString() }),
+  };
+}
+
+function usdPricesWithinConfidence(rawPrice: bigint, indexedPrice: bigint): boolean {
+  if (rawPrice <= 0n || indexedPrice <= 0n) return false;
+  const difference = rawPrice > indexedPrice
+    ? rawPrice - indexedPrice
+    : indexedPrice - rawPrice;
+  return difference * 10_000n <=
+    indexedPrice * BigInt(MARKET_DATA_MAXIMUM_RAW_INDEXED_PRICE_DEVIATION_BPS);
+}
+
+async function executeBitqueryGraphql(
+  query: string,
+  variables: Record<string, unknown>,
+  options: BitqueryReaderOptions & Readonly<{ token: string }>,
+): Promise<GraphqlResponse> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const abort = () => controller.abort();
+  options.signal?.addEventListener("abort", abort, { once: true });
+  try {
+    const response = await fetchImpl(BITQUERY_HTTP_ENDPOINT, {
+      method: "POST",
+      redirect: "error",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${options.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new BitqueryMarketDataError("transport");
+    const declared = Number(response.headers.get("content-length") ?? "0");
+    if (
+      (Number.isFinite(declared) && declared > MAXIMUM_RESPONSE_BYTES) ||
+      !response.headers.get("content-type")?.toLowerCase().includes(
+        "application/json",
+      )
+    ) {
+      throw new BitqueryMarketDataError("response");
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > MAXIMUM_RESPONSE_BYTES) {
+      throw new BitqueryMarketDataError("response");
+    }
+    let payload: unknown;
+    try {
+      payload = JSON.parse(new TextDecoder().decode(bytes));
+    } catch {
+      throw new BitqueryMarketDataError("response");
+    }
+    const envelope = record(payload);
+    const data = record(envelope?.data);
+    const errors = array(envelope?.errors);
+    if (data === null) throw new BitqueryMarketDataError("response");
+    return { data, partial: errors.length > 0 };
+  } catch (error) {
+    if (error instanceof BitqueryMarketDataError) throw error;
+    throw new BitqueryMarketDataError("transport");
+  } finally {
+    clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", abort);
+  }
+}
+
+function indexUniqueRows(
+  rows: readonly unknown[],
+  keyFor: (row: unknown) => string | null,
+): ReadonlyMap<string, unknown> {
+  const indexed = new Map<string, unknown>();
+  for (const row of rows) {
+    const key = keyFor(row);
+    if (key === null || indexed.has(key)) {
+      throw new BitqueryMarketDataError("integrity");
+    }
+    indexed.set(key, row);
+  }
+  return indexed;
+}
+
+function tradeRowPoolId(row: unknown): `0x${string}` | null {
+  return canonicalBytes32(record(record(row)?.Trade)?.PoolId);
+}
+
+function liquidityRowPoolId(row: unknown): `0x${string}` | null {
+  const event = record(record(row)?.PoolEvent);
+  return canonicalBytes32(record(event?.Pool)?.PoolId);
+}
+
+function marketStatsKey(
+  poolId: `0x${string}`,
+  tokenAddress: `0x${string}`,
+): string {
+  return `${poolId}:${tokenAddress}`;
+}
+
+function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
+  const pools = identities.map(({ poolId }) => poolId);
+  const tokenAddresses = [...new Set(
+    identities.map(({ tokenAddress }) => tokenAddress),
+  )].sort();
+  const rowLimit = Math.max(1, identities.length);
+  const statsLimit = Math.max(1, identities.length * 2);
+
+  return {
+    query: `query ProgrammableMarketSnapshot(
+      $pools: [String!]!
+      $tokenAddresses: [String!]!
+    ) {
+      EVM(network: eth) {
+        latestTrades: DEXTrades(
+          limit: { count: ${rowLimit} }
+          limitBy: { by: Trade_PoolId, count: 1 }
+          orderBy: { descending: Block_Time }
+          where: {
+            TransactionStatus: { Success: true }
+            Trade: {
+              Dex: { ProtocolName: { is: "uniswap_v4" } }
+              PoolId: { in: $pools }
+            }
+          }
+        ) { ${tradeSelection()} }
+        latestLiquidity: DEXPoolEvents(
+          limit: { count: ${rowLimit} }
+          limitBy: { by: PoolEvent_Pool_PoolId, count: 1 }
+          orderBy: { descending: Block_Time }
+          where: {
+            TransactionStatus: { Success: true }
+            PoolEvent: {
+              Dex: { ProtocolName: { is: "uniswap_v4" } }
+              Pool: { PoolId: { in: $pools } }
+            }
+          }
+        ) { ${liquiditySelection()} }
+        stats: DEXTradeByTokens(
+          limit: { count: ${statsLimit} }
+          where: {
+            TransactionStatus: { Success: true }
+            Block: { Time: { since_relative: { hours_ago: 24 } } }
+            Trade: {
+              Dex: { ProtocolName: { is: "uniswap_v4" } }
+              PoolId: { in: $pools }
+              Currency: { SmartContract: { in: $tokenAddresses } }
+            }
+          }
+        ) {
+          Trade { PoolId Currency { SmartContract } }
+          count
+          volumeUsd: sum(of: Trade_Side_AmountInUSD)
+        }
+      }
+      Trading {
+        tokenSupplies: Tokens(
+          limit: { count: ${tokenAddresses.length} }
+          limitBy: { by: Token_Address, count: 1 }
+          orderBy: { descending: Block_Time }
+          where: { Token: { Address: { in: $tokenAddresses } } }
+        ) { ${supplySelection()} }
+      }
+    }`,
+    variables: { pools, tokenAddresses },
+  };
+}
+
+function marketChartQuery(
+  range: MarketChartV1["range"],
+  withSince: boolean,
+) {
+  const definitions = withSince
+    ? "$poolId: String!, $tokenAddress: String!, $since: DateTime!"
+    : "$poolId: String!, $tokenAddress: String!";
+  const blockFilter = withSince
+    ? "Block: { Time: { since: $since } }"
+    : "";
+  const dataset = range === "all" ? ", dataset: combined" : "";
+  return `query ProgrammableMarketChart(${definitions}) {
+    EVM(network: eth${dataset}) {
+      DEXTrades(
+        limit: { count: ${MAXIMUM_CHART_TRADES} }
+        orderBy: { descending: Block_Time }
+        where: {
+          TransactionStatus: { Success: true }
+          ${blockFilter}
+          Trade: { Dex: { ProtocolName: { is: "uniswap_v4" } }, PoolId: { is: $poolId } }
+        }
+      ) { ${tradeSelection()} }
+    }
+    Trading {
+      Tokens(
+        limit: { count: 1 }
+        orderBy: { descending: Block_Time }
+        where: { Token: { Address: { is: $tokenAddress } } }
+      ) { ${supplySelection()} }
+    }
+  }`;
+}
+
+function tradeSelection() {
+  return `
+    Block { Number Time }
+    Log { Index }
+    Trade {
+      PoolId
+      Buy { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
+      Sell { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
+    }
+    Transaction { Hash }
+  `;
+}
+
+function liquiditySelection() {
+  return `
+    Block { Number Time }
+    PoolEvent {
+      Pool {
+        PoolId
+        CurrencyA { SmartContract Symbol }
+        CurrencyB { SmartContract Symbol }
+      }
+      Liquidity {
+        AmountCurrencyA
+        AmountCurrencyAInUSD
+        AmountCurrencyB
+        AmountCurrencyBInUSD
+      }
+    }
+  `;
+}
+
+function supplySelection() {
+  return `
+    Token { Id Address }
+    Block { Time }
+    Supply {
+      TotalSupply
+      CirculatingSupply
+      MaxSupply
+    }
+    Price {
+      IsQuotedInUsd
+      Ohlc { Close }
+    }
+  `;
+}
+
+function parseTrade(
+  value: unknown,
+  identity: MarketDataIdentityV1,
+): MarketTradeV1 | null {
+  const row = record(value);
+  const block = record(row?.Block);
+  const log = record(row?.Log);
+  const trade = record(row?.Trade);
+  const transaction = record(row?.Transaction);
+  const transactionHash = canonicalTransactionHash(transaction?.Hash);
+  if (
+    !row ||
+    !block ||
+    !log ||
+    !trade ||
+    !transaction ||
+    canonicalBytes32(trade.PoolId) !== identity.poolId ||
+    !canonicalUnsignedInteger(block.Number) ||
+    nonNegativeSafeInteger(log.Index) === null ||
+    transactionHash === null
+  ) return null;
+  const time = isoTime(block.Time);
+  if (time === null) return null;
+  const buy = record(trade.Buy);
+  const sell = record(trade.Sell);
+  const buyCurrency = record(buy?.Currency);
+  const sellCurrency = record(sell?.Currency);
+  const buyAddress = canonicalAddress(buyCurrency?.SmartContract);
+  const sellAddress = canonicalAddress(sellCurrency?.SmartContract);
+  const tokenIsBuy = buyAddress === identity.tokenAddress;
+  const tokenIsSell = sellAddress === identity.tokenAddress;
+  if (tokenIsBuy === tokenIsSell) return null;
+  const tokenSide = tokenIsBuy ? "buy" as const : "sell" as const;
+  const token = tokenIsBuy ? buy : sell;
+  const quoteCurrency = tokenIsBuy ? sellCurrency : buyCurrency;
+  const tokenAmount = positiveDecimal(token?.Amount);
+  const rawPriceUsdWad = decimalToWad(token?.PriceInUSD);
+  const priceQuoteWad = decimalToWad(token?.Price);
+  const quoteAddress = canonicalCurrencyAddress(quoteCurrency?.SmartContract);
+  const quoteSymbol = nonEmptyString(quoteCurrency?.Symbol);
+  if (rawPriceUsdWad === null && priceQuoteWad === null) return null;
+  return {
+    transactionHash,
+    logIndex: Number(log.Index),
+    blockNumber: String(block.Number),
+    time,
+    tokenSide,
+    ...(tokenAmount === null ? {} : { tokenAmount }),
+    ...(rawPriceUsdWad === null
+      ? {}
+      : { rawPriceUsdWad: rawPriceUsdWad.toString() }),
+    ...(priceQuoteWad === null
+      ? {}
+      : { priceQuoteWad: priceQuoteWad.toString() }),
+    ...(quoteAddress === null ? {} : { quoteAddress }),
+    ...(quoteSymbol === null ? {} : { quoteSymbol }),
+  };
+}
+
+function parseLiquidity(
+  value: unknown,
+  identity: MarketDataIdentityV1,
+  now: Date,
+  latestTrade: MarketTradeV1 | null = null,
+): MarketLiquidityV1 | null {
+  const row = record(value);
+  const block = record(row?.Block);
+  const event = record(row?.PoolEvent);
+  const pool = record(event?.Pool);
+  const liquidity = record(event?.Liquidity);
+  if (
+    !block ||
+    !event ||
+    !pool ||
+    !liquidity ||
+    canonicalBytes32(pool.PoolId) !== identity.poolId ||
+    !canonicalUnsignedInteger(block.Number)
+  ) return null;
+  const time = isoTime(block.Time);
+  const currencyA = record(pool.CurrencyA);
+  const currencyB = record(pool.CurrencyB);
+  const addressA = canonicalCurrencyAddress(currencyA?.SmartContract);
+  const addressB = canonicalCurrencyAddress(currencyB?.SmartContract);
+  const amountA = positiveDecimal(liquidity.AmountCurrencyA);
+  const amountB = positiveDecimal(liquidity.AmountCurrencyB);
+  const observedA = decimalToWad(liquidity.AmountCurrencyAInUSD);
+  const observedB = decimalToWad(liquidity.AmountCurrencyBInUSD);
+  const tradePrice = latestTrade?.priceUsdWad
+    ? BigInt(latestTrade.priceUsdWad)
+    : null;
+  const first = observedA ?? deriveLiquiditySideUsd({
+    address: addressA,
+    amount: amountA,
+    identity,
+    eventTime: time,
+    tokenPriceUsdWad: tradePrice,
+    tokenPriceTime: latestTrade?.priceUsdAsOfTime,
+  });
+  const second = observedB ?? deriveLiquiditySideUsd({
+    address: addressB,
+    amount: amountB,
+    identity,
+    eventTime: time,
+    tokenPriceUsdWad: tradePrice,
+    tokenPriceTime: latestTrade?.priceUsdAsOfTime,
+  });
+  if (time === null || first === null || second === null) return null;
+  const total = first + second;
+  const age = now.getTime() - Date.parse(time);
+  if (age < -MAXIMUM_FUTURE_SKEW_MS) return null;
+  return {
+    asOfTime: time,
+    asOfBlock: String(block.Number),
+    valueUsdWad: total.toString(),
+    freshness: age > MARKET_DATA_CURRENT_MAX_AGE_MS ? "stale" : "current",
+  };
+}
+
+function deriveLiquiditySideUsd(input: Readonly<{
+  address: `0x${string}` | null;
+  amount: string | null;
+  identity: MarketDataIdentityV1;
+  eventTime: string | null;
+  tokenPriceUsdWad: bigint | null;
+  tokenPriceTime?: string;
+}>): bigint | null {
+  if (input.address === null || input.amount === null || input.eventTime === null) {
+    return null;
+  }
+  if (
+    input.address === input.identity.tokenAddress &&
+    input.tokenPriceUsdWad !== null &&
+    input.tokenPriceTime &&
+    Math.abs(Date.parse(input.tokenPriceTime) - Date.parse(input.eventTime)) <=
+      INDEXED_PRICE_MAXIMUM_DISTANCE_MS
+  ) {
+    return multiplyWadByDecimal(input.tokenPriceUsdWad, input.amount);
+  }
+  return null;
+}
+
+function parseStats(value: unknown): Readonly<{
+  volumeUsdWad?: string;
+  tradeCount?: number;
+}> {
+  const row = record(value);
+  if (!row) return {};
+  const volume = decimalToWad(row.volumeUsd);
+  const count = nonNegativeSafeInteger(row.count);
+  return {
+    ...(volume === null ? {} : { volumeUsdWad: volume.toString() }),
+    ...(count === null ? {} : { tradeCount: count }),
+  };
+}
+
+type ParsedSupply = Readonly<{
+  asOfTime: string;
+  totalSupply?: string;
+  circulatingSupply?: string;
+  maxSupply?: string;
+}> | null;
+
+function parseSupply(
+  value: unknown,
+  identity: MarketDataIdentityV1,
+): ParsedSupply {
+  const row = record(value);
+  const token = record(row?.Token);
+  const block = record(row?.Block);
+  const supply = record(row?.Supply);
+  if (!token || !block || !supply) return null;
+  const address = canonicalAddress(token.Address);
+  const id = nonEmptyString(token.Id)?.toLowerCase();
+  if (
+    address !== identity.tokenAddress ||
+    (id !== `eth:${identity.tokenAddress}` &&
+      id !== `bid:eth:${identity.tokenAddress}`)
+  ) return null;
+  const asOfTime = isoTime(block.Time);
+  if (asOfTime === null) return null;
+  const totalSupply = positiveDecimal(supply.TotalSupply);
+  const circulatingSupply = positiveDecimal(supply.CirculatingSupply);
+  const maxSupply = positiveDecimal(supply.MaxSupply);
+  return {
+    asOfTime,
+    ...(totalSupply === null ? {} : { totalSupply }),
+    ...(circulatingSupply === null ? {} : { circulatingSupply }),
+    ...(maxSupply === null ? {} : { maxSupply }),
+  };
+}
+
+function marketPoolData(input: Readonly<{
+  identity: MarketDataIdentityV1;
+  latestTrade: MarketTradeV1 | null;
+  tradeObserved: boolean;
+  liquidity: MarketLiquidityV1 | null;
+  stats: Readonly<{ volumeUsdWad?: string; tradeCount?: number }>;
+  supply: ParsedSupply;
+  now: Date;
+  partialResponse: boolean;
+}>): MarketPoolDataV1 {
+  if (input.latestTrade === null) {
+    if (input.tradeObserved || input.partialResponse) {
+      return unavailablePool(
+        input.identity,
+        input.tradeObserved
+          ? "inconsistent-market-data"
+          : "source-unavailable",
+      );
+    }
+    return {
+      identity: input.identity,
+      source: "bitquery",
+      status: "waiting-for-first-trade",
+      quality: input.partialResponse ? "partial" : "complete",
+      ...(input.liquidity === null ? {} : { liquidity: input.liquidity }),
+      valuation: {
+        status: "unavailable",
+        reason: "waiting-for-first-trade",
+      },
+    };
+  }
+  const age = input.now.getTime() - Date.parse(input.latestTrade.time);
+  if (age < -MAXIMUM_FUTURE_SKEW_MS) {
+    return unavailablePool(input.identity, "inconsistent-market-data");
+  }
+  const status = age > MARKET_DATA_CURRENT_MAX_AGE_MS
+    ? "stale" as const
+    : "current" as const;
+  const sourceValuation = valuationFrom(
+    input.latestTrade,
+    input.supply,
+    input.now,
+  );
+  const liquidityValue = input.liquidity === null
+    ? null
+    : BigInt(input.liquidity.valueUsdWad);
+  const valuation = sourceValuation.status === "available" &&
+      (liquidityValue === null ||
+        liquidityValue < BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD))
+    ? { status: "unavailable" as const, reason: "inconsistent-market-data" as const }
+    : sourceValuation.status === "available" && input.liquidity !== null
+      ? {
+          ...sourceValuation,
+          asOfTime: new Date(Math.min(
+            Date.parse(sourceValuation.asOfTime),
+            Date.parse(input.latestTrade.time),
+            Date.parse(input.liquidity.asOfTime),
+          )).toISOString(),
+          freshness: status === "current" &&
+              sourceValuation.freshness === "current" &&
+              input.liquidity.freshness === "current"
+            ? "current" as const
+            : "stale" as const,
+        }
+      : sourceValuation;
+  const quality = input.partialResponse ||
+    input.liquidity === null ||
+    input.liquidity.freshness === "stale" ||
+    input.stats.volumeUsdWad === undefined ||
+    input.stats.tradeCount === undefined ||
+    valuation.status === "unavailable" ||
+    valuation.freshness === "stale"
+      ? "partial" as const
+      : "complete" as const;
+  return {
+    identity: input.identity,
+    source: "bitquery",
+    status,
+    quality,
+    asOfTime: input.latestTrade.time,
+    latestTrade: input.latestTrade,
+    ...(input.liquidity === null ? {} : { liquidity: input.liquidity }),
+    ...(input.stats.volumeUsdWad === undefined
+      ? {}
+      : { volume24hUsdWad: input.stats.volumeUsdWad }),
+    ...(input.stats.tradeCount === undefined
+      ? {}
+      : { tradeCount24h: input.stats.tradeCount }),
+    valuation,
+  };
+}
+
+function valuationFrom(
+  trade: MarketTradeV1,
+  supply: ParsedSupply,
+  now: Date,
+): MarketValuationV1 {
+  if (
+    !trade.priceUsdWad ||
+    !trade.priceUsdAsOfTime ||
+    trade.priceUsdSource !== MARKET_DATA_USD_PRICE_SOURCE ||
+    !trade.rawPriceUsdWad
+  ) {
+    return { status: "unavailable", reason: "price-unavailable" };
+  }
+  if (!supply) {
+    return { status: "unavailable", reason: "supply-unavailable" };
+  }
+  const tradeTime = Date.parse(trade.time);
+  const priceTime = Date.parse(trade.priceUsdAsOfTime);
+  const supplyTime = Date.parse(supply.asOfTime);
+  const priceUsdWad = BigInt(trade.priceUsdWad);
+  const rawPriceUsdWad = BigInt(trade.rawPriceUsdWad);
+  if (
+    !Number.isFinite(tradeTime) ||
+    !Number.isFinite(priceTime) ||
+    !Number.isFinite(supplyTime) ||
+    Math.abs(tradeTime - priceTime) > INDEXED_PRICE_MAXIMUM_DISTANCE_MS ||
+    Math.abs(priceTime - supplyTime) > SUPPLY_PRICE_MAXIMUM_DISTANCE_MS ||
+    !usdPricesWithinConfidence(rawPriceUsdWad, priceUsdWad) ||
+    tradeTime > now.getTime() + MAXIMUM_FUTURE_SKEW_MS ||
+    priceTime > now.getTime() + MAXIMUM_FUTURE_SKEW_MS ||
+    supplyTime > now.getTime() + MAXIMUM_FUTURE_SKEW_MS
+  ) {
+    return { status: "unavailable", reason: "inconsistent-market-data" };
+  }
+  const total = supply.totalSupply
+    ? multiplyWadByDecimal(priceUsdWad, supply.totalSupply)
+    : null;
+  if (
+    supply.maxSupply &&
+    supply.totalSupply &&
+    comparePositiveDecimals(supply.totalSupply, supply.maxSupply) > 0
+  ) {
+    return { status: "unavailable", reason: "inconsistent-market-data" };
+  }
+  const valuationTime = Math.min(tradeTime, priceTime, supplyTime);
+  const asOfTime = new Date(valuationTime).toISOString();
+  const freshness = now.getTime() - valuationTime > MARKET_DATA_CURRENT_MAX_AGE_MS
+    ? "stale" as const
+    : "current" as const;
+  if (total !== null && supply.totalSupply) {
+    return {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      valueUsdWad: total.toString(),
+      fdvUsdWad: total.toString(),
+      totalSupply: supply.totalSupply,
+      ...(supply.maxSupply ? { maxSupply: supply.maxSupply } : {}),
+      asOfTime,
+      freshness,
+    };
+  }
+  return { status: "unavailable", reason: "supply-unavailable" };
+}
+
+function supplyFromValuation(
+  value: MarketValuationV1 | undefined,
+): ParsedSupply {
+  if (!value || value.status !== "available") return null;
+  return {
+    asOfTime: value.asOfTime,
+    ...(value.totalSupply ? { totalSupply: value.totalSupply } : {}),
+    ...(value.circulatingSupply
+      ? { circulatingSupply: value.circulatingSupply }
+      : {}),
+    ...(value.maxSupply ? { maxSupply: value.maxSupply } : {}),
+  };
+}
+
+function groupTokenMarketData(
+  identities: readonly MarketDataIdentityV1[],
+  pools: ReadonlyMap<string, MarketPoolDataV1>,
+  now: Date,
+): ReadonlyMap<string, TokenMarketDataV1> {
+  const grouped = new Map<string, MarketPoolDataV1[]>();
+  for (const identity of identities) {
+    const value = pools.get(identity.poolId) ?? unavailablePool(
+      identity,
+      "source-unavailable",
+    );
+    const existing = grouped.get(identity.tokenAddress) ?? [];
+    existing.push(value);
+    grouped.set(identity.tokenAddress, existing);
+  }
+  const output = new Map<string, TokenMarketDataV1>();
+  for (const [address, values] of grouped) {
+    const primary = selectPrimaryMarketPoolV1(values);
+    const status = primary === null || primary.status === "unavailable"
+      ? "unavailable" as const
+      : primary.status === "waiting-for-first-trade"
+        ? "waiting-for-first-trade" as const
+        : primary.status === "stale"
+          ? "stale" as const
+          : values.some((value) => value.quality !== "complete")
+            ? "partial" as const
+            : "current" as const;
+    output.set(address, {
+      schemaVersion: PROGRAMMABLE_MARKET_DATA_SCHEMA_VERSION,
+      source: "bitquery",
+      generatedAt: now.toISOString(),
+      status,
+      primaryPoolId: primary?.identity.poolId ?? null,
+      pools: values,
+    });
+  }
+  return output;
+}
+
+function canonicalMarketIdentities(
+  identities: readonly MarketDataIdentityV1[],
+): MarketDataIdentityV1[] {
+  const byPool = new Map<string, MarketDataIdentityV1>();
+  for (const identity of identities) {
+    const tokenAddress = canonicalAddress(identity.tokenAddress);
+    const poolId = canonicalBytes32(identity.poolId);
+    if (
+      identity.chainId !== "1" ||
+      identity.protocol !== "uniswap_v4" ||
+      tokenAddress === null ||
+      poolId === null
+    ) throw new BitqueryMarketDataError("integrity");
+    const normalized = {
+      chainId: "1" as const,
+      tokenAddress,
+      poolId,
+      protocol: "uniswap_v4" as const,
+    };
+    const existing = byPool.get(poolId);
+    if (existing && existing.tokenAddress !== tokenAddress) {
+      throw new BitqueryMarketDataError("integrity");
+    }
+    byPool.set(poolId, normalized);
+  }
+  return [...byPool.values()].sort((a, b) => a.poolId.localeCompare(b.poolId));
+}
+
+function unavailablePool(
+  identity: MarketDataIdentityV1,
+  reason: Extract<MarketValuationV1, { status: "unavailable" }>["reason"],
+): MarketPoolDataV1 {
+  return {
+    identity,
+    source: "bitquery",
+    status: "unavailable",
+    quality: "unavailable",
+    valuation: { status: "unavailable", reason },
+  };
+}
+
+function cachedOrUnavailable(
+  identity: MarketDataIdentityV1,
+  now: Date,
+): MarketPoolDataV1 {
+  const cached = marketCache.get(marketCacheKey(identity));
+  if (!cached || now.getTime() - cached.storedAt > MARKET_CACHE_MAX_AGE_MS) {
+    return unavailablePool(identity, "source-unavailable");
+  }
+  return {
+    ...cached.value,
+    status: cached.value.status === "waiting-for-first-trade"
+      ? "waiting-for-first-trade"
+      : "stale",
+    quality: "partial",
+    valuation: cached.value.valuation.status === "available"
+      ? { ...cached.value.valuation, freshness: "stale" }
+      : cached.value.valuation,
+  };
+}
+
+function cachedChartOrUnavailable(
+  identity: MarketDataIdentityV1,
+  range: MarketChartV1["range"],
+  key: string,
+  now: Date,
+): MarketChartV1 {
+  const cached = chartCache.get(key);
+  if (cached && now.getTime() - cached.storedAt <= CHART_CACHE_MAX_AGE_MS) {
+    return {
+      ...cached.value,
+      status: cached.value.points.length === 0
+        ? "waiting-for-first-trade"
+        : "partial",
+      generatedAt: now.toISOString(),
+      valuation: cached.value.valuation.status === "available"
+        ? { ...cached.value.valuation, freshness: "stale" }
+        : cached.value.valuation,
+    };
+  }
+  return {
+    schemaVersion: PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION,
+    source: "bitquery",
+    status: "unavailable",
+    generatedAt: now.toISOString(),
+    identity,
+    range,
+    points: [],
+    swapCount: 0,
+    valuation: { status: "unavailable", reason: "source-unavailable" },
+    truncated: false,
+  };
+}
+
+function chartRangeStart(range: MarketChartV1["range"], now: Date): Date | null {
+  const duration = range === "1h"
+    ? 60 * 60 * 1_000
+    : range === "1d"
+      ? 24 * 60 * 60 * 1_000
+      : range === "1w"
+        ? 7 * 24 * 60 * 60 * 1_000
+        : null;
+  return duration === null ? null : new Date(now.getTime() - duration);
+}
+
+function canonicalTrades(trades: readonly MarketTradeV1[]): MarketTradeV1[] {
+  const sorted = [...trades].sort((first, second) => {
+    const block = BigInt(first.blockNumber) - BigInt(second.blockNumber);
+    if (block !== 0n) return block < 0n ? -1 : 1;
+    const time = Date.parse(first.time) - Date.parse(second.time);
+    if (time !== 0) return time;
+    const transaction = first.transactionHash.localeCompare(
+      second.transactionHash,
+    );
+    return transaction !== 0 ? transaction : first.logIndex - second.logIndex;
+  });
+  const byKey = new Map<string, MarketTradeV1>();
+  for (const trade of sorted) {
+    const key = [
+      trade.blockNumber,
+      trade.transactionHash,
+      trade.logIndex,
+    ].join(":");
+    byKey.set(key, trade);
+  }
+  return [...byKey.values()];
+}
+
+function chartPoints(
+  trades: readonly MarketTradeV1[],
+  range: MarketChartV1["range"],
+): MarketChartPointV1[] {
+  const duration = chartBucketDurationMs(trades, range);
+  const buckets = new Map<number, MarketTradeV1[]>();
+  for (const trade of trades) {
+    const time = Date.parse(trade.time);
+    const key = Math.floor(time / duration);
+    const values = buckets.get(key) ?? [];
+    values.push(trade);
+    buckets.set(key, values);
+  }
+  return [...buckets.values()].map(chartPoint);
+}
+
+function chartBucketDurationMs(
+  trades: readonly MarketTradeV1[],
+  range: MarketChartV1["range"],
+): number {
+  if (range === "1h") return 60_000;
+  if (range === "1d") return 20 * 60_000;
+  if (range === "1w") return 3 * 60 * 60_000;
+  const first = Date.parse(trades[0]?.time ?? "");
+  const last = Date.parse(trades.at(-1)?.time ?? "");
+  if (!Number.isFinite(first) || !Number.isFinite(last) || last <= first) {
+    return 1;
+  }
+  return Math.max(1, Math.ceil((last - first + 1) / MAXIMUM_CHART_POINTS));
+}
+
+function chartPoint(trades: readonly MarketTradeV1[]): MarketChartPointV1 {
+  const trade = trades.at(-1) as MarketTradeV1;
+  const usdComplete = trades.every((value) => value.priceUsdWad !== undefined);
+  const quoteComplete = trades.every(
+    (value) =>
+      value.priceQuoteWad !== undefined && value.quoteSymbol !== undefined,
+  );
+  const volumeComplete = trades.every(
+    (value) => value.amountUsdWad !== undefined,
+  );
+  const usd = usdComplete
+    ? trades.map((value) => BigInt(value.priceUsdWad as string))
+    : [];
+  const quote = quoteComplete
+    ? trades.map((value) => BigInt(value.priceQuoteWad as string))
+    : [];
+  const quoteSymbols = new Set(
+    trades.map((value) => value.quoteSymbol).filter(
+      (value): value is string => Boolean(value),
+    ),
+  );
+  const ohlcUsd = marketOhlc(usd);
+  const ohlcQuote = quoteSymbols.size === 1 ? marketOhlc(quote) : null;
+  const volume = volumeComplete
+    ? sumPositiveIntegers(trades.map((value) => value.amountUsdWad))
+    : null;
+  return {
+    blockNumber: trade.blockNumber,
+    time: trade.time,
+    ...(ohlcUsd
+      ? { priceUsd: ohlcUsd.close, ohlcUsd }
+      : {}),
+    ...(ohlcQuote
+      ? { priceQuote: ohlcQuote.close, ohlcQuote }
+      : {}),
+    ...(quoteSymbols.size === 1
+      ? { quoteSymbol: [...quoteSymbols][0] }
+      : {}),
+    ...(volume === null ? {} : { volumeUsdWad: volume.toString() }),
+    tradeCount: trades.length,
+  };
+}
+
+function marketOhlc(values: readonly bigint[]): MarketOhlcV1 | null {
+  if (values.length === 0) return null;
+  let high = values[0];
+  let low = values[0];
+  for (const value of values.slice(1)) {
+    if (value > high) high = value;
+    if (value < low) low = value;
+  }
+  return {
+    open: wadToDecimal(values[0]),
+    high: wadToDecimal(high),
+    low: wadToDecimal(low),
+    close: wadToDecimal(values.at(-1) as bigint),
+  };
+}
+
+function marketCacheKey(identity: MarketDataIdentityV1): string {
+  return `${identity.chainId}:${identity.tokenAddress}:${identity.poolId}`;
+}
+
+function resolveToken(explicit: string | null | undefined): string | null {
+  const value = explicit === undefined
+    ? process.env[BITQUERY_OAUTH_TOKEN_ENVIRONMENT_VARIABLE]
+    : explicit;
+  return typeof value === "string" && value.trim().length >= 16
+    ? value.trim()
+    : null;
+}
+
+function canonicalAddress(value: unknown): `0x${string}` | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return ADDRESS.test(normalized) ? normalized as `0x${string}` : null;
+}
+
+function canonicalCurrencyAddress(value: unknown): `0x${string}` | null {
+  if (value === "0x") return "0x0000000000000000000000000000000000000000";
+  return canonicalAddress(value);
+}
+
+function canonicalBytes32(value: unknown): `0x${string}` | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return BYTES32.test(normalized) ? normalized as `0x${string}` : null;
+}
+
+function canonicalTransactionHash(value: unknown): `0x${string}` | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return TRANSACTION_HASH.test(normalized)
+    ? normalized as `0x${string}`
+    : null;
+}
+
+function canonicalUnsignedInteger(value: unknown): value is string {
+  const normalized = typeof value === "number" && Number.isSafeInteger(value)
+    ? String(value)
+    : value;
+  return typeof normalized === "string" &&
+    CANONICAL_UNSIGNED_INTEGER.test(normalized);
+}
+
+function positiveDecimal(value: unknown): string | null {
+  const normalized = decimalString(value);
+  return normalized !== null && !/^0(?:\.0+)?$/u.test(normalized)
+    ? normalized
+    : null;
+}
+
+function decimalString(value: unknown): string | null {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value < 0) return null;
+    const expanded = value.toLocaleString("en-US", {
+      useGrouping: false,
+      maximumFractionDigits: 20,
+    });
+    return /^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/u.test(expanded)
+      ? expanded
+      : null;
+  }
+  if (
+    typeof value !== "string" ||
+    !/^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/u.test(value)
+  ) return null;
+  return value;
+}
+
+function decimalToWad(value: unknown): bigint | null {
+  const normalized = positiveDecimal(value);
+  if (normalized === null) return null;
+  const [whole, fraction = ""] = normalized.split(".");
+  const wad = BigInt(whole) * 10n ** 18n +
+    BigInt(fraction.slice(0, 18).padEnd(18, "0") || "0");
+  return wad > 0n ? wad : null;
+}
+
+function decimalParts(value: string): Readonly<{
+  coefficient: bigint;
+  scale: bigint;
+}> {
+  const [whole, fraction = ""] = value.split(".");
+  return {
+    coefficient: BigInt(`${whole}${fraction}`),
+    scale: 10n ** BigInt(fraction.length),
+  };
+}
+
+function multiplyWadByDecimal(wad: bigint, value: string): bigint | null {
+  const parsed = decimalParts(value);
+  const result = wad * parsed.coefficient / parsed.scale;
+  return result > 0n ? result : null;
+}
+
+function comparePositiveDecimals(first: string, second: string): number {
+  const a = decimalParts(first);
+  const b = decimalParts(second);
+  const comparison = a.coefficient * b.scale - b.coefficient * a.scale;
+  return comparison === 0n ? 0 : comparison > 0n ? 1 : -1;
+}
+
+function wadToDecimal(value: bigint): string {
+  const raw = value.toString().padStart(19, "0");
+  const whole = raw.slice(0, -18);
+  const fraction = raw.slice(-18).replace(/0+$/u, "");
+  return fraction ? `${whole}.${fraction}` : whole;
+}
+
+function sumPositiveIntegers(
+  values: readonly (string | undefined)[],
+): bigint | null {
+  let found = false;
+  let total = 0n;
+  for (const value of values) {
+    if (!value || !CANONICAL_UNSIGNED_INTEGER.test(value)) continue;
+    total += BigInt(value);
+    found = true;
+  }
+  return found && total > 0n ? total : null;
+}
+
+function isoTime(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() !== ""
+    ? value.trim()
+    : null;
+}
+
+function nonNegativeSafeInteger(value: unknown): number | null {
+  const normalized = typeof value === "string" && /^\d+$/u.test(value)
+    ? Number(value)
+    : value;
+  return typeof normalized === "number" &&
+    Number.isSafeInteger(normalized) &&
+    normalized >= 0
+    ? normalized
+    : null;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function array(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -259,7 +259,6 @@ function ageCachedTokenMarketData(
             : "current" as const;
     output.set(address, {
       ...value,
-      generatedAt: now.toISOString(),
       status,
       pools,
     });
@@ -337,6 +336,7 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       const waiting: MarketChartV1 = {
         schemaVersion: PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION,
         source: "bitquery",
+        readStatus: "live",
         status: "waiting-for-first-trade",
         generatedAt: now.toISOString(),
         identity,
@@ -385,6 +385,7 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
     const chart: MarketChartV1 = {
       schemaVersion: PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION,
       source: "bitquery",
+      readStatus: "live",
       status,
       generatedAt: now.toISOString(),
       identity,
@@ -1363,15 +1364,15 @@ function cachedChartOrUnavailable(
     if (cached.value.points.length === 0) {
       return {
         ...cached.value,
+        readStatus: "cache-fallback",
         status: "unavailable",
-        generatedAt: now.toISOString(),
         valuation: { status: "unavailable", reason: "source-unavailable" },
       };
     }
     return {
       ...cached.value,
+      readStatus: "cache-fallback",
       status: "partial",
-      generatedAt: now.toISOString(),
       valuation: cached.value.valuation.status === "available"
         ? { ...cached.value.valuation, freshness: "stale" }
         : cached.value.valuation,
@@ -1380,6 +1381,7 @@ function cachedChartOrUnavailable(
   return {
     schemaVersion: PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION,
     source: "bitquery",
+    readStatus: "cache-fallback",
     status: "unavailable",
     generatedAt: now.toISOString(),
     identity,

--- a/lib/market-data/explore-market-identities.ts
+++ b/lib/market-data/explore-market-identities.ts
@@ -1,0 +1,84 @@
+import type { ExploreEntry } from "../tokens";
+import type { MarketDataIdentityV1 } from "./market-data-v1";
+
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const BYTES32 = /^0x[0-9a-f]{64}$/u;
+
+export function exploreEntryMarketIdentitiesV1(
+  entry: ExploreEntry,
+): readonly MarketDataIdentityV1[] {
+  const tokenAddress = canonicalAddress(entry.tokenAddress);
+  if (tokenAddress === null) return [];
+  if (entry.exploreKind === "token") {
+    const chainId = entry.launchStampProvenance?.chainId ??
+      parseChainIdFromTokenId(entry.id);
+    const poolId = canonicalPoolId(entry.poolId);
+    return chainId === 1 && poolId !== null
+      ? [{
+          chainId: "1",
+          tokenAddress,
+          poolId,
+          protocol: "uniswap_v4",
+        }]
+      : [];
+  }
+  if (entry.chainId !== "1") return [];
+  const byPool = new Map<string, MarketDataIdentityV1>();
+  for (const market of entry.markets) {
+    const poolId = canonicalPoolId(market.poolId);
+    if (poolId === null || market.status === "verification_pending") continue;
+    const base = canonicalAddress(market.baseAsset.identity.value);
+    const quote = canonicalAddress(market.quoteAsset.identity.value);
+    if (base !== tokenAddress && quote !== tokenAddress) continue;
+    byPool.set(poolId, {
+      chainId: "1",
+      tokenAddress,
+      poolId,
+      protocol: "uniswap_v4",
+    });
+  }
+  return [...byPool.values()].sort((first, second) =>
+    first.poolId.localeCompare(second.poolId)
+  );
+}
+
+export function exploreEntriesMarketIdentitiesV1(
+  entries: readonly ExploreEntry[],
+): readonly MarketDataIdentityV1[] {
+  const byPool = new Map<string, MarketDataIdentityV1>();
+  const conflictedPools = new Set<string>();
+  for (const entry of entries) {
+    for (const identity of exploreEntryMarketIdentitiesV1(entry)) {
+      if (conflictedPools.has(identity.poolId)) continue;
+      const existing = byPool.get(identity.poolId);
+      if (existing && existing.tokenAddress !== identity.tokenAddress) {
+        byPool.delete(identity.poolId);
+        conflictedPools.add(identity.poolId);
+        continue;
+      }
+      byPool.set(identity.poolId, identity);
+    }
+  }
+  return [...byPool.values()].sort((first, second) =>
+    first.poolId.localeCompare(second.poolId)
+  );
+}
+
+function parseChainIdFromTokenId(value: string): number | null {
+  const [chainId] = value.split(":", 1);
+  if (!chainId || !/^\d+$/u.test(chainId)) return null;
+  const parsed = Number(chainId);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function canonicalAddress(value: unknown): `0x${string}` | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return ADDRESS.test(normalized) ? normalized as `0x${string}` : null;
+}
+
+function canonicalPoolId(value: unknown): `0x${string}` | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return BYTES32.test(normalized) ? normalized as `0x${string}` : null;
+}

--- a/lib/market-data/market-data-v1.ts
+++ b/lib/market-data/market-data-v1.ts
@@ -54,6 +54,7 @@ export type MarketValuationV1 =
 
 export type MarketTradeV1 = Readonly<{
   transactionHash: `0x${string}`;
+  transactionIndex?: number;
   logIndex: number;
   blockNumber: string;
   time: string;
@@ -414,6 +415,9 @@ function isMarketTradeV1(value: unknown): value is MarketTradeV1 {
     value.priceUsdAsOfTime !== undefined || value.priceUsdSource !== undefined;
   return typeof value.transactionHash === "string" &&
     TRANSACTION_HASH.test(value.transactionHash) &&
+    (value.transactionIndex === undefined ||
+      (Number.isSafeInteger(value.transactionIndex) &&
+        Number(value.transactionIndex) >= 0)) &&
     Number.isSafeInteger(value.logIndex) &&
     Number(value.logIndex) >= 0 &&
     CANONICAL_UNSIGNED_INTEGER.test(String(value.blockNumber)) &&

--- a/lib/market-data/market-data-v1.ts
+++ b/lib/market-data/market-data-v1.ts
@@ -1,0 +1,535 @@
+export const PROGRAMMABLE_MARKET_DATA_SCHEMA_VERSION =
+  "programmable.market-data.v1" as const;
+
+export const PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION =
+  "programmable.market-chart.v1" as const;
+
+export const PROGRAMMABLE_MARKET_CHART_ERROR_SCHEMA_VERSION =
+  "programmable.market-chart-error.v1" as const;
+
+export const MARKET_DATA_CURRENT_MAX_AGE_MS = 5 * 60 * 1_000;
+
+// A public current FDV needs enough exact-pool depth to make a single dust
+// trade an insufficient price signal. This is deliberately conservative: a
+// launch remains discoverable when it is below the threshold, but its USD FDV
+// is unavailable instead of being ranked from an unsafe observation.
+export const MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD =
+  "10000000000000000000000" as const;
+export const MARKET_DATA_MAXIMUM_RAW_INDEXED_PRICE_DEVIATION_BPS = 1_000 as const;
+export const MARKET_DATA_USD_PRICE_SOURCE =
+  "bitquery-token-price-index-v1" as const;
+
+export type MarketDataIdentityV1 = Readonly<{
+  chainId: "1";
+  tokenAddress: `0x${string}`;
+  poolId: `0x${string}`;
+  protocol: "uniswap_v4";
+}>;
+
+export type MarketDataFreshnessV1 = "current" | "stale";
+
+export type MarketValuationV1 =
+  | Readonly<{
+      status: "available";
+      metric: "market-cap" | "fdv";
+      supplyBasis: "circulating" | "total";
+      valueUsdWad: string;
+      fdvUsdWad?: string;
+      marketCapUsdWad?: string;
+      totalSupply?: string;
+      circulatingSupply?: string;
+      maxSupply?: string;
+      asOfTime: string;
+      freshness: MarketDataFreshnessV1;
+    }>
+  | Readonly<{
+      status: "unavailable";
+      reason:
+        | "waiting-for-first-trade"
+        | "price-unavailable"
+        | "supply-unavailable"
+        | "source-unavailable"
+        | "inconsistent-market-data";
+    }>;
+
+export type MarketTradeV1 = Readonly<{
+  transactionHash: `0x${string}`;
+  logIndex: number;
+  blockNumber: string;
+  time: string;
+  tokenSide: "buy" | "sell";
+  tokenAmount?: string;
+  amountUsdWad?: string;
+  priceUsdWad?: string;
+  priceUsdAsOfTime?: string;
+  priceUsdSource?: typeof MARKET_DATA_USD_PRICE_SOURCE;
+  rawPriceUsdWad?: string;
+  priceQuoteWad?: string;
+  quoteAddress?: `0x${string}`;
+  quoteSymbol?: string;
+}>;
+
+export type MarketLiquidityV1 = Readonly<{
+  asOfTime: string;
+  asOfBlock: string;
+  valueUsdWad: string;
+  freshness: MarketDataFreshnessV1;
+}>;
+
+export type MarketPoolDataV1 = Readonly<{
+  identity: MarketDataIdentityV1;
+  source: "bitquery";
+  status:
+    | "current"
+    | "stale"
+    | "waiting-for-first-trade"
+    | "unavailable";
+  quality: "complete" | "partial" | "unavailable";
+  asOfTime?: string;
+  latestTrade?: MarketTradeV1;
+  liquidity?: MarketLiquidityV1;
+  volume24hUsdWad?: string;
+  tradeCount24h?: number;
+  valuation: MarketValuationV1;
+}>;
+
+export type TokenMarketDataV1 = Readonly<{
+  schemaVersion: typeof PROGRAMMABLE_MARKET_DATA_SCHEMA_VERSION;
+  source: "bitquery";
+  generatedAt: string;
+  status:
+    | "current"
+    | "partial"
+    | "stale"
+    | "waiting-for-first-trade"
+    | "unavailable";
+  primaryPoolId: `0x${string}` | null;
+  pools: readonly MarketPoolDataV1[];
+}>;
+
+export type MarketChartPointV1 = Readonly<{
+  blockNumber: string;
+  time: string;
+  priceUsd?: string;
+  priceQuote?: string;
+  quoteSymbol?: string;
+  ohlcUsd?: MarketOhlcV1;
+  ohlcQuote?: MarketOhlcV1;
+  volumeUsdWad?: string;
+  tradeCount: number;
+}>;
+
+export type MarketOhlcV1 = Readonly<{
+  open: string;
+  high: string;
+  low: string;
+  close: string;
+}>;
+
+export type MarketChartV1 = Readonly<{
+  schemaVersion: typeof PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION;
+  source: "bitquery";
+  status:
+    | "ready"
+    | "insufficient-history"
+    | "partial"
+    | "waiting-for-first-trade"
+    | "unavailable";
+  generatedAt: string;
+  identity: MarketDataIdentityV1;
+  range: "1h" | "1d" | "1w" | "all";
+  points: readonly MarketChartPointV1[];
+  swapCount: number;
+  volumeUsdWad?: string;
+  valuation: MarketValuationV1;
+  asOfTime?: string;
+  truncated: boolean;
+}>;
+
+export type MarketChartErrorV1 = Readonly<{
+  schemaVersion: typeof PROGRAMMABLE_MARKET_CHART_ERROR_SCHEMA_VERSION;
+  source: "bitquery";
+  status: "unavailable";
+  generatedAt: string;
+  address: `0x${string}`;
+  range: MarketChartV1["range"];
+  reason: "identity-unavailable" | "market-data-unavailable";
+  error: string;
+}>;
+
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const BYTES32 = /^0x[0-9a-f]{64}$/u;
+const TRANSACTION_HASH = /^0x[0-9a-f]{64}$/u;
+const CANONICAL_UNSIGNED_INTEGER = /^(?:0|[1-9][0-9]*)$/u;
+
+export function isMarketDataIdentityV1(
+  value: unknown,
+): value is MarketDataIdentityV1 {
+  if (!isRecord(value)) return false;
+  return value.chainId === "1" &&
+    typeof value.tokenAddress === "string" &&
+    ADDRESS.test(value.tokenAddress) &&
+    value.tokenAddress === value.tokenAddress.toLowerCase() &&
+    typeof value.poolId === "string" &&
+    BYTES32.test(value.poolId) &&
+    value.poolId === value.poolId.toLowerCase() &&
+    value.protocol === "uniswap_v4";
+}
+
+export function isMarketValuationV1(
+  value: unknown,
+): value is MarketValuationV1 {
+  if (!isRecord(value)) return false;
+  if (value.status === "unavailable") {
+    return [
+      "waiting-for-first-trade",
+      "price-unavailable",
+      "supply-unavailable",
+      "source-unavailable",
+      "inconsistent-market-data",
+    ].includes(String(value.reason));
+  }
+  if (
+    value.status !== "available" ||
+    !["market-cap", "fdv"].includes(String(value.metric)) ||
+    !["circulating", "total"].includes(String(value.supplyBasis)) ||
+    !positiveInteger(value.valueUsdWad) ||
+    !optionalPositiveInteger(value.fdvUsdWad) ||
+    !optionalPositiveInteger(value.marketCapUsdWad) ||
+    !optionalPositiveDecimal(value.totalSupply) ||
+    !optionalPositiveDecimal(value.circulatingSupply) ||
+    !optionalPositiveDecimal(value.maxSupply) ||
+    !validIsoTime(value.asOfTime) ||
+    !["current", "stale"].includes(String(value.freshness))
+  ) {
+    return false;
+  }
+  if (value.metric === "market-cap") {
+    return value.supplyBasis === "circulating" &&
+      positiveInteger(value.marketCapUsdWad) &&
+      positiveDecimal(value.circulatingSupply);
+  }
+  return value.supplyBasis === "total" &&
+    positiveInteger(value.fdvUsdWad) &&
+    positiveDecimal(value.totalSupply);
+}
+
+export function isTokenMarketDataV1(
+  value: unknown,
+): value is TokenMarketDataV1 {
+  if (!isRecord(value)) return false;
+  if (
+    value.schemaVersion !== PROGRAMMABLE_MARKET_DATA_SCHEMA_VERSION ||
+    value.source !== "bitquery" ||
+    !validIsoTime(value.generatedAt) ||
+    ![
+      "current",
+      "partial",
+      "stale",
+      "waiting-for-first-trade",
+      "unavailable",
+    ].includes(String(value.status)) ||
+    !Array.isArray(value.pools) ||
+    (value.primaryPoolId !== null &&
+      (typeof value.primaryPoolId !== "string" ||
+        !BYTES32.test(value.primaryPoolId)))
+  ) {
+    return false;
+  }
+  const pools = value.pools as unknown[];
+  if (!pools.every(isMarketPoolDataV1)) return false;
+  const poolIds = new Set(
+    pools.map((pool) => (pool as MarketPoolDataV1).identity.poolId),
+  );
+  return poolIds.size === pools.length &&
+    (value.primaryPoolId === null || poolIds.has(value.primaryPoolId as `0x${string}`));
+}
+
+export function isMarketChartV1(value: unknown): value is MarketChartV1 {
+  if (!isRecord(value)) return false;
+  if (
+    value.schemaVersion !== PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION ||
+    value.source !== "bitquery" ||
+    ![
+      "ready",
+      "insufficient-history",
+      "partial",
+      "waiting-for-first-trade",
+      "unavailable",
+    ].includes(String(value.status)) ||
+    !validIsoTime(value.generatedAt) ||
+    !isMarketDataIdentityV1(value.identity) ||
+    !["1h", "1d", "1w", "all"].includes(String(value.range)) ||
+    !Array.isArray(value.points) ||
+    !Number.isSafeInteger(value.swapCount) ||
+    Number(value.swapCount) < 0 ||
+    typeof value.truncated !== "boolean" ||
+    !optionalPositiveInteger(value.volumeUsdWad) ||
+    !isMarketValuationV1(value.valuation) ||
+    (value.asOfTime !== undefined && !validIsoTime(value.asOfTime))
+  ) {
+    return false;
+  }
+  const points = value.points as unknown[];
+  if (!points.every(isMarketChartPointV1)) return false;
+  const typedPoints = points as MarketChartPointV1[];
+  let previousBlock: bigint | null = null;
+  let previousTime = Number.NEGATIVE_INFINITY;
+  for (const point of typedPoints) {
+    const block = BigInt(point.blockNumber);
+    const time = Date.parse(point.time);
+    if (
+      (previousBlock !== null && block <= previousBlock) ||
+      time < previousTime
+    ) return false;
+    previousBlock = block;
+    previousTime = time;
+  }
+  const observedTrades = typedPoints.reduce(
+    (total, point) => total + point.tradeCount,
+    0,
+  );
+  if (observedTrades !== value.swapCount) return false;
+  if (value.volumeUsdWad !== undefined) {
+    if (typedPoints.some((point) => point.volumeUsdWad === undefined)) {
+      return false;
+    }
+    const pointVolume = typedPoints.reduce(
+      (total, point) => total + BigInt(point.volumeUsdWad as string),
+      0n,
+    );
+    if (pointVolume.toString() !== value.volumeUsdWad) return false;
+  }
+  if (typedPoints.length === 0) {
+    if (
+      value.swapCount !== 0 ||
+      value.volumeUsdWad !== undefined ||
+      value.asOfTime !== undefined
+    ) return false;
+  } else if (value.asOfTime !== typedPoints.at(-1)?.time) {
+    return false;
+  }
+  if (value.status === "ready") {
+    return typedPoints.length >= 2 && value.truncated === false;
+  }
+  if (value.status === "insufficient-history") {
+    return typedPoints.length === 1 && value.truncated === false;
+  }
+  if (value.status === "partial") return typedPoints.length > 0;
+  return typedPoints.length === 0;
+}
+
+export function marketDataStatusLabel(
+  value: TokenMarketDataV1 | undefined,
+):
+  | "Waiting for first trade"
+  | "Last verified"
+  | "Limited market data"
+  | "Unavailable"
+  | undefined {
+  if (!value || value.status === "unavailable") return "Unavailable";
+  if (value.status === "waiting-for-first-trade") {
+    return "Waiting for first trade";
+  }
+  if (value.status === "stale") return "Last verified";
+  const primary = value.pools.find(
+    (pool) => pool.identity.poolId === value.primaryPoolId,
+  );
+  if (primary?.status === "waiting-for-first-trade") {
+    return "Waiting for first trade";
+  }
+  if (primary?.status === "stale") return "Last verified";
+  if (!primary || primary.status === "unavailable") return "Unavailable";
+  if (
+    primary.valuation.status === "available" &&
+    primary.valuation.freshness === "stale"
+  ) return "Last verified";
+  if (value.status === "partial" || primary.quality === "partial") {
+    return "Limited market data";
+  }
+  return undefined;
+}
+
+export function selectPrimaryMarketPoolV1(
+  pools: readonly MarketPoolDataV1[],
+): MarketPoolDataV1 | null {
+  const ranked = [...pools].sort((first, second) => {
+    const statusDifference = marketPoolRank(first) - marketPoolRank(second);
+    if (statusDifference !== 0) return statusDifference;
+    const firstLiquidity = first.liquidity?.freshness === "current"
+      ? positiveBigInt(first.liquidity.valueUsdWad) ?? 0n
+      : 0n;
+    const secondLiquidity = second.liquidity?.freshness === "current"
+      ? positiveBigInt(second.liquidity.valueUsdWad) ?? 0n
+      : 0n;
+    if (firstLiquidity !== secondLiquidity) {
+      return firstLiquidity > secondLiquidity ? -1 : 1;
+    }
+    const firstTime = Date.parse(first.asOfTime ?? "");
+    const secondTime = Date.parse(second.asOfTime ?? "");
+    if (firstTime !== secondTime) return secondTime - firstTime;
+    return first.identity.poolId.localeCompare(second.identity.poolId);
+  });
+  return ranked.find((pool) => pool.status !== "unavailable") ?? ranked[0] ?? null;
+}
+
+function marketPoolRank(value: MarketPoolDataV1): number {
+  return value.status === "current"
+    ? 0
+    : value.status === "stale"
+      ? 1
+      : value.status === "waiting-for-first-trade"
+        ? 2
+        : 3;
+}
+
+function isMarketPoolDataV1(value: unknown): value is MarketPoolDataV1 {
+  if (!isRecord(value)) return false;
+  if (
+    !isMarketDataIdentityV1(value.identity) ||
+    value.source !== "bitquery" ||
+    !["current", "stale", "waiting-for-first-trade", "unavailable"].includes(
+      String(value.status),
+    ) ||
+    !["complete", "partial", "unavailable"].includes(String(value.quality)) ||
+    (value.asOfTime !== undefined && !validIsoTime(value.asOfTime)) ||
+    !optionalPositiveInteger(value.volume24hUsdWad) ||
+    (value.tradeCount24h !== undefined &&
+      (!Number.isSafeInteger(value.tradeCount24h) ||
+        Number(value.tradeCount24h) < 0)) ||
+    !isMarketValuationV1(value.valuation)
+  ) return false;
+  if (value.latestTrade !== undefined && !isMarketTradeV1(value.latestTrade)) {
+    return false;
+  }
+  if (value.liquidity !== undefined && !isMarketLiquidityV1(value.liquidity)) {
+    return false;
+  }
+  return true;
+}
+
+function isMarketTradeV1(value: unknown): value is MarketTradeV1 {
+  if (!isRecord(value)) return false;
+  const hasIndexedUsdPrice = value.priceUsdWad !== undefined ||
+    value.priceUsdAsOfTime !== undefined || value.priceUsdSource !== undefined;
+  return typeof value.transactionHash === "string" &&
+    TRANSACTION_HASH.test(value.transactionHash) &&
+    Number.isSafeInteger(value.logIndex) &&
+    Number(value.logIndex) >= 0 &&
+    CANONICAL_UNSIGNED_INTEGER.test(String(value.blockNumber)) &&
+    validIsoTime(value.time) &&
+    ["buy", "sell"].includes(String(value.tokenSide)) &&
+    optionalPositiveDecimal(value.tokenAmount) &&
+    optionalPositiveInteger(value.amountUsdWad) &&
+    optionalPositiveInteger(value.priceUsdWad) &&
+    (value.priceUsdAsOfTime === undefined || validIsoTime(value.priceUsdAsOfTime)) &&
+    (value.priceUsdSource === undefined ||
+      value.priceUsdSource === MARKET_DATA_USD_PRICE_SOURCE) &&
+    optionalPositiveInteger(value.rawPriceUsdWad) &&
+    (!hasIndexedUsdPrice ||
+      (positiveInteger(value.priceUsdWad) &&
+        validIsoTime(value.priceUsdAsOfTime) &&
+        value.priceUsdSource === MARKET_DATA_USD_PRICE_SOURCE)) &&
+    (value.amountUsdWad === undefined || hasIndexedUsdPrice) &&
+    optionalPositiveInteger(value.priceQuoteWad) &&
+    (value.quoteAddress === undefined ||
+      (typeof value.quoteAddress === "string" && ADDRESS.test(value.quoteAddress))) &&
+    (value.quoteSymbol === undefined ||
+      (typeof value.quoteSymbol === "string" && value.quoteSymbol.trim() !== ""));
+}
+
+function isMarketLiquidityV1(value: unknown): value is MarketLiquidityV1 {
+  return isRecord(value) &&
+    validIsoTime(value.asOfTime) &&
+    CANONICAL_UNSIGNED_INTEGER.test(String(value.asOfBlock)) &&
+    positiveInteger(value.valueUsdWad) &&
+    ["current", "stale"].includes(String(value.freshness));
+}
+
+function isMarketChartPointV1(value: unknown): value is MarketChartPointV1 {
+  return isRecord(value) &&
+    CANONICAL_UNSIGNED_INTEGER.test(String(value.blockNumber)) &&
+    validIsoTime(value.time) &&
+    optionalPositiveDecimal(value.priceUsd) &&
+    optionalPositiveDecimal(value.priceQuote) &&
+    (positiveDecimal(value.priceUsd) || positiveDecimal(value.priceQuote)) &&
+    (value.ohlcUsd === undefined || isMarketOhlcV1(value.ohlcUsd)) &&
+    (value.ohlcQuote === undefined || isMarketOhlcV1(value.ohlcQuote)) &&
+    (value.ohlcUsd === undefined || value.priceUsd === value.ohlcUsd.close) &&
+    (value.ohlcQuote === undefined ||
+      value.priceQuote === value.ohlcQuote.close) &&
+    optionalPositiveInteger(value.volumeUsdWad) &&
+    Number.isSafeInteger(value.tradeCount) &&
+    Number(value.tradeCount) > 0 &&
+    (value.quoteSymbol === undefined ||
+      (typeof value.quoteSymbol === "string" && value.quoteSymbol.trim() !== ""));
+}
+
+function isMarketOhlcV1(value: unknown): value is MarketOhlcV1 {
+  if (!isRecord(value)) return false;
+  if (
+    !positiveDecimal(value.open) ||
+    !positiveDecimal(value.high) ||
+    !positiveDecimal(value.low) ||
+    !positiveDecimal(value.close)
+  ) return false;
+  const open = decimalParts(value.open);
+  const high = decimalParts(value.high);
+  const low = decimalParts(value.low);
+  const close = decimalParts(value.close);
+  return compareDecimals(high, open) >= 0 &&
+    compareDecimals(high, close) >= 0 &&
+    compareDecimals(open, low) >= 0 &&
+    compareDecimals(close, low) >= 0;
+}
+
+function decimalParts(value: string): Readonly<{
+  coefficient: bigint;
+  scale: bigint;
+}> {
+  const [whole, fraction = ""] = value.split(".");
+  return {
+    coefficient: BigInt(`${whole}${fraction}`),
+    scale: 10n ** BigInt(fraction.length),
+  };
+}
+
+function compareDecimals(first: ReturnType<typeof decimalParts>, second: ReturnType<typeof decimalParts>) {
+  const difference = first.coefficient * second.scale -
+    second.coefficient * first.scale;
+  return difference === 0n ? 0 : difference > 0n ? 1 : -1;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function positiveBigInt(value: unknown): bigint | null {
+  return positiveInteger(value) ? BigInt(value) : null;
+}
+
+function positiveInteger(value: unknown): value is string {
+  return typeof value === "string" &&
+    CANONICAL_UNSIGNED_INTEGER.test(value) &&
+    BigInt(value) > 0n;
+}
+
+function optionalPositiveInteger(value: unknown): boolean {
+  return value === undefined || positiveInteger(value);
+}
+
+function positiveDecimal(value: unknown): value is string {
+  return typeof value === "string" &&
+    /^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/u.test(value) &&
+    !/^0(?:\.0+)?$/u.test(value);
+}
+
+function optionalPositiveDecimal(value: unknown): boolean {
+  return value === undefined || positiveDecimal(value);
+}
+
+function validIsoTime(value: unknown): value is string {
+  return typeof value === "string" &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/u.test(value) &&
+    Number.isFinite(Date.parse(value));
+}

--- a/lib/market-data/market-data-v1.ts
+++ b/lib/market-data/market-data-v1.ts
@@ -130,6 +130,7 @@ export type MarketOhlcV1 = Readonly<{
 export type MarketChartV1 = Readonly<{
   schemaVersion: typeof PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION;
   source: "bitquery";
+  readStatus: "live" | "cache-fallback";
   status:
     | "ready"
     | "insufficient-history"
@@ -251,6 +252,7 @@ export function isMarketChartV1(value: unknown): value is MarketChartV1 {
   if (
     value.schemaVersion !== PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION ||
     value.source !== "bitquery" ||
+    !["live", "cache-fallback"].includes(String(value.readStatus)) ||
     ![
       "ready",
       "insufficient-history",

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -211,8 +211,9 @@ export function evaluateAlchemyExploreSourceContracts(
         "limitBy: { by: Token_Address, count: 1 }",
       ) &&
       bitqueryMarketSource.includes(
-        'const dataset = range === "all" ? ", dataset: combined" : "";',
+        'const dataset = range === "1h" ? "" : ", dataset: combined";',
       ) &&
+      bitqueryMarketSource.includes("EVM(network: eth, dataset: combined)") &&
       !bitqueryMarketSource.includes("NEXT_PUBLIC_BITQUERY") &&
       marketSchemaSource.includes('source: "bitquery"') &&
       marketSchemaSource.includes('protocol: "uniswap_v4"'),

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -17,6 +17,12 @@ const ROUTES = Object.freeze([
       "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
   }),
   Object.freeze({
+    id: "token-chart",
+    path: "app/api/explore/token/chart/route.ts",
+    readyCache:
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
+  }),
+  Object.freeze({
     id: "token-list",
     path: "app/api/indexers/v1/token-list/route.ts",
     readyCache:
@@ -117,6 +123,16 @@ export function evaluateAlchemyExploreSourceContracts(
     ".github/workflows/deploy-production.yml",
     sourceOverrides,
   );
+  const bitqueryMarketSource = readSource(
+    rootDirectory,
+    "lib/market-data/bitquery.server.ts",
+    sourceOverrides,
+  );
+  const marketSchemaSource = readSource(
+    rootDirectory,
+    "lib/market-data/market-data-v1.ts",
+    sourceOverrides,
+  );
 
   check(
     "alchemy-durable-registry",
@@ -179,11 +195,28 @@ export function evaluateAlchemyExploreSourceContracts(
     "an authenticated webhook persists the confirmed cursor before invalidating public caches",
   );
   check(
-    "alchemy-complete-price-batching",
-    runtimeSource.includes("MAX_CONCURRENT_ALCHEMY_PRICE_BATCHES") &&
-      !runtimeSource.includes("MAX_ALCHEMY_PRICE_BATCHES") &&
-      !runtimeSource.includes(".slice(0, MAX_ALCHEMY_PRICE_ADDRESSES"),
-    "live Alchemy price enrichment covers the complete registry in bounded concurrent batches",
+    "bitquery-bounded-market-batching",
+    bitqueryMarketSource.includes(
+      "BITQUERY_OAUTH_TOKEN_ENVIRONMENT_VARIABLE =",
+    ) &&
+      bitqueryMarketSource.includes('"BITQUERY_OAUTH_TOKEN" as const') &&
+      bitqueryMarketSource.includes("MARKET_BATCH_SIZE = 100") &&
+      bitqueryMarketSource.includes("MARKET_BATCH_CONCURRENCY = 2") &&
+      bitqueryMarketSource.includes("PoolId: { in: $pools }") &&
+      bitqueryMarketSource.includes("limitBy: { by: Trade_PoolId, count: 1 }") &&
+      bitqueryMarketSource.includes(
+        "limitBy: { by: PoolEvent_Pool_PoolId, count: 1 }",
+      ) &&
+      bitqueryMarketSource.includes(
+        "limitBy: { by: Token_Address, count: 1 }",
+      ) &&
+      bitqueryMarketSource.includes(
+        'const dataset = range === "all" ? ", dataset: combined" : "";',
+      ) &&
+      !bitqueryMarketSource.includes("NEXT_PUBLIC_BITQUERY") &&
+      marketSchemaSource.includes('source: "bitquery"') &&
+      marketSchemaSource.includes('protocol: "uniswap_v4"'),
+    "Bitquery market reads are server-only, PoolId-native, bounded and archive-aware",
   );
 
   for (const route of routeSources) {
@@ -233,34 +266,46 @@ export function evaluateAlchemyExploreSourceContracts(
   );
 
   check(
-    "alchemy-explore-provenance",
+    "bitquery-market-provenance",
     routeSources
       .filter(({ id }) => id !== "token-list")
       .every(
         ({ source }) =>
-          source.includes("exploreLaunchSourceHeader({") &&
-          source.includes("exploreReadSourceHeader({") &&
-          source.includes("exploreRpcProviderHeader(deployment)") &&
-          source.includes('"X-Programmable-Rpc-Provider": rpcProvider') &&
-          !source.includes('"X-Programmable-Rpc-Provider": "alchemy"'),
+          source.includes('"X-Programmable-Market-Source": "bitquery"') &&
+          !source.includes('"X-Programmable-Rpc-Provider"'),
       ) &&
+      routeSources
+        .filter(({ id }) => ["explore", "token-detail"].includes(id))
+        .every(
+          ({ source }) =>
+            source.includes("exploreLaunchSourceHeader({") &&
+            source.includes("exploreReadSourceHeader({") &&
+            source.includes("...sourceHeaders"),
+        ) &&
       exploreConsumerSource.includes('return "operational+durable"') &&
       exploreConsumerSource.includes('return "last-known-good"') &&
       exploreConsumerSource.includes('"registry.custom-launched"') &&
       exploreConsumerSource.includes('?? "partial"') &&
-      exploreConsumerSource.includes(
-        'return deployment.rpcUrlSecondary\n    ? "operational-dual"\n    : "operational-primary";',
+      deployWorkflowSource.includes("Smoke staged Bitquery market APIs") &&
+      deployWorkflowSource.includes(
+        '"0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"',
       ) &&
-      routeSources
-        .filter(({ id }) => id !== "token-list")
-        .every(({ source }) => source.includes("...sourceHeaders")) &&
+      deployWorkflowSource.includes(
+        '"0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229"',
+      ) &&
+      deployWorkflowSource.includes(
+        'goldenMarket?.schemaVersion !== "programmable.market-data.v1"',
+      ) &&
+      deployWorkflowSource.includes(
+        'goldenChart.schemaVersion !== "programmable.market-chart.v1"',
+      ) &&
       responseSource.includes('"X-Programmable-Read-Source": "blob"') &&
       responseSource.includes('"X-Programmable-Rpc-Provider": "alchemy"') &&
       responseSource.includes('"X-Programmable-Launch-Source": "alchemy"') &&
       responseSource.includes(
         '"X-Programmable-Launch-Source, X-Programmable-Read-Source, X-Programmable-Rpc-Provider"',
       ),
-    "Explore responses expose honest source and operational-provider provenance",
+    "Registry-backed identities and Bitquery-only market responses expose separate source provenance",
   );
 
   return Object.freeze({

--- a/scripts/perf/bitquery-golden-market-parity.mjs
+++ b/scripts/perf/bitquery-golden-market-parity.mjs
@@ -1,0 +1,344 @@
+import {
+  decodeFunctionResult,
+  encodeFunctionData,
+  parseAbi,
+} from "viem";
+
+const PCAN_TOKEN_ADDRESS =
+  "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
+const PCAN_POOL_ID =
+  "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const MAINNET_STATE_VIEW = "0x7fFE42C4a5DEeA5b0feC41C94C136Cf115597227";
+const MAINNET_ETH_USD_FEED = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
+const DEFAULT_RPC_URLS = Object.freeze([
+  "https://ethereum-rpc.publicnode.com",
+  "https://rpc.mevblocker.io",
+]);
+const MINIMUM_CONFIRMATIONS = 12n;
+const MAXIMUM_FEED_AGE_SECONDS = 7_200n;
+const MAXIMUM_DEVIATION_BPS = 1_500n;
+const RUNTIME_CONFIDENCE_DEVIATION_BPS = 1_000n;
+const MINIMUM_LIQUIDITY_USD_WAD = 10_000n * 10n ** 18n;
+const WAD = 10n ** 18n;
+const Q192 = 1n << 192n;
+
+const stateViewAbi = parseAbi([
+  "function getSlot0(bytes32 poolId) view returns (uint160 sqrtPriceX96,int24 tick,uint24 protocolFee,uint24 lpFee)",
+]);
+const erc20Abi = parseAbi([
+  "function decimals() view returns (uint8)",
+  "function totalSupply() view returns (uint256)",
+]);
+const feedAbi = parseAbi([
+  "function decimals() view returns (uint8)",
+  "function latestRoundData() view returns (uint80 roundId,int256 answer,uint256 startedAt,uint256 updatedAt,uint80 answeredInRound)",
+]);
+
+function positiveInteger(value, label) {
+  if (typeof value !== "string" || !/^[1-9][0-9]*$/u.test(value)) {
+    throw new Error(`${label} is not a canonical positive integer`);
+  }
+  return BigInt(value);
+}
+
+function canonicalBlockNumber(value) {
+  const block = positiveInteger(value, "golden trade block");
+  return { block, hex: `0x${block.toString(16)}` };
+}
+
+function validTime(value, label) {
+  const parsed = Date.parse(value ?? "");
+  if (!Number.isFinite(parsed)) throw new Error(`${label} is not an ISO timestamp`);
+  return parsed;
+}
+
+function withinDeviation(reference, observed, maximumBps) {
+  if (reference <= 0n || observed <= 0n) return false;
+  const difference = reference > observed
+    ? reference - observed
+    : observed - reference;
+  return difference * 10_000n <= reference * maximumBps;
+}
+
+async function jsonRpc(fetchImpl, rpcUrl, method, params, id) {
+  const response = await fetchImpl(rpcUrl, {
+    method: "POST",
+    redirect: "error",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const text = await response.text();
+  if (!response.ok || Buffer.byteLength(text, "utf8") > 128 * 1024) {
+    throw new Error("independent market parity RPC was unavailable");
+  }
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error("independent market parity RPC returned invalid JSON");
+  }
+  if (
+    body?.jsonrpc !== "2.0" ||
+    body?.id !== id ||
+    body.error !== undefined ||
+    body.result === undefined
+  ) {
+    throw new Error("independent market parity RPC rejected a canonical read");
+  }
+  return body.result;
+}
+
+async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
+  const slot0Data = encodeFunctionData({
+    abi: stateViewAbi,
+    functionName: "getSlot0",
+    args: [poolId],
+  });
+  const decimalsData = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: "decimals",
+  });
+  const totalSupplyData = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: "totalSupply",
+  });
+  const feedDecimalsData = encodeFunctionData({
+    abi: feedAbi,
+    functionName: "decimals",
+  });
+  const roundData = encodeFunctionData({
+    abi: feedAbi,
+    functionName: "latestRoundData",
+  });
+  const call = (to, data, id) => jsonRpc(
+    fetchImpl,
+    rpcUrl,
+    "eth_call",
+    [{ to, data }, blockHex],
+    id,
+  );
+  const [headHex, block, slot0Hex, decimalsHex, supplyHex, feedDecimalsHex, roundHex] =
+    await Promise.all([
+      jsonRpc(fetchImpl, rpcUrl, "eth_blockNumber", [], 1),
+      jsonRpc(fetchImpl, rpcUrl, "eth_getBlockByNumber", [blockHex, false], 2),
+      call(MAINNET_STATE_VIEW, slot0Data, 3),
+      call(tokenAddress, decimalsData, 4),
+      call(tokenAddress, totalSupplyData, 5),
+      call(MAINNET_ETH_USD_FEED, feedDecimalsData, 6),
+      call(MAINNET_ETH_USD_FEED, roundData, 7),
+    ]);
+  if (
+    !/^0x[0-9a-f]+$/iu.test(headHex ?? "") ||
+    block === null ||
+    !/^0x[0-9a-f]{64}$/iu.test(block?.hash ?? "") ||
+    !/^0x[0-9a-f]+$/iu.test(block?.number ?? "") ||
+    !/^0x[0-9a-f]+$/iu.test(block?.timestamp ?? "")
+  ) {
+    throw new Error("independent market parity block proof is malformed");
+  }
+  const [sqrtPriceX96] = decodeFunctionResult({
+    abi: stateViewAbi,
+    functionName: "getSlot0",
+    data: slot0Hex,
+  });
+  const tokenDecimals = Number(decodeFunctionResult({
+    abi: erc20Abi,
+    functionName: "decimals",
+    data: decimalsHex,
+  }));
+  const totalSupplyRaw = decodeFunctionResult({
+    abi: erc20Abi,
+    functionName: "totalSupply",
+    data: supplyHex,
+  });
+  const feedDecimals = Number(decodeFunctionResult({
+    abi: feedAbi,
+    functionName: "decimals",
+    data: feedDecimalsHex,
+  }));
+  const [roundId, answer, , updatedAt, answeredInRound] = decodeFunctionResult({
+    abi: feedAbi,
+    functionName: "latestRoundData",
+    data: roundHex,
+  });
+  const observation = Object.freeze({
+    head: BigInt(headHex),
+    blockNumber: BigInt(block.number),
+    blockHash: block.hash.toLowerCase(),
+    blockTimestamp: BigInt(block.timestamp),
+    sqrtPriceX96,
+    tokenDecimals,
+    totalSupplyRaw,
+    feedDecimals,
+    roundId,
+    answer,
+    updatedAt,
+    answeredInRound,
+  });
+  if (
+    observation.sqrtPriceX96 <= 0n ||
+    !Number.isInteger(observation.tokenDecimals) ||
+    observation.tokenDecimals < 0 ||
+    observation.tokenDecimals > 255 ||
+    observation.totalSupplyRaw <= 0n ||
+    !Number.isInteger(observation.feedDecimals) ||
+    observation.feedDecimals < 0 ||
+    observation.feedDecimals > 36 ||
+    observation.roundId <= 0n ||
+    observation.answer <= 0n ||
+    observation.updatedAt <= 0n ||
+    observation.answeredInRound < observation.roundId ||
+    observation.updatedAt > observation.blockTimestamp ||
+    observation.blockTimestamp - observation.updatedAt > MAXIMUM_FEED_AGE_SECONDS
+  ) {
+    throw new Error("independent market parity state is invalid or stale");
+  }
+  return observation;
+}
+
+function sameObservation(left, right) {
+  return [
+    "blockNumber",
+    "blockHash",
+    "blockTimestamp",
+    "sqrtPriceX96",
+    "tokenDecimals",
+    "totalSupplyRaw",
+    "feedDecimals",
+    "roundId",
+    "answer",
+    "updatedAt",
+    "answeredInRound",
+  ].every((key) => left[key] === right[key]);
+}
+
+async function readProviderWithRetry(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      return await readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex);
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+  throw lastError ?? new Error("independent market parity provider failed");
+}
+
+/**
+ * Release-only independent correctness proof. Bitquery remains the runtime
+ * market source; two fixed public Ethereum readers only verify that the
+ * golden Bitquery observation has the right units, orientation and scale.
+ */
+export async function verifyBitqueryGoldenMarketParityV1(input) {
+  const token = input?.token;
+  const fetchImpl = input?.fetchImpl ?? fetch;
+  const rpcUrls = input?.rpcUrls ?? DEFAULT_RPC_URLS;
+  if (!Array.isArray(rpcUrls) || rpcUrls.length !== 2 || rpcUrls[0] === rpcUrls[1]) {
+    throw new Error("exactly two independent market parity readers are required");
+  }
+  if (token?.tokenAddress?.toLowerCase() !== PCAN_TOKEN_ADDRESS) {
+    throw new Error("golden market parity token identity is invalid");
+  }
+  const pool = token?.marketData?.pools?.find(
+    (candidate) => candidate?.identity?.poolId === PCAN_POOL_ID,
+  );
+  if (
+    token?.marketData?.primaryPoolId !== PCAN_POOL_ID ||
+    pool?.identity?.tokenAddress?.toLowerCase() !== PCAN_TOKEN_ADDRESS ||
+    pool?.identity?.protocol !== "uniswap_v4"
+  ) {
+    throw new Error("golden market parity pool identity is invalid");
+  }
+  const trade = pool.latestTrade;
+  const priceUsdWad = positiveInteger(trade?.priceUsdWad, "indexed USD price");
+  const rawPriceUsdWad = positiveInteger(trade?.rawPriceUsdWad, "raw USD price");
+  const liquidityUsdWad = positiveInteger(
+    pool?.liquidity?.valueUsdWad,
+    "exact-pool USD liquidity",
+  );
+  const totalSupplyRaw = positiveInteger(token?.totalSupplyRaw, "canonical total supply");
+  const tokenDecimals = token?.tokenDecimals;
+  const { block, hex: blockHex } = canonicalBlockNumber(trade?.blockNumber);
+  const tradeTime = validTime(trade?.time, "golden trade time");
+  const priceTime = validTime(trade?.priceUsdAsOfTime, "indexed USD price time");
+  if (
+    trade?.priceUsdSource !== "bitquery-token-price-index-v1" ||
+    !Number.isInteger(tokenDecimals) ||
+    tokenDecimals < 0 ||
+    tokenDecimals > 255 ||
+    liquidityUsdWad < MINIMUM_LIQUIDITY_USD_WAD ||
+    Math.abs(tradeTime - priceTime) > 5 * 60_000 ||
+    !withinDeviation(priceUsdWad, rawPriceUsdWad, RUNTIME_CONFIDENCE_DEVIATION_BPS)
+  ) {
+    throw new Error("golden Bitquery confidence contract is not satisfied");
+  }
+  const [first, second] = await Promise.all(rpcUrls.map((rpcUrl) =>
+    readProviderWithRetry(
+      fetchImpl,
+      rpcUrl,
+      PCAN_TOKEN_ADDRESS,
+      PCAN_POOL_ID,
+      blockHex,
+    )));
+  if (
+    !sameObservation(first, second) ||
+    first.blockNumber !== block ||
+    first.head < block + MINIMUM_CONFIRMATIONS ||
+    second.head < block + MINIMUM_CONFIRMATIONS ||
+    first.tokenDecimals !== tokenDecimals ||
+    first.totalSupplyRaw !== totalSupplyRaw
+  ) {
+    throw new Error("independent market parity readers did not agree");
+  }
+  const nativeFdvWad =
+    (totalSupplyRaw * Q192 * WAD) /
+    (first.sqrtPriceX96 * first.sqrtPriceX96 * 10n ** 18n);
+  const onchainFdvUsdWad =
+    (nativeFdvWad * first.answer) / 10n ** BigInt(first.feedDecimals);
+  const bitqueryFdvUsdWad =
+    (priceUsdWad * totalSupplyRaw) / 10n ** BigInt(tokenDecimals);
+  const rawFdvUsdWad =
+    (rawPriceUsdWad * totalSupplyRaw) / 10n ** BigInt(tokenDecimals);
+  const publicValuation = positiveInteger(
+    token?.valuation?.valueWad,
+    "public golden FDV",
+  );
+  if (
+    token?.valuation?.status !== "available" ||
+    token.valuation.metric !== "fdv" ||
+    token.valuation.supplyBasis !== "total" ||
+    publicValuation !== bitqueryFdvUsdWad ||
+    !withinDeviation(onchainFdvUsdWad, bitqueryFdvUsdWad, MAXIMUM_DEVIATION_BPS) ||
+    !withinDeviation(onchainFdvUsdWad, rawFdvUsdWad, MAXIMUM_DEVIATION_BPS)
+  ) {
+    throw new Error("Bitquery golden price is outside independent onchain tolerance");
+  }
+  const deviation = onchainFdvUsdWad > bitqueryFdvUsdWad
+    ? onchainFdvUsdWad - bitqueryFdvUsdWad
+    : bitqueryFdvUsdWad - onchainFdvUsdWad;
+  return Object.freeze({
+    schemaVersion: "programmable.bitquery-golden-market-parity.v1",
+    tokenAddress: PCAN_TOKEN_ADDRESS,
+    poolId: PCAN_POOL_ID,
+    blockNumber: block.toString(),
+    blockHash: first.blockHash,
+    confirmations: Number(
+      (first.head < second.head ? first.head : second.head) - block,
+    ),
+    bitqueryFdvUsdWad: bitqueryFdvUsdWad.toString(),
+    onchainFdvUsdWad: onchainFdvUsdWad.toString(),
+    deviationBps: Number((deviation * 10_000n) / onchainFdvUsdWad),
+  });
+}
+
+export const BITQUERY_GOLDEN_MARKET_PARITY_V1 = Object.freeze({
+  tokenAddress: PCAN_TOKEN_ADDRESS,
+  poolId: PCAN_POOL_ID,
+  rpcReaderCount: DEFAULT_RPC_URLS.length,
+  maximumDeviationBps: Number(MAXIMUM_DEVIATION_BPS),
+});

--- a/scripts/perf/read-model-deploy-policy.mjs
+++ b/scripts/perf/read-model-deploy-policy.mjs
@@ -12,6 +12,8 @@ import { runtimeProductionProviderBindingsFromUrls } from "./read-model-provider
 
 export { PROJECTOR_WAKE_ROUTE, QUICKNODE_STREAM_SECRET_ENV_NAME };
 
+export const BITQUERY_MARKET_SECRET_ENV_NAME = "BITQUERY_OAUTH_TOKEN";
+
 export const RELEASE_GATED_FLAG_NAMES = Object.freeze([
   "INDEXED_EXPLORE_LIST_READS_ENABLED",
   "INDEXED_EXPLORE_TOKEN_READS_ENABLED",
@@ -35,6 +37,7 @@ export const WORKER_ACTIVATION_FLAG_NAMES = Object.freeze([
 
 export const REQUIRED_SERVER_SECRET_ENV_NAMES = Object.freeze([
   QUICKNODE_STREAM_SECRET_ENV_NAME,
+  BITQUERY_MARKET_SECRET_ENV_NAME,
 ]);
 
 export const REQUIRED_NON_SECRET_RUNTIME_ENV_NAMES = Object.freeze([
@@ -123,7 +126,9 @@ export function materializeVercelSensitiveRuntimePlaceholders(
   const emptyNames = sensitiveRuntimeNames.filter(
     (name) => runtimeValues[name] === "",
   );
-  if (emptyNames.length === 0) return contents;
+  const namesRequiringMetadata = [
+    ...new Set([BITQUERY_MARKET_SECRET_ENV_NAME, ...emptyNames]),
+  ];
   let metadata;
   try {
     metadata = JSON.parse(metadataContents);
@@ -138,7 +143,7 @@ export function materializeVercelSensitiveRuntimePlaceholders(
   ) {
     throw new Error("Vercel sensitive environment metadata is invalid");
   }
-  for (const name of emptyNames) {
+  for (const name of namesRequiringMetadata) {
     const matches = metadata.envs.filter(
       (entry) => entry !== null && typeof entry === "object" && entry.key === name,
     );
@@ -153,8 +158,12 @@ export function materializeVercelSensitiveRuntimePlaceholders(
       throw new Error(`${name} is not exact sensitive production metadata`);
     }
   }
-  const materializedNames = new Set(emptyNames);
-  return contents
+  const materializedNames = new Set(
+    namesRequiringMetadata.filter(
+      (name) => runtimeValues[name] === "" || runtimeValues[name] === undefined,
+    ),
+  );
+  const materialized = contents
     .split(/\r?\n/u)
     .map((line) => {
       const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/u.exec(line);
@@ -163,6 +172,14 @@ export function materializeVercelSensitiveRuntimePlaceholders(
         : line;
     })
     .join("\n");
+  const missingNames = [...materializedNames].filter(
+    (name) => runtimeValues[name] === undefined,
+  );
+  if (missingNames.length === 0) return materialized;
+  const separator = materialized === "" || materialized.endsWith("\n") ? "" : "\n";
+  return `${materialized}${separator}${missingNames
+    .map((name) => `${name}="[Sensitive]"`)
+    .join("\n")}`;
 }
 
 export function readReleaseGatedFlags(contents) {
@@ -252,15 +269,15 @@ function validateNonSecretRuntimeEnvironment(contents, expectations) {
   });
 }
 
-function validateWakeTriggerSecret(contents, required) {
-  if (!required) {
-    return Object.freeze({ ready: true, invalidNames: Object.freeze([]) });
-  }
+function validateRequiredServerSecrets(contents, wakeCanaryRequired) {
+  const requiredNames = wakeCanaryRequired
+    ? REQUIRED_SERVER_SECRET_ENV_NAMES
+    : [BITQUERY_MARKET_SECRET_ENV_NAME];
   const configured = readSelectedDotenvValues(
     contents,
-    REQUIRED_SERVER_SECRET_ENV_NAMES,
+    requiredNames,
   );
-  const invalidNames = REQUIRED_SERVER_SECRET_ENV_NAMES.filter((name) => {
+  const invalidNames = requiredNames.filter((name) => {
     const value = configured[name];
     if (typeof value !== "string" || value === "") return true;
     if (VERCEL_SENSITIVE_PLACEHOLDER.test(value)) return false;
@@ -356,7 +373,7 @@ export function evaluateReadModelDeployPolicy(
   const wakeCanaryRequired = WORKER_ACTIVATION_FLAG_NAMES.some(
     (name) => workerFlags.values[name],
   );
-  const secretEnvironmentPreflight = validateWakeTriggerSecret(
+  const secretEnvironmentPreflight = validateRequiredServerSecrets(
     contents,
     wakeCanaryRequired,
   );

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -974,6 +974,9 @@ export function evaluateReadModelOperationsSourceContracts(
     "scripts/perf/read-model-real-block-sla-operator.mjs",
   ) ?? "";
   const postPromotion = source("scripts/perf/read-model-post-promotion.mjs") ?? "";
+  const bitqueryGoldenParity = source(
+    "scripts/perf/bitquery-golden-market-parity.mjs",
+  ) ?? "";
   const productionBinding = source(
     "scripts/perf/read-model-production-binding.mjs",
   ) ?? "";
@@ -1152,6 +1155,9 @@ export function evaluateReadModelOperationsSourceContracts(
         'marketSources: Object.freeze(["bitquery"]),',
       ) &&
       stagedBitquerySmokeBlock.includes(
+        'dataQualities: Object.freeze(["complete", "partial", "stale"]),',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
         "const bitqueryChartContract = Object.freeze({",
       ) &&
       stagedBitquerySmokeBlock.includes(
@@ -1162,6 +1168,9 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       stagedBitquerySmokeBlock.includes(
         'response.headers.get(\n                  "x-programmable-market-as-of",',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'response.headers.get(\n                  "x-programmable-data-quality",',
       ) &&
       stagedBitquerySmokeBlock.includes(
         "!headerMatches(rpcProvider, contract.rpcProviders)",
@@ -1238,7 +1247,7 @@ export function evaluateReadModelOperationsSourceContracts(
       stagedBitquerySmokeBlock.includes(
         'valuation.reason === "waiting-for-first-trade"',
       ) &&
-      !stagedBitquerySmokeBlock.includes("currentFdvCount < 1") &&
+      !stagedBitquerySmokeBlock.includes("if (currentFdvCount < 1) {") &&
       stagedBitquerySmokeBlock.includes(
         '"staged Bitquery current Explore and detail FDV are not identical"',
       ) &&
@@ -1247,6 +1256,32 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       stagedBitquerySmokeBlock.includes(
         'goldenValuation.supplyBasis !== "total"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"./scripts/perf/bitquery-golden-market-parity.mjs"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "await verifyBitqueryGoldenMarketParityV1({",
+      ) &&
+      bitqueryGoldenParity.includes(
+        '"https://ethereum-rpc.publicnode.com"',
+      ) &&
+      bitqueryGoldenParity.includes('"https://rpc.mevblocker.io"') &&
+      bitqueryGoldenParity.includes("const MAXIMUM_DEVIATION_BPS = 1_500n") &&
+      bitqueryGoldenParity.includes("const MINIMUM_CONFIRMATIONS = 12n") &&
+      bitqueryGoldenParity.includes("sameObservation(first, second)") &&
+      bitqueryGoldenParity.includes(
+        "Bitquery golden price is outside independent onchain tolerance",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "const historicalPaidPathVerified =",
+      ) &&
+      stagedBitquerySmokeBlock.includes("goldenParity.confirmations >= 12") &&
+      stagedBitquerySmokeBlock.includes(
+        "currentFdvCount < 1 && !historicalPaidPathVerified",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "staged Bitquery Explore stale FDV is too old",
       ) &&
       stagedBitquerySmokeBlock.includes(
         "goldenChart.asOfTime !== goldenChart.points.at(-1)?.time",
@@ -1347,9 +1382,14 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes("honestExploreValuations") &&
       postPromotion.includes("exactGoldenDetail") &&
       postPromotion.includes("exactGoldenChart") &&
+      postPromotion.includes("verifyBitqueryGoldenMarketParityV1") &&
+      postPromotion.includes(
+        'id: "production-bitquery-golden-independent-parity"',
+      ) &&
       postPromotion.includes('response.headers.get("x-programmable-market-source")') &&
       postPromotion.includes('response.headers.get("x-programmable-price-source")') &&
       postPromotion.includes('response.headers.get("x-programmable-market-as-of")') &&
+      postPromotion.includes('response.headers.get("x-programmable-data-quality")') &&
       !postPromotion.includes("/api/indexers/v1/token-list") &&
       postPromotion.includes("verifyLiveCacheAndKeyContracts"),
     "the workflow is stage-only and both operator runbooks require the exact SLA-gated deployment promotion sequence",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1062,10 +1062,19 @@ export function evaluateReadModelOperationsSourceContracts(
       deployPolicy.includes(
         "materializeVercelSensitiveRuntimePlaceholders",
       ) &&
+      deployPolicy.includes(
+        'BITQUERY_MARKET_SECRET_ENV_NAME = "BITQUERY_OAUTH_TOKEN"',
+      ) &&
+      exactEmptyEnvironmentKey(environmentExample, "BITQUERY_OAUTH_TOKEN") &&
+      deployPolicy.includes(
+        "...new Set([BITQUERY_MARKET_SECRET_ENV_NAME, ...emptyNames])",
+      ) &&
+      deployPolicy.includes("validateRequiredServerSecrets") &&
+      deployPolicy.includes(": [BITQUERY_MARKET_SECRET_ENV_NAME];") &&
       deployPolicy.includes('matches[0].type !== "sensitive"') &&
       deployPolicy.includes('matches[0].target[0] !== "production"') &&
       deployPolicy.includes('Object.hasOwn(matches[0], "value")'),
-    "Vercel empty sensitive placeholders require exact value-free production metadata",
+    "Bitquery always requires exact value-free sensitive production metadata",
   );
   const stagedWakeGate = deployWorkflow.indexOf(
     "Gate exact staged QuickNode wake route",
@@ -1100,111 +1109,163 @@ export function evaluateReadModelOperationsSourceContracts(
       stagedWakeGateBlock.includes('--target-url "$STAGED_TARGET_URL"'),
     "an active fast lane must pass the exact unaliased staged wake canary before attestation",
   );
-  const stagedAlchemySmoke = deployWorkflow.indexOf(
-    "Smoke staged Alchemy Explore APIs",
+  const stagedBitquerySmoke = deployWorkflow.indexOf(
+    "Smoke staged Bitquery market APIs",
   );
-  const stagedAlchemySmokeEnd = deployWorkflow.indexOf(
-    "Record Alchemy-only read path",
+  const stagedBitquerySmokeEnd = deployWorkflow.indexOf(
+    "Record registry identity and Bitquery market path",
   );
-  const stagedAlchemySmokeBlock =
-    stagedAlchemySmoke >= 0 && stagedAlchemySmokeEnd > stagedAlchemySmoke
-      ? deployWorkflow.slice(stagedAlchemySmoke, stagedAlchemySmokeEnd)
+  const stagedBitquerySmokeBlock =
+    stagedBitquerySmoke >= 0 && stagedBitquerySmokeEnd > stagedBitquerySmoke
+      ? deployWorkflow.slice(stagedBitquerySmoke, stagedBitquerySmokeEnd)
       : "";
   check(
-    "ops-protected-alchemy-stage-smoke",
-    stagedAlchemySmoke > stagedWakeGateEnd &&
-      stagedAlchemySmokeBlock.includes(
-        "if: steps.read-model-policy.outputs.mode == 'alchemy-only'",
-      ) &&
-      stagedAlchemySmokeBlock.includes(
+    "ops-protected-bitquery-stage-smoke",
+    stagedBitquerySmoke > stagedWakeGateEnd &&
+      !stagedBitquerySmokeBlock.includes("if:") &&
+      stagedBitquerySmokeBlock.includes(
         "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
       ) &&
-      stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes(
         "process.env.VERCEL_AUTOMATION_BYPASS_SECRET",
       ) &&
-      stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes(
         'Buffer.byteLength(\n            automationBypassSecret ?? "",\n            "utf8",\n          )',
       ) &&
-      stagedAlchemySmokeBlock.includes("automationBypassSecretLength < 32") &&
-      stagedAlchemySmokeBlock.includes("automationBypassSecretLength > 512") &&
-      stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes("automationBypassSecretLength < 32") &&
+      stagedBitquerySmokeBlock.includes("automationBypassSecretLength > 512") &&
+      stagedBitquerySmokeBlock.includes(
         "/[\\r\\n]/.test(automationBypassSecret)",
       ) &&
-      stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes(
         '"x-vercel-protection-bypass": automationBypassSecret',
       ) &&
-      stagedAlchemySmokeBlock.includes("headers: alchemySmokeRequestHeaders") &&
-      stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes("headers: bitquerySmokeRequestHeaders") &&
+      stagedBitquerySmokeBlock.includes(
         "STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        'const operationalReadSources = Object.freeze([\n            "operational+durable+postgres",\n          ]);',
+      stagedBitquerySmokeBlock.includes(
+        'readSources: Object.freeze(["operational+durable+postgres"]),',
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        'const operationalRpcProviders = Object.freeze([\n            "operational-dual",\n            "operational-primary",\n          ]);',
+      stagedBitquerySmokeBlock.includes("rpcProviders: null") &&
+      stagedBitquerySmokeBlock.includes(
+        'marketSources: Object.freeze(["bitquery"]),',
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        'const alchemyRpcProviders = Object.freeze(["alchemy"]);',
+      stagedBitquerySmokeBlock.includes(
+        "const bitqueryChartContract = Object.freeze({",
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        'const alchemyReadSources = Object.freeze(["blob"]);',
+      stagedBitquerySmokeBlock.includes(
+        'response.headers.get(\n                  "x-programmable-market-source",',
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        "expectedReadSources,\n            expectedRpcProviders,",
+      stagedBitquerySmokeBlock.includes(
+        'response.headers.get(\n                  "x-programmable-price-source",',
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        '!expectedReadSources.includes(readSource ?? "")',
+      stagedBitquerySmokeBlock.includes(
+        'response.headers.get(\n                  "x-programmable-market-as-of",',
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        '!expectedRpcProviders.includes(rpcProvider ?? "")',
+      stagedBitquerySmokeBlock.includes(
+        "!headerMatches(rpcProvider, contract.rpcProviders)",
       ) &&
-      !stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes(
+        "!headerMatches(marketSource, contract.marketSources)",
+      ) &&
+      !stagedBitquerySmokeBlock.includes(
         'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        '"/api/indexers/v1/token-list",\n            alchemyReadSources,\n            alchemyRpcProviders,',
+      !stagedBitquerySmokeBlock.includes("alchemyIdentityContract") &&
+      !stagedBitquerySmokeBlock.includes("/api/indexers/v1/token-list") &&
+      stagedBitquerySmokeBlock.includes(
+        '"/api/explore?limit=20&page=1&sort=market-cap",\n            bitqueryMarketContract,',
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        '"/api/explore?limit=20&page=1&sort=market-cap",\n            operationalReadSources,\n            operationalRpcProviders,',
-      ) &&
-      stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes(
         '"/api/explore?limit=20&page=1&sort=market-cap"',
       ) &&
-      stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes(
         "entry.launchCategoryProvenance.blockNumber",
       ) &&
-      stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes(
         "entry.launchCategoryProvenance.transactionIndex",
       ) &&
-      stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes(
         "entry.launchCategoryProvenance.logIndex",
       ) &&
-      stagedAlchemySmokeBlock.includes(
-        "staged Alchemy newest entry has no canonical launch order",
+      stagedBitquerySmokeBlock.includes(
+        "staged Bitquery newest entry has no canonical launch order",
       ) &&
-      stagedAlchemySmokeBlock.includes("coordinates === null") &&
-      stagedAlchemySmokeBlock.includes("const newestPageSize = 100") &&
-      stagedAlchemySmokeBlock.includes("seenNewestIds") &&
-      stagedAlchemySmokeBlock.includes("newestTokens.length !== newestTotal") &&
-      stagedAlchemySmokeBlock.includes("launchChainId(entry) !== newestChainId") &&
-      stagedAlchemySmokeBlock.includes("sort=oldest") &&
-      stagedAlchemySmokeBlock.includes(
-        "staged Alchemy oldest page is not ordered oldest-first",
+      stagedBitquerySmokeBlock.includes("coordinates === null") &&
+      stagedBitquerySmokeBlock.includes("const newestPageSize = 100") &&
+      stagedBitquerySmokeBlock.includes("seenNewestIds") &&
+      stagedBitquerySmokeBlock.includes("newestTokens.length !== newestTotal") &&
+      stagedBitquerySmokeBlock.includes("launchChainId(entry) !== newestChainId") &&
+      stagedBitquerySmokeBlock.includes("sort=oldest") &&
+      stagedBitquerySmokeBlock.includes(
+        "staged Bitquery oldest page is not ordered oldest-first",
       ) &&
-      stagedAlchemySmokeBlock.includes('"/api/indexers/v1/token-list"') &&
-      stagedAlchemySmokeBlock.includes("/api/explore/token?address=") &&
-      (stagedAlchemySmokeBlock.match(/\bfetch\(/gu) ?? []).length === 1 &&
-      !stagedAlchemySmokeBlock.includes("/api/ops/health") &&
-      !stagedAlchemySmokeBlock.includes("/api/explore/profile") &&
-      !/(?:database|projector|quicknode|envio|real-block|sla)/iu.test(
-        stagedAlchemySmokeBlock,
+      stagedBitquerySmokeBlock.includes("/api/explore/token?address=") &&
+      stagedBitquerySmokeBlock.includes(
+        "/api/explore?limit=20&page=1&q=${goldenTokenAddress}&sort=market-cap",
       ) &&
-      !stagedAlchemySmokeBlock.includes(
+      stagedBitquerySmokeBlock.includes(
+        "/api/explore/token/chart?address=${goldenTokenAddress}&range=all",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "`/api/explore/token/chart?address=${goldenTokenAddress}&range=all`,\n            bitqueryChartContract,",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'goldenMarket?.schemaVersion !== "programmable.market-data.v1"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'goldenChart.schemaVersion !== "programmable.market-chart.v1"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"staged Bitquery Highest FDV is not monotonically descending"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"staged Bitquery Explore exposed stale or unavailable FDV as current"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"staged Bitquery Explore mislabeled stale FDV as current"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'valuation.freshness === "stale"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'valuation.reason === "waiting-for-first-trade"',
+      ) &&
+      !stagedBitquerySmokeBlock.includes("currentFdvCount < 1") &&
+      stagedBitquerySmokeBlock.includes(
+        '"staged Bitquery current Explore and detail FDV are not identical"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'goldenValuation.metric !== "fdv"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'goldenValuation.supplyBasis !== "total"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "goldenChart.asOfTime !== goldenChart.points.at(-1)?.time",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"staged PCAN chart is not a strictly ordered positive history"',
+      ) &&
+      (stagedBitquerySmokeBlock.match(/\bfetch\(/gu) ?? []).length === 1 &&
+      !stagedBitquerySmokeBlock.includes("/api/ops/health") &&
+      !stagedBitquerySmokeBlock.includes("/api/explore/profile") &&
+      !/\b(?:database|projector|quicknode|envio|real-block|sla)\b/iu.test(
+        stagedBitquerySmokeBlock,
+      ) &&
+      !stagedBitquerySmokeBlock.includes(
         "NEXT_PUBLIC_VERCEL_AUTOMATION_BYPASS_SECRET",
       ) &&
-      !stagedAlchemySmokeBlock.includes("${automationBypassSecret}") &&
-      !stagedAlchemySmokeBlock.includes("console."),
-    "the Alchemy-only staged API smoke proves durable-registry and live-provider provenance without indexed infrastructure or exposing its deployment bypass",
+      !stagedBitquerySmokeBlock.includes("${automationBypassSecret}") &&
+      !stagedBitquerySmokeBlock.includes("console."),
+    "the staged API smoke proves registry identity plus Bitquery-only market provenance without exposing its deployment bypass",
   );
   const stagedReadModelCapture = deployWorkflow.indexOf(
     "Capture staged read-model evidence",
@@ -1218,7 +1279,7 @@ export function evaluateReadModelOperationsSourceContracts(
       : "";
   check(
     "ops-protected-indexed-stage-capture",
-    stagedReadModelCapture > stagedAlchemySmokeEnd &&
+    stagedReadModelCapture > stagedBitquerySmokeEnd &&
       stagedReadModelCaptureBlock.includes(
         "if: steps.read-model-policy.outputs.mode == 'indexed-or-shadow'",
       ) &&
@@ -1276,6 +1337,20 @@ export function evaluateReadModelOperationsSourceContracts(
       productionBinding.includes("resolveProductionBinding") &&
       postPromotion.includes('"/api/ops/health"') &&
       postPromotion.includes('"/api/explore?limit=6&page=1&sort=market-cap"') &&
+      postPromotion.includes(
+        '"0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"',
+      ) &&
+      postPromotion.includes(
+        '"0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229"',
+      ) &&
+      postPromotion.includes("exactBitqueryHeaders") &&
+      postPromotion.includes("honestExploreValuations") &&
+      postPromotion.includes("exactGoldenDetail") &&
+      postPromotion.includes("exactGoldenChart") &&
+      postPromotion.includes('response.headers.get("x-programmable-market-source")') &&
+      postPromotion.includes('response.headers.get("x-programmable-price-source")') &&
+      postPromotion.includes('response.headers.get("x-programmable-market-as-of")') &&
+      !postPromotion.includes("/api/indexers/v1/token-list") &&
       postPromotion.includes("verifyLiveCacheAndKeyContracts"),
     "the workflow is stage-only and both operator runbooks require the exact SLA-gated deployment promotion sequence",
   );

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1278,6 +1278,12 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       stagedBitquerySmokeBlock.includes("goldenParity.confirmations >= 12") &&
       stagedBitquerySmokeBlock.includes(
+        'goldenChart.readStatus !== "live"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'goldenChart.readStatus === "live"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
         "currentFdvCount < 1 && !historicalPaidPathVerified",
       ) &&
       stagedBitquerySmokeBlock.includes(
@@ -1382,6 +1388,7 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes("honestExploreValuations") &&
       postPromotion.includes("exactGoldenDetail") &&
       postPromotion.includes("exactGoldenChart") &&
+      postPromotion.includes('chart.readStatus !== "live"') &&
       postPromotion.includes("verifyBitqueryGoldenMarketParityV1") &&
       postPromotion.includes(
         'id: "production-bitquery-golden-independent-parity"',

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -15,8 +15,23 @@ import {
 
 const HEALTH_PATH = "/api/ops/health";
 const EXPLORE_PATH = "/api/explore?limit=6&page=1&sort=market-cap";
-const TOKEN_LIST_PATH = "/api/indexers/v1/token-list";
+const GOLDEN_TOKEN_ADDRESS =
+  "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
+const GOLDEN_POOL_ID =
+  "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const GOLDEN_DETAIL_PATH = `/api/explore/token?address=${GOLDEN_TOKEN_ADDRESS}`;
+const GOLDEN_CHART_PATH =
+  `/api/explore/token/chart?address=${GOLDEN_TOKEN_ADDRESS}&range=all`;
 const MAXIMUM_RESPONSE_BYTES = 2 * 1024 * 1024;
+const UNAVAILABLE_VALUATION_REASONS = new Set([
+  "no-market",
+  "supply-unavailable",
+  "liquidity-unavailable",
+  "price-unavailable",
+  "inconsistent-snapshot",
+  "waiting-for-first-trade",
+  "source-unavailable",
+]);
 
 function argumentsFrom(argv) {
   const result = {};
@@ -64,6 +79,13 @@ async function request(fetchImpl, targetUrl, path, json = true) {
     ok: response.ok,
     status: response.status,
     body: json ? safeJson(text, url.pathname) : text,
+    headers: Object.freeze({
+      marketAsOf: response.headers.get("x-programmable-market-as-of"),
+      marketSource: response.headers.get("x-programmable-market-source"),
+      priceSource: response.headers.get("x-programmable-price-source"),
+      readSource: response.headers.get("x-programmable-read-source"),
+      rpcProvider: response.headers.get("x-programmable-rpc-provider"),
+    }),
   };
 }
 
@@ -82,6 +104,150 @@ async function retry(operation, attempts = 12, delayMs = 5_000) {
     }
   }
   throw lastError ?? new Error("post-promotion verification failed");
+}
+
+function positiveInteger(value) {
+  return typeof value === "string" && /^[1-9][0-9]*$/u.test(value);
+}
+
+function validMarketTime(value) {
+  const parsed = Date.parse(value ?? "");
+  return Number.isFinite(parsed) && parsed <= Date.now() + 60_000;
+}
+
+function currentMarketTime(value) {
+  return validMarketTime(value) &&
+    Date.now() - Date.parse(value) <= 6 * 60_000;
+}
+
+function exactBitqueryHeaders(response) {
+  return response.headers.marketSource === "bitquery" &&
+    response.headers.readSource === "operational+durable+postgres" &&
+    response.headers.rpcProvider === null;
+}
+
+function honestExploreValuations(response) {
+  const tokens = response.body?.tokens;
+  if (!Array.isArray(tokens) || tokens.length === 0) return false;
+  let previousCurrentFdv = null;
+  let sawNonCurrent = false;
+  let currentCount = 0;
+  for (const token of tokens) {
+    const valuation = token?.valuation;
+    if (valuation?.status === "unavailable") {
+      if (
+        !UNAVAILABLE_VALUATION_REASONS.has(valuation.reason) ||
+        token?.fdvUsdWad !== undefined
+      ) return false;
+      sawNonCurrent = true;
+      continue;
+    }
+    if (
+      valuation?.status !== "available" ||
+      valuation.metric !== "fdv" ||
+      valuation.supplyBasis !== "total" ||
+      valuation.currency !== "usd" ||
+      valuation.source !== "bitquery" ||
+      !["current", "stale"].includes(valuation.freshness) ||
+      !positiveInteger(valuation.valueWad) ||
+      !validMarketTime(valuation.asOfTime)
+    ) return false;
+    if (valuation.freshness === "stale") {
+      if (token?.fdvUsdWad !== undefined) return false;
+      sawNonCurrent = true;
+      continue;
+    }
+    if (
+      sawNonCurrent ||
+      token.fdvUsdWad !== valuation.valueWad ||
+      !currentMarketTime(valuation.asOfTime)
+    ) return false;
+    const value = BigInt(valuation.valueWad);
+    if (previousCurrentFdv !== null && value > previousCurrentFdv) return false;
+    previousCurrentFdv = value;
+    currentCount += 1;
+  }
+  const marketAsOf = response.body?.dataQuality?.valuation?.asOfTime ?? null;
+  return [null, "bitquery"].includes(response.headers.priceSource) &&
+    (currentCount === 0 || response.headers.priceSource === "bitquery") &&
+    response.headers.marketAsOf === marketAsOf &&
+    (marketAsOf === null || validMarketTime(marketAsOf));
+}
+
+function exactGoldenDetail(response) {
+  const token = response.body?.token;
+  const market = token?.marketData;
+  const pool = market?.pools?.find(
+    (candidate) => candidate?.identity?.poolId === GOLDEN_POOL_ID,
+  );
+  const valuation = token?.valuation;
+  return response.ok &&
+    exactBitqueryHeaders(response) &&
+    response.body?.status === "ready" &&
+    token?.tokenAddress?.toLowerCase() === GOLDEN_TOKEN_ADDRESS &&
+    market?.schemaVersion === "programmable.market-data.v1" &&
+    market?.source === "bitquery" &&
+    market?.primaryPoolId === GOLDEN_POOL_ID &&
+    ["current", "stale"].includes(market?.status) &&
+    ["current", "stale"].includes(pool?.status) &&
+    valuation?.status === "available" &&
+    valuation.metric === "fdv" &&
+    valuation.supplyBasis === "total" &&
+    valuation.source === "bitquery" &&
+    positiveInteger(valuation.valueWad) &&
+    validMarketTime(valuation.asOfTime) &&
+    (valuation.freshness !== "current" || currentMarketTime(valuation.asOfTime)) &&
+    (valuation.freshness === "current"
+      ? token.fdvUsdWad === valuation.valueWad &&
+        response.headers.priceSource === "bitquery"
+      : valuation.freshness === "stale" &&
+        token.fdvUsdWad === undefined &&
+        response.headers.priceSource === null);
+}
+
+function exactGoldenChart(response) {
+  const chart = response.body;
+  if (
+    !response.ok ||
+    response.headers.marketSource !== "bitquery" ||
+    response.headers.rpcProvider !== null ||
+    response.headers.priceSource !== "bitquery" ||
+    chart?.schemaVersion !== "programmable.market-chart.v1" ||
+    chart.source !== "bitquery" ||
+    chart.address?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
+    chart.identity?.poolId !== GOLDEN_POOL_ID ||
+    !["ready", "insufficient-history", "partial"].includes(chart.status) ||
+    !Array.isArray(chart.points) ||
+    chart.points.length < 1 ||
+    chart.valuation?.metric !== "fdv" ||
+    chart.valuation?.supplyBasis !== "total" ||
+    !["current", "stale"].includes(chart.valuation?.freshness) ||
+    (chart.valuation?.freshness === "current" &&
+      !currentMarketTime(chart.valuation?.asOfTime)) ||
+    chart.asOfTime !== chart.points.at(-1)?.time ||
+    response.headers.marketAsOf !== chart.asOfTime ||
+    !validMarketTime(chart.asOfTime)
+  ) return false;
+  let previousTime = null;
+  let previousBlock = null;
+  for (const point of chart.points) {
+    const time = Date.parse(point?.time ?? "");
+    const block = positiveInteger(point?.blockNumber)
+      ? BigInt(point.blockNumber)
+      : null;
+    const price = Number(point?.priceUsd ?? point?.priceQuote);
+    if (
+      !Number.isFinite(time) ||
+      block === null ||
+      !Number.isFinite(price) ||
+      price <= 0 ||
+      (previousTime !== null && time <= previousTime) ||
+      (previousBlock !== null && block < previousBlock)
+    ) return false;
+    previousTime = time;
+    previousBlock = block;
+  }
+  return true;
 }
 
 function publicChecks(responses) {
@@ -105,17 +271,19 @@ function publicChecks(responses) {
       condition:
         responses.explore.ok &&
         responses.explore.body?.status === "ready" &&
-        Array.isArray(responses.explore.body?.tokens) &&
-        responses.explore.body.tokens.length > 0,
-      detail: "the production Explore route returns a populated ready token page",
+        exactBitqueryHeaders(responses.explore) &&
+        honestExploreValuations(responses.explore),
+      detail: "the production Explore route returns honest Bitquery FDV freshness",
     },
     {
-      id: "production-token-list",
-      condition:
-        responses.tokenList.ok &&
-        Array.isArray(responses.tokenList.body?.tokens) &&
-        responses.tokenList.body.tokens.length > 0,
-      detail: "the production indexed token list remains populated",
+      id: "production-bitquery-detail",
+      condition: exactGoldenDetail(responses.goldenDetail),
+      detail: "the production PCAN detail is bound to its exact Bitquery v4 pool",
+    },
+    {
+      id: "production-bitquery-chart",
+      condition: exactGoldenChart(responses.goldenChart),
+      detail: "the production PCAN chart exposes ordered Bitquery history",
     },
   ];
 }
@@ -195,13 +363,15 @@ export async function verifyPostPromotion(input) {
     request(fetchImpl, targetUrl, "/", false),
     request(fetchImpl, targetUrl, HEALTH_PATH),
     request(fetchImpl, targetUrl, EXPLORE_PATH),
-    request(fetchImpl, targetUrl, TOKEN_LIST_PATH),
+    request(fetchImpl, targetUrl, GOLDEN_DETAIL_PATH),
+    request(fetchImpl, targetUrl, GOLDEN_CHART_PATH),
   ]);
   const checks = [...deploymentChecks, ...publicChecks({
     root: responses[0],
     health: responses[1],
     explore: responses[2],
-    tokenList: responses[3],
+    goldenDetail: responses[3],
+    goldenChart: responses[4],
   })];
 
   if (input.evidencePath) {

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -12,6 +12,7 @@ import {
   fetchVercelDeployment,
   verifyLiveCacheAndKeyContracts,
 } from "./read-model-live-verifier.mjs";
+import { verifyBitqueryGoldenMarketParityV1 } from "./bitquery-golden-market-parity.mjs";
 
 const HEALTH_PATH = "/api/ops/health";
 const EXPLORE_PATH = "/api/explore?limit=6&page=1&sort=market-cap";
@@ -81,6 +82,7 @@ async function request(fetchImpl, targetUrl, path, json = true) {
     body: json ? safeJson(text, url.pathname) : text,
     headers: Object.freeze({
       marketAsOf: response.headers.get("x-programmable-market-as-of"),
+      dataQuality: response.headers.get("x-programmable-data-quality"),
       marketSource: response.headers.get("x-programmable-market-source"),
       priceSource: response.headers.get("x-programmable-price-source"),
       readSource: response.headers.get("x-programmable-read-source"),
@@ -120,10 +122,16 @@ function currentMarketTime(value) {
     Date.now() - Date.parse(value) <= 6 * 60_000;
 }
 
+function boundedStaleMarketTime(value) {
+  return validMarketTime(value) &&
+    Date.now() - Date.parse(value) <= 24 * 60 * 60_000;
+}
+
 function exactBitqueryHeaders(response) {
   return response.headers.marketSource === "bitquery" &&
     response.headers.readSource === "operational+durable+postgres" &&
-    response.headers.rpcProvider === null;
+    response.headers.rpcProvider === null &&
+    response.headers.dataQuality === response.body?.dataQuality?.status;
 }
 
 function honestExploreValuations(response) {
@@ -184,10 +192,16 @@ function exactGoldenDetail(response) {
   return response.ok &&
     exactBitqueryHeaders(response) &&
     response.body?.status === "ready" &&
+    response.body?.dataQuality?.schemaVersion ===
+      "programmable.explore-data-quality.v1" &&
+    ["complete", "partial", "stale"].includes(
+      response.body?.dataQuality?.status,
+    ) &&
     token?.tokenAddress?.toLowerCase() === GOLDEN_TOKEN_ADDRESS &&
     market?.schemaVersion === "programmable.market-data.v1" &&
     market?.source === "bitquery" &&
     market?.primaryPoolId === GOLDEN_POOL_ID &&
+    currentMarketTime(market?.generatedAt) &&
     ["current", "stale"].includes(market?.status) &&
     ["current", "stale"].includes(pool?.status) &&
     valuation?.status === "available" &&
@@ -196,7 +210,10 @@ function exactGoldenDetail(response) {
     valuation.source === "bitquery" &&
     positiveInteger(valuation.valueWad) &&
     validMarketTime(valuation.asOfTime) &&
+    response.headers.marketAsOf === valuation.asOfTime &&
     (valuation.freshness !== "current" || currentMarketTime(valuation.asOfTime)) &&
+    (valuation.freshness !== "stale" || boundedStaleMarketTime(valuation.asOfTime)) &&
+    response.headers.dataQuality === response.body?.dataQuality?.status &&
     (valuation.freshness === "current"
       ? token.fdvUsdWad === valuation.valueWad &&
         response.headers.priceSource === "bitquery"
@@ -210,10 +227,13 @@ function exactGoldenChart(response) {
   if (
     !response.ok ||
     response.headers.marketSource !== "bitquery" ||
+    response.headers.readSource !== null ||
     response.headers.rpcProvider !== null ||
     response.headers.priceSource !== "bitquery" ||
+    response.headers.dataQuality !== chart?.status ||
     chart?.schemaVersion !== "programmable.market-chart.v1" ||
     chart.source !== "bitquery" ||
+    !currentMarketTime(chart.generatedAt) ||
     chart.address?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
     chart.identity?.poolId !== GOLDEN_POOL_ID ||
     !["ready", "insufficient-history", "partial"].includes(chart.status) ||
@@ -224,6 +244,8 @@ function exactGoldenChart(response) {
     !["current", "stale"].includes(chart.valuation?.freshness) ||
     (chart.valuation?.freshness === "current" &&
       !currentMarketTime(chart.valuation?.asOfTime)) ||
+    (chart.valuation?.freshness === "stale" &&
+      !boundedStaleMarketTime(chart.valuation?.asOfTime)) ||
     chart.asOfTime !== chart.points.at(-1)?.time ||
     response.headers.marketAsOf !== chart.asOfTime ||
     !validMarketTime(chart.asOfTime)
@@ -373,6 +395,22 @@ export async function verifyPostPromotion(input) {
     goldenDetail: responses[3],
     goldenChart: responses[4],
   })];
+  let goldenParity = null;
+  try {
+    goldenParity = await verifyBitqueryGoldenMarketParityV1({
+      token: responses[3].body?.token,
+      fetchImpl,
+      rpcUrls: input.marketParityRpcUrls,
+    });
+  } catch {
+    // The public verifier reports only the typed gate, never provider details.
+  }
+  checks.push({
+    id: "production-bitquery-golden-independent-parity",
+    condition: goldenParity?.schemaVersion ===
+      "programmable.bitquery-golden-market-parity.v1",
+    detail: "the public PCAN market price matches two independent same-block reads",
+  });
 
   if (input.evidencePath) {
     const profile = parseReadModelLoadProfile(

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -161,7 +161,10 @@ function honestExploreValuations(response) {
       !validMarketTime(valuation.asOfTime)
     ) return false;
     if (valuation.freshness === "stale") {
-      if (token?.fdvUsdWad !== undefined) return false;
+      if (
+        token?.fdvUsdWad !== undefined ||
+        !boundedStaleMarketTime(valuation.asOfTime)
+      ) return false;
       sawNonCurrent = true;
       continue;
     }
@@ -233,6 +236,7 @@ function exactGoldenChart(response) {
     response.headers.dataQuality !== chart?.status ||
     chart?.schemaVersion !== "programmable.market-chart.v1" ||
     chart.source !== "bitquery" ||
+    chart.readStatus !== "live" ||
     !currentMarketTime(chart.generatedAt) ||
     chart.address?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
     chart.identity?.poolId !== GOLDEN_POOL_ID ||

--- a/scripts/perf/read-model-smoke.mjs
+++ b/scripts/perf/read-model-smoke.mjs
@@ -13,8 +13,8 @@ try {
   output(
     {
       schemaVersion: 1,
-      profileId: "alchemy-explore-source-v1",
-      mode: "alchemy-only-contract-smoke",
+      profileId: "registry-bitquery-market-source-v1",
+      mode: "registry-bitquery-market-contract-smoke",
       contractValid: source.ok,
       releaseEvidenceAccepted: false,
       checks: source.checks,
@@ -26,7 +26,7 @@ try {
   output(
     {
       schemaVersion: 1,
-      mode: "alchemy-only-contract-smoke",
+      mode: "registry-bitquery-market-contract-smoke",
       contractValid: false,
       releaseEvidenceAccepted: false,
       checks: [],

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -50,6 +50,7 @@ function tradeRow(input: Readonly<{
   block?: string;
   time?: string;
   transaction?: string;
+  transactionIndex?: number;
   logIndex?: number;
   priceUsd?: string;
   priceQuote?: string;
@@ -95,6 +96,7 @@ function tradeRow(input: Readonly<{
     },
     Transaction: {
       Hash: input.transaction ?? `0x${"aa".repeat(32)}`,
+      Index: input.transactionIndex ?? 7,
     },
   };
 }
@@ -250,6 +252,14 @@ describe("Bitquery-only market data", () => {
         expect(request.query).toContain(
           "Currency: { SmartContract: { in: $tokenAddresses } }",
         );
+        expect(request.query).toContain(
+          "EVM(network: eth, dataset: combined)",
+        );
+        expect(request.query).toContain(
+          "{ descending: Transaction_Index }",
+        );
+        expect(request.query).toContain("{ descending: Log_Index }");
+        expect(request.query).toContain("Transaction { Hash Index }");
         expect(request.query).toContain(
           "Token: { Address: { in: $tokenAddresses } }",
         );
@@ -648,6 +658,7 @@ describe("Bitquery-only market data", () => {
         },
       }],
     });
+    expect(isTokenMarketDataV1(values.get(PCAN.tokenAddress))).toBe(true);
   });
 
   it("does not turn a partial response into a false first-trade state", async () => {
@@ -667,6 +678,36 @@ describe("Bitquery-only market data", () => {
         valuation: { reason: "source-unavailable" },
       }],
     });
+  });
+
+  it("does not preserve a cached first-trade claim through provider failure", async () => {
+    const success = vi.fn(async () => jsonResponse(marketResponse({
+      trade: null,
+    }))) as typeof fetch;
+    await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl: success,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const failure = vi.fn(async () => {
+      throw new Error("provider unavailable");
+    }) as typeof fetch;
+
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl: failure,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:03.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)).toMatchObject({
+      status: "unavailable",
+      pools: [{
+        status: "unavailable",
+        quality: "partial",
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+      }],
+    });
+    expect(isTokenMarketDataV1(values.get(PCAN.tokenAddress))).toBe(true);
   });
 
   it("uses only Bitquery last-known-good data during a temporary failure", async () => {
@@ -777,32 +818,80 @@ describe("Bitquery-only market data", () => {
 describe("Bitquery OHLCV chart and server stream", () => {
   beforeEach(() => clearBitqueryMarketDataCachesForTests());
 
-  it("uses the paid combined dataset for the all-history chart", async () => {
-    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
-      const request = JSON.parse(String(init?.body));
-      expect(request.query).toContain("EVM(network: eth, dataset: combined)");
-      expect(request.variables).toEqual({
-        poolId: PCAN.poolId,
-        tokenAddress: PCAN.tokenAddress,
+  it.each(["1d", "1w", "all"] as const)(
+    "uses the paid combined dataset for the %s chart",
+    async (range) => {
+      const fetchImpl = vi.fn(async (
+        _url: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const request = JSON.parse(String(init?.body));
+        expect(request.query).toContain("EVM(network: eth, dataset: combined)");
+        expect(request.query).toContain("{ descending: Block_Number }");
+        expect(request.query).toContain("{ descending: Transaction_Index }");
+        expect(request.query).toContain("{ descending: Log_Index }");
+        expect(request.variables).toMatchObject({
+          poolId: PCAN.poolId,
+          tokenAddress: PCAN.tokenAddress,
+        });
+        if (range === "all") {
+          expect(request.variables).not.toHaveProperty("since");
+        } else {
+          expect(request.variables.since).toMatch(/^2026-08-/u);
+        }
+        return jsonResponse({
+          data: {
+            EVM: { DEXTrades: [] },
+            Trading: { Tokens: [supplyRow()] },
+          },
+        });
+      }) as typeof fetch;
+
+      const chart = await readBitqueryMarketChartV1({
+        identity: PCAN,
+        range,
+        fetchImpl,
+        token: OAUTH_TOKEN,
+        now: new Date("2026-08-11T14:02:00.000Z"),
       });
-      return jsonResponse({
-        data: {
-          EVM: { DEXTrades: [] },
-          Trading: { Tokens: [supplyRow()] },
-        },
-      });
+
+      expect(chart.status).toBe("waiting-for-first-trade");
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("does not preserve a cached empty chart as confirmed through failure", async () => {
+    const success = vi.fn(async () => jsonResponse({
+      data: {
+        EVM: { DEXTrades: [] },
+        Trading: { Tokens: [supplyRow()] },
+      },
+    })) as typeof fetch;
+    await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl: success,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const failure = vi.fn(async () => {
+      throw new Error("provider unavailable");
     }) as typeof fetch;
 
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
-      range: "all",
-      fetchImpl,
+      range: "1h",
+      fetchImpl: failure,
       token: OAUTH_TOKEN,
-      now: new Date("2026-08-11T14:02:00.000Z"),
+      now: new Date("2026-08-11T14:02:03.000Z"),
     });
 
-    expect(chart.status).toBe("waiting-for-first-trade");
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(chart).toMatchObject({
+      status: "unavailable",
+      points: [],
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    });
+    expect(isMarketChartV1(chart)).toBe(true);
   });
 
   it("builds exact-pool quote candles without promoting raw DEX USD", async () => {
@@ -844,8 +933,12 @@ describe("Bitquery OHLCV chart and server stream", () => {
       const request = JSON.parse(String(init?.body));
       expect(request.variables.poolId).toBe(PCAN.poolId);
       expect(request.query).toContain("DEXTrades(");
+      expect(request.query).not.toContain("dataset: combined");
       expect(request.query).toContain("PoolId: { is: $poolId }");
-      expect(request.query).toContain("orderBy: { descending: Block_Time }");
+      expect(request.query).toContain("{ descending: Block_Number }");
+      expect(request.query).toContain("{ descending: Transaction_Index }");
+      expect(request.query).toContain("{ descending: Log_Index }");
+      expect(request.query).toContain("Transaction { Hash Index }");
       expect(request.query).toContain("TransactionStatus: { Success: true }");
       return jsonResponse({
         data: {
@@ -937,6 +1030,47 @@ describe("Bitquery OHLCV chart and server stream", () => {
     });
     expect(chart).not.toHaveProperty("volumeUsdWad");
     expect(isMarketChartV1(chart)).toBe(true);
+  });
+
+  it("orders same-block swaps by transaction index and then log index, never hash", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      data: {
+        EVM: {
+          DEXTrades: [
+            tradeRow({
+              block: "25740000",
+              time: "2026-08-11T14:00:01.000Z",
+              transaction: `0x${"ff".repeat(32)}`,
+              transactionIndex: 1,
+              logIndex: 9,
+              priceQuote: "1",
+            }),
+            tradeRow({
+              block: "25740000",
+              time: "2026-08-11T14:00:01.000Z",
+              transaction: `0x${"00".repeat(32)}`,
+              transactionIndex: 2,
+              logIndex: 1,
+              priceQuote: "2",
+            }),
+          ],
+        },
+        Trading: { Tokens: [supplyRow()] },
+      },
+    })) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(chart.points[0]).toMatchObject({
+      priceQuote: "2",
+      ohlcQuote: { open: "1", close: "2" },
+    });
   });
 
   it("never promotes raw DEX USD into chart prices or volume", async () => {
@@ -1051,6 +1185,7 @@ describe("Bitquery OHLCV chart and server stream", () => {
     );
     expect(BITQUERY_MARKET_STREAM_QUERY.match(/DEXTrades\(/gu)).toHaveLength(1);
     expect(BITQUERY_MARKET_STREAM_QUERY.match(/DEXPoolEvents\(/gu)).toHaveLength(1);
+    expect(BITQUERY_MARKET_STREAM_QUERY).toContain("Transaction { Hash Index }");
     expect(
       BITQUERY_MARKET_STREAM_QUERY.match(
         /TransactionStatus: \{ Success: true \}/gu,

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -1,0 +1,1081 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  BITQUERY_HTTP_ENDPOINT,
+  clearBitqueryMarketDataCachesForTests,
+  readBitqueryMarketChartV1,
+  readBitqueryTokenMarketDataV1,
+  safeBitqueryMarketDataError,
+} from "../lib/market-data/bitquery.server";
+import {
+  BITQUERY_MARKET_STREAM_QUERY,
+  createBitqueryMarketStreamV1,
+} from "../lib/market-data/bitquery-stream.server";
+import {
+  isMarketChartV1,
+  isTokenMarketDataV1,
+  marketDataStatusLabel,
+  selectPrimaryMarketPoolV1,
+  type MarketDataIdentityV1,
+} from "../lib/market-data/market-data-v1";
+import { exploreEntriesMarketIdentitiesV1 } from
+  "../lib/market-data/explore-market-identities";
+import type { ExploreEntry } from "../lib/tokens";
+
+const OAUTH_TOKEN = "ory_at_test_market_data_token_123456";
+const WETH = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+const PCAN: MarketDataIdentityV1 = {
+  chainId: "1",
+  tokenAddress: "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce",
+  poolId: "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229",
+  protocol: "uniswap_v4",
+};
+const CLASSIC: MarketDataIdentityV1 = {
+  chainId: "1",
+  tokenAddress: "0x3f2a426365e7a438a7f9f758766cff419d207d51",
+  poolId: "0x9b8b0aa54cbf844b8534cfb817a0da47c039e67e472d239308f6a47e487e0619",
+  protocol: "uniswap_v4",
+};
+const SECOND_CUSTOM: MarketDataIdentityV1 = {
+  chainId: "1",
+  tokenAddress: "0x1111111111111111111111111111111111111111",
+  poolId: `0x${"33".repeat(32)}`,
+  protocol: "uniswap_v4",
+};
+
+function tradeRow(input: Readonly<{
+  identity?: MarketDataIdentityV1;
+  block?: string;
+  time?: string;
+  transaction?: string;
+  logIndex?: number;
+  priceUsd?: string;
+  priceQuote?: string;
+  amountUsd?: string;
+  omitPriceUsd?: boolean;
+  omitAmountUsd?: boolean;
+  quoteAddress?: string;
+  quoteSymbol?: string;
+}>) {
+  const identity = input.identity ?? PCAN;
+  return {
+    Block: {
+      Number: input.block ?? "25740000",
+      Time: input.time ?? "2026-08-11T14:00:00.000Z",
+    },
+    Log: { Index: input.logIndex ?? 1 },
+    Trade: {
+      PoolId: identity.poolId,
+      Buy: {
+        Currency: {
+          SmartContract: identity.tokenAddress,
+          Symbol: "PCAN",
+        },
+        Amount: "100",
+        ...(input.omitAmountUsd
+          ? {}
+          : { AmountInUSD: input.amountUsd ?? "25" }),
+        Price: input.priceQuote ?? "0.0001",
+        ...(input.omitPriceUsd
+          ? {}
+          : { PriceInUSD: input.priceUsd ?? "0.25" }),
+      },
+      Sell: {
+        Currency: {
+          SmartContract: input.quoteAddress ?? WETH,
+          Symbol: input.quoteSymbol ?? "WETH",
+        },
+        Amount: "0.01",
+        AmountInUSD: input.amountUsd ?? "25",
+        Price: "10000",
+        PriceInUSD: "2500",
+      },
+    },
+    Transaction: {
+      Hash: input.transaction ?? `0x${"aa".repeat(32)}`,
+    },
+  };
+}
+
+function liquidityRow(
+  identity = PCAN,
+  options: Readonly<{
+    omitFirstUsd?: boolean;
+    omitSecondUsd?: boolean;
+    quoteAddress?: string;
+    time?: string;
+    amountFirstUsd?: string;
+    amountSecondUsd?: string;
+  }> = {},
+) {
+  return {
+    Block: {
+      Number: "25740000",
+      Time: options.time ?? "2026-08-11T14:00:00.000Z",
+    },
+    PoolEvent: {
+      Pool: {
+        PoolId: identity.poolId,
+        CurrencyA: {
+          SmartContract: identity.tokenAddress,
+          Symbol: "PCAN",
+        },
+        CurrencyB: {
+          SmartContract: options.quoteAddress ?? WETH,
+          Symbol: "WETH",
+        },
+      },
+      Liquidity: {
+        AmountCurrencyA: "100",
+        AmountCurrencyB: "20",
+        ...(options.omitFirstUsd
+          ? {}
+          : { AmountCurrencyAInUSD: options.amountFirstUsd ?? "100000" }),
+        ...(options.omitSecondUsd
+          ? {}
+          : { AmountCurrencyBInUSD: options.amountSecondUsd ?? "50000" }),
+      },
+    },
+  };
+}
+
+function supplyRow(input: Readonly<{
+  identity?: MarketDataIdentityV1;
+  id?: string;
+  address?: string;
+  total?: string;
+  circulating?: string | null;
+  max?: string | null;
+  time?: string;
+  indexedPrice?: string | null;
+  quotedInUsd?: boolean;
+}> = {}) {
+  const identity = input.identity ?? PCAN;
+  return {
+    Token: {
+      Id: input.id ?? `bid:eth:${identity.tokenAddress}`,
+      Address: input.address ?? identity.tokenAddress,
+    },
+    Block: { Time: input.time ?? "2026-08-11T14:00:00.000Z" },
+    Supply: {
+      TotalSupply: input.total ?? "1000000",
+      CirculatingSupply: input.circulating === undefined
+        ? "800000"
+        : input.circulating,
+      MaxSupply: input.max === undefined ? "1000000" : input.max,
+      MarketCap: "999999999",
+      FullyDilutedValuationUsd: "999999999",
+    },
+    Price: {
+      IsQuotedInUsd: input.quotedInUsd ?? true,
+      Ohlc: {
+        Close: input.indexedPrice === undefined ? "0.25" : input.indexedPrice,
+      },
+    },
+  };
+}
+
+function marketResponse(input: Readonly<{
+  identity?: MarketDataIdentityV1;
+  trade?: unknown;
+  liquidity?: unknown;
+  supply?: unknown;
+  errors?: unknown[];
+}> = {}) {
+  const identity = input.identity ?? PCAN;
+  return {
+    data: {
+      EVM: {
+        latestTrades: input.trade === undefined
+          ? [tradeRow({ identity })]
+          : input.trade === null
+            ? []
+            : [input.trade],
+        latestLiquidity: input.liquidity === undefined
+          ? [liquidityRow(identity)]
+          : input.liquidity === null
+            ? []
+            : [input.liquidity],
+        stats: [{
+          Trade: {
+            PoolId: identity.poolId,
+            Currency: { SmartContract: identity.tokenAddress },
+          },
+          count: "42",
+          volumeUsd: "12345.67",
+        }],
+      },
+      Trading: {
+        tokenSupplies: input.supply === undefined
+          ? [supplyRow({ identity })]
+          : input.supply === null
+            ? []
+            : [input.supply],
+      },
+    },
+    ...(input.errors ? { errors: input.errors } : {}),
+  };
+}
+
+function jsonResponse(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Bitquery-only market data", () => {
+  beforeEach(() => {
+    clearBitqueryMarketDataCachesForTests();
+  });
+
+  it("binds PCAN to its exact v4 PoolId and ignores Bitquery's cap estimates", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe(BITQUERY_HTTP_ENDPOINT);
+      expect(init?.headers).toMatchObject({
+        Accept: "application/json",
+        Authorization: `Bearer ${OAUTH_TOKEN}`,
+        "Content-Type": "application/json",
+      });
+      const request = JSON.parse(String(init?.body));
+      expect(String(init?.body)).not.toContain(OAUTH_TOKEN);
+      if (request.query.includes("ProgrammableMarketSnapshot")) {
+        expect(request.query).toContain('ProtocolName: { is: "uniswap_v4" }');
+        expect(request.query).toContain("PoolId: { in: $pools }");
+        expect(request.query).toContain(
+          "limitBy: { by: Trade_PoolId, count: 1 }",
+        );
+        expect(request.query).toContain(
+          "Currency: { SmartContract: { in: $tokenAddresses } }",
+        );
+        expect(request.query).toContain(
+          "Token: { Address: { in: $tokenAddresses } }",
+        );
+        expect(request.query.match(/TransactionStatus: \{ Success: true \}/gu))
+          .toHaveLength(3);
+        expect(request.query).toContain("Price {");
+        expect(request.query).toContain("IsQuotedInUsd");
+        expect(request.query).not.toContain("MarketCap");
+        expect(request.query).not.toContain("FullyDilutedValuationUsd");
+        expect(request.variables).toEqual({
+          pools: [PCAN.poolId],
+          tokenAddresses: [PCAN.tokenAddress],
+        });
+        return jsonResponse(marketResponse({
+          trade: tradeRow({
+            priceUsd: "0.24",
+            omitAmountUsd: true,
+          }),
+        }));
+      }
+      throw new Error("unexpected second market request");
+    }) as typeof fetch;
+
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const market = values.get(PCAN.tokenAddress);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(market && isTokenMarketDataV1(market)).toBe(true);
+    expect(market).toMatchObject({
+      source: "bitquery",
+      status: "current",
+      primaryPoolId: PCAN.poolId,
+      pools: [{
+        identity: PCAN,
+        status: "current",
+        latestTrade: {
+          priceUsdWad: "250000000000000000",
+          priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
+          priceUsdSource: "bitquery-token-price-index-v1",
+          rawPriceUsdWad: "240000000000000000",
+        },
+        volume24hUsdWad: "12345670000000000000000",
+        tradeCount24h: 42,
+        liquidity: { valueUsdWad: "150000000000000000000000" },
+        valuation: {
+          status: "available",
+          metric: "fdv",
+          supplyBasis: "total",
+          valueUsdWad: "250000000000000000000000",
+          fdvUsdWad: "250000000000000000000000",
+        },
+      }],
+    });
+  });
+
+  it.each([
+    ["wrong token id", supplyRow({ id: `bid:eth:${CLASSIC.tokenAddress}` })],
+    ["wrong token address", supplyRow({ address: CLASSIC.tokenAddress })],
+  ])("rejects %s instead of attaching another token's supply", async (_label, supply) => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(marketResponse({ supply }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "price-unavailable",
+    });
+  });
+
+  it.each([
+    ["more than five minutes in the future", "2026-08-11T14:05:01.000Z"],
+    ["more than five minutes old", "2026-08-11T13:54:59.000Z"],
+  ])("rejects a token price-index observation %s", async (_label, priceTime) => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: tradeRow({ omitAmountUsd: true }),
+      supply: supplyRow({ time: priceTime }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const pool = values.get(PCAN.tokenAddress)?.pools[0];
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(pool?.latestTrade).not.toHaveProperty("priceUsdWad");
+    expect(pool?.valuation).toEqual({
+      status: "unavailable",
+      reason: "price-unavailable",
+    });
+  });
+
+  it("rejects a future indexed USD observation even when it matches the trade", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: tradeRow({ time: "2026-08-11T14:02:30.000Z" }),
+      supply: supplyRow({ time: "2026-08-11T14:04:00.000Z" }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade)
+      .not.toHaveProperty("priceUsdWad");
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "price-unavailable",
+    });
+  });
+
+  it("fails closed when the raw pool price contradicts the indexed USD price", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: tradeRow({ priceUsd: "0.5" }),
+      supply: supplyRow({ indexedPrice: "0.25" }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const pool = values.get(PCAN.tokenAddress)?.pools[0];
+
+    expect(pool?.latestTrade).toMatchObject({
+      rawPriceUsdWad: "500000000000000000",
+      priceQuoteWad: "100000000000000",
+    });
+    expect(pool?.latestTrade).not.toHaveProperty("priceUsdWad");
+    expect(pool?.valuation).toEqual({
+      status: "unavailable",
+      reason: "price-unavailable",
+    });
+  });
+
+  it("keeps a dust-liquidity pool discoverable but makes its FDV unavailable", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      liquidity: liquidityRow(PCAN, {
+        amountFirstUsd: "4999",
+        amountSecondUsd: "5000",
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const pool = values.get(PCAN.tokenAddress)?.pools[0];
+
+    expect(pool?.identity).toEqual(PCAN);
+    expect(pool?.liquidity?.valueUsdWad).toBe("9999000000000000000000");
+    expect(pool?.valuation).toEqual({
+      status: "unavailable",
+      reason: "inconsistent-market-data",
+    });
+  });
+
+  it("keeps exact quote-unit data when the curated USD price is unavailable", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: tradeRow({ omitPriceUsd: true, omitAmountUsd: true }),
+      supply: supplyRow({ indexedPrice: null }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const pool = values.get(PCAN.tokenAddress)?.pools[0];
+
+    expect(pool?.latestTrade).toMatchObject({
+      priceQuoteWad: "100000000000000",
+      quoteAddress: WETH,
+    });
+    expect(pool?.latestTrade).not.toHaveProperty("priceUsdWad");
+    expect(pool?.valuation).toEqual({
+      status: "unavailable",
+      reason: "price-unavailable",
+    });
+  });
+
+  it("normalizes native ETH without inventing missing liquidity USD", async () => {
+    const nativeEth = "0x0000000000000000000000000000000000000000";
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: tradeRow({
+        omitAmountUsd: true,
+        quoteAddress: nativeEth,
+        quoteSymbol: "ETH",
+      }),
+      liquidity: liquidityRow(PCAN, {
+        omitFirstUsd: true,
+        omitSecondUsd: true,
+        quoteAddress: "0x",
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).toMatchObject({
+      latestTrade: {
+        priceUsdWad: "250000000000000000",
+        quoteAddress: nativeEth,
+      },
+    });
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
+      "liquidity",
+    );
+  });
+
+  it.each([
+    ["Classic", CLASSIC],
+    ["second Custom", SECOND_CUSTOM],
+  ])("keeps the %s identity exact", async (_label, identity) => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(marketResponse({
+        identity,
+        trade: tradeRow({ identity }),
+        supply: supplyRow({ identity }),
+      }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([identity], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    expect(values.get(identity.tokenAddress)?.pools[0]?.identity).toEqual(
+      identity,
+    );
+  });
+
+  it("batches multiple canonical v4 pools without crossing their identities", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body));
+      expect(request.variables).toEqual({
+        pools: [PCAN.poolId, CLASSIC.poolId].sort(),
+        tokenAddresses: [PCAN.tokenAddress, CLASSIC.tokenAddress].sort(),
+      });
+      expect(request.query.match(/latestTrades: DEXTrades\(/gu)).toHaveLength(1);
+      expect(request.query.match(/latestLiquidity: DEXPoolEvents\(/gu)).toHaveLength(1);
+      return jsonResponse({
+        data: {
+          EVM: {
+            latestTrades: [
+              tradeRow({ identity: CLASSIC }),
+              tradeRow({ identity: PCAN }),
+            ],
+            latestLiquidity: [
+              liquidityRow(PCAN),
+              liquidityRow(CLASSIC),
+            ],
+            stats: [PCAN, CLASSIC].map((identity) => ({
+              Trade: {
+                PoolId: identity.poolId,
+                Currency: { SmartContract: identity.tokenAddress },
+              },
+              count: "1",
+              volumeUsd: "10",
+            })),
+          },
+          Trading: {
+            tokenSupplies: [
+              supplyRow({ identity: PCAN }),
+              supplyRow({ identity: CLASSIC }),
+            ],
+          },
+        },
+      });
+    }) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN, CLASSIC], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.identity).toEqual(PCAN);
+    expect(values.get(CLASSIC.tokenAddress)?.pools[0]?.identity).toEqual(CLASSIC);
+  });
+
+  it("uses FDV when circulating supply is absent", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      supply: supplyRow({ circulating: null }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toMatchObject({
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      valueUsdWad: "250000000000000000000000",
+    });
+  });
+
+  it("never turns a third-party circulating estimate into Market cap", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      supply: supplyRow({ total: "100", circulating: "101" }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toMatchObject({
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      valueUsdWad: "25000000000000000000",
+    });
+  });
+
+  it("rejects a total supply above max supply instead of publishing FDV", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      supply: supplyRow({
+        total: "1000001",
+        circulating: null,
+        max: "1000000",
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "inconsistent-market-data",
+    });
+  });
+
+  it("dates valuation to the older supply observation and marks it stale", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: tradeRow({ time: "2026-08-11T13:50:00.000Z" }),
+      liquidity: liquidityRow(PCAN, {
+        time: "2026-08-11T13:50:00.000Z",
+      }),
+      supply: supplyRow({ time: "2026-08-11T13:50:00.000Z" }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toMatchObject({
+      status: "available",
+      asOfTime: "2026-08-11T13:50:00.000Z",
+      freshness: "stale",
+    });
+    expect(marketDataStatusLabel(values.get(PCAN.tokenAddress))).toBe(
+      "Last verified",
+    );
+  });
+
+  it("does not invent total USD liquidity when one pool side is missing", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      liquidity: liquidityRow(PCAN, { omitSecondUsd: true }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const market = values.get(PCAN.tokenAddress);
+    expect(market?.pools[0]).not.toHaveProperty("liquidity");
+    expect(market?.pools[0]?.quality).toBe("partial");
+    expect(marketDataStatusLabel(market)).toBe("Limited market data");
+  });
+
+  it("reports a confirmed empty trade result as Waiting for first trade", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: null,
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    expect(values.get(PCAN.tokenAddress)).toMatchObject({
+      status: "waiting-for-first-trade",
+      pools: [{
+        status: "waiting-for-first-trade",
+        valuation: {
+          status: "unavailable",
+          reason: "waiting-for-first-trade",
+        },
+      }],
+    });
+  });
+
+  it("does not turn a partial response into a false first-trade state", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: null,
+      errors: [{ message: "redacted upstream error" }],
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    expect(values.get(PCAN.tokenAddress)).toMatchObject({
+      status: "unavailable",
+      pools: [{
+        status: "unavailable",
+        valuation: { reason: "source-unavailable" },
+      }],
+    });
+  });
+
+  it("uses only Bitquery last-known-good data during a temporary failure", async () => {
+    const success = vi.fn(async () => jsonResponse(marketResponse())) as typeof fetch;
+    await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl: success,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const failure = vi.fn(async () => {
+      throw new Error("https://provider.invalid/?token=must-not-leak");
+    }) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl: failure,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:03.000Z"),
+    });
+    expect(values.get(PCAN.tokenAddress)).toMatchObject({
+      status: "stale",
+      pools: [{ status: "stale", quality: "partial" }],
+    });
+    expect(JSON.stringify(
+      safeBitqueryMarketDataError(new Error(`secret ${OAUTH_TOKEN}`)),
+    )).not.toContain(OAUTH_TOKEN);
+  });
+
+  it("fails closed without a server token and does not call the network", async () => {
+    const fetchImpl = vi.fn() as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: null,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(values.get(PCAN.tokenAddress)).toMatchObject({
+      status: "unavailable",
+      pools: [{ valuation: { reason: "source-unavailable" } }],
+    });
+  });
+
+  it("prefers a traded pool over a higher-liquidity pool with no trades", () => {
+    const traded = {
+      identity: PCAN,
+      source: "bitquery" as const,
+      status: "current" as const,
+      quality: "partial" as const,
+      asOfTime: "2026-08-11T14:00:00.000Z",
+      latestTrade: {
+        transactionHash: `0x${"aa".repeat(32)}` as `0x${string}`,
+        logIndex: 1,
+        blockNumber: "1",
+        time: "2026-08-11T14:00:00.000Z",
+        tokenSide: "buy" as const,
+        priceUsdWad: "1",
+      },
+      liquidity: {
+        asOfTime: "2026-08-11T14:00:00.000Z",
+        asOfBlock: "1",
+        valueUsdWad: "100",
+        freshness: "current" as const,
+      },
+      valuation: { status: "unavailable" as const, reason: "supply-unavailable" as const },
+    };
+    const waiting = {
+      ...traded,
+      identity: SECOND_CUSTOM,
+      status: "waiting-for-first-trade" as const,
+      liquidity: { ...traded.liquidity, valueUsdWad: "1000000" },
+      valuation: {
+        status: "unavailable" as const,
+        reason: "waiting-for-first-trade" as const,
+      },
+    };
+    expect(selectPrimaryMarketPoolV1([waiting, traded])?.identity).toEqual(PCAN);
+  });
+
+  it("omits a conflicted PoolId from market reads without deleting launch identities", () => {
+    const entry = (address: `0x${string}`, id: string): ExploreEntry => ({
+      exploreKind: "token",
+      id,
+      name: id,
+      symbol: id,
+      tokenAddress: address,
+      hookAddress: "0x2222222222222222222222222222222222222222",
+      poolId: PCAN.poolId,
+      launchedAt: "2026-08-11T14:00:00.000Z",
+      totalSwapFeeBps: 100,
+      liquidityPath: "meme",
+      launchCategoryProvenance: {
+        schemaVersion: "programmable.explore-launch-category-provenance.v1",
+        category: "classic",
+        source: "canonical-launch-read-model",
+        recordId: id,
+        modelId: null,
+        modelVersion: null,
+      },
+    });
+    const launches = [
+      entry(PCAN.tokenAddress, "first"),
+      entry(CLASSIC.tokenAddress, "second"),
+    ];
+
+    expect(launches).toHaveLength(2);
+    expect(exploreEntriesMarketIdentitiesV1(launches)).toEqual([]);
+  });
+});
+
+describe("Bitquery OHLCV chart and server stream", () => {
+  beforeEach(() => clearBitqueryMarketDataCachesForTests());
+
+  it("uses the paid combined dataset for the all-history chart", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body));
+      expect(request.query).toContain("EVM(network: eth, dataset: combined)");
+      expect(request.variables).toEqual({
+        poolId: PCAN.poolId,
+        tokenAddress: PCAN.tokenAddress,
+      });
+      return jsonResponse({
+        data: {
+          EVM: { DEXTrades: [] },
+          Trading: { Tokens: [supplyRow()] },
+        },
+      });
+    }) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "all",
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(chart.status).toBe("waiting-for-first-trade");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds exact-pool quote candles without promoting raw DEX USD", async () => {
+    const trades = [
+      tradeRow({
+        block: "25740000",
+        time: "2026-08-11T14:00:01.000Z",
+        transaction: `0x${"01".repeat(32)}`,
+        priceUsd: "1",
+        priceQuote: "1",
+        amountUsd: "10",
+      }),
+      tradeRow({
+        block: "25740001",
+        time: "2026-08-11T14:00:20.000Z",
+        transaction: `0x${"02".repeat(32)}`,
+        priceUsd: "3",
+        priceQuote: "3",
+        amountUsd: "20",
+      }),
+      tradeRow({
+        block: "25740002",
+        time: "2026-08-11T14:00:40.000Z",
+        transaction: `0x${"03".repeat(32)}`,
+        priceUsd: "2",
+        priceQuote: "2",
+        amountUsd: "30",
+      }),
+      tradeRow({
+        block: "25740003",
+        time: "2026-08-11T14:01:10.000Z",
+        transaction: `0x${"04".repeat(32)}`,
+        priceUsd: "4",
+        priceQuote: "4",
+        amountUsd: "40",
+      }),
+    ].reverse();
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body));
+      expect(request.variables.poolId).toBe(PCAN.poolId);
+      expect(request.query).toContain("DEXTrades(");
+      expect(request.query).toContain("PoolId: { is: $poolId }");
+      expect(request.query).toContain("orderBy: { descending: Block_Time }");
+      expect(request.query).toContain("TransactionStatus: { Success: true }");
+      return jsonResponse({
+        data: {
+          EVM: { DEXTrades: trades },
+          Trading: { Tokens: [supplyRow()] },
+        },
+      });
+    }) as typeof fetch;
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(isMarketChartV1(chart)).toBe(true);
+    expect(chart).toMatchObject({
+      source: "bitquery",
+      status: "ready",
+      identity: PCAN,
+      swapCount: 4,
+      points: [
+        {
+          blockNumber: "25740002",
+          priceQuote: "2",
+          ohlcQuote: { open: "1", high: "3", low: "1", close: "2" },
+          tradeCount: 3,
+        },
+        {
+          blockNumber: "25740003",
+          priceQuote: "4",
+          ohlcQuote: { open: "4", high: "4", low: "4", close: "4" },
+          tradeCount: 1,
+        },
+      ],
+    });
+    expect(chart).not.toHaveProperty("volumeUsdWad");
+    expect(chart.points.every((point) => point.priceUsd === undefined)).toBe(true);
+  });
+
+  it("keeps distinct v4 swaps from the same transaction by log index", async () => {
+    const transaction = `0x${"21".repeat(32)}`;
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      data: {
+        EVM: {
+          DEXTrades: [
+            tradeRow({
+              block: "25740000",
+              time: "2026-08-11T14:00:01.000Z",
+              transaction,
+              logIndex: 1,
+              priceUsd: "1",
+              priceQuote: "1",
+              amountUsd: "10",
+            }),
+            tradeRow({
+              block: "25740000",
+              time: "2026-08-11T14:00:02.000Z",
+              transaction,
+              logIndex: 2,
+              priceUsd: "2",
+              priceQuote: "2",
+              amountUsd: "20",
+            }),
+          ],
+        },
+        Trading: { Tokens: [supplyRow()] },
+      },
+    })) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(chart).toMatchObject({
+      status: "insufficient-history",
+      swapCount: 2,
+      points: [{
+        blockNumber: "25740000",
+        priceQuote: "2",
+        ohlcQuote: { open: "1", high: "2", low: "1", close: "2" },
+        tradeCount: 2,
+      }],
+    });
+    expect(chart).not.toHaveProperty("volumeUsdWad");
+    expect(isMarketChartV1(chart)).toBe(true);
+  });
+
+  it("never promotes raw DEX USD into chart prices or volume", async () => {
+    const trades = [
+      tradeRow({
+        block: "25740000",
+        time: "2026-08-11T14:00:01.000Z",
+        transaction: `0x${"11".repeat(32)}`,
+        priceUsd: "1",
+        priceQuote: "1",
+        amountUsd: "10",
+      }),
+      tradeRow({
+        block: "25740001",
+        time: "2026-08-11T14:00:20.000Z",
+        transaction: `0x${"12".repeat(32)}`,
+        omitPriceUsd: true,
+        omitAmountUsd: true,
+        priceQuote: "1.5",
+      }),
+      tradeRow({
+        block: "25740002",
+        time: "2026-08-11T14:01:10.000Z",
+        transaction: `0x${"13".repeat(32)}`,
+        priceUsd: "2",
+        priceQuote: "2",
+        amountUsd: "20",
+      }),
+    ];
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      data: {
+        EVM: { DEXTrades: trades },
+        Trading: { Tokens: [supplyRow({ indexedPrice: null })] },
+      },
+    })) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(isMarketChartV1(chart)).toBe(true);
+    expect(chart.status).toBe("ready");
+    expect(chart).not.toHaveProperty("volumeUsdWad");
+    expect(chart.points[0]).toMatchObject({
+      priceQuote: "1.5",
+      ohlcQuote: { open: "1", high: "1.5", low: "1", close: "1.5" },
+      tradeCount: 2,
+    });
+    expect(chart.points[0]).not.toHaveProperty("priceUsd");
+    expect(chart.points[0]).not.toHaveProperty("ohlcUsd");
+    expect(chart.points[0]).not.toHaveProperty("volumeUsdWad");
+  });
+
+  it("keeps the OAuth token server-side while applying typed live updates", () => {
+    class FakeWebSocket {
+      static instances: FakeWebSocket[] = [];
+      readonly listeners = new Map<string, Array<(event: { data?: string }) => void>>();
+      readonly sent: string[] = [];
+      closed = false;
+
+      constructor(readonly url: string | URL, readonly protocols?: string | string[]) {
+        FakeWebSocket.instances.push(this);
+      }
+
+      addEventListener(type: string, listener: (event: { data?: string }) => void) {
+        const values = this.listeners.get(type) ?? [];
+        values.push(listener);
+        this.listeners.set(type, values);
+      }
+
+      send(value: string) {
+        this.sent.push(value);
+      }
+
+      close() {
+        this.closed = true;
+      }
+
+      emit(type: string, event: { data?: string } = {}) {
+        for (const listener of this.listeners.get(type) ?? []) listener(event);
+      }
+    }
+
+    const onData = vi.fn();
+    const onError = vi.fn();
+    const stream = createBitqueryMarketStreamV1({
+      identities: [PCAN, CLASSIC, SECOND_CUSTOM],
+      token: OAUTH_TOKEN,
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+      onData,
+      onError,
+    });
+    stream.start();
+    const socket = FakeWebSocket.instances[0];
+    expect(String(socket.url)).toContain("?token=");
+    expect(String(socket.url)).toContain(encodeURIComponent(OAUTH_TOKEN));
+    socket.emit("open");
+    socket.emit("message", {
+      data: JSON.stringify({ type: "connection_ack" }),
+    });
+    expect(socket.sent.join("\n")).toContain("connection_init");
+    expect(socket.sent.join("\n")).toContain(PCAN.poolId);
+    expect(socket.sent.join("\n")).toContain(CLASSIC.poolId);
+    expect(socket.sent.join("\n")).toContain(SECOND_CUSTOM.poolId);
+    expect(socket.sent.join("\n")).toContain("uniswap_v4");
+    expect(BITQUERY_MARKET_STREAM_QUERY).toContain(
+      "Pool: { PoolId: { in: $poolIds } }",
+    );
+    expect(BITQUERY_MARKET_STREAM_QUERY.match(/DEXTrades\(/gu)).toHaveLength(1);
+    expect(BITQUERY_MARKET_STREAM_QUERY.match(/DEXPoolEvents\(/gu)).toHaveLength(1);
+    expect(
+      BITQUERY_MARKET_STREAM_QUERY.match(
+        /TransactionStatus: \{ Success: true \}/gu,
+      ),
+    ).toHaveLength(2);
+    expect(socket.sent.filter((value) => value.includes('"type":"start"')))
+      .toHaveLength(1);
+    socket.emit("message", {
+      data: JSON.stringify({
+        id: "programmable-market-stream",
+        type: "data",
+        payload: { data: { EVM: {
+          DEXTrades: [tradeRow({ time: new Date().toISOString() })],
+          DEXPoolEvents: [liquidityRow()],
+        } } },
+      }),
+    });
+    expect(onData).toHaveBeenCalledWith(expect.objectContaining({
+      identity: PCAN,
+      market: expect.objectContaining({ source: "bitquery", status: "current" }),
+    }));
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(JSON.stringify(onData.mock.calls)).not.toContain(OAUTH_TOKEN);
+    stream.stop();
+    expect(socket.closed).toBe(true);
+  });
+});

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -894,6 +894,50 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(isMarketChartV1(chart)).toBe(true);
   });
 
+  it("never presents a populated chart fallback as a live provider read", async () => {
+    const success = vi.fn(async () => jsonResponse({
+      data: {
+        EVM: {
+          DEXTrades: [tradeRow({
+            block: "25740000",
+            time: "2026-08-11T14:01:00.000Z",
+            transaction: `0x${"44".repeat(32)}`,
+            priceQuote: "1",
+          })],
+        },
+        Trading: { Tokens: [supplyRow()] },
+      },
+    })) as typeof fetch;
+    const live = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl: success,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    expect(live).toMatchObject({ readStatus: "live", status: "insufficient-history" });
+
+    const failure = vi.fn(async () => {
+      throw new Error("provider unavailable");
+    }) as typeof fetch;
+    const fallback = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl: failure,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:03.000Z"),
+    });
+
+    expect(fallback).toMatchObject({
+      readStatus: "cache-fallback",
+      status: "partial",
+      generatedAt: live.generatedAt,
+      valuation: { status: "available", freshness: "stale" },
+    });
+    expect(fallback.points).toHaveLength(1);
+    expect(isMarketChartV1(fallback)).toBe(true);
+  });
+
   it("builds exact-pool quote candles without promoting raw DEX USD", async () => {
     const trades = [
       tradeRow({

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -569,6 +569,7 @@ describe("read-model performance contract", () => {
     ).toEqual([
       "source-cache-exploreList",
       "source-cache-tokenDetail",
+      "source-cache-tokenChart",
       "source-cache-tokenList",
       "source-cache-publicIndexer",
     ]);
@@ -939,8 +940,9 @@ describe("read-model performance contract", () => {
     const exactFalse = deployPolicy.RELEASE_GATED_FLAG_NAMES.map(
       (name: string) => `${name}="false"`,
     ).join("\n");
+    const bitquerySecret = '\nBITQUERY_OAUTH_TOKEN="[Sensitive]"';
     const alchemy = deployPolicy.evaluateReadModelDeployPolicy(
-      `${exactFalse}\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL}"`,
+      `${exactFalse}\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL}"${bitquerySecret}`,
       {},
     );
     expect(alchemy).toMatchObject({
@@ -953,7 +955,7 @@ describe("read-model performance contract", () => {
     const indexedEnvironment = `${exactFalse.replace(
       "INDEXED_EXPLORE_TOKEN_READS_ENABLED=\"false\"",
       "INDEXED_EXPLORE_TOKEN_READS_ENABLED=\"true\"",
-    )}\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL}"\nPROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL}"`;
+    )}\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL}"\nPROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL}"${bitquerySecret}`;
     const indexed = deployPolicy.evaluateReadModelDeployPolicy(
       indexedEnvironment,
       {
@@ -972,7 +974,7 @@ describe("read-model performance contract", () => {
     const sensitiveRuntimeEnvironment = `${exactFalse.replace(
       "INDEXED_EXPLORE_TOKEN_READS_ENABLED=\"false\"",
       "INDEXED_EXPLORE_TOKEN_READS_ENABLED=\"[sensitive]\"",
-    )}\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL="[sensitive]"\nPROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL="[sensitive]"`;
+    )}\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL="[sensitive]"\nPROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL="[sensitive]"${bitquerySecret}`;
     expect(
       deployPolicy.evaluateReadModelDeployPolicy(
         sensitiveRuntimeEnvironment,
@@ -1007,7 +1009,7 @@ describe("read-model performance contract", () => {
     const publicFeedEnvironment = `${exactFalse.replace(
       "INDEXED_PUBLIC_INDEXER_FEED_READS_ENABLED=\"false\"",
       "INDEXED_PUBLIC_INDEXER_FEED_READS_ENABLED=\"true\"",
-    )}\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL}"\nPROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL}"`;
+    )}\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL}"\nPROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL="${RUNTIME_RPC_ENVIRONMENT.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL}"${bitquerySecret}`;
     expect(
       deployPolicy.evaluateReadModelDeployPolicy(publicFeedEnvironment, {
         PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT:
@@ -1290,30 +1292,30 @@ describe("read-model performance contract", () => {
         process.cwd(),
       );
     expect(alchemyResult.ok).toBe(true);
-    expect(alchemyResult.checks).toHaveLength(15);
+    expect(alchemyResult.checks).toHaveLength(17);
 
-    const exploreConsumerPath = "lib/explore-consumer.server.ts";
-    const exploreConsumerSource = readFileSync(
-      resolve(process.cwd(), exploreConsumerPath),
+    const exploreRoutePath = "app/api/explore/route.ts";
+    const exploreRouteSource = readFileSync(
+      resolve(process.cwd(), exploreRoutePath),
       "utf8",
     );
-    const staleProviderProvenance =
+    const staleMarketProvenance =
       alchemySourceContracts.evaluateAlchemyExploreSourceContracts(
         process.cwd(),
         {
           sourceOverrides: {
-            [exploreConsumerPath]: exploreConsumerSource.replace(
-              '? "operational-dual"',
-              '? "alchemy"',
+            [exploreRoutePath]: exploreRouteSource.replaceAll(
+              '"X-Programmable-Market-Source": "bitquery"',
+              '"X-Programmable-Market-Source": "alchemy"',
             ),
           },
         },
       );
     expect(
-      staleProviderProvenance.failures.map(
+      staleMarketProvenance.failures.map(
         (failure: { id: string }) => failure.id,
       ),
-    ).toContain("alchemy-explore-provenance");
+    ).toContain("bitquery-market-provenance");
 
     const result = sourceContracts.evaluateReadModelSourceContracts(
       process.cwd(),
@@ -1322,6 +1324,7 @@ describe("read-model performance contract", () => {
     const disconnectedIndexedFailures = [
       "source-cache-exploreList",
       "source-cache-tokenDetail",
+      "source-cache-tokenChart",
       "source-cache-tokenList",
       "source-cache-publicIndexer",
     ];

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -755,6 +755,8 @@ describe("read-model production deploy policy", () => {
     );
     expect(workflow).toContain("const historicalPaidPathVerified =");
     expect(workflow).toContain("goldenParity.confirmations >= 12");
+    expect(workflow).toContain('goldenChart.readStatus !== "live"');
+    expect(workflow).toContain('goldenChart.readStatus === "live"');
     expect(workflow).toContain(
       "currentFdvCount < 1 && !historicalPaidPathVerified",
     );

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -666,11 +666,15 @@ describe("read-model production deploy policy", () => {
     expect(workflow).toContain(
       'marketSources: Object.freeze(["bitquery"]),',
     );
+    expect(workflow).toContain(
+      'dataQualities: Object.freeze(["complete", "partial", "stale"]),',
+    );
     expect(workflow).toContain("rpcProviders: null");
     expect(workflow).not.toContain("alchemyIdentityContract");
     expect(workflow).toContain('"x-programmable-market-source",');
     expect(workflow).toContain('"x-programmable-price-source",');
     expect(workflow).toContain('"x-programmable-market-as-of",');
+    expect(workflow).toContain('"x-programmable-data-quality",');
     expect(workflow).toContain(
       "!headerMatches(rpcProvider, contract.rpcProviders)",
     );
@@ -733,7 +737,7 @@ describe("read-model production deploy policy", () => {
     expect(workflow).toContain(
       'valuation.reason === "waiting-for-first-trade"',
     );
-    expect(workflow).not.toContain("currentFdvCount < 1");
+    expect(workflow).not.toContain("if (currentFdvCount < 1) {");
     expect(workflow).toContain(
       "staged Bitquery current Explore and detail FDV are not identical",
     );
@@ -742,6 +746,17 @@ describe("read-model production deploy policy", () => {
     );
     expect(workflow).toContain(
       'goldenValuation.supplyBasis !== "total"',
+    );
+    expect(workflow).toContain(
+      '"./scripts/perf/bitquery-golden-market-parity.mjs"',
+    );
+    expect(workflow).toContain(
+      "await verifyBitqueryGoldenMarketParityV1({",
+    );
+    expect(workflow).toContain("const historicalPaidPathVerified =");
+    expect(workflow).toContain("goldenParity.confirmations >= 12");
+    expect(workflow).toContain(
+      "currentFdvCount < 1 && !historicalPaidPathVerified",
     );
     expect(workflow).toContain(
       "goldenChart.asOfTime !== goldenChart.points.at(-1)?.time",

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -13,6 +13,7 @@ const {
   createStagedReleaseAttestation,
   evaluateReadModelDeployPolicy,
   materializeVercelSensitiveRuntimePlaceholders,
+  BITQUERY_MARKET_SECRET_ENV_NAME,
   PROJECTOR_WAKE_ROUTE,
   readReleasePolicyExpectations,
   validateStagedReleaseAttestation,
@@ -42,6 +43,14 @@ const COMMITMENTS = Object.freeze({
     ).endpointCommitment,
 });
 
+function sensitiveProductionMetadata(name: string) {
+  return {
+    key: name,
+    type: "sensitive",
+    target: ["production"],
+  };
+}
+
 function environmentFile(input: {
   indexed?: Partial<Record<string, string | undefined>>;
   workers?: Partial<Record<string, string | undefined>>;
@@ -62,7 +71,10 @@ function environmentFile(input: {
     ),
     ...EXPECTATIONS,
     ...Object.fromEntries(
-      REQUIRED_SERVER_SECRET_ENV_NAMES.map((name: string) => [name, ""]),
+      REQUIRED_SERVER_SECRET_ENV_NAMES.map((name: string) => [
+        name,
+        name === BITQUERY_MARKET_SECRET_ENV_NAME ? "[Sensitive]" : "",
+      ]),
     ),
     ...(alchemyRuntime === null
       ? {}
@@ -88,6 +100,7 @@ describe("read-model production deploy policy", () => {
     const contents = environmentFile({
       workers: { PROGRAMMABLE_PROJECTOR_ACTIVE: "true" },
       alchemyRuntime: null,
+      serverSecrets: { [BITQUERY_MARKET_SECRET_ENV_NAME]: "" },
     }).concat(
       "\nPROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL=\nPROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL=",
     );
@@ -103,11 +116,7 @@ describe("read-model production deploy policy", () => {
           type: "sensitive",
           target: ["production"],
         },
-        {
-          key: QUICKNODE_STREAM_SECRET_ENV_NAME,
-          type: "sensitive",
-          target: ["production"],
-        },
+        ...REQUIRED_SERVER_SECRET_ENV_NAMES.map(sensitiveProductionMetadata),
       ],
     });
     const materialized = materializeVercelSensitiveRuntimePlaceholders(
@@ -158,11 +167,9 @@ describe("read-model production deploy policy", () => {
           JSON.stringify({
             envs: [
               ...(entry ? [entry] : []),
-              {
-                key: QUICKNODE_STREAM_SECRET_ENV_NAME,
-                type: "sensitive",
-                target: ["production"],
-              },
+              ...REQUIRED_SERVER_SECRET_ENV_NAMES.map(
+                sensitiveProductionMetadata,
+              ),
             ],
           }),
         ),
@@ -172,19 +179,20 @@ describe("read-model production deploy policy", () => {
 
   it("requires exact sensitive QuickNode stream-secret metadata", () => {
     const contents = environmentFile();
-    const exact = {
-      key: QUICKNODE_STREAM_SECRET_ENV_NAME,
-      type: "sensitive",
-      target: ["production"],
-    };
+    const exact = sensitiveProductionMetadata(
+      QUICKNODE_STREAM_SECRET_ENV_NAME,
+    );
+    const otherSecrets = REQUIRED_SERVER_SECRET_ENV_NAMES
+      .filter((name: string) => name !== QUICKNODE_STREAM_SECRET_ENV_NAME)
+      .map(sensitiveProductionMetadata);
     for (const envs of [
-      [],
-      [{ ...exact, type: "plain" }],
-      [{ ...exact, type: "encrypted" }],
-      [{ ...exact, target: ["preview"] }],
-      [{ ...exact, target: ["production", "preview"] }],
-      [{ ...exact, value: "must-not-be-present" }],
-      [exact, exact],
+      otherSecrets,
+      [...otherSecrets, { ...exact, type: "plain" }],
+      [...otherSecrets, { ...exact, type: "encrypted" }],
+      [...otherSecrets, { ...exact, target: ["preview"] }],
+      [...otherSecrets, { ...exact, target: ["production", "preview"] }],
+      [...otherSecrets, { ...exact, value: "must-not-be-present" }],
+      [...otherSecrets, exact, exact],
     ]) {
       expect(() =>
         materializeVercelSensitiveRuntimePlaceholders(
@@ -195,6 +203,63 @@ describe("read-model production deploy policy", () => {
     }
   });
 
+  it("requires Bitquery as exact sensitive production metadata in every mode", () => {
+    expect(BITQUERY_MARKET_SECRET_ENV_NAME).toBe("BITQUERY_OAUTH_TOKEN");
+    expect(REQUIRED_SERVER_SECRET_ENV_NAMES).toContain(
+      BITQUERY_MARKET_SECRET_ENV_NAME,
+    );
+    const otherSecrets = REQUIRED_SERVER_SECRET_ENV_NAMES
+      .filter((name: string) => name !== BITQUERY_MARKET_SECRET_ENV_NAME)
+      .map(sensitiveProductionMetadata);
+    const exact = sensitiveProductionMetadata(BITQUERY_MARKET_SECRET_ENV_NAME);
+    const withoutBitqueryLine = environmentFile({
+      serverSecrets: { [BITQUERY_MARKET_SECRET_ENV_NAME]: undefined },
+    });
+    for (const entry of [
+      undefined,
+      { ...exact, type: "plain" },
+      { ...exact, target: ["preview"] },
+      { ...exact, target: ["production", "preview"] },
+      { ...exact, value: "must-not-be-present" },
+    ]) {
+      expect(() =>
+        materializeVercelSensitiveRuntimePlaceholders(
+          withoutBitqueryLine,
+          JSON.stringify({ envs: [...otherSecrets, ...(entry ? [entry] : [])] }),
+        )
+      ).toThrow(/BITQUERY_OAUTH_TOKEN is not exact sensitive production metadata/u);
+    }
+    expect(() =>
+      materializeVercelSensitiveRuntimePlaceholders(
+        withoutBitqueryLine,
+        JSON.stringify({ envs: [...otherSecrets, exact, exact] }),
+      )
+    ).toThrow(/BITQUERY_OAUTH_TOKEN is not exact sensitive production metadata/u);
+
+    const materialized = materializeVercelSensitiveRuntimePlaceholders(
+      withoutBitqueryLine,
+      JSON.stringify({ envs: [...otherSecrets, exact] }),
+    );
+    expect(materialized).toContain('BITQUERY_OAUTH_TOKEN="[Sensitive]"');
+    expect(
+      evaluateReadModelDeployPolicy(materialized, {}, EXPECTATIONS),
+    ).toMatchObject({
+      mode: "alchemy-only",
+      policyReady: true,
+      invalidServerSecretEnvironmentNames: [],
+    });
+
+    const missingRuntimeToken = evaluateReadModelDeployPolicy(
+      withoutBitqueryLine,
+      {},
+      EXPECTATIONS,
+    );
+    expect(missingRuntimeToken.policyReady).toBe(false);
+    expect(missingRuntimeToken.invalidServerSecretEnvironmentNames).toEqual([
+      BITQUERY_MARKET_SECRET_ENV_NAME,
+    ]);
+  });
+
   it("preserves a materialized QuickNode stream secret byte-for-byte", () => {
     const contents = environmentFile({
       serverSecrets: {
@@ -202,7 +267,12 @@ describe("read-model production deploy policy", () => {
       },
     });
     expect(
-      materializeVercelSensitiveRuntimePlaceholders(contents, "not-json"),
+      materializeVercelSensitiveRuntimePlaceholders(
+        contents,
+        JSON.stringify({
+          envs: [sensitiveProductionMetadata(BITQUERY_MARKET_SECRET_ENV_NAME)],
+        }),
+      ),
     ).toBe(contents);
   });
 
@@ -567,7 +637,7 @@ describe("read-model production deploy policy", () => {
     expect(PROJECTOR_WAKE_ROUTE).toBe("/api/ops/projector-wake");
   });
 
-  it("smokes the Alchemy-only public APIs and stops at a staged candidate", () => {
+  it("smokes registry identity plus Bitquery market APIs and stops at a staged candidate", () => {
     const workflow = readFileSync(
       resolve(ROOT, ".github/workflows/deploy-production.yml"),
       "utf8",
@@ -582,49 +652,40 @@ describe("read-model production deploy policy", () => {
     expect(workflow.match(/--sensitive-env-metadata/g)).toHaveLength(2);
     expect(workflow).toContain("staged-release-attestation.json");
     expect(workflow).toContain("attestation_sha256");
-    expect(workflow).toContain("Smoke staged Alchemy Explore APIs");
+    expect(workflow).toContain("Smoke staged Bitquery market APIs");
     expect(workflow).toContain(
       "if: steps.read-model-policy.outputs.mode == 'alchemy-only'",
     );
     expect(workflow).toContain(
       '"x-vercel-protection-bypass": automationBypassSecret',
     );
-    expect(workflow).toContain("headers: alchemySmokeRequestHeaders");
+    expect(workflow).toContain("headers: bitquerySmokeRequestHeaders");
     expect(workflow).toContain(
-      'const operationalReadSources = Object.freeze([',
+      'readSources: Object.freeze(["operational+durable+postgres"]),',
     );
     expect(workflow).toContain(
-      '"operational+durable+postgres",',
+      'marketSources: Object.freeze(["bitquery"]),',
+    );
+    expect(workflow).toContain("rpcProviders: null");
+    expect(workflow).not.toContain("alchemyIdentityContract");
+    expect(workflow).toContain('"x-programmable-market-source",');
+    expect(workflow).toContain('"x-programmable-price-source",');
+    expect(workflow).toContain('"x-programmable-market-as-of",');
+    expect(workflow).toContain(
+      "!headerMatches(rpcProvider, contract.rpcProviders)",
     );
     expect(workflow).toContain(
-      'const operationalRpcProviders = Object.freeze([',
+      "!headerMatches(marketSource, contract.marketSources)",
     );
     expect(workflow).toContain(
-      '"operational-dual",\n            "operational-primary",',
-    );
-    expect(workflow).toContain(
-      'const alchemyRpcProviders = Object.freeze(["alchemy"]);',
-    );
-    expect(workflow).toContain(
-      'const alchemyReadSources = Object.freeze(["blob"]);',
-    );
-    expect(workflow).toContain(
-      'expectedReadSources,\n            expectedRpcProviders,',
-    );
-    expect(workflow).toContain(
-      '!expectedReadSources.includes(readSource ?? "")',
-    );
-    expect(workflow).toContain(
-      '!expectedRpcProviders.includes(rpcProvider ?? "")',
+      "!headerMatches(priceSource, contract.priceSources)",
     );
     expect(workflow).not.toContain(
       'response.headers.get("x-programmable-rpc-provider") !== "alchemy"',
     );
+    expect(workflow).not.toContain('"/api/indexers/v1/token-list"');
     expect(workflow).toContain(
-      '"/api/indexers/v1/token-list",\n            alchemyReadSources,\n            alchemyRpcProviders,',
-    );
-    expect(workflow).toContain(
-      '"/api/explore?limit=20&page=1&sort=market-cap",\n            operationalReadSources,\n            operationalRpcProviders,',
+      '"/api/explore?limit=20&page=1&sort=market-cap",\n            bitqueryMarketContract,',
     );
     expect(workflow).toContain("entry.launchCategoryProvenance.blockNumber");
     expect(workflow).toContain(
@@ -632,7 +693,7 @@ describe("read-model production deploy policy", () => {
     );
     expect(workflow).toContain("entry.launchCategoryProvenance.logIndex");
     expect(workflow).toContain(
-      "staged Alchemy newest entry has no canonical launch order",
+      "staged Bitquery newest entry has no canonical launch order",
     );
     expect(workflow).toContain("coordinates === null");
     expect(workflow).toContain("const newestPageSize = 100");
@@ -641,20 +702,67 @@ describe("read-model production deploy policy", () => {
     expect(workflow).toContain("launchChainId(entry) !== newestChainId");
     expect(workflow).toContain("sort=oldest");
     expect(workflow).toContain(
-      "staged Alchemy oldest page is not ordered oldest-first",
+      "staged Bitquery oldest page is not ordered oldest-first",
     );
-    expect(workflow).toContain('"/api/indexers/v1/token-list"');
     expect(workflow).toContain("/api/explore/token?address=");
-    const alchemySmoke = workflow.slice(
-      workflow.indexOf("Smoke staged Alchemy Explore APIs"),
-      workflow.indexOf("Record Alchemy-only read path"),
+    expect(workflow).toContain(
+      "/api/explore/token/chart?address=${goldenTokenAddress}&range=all",
     );
-    expect(alchemySmoke.match(/operationalRpcProviders/g)).toHaveLength(7);
-    expect(alchemySmoke.match(/alchemyRpcProviders/g)).toHaveLength(2);
-    expect(alchemySmoke).not.toContain("/api/ops/health");
-    expect(alchemySmoke).not.toContain("/api/explore/profile");
-    expect(alchemySmoke).not.toMatch(
-      /(?:database|projector|quicknode|envio|real-block|sla)/iu,
+    expect(workflow).toContain(
+      '"0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"',
+    );
+    expect(workflow).toContain(
+      '"0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229"',
+    );
+    expect(workflow).toContain(
+      'goldenMarket?.schemaVersion !== "programmable.market-data.v1"',
+    );
+    expect(workflow).toContain(
+      'goldenChart.schemaVersion !== "programmable.market-chart.v1"',
+    );
+    expect(workflow).toContain(
+      "staged Bitquery Highest FDV is not monotonically descending",
+    );
+    expect(workflow).toContain(
+      "staged Bitquery Explore exposed stale or unavailable FDV as current",
+    );
+    expect(workflow).toContain(
+      "staged Bitquery Explore mislabeled stale FDV as current",
+    );
+    expect(workflow).toContain('valuation.freshness === "stale"');
+    expect(workflow).toContain(
+      'valuation.reason === "waiting-for-first-trade"',
+    );
+    expect(workflow).not.toContain("currentFdvCount < 1");
+    expect(workflow).toContain(
+      "staged Bitquery current Explore and detail FDV are not identical",
+    );
+    expect(workflow).toContain(
+      'goldenValuation.metric !== "fdv"',
+    );
+    expect(workflow).toContain(
+      'goldenValuation.supplyBasis !== "total"',
+    );
+    expect(workflow).toContain(
+      "goldenChart.asOfTime !== goldenChart.points.at(-1)?.time",
+    );
+    expect(workflow).toContain(
+      "staged PCAN chart is not a strictly ordered positive history",
+    );
+    const bitquerySmoke = workflow.slice(
+      workflow.indexOf("Smoke staged Bitquery market APIs"),
+      workflow.indexOf("Record registry identity and Bitquery market path"),
+    );
+    expect(bitquerySmoke).toContain(
+      "/api/explore?limit=20&page=1&q=${goldenTokenAddress}&sort=market-cap",
+    );
+    expect(bitquerySmoke.match(/bitqueryMarketContract/g)).toHaveLength(10);
+    expect(bitquerySmoke.match(/bitqueryChartContract/g)).toHaveLength(2);
+    expect(bitquerySmoke).not.toContain("alchemyIdentityContract");
+    expect(bitquerySmoke).not.toContain("/api/ops/health");
+    expect(bitquerySmoke).not.toContain("/api/explore/profile");
+    expect(bitquerySmoke).not.toMatch(
+      /\b(?:database|projector|quicknode|envio|real-block|sla)\b/iu,
     );
     expect(workflow).toContain("Reverify staged candidate binding");
     expect(workflow).toContain("Record staged candidate handoff");

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -15,6 +15,10 @@ const ROOT = process.cwd();
 const DEPLOYMENT_ID = "dpl_aaaaaaaaaaaaaaaaaaaaaaaa";
 const GIT_HEAD = "b".repeat(40);
 const PROJECT_ID = "prj_programmable_test";
+const GOLDEN_TOKEN_ADDRESS =
+  "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
+const GOLDEN_POOL_ID =
+  "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
 
 const AUTHENTICATED_ROUTE = `
   import { timingSafeEqual } from "node:crypto";
@@ -277,11 +281,10 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("fails closed when the protected Alchemy staged smoke bypass is missing", () => {
+  it("fails closed when the protected Bitquery staged smoke bypass is missing", () => {
     const workflowPath = ".github/workflows/deploy-production.yml";
-    const alchemyStep =
-      "      - name: Smoke staged Alchemy Explore APIs\n" +
-      "        if: steps.read-model-policy.outputs.mode == 'alchemy-only'\n" +
+    const bitqueryStep =
+      "      - name: Smoke staged Bitquery market APIs\n" +
       "        env:\n" +
       "          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}\n" +
       "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}\n";
@@ -289,8 +292,8 @@ describe("read-model operations source contract", () => {
       resolve(ROOT, workflowPath),
       "utf8",
     ).replace(
-      alchemyStep,
-      alchemyStep.replace(
+      bitqueryStep,
+      bitqueryStep.replace(
         "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}\n",
         "",
       ),
@@ -306,34 +309,54 @@ describe("read-model operations source contract", () => {
       expectedSha256Overrides: fixtureDigests(),
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
-      "ops-protected-alchemy-stage-smoke",
+      "ops-protected-bitquery-stage-smoke",
     );
   });
 
-  it("rejects an Alchemy staged smoke bypass relocated to another workflow step", () => {
+  it("fails closed when the Bitquery staged smoke stops proving current FDV order", () => {
+    const workflowPath = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const unsafeWorkflow = workflow.replace(
+      '"staged Bitquery Highest FDV is not monotonically descending"',
+      '"staged Bitquery order was not checked"',
+    );
+    expect(unsafeWorkflow).not.toBe(workflow);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
+  it("rejects a Bitquery staged smoke bypass relocated to another workflow step", () => {
     const workflowPath = ".github/workflows/deploy-production.yml";
     const secretLine =
       "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}\n";
     const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
-    const alchemyStepStart = workflow.indexOf(
-      "      - name: Smoke staged Alchemy Explore APIs",
+    const bitqueryStepStart = workflow.indexOf(
+      "      - name: Smoke staged Bitquery market APIs",
     );
-    const alchemyStepEnd = workflow.indexOf(
-      "      - name: Record Alchemy-only read path",
+    const bitqueryStepEnd = workflow.indexOf(
+      "      - name: Record registry identity and Bitquery market path",
     );
-    expect(alchemyStepStart).toBeGreaterThanOrEqual(0);
-    expect(alchemyStepEnd).toBeGreaterThan(alchemyStepStart);
-    const alchemyStep = workflow.slice(alchemyStepStart, alchemyStepEnd);
-    expect(alchemyStep).toContain(secretLine);
-    const unsafeAlchemyStep = alchemyStep.replace(secretLine, "");
+    expect(bitqueryStepStart).toBeGreaterThanOrEqual(0);
+    expect(bitqueryStepEnd).toBeGreaterThan(bitqueryStepStart);
+    const bitqueryStep = workflow.slice(bitqueryStepStart, bitqueryStepEnd);
+    expect(bitqueryStep).toContain(secretLine);
+    const unsafeBitqueryStep = bitqueryStep.replace(secretLine, "");
     const unsafeWorkflow =
-      workflow.slice(0, alchemyStepStart) +
-      unsafeAlchemyStep +
+      workflow.slice(0, bitqueryStepStart) +
+      unsafeBitqueryStep +
       workflow
-        .slice(alchemyStepEnd)
+        .slice(bitqueryStepEnd)
         .replace(
-          "      - name: Record Alchemy-only read path\n",
-          `      - name: Record Alchemy-only read path\n        env:\n${secretLine}`,
+          "      - name: Record registry identity and Bitquery market path\n",
+          `      - name: Record registry identity and Bitquery market path\n        env:\n${secretLine}`,
         );
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: {
@@ -343,7 +366,7 @@ describe("read-model operations source contract", () => {
       expectedSha256Overrides: fixtureDigests(),
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
-      "ops-protected-alchemy-stage-smoke",
+      "ops-protected-bitquery-stage-smoke",
     );
   });
 
@@ -378,7 +401,7 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("fails closed when the Alchemy staged smoke drops the bypass header", () => {
+  it("fails closed when the Bitquery staged smoke drops the bypass header", () => {
     const workflowPath = ".github/workflows/deploy-production.yml";
     const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
     const unsafeWorkflow = workflow.replace(
@@ -394,7 +417,7 @@ describe("read-model operations source contract", () => {
       expectedSha256Overrides: fixtureDigests(),
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
-      "ops-protected-alchemy-stage-smoke",
+      "ops-protected-bitquery-stage-smoke",
     );
   });
 
@@ -613,6 +636,13 @@ describe("read-model operations source contract", () => {
 function publicFetch(healthStatus = "healthy") {
   return async (input: URL | RequestInfo) => {
     const url = new URL(String(input));
+    const marketAsOf = new Date(Date.now() - 60 * 60_000).toISOString();
+    const earlierMarketTime = new Date(Date.now() - 2 * 60 * 60_000).toISOString();
+    const bitqueryHeaders = {
+      "X-Programmable-Market-As-Of": marketAsOf,
+      "X-Programmable-Market-Source": "bitquery",
+      "X-Programmable-Read-Source": "operational+durable+postgres",
+    };
     if (url.hostname === "api.vercel.com") {
       return Response.json({
         id: DEPLOYMENT_ID,
@@ -637,10 +667,91 @@ function publicFetch(healthStatus = "healthy") {
       );
     }
     if (url.pathname === "/api/explore") {
-      return Response.json({ status: "ready", tokens: [{}] });
+      return Response.json({
+        status: "ready",
+        tokens: [{
+          tokenAddress: GOLDEN_TOKEN_ADDRESS,
+          valuation: {
+            status: "available",
+            metric: "fdv",
+            supplyBasis: "total",
+            currency: "usd",
+            source: "bitquery",
+            freshness: "stale",
+            valueWad: "250000000000000000000000",
+            asOfTime: marketAsOf,
+          },
+        }],
+        dataQuality: { valuation: { asOfTime: marketAsOf } },
+      }, { headers: bitqueryHeaders });
     }
-    if (url.pathname === "/api/indexers/v1/token-list") {
-      return Response.json({ tokens: [{}] });
+    if (url.pathname === "/api/explore/token") {
+      return Response.json({
+        status: "ready",
+        token: {
+          tokenAddress: GOLDEN_TOKEN_ADDRESS,
+          valuation: {
+            status: "available",
+            metric: "fdv",
+            supplyBasis: "total",
+            currency: "usd",
+            source: "bitquery",
+            freshness: "stale",
+            valueWad: "250000000000000000000000",
+            asOfTime: marketAsOf,
+          },
+          marketData: {
+            schemaVersion: "programmable.market-data.v1",
+            source: "bitquery",
+            status: "stale",
+            primaryPoolId: GOLDEN_POOL_ID,
+            pools: [{
+              identity: { poolId: GOLDEN_POOL_ID },
+              status: "stale",
+            }],
+          },
+        },
+      }, {
+        headers: {
+          "X-Programmable-Market-Source": "bitquery",
+          "X-Programmable-Read-Source": "operational+durable+postgres",
+        },
+      });
+    }
+    if (url.pathname === "/api/explore/token/chart") {
+      return Response.json({
+        schemaVersion: "programmable.market-chart.v1",
+        source: "bitquery",
+        status: "ready",
+        address: GOLDEN_TOKEN_ADDRESS,
+        identity: { poolId: GOLDEN_POOL_ID },
+        points: [
+          {
+            blockNumber: "25730000",
+            time: earlierMarketTime,
+            priceUsd: "0.2",
+          },
+          {
+            blockNumber: "25731000",
+            time: marketAsOf,
+            priceUsd: "0.25",
+          },
+        ],
+        valuation: {
+          status: "available",
+          metric: "fdv",
+          supplyBasis: "total",
+          freshness: "stale",
+          asOfTime: marketAsOf,
+        },
+        asOfTime: marketAsOf,
+      }, {
+        headers: {
+          "X-Programmable-Market-As-Of": marketAsOf,
+          "X-Programmable-Market-Source": "bitquery",
+          "X-Programmable-Price-Source": "bitquery",
+        },
+      });
     }
     return Response.json({ error: "not found" }, { status: 404 });
   };
@@ -671,7 +782,8 @@ describe("post-promotion route verification", () => {
       "production-root",
       "production-health",
       "production-explore",
-      "production-token-list",
+      "production-bitquery-detail",
+      "production-bitquery-chart",
     ]);
   });
 
@@ -713,6 +825,42 @@ describe("post-promotion route verification", () => {
         return Response.json({ status: "ready", tokens: [] });
       }
       return base(input);
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-explore" }),
+    );
+  });
+
+  it("rejects missing public Bitquery provenance", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      const response = await base(input);
+      if (url.pathname !== "/api/explore/token/chart") return response;
+      const body = await response.json();
+      return Response.json(body, {
+        headers: { "X-Programmable-Market-Source": "bitquery" },
+      });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-bitquery-chart" }),
+    );
+  });
+
+  it("rejects an old FDV mislabeled as current", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      const response = await base(input);
+      if (url.pathname !== "/api/explore") return response;
+      const body = await response.json();
+      body.tokens[0].valuation.freshness = "current";
+      body.tokens[0].fdvUsdWad = body.tokens[0].valuation.valueWad;
+      return Response.json(body, { headers: response.headers });
     };
     const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
     expect(result.ok).toBe(false);

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { encodeFunctionResult, parseAbi } from "viem";
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
@@ -19,6 +20,23 @@ const GOLDEN_TOKEN_ADDRESS =
   "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
 const GOLDEN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const TEST_STATE_VIEW = "0x7fFE42C4a5DEeA5b0feC41C94C136Cf115597227";
+const TEST_ETH_USD_FEED = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
+const TEST_PARITY_BLOCK = 25_731_000n;
+const TEST_TOTAL_SUPPLY_RAW = 1_000n * 10n ** 18n;
+const TEST_PRICE_USD_WAD = 2_000n * 10n ** 18n;
+const TEST_FDV_USD_WAD = 2_000_000n * 10n ** 18n;
+const testStateViewAbi = parseAbi([
+  "function getSlot0(bytes32 poolId) view returns (uint160 sqrtPriceX96,int24 tick,uint24 protocolFee,uint24 lpFee)",
+]);
+const testErc20Abi = parseAbi([
+  "function decimals() view returns (uint8)",
+  "function totalSupply() view returns (uint256)",
+]);
+const testFeedAbi = parseAbi([
+  "function decimals() view returns (uint8)",
+  "function latestRoundData() view returns (uint80 roundId,int256 answer,uint256 startedAt,uint256 updatedAt,uint80 answeredInRound)",
+]);
 
 const AUTHENTICATED_ROUTE = `
   import { timingSafeEqual } from "node:crypto";
@@ -634,15 +652,80 @@ describe("read-model operations source contract", () => {
 });
 
 function publicFetch(healthStatus = "healthy") {
-  return async (input: URL | RequestInfo) => {
+  return async (input: URL | RequestInfo, init?: RequestInit) => {
     const url = new URL(String(input));
     const marketAsOf = new Date(Date.now() - 60 * 60_000).toISOString();
     const earlierMarketTime = new Date(Date.now() - 2 * 60 * 60_000).toISOString();
     const bitqueryHeaders = {
+      "X-Programmable-Data-Quality": "stale",
       "X-Programmable-Market-As-Of": marketAsOf,
       "X-Programmable-Market-Source": "bitquery",
       "X-Programmable-Read-Source": "operational+durable+postgres",
     };
+    if (url.hostname === "rpc-a.invalid" || url.hostname === "rpc-b.invalid") {
+      const request = JSON.parse(String(init?.body ?? "{}")) as {
+        id: number;
+        method: string;
+        params: readonly unknown[];
+      };
+      let result: unknown;
+      if (request.method === "eth_blockNumber") {
+        result = `0x${(TEST_PARITY_BLOCK + 20n).toString(16)}`;
+      } else if (request.method === "eth_getBlockByNumber") {
+        result = {
+          number: `0x${TEST_PARITY_BLOCK.toString(16)}`,
+          hash: `0x${"11".repeat(32)}`,
+          timestamp: `0x${BigInt(Math.floor(Date.parse(marketAsOf) / 1_000)).toString(16)}`,
+        };
+      } else if (request.method === "eth_call") {
+        const call = request.params[0] as { to: string; data: string };
+        const target = call.to.toLowerCase();
+        if (target === TEST_STATE_VIEW.toLowerCase()) {
+          result = encodeFunctionResult({
+            abi: testStateViewAbi,
+            functionName: "getSlot0",
+            result: [2n ** 96n, 0, 0, 0],
+          });
+        } else if (
+          target === GOLDEN_TOKEN_ADDRESS &&
+          call.data.startsWith("0x313ce567")
+        ) {
+          result = encodeFunctionResult({
+            abi: testErc20Abi,
+            functionName: "decimals",
+            result: 18,
+          });
+        } else if (
+          target === GOLDEN_TOKEN_ADDRESS &&
+          call.data.startsWith("0x18160ddd")
+        ) {
+          result = encodeFunctionResult({
+            abi: testErc20Abi,
+            functionName: "totalSupply",
+            result: TEST_TOTAL_SUPPLY_RAW,
+          });
+        } else if (
+          target === TEST_ETH_USD_FEED.toLowerCase() &&
+          call.data.startsWith("0x313ce567")
+        ) {
+          result = encodeFunctionResult({
+            abi: testFeedAbi,
+            functionName: "decimals",
+            result: 8,
+          });
+        } else {
+          const timestamp = BigInt(Math.floor(Date.parse(marketAsOf) / 1_000));
+          result = encodeFunctionResult({
+            abi: testFeedAbi,
+            functionName: "latestRoundData",
+            result: [1n, 200_000_000_000n, timestamp, timestamp, 1n],
+          });
+        }
+      } else {
+        throw new Error("unexpected parity RPC method");
+      }
+      return Response.json({ jsonrpc: "2.0", id: request.id, result });
+    }
     if (url.hostname === "api.vercel.com") {
       return Response.json({
         id: DEPLOYMENT_ID,
@@ -678,11 +761,14 @@ function publicFetch(healthStatus = "healthy") {
             currency: "usd",
             source: "bitquery",
             freshness: "stale",
-            valueWad: "250000000000000000000000",
+            valueWad: TEST_FDV_USD_WAD.toString(),
             asOfTime: marketAsOf,
           },
         }],
-        dataQuality: { valuation: { asOfTime: marketAsOf } },
+        dataQuality: {
+          status: "stale",
+          valuation: { asOfTime: marketAsOf },
+        },
       }, { headers: bitqueryHeaders });
     }
     if (url.pathname === "/api/explore/token") {
@@ -690,6 +776,8 @@ function publicFetch(healthStatus = "healthy") {
         status: "ready",
         token: {
           tokenAddress: GOLDEN_TOKEN_ADDRESS,
+          totalSupplyRaw: TEST_TOTAL_SUPPLY_RAW.toString(),
+          tokenDecimals: 18,
           valuation: {
             status: "available",
             metric: "fdv",
@@ -697,22 +785,61 @@ function publicFetch(healthStatus = "healthy") {
             currency: "usd",
             source: "bitquery",
             freshness: "stale",
-            valueWad: "250000000000000000000000",
+            valueWad: TEST_FDV_USD_WAD.toString(),
             asOfTime: marketAsOf,
           },
           marketData: {
             schemaVersion: "programmable.market-data.v1",
             source: "bitquery",
+            generatedAt: new Date().toISOString(),
             status: "stale",
             primaryPoolId: GOLDEN_POOL_ID,
             pools: [{
-              identity: { poolId: GOLDEN_POOL_ID },
+              identity: {
+                chainId: "1",
+                tokenAddress: GOLDEN_TOKEN_ADDRESS,
+                poolId: GOLDEN_POOL_ID,
+                protocol: "uniswap_v4",
+              },
               status: "stale",
+              latestTrade: {
+                transactionHash: `0x${"22".repeat(32)}`,
+                logIndex: 1,
+                blockNumber: TEST_PARITY_BLOCK.toString(),
+                time: marketAsOf,
+                tokenSide: "buy",
+                priceUsdWad: TEST_PRICE_USD_WAD.toString(),
+                rawPriceUsdWad: TEST_PRICE_USD_WAD.toString(),
+                priceUsdAsOfTime: marketAsOf,
+                priceUsdSource: "bitquery-token-price-index-v1",
+              },
+              liquidity: {
+                asOfTime: marketAsOf,
+                asOfBlock: TEST_PARITY_BLOCK.toString(),
+                valueUsdWad: (20_000n * 10n ** 18n).toString(),
+                freshness: "stale",
+              },
+              valuation: {
+                status: "available",
+                metric: "fdv",
+                supplyBasis: "total",
+                valueUsdWad: TEST_FDV_USD_WAD.toString(),
+                fdvUsdWad: TEST_FDV_USD_WAD.toString(),
+                totalSupply: "1000",
+                asOfTime: marketAsOf,
+                freshness: "stale",
+              },
             }],
           },
         },
+        dataQuality: {
+          schemaVersion: "programmable.explore-data-quality.v1",
+          status: "stale",
+        },
       }, {
         headers: {
+          "X-Programmable-Market-As-Of": marketAsOf,
+          "X-Programmable-Data-Quality": "stale",
           "X-Programmable-Market-Source": "bitquery",
           "X-Programmable-Read-Source": "operational+durable+postgres",
         },
@@ -723,6 +850,7 @@ function publicFetch(healthStatus = "healthy") {
         schemaVersion: "programmable.market-chart.v1",
         source: "bitquery",
         status: "ready",
+        generatedAt: new Date().toISOString(),
         address: GOLDEN_TOKEN_ADDRESS,
         identity: { poolId: GOLDEN_POOL_ID },
         points: [
@@ -747,6 +875,7 @@ function publicFetch(healthStatus = "healthy") {
         asOfTime: marketAsOf,
       }, {
         headers: {
+          "X-Programmable-Data-Quality": "ready",
           "X-Programmable-Market-As-Of": marketAsOf,
           "X-Programmable-Market-Source": "bitquery",
           "X-Programmable-Price-Source": "bitquery",
@@ -767,6 +896,7 @@ function postPromotionInput(fetchImpl = publicFetch()) {
     teamId: "team_programmable_test",
     projectId: PROJECT_ID,
     fetchImpl,
+    marketParityRpcUrls: ["https://rpc-a.invalid", "https://rpc-b.invalid"],
   };
 }
 
@@ -784,7 +914,71 @@ describe("post-promotion route verification", () => {
       "production-explore",
       "production-bitquery-detail",
       "production-bitquery-chart",
+      "production-bitquery-golden-independent-parity",
     ]);
+  });
+
+  it("rejects an internally coherent Bitquery price with the wrong onchain scale", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (url.pathname !== "/api/explore/token") return response;
+      const body = await response.json();
+      const wrongPrice = 20n * 10n ** 18n;
+      const wrongFdv = 20_000n * 10n ** 18n;
+      body.token.marketData.pools[0].latestTrade.priceUsdWad = wrongPrice.toString();
+      body.token.marketData.pools[0].latestTrade.rawPriceUsdWad = wrongPrice.toString();
+      body.token.marketData.pools[0].valuation.valueUsdWad = wrongFdv.toString();
+      body.token.marketData.pools[0].valuation.fdvUsdWad = wrongFdv.toString();
+      body.token.valuation.valueWad = wrongFdv.toString();
+      return Response.json(body, { headers: response.headers });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({
+        id: "production-bitquery-golden-independent-parity",
+      }),
+    );
+  });
+
+  it("rejects a detail response without its exact market freshness header", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (url.pathname !== "/api/explore/token") return response;
+      const headers = new Headers(response.headers);
+      headers.delete("X-Programmable-Market-As-Of");
+      return Response.json(await response.json(), { headers });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-bitquery-detail" }),
+    );
+  });
+
+  it("rejects two market parity readers that disagree on the exact block", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (url.hostname !== "rpc-b.invalid") return response;
+      const request = JSON.parse(String(init?.body ?? "{}")) as { method: string };
+      if (request.method !== "eth_getBlockByNumber") return response;
+      const body = await response.json();
+      body.result.hash = `0x${"33".repeat(32)}`;
+      return Response.json(body);
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({
+        id: "production-bitquery-golden-independent-parity",
+      }),
+    );
   });
 
   it("fails closed when production health is not healthy", async () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -849,6 +849,7 @@ function publicFetch(healthStatus = "healthy") {
       return Response.json({
         schemaVersion: "programmable.market-chart.v1",
         source: "bitquery",
+        readStatus: "live",
         status: "ready",
         generatedAt: new Date().toISOString(),
         address: GOLDEN_TOKEN_ADDRESS,
@@ -1042,6 +1043,44 @@ describe("post-promotion route verification", () => {
     expect(result.ok).toBe(false);
     expect(result.failures).toContainEqual(
       expect.objectContaining({ id: "production-bitquery-chart" }),
+    );
+  });
+
+  it("rejects a chart served from cache after the live Bitquery read failed", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (url.pathname !== "/api/explore/token/chart") return response;
+      const body = await response.json();
+      body.readStatus = "cache-fallback";
+      return Response.json(body, { headers: response.headers });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-bitquery-chart" }),
+    );
+  });
+
+  it("rejects Explore valuation evidence older than the stale release ceiling", async () => {
+    const base = publicFetch();
+    const tooOld = new Date(Date.now() - 25 * 60 * 60_000).toISOString();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (url.pathname !== "/api/explore") return response;
+      const body = await response.json();
+      body.tokens[0].valuation.asOfTime = tooOld;
+      body.dataQuality.valuation.asOfTime = tooOld;
+      const headers = new Headers(response.headers);
+      headers.set("X-Programmable-Market-As-Of", tooOld);
+      return Response.json(body, { headers });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-explore" }),
     );
   });
 

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import type { ExploreReadModel } from "../lib/onchain/types";
+import type {
+  MarketDataIdentityV1,
+  TokenMarketDataV1,
+} from "../lib/market-data/market-data-v1";
 import type { ExploreEntry, LauncherToken } from "../lib/tokens";
 import { customGraphToken } from "./launch-stamp-surface-fixture";
 
@@ -17,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   readExploreReferenceHeadWithinRouteBudget: vi.fn(),
   getOnchainDeployment: vi.fn(),
   readDurableExploreModel: vi.fn(),
+  readBitqueryTokenMarketDataV1: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
 }));
 
@@ -59,6 +64,10 @@ vi.mock("../lib/onchain/durable-model", () => ({
   readDurableExploreModel: mocks.readDurableExploreModel,
 }));
 
+vi.mock("../lib/market-data/bitquery.server", () => ({
+  readBitqueryTokenMarketDataV1: mocks.readBitqueryTokenMarketDataV1,
+}));
+
 import {
   dedupeExploreEntriesV1,
   GET,
@@ -67,7 +76,6 @@ import {
 
 const HOOK_ADDRESS =
   "0x3333333333333333333333333333333333333333" as const;
-const POOL_ID = `0x${"44".repeat(32)}` as const;
 
 function token(index: number): LauncherToken {
   const tokenAddress = `0x${index.toString(16).padStart(40, "0")}` as const;
@@ -77,7 +85,7 @@ function token(index: number): LauncherToken {
     symbol: `T${index}`,
     tokenAddress,
     hookAddress: HOOK_ADDRESS,
-    poolId: POOL_ID,
+    poolId: `0x${index.toString(16).padStart(64, "0")}`,
     launchedAt: `2026-07-${String(index).padStart(2, "0")}T00:00:00.000Z`,
     launchBlockNumber: String(25_626_490 + index),
     launchTransactionIndex: 0,
@@ -91,6 +99,57 @@ function token(index: number): LauncherToken {
     totalSwapFeeBps: 100,
     liquidityPath: "meme",
   };
+}
+
+function bitqueryMarketData(
+  identities: readonly MarketDataIdentityV1[],
+  options: Readonly<{ freshness?: "current" | "stale" }> = {},
+): ReadonlyMap<string, TokenMarketDataV1> {
+  return new Map(identities.map((identity) => {
+    const value = (BigInt(identity.tokenAddress) * 10n ** 18n).toString();
+    const priceUsdWad = (BigInt(identity.tokenAddress) * 10n ** 9n).toString();
+    return [identity.tokenAddress, {
+      schemaVersion: "programmable.market-data.v1",
+      source: "bitquery",
+      generatedAt: "2026-08-11T14:00:00.000Z",
+      status: options.freshness === "stale" ? "stale" : "current",
+      primaryPoolId: identity.poolId,
+      pools: [{
+        identity,
+        source: "bitquery",
+        status: options.freshness === "stale" ? "stale" : "current",
+        quality: "complete",
+        asOfTime: "2026-08-11T14:00:00.000Z",
+        latestTrade: {
+          transactionHash: `0x${"aa".repeat(32)}`,
+          logIndex: 1,
+          blockNumber: "25740000",
+          time: "2026-08-11T14:00:00.000Z",
+          tokenSide: "buy",
+          priceUsdWad,
+          priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
+          priceUsdSource: "bitquery-token-price-index-v1",
+          rawPriceUsdWad: priceUsdWad,
+        },
+        liquidity: {
+          asOfTime: "2026-08-11T14:00:00.000Z",
+          asOfBlock: "25740000",
+          valueUsdWad: "100000000000000000000000",
+          freshness: options.freshness ?? "current",
+        },
+        valuation: {
+          status: "available",
+          metric: "fdv",
+          supplyBasis: "total",
+          valueUsdWad: value,
+          fdvUsdWad: value,
+          totalSupply: "1000000",
+          asOfTime: "2026-08-11T14:00:00.000Z",
+          freshness: options.freshness ?? "current",
+        },
+      }],
+    } satisfies TokenMarketDataV1];
+  }));
 }
 
 const snapshot = {
@@ -158,7 +217,7 @@ function orderedEntry(input: Readonly<{
   } as unknown as ExploreEntry;
 }
 
-describe("Explore API Alchemy boundary", () => {
+describe("Explore API Bitquery market boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.readAlchemyExploreModel.mockResolvedValue(readyModel());
@@ -180,6 +239,10 @@ describe("Explore API Alchemy boundary", () => {
     );
     mocks.enrichTokensWithAlchemyPoolState.mockImplementation(
       async ({ tokens }: { tokens: readonly LauncherToken[] }) => [...tokens],
+    );
+    mocks.readBitqueryTokenMarketDataV1.mockImplementation(
+      async (identities: readonly MarketDataIdentityV1[]) =>
+        bitqueryMarketData(identities),
     );
   });
 
@@ -407,7 +470,7 @@ describe("Explore API Alchemy boundary", () => {
     "q=token&q=other",
     "sort=newest&extra=1",
     "socials=maybe",
-  ])("rejects non-canonical query shapes before the Alchemy read: %s", async (query) => {
+  ])("rejects non-canonical query shapes before identity or market reads: %s", async (query) => {
     const response = await GET(
       new NextRequest(`http://localhost/api/explore?${query}`),
     );
@@ -450,6 +513,7 @@ describe("Explore API Alchemy boundary", () => {
     expect(body).not.toHaveProperty("launcherFeesAccruedWei");
     expect(body).not.toHaveProperty("launcherFeesAccruedEth");
     expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("X-Programmable-Price-Source")).toBeNull();
     expect(response.headers.get("Retry-After")).toBe("5");
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
       "partial+registry.custom-launched",
@@ -496,7 +560,8 @@ describe("Explore API Alchemy boundary", () => {
           unavailable: 0,
           stale: 0,
           unknown: 0,
-          asOfBlock: "25630000",
+          asOfBlock: null,
+          asOfTime: "2026-08-11T14:00:00.000Z",
         },
       },
     });
@@ -506,8 +571,8 @@ describe("Explore API Alchemy boundary", () => {
       supplyBasis: "total",
       currency: "usd",
       freshness: "current",
-      asOfBlock: "25630000",
-      lagBlocks: "5",
+      source: "bitquery",
+      asOfTime: "2026-08-11T14:00:00.000Z",
     });
     expect(body.tokens[0].fdvUsdWad).toBe(
       body.tokens[0].valuation.valueWad,
@@ -538,24 +603,22 @@ describe("Explore API Alchemy boundary", () => {
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
       "operational+durable+registry.custom-launched",
     );
-    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
-      "operational-dual",
-    );
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBeNull();
     expect(response.headers.get("X-Programmable-Price-Source")).toBe(
-      "read-model",
+      "bitquery",
     );
     expect(response.headers.get("X-Programmable-Data-Quality")).toBe(
       "complete",
     );
-    expect(response.headers.get("X-Programmable-Valuation-Metric")).toBe(
-      "fdv",
+    expect(response.headers.get("X-Programmable-Market-Source")).toBe(
+      "bitquery",
     );
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
   });
 
-  it("binds current FDV to the verified operational block instead of the lagging model snapshot", async () => {
+  it("binds current FDV to Bitquery time instead of the lagging identity snapshot", async () => {
     const staleModelSnapshot = {
       ...snapshot,
       blockNumber: "25628000",
@@ -607,17 +670,13 @@ describe("Explore API Alchemy boundary", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mocks.withSameBlockEthUsdQuote).toHaveBeenCalledWith(
-      expect.objectContaining({ snapshot: operationalSnapshot }),
-    );
-    expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalledWith(
-      expect.objectContaining({ snapshot: operationalSnapshot }),
-    );
+    expect(mocks.withSameBlockEthUsdQuote).not.toHaveBeenCalled();
+    expect(mocks.enrichTokensWithAlchemyPoolState).not.toHaveBeenCalled();
     expect(body.tokens[0].valuation).toMatchObject({
       status: "available",
       freshness: "current",
-      asOfBlock: operationalSnapshot.blockNumber,
-      lagBlocks: "0",
+      source: "bitquery",
+      asOfTime: "2026-08-11T14:00:00.000Z",
     });
     expect(body.dataQuality).toMatchObject({
       launchIdentity: {
@@ -626,7 +685,8 @@ describe("Explore API Alchemy boundary", () => {
       },
       valuation: {
         status: "current",
-        asOfBlock: operationalSnapshot.blockNumber,
+        asOfBlock: null,
+        asOfTime: "2026-08-11T14:00:00.000Z",
       },
     });
   });
@@ -682,10 +742,11 @@ describe("Explore API Alchemy boundary", () => {
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 
-  it("keeps canonical launches visible with honest stale valuation quality during enrichment failure", async () => {
+  it("keeps canonical launches visible with unavailable valuation when Bitquery is down", async () => {
     mocks.enrichTokensWithAlchemyPoolState.mockRejectedValue(
       new Error("provider unavailable"),
     );
+    mocks.readBitqueryTokenMarketDataV1.mockResolvedValue(new Map());
     mocks.readExploreReferenceHeadWithinRouteBudget.mockResolvedValue({
       blockNumber: "25630100",
       blockHash: `0x${"88".repeat(32)}`,
@@ -702,14 +763,12 @@ describe("Explore API Alchemy boundary", () => {
     expect(body.total).toBe(30);
     expect(body.tokens).toHaveLength(30);
     expect(body.tokens.every((entry: {
-      valuation: { status: string; valueWad?: string };
-    }) =>
-      entry.valuation.status === "available" &&
-      entry.valuation.valueWad !== "0"
-    )).toBe(true);
+      valuation: { status: string; reason?: string };
+    }) => entry.valuation.status === "unavailable" &&
+      entry.valuation.reason === "source-unavailable")).toBe(true);
     expect(body.dataQuality).toMatchObject({
       status: "stale",
-      valuation: { status: "stale", stale: 30 },
+      valuation: { status: "unavailable", unavailable: 30 },
     });
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
@@ -745,9 +804,7 @@ describe("Explore API Alchemy boundary", () => {
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
       "durable+registry.custom-launched",
     );
-    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
-      "operational-dual",
-    );
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBeNull();
   });
 
   it.each([
@@ -773,11 +830,9 @@ describe("Explore API Alchemy boundary", () => {
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
       "operational+durable+postgres",
     );
-    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
-      "operational-dual",
-    );
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBeNull();
     expect(response.headers.get("X-Programmable-Price-Source")).toBe(
-      "read-model",
+      "bitquery",
     );
   });
 });

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -6,8 +6,12 @@ import {
   exploreValuation,
   publicExploreEntryV1,
   valuationSortValue,
+  type ValuedExploreEntry,
+  withBitqueryMarketData,
   withExploreValuation,
 } from "../lib/explore-financial-data";
+import type { TokenMarketDataV1 } from
+  "../lib/market-data/market-data-v1";
 import type { LauncherToken } from "../lib/tokens";
 
 const TOKEN_ADDRESS =
@@ -125,6 +129,139 @@ describe("Explore financial-data semantics", () => {
     expect(valuationSortValue(currentQuote)).toBeNull();
   });
 
+  it("keeps last-verified Bitquery FDV out of current sorting and compatibility fields", () => {
+    const poolId = `0x${"33".repeat(32)}` as const;
+    const marketData = {
+      schemaVersion: "programmable.market-data.v1",
+      source: "bitquery",
+      generatedAt: "2026-08-11T14:02:00.000Z",
+      status: "stale",
+      primaryPoolId: poolId,
+      pools: [{
+        identity: {
+          chainId: "1",
+          tokenAddress: TOKEN_ADDRESS,
+          poolId,
+          protocol: "uniswap_v4",
+        },
+        source: "bitquery",
+        status: "stale",
+        quality: "partial",
+        asOfTime: "2026-08-11T13:50:00.000Z",
+        latestTrade: {
+          transactionHash: `0x${"11".repeat(32)}`,
+          logIndex: 1,
+          blockNumber: "25740000",
+          time: "2026-08-11T13:50:00.000Z",
+          tokenSide: "buy",
+          priceUsdWad: "250000000000000000",
+          priceUsdAsOfTime: "2026-08-11T13:50:00.000Z",
+          priceUsdSource: "bitquery-token-price-index-v1",
+          rawPriceUsdWad: "245000000000000000",
+        },
+        liquidity: {
+          asOfTime: "2026-08-11T13:50:00.000Z",
+          asOfBlock: "25740000",
+          valueUsdWad: "50000000000000000000000",
+          freshness: "stale",
+        },
+        valuation: {
+          status: "available",
+          metric: "fdv",
+          supplyBasis: "total",
+          valueUsdWad: "250000000000000000000000",
+          fdvUsdWad: "250000000000000000000000",
+          totalSupply: "1000000",
+          asOfTime: "2026-08-11T13:50:00.000Z",
+          freshness: "stale",
+        },
+      }],
+    } satisfies TokenMarketDataV1;
+    const entry = withBitqueryMarketData(
+      canonicalTokenExploreEntryV1(goldenToken()),
+      marketData,
+    );
+
+    expect(entry.valuation).toMatchObject({
+      status: "available",
+      source: "bitquery",
+      freshness: "stale",
+      metric: "fdv",
+      supplyBasis: "total",
+      valueWad: "250000000000000000000000000",
+    });
+    expect(valuationSortValue(entry)).toBeNull();
+    const published = publicExploreEntryV1(entry);
+    expect(published).not.toHaveProperty("fdvUsdWad");
+    expect(published).not.toHaveProperty("tokenPriceUsdWad");
+    expect(published).not.toHaveProperty("tokenPriceQuoteWad");
+  });
+
+  it("keeps the indexed USD timestamp authoritative for public freshness", () => {
+    const poolId = `0x${"33".repeat(32)}` as const;
+    const marketData = {
+      schemaVersion: "programmable.market-data.v1",
+      source: "bitquery",
+      generatedAt: "2026-08-11T14:02:00.000Z",
+      status: "current",
+      primaryPoolId: poolId,
+      pools: [{
+        identity: {
+          chainId: "1",
+          tokenAddress: TOKEN_ADDRESS,
+          poolId,
+          protocol: "uniswap_v4",
+        },
+        source: "bitquery",
+        status: "current",
+        quality: "complete",
+        asOfTime: "2026-08-11T14:01:00.000Z",
+        latestTrade: {
+          transactionHash: `0x${"22".repeat(32)}`,
+          logIndex: 1,
+          blockNumber: "25740001",
+          time: "2026-08-11T14:01:00.000Z",
+          tokenSide: "buy",
+          priceUsdWad: "250000000000000000",
+          priceUsdAsOfTime: "2026-08-11T13:56:00.000Z",
+          priceUsdSource: "bitquery-token-price-index-v1",
+          rawPriceUsdWad: "245000000000000000",
+        },
+        liquidity: {
+          asOfTime: "2026-08-11T14:01:00.000Z",
+          asOfBlock: "25740001",
+          valueUsdWad: "50000000000000000000000",
+          freshness: "current",
+        },
+        valuation: {
+          status: "available",
+          metric: "fdv",
+          supplyBasis: "total",
+          valueUsdWad: "250000000000000000000000",
+          fdvUsdWad: "250000000000000000000000",
+          totalSupply: "1000000",
+          asOfTime: "2026-08-11T14:01:00.000Z",
+          freshness: "current",
+        },
+      }],
+    } satisfies TokenMarketDataV1;
+    const entry = withBitqueryMarketData(
+      canonicalTokenExploreEntryV1(goldenToken()),
+      marketData,
+    );
+
+    expect(entry.valuation).toMatchObject({
+      status: "available",
+      source: "bitquery",
+      freshness: "stale",
+      asOfTime: "2026-08-11T13:56:00.000Z",
+    });
+    expect(valuationSortValue(entry)).toBeNull();
+    const published = publicExploreEntryV1(entry);
+    expect(published).not.toHaveProperty("fdvUsdWad");
+    expect(published).not.toHaveProperty("tokenPriceUsdWad");
+  });
+
   it("publishes total-supply values only through the FDV contract", () => {
     const entry = withExploreValuation(
       canonicalTokenExploreEntryV1(goldenToken({
@@ -202,6 +339,38 @@ describe("Explore financial-data semantics", () => {
         stale: 0,
         unknown: 0,
       },
+    });
+  });
+
+  it("includes Custom v4 valuations in the shared data-quality summary", () => {
+    const custom = {
+      exploreKind: "custom-project",
+      valuation: {
+        status: "available",
+        metric: "market-cap",
+        supplyBasis: "circulating",
+        currency: "usd",
+        valueWad: "1000000000000000000",
+        freshness: "current",
+        source: "bitquery",
+        asOfTime: "2026-08-11T14:00:00.000Z",
+      },
+    } as ValuedExploreEntry;
+
+    expect(buildExploreDataQuality({
+      entries: [custom],
+      generatedAt: "2026-08-11T14:00:01.000Z",
+      canonicalStatus: "current",
+      customStatus: "current",
+      identityAsOfBlock: "25740000",
+      referenceBlock: "25740000",
+      identityAgeMs: 0,
+    }).valuation).toMatchObject({
+      status: "current",
+      metric: "market-cap",
+      available: 1,
+      unavailable: 0,
+      asOfTime: "2026-08-11T14:00:00.000Z",
     });
   });
 });

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -373,4 +373,54 @@ describe("Explore financial-data semantics", () => {
       asOfTime: "2026-08-11T14:00:00.000Z",
     });
   });
+
+  it("does not call a partial market response complete", () => {
+    const valued = {
+      ...withExploreValuation(
+        canonicalTokenExploreEntryV1(goldenToken()),
+        { referenceBlock: "25725569" },
+      ),
+      marketData: {
+        schemaVersion: "programmable.market-data.v1",
+        source: "bitquery",
+        generatedAt: "2026-08-11T14:00:00.000Z",
+        status: "partial",
+        primaryPoolId: `0x${"33".repeat(32)}`,
+        pools: [{
+          identity: {
+            chainId: "1",
+            tokenAddress: "0x1111111111111111111111111111111111111111",
+            poolId: `0x${"33".repeat(32)}`,
+            protocol: "uniswap_v4",
+          },
+          source: "bitquery",
+          status: "current",
+          quality: "partial",
+          valuation: {
+            status: "available",
+            metric: "fdv",
+            supplyBasis: "total",
+            valueUsdWad: "2779462110000000000000000",
+            fdvUsdWad: "2779462110000000000000000",
+            totalSupply: "1000000000",
+            asOfTime: "2026-08-11T14:00:00.000Z",
+            freshness: "current",
+          },
+        }],
+      },
+    } as ValuedExploreEntry;
+
+    expect(buildExploreDataQuality({
+      entries: [valued],
+      generatedAt: "2026-08-11T14:00:01.000Z",
+      canonicalStatus: "current",
+      customStatus: "current",
+      identityAsOfBlock: "25725569",
+      referenceBlock: "25725569",
+      identityAgeMs: 0,
+    })).toMatchObject({
+      status: "partial",
+      valuation: { status: "partial" },
+    });
+  });
 });

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -3,74 +3,49 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-const mocks = vi.hoisted(() => {
-  class TokenChartIntegrityError extends Error {
-    override name = "TokenChartIntegrityError";
+import type {
+  MarketChartV1,
+  MarketDataIdentityV1,
+  TokenMarketDataV1,
+} from "../lib/market-data/market-data-v1";
+import { customGraphToken } from "./launch-stamp-surface-fixture";
 
-    constructor(readonly reason: string) {
-      super("Token chart inputs failed integrity validation");
-    }
-  }
-  class TokenChartUnavailableError extends Error {
-    override name = "TokenChartUnavailableError";
-
-    constructor(readonly reason: string) {
-      super("Token chart data is unavailable for this pool");
-    }
-  }
-  return {
-    assertTokenChartSupported: vi.fn(),
-    getAlchemyOnchainDeployment: vi.fn(),
-    getWebsiteChartOnchainDeployment: vi.fn(),
-    isTokenChartRange: vi.fn(),
-    enrichTokensWithAlchemyPoolState: vi.fn(),
-    readVerifiedOperationalMarketSnapshot: vi.fn(),
-    withSameBlockEthUsdQuote: vi.fn(),
-    readAlchemyExploreModel: vi.fn(),
-    readDurableExploreModel: vi.fn(),
-    readTokenChartSeries: vi.fn(),
-    safeAlchemyError: vi.fn((error) => error),
-    TokenChartIntegrityError,
-    TokenChartUnavailableError,
-  };
-});
+const mocks = vi.hoisted(() => ({
+  getOnchainDeployment: vi.fn(),
+  isTokenChartRange: vi.fn(),
+  readAlchemyExploreModel: vi.fn(),
+  readBitqueryMarketChartV1: vi.fn(),
+  readBitqueryTokenMarketDataV1: vi.fn(),
+  readDurableExploreModel: vi.fn(),
+  readProductionCustomExploreDirectoryV1: vi.fn(),
+  safeAlchemyError: vi.fn((error) => error),
+}));
 
 vi.mock("../lib/alchemy/explore.server", () => ({
-  getAlchemyOnchainDeployment: mocks.getAlchemyOnchainDeployment,
   readAlchemyExploreModel: mocks.readAlchemyExploreModel,
   safeAlchemyError: mocks.safeAlchemyError,
 }));
 
+vi.mock("../lib/market-data/bitquery.server", () => ({
+  readBitqueryMarketChartV1: mocks.readBitqueryMarketChartV1,
+  readBitqueryTokenMarketDataV1: mocks.readBitqueryTokenMarketDataV1,
+}));
+
 vi.mock("../lib/onchain/chart", () => ({
-  assertTokenChartSupported: mocks.assertTokenChartSupported,
   isTokenChartRange: mocks.isTokenChartRange,
-  readTokenChartSeries: mocks.readTokenChartSeries,
-  TokenChartIntegrityError: mocks.TokenChartIntegrityError,
-  TokenChartUnavailableError: mocks.TokenChartUnavailableError,
 }));
 
 vi.mock("../lib/onchain/config", () => ({
-  getWebsiteChartOnchainDeployment:
-    mocks.getWebsiteChartOnchainDeployment,
+  getOnchainDeployment: mocks.getOnchainDeployment,
 }));
 
 vi.mock("../lib/onchain/durable-model", () => ({
   readDurableExploreModel: mocks.readDurableExploreModel,
 }));
 
-vi.mock("../lib/alchemy/live-market.server", () => ({
-  enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
-  readVerifiedOperationalMarketSnapshot:
-    mocks.readVerifiedOperationalMarketSnapshot,
-  withSameBlockEthUsdQuote: mocks.withSameBlockEthUsdQuote,
-  withoutUnboundEthUsdQuote: (snapshot: {
-    ethUsdQuote?: unknown;
-    [key: string]: unknown;
-  }) => {
-    const withoutQuote = { ...snapshot };
-    delete withoutQuote.ethUsdQuote;
-    return withoutQuote;
-  },
+vi.mock("../lib/server/custom-launch/explore-directory-v1", () => ({
+  readProductionCustomExploreDirectoryV1:
+    mocks.readProductionCustomExploreDirectoryV1,
 }));
 
 import { GET } from "../app/api/explore/token/chart/route";
@@ -87,23 +62,18 @@ const token = {
   liquidityPath: "meme",
 } as const;
 
-const deployment = {
-  status: "ready",
-  chainId: 1,
-  rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/redacted",
-} as const;
-const chartDeployment = {
-  ...deployment,
-  rpcUrl: "https://ethereum-rpc.publicnode.com",
-  rpcUrlSecondary: "https://rpc.mevblocker.io",
-} as const;
+const identity = {
+  chainId: "1",
+  tokenAddress: token.tokenAddress,
+  poolId: token.poolId,
+  protocol: "uniswap_v4",
+} as const satisfies MarketDataIdentityV1;
 
 const snapshot = {
   chainId: 1,
   blockNumber: "25630000",
   blockHash: `0x${"44".repeat(32)}`,
   confirmations: 12,
-  ethUsdQuote: { answer: "350000000000", decimals: 8 },
 } as const;
 const launchDiscoverySnapshot = {
   ...snapshot,
@@ -111,39 +81,97 @@ const launchDiscoverySnapshot = {
   blockHash: `0x${"55".repeat(32)}`,
 } as const;
 
-describe("token chart Alchemy API", () => {
+function tokenMarketData(
+  marketIdentity: MarketDataIdentityV1 = identity,
+): TokenMarketDataV1 {
+  return {
+    schemaVersion: "programmable.market-data.v1",
+    source: "bitquery",
+    generatedAt: "2026-08-11T14:02:00.000Z",
+    status: "current",
+    primaryPoolId: marketIdentity.poolId,
+    pools: [{
+      identity: marketIdentity,
+      source: "bitquery",
+      status: "current",
+      quality: "complete",
+      asOfTime: "2026-08-11T14:02:00.000Z",
+      latestTrade: {
+        transactionHash: `0x${"66".repeat(32)}`,
+        logIndex: 1,
+        blockNumber: "25740002",
+        time: "2026-08-11T14:02:00.000Z",
+        tokenSide: "buy",
+        priceUsdWad: "2000000000000000000",
+      },
+      valuation: {
+        status: "available",
+        metric: "fdv",
+        supplyBasis: "total",
+        valueUsdWad: "2000000000000000000000000",
+        fdvUsdWad: "2000000000000000000000000",
+        totalSupply: "1000000",
+        asOfTime: "2026-08-11T14:02:00.000Z",
+        freshness: "current",
+      },
+    }],
+  };
+}
+
+function chart(
+  overrides: Partial<MarketChartV1> = {},
+  marketIdentity: MarketDataIdentityV1 = identity,
+): MarketChartV1 {
+  return {
+    schemaVersion: "programmable.market-chart.v1",
+    source: "bitquery",
+    status: "ready",
+    generatedAt: "2026-08-11T14:02:00.000Z",
+    identity: marketIdentity,
+    range: "all",
+    points: [
+      {
+        blockNumber: "25740001",
+        time: "2026-08-11T14:01:00.000Z",
+        priceUsd: "1.5",
+        ohlcUsd: { open: "1.4", high: "1.6", low: "1.3", close: "1.5" },
+        volumeUsdWad: "150000000000000000000",
+        tradeCount: 3,
+      },
+      {
+        blockNumber: "25740002",
+        time: "2026-08-11T14:02:00.000Z",
+        priceUsd: "2",
+        ohlcUsd: { open: "1.5", high: "2.1", low: "1.5", close: "2" },
+        volumeUsdWad: "250000000000000000000",
+        tradeCount: 4,
+      },
+    ],
+    swapCount: 7,
+    volumeUsdWad: "400000000000000000000",
+    valuation: {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      valueUsdWad: "2000000000000000000000000",
+      fdvUsdWad: "2000000000000000000000000",
+      totalSupply: "1000000",
+      asOfTime: "2026-08-11T14:02:00.000Z",
+      freshness: "current",
+    },
+    asOfTime: "2026-08-11T14:02:00.000Z",
+    truncated: false,
+    ...overrides,
+  };
+}
+
+describe("token chart Bitquery API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.isTokenChartRange.mockImplementation((range) =>
       ["1h", "1d", "1w", "all"].includes(range),
     );
-    mocks.getAlchemyOnchainDeployment.mockReturnValue(deployment);
-    mocks.getWebsiteChartOnchainDeployment.mockReturnValue(
-      chartDeployment,
-    );
-    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
-      launchDiscoverySnapshot,
-    );
-    mocks.assertTokenChartSupported.mockImplementation((candidate) => {
-      if (candidate.launchModel === "custom-graph") {
-        throw new mocks.TokenChartUnavailableError(
-          "unsupported-pool-orientation",
-        );
-      }
-    });
-    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([token]);
-    mocks.withSameBlockEthUsdQuote.mockImplementation(
-      async ({ snapshot: value }) => ({
-        ...value,
-        ethUsdQuote: {
-          feedAddress: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
-          roundId: "12",
-          answer: "350000000000",
-          decimals: 8,
-          updatedAt: "1786400000",
-        },
-      }),
-    );
+    mocks.getOnchainDeployment.mockReturnValue({ status: "ready" });
     mocks.readAlchemyExploreModel.mockResolvedValue({
       status: "ready",
       tokens: [token],
@@ -153,182 +181,53 @@ describe("token chart Alchemy API", () => {
       launcherFeesAccruedWei: "0",
       launcherFeesAccruedEth: "0",
     });
+    mocks.readProductionCustomExploreDirectoryV1.mockResolvedValue([]);
     mocks.readDurableExploreModel.mockResolvedValue({
       status: "unavailable",
       reason: "missing",
       detail: "No durable index snapshot exists",
     });
-    mocks.readTokenChartSeries.mockResolvedValue({
-      status: "ready",
-      points: [
-        { blockNumber: "25630004", priceEth: "0.49", priceUsd: "1715" },
-        { blockNumber: "25630005", priceEth: "0.5", priceUsd: "1750" },
-      ],
-      swapCount: 2,
-      volumeWei: "1250000000000000000",
-      volumeEth: "1.25",
-      volumeUsdWad: "4375000000000000000000",
-      fdvEthWei: "500000000000000000000",
-      fdvEth: "500",
-      fdvUsdWad: "1750000000000000000000000",
-      freshness: {
-        history: {
-          status: "current",
-          throughBlock: launchDiscoverySnapshot.blockNumber,
-        },
-        price: {
-          status: "current",
-          asOfBlock: launchDiscoverySnapshot.blockNumber,
-          lagBlocks: "0",
-        },
-        valuation: {
-          status: "current",
-          metric: "fdv",
-          asOfBlock: launchDiscoverySnapshot.blockNumber,
-          lagBlocks: "0",
-        },
-      },
-    });
+    mocks.readBitqueryTokenMarketDataV1.mockResolvedValue(
+      new Map([[token.tokenAddress, tokenMarketData()]]),
+    );
+    mocks.readBitqueryMarketChartV1.mockResolvedValue(chart());
   });
 
-  it("forwards the selected range through Alchemy and returns exact volume fields", async () => {
-    const response = await GET(
-      new NextRequest(
-        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}&range=1h`,
-      ),
-    );
+  it("forwards the exact v4 identity and selected range to Bitquery", async () => {
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${token.tokenAddress}&range=1h`,
+    ));
+    const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mocks.readAlchemyExploreModel).toHaveBeenCalledTimes(1);
-    expect(mocks.getAlchemyOnchainDeployment).toHaveBeenCalledTimes(1);
-    expect(mocks.readTokenChartSeries).toHaveBeenCalledWith(
-      expect.objectContaining({
-        deployment: chartDeployment,
-        token,
-        snapshotBlock: 25_630_005n,
-        ethUsdQuote: expect.objectContaining({
-          roundId: "12",
-          answer: "350000000000",
-        }),
-        range: "1h",
-      }),
+    expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledWith(
+      [identity],
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
-    const body = await response.json();
+    expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledWith(
+      expect.objectContaining({ identity, range: "1h", signal: expect.any(AbortSignal) }),
+    );
     expect(body).toMatchObject({
-      address: token.tokenAddress,
-      range: "1h",
-      swapCount: 2,
-      volumeWei: "1250000000000000000",
-      volumeEth: "1.25",
-      volumeUsdWad: "4375000000000000000000",
-      fdvEthWei: "500000000000000000000",
-      fdvEth: "500",
-      fdvUsdWad: "1750000000000000000000000",
-      valuationMetric: "fdv",
-      dataQuality: {
-        schemaVersion: "programmable.explore-chart-data-quality.v1",
-        status: "current",
-        asOfBlock: launchDiscoverySnapshot.blockNumber,
-        blockHash: launchDiscoverySnapshot.blockHash,
-        finality: "confirmed",
-        history: {
-          status: "current",
-          throughBlock: launchDiscoverySnapshot.blockNumber,
-        },
-        price: {
-          status: "current",
-          asOfBlock: launchDiscoverySnapshot.blockNumber,
-          lagBlocks: "0",
-        },
-        valuation: {
-          status: "current",
-          metric: "fdv",
-          asOfBlock: launchDiscoverySnapshot.blockNumber,
-          lagBlocks: "0",
-        },
-      },
-    });
-    expect(body).not.toHaveProperty("marketCapEthWei");
-    expect(body).not.toHaveProperty("marketCapEth");
-    expect(body).not.toHaveProperty("marketCapUsdWad");
-    expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "rpc",
-    );
-    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBeNull();
-    expect(response.headers.get("Cache-Control")).toBe(
-      "public, max-age=0, s-maxage=2, stale-while-revalidate=2",
-    );
-    expect(response.headers.get("X-Programmable-Valuation-Metric")).toBe(
-      "fdv",
-    );
-  });
-
-  it("reads price history through the verified operational block instead of the stale model snapshot", async () => {
-    const operationalSnapshot = {
-      ...launchDiscoverySnapshot,
-      blockNumber: "25632000",
-      blockHash: `0x${"99".repeat(32)}` as const,
-    };
-    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
-      operationalSnapshot,
-    );
-    mocks.readTokenChartSeries.mockResolvedValue({
+      schemaVersion: "programmable.market-chart.v1",
+      source: "bitquery",
       status: "ready",
+      address: token.tokenAddress,
+      fdvUsdWad: "2000000000000000000000000",
+      valuationMetric: "fdv",
       points: [
-        { blockNumber: "25631999", priceEth: "0.49", priceUsd: "1715" },
-        { blockNumber: operationalSnapshot.blockNumber, priceEth: "0.5", priceUsd: "1750" },
+        { priceUsd: "1.5", tradeCount: 3 },
+        { priceUsd: "2", tradeCount: 4 },
       ],
-      swapCount: 2,
-      volumeWei: "1",
-      volumeEth: "0.000000000000000001",
-      freshness: {
-        history: {
-          status: "current",
-          throughBlock: operationalSnapshot.blockNumber,
-        },
-        price: {
-          status: "current",
-          asOfBlock: operationalSnapshot.blockNumber,
-          lagBlocks: "0",
-        },
-        valuation: {
-          status: "current",
-          metric: "fdv",
-          asOfBlock: operationalSnapshot.blockNumber,
-          lagBlocks: "0",
-        },
-      },
     });
-
-    const response = await GET(
-      new NextRequest(
-        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
-      ),
+    expect(response.headers.get("X-Programmable-Market-Source")).toBe("bitquery");
+    expect(response.headers.get("X-Programmable-Price-Source")).toBe("bitquery");
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(mocks.withSameBlockEthUsdQuote).toHaveBeenCalledWith(
-      expect.objectContaining({ snapshot: operationalSnapshot }),
-    );
-    expect(mocks.readTokenChartSeries).toHaveBeenCalledWith(
-      expect.objectContaining({ snapshotBlock: 25_632_000n }),
-    );
-    expect(body.dataQuality).toMatchObject({
-      status: "current",
-      asOfBlock: operationalSnapshot.blockNumber,
-      blockHash: operationalSnapshot.blockHash,
-      history: { throughBlock: operationalSnapshot.blockNumber },
-      price: { asOfBlock: operationalSnapshot.blockNumber },
-      valuation: { asOfBlock: operationalSnapshot.blockNumber },
-    });
-    expect(body.snapshotBlock).toBe(operationalSnapshot.blockNumber);
   });
 
-  it("uses a verified durable identity snapshot when the live registry refresh is unavailable", async () => {
-    mocks.readAlchemyExploreModel.mockRejectedValue(
-      new Error("Operational RPCs are unavailable"),
-    );
+  it("uses a verified durable identity when the primary identity source fails", async () => {
+    mocks.readAlchemyExploreModel.mockRejectedValue(new Error("primary unavailable"));
     mocks.readDurableExploreModel.mockResolvedValue({
       status: "ready",
       ageMs: 60_000,
@@ -336,7 +235,7 @@ describe("token chart Alchemy API", () => {
         payload: {
           model: {
             status: "ready",
-            tokens: [{ ...token, grossVolumeWei: "1000000000000000000" }],
+            tokens: [token],
             snapshot,
             launchDiscoverySnapshot,
             creatorClaims: [],
@@ -347,185 +246,155 @@ describe("token chart Alchemy API", () => {
       },
     });
 
-    const response = await GET(
-      new NextRequest(
-        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
-      ),
-    );
-    const body = await response.json();
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+    ));
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "durable+rpc",
-    );
     expect(mocks.readDurableExploreModel).toHaveBeenCalledWith(
-      deployment,
+      expect.anything(),
       Number.MAX_SAFE_INTEGER,
     );
-    expect(mocks.readTokenChartSeries).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: expect.objectContaining(token),
-        snapshotBlock: BigInt(launchDiscoverySnapshot.blockNumber),
-      }),
-    );
-    expect(
-      mocks.readTokenChartSeries.mock.calls.at(-1)?.[0]?.token,
-    ).not.toHaveProperty("grossVolumeWei");
-    expect(body).toMatchObject({
-      status: "ready",
-      snapshotBlock: launchDiscoverySnapshot.blockNumber,
-      dataQuality: {
-        status: "current",
-        asOfBlock: launchDiscoverySnapshot.blockNumber,
-      },
-    });
+    expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledTimes(1);
   });
 
-  it("fails closed when neither live nor durable identity is verified", async () => {
-    mocks.readAlchemyExploreModel.mockRejectedValue(
-      new Error("Operational RPCs are unavailable"),
+  it("fails closed without fabricated points when all identity sources fail", async () => {
+    const unknownAddress = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    mocks.readAlchemyExploreModel.mockRejectedValue(new Error("primary unavailable"));
+    mocks.readProductionCustomExploreDirectoryV1.mockRejectedValue(
+      new Error("registry unavailable"),
     );
 
-    const response = await GET(
-      new NextRequest(
-        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
-      ),
-    );
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${unknownAddress}`,
+    ));
     const body = await response.json();
 
     expect(response.status).toBe(503);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(body).toMatchObject({
+      schemaVersion: "programmable.market-chart-error.v1",
+      source: "bitquery",
       status: "unavailable",
-      dataQuality: {
-        status: "unavailable",
-        reason: "source-unavailable",
-      },
+      reason: "identity-unavailable",
+      error: "Token identity is temporarily unavailable",
+      address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
     });
-    expect(mocks.readTokenChartSeries).not.toHaveBeenCalled();
+    expect(body).not.toHaveProperty("identity");
+    expect(body).not.toHaveProperty("points");
+    expect(body).not.toHaveProperty("swapCount");
+    expect(body).not.toHaveProperty("priceUsd", "0");
+    expect(mocks.readBitqueryMarketChartV1).not.toHaveBeenCalled();
   });
 
-  it("fails closed and leaves the client to preserve its last verified chart without operational quorum", async () => {
-    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(null);
-
-    const response = await GET(
-      new NextRequest(
-        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
-      ),
-    );
-    const body = await response.json();
-
-    expect(response.status).toBe(503);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
-    expect(body).toMatchObject({
-      status: "unavailable",
-      dataQuality: {
+  it("returns a calm waiting state before the first swap", async () => {
+    mocks.readBitqueryMarketChartV1.mockResolvedValue(chart({
+      status: "waiting-for-first-trade",
+      points: [],
+      swapCount: 0,
+      volumeUsdWad: undefined,
+      valuation: {
         status: "unavailable",
-        reason: "source-unavailable",
+        reason: "waiting-for-first-trade",
       },
-    });
-    expect(body).not.toHaveProperty("snapshotBlock");
-    expect(mocks.withSameBlockEthUsdQuote).not.toHaveBeenCalled();
-    expect(mocks.enrichTokensWithAlchemyPoolState).not.toHaveBeenCalled();
-    expect(mocks.readTokenChartSeries).not.toHaveBeenCalled();
-  });
+      asOfTime: undefined,
+    }));
 
-  it("returns partial freshness without caching an older price as current", async () => {
-    mocks.readTokenChartSeries.mockResolvedValue({
-      status: "partial",
-      points: [{ blockNumber: "25630000", priceEth: "0.5" }],
-      swapCount: 1,
-      volumeWei: "1",
-      volumeEth: "0.000000000000000001",
-      fdvEthWei: "500000000000000000000",
-      freshness: {
-        history: {
-          status: "current",
-          throughBlock: launchDiscoverySnapshot.blockNumber,
-        },
-        price: {
-          status: "stale",
-          asOfBlock: snapshot.blockNumber,
-          lagBlocks: "5",
-        },
-        valuation: {
-          status: "stale",
-          metric: "fdv",
-          asOfBlock: snapshot.blockNumber,
-          lagBlocks: "5",
-        },
-      },
-    });
-
-    const response = await GET(
-      new NextRequest(
-        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
-      ),
-    );
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+    ));
     const body = await response.json();
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
-    expect(response.headers.get("X-Programmable-Data-Quality")).toBe(
-      "partial",
-    );
     expect(body).toMatchObject({
-      status: "partial",
-      points: [{ blockNumber: "25630000", priceEth: "0.5" }],
-      dataQuality: {
-        status: "partial",
-        price: {
-          status: "stale",
-          asOfBlock: snapshot.blockNumber,
-          lagBlocks: "5",
-        },
-      },
+      status: "waiting-for-first-trade",
+      points: [],
+      swapCount: 0,
+      valuation: { reason: "waiting-for-first-trade" },
+    });
+    expect(body).not.toHaveProperty("fdvUsdWad");
+    expect(response.headers.get("X-Programmable-Price-Source")).toBeNull();
+  });
+
+  it("returns typed unavailable and lets the client preserve its Bitquery LKG", async () => {
+    mocks.readBitqueryMarketChartV1.mockResolvedValue(chart({
+      status: "unavailable",
+      points: [],
+      swapCount: 0,
+      volumeUsdWad: undefined,
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+      asOfTime: undefined,
+    }));
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+    ));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Retry-After")).toBe("5");
+    expect(body).toMatchObject({
+      status: "unavailable",
+      source: "bitquery",
+      points: [],
+      error: "Price history is temporarily unavailable",
     });
   });
 
-  it.each(["deployment", "model"])(
-    "returns unavailable without fabricated zero series when %s is not ready",
-    async (unavailable) => {
-      if (unavailable === "deployment") {
-        mocks.getAlchemyOnchainDeployment.mockReturnValue({
-          status: "not-deployed",
-        });
-      } else {
-        mocks.readAlchemyExploreModel.mockResolvedValue({
-          status: "not-deployed",
-          tokens: [],
-          snapshot: null,
-          creatorClaims: [],
-          launcherFeesAccruedWei: "0",
-          launcherFeesAccruedEth: "0",
-        });
-      }
-
-      const response = await GET(
-        new NextRequest(
-          `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
-        ),
-      );
-      const body = await response.json();
-
-      expect(response.status).toBe(503);
-      expect(response.headers.get("Cache-Control")).toBe("no-store");
-      expect(body).toMatchObject({
-        status: "unavailable",
-        error: "Onchain chart data is temporarily unavailable",
-      });
-      expect(body).not.toHaveProperty("points");
-      expect(body).not.toHaveProperty("swapCount");
-      expect(body).not.toHaveProperty("volumeWei");
-      expect(body).not.toHaveProperty("volumeEth");
-      expect(mocks.readTokenChartSeries).not.toHaveBeenCalled();
-    },
-  );
-
-  it("fails closed for Custom Graph before enrichment or chart reads", async () => {
+  it("supports a Router-stamped Custom v4 pool", async () => {
+    const customIdentity = {
+      chainId: "1",
+      tokenAddress: customGraphToken.tokenAddress.toLowerCase() as `0x${string}`,
+      poolId: customGraphToken.poolId,
+      protocol: "uniswap_v4",
+    } as const satisfies MarketDataIdentityV1;
     mocks.readAlchemyExploreModel.mockResolvedValue({
       status: "ready",
-      tokens: [{ ...token, launchModel: "custom-graph" }],
+      tokens: [customGraphToken],
+      snapshot,
+      launchDiscoverySnapshot,
+      creatorClaims: [],
+      launcherFeesAccruedWei: "0",
+      launcherFeesAccruedEth: "0",
+    });
+    mocks.readBitqueryTokenMarketDataV1.mockResolvedValue(
+      new Map([[customIdentity.tokenAddress, tokenMarketData(customIdentity)]]),
+    );
+    mocks.readBitqueryMarketChartV1.mockResolvedValue(
+      chart({}, customIdentity),
+    );
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${customGraphToken.tokenAddress}`,
+    ));
+
+    expect(response.status).toBe(200);
+    expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledWith(
+      expect.objectContaining({ identity: customIdentity }),
+    );
+  });
+
+  it.each([
+    `address=${token.tokenAddress}&unused=random`,
+    `address=${token.tokenAddress}&address=0x2222222222222222222222222222222222222222`,
+    `address=${token.tokenAddress}&range=1h&range=1d`,
+    `address=${token.tokenAddress}&range=invalid`,
+  ])("rejects non-canonical query shapes before market reads: %s", async (query) => {
+    const response = await GET(
+      new NextRequest(`http://localhost/api/explore/token/chart?${query}`),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.readAlchemyExploreModel).not.toHaveBeenCalled();
+    expect(mocks.readBitqueryMarketChartV1).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 only when both identity sources are current", async () => {
+    mocks.readAlchemyExploreModel.mockResolvedValue({
+      status: "ready",
+      tokens: [],
       snapshot,
       launchDiscoverySnapshot,
       creatorClaims: [],
@@ -533,67 +402,12 @@ describe("token chart Alchemy API", () => {
       launcherFeesAccruedEth: "0",
     });
 
-    const response = await GET(
-      new NextRequest(
-        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
-      ),
-    );
-    const body = await response.json();
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+    ));
 
-    expect(response.status).toBe(503);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
-    expect(response.headers.get("Retry-After")).toBeNull();
-    expect(body).toMatchObject({
-      status: "unavailable",
-      dataQuality: {
-        status: "unavailable",
-        reason: "unsupported-pool-orientation",
-      },
-    });
-    expect(body).not.toHaveProperty("points");
-    expect(mocks.enrichTokensWithAlchemyPoolState).not.toHaveBeenCalled();
-    expect(mocks.readTokenChartSeries).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    `address=${token.tokenAddress}&unused=random`,
-    `address=${token.tokenAddress}&address=0x2222222222222222222222222222222222222222`,
-    `address=${token.tokenAddress}&range=1h&range=1d`,
-  ])("rejects non-canonical query shapes before the Alchemy read: %s", async (query) => {
-    const response = await GET(
-      new NextRequest(`http://localhost/api/explore/token/chart?${query}`),
-    );
-
-    expect(response.status).toBe(400);
-    expect(mocks.readAlchemyExploreModel).not.toHaveBeenCalled();
-    expect(mocks.getAlchemyOnchainDeployment).not.toHaveBeenCalled();
-  });
-
-  it("reports read-model conflicts as integrity-unavailable without zero data", async () => {
-    mocks.readTokenChartSeries.mockRejectedValue(
-      new mocks.TokenChartIntegrityError("invalid-token-decimals"),
-    );
-
-    const response = await GET(
-      new NextRequest(
-        `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
-      ),
-    );
-    const body = await response.json();
-
-    expect(response.status).toBe(503);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
-    expect(response.headers.get("Retry-After")).toBeNull();
-    expect(body).toMatchObject({
-      status: "unavailable",
-      dataQuality: {
-        schemaVersion: "programmable.explore-chart-data-quality.v1",
-        status: "unavailable",
-        reason: "integrity",
-      },
-    });
-    expect(body).not.toHaveProperty("points");
-    expect(body).not.toHaveProperty("volumeWei");
-    expect(body).not.toHaveProperty("volumeEth");
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Token not found" });
+    expect(mocks.readBitqueryMarketChartV1).not.toHaveBeenCalled();
   });
 });

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -125,6 +125,7 @@ function chart(
   return {
     schemaVersion: "programmable.market-chart.v1",
     source: "bitquery",
+    readStatus: "live",
     status: "ready",
     generatedAt: "2026-08-11T14:02:00.000Z",
     identity: marketIdentity,

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import type { ExploreReadModel } from "../lib/onchain/types";
+import type {
+  MarketDataIdentityV1,
+  TokenMarketDataV1,
+} from "../lib/market-data/market-data-v1";
 import type { LauncherToken } from "../lib/tokens";
 import { customGraphToken } from "./launch-stamp-surface-fixture";
 
@@ -17,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   readExploreReferenceHeadWithinRouteBudget: vi.fn(),
   getOnchainDeployment: vi.fn(),
   readDurableExploreModel: vi.fn(),
+  readBitqueryTokenMarketDataV1: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
 }));
 
@@ -59,6 +64,10 @@ vi.mock("../lib/onchain/durable-model", () => ({
   readDurableExploreModel: mocks.readDurableExploreModel,
 }));
 
+vi.mock("../lib/market-data/bitquery.server", () => ({
+  readBitqueryTokenMarketDataV1: mocks.readBitqueryTokenMarketDataV1,
+}));
+
 import { GET } from "../app/api/explore/token/route";
 
 const TOKEN_ADDRESS =
@@ -99,7 +108,54 @@ const launchDiscoverySnapshot = {
   blockHash: `0x${"66".repeat(32)}` as const,
 };
 
-describe("token detail Alchemy read", () => {
+function bitqueryMarketData(
+  identities: readonly MarketDataIdentityV1[],
+  valueUsdWad = "1250000000000000000000000",
+): ReadonlyMap<string, TokenMarketDataV1> {
+  return new Map(identities.map((identity) => [identity.tokenAddress, {
+    schemaVersion: "programmable.market-data.v1",
+    source: "bitquery",
+    generatedAt: "2026-08-11T14:00:00.000Z",
+    status: "current",
+    primaryPoolId: identity.poolId,
+    pools: [{
+      identity,
+      source: "bitquery",
+      status: "current",
+      quality: "complete",
+      asOfTime: "2026-08-11T14:00:00.000Z",
+      latestTrade: {
+        transactionHash: `0x${"aa".repeat(32)}`,
+        logIndex: 1,
+        blockNumber: "25740000",
+        time: "2026-08-11T14:00:00.000Z",
+        tokenSide: "buy",
+        priceUsdWad: (BigInt(valueUsdWad) / 1_000_000n).toString(),
+        priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
+        priceUsdSource: "bitquery-token-price-index-v1",
+        rawPriceUsdWad: (BigInt(valueUsdWad) / 1_000_000n).toString(),
+      },
+      liquidity: {
+        asOfTime: "2026-08-11T14:00:00.000Z",
+        asOfBlock: "25740000",
+        valueUsdWad: "100000000000000000000000",
+        freshness: "current",
+      },
+      valuation: {
+        status: "available",
+        metric: "fdv",
+        supplyBasis: "total",
+        valueUsdWad,
+        fdvUsdWad: valueUsdWad,
+        totalSupply: "1000000",
+        asOfTime: "2026-08-11T14:00:00.000Z",
+        freshness: "current",
+      },
+    }],
+  } satisfies TokenMarketDataV1]));
+}
+
+describe("token detail Bitquery market read", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getAlchemyOnchainDeployment.mockReturnValue({
@@ -129,9 +185,13 @@ describe("token detail Alchemy read", () => {
             launchDiscoverySnapshot.blockNumber,
         })),
     );
+    mocks.readBitqueryTokenMarketDataV1.mockImplementation(
+      async (identities: readonly MarketDataIdentityV1[]) =>
+        bitqueryMarketData(identities),
+    );
   });
 
-  it("refreshes only the canonical token from current StateView data", async () => {
+  it("reads Bitquery market data only for the canonical token PoolId", async () => {
     const canonical = token(TOKEN_ADDRESS, {
       totalSupplyRaw: "1000000000000000000000000",
       tokenDecimals: 18,
@@ -162,8 +222,17 @@ describe("token detail Alchemy read", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.readAlchemyExploreModel).toHaveBeenCalledTimes(1);
-    expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalledWith(
-      expect.objectContaining({ tokens: [canonical] }),
+    expect(mocks.enrichTokensWithAlchemyPoolState).not.toHaveBeenCalled();
+    expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledWith(
+      [
+        {
+          chainId: "1",
+          tokenAddress: TOKEN_ADDRESS,
+          poolId: POOL_ID,
+          protocol: "uniswap_v4",
+        },
+      ],
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(body.token).toMatchObject({
       id: canonical.id,
@@ -178,8 +247,8 @@ describe("token detail Alchemy read", () => {
         currency: "usd",
         valueWad: "1250000000000000000000000",
         freshness: "current",
-        asOfBlock: launchDiscoverySnapshot.blockNumber,
-        lagBlocks: "0",
+        source: "bitquery",
+        asOfTime: "2026-08-11T14:00:00.000Z",
       },
     });
     expect(body.dataQuality).toMatchObject({
@@ -206,24 +275,25 @@ describe("token detail Alchemy read", () => {
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
       "operational+durable+postgres",
     );
-    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
-      "operational-dual",
-    );
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBeNull();
     expect(response.headers.get("X-Programmable-Price-Source")).toBe(
-      "state-view+chainlink",
+      "bitquery",
+    );
+    expect(response.headers.get("X-Programmable-Market-As-Of")).toBe(
+      "2026-08-11T14:00:00.000Z",
     );
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
       "operational+durable+registry.custom-launched",
     );
-    expect(response.headers.get("X-Programmable-Valuation-Metric")).toBe(
-      "fdv",
+    expect(response.headers.get("X-Programmable-Market-Source")).toBe(
+      "bitquery",
     );
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
   });
 
-  it("reports detail FDV at the verified operational block, not the stale launch snapshot", async () => {
+  it("reports detail FDV at the verified Bitquery time, not the stale launch snapshot", async () => {
     const canonical = token(TOKEN_ADDRESS, {
       totalSupplyRaw: "1000000000000000000000000",
       tokenDecimals: 18,
@@ -231,11 +301,6 @@ describe("token detail Alchemy read", () => {
       indexedMarketCapUsdWad: "1620000000000000000000000",
       indexedValuationBlockNumber: snapshot.blockNumber,
     });
-    const operationalSnapshot = {
-      ...launchDiscoverySnapshot,
-      blockNumber: "25632000",
-      blockHash: `0x${"99".repeat(32)}` as const,
-    };
     mocks.readAlchemyExploreModel.mockResolvedValue({
       status: "ready",
       tokens: [canonical],
@@ -245,22 +310,9 @@ describe("token detail Alchemy read", () => {
       launcherFeesAccruedWei: "0",
       launcherFeesAccruedEth: "0",
     } satisfies ExploreReadModel);
-    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
-      operationalSnapshot,
-    );
-    mocks.readExploreReferenceHeadWithinRouteBudget.mockResolvedValue({
-      blockNumber: operationalSnapshot.blockNumber,
-      blockHash: operationalSnapshot.blockHash,
-      indexedAt: "2026-08-10T18:00:00.000Z",
-      finality: "confirmed",
-    });
-    mocks.enrichTokensWithAlchemyPoolState.mockImplementation(
-      async ({ snapshot: readSnapshot }) => [{
-        ...canonical,
-        indexedMarketCapUsdWad: undefined,
-        indexedValuationBlockNumber: readSnapshot.blockNumber,
-        fdvUsdWad: "2334305942998987256153723",
-      }],
+    mocks.readBitqueryTokenMarketDataV1.mockImplementation(
+      async (identities: readonly MarketDataIdentityV1[]) =>
+        bitqueryMarketData(identities, "2334305942998987256153723"),
     );
 
     const response = await GET(
@@ -271,24 +323,21 @@ describe("token detail Alchemy read", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mocks.withSameBlockEthUsdQuote).toHaveBeenCalledWith(
-      expect.objectContaining({ snapshot: operationalSnapshot }),
-    );
-    expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalledWith(
-      expect.objectContaining({ snapshot: operationalSnapshot }),
-    );
+    expect(mocks.withSameBlockEthUsdQuote).not.toHaveBeenCalled();
+    expect(mocks.enrichTokensWithAlchemyPoolState).not.toHaveBeenCalled();
     expect(body.token).toMatchObject({
-      fdvUsdWad: "2334305942998987256153723",
+      fdvUsdWad: "2334305942998987256000000",
       valuation: {
         status: "available",
         freshness: "current",
-        asOfBlock: operationalSnapshot.blockNumber,
-        lagBlocks: "0",
+        source: "bitquery",
+        asOfTime: "2026-08-11T14:00:00.000Z",
       },
     });
     expect(body.dataQuality.valuation).toMatchObject({
       status: "current",
-      asOfBlock: operationalSnapshot.blockNumber,
+      asOfBlock: null,
+      asOfTime: "2026-08-11T14:00:00.000Z",
     });
     expect(body.launchDiscoverySnapshot).toEqual(launchDiscoverySnapshot);
   });
@@ -371,7 +420,7 @@ describe("token detail Alchemy read", () => {
     );
   });
 
-  it("retains canonical identity and reports unavailable FDV when enrichment fails", async () => {
+  it("retains canonical identity and reports unavailable FDV when Bitquery has no data", async () => {
     const canonical = token(TOKEN_ADDRESS, {
       totalSupplyRaw: "1000000000000000000000000",
       tokenDecimals: 18,
@@ -385,9 +434,7 @@ describe("token detail Alchemy read", () => {
       launcherFeesAccruedWei: "0",
       launcherFeesAccruedEth: "0",
     } satisfies ExploreReadModel);
-    mocks.enrichTokensWithAlchemyPoolState.mockRejectedValue(
-      new Error("pool unavailable"),
-    );
+    mocks.readBitqueryTokenMarketDataV1.mockResolvedValue(new Map());
 
     const response = await GET(
       new NextRequest(
@@ -401,7 +448,7 @@ describe("token detail Alchemy read", () => {
       tokenAddress: TOKEN_ADDRESS,
       valuation: {
         status: "unavailable",
-        reason: "liquidity-unavailable",
+        reason: "source-unavailable",
       },
     });
     expect(body.token.valuation).not.toHaveProperty("valueWad", "0");
@@ -410,5 +457,6 @@ describe("token detail Alchemy read", () => {
       valuation: { status: "unavailable", available: 0, unavailable: 1 },
     });
     expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("X-Programmable-Price-Source")).toBeNull();
   });
 });

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -32,17 +32,17 @@ describe("token detail layout", () => {
     );
 
     expect(chartSource).toContain(
-      "`${formatPrice(activePoint.value, chart.unit)}, block ${activePoint.blockNumber}`",
+      "`${formatPrice(activePoint.value, chart.unit)}, ${chartPointContext(activePoint)}`",
     );
     expect(chartSource).toMatch(
-      /className=\{styles\.tooltip\}[\s\S]*?aria-hidden="true"[\s\S]*?<strong>\{formatPrice\(activePoint\.value, chart\.unit\)\}<\/strong>[\s\S]*?<span>Block \{activePoint\.blockNumber\}<\/span>/,
+      /className=\{styles\.tooltip\}[\s\S]*?aria-hidden="true"[\s\S]*?<strong>\{formatPrice\(activePoint\.value, chart\.unit\)\}<\/strong>[\s\S]*?<span>\{chartPointContext\(activePoint\)\}<\/span>/,
     );
     expect(activeValueIdIndex).toBeGreaterThan(-1);
     expect(liveRegion).toContain('className="sr-only"');
     expect(liveRegion).toContain('role="status"');
     expect(liveRegion).toContain('aria-live="polite"');
     expect(liveRegion).toContain('aria-atomic="true"');
-    expect(liveRegion).toContain("activePoint.blockNumber");
+    expect(liveRegion).toContain("chartPointContext(activePoint)");
     expect(chartSource).toMatch(
       /style=\{\{[\s\S]*?left:\s*`clamp\([^`]+\)`[\s\S]*?\}\}/,
     );
@@ -139,8 +139,8 @@ describe("token detail layout", () => {
   });
 
   it("uses only typed chart FDV while labeling total-supply value as FDV", () => {
-    expect(detailSource).toContain('label: "FDV"');
-    expect(detailSource).not.toContain('label: "Market cap"');
+    expect(detailSource).toContain(': "FDV",');
+    expect(detailSource).toContain('valuation.metric === "market-cap"');
     expect(detailSource).not.toContain("fdvEthWei={");
     expect(detailSource).not.toContain("fdvUsdWad={");
     expect(chartSource).not.toContain("payload.marketCap");

--- a/tests/token-detail-view.test.ts
+++ b/tests/token-detail-view.test.ts
@@ -91,6 +91,13 @@ describe("token detail metrics", () => {
     });
   });
 
+  it("shows unavailable for a historical point without evidenced USD or ETH FDV", () => {
+    expect(buildTokenDetailMetrics(token, "Unavailable")[0]).toEqual({
+      label: "FDV",
+      value: "Unavailable",
+    });
+  });
+
   it("labels a stale value as last verified instead of current FDV", () => {
     expect(buildTokenDetailMetrics({
       ...token,

--- a/tests/token-detail-view.test.ts
+++ b/tests/token-detail-view.test.ts
@@ -9,6 +9,7 @@ import {
   parseDetailPayload,
 } from "../components/token-detail-view";
 import type { PreparedTokenTrade } from "../components/token-trade";
+import type { TokenMarketDataV1 } from "../lib/market-data/market-data-v1";
 import type { CanonicalTokenExploreEntry, LauncherToken } from "../lib/tokens";
 
 const token = {
@@ -47,11 +48,10 @@ const canonicalToken = {
 } satisfies CanonicalTokenExploreEntry;
 
 describe("token detail metrics", () => {
-  it("shows only user-facing market stats and converts volume to USD", () => {
+  it("ignores legacy market volume without Bitquery provenance", () => {
     expect(buildTokenDetailMetrics(token)).toEqual([
       { label: "FDV", value: "$168.56K" },
       { label: "Category", value: "Classic" },
-      { label: "Volume", value: "$900K" },
       { label: "Swap fee", value: "1%" },
     ]);
   });
@@ -88,6 +88,25 @@ describe("token detail metrics", () => {
     expect(buildTokenDetailMetrics(token, "$212.4K")[0]).toEqual({
       label: "FDV",
       value: "$212.4K",
+    });
+  });
+
+  it("labels a stale value as last verified instead of current FDV", () => {
+    expect(buildTokenDetailMetrics({
+      ...token,
+      valuation: {
+        status: "available",
+        metric: "fdv",
+        supplyBasis: "total",
+        currency: "usd",
+        valueWad: parseEther("168560").toString(),
+        freshness: "stale",
+        source: "bitquery",
+        asOfTime: "2026-08-10T11:50:47.000Z",
+      },
+    })[0]).toEqual({
+      label: "Last verified FDV",
+      value: "$168.56K",
     });
   });
 
@@ -151,7 +170,7 @@ describe("token detail metrics", () => {
     ).toEqual({ label: "Deep fee", value: "1%" });
   });
 
-  it("prefers official Uniswap v4 USD volume and shows pool liquidity", () => {
+  it("ignores legacy subgraph market analytics", () => {
     const enriched = {
       ...token,
       uniswapV4Pool: {
@@ -171,10 +190,94 @@ describe("token detail metrics", () => {
     expect(buildTokenDetailMetrics(enriched)).toEqual([
       { label: "FDV", value: "$168.56K" },
       { label: "Category", value: "Classic" },
-      { label: "Volume", value: "$1.2M" },
-      { label: "Liquidity now", value: "$98.8K" },
       { label: "Swap fee", value: "1%" },
     ]);
+  });
+
+  it("shows only typed Bitquery market cap, volume, and liquidity", () => {
+    const marketData = {
+      schemaVersion: "programmable.market-data.v1",
+      source: "bitquery",
+      generatedAt: "2026-08-11T14:00:00.000Z",
+      status: "current",
+      primaryPoolId: token.poolId,
+      pools: [{
+        identity: {
+          chainId: "1",
+          tokenAddress: token.tokenAddress,
+          poolId: token.poolId,
+          protocol: "uniswap_v4",
+        },
+        source: "bitquery",
+        status: "current",
+        quality: "complete",
+        asOfTime: "2026-08-11T14:00:00.000Z",
+        latestTrade: {
+          transactionHash: `0x${"55".repeat(32)}`,
+          logIndex: 1,
+          blockNumber: "25740000",
+          time: "2026-08-11T14:00:00.000Z",
+          tokenSide: "buy",
+          priceUsdWad: parseEther("2").toString(),
+        },
+        liquidity: {
+          asOfTime: "2026-08-11T14:00:00.000Z",
+          asOfBlock: "25740000",
+          valueUsdWad: parseEther("98765").toString(),
+          freshness: "current",
+        },
+        volume24hUsdWad: parseEther("1234567").toString(),
+        tradeCount24h: 42,
+        valuation: {
+          status: "available",
+          metric: "market-cap",
+          supplyBasis: "circulating",
+          valueUsdWad: parseEther("140000").toString(),
+          marketCapUsdWad: parseEther("140000").toString(),
+          fdvUsdWad: parseEther("168560").toString(),
+          totalSupply: "1000000",
+          circulatingSupply: "830565",
+          asOfTime: "2026-08-11T14:00:00.000Z",
+          freshness: "current",
+        },
+      }],
+    } as const satisfies TokenMarketDataV1;
+
+    expect(buildTokenDetailMetrics({
+      ...token,
+      valuation: {
+        status: "available",
+        metric: "market-cap",
+        supplyBasis: "circulating",
+        currency: "usd",
+        valueWad: parseEther("140000").toString(),
+        freshness: "current",
+        source: "bitquery",
+        asOfTime: "2026-08-11T14:00:00.000Z",
+      },
+      marketData,
+    })).toEqual([
+      { label: "Market cap", value: "$140K" },
+      { label: "Category", value: "Classic" },
+      { label: "24h volume", value: "$1.2M" },
+      { label: "Liquidity", value: "$98.8K" },
+      { label: "Swap fee", value: "1%" },
+    ]);
+
+    const staleLiquidity = {
+      ...marketData,
+      pools: [{
+        ...marketData.pools[0],
+        liquidity: {
+          ...marketData.pools[0].liquidity,
+          freshness: "stale" as const,
+        },
+      }],
+    } satisfies TokenMarketDataV1;
+    expect(buildTokenDetailMetrics({
+      ...token,
+      marketData: staleLiquidity,
+    })).not.toContainEqual(expect.objectContaining({ label: "Liquidity" }));
   });
 
   it("strictly validates optional official Uniswap v4 pool analytics", () => {
@@ -264,7 +367,7 @@ describe("token detail metrics", () => {
       buildTokenDetailMetrics(stockToken).find(
         (metric) => metric.label === "Volume",
       ),
-    ).toEqual({ label: "Volume", value: "$54.90" });
+    ).toBeUndefined();
   });
 
   it("shows Stock-Paired gross volume in its quote unit when no validated USD rate is available", () => {
@@ -284,7 +387,7 @@ describe("token detail metrics", () => {
       buildTokenDetailMetrics(stockToken).find(
         (metric) => metric.label === "Volume",
       ),
-    ).toEqual({ label: "Volume", value: "18.3 SVON" });
+    ).toBeUndefined();
   });
 
   it("labels the canonical Stock-Paired sell output as ETH after unwrap", () => {

--- a/tests/token-price-chart-refresh.test.ts
+++ b/tests/token-price-chart-refresh.test.ts
@@ -90,7 +90,7 @@ describe("token price chart inspection", () => {
     expect(shouldClearChartInspectionAfterPointerUp("")).toBe(true);
   });
 
-  it("updates FDV to the inspected historical price", () => {
+  it("updates historical FDV only from matching ETH and USD evidence", () => {
     expect(
       getChartFdvAtPoint(
         {
@@ -103,7 +103,7 @@ describe("token price chart inspection", () => {
           fdvEth: "1000",
           fdvUsdWad: "2000000000000000000000000",
         },
-        { blockNumber: "1", priceEth: "0.5" },
+        { blockNumber: "1", priceEth: "0.5", priceUsd: "1250" },
         { blockNumber: "2", priceEth: "1", priceUsd: "2500" },
       ),
     ).toEqual({
@@ -113,7 +113,7 @@ describe("token price chart inspection", () => {
     });
   });
 
-  it("retains verified FDV when historical integer scaling would underflow", () => {
+  it("does not substitute current FDV when historical scaling underflows", () => {
     expect(
       getChartFdvAtPoint(
         {
@@ -129,10 +129,31 @@ describe("token price chart inspection", () => {
         { blockNumber: "1", priceEth: "0.5" },
         { blockNumber: "2", priceEth: "1" },
       ),
-    ).toEqual({
-      fdvEthWei: "1",
-      fdvEth: "0.000000000000000001",
-      fdvUsdWad: "1",
+    ).toEqual({});
+  });
+
+  it("never derives historical USD FDV from ETH or arbitrary quote ratios", () => {
+    const payload = {
+      status: "ready" as const,
+      points: [],
+      swapCount: 2,
+      fdvEthWei: "1000000000000000000000",
+      fdvEth: "1000",
+      fdvUsdWad: "2000000000000000000000000",
+    };
+
+    expect(getChartFdvAtPoint(
+      payload,
+      { blockNumber: "1", priceQuote: "5", quoteSymbol: "USDC" },
+      { blockNumber: "2", priceQuote: "10", quoteSymbol: "USDC" },
+    )).toEqual({});
+    expect(getChartFdvAtPoint(
+      payload,
+      { blockNumber: "1", priceEth: "0.5" },
+      { blockNumber: "2", priceEth: "1", priceUsd: "2500" },
+    )).toEqual({
+      fdvEthWei: "500000000000000000000",
+      fdvEth: "500",
     });
   });
 


### PR DESCRIPTION
## What changed

- makes Bitquery the only external market-data source for Explore, token detail and price history
- keeps Router/Registry as the canonical token and Uniswap v4 PoolId identity source
- publishes only current FDV backed by canonical total supply, the curated Bitquery price index, a current exact-pool trade, at least $10,000 exact-pool liquidity and raw/index agreement within 10%
- keeps stale, unavailable and waiting-for-first-trade states visible without invented zeroes or stale ranking
- fetches newest chart trades first, preserves quote-unit history and rejects untrusted raw USD history
- adds fail-closed Production secret metadata, stage canaries and public post-promotion readback for Bitquery

## Root cause

The previous market path mixed lagging indexed values, Alchemy enrichment and historical chart data. That could expose stale FDV as current, misorder Highest FDV and make charts unavailable when the Alchemy market path failed.

## Validation

- 159 focused Vitest tests
- TypeScript and scoped ESLint
- read-model smoke and operations source gate
- actionlint and diff-check
- clean Next.js 16 Turbopack production build
- independent frozen reviews running on commit `f49c7ecdafa0c218ee359f9100e6401f59d8bb67`

No Router, contract, reward or claim path is changed. `BITQUERY_OAUTH_TOKEN` remains server-only and is never logged or serialized.
