### PR TITLE
Fix Bitquery market supply hydration

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -21,6 +21,8 @@ import {
 } from "../../../lib/explore-financial-data";
 import { readBitqueryTokenMarketDataV1 } from
   "../../../lib/market-data/bitquery.server";
+import { hydrateMissingCanonicalTokenSupplyV1 } from
+  "../../../lib/market-data/canonical-token-supply.server";
 import { exploreEntriesMarketIdentitiesV1 } from
   "../../../lib/market-data/explore-market-identities";
 import type { TokenMarketDataV1 } from
@@ -437,12 +439,15 @@ export async function GET(request: NextRequest) {
       identityAsOfBlock,
       referenceHead?.blockNumber,
     );
-    const identityEntries = dedupeExploreEntriesV1([
+    const unresolvedIdentityEntries = dedupeExploreEntriesV1([
       ...(identityModel
         ? visibleExploreTokens(identityModel).map(canonicalTokenExploreEntryV1)
         : []),
       ...customProjects,
     ]);
+    const identityEntries = await hydrateMissingCanonicalTokenSupplyV1(
+      unresolvedIdentityEntries,
+    );
     const marketByToken = await readBitqueryTokenMarketDataV1(
       exploreEntriesMarketIdentitiesV1(identityEntries),
       { signal: request.signal },

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -19,6 +19,8 @@ import {
   readBitqueryMarketChartV1,
   readBitqueryTokenMarketDataV1,
 } from "../../../../../lib/market-data/bitquery.server";
+import { hydrateMissingCanonicalTokenSupplyV1 } from
+  "../../../../../lib/market-data/canonical-token-supply.server";
 import { exploreEntryMarketIdentitiesV1 } from
   "../../../../../lib/market-data/explore-market-identities";
 import type { MarketChartV1 } from
@@ -140,9 +142,14 @@ export async function GET(request: NextRequest) {
     if (token && customProject) {
       throw new Error("Canonical token chart sources disagree on launch category");
     }
-    const entry: ExploreEntry | null = token
+    const unresolvedEntry: ExploreEntry | null = token
       ? canonicalTokenExploreEntryV1(token)
       : customProject ?? null;
+    const entry = unresolvedEntry
+      ? (await hydrateMissingCanonicalTokenSupplyV1([
+          unresolvedEntry,
+        ]))[0] ?? unresolvedEntry
+      : null;
     if (!entry) {
       if (
         canonicalSource?.status === "current" &&

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -21,6 +21,8 @@ import {
 } from "../../../../lib/explore-financial-data";
 import { readBitqueryTokenMarketDataV1 } from
   "../../../../lib/market-data/bitquery.server";
+import { hydrateMissingCanonicalTokenSupplyV1 } from
+  "../../../../lib/market-data/canonical-token-supply.server";
 import { exploreEntryMarketIdentitiesV1 } from
   "../../../../lib/market-data/explore-market-identities";
 import type { TokenMarketDataV1 } from
@@ -197,9 +199,14 @@ export async function GET(request: NextRequest) {
       identityAsOfBlock,
       referenceHead?.blockNumber,
     );
-    const identityEntry = token
+    const unresolvedIdentityEntry = token
       ? canonicalTokenExploreEntryV1(token)
       : customProject ?? null;
+    const identityEntry = unresolvedIdentityEntry
+      ? (await hydrateMissingCanonicalTokenSupplyV1([
+          unresolvedIdentityEntry,
+        ]))[0] ?? unresolvedIdentityEntry
+      : null;
     const marketByToken = identityEntry
       ? await readBitqueryTokenMarketDataV1(
           exploreEntryMarketIdentitiesV1(identityEntry),

--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -378,9 +378,9 @@ function reconcileBitqueryValuations<T extends ExploreEntry>(
       };
     }
     if (
-      !pool.liquidity ||
-      liquidity === null ||
-      liquidity < BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD)
+      pool.liquidity &&
+      (liquidity === null ||
+        liquidity < BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD))
     ) {
       return {
         ...pool,
@@ -412,17 +412,20 @@ function reconcileBitqueryValuations<T extends ExploreEntry>(
     }
     const tradeTime = Date.parse(pool.latestTrade?.time ?? "");
     const priceTime = Date.parse(pool.latestTrade.priceUsdAsOfTime);
-    const liquidityTime = Date.parse(pool.liquidity.asOfTime);
+    const liquidityTime = pool.liquidity
+      ? Date.parse(pool.liquidity.asOfTime)
+      : null;
     const generatedTime = Date.parse(marketData.generatedAt);
     if (
       !Number.isFinite(tradeTime) ||
       !Number.isFinite(priceTime) ||
-      !Number.isFinite(liquidityTime) ||
+      (liquidityTime !== null && !Number.isFinite(liquidityTime)) ||
       !Number.isFinite(generatedTime) ||
       Math.abs(tradeTime - priceTime) > MARKET_DATA_CURRENT_MAX_AGE_MS ||
       tradeTime > generatedTime + MAXIMUM_MARKET_FUTURE_SKEW_MS ||
       priceTime > generatedTime + MAXIMUM_MARKET_FUTURE_SKEW_MS ||
-      liquidityTime > generatedTime + MAXIMUM_MARKET_FUTURE_SKEW_MS
+      (liquidityTime !== null &&
+        liquidityTime > generatedTime + MAXIMUM_MARKET_FUTURE_SKEW_MS)
     ) {
       return {
         ...pool,
@@ -433,14 +436,16 @@ function reconcileBitqueryValuations<T extends ExploreEntry>(
         },
       };
     }
-    const asOfTime = new Date(
-      Math.min(tradeTime, priceTime, liquidityTime),
-    ).toISOString();
-    const evidenceIsCurrent = [tradeTime, priceTime, liquidityTime].every(
+    const evidenceTimes = liquidityTime === null
+      ? [tradeTime, priceTime]
+      : [tradeTime, priceTime, liquidityTime];
+    const asOfTime = new Date(Math.min(...evidenceTimes)).toISOString();
+    const evidenceIsCurrent = pool.liquidity !== undefined &&
+      evidenceTimes.every(
       (time) => generatedTime - time <= MARKET_DATA_CURRENT_MAX_AGE_MS,
-    );
+      );
     const freshness = pool.status === "current" &&
-        pool.liquidity.freshness === "current" &&
+        pool.liquidity?.freshness === "current" &&
         evidenceIsCurrent
       ? "current" as const
       : "stale" as const;

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -45,6 +45,11 @@ const ADDRESS = /^0x[0-9a-f]{40}$/u;
 const BYTES32 = /^0x[0-9a-f]{64}$/u;
 const TRANSACTION_HASH = /^0x[0-9a-f]{64}$/u;
 const CANONICAL_UNSIGNED_INTEGER = /^(?:0|[1-9][0-9]*)$/u;
+const NATIVE_ETH_ADDRESS =
+  "0x0000000000000000000000000000000000000000" as const;
+const WETH_ADDRESS =
+  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" as const;
+const WAD = 10n ** 18n;
 
 type FetchImplementation = typeof fetch;
 
@@ -487,24 +492,59 @@ async function readMarketBatch(
   identities: readonly MarketDataIdentityV1[],
   options: BitqueryReaderOptions & Readonly<{ token: string; now: Date }>,
 ): Promise<readonly MarketPoolDataV1[]> {
-  const { query, variables } = marketBatchQuery(identities);
-  const response = await executeBitqueryGraphql(query, variables, options);
-  const evm = record(response.data.EVM);
-  const trading = record(response.data.Trading);
-  if (evm === null || trading === null) {
-    throw new BitqueryMarketDataError("response");
-  }
-
-  const tradesByPool = indexUniqueRows(
-    array(evm.latestTrades),
-    tradeRowPoolId,
+  const coreRequest = marketBatchQuery(identities);
+  const liquidityRequest = marketLiquidityQuery(identities);
+  const statsRequest = marketStatsQuery(identities);
+  const response = await executeBitqueryGraphql(
+    coreRequest.query,
+    coreRequest.variables,
+    options,
   );
+  const evm = record(response.data.EVM);
+  if (evm === null) throw new BitqueryMarketDataError("response");
+  const tradesByPool = indexUniqueRows(array(evm.latestTrades), tradeRowPoolId);
+  const parsedTrades = identities.map((identity) => {
+    const row = tradesByPool.get(identity.poolId);
+    return {
+      row,
+      trade: parseTrade(row, identity),
+    };
+  });
+  const priceRequest = marketPriceQuery(parsedTrades.map(({ trade }) => trade));
+  const [priceResult, liquidityResult, statsResult] = await Promise.allSettled([
+      executeBitqueryGraphql(
+        priceRequest.query,
+        priceRequest.variables,
+        options,
+      ),
+      executeBitqueryGraphql(
+        liquidityRequest.query,
+        liquidityRequest.variables,
+        options,
+      ),
+      executeBitqueryGraphql(
+        statsRequest.query,
+        statsRequest.variables,
+        options,
+      ),
+    ]);
+
+  const priceTrading = priceResult.status === "fulfilled"
+    ? record(priceResult.value.data.Trading)
+    : null;
+  const liquidityEvm = liquidityResult.status === "fulfilled"
+    ? record(liquidityResult.value.data.EVM)
+    : null;
+  const statsEvm = statsResult.status === "fulfilled"
+    ? record(statsResult.value.data.EVM)
+    : null;
+
   const liquidityByPool = indexUniqueRows(
-    array(evm.latestLiquidity),
+    array(liquidityEvm?.latestLiquidity),
     liquidityRowPoolId,
   );
   const statsByMarket = indexUniqueRows(
-    array(evm.stats),
+    array(statsEvm?.stats),
     (row) => {
       const trade = record(record(row)?.Trade);
       const poolId = canonicalBytes32(trade?.PoolId);
@@ -514,22 +554,20 @@ async function readMarketBatch(
       return poolId && address ? marketStatsKey(poolId, address) : null;
     },
   );
-  const supplyByToken = indexUniqueRows(
-    array(trading.tokenSupplies),
-    (row) => canonicalAddress(record(record(row)?.Token)?.Address),
-  );
-  const parsed = identities.map((identity) => {
-    const latestTradeRow = tradesByPool.get(identity.poolId);
+  const parsed = identities.map((identity, index) => {
+    const latestTradeRow = parsedTrades[index]?.row;
     const latestTradeRows = latestTradeRow === undefined
       ? []
       : [latestTradeRow];
-    const tokenRow = supplyByToken.get(identity.tokenAddress);
-    const parsedTrade = parseTrade(latestTradeRows[0], identity);
+    const parsedTrade = parsedTrades[index]?.trade ?? null;
     const latestTrade = parsedTrade === null
       ? null
       : enrichTradeWithIndexedUsd(
           parsedTrade,
-          parseTokenPriceObservation(tokenRow, identity),
+          parseNativeQuotePriceObservation(
+            array(priceTrading?.[`price${index}`])[0],
+            parsedTrade,
+          ),
           options.now,
         );
     return {
@@ -540,7 +578,7 @@ async function readMarketBatch(
       stats: parseStats(statsByMarket.get(
         marketStatsKey(identity.poolId, identity.tokenAddress),
       )),
-      supply: parseSupply(tokenRow, identity),
+      supply: null,
     };
   });
 
@@ -559,7 +597,14 @@ async function readMarketBatch(
       stats: value.stats,
       supply: value.supply,
       now: options.now,
-      partialResponse: response.partial,
+      partialResponse:
+        response.partial ||
+        priceResult.status !== "fulfilled" ||
+        priceResult.value.partial ||
+        liquidityResult.status !== "fulfilled" ||
+        liquidityResult.value.partial ||
+        statsResult.status !== "fulfilled" ||
+        statsResult.value.partial,
     });
   });
 }
@@ -592,6 +637,29 @@ function parseTokenPriceObservation(
     : { time, priceUsdWad: priceUsdWad.toString() };
 }
 
+function parseNativeQuotePriceObservation(
+  value: unknown,
+  trade: MarketTradeV1,
+): TokenPriceObservation | null {
+  const row = record(value);
+  const block = record(row?.Block);
+  const pair = record(row?.Pair);
+  const token = record(pair?.Token);
+  const tokenId = nonEmptyString(token?.Id)?.toLowerCase();
+  if (
+    (trade.quoteAddress !== NATIVE_ETH_ADDRESS &&
+      trade.quoteAddress !== WETH_ADDRESS) ||
+    tokenId !== "bid:eth"
+  ) return null;
+  const time = isoTime(block?.Time);
+  const priceUsdWad = decimalToWad(row?.PriceInUsd);
+  return time !== null && priceUsdWad !== null &&
+      Date.parse(time) <= Date.parse(trade.time) &&
+      Date.parse(trade.time) - Date.parse(time) <= INDEXED_PRICE_MAXIMUM_DISTANCE_MS
+    ? { time, priceUsdWad: priceUsdWad.toString() }
+    : null;
+}
+
 function enrichTradeWithIndexedUsd(
   trade: MarketTradeV1,
   indexed: TokenPriceObservation | null,
@@ -603,24 +671,33 @@ function enrichTradeWithIndexedUsd(
     ? null
     : BigInt(trade.rawPriceUsdWad);
   const indexedPrice = indexed === null ? null : BigInt(indexed.priceUsdWad);
+  const quotePrice = trade.priceQuoteWad === undefined
+    ? null
+    : BigInt(trade.priceQuoteWad);
+  const derivedPrice = quotePrice === null || indexedPrice === null
+    ? null
+    : quotePrice * indexedPrice / WAD;
+  if (trade.priceUsdWad) return trade;
   if (
     indexed === null ||
-    rawPrice === null ||
     indexedPrice === null ||
+    derivedPrice === null ||
+    derivedPrice <= 0n ||
     !Number.isFinite(indexedTime) ||
     !Number.isFinite(tradeTime) ||
     indexedTime > now.getTime() + MAXIMUM_FUTURE_SKEW_MS ||
     Math.abs(indexedTime - tradeTime) > INDEXED_PRICE_MAXIMUM_DISTANCE_MS ||
-    !usdPricesWithinConfidence(rawPrice, indexedPrice)
+    (rawPrice !== null && !usdPricesWithinConfidence(rawPrice, derivedPrice))
   ) return trade;
   const amountUsdWad = trade.tokenAmount
-    ? multiplyWadByDecimal(indexedPrice, trade.tokenAmount)
+    ? multiplyWadByDecimal(derivedPrice, trade.tokenAmount)
     : null;
   return {
     ...trade,
-    priceUsdWad: indexed.priceUsdWad,
+    priceUsdWad: derivedPrice.toString(),
     priceUsdAsOfTime: indexed.time,
     priceUsdSource: MARKET_DATA_USD_PRICE_SOURCE,
+    rawPriceUsdWad: rawPrice?.toString() ?? derivedPrice.toString(),
     ...(amountUsdWad === null ? {} : { amountUsdWad: amountUsdWad.toString() }),
   };
 }
@@ -723,17 +800,10 @@ function marketStatsKey(
 
 function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
   const pools = identities.map(({ poolId }) => poolId);
-  const tokenAddresses = [...new Set(
-    identities.map(({ tokenAddress }) => tokenAddress),
-  )].sort();
   const rowLimit = Math.max(1, identities.length);
-  const statsLimit = Math.max(1, identities.length * 2);
 
   return {
-    query: `query ProgrammableMarketSnapshot(
-      $pools: [String!]!
-      $tokenAddresses: [String!]!
-    ) {
+    query: `query ProgrammableMarketSnapshot($pools: [String!]!) {
       EVM(network: eth, dataset: combined) {
         latestTrades: DEXTrades(
           limit: { count: ${rowLimit} }
@@ -751,6 +821,44 @@ function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
             }
           }
         ) { ${tradeSelection()} }
+      }
+    }`,
+    variables: { pools },
+  };
+}
+
+function marketPriceQuery(trades: readonly (MarketTradeV1 | null)[]) {
+  const selections = trades.map((trade, index) => `
+    price${index}: Trades(
+      limit: { count: 1 }
+      orderBy: { descending: Block_Time }
+      where: {
+        ${trade ? `Block: { Time: { till: "${trade.time}" } }` : ""}
+        Pair: {
+          Market: { NetworkBid: { is: "bid:eth" } }
+          Token: { Id: { is: "bid:eth" } }
+        }
+      }
+    ) {
+      Block { Time }
+      Pair { Token { Id Address } }
+      PriceInUsd
+    }
+  `).join("\n");
+  return {
+    query: `query ProgrammableMarketPrices {
+      Trading { ${selections} }
+    }`,
+    variables: {},
+  };
+}
+
+function marketLiquidityQuery(identities: readonly MarketDataIdentityV1[]) {
+  const pools = identities.map(({ poolId }) => poolId);
+  const rowLimit = Math.max(1, identities.length);
+  return {
+    query: `query ProgrammableMarketLiquidity($pools: [String!]!) {
+      EVM(network: eth, dataset: combined) {
         latestLiquidity: DEXPoolEvents(
           limit: { count: ${rowLimit} }
           limitBy: { by: PoolEvent_Pool_PoolId, count: 1 }
@@ -767,6 +875,24 @@ function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
             }
           }
         ) { ${liquiditySelection()} }
+      }
+    }`,
+    variables: { pools },
+  };
+}
+
+function marketStatsQuery(identities: readonly MarketDataIdentityV1[]) {
+  const pools = identities.map(({ poolId }) => poolId);
+  const tokenAddresses = [...new Set(
+    identities.map(({ tokenAddress }) => tokenAddress),
+  )].sort();
+  const statsLimit = Math.max(1, identities.length * 2);
+  return {
+    query: `query ProgrammableMarketStats(
+      $pools: [String!]!
+      $tokenAddresses: [String!]!
+    ) {
+      EVM(network: eth, dataset: combined) {
         stats: DEXTradeByTokens(
           limit: { count: ${statsLimit} }
           where: {
@@ -783,14 +909,6 @@ function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
           count
           volumeUsd: sum(of: Trade_Side_AmountInUSD)
         }
-      }
-      Trading {
-        tokenSupplies: Tokens(
-          limit: { count: ${tokenAddresses.length} }
-          limitBy: { by: Token_Address, count: 1 }
-          orderBy: { descending: Block_Time }
-          where: { Token: { Address: { in: $tokenAddresses } } }
-        ) { ${supplySelection()} }
       }
     }`,
     variables: { pools, tokenAddresses },
@@ -918,12 +1036,28 @@ function parseTrade(
   if (tokenIsBuy === tokenIsSell) return null;
   const tokenSide = tokenIsBuy ? "buy" as const : "sell" as const;
   const token = tokenIsBuy ? buy : sell;
+  const quote = tokenIsBuy ? sell : buy;
   const quoteCurrency = tokenIsBuy ? sellCurrency : buyCurrency;
   const tokenAmount = positiveDecimal(token?.Amount);
   const rawPriceUsdWad = decimalToWad(token?.PriceInUSD);
   const priceQuoteWad = decimalToWad(token?.Price);
   const quoteAddress = canonicalCurrencyAddress(quoteCurrency?.SmartContract);
   const quoteSymbol = nonEmptyString(quoteCurrency?.Symbol);
+  const quotePriceUsdWad = decimalToWad(quote?.PriceInUSD);
+  const sameTradePriceUsdWad =
+    (quoteAddress === NATIVE_ETH_ADDRESS || quoteAddress === WETH_ADDRESS) &&
+      priceQuoteWad !== null && quotePriceUsdWad !== null
+      ? priceQuoteWad * quotePriceUsdWad / WAD
+      : null;
+  const verifiedSameTradePriceUsdWad = sameTradePriceUsdWad !== null &&
+      sameTradePriceUsdWad > 0n &&
+      (rawPriceUsdWad === null ||
+        usdPricesWithinConfidence(rawPriceUsdWad, sameTradePriceUsdWad))
+    ? sameTradePriceUsdWad
+    : null;
+  const amountUsdWad = verifiedSameTradePriceUsdWad !== null && tokenAmount
+    ? multiplyWadByDecimal(verifiedSameTradePriceUsdWad, tokenAmount)
+    : null;
   if (rawPriceUsdWad === null && priceQuoteWad === null) return null;
   return {
     transactionHash,
@@ -934,8 +1068,18 @@ function parseTrade(
     tokenSide,
     ...(tokenAmount === null ? {} : { tokenAmount }),
     ...(rawPriceUsdWad === null
-      ? {}
+      ? verifiedSameTradePriceUsdWad === null
+        ? {}
+        : { rawPriceUsdWad: verifiedSameTradePriceUsdWad.toString() }
       : { rawPriceUsdWad: rawPriceUsdWad.toString() }),
+    ...(verifiedSameTradePriceUsdWad === null
+      ? {}
+      : {
+          priceUsdWad: verifiedSameTradePriceUsdWad.toString(),
+          priceUsdAsOfTime: time,
+          priceUsdSource: MARKET_DATA_USD_PRICE_SOURCE,
+        }),
+    ...(amountUsdWad === null ? {} : { amountUsdWad: amountUsdWad.toString() }),
     ...(priceQuoteWad === null
       ? {}
       : { priceQuoteWad: priceQuoteWad.toString() }),

--- a/lib/market-data/canonical-token-supply.server.ts
+++ b/lib/market-data/canonical-token-supply.server.ts
@@ -1,0 +1,170 @@
+import "server-only";
+
+import { createPublicClient, http, type Hex } from "viem";
+import { mainnet } from "viem/chains";
+
+import { uerc20ReadAbi } from "../onchain/abis";
+import {
+  getWebsiteChartOnchainDeployment,
+  getWebsiteReadOnchainDeployment,
+} from "../onchain/config";
+import type { ReadyOnchainDeployment } from "../onchain/types";
+import type { ExploreEntry } from "../tokens";
+
+type SupplyObservation = Readonly<{
+  blockHash: Hex;
+  decimals: number;
+  totalSupplyRaw: string;
+}>;
+
+type SupplyClient = Readonly<{
+  getBlockNumber: () => Promise<bigint>;
+  getBlock: (input: Readonly<{ blockNumber: bigint }>) => Promise<{
+    hash: Hex | null;
+    number: bigint | null;
+  }>;
+  readContract: (input: Readonly<{
+    address: `0x${string}`;
+    abi: typeof uerc20ReadAbi;
+    functionName: "decimals" | "totalSupply";
+    blockNumber: bigint;
+  }>) => Promise<unknown>;
+}>;
+
+export type CanonicalTokenSupplyDependencies = Readonly<{
+  deployment?: ReadyOnchainDeployment;
+  additionalRpcUrls?: readonly string[];
+  createClient?: (rpcUrl: string) => SupplyClient;
+}>;
+
+function needsCanonicalSupply(entry: ExploreEntry): boolean {
+  return entry.exploreKind === "token" &&
+    (typeof entry.totalSupplyRaw !== "string" ||
+      !/^[1-9][0-9]*$/u.test(entry.totalSupplyRaw) ||
+      typeof entry.tokenDecimals !== "number" ||
+      !Number.isInteger(entry.tokenDecimals) ||
+      entry.tokenDecimals < 0 ||
+      entry.tokenDecimals > 255);
+}
+
+async function observeSupply(
+  client: SupplyClient,
+  tokenAddress: `0x${string}`,
+  blockNumber: bigint,
+): Promise<SupplyObservation> {
+  const [block, decimalsValue, totalSupplyValue] = await Promise.all([
+    client.getBlock({ blockNumber }),
+    client.readContract({
+      address: tokenAddress,
+      abi: uerc20ReadAbi,
+      functionName: "decimals",
+      blockNumber,
+    }),
+    client.readContract({
+      address: tokenAddress,
+      abi: uerc20ReadAbi,
+      functionName: "totalSupply",
+      blockNumber,
+    }),
+  ]);
+  const decimals = Number(decimalsValue);
+  const totalSupply = BigInt(totalSupplyValue as bigint);
+  if (
+    block.number !== blockNumber ||
+    !block.hash ||
+    !/^0x[0-9a-fA-F]{64}$/u.test(block.hash) ||
+    !Number.isInteger(decimals) ||
+    decimals < 0 ||
+    decimals > 255 ||
+    totalSupply <= 0n
+  ) {
+    throw new Error("Canonical token supply proof is invalid");
+  }
+  return {
+    blockHash: block.hash,
+    decimals,
+    totalSupplyRaw: totalSupply.toString(),
+  };
+}
+
+/**
+ * Completes missing Router token supply from two fixed Website readers at the
+ * same quorum-verified block. Identity remains usable when the proof is not
+ * available, but no numeric FDV is manufactured from a single provider.
+ */
+export async function hydrateMissingCanonicalTokenSupplyV1<T extends ExploreEntry>(
+  entries: readonly T[],
+  dependencies: CanonicalTokenSupplyDependencies = {},
+): Promise<T[]> {
+  if (!entries.some(needsCanonicalSupply)) return [...entries];
+
+  try {
+    const configured = dependencies.deployment ??
+      getWebsiteReadOnchainDeployment("production");
+    const rpcUrlSecondary = configured.rpcUrlSecondary;
+    if (
+      configured.status !== "ready" ||
+      !rpcUrlSecondary ||
+      rpcUrlSecondary === configured.rpcUrl
+    ) return [...entries];
+    const deployment = configured as ReadyOnchainDeployment;
+    const createClient = dependencies.createClient ?? ((rpcUrl: string) =>
+      createPublicClient({
+        chain: mainnet,
+        transport: http(rpcUrl, { retryCount: 0, timeout: 12_000 }),
+      }));
+    const defaultAdditionalRpc = dependencies.deployment
+      ? []
+      : [getWebsiteChartOnchainDeployment("production").rpcUrlSecondary]
+          .filter((value): value is string => typeof value === "string");
+    const rpcUrls = [...new Set([
+      deployment.rpcUrl,
+      rpcUrlSecondary,
+      ...(dependencies.additionalRpcUrls ?? defaultAdditionalRpc),
+    ])];
+    if (rpcUrls.length < 2) return [...entries];
+    const clients = rpcUrls.map(createClient);
+    const heads = (await Promise.allSettled(clients.map((client) =>
+      client.getBlockNumber())))
+      .flatMap((result) => result.status === "fulfilled" && result.value >= 0n
+        ? [result.value]
+        : []);
+    if (heads.length < 2) return [...entries];
+    const lowestHead = heads.reduce((lowest, head) =>
+      head < lowest ? head : lowest);
+    const blockNumber = lowestHead > deployment.confirmations
+      ? lowestHead - deployment.confirmations
+      : 0n;
+
+    return await Promise.all(entries.map(async (entry) => {
+      if (!needsCanonicalSupply(entry) || entry.exploreKind !== "token") {
+        return entry;
+      }
+      try {
+        const observations = (await Promise.allSettled(clients.map((client) =>
+          observeSupply(client, entry.tokenAddress, blockNumber))))
+          .flatMap((result) => result.status === "fulfilled" ? [result.value] : []);
+        const groups = new Map<string, SupplyObservation[]>();
+        for (const observation of observations) {
+          const key = [
+            observation.blockHash.toLowerCase(),
+            observation.decimals,
+            observation.totalSupplyRaw,
+          ].join(":");
+          groups.set(key, [...(groups.get(key) ?? []), observation]);
+        }
+        const agreed = [...groups.values()].find((group) => group.length >= 2)?.[0];
+        if (!agreed) return entry;
+        return {
+          ...entry,
+          totalSupplyRaw: agreed.totalSupplyRaw,
+          tokenDecimals: agreed.decimals,
+        } as T;
+      } catch {
+        return entry;
+      }
+    }));
+  } catch {
+    return [...entries];
+  }
+}

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -128,6 +128,13 @@ export function evaluateAlchemyExploreSourceContracts(
     "lib/market-data/bitquery.server.ts",
     sourceOverrides,
   );
+  const canonicalSupplyPath =
+    "lib/market-data/canonical-token-supply.server.ts";
+  const canonicalSupplySource = readSource(
+    rootDirectory,
+    canonicalSupplyPath,
+    sourceOverrides,
+  );
   const marketSchemaSource = readSource(
     rootDirectory,
     "lib/market-data/market-data-v1.ts",
@@ -207,9 +214,14 @@ export function evaluateAlchemyExploreSourceContracts(
       bitqueryMarketSource.includes(
         "limitBy: { by: PoolEvent_Pool_PoolId, count: 1 }",
       ) &&
+      bitqueryMarketSource.includes("query ProgrammableMarketPrices") &&
       bitqueryMarketSource.includes(
-        "limitBy: { by: Token_Address, count: 1 }",
+        'Block: { Time: { till: "${trade.time}" } }',
       ) &&
+      bitqueryMarketSource.includes(
+        'Token: { Id: { is: "bid:eth" } }',
+      ) &&
+      bitqueryMarketSource.includes("supply: null") &&
       bitqueryMarketSource.includes(
         'const dataset = range === "1h" ? "" : ", dataset: combined";',
       ) &&
@@ -217,7 +229,44 @@ export function evaluateAlchemyExploreSourceContracts(
       !bitqueryMarketSource.includes("NEXT_PUBLIC_BITQUERY") &&
       marketSchemaSource.includes('source: "bitquery"') &&
       marketSchemaSource.includes('protocol: "uniswap_v4"'),
-    "Bitquery market reads are server-only, PoolId-native, bounded and archive-aware",
+    "Bitquery market reads are server-only, PoolId-native, historically priced, bounded and archive-aware",
+  );
+  check(
+    "canonical-token-supply-quorum",
+    canonicalSupplySource.includes('import "server-only"') &&
+      canonicalSupplySource.includes(
+        'getWebsiteReadOnchainDeployment("production")',
+      ) &&
+      canonicalSupplySource.includes(
+        'getWebsiteChartOnchainDeployment("production").rpcUrlSecondary',
+      ) &&
+      canonicalSupplySource.includes(
+        "rpcUrlSecondary === configured.rpcUrl",
+      ) &&
+      canonicalSupplySource.includes("clients.map((client) =>") &&
+      canonicalSupplySource.includes("client.getBlockNumber()") &&
+      canonicalSupplySource.includes(
+        "lowestHead - deployment.confirmations",
+      ) &&
+      canonicalSupplySource.includes(
+        "observation.blockHash.toLowerCase()",
+      ) &&
+      canonicalSupplySource.includes("observation.decimals") &&
+      canonicalSupplySource.includes("observation.totalSupplyRaw") &&
+      canonicalSupplySource.includes("group.length >= 2") &&
+      canonicalSupplySource.includes("if (!agreed) return entry;") &&
+      routeSources
+        .filter(({ id }) => id !== "token-list")
+        .every(({ source }) => {
+          const supplyHydration = source.indexOf(
+            "await hydrateMissingCanonicalTokenSupplyV1(",
+          );
+          const marketRead = source.indexOf(
+            "await readBitqueryTokenMarketDataV1(",
+          );
+          return supplyHydration >= 0 && marketRead > supplyHydration;
+        }),
+    "missing supply is hydrated before market valuation only after fixed readers agree on block hash, decimals and total supply",
   );
 
   for (const route of routeSources) {

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -56,6 +56,7 @@ function tradeRow(input: Readonly<{
   priceQuote?: string;
   amountUsd?: string;
   omitPriceUsd?: boolean;
+  omitQuotePriceUsd?: boolean;
   omitAmountUsd?: boolean;
   quoteAddress?: string;
   quoteSymbol?: string;
@@ -91,7 +92,7 @@ function tradeRow(input: Readonly<{
         Amount: "0.01",
         AmountInUSD: input.amountUsd ?? "25",
         Price: "10000",
-        PriceInUSD: "2500",
+        ...(input.omitQuotePriceUsd ? {} : { PriceInUSD: "2500" }),
       },
     },
     Transaction: {
@@ -179,6 +180,26 @@ function supplyRow(input: Readonly<{
   };
 }
 
+function tradingPriceRow(
+  input: Readonly<{
+    tokenId?: string;
+    tokenAddress?: string;
+    time?: string;
+    priceUsd?: string | null;
+  }> = {},
+) {
+  return {
+    Block: { Time: input.time ?? "2026-08-11T14:00:00.000Z" },
+    Pair: {
+      Token: {
+        Id: input.tokenId ?? "bid:eth",
+        Address: input.tokenAddress ?? "0x",
+      },
+    },
+    PriceInUsd: input.priceUsd === undefined ? "2500" : input.priceUsd,
+  };
+}
+
 function marketResponse(input: Readonly<{
   identity?: MarketDataIdentityV1;
   trade?: unknown;
@@ -187,6 +208,10 @@ function marketResponse(input: Readonly<{
   errors?: unknown[];
 }> = {}) {
   const identity = input.identity ?? PCAN;
+  const supplied = input.supply === undefined
+    ? supplyRow({ identity })
+    : input.supply;
+  const suppliedRecord = supplied as ReturnType<typeof supplyRow> | null;
   return {
     data: {
       EVM: {
@@ -215,6 +240,11 @@ function marketResponse(input: Readonly<{
           : input.supply === null
             ? []
             : [input.supply],
+        price0: suppliedRecord === null
+          ? []
+          : [tradingPriceRow({
+              time: suppliedRecord.Block.Time,
+            })],
       },
     },
     ...(input.errors ? { errors: input.errors } : {}),
@@ -250,9 +280,6 @@ describe("Bitquery-only market data", () => {
           "limitBy: { by: Trade_PoolId, count: 1 }",
         );
         expect(request.query).toContain(
-          "Currency: { SmartContract: { in: $tokenAddresses } }",
-        );
-        expect(request.query).toContain(
           "EVM(network: eth, dataset: combined)",
         );
         expect(request.query).toContain(
@@ -260,19 +287,11 @@ describe("Bitquery-only market data", () => {
         );
         expect(request.query).toContain("{ descending: Log_Index }");
         expect(request.query).toContain("Transaction { Hash Index }");
-        expect(request.query).toContain(
-          "Token: { Address: { in: $tokenAddresses } }",
-        );
         expect(request.query.match(/TransactionStatus: \{ Success: true \}/gu))
-          .toHaveLength(3);
-        expect(request.query).toContain("Price {");
-        expect(request.query).toContain("IsQuotedInUsd");
+          .toHaveLength(1);
         expect(request.query).not.toContain("MarketCap");
         expect(request.query).not.toContain("FullyDilutedValuationUsd");
-        expect(request.variables).toEqual({
-          pools: [PCAN.poolId],
-          tokenAddresses: [PCAN.tokenAddress],
-        });
+        expect(request.variables).toEqual({ pools: [PCAN.poolId] });
         return jsonResponse(marketResponse({
           trade: tradeRow({
             priceUsd: "0.24",
@@ -280,7 +299,52 @@ describe("Bitquery-only market data", () => {
           }),
         }));
       }
-      throw new Error("unexpected second market request");
+      if (request.query.includes("ProgrammableMarketPrices")) {
+        expect(request.variables).toEqual({});
+        expect(request.query).toContain(
+          `Token: { Id: { is: "bid:eth" } }`,
+        );
+        expect(request.query).toContain(
+          `Block: { Time: { till: "2026-08-11T14:00:00.000Z" } }`,
+        );
+        return jsonResponse({
+          data: { Trading: { price0: [tradingPriceRow()] } },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketLiquidity")) {
+        expect(request.variables).toEqual({ pools: [PCAN.poolId] });
+        expect(request.query).toContain("latestLiquidity: DEXPoolEvents(");
+        expect(request.query).not.toContain("latestTrades: DEXTrades(");
+        return jsonResponse({
+          data: { EVM: { latestLiquidity: [liquidityRow(PCAN)] } },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketStats")) {
+        expect(request.variables).toEqual({
+          pools: [PCAN.poolId],
+          tokenAddresses: [PCAN.tokenAddress],
+        });
+        expect(request.query).toContain("stats: DEXTradeByTokens(");
+        expect(request.query).toContain(
+          "Currency: { SmartContract: { in: $tokenAddresses } }",
+        );
+        expect(request.query).not.toContain("latestTrades: DEXTrades(");
+        return jsonResponse({
+          data: {
+            EVM: {
+              stats: [{
+                Trade: {
+                  PoolId: PCAN.poolId,
+                  Currency: { SmartContract: PCAN.tokenAddress },
+                },
+                count: "42",
+                volumeUsd: "12345.67",
+              }],
+            },
+          },
+        });
+      }
+      throw new Error("unexpected market request");
     }) as typeof fetch;
 
     const values = await readBitqueryTokenMarketDataV1([PCAN], {
@@ -290,11 +354,11 @@ describe("Bitquery-only market data", () => {
     });
     const market = values.get(PCAN.tokenAddress);
 
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
     expect(market && isTokenMarketDataV1(market)).toBe(true);
     expect(market).toMatchObject({
       source: "bitquery",
-      status: "current",
+      status: "partial",
       primaryPoolId: PCAN.poolId,
       pools: [{
         identity: PCAN,
@@ -309,11 +373,8 @@ describe("Bitquery-only market data", () => {
         tradeCount24h: 42,
         liquidity: { valueUsdWad: "150000000000000000000000" },
         valuation: {
-          status: "available",
-          metric: "fdv",
-          supplyBasis: "total",
-          valueUsdWad: "250000000000000000000000",
-          fdvUsdWad: "250000000000000000000000",
+          status: "unavailable",
+          reason: "supply-unavailable",
         },
       }],
     });
@@ -333,7 +394,7 @@ describe("Bitquery-only market data", () => {
 
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toEqual({
       status: "unavailable",
-      reason: "price-unavailable",
+      reason: "supply-unavailable",
     });
   });
 
@@ -352,11 +413,14 @@ describe("Bitquery-only market data", () => {
     });
     const pool = values.get(PCAN.tokenAddress)?.pools[0];
 
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect(pool?.latestTrade).not.toHaveProperty("priceUsdWad");
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(pool?.latestTrade).toMatchObject({
+      priceUsdWad: "250000000000000000",
+      priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
+    });
     expect(pool?.valuation).toEqual({
       status: "unavailable",
-      reason: "price-unavailable",
+      reason: "supply-unavailable",
     });
   });
 
@@ -371,11 +435,13 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade)
-      .not.toHaveProperty("priceUsdWad");
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade).toMatchObject({
+      priceUsdWad: "250000000000000000",
+      priceUsdAsOfTime: "2026-08-11T14:02:30.000Z",
+    });
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toEqual({
       status: "unavailable",
-      reason: "price-unavailable",
+      reason: "supply-unavailable",
     });
   });
 
@@ -420,14 +486,18 @@ describe("Bitquery-only market data", () => {
     expect(pool?.liquidity?.valueUsdWad).toBe("9999000000000000000000");
     expect(pool?.valuation).toEqual({
       status: "unavailable",
-      reason: "inconsistent-market-data",
+      reason: "supply-unavailable",
     });
   });
 
   it("keeps exact quote-unit data when the curated USD price is unavailable", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
-      trade: tradeRow({ omitPriceUsd: true, omitAmountUsd: true }),
-      supply: supplyRow({ indexedPrice: null }),
+      trade: tradeRow({
+        omitPriceUsd: true,
+        omitQuotePriceUsd: true,
+        omitAmountUsd: true,
+      }),
+      supply: null,
     }))) as typeof fetch;
     const values = await readBitqueryTokenMarketDataV1([PCAN], {
       fetchImpl,
@@ -444,6 +514,32 @@ describe("Bitquery-only market data", () => {
     expect(pool?.valuation).toEqual({
       status: "unavailable",
       reason: "price-unavailable",
+    });
+  });
+
+  it("derives USD from the historical native index at the exact-pool trade time", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: tradeRow({
+        omitPriceUsd: true,
+        omitQuotePriceUsd: true,
+        omitAmountUsd: true,
+      }),
+      supply: supplyRow({ indexedPrice: null }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade).toMatchObject({
+      priceQuoteWad: "100000000000000",
+      quoteAddress: WETH,
+      priceUsdWad: "250000000000000000",
+      priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
+      priceUsdSource: "bitquery-token-price-index-v1",
+      rawPriceUsdWad: "250000000000000000",
+      amountUsdWad: "25000000000000000000",
     });
   });
 
@@ -501,36 +597,45 @@ describe("Bitquery-only market data", () => {
   it("batches multiple canonical v4 pools without crossing their identities", async () => {
     const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       const request = JSON.parse(String(init?.body));
-      expect(request.variables).toEqual({
-        pools: [PCAN.poolId, CLASSIC.poolId].sort(),
-        tokenAddresses: [PCAN.tokenAddress, CLASSIC.tokenAddress].sort(),
-      });
-      expect(request.query.match(/latestTrades: DEXTrades\(/gu)).toHaveLength(1);
-      expect(request.query.match(/latestLiquidity: DEXPoolEvents\(/gu)).toHaveLength(1);
+      const pools = [PCAN.poolId, CLASSIC.poolId].sort();
+      const tokenAddresses = [PCAN.tokenAddress, CLASSIC.tokenAddress].sort();
+      if (request.query.includes("ProgrammableMarketPrices")) {
+        return jsonResponse({
+          data: {
+            Trading: {
+              price0: [tradingPriceRow()],
+              price1: [tradingPriceRow()],
+            },
+          },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketLiquidity")) {
+        expect(request.variables).toEqual({ pools });
+        return jsonResponse({ data: { EVM: { latestLiquidity: [
+          liquidityRow(PCAN),
+          liquidityRow(CLASSIC),
+        ] } } });
+      }
+      if (request.query.includes("ProgrammableMarketStats")) {
+        expect(request.variables).toEqual({ pools, tokenAddresses });
+        return jsonResponse({ data: { EVM: { stats: [PCAN, CLASSIC].map(
+          (identity) => ({
+            Trade: {
+              PoolId: identity.poolId,
+              Currency: { SmartContract: identity.tokenAddress },
+            },
+            count: "1",
+            volumeUsd: "10",
+          }),
+        ) } } });
+      }
+      expect(request.variables).toEqual({ pools });
       return jsonResponse({
         data: {
           EVM: {
             latestTrades: [
               tradeRow({ identity: CLASSIC }),
               tradeRow({ identity: PCAN }),
-            ],
-            latestLiquidity: [
-              liquidityRow(PCAN),
-              liquidityRow(CLASSIC),
-            ],
-            stats: [PCAN, CLASSIC].map((identity) => ({
-              Trade: {
-                PoolId: identity.poolId,
-                Currency: { SmartContract: identity.tokenAddress },
-              },
-              count: "1",
-              volumeUsd: "10",
-            })),
-          },
-          Trading: {
-            tokenSupplies: [
-              supplyRow({ identity: PCAN }),
-              supplyRow({ identity: CLASSIC }),
             ],
           },
         },
@@ -542,12 +647,12 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.identity).toEqual(PCAN);
     expect(values.get(CLASSIC.tokenAddress)?.pools[0]?.identity).toEqual(CLASSIC);
   });
 
-  it("uses FDV when circulating supply is absent", async () => {
+  it("does not use Bitquery supply when circulating supply is absent", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       supply: supplyRow({ circulating: null }),
     }))) as typeof fetch;
@@ -556,11 +661,9 @@ describe("Bitquery-only market data", () => {
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
-    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toMatchObject({
-      status: "available",
-      metric: "fdv",
-      supplyBasis: "total",
-      valueUsdWad: "250000000000000000000000",
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "supply-unavailable",
     });
   });
 
@@ -573,11 +676,9 @@ describe("Bitquery-only market data", () => {
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
-    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toMatchObject({
-      status: "available",
-      metric: "fdv",
-      supplyBasis: "total",
-      valueUsdWad: "25000000000000000000",
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "supply-unavailable",
     });
   });
 
@@ -596,11 +697,11 @@ describe("Bitquery-only market data", () => {
     });
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toEqual({
       status: "unavailable",
-      reason: "inconsistent-market-data",
+      reason: "supply-unavailable",
     });
   });
 
-  it("dates valuation to the older supply observation and marks it stale", async () => {
+  it("does not date valuation from a Bitquery supply observation", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       trade: tradeRow({ time: "2026-08-11T13:50:00.000Z" }),
       liquidity: liquidityRow(PCAN, {
@@ -614,10 +715,9 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toMatchObject({
-      status: "available",
-      asOfTime: "2026-08-11T13:50:00.000Z",
-      freshness: "stale",
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "supply-unavailable",
     });
     expect(marketDataStatusLabel(values.get(PCAN.tokenAddress))).toBe(
       "Last verified",

--- a/tests/canonical-token-supply.test.ts
+++ b/tests/canonical-token-supply.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { hydrateMissingCanonicalTokenSupplyV1 } from
+  "../lib/market-data/canonical-token-supply.server";
+import type { ReadyOnchainDeployment } from "../lib/onchain/types";
+import type { ExploreEntry } from "../lib/tokens";
+
+const PCAN_ADDRESS = "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce" as const;
+const BLOCK_HASH = `0x${"11".repeat(32)}` as const;
+const SUPPLY = 1_000_000n * 10n ** 18n;
+
+const deployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: "0x1111111111111111111111111111111111111111",
+  feeHook: "0x2222222222222222222222222222222222222222",
+  launcherRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  deploymentBlock: 1n,
+  stateView: "0x3333333333333333333333333333333333333333",
+  stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  rpcUrl: "https://primary.example/rpc",
+  rpcUrlSecondary: "https://secondary.example/rpc",
+  confirmations: 12n,
+  logBlockRange: 5_000n,
+} satisfies ReadyOnchainDeployment;
+
+const entry = {
+  exploreKind: "token",
+  tokenAddress: PCAN_ADDRESS,
+} as unknown as ExploreEntry;
+
+function supplyClient(input: Readonly<{
+  blockHash?: `0x${string}`;
+  decimals?: number;
+  totalSupply?: bigint;
+}> = {}) {
+  return {
+    getBlockNumber: vi.fn(async () => 112n),
+    getBlock: vi.fn(async () => ({
+      hash: input.blockHash ?? BLOCK_HASH,
+      number: 100n,
+    })),
+    readContract: vi.fn(async ({ functionName }: { functionName: string }) =>
+      functionName === "decimals"
+        ? input.decimals ?? 18
+        : input.totalSupply ?? SUPPLY),
+  };
+}
+
+describe("canonical token supply hydration", () => {
+  it("hydrates missing supply only when both fixed readers agree", async () => {
+    const primary = supplyClient();
+    const secondary = supplyClient();
+    const createClient = vi.fn((rpcUrl: string) =>
+      rpcUrl === deployment.rpcUrl ? primary : secondary);
+
+    const [hydrated] = await hydrateMissingCanonicalTokenSupplyV1([entry], {
+      deployment,
+      createClient,
+    });
+
+    expect(hydrated).toMatchObject({
+      tokenAddress: PCAN_ADDRESS,
+      tokenDecimals: 18,
+      totalSupplyRaw: SUPPLY.toString(),
+    });
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(primary.readContract).toHaveBeenCalledTimes(2);
+    expect(secondary.readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves identity unchanged when the two readers disagree", async () => {
+    const primary = supplyClient();
+    const secondary = supplyClient({ totalSupply: SUPPLY - 1n });
+
+    await expect(hydrateMissingCanonicalTokenSupplyV1([entry], {
+      deployment,
+      createClient: (rpcUrl) =>
+        rpcUrl === deployment.rpcUrl ? primary : secondary,
+    })).resolves.toEqual([entry]);
+  });
+
+  it("accepts two matching fixed readers when one candidate is unavailable", async () => {
+    const unavailable = supplyClient();
+    unavailable.getBlock.mockRejectedValue(new Error("unavailable"));
+    const first = supplyClient();
+    const second = supplyClient();
+    const [hydrated] = await hydrateMissingCanonicalTokenSupplyV1([entry], {
+      deployment,
+      additionalRpcUrls: ["https://third.example/rpc"],
+      createClient: (rpcUrl) => rpcUrl === deployment.rpcUrl
+        ? unavailable
+        : rpcUrl === deployment.rpcUrlSecondary
+          ? first
+          : second,
+    });
+
+    expect(hydrated).toMatchObject({
+      tokenDecimals: 18,
+      totalSupplyRaw: SUPPLY.toString(),
+    });
+  });
+
+  it("does not read supply without two available fixed readers", async () => {
+    const unavailable = supplyClient();
+    unavailable.getBlockNumber.mockRejectedValue(new Error("unavailable"));
+    const createClient = vi.fn((rpcUrl: string) =>
+      rpcUrl === deployment.rpcUrl ? supplyClient() : unavailable);
+
+    await expect(hydrateMissingCanonicalTokenSupplyV1([entry], {
+      deployment,
+      createClient,
+    })).resolves.toEqual([entry]);
+    expect(createClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not re-read an already canonical supply", async () => {
+    const canonicalEntry = {
+      ...entry,
+      tokenDecimals: 18,
+      totalSupplyRaw: SUPPLY.toString(),
+    } as ExploreEntry;
+    const createClient = vi.fn();
+
+    await expect(hydrateMissingCanonicalTokenSupplyV1([canonicalEntry], {
+      deployment,
+      createClient,
+    })).resolves.toEqual([canonicalEntry]);
+    expect(createClient).not.toHaveBeenCalled();
+  });
+});

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -1292,7 +1292,7 @@ describe("read-model performance contract", () => {
         process.cwd(),
       );
     expect(alchemyResult.ok).toBe(true);
-    expect(alchemyResult.checks).toHaveLength(17);
+    expect(alchemyResult.checks).toHaveLength(18);
 
     const exploreRoutePath = "app/api/explore/route.ts";
     const exploreRouteSource = readFileSync(
@@ -1316,6 +1316,30 @@ describe("read-model performance contract", () => {
         (failure: { id: string }) => failure.id,
       ),
     ).toContain("bitquery-market-provenance");
+
+    const canonicalSupplyPath =
+      "lib/market-data/canonical-token-supply.server.ts";
+    const canonicalSupplySource = readFileSync(
+      resolve(process.cwd(), canonicalSupplyPath),
+      "utf8",
+    );
+    const singleProviderSupply =
+      alchemySourceContracts.evaluateAlchemyExploreSourceContracts(
+        process.cwd(),
+        {
+          sourceOverrides: {
+            [canonicalSupplyPath]: canonicalSupplySource.replace(
+              "group.length >= 2",
+              "group.length >= 1",
+            ),
+          },
+        },
+      );
+    expect(
+      singleProviderSupply.failures.map(
+        (failure: { id: string }) => failure.id,
+      ),
+    ).toContain("canonical-token-supply-quorum");
 
     const result = sourceContracts.evaluateReadModelSourceContracts(
       process.cwd(),

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -197,6 +197,55 @@ describe("Explore financial-data semantics", () => {
     expect(published).not.toHaveProperty("tokenPriceQuoteWad");
   });
 
+  it("publishes an exact-pool last-trade FDV as stale when liquidity is unavailable", () => {
+    const poolId = `0x${"34".repeat(32)}` as const;
+    const marketData = {
+      schemaVersion: "programmable.market-data.v1",
+      source: "bitquery",
+      generatedAt: "2026-08-11T14:02:00.000Z",
+      status: "stale",
+      primaryPoolId: poolId,
+      pools: [{
+        identity: {
+          chainId: "1",
+          tokenAddress: TOKEN_ADDRESS,
+          poolId,
+          protocol: "uniswap_v4",
+        },
+        source: "bitquery",
+        status: "stale",
+        quality: "partial",
+        asOfTime: "2026-08-10T11:50:47.000Z",
+        latestTrade: {
+          transactionHash: `0x${"12".repeat(32)}`,
+          logIndex: 1,
+          blockNumber: "25724408",
+          time: "2026-08-10T11:50:47.000Z",
+          tokenSide: "buy",
+          priceUsdWad: "44033668556000000",
+          priceUsdAsOfTime: "2026-08-10T11:50:47.000Z",
+          priceUsdSource: "bitquery-token-price-index-v1",
+          rawPriceUsdWad: "44033668556000000",
+        },
+        valuation: { status: "unavailable", reason: "supply-unavailable" },
+      }],
+    } satisfies TokenMarketDataV1;
+    const entry = withBitqueryMarketData(
+      canonicalTokenExploreEntryV1(goldenToken()),
+      marketData,
+    );
+
+    expect(entry.valuation).toMatchObject({
+      status: "available",
+      source: "bitquery",
+      freshness: "stale",
+      metric: "fdv",
+      supplyBasis: "total",
+    });
+    expect(valuationSortValue(entry)).toBeNull();
+    expect(publicExploreEntryV1(entry)).not.toHaveProperty("fdvUsdWad");
+  });
+
   it("keeps the indexed USD timestamp authoritative for public freshness", () => {
     const poolId = `0x${"33".repeat(32)}` as const;
     const marketData = {


### PR DESCRIPTION
## What changed

- hydrates missing canonical ERC-20 supply only after two fixed independent RPC readers agree at the same confirmed block
- derives USD price from the exact Bitquery Uniswap v4 trade and Bitquery's historical native-asset USD index at that trade time
- keeps missing-liquidity and historical observations explicitly stale and out of Highest FDV ranking
- preserves canonical Router/Registry token and pool identity while Bitquery owns market history

## Root cause

The live PCAN route had exact Bitquery pool history but no direct token USD observation and no canonical supply in the cached identity model. That left FDV unavailable, while the older production path could show unrelated stale market values.

## Validation

- 6 focused files / 96 tests passed
- TypeScript passed
- focused ESLint passed with zero warnings
- production build passed
- Vercel stage `dpl_Ah3enDt6LmS4mvc2L5uKibLvdHU9` is READY
- stage PCAN detail proves canonical supply 1,000,000, exact pool trade, stale FDV about $21.10, and Bitquery source
- stage PCAN all-history chart is ready with 4 canonical points
