### PR TITLE
Fix production attestation filter compatibility

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -101,7 +101,6 @@ jobs:
           gh attestation verify "$proof" \
             --repo "$GITHUB_REPOSITORY" \
             --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/verify.yml" \
-            --cert-identity "https://github.com/$GITHUB_REPOSITORY/.github/workflows/verify.yml@$GITHUB_REF" \
             --source-ref "$GITHUB_REF" \
             --source-digest "$GITHUB_SHA" \
             --signer-digest "$GITHUB_SHA" \

--- a/scripts/test/custom-launch-release-workflow-contract.test.mjs
+++ b/scripts/test/custom-launch-release-workflow-contract.test.mjs
@@ -43,10 +43,12 @@ function workflowFailures(source) {
     "proof-signer-workflow",
     '--signer-workflow "$GITHUB_REPOSITORY/.github/workflows/verify.yml"',
   );
-  requireText(
-    "proof-certificate-identity",
-    '--cert-identity "https://github.com/$GITHUB_REPOSITORY/.github/workflows/verify.yml@$GITHUB_REF"',
-  );
+  if (
+    source.includes('--signer-workflow "$GITHUB_REPOSITORY/.github/workflows/verify.yml"') &&
+    source.includes('--cert-identity ')
+  ) {
+    failures.push("proof-attestation-filters-mutually-exclusive");
+  }
   requireText("proof-source-ref", '--source-ref "$GITHUB_REF"');
   requireText("proof-source-digest", '--source-digest "$GITHUB_SHA"');
   requireText("proof-signer-digest", '--signer-digest "$GITHUB_SHA"');


### PR DESCRIPTION
## Summary
- remove the mutually exclusive `--cert-identity` flag from the Stage Production Candidate attestation verification
- keep signer-workflow, source ref/digest, signer digest, and hosted-runner checks
- add a regression guard so the incompatible flag pair cannot return

## Evidence
The first exact production Stage run 31545758215 failed before deployment because `gh attestation verify` rejected `--cert-identity` and `--signer-workflow` together. No Vercel deployment or promotion occurred.

## Checks
- actionlint passed
- focused production workflow contract tests: 6/6 passed
- git diff --check passed

This is a fail-closed deployment compatibility fix; it does not bypass required checks or promote a deployment.