### PR TITLE
ci: add fail-closed production verification aggregate

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -337,3 +337,37 @@ jobs:
             echo "- Artifact SHA-256: \`$ARTIFACT_DIGEST\`"
             echo "- Sigstore attestation: $ATTESTATION_URL"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  aggregate:
+    # Keep one stable, always-run PR context while the lane jobs remain
+    # independently addressable and path-routed. The production proof above
+    # remains separate and still binds the exact full push verification.
+    name: Verify aggregate
+    needs:
+      - scope
+      - secret-scan
+      - indexer
+      - database-pglite
+      - interface
+      - contracts
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Require every protected verification lane to complete
+        env:
+          SCOPE_RESULT: ${{ needs.scope.result }}
+          SECRET_SCAN_RESULT: ${{ needs.secret-scan.result }}
+          INDEXER_RESULT: ${{ needs.indexer.result }}
+          DATABASE_RESULT: ${{ needs.database-pglite.result }}
+          INTERFACE_RESULT: ${{ needs.interface.result }}
+          CONTRACTS_RESULT: ${{ needs.contracts.result }}
+        run: |
+          set -euo pipefail
+          for result in "$SCOPE_RESULT" "$SECRET_SCAN_RESULT" "$INDEXER_RESULT" "$DATABASE_RESULT" "$INTERFACE_RESULT" "$CONTRACTS_RESULT"; do
+            test "$result" = success || {
+              echo "Verification lane did not succeed: $result" >&2
+              exit 1
+            }
+          done

--- a/scripts/ci/classify-verify-paths.test.mjs
+++ b/scripts/ci/classify-verify-paths.test.mjs
@@ -172,7 +172,7 @@ test("keeps protected jobs fail closed and production pushes complete", () => {
     workflow,
     /name: Verify affected interface\n        if: needs\.scope\.outputs\.interface == 'true'/u,
   );
-  assert.equal(workflow.match(/^    if: always\(\)$/gmu)?.length, 4);
+  assert.equal(workflow.match(/^    if: always\(\)$/gmu)?.length, 5);
   assert.equal(
     workflow.match(/name: Require successful change classification/gmu)?.length,
     4,
@@ -188,4 +188,17 @@ test("keeps protected jobs fail closed and production pushes complete", () => {
   ]) {
     assert.match(workflow, new RegExp(`name: ${name.replace(/[()]/gu, "\\$&")}`));
   }
+  assert.match(workflow, /name: Verify aggregate/u);
+  for (const dependency of [
+    "scope",
+    "secret-scan",
+    "indexer",
+    "database-pglite",
+    "interface",
+    "contracts",
+  ]) {
+    assert.match(workflow, new RegExp(`      - ${dependency}\\n`, "u"));
+  }
+  assert.match(workflow, /SCOPE_RESULT: \$\{\{ needs\.scope\.result \}\}/u);
+  assert.match(workflow, /test "\$result" = success/u);
 });


### PR DESCRIPTION
## Summary

- keep the existing trusted path-routed Interface/DB/Indexer/Contracts lanes
- add a stable always-run `Verify aggregate` context that fails closed on any lane or classification failure
- preserve the exact production Verify proof and deploy/attestation workflow

## Exact base and dependency

- Base at branch creation: `cc8bf9ea8cc87699512c4487ca33ea7fb93b7bdb` (`origin/production`)
- PR #229 is still open and currently targets that exact base (`3cd7bbe1c8a9dac06fec96ab61de02249476f904`, BLOCKED). It is not changed by this PR. Before merging this PR, rebase onto PR #229's eventual merge SHA if that hotfix lands first.
- PR #228 is already included in the base and is not changed by this PR.

## Local validation

- `npm run test:ci-scope`: 13/13 pass
- `actionlint .github/workflows/*.yml`: pass
- `gitleaks` over the exact PR commit: no leaks
- `git diff --check`: pass
- `npm run verify:interface:ci`: 2,722 tests pass, build/typecheck pass, 63.25s wall time (93 pre-existing ESLint warnings, 0 errors)

No required context was removed or globally disabled. No production/deploy/live claim is made.