### PR TITLE
fix: include Verify aggregate in production proof inventory

### DIFF
--- a/scripts/production-verify-proof.mjs
+++ b/scripts/production-verify-proof.mjs
@@ -17,6 +17,7 @@ export const PRODUCTION_REF = "refs/heads/production";
 export const VERIFY_WORKFLOW_PATH = ".github/workflows/verify.yml";
 export const VERIFY_WORKFLOW_NAME = "Verify";
 export const VERIFY_SCOPE_JOB_NAME = "Change scope";
+export const VERIFY_AGGREGATE_JOB_NAME = "Verify aggregate";
 export const VERIFY_PROOF_JOB_NAME = "Bind full production Verify proof";
 
 export const REQUIRED_PRODUCTION_VERIFY_CHECKS = Object.freeze([
@@ -358,6 +359,7 @@ function validateVerifyJobs(response, run) {
     VERIFY_SCOPE_JOB_NAME,
     ...REQUIRED_PRODUCTION_VERIFY_CHECKS.map(({ name }) => name),
     VERIFY_PROOF_JOB_NAME,
+    VERIFY_AGGREGATE_JOB_NAME,
   ];
   if (
     !isObject(response)

--- a/scripts/test/production-verify-proof.test.mjs
+++ b/scripts/test/production-verify-proof.test.mjs
@@ -7,6 +7,7 @@ import {
   PRODUCTION_REPOSITORY_ID,
   PRODUCTION_VERIFY_PROOF_MAX_AGE_MS,
   REQUIRED_PRODUCTION_VERIFY_CHECKS,
+  VERIFY_AGGREGATE_JOB_NAME,
   VERIFY_PROOF_JOB_NAME,
   VERIFY_SCOPE_JOB_NAME,
   VERIFY_WORKFLOW_PATH,
@@ -94,6 +95,22 @@ function validApiFixtures() {
       completed_at: "2026-08-11T18:04:40Z",
       runner_id: 1_000_010,
       runner_name: "GitHub Actions 1000010",
+      runner_group_id: 0,
+      runner_group_name: "GitHub Actions",
+      labels: ["ubuntu-latest"],
+    },
+    {
+      id: 90_101,
+      run_id: RUN_ID,
+      run_attempt: RUN_ATTEMPT,
+      head_sha: COMMIT,
+      name: VERIFY_AGGREGATE_JOB_NAME,
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-08-11T18:04:41Z",
+      completed_at: "2026-08-11T18:04:42Z",
+      runner_id: 1_000_011,
+      runner_name: "GitHub Actions 1000011",
       runner_group_id: 0,
       runner_group_name: "GitHub Actions",
       labels: ["ubuntu-latest"],
@@ -329,6 +346,12 @@ test("resolver rejects branch, workflow, and run identity drift", async () => {
 test("resolver rejects missing, failed, skipped, unexpected, or self-hosted jobs", async () => {
   const mutations = [
     (fixtures) => { fixtures.jobs.jobs.pop(); fixtures.jobs.total_count -= 1; },
+    (fixtures) => {
+      fixtures.jobs.jobs = fixtures.jobs.jobs.filter(
+        ({ name }) => name !== VERIFY_AGGREGATE_JOB_NAME,
+      );
+      fixtures.jobs.total_count -= 1;
+    },
     (fixtures) => { fixtures.jobs.jobs[0].conclusion = "failure"; },
     (fixtures) => { fixtures.jobs.jobs[1].conclusion = "skipped"; },
     (fixtures) => { fixtures.jobs.jobs[2].name = "Unexpected"; },


### PR DESCRIPTION
## Summary
- include the always-present `Verify aggregate` job in the exact production proof inventory
- add a regression fixture and missing-aggregate rejection

## Validation
- `node --test scripts/test/production-verify-proof.test.mjs` (10/10)
- `git diff --check`

This is required for Stage Production Candidate after the CI fast-lane merge; no deploy is performed by this PR.