### PR TITLE
Fix partial Bitquery batch price recovery

### DIFF
--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -31,6 +31,8 @@ const REQUEST_TIMEOUT_MS = 8_000;
 const MAXIMUM_RESPONSE_BYTES = 1_500_000;
 const MARKET_BATCH_SIZE = 100;
 const MARKET_BATCH_CONCURRENCY = 2;
+const INDEXED_PRICE_RECOVERY_CONCURRENCY = 4;
+const MAXIMUM_INDEXED_PRICE_RECOVERIES_PER_BATCH = 20;
 const MARKET_CACHE_CURRENT_MAX_AGE_MS = 2_000;
 const MARKET_CACHE_MAX_AGE_MS = 15 * 60 * 1_000;
 const DURABLE_MARKET_CACHE_SECONDS = 5 * 60;
@@ -554,20 +556,66 @@ async function readMarketBatch(
       return poolId && address ? marketStatsKey(poolId, address) : null;
     },
   );
+  const indexedPricesByIndex = new Map<number, TokenPriceObservation | null>();
+  const priceLookupWasPartial = priceResult.status !== "fulfilled" ||
+    priceResult.value.partial;
+  const missingIndexedPrices = priceLookupWasPartial
+    ? parsedTrades.flatMap(({ trade }, index) => {
+        if (!trade) return [];
+        const observation = parseNativeQuotePriceObservation(
+          array(priceTrading?.[`price${index}`])[0],
+          trade,
+        );
+        if (observation !== null) {
+          indexedPricesByIndex.set(index, observation);
+          return [];
+        }
+        return [{ index, trade }];
+      }).slice(0, MAXIMUM_INDEXED_PRICE_RECOVERIES_PER_BATCH)
+    : [];
+  await mapWithConcurrency(
+    missingIndexedPrices,
+    INDEXED_PRICE_RECOVERY_CONCURRENCY,
+    async ({ index, trade }) => {
+      try {
+        const request = marketPriceQuery([trade]);
+        const response = await executeBitqueryGraphql(
+          request.query,
+          request.variables,
+          options,
+        );
+        const trading = record(response.data.Trading);
+        indexedPricesByIndex.set(
+          index,
+          parseNativeQuotePriceObservation(
+            array(trading?.price0)[0],
+            trade,
+          ),
+        );
+      } catch {
+        indexedPricesByIndex.set(index, null);
+      }
+    },
+  );
   const parsed = identities.map((identity, index) => {
     const latestTradeRow = parsedTrades[index]?.row;
     const latestTradeRows = latestTradeRow === undefined
       ? []
       : [latestTradeRow];
     const parsedTrade = parsedTrades[index]?.trade ?? null;
+    const indexedPrice = indexedPricesByIndex.has(index)
+      ? indexedPricesByIndex.get(index) ?? null
+      : parsedTrade
+        ? parseNativeQuotePriceObservation(
+            array(priceTrading?.[`price${index}`])[0],
+            parsedTrade,
+          )
+        : null;
     const latestTrade = parsedTrade === null
       ? null
       : enrichTradeWithIndexedUsd(
           parsedTrade,
-          parseNativeQuotePriceObservation(
-            array(priceTrading?.[`price${index}`])[0],
-            parsedTrade,
-          ),
+          indexedPrice,
           options.now,
         );
     return {

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -652,6 +652,80 @@ describe("Bitquery-only market data", () => {
     expect(values.get(CLASSIC.tokenAddress)?.pools[0]?.identity).toEqual(CLASSIC);
   });
 
+  it("recovers missing indexed prices from bounded singleton queries", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body));
+      if (request.query.includes("ProgrammableMarketSnapshot")) {
+        return jsonResponse({
+          data: {
+            EVM: {
+              latestTrades: [
+                tradeRow({ identity: PCAN }),
+                tradeRow({ identity: CLASSIC }),
+              ],
+            },
+          },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketPrices")) {
+        if (request.query.includes("price1:")) {
+          return jsonResponse({
+            data: { Trading: { price0: [], price1: [] } },
+            errors: [{ message: "bounded batch price lookup was partial" }],
+          });
+        }
+        return jsonResponse({
+          data: { Trading: { price0: [tradingPriceRow()] } },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketLiquidity")) {
+        return jsonResponse({
+          data: {
+            EVM: {
+              latestLiquidity: [
+                liquidityRow(PCAN),
+                liquidityRow(CLASSIC),
+              ],
+            },
+          },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketStats")) {
+        return jsonResponse({
+          data: {
+            EVM: {
+              stats: [PCAN, CLASSIC].map((identity) => ({
+                Trade: {
+                  PoolId: identity.poolId,
+                  Currency: { SmartContract: identity.tokenAddress },
+                },
+                count: "1",
+                volumeUsd: "10",
+              })),
+            },
+          },
+        });
+      }
+      throw new Error("unexpected market request");
+    }) as typeof fetch;
+
+    const values = await readBitqueryTokenMarketDataV1([PCAN, CLASSIC], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade).toMatchObject({
+      priceUsdWad: "250000000000000000",
+      priceUsdSource: "bitquery-token-price-index-v1",
+    });
+    expect(values.get(CLASSIC.tokenAddress)?.pools[0]?.latestTrade).toMatchObject({
+      priceUsdWad: "250000000000000000",
+      priceUsdSource: "bitquery-token-price-index-v1",
+    });
+  });
+
   it("does not use Bitquery supply when circulating supply is absent", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       supply: supplyRow({ circulating: null }),


### PR DESCRIPTION
## Summary
- recover missing indexed USD prices with bounded singleton reads only when the shared Bitquery price response is partial or failed
- cap recovery at 20 identities per batch with concurrency 4
- preserve fail-closed unavailable data when recovery cannot produce a valid observation

## Verification
- 64 focused market/explore/token-detail tests
- TypeScript
- scoped ESLint
- read-model operations contract
- production Next.js build

This fixes the staged PCAN list/detail divergence without weakening the protected Bitquery smoke.