### PR TITLE
Speed up production verification for scoped changes

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,6 +52,12 @@ jobs:
       artifact_id: ${{ steps.resolve-proof.outputs.artifact_id }}
       proof_sha256: ${{ steps.verify-proof.outputs.proof_sha256 }}
       artifact_digest: ${{ steps.verify-proof.outputs.artifact_digest }}
+      verified_contracts: ${{ steps.verify-proof.outputs.verified_contracts }}
+      verified_database: ${{ steps.verify-proof.outputs.verified_database }}
+      verified_dependencies: ${{ steps.verify-proof.outputs.verified_dependencies }}
+      verified_indexer: ${{ steps.verify-proof.outputs.verified_indexer }}
+      verified_interface: ${{ steps.verify-proof.outputs.verified_interface }}
+      verified_read_model: ${{ steps.verify-proof.outputs.verified_read_model }}
 
     steps:
       - name: Check out exact production commit
@@ -129,13 +135,14 @@ jobs:
           ARTIFACT_DIGEST: ${{ steps.verify-proof.outputs.artifact_digest }}
         run: |
           {
-            echo "## Consumed full production Verify proof"
+            echo "## Consumed production Verify proof"
             echo
             echo "- Commit: \`$GITHUB_SHA\`"
             echo "- Verify run: $VERIFY_RUN_URL"
             echo "- Proof completed: \`$PROOF_COMPLETED_AT\`"
             echo "- Proof SHA-256: \`$PROOF_SHA256\`"
             echo "- Immutable artifact digest: \`$ARTIFACT_DIGEST\`"
+            echo "- Read-model lane required: \`${{ steps.verify-proof.outputs.verified_read_model }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
@@ -458,7 +465,7 @@ jobs:
           retention-days: 90
 
       - name: Gate exact staged QuickNode wake route
-        if: steps.read-model-policy.outputs.wake_canary_required == 'true'
+        if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.wake_canary_required == 'true'
         env:
           PROGRAMMABLE_QUICKNODE_STREAM_SECRET: ${{ secrets.PROGRAMMABLE_QUICKNODE_STREAM_SECRET }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -524,6 +531,7 @@ jobs:
           --target-url "$STAGED_TARGET_URL"
 
       - name: Smoke staged Bitquery market APIs
+        if: needs.release-gate.outputs.verified_read_model == 'true'
         env:
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -1216,7 +1224,7 @@ jobs:
           NODE
 
       - name: Record registry identity and Bitquery market path
-        if: steps.read-model-policy.outputs.mode == 'alchemy-only'
+        if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.mode == 'alchemy-only'
         run: |
           {
             echo "## Read-model release policy"
@@ -1227,7 +1235,7 @@ jobs:
 
       - name: Capture staged read-model evidence
         id: read-model-capture
-        if: steps.read-model-policy.outputs.mode == 'indexed-or-shadow'
+        if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.mode == 'indexed-or-shadow'
         env:
           PROGRAMMABLE_PERFORMANCE_PROBE_TOKEN: ${{ secrets.PROGRAMMABLE_PERFORMANCE_PROBE_TOKEN }}
           PROGRAMMABLE_SHADOW_PROBE_TOKEN: ${{ secrets.PROGRAMMABLE_SHADOW_PROBE_TOKEN }}
@@ -1243,7 +1251,7 @@ jobs:
           --github-output "$GITHUB_OUTPUT"
 
       - name: Preserve staged read-model evidence
-        if: steps.read-model-policy.outputs.mode == 'indexed-or-shadow'
+        if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.mode == 'indexed-or-shadow'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: read-model-evidence-${{ github.run_id }}-${{ github.run_attempt }}
@@ -1252,7 +1260,7 @@ jobs:
           retention-days: 7
 
       - name: Gate indexed or shadow read path
-        if: steps.read-model-policy.outputs.mode == 'indexed-or-shadow'
+        if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.mode == 'indexed-or-shadow'
         env:
           PROGRAMMABLE_READ_MODEL_PERF_EVIDENCE_PATH: ${{ steps.read-model-capture.outputs.evidence_path }}
           PROGRAMMABLE_READ_MODEL_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
@@ -1283,6 +1291,7 @@ jobs:
           PREVIOUS_DEPLOYMENT_ID: ${{ steps.production-before.outputs.deployment_id }}
           PREVIOUS_GIT_HEAD: ${{ steps.production-before.outputs.git_head }}
           POLICY_MODE: ${{ steps.read-model-policy.outputs.mode }}
+          READ_MODEL_REQUIRED: ${{ needs.release-gate.outputs.verified_read_model }}
         run: |
           {
             echo "## Staged production candidate"
@@ -1293,9 +1302,13 @@ jobs:
             echo "- Previous production deployment: \`$PREVIOUS_DEPLOYMENT_ID\`"
             echo "- Previous production commit: \`$PREVIOUS_GIT_HEAD\`"
             echo "- Read model: ${{ steps.read-model-policy.outputs.mode }}"
+            echo "- Read-model verification required by this commit: \`$READ_MODEL_REQUIRED\`"
             echo
             echo "Stage-only: no production promotion was attempted."
-            if [ "$POLICY_MODE" = "indexed-or-shadow" ]; then
+            if [ "$READ_MODEL_REQUIRED" != "true" ]; then
+              echo "This source-only UI/docs candidate leaves read-model bytes unchanged; the provider-specific release lane was not rerun."
+              echo "Before any separately authorized promotion, reverify this exact staged deployment ID and commit binding."
+            elif [ "$POLICY_MODE" = "indexed-or-shadow" ]; then
               echo "The manual operator must next capture and verify the DB-authored real-block SLA attestation, reverify this exact staged binding, promote this exact deployment ID, and run the post-promotion binding gate."
             elif [ "$POLICY_MODE" = "alchemy-only" ]; then
               echo "Before any separately authorized promotion, reverify this exact staged deployment ID and commit binding."

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,13 +37,12 @@ jobs:
         id: scope
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-          FORCE_ALL: ${{ github.event_name == 'push' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ "$FORCE_ALL" == "true" ]] || [[ -z "${BASE_SHA:-}" || "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "$BASE_SHA^{commit}"; then
+          if [[ -z "${BASE_SHA:-}" || "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "$BASE_SHA^{commit}"; then
             node scripts/ci/classify-verify-paths.mjs --all >> "$GITHUB_OUTPUT"
           else
             git diff --no-renames --name-only "$BASE_SHA" "$HEAD_SHA" > "$RUNNER_TEMP/changed-paths.txt"
@@ -268,9 +267,10 @@ jobs:
         run: echo "No contract paths changed."
 
   production-proof:
-    name: Bind full production Verify proof
+    name: Bind production Verify proof
     if: github.event_name == 'push' && github.ref == 'refs/heads/production'
     needs:
+      - scope
       - secret-scan
       - indexer
       - database-pglite
@@ -297,8 +297,14 @@ jobs:
         with:
           node-version: 24.14.0
 
-      - name: Create exact full production Verify proof
+      - name: Create exact production Verify proof
         env:
+          PRODUCTION_VERIFY_SCOPE_CONTRACTS: ${{ needs.scope.outputs.contracts }}
+          PRODUCTION_VERIFY_SCOPE_DATABASE: ${{ needs.scope.outputs.database }}
+          PRODUCTION_VERIFY_SCOPE_DEPENDENCIES: ${{ needs.scope.outputs.dependencies }}
+          PRODUCTION_VERIFY_SCOPE_INDEXER: ${{ needs.scope.outputs.indexer }}
+          PRODUCTION_VERIFY_SCOPE_INTERFACE: ${{ needs.scope.outputs.interface }}
+          PRODUCTION_VERIFY_SCOPE_READ_MODEL: ${{ needs.scope.outputs.read_model }}
           PRODUCTION_VERIFY_SECRET_SCAN_RESULT: ${{ needs.secret-scan.result }}
           PRODUCTION_VERIFY_INDEXER_RESULT: ${{ needs.indexer.result }}
           PRODUCTION_VERIFY_DATABASE_PGLITE_RESULT: ${{ needs.database-pglite.result }}
@@ -309,13 +315,13 @@ jobs:
           --repository-root "$GITHUB_WORKSPACE"
           --output "$RUNNER_TEMP/production-verify-proof.json"
 
-      - name: Attest exact full production Verify proof
+      - name: Attest exact production Verify proof
         id: attest-proof
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: ${{ runner.temp }}/production-verify-proof.json
 
-      - name: Preserve immutable full production Verify proof
+      - name: Preserve immutable production Verify proof
         id: upload-proof
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -324,13 +330,13 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Record exact full production Verify proof
+      - name: Record exact production Verify proof
         env:
           ATTESTATION_URL: ${{ steps.attest-proof.outputs.attestation-url }}
           ARTIFACT_DIGEST: ${{ steps.upload-proof.outputs.artifact-digest }}
         run: |
           {
-            echo "## Full production Verify proof"
+            echo "## Production Verify proof"
             echo
             echo "- Commit: \`$GITHUB_SHA\`"
             echo "- Run: \`$GITHUB_RUN_ID\` attempt \`$GITHUB_RUN_ATTEMPT\`"
@@ -341,7 +347,7 @@ jobs:
   aggregate:
     # Keep one stable, always-run PR context while the lane jobs remain
     # independently addressable and path-routed. The production proof above
-    # remains separate and still binds the exact full push verification.
+    # remains separate and binds the exact path-scoped push verification.
     name: Verify aggregate
     needs:
       - scope

--- a/scripts/ci/classify-verify-paths.mjs
+++ b/scripts/ci/classify-verify-paths.mjs
@@ -54,7 +54,9 @@ export function classifyVerifyPaths(paths, { forceAll = false } = {}) {
         path,
       ) ||
       /^(?:\.github|config|ops|releases|scripts)\//u.test(path) ||
-      /^(?:docs\/(?:operations\/releases|security)|lib\/vendor)\//u.test(path) ||
+      /^(?:docs\/(?:operations\/releases|security)|lib\/vendor)\//u.test(
+        path,
+      ) ||
       /^(?:Dockerfile|docker-compose\.ya?ml)$/u.test(path)
     ) {
       markAll(scope);
@@ -76,11 +78,7 @@ export function classifyVerifyPaths(paths, { forceAll = false } = {}) {
       continue;
     }
 
-    if (
-      /^(?:contracts\/|foundry\.toml$|remappings\.txt$)/u.test(
-        path,
-      )
-    ) {
+    if (/^(?:contracts\/|foundry\.toml$|remappings\.txt$)/u.test(path)) {
       scope.contracts = true;
       scope.interface = true;
       continue;
@@ -127,20 +125,19 @@ export function classifyVerifyPaths(paths, { forceAll = false } = {}) {
     if (/^lib\/onchain\//u.test(path)) {
       scope.contracts = true;
       scope.interface = true;
+      scope.read_model = true;
       continue;
     }
 
     if (
-      /^(?:app|assets|components|lib|public|tests)\//u.test(
-        path,
-      ) ||
+      /^(?:app|assets|components|lib|public|tests)\//u.test(path) ||
       /^(?:next-env\.d\.ts|vercel\.json)$/u.test(path)
     ) {
       scope.interface = true;
       if (
-        /^(?:app\/api\/(?:explore|ops)\/|lib\/data-pipeline\/)/u.test(
-          path,
-        ) ||
+        /^(?:app\/api\/(?:explore|ops)\/|lib\/data-pipeline\/)/u.test(path) ||
+        /^lib\/market-data\//u.test(path) ||
+        path === "lib/explore-financial-data.ts" ||
         path === "vercel.json"
       ) {
         scope.read_model = true;

--- a/scripts/ci/classify-verify-paths.test.mjs
+++ b/scripts/ci/classify-verify-paths.test.mjs
@@ -49,11 +49,17 @@ test("routes ordinary website changes only to the interface lane", () => {
 });
 
 test("routes read-model API changes to interface and operations checks", () => {
-  assert.deepEqual(classifyVerifyPaths(["app/api/explore/route.ts"]), {
-    ...none,
-    interface: true,
-    read_model: true,
-  });
+  for (const path of [
+    "app/api/explore/route.ts",
+    "lib/market-data/bitquery.server.ts",
+    "lib/explore-financial-data.ts",
+  ]) {
+    assert.deepEqual(classifyVerifyPaths([path]), {
+      ...none,
+      interface: true,
+      read_model: true,
+    });
+  }
 });
 
 test("keeps contract, database, and indexer lanes independent", () => {
@@ -161,12 +167,19 @@ test("partitions every database runtime suite out of the concurrent interface ba
   assert.match(verifyCommand, /npm run test:database-runtime:ci/u);
 });
 
-test("keeps protected jobs fail closed and production pushes complete", () => {
+test("keeps protected jobs fail closed and production pushes path scoped", () => {
   const workflow = readFileSync(".github/workflows/verify.yml", "utf8");
 
   assert.match(workflow, /git diff --no-renames --name-only/u);
-  assert.match(workflow, /git show "\$BASE_SHA:scripts\/ci\/classify-verify-paths\.mjs"/u);
-  assert.match(workflow, /FORCE_ALL: \$\{\{ github\.event_name == 'push' \}\}/u);
+  assert.match(
+    workflow,
+    /git show "\$BASE_SHA:scripts\/ci\/classify-verify-paths\.mjs"/u,
+  );
+  assert.doesNotMatch(workflow, /FORCE_ALL:/u);
+  assert.match(
+    workflow,
+    /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.before \}\}/u,
+  );
   assert.doesNotMatch(workflow, /run: npm run verify\n/u);
   assert.match(
     workflow,
@@ -177,7 +190,10 @@ test("keeps protected jobs fail closed and production pushes complete", () => {
     workflow.match(/name: Require successful change classification/gmu)?.length,
     4,
   );
-  assert.equal(workflow.match(/if: needs\.scope\.result != 'success'/gmu)?.length, 4);
+  assert.equal(
+    workflow.match(/if: needs\.scope\.result != 'success'/gmu)?.length,
+    4,
+  );
 
   for (const name of [
     "Credential leak gate",
@@ -186,9 +202,13 @@ test("keeps protected jobs fail closed and production pushes complete", () => {
     "Interface",
     "Contracts",
   ]) {
-    assert.match(workflow, new RegExp(`name: ${name.replace(/[()]/gu, "\\$&")}`));
+    assert.match(
+      workflow,
+      new RegExp(`name: ${name.replace(/[()]/gu, "\\$&")}`),
+    );
   }
   assert.match(workflow, /name: Verify aggregate/u);
+  assert.match(workflow, /name: Bind production Verify proof/u);
   for (const dependency of [
     "scope",
     "secret-scan",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1097,7 +1097,7 @@ export function evaluateReadModelOperationsSourceContracts(
       stagedWakeGate > deployWorkflow.indexOf("Resolve exact staged deployment") &&
       stagedWakeGate < stagedWakeGateEnd &&
       stagedWakeGateBlock.includes(
-        "if: steps.read-model-policy.outputs.wake_canary_required == 'true'",
+        "if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.wake_canary_required == 'true'",
       ) &&
       stagedWakeGateBlock.includes(
         "PROGRAMMABLE_QUICKNODE_STREAM_SECRET: ${{ secrets.PROGRAMMABLE_QUICKNODE_STREAM_SECRET }}",
@@ -1125,7 +1125,9 @@ export function evaluateReadModelOperationsSourceContracts(
   check(
     "ops-protected-bitquery-stage-smoke",
     stagedBitquerySmoke > stagedWakeGateEnd &&
-      !stagedBitquerySmokeBlock.includes("if:") &&
+      stagedBitquerySmokeBlock.includes(
+        "if: needs.release-gate.outputs.verified_read_model == 'true'",
+      ) &&
       stagedBitquerySmokeBlock.includes(
         "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
       ) &&
@@ -1322,7 +1324,7 @@ export function evaluateReadModelOperationsSourceContracts(
     "ops-protected-indexed-stage-capture",
     stagedReadModelCapture > stagedBitquerySmokeEnd &&
       stagedReadModelCaptureBlock.includes(
-        "if: steps.read-model-policy.outputs.mode == 'indexed-or-shadow'",
+        "if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.mode == 'indexed-or-shadow'",
       ) &&
       stagedReadModelCaptureBlock.includes(
         "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
@@ -1396,10 +1398,13 @@ export function evaluateReadModelOperationsSourceContracts(
   check(
     "ops-verify-workflow-binding",
     verifyWorkflow.includes("npm run perf:read-model:ops-gate") &&
-      verifyWorkflow.includes("name: Bind full production Verify proof") &&
-      verifyWorkflow.includes("needs:\n      - secret-scan") &&
+      verifyWorkflow.includes("name: Bind production Verify proof") &&
+      verifyWorkflow.includes("needs:\n      - scope\n      - secret-scan") &&
       verifyWorkflow.includes(
         "PRODUCTION_VERIFY_CONTRACTS_RESULT: ${{ needs.contracts.result }}",
+      ) &&
+      verifyWorkflow.includes(
+        "PRODUCTION_VERIFY_SCOPE_READ_MODEL: ${{ needs.scope.outputs.read_model }}",
       ) &&
       verifyWorkflow.includes(
         "uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26",

--- a/scripts/production-verify-proof.mjs
+++ b/scripts/production-verify-proof.mjs
@@ -9,7 +9,7 @@ import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 export const PRODUCTION_VERIFY_PROOF_SCHEMA_VERSION =
-  "programmable.production-verify-proof.v1";
+  "programmable.production-verify-proof.v2";
 export const PRODUCTION_VERIFY_PROOF_MAX_AGE_MS = 6 * 60 * 60 * 1_000;
 export const PRODUCTION_REPOSITORY = "0xprogrammable/programmable";
 export const PRODUCTION_REPOSITORY_ID = 1_314_365_508;
@@ -18,14 +18,23 @@ export const VERIFY_WORKFLOW_PATH = ".github/workflows/verify.yml";
 export const VERIFY_WORKFLOW_NAME = "Verify";
 export const VERIFY_SCOPE_JOB_NAME = "Change scope";
 export const VERIFY_AGGREGATE_JOB_NAME = "Verify aggregate";
-export const VERIFY_PROOF_JOB_NAME = "Bind full production Verify proof";
+export const VERIFY_PROOF_JOB_NAME = "Bind production Verify proof";
+
+export const PRODUCTION_VERIFY_SCOPE_KEYS = Object.freeze([
+  "contracts",
+  "database",
+  "dependencies",
+  "indexer",
+  "interface",
+  "read_model",
+]);
 
 export const REQUIRED_PRODUCTION_VERIFY_CHECKS = Object.freeze([
-  Object.freeze({ id: "secret-scan", name: "Credential leak gate" }),
-  Object.freeze({ id: "indexer", name: "Realtime indexer" }),
-  Object.freeze({ id: "database-pglite", name: "Database (PGlite)" }),
-  Object.freeze({ id: "interface", name: "Interface" }),
-  Object.freeze({ id: "contracts", name: "Contracts" }),
+  Object.freeze({ id: "secret-scan", name: "Credential leak gate", scopeKey: null }),
+  Object.freeze({ id: "indexer", name: "Realtime indexer", scopeKey: "indexer" }),
+  Object.freeze({ id: "database-pglite", name: "Database (PGlite)", scopeKey: "database" }),
+  Object.freeze({ id: "interface", name: "Interface", scopeKey: "interface" }),
+  Object.freeze({ id: "contracts", name: "Contracts", scopeKey: "contracts" }),
 ]);
 
 const COMMIT = /^[0-9a-f]{40}$/u;
@@ -58,13 +67,21 @@ export function buildProductionVerifyProofV1(input) {
   requirePositiveInteger(input.runAttempt, "run attempt");
   requireExact(input.eventName, "push", "workflow event");
 
+  const scope = validateProductionVerifyScope(input.scopeResults);
   const checks = REQUIRED_PRODUCTION_VERIFY_CHECKS.map((check) => {
+    const required = check.scopeKey === null ? true : scope[check.scopeKey];
+    const expectedResult = required ? "success" : "skipped";
     requireExact(
       input.checkResults?.[check.id],
-      "success",
+      expectedResult,
       `${check.name} result`,
     );
-    return Object.freeze({ ...check, conclusion: "success" });
+    return Object.freeze({
+      id: check.id,
+      name: check.name,
+      required,
+      conclusion: expectedResult,
+    });
   });
   assertExactKeys(
     input.checkResults,
@@ -83,6 +100,7 @@ export function buildProductionVerifyProofV1(input) {
       commitSha: input.commitSha,
       treeSha: input.treeSha,
     }),
+    scope,
     workflow: Object.freeze({
       path: VERIFY_WORKFLOW_PATH,
       ref: input.workflowRef,
@@ -132,7 +150,7 @@ export function parseProductionVerifyProofV1(bytes, expected) {
 export function validateProductionVerifyProofV1(proof, expected) {
   assertExactKeys(
     proof,
-    ["schemaVersion", "repository", "source", "workflow", "run", "checks"],
+    ["schemaVersion", "repository", "source", "scope", "workflow", "run", "checks"],
     "proof",
   );
   requireExact(
@@ -157,6 +175,7 @@ export function validateProductionVerifyProofV1(proof, expected) {
   requirePattern(proof.source.treeSha, COMMIT, "proof tree");
   requireExact(proof.source.commitSha, expected.commitSha, "proof commit");
   requireExact(proof.source.treeSha, expected.treeSha, "proof tree");
+  const scope = validateProductionVerifyScope(proof.scope);
   assertExactKeys(
     proof.workflow,
     ["path", "ref", "sourceCommitSha", "fileSha256"],
@@ -193,10 +212,21 @@ export function validateProductionVerifyProofV1(proof, expected) {
   }
   for (const [index, expectedCheck] of REQUIRED_PRODUCTION_VERIFY_CHECKS.entries()) {
     const check = proof.checks[index];
-    assertExactKeys(check, ["id", "name", "conclusion"], "proof check");
+    assertExactKeys(check, ["id", "name", "required", "conclusion"], "proof check");
     requireExact(check.id, expectedCheck.id, "proof check ID");
     requireExact(check.name, expectedCheck.name, "proof check name");
-    requireExact(check.conclusion, "success", `${expectedCheck.name} conclusion`);
+    requireExact(
+      check.required,
+      expectedCheck.scopeKey === null ? true : scope[expectedCheck.scopeKey],
+      `${expectedCheck.name} requirement`,
+    );
+    const expectedRequired =
+      expectedCheck.scopeKey === null ? true : scope[expectedCheck.scopeKey];
+    requireExact(
+      check.conclusion,
+      expectedRequired ? "success" : "skipped",
+      `${expectedCheck.name} conclusion`,
+    );
   }
   return true;
 }
@@ -270,7 +300,7 @@ export async function resolveProductionVerifyProofFromGitHubV1(input) {
   const proofCompletedAt = validateVerifyJobs(jobs, run);
   const ageMs = input.nowMs - proofCompletedAt;
   if (ageMs < 0 || ageMs > input.maxAgeMs) {
-    throw new Error("Latest full production Verify proof is stale.");
+    throw new Error("Latest production Verify proof is stale.");
   }
   const artifact = validateVerifyArtifact(artifacts, run);
 
@@ -319,7 +349,7 @@ function selectLatestExactVerifyRun(response, expected) {
     || !Array.isArray(response.workflow_runs)
     || response.workflow_runs.length < 1
   ) {
-    throw new Error("No full production Verify run exists for the dispatch commit.");
+    throw new Error("No production Verify run exists for the dispatch commit.");
   }
   const runs = [...response.workflow_runs].sort((left, right) => {
     const timeDifference = parseTimestamp(right.run_started_at, "run start")
@@ -348,7 +378,7 @@ function selectLatestExactVerifyRun(response, expected) {
     || run.head_repository?.full_name !== PRODUCTION_REPOSITORY
     || run.html_url !== `${run.repository.html_url}/actions/runs/${run.id}`
   ) {
-    throw new Error("Latest full production Verify run is canceled, incomplete, or mismatched.");
+    throw new Error("Latest production Verify run is canceled, incomplete, or mismatched.");
   }
   parseTimestamp(run.updated_at, "run update");
   return run;
@@ -367,7 +397,7 @@ function validateVerifyJobs(response, run) {
     || !Array.isArray(response.jobs)
     || response.jobs.length !== expectedNames.length
   ) {
-    throw new Error("Full production Verify job inventory is incomplete or unexpected.");
+    throw new Error("Production Verify job inventory is incomplete or unexpected.");
   }
   const jobsByName = new Map();
   for (const job of response.jobs) {
@@ -389,7 +419,7 @@ function validateVerifyJobs(response, run) {
       || job.labels.length !== 1
       || job.labels[0] !== "ubuntu-latest"
     ) {
-      throw new Error("Full production Verify contains a failed or mismatched job.");
+      throw new Error("Production Verify contains a failed or mismatched job.");
     }
     parseTimestamp(job.started_at, `${job.name} start`);
     parseTimestamp(job.completed_at, `${job.name} completion`);
@@ -399,7 +429,7 @@ function validateVerifyJobs(response, run) {
     expectedNames.some((name) => !jobsByName.has(name))
     || [...jobsByName.keys()].some((name) => !expectedNames.includes(name))
   ) {
-    throw new Error("Full production Verify job names do not match the closed inventory.");
+    throw new Error("Production Verify job names do not match the closed inventory.");
   }
   return parseTimestamp(
     jobsByName.get(VERIFY_PROOF_JOB_NAME).completed_at,
@@ -552,6 +582,15 @@ async function runCli() {
         "Actions run attempt",
       ),
       eventName: process.env.GITHUB_EVENT_NAME,
+      scopeResults: Object.fromEntries(
+        PRODUCTION_VERIFY_SCOPE_KEYS.map((key) => [
+          key,
+          parseBoolean(
+            process.env[`PRODUCTION_VERIFY_SCOPE_${key.toUpperCase()}`],
+            `${key} scope`,
+          ),
+        ]),
+      ),
       checkResults: Object.fromEntries(
         REQUIRED_PRODUCTION_VERIFY_CHECKS.map(({ id }) => [
           id,
@@ -607,7 +646,7 @@ async function runCli() {
     const artifactDigest = requiredArgument(argumentsByName, "artifact-digest");
     requirePattern(artifactDigest, SHA256, "resolved artifact digest");
     const proofBytes = readFileSync(proofPath);
-    parseProductionVerifyProofV1(proofBytes, {
+    const proof = parseProductionVerifyProofV1(proofBytes, {
       commitSha: context.commitSha,
       treeSha: context.treeSha,
       workflowFileSha256: context.workflowFileSha256,
@@ -621,6 +660,12 @@ async function runCli() {
       verify_run_attempt: runAttempt,
       proof_sha256: prefixedSha256(proofBytes),
       artifact_digest: artifactDigest,
+      ...Object.fromEntries(
+        PRODUCTION_VERIFY_SCOPE_KEYS.map((key) => [
+          `verified_${key}`,
+          proof.scope[key],
+        ]),
+      ),
     });
     return;
   }
@@ -710,6 +755,24 @@ function parsePositiveInteger(value, name) {
 
 function numeric(value) {
   return Number.isSafeInteger(value) ? value : 0;
+}
+
+function parseBoolean(value, name) {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`${name} is invalid.`);
+}
+
+function validateProductionVerifyScope(value) {
+  assertExactKeys(value, PRODUCTION_VERIFY_SCOPE_KEYS, "verification scope");
+  const scope = {};
+  for (const key of PRODUCTION_VERIFY_SCOPE_KEYS) {
+    if (typeof value[key] !== "boolean") {
+      throw new Error(`${key} verification scope is invalid.`);
+    }
+    scope[key] = value[key];
+  }
+  return Object.freeze(scope);
 }
 
 function requirePositiveInteger(value, name) {

--- a/scripts/test/production-verify-proof.test.mjs
+++ b/scripts/test/production-verify-proof.test.mjs
@@ -6,6 +6,7 @@ import {
   PRODUCTION_REPOSITORY,
   PRODUCTION_REPOSITORY_ID,
   PRODUCTION_VERIFY_PROOF_MAX_AGE_MS,
+  PRODUCTION_VERIFY_SCOPE_KEYS,
   REQUIRED_PRODUCTION_VERIFY_CHECKS,
   VERIFY_AGGREGATE_JOB_NAME,
   VERIFY_PROOF_JOB_NAME,
@@ -43,6 +44,9 @@ function validProofInput() {
     runId: RUN_ID,
     runAttempt: RUN_ATTEMPT,
     eventName: "push",
+    scopeResults: Object.fromEntries(
+      PRODUCTION_VERIFY_SCOPE_KEYS.map((key) => [key, true]),
+    ),
     checkResults: Object.fromEntries(
       REQUIRED_PRODUCTION_VERIFY_CHECKS.map(({ id }) => [id, "success"]),
     ),
@@ -237,6 +241,69 @@ test("full production Verify proof is deterministic and exact", () => {
       runAttempt: RUN_ATTEMPT,
     }),
     proof,
+  );
+});
+
+test("proof binds the path scope and distinguishes skipped lanes", () => {
+  const input = validProofInput();
+  input.scopeResults = {
+    contracts: false,
+    database: false,
+    dependencies: false,
+    indexer: false,
+    interface: true,
+    read_model: false,
+  };
+  input.checkResults = {
+    "secret-scan": "success",
+    indexer: "skipped",
+    "database-pglite": "skipped",
+    interface: "success",
+    contracts: "skipped",
+  };
+  const proof = buildProductionVerifyProofV1(input);
+  assert.deepEqual(proof.scope, input.scopeResults);
+  assert.deepEqual(
+    Object.fromEntries(proof.checks.map(({ id, required }) => [id, required])),
+    {
+      "secret-scan": true,
+      indexer: false,
+      "database-pglite": false,
+      interface: true,
+      contracts: false,
+    },
+  );
+  assert.doesNotThrow(() =>
+    parseProductionVerifyProofV1(
+      encodeProductionVerifyProofV1(proof),
+      {
+        commitSha: COMMIT,
+        treeSha: TREE,
+        workflowFileSha256: WORKFLOW_SHA256,
+        runId: RUN_ID,
+        runAttempt: RUN_ATTEMPT,
+      },
+    ),
+  );
+});
+
+test("path-scoped proof rejects a skipped required lane", () => {
+  const input = validProofInput();
+  input.scopeResults = {
+    contracts: false,
+    database: false,
+    dependencies: false,
+    indexer: false,
+    interface: true,
+    read_model: false,
+  };
+  input.checkResults.interface = "skipped";
+  input.checkResults.indexer = "skipped";
+  input.checkResults["database-pglite"] = "skipped";
+  input.checkResults.contracts = "skipped";
+  assert.throws(
+    () => buildProductionVerifyProofV1(input),
+    /Interface result does not match/,
   );
 });
 

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -654,7 +654,7 @@ describe("read-model production deploy policy", () => {
     expect(workflow).toContain("attestation_sha256");
     expect(workflow).toContain("Smoke staged Bitquery market APIs");
     expect(workflow).toContain(
-      "if: steps.read-model-policy.outputs.mode == 'alchemy-only'",
+      "if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.mode == 'alchemy-only'",
     );
     expect(workflow).toContain(
       '"x-vercel-protection-bypass": automationBypassSecret',

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -240,7 +240,7 @@ describe("read-model operations source contract", () => {
       "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}\n";
     const quickNodeStep =
       "      - name: Gate exact staged QuickNode wake route\n" +
-      "        if: steps.read-model-policy.outputs.wake_canary_required == 'true'\n" +
+      "        if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.wake_canary_required == 'true'\n" +
       "        env:\n" +
       "          PROGRAMMABLE_QUICKNODE_STREAM_SECRET: ${{ secrets.PROGRAMMABLE_QUICKNODE_STREAM_SECRET }}\n" +
       secretLine;
@@ -303,6 +303,7 @@ describe("read-model operations source contract", () => {
     const workflowPath = ".github/workflows/deploy-production.yml";
     const bitqueryStep =
       "      - name: Smoke staged Bitquery market APIs\n" +
+      "        if: needs.release-gate.outputs.verified_read_model == 'true'\n" +
       "        env:\n" +
       "          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}\n" +
       "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}\n";


### PR DESCRIPTION
This change introduces a fail-closed changed-path matrix for production verification.

- UI/docs-only changes run the interface lane and stable aggregate.
- Read-model/API paths retain database/indexer/provider coverage.
- Contracts, dependencies, workflows, and unknown paths remain full-lane.
- Production proof binds the exact scope so skipped lanes cannot be misrepresented.
- Staging provider checks run only when the exact production proof requires the read-model lane.

The first rollout commit intentionally triggers the full control-plane validation; later pure UI/docs commits use the shorter route. Local validation: full npm verify, 25 production-proof tests, 43 release-record tests, 47 read-model tests, actionlint, diff-check.