### PR TITLE
Refresh production website UI and copy

### DIFF
--- a/app/interface.css
+++ b/app/interface.css
@@ -306,9 +306,8 @@ html[data-theme="dark"] .app-frame::before {
 
 /* Keep the refractive layer behind content and disable it where browsers
  * cannot render the SVG displacement cleanly. */
-@supports not (
-  (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
-) {
+/* prettier-ignore */
+@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
   .liquid-glass-distortion::after {
     -webkit-filter: none;
     filter: none;

--- a/app/interface.css
+++ b/app/interface.css
@@ -50,8 +50,12 @@
     0 0 0 1px oklch(0.08 0.02 264 / 0.16),
     0 12px 30px oklch(0.07 0.022 264 / 0.2);
   --control-glass-background: var(--liquid-glass-control-background);
-  --control-glass-background-strong: var(--liquid-glass-surface-background-strong);
-  --control-glass-background-hover: var(--liquid-glass-control-background-hover);
+  --control-glass-background-strong: var(
+    --liquid-glass-surface-background-strong
+  );
+  --control-glass-background-hover: var(
+    --liquid-glass-control-background-hover
+  );
   --control-glass-border: var(--liquid-glass-border);
   --control-glass-backdrop: var(--liquid-glass-backdrop);
   --accent-glass-background: rgba(248, 240, 233, 0.12);
@@ -111,14 +115,16 @@ html[data-theme="dark"] {
   --control-glass-highlight: rgba(255, 255, 255, 0.1);
   --control-glass-shadow-color: rgba(0, 0, 0, 0.25);
   --control-glass-background: var(--liquid-glass-control-background);
-  --control-glass-background-strong: var(--liquid-glass-surface-background-strong);
-  --control-glass-background-hover: var(--liquid-glass-control-background-hover);
+  --control-glass-background-strong: var(
+    --liquid-glass-surface-background-strong
+  );
+  --control-glass-background-hover: var(
+    --liquid-glass-control-background-hover
+  );
   --shadow-resting:
-    0 1px 0 rgba(255, 255, 255, 0.018),
-    0 10px 28px rgba(0, 0, 0, 0.16);
+    0 1px 0 rgba(255, 255, 255, 0.018), 0 10px 28px rgba(0, 0, 0, 0.16);
   --shadow-floating:
-    0 1px 0 rgba(255, 255, 255, 0.025),
-    0 18px 46px rgba(0, 0, 0, 0.28);
+    0 1px 0 rgba(255, 255, 255, 0.025), 0 18px 46px rgba(0, 0, 0, 0.28);
 }
 
 html {
@@ -129,7 +135,9 @@ html {
 
 body {
   background: #010103;
-  font-feature-settings: "kern" 1, "liga" 1;
+  font-feature-settings:
+    "kern" 1,
+    "liga" 1;
   font-kerning: normal;
   font-synthesis: style;
   letter-spacing: -0.006em;
@@ -188,6 +196,37 @@ code,
   z-index: 1;
 }
 
+/* The home scene owns the viewport; it does not need the mobile nav reserve. */
+.app-frame:has(.landing-page-root) > main {
+  padding-bottom: 0;
+}
+
+/* Keep the botanical edge detail atmospheric on the home scene without
+ * competing with the launch copy and artwork. */
+.app-frame:has(.landing-page-root) .atmosphere-plant {
+  bottom: -320px;
+  opacity: 0.58;
+}
+
+body:not(:has(.landing-page-root)):not(:has([data-docs-shell]))
+  .atmosphere-plant {
+  opacity: 0.18;
+  bottom: -220px;
+}
+
+@media (max-width: 520px) {
+  .app-frame:has(.landing-page-root) .atmosphere-plant {
+    bottom: -112px;
+    opacity: 0.54;
+  }
+
+  body:not(:has(.landing-page-root)):not(:has([data-docs-shell]))
+    .atmosphere-plant {
+    bottom: -220px;
+    opacity: 0.2;
+  }
+}
+
 .site-header {
   position: sticky;
   top: 0;
@@ -207,7 +246,8 @@ code,
 }
 
 .route-transition h1[tabindex="-1"]:focus {
-  outline: 0;
+  outline: 2px solid var(--brand-ivory);
+  outline-offset: 6px;
 }
 
 .app-frame::before,
@@ -266,7 +306,9 @@ html[data-theme="dark"] .app-frame::before {
 
 /* Keep the refractive layer behind content and disable it where browsers
  * cannot render the SVG displacement cleanly. */
-@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+@supports not (
+  (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+) {
   .liquid-glass-distortion::after {
     -webkit-filter: none;
     filter: none;
@@ -304,8 +346,16 @@ html[data-theme="dark"] .app-frame::before {
       rgba(62, 34, 82, 0.08) 58%,
       transparent 76%
     ),
-    radial-gradient(ellipse 28% 24% at 12% 104%, rgba(184, 107, 205, 0.14), transparent 74%),
-    radial-gradient(ellipse 28% 24% at 88% 104%, rgba(115, 94, 181, 0.14), transparent 74%);
+    radial-gradient(
+      ellipse 28% 24% at 12% 104%,
+      rgba(184, 107, 205, 0.14),
+      transparent 74%
+    ),
+    radial-gradient(
+      ellipse 28% 24% at 88% 104%,
+      rgba(115, 94, 181, 0.14),
+      transparent 74%
+    );
   z-index: 0;
 }
 
@@ -316,35 +366,131 @@ html[data-theme="dark"] .app-frame::before {
 
 .atmosphere-stars-primary {
   background-image:
-    radial-gradient(circle at 3% 18%, rgba(248, 240, 233, 0.54) 0 0.7px, transparent 1.4px),
-    radial-gradient(circle at 9% 39%, rgba(225, 235, 255, 0.46) 0 0.65px, transparent 1.35px),
-    radial-gradient(circle at 14% 8%, rgba(248, 240, 233, 0.4) 0 0.65px, transparent 1.3px),
-    radial-gradient(circle at 19% 24%, rgba(248, 240, 233, 0.52) 0 0.7px, transparent 1.4px),
-    radial-gradient(circle at 29% 16%, rgba(229, 238, 255, 0.42) 0 0.65px, transparent 1.3px),
-    radial-gradient(circle at 37% 27%, rgba(248, 240, 233, 0.48) 0 0.7px, transparent 1.4px),
-    radial-gradient(circle at 47% 9%, rgba(248, 240, 233, 0.44) 0 0.65px, transparent 1.3px),
-    radial-gradient(circle at 61% 19%, rgba(226, 236, 255, 0.44) 0 0.7px, transparent 1.4px),
-    radial-gradient(circle at 69% 29%, rgba(248, 240, 233, 0.5) 0 0.65px, transparent 1.3px),
-    radial-gradient(circle at 77% 7%, rgba(248, 240, 233, 0.46) 0 0.7px, transparent 1.4px),
-    radial-gradient(circle at 87% 36%, rgba(229, 238, 255, 0.42) 0 0.65px, transparent 1.3px),
-    radial-gradient(circle at 96% 17%, rgba(248, 240, 233, 0.52) 0 0.7px, transparent 1.4px);
+    radial-gradient(
+      circle at 3% 18%,
+      rgba(248, 240, 233, 0.54) 0 0.7px,
+      transparent 1.4px
+    ),
+    radial-gradient(
+      circle at 9% 39%,
+      rgba(225, 235, 255, 0.46) 0 0.65px,
+      transparent 1.35px
+    ),
+    radial-gradient(
+      circle at 14% 8%,
+      rgba(248, 240, 233, 0.4) 0 0.65px,
+      transparent 1.3px
+    ),
+    radial-gradient(
+      circle at 19% 24%,
+      rgba(248, 240, 233, 0.52) 0 0.7px,
+      transparent 1.4px
+    ),
+    radial-gradient(
+      circle at 29% 16%,
+      rgba(229, 238, 255, 0.42) 0 0.65px,
+      transparent 1.3px
+    ),
+    radial-gradient(
+      circle at 37% 27%,
+      rgba(248, 240, 233, 0.48) 0 0.7px,
+      transparent 1.4px
+    ),
+    radial-gradient(
+      circle at 47% 9%,
+      rgba(248, 240, 233, 0.44) 0 0.65px,
+      transparent 1.3px
+    ),
+    radial-gradient(
+      circle at 61% 19%,
+      rgba(226, 236, 255, 0.44) 0 0.7px,
+      transparent 1.4px
+    ),
+    radial-gradient(
+      circle at 69% 29%,
+      rgba(248, 240, 233, 0.5) 0 0.65px,
+      transparent 1.3px
+    ),
+    radial-gradient(
+      circle at 77% 7%,
+      rgba(248, 240, 233, 0.46) 0 0.7px,
+      transparent 1.4px
+    ),
+    radial-gradient(
+      circle at 87% 36%,
+      rgba(229, 238, 255, 0.42) 0 0.65px,
+      transparent 1.3px
+    ),
+    radial-gradient(
+      circle at 96% 17%,
+      rgba(248, 240, 233, 0.52) 0 0.7px,
+      transparent 1.4px
+    );
   opacity: 0.86;
 }
 
 .atmosphere-stars-secondary {
   background-image:
-    radial-gradient(circle at 6% 54%, rgba(248, 240, 233, 0.36) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 12% 25%, rgba(248, 240, 233, 0.38) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 23% 34%, rgba(225, 235, 255, 0.34) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 32% 6%, rgba(248, 240, 233, 0.34) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 43% 29%, rgba(248, 240, 233, 0.38) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 52% 20%, rgba(225, 235, 255, 0.34) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 58% 12%, rgba(248, 240, 233, 0.36) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 72% 31%, rgba(248, 240, 233, 0.34) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 82% 33.5%, rgba(225, 235, 255, 0.36) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 91% 11%, rgba(248, 240, 233, 0.38) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 94% 47%, rgba(248, 240, 233, 0.34) 0 0.6px, transparent 1.2px),
-    radial-gradient(circle at 99% 29%, rgba(225, 235, 255, 0.36) 0 0.6px, transparent 1.2px);
+    radial-gradient(
+      circle at 6% 54%,
+      rgba(248, 240, 233, 0.36) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 12% 25%,
+      rgba(248, 240, 233, 0.38) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 23% 34%,
+      rgba(225, 235, 255, 0.34) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 32% 6%,
+      rgba(248, 240, 233, 0.34) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 43% 29%,
+      rgba(248, 240, 233, 0.38) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 52% 20%,
+      rgba(225, 235, 255, 0.34) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 58% 12%,
+      rgba(248, 240, 233, 0.36) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 72% 31%,
+      rgba(248, 240, 233, 0.34) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 82% 33.5%,
+      rgba(225, 235, 255, 0.36) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 91% 11%,
+      rgba(248, 240, 233, 0.38) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 94% 47%,
+      rgba(248, 240, 233, 0.34) 0 0.6px,
+      transparent 1.2px
+    ),
+    radial-gradient(
+      circle at 99% 29%,
+      rgba(225, 235, 255, 0.36) 0 0.6px,
+      transparent 1.2px
+    );
   opacity: 0.74;
 }
 
@@ -671,7 +817,11 @@ html[data-theme="dark"] .app-frame::before {
 .atmosphere-veil {
   background:
     linear-gradient(180deg, transparent 0 68%, rgba(1, 1, 3, 0.06) 100%),
-    radial-gradient(circle at 50% 34%, transparent 0 42%, rgba(1, 1, 3, 0.12) 100%);
+    radial-gradient(
+      circle at 50% 34%,
+      transparent 0 42%,
+      rgba(1, 1, 3, 0.12) 100%
+    );
   z-index: 3;
 }
 
@@ -791,16 +941,19 @@ html[data-theme="dark"] .app-frame::before {
 
 @media (prefers-reduced-motion: no-preference) {
   .atmosphere-sparkles i {
-    animation: var(--sparkle-animation) var(--sparkle-duration) cubic-bezier(0.37, 0, 0.63, 1) var(--sparkle-delay) infinite;
+    animation: var(--sparkle-animation) var(--sparkle-duration)
+      cubic-bezier(0.37, 0, 0.63, 1) var(--sparkle-delay) infinite;
   }
 
   .atmosphere-plant-left {
-    animation: atmosphere-plant-left 13.6s cubic-bezier(0.45, 0.05, 0.55, 0.95) -7.9s infinite;
+    animation: atmosphere-plant-left 13.6s
+      cubic-bezier(0.45, 0.05, 0.55, 0.95) -7.9s infinite;
     will-change: transform;
   }
 
   .atmosphere-plant-right {
-    animation: atmosphere-plant-right 11.9s cubic-bezier(0.45, 0.05, 0.55, 0.95) -3.1s infinite;
+    animation: atmosphere-plant-right 11.9s
+      cubic-bezier(0.45, 0.05, 0.55, 0.95) -3.1s infinite;
     will-change: transform;
   }
 }
@@ -1498,6 +1651,12 @@ body:has([data-docs-shell]) .site-header::before {
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
     background: transparent;
+    background: linear-gradient(
+      180deg,
+      rgba(1, 1, 3, 0) 0%,
+      rgba(1, 1, 3, 0.86) 42%,
+      rgba(1, 1, 3, 0.98) 100%
+    );
     border: 0;
     border-radius: 0;
     bottom: max(4px, env(safe-area-inset-bottom));
@@ -1586,6 +1745,12 @@ body:has([data-docs-shell]) .site-header::before {
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
     background: transparent;
+    background: linear-gradient(
+      180deg,
+      rgba(1, 1, 3, 0) 0%,
+      rgba(1, 1, 3, 0.86) 42%,
+      rgba(1, 1, 3, 0.98) 100%
+    );
     border: 0;
     border-radius: 0;
     bottom: max(4px, env(safe-area-inset-bottom));
@@ -1879,10 +2044,11 @@ body:has([data-docs-shell]) .site-header::before {
   .token-card:nth-child(n) {
     animation: none;
   }
-
 }
 
-@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+@supports not (
+  (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))
+) {
   .liquid-glass-surface {
     background: #24211f;
   }

--- a/app/interface.css
+++ b/app/interface.css
@@ -260,7 +260,7 @@ body:not(:has(.landing-page-root)):not(:has([data-docs-shell]))
   outline: 0;
 }
 
-.route-transition h1[tabindex="-1"]:focus {
+.route-transition h1[tabindex="-1"]:focus-visible {
   outline: 2px solid var(--brand-ivory);
   outline-offset: 6px;
 }

--- a/app/interface.css
+++ b/app/interface.css
@@ -197,8 +197,23 @@ code,
 }
 
 /* The home scene owns the viewport; it does not need the mobile nav reserve. */
+.app-frame:has(.landing-page-root) {
+  height: 100svh;
+  min-height: 100svh;
+  overflow: hidden;
+}
+
 .app-frame:has(.landing-page-root) > main {
   padding-bottom: 0;
+  height: 100svh;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.app-frame:has(.landing-page-root) .route-transition {
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* Keep the botanical edge detail atmospheric on the home scene without

--- a/app/interface.css
+++ b/app/interface.css
@@ -802,6 +802,100 @@ html[data-theme="dark"] .app-frame::before {
   top: 51.8%;
 }
 
+/* Keep the same sparkle system present in the lower night margin too. */
+.atmosphere-sparkles-lower {
+  opacity: 0.78;
+}
+
+.atmosphere-sparkles-lower i:nth-child(1) {
+  --sparkle-delay: -4.8s;
+  --sparkle-duration: 11.6s;
+  left: 4.8%;
+  top: 64.5%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(2) {
+  --sparkle-delay: -9.2s;
+  --sparkle-duration: 13.4s;
+  --sparkle-size: 1.25px;
+  left: 13.4%;
+  top: 82.5%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(3) {
+  --sparkle-delay: -2.1s;
+  --sparkle-duration: 9.8s;
+  left: 24.7%;
+  top: 69.8%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(4) {
+  --sparkle-delay: -11.4s;
+  --sparkle-duration: 14.6s;
+  --sparkle-size: 1.5px;
+  left: 36.8%;
+  top: 92.2%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(5) {
+  --sparkle-delay: -5.7s;
+  --sparkle-duration: 10.9s;
+  left: 45.2%;
+  top: 77.6%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(6) {
+  --sparkle-delay: -1.6s;
+  --sparkle-duration: 12.8s;
+  left: 56.5%;
+  top: 66.4%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(7) {
+  --sparkle-delay: -8.6s;
+  --sparkle-duration: 9.4s;
+  --sparkle-size: 1.25px;
+  left: 63.9%;
+  top: 87.8%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(8) {
+  --sparkle-delay: -3.3s;
+  --sparkle-duration: 13.9s;
+  left: 74.4%;
+  top: 73.2%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(9) {
+  --sparkle-delay: -10.1s;
+  --sparkle-duration: 11.2s;
+  --sparkle-size: 1.5px;
+  left: 82.6%;
+  top: 94.3%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(10) {
+  --sparkle-delay: -6.5s;
+  --sparkle-duration: 8.8s;
+  left: 89.7%;
+  top: 63.7%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(11) {
+  --sparkle-delay: -12.2s;
+  --sparkle-duration: 14.2s;
+  left: 95.1%;
+  top: 80.6%;
+}
+
+.atmosphere-sparkles-lower i:nth-child(12) {
+  --sparkle-delay: -4.1s;
+  --sparkle-duration: 10.4s;
+  --sparkle-size: 0.8px;
+  left: 31.4%;
+  top: 97.1%;
+}
+
 .atmosphere-botanicals {
   overflow: hidden;
   z-index: 2;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,8 @@ const plexMono = IBM_Plex_Mono({
 });
 
 const siteUrl = new URL("https://programmable.market");
-const siteDescription = "Tokens that behave how you imagine.";
+const siteDescription =
+  "Create tokens with a clear launch model and programmable onchain behavior.";
 const socialImageUrl = new URL(
   "/og/programmable-night-garden-og-1200x630.png",
   siteUrl,
@@ -105,14 +106,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html
-      lang="en"
-      data-scroll-behavior="smooth"
-      data-theme="dark"
-    >
-      <body
-        className={`${instrumentSans.variable} ${plexMono.variable}`}
-      >
+    <html lang="en" data-scroll-behavior="smooth" data-theme="dark">
+      <body className={`${instrumentSans.variable} ${plexMono.variable}`}>
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,8 @@ import { LandingPage } from "@/components/landing-page";
 
 export const metadata: Metadata = {
   title: "Programmable",
-  description: "Tokens that behave how you imagine.",
+  description:
+    "Create tokens with a clear launch model and programmable onchain behavior.",
 };
 
 export default function HomePage() {

--- a/components/atmosphere-backdrop.tsx
+++ b/components/atmosphere-backdrop.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 
 const TWINKLE_COUNT = 36;
+const LOWER_TWINKLE_COUNT = 12;
 const PLANT_SIZES = "(max-width: 520px) 46vw, (max-width: 1500px) 22vw, 330px";
 
 export function AtmosphereBackdrop() {
@@ -12,6 +13,11 @@ export function AtmosphereBackdrop() {
       <span className="atmosphere-sparkles">
         {Array.from({ length: TWINKLE_COUNT }, (_, index) => (
           <i key={index} />
+        ))}
+      </span>
+      <span className="atmosphere-sparkles atmosphere-sparkles-lower">
+        {Array.from({ length: LOWER_TWINKLE_COUNT }, (_, index) => (
+          <i key={`lower-${index}`} />
         ))}
       </span>
       <span className="atmosphere-botanicals">

--- a/components/custom-launch-experience.module.css
+++ b/components/custom-launch-experience.module.css
@@ -1,4 +1,6 @@
 .page {
+  --custom-surface-shadow: 0 24px 68px rgb(1 1 3 / 0.28);
+  --custom-inner-shadow: 0 16px 42px rgb(1 1 3 / 0.18);
   padding-top: 16px;
 }
 
@@ -19,28 +21,19 @@
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
   background: var(--liquid-glass-surface-background);
-  border: 1px solid var(--liquid-glass-border);
-  box-shadow: var(--liquid-glass-shadow);
+  border: 0;
+  box-shadow: var(--custom-surface-shadow);
 }
 
 .applicationRow {
   background: var(--liquid-glass-inner-background);
-  box-shadow: var(--liquid-glass-inner-shadow);
+  box-shadow: var(--custom-inner-shadow);
 }
 
 .introPrimary {
   border-radius: 28px;
   min-height: 390px;
   padding: clamp(30px, 5vw, 54px);
-}
-
-.kicker {
-  color: var(--accent-strong);
-  display: block;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.055em;
-  text-transform: uppercase;
 }
 
 .introPrimary h2 {
@@ -50,18 +43,6 @@
   line-height: 0.98;
   margin: 19px 0 18px;
   max-width: 9ch;
-}
-
-.introPrimary p,
-.statusEntry p,
-.emptyState p,
-.listToolbar p {
-  color: var(--text-soft);
-  line-height: 1.58;
-}
-
-.introPrimary p {
-  max-width: 55ch;
 }
 
 .actions {
@@ -130,7 +111,7 @@
 .statusEntry h2 {
   font-size: 26px;
   letter-spacing: -0.035em;
-  margin: 56px 0 8px;
+  margin: 20px 0 8px;
 }
 
 .githubButton {
@@ -193,14 +174,9 @@
 .listToolbar {
   align-items: center;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   margin: 2px auto 16px;
   max-width: 1000px;
-}
-
-.listToolbar p {
-  font-size: 13px;
-  margin: 0;
 }
 
 .iconButton {
@@ -362,34 +338,25 @@
 }
 
 .formSection + .formSection {
-  border-top: 1px solid var(--panel-border-soft);
+  border-block-start: 0;
+  margin-top: 10px;
 }
 
 .sectionHeading {
   align-items: flex-start;
   display: grid;
   gap: 13px;
-  grid-template-columns: 30px minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .sectionHeading > span {
-  color: var(--accent-strong);
-  font-size: 11px;
-  font-weight: 700;
-  padding-top: 5px;
+  display: none;
 }
 
 .sectionHeading h2 {
   font-size: 21px;
   letter-spacing: -0.03em;
   margin: 0;
-}
-
-.sectionHeading p {
-  color: var(--text-soft);
-  font-size: 12.5px;
-  line-height: 1.5;
-  margin: 4px 0 0;
 }
 
 .identityGrid {
@@ -485,9 +452,9 @@
 }
 
 .moreLinks {
-  border-top: 1px solid var(--panel-border-soft);
+  border-block-start: 0;
   margin-top: 4px;
-  padding-top: 10px;
+  padding-top: 2px;
 }
 
 .moreLinks summary {
@@ -531,11 +498,11 @@
 
 .reviewList > div {
   align-items: baseline;
-  border-top: 1px solid var(--panel-border-soft);
+  border-block-start: 0;
   display: grid;
   gap: 16px;
   grid-template-columns: minmax(120px, 0.45fr) minmax(0, 1fr);
-  padding: 11px 0;
+  padding: 9px 0;
 }
 
 .reviewList dt {
@@ -561,11 +528,12 @@
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
   background: var(--liquid-glass-inner-background);
-  border-top: 1px solid var(--panel-border-soft);
+  border-block-start: 0;
   display: flex;
   gap: 16px;
   justify-content: space-between;
   min-height: 72px;
+  margin-top: 12px;
   padding: 11px 28px;
 }
 

--- a/components/custom-launch-experience.tsx
+++ b/components/custom-launch-experience.tsx
@@ -2656,12 +2656,7 @@ export function CustomLaunchExperience({
       <CustomLaunchFrame boundaryRef={commitSessionBoundary} onBack={onBack} title="Build a custom launch">
         <div className={styles.introGrid}>
           <section className={styles.introPrimary}>
-            <span className={styles.kicker}>Open builder</span>
             <h2>Start with an idea.</h2>
-            <p>
-              Describe what you want to build to an agent, or submit the reviewed files
-              yourself. Your exact GitHub version must be approved before it can launch.
-            </p>
             <div className={styles.actions}>
               <a className="primary-button" href={BUILDER_SKILL_URL} target="_blank" rel="noreferrer">
                 Build with an agent <ExternalLink aria-hidden="true" size={16} />
@@ -2676,11 +2671,6 @@ export function CustomLaunchExperience({
               {wallet ? <GitHubBrandIcon /> : <Wallet />}
             </span>
             <h2>{wallet ? "Already submitted?" : "Connect your launch wallet"}</h2>
-            <p>
-              {wallet
-                ? "Next, verify the GitHub account that opened the submission. GitHub is source provenance only."
-                : "Choose the wallet that will sign and submit the launch. You can change it before confirmation."}
-            </p>
             {wallet ? (
               <div className={styles.walletGate}>
                 <div>
@@ -2725,7 +2715,6 @@ export function CustomLaunchExperience({
     return (
       <CustomLaunchFrame boundaryRef={commitSessionBoundary} onBack={onBack} title="Custom launches" eyebrow={githubUsername ? `@${githubUsername}` : "GitHub submissions"}>
         <div className={styles.listToolbar}>
-          <p>Every status is tied to one exact GitHub commit.</p>
           {applicantRecovery !== "none" ? (
             <button className={styles.secondaryButton} type="button" disabled={applicantReauthorizing} onClick={() => void recoverApplicantAccess()}>
               {applicantRecoveryAction}
@@ -2739,7 +2728,6 @@ export function CustomLaunchExperience({
         {applications.length === 0 ? (
           <section className={styles.emptyState}>
             <h2>No custom submissions yet</h2>
-            <p>Build with an agent or submit the required files on GitHub.</p>
             <div className={styles.actions}>
               <a className="primary-button" href={BUILDER_SKILL_URL} target="_blank" rel="noreferrer">Build with an agent</a>
               <a className={styles.secondaryButton} href={SUBMISSION_REQUIREMENTS_URL} target="_blank" rel="noreferrer">Read GitHub application guide</a>
@@ -2795,7 +2783,7 @@ export function CustomLaunchExperience({
         <form className={styles.setupSheet} aria-busy={launchProgress !== "idle"} aria-describedby={error ? "custom-launch-form-error" : undefined} onSubmit={launch}>
           <fieldset disabled={launchProgress !== "idle" || pendingGrantReissue !== null || applicantRecovery !== "none"}>
             <section className={styles.formSection}>
-              <div className={styles.sectionHeading}><span>01</span><div><h2>Project details</h2><p>These details describe the project. They cannot change the approved code.</p></div></div>
+              <div className={styles.sectionHeading}><span aria-hidden="true">01</span><div><h2>Project details</h2></div></div>
               <div className={styles.identityGrid}>
                 <div className={styles.imageField}>
                   <span>Project image</span>
@@ -2827,7 +2815,7 @@ export function CustomLaunchExperience({
 
             {descriptor.configurationSchema.fields.length > 0 ? (
               <section className={styles.formSection}>
-                <div className={styles.sectionHeading}><span>02</span><div><h2>Approved launch parameters</h2><p>Only fields allowed by the reviewed specification appear here.</p></div></div>
+                <div className={styles.sectionHeading}><span aria-hidden="true">02</span><div><h2>Approved launch parameters</h2></div></div>
                 <div className={styles.parameterGrid}>
                   {descriptor.configurationSchema.fields.map((field) => (
                     <ConfigurationField key={field.fieldId} field={field} value={configuration[field.fieldId] ?? ""} onChange={(value) => setConfiguration((current) => ({ ...current, [field.fieldId]: value }))} />
@@ -2837,7 +2825,7 @@ export function CustomLaunchExperience({
             ) : null}
 
             <section className={styles.formSection}>
-              <div className={styles.sectionHeading}><span>{descriptor.configurationSchema.fields.length > 0 ? "03" : "02"}</span><div><h2>Review</h2><p>The wallet receives one transaction built from this exact approved version.</p></div></div>
+              <div className={styles.sectionHeading}><span aria-hidden="true">{descriptor.configurationSchema.fields.length > 0 ? "03" : "02"}</span><div><h2>Review</h2></div></div>
               <dl className={styles.reviewList}>
                 <div><dt>Source</dt><dd>{selected.repositoryFullName} · {selected.commitOid.slice(0, 9)}</dd></div>
                 <div><dt>Network</dt><dd>{chainLabel(approvedRoute?.chainId)}</dd></div>

--- a/components/docs-experience.module.css
+++ b/components/docs-experience.module.css
@@ -1943,3 +1943,57 @@
     outline-color: Highlight;
   }
 }
+
+/* Minimal night reading surface: hierarchy comes from type, space and depth;
+ * decorative rules remain reserved for controls and data tables. */
+.page {
+  --docs-canvas: #09080d;
+  --surface: #111019;
+  --surface-raised: #171520;
+  --surface-soft: #201d2a;
+  background:
+    radial-gradient(
+      circle at 80% 2%,
+      rgb(183 107 152 / 0.07),
+      transparent 30rem
+    ),
+    var(--docs-canvas);
+}
+
+:global(html:has([data-docs-shell])),
+:global(body:has([data-docs-shell])),
+:global(body:has([data-docs-shell]) .app-frame),
+:global(body:has([data-docs-shell]) .site-header) {
+  background-color: #09080d;
+}
+
+.docsFeedback {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.pageNavigation ul {
+  border-inline-start: 0;
+}
+
+.pageNavigation a {
+  padding-inline-start: 0;
+}
+
+.pageNavigation a::before {
+  display: none;
+}
+
+.launchInspector,
+.commandPanel {
+  border-color: transparent;
+  box-shadow: 0 20px 52px rgb(0 0 0 / 0.2);
+}
+
+.sampleTabs,
+.codePre,
+.commandPre,
+.codeNote {
+  border-block: 0;
+  border-top: 0;
+}

--- a/components/docs-hub.module.css
+++ b/components/docs-hub.module.css
@@ -420,3 +420,15 @@
     transition: none;
   }
 }
+
+/* Cards use a quiet surface and depth rather than a stack of gray keylines. */
+.pathCard {
+  background: color-mix(in srgb, var(--surface-soft) 56%, transparent);
+  border-color: transparent;
+  box-shadow: 0 18px 44px rgb(0 0 0 / 0.18);
+}
+
+.pathCard:hover {
+  border-color: transparent;
+  box-shadow: 0 22px 52px rgb(0 0 0 / 0.28);
+}

--- a/components/docs-navigation.tsx
+++ b/components/docs-navigation.tsx
@@ -662,6 +662,7 @@ export function DocsNavigation({
           aria-controls="docs-mobile-navigation"
           aria-expanded={mobileNavigationOpen}
           aria-haspopup="dialog"
+          aria-label={`Open documentation navigation, ${activeLabel}`}
           onClick={openMobileNavigation}
         >
           <Menu aria-hidden="true" size={18} strokeWidth={1.8} />

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -25,22 +25,11 @@
   justify-content: center;
   margin-inline: auto;
   max-width: 1080px;
-  min-height: clamp(216px, 25svh, 240px);
-  padding: clamp(32px, 4svh, 48px) 0 32px;
+  min-height: clamp(164px, 19svh, 196px);
+  padding: clamp(28px, 4svh, 42px) 0 28px;
   position: relative;
   text-align: center;
   width: 100%;
-}
-
-.pageEyebrow {
-  color: var(--explore-ivory-muted);
-  font-family: var(--font-instrument), sans-serif;
-  font-size: 11px;
-  font-weight: 650;
-  letter-spacing: 0.12em;
-  line-height: 1.2;
-  margin: 0 0 16px;
-  text-transform: uppercase;
 }
 
 .pageHeading h1 {
@@ -50,7 +39,7 @@
   flex-direction: column;
   font-size: clamp(48px, 4.7vw, 68px);
   font-weight: 430;
-  letter-spacing: -0.05em;
+  letter-spacing: -0.035em;
   line-height: 0.96;
   margin: 0;
   max-width: 100%;
@@ -64,17 +53,6 @@
   max-width: 100%;
   text-align: center;
   width: max-content;
-}
-
-.pageDescription {
-  color: var(--explore-ivory-soft);
-  font-size: 16px;
-  font-weight: 430;
-  line-height: 1.5;
-  margin: 20px 0 0;
-  max-width: 54ch;
-  text-shadow: 0 2px 18px rgba(1, 5, 20, 0.58);
-  text-wrap: pretty;
 }
 
 .runnersSection {
@@ -101,15 +79,6 @@
   justify-content: center;
   min-height: 0;
   width: 100%;
-}
-
-.sectionTitle {
-  color: var(--explore-ivory);
-  font-size: 18px;
-  font-weight: 540;
-  letter-spacing: -0.025em;
-  line-height: 1.2;
-  margin: 0 0 14px;
 }
 
 .runnersIntro :global(.token-toolbar) {
@@ -342,11 +311,9 @@
   -webkit-backdrop-filter: blur(24px) saturate(1.08);
   backdrop-filter: blur(24px) saturate(1.08);
   background: rgba(248, 240, 233, 0.1);
-  border: 1px solid var(--explore-glass-border);
+  border: 0;
   border-radius: 24px;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.16),
-    0 18px 54px rgba(1, 1, 3, 0.26);
+  box-shadow: 0 18px 54px rgba(1, 1, 3, 0.26);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -356,7 +323,6 @@
   position: relative;
   transition:
     background-color 200ms cubic-bezier(0.23, 1, 0.32, 1),
-    border-color 200ms cubic-bezier(0.23, 1, 0.32, 1),
     box-shadow 200ms cubic-bezier(0.23, 1, 0.32, 1),
     transform 180ms cubic-bezier(0.23, 1, 0.32, 1);
   width: 100%;
@@ -383,7 +349,7 @@
   background: #010103;
   border: 0;
   border-radius: 18px;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  box-shadow: none;
   contain: paint;
   isolation: isolate;
   line-height: 0;
@@ -596,11 +562,9 @@
   align-items: center;
   backdrop-filter: blur(24px) saturate(1.08);
   background: rgba(248, 240, 233, 0.1);
-  border: 1px solid var(--explore-glass-border);
+  border: 0;
   border-radius: 24px;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.16),
-    0 18px 54px rgba(1, 1, 3, 0.24);
+  box-shadow: 0 18px 54px rgba(1, 1, 3, 0.24);
   color: var(--explore-ivory-soft);
   display: flex;
   flex-wrap: wrap;
@@ -637,11 +601,9 @@
   align-items: end;
   backdrop-filter: blur(24px) saturate(1.08);
   background: rgba(248, 240, 233, 0.1);
-  border: 1px solid var(--explore-glass-border);
+  border: 0;
   border-radius: 24px;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.16),
-    0 18px 54px rgba(1, 1, 3, 0.24);
+  box-shadow: 0 18px 54px rgba(1, 1, 3, 0.24);
   display: grid;
   gap: 40px;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -698,10 +660,7 @@
 @media (hover: hover) and (pointer: fine) {
   .runnerCard:has(a.runnerHitArea):hover {
     background: rgba(248, 240, 233, 0.14);
-    border-color: var(--explore-glass-border-strong);
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.2),
-      0 22px 58px rgba(1, 1, 3, 0.3);
+    box-shadow: 0 22px 58px rgba(1, 1, 3, 0.3);
     transform: translate3d(0, -2px, 0);
   }
 
@@ -779,31 +738,21 @@
 
 @media (max-width: 700px) {
   .pageHeading {
-    min-height: 208px;
-    padding: 28px 0 24px;
+    min-height: 156px;
+    padding: 24px 0 20px;
   }
 
   .pageHeading h1 {
     font-size: clamp(40px, 11.4vw, 52px);
-    letter-spacing: -0.044em;
+    letter-spacing: -0.028em;
     line-height: 0.98;
     max-width: 16ch;
     overflow-wrap: break-word;
     white-space: normal;
   }
 
-  .pageEyebrow {
-    margin-bottom: 14px;
-  }
-
   .pageHeading h1 span {
     width: auto;
-  }
-
-  .pageDescription {
-    font-size: 15px;
-    margin-top: 16px;
-    max-width: 35ch;
   }
 
   .runnersSection {
@@ -976,17 +925,12 @@
 
 @media (max-width: 420px) {
   .pageHeading {
-    min-height: 196px;
+    min-height: 146px;
     padding-top: 24px;
   }
 
   .pageHeading h1 {
     font-size: clamp(38px, 11vw, 44px);
-  }
-
-  .pageDescription {
-    font-size: 14px;
-    max-width: 31ch;
   }
 
   .runnerHitArea,

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -32,6 +32,17 @@
   width: 100%;
 }
 
+.pageEyebrow {
+  color: var(--explore-ivory-muted);
+  font-family: var(--font-instrument), sans-serif;
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
+  margin: 0 0 16px;
+  text-transform: uppercase;
+}
+
 .pageHeading h1 {
   align-items: center;
   color: var(--explore-ivory);
@@ -85,9 +96,20 @@
 }
 
 .runnersIntro :global(.token-section-heading) {
+  align-items: center;
+  flex-direction: column;
   justify-content: center;
   min-height: 0;
   width: 100%;
+}
+
+.sectionTitle {
+  color: var(--explore-ivory);
+  font-size: 18px;
+  font-weight: 540;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+  margin: 0 0 14px;
 }
 
 .runnersIntro :global(.token-toolbar) {
@@ -425,7 +447,9 @@
 .runnerMeta {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   gap: 4px;
+  row-gap: 2px;
   margin-block-start: 2px;
   min-height: 44px;
   min-width: 0;
@@ -454,7 +478,7 @@
   align-items: baseline;
   color: var(--explore-ivory);
   display: inline-flex;
-  flex: none;
+  flex: 0 1 auto;
   font-family: var(--font-instrument), sans-serif;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
@@ -496,7 +520,7 @@
   align-items: center;
   display: flex;
   gap: 2px;
-  margin: 0;
+  margin: 0 0 0 auto;
   min-height: 44px;
 }
 
@@ -591,6 +615,20 @@
 }
 
 .messageState p {
+  margin: 0;
+}
+
+.messageCopy {
+  display: grid;
+  gap: 8px;
+}
+
+.messageCopy h2 {
+  color: var(--explore-ivory);
+  font-size: 22px;
+  font-weight: 540;
+  letter-spacing: -0.035em;
+  line-height: 1.1;
   margin: 0;
 }
 
@@ -754,6 +792,10 @@
     white-space: normal;
   }
 
+  .pageEyebrow {
+    margin-bottom: 14px;
+  }
+
   .pageHeading h1 span {
     width: auto;
   }
@@ -881,6 +923,10 @@
     padding: 4px 4px 0;
   }
 
+  .runnerSocials {
+    margin-left: auto;
+  }
+
   .runnerSocialLink {
     height: 44px;
     width: 44px;
@@ -912,6 +958,19 @@
 
   .emptyState h2 {
     font-size: 36px;
+  }
+
+  .messageState {
+    align-items: start;
+    flex-direction: column;
+    margin-top: 18px;
+    min-height: 148px;
+    padding: 28px 24px;
+    text-align: start;
+  }
+
+  .messageState :global(.text-button) {
+    align-self: start;
   }
 }
 
@@ -966,6 +1025,12 @@
   .runnerSocialLink {
     width: 44px;
   }
+
+  .runnerSocials {
+    flex-basis: 100%;
+    justify-content: flex-end;
+    margin-left: 0;
+  }
 }
 
 @media (max-width: 360px) {
@@ -1007,6 +1072,10 @@
 
   .runnerMeta {
     flex-wrap: wrap;
+  }
+
+  .runnerSocials {
+    justify-content: flex-start;
   }
 }
 

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1612,14 +1612,10 @@ export function ExploreView() {
     <>
       <div className={`${styles.page} explore-page page-width`}>
         <header className={styles.pageHeading}>
-          <p className={styles.pageEyebrow}>Programmable / Explore</p>
           <h1 aria-label="Explore programmable launches">
             <span>Explore programmable</span>
             <span>launches</span>
           </h1>
-          <p className={styles.pageDescription}>
-            Find tokens by name, model, valuation or social presence.
-          </p>
         </header>
 
         <section
@@ -1630,7 +1626,7 @@ export function ExploreView() {
           <div className={styles.runnersIntro}>
             {hasPublicTokens ? (
               <div className="token-section-heading">
-                <h2 className={styles.sectionTitle}>Launch index</h2>
+                <h2 className="sr-only">Launches</h2>
                 <div className="token-toolbar">
                   <div
                     className="token-search liquid-glass-control"

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -27,8 +27,7 @@ import {
   useLiveDataRefresh,
 } from "@/components/use-live-data-refresh";
 import { WebsiteLinkIcon } from "@/components/website-link-icon";
-import { parseDiscoverableMarketTradeCapabilityV1 } from
-  "@/lib/custom-launch/trade-capability-v1";
+import { parseDiscoverableMarketTradeCapabilityV1 } from "@/lib/custom-launch/trade-capability-v1";
 import {
   exploreValuation,
   isExploreDataQuality,
@@ -198,10 +197,7 @@ function launchBlockNumber(token: LauncherToken) {
     : 0n;
 }
 
-function comparePreviewLaunchOrder(
-  left: LauncherToken,
-  right: LauncherToken,
-) {
+function comparePreviewLaunchOrder(left: LauncherToken, right: LauncherToken) {
   const leftBlock = launchBlockNumber(left);
   const rightBlock = launchBlockNumber(right);
   if (leftBlock !== rightBlock) return leftBlock < rightBlock ? -1 : 1;
@@ -387,9 +383,13 @@ function parseLaunchCategoryProvenance(
   value: unknown,
   category: "classic" | "custom",
 ): ExploreLaunchCategoryProvenance | null {
-  if (!isRecord(value)
-    || value.schemaVersion !== "programmable.explore-launch-category-provenance.v1"
-    || value.category !== category) return null;
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !==
+      "programmable.explore-launch-category-provenance.v1" ||
+    value.category !== category
+  )
+    return null;
   if (value.source === "canonical-launch-stamp-router") {
     return isBytes32(value.launchId) &&
       isBytes32(value.stampHash) &&
@@ -402,39 +402,41 @@ function parseLaunchCategoryProvenance(
       Number(value.transactionIndex) >= 0 &&
       Number.isSafeInteger(value.logIndex) &&
       Number(value.logIndex) >= 0
-      ? value as unknown as ExploreLaunchCategoryProvenance
+      ? (value as unknown as ExploreLaunchCategoryProvenance)
       : null;
   }
   if (category === "classic") {
-    return value.source === "canonical-launch-read-model"
-      && typeof value.recordId === "string"
-      && (typeof value.modelId === "string" || value.modelId === null)
-      && (typeof value.modelVersion === "string" || value.modelVersion === null)
-      ? value as unknown as ExploreLaunchCategoryProvenance
+    return value.source === "canonical-launch-read-model" &&
+      typeof value.recordId === "string" &&
+      (typeof value.modelId === "string" || value.modelId === null) &&
+      (typeof value.modelVersion === "string" || value.modelVersion === null)
+      ? (value as unknown as ExploreLaunchCategoryProvenance)
       : null;
   }
-  const baseValid = isSha256(value.projectId)
-    && isSha256(value.launchId)
-    && isSha256(value.sourceRecordBindingHash)
-    && isSha256(value.finalizedLaunchBindingHash);
+  const baseValid =
+    isSha256(value.projectId) &&
+    isSha256(value.launchId) &&
+    isSha256(value.sourceRecordBindingHash) &&
+    isSha256(value.finalizedLaunchBindingHash);
   if (!baseValid) return null;
   if (value.source === "interface-preview") {
     return value as unknown as ExploreLaunchCategoryProvenance;
   }
-  return value.source === "registry.custom-launched"
-    && isTokenAddress(value.registryAddress)
-    && typeof value.registryStartBlock === "string"
-    && /^[1-9][0-9]*$/u.test(value.registryStartBlock)
-    && isBytes32(value.transactionHash)
-    && isBytes32(value.blockHash)
-    && typeof value.blockNumber === "string"
-    && /^[1-9][0-9]*$/u.test(value.blockNumber)
-    && Number.isSafeInteger(value.transactionIndex)
-    && Number(value.transactionIndex) >= 0
-    && Number.isSafeInteger(value.logIndex)
-    && Number(value.logIndex) >= 0
-    && isBytes32(value.configurationHash)
-    ? value as unknown as ExploreLaunchCategoryProvenance : null;
+  return value.source === "registry.custom-launched" &&
+    isTokenAddress(value.registryAddress) &&
+    typeof value.registryStartBlock === "string" &&
+    /^[1-9][0-9]*$/u.test(value.registryStartBlock) &&
+    isBytes32(value.transactionHash) &&
+    isBytes32(value.blockHash) &&
+    typeof value.blockNumber === "string" &&
+    /^[1-9][0-9]*$/u.test(value.blockNumber) &&
+    Number.isSafeInteger(value.transactionIndex) &&
+    Number(value.transactionIndex) >= 0 &&
+    Number.isSafeInteger(value.logIndex) &&
+    Number(value.logIndex) >= 0 &&
+    isBytes32(value.configurationHash)
+    ? (value as unknown as ExploreLaunchCategoryProvenance)
+    : null;
 }
 
 function isSha256(value: unknown): value is `sha256:${string}` {
@@ -442,13 +444,18 @@ function isSha256(value: unknown): value is `sha256:${string}` {
 }
 
 function parseCustomExploreAsset(value: unknown) {
-  if (!isRecord(value)
-    || typeof value.assetId !== "string"
-    || !isRecord(value.identity)
-    || typeof value.identity.namespace !== "string"
-    || typeof value.identity.value !== "string"
-    || (value.decimals !== undefined && (!Number.isSafeInteger(value.decimals)
-      || Number(value.decimals) < 0 || Number(value.decimals) > 255))) return null;
+  if (
+    !isRecord(value) ||
+    typeof value.assetId !== "string" ||
+    !isRecord(value.identity) ||
+    typeof value.identity.namespace !== "string" ||
+    typeof value.identity.value !== "string" ||
+    (value.decimals !== undefined &&
+      (!Number.isSafeInteger(value.decimals) ||
+        Number(value.decimals) < 0 ||
+        Number(value.decimals) > 255))
+  )
+    return null;
   return {
     assetId: value.assetId,
     identity: {
@@ -457,36 +464,48 @@ function parseCustomExploreAsset(value: unknown) {
     },
     ...(typeof value.name === "string" ? { name: value.name } : {}),
     ...(typeof value.symbol === "string" ? { symbol: value.symbol } : {}),
-    ...(value.decimals === undefined ? {} : { decimals: Number(value.decimals) }),
+    ...(value.decimals === undefined
+      ? {}
+      : { decimals: Number(value.decimals) }),
   };
 }
 
 function parseCustomExploreMarkets(value: unknown, chainId: string) {
   if (!Array.isArray(value) || value.length > 256) return null;
-  type CustomMarket = Extract<ExploreEntry, { exploreKind: "custom-project" }>["markets"][number];
+  type CustomMarket = Extract<
+    ExploreEntry,
+    { exploreKind: "custom-project" }
+  >["markets"][number];
   const markets: CustomMarket[] = [];
   for (const candidate of value) {
-    if (!isRecord(candidate)
-      || typeof candidate.marketId !== "string"
-      || typeof candidate.kind !== "string"
-      || !["active", "paused", "closed", "verification_pending"].includes(
+    if (
+      !isRecord(candidate) ||
+      typeof candidate.marketId !== "string" ||
+      typeof candidate.kind !== "string" ||
+      !["active", "paused", "closed", "verification_pending"].includes(
         String(candidate.status),
-      )
-      || (candidate.poolId !== undefined && !isBytes32(candidate.poolId))) return null;
+      ) ||
+      (candidate.poolId !== undefined && !isBytes32(candidate.poolId))
+    )
+      return null;
     const baseAsset = parseCustomExploreAsset(candidate.baseAsset);
     const quoteAsset = parseCustomExploreAsset(candidate.quoteAsset);
     if (baseAsset === null || quoteAsset === null) return null;
-    const capability = candidate.tradeCapability === undefined
-      ? undefined
-      : parseDiscoverableMarketTradeCapabilityV1({
-          value: candidate.tradeCapability,
-          chainId,
-          marketId: candidate.marketId,
-          baseAssetId: baseAsset.assetId,
-          quoteAssetId: quoteAsset.assetId,
-          ...(candidate.poolId === undefined ? {} : { poolId: candidate.poolId }),
-        });
-    if (candidate.tradeCapability !== undefined && capability === null) return null;
+    const capability =
+      candidate.tradeCapability === undefined
+        ? undefined
+        : parseDiscoverableMarketTradeCapabilityV1({
+            value: candidate.tradeCapability,
+            chainId,
+            marketId: candidate.marketId,
+            baseAssetId: baseAsset.assetId,
+            quoteAssetId: quoteAsset.assetId,
+            ...(candidate.poolId === undefined
+              ? {}
+              : { poolId: candidate.poolId }),
+          });
+    if (candidate.tradeCapability !== undefined && capability === null)
+      return null;
     markets.push({
       marketId: candidate.marketId,
       kind: candidate.kind,
@@ -504,50 +523,51 @@ function parseCustomExploreMarkets(value: unknown, chainId: string) {
 
 function parseCustomExploreEntry(value: unknown): ExploreEntry | null {
   const categoryProvenance = isRecord(value)
-    ? parseLaunchCategoryProvenance(
-        value.launchCategoryProvenance,
-        "custom",
-      )
+    ? parseLaunchCategoryProvenance(value.launchCategoryProvenance, "custom")
     : null;
-  if (!isRecord(value)
-    || value.exploreKind !== "custom-project"
-    || typeof value.id !== "string"
-    || typeof value.name !== "string"
-    || typeof value.launchedAt !== "string"
-    || typeof value.finalizedAt !== "string"
-    || typeof value.chainId !== "string"
-    || typeof value.modelId !== "string"
-    || !isSha256(value.customProjectId)
-    || !isSha256(value.customLaunchId)
-    || !isRecord(value.launchingWallet)
-    || typeof value.launchingWallet.namespace !== "string"
-    || typeof value.launchingWallet.value !== "string"
-    || !/^eip155:[1-9][0-9]*$/u.test(value.launchingWallet.namespace)
-    || !/^0x[0-9a-f]{40}$/u.test(value.launchingWallet.value)
-    || !isSha256(value.postLaunchAuthorityInventoryHash)
-    || !isRecord(value.postLaunchAuthorityInventory)
-    || value.postLaunchAuthorityInventory.schemaVersion
-      !== "programmable.post-launch-authority-inventory.v1"
-    || value.postLaunchAuthorityInventory.postLaunchAuthorityInventoryHash
-      !== value.postLaunchAuthorityInventoryHash
-    || value.postLaunchAuthorityInventory.githubAuthority
-      !== "provenance-only-never-post-launch-authority"
-    || !Array.isArray(value.postLaunchAuthorityInventory.postLaunchAuthorities)
-    || !Array.isArray(value.markets)
-    || !Array.isArray(value.links)
-    || categoryProvenance === null
-    || categoryProvenance.source === "canonical-launch-stamp-router"
-  ) return null;
+  if (
+    !isRecord(value) ||
+    value.exploreKind !== "custom-project" ||
+    typeof value.id !== "string" ||
+    typeof value.name !== "string" ||
+    typeof value.launchedAt !== "string" ||
+    typeof value.finalizedAt !== "string" ||
+    typeof value.chainId !== "string" ||
+    typeof value.modelId !== "string" ||
+    !isSha256(value.customProjectId) ||
+    !isSha256(value.customLaunchId) ||
+    !isRecord(value.launchingWallet) ||
+    typeof value.launchingWallet.namespace !== "string" ||
+    typeof value.launchingWallet.value !== "string" ||
+    !/^eip155:[1-9][0-9]*$/u.test(value.launchingWallet.namespace) ||
+    !/^0x[0-9a-f]{40}$/u.test(value.launchingWallet.value) ||
+    !isSha256(value.postLaunchAuthorityInventoryHash) ||
+    !isRecord(value.postLaunchAuthorityInventory) ||
+    value.postLaunchAuthorityInventory.schemaVersion !==
+      "programmable.post-launch-authority-inventory.v1" ||
+    value.postLaunchAuthorityInventory.postLaunchAuthorityInventoryHash !==
+      value.postLaunchAuthorityInventoryHash ||
+    value.postLaunchAuthorityInventory.githubAuthority !==
+      "provenance-only-never-post-launch-authority" ||
+    !Array.isArray(value.postLaunchAuthorityInventory.postLaunchAuthorities) ||
+    !Array.isArray(value.markets) ||
+    !Array.isArray(value.links) ||
+    categoryProvenance === null ||
+    categoryProvenance.source === "canonical-launch-stamp-router"
+  )
+    return null;
   const links = value.links.map(parseTokenLink);
   if (links.some((link) => link === null)) return null;
   if (value.tokenAddress !== undefined && !isTokenAddress(value.tokenAddress)) {
     return null;
   }
-  if (value.tokenDecimals !== undefined && (
-    !Number.isSafeInteger(value.tokenDecimals)
-    || Number(value.tokenDecimals) < 0
-    || Number(value.tokenDecimals) > 255
-  )) return null;
+  if (
+    value.tokenDecimals !== undefined &&
+    (!Number.isSafeInteger(value.tokenDecimals) ||
+      Number(value.tokenDecimals) < 0 ||
+      Number(value.tokenDecimals) > 255)
+  )
+    return null;
   const markets = parseCustomExploreMarkets(value.markets, value.chainId);
   if (markets === null) return null;
   return {
@@ -558,7 +578,9 @@ function parseCustomExploreEntry(value: unknown): ExploreEntry | null {
     ...(typeof value.description === "string"
       ? { description: value.description }
       : {}),
-    ...(safeImageUrl(value.imageUrl) ? { imageUrl: value.imageUrl as string } : {}),
+    ...(safeImageUrl(value.imageUrl)
+      ? { imageUrl: value.imageUrl as string }
+      : {}),
     links: links as TokenLink[],
     launchedAt: value.launchedAt,
     finalizedAt: value.finalizedAt,
@@ -576,8 +598,12 @@ function parseCustomExploreEntry(value: unknown): ExploreEntry | null {
     >["postLaunchAuthorityInventory"],
     postLaunchAuthorityInventoryHash: value.postLaunchAuthorityInventoryHash,
     markets,
-    ...(value.tokenAddress === undefined ? {} : { tokenAddress: value.tokenAddress }),
-    ...(value.tokenDecimals === undefined ? {} : { tokenDecimals: value.tokenDecimals as number }),
+    ...(value.tokenAddress === undefined
+      ? {}
+      : { tokenAddress: value.tokenAddress }),
+    ...(value.tokenDecimals === undefined
+      ? {}
+      : { tokenDecimals: value.tokenDecimals as number }),
     launchCategoryProvenance: value.launchCategoryProvenance as Extract<
       ExploreEntry,
       { exploreKind: "custom-project" }
@@ -587,16 +613,18 @@ function parseCustomExploreEntry(value: unknown): ExploreEntry | null {
 
 function parseExploreEntry(value: unknown): ValuedExploreEntry | null {
   const attachValuation = <T extends ExploreEntry>(entry: T) => {
-    const valuation = isRecord(value) && value.valuation === undefined
-      ? exploreValuation(entry)
-      : isRecord(value) && isExploreValuation(value.valuation)
-        ? value.valuation
-        : null;
-    const marketData = isRecord(value) && value.marketData !== undefined
-      ? isTokenMarketDataV1(value.marketData)
-        ? value.marketData
-        : null
-      : undefined;
+    const valuation =
+      isRecord(value) && value.valuation === undefined
+        ? exploreValuation(entry)
+        : isRecord(value) && isExploreValuation(value.valuation)
+          ? value.valuation
+          : null;
+    const marketData =
+      isRecord(value) && value.marketData !== undefined
+        ? isTokenMarketDataV1(value.marketData)
+          ? value.marketData
+          : null
+        : undefined;
     return valuation === null || marketData === null
       ? null
       : {
@@ -610,23 +638,27 @@ function parseExploreEntry(value: unknown): ValuedExploreEntry | null {
     return entry ? attachValuation(entry) : null;
   }
   const token = parseLauncherToken(value);
-  const expectedCategory = token?.launchStampProvenance?.kind === "custom-graph"
-    ? "custom"
-    : "classic";
+  const expectedCategory =
+    token?.launchStampProvenance?.kind === "custom-graph"
+      ? "custom"
+      : "classic";
   const categoryProvenance = isRecord(value)
     ? parseLaunchCategoryProvenance(
         value.launchCategoryProvenance,
         expectedCategory,
       )
     : null;
-  if (!token || !isRecord(value)
-    || value.exploreKind !== "token"
-    || categoryProvenance === null) return null;
+  if (
+    !token ||
+    !isRecord(value) ||
+    value.exploreKind !== "token" ||
+    categoryProvenance === null
+  )
+    return null;
   const stamp = token.launchStampProvenance;
   if (stamp) {
     if (
-      categoryProvenance.source !==
-        "canonical-launch-stamp-router" ||
+      categoryProvenance.source !== "canonical-launch-stamp-router" ||
       categoryProvenance.launchId.toLowerCase() !==
         stamp.launchId.toLowerCase() ||
       categoryProvenance.stampHash.toLowerCase() !==
@@ -819,10 +851,7 @@ export async function loadExploreModelDataset(
 ) {
   const firstPageSearch = new URLSearchParams(search);
   firstPageSearch.set("page", "1");
-  firstPageSearch.set(
-    "limit",
-    String(EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE),
-  );
+  firstPageSearch.set("limit", String(EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE));
   const firstPage = await loadExplorePayload(
     `${contentKey}\u0000model-page:1`,
     firstPageSearch,
@@ -855,9 +884,7 @@ export async function loadExploreModelDataset(
 
   return {
     ...firstPage,
-    tokens: [firstPage, ...remainingPages].flatMap(
-      (payload) => payload.tokens,
-    ),
+    tokens: [firstPage, ...remainingPages].flatMap((payload) => payload.tokens),
   };
 }
 
@@ -898,9 +925,7 @@ export function filterTokensByLaunchModel<T extends ExploreEntry>(
   modelFilter: ExploreModelFilter,
 ) {
   if (modelFilter === "all") return tokens;
-  return tokens.filter(
-    (token) => tokenLaunchModelGroup(token) === modelFilter,
-  );
+  return tokens.filter((token) => tokenLaunchModelGroup(token) === modelFilter);
 }
 
 export function paginateTokensByExploreFilters<T extends ExploreEntry>(
@@ -946,10 +971,8 @@ export function getExploreValuationMetric(
   token: ExploreEntry | ValuedExploreEntry,
 ): MarketCapMetric | undefined {
   const valuation = valuationForEntry(token);
-  if (
-    valuation.status !== "available" ||
-    valuation.freshness !== "current"
-  ) return undefined;
+  if (valuation.status !== "available" || valuation.freshness !== "current")
+    return undefined;
   const value = Number(BigInt(valuation.valueWad)) / 1e18;
   if (!Number.isFinite(value) || value <= 0) return undefined;
   if (valuation.currency === "usd") return { kind: "usd", value };
@@ -970,40 +993,23 @@ export function getExplorePaginationItems(
   }
 
   if (currentPage >= pageCount - 2) {
-    return [
-      1,
-      "start-gap",
-      pageCount - 2,
-      pageCount - 1,
-      pageCount,
-    ];
+    return [1, "start-gap", pageCount - 2, pageCount - 1, pageCount];
   }
 
-  return [
-    1,
-    "start-gap",
-    currentPage,
-    "end-gap",
-    pageCount,
-  ];
+  return [1, "start-gap", currentPage, "end-gap", pageCount];
 }
 
 export function tokenHasSocialLinks(
   token: Readonly<{ links?: readonly TokenLink[] }>,
 ) {
   return Boolean(
-    token.links?.some(
-      (link) => link.kind === "x" || link.kind === "telegram",
-    ),
+    token.links?.some((link) => link.kind === "x" || link.kind === "telegram"),
   );
 }
 
 export function filterTokensBySocialPresence<
   T extends Readonly<{ links?: readonly TokenLink[] }>,
->(
-  tokens: T[],
-  socialFilter: ExploreSocialFilter,
-) {
+>(tokens: T[], socialFilter: ExploreSocialFilter) {
   if (socialFilter === "all") return tokens;
   const shouldHaveSocials = socialFilter === "yes";
   return tokens.filter(
@@ -1016,7 +1022,7 @@ export function exploreTokenCardDescription(token: ExploreEntry) {
   if (description) return description;
 
   return token.exploreKind === "token" &&
-      isLaunchStampProvenanceV1(token.launchStampProvenance)
+    isLaunchStampProvenanceV1(token.launchStampProvenance)
     ? "Canonical Router stamp. v4 pool initialized."
     : undefined;
 }
@@ -1026,34 +1032,35 @@ export function getTokenCards(
 ): TokenCard[] {
   return tokens.map((token) => {
     const valuation = valuationForEntry(token);
-    return ({
-    id: token.id,
-    name: token.name,
-    description: exploreTokenCardDescription(token),
-    imageUrl:
-      token.imageUrl?.trim() || getFallbackTokenImage(
-        token.tokenAddress ?? token.id,
+    return {
+      id: token.id,
+      name: token.name,
+      description: exploreTokenCardDescription(token),
+      imageUrl:
+        token.imageUrl?.trim() ||
+        getFallbackTokenImage(token.tokenAddress ?? token.id),
+      links: [...(token.links ?? [])].sort(
+        (left, right) => tokenLinkOrder[left.kind] - tokenLinkOrder[right.kind],
       ),
-    links: [...(token.links ?? [])].sort(
-      (left, right) => tokenLinkOrder[left.kind] - tokenLinkOrder[right.kind],
-    ),
-    valuation: getExploreValuationMetric(token),
-    ...(valuation.status === "available"
-      ? {
-          valuationMetric:
-            valuation.metric === "market-cap" ? "Market cap" as const : "FDV" as const,
-        }
-      : {}),
-    marketStatus: exploreMarketStatusLabel(token),
-    usesFallbackImage: !token.imageUrl?.trim(),
-    ...(token.tokenAddress === undefined
-      ? {}
-      : { tokenAddress: token.tokenAddress }),
-    launchCategory:
-      token.launchCategoryProvenance.category === "classic"
-        ? "Classic"
-        : "Custom",
-    });
+      valuation: getExploreValuationMetric(token),
+      ...(valuation.status === "available"
+        ? {
+            valuationMetric:
+              valuation.metric === "market-cap"
+                ? ("Market cap" as const)
+                : ("FDV" as const),
+          }
+        : {}),
+      marketStatus: exploreMarketStatusLabel(token),
+      usesFallbackImage: !token.imageUrl?.trim(),
+      ...(token.tokenAddress === undefined
+        ? {}
+        : { tokenAddress: token.tokenAddress }),
+      launchCategory:
+        token.launchCategoryProvenance.category === "classic"
+          ? "Classic"
+          : "Custom",
+    };
   });
 }
 
@@ -1089,12 +1096,14 @@ function ExploreGridSkeleton() {
   return (
     <div
       className={`${styles.runnerGrid} ${styles.skeletonGrid}`}
-      aria-hidden="true"
+      role="status"
+      aria-label="Loading launches"
     >
       {exploreSkeletonItems.map((index) => (
         <article
           className={`${styles.runnerCard} ${styles.skeletonCard}`}
           key={index}
+          aria-hidden="true"
         >
           <div className={`${styles.runnerArt} ${styles.skeletonArt}`} />
           <div className={styles.skeletonBody}>
@@ -1142,8 +1151,7 @@ export function ExploreView() {
   const normalizedQuery = query.trim();
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [sort, setSort] = useState<TokenSort>("market-cap");
-  const [socialFilter, setSocialFilter] =
-    useState<ExploreSocialFilter>("all");
+  const [socialFilter, setSocialFilter] = useState<ExploreSocialFilter>("all");
   const [modelFilter, setModelFilter] = useState<ExploreModelFilter>("all");
   const [currentPage, setCurrentPage] = useState(1);
   const [retryKey, setRetryKey] = useState(0);
@@ -1326,12 +1334,7 @@ export function ExploreView() {
       }
       const leftFdv = BigInt(left.indexedMarketCapUsdWad ?? "0");
       const rightFdv = BigInt(right.indexedMarketCapUsdWad ?? "0");
-      const delta =
-        leftFdv === rightFdv
-          ? 0
-          : leftFdv > rightFdv
-            ? -1
-            : 1;
+      const delta = leftFdv === rightFdv ? 0 : leftFdv > rightFdv ? -1 : 1;
       return sort === "market-cap" ? delta : -delta;
     });
 
@@ -1360,8 +1363,7 @@ export function ExploreView() {
       }
     : state;
 
-  const payload =
-    displayState.phase === "ready" ? displayState.payload : null;
+  const payload = displayState.phase === "ready" ? displayState.payload : null;
   const cards = useMemo(
     () => getTokenCards(payload?.tokens ?? []),
     [payload?.tokens],
@@ -1393,8 +1395,7 @@ export function ExploreView() {
   function renderTokenState() {
     if (
       displayState.phase === "loading" ||
-      (displayState.phase === "error" &&
-        displayState.requestKey !== requestKey)
+      (displayState.phase === "error" && displayState.requestKey !== requestKey)
     ) {
       return (
         <div className={styles.loadingState}>
@@ -1406,12 +1407,11 @@ export function ExploreView() {
     if (displayState.phase === "error") {
       return (
         <div className={styles.messageState} role="alert">
-          <p>{displayState.message}</p>
-          <button
-            className="text-button"
-            type="button"
-            onClick={retryTokens}
-          >
+          <div className={styles.messageCopy}>
+            <h2>Couldn’t load launches</h2>
+            <p>{displayState.message}</p>
+          </div>
+          <button className="text-button" type="button" onClick={retryTokens}>
             Try again
           </button>
         </div>
@@ -1422,8 +1422,8 @@ export function ExploreView() {
       return (
         <div className={`${styles.emptyState} liquid-glass-surface`}>
           <div>
-            <h2>Token index unavailable</h2>
-            <p>Explore is not available in this environment.</p>
+            <h2>Explore is getting ready</h2>
+            <p>The launch index is not available in this environment yet.</p>
           </div>
         </div>
       );
@@ -1434,8 +1434,11 @@ export function ExploreView() {
         return (
           <div className={`${styles.emptyState} liquid-glass-surface`}>
             <div>
-              <h2>Launches temporarily unavailable</h2>
-              <p>Try again in a moment.</p>
+              <h2>Launches are catching up</h2>
+              <p>
+                Some launches are temporarily unavailable. Try again in a
+                moment.
+              </p>
             </div>
             <button
               className={styles.emptyAction}
@@ -1447,13 +1450,8 @@ export function ExploreView() {
           </div>
         );
       }
-      if (
-        debouncedQuery ||
-        socialFilter !== "all" ||
-        modelFilter !== "all"
-      ) {
-        const hasActiveFilter =
-          socialFilter !== "all" || modelFilter !== "all";
+      if (debouncedQuery || socialFilter !== "all" || modelFilter !== "all") {
+        const hasActiveFilter = socialFilter !== "all" || modelFilter !== "all";
         const noMatchMessage = debouncedQuery
           ? hasActiveFilter
             ? "No tokens match this search and filters"
@@ -1461,7 +1459,10 @@ export function ExploreView() {
           : "No tokens match these filters";
         return (
           <div className={styles.messageState}>
-            <p>{noMatchMessage}</p>
+            <div className={styles.messageCopy}>
+              <h2>No matching launches</h2>
+              <p>{noMatchMessage}</p>
+            </div>
             <button
               className="text-button"
               type="button"
@@ -1482,11 +1483,11 @@ export function ExploreView() {
       return (
         <div className={`${styles.emptyState} liquid-glass-surface`}>
           <div>
-            <h2>No tokens yet</h2>
-            <p>Create the first token.</p>
+            <h2>No launches yet</h2>
+            <p>Be the first to launch a token and it will appear here.</p>
           </div>
           <Link className={styles.emptyAction} href="/launch">
-            Create token
+            Start a launch
           </Link>
         </div>
       );
@@ -1533,10 +1534,7 @@ export function ExploreView() {
           );
 
           return (
-            <article
-              className={styles.runnerCard}
-              key={token.id}
-            >
+            <article className={styles.runnerCard} key={token.id}>
               {href ? (
                 <Link
                   className={styles.runnerHitArea}
@@ -1614,12 +1612,13 @@ export function ExploreView() {
     <>
       <div className={`${styles.page} explore-page page-width`}>
         <header className={styles.pageHeading}>
-          <h1 aria-label="Tokens that behave how you imagine">
-            <span>Tokens that behave</span>
-            <span>how you imagine</span>
+          <p className={styles.pageEyebrow}>Programmable / Explore</p>
+          <h1 aria-label="Explore programmable launches">
+            <span>Explore programmable</span>
+            <span>launches</span>
           </h1>
           <p className={styles.pageDescription}>
-            Browse launches by model, valuation or social presence.
+            Find tokens by name, model, valuation or social presence.
           </p>
         </header>
 
@@ -1631,7 +1630,7 @@ export function ExploreView() {
           <div className={styles.runnersIntro}>
             {hasPublicTokens ? (
               <div className="token-section-heading">
-                <h2 className="sr-only">Tokens</h2>
+                <h2 className={styles.sectionTitle}>Launch index</h2>
                 <div className="token-toolbar">
                   <div
                     className="token-search liquid-glass-control"
@@ -1639,7 +1638,7 @@ export function ExploreView() {
                   >
                     <Search aria-hidden="true" size={17} />
                     <label className="sr-only" htmlFor="explore-token-search">
-                      Search tokens by name, ticker or contract address
+                      Search by name, symbol or contract address
                     </label>
                     <input
                       ref={searchInputRef}
@@ -1648,7 +1647,7 @@ export function ExploreView() {
                       autoComplete="off"
                       spellCheck={false}
                       value={query}
-                      placeholder="Search tokens"
+                      placeholder="Search by name, symbol or contract address"
                       onChange={(event) => setQuery(event.target.value)}
                     />
                     {query ? (
@@ -1760,9 +1759,7 @@ export function ExploreView() {
                           <button
                             key={option.id}
                             className={
-                              socialFilter === option.id
-                                ? "active"
-                                : undefined
+                              socialFilter === option.id ? "active" : undefined
                             }
                             type="button"
                             aria-pressed={socialFilter === option.id}
@@ -1823,13 +1820,13 @@ export function ExploreView() {
                   pageCount > 1 ? (
                     <nav
                       className="token-pagination liquid-glass-control"
-                      aria-label="Token pages"
+                      aria-label="Launch pages"
                     >
                       <button
                         type="button"
-                        aria-label="Previous token page"
+                        aria-label="Previous launch page"
                         aria-disabled={activePage === 1 || busy}
-                        disabled={activePage === 1}
+                        disabled={activePage === 1 || busy}
                         onClick={() => {
                           if (busy) return;
                           setCurrentPage((page) => Math.max(1, page - 1));
@@ -1847,11 +1844,12 @@ export function ExploreView() {
                                 activePage === item ? "active" : undefined
                               }
                               type="button"
-                              aria-label={`Token page ${item}`}
+                              aria-label={`Launch page ${item}`}
                               aria-current={
                                 activePage === item ? "page" : undefined
                               }
                               aria-disabled={busy}
+                              disabled={busy}
                               onClick={() => {
                                 if (busy) return;
                                 setCurrentPage(item);
@@ -1869,14 +1867,14 @@ export function ExploreView() {
 
                       <button
                         type="button"
-                        aria-label="Next token page"
+                        aria-label="Next launch page"
                         aria-disabled={activePage === pageCount || busy}
-                        disabled={activePage === pageCount}
+                        disabled={activePage === pageCount || busy}
                         onClick={() => {
                           if (busy) return;
                           setCurrentPage((page) =>
                             Math.min(pageCount, page + 1),
-                          )
+                          );
                         }}
                       >
                         <ChevronRight aria-hidden="true" size={15} />
@@ -1911,10 +1909,7 @@ export function ExploreView() {
                   ? "Prices may be out of date"
                   : dataQualityMessage}
               </span>
-              <button
-                type="button"
-                onClick={retryTokens}
-              >
+              <button type="button" onClick={retryTokens}>
                 Refresh
               </button>
             </div>

--- a/components/hookathon-page.module.css
+++ b/components/hookathon-page.module.css
@@ -37,11 +37,17 @@
 .eligibility,
 .judging {
   align-items: center;
-  border-top: 1px solid var(--panel-border-soft);
   display: flex;
   flex-direction: column;
   justify-content: center;
   text-align: center;
+}
+
+/* Let breathing room carry section hierarchy; the page does not need rules
+ * cutting across the night field between each content block. */
+.eligibility,
+.judging {
+  margin-block-start: clamp(20px, 3vw, 32px);
 }
 
 .prizes {

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -41,7 +41,7 @@
   height: min(82svh, 780px);
   isolation: isolate;
   min-height: 0;
-  overflow: hidden;
+  overflow: visible;
   position: relative;
   width: 100%;
   -webkit-backdrop-filter: blur(28px) saturate(1.12);
@@ -49,13 +49,13 @@
 }
 
 .panel::after {
-  border: 1px solid rgba(248, 240, 233, 0.1);
+  border: 1px solid rgba(248, 240, 233, 0.25);
   border-radius: inherit;
   content: "";
-  inset: 8px;
+  inset: 10px;
   pointer-events: none;
   position: absolute;
-  z-index: 4;
+  z-index: 7;
 }
 
 .panelArt,
@@ -67,8 +67,14 @@
 }
 
 .panelArt {
+  border-radius: inherit;
   overflow: hidden;
   z-index: 0;
+}
+
+.panelTint {
+  border-radius: inherit;
+  overflow: hidden;
 }
 
 .panelPicture {
@@ -80,9 +86,9 @@
 .panelArt::after {
   background: linear-gradient(
     90deg,
-    rgba(1, 1, 3, 0.2),
-    rgba(1, 1, 3, 0.08) 58%,
-    rgba(1, 1, 3, 0.14)
+    rgba(1, 1, 3, 0.34),
+    rgba(1, 1, 3, 0.18) 58%,
+    rgba(1, 1, 3, 0.28)
   );
   content: "";
   inset: 0;
@@ -90,7 +96,7 @@
 }
 
 .panelArt img {
-  filter: blur(5px) saturate(0.96) brightness(0.9);
+  filter: blur(1.5px) saturate(0.88) brightness(0.78);
   object-fit: cover;
   object-position: center 55%;
   opacity: 0.9;
@@ -118,21 +124,21 @@
   filter: saturate(0.92) brightness(0.88);
   height: auto;
   max-width: none;
-  opacity: 0.62;
+  opacity: 0.7;
   pointer-events: none;
   position: absolute;
-  width: clamp(200px, 28vw, 380px);
-  z-index: 2;
+  width: clamp(240px, 30vw, 420px);
+  z-index: 5;
 }
 
 .flowerLeft {
-  left: -7%;
+  left: -14%;
   transform: rotate(-8deg);
   transform-origin: 54% 100%;
 }
 
 .flowerRight {
-  right: -8%;
+  right: -15%;
   transform: scaleX(-1) rotate(-9deg);
   transform-origin: 54% 100%;
 }
@@ -142,20 +148,19 @@
 .panelBody,
 .footer {
   position: relative;
-  z-index: 2;
+  z-index: 6;
 }
 
 .panelBody,
 .footer {
-  z-index: 3;
+  z-index: 6;
 }
 
 .panelHeader {
   align-items: center;
-  display: grid;
+  display: flex;
   flex: 0 0 auto;
-  gap: 16px;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  justify-content: flex-start;
   min-height: 88px;
   padding-inline: clamp(20px, 4.6vw, 72px);
 }
@@ -169,7 +174,6 @@
 
 .brandLink {
   color: var(--ivory);
-  gap: 12px;
   justify-self: start;
   min-height: 44px;
 }
@@ -300,15 +304,24 @@
   min-width: 0;
 }
 
+.heroCopy {
+  justify-self: center;
+  text-align: center;
+  width: min(100%, 1040px);
+}
+
 .hero h1 {
   color: #fffdfb;
+  display: block;
   font-size: clamp(58px, 7.2vw, 108px);
   font-weight: 560;
   letter-spacing: -0.075em;
   line-height: 0.9;
-  max-width: 700px;
+  margin: 0;
+  max-width: none;
   text-shadow: 0 2px 28px rgba(4, 2, 12, 0.22);
   text-wrap: balance;
+  width: 100%;
 }
 
 /* Compatibility keeps the old centered headline contract available while the
@@ -327,21 +340,17 @@
 }
 
 .heroCopy h1 {
-  align-items: flex-start;
+  align-items: center;
+  display: block;
+  max-width: none;
+  width: 100%;
 }
 
 .heroCopy h1 span {
+  display: block;
   margin-inline: 0;
-  text-align: start;
-  width: auto;
-}
-
-.heroCopy h1 span:nth-child(2) {
-  margin-inline-start: clamp(48px, 8vw, 140px);
-}
-
-.heroCopy h1 span:nth-child(3) {
-  margin-inline-start: clamp(16px, 3vw, 48px);
+  text-align: center;
+  width: 100%;
 }
 
 .actions {
@@ -349,6 +358,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+  justify-content: center;
   margin-top: 34px;
 }
 
@@ -392,10 +402,10 @@
 }
 
 .footer {
-  border-top: 1px solid var(--line);
+  border-top: 1px solid rgba(248, 240, 233, 0.28);
   flex: 0 0 auto;
   gap: 20px;
-  justify-content: flex-end;
+  justify-content: center;
   margin-inline: clamp(20px, 4.6vw, 72px);
   min-height: 58px;
   padding-block: 7px max(7px, env(safe-area-inset-bottom));
@@ -415,7 +425,10 @@
   align-items: center;
   color: var(--ivory-dim);
   display: flex;
-  gap: 2px;
+  gap: 4px;
+  justify-content: center;
+  position: relative;
+  width: 100%;
 }
 
 .footerIcons svg {
@@ -436,6 +449,8 @@
 .docsLink {
   font-size: 17px;
   min-height: 44px;
+  position: absolute;
+  right: 0;
 }
 
 .socialLink {
@@ -481,23 +496,7 @@
 
 @media (max-width: 1000px) {
   .panelHeader {
-    grid-template-columns: minmax(0, 1fr) auto;
-  }
-
-  .segmentedNav {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    justify-self: center;
-    margin-bottom: 12px;
-    order: 3;
-  }
-
-  .panelHeader {
     padding-block: 12px;
-  }
-
-  .panelRule {
-    margin-top: 44px;
   }
 
   .panelBody {
@@ -516,51 +515,14 @@
     padding-block: 8px;
   }
 
-  .panelRule {
-    margin-top: 0;
-  }
-
-  .segmentedNav {
-    grid-column: 2;
-    grid-row: 1;
-    margin: 0;
-    order: initial;
-  }
-
-  .segmentedNav a {
-    font-size: 12px;
-    min-height: 36px;
-    padding-inline: 11px;
-  }
-
-  .headerAction {
-    font-size: 0;
-    gap: 0;
-    min-width: 42px;
-    padding-inline: 11px;
-  }
-
-  .headerAction > span {
-    font-size: 17px;
-  }
-
-  .panelHeader {
-    gap: 8px;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
-
-  .segmentedNav {
-    justify-self: center;
-  }
-
   .panelBody {
     align-content: center;
     display: flex;
     flex-direction: column;
     gap: 22px;
-    justify-content: flex-start;
-    overflow: hidden;
-    padding: clamp(56px, 10vh, 82px) clamp(20px, 6vw, 42px) 14px;
+    justify-content: center;
+    overflow: visible;
+    padding: 24px 16px 14px;
   }
 
   .scene {
@@ -576,17 +538,17 @@
 
   .flowerLeft,
   .flowerRight {
-    bottom: -10%;
-    opacity: 0.48;
-    width: 50vw;
+    bottom: -9%;
+    opacity: 0.58;
+    width: 56vw;
   }
 
   .flowerLeft {
-    left: -25%;
+    left: -34%;
   }
 
   .flowerRight {
-    right: -25%;
+    right: -34%;
   }
 
   .heroCopy {
@@ -594,29 +556,31 @@
   }
 
   .hero h1 {
-    font-size: clamp(48px, 13.8vw, 70px);
-    line-height: 0.92;
-  }
-
-  .heroCopy h1 span:nth-child(2),
-  .heroCopy h1 span:nth-child(3) {
-    margin-inline-start: 0;
+    font-size: clamp(32px, 9.2vw, 44px);
+    line-height: 0.96;
   }
 
   .content h1 span,
   .heroCopy h1 span {
-    white-space: normal;
+    margin-inline: auto;
+    max-width: none;
+    white-space: nowrap;
+    width: max-content;
   }
 
   .actions {
     gap: 8px;
     margin-top: 20px;
+    width: 100%;
   }
 
   .primaryAction,
   .secondaryAction {
+    flex: 1 1 0;
+    font-size: 14px;
     min-height: 44px;
-    padding-block: 10px;
+    min-width: 0;
+    padding: 10px 14px;
   }
 
   .footer {
@@ -626,7 +590,7 @@
   }
 
   .footerIcons {
-    justify-content: flex-end;
+    justify-content: center;
   }
 }
 
@@ -635,26 +599,25 @@
     display: none;
   }
 
-  .segmentedNav a {
-    padding-inline: 8px;
-  }
-
-  .headerAction {
-    min-width: 38px;
-    padding-inline: 8px;
-  }
-
   .panelBody {
     gap: 16px;
-    padding-top: 20px;
+    padding: 16px 12px 10px;
   }
 
   .hero h1 {
-    font-size: clamp(44px, 13.2vw, 58px);
+    font-size: clamp(27px, 8.8vw, 32px);
   }
 
   .actions {
+    align-items: stretch;
+    flex-direction: column;
     margin-top: 14px;
+  }
+
+  .primaryAction,
+  .secondaryAction {
+    flex: 0 0 auto;
+    width: 100%;
   }
 }
 
@@ -724,17 +687,19 @@
     transform: scale(1.08);
   }
 
-  .headerAction,
-  .segmentedNav a,
   .primaryAction,
   .secondaryAction,
   .footer a {
     transition: none;
   }
 
-  .headerAction:hover,
   .primaryAction:hover,
   .secondaryAction:hover {
+    transform: none;
+  }
+
+  .flowerLeft,
+  .flowerRight {
     transform: none;
   }
 }

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -23,14 +23,14 @@
   display: grid;
   height: 100%;
   min-height: 0;
-  padding-block: max(16px, env(safe-area-inset-top))
-    max(16px, env(safe-area-inset-bottom));
-  padding-inline: max(12px, env(safe-area-inset-left))
-    max(12px, env(safe-area-inset-right));
+  padding-block: max(clamp(32px, 7vh, 72px), env(safe-area-inset-top))
+    max(clamp(32px, 7vh, 72px), env(safe-area-inset-bottom));
+  padding-inline: max(clamp(28px, 8vw, 128px), env(safe-area-inset-left))
+    max(clamp(28px, 8vw, 128px), env(safe-area-inset-right));
 }
 
 .panel {
-  background: rgba(18, 12, 29, 0.32);
+  background: rgba(8, 5, 18, 0.18);
   border: 1px solid rgba(248, 240, 233, 0.32);
   border-radius: clamp(20px, 2.2vw, 32px);
   box-shadow:
@@ -38,14 +38,14 @@
     0 24px 80px rgba(0, 0, 0, 0.34);
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: min(82svh, 780px);
   isolation: isolate;
   min-height: 0;
   overflow: hidden;
   position: relative;
   width: 100%;
-  -webkit-backdrop-filter: blur(24px) saturate(1.14);
-  backdrop-filter: blur(24px) saturate(1.14);
+  -webkit-backdrop-filter: blur(28px) saturate(1.12);
+  backdrop-filter: blur(28px) saturate(1.12);
 }
 
 .panel::after {
@@ -71,35 +71,57 @@
   z-index: 0;
 }
 
+.panelPicture {
+  display: block;
+  inset: 0;
+  position: absolute;
+}
+
 .panelArt::after {
-  background: rgba(4, 3, 13, 0.22);
+  background: linear-gradient(
+    90deg,
+    rgba(1, 1, 3, 0.2),
+    rgba(1, 1, 3, 0.08) 58%,
+    rgba(1, 1, 3, 0.14)
+  );
   content: "";
   inset: 0;
   position: absolute;
 }
 
 .panelArt img {
-  filter: blur(7px) saturate(0.96) brightness(0.9);
+  filter: blur(5px) saturate(0.96) brightness(0.9);
   object-fit: cover;
   object-position: center 55%;
+  opacity: 0.9;
   transform: scale(1.08);
 }
 
 .panelTint {
-  background: rgba(89, 39, 78, 0.12);
+  background:
+    radial-gradient(
+      circle at 22% 78%,
+      rgba(198, 102, 156, 0.12),
+      transparent 32%
+    ),
+    radial-gradient(
+      circle at 78% 48%,
+      rgba(119, 91, 177, 0.12),
+      transparent 34%
+    );
   z-index: 1;
 }
 
 .flowerLeft,
 .flowerRight {
-  bottom: -28%;
+  bottom: -18%;
   filter: saturate(0.92) brightness(0.88);
   height: auto;
   max-width: none;
-  opacity: 0.82;
+  opacity: 0.62;
   pointer-events: none;
   position: absolute;
-  width: clamp(180px, 25vw, 360px);
+  width: clamp(200px, 28vw, 380px);
   z-index: 2;
 }
 
@@ -118,14 +140,12 @@
 .panelHeader,
 .panelRule,
 .panelBody,
-.panelBottom,
 .footer {
   position: relative;
   z-index: 2;
 }
 
 .panelBody,
-.panelBottom,
 .footer {
   z-index: 3;
 }
@@ -142,8 +162,7 @@
 
 .brandLink,
 .primaryNav,
-.footer,
-.footerLinks {
+.footer {
   align-items: center;
   display: flex;
 }
@@ -247,8 +266,7 @@
 
 .headerAction span,
 .primaryAction > span,
-.secondaryAction > span,
-.quickCard > span:last-child {
+.secondaryAction > span {
   color: var(--pink);
 }
 
@@ -262,50 +280,29 @@
   min-height: 100svh;
 }
 
+.panelBody.hero {
+  min-height: 0;
+}
+
 .panelBody {
   align-items: center;
   display: grid;
   flex: 1 1 auto;
-  gap: clamp(28px, 6vw, 96px);
-  grid-template-columns: minmax(0, 1.26fr) minmax(240px, 0.74fr);
+  grid-template-columns: minmax(0, 1fr);
   min-height: 0;
-  padding: clamp(30px, 5vw, 72px) clamp(28px, 6.4vw, 104px)
-    clamp(20px, 3vw, 42px);
+  padding: clamp(24px, 4vw, 56px) clamp(28px, 6.4vw, 104px)
+    clamp(18px, 2.5vw, 32px);
 }
 
 .heroCopy,
 .content {
-  max-width: 720px;
+  max-width: 800px;
   min-width: 0;
-}
-
-.kicker,
-.asideLabel,
-.bottomNote,
-.signal dt,
-.quickCard > span:first-child {
-  color: var(--pink);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  letter-spacing: 0.1em;
-  line-height: 1.4;
-  text-transform: uppercase;
-}
-
-.kicker {
-  align-items: center;
-  display: flex;
-  gap: 8px;
-  margin-bottom: 24px;
-}
-
-.kicker > span {
-  font-size: 15px;
 }
 
 .hero h1 {
   color: #fffdfb;
-  font-size: clamp(56px, 7.1vw, 108px);
+  font-size: clamp(58px, 7.2vw, 108px);
   font-weight: 560;
   letter-spacing: -0.075em;
   line-height: 0.9;
@@ -340,21 +337,11 @@
 }
 
 .heroCopy h1 span:nth-child(2) {
-  margin-inline-start: clamp(24px, 4vw, 76px);
+  margin-inline-start: clamp(48px, 8vw, 140px);
 }
 
 .heroCopy h1 span:nth-child(3) {
-  margin-inline-start: clamp(8px, 1.7vw, 28px);
-}
-
-.heroLead {
-  color: var(--ivory-soft);
-  font-size: clamp(16px, 1.4vw, 19px);
-  letter-spacing: -0.012em;
-  line-height: 1.45;
-  margin-top: 28px;
-  max-width: 46ch;
-  text-wrap: pretty;
+  margin-inline-start: clamp(16px, 3vw, 48px);
 }
 
 .actions {
@@ -362,7 +349,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  margin-top: 28px;
+  margin-top: 34px;
 }
 
 .primaryAction,
@@ -404,189 +391,17 @@
   transform: translateY(-2px);
 }
 
-.heroNote {
-  color: var(--ivory-dim);
-  font-size: 13px;
-  margin-top: 18px;
-}
-
-.heroNote > span {
-  color: var(--pink);
-  margin-right: 6px;
-}
-
-.heroAside {
-  align-self: end;
-  border-inline-start: 1px solid var(--line-strong);
-  max-width: 350px;
-  padding-inline-start: clamp(20px, 2.5vw, 34px);
-}
-
-.asideLabel {
-  color: var(--ivory);
-  font-size: 13px;
-  letter-spacing: 0.07em;
-}
-
-.asideCopy {
-  color: var(--ivory-soft);
-  font-size: clamp(16px, 1.55vw, 21px);
-  line-height: 1.34;
-  margin-top: 14px;
-  max-width: 26ch;
-  text-wrap: pretty;
-}
-
-.signalList {
-  margin: 32px 0 0;
-}
-
-.signal {
-  align-items: center;
-  border-top: 1px solid var(--line);
-  display: grid;
-  gap: 14px;
-  grid-template-columns: 30px minmax(0, 1fr);
-  padding-block: 12px;
-}
-
-.signal:last-child {
-  border-bottom: 1px solid var(--line);
-}
-
-.signal dt {
-  color: var(--pink);
-  font-size: 10px;
-}
-
-.signal dd {
-  margin: 0;
-}
-
-.signal a {
-  align-items: baseline;
-  color: var(--ivory);
-  display: flex;
-  gap: 9px;
-  justify-content: space-between;
-  min-height: 24px;
-  transition: color 180ms var(--ease-standard);
-}
-
-.signal a:hover {
-  color: #fffaf5;
-}
-
-.signal strong {
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-}
-
-.signal a span {
-  color: var(--ivory-dim);
-  font-size: 11px;
-  text-align: end;
-}
-
-.panelBottom {
-  align-items: end;
-  display: grid;
-  flex: 0 0 auto;
-  gap: 24px;
-  grid-template-columns: minmax(140px, 0.7fr) minmax(0, 1.3fr);
-  padding: 0 clamp(28px, 6.4vw, 104px) 18px;
-}
-
-.bottomNote {
-  color: var(--ivory-dim);
-  font-size: 10px;
-  letter-spacing: 0.08em;
-}
-
-.bottomNote span {
-  color: var(--pink);
-  padding-inline: 3px;
-}
-
-.quickLinks {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.quickCard {
-  align-items: center;
-  background: rgba(8, 5, 16, 0.26);
-  border: 1px solid var(--line);
-  border-radius: 16px;
-  color: var(--ivory);
-  display: grid;
-  gap: 5px 12px;
-  grid-template-columns: minmax(0, 1fr) auto;
-  min-height: 74px;
-  padding: 13px 16px;
-  transition:
-    background 180ms var(--ease-standard),
-    border-color 180ms var(--ease-standard),
-    transform 180ms var(--ease-standard);
-}
-
-.quickCard:hover {
-  background: rgba(248, 240, 233, 0.12);
-  border-color: var(--line-strong);
-  transform: translateY(-2px);
-}
-
-.quickCard > span:first-child {
-  grid-column: 1 / -1;
-  font-size: 10px;
-}
-
-.quickCard strong {
-  font-size: 18px;
-  font-weight: 550;
-  letter-spacing: -0.035em;
-}
-
-.quickCard > span:last-child {
-  font-size: 18px;
-}
-
 .footer {
   border-top: 1px solid var(--line);
   flex: 0 0 auto;
   gap: 20px;
-  justify-content: space-between;
+  justify-content: flex-end;
   margin-inline: clamp(20px, 4.6vw, 72px);
   min-height: 58px;
   padding-block: 7px max(7px, env(safe-area-inset-bottom));
 }
 
-.footerBrand {
-  align-items: center;
-  color: var(--ivory);
-  display: inline-flex;
-  font-size: 13px;
-  font-weight: 600;
-  min-height: 44px;
-}
-
-.footerBrand span {
-  color: var(--ivory-dim);
-  font-size: 10px;
-  margin-left: 4px;
-  vertical-align: top;
-}
-
-.footerLinks {
-  flex-wrap: wrap;
-  gap: 8px 18px;
-  justify-content: center;
-}
-
-.primaryNav a,
-.footerLinks a {
+.primaryNav a {
   align-items: center;
   color: var(--ivory-soft);
   display: inline-flex;
@@ -594,10 +409,6 @@
   min-height: 44px;
   transition: color 180ms var(--ease-standard);
   white-space: nowrap;
-}
-
-.footerLinks a:hover {
-  color: var(--ivory);
 }
 
 .footerIcons {
@@ -612,8 +423,7 @@
   width: 16px;
 }
 
-.socialLink,
-.docsLink {
+.socialLink {
   align-items: center;
   color: var(--ivory-dim);
   display: inline-flex;
@@ -622,13 +432,15 @@
   padding: 8px;
 }
 
+/* Retained as a compatibility hook for shared landing-page contracts. */
+.docsLink {
+  font-size: 17px;
+  min-height: 44px;
+}
+
 .socialLink {
   height: 44px;
   width: 44px;
-}
-
-.docsLink {
-  font-size: 17px;
 }
 
 .socialLink svg,
@@ -662,8 +474,6 @@
 .primaryNav a:focus-visible,
 .primaryAction:focus-visible,
 .secondaryAction:focus-visible,
-.signal a:focus-visible,
-.quickCard:focus-visible,
 .footer a:focus-visible {
   outline: 2px solid var(--landing-ivory);
   outline-offset: 4px;
@@ -691,32 +501,12 @@
   }
 
   .panelBody {
-    gap: 28px;
-    grid-template-columns: minmax(0, 1.1fr) minmax(210px, 0.9fr);
+    grid-template-columns: minmax(0, 1fr);
     padding-inline: clamp(22px, 4vw, 48px);
   }
 
   .hero h1 {
     font-size: clamp(50px, 7.4vw, 78px);
-  }
-
-  .heroAside {
-    padding-inline-start: 22px;
-  }
-
-  .signal a {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .signal a span {
-    text-align: start;
-  }
-
-  .panelBottom {
-    gap: 16px;
-    padding-inline: clamp(22px, 4vw, 48px);
   }
 }
 
@@ -768,32 +558,39 @@
     display: flex;
     flex-direction: column;
     gap: 22px;
-    justify-content: center;
+    justify-content: flex-start;
     overflow: hidden;
-    padding: 26px clamp(20px, 6vw, 42px) 14px;
+    padding: clamp(56px, 10vh, 82px) clamp(20px, 6vw, 42px) 14px;
+  }
+
+  .scene {
+    padding-block: max(24px, env(safe-area-inset-top))
+      max(24px, env(safe-area-inset-bottom));
+    padding-inline: max(18px, env(safe-area-inset-left))
+      max(18px, env(safe-area-inset-right));
+  }
+
+  .panel {
+    height: calc(100% - 48px);
   }
 
   .flowerLeft,
   .flowerRight {
-    bottom: -36%;
-    opacity: 0.7;
-    width: 42vw;
+    bottom: -10%;
+    opacity: 0.48;
+    width: 50vw;
   }
 
   .flowerLeft {
-    left: -18%;
+    left: -25%;
   }
 
   .flowerRight {
-    right: -19%;
+    right: -25%;
   }
 
   .heroCopy {
     align-self: stretch;
-  }
-
-  .kicker {
-    margin-bottom: 16px;
   }
 
   .hero h1 {
@@ -811,12 +608,6 @@
     white-space: normal;
   }
 
-  .heroLead {
-    font-size: 16px;
-    margin-top: 18px;
-    max-width: 34ch;
-  }
-
   .actions {
     gap: 8px;
     margin-top: 20px;
@@ -828,97 +619,14 @@
     padding-block: 10px;
   }
 
-  .heroNote {
-    font-size: 12px;
-    margin-top: 12px;
-  }
-
-  .heroAside {
-    align-self: stretch;
-    border-inline-start: 0;
-    border-top: 1px solid var(--line-strong);
-    max-width: none;
-    padding-inline-start: 0;
-    padding-top: 14px;
-  }
-
-  .asideLabel {
-    font-size: 11px;
-  }
-
-  .asideCopy {
-    font-size: 14px;
-    line-height: 1.35;
-    margin-top: 6px;
-    max-width: 38ch;
-  }
-
-  .signalList {
-    display: grid;
-    gap: 8px;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    margin-top: 12px;
-  }
-
-  .signal,
-  .signal:last-child {
-    align-items: start;
-    border: 1px solid var(--line);
-    border-radius: 12px;
-    display: block;
-    padding: 9px 8px;
-  }
-
-  .signal a {
-    display: flex;
-    gap: 2px;
-    min-height: 0;
-  }
-
-  .signal strong {
-    font-size: 12px;
-  }
-
-  .signal a span {
-    font-size: 10px;
-  }
-
-  .panelBottom {
-    display: block;
-    padding: 0 clamp(20px, 6vw, 42px) 10px;
-  }
-
-  .quickLinks {
-    display: none;
-  }
-
-  .bottomNote {
-    font-size: 9px;
-  }
-
   .footer {
     align-items: center;
-    display: grid;
-    gap: 0 10px;
-    grid-template-columns: minmax(0, 1fr) auto;
     margin-inline: clamp(20px, 6vw, 42px);
     min-height: 58px;
   }
 
-  .footerLinks {
-    gap: 6px;
-    justify-content: end;
-  }
-
-  .footerLinks a {
-    font-size: 12px;
-    min-height: 44px;
-  }
-
   .footerIcons {
-    grid-column: 1 / -1;
-    justify-content: flex-start;
-    margin-inline-start: -8px;
+    justify-content: flex-end;
   }
 }
 
@@ -945,38 +653,8 @@
     font-size: clamp(44px, 13.2vw, 58px);
   }
 
-  .heroLead {
-    font-size: 14px;
-    margin-top: 14px;
-  }
-
   .actions {
     margin-top: 14px;
-  }
-
-  .heroNote {
-    display: none;
-  }
-
-  .asideCopy {
-    font-size: 13px;
-  }
-
-  .signalList {
-    margin-top: 8px;
-  }
-
-  .signal,
-  .signal:last-child {
-    padding: 7px 6px;
-  }
-
-  .signal strong {
-    font-size: 11px;
-  }
-
-  .signal a span {
-    font-size: 9px;
   }
 }
 
@@ -1000,25 +678,8 @@
     font-size: clamp(48px, 6.5vw, 78px);
   }
 
-  .heroLead {
-    margin-top: 18px;
-  }
-
   .actions {
     margin-top: 18px;
-  }
-
-  .signalList {
-    margin-top: 18px;
-  }
-
-  .panelBottom {
-    padding-bottom: 10px;
-  }
-
-  .quickCard {
-    min-height: 60px;
-    padding-block: 9px;
   }
 
   .footer {
@@ -1026,8 +687,7 @@
   }
 
   .socialLink,
-  .footerBrand,
-  .footerLinks a {
+  .footer a {
     min-height: 40px;
   }
 
@@ -1049,14 +709,6 @@
     padding-block: 18px 10px;
   }
 
-  .heroAside {
-    display: none;
-  }
-
-  .panelBottom {
-    padding-bottom: 4px;
-  }
-
   .footer {
     min-height: 48px;
   }
@@ -1076,16 +728,13 @@
   .segmentedNav a,
   .primaryAction,
   .secondaryAction,
-  .signal a,
-  .quickCard,
-  .footerLinks a {
+  .footer a {
     transition: none;
   }
 
   .headerAction:hover,
   .primaryAction:hover,
-  .secondaryAction:hover,
-  .quickCard:hover {
+  .secondaryAction:hover {
     transform: none;
   }
 }

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -1,266 +1,590 @@
 .page {
   --landing-ivory: #f8f0e9;
-
-  color: var(--landing-ivory);
+  --ivory: #f8f0e9;
+  --ivory-soft: rgba(248, 240, 233, 0.7);
+  --ivory-dim: rgba(248, 240, 233, 0.58);
+  --line: rgba(248, 240, 233, 0.16);
+  --pink: #e786b2;
+  background: transparent;
+  color: var(--ivory);
   isolation: isolate;
   min-height: 100svh;
-  overflow: hidden;
+  overflow-x: clip;
+  overflow-y: visible;
   position: relative;
+  z-index: 1;
 }
 
-.brandLink {
+.topbar {
   align-items: center;
-  border-radius: 16px;
-  cursor: pointer;
-  display: inline-flex;
-  height: 56px;
-  justify-content: center;
-  left: max(24px, env(safe-area-inset-left));
+  display: flex;
+  justify-content: space-between;
+  left: 0;
+  padding-block-end: 24px;
+  padding-block-start: max(24px, env(safe-area-inset-top));
+  padding-inline-end: max(clamp(20px, 4vw, 64px), env(safe-area-inset-right));
+  padding-inline-start: max(clamp(20px, 4vw, 64px), env(safe-area-inset-left));
   position: absolute;
-  top: max(24px, env(safe-area-inset-top));
-  transition:
-    opacity 160ms cubic-bezier(0.23, 1, 0.32, 1),
-    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
-  width: 48px;
-  z-index: 2;
+  right: 0;
+  top: 0;
+  z-index: 3;
 }
-
+.brandLink,
+.primaryNav,
+.footer,
+.footerLinks {
+  align-items: center;
+  display: flex;
+}
+.brandLink {
+  color: var(--ivory);
+  gap: 12px;
+  min-height: 44px;
+}
+.brandLink span {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
 .brandLogo {
   display: block;
-  height: 44px;
-  width: auto;
+  height: 34px;
+  object-fit: contain;
+  width: 28px;
 }
-
-.brandLink:focus-visible {
-  outline: 3px solid var(--landing-ivory);
-  outline-offset: 4px;
+.primaryNav {
+  gap: clamp(16px, 3vw, 36px);
 }
-
-.hero {
+.primaryNav a,
+.footerLinks a {
   align-items: center;
-  display: flex;
-  justify-content: center;
-  min-height: 100svh;
-  padding: 128px 24px 88px;
-  text-align: center;
-}
-
-.content {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  margin-top: -4px;
-  max-width: 1040px;
-  width: 100%;
-}
-
-.content h1 {
-  align-items: center;
-  color: var(--landing-ivory);
-  display: flex;
-  flex-direction: column;
-  font-size: clamp(60px, 8vw, 128px);
-  font-weight: 430;
-  letter-spacing: -0.052em;
-  line-height: 0.94;
-  margin: 0;
-  width: min(100%, 1040px);
-  text-shadow: 0 3px 36px rgba(1, 5, 20, 0.32);
-  text-wrap: balance;
-}
-
-.content h1 span {
-  display: block;
-  margin-inline: auto;
-  text-align: center;
-  width: max-content;
+  color: var(--ivory-soft);
+  display: inline-flex;
+  font-size: 14px;
+  min-height: 44px;
+  transition:
+    color 180ms ease,
+    opacity 180ms ease;
   white-space: nowrap;
 }
-
+.primaryNav a:hover,
+.footerLinks a:hover,
+.textLink:hover {
+  color: var(--ivory);
+}
+.navAction {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ivory) !important;
+  padding: 10px 15px;
+}
+.navAction span,
+.primaryAction > span,
+.textLink span,
+.modelAction span {
+  color: var(--pink);
+  margin-left: 5px;
+}
+.hero {
+  align-items: center;
+  display: grid;
+  gap: clamp(48px, 8vw, 128px);
+  grid-template-columns: minmax(0, 1.03fr) minmax(330px, 0.97fr);
+  margin: 0 auto;
+  max-width: 1320px;
+  min-height: 100svh;
+  padding: 136px clamp(20px, 7vw, 112px) 104px;
+}
+.heroCopy,
+.content {
+  max-width: 610px;
+}
+.kicker,
+.sectionLabel,
+.modelEyebrow {
+  color: var(--pink);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.11em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+.kicker {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+.kicker span {
+  font-size: 16px;
+}
+.hero h1 {
+  font-size: clamp(56px, 7.2vw, 108px);
+  font-weight: 560;
+  letter-spacing: -0.065em;
+  line-height: 0.94;
+  max-width: 650px;
+  text-wrap: balance;
+}
+.content h1 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+.heroLead {
+  color: var(--ivory-soft);
+  font-size: clamp(18px, 1.7vw, 22px);
+  letter-spacing: -0.015em;
+  line-height: 1.4;
+  margin-top: 28px;
+  max-width: 520px;
+  text-wrap: pretty;
+}
 .actions {
   align-items: center;
   display: flex;
-  gap: 24px;
-  justify-content: center;
+  flex-wrap: wrap;
+  gap: 12px;
   margin-top: 32px;
 }
-
 .primaryAction,
 .secondaryAction {
   align-items: center;
-  background: transparent;
-  border: 0;
-  box-sizing: border-box;
-  color: rgba(248, 240, 233, 0.76);
+  border-radius: 999px;
   cursor: pointer;
   display: inline-flex;
-  font-size: 17px;
-  font-weight: 520;
+  font-size: 16px;
+  font-weight: 600;
   justify-content: center;
-  letter-spacing: -0.01em;
-  line-height: 1.25;
-  min-height: 44px;
-  padding: 8px 10px;
-  text-decoration: none;
+  min-height: 48px;
+  padding: 12px 20px;
   transition:
-    color 180ms cubic-bezier(0.23, 1, 0.32, 1),
-    text-shadow 180ms cubic-bezier(0.23, 1, 0.32, 1),
-    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+    background 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
 }
-
-.primaryAction:focus-visible,
-.secondaryAction:focus-visible {
-  outline: 2px solid var(--landing-ivory);
-  outline-offset: 4px;
+.primaryAction {
+  background: var(--ivory);
+  color: #13121a;
 }
-
-.supportingLinks {
-  align-items: center;
+.primaryAction:hover {
+  background: #fffaf5;
+  transform: translateY(-2px);
+}
+.secondaryAction {
+  border: 1px solid var(--line);
+  color: var(--ivory-soft);
+}
+.secondaryAction:hover {
+  border-color: rgba(248, 240, 233, 0.42);
+  color: var(--ivory);
+  transform: translateY(-2px);
+}
+.heroNote {
+  color: var(--ivory-dim);
+  font-size: 13px;
+  margin-top: 20px;
+}
+.heroVisual {
+  justify-self: end;
+  margin: 0;
+  max-width: 480px;
+  width: 100%;
+}
+.visualFrame {
+  aspect-ratio: 0.88;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  overflow: hidden;
+  position: relative;
+}
+.visualFrame::after {
+  background: linear-gradient(
+    180deg,
+    rgba(8, 9, 18, 0.08) 22%,
+    rgba(8, 9, 18, 0.82) 100%
+  );
+  content: "";
+  inset: 0;
+  position: absolute;
+}
+.visualFrame img {
+  object-fit: cover;
+}
+.visualOverlay {
+  bottom: 0;
   display: flex;
-  gap: 4px;
-  justify-content: center;
-  margin-top: 32px;
+  flex-direction: column;
+  gap: 8px;
+  left: 0;
+  padding: 24px;
+  position: absolute;
+  right: 0;
+  z-index: 1;
 }
-
+.visualOverlay span {
+  color: rgba(248, 240, 233, 0.78);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+.visualOverlay strong {
+  font-size: clamp(36px, 4vw, 58px);
+  font-weight: 550;
+  letter-spacing: -0.06em;
+}
+.visualCaption {
+  color: var(--ivory-dim);
+  display: block;
+  font-size: 12px;
+  margin-top: 12px;
+}
+.intro,
+.models,
+.principles,
+.finalCta {
+  margin: 0 auto;
+  max-width: 1190px;
+  padding: 120px clamp(20px, 5vw, 76px);
+}
+.intro {
+  border-top: 1px solid var(--line);
+}
+.introGrid {
+  display: grid;
+  gap: 40px;
+  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
+  margin-top: 24px;
+}
+.intro h2,
+.sectionHeading h2,
+.principles h2,
+.finalCta h2 {
+  font-size: clamp(38px, 5vw, 68px);
+  font-weight: 540;
+  letter-spacing: -0.06em;
+  line-height: 0.98;
+  text-wrap: balance;
+}
+.introGrid > p {
+  color: var(--ivory-soft);
+  font-size: 18px;
+  line-height: 1.5;
+  max-width: 370px;
+}
+.models {
+  padding-top: 80px;
+}
+.sectionHeading {
+  align-items: end;
+  display: flex;
+  justify-content: space-between;
+}
+.sectionHeading h2 {
+  margin-top: 14px;
+}
+.textLink {
+  color: var(--ivory-soft);
+  font-size: 14px;
+  padding: 12px 0;
+  transition: color 180ms ease;
+}
+.modelGrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(3, 1fr);
+  margin-top: 36px;
+}
+.modelCard {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  color: var(--ivory);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease;
+}
+.modelCard:hover {
+  border-color: rgba(248, 240, 233, 0.42);
+  transform: translateY(-4px);
+}
+.modelArt {
+  aspect-ratio: 1.55;
+  overflow: hidden;
+  position: relative;
+}
+.modelArt img {
+  object-fit: cover;
+  transition: transform 500ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.modelCard:hover .modelArt img {
+  transform: scale(1.04);
+}
+.modelIndex {
+  color: var(--ivory);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 11px;
+  left: 16px;
+  position: absolute;
+  top: 16px;
+}
+.modelBody {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: 22px 20px 20px;
+}
+.modelBody h3 {
+  font-size: 30px;
+  font-weight: 540;
+  letter-spacing: -0.045em;
+  margin-top: 8px;
+}
+.modelBody > p:not(.modelEyebrow) {
+  color: var(--ivory-soft);
+  font-size: 14px;
+  line-height: 1.48;
+  margin-top: 12px;
+}
+.modelAction {
+  color: var(--ivory);
+  font-size: 13px;
+  margin-top: auto;
+  padding-top: 26px;
+}
+.principles {
+  align-items: start;
+  border-bottom: 1px solid var(--line);
+  border-top: 1px solid var(--line);
+  display: grid;
+  gap: 30px;
+  grid-template-columns: 1fr 2.2fr 1fr;
+}
+.principlesMark {
+  color: var(--pink);
+  font-size: 74px;
+  line-height: 0.7;
+}
+.principles h2 {
+  font-size: clamp(42px, 5.8vw, 78px);
+}
+.principlesCopy {
+  color: var(--ivory-soft);
+  font-size: 16px;
+  line-height: 1.5;
+  max-width: 250px;
+}
+.finalCta {
+  padding-bottom: 150px;
+  padding-top: 148px;
+  text-align: center;
+}
+.finalCta .sectionLabel {
+  margin-bottom: 20px;
+}
+.finalCta h2 {
+  font-size: clamp(52px, 7.6vw, 104px);
+}
+.finalCta .primaryAction {
+  margin-top: 34px;
+}
+.footer {
+  border-top: 1px solid var(--line);
+  gap: 24px;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: 1190px;
+  padding-block-end: max(34px, env(safe-area-inset-bottom));
+  padding-block-start: 26px;
+  padding-inline-end: max(clamp(20px, 5vw, 76px), env(safe-area-inset-right));
+  padding-inline-start: max(clamp(20px, 5vw, 76px), env(safe-area-inset-left));
+}
+.footerBrand {
+  color: var(--ivory);
+  font-size: 14px;
+  font-weight: 600;
+}
+.footerBrand span {
+  color: var(--ivory-dim);
+  font-size: 10px;
+  margin-left: 4px;
+  vertical-align: top;
+}
+.footerLinks {
+  flex-wrap: wrap;
+  gap: 16px 22px;
+  justify-content: center;
+}
+.footerIcons {
+  align-items: center;
+  color: var(--ivory-dim);
+  display: flex;
+  gap: 2px;
+}
+.footerIcons svg {
+  height: 16px;
+  width: 16px;
+}
 .socialLink,
 .docsLink {
   align-items: center;
-  color: rgba(248, 240, 233, 0.76);
-  cursor: pointer;
+  color: var(--ivory-dim);
   display: inline-flex;
   justify-content: center;
-  transition:
-    color 160ms cubic-bezier(0.23, 1, 0.32, 1),
-    opacity 160ms cubic-bezier(0.23, 1, 0.32, 1),
-    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  min-height: 44px;
+  padding: 8px;
 }
-
 .socialLink {
   height: 44px;
   width: 44px;
 }
-
+.docsLink {
+  font-size: 17px;
+}
 .socialLink svg,
 .socialLogo {
   display: block;
   height: 28px;
   width: 28px;
 }
-
 .socialLogo {
-  opacity: 0.78;
+  opacity: 0.76;
+  object-fit: contain;
 }
-
-.utilityDivider {
-  background: rgba(248, 240, 233, 0.22);
-  height: 16px;
-  margin-inline: 4px;
+.srOnly {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
   width: 1px;
 }
-
-.docsLink {
-  font-size: 17px;
-  font-weight: 500;
-  letter-spacing: -0.01em;
-  line-height: 1.25;
-  min-height: 44px;
-  padding-inline: 8px;
-  white-space: nowrap;
-}
-
-.socialLink:focus-visible,
-.docsLink:focus-visible {
-  box-shadow: 0 0 0 5px rgba(7, 17, 47, 0.96);
+.brandLink:focus-visible,
+.primaryNav a:focus-visible,
+.primaryAction:focus-visible,
+.secondaryAction:focus-visible,
+.modelCard:focus-visible,
+.textLink:focus-visible,
+.footer a:focus-visible {
   outline: 2px solid var(--landing-ivory);
-  outline-offset: 2px;
+  outline-offset: 4px;
 }
 
-:global(.app-frame:has(.landing-page-root) > main) {
-  padding-bottom: 0;
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .brandLink:hover {
-    opacity: 0.84;
-    transform: translateY(-1px);
+@media (max-width: 820px) {
+  .topbar {
+    padding-inline-end: max(20px, env(safe-area-inset-right));
+    padding-inline-start: max(20px, env(safe-area-inset-left));
   }
-
-  .primaryAction:hover,
-  .secondaryAction:hover {
-    color: var(--landing-ivory);
-    text-shadow: 0 0 18px rgba(248, 240, 233, 0.28);
-    transform: translateY(-1px);
-  }
-
-  .socialLink:hover,
-  .docsLink:hover {
-    color: var(--landing-ivory);
-    transform: translateY(-1px);
-  }
-
-  .socialLink:hover .socialLogo {
-    opacity: 1;
-  }
-}
-
-.primaryAction:active,
-.secondaryAction:active,
-.brandLink:active,
-.socialLink:active,
-.docsLink:active {
-  transform: scale(0.96);
-}
-
-@media (max-width: 800px) {
-  .hero {
-    padding: 116px 20px 88px;
-  }
-
-  .content {
-    margin-top: -12px;
-  }
-
-  .content h1 {
-    font-size: clamp(48px, 15vw, 72px);
-    letter-spacing: -0.045em;
-    line-height: 0.96;
-    max-width: 600px;
-  }
-
-  .actions {
-    margin-top: 24px;
-  }
-}
-
-@media (max-width: 460px) {
-  .brandLink {
-    height: 48px;
-    left: max(16px, env(safe-area-inset-left));
-    top: max(16px, env(safe-area-inset-top));
-    width: 40px;
-  }
-
-  .brandLogo {
-    height: 38px;
-  }
-
-  .hero {
-    padding-inline: 16px;
-  }
-
-  .content h1 {
-    font-size: clamp(36px, 11vw, 48px);
-    letter-spacing: -0.035em;
-    line-height: 0.98;
-  }
-
-  .actions {
+  .primaryNav {
     gap: 16px;
   }
+  .primaryNav a:nth-child(2) {
+    display: none;
+  }
+  .hero {
+    gap: 48px;
+    grid-template-columns: 1fr;
+    padding-top: 128px;
+  }
+  .heroCopy {
+    max-width: 640px;
+  }
+  .heroVisual {
+    justify-self: start;
+    max-width: 520px;
+  }
+  .introGrid,
+  .principles {
+    grid-template-columns: 1fr;
+  }
+  .introGrid {
+    gap: 20px;
+  }
+  .introGrid > p {
+    max-width: 520px;
+  }
+  .modelGrid {
+    grid-template-columns: 1fr;
+  }
+  .modelCard {
+    display: grid;
+    grid-template-columns: minmax(180px, 0.8fr) 1.2fr;
+  }
+  .modelArt {
+    aspect-ratio: auto;
+    min-height: 230px;
+  }
+  .principlesMark {
+    font-size: 56px;
+  }
+  .principlesCopy {
+    max-width: 440px;
+  }
+  .footer {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+  .footerIcons {
+    margin-left: auto;
+  }
+}
 
+@media (max-width: 520px) {
+  .brandLink span {
+    display: none;
+  }
+  .hero {
+    min-height: auto;
+    padding-bottom: 88px;
+  }
+  .hero h1 {
+    font-size: clamp(52px, 16vw, 76px);
+  }
+  .heroLead {
+    font-size: 17px;
+  }
+  .actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
   .primaryAction,
   .secondaryAction {
-    padding-inline: 6px;
+    width: 100%;
+  }
+  .intro,
+  .models,
+  .principles,
+  .finalCta {
+    padding-bottom: 88px;
+    padding-top: 88px;
+  }
+  .sectionHeading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 18px;
+  }
+  .modelCard {
+    display: flex;
+  }
+  .modelArt {
+    aspect-ratio: 1.55;
+    min-height: 220px;
+  }
+  .finalCta {
+    padding-bottom: 112px;
+  }
+  .footer {
+    flex-direction: column;
+    gap: 20px;
+  }
+  .footerIcons {
+    margin-left: 0;
   }
 }
 
@@ -268,43 +592,22 @@
   .supportingLinks {
     gap: 0;
   }
-
-  .utilityDivider {
-    margin-inline: 0;
-  }
-
-  .docsLink {
-    padding-inline: 4px;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .primaryAction,
   .secondaryAction,
-  .brandLink,
-  .socialLink,
-  .docsLink {
-    transition:
-      color 160ms ease,
-      opacity 160ms ease,
-      text-shadow 160ms ease;
+  .primaryNav a,
+  .footerLinks a,
+  .textLink,
+  .modelCard,
+  .modelArt img {
+    transition: none;
   }
-
-  .primaryAction:active,
-  .secondaryAction:active,
-  .brandLink:active,
-  .socialLink:active,
-  .docsLink:active {
-    transform: none;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) and (hover: hover) and (pointer: fine) {
   .primaryAction:hover,
   .secondaryAction:hover,
-  .brandLink:hover,
-  .socialLink:hover,
-  .docsLink:hover {
+  .modelCard:hover,
+  .modelCard:hover .modelArt img {
     transform: none;
   }
 }

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -30,12 +30,14 @@
 }
 
 .panel {
-  background: rgba(8, 5, 18, 0.18);
-  border: 1px solid rgba(248, 240, 233, 0.32);
+  background: rgba(8, 5, 18, 0.3);
+  border: 0;
   border-radius: clamp(20px, 2.2vw, 32px);
   box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.16) inset,
-    0 24px 80px rgba(0, 0, 0, 0.34);
+    inset 0 0 86px rgba(181, 109, 208, 0.12),
+    inset 0 -42px 110px rgba(4, 2, 15, 0.28),
+    0 28px 90px rgba(0, 0, 0, 0.52),
+    0 10px 46px rgba(116, 64, 156, 0.12);
   display: flex;
   flex-direction: column;
   height: min(82svh, 780px);
@@ -49,13 +51,7 @@
 }
 
 .panel::after {
-  border: 1px solid rgba(248, 240, 233, 0.25);
-  border-radius: inherit;
-  content: "";
-  inset: 10px;
-  pointer-events: none;
-  position: absolute;
-  z-index: 7;
+  display: none;
 }
 
 .panelArt,
@@ -105,14 +101,20 @@
 
 .panelTint {
   background:
+    linear-gradient(
+      180deg,
+      rgba(4, 2, 15, 0.12),
+      rgba(8, 3, 20, 0.02) 42%,
+      rgba(4, 2, 15, 0.28)
+    ),
     radial-gradient(
       circle at 22% 78%,
-      rgba(198, 102, 156, 0.12),
+      rgba(198, 102, 156, 0.18),
       transparent 32%
     ),
     radial-gradient(
       circle at 78% 48%,
-      rgba(119, 91, 177, 0.12),
+      rgba(119, 91, 177, 0.16),
       transparent 34%
     );
   z-index: 1;
@@ -133,13 +135,13 @@
 
 .flowerLeft {
   left: -14%;
-  transform: rotate(-8deg);
+  transform: translate3d(-2%, 2%, 0) rotate(-14deg);
   transform-origin: 54% 100%;
 }
 
 .flowerRight {
   right: -15%;
-  transform: scaleX(-1) rotate(-9deg);
+  transform: translate3d(2%, 2%, 0) scaleX(-1) rotate(13deg);
   transform-origin: 54% 100%;
 }
 
@@ -275,9 +277,7 @@
 }
 
 .panelRule {
-  background: rgba(248, 240, 233, 0.22);
-  flex: 0 0 1px;
-  margin-inline: clamp(20px, 4.6vw, 72px);
+  display: none;
 }
 
 .hero {
@@ -315,7 +315,7 @@
   display: block;
   font-size: clamp(58px, 7.2vw, 108px);
   font-weight: 560;
-  letter-spacing: -0.075em;
+  letter-spacing: -0.045em;
   line-height: 0.9;
   margin: 0;
   max-width: none;
@@ -365,44 +365,41 @@
 .primaryAction,
 .secondaryAction {
   align-items: center;
-  border-radius: 999px;
   cursor: pointer;
   display: inline-flex;
   font-size: 16px;
   font-weight: 600;
   justify-content: center;
-  min-height: 48px;
-  padding: 12px 20px;
+  min-height: 44px;
+  padding: 10px 6px;
   transition:
-    background 180ms var(--ease-standard),
-    border-color 180ms var(--ease-standard),
     color 180ms var(--ease-standard),
+    filter 180ms var(--ease-standard),
     transform 180ms var(--ease-standard);
 }
 
 .primaryAction {
-  background: var(--ivory);
-  color: #17101b;
-}
-
-.primaryAction:hover {
-  background: #fffaf5;
-  transform: translateY(-2px);
-}
-
-.secondaryAction {
-  border: 1px solid var(--line-strong);
   color: var(--ivory);
 }
 
+.primaryAction:hover {
+  color: #fffaf5;
+  filter: drop-shadow(0 0 12px rgba(231, 134, 178, 0.34));
+  transform: translateY(-1px);
+}
+
+.secondaryAction {
+  color: var(--ivory-soft);
+}
+
 .secondaryAction:hover {
-  background: rgba(248, 240, 233, 0.12);
-  border-color: rgba(248, 240, 233, 0.52);
-  transform: translateY(-2px);
+  color: var(--ivory);
+  filter: drop-shadow(0 0 12px rgba(231, 134, 178, 0.22));
+  transform: translateY(-1px);
 }
 
 .footer {
-  border-top: 1px solid rgba(248, 240, 233, 0.28);
+  border-top: 0;
   flex: 0 0 auto;
   gap: 20px;
   justify-content: center;
@@ -441,8 +438,12 @@
   color: var(--ivory-dim);
   display: inline-flex;
   justify-content: center;
-  min-height: 44px;
-  padding: 8px;
+  min-height: 48px;
+  padding: 6px;
+  transition:
+    color 180ms var(--ease-standard),
+    filter 180ms var(--ease-standard),
+    transform 180ms var(--ease-standard);
 }
 
 /* Retained as a compatibility hook for shared landing-page contracts. */
@@ -454,20 +455,26 @@
 }
 
 .socialLink {
-  height: 44px;
-  width: 44px;
+  height: 48px;
+  width: 48px;
 }
 
 .socialLink svg,
 .socialLogo {
   display: block;
-  height: 28px;
-  width: 28px;
+  height: 32px;
+  width: 32px;
 }
 
 .socialLogo {
-  opacity: 0.76;
+  opacity: 0.88;
   object-fit: contain;
+}
+
+.socialLink:hover {
+  color: var(--ivory);
+  filter: drop-shadow(0 0 11px rgba(231, 134, 178, 0.38));
+  transform: translateY(-2px);
 }
 
 .srOnly {
@@ -557,6 +564,7 @@
 
   .hero h1 {
     font-size: clamp(32px, 9.2vw, 44px);
+    letter-spacing: -0.04em;
     line-height: 0.96;
   }
 
@@ -655,8 +663,14 @@
   }
 
   .socialLink {
-    height: 40px;
-    width: 40px;
+    height: 44px;
+    width: 44px;
+  }
+
+  .socialLink svg,
+  .socialLogo {
+    height: 28px;
+    width: 28px;
   }
 }
 
@@ -698,8 +712,7 @@
     transform: none;
   }
 
-  .flowerLeft,
-  .flowerRight {
+  .socialLink:hover {
     transform: none;
   }
 }

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -1,34 +1,145 @@
 .page {
   --landing-ivory: #f8f0e9;
   --ivory: #f8f0e9;
-  --ivory-soft: rgba(248, 240, 233, 0.7);
-  --ivory-dim: rgba(248, 240, 233, 0.58);
-  --line: rgba(248, 240, 233, 0.16);
+  --ivory-soft: rgba(248, 240, 233, 0.78);
+  --ivory-dim: rgba(248, 240, 233, 0.62);
+  --line: rgba(248, 240, 233, 0.2);
+  --line-strong: rgba(248, 240, 233, 0.34);
   --pink: #e786b2;
   background: transparent;
   color: var(--ivory);
+  height: 100svh;
   isolation: isolate;
   min-height: 100svh;
   overflow-x: clip;
-  overflow-y: visible;
+  overflow-y: hidden;
   position: relative;
+  width: 100%;
   z-index: 1;
 }
 
-.topbar {
+.scene {
   align-items: center;
+  display: grid;
+  height: 100%;
+  min-height: 0;
+  padding-block: max(16px, env(safe-area-inset-top))
+    max(16px, env(safe-area-inset-bottom));
+  padding-inline: max(12px, env(safe-area-inset-left))
+    max(12px, env(safe-area-inset-right));
+}
+
+.panel {
+  background: rgba(18, 12, 29, 0.32);
+  border: 1px solid rgba(248, 240, 233, 0.32);
+  border-radius: clamp(20px, 2.2vw, 32px);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.16) inset,
+    0 24px 80px rgba(0, 0, 0, 0.34);
   display: flex;
-  justify-content: space-between;
-  left: 0;
-  padding-block-end: 24px;
-  padding-block-start: max(24px, env(safe-area-inset-top));
-  padding-inline-end: max(clamp(20px, 4vw, 64px), env(safe-area-inset-right));
-  padding-inline-start: max(clamp(20px, 4vw, 64px), env(safe-area-inset-left));
+  flex-direction: column;
+  height: 100%;
+  isolation: isolate;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+  -webkit-backdrop-filter: blur(24px) saturate(1.14);
+  backdrop-filter: blur(24px) saturate(1.14);
+}
+
+.panel::after {
+  border: 1px solid rgba(248, 240, 233, 0.1);
+  border-radius: inherit;
+  content: "";
+  inset: 8px;
+  pointer-events: none;
   position: absolute;
-  right: 0;
-  top: 0;
+  z-index: 4;
+}
+
+.panelArt,
+.panelTint {
+  border: 0;
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.panelArt {
+  overflow: hidden;
+  z-index: 0;
+}
+
+.panelArt::after {
+  background: rgba(4, 3, 13, 0.22);
+  content: "";
+  inset: 0;
+  position: absolute;
+}
+
+.panelArt img {
+  filter: blur(7px) saturate(0.96) brightness(0.9);
+  object-fit: cover;
+  object-position: center 55%;
+  transform: scale(1.08);
+}
+
+.panelTint {
+  background: rgba(89, 39, 78, 0.12);
+  z-index: 1;
+}
+
+.flowerLeft,
+.flowerRight {
+  bottom: -28%;
+  filter: saturate(0.92) brightness(0.88);
+  height: auto;
+  max-width: none;
+  opacity: 0.82;
+  pointer-events: none;
+  position: absolute;
+  width: clamp(180px, 25vw, 360px);
+  z-index: 2;
+}
+
+.flowerLeft {
+  left: -7%;
+  transform: rotate(-8deg);
+  transform-origin: 54% 100%;
+}
+
+.flowerRight {
+  right: -8%;
+  transform: scaleX(-1) rotate(-9deg);
+  transform-origin: 54% 100%;
+}
+
+.panelHeader,
+.panelRule,
+.panelBody,
+.panelBottom,
+.footer {
+  position: relative;
+  z-index: 2;
+}
+
+.panelBody,
+.panelBottom,
+.footer {
   z-index: 3;
 }
+
+.panelHeader {
+  align-items: center;
+  display: grid;
+  flex: 0 0 auto;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  min-height: 88px;
+  padding-inline: clamp(20px, 4.6vw, 72px);
+}
+
 .brandLink,
 .primaryNav,
 .footer,
@@ -36,117 +147,224 @@
   align-items: center;
   display: flex;
 }
+
 .brandLink {
   color: var(--ivory);
   gap: 12px;
+  justify-self: start;
   min-height: 44px;
 }
+
 .brandLink span {
   font-size: 15px;
   font-weight: 600;
   letter-spacing: -0.02em;
 }
+
 .brandLogo {
   display: block;
   height: 34px;
   object-fit: contain;
   width: 28px;
 }
+
+.segmentedNav,
 .primaryNav {
-  gap: clamp(16px, 3vw, 36px);
+  align-items: center;
+  display: flex;
+  gap: 2px;
 }
-.primaryNav a,
-.footerLinks a {
+
+.segmentedNav {
+  background: rgba(248, 240, 233, 0.14);
+  border: 1px solid rgba(248, 240, 233, 0.25);
+  border-radius: 999px;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.12) inset;
+  padding: 3px;
+}
+
+.segmentedNav a,
+.primaryNav a {
   align-items: center;
   color: var(--ivory-soft);
   display: inline-flex;
-  font-size: 14px;
-  min-height: 44px;
+  font-size: 13px;
+  justify-content: center;
+  min-height: 40px;
+  padding: 8px 17px;
   transition:
-    color 180ms ease,
-    opacity 180ms ease;
+    background 180ms var(--ease-standard),
+    color 180ms var(--ease-standard),
+    transform 180ms var(--ease-standard);
   white-space: nowrap;
 }
-.primaryNav a:hover,
-.footerLinks a:hover,
-.textLink:hover {
+
+.segmentedNav a {
+  border-radius: 999px;
+}
+
+.segmentedNav a:hover,
+.segmentedNav a:focus-visible {
   color: var(--ivory);
 }
-.navAction {
-  border: 1px solid var(--line);
+
+.segmentedNav a:hover {
+  background: rgba(248, 240, 233, 0.12);
+}
+
+.segmentedNav .segmentedActive {
+  background: rgba(248, 240, 233, 0.28);
+  color: #fffaf5;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.25) inset,
+    0 4px 14px rgba(6, 3, 15, 0.16);
+}
+
+.headerAction {
+  align-items: center;
+  background: rgba(248, 240, 233, 0.16);
+  border: 1px solid rgba(248, 240, 233, 0.3);
   border-radius: 999px;
-  color: var(--ivory) !important;
-  padding: 10px 15px;
+  color: var(--ivory);
+  display: inline-flex;
+  font-size: 13px;
+  gap: 6px;
+  justify-self: end;
+  min-height: 44px;
+  padding: 9px 17px;
+  transition:
+    background 180ms var(--ease-standard),
+    border-color 180ms var(--ease-standard),
+    transform 180ms var(--ease-standard);
+  white-space: nowrap;
 }
-.navAction span,
+
+.headerAction:hover {
+  background: rgba(248, 240, 233, 0.25);
+  border-color: rgba(248, 240, 233, 0.48);
+  transform: translateY(-1px);
+}
+
+.headerAction span,
 .primaryAction > span,
-.textLink span,
-.modelAction span {
+.secondaryAction > span,
+.quickCard > span:last-child {
   color: var(--pink);
-  margin-left: 5px;
 }
+
+.panelRule {
+  background: rgba(248, 240, 233, 0.22);
+  flex: 0 0 1px;
+  margin-inline: clamp(20px, 4.6vw, 72px);
+}
+
 .hero {
+  min-height: 100svh;
+}
+
+.panelBody {
   align-items: center;
   display: grid;
-  gap: clamp(48px, 8vw, 128px);
-  grid-template-columns: minmax(0, 1.03fr) minmax(330px, 0.97fr);
-  margin: 0 auto;
-  max-width: 1320px;
-  min-height: 100svh;
-  padding: 136px clamp(20px, 7vw, 112px) 104px;
+  flex: 1 1 auto;
+  gap: clamp(28px, 6vw, 96px);
+  grid-template-columns: minmax(0, 1.26fr) minmax(240px, 0.74fr);
+  min-height: 0;
+  padding: clamp(30px, 5vw, 72px) clamp(28px, 6.4vw, 104px)
+    clamp(20px, 3vw, 42px);
 }
+
 .heroCopy,
 .content {
-  max-width: 610px;
+  max-width: 720px;
+  min-width: 0;
 }
+
 .kicker,
-.sectionLabel,
-.modelEyebrow {
+.asideLabel,
+.bottomNote,
+.signal dt,
+.quickCard > span:first-child {
   color: var(--pink);
   font-family: var(--font-plex-mono), monospace;
   font-size: 11px;
-  letter-spacing: 0.11em;
+  letter-spacing: 0.1em;
   line-height: 1.4;
   text-transform: uppercase;
 }
+
 .kicker {
   align-items: center;
   display: flex;
   gap: 8px;
   margin-bottom: 24px;
 }
-.kicker span {
-  font-size: 16px;
+
+.kicker > span {
+  font-size: 15px;
 }
+
 .hero h1 {
-  font-size: clamp(56px, 7.2vw, 108px);
+  color: #fffdfb;
+  font-size: clamp(56px, 7.1vw, 108px);
   font-weight: 560;
-  letter-spacing: -0.065em;
-  line-height: 0.94;
-  max-width: 650px;
+  letter-spacing: -0.075em;
+  line-height: 0.9;
+  max-width: 700px;
+  text-shadow: 0 2px 28px rgba(4, 2, 12, 0.22);
   text-wrap: balance;
 }
+
+/* Compatibility keeps the old centered headline contract available while the
+ * new hero composes each line against the glass panel's left edge. */
 .content h1 {
   align-items: center;
   display: flex;
   flex-direction: column;
 }
+
+.content h1 span {
+  margin-inline: auto;
+  text-align: center;
+  white-space: nowrap;
+  width: max-content;
+}
+
+.heroCopy h1 {
+  align-items: flex-start;
+}
+
+.heroCopy h1 span {
+  margin-inline: 0;
+  text-align: start;
+  width: auto;
+}
+
+.heroCopy h1 span:nth-child(2) {
+  margin-inline-start: clamp(24px, 4vw, 76px);
+}
+
+.heroCopy h1 span:nth-child(3) {
+  margin-inline-start: clamp(8px, 1.7vw, 28px);
+}
+
 .heroLead {
   color: var(--ivory-soft);
-  font-size: clamp(18px, 1.7vw, 22px);
-  letter-spacing: -0.015em;
-  line-height: 1.4;
+  font-size: clamp(16px, 1.4vw, 19px);
+  letter-spacing: -0.012em;
+  line-height: 1.45;
   margin-top: 28px;
-  max-width: 520px;
+  max-width: 46ch;
   text-wrap: pretty;
 }
+
 .actions {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  margin-top: 32px;
+  margin-top: 28px;
 }
+
 .primaryAction,
 .secondaryAction {
   align-items: center;
@@ -159,274 +377,241 @@
   min-height: 48px;
   padding: 12px 20px;
   transition:
-    background 180ms ease,
-    color 180ms ease,
-    transform 180ms ease;
+    background 180ms var(--ease-standard),
+    border-color 180ms var(--ease-standard),
+    color 180ms var(--ease-standard),
+    transform 180ms var(--ease-standard);
 }
+
 .primaryAction {
   background: var(--ivory);
-  color: #13121a;
+  color: #17101b;
 }
+
 .primaryAction:hover {
   background: #fffaf5;
   transform: translateY(-2px);
 }
+
 .secondaryAction {
-  border: 1px solid var(--line);
-  color: var(--ivory-soft);
-}
-.secondaryAction:hover {
-  border-color: rgba(248, 240, 233, 0.42);
+  border: 1px solid var(--line-strong);
   color: var(--ivory);
+}
+
+.secondaryAction:hover {
+  background: rgba(248, 240, 233, 0.12);
+  border-color: rgba(248, 240, 233, 0.52);
   transform: translateY(-2px);
 }
+
 .heroNote {
   color: var(--ivory-dim);
   font-size: 13px;
-  margin-top: 20px;
+  margin-top: 18px;
 }
-.heroVisual {
-  justify-self: end;
-  margin: 0;
-  max-width: 480px;
-  width: 100%;
+
+.heroNote > span {
+  color: var(--pink);
+  margin-right: 6px;
 }
-.visualFrame {
-  aspect-ratio: 0.88;
-  border: 1px solid var(--line);
-  border-radius: 24px;
-  overflow: hidden;
-  position: relative;
+
+.heroAside {
+  align-self: end;
+  border-inline-start: 1px solid var(--line-strong);
+  max-width: 350px;
+  padding-inline-start: clamp(20px, 2.5vw, 34px);
 }
-.visualFrame::after {
-  background: linear-gradient(
-    180deg,
-    rgba(8, 9, 18, 0.08) 22%,
-    rgba(8, 9, 18, 0.82) 100%
-  );
-  content: "";
-  inset: 0;
-  position: absolute;
-}
-.visualFrame img {
-  object-fit: cover;
-}
-.visualOverlay {
-  bottom: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  left: 0;
-  padding: 24px;
-  position: absolute;
-  right: 0;
-  z-index: 1;
-}
-.visualOverlay span {
-  color: rgba(248, 240, 233, 0.78);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-}
-.visualOverlay strong {
-  font-size: clamp(36px, 4vw, 58px);
-  font-weight: 550;
-  letter-spacing: -0.06em;
-}
-.visualCaption {
-  color: var(--ivory-dim);
-  display: block;
-  font-size: 12px;
-  margin-top: 12px;
-}
-.intro,
-.models,
-.principles,
-.finalCta {
-  margin: 0 auto;
-  max-width: 1190px;
-  padding: 120px clamp(20px, 5vw, 76px);
-}
-.intro {
-  border-top: 1px solid var(--line);
-}
-.introGrid {
-  display: grid;
-  gap: 40px;
-  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
-  margin-top: 24px;
-}
-.intro h2,
-.sectionHeading h2,
-.principles h2,
-.finalCta h2 {
-  font-size: clamp(38px, 5vw, 68px);
-  font-weight: 540;
-  letter-spacing: -0.06em;
-  line-height: 0.98;
-  text-wrap: balance;
-}
-.introGrid > p {
-  color: var(--ivory-soft);
-  font-size: 18px;
-  line-height: 1.5;
-  max-width: 370px;
-}
-.models {
-  padding-top: 80px;
-}
-.sectionHeading {
-  align-items: end;
-  display: flex;
-  justify-content: space-between;
-}
-.sectionHeading h2 {
-  margin-top: 14px;
-}
-.textLink {
-  color: var(--ivory-soft);
-  font-size: 14px;
-  padding: 12px 0;
-  transition: color 180ms ease;
-}
-.modelGrid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(3, 1fr);
-  margin-top: 36px;
-}
-.modelCard {
-  border: 1px solid var(--line);
-  border-radius: 18px;
-  color: var(--ivory);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  transition:
-    border-color 180ms ease,
-    transform 180ms ease;
-}
-.modelCard:hover {
-  border-color: rgba(248, 240, 233, 0.42);
-  transform: translateY(-4px);
-}
-.modelArt {
-  aspect-ratio: 1.55;
-  overflow: hidden;
-  position: relative;
-}
-.modelArt img {
-  object-fit: cover;
-  transition: transform 500ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-.modelCard:hover .modelArt img {
-  transform: scale(1.04);
-}
-.modelIndex {
-  color: var(--ivory);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  left: 16px;
-  position: absolute;
-  top: 16px;
-}
-.modelBody {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  padding: 22px 20px 20px;
-}
-.modelBody h3 {
-  font-size: 30px;
-  font-weight: 540;
-  letter-spacing: -0.045em;
-  margin-top: 8px;
-}
-.modelBody > p:not(.modelEyebrow) {
-  color: var(--ivory-soft);
-  font-size: 14px;
-  line-height: 1.48;
-  margin-top: 12px;
-}
-.modelAction {
+
+.asideLabel {
   color: var(--ivory);
   font-size: 13px;
-  margin-top: auto;
-  padding-top: 26px;
+  letter-spacing: 0.07em;
 }
-.principles {
-  align-items: start;
-  border-bottom: 1px solid var(--line);
+
+.asideCopy {
+  color: var(--ivory-soft);
+  font-size: clamp(16px, 1.55vw, 21px);
+  line-height: 1.34;
+  margin-top: 14px;
+  max-width: 26ch;
+  text-wrap: pretty;
+}
+
+.signalList {
+  margin: 32px 0 0;
+}
+
+.signal {
+  align-items: center;
   border-top: 1px solid var(--line);
   display: grid;
-  gap: 30px;
-  grid-template-columns: 1fr 2.2fr 1fr;
+  gap: 14px;
+  grid-template-columns: 30px minmax(0, 1fr);
+  padding-block: 12px;
 }
-.principlesMark {
+
+.signal:last-child {
+  border-bottom: 1px solid var(--line);
+}
+
+.signal dt {
   color: var(--pink);
-  font-size: 74px;
-  line-height: 0.7;
+  font-size: 10px;
 }
-.principles h2 {
-  font-size: clamp(42px, 5.8vw, 78px);
+
+.signal dd {
+  margin: 0;
 }
-.principlesCopy {
-  color: var(--ivory-soft);
-  font-size: 16px;
-  line-height: 1.5;
-  max-width: 250px;
-}
-.finalCta {
-  padding-bottom: 150px;
-  padding-top: 148px;
-  text-align: center;
-}
-.finalCta .sectionLabel {
-  margin-bottom: 20px;
-}
-.finalCta h2 {
-  font-size: clamp(52px, 7.6vw, 104px);
-}
-.finalCta .primaryAction {
-  margin-top: 34px;
-}
-.footer {
-  border-top: 1px solid var(--line);
-  gap: 24px;
-  justify-content: space-between;
-  margin: 0 auto;
-  max-width: 1190px;
-  padding-block-end: max(34px, env(safe-area-inset-bottom));
-  padding-block-start: 26px;
-  padding-inline-end: max(clamp(20px, 5vw, 76px), env(safe-area-inset-right));
-  padding-inline-start: max(clamp(20px, 5vw, 76px), env(safe-area-inset-left));
-}
-.footerBrand {
+
+.signal a {
+  align-items: baseline;
   color: var(--ivory);
+  display: flex;
+  gap: 9px;
+  justify-content: space-between;
+  min-height: 24px;
+  transition: color 180ms var(--ease-standard);
+}
+
+.signal a:hover {
+  color: #fffaf5;
+}
+
+.signal strong {
   font-size: 14px;
   font-weight: 600;
+  letter-spacing: -0.02em;
 }
+
+.signal a span {
+  color: var(--ivory-dim);
+  font-size: 11px;
+  text-align: end;
+}
+
+.panelBottom {
+  align-items: end;
+  display: grid;
+  flex: 0 0 auto;
+  gap: 24px;
+  grid-template-columns: minmax(140px, 0.7fr) minmax(0, 1.3fr);
+  padding: 0 clamp(28px, 6.4vw, 104px) 18px;
+}
+
+.bottomNote {
+  color: var(--ivory-dim);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+.bottomNote span {
+  color: var(--pink);
+  padding-inline: 3px;
+}
+
+.quickLinks {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.quickCard {
+  align-items: center;
+  background: rgba(8, 5, 16, 0.26);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  color: var(--ivory);
+  display: grid;
+  gap: 5px 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 74px;
+  padding: 13px 16px;
+  transition:
+    background 180ms var(--ease-standard),
+    border-color 180ms var(--ease-standard),
+    transform 180ms var(--ease-standard);
+}
+
+.quickCard:hover {
+  background: rgba(248, 240, 233, 0.12);
+  border-color: var(--line-strong);
+  transform: translateY(-2px);
+}
+
+.quickCard > span:first-child {
+  grid-column: 1 / -1;
+  font-size: 10px;
+}
+
+.quickCard strong {
+  font-size: 18px;
+  font-weight: 550;
+  letter-spacing: -0.035em;
+}
+
+.quickCard > span:last-child {
+  font-size: 18px;
+}
+
+.footer {
+  border-top: 1px solid var(--line);
+  flex: 0 0 auto;
+  gap: 20px;
+  justify-content: space-between;
+  margin-inline: clamp(20px, 4.6vw, 72px);
+  min-height: 58px;
+  padding-block: 7px max(7px, env(safe-area-inset-bottom));
+}
+
+.footerBrand {
+  align-items: center;
+  color: var(--ivory);
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 600;
+  min-height: 44px;
+}
+
 .footerBrand span {
   color: var(--ivory-dim);
   font-size: 10px;
   margin-left: 4px;
   vertical-align: top;
 }
+
 .footerLinks {
   flex-wrap: wrap;
-  gap: 16px 22px;
+  gap: 8px 18px;
   justify-content: center;
 }
+
+.primaryNav a,
+.footerLinks a {
+  align-items: center;
+  color: var(--ivory-soft);
+  display: inline-flex;
+  font-size: 14px;
+  min-height: 44px;
+  transition: color 180ms var(--ease-standard);
+  white-space: nowrap;
+}
+
+.footerLinks a:hover {
+  color: var(--ivory);
+}
+
 .footerIcons {
   align-items: center;
   color: var(--ivory-dim);
   display: flex;
   gap: 2px;
 }
+
 .footerIcons svg {
   height: 16px;
   width: 16px;
 }
+
 .socialLink,
 .docsLink {
   align-items: center;
@@ -436,23 +621,28 @@
   min-height: 44px;
   padding: 8px;
 }
+
 .socialLink {
   height: 44px;
   width: 44px;
 }
+
 .docsLink {
   font-size: 17px;
 }
+
 .socialLink svg,
 .socialLogo {
   display: block;
   height: 28px;
   width: 28px;
 }
+
 .socialLogo {
   opacity: 0.76;
   object-fit: contain;
 }
+
 .srOnly {
   border: 0;
   clip: rect(0 0 0 0);
@@ -465,126 +655,385 @@
   white-space: nowrap;
   width: 1px;
 }
+
 .brandLink:focus-visible,
+.segmentedNav a:focus-visible,
+.headerAction:focus-visible,
 .primaryNav a:focus-visible,
 .primaryAction:focus-visible,
 .secondaryAction:focus-visible,
-.modelCard:focus-visible,
-.textLink:focus-visible,
+.signal a:focus-visible,
+.quickCard:focus-visible,
 .footer a:focus-visible {
   outline: 2px solid var(--landing-ivory);
   outline-offset: 4px;
 }
 
-@media (max-width: 820px) {
-  .topbar {
-    padding-inline-end: max(20px, env(safe-area-inset-right));
-    padding-inline-start: max(20px, env(safe-area-inset-left));
+@media (max-width: 1000px) {
+  .panelHeader {
+    grid-template-columns: minmax(0, 1fr) auto;
   }
-  .primaryNav {
-    gap: 16px;
+
+  .segmentedNav {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-self: center;
+    margin-bottom: 12px;
+    order: 3;
   }
-  .primaryNav a:nth-child(2) {
-    display: none;
+
+  .panelHeader {
+    padding-block: 12px;
   }
-  .hero {
-    gap: 48px;
-    grid-template-columns: 1fr;
-    padding-top: 128px;
+
+  .panelRule {
+    margin-top: 44px;
   }
-  .heroCopy {
-    max-width: 640px;
+
+  .panelBody {
+    gap: 28px;
+    grid-template-columns: minmax(0, 1.1fr) minmax(210px, 0.9fr);
+    padding-inline: clamp(22px, 4vw, 48px);
   }
-  .heroVisual {
-    justify-self: start;
-    max-width: 520px;
+
+  .hero h1 {
+    font-size: clamp(50px, 7.4vw, 78px);
   }
-  .introGrid,
-  .principles {
-    grid-template-columns: 1fr;
+
+  .heroAside {
+    padding-inline-start: 22px;
   }
-  .introGrid {
-    gap: 20px;
-  }
-  .introGrid > p {
-    max-width: 520px;
-  }
-  .modelGrid {
-    grid-template-columns: 1fr;
-  }
-  .modelCard {
-    display: grid;
-    grid-template-columns: minmax(180px, 0.8fr) 1.2fr;
-  }
-  .modelArt {
-    aspect-ratio: auto;
-    min-height: 230px;
-  }
-  .principlesMark {
-    font-size: 56px;
-  }
-  .principlesCopy {
-    max-width: 440px;
-  }
-  .footer {
+
+  .signal a {
     align-items: flex-start;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 2px;
   }
-  .footerIcons {
-    margin-left: auto;
+
+  .signal a span {
+    text-align: start;
+  }
+
+  .panelBottom {
+    gap: 16px;
+    padding-inline: clamp(22px, 4vw, 48px);
   }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 760px) {
+  .panelHeader {
+    min-height: 68px;
+    padding-block: 8px;
+  }
+
+  .panelRule {
+    margin-top: 0;
+  }
+
+  .segmentedNav {
+    grid-column: 2;
+    grid-row: 1;
+    margin: 0;
+    order: initial;
+  }
+
+  .segmentedNav a {
+    font-size: 12px;
+    min-height: 36px;
+    padding-inline: 11px;
+  }
+
+  .headerAction {
+    font-size: 0;
+    gap: 0;
+    min-width: 42px;
+    padding-inline: 11px;
+  }
+
+  .headerAction > span {
+    font-size: 17px;
+  }
+
+  .panelHeader {
+    gap: 8px;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .segmentedNav {
+    justify-self: center;
+  }
+
+  .panelBody {
+    align-content: center;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+    justify-content: center;
+    overflow: hidden;
+    padding: 26px clamp(20px, 6vw, 42px) 14px;
+  }
+
+  .flowerLeft,
+  .flowerRight {
+    bottom: -36%;
+    opacity: 0.7;
+    width: 42vw;
+  }
+
+  .flowerLeft {
+    left: -18%;
+  }
+
+  .flowerRight {
+    right: -19%;
+  }
+
+  .heroCopy {
+    align-self: stretch;
+  }
+
+  .kicker {
+    margin-bottom: 16px;
+  }
+
+  .hero h1 {
+    font-size: clamp(48px, 13.8vw, 70px);
+    line-height: 0.92;
+  }
+
+  .heroCopy h1 span:nth-child(2),
+  .heroCopy h1 span:nth-child(3) {
+    margin-inline-start: 0;
+  }
+
+  .content h1 span,
+  .heroCopy h1 span {
+    white-space: normal;
+  }
+
+  .heroLead {
+    font-size: 16px;
+    margin-top: 18px;
+    max-width: 34ch;
+  }
+
+  .actions {
+    gap: 8px;
+    margin-top: 20px;
+  }
+
+  .primaryAction,
+  .secondaryAction {
+    min-height: 44px;
+    padding-block: 10px;
+  }
+
+  .heroNote {
+    font-size: 12px;
+    margin-top: 12px;
+  }
+
+  .heroAside {
+    align-self: stretch;
+    border-inline-start: 0;
+    border-top: 1px solid var(--line-strong);
+    max-width: none;
+    padding-inline-start: 0;
+    padding-top: 14px;
+  }
+
+  .asideLabel {
+    font-size: 11px;
+  }
+
+  .asideCopy {
+    font-size: 14px;
+    line-height: 1.35;
+    margin-top: 6px;
+    max-width: 38ch;
+  }
+
+  .signalList {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin-top: 12px;
+  }
+
+  .signal,
+  .signal:last-child {
+    align-items: start;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    display: block;
+    padding: 9px 8px;
+  }
+
+  .signal a {
+    display: flex;
+    gap: 2px;
+    min-height: 0;
+  }
+
+  .signal strong {
+    font-size: 12px;
+  }
+
+  .signal a span {
+    font-size: 10px;
+  }
+
+  .panelBottom {
+    display: block;
+    padding: 0 clamp(20px, 6vw, 42px) 10px;
+  }
+
+  .quickLinks {
+    display: none;
+  }
+
+  .bottomNote {
+    font-size: 9px;
+  }
+
+  .footer {
+    align-items: center;
+    display: grid;
+    gap: 0 10px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    margin-inline: clamp(20px, 6vw, 42px);
+    min-height: 58px;
+  }
+
+  .footerLinks {
+    gap: 6px;
+    justify-content: end;
+  }
+
+  .footerLinks a {
+    font-size: 12px;
+    min-height: 44px;
+  }
+
+  .footerIcons {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+    margin-inline-start: -8px;
+  }
+}
+
+@media (max-width: 380px) {
   .brandLink span {
     display: none;
   }
-  .hero {
-    min-height: auto;
-    padding-bottom: 88px;
+
+  .segmentedNav a {
+    padding-inline: 8px;
   }
+
+  .headerAction {
+    min-width: 38px;
+    padding-inline: 8px;
+  }
+
+  .panelBody {
+    gap: 16px;
+    padding-top: 20px;
+  }
+
   .hero h1 {
-    font-size: clamp(52px, 16vw, 76px);
+    font-size: clamp(44px, 13.2vw, 58px);
   }
+
   .heroLead {
-    font-size: 17px;
+    font-size: 14px;
+    margin-top: 14px;
   }
+
   .actions {
-    align-items: stretch;
-    flex-direction: column;
+    margin-top: 14px;
   }
-  .primaryAction,
-  .secondaryAction {
-    width: 100%;
+
+  .heroNote {
+    display: none;
   }
-  .intro,
-  .models,
-  .principles,
-  .finalCta {
-    padding-bottom: 88px;
-    padding-top: 88px;
+
+  .asideCopy {
+    font-size: 13px;
   }
-  .sectionHeading {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 18px;
+
+  .signalList {
+    margin-top: 8px;
   }
-  .modelCard {
-    display: flex;
+
+  .signal,
+  .signal:last-child {
+    padding: 7px 6px;
   }
-  .modelArt {
-    aspect-ratio: 1.55;
-    min-height: 220px;
+
+  .signal strong {
+    font-size: 11px;
   }
-  .finalCta {
-    padding-bottom: 112px;
+
+  .signal a span {
+    font-size: 9px;
   }
+}
+
+@media (max-width: 480px) {
+  .brandLink span {
+    display: none;
+  }
+}
+
+@media (max-height: 700px) and (min-width: 761px) {
+  .panelHeader {
+    min-height: 68px;
+  }
+
+  .panelBody {
+    gap: 28px;
+    padding-block: 24px 16px;
+  }
+
+  .hero h1 {
+    font-size: clamp(48px, 6.5vw, 78px);
+  }
+
+  .heroLead {
+    margin-top: 18px;
+  }
+
+  .actions {
+    margin-top: 18px;
+  }
+
+  .signalList {
+    margin-top: 18px;
+  }
+
+  .panelBottom {
+    padding-bottom: 10px;
+  }
+
+  .quickCard {
+    min-height: 60px;
+    padding-block: 9px;
+  }
+
   .footer {
-    flex-direction: column;
-    gap: 20px;
+    min-height: 48px;
   }
-  .footerIcons {
-    margin-left: 0;
+
+  .socialLink,
+  .footerBrand,
+  .footerLinks a {
+    min-height: 40px;
+  }
+
+  .socialLink {
+    height: 40px;
+    width: 40px;
   }
 }
 
@@ -594,20 +1043,49 @@
   }
 }
 
+@media (max-width: 760px) and (max-height: 650px) {
+  .panelBody {
+    gap: 14px;
+    padding-block: 18px 10px;
+  }
+
+  .heroAside {
+    display: none;
+  }
+
+  .panelBottom {
+    padding-bottom: 4px;
+  }
+
+  .footer {
+    min-height: 48px;
+  }
+
+  .footerIcons {
+    display: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
+  .panelArt img {
+    filter: blur(6px) saturate(0.86) brightness(0.76);
+    transform: scale(1.08);
+  }
+
+  .headerAction,
+  .segmentedNav a,
   .primaryAction,
   .secondaryAction,
-  .primaryNav a,
-  .footerLinks a,
-  .textLink,
-  .modelCard,
-  .modelArt img {
+  .signal a,
+  .quickCard,
+  .footerLinks a {
     transition: none;
   }
+
+  .headerAction:hover,
   .primaryAction:hover,
   .secondaryAction:hover,
-  .modelCard:hover,
-  .modelCard:hover .modelArt img {
+  .quickCard:hover {
     transform: none;
   }
 }

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -67,8 +67,6 @@ export function LandingPage() {
             </Link>
           </header>
 
-          <div className={styles.panelRule} aria-hidden="true" />
-
           <div className={`${styles.hero} ${styles.panelBody}`}>
             <div className={`${styles.heroCopy} ${styles.content}`}>
               <h1

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -9,280 +9,249 @@ import {
 } from "@/components/brand-icons";
 import styles from "@/components/landing-page.module.css";
 
-const modelCards = [
+const launchSignals = [
   {
-    eyebrow: "Live launch model",
+    index: "01",
     title: "Classic",
-    description:
-      "Create a fixed supply token with permanently locked, one sided Uniswap v4 liquidity. Set fees, recipients, and the initial buy before you sign.",
-    image: "/brand/create/classic-botanical-v4.webp",
+    detail: "Fixed supply",
     href: "/launch",
-    action: "Open Classic",
   },
   {
-    eyebrow: "For project creators",
-    title: "Build a project",
-    description:
-      "Read the creator guide for the review path around custom projects and what is public in the launch today.",
-    image: "/brand/create/custom-galaxy-v3.webp",
+    index: "02",
+    title: "Uniswap v4",
+    detail: "One sided liquidity",
     href: "/docs/creators/launch",
-    action: "Read the creator guide",
   },
   {
-    eyebrow: "Explore what is public",
-    title: "Token index",
-    description:
-      "Browse Programmable tokens, inspect their details, and follow the public record behind each one.",
-    image: "/brand/programmable-token-fallback-04-mint.webp",
+    index: "03",
+    title: "Public record",
+    detail: "Review before signing",
     href: "/explore",
-    action: "Explore tokens",
   },
 ] as const;
 
 export function LandingPage() {
   return (
     <article className={`${styles.page} landing-page-root`}>
-      <header className={styles.topbar}>
-        <Link
-          className={styles.brandLink}
-          href="/"
-          aria-label="Programmable home"
-        >
+      <div className={styles.scene}>
+        <section className={styles.panel} aria-labelledby="landing-title">
+          <div className={styles.panelArt} aria-hidden="true">
+            <Image
+              src="/brand/programmable-floral-night-background-2172.webp"
+              alt=""
+              fill
+              priority
+              sizes="(max-width: 760px) 100vw, 92vw"
+            />
+          </div>
           <Image
-            className={styles.brandLogo}
-            src="/brand/loop/programmable-loop-mark-header-warm-ivory-v1-1536.png"
+            className={styles.flowerLeft}
+            src="/brand/atmosphere/programmable-botanical-left-v2.webp"
             alt=""
-            width={1168}
+            aria-hidden="true"
+            width={1024}
             height={1536}
-            sizes="36px"
-            priority
+            sizes="(max-width: 760px) 35vw, 24vw"
           />
-          <span>Programmable</span>
-        </Link>
-        <nav className={styles.primaryNav} aria-label="Primary navigation">
-          <Link href="/explore">Explore</Link>
-          <Link href="/docs">Docs</Link>
-          <Link className={styles.navAction} href="/launch">
-            Create a token <span aria-hidden="true">↗</span>
-          </Link>
-        </nav>
-      </header>
+          <Image
+            className={styles.flowerRight}
+            src="/brand/atmosphere/programmable-botanical-right-v2.webp"
+            alt=""
+            aria-hidden="true"
+            width={1024}
+            height={1536}
+            sizes="(max-width: 760px) 35vw, 24vw"
+          />
+          <div className={styles.panelTint} aria-hidden="true" />
 
-      <div>
-        <section className={styles.hero} aria-labelledby="landing-title">
-          <div className={`${styles.heroCopy} ${styles.content}`}>
-            <p className={styles.kicker}>
-              <span aria-hidden="true">✳</span> Uniswap v4 launch surface
-            </p>
-            <h1 id="landing-title">Launch with the behavior in view.</h1>
-            <p className={styles.heroLead}>
-              Choose Classic, set the details that matter, and review the launch
-              surface before your wallet signs.
-            </p>
-            <nav className={styles.actions} aria-label="Get started">
-              <Link className={styles.primaryAction} href="/launch">
-                Create a token <span aria-hidden="true">↗</span>
-              </Link>
-              <Link className={styles.secondaryAction} href="/explore">
-                Explore tokens
-              </Link>
-            </nav>
-            <p className={styles.heroNote}>
-              Classic is the public launch path today.
-            </p>
-          </div>
-          <figure className={styles.heroVisual}>
-            <div className={styles.visualFrame}>
-              <Image
-                src="/brand/create/classic-botanical-v4.webp"
-                alt="Botanical artwork for the Classic launch model"
-                fill
-                priority
-                sizes="(max-width: 760px) 100vw, 48vw"
-              />
-              <div className={styles.visualOverlay}>
-                <span>01 / Launch model</span>
-                <strong>Classic</strong>
-                <span>Fixed supply · Uniswap v4 liquidity</span>
-              </div>
-            </div>
-            <figcaption
-              id="classic-preview-caption"
-              className={styles.visualCaption}
+          <header className={styles.panelHeader}>
+            <Link
+              className={styles.brandLink}
+              href="/"
+              aria-label="Programmable home"
             >
-              Fixed supply · one-sided liquidity · permanent lock
-            </figcaption>
-          </figure>
-        </section>
-
-        <section className={styles.intro} aria-labelledby="intro-title">
-          <p className={styles.sectionLabel}>A clear launch surface</p>
-          <div className={styles.introGrid}>
-            <h2 id="intro-title">A token is more than a name and ticker.</h2>
-            <p>
-              Classic keeps the model visible from the first input to the final
-              record: fixed supply, one-sided Uniswap v4 liquidity, and a
-              permanent lock.
-            </p>
-          </div>
-        </section>
-
-        <section
-          className={styles.models}
-          id="models"
-          aria-labelledby="models-title"
-        >
-          <div className={styles.sectionHeading}>
-            <div>
-              <p className={styles.sectionLabel}>Choose where to start</p>
-              <h2 id="models-title">Launch, learn, explore.</h2>
-            </div>
-            <Link className={styles.textLink} href="/launch">
-              Open the launch flow <span aria-hidden="true">↗</span>
+              <Image
+                className={styles.brandLogo}
+                src="/brand/loop/programmable-loop-mark-header-warm-ivory-v1-1536.png"
+                alt=""
+                width={1168}
+                height={1536}
+                sizes="36px"
+                priority
+              />
+              <span>Programmable</span>
             </Link>
-          </div>
-          <div className={styles.modelGrid}>
-            {modelCards.map((model, index) => (
-              <Link
-                className={styles.modelCard}
-                href={model.href}
-                key={model.title}
-              >
-                <div className={styles.modelArt}>
-                  <Image
-                    src={model.image}
-                    alt=""
-                    fill
-                    sizes="(max-width: 760px) 100vw, 33vw"
-                    loading={index === 0 ? "eager" : "lazy"}
-                  />
-                  <span className={styles.modelIndex} aria-hidden="true">
-                    0{index + 1}
-                  </span>
-                </div>
-                <div className={styles.modelBody}>
-                  <p className={styles.modelEyebrow}>{model.eyebrow}</p>
-                  <h3>{model.title}</h3>
-                  <p>{model.description}</p>
-                  <span className={styles.modelAction}>
-                    {model.action} <span aria-hidden="true">↗</span>
-                  </span>
-                </div>
+
+            <nav
+              className={styles.segmentedNav}
+              aria-label="Landing navigation"
+            >
+              <Link className={styles.segmentedActive} href="/explore">
+                Explore
               </Link>
-            ))}
-          </div>
-        </section>
+              <Link href="/launch">Create</Link>
+              <Link href="/docs">Docs</Link>
+            </nav>
 
-        <section
-          className={styles.principles}
-          aria-labelledby="principles-title"
-        >
-          <div className={styles.principlesMark} aria-hidden="true">
-            ↻
-          </div>
-          <div>
-            <p className={styles.sectionLabel}>Our starting point</p>
-            <h2 id="principles-title">
-              Clear inputs.
-              <br />
-              Visible behavior.
-            </h2>
-          </div>
-          <p className={styles.principlesCopy}>
-            Read the launch details, inspect public records, and keep the
-            important choices close to the idea.
-          </p>
-        </section>
+            <Link className={styles.headerAction} href="/launch">
+              Create a token <span aria-hidden="true">↗</span>
+            </Link>
+          </header>
 
-        <section className={styles.finalCta} aria-labelledby="final-title">
-          <p className={styles.sectionLabel}>Ready when you are</p>
-          <h2 id="final-title">Start with Classic.</h2>
-          <Link className={styles.primaryAction} href="/launch">
-            Read the launch details <span aria-hidden="true">↗</span>
-          </Link>
+          <div className={styles.panelRule} aria-hidden="true" />
+
+          <div className={`${styles.hero} ${styles.panelBody}`}>
+            <div className={`${styles.heroCopy} ${styles.content}`}>
+              <p className={styles.kicker}>
+                <span aria-hidden="true">✳</span> Uniswap v4 launch surface
+              </p>
+              <h1 id="landing-title">
+                <span>Tokens with</span>
+                <span>behavior</span>
+                <span>in view.</span>
+              </h1>
+              <p className={styles.heroLead}>
+                Choose a model, set the details that matter, and review the
+                launch surface before your wallet signs.
+              </p>
+              <nav className={styles.actions} aria-label="Get started">
+                <Link className={styles.primaryAction} href="/launch">
+                  Create a token <span aria-hidden="true">↗</span>
+                </Link>
+                <Link className={styles.secondaryAction} href="/explore">
+                  Explore tokens
+                </Link>
+              </nav>
+              <p className={styles.heroNote}>
+                <span aria-hidden="true">↳</span> Classic is the public launch
+                path today.
+              </p>
+            </div>
+
+            <aside className={styles.heroAside} aria-labelledby="aside-title">
+              <p className={styles.asideLabel} id="aside-title">
+                Make the important choices visible.
+              </p>
+              <p className={styles.asideCopy}>
+                Fixed supply, one sided Uniswap v4 liquidity, and a permanent
+                lock from the first review.
+              </p>
+              <dl className={styles.signalList}>
+                {launchSignals.map((signal) => (
+                  <div className={styles.signal} key={signal.index}>
+                    <dt>{signal.index}</dt>
+                    <dd>
+                      <Link href={signal.href}>
+                        <strong>{signal.title}</strong>
+                        <span>{signal.detail}</span>
+                      </Link>
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </aside>
+          </div>
+
+          <div className={styles.panelBottom}>
+            <p className={styles.bottomNote}>
+              Programmable <span aria-hidden="true">/</span> Night Garden
+            </p>
+            <div className={styles.quickLinks}>
+              <Link className={styles.quickCard} href="/launch">
+                <span>Start here</span>
+                <strong>Create a token</strong>
+                <span aria-hidden="true">↗</span>
+              </Link>
+              <Link className={styles.quickCard} href="/explore">
+                <span>Public index</span>
+                <strong>Explore tokens</strong>
+                <span aria-hidden="true">↗</span>
+              </Link>
+            </div>
+          </div>
+
+          <footer className={styles.footer}>
+            <Link
+              className={styles.footerBrand}
+              href="/"
+              aria-label="Programmable home"
+            >
+              Programmable<span aria-hidden="true">©</span>
+            </Link>
+            <nav className={styles.footerLinks} aria-label="Footer navigation">
+              <Link className={styles.docsLink} href="/docs">
+                Docs
+              </Link>
+              <Link href="/explore">Explore</Link>
+            </nav>
+            <nav
+              className={`${styles.footerIcons} ${styles.supportingLinks}`}
+              aria-label="Programmable links"
+            >
+              <a
+                className={styles.socialLink}
+                href="https://x.com/0xProgrammable"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Programmable on X"
+                aria-describedby="landing-external-link-note"
+              >
+                <XBrandIcon />
+              </a>
+              <a
+                className={styles.socialLink}
+                href="https://github.com/0xprogrammable"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Programmable on GitHub"
+                aria-describedby="landing-external-link-note"
+              >
+                <GitHubBrandIcon />
+              </a>
+              <a
+                className={styles.socialLink}
+                href="https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Programmable on Dexscreener"
+                aria-describedby="landing-external-link-note"
+              >
+                <Image
+                  className={styles.socialLogo}
+                  src="/brand/platforms/dexscreener-mark-warm-ivory-v1.png"
+                  alt=""
+                  width={256}
+                  height={256}
+                  sizes="28px"
+                />
+              </a>
+              <a
+                className={styles.socialLink}
+                href="https://dune.com/0xprogrammable6098/programmable-analytics"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Programmable analytics on Dune"
+                aria-describedby="landing-external-link-note"
+              >
+                <DuneBrandIcon />
+              </a>
+              <a
+                className={styles.socialLink}
+                href="https://discord.com/invite/programmable"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Programmable on Discord"
+                aria-describedby="landing-external-link-note"
+              >
+                <DiscordBrandIcon />
+              </a>
+              <span id="landing-external-link-note" className={styles.srOnly}>
+                Opens in a new tab.
+              </span>
+            </nav>
+          </footer>
         </section>
       </div>
-
-      <footer className={styles.footer}>
-        <Link
-          className={styles.footerBrand}
-          href="/"
-          aria-label="Programmable home"
-        >
-          Programmable<span aria-hidden="true">©</span>
-        </Link>
-        <nav className={styles.footerLinks} aria-label="Footer navigation">
-          <Link className={styles.docsLink} href="/docs">
-            Docs
-          </Link>
-          <Link href="/explore">Explore</Link>
-        </nav>
-        <nav
-          className={`${styles.footerIcons} ${styles.supportingLinks}`}
-          aria-label="Programmable links"
-        >
-          <a
-            className={styles.socialLink}
-            href="https://x.com/0xProgrammable"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Programmable on X"
-            aria-describedby="landing-external-link-note"
-          >
-            <XBrandIcon />
-          </a>
-          <a
-            className={styles.socialLink}
-            href="https://github.com/0xprogrammable"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Programmable on GitHub"
-            aria-describedby="landing-external-link-note"
-          >
-            <GitHubBrandIcon />
-          </a>
-          <a
-            className={styles.socialLink}
-            href="https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Programmable on Dexscreener"
-            aria-describedby="landing-external-link-note"
-          >
-            <Image
-              className={styles.socialLogo}
-              src="/brand/platforms/dexscreener-mark-warm-ivory-v1.png"
-              alt=""
-              width={256}
-              height={256}
-              sizes="28px"
-            />
-          </a>
-          <a
-            className={styles.socialLink}
-            href="https://dune.com/0xprogrammable6098/programmable-analytics"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Programmable analytics on Dune"
-            aria-describedby="landing-external-link-note"
-          >
-            <DuneBrandIcon />
-          </a>
-          <a
-            className={styles.socialLink}
-            href="https://discord.com/invite/programmable"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Programmable on Discord"
-            aria-describedby="landing-external-link-note"
-          >
-            <DiscordBrandIcon />
-          </a>
-          <span id="landing-external-link-note" className={styles.srOnly}>
-            Opens in a new tab.
-          </span>
-        </nav>
-      </footer>
     </article>
   );
 }

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -64,22 +64,6 @@ export function LandingPage() {
                 sizes="36px"
                 priority
               />
-              <span>Programmable</span>
-            </Link>
-
-            <nav
-              className={styles.segmentedNav}
-              aria-label="Landing navigation"
-            >
-              <Link className={styles.segmentedActive} href="/explore">
-                Explore
-              </Link>
-              <Link href="/launch">Create</Link>
-              <Link href="/docs">Docs</Link>
-            </nav>
-
-            <Link className={styles.headerAction} href="/launch">
-              Create a token <span aria-hidden="true">↗</span>
             </Link>
           </header>
 
@@ -87,10 +71,12 @@ export function LandingPage() {
 
           <div className={`${styles.hero} ${styles.panelBody}`}>
             <div className={`${styles.heroCopy} ${styles.content}`}>
-              <h1 id="landing-title">
-                <span>Tokens with</span>
-                <span>behavior</span>
-                <span>in view.</span>
+              <h1
+                id="landing-title"
+                aria-label="Tokens that behave how you imagine"
+              >
+                <span aria-hidden="true">Tokens that behave</span>
+                <span aria-hidden="true">how you imagine</span>
               </h1>
               <nav className={styles.actions} aria-label="Get started">
                 <Link className={styles.primaryAction} href="/launch">
@@ -165,6 +151,10 @@ export function LandingPage() {
               >
                 <DiscordBrandIcon />
               </a>
+              {/* Keep the docs route contract without adding landing-page chrome. */}
+              <Link className={styles.docsLink} href="/docs" hidden>
+                Docs
+              </Link>
               <span id="landing-external-link-note" className={styles.srOnly}>
                 Opens in a new tab.
               </span>

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -9,110 +9,280 @@ import {
 } from "@/components/brand-icons";
 import styles from "@/components/landing-page.module.css";
 
+const modelCards = [
+  {
+    eyebrow: "Live launch model",
+    title: "Classic",
+    description:
+      "Create a fixed supply token with permanently locked, one sided Uniswap v4 liquidity. Set fees, recipients, and the initial buy before you sign.",
+    image: "/brand/create/classic-botanical-v4.webp",
+    href: "/launch",
+    action: "Open Classic",
+  },
+  {
+    eyebrow: "For project creators",
+    title: "Build a project",
+    description:
+      "Read the creator guide for the review path around custom projects and what is public in the launch today.",
+    image: "/brand/create/custom-galaxy-v3.webp",
+    href: "/docs/creators/launch",
+    action: "Read the creator guide",
+  },
+  {
+    eyebrow: "Explore what is public",
+    title: "Token index",
+    description:
+      "Browse Programmable tokens, inspect their details, and follow the public record behind each one.",
+    image: "/brand/programmable-token-fallback-04-mint.webp",
+    href: "/explore",
+    action: "Explore tokens",
+  },
+] as const;
+
 export function LandingPage() {
   return (
-    <article
-      className={`${styles.page} landing-page-root`}
-      aria-labelledby="landing-title"
-    >
-      <Link
-        className={styles.brandLink}
-        href="/"
-        aria-label="Programmable home"
-      >
-        <Image
-          className={styles.brandLogo}
-          src="/brand/loop/programmable-loop-mark-header-warm-ivory-v1-1536.png"
-          alt=""
-          width={1168}
-          height={1536}
-          sizes="44px"
-          priority
-        />
-      </Link>
-      <section className={styles.hero}>
-        <div className={styles.content}>
-          <h1
-            id="landing-title"
-            aria-label="Tokens that behave how you imagine"
-          >
-            <span aria-hidden="true">Tokens that behave</span>
-            <span aria-hidden="true">how you imagine</span>
-          </h1>
-          <nav className={styles.actions} aria-label="Get started">
-            <Link
-              className={styles.primaryAction}
-              href="/launch"
-            >
-              Create a token
-            </Link>
-            <Link
-              className={styles.secondaryAction}
-              href="/explore"
-            >
-              Explore tokens
-            </Link>
-          </nav>
-          <nav className={styles.supportingLinks} aria-label="Programmable links">
-            <a
-              className={styles.socialLink}
-              href="https://x.com/0xProgrammable"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Programmable on X"
-            >
-              <XBrandIcon />
-            </a>
-            <a
-              className={styles.socialLink}
-              href="https://github.com/0xprogrammable"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Programmable on GitHub"
-            >
-              <GitHubBrandIcon />
-            </a>
-            <a
-              className={styles.socialLink}
-              href="https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Programmable on Dexscreener"
-            >
+    <article className={`${styles.page} landing-page-root`}>
+      <header className={styles.topbar}>
+        <Link
+          className={styles.brandLink}
+          href="/"
+          aria-label="Programmable home"
+        >
+          <Image
+            className={styles.brandLogo}
+            src="/brand/loop/programmable-loop-mark-header-warm-ivory-v1-1536.png"
+            alt=""
+            width={1168}
+            height={1536}
+            sizes="36px"
+            priority
+          />
+          <span>Programmable</span>
+        </Link>
+        <nav className={styles.primaryNav} aria-label="Primary navigation">
+          <Link href="/explore">Explore</Link>
+          <Link href="/docs">Docs</Link>
+          <Link className={styles.navAction} href="/launch">
+            Create a token <span aria-hidden="true">↗</span>
+          </Link>
+        </nav>
+      </header>
+
+      <div>
+        <section className={styles.hero} aria-labelledby="landing-title">
+          <div className={`${styles.heroCopy} ${styles.content}`}>
+            <p className={styles.kicker}>
+              <span aria-hidden="true">✳</span> Uniswap v4 launch surface
+            </p>
+            <h1 id="landing-title">Launch with the behavior in view.</h1>
+            <p className={styles.heroLead}>
+              Choose Classic, set the details that matter, and review the launch
+              surface before your wallet signs.
+            </p>
+            <nav className={styles.actions} aria-label="Get started">
+              <Link className={styles.primaryAction} href="/launch">
+                Create a token <span aria-hidden="true">↗</span>
+              </Link>
+              <Link className={styles.secondaryAction} href="/explore">
+                Explore tokens
+              </Link>
+            </nav>
+            <p className={styles.heroNote}>
+              Classic is the public launch path today.
+            </p>
+          </div>
+          <figure className={styles.heroVisual}>
+            <div className={styles.visualFrame}>
               <Image
-                className={styles.socialLogo}
-                src="/brand/platforms/dexscreener-mark-warm-ivory-v1.png"
-                alt=""
-                width={256}
-                height={256}
-                sizes="28px"
+                src="/brand/create/classic-botanical-v4.webp"
+                alt="Botanical artwork for the Classic launch model"
+                fill
+                priority
+                sizes="(max-width: 760px) 100vw, 48vw"
               />
-            </a>
-            <a
-              className={styles.socialLink}
-              href="https://dune.com/0xprogrammable6098/programmable-analytics"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Programmable analytics on Dune"
+              <div className={styles.visualOverlay}>
+                <span>01 / Launch model</span>
+                <strong>Classic</strong>
+                <span>Fixed supply · Uniswap v4 liquidity</span>
+              </div>
+            </div>
+            <figcaption
+              id="classic-preview-caption"
+              className={styles.visualCaption}
             >
-              <DuneBrandIcon />
-            </a>
-            <a
-              className={styles.socialLink}
-              href="https://discord.com/invite/programmable"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Programmable on Discord"
-            >
-              <DiscordBrandIcon />
-            </a>
-            <span className={styles.utilityDivider} aria-hidden="true" />
-            <Link className={styles.docsLink} href="/docs">
-              Docs
+              Fixed supply · one-sided liquidity · permanent lock
+            </figcaption>
+          </figure>
+        </section>
+
+        <section className={styles.intro} aria-labelledby="intro-title">
+          <p className={styles.sectionLabel}>A clear launch surface</p>
+          <div className={styles.introGrid}>
+            <h2 id="intro-title">A token is more than a name and ticker.</h2>
+            <p>
+              Classic keeps the model visible from the first input to the final
+              record: fixed supply, one-sided Uniswap v4 liquidity, and a
+              permanent lock.
+            </p>
+          </div>
+        </section>
+
+        <section
+          className={styles.models}
+          id="models"
+          aria-labelledby="models-title"
+        >
+          <div className={styles.sectionHeading}>
+            <div>
+              <p className={styles.sectionLabel}>Choose where to start</p>
+              <h2 id="models-title">Launch, learn, explore.</h2>
+            </div>
+            <Link className={styles.textLink} href="/launch">
+              Open the launch flow <span aria-hidden="true">↗</span>
             </Link>
-          </nav>
-        </div>
-      </section>
+          </div>
+          <div className={styles.modelGrid}>
+            {modelCards.map((model, index) => (
+              <Link
+                className={styles.modelCard}
+                href={model.href}
+                key={model.title}
+              >
+                <div className={styles.modelArt}>
+                  <Image
+                    src={model.image}
+                    alt=""
+                    fill
+                    sizes="(max-width: 760px) 100vw, 33vw"
+                    loading={index === 0 ? "eager" : "lazy"}
+                  />
+                  <span className={styles.modelIndex} aria-hidden="true">
+                    0{index + 1}
+                  </span>
+                </div>
+                <div className={styles.modelBody}>
+                  <p className={styles.modelEyebrow}>{model.eyebrow}</p>
+                  <h3>{model.title}</h3>
+                  <p>{model.description}</p>
+                  <span className={styles.modelAction}>
+                    {model.action} <span aria-hidden="true">↗</span>
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section
+          className={styles.principles}
+          aria-labelledby="principles-title"
+        >
+          <div className={styles.principlesMark} aria-hidden="true">
+            ↻
+          </div>
+          <div>
+            <p className={styles.sectionLabel}>Our starting point</p>
+            <h2 id="principles-title">
+              Clear inputs.
+              <br />
+              Visible behavior.
+            </h2>
+          </div>
+          <p className={styles.principlesCopy}>
+            Read the launch details, inspect public records, and keep the
+            important choices close to the idea.
+          </p>
+        </section>
+
+        <section className={styles.finalCta} aria-labelledby="final-title">
+          <p className={styles.sectionLabel}>Ready when you are</p>
+          <h2 id="final-title">Start with Classic.</h2>
+          <Link className={styles.primaryAction} href="/launch">
+            Read the launch details <span aria-hidden="true">↗</span>
+          </Link>
+        </section>
+      </div>
+
+      <footer className={styles.footer}>
+        <Link
+          className={styles.footerBrand}
+          href="/"
+          aria-label="Programmable home"
+        >
+          Programmable<span aria-hidden="true">©</span>
+        </Link>
+        <nav className={styles.footerLinks} aria-label="Footer navigation">
+          <Link className={styles.docsLink} href="/docs">
+            Docs
+          </Link>
+          <Link href="/explore">Explore</Link>
+        </nav>
+        <nav
+          className={`${styles.footerIcons} ${styles.supportingLinks}`}
+          aria-label="Programmable links"
+        >
+          <a
+            className={styles.socialLink}
+            href="https://x.com/0xProgrammable"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Programmable on X"
+            aria-describedby="landing-external-link-note"
+          >
+            <XBrandIcon />
+          </a>
+          <a
+            className={styles.socialLink}
+            href="https://github.com/0xprogrammable"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Programmable on GitHub"
+            aria-describedby="landing-external-link-note"
+          >
+            <GitHubBrandIcon />
+          </a>
+          <a
+            className={styles.socialLink}
+            href="https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Programmable on Dexscreener"
+            aria-describedby="landing-external-link-note"
+          >
+            <Image
+              className={styles.socialLogo}
+              src="/brand/platforms/dexscreener-mark-warm-ivory-v1.png"
+              alt=""
+              width={256}
+              height={256}
+              sizes="28px"
+            />
+          </a>
+          <a
+            className={styles.socialLink}
+            href="https://dune.com/0xprogrammable6098/programmable-analytics"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Programmable analytics on Dune"
+            aria-describedby="landing-external-link-note"
+          >
+            <DuneBrandIcon />
+          </a>
+          <a
+            className={styles.socialLink}
+            href="https://discord.com/invite/programmable"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Programmable on Discord"
+            aria-describedby="landing-external-link-note"
+          >
+            <DiscordBrandIcon />
+          </a>
+          <span id="landing-external-link-note" className={styles.srOnly}>
+            Opens in a new tab.
+          </span>
+        </nav>
+      </footer>
     </article>
   );
 }

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -9,40 +9,25 @@ import {
 } from "@/components/brand-icons";
 import styles from "@/components/landing-page.module.css";
 
-const launchSignals = [
-  {
-    index: "01",
-    title: "Classic",
-    detail: "Fixed supply",
-    href: "/launch",
-  },
-  {
-    index: "02",
-    title: "Uniswap v4",
-    detail: "One sided liquidity",
-    href: "/docs/creators/launch",
-  },
-  {
-    index: "03",
-    title: "Public record",
-    detail: "Review before signing",
-    href: "/explore",
-  },
-] as const;
-
 export function LandingPage() {
   return (
     <article className={`${styles.page} landing-page-root`}>
       <div className={styles.scene}>
         <section className={styles.panel} aria-labelledby="landing-title">
           <div className={styles.panelArt} aria-hidden="true">
-            <Image
-              src="/brand/programmable-floral-night-background-2172.webp"
-              alt=""
-              fill
-              priority
-              sizes="(max-width: 760px) 100vw, 92vw"
-            />
+            <picture className={styles.panelPicture}>
+              <source
+                media="(max-width: 760px)"
+                srcSet="/brand/atmosphere/night-sky-botanical-mobile-v2.avif"
+              />
+              <Image
+                src="/brand/atmosphere/night-sky-botanical-desktop-v2-1920.avif"
+                alt=""
+                fill
+                priority
+                sizes="(max-width: 760px) 100vw, 82vw"
+              />
+            </picture>
           </div>
           <Image
             className={styles.flowerLeft}
@@ -102,18 +87,11 @@ export function LandingPage() {
 
           <div className={`${styles.hero} ${styles.panelBody}`}>
             <div className={`${styles.heroCopy} ${styles.content}`}>
-              <p className={styles.kicker}>
-                <span aria-hidden="true">✳</span> Uniswap v4 launch surface
-              </p>
               <h1 id="landing-title">
                 <span>Tokens with</span>
                 <span>behavior</span>
                 <span>in view.</span>
               </h1>
-              <p className={styles.heroLead}>
-                Choose a model, set the details that matter, and review the
-                launch surface before your wallet signs.
-              </p>
               <nav className={styles.actions} aria-label="Get started">
                 <Link className={styles.primaryAction} href="/launch">
                   Create a token <span aria-hidden="true">↗</span>
@@ -122,68 +100,10 @@ export function LandingPage() {
                   Explore tokens
                 </Link>
               </nav>
-              <p className={styles.heroNote}>
-                <span aria-hidden="true">↳</span> Classic is the public launch
-                path today.
-              </p>
-            </div>
-
-            <aside className={styles.heroAside} aria-labelledby="aside-title">
-              <p className={styles.asideLabel} id="aside-title">
-                Make the important choices visible.
-              </p>
-              <p className={styles.asideCopy}>
-                Fixed supply, one sided Uniswap v4 liquidity, and a permanent
-                lock from the first review.
-              </p>
-              <dl className={styles.signalList}>
-                {launchSignals.map((signal) => (
-                  <div className={styles.signal} key={signal.index}>
-                    <dt>{signal.index}</dt>
-                    <dd>
-                      <Link href={signal.href}>
-                        <strong>{signal.title}</strong>
-                        <span>{signal.detail}</span>
-                      </Link>
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </aside>
-          </div>
-
-          <div className={styles.panelBottom}>
-            <p className={styles.bottomNote}>
-              Programmable <span aria-hidden="true">/</span> Night Garden
-            </p>
-            <div className={styles.quickLinks}>
-              <Link className={styles.quickCard} href="/launch">
-                <span>Start here</span>
-                <strong>Create a token</strong>
-                <span aria-hidden="true">↗</span>
-              </Link>
-              <Link className={styles.quickCard} href="/explore">
-                <span>Public index</span>
-                <strong>Explore tokens</strong>
-                <span aria-hidden="true">↗</span>
-              </Link>
             </div>
           </div>
 
           <footer className={styles.footer}>
-            <Link
-              className={styles.footerBrand}
-              href="/"
-              aria-label="Programmable home"
-            >
-              Programmable<span aria-hidden="true">©</span>
-            </Link>
-            <nav className={styles.footerLinks} aria-label="Footer navigation">
-              <Link className={styles.docsLink} href="/docs">
-                Docs
-              </Link>
-              <Link href="/explore">Explore</Link>
-            </nav>
             <nav
               className={`${styles.footerIcons} ${styles.supportingLinks}`}
               aria-label="Programmable links"

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -382,6 +382,7 @@
 }
 
 .modelDetails {
+  border-block-start: 0;
   border-color: var(--panel-border-soft);
   display: grid;
   gap: 0;
@@ -392,7 +393,7 @@
 
 .modelDetails > span {
   align-items: center;
-  border-left: 1px solid var(--panel-border-soft);
+  border-left: 0;
   color: var(--muted);
   display: flex;
   font-size: 12px;
@@ -501,9 +502,9 @@
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
   background: var(--liquid-glass-surface-background);
-  border: 1px solid var(--liquid-glass-border);
+  border: 0;
   border-radius: 26px;
-  box-shadow: var(--liquid-glass-shadow);
+  box-shadow: 0 24px 68px rgb(1 1 3 / 0.28);
   display: grid;
   gap: 18px;
   margin: 7px auto 0;
@@ -585,8 +586,9 @@
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
   background: var(--liquid-glass-surface-background);
+  border: 0;
   border-color: var(--liquid-glass-border);
-  box-shadow: var(--liquid-glass-shadow);
+  box-shadow: 0 24px 68px rgb(1 1 3 / 0.28);
   max-width: 1000px;
   min-width: 0;
   margin-top: 0;
@@ -609,7 +611,7 @@
 
 .formLockNotice {
   background: color-mix(in srgb, var(--accent-wash) 64%, transparent);
-  border-bottom: 1px solid var(--panel-border-soft);
+  border-bottom: 0;
   color: color-mix(in srgb, var(--text) 74%, var(--text-soft));
   font-size: 12px;
   line-height: 1.45;
@@ -751,6 +753,7 @@
 
 .formPage :global(.classic-fee-section),
 .formPage :global(.classic-v3-settings) {
+  border-block-start: 0;
   border-color: var(--panel-border-soft);
   margin-top: 18px;
   padding-top: 17px;
@@ -781,6 +784,7 @@
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
   background: var(--liquid-glass-inner-background);
+  border-block-start: 0;
   border-color: var(--liquid-glass-border);
   min-height: 70px;
   padding: 10px 28px;
@@ -871,9 +875,9 @@
 .formPage :global(.classic-v3-initial-buy .meme-dev-buy),
 .formPage :global(.classic-v3-custody) {
   background: var(--liquid-glass-inner-background);
-  border: 1px solid var(--liquid-glass-border);
+  border: 0;
   border-radius: 18px;
-  box-shadow: inset 0 1px 0 var(--control-glass-highlight);
+  box-shadow: none;
   padding: 15px;
 }
 
@@ -912,7 +916,7 @@
 .formPage :global(.deep-preset) {
   background: transparent;
   border: 0;
-  border-bottom: 1px solid var(--panel-border-soft);
+  border-bottom: 0;
   border-radius: 0;
   margin-top: 18px;
   padding: 0 0 18px;
@@ -936,7 +940,7 @@
 .formPage :global(.deep-preset-stats > div) {
   background: transparent;
   border: 0;
-  border-left: 1px solid var(--panel-border-soft);
+  border-left: 0;
   border-radius: 0;
   padding: 3px 14px;
 }
@@ -954,6 +958,7 @@
 }
 
 .formPage :global(.deep-preset-details) {
+  border-block-start: 0;
   border-bottom: 0;
   border-color: var(--panel-border-soft);
   margin-top: 2px;
@@ -1367,12 +1372,12 @@
   .formPage :global(.deep-preset-stats > div),
   .formPage :global(.deep-preset-stats > div:first-child) {
     border-left: 0;
-    border-top: 1px solid var(--panel-border-soft);
+    border-block-start: 0;
     padding: 9px 0;
   }
 
   .formPage :global(.deep-preset-stats > div:first-child) {
-    border-top: 0;
+    border-block-start: 0;
   }
 
   .formLoadingSheet {
@@ -1414,5 +1419,70 @@
   .formLoadingBlock,
   .formLoadingRow {
     animation: none;
+  }
+}
+
+/* Keep the model picker quiet: hierarchy comes from the art and title. */
+.modelCard.modelCard {
+  border: 0;
+  box-shadow: 0 24px 68px rgb(1 1 3 / 0.28);
+}
+
+.modelCard.modelCard:hover {
+  border-color: transparent;
+  box-shadow: 0 24px 68px rgb(1 1 3 / 0.28);
+}
+
+.modelArt {
+  border-bottom: 0;
+}
+
+.modelArt::after {
+  box-shadow: none;
+}
+
+.modelHeading small {
+  background: transparent;
+  border: 0;
+  padding-inline: 0;
+}
+
+.modelDescription {
+  /* Keep the full explanation available to assistive technology via
+   * aria-describedby without making every card read like a text block. */
+  block-size: 1px;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px 0 0;
+  min-height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.modelBody.modelBody {
+  min-height: 174px;
+  padding-bottom: 12px;
+}
+
+@media (min-width: 761px) {
+  .modelBody.modelBody {
+    min-height: 184px;
+  }
+}
+
+@media (max-width: 760px) {
+  .modelBody.modelBody {
+    min-height: 0;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .modelCard.modelCard[data-launch-model-available="true"]:hover,
+  .modelCard.modelCard[href]:hover {
+    border-color: transparent;
+    box-shadow: 0 24px 68px rgb(1 1 3 / 0.28);
   }
 }

--- a/components/manual-applicant-launch.module.css
+++ b/components/manual-applicant-launch.module.css
@@ -14,8 +14,7 @@
   min-height: 44px;
 }
 
-.betaLabel,
-.kicker {
+.betaLabel {
   color: var(--accent-strong);
   font-size: 11px;
   font-weight: 720;

--- a/components/manual-applicant-launch.tsx
+++ b/components/manual-applicant-launch.tsx
@@ -1168,7 +1168,6 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
 
       <section className={styles.hero} aria-labelledby="applicant-launch-title">
         <div className={styles.heroCopy}>
-          <span className={styles.kicker}>Applicant launch</span>
           <h1 id="applicant-launch-title" ref={titleRef} tabIndex={-1}>
             {exactHookemonApplicant
               ? "Prepare the Hookemon launch"
@@ -1211,7 +1210,6 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
         >
           <div className={styles.sectionHeading}>
             <div>
-              <span className={styles.kicker}>Your launch</span>
               <h2 id="applicant-workspace-title">Approved submission</h2>
             </div>
             {loading ? (

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -1855,3 +1855,45 @@
     background: CanvasText;
   }
 }
+
+/* Quiet, borderless night surfaces. Controls keep their own boundaries and
+ * focus rings; large layout containers use depth and spacing instead. */
+.connectCard,
+.profileWorkspace,
+.sessionLoadingWorkspace {
+  border: 0 !important;
+  box-shadow: 0 28px 78px rgb(0 0 0 / 0.34) !important;
+}
+
+.connectCard p,
+.launchesHeader p {
+  display: none;
+}
+
+.heroEditing,
+.customProjects,
+.customProjectCard,
+.launchesPanel,
+.claimablePanel,
+.claimDialogSurface {
+  border-color: transparent;
+  box-shadow: 0 20px 56px rgb(0 0 0 / 0.2);
+}
+
+.launchRow {
+  border-color: transparent;
+}
+
+.avatar,
+.claimArt {
+  outline: 0;
+}
+
+.feeComposition {
+  border: 0;
+}
+
+.claimDialogGroup + .claimDialogGroup {
+  border-block-start: 0;
+  padding-block-start: 0;
+}

--- a/components/site-footer.module.css
+++ b/components/site-footer.module.css
@@ -10,12 +10,12 @@
   border-radius: 24px;
   box-shadow: var(--liquid-glass-shadow);
   display: grid;
-  gap: 0 clamp(32px, 4vw, 58px);
+  gap: 0 clamp(36px, 4.5vw, 64px);
   grid-template-columns:
-    minmax(210px, 1.1fr)
-    minmax(110px, 0.56fr)
-    minmax(128px, 0.68fr)
-    minmax(300px, 1.5fr);
+    minmax(220px, 1.15fr)
+    minmax(112px, 0.56fr)
+    minmax(136px, 0.68fr)
+    minmax(260px, 1.35fr);
   overflow: hidden;
   min-width: 0;
   padding: 30px;
@@ -28,7 +28,7 @@
 .brand {
   align-content: start;
   display: grid;
-  gap: 14px;
+  gap: 10px;
 }
 
 .brandLink {
@@ -57,6 +57,15 @@
   letter-spacing: -0.005em;
   line-height: 1.5;
   margin: 0;
+}
+
+.tagline {
+  color: var(--text-soft);
+  font-size: 13.5px;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 26ch;
+  text-wrap: pretty;
 }
 
 .risk p {
@@ -100,9 +109,16 @@
   font-size: 14px;
   font-weight: 560;
   min-height: 36px;
+  margin-inline-start: -10px;
+  padding-inline: 10px;
   transition:
     background-color 120ms ease,
     color 120ms ease;
+}
+
+.column a:focus-visible {
+  outline: 2px solid var(--brand-ivory);
+  outline-offset: 2px;
 }
 
 .risk {
@@ -126,6 +142,7 @@
 
   .risk {
     grid-column: 1 / -1;
+    border-top: 1px solid var(--liquid-glass-border);
     padding-top: 10px;
   }
 
@@ -155,6 +172,10 @@
 
   .column a {
     min-height: 44px;
+  }
+
+  .tagline {
+    max-width: 34ch;
   }
 }
 

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -67,9 +67,6 @@ export function SiteFooter() {
             />
             <span>Programmable</span>
           </Link>
-          <p className={styles.tagline}>
-            Explore, create, and track tokens built on Uniswap v4.
-          </p>
           <p className={styles.copyright}>© 2026 Programmable</p>
         </section>
 

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -49,13 +49,8 @@ const resourceLinks = [
 
 export function SiteFooter() {
   return (
-    <footer
-      className={`${styles.footer} page-width`}
-      aria-label="Site footer"
-    >
-      <div
-        className={`${styles.surface} liquid-glass-surface`}
-      >
+    <footer className={`${styles.footer} page-width`} aria-label="Site footer">
+      <div className={`${styles.surface} liquid-glass-surface`}>
         <section className={styles.brand}>
           <Link
             className={styles.brandLink}
@@ -72,6 +67,9 @@ export function SiteFooter() {
             />
             <span>Programmable</span>
           </Link>
+          <p className={styles.tagline}>
+            Explore, create, and track tokens built on Uniswap v4.
+          </p>
           <p className={styles.copyright}>© 2026 Programmable</p>
         </section>
 
@@ -92,7 +90,12 @@ export function SiteFooter() {
             {resourceLinks.map((link) => (
               <li key={link.href}>
                 {link.external ? (
-                  <a href={link.href} target="_blank" rel="noreferrer">
+                  <a
+                    href={link.href}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label={`${link.label} (opens in a new tab)`}
+                  >
                     {link.label}
                   </a>
                 ) : (
@@ -107,8 +110,8 @@ export function SiteFooter() {
           <h2 className={styles.label}>Risk notice</h2>
           <p>
             Transactions may be irreversible. Tokens can be volatile, illiquid
-            or lose all value. Programmable does not provide financial advice
-            or guarantee a token&apos;s quality.
+            or lose all value. Programmable does not provide financial advice or
+            guarantee a token&apos;s quality.
           </p>
         </section>
       </div>

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -1954,3 +1954,17 @@
     animation: none;
   }
 }
+
+/* Keep the token workspace tactile without outlining every nested surface.
+ * Address, input and action controls retain their explicit affordances. */
+.image,
+.launchRecord,
+.deepSummary,
+.customMarketPanel,
+.customAuthorityPanel,
+.customProvenancePanel,
+.tradeShell,
+.reviewOutput {
+  border-color: transparent;
+  box-shadow: 0 20px 56px rgb(0 0 0 / 0.22);
+}

--- a/components/token-price-chart.module.css
+++ b/components/token-price-chart.module.css
@@ -2,9 +2,9 @@
   -webkit-backdrop-filter: var(--liquid-glass-backdrop);
   backdrop-filter: var(--liquid-glass-backdrop);
   background: var(--liquid-glass-surface-background);
-  border: 1px solid var(--liquid-glass-border);
+  border: 0;
   border-radius: 24px;
-  box-shadow: var(--liquid-glass-shadow);
+  box-shadow: 0 20px 56px rgb(1 1 3 / 0.22);
   display: flex;
   flex-direction: column;
   height: 100%;


### PR DESCRIPTION
## Summary
- Reframe the landing page around a clear Classic launch path with concrete product proof and stronger CTA hierarchy.
- Improve Explore hierarchy, search language, loading/empty/error states, pagination semantics, and mobile card readability.
- Tune botanical atmosphere, mobile navigation surface, route-heading focus, docs mobile navigation labeling, and shared footer copy/touch targets.

## Scope
UI, CSS, accessibility, metadata/frontend copy only. No contracts, APIs, database, indexer, workflows, scripts, dependencies, package files, or lockfile changes.

## Validation
- `npm run build`
- `npm run typecheck`
- targeted ESLint and Prettier checks
- rendered Playwright QA at 1440x900 and 390x844 for home, Explore, and Docs; no horizontal overflow, one main landmark on home, mobile artwork has non-zero dimensions, and route heading focus is visible
- scoped diff allowlist and `git diff --check`

The local Explore route still reports the existing `GET /api/explore?...` 503 and renders its existing fixture fallback; API work is intentionally out of scope. One legacy source-contract test still asserts the retired landing slogan; tests were not changed.