### PR TITLE
Fix scoped production proof results

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -306,10 +306,10 @@ jobs:
           PRODUCTION_VERIFY_SCOPE_INTERFACE: ${{ needs.scope.outputs.interface }}
           PRODUCTION_VERIFY_SCOPE_READ_MODEL: ${{ needs.scope.outputs.read_model }}
           PRODUCTION_VERIFY_SECRET_SCAN_RESULT: ${{ needs.secret-scan.result }}
-          PRODUCTION_VERIFY_INDEXER_RESULT: ${{ needs.indexer.result }}
-          PRODUCTION_VERIFY_DATABASE_PGLITE_RESULT: ${{ needs.database-pglite.result }}
-          PRODUCTION_VERIFY_INTERFACE_RESULT: ${{ needs.interface.result }}
-          PRODUCTION_VERIFY_CONTRACTS_RESULT: ${{ needs.contracts.result }}
+          PRODUCTION_VERIFY_INDEXER_RESULT: ${{ needs.scope.outputs.indexer == 'true' && needs.indexer.result || 'skipped' }}
+          PRODUCTION_VERIFY_DATABASE_PGLITE_RESULT: ${{ needs.scope.outputs.database == 'true' && needs.database-pglite.result || 'skipped' }}
+          PRODUCTION_VERIFY_INTERFACE_RESULT: ${{ needs.scope.outputs.interface == 'true' && needs.interface.result || 'skipped' }}
+          PRODUCTION_VERIFY_CONTRACTS_RESULT: ${{ needs.scope.outputs.contracts == 'true' && needs.contracts.result || 'skipped' }}
         run: >-
           node scripts/production-verify-proof.mjs create
           --repository-root "$GITHUB_WORKSPACE"

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1401,7 +1401,16 @@ export function evaluateReadModelOperationsSourceContracts(
       verifyWorkflow.includes("name: Bind production Verify proof") &&
       verifyWorkflow.includes("needs:\n      - scope\n      - secret-scan") &&
       verifyWorkflow.includes(
-        "PRODUCTION_VERIFY_CONTRACTS_RESULT: ${{ needs.contracts.result }}",
+        "PRODUCTION_VERIFY_INDEXER_RESULT: ${{ needs.scope.outputs.indexer == 'true' && needs.indexer.result || 'skipped' }}",
+      ) &&
+      verifyWorkflow.includes(
+        "PRODUCTION_VERIFY_DATABASE_PGLITE_RESULT: ${{ needs.scope.outputs.database == 'true' && needs.database-pglite.result || 'skipped' }}",
+      ) &&
+      verifyWorkflow.includes(
+        "PRODUCTION_VERIFY_INTERFACE_RESULT: ${{ needs.scope.outputs.interface == 'true' && needs.interface.result || 'skipped' }}",
+      ) &&
+      verifyWorkflow.includes(
+        "PRODUCTION_VERIFY_CONTRACTS_RESULT: ${{ needs.scope.outputs.contracts == 'true' && needs.contracts.result || 'skipped' }}",
       ) &&
       verifyWorkflow.includes(
         "PRODUCTION_VERIFY_SCOPE_READ_MODEL: ${{ needs.scope.outputs.read_model }}",


### PR DESCRIPTION
## Summary
- report non-required verification lanes as skipped when building the path-scoped production proof
- retain actual GitHub job conclusions for every required lane
- bind all four lane mappings in the existing fail-closed operations source contract

## Why
Production commit 9fe4285 passed every required verification lane, but proof creation rejected the successful no-op indexer job because the scoped proof correctly expects skipped for a non-required lane.

## Verification
- actionlint
- production proof tests: 12 passed
- read-model operations contract: 32 passed
- source-contract evaluator: green
- git diff --check