### PR TITLE
fix(ci): verify shallow merge parents from raw bytes

### DIFF
--- a/scripts/test/verify-main-ci-control-change.test.mjs
+++ b/scripts/test/verify-main-ci-control-change.test.mjs
@@ -98,7 +98,7 @@ test("workflow, local action, ownership, submodule, and routing controls are pro
   }
 });
 
-test("candidate Git evidence retains both sides of a protected rename and exact merge identity", (t) => {
+test("candidate Git evidence retains exact merge identity across a shallow fetch boundary", (t) => {
   const repositoryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "programmable-main-ci-guard-"));
   t.after(() => fs.rmSync(repositoryRoot, { recursive: true, force: true }));
   git(repositoryRoot, ["init", "--quiet"]);
@@ -122,6 +122,12 @@ test("candidate Git evidence retains both sides of a protected rename and exact 
   git(repositoryRoot, ["checkout", "--quiet", baseBranch]);
   git(repositoryRoot, ["merge", "--quiet", "--no-ff", "candidate", "-m", "merge"]);
   const mergeCommit = git(repositoryRoot, ["rev-parse", "HEAD"]).trim();
+  fs.writeFileSync(path.join(repositoryRoot, ".git", "shallow"), `${mergeCommit}\n`);
+  assert.equal(
+    git(repositoryRoot, ["show", "-s", "--format=%P", mergeCommit]).trim(),
+    "",
+    "the regression fixture must reproduce the traversal-level parent loss"
+  );
 
   const evidence = readCandidateChange({
     candidateRoot: repositoryRoot,

--- a/scripts/verify-main-ci-control-change.mjs
+++ b/scripts/verify-main-ci-control-change.mjs
@@ -78,9 +78,7 @@ export function readCandidateChange({
   execGit(root, ["cat-file", "-e", `${expectedCandidateCommit}^{commit}`]);
   execGit(root, ["cat-file", "-e", `${expectedMergeCommit}^{commit}`]);
 
-  const mergeParents = execGit(root, ["show", "-s", "--format=%P", expectedMergeCommit], "utf8")
-    .trim()
-    .split(" ");
+  const mergeParents = readCommitParents(root, expectedMergeCommit);
   if (
     mergeParents.length !== 2
     || mergeParents[0] !== expectedBaseCommit
@@ -105,6 +103,22 @@ export function readCandidateChange({
     candidateTree,
     changedPaths
   };
+}
+
+function readCommitParents(repositoryRoot, commit) {
+  const commitBytes = execGit(repositoryRoot, ["cat-file", "commit", commit]);
+  const headerEnd = commitBytes.indexOf("\n\n");
+  if (headerEnd === -1) throw new Error("candidate merge commit has no canonical header boundary");
+
+  const parents = [];
+  const headerLines = commitBytes.subarray(0, headerEnd).toString("utf8").split("\n");
+  for (const line of headerLines) {
+    if (!line.startsWith("parent ")) continue;
+    const parent = line.slice("parent ".length);
+    requireObjectId(parent, "candidate merge parent");
+    parents.push(parent);
+  }
+  return parents;
 }
 
 function parseChangedPathStream(output) {
@@ -149,7 +163,7 @@ function validateChangedPaths(inputPaths) {
 }
 
 function execGit(repositoryRoot, arguments_, encoding = null) {
-  return execFileSync("git", arguments_, {
+  return execFileSync("git", ["--no-pager", "--no-replace-objects", ...arguments_], {
     cwd: repositoryRoot,
     encoding,
     maxBuffer: MAX_GIT_OUTPUT_BYTES,


### PR DESCRIPTION
## Summary

- read authenticated merge parents from the raw commit object instead of the traversal view hidden by a depth-1 shallow boundary
- disable replace-object interpretation for every guard Git command
- reproduce the exact shallow Candidate-store failure in a regression test

This preserves the existing exact base/head parent check and does not widen the accepted path or control-plane policy.

## Validation

- main CI control guard and workflow tests: 8/8 passed
- `git diff --check`

Observed blocker: Programmable main PR #240 fetched the correct merge object `89cd92c70370f0604063c45ebd084e0677d35bb6`, but `git show --format=%P` returned no parents because that merge was marked shallow.