### PR TITLE
Route Custom Launch through the generic applicant flow

### DIFF
--- a/app/launch/page.tsx
+++ b/app/launch/page.tsx
@@ -5,8 +5,6 @@ import {
   configuredLaunchPermitSignersV2,
   isCustomLaunchPublicEnabled,
 } from "@/lib/server/custom-launch/public-readiness";
-import { isManualRouterApplicantLaunchEnabledV1 } from
-  "@/lib/server/custom-launch/manual-router-config-v1";
 
 export const dynamic = "force-dynamic";
 
@@ -23,7 +21,6 @@ export default function LaunchPage() {
   return (
     <LaunchExperience
       customLaunchPublicEnabled={isCustomLaunchPublicEnabled()}
-      manualApplicantLaunchEnabled={isManualRouterApplicantLaunchEnabledV1()}
       trustedLaunchPermitSigners={configuredLaunchPermitSignersV2()}
     />
   );

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -34,10 +34,6 @@ function loadCustomLaunch() {
   return import("@/components/custom-launch-experience");
 }
 
-function loadManualApplicantLaunch() {
-  return import("@/components/manual-applicant-launch");
-}
-
 const LazyLaunchBuilderForm = lazy(async () => {
   const launchModule = await loadLaunchForm();
   return { default: launchModule.LaunchBuilderForm };
@@ -48,12 +44,13 @@ const LazyCustomLaunchExperience = lazy(async () => {
   return { default: customModule.CustomLaunchExperience };
 });
 
-const LazyManualApplicantLaunch = lazy(async () => {
-  const applicantModule = await loadManualApplicantLaunch();
-  return { default: applicantModule.ManualApplicantLaunch };
-});
-
-function LaunchFormLoading({ onBack }: { onBack: () => void }) {
+function LaunchFormLoading({
+  onBack,
+  title = "Create token",
+}: {
+  onBack: () => void;
+  title?: string;
+}) {
   return (
     <div
       className={`launch-page page-width ${launchExperience.formPage} ${launchExperience.formLoadingPage}`}
@@ -69,7 +66,7 @@ function LaunchFormLoading({ onBack }: { onBack: () => void }) {
           Back
         </button>
         <div className={`launch-page-title ${launchExperience.formPageTitle}`}>
-          <h1>Create token</h1>
+          <h1>{title}</h1>
         </div>
       </header>
       <div
@@ -87,32 +84,22 @@ function LaunchFormLoading({ onBack }: { onBack: () => void }) {
 
 export function LaunchExperience({
   customLaunchPublicEnabled,
-  manualApplicantLaunchEnabled = false,
   trustedLaunchPermitSigners = [],
 }: {
   customLaunchPublicEnabled: boolean;
-  manualApplicantLaunchEnabled?: boolean;
   trustedLaunchPermitSigners?: readonly TrustedLaunchPermitSignerV2[];
 }) {
-  const [selectedModel, setSelectedModel] = useState<
-    LaunchModel | "custom" | "manual-applicant" | null
-  >(null);
-  const manualApplicantButtonRef = useRef<HTMLButtonElement>(null);
-  const restoreManualApplicantFocusRef = useRef(false);
+  const [selectedModel, setSelectedModel] = useState<LaunchModel | "custom" | null>(null);
+  const customLaunchButtonRef = useRef<HTMLButtonElement>(null);
+  const restoreCustomLaunchFocusRef = useRef(false);
 
   useEffect(() => {
-    if (selectedModel !== null || !restoreManualApplicantFocusRef.current) return;
-    restoreManualApplicantFocusRef.current = false;
-    manualApplicantButtonRef.current?.focus();
+    if (selectedModel !== null || !restoreCustomLaunchFocusRef.current) return;
+    restoreCustomLaunchFocusRef.current = false;
+    customLaunchButtonRef.current?.focus();
   }, [selectedModel]);
 
-  function chooseModel(candidate: LaunchModel | "custom" | "manual-applicant") {
-    if (candidate === "manual-applicant") {
-      if (!manualApplicantLaunchEnabled) return;
-      window.scrollTo({ left: 0, top: 0, behavior: "auto" });
-      setSelectedModel(candidate);
-      return;
-    }
+  function chooseModel(candidate: LaunchModel | "custom") {
     if (candidate === "custom") {
       if (!customLaunchPublicEnabled) return;
       window.scrollTo({ left: 0, top: 0, behavior: "auto" });
@@ -134,7 +121,7 @@ export function LaunchExperience({
   }
 
   function returnToModels() {
-    restoreManualApplicantFocusRef.current = selectedModel === "manual-applicant";
+    restoreCustomLaunchFocusRef.current = selectedModel === "custom";
     window.scrollTo({ left: 0, top: 0, behavior: "auto" });
     setSelectedModel(null);
   }
@@ -142,8 +129,8 @@ export function LaunchExperience({
   if (!selectedModel) {
     return (
       <LaunchModelPicker
-        manualApplicantLaunchEnabled={manualApplicantLaunchEnabled}
-        manualApplicantButtonRef={manualApplicantButtonRef}
+        customLaunchPublicEnabled={customLaunchPublicEnabled}
+        customLaunchButtonRef={customLaunchButtonRef}
         onChoose={chooseModel}
       />
     );
@@ -151,19 +138,11 @@ export function LaunchExperience({
 
   if (selectedModel === "custom") {
     return (
-      <Suspense fallback={<LaunchFormLoading onBack={returnToModels} />}>
+      <Suspense fallback={<LaunchFormLoading title="Custom launch" onBack={returnToModels} />}>
         <LazyCustomLaunchExperience
           onBack={returnToModels}
           trustedLaunchPermitSigners={trustedLaunchPermitSigners}
         />
-      </Suspense>
-    );
-  }
-
-  if (selectedModel === "manual-applicant") {
-    return (
-      <Suspense fallback={<LaunchFormLoading onBack={returnToModels} />}>
-        <LazyManualApplicantLaunch onBack={returnToModels} />
       </Suspense>
     );
   }
@@ -180,19 +159,23 @@ export function LaunchExperience({
 }
 
 export function LaunchModelPicker({
-  manualApplicantLaunchEnabled = false,
-  manualApplicantButtonRef,
+  customLaunchPublicEnabled = false,
+  customLaunchButtonRef,
   onChoose,
 }: {
-  manualApplicantLaunchEnabled?: boolean;
-  manualApplicantButtonRef?: RefObject<HTMLButtonElement | null>;
-  onChoose: (model: LaunchModel | "manual-applicant") => void;
+  /**
+   * This is the same closed-world gate used by the generic Custom Launch API.
+   * The picker must never infer launchability from a legacy/manual flag.
+   */
+  customLaunchPublicEnabled?: boolean;
+  customLaunchButtonRef?: RefObject<HTMLButtonElement | null>;
+  onChoose: (model: LaunchModel | "custom") => void;
 }) {
   const preloadAvailableForm = () => {
     void loadLaunchForm();
   };
-  const preloadManualApplicantLaunch = () => {
-    void loadManualApplicantLaunch();
+  const preloadCustomLaunch = () => {
+    void loadCustomLaunch();
   };
 
   return (
@@ -206,19 +189,19 @@ export function LaunchModelPicker({
       </header>
 
       <div className={`launch-model-grid ${launchExperience.modelGrid}`}>
-        {manualApplicantLaunchEnabled ? (
+        {customLaunchPublicEnabled ? (
           <button
-            ref={manualApplicantButtonRef}
+            ref={customLaunchButtonRef}
             className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
-            data-launch-model-option="manual-applicant"
+            data-launch-model-option="custom"
             data-launch-model-available="true"
             data-launch-model-launchable="true"
             type="button"
-            aria-labelledby="launch-model-manual-applicant-title"
-            aria-describedby="launch-model-manual-applicant-description"
-            onPointerEnter={preloadManualApplicantLaunch}
-            onFocus={preloadManualApplicantLaunch}
-            onClick={() => onChoose("manual-applicant")}
+            aria-labelledby="launch-model-custom-title"
+            aria-describedby="launch-model-custom-description"
+            onPointerEnter={preloadCustomLaunch}
+            onFocus={preloadCustomLaunch}
+            onClick={() => onChoose("custom")}
           >
             <span
               className={`launch-model-art ${launchExperience.modelArt} ${launchExperience.customArt}`}
@@ -248,22 +231,22 @@ export function LaunchModelPicker({
               <span
                 className={`launch-model-card-heading ${launchExperience.modelHeading}`}
               >
-                <strong id="launch-model-manual-applicant-title">
+                <strong id="launch-model-custom-title">
                   Custom Hook
                 </strong>
-                <small data-status="ready">Ready</small>
+                <small data-status="available">Available</small>
               </span>
               <span
                 className={`launch-model-description ${launchExperience.modelDescription}`}
-                id="launch-model-manual-applicant-description"
+                id="launch-model-custom-description"
               >
-                Sign in with the GitHub account and wallet approved in your
-                Hookbuilder submission. Your exact coin loads automatically.
+                Launch a project only after its exact GitHub revision has been
+                reviewed and approved by Programmable.
               </span>
               <span
                 className={`launch-model-action ${launchExperience.modelAction}`}
               >
-                Open Custom Hook launch
+                Open approved Custom Hook launch
                 <ArrowRight aria-hidden="true" size={16} />
               </span>
             </span>

--- a/components/manual-applicant-launch.tsx
+++ b/components/manual-applicant-launch.tsx
@@ -36,6 +36,9 @@ import {
   isExactHookemonApplicantGithubLoginV1,
 } from "@/lib/custom-launch/hookemon-applicant-presentation-v1";
 import {
+  isApplicantRefreshUserUnavailableErrorV1,
+} from "@/lib/custom-launch/applicant-refresh-user-gate-v1";
+import {
   type ManualRouterApplicantListResponseV1,
   type ManualRouterPersistedAttemptV1,
   type ManualRouterResolveResponseV1,
@@ -207,7 +210,20 @@ export async function acquireManualRouterWebsiteSessionV1(input: Readonly<{
   ) => Promise<WalletApplicantSessionV1 | null>;
   requirement?: WalletApplicantIdentityRequirementV1;
 }>): Promise<ManualRouterWebsiteSessionV1> {
-  const session = await input.refreshApplicantSession(input.requirement);
+  let session: WalletApplicantSessionV1 | null;
+  try {
+    session = await input.refreshApplicantSession(input.requirement);
+  } catch (error) {
+    if (isApplicantRefreshUserUnavailableErrorV1(error)) {
+      throw new ManualRouterWebsiteRequestErrorV1(
+        error.status,
+        error.code,
+        error.message,
+        error.retryable,
+      );
+    }
+    throw error;
+  }
   if (!session) {
     throw new ManualRouterWebsiteRequestErrorV1(
       401,

--- a/components/manual-applicant-launch.tsx
+++ b/components/manual-applicant-launch.tsx
@@ -285,6 +285,7 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     useState<ManualRouterDirectory | null>(null);
   const [selectedSubjectHash, setSelectedSubjectHash] =
     useState<ManualRouterSha256V1 | "">("");
+  const selectedSubjectHashRef = useRef<ManualRouterSha256V1 | "">("");
   const [resolved, setResolved] =
     useState<ManualRouterResolved | null>(null);
   const [routeAcceptance, setRouteAcceptance] =
@@ -466,11 +467,13 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
         requireExactShardsRoute: exactShardsApplicant,
       });
       if (controller.signal.aborted || sequence !== loadSequenceRef.current) return;
-      const preferred = options?.preferredSubjectHash || selectedSubjectHash;
+      const preferred = options?.preferredSubjectHash
+        || selectedSubjectHashRef.current;
       const chosen = next.submissions.some(({ subjectHash }) =>
         subjectHash === preferred)
         ? preferred
         : preferredSubmission(next.submissions)?.subjectHash ?? "";
+      selectedSubjectHashRef.current = chosen;
       setSelectedSubjectHash(chosen);
       const chosenSubmission = next.submissions.find(({ subjectHash }) =>
         subjectHash === chosen) ?? null;
@@ -635,7 +638,6 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
     githubConnected,
     githubUsername,
     exactShardsApplicant,
-    selectedSubjectHash,
     routeDiscoveryAllowed,
     wallet,
   ]);
@@ -677,6 +679,7 @@ export function ManualApplicantLaunch({ onBack }: { onBack: () => void }) {
 
   const chooseSubmission = useCallback(async (subjectHash: string) => {
     if (!/^sha256:[0-9a-f]{64}$/u.test(subjectHash)) return;
+    selectedSubjectHashRef.current = subjectHash as ManualRouterSha256V1;
     setSelectedSubjectHash(subjectHash as ManualRouterSha256V1);
     setResolved(null);
     setAttempt(null);

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -807,6 +807,14 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
   }, [applicantRefreshUserGate, refreshUser]);
   const { reauthorize } = useOAuthTokens();
   const { identityToken } = useIdentityToken();
+  // Keep the latest hook value available to stable Applicant callbacks. The
+  // callback must not depend on the token itself: Privy updates this value
+  // after `refreshUser()`, and changing the callback identity would restart
+  // the discovery effect while its first request is still settling.
+  const applicantIdentityTokenRef = useRef<string | null>(identityToken);
+  useEffect(() => {
+    applicantIdentityTokenRef.current = identityToken;
+  }, [identityToken]);
   const { sendTransaction: sendPrivyTransaction } = usePrivySendTransaction();
   const { signMessage: signPrivyMessage } = usePrivySignMessage();
   const { ready: walletsReady, wallets } = useWallets();
@@ -960,11 +968,23 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
         readCurrentAuthority: () => applicantAuthorityRef.current,
         refreshUser: () => applicantRefreshUserGate.refresh(authorityKey),
         getAccessToken,
-        getIdentityToken: getPrivyIdentityToken,
+        // `refreshUser()` already performs Privy's `/users/me` read and updates
+        // its identity-token store. Calling the exported global
+        // `getIdentityToken()` here would perform a second `/users/me` read and
+        // deterministically hit Privy's one-request rate bucket. Applicant
+        // sessions therefore consume only the hook-cached token; if hydration
+        // has not exposed it yet, the session fails closed and the next retry
+        // can use the updated hook value.
+        getIdentityToken: async () => applicantIdentityTokenRef.current,
         requirement,
       });
     },
-    [activeAuthenticated, applicantRefreshUserGate, getAccessToken, ready],
+    [
+      activeAuthenticated,
+      applicantRefreshUserGate,
+      getAccessToken,
+      ready,
+    ],
   );
   const reauthorizeGithub = useCallback(async () => {
     if (!ready || !activeAuthenticated || !githubConnected) {

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -51,6 +51,12 @@ import {
 import {
   verifyHookemonActionIdentifierAuthorityForSendV1,
 } from "@/lib/custom-launch/hookemon-action-identifier-verifier-v1";
+import {
+  applicantRefreshUserIsRateLimitedV1,
+  createApplicantRefreshUserGateV1,
+  isApplicantRefreshUserUnavailableErrorV1,
+  type ApplicantRefreshUserGateV1,
+} from "@/lib/custom-launch/applicant-refresh-user-gate-v1";
 import { parseLocalProfile } from "@/lib/profile/local-profile";
 import {
   buildEip1193TransactionRequest,
@@ -199,7 +205,48 @@ type ApplicantAuthoritySnapshotV1 = Readonly<{
   githubUserId: string | null;
   githubLogin: string | null;
   walletAddress: string | null;
+  linkedAccountsFingerprint: string | null;
 }>;
+
+function applicantLinkedAccountsFingerprintV1(
+  linkedAccounts: unknown,
+): string | null {
+  if (!Array.isArray(linkedAccounts)) return null;
+
+  const records = linkedAccounts.map((account) => {
+    if (account === null || typeof account !== "object") {
+      return ["invalid", null, null, null, null] as const;
+    }
+    const record = account as Readonly<Record<string, unknown>>;
+    const normalized = (field: string, lowerCase = false): string | null => {
+      const value = record[field];
+      if (typeof value !== "string") return null;
+      return lowerCase ? value.toLowerCase() : value;
+    };
+    return [
+      normalized("type"),
+      normalized("subject"),
+      normalized("username", true),
+      normalized("address", true),
+      normalized("chainType", true),
+    ] as const;
+  });
+  records.sort((left, right) =>
+    JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  return JSON.stringify(records);
+}
+
+function applicantAuthorityCacheKeyV1(
+  authority: ApplicantAuthoritySnapshotV1,
+): string {
+  return JSON.stringify([
+    authority.privyUserId,
+    authority.githubUserId,
+    authority.githubLogin?.toLowerCase() ?? null,
+    authority.walletAddress?.toLowerCase() ?? null,
+    authority.linkedAccountsFingerprint,
+  ]);
+}
 
 export async function refreshWalletApplicantSessionV1(input: Readonly<{
   authenticated: boolean;
@@ -291,7 +338,8 @@ export async function refreshWalletApplicantSessionV1(input: Readonly<{
       githubLogin: github.username,
       launchWallet,
     });
-  } catch {
+  } catch (error) {
+    if (isApplicantRefreshUserUnavailableErrorV1(error)) throw error;
     return null;
   }
 }
@@ -304,7 +352,8 @@ function authoritySnapshotMatches(
     && current.githubUserId === expected.githubUserId
     && current.githubLogin?.toLowerCase() === expected.githubLogin?.toLowerCase()
     && current.walletAddress?.toLowerCase()
-      === expected.walletAddress?.toLowerCase();
+      === expected.walletAddress?.toLowerCase()
+    && current.linkedAccountsFingerprint === expected.linkedAccountsFingerprint;
 }
 
 export function getWalletProfileStorageKey(account: string) {
@@ -742,6 +791,20 @@ function ConfiguredWalletProvider({
 function PrivyWalletBridge({ children }: { children: ReactNode }) {
   const { authenticated, getAccessToken, logout, ready, user } = usePrivy();
   const { refreshUser } = useUser();
+  const [applicantRefreshUserGate] = useState<ApplicantRefreshUserGateV1<
+    RefreshableApplicantUserV1 | null | undefined
+  >>(() => createApplicantRefreshUserGateV1<
+    RefreshableApplicantUserV1 | null | undefined
+  >({
+    source: () =>
+      refreshUser() as Promise<RefreshableApplicantUserV1>,
+    isRateLimited: applicantRefreshUserIsRateLimitedV1,
+  }));
+  useEffect(() => {
+    applicantRefreshUserGate.setSource(
+      () => refreshUser() as Promise<RefreshableApplicantUserV1>,
+    );
+  }, [applicantRefreshUserGate, refreshUser]);
   const { reauthorize } = useOAuthTokens();
   const { identityToken } = useIdentityToken();
   const { sendTransaction: sendPrivyTransaction } = usePrivySendTransaction();
@@ -757,6 +820,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
   const [selectedWalletAddress, setSelectedWalletAddress] = useState<string | null>(null);
   const { login } = useLogin({
     onComplete: () => {
+      applicantRefreshUserGate.invalidate();
       setSessionSuppressed(false);
       setError("");
       setDialogOpen(false);
@@ -771,6 +835,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
   });
   const { linkGithub, linkWallet } = useLinkAccount({
     onSuccess: () => {
+      applicantRefreshUserGate.invalidate();
       setError("");
       setDialogOpen(false);
     },
@@ -815,16 +880,22 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
     });
   }, [wallets]);
 
+  const connectedWalletAddress = connectedWallet?.address;
+  const connectedWalletChainId = connectedWallet?.chainId;
   const wallet = useMemo<WalletState | null>(() => {
-    if (!connectedWallet || !isEthereumAddress(connectedWallet.address)) {
+    if (
+      !connectedWalletAddress
+      || typeof connectedWalletChainId !== "string"
+      || !isEthereumAddress(connectedWalletAddress)
+    ) {
       return null;
     }
 
     return {
-      account: connectedWallet.address,
-      chainId: normalizeChainId(connectedWallet.chainId),
+      account: connectedWalletAddress,
+      chainId: normalizeChainId(connectedWalletChainId),
     };
-  }, [connectedWallet]);
+  }, [connectedWalletAddress, connectedWalletChainId]);
   const providerSettled = isWalletProviderSettled(
     ready,
     walletsReady,
@@ -840,31 +911,60 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
     }),
     [activeAuthenticated, identityToken],
   );
-  const applicantAuthorityRef = useRef<ApplicantAuthoritySnapshotV1>({
+  const applicantLinkedAccountsFingerprint = useMemo(
+    () => applicantLinkedAccountsFingerprintV1(user?.linkedAccounts),
+    [user?.linkedAccounts],
+  );
+  const initialApplicantAuthority: ApplicantAuthoritySnapshotV1 = {
     privyUserId: user?.id ?? null,
     githubUserId: user?.github?.subject ?? null,
     githubLogin: user?.github?.username ?? null,
     walletAddress: wallet?.account ?? null,
-  });
+    linkedAccountsFingerprint: applicantLinkedAccountsFingerprint,
+  };
+  const applicantAuthorityRef = useRef<ApplicantAuthoritySnapshotV1>(
+    initialApplicantAuthority,
+  );
+  const applicantAuthorityKeyRef = useRef(
+    applicantAuthorityCacheKeyV1(initialApplicantAuthority),
+  );
   useEffect(() => {
-    applicantAuthorityRef.current = {
+    const nextAuthority: ApplicantAuthoritySnapshotV1 = {
       privyUserId: user?.id ?? null,
       githubUserId: user?.github?.subject ?? null,
       githubLogin: user?.github?.username ?? null,
       walletAddress: wallet?.account ?? null,
+      linkedAccountsFingerprint: applicantLinkedAccountsFingerprint,
     };
-  }, [user?.github?.subject, user?.github?.username, user?.id, wallet?.account]);
+    const nextAuthorityKey = applicantAuthorityCacheKeyV1(nextAuthority);
+    if (applicantAuthorityKeyRef.current !== nextAuthorityKey) {
+      applicantRefreshUserGate.invalidate();
+    }
+    applicantAuthorityRef.current = nextAuthority;
+    applicantAuthorityKeyRef.current = nextAuthorityKey;
+  }, [
+    applicantLinkedAccountsFingerprint,
+    applicantRefreshUserGate,
+    user?.github?.subject,
+    user?.github?.username,
+    user?.id,
+    wallet?.account,
+  ]);
   const refreshApplicantSession = useCallback(
-    (requirement?: WalletApplicantIdentityRequirementV1) =>
-      refreshWalletApplicantSessionV1({
+    (requirement?: WalletApplicantIdentityRequirementV1) => {
+      const authorityKey = applicantAuthorityCacheKeyV1(
+        applicantAuthorityRef.current,
+      );
+      return refreshWalletApplicantSessionV1({
         authenticated: activeAuthenticated && ready,
         readCurrentAuthority: () => applicantAuthorityRef.current,
-        refreshUser,
+        refreshUser: () => applicantRefreshUserGate.refresh(authorityKey),
         getAccessToken,
         getIdentityToken: getPrivyIdentityToken,
         requirement,
-      }),
-    [activeAuthenticated, getAccessToken, ready, refreshUser],
+      });
+    },
+    [activeAuthenticated, applicantRefreshUserGate, getAccessToken, ready],
   );
   const reauthorizeGithub = useCallback(async () => {
     if (!ready || !activeAuthenticated || !githubConnected) {
@@ -872,8 +972,16 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
     }
     // No OAuth grant callback is registered: the Website never receives,
     // stores or logs the provider access token during reauthorization.
+    applicantRefreshUserGate.invalidate();
     await reauthorize({ provider: "github" });
-  }, [activeAuthenticated, githubConnected, ready, reauthorize]);
+    applicantRefreshUserGate.invalidate();
+  }, [
+    activeAuthenticated,
+    applicantRefreshUserGate,
+    githubConnected,
+    ready,
+    reauthorize,
+  ]);
 
   const profileValue = useSyncExternalStore(
     subscribeToProfiles,
@@ -992,6 +1100,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
   const disconnect = useCallback(async (options?: {
     showDialogOnFailure?: boolean;
   }) => {
+    applicantRefreshUserGate.invalidate();
     setDisconnecting(true);
     setError("");
     const markDisconnectFailed = () => {
@@ -1030,7 +1139,7 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
     } finally {
       setDisconnecting(false);
     }
-  }, [authenticated, logout, wallets]);
+  }, [applicantRefreshUserGate, authenticated, logout, wallets]);
 
   const copyAddress = useCallback(async () => {
     if (!wallet) return;

--- a/lib/custom-launch/applicant-refresh-user-gate-v1.ts
+++ b/lib/custom-launch/applicant-refresh-user-gate-v1.ts
@@ -1,0 +1,186 @@
+const DEFAULT_CACHE_TTL_MS = 10_000;
+const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 4_000;
+
+export class ApplicantRefreshUserUnavailableErrorV1 extends Error {
+  readonly status = 429;
+  readonly code = "applicant_session_rate_limited";
+  readonly retryable = true;
+
+  constructor() {
+    super("Applicant authentication is temporarily rate limited. Retry shortly");
+    this.name = "ApplicantRefreshUserUnavailableErrorV1";
+  }
+}
+
+export type ApplicantRefreshUserGateV1<T> = Readonly<{
+  refresh: (key: string) => Promise<T>;
+  invalidate: () => void;
+  setSource: (source: () => Promise<T>) => void;
+}>;
+
+type InFlightV1<T> = {
+  readonly generation: number;
+  readonly key: string;
+  promise: Promise<T>;
+};
+
+type CachedV1<T> = Readonly<{
+  generation: number;
+  key: string;
+  value: T;
+  expiresAt: number;
+}>;
+
+/**
+ * Privy's browser `refreshUser` endpoint is a deliberately small bucket. The
+ * Applicant flow can ask for the same current user from several effects and
+ * from list/resolve/preflight in one operation. This gate coalesces equal
+ * requests and keeps only a short-lived successful snapshot; failures are
+ * never cached as authority.
+ */
+export function createApplicantRefreshUserGateV1<T>(input: Readonly<{
+  source: () => Promise<T>;
+  now?: () => number;
+  cacheTtlMs?: number;
+  rateLimitCooldownMs?: number;
+  shouldCache?: (value: T) => boolean;
+  isRateLimited?: (error: unknown) => boolean;
+}>): ApplicantRefreshUserGateV1<T> {
+  const now = input.now ?? Date.now;
+  const cacheTtlMs = input.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const rateLimitCooldownMs =
+    input.rateLimitCooldownMs ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS;
+  const shouldCache = input.shouldCache
+    ?? ((value: T) => value !== null && value !== undefined);
+  const isRateLimited = input.isRateLimited
+    ?? applicantRefreshUserIsRateLimitedV1;
+  let source = input.source;
+
+  if (!Number.isFinite(cacheTtlMs) || cacheTtlMs < 0) {
+    throw new RangeError("Applicant refresh cache TTL is invalid");
+  }
+  if (!Number.isFinite(rateLimitCooldownMs) || rateLimitCooldownMs < 0) {
+    throw new RangeError("Applicant refresh rate-limit cooldown is invalid");
+  }
+
+  let generation = 0;
+  const cachedByKey = new Map<string, CachedV1<T>>();
+  const inFlightByKey = new Map<string, InFlightV1<T>>();
+  let sourceInFlight: Promise<T> | null = null;
+  let nextSourceAt = 0;
+  let rateLimitRetryAt = 0;
+  let rateLimitError: unknown = null;
+
+  const refresh = (key: string): Promise<T> => {
+    if (typeof key !== "string" || key.length === 0) {
+      return Promise.reject(new TypeError("Applicant refresh key is invalid"));
+    }
+
+    const currentTime = now();
+    const cached = cachedByKey.get(key);
+    if (
+      cached !== undefined
+      && cached.generation === generation
+      && cached.expiresAt > currentTime
+    ) {
+      return Promise.resolve(cached.value);
+    }
+    if (cached !== undefined) cachedByKey.delete(key);
+
+    const inFlight = inFlightByKey.get(key);
+    if (
+      inFlight !== undefined
+      && inFlight.generation === generation
+    ) {
+      return inFlight.promise;
+    }
+    if (inFlight !== undefined) inFlightByKey.delete(key);
+
+    if (
+      sourceInFlight !== null
+      || nextSourceAt > currentTime
+      || rateLimitRetryAt > currentTime
+    ) {
+      return Promise.reject(
+        rateLimitError
+          ?? new ApplicantRefreshUserUnavailableErrorV1(),
+      );
+    }
+
+    const requestGeneration = generation;
+    nextSourceAt = currentTime + rateLimitCooldownMs;
+    const request = Promise.resolve().then(source).then(
+      (value) => {
+        if (requestGeneration === generation) {
+          rateLimitRetryAt = 0;
+          rateLimitError = null;
+          if (shouldCache(value)) {
+            cachedByKey.set(key, Object.freeze({
+              generation,
+              key,
+              value,
+              expiresAt: now() + cacheTtlMs,
+            }));
+          }
+        }
+        return value;
+      },
+      (error: unknown) => {
+        if (requestGeneration === generation && isRateLimited(error)) {
+          const unavailable = new ApplicantRefreshUserUnavailableErrorV1();
+          rateLimitRetryAt = now() + rateLimitCooldownMs;
+          rateLimitError = unavailable;
+          throw unavailable;
+        }
+        throw error;
+      },
+    );
+    const entry: InFlightV1<T> = {
+      generation: requestGeneration,
+      key,
+      promise: request,
+    };
+    inFlightByKey.set(key, entry);
+    sourceInFlight = request;
+    request.then(
+      () => {
+        if (inFlightByKey.get(key) === entry) inFlightByKey.delete(key);
+        if (sourceInFlight === request) sourceInFlight = null;
+      },
+      () => {
+        if (inFlightByKey.get(key) === entry) inFlightByKey.delete(key);
+        if (sourceInFlight === request) sourceInFlight = null;
+      },
+    );
+    return request;
+  };
+
+  const invalidate = (): void => {
+    generation += 1;
+    cachedByKey.clear();
+  };
+
+  const setSource = (nextSource: () => Promise<T>): void => {
+    if (typeof nextSource !== "function") {
+      throw new TypeError("Applicant refresh source is invalid");
+    }
+    source = nextSource;
+  };
+
+  return Object.freeze({ refresh, invalidate, setSource });
+}
+
+export function applicantRefreshUserIsRateLimitedV1(error: unknown): boolean {
+  if (error === null || typeof error !== "object") return false;
+  const record = error as Readonly<Record<string, unknown>>;
+  return record.privyErrorCode === "too_many_requests"
+    || record.code === "too_many_requests"
+    || record.status === 429
+    || record.name === "TooManyRequestsError";
+}
+
+export function isApplicantRefreshUserUnavailableErrorV1(
+  error: unknown,
+): error is ApplicantRefreshUserUnavailableErrorV1 {
+  return error instanceof ApplicantRefreshUserUnavailableErrorV1;
+}

--- a/lib/custom-launch/applicant-session-v2.ts
+++ b/lib/custom-launch/applicant-session-v2.ts
@@ -1,5 +1,8 @@
 import { CustomLaunchWebsiteRequestErrorV2 } from "./client-v2";
 import {
+  isApplicantRefreshUserUnavailableErrorV1,
+} from "./applicant-refresh-user-gate-v1";
+import {
   customApplicationIntakeIsLaunchableV2,
   type CustomLaunchWebsiteSessionV2,
   type PrincipalCustomLaunchApplicationSummaryV2,
@@ -309,7 +312,14 @@ export async function acquireCurrentCustomLaunchWebsiteSessionV2(input: Readonly
       githubLogin: input.expectedGithubLogin,
       launchWallet: expectedWalletAccount as `0x${string}`,
     });
-  } catch {
+  } catch (error) {
+    if (isApplicantRefreshUserUnavailableErrorV1(error)) {
+      throw new CustomLaunchWebsiteRequestErrorV2(
+        error.status,
+        error.code,
+        error.message,
+      );
+    }
     refreshed = null;
   }
   assertCurrentApplicantBoundaryV2(input.isCurrent);

--- a/tests/applicant-refresh-user-gate-v1.test.ts
+++ b/tests/applicant-refresh-user-gate-v1.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ApplicantRefreshUserUnavailableErrorV1,
+  createApplicantRefreshUserGateV1,
+} from "../lib/custom-launch/applicant-refresh-user-gate-v1";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("Applicant refreshUser gate", () => {
+  it("coalesces concurrent refreshes and reuses one short-lived success", async () => {
+    let now = 1_000;
+    const pending = deferred<{ id: string }>();
+    const source = vi.fn(() => pending.promise);
+    const gate = createApplicantRefreshUserGateV1({
+      source,
+      now: () => now,
+      cacheTtlMs: 5_000,
+    });
+
+    const first = gate.refresh("same-authority");
+    const second = gate.refresh("same-authority");
+    expect(second).toBe(first);
+    await Promise.resolve();
+    expect(source).toHaveBeenCalledTimes(1);
+
+    pending.resolve({ id: "did:privy:applicant" });
+    await expect(first).resolves.toEqual({ id: "did:privy:applicant" });
+    await expect(gate.refresh("same-authority"))
+      .resolves.toEqual({ id: "did:privy:applicant" });
+    expect(source).toHaveBeenCalledTimes(1);
+
+    now += 5_001;
+    await gate.refresh("same-authority");
+    expect(source).toHaveBeenCalledTimes(2);
+  });
+
+  it("never reuses a success for another authority key", async () => {
+    const source = vi.fn(async () => ({ id: crypto.randomUUID() }));
+    const gate = createApplicantRefreshUserGateV1({
+      source,
+      rateLimitCooldownMs: 0,
+    });
+
+    await gate.refresh("authority-a");
+    await gate.refresh("authority-b");
+    expect(source).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not overlap provider calls for interleaved authority keys", async () => {
+    let now = 1_000;
+    const first = deferred<{ id: string }>();
+    const source = vi.fn(() => first.promise);
+    const gate = createApplicantRefreshUserGateV1({
+      source,
+      now: () => now,
+      rateLimitCooldownMs: 4_000,
+    });
+
+    const authorityA = gate.refresh("authority-a");
+    await expect(gate.refresh("authority-b")).rejects.toMatchObject({
+      code: "applicant_session_rate_limited",
+      retryable: true,
+      status: 429,
+    });
+    expect(gate.refresh("authority-a")).toBe(authorityA);
+    await Promise.resolve();
+    expect(source).toHaveBeenCalledTimes(1);
+
+    first.resolve({ id: "did:privy:authority-a" });
+    await expect(authorityA).resolves.toEqual({
+      id: "did:privy:authority-a",
+    });
+    await expect(gate.refresh("authority-b"))
+      .rejects.toBeInstanceOf(ApplicantRefreshUserUnavailableErrorV1);
+    expect(source).toHaveBeenCalledTimes(1);
+
+    now += 4_001;
+    await gate.refresh("authority-b");
+    expect(source).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache null results or ordinary failures", async () => {
+    const source = vi.fn<() => Promise<{ id: string } | null>>()
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("provider unavailable"))
+      .mockResolvedValueOnce({ id: "did:privy:applicant" });
+    const gate = createApplicantRefreshUserGateV1({
+      source,
+      rateLimitCooldownMs: 0,
+    });
+
+    await expect(gate.refresh("authority")).resolves.toBeNull();
+    await expect(gate.refresh("authority")).rejects.toThrow(
+      "provider unavailable",
+    );
+    await expect(gate.refresh("authority")).resolves.toEqual({
+      id: "did:privy:applicant",
+    });
+    expect(source).toHaveBeenCalledTimes(3);
+  });
+
+  it("turns a provider 429 into bounded retryable capacity state", async () => {
+    let now = 10_000;
+    const source = vi.fn<() => Promise<{ id: string }>>()
+      .mockRejectedValueOnce(Object.assign(new Error("limited"), {
+        privyErrorCode: "too_many_requests",
+        status: 429,
+      }))
+      .mockResolvedValueOnce({ id: "did:privy:applicant" });
+    const gate = createApplicantRefreshUserGateV1({
+      source,
+      now: () => now,
+      rateLimitCooldownMs: 4_000,
+    });
+
+    await expect(gate.refresh("authority")).rejects.toMatchObject({
+      code: "applicant_session_rate_limited",
+      retryable: true,
+      status: 429,
+    });
+    await expect(gate.refresh("authority"))
+      .rejects.toBeInstanceOf(ApplicantRefreshUserUnavailableErrorV1);
+    expect(source).toHaveBeenCalledTimes(1);
+
+    now += 4_001;
+    await expect(gate.refresh("authority")).resolves.toEqual({
+      id: "did:privy:applicant",
+    });
+    expect(source).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates cached authority without letting stale completion win", async () => {
+    let now = 1_000;
+    const first = deferred<{ id: string }>();
+    const second = deferred<{ id: string }>();
+    const source = vi.fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const gate = createApplicantRefreshUserGateV1({
+      source,
+      now: () => now,
+      rateLimitCooldownMs: 4_000,
+    });
+
+    const stale = gate.refresh("authority");
+    gate.invalidate();
+    await expect(gate.refresh("authority"))
+      .rejects.toBeInstanceOf(ApplicantRefreshUserUnavailableErrorV1);
+    first.resolve({ id: "stale" });
+    await expect(stale).resolves.toEqual({ id: "stale" });
+
+    now += 4_001;
+    const current = gate.refresh("authority");
+    expect(gate.refresh("authority")).toBe(current);
+    second.resolve({ id: "current" });
+    await expect(current).resolves.toEqual({ id: "current" });
+    await expect(gate.refresh("authority")).resolves.toEqual({ id: "current" });
+    expect(source).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/custom-launch-applicant-session-v2.test.ts
+++ b/tests/custom-launch-applicant-session-v2.test.ts
@@ -35,6 +35,8 @@ import {
   createCustomLaunchWebsiteClientV2,
   CustomLaunchWebsiteRequestErrorV2,
 } from "../lib/custom-launch/client-v2";
+import { ApplicantRefreshUserUnavailableErrorV1 } from
+  "../lib/custom-launch/applicant-refresh-user-gate-v1";
 import type { PrincipalCustomLaunchApplicationSummaryV2 } from "../lib/custom-launch/contract-v2";
 
 const digest = (digit: string) => `sha256:${digit.repeat(64)}` as const;
@@ -416,6 +418,22 @@ describe("custom launch applicant session currentness", () => {
     });
     expect(refreshApplicantSession).toHaveBeenCalledOnce();
     expect(downstream).not.toHaveBeenCalled();
+  });
+
+  it("preserves refresh rate limits as retryable service capacity", async () => {
+    const request = acquireCurrentCustomLaunchWebsiteSessionV2(sessionInput({
+      refreshApplicantSession: async () => {
+        throw new ApplicantRefreshUserUnavailableErrorV1();
+      },
+    }));
+
+    await expect(request).rejects.toMatchObject({
+      code: "applicant_session_rate_limited",
+      status: 429,
+    });
+    await request.catch((error: unknown) => {
+      expect(customLaunchApplicantRecoveryV2(error)).toBe("retry");
+    });
   });
 
   it("keeps the production dangerous sequence at zero effects for refresh-null", async () => {

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -158,10 +158,10 @@ describe("unreleased launch model gating", () => {
     ).toEqual([-1, -1, 0, -1, -1, -1]);
   });
 
-  it("opens the approved Custom Hook launcher without the legacy Custom card", () => {
+  it("opens the generic Custom Hook launcher only behind the public readiness gate", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
-        manualApplicantLaunchEnabled: true,
+        customLaunchPublicEnabled: true,
         onChoose: () => undefined,
       }),
     );
@@ -177,17 +177,19 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain(
       'id="launch-model-classic-title">Classic</strong>',
     );
-    expect(html).toContain('data-launch-model-option="manual-applicant"');
+    expect(html).toContain('data-launch-model-option="custom"');
     const customCard = html.match(
-      /<button[^>]*data-launch-model-option="manual-applicant"[^>]*>/,
+      /<button[^>]*data-launch-model-option="custom"[^>]*>/,
     )?.[0];
     expect(customCard).toContain('data-launch-model-launchable="true"');
     expect(html).toContain(
-      'id="launch-model-manual-applicant-title">Custom Hook</strong>',
+      'id="launch-model-custom-title">Custom Hook</strong>',
     );
     expect(html).toContain("Create a Classic coin");
-    expect(html).toContain("Open Custom Hook launch");
-    expect(html).not.toContain('data-launch-model-option="custom"');
+    expect(html).toContain("Open approved Custom Hook launch");
+    expect(html).toContain('data-status="available">Available</small>');
+    expect(html).not.toContain('data-launch-model-option="manual-applicant"');
+    expect(html).not.toContain(">Ready</small>");
     expect(html).not.toContain("Build or resume");
     expect(html).not.toContain("Coming soon");
     expect(html).toContain('data-launch-model-option="aeon"');
@@ -242,7 +244,9 @@ describe("unreleased launch model gating", () => {
       }),
     );
     expect(html).not.toContain('data-launch-model-option="custom"');
+    expect(html).not.toContain('data-launch-model-option="manual-applicant"');
     expect(html).not.toContain('id="launch-model-custom-title"');
+    expect(html).not.toContain('id="launch-model-manual-applicant-title"');
     expect(html).not.toContain("Coming soon");
     expect(html).not.toContain("Build or resume");
   });

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -50,14 +50,14 @@ describe("launch model artwork", () => {
     expect(source).toContain(
       'aria-describedby="launch-model-classic-description"',
     );
-    expect(source).toContain('onClick={() => onChoose("manual-applicant")}');
+    expect(source).toContain('onClick={() => onChoose("custom")}');
     expect(source).toContain(
-      'aria-labelledby="launch-model-manual-applicant-title"',
+      'aria-labelledby="launch-model-custom-title"',
     );
     expect(source).toContain(
-      'aria-describedby="launch-model-manual-applicant-description"',
+      'aria-describedby="launch-model-custom-description"',
     );
-    expect(source).not.toContain('data-launch-model-option="custom"');
+    expect(source).toContain('data-launch-model-option="custom"');
     expect(source).toContain('href="https://x.com/aeonframework"');
     expect(source).toContain(
       'aria-labelledby="launch-model-aeon-title"',

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -2168,22 +2168,32 @@ describe("manual Applicant browser contract", () => {
     });
   });
 
-  it("adds the Applicant entry only behind its separate flag and exposes no upload fallback", () => {
+  it("keeps the legacy Applicant implementation out of the public picker", () => {
     const disabled = renderToStaticMarkup(createElement(LaunchModelPicker, {
-      manualApplicantLaunchEnabled: false,
+      customLaunchPublicEnabled: false,
       onChoose: () => undefined,
     }));
     const enabled = renderToStaticMarkup(createElement(LaunchModelPicker, {
-      manualApplicantLaunchEnabled: true,
+      customLaunchPublicEnabled: true,
       onChoose: () => undefined,
     }));
     expect(disabled).not.toContain('data-launch-model-option="manual-applicant"');
-    expect(enabled).toContain('data-launch-model-option="manual-applicant"');
+    expect(disabled).not.toContain('data-launch-model-option="custom"');
+    expect(enabled).toContain('data-launch-model-option="custom"');
+    expect(enabled).not.toContain('data-launch-model-option="manual-applicant"');
     expect(enabled).toContain(
-      'id="launch-model-manual-applicant-title">Custom Hook</strong>',
+      'id="launch-model-custom-title">Custom Hook</strong>',
     );
-    expect(enabled).toContain("Open Custom Hook launch");
-    expect(enabled).not.toContain('data-launch-model-option="custom"');
+    expect(enabled).toContain("Open approved Custom Hook launch");
+    expect(enabled).toContain('data-status="available">Available</small>');
+    expect(enabled).not.toContain(">Ready</small>");
+
+    const entry = readFileSync(
+      join(process.cwd(), "components/launch-entry.tsx"),
+      "utf8",
+    );
+    expect(entry).not.toContain('from "@/components/manual-applicant-launch"');
+    expect(entry).not.toContain('"manual-applicant"');
 
     const component = readFileSync(
       join(process.cwd(), "components/manual-applicant-launch.tsx"),
@@ -2241,12 +2251,6 @@ describe("manual Applicant browser contract", () => {
     expect(component).not.toContain("Fresh signature");
     expect(component).not.toContain("signing team");
 
-    const entry = readFileSync(
-      join(process.cwd(), "components/launch-entry.tsx"),
-      "utf8",
-    );
-    expect(entry).toContain("manualApplicantButtonRef.current?.focus()");
-    expect(entry).toContain("ref={manualApplicantButtonRef}");
   });
 
   it("imports the canonical Router binding instead of creating a second profile producer", () => {

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -20,6 +20,8 @@ import {
   MANUAL_ROUTER_PRODUCTION_BINDING_V1,
   assertManualRouterProductionBindingV1,
 } from "../lib/custom-launch/manual-router-bindings-v1";
+import { ApplicantRefreshUserUnavailableErrorV1 } from
+  "../lib/custom-launch/applicant-refresh-user-gate-v1";
 import {
   MANUAL_ROUTER_NESTED_FACTORY_BINDING_V2,
   MANUAL_ROUTER_NESTED_FACTORY_PROFILE_TYPE_V2,
@@ -187,6 +189,23 @@ describe("manual Applicant Privy hydration", () => {
       code: "applicant_authentication_required",
     });
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("renders Privy capacity as retryable without asking for GitHub again", async () => {
+    const request = acquireManualRouterWebsiteSessionV1({
+      refreshApplicantSession: async () => {
+        throw new ApplicantRefreshUserUnavailableErrorV1();
+      },
+    });
+
+    await expect(request).rejects.toMatchObject({
+      code: "applicant_session_rate_limited",
+      retryable: true,
+      status: 429,
+    });
+    await request.catch((error: unknown) => {
+      expect(manualRouterRetainsKnownApprovalV1(error)).toBe(true);
+    });
   });
 
   it("rejects a refreshed session for the wrong numeric principal or wallet", async () => {

--- a/tests/manual-applicant-launch-foundations.test.ts
+++ b/tests/manual-applicant-launch-foundations.test.ts
@@ -154,6 +154,25 @@ describe("manual Applicant Privy hydration", () => {
     expect(component).toContain("authReady,\n    authenticated,\n    githubConnected,\n    loadDirectory");
   });
 
+  it("keeps selection changes out of the discovery effect dependency", () => {
+    const component = readFileSync(
+      join(process.cwd(), "components/manual-applicant-launch.tsx"),
+      "utf8",
+    );
+    const loadStart = component.indexOf(
+      "const loadDirectory = useCallback(async",
+    );
+    const loadEnd = component.indexOf("\n  useEffect(() => {", loadStart);
+    const loadSource = component.slice(loadStart, loadEnd);
+
+    expect(loadSource).toContain("selectedSubjectHashRef.current");
+    expect(loadSource.match(/runManualRouterRequestWithFreshSessionV1/gu))
+      .toHaveLength(2);
+    expect(loadSource).not.toContain(
+      "selectedSubjectHash,\n",
+    );
+  });
+
   it("requires one refreshed Applicant session and never retries a request", async () => {
     const refreshApplicantSession = vi.fn(async () => ({
       accessToken: "access-token",

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -386,7 +386,16 @@ describe("wallet recovery state", () => {
       "utf8",
     );
     expect(provider).toContain("const { refreshUser } = useUser();");
-    expect(provider).toContain("getIdentityToken: getPrivyIdentityToken");
+    expect(provider).toContain(
+      "getIdentityToken: async () => applicantIdentityTokenRef.current",
+    );
+    expect(provider).toContain(
+      "changing the callback identity would restart\n  // the discovery effect",
+    );
+    expect(provider).toContain("perform a second `/users/me` read");
+    expect(provider).not.toContain(
+      "getIdentityToken: getPrivyIdentityToken,\n        requirement,",
+    );
     expect(provider).toContain("const { reauthorize } = useOAuthTokens();");
     expect(provider).toContain('await reauthorize({ provider: "github" });');
     expect(provider).not.toContain("onOAuthTokenGrant");

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { getCreateAddress, keccak256 } from "viem";
 import * as walletProvider from "../components/wallet-provider";
+import { ApplicantRefreshUserUnavailableErrorV1 } from
+  "../lib/custom-launch/applicant-refresh-user-gate-v1";
 import {
   HOOKEMON_APPROVE_SELECTOR,
   HOOKEMON_MAINNET_USDC,
@@ -113,12 +115,14 @@ function applicantAuthority(overrides?: Partial<{
   githubUserId: string | null;
   githubLogin: string | null;
   walletAddress: string | null;
+  linkedAccountsFingerprint: string | null;
 }>) {
   return {
     privyUserId: APPLICANT_PRIVY_USER_ID,
     githubUserId: APPLICANT_GITHUB_USER_ID,
     githubLogin: APPLICANT_GITHUB_LOGIN,
     walletAddress: APPLICANT_WALLET,
+    linkedAccountsFingerprint: "linked-accounts:v1",
     ...overrides,
   };
 }
@@ -489,6 +493,24 @@ describe("wallet recovery state", () => {
     }
   });
 
+  it("preserves provider rate limits as retryable capacity state", async () => {
+    const getAccessToken = vi.fn(async () => "unexpected-access");
+    const getIdentityToken = vi.fn(async () => "unexpected-identity");
+
+    await expect(walletProvider.refreshWalletApplicantSessionV1({
+      authenticated: true,
+      readCurrentAuthority: applicantAuthority,
+      refreshUser: async () => {
+        throw new ApplicantRefreshUserUnavailableErrorV1();
+      },
+      getAccessToken,
+      getIdentityToken,
+      requirement: applicantRequirement,
+    })).rejects.toBeInstanceOf(ApplicantRefreshUserUnavailableErrorV1);
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(getIdentityToken).not.toHaveBeenCalled();
+  });
+
   it("rejects wrong or missing identity and wallet data before token acquisition", async () => {
     const candidates = [
       { id: APPLICANT_PRIVY_USER_ID, linkedAccounts: [] },
@@ -558,6 +580,25 @@ describe("wallet recovery state", () => {
         return readCount === 1
           ? applicantAuthority()
           : applicantAuthority({ walletAddress: OTHER_WALLET });
+      },
+      refreshUser: async () => applicantUser(),
+      getAccessToken,
+      getIdentityToken,
+      requirement: applicantRequirement,
+    })).resolves.toBeNull();
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(getIdentityToken).not.toHaveBeenCalled();
+
+    readCount = 0;
+    await expect(walletProvider.refreshWalletApplicantSessionV1({
+      authenticated: true,
+      readCurrentAuthority: () => {
+        readCount += 1;
+        return readCount === 1
+          ? applicantAuthority()
+          : applicantAuthority({
+            linkedAccountsFingerprint: "linked-accounts:v2",
+          });
       },
       refreshUser: async () => applicantUser(),
       getAccessToken,


### PR DESCRIPTION
## Outcome

- Rebases the applicant-session fixes onto the current production branch.
- Routes the public Custom Hook picker exclusively through the generic V3/V2 application, wallet, descriptor, and permit flow.
- Removes the legacy manual-applicant card from the public picker and avoids the misleading Ready state.
- Keeps the generic entry fail-closed behind the existing public-readiness gate.

## Validation on this exact branch

- Focused Vitest: 6 files, 139/139 tests passed
- TypeScript: passed
- Targeted ESLint: passed
- Production Next.js build: passed
- git diff --check: passed
- Browser QA on the source commit: 1440x900 and 390x844, no horizontal overflow; generic Custom flow opens; Back restores focus; legacy manual card absent

## Release boundary

This PR does not enable public submissions and does not configure the Approval Service, production Privy application, signer ring, Registry writer/finalizer, or Developer feed. Those remain separate fail-closed release gates.