### PR TITLE
Freeze exact Shards launch eligibility blockers

### DIFF
--- a/config/shards-canary-descriptor-eligibility.v1.json
+++ b/config/shards-canary-descriptor-eligibility.v1.json
@@ -1,0 +1,256 @@
+{
+  "schemaVersion": "programmable.shards-canary-descriptor-eligibility.v1",
+  "status": "ANALYSIS_PENDING",
+  "launchAllowed": false,
+  "activationAllowed": false,
+  "descriptor": null,
+  "reasonCodes": [
+    "ROUTER_V3_DEPLOYMENT_BOUND_SUCCESSOR_MISSING",
+    "NESTED_FACTORY_PROFILE_CAPABILITY_BINDING_MISSING",
+    "SHARDS_ACTIVE_GRANT_MISSING",
+    "SHARDS_REGISTRY_V1_ROUTE_ADAPTER_MISSING",
+    "SHARDS_LAUNCH_DESCRIPTOR_FEE_POLICY_PROFILE_MISSING",
+    "SHARDS_REGISTRY_V1_FEE_POLICY_PROFILE_MISSING",
+    "SHARDS_REGISTRY_V1_AUTHORIZATION_AND_FINALITY_BYTES_MISSING",
+    "CUSTOM_LAUNCH_AUTHENTICATED_CANARY_FEE_POLICY_SCHEMA_DRIFT"
+  ],
+  "reviewedApplicant": {
+    "githubLogin": "jesse-stahl",
+    "githubUserId": "155705664",
+    "launchWallet": "0xceebb3a6543cebeb2ed66963897a0abea52a50cc",
+    "sourceRepository": "jesse-stahl/shards-v1",
+    "sourceRepositoryId": "1329073878",
+    "sourceCommit": "91b38f3de64d96cac7e29f127c004f128fc1da59",
+    "sourceTree": "92d6def8609e829487adea66c13901734e43c8c7",
+    "approvalPullRequest": "0xprogrammable/hookbuilder#6",
+    "approvalHead": "1aa5017154d227e639cfe6256f39bf3916352124",
+    "approvalTree": "48149d436bf222c440980e1fc31a71899b833af7"
+  },
+  "reviewedArtifacts": {
+    "submissionRequest": {
+      "path": "submissions/requests/1329073878-shards-v1.json",
+      "byteLength": 2631,
+      "rawSha256": "5df0061500df503d3f23115ef9099fd4a9ebe7900eec3f3360ec9ab811f28246",
+      "canonicalJsonSha256": "e069926d380e56bee001dd7cfeda591db56164b1acf7478b478dd62a6e119ec2"
+    },
+    "reviewedRoutePlan": {
+      "path": "submissions/examples/shards-reviewed-route-plan-v1.example.json",
+      "introducedCommit": "0ec6cd4fdf7c1fc68edd728be22a255b58011c2f",
+      "introducedTree": "17075bc60f5d997190b6085ce852aac3f73ad7d8",
+      "byteLength": 14519,
+      "rawSha256": "aa55cf226434a9350a55797fe296fae5eb216d52db3e0c9cbacfb9cc39717fc3",
+      "reviewedPlanSha256": "cfe926c42918ce1ca23efe8fa7352c2b6ed7090002f62a0d6d64481883205591"
+    },
+    "nestedFactoryRoute": {
+      "path": "outputs/shards-nested-factory-route-v1.canonical.json",
+      "presentInWebsite": false,
+      "byteLength": 1287041,
+      "sha256": "066475058bfd47b85b4216f95b434756d67d7e289ffb36535c121ef5d7c11bab",
+      "keccak256": "0x8c5521d6796e3e63c3e2cf82e1122c952e6465c345d8a10b3773a70aa2419fb3",
+      "integritySha256": "74028d65363189804912f2907400da11098d90579c9261e1d087b2d5a709ae6f",
+      "routerSourceCommit": "1ac92f9694fb5c3ae534c65669775e634e3214f7",
+      "routerSourceTree": "8e6920b46aa30e5a8afbebc3a86adfba22cc7628"
+    },
+    "feeDescriptor": {
+      "path": "artifacts/shards-router-v1-postcompile-final/shards-router-v1-fee-descriptor.v1.json",
+      "rawSha256": "d1c911686afc62b70f3d65c9807e89146d119c4e6f4604e72d3dab2b4ef8dc22",
+      "revenuePolicyHash": "0xaa78b0bf63fca83fa9b969fbb6b2bb1ecabcbe49908a48f92403e8e51e4adab2",
+      "totalFeeBps": 100,
+      "chargeMode": "included-in-total",
+      "legs": [
+        { "role": "nft-holders", "rateBps": 80 },
+        { "role": "builder", "rateBps": 10 },
+        { "role": "programmable", "rateBps": 10 }
+      ]
+    }
+  },
+  "websiteBaseline": {
+    "commit": "32a79b53f99fcf4fa050b327db9a20fc96cf6c66",
+    "tree": "cb4cfea01ed72b5ec4aa11f85c62239f8869ccdc",
+    "fileBindings": [
+      {
+        "path": "lib/custom-launch/contract-v2.ts",
+        "rawSha256": "0ecce91d1871886c54de90b7882c8ef86aa46f48d5894f31d8cb0e046cdd96af"
+      },
+      {
+        "path": "lib/custom-launch/response-contract-v2.ts",
+        "rawSha256": "30f0f3f04f6387b51b5aab0d5773cff3c4620f798c089b943f0c6fcf7e142dc8"
+      },
+      {
+        "path": "lib/custom-launch/manual-router-bindings-v2.ts",
+        "rawSha256": "402d75a2f016efa8c0466de70e523d48229cbd7fd550e095fac9c57e9ba7ab50"
+      },
+      {
+        "path": "lib/server/custom-launch/router-v2-shared-lifecycle-v3.ts",
+        "rawSha256": "74dfcbec04b9019eecf0aa988e3d2d6414805cb40341fab6c7b4184de2bc8ffa"
+      },
+      {
+        "path": "lib/vendor/router-v2-shared-lifecycle-v3/artifact-manifest.v3.json",
+        "rawSha256": "fc5744aafd501601d828f026f46a05c00f310ef367f7fad547c05ad64710aa13"
+      },
+      {
+        "path": "contracts/deployments/mainnet-custom-registry-v1.json",
+        "rawSha256": "2ebb31331a4e16874caf27f643c22b3b767c0b2b1806ea217d5a7905959dfded"
+      },
+      {
+        "path": "contracts/src/ProgrammableCustomFeePolicyVerifierV1.sol",
+        "rawSha256": "59ede0260cf0d7f6c939275707d551e2507bbd0ffebe577d3a8be61b60c1eb37"
+      },
+      {
+        "path": "contracts/src/ProgrammableCustomAtomicRegistrarV1.sol",
+        "rawSha256": "df46bba619b589fbd61c339661ee0aaa3c7ef9386979736dea6e3b8b0888563d"
+      }
+    ]
+  },
+  "genericRouteContract": {
+    "applicantDescriptorSchemaVersion": "programmable.launch-route-discovery.v3",
+    "profileDescriptorSchemaVersion": "programmable.router-v2-launch-profile-descriptor.v3",
+    "lifecycleVersion": "3.0.0",
+    "deploymentState": "UNDEPLOYED",
+    "activationState": "DENY",
+    "authorityIoState": "HARD_DENY_REQUIRES_VERSIONED_DEPLOYMENT_BOUND_SUCCESSOR",
+    "websiteBindingState": "UNBOUND_EXTERNAL_WRITER_DENY",
+    "nestedFactorySlotId": "nested-factory-v1",
+    "nestedFactoryState": "DENY_PENDING_CONTRACT_ARTIFACT",
+    "feePolicyCompatibility": "ANALYSIS_PENDING_NO_100_BPS_INCLUSIVE_80_10_10_PROFILE",
+    "deploymentProbeFeePolicyFieldState": "MISSING_REQUIRED_ROUTE_FIELD",
+    "shardsState": "DENY"
+  },
+  "registryV1": {
+    "chainId": "1",
+    "minimumFinalityBlocks": 64,
+    "registry": {
+      "address": "0x17e18c88bda9bfb73924cdc989c07b0707e72671",
+      "startBlock": "25701139",
+      "runtimeCodeHash": "0xa3276868befc509594adea6c5bd81c3c1bd013686f03fd57914fd39c917185f7"
+    },
+    "atomicRegistrar": {
+      "address": "0xcc916e5200d2626edfd918dc219bc4296629e997",
+      "startBlock": "25701142",
+      "runtimeCodeHash": "0xae00412005beb660afba47767240cf771bf3c65306d68c1a7bfcb8fe2c0450f5",
+      "deployInitializeAndRegisterSelector": "0xdc6cbcc2",
+      "topology": "SINGLE_PRIMARY_CREATE2_DEPLOY_INITIALIZE_REGISTER"
+    },
+    "routeCompatibility": "ANALYSIS_PENDING_NO_SHARDS_ADAPTER",
+    "feePolicyCompatibility": "ANALYSIS_PENDING_NO_100_BPS_INCLUSIVE_PROFILE",
+    "supportedFeeProfiles": [
+      "NATIVE_CUSTOM_10_BPS_PROGRAMMABLE",
+      "AEON_20_BPS_15_5",
+      "NO_QUALIFYING_MARKET_0_BPS"
+    ]
+  },
+  "requiredBindings": [
+    {
+      "id": "router-v3-contract-deployment-binding",
+      "expectedFormat": "programmable.completed-graph-adoption-contract-deployment-binding.successor",
+      "requiredFields": [
+        "routerAddress",
+        "routerRuntimeCodeHash",
+        "directLaunchSelector",
+        "moduleAddress",
+        "moduleRuntimeCodeHash",
+        "deploymentTransactionHash",
+        "deploymentReceiptHash"
+      ],
+      "value": null
+    },
+    {
+      "id": "nested-factory-profile-capability-binding",
+      "expectedFormat": "programmable.nested-factory-profile-capability-binding.successor",
+      "requiredFields": [
+        "profileBindingHash",
+        "profileDescriptorHash",
+        "grantConsumerSelector",
+        "grantStateReaderSelector",
+        "eventTopics",
+        "schemaHashes"
+      ],
+      "value": null
+    },
+    {
+      "id": "shards-active-grant",
+      "expectedFormat": "programmable.router-v2-launch-grant.successor",
+      "requiredFields": [
+        "grantId",
+        "grantHash",
+        "grantBindingHash",
+        "profileBindingHash",
+        "sourceCommit",
+        "sourceTree",
+        "launchWallet",
+        "state",
+        "currentnessEvidenceHash"
+      ],
+      "value": null
+    },
+    {
+      "id": "shards-launch-route-discovery-descriptor",
+      "expectedFormat": "programmable.launch-route-discovery.v3",
+      "requiredFields": [
+        "applicationHandle",
+        "grantId",
+        "grantBindingHash",
+        "descriptorHash",
+        "validUntil",
+        "configurationSchema.schemaHash",
+        "routes[0].launchRouteBindingHash",
+        "routes[0].routeAdapterId",
+        "routes[0].transactionValuePolicy.valueWei",
+        "routes[0].feePolicy"
+      ],
+      "value": null
+    },
+    {
+      "id": "shards-launch-descriptor-fee-policy-profile",
+      "expectedFormat": "versioned-reviewed-inclusive-custom-fee-policy",
+      "requiredFields": [
+        "schemaVersion",
+        "reviewedPolicyHash",
+        "totalRateBps",
+        "chargeMode",
+        "nftHolderLeg",
+        "builderLeg",
+        "programmableLeg"
+      ],
+      "value": null
+    },
+    {
+      "id": "shards-registry-v1-route-adapter",
+      "expectedFormat": "reviewed-atomic-registry-adapter-or-new-reviewed-topology",
+      "requiredFields": [
+        "adapterSourceCommit",
+        "adapterSourceTree",
+        "adapterArtifactHash",
+        "adapterRuntimeCodeHash",
+        "launchRegistrationV1CanonicalBytesHash",
+        "atomicLaunchRequestV1CanonicalBytesHash"
+      ],
+      "value": null
+    },
+    {
+      "id": "shards-registry-fee-policy-profile",
+      "expectedFormat": "new-reviewed-fee-verifier-and-registry-generation-or-compatible-bound-successor",
+      "requiredFields": [
+        "feeVerifierSourceCommit",
+        "feeVerifierRuntimeCodeHash",
+        "registryGeneration",
+        "feePolicyHash",
+        "feeEvidenceHash"
+      ],
+      "value": null
+    },
+    {
+      "id": "shards-registry-authorization-and-finality",
+      "expectedFormat": "programmable.custom-registry-v1-execution-evidence",
+      "requiredFields": [
+        "approvalAuthorizationV1CanonicalBytesHash",
+        "approvalValidityWindow",
+        "approvalEvidenceHash",
+        "finalityProofV1CanonicalBytesHash",
+        "finalizerAuthorityBindingHash"
+      ],
+      "value": null
+    }
+  ],
+  "externalActionOccurred": false
+}

--- a/tests/shards-canary-descriptor-eligibility.test.ts
+++ b/tests/shards-canary-descriptor-eligibility.test.ts
@@ -1,0 +1,179 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import eligibility from "../config/shards-canary-descriptor-eligibility.v1.json";
+import registryDeployment from
+  "../contracts/deployments/mainnet-custom-registry-v1.json";
+import {
+  MANUAL_ROUTER_NESTED_FACTORY_BINDING_V2,
+} from "../lib/custom-launch/manual-router-bindings-v2";
+import {
+  ROUTER_V2_SHARED_LIFECYCLE_V3_SOURCE_ONLY_STATE,
+} from "../lib/server/custom-launch/router-v2-shared-lifecycle-v3";
+
+type FileBinding = Readonly<{ path: string; rawSha256: string }>;
+
+function rawSha256(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+describe("Shards generic V3 canary descriptor eligibility", () => {
+  it("publishes no synthetic descriptor while required authority bytes are absent", () => {
+    expect(eligibility).toMatchObject({
+      schemaVersion: "programmable.shards-canary-descriptor-eligibility.v1",
+      status: "ANALYSIS_PENDING",
+      launchAllowed: false,
+      activationAllowed: false,
+      descriptor: null,
+      externalActionOccurred: false,
+    });
+    expect(eligibility.reasonCodes).toEqual([
+      "ROUTER_V3_DEPLOYMENT_BOUND_SUCCESSOR_MISSING",
+      "NESTED_FACTORY_PROFILE_CAPABILITY_BINDING_MISSING",
+      "SHARDS_ACTIVE_GRANT_MISSING",
+      "SHARDS_REGISTRY_V1_ROUTE_ADAPTER_MISSING",
+      "SHARDS_LAUNCH_DESCRIPTOR_FEE_POLICY_PROFILE_MISSING",
+      "SHARDS_REGISTRY_V1_FEE_POLICY_PROFILE_MISSING",
+      "SHARDS_REGISTRY_V1_AUTHORIZATION_AND_FINALITY_BYTES_MISSING",
+      "CUSTOM_LAUNCH_AUTHENTICATED_CANARY_FEE_POLICY_SCHEMA_DRIFT",
+    ]);
+    expect(eligibility.requiredBindings).toHaveLength(8);
+    expect(eligibility.requiredBindings.every(({ value }) => value === null))
+      .toBe(true);
+    expect(JSON.stringify(eligibility).toLowerCase()).not.toContain("hookemon");
+  });
+
+  it("binds the reviewed Shards applicant, route artifact, and inclusive 80/10/10 fee", () => {
+    expect(eligibility.reviewedApplicant).toEqual({
+      githubLogin: "jesse-stahl",
+      githubUserId: "155705664",
+      launchWallet: "0xceebb3a6543cebeb2ed66963897a0abea52a50cc",
+      sourceRepository: "jesse-stahl/shards-v1",
+      sourceRepositoryId: "1329073878",
+      sourceCommit: "91b38f3de64d96cac7e29f127c004f128fc1da59",
+      sourceTree: "92d6def8609e829487adea66c13901734e43c8c7",
+      approvalPullRequest: "0xprogrammable/hookbuilder#6",
+      approvalHead: "1aa5017154d227e639cfe6256f39bf3916352124",
+      approvalTree: "48149d436bf222c440980e1fc31a71899b833af7",
+    });
+    expect(eligibility.reviewedArtifacts.nestedFactoryRoute).toMatchObject({
+      presentInWebsite: false,
+      byteLength: 1_287_041,
+      sha256:
+        "066475058bfd47b85b4216f95b434756d67d7e289ffb36535c121ef5d7c11bab",
+      keccak256:
+        "0x8c5521d6796e3e63c3e2cf82e1122c952e6465c345d8a10b3773a70aa2419fb3",
+    });
+    expect(existsSync(join(
+      process.cwd(),
+      eligibility.reviewedArtifacts.nestedFactoryRoute.path,
+    ))).toBe(false);
+    const fee = eligibility.reviewedArtifacts.feeDescriptor;
+    expect(fee).toMatchObject({
+      rawSha256:
+        "d1c911686afc62b70f3d65c9807e89146d119c4e6f4604e72d3dab2b4ef8dc22",
+      revenuePolicyHash:
+        "0xaa78b0bf63fca83fa9b969fbb6b2bb1ecabcbe49908a48f92403e8e51e4adab2",
+      totalFeeBps: 100,
+      chargeMode: "included-in-total",
+    });
+    expect(fee.legs.reduce((sum, { rateBps }) => sum + rateBps, 0)).toBe(100);
+    expect(fee.legs).toEqual([
+      { role: "nft-holders", rateBps: 80 },
+      { role: "builder", rateBps: 10 },
+      { role: "programmable", rateBps: 10 },
+    ]);
+  });
+
+  it("matches the current source-only V3 and inert nested-factory bindings", () => {
+    expect(ROUTER_V2_SHARED_LIFECYCLE_V3_SOURCE_ONLY_STATE).toMatchObject({
+      lifecycleVersion: eligibility.genericRouteContract.lifecycleVersion,
+      deploymentState: eligibility.genericRouteContract.deploymentState,
+      activationState: eligibility.genericRouteContract.activationState,
+      authorityIoState: eligibility.genericRouteContract.authorityIoState,
+      websiteBindingState: eligibility.genericRouteContract.websiteBindingState,
+      shardsState: eligibility.genericRouteContract.shardsState,
+      activationAllowed: false,
+    });
+    expect(eligibility.genericRouteContract).toMatchObject({
+      feePolicyCompatibility:
+        "ANALYSIS_PENDING_NO_100_BPS_INCLUSIVE_80_10_10_PROFILE",
+      deploymentProbeFeePolicyFieldState: "MISSING_REQUIRED_ROUTE_FIELD",
+    });
+    const responseContract = readFileSync(join(
+      process.cwd(),
+      "lib/custom-launch/response-contract-v2.ts",
+    ), "utf8");
+    const deploymentProbe = readFileSync(join(
+      process.cwd(),
+      "scripts/custom-launch-deployment-probe-core.mjs",
+    ), "utf8");
+    const routeProbe = deploymentProbe.slice(
+      deploymentProbe.indexOf("function validateLaunchRoute(value)"),
+      deploymentProbe.indexOf("function validateForeignApplicationDenial(value)"),
+    );
+    expect(responseContract).toContain('"walletExecutionKind", "transactionValuePolicy", "feePolicy"');
+    expect(routeProbe).not.toContain('"feePolicy"');
+    const nested = ROUTER_V2_SHARED_LIFECYCLE_V3_SOURCE_ONLY_STATE.profiles
+      .find(({ slotId }) => slotId === eligibility.genericRouteContract.nestedFactorySlotId);
+    expect(nested).toMatchObject({
+      architecture: "NESTED_FACTORY",
+      state: eligibility.genericRouteContract.nestedFactoryState,
+      activationAllowed: false,
+    });
+    expect(MANUAL_ROUTER_NESTED_FACTORY_BINDING_V2).toMatchObject({
+      active: false,
+      activationAllowed: false,
+      router: {
+        address: null,
+        runtimeCodeHash: null,
+        directLaunchSelector: null,
+      },
+      module: { address: null, runtimeCodeHash: null },
+      exactPlan: {
+        launchWallet: null,
+        revenuePolicyHash:
+          eligibility.reviewedArtifacts.feeDescriptor.revenuePolicyHash,
+      },
+    });
+  });
+
+  it("pins the deployed Registry V1 while denying an invented Shards bridge", () => {
+    const registry = registryDeployment.contracts.find(
+      ({ name }) => name === "ProgrammableCustomRegistryV1",
+    );
+    const registrar = registryDeployment.contracts.find(
+      ({ name }) => name === "ProgrammableCustomAtomicRegistrarV1",
+    );
+    expect(registry).toMatchObject({
+      address: eligibility.registryV1.registry.address,
+      blockNumber: eligibility.registryV1.registry.startBlock,
+      runtimeCodeHash: eligibility.registryV1.registry.runtimeCodeHash,
+    });
+    expect(registrar).toMatchObject({
+      address: eligibility.registryV1.atomicRegistrar.address,
+      blockNumber: eligibility.registryV1.atomicRegistrar.startBlock,
+      runtimeCodeHash: eligibility.registryV1.atomicRegistrar.runtimeCodeHash,
+    });
+    expect(eligibility.registryV1).toMatchObject({
+      routeCompatibility: "ANALYSIS_PENDING_NO_SHARDS_ADAPTER",
+      feePolicyCompatibility: "ANALYSIS_PENDING_NO_100_BPS_INCLUSIVE_PROFILE",
+      minimumFinalityBlocks: 64,
+    });
+    expect(eligibility.registryV1.supportedFeeProfiles).not.toContain(
+      "SHARDS_100_BPS_80_10_10",
+    );
+  });
+
+  it("fails if any exact Website source input drifts", () => {
+    for (const binding of eligibility.websiteBaseline.fileBindings as FileBinding[]) {
+      expect(rawSha256(join(process.cwd(), binding.path)), binding.path)
+        .toBe(binding.rawSha256);
+    }
+  });
+});


### PR DESCRIPTION
## Outcome

- Adds a machine-readable, exact-bound Shards eligibility manifest.
- Records the reviewed applicant/source/artifact/fee identities.
- Fails closed with `ANALYSIS_PENDING`, `launchAllowed=false`, and `descriptor=null` until eight concrete authority, route, fee, Registry, and finality bindings exist.
- Prevents an inactive nested-factory artifact or the Atomic Registrar from being substituted as an unreviewed Shards route.

## Validation

- Focused Shards and Router lifecycle tests: 9/9
- TypeScript: passed
- git diff --check: passed

## Release boundary

This PR deliberately does not activate Shards. It gives the release path a deterministic checklist and prevents a fabricated positive descriptor.