### PR TITLE
Fix filtered Explore Bitquery parity

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -445,8 +445,14 @@ export async function GET(request: NextRequest) {
         : []),
       ...customProjects,
     ]);
-    const identityEntries = await hydrateMissingCanonicalTokenSupplyV1(
+    assertNoExploreCategoryCollision(unresolvedIdentityEntries);
+    const requestedIdentityEntries = filterExploreEntries(
       unresolvedIdentityEntries,
+      options.query,
+      options.socials,
+    );
+    const identityEntries = await hydrateMissingCanonicalTokenSupplyV1(
+      requestedIdentityEntries,
     );
     const marketByToken = await readBitqueryTokenMarketDataV1(
       exploreEntriesMarketIdentitiesV1(identityEntries),
@@ -456,7 +462,6 @@ export async function GET(request: NextRequest) {
       identityEntries,
       marketByToken,
     );
-    assertNoExploreCategoryCollision(entries);
     const useTopValuationView =
       options.sort === "market-cap" &&
       options.query.length === 0 &&
@@ -489,7 +494,7 @@ export async function GET(request: NextRequest) {
         custom: customSource,
       }),
     };
-    if (canonicalSource === null && entries.length === 0) {
+    if (canonicalSource === null && unresolvedIdentityEntries.length === 0) {
       return NextResponse.json(
         {
           status: "unavailable",

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -742,6 +742,36 @@ describe("Explore API Bitquery market boundary", () => {
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 
+  it("scopes an exact token search to the matching Bitquery market", async () => {
+    const target = token(30);
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/explore?q=${target.tokenAddress}&sort=market-cap`,
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.total).toBe(1);
+    expect(body.tokens).toHaveLength(1);
+    expect(body.tokens[0]).toMatchObject({
+      tokenAddress: target.tokenAddress,
+      valuation: {
+        status: "available",
+        source: "bitquery",
+      },
+    });
+    expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledTimes(1);
+    const identities = mocks.readBitqueryTokenMarketDataV1.mock.calls[0]?.[0];
+    expect(identities).toHaveLength(1);
+    expect(identities?.[0]).toEqual({
+      chainId: "1",
+      tokenAddress: target.tokenAddress,
+      poolId: target.poolId,
+      protocol: "uniswap_v4",
+    });
+  });
+
   it("keeps canonical launches visible with unavailable valuation when Bitquery is down", async () => {
     mocks.enrichTokensWithAlchemyPoolState.mockRejectedValue(
       new Error("provider unavailable"),


### PR DESCRIPTION
## Summary
- scope filtered Explore requests before supply and Bitquery hydration
- keep collision detection on the complete canonical identity set
- make exact-address search return the same Bitquery FDV as token detail and chart

## Evidence
- reproduced on staged production candidate: Explore search was `price-unavailable` while detail/chart had a Bitquery FDV
- 66 focused Explore/detail/Bitquery tests pass
- TypeScript and targeted ESLint pass
- read-model operations source gate passes
- diff check passes