### PR TITLE
ci: approve exact Hookbuilder sync candidate

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -113,8 +113,8 @@ jobs:
           EXPECTED_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
           EXPECTED_CANDIDATE_COMMIT: ${{ github.event.pull_request.head.sha }}
           EXPECTED_MERGE_COMMIT: ${{ steps.candidate_fetch.outputs.merge_commit }}
-          APPROVED_MAIN_CI_CONTROL_COMMIT: 4758c979ce1538eacaa33e35b4f1297809af79e3
-          APPROVED_MAIN_CI_CONTROL_TREE: 990af077adcc3dcdc4f134882f8fac489938474b
+          APPROVED_MAIN_CI_CONTROL_COMMIT: 6520f1c4af583bd9420549dd811db8e1e301696e
+          APPROVED_MAIN_CI_CONTROL_TREE: e5104254109e7c0f58a59c0cc5b9ad8fddd04f6c
         run: |
           set -euo pipefail
 

--- a/scripts/test/verify-main-ci-control-workflow.test.mjs
+++ b/scripts/test/verify-main-ci-control-workflow.test.mjs
@@ -39,8 +39,8 @@ test("CI control guard executes only exact default-branch code over inert candid
 });
 
 test("trusted guard is bound to the exact audited main candidate commit and tree", () => {
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 4758c979ce1538eacaa33e35b4f1297809af79e3/u);
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: 990af077adcc3dcdc4f134882f8fac489938474b/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 6520f1c4af583bd9420549dd811db8e1e301696e/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: e5104254109e7c0f58a59c0cc5b9ad8fddd04f6c/u);
   assert.match(workflow, /--approved-commit "\$APPROVED_MAIN_CI_CONTROL_COMMIT"/u);
   assert.match(workflow, /--approved-tree "\$APPROVED_MAIN_CI_CONTROL_TREE"/u);
 });


### PR DESCRIPTION
## Outcome

- bind the trusted default-branch guard to candidate commit `6520f1c4af583bd9420549dd811db8e1e301696e`
- bind the same approval to candidate tree `e5104254109e7c0f58a59c0cc5b9ad8fddd04f6c`
- preserve fail-closed rejection for every other main CI control-plane change

## Candidate evidence

- complete embedded Hookbuilder maintenance gate passed, including 1,610 model tests, plugin packaging and evals
- Foundry, gas snapshot and security gates passed
- canonical 640-file skill copy and generated distributions are byte-bound in the candidate
- no merge, deploy, signing or launch permission is created by this approval

## Validation

- main CI control guard and workflow tests: 8/8 passed
- exact candidate commit and tree independently re-read from the clean candidate worktree
- `git diff --check` passed