### PR TITLE
ci: recognize public route profile hashes

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -142,6 +142,16 @@ regexes = [
 ]
 
 [[allowlists]]
+description = "Route-closure manifests contain public onchain profile keys, not credentials"
+condition = "AND"
+regexTarget = "match"
+paths = [
+  '''config/hookemon-route-closure\.v1\.json''',
+  '''contracts/spec/shards-route-closure-v1\.json''',
+]
+regexes = ['''profileKey"?:\s*"0x[0-9a-fA-F]{64}"''']
+
+[[allowlists]]
 description = "Router V3 vendored artifacts contain public bytes32 profile and winner bindings"
 condition = "AND"
 regexTarget = "match"


### PR DESCRIPTION
## What

Adds a path- and field-scoped Gitleaks allowlist for public onchain `profileKey` bytes32 values in the Hookemon and Shards route-closure manifests.

## Why

The generic API-key rule correctly flags high-entropy values, but these exact fields are public onchain profile identifiers, not credentials. The allowlist does not permit other fields, paths, or arbitrary hashes.

## Validation

- Current production history scan: no leaks
- Hookemon closure commit with this config: no leaks
- Shards closure commit with this config: no leaks
- `git diff --check`: pass
