### PR TITLE
release: add record-bound dark Custom Launch staging

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,6 +8,11 @@ on:
         required: true
         default: false
         type: boolean
+      custom_launch_dark_release:
+        description: Require the detached Custom Launch release record and stage a disabled dark candidate
+        required: true
+        default: false
+        type: boolean
       custom_launch_release_record_commit_sha:
         description: Exact commit on command-center-release-records containing the detached record
         required: false
@@ -228,11 +233,13 @@ jobs:
         id: custom-launch-policy
         env:
           CUSTOM_LAUNCH_PUBLIC_ENABLEMENT_REQUESTED: ${{ inputs.custom_launch_public_enablement }}
+          CUSTOM_LAUNCH_DARK_RELEASE_REQUESTED: ${{ inputs.custom_launch_dark_release }}
           CUSTOM_LAUNCH_PRODUCTION_MODE: ${{ vars.CUSTOM_LAUNCH_PRODUCTION_MODE }}
         run: >-
           node scripts/resolve-custom-launch-staging-policy.mjs
           --env-file .vercel/.env.production.local
           --requested "$CUSTOM_LAUNCH_PUBLIC_ENABLEMENT_REQUESTED"
+          --dark-release-requested "$CUSTOM_LAUNCH_DARK_RELEASE_REQUESTED"
           --production-mode "$CUSTOM_LAUNCH_PRODUCTION_MODE"
           --github-output "$GITHUB_OUTPUT"
 
@@ -279,6 +286,7 @@ jobs:
         if: steps.custom-launch-policy.outputs.release_record_required == 'true'
         env:
           RECORD_COMMIT_SHA: ${{ inputs.custom_launch_release_record_commit_sha }}
+          RECORD_VERIFICATION_LEVEL: ${{ steps.custom-launch-policy.outputs.release_record_verification_level }}
           EXPECTED_RECORD_SHA256: ${{ inputs.custom_launch_release_record_sha256 }}
           EXPECTED_PACKAGE_ARTIFACT_HASH: ${{ secrets.PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_PACKAGE_ARTIFACT_HASH }}
           EXPECTED_CROSS_REPOSITORY_ATTESTATION_COMMIT_SHA: ${{ vars.PROGRAMMABLE_BACKEND_CROSS_REPOSITORY_ATTESTATION_COMMIT_SHA }}
@@ -298,6 +306,13 @@ jobs:
             echo "The detached record must not be stored in its Website subject commit" >&2
             exit 1
           fi
+          case "$RECORD_VERIFICATION_LEVEL" in
+            staging|dark-staging) ;;
+            *)
+              echo "Custom Launch release-record verification level is invalid" >&2
+              exit 1
+              ;;
+          esac
           record_ref="refs/remotes/origin/command-center-release-records"
           record_path="release-records/custom-launch-v1/release-record.json"
           record_file="$RUNNER_TEMP/custom-launch-release-record.json"
@@ -333,7 +348,7 @@ jobs:
           attestation_summary_file="$RUNNER_TEMP/custom-launch-cross-repository-attestation.json"
           test ! -e "$attestation_summary_file"
           node scripts/verify-custom-launch-release-record.mjs "$record_file" \
-            --require staging \
+            --require "$RECORD_VERIFICATION_LEVEL" \
             --verify-cross-repository-attestation \
             --cross-repository-attestation-summary "$attestation_summary_file" \
             --expect-website-commit "$GITHUB_SHA" \
@@ -371,7 +386,8 @@ jobs:
             echo "- Backend cross-repository attestation: \`${{ steps.custom-launch-record.outputs.cross_repository_attestation_commit_sha }}\`"
             echo "- Backend binding document: \`${{ steps.custom-launch-record.outputs.cross_repository_binding_document_sha256 }}\`"
             echo "- Review authority: \`${{ steps.custom-launch-record.outputs.review_authority_mode }}\`"
-            echo "- Gate: verified for staging only"
+            echo "- Gate: \`${{ steps.custom-launch-policy.outputs.release_record_verification_level }}\` only"
+            echo "- Stage mode: \`${{ steps.custom-launch-policy.outputs.staging_mode }}\`"
             echo
             echo "No promotion is authorized by this staging gate."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -421,7 +437,7 @@ jobs:
 
       - name: Gate exact staged Custom Launch candidate
         id: custom-launch-canary
-        if: steps.custom-launch-policy.outputs.release_record_required == 'true'
+        if: steps.custom-launch-policy.outputs.staging_mode == 'enabled'
         env:
           STAGED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
@@ -456,11 +472,62 @@ jobs:
           echo "evidence_path=$RUNNER_TEMP/custom-launch-candidate-canary-evidence.json" >> "$GITHUB_OUTPUT"
 
       - name: Preserve redacted Custom Launch candidate evidence
-        if: steps.custom-launch-policy.outputs.release_record_required == 'true'
+        if: steps.custom-launch-policy.outputs.staging_mode == 'enabled'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: custom-launch-candidate-canary-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.custom-launch-canary.outputs.evidence_path }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Gate exact staged dark Custom Launch candidate
+        id: custom-launch-dark-release
+        if: steps.custom-launch-policy.outputs.staging_mode == 'dark'
+        env:
+          STAGED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}
+          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
+          PROGRAMMABLE_RELEASE_EXPECTED_COMMIT_SHA: ${{ github.sha }}
+          PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_PACKAGE_ARTIFACT_HASH: ${{ secrets.PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_PACKAGE_ARTIFACT_HASH }}
+          PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_REVIEW_AUTHORITY_MODE: ${{ steps.custom-launch-record.outputs.review_authority_mode }}
+          RELEASE_SUBJECT_SHA256: ${{ steps.custom-launch-record.outputs.release_subject_sha256 }}
+          DETACHED_RECORD_SHA256: ${{ steps.custom-launch-record.outputs.detached_record_sha256 }}
+          CROSS_REPOSITORY_ATTESTATION_COMMIT_SHA: ${{ steps.custom-launch-record.outputs.cross_repository_attestation_commit_sha }}
+          CROSS_REPOSITORY_BINDING_DOCUMENT_SHA256: ${{ steps.custom-launch-record.outputs.cross_repository_binding_document_sha256 }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          set -euo pipefail
+          deployment_host="$(node --input-type=module -e '
+            const url = new URL(process.env.STAGED_TARGET_URL);
+            if (
+              url.protocol !== "https:" ||
+              url.username !== "" ||
+              url.password !== "" ||
+              url.pathname !== "/" ||
+              url.search !== "" ||
+              url.hash !== "" ||
+              !url.hostname.endsWith(".vercel.app")
+            ) throw new Error("Custom Launch dark target is not an immutable Vercel origin");
+            process.stdout.write(url.host);
+          ')"
+          export PROGRAMMABLE_RELEASE_EXPECTED_DEPLOYMENT_HOST="$deployment_host"
+          evidence_path="$RUNNER_TEMP/custom-launch-dark-release-evidence.json"
+          npm run probe:custom-launch -- \
+            "--base-url=$STAGED_TARGET_URL" \
+            "--deployment-id=$STAGED_DEPLOYMENT_ID" \
+            "--dark-release-evidence-output=$evidence_path" \
+            "--release-subject-sha256=$RELEASE_SUBJECT_SHA256" \
+            "--detached-record-sha256=$DETACHED_RECORD_SHA256" \
+            "--cross-repository-attestation-commit-sha=$CROSS_REPOSITORY_ATTESTATION_COMMIT_SHA" \
+            "--cross-repository-binding-document-sha256=$CROSS_REPOSITORY_BINDING_DOCUMENT_SHA256" \
+            --require-disabled
+          echo "evidence_path=$evidence_path" >> "$GITHUB_OUTPUT"
+
+      - name: Preserve redacted Custom Launch dark release evidence
+        if: steps.custom-launch-policy.outputs.staging_mode == 'dark'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: custom-launch-dark-release-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.custom-launch-dark-release.outputs.evidence_path }}
           if-no-files-found: error
           retention-days: 90
 

--- a/docs/operations/CUSTOM-LAUNCH-PRODUCTION-ACTIVATION-V1.md
+++ b/docs/operations/CUSTOM-LAUNCH-PRODUCTION-ACTIVATION-V1.md
@@ -123,6 +123,19 @@ blank, differently cased, or any other value fails the workflow before deploymen
 continuing production policy for every later push, not a one-run checkbox. After activation it must
 remain `enabled` unless Command Center explicitly authorizes the emergency-disable procedure.
 
+The stage workflow has three mutually exclusive Custom Launch modes:
+
+| Dispatch | Pulled public flag / protected mode | Detached record | Runtime gate |
+| --- | --- | --- | --- |
+| `custom_launch_public_enablement=false`, `custom_launch_dark_release=false` | `false` / `disabled` | Not consumed; this is an ordinary Website candidate | No Custom Launch release claim |
+| `custom_launch_public_enablement=false`, `custom_launch_dark_release=true` | `false` / `disabled` | Required with `targetMode="disabled"` and verification level `dark-staging` | Disabled readiness with every required dependency component `ready` |
+| `custom_launch_public_enablement=true`, `custom_launch_dark_release=false` | `true` / `enabled` | Required with `targetMode="enabled"` and verification level `staging` | Enabled readiness and authenticated principal canary |
+
+The workflow rejects both dispatch booleans being `true`, any disagreement with pulled production
+configuration, and any disagreement with the protected production mode. A dispatch selects the
+gate; it never rewrites production configuration. Both record-bound modes remain immutable
+`--skip-domain` stages and carry no promotion or public-activation authority.
+
 ## Gate 2 — production dependencies
 
 Provision and validate every dependency while the public switch remains absent or exactly `false`.
@@ -195,7 +208,21 @@ After freeze clearance and all preceding gates, deploy through the reviewed prod
 do not run an unrecorded laptop deployment or promote a different build. The workflow creates a
 production-targeted immutable candidate with `--skip-domain`; it does not move the production alias
 until the candidate returns its exact commit and immutable Vercel host and every mode-required probe
-passes. Only the resulting protected `verified=true` step output permits promotion of that same URL.
+passes. Only an enabled candidate may later enter the separate candidate-verification and promotion
+process. A dark candidate never produces promotion authority.
+
+For the dark deployment, dispatch the exact `production` commit with:
+
+- `custom_launch_public_enablement=false`;
+- `custom_launch_dark_release=true`;
+- the exact detached-record commit and canonical detached-record SHA-256.
+
+The detached record must bind the same Website commit, approval-service package, cross-repository
+attestation and binding document, rollback deployment, and `targetMode="disabled"`. Its eight
+validation gates and production dependencies must be complete, while candidate, promotion, live,
+and canary fields remain pending. The workflow verifies it at `dark-staging`, stages only with
+`vercel deploy --prebuilt --prod --skip-domain`, and retains run-scoped record, attestation, and dark
+readiness evidence. It contains no alias, promotion, or public-enable operation.
 
 Keep `PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED=false`. Verify both the immutable deployment URL and
 `https://programmable.market`:
@@ -223,6 +250,18 @@ results and the exact release commit and immutable deployment host:
     "reviewAuthorityMode": "<manual_review-or-autonomous_ai>"
   }
 }
+```
+
+The protected workflow enforces the same condition with:
+
+```bash
+PROGRAMMABLE_RELEASE_EXPECTED_COMMIT_SHA=<exact-40-character-commit> \
+PROGRAMMABLE_RELEASE_EXPECTED_DEPLOYMENT_HOST=<immutable-vercel-host> \
+PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_PACKAGE_ARTIFACT_HASH=sha256:<exact-reviewed-package-hash> \
+PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_REVIEW_AUTHORITY_MODE=<manual_review-or-autonomous_ai> \
+npm run probe:custom-launch -- \
+  --base-url=https://<immutable-deployment-host> \
+  --require-disabled
 ```
 
 The response also includes `checkedAt`. No readiness response may contain secret or internal

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "brand:favicons": "node scripts/generate-programmable-favicons.mjs",
     "audit:prod": "npm audit --omit=dev --audit-level=moderate",
     "release:custom-launch:record:verify": "node scripts/verify-custom-launch-release-record.mjs",
-    "release:custom-launch:record:test": "node --test scripts/test/custom-launch-cross-repository-attestation.test.mjs scripts/test/custom-launch-release-record.test.mjs scripts/test/custom-launch-release-workflow-contract.test.mjs scripts/test/production-verify-proof.test.mjs",
+    "release:custom-launch:record:test": "node --test scripts/test/custom-launch-cross-repository-attestation.test.mjs scripts/test/custom-launch-dark-release-evidence.test.mjs scripts/test/custom-launch-release-record.test.mjs scripts/test/custom-launch-release-workflow-contract.test.mjs scripts/test/production-verify-proof.test.mjs",
     "release:manual-applicant:policy:test": "node --test scripts/test/manual-applicant-launch-policy.test.mjs",
     "release:manual-applicant:vendor:test": "node --test scripts/test/manual-router-authority-vendor.test.mjs scripts/test/router-v2-shared-lifecycle-v3-vendor.test.mjs",
     "release:manual-applicant:vendor:verify": "node scripts/verify-manual-router-authority-vendor.mjs && node scripts/verify-router-v2-shared-lifecycle-v3-vendor.mjs && node scripts/verify-manual-applicant-portable-imports.mjs --entry lib/vendor/manual-router-authority-v1/manual-router-portable.v1.mjs && node scripts/verify-manual-applicant-portable-imports.mjs --entry lib/vendor/router-v2-shared-lifecycle-v3/artifacts/router-v2-shared-lifecycle-v3/router-v2-shared-lifecycle-portable.v3.mjs",

--- a/scripts/custom-launch-dark-release-evidence.mjs
+++ b/scripts/custom-launch-dark-release-evidence.mjs
@@ -1,0 +1,115 @@
+import { writeFile } from "node:fs/promises";
+
+const SHA256_DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const GIT_COMMIT_OID = /^[0-9a-f]{40}$/u;
+const VERCEL_DEPLOYMENT_ID = /^dpl_[A-Za-z0-9]{8,128}$/u;
+const REVIEW_AUTHORITY_MODES = new Set(["manual_review", "autonomous_ai"]);
+const REQUIRED_COMPONENTS = Object.freeze([
+  "approvalService",
+  "permitSignerKeyring",
+  "publicConfiguration",
+  "websiteProjectionDatabase",
+]);
+
+export function createCustomLaunchDarkReleaseEvidence(input) {
+  if (input === null || typeof input !== "object") {
+    throw new TypeError("Custom Launch dark release evidence input is invalid");
+  }
+  const targetUrl = exactImmutableCandidateOrigin(input.targetUrl);
+  if (
+    input.probeResult?.baseUrl !== targetUrl
+    || input.probeResult?.status !== "disabled"
+    || input.probeResult?.authenticatedCanary !== "not_requested"
+  ) throw new TypeError("Custom Launch dark release readiness did not pass");
+  if (
+    typeof input.deploymentId !== "string"
+    || !VERCEL_DEPLOYMENT_ID.test(input.deploymentId)
+  ) throw new TypeError("Custom Launch dark deployment id is invalid");
+  if (
+    typeof input.websiteCommitSha !== "string"
+    || !GIT_COMMIT_OID.test(input.websiteCommitSha)
+  ) throw new TypeError("Custom Launch dark release commit is invalid");
+  if (
+    typeof input.approvalServicePackageArtifactHash !== "string"
+    || !SHA256_DIGEST.test(input.approvalServicePackageArtifactHash)
+  ) throw new TypeError("Custom Launch approval package identity is invalid");
+  if (!REVIEW_AUTHORITY_MODES.has(input.reviewAuthorityMode)) {
+    throw new TypeError("Custom Launch review authority mode is invalid");
+  }
+  for (const [name, value] of [
+    ["release subject", input.releaseSubjectSha256],
+    ["detached record", input.detachedRecordSha256],
+    ["cross-repository binding document", input.crossRepositoryBindingDocumentSha256],
+  ]) {
+    if (typeof value !== "string" || !SHA256_DIGEST.test(value)) {
+      throw new TypeError(`Custom Launch ${name} identity is invalid`);
+    }
+  }
+  if (
+    typeof input.crossRepositoryAttestationCommitSha !== "string"
+    || !GIT_COMMIT_OID.test(input.crossRepositoryAttestationCommitSha)
+  ) throw new TypeError("Custom Launch cross-repository attestation commit is invalid");
+
+  return Object.freeze({
+    schemaVersion: "programmable.custom-launch-dark-release-evidence.v1",
+    result: "passed",
+    candidate: Object.freeze({
+      deploymentId: input.deploymentId,
+      targetUrl,
+      websiteCommitSha: input.websiteCommitSha,
+    }),
+    releaseRecord: Object.freeze({
+      verificationLevel: "dark-staging",
+      releaseSubjectSha256: input.releaseSubjectSha256,
+      detachedRecordSha256: input.detachedRecordSha256,
+      crossRepositoryAttestationCommitSha:
+        input.crossRepositoryAttestationCommitSha,
+      crossRepositoryBindingDocumentSha256:
+        input.crossRepositoryBindingDocumentSha256,
+    }),
+    approvalService: Object.freeze({
+      packageArtifactHash: input.approvalServicePackageArtifactHash,
+      reviewAuthorityMode: input.reviewAuthorityMode,
+    }),
+    readiness: Object.freeze({
+      status: "disabled",
+      publicEnabled: false,
+      authenticatedCanary: "not_requested",
+      requiredComponents: Object.freeze(Object.fromEntries(
+        REQUIRED_COMPONENTS.map((component) => [component, "ready"]),
+      )),
+    }),
+  });
+}
+
+export async function writeCustomLaunchDarkReleaseEvidence(path, evidence) {
+  if (
+    typeof path !== "string"
+    || path.trim() !== path
+    || path.length === 0
+    || path.length > 4_096
+    || /[\r\n\0]/u.test(path)
+  ) throw new TypeError("Custom Launch dark release evidence path is invalid");
+  await writeFile(path, `${JSON.stringify(evidence)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+}
+
+function exactImmutableCandidateOrigin(value) {
+  if (typeof value !== "string" || value.trim() !== value || value.length === 0) {
+    throw new TypeError("Custom Launch dark candidate URL is invalid");
+  }
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:"
+    || url.username !== ""
+    || url.password !== ""
+    || url.pathname !== "/"
+    || url.search !== ""
+    || url.hash !== ""
+    || !url.hostname.endsWith(".vercel.app")
+  ) throw new TypeError("Custom Launch dark candidate URL must be an immutable Vercel origin");
+  return url.origin;
+}

--- a/scripts/resolve-custom-launch-staging-policy.mjs
+++ b/scripts/resolve-custom-launch-staging-policy.mjs
@@ -50,6 +50,7 @@ export function readCustomLaunchPublicFlag(envSource) {
 
 export function resolveCustomLaunchStagingPolicy({
   requested,
+  darkReleaseRequested = false,
   productionEnvSource,
   productionMode,
 }) {
@@ -57,8 +58,17 @@ export function resolveCustomLaunchStagingPolicy({
     requested,
     "Custom Launch dispatch request",
   );
+  const requestedDarkRelease = parseBoolean(
+    darkReleaseRequested,
+    "Custom Launch dark release dispatch request",
+  );
   const configuredEnablement = readCustomLaunchPublicFlag(productionEnvSource);
   const modeEnablement = parseProductionMode(productionMode);
+  if (requestedEnablement && requestedDarkRelease) {
+    throw new Error(
+      "Custom Launch public enablement and dark release dispatch requests are mutually exclusive",
+    );
+  }
   if (requestedEnablement !== configuredEnablement) {
     throw new Error(
       "Custom Launch dispatch request and pulled production configuration disagree",
@@ -69,9 +79,20 @@ export function resolveCustomLaunchStagingPolicy({
       "Custom Launch protected production mode and pulled production configuration disagree",
     );
   }
+  const stagingMode = requestedEnablement
+    ? "enabled"
+    : requestedDarkRelease
+      ? "dark"
+      : "generic-disabled";
   return Object.freeze({
-    releaseRecordRequired: requestedEnablement,
+    releaseRecordRequired: requestedEnablement || requestedDarkRelease,
+    releaseRecordVerificationLevel: requestedDarkRelease
+      ? "dark-staging"
+      : requestedEnablement
+        ? "staging"
+        : "none",
     configuredEnablement,
+    stagingMode,
   });
 }
 
@@ -92,6 +113,7 @@ function argumentsFrom(argv) {
   for (const name of [
     "env-file",
     "requested",
+    "dark-release-requested",
     "production-mode",
     "github-output",
   ]) {
@@ -104,6 +126,7 @@ async function main(argv) {
   const args = argumentsFrom(argv);
   const result = resolveCustomLaunchStagingPolicy({
     requested: args.requested,
+    darkReleaseRequested: args["dark-release-requested"],
     productionEnvSource: await readFile(args["env-file"], "utf8"),
     productionMode: args["production-mode"],
   });
@@ -111,13 +134,20 @@ async function main(argv) {
     args["github-output"],
     [
       `release_record_required=${result.releaseRecordRequired}`,
+      `release_record_verification_level=${result.releaseRecordVerificationLevel}`,
       `configured_enablement=${result.configuredEnablement}`,
+      `staging_mode=${result.stagingMode}`,
       "",
     ].join("\n"),
     { encoding: "utf8", mode: 0o600 },
   );
   process.stdout.write(
-    `${JSON.stringify({ status: "verified", releaseRecordRequired: result.releaseRecordRequired })}\n`,
+    `${JSON.stringify({
+      status: "verified",
+      releaseRecordRequired: result.releaseRecordRequired,
+      releaseRecordVerificationLevel: result.releaseRecordVerificationLevel,
+      stagingMode: result.stagingMode,
+    })}\n`,
   );
 }
 

--- a/scripts/test/custom-launch-dark-release-evidence.test.mjs
+++ b/scripts/test/custom-launch-dark-release-evidence.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  createCustomLaunchDarkReleaseEvidence,
+  writeCustomLaunchDarkReleaseEvidence,
+} from "../custom-launch-dark-release-evidence.mjs";
+
+const input = Object.freeze({
+  probeResult: Object.freeze({
+    baseUrl: "https://launcher-v4-dark.vercel.app",
+    status: "disabled",
+    authenticatedCanary: "not_requested",
+  }),
+  targetUrl: "https://launcher-v4-dark.vercel.app",
+  deploymentId: "dpl_12345678",
+  websiteCommitSha: "1".repeat(40),
+  approvalServicePackageArtifactHash: `sha256:${"2".repeat(64)}`,
+  reviewAuthorityMode: "manual_review",
+  releaseSubjectSha256: `sha256:${"3".repeat(64)}`,
+  detachedRecordSha256: `sha256:${"4".repeat(64)}`,
+  crossRepositoryAttestationCommitSha: "5".repeat(40),
+  crossRepositoryBindingDocumentSha256: `sha256:${"6".repeat(64)}`,
+});
+
+test("dark release evidence binds the disabled probe and exact release record", () => {
+  const evidence = createCustomLaunchDarkReleaseEvidence(input);
+  assert.deepEqual(evidence, {
+    schemaVersion: "programmable.custom-launch-dark-release-evidence.v1",
+    result: "passed",
+    candidate: {
+      deploymentId: input.deploymentId,
+      targetUrl: input.targetUrl,
+      websiteCommitSha: input.websiteCommitSha,
+    },
+    releaseRecord: {
+      verificationLevel: "dark-staging",
+      releaseSubjectSha256: input.releaseSubjectSha256,
+      detachedRecordSha256: input.detachedRecordSha256,
+      crossRepositoryAttestationCommitSha:
+        input.crossRepositoryAttestationCommitSha,
+      crossRepositoryBindingDocumentSha256:
+        input.crossRepositoryBindingDocumentSha256,
+    },
+    approvalService: {
+      packageArtifactHash: input.approvalServicePackageArtifactHash,
+      reviewAuthorityMode: input.reviewAuthorityMode,
+    },
+    readiness: {
+      status: "disabled",
+      publicEnabled: false,
+      authenticatedCanary: "not_requested",
+      requiredComponents: {
+        approvalService: "ready",
+        permitSignerKeyring: "ready",
+        publicConfiguration: "ready",
+        websiteProjectionDatabase: "ready",
+      },
+    },
+  });
+});
+
+test("dark release evidence rejects enabled, incomplete, and mutable targets", () => {
+  assert.throws(
+    () => createCustomLaunchDarkReleaseEvidence({
+      ...input,
+      probeResult: { ...input.probeResult, status: "ready" },
+    }),
+    /readiness did not pass/,
+  );
+  assert.throws(
+    () => createCustomLaunchDarkReleaseEvidence({
+      ...input,
+      targetUrl: "https://programmable.market",
+      probeResult: { ...input.probeResult, baseUrl: "https://programmable.market" },
+    }),
+    /immutable Vercel origin/,
+  );
+  assert.throws(
+    () => createCustomLaunchDarkReleaseEvidence({
+      ...input,
+      detachedRecordSha256: undefined,
+    }),
+    /detached record identity/,
+  );
+});
+
+test("dark release evidence is written once as canonical private JSON", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "custom-launch-dark-release-"));
+  try {
+    const path = join(directory, "evidence.json");
+    const evidence = createCustomLaunchDarkReleaseEvidence(input);
+    await writeCustomLaunchDarkReleaseEvidence(path, evidence);
+    assert.equal(await readFile(path, "utf8"), `${JSON.stringify(evidence)}\n`);
+    await assert.rejects(
+      writeCustomLaunchDarkReleaseEvidence(path, evidence),
+      /EEXIST/,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/scripts/test/custom-launch-release-record.test.mjs
+++ b/scripts/test/custom-launch-release-record.test.mjs
@@ -91,11 +91,11 @@ function decision(status, subjectHash, suffix) {
   };
 }
 
-async function completeRecord(level = "live") {
+async function completeRecord(level = "live", targetMode = "enabled") {
   const record = await readTemplate();
   record.createdAt = "2026-08-06T11:00:00Z";
   record.releaseIntent.releaseId = "custom-launch-v1-20260806-001";
-  record.releaseIntent.targetMode = "enabled";
+  record.releaseIntent.targetMode = targetMode;
   record.subject.website.commitSha = commits.website;
   record.subject.website.reviewedDiffBaseSha = commits.base;
   record.subject.website.reviewedDiffHeadSha = commits.website;
@@ -353,6 +353,34 @@ test("each release level is independently fail closed", async () => {
 
   const live = await completeRecord("live");
   assert.equal(verifyReleaseRecord(live, { require: "live" }).ok, true);
+});
+
+test("dark staging requires a disabled target with complete staging evidence", async () => {
+  const darkStaging = await completeRecord("staging", "disabled");
+  assert.equal(
+    verifyReleaseRecord(darkStaging, { require: "dark-staging" }).ok,
+    true,
+  );
+
+  const enabledAsDark = await completeRecord("staging", "enabled");
+  const enabledAsDarkResult = verifyReleaseRecord(enabledAsDark, {
+    require: "dark-staging",
+  });
+  assert.equal(enabledAsDarkResult.ok, false);
+  assert.match(enabledAsDarkResult.errors.join("\n"), /targetMode/);
+
+  const disabledAsEnabled = verifyReleaseRecord(darkStaging, {
+    require: "staging",
+  });
+  assert.equal(disabledAsEnabled.ok, false);
+  assert.match(disabledAsEnabled.errors.join("\n"), /targetMode/);
+
+  darkStaging.productionDependencies = null;
+  const missingDependencies = verifyReleaseRecord(darkStaging, {
+    require: "dark-staging",
+  });
+  assert.equal(missingDependencies.ok, false);
+  assert.match(missingDependencies.errors.join("\n"), /productionDependencies/);
 });
 
 test("release records reject the former production alias", async () => {

--- a/scripts/test/custom-launch-release-workflow-contract.test.mjs
+++ b/scripts/test/custom-launch-release-workflow-contract.test.mjs
@@ -24,6 +24,7 @@ function workflowFailures(source) {
   };
 
   requireText("dispatch-boolean", "custom_launch_public_enablement:");
+  requireText("dispatch-dark-release-boolean", "custom_launch_dark_release:");
   if (source.includes("\n  push:\n")) failures.push("dispatch-only-stage");
   requireText(
     "exact-production-verify-proof-gate",
@@ -114,6 +115,14 @@ function workflowFailures(source) {
     "production-config-input",
     "CUSTOM_LAUNCH_PUBLIC_ENABLEMENT_REQUESTED: ${{ inputs.custom_launch_public_enablement }}",
   );
+  requireText(
+    "dark-release-config-input",
+    "CUSTOM_LAUNCH_DARK_RELEASE_REQUESTED: ${{ inputs.custom_launch_dark_release }}",
+  );
+  requireText(
+    "dark-release-policy-input",
+    '--dark-release-requested "$CUSTOM_LAUNCH_DARK_RELEASE_REQUESTED"',
+  );
   requireText("canonical-stage-name", "Stage programmable.market candidate");
   requireText(
     "canonical-rollback-target",
@@ -190,7 +199,15 @@ function workflowFailures(source) {
     "record-fixed-path",
     'record_path="release-records/custom-launch-v1/release-record.json"',
   );
-  requireText("record-staging-level", "--require staging");
+  requireText(
+    "record-verification-level-binding",
+    "RECORD_VERIFICATION_LEVEL: ${{ steps.custom-launch-policy.outputs.release_record_verification_level }}",
+  );
+  requireText("record-verification-level-allowlist", "staging|dark-staging) ;;");
+  requireText(
+    "record-verification-level-argument",
+    '--require "$RECORD_VERIFICATION_LEVEL"',
+  );
   requireText(
     "record-website-binding",
     '--expect-website-commit "$GITHUB_SHA"',
@@ -268,6 +285,10 @@ function workflowFailures(source) {
     "candidate-runtime-commit-binding",
     '--env PROGRAMMABLE_RELEASE_COMMIT_SHA="$GITHUB_SHA"',
   );
+  requireText(
+    "stage-skips-domain-assignment",
+    "vercel deploy --prebuilt --prod --skip-domain",
+  );
   requireOrder(
     "record-after-rollback-capture",
     "Capture current production rollback target",
@@ -294,18 +315,27 @@ function workflowFailures(source) {
     "Install dependencies",
   );
   requireText("candidate-canary", "Gate exact staged Custom Launch candidate");
+  const candidateGateStart = source.indexOf(
+    "      - name: Gate exact staged Custom Launch candidate",
+  );
+  const candidateGateEnd = source.indexOf(
+    "      - name: Preserve redacted Custom Launch candidate evidence",
+  );
+  const candidateGateBlock =
+    candidateGateStart >= 0 && candidateGateEnd > candidateGateStart
+      ? source.slice(candidateGateStart, candidateGateEnd)
+      : "";
   requireText(
     "candidate-canary-conditional",
-    "id: custom-launch-canary\n        if: steps.custom-launch-policy.outputs.release_record_required == 'true'",
+    "id: custom-launch-canary\n        if: steps.custom-launch-policy.outputs.staging_mode == 'enabled'",
   );
   requireText(
     "candidate-canary-immutable-target",
     "STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
   );
-  requireText(
-    "candidate-canary-deployment-binding",
-    '"--deployment-id=$STAGED_DEPLOYMENT_ID"',
-  );
+  if (!candidateGateBlock.includes('"--deployment-id=$STAGED_DEPLOYMENT_ID"')) {
+    failures.push("candidate-canary-deployment-binding");
+  }
   requireText(
     "candidate-canary-package-binding",
     "PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_PACKAGE_ARTIFACT_HASH: ${{ secrets.PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_PACKAGE_ARTIFACT_HASH }}",
@@ -333,6 +363,51 @@ function workflowFailures(source) {
     "Resolve exact staged deployment",
     "Gate exact staged Custom Launch candidate",
   );
+  const darkGateStart = source.indexOf(
+    "      - name: Gate exact staged dark Custom Launch candidate",
+  );
+  const darkGateEnd = source.indexOf(
+    "      - name: Preserve redacted Custom Launch dark release evidence",
+  );
+  const darkGateBlock =
+    darkGateStart >= 0 && darkGateEnd > darkGateStart
+      ? source.slice(darkGateStart, darkGateEnd)
+      : "";
+  if (!darkGateBlock.includes("if: steps.custom-launch-policy.outputs.staging_mode == 'dark'")) {
+    failures.push("dark-candidate-conditional");
+  }
+  for (const [id, binding] of [
+    ["dark-candidate-disabled", "--require-disabled"],
+    ["dark-candidate-evidence-output", "--dark-release-evidence-output=$evidence_path"],
+    ["dark-candidate-deployment-binding", "--deployment-id=$STAGED_DEPLOYMENT_ID"],
+    ["dark-candidate-record-subject", "--release-subject-sha256=$RELEASE_SUBJECT_SHA256"],
+    ["dark-candidate-record-digest", "--detached-record-sha256=$DETACHED_RECORD_SHA256"],
+    ["dark-candidate-attestation", "--cross-repository-attestation-commit-sha=$CROSS_REPOSITORY_ATTESTATION_COMMIT_SHA"],
+    ["dark-candidate-binding-document", "--cross-repository-binding-document-sha256=$CROSS_REPOSITORY_BINDING_DOCUMENT_SHA256"],
+  ]) {
+    if (!darkGateBlock.includes(binding)) failures.push(id);
+  }
+  if (darkGateBlock.includes("--require-enabled")) {
+    failures.push("dark-candidate-must-not-enable");
+  }
+  if (darkGateBlock.includes("--authenticated-canary")) {
+    failures.push("dark-candidate-must-not-authenticate");
+  }
+  for (const secret of [
+    "PROGRAMMABLE_CUSTOM_LAUNCH_CANARY_ACCESS_TOKEN",
+    "PROGRAMMABLE_CUSTOM_LAUNCH_CANARY_IDENTITY_TOKEN",
+  ]) {
+    if (darkGateBlock.includes(secret)) failures.push(`dark-candidate-${secret.toLowerCase()}`);
+  }
+  requireText(
+    "dark-candidate-evidence-artifact",
+    "custom-launch-dark-release-${{ github.run_id }}-${{ github.run_attempt }}",
+  );
+  requireOrder(
+    "dark-candidate-after-stage-resolution",
+    "Resolve exact staged deployment",
+    "Gate exact staged dark Custom Launch candidate",
+  );
   if (/\bvercel\s+(?:promote|rollback)(?:\s|$)/mu.test(source)) {
     failures.push("stage-only");
   }
@@ -346,7 +421,12 @@ test("generic production staging remains record-free only while Custom Launch is
       productionEnvSource: "OTHER_FLAG=true\n",
       productionMode: "disabled",
     }),
-    { releaseRecordRequired: false, configuredEnablement: false },
+    {
+      releaseRecordRequired: false,
+      releaseRecordVerificationLevel: "none",
+      configuredEnablement: false,
+      stagingMode: "generic-disabled",
+    },
   );
   assert.deepEqual(
     resolveCustomLaunchStagingPolicy({
@@ -354,8 +434,47 @@ test("generic production staging remains record-free only while Custom Launch is
       productionEnvSource: `${"PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED"}=\"false\"\n`,
       productionMode: "disabled",
     }),
-    { releaseRecordRequired: false, configuredEnablement: false },
+    {
+      releaseRecordRequired: false,
+      releaseRecordVerificationLevel: "none",
+      configuredEnablement: false,
+      stagingMode: "generic-disabled",
+    },
   );
+});
+
+test("dark release requires an explicit disabled record-bound dispatch", () => {
+  assert.deepEqual(
+    resolveCustomLaunchStagingPolicy({
+      requested: "false",
+      darkReleaseRequested: "true",
+      productionEnvSource: "PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED=false\n",
+      productionMode: "disabled",
+    }),
+    {
+      releaseRecordRequired: true,
+      releaseRecordVerificationLevel: "dark-staging",
+      configuredEnablement: false,
+      stagingMode: "dark",
+    },
+  );
+  assert.throws(
+    () => resolveCustomLaunchStagingPolicy({
+      requested: "true",
+      darkReleaseRequested: "true",
+      productionEnvSource: "PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED=true\n",
+      productionMode: "enabled",
+    }),
+    /mutually exclusive/,
+  );
+  for (const darkReleaseRequested of [null, "", "TRUE", "1"]) {
+    assert.throws(() => resolveCustomLaunchStagingPolicy({
+      requested: "false",
+      darkReleaseRequested,
+      productionEnvSource: "PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED=false\n",
+      productionMode: "disabled",
+    }));
+  }
 });
 
 test("enabled production configuration requires an explicit matching dispatch", () => {
@@ -365,7 +484,12 @@ test("enabled production configuration requires an explicit matching dispatch", 
       productionEnvSource: "PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED='true'\n",
       productionMode: "enabled",
     }),
-    { releaseRecordRequired: true, configuredEnablement: true },
+    {
+      releaseRecordRequired: true,
+      releaseRecordVerificationLevel: "staging",
+      configuredEnablement: true,
+      stagingMode: "enabled",
+    },
   );
   assert.throws(
     () =>
@@ -433,7 +557,15 @@ test("workflow contract detects weakened record and stage-only gates", async () 
       "if: steps.custom-launch-policy.outputs.release_record_required == 'true'",
       "if: always()",
     ),
-    source.replace("--require staging", "--require clearance"),
+    source.replace(
+      '--require "$RECORD_VERIFICATION_LEVEL"',
+      "--require clearance",
+    ),
+    source.replace("staging|dark-staging) ;;", "staging) ;;"),
+    source.replace(
+      '--dark-release-requested "$CUSTOM_LAUNCH_DARK_RELEASE_REQUESTED"',
+      "",
+    ),
     source.replace(
       '--expect-package-artifact-hash "$EXPECTED_PACKAGE_ARTIFACT_HASH"',
       "",
@@ -467,11 +599,19 @@ test("workflow contract detects weakened record and stage-only gates", async () 
     source.replace('--production-mode "$CUSTOM_LAUNCH_PRODUCTION_MODE"', ""),
     source.replace('--env PROGRAMMABLE_RELEASE_COMMIT_SHA="$GITHUB_SHA"', ""),
     source.replace("--authenticated-canary", ""),
+    source.replace("--require-disabled", ""),
+    source.replace("--dark-release-evidence-output=$evidence_path", ""),
+    source.replace("--release-subject-sha256=$RELEASE_SUBJECT_SHA256", ""),
     source.replace('"--deployment-id=$STAGED_DEPLOYMENT_ID"', ""),
     source.replace(
       "custom-launch-candidate-canary-${{ github.run_id }}-${{ github.run_attempt }}",
       "missing-candidate-artifact",
     ),
+    source.replace(
+      "custom-launch-dark-release-${{ github.run_id }}-${{ github.run_attempt }}",
+      "missing-dark-release-artifact",
+    ),
+    source.replace("--skip-domain", ""),
     source.replace('--source-digest "$GITHUB_SHA"', ""),
     source.replace('--signer-digest "$GITHUB_SHA"', ""),
     source.replace("--deny-self-hosted-runners", ""),

--- a/scripts/verify-custom-launch-deployment.mjs
+++ b/scripts/verify-custom-launch-deployment.mjs
@@ -8,6 +8,10 @@ import {
   createCustomLaunchCanaryEvidence,
   writeCustomLaunchCanaryEvidence,
 } from "./custom-launch-canary-evidence.mjs";
+import {
+  createCustomLaunchDarkReleaseEvidence,
+  writeCustomLaunchDarkReleaseEvidence,
+} from "./custom-launch-dark-release-evidence.mjs";
 
 try {
   const runnerArguments = parseRunnerArguments(process.argv.slice(2));
@@ -31,6 +35,27 @@ try {
     });
     await writeCustomLaunchCanaryEvidence(runnerArguments.evidenceOutput, evidence);
   }
+  if (runnerArguments.darkReleaseEvidenceOutput !== undefined) {
+    const evidence = createCustomLaunchDarkReleaseEvidence({
+      probeResult: result,
+      targetUrl: probeInput.baseUrl,
+      deploymentId: runnerArguments.deploymentId,
+      websiteCommitSha: probeInput.expectedCommitSha,
+      approvalServicePackageArtifactHash:
+        probeInput.expectedApprovalServicePackageArtifactHash,
+      reviewAuthorityMode: probeInput.expectedApprovalServiceReviewAuthorityMode,
+      releaseSubjectSha256: runnerArguments.releaseSubjectSha256,
+      detachedRecordSha256: runnerArguments.detachedRecordSha256,
+      crossRepositoryAttestationCommitSha:
+        runnerArguments.crossRepositoryAttestationCommitSha,
+      crossRepositoryBindingDocumentSha256:
+        runnerArguments.crossRepositoryBindingDocumentSha256,
+    });
+    await writeCustomLaunchDarkReleaseEvidence(
+      runnerArguments.darkReleaseEvidenceOutput,
+      evidence,
+    );
+  }
   process.stdout.write(
     `Custom launch deployment ${result.status} at ${result.baseUrl}`
     + ` (authenticated canary: ${result.authenticatedCanary})\n`,
@@ -44,22 +69,93 @@ try {
 function parseRunnerArguments(argv) {
   const probeArguments = [];
   let evidenceOutput;
+  let darkReleaseEvidenceOutput;
   let deploymentId;
+  let releaseSubjectSha256;
+  let detachedRecordSha256;
+  let crossRepositoryAttestationCommitSha;
+  let crossRepositoryBindingDocumentSha256;
   for (const argument of argv) {
     if (argument.startsWith("--evidence-output=") && evidenceOutput === undefined) {
       evidenceOutput = argument.slice("--evidence-output=".length);
     } else if (argument.startsWith("--deployment-id=") && deploymentId === undefined) {
       deploymentId = argument.slice("--deployment-id=".length);
+    } else if (
+      argument.startsWith("--dark-release-evidence-output=")
+      && darkReleaseEvidenceOutput === undefined
+    ) {
+      darkReleaseEvidenceOutput = argument.slice(
+        "--dark-release-evidence-output=".length,
+      );
+    } else if (
+      argument.startsWith("--release-subject-sha256=")
+      && releaseSubjectSha256 === undefined
+    ) {
+      releaseSubjectSha256 = argument.slice("--release-subject-sha256=".length);
+    } else if (
+      argument.startsWith("--detached-record-sha256=")
+      && detachedRecordSha256 === undefined
+    ) {
+      detachedRecordSha256 = argument.slice("--detached-record-sha256=".length);
+    } else if (
+      argument.startsWith("--cross-repository-attestation-commit-sha=")
+      && crossRepositoryAttestationCommitSha === undefined
+    ) {
+      crossRepositoryAttestationCommitSha = argument.slice(
+        "--cross-repository-attestation-commit-sha=".length,
+      );
+    } else if (
+      argument.startsWith("--cross-repository-binding-document-sha256=")
+      && crossRepositoryBindingDocumentSha256 === undefined
+    ) {
+      crossRepositoryBindingDocumentSha256 = argument.slice(
+        "--cross-repository-binding-document-sha256=".length,
+      );
     } else {
       probeArguments.push(argument);
     }
   }
-  if ((evidenceOutput === undefined) !== (deploymentId === undefined)) {
+  if (evidenceOutput !== undefined && darkReleaseEvidenceOutput !== undefined) {
+    throw new TypeError("Canary and dark release evidence outputs are mutually exclusive");
+  }
+  if (evidenceOutput !== undefined && deploymentId === undefined) {
     throw new TypeError("Canary evidence output and deployment id must be provided together");
+  }
+  const darkReleaseBindings = [
+    releaseSubjectSha256,
+    detachedRecordSha256,
+    crossRepositoryAttestationCommitSha,
+    crossRepositoryBindingDocumentSha256,
+  ];
+  if (
+    darkReleaseEvidenceOutput !== undefined
+    && (deploymentId === undefined || darkReleaseBindings.some((value) => value === undefined))
+  ) {
+    throw new TypeError(
+      "Dark release evidence requires deployment and exact release-record bindings",
+    );
+  }
+  if (
+    darkReleaseEvidenceOutput === undefined
+    && darkReleaseBindings.some((value) => value !== undefined)
+  ) {
+    throw new TypeError("Dark release bindings require a dark release evidence output");
+  }
+  if (
+    deploymentId !== undefined
+    && evidenceOutput === undefined
+    && darkReleaseEvidenceOutput === undefined
+  ) {
+    throw new TypeError("Deployment id requires an evidence output");
   }
   return Object.freeze({
     probeArguments: Object.freeze(probeArguments),
     evidenceOutput,
+    darkReleaseEvidenceOutput,
     deploymentId,
+    releaseSubjectSha256,
+    detachedRecordSha256,
+    crossRepositoryAttestationCommitSha,
+    crossRepositoryBindingDocumentSha256,
   });
 }

--- a/scripts/verify-custom-launch-release-record.mjs
+++ b/scripts/verify-custom-launch-release-record.mjs
@@ -34,7 +34,15 @@ const RECORD_STATUSES = new Set([
   "live",
 ]);
 const REVIEW_AUTHORITY_MODES = new Set(["manual_review", "autonomous_ai"]);
-const REQUIRED_LEVELS = new Set(["template", "clearance", "staging", "candidate", "promotion", "live"]);
+const REQUIRED_LEVELS = new Set([
+  "template",
+  "clearance",
+  "dark-staging",
+  "staging",
+  "candidate",
+  "promotion",
+  "live",
+]);
 const FORBIDDEN_SECRET_KEY = /^(?:access[_-]?token|identity[_-]?token|private[_-]?key|password|secret|database[_-]?url|credential)(?:[_-]?value)?$/i;
 const PLACEHOLDER_PATTERN = /(?:<[^>]+>|example\.invalid|replace[_ -]?me|todo|yyyy|nnn)/i;
 const CROSS_REPOSITORY_BINDING_REPOSITORY =
@@ -498,7 +506,8 @@ export function verifyReleaseRecord(
   if (schemaFailure !== null) return schemaFailure;
   const errors = [];
   const levels = ["template", "clearance", "staging", "candidate", "promotion", "live"];
-  const requiredIndex = levels.indexOf(require);
+  const darkStaging = require === "dark-staging";
+  const requiredIndex = darkStaging ? levels.indexOf("staging") : levels.indexOf(require);
   requireExactKeys(errors, record, "$", ["schemaVersion", "recordStatus", "createdAt", "releaseIntent", "subject", "commandCenter", "validation", "productionDependencies", "deployment", "promotionGate", "canary"]);
   const allowPlaceholders = require === "template";
   walkForSecretsAndPlaceholders(record, "", errors, allowPlaceholders);
@@ -578,7 +587,12 @@ export function verifyReleaseRecord(
   if (requiredIndex >= 2) {
     validateDependencies(errors, record.productionDependencies);
     validateRollback(errors, record.deployment?.rollback);
-    requireExact(errors, record.releaseIntent?.targetMode, "releaseIntent.targetMode", "enabled");
+    requireExact(
+      errors,
+      record.releaseIntent?.targetMode,
+      "releaseIntent.targetMode",
+      darkStaging ? "disabled" : "enabled",
+    );
   }
   if (requiredIndex === 2) {
     requireExact(errors, record.recordStatus, "recordStatus", "freeze_cleared");
@@ -781,7 +795,7 @@ function parseArguments(argv) {
     else if (file === null) file = argument;
     else throw new Error(`unexpected argument: ${argument}`);
   }
-  if (file === null) throw new Error("usage: verify-custom-launch-release-record.mjs <record.json> [--require template|clearance|staging|candidate|promotion|live] [--verify-cross-repository-attestation] [--cross-repository-attestation-summary path] [--json] [--github-output path] [expectation flags]");
+  if (file === null) throw new Error("usage: verify-custom-launch-release-record.mjs <record.json> [--require template|clearance|dark-staging|staging|candidate|promotion|live] [--verify-cross-repository-attestation] [--cross-repository-attestation-summary path] [--json] [--github-output path] [expectation flags]");
   if (crossRepositoryAttestationSummary !== null && !verifyCrossRepositoryAttestation) {
     throw new Error("cross-repository attestation summary output requires live attestation verification");
   }


### PR DESCRIPTION
## What

Adds a fail-closed Custom Launch dark-release mode that validates the exact detached release record and cross-repository attestation while public launch remains disabled.

## Safety boundary

- `public=false` and protected status remains disabled
- all four production dependencies must still be ready
- immutable `vercel deploy --prebuilt --prod --skip-domain`
- no alias move, promotion, authenticated canary secrets, or public enablement
- existing enabled-release semantics remain unchanged

## Validation

- Release record/policy suite: 48/48
- Deployment probe/canary tests: 12/12
- CI routing: 13/13
- Typecheck: pass
- Workflow YAML parse: pass
- Lint: 0 errors
- Diff check: pass
