### PR TITLE
ci: approve exact Node 24 Hookbuilder candidate

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -73,9 +73,9 @@ jobs:
           test "$(git -C "$GITHUB_WORKSPACE/base" rev-parse HEAD)" = "$EXPECTED_BASE_SHA"
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24.14.0
+          node-version: 24.19.0
 
       - name: Fetch exact candidate merge as blobless data
         id: candidate_fetch
@@ -113,8 +113,8 @@ jobs:
           EXPECTED_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
           EXPECTED_CANDIDATE_COMMIT: ${{ github.event.pull_request.head.sha }}
           EXPECTED_MERGE_COMMIT: ${{ steps.candidate_fetch.outputs.merge_commit }}
-          APPROVED_MAIN_CI_CONTROL_COMMIT: 6520f1c4af583bd9420549dd811db8e1e301696e
-          APPROVED_MAIN_CI_CONTROL_TREE: e5104254109e7c0f58a59c0cc5b9ad8fddd04f6c
+          APPROVED_MAIN_CI_CONTROL_COMMIT: 34e8c233e71ca0f2dcc68d40af70632b86b2a92a
+          APPROVED_MAIN_CI_CONTROL_TREE: 525b5524e2c12c84753f7ac46788f7f244dc9709
         run: |
           set -euo pipefail
 

--- a/scripts/test/verify-main-ci-control-workflow.test.mjs
+++ b/scripts/test/verify-main-ci-control-workflow.test.mjs
@@ -39,10 +39,20 @@ test("CI control guard executes only exact default-branch code over inert candid
 });
 
 test("trusted guard is bound to the exact audited main candidate commit and tree", () => {
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 6520f1c4af583bd9420549dd811db8e1e301696e/u);
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: e5104254109e7c0f58a59c0cc5b9ad8fddd04f6c/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 34e8c233e71ca0f2dcc68d40af70632b86b2a92a/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: 525b5524e2c12c84753f7ac46788f7f244dc9709/u);
   assert.match(workflow, /--approved-commit "\$APPROVED_MAIN_CI_CONTROL_COMMIT"/u);
   assert.match(workflow, /--approved-tree "\$APPROVED_MAIN_CI_CONTROL_TREE"/u);
+});
+
+test("trusted production intake uses the exact current Node 24 LTS runtime", () => {
+  const publicIntake = section(workflow, "  public-intake:");
+  assert.match(
+    publicIntake,
+    /actions\/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7\.0\.0/u
+  );
+  assert.match(publicIntake, /node-version: 24\.19\.0/u);
+  assert.doesNotMatch(publicIntake, /node-version: (?:20|22)(?:\D|$)/u);
 });
 
 function section(source, start, end = null) {


### PR DESCRIPTION
## Exact approval scope

Approve only the frozen Programmable Hookbuilder candidate for trusted `main` intake:

- candidate commit: `34e8c233e71ca0f2dcc68d40af70632b86b2a92a`
- candidate tree: `525b5524e2c12c84753f7ac46788f7f244dc9709`
- source Hookbuilder ref: `main`
- source Hookbuilder commit: `509060301ce9bb1b5e318b28aeeeeb846c020f68`
- source Hookbuilder repository tree: `f49b32d6ff60e7e2b1457e5bd7e32ee3c81710a8`
- canonical skill tree: `7543cac1e4556664e494b30186a51a796aa3a7b7`

## Runtime control

- trusted production intake uses pinned `actions/setup-node` v7
- trusted production intake uses exact current LTS Node `24.19.0`
- the exact candidate commit/tree guard remains fail closed
- Node 22 remains the model's supported compatibility floor; Node 20 is not in the current model path

## Local validation

- `node --test scripts/test/verify-main-ci-control-workflow.test.mjs`: 4 passed, 0 failed
- `git diff --check`: passed
- branch rebased onto current `production` commit `f2b7ff0cbb52ad7c1af89cf7962c96b55e117e00`

This PR changes only the protected approval binding and its exact test. It does not approve, merge, release, or publish the `main` candidate by itself.
