### PR TITLE
feat(contracts): make Shards launch atomic across routes

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -152,6 +152,34 @@ paths = [
 regexes = ['''profileKey"?:\s*"0x[0-9a-fA-F]{64}"''']
 
 [[allowlists]]
+description = "Exact Shards contracts and specs pin the reviewed public Router V4 profile key"
+condition = "AND"
+regexTarget = "match"
+paths = [
+  '''contracts/spec/shards-fee-policy-verifier-v1\.json''',
+  '''contracts/spec/shards-registry-successor-v1\.json''',
+  '''contracts/src/ProgrammableExactShardsFeePolicyVerifierV1\.sol''',
+  '''contracts/src/ProgrammableExactShardsRegistryV1\.sol''',
+]
+regexes = ['''(?i)0xb90e215e0e29c0dacf021e5e778847af4100433ee7d22014b73f8ca4add09d0c''']
+
+[[allowlists]]
+description = "GitHub lineage specs and tests pin public deterministic repository-key vectors"
+condition = "AND"
+regexTarget = "match"
+paths = [
+  '''contracts/spec/github-repository-lineage-registry-v1\.json''',
+  '''contracts/spec/shards-registry-successor-v1\.json''',
+  '''contracts/test/ProgrammableGithubRepositoryLineageRegistryV1\.t\.sol''',
+]
+regexes = [
+  '''(?i)0x84f907641e97fb220312430fcf0f98c1d513664a984d99df24aee57c226d174c''',
+  '''(?i)0x02ed38e86a7c41d5dea93cf5e3f829420837c4d351d9f4675929c6ce0041e835''',
+  '''(?i)0x85af67313879b9844f94b66f3eb6bdc2f200e2647507f73f43242a576580961b''',
+  '''(?i)0x97316281428a106b570b0e26031c4ae18b9e959742ea4cc41c1e7cd43b921dfb''',
+]
+
+[[allowlists]]
 description = "Router V3 vendored artifacts contain public bytes32 profile and winner bindings"
 condition = "AND"
 regexTarget = "match"

--- a/contracts/spec/github-repository-lineage-registry-v1.json
+++ b/contracts/spec/github-repository-lineage-registry-v1.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": "programmable.github-repository-lineage-registry.v1",
+  "status": "IMPLEMENTATION_READY_NOT_DEPLOYED",
+  "activationAllowed": false,
+  "externalActionOccurred": false,
+  "deployment": {
+    "addressState": "UNSET",
+    "address": null,
+    "runtimeCodeKeccak256": null,
+    "transactionHash": null,
+    "blockNumber": null
+  },
+  "authority": {
+    "adminModel": "OPENZEPPELIN_ACCESS_CONTROL_DEFAULT_ADMIN_RULES",
+    "consumerRole": "keccak256(bytes(\"programmable.github-repository-lineage.consumer.v1\"))",
+    "authorizedConsumers": [],
+    "authorizedConsumerState": "NONE_UNTIL_CANONICAL_DEPLOYMENT",
+    "rule": "ONLY_EXACT_REVIEWED_ATOMIC_ROUTE_CONTRACTS_ON_ONE_CANONICAL_INSTANCE",
+    "forbiddenConsumers": [
+      "EOA",
+      "REGISTRY_CONTRACT",
+      "DIRECT_FACTORY",
+      "ADAPTER_WITH_STANDALONE_CONSUME_SELECTOR"
+    ],
+    "requiredRoleGrantEvidence": "EXACT_ATOMIC_ROUTE_ADDRESS_RUNTIME_CODE_HASH_AND_ROLE_GRANTED_EVENT"
+  },
+  "repositoryKey": {
+    "githubRepositoryIdType": "uint64",
+    "allowedRange": {
+      "minimum": 1,
+      "maximum": "18446744073709551615",
+      "approvalDatabaseMustEnforceSameRange": true
+    },
+    "derivation": "keccak256(abi.encode(\"programmable.github.repository.v1\", uint256(githubRepositoryId)))",
+    "displayRepositoryNameIsIdentity": false,
+    "knownVectors": [
+      {
+        "githubRepositoryId": 1,
+        "repositoryKey": "0x84f907641e97fb220312430fcf0f98c1d513664a984d99df24aee57c226d174c"
+      },
+      {
+        "project": "Shards",
+        "githubRepositoryId": 1329073878,
+        "repositoryKey": "0x02ed38e86a7c41d5dea93cf5e3f829420837c4d351d9f4675929c6ce0041e835"
+      },
+      {
+        "project": "Hookemon",
+        "githubRepositoryId": 1324982531,
+        "repositoryKey": "0x85af67313879b9844f94b66f3eb6bdc2f200e2647507f73f43242a576580961b"
+      },
+      {
+        "githubRepositoryId": "18446744073709551615",
+        "repositoryKey": "0x97316281428a106b570b0e26031c4ae18b9e959742ea4cc41c1e7cd43b921dfb"
+      }
+    ]
+  },
+  "semantics": {
+    "oneSuccessfulLaunchPerRepositoryLineage": true,
+    "crossRouteAndFactoryAuthority": true,
+    "exactRetry": "IDEMPOTENT_ONLY_FOR_SAME_REPOSITORY_LAUNCH_ROUTE_AND_CONSUMER",
+    "otherDuplicate": "REVERT",
+    "consumeTiming": "IMMEDIATELY_BEFORE_IRREVERSIBLE_ROUTE_EXECUTION_WITH_REGISTRATION_IN_SAME_TRANSACTION",
+    "downstreamRevert": "ROLLS_BACK_CONSUMPTION"
+  },
+  "implementation": {
+    "contractPath": "contracts/src/ProgrammableGithubRepositoryLineageRegistryV1.sol",
+    "interfacePath": "contracts/src/interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol",
+    "unitTestPath": "contracts/test/ProgrammableGithubRepositoryLineageRegistryV1.t.sol",
+    "invariantTestPath": "contracts/test/invariant/ProgrammableGithubRepositoryLineageRegistryV1Invariant.t.sol",
+    "compiler": {
+      "solc": "0.8.26",
+      "evmVersion": "cancun",
+      "optimizer": true,
+      "optimizerRuns": 1000,
+      "viaIr": false,
+      "bytecodeHash": "none",
+      "cborMetadata": false
+    },
+    "artifact": {
+      "contractSourceSha256": "0xf68617a5b45d6a63287312b8a519bfba7f783e3dad5b9312bc6043dc9880a59b",
+      "interfaceSourceSha256": "0xbeccdffd2a9d6d46af6786bb8d78153c72144013bef67698e33d7f328eb3d512",
+      "canonicalAbiSha256": "0xe90eb2d1c59415f885898e4153e20cef0c7564c9290010740bec7dc3d492d83f",
+      "creationCodeByteLength": 6130,
+      "creationCodeKeccak256": "0xf83413d5efe52fc562c1c1dee048413058a1ca24053c7d2b9f396fc6837b1c36",
+      "unlinkedRuntimeCodeByteLength": 5515,
+      "unlinkedRuntimeCodeKeccak256": "0x0374fd9de2c84fe89522fd3602dd4b0fb2ba2c5ed07fd2130b64e1d5821b7bf4",
+      "runtimeCodeLimitMarginBytes": 19061
+    },
+    "selectors": {
+      "consume(uint64,bytes32,bytes32)": "0xd11fffa9",
+      "computeRepositoryKey(uint64)": "0x74f67ed9",
+      "consumption(bytes32)": "0xca979f28",
+      "repositoryKeyByLaunchId(bytes32)": "0xe1fa2b9e",
+      "consumptionCount()": "0xd2cfddfe"
+    }
+  },
+  "prohibitions": [
+    "NO_ROUTE_LOCAL_MAPPING_AS_SOLE_AUTHORITY",
+    "NO_HASHED_DOMAIN_CONSTANT_SUBSTITUTE",
+    "NO_UINT64_ABI_SLOT_SUBSTITUTE",
+    "NO_DEPLOYMENT_ADDRESS_INVENTION",
+    "NO_ACTIVATION_BEFORE_INDEPENDENT_REVIEW_AND_CANONICAL_DEPLOYMENT"
+  ]
+}

--- a/contracts/spec/shards-atomic-launch-route-v1.json
+++ b/contracts/spec/shards-atomic-launch-route-v1.json
@@ -1,0 +1,162 @@
+{
+  "schemaVersion": "programmable.exact-shards-atomic-launch-route.v1",
+  "status": "IMPLEMENTATION_READY_NOT_DEPLOYED",
+  "activationAllowed": false,
+  "launchAllowed": false,
+  "externalActionOccurred": false,
+  "compiler": {
+    "solc": "0.8.26",
+    "evmVersion": "cancun",
+    "optimizer": true,
+    "optimizerRuns": 1000,
+    "viaIr": false,
+    "bytecodeHash": "none",
+    "cborMetadata": false
+  },
+  "canonicalDeployment": {
+    "chainId": 1,
+    "sharedRepositoryLineageRegistry": {
+      "addressState": "UNSET",
+      "address": null,
+      "runtimeCodeKeccak256": null,
+      "transactionHash": null,
+      "blockNumber": null,
+      "oneCanonicalInstanceForEveryRouteAndFactory": true
+    },
+    "exactShardsRegistry": {
+      "addressState": "UNSET",
+      "address": null,
+      "runtimeCodeKeccak256": null,
+      "transactionHash": null,
+      "blockNumber": null
+    },
+    "exactShardsAtomicRoute": {
+      "addressState": "UNSET",
+      "address": null,
+      "runtimeCodeKeccak256": null,
+      "transactionHash": null,
+      "blockNumber": null
+    },
+    "reviewedShardsFactory": {
+      "addressState": "UNSET",
+      "address": null,
+      "runtimeCodeKeccak256": "0x134a9e5674f22e62e939c2238693077b8027c553bb26d6a4e9e3d8554e5f85b5",
+      "reviewedSourceCommit": "91b38f3de64d96cac7e29f127c004f128fc1da59"
+    }
+  },
+  "rolePolicy": {
+    "repositoryLineageConsumerRole": "keccak256(bytes(\"programmable.github-repository-lineage.consumer.v1\"))",
+    "requiredConsumerRoleGrantTargets": [
+      "EXACT_REVIEWED_ATOMIC_ROUTE_CONTRACT"
+    ],
+    "forbiddenConsumerRoleGrantTargets": [
+      "EOA",
+      "SHARDS_REGISTRY",
+      "DIRECT_SHARDS_FACTORY",
+      "ARBITRARY_ADAPTER",
+      "CONTRACT_WITH_STANDALONE_CONSUME_SELECTOR"
+    ],
+    "exactShardsRegistryWriterBeforeActivation": "EXACT_SHARDS_ATOMIC_ROUTE_ONLY",
+    "bootstrapWriterMustBeRevokedBeforeActivation": true,
+    "grantEvidenceRequired": [
+      "EXACT_ROUTE_ADDRESS",
+      "EXACT_ROUTE_RUNTIME_CODE_HASH",
+      "CONSUMER_ROLE_GRANTED_EVENT",
+      "REGISTRY_WRITER_ROLE_GRANTED_EVENT",
+      "NO_OTHER_ACTIVE_CONSUMER_OR_WRITER_GRANTS"
+    ]
+  },
+  "atomicTopology": {
+    "entrypoint": "launch((...),bytes32,bytes32,bytes,(...))",
+    "orderedOperations": [
+      "VALIDATE_CALLER_AND_WEBSITE_SELECTED_METADATA_HASHES",
+      "CONSUME_CANONICAL_GITHUB_REPOSITORY_LINEAGE",
+      "EXECUTE_EXACT_REVIEWED_SHARDS_FACTORY",
+      "VERIFY_PRODUCED_TOKEN_ADDRESS_RUNTIME_NAME_AND_SYMBOL",
+      "REGISTER_EXACT_FINAL_RECORD",
+      "EMIT_ATOMIC_COMPLETION_WITH_PRESENTATION_BINDING"
+    ],
+    "sameEvmTransaction": true,
+    "downstreamRevertRollsBackFactoryDeploymentLineageAndRegistration": true,
+    "losingCrossRouteAttemptDeploysNoTokenOrHook": true,
+    "standaloneConsumeSelector": false,
+    "exactRetryCannotCreateSecondLaunch": true
+  },
+  "websiteMetadataBoundary": {
+    "technicalGithubApprovalExcludes": [
+      "tokenName",
+      "tokenSymbol",
+      "description",
+      "image",
+      "links"
+    ],
+    "websiteSelectableFactoryFields": [
+      "tokenName",
+      "tokenSymbol"
+    ],
+    "presentationBindingFields": [
+      "description",
+      "image",
+      "links"
+    ],
+    "jitPermitBindsExactSelection": true,
+    "substitutionAfterPermit": "REVERT",
+    "producedTokenNameAndSymbolPostcondition": true
+  },
+  "source": {
+    "routePath": "contracts/src/ProgrammableExactShardsAtomicLaunchRouteV1.sol",
+    "factoryInterfacePath": "contracts/src/interfaces/IProgrammableExactShardsLaunchFactoryV1.sol",
+    "factoryInterfaceSha256": "0x72f676157e109b6af5bbb7fc098f4a1fc1be6aa64c319a277e4d9f4825403021",
+    "sharedRegistryPath": "contracts/src/ProgrammableGithubRepositoryLineageRegistryV1.sol",
+    "sharedRegistryInterfacePath": "contracts/src/interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol",
+    "sharedRegistryInterfaceSha256": "0xbeccdffd2a9d6d46af6786bb8d78153c72144013bef67698e33d7f328eb3d512",
+    "shardsRegistryPath": "contracts/src/ProgrammableExactShardsRegistryV1.sol",
+    "shardsRegistryInterfacePath": "contracts/src/interfaces/IProgrammableExactShardsRegistryV1.sol",
+    "shardsRegistryInterfaceSha256": "0x9d5a84730dc874f8e2f39c2695d500b28d25a9bceb601e0593350e06f89a3d95",
+    "unitTestPath": "contracts/test/ProgrammableExactShardsAtomicLaunchRouteV1.t.sol"
+  },
+  "artifacts": {
+    "route": {
+      "sourceSha256": "0xee3bb8a620377b1feb97c22d466b15ee3e9e69285cf129d3e69741ffc7f7b530",
+      "canonicalAbiSha256": "0xa76815a0d8ac20371e9c971c7c18b46fea1ed5ad618441159cd11b44612056e4",
+      "creationCodeByteLength": 4524,
+      "creationCodeKeccak256": "0x2a6d22a255165cde1c2378e7d5f63efd52e992595bffb61166edf45383b49f3b",
+      "unlinkedRuntimeCodeByteLength": 3992,
+      "unlinkedRuntimeCodeKeccak256": "0x46c406140f599ee37b9a17644d9ae474a4da9d18ec3d9d7d2fa5304fca05dfb9",
+      "runtimeCodeLimitMarginBytes": 20584
+    },
+    "sharedRepositoryLineageRegistry": {
+      "sourceSha256": "0xf68617a5b45d6a63287312b8a519bfba7f783e3dad5b9312bc6043dc9880a59b",
+      "canonicalAbiSha256": "0xe90eb2d1c59415f885898e4153e20cef0c7564c9290010740bec7dc3d492d83f",
+      "creationCodeByteLength": 6130,
+      "creationCodeKeccak256": "0xf83413d5efe52fc562c1c1dee048413058a1ca24053c7d2b9f396fc6837b1c36",
+      "unlinkedRuntimeCodeByteLength": 5515,
+      "unlinkedRuntimeCodeKeccak256": "0x0374fd9de2c84fe89522fd3602dd4b0fb2ba2c5ed07fd2130b64e1d5821b7bf4",
+      "runtimeCodeLimitMarginBytes": 19061
+    },
+    "exactShardsRegistry": {
+      "sourceSha256": "0x2edefb9eef07a045acb12cba832b2990aee6c3bd93425629acd62b884aca8cf2",
+      "canonicalAbiSha256": "0x9492f1b19fe8dba9ebddcb8ae474c01971de51d64fe502bb2277c53f405aed62",
+      "creationCodeByteLength": 27268,
+      "creationCodeKeccak256": "0x15bc577db8933f8f9985ff77f768faabe62c197b53a1258915fda618f8c3650b",
+      "unlinkedRuntimeCodeByteLength": 24303,
+      "unlinkedRuntimeCodeKeccak256": "0x21c4e08e2471be1119f158021c4d6e426e5c953ea26719381b39fbcd0cc70d77",
+      "runtimeCodeLimitMarginBytes": 273
+    }
+  },
+  "activationRequirements": [
+    "INDEPENDENT_SECURITY_REVIEW_OF_EXACT_SOURCE_AND_RUNTIME",
+    "CANONICAL_DEPLOYMENT_RECEIPTS_FINALIZED",
+    "ALL_CONSTRUCTOR_RUNTIME_BINDINGS_MATCH",
+    "ONLY_EXACT_ATOMIC_ROUTE_HAS_SHARED_CONSUMER_ROLE",
+    "ONLY_EXACT_ATOMIC_ROUTE_HAS_SHARDS_REGISTRY_WRITER_ROLE",
+    "WEBSITE_DESCRIPTOR_BINDS_CANONICAL_ADDRESSES_AND_RUNTIMES",
+    "INDEXERS_BIND_FINAL_REGISTRY_AND_ATOMIC_ROUTE_EVENTS"
+  ],
+  "prohibitions": [
+    "NO_DEPLOYMENT_ADDRESS_INVENTION",
+    "NO_ROLE_GRANT_TO_EOA_REGISTRY_DIRECT_FACTORY_OR_GENERIC_ADAPTER",
+    "NO_SEPARATE_FACTORY_AND_POST_REGISTRATION_TRANSACTIONS",
+    "NO_ACTIVATION_FROM_LOCAL_OR_CI_EVIDENCE_ONLY"
+  ]
+}

--- a/contracts/spec/shards-fee-policy-verifier-v1.json
+++ b/contracts/spec/shards-fee-policy-verifier-v1.json
@@ -5,8 +5,8 @@
   "launchAllowed": false,
   "externalActionOccurred": false,
   "productionBase": {
-    "commit": "a9260ec54324731226ccf0998a5110760ae1fc20",
-    "tree": "b810409f660d641f9205d6bf31b279133f0bef3b"
+    "commit": "3efcacb27c8416725a6985b47b2f26385d164ca6",
+    "tree": "a9e35947fc6a0f4485aeca177fc2ca8d407c2dec"
   },
   "decision": {
     "existingReviewedVerifierSupportsExactPolicy": false,
@@ -15,6 +15,19 @@
     "newShardsExecutionContractRequired": false,
     "smallestMissingLayerImplementedHere": "STATELESS_EXACT_THREE_CLAIM_FEE_POLICY_VERIFIER",
     "remainingRegistryRequirement": "DEPLOYED_REGISTRY_SUCCESSOR_MUST_BIND_THIS_EXACT_VERIFIER_AND STORE_THREE_DISTINCT_CLAIMS"
+  },
+  "uiMetadataBoundary": {
+    "feePolicyIncludesTokenName": false,
+    "feePolicyIncludesTokenSymbol": false,
+    "feePolicyIncludesPresentationBindingHash": false,
+    "githubTechnicalApprovalIncludesSelectedUiMetadata": false,
+    "websitePresentationFields": [
+      "description",
+      "image",
+      "links"
+    ],
+    "presentationValuesAreSourceArtifactInputs": false,
+    "economicsRemainExactly": "INCLUSIVE_100_BPS_SPLIT_10_10_80"
   },
   "candidateAudit": {
     "deployedRegistryV1": {

--- a/contracts/spec/shards-fee-policy-verifier-v1.json
+++ b/contracts/spec/shards-fee-policy-verifier-v1.json
@@ -5,8 +5,8 @@
   "launchAllowed": false,
   "externalActionOccurred": false,
   "productionBase": {
-    "commit": "e0851b30d7dfd759ccffea1d4c1acace044c05ad",
-    "tree": "9d79e375b4dea1772b90cb07123581dbd8bf62dc"
+    "commit": "c05b2df79ea18dfafe8d190183fc4ecbac143087",
+    "tree": "45c776cbe39e78bcb00e70bcab78d6aed50235e3"
   },
   "decision": {
     "existingReviewedVerifierSupportsExactPolicy": false,

--- a/contracts/spec/shards-fee-policy-verifier-v1.json
+++ b/contracts/spec/shards-fee-policy-verifier-v1.json
@@ -1,0 +1,277 @@
+{
+  "schemaVersion": "programmable.exact-shards-fee-policy-verifier.v1",
+  "status": "IMPLEMENTATION_READY_NOT_DEPLOYED",
+  "activationAllowed": false,
+  "launchAllowed": false,
+  "externalActionOccurred": false,
+  "productionBase": {
+    "commit": "e0851b30d7dfd759ccffea1d4c1acace044c05ad",
+    "tree": "9d79e375b4dea1772b90cb07123581dbd8bf62dc"
+  },
+  "decision": {
+    "existingReviewedVerifierSupportsExactPolicy": false,
+    "currentContractsCanLaunch": false,
+    "reviewedShardsSemanticsChanged": false,
+    "newShardsExecutionContractRequired": false,
+    "smallestMissingLayerImplementedHere": "STATELESS_EXACT_THREE_CLAIM_FEE_POLICY_VERIFIER",
+    "remainingRegistryRequirement": "DEPLOYED_REGISTRY_SUCCESSOR_MUST_BIND_THIS_EXACT_VERIFIER_AND STORE_THREE_DISTINCT_CLAIMS"
+  },
+  "candidateAudit": {
+    "deployedRegistryV1": {
+      "address": "0x17e18c88bda9bfb73924cdc989c07b0707e72671",
+      "runtimeCodeHash": "0xa3276868befc509594adea6c5bd81c3c1bd013686f03fd57914fd39c917185f7",
+      "generation": 1,
+      "feeVerifier": "0x6a57bf3e092626be760d417986e6103c20fdbc3e",
+      "feeVerifierRuntimeCodeHash": "0x2a4182b580725a156c42061dd58b7ed92b4588682ee1b66b356ceff1ddd90882",
+      "feeVerifierBinding": "IMMUTABLE",
+      "feeLegCount": 2,
+      "supportedProfiles": [
+        "NATIVE_CUSTOM_10_BPS_PROGRAMMABLE_ADDED_ON_TOP",
+        "PARTNER_20_BPS_15_5",
+        "NO_QUALIFYING_MARKET_ZERO_BPS"
+      ],
+      "exactShardsSupported": false
+    },
+    "registryGen2Candidate": {
+      "pullRequest": "0xprogrammable/programmable#162",
+      "headCommit": "244e452233a8a1145067308182380fad8e54041f",
+      "headTree": "992e04275c1b70586caf662fc3dabd516cea0247",
+      "statusAtAudit": "OPEN_DRAFT_CONFLICTING",
+      "registryGeneration": 2,
+      "registryAbi": "INHERITED_V1_TWO_LEG_FEE_POLICY",
+      "nativeProfile": "10_BPS_PROGRAMMABLE",
+      "partnerProfile": "20_BPS_15_5_PROVIDER_NEUTRAL",
+      "exactShardsSupported": false
+    },
+    "reviewedThreeClaimSpecification": {
+      "path": "outputs/shards-nested-factory-route-v1.canonical.json",
+      "byteLength": 1287041,
+      "sha256": "0x066475058bfd47b85b4216f95b434756d67d7e289ffb36535c121ef5d7c11bab",
+      "keccak256": "0x8c5521d6796e3e63c3e2cf82e1122c952e6465c345d8a10b3773a70aa2419fb3",
+      "reusedWithoutSemanticChange": true
+    }
+  },
+  "reviewedSource": {
+    "repository": "jesse-stahl/shards-v1",
+    "commit": "91b38f3de64d96cac7e29f127c004f128fc1da59",
+    "tree": "92d6def8609e829487adea66c13901734e43c8c7",
+    "sourceRevisionHash": "0x3352fe14662ce467e98f475cf91f10304ce4d69b6342fae4bf3dc968c494d6dc",
+    "feeDescriptorSha256": "0xd1c911686afc62b70f3d65c9807e89146d119c4e6f4604e72d3dab2b4ef8dc22"
+  },
+  "routerV4": {
+    "repository": "0xprogrammable/programmable",
+    "sourceCommit": "d6cfb78543b159f9e0ed9f193a5b29637bd817fc",
+    "sourceTree": "cbdad7210dee6fac708d2957e9f5288090bb20f8",
+    "exactProfileSource": {
+      "path": "src/ProgrammableExactShardsProfileV1.sol",
+      "gitBlob": "d802fa387505da47a0ac4d65a6e5b5e4efa7026d"
+    },
+    "nestedAdapterSource": {
+      "path": "deployment/router-v4/src/ProgrammableExactShardsNestedFactoryV1.sol",
+      "gitBlob": "cf2b92f67ec00b0c0a844708dd62ab70a32fdf3a"
+    },
+    "profileKey": "0xb90e215e0e29c0dacf021e5e778847af4100433ee7d22014b73f8ca4add09d0c",
+    "existingRevenuePolicyHash": "0xaa78b0bf63fca83fa9b969fbb6b2bb1ecabcbe49908a48f92403e8e51e4adab2",
+    "existingInitialRevenueStateHash": "0xf0bc686422736754322da4ea358a823274df35c35718939d71d339a41b8f9b75",
+    "reusedWithoutNewRouteSemantics": true,
+    "orderedOwnerPackagePhases": [
+      "DEPLOY_GRAPH_DEPLOYER",
+      "FOUNDATIONS",
+      "PREFLIGHT_ROOTS",
+      "COMPLETED_GRAPH_ADOPTION_COMPAT_VALIDATORS",
+      "UNIVERSAL_KERNEL",
+      "DEPLOY_COMPLETED_GRAPH_ADOPTION_COMPAT_REGISTRY",
+      "BIND_REVIEWER",
+      "BIND_GOVERNANCE",
+      "BIND_FINALITY",
+      "BIND_INDEXER",
+      "SHARDS_ADAPTERS",
+      "DEPLOY_NESTED_FACTORY_PROFILE",
+      "DEPLOY_SHARDS_FACTORY",
+      "ACTIVATE_UNIVERSAL",
+      "ACTIVATE_COMPLETED_GRAPH_ADOPTION_COMPAT"
+    ],
+    "shardsRequiredUnfinishedPhasesAtObservedBlock": [
+      "SHARDS_ADAPTERS",
+      "DEPLOY_NESTED_FACTORY_PROFILE",
+      "DEPLOY_SHARDS_FACTORY",
+      "ACTIVATE_UNIVERSAL"
+    ],
+    "liveObservation": {
+      "chainId": 1,
+      "blockNumber": 25739301,
+      "blockHash": "0xeab4a61344592f530644eb86c57a174b06d1d8af1e20f62286e4d0834fceab8e",
+      "independentRpcAgreement": [
+        "publicnode",
+        "drpc"
+      ],
+      "kernel": "0x25e9ddeb5de79751db2156d426893d52c8f14dcf",
+      "kernelRuntimeCodeHash": "0x316dcd57dcefd06149e3cb2a78a25d2421312c7431df2bdf3c62ca501341f1cf",
+      "kernelGlobalKilled": true,
+      "exactShardsProfileRegistered": false,
+      "providerAddress": "0x03385476770cae102ef673adf9a4631e84258e58",
+      "providerStatus": "VACANT",
+      "verifierAddress": "0xa4867b0d72bce8c1db040e91454d562239daf923",
+      "verifierStatus": "VACANT",
+      "nestedProfileAddress": "0x6d2d661ab0e462e8047597adc5bece4bca157c4c",
+      "nestedProfileStatus": "VACANT",
+      "shardsFactoryAddress": "0x9442a520e7b31d10177c75a363355c2c29141ac5",
+      "shardsFactoryStatus": "VACANT"
+    }
+  },
+  "canonicalPolicy": {
+    "feeAsset": "0x0000000000000000000000000000000000000000",
+    "feeAssetSemantic": "NATIVE_ETH",
+    "feeBasisLabel": "ProgrammableRevenueFeeBasisV1:inclusive-gross-eth-moved",
+    "feeBasisHash": "0xfb8110e8ea13fee890a868300dd1a9a5c467acb19a53f63beccc482757a36191",
+    "chargeMode": "INCLUDED_IN_TOTAL",
+    "totalFeeBps": 100,
+    "shareDenominatorBps": 10000,
+    "orderedLegs": [
+      {
+        "role": "BUILDER",
+        "roleHash": "0x36a60a66fdf8fc39bbaab0d3ff46b52ffc8a9b6f3dc94b5fe9836816d72890af",
+        "grossVolumeFeeBps": 10,
+        "shareOfFeeBps": 1000,
+        "initialRecipient": "0xceebb3a6543cebeb2ed66963897a0abea52a50cc",
+        "recipientMode": "CURRENT_BUILDER_MAY_ROTATE_TO_SUCCESSOR",
+        "recipientModeHash": "0xc1ed7eaa8d37d922e99971bb6369533361b226b731cf9677e60e36b376519ea4",
+        "claimSelector": "0x69f9a5f0",
+        "handoffSelector": "0x4ce11d21",
+        "legHash": "0x10c851ca78aa2bf257e924b5b4b1a471b8f091e5d971f1a2422165a60bd325ac"
+      },
+      {
+        "role": "PROGRAMMABLE",
+        "roleHash": "0x069cb8bbaf512d6f3d7fd962d64b67ce531a420f558aa3a2301e77be3640d875",
+        "grossVolumeFeeBps": 10,
+        "shareOfFeeBps": 1000,
+        "recipient": "0x4957f49620aff3adbbe8195a4f633e49cc93376c",
+        "recipientMode": "IMMUTABLE_LAUNCHER_RECIPIENT",
+        "recipientModeHash": "0x496f134b2bbc4d8ae230c1aa1a607788d75231c8ee823312e515b851a927d4f4",
+        "claimSelector": "0x64d46b85",
+        "legHash": "0xccc9d7a84cef40c38d165ba1ce0f1817f77172bc97b49155ac6a14fcc5e6cff5"
+      },
+      {
+        "role": "NFT_HOLDERS",
+        "roleHash": "0x84edd196638e45435db849686913b0ffb528525a1edc3aece78548ed6f2577f1",
+        "grossVolumeFeeBps": 80,
+        "shareOfFeeBps": 8000,
+        "accumulator": "0xba318baa8649962fd77cc7082d098f2c09fd60cc",
+        "recipientMode": "EXACT_SHARDS_HOOK_RUNNING_HOLDER_ACCUMULATOR",
+        "recipientModeHash": "0x9aec909e12714c25df903902800a480772830ed15716e130e797f7447138ba55",
+        "claimSelector": "0x6ba4c138",
+        "legHash": "0x30cf730abcc37ad7db1d6e91abad8c1564fc624c777c456da987f0e006b9ff9e"
+      }
+    ],
+    "legsHash": "0x14e66b725eaebf6f894323565651567cc05a71bbb263db373d1f9f59ea171899",
+    "revenuePolicyHash": "0xaa78b0bf63fca83fa9b969fbb6b2bb1ecabcbe49908a48f92403e8e51e4adab2",
+    "roundingSemantics": [
+      "OUTER_FEE_NUMERATOR_REMAINDER_CARRIED_BY_EXACTNESS",
+      "COMBINED_BUILDER_AND_PROGRAMMABLE_CUT_REMAINDER_CARRIED",
+      "ODD_OPERATOR_WEI_CARRIED_TO_PROGRAMMABLE",
+      "HOLDERS_RECEIVE_REMAINDER",
+      "DONATIONS_BYPASS_OPERATOR_SPLIT"
+    ]
+  },
+  "typedHashSpec": {
+    "legType": "ProgrammableRevenueLegV1(bytes32 roleHash,uint16 feeBps,address recipient,bytes32 recipientModeHash)",
+    "legTypeHash": "0x6b5107011760a096b681164d179eacb4aeae665d02a08c0447d81f87191f09b7",
+    "policyType": "ProgrammableRevenuePolicyV1(bytes32 profileKey,address feeAsset,bytes32 feeBasisHash,uint16 totalFeeBps,bytes32 legsHash)",
+    "policyTypeHash": "0x59529fb66a882121389cebbaa9a4bbbfa4ccf1fe6ce4bcecc00d5f38935f3202",
+    "legsHashEncoding": "keccak256(abi.encode(builderLegHash,programmableLegHash,holderLegHash))",
+    "policyHashEncoding": "keccak256(abi.encode(policyTypeHash,profileKey,feeAsset,feeBasisHash,totalFeeBps,legsHash))",
+    "bindingTypeHashes": {
+      "source": "0x6ebc17cf7d3568ae5dc69cd9ad5e72bfc89ec62ee8a5270b1f1b5a677177fe61",
+      "router": "0xdfb854b0298963df7d738612117ec62c31603fe0109535b0a445b8f7d56c06b7",
+      "economics": "0xa3ea01024027b9ae11ae3183354dc457d781266fc490fe34b0bb1b57aef1bb6c",
+      "final": "0xa27a89fc8c356e6f8be5037157ba922b6128a9ca3775a0aeb6f41fa37759b8c8"
+    },
+    "bindingSubhashes": {
+      "source": "0x245dd60dca506e9cdb0cd8558b50f8bb3ca88af49c4326a5b469ef66c34b0ce2",
+      "router": "0xb4fcef386fdc8274e3ca4a4172f39bbf6aba4b29ddabf31995d9b8d372dd376b",
+      "economics": "0xa81ff847bc15a7a7b10c28917c14e2171d71e1b3bb3977fd594e8c3fa2d4052a"
+    },
+    "feePolicyBindingHash": "0x5d5d1c46e7627f6e171a18acdbecbfe9e40eca80016fba0142ddca6a054f6169"
+  },
+  "implementation": {
+    "contract": {
+      "path": "contracts/src/ProgrammableExactShardsFeePolicyVerifierV1.sol",
+      "sha256": "0xde6d1e23520ef4f77c74dd3487099520908b616afb5ea5457daaffa71516b51f"
+    },
+    "interface": {
+      "path": "contracts/src/interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol",
+      "sha256": "0xb5b0c02507086952de695803813b864ffbb14f29eb874a6ac18ed859c9e80c12"
+    },
+    "test": {
+      "path": "contracts/test/ProgrammableExactShardsFeePolicyVerifierV1.t.sol"
+    },
+    "compiler": {
+      "solc": "0.8.26",
+      "evmVersion": "cancun",
+      "optimizer": true,
+      "optimizerRuns": 1000,
+      "viaIr": false,
+      "bytecodeHash": "none",
+      "cborMetadata": false
+    },
+    "artifact": {
+      "creationCodeByteLength": 4832,
+      "creationCodeKeccak256": "0xf82a1609d4d5c4491c4b3318973a50d2775874be16414864790f5927e115d95d",
+      "runtimeCodeByteLength": 4804,
+      "runtimeCodeKeccak256": "0xb4af3325444133062ec8382bc29c551ef87e812cbf269712a45ef6ec64db20c0",
+      "canonicalAbiSha256": "0xed07ccf951be118fabda8efb9d01d6ea6c180bf9fb37365c28a88151bb3045f2"
+    },
+    "verificationBoundary": [
+      "PURE_POLICY_HASH_AND_EXACT_FIELD_VALIDATION",
+      "CONTENT_ADDRESS_BINDING_TO_REVIEWED_SOURCE_ROUTE_AND_ROUTER_V4",
+      "NO_APPROVAL_EFFECT",
+      "NO_REGISTRY_WRITE",
+      "NO_DEPLOYMENT_OR_ACTIVATION_EFFECT"
+    ]
+  },
+  "remainingProductionActions": [
+    {
+      "sequence": 1,
+      "action": "INDEPENDENTLY_REVIEW_AND_RECOMPILE_EXACT_VERIFIER",
+      "requiredAuthority": "SECURITY_REVIEW_OWNER"
+    },
+    {
+      "sequence": 2,
+      "action": "DEPLOY_EXACT_VERIFIER_AND_RECORD_SOURCE_RUNTIME_AND_FINALITY_RECEIPTS",
+      "requiredAuthority": "AUTHORIZED_CONTRACT_DEPLOYER"
+    },
+    {
+      "sequence": 3,
+      "action": "DEPLOY_REGISTRY_SUCCESSOR_WITH_NATIVE_THREE_CLAIM_STORAGE_AND_IMMUTABLE_EXACT_VERIFIER_BINDING",
+      "requiredAuthority": "REGISTRY_DEPLOYER_AND_ADMIN_AUTHORITY"
+    },
+    {
+      "sequence": 4,
+      "action": "EXECUTE_REMAINING_ROUTER_V4_SHARDS_PHASES_IN_FROZEN_ORDER",
+      "requiredAuthority": "ROUTER_DEPLOYER_0x2bb333d48dfaf1596d9036671d2e43168994249e_AND_CONTROLLER_SAFE_0x755509ea6e3f5ec1aa2e797bb68f1b87dd8b886b"
+    },
+    {
+      "sequence": 5,
+      "action": "AUTHORIZE_EXACT_SHARDS_GRANT_AND_BIND_REGISTRY_REGISTRATION_BYTES",
+      "requiredAuthority": "ROUTER_REVIEW_GOVERNANCE_AND_REGISTRY_APPROVER"
+    },
+    {
+      "sequence": 6,
+      "action": "REGISTER_OBSERVED_LAUNCH_FINALIZE_AFTER_MINIMUM_FINALITY_AND_PUBLISH_INDEXER_RECEIPT",
+      "requiredAuthority": "REGISTRY_WRITER_FINALIZER_AND_INDEXER_AUTHORITIES"
+    },
+    {
+      "sequence": 7,
+      "action": "ENABLE_WEBSITE_DESCRIPTOR_ONLY_AFTER_ALL_DEPLOYED_BINDINGS_MATCH",
+      "requiredAuthority": "WEBSITE_RELEASE_OWNER"
+    }
+  ],
+  "prohibitions": [
+    "NO_TWO_CLAIM_DOWNCONVERSION",
+    "NO_90_10_COLLAPSE",
+    "NO_ADDED_ON_TOP_REINTERPRETATION",
+    "NO_MUTABLE_PROGRAMMABLE_RECIPIENT",
+    "NO_FIXED_HOLDER_RECIPIENT_REINTERPRETATION",
+    "NO_DEPLOYMENT_SIGNING_GRANT_REGISTRATION_OR_TRANSACTION_FROM_THIS_ARTIFACT"
+  ]
+}

--- a/contracts/spec/shards-fee-policy-verifier-v1.json
+++ b/contracts/spec/shards-fee-policy-verifier-v1.json
@@ -5,8 +5,8 @@
   "launchAllowed": false,
   "externalActionOccurred": false,
   "productionBase": {
-    "commit": "c05b2df79ea18dfafe8d190183fc4ecbac143087",
-    "tree": "45c776cbe39e78bcb00e70bcab78d6aed50235e3"
+    "commit": "a9260ec54324731226ccf0998a5110760ae1fc20",
+    "tree": "b810409f660d641f9205d6bf31b279133f0bef3b"
   },
   "decision": {
     "existingReviewedVerifierSupportsExactPolicy": false,

--- a/contracts/spec/shards-registry-successor-v1.json
+++ b/contracts/spec/shards-registry-successor-v1.json
@@ -5,8 +5,8 @@
   "launchAllowed": false,
   "externalActionOccurred": false,
   "productionBase": {
-    "commit": "c05b2df79ea18dfafe8d190183fc4ecbac143087",
-    "tree": "45c776cbe39e78bcb00e70bcab78d6aed50235e3"
+    "commit": "a9260ec54324731226ccf0998a5110760ae1fc20",
+    "tree": "b810409f660d641f9205d6bf31b279133f0bef3b"
   },
   "decision": {
     "existingRegistryV1SupportsExactPolicy": false,

--- a/contracts/spec/shards-registry-successor-v1.json
+++ b/contracts/spec/shards-registry-successor-v1.json
@@ -1,0 +1,253 @@
+{
+  "schemaVersion": "programmable.exact-shards-registry-successor.v1",
+  "status": "IMPLEMENTATION_READY_NOT_DEPLOYED",
+  "activationAllowed": false,
+  "launchAllowed": false,
+  "externalActionOccurred": false,
+  "productionBase": {
+    "commit": "c05b2df79ea18dfafe8d190183fc4ecbac143087",
+    "tree": "45c776cbe39e78bcb00e70bcab78d6aed50235e3"
+  },
+  "decision": {
+    "existingRegistryV1SupportsExactPolicy": false,
+    "existingRegistryGen2CandidateSupportsExactPolicy": false,
+    "newShardsExecutionSemanticsAdded": false,
+    "newRouterOrFactorySemanticsAdded": false,
+    "smallestNativeSuccessorImplemented": true,
+    "currentContractsCanLaunch": false,
+    "reasonCurrentContractsCannotLaunch": [
+      "THIS_REGISTRY_SUCCESSOR_AND_ITS_EXACT_VERIFIER_ARE_NOT_DEPLOYED",
+      "ROUTER_V4_EXACT_SHARDS_PHASES_ARE_NOT_ACTIVATED",
+      "NO_DEPLOYMENT_BOUND_REGISTRATION_OR_FINALITY_RECEIPT_EXISTS"
+    ]
+  },
+  "reviewedInputs": {
+    "shardsSource": {
+      "repository": "jesse-stahl/shards-v1",
+      "commit": "91b38f3de64d96cac7e29f127c004f128fc1da59",
+      "tree": "92d6def8609e829487adea66c13901734e43c8c7",
+      "sourceRevisionHash": "0x3352fe14662ce467e98f475cf91f10304ce4d69b6342fae4bf3dc968c494d6dc"
+    },
+    "routeArtifact": {
+      "sha256": "0x066475058bfd47b85b4216f95b434756d67d7e289ffb36535c121ef5d7c11bab"
+    },
+    "feeVerifier": {
+      "path": "contracts/src/ProgrammableExactShardsFeePolicyVerifierV1.sol",
+      "contentBindingHash": "0x5d5d1c46e7627f6e171a18acdbecbfe9e40eca80016fba0142ddca6a054f6169",
+      "runtimeCodeKeccak256": "0xb4af3325444133062ec8382bc29c551ef87e812cbf269712a45ef6ec64db20c0",
+      "policyHash": "0xaa78b0bf63fca83fa9b969fbb6b2bb1ecabcbe49908a48f92403e8e51e4adab2"
+    }
+  },
+  "implementation": {
+    "contract": {
+      "path": "contracts/src/ProgrammableExactShardsRegistryV1.sol",
+      "sha256": "0xcbfeeba3c82d3483333c89870004d7a9ddd605eef4ca139f6720af6edd79b867"
+    },
+    "interface": {
+      "path": "contracts/src/interfaces/IProgrammableExactShardsRegistryV1.sol",
+      "sha256": "0xabb460e5c0cb30a2f875ea4c68f569af6dc9772d0319640fc74b368ac8f638fa"
+    },
+    "unitTest": {
+      "path": "contracts/test/ProgrammableExactShardsRegistryV1.t.sol"
+    },
+    "invariantTest": {
+      "path": "contracts/test/invariant/ProgrammableExactShardsRegistryV1Invariant.t.sol"
+    },
+    "compiler": {
+      "solc": "0.8.26",
+      "evmVersion": "cancun",
+      "optimizer": true,
+      "optimizerRuns": 1000,
+      "viaIr": false,
+      "bytecodeHash": "none",
+      "cborMetadata": false
+    },
+    "artifact": {
+      "creationCodeByteLength": 25744,
+      "creationCodeKeccak256": "0xc2aea6763ca383a2909fc5cbb189461c3fd72d2043be46b9bdd83cefeb15759b",
+      "unlinkedRuntimeCodeByteLength": 22962,
+      "unlinkedRuntimeCodeKeccak256": "0xb73a272caeb4f9a9c7180f585c49c6ef7731416de4980dcbd62b92bcb09157da",
+      "runtimeCodeLimitMarginBytes": 1614,
+      "canonicalAbiSha256": "0x9406ed38d932dc1533314b6d5752e3aaa1626423c71fedf345d02c4c198acecb"
+    }
+  },
+  "exactPolicy": {
+    "profileKey": "0xb90e215e0e29c0dacf021e5e778847af4100433ee7d22014b73f8ca4add09d0c",
+    "feeAsset": "0x0000000000000000000000000000000000000000",
+    "feeAssetSemantic": "NATIVE_ETH",
+    "chargeMode": "INCLUDED_IN_TOTAL",
+    "feeBasisHash": "0xfb8110e8ea13fee890a868300dd1a9a5c467acb19a53f63beccc482757a36191",
+    "totalFeeBps": 100,
+    "orderedClaims": [
+      {
+        "ordinal": 0,
+        "role": "BUILDER",
+        "grossVolumeFeeBps": 10,
+        "shareOfFeeBps": 1000,
+        "claimSelector": "0x69f9a5f0",
+        "handoffSelector": "0x4ce11d21",
+        "recipientMode": "CURRENT_BUILDER_MAY_ROTATE_TO_SUCCESSOR"
+      },
+      {
+        "ordinal": 1,
+        "role": "PROGRAMMABLE",
+        "grossVolumeFeeBps": 10,
+        "shareOfFeeBps": 1000,
+        "claimSelector": "0x64d46b85",
+        "handoffSelector": "0x00000000",
+        "recipientMode": "IMMUTABLE_LAUNCHER_RECIPIENT"
+      },
+      {
+        "ordinal": 2,
+        "role": "NFT_HOLDERS",
+        "grossVolumeFeeBps": 80,
+        "shareOfFeeBps": 8000,
+        "claimSelector": "0x6ba4c138",
+        "handoffSelector": "0x00000000",
+        "recipientMode": "EXACT_SHARDS_HOOK_RUNNING_HOLDER_ACCUMULATOR"
+      }
+    ],
+    "legsHash": "0x14e66b725eaebf6f894323565651567cc05a71bbb263db373d1f9f59ea171899",
+    "policyHash": "0xaa78b0bf63fca83fa9b969fbb6b2bb1ecabcbe49908a48f92403e8e51e4adab2"
+  },
+  "storageAndHashBinding": {
+    "registryInstanceHashFields": [
+      "registrySchemaId",
+      "chainId",
+      "registryGeneration",
+      "registryAddress",
+      "chainProfileHash",
+      "registryPolicyHash",
+      "feeVerifierAddress",
+      "feeVerifierRuntimeCodeHash",
+      "feeVerifierContentBindingHash"
+    ],
+    "feePolicyRecordHashFields": [
+      "feePolicyRecordDomain",
+      "registryInstanceHash",
+      "feeVerifierAddress",
+      "feeVerifierRuntimeCodeHash",
+      "feeVerifierContentBindingHash",
+      "exactPolicyHash",
+      "orderedClaimSetHash"
+    ],
+    "storedPolicyFields": [
+      "profileKey",
+      "feeAsset",
+      "feeBasisHash",
+      "totalFeeBps",
+      "legsHash",
+      "policyHash",
+      "claimSetHash",
+      "verifierBindingHash",
+      "verifierRuntimeCodeHash",
+      "feePolicyRecordHash"
+    ],
+    "storedPerClaimFields": [
+      "ordinal",
+      "roleHash",
+      "grossVolumeFeeBps",
+      "shareOfFeeBps",
+      "initialRecipientOrAccumulator",
+      "recipientModeHash",
+      "claimSelector",
+      "handoffSelector",
+      "legHash",
+      "storedClaimHash"
+    ],
+    "registrationAlsoPins": [
+      "reviewedSourceRevisionHash",
+      "reviewedRouteArtifactSha256",
+      "exactProfileKey",
+      "providerIdMustBeZero",
+      "primaryRuntimeCodeHash",
+      "approvalBindingHash",
+      "reviewDeploymentBindingHash",
+      "registeredRecordCommitment"
+    ]
+  },
+  "lifecycle": {
+    "approval": "APPEND_ONLY_WINDOWED_INDEPENDENT_APPROVER_AND_WRITER",
+    "registration": "OBSERVED_AND_ONE_USE_BOUND_TO_APPROVAL_DEPLOYMENT_INSTANCE_AND_EXACT_ECONOMICS",
+    "finality": "NATIVE_BLOCKHASH_AND_MINIMUM_DEPTH_WITH_ONE_USE_EVIDENCE",
+    "correction": "FINALIZED_ONLY_APPEND_ONLY_REVISION_CHAIN",
+    "revocation": "OBSERVED_OR_FINALIZED_TO_TERMINAL_REVOKED",
+    "feePolicyAfterCorrectionOrRevocation": "IMMUTABLE"
+  },
+  "replayProtection": [
+    "APPROVAL_ID_ONE_USE",
+    "DEPLOYMENT_ID_ONE_USE",
+    "TRANSITION_EVIDENCE_HASH_ONE_USE",
+    "REGISTRY_INSTANCE_DOMAIN_BINDS_CHAIN_GENERATION_AND_ADDRESS",
+    "REGISTERED_LAUNCH_CANNOT_BE_REPLAYED_OR_REVIVED",
+    "FEE_POLICY_RECORD_BINDS_ORDERED_CLAIM_SET"
+  ],
+  "localEvidence": {
+    "unitTests": {
+      "count": 13,
+      "fuzzRuns": 1000,
+      "maximumRegistrationGas": 2200000
+    },
+    "statefulInvariants": {
+      "count": 4,
+      "runsPerInvariant": 256,
+      "depthPerRun": 64,
+      "callsPerInvariant": 16384,
+      "handlerReverts": 0
+    },
+    "registryV1RegressionTests": {
+      "count": 40
+    },
+    "feeVerifierTests": {
+      "count": 8
+    },
+    "securityBoundary": [
+      "NO_FUNDS_CUSTODY",
+      "NO_ROUTER_CALLBACK_OR_V4_DELTA_PATH",
+      "NO_DEPLOYMENT",
+      "NO_APPROVAL_SELF_ISSUANCE",
+      "NO_ACTIVATION",
+      "NO_REGISTRY_MIGRATION"
+    ]
+  },
+  "remainingProductionActions": [
+    {
+      "sequence": 1,
+      "action": "INDEPENDENTLY_REVIEW_AND_RECOMPILE_EXACT_VERIFIER_AND_REGISTRY_SUCCESSOR",
+      "requiredAuthority": "SECURITY_REVIEW_OWNER"
+    },
+    {
+      "sequence": 2,
+      "action": "DEPLOY_EXACT_VERIFIER_AND_REGISTRY_SUCCESSOR_WITH_FINAL_CONSTRUCTOR_AUTHORITIES",
+      "requiredAuthority": "AUTHORIZED_CONTRACT_DEPLOYER_AND_REGISTRY_ADMIN_AUTHORITY"
+    },
+    {
+      "sequence": 3,
+      "action": "RECORD_SOURCE_RUNTIME_CONFIGURATION_AND_FINALITY_RECEIPTS",
+      "requiredAuthority": "DEPLOYMENT_EVIDENCE_OWNER"
+    },
+    {
+      "sequence": 4,
+      "action": "EXECUTE_REMAINING_FROZEN_ROUTER_V4_SHARDS_PHASES",
+      "requiredAuthority": "ROUTER_DEPLOYER_AND_CONTROLLER_SAFE"
+    },
+    {
+      "sequence": 5,
+      "action": "AUTHORIZE_REGISTER_FINALIZE_AND_PUBLISH_INDEXER_RECEIPT",
+      "requiredAuthority": "INDEPENDENT_APPROVER_WRITER_FINALIZER_AND_INDEXER_AUTHORITIES"
+    },
+    {
+      "sequence": 6,
+      "action": "ENABLE_WEBSITE_DESCRIPTOR_ONLY_AFTER_ALL_DEPLOYED_BINDINGS_MATCH",
+      "requiredAuthority": "WEBSITE_RELEASE_OWNER"
+    }
+  ],
+  "prohibitions": [
+    "NO_TWO_CLAIM_DOWNCONVERSION",
+    "NO_90_10_COLLAPSE",
+    "NO_ADDED_ON_TOP_REINTERPRETATION",
+    "NO_UNREVIEWED_SOURCE_ROUTE_PROFILE_OR_PROVIDER",
+    "NO_DEPLOYMENT_ADDRESS_INVENTION",
+    "NO_DEPLOYMENT_SIGNING_REGISTRATION_OR_TRANSACTION_FROM_THIS_ARTIFACT"
+  ]
+}

--- a/contracts/spec/shards-registry-successor-v1.json
+++ b/contracts/spec/shards-registry-successor-v1.json
@@ -5,21 +5,107 @@
   "launchAllowed": false,
   "externalActionOccurred": false,
   "productionBase": {
-    "commit": "a9260ec54324731226ccf0998a5110760ae1fc20",
-    "tree": "b810409f660d641f9205d6bf31b279133f0bef3b"
+    "commit": "3efcacb27c8416725a6985b47b2f26385d164ca6",
+    "tree": "a9e35947fc6a0f4485aeca177fc2ca8d407c2dec"
   },
   "decision": {
     "existingRegistryV1SupportsExactPolicy": false,
     "existingRegistryGen2CandidateSupportsExactPolicy": false,
     "newShardsExecutionSemanticsAdded": false,
-    "newRouterOrFactorySemanticsAdded": false,
+    "newRouterOrFactorySemanticsAdded": true,
+    "newAtomicExecutionRouteAdded": true,
     "smallestNativeSuccessorImplemented": true,
     "currentContractsCanLaunch": false,
     "reasonCurrentContractsCannotLaunch": [
       "THIS_REGISTRY_SUCCESSOR_AND_ITS_EXACT_VERIFIER_ARE_NOT_DEPLOYED",
+      "THE_SHARED_REPOSITORY_LINEAGE_REGISTRY_AND_ATOMIC_SHARDS_ROUTE_ARE_NOT_DEPLOYED",
       "ROUTER_V4_EXACT_SHARDS_PHASES_ARE_NOT_ACTIVATED",
       "NO_DEPLOYMENT_BOUND_REGISTRATION_OR_FINALITY_RECEIPT_EXISTS"
     ]
+  },
+  "postApprovalLaunchMetadataBoundary": {
+    "githubSubmissionApproval": {
+      "binding": "REVIEWED_TECHNICAL_CODE_SECURITY_AND_EXACT_ECONOMICS_ONLY",
+      "includesSelectedUiMetadata": false,
+      "remainsValidWhenOnlyUiMetadataChanges": true
+    },
+    "launchDescriptor": {
+      "configurationFieldIds": [
+        "tokenName",
+        "tokenSymbol"
+      ],
+      "additionalConfigurationFieldsAllowed": false,
+      "presentationFieldIds": [
+        "description",
+        "image",
+        "links"
+      ],
+      "presentationValuesAreSourceArtifactInputs": false
+    },
+    "canonicalFieldBindings": {
+      "tokenNameHash": "keccak256(bytes(tokenName))",
+      "tokenSymbolHash": "keccak256(bytes(tokenSymbol))",
+      "presentationBindingHash": "EXACT_WEBSITE_PRESENTATION_RECORD_BINDING_FOR_DESCRIPTION_IMAGE_AND_LINKS"
+    },
+    "jitLaunchIntentPermit": {
+      "required": true,
+      "bindingAlgorithm": "TEST_ONLY_BINDING_HARNESS_REPRODUCES_EXACT_ONCHAIN_IDENTITY_HASH",
+      "bindingHarnessPath": "contracts/test/utils/ProgrammableExactShardsBindingHarnessV1.sol",
+      "authorizationField": "ApprovalAuthorizationV1.registrationBindingHash",
+      "boundFields": [
+        "tokenNameHash",
+        "tokenSymbolHash",
+        "presentationBindingHash",
+        "deploymentAndWalletSelection",
+        "registeredRecordCommitment"
+      ],
+      "substitutionAfterPermit": "REJECT"
+    },
+    "registryFinalRecord": {
+      "bindsTokenNameHash": true,
+      "bindsTokenSymbolHash": true,
+      "bindsPresentationBindingHash": true,
+      "registryCommitmentBindsMetadata": true,
+      "atomicRouteEmitsMetadataBindingEvent": true
+    },
+    "executionRouteConformance": {
+      "reviewedSourceCommit": "91b38f3de64d96cac7e29f127c004f128fc1da59",
+      "factorySource": {
+        "path": "src/ShardLaunchFactoryV1.sol",
+        "gitBlob": "dc036527de168bb0505755d3d4cfac98a3cda509",
+        "sha256": "0x22f57deb2bb730b88ab6a1f948675d1cb6fbef0442e982f339e9c716e172e14f"
+      },
+      "tokenSource": {
+        "path": "src/ShardTokenV1.sol",
+        "gitBlob": "962c76971773ef2df5e30fad007084b9403cb535",
+        "sha256": "0x5c53920c52c69a87b38159d8a06285a2006e69773543ad72f2b5eb92f63ee22d"
+      },
+      "upstreamTest": {
+        "path": "test/ShardLaunchFactoryV1.t.sol",
+        "gitBlob": "7d5687974d8426c0637cebb818e4b96b723cf1ea",
+        "sha256": "0x5fc169351aea85703411a72b1ba3e2e8e97d6c329ed0bb65dded10c7dd62c5c6",
+        "testName": "test_launchedTokenAndNftCarryTheSuppliedMetadata",
+        "result": "PASS_1_OF_1_EXACT_SOURCE",
+        "selectedTokenName": "Fragment",
+        "selectedTokenSymbol": "FRAG",
+        "assertsProducedTokenNameAndSymbol": true
+      },
+      "factoryLaunchParamsContainTokenNameAndTokenSymbol": true,
+      "tokenInitCodeReceivesSelectedTokenNameAndTokenSymbol": true,
+      "producedErc20NameAndSymbolMatchSelection": true,
+      "nameMaximumUtf8Bytes": 32,
+      "symbolMaximumUtf8Bytes": 12,
+      "frozenRouteCalldataMayBeReusedForDifferentMetadata": false
+    },
+    "atomicRouteConformance": {
+      "specPath": "contracts/spec/shards-atomic-launch-route-v1.json",
+      "contractPath": "contracts/src/ProgrammableExactShardsAtomicLaunchRouteV1.sol",
+      "testPath": "contracts/test/ProgrammableExactShardsAtomicLaunchRouteV1.t.sol",
+      "consumeFactoryVerifyAndRegisterSameTransaction": true,
+      "downstreamRevertRollsBackDeploymentAndLineage": true,
+      "losingCrossRouteAttemptDeploysNoSecondToken": true,
+      "standaloneConsumeSelector": false
+    }
   },
   "reviewedInputs": {
     "shardsSource": {
@@ -41,17 +127,36 @@
   "implementation": {
     "contract": {
       "path": "contracts/src/ProgrammableExactShardsRegistryV1.sol",
-      "sha256": "0xcbfeeba3c82d3483333c89870004d7a9ddd605eef4ca139f6720af6edd79b867"
+      "sha256": "0x2edefb9eef07a045acb12cba832b2990aee6c3bd93425629acd62b884aca8cf2"
     },
     "interface": {
       "path": "contracts/src/interfaces/IProgrammableExactShardsRegistryV1.sol",
-      "sha256": "0xabb460e5c0cb30a2f875ea4c68f569af6dc9772d0319640fc74b368ac8f638fa"
+      "sha256": "0x9d5a84730dc874f8e2f39c2695d500b28d25a9bceb601e0593350e06f89a3d95"
     },
     "unitTest": {
       "path": "contracts/test/ProgrammableExactShardsRegistryV1.t.sol"
     },
     "invariantTest": {
       "path": "contracts/test/invariant/ProgrammableExactShardsRegistryV1Invariant.t.sol"
+    },
+    "sharedRepositoryLineageAuthority": {
+      "specPath": "contracts/spec/github-repository-lineage-registry-v1.json",
+      "contractPath": "contracts/src/ProgrammableGithubRepositoryLineageRegistryV1.sol",
+      "interfacePath": "contracts/src/interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol",
+      "deploymentAddress": null,
+      "activationAllowed": false,
+      "repositoryKeyDerivation": "keccak256(abi.encode(\"programmable.github.repository.v1\", uint256(githubRepositoryId)))",
+      "shardsGithubRepositoryId": 1329073878,
+      "shardsRepositoryKey": "0x02ed38e86a7c41d5dea93cf5e3f829420837c4d351d9f4675929c6ce0041e835"
+    },
+    "atomicLaunchRoute": {
+      "specPath": "contracts/spec/shards-atomic-launch-route-v1.json",
+      "contractPath": "contracts/src/ProgrammableExactShardsAtomicLaunchRouteV1.sol",
+      "factoryInterfacePath": "contracts/src/interfaces/IProgrammableExactShardsLaunchFactoryV1.sol",
+      "deploymentAddress": null,
+      "activationAllowed": false,
+      "repositoryLineageConsumerRoleTarget": "EXACT_ATOMIC_ROUTE_ONLY",
+      "registryWriterRoleBeforeActivation": "EXACT_ATOMIC_ROUTE_ONLY"
     },
     "compiler": {
       "solc": "0.8.26",
@@ -63,12 +168,12 @@
       "cborMetadata": false
     },
     "artifact": {
-      "creationCodeByteLength": 25744,
-      "creationCodeKeccak256": "0xc2aea6763ca383a2909fc5cbb189461c3fd72d2043be46b9bdd83cefeb15759b",
-      "unlinkedRuntimeCodeByteLength": 22962,
-      "unlinkedRuntimeCodeKeccak256": "0xb73a272caeb4f9a9c7180f585c49c6ef7731416de4980dcbd62b92bcb09157da",
-      "runtimeCodeLimitMarginBytes": 1614,
-      "canonicalAbiSha256": "0x9406ed38d932dc1533314b6d5752e3aaa1626423c71fedf345d02c4c198acecb"
+      "creationCodeByteLength": 27268,
+      "creationCodeKeccak256": "0x15bc577db8933f8f9985ff77f768faabe62c197b53a1258915fda618f8c3650b",
+      "unlinkedRuntimeCodeByteLength": 24303,
+      "unlinkedRuntimeCodeKeccak256": "0x21c4e08e2471be1119f158021c4d6e426e5c953ea26719381b39fbcd0cc70d77",
+      "runtimeCodeLimitMarginBytes": 273,
+      "canonicalAbiSha256": "0x9492f1b19fe8dba9ebddcb8ae474c01971de51d64fe502bb2277c53f405aed62"
     }
   },
   "exactPolicy": {
@@ -120,7 +225,9 @@
       "registryPolicyHash",
       "feeVerifierAddress",
       "feeVerifierRuntimeCodeHash",
-      "feeVerifierContentBindingHash"
+      "feeVerifierContentBindingHash",
+      "sharedRepositoryLineageRegistryAddress",
+      "sharedRepositoryLineageRegistryRuntimeCodeHash"
     ],
     "feePolicyRecordHashFields": [
       "feePolicyRecordDomain",
@@ -162,13 +269,17 @@
       "providerIdMustBeZero",
       "primaryRuntimeCodeHash",
       "approvalBindingHash",
+      "jitLaunchIntentBindingHash",
+      "tokenNameHash",
+      "tokenSymbolHash",
+      "presentationBindingHash",
       "reviewDeploymentBindingHash",
       "registeredRecordCommitment"
     ]
   },
   "lifecycle": {
-    "approval": "APPEND_ONLY_WINDOWED_INDEPENDENT_APPROVER_AND_WRITER",
-    "registration": "OBSERVED_AND_ONE_USE_BOUND_TO_APPROVAL_DEPLOYMENT_INSTANCE_AND_EXACT_ECONOMICS",
+    "approval": "DURABLE_TECHNICAL_APPROVAL_PLUS_SHORT_WINDOW_EXACT_JIT_LAUNCH_INTENT",
+    "registration": "ATOMIC_WITH_FACTORY_EXECUTION_AND_BOUND_TO_APPROVAL_DEPLOYMENT_METADATA_AND_EXACT_ECONOMICS",
     "finality": "NATIVE_BLOCKHASH_AND_MINIMUM_DEPTH_WITH_ONE_USE_EVIDENCE",
     "correction": "FINALIZED_ONLY_APPEND_ONLY_REVISION_CHAIN",
     "revocation": "OBSERVED_OR_FINALIZED_TO_TERMINAL_REVOKED",
@@ -177,6 +288,7 @@
   "replayProtection": [
     "APPROVAL_ID_ONE_USE",
     "DEPLOYMENT_ID_ONE_USE",
+    "NUMERIC_GITHUB_REPOSITORY_LINEAGE_ONE_SUCCESSFUL_LAUNCH_ACROSS_ALL_AUTHORIZED_ROUTES",
     "TRANSITION_EVIDENCE_HASH_ONE_USE",
     "REGISTRY_INSTANCE_DOMAIN_BINDS_CHAIN_GENERATION_AND_ADDRESS",
     "REGISTERED_LAUNCH_CANNOT_BE_REPLAYED_OR_REVIVED",
@@ -184,7 +296,7 @@
   ],
   "localEvidence": {
     "unitTests": {
-      "count": 13,
+      "count": 15,
       "fuzzRuns": 1000,
       "maximumRegistrationGas": 2200000
     },
@@ -200,6 +312,17 @@
     },
     "feeVerifierTests": {
       "count": 8
+    },
+    "sharedRepositoryLineageTests": {
+      "unitCount": 10,
+      "invariantCount": 1,
+      "invariantCalls": 16384,
+      "handlerReverts": 0
+    },
+    "atomicLaunchRouteTests": {
+      "count": 5,
+      "crossRouteLoserDeploysNoTokenHookOrNft": true,
+      "downstreamRevertRollsBackAllDeploymentsAndLineage": true
     },
     "securityBoundary": [
       "NO_FUNDS_CUSTODY",

--- a/contracts/src/ProgrammableExactShardsAtomicLaunchRouteV1.sol
+++ b/contracts/src/ProgrammableExactShardsAtomicLaunchRouteV1.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IProgrammableExactShardsLaunchFactoryV1 } from "./interfaces/IProgrammableExactShardsLaunchFactoryV1.sol";
+import { IProgrammableExactShardsRegistryV1 } from "./interfaces/IProgrammableExactShardsRegistryV1.sol";
+import {
+    IProgrammableGithubRepositoryLineageRegistryV1
+} from "./interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol";
+
+interface IExactShardsTokenMetadataV1 {
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+}
+
+/// @title ProgrammableExactShardsAtomicLaunchRouteV1
+/// @notice The only authorized Shards lineage consumer: consume, deploy, verify and register in one transaction.
+contract ProgrammableExactShardsAtomicLaunchRouteV1 {
+    bytes32 public constant ROUTE_ID = keccak256("programmable.exact-shards.atomic-launch-route.v1");
+    // Immutable manifest fields intentionally use the same uppercase convention as the bound Registry.
+    // slither-disable-next-line naming-convention
+    IProgrammableGithubRepositoryLineageRegistryV1 public immutable LINEAGE_REGISTRY;
+    // slither-disable-next-line naming-convention
+    IProgrammableExactShardsLaunchFactoryV1 public immutable FACTORY;
+    // slither-disable-next-line naming-convention
+    IProgrammableExactShardsRegistryV1 public immutable REGISTRY;
+    // slither-disable-next-line naming-convention
+    bytes32 public immutable LINEAGE_REGISTRY_RUNTIME_CODE_HASH;
+    // slither-disable-next-line naming-convention
+    bytes32 public immutable FACTORY_RUNTIME_CODE_HASH;
+    // slither-disable-next-line naming-convention
+    bytes32 public immutable REGISTRY_RUNTIME_CODE_HASH;
+
+    error ConfigurationInvalid(bytes32 field);
+    error FactoryRuntimeCodeHashMismatch(bytes32 supplied);
+    error LaunchWalletMismatch(address caller, address launchWallet);
+    error SelectedTokenMetadataMismatch(bytes32 nameHash, bytes32 symbolHash);
+    error ProducedAddressMismatch(address produced, address registered);
+    error ProducedRuntimeCodeHashMismatch(bytes32 produced, bytes32 registered);
+
+    event ExactShardsAtomicLaunchCompletedV1(
+        bytes32 indexed launchId, bytes32 indexed repositoryKey, address indexed shard, address hook, address nft
+    );
+    event ExactShardsLaunchMetadataBoundV1(
+        bytes32 indexed launchId, bytes32 tokenNameHash, bytes32 tokenSymbolHash, bytes32 presentationBindingHash
+    );
+
+    constructor(
+        IProgrammableGithubRepositoryLineageRegistryV1 lineageRegistry,
+        IProgrammableExactShardsLaunchFactoryV1 factory,
+        IProgrammableExactShardsRegistryV1 registry,
+        bytes32 factoryRuntimeCodeHash
+    ) {
+        if (address(lineageRegistry).code.length == 0) {
+            revert ConfigurationInvalid(bytes32("lineage-registry"));
+        }
+        if (address(factory).code.length == 0) revert ConfigurationInvalid(bytes32("factory"));
+        if (address(registry).code.length == 0) revert ConfigurationInvalid(bytes32("registry"));
+        if (factoryRuntimeCodeHash == bytes32(0) || address(factory).codehash != factoryRuntimeCodeHash) {
+            revert FactoryRuntimeCodeHashMismatch(address(factory).codehash);
+        }
+        LINEAGE_REGISTRY = lineageRegistry;
+        FACTORY = factory;
+        REGISTRY = registry;
+        LINEAGE_REGISTRY_RUNTIME_CODE_HASH = address(lineageRegistry).codehash;
+        FACTORY_RUNTIME_CODE_HASH = factoryRuntimeCodeHash;
+        REGISTRY_RUNTIME_CODE_HASH = address(registry).codehash;
+    }
+
+    // Completion events deliberately follow all three external atomic steps so no success log can precede
+    // the factory postconditions or final Registry append. A revert rolls back every call and event.
+    // slither-disable-next-line reentrancy-events
+    function launch(
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 calldata registration,
+        bytes32 tokenSalt,
+        bytes32 hookSalt,
+        bytes calldata hookCreationCode,
+        IProgrammableExactShardsLaunchFactoryV1.LaunchParams calldata params
+    ) external returns (address hook, address shard, address nft) {
+        if (msg.sender != registration.launchWallet) {
+            revert LaunchWalletMismatch(msg.sender, registration.launchWallet);
+        }
+        _validateSelectedMetadata(registration, params);
+
+        // No standalone consume entry point exists. This call is immediately followed by the irreversible factory
+        // execution and Registry append; any downstream revert rolls all three operations back.
+        bytes32 repositoryKey =
+            LINEAGE_REGISTRY.consume(registration.githubRepositoryId, registration.launchId, ROUTE_ID);
+        (hook, shard, nft) = FACTORY.launch(tokenSalt, hookSalt, hookCreationCode, params);
+
+        if (shard != registration.primaryContract) revert ProducedAddressMismatch(shard, registration.primaryContract);
+        if (shard.codehash != registration.primaryRuntimeCodeHash) {
+            revert ProducedRuntimeCodeHashMismatch(shard.codehash, registration.primaryRuntimeCodeHash);
+        }
+        _validateProducedMetadata(registration, shard);
+
+        REGISTRY.registerLaunch(registration);
+        emit ExactShardsAtomicLaunchCompletedV1(registration.launchId, repositoryKey, shard, hook, nft);
+        emit ExactShardsLaunchMetadataBoundV1(
+            registration.launchId,
+            registration.tokenNameHash,
+            registration.tokenSymbolHash,
+            registration.presentationBindingHash
+        );
+    }
+
+    function _validateSelectedMetadata(
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 calldata registration,
+        IProgrammableExactShardsLaunchFactoryV1.LaunchParams calldata params
+    ) private pure {
+        bytes32 tokenNameHash = keccak256(bytes(params.tokenName));
+        bytes32 tokenSymbolHash = keccak256(bytes(params.tokenSymbol));
+        if (tokenNameHash != registration.tokenNameHash || tokenSymbolHash != registration.tokenSymbolHash) {
+            revert SelectedTokenMetadataMismatch(tokenNameHash, tokenSymbolHash);
+        }
+    }
+
+    function _validateProducedMetadata(
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 calldata registration,
+        address shard
+    ) private view {
+        bytes32 tokenNameHash = keccak256(bytes(IExactShardsTokenMetadataV1(shard).name()));
+        bytes32 tokenSymbolHash = keccak256(bytes(IExactShardsTokenMetadataV1(shard).symbol()));
+        if (tokenNameHash != registration.tokenNameHash || tokenSymbolHash != registration.tokenSymbolHash) {
+            revert SelectedTokenMetadataMismatch(tokenNameHash, tokenSymbolHash);
+        }
+    }
+}

--- a/contracts/src/ProgrammableExactShardsFeePolicyVerifierV1.sol
+++ b/contracts/src/ProgrammableExactShardsFeePolicyVerifierV1.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {
+    IProgrammableExactShardsFeePolicyVerifierV1
+} from "./interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol";
+
+/// @notice Exact hashing and validation shared by the public Shards fee-policy verifier.
+library ProgrammableExactShardsFeePolicyVerifierLibV1 {
+    bytes32 internal constant LEG_TYPEHASH = keccak256(
+        "ProgrammableRevenueLegV1(bytes32 roleHash,uint16 feeBps,address recipient,bytes32 recipientModeHash)"
+    );
+    bytes32 internal constant POLICY_TYPEHASH = keccak256(
+        "ProgrammableRevenuePolicyV1(bytes32 profileKey,address feeAsset,bytes32 feeBasisHash,uint16 totalFeeBps,bytes32 legsHash)"
+    );
+
+    bytes32 internal constant PROFILE_KEY = 0xb90e215e0e29c0dacf021e5e778847af4100433ee7d22014b73f8ca4add09d0c;
+    bytes32 internal constant FEE_BASIS_HASH = 0xfb8110e8ea13fee890a868300dd1a9a5c467acb19a53f63beccc482757a36191;
+    uint16 internal constant TOTAL_FEE_BPS = 100;
+
+    bytes32 internal constant BUILDER_ROLE_HASH = 0x36a60a66fdf8fc39bbaab0d3ff46b52ffc8a9b6f3dc94b5fe9836816d72890af;
+    bytes32 internal constant BUILDER_RECIPIENT_MODE_HASH =
+        0xc1ed7eaa8d37d922e99971bb6369533361b226b731cf9677e60e36b376519ea4;
+    address internal constant INITIAL_BUILDER_RECIPIENT = 0xceeBB3A6543CeBEB2ED66963897A0abEA52A50cC;
+    uint16 internal constant BUILDER_FEE_BPS = 10;
+
+    bytes32 internal constant PROGRAMMABLE_ROLE_HASH =
+        0x069cb8bbaf512d6f3d7fd962d64b67ce531a420f558aa3a2301e77be3640d875;
+    bytes32 internal constant PROGRAMMABLE_RECIPIENT_MODE_HASH =
+        0x496f134b2bbc4d8ae230c1aa1a607788d75231c8ee823312e515b851a927d4f4;
+    address internal constant PROGRAMMABLE_RECIPIENT = 0x4957f49620AFf3Adbbe8195a4f633E49cc93376c;
+    uint16 internal constant PROGRAMMABLE_FEE_BPS = 10;
+
+    bytes32 internal constant HOLDER_ROLE_HASH = 0x84edd196638e45435db849686913b0ffb528525a1edc3aece78548ed6f2577f1;
+    bytes32 internal constant HOLDER_RECIPIENT_MODE_HASH =
+        0x9aec909e12714c25df903902800a480772830ed15716e130e797f7447138ba55;
+    address internal constant HOLDER_ACCUMULATOR = 0xbA318baA8649962fD77CC7082d098f2C09Fd60cC;
+    uint16 internal constant HOLDER_FEE_BPS = 80;
+
+    bytes32 internal constant BUILDER_LEG_HASH = 0x10c851ca78aa2bf257e924b5b4b1a471b8f091e5d971f1a2422165a60bd325ac;
+    bytes32 internal constant PROGRAMMABLE_LEG_HASH =
+        0xccc9d7a84cef40c38d165ba1ce0f1817f77172bc97b49155ac6a14fcc5e6cff5;
+    bytes32 internal constant HOLDER_LEG_HASH = 0x30cf730abcc37ad7db1d6e91abad8c1564fc624c777c456da987f0e006b9ff9e;
+    bytes32 internal constant LEGS_HASH = 0x14e66b725eaebf6f894323565651567cc05a71bbb263db373d1f9f59ea171899;
+    bytes32 internal constant REVENUE_POLICY_HASH = 0xaa78b0bf63fca83fa9b969fbb6b2bb1ecabcbe49908a48f92403e8e51e4adab2;
+
+    uint8 private constant FIELD_PROFILE = 1;
+    uint8 private constant FIELD_FEE_ASSET = 2;
+    uint8 private constant FIELD_FEE_BASIS = 3;
+    uint8 private constant FIELD_TOTAL_FEE = 4;
+    uint8 private constant FIELD_BUILDER = 5;
+    uint8 private constant FIELD_PROGRAMMABLE = 6;
+    uint8 private constant FIELD_HOLDERS = 7;
+    uint8 private constant FIELD_LEG_SUM = 8;
+    uint8 private constant FIELD_LEGS_HASH = 9;
+    uint8 private constant FIELD_POLICY_HASH = 10;
+
+    function validateAndHash(
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
+    ) internal pure returns (bytes32 policyHash) {
+        if (policy.profileKey != PROFILE_KEY) _invalid(FIELD_PROFILE);
+        if (policy.feeAsset != address(0)) _invalid(FIELD_FEE_ASSET);
+        if (policy.feeBasisHash != FEE_BASIS_HASH) _invalid(FIELD_FEE_BASIS);
+        if (policy.totalFeeBps != TOTAL_FEE_BPS) _invalid(FIELD_TOTAL_FEE);
+
+        bytes32 builderHash = hashLeg(orderedLegs[0]);
+        bytes32 programmableHash = hashLeg(orderedLegs[1]);
+        bytes32 holderHash = hashLeg(orderedLegs[2]);
+        if (builderHash != BUILDER_LEG_HASH) _invalid(FIELD_BUILDER);
+        if (programmableHash != PROGRAMMABLE_LEG_HASH) _invalid(FIELD_PROGRAMMABLE);
+        if (holderHash != HOLDER_LEG_HASH) _invalid(FIELD_HOLDERS);
+
+        uint256 legSum =
+            uint256(orderedLegs[0].feeBps) + uint256(orderedLegs[1].feeBps) + uint256(orderedLegs[2].feeBps);
+        if (legSum != policy.totalFeeBps) _invalid(FIELD_LEG_SUM);
+
+        bytes32 legsHash = keccak256(abi.encode(builderHash, programmableHash, holderHash));
+        if (legsHash != LEGS_HASH || policy.legsHash != legsHash) _invalid(FIELD_LEGS_HASH);
+
+        policyHash = hashPolicy(policy);
+        if (policyHash != REVENUE_POLICY_HASH) _invalid(FIELD_POLICY_HASH);
+    }
+
+    function hashLeg(IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1 calldata leg)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(LEG_TYPEHASH, leg.roleHash, leg.feeBps, leg.recipient, leg.recipientModeHash));
+    }
+
+    function hashPolicy(IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                POLICY_TYPEHASH,
+                policy.profileKey,
+                policy.feeAsset,
+                policy.feeBasisHash,
+                policy.totalFeeBps,
+                policy.legsHash
+            )
+        );
+    }
+
+    function _invalid(uint8 field) private pure {
+        revert IProgrammableExactShardsFeePolicyVerifierV1.InvalidShardsFeePolicy(field);
+    }
+}
+
+/// @title ProgrammableExactShardsFeePolicyVerifierV1
+/// @notice Stateless verifier for the exact reviewed Shards 1.00% inclusive, three-claim policy.
+/// @dev Reproduces the typed hashes already frozen in the reviewed nested-factory route artifact. It does not
+///      authorize, register, deploy or activate a launch; a registry successor must bind this exact verifier.
+contract ProgrammableExactShardsFeePolicyVerifierV1 is IProgrammableExactShardsFeePolicyVerifierV1 {
+    bytes32 public constant LEG_TYPEHASH = ProgrammableExactShardsFeePolicyVerifierLibV1.LEG_TYPEHASH;
+    bytes32 public constant POLICY_TYPEHASH = ProgrammableExactShardsFeePolicyVerifierLibV1.POLICY_TYPEHASH;
+
+    bytes20 public constant REVIEWED_SOURCE_COMMIT = hex"91b38f3de64d96cac7e29f127c004f128fc1da59";
+    bytes20 public constant REVIEWED_SOURCE_TREE = hex"92d6def8609e829487adea66c13901734e43c8c7";
+    bytes32 public constant SOURCE_REVISION_HASH = 0x3352fe14662ce467e98f475cf91f10304ce4d69b6342fae4bf3dc968c494d6dc;
+    bytes32 public constant NESTED_FACTORY_ARTIFACT_SHA256 =
+        0x066475058bfd47b85b4216f95b434756d67d7e289ffb36535c121ef5d7c11bab;
+    bytes32 public constant REVIEWED_FEE_DESCRIPTOR_SHA256 =
+        0xd1c911686afc62b70f3d65c9807e89146d119c4e6f4604e72d3dab2b4ef8dc22;
+
+    bytes20 public constant ROUTER_V4_SOURCE_COMMIT = hex"d6cfb78543b159f9e0ed9f193a5b29637bd817fc";
+    bytes20 public constant ROUTER_V4_SOURCE_TREE = hex"cbdad7210dee6fac708d2957e9f5288090bb20f8";
+    bytes20 public constant ROUTER_V4_PROFILE_SOURCE_BLOB = hex"d802fa387505da47a0ac4d65a6e5b5e4efa7026d";
+    bytes20 public constant ROUTER_V4_NESTED_ADAPTER_SOURCE_BLOB = hex"cf2b92f67ec00b0c0a844708dd62ab70a32fdf3a";
+
+    bytes32 public constant PROFILE_KEY = ProgrammableExactShardsFeePolicyVerifierLibV1.PROFILE_KEY;
+    address public constant FACTORY = 0x9442a520e7b31D10177C75A363355C2C29141ac5;
+    bytes32 public constant FACTORY_RUNTIME_CODE_HASH =
+        0x134a9e5674f22e62e939c2238693077b8027c553bb26d6a4e9e3d8554e5f85b5;
+    address public constant HOOK = ProgrammableExactShardsFeePolicyVerifierLibV1.HOLDER_ACCUMULATOR;
+    bytes32 public constant HOOK_RUNTIME_CODE_HASH = 0x2a2174aff52c3ea9ddf0a6081464c9c6dbc43ddc93609c74d9610f50f486c1e1;
+
+    address public constant FEE_ASSET = address(0);
+    bytes32 public constant FEE_BASIS_HASH = ProgrammableExactShardsFeePolicyVerifierLibV1.FEE_BASIS_HASH;
+    uint16 public constant TOTAL_FEE_BPS = ProgrammableExactShardsFeePolicyVerifierLibV1.TOTAL_FEE_BPS;
+    uint16 public constant SHARE_DENOMINATOR_BPS = 10_000;
+    uint16 public constant HOLDER_SHARE_OF_FEE_BPS = 8000;
+    uint16 public constant BUILDER_SHARE_OF_FEE_BPS = 1000;
+    uint16 public constant PROGRAMMABLE_SHARE_OF_FEE_BPS = 1000;
+
+    bytes32 public constant BUILDER_ROLE_HASH = ProgrammableExactShardsFeePolicyVerifierLibV1.BUILDER_ROLE_HASH;
+    bytes32 public constant BUILDER_RECIPIENT_MODE_HASH =
+        ProgrammableExactShardsFeePolicyVerifierLibV1.BUILDER_RECIPIENT_MODE_HASH;
+    address public constant INITIAL_BUILDER_RECIPIENT =
+        ProgrammableExactShardsFeePolicyVerifierLibV1.INITIAL_BUILDER_RECIPIENT;
+    uint16 public constant BUILDER_FEE_BPS = ProgrammableExactShardsFeePolicyVerifierLibV1.BUILDER_FEE_BPS;
+
+    bytes32 public constant PROGRAMMABLE_ROLE_HASH =
+        ProgrammableExactShardsFeePolicyVerifierLibV1.PROGRAMMABLE_ROLE_HASH;
+    bytes32 public constant PROGRAMMABLE_RECIPIENT_MODE_HASH =
+        ProgrammableExactShardsFeePolicyVerifierLibV1.PROGRAMMABLE_RECIPIENT_MODE_HASH;
+    address public constant PROGRAMMABLE_RECIPIENT =
+        ProgrammableExactShardsFeePolicyVerifierLibV1.PROGRAMMABLE_RECIPIENT;
+    uint16 public constant PROGRAMMABLE_FEE_BPS = ProgrammableExactShardsFeePolicyVerifierLibV1.PROGRAMMABLE_FEE_BPS;
+
+    bytes32 public constant HOLDER_ROLE_HASH = ProgrammableExactShardsFeePolicyVerifierLibV1.HOLDER_ROLE_HASH;
+    bytes32 public constant HOLDER_RECIPIENT_MODE_HASH =
+        ProgrammableExactShardsFeePolicyVerifierLibV1.HOLDER_RECIPIENT_MODE_HASH;
+    address public constant HOLDER_ACCUMULATOR = ProgrammableExactShardsFeePolicyVerifierLibV1.HOLDER_ACCUMULATOR;
+    uint16 public constant HOLDER_FEE_BPS = ProgrammableExactShardsFeePolicyVerifierLibV1.HOLDER_FEE_BPS;
+
+    bytes32 public constant BUILDER_LEG_HASH = ProgrammableExactShardsFeePolicyVerifierLibV1.BUILDER_LEG_HASH;
+    bytes32 public constant PROGRAMMABLE_LEG_HASH = ProgrammableExactShardsFeePolicyVerifierLibV1.PROGRAMMABLE_LEG_HASH;
+    bytes32 public constant HOLDER_LEG_HASH = ProgrammableExactShardsFeePolicyVerifierLibV1.HOLDER_LEG_HASH;
+    bytes32 public constant LEGS_HASH = ProgrammableExactShardsFeePolicyVerifierLibV1.LEGS_HASH;
+    bytes32 public constant REVENUE_POLICY_HASH = ProgrammableExactShardsFeePolicyVerifierLibV1.REVENUE_POLICY_HASH;
+    bytes32 public constant INITIAL_REVENUE_STATE_HASH =
+        0xf0bc686422736754322da4ea358a823274df35c35718939d71d339a41b8f9b75;
+
+    bytes4 public constant HOLDER_CLAIM_SELECTOR = bytes4(keccak256("claim(uint256[])"));
+    bytes4 public constant BUILDER_CLAIM_SELECTOR = bytes4(keccak256("claimBuilderFees()"));
+    bytes4 public constant PROGRAMMABLE_CLAIM_SELECTOR = bytes4(keccak256("claimLauncherFees()"));
+    bytes4 public constant BUILDER_HANDOFF_SELECTOR = bytes4(keccak256("setBuilderFeeRecipient(address)"));
+
+    bytes32 public constant SOURCE_BINDING_TYPEHASH = keccak256(
+        "ProgrammableExactShardsSourceBindingV1(bytes20 sourceCommit,bytes20 sourceTree,bytes32 sourceRevisionHash,bytes32 nestedFactoryArtifactSha256,bytes32 feeDescriptorSha256)"
+    );
+    bytes32 public constant ROUTER_BINDING_TYPEHASH = keccak256(
+        "ProgrammableExactShardsRouterBindingV1(bytes20 routerSourceCommit,bytes20 routerSourceTree,bytes20 profileSourceBlob,bytes20 nestedAdapterSourceBlob)"
+    );
+    bytes32 public constant ECONOMICS_BINDING_TYPEHASH = keccak256(
+        "ProgrammableExactShardsEconomicsBindingV1(bytes32 profileKey,address factory,bytes32 factoryRuntimeCodeHash,address hook,bytes32 hookRuntimeCodeHash,bytes32 revenuePolicyHash,bytes32 initialRevenueStateHash)"
+    );
+    bytes32 public constant FEE_POLICY_BINDING_TYPEHASH = keccak256(
+        "ProgrammableExactShardsFeePolicyBindingV1(bytes32 sourceBindingHash,bytes32 routerBindingHash,bytes32 economicsBindingHash)"
+    );
+
+    function verify(ProgrammableRevenuePolicyV1 calldata policy, ProgrammableRevenueLegV1[3] calldata orderedLegs)
+        external
+        pure
+        returns (bytes32 policyHash)
+    {
+        return ProgrammableExactShardsFeePolicyVerifierLibV1.validateAndHash(policy, orderedLegs);
+    }
+
+    function hashLeg(ProgrammableRevenueLegV1 calldata leg) external pure returns (bytes32) {
+        return ProgrammableExactShardsFeePolicyVerifierLibV1.hashLeg(leg);
+    }
+
+    function hashPolicy(ProgrammableRevenuePolicyV1 calldata policy) external pure returns (bytes32) {
+        return ProgrammableExactShardsFeePolicyVerifierLibV1.hashPolicy(policy);
+    }
+
+    function feePolicyBindingHashV1() external pure returns (bytes32) {
+        bytes32 sourceBindingHash = keccak256(
+            abi.encode(
+                SOURCE_BINDING_TYPEHASH,
+                REVIEWED_SOURCE_COMMIT,
+                REVIEWED_SOURCE_TREE,
+                SOURCE_REVISION_HASH,
+                NESTED_FACTORY_ARTIFACT_SHA256,
+                REVIEWED_FEE_DESCRIPTOR_SHA256
+            )
+        );
+        bytes32 routerBindingHash = keccak256(
+            abi.encode(
+                ROUTER_BINDING_TYPEHASH,
+                ROUTER_V4_SOURCE_COMMIT,
+                ROUTER_V4_SOURCE_TREE,
+                ROUTER_V4_PROFILE_SOURCE_BLOB,
+                ROUTER_V4_NESTED_ADAPTER_SOURCE_BLOB
+            )
+        );
+        bytes32 economicsBindingHash = keccak256(
+            abi.encode(
+                ECONOMICS_BINDING_TYPEHASH,
+                PROFILE_KEY,
+                FACTORY,
+                FACTORY_RUNTIME_CODE_HASH,
+                HOOK,
+                HOOK_RUNTIME_CODE_HASH,
+                REVENUE_POLICY_HASH,
+                INITIAL_REVENUE_STATE_HASH
+            )
+        );
+        return keccak256(
+            abi.encode(FEE_POLICY_BINDING_TYPEHASH, sourceBindingHash, routerBindingHash, economicsBindingHash)
+        );
+    }
+}

--- a/contracts/src/ProgrammableExactShardsRegistryV1.sol
+++ b/contracts/src/ProgrammableExactShardsRegistryV1.sol
@@ -12,6 +12,9 @@ import {
     IProgrammableExactShardsFeePolicyVerifierV1
 } from "./interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol";
 import { IProgrammableExactShardsRegistryV1 } from "./interfaces/IProgrammableExactShardsRegistryV1.sol";
+import {
+    IProgrammableGithubRepositoryLineageRegistryV1
+} from "./interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol";
 
 /// @title ProgrammableExactShardsRegistryV1
 /// @notice Native append-only Registry successor for the reviewed Shards three-claim policy.
@@ -47,6 +50,8 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
     bytes32 internal constant IDENTITY_DOMAIN = keccak256("programmable.exact-shards-launch-identity.v1");
     bytes32 internal constant REGISTERED_RECORD_COMMITMENT_DOMAIN =
         keccak256("programmable.exact-shards-registered-record.v1");
+    bytes32 internal constant LAUNCH_METADATA_BINDING_DOMAIN =
+        keccak256("programmable.exact-shards-launch-metadata-binding.v1");
     bytes32 internal constant STORED_CLAIM_TYPEHASH = keccak256(
         "ProgrammableExactShardsStoredFeeClaimV1(uint8 ordinal,bytes32 roleHash,uint16 grossVolumeFeeBps,uint16 shareOfFeeBps,address initialRecipientOrAccumulator,bytes32 recipientModeHash,bytes4 claimSelector,bytes4 handoffSelector,bytes32 legHash)"
     );
@@ -80,6 +85,7 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
     uint16 internal constant PROGRAMMABLE_SHARE_OF_FEE_BPS = 1000;
     uint16 internal constant HOLDER_SHARE_OF_FEE_BPS = 8000;
     uint8 internal constant FEE_CLAIM_COUNT = 3;
+    uint64 internal constant MAX_LAUNCH_INTENT_BLOCK_WINDOW = 1200;
 
     // Immutable manifest fields intentionally use the same uppercase convention as Registry V1.
     // slither-disable-next-line naming-convention
@@ -100,9 +106,10 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
     bytes32 public immutable FEE_POLICY_BINDING_HASH;
     // slither-disable-next-line naming-convention
     ProgrammableExactShardsFeePolicyVerifierV1 public immutable FEE_POLICY_VERIFIER;
+    // slither-disable-next-line naming-convention
+    IProgrammableGithubRepositoryLineageRegistryV1 public immutable REPOSITORY_LINEAGE_REGISTRY;
 
     uint64 public registrationCount;
-    uint64 public approvalAuthorizationCount;
     uint64 public transitionCount;
 
     mapping(bytes32 launchId => LaunchStateV1 state) private _launchStates;
@@ -111,6 +118,7 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
     mapping(bytes32 launchId => mapping(uint8 ordinal => StoredFeeClaimV1 claim)) private _feeClaims;
     mapping(bytes32 launchId => mapping(uint64 revision => bytes32 recordHash)) private _recordHashes;
     mapping(bytes32 approvalId => IProgrammableCustomRegistryV1.ApprovalStateV1 state) private _approvalStates;
+    mapping(bytes32 approvalId => LaunchIntentStateV1 state) private _launchIntentStates;
     mapping(bytes32 approvalId => bool consumed) public approvalConsumed;
     mapping(bytes32 deploymentId => bool consumed) public deploymentConsumed;
     mapping(bytes32 evidenceHash => bool consumed) public transitionEvidenceConsumed;
@@ -138,6 +146,8 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
     );
     error InvalidObservedTransactionHash();
     error LaunchAlreadyRegistered(bytes32 launchId);
+    error LaunchIntentAlreadyActive(bytes32 approvalId, uint64 expiresAtBlock);
+    error LaunchIntentWindowTooLong(uint64 validAfterBlock, uint64 expiresAtBlock);
     error NoncanonicalBlock(uint64 blockNumber, uint256 currentBlock);
     error PairMismatch(bytes32 idField, bytes32 versionField);
     error PrimaryContractHasNoCode(address primaryContract);
@@ -150,9 +160,13 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
     error ReviewDeploymentBindingMismatch(bytes32 supplied, bytes32 expected);
     error RuntimeCodeHashMismatch(address target, bytes32 supplied, bytes32 actual);
 
-    constructor(RegistryConfigV1 memory config, ProgrammableExactShardsFeePolicyVerifierV1 feePolicyVerifier)
-        AccessControlDefaultAdminRules(config.initialAdminDelay, config.initialAdmin)
-    {
+    // Explicit fail-closed configuration guards are intentionally kept separate for field-level diagnostics.
+    // slither-disable-next-line cyclomatic-complexity
+    constructor(
+        RegistryConfigV1 memory config,
+        ProgrammableExactShardsFeePolicyVerifierV1 feePolicyVerifier,
+        IProgrammableGithubRepositoryLineageRegistryV1 repositoryLineageRegistry
+    ) AccessControlDefaultAdminRules(config.initialAdminDelay, config.initialAdmin) {
         if (config.initialApprover == address(0)) revert RegistryConfigurationInvalid(bytes32("approver"));
         if (config.initialWriter == address(0)) revert RegistryConfigurationInvalid(bytes32("writer"));
         if (config.initialApprover == config.initialWriter) {
@@ -169,6 +183,9 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         if (config.registryPolicyHash == bytes32(0)) revert RegistryConfigurationInvalid(bytes32("registry-policy"));
         if (address(feePolicyVerifier) == address(0) || address(feePolicyVerifier).code.length == 0) {
             revert RegistryConfigurationInvalid(bytes32("fee-policy-verifier"));
+        }
+        if (address(repositoryLineageRegistry) == address(0) || address(repositoryLineageRegistry).code.length == 0) {
+            revert RegistryConfigurationInvalid(bytes32("repository-lineage-registry"));
         }
 
         bytes32 verifierRuntimeCodeHash = address(feePolicyVerifier).codehash;
@@ -190,6 +207,7 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         VERIFIER_RUNTIME_CODE_HASH = verifierRuntimeCodeHash;
         FEE_POLICY_BINDING_HASH = feePolicyBindingHash;
         FEE_POLICY_VERIFIER = feePolicyVerifier;
+        REPOSITORY_LINEAGE_REGISTRY = repositoryLineageRegistry;
         REGISTRY_INSTANCE_HASH = keccak256(
             abi.encode(
                 REGISTRY_SCHEMA_ID,
@@ -200,7 +218,9 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
                 config.registryPolicyHash,
                 address(feePolicyVerifier),
                 verifierRuntimeCodeHash,
-                feePolicyBindingHash
+                feePolicyBindingHash,
+                address(repositoryLineageRegistry),
+                address(repositoryLineageRegistry).codehash
             )
         );
 
@@ -211,17 +231,6 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         _grantRole(REVOKER_ROLE, config.initialRevoker);
     }
 
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(AccessControlDefaultAdminRules)
-        returns (bool)
-    {
-        return interfaceId == type(IProgrammableExactShardsRegistryV1).interfaceId
-            || super.supportsInterface(interfaceId);
-    }
-
     function authorizeApproval(IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 calldata authorization)
         external
         onlyRole(APPROVER_ROLE)
@@ -230,14 +239,19 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         _requireBinding(authorization.approvalId, bytes32("approval-id"));
         _requireBinding(authorization.launchId, bytes32("launch-id"));
         _requireBinding(authorization.approvalBindingHash, bytes32("approval-binding"));
-        _requireBinding(authorization.registrationBindingHash, bytes32("registration-binding"));
         _requireBinding(authorization.evidenceHash, bytes32("approval-evidence"));
+        // The durable GitHub approval is technical-only. The legacy registration-binding slot is
+        // deliberately equal to that technical hash until a separate just-in-time launch intent is bound.
+        if (authorization.registrationBindingHash != authorization.approvalBindingHash) {
+            revert ApprovalBindingMismatch(authorization.registrationBindingHash, authorization.approvalBindingHash);
+        }
         if (_approvalStates[authorization.approvalId].approvalBindingHash != bytes32(0)) {
             revert ApprovalAlreadyAuthorized(authorization.approvalId);
         }
         if (
             authorization.validAfterBlock == 0 || authorization.expiresAtBlock == 0
                 || authorization.validAfterBlock > authorization.expiresAtBlock
+                || authorization.expiresAtBlock != type(uint64).max
         ) {
             revert InvalidApprovalWindow(authorization.validAfterBlock, authorization.expiresAtBlock);
         }
@@ -248,7 +262,6 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
             revert EvidenceAlreadyConsumed(authorization.evidenceHash);
         }
 
-        uint64 authorizationSequence = approvalAuthorizationCount + 1;
         uint64 nextTransitionSequence = transitionCount + 1;
         _approvalStates[authorization.approvalId] = IProgrammableCustomRegistryV1.ApprovalStateV1({
             launchId: authorization.launchId,
@@ -260,7 +273,6 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
             consumed: false
         });
         transitionEvidenceConsumed[authorization.evidenceHash] = true;
-        approvalAuthorizationCount = authorizationSequence;
         transitionCount = nextTransitionSequence;
 
         emit ExactShardsApprovalAuthorizedV1(
@@ -275,10 +287,80 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         );
     }
 
+    function authorizeLaunchIntent(IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 calldata authorization)
+        external
+        onlyRole(APPROVER_ROLE)
+    {
+        _requireScope(authorization.chainId, authorization.registryGeneration);
+        _requireBinding(authorization.approvalId, bytes32("approval-id"));
+        _requireBinding(authorization.launchId, bytes32("launch-id"));
+        _requireBinding(authorization.approvalBindingHash, bytes32("approval-binding"));
+        _requireBinding(authorization.registrationBindingHash, bytes32("launch-intent-binding"));
+        _requireBinding(authorization.evidenceHash, bytes32("launch-intent-evidence"));
+
+        IProgrammableCustomRegistryV1.ApprovalStateV1 storage approval = _approvalStates[authorization.approvalId];
+        if (approval.approvalBindingHash == bytes32(0)) revert ApprovalNotAuthorized(authorization.approvalId);
+        if (approval.consumed || approvalConsumed[authorization.approvalId]) {
+            revert ApprovalAlreadyConsumed(authorization.approvalId);
+        }
+        if (authorization.launchId != approval.launchId) {
+            revert ApprovalLaunchIdMismatch(authorization.launchId, approval.launchId);
+        }
+        if (authorization.approvalBindingHash != approval.approvalBindingHash) {
+            revert ApprovalBindingMismatch(authorization.approvalBindingHash, approval.approvalBindingHash);
+        }
+        if (block.number < approval.validAfterBlock) {
+            revert ApprovalNotYetValid(approval.validAfterBlock, block.number);
+        }
+        if (
+            authorization.validAfterBlock == 0 || authorization.expiresAtBlock == 0
+                || authorization.validAfterBlock > authorization.expiresAtBlock
+        ) {
+            revert InvalidApprovalWindow(authorization.validAfterBlock, authorization.expiresAtBlock);
+        }
+        if (authorization.expiresAtBlock < block.number) {
+            revert ApprovalExpired(authorization.expiresAtBlock, block.number);
+        }
+        if (
+            uint256(authorization.expiresAtBlock) - uint256(authorization.validAfterBlock)
+                > MAX_LAUNCH_INTENT_BLOCK_WINDOW
+        ) {
+            revert LaunchIntentWindowTooLong(authorization.validAfterBlock, authorization.expiresAtBlock);
+        }
+        LaunchIntentStateV1 storage intent = _launchIntentStates[authorization.approvalId];
+        if (
+            intent.bindingHash == authorization.registrationBindingHash
+                && intent.validAfterBlock == authorization.validAfterBlock
+                && intent.expiresAtBlock == authorization.expiresAtBlock
+                && intent.evidenceHash == authorization.evidenceHash
+        ) return;
+        if (intent.bindingHash != bytes32(0) && intent.expiresAtBlock >= block.number) {
+            revert LaunchIntentAlreadyActive(authorization.approvalId, intent.expiresAtBlock);
+        }
+        if (transitionEvidenceConsumed[authorization.evidenceHash]) {
+            revert EvidenceAlreadyConsumed(authorization.evidenceHash);
+        }
+
+        uint64 nextTransitionSequence = transitionCount + 1;
+        _launchIntentStates[authorization.approvalId] = LaunchIntentStateV1({
+            bindingHash: authorization.registrationBindingHash,
+            evidenceHash: authorization.evidenceHash,
+            validAfterBlock: authorization.validAfterBlock,
+            expiresAtBlock: authorization.expiresAtBlock
+        });
+        transitionEvidenceConsumed[authorization.evidenceHash] = true;
+        transitionCount = nextTransitionSequence;
+    }
+
     function registerLaunch(LaunchRegistrationV1 calldata registration) external onlyRole(WRITER_ROLE) {
         _requireScope(registration.chainId, registration.registryGeneration);
         _requireBinding(registration.launchId, bytes32("launch-id"));
-        if (_launchStates[registration.launchId].status != IProgrammableCustomRegistryV1.LaunchStatus.None) {
+        LaunchStateV1 storage existingLaunch = _launchStates[registration.launchId];
+        if (existingLaunch.status != IProgrammableCustomRegistryV1.LaunchStatus.None) {
+            if (
+                existingLaunch.status != IProgrammableCustomRegistryV1.LaunchStatus.Revoked
+                    && registration.registeredRecordCommitment == existingLaunch.latestRecordHash
+            ) return;
             revert LaunchAlreadyRegistered(registration.launchId);
         }
 
@@ -290,22 +372,22 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         if (registration.launchId != approval.launchId) {
             revert ApprovalLaunchIdMismatch(registration.launchId, approval.launchId);
         }
-        if (block.number < approval.validAfterBlock) {
-            revert ApprovalNotYetValid(approval.validAfterBlock, block.number);
+        LaunchIntentStateV1 memory intent = _launchIntentStates[registration.approvalId];
+        if (block.number < intent.validAfterBlock) {
+            revert ApprovalNotYetValid(intent.validAfterBlock, block.number);
         }
-        if (block.number > approval.expiresAtBlock) {
-            revert ApprovalExpired(approval.expiresAtBlock, block.number);
+        if (intent.bindingHash == bytes32(0) || block.number > intent.expiresAtBlock) {
+            revert ApprovalExpired(intent.expiresAtBlock, block.number);
         }
         if (deploymentConsumed[registration.deploymentId]) revert DeploymentAlreadyConsumed(registration.deploymentId);
-
         FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
         _validateRegistration(registration, feeHashes.feePolicyRecordHash);
         if (registration.approvalBindingHash != approval.approvalBindingHash) {
             revert ApprovalBindingMismatch(registration.approvalBindingHash, approval.approvalBindingHash);
         }
         bytes32 identityHash = _identityHash(registration, feeHashes.feePolicyRecordHash);
-        if (identityHash != approval.registrationBindingHash) {
-            revert RegistrationBindingMismatch(identityHash, approval.registrationBindingHash);
+        if (identityHash != intent.bindingHash) {
+            revert RegistrationBindingMismatch(identityHash, intent.bindingHash);
         }
 
         uint64 observedAtBlock = block.number.toUint64();
@@ -516,52 +598,6 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         return _recordHashes[launchId][revision];
     }
 
-    function computeFeePolicyHash(
-        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
-        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
-    ) external view returns (bytes32) {
-        return FEE_POLICY_VERIFIER.verify(policy, orderedLegs);
-    }
-
-    function computeFeePolicyRecordHash(
-        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
-        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
-    ) external view returns (bytes32) {
-        return _verifiedFeeHashes(policy, orderedLegs).feePolicyRecordHash;
-    }
-
-    function computeApprovalBindingHash(LaunchRegistrationV1 calldata registration) external view returns (bytes32) {
-        FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
-        return _approvalBindingHash(registration, feeHashes.feePolicyRecordHash);
-    }
-
-    function computeRegistrationBindingHash(LaunchRegistrationV1 calldata registration)
-        external
-        view
-        returns (bytes32)
-    {
-        FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
-        return _identityHash(registration, feeHashes.feePolicyRecordHash);
-    }
-
-    function computeRegisteredRecordCommitment(LaunchRegistrationV1 calldata registration)
-        external
-        view
-        returns (bytes32)
-    {
-        FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
-        return _registeredRecordCommitment(registration, feeHashes.feePolicyRecordHash);
-    }
-
-    function computeReviewDeploymentBindingHash(LaunchRegistrationV1 calldata registration)
-        external
-        view
-        returns (bytes32)
-    {
-        FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
-        return _reviewDeploymentBindingHash(registration, feeHashes.feePolicyRecordHash);
-    }
-
     function _validateRegistration(LaunchRegistrationV1 calldata registration, bytes32 feePolicyRecordHash)
         private
         view
@@ -612,13 +648,16 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
     function _requireBindings(LaunchRegistrationV1 calldata registration) private pure {
         _requireBinding(registration.projectId, bytes32("project-id"));
         _requireBinding(registration.approvalId, bytes32("approval-id"));
-        _requireBinding(registration.repositoryId, bytes32("repository-id"));
+        if (registration.githubRepositoryId == 0) revert InvalidBinding(bytes32("github-repository-id"));
         _requireBinding(registration.commitId, bytes32("commit-id"));
         _requireBinding(registration.sourceCommitment, bytes32("source"));
         _requireBinding(registration.buildCommitment, bytes32("build"));
         _requireBinding(registration.artifactSetHash, bytes32("artifacts"));
         _requireBinding(registration.deploymentConfigurationHash, bytes32("deployment-config"));
         _requireBinding(registration.configurationHash, bytes32("configuration-hash"));
+        _requireBinding(registration.tokenNameHash, bytes32("token-name"));
+        _requireBinding(registration.tokenSymbolHash, bytes32("token-symbol"));
+        _requireBinding(registration.presentationBindingHash, bytes32("presentation"));
         _requireBinding(registration.permissionsHash, bytes32("permissions"));
         _requireBinding(registration.deploymentId, bytes32("deployment-id"));
         _requireBinding(registration.deploymentSetHash, bytes32("deployments"));
@@ -784,9 +823,8 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         pure
         returns (bytes32)
     {
-        return keccak256(
-            abi.encode(REVENUE_LEG_TYPEHASH, leg.roleHash, leg.feeBps, leg.recipient, leg.recipientModeHash)
-        );
+        return
+            keccak256(abi.encode(REVENUE_LEG_TYPEHASH, leg.roleHash, leg.feeBps, leg.recipient, leg.recipientModeHash));
     }
 
     function _approvalBindingHash(LaunchRegistrationV1 calldata registration, bytes32 feePolicyRecordHash)
@@ -794,37 +832,28 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         view
         returns (bytes32)
     {
-        bytes32 sourceHash = keccak256(
+        // Durable GitHub approval binds reviewed technical material only. Deployment choices, wallet,
+        // token name/symbol and Website presentation are bound later by the one-use launch-intent hash.
+        bytes32 reviewedSourceHash = keccak256(
             abi.encode(
-                registration.repositoryId,
+                registration.githubRepositoryId,
+                _repositoryKey(registration.githubRepositoryId),
                 registration.commitId,
                 registration.sourceCommitment,
                 registration.buildCommitment,
-                registration.artifactSetHash,
-                registration.deploymentConfigurationHash,
-                registration.configurationHash,
-                registration.permissionsHash
+                registration.artifactSetHash
             )
         );
-        bytes32 deploymentExpectationHash = keccak256(
-            abi.encode(
-                registration.deploymentId,
-                registration.deploymentSetHash,
-                registration.runtimeCodeSetHash,
-                registration.primaryContract,
-                registration.primaryRuntimeCodeHash
-            )
-        );
-        bytes32 attributionHash = keccak256(
+        bytes32 reviewedModelHash = keccak256(
             abi.encode(
                 registration.modelId,
                 registration.modelVersion,
                 registration.templateId,
                 registration.templateVersion,
                 registration.providerId,
-                registration.builderAttributionHash,
-                registration.originHash,
-                registration.marketPathId
+                registration.permissionsHash,
+                registration.marketPathId,
+                registration.capabilitySetHash
             )
         );
         bytes32 scopeHash = keccak256(
@@ -837,17 +866,22 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
                 registration.approvalId
             )
         );
-        bytes32 controlHash =
-            keccak256(abi.encode(registration.launchWallet, feePolicyRecordHash, registration.reviewPolicyHash));
+        bytes32 reviewedSecurityAndEconomicsHash = keccak256(
+            abi.encode(
+                registration.reviewPolicyHash,
+                registration.securityReviewHash,
+                registration.reviewResultId,
+                feePolicyRecordHash
+            )
+        );
         return keccak256(
             abi.encode(
                 APPROVAL_BINDING_DOMAIN,
                 REGISTRY_INSTANCE_HASH,
                 scopeHash,
-                sourceHash,
-                deploymentExpectationHash,
-                attributionHash,
-                controlHash
+                reviewedSourceHash,
+                reviewedModelHash,
+                reviewedSecurityAndEconomicsHash
             )
         );
     }
@@ -900,28 +934,41 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
                 _sourceAndDeploymentHash(registration),
                 _attributionHash(registration),
                 _reviewHash(registration),
+                _launchMetadataBindingHash(registration),
                 feePolicyRecordHash,
                 registration.finalityPolicyHash
             )
         );
     }
 
+    function _launchMetadataBindingHash(LaunchRegistrationV1 calldata registration) private pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                LAUNCH_METADATA_BINDING_DOMAIN,
+                registration.tokenNameHash,
+                registration.tokenSymbolHash,
+                registration.presentationBindingHash
+            )
+        );
+    }
+
     function _sourceAndDeploymentHash(LaunchRegistrationV1 calldata registration) private pure returns (bytes32) {
-        bytes32[14] memory words;
-        words[0] = registration.repositoryId;
-        words[1] = registration.commitId;
-        words[2] = registration.sourceCommitment;
-        words[3] = registration.buildCommitment;
-        words[4] = registration.artifactSetHash;
-        words[5] = registration.deploymentConfigurationHash;
-        words[6] = registration.configurationHash;
-        words[7] = registration.permissionsHash;
-        words[8] = registration.deploymentId;
-        words[9] = registration.deploymentSetHash;
-        words[10] = registration.runtimeCodeSetHash;
-        words[11] = bytes32(uint256(uint160(registration.primaryContract)));
-        words[12] = registration.primaryRuntimeCodeHash;
-        words[13] = bytes32(uint256(uint160(registration.launchWallet)));
+        bytes32[15] memory words;
+        words[0] = bytes32(uint256(registration.githubRepositoryId));
+        words[1] = _repositoryKey(registration.githubRepositoryId);
+        words[2] = registration.commitId;
+        words[3] = registration.sourceCommitment;
+        words[4] = registration.buildCommitment;
+        words[5] = registration.artifactSetHash;
+        words[6] = registration.deploymentConfigurationHash;
+        words[7] = registration.configurationHash;
+        words[8] = registration.permissionsHash;
+        words[9] = registration.deploymentId;
+        words[10] = registration.deploymentSetHash;
+        words[11] = registration.runtimeCodeSetHash;
+        words[12] = bytes32(uint256(uint160(registration.primaryContract)));
+        words[13] = registration.primaryRuntimeCodeHash;
+        words[14] = bytes32(uint256(uint160(registration.launchWallet)));
         return keccak256(abi.encode(words));
     }
 
@@ -977,6 +1024,10 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
         if (chainId != CHAIN_ID || registryGeneration != REGISTRY_GENERATION) {
             revert RegistryScopeMismatch(chainId, registryGeneration);
         }
+    }
+
+    function _repositoryKey(uint64 githubRepositoryId) private pure returns (bytes32) {
+        return keccak256(abi.encode("programmable.github.repository.v1", uint256(githubRepositoryId)));
     }
 
     function _requireCanonicalHistoricalBlock(uint64 blockNumber, bytes32 suppliedBlockHash) private view {

--- a/contracts/src/ProgrammableExactShardsRegistryV1.sol
+++ b/contracts/src/ProgrammableExactShardsRegistryV1.sol
@@ -1,0 +1,1009 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {
+    AccessControlDefaultAdminRules
+} from "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import { ProgrammableExactShardsFeePolicyVerifierV1 } from "./ProgrammableExactShardsFeePolicyVerifierV1.sol";
+import { IProgrammableCustomRegistryV1 } from "./interfaces/IProgrammableCustomRegistryV1.sol";
+import {
+    IProgrammableExactShardsFeePolicyVerifierV1
+} from "./interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol";
+import { IProgrammableExactShardsRegistryV1 } from "./interfaces/IProgrammableExactShardsRegistryV1.sol";
+
+/// @title ProgrammableExactShardsRegistryV1
+/// @notice Native append-only Registry successor for the reviewed Shards three-claim policy.
+/// @dev Reuses the Registry V1 approval, finality, correction and revocation primitives while replacing its
+///      structurally insufficient two-leg fee record. This contract never deploys or activates Shards.
+contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IProgrammableExactShardsRegistryV1 {
+    using SafeCast for uint256;
+
+    struct RegistryConfigV1 {
+        uint48 initialAdminDelay;
+        address initialAdmin;
+        address initialApprover;
+        address initialWriter;
+        address initialFinalizer;
+        address initialCorrector;
+        address initialRevoker;
+        uint64 registryGeneration;
+        uint64 minimumFinalityBlocks;
+        bytes32 chainProfileHash;
+        bytes32 registryPolicyHash;
+    }
+
+    struct FeeHashesV1 {
+        bytes32 policyHash;
+        bytes32 claimSetHash;
+        bytes32 feePolicyRecordHash;
+    }
+
+    bytes32 public constant REGISTRY_SCHEMA_ID = keccak256("programmable.exact-shards-registry.v1");
+    bytes32 internal constant APPROVAL_BINDING_DOMAIN = keccak256("programmable.exact-shards-approval-binding.v1");
+    bytes32 internal constant REVIEW_DEPLOYMENT_BINDING_DOMAIN =
+        keccak256("programmable.exact-shards-review-deployment-binding.v1");
+    bytes32 internal constant IDENTITY_DOMAIN = keccak256("programmable.exact-shards-launch-identity.v1");
+    bytes32 internal constant REGISTERED_RECORD_COMMITMENT_DOMAIN =
+        keccak256("programmable.exact-shards-registered-record.v1");
+    bytes32 internal constant STORED_CLAIM_TYPEHASH = keccak256(
+        "ProgrammableExactShardsStoredFeeClaimV1(uint8 ordinal,bytes32 roleHash,uint16 grossVolumeFeeBps,uint16 shareOfFeeBps,address initialRecipientOrAccumulator,bytes32 recipientModeHash,bytes4 claimSelector,bytes4 handoffSelector,bytes32 legHash)"
+    );
+    bytes32 internal constant FEE_POLICY_RECORD_DOMAIN = keccak256("programmable.exact-shards-fee-policy-record.v1");
+
+    bytes32 public constant APPROVER_ROLE = keccak256("programmable.custom-registry.approver.v1");
+    bytes32 public constant WRITER_ROLE = keccak256("programmable.custom-registry.writer.v1");
+    bytes32 public constant FINALIZER_ROLE = keccak256("programmable.custom-registry.finalizer.v1");
+    bytes32 public constant CORRECTOR_ROLE = keccak256("programmable.custom-registry.corrector.v1");
+    bytes32 public constant REVOKER_ROLE = keccak256("programmable.custom-registry.revoker.v1");
+
+    bytes32 public constant EXPECTED_FEE_POLICY_BINDING_HASH =
+        0x5d5d1c46e7627f6e171a18acdbecbfe9e40eca80016fba0142ddca6a054f6169;
+    bytes32 public constant EXPECTED_VERIFIER_RUNTIME_CODE_HASH =
+        0xb4af3325444133062ec8382bc29c551ef87e812cbf269712a45ef6ec64db20c0;
+    bytes32 internal constant EXPECTED_SOURCE_REVISION_HASH =
+        0x3352fe14662ce467e98f475cf91f10304ce4d69b6342fae4bf3dc968c494d6dc;
+    bytes32 internal constant EXPECTED_ROUTE_ARTIFACT_SHA256 =
+        0x066475058bfd47b85b4216f95b434756d67d7e289ffb36535c121ef5d7c11bab;
+    bytes32 internal constant EXPECTED_PROFILE_KEY = 0xb90e215e0e29c0dacf021e5e778847af4100433ee7d22014b73f8ca4add09d0c;
+    bytes32 internal constant REVENUE_LEG_TYPEHASH = keccak256(
+        "ProgrammableRevenueLegV1(bytes32 roleHash,uint16 feeBps,address recipient,bytes32 recipientModeHash)"
+    );
+
+    bytes4 internal constant HOLDER_CLAIM_SELECTOR = bytes4(keccak256("claim(uint256[])"));
+    bytes4 internal constant BUILDER_CLAIM_SELECTOR = bytes4(keccak256("claimBuilderFees()"));
+    bytes4 internal constant PROGRAMMABLE_CLAIM_SELECTOR = bytes4(keccak256("claimLauncherFees()"));
+    bytes4 internal constant BUILDER_HANDOFF_SELECTOR = bytes4(keccak256("setBuilderFeeRecipient(address)"));
+
+    uint16 internal constant BUILDER_SHARE_OF_FEE_BPS = 1000;
+    uint16 internal constant PROGRAMMABLE_SHARE_OF_FEE_BPS = 1000;
+    uint16 internal constant HOLDER_SHARE_OF_FEE_BPS = 8000;
+    uint8 internal constant FEE_CLAIM_COUNT = 3;
+
+    // Immutable manifest fields intentionally use the same uppercase convention as Registry V1.
+    // slither-disable-next-line naming-convention
+    uint256 public immutable CHAIN_ID;
+    // slither-disable-next-line naming-convention
+    uint64 public immutable REGISTRY_GENERATION;
+    // slither-disable-next-line naming-convention
+    uint64 public immutable MINIMUM_FINALITY_BLOCKS;
+    // slither-disable-next-line naming-convention
+    bytes32 public immutable CHAIN_PROFILE_HASH;
+    // slither-disable-next-line naming-convention
+    bytes32 public immutable REGISTRY_POLICY_HASH;
+    // slither-disable-next-line naming-convention
+    bytes32 public immutable REGISTRY_INSTANCE_HASH;
+    // slither-disable-next-line naming-convention
+    bytes32 public immutable VERIFIER_RUNTIME_CODE_HASH;
+    // slither-disable-next-line naming-convention
+    bytes32 public immutable FEE_POLICY_BINDING_HASH;
+    ProgrammableExactShardsFeePolicyVerifierV1 public immutable FEE_POLICY_VERIFIER;
+
+    uint64 public registrationCount;
+    uint64 public approvalAuthorizationCount;
+    uint64 public transitionCount;
+
+    mapping(bytes32 launchId => LaunchStateV1 state) private _launchStates;
+    mapping(bytes32 launchId => IProgrammableCustomRegistryV1.LaunchDetailsV1 details) private _launchDetails;
+    mapping(bytes32 launchId => StoredFeePolicyV1 policy) private _feePolicies;
+    mapping(bytes32 launchId => mapping(uint8 ordinal => StoredFeeClaimV1 claim)) private _feeClaims;
+    mapping(bytes32 launchId => mapping(uint64 revision => bytes32 recordHash)) private _recordHashes;
+    mapping(bytes32 approvalId => IProgrammableCustomRegistryV1.ApprovalStateV1 state) private _approvalStates;
+    mapping(bytes32 approvalId => bool consumed) public approvalConsumed;
+    mapping(bytes32 deploymentId => bool consumed) public deploymentConsumed;
+    mapping(bytes32 evidenceHash => bool consumed) public transitionEvidenceConsumed;
+
+    error ApprovalAlreadyAuthorized(bytes32 approvalId);
+    error ApprovalAlreadyConsumed(bytes32 approvalId);
+    error ApprovalBindingMismatch(bytes32 supplied, bytes32 expected);
+    error ApprovalExpired(uint64 expiresAtBlock, uint256 currentBlock);
+    error ApprovalLaunchIdMismatch(bytes32 supplied, bytes32 authorized);
+    error ApprovalNotAuthorized(bytes32 approvalId);
+    error ApprovalNotYetValid(uint64 validAfterBlock, uint256 currentBlock);
+    error BlockHashMismatch(uint64 blockNumber, bytes32 supplied, bytes32 canonical);
+    error DeploymentAlreadyConsumed(bytes32 deploymentId);
+    error EvidenceAlreadyConsumed(bytes32 evidenceHash);
+    error FinalityDepthInsufficient(uint64 observedBlock, uint64 confirmedHeadBlock, uint64 minimumBlocks);
+    error HistoricalBlockOutsideNativeWindow(uint64 blockNumber, uint256 currentBlock);
+    error IncompatibleOperationalRoles(address account);
+    error InvalidBinding(bytes32 field);
+    error InvalidApprovalWindow(uint64 validAfterBlock, uint64 expiresAtBlock);
+    error InvalidFeeClaimIndex(uint8 ordinal);
+    error InvalidLaunchState(
+        bytes32 launchId,
+        IProgrammableCustomRegistryV1.LaunchStatus supplied,
+        IProgrammableCustomRegistryV1.LaunchStatus required
+    );
+    error InvalidObservedTransactionHash();
+    error LaunchAlreadyRegistered(bytes32 launchId);
+    error NoncanonicalBlock(uint64 blockNumber, uint256 currentBlock);
+    error PairMismatch(bytes32 idField, bytes32 versionField);
+    error PrimaryContractHasNoCode(address primaryContract);
+    error RecordHashUnchanged(bytes32 recordHash);
+    error RecordRevisionMismatch(uint64 supplied, uint64 expected);
+    error RegisteredRecordCommitmentMismatch(bytes32 supplied, bytes32 expected);
+    error RegistrationBindingMismatch(bytes32 supplied, bytes32 authorized);
+    error RegistryConfigurationInvalid(bytes32 field);
+    error RegistryScopeMismatch(uint256 suppliedChainId, uint64 suppliedGeneration);
+    error ReviewDeploymentBindingMismatch(bytes32 supplied, bytes32 expected);
+    error RuntimeCodeHashMismatch(address target, bytes32 supplied, bytes32 actual);
+
+    constructor(RegistryConfigV1 memory config, ProgrammableExactShardsFeePolicyVerifierV1 feePolicyVerifier)
+        AccessControlDefaultAdminRules(config.initialAdminDelay, config.initialAdmin)
+    {
+        if (config.initialApprover == address(0)) revert RegistryConfigurationInvalid(bytes32("approver"));
+        if (config.initialWriter == address(0)) revert RegistryConfigurationInvalid(bytes32("writer"));
+        if (config.initialApprover == config.initialWriter) {
+            revert IncompatibleOperationalRoles(config.initialApprover);
+        }
+        if (config.initialFinalizer == address(0)) revert RegistryConfigurationInvalid(bytes32("finalizer"));
+        if (config.initialCorrector == address(0)) revert RegistryConfigurationInvalid(bytes32("corrector"));
+        if (config.initialRevoker == address(0)) revert RegistryConfigurationInvalid(bytes32("revoker"));
+        if (config.registryGeneration == 0) revert RegistryConfigurationInvalid(bytes32("generation"));
+        if (config.minimumFinalityBlocks == 0 || config.minimumFinalityBlocks > 255) {
+            revert RegistryConfigurationInvalid(bytes32("finality-blocks"));
+        }
+        if (config.chainProfileHash == bytes32(0)) revert RegistryConfigurationInvalid(bytes32("chain-profile"));
+        if (config.registryPolicyHash == bytes32(0)) revert RegistryConfigurationInvalid(bytes32("registry-policy"));
+        if (address(feePolicyVerifier) == address(0) || address(feePolicyVerifier).code.length == 0) {
+            revert RegistryConfigurationInvalid(bytes32("fee-policy-verifier"));
+        }
+
+        bytes32 verifierRuntimeCodeHash = address(feePolicyVerifier).codehash;
+        if (verifierRuntimeCodeHash != EXPECTED_VERIFIER_RUNTIME_CODE_HASH) {
+            revert RuntimeCodeHashMismatch(
+                address(feePolicyVerifier), EXPECTED_VERIFIER_RUNTIME_CODE_HASH, verifierRuntimeCodeHash
+            );
+        }
+        bytes32 feePolicyBindingHash = feePolicyVerifier.feePolicyBindingHashV1();
+        if (feePolicyBindingHash != EXPECTED_FEE_POLICY_BINDING_HASH) {
+            revert RegistryConfigurationInvalid(bytes32("fee-policy-binding"));
+        }
+
+        CHAIN_ID = block.chainid;
+        REGISTRY_GENERATION = config.registryGeneration;
+        MINIMUM_FINALITY_BLOCKS = config.minimumFinalityBlocks;
+        CHAIN_PROFILE_HASH = config.chainProfileHash;
+        REGISTRY_POLICY_HASH = config.registryPolicyHash;
+        VERIFIER_RUNTIME_CODE_HASH = verifierRuntimeCodeHash;
+        FEE_POLICY_BINDING_HASH = feePolicyBindingHash;
+        FEE_POLICY_VERIFIER = feePolicyVerifier;
+        REGISTRY_INSTANCE_HASH = keccak256(
+            abi.encode(
+                REGISTRY_SCHEMA_ID,
+                block.chainid,
+                config.registryGeneration,
+                address(this),
+                config.chainProfileHash,
+                config.registryPolicyHash,
+                address(feePolicyVerifier),
+                verifierRuntimeCodeHash,
+                feePolicyBindingHash
+            )
+        );
+
+        _grantRole(APPROVER_ROLE, config.initialApprover);
+        _grantRole(WRITER_ROLE, config.initialWriter);
+        _grantRole(FINALIZER_ROLE, config.initialFinalizer);
+        _grantRole(CORRECTOR_ROLE, config.initialCorrector);
+        _grantRole(REVOKER_ROLE, config.initialRevoker);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(AccessControlDefaultAdminRules)
+        returns (bool)
+    {
+        return interfaceId == type(IProgrammableExactShardsRegistryV1).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
+    function authorizeApproval(IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 calldata authorization)
+        external
+        onlyRole(APPROVER_ROLE)
+    {
+        _requireScope(authorization.chainId, authorization.registryGeneration);
+        _requireBinding(authorization.approvalId, bytes32("approval-id"));
+        _requireBinding(authorization.launchId, bytes32("launch-id"));
+        _requireBinding(authorization.approvalBindingHash, bytes32("approval-binding"));
+        _requireBinding(authorization.registrationBindingHash, bytes32("registration-binding"));
+        _requireBinding(authorization.evidenceHash, bytes32("approval-evidence"));
+        if (_approvalStates[authorization.approvalId].approvalBindingHash != bytes32(0)) {
+            revert ApprovalAlreadyAuthorized(authorization.approvalId);
+        }
+        if (
+            authorization.validAfterBlock == 0 || authorization.expiresAtBlock == 0
+                || authorization.validAfterBlock > authorization.expiresAtBlock
+        ) {
+            revert InvalidApprovalWindow(authorization.validAfterBlock, authorization.expiresAtBlock);
+        }
+        if (authorization.expiresAtBlock < block.number) {
+            revert ApprovalExpired(authorization.expiresAtBlock, block.number);
+        }
+        if (transitionEvidenceConsumed[authorization.evidenceHash]) {
+            revert EvidenceAlreadyConsumed(authorization.evidenceHash);
+        }
+
+        uint64 authorizationSequence = approvalAuthorizationCount + 1;
+        uint64 nextTransitionSequence = transitionCount + 1;
+        _approvalStates[authorization.approvalId] = IProgrammableCustomRegistryV1.ApprovalStateV1({
+            launchId: authorization.launchId,
+            approvalBindingHash: authorization.approvalBindingHash,
+            registrationBindingHash: authorization.registrationBindingHash,
+            validAfterBlock: authorization.validAfterBlock,
+            expiresAtBlock: authorization.expiresAtBlock,
+            evidenceHash: authorization.evidenceHash,
+            consumed: false
+        });
+        transitionEvidenceConsumed[authorization.evidenceHash] = true;
+        approvalAuthorizationCount = authorizationSequence;
+        transitionCount = nextTransitionSequence;
+
+        emit ExactShardsApprovalAuthorizedV1(
+            authorization.approvalId,
+            authorization.launchId,
+            authorization.approvalBindingHash,
+            authorization.registrationBindingHash,
+            nextTransitionSequence,
+            authorization.validAfterBlock,
+            authorization.expiresAtBlock,
+            authorization.evidenceHash
+        );
+    }
+
+    function registerLaunch(LaunchRegistrationV1 calldata registration) external onlyRole(WRITER_ROLE) {
+        _requireScope(registration.chainId, registration.registryGeneration);
+        _requireBinding(registration.launchId, bytes32("launch-id"));
+        if (_launchStates[registration.launchId].status != IProgrammableCustomRegistryV1.LaunchStatus.None) {
+            revert LaunchAlreadyRegistered(registration.launchId);
+        }
+
+        IProgrammableCustomRegistryV1.ApprovalStateV1 storage approval = _approvalStates[registration.approvalId];
+        if (approval.approvalBindingHash == bytes32(0)) revert ApprovalNotAuthorized(registration.approvalId);
+        if (approval.consumed || approvalConsumed[registration.approvalId]) {
+            revert ApprovalAlreadyConsumed(registration.approvalId);
+        }
+        if (registration.launchId != approval.launchId) {
+            revert ApprovalLaunchIdMismatch(registration.launchId, approval.launchId);
+        }
+        if (block.number < approval.validAfterBlock) {
+            revert ApprovalNotYetValid(approval.validAfterBlock, block.number);
+        }
+        if (block.number > approval.expiresAtBlock) {
+            revert ApprovalExpired(approval.expiresAtBlock, block.number);
+        }
+        if (deploymentConsumed[registration.deploymentId]) revert DeploymentAlreadyConsumed(registration.deploymentId);
+
+        FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
+        _validateRegistration(registration, feeHashes.feePolicyRecordHash);
+        if (registration.approvalBindingHash != approval.approvalBindingHash) {
+            revert ApprovalBindingMismatch(registration.approvalBindingHash, approval.approvalBindingHash);
+        }
+        bytes32 identityHash = _identityHash(registration, feeHashes.feePolicyRecordHash);
+        if (identityHash != approval.registrationBindingHash) {
+            revert RegistrationBindingMismatch(identityHash, approval.registrationBindingHash);
+        }
+
+        uint64 observedAtBlock = block.number.toUint64();
+        uint64 registrationSequence = registrationCount + 1;
+        uint64 nextTransitionSequence = transitionCount + 1;
+        approval.consumed = true;
+        approvalConsumed[registration.approvalId] = true;
+        deploymentConsumed[registration.deploymentId] = true;
+        registrationCount = registrationSequence;
+        transitionCount = nextTransitionSequence;
+
+        _launchStates[registration.launchId] = LaunchStateV1({
+            status: IProgrammableCustomRegistryV1.LaunchStatus.Observed,
+            observedAtBlock: observedAtBlock,
+            finalizedAtBlock: 0,
+            latestRecordRevision: 1,
+            latestRecordHash: registration.registeredRecordCommitment,
+            identityHash: identityHash,
+            feePolicyHash: feeHashes.policyHash,
+            feePolicyRecordHash: feeHashes.feePolicyRecordHash,
+            finalityEvidenceHash: bytes32(0)
+        });
+        _launchDetails[registration.launchId] = IProgrammableCustomRegistryV1.LaunchDetailsV1({
+            projectId: registration.projectId,
+            approvalId: registration.approvalId,
+            approvalBindingHash: registration.approvalBindingHash,
+            deploymentId: registration.deploymentId,
+            deploymentSetHash: registration.deploymentSetHash,
+            runtimeCodeSetHash: registration.runtimeCodeSetHash,
+            primaryContract: registration.primaryContract,
+            primaryRuntimeCodeHash: registration.primaryRuntimeCodeHash,
+            launchWallet: registration.launchWallet,
+            modelId: registration.modelId,
+            modelVersion: registration.modelVersion,
+            templateId: registration.templateId,
+            templateVersion: registration.templateVersion,
+            providerId: registration.providerId,
+            configurationHash: registration.configurationHash,
+            permissionsHash: registration.permissionsHash,
+            marketPathId: registration.marketPathId,
+            reviewPolicyHash: registration.reviewPolicyHash,
+            securityReviewHash: registration.securityReviewHash,
+            reviewResultId: registration.reviewResultId,
+            reviewDeploymentBindingHash: registration.reviewDeploymentBindingHash,
+            finalityPolicyHash: registration.finalityPolicyHash
+        });
+        _recordHashes[registration.launchId][1] = registration.registeredRecordCommitment;
+        _storeFeePolicy(registration, feeHashes);
+        _emitLaunchRegistered(registration, feeHashes, registrationSequence, identityHash, observedAtBlock);
+    }
+
+    function finalizeLaunch(IProgrammableCustomRegistryV1.FinalityProofV1 calldata proof)
+        external
+        onlyRole(FINALIZER_ROLE)
+    {
+        _requireScope(proof.chainId, proof.registryGeneration);
+        LaunchStateV1 storage state = _launchStates[proof.launchId];
+        if (state.status != IProgrammableCustomRegistryV1.LaunchStatus.Observed) {
+            revert InvalidLaunchState(proof.launchId, state.status, IProgrammableCustomRegistryV1.LaunchStatus.Observed);
+        }
+        if (proof.observedBlockNumber != state.observedAtBlock) {
+            revert NoncanonicalBlock(proof.observedBlockNumber, state.observedAtBlock);
+        }
+        if (proof.observedTransactionHash == bytes32(0)) revert InvalidObservedTransactionHash();
+        if (proof.finalityPolicyHash != _launchDetails[proof.launchId].finalityPolicyHash) {
+            revert InvalidBinding(bytes32("finality-policy"));
+        }
+        _requireBinding(proof.finalityEvidenceHash, bytes32("finality-evidence"));
+        if (transitionEvidenceConsumed[proof.finalityEvidenceHash]) {
+            revert EvidenceAlreadyConsumed(proof.finalityEvidenceHash);
+        }
+        if (uint256(proof.confirmedHeadBlockNumber) < uint256(proof.observedBlockNumber) + MINIMUM_FINALITY_BLOCKS) {
+            revert FinalityDepthInsufficient(
+                proof.observedBlockNumber, proof.confirmedHeadBlockNumber, MINIMUM_FINALITY_BLOCKS
+            );
+        }
+        _requireCanonicalHistoricalBlock(proof.observedBlockNumber, proof.observedBlockHash);
+        _requireCanonicalHistoricalBlock(proof.confirmedHeadBlockNumber, proof.confirmedHeadBlockHash);
+
+        uint64 nextTransitionSequence = transitionCount + 1;
+        uint64 finalizedAtBlock = block.number.toUint64();
+        state.status = IProgrammableCustomRegistryV1.LaunchStatus.Finalized;
+        state.finalizedAtBlock = finalizedAtBlock;
+        state.finalityEvidenceHash = proof.finalityEvidenceHash;
+        transitionEvidenceConsumed[proof.finalityEvidenceHash] = true;
+        transitionCount = nextTransitionSequence;
+
+        emit ExactShardsLaunchFinalizedV1(
+            proof.launchId,
+            proof.observedTransactionHash,
+            proof.finalityEvidenceHash,
+            nextTransitionSequence,
+            proof.observedBlockNumber,
+            proof.observedBlockHash,
+            proof.observedTransactionIndex,
+            proof.observedLogIndex,
+            proof.confirmedHeadBlockNumber,
+            proof.confirmedHeadBlockHash,
+            proof.finalityPolicyHash,
+            finalizedAtBlock,
+            block.timestamp.toUint64()
+        );
+    }
+
+    function correctLaunchRecord(IProgrammableCustomRegistryV1.RecordCorrectionV1 calldata correction)
+        external
+        onlyRole(CORRECTOR_ROLE)
+    {
+        _requireScope(correction.chainId, correction.registryGeneration);
+        LaunchStateV1 storage state = _launchStates[correction.launchId];
+        if (state.status != IProgrammableCustomRegistryV1.LaunchStatus.Finalized) {
+            revert InvalidLaunchState(
+                correction.launchId, state.status, IProgrammableCustomRegistryV1.LaunchStatus.Finalized
+            );
+        }
+        uint64 expectedRevision = state.latestRecordRevision + 1;
+        if (correction.revision != expectedRevision) {
+            revert RecordRevisionMismatch(correction.revision, expectedRevision);
+        }
+        if (correction.previousRecordHash != state.latestRecordHash) {
+            revert InvalidBinding(bytes32("previous-record"));
+        }
+        _requireBinding(correction.correctedRecordHash, bytes32("corrected-record"));
+        if (correction.correctedRecordHash == correction.previousRecordHash) {
+            revert RecordHashUnchanged(correction.correctedRecordHash);
+        }
+        _consumeTransitionEvidence(correction.reasonCode, correction.evidenceHash);
+
+        uint64 nextTransitionSequence = transitionCount + 1;
+        state.latestRecordRevision = correction.revision;
+        state.latestRecordHash = correction.correctedRecordHash;
+        _recordHashes[correction.launchId][correction.revision] = correction.correctedRecordHash;
+        transitionCount = nextTransitionSequence;
+
+        emit ExactShardsLaunchRecordCorrectedV1(
+            correction.launchId,
+            correction.revision,
+            correction.correctedRecordHash,
+            nextTransitionSequence,
+            correction.previousRecordHash,
+            correction.reasonCode,
+            correction.evidenceHash
+        );
+    }
+
+    function revokeLaunch(IProgrammableCustomRegistryV1.LaunchRevocationV1 calldata revocation)
+        external
+        onlyRole(REVOKER_ROLE)
+    {
+        _requireScope(revocation.chainId, revocation.registryGeneration);
+        LaunchStateV1 storage state = _launchStates[revocation.launchId];
+        if (
+            state.status != IProgrammableCustomRegistryV1.LaunchStatus.Observed
+                && state.status != IProgrammableCustomRegistryV1.LaunchStatus.Finalized
+        ) {
+            revert InvalidLaunchState(
+                revocation.launchId, state.status, IProgrammableCustomRegistryV1.LaunchStatus.Finalized
+            );
+        }
+        _consumeTransitionEvidence(revocation.reasonCode, revocation.evidenceHash);
+
+        uint64 nextTransitionSequence = transitionCount + 1;
+        state.status = IProgrammableCustomRegistryV1.LaunchStatus.Revoked;
+        transitionCount = nextTransitionSequence;
+
+        emit ExactShardsLaunchRevokedV1(
+            revocation.launchId,
+            revocation.reasonCode,
+            revocation.evidenceHash,
+            nextTransitionSequence,
+            state.latestRecordRevision,
+            state.latestRecordHash,
+            block.number.toUint64(),
+            block.timestamp.toUint64()
+        );
+    }
+
+    function launchState(bytes32 launchId) external view returns (LaunchStateV1 memory) {
+        return _launchStates[launchId];
+    }
+
+    function launchDetails(bytes32 launchId)
+        external
+        view
+        returns (IProgrammableCustomRegistryV1.LaunchDetailsV1 memory)
+    {
+        return _launchDetails[launchId];
+    }
+
+    function approvalState(bytes32 approvalId)
+        external
+        view
+        returns (IProgrammableCustomRegistryV1.ApprovalStateV1 memory)
+    {
+        return _approvalStates[approvalId];
+    }
+
+    function feePolicyState(bytes32 launchId) external view returns (StoredFeePolicyV1 memory) {
+        return _feePolicies[launchId];
+    }
+
+    function feeClaim(bytes32 launchId, uint8 ordinal) external view returns (StoredFeeClaimV1 memory) {
+        if (ordinal >= FEE_CLAIM_COUNT) revert InvalidFeeClaimIndex(ordinal);
+        return _feeClaims[launchId][ordinal];
+    }
+
+    function recordHashAtRevision(bytes32 launchId, uint64 revision) external view returns (bytes32) {
+        return _recordHashes[launchId][revision];
+    }
+
+    function computeFeePolicyHash(
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
+    ) external view returns (bytes32) {
+        return FEE_POLICY_VERIFIER.verify(policy, orderedLegs);
+    }
+
+    function computeFeePolicyRecordHash(
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
+    ) external view returns (bytes32) {
+        return _verifiedFeeHashes(policy, orderedLegs).feePolicyRecordHash;
+    }
+
+    function computeApprovalBindingHash(LaunchRegistrationV1 calldata registration) external view returns (bytes32) {
+        FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
+        return _approvalBindingHash(registration, feeHashes.feePolicyRecordHash);
+    }
+
+    function computeRegistrationBindingHash(LaunchRegistrationV1 calldata registration)
+        external
+        view
+        returns (bytes32)
+    {
+        FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
+        return _identityHash(registration, feeHashes.feePolicyRecordHash);
+    }
+
+    function computeRegisteredRecordCommitment(LaunchRegistrationV1 calldata registration)
+        external
+        view
+        returns (bytes32)
+    {
+        FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
+        return _registeredRecordCommitment(registration, feeHashes.feePolicyRecordHash);
+    }
+
+    function computeReviewDeploymentBindingHash(LaunchRegistrationV1 calldata registration)
+        external
+        view
+        returns (bytes32)
+    {
+        FeeHashesV1 memory feeHashes = _verifiedFeeHashes(registration.feePolicy, registration.orderedFeeLegs);
+        return _reviewDeploymentBindingHash(registration, feeHashes.feePolicyRecordHash);
+    }
+
+    function _validateRegistration(LaunchRegistrationV1 calldata registration, bytes32 feePolicyRecordHash)
+        private
+        view
+    {
+        _requireBindings(registration);
+        _validatePair(registration.modelId, registration.modelVersion, bytes32("model-id"), bytes32("model-version"));
+        _validatePair(
+            registration.templateId, registration.templateVersion, bytes32("template-id"), bytes32("template-version")
+        );
+        if (registration.sourceCommitment != EXPECTED_SOURCE_REVISION_HASH) {
+            revert InvalidBinding(bytes32("reviewed-source"));
+        }
+        if (registration.buildCommitment != EXPECTED_ROUTE_ARTIFACT_SHA256) {
+            revert InvalidBinding(bytes32("reviewed-route"));
+        }
+        if (
+            registration.marketPathId != EXPECTED_PROFILE_KEY
+                || registration.marketPathId != registration.feePolicy.profileKey
+        ) {
+            revert InvalidBinding(bytes32("market-profile"));
+        }
+        if (registration.providerId != bytes32(0)) revert InvalidBinding(bytes32("provider-id"));
+        if (registration.launchWallet == address(0)) revert InvalidBinding(bytes32("launch-wallet"));
+        if (registration.primaryContract.code.length == 0) {
+            revert PrimaryContractHasNoCode(registration.primaryContract);
+        }
+        bytes32 actualRuntimeCodeHash = registration.primaryContract.codehash;
+        if (actualRuntimeCodeHash != registration.primaryRuntimeCodeHash) {
+            revert RuntimeCodeHashMismatch(
+                registration.primaryContract, registration.primaryRuntimeCodeHash, actualRuntimeCodeHash
+            );
+        }
+
+        bytes32 expectedApprovalBindingHash = _approvalBindingHash(registration, feePolicyRecordHash);
+        if (registration.approvalBindingHash != expectedApprovalBindingHash) {
+            revert ApprovalBindingMismatch(registration.approvalBindingHash, expectedApprovalBindingHash);
+        }
+        bytes32 expectedReviewBindingHash = _reviewDeploymentBindingHash(registration, feePolicyRecordHash);
+        if (registration.reviewDeploymentBindingHash != expectedReviewBindingHash) {
+            revert ReviewDeploymentBindingMismatch(registration.reviewDeploymentBindingHash, expectedReviewBindingHash);
+        }
+        bytes32 expectedRecordCommitment = _registeredRecordCommitment(registration, feePolicyRecordHash);
+        if (registration.registeredRecordCommitment != expectedRecordCommitment) {
+            revert RegisteredRecordCommitmentMismatch(registration.registeredRecordCommitment, expectedRecordCommitment);
+        }
+    }
+
+    function _requireBindings(LaunchRegistrationV1 calldata registration) private pure {
+        _requireBinding(registration.projectId, bytes32("project-id"));
+        _requireBinding(registration.approvalId, bytes32("approval-id"));
+        _requireBinding(registration.repositoryId, bytes32("repository-id"));
+        _requireBinding(registration.commitId, bytes32("commit-id"));
+        _requireBinding(registration.sourceCommitment, bytes32("source"));
+        _requireBinding(registration.buildCommitment, bytes32("build"));
+        _requireBinding(registration.artifactSetHash, bytes32("artifacts"));
+        _requireBinding(registration.deploymentConfigurationHash, bytes32("deployment-config"));
+        _requireBinding(registration.configurationHash, bytes32("configuration-hash"));
+        _requireBinding(registration.permissionsHash, bytes32("permissions"));
+        _requireBinding(registration.deploymentId, bytes32("deployment-id"));
+        _requireBinding(registration.deploymentSetHash, bytes32("deployments"));
+        _requireBinding(registration.runtimeCodeSetHash, bytes32("runtimes"));
+        _requireBinding(registration.primaryRuntimeCodeHash, bytes32("primary-runtime"));
+        _requireBinding(registration.builderAttributionHash, bytes32("builder"));
+        _requireBinding(registration.originHash, bytes32("origin"));
+        _requireBinding(registration.assetSetHash, bytes32("assets"));
+        _requireBinding(registration.marketSetHash, bytes32("markets"));
+        _requireBinding(registration.marketPathId, bytes32("market-path"));
+        _requireBinding(registration.capabilitySetHash, bytes32("capabilities"));
+        _requireBinding(registration.reviewPolicyHash, bytes32("review-policy"));
+        _requireBinding(registration.securityReviewHash, bytes32("security-review"));
+        _requireBinding(registration.reviewResultId, bytes32("review-result"));
+        _requireBinding(registration.finalityPolicyHash, bytes32("finality-policy"));
+        _requireBinding(registration.registeredRecordCommitment, bytes32("registered-record-commitment"));
+    }
+
+    function _storeFeePolicy(LaunchRegistrationV1 calldata registration, FeeHashesV1 memory feeHashes) private {
+        _feePolicies[registration.launchId] = StoredFeePolicyV1({
+            profileKey: registration.feePolicy.profileKey,
+            feeAsset: registration.feePolicy.feeAsset,
+            feeBasisHash: registration.feePolicy.feeBasisHash,
+            totalFeeBps: registration.feePolicy.totalFeeBps,
+            legsHash: registration.feePolicy.legsHash,
+            policyHash: feeHashes.policyHash,
+            claimSetHash: feeHashes.claimSetHash,
+            verifierBindingHash: FEE_POLICY_BINDING_HASH,
+            verifierRuntimeCodeHash: VERIFIER_RUNTIME_CODE_HASH,
+            feePolicyRecordHash: feeHashes.feePolicyRecordHash
+        });
+
+        emit ExactShardsFeePolicyBoundV1(
+            registration.launchId,
+            feeHashes.policyHash,
+            feeHashes.feePolicyRecordHash,
+            feeHashes.claimSetHash,
+            FEE_POLICY_BINDING_HASH,
+            registration.feePolicy.profileKey,
+            registration.feePolicy.feeAsset,
+            registration.feePolicy.feeBasisHash,
+            registration.feePolicy.totalFeeBps,
+            registration.feePolicy.legsHash
+        );
+
+        for (uint8 ordinal; ordinal < FEE_CLAIM_COUNT; ++ordinal) {
+            StoredFeeClaimV1 memory claim = _storedClaim(ordinal, registration.orderedFeeLegs[ordinal]);
+            _feeClaims[registration.launchId][ordinal] = claim;
+            emit ExactShardsFeeClaimBoundV1(
+                registration.launchId,
+                ordinal,
+                claim.roleHash,
+                claim.grossVolumeFeeBps,
+                claim.shareOfFeeBps,
+                claim.initialRecipientOrAccumulator,
+                claim.recipientModeHash,
+                claim.claimSelector,
+                claim.handoffSelector,
+                claim.legHash,
+                claim.storedClaimHash
+            );
+        }
+    }
+
+    function _emitLaunchRegistered(
+        LaunchRegistrationV1 calldata registration,
+        FeeHashesV1 memory feeHashes,
+        uint64 registrationSequence,
+        bytes32 identityHash,
+        uint64 observedAtBlock
+    ) private {
+        emit ExactShardsLaunchRegisteredV1(
+            registration.launchId,
+            registration.projectId,
+            registration.primaryContract,
+            registrationSequence,
+            registration.approvalId,
+            registration.deploymentId,
+            identityHash,
+            registration.registeredRecordCommitment,
+            feeHashes.policyHash,
+            feeHashes.feePolicyRecordHash,
+            observedAtBlock
+        );
+    }
+
+    function _verifiedFeeHashes(
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
+    ) private view returns (FeeHashesV1 memory feeHashes) {
+        feeHashes.policyHash = FEE_POLICY_VERIFIER.verify(policy, orderedLegs);
+        bytes32 builderClaimHash = _storedClaimHash(0, orderedLegs[0]);
+        bytes32 programmableClaimHash = _storedClaimHash(1, orderedLegs[1]);
+        bytes32 holderClaimHash = _storedClaimHash(2, orderedLegs[2]);
+        feeHashes.claimSetHash = keccak256(abi.encode(builderClaimHash, programmableClaimHash, holderClaimHash));
+        feeHashes.feePolicyRecordHash = keccak256(
+            abi.encode(
+                FEE_POLICY_RECORD_DOMAIN,
+                REGISTRY_INSTANCE_HASH,
+                address(FEE_POLICY_VERIFIER),
+                VERIFIER_RUNTIME_CODE_HASH,
+                FEE_POLICY_BINDING_HASH,
+                feeHashes.policyHash,
+                feeHashes.claimSetHash
+            )
+        );
+    }
+
+    function _storedClaim(
+        uint8 ordinal,
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1 calldata leg
+    ) private pure returns (StoredFeeClaimV1 memory claim) {
+        (uint16 shareOfFeeBps, bytes4 claimSelector, bytes4 handoffSelector) = _claimConstants(ordinal);
+        bytes32 legHash = _legHash(leg);
+        claim = StoredFeeClaimV1({
+            ordinal: ordinal,
+            roleHash: leg.roleHash,
+            grossVolumeFeeBps: leg.feeBps,
+            shareOfFeeBps: shareOfFeeBps,
+            initialRecipientOrAccumulator: leg.recipient,
+            recipientModeHash: leg.recipientModeHash,
+            claimSelector: claimSelector,
+            handoffSelector: handoffSelector,
+            legHash: legHash,
+            storedClaimHash: _storedClaimHash(ordinal, leg)
+        });
+    }
+
+    function _storedClaimHash(
+        uint8 ordinal,
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1 calldata leg
+    ) private pure returns (bytes32) {
+        (uint16 shareOfFeeBps, bytes4 claimSelector, bytes4 handoffSelector) = _claimConstants(ordinal);
+        return keccak256(
+            abi.encode(
+                STORED_CLAIM_TYPEHASH,
+                ordinal,
+                leg.roleHash,
+                leg.feeBps,
+                shareOfFeeBps,
+                leg.recipient,
+                leg.recipientModeHash,
+                claimSelector,
+                handoffSelector,
+                _legHash(leg)
+            )
+        );
+    }
+
+    function _claimConstants(uint8 ordinal)
+        private
+        pure
+        returns (uint16 shareOfFeeBps, bytes4 claimSelector, bytes4 handoffSelector)
+    {
+        if (ordinal == 0) return (BUILDER_SHARE_OF_FEE_BPS, BUILDER_CLAIM_SELECTOR, BUILDER_HANDOFF_SELECTOR);
+        if (ordinal == 1) return (PROGRAMMABLE_SHARE_OF_FEE_BPS, PROGRAMMABLE_CLAIM_SELECTOR, bytes4(0));
+        if (ordinal == 2) return (HOLDER_SHARE_OF_FEE_BPS, HOLDER_CLAIM_SELECTOR, bytes4(0));
+        revert InvalidFeeClaimIndex(ordinal);
+    }
+
+    function _legHash(IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1 calldata leg)
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(REVENUE_LEG_TYPEHASH, leg.roleHash, leg.feeBps, leg.recipient, leg.recipientModeHash)
+        );
+    }
+
+    function _approvalBindingHash(LaunchRegistrationV1 calldata registration, bytes32 feePolicyRecordHash)
+        private
+        view
+        returns (bytes32)
+    {
+        bytes32 sourceHash = keccak256(
+            abi.encode(
+                registration.repositoryId,
+                registration.commitId,
+                registration.sourceCommitment,
+                registration.buildCommitment,
+                registration.artifactSetHash,
+                registration.deploymentConfigurationHash,
+                registration.configurationHash,
+                registration.permissionsHash
+            )
+        );
+        bytes32 deploymentExpectationHash = keccak256(
+            abi.encode(
+                registration.deploymentId,
+                registration.deploymentSetHash,
+                registration.runtimeCodeSetHash,
+                registration.primaryContract,
+                registration.primaryRuntimeCodeHash
+            )
+        );
+        bytes32 attributionHash = keccak256(
+            abi.encode(
+                registration.modelId,
+                registration.modelVersion,
+                registration.templateId,
+                registration.templateVersion,
+                registration.providerId,
+                registration.builderAttributionHash,
+                registration.originHash,
+                registration.marketPathId
+            )
+        );
+        bytes32 scopeHash = keccak256(
+            abi.encode(
+                REGISTRY_INSTANCE_HASH,
+                registration.chainId,
+                registration.registryGeneration,
+                registration.launchId,
+                registration.projectId,
+                registration.approvalId
+            )
+        );
+        bytes32 controlHash =
+            keccak256(abi.encode(registration.launchWallet, feePolicyRecordHash, registration.reviewPolicyHash));
+        return keccak256(
+            abi.encode(
+                APPROVAL_BINDING_DOMAIN,
+                REGISTRY_INSTANCE_HASH,
+                scopeHash,
+                sourceHash,
+                deploymentExpectationHash,
+                attributionHash,
+                controlHash
+            )
+        );
+    }
+
+    function _reviewDeploymentBindingHash(LaunchRegistrationV1 calldata registration, bytes32 feePolicyRecordHash)
+        private
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                REVIEW_DEPLOYMENT_BINDING_DOMAIN,
+                REGISTRY_INSTANCE_HASH,
+                registration.approvalBindingHash,
+                registration.deploymentId,
+                registration.deploymentSetHash,
+                registration.runtimeCodeSetHash,
+                registration.primaryContract,
+                registration.primaryRuntimeCodeHash,
+                registration.deploymentConfigurationHash,
+                registration.configurationHash,
+                registration.permissionsHash,
+                feePolicyRecordHash
+            )
+        );
+    }
+
+    function _identityHash(LaunchRegistrationV1 calldata registration, bytes32 feePolicyRecordHash)
+        private
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                IDENTITY_DOMAIN, REGISTRY_INSTANCE_HASH, _registeredRecordCommitment(registration, feePolicyRecordHash)
+            )
+        );
+    }
+
+    function _registeredRecordCommitment(LaunchRegistrationV1 calldata registration, bytes32 feePolicyRecordHash)
+        private
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                REGISTERED_RECORD_COMMITMENT_DOMAIN,
+                REGISTRY_INSTANCE_HASH,
+                _scopeAndApprovalHash(registration),
+                _sourceAndDeploymentHash(registration),
+                _attributionHash(registration),
+                _reviewHash(registration),
+                feePolicyRecordHash,
+                registration.finalityPolicyHash
+            )
+        );
+    }
+
+    function _sourceAndDeploymentHash(LaunchRegistrationV1 calldata registration) private pure returns (bytes32) {
+        bytes32[14] memory words;
+        words[0] = registration.repositoryId;
+        words[1] = registration.commitId;
+        words[2] = registration.sourceCommitment;
+        words[3] = registration.buildCommitment;
+        words[4] = registration.artifactSetHash;
+        words[5] = registration.deploymentConfigurationHash;
+        words[6] = registration.configurationHash;
+        words[7] = registration.permissionsHash;
+        words[8] = registration.deploymentId;
+        words[9] = registration.deploymentSetHash;
+        words[10] = registration.runtimeCodeSetHash;
+        words[11] = bytes32(uint256(uint160(registration.primaryContract)));
+        words[12] = registration.primaryRuntimeCodeHash;
+        words[13] = bytes32(uint256(uint160(registration.launchWallet)));
+        return keccak256(abi.encode(words));
+    }
+
+    function _attributionHash(LaunchRegistrationV1 calldata registration) private pure returns (bytes32) {
+        bytes32[11] memory words;
+        words[0] = registration.modelId;
+        words[1] = registration.modelVersion;
+        words[2] = registration.templateId;
+        words[3] = registration.templateVersion;
+        words[4] = registration.providerId;
+        words[5] = registration.builderAttributionHash;
+        words[6] = registration.originHash;
+        words[7] = registration.assetSetHash;
+        words[8] = registration.marketSetHash;
+        words[9] = registration.marketPathId;
+        words[10] = registration.capabilitySetHash;
+        return keccak256(abi.encode(words));
+    }
+
+    function _reviewHash(LaunchRegistrationV1 calldata registration) private pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                registration.reviewPolicyHash,
+                registration.securityReviewHash,
+                registration.reviewResultId,
+                registration.reviewDeploymentBindingHash
+            )
+        );
+    }
+
+    function _scopeAndApprovalHash(LaunchRegistrationV1 calldata registration) private pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                registration.chainId,
+                registration.registryGeneration,
+                registration.launchId,
+                registration.projectId,
+                registration.approvalId,
+                registration.approvalBindingHash
+            )
+        );
+    }
+
+    function _requireBinding(bytes32 value, bytes32 field) private pure {
+        if (value == bytes32(0)) revert InvalidBinding(field);
+    }
+
+    function _validatePair(bytes32 id, bytes32 version, bytes32 idField, bytes32 versionField) private pure {
+        if ((id == bytes32(0)) != (version == bytes32(0))) revert PairMismatch(idField, versionField);
+    }
+
+    function _requireScope(uint256 chainId, uint64 registryGeneration) private view {
+        if (chainId != CHAIN_ID || registryGeneration != REGISTRY_GENERATION) {
+            revert RegistryScopeMismatch(chainId, registryGeneration);
+        }
+    }
+
+    function _requireCanonicalHistoricalBlock(uint64 blockNumber, bytes32 suppliedBlockHash) private view {
+        if (suppliedBlockHash == bytes32(0) || blockNumber >= block.number) {
+            revert NoncanonicalBlock(blockNumber, block.number);
+        }
+        if (block.number - blockNumber > 256) {
+            revert HistoricalBlockOutsideNativeWindow(blockNumber, block.number);
+        }
+        bytes32 canonical = blockhash(blockNumber);
+        if (canonical != suppliedBlockHash) revert BlockHashMismatch(blockNumber, suppliedBlockHash, canonical);
+    }
+
+    function _consumeTransitionEvidence(bytes32 reasonCode, bytes32 evidenceHash) private {
+        _requireBinding(reasonCode, bytes32("reason"));
+        _requireBinding(evidenceHash, bytes32("evidence"));
+        if (transitionEvidenceConsumed[evidenceHash]) revert EvidenceAlreadyConsumed(evidenceHash);
+        transitionEvidenceConsumed[evidenceHash] = true;
+    }
+
+    /// @dev Approval and writer remain independently held, matching Registry V1.
+    function _grantRole(bytes32 role, address account) internal virtual override returns (bool) {
+        if (
+            (role == APPROVER_ROLE && hasRole(WRITER_ROLE, account))
+                || (role == WRITER_ROLE && hasRole(APPROVER_ROLE, account))
+        ) {
+            revert IncompatibleOperationalRoles(account);
+        }
+        return super._grantRole(role, account);
+    }
+}

--- a/contracts/src/ProgrammableExactShardsRegistryV1.sol
+++ b/contracts/src/ProgrammableExactShardsRegistryV1.sol
@@ -98,6 +98,7 @@ contract ProgrammableExactShardsRegistryV1 is AccessControlDefaultAdminRules, IP
     bytes32 public immutable VERIFIER_RUNTIME_CODE_HASH;
     // slither-disable-next-line naming-convention
     bytes32 public immutable FEE_POLICY_BINDING_HASH;
+    // slither-disable-next-line naming-convention
     ProgrammableExactShardsFeePolicyVerifierV1 public immutable FEE_POLICY_VERIFIER;
 
     uint64 public registrationCount;

--- a/contracts/src/ProgrammableGithubRepositoryLineageRegistryV1.sol
+++ b/contracts/src/ProgrammableGithubRepositoryLineageRegistryV1.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {
+    AccessControlDefaultAdminRules
+} from "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import {
+    IProgrammableGithubRepositoryLineageRegistryV1
+} from "./interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol";
+
+/// @title ProgrammableGithubRepositoryLineageRegistryV1
+/// @notice Shared, route-neutral one-launch authority for stable numeric GitHub repository IDs.
+/// @dev Every launch route/factory must use the same deployed instance and consume in the launch transaction.
+contract ProgrammableGithubRepositoryLineageRegistryV1 is
+    AccessControlDefaultAdminRules,
+    IProgrammableGithubRepositoryLineageRegistryV1
+{
+    using SafeCast for uint256;
+
+    bytes32 public constant CONSUMER_ROLE = keccak256("programmable.github-repository-lineage.consumer.v1");
+
+    uint64 public consumptionCount;
+    mapping(bytes32 repositoryKey => RepositoryConsumptionV1 record) private _consumptions;
+    mapping(bytes32 launchId => bytes32 repositoryKey) public repositoryKeyByLaunchId;
+
+    error GithubRepositoryIdIsZero();
+    error LaunchIdIsZero();
+    error RouteIdIsZero();
+    error RepositoryAlreadyConsumed(
+        bytes32 repositoryKey, bytes32 existingLaunchId, bytes32 existingRouteId, address existingConsumer
+    );
+    error LaunchAlreadyConsumed(bytes32 launchId, bytes32 existingRepositoryKey);
+    error ConsumerMustBeContract(address consumer);
+
+    constructor(uint48 initialAdminDelay, address initialAdmin)
+        AccessControlDefaultAdminRules(initialAdminDelay, initialAdmin)
+    { }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(AccessControlDefaultAdminRules)
+        returns (bool)
+    {
+        return interfaceId == type(IProgrammableGithubRepositoryLineageRegistryV1).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
+    function consume(uint64 githubRepositoryId, bytes32 launchId, bytes32 routeId)
+        external
+        onlyRole(CONSUMER_ROLE)
+        returns (bytes32 repositoryKey)
+    {
+        repositoryKey = _repositoryKey(githubRepositoryId);
+        if (launchId == bytes32(0)) revert LaunchIdIsZero();
+        if (routeId == bytes32(0)) revert RouteIdIsZero();
+
+        RepositoryConsumptionV1 storage existing = _consumptions[repositoryKey];
+        if (existing.launchId != bytes32(0)) {
+            if (existing.launchId == launchId && existing.routeId == routeId && existing.consumer == msg.sender) {
+                return repositoryKey;
+            }
+            revert RepositoryAlreadyConsumed(repositoryKey, existing.launchId, existing.routeId, existing.consumer);
+        }
+
+        bytes32 existingRepositoryKey = repositoryKeyByLaunchId[launchId];
+        if (existingRepositoryKey != bytes32(0)) revert LaunchAlreadyConsumed(launchId, existingRepositoryKey);
+
+        uint64 consumedAtBlock = block.number.toUint64();
+        uint64 nextCount = consumptionCount + 1;
+        _consumptions[repositoryKey] = RepositoryConsumptionV1({
+            githubRepositoryId: githubRepositoryId,
+            consumedAtBlock: consumedAtBlock,
+            launchId: launchId,
+            routeId: routeId,
+            consumer: msg.sender
+        });
+        repositoryKeyByLaunchId[launchId] = repositoryKey;
+        consumptionCount = nextCount;
+
+        emit GithubRepositoryLineageConsumedV1(
+            repositoryKey, launchId, routeId, githubRepositoryId, msg.sender, consumedAtBlock
+        );
+    }
+
+    function computeRepositoryKey(uint64 githubRepositoryId) external pure returns (bytes32) {
+        return _repositoryKey(githubRepositoryId);
+    }
+
+    function consumption(bytes32 repositoryKey) external view returns (RepositoryConsumptionV1 memory) {
+        return _consumptions[repositoryKey];
+    }
+
+    function _repositoryKey(uint64 githubRepositoryId) private pure returns (bytes32) {
+        if (githubRepositoryId == 0) revert GithubRepositoryIdIsZero();
+        return keccak256(abi.encode("programmable.github.repository.v1", uint256(githubRepositoryId)));
+    }
+
+    function _grantRole(bytes32 role, address account) internal virtual override returns (bool) {
+        // Role identity and deployed-code existence are intentionally exact authorization predicates;
+        // neither comparison is time-based or an approximate numeric condition.
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (role == CONSUMER_ROLE && account.code.length == 0) revert ConsumerMustBeContract(account);
+        return super._grantRole(role, account);
+    }
+}

--- a/contracts/src/interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol
+++ b/contracts/src/interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title IProgrammableExactShardsFeePolicyVerifierV1
+/// @notice Canonical three-claim fee policy for the reviewed Shards launch route.
+interface IProgrammableExactShardsFeePolicyVerifierV1 {
+    struct ProgrammableRevenueLegV1 {
+        bytes32 roleHash;
+        uint16 feeBps;
+        address recipient;
+        bytes32 recipientModeHash;
+    }
+
+    struct ProgrammableRevenuePolicyV1 {
+        bytes32 profileKey;
+        address feeAsset;
+        bytes32 feeBasisHash;
+        uint16 totalFeeBps;
+        bytes32 legsHash;
+    }
+
+    error InvalidShardsFeePolicy(uint8 field);
+
+    /// @notice Verifies the exact reviewed builder, Programmable and holder legs in that order.
+    /// @return policyHash The reviewed `ProgrammableRevenuePolicyV1` commitment.
+    function verify(ProgrammableRevenuePolicyV1 calldata policy, ProgrammableRevenueLegV1[3] calldata orderedLegs)
+        external
+        pure
+        returns (bytes32 policyHash);
+
+    function hashLeg(ProgrammableRevenueLegV1 calldata leg) external pure returns (bytes32);
+
+    function hashPolicy(ProgrammableRevenuePolicyV1 calldata policy) external pure returns (bytes32);
+
+    /// @notice Content-addressed binding joining the exact Shards source, route artifact and Router V4 adapter.
+    function feePolicyBindingHashV1() external pure returns (bytes32);
+}

--- a/contracts/src/interfaces/IProgrammableExactShardsLaunchFactoryV1.sol
+++ b/contracts/src/interfaces/IProgrammableExactShardsLaunchFactoryV1.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @notice Exact Website-facing subset of reviewed ShardLaunchFactoryV1 at source commit 91b38f3d...da59.
+interface IProgrammableExactShardsLaunchFactoryV1 {
+    struct LaunchParams {
+        int24 tickLower;
+        int24 tickBand;
+        int24 tickUpper;
+        uint160 startSqrtPriceX96;
+        address renderer;
+        string tokenName;
+        string tokenSymbol;
+        string nftName;
+        string nftSymbol;
+    }
+
+    function launch(bytes32 tokenSalt, bytes32 hookSalt, bytes calldata hookCreationCode, LaunchParams calldata params)
+        external
+        returns (address hook, address shard, address nft);
+}

--- a/contracts/src/interfaces/IProgrammableExactShardsRegistryV1.sol
+++ b/contracts/src/interfaces/IProgrammableExactShardsRegistryV1.sol
@@ -15,13 +15,21 @@ interface IProgrammableExactShardsRegistryV1 {
         bytes32 projectId;
         bytes32 approvalId;
         bytes32 approvalBindingHash;
-        bytes32 repositoryId;
+        /// @dev Stable numeric GitHub repository ID; independent of owner/name, transfer and rename.
+        uint64 githubRepositoryId;
         bytes32 commitId;
         bytes32 sourceCommitment;
         bytes32 buildCommitment;
         bytes32 artifactSetHash;
         bytes32 deploymentConfigurationHash;
+        /// @dev Reviewed technical configuration commitment. It MUST NOT contain website presentation data.
         bytes32 configurationHash;
+        /// @dev keccak256(bytes(tokenName)) for the exact name selected on the Website after technical approval.
+        bytes32 tokenNameHash;
+        /// @dev keccak256(bytes(tokenSymbol)) for the exact symbol selected on the Website after technical approval.
+        bytes32 tokenSymbolHash;
+        /// @dev Exact Website presentation-record binding for description, image and links; never a source input.
+        bytes32 presentationBindingHash;
         bytes32 permissionsHash;
         bytes32 deploymentId;
         bytes32 deploymentSetHash;
@@ -98,6 +106,13 @@ interface IProgrammableExactShardsRegistryV1 {
         uint64 expiresAtBlock,
         bytes32 evidenceHash
     );
+
+    struct LaunchIntentStateV1 {
+        bytes32 bindingHash;
+        bytes32 evidenceHash;
+        uint64 validAfterBlock;
+        uint64 expiresAtBlock;
+    }
 
     event ExactShardsLaunchRegisteredV1(
         bytes32 indexed launchId,
@@ -178,6 +193,8 @@ interface IProgrammableExactShardsRegistryV1 {
     );
 
     function authorizeApproval(IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 calldata authorization) external;
+    function authorizeLaunchIntent(IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 calldata authorization)
+        external;
     function registerLaunch(LaunchRegistrationV1 calldata registration) external;
     function finalizeLaunch(IProgrammableCustomRegistryV1.FinalityProofV1 calldata proof) external;
     function correctLaunchRecord(IProgrammableCustomRegistryV1.RecordCorrectionV1 calldata correction) external;
@@ -196,22 +213,6 @@ interface IProgrammableExactShardsRegistryV1 {
     function feeClaim(bytes32 launchId, uint8 ordinal) external view returns (StoredFeeClaimV1 memory);
     function recordHashAtRevision(bytes32 launchId, uint64 revision) external view returns (bytes32);
 
-    function computeFeePolicyHash(
-        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
-        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
-    ) external view returns (bytes32);
-    function computeFeePolicyRecordHash(
-        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
-        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
-    ) external view returns (bytes32);
-    function computeApprovalBindingHash(LaunchRegistrationV1 calldata registration) external view returns (bytes32);
-    function computeRegistrationBindingHash(LaunchRegistrationV1 calldata registration) external view returns (bytes32);
-    function computeRegisteredRecordCommitment(LaunchRegistrationV1 calldata registration)
-        external
-        view
-        returns (bytes32);
-    function computeReviewDeploymentBindingHash(LaunchRegistrationV1 calldata registration)
-        external
-        view
-        returns (bytes32);
+    /// @dev Deterministic binding helpers are deliberately offchain/test-only so the production Registry
+    ///      remains below EIP-170. Every submitted binding is recomputed and checked during registration.
 }

--- a/contracts/src/interfaces/IProgrammableExactShardsRegistryV1.sol
+++ b/contracts/src/interfaces/IProgrammableExactShardsRegistryV1.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IProgrammableCustomRegistryV1 } from "./IProgrammableCustomRegistryV1.sol";
+import { IProgrammableExactShardsFeePolicyVerifierV1 } from "./IProgrammableExactShardsFeePolicyVerifierV1.sol";
+
+/// @title IProgrammableExactShardsRegistryV1
+/// @notice Append-only launch registry restricted to the reviewed Shards three-claim economics.
+/// @dev Registration is an origin record. It does not deploy, activate, approve or certify a launch.
+interface IProgrammableExactShardsRegistryV1 {
+    struct LaunchRegistrationV1 {
+        uint256 chainId;
+        uint64 registryGeneration;
+        bytes32 launchId;
+        bytes32 projectId;
+        bytes32 approvalId;
+        bytes32 approvalBindingHash;
+        bytes32 repositoryId;
+        bytes32 commitId;
+        bytes32 sourceCommitment;
+        bytes32 buildCommitment;
+        bytes32 artifactSetHash;
+        bytes32 deploymentConfigurationHash;
+        bytes32 configurationHash;
+        bytes32 permissionsHash;
+        bytes32 deploymentId;
+        bytes32 deploymentSetHash;
+        bytes32 runtimeCodeSetHash;
+        address primaryContract;
+        bytes32 primaryRuntimeCodeHash;
+        address launchWallet;
+        bytes32 modelId;
+        bytes32 modelVersion;
+        bytes32 templateId;
+        bytes32 templateVersion;
+        bytes32 providerId;
+        bytes32 builderAttributionHash;
+        bytes32 originHash;
+        bytes32 assetSetHash;
+        bytes32 marketSetHash;
+        bytes32 marketPathId;
+        bytes32 capabilitySetHash;
+        bytes32 reviewPolicyHash;
+        bytes32 securityReviewHash;
+        bytes32 reviewResultId;
+        bytes32 reviewDeploymentBindingHash;
+        bytes32 finalityPolicyHash;
+        bytes32 registeredRecordCommitment;
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 feePolicy;
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] orderedFeeLegs;
+    }
+
+    struct LaunchStateV1 {
+        IProgrammableCustomRegistryV1.LaunchStatus status;
+        uint64 observedAtBlock;
+        uint64 finalizedAtBlock;
+        uint64 latestRecordRevision;
+        bytes32 latestRecordHash;
+        bytes32 identityHash;
+        bytes32 feePolicyHash;
+        bytes32 feePolicyRecordHash;
+        bytes32 finalityEvidenceHash;
+    }
+
+    struct StoredFeePolicyV1 {
+        bytes32 profileKey;
+        address feeAsset;
+        bytes32 feeBasisHash;
+        uint16 totalFeeBps;
+        bytes32 legsHash;
+        bytes32 policyHash;
+        bytes32 claimSetHash;
+        bytes32 verifierBindingHash;
+        bytes32 verifierRuntimeCodeHash;
+        bytes32 feePolicyRecordHash;
+    }
+
+    struct StoredFeeClaimV1 {
+        uint8 ordinal;
+        bytes32 roleHash;
+        uint16 grossVolumeFeeBps;
+        uint16 shareOfFeeBps;
+        address initialRecipientOrAccumulator;
+        bytes32 recipientModeHash;
+        bytes4 claimSelector;
+        bytes4 handoffSelector;
+        bytes32 legHash;
+        bytes32 storedClaimHash;
+    }
+
+    event ExactShardsApprovalAuthorizedV1(
+        bytes32 indexed approvalId,
+        bytes32 indexed launchId,
+        bytes32 indexed approvalBindingHash,
+        bytes32 registrationBindingHash,
+        uint64 transitionSequence,
+        uint64 validAfterBlock,
+        uint64 expiresAtBlock,
+        bytes32 evidenceHash
+    );
+
+    event ExactShardsLaunchRegisteredV1(
+        bytes32 indexed launchId,
+        bytes32 indexed projectId,
+        address indexed primaryContract,
+        uint64 registrationSequence,
+        bytes32 approvalId,
+        bytes32 deploymentId,
+        bytes32 identityHash,
+        bytes32 registeredRecordCommitment,
+        bytes32 feePolicyHash,
+        bytes32 feePolicyRecordHash,
+        uint64 observedAtBlock
+    );
+
+    event ExactShardsFeePolicyBoundV1(
+        bytes32 indexed launchId,
+        bytes32 indexed policyHash,
+        bytes32 indexed feePolicyRecordHash,
+        bytes32 claimSetHash,
+        bytes32 verifierBindingHash,
+        bytes32 profileKey,
+        address feeAsset,
+        bytes32 feeBasisHash,
+        uint16 totalFeeBps,
+        bytes32 legsHash
+    );
+
+    event ExactShardsFeeClaimBoundV1(
+        bytes32 indexed launchId,
+        uint8 indexed ordinal,
+        bytes32 indexed roleHash,
+        uint16 grossVolumeFeeBps,
+        uint16 shareOfFeeBps,
+        address initialRecipientOrAccumulator,
+        bytes32 recipientModeHash,
+        bytes4 claimSelector,
+        bytes4 handoffSelector,
+        bytes32 legHash,
+        bytes32 storedClaimHash
+    );
+
+    event ExactShardsLaunchFinalizedV1(
+        bytes32 indexed launchId,
+        bytes32 indexed observedTransactionHash,
+        bytes32 indexed finalityEvidenceHash,
+        uint64 transitionSequence,
+        uint64 observedBlockNumber,
+        bytes32 observedBlockHash,
+        uint32 observedTransactionIndex,
+        uint32 observedLogIndex,
+        uint64 confirmedHeadBlockNumber,
+        bytes32 confirmedHeadBlockHash,
+        bytes32 finalityPolicyHash,
+        uint64 finalizedAtBlock,
+        uint64 finalizedAtTimestamp
+    );
+
+    event ExactShardsLaunchRecordCorrectedV1(
+        bytes32 indexed launchId,
+        uint64 indexed revision,
+        bytes32 indexed correctedRecordHash,
+        uint64 transitionSequence,
+        bytes32 previousRecordHash,
+        bytes32 reasonCode,
+        bytes32 evidenceHash
+    );
+
+    event ExactShardsLaunchRevokedV1(
+        bytes32 indexed launchId,
+        bytes32 indexed reasonCode,
+        bytes32 indexed evidenceHash,
+        uint64 transitionSequence,
+        uint64 latestRecordRevision,
+        bytes32 latestRecordHash,
+        uint64 revokedAtBlock,
+        uint64 revokedAtTimestamp
+    );
+
+    function authorizeApproval(IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 calldata authorization) external;
+    function registerLaunch(LaunchRegistrationV1 calldata registration) external;
+    function finalizeLaunch(IProgrammableCustomRegistryV1.FinalityProofV1 calldata proof) external;
+    function correctLaunchRecord(IProgrammableCustomRegistryV1.RecordCorrectionV1 calldata correction) external;
+    function revokeLaunch(IProgrammableCustomRegistryV1.LaunchRevocationV1 calldata revocation) external;
+
+    function launchState(bytes32 launchId) external view returns (LaunchStateV1 memory);
+    function launchDetails(bytes32 launchId)
+        external
+        view
+        returns (IProgrammableCustomRegistryV1.LaunchDetailsV1 memory);
+    function approvalState(bytes32 approvalId)
+        external
+        view
+        returns (IProgrammableCustomRegistryV1.ApprovalStateV1 memory);
+    function feePolicyState(bytes32 launchId) external view returns (StoredFeePolicyV1 memory);
+    function feeClaim(bytes32 launchId, uint8 ordinal) external view returns (StoredFeeClaimV1 memory);
+    function recordHashAtRevision(bytes32 launchId, uint64 revision) external view returns (bytes32);
+
+    function computeFeePolicyHash(
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
+    ) external view returns (bytes32);
+    function computeFeePolicyRecordHash(
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 calldata policy,
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] calldata orderedLegs
+    ) external view returns (bytes32);
+    function computeApprovalBindingHash(LaunchRegistrationV1 calldata registration) external view returns (bytes32);
+    function computeRegistrationBindingHash(LaunchRegistrationV1 calldata registration) external view returns (bytes32);
+    function computeRegisteredRecordCommitment(LaunchRegistrationV1 calldata registration)
+        external
+        view
+        returns (bytes32);
+    function computeReviewDeploymentBindingHash(LaunchRegistrationV1 calldata registration)
+        external
+        view
+        returns (bytes32);
+}

--- a/contracts/src/interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol
+++ b/contracts/src/interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title IProgrammableGithubRepositoryLineageRegistryV1
+/// @notice Canonical cross-route authority that allows one successful launch per numeric GitHub repository lineage.
+interface IProgrammableGithubRepositoryLineageRegistryV1 {
+    struct RepositoryConsumptionV1 {
+        uint64 githubRepositoryId;
+        uint64 consumedAtBlock;
+        bytes32 launchId;
+        bytes32 routeId;
+        address consumer;
+    }
+
+    event GithubRepositoryLineageConsumedV1(
+        bytes32 indexed repositoryKey,
+        bytes32 indexed launchId,
+        bytes32 indexed routeId,
+        uint64 githubRepositoryId,
+        address consumer,
+        uint64 consumedAtBlock
+    );
+
+    /// @notice Atomically consumes a repository lineage for one launch.
+    /// @dev An exact retry by the same consumer and route is a no-op. Every non-exact duplicate reverts.
+    function consume(uint64 githubRepositoryId, bytes32 launchId, bytes32 routeId)
+        external
+        returns (bytes32 repositoryKey);
+
+    /// @notice The only canonical repository-key derivation.
+    /// @dev Valid numeric GitHub repository IDs are 1 through type(uint64).max, inclusive. Offchain approval
+    ///      storage MUST enforce the same range before encoding this ABI.
+    function computeRepositoryKey(uint64 githubRepositoryId) external pure returns (bytes32);
+
+    function consumption(bytes32 repositoryKey) external view returns (RepositoryConsumptionV1 memory);
+    function repositoryKeyByLaunchId(bytes32 launchId) external view returns (bytes32);
+    function consumptionCount() external view returns (uint64);
+}

--- a/contracts/test/ProgrammableExactShardsAtomicLaunchRouteV1.t.sol
+++ b/contracts/test/ProgrammableExactShardsAtomicLaunchRouteV1.t.sol
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+
+import { ProgrammableExactShardsAtomicLaunchRouteV1 } from "../src/ProgrammableExactShardsAtomicLaunchRouteV1.sol";
+import {
+    ProgrammableGithubRepositoryLineageRegistryV1
+} from "../src/ProgrammableGithubRepositoryLineageRegistryV1.sol";
+import { IProgrammableExactShardsLaunchFactoryV1 } from "../src/interfaces/IProgrammableExactShardsLaunchFactoryV1.sol";
+import { IProgrammableExactShardsRegistryV1 } from "../src/interfaces/IProgrammableExactShardsRegistryV1.sol";
+
+contract MockShardsMetadataTokenV1 {
+    string public name;
+    string public symbol;
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+    }
+}
+
+contract MockShardsSatelliteV1 { }
+
+contract MockExactShardsFactoryV1 {
+    uint256 public successfulLaunchCount;
+
+    function predictToken(bytes32 tokenSalt, IProgrammableExactShardsLaunchFactoryV1.LaunchParams calldata params)
+        external
+        view
+        returns (address)
+    {
+        bytes32 initCodeHash = keccak256(
+            bytes.concat(type(MockShardsMetadataTokenV1).creationCode, abi.encode(params.tokenName, params.tokenSymbol))
+        );
+        return
+            address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), tokenSalt, initCodeHash)))));
+    }
+
+    function launch(
+        bytes32 tokenSalt,
+        bytes32,
+        bytes calldata,
+        IProgrammableExactShardsLaunchFactoryV1.LaunchParams calldata params
+    ) external returns (address hook, address shard, address nft) {
+        shard = address(new MockShardsMetadataTokenV1{ salt: tokenSalt }(params.tokenName, params.tokenSymbol));
+        hook = address(new MockShardsSatelliteV1{ salt: keccak256(abi.encode("hook", shard)) }());
+        nft = address(new MockShardsSatelliteV1{ salt: keccak256(abi.encode("nft", shard)) }());
+        successfulLaunchCount++;
+    }
+
+    function predictHook(address shard) external view returns (address) {
+        return _predictSatellite(keccak256(abi.encode("hook", shard)));
+    }
+
+    function predictNft(address shard) external view returns (address) {
+        return _predictSatellite(keccak256(abi.encode("nft", shard)));
+    }
+
+    function _predictSatellite(bytes32 salt) private view returns (address) {
+        return address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            bytes1(0xff), address(this), salt, keccak256(type(MockShardsSatelliteV1).creationCode)
+                        )
+                    )
+                )
+            )
+        );
+    }
+}
+
+contract MockAtomicShardsRegistryV1 {
+    uint256 public registrationCount;
+    bool public failRegistration;
+    bytes32 public lastLaunchId;
+
+    error ForcedRegistrationFailure();
+
+    function setFailRegistration(bool value) external {
+        failRegistration = value;
+    }
+
+    function registerLaunch(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 calldata registration) external {
+        if (failRegistration) revert ForcedRegistrationFailure();
+        registrationCount++;
+        lastLaunchId = registration.launchId;
+    }
+}
+
+contract ProgrammableExactShardsAtomicLaunchRouteV1Test is Test {
+    address internal constant ADMIN = address(0xA11CE);
+    address internal constant LAUNCHER = address(0x51A4D5);
+    uint64 internal constant SHARDS_GITHUB_REPOSITORY_ID = 1_329_073_878;
+
+    ProgrammableGithubRepositoryLineageRegistryV1 internal lineageRegistry;
+    MockExactShardsFactoryV1 internal factory;
+    MockAtomicShardsRegistryV1 internal registry;
+    ProgrammableExactShardsAtomicLaunchRouteV1 internal routeA;
+    ProgrammableExactShardsAtomicLaunchRouteV1 internal routeB;
+
+    function setUp() public {
+        lineageRegistry = new ProgrammableGithubRepositoryLineageRegistryV1(2 days, ADMIN);
+        factory = new MockExactShardsFactoryV1();
+        registry = new MockAtomicShardsRegistryV1();
+        routeA = _newRoute();
+        routeB = _newRoute();
+
+        vm.startPrank(ADMIN);
+        lineageRegistry.grantRole(lineageRegistry.CONSUMER_ROLE(), address(routeA));
+        lineageRegistry.grantRole(lineageRegistry.CONSUMER_ROLE(), address(routeB));
+        vm.stopPrank();
+    }
+
+    function test_selectedWebsiteNameAndTickerAreProducedAndRegisteredAtomically() public {
+        IProgrammableExactShardsLaunchFactoryV1.LaunchParams memory params = _params("Fragment", "FRAG");
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration =
+            _registration("selected", bytes32("selected-salt"), params);
+
+        vm.prank(LAUNCHER);
+        (, address shard,) = routeA.launch(registration, bytes32("selected-salt"), bytes32(0), hex"01", params);
+
+        assertEq(MockShardsMetadataTokenV1(shard).name(), "Fragment");
+        assertEq(MockShardsMetadataTokenV1(shard).symbol(), "FRAG");
+        assertEq(factory.successfulLaunchCount(), 1);
+        assertEq(registry.registrationCount(), 1);
+        assertEq(registry.lastLaunchId(), registration.launchId);
+    }
+
+    function test_twoAuthorizedRoutesForSameRepositoryLeaveOnlyOneTokenDeployment() public {
+        IProgrammableExactShardsLaunchFactoryV1.LaunchParams memory firstParams = _params("First", "ONE");
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory first =
+            _registration("first", bytes32("first-salt"), firstParams);
+        vm.prank(LAUNCHER);
+        routeA.launch(first, bytes32("first-salt"), bytes32(0), hex"01", firstParams);
+
+        IProgrammableExactShardsLaunchFactoryV1.LaunchParams memory secondParams = _params("Second", "TWO");
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory second =
+            _registration("second", bytes32("second-salt"), secondParams);
+        address losingHook = factory.predictHook(second.primaryContract);
+        address losingNft = factory.predictNft(second.primaryContract);
+        vm.expectPartialRevert(ProgrammableGithubRepositoryLineageRegistryV1.RepositoryAlreadyConsumed.selector);
+        vm.prank(LAUNCHER);
+        routeB.launch(second, bytes32("second-salt"), bytes32(0), hex"01", secondParams);
+
+        assertEq(factory.successfulLaunchCount(), 1);
+        assertEq(registry.registrationCount(), 1);
+        assertEq(second.primaryContract.code.length, 0);
+        assertEq(losingHook.code.length, 0);
+        assertEq(losingNft.code.length, 0);
+    }
+
+    function test_downstreamRegistrationRevertRollsBackConsumptionAndTokenDeployment() public {
+        IProgrammableExactShardsLaunchFactoryV1.LaunchParams memory params = _params("Rollback", "ROLL");
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration =
+            _registration("rollback", bytes32("rollback-salt"), params);
+        address rolledBackHook = factory.predictHook(registration.primaryContract);
+        address rolledBackNft = factory.predictNft(registration.primaryContract);
+        registry.setFailRegistration(true);
+
+        vm.expectRevert(MockAtomicShardsRegistryV1.ForcedRegistrationFailure.selector);
+        vm.prank(LAUNCHER);
+        routeA.launch(registration, bytes32("rollback-salt"), bytes32(0), hex"01", params);
+
+        bytes32 repositoryKey = lineageRegistry.computeRepositoryKey(SHARDS_GITHUB_REPOSITORY_ID);
+        assertEq(lineageRegistry.consumption(repositoryKey).launchId, bytes32(0));
+        assertEq(factory.successfulLaunchCount(), 0);
+        assertEq(registration.primaryContract.code.length, 0);
+        assertEq(rolledBackHook.code.length, 0);
+        assertEq(rolledBackNft.code.length, 0);
+
+        registry.setFailRegistration(false);
+        vm.prank(LAUNCHER);
+        routeA.launch(registration, bytes32("rollback-salt"), bytes32(0), hex"01", params);
+        assertEq(factory.successfulLaunchCount(), 1);
+    }
+
+    function test_routeHasNoStandaloneConsumeSelector() public {
+        (bool ok,) = address(routeA)
+            .call(
+                abi.encodeWithSelector(
+                    bytes4(keccak256("consume(uint64,bytes32,bytes32)")),
+                    SHARDS_GITHUB_REPOSITORY_ID,
+                    keccak256("standalone"),
+                    routeA.ROUTE_ID()
+                )
+            );
+        assertFalse(ok);
+        assertEq(lineageRegistry.consumptionCount(), 0);
+    }
+
+    function test_deploymentPolicyAllowsOnlyExactAtomicRouteAndRemainsInactive() public view {
+        string memory json = vm.readFile(string.concat(vm.projectRoot(), "/spec/shards-atomic-launch-route-v1.json"));
+        assertEq(vm.parseJsonString(json, ".schemaVersion"), "programmable.exact-shards-atomic-launch-route.v1");
+        assertFalse(vm.parseJsonBool(json, ".activationAllowed"));
+        assertFalse(vm.parseJsonBool(json, ".launchAllowed"));
+        assertEq(vm.parseJsonString(json, ".canonicalDeployment.sharedRepositoryLineageRegistry.addressState"), "UNSET");
+        assertEq(vm.parseJsonString(json, ".canonicalDeployment.exactShardsRegistry.addressState"), "UNSET");
+        assertEq(vm.parseJsonString(json, ".canonicalDeployment.exactShardsAtomicRoute.addressState"), "UNSET");
+        assertFalse(vm.parseJsonBool(json, ".compiler.viaIr"));
+        assertEq(vm.parseJsonUint(json, ".compiler.optimizerRuns"), 1000);
+        assertTrue(
+            vm.parseJsonBool(
+                json, ".canonicalDeployment.sharedRepositoryLineageRegistry.oneCanonicalInstanceForEveryRouteAndFactory"
+            )
+        );
+        assertFalse(vm.parseJsonBool(json, ".atomicTopology.standaloneConsumeSelector"));
+        assertTrue(vm.parseJsonBool(json, ".atomicTopology.sameEvmTransaction"));
+        assertTrue(
+            vm.parseJsonBool(json, ".atomicTopology.downstreamRevertRollsBackFactoryDeploymentLineageAndRegistration")
+        );
+        assertEq(
+            vm.parseJsonStringArray(json, ".rolePolicy.requiredConsumerRoleGrantTargets")[0],
+            "EXACT_REVIEWED_ATOMIC_ROUTE_CONTRACT"
+        );
+        string[] memory forbidden = vm.parseJsonStringArray(json, ".rolePolicy.forbiddenConsumerRoleGrantTargets");
+        assertEq(forbidden.length, 5);
+        assertEq(forbidden[0], "EOA");
+        assertEq(forbidden[1], "SHARDS_REGISTRY");
+        assertEq(forbidden[2], "DIRECT_SHARDS_FACTORY");
+        assertEq(forbidden[3], "ARBITRARY_ADAPTER");
+        assertEq(forbidden[4], "CONTRACT_WITH_STANDALONE_CONSUME_SELECTOR");
+        assertEq(
+            keccak256(type(ProgrammableExactShardsAtomicLaunchRouteV1).creationCode),
+            vm.parseJsonBytes32(json, ".artifacts.route.creationCodeKeccak256")
+        );
+        string memory buildArtifact = vm.readFile(
+            string.concat(
+                vm.projectRoot(),
+                "/out/ProgrammableExactShardsAtomicLaunchRouteV1.sol/ProgrammableExactShardsAtomicLaunchRouteV1.json"
+            )
+        );
+        bytes memory unlinkedRuntime = vm.parseBytes(vm.parseJsonString(buildArtifact, ".deployedBytecode.object"));
+        assertEq(keccak256(unlinkedRuntime), vm.parseJsonBytes32(json, ".artifacts.route.unlinkedRuntimeCodeKeccak256"));
+        assertEq(unlinkedRuntime.length, vm.parseJsonUint(json, ".artifacts.route.unlinkedRuntimeCodeByteLength"));
+        assertEq(
+            24_576 - unlinkedRuntime.length, vm.parseJsonUint(json, ".artifacts.route.runtimeCodeLimitMarginBytes")
+        );
+    }
+
+    function _newRoute() private returns (ProgrammableExactShardsAtomicLaunchRouteV1) {
+        return new ProgrammableExactShardsAtomicLaunchRouteV1(
+            lineageRegistry,
+            IProgrammableExactShardsLaunchFactoryV1(address(factory)),
+            IProgrammableExactShardsRegistryV1(address(registry)),
+            address(factory).codehash
+        );
+    }
+
+    function _params(string memory name, string memory symbol)
+        private
+        pure
+        returns (IProgrammableExactShardsLaunchFactoryV1.LaunchParams memory params)
+    {
+        params.tickLower = -120;
+        params.tickBand = 60;
+        params.tickUpper = 120;
+        params.startSqrtPriceX96 = uint160(1 << 96);
+        params.tokenName = name;
+        params.tokenSymbol = symbol;
+        params.nftName = string.concat(name, " Pieces");
+        params.nftSymbol = string.concat(symbol, "N");
+    }
+
+    function _registration(
+        string memory label,
+        bytes32 tokenSalt,
+        IProgrammableExactShardsLaunchFactoryV1.LaunchParams memory params
+    ) private view returns (IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration) {
+        registration.githubRepositoryId = SHARDS_GITHUB_REPOSITORY_ID;
+        registration.launchId = keccak256(bytes(label));
+        registration.launchWallet = LAUNCHER;
+        registration.tokenNameHash = keccak256(bytes(params.tokenName));
+        registration.tokenSymbolHash = keccak256(bytes(params.tokenSymbol));
+        registration.primaryContract = factory.predictToken(tokenSalt, params);
+        registration.primaryRuntimeCodeHash = keccak256(type(MockShardsMetadataTokenV1).runtimeCode);
+    }
+}

--- a/contracts/test/ProgrammableExactShardsFeePolicyVerifierV1.t.sol
+++ b/contracts/test/ProgrammableExactShardsFeePolicyVerifierV1.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+
+import { ProgrammableExactShardsFeePolicyVerifierV1 } from "../src/ProgrammableExactShardsFeePolicyVerifierV1.sol";
+import {
+    IProgrammableExactShardsFeePolicyVerifierV1
+} from "../src/interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol";
+
+contract ProgrammableExactShardsFeePolicyVerifierV1Test is Test {
+    ProgrammableExactShardsFeePolicyVerifierV1 private verifier;
+
+    function setUp() external {
+        verifier = new ProgrammableExactShardsFeePolicyVerifierV1();
+    }
+
+    function testCanonicalPolicyReproducesReviewedArtifactHashes() external view {
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] memory legs = _legs();
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 memory policy = _policy();
+
+        assertEq(verifier.hashLeg(legs[0]), verifier.BUILDER_LEG_HASH());
+        assertEq(verifier.hashLeg(legs[1]), verifier.PROGRAMMABLE_LEG_HASH());
+        assertEq(verifier.hashLeg(legs[2]), verifier.HOLDER_LEG_HASH());
+        assertEq(
+            keccak256(
+                abi.encode(verifier.BUILDER_LEG_HASH(), verifier.PROGRAMMABLE_LEG_HASH(), verifier.HOLDER_LEG_HASH())
+            ),
+            verifier.LEGS_HASH()
+        );
+        assertEq(verifier.hashPolicy(policy), verifier.REVENUE_POLICY_HASH());
+        assertEq(verifier.verify(policy, legs), verifier.REVENUE_POLICY_HASH());
+    }
+
+    function testCanonicalPolicyIsInclusiveOnePercentAndThreeClaims() external view {
+        assertEq(verifier.TOTAL_FEE_BPS(), 100);
+        assertEq(verifier.HOLDER_FEE_BPS(), 80);
+        assertEq(verifier.BUILDER_FEE_BPS(), 10);
+        assertEq(verifier.PROGRAMMABLE_FEE_BPS(), 10);
+        assertEq(verifier.HOLDER_SHARE_OF_FEE_BPS(), 8000);
+        assertEq(verifier.BUILDER_SHARE_OF_FEE_BPS(), 1000);
+        assertEq(verifier.PROGRAMMABLE_SHARE_OF_FEE_BPS(), 1000);
+        assertEq(verifier.FEE_ASSET(), address(0));
+        assertEq(verifier.HOLDER_ACCUMULATOR(), verifier.HOOK());
+        assertEq(verifier.PROGRAMMABLE_RECIPIENT(), 0x4957f49620AFf3Adbbe8195a4f633E49cc93376c);
+        assertEq(verifier.INITIAL_BUILDER_RECIPIENT(), 0xceeBB3A6543CeBEB2ED66963897A0abEA52A50cC);
+        assertTrue(verifier.BUILDER_RECIPIENT_MODE_HASH() != verifier.PROGRAMMABLE_RECIPIENT_MODE_HASH());
+        assertTrue(verifier.HOLDER_RECIPIENT_MODE_HASH() != verifier.BUILDER_RECIPIENT_MODE_HASH());
+    }
+
+    function testBindingPinsReviewedSourceRouteAndRouterV4() external view {
+        assertTrue(verifier.REVIEWED_SOURCE_COMMIT() == hex"91b38f3de64d96cac7e29f127c004f128fc1da59");
+        assertTrue(verifier.REVIEWED_SOURCE_TREE() == hex"92d6def8609e829487adea66c13901734e43c8c7");
+        assertEq(
+            verifier.NESTED_FACTORY_ARTIFACT_SHA256(),
+            0x066475058bfd47b85b4216f95b434756d67d7e289ffb36535c121ef5d7c11bab
+        );
+        assertTrue(verifier.ROUTER_V4_SOURCE_COMMIT() == hex"d6cfb78543b159f9e0ed9f193a5b29637bd817fc");
+        assertTrue(verifier.ROUTER_V4_PROFILE_SOURCE_BLOB() == hex"d802fa387505da47a0ac4d65a6e5b5e4efa7026d");
+        assertTrue(verifier.ROUTER_V4_NESTED_ADAPTER_SOURCE_BLOB() == hex"cf2b92f67ec00b0c0a844708dd62ab70a32fdf3a");
+        assertEq(
+            verifier.INITIAL_REVENUE_STATE_HASH(), 0xf0bc686422736754322da4ea358a823274df35c35718939d71d339a41b8f9b75
+        );
+        assertEq(verifier.feePolicyBindingHashV1(), 0x5d5d1c46e7627f6e171a18acdbecbfe9e40eca80016fba0142ddca6a054f6169);
+    }
+
+    function testSelectorsBindThreeClaimsAndBuilderSelfHandoff() external view {
+        assertEq(verifier.HOLDER_CLAIM_SELECTOR(), bytes4(0x6ba4c138));
+        assertEq(verifier.BUILDER_CLAIM_SELECTOR(), bytes4(0x69f9a5f0));
+        assertEq(verifier.PROGRAMMABLE_CLAIM_SELECTOR(), bytes4(0x64d46b85));
+        assertEq(verifier.BUILDER_HANDOFF_SELECTOR(), bytes4(0x4ce11d21));
+    }
+
+    function testMachineCheckableSpecMatchesPolicyAndBytecode() external view {
+        string memory root = vm.projectRoot();
+        string memory json = vm.readFile(string.concat(root, "/spec/shards-fee-policy-verifier-v1.json"));
+
+        assertEq(vm.parseJsonString(json, ".schemaVersion"), "programmable.exact-shards-fee-policy-verifier.v1");
+        assertEq(vm.parseJsonString(json, ".status"), "IMPLEMENTATION_READY_NOT_DEPLOYED");
+        assertFalse(vm.parseJsonBool(json, ".activationAllowed"));
+        assertFalse(vm.parseJsonBool(json, ".launchAllowed"));
+        assertFalse(vm.parseJsonBool(json, ".decision.currentContractsCanLaunch"));
+        assertEq(vm.parseJsonBytes32(json, ".canonicalPolicy.revenuePolicyHash"), verifier.REVENUE_POLICY_HASH());
+        assertEq(vm.parseJsonBytes32(json, ".typedHashSpec.feePolicyBindingHash"), verifier.feePolicyBindingHashV1());
+
+        assertEq(
+            keccak256(type(ProgrammableExactShardsFeePolicyVerifierV1).creationCode),
+            vm.parseJsonBytes32(json, ".implementation.artifact.creationCodeKeccak256")
+        );
+        assertEq(
+            keccak256(type(ProgrammableExactShardsFeePolicyVerifierV1).runtimeCode),
+            vm.parseJsonBytes32(json, ".implementation.artifact.runtimeCodeKeccak256")
+        );
+        assertEq(
+            type(ProgrammableExactShardsFeePolicyVerifierV1).creationCode.length,
+            vm.parseJsonUint(json, ".implementation.artifact.creationCodeByteLength")
+        );
+        assertEq(
+            type(ProgrammableExactShardsFeePolicyVerifierV1).runtimeCode.length,
+            vm.parseJsonUint(json, ".implementation.artifact.runtimeCodeByteLength")
+        );
+    }
+
+    function testRejectsProfileAssetBasisAndTotalDrift() external {
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] memory legs = _legs();
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 memory policy = _policy();
+
+        policy.profileKey = keccak256("wrong-profile");
+        _expectField(1);
+        verifier.verify(policy, legs);
+
+        policy = _policy();
+        policy.feeAsset = address(1);
+        _expectField(2);
+        verifier.verify(policy, legs);
+
+        policy = _policy();
+        policy.feeBasisHash = keccak256("added-on-top");
+        _expectField(3);
+        verifier.verify(policy, legs);
+
+        policy = _policy();
+        policy.totalFeeBps = 101;
+        _expectField(4);
+        verifier.verify(policy, legs);
+    }
+
+    function testRejectsAnyClaimMutationOrReordering() external {
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 memory policy = _policy();
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] memory legs = _legs();
+
+        legs[0].recipient = address(1);
+        _expectField(5);
+        verifier.verify(policy, legs);
+
+        legs = _legs();
+        legs[1].recipientModeHash = keccak256("mutable-programmable");
+        _expectField(6);
+        verifier.verify(policy, legs);
+
+        legs = _legs();
+        legs[2].recipient = address(2);
+        _expectField(7);
+        verifier.verify(policy, legs);
+
+        legs = _legs();
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1 memory first = legs[0];
+        legs[0] = legs[2];
+        legs[2] = first;
+        _expectField(5);
+        verifier.verify(policy, legs);
+    }
+
+    function testRejectsClaimSumAndPrecommittedLegHashDrift() external {
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] memory legs = _legs();
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 memory policy = _policy();
+
+        legs[2].feeBps = 79;
+        _expectField(7);
+        verifier.verify(policy, legs);
+
+        legs = _legs();
+        policy.legsHash = keccak256("collapsed-two-claim-policy");
+        _expectField(9);
+        verifier.verify(policy, legs);
+    }
+
+    function _policy()
+        private
+        view
+        returns (IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenuePolicyV1 memory policy)
+    {
+        policy.profileKey = verifier.PROFILE_KEY();
+        policy.feeAsset = address(0);
+        policy.feeBasisHash = verifier.FEE_BASIS_HASH();
+        policy.totalFeeBps = verifier.TOTAL_FEE_BPS();
+        policy.legsHash = verifier.LEGS_HASH();
+    }
+
+    function _legs()
+        private
+        view
+        returns (IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1[3] memory legs)
+    {
+        legs[0] = IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1({
+            roleHash: verifier.BUILDER_ROLE_HASH(),
+            feeBps: verifier.BUILDER_FEE_BPS(),
+            recipient: verifier.INITIAL_BUILDER_RECIPIENT(),
+            recipientModeHash: verifier.BUILDER_RECIPIENT_MODE_HASH()
+        });
+        legs[1] = IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1({
+            roleHash: verifier.PROGRAMMABLE_ROLE_HASH(),
+            feeBps: verifier.PROGRAMMABLE_FEE_BPS(),
+            recipient: verifier.PROGRAMMABLE_RECIPIENT(),
+            recipientModeHash: verifier.PROGRAMMABLE_RECIPIENT_MODE_HASH()
+        });
+        legs[2] = IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1({
+            roleHash: verifier.HOLDER_ROLE_HASH(),
+            feeBps: verifier.HOLDER_FEE_BPS(),
+            recipient: verifier.HOLDER_ACCUMULATOR(),
+            recipientModeHash: verifier.HOLDER_RECIPIENT_MODE_HASH()
+        });
+    }
+
+    function _expectField(uint8 field) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IProgrammableExactShardsFeePolicyVerifierV1.InvalidShardsFeePolicy.selector, field)
+        );
+    }
+}

--- a/contracts/test/ProgrammableExactShardsFeePolicyVerifierV1.t.sol
+++ b/contracts/test/ProgrammableExactShardsFeePolicyVerifierV1.t.sol
@@ -80,6 +80,13 @@ contract ProgrammableExactShardsFeePolicyVerifierV1Test is Test {
         assertFalse(vm.parseJsonBool(json, ".activationAllowed"));
         assertFalse(vm.parseJsonBool(json, ".launchAllowed"));
         assertFalse(vm.parseJsonBool(json, ".decision.currentContractsCanLaunch"));
+        assertFalse(vm.parseJsonBool(json, ".uiMetadataBoundary.feePolicyIncludesTokenName"));
+        assertFalse(vm.parseJsonBool(json, ".uiMetadataBoundary.feePolicyIncludesTokenSymbol"));
+        assertFalse(vm.parseJsonBool(json, ".uiMetadataBoundary.feePolicyIncludesPresentationBindingHash"));
+        assertFalse(vm.parseJsonBool(json, ".uiMetadataBoundary.presentationValuesAreSourceArtifactInputs"));
+        assertEq(
+            vm.parseJsonString(json, ".uiMetadataBoundary.economicsRemainExactly"), "INCLUSIVE_100_BPS_SPLIT_10_10_80"
+        );
         assertEq(vm.parseJsonBytes32(json, ".canonicalPolicy.revenuePolicyHash"), verifier.REVENUE_POLICY_HASH());
         assertEq(vm.parseJsonBytes32(json, ".typedHashSpec.feePolicyBindingHash"), verifier.feePolicyBindingHashV1());
 

--- a/contracts/test/ProgrammableExactShardsRegistryV1.t.sol
+++ b/contracts/test/ProgrammableExactShardsRegistryV1.t.sol
@@ -18,6 +18,12 @@ contract ExactShardsRegistryRuntimeTargetV1 {
     }
 }
 
+contract ExactShardsVerifierImpostorV1 {
+    function feePolicyBindingHashV1() external pure returns (bytes32) {
+        return 0x5d5d1c46e7627f6e171a18acdbecbfe9e40eca80016fba0142ddca6a054f6169;
+    }
+}
+
 contract ProgrammableExactShardsRegistryV1Test is Test {
     address internal constant ADMIN = address(0xA11CE);
     address internal constant APPROVER = address(0xA990);
@@ -29,6 +35,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
 
     uint64 internal constant GENERATION = 3;
     uint64 internal constant FINALITY_BLOCKS = 3;
+    uint256 internal constant MAX_REGISTRATION_GAS = 2_200_000;
 
     ProgrammableExactShardsFeePolicyVerifierV1 internal verifier;
     ProgrammableExactShardsRegistryV1 internal registry;
@@ -72,6 +79,58 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         assertTrue(registry.hasRole(registry.WRITER_ROLE(), WRITER));
         assertFalse(registry.hasRole(registry.APPROVER_ROLE(), WRITER));
         assertFalse(registry.hasRole(registry.WRITER_ROLE(), APPROVER));
+    }
+
+    function test_constructorRejectsVerifierImpostorDespiteMatchingClaimedBinding() public {
+        ExactShardsVerifierImpostorV1 impostor = new ExactShardsVerifierImpostorV1();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableExactShardsRegistryV1.RuntimeCodeHashMismatch.selector,
+                address(impostor),
+                registry.EXPECTED_VERIFIER_RUNTIME_CODE_HASH(),
+                address(impostor).codehash
+            )
+        );
+        new ProgrammableExactShardsRegistryV1(_config(), ProgrammableExactShardsFeePolicyVerifierV1(address(impostor)));
+    }
+
+    function test_machineCheckableSpecMatchesArtifactAndFailClosedBoundary() public view {
+        string memory json = vm.readFile(string.concat(vm.projectRoot(), "/spec/shards-registry-successor-v1.json"));
+        assertEq(vm.parseJsonString(json, ".schemaVersion"), "programmable.exact-shards-registry-successor.v1");
+        assertEq(vm.parseJsonString(json, ".status"), "IMPLEMENTATION_READY_NOT_DEPLOYED");
+        assertFalse(vm.parseJsonBool(json, ".activationAllowed"));
+        assertFalse(vm.parseJsonBool(json, ".launchAllowed"));
+        assertFalse(vm.parseJsonBool(json, ".decision.currentContractsCanLaunch"));
+        assertEq(vm.parseJsonUint(json, ".exactPolicy.totalFeeBps"), 100);
+        assertEq(vm.parseJsonUint(json, ".exactPolicy.orderedClaims[0].grossVolumeFeeBps"), 10);
+        assertEq(vm.parseJsonUint(json, ".exactPolicy.orderedClaims[1].grossVolumeFeeBps"), 10);
+        assertEq(vm.parseJsonUint(json, ".exactPolicy.orderedClaims[2].grossVolumeFeeBps"), 80);
+        assertEq(
+            vm.parseJsonBytes32(json, ".reviewedInputs.feeVerifier.contentBindingHash"),
+            registry.FEE_POLICY_BINDING_HASH()
+        );
+        assertEq(
+            keccak256(type(ProgrammableExactShardsRegistryV1).creationCode),
+            vm.parseJsonBytes32(json, ".implementation.artifact.creationCodeKeccak256")
+        );
+        string memory buildArtifact = vm.readFile(
+            string.concat(
+                vm.projectRoot(), "/out/ProgrammableExactShardsRegistryV1.sol/ProgrammableExactShardsRegistryV1.json"
+            )
+        );
+        bytes memory unlinkedRuntime = vm.parseBytes(vm.parseJsonString(buildArtifact, ".deployedBytecode.object"));
+        assertEq(
+            keccak256(unlinkedRuntime),
+            vm.parseJsonBytes32(json, ".implementation.artifact.unlinkedRuntimeCodeKeccak256")
+        );
+        assertEq(
+            type(ProgrammableExactShardsRegistryV1).creationCode.length,
+            vm.parseJsonUint(json, ".implementation.artifact.creationCodeByteLength")
+        );
+        assertEq(
+            unlinkedRuntime.length, vm.parseJsonUint(json, ".implementation.artifact.unlinkedRuntimeCodeByteLength")
+        );
+        assertEq(address(registry).code.length, unlinkedRuntime.length);
     }
 
     function test_registersAndStoresAllThreeClaimsWithExactHashBinding() public {
@@ -121,6 +180,18 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         );
         assertTrue(registry.approvalConsumed(registration.approvalId));
         assertTrue(registry.deploymentConsumed(registration.deploymentId));
+    }
+
+    function test_registrationGasStaysBelowHardMaximum() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration("gas-bound");
+        _authorize(registration);
+
+        vm.prank(WRITER);
+        uint256 gasBefore = gasleft();
+        registry.registerLaunch(registration);
+        uint256 registrationGas = gasBefore - gasleft();
+
+        assertLe(registrationGas, MAX_REGISTRATION_GAS);
     }
 
     function test_completeLifecycleFinalityCorrectionAndRevocation() public {
@@ -418,22 +489,23 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         private
         returns (ProgrammableExactShardsRegistryV1)
     {
-        return new ProgrammableExactShardsRegistryV1(
-            ProgrammableExactShardsRegistryV1.RegistryConfigV1({
-                initialAdminDelay: 2 days,
-                initialAdmin: ADMIN,
-                initialApprover: APPROVER,
-                initialWriter: WRITER,
-                initialFinalizer: FINALIZER,
-                initialCorrector: CORRECTOR,
-                initialRevoker: REVOKER,
-                registryGeneration: GENERATION,
-                minimumFinalityBlocks: FINALITY_BLOCKS,
-                chainProfileHash: _hash("ethereum-mainnet-chain-profile"),
-                registryPolicyHash: _hash("exact-shards-registry-policy")
-            }),
-            verifier_
-        );
+        return new ProgrammableExactShardsRegistryV1(_config(), verifier_);
+    }
+
+    function _config() private pure returns (ProgrammableExactShardsRegistryV1.RegistryConfigV1 memory config) {
+        config = ProgrammableExactShardsRegistryV1.RegistryConfigV1({
+            initialAdminDelay: 2 days,
+            initialAdmin: ADMIN,
+            initialApprover: APPROVER,
+            initialWriter: WRITER,
+            initialFinalizer: FINALIZER,
+            initialCorrector: CORRECTOR,
+            initialRevoker: REVOKER,
+            registryGeneration: GENERATION,
+            minimumFinalityBlocks: FINALITY_BLOCKS,
+            chainProfileHash: _hash("ethereum-mainnet-chain-profile"),
+            registryPolicyHash: _hash("exact-shards-registry-policy")
+        });
     }
 
     function _registration(string memory label)

--- a/contracts/test/ProgrammableExactShardsRegistryV1.t.sol
+++ b/contracts/test/ProgrammableExactShardsRegistryV1.t.sol
@@ -1,0 +1,572 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { ProgrammableExactShardsFeePolicyVerifierV1 } from "../src/ProgrammableExactShardsFeePolicyVerifierV1.sol";
+import { ProgrammableExactShardsRegistryV1 } from "../src/ProgrammableExactShardsRegistryV1.sol";
+import { IProgrammableCustomRegistryV1 } from "../src/interfaces/IProgrammableCustomRegistryV1.sol";
+import {
+    IProgrammableExactShardsFeePolicyVerifierV1
+} from "../src/interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol";
+import { IProgrammableExactShardsRegistryV1 } from "../src/interfaces/IProgrammableExactShardsRegistryV1.sol";
+
+contract ExactShardsRegistryRuntimeTargetV1 {
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract ProgrammableExactShardsRegistryV1Test is Test {
+    address internal constant ADMIN = address(0xA11CE);
+    address internal constant APPROVER = address(0xA990);
+    address internal constant WRITER = address(0xB001);
+    address internal constant FINALIZER = address(0xF1A1);
+    address internal constant CORRECTOR = address(0xC011);
+    address internal constant REVOKER = address(0xDEAD);
+    address internal constant OUTSIDER = address(0xBAD);
+
+    uint64 internal constant GENERATION = 3;
+    uint64 internal constant FINALITY_BLOCKS = 3;
+
+    ProgrammableExactShardsFeePolicyVerifierV1 internal verifier;
+    ProgrammableExactShardsRegistryV1 internal registry;
+    ExactShardsRegistryRuntimeTargetV1 internal runtimeTarget;
+
+    function setUp() public {
+        vm.chainId(1);
+        vm.roll(100);
+        vm.warp(1_800_000_000);
+        verifier = new ProgrammableExactShardsFeePolicyVerifierV1();
+        runtimeTarget = new ExactShardsRegistryRuntimeTargetV1();
+        registry = _newRegistry(verifier);
+    }
+
+    function test_constructorPinsExactVerifierInstanceScopeAndLeastPrivilege() public view {
+        assertEq(registry.CHAIN_ID(), 1);
+        assertEq(registry.REGISTRY_GENERATION(), GENERATION);
+        assertEq(registry.MINIMUM_FINALITY_BLOCKS(), FINALITY_BLOCKS);
+        assertEq(address(registry.FEE_POLICY_VERIFIER()), address(verifier));
+        assertEq(registry.VERIFIER_RUNTIME_CODE_HASH(), address(verifier).codehash);
+        assertEq(registry.VERIFIER_RUNTIME_CODE_HASH(), registry.EXPECTED_VERIFIER_RUNTIME_CODE_HASH());
+        assertEq(registry.FEE_POLICY_BINDING_HASH(), verifier.feePolicyBindingHashV1());
+        assertEq(registry.FEE_POLICY_BINDING_HASH(), registry.EXPECTED_FEE_POLICY_BINDING_HASH());
+        assertEq(
+            registry.REGISTRY_INSTANCE_HASH(),
+            keccak256(
+                abi.encode(
+                    registry.REGISTRY_SCHEMA_ID(),
+                    block.chainid,
+                    GENERATION,
+                    address(registry),
+                    registry.CHAIN_PROFILE_HASH(),
+                    registry.REGISTRY_POLICY_HASH(),
+                    address(verifier),
+                    address(verifier).codehash,
+                    verifier.feePolicyBindingHashV1()
+                )
+            )
+        );
+        assertTrue(registry.hasRole(registry.APPROVER_ROLE(), APPROVER));
+        assertTrue(registry.hasRole(registry.WRITER_ROLE(), WRITER));
+        assertFalse(registry.hasRole(registry.APPROVER_ROLE(), WRITER));
+        assertFalse(registry.hasRole(registry.WRITER_ROLE(), APPROVER));
+    }
+
+    function test_registersAndStoresAllThreeClaimsWithExactHashBinding() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration("canonical");
+        bytes32 feePolicyRecordHash =
+            registry.computeFeePolicyRecordHash(registration.feePolicy, registration.orderedFeeLegs);
+        bytes32 policyHash = registry.computeFeePolicyHash(registration.feePolicy, registration.orderedFeeLegs);
+        _authorize(registration);
+
+        vm.prank(WRITER);
+        registry.registerLaunch(registration);
+
+        IProgrammableExactShardsRegistryV1.LaunchStateV1 memory state = registry.launchState(registration.launchId);
+        IProgrammableExactShardsRegistryV1.StoredFeePolicyV1 memory storedPolicy =
+            registry.feePolicyState(registration.launchId);
+        assertEq(uint8(state.status), uint8(IProgrammableCustomRegistryV1.LaunchStatus.Observed));
+        assertEq(state.feePolicyHash, policyHash);
+        assertEq(state.feePolicyRecordHash, feePolicyRecordHash);
+        assertEq(storedPolicy.policyHash, policyHash);
+        assertEq(storedPolicy.feePolicyRecordHash, feePolicyRecordHash);
+        assertEq(storedPolicy.verifierBindingHash, verifier.feePolicyBindingHashV1());
+        assertEq(storedPolicy.verifierRuntimeCodeHash, address(verifier).codehash);
+        assertEq(storedPolicy.totalFeeBps, 100);
+
+        IProgrammableExactShardsRegistryV1.StoredFeeClaimV1 memory builder = registry.feeClaim(registration.launchId, 0);
+        IProgrammableExactShardsRegistryV1.StoredFeeClaimV1 memory programmable =
+            registry.feeClaim(registration.launchId, 1);
+        IProgrammableExactShardsRegistryV1.StoredFeeClaimV1 memory holders = registry.feeClaim(registration.launchId, 2);
+        assertEq(builder.ordinal, 0);
+        assertEq(builder.grossVolumeFeeBps, 10);
+        assertEq(builder.shareOfFeeBps, 1000);
+        assertEq(builder.claimSelector, bytes4(0x69f9a5f0));
+        assertEq(builder.handoffSelector, bytes4(0x4ce11d21));
+        assertEq(programmable.ordinal, 1);
+        assertEq(programmable.grossVolumeFeeBps, 10);
+        assertEq(programmable.shareOfFeeBps, 1000);
+        assertEq(programmable.claimSelector, bytes4(0x64d46b85));
+        assertEq(programmable.handoffSelector, bytes4(0));
+        assertEq(holders.ordinal, 2);
+        assertEq(holders.grossVolumeFeeBps, 80);
+        assertEq(holders.shareOfFeeBps, 8000);
+        assertEq(holders.claimSelector, bytes4(0x6ba4c138));
+        assertEq(holders.handoffSelector, bytes4(0));
+        assertEq(
+            storedPolicy.claimSetHash,
+            keccak256(abi.encode(builder.storedClaimHash, programmable.storedClaimHash, holders.storedClaimHash))
+        );
+        assertTrue(registry.approvalConsumed(registration.approvalId));
+        assertTrue(registry.deploymentConsumed(registration.deploymentId));
+    }
+
+    function test_completeLifecycleFinalityCorrectionAndRevocation() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration("lifecycle");
+        _register(registration);
+        bytes32 feePolicyRecordHash = registry.feePolicyState(registration.launchId).feePolicyRecordHash;
+        bytes32 builderClaimHash = registry.feeClaim(registration.launchId, 0).storedClaimHash;
+
+        vm.roll(104);
+        bytes32 observedHash = _hash("block-100");
+        bytes32 confirmedHeadHash = _hash("block-103");
+        vm.setBlockhash(100, observedHash);
+        vm.setBlockhash(103, confirmedHeadHash);
+        IProgrammableCustomRegistryV1.FinalityProofV1 memory proof =
+            _finalityProof(registration, observedHash, confirmedHeadHash, _hash("finality-evidence"));
+        vm.prank(FINALIZER);
+        registry.finalizeLaunch(proof);
+
+        bytes32 correctedHash = _hash("corrected-record");
+        vm.prank(CORRECTOR);
+        registry.correctLaunchRecord(
+            IProgrammableCustomRegistryV1.RecordCorrectionV1({
+                chainId: block.chainid,
+                registryGeneration: GENERATION,
+                launchId: registration.launchId,
+                revision: 2,
+                previousRecordHash: registration.registeredRecordCommitment,
+                correctedRecordHash: correctedHash,
+                reasonCode: _hash("correction-reason"),
+                evidenceHash: _hash("correction-evidence")
+            })
+        );
+
+        vm.prank(REVOKER);
+        registry.revokeLaunch(
+            IProgrammableCustomRegistryV1.LaunchRevocationV1({
+                chainId: block.chainid,
+                registryGeneration: GENERATION,
+                launchId: registration.launchId,
+                reasonCode: _hash("revocation-reason"),
+                evidenceHash: _hash("revocation-evidence")
+            })
+        );
+
+        IProgrammableExactShardsRegistryV1.LaunchStateV1 memory state = registry.launchState(registration.launchId);
+        assertEq(uint8(state.status), uint8(IProgrammableCustomRegistryV1.LaunchStatus.Revoked));
+        assertEq(state.finalizedAtBlock, 104);
+        assertEq(state.finalityEvidenceHash, proof.finalityEvidenceHash);
+        assertEq(state.latestRecordRevision, 2);
+        assertEq(state.latestRecordHash, correctedHash);
+        assertEq(registry.recordHashAtRevision(registration.launchId, 1), registration.registeredRecordCommitment);
+        assertEq(registry.recordHashAtRevision(registration.launchId, 2), correctedHash);
+        assertEq(registry.feePolicyState(registration.launchId).feePolicyRecordHash, feePolicyRecordHash);
+        assertEq(registry.feeClaim(registration.launchId, 0).storedClaimHash, builderClaimHash);
+        assertEq(registry.transitionCount(), 5);
+    }
+
+    function test_rejectsWrongLegWrongEconomicsAndTwoClaimCollapseWithoutConsumption() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory wrongLeg = _registration("wrong-leg");
+        _authorize(wrongLeg);
+        wrongLeg.orderedFeeLegs[0].recipient = address(1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProgrammableExactShardsFeePolicyVerifierV1.InvalidShardsFeePolicy.selector, uint8(5)
+            )
+        );
+        vm.prank(WRITER);
+        registry.registerLaunch(wrongLeg);
+        assertFalse(registry.approvalConsumed(wrongLeg.approvalId));
+        assertFalse(registry.deploymentConsumed(wrongLeg.deploymentId));
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory wrongEconomics = _registration("wrong-economics");
+        _authorize(wrongEconomics);
+        wrongEconomics.feePolicy.totalFeeBps = 101;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProgrammableExactShardsFeePolicyVerifierV1.InvalidShardsFeePolicy.selector, uint8(4)
+            )
+        );
+        vm.prank(WRITER);
+        registry.registerLaunch(wrongEconomics);
+        assertFalse(registry.approvalConsumed(wrongEconomics.approvalId));
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory collapsed = _registration("collapsed");
+        _authorize(collapsed);
+        collapsed.orderedFeeLegs[0].feeBps = 20;
+        collapsed.orderedFeeLegs[1] = collapsed.orderedFeeLegs[2];
+        collapsed.orderedFeeLegs[2].feeBps = 0;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProgrammableExactShardsFeePolicyVerifierV1.InvalidShardsFeePolicy.selector, uint8(5)
+            )
+        );
+        vm.prank(WRITER);
+        registry.registerLaunch(collapsed);
+        assertFalse(registry.approvalConsumed(collapsed.approvalId));
+    }
+
+    function test_rejectsApprovalDeploymentEvidenceAndRegistryInstanceReplay() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory first = _registration("first");
+        _register(first);
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory approvalReplay = _registration("approval-replay");
+        approvalReplay.approvalId = first.approvalId;
+        _rebind(approvalReplay);
+        vm.expectRevert(
+            abi.encodeWithSelector(ProgrammableExactShardsRegistryV1.ApprovalAlreadyConsumed.selector, first.approvalId)
+        );
+        vm.prank(WRITER);
+        registry.registerLaunch(approvalReplay);
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory deploymentReplay =
+            _registration("deployment-replay");
+        deploymentReplay.deploymentId = first.deploymentId;
+        _rebind(deploymentReplay);
+        _authorize(deploymentReplay);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableExactShardsRegistryV1.DeploymentAlreadyConsumed.selector, first.deploymentId
+            )
+        );
+        vm.prank(WRITER);
+        registry.registerLaunch(deploymentReplay);
+
+        IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory evidenceReplay = _authorization(first);
+        evidenceReplay.approvalId = _hash("fresh-approval-id");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableExactShardsRegistryV1.EvidenceAlreadyConsumed.selector, evidenceReplay.evidenceHash
+            )
+        );
+        vm.prank(APPROVER);
+        registry.authorizeApproval(evidenceReplay);
+
+        ProgrammableExactShardsRegistryV1 otherRegistry = _newRegistry(verifier);
+        assertNotEq(otherRegistry.REGISTRY_INSTANCE_HASH(), registry.REGISTRY_INSTANCE_HASH());
+        IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory copiedAuthorization = _authorization(first);
+        vm.prank(APPROVER);
+        otherRegistry.authorizeApproval(copiedAuthorization);
+        vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.ApprovalBindingMismatch.selector);
+        vm.prank(WRITER);
+        otherRegistry.registerLaunch(first);
+    }
+
+    function test_rejectsAuthorizationMutationAndTerminalRevocation() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory mutation = _registration("mutation");
+        _authorize(mutation);
+        mutation.securityReviewHash = _hash("substituted-review");
+        _rebindRecordOnly(mutation);
+        vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.RegistrationBindingMismatch.selector);
+        vm.prank(WRITER);
+        registry.registerLaunch(mutation);
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory revoked = _registration("revoked");
+        _register(revoked);
+        vm.prank(REVOKER);
+        registry.revokeLaunch(
+            IProgrammableCustomRegistryV1.LaunchRevocationV1({
+                chainId: block.chainid,
+                registryGeneration: GENERATION,
+                launchId: revoked.launchId,
+                reasonCode: _hash("reason"),
+                evidenceHash: _hash("evidence")
+            })
+        );
+        vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.LaunchAlreadyRegistered.selector);
+        vm.prank(WRITER);
+        registry.registerLaunch(revoked);
+    }
+
+    function test_rejectsApprovedSourceRouteProfileAndProviderDrift() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory sourceDrift = _registration("source-drift");
+        sourceDrift.sourceCommitment = _hash("different-source");
+        _rebind(sourceDrift);
+        _authorize(sourceDrift);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableExactShardsRegistryV1.InvalidBinding.selector, bytes32("reviewed-source")
+            )
+        );
+        vm.prank(WRITER);
+        registry.registerLaunch(sourceDrift);
+        assertFalse(registry.approvalConsumed(sourceDrift.approvalId));
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory routeDrift = _registration("route-drift");
+        routeDrift.buildCommitment = _hash("different-route");
+        _rebind(routeDrift);
+        _authorize(routeDrift);
+        vm.expectRevert(
+            abi.encodeWithSelector(ProgrammableExactShardsRegistryV1.InvalidBinding.selector, bytes32("reviewed-route"))
+        );
+        vm.prank(WRITER);
+        registry.registerLaunch(routeDrift);
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory profileDrift = _registration("profile-drift");
+        profileDrift.marketPathId = _hash("different-profile");
+        _rebind(profileDrift);
+        _authorize(profileDrift);
+        vm.expectRevert(
+            abi.encodeWithSelector(ProgrammableExactShardsRegistryV1.InvalidBinding.selector, bytes32("market-profile"))
+        );
+        vm.prank(WRITER);
+        registry.registerLaunch(profileDrift);
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory providerDrift = _registration("provider-drift");
+        providerDrift.providerId = _hash("unreviewed-provider");
+        _rebind(providerDrift);
+        _authorize(providerDrift);
+        vm.expectRevert(
+            abi.encodeWithSelector(ProgrammableExactShardsRegistryV1.InvalidBinding.selector, bytes32("provider-id"))
+        );
+        vm.prank(WRITER);
+        registry.registerLaunch(providerDrift);
+    }
+
+    function test_finalityFailsClosedOnDepthHashAndEvidenceReplay() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration("finality");
+        _register(registration);
+        vm.roll(102);
+        vm.setBlockhash(100, _hash("block-100"));
+        vm.setBlockhash(101, _hash("block-101"));
+        IProgrammableCustomRegistryV1.FinalityProofV1 memory shallow =
+            _finalityProof(registration, _hash("block-100"), _hash("block-101"), _hash("shallow-evidence"));
+        shallow.confirmedHeadBlockNumber = 101;
+        vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.FinalityDepthInsufficient.selector);
+        vm.prank(FINALIZER);
+        registry.finalizeLaunch(shallow);
+
+        vm.roll(104);
+        vm.setBlockhash(100, _hash("canonical-100"));
+        vm.setBlockhash(103, _hash("block-103"));
+        IProgrammableCustomRegistryV1.FinalityProofV1 memory wrongHash =
+            _finalityProof(registration, _hash("fake-100"), _hash("block-103"), _hash("wrong-hash-evidence"));
+        vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.BlockHashMismatch.selector);
+        vm.prank(FINALIZER);
+        registry.finalizeLaunch(wrongHash);
+
+        IProgrammableCustomRegistryV1.FinalityProofV1 memory valid = _finalityProof(
+            registration, _hash("canonical-100"), _hash("block-103"), _hash("valid-finality-evidence")
+        );
+        vm.prank(FINALIZER);
+        registry.finalizeLaunch(valid);
+        assertTrue(registry.transitionEvidenceConsumed(valid.finalityEvidenceHash));
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory second = _registration("second-finality");
+        _register(second);
+        vm.roll(108);
+        vm.setBlockhash(104, _hash("block-104"));
+        vm.setBlockhash(107, _hash("block-107"));
+        IProgrammableCustomRegistryV1.FinalityProofV1 memory replay =
+            _finalityProof(second, _hash("block-104"), _hash("block-107"), valid.finalityEvidenceHash);
+        replay.observedBlockNumber = 104;
+        replay.confirmedHeadBlockNumber = 107;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableExactShardsRegistryV1.EvidenceAlreadyConsumed.selector, valid.finalityEvidenceHash
+            )
+        );
+        vm.prank(FINALIZER);
+        registry.finalizeLaunch(replay);
+    }
+
+    function test_roleSeparationAndWrongCallerFailClosed() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration("roles");
+        _authorize(registration);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, OUTSIDER, registry.WRITER_ROLE()
+            )
+        );
+        vm.prank(OUTSIDER);
+        registry.registerLaunch(registration);
+
+        bytes32 writerRole = registry.WRITER_ROLE();
+        vm.expectRevert(
+            abi.encodeWithSelector(ProgrammableExactShardsRegistryV1.IncompatibleOperationalRoles.selector, APPROVER)
+        );
+        vm.prank(ADMIN);
+        registry.grantRole(writerRole, APPROVER);
+    }
+
+    function testFuzz_anyGrossFeeMutationFailsClosed(uint16 builderFee, uint16 programmableFee, uint16 holderFee)
+        public
+    {
+        vm.assume(builderFee != 10 || programmableFee != 10 || holderFee != 80);
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration("fuzz-fees");
+        registration.orderedFeeLegs[0].feeBps = builderFee;
+        registration.orderedFeeLegs[1].feeBps = programmableFee;
+        registration.orderedFeeLegs[2].feeBps = holderFee;
+        vm.expectRevert();
+        registry.computeFeePolicyRecordHash(registration.feePolicy, registration.orderedFeeLegs);
+    }
+
+    function _newRegistry(ProgrammableExactShardsFeePolicyVerifierV1 verifier_)
+        private
+        returns (ProgrammableExactShardsRegistryV1)
+    {
+        return new ProgrammableExactShardsRegistryV1(
+            ProgrammableExactShardsRegistryV1.RegistryConfigV1({
+                initialAdminDelay: 2 days,
+                initialAdmin: ADMIN,
+                initialApprover: APPROVER,
+                initialWriter: WRITER,
+                initialFinalizer: FINALIZER,
+                initialCorrector: CORRECTOR,
+                initialRevoker: REVOKER,
+                registryGeneration: GENERATION,
+                minimumFinalityBlocks: FINALITY_BLOCKS,
+                chainProfileHash: _hash("ethereum-mainnet-chain-profile"),
+                registryPolicyHash: _hash("exact-shards-registry-policy")
+            }),
+            verifier_
+        );
+    }
+
+    function _registration(string memory label)
+        private
+        view
+        returns (IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+    {
+        registration.chainId = block.chainid;
+        registration.registryGeneration = GENERATION;
+        registration.launchId = _hash(string.concat(label, "-launch-id"));
+        registration.projectId = _hash(string.concat(label, "-project-id"));
+        registration.approvalId = _hash(string.concat(label, "-approval-id"));
+        registration.repositoryId = _hash("jesse-stahl/shards-v1");
+        registration.commitId = bytes32(bytes20(hex"91b38f3de64d96cac7e29f127c004f128fc1da59"));
+        registration.sourceCommitment = verifier.SOURCE_REVISION_HASH();
+        registration.buildCommitment = verifier.NESTED_FACTORY_ARTIFACT_SHA256();
+        registration.artifactSetHash = _hash(string.concat(label, "-artifact-set"));
+        registration.deploymentConfigurationHash = _hash(string.concat(label, "-deployment-configuration"));
+        registration.configurationHash = _hash(string.concat(label, "-configuration"));
+        registration.permissionsHash = _hash(string.concat(label, "-permissions"));
+        registration.deploymentId = _hash(string.concat(label, "-deployment-id"));
+        registration.deploymentSetHash = _hash(string.concat(label, "-deployment-set"));
+        registration.runtimeCodeSetHash = _hash(string.concat(label, "-runtime-code-set"));
+        registration.primaryContract = address(runtimeTarget);
+        registration.primaryRuntimeCodeHash = address(runtimeTarget).codehash;
+        registration.launchWallet = address(0x51A4D5);
+        registration.modelId = _hash("programmable.exact-shards.v1");
+        registration.modelVersion = _hash("1");
+        registration.templateId = _hash("programmable.exact-shards.nested-factory.v1");
+        registration.templateVersion = _hash("1");
+        registration.providerId = bytes32(0);
+        registration.builderAttributionHash = _hash(string.concat(label, "-builder"));
+        registration.originHash = _hash(string.concat(label, "-origin"));
+        registration.assetSetHash = _hash(string.concat(label, "-assets"));
+        registration.marketSetHash = _hash(string.concat(label, "-markets"));
+        registration.marketPathId = verifier.PROFILE_KEY();
+        registration.capabilitySetHash = _hash(string.concat(label, "-capabilities"));
+        registration.reviewPolicyHash = _hash("programmable-shards-review-policy-v1");
+        registration.securityReviewHash = _hash(string.concat(label, "-security-review"));
+        registration.reviewResultId = _hash(string.concat(label, "-review-result"));
+        registration.finalityPolicyHash = _hash("programmable-finality-policy-v1");
+
+        registration.feePolicy.profileKey = verifier.PROFILE_KEY();
+        registration.feePolicy.feeAsset = verifier.FEE_ASSET();
+        registration.feePolicy.feeBasisHash = verifier.FEE_BASIS_HASH();
+        registration.feePolicy.totalFeeBps = verifier.TOTAL_FEE_BPS();
+        registration.feePolicy.legsHash = verifier.LEGS_HASH();
+        registration.orderedFeeLegs[0] = IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1({
+            roleHash: verifier.BUILDER_ROLE_HASH(),
+            feeBps: verifier.BUILDER_FEE_BPS(),
+            recipient: verifier.INITIAL_BUILDER_RECIPIENT(),
+            recipientModeHash: verifier.BUILDER_RECIPIENT_MODE_HASH()
+        });
+        registration.orderedFeeLegs[1] = IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1({
+            roleHash: verifier.PROGRAMMABLE_ROLE_HASH(),
+            feeBps: verifier.PROGRAMMABLE_FEE_BPS(),
+            recipient: verifier.PROGRAMMABLE_RECIPIENT(),
+            recipientModeHash: verifier.PROGRAMMABLE_RECIPIENT_MODE_HASH()
+        });
+        registration.orderedFeeLegs[2] = IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1({
+            roleHash: verifier.HOLDER_ROLE_HASH(),
+            feeBps: verifier.HOLDER_FEE_BPS(),
+            recipient: verifier.HOLDER_ACCUMULATOR(),
+            recipientModeHash: verifier.HOLDER_RECIPIENT_MODE_HASH()
+        });
+        _rebind(registration);
+    }
+
+    function _rebind(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration) private view {
+        registration.approvalBindingHash = registry.computeApprovalBindingHash(registration);
+        registration.reviewDeploymentBindingHash = registry.computeReviewDeploymentBindingHash(registration);
+        registration.registeredRecordCommitment = registry.computeRegisteredRecordCommitment(registration);
+    }
+
+    function _rebindRecordOnly(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        view
+    {
+        registration.reviewDeploymentBindingHash = registry.computeReviewDeploymentBindingHash(registration);
+        registration.registeredRecordCommitment = registry.computeRegisteredRecordCommitment(registration);
+    }
+
+    function _authorization(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        view
+        returns (IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory authorization)
+    {
+        authorization = IProgrammableCustomRegistryV1.ApprovalAuthorizationV1({
+            chainId: registration.chainId,
+            registryGeneration: registration.registryGeneration,
+            approvalId: registration.approvalId,
+            launchId: registration.launchId,
+            approvalBindingHash: registration.approvalBindingHash,
+            registrationBindingHash: registry.computeRegistrationBindingHash(registration),
+            validAfterBlock: uint64(block.number),
+            expiresAtBlock: uint64(block.number + 200),
+            evidenceHash: keccak256(abi.encode("approval-evidence", registration.approvalId))
+        });
+    }
+
+    function _authorize(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration) private {
+        IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory authorization = _authorization(registration);
+        vm.prank(APPROVER);
+        registry.authorizeApproval(authorization);
+    }
+
+    function _register(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration) private {
+        _authorize(registration);
+        vm.prank(WRITER);
+        registry.registerLaunch(registration);
+    }
+
+    function _finalityProof(
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration,
+        bytes32 observedBlockHash,
+        bytes32 confirmedHeadBlockHash,
+        bytes32 evidenceHash
+    ) private pure returns (IProgrammableCustomRegistryV1.FinalityProofV1 memory proof) {
+        proof.chainId = registration.chainId;
+        proof.registryGeneration = registration.registryGeneration;
+        proof.launchId = registration.launchId;
+        proof.observedBlockNumber = 100;
+        proof.observedBlockHash = observedBlockHash;
+        proof.observedTransactionHash = _hash("observed-transaction");
+        proof.observedTransactionIndex = 1;
+        proof.observedLogIndex = 2;
+        proof.confirmedHeadBlockNumber = 103;
+        proof.confirmedHeadBlockHash = confirmedHeadBlockHash;
+        proof.finalityPolicyHash = registration.finalityPolicyHash;
+        proof.finalityEvidenceHash = evidenceHash;
+    }
+
+    function _hash(string memory value) private pure returns (bytes32) {
+        return keccak256(bytes(value));
+    }
+}

--- a/contracts/test/ProgrammableExactShardsRegistryV1.t.sol
+++ b/contracts/test/ProgrammableExactShardsRegistryV1.t.sol
@@ -6,11 +6,15 @@ import { Test } from "forge-std/Test.sol";
 
 import { ProgrammableExactShardsFeePolicyVerifierV1 } from "../src/ProgrammableExactShardsFeePolicyVerifierV1.sol";
 import { ProgrammableExactShardsRegistryV1 } from "../src/ProgrammableExactShardsRegistryV1.sol";
+import {
+    ProgrammableGithubRepositoryLineageRegistryV1
+} from "../src/ProgrammableGithubRepositoryLineageRegistryV1.sol";
 import { IProgrammableCustomRegistryV1 } from "../src/interfaces/IProgrammableCustomRegistryV1.sol";
 import {
     IProgrammableExactShardsFeePolicyVerifierV1
 } from "../src/interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol";
 import { IProgrammableExactShardsRegistryV1 } from "../src/interfaces/IProgrammableExactShardsRegistryV1.sol";
+import { ProgrammableExactShardsBindingHarnessV1 } from "./utils/ProgrammableExactShardsBindingHarnessV1.sol";
 
 contract ExactShardsRegistryRuntimeTargetV1 {
     function version() external pure returns (uint256) {
@@ -21,6 +25,25 @@ contract ExactShardsRegistryRuntimeTargetV1 {
 contract ExactShardsVerifierImpostorV1 {
     function feePolicyBindingHashV1() external pure returns (bytes32) {
         return 0x5d5d1c46e7627f6e171a18acdbecbfe9e40eca80016fba0142ddca6a054f6169;
+    }
+}
+
+contract ExactShardsAtomicWriterHarnessV1 {
+    bytes32 private constant ROUTE_ID = keccak256("programmable.exact-shards.atomic-launch-route.v1");
+    ProgrammableGithubRepositoryLineageRegistryV1 private immutable _lineageRegistry;
+    ProgrammableExactShardsRegistryV1 private immutable _registry;
+
+    constructor(
+        ProgrammableGithubRepositoryLineageRegistryV1 lineageRegistry,
+        ProgrammableExactShardsRegistryV1 registry
+    ) {
+        _lineageRegistry = lineageRegistry;
+        _registry = registry;
+    }
+
+    function register(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 calldata registration) external {
+        _lineageRegistry.consume(registration.githubRepositoryId, registration.launchId, ROUTE_ID);
+        _registry.registerLaunch(registration);
     }
 }
 
@@ -35,10 +58,14 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
 
     uint64 internal constant GENERATION = 3;
     uint64 internal constant FINALITY_BLOCKS = 3;
+    uint64 internal constant SHARDS_GITHUB_REPOSITORY_ID = 1_329_073_878;
     uint256 internal constant MAX_REGISTRATION_GAS = 2_200_000;
 
     ProgrammableExactShardsFeePolicyVerifierV1 internal verifier;
     ProgrammableExactShardsRegistryV1 internal registry;
+    ProgrammableGithubRepositoryLineageRegistryV1 internal lineageRegistry;
+    ProgrammableExactShardsBindingHarnessV1 internal bindingHarness;
+    ExactShardsAtomicWriterHarnessV1 internal writerHarness;
     ExactShardsRegistryRuntimeTargetV1 internal runtimeTarget;
 
     function setUp() public {
@@ -46,8 +73,17 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         vm.roll(100);
         vm.warp(1_800_000_000);
         verifier = new ProgrammableExactShardsFeePolicyVerifierV1();
+        lineageRegistry = new ProgrammableGithubRepositoryLineageRegistryV1(2 days, ADMIN);
         runtimeTarget = new ExactShardsRegistryRuntimeTargetV1();
         registry = _newRegistry(verifier);
+        bindingHarness = new ProgrammableExactShardsBindingHarnessV1(registry, verifier, lineageRegistry);
+        writerHarness = new ExactShardsAtomicWriterHarnessV1(lineageRegistry, registry);
+        bytes32 lineageConsumerRole = lineageRegistry.CONSUMER_ROLE();
+        bytes32 registryWriterRole = registry.WRITER_ROLE();
+        vm.prank(ADMIN);
+        lineageRegistry.grantRole(lineageConsumerRole, address(writerHarness));
+        vm.prank(ADMIN);
+        registry.grantRole(registryWriterRole, address(writerHarness));
     }
 
     function test_constructorPinsExactVerifierInstanceScopeAndLeastPrivilege() public view {
@@ -71,7 +107,9 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
                     registry.REGISTRY_POLICY_HASH(),
                     address(verifier),
                     address(verifier).codehash,
-                    verifier.feePolicyBindingHashV1()
+                    verifier.feePolicyBindingHashV1(),
+                    address(lineageRegistry),
+                    address(lineageRegistry).codehash
                 )
             )
         );
@@ -91,7 +129,9 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
                 address(impostor).codehash
             )
         );
-        new ProgrammableExactShardsRegistryV1(_config(), ProgrammableExactShardsFeePolicyVerifierV1(address(impostor)));
+        new ProgrammableExactShardsRegistryV1(
+            _config(), ProgrammableExactShardsFeePolicyVerifierV1(address(impostor)), lineageRegistry
+        );
     }
 
     function test_machineCheckableSpecMatchesArtifactAndFailClosedBoundary() public view {
@@ -105,6 +145,73 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         assertEq(vm.parseJsonUint(json, ".exactPolicy.orderedClaims[0].grossVolumeFeeBps"), 10);
         assertEq(vm.parseJsonUint(json, ".exactPolicy.orderedClaims[1].grossVolumeFeeBps"), 10);
         assertEq(vm.parseJsonUint(json, ".exactPolicy.orderedClaims[2].grossVolumeFeeBps"), 80);
+        assertFalse(
+            vm.parseJsonBool(
+                json, ".postApprovalLaunchMetadataBoundary.githubSubmissionApproval.includesSelectedUiMetadata"
+            )
+        );
+        assertFalse(
+            vm.parseJsonBool(
+                json, ".postApprovalLaunchMetadataBoundary.launchDescriptor.presentationValuesAreSourceArtifactInputs"
+            )
+        );
+        assertFalse(
+            vm.parseJsonBool(
+                json, ".postApprovalLaunchMetadataBoundary.launchDescriptor.additionalConfigurationFieldsAllowed"
+            )
+        );
+        string[] memory configurationFields =
+            vm.parseJsonStringArray(json, ".postApprovalLaunchMetadataBoundary.launchDescriptor.configurationFieldIds");
+        assertEq(configurationFields.length, 2);
+        assertEq(configurationFields[0], "tokenName");
+        assertEq(configurationFields[1], "tokenSymbol");
+        assertEq(
+            vm.parseJsonString(
+                json, ".postApprovalLaunchMetadataBoundary.jitLaunchIntentPermit.substitutionAfterPermit"
+            ),
+            "REJECT"
+        );
+        assertTrue(vm.parseJsonBool(json, ".postApprovalLaunchMetadataBoundary.registryFinalRecord.bindsTokenNameHash"));
+        assertTrue(
+            vm.parseJsonBool(json, ".postApprovalLaunchMetadataBoundary.registryFinalRecord.bindsTokenSymbolHash")
+        );
+        assertTrue(
+            vm.parseJsonBool(
+                json, ".postApprovalLaunchMetadataBoundary.registryFinalRecord.bindsPresentationBindingHash"
+            )
+        );
+        assertTrue(
+            vm.parseJsonBool(
+                json,
+                ".postApprovalLaunchMetadataBoundary.executionRouteConformance.factoryLaunchParamsContainTokenNameAndTokenSymbol"
+            )
+        );
+        assertTrue(
+            vm.parseJsonBool(
+                json,
+                ".postApprovalLaunchMetadataBoundary.executionRouteConformance.producedErc20NameAndSymbolMatchSelection"
+            )
+        );
+        assertTrue(
+            vm.parseJsonBool(
+                json,
+                ".postApprovalLaunchMetadataBoundary.executionRouteConformance.upstreamTest.assertsProducedTokenNameAndSymbol"
+            )
+        );
+        assertEq(
+            vm.parseJsonString(
+                json, ".postApprovalLaunchMetadataBoundary.executionRouteConformance.upstreamTest.result"
+            ),
+            "PASS_1_OF_1_EXACT_SOURCE"
+        );
+        assertEq(
+            vm.parseJsonUint(json, ".implementation.sharedRepositoryLineageAuthority.shardsGithubRepositoryId"),
+            SHARDS_GITHUB_REPOSITORY_ID
+        );
+        assertEq(
+            vm.parseJsonBytes32(json, ".implementation.sharedRepositoryLineageAuthority.shardsRepositoryKey"),
+            lineageRegistry.computeRepositoryKey(SHARDS_GITHUB_REPOSITORY_ID)
+        );
         assertEq(
             vm.parseJsonBytes32(json, ".reviewedInputs.feeVerifier.contentBindingHash"),
             registry.FEE_POLICY_BINDING_HASH()
@@ -119,6 +226,9 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
             )
         );
         bytes memory unlinkedRuntime = vm.parseBytes(vm.parseJsonString(buildArtifact, ".deployedBytecode.object"));
+        assertTrue(vm.parseJsonBool(json, ".implementation.compiler.optimizer"));
+        assertEq(vm.parseJsonUint(json, ".implementation.compiler.optimizerRuns"), 1000);
+        assertFalse(vm.parseJsonBool(json, ".implementation.compiler.viaIr"));
         assertEq(
             keccak256(unlinkedRuntime),
             vm.parseJsonBytes32(json, ".implementation.artifact.unlinkedRuntimeCodeKeccak256")
@@ -131,24 +241,25 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
             unlinkedRuntime.length, vm.parseJsonUint(json, ".implementation.artifact.unlinkedRuntimeCodeByteLength")
         );
         assertEq(address(registry).code.length, unlinkedRuntime.length);
+        assertEq(
+            24_576 - unlinkedRuntime.length,
+            vm.parseJsonUint(json, ".implementation.artifact.runtimeCodeLimitMarginBytes")
+        );
     }
 
     function test_registersAndStoresAllThreeClaimsWithExactHashBinding() public {
         IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration("canonical");
-        bytes32 feePolicyRecordHash =
-            registry.computeFeePolicyRecordHash(registration.feePolicy, registration.orderedFeeLegs);
-        bytes32 policyHash = registry.computeFeePolicyHash(registration.feePolicy, registration.orderedFeeLegs);
+        bytes32 policyHash = verifier.verify(registration.feePolicy, registration.orderedFeeLegs);
         _authorize(registration);
 
-        vm.prank(WRITER);
-        registry.registerLaunch(registration);
+        writerHarness.register(registration);
 
         IProgrammableExactShardsRegistryV1.LaunchStateV1 memory state = registry.launchState(registration.launchId);
         IProgrammableExactShardsRegistryV1.StoredFeePolicyV1 memory storedPolicy =
             registry.feePolicyState(registration.launchId);
         assertEq(uint8(state.status), uint8(IProgrammableCustomRegistryV1.LaunchStatus.Observed));
         assertEq(state.feePolicyHash, policyHash);
-        assertEq(state.feePolicyRecordHash, feePolicyRecordHash);
+        bytes32 feePolicyRecordHash = state.feePolicyRecordHash;
         assertEq(storedPolicy.policyHash, policyHash);
         assertEq(storedPolicy.feePolicyRecordHash, feePolicyRecordHash);
         assertEq(storedPolicy.verifierBindingHash, verifier.feePolicyBindingHashV1());
@@ -182,13 +293,86 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         assertTrue(registry.deploymentConsumed(registration.deploymentId));
     }
 
+    function test_technicalApprovalPreexistsAndJitPermitBindsExactWebsiteMetadata() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory selected = _registration("metadata-bound");
+        bytes32 technicalApprovalBinding = selected.approvalBindingHash;
+        (, bytes32 permittedLaunchIntent,,) = bindingHarness.computeBindings(selected);
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory technicalTemplate =
+            _registration("metadata-bound");
+        technicalTemplate.tokenNameHash = bytes32(0);
+        technicalTemplate.tokenSymbolHash = bytes32(0);
+        technicalTemplate.presentationBindingHash = bytes32(0);
+        (bytes32 templateApprovalBinding,,,) = bindingHarness.computeBindings(technicalTemplate);
+        assertEq(templateApprovalBinding, technicalApprovalBinding);
+        _authorizeTechnical(technicalTemplate);
+        assertEq(registry.approvalState(selected.approvalId).registrationBindingHash, technicalApprovalBinding);
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory substituted = _registration("metadata-bound");
+        substituted.tokenNameHash = keccak256(bytes("Substituted Shards"));
+        substituted.tokenSymbolHash = keccak256(bytes("FAKE"));
+        substituted.presentationBindingHash = _hash("substituted-description-image-links");
+        _rebindRecordOnly(substituted);
+
+        // GitHub approval remains the same because it binds reviewed technical material, not UI values.
+        (bytes32 substitutedApprovalBinding, bytes32 substitutedIntent,,) = bindingHarness.computeBindings(substituted);
+        assertEq(substitutedApprovalBinding, technicalApprovalBinding);
+        // The one-use just-in-time permit and final Registry record both bind the exact selected values.
+        assertNotEq(substitutedIntent, permittedLaunchIntent);
+        assertNotEq(substituted.registeredRecordCommitment, selected.registeredRecordCommitment);
+
+        _authorizeLaunchIntent(selected);
+        vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.RegistrationBindingMismatch.selector);
+        writerHarness.register(substituted);
+        assertFalse(registry.approvalConsumed(selected.approvalId));
+        assertEq(
+            lineageRegistry.consumption(lineageRegistry.computeRepositoryKey(selected.githubRepositoryId)).launchId,
+            bytes32(0)
+        );
+
+        writerHarness.register(selected);
+        assertTrue(registry.approvalConsumed(selected.approvalId));
+        assertEq(registry.launchState(selected.launchId).latestRecordHash, selected.registeredRecordCommitment);
+    }
+
+    function test_numericGithubRepositoryLineageIsOneLaunchAndExactReceiptRetryIsIdempotent() public {
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory first = _registration("repository-first");
+        _register(first);
+        bytes32 repositoryKey = lineageRegistry.computeRepositoryKey(first.githubRepositoryId);
+        assertEq(lineageRegistry.consumption(repositoryKey).launchId, first.launchId);
+
+        uint64 registrationsBeforeRetry = registry.registrationCount();
+        uint64 transitionsBeforeRetry = registry.transitionCount();
+        writerHarness.register(first);
+        assertEq(registry.registrationCount(), registrationsBeforeRetry);
+        assertEq(registry.transitionCount(), transitionsBeforeRetry);
+
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory second =
+            _registration("repository-second-revision-factory");
+        second.templateVersion = _hash("different-reviewed-factory-revision");
+        _rebind(second);
+        _authorize(second);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableGithubRepositoryLineageRegistryV1.RepositoryAlreadyConsumed.selector,
+                repositoryKey,
+                first.launchId,
+                keccak256("programmable.exact-shards.atomic-launch-route.v1"),
+                address(writerHarness)
+            )
+        );
+        writerHarness.register(second);
+        assertFalse(registry.approvalConsumed(second.approvalId));
+        assertFalse(registry.deploymentConsumed(second.deploymentId));
+        assertEq(lineageRegistry.consumption(repositoryKey).launchId, first.launchId);
+    }
+
     function test_registrationGasStaysBelowHardMaximum() public {
         IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration("gas-bound");
         _authorize(registration);
 
-        vm.prank(WRITER);
         uint256 gasBefore = gasleft();
-        registry.registerLaunch(registration);
+        writerHarness.register(registration);
         uint256 registrationGas = gasBefore - gasleft();
 
         assertLe(registrationGas, MAX_REGISTRATION_GAS);
@@ -246,7 +430,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         assertEq(registry.recordHashAtRevision(registration.launchId, 2), correctedHash);
         assertEq(registry.feePolicyState(registration.launchId).feePolicyRecordHash, feePolicyRecordHash);
         assertEq(registry.feeClaim(registration.launchId, 0).storedClaimHash, builderClaimHash);
-        assertEq(registry.transitionCount(), 5);
+        assertEq(registry.transitionCount(), 6);
     }
 
     function test_rejectsWrongLegWrongEconomicsAndTwoClaimCollapseWithoutConsumption() public {
@@ -258,8 +442,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
                 IProgrammableExactShardsFeePolicyVerifierV1.InvalidShardsFeePolicy.selector, uint8(5)
             )
         );
-        vm.prank(WRITER);
-        registry.registerLaunch(wrongLeg);
+        writerHarness.register(wrongLeg);
         assertFalse(registry.approvalConsumed(wrongLeg.approvalId));
         assertFalse(registry.deploymentConsumed(wrongLeg.deploymentId));
 
@@ -271,8 +454,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
                 IProgrammableExactShardsFeePolicyVerifierV1.InvalidShardsFeePolicy.selector, uint8(4)
             )
         );
-        vm.prank(WRITER);
-        registry.registerLaunch(wrongEconomics);
+        writerHarness.register(wrongEconomics);
         assertFalse(registry.approvalConsumed(wrongEconomics.approvalId));
 
         IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory collapsed = _registration("collapsed");
@@ -285,8 +467,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
                 IProgrammableExactShardsFeePolicyVerifierV1.InvalidShardsFeePolicy.selector, uint8(5)
             )
         );
-        vm.prank(WRITER);
-        registry.registerLaunch(collapsed);
+        writerHarness.register(collapsed);
         assertFalse(registry.approvalConsumed(collapsed.approvalId));
     }
 
@@ -331,6 +512,9 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory copiedAuthorization = _authorization(first);
         vm.prank(APPROVER);
         otherRegistry.authorizeApproval(copiedAuthorization);
+        IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory copiedIntent = _launchIntentAuthorization(first);
+        vm.prank(APPROVER);
+        otherRegistry.authorizeLaunchIntent(copiedIntent);
         vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.ApprovalBindingMismatch.selector);
         vm.prank(WRITER);
         otherRegistry.registerLaunch(first);
@@ -341,9 +525,8 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         _authorize(mutation);
         mutation.securityReviewHash = _hash("substituted-review");
         _rebindRecordOnly(mutation);
-        vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.RegistrationBindingMismatch.selector);
-        vm.prank(WRITER);
-        registry.registerLaunch(mutation);
+        vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.ApprovalBindingMismatch.selector);
+        writerHarness.register(mutation);
 
         IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory revoked = _registration("revoked");
         _register(revoked);
@@ -358,8 +541,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
             })
         );
         vm.expectPartialRevert(ProgrammableExactShardsRegistryV1.LaunchAlreadyRegistered.selector);
-        vm.prank(WRITER);
-        registry.registerLaunch(revoked);
+        writerHarness.register(revoked);
     }
 
     function test_rejectsApprovedSourceRouteProfileAndProviderDrift() public {
@@ -372,8 +554,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
                 ProgrammableExactShardsRegistryV1.InvalidBinding.selector, bytes32("reviewed-source")
             )
         );
-        vm.prank(WRITER);
-        registry.registerLaunch(sourceDrift);
+        writerHarness.register(sourceDrift);
         assertFalse(registry.approvalConsumed(sourceDrift.approvalId));
 
         IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory routeDrift = _registration("route-drift");
@@ -383,8 +564,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         vm.expectRevert(
             abi.encodeWithSelector(ProgrammableExactShardsRegistryV1.InvalidBinding.selector, bytes32("reviewed-route"))
         );
-        vm.prank(WRITER);
-        registry.registerLaunch(routeDrift);
+        writerHarness.register(routeDrift);
 
         IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory profileDrift = _registration("profile-drift");
         profileDrift.marketPathId = _hash("different-profile");
@@ -393,8 +573,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         vm.expectRevert(
             abi.encodeWithSelector(ProgrammableExactShardsRegistryV1.InvalidBinding.selector, bytes32("market-profile"))
         );
-        vm.prank(WRITER);
-        registry.registerLaunch(profileDrift);
+        writerHarness.register(profileDrift);
 
         IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory providerDrift = _registration("provider-drift");
         providerDrift.providerId = _hash("unreviewed-provider");
@@ -403,8 +582,7 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         vm.expectRevert(
             abi.encodeWithSelector(ProgrammableExactShardsRegistryV1.InvalidBinding.selector, bytes32("provider-id"))
         );
-        vm.prank(WRITER);
-        registry.registerLaunch(providerDrift);
+        writerHarness.register(providerDrift);
     }
 
     function test_finalityFailsClosedOnDepthHashAndEvidenceReplay() public {
@@ -429,14 +607,15 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         vm.prank(FINALIZER);
         registry.finalizeLaunch(wrongHash);
 
-        IProgrammableCustomRegistryV1.FinalityProofV1 memory valid = _finalityProof(
-            registration, _hash("canonical-100"), _hash("block-103"), _hash("valid-finality-evidence")
-        );
+        IProgrammableCustomRegistryV1.FinalityProofV1 memory valid =
+            _finalityProof(registration, _hash("canonical-100"), _hash("block-103"), _hash("valid-finality-evidence"));
         vm.prank(FINALIZER);
         registry.finalizeLaunch(valid);
         assertTrue(registry.transitionEvidenceConsumed(valid.finalityEvidenceHash));
 
         IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory second = _registration("second-finality");
+        second.githubRepositoryId = SHARDS_GITHUB_REPOSITORY_ID + 1;
+        _rebind(second);
         _register(second);
         vm.roll(108);
         vm.setBlockhash(104, _hash("block-104"));
@@ -482,14 +661,14 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         registration.orderedFeeLegs[1].feeBps = programmableFee;
         registration.orderedFeeLegs[2].feeBps = holderFee;
         vm.expectRevert();
-        registry.computeFeePolicyRecordHash(registration.feePolicy, registration.orderedFeeLegs);
+        verifier.verify(registration.feePolicy, registration.orderedFeeLegs);
     }
 
     function _newRegistry(ProgrammableExactShardsFeePolicyVerifierV1 verifier_)
         private
         returns (ProgrammableExactShardsRegistryV1)
     {
-        return new ProgrammableExactShardsRegistryV1(_config(), verifier_);
+        return new ProgrammableExactShardsRegistryV1(_config(), verifier_, lineageRegistry);
     }
 
     function _config() private pure returns (ProgrammableExactShardsRegistryV1.RegistryConfigV1 memory config) {
@@ -518,13 +697,16 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
         registration.launchId = _hash(string.concat(label, "-launch-id"));
         registration.projectId = _hash(string.concat(label, "-project-id"));
         registration.approvalId = _hash(string.concat(label, "-approval-id"));
-        registration.repositoryId = _hash("jesse-stahl/shards-v1");
+        registration.githubRepositoryId = SHARDS_GITHUB_REPOSITORY_ID;
         registration.commitId = bytes32(bytes20(hex"91b38f3de64d96cac7e29f127c004f128fc1da59"));
         registration.sourceCommitment = verifier.SOURCE_REVISION_HASH();
         registration.buildCommitment = verifier.NESTED_FACTORY_ARTIFACT_SHA256();
         registration.artifactSetHash = _hash(string.concat(label, "-artifact-set"));
         registration.deploymentConfigurationHash = _hash(string.concat(label, "-deployment-configuration"));
         registration.configurationHash = _hash(string.concat(label, "-configuration"));
+        registration.tokenNameHash = keccak256(bytes("Shards"));
+        registration.tokenSymbolHash = keccak256(bytes("SHARDS"));
+        registration.presentationBindingHash = _hash(string.concat(label, "-description-image-links"));
         registration.permissionsHash = _hash(string.concat(label, "-permissions"));
         registration.deploymentId = _hash(string.concat(label, "-deployment-id"));
         registration.deploymentSetHash = _hash(string.concat(label, "-deployment-set"));
@@ -575,17 +757,17 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
     }
 
     function _rebind(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration) private view {
-        registration.approvalBindingHash = registry.computeApprovalBindingHash(registration);
-        registration.reviewDeploymentBindingHash = registry.computeReviewDeploymentBindingHash(registration);
-        registration.registeredRecordCommitment = registry.computeRegisteredRecordCommitment(registration);
+        (registration.approvalBindingHash,,,) = bindingHarness.computeBindings(registration);
+        (,, registration.reviewDeploymentBindingHash,) = bindingHarness.computeBindings(registration);
+        (,,, registration.registeredRecordCommitment) = bindingHarness.computeBindings(registration);
     }
 
     function _rebindRecordOnly(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
         private
         view
     {
-        registration.reviewDeploymentBindingHash = registry.computeReviewDeploymentBindingHash(registration);
-        registration.registeredRecordCommitment = registry.computeRegisteredRecordCommitment(registration);
+        (,, registration.reviewDeploymentBindingHash,) = bindingHarness.computeBindings(registration);
+        (,,, registration.registeredRecordCommitment) = bindingHarness.computeBindings(registration);
     }
 
     function _authorization(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
@@ -599,23 +781,62 @@ contract ProgrammableExactShardsRegistryV1Test is Test {
             approvalId: registration.approvalId,
             launchId: registration.launchId,
             approvalBindingHash: registration.approvalBindingHash,
-            registrationBindingHash: registry.computeRegistrationBindingHash(registration),
+            registrationBindingHash: registration.approvalBindingHash,
             validAfterBlock: uint64(block.number),
-            expiresAtBlock: uint64(block.number + 200),
+            expiresAtBlock: type(uint64).max,
             evidenceHash: keccak256(abi.encode("approval-evidence", registration.approvalId))
         });
     }
 
-    function _authorize(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration) private {
+    function _launchIntentAuthorization(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        view
+        returns (IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory authorization)
+    {
+        authorization = IProgrammableCustomRegistryV1.ApprovalAuthorizationV1({
+            chainId: registration.chainId,
+            registryGeneration: registration.registryGeneration,
+            approvalId: registration.approvalId,
+            launchId: registration.launchId,
+            approvalBindingHash: registration.approvalBindingHash,
+            registrationBindingHash: _launchIntentBinding(registration),
+            validAfterBlock: uint64(block.number),
+            expiresAtBlock: uint64(block.number + 200),
+            evidenceHash: keccak256(abi.encode("launch-intent-evidence", registration.approvalId))
+        });
+    }
+
+    function _launchIntentBinding(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        view
+        returns (bytes32 bindingHash)
+    {
+        (, bindingHash,,) = bindingHarness.computeBindings(registration);
+    }
+
+    function _authorizeTechnical(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration) private {
         IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory authorization = _authorization(registration);
         vm.prank(APPROVER);
         registry.authorizeApproval(authorization);
     }
 
+    function _authorizeLaunchIntent(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+    {
+        IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory authorization =
+            _launchIntentAuthorization(registration);
+        vm.prank(APPROVER);
+        registry.authorizeLaunchIntent(authorization);
+    }
+
+    function _authorize(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration) private {
+        _authorizeTechnical(registration);
+        _authorizeLaunchIntent(registration);
+    }
+
     function _register(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration) private {
         _authorize(registration);
-        vm.prank(WRITER);
-        registry.registerLaunch(registration);
+        writerHarness.register(registration);
     }
 
     function _finalityProof(

--- a/contracts/test/ProgrammableGithubRepositoryLineageRegistryV1.t.sol
+++ b/contracts/test/ProgrammableGithubRepositoryLineageRegistryV1.t.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { Test } from "forge-std/Test.sol";
+
+import {
+    ProgrammableGithubRepositoryLineageRegistryV1
+} from "../src/ProgrammableGithubRepositoryLineageRegistryV1.sol";
+import {
+    IProgrammableGithubRepositoryLineageRegistryV1
+} from "../src/interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol";
+
+contract MockRepositoryRouteConsumerV1 {
+    IProgrammableGithubRepositoryLineageRegistryV1 public immutable REGISTRY;
+    bytes32 public immutable ROUTE_ID;
+    uint256 public irreversibleExecutionCount;
+
+    error MockRouteExecutionReverted();
+
+    constructor(IProgrammableGithubRepositoryLineageRegistryV1 registry, bytes32 routeId) {
+        REGISTRY = registry;
+        ROUTE_ID = routeId;
+    }
+
+    function consumeOnly(uint64 githubRepositoryId, bytes32 launchId) external returns (bytes32) {
+        return REGISTRY.consume(githubRepositoryId, launchId, ROUTE_ID);
+    }
+
+    function consumeThenExecute(uint64 githubRepositoryId, bytes32 launchId, bool revertAfterConsume) external {
+        REGISTRY.consume(githubRepositoryId, launchId, ROUTE_ID);
+        if (revertAfterConsume) revert MockRouteExecutionReverted();
+        irreversibleExecutionCount++;
+    }
+}
+
+contract ProgrammableGithubRepositoryLineageRegistryV1Test is Test {
+    address internal constant ADMIN = address(0xA11CE);
+    uint64 internal constant SHARDS_GITHUB_REPOSITORY_ID = 1_329_073_878;
+    uint64 internal constant HOOKEMON_GITHUB_REPOSITORY_ID = 1_324_982_531;
+    bytes32 internal constant SHARDS_REPOSITORY_KEY =
+        0x02ed38e86a7c41d5dea93cf5e3f829420837c4d351d9f4675929c6ce0041e835;
+    bytes32 internal constant HOOKEMON_REPOSITORY_KEY =
+        0x85af67313879b9844f94b66f3eb6bdc2f200e2647507f73f43242a576580961b;
+    bytes32 internal constant MIN_REPOSITORY_KEY = 0x84f907641e97fb220312430fcf0f98c1d513664a984d99df24aee57c226d174c;
+    bytes32 internal constant MAX_REPOSITORY_KEY = 0x97316281428a106b570b0e26031c4ae18b9e959742ea4cc41c1e7cd43b921dfb;
+    bytes32 internal constant ROUTE_A_ID = keccak256("programmable.mock.route-a.v1");
+    bytes32 internal constant ROUTE_B_ID = keccak256("programmable.mock.route-b.v1");
+
+    ProgrammableGithubRepositoryLineageRegistryV1 internal registry;
+    MockRepositoryRouteConsumerV1 internal routeA;
+    MockRepositoryRouteConsumerV1 internal routeB;
+
+    function setUp() public {
+        vm.roll(100);
+        registry = new ProgrammableGithubRepositoryLineageRegistryV1(2 days, ADMIN);
+        routeA = new MockRepositoryRouteConsumerV1(registry, ROUTE_A_ID);
+        routeB = new MockRepositoryRouteConsumerV1(registry, ROUTE_B_ID);
+
+        vm.startPrank(ADMIN);
+        registry.grantRole(registry.CONSUMER_ROLE(), address(routeA));
+        registry.grantRole(registry.CONSUMER_ROLE(), address(routeB));
+        vm.stopPrank();
+    }
+
+    function test_exactOffchainRepositoryKeyVectorUsesLiteralDomainAndUint256Slot() public view {
+        assertEq(registry.computeRepositoryKey(SHARDS_GITHUB_REPOSITORY_ID), SHARDS_REPOSITORY_KEY);
+        assertEq(
+            SHARDS_REPOSITORY_KEY,
+            keccak256(abi.encode("programmable.github.repository.v1", uint256(SHARDS_GITHUB_REPOSITORY_ID)))
+        );
+    }
+
+    function test_offchainRepositoryKeyVectorsCoverAllowedUint64RangeAndBothCanaries() public view {
+        assertEq(registry.computeRepositoryKey(1), MIN_REPOSITORY_KEY);
+        assertEq(registry.computeRepositoryKey(SHARDS_GITHUB_REPOSITORY_ID), SHARDS_REPOSITORY_KEY);
+        assertEq(registry.computeRepositoryKey(HOOKEMON_GITHUB_REPOSITORY_ID), HOOKEMON_REPOSITORY_KEY);
+        assertEq(registry.computeRepositoryKey(type(uint64).max), MAX_REPOSITORY_KEY);
+    }
+
+    function test_machineCheckableSpecKeepsCanonicalDeploymentUnsetAndActivationFalse() public view {
+        string memory json =
+            vm.readFile(string.concat(vm.projectRoot(), "/spec/github-repository-lineage-registry-v1.json"));
+        assertEq(vm.parseJsonString(json, ".schemaVersion"), "programmable.github-repository-lineage-registry.v1");
+        assertEq(vm.parseJsonString(json, ".status"), "IMPLEMENTATION_READY_NOT_DEPLOYED");
+        assertFalse(vm.parseJsonBool(json, ".activationAllowed"));
+        assertEq(vm.parseJsonString(json, ".deployment.addressState"), "UNSET");
+        assertEq(vm.parseJsonString(json, ".authority.authorizedConsumerState"), "NONE_UNTIL_CANONICAL_DEPLOYMENT");
+        assertEq(vm.parseJsonUint(json, ".repositoryKey.allowedRange.minimum"), 1);
+        assertEq(vm.parseJsonString(json, ".repositoryKey.allowedRange.maximum"), "18446744073709551615");
+        assertTrue(vm.parseJsonBool(json, ".repositoryKey.allowedRange.approvalDatabaseMustEnforceSameRange"));
+        assertEq(vm.parseJsonUint(json, ".repositoryKey.knownVectors[0].githubRepositoryId"), 1);
+        assertEq(vm.parseJsonBytes32(json, ".repositoryKey.knownVectors[0].repositoryKey"), MIN_REPOSITORY_KEY);
+        assertEq(
+            vm.parseJsonUint(json, ".repositoryKey.knownVectors[1].githubRepositoryId"), SHARDS_GITHUB_REPOSITORY_ID
+        );
+        assertEq(vm.parseJsonBytes32(json, ".repositoryKey.knownVectors[1].repositoryKey"), SHARDS_REPOSITORY_KEY);
+        assertEq(
+            vm.parseJsonUint(json, ".repositoryKey.knownVectors[2].githubRepositoryId"), HOOKEMON_GITHUB_REPOSITORY_ID
+        );
+        assertEq(vm.parseJsonBytes32(json, ".repositoryKey.knownVectors[2].repositoryKey"), HOOKEMON_REPOSITORY_KEY);
+        assertEq(vm.parseJsonString(json, ".repositoryKey.knownVectors[3].githubRepositoryId"), "18446744073709551615");
+        assertEq(vm.parseJsonBytes32(json, ".repositoryKey.knownVectors[3].repositoryKey"), MAX_REPOSITORY_KEY);
+        assertTrue(vm.parseJsonBool(json, ".semantics.oneSuccessfulLaunchPerRepositoryLineage"));
+        assertTrue(vm.parseJsonBool(json, ".semantics.crossRouteAndFactoryAuthority"));
+        assertFalse(vm.parseJsonBool(json, ".implementation.compiler.viaIr"));
+        assertEq(vm.parseJsonUint(json, ".implementation.compiler.optimizerRuns"), 1000);
+        assertEq(
+            keccak256(type(ProgrammableGithubRepositoryLineageRegistryV1).creationCode),
+            vm.parseJsonBytes32(json, ".implementation.artifact.creationCodeKeccak256")
+        );
+        string memory buildArtifact = vm.readFile(
+            string.concat(
+                vm.projectRoot(),
+                "/out/ProgrammableGithubRepositoryLineageRegistryV1.sol/ProgrammableGithubRepositoryLineageRegistryV1.json"
+            )
+        );
+        bytes memory unlinkedRuntime = vm.parseBytes(vm.parseJsonString(buildArtifact, ".deployedBytecode.object"));
+        assertEq(
+            keccak256(unlinkedRuntime),
+            vm.parseJsonBytes32(json, ".implementation.artifact.unlinkedRuntimeCodeKeccak256")
+        );
+        assertEq(
+            unlinkedRuntime.length, vm.parseJsonUint(json, ".implementation.artifact.unlinkedRuntimeCodeByteLength")
+        );
+        assertEq(
+            24_576 - unlinkedRuntime.length,
+            vm.parseJsonUint(json, ".implementation.artifact.runtimeCodeLimitMarginBytes")
+        );
+    }
+
+    function test_twoAuthorizedConsumersCannotLaunchSameRepositoryLineage() public {
+        bytes32 firstLaunchId = keccak256("first-launch");
+        bytes32 secondLaunchId = keccak256("second-launch");
+        routeA.consumeThenExecute(SHARDS_GITHUB_REPOSITORY_ID, firstLaunchId, false);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableGithubRepositoryLineageRegistryV1.RepositoryAlreadyConsumed.selector,
+                SHARDS_REPOSITORY_KEY,
+                firstLaunchId,
+                ROUTE_A_ID,
+                address(routeA)
+            )
+        );
+        routeB.consumeThenExecute(SHARDS_GITHUB_REPOSITORY_ID, secondLaunchId, false);
+
+        assertEq(routeA.irreversibleExecutionCount(), 1);
+        assertEq(routeB.irreversibleExecutionCount(), 0);
+        assertEq(registry.consumptionCount(), 1);
+    }
+
+    function test_exactReceiptRetryIsIdempotentAndCannotCreateSecondConsumption() public {
+        bytes32 launchId = keccak256("same-receipt");
+        assertEq(routeA.consumeOnly(SHARDS_GITHUB_REPOSITORY_ID, launchId), SHARDS_REPOSITORY_KEY);
+        assertEq(routeA.consumeOnly(SHARDS_GITHUB_REPOSITORY_ID, launchId), SHARDS_REPOSITORY_KEY);
+        assertEq(registry.consumptionCount(), 1);
+
+        IProgrammableGithubRepositoryLineageRegistryV1.RepositoryConsumptionV1 memory record =
+            registry.consumption(SHARDS_REPOSITORY_KEY);
+        assertEq(record.githubRepositoryId, SHARDS_GITHUB_REPOSITORY_ID);
+        assertEq(record.launchId, launchId);
+        assertEq(record.routeId, ROUTE_A_ID);
+        assertEq(record.consumer, address(routeA));
+        assertEq(record.consumedAtBlock, 100);
+        assertEq(registry.repositoryKeyByLaunchId(launchId), SHARDS_REPOSITORY_KEY);
+    }
+
+    function test_revertAfterConsumeRollsBackAndAllowsLaterRetry() public {
+        bytes32 launchId = keccak256("rollback-retry");
+        vm.expectRevert(MockRepositoryRouteConsumerV1.MockRouteExecutionReverted.selector);
+        routeA.consumeThenExecute(SHARDS_GITHUB_REPOSITORY_ID, launchId, true);
+
+        assertEq(registry.consumptionCount(), 0);
+        assertEq(registry.repositoryKeyByLaunchId(launchId), bytes32(0));
+        assertEq(registry.consumption(SHARDS_REPOSITORY_KEY).launchId, bytes32(0));
+
+        routeB.consumeThenExecute(SHARDS_GITHUB_REPOSITORY_ID, launchId, false);
+        assertEq(registry.consumptionCount(), 1);
+        assertEq(routeB.irreversibleExecutionCount(), 1);
+    }
+
+    function test_sameLaunchIdCannotConsumeTwoRepositories() public {
+        bytes32 launchId = keccak256("one-launch-id");
+        routeA.consumeOnly(SHARDS_GITHUB_REPOSITORY_ID, launchId);
+        uint64 otherRepositoryId = SHARDS_GITHUB_REPOSITORY_ID + 1;
+        bytes32 existingKey = registry.computeRepositoryKey(SHARDS_GITHUB_REPOSITORY_ID);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableGithubRepositoryLineageRegistryV1.LaunchAlreadyConsumed.selector, launchId, existingKey
+            )
+        );
+        routeA.consumeOnly(otherRepositoryId, launchId);
+    }
+
+    function test_unauthorizedCallerCannotConsume() public {
+        bytes32 launchId = keccak256("unauthorized");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), registry.CONSUMER_ROLE()
+            )
+        );
+        registry.consume(SHARDS_GITHUB_REPOSITORY_ID, launchId, ROUTE_A_ID);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, ADMIN, registry.CONSUMER_ROLE()
+            )
+        );
+        vm.prank(ADMIN);
+        registry.consume(SHARDS_GITHUB_REPOSITORY_ID, launchId, ROUTE_A_ID);
+    }
+
+    function test_adminCannotGrantConsumerRoleToEoaOrItself() public {
+        bytes32 consumerRole = registry.CONSUMER_ROLE();
+        vm.startPrank(ADMIN);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ProgrammableGithubRepositoryLineageRegistryV1.ConsumerMustBeContract.selector, address(0xBEEF)
+            )
+        );
+        registry.grantRole(consumerRole, address(0xBEEF));
+        vm.expectRevert(
+            abi.encodeWithSelector(ProgrammableGithubRepositoryLineageRegistryV1.ConsumerMustBeContract.selector, ADMIN)
+        );
+        registry.grantRole(consumerRole, ADMIN);
+        vm.stopPrank();
+    }
+
+    function testFuzz_distinctRepositoryIdsProduceDistinctKeysAndRecords(uint64 firstId, uint64 secondId) public {
+        firstId = uint64(bound(firstId, 1, type(uint64).max));
+        secondId = uint64(bound(secondId, 1, type(uint64).max));
+        vm.assume(firstId != secondId);
+
+        bytes32 firstKey = routeA.consumeOnly(firstId, keccak256(abi.encode("first", firstId)));
+        bytes32 secondKey = routeB.consumeOnly(secondId, keccak256(abi.encode("second", secondId)));
+        assertNotEq(firstKey, secondKey);
+        assertEq(registry.consumption(firstKey).githubRepositoryId, firstId);
+        assertEq(registry.consumption(secondKey).githubRepositoryId, secondId);
+        assertEq(registry.consumptionCount(), 2);
+    }
+}

--- a/contracts/test/invariant/ProgrammableExactShardsRegistryV1Invariant.t.sol
+++ b/contracts/test/invariant/ProgrammableExactShardsRegistryV1Invariant.t.sol
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { ProgrammableExactShardsFeePolicyVerifierV1 } from "../../src/ProgrammableExactShardsFeePolicyVerifierV1.sol";
+import { ProgrammableExactShardsRegistryV1 } from "../../src/ProgrammableExactShardsRegistryV1.sol";
+import { IProgrammableCustomRegistryV1 } from "../../src/interfaces/IProgrammableCustomRegistryV1.sol";
+import {
+    IProgrammableExactShardsFeePolicyVerifierV1
+} from "../../src/interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol";
+import { IProgrammableExactShardsRegistryV1 } from "../../src/interfaces/IProgrammableExactShardsRegistryV1.sol";
+
+contract ExactShardsRegistryInvariantRuntimeV1 {
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract ExactShardsRegistryInvariantApprovalActorV1 {
+    ProgrammableExactShardsRegistryV1 public immutable registry;
+
+    constructor(ProgrammableExactShardsRegistryV1 registry_) {
+        registry = registry_;
+    }
+
+    function authorize(IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 calldata authorization) external {
+        registry.authorizeApproval(authorization);
+    }
+}
+
+contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
+    struct Record {
+        bytes32 label;
+        bytes32 launchId;
+        bytes32 approvalId;
+        bytes32 deploymentId;
+        bytes32 feePolicyRecordHash;
+        bytes32 claimSetHash;
+        bytes32 builderClaimHash;
+        bytes32 programmableClaimHash;
+        bytes32 holderClaimHash;
+        uint64 latestRevision;
+        bytes32 latestRecordHash;
+        bool finalized;
+        bool revoked;
+    }
+
+    uint256 private constant MAX_RECORDS = 16;
+
+    ProgrammableExactShardsRegistryV1 public immutable registry;
+    ProgrammableExactShardsFeePolicyVerifierV1 public immutable verifier;
+    ExactShardsRegistryInvariantApprovalActorV1 public immutable approvalActor;
+    ExactShardsRegistryInvariantRuntimeV1 public immutable runtimeTarget;
+
+    Record[] private records;
+    uint256 public sequence;
+    uint64 public successfulRegistrations;
+    uint64 public successfulFinalizations;
+    uint64 public successfulCorrections;
+    uint64 public successfulRevocations;
+    bool public replaySucceeded;
+    bool public revokedLaunchRevived;
+
+    constructor(
+        ProgrammableExactShardsRegistryV1 registry_,
+        ProgrammableExactShardsFeePolicyVerifierV1 verifier_,
+        ExactShardsRegistryInvariantApprovalActorV1 approvalActor_,
+        ExactShardsRegistryInvariantRuntimeV1 runtimeTarget_
+    ) {
+        registry = registry_;
+        verifier = verifier_;
+        approvalActor = approvalActor_;
+        runtimeTarget = runtimeTarget_;
+    }
+
+    function register(uint256 entropy) external {
+        if (records.length >= MAX_RECORDS) return;
+        bytes32 label = keccak256(abi.encode("exact-shards-registry-invariant", ++sequence, entropy));
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration(label);
+        IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory authorization =
+            IProgrammableCustomRegistryV1.ApprovalAuthorizationV1({
+                chainId: block.chainid,
+                registryGeneration: registry.REGISTRY_GENERATION(),
+                approvalId: registration.approvalId,
+                launchId: registration.launchId,
+                approvalBindingHash: registration.approvalBindingHash,
+                registrationBindingHash: registry.computeRegistrationBindingHash(registration),
+                validAfterBlock: uint64(block.number),
+                expiresAtBlock: uint64(block.number + 10_000),
+                evidenceHash: _field(label, "approval-evidence")
+            });
+        approvalActor.authorize(authorization);
+        registry.registerLaunch(registration);
+
+        IProgrammableExactShardsRegistryV1.StoredFeePolicyV1 memory storedPolicy =
+            registry.feePolicyState(registration.launchId);
+        records.push(
+            Record({
+                label: label,
+                launchId: registration.launchId,
+                approvalId: registration.approvalId,
+                deploymentId: registration.deploymentId,
+                feePolicyRecordHash: storedPolicy.feePolicyRecordHash,
+                claimSetHash: storedPolicy.claimSetHash,
+                builderClaimHash: registry.feeClaim(registration.launchId, 0).storedClaimHash,
+                programmableClaimHash: registry.feeClaim(registration.launchId, 1).storedClaimHash,
+                holderClaimHash: registry.feeClaim(registration.launchId, 2).storedClaimHash,
+                latestRevision: 1,
+                latestRecordHash: registration.registeredRecordCommitment,
+                finalized: false,
+                revoked: false
+            })
+        );
+        successfulRegistrations += 1;
+    }
+
+    function finalize(uint256 rawIndex) external {
+        if (records.length == 0) return;
+        Record storage record = records[rawIndex % records.length];
+        if (record.finalized || record.revoked) return;
+        IProgrammableExactShardsRegistryV1.LaunchStateV1 memory state = registry.launchState(record.launchId);
+        uint64 confirmedHead = state.observedAtBlock + registry.MINIMUM_FINALITY_BLOCKS();
+        if (block.number <= confirmedHead) vm.roll(uint256(confirmedHead) + 1);
+        bytes32 observedHash = _field(record.label, "observed-block");
+        bytes32 confirmedHash = _field(record.label, "confirmed-block");
+        vm.setBlockhash(state.observedAtBlock, observedHash);
+        vm.setBlockhash(confirmedHead, confirmedHash);
+        registry.finalizeLaunch(
+            IProgrammableCustomRegistryV1.FinalityProofV1({
+                chainId: block.chainid,
+                registryGeneration: registry.REGISTRY_GENERATION(),
+                launchId: record.launchId,
+                observedBlockNumber: state.observedAtBlock,
+                observedBlockHash: observedHash,
+                observedTransactionHash: _field(record.label, "observed-transaction"),
+                observedTransactionIndex: 1,
+                observedLogIndex: 2,
+                confirmedHeadBlockNumber: confirmedHead,
+                confirmedHeadBlockHash: confirmedHash,
+                finalityPolicyHash: _field(record.label, "finality-policy"),
+                finalityEvidenceHash: _field(record.label, "finality-evidence")
+            })
+        );
+        record.finalized = true;
+        successfulFinalizations += 1;
+    }
+
+    function correct(uint256 rawIndex, uint256 entropy) external {
+        if (records.length == 0) return;
+        Record storage record = records[rawIndex % records.length];
+        if (!record.finalized || record.revoked) return;
+        uint64 revision = record.latestRevision + 1;
+        bytes32 correctedHash = keccak256(abi.encode(record.label, "corrected-record", revision, entropy));
+        registry.correctLaunchRecord(
+            IProgrammableCustomRegistryV1.RecordCorrectionV1({
+                chainId: block.chainid,
+                registryGeneration: registry.REGISTRY_GENERATION(),
+                launchId: record.launchId,
+                revision: revision,
+                previousRecordHash: record.latestRecordHash,
+                correctedRecordHash: correctedHash,
+                reasonCode: keccak256(abi.encode(record.label, "correction-reason", revision)),
+                evidenceHash: keccak256(abi.encode(record.label, "correction-evidence", revision))
+            })
+        );
+        record.latestRevision = revision;
+        record.latestRecordHash = correctedHash;
+        successfulCorrections += 1;
+    }
+
+    function revoke(uint256 rawIndex) external {
+        if (records.length == 0) return;
+        Record storage record = records[rawIndex % records.length];
+        if (record.revoked) return;
+        registry.revokeLaunch(
+            IProgrammableCustomRegistryV1.LaunchRevocationV1({
+                chainId: block.chainid,
+                registryGeneration: registry.REGISTRY_GENERATION(),
+                launchId: record.launchId,
+                reasonCode: _field(record.label, "revocation-reason"),
+                evidenceHash: _field(record.label, "revocation-evidence")
+            })
+        );
+        record.revoked = true;
+        successfulRevocations += 1;
+    }
+
+    function replay(uint256 rawIndex) external {
+        if (records.length == 0) return;
+        Record storage record = records[rawIndex % records.length];
+        try registry.registerLaunch(_boundRegistration(record.label)) {
+            replaySucceeded = true;
+        } catch { }
+    }
+
+    function attemptRevive(uint256 rawIndex) external {
+        if (records.length == 0) return;
+        Record storage record = records[rawIndex % records.length];
+        if (!record.revoked) return;
+        try registry.registerLaunch(_boundRegistration(record.label)) {
+            revokedLaunchRevived = true;
+        } catch { }
+    }
+
+    function recordCount() external view returns (uint256) {
+        return records.length;
+    }
+
+    function recordAt(uint256 index) external view returns (Record memory) {
+        return records[index];
+    }
+
+    function _boundRegistration(bytes32 label)
+        private
+        view
+        returns (IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+    {
+        return _registration(label);
+    }
+
+    function _registration(bytes32 label)
+        private
+        view
+        returns (IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+    {
+        registration.chainId = block.chainid;
+        registration.registryGeneration = registry.REGISTRY_GENERATION();
+        registration.launchId = _field(label, "launch-id");
+        registration.projectId = _field(label, "project-id");
+        registration.approvalId = _field(label, "approval-id");
+        registration.repositoryId = keccak256("jesse-stahl/shards-v1");
+        registration.commitId = bytes32(bytes20(hex"91b38f3de64d96cac7e29f127c004f128fc1da59"));
+        registration.sourceCommitment = verifier.SOURCE_REVISION_HASH();
+        registration.buildCommitment = verifier.NESTED_FACTORY_ARTIFACT_SHA256();
+        registration.artifactSetHash = _field(label, "artifact-set");
+        registration.deploymentConfigurationHash = _field(label, "deployment-configuration");
+        registration.configurationHash = _field(label, "configuration");
+        registration.permissionsHash = _field(label, "permissions");
+        registration.deploymentId = _field(label, "deployment-id");
+        registration.deploymentSetHash = _field(label, "deployment-set");
+        registration.runtimeCodeSetHash = _field(label, "runtime-code-set");
+        registration.primaryContract = address(runtimeTarget);
+        registration.primaryRuntimeCodeHash = address(runtimeTarget).codehash;
+        registration.launchWallet = address(this);
+        registration.modelId = keccak256("programmable.exact-shards.v1");
+        registration.modelVersion = keccak256("1");
+        registration.templateId = keccak256("programmable.exact-shards.nested-factory.v1");
+        registration.templateVersion = keccak256("1");
+        registration.builderAttributionHash = _field(label, "builder");
+        registration.originHash = _field(label, "origin");
+        registration.assetSetHash = _field(label, "assets");
+        registration.marketSetHash = _field(label, "markets");
+        registration.marketPathId = verifier.PROFILE_KEY();
+        registration.capabilitySetHash = _field(label, "capabilities");
+        registration.reviewPolicyHash = keccak256("programmable-shards-review-policy-v1");
+        registration.securityReviewHash = _field(label, "security-review");
+        registration.reviewResultId = _field(label, "review-result");
+        registration.finalityPolicyHash = _field(label, "finality-policy");
+        registration.feePolicy.profileKey = verifier.PROFILE_KEY();
+        registration.feePolicy.feeAsset = verifier.FEE_ASSET();
+        registration.feePolicy.feeBasisHash = verifier.FEE_BASIS_HASH();
+        registration.feePolicy.totalFeeBps = verifier.TOTAL_FEE_BPS();
+        registration.feePolicy.legsHash = verifier.LEGS_HASH();
+        registration.orderedFeeLegs[0] = IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1({
+            roleHash: verifier.BUILDER_ROLE_HASH(),
+            feeBps: verifier.BUILDER_FEE_BPS(),
+            recipient: verifier.INITIAL_BUILDER_RECIPIENT(),
+            recipientModeHash: verifier.BUILDER_RECIPIENT_MODE_HASH()
+        });
+        registration.orderedFeeLegs[1] = IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1({
+            roleHash: verifier.PROGRAMMABLE_ROLE_HASH(),
+            feeBps: verifier.PROGRAMMABLE_FEE_BPS(),
+            recipient: verifier.PROGRAMMABLE_RECIPIENT(),
+            recipientModeHash: verifier.PROGRAMMABLE_RECIPIENT_MODE_HASH()
+        });
+        registration.orderedFeeLegs[2] = IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1({
+            roleHash: verifier.HOLDER_ROLE_HASH(),
+            feeBps: verifier.HOLDER_FEE_BPS(),
+            recipient: verifier.HOLDER_ACCUMULATOR(),
+            recipientModeHash: verifier.HOLDER_RECIPIENT_MODE_HASH()
+        });
+        registration.approvalBindingHash = registry.computeApprovalBindingHash(registration);
+        registration.reviewDeploymentBindingHash = registry.computeReviewDeploymentBindingHash(registration);
+        registration.registeredRecordCommitment = registry.computeRegisteredRecordCommitment(registration);
+    }
+
+    function _field(bytes32 label, string memory field) private pure returns (bytes32) {
+        return keccak256(abi.encode(label, field));
+    }
+}
+
+contract ProgrammableExactShardsRegistryV1InvariantTest is StdInvariant, Test {
+    ProgrammableExactShardsRegistryV1 internal registry;
+    ProgrammableExactShardsRegistryV1InvariantHandler internal handler;
+
+    uint64 private lastRegistrationCount;
+    uint64 private lastApprovalCount;
+    uint64 private lastTransitionCount;
+
+    function setUp() public {
+        vm.chainId(1);
+        vm.roll(100);
+        ProgrammableExactShardsFeePolicyVerifierV1 verifier = new ProgrammableExactShardsFeePolicyVerifierV1();
+        ExactShardsRegistryInvariantRuntimeV1 runtimeTarget = new ExactShardsRegistryInvariantRuntimeV1();
+        registry = new ProgrammableExactShardsRegistryV1(
+            ProgrammableExactShardsRegistryV1.RegistryConfigV1({
+                initialAdminDelay: 2 days,
+                initialAdmin: address(this),
+                initialApprover: address(0xA990),
+                initialWriter: address(0xB001),
+                initialFinalizer: address(this),
+                initialCorrector: address(this),
+                initialRevoker: address(this),
+                registryGeneration: 3,
+                minimumFinalityBlocks: 3,
+                chainProfileHash: keccak256("ethereum-mainnet-chain-profile"),
+                registryPolicyHash: keccak256("exact-shards-registry-policy")
+            }),
+            verifier
+        );
+        ExactShardsRegistryInvariantApprovalActorV1 approvalActor =
+            new ExactShardsRegistryInvariantApprovalActorV1(registry);
+        registry.grantRole(registry.APPROVER_ROLE(), address(approvalActor));
+        registry.revokeRole(registry.APPROVER_ROLE(), address(0xA990));
+        handler =
+            new ProgrammableExactShardsRegistryV1InvariantHandler(registry, verifier, approvalActor, runtimeTarget);
+        registry.grantRole(registry.WRITER_ROLE(), address(handler));
+        registry.revokeRole(registry.WRITER_ROLE(), address(0xB001));
+        registry.grantRole(registry.FINALIZER_ROLE(), address(handler));
+        registry.grantRole(registry.CORRECTOR_ROLE(), address(handler));
+        registry.grantRole(registry.REVOKER_ROLE(), address(handler));
+
+        bytes4[] memory selectors = new bytes4[](6);
+        selectors[0] = handler.register.selector;
+        selectors[1] = handler.finalize.selector;
+        selectors[2] = handler.correct.selector;
+        selectors[3] = handler.revoke.selector;
+        selectors[4] = handler.replay.selector;
+        selectors[5] = handler.attemptRevive.selector;
+        targetSelector(FuzzSelector({ addr: address(handler), selectors: selectors }));
+        targetContract(address(handler));
+    }
+
+    function invariant_countsAreMonotonicAndMatchSuccessfulTransitions() public {
+        uint64 registrations = registry.registrationCount();
+        uint64 approvals = registry.approvalAuthorizationCount();
+        uint64 transitions = registry.transitionCount();
+        assertGe(registrations, lastRegistrationCount);
+        assertGe(approvals, lastApprovalCount);
+        assertGe(transitions, lastTransitionCount);
+        assertEq(registrations, handler.successfulRegistrations());
+        assertEq(approvals, handler.successfulRegistrations());
+        assertEq(
+            transitions,
+            handler.successfulRegistrations() * 2 + handler.successfulFinalizations() + handler.successfulCorrections()
+                + handler.successfulRevocations()
+        );
+        lastRegistrationCount = registrations;
+        lastApprovalCount = approvals;
+        lastTransitionCount = transitions;
+    }
+
+    function invariant_feePolicyAndThreeClaimsRemainImmutable() public view {
+        uint256 count = handler.recordCount();
+        for (uint256 index; index < count; ++index) {
+            ProgrammableExactShardsRegistryV1InvariantHandler.Record memory record = handler.recordAt(index);
+            IProgrammableExactShardsRegistryV1.StoredFeePolicyV1 memory policy =
+                registry.feePolicyState(record.launchId);
+            assertEq(policy.feePolicyRecordHash, record.feePolicyRecordHash);
+            assertEq(policy.claimSetHash, record.claimSetHash);
+            assertEq(policy.totalFeeBps, 100);
+            assertEq(registry.feeClaim(record.launchId, 0).storedClaimHash, record.builderClaimHash);
+            assertEq(registry.feeClaim(record.launchId, 1).storedClaimHash, record.programmableClaimHash);
+            assertEq(registry.feeClaim(record.launchId, 2).storedClaimHash, record.holderClaimHash);
+            assertEq(registry.feeClaim(record.launchId, 0).shareOfFeeBps, 1000);
+            assertEq(registry.feeClaim(record.launchId, 1).shareOfFeeBps, 1000);
+            assertEq(registry.feeClaim(record.launchId, 2).shareOfFeeBps, 8000);
+        }
+    }
+
+    function invariant_approvalDeploymentAndRevisionAreOneUseBound() public view {
+        uint256 count = handler.recordCount();
+        for (uint256 index; index < count; ++index) {
+            ProgrammableExactShardsRegistryV1InvariantHandler.Record memory record = handler.recordAt(index);
+            IProgrammableExactShardsRegistryV1.LaunchStateV1 memory state = registry.launchState(record.launchId);
+            assertTrue(registry.approvalConsumed(record.approvalId));
+            assertTrue(registry.approvalState(record.approvalId).consumed);
+            assertTrue(registry.deploymentConsumed(record.deploymentId));
+            assertEq(state.latestRecordRevision, record.latestRevision);
+            assertEq(state.latestRecordHash, record.latestRecordHash);
+            assertEq(registry.recordHashAtRevision(record.launchId, record.latestRevision), record.latestRecordHash);
+        }
+        assertFalse(handler.replaySucceeded());
+    }
+
+    function invariant_revocationIsTerminal() public view {
+        uint256 count = handler.recordCount();
+        for (uint256 index; index < count; ++index) {
+            ProgrammableExactShardsRegistryV1InvariantHandler.Record memory record = handler.recordAt(index);
+            IProgrammableCustomRegistryV1.LaunchStatus expected;
+            if (record.revoked) expected = IProgrammableCustomRegistryV1.LaunchStatus.Revoked;
+            else if (record.finalized) expected = IProgrammableCustomRegistryV1.LaunchStatus.Finalized;
+            else expected = IProgrammableCustomRegistryV1.LaunchStatus.Observed;
+            assertEq(uint8(registry.launchState(record.launchId).status), uint8(expected));
+        }
+        assertFalse(handler.revokedLaunchRevived());
+    }
+}

--- a/contracts/test/invariant/ProgrammableExactShardsRegistryV1Invariant.t.sol
+++ b/contracts/test/invariant/ProgrammableExactShardsRegistryV1Invariant.t.sol
@@ -6,11 +6,15 @@ import { Test } from "forge-std/Test.sol";
 
 import { ProgrammableExactShardsFeePolicyVerifierV1 } from "../../src/ProgrammableExactShardsFeePolicyVerifierV1.sol";
 import { ProgrammableExactShardsRegistryV1 } from "../../src/ProgrammableExactShardsRegistryV1.sol";
+import {
+    ProgrammableGithubRepositoryLineageRegistryV1
+} from "../../src/ProgrammableGithubRepositoryLineageRegistryV1.sol";
 import { IProgrammableCustomRegistryV1 } from "../../src/interfaces/IProgrammableCustomRegistryV1.sol";
 import {
     IProgrammableExactShardsFeePolicyVerifierV1
 } from "../../src/interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol";
 import { IProgrammableExactShardsRegistryV1 } from "../../src/interfaces/IProgrammableExactShardsRegistryV1.sol";
+import { ProgrammableExactShardsBindingHarnessV1 } from "../utils/ProgrammableExactShardsBindingHarnessV1.sol";
 
 contract ExactShardsRegistryInvariantRuntimeV1 {
     function version() external pure returns (uint256) {
@@ -28,6 +32,12 @@ contract ExactShardsRegistryInvariantApprovalActorV1 {
     function authorize(IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 calldata authorization) external {
         registry.authorizeApproval(authorization);
     }
+
+    function authorizeLaunchIntent(IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 calldata authorization)
+        external
+    {
+        registry.authorizeLaunchIntent(authorization);
+    }
 }
 
 contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
@@ -36,6 +46,8 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
         bytes32 launchId;
         bytes32 approvalId;
         bytes32 deploymentId;
+        uint64 githubRepositoryId;
+        bytes32 repositoryKey;
         bytes32 feePolicyRecordHash;
         bytes32 claimSetHash;
         bytes32 builderClaimHash;
@@ -51,6 +63,8 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
 
     ProgrammableExactShardsRegistryV1 public immutable registry;
     ProgrammableExactShardsFeePolicyVerifierV1 public immutable verifier;
+    ProgrammableGithubRepositoryLineageRegistryV1 public immutable lineageRegistry;
+    ProgrammableExactShardsBindingHarnessV1 public immutable bindingHarness;
     ExactShardsRegistryInvariantApprovalActorV1 public immutable approvalActor;
     ExactShardsRegistryInvariantRuntimeV1 public immutable runtimeTarget;
 
@@ -66,11 +80,15 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
     constructor(
         ProgrammableExactShardsRegistryV1 registry_,
         ProgrammableExactShardsFeePolicyVerifierV1 verifier_,
+        ProgrammableGithubRepositoryLineageRegistryV1 lineageRegistry_,
+        ProgrammableExactShardsBindingHarnessV1 bindingHarness_,
         ExactShardsRegistryInvariantApprovalActorV1 approvalActor_,
         ExactShardsRegistryInvariantRuntimeV1 runtimeTarget_
     ) {
         registry = registry_;
         verifier = verifier_;
+        lineageRegistry = lineageRegistry_;
+        bindingHarness = bindingHarness_;
         approvalActor = approvalActor_;
         runtimeTarget = runtimeTarget_;
     }
@@ -79,19 +97,37 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
         if (records.length >= MAX_RECORDS) return;
         bytes32 label = keccak256(abi.encode("exact-shards-registry-invariant", ++sequence, entropy));
         IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration = _registration(label);
-        IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory authorization =
+        IProgrammableCustomRegistryV1.ApprovalAuthorizationV1 memory technicalAuthorization =
             IProgrammableCustomRegistryV1.ApprovalAuthorizationV1({
                 chainId: block.chainid,
                 registryGeneration: registry.REGISTRY_GENERATION(),
                 approvalId: registration.approvalId,
                 launchId: registration.launchId,
                 approvalBindingHash: registration.approvalBindingHash,
-                registrationBindingHash: registry.computeRegistrationBindingHash(registration),
+                registrationBindingHash: registration.approvalBindingHash,
                 validAfterBlock: uint64(block.number),
-                expiresAtBlock: uint64(block.number + 10_000),
+                expiresAtBlock: type(uint64).max,
                 evidenceHash: _field(label, "approval-evidence")
             });
-        approvalActor.authorize(authorization);
+        approvalActor.authorize(technicalAuthorization);
+        approvalActor.authorizeLaunchIntent(
+            IProgrammableCustomRegistryV1.ApprovalAuthorizationV1({
+                chainId: block.chainid,
+                registryGeneration: registry.REGISTRY_GENERATION(),
+                approvalId: registration.approvalId,
+                launchId: registration.launchId,
+                approvalBindingHash: registration.approvalBindingHash,
+                registrationBindingHash: _launchIntentBinding(registration),
+                validAfterBlock: uint64(block.number),
+                expiresAtBlock: uint64(block.number + 200),
+                evidenceHash: _field(label, "launch-intent-evidence")
+            })
+        );
+        lineageRegistry.consume(
+            registration.githubRepositoryId,
+            registration.launchId,
+            keccak256("programmable.exact-shards.atomic-launch-route.v1")
+        );
         registry.registerLaunch(registration);
 
         IProgrammableExactShardsRegistryV1.StoredFeePolicyV1 memory storedPolicy =
@@ -102,6 +138,8 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
                 launchId: registration.launchId,
                 approvalId: registration.approvalId,
                 deploymentId: registration.deploymentId,
+                githubRepositoryId: registration.githubRepositoryId,
+                repositoryKey: lineageRegistry.computeRepositoryKey(registration.githubRepositoryId),
                 feePolicyRecordHash: storedPolicy.feePolicyRecordHash,
                 claimSetHash: storedPolicy.claimSetHash,
                 builderClaimHash: registry.feeClaim(registration.launchId, 0).storedClaimHash,
@@ -190,8 +228,13 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
     function replay(uint256 rawIndex) external {
         if (records.length == 0) return;
         Record storage record = records[rawIndex % records.length];
+        uint64 registrationsBefore = registry.registrationCount();
+        uint64 transitionsBefore = registry.transitionCount();
         try registry.registerLaunch(_boundRegistration(record.label)) {
-            replaySucceeded = true;
+            if (registry.registrationCount() != registrationsBefore || registry.transitionCount() != transitionsBefore)
+            {
+                replaySucceeded = true;
+            }
         } catch { }
     }
 
@@ -200,7 +243,9 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
         Record storage record = records[rawIndex % records.length];
         if (!record.revoked) return;
         try registry.registerLaunch(_boundRegistration(record.label)) {
-            revokedLaunchRevived = true;
+            if (registry.launchState(record.launchId).status != IProgrammableCustomRegistryV1.LaunchStatus.Revoked) {
+                revokedLaunchRevived = true;
+            }
         } catch { }
     }
 
@@ -230,13 +275,17 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
         registration.launchId = _field(label, "launch-id");
         registration.projectId = _field(label, "project-id");
         registration.approvalId = _field(label, "approval-id");
-        registration.repositoryId = keccak256("jesse-stahl/shards-v1");
+        registration.githubRepositoryId = uint64(uint256(label));
+        if (registration.githubRepositoryId == 0) registration.githubRepositoryId = 1;
         registration.commitId = bytes32(bytes20(hex"91b38f3de64d96cac7e29f127c004f128fc1da59"));
         registration.sourceCommitment = verifier.SOURCE_REVISION_HASH();
         registration.buildCommitment = verifier.NESTED_FACTORY_ARTIFACT_SHA256();
         registration.artifactSetHash = _field(label, "artifact-set");
         registration.deploymentConfigurationHash = _field(label, "deployment-configuration");
         registration.configurationHash = _field(label, "configuration");
+        registration.tokenNameHash = keccak256(bytes("Shards"));
+        registration.tokenSymbolHash = keccak256(bytes("SHARDS"));
+        registration.presentationBindingHash = _field(label, "description-image-links");
         registration.permissionsHash = _field(label, "permissions");
         registration.deploymentId = _field(label, "deployment-id");
         registration.deploymentSetHash = _field(label, "deployment-set");
@@ -281,9 +330,17 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
             recipient: verifier.HOLDER_ACCUMULATOR(),
             recipientModeHash: verifier.HOLDER_RECIPIENT_MODE_HASH()
         });
-        registration.approvalBindingHash = registry.computeApprovalBindingHash(registration);
-        registration.reviewDeploymentBindingHash = registry.computeReviewDeploymentBindingHash(registration);
-        registration.registeredRecordCommitment = registry.computeRegisteredRecordCommitment(registration);
+        (registration.approvalBindingHash,,,) = bindingHarness.computeBindings(registration);
+        (,, registration.reviewDeploymentBindingHash,) = bindingHarness.computeBindings(registration);
+        (,,, registration.registeredRecordCommitment) = bindingHarness.computeBindings(registration);
+    }
+
+    function _launchIntentBinding(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        view
+        returns (bytes32 bindingHash)
+    {
+        (, bindingHash,,) = bindingHarness.computeBindings(registration);
     }
 
     function _field(bytes32 label, string memory field) private pure returns (bytes32) {
@@ -293,16 +350,17 @@ contract ProgrammableExactShardsRegistryV1InvariantHandler is Test {
 
 contract ProgrammableExactShardsRegistryV1InvariantTest is StdInvariant, Test {
     ProgrammableExactShardsRegistryV1 internal registry;
+    ProgrammableGithubRepositoryLineageRegistryV1 internal lineageRegistry;
     ProgrammableExactShardsRegistryV1InvariantHandler internal handler;
 
     uint64 private lastRegistrationCount;
-    uint64 private lastApprovalCount;
     uint64 private lastTransitionCount;
 
     function setUp() public {
         vm.chainId(1);
         vm.roll(100);
         ProgrammableExactShardsFeePolicyVerifierV1 verifier = new ProgrammableExactShardsFeePolicyVerifierV1();
+        lineageRegistry = new ProgrammableGithubRepositoryLineageRegistryV1(2 days, address(this));
         ExactShardsRegistryInvariantRuntimeV1 runtimeTarget = new ExactShardsRegistryInvariantRuntimeV1();
         registry = new ProgrammableExactShardsRegistryV1(
             ProgrammableExactShardsRegistryV1.RegistryConfigV1({
@@ -318,15 +376,20 @@ contract ProgrammableExactShardsRegistryV1InvariantTest is StdInvariant, Test {
                 chainProfileHash: keccak256("ethereum-mainnet-chain-profile"),
                 registryPolicyHash: keccak256("exact-shards-registry-policy")
             }),
-            verifier
+            verifier,
+            lineageRegistry
         );
         ExactShardsRegistryInvariantApprovalActorV1 approvalActor =
             new ExactShardsRegistryInvariantApprovalActorV1(registry);
+        ProgrammableExactShardsBindingHarnessV1 bindingHarness =
+            new ProgrammableExactShardsBindingHarnessV1(registry, verifier, lineageRegistry);
         registry.grantRole(registry.APPROVER_ROLE(), address(approvalActor));
         registry.revokeRole(registry.APPROVER_ROLE(), address(0xA990));
-        handler =
-            new ProgrammableExactShardsRegistryV1InvariantHandler(registry, verifier, approvalActor, runtimeTarget);
+        handler = new ProgrammableExactShardsRegistryV1InvariantHandler(
+            registry, verifier, lineageRegistry, bindingHarness, approvalActor, runtimeTarget
+        );
         registry.grantRole(registry.WRITER_ROLE(), address(handler));
+        lineageRegistry.grantRole(lineageRegistry.CONSUMER_ROLE(), address(handler));
         registry.revokeRole(registry.WRITER_ROLE(), address(0xB001));
         registry.grantRole(registry.FINALIZER_ROLE(), address(handler));
         registry.grantRole(registry.CORRECTOR_ROLE(), address(handler));
@@ -345,20 +408,16 @@ contract ProgrammableExactShardsRegistryV1InvariantTest is StdInvariant, Test {
 
     function invariant_countsAreMonotonicAndMatchSuccessfulTransitions() public {
         uint64 registrations = registry.registrationCount();
-        uint64 approvals = registry.approvalAuthorizationCount();
         uint64 transitions = registry.transitionCount();
         assertGe(registrations, lastRegistrationCount);
-        assertGe(approvals, lastApprovalCount);
         assertGe(transitions, lastTransitionCount);
         assertEq(registrations, handler.successfulRegistrations());
-        assertEq(approvals, handler.successfulRegistrations());
         assertEq(
             transitions,
-            handler.successfulRegistrations() * 2 + handler.successfulFinalizations() + handler.successfulCorrections()
+            handler.successfulRegistrations() * 3 + handler.successfulFinalizations() + handler.successfulCorrections()
                 + handler.successfulRevocations()
         );
         lastRegistrationCount = registrations;
-        lastApprovalCount = approvals;
         lastTransitionCount = transitions;
     }
 
@@ -388,6 +447,8 @@ contract ProgrammableExactShardsRegistryV1InvariantTest is StdInvariant, Test {
             assertTrue(registry.approvalConsumed(record.approvalId));
             assertTrue(registry.approvalState(record.approvalId).consumed);
             assertTrue(registry.deploymentConsumed(record.deploymentId));
+            assertEq(lineageRegistry.consumption(record.repositoryKey).launchId, record.launchId);
+            assertEq(lineageRegistry.computeRepositoryKey(record.githubRepositoryId), record.repositoryKey);
             assertEq(state.latestRecordRevision, record.latestRevision);
             assertEq(state.latestRecordHash, record.latestRecordHash);
             assertEq(registry.recordHashAtRevision(record.launchId, record.latestRevision), record.latestRecordHash);

--- a/contracts/test/invariant/ProgrammableGithubRepositoryLineageRegistryV1Invariant.t.sol
+++ b/contracts/test/invariant/ProgrammableGithubRepositoryLineageRegistryV1Invariant.t.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+import { Test } from "forge-std/Test.sol";
+
+import {
+    ProgrammableGithubRepositoryLineageRegistryV1
+} from "../../src/ProgrammableGithubRepositoryLineageRegistryV1.sol";
+import {
+    IProgrammableGithubRepositoryLineageRegistryV1
+} from "../../src/interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol";
+
+contract LineageInvariantRouteV1 {
+    IProgrammableGithubRepositoryLineageRegistryV1 public immutable REGISTRY;
+    bytes32 public immutable ROUTE_ID;
+
+    constructor(IProgrammableGithubRepositoryLineageRegistryV1 registry, bytes32 routeId) {
+        REGISTRY = registry;
+        ROUTE_ID = routeId;
+    }
+
+    function consume(uint64 githubRepositoryId, bytes32 launchId) external returns (bytes32) {
+        return REGISTRY.consume(githubRepositoryId, launchId, ROUTE_ID);
+    }
+}
+
+contract LineageInvariantHandlerV1 is Test {
+    ProgrammableGithubRepositoryLineageRegistryV1 public immutable REGISTRY;
+    LineageInvariantRouteV1 public immutable ROUTE_A;
+    LineageInvariantRouteV1 public immutable ROUTE_B;
+
+    bytes32[] private _successfulRepositoryKeys;
+    mapping(bytes32 repositoryKey => bool tracked) private _trackedRepositoryKeys;
+    uint64 public successfulConsumptionCount;
+
+    constructor(
+        ProgrammableGithubRepositoryLineageRegistryV1 registry,
+        LineageInvariantRouteV1 routeA,
+        LineageInvariantRouteV1 routeB
+    ) {
+        REGISTRY = registry;
+        ROUTE_A = routeA;
+        ROUTE_B = routeB;
+    }
+
+    function consume(uint64 rawRepositoryId, bytes32 rawLaunchId, bool useRouteB) external {
+        uint64 repositoryId = rawRepositoryId == 0 ? 1 : rawRepositoryId;
+        bytes32 launchId = rawLaunchId == bytes32(0) ? keccak256(abi.encode(repositoryId, useRouteB)) : rawLaunchId;
+        LineageInvariantRouteV1 route = useRouteB ? ROUTE_B : ROUTE_A;
+        try route.consume(repositoryId, launchId) returns (bytes32 repositoryKey) {
+            if (!_trackedRepositoryKeys[repositoryKey]) {
+                _trackedRepositoryKeys[repositoryKey] = true;
+                _successfulRepositoryKeys.push(repositoryKey);
+                successfulConsumptionCount++;
+            }
+        } catch { }
+    }
+
+    function retryKnown(uint256 seed) external {
+        if (_successfulRepositoryKeys.length == 0) return;
+        bytes32 repositoryKey = _successfulRepositoryKeys[seed % _successfulRepositoryKeys.length];
+        IProgrammableGithubRepositoryLineageRegistryV1.RepositoryConsumptionV1 memory record =
+            REGISTRY.consumption(repositoryKey);
+        LineageInvariantRouteV1 route = record.consumer == address(ROUTE_A) ? ROUTE_A : ROUTE_B;
+        route.consume(record.githubRepositoryId, record.launchId);
+    }
+
+    function successfulRepositoryKeyAt(uint256 index) external view returns (bytes32) {
+        return _successfulRepositoryKeys[index];
+    }
+}
+
+contract ProgrammableGithubRepositoryLineageRegistryV1InvariantTest is StdInvariant, Test {
+    address internal constant ADMIN = address(0xA11CE);
+
+    ProgrammableGithubRepositoryLineageRegistryV1 internal registry;
+    LineageInvariantRouteV1 internal routeA;
+    LineageInvariantRouteV1 internal routeB;
+    LineageInvariantHandlerV1 internal handler;
+
+    function setUp() public {
+        registry = new ProgrammableGithubRepositoryLineageRegistryV1(2 days, ADMIN);
+        routeA = new LineageInvariantRouteV1(registry, keccak256("programmable.invariant.route-a.v1"));
+        routeB = new LineageInvariantRouteV1(registry, keccak256("programmable.invariant.route-b.v1"));
+        vm.startPrank(ADMIN);
+        registry.grantRole(registry.CONSUMER_ROLE(), address(routeA));
+        registry.grantRole(registry.CONSUMER_ROLE(), address(routeB));
+        vm.stopPrank();
+
+        handler = new LineageInvariantHandlerV1(registry, routeA, routeB);
+        targetContract(address(handler));
+    }
+
+    function invariant_oneStoredRecordPerSuccessfulRepositoryKey() public view {
+        uint64 count = registry.consumptionCount();
+        assertEq(count, handler.successfulConsumptionCount());
+        for (uint256 i; i < count; ++i) {
+            bytes32 repositoryKey = handler.successfulRepositoryKeyAt(i);
+            IProgrammableGithubRepositoryLineageRegistryV1.RepositoryConsumptionV1 memory record =
+                registry.consumption(repositoryKey);
+            assertNotEq(record.launchId, bytes32(0));
+            assertEq(registry.repositoryKeyByLaunchId(record.launchId), repositoryKey);
+            assertEq(registry.computeRepositoryKey(record.githubRepositoryId), repositoryKey);
+            assertTrue(record.consumer == address(routeA) || record.consumer == address(routeB));
+        }
+    }
+}

--- a/contracts/test/utils/ProgrammableExactShardsBindingHarnessV1.sol
+++ b/contracts/test/utils/ProgrammableExactShardsBindingHarnessV1.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { ProgrammableExactShardsFeePolicyVerifierV1 } from "../../src/ProgrammableExactShardsFeePolicyVerifierV1.sol";
+import { ProgrammableExactShardsRegistryV1 } from "../../src/ProgrammableExactShardsRegistryV1.sol";
+import {
+    IProgrammableExactShardsFeePolicyVerifierV1
+} from "../../src/interfaces/IProgrammableExactShardsFeePolicyVerifierV1.sol";
+import { IProgrammableExactShardsRegistryV1 } from "../../src/interfaces/IProgrammableExactShardsRegistryV1.sol";
+import {
+    IProgrammableGithubRepositoryLineageRegistryV1
+} from "../../src/interfaces/IProgrammableGithubRepositoryLineageRegistryV1.sol";
+
+/// @dev Test-only independent reproduction of the offchain binding algorithm. It is never a deployment artifact.
+contract ProgrammableExactShardsBindingHarnessV1 {
+    ProgrammableExactShardsRegistryV1 public immutable REGISTRY;
+    ProgrammableExactShardsFeePolicyVerifierV1 public immutable VERIFIER;
+    IProgrammableGithubRepositoryLineageRegistryV1 public immutable LINEAGE_REGISTRY;
+
+    bytes32 private constant APPROVAL_DOMAIN = keccak256("programmable.exact-shards-approval-binding.v1");
+    bytes32 private constant REVIEW_DEPLOYMENT_DOMAIN =
+        keccak256("programmable.exact-shards-review-deployment-binding.v1");
+    bytes32 private constant IDENTITY_DOMAIN = keccak256("programmable.exact-shards-launch-identity.v1");
+    bytes32 private constant RECORD_DOMAIN = keccak256("programmable.exact-shards-registered-record.v1");
+    bytes32 private constant METADATA_DOMAIN = keccak256("programmable.exact-shards-launch-metadata-binding.v1");
+    bytes32 private constant FEE_RECORD_DOMAIN = keccak256("programmable.exact-shards-fee-policy-record.v1");
+    bytes32 private constant LEG_TYPEHASH = keccak256(
+        "ProgrammableRevenueLegV1(bytes32 roleHash,uint16 feeBps,address recipient,bytes32 recipientModeHash)"
+    );
+    bytes32 private constant STORED_CLAIM_TYPEHASH = keccak256(
+        "ProgrammableExactShardsStoredFeeClaimV1(uint8 ordinal,bytes32 roleHash,uint16 grossVolumeFeeBps,uint16 shareOfFeeBps,address initialRecipientOrAccumulator,bytes32 recipientModeHash,bytes4 claimSelector,bytes4 handoffSelector,bytes32 legHash)"
+    );
+
+    constructor(
+        ProgrammableExactShardsRegistryV1 registry,
+        ProgrammableExactShardsFeePolicyVerifierV1 verifier,
+        IProgrammableGithubRepositoryLineageRegistryV1 lineageRegistry
+    ) {
+        REGISTRY = registry;
+        VERIFIER = verifier;
+        LINEAGE_REGISTRY = lineageRegistry;
+    }
+
+    function computeBindings(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        external
+        view
+        returns (
+            bytes32 approvalBindingHash,
+            bytes32 launchIntentBindingHash,
+            bytes32 reviewDeploymentBindingHash,
+            bytes32 registeredRecordCommitment
+        )
+    {
+        bytes32 feePolicyRecordHash = _feePolicyRecordHash(registration);
+        approvalBindingHash = _approvalBindingHash(registration, feePolicyRecordHash);
+        reviewDeploymentBindingHash = _reviewDeploymentBindingHash(registration, feePolicyRecordHash);
+        registeredRecordCommitment = _registeredRecordCommitment(registration, feePolicyRecordHash);
+        launchIntentBindingHash =
+            keccak256(abi.encode(IDENTITY_DOMAIN, REGISTRY.REGISTRY_INSTANCE_HASH(), registeredRecordCommitment));
+    }
+
+    function _feePolicyRecordHash(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        view
+        returns (bytes32)
+    {
+        bytes32 policyHash = VERIFIER.verify(registration.feePolicy, registration.orderedFeeLegs);
+        bytes32 builder = _storedClaimHash(0, registration.orderedFeeLegs[0]);
+        bytes32 programmable = _storedClaimHash(1, registration.orderedFeeLegs[1]);
+        bytes32 holder = _storedClaimHash(2, registration.orderedFeeLegs[2]);
+        return keccak256(
+            abi.encode(
+                FEE_RECORD_DOMAIN,
+                REGISTRY.REGISTRY_INSTANCE_HASH(),
+                address(VERIFIER),
+                address(VERIFIER).codehash,
+                VERIFIER.feePolicyBindingHashV1(),
+                policyHash,
+                keccak256(abi.encode(builder, programmable, holder))
+            )
+        );
+    }
+
+    function _approvalBindingHash(
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration,
+        bytes32 feePolicyRecordHash
+    ) private view returns (bytes32) {
+        bytes32 reviewedSourceHash = keccak256(
+            abi.encode(
+                registration.githubRepositoryId,
+                LINEAGE_REGISTRY.computeRepositoryKey(registration.githubRepositoryId),
+                registration.commitId,
+                registration.sourceCommitment,
+                registration.buildCommitment,
+                registration.artifactSetHash
+            )
+        );
+        bytes32 reviewedModelHash = keccak256(
+            abi.encode(
+                registration.modelId,
+                registration.modelVersion,
+                registration.templateId,
+                registration.templateVersion,
+                registration.providerId,
+                registration.permissionsHash,
+                registration.marketPathId,
+                registration.capabilitySetHash
+            )
+        );
+        bytes32 scopeHash = keccak256(
+            abi.encode(
+                REGISTRY.REGISTRY_INSTANCE_HASH(),
+                registration.chainId,
+                registration.registryGeneration,
+                registration.launchId,
+                registration.projectId,
+                registration.approvalId
+            )
+        );
+        bytes32 reviewedSecurityAndEconomicsHash = keccak256(
+            abi.encode(
+                registration.reviewPolicyHash,
+                registration.securityReviewHash,
+                registration.reviewResultId,
+                feePolicyRecordHash
+            )
+        );
+        return keccak256(
+            abi.encode(
+                APPROVAL_DOMAIN,
+                REGISTRY.REGISTRY_INSTANCE_HASH(),
+                scopeHash,
+                reviewedSourceHash,
+                reviewedModelHash,
+                reviewedSecurityAndEconomicsHash
+            )
+        );
+    }
+
+    function _reviewDeploymentBindingHash(
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration,
+        bytes32 feePolicyRecordHash
+    ) private view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                REVIEW_DEPLOYMENT_DOMAIN,
+                REGISTRY.REGISTRY_INSTANCE_HASH(),
+                registration.approvalBindingHash,
+                registration.deploymentId,
+                registration.deploymentSetHash,
+                registration.runtimeCodeSetHash,
+                registration.primaryContract,
+                registration.primaryRuntimeCodeHash,
+                registration.deploymentConfigurationHash,
+                registration.configurationHash,
+                registration.permissionsHash,
+                feePolicyRecordHash
+            )
+        );
+    }
+
+    function _registeredRecordCommitment(
+        IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration,
+        bytes32 feePolicyRecordHash
+    ) private view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                RECORD_DOMAIN,
+                REGISTRY.REGISTRY_INSTANCE_HASH(),
+                _scopeAndApprovalHash(registration),
+                _sourceAndDeploymentHash(registration),
+                _attributionHash(registration),
+                _reviewHash(registration),
+                keccak256(
+                    abi.encode(
+                        METADATA_DOMAIN,
+                        registration.tokenNameHash,
+                        registration.tokenSymbolHash,
+                        registration.presentationBindingHash
+                    )
+                ),
+                feePolicyRecordHash,
+                registration.finalityPolicyHash
+            )
+        );
+    }
+
+    function _storedClaimHash(
+        uint8 ordinal,
+        IProgrammableExactShardsFeePolicyVerifierV1.ProgrammableRevenueLegV1 memory leg
+    ) private pure returns (bytes32) {
+        uint16 shareOfFeeBps = ordinal == 0 ? 1000 : ordinal == 1 ? 1000 : 8000;
+        bytes4 claimSelector =
+            ordinal == 0 ? bytes4(0x69f9a5f0) : ordinal == 1 ? bytes4(0x64d46b85) : bytes4(0x6ba4c138);
+        bytes4 handoffSelector = ordinal == 0 ? bytes4(0x4ce11d21) : bytes4(0);
+        bytes32 legHash =
+            keccak256(abi.encode(LEG_TYPEHASH, leg.roleHash, leg.feeBps, leg.recipient, leg.recipientModeHash));
+        return keccak256(
+            abi.encode(
+                STORED_CLAIM_TYPEHASH,
+                ordinal,
+                leg.roleHash,
+                leg.feeBps,
+                shareOfFeeBps,
+                leg.recipient,
+                leg.recipientModeHash,
+                claimSelector,
+                handoffSelector,
+                legHash
+            )
+        );
+    }
+
+    function _sourceAndDeploymentHash(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        view
+        returns (bytes32)
+    {
+        bytes32[15] memory words;
+        words[0] = bytes32(uint256(registration.githubRepositoryId));
+        words[1] = LINEAGE_REGISTRY.computeRepositoryKey(registration.githubRepositoryId);
+        words[2] = registration.commitId;
+        words[3] = registration.sourceCommitment;
+        words[4] = registration.buildCommitment;
+        words[5] = registration.artifactSetHash;
+        words[6] = registration.deploymentConfigurationHash;
+        words[7] = registration.configurationHash;
+        words[8] = registration.permissionsHash;
+        words[9] = registration.deploymentId;
+        words[10] = registration.deploymentSetHash;
+        words[11] = registration.runtimeCodeSetHash;
+        words[12] = bytes32(uint256(uint160(registration.primaryContract)));
+        words[13] = registration.primaryRuntimeCodeHash;
+        words[14] = bytes32(uint256(uint160(registration.launchWallet)));
+        return keccak256(abi.encode(words));
+    }
+
+    function _attributionHash(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        pure
+        returns (bytes32)
+    {
+        bytes32[11] memory words;
+        words[0] = registration.modelId;
+        words[1] = registration.modelVersion;
+        words[2] = registration.templateId;
+        words[3] = registration.templateVersion;
+        words[4] = registration.providerId;
+        words[5] = registration.builderAttributionHash;
+        words[6] = registration.originHash;
+        words[7] = registration.assetSetHash;
+        words[8] = registration.marketSetHash;
+        words[9] = registration.marketPathId;
+        words[10] = registration.capabilitySetHash;
+        return keccak256(abi.encode(words));
+    }
+
+    function _reviewHash(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                registration.reviewPolicyHash,
+                registration.securityReviewHash,
+                registration.reviewResultId,
+                registration.reviewDeploymentBindingHash
+            )
+        );
+    }
+
+    function _scopeAndApprovalHash(IProgrammableExactShardsRegistryV1.LaunchRegistrationV1 memory registration)
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                registration.chainId,
+                registration.registryGeneration,
+                registration.launchId,
+                registration.projectId,
+                registration.approvalId,
+                registration.approvalBindingHash
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Outcome

Adds the shared one-launch-per-GitHub-repository authority and the exact Shards atomic route needed to make approval and launch safe across every authorized route. The route consumes the canonical repository lineage, executes the reviewed Shards factory, verifies the produced token runtime plus Website-selected name and ticker, and appends the final Registry record in one EVM transaction. Any downstream failure rolls the deployment and lineage consumption back.

Durable GitHub approval binds reviewed technical code, security and the exact inclusive 100 bps economics only. Website-selected token name, symbol and presentation record are bound separately by a short-window launch intent and the final Registry record; substitution after the permit fails.

The exact fee split remains unchanged:

- 10 bps mutable builder claim
- 10 bps fixed Programmable claim
- 80 bps dynamic NFT-holder accumulator claim

## Evidence

- complete contracts verification passed, including deterministic suites and RPC-fallback Mainnet 125/125 plus Sepolia 16/16
- exact Shards Registry: 15/15 with 1,000 fee-mutation fuzz runs
- atomic Shards route: 5/5, including rollback and cross-route loser leaving no token, hook or NFT code
- shared GitHub lineage Registry: 10/10 plus 1 invariant at 256 runs x 64 depth
- exact Shards Registry invariants: 4/4 at 256 runs x 64 depth with zero handler reverts
- Registry V1 regression: 40/40
- exact fee verifier: 8/8
- targeted strict Slither on the three new production contracts: 0 findings; repo-wide strict remains baseline-nonzero and is not claimed green
- official deployment gate: 9/9 plus live Registry verifier
- release Custom Launch records: 48/48
- source, interface, canonical ABI, creation bytecode and runtime bytecode hashes independently reproduce the machine-readable specs
- Registry runtime: 24,303 bytes, 273 bytes below EIP-170
- atomic route runtime: 3,992 bytes
- shared lineage Registry runtime: 5,515 bytes
- credential leak gate passes with exact public-hash allowlists only

## Authority boundary

All new deployment addresses remain unset and activationAllowed plus launchAllowed remain false. Consumer and writer roles are not granted. This PR does not deploy, sign, transact, authorize, register, finalize or activate anything. Canonical deployment and role grants remain independent-review steps.