### PR TITLE
Harden custom launch image receipts

### DIFF
--- a/app/api/token-image/route.ts
+++ b/app/api/token-image/route.ts
@@ -1,25 +1,213 @@
-import { put } from "@vercel/blob";
+import { createHash } from "node:crypto";
+
+import { put, type PutBlobResult } from "@vercel/blob";
 import { PrivyClient } from "@privy-io/node";
 import { NextResponse } from "next/server";
 
+import type {
+  TokenImageUploadReceiptLaunchScopeV1,
+  TokenImageUploadReceiptOwnerV1,
+} from "@/lib/custom-launch/token-image-upload-receipt-v1";
+import type { Sha256DigestV2 } from "@/lib/custom-launch/contract-v2";
 import {
-  hasValidTokenImageSignature,
+  createPrivyGitHubPrincipalAuthenticatorV1,
+  type AuthenticatedGitHubPrincipalV1,
+} from "@/lib/server/projection-target/github-entitlement";
+import {
+  parseStrictJson,
+  type JsonValue,
+} from "@/lib/server/projection-target/canonical-json";
+import {
+  createProductionTokenImageUploadReceiptSignerV1,
+  type TokenImageUploadReceiptSignerV1,
+} from "@/lib/server/token-image-upload-receipt-v1";
+import { verifyTokenImageWebpV1 } from "@/lib/server/token-image-webp-v1";
+import {
+  getProgrammableTokenImageAssetName,
   MAX_TOKEN_IMAGE_UPLOAD_BYTES,
+  PROGRAMMABLE_TOKEN_IMAGE_HOST,
+  PROGRAMMABLE_TOKEN_IMAGE_STORE_ID,
+  TOKEN_IMAGE_OUTPUT_SIZE,
 } from "@/lib/token-image";
 
 export const runtime = "nodejs";
-export const maxDuration = 10;
+export const maxDuration = 20;
+
+const READBACK_TIMEOUT_MS = 5_000;
+const MAXIMUM_RECEIPT_SCOPE_BYTES = 2_048;
+const moduleFetch = globalThis.fetch.bind(globalThis);
 
 const responseHeaders = {
   "Cache-Control": "no-store",
   "X-Content-Type-Options": "nosniff",
+  Vary: "Authorization, X-Privy-Identity-Token",
 };
 
+type TokenImageUploadSessionV1 = Readonly<{ privyUserId: string }>;
+type TokenImageReadbackV1 = Readonly<{
+  url: string;
+  etag: string;
+  contentType: string;
+  bytes: Uint8Array;
+}>;
+
+export type TokenImageUploadHandlerDependenciesV1 = Readonly<{
+  blobToken: string;
+  authenticateSession(request: Request): Promise<TokenImageUploadSessionV1 | null>;
+  authenticatePrincipal(request: Request): Promise<AuthenticatedGitHubPrincipalV1>;
+  prepareReceiptSigner(): Promise<TokenImageUploadReceiptSignerV1>;
+  putBlob(pathname: string, file: File, token: string): Promise<PutBlobResult>;
+  readBlob(blob: PutBlobResult, signal: AbortSignal): Promise<TokenImageReadbackV1>;
+  readbackTimeoutMs?: number;
+}>;
+
+export function createTokenImageUploadHandlerV1(
+  dependencies: TokenImageUploadHandlerDependenciesV1,
+): (request: Request) => Promise<Response> {
+  return async function tokenImageUpload(request: Request): Promise<Response> {
+    const contentLength = Number(request.headers.get("content-length") ?? "0");
+    if (
+      Number.isFinite(contentLength)
+      && contentLength > MAX_TOKEN_IMAGE_UPLOAD_BYTES + 100_000
+    ) return errorResponse("Choose a smaller image", 413);
+
+    const session = await dependencies.authenticateSession(request);
+    if (!session) return errorResponse("Connect your wallet and try again", 401);
+
+    let form: FormData;
+    try {
+      form = await request.formData();
+    } catch {
+      return errorResponse("The image could not be read", 400);
+    }
+    const file = form.get("file");
+    if (!(file instanceof File)) return errorResponse("Choose an image", 400);
+    if (
+      file.type !== "image/webp"
+      || file.size === 0
+      || file.size > MAX_TOKEN_IMAGE_UPLOAD_BYTES
+    ) return errorResponse("Choose a valid token image", 400);
+
+    let verifiedSource;
+    try {
+      verifiedSource = await verifyTokenImageWebpV1(file);
+    } catch {
+      return errorResponse("Choose a valid token image", 400);
+    }
+
+    let scope: TokenImageUploadReceiptLaunchScopeV1 | null = null;
+    try {
+      scope = parseReceiptScope(form.get("receiptScope"));
+    } catch {
+      return errorResponse("The image upload request is invalid", 400);
+    }
+    let principal: AuthenticatedGitHubPrincipalV1 | null = null;
+    let signer: TokenImageUploadReceiptSignerV1 | null = null;
+    if (scope !== null) {
+      try {
+        principal = await dependencies.authenticatePrincipal(request);
+      } catch {
+        return errorResponse("Connect the approved GitHub account and try again", 403);
+      }
+      if (principal.privyUserId !== session.privyUserId) {
+        return errorResponse("Connect the approved GitHub account and try again", 403);
+      }
+      try {
+        // Resolve signer authority before the irreversible Blob write. There is
+        // deliberately no local/private-key fallback.
+        signer = await dependencies.prepareReceiptSigner();
+      } catch {
+        return errorResponse("Verified image uploads are temporarily unavailable", 503);
+      }
+    }
+
+    let blob: PutBlobResult;
+    try {
+      blob = await dependencies.putBlob(
+        `token-images/${crypto.randomUUID()}.webp`,
+        new File(
+          [Uint8Array.from(verifiedSource.bytes).buffer],
+          "custom-launch.webp",
+          { type: "image/webp" },
+        ),
+        dependencies.blobToken,
+      );
+      validateWrittenBlob(blob);
+    } catch {
+      return errorResponse("The image could not be uploaded", 502);
+    }
+
+    let readback: TokenImageReadbackV1;
+    let verifiedReadback;
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(
+        () => controller.abort(new Error("token image readback deadline exceeded")),
+        dependencies.readbackTimeoutMs ?? READBACK_TIMEOUT_MS,
+      );
+      const signal = AbortSignal.any([request.signal, controller.signal]);
+      try {
+        readback = await dependencies.readBlob(blob, signal);
+      } finally {
+        clearTimeout(timeout);
+      }
+      validateReadback(blob, readback);
+      verifiedReadback = await verifyTokenImageWebpV1(readback.bytes);
+      if (
+        rawDigest(verifiedReadback.bytes) !== rawDigest(verifiedSource.bytes)
+        || verifiedReadback.bytes.byteLength !== verifiedSource.bytes.byteLength
+      ) throw new TypeError("token image readback bytes changed");
+    } catch {
+      return errorResponse("The uploaded image could not be verified", 502);
+    }
+
+    if (scope === null || principal === null || signer === null) {
+      return NextResponse.json(
+        { url: blob.url },
+        { status: 201, headers: responseHeaders },
+      );
+    }
+
+    const uploadOwner: TokenImageUploadReceiptOwnerV1 = Object.freeze({
+      provider: "privy-github",
+      privyUserId: principal.privyUserId,
+      githubUserId: principal.githubUserId,
+      githubPrincipalHash: principal.githubPrincipalHash as Sha256DigestV2,
+    });
+    try {
+      const receipt = await signer.sign({
+        launchScope: scope,
+        uploadOwner,
+        blob: Object.freeze({
+          storeId: PROGRAMMABLE_TOKEN_IMAGE_STORE_ID,
+          host: PROGRAMMABLE_TOKEN_IMAGE_HOST,
+          pathname: blob.pathname,
+          url: blob.url,
+          etag: normalizeStrongEtag(blob.etag),
+        }),
+        image: Object.freeze({
+          contentSha256: rawDigest(verifiedReadback.bytes),
+          mediaType: "image/webp",
+          byteLength: verifiedReadback.bytes.byteLength,
+          width: TOKEN_IMAGE_OUTPUT_SIZE,
+          height: TOKEN_IMAGE_OUTPUT_SIZE,
+        }),
+        signal: request.signal,
+      });
+      return NextResponse.json(
+        { url: blob.url, receipt },
+        { status: 201, headers: responseHeaders },
+      );
+    } catch {
+      // The Blob may now be orphaned. Never delete it here: deletion is an
+      // independent external mutation and a receipt/presentation was not issued.
+      return errorResponse("The uploaded image could not be verified", 502);
+    }
+  };
+}
+
 function errorResponse(error: string, status: number) {
-  return NextResponse.json(
-    { error },
-    { status, headers: responseHeaders },
-  );
+  return NextResponse.json({ error }, { status, headers: responseHeaders });
 }
 
 function getBearerToken(request: Request) {
@@ -29,80 +217,201 @@ function getBearerToken(request: Request) {
     : "";
 }
 
-async function verifyPrivySession(request: Request) {
+async function verifyPrivySession(request: Request): Promise<TokenImageUploadSessionV1 | null> {
   const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID?.trim();
   const appSecret = process.env.PRIVY_APP_SECRET?.trim();
   const accessToken = getBearerToken(request);
   if (!appId || !appSecret || !accessToken) return null;
-
   const privy = new PrivyClient({ appId, appSecret });
   try {
-    return await privy.utils().auth().verifyAccessToken(accessToken);
+    const session = await privy.utils().auth().verifyAccessToken(accessToken);
+    if (session.app_id !== appId || !session.user_id) return null;
+    return Object.freeze({ privyUserId: session.user_id });
   } catch {
     return null;
   }
 }
 
+export async function readProductionTokenImageBlobV1(
+  blob: PutBlobResult,
+  signal: AbortSignal,
+  transport: typeof fetch = moduleFetch,
+): Promise<TokenImageReadbackV1> {
+  const response = await transport(blob.url, {
+    method: "GET",
+    redirect: "error",
+    cache: "no-store",
+    credentials: "omit",
+    signal,
+    headers: {
+      accept: "image/webp",
+    },
+  });
+  if (response.redirected || response.status !== 200 || response.url !== blob.url) {
+    throw new TypeError("token image readback target changed");
+  }
+  const contentType = response.headers.get("content-type")
+    ?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  const etag = response.headers.get("etag") ?? "";
+  return Object.freeze({
+    url: response.url,
+    etag,
+    contentType,
+    bytes: await readBoundedBody(response, MAX_TOKEN_IMAGE_UPLOAD_BYTES),
+  });
+}
+
+async function readBoundedBody(response: Response, maximumBytes: number): Promise<Uint8Array> {
+  const declared = Number(response.headers.get("content-length") ?? "0");
+  if (Number.isFinite(declared) && declared > maximumBytes) {
+    throw new TypeError("token image readback is too large");
+  }
+  if (response.body === null) throw new TypeError("token image readback is empty");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maximumBytes) throw new TypeError("token image readback is too large");
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (total < 1) throw new TypeError("token image readback is empty");
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function parseReceiptScope(value: FormDataEntryValue | null):
+TokenImageUploadReceiptLaunchScopeV1 | null {
+  if (value === null) return null;
+  if (
+    typeof value !== "string"
+    || value.length < 1
+    || new TextEncoder().encode(value).byteLength > MAXIMUM_RECEIPT_SCOPE_BYTES
+  ) throw new TypeError("token image receipt scope is invalid");
+  const parsed = parseStrictJson(value, {
+    maximumBytes: MAXIMUM_RECEIPT_SCOPE_BYTES,
+    maximumDepth: 3,
+  });
+  const record = jsonRecord(parsed, "token image receipt scope");
+  exactKeys(record, [
+    "applicationHandle", "applicationId", "grantBindingHash", "grantId",
+  ], "token image receipt scope");
+  if (
+    typeof record.applicationId !== "string"
+    || typeof record.applicationHandle !== "string"
+    || typeof record.grantId !== "string"
+    || typeof record.grantBindingHash !== "string"
+    || record.applicationId.length < 1
+    || record.applicationId.length > 256
+    || !/^github-[0-9a-f]{64}$/u.test(record.applicationHandle)
+    || record.grantId.length < 1
+    || record.grantId.length > 256
+    || !/^sha256:[0-9a-f]{64}$/u.test(record.grantBindingHash)
+  ) throw new TypeError("token image receipt scope is invalid");
+  return Object.freeze({
+    applicationId: record.applicationId,
+    applicationHandle: record.applicationHandle as `github-${string}`,
+    grantId: record.grantId,
+    grantBindingHash: record.grantBindingHash as Sha256DigestV2,
+  });
+}
+
+function validateWrittenBlob(blob: PutBlobResult): void {
+  const asset = getProgrammableTokenImageAssetName(blob.url);
+  const url = new URL(blob.url);
+  if (
+    asset === ""
+    || blob.contentType !== "image/webp"
+    || blob.pathname !== url.pathname.slice(1)
+    || normalizeStrongEtag(blob.etag) === ""
+  ) throw new TypeError("written token image Blob is invalid");
+}
+
+function validateReadback(blob: PutBlobResult, readback: TokenImageReadbackV1): void {
+  if (
+    readback.url !== blob.url
+    || readback.contentType !== "image/webp"
+    || normalizeStrongEtag(readback.etag) !== normalizeStrongEtag(blob.etag)
+    || readback.bytes.byteLength < 1
+    || readback.bytes.byteLength > MAX_TOKEN_IMAGE_UPLOAD_BYTES
+  ) throw new TypeError("token image Blob readback is invalid");
+}
+
+function normalizeStrongEtag(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed === "" || trimmed.startsWith("W/") || trimmed.length > 256) {
+    throw new TypeError("token image Blob etag is invalid");
+  }
+  const unquoted = trimmed.startsWith('"') && trimmed.endsWith('"')
+    ? trimmed.slice(1, -1)
+    : trimmed;
+  if (unquoted === "" || /[\s\u0000-\u001f\u007f"]/u.test(unquoted)) {
+    throw new TypeError("token image Blob etag is invalid");
+  }
+  return unquoted;
+}
+
+function rawDigest(bytes: Uint8Array): Sha256DigestV2 {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function jsonRecord(value: JsonValue, label: string): Readonly<Record<string, JsonValue>> {
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function exactKeys(
+  value: Readonly<Record<string, JsonValue>>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new TypeError(`${label} has unknown or missing fields`);
+  }
+}
+
+let productionHandler: ((request: Request) => Promise<Response>) | null = null;
+
 export async function POST(request: Request) {
-  const blobToken =
-    process.env.TOKEN_IMAGE_BLOB_READ_WRITE_TOKEN?.trim();
+  const blobToken = process.env.TOKEN_IMAGE_BLOB_READ_WRITE_TOKEN?.trim();
   if (!blobToken) {
     return errorResponse("Image uploads are temporarily unavailable", 503);
   }
-
-  const contentLength = Number(
-    request.headers.get("content-length") ?? "0",
-  );
-  if (
-    Number.isFinite(contentLength) &&
-    contentLength > MAX_TOKEN_IMAGE_UPLOAD_BYTES + 100_000
-  ) {
-    return errorResponse("Choose a smaller image", 413);
-  }
-
-  const session = await verifyPrivySession(request);
-  if (!session) {
-    return errorResponse("Connect your wallet and try again", 401);
-  }
-
-  let form: FormData;
-  try {
-    form = await request.formData();
-  } catch {
-    return errorResponse("The image could not be read", 400);
-  }
-
-  const file = form.get("file");
-  if (!(file instanceof File)) {
-    return errorResponse("Choose an image", 400);
-  }
-  if (
-    file.type !== "image/webp" ||
-    file.size === 0 ||
-    file.size > MAX_TOKEN_IMAGE_UPLOAD_BYTES ||
-    !(await hasValidTokenImageSignature(file))
-  ) {
-    return errorResponse("Choose a valid token image", 400);
-  }
-
-  try {
-    const blob = await put(
-      `token-images/${crypto.randomUUID()}.webp`,
-      file,
-      {
-        access: "public",
-        addRandomSuffix: true,
-        cacheControlMaxAge: 31_536_000,
-        contentType: "image/webp",
-        token: blobToken,
+  if (productionHandler === null) {
+    productionHandler = createTokenImageUploadHandlerV1({
+      blobToken,
+      authenticateSession: verifyPrivySession,
+      authenticatePrincipal(request) {
+        return createPrivyGitHubPrincipalAuthenticatorV1().authenticate(request);
       },
-    );
-
-    return NextResponse.json(
-      { url: blob.url },
-      { status: 201, headers: responseHeaders },
-    );
-  } catch {
-    return errorResponse("The image could not be uploaded", 502);
+      prepareReceiptSigner: () => createProductionTokenImageUploadReceiptSignerV1(),
+      putBlob(pathname, file, token) {
+        return put(pathname, file, {
+          access: "public",
+          addRandomSuffix: true,
+          allowOverwrite: false,
+          cacheControlMaxAge: 31_536_000,
+          contentType: "image/webp",
+          token,
+        });
+      },
+      readBlob: readProductionTokenImageBlobV1,
+    });
   }
+  return productionHandler(request);
 }

--- a/components/custom-launch-experience.tsx
+++ b/components/custom-launch-experience.tsx
@@ -75,6 +75,11 @@ import {
 } from "@/lib/custom-launch/launch-authority-refresh-v1";
 import { readAllPrincipalApplicationsV3 } from "@/lib/custom-launch/principal-application-pagination-v3";
 import {
+  parseSignedTokenImageUploadReceiptV1,
+  tokenImageUploadReceiptMatchesV1,
+  type SignedTokenImageUploadReceiptV1,
+} from "@/lib/custom-launch/token-image-upload-receipt-v1";
+import {
   customApplicationIntakeIsLaunchableV2,
   type ApplicationHandleV3,
   type AuthorizedLaunchPermitViewV2,
@@ -354,6 +359,7 @@ export type PresentationForm = {
   preservedLinks: LaunchPresentationDraftV1["links"];
   image: LaunchPresentationDraftV1["image"];
   imagePreview: string;
+  imageUploadReceipt: SignedTokenImageUploadReceiptV1 | null;
 };
 
 const emptyPresentation: PresentationForm = {
@@ -368,6 +374,7 @@ const emptyPresentation: PresentationForm = {
   preservedLinks: [],
   image: null,
   imagePreview: "",
+  imageUploadReceipt: null,
 };
 
 export type CustomApplicationDisplayState = Readonly<{
@@ -1911,7 +1918,7 @@ export function CustomLaunchExperience({
   async function selectImage(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
     event.target.value = "";
-    if (!file || !selected) return;
+    if (!file || !selected || !descriptor) return;
     imageUploadAbortControllerRef.current?.abort();
     const imageController = new AbortController();
     imageUploadAbortControllerRef.current = imageController;
@@ -1933,9 +1940,18 @@ export function CustomLaunchExperience({
       if (!isCurrent()) return;
       const form = new FormData();
       form.append("file", new File([image], "custom-launch.webp", { type: "image/webp" }));
+      form.append("receiptScope", canonicalBrowserJsonV2({
+        applicationId: selected.applicationId,
+        applicationHandle: selected.applicationHandle,
+        grantId: descriptor.grantId,
+        grantBindingHash: descriptor.grantBindingHash,
+      }));
       const response = await fetch("/api/token-image", {
         method: "POST",
-        headers: { authorization: `Bearer ${session.accessToken}` },
+        headers: {
+          authorization: `Bearer ${session.accessToken}`,
+          "x-privy-identity-token": session.identityToken,
+        },
         body: form,
         cache: "no-store",
         credentials: "same-origin",
@@ -1947,7 +1963,11 @@ export function CustomLaunchExperience({
       if (contentType !== "application/json" || response.redirected) {
         throw new Error("Unable to verify the uploaded image");
       }
-      const body = await response.json() as { url?: unknown; error?: unknown };
+      const body = await response.json() as {
+        url?: unknown;
+        receipt?: unknown;
+        error?: unknown;
+      };
       if (!isCurrent()) return;
       if (!response.ok) {
         throw new Error(typeof body.error === "string"
@@ -1962,9 +1982,24 @@ export function CustomLaunchExperience({
         new Uint8Array(await image.arrayBuffer()),
       );
       if (!isCurrent()) return;
+      const imageUploadReceipt = parseSignedTokenImageUploadReceiptV1(body.receipt);
+      if (!tokenImageUploadReceiptMatchesV1(imageUploadReceipt, {
+        launchScope: {
+          applicationId: selected.applicationId,
+          applicationHandle: selected.applicationHandle,
+          grantId: descriptor.grantId,
+          grantBindingHash: descriptor.grantBindingHash,
+        },
+        uri: imageUrl,
+        contentSha256,
+        byteLength: image.size,
+        width: TOKEN_IMAGE_OUTPUT_SIZE,
+        height: TOKEN_IMAGE_OUTPUT_SIZE,
+      })) throw new Error("Unable to verify the uploaded image");
       setPresentation((current) => ({
         ...current,
         imagePreview: imageUrl,
+        imageUploadReceipt,
         image: {
           uri: imageUrl,
           contentSha256,
@@ -2097,6 +2132,13 @@ export function CustomLaunchExperience({
     ));
     if (currentPresentation !== null) {
       setPresentation(presentationFormFromResponse(currentPresentation));
+    } else {
+      setPresentation((current) => ({
+        ...current,
+        image: null,
+        imagePreview: "",
+        imageUploadReceipt: null,
+      }));
     }
     setPresentationVersion(currentPresentation?.version ?? 0);
     setPendingGrantReissue(null);
@@ -2226,6 +2268,7 @@ export function CustomLaunchExperience({
           grantBindingHash: activeDescriptor.grantBindingHash,
           expectedVersion: presentationVersion,
           presentation: presentationDraft,
+          imageUploadReceipt: presentation.imageUploadReceipt,
         },
         idempotencyKey("presentation"),
         { signal },
@@ -2852,7 +2895,7 @@ export function CustomLaunchExperience({
                     {imageUploading ? <><LoaderCircle aria-hidden="true" className={styles.spin} size={22} /><span>Preparing image</span></> : isProgrammableTokenImageUrl(presentation.imagePreview) ? <Image src={getTokenCardImageSource(presentation.imagePreview)} alt="Project image preview" width={150} height={150} unoptimized /> : <><ImagePlus aria-hidden="true" size={22} /><span>Choose image</span></>}
                     <input className={styles.visuallyHidden} type="file" aria-label={presentation.image ? "Change project image" : "Choose project image"} accept="image/png,image/jpeg,image/webp" onChange={(event) => void selectImage(event)} />
                   </label>
-                  {presentation.image ? <button className={styles.removeImageButton} type="button" onClick={() => setPresentation((current) => ({ ...current, image: null, imagePreview: "" }))}>Remove image</button> : null}
+                  {presentation.image ? <button className={styles.removeImageButton} type="button" onClick={() => setPresentation((current) => ({ ...current, image: null, imagePreview: "", imageUploadReceipt: null }))}>Remove image</button> : null}
                 </div>
                 <div className={styles.fieldStack}>
                   <label><span>Short description</span><textarea value={presentation.description} maxLength={4096} onChange={(event) => setPresentation((current) => ({ ...current, description: event.target.value }))} placeholder="What does this project make possible?" /></label>
@@ -3050,6 +3093,7 @@ export function presentationFormFromResponse(response: PrincipalLaunchPresentati
     description: draft.description,
     image: draft.image,
     imagePreview: draft.image?.uri ?? "",
+    imageUploadReceipt: null,
     website: link("website"),
     documentation: link("documentation"),
     x: link("x"),

--- a/config/shards-canary-descriptor-eligibility.v1.json
+++ b/config/shards-canary-descriptor-eligibility.v1.json
@@ -70,7 +70,7 @@
     "fileBindings": [
       {
         "path": "lib/custom-launch/contract-v2.ts",
-        "rawSha256": "0ecce91d1871886c54de90b7882c8ef86aa46f48d5894f31d8cb0e046cdd96af"
+        "rawSha256": "dd100161ba26297dcd042c79abd1259167934983c49f6147f0426e84d4a77acc"
       },
       {
         "path": "lib/custom-launch/response-contract-v2.ts",

--- a/lib/custom-launch/artifacts/token-image-upload-receipt-v1.schema.json
+++ b/lib/custom-launch/artifacts/token-image-upload-receipt-v1.schema.json
@@ -1,0 +1,300 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://programmable.example/schemas/token-image-upload-receipt-v1.schema.json",
+  "title": "Programmable signed token image upload receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "payload",
+    "payloadSha256",
+    "signature",
+    "signatureSha256",
+    "providerReceipt",
+    "providerReceiptSha256",
+    "providerReceiptSignature",
+    "providerReceiptSignatureSha256"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "programmable.signed-token-image-upload-receipt.v1"
+    },
+    "payload": {
+      "$ref": "#/definitions/payload"
+    },
+    "payloadSha256": {
+      "$ref": "#/definitions/sha256"
+    },
+    "signature": {
+      "$ref": "#/definitions/ed25519Signature"
+    },
+    "signatureSha256": {
+      "$ref": "#/definitions/sha256"
+    },
+    "providerReceipt": {
+      "$ref": "#/definitions/providerReceipt"
+    },
+    "providerReceiptSha256": {
+      "$ref": "#/definitions/sha256"
+    },
+    "providerReceiptSignature": {
+      "$ref": "#/definitions/ed25519Signature"
+    },
+    "providerReceiptSignatureSha256": {
+      "$ref": "#/definitions/sha256"
+    }
+  },
+  "definitions": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "ed25519Signature": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{86}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$"
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "audience",
+        "launchScope",
+        "uploadOwner",
+        "blob",
+        "image",
+        "signingAuthority",
+        "issuedAt",
+        "expiresAt"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.token-image-upload-receipt.v1"
+        },
+        "audience": {
+          "const": "programmable.launch-presentation-image.v1"
+        },
+        "launchScope": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "applicationId",
+            "applicationHandle",
+            "grantId",
+            "grantBindingHash"
+          ],
+          "properties": {
+            "applicationId": {
+              "type": "string",
+              "maxLength": 80,
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            },
+            "applicationHandle": {
+              "type": "string",
+              "pattern": "^github-[0-9a-f]{64}$"
+            },
+            "grantId": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+            },
+            "grantBindingHash": {
+              "$ref": "#/definitions/sha256"
+            }
+          }
+        },
+        "uploadOwner": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "provider",
+            "privyUserId",
+            "githubUserId",
+            "githubPrincipalHash"
+          ],
+          "properties": {
+            "provider": {
+              "const": "privy-github"
+            },
+            "privyUserId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 512
+            },
+            "githubUserId": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]{0,19}$"
+            },
+            "githubPrincipalHash": {
+              "$ref": "#/definitions/sha256"
+            }
+          }
+        },
+        "blob": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "storeId",
+            "host",
+            "pathname",
+            "url",
+            "etag"
+          ],
+          "properties": {
+            "storeId": {
+              "const": "store_k2uoiPT9WCHJtz3H"
+            },
+            "host": {
+              "const": "k2uoipt9wchjtz3h.public.blob.vercel-storage.com"
+            },
+            "pathname": {
+              "type": "string",
+              "pattern": "^token-images/[A-Za-z0-9][A-Za-z0-9._-]{0,199}\\.webp$"
+            },
+            "url": {
+              "type": "string",
+              "pattern": "^https://k2uoipt9wchjtz3h\\.public\\.blob\\.vercel-storage\\.com/token-images/[A-Za-z0-9][A-Za-z0-9._-]{0,199}\\.webp$"
+            },
+            "etag": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "pattern": "^[^\\s\\u0000-\\u001f\\u007f\"]+$"
+            }
+          }
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "contentSha256",
+            "mediaType",
+            "byteLength",
+            "width",
+            "height"
+          ],
+          "properties": {
+            "contentSha256": {
+              "$ref": "#/definitions/sha256"
+            },
+            "mediaType": {
+              "const": "image/webp"
+            },
+            "byteLength": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000000
+            },
+            "width": {
+              "const": 1000
+            },
+            "height": {
+              "const": 1000
+            }
+          }
+        },
+        "signingAuthority": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "providerIdentityHash",
+            "keyId",
+            "keyEpoch",
+            "publicKeySpkiSha256"
+          ],
+          "properties": {
+            "providerIdentityHash": {
+              "$ref": "#/definitions/sha256"
+            },
+            "keyId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
+            },
+            "keyEpoch": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
+            },
+            "publicKeySpkiSha256": {
+              "$ref": "#/definitions/sha256"
+            }
+          }
+        },
+        "issuedAt": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "expiresAt": {
+          "$ref": "#/definitions/timestamp"
+        }
+      }
+    },
+    "providerReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "outcome",
+        "audience",
+        "keyId",
+        "keyEpoch",
+        "algorithm",
+        "providerIdentityHash",
+        "idempotencyKey",
+        "messageSha256",
+        "requestDigest",
+        "signature",
+        "observedAt",
+        "expiresAt"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.remote-signing-provider-receipt.v2"
+        },
+        "outcome": {
+          "const": "completed"
+        },
+        "audience": {
+          "const": "programmable.launch-presentation-image.v1"
+        },
+        "keyId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "keyEpoch": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "algorithm": {
+          "const": "Ed25519"
+        },
+        "providerIdentityHash": {
+          "$ref": "#/definitions/sha256"
+        },
+        "idempotencyKey": {
+          "$ref": "#/definitions/sha256"
+        },
+        "messageSha256": {
+          "$ref": "#/definitions/sha256"
+        },
+        "requestDigest": {
+          "$ref": "#/definitions/sha256"
+        },
+        "signature": {
+          "$ref": "#/definitions/ed25519Signature"
+        },
+        "observedAt": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "expiresAt": {
+          "$ref": "#/definitions/timestamp"
+        }
+      }
+    }
+  }
+}

--- a/lib/custom-launch/contract-v2.ts
+++ b/lib/custom-launch/contract-v2.ts
@@ -878,6 +878,9 @@ export interface PrincipalLaunchPresentationCommitRequestV1 {
   readonly grantBindingHash: Sha256DigestV2;
   readonly expectedVersion: number;
   readonly presentation: LaunchPresentationDraftV1;
+  /** Required when an image is first created or changed; null for no/unchanged image. */
+  readonly imageUploadReceipt: import("./token-image-upload-receipt-v1")
+    .SignedTokenImageUploadReceiptV1 | null;
 }
 
 export interface PrincipalLaunchPresentationResponseV1 {

--- a/lib/custom-launch/token-image-upload-receipt-v1.ts
+++ b/lib/custom-launch/token-image-upload-receipt-v1.ts
@@ -1,0 +1,381 @@
+import type {
+  ApplicationHandleV3,
+  Sha256DigestV2,
+} from "./contract-v2";
+import {
+  getProgrammableTokenImageAssetName,
+  PROGRAMMABLE_TOKEN_IMAGE_HOST,
+  PROGRAMMABLE_TOKEN_IMAGE_STORE_ID,
+} from "../token-image";
+
+export const TOKEN_IMAGE_UPLOAD_RECEIPT_AUDIENCE_V1 =
+  "programmable.launch-presentation-image.v1" as const;
+export const TOKEN_IMAGE_UPLOAD_RECEIPT_MAX_AGE_MS_V1 = 300_000;
+export const TOKEN_IMAGE_UPLOAD_RECEIPT_SCHEMA_SHA256_V1 =
+  "sha256:e04adb01d0a522a31a4167021fbac2626457b2b6b2f0becc30c59ea329506de8" as const;
+
+export type TokenImageUploadReceiptLaunchScopeV1 = Readonly<{
+  applicationId: string;
+  applicationHandle: ApplicationHandleV3;
+  grantId: string;
+  grantBindingHash: Sha256DigestV2;
+}>;
+
+export type TokenImageUploadReceiptOwnerV1 = Readonly<{
+  provider: "privy-github";
+  privyUserId: string;
+  githubUserId: string;
+  githubPrincipalHash: Sha256DigestV2;
+}>;
+
+export type TokenImageUploadReceiptPayloadV1 = Readonly<{
+  schemaVersion: "programmable.token-image-upload-receipt.v1";
+  audience: typeof TOKEN_IMAGE_UPLOAD_RECEIPT_AUDIENCE_V1;
+  launchScope: TokenImageUploadReceiptLaunchScopeV1;
+  uploadOwner: TokenImageUploadReceiptOwnerV1;
+  blob: Readonly<{
+    storeId: string;
+    host: string;
+    pathname: string;
+    url: string;
+    etag: string;
+  }>;
+  image: Readonly<{
+    contentSha256: Sha256DigestV2;
+    mediaType: "image/webp";
+    byteLength: number;
+    width: 1000;
+    height: 1000;
+  }>;
+  signingAuthority: Readonly<{
+    providerIdentityHash: Sha256DigestV2;
+    keyId: string;
+    keyEpoch: string;
+    publicKeySpkiSha256: Sha256DigestV2;
+  }>;
+  issuedAt: string;
+  expiresAt: string;
+}>;
+
+export type TokenImageRemoteSigningProviderReceiptV2 = Readonly<{
+  schemaVersion: "programmable.remote-signing-provider-receipt.v2";
+  outcome: "completed";
+  audience: typeof TOKEN_IMAGE_UPLOAD_RECEIPT_AUDIENCE_V1;
+  keyId: string;
+  keyEpoch: string;
+  algorithm: "Ed25519";
+  providerIdentityHash: Sha256DigestV2;
+  idempotencyKey: Sha256DigestV2;
+  messageSha256: Sha256DigestV2;
+  requestDigest: Sha256DigestV2;
+  signature: string;
+  observedAt: string;
+  expiresAt: string;
+}>;
+
+export type SignedTokenImageUploadReceiptV1 = Readonly<{
+  schemaVersion: "programmable.signed-token-image-upload-receipt.v1";
+  payload: TokenImageUploadReceiptPayloadV1;
+  payloadSha256: Sha256DigestV2;
+  signature: string;
+  signatureSha256: Sha256DigestV2;
+  providerReceipt: TokenImageRemoteSigningProviderReceiptV2;
+  providerReceiptSha256: Sha256DigestV2;
+  providerReceiptSignature: string;
+  providerReceiptSignatureSha256: Sha256DigestV2;
+}>;
+
+export function parseSignedTokenImageUploadReceiptV1(
+  value: unknown,
+): SignedTokenImageUploadReceiptV1 {
+  const receipt = record(value, "image upload receipt");
+  exactKeys(receipt, [
+    "payload",
+    "payloadSha256",
+    "providerReceipt",
+    "providerReceiptSha256",
+    "providerReceiptSignature",
+    "providerReceiptSignatureSha256",
+    "schemaVersion",
+    "signature",
+    "signatureSha256",
+  ], "image upload receipt");
+  if (receipt.schemaVersion !== "programmable.signed-token-image-upload-receipt.v1") {
+    throw new TypeError("image upload receipt schema is invalid");
+  }
+  const payload = parsePayload(receipt.payload);
+  const providerReceipt = parseProviderReceipt(receipt.providerReceipt);
+  const parsed = Object.freeze({
+    schemaVersion: receipt.schemaVersion,
+    payload,
+    payloadSha256: digest(receipt.payloadSha256, "image upload receipt payload hash"),
+    signature: signature(receipt.signature, "image upload receipt signature"),
+    signatureSha256: digest(receipt.signatureSha256, "image upload receipt signature hash"),
+    providerReceipt,
+    providerReceiptSha256: digest(
+      receipt.providerReceiptSha256,
+      "image upload provider receipt hash",
+    ),
+    providerReceiptSignature: signature(
+      receipt.providerReceiptSignature,
+      "image upload provider receipt signature",
+    ),
+    providerReceiptSignatureSha256: digest(
+      receipt.providerReceiptSignatureSha256,
+      "image upload provider receipt signature hash",
+    ),
+  });
+  if (
+    providerReceipt.audience !== payload.audience
+    || providerReceipt.keyId !== payload.signingAuthority.keyId
+    || providerReceipt.keyEpoch !== payload.signingAuthority.keyEpoch
+    || providerReceipt.providerIdentityHash
+      !== payload.signingAuthority.providerIdentityHash
+    || providerReceipt.messageSha256 !== parsed.payloadSha256
+    || providerReceipt.signature !== parsed.signature
+  ) throw new TypeError("image upload receipt signer binding is invalid");
+  return parsed;
+}
+
+export function tokenImageUploadReceiptMatchesV1(
+  receipt: SignedTokenImageUploadReceiptV1,
+  expected: Readonly<{
+    launchScope: TokenImageUploadReceiptLaunchScopeV1;
+    uri: string;
+    contentSha256: Sha256DigestV2;
+    byteLength: number;
+    width: number;
+    height: number;
+  }>,
+): boolean {
+  const { payload } = receipt;
+  return payload.launchScope.applicationId === expected.launchScope.applicationId
+    && payload.launchScope.applicationHandle === expected.launchScope.applicationHandle
+    && payload.launchScope.grantId === expected.launchScope.grantId
+    && payload.launchScope.grantBindingHash === expected.launchScope.grantBindingHash
+    && payload.blob.url === expected.uri
+    && payload.image.contentSha256 === expected.contentSha256
+    && payload.image.byteLength === expected.byteLength
+    && payload.image.width === expected.width
+    && payload.image.height === expected.height;
+}
+
+function parsePayload(value: unknown): TokenImageUploadReceiptPayloadV1 {
+  const payload = record(value, "image upload receipt payload");
+  exactKeys(payload, [
+    "audience", "blob", "expiresAt", "image", "issuedAt", "launchScope",
+    "schemaVersion", "signingAuthority", "uploadOwner",
+  ], "image upload receipt payload");
+  if (
+    payload.schemaVersion !== "programmable.token-image-upload-receipt.v1"
+    || payload.audience !== TOKEN_IMAGE_UPLOAD_RECEIPT_AUDIENCE_V1
+  ) throw new TypeError("image upload receipt payload schema is invalid");
+
+  const launchScope = record(payload.launchScope, "image upload launch scope");
+  exactKeys(launchScope, [
+    "applicationHandle", "applicationId", "grantBindingHash", "grantId",
+  ], "image upload launch scope");
+  const uploadOwner = record(payload.uploadOwner, "image upload owner");
+  exactKeys(uploadOwner, [
+    "githubPrincipalHash", "githubUserId", "privyUserId", "provider",
+  ], "image upload owner");
+  const blob = record(payload.blob, "image upload blob");
+  exactKeys(blob, ["etag", "host", "pathname", "storeId", "url"], "image upload blob");
+  const image = record(payload.image, "image upload metadata");
+  exactKeys(image, [
+    "byteLength", "contentSha256", "height", "mediaType", "width",
+  ], "image upload metadata");
+  const authority = record(payload.signingAuthority, "image upload signing authority");
+  exactKeys(authority, [
+    "keyEpoch", "keyId", "providerIdentityHash", "publicKeySpkiSha256",
+  ], "image upload signing authority");
+
+  if (
+    uploadOwner.provider !== "privy-github"
+    || image.mediaType !== "image/webp"
+    || image.width !== 1000
+    || image.height !== 1000
+    || typeof image.byteLength !== "number"
+    || !Number.isSafeInteger(image.byteLength)
+    || image.byteLength < 1
+    || image.byteLength > 1_000_000
+  ) throw new TypeError("image upload receipt metadata is invalid");
+  const applicationId = safeString(launchScope.applicationId, "application id", 80);
+  const applicationHandle = safeString(
+    launchScope.applicationHandle,
+    "application handle",
+    80,
+  );
+  const grantId = safeString(launchScope.grantId, "grant id", 36);
+  const githubUserId = safeString(uploadOwner.githubUserId, "GitHub user id", 20);
+  const blobUrl = safeString(blob.url, "blob URL", 1_024);
+  const blobPathname = safeString(blob.pathname, "blob pathname", 512);
+  if (
+    !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(applicationId)
+    || !/^github-[0-9a-f]{64}$/u.test(applicationHandle)
+    || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u
+      .test(grantId)
+    || !/^[1-9][0-9]{0,19}$/u.test(githubUserId)
+    || blob.storeId !== PROGRAMMABLE_TOKEN_IMAGE_STORE_ID
+    || blob.host !== PROGRAMMABLE_TOKEN_IMAGE_HOST
+    || !isExactTokenImageBlob(blobUrl, blobPathname)
+  ) throw new TypeError("image upload receipt authority is invalid");
+  const issuedAt = timestamp(payload.issuedAt, "image receipt issue time");
+  const expiresAt = timestamp(payload.expiresAt, "image receipt expiry time");
+  if (
+    Date.parse(expiresAt) <= Date.parse(issuedAt)
+    || Date.parse(expiresAt) - Date.parse(issuedAt)
+      > TOKEN_IMAGE_UPLOAD_RECEIPT_MAX_AGE_MS_V1
+  ) throw new TypeError("image upload receipt time window is invalid");
+  return Object.freeze({
+    schemaVersion: payload.schemaVersion,
+    audience: payload.audience,
+    launchScope: Object.freeze({
+      applicationId,
+      applicationHandle: applicationHandle as ApplicationHandleV3,
+      grantId,
+      grantBindingHash: digest(launchScope.grantBindingHash, "grant binding hash"),
+    }),
+    uploadOwner: Object.freeze({
+      provider: uploadOwner.provider,
+      privyUserId: safeString(uploadOwner.privyUserId, "Privy user id", 512),
+      githubUserId,
+      githubPrincipalHash: digest(
+        uploadOwner.githubPrincipalHash,
+        "GitHub principal hash",
+      ),
+    }),
+    blob: Object.freeze({
+      storeId: PROGRAMMABLE_TOKEN_IMAGE_STORE_ID,
+      host: PROGRAMMABLE_TOKEN_IMAGE_HOST,
+      pathname: blobPathname,
+      url: blobUrl,
+      etag: safeString(blob.etag, "blob etag", 256),
+    }),
+    image: Object.freeze({
+      contentSha256: digest(image.contentSha256, "image content hash"),
+      mediaType: "image/webp",
+      byteLength: image.byteLength,
+      width: image.width,
+      height: image.height,
+    }),
+    signingAuthority: Object.freeze({
+      providerIdentityHash: digest(
+        authority.providerIdentityHash,
+        "image signer provider identity hash",
+      ),
+      keyId: safeString(authority.keyId, "image signer key id", 128),
+      keyEpoch: safeString(authority.keyEpoch, "image signer key epoch", 128),
+      publicKeySpkiSha256: digest(
+        authority.publicKeySpkiSha256,
+        "image signer public key hash",
+      ),
+    }),
+    issuedAt,
+    expiresAt,
+  });
+}
+
+function parseProviderReceipt(value: unknown): TokenImageRemoteSigningProviderReceiptV2 {
+  const receipt = record(value, "remote image signer receipt");
+  exactKeys(receipt, [
+    "algorithm", "audience", "expiresAt", "idempotencyKey", "keyEpoch",
+    "keyId", "messageSha256", "observedAt", "outcome", "providerIdentityHash",
+    "requestDigest", "schemaVersion", "signature",
+  ], "remote image signer receipt");
+  if (
+    receipt.schemaVersion !== "programmable.remote-signing-provider-receipt.v2"
+    || receipt.outcome !== "completed"
+    || receipt.audience !== TOKEN_IMAGE_UPLOAD_RECEIPT_AUDIENCE_V1
+    || receipt.algorithm !== "Ed25519"
+  ) throw new TypeError("remote image signer receipt schema is invalid");
+  const observedAt = timestamp(receipt.observedAt, "remote image signer observed time");
+  const expiresAt = timestamp(receipt.expiresAt, "remote image signer expiry time");
+  if (
+    Date.parse(expiresAt) <= Date.parse(observedAt)
+    || Date.parse(expiresAt) - Date.parse(observedAt)
+      > TOKEN_IMAGE_UPLOAD_RECEIPT_MAX_AGE_MS_V1
+  ) throw new TypeError("remote image signer receipt time window is invalid");
+  return Object.freeze({
+    schemaVersion: receipt.schemaVersion,
+    outcome: receipt.outcome,
+    audience: receipt.audience,
+    keyId: safeString(receipt.keyId, "remote image signer key id", 128),
+    keyEpoch: safeString(receipt.keyEpoch, "remote image signer key epoch", 128),
+    algorithm: receipt.algorithm,
+    providerIdentityHash: digest(
+      receipt.providerIdentityHash,
+      "remote image signer provider hash",
+    ),
+    idempotencyKey: digest(receipt.idempotencyKey, "remote image signer idempotency key"),
+    messageSha256: digest(receipt.messageSha256, "remote image signer message hash"),
+    requestDigest: digest(receipt.requestDigest, "remote image signer request hash"),
+    signature: signature(receipt.signature, "remote image signer signature"),
+    observedAt,
+    expiresAt,
+  });
+}
+
+function record(value: unknown, label: string): Readonly<Record<string, unknown>> {
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function exactKeys(
+  value: Readonly<Record<string, unknown>>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new TypeError(`${label} has unknown or missing fields`);
+  }
+}
+
+function digest(value: unknown, label: string): Sha256DigestV2 {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Sha256DigestV2;
+}
+
+function signature(value: unknown, label: string): string {
+  if (
+    typeof value !== "string"
+    || !/^[A-Za-z0-9_-]{86}$/u.test(value)
+  ) throw new TypeError(`${label} is invalid`);
+  return value;
+}
+
+function timestamp(value: unknown, label: string): string {
+  if (
+    typeof value !== "string"
+    || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || new Date(value).toISOString() !== value
+  ) throw new TypeError(`${label} is invalid`);
+  return value;
+}
+
+function safeString(value: unknown, label: string, maximumBytes: number): string {
+  if (
+    typeof value !== "string"
+    || value.length < 1
+    || new TextEncoder().encode(value).byteLength > maximumBytes
+    || value.normalize("NFC") !== value
+    || /[\u0000-\u001f\u007f]/u.test(value)
+  ) throw new TypeError(`${label} is invalid`);
+  return value;
+}
+
+function isExactTokenImageBlob(url: string, pathname: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return getProgrammableTokenImageAssetName(url) !== ""
+      && parsed.pathname.slice(1) === pathname;
+  } catch {
+    return false;
+  }
+}

--- a/lib/server/custom-launch/public-readiness.ts
+++ b/lib/server/custom-launch/public-readiness.ts
@@ -4,6 +4,9 @@ import { createHash } from "node:crypto";
 
 import type { TrustedLaunchPermitSignerV2 } from "@/lib/custom-launch/contract-v2";
 import { isReviewAuthorityModeV1 } from "@/lib/custom-launch/review-authority-v1";
+import {
+  isProductionTokenImageUploadReceiptSignerConfiguredV1,
+} from "@/lib/server/token-image-upload-receipt-v1";
 
 const SIGNER_KEYS = [
   "keyId",
@@ -25,7 +28,12 @@ export function isCustomLaunchPublicEnabled(
     return false;
   }
   const origin = environment.PROGRAMMABLE_APPROVAL_SERVICE_V2_ORIGIN?.trim();
-  if (!origin || !environment.NEXT_PUBLIC_PRIVY_APP_ID?.trim() || !environment.PRIVY_APP_SECRET?.trim()) {
+  if (
+    !origin
+    || !environment.NEXT_PUBLIC_PRIVY_APP_ID?.trim()
+    || !environment.PRIVY_APP_SECRET?.trim()
+    || !environment.TOKEN_IMAGE_BLOB_READ_WRITE_TOKEN?.trim()
+  ) {
     return false;
   }
   if (
@@ -35,6 +43,9 @@ export function isCustomLaunchPublicEnabled(
     )
   ) return false;
   if (configuredLaunchPermitSignersV2(environment).length === 0) return false;
+  if (!isProductionTokenImageUploadReceiptSignerConfiguredV1(environment)) {
+    return false;
+  }
   try {
     const url = new URL(origin);
     return url.protocol === "https:"

--- a/lib/server/token-image-upload-receipt-v1.ts
+++ b/lib/server/token-image-upload-receipt-v1.ts
@@ -1,0 +1,739 @@
+import "server-only";
+
+import {
+  createHash,
+  createPublicKey,
+  verify as verifySignature,
+  type KeyObject,
+} from "node:crypto";
+import { getVercelOidcToken } from "@vercel/oidc";
+
+import {
+  TOKEN_IMAGE_UPLOAD_RECEIPT_AUDIENCE_V1,
+  TOKEN_IMAGE_UPLOAD_RECEIPT_MAX_AGE_MS_V1,
+  parseSignedTokenImageUploadReceiptV1,
+  tokenImageUploadReceiptMatchesV1,
+  type SignedTokenImageUploadReceiptV1,
+  type TokenImageRemoteSigningProviderReceiptV2,
+  type TokenImageUploadReceiptLaunchScopeV1,
+  type TokenImageUploadReceiptOwnerV1,
+  type TokenImageUploadReceiptPayloadV1,
+} from "@/lib/custom-launch/token-image-upload-receipt-v1";
+import type { Sha256DigestV2 } from "@/lib/custom-launch/contract-v2";
+import {
+  canonicalizeJson,
+  parseStrictJson,
+} from "@/lib/server/projection-target/canonical-json";
+import { canonicalSha256 } from "@/lib/server/projection-target/hashing";
+import {
+  getProgrammableTokenImageAssetName,
+  PROGRAMMABLE_TOKEN_IMAGE_HOST,
+  PROGRAMMABLE_TOKEN_IMAGE_STORE_ID,
+} from "@/lib/token-image";
+
+const SIGNER_CONFIGURATION_ENV =
+  "PROGRAMMABLE_TOKEN_IMAGE_UPLOAD_RECEIPT_SIGNER_V1_JSON";
+const MAXIMUM_SIGNER_CONFIGURATION_BYTES = 16_384;
+const MAXIMUM_SIGNER_RESPONSE_BYTES = 65_536;
+const MAXIMUM_SIGNER_TIMEOUT_MS = 10_000;
+const DEFAULT_SIGNER_TIMEOUT_MS = 5_000;
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,127}$/u;
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+const moduleFetch = globalThis.fetch.bind(globalThis);
+
+export type TokenImageUploadReceiptSignerBindingV1 = Readonly<{
+  schemaVersion: "programmable.token-image-upload-receipt-signer-binding.v1";
+  endpoint: string;
+  audience: typeof TOKEN_IMAGE_UPLOAD_RECEIPT_AUDIENCE_V1;
+  keyId: string;
+  keyEpoch: string;
+  publicKeyBase64Url: string;
+  publicKeySpkiSha256: Sha256DigestV2;
+  providerIdentityHash: Sha256DigestV2;
+  credentialMode: "vercel-oidc-bearer";
+}>;
+
+export type TokenImageUploadReceiptSigningInputV1 = Readonly<{
+  launchScope: TokenImageUploadReceiptLaunchScopeV1;
+  uploadOwner: TokenImageUploadReceiptOwnerV1;
+  blob: TokenImageUploadReceiptPayloadV1["blob"];
+  image: TokenImageUploadReceiptPayloadV1["image"];
+  signal?: AbortSignal;
+}>;
+
+export interface TokenImageUploadReceiptSignerV1 {
+  readonly binding: TokenImageUploadReceiptSignerBindingV1;
+  sign(input: TokenImageUploadReceiptSigningInputV1):
+    Promise<SignedTokenImageUploadReceiptV1>;
+}
+
+export type PresentationTokenImageV1 = Readonly<{
+  uri: string;
+  contentSha256: Sha256DigestV2;
+  mediaType: "image/webp";
+  byteLength: number;
+  width: number;
+  height: number;
+}>;
+
+export function authorizeTokenImagePresentationMutationV1(input: Readonly<{
+  currentImage: PresentationTokenImageV1 | null;
+  requestedImage: PresentationTokenImageV1 | null;
+  receipt: unknown;
+  trustedSigner: TokenImageUploadReceiptSignerBindingV1;
+  expectedLaunchScope: TokenImageUploadReceiptLaunchScopeV1;
+  expectedPrincipal: Readonly<{
+    privyUserId?: string;
+    githubUserId: string;
+    githubPrincipalHash: Sha256DigestV2;
+  }>;
+  now: Date;
+}>): "created-or-changed" | "removed" | "unchanged" {
+  if (samePresentationImage(input.currentImage, input.requestedImage)) {
+    // A previously verified immutable digest remains the durable authority.
+    // Its short-lived upload receipt is intentionally not revalidated.
+    return "unchanged";
+  }
+  if (input.requestedImage === null) return "removed";
+  if (input.receipt === null || input.receipt === undefined) {
+    throw new TypeError("image upload receipt is required for a new image revision");
+  }
+  verifyTokenImageUploadReceiptForPresentationV1({
+    receipt: input.receipt,
+    trustedSigner: input.trustedSigner,
+    expectedLaunchScope: input.expectedLaunchScope,
+    expectedPrincipal: input.expectedPrincipal,
+    expectedImage: input.requestedImage,
+    now: input.now,
+  });
+  return "created-or-changed";
+}
+
+export function verifyTokenImageUploadReceiptForPresentationV1(input: Readonly<{
+  receipt: unknown;
+  trustedSigner: TokenImageUploadReceiptSignerBindingV1;
+  expectedLaunchScope: TokenImageUploadReceiptLaunchScopeV1;
+  expectedPrincipal: Readonly<{
+    privyUserId?: string;
+    githubUserId: string;
+    githubPrincipalHash: Sha256DigestV2;
+  }>;
+  expectedImage: Readonly<{
+    uri: string;
+    contentSha256: Sha256DigestV2;
+    mediaType: "image/webp";
+    byteLength: number;
+    width: number;
+    height: number;
+  }>;
+  now: Date;
+}>): TokenImageUploadReceiptPayloadV1 {
+  const trusted = parseTokenImageUploadReceiptSignerBindingV1(input.trustedSigner);
+  const receipt = parseSignedTokenImageUploadReceiptV1(input.receipt);
+  const payload = receipt.payload;
+  if (
+    payload.signingAuthority.providerIdentityHash !== trusted.providerIdentityHash
+    || payload.signingAuthority.keyId !== trusted.keyId
+    || payload.signingAuthority.keyEpoch !== trusted.keyEpoch
+    || payload.signingAuthority.publicKeySpkiSha256 !== trusted.publicKeySpkiSha256
+  ) throw new TypeError("image upload receipt uses an untrusted signer");
+  if (
+    payload.uploadOwner.githubUserId !== input.expectedPrincipal.githubUserId
+    || payload.uploadOwner.githubPrincipalHash
+      !== input.expectedPrincipal.githubPrincipalHash
+    || (
+      input.expectedPrincipal.privyUserId !== undefined
+      && payload.uploadOwner.privyUserId !== input.expectedPrincipal.privyUserId
+    )
+  ) throw new TypeError("image upload receipt belongs to another principal");
+  if (!tokenImageUploadReceiptMatchesV1(receipt, {
+    launchScope: input.expectedLaunchScope,
+    uri: input.expectedImage.uri,
+    contentSha256: input.expectedImage.contentSha256,
+    byteLength: input.expectedImage.byteLength,
+    width: input.expectedImage.width,
+    height: input.expectedImage.height,
+  }) || input.expectedImage.mediaType !== "image/webp") {
+    throw new TypeError("image upload receipt does not match the presentation");
+  }
+  if (
+    payload.blob.storeId !== PROGRAMMABLE_TOKEN_IMAGE_STORE_ID
+    || payload.blob.host !== PROGRAMMABLE_TOKEN_IMAGE_HOST
+    || payload.blob.url !== input.expectedImage.uri
+    || payload.blob.pathname !== new URL(payload.blob.url).pathname.slice(1)
+    || getProgrammableTokenImageAssetName(payload.blob.url) === ""
+  ) throw new TypeError("image upload receipt Blob authority is invalid");
+
+  const nowMs = input.now.getTime();
+  const issuedMs = Date.parse(payload.issuedAt);
+  const expiresMs = Date.parse(payload.expiresAt);
+  const observedMs = Date.parse(receipt.providerReceipt.observedAt);
+  const providerExpiresMs = Date.parse(receipt.providerReceipt.expiresAt);
+  if (
+    !Number.isFinite(nowMs)
+    || issuedMs > nowMs
+    || nowMs >= expiresMs
+    || expiresMs - issuedMs > TOKEN_IMAGE_UPLOAD_RECEIPT_MAX_AGE_MS_V1
+    || observedMs < issuedMs
+    || observedMs > nowMs
+    || nowMs >= providerExpiresMs
+    || providerExpiresMs - observedMs > TOKEN_IMAGE_UPLOAD_RECEIPT_MAX_AGE_MS_V1
+  ) throw new TypeError("image upload receipt is expired or not yet valid");
+
+  const payloadBytes = Buffer.from(canonicalizeJson(payload), "utf8");
+  const signature = decodeSignature(receipt.signature);
+  const providerReceiptBytes = Buffer.from(
+    canonicalizeJson(receipt.providerReceipt),
+    "utf8",
+  );
+  const providerReceiptSignature = decodeSignature(
+    receipt.providerReceiptSignature,
+  );
+  const expectedIdempotencyKey = canonicalSha256(
+    "programmable.token-image-upload-receipt-signing-idempotency.v1",
+    Object.freeze({
+      schemaVersion:
+        "programmable.token-image-upload-receipt-signing-idempotency.v1" as const,
+      payloadSha256: receipt.payloadSha256,
+      blobEtag: payload.blob.etag,
+      githubPrincipalHash: payload.uploadOwner.githubPrincipalHash,
+      applicationId: payload.launchScope.applicationId,
+      grantId: payload.launchScope.grantId,
+    }),
+  );
+  const expectedRequestDigest = canonicalSha256(
+    "programmable.remote-signing-request.v2",
+    Object.freeze({
+      schemaVersion: "programmable.remote-signing-request.v2" as const,
+      audience: trusted.audience,
+      keyId: trusted.keyId,
+      keyEpoch: trusted.keyEpoch,
+      algorithm: "Ed25519" as const,
+      providerIdentityHash: trusted.providerIdentityHash,
+      idempotencyKey: expectedIdempotencyKey,
+      messageEncoding: "base64url" as const,
+      message: payloadBytes.toString("base64url"),
+      messageSha256: receipt.payloadSha256,
+    }),
+  );
+  if (
+    rawDigest(payloadBytes) !== receipt.payloadSha256
+    || rawDigest(signature) !== receipt.signatureSha256
+    || rawDigest(providerReceiptBytes) !== receipt.providerReceiptSha256
+    || rawDigest(providerReceiptSignature)
+      !== receipt.providerReceiptSignatureSha256
+    || receipt.providerReceipt.idempotencyKey !== expectedIdempotencyKey
+    || receipt.providerReceipt.requestDigest !== expectedRequestDigest
+  ) throw new TypeError("image upload receipt byte integrity is invalid");
+  const publicKey = publicKeyForBinding(trusted);
+  if (
+    !verifySignature(null, payloadBytes, publicKey, signature)
+    || !verifySignature(
+      null,
+      providerReceiptBytes,
+      publicKey,
+      providerReceiptSignature,
+    )
+  ) throw new TypeError("image upload receipt signature is invalid");
+  return payload;
+}
+
+export function productionTokenImageUploadReceiptSignerBindingV1(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): TokenImageUploadReceiptSignerBindingV1 {
+  const source = environment[SIGNER_CONFIGURATION_ENV]?.trim();
+  if (!source) throw new TypeError("token image receipt signer is not configured");
+  if (Buffer.byteLength(source, "utf8") > MAXIMUM_SIGNER_CONFIGURATION_BYTES) {
+    throw new TypeError("token image receipt signer configuration is too large");
+  }
+  return parseTokenImageUploadReceiptSignerBindingV1(
+    parseStrictJson(source, {
+      maximumBytes: MAXIMUM_SIGNER_CONFIGURATION_BYTES,
+      maximumDepth: 4,
+    }),
+  );
+}
+
+export function isProductionTokenImageUploadReceiptSignerConfiguredV1(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  try {
+    productionTokenImageUploadReceiptSignerBindingV1(environment);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function createProductionTokenImageUploadReceiptSignerV1(
+  options: Readonly<{
+    credentialProvider?: () => Promise<string>;
+    fetch?: typeof fetch;
+    now?: () => Date;
+  }> = {},
+): Promise<TokenImageUploadReceiptSignerV1> {
+  // The credential comes from Vercel's request-context/env authority, never
+  // from the user-controlled Request headers passed to the upload handler.
+  const credential = (await (options.credentialProvider ?? getVercelOidcToken)()).trim();
+  if (
+    credential.length < 20
+    || credential.length > 131_072
+    || !/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/u.test(credential)
+  ) throw new TypeError("Vercel workload identity is unavailable");
+  return createRemoteTokenImageUploadReceiptSignerV1({
+    binding: productionTokenImageUploadReceiptSignerBindingV1(),
+    credential,
+    fetch: options.fetch ?? moduleFetch,
+    ...(options.now === undefined ? {} : { now: options.now }),
+  });
+}
+
+export function createRemoteTokenImageUploadReceiptSignerV1(input: Readonly<{
+  binding: TokenImageUploadReceiptSignerBindingV1;
+  credential: string;
+  fetch: typeof fetch;
+  now?: () => Date;
+  timeoutMs?: number;
+}>): TokenImageUploadReceiptSignerV1 {
+  const binding = parseTokenImageUploadReceiptSignerBindingV1(input.binding);
+  if (
+    typeof input.credential !== "string"
+    || input.credential.length < 20
+    || input.credential.length > 131_072
+    || /[\s\u0000]/u.test(input.credential)
+  ) throw new TypeError("image receipt signer credential is invalid");
+  if (typeof input.fetch !== "function") {
+    throw new TypeError("image receipt signer transport is invalid");
+  }
+  const timeoutMs = input.timeoutMs ?? DEFAULT_SIGNER_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(timeoutMs)
+    || timeoutMs < 500
+    || timeoutMs > MAXIMUM_SIGNER_TIMEOUT_MS
+  ) throw new TypeError("image receipt signer timeout is invalid");
+  const now = input.now ?? (() => new Date());
+  const publicKey = publicKeyForBinding(binding);
+
+  return Object.freeze({
+    binding,
+    async sign(
+      signingInput: TokenImageUploadReceiptSigningInputV1,
+    ): Promise<SignedTokenImageUploadReceiptV1> {
+      signingInput.signal?.throwIfAborted();
+      const issued = now();
+      const issuedMs = issued.getTime();
+      if (!Number.isFinite(issuedMs)) throw new TypeError("image receipt clock is invalid");
+      const issuedAt = issued.toISOString();
+      const expiresAt = new Date(
+        issuedMs + TOKEN_IMAGE_UPLOAD_RECEIPT_MAX_AGE_MS_V1,
+      ).toISOString();
+      const payload = Object.freeze({
+        schemaVersion: "programmable.token-image-upload-receipt.v1" as const,
+        audience: binding.audience,
+        launchScope: Object.freeze({ ...signingInput.launchScope }),
+        uploadOwner: Object.freeze({ ...signingInput.uploadOwner }),
+        blob: Object.freeze({ ...signingInput.blob }),
+        image: Object.freeze({ ...signingInput.image }),
+        signingAuthority: Object.freeze({
+          providerIdentityHash: binding.providerIdentityHash,
+          keyId: binding.keyId,
+          keyEpoch: binding.keyEpoch,
+          publicKeySpkiSha256: binding.publicKeySpkiSha256,
+        }),
+        issuedAt,
+        expiresAt,
+      }) satisfies TokenImageUploadReceiptPayloadV1;
+      const message = Buffer.from(canonicalizeJson(payload), "utf8");
+      const payloadSha256 = rawDigest(message);
+      const idempotencyKey = canonicalSha256(
+        "programmable.token-image-upload-receipt-signing-idempotency.v1",
+        Object.freeze({
+          schemaVersion:
+            "programmable.token-image-upload-receipt-signing-idempotency.v1" as const,
+          payloadSha256,
+          blobEtag: payload.blob.etag,
+          githubPrincipalHash: payload.uploadOwner.githubPrincipalHash,
+          applicationId: payload.launchScope.applicationId,
+          grantId: payload.launchScope.grantId,
+        }),
+      ) as Sha256DigestV2;
+      const unsignedRequest = Object.freeze({
+        schemaVersion: "programmable.remote-signing-request.v2" as const,
+        audience: binding.audience,
+        keyId: binding.keyId,
+        keyEpoch: binding.keyEpoch,
+        algorithm: "Ed25519" as const,
+        providerIdentityHash: binding.providerIdentityHash,
+        idempotencyKey,
+        messageEncoding: "base64url" as const,
+        message: message.toString("base64url"),
+        messageSha256: payloadSha256,
+      });
+      const requestDigest = canonicalSha256(
+        "programmable.remote-signing-request.v2",
+        unsignedRequest,
+      ) as Sha256DigestV2;
+      const controller = new AbortController();
+      const timeout = setTimeout(
+        () => controller.abort(new Error("image receipt signer deadline exceeded")),
+        timeoutMs,
+      );
+      const signal = signingInput.signal === undefined
+        ? controller.signal
+        : AbortSignal.any([controller.signal, signingInput.signal]);
+      let response: Response;
+      try {
+        response = await input.fetch(new URL(binding.endpoint), {
+          method: "POST",
+          redirect: "error",
+          cache: "no-store",
+          credentials: "omit",
+          signal,
+          headers: {
+            accept: "application/json",
+            authorization: `Bearer ${input.credential}`,
+            "content-type": "application/json",
+            "idempotency-key": idempotencyKey,
+            "x-programmable-operation": "sign-v2",
+            "x-programmable-request-digest": requestDigest,
+          },
+          body: canonicalizeJson({ ...unsignedRequest, requestDigest }),
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
+      if (response.redirected || response.status !== 200) {
+        throw new TypeError("image receipt signer rejected the request");
+      }
+      const contentType = response.headers.get("content-type")
+        ?.split(";", 1)[0]?.trim().toLowerCase();
+      if (contentType !== "application/json") {
+        throw new TypeError("image receipt signer response is invalid");
+      }
+      const responseBytes = await readBoundedResponse(
+        response,
+        MAXIMUM_SIGNER_RESPONSE_BYTES,
+      );
+      const authenticated = parseAuthenticatedSignerResponse(responseBytes);
+      const providerReceipt = authenticated.providerReceipt;
+      if (
+        providerReceipt.outcome !== "completed"
+        || providerReceipt.audience !== binding.audience
+        || providerReceipt.keyId !== binding.keyId
+        || providerReceipt.keyEpoch !== binding.keyEpoch
+        || providerReceipt.providerIdentityHash !== binding.providerIdentityHash
+        || providerReceipt.idempotencyKey !== idempotencyKey
+        || providerReceipt.messageSha256 !== payloadSha256
+        || providerReceipt.requestDigest !== requestDigest
+      ) throw new TypeError("image receipt signer response binding is invalid");
+      validateProviderWindow(providerReceipt, now());
+      const providerReceiptBytes = Buffer.from(
+        canonicalizeJson(providerReceipt),
+        "utf8",
+      );
+      const providerReceiptSha256 = rawDigest(providerReceiptBytes);
+      if (authenticated.providerReceiptDigest !== providerReceiptSha256) {
+        throw new TypeError("image receipt signer evidence hash is invalid");
+      }
+      const signature = decodeSignature(providerReceipt.signature);
+      const providerReceiptSignature = decodeSignature(
+        authenticated.providerReceiptSignature,
+      );
+      if (
+        !verifySignature(null, message, publicKey, signature)
+        || !verifySignature(
+          null,
+          providerReceiptBytes,
+          publicKey,
+          providerReceiptSignature,
+        )
+      ) throw new TypeError("image receipt signer signature is invalid");
+      return Object.freeze({
+        schemaVersion: "programmable.signed-token-image-upload-receipt.v1" as const,
+        payload,
+        payloadSha256,
+        signature: providerReceipt.signature,
+        signatureSha256: rawDigest(signature),
+        providerReceipt,
+        providerReceiptSha256,
+        providerReceiptSignature: authenticated.providerReceiptSignature,
+        providerReceiptSignatureSha256: rawDigest(providerReceiptSignature),
+      });
+    },
+  });
+}
+
+export function parseTokenImageUploadReceiptSignerBindingV1(
+  value: unknown,
+): TokenImageUploadReceiptSignerBindingV1 {
+  const parsed = record(value, "image receipt signer binding");
+  exactKeys(parsed, [
+    "audience", "credentialMode", "endpoint", "keyEpoch", "keyId",
+    "providerIdentityHash", "publicKeyBase64Url", "publicKeySpkiSha256",
+    "schemaVersion",
+  ], "image receipt signer binding");
+  if (
+    parsed.schemaVersion !== "programmable.token-image-upload-receipt-signer-binding.v1"
+    || parsed.audience !== TOKEN_IMAGE_UPLOAD_RECEIPT_AUDIENCE_V1
+    || parsed.credentialMode !== "vercel-oidc-bearer"
+  ) throw new TypeError("image receipt signer binding schema is invalid");
+  const endpoint = validateEndpoint(parsed.endpoint);
+  const keyId = safeId(parsed.keyId, "image receipt signer key id");
+  const keyEpoch = safeId(parsed.keyEpoch, "image receipt signer key epoch");
+  const publicKeyBase64Url = rawPublicKey(parsed.publicKeyBase64Url);
+  const spki = Buffer.concat([
+    ED25519_SPKI_PREFIX,
+    Buffer.from(publicKeyBase64Url, "base64url"),
+  ]);
+  const publicKeySpkiSha256 = digest(
+    parsed.publicKeySpkiSha256,
+    "image receipt signer public key hash",
+  );
+  if (rawDigest(spki) !== publicKeySpkiSha256) {
+    throw new TypeError("image receipt signer public key binding is invalid");
+  }
+  const computedProviderIdentity = canonicalSha256(
+    "programmable.remote-ed25519-provider-identity.v2",
+    Object.freeze({
+      schemaVersion: "programmable.remote-ed25519-provider-identity.v2" as const,
+      endpoint,
+      audience: parsed.audience,
+      keyId,
+      keyEpoch,
+      publicKeySpkiSha256,
+    }),
+  ) as Sha256DigestV2;
+  if (
+    digest(parsed.providerIdentityHash, "image receipt signer provider identity")
+      !== computedProviderIdentity
+  ) throw new TypeError("image receipt signer provider identity is invalid");
+  return Object.freeze({
+    schemaVersion: parsed.schemaVersion,
+    endpoint,
+    audience: parsed.audience,
+    keyId,
+    keyEpoch,
+    publicKeyBase64Url,
+    publicKeySpkiSha256,
+    providerIdentityHash: computedProviderIdentity,
+    credentialMode: parsed.credentialMode,
+  });
+}
+
+function parseAuthenticatedSignerResponse(bytes: Uint8Array): Readonly<{
+  providerReceipt: TokenImageRemoteSigningProviderReceiptV2;
+  providerReceiptDigest: Sha256DigestV2;
+  providerReceiptSignature: string;
+}> {
+  const parsed = record(parseStrictJson(Buffer.from(bytes).toString("utf8"), {
+    maximumBytes: MAXIMUM_SIGNER_RESPONSE_BYTES,
+    maximumDepth: 8,
+  }), "image receipt signer response");
+  exactKeys(parsed, [
+    "providerReceipt", "providerReceiptDigest", "providerReceiptSignature",
+    "schemaVersion",
+  ], "image receipt signer response");
+  if (parsed.schemaVersion !== "programmable.remote-signing-authenticated-response.v2") {
+    throw new TypeError("image receipt signer response schema is invalid");
+  }
+  const receipt = record(parsed.providerReceipt, "image signer provider receipt");
+  exactKeys(receipt, [
+    "algorithm", "audience", "expiresAt", "idempotencyKey", "keyEpoch",
+    "keyId", "messageSha256", "observedAt", "outcome", "providerIdentityHash",
+    "requestDigest", "schemaVersion", "signature",
+  ], "image signer provider receipt");
+  if (
+    receipt.schemaVersion !== "programmable.remote-signing-provider-receipt.v2"
+    || receipt.outcome !== "completed"
+    || receipt.audience !== TOKEN_IMAGE_UPLOAD_RECEIPT_AUDIENCE_V1
+    || receipt.algorithm !== "Ed25519"
+  ) throw new TypeError("image signer provider receipt is invalid");
+  return Object.freeze({
+    providerReceipt: Object.freeze({
+      schemaVersion: receipt.schemaVersion,
+      outcome: receipt.outcome,
+      audience: receipt.audience,
+      keyId: safeId(receipt.keyId, "image signer receipt key id"),
+      keyEpoch: safeId(receipt.keyEpoch, "image signer receipt key epoch"),
+      algorithm: receipt.algorithm,
+      providerIdentityHash: digest(
+        receipt.providerIdentityHash,
+        "image signer receipt provider identity",
+      ),
+      idempotencyKey: digest(receipt.idempotencyKey, "image signer idempotency key"),
+      messageSha256: digest(receipt.messageSha256, "image signer message hash"),
+      requestDigest: digest(receipt.requestDigest, "image signer request hash"),
+      signature: canonicalSignature(receipt.signature, "image signer signature"),
+      observedAt: canonicalTimestamp(receipt.observedAt, "image signer observed time"),
+      expiresAt: canonicalTimestamp(receipt.expiresAt, "image signer expiry time"),
+    }),
+    providerReceiptDigest: digest(
+      parsed.providerReceiptDigest,
+      "image signer provider receipt hash",
+    ),
+    providerReceiptSignature: canonicalSignature(
+      parsed.providerReceiptSignature,
+      "image signer provider receipt signature",
+    ),
+  });
+}
+
+async function readBoundedResponse(response: Response, maximumBytes: number): Promise<Uint8Array> {
+  const declared = Number(response.headers.get("content-length") ?? "0");
+  if (Number.isFinite(declared) && declared > maximumBytes) {
+    throw new TypeError("image receipt signer response is too large");
+  }
+  if (response.body === null) throw new TypeError("image receipt signer response is empty");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maximumBytes) throw new TypeError("image receipt signer response is too large");
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+function validateProviderWindow(
+  receipt: TokenImageRemoteSigningProviderReceiptV2,
+  now: Date,
+): void {
+  const observed = Date.parse(receipt.observedAt);
+  const expires = Date.parse(receipt.expiresAt);
+  const nowMs = now.getTime();
+  if (
+    !Number.isFinite(nowMs)
+    || observed > nowMs
+    || nowMs >= expires
+    || expires - observed > TOKEN_IMAGE_UPLOAD_RECEIPT_MAX_AGE_MS_V1
+  ) throw new TypeError("image signer provider receipt window is invalid");
+}
+
+function publicKeyForBinding(binding: TokenImageUploadReceiptSignerBindingV1): KeyObject {
+  const spki = Buffer.concat([
+    ED25519_SPKI_PREFIX,
+    Buffer.from(binding.publicKeyBase64Url, "base64url"),
+  ]);
+  const key = createPublicKey({ key: spki, format: "der", type: "spki" });
+  if (key.asymmetricKeyType !== "ed25519") {
+    throw new TypeError("image receipt signer public key is not Ed25519");
+  }
+  return key;
+}
+
+function validateEndpoint(value: unknown): string {
+  if (typeof value !== "string" || value.length > 2_048) {
+    throw new TypeError("image receipt signer endpoint is invalid");
+  }
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:"
+    || url.username !== ""
+    || url.password !== ""
+    || url.port !== ""
+    || url.search !== ""
+    || url.hash !== ""
+    || url.pathname === "/"
+  ) throw new TypeError("image receipt signer endpoint is invalid");
+  return url.toString();
+}
+
+function rawPublicKey(value: unknown): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]{43}$/u.test(value)) {
+    throw new TypeError("image receipt signer public key is invalid");
+  }
+  const bytes = Buffer.from(value, "base64url");
+  if (bytes.byteLength !== 32 || bytes.toString("base64url") !== value) {
+    throw new TypeError("image receipt signer public key is invalid");
+  }
+  return value;
+}
+
+function safeId(value: unknown, label: string): string {
+  if (typeof value !== "string" || !SAFE_ID.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function digest(value: unknown, label: string): Sha256DigestV2 {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Sha256DigestV2;
+}
+
+function canonicalSignature(value: unknown, label: string): string {
+  if (typeof value !== "string") throw new TypeError(`${label} is invalid`);
+  decodeSignature(value);
+  return value;
+}
+
+function decodeSignature(value: string): Buffer {
+  if (!/^[A-Za-z0-9_-]{86}$/u.test(value)) {
+    throw new TypeError("image signer signature is invalid");
+  }
+  const bytes = Buffer.from(value, "base64url");
+  if (bytes.byteLength !== 64 || bytes.toString("base64url") !== value) {
+    throw new TypeError("image signer signature is invalid");
+  }
+  return bytes;
+}
+
+function canonicalTimestamp(value: unknown, label: string): string {
+  if (
+    typeof value !== "string"
+    || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || new Date(value).toISOString() !== value
+  ) throw new TypeError(`${label} is invalid`);
+  return value;
+}
+
+function rawDigest(bytes: Uint8Array): Sha256DigestV2 {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function record(value: unknown, label: string): Readonly<Record<string, unknown>> {
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function exactKeys(
+  value: Readonly<Record<string, unknown>>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new TypeError(`${label} has unknown or missing fields`);
+  }
+}
+
+function samePresentationImage(
+  left: PresentationTokenImageV1 | null,
+  right: PresentationTokenImageV1 | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return left.uri === right.uri
+    && left.contentSha256 === right.contentSha256
+    && left.mediaType === right.mediaType
+    && left.byteLength === right.byteLength
+    && left.width === right.width
+    && left.height === right.height;
+}

--- a/lib/server/token-image-webp-v1.ts
+++ b/lib/server/token-image-webp-v1.ts
@@ -1,0 +1,193 @@
+import "server-only";
+
+import sharp from "sharp";
+
+import {
+  MAX_TOKEN_IMAGE_UPLOAD_BYTES,
+  TOKEN_IMAGE_OUTPUT_SIZE,
+} from "@/lib/token-image";
+
+const WEBP_HEADER_BYTES = 12;
+const WEBP_EXTENDED_HEADER_BYTES = 10;
+const WEBP_LOSSY_HEADER_BYTES = 10;
+const WEBP_LOSSLESS_HEADER_BYTES = 5;
+
+export type VerifiedTokenImageWebpV1 = Readonly<{
+  bytes: Uint8Array;
+  width: typeof TOKEN_IMAGE_OUTPUT_SIZE;
+  height: typeof TOKEN_IMAGE_OUTPUT_SIZE;
+}>;
+
+export class TokenImageWebpVerificationErrorV1 extends TypeError {
+  constructor(message = "token image WebP is invalid") {
+    super(message);
+    this.name = "TokenImageWebpVerificationErrorV1";
+  }
+}
+
+export async function verifyTokenImageWebpV1(
+  source: Blob | Uint8Array,
+): Promise<VerifiedTokenImageWebpV1> {
+  const bytes = source instanceof Uint8Array
+    ? Uint8Array.from(source)
+    : new Uint8Array(await source.arrayBuffer());
+  if (bytes.byteLength < WEBP_HEADER_BYTES || bytes.byteLength > MAX_TOKEN_IMAGE_UPLOAD_BYTES) {
+    throw new TokenImageWebpVerificationErrorV1();
+  }
+
+  const structure = inspectWebpStructure(bytes);
+  if (
+    structure.width !== TOKEN_IMAGE_OUTPUT_SIZE
+    || structure.height !== TOKEN_IMAGE_OUTPUT_SIZE
+  ) throw new TokenImageWebpVerificationErrorV1("token image must be exactly 1000 by 1000 pixels");
+
+  try {
+    const decoded = await sharp(bytes, {
+      animated: false,
+      failOn: "error",
+      limitInputPixels: TOKEN_IMAGE_OUTPUT_SIZE * TOKEN_IMAGE_OUTPUT_SIZE,
+      sequentialRead: true,
+    }).raw().toBuffer({ resolveWithObject: true });
+    if (
+      decoded.info.width !== TOKEN_IMAGE_OUTPUT_SIZE
+      || decoded.info.height !== TOKEN_IMAGE_OUTPUT_SIZE
+      || decoded.info.width !== structure.width
+      || decoded.info.height !== structure.height
+      || (decoded.info.pages ?? 1) > 1
+      || decoded.data.byteLength
+        !== decoded.info.width * decoded.info.height * decoded.info.channels
+    ) throw new TokenImageWebpVerificationErrorV1();
+  } catch (cause) {
+    if (cause instanceof TokenImageWebpVerificationErrorV1) throw cause;
+    throw new TokenImageWebpVerificationErrorV1();
+  }
+
+  return Object.freeze({
+    bytes,
+    width: TOKEN_IMAGE_OUTPUT_SIZE,
+    height: TOKEN_IMAGE_OUTPUT_SIZE,
+  });
+}
+
+export function inspectWebpStructure(bytes: Uint8Array): Readonly<{
+  width: number;
+  height: number;
+}> {
+  if (
+    bytes.byteLength < WEBP_HEADER_BYTES
+    || ascii(bytes, 0, 4) !== "RIFF"
+    || ascii(bytes, 8, 12) !== "WEBP"
+    || uint32(bytes, 4) !== bytes.byteLength - 8
+  ) throw new TokenImageWebpVerificationErrorV1();
+
+  let cursor = WEBP_HEADER_BYTES;
+  let extended: Readonly<{ width: number; height: number }> | null = null;
+  let image: Readonly<{ width: number; height: number }> | null = null;
+  let extendedFlags = 0;
+  const chunks = new Set<string>();
+
+  while (cursor < bytes.byteLength) {
+    if (cursor + 8 > bytes.byteLength) throw new TokenImageWebpVerificationErrorV1();
+    const kind = ascii(bytes, cursor, cursor + 4);
+    const length = uint32(bytes, cursor + 4);
+    const start = cursor + 8;
+    const end = start + length;
+    const paddedEnd = end + (length & 1);
+    if (!/^[A-Z0-9 ]{4}$/u.test(kind) || end < start || paddedEnd > bytes.byteLength) {
+      throw new TokenImageWebpVerificationErrorV1();
+    }
+    if ((length & 1) === 1 && bytes[end] !== 0) {
+      throw new TokenImageWebpVerificationErrorV1();
+    }
+    if (chunks.has(kind) && kind !== "ANMF") {
+      throw new TokenImageWebpVerificationErrorV1();
+    }
+    chunks.add(kind);
+
+    if (kind === "VP8X") {
+      if (cursor !== WEBP_HEADER_BYTES || extended !== null || length !== WEBP_EXTENDED_HEADER_BYTES) {
+        throw new TokenImageWebpVerificationErrorV1();
+      }
+      extendedFlags = bytes[start]!;
+      if (
+        (extendedFlags & 0xc3) !== 0
+        || bytes[start + 1] !== 0
+        || bytes[start + 2] !== 0
+        || bytes[start + 3] !== 0
+      ) throw new TokenImageWebpVerificationErrorV1();
+      extended = Object.freeze({
+        width: 1 + uint24(bytes, start + 4),
+        height: 1 + uint24(bytes, start + 7),
+      });
+    } else if (kind === "VP8 ") {
+      if (image !== null || length < WEBP_LOSSY_HEADER_BYTES) {
+        throw new TokenImageWebpVerificationErrorV1();
+      }
+      const frameTag = bytes[start]! | (bytes[start + 1]! << 8) | (bytes[start + 2]! << 16);
+      if (
+        (frameTag & 1) !== 0
+        || bytes[start + 3] !== 0x9d
+        || bytes[start + 4] !== 0x01
+        || bytes[start + 5] !== 0x2a
+      ) throw new TokenImageWebpVerificationErrorV1();
+      image = Object.freeze({
+        width: uint16(bytes, start + 6) & 0x3fff,
+        height: uint16(bytes, start + 8) & 0x3fff,
+      });
+    } else if (kind === "VP8L") {
+      if (image !== null || length < WEBP_LOSSLESS_HEADER_BYTES || bytes[start] !== 0x2f) {
+        throw new TokenImageWebpVerificationErrorV1();
+      }
+      const bits = uint32(bytes, start + 1);
+      if ((bits >>> 29) !== 0) throw new TokenImageWebpVerificationErrorV1();
+      image = Object.freeze({
+        width: 1 + (bits & 0x3fff),
+        height: 1 + ((bits >>> 14) & 0x3fff),
+      });
+    } else if (!new Set(["ALPH", "ICCP", "EXIF", "XMP "]).has(kind)) {
+      // The browser preparation path emits a still image. Animation and unknown
+      // chunks are rejected so a relabelled or polyglot payload cannot pass.
+      throw new TokenImageWebpVerificationErrorV1();
+    }
+    cursor = paddedEnd;
+  }
+
+  if (cursor !== bytes.byteLength || image === null || image.width < 1 || image.height < 1) {
+    throw new TokenImageWebpVerificationErrorV1();
+  }
+  if (
+    extended !== null
+    && (extended.width !== image.width || extended.height !== image.height)
+  ) throw new TokenImageWebpVerificationErrorV1();
+  if (extended === null && chunks.size !== 1) {
+    throw new TokenImageWebpVerificationErrorV1();
+  }
+  if (
+    ((extendedFlags & 0x20) !== 0) !== chunks.has("ICCP")
+    || ((extendedFlags & 0x08) !== 0) !== chunks.has("EXIF")
+    || ((extendedFlags & 0x04) !== 0) !== chunks.has("XMP ")
+    || (chunks.has("ALPH") && (extendedFlags & 0x10) === 0)
+  ) throw new TokenImageWebpVerificationErrorV1();
+  return extended ?? image;
+}
+
+function ascii(bytes: Uint8Array, start: number, end: number): string {
+  return String.fromCharCode(...bytes.subarray(start, end));
+}
+
+function uint16(bytes: Uint8Array, offset: number): number {
+  return bytes[offset]! | (bytes[offset + 1]! << 8);
+}
+
+function uint24(bytes: Uint8Array, offset: number): number {
+  return bytes[offset]! | (bytes[offset + 1]! << 8) | (bytes[offset + 2]! << 16);
+}
+
+function uint32(bytes: Uint8Array, offset: number): number {
+  return (
+    bytes[offset]!
+    + bytes[offset + 1]! * 0x100
+    + bytes[offset + 2]! * 0x1_0000
+    + bytes[offset + 3]! * 0x100_0000
+  );
+}

--- a/lib/token-image.ts
+++ b/lib/token-image.ts
@@ -3,6 +3,7 @@ export const MAX_TOKEN_IMAGE_SOURCE_BYTES = 8_000_000;
 export const MAX_TOKEN_IMAGE_UPLOAD_BYTES = 1_000_000;
 export const PROGRAMMABLE_TOKEN_IMAGE_HOST =
   "k2uoipt9wchjtz3h.public.blob.vercel-storage.com";
+export const PROGRAMMABLE_TOKEN_IMAGE_STORE_ID = "store_k2uoiPT9WCHJtz3H";
 
 const acceptedTokenImageTypes = new Set([
   "image/jpeg",
@@ -23,6 +24,8 @@ export function isProgrammableTokenImageUrl(source: string) {
       url.port === "" &&
       url.username === "" &&
       url.password === "" &&
+      url.search === "" &&
+      url.hash === "" &&
       url.pathname.startsWith("/token-images/") &&
       url.pathname.endsWith(".webp")
     );
@@ -130,29 +133,4 @@ export async function prepareTokenImage(file: File) {
   } finally {
     URL.revokeObjectURL(objectUrl);
   }
-}
-
-export async function hasValidTokenImageSignature(file: Blob) {
-  const bytes = new Uint8Array(await file.slice(0, 12).arrayBuffer());
-  const isJpeg =
-    bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
-  const isPng =
-    bytes[0] === 0x89 &&
-    bytes[1] === 0x50 &&
-    bytes[2] === 0x4e &&
-    bytes[3] === 0x47 &&
-    bytes[4] === 0x0d &&
-    bytes[5] === 0x0a &&
-    bytes[6] === 0x1a &&
-    bytes[7] === 0x0a;
-  const isWebp =
-    bytes[0] === 0x52 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46 &&
-    bytes[3] === 0x46 &&
-    bytes[8] === 0x57 &&
-    bytes[9] === 0x45 &&
-    bytes[10] === 0x42 &&
-    bytes[11] === 0x50;
-  return isJpeg || isPng || isWebp;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@uniswap/universal-router-sdk": "5.11.1",
         "@uniswap/v4-sdk": "2.3.1",
         "@vercel/blob": "2.6.1",
+        "@vercel/oidc": "3.8.1",
         "lucide-react": "1.26.0",
         "next": "16.2.11",
         "pg": "8.22.0",
@@ -25,6 +26,7 @@
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "server-only": "0.0.1",
+        "sharp": "0.35.3",
         "viem": "2.55.5"
       },
       "devDependencies": {
@@ -2520,7 +2522,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -11115,7 +11116,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -16301,7 +16301,6 @@
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
       "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
@@ -16351,7 +16350,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@uniswap/universal-router-sdk": "5.11.1",
     "@uniswap/v4-sdk": "2.3.1",
     "@vercel/blob": "2.6.1",
+    "@vercel/oidc": "3.8.1",
     "lucide-react": "1.26.0",
     "next": "16.2.11",
     "pg": "8.22.0",
@@ -175,6 +176,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "server-only": "0.0.1",
+    "sharp": "0.35.3",
     "viem": "2.55.5"
   },
   "devDependencies": {

--- a/tests/custom-launch-deployment-readiness.test.ts
+++ b/tests/custom-launch-deployment-readiness.test.ts
@@ -7,6 +7,7 @@ vi.mock("server-only", () => ({}));
 import {
   createCustomLaunchDeploymentReadinessHandlerV1,
 } from "../lib/server/custom-launch/deployment-readiness";
+import { canonicalSha256 } from "../lib/server/projection-target/hashing";
 
 const NOW = new Date("2026-08-05T12:00:00.000Z");
 const PACKAGE_ARTIFACT_HASH = `sha256:${"9".repeat(64)}`;
@@ -21,6 +22,25 @@ const permitSigner = {
     rawPermitPublicKey,
   ])).digest("hex")}`,
 };
+const receiptSignerCore = {
+  schemaVersion: "programmable.remote-ed25519-provider-identity.v2" as const,
+  endpoint: "https://signer.programmable.example/v1/sign",
+  audience: "programmable.launch-presentation-image.v1",
+  keyId: "token-image-receipt",
+  keyEpoch: "1",
+  publicKeySpkiSha256: permitSigner.publicKeySpkiSha256,
+};
+const receiptSigner = {
+  schemaVersion: "programmable.token-image-upload-receipt-signer-binding.v1",
+  endpoint: receiptSignerCore.endpoint,
+  audience: receiptSignerCore.audience,
+  keyId: receiptSignerCore.keyId,
+  keyEpoch: receiptSignerCore.keyEpoch,
+  publicKeyBase64Url: permitSigner.publicKeyBase64Url,
+  publicKeySpkiSha256: receiptSignerCore.publicKeySpkiSha256,
+  providerIdentityHash: canonicalSha256(receiptSignerCore.schemaVersion, receiptSignerCore),
+  credentialMode: "vercel-oidc-bearer",
+};
 const configured = {
   PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED: "true",
   PROGRAMMABLE_APPROVAL_SERVICE_V2_ORIGIN: "https://approval.programmable.example",
@@ -28,7 +48,10 @@ const configured = {
   PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_REVIEW_AUTHORITY_MODE: "manual_review",
   NEXT_PUBLIC_PRIVY_APP_ID: "privy-app",
   PRIVY_APP_SECRET: "privy-secret",
+  TOKEN_IMAGE_BLOB_READ_WRITE_TOKEN: "blob-token",
   PROGRAMMABLE_LAUNCH_PERMIT_SIGNERS_V2_JSON: JSON.stringify([permitSigner]),
+  PROGRAMMABLE_TOKEN_IMAGE_UPLOAD_RECEIPT_SIGNER_V1_JSON:
+    JSON.stringify(receiptSigner),
   PROGRAMMABLE_RELEASE_COMMIT_SHA: "1".repeat(40),
   VERCEL_URL: "programmable-immutable-abc.vercel.app",
 };

--- a/tests/custom-launch-experience-v2.test.ts
+++ b/tests/custom-launch-experience-v2.test.ts
@@ -1513,6 +1513,7 @@ describe("custom launch browser authority", () => {
       preservedLinks: [],
       image: null,
       imagePreview: "",
+      imageUploadReceipt: null,
     } as const;
 
     expect(buildPresentationDraftFromForm({

--- a/tests/custom-launch-public-readiness.test.ts
+++ b/tests/custom-launch-public-readiness.test.ts
@@ -10,6 +10,7 @@ import {
   isCustomLaunchRegistryPublicReadEnabled,
 } from "../lib/server/custom-launch/public-readiness";
 import { handleProductionCustomLaunchBridgeV2 } from "../lib/server/custom-launch/launch-bridge-v2";
+import { canonicalSha256 } from "../lib/server/projection-target/hashing";
 import { GET as legacyEntitlementGET } from "../app/api/custom-launch/entitlements/route";
 import { GET as trustedTimeGET } from "../app/api/custom-launch/trusted-time/route";
 
@@ -24,6 +25,25 @@ const permitSigner = {
     rawPermitPublicKey,
   ])).digest("hex")}`,
 };
+const receiptSignerCore = {
+  schemaVersion: "programmable.remote-ed25519-provider-identity.v2" as const,
+  endpoint: "https://signer.programmable.example/v1/sign",
+  audience: "programmable.launch-presentation-image.v1",
+  keyId: "token-image-receipt",
+  keyEpoch: "1",
+  publicKeySpkiSha256: permitSigner.publicKeySpkiSha256,
+};
+const receiptSigner = {
+  schemaVersion: "programmable.token-image-upload-receipt-signer-binding.v1",
+  endpoint: receiptSignerCore.endpoint,
+  audience: receiptSignerCore.audience,
+  keyId: receiptSignerCore.keyId,
+  keyEpoch: receiptSignerCore.keyEpoch,
+  publicKeyBase64Url: permitSigner.publicKeyBase64Url,
+  publicKeySpkiSha256: receiptSignerCore.publicKeySpkiSha256,
+  providerIdentityHash: canonicalSha256(receiptSignerCore.schemaVersion, receiptSignerCore),
+  credentialMode: "vercel-oidc-bearer",
+};
 
 const configured = {
   PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED: "true",
@@ -32,7 +52,10 @@ const configured = {
   PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_REVIEW_AUTHORITY_MODE: "manual_review",
   NEXT_PUBLIC_PRIVY_APP_ID: "privy-app",
   PRIVY_APP_SECRET: "privy-secret",
+  TOKEN_IMAGE_BLOB_READ_WRITE_TOKEN: "blob-token",
   PROGRAMMABLE_LAUNCH_PERMIT_SIGNERS_V2_JSON: JSON.stringify([permitSigner]),
+  PROGRAMMABLE_TOKEN_IMAGE_UPLOAD_RECEIPT_SIGNER_V1_JSON:
+    JSON.stringify(receiptSigner),
 };
 
 function trustedTimeRequest(signer = permitSigner): Request {
@@ -69,7 +92,15 @@ describe("Custom launch public readiness", () => {
     expect(isCustomLaunchPublicEnabled({ ...configured, PRIVY_APP_SECRET: "" })).toBe(false);
     expect(isCustomLaunchPublicEnabled({
       ...configured,
+      TOKEN_IMAGE_BLOB_READ_WRITE_TOKEN: "",
+    })).toBe(false);
+    expect(isCustomLaunchPublicEnabled({
+      ...configured,
       PROGRAMMABLE_LAUNCH_PERMIT_SIGNERS_V2_JSON: "",
+    })).toBe(false);
+    expect(isCustomLaunchPublicEnabled({
+      ...configured,
+      PROGRAMMABLE_TOKEN_IMAGE_UPLOAD_RECEIPT_SIGNER_V1_JSON: "",
     })).toBe(false);
   });
 

--- a/tests/fixtures/token-image-upload-receipt-v1.json
+++ b/tests/fixtures/token-image-upload-receipt-v1.json
@@ -1,0 +1,75 @@
+{
+  "signerBinding": {
+    "schemaVersion": "programmable.token-image-upload-receipt-signer-binding.v1",
+    "endpoint": "https://signer.programmable.example/v1/sign",
+    "audience": "programmable.launch-presentation-image.v1",
+    "keyId": "token-image-receipt",
+    "keyEpoch": "1",
+    "publicKeyBase64Url": "iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
+    "publicKeySpkiSha256": "sha256:fd110d301d2f077de1414b8f99f441b1403fab207b2052fbd2c065e4ee8e7dc2",
+    "providerIdentityHash": "sha256:3a30a6d68e0a7a136abbf533caefcf9eade51fcc4238b76ca53f9fded3e6d5a5",
+    "credentialMode": "vercel-oidc-bearer"
+  },
+  "receipt": {
+    "schemaVersion": "programmable.signed-token-image-upload-receipt.v1",
+    "payload": {
+      "schemaVersion": "programmable.token-image-upload-receipt.v1",
+      "audience": "programmable.launch-presentation-image.v1",
+      "launchScope": {
+        "applicationId": "wild-game",
+        "applicationHandle": "github-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "grantId": "10000000-0000-4000-8000-000000000001",
+        "grantBindingHash": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+      },
+      "uploadOwner": {
+        "provider": "privy-github",
+        "privyUserId": "did:privy:user-1",
+        "githubUserId": "123",
+        "githubPrincipalHash": "sha256:5eddbd98594c77b50b0ace34c085e484cf7df75cd7abfe788e2aae5191757d57"
+      },
+      "blob": {
+        "storeId": "store_k2uoiPT9WCHJtz3H",
+        "host": "k2uoipt9wchjtz3h.public.blob.vercel-storage.com",
+        "pathname": "token-images/golden.webp",
+        "url": "https://k2uoipt9wchjtz3h.public.blob.vercel-storage.com/token-images/golden.webp",
+        "etag": "golden-etag-v1"
+      },
+      "image": {
+        "contentSha256": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "mediaType": "image/webp",
+        "byteLength": 12345,
+        "width": 1000,
+        "height": 1000
+      },
+      "signingAuthority": {
+        "providerIdentityHash": "sha256:3a30a6d68e0a7a136abbf533caefcf9eade51fcc4238b76ca53f9fded3e6d5a5",
+        "keyId": "token-image-receipt",
+        "keyEpoch": "1",
+        "publicKeySpkiSha256": "sha256:fd110d301d2f077de1414b8f99f441b1403fab207b2052fbd2c065e4ee8e7dc2"
+      },
+      "issuedAt": "2026-08-12T12:00:00.000Z",
+      "expiresAt": "2026-08-12T12:05:00.000Z"
+    },
+    "payloadSha256": "sha256:9eb89b5303a2f365e9da1d21f0f9512acb6db82450953654a73b79a0926d7328",
+    "signature": "qnqh0SKR1Is9dxKPTKg3dJgkaenrYCZRJ_7g6EA04fNBOd9DrPfrztfUQALRGlGJgf2di4mQjXd9QmoP_bDYBg",
+    "signatureSha256": "sha256:83526e1b68092d4dde4fed9086bdf4e11b5b5f0a314685dedf0e3b14c48fe9fb",
+    "providerReceipt": {
+      "schemaVersion": "programmable.remote-signing-provider-receipt.v2",
+      "outcome": "completed",
+      "audience": "programmable.launch-presentation-image.v1",
+      "keyId": "token-image-receipt",
+      "keyEpoch": "1",
+      "algorithm": "Ed25519",
+      "providerIdentityHash": "sha256:3a30a6d68e0a7a136abbf533caefcf9eade51fcc4238b76ca53f9fded3e6d5a5",
+      "idempotencyKey": "sha256:39ba65b39aac9077dfd152fc2ab910ef053935a93cd0172569da5dbef8a65f34",
+      "messageSha256": "sha256:9eb89b5303a2f365e9da1d21f0f9512acb6db82450953654a73b79a0926d7328",
+      "requestDigest": "sha256:0610676df54bc8a3aebdf829ebf4c20a72b48c88984898ec673ac86660ff00df",
+      "signature": "qnqh0SKR1Is9dxKPTKg3dJgkaenrYCZRJ_7g6EA04fNBOd9DrPfrztfUQALRGlGJgf2di4mQjXd9QmoP_bDYBg",
+      "observedAt": "2026-08-12T12:00:00.000Z",
+      "expiresAt": "2026-08-12T12:05:00.000Z"
+    },
+    "providerReceiptSha256": "sha256:a98d746fa9d3d1c3d257e3b00ff5619c9d6338fcdfcabf5dd9ce065c0985bc4d",
+    "providerReceiptSignature": "8rLYkiWDOhzYe8Qf1OJ5s7NOm8SYpAZjdwcbI0KfBCL0sCVa81GtOy5wbcdFvIZdDHpfeFlkXBg5SkLr-KkHCQ",
+    "providerReceiptSignatureSha256": "sha256:60025d9647c3f454dba1ccc27dd7c158e68c670aba61f467041dfea88725316a"
+  }
+}

--- a/tests/token-image-upload-receipt.test.ts
+++ b/tests/token-image-upload-receipt.test.ts
@@ -1,0 +1,422 @@
+import {
+  createHash,
+  generateKeyPairSync,
+  sign as signBytes,
+  type KeyObject,
+} from "node:crypto";
+import { readFileSync } from "node:fs";
+
+import Ajv from "ajv";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type {
+  SignedTokenImageUploadReceiptV1,
+  TokenImageUploadReceiptLaunchScopeV1,
+} from "../lib/custom-launch/token-image-upload-receipt-v1";
+import {
+  parseSignedTokenImageUploadReceiptV1,
+  TOKEN_IMAGE_UPLOAD_RECEIPT_SCHEMA_SHA256_V1,
+} from "../lib/custom-launch/token-image-upload-receipt-v1";
+import { canonicalizeJson } from "../lib/server/projection-target/canonical-json";
+import { canonicalSha256 } from "../lib/server/projection-target/hashing";
+import {
+  createRemoteTokenImageUploadReceiptSignerV1,
+  createProductionTokenImageUploadReceiptSignerV1,
+  authorizeTokenImagePresentationMutationV1,
+  parseTokenImageUploadReceiptSignerBindingV1,
+  verifyTokenImageUploadReceiptForPresentationV1,
+  type TokenImageUploadReceiptSignerBindingV1,
+} from "../lib/server/token-image-upload-receipt-v1";
+import {
+  PROGRAMMABLE_TOKEN_IMAGE_HOST,
+  PROGRAMMABLE_TOKEN_IMAGE_STORE_ID,
+} from "../lib/token-image";
+import receiptSchema from "../lib/custom-launch/artifacts/token-image-upload-receipt-v1.schema.json";
+import receiptGolden from "./fixtures/token-image-upload-receipt-v1.json";
+
+const NOW = new Date("2026-08-12T12:00:00.000Z");
+const IMAGE_URL = `https://${PROGRAMMABLE_TOKEN_IMAGE_HOST}/token-images/example.webp`;
+const CONTENT_HASH = digest(0x11);
+const PRINCIPAL_HASH = digest(0x22);
+const GRANT_HASH = digest(0x33);
+const SCOPE: TokenImageUploadReceiptLaunchScopeV1 = Object.freeze({
+  applicationId: "application-1",
+  applicationHandle: `github-${"a".repeat(64)}`,
+  grantId: "123e4567-e89b-42d3-a456-426614174002",
+  grantBindingHash: GRANT_HASH,
+});
+
+type SignerHarness = Readonly<{
+  privateKey: KeyObject;
+  publicKey: KeyObject;
+  binding: TokenImageUploadReceiptSignerBindingV1;
+  fetch: typeof fetch;
+}>;
+
+describe("token image upload receipt v1", () => {
+  it("keeps the portable JSON schema and cryptographic golden fixture exact", () => {
+    expect(rawDigest(readFileSync(new URL(
+      "../lib/custom-launch/artifacts/token-image-upload-receipt-v1.schema.json",
+      import.meta.url,
+    )))).toBe(TOKEN_IMAGE_UPLOAD_RECEIPT_SCHEMA_SHA256_V1);
+    const validate = new Ajv({ allErrors: true, strict: true }).compile(receiptSchema);
+    expect(validate(receiptGolden.receipt), JSON.stringify(validate.errors)).toBe(true);
+    const parsed = parseSignedTokenImageUploadReceiptV1(receiptGolden.receipt);
+    expect(parsed).toEqual(receiptGolden.receipt);
+    expect(verifyTokenImageUploadReceiptForPresentationV1({
+      receipt: parsed,
+      trustedSigner: parseTokenImageUploadReceiptSignerBindingV1(
+        receiptGolden.signerBinding,
+      ),
+      expectedLaunchScope: parsed.payload.launchScope,
+      expectedPrincipal: {
+        githubUserId: "123",
+        githubPrincipalHash: parsed.payload.uploadOwner.githubPrincipalHash,
+      },
+      expectedImage: {
+        uri: parsed.payload.blob.url,
+        ...parsed.payload.image,
+      },
+      now: new Date("2026-08-12T12:00:01.000Z"),
+    })).toEqual(parsed.payload);
+  });
+
+  it("authenticates an exact principal, grant, immutable Blob and image", async () => {
+    const harness = signerHarness();
+    const receipt = await issueReceipt(harness);
+    expect(parseSignedTokenImageUploadReceiptV1(receipt)).toEqual(receipt);
+    expect(verify(receipt, harness.binding)).toMatchObject({
+      launchScope: SCOPE,
+      image: {
+        contentSha256: CONTENT_HASH,
+        byteLength: 12_345,
+        width: 1_000,
+        height: 1_000,
+      },
+      blob: {
+        storeId: PROGRAMMABLE_TOKEN_IMAGE_STORE_ID,
+        host: PROGRAMMABLE_TOKEN_IMAGE_HOST,
+        etag: "etag-1",
+      },
+    });
+  });
+
+  it("rejects foreign principals and replay across application or grant", async () => {
+    const harness = signerHarness();
+    const receipt = await issueReceipt(harness);
+    expect(() => verify(receipt, harness.binding, {
+      principal: { githubUserId: "999", githubPrincipalHash: digest(0x99) },
+    })).toThrow("another principal");
+    expect(() => verify(receipt, harness.binding, {
+      scope: { ...SCOPE, applicationId: "application-2" },
+    })).toThrow("presentation");
+    expect(() => verify(receipt, harness.binding, {
+      scope: { ...SCOPE, grantId: "123e4567-e89b-42d3-a456-426614174099" },
+    })).toThrow("presentation");
+  });
+
+  it("rejects expired receipts and old signer epochs", async () => {
+    const harness = signerHarness();
+    const receipt = await issueReceipt(harness);
+    expect(() => verify(receipt, harness.binding, {
+      now: new Date("2026-08-12T12:05:00.000Z"),
+    })).toThrow("expired");
+    const oldEpoch = bindingForPublicKey(harness.publicKey, "epoch-0");
+    expect(() => verify(receipt, oldEpoch)).toThrow("untrusted signer");
+  });
+
+  it("rejects URL, hash, size and dimension substitutions", async () => {
+    const harness = signerHarness();
+    const receipt = await issueReceipt(harness);
+    expect(() => verify(receipt, harness.binding, {
+      image: { uri: `${IMAGE_URL}.other` },
+    })).toThrow("presentation");
+    expect(() => verify(receipt, harness.binding, {
+      image: { contentSha256: digest(0x44) },
+    })).toThrow("presentation");
+    expect(() => verify(receipt, harness.binding, {
+      image: { byteLength: 12_346 },
+    })).toThrow("presentation");
+    expect(() => verify(receipt, harness.binding, {
+      image: { width: 999 },
+    })).toThrow("presentation");
+    expect(() => verify(receipt, harness.binding, {
+      image: { mediaType: "image/png" as "image/webp" },
+    })).toThrow("presentation");
+  });
+
+  it("rejects signed-field tampering including the Blob ETag", async () => {
+    const harness = signerHarness();
+    const receipt = await issueReceipt(harness);
+    const tampered = structuredClone(receipt) as {
+      payload: { blob: { etag: string } };
+    } & SignedTokenImageUploadReceiptV1;
+    tampered.payload.blob.etag = "etag-2";
+    expect(() => verify(tampered, harness.binding)).toThrow("byte integrity");
+  });
+
+  it("rejects unknown receipt fields before cryptographic verification", async () => {
+    const harness = signerHarness();
+    const receipt = await issueReceipt(harness);
+    expect(() => parseSignedTokenImageUploadReceiptV1({
+      ...receipt,
+      localSignerFallback: true,
+    })).toThrow("unknown or missing");
+  });
+
+  it("fails closed on signer redirect, timeout and oversized response", async () => {
+    const base = signerHarness();
+    const redirected = createRemoteTokenImageUploadReceiptSignerV1({
+      binding: base.binding,
+      credential: "opaque-workload-token-value",
+      now: () => NOW,
+      fetch: async () => ({ redirected: true, status: 200 }) as Response,
+    });
+    await expect(redirected.sign(signingInput())).rejects.toThrow("rejected");
+
+    const timedOut = createRemoteTokenImageUploadReceiptSignerV1({
+      binding: base.binding,
+      credential: "opaque-workload-token-value",
+      now: () => NOW,
+      timeoutMs: 500,
+      fetch: async (_url, init) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+          once: true,
+        });
+      }),
+    });
+    await expect(timedOut.sign(signingInput())).rejects.toThrow("deadline");
+
+    const oversized = createRemoteTokenImageUploadReceiptSignerV1({
+      binding: base.binding,
+      credential: "opaque-workload-token-value",
+      now: () => NOW,
+      fetch: async () => new Response("{}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "content-length": "999999",
+        },
+      }),
+    });
+    await expect(oversized.sign(signingInput())).rejects.toThrow("too large");
+  });
+
+  it("gets signer credentials from the Vercel authority, not a caller header", async () => {
+    const harness = signerHarness();
+    const hostileRequest = new Request("https://programmable.example/api/token-image", {
+      headers: { "x-vercel-oidc-token": "attacker-selected-token" },
+    });
+    expect(hostileRequest.headers.get("x-vercel-oidc-token")).toBe(
+      "attacker-selected-token",
+    );
+    vi.stubEnv(
+      "PROGRAMMABLE_TOKEN_IMAGE_UPLOAD_RECEIPT_SIGNER_V1_JSON",
+      canonicalizeJson(harness.binding),
+    );
+    let authorization = "";
+    const signer = await createProductionTokenImageUploadReceiptSignerV1({
+      credentialProvider: async () => "vercel-context-header.payload.signature",
+      now: () => NOW,
+      fetch: async (url, init) => {
+        authorization = new Headers(init?.headers).get("authorization") ?? "";
+        return harness.fetch(url, init);
+      },
+    });
+    await signer.sign(signingInput());
+    expect(authorization).toBe("Bearer vercel-context-header.payload.signature");
+    expect(authorization).not.toContain("attacker-selected-token");
+    vi.unstubAllEnvs();
+  });
+
+  it("reuses an unchanged durable image after receipt expiry but gates create/change", async () => {
+    const harness = signerHarness();
+    const receipt = await issueReceipt(harness);
+    const image = signingInput().image;
+    const presentationImage = {
+      uri: IMAGE_URL,
+      ...image,
+    };
+    const common = {
+      trustedSigner: harness.binding,
+      expectedLaunchScope: SCOPE,
+      expectedPrincipal: {
+        githubUserId: "123",
+        githubPrincipalHash: PRINCIPAL_HASH,
+      },
+      now: new Date("2026-08-12T13:00:00.000Z"),
+    };
+    expect(authorizeTokenImagePresentationMutationV1({
+      ...common,
+      currentImage: presentationImage,
+      requestedImage: { ...presentationImage },
+      receipt: null,
+    })).toBe("unchanged");
+    expect(() => authorizeTokenImagePresentationMutationV1({
+      ...common,
+      currentImage: null,
+      requestedImage: presentationImage,
+      receipt: null,
+    })).toThrow("required");
+    expect(() => authorizeTokenImagePresentationMutationV1({
+      ...common,
+      currentImage: null,
+      requestedImage: presentationImage,
+      receipt,
+    })).toThrow("expired");
+  });
+});
+
+function signerHarness(): SignerHarness {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const binding = bindingForPublicKey(publicKey, "epoch-1");
+  const transport: typeof fetch = async (_url, init) => {
+    const request = JSON.parse(String(init?.body)) as Record<string, string>;
+    const message = Buffer.from(request.message!, "base64url");
+    const signature = signBytes(null, message, privateKey).toString("base64url");
+    const providerReceipt = {
+      schemaVersion: "programmable.remote-signing-provider-receipt.v2",
+      outcome: "completed",
+      audience: request.audience,
+      keyId: request.keyId,
+      keyEpoch: request.keyEpoch,
+      algorithm: "Ed25519",
+      providerIdentityHash: request.providerIdentityHash,
+      idempotencyKey: request.idempotencyKey,
+      messageSha256: request.messageSha256,
+      requestDigest: request.requestDigest,
+      signature,
+      observedAt: NOW.toISOString(),
+      expiresAt: new Date(NOW.getTime() + 300_000).toISOString(),
+    };
+    const receiptBytes = Buffer.from(canonicalizeJson(providerReceipt), "utf8");
+    const response = {
+      schemaVersion: "programmable.remote-signing-authenticated-response.v2",
+      providerReceipt,
+      providerReceiptDigest: rawDigest(receiptBytes),
+      providerReceiptSignature: signBytes(null, receiptBytes, privateKey)
+        .toString("base64url"),
+    };
+    return new Response(canonicalizeJson(response), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return Object.freeze({ privateKey, publicKey, binding, fetch: transport });
+}
+
+async function issueReceipt(harness: SignerHarness) {
+  const signer = createRemoteTokenImageUploadReceiptSignerV1({
+    binding: harness.binding,
+    credential: "opaque-workload-token-value",
+    fetch: harness.fetch,
+    now: () => NOW,
+  });
+  return signer.sign(signingInput());
+}
+
+function signingInput() {
+  return {
+    launchScope: SCOPE,
+    uploadOwner: {
+      provider: "privy-github" as const,
+      privyUserId: "did:privy:user-1",
+      githubUserId: "123",
+      githubPrincipalHash: PRINCIPAL_HASH,
+    },
+    blob: {
+      storeId: PROGRAMMABLE_TOKEN_IMAGE_STORE_ID,
+      host: PROGRAMMABLE_TOKEN_IMAGE_HOST,
+      pathname: "token-images/example.webp",
+      url: IMAGE_URL,
+      etag: "etag-1",
+    },
+    image: {
+      contentSha256: CONTENT_HASH,
+      mediaType: "image/webp" as const,
+      byteLength: 12_345,
+      width: 1_000 as const,
+      height: 1_000 as const,
+    },
+  };
+}
+
+function verify(
+  receipt: unknown,
+  binding: TokenImageUploadReceiptSignerBindingV1,
+  overrides: Readonly<{
+    now?: Date;
+    scope?: TokenImageUploadReceiptLaunchScopeV1;
+    principal?: Readonly<{
+      githubUserId: string;
+      githubPrincipalHash: `sha256:${string}`;
+    }>;
+    image?: Partial<{
+      uri: string;
+      contentSha256: `sha256:${string}`;
+      mediaType: "image/webp";
+      byteLength: number;
+      width: number;
+      height: number;
+    }>;
+  }> = {},
+) {
+  return verifyTokenImageUploadReceiptForPresentationV1({
+    receipt,
+    trustedSigner: binding,
+    expectedLaunchScope: overrides.scope ?? SCOPE,
+    expectedPrincipal: overrides.principal ?? {
+      githubUserId: "123",
+      githubPrincipalHash: PRINCIPAL_HASH,
+    },
+    expectedImage: {
+      uri: IMAGE_URL,
+      contentSha256: CONTENT_HASH,
+      mediaType: "image/webp",
+      byteLength: 12_345,
+      width: 1_000,
+      height: 1_000,
+      ...overrides.image,
+    },
+    now: overrides.now ?? new Date(NOW.getTime() + 1_000),
+  });
+}
+
+function bindingForPublicKey(
+  publicKey: KeyObject,
+  keyEpoch: string,
+): TokenImageUploadReceiptSignerBindingV1 {
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  const publicKeyBase64Url = spki.subarray(-32).toString("base64url");
+  const publicKeySpkiSha256 = rawDigest(spki);
+  const endpoint = "https://signer.example/v1/sign";
+  const core = {
+    schemaVersion: "programmable.remote-ed25519-provider-identity.v2" as const,
+    endpoint,
+    audience: "programmable.launch-presentation-image.v1" as const,
+    keyId: "token-image-receipt",
+    keyEpoch,
+    publicKeySpkiSha256,
+  };
+  return parseTokenImageUploadReceiptSignerBindingV1({
+    schemaVersion: "programmable.token-image-upload-receipt-signer-binding.v1",
+    endpoint,
+    audience: core.audience,
+    keyId: core.keyId,
+    keyEpoch,
+    publicKeyBase64Url,
+    publicKeySpkiSha256,
+    providerIdentityHash: canonicalSha256(core.schemaVersion, core),
+    credentialMode: "vercel-oidc-bearer",
+  });
+}
+
+function digest(byte: number): `sha256:${string}` {
+  return `sha256:${byte.toString(16).padStart(2, "0").repeat(32)}`;
+}
+
+function rawDigest(bytes: Uint8Array): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}

--- a/tests/token-image-upload-route.test.ts
+++ b/tests/token-image-upload-route.test.ts
@@ -1,0 +1,233 @@
+import type { PutBlobResult } from "@vercel/blob";
+import sharp from "sharp";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createTokenImageUploadHandlerV1,
+  readProductionTokenImageBlobV1,
+  type TokenImageUploadHandlerDependenciesV1,
+} from "../app/api/token-image/route";
+import type {
+  SignedTokenImageUploadReceiptV1,
+} from "../lib/custom-launch/token-image-upload-receipt-v1";
+import type {
+  TokenImageUploadReceiptSignerV1,
+} from "../lib/server/token-image-upload-receipt-v1";
+import {
+  PROGRAMMABLE_TOKEN_IMAGE_HOST,
+} from "../lib/token-image";
+
+const BLOB_URL = `https://${PROGRAMMABLE_TOKEN_IMAGE_HOST}/token-images/example.webp`;
+const BLOB: PutBlobResult = Object.freeze({
+  url: BLOB_URL,
+  downloadUrl: `${BLOB_URL}?download=1`,
+  pathname: "token-images/example.webp",
+  contentType: "image/webp",
+  contentDisposition: "inline",
+  etag: "etag-1",
+});
+const SCOPE = JSON.stringify({
+  applicationId: "application-1",
+  applicationHandle: `github-${"a".repeat(64)}`,
+  grantId: "123e4567-e89b-42d3-a456-426614174002",
+  grantBindingHash: `sha256:${"33".repeat(32)}`,
+});
+
+let webp: Uint8Array;
+let jpeg: Uint8Array;
+
+beforeAll(async () => {
+  webp = await sharp({
+    create: {
+      width: 1_000,
+      height: 1_000,
+      channels: 4,
+      background: { r: 21, g: 32, b: 43, alpha: 1 },
+    },
+  }).webp().toBuffer();
+  jpeg = await sharp({
+    create: {
+      width: 1_000,
+      height: 1_000,
+      channels: 3,
+      background: { r: 21, g: 32, b: 43 },
+    },
+  }).jpeg().toBuffer();
+});
+
+describe("token image upload route", () => {
+  it("rejects JPEG bytes relabelled as WebP before Blob write", async () => {
+    const putBlob = vi.fn<Dependencies["putBlob"]>();
+    const handler = createTokenImageUploadHandlerV1(dependencies({ putBlob }));
+    const response = await handler(request(jpeg));
+    expect(response.status).toBe(400);
+    expect(putBlob).not.toHaveBeenCalled();
+  });
+
+  it("requires a configured managed signer before a scoped Blob write", async () => {
+    const putBlob = vi.fn<Dependencies["putBlob"]>();
+    const handler = createTokenImageUploadHandlerV1(dependencies({
+      putBlob,
+      prepareReceiptSigner: async () => {
+        throw new TypeError("unconfigured");
+      },
+    }));
+    const response = await handler(request(webp, true));
+    expect(response.status).toBe(503);
+    expect(putBlob).not.toHaveBeenCalled();
+  });
+
+  it("rejects foreign Privy principal before a scoped Blob write", async () => {
+    const putBlob = vi.fn<Dependencies["putBlob"]>();
+    const handler = createTokenImageUploadHandlerV1(dependencies({
+      putBlob,
+      authenticatePrincipal: async () => ({
+        privyUserId: "did:privy:other",
+        githubUserId: "123",
+        githubUsername: "project",
+        githubPrincipalHash: `sha256:${"22".repeat(32)}`,
+      }),
+    }));
+    const response = await handler(request(webp, true));
+    expect(response.status).toBe(403);
+    expect(putBlob).not.toHaveBeenCalled();
+  });
+
+  it("does not issue a receipt when readback bytes, ETag or URL differ", async () => {
+    for (const readBlob of [
+      async () => ({ ...readback(webp), bytes: Uint8Array.from([...webp, 0]) }),
+      async () => ({ ...readback(webp), etag: "etag-2" }),
+      async () => ({ ...readback(webp), url: `${BLOB_URL}.other` }),
+    ]) {
+      const signer = signerStub();
+      const handler = createTokenImageUploadHandlerV1(dependencies({
+        readBlob,
+        prepareReceiptSigner: async () => signer,
+      }));
+      const response = await handler(request(webp, true));
+      expect(response.status).toBe(502);
+      expect(signer.sign).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not publish a receipt when readback times out", async () => {
+    const signer = signerStub();
+    const handler = createTokenImageUploadHandlerV1(dependencies({
+      readbackTimeoutMs: 5,
+      readBlob: async (_blob, signal) => new Promise((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        void resolve;
+      }),
+      prepareReceiptSigner: async () => signer,
+    }));
+    const response = await handler(request(webp, true));
+    expect(response.status).toBe(502);
+    expect(signer.sign).not.toHaveBeenCalled();
+  });
+
+  it("rejects a redirected, oversized or wrong-type production readback", async () => {
+    for (const response of [
+      ({ redirected: true, status: 200, url: BLOB_URL }) as Response,
+      new Response(Uint8Array.from(webp).buffer, {
+        status: 200,
+        headers: {
+          "content-type": "image/webp",
+          "content-length": "1000001",
+          etag: "etag-1",
+        },
+      }),
+      new Response(Uint8Array.from(webp).buffer, {
+        status: 200,
+        headers: { "content-type": "image/jpeg", etag: "etag-1" },
+      }),
+    ]) {
+      await expect(readProductionTokenImageBlobV1(
+        BLOB,
+        new AbortController().signal,
+        async () => response,
+      )).rejects.toThrow();
+    }
+  });
+
+  it("publishes the exact remotely signed receipt only after valid readback", async () => {
+    const receipt = {
+      schemaVersion: "programmable.signed-token-image-upload-receipt.v1",
+    } as SignedTokenImageUploadReceiptV1;
+    const signer = signerStub(receipt);
+    const handler = createTokenImageUploadHandlerV1(dependencies({
+      prepareReceiptSigner: async () => signer,
+    }));
+    const response = await handler(request(webp, true));
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({ url: BLOB_URL, receipt });
+    expect(signer.sign).toHaveBeenCalledWith(expect.objectContaining({
+      launchScope: expect.objectContaining({ applicationId: "application-1" }),
+      blob: expect.objectContaining({
+        url: BLOB_URL,
+        etag: "etag-1",
+      }),
+      image: expect.objectContaining({
+        byteLength: webp.byteLength,
+        width: 1_000,
+        height: 1_000,
+        mediaType: "image/webp",
+      }),
+    }));
+  });
+});
+
+type Dependencies = TokenImageUploadHandlerDependenciesV1;
+
+function dependencies(overrides: Partial<Dependencies> = {}): Dependencies {
+  return {
+    blobToken: "blob-token",
+    authenticateSession: async () => ({ privyUserId: "did:privy:user-1" }),
+    authenticatePrincipal: async () => ({
+      privyUserId: "did:privy:user-1",
+      githubUserId: "123",
+      githubUsername: "project",
+      githubPrincipalHash: `sha256:${"22".repeat(32)}`,
+    }),
+    prepareReceiptSigner: async () => signerStub(),
+    putBlob: async () => BLOB,
+    readBlob: async () => readback(webp),
+    ...overrides,
+  };
+}
+
+function request(bytes: Uint8Array, scoped = false): Request {
+  const form = new FormData();
+  form.append("file", new File(
+    [Uint8Array.from(bytes).buffer],
+    "image.webp",
+    { type: "image/webp" },
+  ));
+  if (scoped) form.append("receiptScope", SCOPE);
+  return new Request("https://programmable.example/api/token-image", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer access-token",
+      "x-privy-identity-token": "identity-token",
+    },
+    body: form,
+  });
+}
+
+function readback(bytes: Uint8Array) {
+  return Object.freeze({
+    url: BLOB_URL,
+    etag: "etag-1",
+    contentType: "image/webp",
+    bytes: Uint8Array.from(bytes),
+  });
+}
+
+function signerStub(receipt = {} as SignedTokenImageUploadReceiptV1):
+TokenImageUploadReceiptSignerV1 {
+  return {
+    binding: {} as TokenImageUploadReceiptSignerV1["binding"],
+    sign: vi.fn(async () => receipt),
+  };
+}

--- a/tests/token-image.test.ts
+++ b/tests/token-image.test.ts
@@ -1,15 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import sharp from "sharp";
+
+vi.mock("server-only", () => ({}));
 
 import {
   canOptimizeTokenImage,
   getProgrammableTokenImageAssetName,
   getTokenCardImageSource,
   getTokenImageFileError,
-  hasValidTokenImageSignature,
   isProgrammableTokenImageUrl,
   MAX_TOKEN_IMAGE_UPLOAD_BYTES,
   PROGRAMMABLE_TOKEN_IMAGE_HOST,
 } from "../lib/token-image";
+import {
+  inspectWebpStructure,
+  verifyTokenImageWebpV1,
+} from "../lib/server/token-image-webp-v1";
 
 describe("token image policy", () => {
   it("keeps prepared uploads within the card-performance budget", () => {
@@ -40,16 +46,66 @@ describe("token image policy", () => {
     ).toContain("smaller than 8 MB");
   });
 
-  it("checks the uploaded image signature", async () => {
-    const webp = new Blob([
-      new Uint8Array([
-        0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50,
-      ]),
-    ]);
-    const fake = new Blob([new TextEncoder().encode("not an image")]);
+  it("fully decodes only a structurally valid 1000 by 1000 WebP", async () => {
+    const webp = await sharp({
+      create: {
+        width: 1_000,
+        height: 1_000,
+        channels: 4,
+        background: { r: 21, g: 32, b: 43, alpha: 1 },
+      },
+    }).webp().toBuffer();
+    await expect(verifyTokenImageWebpV1(webp)).resolves.toMatchObject({
+      width: 1_000,
+      height: 1_000,
+    });
+    expect(inspectWebpStructure(webp)).toEqual({ width: 1_000, height: 1_000 });
+  });
 
-    await expect(hasValidTokenImageSignature(webp)).resolves.toBe(true);
-    await expect(hasValidTokenImageSignature(fake)).resolves.toBe(false);
+  it("rejects JPEG and PNG bytes relabelled as WebP", async () => {
+    const jpeg = await sharp({
+      create: {
+        width: 1_000,
+        height: 1_000,
+        channels: 3,
+        background: { r: 21, g: 32, b: 43 },
+      },
+    }).jpeg().toBuffer();
+    const png = await sharp({
+      create: {
+        width: 1_000,
+        height: 1_000,
+        channels: 3,
+        background: { r: 21, g: 32, b: 43 },
+      },
+    }).png().toBuffer();
+    await expect(verifyTokenImageWebpV1(jpeg)).rejects.toThrow("WebP");
+    await expect(verifyTokenImageWebpV1(png)).rejects.toThrow("WebP");
+  });
+
+  it("rejects wrong dimensions, broken RIFF lengths and corrupt image bytes", async () => {
+    const wrongDimensions = await sharp({
+      create: {
+        width: 999,
+        height: 1_000,
+        channels: 3,
+        background: { r: 21, g: 32, b: 43 },
+      },
+    }).webp().toBuffer();
+    const valid = await sharp({
+      create: {
+        width: 1_000,
+        height: 1_000,
+        channels: 3,
+        background: { r: 21, g: 32, b: 43 },
+      },
+    }).webp().toBuffer();
+    const brokenLength = Uint8Array.from(valid);
+    brokenLength[4] = (brokenLength[4]! + 1) & 0xff;
+    const corrupt = valid.subarray(0, valid.byteLength - 3);
+    await expect(verifyTokenImageWebpV1(wrongDimensions)).rejects.toThrow("1000");
+    await expect(verifyTokenImageWebpV1(brokenLength)).rejects.toThrow("WebP");
+    await expect(verifyTokenImageWebpV1(corrupt)).rejects.toThrow("WebP");
   });
 
   it("optimizes only local token images", () => {
@@ -83,6 +139,8 @@ describe("token image policy", () => {
         `https://${PROGRAMMABLE_TOKEN_IMAGE_HOST}.example.com/token-images/example.webp`,
       ),
     ).toBe(false);
+    expect(isProgrammableTokenImageUrl(`${image}?version=2`)).toBe(false);
+    expect(isProgrammableTokenImageUrl(`${image}#replacement`)).toBe(false);
     expect(
       getTokenCardImageSource("https://example.com/token.webp"),
     ).toBe("https://example.com/token.webp");


### PR DESCRIPTION
## Outcome

Binds every new or changed custom-launch image revision to a short-lived, remotely signed upload receipt after bounded Blob readback. The receipt covers the authenticated principal, exact application/grant scope, immutable Blob URL/path/store/ETag, SHA-256, byte length, decoded 1000x1000 WebP dimensions, media type, audience, signer key/epoch, and provider evidence.

The Approval-side consumer can verify this contract offline. This Website change contains no private-key fallback, no deployment, and remains fail-closed until the Blob and remote signer bindings are configured.

## Security boundary

- Strict WebP structure and full decode after 1 MB / 1 MP pre-decode bounds
- Blob write followed by redirect-free, timeout-bounded public readback before signing
- Vercel OIDC credential obtained from request context, never caller headers
- Exact signed schema and golden cross-service fixture
- Receipt required only for image create/change; byte-identical stored revisions remain reusable

## Verification

- TypeScript typecheck
- 7 focused files, 88 tests
- Scoped ESLint
- Exact source-of-truth diff check
- Full Next.js 16.2.11 production build, including /api/token-image
- Linux x64 sharp/libvips optional package resolution verified

No deploy, promotion, or external transaction performed.