### PR TITLE
docs: tighten mobile fee table copy

### DIFF
--- a/docs/public/economics.md
+++ b/docs/public/economics.md
@@ -6,7 +6,7 @@ description: Transaction fees, creator rewards and Programmable revenue
 
 Programmable fees depend on the transaction that actually executes. A launch model alone does not determine the fee. Each release must state the complete rate, how it is divided and which transactions pay it.
 
-| Path            | Programmable share                                       | How it is charged                                      |
+| Path            | Programmable                                             | How it works                                           |
 | --------------- | -------------------------------------------------------- | ------------------------------------------------------ |
 | Classic         | 0.1% of the gross ETH amount exchanged                   | Included in the selected buy or sell transaction fee   |
 | Standard Custom | 0.1% of the gross amount exchanged on the approved route | Defined by the exact accepted release                  |


### PR DESCRIPTION
## Summary

Shorten the fee table headings so the GitBook mobile view does not split Programmable in the middle of the word.

## Validation

- live 390px check identified the wrapping issue
- Markdown passes Prettier
- `git diff --check` passes
- diff is limited to `docs/public/economics.md`