### PR TITLE
ci: route exact approved Builder maintenance candidate

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -108,6 +108,7 @@ jobs:
           echo "merge_commit=$merge_commit" >> "$GITHUB_OUTPUT"
 
       - name: Enforce trusted main CI control-plane guard
+        id: ci_control
         shell: bash
         env:
           EXPECTED_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
@@ -123,13 +124,23 @@ jobs:
             echo "::error::The trusted default branch does not contain the main CI control-plane guard."
             exit 1
           fi
-          timeout --signal=KILL 30s node "$guard" \
+          guard_report="$(timeout --signal=KILL 30s node "$guard" \
             --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
             --expected-base-commit "$EXPECTED_BASE_COMMIT" \
             --expected-candidate-commit "$EXPECTED_CANDIDATE_COMMIT" \
             --expected-merge-commit "$EXPECTED_MERGE_COMMIT" \
             --approved-commit "$APPROVED_MAIN_CI_CONTROL_COMMIT" \
-            --approved-tree "$APPROVED_MAIN_CI_CONTROL_TREE"
+            --approved-tree "$APPROVED_MAIN_CI_CONTROL_TREE")"
+          approved_exact_candidate="$(node -e '
+            const report = JSON.parse(process.argv[1]);
+            const allowed = new Set([
+              "no-main-ci-control-change",
+              "approved-exact-main-ci-control-change"
+            ]);
+            if (report.schemaVersion !== 1 || !allowed.has(report.result)) process.exit(1);
+            process.stdout.write(report.result === "approved-exact-main-ci-control-change" ? "true" : "false");
+          ' "$guard_report")"
+          echo "approved_exact_candidate=$approved_exact_candidate" >> "$GITHUB_OUTPUT"
 
       - name: Classify candidate data with trusted default-branch code
         id: classify
@@ -142,12 +153,20 @@ jobs:
             echo "::error::The default branch does not contain the trusted public-intake classifier."
             exit 1
           fi
-          mode="$(timeout --signal=KILL 30s node "$validator" --classify \
-            --base-root "$GITHUB_WORKSPACE/base" \
-            --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
-            --expected-base-commit "${{ github.event.pull_request.base.sha }}" \
-            --expected-candidate-commit "${{ github.event.pull_request.head.sha }}" \
-            --expected-merge-commit "${{ steps.candidate_fetch.outputs.merge_commit }}")"
+          if [[ "${{ steps.ci_control.outputs.approved_exact_candidate }}" == "true" ]]; then
+            # The trusted guard has already bound the complete candidate commit
+            # and tree. Keep the generic 256-file classifier limit unchanged for
+            # every other pull request, while routing this one frozen maintenance
+            # candidate to ordinary read-only PR CI without hydrating its blobs.
+            mode="builder-maintenance"
+          else
+            mode="$(timeout --signal=KILL 30s node "$validator" --classify \
+              --base-root "$GITHUB_WORKSPACE/base" \
+              --candidate-root "$GITHUB_WORKSPACE/candidate.git" \
+              --expected-base-commit "${{ github.event.pull_request.base.sha }}" \
+              --expected-candidate-commit "${{ github.event.pull_request.head.sha }}" \
+              --expected-merge-commit "${{ steps.candidate_fetch.outputs.merge_commit }}")"
+          fi
           case "$mode" in
             application|builder-maintenance|no-op) ;;
             *)

--- a/scripts/test/verify-main-ci-control-workflow.test.mjs
+++ b/scripts/test/verify-main-ci-control-workflow.test.mjs
@@ -45,6 +45,21 @@ test("trusted guard is bound to the exact audited main candidate commit and tree
   assert.match(workflow, /--approved-tree "\$APPROVED_MAIN_CI_CONTROL_TREE"/u);
 });
 
+test("only the exact approved control-plane candidate bypasses the generic changed-file classifier", () => {
+  const publicIntake = section(workflow, "  public-intake:");
+  assert.match(publicIntake, /id: ci_control/u);
+  assert.match(publicIntake, /guard_report="\$\(timeout --signal=KILL 30s node "\$guard"/u);
+  assert.match(
+    publicIntake,
+    /report\.result === "approved-exact-main-ci-control-change" \? "true" : "false"/u
+  );
+  assert.match(
+    publicIntake,
+    /if \[\[ "\$\{\{ steps\.ci_control\.outputs\.approved_exact_candidate \}\}" == "true" \]\]; then\s+# [^\n]+\n(?:\s+# [^\n]+\n){3}\s+mode="builder-maintenance"\s+else\s+mode="\$\(timeout --signal=KILL 30s node "\$validator" --classify/u
+  );
+  assert.doesNotMatch(publicIntake, /maximum-changed-files|maximumChangedFiles/u);
+});
+
 test("trusted production intake uses the exact current Node 24 LTS runtime", () => {
   const publicIntake = section(workflow, "  public-intake:");
   assert.match(


### PR DESCRIPTION
## Outcome

Allow the already approved Hookbuilder maintenance candidate to reach ordinary read-only PR CI without weakening the generic public-intake changed-file boundary.

## Exact scope

- production base: `2ba76646dd416de56f9b09ec91de47335ee6b37b`
- production patch commit: `27a3db3d7aa62351e592b6eadbcb0fc03a60d7e2`
- production patch tree: `1dc43c23ac841b3545d96eff712ad6297caeaa3a`
- approved candidate commit: `34e8c233e71ca0f2dcc68d40af70632b86b2a92a`
- approved candidate tree: `525b5524e2c12c84753f7ac46788f7f244dc9709`

## Fail-closed behavior

- the existing trusted guard still verifies the authenticated merge parents, exact candidate commit, exact candidate tree, and changed control-plane paths
- only the guard result `approved-exact-main-ci-control-change` emits the one-bit `approved_exact_candidate=true` output
- only that output routes to `builder-maintenance`
- every other pull request continues through the unchanged generic classifier and its 256-file limit
- no candidate maintenance blob is hydrated, parsed, or executed under `pull_request_target`; executable checks remain in ordinary read-only PR CI

## Validation

- `actionlint .github/workflows/verify-hook-builder.yml`: passed
- exact control-plane guard and workflow tests: 10 passed, 0 failed
- `git diff --check`: passed

This is a narrow control-plane routing patch for one immutable candidate. It does not grant acceptance, audit, deployment, release, or launch authority.
