### PR TITLE
Unify responsive UI and loading experience

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7447,6 +7447,188 @@ html[data-theme="dark"] .theme-toggle-sun {
   transform: translateY(-50%);
 }
 
+/* Classic controls share one milky material across closed, open and selected
+   states. Keep focus as a separate outline so adjacent control edges do not
+   visually merge when a listbox opens. */
+.launch-page[data-launch-model="classic-v3"] {
+  --classic-control-surface: rgba(255, 253, 249, 0.82);
+  --classic-control-surface-hover: rgba(255, 253, 249, 0.9);
+  --classic-control-surface-selected: rgba(255, 253, 249, 0.96);
+  --classic-control-border: rgba(16, 40, 64, 0.18);
+  --classic-control-border-strong: rgba(16, 40, 64, 0.3);
+  --classic-popover-surface: rgba(255, 253, 249, 0.98);
+}
+
+html[data-theme="dark"] .launch-page[data-launch-model="classic-v3"] {
+  --classic-control-surface: color-mix(
+    in srgb,
+    var(--brand-ivory) 13%,
+    transparent
+  );
+  --classic-control-surface-hover: color-mix(
+    in srgb,
+    var(--brand-ivory) 18%,
+    transparent
+  );
+  --classic-control-surface-selected: color-mix(
+    in srgb,
+    var(--brand-ivory) 24%,
+    transparent
+  );
+  --classic-control-border: color-mix(
+    in srgb,
+    var(--brand-ivory) 19%,
+    transparent
+  );
+  --classic-control-border-strong: color-mix(
+    in srgb,
+    var(--brand-ivory) 31%,
+    transparent
+  );
+  --classic-popover-surface: color-mix(
+    in srgb,
+    var(--brand-ivory) 24%,
+    rgb(1 1 3 / 0.86)
+  );
+}
+
+.launch-page[data-launch-model="classic-v3"] .classic-v3-fees,
+.launch-page[data-launch-model="classic-v3"] .classic-v3-reward-mode,
+.launch-page[data-launch-model="classic-v3"]
+  .classic-v3-initial-buy
+  .meme-dev-buy,
+.launch-page[data-launch-model="classic-v3"] .classic-v3-custody {
+  background: var(--classic-control-surface);
+  box-shadow: inset 0 0 0 1px var(--classic-control-border);
+}
+
+.launch-page[data-launch-model="classic-v3"] .launch-select-trigger,
+.launch-page[data-launch-model="classic-v3"] .classic-v3-address-field input,
+.launch-page[data-launch-model="classic-v3"] .classic-v3-split-row input,
+.launch-page[data-launch-model="classic-v3"] .classic-v3-custody input,
+.launch-page[data-launch-model="classic-v3"] .meme-dev-buy-input,
+.launch-page[data-launch-model="classic-v3"]
+  .classic-link-disclosure
+  summary {
+  background: var(--classic-control-surface);
+  border-color: var(--classic-control-border);
+}
+
+.launch-page[data-launch-model="classic-v3"]
+  .launch-select-trigger[aria-expanded="true"] {
+  background: var(--classic-control-surface-hover);
+  border-color: var(--classic-control-border-strong);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 12%, transparent);
+}
+
+.launch-page[data-launch-model="classic-v3"]
+  .launch-select-trigger:focus-visible,
+.launch-page[data-launch-model="classic-v3"]
+  .classic-v3-reward-mode
+  button:focus-visible {
+  border-color: var(--classic-control-border-strong);
+  box-shadow: none;
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.launch-page[data-launch-model="classic-v3"] .launch-select-menu {
+  -webkit-backdrop-filter: blur(28px) saturate(1.08);
+  backdrop-filter: blur(28px) saturate(1.08);
+  background: var(--classic-popover-surface);
+  border-color: var(--classic-control-border-strong);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 12%, transparent),
+    0 18px 44px rgb(0 0 0 / 0.34);
+  width: 100%;
+}
+
+.launch-page[data-launch-model="classic-v3"] .launch-select-option {
+  border-color: transparent;
+  min-height: 40px;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.launch-page[data-launch-model="classic-v3"]
+  .launch-select-option[aria-selected="true"] {
+  background: var(--classic-control-surface-selected);
+  color: var(--text);
+}
+
+.launch-page[data-launch-model="classic-v3"]
+  .launch-select-option[data-active="true"] {
+  background: var(--classic-control-surface-hover);
+  color: var(--text);
+}
+
+.launch-page[data-launch-model="classic-v3"]
+  .launch-select-option[aria-selected="true"][data-active="true"] {
+  background: var(--classic-control-surface-selected);
+}
+
+.launch-page[data-launch-model="classic-v3"]
+  .launch-select-option:focus-visible {
+  border-color: transparent;
+  box-shadow: none;
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
+.launch-page[data-launch-model="classic-v3"]
+  .classic-v3-reward-mode
+  > div {
+  background: var(--classic-control-surface);
+  border-color: var(--classic-control-border);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+}
+
+.launch-page[data-launch-model="classic-v3"]
+  .classic-v3-reward-mode
+  button.is-selected {
+  background: var(--classic-control-surface-selected);
+  box-shadow: inset 0 0 0 1px var(--classic-control-border);
+  color: var(--text);
+}
+
+.launch-page[data-launch-model="classic-v3"]
+  .classic-v3-initial-buy
+  .meme-dev-buy-input
+  button {
+  background: var(--classic-control-surface-selected);
+  color: var(--text);
+}
+
+.classic-link-disclosure-icon {
+  flex: none;
+  margin-inline-start: auto;
+  transition: transform 150ms var(--ease-out);
+}
+
+.classic-link-disclosure[open] .classic-link-disclosure-icon {
+  transform: rotate(180deg);
+}
+
+.classic-link-disclosure summary::after {
+  content: none !important;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .launch-page[data-launch-model="classic-v3"]
+    .classic-v3-reward-mode
+    button:not(.is-selected):hover {
+    background: var(--classic-control-surface-hover);
+    color: var(--text-soft);
+  }
+}
+
+@media (max-width: 520px) {
+  .launch-page[data-launch-model="classic-v3"] .launch-select-option {
+    min-height: 44px;
+  }
+}
+
 .deep-preset {
   background:
     linear-gradient(140deg, var(--accent-wash), transparent 48%),

--- a/app/globals.css
+++ b/app/globals.css
@@ -7627,6 +7627,19 @@ html[data-theme="dark"] .launch-page[data-launch-model="classic-v3"] {
   .launch-page[data-launch-model="classic-v3"] .launch-select-option {
     min-height: 44px;
   }
+
+  .launch-page[data-launch-model="classic-v3"] .launch-select-menu {
+    bottom: max(16px, env(safe-area-inset-bottom));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    inset-inline: 16px;
+    max-height: min(280px, calc(100dvh - 32px));
+    min-width: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    position: fixed;
+    top: auto;
+    width: auto;
+  }
 }
 
 .deep-preset {

--- a/app/interface.css
+++ b/app/interface.css
@@ -13,15 +13,15 @@
   --radius-control: 18px;
   --radius-control-inner: 14px;
   --radius-panel: 28px;
-  --liquid-glass-surface-background: oklch(0.94 0.012 76 / 0.135);
-  --liquid-glass-surface-background-strong: oklch(0.94 0.012 76 / 0.2);
-  --liquid-glass-inner-background: oklch(0.96 0.009 76 / 0.08);
-  --liquid-glass-control-background: oklch(0.96 0.009 76 / 0.11);
-  --liquid-glass-control-background-hover: oklch(0.96 0.009 76 / 0.19);
+  --liquid-glass-surface-background: oklch(0.94 0.012 76 / 0.18);
+  --liquid-glass-surface-background-strong: oklch(0.94 0.012 76 / 0.25);
+  --liquid-glass-inner-background: oklch(0.96 0.009 76 / 0.11);
+  --liquid-glass-control-background: oklch(0.96 0.009 76 / 0.15);
+  --liquid-glass-control-background-hover: oklch(0.96 0.009 76 / 0.22);
   --liquid-glass-border: oklch(0.96 0.009 76 / 0.19);
   --liquid-glass-border-strong: oklch(0.97 0.007 76 / 0.27);
   --liquid-glass-highlight: oklch(0.99 0.004 76 / 0.23);
-  --liquid-glass-backdrop: blur(24px) saturate(1.12);
+  --liquid-glass-backdrop: blur(20px) saturate(1.08);
   --liquid-glass-shadow:
     inset 0 1px 0 oklch(0.99 0.004 76 / 0.18),
     inset 0 -1px 0 oklch(0.08 0.018 264 / 0.24),
@@ -36,8 +36,8 @@
   --liquid-glass-inner-shadow:
     inset 0 1px 0 oklch(0.99 0.004 85 / 0.07),
     0 0 0 1px oklch(0.08 0.02 264 / 0.12);
-  --navigation-glass-background: oklch(0.16 0.025 264 / 0.8);
-  --navigation-glass-background-hover: oklch(0.24 0.027 264 / 0.74);
+  --navigation-glass-background: oklch(0.94 0.012 76 / 0.14);
+  --navigation-glass-background-hover: oklch(0.94 0.012 76 / 0.2);
   --navigation-glass-border: oklch(0.95 0.008 85 / 0.11);
   --navigation-glass-highlight: oklch(0.99 0.004 85 / 0.13);
   --navigation-glass-ink: var(--brand-ivory);
@@ -214,32 +214,6 @@ code,
   height: 100%;
   min-height: 0;
   overflow: hidden;
-}
-
-/* Keep the botanical edge detail atmospheric on the home scene without
- * competing with the launch copy and artwork. */
-.app-frame:has(.landing-page-root) .atmosphere-plant {
-  bottom: -320px;
-  opacity: 0.58;
-}
-
-body:not(:has(.landing-page-root)):not(:has([data-docs-shell]))
-  .atmosphere-plant {
-  opacity: 0.18;
-  bottom: -220px;
-}
-
-@media (max-width: 520px) {
-  .app-frame:has(.landing-page-root) .atmosphere-plant {
-    bottom: -112px;
-    opacity: 0.54;
-  }
-
-  body:not(:has(.landing-page-root)):not(:has([data-docs-shell]))
-    .atmosphere-plant {
-    bottom: -220px;
-    opacity: 0.2;
-  }
 }
 
 .site-header {
@@ -523,7 +497,7 @@ html[data-theme="dark"] .app-frame::before {
   height: var(--sparkle-size);
   opacity: 0.12;
   position: absolute;
-  transform: scale(0.72);
+  transform: none;
   width: var(--sparkle-size);
 }
 
@@ -902,23 +876,24 @@ html[data-theme="dark"] .app-frame::before {
 }
 
 .atmosphere-plant {
-  bottom: -42px;
+  bottom: -170px;
   display: block;
-  filter: saturate(1.18) brightness(1.04);
+  filter: saturate(1.08) brightness(0.88);
   height: auto;
-  opacity: 0.94;
+  opacity: 0.24;
   position: absolute;
-  transform: translate3d(0, 0, 0) rotate(0deg);
-  width: clamp(210px, 22vw, 330px);
+  width: clamp(190px, 20vw, 300px);
 }
 
 .atmosphere-plant-left {
-  left: max(-18px, calc((100vw - 1680px) / 2));
+  left: clamp(-120px, -7vw, -72px);
+  transform: rotate(-13deg);
   transform-origin: 54% 101%;
 }
 
 .atmosphere-plant-right {
-  right: max(-20px, calc((100vw - 1680px) / 2));
+  right: clamp(-120px, -7vw, -72px);
+  transform: rotate(13deg);
   transform-origin: 68% 101%;
 }
 
@@ -938,17 +913,14 @@ html[data-theme="dark"] .app-frame::before {
   62%,
   100% {
     opacity: 0.12;
-    transform: scale(0.72);
   }
 
   69% {
     opacity: 0.96;
-    transform: scale(1.42);
   }
 
   77% {
     opacity: 0.26;
-    transform: scale(0.9);
   }
 }
 
@@ -957,17 +929,14 @@ html[data-theme="dark"] .app-frame::before {
   38%,
   100% {
     opacity: 0.08;
-    transform: scale(0.68);
   }
 
   48% {
     opacity: 0.74;
-    transform: scale(1.18);
   }
 
   57% {
     opacity: 0.18;
-    transform: scale(0.84);
   }
 }
 
@@ -977,30 +946,27 @@ html[data-theme="dark"] .app-frame::before {
   47%,
   100% {
     opacity: 0.1;
-    transform: scale(0.7);
   }
 
   28% {
     opacity: 0.64;
-    transform: scale(1.12);
   }
 
   72% {
     opacity: 0.12;
-    transform: scale(0.76);
   }
 
   79% {
     opacity: 0.9;
-    transform: scale(1.34);
   }
 
   88% {
     opacity: 0.2;
-    transform: scale(0.86);
   }
 }
 
+/* Kept as stable motion contracts for older clients. The live night garden
+ * overrides both animations below so its botanical silhouettes stay fixed. */
 @keyframes atmosphere-plant-left {
   0%,
   100% {
@@ -1056,13 +1022,17 @@ html[data-theme="dark"] .app-frame::before {
   .atmosphere-plant-left {
     animation: atmosphere-plant-left 13.6s
       cubic-bezier(0.45, 0.05, 0.55, 0.95) -7.9s infinite;
-    will-change: transform;
   }
 
   .atmosphere-plant-right {
     animation: atmosphere-plant-right 11.9s
       cubic-bezier(0.45, 0.05, 0.55, 0.95) -3.1s infinite;
-    will-change: transform;
+  }
+
+  .atmosphere-plant-left,
+  .atmosphere-plant-right {
+    animation: none;
+    will-change: auto;
   }
 }
 
@@ -1077,17 +1047,17 @@ html[data-theme="dark"] .app-frame::before {
   }
 
   .atmosphere-plant {
-    bottom: -18px;
-    opacity: 0.92;
-    width: clamp(150px, 46vw, 184px);
+    bottom: -94px;
+    opacity: 0.22;
+    width: clamp(170px, 50vw, 210px);
   }
 
   .atmosphere-plant-left {
-    left: -38px;
+    left: -82px;
   }
 
   .atmosphere-plant-right {
-    right: -42px;
+    right: -86px;
   }
 }
 
@@ -2140,6 +2110,14 @@ body:has([data-docs-shell]) .site-header::before {
     animation: none;
     transform: none;
     will-change: auto;
+  }
+
+  .atmosphere-plant-left {
+    transform: rotate(-13deg);
+  }
+
+  .atmosphere-plant-right {
+    transform: rotate(13deg);
   }
 
   .theme-toggle-icons,

--- a/app/interface.css
+++ b/app/interface.css
@@ -2096,6 +2096,18 @@ body:has([data-docs-shell]) .site-header::before {
   }
 }
 
+/* Responsive navigation now expands from the header instead of occupying a
+ * fixed bottom rail. Keep only a small safe-area finish below route content. */
+@media (max-width: 960px) {
+  .app-frame > main {
+    padding-bottom: max(24px, env(safe-area-inset-bottom));
+  }
+
+  .app-frame:has(.landing-page-root) > main {
+    padding-bottom: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     transition: none;

--- a/components/create-guide.module.css
+++ b/components/create-guide.module.css
@@ -210,7 +210,7 @@
 
 .promptBox pre {
   color: var(--text);
-  font-family: var(--font-geist-mono), "SFMono-Regular", Consolas, monospace;
+  font-family: var(--font-plex-mono), "SFMono-Regular", Consolas, monospace;
   font-size: 13px;
   line-height: 1.55;
   margin: 0;

--- a/components/create-guide.module.css
+++ b/components/create-guide.module.css
@@ -1,0 +1,367 @@
+.entry {
+  display: flex;
+  justify-content: center;
+  margin-top: 12px;
+}
+
+.trigger {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 12px;
+  color: var(--text-soft);
+  display: inline-flex;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 560;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 12px;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 42%, transparent);
+  text-decoration-thickness: from-font;
+  text-underline-offset: 4px;
+  transition:
+    color 140ms var(--ease-out),
+    text-decoration-color 140ms var(--ease-out),
+    scale 140ms var(--ease-out);
+}
+
+.trigger:hover {
+  color: var(--text);
+  text-decoration-color: currentColor;
+}
+
+.trigger:active {
+  scale: 0.96;
+}
+
+.trigger:focus-visible,
+.closeButton:focus-visible,
+.copyButton:focus-visible,
+.links a:focus-visible,
+.promptBox pre:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.dialog {
+  -webkit-backdrop-filter: blur(30px) saturate(1.08);
+  backdrop-filter: blur(30px) saturate(1.08);
+  background: var(--liquid-glass-surface-background-strong);
+  border: 1px solid var(--liquid-glass-border-strong);
+  border-radius: 28px;
+  box-shadow:
+    inset 0 1px 0 var(--liquid-glass-highlight),
+    0 0 0 1px color-mix(in srgb, var(--liquid-glass-border) 52%, transparent),
+    0 28px 90px rgb(1 1 3 / 0.5);
+  color: var(--text);
+  height: auto;
+  margin: auto;
+  max-height: min(760px, calc(100dvh - 32px));
+  max-width: 760px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0;
+  width: calc(100% - 32px);
+}
+
+.dialog[open] {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.dialog::backdrop {
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  background: rgb(1 1 3 / 0.72);
+}
+
+.header {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) 44px;
+  padding: 24px 24px 16px;
+}
+
+.eyebrow {
+  color: var(--text-soft);
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  line-height: 1.35;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+
+.header h2 {
+  font-size: 30px;
+  font-weight: 590;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.closeButton {
+  align-items: center;
+  background: var(--liquid-glass-control-background);
+  border: 1px solid var(--liquid-glass-border);
+  border-radius: 14px;
+  color: var(--text-soft);
+  display: inline-flex;
+  height: 44px;
+  justify-content: center;
+  padding: 0;
+  transition:
+    background-color 140ms var(--ease-out),
+    color 140ms var(--ease-out),
+    scale 140ms var(--ease-out);
+  width: 44px;
+}
+
+.closeButton:hover {
+  background: var(--liquid-glass-control-background-hover);
+  color: var(--text);
+}
+
+.closeButton:active,
+.copyButton:active {
+  scale: 0.96;
+}
+
+.content {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0 24px calc(24px + env(safe-area-inset-bottom));
+  scrollbar-gutter: stable;
+}
+
+.lede {
+  color: var(--text-soft);
+  font-size: 16px;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 62ch;
+  text-wrap: pretty;
+}
+
+.steps {
+  display: grid;
+  gap: 32px;
+  list-style: none;
+  margin: 32px 0 0;
+  padding: 0;
+}
+
+.steps > li {
+  align-items: start;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 32px minmax(0, 1fr);
+}
+
+.stepNumber {
+  align-items: center;
+  background: var(--liquid-glass-inner-background);
+  border-radius: 10px;
+  color: var(--accent-strong);
+  display: inline-flex;
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  height: 32px;
+  justify-content: center;
+  width: 32px;
+}
+
+.steps h3 {
+  font-size: 18px;
+  font-weight: 620;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  margin: 2px 0 8px;
+  text-wrap: balance;
+}
+
+.steps p {
+  color: var(--text-soft);
+  font-size: 15px;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 65ch;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+
+.steps strong {
+  color: var(--text);
+  font-weight: 620;
+}
+
+.promptBox {
+  background: var(--liquid-glass-inner-background);
+  border-radius: 18px;
+  margin-top: 16px;
+  padding: 16px;
+}
+
+.promptBox pre {
+  color: var(--text);
+  font-family: var(--font-geist-mono), "SFMono-Regular", Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.copyButton {
+  align-items: center;
+  background: var(--liquid-glass-control-background);
+  border: 1px solid var(--liquid-glass-border);
+  border-radius: 12px;
+  color: var(--text);
+  display: inline-flex;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 620;
+  gap: 8px;
+  margin-top: 16px;
+  min-height: 44px;
+  padding: 8px 12px;
+  transition:
+    background-color 140ms var(--ease-out),
+    border-color 140ms var(--ease-out),
+    scale 140ms var(--ease-out);
+}
+
+.copyButton:hover {
+  background: var(--liquid-glass-control-background-hover);
+  border-color: var(--liquid-glass-border-strong);
+}
+
+.copyStatus {
+  color: var(--text-soft);
+  font-size: 13px !important;
+  line-height: 1.45 !important;
+  min-height: 19px;
+  margin-top: 8px !important;
+}
+
+.links {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  margin-top: 16px;
+}
+
+.links a {
+  align-items: center;
+  border-radius: 8px;
+  color: var(--accent-strong);
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 620;
+  gap: 7px;
+  min-height: 44px;
+  text-decoration-line: underline;
+  text-decoration-thickness: from-font;
+  text-underline-offset: 4px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .links a:hover {
+    color: var(--text);
+  }
+}
+
+@media (max-width: 520px) {
+  .entry {
+    margin-top: 8px;
+  }
+
+  .dialog {
+    border-radius: 22px;
+    max-height: calc(100dvh - 16px);
+    width: calc(100% - 16px);
+  }
+
+  .header {
+    gap: 16px;
+    padding: 20px 16px 14px;
+  }
+
+  .header h2 {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+
+  .content {
+    padding: 0 16px calc(20px + env(safe-area-inset-bottom));
+    scrollbar-gutter: auto;
+  }
+
+  .steps {
+    gap: 24px;
+    margin-top: 24px;
+  }
+
+  .steps > li {
+    gap: 12px;
+  }
+
+  .promptBox {
+    border-radius: 16px;
+    padding: 12px;
+  }
+
+  .links {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+}
+
+@media (max-width: 340px) {
+  .dialog {
+    border-radius: 18px;
+    max-height: calc(100dvh - 8px);
+    width: calc(100% - 8px);
+  }
+
+  .header,
+  .content {
+    padding-inline: 12px;
+  }
+
+  .steps > li {
+    grid-template-columns: 28px minmax(0, 1fr);
+  }
+
+  .stepNumber {
+    border-radius: 8px;
+    height: 28px;
+    width: 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trigger,
+  .closeButton,
+  .copyButton {
+    transition-duration: 0.01ms;
+  }
+}
+
+@media (forced-colors: active) {
+  .dialog,
+  .closeButton,
+  .copyButton {
+    border: 1px solid CanvasText;
+  }
+}

--- a/components/create-guide.tsx
+++ b/components/create-guide.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { Check, CircleHelp, Copy, ExternalLink, X } from "lucide-react";
+
+import styles from "@/components/create-guide.module.css";
+
+const BUILD_PROMPT = `Build a Uniswap v4 hook for Programmable. Start from the official Hookbuilder at https://github.com/0xprogrammable/hookbuilder. The token should [describe the behavior in plain words]. Keep the project limited to that behavior, add tests, run the local checks, and explain the results. Prepare the exact GitHub revision for Programmable review. Do not deploy, sign, or submit anything without asking me first.`;
+
+type CopyState = "idle" | "copied" | "failed";
+
+export function CreateGuide() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const resetTimerRef = useRef<number | null>(null);
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
+
+  function openGuide() {
+    const dialog = dialogRef.current;
+    if (!dialog || dialog.open) return;
+
+    setCopyState("idle");
+    dialog.showModal();
+    window.requestAnimationFrame(() => closeButtonRef.current?.focus());
+  }
+
+  function closeGuide() {
+    dialogRef.current?.close();
+  }
+
+  function handleDialogClose() {
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    }
+    setCopyState("idle");
+    window.requestAnimationFrame(() => triggerRef.current?.focus());
+  }
+
+  function handleDialogClick(event: ReactMouseEvent<HTMLDialogElement>) {
+    if (event.target === event.currentTarget) closeGuide();
+  }
+
+  async function copyPrompt() {
+    try {
+      if (!navigator.clipboard) throw new Error("Clipboard unavailable");
+      await navigator.clipboard.writeText(BUILD_PROMPT);
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = window.setTimeout(() => {
+      setCopyState("idle");
+      resetTimerRef.current = null;
+    }, 4_000);
+  }
+
+  return (
+    <div className={styles.entry}>
+      <button
+        ref={triggerRef}
+        className={styles.trigger}
+        type="button"
+        aria-haspopup="dialog"
+        aria-controls="create-guide-dialog"
+        onClick={openGuide}
+      >
+        <CircleHelp aria-hidden="true" size={17} strokeWidth={1.8} />
+        How does it work?
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        className={styles.dialog}
+        id="create-guide-dialog"
+        aria-labelledby="create-guide-title"
+        aria-describedby="create-guide-description"
+        onClick={handleDialogClick}
+        onClose={handleDialogClose}
+      >
+        <header className={styles.header}>
+          <div>
+            <p className={styles.eyebrow}>Create a token</p>
+            <h2 id="create-guide-title">Start with the right path</h2>
+          </div>
+          <button
+            ref={closeButtonRef}
+            className={styles.closeButton}
+            type="button"
+            aria-label="Close guide"
+            onClick={closeGuide}
+          >
+            <X aria-hidden="true" size={19} strokeWidth={1.8} />
+          </button>
+        </header>
+
+        <div className={styles.content}>
+          <p className={styles.lede} id="create-guide-description">
+            Classic uses Programmable&apos;s standard token setup. Custom Hook is
+            for behavior that needs its own Uniswap v4 hook.
+          </p>
+
+          <ol className={styles.steps}>
+            <li>
+              <span className={styles.stepNumber} aria-hidden="true">
+                1
+              </span>
+              <div>
+                <h3>Choose the launch path</h3>
+                <p>
+                  Choose <strong>Classic</strong> for a standard token. Choose
+                  <strong> Custom Hook</strong> when swaps or token behavior need
+                  custom logic.
+                </p>
+              </div>
+            </li>
+
+            <li>
+              <span className={styles.stepNumber} aria-hidden="true">
+                2
+              </span>
+              <div>
+                <h3>Describe the hook</h3>
+                <p>
+                  Use a coding assistant such as Codex or Claude Code. Replace the
+                  bracketed sentence, then send this prompt.
+                </p>
+                <div className={styles.promptBox}>
+                  <pre tabIndex={0}>{BUILD_PROMPT}</pre>
+                  <button
+                    className={styles.copyButton}
+                    type="button"
+                    onClick={() => void copyPrompt()}
+                  >
+                    {copyState === "copied" ? (
+                      <Check aria-hidden="true" size={17} strokeWidth={2} />
+                    ) : (
+                      <Copy aria-hidden="true" size={17} strokeWidth={1.8} />
+                    )}
+                    {copyState === "copied" ? "Copied" : "Copy prompt"}
+                  </button>
+                  <p className={styles.copyStatus} role="status" aria-live="polite">
+                    {copyState === "failed"
+                      ? "Copy failed. Select the prompt and copy it manually."
+                      : ""}
+                  </p>
+                </div>
+              </div>
+            </li>
+
+            <li>
+              <span className={styles.stepNumber} aria-hidden="true">
+                3
+              </span>
+              <div>
+                <h3>Review it locally</h3>
+                <p>
+                  Ask the coding assistant to explain the changes, run the local
+                  checks, and fix any failures. Keep the exact commit you want
+                  reviewed on GitHub.
+                </p>
+              </div>
+            </li>
+
+            <li>
+              <span className={styles.stepNumber} aria-hidden="true">
+                4
+              </span>
+              <div>
+                <h3>Submit the exact revision</h3>
+                <p>
+                  Hookbuilder prepares the project. Submit a Launch records the
+                  exact revision for Programmable review. After review and release
+                  binding, the approved project can continue through the Custom
+                  Hook launch here.
+                </p>
+                <div className={styles.links}>
+                  <a
+                    href="https://github.com/0xprogrammable/hookbuilder/releases/latest"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Open Hookbuilder
+                    <ExternalLink aria-hidden="true" size={15} strokeWidth={1.8} />
+                  </a>
+                  <a
+                    href="https://github.com/0xprogrammable/submit-launch"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Open Submit a Launch
+                    <ExternalLink aria-hidden="true" size={15} strokeWidth={1.8} />
+                  </a>
+                </div>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </dialog>
+    </div>
+  );
+}

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -158,6 +158,10 @@
     box-shadow 180ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
+.runnersIntro :global(.token-filter summary::marker) {
+  content: "";
+}
+
 .runnersIntro :global(.token-filter[open] summary) {
   background: var(--explore-glass-strong);
   border-color: rgba(255, 253, 249, 0.34);
@@ -525,16 +529,15 @@
 }
 
 .skeletonBody {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  min-height: 162px;
-  padding: 22px 12px 10px;
+  min-height: 118px;
 }
 
 .skeletonTitle,
 .skeletonDescription,
-.skeletonMeta {
+.skeletonDescriptionShort,
+.skeletonCategory,
+.skeletonMeta,
+.skeletonSocial {
   background: rgba(255, 253, 249, 0.08);
   border-radius: 6px;
   display: block;
@@ -551,10 +554,33 @@
   width: 82%;
 }
 
+.skeletonDescriptionShort {
+  height: 12px;
+  margin-top: 8px;
+  width: 64%;
+}
+
+.skeletonMetaRow {
+  flex-wrap: nowrap;
+  gap: 8px;
+}
+
+.skeletonCategory {
+  height: 10px;
+  margin-inline-start: 4px;
+  width: 46px;
+}
+
 .skeletonMeta {
   height: 10px;
-  margin-block: auto 16px;
-  width: 38%;
+  width: 72px;
+}
+
+.skeletonSocial {
+  border-radius: 50%;
+  height: 24px;
+  margin-inline-start: auto;
+  width: 24px;
 }
 
 .messageState {
@@ -882,18 +908,22 @@
   }
 
   .skeletonCard {
+    display: flex;
+  }
+
+  .skeletonHitArea {
     display: grid;
     grid-template-columns: 112px minmax(0, 1fr);
   }
 
-  .skeletonCard .skeletonArt {
+  .skeletonHitArea .skeletonArt {
     align-self: start;
     width: 112px;
   }
 
   .skeletonBody {
     min-height: 112px;
-    padding: 16px;
+    padding: 16px 12px 8px 16px;
   }
 
   .emptyState {
@@ -934,12 +964,12 @@
   }
 
   .runnerHitArea,
-  .skeletonCard {
+  .skeletonHitArea {
     grid-template-columns: 104px minmax(0, 1fr);
   }
 
   .runnerArt,
-  .skeletonCard .skeletonArt {
+  .skeletonHitArea .skeletonArt {
     width: 104px;
   }
 
@@ -996,12 +1026,12 @@
   }
 
   .runnerHitArea,
-  .skeletonCard {
+  .skeletonHitArea {
     grid-template-columns: 96px minmax(0, 1fr);
   }
 
   .runnerArt,
-  .skeletonCard .skeletonArt {
+  .skeletonHitArea .skeletonArt {
     width: 96px;
   }
 
@@ -1020,6 +1050,52 @@
 
   .runnerSocials {
     justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .revealedGrid .runnerCard {
+    animation: explore-card-reveal 440ms cubic-bezier(0.32, 0.72, 0, 1) both;
+  }
+
+  .revealedGrid .runnerCard:nth-child(2) {
+    animation-delay: 45ms;
+  }
+
+  .revealedGrid .runnerCard:nth-child(3),
+  .revealedGrid .runnerCard:nth-child(n + 4) {
+    animation-delay: 90ms;
+  }
+
+  .skeletonArt,
+  .skeletonTitle,
+  .skeletonDescription,
+  .skeletonDescriptionShort,
+  .skeletonCategory,
+  .skeletonMeta,
+  .skeletonSocial {
+    animation: explore-skeleton-breathe 1.2s cubic-bezier(0.32, 0.72, 0, 1)
+      infinite alternate;
+  }
+}
+
+@keyframes explore-card-reveal {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes explore-skeleton-breathe {
+  from {
+    opacity: 0.56;
+  }
+
+  to {
+    opacity: 1;
   }
 }
 

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1105,11 +1105,18 @@ function ExploreGridSkeleton() {
           key={index}
           aria-hidden="true"
         >
-          <div className={`${styles.runnerArt} ${styles.skeletonArt}`} />
-          <div className={styles.skeletonBody}>
-            <span className={styles.skeletonTitle} />
-            <span className={styles.skeletonDescription} />
+          <div className={`${styles.runnerHitArea} ${styles.skeletonHitArea}`}>
+            <div className={`${styles.runnerArt} ${styles.skeletonArt}`} />
+            <div className={`${styles.runnerBody} ${styles.skeletonBody}`}>
+              <span className={styles.skeletonTitle} />
+              <span className={styles.skeletonDescription} />
+              <span className={styles.skeletonDescriptionShort} />
+            </div>
+          </div>
+          <div className={`${styles.runnerMeta} ${styles.skeletonMetaRow}`}>
+            <span className={styles.skeletonCategory} />
             <span className={styles.skeletonMeta} />
+            <span className={styles.skeletonSocial} />
           </div>
         </article>
       ))}
@@ -1494,7 +1501,10 @@ export function ExploreView() {
     }
 
     return (
-      <div className={styles.runnerGrid}>
+      <div
+        className={`${styles.runnerGrid} ${styles.revealedGrid}`}
+        key={displayState.contentKey}
+      >
         {cards.map((token, index) => {
           const href = token.tokenAddress
             ? `/token/${token.tokenAddress}`

--- a/components/hookathon-page.module.css
+++ b/components/hookathon-page.module.css
@@ -188,7 +188,7 @@
 
 @media (max-width: 720px) {
   .page {
-    padding: 12px 16px calc(104px + env(safe-area-inset-bottom));
+    padding: 12px 16px max(32px, env(safe-area-inset-bottom));
   }
 
   .shell {

--- a/components/hookathon-page.module.css
+++ b/components/hookathon-page.module.css
@@ -3,13 +3,19 @@
   color: var(--brand-ivory);
   min-height: calc(100svh - var(--header-height));
   min-width: 0;
+  padding: clamp(16px, 2.4vw, 30px) 32px 40px;
   position: relative;
 }
 
 .shell {
+  background: var(--liquid-glass-surface-background-strong);
+  border-color: var(--liquid-glass-border);
+  border-radius: 28px;
+  box-shadow: var(--liquid-glass-shadow);
   margin: 0 auto;
-  max-width: var(--page-width);
-  padding: 8px 32px 16px;
+  max-width: 1180px;
+  overflow: hidden;
+  padding: 8px 40px 20px;
   width: 100%;
 }
 
@@ -181,12 +187,17 @@
 }
 
 @media (max-width: 720px) {
+  .page {
+    padding: 12px 16px calc(104px + env(safe-area-inset-bottom));
+  }
+
   .shell {
-    padding: 0 20px calc(104px + env(safe-area-inset-bottom));
+    border-radius: 20px;
+    padding: 0 18px 16px;
   }
 
   .hero {
-    min-height: 288px;
+    min-height: 272px;
     padding: 32px 0;
   }
 
@@ -252,8 +263,13 @@
 }
 
 @media (max-width: 360px) {
+  .page {
+    padding-inline: 12px;
+  }
+
   .shell {
-    padding-inline: 16px;
+    border-radius: 18px;
+    padding-inline: 14px;
   }
 
   .prizeSplit {

--- a/components/hookathon-page.tsx
+++ b/components/hookathon-page.tsx
@@ -18,7 +18,7 @@ export function HookathonPage({ initialNowMs }: HookathonPageProps) {
       className={`${styles.page} hookathon-root`}
       aria-labelledby="hookathon-title"
     >
-      <div className={styles.shell}>
+      <div className={`${styles.shell} liquid-glass-surface`}>
         <header className={styles.hero}>
           <h1 id="hookathon-title">{hookathonConfig.name}</h1>
           <HookathonCountdown
@@ -61,10 +61,7 @@ export function HookathonPage({ initialNowMs }: HookathonPageProps) {
           </p>
         </section>
 
-        <section
-          className={styles.judging}
-          aria-labelledby="hookathon-judging"
-        >
+        <section className={styles.judging} aria-labelledby="hookathon-judging">
           <h2 id="hookathon-judging">Judging</h2>
           <ul aria-label="Judging criteria">
             {hookathonConfig.judging.criteria.map((criterion) => (

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -628,11 +628,28 @@
   }
 
   .footer {
-    min-height: 48px;
+    min-height: 44px;
   }
 
   .footerIcons {
-    display: none;
+    display: flex;
+    gap: 0;
+  }
+
+  .socialLink,
+  .footer a {
+    min-height: 44px;
+  }
+
+  .socialLink {
+    height: 44px;
+    width: 44px;
+  }
+
+  .socialLink svg,
+  .socialLogo {
+    height: 28px;
+    width: 28px;
   }
 }
 

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -30,14 +30,15 @@
 }
 
 .panel {
-  background: rgba(8, 5, 18, 0.3);
+  background: rgba(232, 217, 237, 0.11);
   border: 0;
   border-radius: clamp(20px, 2.2vw, 32px);
   box-shadow:
-    inset 0 0 86px rgba(181, 109, 208, 0.12),
-    inset 0 -42px 110px rgba(4, 2, 15, 0.28),
-    0 28px 90px rgba(0, 0, 0, 0.52),
-    0 10px 46px rgba(116, 64, 156, 0.12);
+    inset 0 0 0 1px rgba(255, 252, 249, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    inset 0 -44px 108px rgba(40, 17, 52, 0.16),
+    0 28px 90px rgba(0, 0, 0, 0.48),
+    0 10px 46px rgba(116, 64, 156, 0.1);
   display: flex;
   flex-direction: column;
   height: min(82svh, 780px);
@@ -46,103 +47,41 @@
   overflow: visible;
   position: relative;
   width: 100%;
-  -webkit-backdrop-filter: blur(28px) saturate(1.12);
-  backdrop-filter: blur(28px) saturate(1.12);
+  -webkit-backdrop-filter: blur(34px) saturate(0.94) brightness(1.06);
+  backdrop-filter: blur(34px) saturate(0.94) brightness(1.06);
 }
 
 .panel::after {
-  display: none;
-}
-
-.panelArt,
-.panelTint {
-  border: 0;
+  content: "";
   inset: 0;
   pointer-events: none;
   position: absolute;
-}
-
-.panelArt {
-  border-radius: inherit;
-  overflow: hidden;
-  z-index: 0;
-}
-
-.panelTint {
-  border-radius: inherit;
-  overflow: hidden;
-}
-
-.panelPicture {
-  display: block;
-  inset: 0;
-  position: absolute;
-}
-
-.panelArt::after {
-  background: linear-gradient(
-    90deg,
-    rgba(1, 1, 3, 0.34),
-    rgba(1, 1, 3, 0.18) 58%,
-    rgba(1, 1, 3, 0.28)
-  );
-  content: "";
-  inset: 0;
-  position: absolute;
-}
-
-.panelArt img {
-  filter: blur(1.5px) saturate(0.88) brightness(0.78);
-  object-fit: cover;
-  object-position: center 55%;
-  opacity: 0.9;
-  transform: scale(1.08);
-}
-
-.panelTint {
-  background:
-    linear-gradient(
-      180deg,
-      rgba(4, 2, 15, 0.12),
-      rgba(8, 3, 20, 0.02) 42%,
-      rgba(4, 2, 15, 0.28)
-    ),
-    radial-gradient(
-      circle at 22% 78%,
-      rgba(198, 102, 156, 0.18),
-      transparent 32%
-    ),
-    radial-gradient(
-      circle at 78% 48%,
-      rgba(119, 91, 177, 0.16),
-      transparent 34%
-    );
-  z-index: 1;
+  z-index: 2;
 }
 
 .flowerLeft,
 .flowerRight {
-  bottom: -18%;
-  filter: saturate(0.92) brightness(0.88);
+  bottom: -15%;
+  filter: saturate(0.96) brightness(0.92);
   height: auto;
   max-width: none;
-  opacity: 0.7;
+  opacity: 0.76;
   pointer-events: none;
   position: absolute;
-  width: clamp(240px, 30vw, 420px);
+  width: clamp(260px, 24vw, 360px);
   z-index: 5;
 }
 
 .flowerLeft {
-  left: -14%;
-  transform: translate3d(-2%, 2%, 0) rotate(-14deg);
-  transform-origin: 54% 100%;
+  left: -16%;
+  transform: translate3d(-4%, 3%, 0) rotate(36deg);
+  transform-origin: 50% 100%;
 }
 
 .flowerRight {
-  right: -15%;
-  transform: translate3d(2%, 2%, 0) scaleX(-1) rotate(13deg);
-  transform-origin: 54% 100%;
+  right: -16%;
+  transform: translate3d(4%, 3%, 0) rotate(-36deg);
+  transform-origin: 50% 100%;
 }
 
 .panelHeader,
@@ -315,7 +254,7 @@
   display: block;
   font-size: clamp(58px, 7.2vw, 108px);
   font-weight: 560;
-  letter-spacing: -0.045em;
+  letter-spacing: -0.035em;
   line-height: 0.9;
   margin: 0;
   max-width: none;
@@ -535,8 +474,8 @@
   .scene {
     padding-block: max(24px, env(safe-area-inset-top))
       max(24px, env(safe-area-inset-bottom));
-    padding-inline: max(18px, env(safe-area-inset-left))
-      max(18px, env(safe-area-inset-right));
+    padding-inline: max(clamp(18px, 5.6vw, 24px), env(safe-area-inset-left))
+      max(clamp(18px, 5.6vw, 24px), env(safe-area-inset-right));
   }
 
   .panel {
@@ -545,17 +484,19 @@
 
   .flowerLeft,
   .flowerRight {
-    bottom: -9%;
-    opacity: 0.58;
-    width: 56vw;
+    bottom: -12%;
+    opacity: 0.66;
+    width: clamp(160px, 52vw, 220px);
   }
 
   .flowerLeft {
-    left: -34%;
+    left: -52%;
+    transform: translate3d(-3%, 2%, 0) rotate(48deg);
   }
 
   .flowerRight {
-    right: -34%;
+    right: -52%;
+    transform: translate3d(3%, 2%, 0) rotate(-48deg);
   }
 
   .heroCopy {
@@ -564,7 +505,7 @@
 
   .hero h1 {
     font-size: clamp(32px, 9.2vw, 44px);
-    letter-spacing: -0.04em;
+    letter-spacing: -0.025em;
     line-height: 0.96;
   }
 
@@ -696,11 +637,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .panelArt img {
-    filter: blur(6px) saturate(0.86) brightness(0.76);
-    transform: scale(1.08);
-  }
-
   .primaryAction,
   .secondaryAction,
   .footer a {

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -14,21 +14,6 @@ export function LandingPage() {
     <article className={`${styles.page} landing-page-root`}>
       <div className={styles.scene}>
         <section className={styles.panel} aria-labelledby="landing-title">
-          <div className={styles.panelArt} aria-hidden="true">
-            <picture className={styles.panelPicture}>
-              <source
-                media="(max-width: 760px)"
-                srcSet="/brand/atmosphere/night-sky-botanical-mobile-v2.avif"
-              />
-              <Image
-                src="/brand/atmosphere/night-sky-botanical-desktop-v2-1920.avif"
-                alt=""
-                fill
-                priority
-                sizes="(max-width: 760px) 100vw, 82vw"
-              />
-            </picture>
-          </div>
           <Image
             className={styles.flowerLeft}
             src="/brand/atmosphere/programmable-botanical-left-v2.webp"
@@ -47,7 +32,6 @@ export function LandingPage() {
             height={1536}
             sizes="(max-width: 760px) 35vw, 24vw"
           />
-          <div className={styles.panelTint} aria-hidden="true" />
 
           <header className={styles.panelHeader}>
             <Link
@@ -78,7 +62,7 @@ export function LandingPage() {
               </h1>
               <nav className={styles.actions} aria-label="Get started">
                 <Link className={styles.primaryAction} href="/launch">
-                  Create a token <span aria-hidden="true">↗</span>
+                  Create a token
                 </Link>
                 <Link className={styles.secondaryAction} href="/explore">
                   Explore tokens

--- a/components/launch-builder.tsx
+++ b/components/launch-builder.tsx
@@ -2793,6 +2793,12 @@ function TokenStep({
             <summary>
               <span>Project links</span>
               <small>Optional</small>
+              <ChevronDown
+                aria-hidden="true"
+                className="classic-link-disclosure-icon"
+                size={17}
+                strokeWidth={1.9}
+              />
             </summary>
             <div className="classic-link-fields">
               <label className="field">

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -13,6 +13,7 @@ import {
 import { ArrowLeft, ArrowRight } from "lucide-react";
 
 import { XBrandIcon } from "@/components/brand-icons";
+import { CreateGuide } from "@/components/create-guide";
 import launchExperience from "@/components/launch-experience.module.css";
 import { isConfiguredClassicV3ReleaseReady } from "@/lib/classic-v3-release";
 import { resolveImplementedLaunchModel } from "@/lib/launch-model-gating";
@@ -186,6 +187,7 @@ export function LaunchModelPicker({
         className={`launch-model-heading ${launchExperience.pickerHeading}`}
       >
         <h1>Choose your launch model</h1>
+        <CreateGuide />
       </header>
 
       <div className={`launch-model-grid ${launchExperience.modelGrid}`}>

--- a/components/navigation-icons.tsx
+++ b/components/navigation-icons.tsx
@@ -1,0 +1,13 @@
+import { Menu, X } from "lucide-react";
+
+type NavigationIconProps = {
+  className?: string;
+};
+
+export function NavigationMenuIcon({ className }: NavigationIconProps) {
+  return <Menu aria-hidden="true" className={className} strokeWidth={1.8} />;
+}
+
+export function NavigationCloseIcon({ className }: NavigationIconProps) {
+  return <X aria-hidden="true" className={className} strokeWidth={1.8} />;
+}

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -61,14 +61,10 @@
   height: 56px;
   justify-content: center;
   overflow: hidden;
-  outline: 1px solid color-mix(in srgb, black 9%, transparent);
+  outline: 1px solid var(--liquid-glass-border);
   outline-offset: -1px;
   position: relative;
   width: 56px;
-}
-
-:global(html[data-theme="dark"]) .avatar {
-  outline-color: color-mix(in srgb, white 10%, transparent);
 }
 
 .avatar img {
@@ -936,15 +932,11 @@
   border-radius: 10px;
   flex: none;
   height: 42px;
-  outline: 1px solid color-mix(in srgb, black 9%, transparent);
+  outline: 1px solid var(--liquid-glass-border);
   outline-offset: -1px;
   overflow: hidden;
   position: relative;
   width: 42px;
-}
-
-:global(html[data-theme="dark"]) .claimArt {
-  outline-color: color-mix(in srgb, white 10%, transparent);
 }
 
 .claimArt img {
@@ -1856,44 +1848,7 @@
   }
 }
 
-/* Quiet, borderless night surfaces. Controls keep their own boundaries and
- * focus rings; large layout containers use depth and spacing instead. */
-.connectCard,
-.profileWorkspace,
-.sessionLoadingWorkspace {
-  border: 0 !important;
-  box-shadow: 0 28px 78px rgb(0 0 0 / 0.34) !important;
-}
-
 .connectCard p,
 .launchesHeader p {
   display: none;
-}
-
-.heroEditing,
-.customProjects,
-.customProjectCard,
-.launchesPanel,
-.claimablePanel,
-.claimDialogSurface {
-  border-color: transparent;
-  box-shadow: 0 20px 56px rgb(0 0 0 / 0.2);
-}
-
-.launchRow {
-  border-color: transparent;
-}
-
-.avatar,
-.claimArt {
-  outline: 0;
-}
-
-.feeComposition {
-  border: 0;
-}
-
-.claimDialogGroup + .claimDialogGroup {
-  border-block-start: 0;
-  padding-block-start: 0;
 }

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { formatUnits, parseUnits, type Hex } from "viem";
 import {
   useCallback,
@@ -3854,7 +3855,7 @@ function ProfileAccountWorkspace({
                     setClaimPage(Math.max(1, claimPageData.currentPage - 1))
                   }
                 >
-                  <span aria-hidden="true">←</span>
+                  <ChevronLeft aria-hidden="true" size={17} strokeWidth={1.8} />
                 </button>
                 <span aria-live="polite" aria-atomic="true">
                   {claimPageData.currentPage} / {claimPageData.totalPages}
@@ -3874,7 +3875,7 @@ function ProfileAccountWorkspace({
                     )
                   }
                 >
-                  <span aria-hidden="true">→</span>
+                  <ChevronRight aria-hidden="true" size={17} strokeWidth={1.8} />
                 </button>
               </nav>
             ) : null}
@@ -4507,7 +4508,7 @@ function ProfileClaimDialog({
             aria-label="Close claim rewards"
             onClick={onClose}
           >
-            <span aria-hidden="true">×</span>
+            <X aria-hidden="true" size={18} strokeWidth={1.8} />
           </button>
         </header>
 

--- a/components/site-navigation.module.css
+++ b/components/site-navigation.module.css
@@ -1,0 +1,258 @@
+.menuButton,
+.mobileSheet {
+  display: none;
+}
+
+@media (max-width: 60rem) {
+  .siteHeader.siteHeader {
+    height: auto;
+    min-height: var(--header-height);
+  }
+
+  .headerInner.headerInner {
+    grid-template-columns: minmax(44px, 1fr) auto;
+  }
+
+  .headerActions.headerActions {
+    gap: 8px;
+  }
+
+  .headerSocials.headerSocials {
+    display: none;
+  }
+
+  .menuButton {
+    align-items: center;
+    -webkit-backdrop-filter: var(--control-glass-backdrop);
+    backdrop-filter: var(--control-glass-backdrop);
+    background: var(--control-glass-background);
+    border: 1px solid var(--control-glass-border);
+    border-radius: var(--radius-control);
+    box-shadow: var(--liquid-glass-control-shadow);
+    color: var(--navigation-glass-ink);
+    display: inline-flex;
+    flex: none;
+    font-family: var(--font-instrument), sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    gap: 8px;
+    height: 44px;
+    justify-content: center;
+    line-height: 1;
+    min-width: 80px;
+    padding: 0 12px;
+    transition:
+      background-color 180ms cubic-bezier(0.32, 0.72, 0, 1),
+      border-color 180ms cubic-bezier(0.32, 0.72, 0, 1),
+      box-shadow 180ms cubic-bezier(0.32, 0.72, 0, 1),
+      transform 180ms cubic-bezier(0.32, 0.72, 0, 1);
+  }
+
+  .menuButton:active {
+    transform: scale(0.96);
+  }
+
+  .menuButton:focus-visible {
+    box-shadow: 0 0 0 5px rgba(3, 8, 24, 0.86);
+    outline: 2px solid var(--brand-ivory);
+    outline-offset: 2px;
+  }
+
+  .menuIcon {
+    display: block;
+    height: 18px;
+    position: relative;
+    width: 18px;
+  }
+
+  .menuIcon svg {
+    height: 18px;
+    inset: 0;
+    position: absolute;
+    transition:
+      filter 200ms cubic-bezier(0.2, 0, 0, 1),
+      opacity 180ms cubic-bezier(0.2, 0, 0, 1),
+      transform 200ms cubic-bezier(0.2, 0, 0, 1);
+    width: 18px;
+  }
+
+  .iconVisible {
+    filter: blur(0);
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .iconHidden {
+    filter: blur(4px);
+    opacity: 0;
+    transform: scale(0.25);
+  }
+
+  .mobileSheet {
+    display: block;
+    margin: 0 auto;
+    max-height: 0;
+    max-width: 60rem;
+    opacity: 0;
+    overflow: hidden;
+    padding-inline-end: max(12px, env(safe-area-inset-right));
+    padding-inline-start: max(12px, env(safe-area-inset-left));
+    pointer-events: none;
+    transform: translateY(-8px);
+    transition:
+      max-height 300ms cubic-bezier(0.32, 0.72, 0, 1),
+      opacity 180ms cubic-bezier(0.32, 0.72, 0, 1),
+      transform 300ms cubic-bezier(0.32, 0.72, 0, 1),
+      visibility 0s linear 300ms;
+    visibility: hidden;
+    width: 100%;
+  }
+
+  .mobileSheetOpen {
+    margin-bottom: 12px;
+    max-height: 128px;
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+    transition:
+      max-height 300ms cubic-bezier(0.32, 0.72, 0, 1),
+      opacity 180ms cubic-bezier(0.32, 0.72, 0, 1),
+      transform 300ms cubic-bezier(0.32, 0.72, 0, 1),
+      visibility 0s linear 0s;
+    visibility: visible;
+  }
+
+  .mobileSheetSurface {
+    -webkit-backdrop-filter: blur(24px) saturate(1.12);
+    backdrop-filter: blur(24px) saturate(1.12);
+    background: var(--liquid-glass-surface-background-strong);
+    border: 1px solid var(--liquid-glass-border);
+    border-radius: 20px;
+    box-shadow: var(--liquid-glass-shadow);
+    padding: 8px;
+  }
+
+  .mobileSheet.mobileSheet :global(.mobile-nav) {
+    align-items: center;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    bottom: auto;
+    box-shadow: none;
+    display: grid;
+    gap: 4px;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    height: auto;
+    inset: auto;
+    max-width: none;
+    min-width: 0;
+    padding: 0;
+    position: static;
+    width: 100%;
+  }
+
+  .mobileSheet.mobileSheet :global(.mobile-nav a) {
+    align-items: center;
+    background: transparent;
+    border-radius: 12px;
+    color: var(--navigation-glass-ink-muted);
+    display: flex;
+    font-family: var(--font-instrument), sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    justify-content: center;
+    line-height: 1;
+    min-height: 48px;
+    min-width: 0;
+    padding: 0 8px;
+    text-align: center;
+    text-shadow: none;
+    transition:
+      background-color 160ms cubic-bezier(0.32, 0.72, 0, 1),
+      color 160ms cubic-bezier(0.32, 0.72, 0, 1),
+      transform 160ms cubic-bezier(0.32, 0.72, 0, 1);
+  }
+
+  .mobileSheet.mobileSheet :global(.mobile-nav a::before) {
+    display: none;
+  }
+
+  .mobileSheet.mobileSheet :global(.mobile-nav a.active) {
+    background: var(--accent-soft);
+    color: var(--navigation-glass-ink);
+    font-weight: 600;
+  }
+
+  .mobileSheet.mobileSheet :global(.mobile-nav a:active) {
+    transform: scale(0.96);
+  }
+
+  .mobileSheet.mobileSheet :global(.mobile-nav a:focus-visible) {
+    box-shadow: none;
+    outline: 2px solid var(--brand-ivory);
+    outline-offset: -2px;
+  }
+}
+
+@media (max-width: 36rem) {
+  .mobileSheetOpen {
+    max-height: 184px;
+  }
+
+  .mobileSheet.mobileSheet :global(.mobile-nav) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 23.125rem) {
+  .menuButton {
+    min-width: 44px;
+    padding: 0;
+    width: 44px;
+  }
+
+  .menuButton > span:last-child {
+    display: none;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) and (max-width: 60rem) {
+  .menuButton:hover {
+    background: var(--control-glass-background-hover);
+    border-color: var(--liquid-glass-border-strong);
+  }
+
+  .mobileSheet.mobileSheet :global(.mobile-nav a:hover) {
+    background: var(--control-glass-background-hover);
+    color: var(--navigation-glass-ink);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .menuButton,
+  .menuIcon svg,
+  .mobileSheet,
+  .mobileSheetOpen,
+  .mobileSheet.mobileSheet :global(.mobile-nav a) {
+    transition-duration: 0.01ms;
+  }
+
+  .mobileSheet {
+    transform: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .menuButton,
+  .mobileSheetSurface {
+    border-color: CanvasText;
+    box-shadow: none;
+  }
+
+  .menuButton:focus-visible,
+  .mobileSheet.mobileSheet :global(.mobile-nav a:focus-visible) {
+    outline-color: Highlight;
+  }
+}

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -4,13 +4,16 @@ import { useEffect, useId, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Menu, X } from "lucide-react";
 import {
   DiscordBrandIcon,
   DuneBrandIcon,
   GitHubBrandIcon,
   XBrandIcon,
 } from "@/components/brand-icons";
+import {
+  NavigationCloseIcon,
+  NavigationMenuIcon,
+} from "@/components/navigation-icons";
 import { WalletButton } from "@/components/wallet-provider";
 import styles from "@/components/site-navigation.module.css";
 
@@ -167,13 +170,11 @@ export function SiteHeader() {
             onClick={() => setMenuPath(menuOpen ? null : pathname)}
           >
             <span className={styles.menuIcon} aria-hidden="true">
-              <Menu
+              <NavigationMenuIcon
                 className={menuOpen ? styles.iconHidden : styles.iconVisible}
-                strokeWidth={1.8}
               />
-              <X
+              <NavigationCloseIcon
                 className={menuOpen ? styles.iconVisible : styles.iconHidden}
-                strokeWidth={1.8}
               />
             </span>
             <span>Menu</span>
@@ -186,7 +187,7 @@ export function SiteHeader() {
           menuOpen ? styles.mobileSheetOpen : ""
         }`}
       >
-        <div className={styles.mobileSheetSurface}>
+        <div className={styles.mobileSheetSurface} id={menuId}>
           <MobileNavigation
             id={menuId}
             open={menuOpen}
@@ -219,12 +220,7 @@ export function MobileNavigation({
   if (!id) return null;
 
   return (
-    <nav
-      id={id}
-      className="mobile-nav"
-      aria-label="Primary navigation"
-      aria-hidden={!open}
-    >
+    <nav className="mobile-nav" aria-label="Primary navigation">
       {mobileNavItems.map((item) => {
         const current = isCurrent(pathname, item.href);
         return (

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useEffect, useId, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { Menu, X } from "lucide-react";
 import {
   DiscordBrandIcon,
   DuneBrandIcon,
@@ -10,6 +12,7 @@ import {
   XBrandIcon,
 } from "@/components/brand-icons";
 import { WalletButton } from "@/components/wallet-provider";
+import styles from "@/components/site-navigation.module.css";
 
 const desktopNavItems = [
   { href: "/explore", label: "Explore" },
@@ -30,12 +33,47 @@ function isCurrent(pathname: string, href: string) {
 
 export function SiteHeader() {
   const pathname = usePathname();
+  const menuId = useId();
+  const headerRef = useRef<HTMLElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const [menuPath, setMenuPath] = useState<string | null>(null);
+  const menuOpen = menuPath === pathname;
+
+  useEffect(() => {
+    if (!menuOpen) return;
+
+    const closeOnOutsidePress = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node &&
+        !headerRef.current?.contains(event.target)
+      ) {
+        setMenuPath(null);
+      }
+    };
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setMenuPath(null);
+      menuButtonRef.current?.focus();
+    };
+
+    document.addEventListener("pointerdown", closeOnOutsidePress);
+    document.addEventListener("keydown", closeOnEscape);
+
+    return () => {
+      document.removeEventListener("pointerdown", closeOnOutsidePress);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [menuOpen]);
 
   if (pathname === "/") return null;
 
   return (
-    <header className="site-header">
-      <div className="header-inner">
+    <header
+      ref={headerRef}
+      className={`site-header ${styles.siteHeader}`}
+    >
+      <div className={`header-inner ${styles.headerInner}`}>
         <div className="header-brand">
           <Link className="wordmark" href="/" aria-label="Programmable home">
             <Image
@@ -63,8 +101,8 @@ export function SiteHeader() {
           ))}
         </nav>
 
-        <div className="header-actions">
-          <div className="header-socials">
+        <div className={`header-actions ${styles.headerActions}`}>
+          <div className={`header-socials ${styles.headerSocials}`}>
             <a
               className="header-social-link"
               href="https://x.com/0xProgrammable"
@@ -119,19 +157,74 @@ export function SiteHeader() {
             </a>
           </div>
           <WalletButton compact />
+          <button
+            ref={menuButtonRef}
+            className={styles.menuButton}
+            type="button"
+            aria-controls={menuId}
+            aria-expanded={menuOpen}
+            aria-label={menuOpen ? "Close navigation" : "Open navigation"}
+            onClick={() => setMenuPath(menuOpen ? null : pathname)}
+          >
+            <span className={styles.menuIcon} aria-hidden="true">
+              <Menu
+                className={menuOpen ? styles.iconHidden : styles.iconVisible}
+                strokeWidth={1.8}
+              />
+              <X
+                className={menuOpen ? styles.iconVisible : styles.iconHidden}
+                strokeWidth={1.8}
+              />
+            </span>
+            <span>Menu</span>
+          </button>
+        </div>
+      </div>
+
+      <div
+        className={`${styles.mobileSheet} ${
+          menuOpen ? styles.mobileSheetOpen : ""
+        }`}
+      >
+        <div className={styles.mobileSheetSurface}>
+          <MobileNavigation
+            id={menuId}
+            open={menuOpen}
+            onNavigate={() => setMenuPath(null)}
+          />
         </div>
       </div>
     </header>
   );
 }
 
-export function MobileNavigation() {
+type MobileNavigationProps = {
+  id?: string;
+  open?: boolean;
+  onNavigate?: () => void;
+};
+
+export function MobileNavigation({
+  id,
+  open = false,
+  onNavigate,
+}: MobileNavigationProps = {}) {
   const pathname = usePathname();
 
   if (pathname === "/") return null;
 
+  // AppShell retains this export for compatibility. The responsive navigation
+  // is rendered inside SiteHeader so its visual and keyboard order stay at the
+  // top of the page.
+  if (!id) return null;
+
   return (
-    <nav className="mobile-nav" aria-label="Primary navigation">
+    <nav
+      id={id}
+      className="mobile-nav"
+      aria-label="Primary navigation"
+      aria-hidden={!open}
+    >
       {mobileNavItems.map((item) => {
         const current = isCurrent(pathname, item.href);
         return (
@@ -140,6 +233,8 @@ export function MobileNavigation() {
             className={current ? "active" : undefined}
             href={item.href}
             aria-current={current ? "page" : undefined}
+            tabIndex={open ? undefined : -1}
+            onClick={onNavigate}
           >
             <span>{item.label}</span>
           </Link>

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -84,7 +84,7 @@
 
 .image {
   aspect-ratio: 1;
-  background: #07112f;
+  background: var(--liquid-glass-inner-background);
   border: 1px solid var(--liquid-glass-border);
   border-radius: 22px;
   isolation: isolate;
@@ -93,7 +93,7 @@
 }
 
 .image img {
-  background: #07112f;
+  background: var(--liquid-glass-inner-background);
   display: block;
   height: calc(100% + 4px) !important;
   inset: -2px !important;
@@ -579,7 +579,7 @@
 
 .customSideControl .sideButtonSelected {
   background: var(--liquid-glass-control-background-hover);
-  box-shadow: 0 2px 8px color-mix(in srgb, black 7%, transparent);
+  box-shadow: var(--liquid-glass-control-shadow);
 }
 
 .tradeFooter > span {
@@ -855,9 +855,7 @@
   background: var(--accent-glass-background);
   border: 1px solid var(--accent-glass-border);
   border-radius: 20px;
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, white 18%, transparent),
-    0 10px 28px var(--control-glass-shadow-color);
+  box-shadow: var(--liquid-glass-control-shadow);
   color: var(--accent-ink);
   display: inline-flex;
   font-size: 12px;
@@ -1019,7 +1017,7 @@
   border: 0;
   border-radius: 11px;
   bottom: 4px;
-  box-shadow: 0 2px 8px color-mix(in srgb, black 7%, transparent);
+  box-shadow: var(--liquid-glass-control-shadow);
   left: 4px;
   pointer-events: none;
   position: absolute;
@@ -1953,18 +1951,4 @@
   .submitted {
     animation: none;
   }
-}
-
-/* Keep the token workspace tactile without outlining every nested surface.
- * Address, input and action controls retain their explicit affordances. */
-.image,
-.launchRecord,
-.deepSummary,
-.customMarketPanel,
-.customAuthorityPanel,
-.customProvenancePanel,
-.tradeShell,
-.reviewOutput {
-  border-color: transparent;
-  box-shadow: 0 20px 56px rgb(0 0 0 / 0.22);
 }


### PR DESCRIPTION
## What changed

- replaces the fixed responsive bottom navigation with an accessible topbar menu
- keeps the night-garden atmosphere visually static and aligns shared milk-glass materials
- refines the landing glass, typography, botanical framing and mobile reflow
- fades Explore cards in from matched skeleton geometry without changing data fetching
- unifies Classic fee, percentage and reward-control states
- adds a nontechnical Create guide with an accessible dialog and copyable Hookbuilder prompt
- brings Hookathon, Profile and Token surfaces onto the shared material system
- replaces fallback text glyphs with the existing Lucide icon system

## Scope

UI, CSS and frontend copy only. No contracts, APIs, database, indexer, workflows, scripts, dependencies, lockfiles or onchain data behavior changed.

## Validation

- TypeScript passed
- targeted ESLint passed
- 163 targeted interface tests passed
- `git diff --check` passed
- desktop, narrow-desktop and mobile browser QA at 1440x900, 900x800, 390x844 and 320x568
- no horizontal overflow or fixed-navigation content overlap in checked routes

Local Turbopack could not follow the temporary external node_modules symlink. Webpack reached two pre-existing CSS Module purity errors in unchanged Docs styles; the remote production build is the authoritative build gate.