### PR TITLE
ci: approve exact post-merge Foundry candidate

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -114,8 +114,8 @@ jobs:
           EXPECTED_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
           EXPECTED_CANDIDATE_COMMIT: ${{ github.event.pull_request.head.sha }}
           EXPECTED_MERGE_COMMIT: ${{ steps.candidate_fetch.outputs.merge_commit }}
-          APPROVED_MAIN_CI_CONTROL_COMMIT: 34e8c233e71ca0f2dcc68d40af70632b86b2a92a
-          APPROVED_MAIN_CI_CONTROL_TREE: 525b5524e2c12c84753f7ac46788f7f244dc9709
+          APPROVED_MAIN_CI_CONTROL_COMMIT: 48d925ce01c4b83064e5b30ef76e86458e97e783
+          APPROVED_MAIN_CI_CONTROL_TREE: 22f7b39d922257952475ec6c834f30b3d76ead65
         run: |
           set -euo pipefail
 

--- a/scripts/test/verify-main-ci-control-workflow.test.mjs
+++ b/scripts/test/verify-main-ci-control-workflow.test.mjs
@@ -39,8 +39,8 @@ test("CI control guard executes only exact default-branch code over inert candid
 });
 
 test("trusted guard is bound to the exact audited main candidate commit and tree", () => {
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 34e8c233e71ca0f2dcc68d40af70632b86b2a92a/u);
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: 525b5524e2c12c84753f7ac46788f7f244dc9709/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 48d925ce01c4b83064e5b30ef76e86458e97e783/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: 22f7b39d922257952475ec6c834f30b3d76ead65/u);
   assert.match(workflow, /--approved-commit "\$APPROVED_MAIN_CI_CONTROL_COMMIT"/u);
   assert.match(workflow, /--approved-tree "\$APPROVED_MAIN_CI_CONTROL_TREE"/u);
 });


### PR DESCRIPTION
## Exact approval scope

Approve only the frozen `main` CI repair that installs the already pinned Foundry toolchain in `trusted-post-merge`:

- candidate commit: `48d925ce01c4b83064e5b30ef76e86458e97e783`
- candidate tree: `22f7b39d922257952475ec6c834f30b3d76ead65`
- candidate base main: `bcd7570982f76b574f881c439546a52bdbdbec8c`
- current production base: `63574fd5e81b881ec111837e363025bb618dc18e`

## Evidence

The merged model's trusted post-merge run `31630033172` passed 1,608 maintained skill tests, skipped 2, and failed only two tests with `PROJECT_COMMAND_TOOL_UNRESOLVED` because `forge` was absent. Ordinary Hookbuilder maintenance on the same model installs the identical pinned Foundry toolchain and is successful.

## Runtime control

- trusted production intake remains on Node `24.19.0` and pinned `actions/setup-node` v7
- the exact candidate commit/tree guard remains fail closed
- the generic 256-file changed-file limit and exact maintenance routing remain unchanged
- this approval changes only the frozen candidate binding and its test

## Local validation

- `actionlint .github/workflows/verify-hook-builder.yml`: passed
- exact control-plane guard/workflow tests: 10 passed, 0 failed
- `git diff --check`: passed

This PR does not merge the candidate, alter model bytes, or grant acceptance, release, deployment, or launch authority.
