### PR TITLE
ci: install Foundry for trusted post-merge tests

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -207,6 +207,16 @@ jobs:
         with:
           node-version: 24
 
+      - name: Install Foundry for maintained skill tests
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1
+        with:
+          version: v1.7.1
+
+      - name: Preload the portable-test Solidity compiler
+        run: |
+          mkdir -p -- "$RUNNER_TEMP/programmable-foundry-bootstrap"
+          forge build --use 0.8.26 --root "$RUNNER_TEMP/programmable-foundry-bootstrap"
+
       - name: Execute maintained skill tests
         working-directory: source
         shell: bash

--- a/scripts/test/verify-public-hook-application-workflow.test.mjs
+++ b/scripts/test/verify-public-hook-application-workflow.test.mjs
@@ -107,6 +107,17 @@ test("Hookbuilder maintenance and trusted intake run on the current Node 24 LTS 
   }
 });
 
+test("trusted post-merge installs pinned Foundry before executing maintained skill tests", () => {
+  const foundryPin = "foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09";
+  const installIndex = postMergeJob.indexOf("- name: Install Foundry for maintained skill tests");
+  const preloadIndex = postMergeJob.indexOf("- name: Preload the portable-test Solidity compiler");
+  const executeIndex = postMergeJob.indexOf("- name: Execute maintained skill tests");
+  assert.ok(installIndex > 0 && installIndex < preloadIndex && preloadIndex < executeIndex);
+  assert.match(postMergeJob, new RegExp(foundryPin, "u"));
+  assert.match(postMergeJob, /version: v1\.7\.1/u);
+  assert.match(postMergeJob, /forge build --use 0\.8\.26/u);
+});
+
 test("candidate data is an exact base-repository PR merge in a bare blobless object store", () => {
   assert.match(candidateFetchStep, /--fetch-candidate/u);
   assert.match(candidateFetchStep, /--repository "\$\{\{ github\.repository \}\}"/u);


### PR DESCRIPTION
## Root cause

The exact post-merge run for `main@bcd7570982f76b574f881c439546a52bdbdbec8c` executed 1,610 maintained skill tests. It passed 1,608, skipped 2, and failed two tradable project tests because the `trusted-post-merge` job had not installed `forge`:

- `PROJECT_COMMAND_TOOL_UNRESOLVED: command executable cannot be resolved: forge`
- failing job: `94226132529`
- run: `31630033172`

The ordinary read-only Hookbuilder maintenance job already installs the same pinned toolchain and passed on the exact merged model.

## Fix

- install `foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09` (`v1`) in `trusted-post-merge`
- pin Foundry to `v1.7.1`, matching the maintained skill test lane
- preload Solidity `0.8.26` before executing maintained skill tests
- preserve read-only permissions, exact checkout, Node 24, and all existing test commands

## Frozen candidate

- base main: `bcd7570982f76b574f881c439546a52bdbdbec8c`
- candidate commit: `48d925ce01c4b83064e5b30ef76e86458e97e783`
- candidate tree: `22f7b39d922257952475ec6c834f30b3d76ead65`

## Production control plane

- exact approval PR: `#263`
- production merge: `add7e25af34d6c1edf171ca6d024edc92b9c5327`
- production tree: `624c6305baaac6a43d4fe0f5c6c256c965642b7e`
- approved main candidate: `48d925ce01c4b83064e5b30ef76e86458e97e783` / `22f7b39d922257952475ec6c834f30b3d76ead65`
- trusted runtime remains Node `24.19.0`

## Validation

- exact-head Foundry: passed
- full Hookbuilder maintenance: passed
- exact-head security retry: passed
- fresh production-bound public-intake: passed
- `actionlint .github/workflows/verify-hook-builder.yml`: passed
- workflow authority/runtime tests: 16 passed, 0 failed
- exact production control-plane tests: 10 passed, 0 failed
- `git diff --check`: passed

This repairs missing CI tooling only. It does not change the Hookbuilder model bytes, intake authority, production permissions, application acceptance, or release status. Owner authorization may satisfy the repository CODEOWNER gate, but is not an independent audit.
