### PR TITLE
ci: run maintained Hookbuilder tests once

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -189,7 +189,7 @@ jobs:
   trusted-post-merge:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout trusted revision
@@ -225,7 +225,6 @@ jobs:
 
           npm ci --prefix scripts/test/schema-validator --ignore-scripts --no-audit --no-fund
           node --test --test-concurrency=1 scripts/test/verify-public-hook-application*.test.mjs
-          node --test skills/programmable-v4-hook-builder/scripts/test/*.test.mjs
           node skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
           node skills/programmable-v4-hook-builder/scripts/verify-skill.mjs --installed
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Verify trusted intake and canonical skill
         run: |
           node --test --test-concurrency=1 scripts/test/verify-public-hook-application*.test.mjs
-          node --test skills/programmable-v4-hook-builder/scripts/test/*.test.mjs
           node skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
           node skills/programmable-v4-hook-builder/scripts/verify-skill.mjs --installed
 

--- a/scripts/test/verify-public-hook-application-workflow.test.mjs
+++ b/scripts/test/verify-public-hook-application-workflow.test.mjs
@@ -242,10 +242,24 @@ test("builder maintenance runs only in normal read-only CI with closed offline c
   assert.doesNotMatch(normalMaintenanceJob, /ANTHROPIC_API_KEY|--require-provider|github\.token/u);
 });
 
+test("maintained skill tests run once through the bounded canonical verifier", () => {
+  for (const job of [normalMaintenanceJob, postMergeJob]) {
+    assert.equal(
+      (job.match(/^\s*node skills\/programmable-v4-hook-builder\/scripts\/verify-skill\.mjs$/gmu) ?? []).length,
+      1
+    );
+    assert.equal(
+      (job.match(/^\s*node skills\/programmable-v4-hook-builder\/scripts\/verify-skill\.mjs --installed$/gmu) ?? []).length,
+      1
+    );
+    assert.doesNotMatch(job, /node --test skills\/programmable-v4-hook-builder\/scripts\/test\/\*\.test\.mjs/u);
+  }
+});
+
 test("workflow bounds job lifetime and cancels superseded pull-request work", () => {
   assert.match(workflow, /concurrency:[\s\S]*?cancel-in-progress: true/u);
   assert.match(publicJob, /timeout-minutes: 10/u);
-  assert.match(postMergeJob, /timeout-minutes: 15/u);
+  assert.match(postMergeJob, /timeout-minutes: 20/u);
 });
 
 test("post-merge validation does not impose a repository-global application cap", () => {


### PR DESCRIPTION
## Summary

- keep the canonical bounded `verify-skill.mjs` run as the single full maintained Hookbuilder test path
- remove the redundant direct 75-file test glob from normal maintenance and trusted post-merge CI
- give the outer trusted post-merge job a five-minute cleanup/setup reserve over the unchanged inner 15-minute fail-closed verifier bound
- add a workflow contract test that prevents the duplicate full test path from returning

## Frozen candidate

- commit: `140771f8fc2b3a30cc021f6352ccd830850e68e6`
- tree: `a5f359e200ab42917e6c2055e1d5a9685e33c137`
- base: `1432d17bc1c20e5c82cd9f40f10a2a60e7339c04`
- Hookbuilder source remains `509060301ce9bb1b5e318b28aeeeeb846c020f68`
- canonical skill tree remains `7543cac1e4556664e494b30186a51a796aa3a7b7`

## Evidence

Two post-merge attempts proved the direct full skill run green (`1611` passed, `1` platform skip, `0` failed) before GitHub cancelled the duplicate verifier run at the outer 15-minute job limit. This change does not relax the verifier: its two deterministic shards, concurrency 2, shared 15-minute deadline, shared 128 MiB output cap, Foundry preload, installed-mode verification, Node 24 runtime, and all fail-closed assertions remain unchanged.

Local checks passed: Actionlint; workflow contract `17/17`; focused verifier safety `36/36`; plugin packaging `10/10`; generator and `git diff --check`.

This changes no submission acceptance, review, deployment, routing, or launch authority. Fresh protected CI, exact production binding, and CODEOWNER review remain required.\n\nProduction binding refreshed after approval merge `edd16fed9e905c741686aa00711de7c8b0608542`; fresh protected intake required.