### PR TITLE
ci: approve deduplicated Hookbuilder test candidate

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -114,8 +114,8 @@ jobs:
           EXPECTED_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
           EXPECTED_CANDIDATE_COMMIT: ${{ github.event.pull_request.head.sha }}
           EXPECTED_MERGE_COMMIT: ${{ steps.candidate_fetch.outputs.merge_commit }}
-          APPROVED_MAIN_CI_CONTROL_COMMIT: 48d925ce01c4b83064e5b30ef76e86458e97e783
-          APPROVED_MAIN_CI_CONTROL_TREE: 22f7b39d922257952475ec6c834f30b3d76ead65
+          APPROVED_MAIN_CI_CONTROL_COMMIT: 140771f8fc2b3a30cc021f6352ccd830850e68e6
+          APPROVED_MAIN_CI_CONTROL_TREE: a5f359e200ab42917e6c2055e1d5a9685e33c137
         run: |
           set -euo pipefail
 

--- a/scripts/test/verify-main-ci-control-workflow.test.mjs
+++ b/scripts/test/verify-main-ci-control-workflow.test.mjs
@@ -39,8 +39,8 @@ test("CI control guard executes only exact default-branch code over inert candid
 });
 
 test("trusted guard is bound to the exact audited main candidate commit and tree", () => {
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 48d925ce01c4b83064e5b30ef76e86458e97e783/u);
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: 22f7b39d922257952475ec6c834f30b3d76ead65/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 140771f8fc2b3a30cc021f6352ccd830850e68e6/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: a5f359e200ab42917e6c2055e1d5a9685e33c137/u);
   assert.match(workflow, /--approved-commit "\$APPROVED_MAIN_CI_CONTROL_COMMIT"/u);
   assert.match(workflow, /--approved-tree "\$APPROVED_MAIN_CI_CONTROL_TREE"/u);
 });


### PR DESCRIPTION
## Summary

Approve exactly one main-branch CI-control candidate that removes a redundant second full Hookbuilder test invocation while retaining the bounded canonical verifier.

## Exact binding

- approved main candidate commit: `140771f8fc2b3a30cc021f6352ccd830850e68e6`
- approved main candidate tree: `a5f359e200ab42917e6c2055e1d5a9685e33c137`
- approval commit: `49c24167f184ecc05cb97c5c866254ba61b1283f`
- approval tree: `f8eadb6ec41f5c3800fc271a9a594ef0e1938365`
- production base: `add7e25af34d6c1edf171ca6d024edc92b9c5327`

The approved candidate retains Node 24, pinned Foundry, the canonical two-shard verifier, its shared 15-minute deadline and output cap, installed-mode verification, and all existing fail-closed gates. It adds only outer cleanup/setup reserve and a regression test preventing duplicate full test execution.

Local checks: Actionlint; production binding tests `10/10`; `git diff --check`. This approval grants no submission acceptance, deployment, routing, launch, or review authority.