### PR TITLE
Speed up and correct public market data

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -853,18 +853,36 @@ jobs:
                 "staged Bitquery Highest FDV is not monotonically descending",
               );
             }
+            const tokenAddress = token?.tokenAddress?.toLowerCase();
             const primary = token.marketData?.pools?.find(
               (pool) => pool.identity?.poolId === token.marketData?.primaryPoolId,
             );
             if (
+              !/^0x[0-9a-f]{40}$/.test(tokenAddress ?? "") ||
+              tokenAddress === goldenTokenAddress ||
+              token.marketData?.schemaVersion !==
+                "programmable.market-data.v1" ||
+              token.marketData.source !== "bitquery" ||
+              !currentMarketTime(token.marketData.generatedAt) ||
               !primary ||
+              primary.identity?.chainId !== "1" ||
+              primary.identity?.tokenAddress !== tokenAddress ||
+              primary.source !== "bitquery" ||
               primary.status !== "current" ||
               primary.liquidity?.freshness !== "current" ||
               !positiveInteger(primary.liquidity?.valueUsdWad) ||
-              primary.valuation?.asOfTime !== valuation.asOfTime
+              !positiveInteger(primary.liquidity?.asOfBlock) ||
+              primary.liquidity?.asOfTime !== valuation.asOfTime ||
+              !currentMarketTime(primary.liquidity?.asOfTime) ||
+              primary.valuation?.status !== "available" ||
+              primary.valuation.metric !== "fdv" ||
+              primary.valuation.supplyBasis !== "total" ||
+              primary.valuation.freshness !== "current" ||
+              primary.valuation.valueUsdWad !== valuation.valueWad ||
+              primary.valuation.asOfTime !== valuation.asOfTime
             ) {
               throw new Error(
-                "staged Bitquery current FDV lacks current trade and liquidity evidence",
+                "staged Bitquery current public FDV lacks exact primary-pool liquidity evidence",
               );
             }
             previousCurrentFdv = value;
@@ -900,6 +918,11 @@ jobs:
           ) {
             throw new Error(
               "staged Bitquery Explore has inconsistent market provenance",
+            );
+          }
+          if (currentFdvCount < 1) {
+            throw new Error(
+              "staged Bitquery market path has no current public non-PCAN FDV with exact primary-pool liquidity evidence",
             );
           }
           const newestPageSize = 100;
@@ -1274,11 +1297,6 @@ jobs:
             goldenChart.__marketHeaders?.dataQuality === goldenChart.status &&
             goldenChart.__marketHeaders?.marketSource === "bitquery" &&
             goldenChart.__marketHeaders?.priceSource === "bitquery";
-          if (currentFdvCount < 1 && !historicalPaidPathVerified) {
-            throw new Error(
-              "staged Bitquery market path has no current or independently verified history",
-            );
-          }
           process.stdout.write(
             `${JSON.stringify({
               status: "verified-bitquery-staged-market-apis",

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -864,9 +864,14 @@ jobs:
                 "programmable.market-data.v1" ||
               token.marketData.source !== "bitquery" ||
               !currentMarketTime(token.marketData.generatedAt) ||
+              !/^0x[0-9a-f]{64}$/.test(
+                token.marketData.primaryPoolId ?? "",
+              ) ||
               !primary ||
               primary.identity?.chainId !== "1" ||
               primary.identity?.tokenAddress !== tokenAddress ||
+              primary.identity?.poolId !== token.marketData.primaryPoolId ||
+              primary.identity?.protocol !== "uniswap_v4" ||
               primary.source !== "bitquery" ||
               primary.status !== "current" ||
               primary.liquidity?.freshness !== "current" ||

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -607,6 +607,16 @@ jobs:
           const { verifyBitqueryGoldenMarketParityV1 } = await import(
             "./scripts/perf/bitquery-golden-market-parity.mjs"
           );
+          const {
+            boundedStaleMarketTimeV1,
+            verifyBitqueryHistoricalGoldenReleaseV1,
+          } = await import(
+            "./scripts/perf/bitquery-historical-release-gate.mjs"
+          );
+          const goldenTokenAddress =
+            "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
+          const goldenPoolId =
+            "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
           const origin = new URL(process.env.STAGED_TARGET_URL);
           if (
             origin.protocol !== "https:" ||
@@ -684,9 +694,7 @@ jobs:
           const currentMarketTime = (value) =>
             validMarketTime(value) &&
             Date.now() - Date.parse(value) <= 6 * 60_000;
-          const boundedStaleMarketTime = (value) =>
-            validMarketTime(value) &&
-            Date.now() - Date.parse(value) <= 24 * 60 * 60_000;
+          const boundedStaleMarketTime = boundedStaleMarketTimeV1;
 
           const requestJson = async (path, contract) => {
             let lastError;
@@ -1111,19 +1119,19 @@ jobs:
               );
             }
           }
-          const goldenTokenAddress =
-            "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
-          const goldenPoolId =
-            "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
-          const goldenExplore = await requestJson(
+          const goldenSearch = await requestJson(
             `/api/explore?limit=20&page=1&q=${goldenTokenAddress}&sort=market-cap`,
             bitqueryMarketContract,
           );
-          const goldenExploreToken = goldenExplore.tokens?.find(
-            (token) => token?.tokenAddress?.toLowerCase() === goldenTokenAddress,
-          );
-          if (goldenExplore.status !== "ready" || !goldenExploreToken) {
-            throw new Error("staged Explore did not retain the canonical PCAN identity");
+          if (
+            goldenSearch.status !== "ready" ||
+            !Array.isArray(goldenSearch.tokens) ||
+            goldenSearch.tokens.some(
+              (token) => token?.tokenAddress?.toLowerCase() === goldenTokenAddress,
+            ) ||
+            goldenSearch.total !== 0
+          ) {
+            throw new Error("staged Explore exposed the non-public PCAN release canary");
           }
           const goldenDetail = await requestJson(
             `/api/explore/token?address=${goldenTokenAddress}`,
@@ -1172,27 +1180,19 @@ jobs:
             !validMarketTime(goldenValuation.asOfTime) ||
             (goldenValuation.freshness === "current" &&
               !currentMarketTime(goldenValuation.asOfTime)) ||
-            (goldenValuation.freshness === "stale" &&
-              !boundedStaleMarketTime(goldenValuation.asOfTime)) ||
             goldenPool?.valuation?.metric !== "fdv" ||
             goldenPool?.valuation?.marketCapUsdWad !== undefined ||
             expectedGoldenFdv === null ||
             expectedGoldenFdv <= 0n ||
             goldenPool?.valuation?.fdvUsdWad !== expectedGoldenFdv.toString() ||
             goldenValuation.valueWad !== expectedGoldenFdv.toString() ||
-            goldenExploreToken.valuation?.status !== "available" ||
-            goldenExploreToken.valuation.valueWad !== goldenValuation.valueWad ||
-            goldenExploreToken.valuation.freshness !== goldenValuation.freshness ||
-            goldenExploreToken.valuation.asOfTime !== goldenValuation.asOfTime ||
             goldenDetail.__marketHeaders?.marketAsOf !== goldenValuation.asOfTime ||
             (goldenValuation.freshness === "current"
               ? goldenDetail.__marketHeaders?.priceSource !== "bitquery"
               : goldenDetail.__marketHeaders?.priceSource !== null) ||
             (goldenValuation.freshness === "current"
-              ? goldenDetail.token.fdvUsdWad !== goldenValuation.valueWad ||
-                goldenExploreToken.fdvUsdWad !== goldenValuation.valueWad
-              : goldenDetail.token.fdvUsdWad !== undefined ||
-                goldenExploreToken.fdvUsdWad !== undefined)
+              ? goldenDetail.token.fdvUsdWad !== goldenValuation.valueWad
+              : goldenDetail.token.fdvUsdWad !== undefined)
           ) {
             throw new Error("staged PCAN market valuation is not Bitquery-bound");
           }
@@ -1220,8 +1220,6 @@ jobs:
             !["current", "stale"].includes(goldenChart.valuation?.freshness) ||
             (goldenChart.valuation?.freshness === "current" &&
               !currentMarketTime(goldenChart.valuation?.asOfTime)) ||
-            (goldenChart.valuation?.freshness === "stale" &&
-              !boundedStaleMarketTime(goldenChart.valuation?.asOfTime)) ||
             goldenChart.asOfTime !== goldenChart.points.at(-1)?.time ||
             goldenChart.__marketHeaders?.marketAsOf !== goldenChart.asOfTime ||
             goldenChart.__marketHeaders?.dataQuality !== goldenChart.status ||
@@ -1254,12 +1252,22 @@ jobs:
             previousChartTime = time;
             previousChartBlock = block;
           }
+          const historicalGoldenRelease =
+            verifyBitqueryHistoricalGoldenReleaseV1({
+              detailToken: goldenDetail.token,
+              chart: goldenChart,
+              parity: goldenParity,
+            });
           const historicalPaidPathVerified =
-            goldenParity.schemaVersion ===
-              "programmable.bitquery-golden-market-parity.v1" &&
-            goldenParity.tokenAddress === goldenTokenAddress &&
-            goldenParity.poolId === goldenPoolId &&
-            goldenParity.confirmations >= 12 &&
+            historicalGoldenRelease.schemaVersion ===
+              "programmable.bitquery-historical-release.v1" &&
+            historicalGoldenRelease.tokenAddress === goldenTokenAddress &&
+            historicalGoldenRelease.poolId === goldenPoolId &&
+            historicalGoldenRelease.blockNumber ===
+              goldenPool.latestTrade.blockNumber &&
+            historicalGoldenRelease.bitqueryFdvUsdWad ===
+              goldenValuation.valueWad &&
+            historicalGoldenRelease.confirmations >= 12 &&
             goldenChart.points.length >= 1 &&
             goldenChart.readStatus === "live" &&
             currentMarketTime(goldenChart.generatedAt) &&
@@ -1278,6 +1286,7 @@ jobs:
               goldenTokenAddress,
               goldenPoolId,
               goldenParity,
+              historicalGoldenRelease,
               historicalPaidPathVerified,
               currentFdvCount,
               availableFdvCount,

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -83,8 +83,10 @@ condition = "AND"
 regexTarget = "match"
 paths = [
   '''scripts/perf/bitquery-golden-market-parity\.mjs''',
+  '''scripts/perf/bitquery-historical-release-gate\.mjs''',
   '''scripts/perf/read-model-post-promotion\.mjs''',
   '''tests/bitquery-market-data\.test\.ts''',
+  '''tests/data-pipeline/bitquery-historical-release-gate\.test\.ts''',
   '''tests/data-pipeline/read-model-ops-contract\.test\.ts''',
 ]
 regexes = ['''(?i)0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce''']

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -329,6 +329,33 @@ function hasVerifiedBitqueryPrice(entries: readonly ValuedExploreEntry[]): boole
   });
 }
 
+function hasTemporaryMarketSourceFailure(
+  entries: readonly ValuedExploreEntry[],
+): boolean {
+  return entries.some((entry) =>
+    entry.valuation.status === "unavailable" &&
+    entry.valuation.reason === "source-unavailable"
+  );
+}
+
+function exploreResponseCacheControl(input: Readonly<{
+  dataQuality: ReturnType<typeof buildExploreDataQuality>;
+  entries: readonly ValuedExploreEntry[];
+  status: "ready" | "not-deployed";
+}>): string {
+  // Do not cache a degraded source read. Known stale or unavailable market
+  // observations remain honest in the payload and are safe to reuse briefly.
+  if (
+    input.dataQuality.launchIdentity.status !== "current" ||
+    hasTemporaryMarketSourceFailure(input.entries)
+  ) {
+    return "no-store";
+  }
+  return input.status === "ready"
+    ? "public, max-age=0, s-maxage=2, stale-while-revalidate=5"
+    : "public, max-age=0, s-maxage=30";
+}
+
 function paginateEntries(
   ordered: readonly ExploreEntry[],
   input: Readonly<{ page: number; pageSize: number }>,
@@ -372,6 +399,61 @@ export function paginateExploreEntriesV1(
   const newest = sortExploreEntries(filtered, "newest")
     .filter(({ id }) => !topIds.has(id));
   return paginateEntries([...top, ...newest], input);
+}
+
+async function valueExplorePage(input: Readonly<{
+  identityEntries: readonly ExploreEntry[];
+  options: Readonly<{
+    page: number;
+    pageSize: number;
+    query: string;
+    socials: "yes" | "no" | null;
+    sort: ExploreSort;
+  }>;
+  signal: AbortSignal;
+}>) {
+  const requiresGlobalMarketRanking =
+    input.options.sort === "market-cap" ||
+    input.options.sort === "market-cap-asc";
+  const identityPage = requiresGlobalMarketRanking
+    ? null
+    : paginateExploreEntriesV1(input.identityEntries, {
+        ...input.options,
+        query: "",
+        socials: null,
+        topThenNewest: false,
+      });
+  const entriesToValue = identityPage?.tokens ?? input.identityEntries;
+  const [hydratedEntries, marketByToken] = await Promise.all([
+    hydrateMissingCanonicalTokenSupplyV1(entriesToValue),
+    readBitqueryTokenMarketDataV1(
+      exploreEntriesMarketIdentitiesV1(entriesToValue),
+      { signal: input.signal },
+    ),
+  ]);
+  const valuedEntries = valueExploreEntriesWithMarketData(
+    hydratedEntries,
+    marketByToken,
+  );
+  if (identityPage !== null) {
+    return {
+      entries: valuedEntries,
+      paginated: { ...identityPage, tokens: valuedEntries },
+    };
+  }
+  const useTopValuationView =
+    input.options.sort === "market-cap" &&
+    input.options.query.length === 0 &&
+    input.options.socials === null;
+  return {
+    entries: valuedEntries,
+    paginated: paginateExploreEntriesV1(valuedEntries, {
+      ...input.options,
+      query: "",
+      socials: null,
+      topThenNewest: useTopValuationView,
+    }),
+  };
 }
 
 export async function GET(request: NextRequest) {
@@ -451,24 +533,10 @@ export async function GET(request: NextRequest) {
       options.query,
       options.socials,
     );
-    const identityEntries = await hydrateMissingCanonicalTokenSupplyV1(
-      requestedIdentityEntries,
-    );
-    const marketByToken = await readBitqueryTokenMarketDataV1(
-      exploreEntriesMarketIdentitiesV1(identityEntries),
-      { signal: request.signal },
-    );
-    const entries = valueExploreEntriesWithMarketData(
-      identityEntries,
-      marketByToken,
-    );
-    const useTopValuationView =
-      options.sort === "market-cap" &&
-      options.query.length === 0 &&
-      options.socials === null;
-    const paginated = paginateExploreEntriesV1(entries, {
-      ...options,
-      topThenNewest: useTopValuationView,
+    const { entries, paginated } = await valueExplorePage({
+      identityEntries: requestedIdentityEntries,
+      options,
+      signal: request.signal,
     });
     const pageEntries = paginated.tokens as ValuedExploreEntry[];
 
@@ -543,11 +611,11 @@ export async function GET(request: NextRequest) {
       {
         headers: {
           "Cache-Control":
-            customProjects.length > 0 || dataQuality.status !== "complete"
-              ? "no-store"
-              : page.status === "ready"
-              ? "public, max-age=0, s-maxage=2, stale-while-revalidate=5"
-              : "public, max-age=0, s-maxage=30",
+            exploreResponseCacheControl({
+              dataQuality,
+              entries,
+              status: page.status,
+            }),
           "X-Programmable-Data-Quality": dataQuality.status,
           "X-Programmable-Market-Source": "bitquery",
           ...(dataQuality.valuation.asOfTime

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -50,6 +50,19 @@ const UNAVAILABLE_CANONICAL_VALUATION = Object.freeze({
   status: "unavailable",
   reason: "source-unavailable",
 } as const satisfies MarketValuationV1);
+const REUSABLE_CHART_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=2, stale-while-revalidate=5";
+
+function chartResponseCacheControl(chart: MarketChartV1): string {
+  const hasReusableHistory =
+    chart.status === "ready" || chart.status === "insufficient-history";
+  return chart.readStatus === "live" &&
+      hasReusableHistory &&
+      chart.valuation.status === "available" &&
+      chart.valuation.freshness === "current"
+    ? REUSABLE_CHART_CACHE_CONTROL
+    : "no-store";
+}
 
 async function readPrimaryChartModel() {
   const model = await readAlchemyExploreModel();
@@ -258,12 +271,7 @@ export async function GET(request: NextRequest) {
       },
       {
         headers: {
-          "Cache-Control":
-            chart.status === "ready" &&
-                chart.valuation.status === "available" &&
-                chart.valuation.freshness === "current"
-              ? "public, max-age=0, s-maxage=2, stale-while-revalidate=5"
-              : "no-store",
+          "Cache-Control": chartResponseCacheControl(chart),
           "X-Programmable-Data-Quality": chart.status,
           "X-Programmable-Market-Source": "bitquery",
           ...(hasVerifiedPrice

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -23,7 +23,7 @@ import { hydrateMissingCanonicalTokenSupplyV1 } from
   "../../../../../lib/market-data/canonical-token-supply.server";
 import { exploreEntryMarketIdentitiesV1 } from
   "../../../../../lib/market-data/explore-market-identities";
-import type { MarketChartV1 } from
+import type { MarketChartV1, MarketValuationV1 } from
   "../../../../../lib/market-data/market-data-v1";
 import { PROGRAMMABLE_MARKET_CHART_ERROR_SCHEMA_VERSION } from
   "../../../../../lib/market-data/market-data-v1";
@@ -46,6 +46,10 @@ const readCanonicalChartSource = createExploreConsumerSource<ExploreReadModel>({
 const readCustomChartSource = createExploreConsumerSource<
   readonly CustomProjectExploreEntry[]
 >({});
+const UNAVAILABLE_CANONICAL_VALUATION = Object.freeze({
+  status: "unavailable",
+  reason: "source-unavailable",
+} as const satisfies MarketValuationV1);
 
 async function readPrimaryChartModel() {
   const model = await readAlchemyExploreModel();
@@ -145,12 +149,7 @@ export async function GET(request: NextRequest) {
     const unresolvedEntry: ExploreEntry | null = token
       ? canonicalTokenExploreEntryV1(token)
       : customProject ?? null;
-    const entry = unresolvedEntry
-      ? (await hydrateMissingCanonicalTokenSupplyV1([
-          unresolvedEntry,
-        ]))[0] ?? unresolvedEntry
-      : null;
-    if (!entry) {
+    if (!unresolvedEntry) {
       if (
         canonicalSource?.status === "current" &&
         customSource?.status === "current"
@@ -167,7 +166,7 @@ export async function GET(request: NextRequest) {
         "Token identity is temporarily unavailable",
       );
     }
-    const identities = exploreEntryMarketIdentitiesV1(entry);
+    const identities = exploreEntryMarketIdentitiesV1(unresolvedEntry);
     if (identities.length === 0) {
       return unavailable(
         address,
@@ -176,25 +175,62 @@ export async function GET(request: NextRequest) {
         "Price history is unavailable for this market",
       );
     }
-    const marketByToken = await readBitqueryTokenMarketDataV1(identities, {
-      signal: request.signal,
-    });
-    const marketDataRead = marketByToken.get(address.toLowerCase());
-    const marketData = marketDataRead
-      ? withBitqueryMarketData(entry, marketDataRead).marketData
-      : undefined;
-    const identity = identities.find(
-      (candidate) => candidate.poolId === marketData?.primaryPoolId,
-    ) ?? identities[0];
-    const primaryMarket = marketData?.pools.find(
-      (candidate) => candidate.identity.poolId === identity.poolId,
-    );
-    const chart = await readBitqueryMarketChartV1({
-      identity,
-      range,
-      ...(primaryMarket ? { valuation: primaryMarket.valuation } : {}),
-      signal: request.signal,
-    });
+    const entryPromise = hydrateMissingCanonicalTokenSupplyV1([
+      unresolvedEntry,
+    ]).then((entries) => entries[0] ?? unresolvedEntry);
+    let chart: MarketChartV1;
+    if (identities.length === 1) {
+      const identity = identities[0];
+      const [entry, marketByToken, chartRead] = await Promise.all([
+        entryPromise,
+        readBitqueryTokenMarketDataV1(identities, {
+          signal: request.signal,
+        }),
+        readBitqueryMarketChartV1({
+          identity,
+          range,
+          valuation: UNAVAILABLE_CANONICAL_VALUATION,
+          signal: request.signal,
+        }),
+      ]);
+      const marketDataRead = marketByToken.get(address.toLowerCase());
+      const marketData = marketDataRead
+        ? withBitqueryMarketData(entry, marketDataRead).marketData
+        : undefined;
+      const primaryMarket = marketData?.pools.find(
+        (candidate) => candidate.identity.poolId === identity.poolId,
+      );
+      chart = {
+        ...chartRead,
+        valuation:
+          chartRead.readStatus === "live" && chartRead.points.length > 0
+            ? primaryMarket?.valuation ?? UNAVAILABLE_CANONICAL_VALUATION
+            : chartRead.valuation,
+      };
+    } else {
+      const [entry, marketByToken] = await Promise.all([
+        entryPromise,
+        readBitqueryTokenMarketDataV1(identities, {
+          signal: request.signal,
+        }),
+      ]);
+      const marketDataRead = marketByToken.get(address.toLowerCase());
+      const marketData = marketDataRead
+        ? withBitqueryMarketData(entry, marketDataRead).marketData
+        : undefined;
+      const identity = identities.find(
+        (candidate) => candidate.poolId === marketData?.primaryPoolId,
+      ) ?? identities[0];
+      const primaryMarket = marketData?.pools.find(
+        (candidate) => candidate.identity.poolId === identity.poolId,
+      );
+      chart = await readBitqueryMarketChartV1({
+        identity,
+        range,
+        valuation: primaryMarket?.valuation ?? UNAVAILABLE_CANONICAL_VALUATION,
+        signal: request.signal,
+      });
+    }
     if (chart.status === "unavailable") {
       return unavailable(
         address,

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -202,17 +202,17 @@ export async function GET(request: NextRequest) {
     const unresolvedIdentityEntry = token
       ? canonicalTokenExploreEntryV1(token)
       : customProject ?? null;
-    const identityEntry = unresolvedIdentityEntry
-      ? (await hydrateMissingCanonicalTokenSupplyV1([
-          unresolvedIdentityEntry,
-        ]))[0] ?? unresolvedIdentityEntry
-      : null;
-    const marketByToken = identityEntry
-      ? await readBitqueryTokenMarketDataV1(
-          exploreEntryMarketIdentitiesV1(identityEntry),
-          { signal: request.signal },
-        )
-      : new Map<string, TokenMarketDataV1>();
+    const [identityEntry, marketByToken] = unresolvedIdentityEntry
+      ? await Promise.all([
+          hydrateMissingCanonicalTokenSupplyV1([
+            unresolvedIdentityEntry,
+          ]).then((entries) => entries[0] ?? unresolvedIdentityEntry),
+          readBitqueryTokenMarketDataV1(
+            exploreEntryMarketIdentitiesV1(unresolvedIdentityEntry),
+            { signal: request.signal },
+          ),
+        ])
+      : [null, new Map<string, TokenMarketDataV1>()] as const;
     const marketData = identityEntry?.tokenAddress
       ? marketByToken.get(identityEntry.tokenAddress.toLowerCase())
       : undefined;

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -4,10 +4,8 @@ import { NextRequest } from "next/server";
 import { Suspense } from "react";
 
 import { GET as readExploreResponse } from "@/app/api/explore/route";
-import {
-  ExploreView,
-  type ExploreInitialResponse,
-} from "@/components/explore-view";
+import { ExploreView } from "@/components/explore-view";
+import type { ExploreInitialResponse } from "@/components/explore-view";
 
 export const dynamic = "force-dynamic";
 
@@ -59,9 +57,7 @@ export const metadata: Metadata = {
 };
 
 function isLocalPreviewHost(host: string | null) {
-  const hostname = host
-    ?.replace(/^\[|\](?::\d+)?$|:\d+$/gu, "")
-    .toLowerCase();
+  const hostname = host?.replace(/^\[|\](?::\d+)?$|:\d+$/gu, "").toLowerCase();
   return (
     hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
   );
@@ -75,6 +71,7 @@ async function InitialExploreView() {
 
   const initialResponse = await readInitialExploreWithinDeadline(
     async (signal) => {
+      // prettier-ignore
       const response = await readExploreResponse(new NextRequest(
         `http://programmable.local/api/explore?${INITIAL_EXPLORE_QUERY}`,
         {

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -11,7 +11,7 @@ export const dynamic = "force-dynamic";
 const INITIAL_EXPLORE_TIMEOUT_MS = 12_000;
 const INITIAL_EXPLORE_QUERY = new URLSearchParams({
   q: "",
-  sort: "market-cap",
+  sort: "newest",
   page: "1",
   limit: "9",
 }).toString();

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -4,7 +4,10 @@ import { NextRequest } from "next/server";
 import { Suspense } from "react";
 
 import { GET as readExploreResponse } from "@/app/api/explore/route";
-import { ExploreView } from "@/components/explore-view";
+import {
+  ExploreView,
+  type ExploreInitialResponse,
+} from "@/components/explore-view";
 
 export const dynamic = "force-dynamic";
 
@@ -15,6 +18,37 @@ const INITIAL_EXPLORE_QUERY = new URLSearchParams({
   page: "1",
   limit: "9",
 }).toString();
+
+function unavailableInitialExploreResponse(): ExploreInitialResponse {
+  return {
+    ok: false,
+    body: { error: "Tokens are temporarily unavailable" },
+  };
+}
+
+export async function readInitialExploreWithinDeadline(
+  read: (signal: AbortSignal) => Promise<ExploreInitialResponse>,
+  timeoutMs = INITIAL_EXPLORE_TIMEOUT_MS,
+): Promise<ExploreInitialResponse> {
+  const controller = new AbortController();
+  const guardedRead = Promise.resolve()
+    .then(() => read(controller.signal))
+    .catch(() => unavailableInitialExploreResponse());
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<ExploreInitialResponse>((resolve) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      resolve(unavailableInitialExploreResponse());
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([guardedRead, deadline]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+    controller.abort();
+  }
+}
 
 export const metadata: Metadata = {
   title: "Programmable",
@@ -39,23 +73,19 @@ async function InitialExploreView() {
     return <ExploreView />;
   }
 
-  let initialResponse: Readonly<{ ok: boolean; body: unknown }>;
-  try {
-    const response = await readExploreResponse(new NextRequest(
-      `http://programmable.local/api/explore?${INITIAL_EXPLORE_QUERY}`,
-      {
-        headers: { Accept: "application/json" },
-        signal: AbortSignal.timeout(INITIAL_EXPLORE_TIMEOUT_MS),
-      },
-    ));
-    const body: unknown = await response.json().catch(() => null);
-    initialResponse = { ok: response.ok, body };
-  } catch {
-    initialResponse = {
-      ok: false,
-      body: { error: "Tokens are temporarily unavailable" },
-    };
-  }
+  const initialResponse = await readInitialExploreWithinDeadline(
+    async (signal) => {
+      const response = await readExploreResponse(new NextRequest(
+        `http://programmable.local/api/explore?${INITIAL_EXPLORE_QUERY}`,
+        {
+          headers: { Accept: "application/json" },
+          signal,
+        },
+      ));
+      const body: unknown = await response.json().catch(() => null);
+      return { ok: response.ok, body };
+    },
+  );
 
   return <ExploreView initialResponse={initialResponse} />;
 }

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { Suspense } from "react";
 
 import { ExploreView } from "@/components/explore-view";
+
+export const dynamic = "force-dynamic";
+
+const INITIAL_EXPLORE_URL = "https://programmable.market/api/explore";
+const INITIAL_EXPLORE_TIMEOUT_MS = 12_000;
 
 export const metadata: Metadata = {
   title: "Programmable",
@@ -10,6 +17,43 @@ export const metadata: Metadata = {
   },
 };
 
+function isLocalPreviewHost(host: string | null) {
+  const hostname = host
+    ?.replace(/^\[|\](?::\d+)?$|:\d+$/gu, "")
+    .toLowerCase();
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+  );
+}
+
+async function InitialExploreView() {
+  const requestHeaders = await headers();
+  if (isLocalPreviewHost(requestHeaders.get("host"))) {
+    return <ExploreView />;
+  }
+
+  let initialResponse: Readonly<{ ok: boolean; body: unknown }>;
+  try {
+    const response = await fetch(INITIAL_EXPLORE_URL, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(INITIAL_EXPLORE_TIMEOUT_MS),
+    });
+    const body: unknown = await response.json().catch(() => null);
+    initialResponse = { ok: response.ok, body };
+  } catch {
+    initialResponse = {
+      ok: false,
+      body: { error: "Tokens are temporarily unavailable" },
+    };
+  }
+
+  return <ExploreView initialResponse={initialResponse} />;
+}
+
 export default function ExplorePage() {
-  return <ExploreView />;
+  return (
+    <Suspense fallback={<ExploreView loadingOnly />}>
+      <InitialExploreView />
+    </Suspense>
+  );
 }

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,13 +1,20 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
+import { NextRequest } from "next/server";
 import { Suspense } from "react";
 
+import { GET as readExploreResponse } from "@/app/api/explore/route";
 import { ExploreView } from "@/components/explore-view";
 
 export const dynamic = "force-dynamic";
 
-const INITIAL_EXPLORE_URL = "https://programmable.market/api/explore";
 const INITIAL_EXPLORE_TIMEOUT_MS = 12_000;
+const INITIAL_EXPLORE_QUERY = new URLSearchParams({
+  q: "",
+  sort: "market-cap",
+  page: "1",
+  limit: "9",
+}).toString();
 
 export const metadata: Metadata = {
   title: "Programmable",
@@ -34,10 +41,13 @@ async function InitialExploreView() {
 
   let initialResponse: Readonly<{ ok: boolean; body: unknown }>;
   try {
-    const response = await fetch(INITIAL_EXPLORE_URL, {
-      headers: { Accept: "application/json" },
-      signal: AbortSignal.timeout(INITIAL_EXPLORE_TIMEOUT_MS),
-    });
+    const response = await readExploreResponse(new NextRequest(
+      `http://programmable.local/api/explore?${INITIAL_EXPLORE_QUERY}`,
+      {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(INITIAL_EXPLORE_TIMEOUT_MS),
+      },
+    ));
     const body: unknown = await response.json().catch(() => null);
     initialResponse = { ok: response.ok, body };
   } catch {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -128,6 +128,11 @@ type ExploreState =
       refreshError?: string;
     };
 
+export type ExploreInitialResponse = Readonly<{
+  ok: boolean;
+  body: unknown;
+}>;
+
 export function preserveExplorePayloadOnRefreshFailure(
   current: ExploreState,
   input: {
@@ -738,6 +743,47 @@ function readApiError(value: unknown) {
     : "Tokens are temporarily unavailable";
 }
 
+export function createExploreInitialState(
+  response: ExploreInitialResponse | undefined,
+  input: Readonly<{
+    requestKey: string;
+    contentKey: string;
+  }>,
+): ExploreState | null {
+  if (response === undefined) return null;
+  if (!response.ok) {
+    return {
+      phase: "error",
+      message: readApiError(response.body),
+      ...input,
+    };
+  }
+
+  try {
+    const payload = parseExplorePayload(response.body);
+    if (
+      payload.page !== 1 ||
+      payload.pageSize !== EXPLORE_TOKENS_PER_PAGE
+    ) {
+      throw new Error("The token registry returned an unexpected first page");
+    }
+    return {
+      phase: "ready",
+      payload,
+      ...input,
+    };
+  } catch (error) {
+    return {
+      phase: "error",
+      message:
+        error instanceof Error
+          ? error.message
+          : "The token registry returned an invalid response",
+      ...input,
+    };
+  }
+}
+
 type PendingExploreRequest = {
   controller: AbortController;
   promise: Promise<ExplorePayload>;
@@ -1152,7 +1198,13 @@ export function exploreDataQualityMessage(
   return null;
 }
 
-export function ExploreView() {
+export function ExploreView({
+  initialResponse,
+  loadingOnly = false,
+}: Readonly<{
+  initialResponse?: ExploreInitialResponse;
+  loadingOnly?: boolean;
+}> = {}) {
   const preview = useInterfacePreview();
   const [query, setQuery] = useState("");
   const normalizedQuery = query.trim();
@@ -1162,7 +1214,9 @@ export function ExploreView() {
   const [modelFilter, setModelFilter] = useState<ExploreModelFilter>("all");
   const [currentPage, setCurrentPage] = useState(1);
   const [retryKey, setRetryKey] = useState(0);
-  const refreshKey = useLiveDataRefresh({ enabled: !preview });
+  const refreshKey = useLiveDataRefresh({
+    enabled: !preview && !loadingOnly,
+  });
   const activeExploreContentKey = useRef<string | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const resultStatusRef = useRef<HTMLParagraphElement>(null);
@@ -1176,7 +1230,17 @@ export function ExploreView() {
   const modelDatasetKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}\u0000${refreshKey}`;
   const activeRequestContentKey =
     modelFilter === "all" ? contentKey : modelDatasetKey;
+  const [initialState] = useState(() =>
+    createExploreInitialState(initialResponse, {
+      requestKey,
+      contentKey,
+    }),
+  );
+  const handledRequestKey = useRef<string | null>(
+    initialState === null ? null : requestKey,
+  );
   const [state, setState] = useState<ExploreState>(() => {
+    if (initialState !== null) return initialState;
     const cached = readResolvedExplorePayload(activeRequestContentKey);
     return cached
       ? {
@@ -1187,7 +1251,6 @@ export function ExploreView() {
         }
       : { phase: "loading" };
   });
-
   useEffect(
     () => () => {
       if (activeExploreContentKey.current) {
@@ -1235,7 +1298,18 @@ export function ExploreView() {
   }, []);
 
   useEffect(() => {
-    if (preview) return;
+    if (preview || loadingOnly) return;
+
+    if (handledRequestKey.current === requestKey) {
+      activeExploreContentKey.current = activeRequestContentKey;
+      if (initialState?.phase === "ready") {
+        cacheResolvedExplorePayload(
+          activeRequestContentKey,
+          initialState.payload,
+        );
+      }
+      return;
+    }
 
     let ignore = false;
     const previousContentKey = activeExploreContentKey.current;
@@ -1288,6 +1362,7 @@ export function ExploreView() {
         if (payload.page !== currentPage) {
           setCurrentPage(payload.page);
         }
+        handledRequestKey.current = requestKey;
         setState({
           phase: "ready",
           payload,
@@ -1321,6 +1396,8 @@ export function ExploreView() {
     activeRequestContentKey,
     modelDatasetKey,
     modelFilter,
+    initialState,
+    loadingOnly,
     preview,
     requestKey,
     socialFilter,

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1209,7 +1209,7 @@ export function ExploreView({
   const [query, setQuery] = useState("");
   const normalizedQuery = query.trim();
   const [debouncedQuery, setDebouncedQuery] = useState("");
-  const [sort, setSort] = useState<TokenSort>("market-cap");
+  const [sort, setSort] = useState<TokenSort>("newest");
   const [socialFilter, setSocialFilter] = useState<ExploreSocialFilter>("all");
   const [modelFilter, setModelFilter] = useState<ExploreModelFilter>("all");
   const [currentPage, setCurrentPage] = useState(1);

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -784,6 +784,13 @@ export function createExploreInitialState(
   }
 }
 
+export function handledInitialExploreRequestKey(
+  state: ExploreState | null,
+  requestKey: string,
+): string | null {
+  return state?.phase === "ready" ? requestKey : null;
+}
+
 type PendingExploreRequest = {
   controller: AbortController;
   promise: Promise<ExplorePayload>;
@@ -1237,7 +1244,7 @@ export function ExploreView({
     }),
   );
   const handledRequestKey = useRef<string | null>(
-    initialState === null ? null : requestKey,
+    handledInitialExploreRequestKey(initialState, requestKey),
   );
   const [state, setState] = useState<ExploreState>(() => {
     if (initialState !== null) return initialState;

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -852,6 +852,23 @@ export function buildChartVolumeMetric(
   };
 }
 
+export function getValuationMetricLabel(
+  valuation: ExploreValuation | undefined,
+): string {
+  const isMarketCap = valuation?.status === "available" &&
+    valuation.metric === "market-cap" &&
+    valuation.supplyBasis === "circulating";
+  const currentLabel = isMarketCap ? "Market cap" : "FDV";
+
+  if (valuation?.status !== "available" || valuation.freshness === "current") {
+    return currentLabel;
+  }
+  if (valuation.freshness === "stale") {
+    return isMarketCap ? "Last verified market cap" : "Last verified FDV";
+  }
+  return isMarketCap ? "Unverified market cap" : "Unverified FDV";
+}
+
 export function buildTokenDetailMetrics(
   token: LauncherToken & Readonly<{
     valuation?: ExploreValuation;
@@ -890,14 +907,7 @@ export function buildTokenDetailMetrics(
     : null;
   const values: Array<TokenMetric | null> = [
     {
-      label:
-        valuation.status === "available" && valuation.freshness === "stale"
-          ? valuation.metric === "market-cap"
-            ? "Last verified market cap"
-            : "Last verified FDV"
-          : valuation.status === "available" && valuation.metric === "market-cap"
-            ? "Market cap"
-            : "FDV",
+      label: getValuationMetricLabel(valuation),
       value: formattedFdv ?? "Unavailable",
     },
     {
@@ -1771,10 +1781,7 @@ function customMarketMetrics(project: DetailCustomProject): TokenMetric[] {
           : "Unavailable";
   return [
     {
-      label:
-        valuation?.status === "available" && valuation.metric === "market-cap"
-          ? "Market cap"
-          : "FDV",
+      label: getValuationMetricLabel(valuation),
       value: valuationValue ?? "Unavailable",
     },
     { label: "Market data", value: marketStatus },

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -2057,10 +2057,14 @@ export function TokenDetailView({ address }: { address: string }) {
 
   useEffect(() => {
     if (!normalizedAddress || preview) return;
+    void preloadTokenChart(normalizedAddress, "1d");
+  }, [normalizedAddress, preview]);
+
+  useEffect(() => {
+    if (!normalizedAddress || preview) return;
 
     const tokenAddress = normalizedAddress;
     const controller = new AbortController();
-    void preloadTokenChart(tokenAddress, "1d");
 
     async function loadToken() {
       try {

--- a/lib/explore-public-visibility.ts
+++ b/lib/explore-public-visibility.ts
@@ -1,0 +1,72 @@
+type EvidenceBoundExploreExclusionV1 = Readonly<{
+  identity: string;
+  evidence: string;
+  kind: "release-canary-token";
+}>;
+
+/**
+ * Discovery exclusions are limited to identities that the repository's
+ * canonical release evidence explicitly classifies as canaries. Display
+ * names, symbols, creators, liquidity and market activity are deliberately
+ * excluded from this policy because none of them proves launch intent.
+ */
+export const NON_PUBLIC_EXPLORE_IDENTITIES_V1 = Object.freeze({
+  tokens: Object.freeze([
+    Object.freeze({
+      identity: "0xFA5D9694D9f8fa47b8A6c15Df4510b76cb844e2c",
+      evidence:
+        "contracts/deployments/mainnet-classic-v3.json#lifecycleEvidence.canaryToken",
+      kind: "release-canary-token" as const,
+    }),
+    Object.freeze({
+      identity: "0x3a778578b3a21dd842c29be3d1816b1af37d54f3",
+      evidence:
+        "contracts/deployments/mainnet-deep-full-range-v1.json#lifecycleEvidence.canaryToken",
+      kind: "release-canary-token" as const,
+    }),
+    Object.freeze({
+      identity: "0x3C82787014931BD11b9edb789E42F92d792Dd07f",
+      evidence:
+        "contracts/deployments/mainnet-stock-paired-v1.json#lifecycleEvidence.canaryToken",
+      kind: "release-canary-token" as const,
+    }),
+    Object.freeze({
+      identity: "0x369f5fa21942560c42Ba9FDb8a156F5C962BD2eC",
+      evidence:
+        "contracts/deployments/mainnet-stock-paired-v2.json#lifecycleEvidence.canaryToken",
+      kind: "release-canary-token" as const,
+    }),
+    Object.freeze({
+      identity: "0x2C348590Cb56Fcc5984F035D57bdb01e32c945D5",
+      evidence:
+        "contracts/deployments/mainnet-stock-paired-v3.json#lifecycleEvidence.canaryToken",
+      kind: "release-canary-token" as const,
+    }),
+    Object.freeze({
+      identity: "0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE",
+      evidence:
+        "components/launch-stamp-docs-contract.ts#PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter.canaryEvidence.components.token",
+      kind: "release-canary-token" as const,
+    }),
+  ] satisfies readonly EvidenceBoundExploreExclusionV1[]),
+});
+
+const NON_PUBLIC_TOKEN_ADDRESSES = new Set(
+  NON_PUBLIC_EXPLORE_IDENTITIES_V1.tokens.map(({ identity }) =>
+    identity.toLowerCase()),
+);
+/**
+ * Controls only public discovery. Direct token lookup remains available so
+ * historical evidence and exact-address access are preserved.
+ */
+export function isPublicExploreIdentityV1(
+  identity: Readonly<{ tokenAddress?: string }>,
+): boolean {
+  if (
+    typeof identity.tokenAddress === "string" &&
+    NON_PUBLIC_TOKEN_ADDRESSES.has(identity.tokenAddress.toLowerCase())
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/lib/market-data/bitquery-stream.server.ts
+++ b/lib/market-data/bitquery-stream.server.ts
@@ -224,6 +224,7 @@ export const BITQUERY_MARKET_STREAM_QUERY = `
         }
       ) {
         Block { Number Time }
+        Log { Index }
         PoolEvent {
           Pool {
             PoolId
@@ -237,7 +238,7 @@ export const BITQUERY_MARKET_STREAM_QUERY = `
             AmountCurrencyBInUSD
           }
         }
-        Transaction { Hash }
+        Transaction { Hash Index }
       }
     }
   }

--- a/lib/market-data/bitquery-stream.server.ts
+++ b/lib/market-data/bitquery-stream.server.ts
@@ -225,8 +225,17 @@ export const BITQUERY_MARKET_STREAM_QUERY = `
       ) {
         Block { Number Time }
         PoolEvent {
-          Pool { PoolId }
-          Liquidity { AmountCurrencyAInUSD AmountCurrencyBInUSD }
+          Pool {
+            PoolId
+            CurrencyA { SmartContract Symbol }
+            CurrencyB { SmartContract Symbol }
+          }
+          Liquidity {
+            AmountCurrencyA
+            AmountCurrencyAInUSD
+            AmountCurrencyB
+            AmountCurrencyBInUSD
+          }
         }
         Transaction { Hash }
       }

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -42,6 +42,7 @@ const CHART_CACHE_CURRENT_MAX_AGE_MS = 2_000;
 const CHART_CACHE_MAX_AGE_MS = 2 * 60 * 1_000;
 const MAXIMUM_CHART_TRADES = 2_000;
 const CHART_TRADE_PAGE_SIZE = 500;
+const CHART_READ_TIMEOUT_MS = 12_000;
 const MAXIMUM_CHART_POINTS = 80;
 const SUPPLY_PRICE_MAXIMUM_DISTANCE_MS = 24 * 60 * 60 * 1_000;
 const INDEXED_PRICE_MAXIMUM_DISTANCE_MS = MARKET_DATA_CURRENT_MAX_AGE_MS;
@@ -79,6 +80,12 @@ type MarketCacheEntry = Readonly<{
 type ChartCacheEntry = Readonly<{
   storedAt: number;
   value: MarketChartV1;
+}>;
+
+type ChartTradeCursor = Readonly<{
+  blockNumber: string;
+  transactionIndex: number;
+  logIndex: number;
 }>;
 
 const marketCache = new Map<string, MarketCacheEntry>();
@@ -313,24 +320,30 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
 
   const since = chartRangeStart(input.range, now);
   const deriveValuation = input.valuation === undefined;
+  const chartController = new AbortController();
+  const abortChartRead = () => chartController.abort();
+  if (input.signal?.aborted) abortChartRead();
+  input.signal?.addEventListener("abort", abortChartRead, { once: true });
+  const chartTimeout = setTimeout(abortChartRead, CHART_READ_TIMEOUT_MS);
   try {
-    const rows: unknown[] = [];
+    const rows: MarketTradeV1[] = [];
     let trading: Record<string, unknown> | null = null;
     let responseWasPartial = false;
+    let cursor: ChartTradeCursor | null = null;
     for (
-      let offset = 0;
-      offset < MAXIMUM_CHART_TRADES;
-      offset += CHART_TRADE_PAGE_SIZE
+      let pageIndex = 0;
+      pageIndex * CHART_TRADE_PAGE_SIZE < MAXIMUM_CHART_TRADES;
+      pageIndex += 1
     ) {
-      const withValuation = deriveValuation && offset === 0;
+      const withValuation = deriveValuation && pageIndex === 0;
       const query = marketChartQuery(
         input.range,
         since !== null,
         withValuation,
+        cursor,
       );
       const variables: Record<string, unknown> = {
         poolId: identity.poolId,
-        offset,
         till: now.toISOString(),
         ...(withValuation ? { tokenAddress: identity.tokenAddress } : {}),
         ...(since === null ? {} : { since: since.toISOString() }),
@@ -338,10 +351,19 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       const response = await executeBitqueryGraphql(query, variables, {
         ...input,
         token,
+        signal: chartController.signal,
       });
       const evm = record(response.data.EVM);
-      const page = array(evm?.DEXTrades);
       if (evm === null) throw new BitqueryMarketDataError("response");
+      const pageRows = array(evm.DEXTrades);
+      const page = pageRows.flatMap((row) => {
+        const trade = parseTrade(row, identity);
+        return trade === null ? [] : [trade];
+      });
+      if (page.length !== pageRows.length) {
+        throw new BitqueryMarketDataError("integrity");
+      }
+      assertDescendingChartPage(page, cursor);
       if (withValuation) {
         trading = record(response.data.Trading);
         if (trading === null) throw new BitqueryMarketDataError("response");
@@ -349,20 +371,17 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       rows.push(...page);
       responseWasPartial ||= response.partial;
       if (page.length < CHART_TRADE_PAGE_SIZE) break;
+      cursor = chartTradeCursor(page.at(-1) as MarketTradeV1);
     }
     const indexedPrice = deriveValuation
       ? parseTokenPriceObservation(array(trading?.Tokens)[0], identity)
       : null;
-    const parsed = rows.flatMap((row) => {
-      const trade = parseTrade(row, identity);
-      return trade === null ? [] : [trade];
-    });
-    const trades = canonicalTrades(parsed);
+    const trades = canonicalTrades(rows);
     const supply = deriveValuation
       ? parseSupply(array(trading?.Tokens)[0], identity)
       : null;
 
-    if (rows.length !== parsed.length) {
+    if (rows.length !== trades.length) {
       throw new BitqueryMarketDataError("integrity");
     }
     if (trades.length === 0) {
@@ -438,6 +457,9 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
     return chart;
   } catch {
     return cachedChartOrUnavailable(identity, input.range, cacheKey, now);
+  } finally {
+    clearTimeout(chartTimeout);
+    input.signal?.removeEventListener("abort", abortChartRead);
   }
 }
 
@@ -850,6 +872,7 @@ async function executeBitqueryGraphql(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   const abort = () => controller.abort();
+  if (options.signal?.aborted) abort();
   options.signal?.addEventListener("abort", abort, { once: true });
   try {
     const response = await fetchImpl(BITQUERY_HTTP_ENDPOINT, {
@@ -1062,10 +1085,10 @@ function marketChartQuery(
   range: MarketChartV1["range"],
   withSince: boolean,
   withValuation: boolean,
+  cursor: ChartTradeCursor | null,
 ) {
   const definitions = [
     "$poolId: String!",
-    "$offset: Int!",
     "$till: DateTime!",
     ...(withValuation ? ["$tokenAddress: String!"] : []),
     ...(withSince ? ["$since: DateTime!"] : []),
@@ -1073,11 +1096,25 @@ function marketChartQuery(
   const blockFilter = withSince
     ? "Block: { Time: { since: $since, till: $till } }"
     : "Block: { Time: { till: $till } }";
+  const cursorFilter = cursor === null
+    ? ""
+    : `any: [
+            { Block: { Number: { lt: "${cursor.blockNumber}" } } }
+            {
+              Block: { Number: { eq: "${cursor.blockNumber}" } }
+              Transaction: { Index: { lt: ${cursor.transactionIndex} } }
+            }
+            {
+              Block: { Number: { eq: "${cursor.blockNumber}" } }
+              Transaction: { Index: { eq: ${cursor.transactionIndex} } }
+              Log: { Index: { lt: ${cursor.logIndex} } }
+            }
+          ]`;
   const dataset = range === "1h" ? "" : ", dataset: combined";
   return `query ProgrammableMarketChart(${definitions}) {
     EVM(network: eth${dataset}) {
       DEXTrades(
-        limit: { count: ${CHART_TRADE_PAGE_SIZE}, offset: $offset }
+        limit: { count: ${CHART_TRADE_PAGE_SIZE} }
         orderBy: [
           { descending: Block_Number }
           { descending: Transaction_Index }
@@ -1086,6 +1123,7 @@ function marketChartQuery(
         where: {
           TransactionStatus: { Success: true }
           ${blockFilter}
+          ${cursorFilter}
           Trade: { Dex: { ProtocolName: { is: "uniswap_v4" } }, PoolId: { is: $poolId } }
         }
       ) { ${tradeSelection()} }
@@ -1116,7 +1154,8 @@ function tradeSelection() {
 function liquiditySelection() {
   return `
     Block { Number Time }
-    Transaction { Hash }
+    Log { Index }
+    Transaction { Hash Index }
     PoolEvent {
       Pool {
         PoolId
@@ -1245,35 +1284,58 @@ function parseLiquidity(
 ): MarketLiquidityV1 | null {
   const row = record(value);
   const block = record(row?.Block);
+  const log = record(row?.Log);
   const transaction = record(row?.Transaction);
   const event = record(row?.PoolEvent);
   const pool = record(event?.Pool);
   const liquidity = record(event?.Liquidity);
+  const eventTransactionHash = canonicalTransactionHash(transaction?.Hash);
+  const eventTransactionIndex = nonNegativeSafeInteger(transaction?.Index);
+  const eventLogIndex = nonNegativeSafeInteger(log?.Index);
   if (
     !block ||
+    !log ||
+    !transaction ||
     !event ||
     !pool ||
     !liquidity ||
     canonicalBytes32(pool.PoolId) !== identity.poolId ||
-    !canonicalUnsignedInteger(block.Number)
+    !canonicalUnsignedInteger(block.Number) ||
+    eventTransactionHash === null ||
+    eventTransactionIndex === null ||
+    eventLogIndex === null
   ) return null;
   const time = isoTime(block.Time);
   const currencyA = record(pool.CurrencyA);
   const currencyB = record(pool.CurrencyB);
   const eventBlockNumber = String(block.Number);
-  const eventTransactionHash = canonicalTransactionHash(transaction?.Hash);
   const addressA = canonicalCurrencyAddress(currencyA?.SmartContract);
   const addressB = canonicalCurrencyAddress(currencyB?.SmartContract);
+  const tokenIsA = addressA === identity.tokenAddress;
+  const tokenIsB = addressB === identity.tokenAddress;
+  if (tokenIsA === tokenIsB) return null;
+  const quoteAddress = tokenIsA ? addressB : addressA;
+  if (
+    quoteAddress === null ||
+    (sameEventTrade?.quoteAddress !== undefined &&
+      sameEventTrade.quoteAddress !== quoteAddress)
+  ) return null;
   const amountA = decimalString(liquidity.AmountCurrencyA);
   const amountB = decimalString(liquidity.AmountCurrencyB);
+  const amountAInUsd = liquidity.AmountCurrencyAInUSD;
+  const amountBInUsd = liquidity.AmountCurrencyBInUSD;
   const observedA = liquidityUsdWad(
-    liquidity.AmountCurrencyAInUSD,
+    amountAInUsd,
     amountA,
   );
   const observedB = liquidityUsdWad(
-    liquidity.AmountCurrencyBInUSD,
+    amountBInUsd,
     amountB,
   );
+  if (
+    (amountAInUsd !== undefined && amountAInUsd !== null && observedA === null) ||
+    (amountBInUsd !== undefined && amountBInUsd !== null && observedB === null)
+  ) return null;
   const tradePrice = sameEventTrade?.priceUsdWad
     ? BigInt(sameEventTrade.priceUsdWad)
     : null;
@@ -1287,10 +1349,14 @@ function parseLiquidity(
     eventTime: time,
     eventBlockNumber,
     eventTransactionHash,
+    eventTransactionIndex,
+    eventLogIndex,
     tokenPriceUsdWad: tradePrice,
     tokenPriceTime: sameEventTrade?.priceUsdAsOfTime,
     tokenPriceBlockNumber: sameEventTrade?.blockNumber,
     tokenPriceTransactionHash: sameEventTrade?.transactionHash,
+    tokenPriceTransactionIndex: sameEventTrade?.transactionIndex,
+    tokenPriceLogIndex: sameEventTrade?.logIndex,
     tokenPriceQuoteWad: tradeQuotePrice,
     quoteAddress: sameEventTrade?.quoteAddress,
   });
@@ -1301,10 +1367,14 @@ function parseLiquidity(
     eventTime: time,
     eventBlockNumber,
     eventTransactionHash,
+    eventTransactionIndex,
+    eventLogIndex,
     tokenPriceUsdWad: tradePrice,
     tokenPriceTime: sameEventTrade?.priceUsdAsOfTime,
     tokenPriceBlockNumber: sameEventTrade?.blockNumber,
     tokenPriceTransactionHash: sameEventTrade?.transactionHash,
+    tokenPriceTransactionIndex: sameEventTrade?.transactionIndex,
+    tokenPriceLogIndex: sameEventTrade?.logIndex,
     tokenPriceQuoteWad: tradeQuotePrice,
     quoteAddress: sameEventTrade?.quoteAddress,
   });
@@ -1327,11 +1397,15 @@ function deriveLiquiditySideUsd(input: Readonly<{
   identity: MarketDataIdentityV1;
   eventTime: string | null;
   eventBlockNumber: string;
-  eventTransactionHash: `0x${string}` | null;
+  eventTransactionHash: `0x${string}`;
+  eventTransactionIndex: number;
+  eventLogIndex: number;
   tokenPriceUsdWad: bigint | null;
   tokenPriceTime?: string;
   tokenPriceBlockNumber?: string;
   tokenPriceTransactionHash?: `0x${string}`;
+  tokenPriceTransactionIndex?: number;
+  tokenPriceLogIndex?: number;
   tokenPriceQuoteWad: bigint | null;
   quoteAddress?: `0x${string}`;
 }>): bigint | null {
@@ -1341,8 +1415,9 @@ function deriveLiquiditySideUsd(input: Readonly<{
   if (/^0(?:\.0+)?$/u.test(input.amount)) return 0n;
   const priceIsEventBound = input.tokenPriceTime === input.eventTime &&
     input.tokenPriceBlockNumber === input.eventBlockNumber &&
-    input.eventTransactionHash !== null &&
-    input.tokenPriceTransactionHash === input.eventTransactionHash;
+    input.tokenPriceTransactionHash === input.eventTransactionHash &&
+    input.tokenPriceTransactionIndex === input.eventTransactionIndex &&
+    input.tokenPriceLogIndex === input.eventLogIndex;
   if (
     input.address === input.identity.tokenAddress &&
     input.tokenPriceUsdWad !== null &&
@@ -1373,15 +1448,15 @@ function liquidityUsdWad(
   rawAmount: string | null,
 ): bigint | null {
   const normalized = decimalString(value);
-  if (normalized === null) return null;
+  if (normalized === null || rawAmount === null) return null;
+  const amountIsZero = /^0(?:\.0+)?$/u.test(rawAmount);
+  const usdIsZero = /^0(?:\.0+)?$/u.test(normalized);
+  if (amountIsZero !== usdIsZero) return null;
+  if (usdIsZero) return 0n;
   const [whole, fraction = ""] = normalized.split(".");
   const wad = BigInt(whole) * WAD +
     BigInt(fraction.slice(0, 18).padEnd(18, "0") || "0");
-  if (
-    wad === 0n &&
-    (rawAmount === null || !/^0(?:\.0+)?$/u.test(rawAmount))
-  ) return null;
-  return wad;
+  return wad > 0n ? wad : null;
 }
 
 function parseStats(value: unknown): Readonly<{
@@ -1832,6 +1907,50 @@ function canonicalTrades(trades: readonly MarketTradeV1[]): MarketTradeV1[] {
     byKey.set(key, trade);
   }
   return [...byKey.values()];
+}
+
+function chartTradeCursor(trade: MarketTradeV1): ChartTradeCursor {
+  if (trade.transactionIndex === undefined) {
+    throw new BitqueryMarketDataError("integrity");
+  }
+  return {
+    blockNumber: trade.blockNumber,
+    transactionIndex: trade.transactionIndex,
+    logIndex: trade.logIndex,
+  };
+}
+
+function compareChartTradePosition(
+  first: ChartTradeCursor,
+  second: ChartTradeCursor,
+): number {
+  const firstBlock = BigInt(first.blockNumber);
+  const secondBlock = BigInt(second.blockNumber);
+  if (firstBlock !== secondBlock) return firstBlock < secondBlock ? -1 : 1;
+  if (first.transactionIndex !== second.transactionIndex) {
+    return first.transactionIndex < second.transactionIndex ? -1 : 1;
+  }
+  if (first.logIndex !== second.logIndex) {
+    return first.logIndex < second.logIndex ? -1 : 1;
+  }
+  return 0;
+}
+
+function assertDescendingChartPage(
+  trades: readonly MarketTradeV1[],
+  previousPageCursor: ChartTradeCursor | null,
+): void {
+  let previous = previousPageCursor;
+  for (const trade of trades) {
+    const current = chartTradeCursor(trade);
+    if (
+      previous !== null &&
+      compareChartTradePosition(current, previous) >= 0
+    ) {
+      throw new BitqueryMarketDataError("integrity");
+    }
+    previous = current;
+  }
 }
 
 function chartPoints(

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -465,14 +465,14 @@ export function ingestBitqueryMarketStreamPayloadV1(input: Readonly<{
   if (parsedTrades.length !== tradeRows.length) {
     throw new BitqueryMarketDataError("integrity");
   }
+  const latestTrade = canonicalTrades(parsedTrades).at(-1) ?? null;
   const parsedLiquidity = liquidityRows.flatMap((row) => {
-    const liquidity = parseLiquidity(row, identity, now);
+    const liquidity = parseLiquidity(row, identity, now, latestTrade);
     return liquidity === null ? [] : [liquidity];
   });
   if (parsedLiquidity.length !== liquidityRows.length) {
     throw new BitqueryMarketDataError("integrity");
   }
-  const latestTrade = canonicalTrades(parsedTrades).at(-1) ?? null;
   const latestLiquidity = parsedLiquidity.sort((first, second) => {
     const left = BigInt(first.asOfBlock);
     const right = BigInt(second.asOfBlock);
@@ -620,6 +620,7 @@ async function readMarketBatch(
       identity,
       latestTradeRows,
       latestTrade,
+      liquidityPriceTrade: parsedTrade,
       liquidityRow: liquidityByPool.get(identity.poolId),
       stats: parseStats(statsByMarket.get(
         marketStatsKey(identity.poolId, identity.tokenAddress),
@@ -633,7 +634,7 @@ async function readMarketBatch(
       value.liquidityRow,
       value.identity,
       options.now,
-      value.latestTrade,
+      value.liquidityPriceTrade,
     );
     return marketPoolData({
       identity: value.identity,
@@ -1115,6 +1116,7 @@ function tradeSelection() {
 function liquiditySelection() {
   return `
     Block { Number Time }
+    Transaction { Hash }
     PoolEvent {
       Pool {
         PoolId
@@ -1239,10 +1241,11 @@ function parseLiquidity(
   value: unknown,
   identity: MarketDataIdentityV1,
   now: Date,
-  latestTrade: MarketTradeV1 | null = null,
+  sameEventTrade: MarketTradeV1 | null = null,
 ): MarketLiquidityV1 | null {
   const row = record(value);
   const block = record(row?.Block);
+  const transaction = record(row?.Transaction);
   const event = record(row?.PoolEvent);
   const pool = record(event?.Pool);
   const liquidity = record(event?.Liquidity);
@@ -1257,38 +1260,62 @@ function parseLiquidity(
   const time = isoTime(block.Time);
   const currencyA = record(pool.CurrencyA);
   const currencyB = record(pool.CurrencyB);
+  const eventBlockNumber = String(block.Number);
+  const eventTransactionHash = canonicalTransactionHash(transaction?.Hash);
   const addressA = canonicalCurrencyAddress(currencyA?.SmartContract);
   const addressB = canonicalCurrencyAddress(currencyB?.SmartContract);
-  const amountA = positiveDecimal(liquidity.AmountCurrencyA);
-  const amountB = positiveDecimal(liquidity.AmountCurrencyB);
-  const observedA = decimalToWad(liquidity.AmountCurrencyAInUSD);
-  const observedB = decimalToWad(liquidity.AmountCurrencyBInUSD);
-  const tradePrice = latestTrade?.priceUsdWad
-    ? BigInt(latestTrade.priceUsdWad)
+  const amountA = decimalString(liquidity.AmountCurrencyA);
+  const amountB = decimalString(liquidity.AmountCurrencyB);
+  const observedA = liquidityUsdWad(
+    liquidity.AmountCurrencyAInUSD,
+    amountA,
+  );
+  const observedB = liquidityUsdWad(
+    liquidity.AmountCurrencyBInUSD,
+    amountB,
+  );
+  const tradePrice = sameEventTrade?.priceUsdWad
+    ? BigInt(sameEventTrade.priceUsdWad)
+    : null;
+  const tradeQuotePrice = sameEventTrade?.priceQuoteWad
+    ? BigInt(sameEventTrade.priceQuoteWad)
     : null;
   const first = observedA ?? deriveLiquiditySideUsd({
     address: addressA,
     amount: amountA,
     identity,
     eventTime: time,
+    eventBlockNumber,
+    eventTransactionHash,
     tokenPriceUsdWad: tradePrice,
-    tokenPriceTime: latestTrade?.priceUsdAsOfTime,
+    tokenPriceTime: sameEventTrade?.priceUsdAsOfTime,
+    tokenPriceBlockNumber: sameEventTrade?.blockNumber,
+    tokenPriceTransactionHash: sameEventTrade?.transactionHash,
+    tokenPriceQuoteWad: tradeQuotePrice,
+    quoteAddress: sameEventTrade?.quoteAddress,
   });
   const second = observedB ?? deriveLiquiditySideUsd({
     address: addressB,
     amount: amountB,
     identity,
     eventTime: time,
+    eventBlockNumber,
+    eventTransactionHash,
     tokenPriceUsdWad: tradePrice,
-    tokenPriceTime: latestTrade?.priceUsdAsOfTime,
+    tokenPriceTime: sameEventTrade?.priceUsdAsOfTime,
+    tokenPriceBlockNumber: sameEventTrade?.blockNumber,
+    tokenPriceTransactionHash: sameEventTrade?.transactionHash,
+    tokenPriceQuoteWad: tradeQuotePrice,
+    quoteAddress: sameEventTrade?.quoteAddress,
   });
   if (time === null || first === null || second === null) return null;
   const total = first + second;
+  if (total <= 0n) return null;
   const age = now.getTime() - Date.parse(time);
   if (age < -MAXIMUM_FUTURE_SKEW_MS) return null;
   return {
     asOfTime: time,
-    asOfBlock: String(block.Number),
+    asOfBlock: eventBlockNumber,
     valueUsdWad: total.toString(),
     freshness: age > MARKET_DATA_CURRENT_MAX_AGE_MS ? "stale" : "current",
   };
@@ -1299,22 +1326,62 @@ function deriveLiquiditySideUsd(input: Readonly<{
   amount: string | null;
   identity: MarketDataIdentityV1;
   eventTime: string | null;
+  eventBlockNumber: string;
+  eventTransactionHash: `0x${string}` | null;
   tokenPriceUsdWad: bigint | null;
   tokenPriceTime?: string;
+  tokenPriceBlockNumber?: string;
+  tokenPriceTransactionHash?: `0x${string}`;
+  tokenPriceQuoteWad: bigint | null;
+  quoteAddress?: `0x${string}`;
 }>): bigint | null {
   if (input.address === null || input.amount === null || input.eventTime === null) {
     return null;
   }
+  if (/^0(?:\.0+)?$/u.test(input.amount)) return 0n;
+  const priceIsEventBound = input.tokenPriceTime === input.eventTime &&
+    input.tokenPriceBlockNumber === input.eventBlockNumber &&
+    input.eventTransactionHash !== null &&
+    input.tokenPriceTransactionHash === input.eventTransactionHash;
   if (
     input.address === input.identity.tokenAddress &&
     input.tokenPriceUsdWad !== null &&
-    input.tokenPriceTime &&
-    Math.abs(Date.parse(input.tokenPriceTime) - Date.parse(input.eventTime)) <=
-      INDEXED_PRICE_MAXIMUM_DISTANCE_MS
+    priceIsEventBound
   ) {
     return multiplyWadByDecimal(input.tokenPriceUsdWad, input.amount);
   }
+  if (
+    input.address === input.quoteAddress &&
+    (input.quoteAddress === NATIVE_ETH_ADDRESS ||
+      input.quoteAddress === WETH_ADDRESS) &&
+    input.tokenPriceUsdWad !== null &&
+    input.tokenPriceQuoteWad !== null &&
+    input.tokenPriceQuoteWad > 0n &&
+    priceIsEventBound
+  ) {
+    const quotePriceUsdWad = input.tokenPriceUsdWad * WAD /
+      input.tokenPriceQuoteWad;
+    return quotePriceUsdWad > 0n
+      ? multiplyWadByDecimal(quotePriceUsdWad, input.amount)
+      : null;
+  }
   return null;
+}
+
+function liquidityUsdWad(
+  value: unknown,
+  rawAmount: string | null,
+): bigint | null {
+  const normalized = decimalString(value);
+  if (normalized === null) return null;
+  const [whole, fraction = ""] = normalized.split(".");
+  const wad = BigInt(whole) * WAD +
+    BigInt(fraction.slice(0, 18).padEnd(18, "0") || "0");
+  if (
+    wad === 0n &&
+    (rawAmount === null || !/^0(?:\.0+)?$/u.test(rawAmount))
+  ) return null;
+  return wad;
 }
 
 function parseStats(value: unknown): Readonly<{

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -31,6 +31,8 @@ const REQUEST_TIMEOUT_MS = 8_000;
 const MAXIMUM_RESPONSE_BYTES = 1_500_000;
 const MARKET_BATCH_SIZE = 100;
 const MARKET_BATCH_CONCURRENCY = 2;
+const INDEXED_PRICE_BATCH_SIZE = 20;
+const INDEXED_PRICE_BATCH_CONCURRENCY = 2;
 const INDEXED_PRICE_RECOVERY_CONCURRENCY = 4;
 const MAXIMUM_INDEXED_PRICE_RECOVERIES_PER_BATCH = 20;
 const MARKET_CACHE_CURRENT_MAX_AGE_MS = 2_000;
@@ -522,13 +524,15 @@ async function readMarketBatch(
       trade: parseTrade(row, identity),
     };
   });
-  const priceRequest = marketPriceQuery(parsedTrades.map(({ trade }) => trade));
+  const priceCandidates = parsedTrades.flatMap(({ trade }, index) =>
+    trade && trade.priceUsdWad === undefined &&
+        (trade.quoteAddress === NATIVE_ETH_ADDRESS ||
+          trade.quoteAddress === WETH_ADDRESS)
+      ? [{ index, trade }]
+      : []
+  );
   const [priceResult, liquidityResult, statsResult] = await Promise.allSettled([
-      executeBitqueryGraphql(
-        priceRequest.query,
-        priceRequest.variables,
-        options,
-      ),
+      readIndexedPriceObservations(priceCandidates, options),
       executeBitqueryGraphql(
         liquidityRequest.query,
         liquidityRequest.variables,
@@ -541,9 +545,11 @@ async function readMarketBatch(
       ),
     ]);
 
-  const priceTrading = priceResult.status === "fulfilled"
-    ? record(priceResult.value.data.Trading)
-    : null;
+  const indexedPricesByIndex = priceResult.status === "fulfilled"
+    ? priceResult.value.observations
+    : new Map<number, TokenPriceObservation | null>();
+  const priceLookupWasPartial = priceResult.status !== "fulfilled" ||
+    priceResult.value.partial;
   const liquidityEvm = liquidityResult.status === "fulfilled"
     ? record(liquidityResult.value.data.EVM)
     : null;
@@ -574,57 +580,13 @@ async function readMarketBatch(
       suppliesByAddress.set(address, row);
     }
   }
-  const indexedPricesByIndex = new Map<number, TokenPriceObservation | null>();
-  const missingIndexedPrices = parsedTrades.flatMap(({ trade }, index) => {
-    if (!trade || trade.priceUsdWad !== undefined) return [];
-    const observation = parseNativeQuotePriceObservation(
-      array(priceTrading?.[`price${index}`])[0],
-      trade,
-    );
-    if (observation !== null) {
-      indexedPricesByIndex.set(index, observation);
-      return [];
-    }
-    return [{ index, trade }];
-  }).slice(0, MAXIMUM_INDEXED_PRICE_RECOVERIES_PER_BATCH);
-  await mapWithConcurrency(
-    missingIndexedPrices,
-    INDEXED_PRICE_RECOVERY_CONCURRENCY,
-    async ({ index, trade }) => {
-      try {
-        const request = marketPriceQuery([trade]);
-        const response = await executeBitqueryGraphql(
-          request.query,
-          request.variables,
-          options,
-        );
-        const trading = record(response.data.Trading);
-        indexedPricesByIndex.set(
-          index,
-          parseNativeQuotePriceObservation(
-            array(trading?.price0)[0],
-            trade,
-          ),
-        );
-      } catch {
-        indexedPricesByIndex.set(index, null);
-      }
-    },
-  );
   const parsed = identities.map((identity, index) => {
     const latestTradeRow = parsedTrades[index]?.row;
     const latestTradeRows = latestTradeRow === undefined
       ? []
       : [latestTradeRow];
     const parsedTrade = parsedTrades[index]?.trade ?? null;
-    const indexedPrice = indexedPricesByIndex.has(index)
-      ? indexedPricesByIndex.get(index) ?? null
-      : parsedTrade
-        ? parseNativeQuotePriceObservation(
-            array(priceTrading?.[`price${index}`])[0],
-            parsedTrade,
-          )
-        : null;
+    const indexedPrice = indexedPricesByIndex.get(index) ?? null;
     const latestTrade = parsedTrade === null
       ? null
       : enrichTradeWithIndexedUsd(
@@ -661,14 +623,94 @@ async function readMarketBatch(
       now: options.now,
       partialResponse:
         response.partial ||
-        priceResult.status !== "fulfilled" ||
-        priceResult.value.partial ||
+        priceLookupWasPartial ||
         liquidityResult.status !== "fulfilled" ||
         liquidityResult.value.partial ||
         statsResult.status !== "fulfilled" ||
         statsResult.value.partial,
     });
   });
+}
+
+type IndexedPriceCandidate = Readonly<{
+  index: number;
+  trade: MarketTradeV1;
+}>;
+
+async function readIndexedPriceObservations(
+  candidates: readonly IndexedPriceCandidate[],
+  options: BitqueryReaderOptions & Readonly<{ token: string }>,
+): Promise<Readonly<{
+  observations: Map<number, TokenPriceObservation | null>;
+  partial: boolean;
+}>> {
+  const observations = new Map<number, TokenPriceObservation | null>();
+  const batches: IndexedPriceCandidate[][] = [];
+  for (let offset = 0; offset < candidates.length; offset += INDEXED_PRICE_BATCH_SIZE) {
+    batches.push(candidates.slice(offset, offset + INDEXED_PRICE_BATCH_SIZE));
+  }
+  let partial = false;
+  await mapWithConcurrency(
+    batches,
+    INDEXED_PRICE_BATCH_CONCURRENCY,
+    async (batch) => {
+      try {
+        const request = marketPriceQuery(batch.map(({ trade }) => trade));
+        const response = await executeBitqueryGraphql(
+          request.query,
+          request.variables,
+          options,
+        );
+        const trading = record(response.data.Trading);
+        if (trading === null) {
+          partial = true;
+          return;
+        }
+        if (response.partial) partial = true;
+        for (let index = 0; index < batch.length; index += 1) {
+          const candidate = batch[index];
+          const observation = parseNativeQuotePriceObservation(
+            array(trading[`price${index}`])[0],
+            candidate.trade,
+          );
+          if (observation !== null) {
+            observations.set(candidate.index, observation);
+          }
+        }
+      } catch {
+        partial = true;
+      }
+    },
+  );
+
+  const missing = candidates.filter(
+    ({ index }) => !observations.has(index),
+  ).slice(0, MAXIMUM_INDEXED_PRICE_RECOVERIES_PER_BATCH);
+  await mapWithConcurrency(
+    missing,
+    INDEXED_PRICE_RECOVERY_CONCURRENCY,
+    async ({ index, trade }) => {
+      try {
+        const request = marketPriceQuery([trade]);
+        const response = await executeBitqueryGraphql(
+          request.query,
+          request.variables,
+          options,
+        );
+        const trading = record(response.data.Trading);
+        observations.set(
+          index,
+          parseNativeQuotePriceObservation(
+            array(trading?.price0)[0],
+            trade,
+          ),
+        );
+      } catch {
+        observations.set(index, null);
+      }
+    },
+  );
+  return { observations, partial };
 }
 
 type TokenPriceObservation = Readonly<{
@@ -904,7 +946,7 @@ function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
   };
 }
 
-function marketPriceQuery(trades: readonly (MarketTradeV1 | null)[]) {
+function marketPriceQuery(trades: readonly MarketTradeV1[]) {
   // The legacy Trades filter `Token: { Id: { is: "bid:eth" } }` did not
   // provide a reliable USD observation. The Tokens price index requires the
   // full WETH token identity instead.
@@ -913,7 +955,7 @@ function marketPriceQuery(trades: readonly (MarketTradeV1 | null)[]) {
       limit: { count: 1 }
       orderBy: { descending: Block_Time }
       where: {
-        ${trade ? `Block: { Time: { till: "${trade.time}" } }` : ""}
+        Block: { Time: { till: "${trade.time}" } }
         Token: { Id: { is: "bid:eth:${WETH_ADDRESS}" } }
         Price: { IsQuotedInUsd: true }
       }

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -524,11 +524,24 @@ async function readMarketBatch(
   const coreRequest = marketBatchQuery(identities);
   const liquidityRequest = marketLiquidityQuery(identities);
   const statsRequest = marketStatsQuery(identities);
-  const response = await executeBitqueryGraphql(
+  const coreRead = executeBitqueryGraphql(
     coreRequest.query,
     coreRequest.variables,
     options,
   );
+  const supplementaryReads = Promise.allSettled([
+    executeBitqueryGraphql(
+      liquidityRequest.query,
+      liquidityRequest.variables,
+      options,
+    ),
+    executeBitqueryGraphql(
+      statsRequest.query,
+      statsRequest.variables,
+      options,
+    ),
+  ]);
+  const response = await coreRead;
   const evm = record(response.data.EVM);
   const trading = record(response.data.Trading);
   if (evm === null) throw new BitqueryMarketDataError("response");
@@ -547,19 +560,12 @@ async function readMarketBatch(
       ? [{ index, trade }]
       : []
   );
-  const [priceResult, liquidityResult, statsResult] = await Promise.allSettled([
+  const [[priceResult], [liquidityResult, statsResult]] = await Promise.all([
+    Promise.allSettled([
       readIndexedPriceObservations(priceCandidates, options),
-      executeBitqueryGraphql(
-        liquidityRequest.query,
-        liquidityRequest.variables,
-        options,
-      ),
-      executeBitqueryGraphql(
-        statsRequest.query,
-        statsRequest.variables,
-        options,
-      ),
-    ]);
+    ]),
+    supplementaryReads,
+  ]);
 
   const indexedPricesByIndex = priceResult.status === "fulfilled"
     ? priceResult.value.observations

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -36,6 +36,7 @@ const MAXIMUM_INDEXED_PRICE_RECOVERIES_PER_BATCH = 20;
 const MARKET_CACHE_CURRENT_MAX_AGE_MS = 2_000;
 const MARKET_CACHE_MAX_AGE_MS = 15 * 60 * 1_000;
 const DURABLE_MARKET_CACHE_SECONDS = 5 * 60;
+const CHART_CACHE_CURRENT_MAX_AGE_MS = 2_000;
 const CHART_CACHE_MAX_AGE_MS = 2 * 60 * 1_000;
 const MAXIMUM_CHART_TRADES = 2_000;
 const MAXIMUM_CHART_POINTS = 80;
@@ -299,17 +300,24 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
   const now = input.now ?? new Date();
   const identity = canonicalMarketIdentities([input.identity])[0];
   if (!identity) throw new BitqueryMarketDataError("integrity");
-  const cacheKey = `${marketCacheKey(identity)}:${input.range}`;
+  const cacheKey = chartCacheKey(identity, input.range, input.valuation);
   const token = resolveToken(input.token);
   if (token === null) {
     return cachedChartOrUnavailable(identity, input.range, cacheKey, now);
   }
+  const currentCached = currentCachedChart(cacheKey, now);
+  if (currentCached !== null) return currentCached;
 
   const since = chartRangeStart(input.range, now);
-  const query = marketChartQuery(input.range, since !== null);
+  const deriveValuation = input.valuation === undefined;
+  const query = marketChartQuery(
+    input.range,
+    since !== null,
+    deriveValuation,
+  );
   const variables: Record<string, unknown> = {
     poolId: identity.poolId,
-    tokenAddress: identity.tokenAddress,
+    ...(deriveValuation ? { tokenAddress: identity.tokenAddress } : {}),
     ...(since === null ? {} : { since: since.toISOString() }),
   };
 
@@ -319,21 +327,22 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       token,
     });
     const evm = record(response.data.EVM);
-    const trading = record(response.data.Trading);
-    if (evm === null || trading === null) {
+    const trading = deriveValuation ? record(response.data.Trading) : null;
+    if (evm === null || (deriveValuation && trading === null)) {
       throw new BitqueryMarketDataError("response");
     }
     const rows = array(evm?.DEXTrades);
-    const indexedPrice = parseTokenPriceObservation(
-      array(trading?.Tokens)[0],
-      identity,
-    );
+    const indexedPrice = deriveValuation
+      ? parseTokenPriceObservation(array(trading?.Tokens)[0], identity)
+      : null;
     const parsed = rows.flatMap((row) => {
       const trade = parseTrade(row, identity);
       return trade === null ? [] : [trade];
     });
     const trades = canonicalTrades(parsed);
-    const supply = parseSupply(array(trading?.Tokens)[0], identity);
+    const supply = deriveValuation
+      ? parseSupply(array(trading?.Tokens)[0], identity)
+      : null;
 
     if (rows.length !== parsed.length) {
       throw new BitqueryMarketDataError("integrity");
@@ -987,10 +996,13 @@ function marketStatsQuery(identities: readonly MarketDataIdentityV1[]) {
 function marketChartQuery(
   range: MarketChartV1["range"],
   withSince: boolean,
+  withValuation: boolean,
 ) {
-  const definitions = withSince
-    ? "$poolId: String!, $tokenAddress: String!, $since: DateTime!"
-    : "$poolId: String!, $tokenAddress: String!";
+  const definitions = [
+    "$poolId: String!",
+    ...(withValuation ? ["$tokenAddress: String!"] : []),
+    ...(withSince ? ["$since: DateTime!"] : []),
+  ].join(", ");
   const blockFilter = withSince
     ? "Block: { Time: { since: $since } }"
     : "";
@@ -1011,13 +1023,13 @@ function marketChartQuery(
         }
       ) { ${tradeSelection()} }
     }
-    Trading {
+    ${withValuation ? `Trading {
       Tokens(
         limit: { count: 1 }
         orderBy: { descending: Block_Time }
         where: { Token: { Address: { is: $tokenAddress } } }
       ) { ${supplySelection()} }
-    }
+    }` : ""}
   }`;
 }
 
@@ -1604,6 +1616,53 @@ function cachedChartOrUnavailable(
     valuation: { status: "unavailable", reason: "source-unavailable" },
     truncated: false,
   };
+}
+
+function currentCachedChart(
+  key: string,
+  now: Date,
+): MarketChartV1 | null {
+  const cached = chartCache.get(key);
+  if (
+    !cached ||
+    cached.value.points.length === 0 ||
+    now.getTime() - cached.storedAt > CHART_CACHE_CURRENT_MAX_AGE_MS
+  ) {
+    return null;
+  }
+  const valuation = cached.value.valuation.status === "available" &&
+      now.getTime() - Date.parse(cached.value.valuation.asOfTime) >
+        MARKET_DATA_CURRENT_MAX_AGE_MS
+    ? { ...cached.value.valuation, freshness: "stale" as const }
+    : cached.value.valuation;
+  return valuation === cached.value.valuation
+    ? cached.value
+    : { ...cached.value, valuation };
+}
+
+function chartCacheKey(
+  identity: MarketDataIdentityV1,
+  range: MarketChartV1["range"],
+  valuation: MarketValuationV1 | undefined,
+): string {
+  const valuationKey = valuation === undefined
+    ? "derived"
+    : valuation.status === "unavailable"
+      ? `unavailable:${valuation.reason}`
+      : [
+          "available",
+          valuation.metric,
+          valuation.supplyBasis,
+          valuation.valueUsdWad,
+          valuation.fdvUsdWad ?? "",
+          valuation.marketCapUsdWad ?? "",
+          valuation.totalSupply ?? "",
+          valuation.circulatingSupply ?? "",
+          valuation.maxSupply ?? "",
+          valuation.asOfTime,
+          valuation.freshness,
+        ].join(":");
+  return `${marketCacheKey(identity)}:${range}:${valuationKey}`;
 }
 
 function chartRangeStart(range: MarketChartV1["range"], now: Date): Date | null {

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -41,6 +41,7 @@ const DURABLE_MARKET_CACHE_SECONDS = 5 * 60;
 const CHART_CACHE_CURRENT_MAX_AGE_MS = 2_000;
 const CHART_CACHE_MAX_AGE_MS = 2 * 60 * 1_000;
 const MAXIMUM_CHART_TRADES = 2_000;
+const CHART_TRADE_PAGE_SIZE = 500;
 const MAXIMUM_CHART_POINTS = 80;
 const SUPPLY_PRICE_MAXIMUM_DISTANCE_MS = 24 * 60 * 60 * 1_000;
 const INDEXED_PRICE_MAXIMUM_DISTANCE_MS = MARKET_DATA_CURRENT_MAX_AGE_MS;
@@ -312,28 +313,43 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
 
   const since = chartRangeStart(input.range, now);
   const deriveValuation = input.valuation === undefined;
-  const query = marketChartQuery(
-    input.range,
-    since !== null,
-    deriveValuation,
-  );
-  const variables: Record<string, unknown> = {
-    poolId: identity.poolId,
-    ...(deriveValuation ? { tokenAddress: identity.tokenAddress } : {}),
-    ...(since === null ? {} : { since: since.toISOString() }),
-  };
-
   try {
-    const response = await executeBitqueryGraphql(query, variables, {
-      ...input,
-      token,
-    });
-    const evm = record(response.data.EVM);
-    const trading = deriveValuation ? record(response.data.Trading) : null;
-    if (evm === null || (deriveValuation && trading === null)) {
-      throw new BitqueryMarketDataError("response");
+    const rows: unknown[] = [];
+    let trading: Record<string, unknown> | null = null;
+    let responseWasPartial = false;
+    for (
+      let offset = 0;
+      offset < MAXIMUM_CHART_TRADES;
+      offset += CHART_TRADE_PAGE_SIZE
+    ) {
+      const withValuation = deriveValuation && offset === 0;
+      const query = marketChartQuery(
+        input.range,
+        since !== null,
+        withValuation,
+      );
+      const variables: Record<string, unknown> = {
+        poolId: identity.poolId,
+        offset,
+        till: now.toISOString(),
+        ...(withValuation ? { tokenAddress: identity.tokenAddress } : {}),
+        ...(since === null ? {} : { since: since.toISOString() }),
+      };
+      const response = await executeBitqueryGraphql(query, variables, {
+        ...input,
+        token,
+      });
+      const evm = record(response.data.EVM);
+      const page = array(evm?.DEXTrades);
+      if (evm === null) throw new BitqueryMarketDataError("response");
+      if (withValuation) {
+        trading = record(response.data.Trading);
+        if (trading === null) throw new BitqueryMarketDataError("response");
+      }
+      rows.push(...page);
+      responseWasPartial ||= response.partial;
+      if (page.length < CHART_TRADE_PAGE_SIZE) break;
     }
-    const rows = array(evm?.DEXTrades);
     const indexedPrice = deriveValuation
       ? parseTokenPriceObservation(array(trading?.Tokens)[0], identity)
       : null;
@@ -350,7 +366,7 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       throw new BitqueryMarketDataError("integrity");
     }
     if (trades.length === 0) {
-      if (response.partial) throw new BitqueryMarketDataError("response");
+      if (responseWasPartial) throw new BitqueryMarketDataError("response");
       const waiting: MarketChartV1 = {
         schemaVersion: PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION,
         source: "bitquery",
@@ -394,7 +410,7 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       (trade) =>
         trade.priceQuoteWad !== undefined && trade.quoteSymbol !== undefined,
     );
-    const partial = truncated || response.partial || !quotePriceComplete;
+    const partial = truncated || responseWasPartial || !quotePriceComplete;
     const status = partial
       ? "partial" as const
       : points.length === 1
@@ -1042,17 +1058,19 @@ function marketChartQuery(
 ) {
   const definitions = [
     "$poolId: String!",
+    "$offset: Int!",
+    "$till: DateTime!",
     ...(withValuation ? ["$tokenAddress: String!"] : []),
     ...(withSince ? ["$since: DateTime!"] : []),
   ].join(", ");
   const blockFilter = withSince
-    ? "Block: { Time: { since: $since } }"
-    : "";
+    ? "Block: { Time: { since: $since, till: $till } }"
+    : "Block: { Time: { till: $till } }";
   const dataset = range === "1h" ? "" : ", dataset: combined";
   return `query ProgrammableMarketChart(${definitions}) {
     EVM(network: eth${dataset}) {
       DEXTrades(
-        limit: { count: ${MAXIMUM_CHART_TRADES} }
+        limit: { count: ${CHART_TRADE_PAGE_SIZE}, offset: $offset }
         orderBy: [
           { descending: Block_Number }
           { descending: Transaction_Index }

--- a/lib/onchain/query.ts
+++ b/lib/onchain/query.ts
@@ -1,4 +1,5 @@
 import type { LauncherToken } from "../tokens";
+import { isPublicExploreIdentityV1 } from "../explore-public-visibility";
 
 import type {
   ExplorePage,
@@ -127,6 +128,7 @@ export function visibleExploreTokens(model: ExploreReadModel) {
     ? model.tokens.filter((token) => {
         const launchBlock = token.launchBlockNumber;
         return (
+          isPublicExploreIdentityV1(token) &&
           typeof launchBlock === "string" &&
           /^\d+$/u.test(launchBlock) &&
           BigInt(launchBlock) >= MAINNET_PUBLIC_EXPLORE_START_BLOCK

--- a/lib/onchain/query.ts
+++ b/lib/onchain/query.ts
@@ -22,7 +22,7 @@ export function parseExploreSort(value: string | null): ExploreSort {
   if (value === "market-cap-asc" || value === "lowest-market-cap") {
     return "market-cap-asc";
   }
-  return "market-cap";
+  return "newest";
 }
 
 function launchOrder(token: LauncherToken) {

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -209,6 +209,14 @@ export function evaluateAlchemyExploreSourceContracts(
       bitqueryMarketSource.includes('"BITQUERY_OAUTH_TOKEN" as const') &&
       bitqueryMarketSource.includes("MARKET_BATCH_SIZE = 100") &&
       bitqueryMarketSource.includes("MARKET_BATCH_CONCURRENCY = 2") &&
+      bitqueryMarketSource.includes("INDEXED_PRICE_BATCH_SIZE = 20") &&
+      bitqueryMarketSource.includes("INDEXED_PRICE_BATCH_CONCURRENCY = 2") &&
+      bitqueryMarketSource.includes(
+        "offset += INDEXED_PRICE_BATCH_SIZE",
+      ) &&
+      bitqueryMarketSource.includes(
+        "readIndexedPriceObservations(priceCandidates, options)",
+      ) &&
       bitqueryMarketSource.includes("PoolId: { in: $pools }") &&
       bitqueryMarketSource.includes("limitBy: { by: Trade_PoolId, count: 1 }") &&
       bitqueryMarketSource.includes(
@@ -222,7 +230,7 @@ export function evaluateAlchemyExploreSourceContracts(
         'Block: { Time: { till: "${trade.time}" } }',
       ) &&
       bitqueryMarketSource.includes(
-        'Token: { Id: { is: "bid:eth" } }',
+        'Token: { Id: { is: "bid:eth:${WETH_ADDRESS}" } }',
       ) &&
       bitqueryMarketSource.includes(
         'const dataset = range === "1h" ? "" : ", dataset: combined";',

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -261,12 +261,32 @@ export function evaluateAlchemyExploreSourceContracts(
         .filter(({ id }) => id !== "token-list")
         .every(({ source }) => {
           const supplyHydration = source.indexOf(
-            "await hydrateMissingCanonicalTokenSupplyV1(",
+            "hydrateMissingCanonicalTokenSupplyV1(",
           );
           const marketRead = source.indexOf(
-            "await readBitqueryTokenMarketDataV1(",
+            "readBitqueryTokenMarketDataV1(",
           );
-          return supplyHydration >= 0 && marketRead > supplyHydration;
+          const inputEnd = Math.max(supplyHydration, marketRead);
+          const reconciliation = [
+            "valueExploreEntriesWithMarketData(",
+            "withBitqueryMarketData(",
+          ]
+            .map((needle) => source.indexOf(needle, inputEnd))
+            .filter((position) => position >= 0)
+            .sort((left, right) => left - right)[0] ?? -1;
+          const inputWindow = source.slice(
+            Math.max(0, Math.min(supplyHydration, marketRead) - 160),
+            reconciliation,
+          );
+          const supplyCompletesFirst =
+            source.slice(Math.max(0, supplyHydration - 16), supplyHydration)
+              .includes("await") &&
+            marketRead > supplyHydration;
+          const inputsJoinBeforeValuation = inputWindow.includes("Promise.all");
+          return supplyHydration >= 0 &&
+            marketRead >= 0 &&
+            reconciliation > inputEnd &&
+            (supplyCompletesFirst || inputsJoinBeforeValuation);
         }),
     "missing supply is hydrated before market valuation only after fixed readers agree on block hash, decimals and total supply",
   );

--- a/scripts/perf/bitquery-golden-market-parity.mjs
+++ b/scripts/perf/bitquery-golden-market-parity.mjs
@@ -18,12 +18,12 @@ const MINIMUM_CONFIRMATIONS = 12n;
 const MAXIMUM_FEED_AGE_SECONDS = 7_200n;
 const MAXIMUM_DEVIATION_BPS = 1_500n;
 const RUNTIME_CONFIDENCE_DEVIATION_BPS = 1_000n;
-const MINIMUM_LIQUIDITY_USD_WAD = 10_000n * 10n ** 18n;
 const WAD = 10n ** 18n;
 const Q192 = 1n << 192n;
 
 const stateViewAbi = parseAbi([
   "function getSlot0(bytes32 poolId) view returns (uint160 sqrtPriceX96,int24 tick,uint24 protocolFee,uint24 lpFee)",
+  "function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)",
 ]);
 const erc20Abi = parseAbi([
   "function decimals() view returns (uint8)",
@@ -102,6 +102,11 @@ async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
     abi: erc20Abi,
     functionName: "decimals",
   });
+  const liquidityData = encodeFunctionData({
+    abi: stateViewAbi,
+    functionName: "getLiquidity",
+    args: [poolId],
+  });
   const totalSupplyData = encodeFunctionData({
     abi: erc20Abi,
     functionName: "totalSupply",
@@ -121,15 +126,25 @@ async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
     [{ to, data }, blockHex],
     id,
   );
-  const [headHex, block, slot0Hex, decimalsHex, supplyHex, feedDecimalsHex, roundHex] =
+  const [
+    headHex,
+    block,
+    slot0Hex,
+    liquidityHex,
+    decimalsHex,
+    supplyHex,
+    feedDecimalsHex,
+    roundHex,
+  ] =
     await Promise.all([
       jsonRpc(fetchImpl, rpcUrl, "eth_blockNumber", [], 1),
       jsonRpc(fetchImpl, rpcUrl, "eth_getBlockByNumber", [blockHex, false], 2),
       call(MAINNET_STATE_VIEW, slot0Data, 3),
-      call(tokenAddress, decimalsData, 4),
-      call(tokenAddress, totalSupplyData, 5),
-      call(MAINNET_ETH_USD_FEED, feedDecimalsData, 6),
-      call(MAINNET_ETH_USD_FEED, roundData, 7),
+      call(MAINNET_STATE_VIEW, liquidityData, 4),
+      call(tokenAddress, decimalsData, 5),
+      call(tokenAddress, totalSupplyData, 6),
+      call(MAINNET_ETH_USD_FEED, feedDecimalsData, 7),
+      call(MAINNET_ETH_USD_FEED, roundData, 8),
     ]);
   if (
     !/^0x[0-9a-f]+$/iu.test(headHex ?? "") ||
@@ -144,6 +159,11 @@ async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
     abi: stateViewAbi,
     functionName: "getSlot0",
     data: slot0Hex,
+  });
+  const poolLiquidity = decodeFunctionResult({
+    abi: stateViewAbi,
+    functionName: "getLiquidity",
+    data: liquidityHex,
   });
   const tokenDecimals = Number(decodeFunctionResult({
     abi: erc20Abi,
@@ -171,6 +191,7 @@ async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
     blockHash: block.hash.toLowerCase(),
     blockTimestamp: BigInt(block.timestamp),
     sqrtPriceX96,
+    poolLiquidity,
     tokenDecimals,
     totalSupplyRaw,
     feedDecimals,
@@ -181,6 +202,7 @@ async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
   });
   if (
     observation.sqrtPriceX96 <= 0n ||
+    observation.poolLiquidity <= 0n ||
     !Number.isInteger(observation.tokenDecimals) ||
     observation.tokenDecimals < 0 ||
     observation.tokenDecimals > 255 ||
@@ -206,6 +228,7 @@ function sameObservation(left, right) {
     "blockHash",
     "blockTimestamp",
     "sqrtPriceX96",
+    "poolLiquidity",
     "tokenDecimals",
     "totalSupplyRaw",
     "feedDecimals",
@@ -233,6 +256,8 @@ async function readProviderWithRetry(fetchImpl, rpcUrl, tokenAddress, poolId, bl
  * Release-only independent correctness proof. Bitquery remains the runtime
  * market source; two fixed public Ethereum readers only verify that the
  * golden Bitquery observation has the right units, orientation and scale.
+ * StateView liquidity is read at that historical block only to prove the pool
+ * was active; it is neither a current-liquidity nor a USD-liquidity claim.
  */
 export async function verifyBitqueryGoldenMarketParityV1(input) {
   const token = input?.token;
@@ -257,10 +282,6 @@ export async function verifyBitqueryGoldenMarketParityV1(input) {
   const trade = pool.latestTrade;
   const priceUsdWad = positiveInteger(trade?.priceUsdWad, "indexed USD price");
   const rawPriceUsdWad = positiveInteger(trade?.rawPriceUsdWad, "raw USD price");
-  const liquidityUsdWad = positiveInteger(
-    pool?.liquidity?.valueUsdWad,
-    "exact-pool USD liquidity",
-  );
   const totalSupplyRaw = positiveInteger(token?.totalSupplyRaw, "canonical total supply");
   const tokenDecimals = token?.tokenDecimals;
   const { block, hex: blockHex } = canonicalBlockNumber(trade?.blockNumber);
@@ -271,7 +292,6 @@ export async function verifyBitqueryGoldenMarketParityV1(input) {
     !Number.isInteger(tokenDecimals) ||
     tokenDecimals < 0 ||
     tokenDecimals > 255 ||
-    liquidityUsdWad < MINIMUM_LIQUIDITY_USD_WAD ||
     Math.abs(tradeTime - priceTime) > 5 * 60_000 ||
     !withinDeviation(priceUsdWad, rawPriceUsdWad, RUNTIME_CONFIDENCE_DEVIATION_BPS)
   ) {
@@ -288,6 +308,7 @@ export async function verifyBitqueryGoldenMarketParityV1(input) {
   if (
     !sameObservation(first, second) ||
     first.blockNumber !== block ||
+    tradeTime !== Number(first.blockTimestamp) * 1_000 ||
     first.head < block + MINIMUM_CONFIRMATIONS ||
     second.head < block + MINIMUM_CONFIRMATIONS ||
     first.tokenDecimals !== tokenDecimals ||
@@ -327,6 +348,8 @@ export async function verifyBitqueryGoldenMarketParityV1(input) {
     poolId: PCAN_POOL_ID,
     blockNumber: block.toString(),
     blockHash: first.blockHash,
+    blockTime: new Date(Number(first.blockTimestamp) * 1_000).toISOString(),
+    historicalPoolLiquidity: first.poolLiquidity.toString(),
     confirmations: Number(
       (first.head < second.head ? first.head : second.head) - block,
     ),

--- a/scripts/perf/bitquery-historical-release-gate.mjs
+++ b/scripts/perf/bitquery-historical-release-gate.mjs
@@ -1,0 +1,208 @@
+const GOLDEN_TOKEN_ADDRESS =
+  "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
+const GOLDEN_POOL_ID =
+  "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const MAXIMUM_FUTURE_SKEW_MS = 60_000;
+const MAXIMUM_STALE_AGE_MS = 24 * 60 * 60_000;
+const MINIMUM_CONFIRMATIONS = 12;
+const MAXIMUM_DEVIATION_BPS = 1_500;
+
+function validMarketTime(value, nowMs) {
+  const parsed = Date.parse(value ?? "");
+  return Number.isFinite(parsed) && parsed <= nowMs + MAXIMUM_FUTURE_SKEW_MS;
+}
+
+function positiveInteger(value) {
+  return typeof value === "string" && /^[1-9][0-9]*$/u.test(value);
+}
+
+function positiveDecimalToWad(value) {
+  const match = /^(0|[1-9][0-9]*)(?:\.([0-9]{1,18}))?$/u.exec(
+    String(value ?? ""),
+  );
+  if (!match) return null;
+  const wad = BigInt(match[1]) * 10n ** 18n +
+    BigInt((match[2] ?? "").slice(0, 18).padEnd(18, "0") || "0");
+  return wad > 0n ? wad : null;
+}
+
+function exactGoldenPool(token) {
+  const market = token?.marketData;
+  if (
+    token?.tokenAddress?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
+    market?.schemaVersion !== "programmable.market-data.v1" ||
+    market.source !== "bitquery" ||
+    market.primaryPoolId !== GOLDEN_POOL_ID
+  ) return null;
+  const pool = market.pools?.find(
+    (candidate) => candidate?.identity?.poolId === GOLDEN_POOL_ID,
+  );
+  return pool?.identity?.tokenAddress?.toLowerCase() === GOLDEN_TOKEN_ADDRESS &&
+      pool?.identity?.chainId === "1" &&
+      pool?.identity?.protocol === "uniswap_v4" &&
+      pool?.source === "bitquery" &&
+      ["complete", "partial"].includes(pool?.quality) &&
+      pool?.asOfTime === pool?.latestTrade?.time
+    ? pool
+    : null;
+}
+
+export function boundedStaleMarketTimeV1(value, nowMs = Date.now()) {
+  return validMarketTime(value, nowMs) &&
+    nowMs - Date.parse(value) <= MAXIMUM_STALE_AGE_MS;
+}
+
+function currentMarketTime(value, nowMs) {
+  return validMarketTime(value, nowMs) &&
+    nowMs - Date.parse(value) <= 6 * 60_000;
+}
+
+/**
+ * The general stale ceiling stays at 24 hours. An older value can only be
+ * deferred when the response itself carries the exact PCAN token and primary
+ * pool identity. Deferral is not acceptance: the release must subsequently
+ * pass verifyBitqueryHistoricalGoldenReleaseV1.
+ */
+export function classifyBitqueryStaleMarketReleaseV1(input) {
+  const nowMs = input?.nowMs ?? Date.now();
+  const token = input?.token;
+  const valuation = token?.valuation;
+  if (
+    valuation?.status !== "available" ||
+    valuation.freshness !== "stale" ||
+    !validMarketTime(valuation.asOfTime, nowMs)
+  ) {
+    throw new Error("stale market release candidate is invalid");
+  }
+  if (boundedStaleMarketTimeV1(valuation.asOfTime, nowMs)) {
+    return Object.freeze({ status: "bounded" });
+  }
+  if (exactGoldenPool(token) === null) {
+    throw new Error("stale market release candidate exceeds the 24 hour ceiling");
+  }
+  return Object.freeze({
+    status: "deferred-pcan",
+    tokenAddress: GOLDEN_TOKEN_ADDRESS,
+    poolId: GOLDEN_POOL_ID,
+    asOfTime: valuation.asOfTime,
+    valueWad: valuation.valueWad,
+  });
+}
+
+/**
+ * Resolve the direct-address PCAN canary after the independent parity read.
+ * PCAN is intentionally absent from public Explore discovery. Its detail,
+ * exact-pool valuation, chart close and parity receipt are bound to one token,
+ * pool, block, time, price and FDV. The only older-than-24h value admitted by
+ * this function is the exact PCAN candidate classified above.
+ */
+export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
+  const nowMs = input?.nowMs ?? Date.now();
+  const detailToken = input?.detailToken;
+  const chart = input?.chart;
+  const parity = input?.parity;
+  const detailPool = exactGoldenPool(detailToken);
+  const detailValuation = detailToken?.valuation;
+  const poolValuation = detailPool?.valuation;
+  const chartValuation = chart?.valuation;
+  const trade = detailPool?.latestTrade;
+  const lastPoint = Array.isArray(chart?.points) ? chart.points.at(-1) : null;
+  const expectedValue = detailValuation?.valueWad;
+  const expectedTime = detailValuation?.asOfTime;
+  const expectedBlock = trade?.blockNumber;
+  const expectedPrice = positiveInteger(trade?.priceUsdWad)
+    ? BigInt(trade.priceUsdWad)
+    : null;
+  const chartPrice = positiveDecimalToWad(lastPoint?.priceUsd);
+  let temporalStatus;
+  if (detailValuation?.freshness === "current") {
+    if (!currentMarketTime(detailValuation.asOfTime, nowMs)) {
+      throw new Error("current PCAN release evidence is not current");
+    }
+    temporalStatus = "current";
+  } else {
+    temporalStatus = classifyBitqueryStaleMarketReleaseV1({
+      token: detailToken,
+      nowMs,
+    }).status;
+  }
+
+  if (
+    detailPool === null ||
+    detailValuation?.status !== "available" ||
+    detailValuation.source !== "bitquery" ||
+    detailValuation.metric !== "fdv" ||
+    detailValuation.supplyBasis !== "total" ||
+    detailValuation.currency !== "usd" ||
+    !["current", "stale"].includes(detailValuation.freshness) ||
+    poolValuation?.status !== "available" ||
+    poolValuation.metric !== "fdv" ||
+    poolValuation.supplyBasis !== "total" ||
+    poolValuation.freshness !== detailValuation.freshness ||
+    chartValuation?.status !== "available" ||
+    chartValuation.metric !== "fdv" ||
+    chartValuation.supplyBasis !== "total" ||
+    chartValuation.freshness !== detailValuation.freshness ||
+    !positiveInteger(expectedValue) ||
+    !validMarketTime(expectedTime, nowMs) ||
+    poolValuation.valueUsdWad !== expectedValue ||
+    poolValuation.fdvUsdWad !== expectedValue ||
+    poolValuation.asOfTime !== expectedTime ||
+    chartValuation.valueUsdWad !== expectedValue ||
+    chartValuation.fdvUsdWad !== expectedValue ||
+    chartValuation.asOfTime !== expectedTime ||
+    chart?.schemaVersion !== "programmable.market-chart.v1" ||
+    chart.source !== "bitquery" ||
+    chart.readStatus !== "live" ||
+    !["ready", "insufficient-history", "partial"].includes(chart.status) ||
+    chart?.address?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
+    chart?.range !== "all" ||
+    chart?.identity?.chainId !== "1" ||
+    chart?.identity?.tokenAddress?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
+    chart?.identity?.poolId !== GOLDEN_POOL_ID ||
+    chart?.identity?.protocol !== "uniswap_v4" ||
+    !Array.isArray(chart?.points) ||
+    chart.points.length < 1 ||
+    chart.asOfTime !== lastPoint?.time ||
+    lastPoint?.time !== trade?.time ||
+    lastPoint?.blockNumber !== expectedBlock ||
+    expectedPrice === null ||
+    chartPrice !== expectedPrice ||
+    parity?.schemaVersion !== "programmable.bitquery-golden-market-parity.v1" ||
+    parity.tokenAddress !== GOLDEN_TOKEN_ADDRESS ||
+    parity.poolId !== GOLDEN_POOL_ID ||
+    parity.blockNumber !== expectedBlock ||
+    parity.blockTime !== trade?.time ||
+    !/^0x[0-9a-f]{64}$/u.test(parity.blockHash ?? "") ||
+    !positiveInteger(parity.historicalPoolLiquidity) ||
+    !Number.isSafeInteger(parity.confirmations) ||
+    parity.confirmations < MINIMUM_CONFIRMATIONS ||
+    parity.bitqueryFdvUsdWad !== expectedValue ||
+    !positiveInteger(parity.onchainFdvUsdWad) ||
+    !Number.isSafeInteger(parity.deviationBps) ||
+    parity.deviationBps < 0 ||
+    parity.deviationBps > MAXIMUM_DEVIATION_BPS
+  ) {
+    throw new Error("historical PCAN release evidence is not exactly bound");
+  }
+
+  return Object.freeze({
+    schemaVersion: "programmable.bitquery-historical-release.v1",
+    tokenAddress: GOLDEN_TOKEN_ADDRESS,
+    poolId: GOLDEN_POOL_ID,
+    blockNumber: expectedBlock,
+    asOfTime: expectedTime,
+    bitqueryFdvUsdWad: expectedValue,
+    historicalPoolLiquidity: parity.historicalPoolLiquidity,
+    confirmations: parity.confirmations,
+    temporalStatus,
+  });
+}
+
+export const BITQUERY_HISTORICAL_RELEASE_V1 = Object.freeze({
+  tokenAddress: GOLDEN_TOKEN_ADDRESS,
+  poolId: GOLDEN_POOL_ID,
+  maximumStaleAgeMs: MAXIMUM_STALE_AGE_MS,
+  minimumConfirmations: MINIMUM_CONFIRMATIONS,
+  maximumDeviationBps: MAXIMUM_DEVIATION_BPS,
+});

--- a/scripts/perf/bitquery-historical-release-gate.mjs
+++ b/scripts/perf/bitquery-historical-release-gate.mjs
@@ -4,6 +4,7 @@ const GOLDEN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
 const MAXIMUM_FUTURE_SKEW_MS = 60_000;
 const MAXIMUM_STALE_AGE_MS = 24 * 60 * 60_000;
+const MAXIMUM_DEFERRED_PCAN_AGE_MS = 96 * 60 * 60_000;
 const MINIMUM_CONFIRMATIONS = 12;
 const MAXIMUM_DEVIATION_BPS = 1_500;
 
@@ -60,8 +61,10 @@ function currentMarketTime(value, nowMs) {
 /**
  * The general stale ceiling stays at 24 hours. An older value can only be
  * deferred when the response itself carries the exact PCAN token and primary
- * pool identity. Deferral is not acceptance: the release must subsequently
- * pass verifyBitqueryHistoricalGoldenReleaseV1.
+ * pool identity and is capped at 96 hours. That fixed window keeps this
+ * historical correctness canary finite; it is never evidence that the current
+ * provider path is fresh. Deferral is not acceptance: the release must
+ * subsequently pass verifyBitqueryHistoricalGoldenReleaseV1.
  */
 export function classifyBitqueryStaleMarketReleaseV1(input) {
   const nowMs = input?.nowMs ?? Date.now();
@@ -79,6 +82,11 @@ export function classifyBitqueryStaleMarketReleaseV1(input) {
   }
   if (exactGoldenPool(token) === null) {
     throw new Error("stale market release candidate exceeds the 24 hour ceiling");
+  }
+  if (
+    nowMs - Date.parse(valuation.asOfTime) > MAXIMUM_DEFERRED_PCAN_AGE_MS
+  ) {
+    throw new Error("historical PCAN release evidence exceeds the 96 hour ceiling");
   }
   return Object.freeze({
     status: "deferred-pcan",
@@ -203,6 +211,7 @@ export const BITQUERY_HISTORICAL_RELEASE_V1 = Object.freeze({
   tokenAddress: GOLDEN_TOKEN_ADDRESS,
   poolId: GOLDEN_POOL_ID,
   maximumStaleAgeMs: MAXIMUM_STALE_AGE_MS,
+  maximumDeferredPcanAgeMs: MAXIMUM_DEFERRED_PCAN_AGE_MS,
   minimumConfirmations: MINIMUM_CONFIRMATIONS,
   maximumDeviationBps: MAXIMUM_DEVIATION_BPS,
 });

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -977,6 +977,9 @@ export function evaluateReadModelOperationsSourceContracts(
   const bitqueryGoldenParity = source(
     "scripts/perf/bitquery-golden-market-parity.mjs",
   ) ?? "";
+  const bitqueryHistoricalRelease = source(
+    "scripts/perf/bitquery-historical-release-gate.mjs",
+  ) ?? "";
   const productionBinding = source(
     "scripts/perf/read-model-production-binding.mjs",
   ) ?? "";
@@ -1217,6 +1220,10 @@ export function evaluateReadModelOperationsSourceContracts(
         "/api/explore?limit=20&page=1&q=${goldenTokenAddress}&sort=market-cap",
       ) &&
       stagedBitquerySmokeBlock.includes(
+        "staged Explore exposed the non-public PCAN release canary",
+      ) &&
+      stagedBitquerySmokeBlock.includes("goldenSearch.total !== 0") &&
+      stagedBitquerySmokeBlock.includes(
         "/api/explore/token/chart?address=${goldenTokenAddress}&range=all",
       ) &&
       stagedBitquerySmokeBlock.includes(
@@ -1263,6 +1270,12 @@ export function evaluateReadModelOperationsSourceContracts(
         '"./scripts/perf/bitquery-golden-market-parity.mjs"',
       ) &&
       stagedBitquerySmokeBlock.includes(
+        '"./scripts/perf/bitquery-historical-release-gate.mjs"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "const boundedStaleMarketTime = boundedStaleMarketTimeV1",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
         "await verifyBitqueryGoldenMarketParityV1({",
       ) &&
       bitqueryGoldenParity.includes(
@@ -1273,12 +1286,63 @@ export function evaluateReadModelOperationsSourceContracts(
       bitqueryGoldenParity.includes("const MINIMUM_CONFIRMATIONS = 12n") &&
       bitqueryGoldenParity.includes("sameObservation(first, second)") &&
       bitqueryGoldenParity.includes(
+        'function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)',
+      ) &&
+      bitqueryGoldenParity.includes("observation.poolLiquidity <= 0n") &&
+      bitqueryGoldenParity.includes(
+        "historicalPoolLiquidity: first.poolLiquidity.toString()",
+      ) &&
+      bitqueryGoldenParity.includes(
+        "tradeTime !== Number(first.blockTimestamp) * 1_000",
+      ) &&
+      !bitqueryGoldenParity.includes("pool?.liquidity?.valueUsdWad") &&
+      bitqueryGoldenParity.includes(
         "Bitquery golden price is outside independent onchain tolerance",
       ) &&
+      bitqueryHistoricalRelease.includes(
+        "const MAXIMUM_STALE_AGE_MS = 24 * 60 * 60_000",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "export function classifyBitqueryStaleMarketReleaseV1",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "export function verifyBitqueryHistoricalGoldenReleaseV1",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        'parity?.schemaVersion !== "programmable.bitquery-golden-market-parity.v1"',
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        'market?.schemaVersion !== "programmable.market-data.v1"',
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "poolValuation.valueUsdWad !== expectedValue",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "chartValuation.valueUsdWad !== expectedValue",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "!positiveInteger(parity.historicalPoolLiquidity)",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "chart?.identity?.poolId !== GOLDEN_POOL_ID",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "lastPoint?.blockNumber !== expectedBlock",
+      ) &&
+      bitqueryHistoricalRelease.includes("chartPrice !== expectedPrice") &&
+      bitqueryHistoricalRelease.includes("parity.confirmations < MINIMUM_CONFIRMATIONS") &&
       stagedBitquerySmokeBlock.includes(
         "const historicalPaidPathVerified =",
       ) &&
-      stagedBitquerySmokeBlock.includes("goldenParity.confirmations >= 12") &&
+      stagedBitquerySmokeBlock.includes(
+        "verifyBitqueryHistoricalGoldenReleaseV1({",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"programmable.bitquery-historical-release.v1"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "historicalGoldenRelease.confirmations >= 12",
+      ) &&
       stagedBitquerySmokeBlock.includes(
         'goldenChart.readStatus !== "live"',
       ) &&
@@ -1451,9 +1515,18 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes("exactBitqueryHeaders") &&
       postPromotion.includes("honestExploreValuations") &&
       postPromotion.includes("exactGoldenDetail") &&
+      postPromotion.includes("exactGoldenSearch") &&
       postPromotion.includes("exactGoldenChart") &&
+      postPromotion.includes(
+        "const boundedStaleMarketTime = boundedStaleMarketTimeV1",
+      ) &&
       postPromotion.includes('chart.readStatus !== "live"') &&
       postPromotion.includes("verifyBitqueryGoldenMarketParityV1") &&
+      postPromotion.includes("verifyBitqueryHistoricalGoldenReleaseV1") &&
+      postPromotion.includes('id: "production-bitquery-canary-hidden"') &&
+      postPromotion.includes(
+        '(marketAsOf === null || boundedStaleMarketTime(marketAsOf))',
+      ) &&
       postPromotion.includes(
         'id: "production-bitquery-golden-independent-parity"',
       ) &&

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1256,7 +1256,22 @@ export function evaluateReadModelOperationsSourceContracts(
       stagedBitquerySmokeBlock.includes(
         'valuation.reason === "waiting-for-first-trade"',
       ) &&
-      !stagedBitquerySmokeBlock.includes("if (currentFdvCount < 1) {") &&
+      stagedBitquerySmokeBlock.includes(
+        'tokenAddress === goldenTokenAddress',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'primary.liquidity?.asOfTime !== valuation.asOfTime',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '!currentMarketTime(primary.liquidity?.asOfTime)',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"staged Bitquery current public FDV lacks exact primary-pool liquidity evidence"',
+      ) &&
+      stagedBitquerySmokeBlock.includes("if (currentFdvCount < 1) {") &&
+      stagedBitquerySmokeBlock.includes(
+        '"staged Bitquery market path has no current public non-PCAN FDV with exact primary-pool liquidity evidence"',
+      ) &&
       stagedBitquerySmokeBlock.includes(
         '"staged Bitquery current Explore and detail FDV are not identical"',
       ) &&
@@ -1361,7 +1376,7 @@ export function evaluateReadModelOperationsSourceContracts(
       stagedBitquerySmokeBlock.includes(
         'goldenChart.readStatus === "live"',
       ) &&
-      stagedBitquerySmokeBlock.includes(
+      !stagedBitquerySmokeBlock.includes(
         "currentFdvCount < 1 && !historicalPaidPathVerified",
       ) &&
       stagedBitquerySmokeBlock.includes(
@@ -1526,6 +1541,7 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       postPromotion.includes("exactBitqueryHeaders") &&
       postPromotion.includes("honestExploreValuations") &&
+      postPromotion.includes("exactCurrentPublicFdvLiquidity") &&
       postPromotion.includes("exactGoldenDetail") &&
       postPromotion.includes("exactGoldenSearch") &&
       postPromotion.includes("exactGoldenChart") &&
@@ -1537,7 +1553,19 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes("verifyBitqueryHistoricalGoldenReleaseV1") &&
       postPromotion.includes('id: "production-bitquery-canary-hidden"') &&
       postPromotion.includes(
-        '(marketAsOf === null || boundedStaleMarketTime(marketAsOf))',
+        "return currentCount > 0 &&",
+      ) &&
+      postPromotion.includes(
+        'tokenAddress !== GOLDEN_TOKEN_ADDRESS',
+      ) &&
+      postPromotion.includes(
+        'liquidity.asOfTime === valuation.asOfTime',
+      ) &&
+      postPromotion.includes(
+        'currentMarketTime(liquidity.asOfTime)',
+      ) &&
+      postPromotion.includes(
+        'currentMarketTime(marketAsOf)',
       ) &&
       postPromotion.includes(
         'id: "production-bitquery-golden-independent-parity"',

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1303,6 +1303,18 @@ export function evaluateReadModelOperationsSourceContracts(
         "const MAXIMUM_STALE_AGE_MS = 24 * 60 * 60_000",
       ) &&
       bitqueryHistoricalRelease.includes(
+        "const MAXIMUM_DEFERRED_PCAN_AGE_MS = 96 * 60 * 60_000",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "maximumDeferredPcanAgeMs: MAXIMUM_DEFERRED_PCAN_AGE_MS",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "nowMs - Date.parse(valuation.asOfTime) > MAXIMUM_DEFERRED_PCAN_AGE_MS",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        'throw new Error("historical PCAN release evidence exceeds the 96 hour ceiling")',
+      ) &&
+      bitqueryHistoricalRelease.includes(
         "export function classifyBitqueryStaleMarketReleaseV1",
       ) &&
       bitqueryHistoricalRelease.includes(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1260,6 +1260,27 @@ export function evaluateReadModelOperationsSourceContracts(
         'tokenAddress === goldenTokenAddress',
       ) &&
       stagedBitquerySmokeBlock.includes(
+        '!/^0x[0-9a-f]{64}$/.test(',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'token.marketData.primaryPoolId ?? ""',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'primary.identity?.poolId !== token.marketData.primaryPoolId',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'primary.identity?.protocol !== "uniswap_v4"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '!positiveInteger(primary.liquidity?.valueUsdWad)',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '!positiveInteger(primary.liquidity?.asOfBlock)',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'primary.valuation.valueUsdWad !== valuation.valueWad',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
         'primary.liquidity?.asOfTime !== valuation.asOfTime',
       ) &&
       stagedBitquerySmokeBlock.includes(
@@ -1557,6 +1578,21 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       postPromotion.includes(
         'tokenAddress !== GOLDEN_TOKEN_ADDRESS',
+      ) &&
+      postPromotion.includes(
+        'primary.identity.poolId === market.primaryPoolId',
+      ) &&
+      postPromotion.includes(
+        'primary.identity.protocol === "uniswap_v4"',
+      ) &&
+      postPromotion.includes(
+        'positiveInteger(liquidity.valueUsdWad)',
+      ) &&
+      postPromotion.includes(
+        'positiveInteger(liquidity.asOfBlock)',
+      ) &&
+      postPromotion.includes(
+        'poolValuation.valueUsdWad === valuation.valueWad',
       ) &&
       postPromotion.includes(
         'liquidity.asOfTime === valuation.asOfTime',

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -13,6 +13,10 @@ import {
   verifyLiveCacheAndKeyContracts,
 } from "./read-model-live-verifier.mjs";
 import { verifyBitqueryGoldenMarketParityV1 } from "./bitquery-golden-market-parity.mjs";
+import {
+  boundedStaleMarketTimeV1,
+  verifyBitqueryHistoricalGoldenReleaseV1,
+} from "./bitquery-historical-release-gate.mjs";
 
 const HEALTH_PATH = "/api/ops/health";
 const EXPLORE_PATH = "/api/explore?limit=6&page=1&sort=market-cap";
@@ -21,6 +25,8 @@ const GOLDEN_TOKEN_ADDRESS =
 const GOLDEN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
 const GOLDEN_DETAIL_PATH = `/api/explore/token?address=${GOLDEN_TOKEN_ADDRESS}`;
+const GOLDEN_SEARCH_PATH =
+  `/api/explore?limit=20&page=1&q=${GOLDEN_TOKEN_ADDRESS}&sort=market-cap`;
 const GOLDEN_CHART_PATH =
   `/api/explore/token/chart?address=${GOLDEN_TOKEN_ADDRESS}&range=all`;
 const MAXIMUM_RESPONSE_BYTES = 2 * 1024 * 1024;
@@ -122,10 +128,7 @@ function currentMarketTime(value) {
     Date.now() - Date.parse(value) <= 6 * 60_000;
 }
 
-function boundedStaleMarketTime(value) {
-  return validMarketTime(value) &&
-    Date.now() - Date.parse(value) <= 24 * 60 * 60_000;
-}
+const boundedStaleMarketTime = boundedStaleMarketTimeV1;
 
 function exactBitqueryHeaders(response) {
   return response.headers.marketSource === "bitquery" &&
@@ -182,7 +185,7 @@ function honestExploreValuations(response) {
   return [null, "bitquery"].includes(response.headers.priceSource) &&
     (currentCount === 0 || response.headers.priceSource === "bitquery") &&
     response.headers.marketAsOf === marketAsOf &&
-    (marketAsOf === null || validMarketTime(marketAsOf));
+    (marketAsOf === null || boundedStaleMarketTime(marketAsOf));
 }
 
 function exactGoldenDetail(response) {
@@ -215,7 +218,6 @@ function exactGoldenDetail(response) {
     validMarketTime(valuation.asOfTime) &&
     response.headers.marketAsOf === valuation.asOfTime &&
     (valuation.freshness !== "current" || currentMarketTime(valuation.asOfTime)) &&
-    (valuation.freshness !== "stale" || boundedStaleMarketTime(valuation.asOfTime)) &&
     response.headers.dataQuality === response.body?.dataQuality?.status &&
     (valuation.freshness === "current"
       ? token.fdvUsdWad === valuation.valueWad &&
@@ -223,6 +225,17 @@ function exactGoldenDetail(response) {
       : valuation.freshness === "stale" &&
         token.fdvUsdWad === undefined &&
         response.headers.priceSource === null);
+}
+
+function exactGoldenSearch(response) {
+  return response.ok &&
+    exactBitqueryHeaders(response) &&
+    response.body?.status === "ready" &&
+    Array.isArray(response.body?.tokens) &&
+    response.body.tokens.every(
+      (token) => token?.tokenAddress?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS,
+    ) &&
+    response.body.total === 0;
 }
 
 function exactGoldenChart(response) {
@@ -248,8 +261,6 @@ function exactGoldenChart(response) {
     !["current", "stale"].includes(chart.valuation?.freshness) ||
     (chart.valuation?.freshness === "current" &&
       !currentMarketTime(chart.valuation?.asOfTime)) ||
-    (chart.valuation?.freshness === "stale" &&
-      !boundedStaleMarketTime(chart.valuation?.asOfTime)) ||
     chart.asOfTime !== chart.points.at(-1)?.time ||
     response.headers.marketAsOf !== chart.asOfTime ||
     !validMarketTime(chart.asOfTime)
@@ -300,6 +311,11 @@ function publicChecks(responses) {
         exactBitqueryHeaders(responses.explore) &&
         honestExploreValuations(responses.explore),
       detail: "the production Explore route returns honest Bitquery FDV freshness",
+    },
+    {
+      id: "production-bitquery-canary-hidden",
+      condition: exactGoldenSearch(responses.goldenSearch),
+      detail: "the PCAN release canary stays absent from public Explore discovery",
     },
     {
       id: "production-bitquery-detail",
@@ -389,6 +405,7 @@ export async function verifyPostPromotion(input) {
     request(fetchImpl, targetUrl, "/", false),
     request(fetchImpl, targetUrl, HEALTH_PATH),
     request(fetchImpl, targetUrl, EXPLORE_PATH),
+    request(fetchImpl, targetUrl, GOLDEN_SEARCH_PATH),
     request(fetchImpl, targetUrl, GOLDEN_DETAIL_PATH),
     request(fetchImpl, targetUrl, GOLDEN_CHART_PATH),
   ]);
@@ -396,24 +413,32 @@ export async function verifyPostPromotion(input) {
     root: responses[0],
     health: responses[1],
     explore: responses[2],
-    goldenDetail: responses[3],
-    goldenChart: responses[4],
+    goldenSearch: responses[3],
+    goldenDetail: responses[4],
+    goldenChart: responses[5],
   })];
   let goldenParity = null;
+  let historicalGoldenRelease = null;
   try {
     goldenParity = await verifyBitqueryGoldenMarketParityV1({
-      token: responses[3].body?.token,
+      token: responses[4].body?.token,
       fetchImpl,
       rpcUrls: input.marketParityRpcUrls,
+    });
+    historicalGoldenRelease = verifyBitqueryHistoricalGoldenReleaseV1({
+      detailToken: responses[4].body?.token,
+      chart: responses[5].body,
+      parity: goldenParity,
     });
   } catch {
     // The public verifier reports only the typed gate, never provider details.
   }
   checks.push({
     id: "production-bitquery-golden-independent-parity",
-    condition: goldenParity?.schemaVersion ===
-      "programmable.bitquery-golden-market-parity.v1",
-    detail: "the public PCAN market price matches two independent same-block reads",
+    condition: historicalGoldenRelease?.schemaVersion ===
+        "programmable.bitquery-historical-release.v1" &&
+      historicalGoldenRelease.confirmations >= 12,
+    detail: "the direct PCAN history matches two independent same-block price, supply and liquidity reads",
   });
 
   if (input.evidencePath) {

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -137,6 +137,49 @@ function exactBitqueryHeaders(response) {
     response.headers.dataQuality === response.body?.dataQuality?.status;
 }
 
+function exactCurrentPublicFdvLiquidity(token) {
+  const tokenAddress = token?.tokenAddress?.toLowerCase();
+  const valuation = token?.valuation;
+  const market = token?.marketData;
+  const primary = market?.pools?.find(
+    (pool) => pool?.identity?.poolId === market?.primaryPoolId,
+  );
+  const liquidity = primary?.liquidity;
+  const poolValuation = primary?.valuation;
+  return /^0x[0-9a-f]{40}$/u.test(tokenAddress ?? "") &&
+    tokenAddress !== GOLDEN_TOKEN_ADDRESS &&
+    valuation?.status === "available" &&
+    valuation.metric === "fdv" &&
+    valuation.supplyBasis === "total" &&
+    valuation.currency === "usd" &&
+    valuation.source === "bitquery" &&
+    valuation.freshness === "current" &&
+    positiveInteger(valuation.valueWad) &&
+    token.fdvUsdWad === valuation.valueWad &&
+    currentMarketTime(valuation.asOfTime) &&
+    market?.schemaVersion === "programmable.market-data.v1" &&
+    market.source === "bitquery" &&
+    currentMarketTime(market.generatedAt) &&
+    /^0x[0-9a-f]{64}$/u.test(market.primaryPoolId ?? "") &&
+    primary?.identity?.chainId === "1" &&
+    primary.identity.tokenAddress === tokenAddress &&
+    primary.identity.poolId === market.primaryPoolId &&
+    primary.identity.protocol === "uniswap_v4" &&
+    primary.source === "bitquery" &&
+    primary.status === "current" &&
+    liquidity?.freshness === "current" &&
+    positiveInteger(liquidity.valueUsdWad) &&
+    positiveInteger(liquidity.asOfBlock) &&
+    liquidity.asOfTime === valuation.asOfTime &&
+    currentMarketTime(liquidity.asOfTime) &&
+    poolValuation?.status === "available" &&
+    poolValuation.metric === "fdv" &&
+    poolValuation.supplyBasis === "total" &&
+    poolValuation.freshness === "current" &&
+    poolValuation.valueUsdWad === valuation.valueWad &&
+    poolValuation.asOfTime === valuation.asOfTime;
+}
+
 function honestExploreValuations(response) {
   const tokens = response.body?.tokens;
   if (!Array.isArray(tokens) || tokens.length === 0) return false;
@@ -174,7 +217,8 @@ function honestExploreValuations(response) {
     if (
       sawNonCurrent ||
       token.fdvUsdWad !== valuation.valueWad ||
-      !currentMarketTime(valuation.asOfTime)
+      !currentMarketTime(valuation.asOfTime) ||
+      !exactCurrentPublicFdvLiquidity(token)
     ) return false;
     const value = BigInt(valuation.valueWad);
     if (previousCurrentFdv !== null && value > previousCurrentFdv) return false;
@@ -182,10 +226,10 @@ function honestExploreValuations(response) {
     currentCount += 1;
   }
   const marketAsOf = response.body?.dataQuality?.valuation?.asOfTime ?? null;
-  return [null, "bitquery"].includes(response.headers.priceSource) &&
-    (currentCount === 0 || response.headers.priceSource === "bitquery") &&
+  return currentCount > 0 &&
+    response.headers.priceSource === "bitquery" &&
     response.headers.marketAsOf === marketAsOf &&
-    (marketAsOf === null || boundedStaleMarketTime(marketAsOf));
+    currentMarketTime(marketAsOf);
 }
 
 function exactGoldenDetail(response) {

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -117,8 +117,11 @@ function liquidityRow(
     omitFirstUsd?: boolean;
     omitSecondUsd?: boolean;
     quoteAddress?: string;
+    tokenAddress?: string;
     time?: string;
     transaction?: string;
+    transactionIndex?: number;
+    logIndex?: number;
     amountFirst?: string;
     amountSecond?: string;
     amountFirstUsd?: string;
@@ -130,14 +133,16 @@ function liquidityRow(
       Number: "25740000",
       Time: options.time ?? "2026-08-11T14:00:00.000Z",
     },
+    Log: { Index: options.logIndex ?? 1 },
     Transaction: {
       Hash: options.transaction ?? `0x${"aa".repeat(32)}`,
+      Index: options.transactionIndex ?? 7,
     },
     PoolEvent: {
       Pool: {
         PoolId: identity.poolId,
         CurrencyA: {
-          SmartContract: identity.tokenAddress,
+          SmartContract: options.tokenAddress ?? identity.tokenAddress,
           Symbol: "PCAN",
         },
         CurrencyB: {
@@ -339,7 +344,8 @@ describe("Bitquery-only market data", () => {
         expect(request.query).toContain("CurrencyA { SmartContract Symbol }");
         expect(request.query).toContain("AmountCurrencyA");
         expect(request.query).toContain("AmountCurrencyB");
-        expect(request.query).toContain("Transaction { Hash }");
+        expect(request.query).toContain("Log { Index }");
+        expect(request.query).toContain("Transaction { Hash Index }");
         expect(request.query).not.toContain("latestTrades: DEXTrades(");
         return jsonResponse({
           data: { EVM: { latestLiquidity: [liquidityRow(PCAN)] } },
@@ -746,6 +752,60 @@ describe("Bitquery-only market data", () => {
         omitSecondUsd: true,
         transaction: `0x${"bb".repeat(32)}`,
       }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
+      "liquidity",
+    );
+  });
+
+  it("does not derive liquidity USD across different event logs", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      liquidity: liquidityRow(PCAN, {
+        omitFirstUsd: true,
+        omitSecondUsd: true,
+        logIndex: 2,
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
+      "liquidity",
+    );
+  });
+
+  it("rejects liquidity whose currencies do not contain the bound token", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      liquidity: liquidityRow(PCAN, {
+        tokenAddress: "0x2222222222222222222222222222222222222222",
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
+      "liquidity",
+    );
+  });
+
+  it.each([
+    ["zero reserve with positive USD", "0", "1"],
+    ["positive reserve with zero USD", "1", "0"],
+  ])("rejects %s", async (_label, amountFirst, amountFirstUsd) => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      liquidity: liquidityRow(PCAN, { amountFirst, amountFirstUsd }),
     }))) as typeof fetch;
     const values = await readBitqueryTokenMarketDataV1([PCAN], {
       fetchImpl,
@@ -1389,25 +1449,43 @@ describe("Bitquery OHLCV chart and server stream", () => {
       transactionIndex: index % 200,
       logIndex: index % 1_000,
     }));
-    const offsets: number[] = [];
+    const pageIndexes: number[] = [];
     const fetchImpl = vi.fn(async (
       _url: string | URL | Request,
       init?: RequestInit,
     ) => {
       const request = JSON.parse(String(init?.body));
-      const offset = Number(request.variables.offset);
-      offsets.push(offset);
-      expect(request.query).toContain("limit: { count: 500, offset: $offset }");
+      const pageIndex = pageIndexes.length;
+      pageIndexes.push(pageIndex);
+      expect(request.query).toContain("limit: { count: 500 }");
+      expect(request.query).not.toContain("offset");
       expect(request.query).toContain("dataset: combined");
       expect(request.query).toContain("since: $since, till: $till");
       expect(request.variables).toMatchObject({
         poolId: PCAN.poolId,
         till: now.toISOString(),
       });
+      if (pageIndex === 0) {
+        expect(request.query).not.toContain("any: [");
+      } else {
+        const prior = trades[pageIndex * 500 - 1];
+        expect(request.query).toContain("any: [");
+        expect(request.query).toContain(
+          `Number: { lt: "${prior.Block.Number}" }`,
+        );
+        expect(request.query).toContain(
+          `Transaction: { Index: { eq: ${prior.Transaction.Index} } }`,
+        );
+        expect(request.query).toContain(
+          `Log: { Index: { lt: ${prior.Log.Index} } }`,
+        );
+      }
       expect(request.query).not.toContain("Trading {");
       return jsonResponse({
         data: {
-          EVM: { DEXTrades: trades.slice(offset, offset + 500) },
+          EVM: {
+            DEXTrades: trades.slice(pageIndex * 500, (pageIndex + 1) * 500),
+          },
         },
       });
     }) as typeof fetch;
@@ -1421,7 +1499,7 @@ describe("Bitquery OHLCV chart and server stream", () => {
       now,
     });
 
-    expect(offsets).toEqual([0, 500, 1_000]);
+    expect(pageIndexes).toEqual([0, 1, 2]);
     expect(chart).toMatchObject({
       readStatus: "live",
       status: "ready",
@@ -1436,7 +1514,46 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(isMarketChartV1(chart)).toBe(true);
   });
 
-  it("deduplicates page boundaries and marks the exact raw cap as truncated", async () => {
+  it("fails closed when a provider page overlaps the prior keyset boundary", async () => {
+    const now = new Date("2026-08-11T14:02:00.000Z");
+    const trades = Array.from({ length: 1_000 }, (_, index) => tradeRow({
+      block: String(25_750_000 - index),
+      time: new Date(now.getTime() - (index + 1) * 60_000).toISOString(),
+      transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
+      transactionIndex: index % 200,
+      logIndex: index % 1_000,
+    }));
+    const pages = [
+      trades.slice(0, 500),
+      [trades[499], ...trades.slice(500, 727)],
+    ];
+    let pageIndex = 0;
+    const fetchImpl = vi.fn(async () => {
+      return jsonResponse({
+        data: { EVM: { DEXTrades: pages[pageIndex++] } },
+      });
+    }) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "all",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(chart).toMatchObject({
+      readStatus: "cache-fallback",
+      status: "unavailable",
+      swapCount: 0,
+      truncated: false,
+    });
+    expect(isMarketChartV1(chart)).toBe(true);
+  });
+
+  it("marks an exact keyset cap as truncated without inventing completeness", async () => {
     const now = new Date("2026-08-11T14:02:00.000Z");
     const trades = Array.from({ length: 2_000 }, (_, index) => tradeRow({
       block: String(25_750_000 - index),
@@ -1445,15 +1562,16 @@ describe("Bitquery OHLCV chart and server stream", () => {
       transactionIndex: index % 200,
       logIndex: index % 1_000,
     }));
-    trades[500] = trades[499];
-    const fetchImpl = vi.fn(async (
-      _url: string | URL | Request,
-      init?: RequestInit,
-    ) => {
-      const request = JSON.parse(String(init?.body));
-      const offset = Number(request.variables.offset);
+    let pageIndex = 0;
+    const fetchImpl = vi.fn(async () => {
+      const offset = pageIndex * 500;
+      pageIndex += 1;
       return jsonResponse({
-        data: { EVM: { DEXTrades: trades.slice(offset, offset + 500) } },
+        data: {
+          EVM: {
+            DEXTrades: trades.slice(offset, offset + 500),
+          },
+        },
       });
     }) as typeof fetch;
 
@@ -1470,13 +1588,10 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(chart).toMatchObject({
       readStatus: "live",
       status: "partial",
-      swapCount: 1_999,
-      volumeUsdWad: (25n * 1_999n * 10n ** 18n).toString(),
+      swapCount: 2_000,
+      volumeUsdWad: (25n * 2_000n * 10n ** 18n).toString(),
       truncated: true,
     });
-    expect(chart.points.every((point, index) =>
-      index === 0 || Date.parse(chart.points[index - 1].time) <= Date.parse(point.time)
-    )).toBe(true);
     expect(isMarketChartV1(chart)).toBe(true);
   });
 
@@ -1487,12 +1602,10 @@ describe("Bitquery OHLCV chart and server stream", () => {
       transactionIndex: index % 200,
       logIndex: index,
     }));
-    const fetchImpl = vi.fn(async (
-      _url: string | URL | Request,
-      init?: RequestInit,
-    ) => {
-      const request = JSON.parse(String(init?.body));
-      if (request.variables.offset === 0) {
+    let requestCount = 0;
+    const fetchImpl = vi.fn(async () => {
+      requestCount += 1;
+      if (requestCount === 1) {
         return jsonResponse({ data: { EVM: { DEXTrades: firstPage } } });
       }
       throw new Error("provider page failed");
@@ -1515,6 +1628,75 @@ describe("Bitquery OHLCV chart and server stream", () => {
       swapCount: 0,
     });
     expect(isMarketChartV1(chart)).toBe(true);
+  });
+
+  it("bounds all history pages by one twelve-second read deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const firstPage = Array.from({ length: 500 }, (_, index) => tradeRow({
+        block: String(25_750_000 - index),
+        transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
+        transactionIndex: index % 200,
+        logIndex: index,
+      }));
+      let callCount = 0;
+      const fetchImpl = vi.fn((
+        _url: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        callCount += 1;
+        const response = callCount === 1
+          ? jsonResponse({ data: { EVM: { DEXTrades: firstPage } } })
+          : null;
+        const delay = callCount === 1 ? 7_000 : 20_000;
+        return new Promise<Response>((resolve, reject) => {
+          const signal = init?.signal;
+          const onAbort = () => {
+            clearTimeout(timer);
+            reject(new DOMException("Aborted", "AbortError"));
+          };
+          const timer = setTimeout(() => {
+            signal?.removeEventListener("abort", onAbort);
+            if (response === null) {
+              reject(new Error("unexpected late response"));
+            } else {
+              resolve(response);
+            }
+          }, delay);
+          if (signal?.aborted) onAbort();
+          else signal?.addEventListener("abort", onAbort, { once: true });
+        });
+      }) as typeof fetch;
+
+      let settled = false;
+      const pending = readBitqueryMarketChartV1({
+        identity: PCAN,
+        range: "1d",
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+        fetchImpl,
+        token: OAUTH_TOKEN,
+        now: new Date("2026-08-11T14:02:00.000Z"),
+      }).then((value) => {
+        settled = true;
+        return value;
+      });
+
+      await vi.advanceTimersByTimeAsync(7_000);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+
+      const chart = await pending;
+      expect(chart).toMatchObject({
+        readStatus: "cache-fallback",
+        status: "unavailable",
+        swapCount: 0,
+      });
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not preserve a cached empty chart as confirmed through failure", async () => {
@@ -1814,21 +1996,21 @@ describe("Bitquery OHLCV chart and server stream", () => {
           DEXTrades: [
             tradeRow({
               block: "25740000",
-              time: "2026-08-11T14:00:01.000Z",
-              transaction,
-              logIndex: 1,
-              priceUsd: "1",
-              priceQuote: "1",
-              amountUsd: "10",
-            }),
-            tradeRow({
-              block: "25740000",
               time: "2026-08-11T14:00:02.000Z",
               transaction,
               logIndex: 2,
               priceUsd: "2",
               priceQuote: "2",
               amountUsd: "20",
+            }),
+            tradeRow({
+              block: "25740000",
+              time: "2026-08-11T14:00:01.000Z",
+              transaction,
+              logIndex: 1,
+              priceUsd: "1",
+              priceQuote: "1",
+              amountUsd: "10",
             }),
           ],
         },
@@ -1866,18 +2048,18 @@ describe("Bitquery OHLCV chart and server stream", () => {
             tradeRow({
               block: "25740000",
               time: "2026-08-11T14:00:01.000Z",
-              transaction: `0x${"ff".repeat(32)}`,
-              transactionIndex: 1,
-              logIndex: 9,
-              priceQuote: "1",
-            }),
-            tradeRow({
-              block: "25740000",
-              time: "2026-08-11T14:00:01.000Z",
               transaction: `0x${"00".repeat(32)}`,
               transactionIndex: 2,
               logIndex: 1,
               priceQuote: "2",
+            }),
+            tradeRow({
+              block: "25740000",
+              time: "2026-08-11T14:00:01.000Z",
+              transaction: `0x${"ff".repeat(32)}`,
+              transactionIndex: 1,
+              logIndex: 9,
+              priceQuote: "1",
             }),
           ],
         },
@@ -1902,12 +2084,12 @@ describe("Bitquery OHLCV chart and server stream", () => {
   it("never promotes raw DEX USD into chart prices or volume", async () => {
     const trades = [
       tradeRow({
-        block: "25740000",
-        time: "2026-08-11T14:00:01.000Z",
-        transaction: `0x${"11".repeat(32)}`,
-        priceUsd: "1",
-        priceQuote: "1",
-        amountUsd: "10",
+        block: "25740002",
+        time: "2026-08-11T14:01:10.000Z",
+        transaction: `0x${"13".repeat(32)}`,
+        priceUsd: "2",
+        priceQuote: "2",
+        amountUsd: "20",
       }),
       tradeRow({
         block: "25740001",
@@ -1918,12 +2100,12 @@ describe("Bitquery OHLCV chart and server stream", () => {
         priceQuote: "1.5",
       }),
       tradeRow({
-        block: "25740002",
-        time: "2026-08-11T14:01:10.000Z",
-        transaction: `0x${"13".repeat(32)}`,
-        priceUsd: "2",
-        priceQuote: "2",
-        amountUsd: "20",
+        block: "25740000",
+        time: "2026-08-11T14:00:01.000Z",
+        transaction: `0x${"11".repeat(32)}`,
+        priceUsd: "1",
+        priceQuote: "1",
+        amountUsd: "10",
       }),
     ];
     const fetchImpl = vi.fn(async () => jsonResponse({
@@ -2014,9 +2196,12 @@ describe("Bitquery OHLCV chart and server stream", () => {
     );
     expect(BITQUERY_MARKET_STREAM_QUERY).toContain("AmountCurrencyA");
     expect(BITQUERY_MARKET_STREAM_QUERY).toContain("AmountCurrencyB");
+    expect(BITQUERY_MARKET_STREAM_QUERY.match(/Log \{ Index \}/gu)).toHaveLength(2);
     expect(BITQUERY_MARKET_STREAM_QUERY.match(/DEXTrades\(/gu)).toHaveLength(1);
     expect(BITQUERY_MARKET_STREAM_QUERY.match(/DEXPoolEvents\(/gu)).toHaveLength(1);
-    expect(BITQUERY_MARKET_STREAM_QUERY).toContain("Transaction { Hash Index }");
+    expect(
+      BITQUERY_MARKET_STREAM_QUERY.match(/Transaction \{ Hash Index \}/gu),
+    ).toHaveLength(2);
     expect(
       BITQUERY_MARKET_STREAM_QUERY.match(
         /TransactionStatus: \{ Success: true \}/gu,

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -1217,6 +1217,143 @@ describe("Bitquery OHLCV chart and server stream", () => {
     },
   );
 
+  it("pages active exact-pool history within the provider response bound", async () => {
+    const now = new Date("2026-08-11T14:02:00.000Z");
+    const trades = Array.from({ length: 1_228 }, (_, index) => tradeRow({
+      block: String(25_750_000 - index),
+      time: new Date(now.getTime() - (index + 1) * 60_000).toISOString(),
+      transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
+      transactionIndex: index % 200,
+      logIndex: index % 1_000,
+    }));
+    const offsets: number[] = [];
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      const offset = Number(request.variables.offset);
+      offsets.push(offset);
+      expect(request.query).toContain("limit: { count: 500, offset: $offset }");
+      expect(request.query).toContain("dataset: combined");
+      expect(request.query).toContain("since: $since, till: $till");
+      expect(request.variables).toMatchObject({
+        poolId: PCAN.poolId,
+        till: now.toISOString(),
+      });
+      expect(request.query).not.toContain("Trading {");
+      return jsonResponse({
+        data: {
+          EVM: { DEXTrades: trades.slice(offset, offset + 500) },
+        },
+      });
+    }) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1d",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now,
+    });
+
+    expect(offsets).toEqual([0, 500, 1_000]);
+    expect(chart).toMatchObject({
+      readStatus: "live",
+      status: "ready",
+      swapCount: 1_228,
+      volumeUsdWad: (25n * 1_228n * 10n ** 18n).toString(),
+      truncated: false,
+    });
+    expect(chart.points.length).toBeGreaterThan(1);
+    expect(chart.points.every((point, index) =>
+      index === 0 || Date.parse(chart.points[index - 1].time) <= Date.parse(point.time)
+    )).toBe(true);
+    expect(isMarketChartV1(chart)).toBe(true);
+  });
+
+  it("deduplicates page boundaries and marks the exact raw cap as truncated", async () => {
+    const now = new Date("2026-08-11T14:02:00.000Z");
+    const trades = Array.from({ length: 2_000 }, (_, index) => tradeRow({
+      block: String(25_750_000 - index),
+      time: new Date(now.getTime() - (index + 1) * 60_000).toISOString(),
+      transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
+      transactionIndex: index % 200,
+      logIndex: index % 1_000,
+    }));
+    trades[500] = trades[499];
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      const offset = Number(request.variables.offset);
+      return jsonResponse({
+        data: { EVM: { DEXTrades: trades.slice(offset, offset + 500) } },
+      });
+    }) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "all",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(chart).toMatchObject({
+      readStatus: "live",
+      status: "partial",
+      swapCount: 1_999,
+      volumeUsdWad: (25n * 1_999n * 10n ** 18n).toString(),
+      truncated: true,
+    });
+    expect(chart.points.every((point, index) =>
+      index === 0 || Date.parse(chart.points[index - 1].time) <= Date.parse(point.time)
+    )).toBe(true);
+    expect(isMarketChartV1(chart)).toBe(true);
+  });
+
+  it("does not publish an incomplete chart when a later history page fails", async () => {
+    const firstPage = Array.from({ length: 500 }, (_, index) => tradeRow({
+      block: String(25_750_000 - index),
+      transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
+      transactionIndex: index % 200,
+      logIndex: index,
+    }));
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      if (request.variables.offset === 0) {
+        return jsonResponse({ data: { EVM: { DEXTrades: firstPage } } });
+      }
+      throw new Error("provider page failed");
+    }) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1d",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(chart).toMatchObject({
+      readStatus: "cache-fallback",
+      status: "unavailable",
+      points: [],
+      swapCount: 0,
+    });
+    expect(isMarketChartV1(chart)).toBe(true);
+  });
+
   it("does not preserve a cached empty chart as confirmed through failure", async () => {
     const success = vi.fn(async () => jsonResponse({
       data: {

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -45,6 +45,15 @@ const SECOND_CUSTOM: MarketDataIdentityV1 = {
   protocol: "uniswap_v4",
 };
 
+function generatedIdentity(index: number): MarketDataIdentityV1 {
+  return {
+    chainId: "1",
+    tokenAddress: `0x${index.toString(16).padStart(40, "0")}`,
+    poolId: `0x${index.toString(16).padStart(64, "0")}`,
+    protocol: "uniswap_v4",
+  };
+}
+
 function tradeRow(input: Readonly<{
   identity?: MarketDataIdentityV1;
   block?: string;
@@ -361,7 +370,7 @@ describe("Bitquery-only market data", () => {
     });
     const market = values.get(PCAN.tokenAddress);
 
-    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(market && isTokenMarketDataV1(market)).toBe(true);
     expect(market).toMatchObject({
       source: "bitquery",
@@ -421,7 +430,7 @@ describe("Bitquery-only market data", () => {
     });
     const pool = values.get(PCAN.tokenAddress)?.pools[0];
 
-    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(pool?.latestTrade).toMatchObject({
       priceUsdWad: "250000000000000000",
       priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
@@ -671,9 +680,79 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.identity).toEqual(PCAN);
     expect(values.get(CLASSIC.tokenAddress)?.pools[0]?.identity).toEqual(CLASSIC);
+  });
+
+  it("bounds historical USD price aliases without dropping later pools", async () => {
+    const identities = Array.from(
+      { length: 41 },
+      (_, index) => generatedIdentity(index + 1),
+    );
+    const priceBatchSizes: number[] = [];
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body));
+      if (request.query.includes("ProgrammableMarketSnapshot")) {
+        return jsonResponse({
+          data: {
+            EVM: {
+              latestTrades: identities.map((identity) => tradeRow({
+                identity,
+                omitPriceUsd: true,
+                omitQuotePriceUsd: true,
+              })),
+            },
+            Trading: {
+              tokenSupplies: identities.map((identity) => supplyRow({ identity })),
+            },
+          },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketPrices")) {
+        const aliases = [...request.query.matchAll(/price(\d+): Tokens/gu)];
+        priceBatchSizes.push(aliases.length);
+        return jsonResponse({
+          data: {
+            Trading: Object.fromEntries(aliases.map((match) => [
+              `price${match[1]}`,
+              [tradingPriceRow()],
+            ])),
+          },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketLiquidity")) {
+        return jsonResponse({
+          data: {
+            EVM: {
+              latestLiquidity: identities.map((identity) =>
+                liquidityRow(identity)),
+            },
+          },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketStats")) {
+        return jsonResponse({ data: { EVM: { stats: [] } } });
+      }
+      throw new Error("unexpected market request");
+    }) as typeof fetch;
+
+    const values = await readBitqueryTokenMarketDataV1(identities, {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
+    expect(priceBatchSizes.sort((first, second) => first - second)).toEqual([
+      1,
+      20,
+      20,
+    ]);
+    expect(identities.every((identity) =>
+      values.get(identity.tokenAddress)?.pools[0]?.latestTrade?.priceUsdWad ===
+        "250000000000000000"
+    )).toBe(true);
   });
 
   it("recovers missing indexed prices from bounded singleton queries", async () => {

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -397,6 +397,48 @@ describe("Bitquery-only market data", () => {
     });
   });
 
+  it("starts independent market reads before the core snapshot completes", async () => {
+    let releaseCore: (() => void) | undefined;
+    const corePending = new Promise<void>((resolve) => {
+      releaseCore = resolve;
+    });
+    const started = new Set<string>();
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      if (request.query.includes("ProgrammableMarketSnapshot")) {
+        started.add("core");
+        await corePending;
+      } else if (request.query.includes("ProgrammableMarketLiquidity")) {
+        started.add("liquidity");
+      } else if (request.query.includes("ProgrammableMarketStats")) {
+        started.add("stats");
+      } else {
+        throw new Error("unexpected market request");
+      }
+      return jsonResponse(marketResponse());
+    }) as typeof fetch;
+
+    const read = readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    try {
+      await vi.waitFor(() => {
+        expect([...started].sort()).toEqual(["core", "liquidity", "stats"]);
+      });
+    } finally {
+      releaseCore?.();
+    }
+
+    const values = await read;
+    expect(values.get(PCAN.tokenAddress)).toMatchObject({ source: "bitquery" });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
   it.each([
     ["wrong token id", supplyRow({ id: `bid:eth:${CLASSIC.tokenAddress}` })],
     ["wrong token address", supplyRow({ address: CLASSIC.tokenAddress })],

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -1216,6 +1216,131 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(isMarketChartV1(fallback)).toBe(true);
   });
 
+  it("reuses a populated chart for the two-second server cache window", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      data: {
+        EVM: {
+          DEXTrades: [tradeRow({
+            block: "25740000",
+            time: "2026-08-11T14:01:00.000Z",
+            transaction: `0x${"45".repeat(32)}`,
+            priceQuote: "1",
+          })],
+        },
+        Trading: { Tokens: [supplyRow()] },
+      },
+    })) as typeof fetch;
+    const first = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const second = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:01.999Z"),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  it("does not reuse a chart across different canonical valuations", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      data: {
+        EVM: {
+          DEXTrades: [tradeRow({
+            block: "25740000",
+            time: "2026-08-11T14:01:00.000Z",
+            transaction: `0x${"46".repeat(32)}`,
+            priceQuote: "1",
+          })],
+        },
+        Trading: { Tokens: [supplyRow()] },
+      },
+    })) as typeof fetch;
+    const firstValuation = {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      valueUsdWad: "100",
+      fdvUsdWad: "100",
+      totalSupply: "1000",
+      asOfTime: "2026-08-11T14:01:00.000Z",
+      freshness: "current",
+    } as const;
+    const secondValuation = {
+      ...firstValuation,
+      valueUsdWad: "200",
+      fdvUsdWad: "200",
+    } as const;
+    const first = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      valuation: firstValuation,
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const second = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      valuation: secondValuation,
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:01.000Z"),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(first.valuation).toEqual(firstValuation);
+    expect(second.valuation).toEqual(secondValuation);
+  });
+
+  it("omits redundant supply pricing when canonical valuation is provided", async () => {
+    const valuation = {
+      status: "unavailable",
+      reason: "source-unavailable",
+    } as const;
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      expect(request.query).not.toContain("Trading {");
+      expect(request.query).not.toContain("Tokens(");
+      expect(request.variables).not.toHaveProperty("tokenAddress");
+      return jsonResponse({
+        data: {
+          EVM: {
+            DEXTrades: [tradeRow({
+              block: "25740000",
+              time: "2026-08-11T14:01:00.000Z",
+              transaction: `0x${"47".repeat(32)}`,
+              priceQuote: "1",
+            })],
+          },
+        },
+      });
+    }) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      valuation,
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(chart.valuation).toEqual(valuation);
+    expect(chart.points).toHaveLength(1);
+  });
+
   it("builds exact-pool quote candles without promoting raw DEX USD", async () => {
     const trades = [
       tradeRow({

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -118,6 +118,9 @@ function liquidityRow(
     omitSecondUsd?: boolean;
     quoteAddress?: string;
     time?: string;
+    transaction?: string;
+    amountFirst?: string;
+    amountSecond?: string;
     amountFirstUsd?: string;
     amountSecondUsd?: string;
   }> = {},
@@ -126,6 +129,9 @@ function liquidityRow(
     Block: {
       Number: "25740000",
       Time: options.time ?? "2026-08-11T14:00:00.000Z",
+    },
+    Transaction: {
+      Hash: options.transaction ?? `0x${"aa".repeat(32)}`,
     },
     PoolEvent: {
       Pool: {
@@ -140,8 +146,8 @@ function liquidityRow(
         },
       },
       Liquidity: {
-        AmountCurrencyA: "100",
-        AmountCurrencyB: "20",
+        AmountCurrencyA: options.amountFirst ?? "100",
+        AmountCurrencyB: options.amountSecond ?? "20",
         ...(options.omitFirstUsd
           ? {}
           : { AmountCurrencyAInUSD: options.amountFirstUsd ?? "100000" }),
@@ -330,6 +336,10 @@ describe("Bitquery-only market data", () => {
       if (request.query.includes("ProgrammableMarketLiquidity")) {
         expect(request.variables).toEqual({ pools: [PCAN.poolId] });
         expect(request.query).toContain("latestLiquidity: DEXPoolEvents(");
+        expect(request.query).toContain("CurrencyA { SmartContract Symbol }");
+        expect(request.query).toContain("AmountCurrencyA");
+        expect(request.query).toContain("AmountCurrencyB");
+        expect(request.query).toContain("Transaction { Hash }");
         expect(request.query).not.toContain("latestTrades: DEXTrades(");
         return jsonResponse({
           data: { EVM: { latestLiquidity: [liquidityRow(PCAN)] } },
@@ -609,7 +619,7 @@ describe("Bitquery-only market data", () => {
     });
   });
 
-  it("normalizes native ETH without inventing missing liquidity USD", async () => {
+  it("derives exact-pool USD liquidity from event reserves and the bound native trade", async () => {
     const nativeEth = "0x0000000000000000000000000000000000000000";
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       trade: tradeRow({
@@ -634,7 +644,115 @@ describe("Bitquery-only market data", () => {
         priceUsdWad: "250000000000000000",
         quoteAddress: nativeEth,
       },
+      liquidity: {
+        valueUsdWad: "50025000000000000000000",
+        asOfBlock: "25740000",
+      },
     });
+  });
+
+  it("does not treat an indexed native price as transaction-bound liquidity evidence", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: tradeRow({
+        omitPriceUsd: true,
+        omitQuotePriceUsd: true,
+        omitAmountUsd: true,
+      }),
+      liquidity: liquidityRow(PCAN, {
+        omitFirstUsd: true,
+        omitSecondUsd: true,
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade).toHaveProperty(
+      "priceUsdWad",
+    );
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
+      "liquidity",
+    );
+  });
+
+  it("keeps a legitimate zero reserve while requiring positive total liquidity", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      liquidity: liquidityRow(PCAN, {
+        amountFirst: "0",
+        amountFirstUsd: "0",
+        amountSecond: "20",
+        amountSecondUsd: "50000",
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.liquidity).toMatchObject({
+      valueUsdWad: "50000000000000000000000",
+      freshness: "current",
+    });
+  });
+
+  it("does not publish zero total liquidity", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      liquidity: liquidityRow(PCAN, {
+        amountFirst: "0",
+        amountFirstUsd: "0",
+        amountSecond: "0",
+        amountSecondUsd: "0",
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
+      "liquidity",
+    );
+  });
+
+  it("does not derive missing liquidity USD for an unverified quote asset", async () => {
+    const unknownQuote = "0x2222222222222222222222222222222222222222";
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      trade: tradeRow({ quoteAddress: unknownQuote, quoteSymbol: "QUOTE" }),
+      liquidity: liquidityRow(PCAN, {
+        omitFirstUsd: true,
+        omitSecondUsd: true,
+        quoteAddress: unknownQuote,
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
+      "liquidity",
+    );
+  });
+
+  it("does not derive liquidity USD across different transactions", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
+      liquidity: liquidityRow(PCAN, {
+        omitFirstUsd: true,
+        omitSecondUsd: true,
+        transaction: `0x${"bb".repeat(32)}`,
+      }),
+    }))) as typeof fetch;
+    const values = await readBitqueryTokenMarketDataV1([PCAN], {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
     expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
       "liquidity",
     );
@@ -1025,7 +1143,10 @@ describe("Bitquery-only market data", () => {
 
   it("does not invent total USD liquidity when one pool side is missing", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
-      liquidity: liquidityRow(PCAN, { omitSecondUsd: true }),
+      liquidity: liquidityRow(PCAN, {
+        omitSecondUsd: true,
+        transaction: `0x${"bb".repeat(32)}`,
+      }),
     }))) as typeof fetch;
     const values = await readBitqueryTokenMarketDataV1([PCAN], {
       fetchImpl,
@@ -1888,6 +2009,11 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(BITQUERY_MARKET_STREAM_QUERY).toContain(
       "Pool: { PoolId: { in: $poolIds } }",
     );
+    expect(BITQUERY_MARKET_STREAM_QUERY).toContain(
+      "CurrencyA { SmartContract Symbol }",
+    );
+    expect(BITQUERY_MARKET_STREAM_QUERY).toContain("AmountCurrencyA");
+    expect(BITQUERY_MARKET_STREAM_QUERY).toContain("AmountCurrencyB");
     expect(BITQUERY_MARKET_STREAM_QUERY.match(/DEXTrades\(/gu)).toHaveLength(1);
     expect(BITQUERY_MARKET_STREAM_QUERY.match(/DEXPoolEvents\(/gu)).toHaveLength(1);
     expect(BITQUERY_MARKET_STREAM_QUERY).toContain("Transaction { Hash Index }");

--- a/tests/data-pipeline/bitquery-historical-release-gate.test.ts
+++ b/tests/data-pipeline/bitquery-historical-release-gate.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error Operational JavaScript modules intentionally have no declarations.
+import * as historicalReleaseGate from "../../scripts/perf/bitquery-historical-release-gate.mjs";
+
+const {
+  boundedStaleMarketTimeV1,
+  classifyBitqueryStaleMarketReleaseV1,
+  verifyBitqueryHistoricalGoldenReleaseV1,
+} = historicalReleaseGate;
+
+const TOKEN = "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
+const POOL =
+  "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const BLOCK = "25731000";
+const TIME = "2026-08-10T11:50:47.000Z";
+const NOW = Date.parse("2026-08-13T00:00:00.000Z");
+const PRICE = "2000000000000000000000";
+const FDV = "2000000000000000000000000";
+
+function detailToken(overrides: Record<string, unknown> = {}) {
+  return {
+    tokenAddress: TOKEN,
+    tokenDecimals: 18,
+    totalSupplyRaw: "1000000000000000000000",
+    valuation: {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      currency: "usd",
+      source: "bitquery",
+      freshness: "stale",
+      valueWad: FDV,
+      asOfTime: TIME,
+    },
+    marketData: {
+      schemaVersion: "programmable.market-data.v1",
+      source: "bitquery",
+      primaryPoolId: POOL,
+      pools: [{
+        identity: {
+          chainId: "1",
+          tokenAddress: TOKEN,
+          poolId: POOL,
+          protocol: "uniswap_v4",
+        },
+        source: "bitquery",
+        status: "stale",
+        quality: "partial",
+        asOfTime: TIME,
+        latestTrade: {
+          blockNumber: BLOCK,
+          time: TIME,
+          priceUsdWad: PRICE,
+        },
+        valuation: {
+          status: "available",
+          metric: "fdv",
+          supplyBasis: "total",
+          freshness: "stale",
+          valueUsdWad: FDV,
+          fdvUsdWad: FDV,
+          asOfTime: TIME,
+        },
+      }],
+    },
+    ...overrides,
+  };
+}
+
+function chart() {
+  return {
+    schemaVersion: "programmable.market-chart.v1",
+    source: "bitquery",
+    readStatus: "live",
+    status: "ready",
+    range: "all",
+    address: TOKEN,
+    identity: {
+      chainId: "1",
+      tokenAddress: TOKEN,
+      poolId: POOL,
+      protocol: "uniswap_v4",
+    },
+    points: [
+      { blockNumber: "25730000", time: "2026-08-10T10:50:47.000Z", priceUsd: "1900" },
+      { blockNumber: BLOCK, time: TIME, priceUsd: "2000" },
+    ],
+    valuation: {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      freshness: "stale",
+      valueUsdWad: FDV,
+      fdvUsdWad: FDV,
+      asOfTime: TIME,
+    },
+    asOfTime: TIME,
+  };
+}
+
+function parity(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: "programmable.bitquery-golden-market-parity.v1",
+    tokenAddress: TOKEN,
+    poolId: POOL,
+    blockNumber: BLOCK,
+    blockHash: `0x${"11".repeat(32)}`,
+    blockTime: TIME,
+    historicalPoolLiquidity: "1000000",
+    confirmations: 20,
+    bitqueryFdvUsdWad: FDV,
+    onchainFdvUsdWad: FDV,
+    deviationBps: 0,
+    ...overrides,
+  };
+}
+
+describe("Bitquery historical release gate", () => {
+  it("accepts an older-than-24h PCAN observation only after exact parity", () => {
+    const token = detailToken();
+    expect(boundedStaleMarketTimeV1(TIME, NOW)).toBe(false);
+    expect(classifyBitqueryStaleMarketReleaseV1({ token, nowMs: NOW })).toMatchObject({
+      status: "deferred-pcan",
+      tokenAddress: TOKEN,
+      poolId: POOL,
+    });
+    expect(verifyBitqueryHistoricalGoldenReleaseV1({
+      detailToken: token,
+      chart: chart(),
+      parity: parity(),
+      nowMs: NOW,
+    })).toMatchObject({
+      schemaVersion: "programmable.bitquery-historical-release.v1",
+      temporalStatus: "deferred-pcan",
+      blockNumber: BLOCK,
+      bitqueryFdvUsdWad: FDV,
+      historicalPoolLiquidity: "1000000",
+      confirmations: 20,
+    });
+  });
+
+  it.each([
+    ["schema", { schemaVersion: "programmable.bitquery-golden-market-parity.v2" }],
+    ["token", { tokenAddress: "0x1111111111111111111111111111111111111111" }],
+    ["pool", { poolId: `0x${"22".repeat(32)}` }],
+    ["block", { blockNumber: "25731001" }],
+    ["value", { bitqueryFdvUsdWad: (BigInt(FDV) + 1n).toString() }],
+    ["confirmations", { confirmations: 11 }],
+    ["historical liquidity", { historicalPoolLiquidity: "0" }],
+  ])("fails closed when the deferred PCAN parity drifts in %s", (_field, drift) => {
+    expect(() => verifyBitqueryHistoricalGoldenReleaseV1({
+      detailToken: detailToken(),
+      chart: chart(),
+      parity: parity(drift),
+      nowMs: NOW,
+    })).toThrow("historical PCAN release evidence is not exactly bound");
+  });
+
+  it("fails closed when the direct chart close is not the exact trade block", () => {
+    const driftedChart = chart();
+    driftedChart.points[1].blockNumber = "25731001";
+    expect(() => verifyBitqueryHistoricalGoldenReleaseV1({
+      detailToken: detailToken(),
+      chart: driftedChart,
+      parity: parity(),
+      nowMs: NOW,
+    })).toThrow("historical PCAN release evidence is not exactly bound");
+  });
+
+  it("keeps the 24h ceiling hard for every non-PCAN token", () => {
+    const token = detailToken({
+      tokenAddress: "0x1111111111111111111111111111111111111111",
+    });
+    expect(() => classifyBitqueryStaleMarketReleaseV1({
+      token,
+      nowMs: NOW,
+    })).toThrow("exceeds the 24 hour ceiling");
+  });
+
+  it("does not defer PCAN when its primary pool binding is wrong", () => {
+    const token = detailToken();
+    token.marketData.primaryPoolId = `0x${"22".repeat(32)}`;
+    expect(() => classifyBitqueryStaleMarketReleaseV1({
+      token,
+      nowMs: NOW,
+    })).toThrow("exceeds the 24 hour ceiling");
+  });
+});

--- a/tests/data-pipeline/bitquery-historical-release-gate.test.ts
+++ b/tests/data-pipeline/bitquery-historical-release-gate.test.ts
@@ -17,6 +17,7 @@ const TIME = "2026-08-10T11:50:47.000Z";
 const NOW = Date.parse("2026-08-13T00:00:00.000Z");
 const PRICE = "2000000000000000000000";
 const FDV = "2000000000000000000000000";
+const MAXIMUM_DEFERRED_PCAN_AGE_MS = 96 * 60 * 60_000;
 
 function detailToken(overrides: Record<string, unknown> = {}) {
   return {
@@ -117,6 +118,13 @@ function parity(overrides: Record<string, unknown> = {}) {
 }
 
 describe("Bitquery historical release gate", () => {
+  it("publishes the finite deferred PCAN evidence ceiling", () => {
+    expect(
+      historicalReleaseGate.BITQUERY_HISTORICAL_RELEASE_V1
+        .maximumDeferredPcanAgeMs,
+    ).toBe(MAXIMUM_DEFERRED_PCAN_AGE_MS);
+  });
+
   it("accepts an older-than-24h PCAN observation only after exact parity", () => {
     const token = detailToken();
     expect(boundedStaleMarketTimeV1(TIME, NOW)).toBe(false);
@@ -138,6 +146,25 @@ describe("Bitquery historical release gate", () => {
       historicalPoolLiquidity: "1000000",
       confirmations: 20,
     });
+  });
+
+  it("accepts the exact 96h boundary and rejects evidence one millisecond older", () => {
+    const token = detailToken();
+    const boundaryNow = Date.parse(TIME) + MAXIMUM_DEFERRED_PCAN_AGE_MS;
+    expect(classifyBitqueryStaleMarketReleaseV1({
+      token,
+      nowMs: boundaryNow,
+    })).toMatchObject({ status: "deferred-pcan" });
+    expect(() => classifyBitqueryStaleMarketReleaseV1({
+      token,
+      nowMs: boundaryNow + 1,
+    })).toThrow("historical PCAN release evidence exceeds the 96 hour ceiling");
+    expect(() => verifyBitqueryHistoricalGoldenReleaseV1({
+      detailToken: token,
+      chart: chart(),
+      parity: parity(),
+      nowMs: boundaryNow + 1,
+    })).toThrow("historical PCAN release evidence exceeds the 96 hour ceiling");
   });
 
   it.each([

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -713,6 +713,10 @@ describe("read-model production deploy policy", () => {
       "/api/explore/token/chart?address=${goldenTokenAddress}&range=all",
     );
     expect(workflow).toContain(
+      "staged Explore exposed the non-public PCAN release canary",
+    );
+    expect(workflow).toContain("goldenSearch.total !== 0");
+    expect(workflow).toContain(
       '"0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"',
     );
     expect(workflow).toContain(
@@ -751,10 +755,18 @@ describe("read-model production deploy policy", () => {
       '"./scripts/perf/bitquery-golden-market-parity.mjs"',
     );
     expect(workflow).toContain(
+      '"./scripts/perf/bitquery-historical-release-gate.mjs"',
+    );
+    expect(workflow).toContain(
       "await verifyBitqueryGoldenMarketParityV1({",
     );
     expect(workflow).toContain("const historicalPaidPathVerified =");
-    expect(workflow).toContain("goldenParity.confirmations >= 12");
+    expect(workflow).toContain(
+      "verifyBitqueryHistoricalGoldenReleaseV1({",
+    );
+    expect(workflow).toContain(
+      "historicalGoldenRelease.confirmations >= 12",
+    );
     expect(workflow).toContain('goldenChart.readStatus !== "live"');
     expect(workflow).toContain('goldenChart.readStatus === "live"');
     expect(workflow).toContain(

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -741,7 +741,16 @@ describe("read-model production deploy policy", () => {
     expect(workflow).toContain(
       'valuation.reason === "waiting-for-first-trade"',
     );
-    expect(workflow).not.toContain("if (currentFdvCount < 1) {");
+    expect(workflow).toContain("if (currentFdvCount < 1) {");
+    expect(workflow).toContain(
+      "staged Bitquery market path has no current public non-PCAN FDV with exact primary-pool liquidity evidence",
+    );
+    expect(workflow).toContain(
+      "primary.liquidity?.asOfTime !== valuation.asOfTime",
+    );
+    expect(workflow).toContain(
+      "!currentMarketTime(primary.liquidity?.asOfTime)",
+    );
     expect(workflow).toContain(
       "staged Bitquery current Explore and detail FDV are not identical",
     );
@@ -769,7 +778,7 @@ describe("read-model production deploy policy", () => {
     );
     expect(workflow).toContain('goldenChart.readStatus !== "live"');
     expect(workflow).toContain('goldenChart.readStatus === "live"');
-    expect(workflow).toContain(
+    expect(workflow).not.toContain(
       "currentFdvCount < 1 && !historicalPaidPathVerified",
     );
     expect(workflow).toContain(

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -748,6 +748,22 @@ describe("read-model production deploy policy", () => {
     expect(workflow).toContain(
       "primary.liquidity?.asOfTime !== valuation.asOfTime",
     );
+    expect(workflow).toContain('!/^0x[0-9a-f]{64}$/.test(');
+    expect(workflow).toContain(
+      'token.marketData.primaryPoolId ?? ""',
+    );
+    expect(workflow).toContain(
+      "primary.identity?.poolId !== token.marketData.primaryPoolId",
+    );
+    expect(workflow).toContain(
+      'primary.identity?.protocol !== "uniswap_v4"',
+    );
+    expect(workflow).toContain(
+      "!positiveInteger(primary.liquidity?.valueUsdWad)",
+    );
+    expect(workflow).toContain(
+      "!positiveInteger(primary.liquidity?.asOfBlock)",
+    );
     expect(workflow).toContain(
       "!currentMarketTime(primary.liquidity?.asOfTime)",
     );

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -375,6 +375,26 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it("fails closed when the historical PCAN deferral ceiling is widened", () => {
+    const helperPath = "scripts/perf/bitquery-historical-release-gate.mjs";
+    const helper = readFileSync(resolve(ROOT, helperPath), "utf8");
+    const unsafeHelper = helper.replace(
+      "const MAXIMUM_DEFERRED_PCAN_AGE_MS = 96 * 60 * 60_000",
+      "const MAXIMUM_DEFERRED_PCAN_AGE_MS = 365 * 24 * 60 * 60_000",
+    );
+    expect(unsafeHelper).not.toBe(helper);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [helperPath]: unsafeHelper,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
   it("fails closed when independent PCAN parity drops exact-block liquidity", () => {
     const parityPath = "scripts/perf/bitquery-golden-market-parity.mjs";
     const parity = readFileSync(resolve(ROOT, parityPath), "utf8");

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -22,6 +22,7 @@ const GOLDEN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
 const PUBLIC_TOKEN_ADDRESS =
   "0x1111111111111111111111111111111111111111";
+const PUBLIC_POOL_ID = `0x${"44".repeat(32)}`;
 const TEST_STATE_VIEW = "0x7fFE42C4a5DEeA5b0feC41C94C136Cf115597227";
 const TEST_ETH_USD_FEED = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
 const TEST_PARITY_BLOCK = 25_731_000n;
@@ -352,6 +353,50 @@ describe("read-model operations source contract", () => {
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
       "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
+  it("fails closed when staged release permits zero current public FDVs", () => {
+    const workflowPath = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const unsafeWorkflow = workflow.replace(
+      "          if (currentFdvCount < 1) {",
+      "          if (currentFdvCount < 0) {",
+    );
+    expect(unsafeWorkflow).not.toBe(workflow);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
+  it("fails closed when post-promotion permits zero current public FDVs", () => {
+    const postPromotionPath =
+      "scripts/perf/read-model-post-promotion.mjs";
+    const postPromotion = readFileSync(
+      resolve(ROOT, postPromotionPath),
+      "utf8",
+    );
+    const unsafePostPromotion = postPromotion.replace(
+      "  return currentCount > 0 &&",
+      "  return currentCount >= 0 &&",
+    );
+    expect(unsafePostPromotion).not.toBe(postPromotion);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [postPromotionPath]: unsafePostPromotion,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-post-promotion-binding",
     );
   });
 
@@ -747,7 +792,7 @@ function publicFetch(
     Math.floor((fixtureNow - goldenMarketAgeMs) / 1_000) * 1_000,
   ).toISOString();
   const publicMarketAsOf = new Date(
-    Math.floor((fixtureNow - 60 * 60_000) / 1_000) * 1_000,
+    Math.floor((fixtureNow - 2 * 60_000) / 1_000) * 1_000,
   ).toISOString();
   const earlierMarketTime = new Date(
     Date.parse(goldenMarketAsOf) - 60 * 60_000,
@@ -756,9 +801,10 @@ function publicFetch(
   return async (input: URL | RequestInfo, init?: RequestInit) => {
     const url = new URL(String(input));
     const publicBitqueryHeaders = {
-      "X-Programmable-Data-Quality": "stale",
+      "X-Programmable-Data-Quality": "complete",
       "X-Programmable-Market-As-Of": publicMarketAsOf,
       "X-Programmable-Market-Source": "bitquery",
+      "X-Programmable-Price-Source": "bitquery",
       "X-Programmable-Read-Source": "operational+durable+postgres",
     };
     if (url.hostname === "rpc-a.invalid" || url.hostname === "rpc-b.invalid") {
@@ -883,19 +929,55 @@ function publicFetch(
         status: "ready",
         tokens: [{
           tokenAddress: PUBLIC_TOKEN_ADDRESS,
+          fdvUsdWad: TEST_FDV_USD_WAD.toString(),
           valuation: {
             status: "available",
             metric: "fdv",
             supplyBasis: "total",
             currency: "usd",
             source: "bitquery",
-            freshness: "stale",
+            freshness: "current",
             valueWad: TEST_FDV_USD_WAD.toString(),
             asOfTime: publicMarketAsOf,
           },
+          marketData: {
+            schemaVersion: "programmable.market-data.v1",
+            source: "bitquery",
+            generatedAt: new Date(fixtureNow).toISOString(),
+            status: "current",
+            primaryPoolId: PUBLIC_POOL_ID,
+            pools: [{
+              identity: {
+                chainId: "1",
+                tokenAddress: PUBLIC_TOKEN_ADDRESS,
+                poolId: PUBLIC_POOL_ID,
+                protocol: "uniswap_v4",
+              },
+              source: "bitquery",
+              status: "current",
+              quality: "complete",
+              asOfTime: publicMarketAsOf,
+              liquidity: {
+                asOfTime: publicMarketAsOf,
+                asOfBlock: TEST_PARITY_BLOCK.toString(),
+                valueUsdWad: (50_000n * 10n ** 18n).toString(),
+                freshness: "current",
+              },
+              valuation: {
+                status: "available",
+                metric: "fdv",
+                supplyBasis: "total",
+                valueUsdWad: TEST_FDV_USD_WAD.toString(),
+                fdvUsdWad: TEST_FDV_USD_WAD.toString(),
+                totalSupply: "1000",
+                asOfTime: publicMarketAsOf,
+                freshness: "current",
+              },
+            }],
+          },
         }],
         dataQuality: {
-          status: "stale",
+          status: "complete",
           valuation: { asOfTime: publicMarketAsOf },
         },
       }, { headers: publicBitqueryHeaders });
@@ -1052,6 +1134,97 @@ describe("post-promotion route verification", () => {
       "production-bitquery-chart",
       "production-bitquery-golden-independent-parity",
     ]);
+  });
+
+  it("rejects zero current public FDVs even when exact PCAN history passes", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (
+        url.pathname !== "/api/explore" ||
+        url.searchParams.has("q")
+      ) return response;
+      const body = await response.json();
+      body.tokens[0].valuation.freshness = "stale";
+      delete body.tokens[0].fdvUsdWad;
+      return Response.json(body, { headers: response.headers });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-explore" }),
+    );
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        id: "production-bitquery-golden-independent-parity",
+        status: "pass",
+      }),
+    );
+  });
+
+  it("rejects a current public FDV without positive primary-pool liquidity", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (
+        url.pathname !== "/api/explore" ||
+        url.searchParams.has("q")
+      ) return response;
+      const body = await response.json();
+      body.tokens[0].marketData.pools[0].liquidity.valueUsdWad = "0";
+      return Response.json(body, { headers: response.headers });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-explore" }),
+    );
+  });
+
+  it("rejects current liquidity from a different observation time", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (
+        url.pathname !== "/api/explore" ||
+        url.searchParams.has("q")
+      ) return response;
+      const body = await response.json();
+      body.tokens[0].marketData.pools[0].liquidity.asOfTime = new Date(
+        Date.parse(body.tokens[0].valuation.asOfTime) - 1_000,
+      ).toISOString();
+      return Response.json(body, { headers: response.headers });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-explore" }),
+    );
+  });
+
+  it("rejects PCAN as the only current public FDV", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (
+        url.pathname !== "/api/explore" ||
+        url.searchParams.has("q")
+      ) return response;
+      const body = await response.json();
+      body.tokens[0].tokenAddress = GOLDEN_TOKEN_ADDRESS;
+      body.tokens[0].marketData.pools[0].identity.tokenAddress =
+        GOLDEN_TOKEN_ADDRESS;
+      return Response.json(body, { headers: response.headers });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-explore" }),
+    );
   });
 
   it("accepts PCAN evidence older than 24 hours only after exact independent parity", async () => {
@@ -1307,6 +1480,7 @@ describe("post-promotion route verification", () => {
 
   it("rejects an old FDV mislabeled as current", async () => {
     const base = publicFetch();
+    const tooOld = new Date(Date.now() - 7 * 60_000).toISOString();
     const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
       const url = new URL(String(input));
       const response = await base(input, init);
@@ -1315,8 +1489,14 @@ describe("post-promotion route verification", () => {
       }
       const body = await response.json();
       body.tokens[0].valuation.freshness = "current";
+      body.tokens[0].valuation.asOfTime = tooOld;
       body.tokens[0].fdvUsdWad = body.tokens[0].valuation.valueWad;
-      return Response.json(body, { headers: response.headers });
+      body.tokens[0].marketData.pools[0].liquidity.asOfTime = tooOld;
+      body.tokens[0].marketData.pools[0].valuation.asOfTime = tooOld;
+      body.dataQuality.valuation.asOfTime = tooOld;
+      const headers = new Headers(response.headers);
+      headers.set("X-Programmable-Market-As-Of", tooOld);
+      return Response.json(body, { headers });
     };
     const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
     expect(result.ok).toBe(false);

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { encodeFunctionResult, parseAbi } from "viem";
+import { encodeFunctionData, encodeFunctionResult, parseAbi } from "viem";
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
@@ -20,6 +20,8 @@ const GOLDEN_TOKEN_ADDRESS =
   "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
 const GOLDEN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const PUBLIC_TOKEN_ADDRESS =
+  "0x1111111111111111111111111111111111111111";
 const TEST_STATE_VIEW = "0x7fFE42C4a5DEeA5b0feC41C94C136Cf115597227";
 const TEST_ETH_USD_FEED = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
 const TEST_PARITY_BLOCK = 25_731_000n;
@@ -28,6 +30,7 @@ const TEST_PRICE_USD_WAD = 2_000n * 10n ** 18n;
 const TEST_FDV_USD_WAD = 2_000_000n * 10n ** 18n;
 const testStateViewAbi = parseAbi([
   "function getSlot0(bytes32 poolId) view returns (uint160 sqrtPriceX96,int24 tick,uint24 protocolFee,uint24 lpFee)",
+  "function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)",
 ]);
 const testErc20Abi = parseAbi([
   "function decimals() view returns (uint8)",
@@ -352,6 +355,69 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it("fails closed when the historical PCAN gate widens the general stale ceiling", () => {
+    const helperPath = "scripts/perf/bitquery-historical-release-gate.mjs";
+    const helper = readFileSync(resolve(ROOT, helperPath), "utf8");
+    const unsafeHelper = helper.replace(
+      "const MAXIMUM_STALE_AGE_MS = 24 * 60 * 60_000",
+      "const MAXIMUM_STALE_AGE_MS = 48 * 60 * 60_000",
+    );
+    expect(unsafeHelper).not.toBe(helper);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [helperPath]: unsafeHelper,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
+  it("fails closed when independent PCAN parity drops exact-block liquidity", () => {
+    const parityPath = "scripts/perf/bitquery-golden-market-parity.mjs";
+    const parity = readFileSync(resolve(ROOT, parityPath), "utf8");
+    const unsafeParity = parity.replace(
+      '  "function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)",\n',
+      "",
+    );
+    expect(unsafeParity).not.toBe(parity);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [parityPath]: unsafeParity,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
+  it("fails closed when the staged PCAN canary becomes discoverable", () => {
+    const workflowPath = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const unsafeWorkflow = workflow.replace(
+      `            goldenSearch.tokens.some(
+              (token) => token?.tokenAddress?.toLowerCase() === goldenTokenAddress,
+            ) ||
+            goldenSearch.total !== 0`,
+      "            false",
+    );
+    expect(unsafeWorkflow).not.toBe(workflow);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
   it("rejects a Bitquery staged smoke bypass relocated to another workflow step", () => {
     const workflowPath = ".github/workflows/deploy-production.yml";
     const secretLine =
@@ -652,14 +718,24 @@ describe("read-model operations source contract", () => {
   });
 });
 
-function publicFetch(healthStatus = "healthy") {
+function publicFetch(
+  healthStatus = "healthy",
+  goldenMarketAgeMs = 60 * 60_000,
+) {
   return async (input: URL | RequestInfo, init?: RequestInit) => {
     const url = new URL(String(input));
-    const marketAsOf = new Date(Date.now() - 60 * 60_000).toISOString();
-    const earlierMarketTime = new Date(Date.now() - 2 * 60 * 60_000).toISOString();
-    const bitqueryHeaders = {
+    const goldenMarketAsOf = new Date(
+      Math.floor((Date.now() - goldenMarketAgeMs) / 1_000) * 1_000,
+    ).toISOString();
+    const publicMarketAsOf = new Date(
+      Math.floor((Date.now() - 60 * 60_000) / 1_000) * 1_000,
+    ).toISOString();
+    const earlierMarketTime = new Date(
+      Date.parse(goldenMarketAsOf) - 60 * 60_000,
+    ).toISOString();
+    const publicBitqueryHeaders = {
       "X-Programmable-Data-Quality": "stale",
-      "X-Programmable-Market-As-Of": marketAsOf,
+      "X-Programmable-Market-As-Of": publicMarketAsOf,
       "X-Programmable-Market-Source": "bitquery",
       "X-Programmable-Read-Source": "operational+durable+postgres",
     };
@@ -676,17 +752,28 @@ function publicFetch(healthStatus = "healthy") {
         result = {
           number: `0x${TEST_PARITY_BLOCK.toString(16)}`,
           hash: `0x${"11".repeat(32)}`,
-          timestamp: `0x${BigInt(Math.floor(Date.parse(marketAsOf) / 1_000)).toString(16)}`,
+          timestamp: `0x${BigInt(Math.floor(Date.parse(goldenMarketAsOf) / 1_000)).toString(16)}`,
         };
       } else if (request.method === "eth_call") {
         const call = request.params[0] as { to: string; data: string };
         const target = call.to.toLowerCase();
         if (target === TEST_STATE_VIEW.toLowerCase()) {
-          result = encodeFunctionResult({
+          const liquiditySelector = encodeFunctionData({
             abi: testStateViewAbi,
-            functionName: "getSlot0",
-            result: [2n ** 96n, 0, 0, 0],
-          });
+            functionName: "getLiquidity",
+            args: [GOLDEN_POOL_ID],
+          }).slice(0, 10);
+          result = call.data.startsWith(liquiditySelector)
+            ? encodeFunctionResult({
+                abi: testStateViewAbi,
+                functionName: "getLiquidity",
+                result: 1_000_000n,
+              })
+            : encodeFunctionResult({
+                abi: testStateViewAbi,
+                functionName: "getSlot0",
+                result: [2n ** 96n, 0, 0, 0],
+              });
         } else if (
           target === GOLDEN_TOKEN_ADDRESS &&
           call.data.startsWith("0x313ce567")
@@ -715,7 +802,9 @@ function publicFetch(healthStatus = "healthy") {
             result: 8,
           });
         } else {
-          const timestamp = BigInt(Math.floor(Date.parse(marketAsOf) / 1_000));
+          const timestamp = BigInt(
+            Math.floor(Date.parse(goldenMarketAsOf) / 1_000),
+          );
           result = encodeFunctionResult({
             abi: testFeedAbi,
             functionName: "latestRoundData",
@@ -751,10 +840,27 @@ function publicFetch(healthStatus = "healthy") {
       );
     }
     if (url.pathname === "/api/explore") {
+      if (url.searchParams.get("q") === GOLDEN_TOKEN_ADDRESS) {
+        return Response.json({
+          status: "ready",
+          tokens: [],
+          total: 0,
+          dataQuality: {
+            status: "partial",
+            valuation: { asOfTime: null },
+          },
+        }, {
+          headers: {
+            "X-Programmable-Data-Quality": "partial",
+            "X-Programmable-Market-Source": "bitquery",
+            "X-Programmable-Read-Source": "operational+durable+postgres",
+          },
+        });
+      }
       return Response.json({
         status: "ready",
         tokens: [{
-          tokenAddress: GOLDEN_TOKEN_ADDRESS,
+          tokenAddress: PUBLIC_TOKEN_ADDRESS,
           valuation: {
             status: "available",
             metric: "fdv",
@@ -763,14 +869,14 @@ function publicFetch(healthStatus = "healthy") {
             source: "bitquery",
             freshness: "stale",
             valueWad: TEST_FDV_USD_WAD.toString(),
-            asOfTime: marketAsOf,
+            asOfTime: publicMarketAsOf,
           },
         }],
         dataQuality: {
           status: "stale",
-          valuation: { asOfTime: marketAsOf },
+          valuation: { asOfTime: publicMarketAsOf },
         },
-      }, { headers: bitqueryHeaders });
+      }, { headers: publicBitqueryHeaders });
     }
     if (url.pathname === "/api/explore/token") {
       return Response.json({
@@ -787,7 +893,7 @@ function publicFetch(healthStatus = "healthy") {
             source: "bitquery",
             freshness: "stale",
             valueWad: TEST_FDV_USD_WAD.toString(),
-            asOfTime: marketAsOf,
+            asOfTime: goldenMarketAsOf,
           },
           marketData: {
             schemaVersion: "programmable.market-data.v1",
@@ -802,23 +908,20 @@ function publicFetch(healthStatus = "healthy") {
                 poolId: GOLDEN_POOL_ID,
                 protocol: "uniswap_v4",
               },
+              source: "bitquery",
               status: "stale",
+              quality: "partial",
+              asOfTime: goldenMarketAsOf,
               latestTrade: {
                 transactionHash: `0x${"22".repeat(32)}`,
                 logIndex: 1,
                 blockNumber: TEST_PARITY_BLOCK.toString(),
-                time: marketAsOf,
+                time: goldenMarketAsOf,
                 tokenSide: "buy",
                 priceUsdWad: TEST_PRICE_USD_WAD.toString(),
                 rawPriceUsdWad: TEST_PRICE_USD_WAD.toString(),
-                priceUsdAsOfTime: marketAsOf,
+                priceUsdAsOfTime: goldenMarketAsOf,
                 priceUsdSource: "bitquery-token-price-index-v1",
-              },
-              liquidity: {
-                asOfTime: marketAsOf,
-                asOfBlock: TEST_PARITY_BLOCK.toString(),
-                valueUsdWad: (20_000n * 10n ** 18n).toString(),
-                freshness: "stale",
               },
               valuation: {
                 status: "available",
@@ -827,7 +930,7 @@ function publicFetch(healthStatus = "healthy") {
                 valueUsdWad: TEST_FDV_USD_WAD.toString(),
                 fdvUsdWad: TEST_FDV_USD_WAD.toString(),
                 totalSupply: "1000",
-                asOfTime: marketAsOf,
+                asOfTime: goldenMarketAsOf,
                 freshness: "stale",
               },
             }],
@@ -839,7 +942,7 @@ function publicFetch(healthStatus = "healthy") {
         },
       }, {
         headers: {
-          "X-Programmable-Market-As-Of": marketAsOf,
+          "X-Programmable-Market-As-Of": goldenMarketAsOf,
           "X-Programmable-Data-Quality": "stale",
           "X-Programmable-Market-Source": "bitquery",
           "X-Programmable-Read-Source": "operational+durable+postgres",
@@ -852,19 +955,25 @@ function publicFetch(healthStatus = "healthy") {
         source: "bitquery",
         readStatus: "live",
         status: "ready",
+        range: "all",
         generatedAt: new Date().toISOString(),
         address: GOLDEN_TOKEN_ADDRESS,
-        identity: { poolId: GOLDEN_POOL_ID },
+        identity: {
+          chainId: "1",
+          tokenAddress: GOLDEN_TOKEN_ADDRESS,
+          poolId: GOLDEN_POOL_ID,
+          protocol: "uniswap_v4",
+        },
         points: [
           {
             blockNumber: "25730000",
             time: earlierMarketTime,
-            priceUsd: "0.2",
+            priceUsd: "1900",
           },
           {
             blockNumber: "25731000",
-            time: marketAsOf,
-            priceUsd: "0.25",
+            time: goldenMarketAsOf,
+            priceUsd: "2000",
           },
         ],
         valuation: {
@@ -872,13 +981,15 @@ function publicFetch(healthStatus = "healthy") {
           metric: "fdv",
           supplyBasis: "total",
           freshness: "stale",
-          asOfTime: marketAsOf,
+          valueUsdWad: TEST_FDV_USD_WAD.toString(),
+          fdvUsdWad: TEST_FDV_USD_WAD.toString(),
+          asOfTime: goldenMarketAsOf,
         },
-        asOfTime: marketAsOf,
+        asOfTime: goldenMarketAsOf,
       }, {
         headers: {
           "X-Programmable-Data-Quality": "ready",
-          "X-Programmable-Market-As-Of": marketAsOf,
+          "X-Programmable-Market-As-Of": goldenMarketAsOf,
           "X-Programmable-Market-Source": "bitquery",
           "X-Programmable-Price-Source": "bitquery",
         },
@@ -914,10 +1025,95 @@ describe("post-promotion route verification", () => {
       "production-root",
       "production-health",
       "production-explore",
+      "production-bitquery-canary-hidden",
       "production-bitquery-detail",
       "production-bitquery-chart",
       "production-bitquery-golden-independent-parity",
     ]);
+  });
+
+  it("accepts PCAN evidence older than 24 hours only after exact independent parity", async () => {
+    const result = await verifyPostPromotion(
+      postPromotionInput(publicFetch("healthy", 58 * 60 * 60_000)),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        id: "production-bitquery-golden-independent-parity",
+        status: "pass",
+      }),
+    );
+  });
+
+  it("rejects historical PCAN evidence when exact-block pool liquidity is zero", async () => {
+    const base = publicFetch("healthy", 58 * 60 * 60_000);
+    const liquiditySelector = encodeFunctionData({
+      abi: testStateViewAbi,
+      functionName: "getLiquidity",
+      args: [GOLDEN_POOL_ID],
+    }).slice(0, 10);
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.hostname !== "rpc-a.invalid" && url.hostname !== "rpc-b.invalid") {
+        return base(input, init);
+      }
+      const request = JSON.parse(String(init?.body ?? "{}")) as {
+        id: number;
+        method: string;
+        params: readonly [{ data?: string }];
+      };
+      if (
+        request.method === "eth_call" &&
+        request.params[0]?.data?.startsWith(liquiditySelector)
+      ) {
+        return Response.json({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: encodeFunctionResult({
+            abi: testStateViewAbi,
+            functionName: "getLiquidity",
+            result: 0n,
+          }),
+        });
+      }
+      return base(input, init);
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({
+        id: "production-bitquery-golden-independent-parity",
+      }),
+    );
+  });
+
+  it("rejects a publicly discoverable PCAN release canary", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (
+        url.pathname !== "/api/explore" ||
+        url.searchParams.get("q") !== GOLDEN_TOKEN_ADDRESS
+      ) return base(input, init);
+      return Response.json({
+        status: "ready",
+        tokens: [{ tokenAddress: GOLDEN_TOKEN_ADDRESS }],
+        total: 1,
+        dataQuality: { status: "partial", valuation: { asOfTime: null } },
+      }, {
+        headers: {
+          "X-Programmable-Data-Quality": "partial",
+          "X-Programmable-Market-Source": "bitquery",
+          "X-Programmable-Read-Source": "operational+durable+postgres",
+        },
+      });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-bitquery-canary-hidden" }),
+    );
   });
 
   it("rejects an internally coherent Bitquery price with the wrong onchain scale", async () => {
@@ -1064,13 +1260,15 @@ describe("post-promotion route verification", () => {
     );
   });
 
-  it("rejects Explore valuation evidence older than the stale release ceiling", async () => {
+  it("rejects non-PCAN Explore valuation evidence older than the stale release ceiling", async () => {
     const base = publicFetch();
     const tooOld = new Date(Date.now() - 25 * 60 * 60_000).toISOString();
     const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
       const url = new URL(String(input));
       const response = await base(input, init);
-      if (url.pathname !== "/api/explore") return response;
+      if (url.pathname !== "/api/explore" || url.searchParams.has("q")) {
+        return response;
+      }
       const body = await response.json();
       body.tokens[0].valuation.asOfTime = tooOld;
       body.dataQuality.valuation.asOfTime = tooOld;
@@ -1087,10 +1285,12 @@ describe("post-promotion route verification", () => {
 
   it("rejects an old FDV mislabeled as current", async () => {
     const base = publicFetch();
-    const fetchImpl = async (input: URL | RequestInfo) => {
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
       const url = new URL(String(input));
-      const response = await base(input);
-      if (url.pathname !== "/api/explore") return response;
+      const response = await base(input, init);
+      if (url.pathname !== "/api/explore" || url.searchParams.has("q")) {
+        return response;
+      }
       const body = await response.json();
       body.tokens[0].valuation.freshness = "current";
       body.tokens[0].fdvUsdWad = body.tokens[0].valuation.valueWad;

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -376,6 +376,31 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it.each([
+    ["positive liquidity", "!positiveInteger(primary.liquidity?.valueUsdWad)"],
+    ["liquidity block", "!positiveInteger(primary.liquidity?.asOfBlock)"],
+    ["Uniswap v4 protocol", 'primary.identity?.protocol !== "uniswap_v4"'],
+    [
+      "canonical primary pool identity",
+      "primary.identity?.poolId !== token.marketData.primaryPoolId",
+    ],
+  ])("fails closed when staged release drops %s binding", (_label, needle) => {
+    const workflowPath = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const unsafeWorkflow = workflow.replace(needle, "false");
+    expect(unsafeWorkflow).not.toBe(workflow);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
   it("fails closed when post-promotion permits zero current public FDVs", () => {
     const postPromotionPath =
       "scripts/perf/read-model-post-promotion.mjs";
@@ -387,6 +412,39 @@ describe("read-model operations source contract", () => {
       "  return currentCount > 0 &&",
       "  return currentCount >= 0 &&",
     );
+    expect(unsafePostPromotion).not.toBe(postPromotion);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [postPromotionPath]: unsafePostPromotion,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-post-promotion-binding",
+    );
+  });
+
+  it.each([
+    ["positive liquidity", "positiveInteger(liquidity.valueUsdWad)"],
+    ["liquidity block", "positiveInteger(liquidity.asOfBlock)"],
+    ["Uniswap v4 protocol", 'primary.identity.protocol === "uniswap_v4"'],
+    [
+      "canonical primary pool identity",
+      "primary.identity.poolId === market.primaryPoolId",
+    ],
+    [
+      "valuation equality",
+      "poolValuation.valueUsdWad === valuation.valueWad",
+    ],
+  ])("fails closed when post-promotion drops %s binding", (_label, needle) => {
+    const postPromotionPath =
+      "scripts/perf/read-model-post-promotion.mjs";
+    const postPromotion = readFileSync(
+      resolve(ROOT, postPromotionPath),
+      "utf8",
+    );
+    const unsafePostPromotion = postPromotion.replace(needle, "false");
     expect(unsafePostPromotion).not.toBe(postPromotion);
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -722,17 +722,19 @@ function publicFetch(
   healthStatus = "healthy",
   goldenMarketAgeMs = 60 * 60_000,
 ) {
+  const fixtureNow = Date.now();
+  const goldenMarketAsOf = new Date(
+    Math.floor((fixtureNow - goldenMarketAgeMs) / 1_000) * 1_000,
+  ).toISOString();
+  const publicMarketAsOf = new Date(
+    Math.floor((fixtureNow - 60 * 60_000) / 1_000) * 1_000,
+  ).toISOString();
+  const earlierMarketTime = new Date(
+    Date.parse(goldenMarketAsOf) - 60 * 60_000,
+  ).toISOString();
+
   return async (input: URL | RequestInfo, init?: RequestInit) => {
     const url = new URL(String(input));
-    const goldenMarketAsOf = new Date(
-      Math.floor((Date.now() - goldenMarketAgeMs) / 1_000) * 1_000,
-    ).toISOString();
-    const publicMarketAsOf = new Date(
-      Math.floor((Date.now() - 60 * 60_000) / 1_000) * 1_000,
-    ).toISOString();
-    const earlierMarketTime = new Date(
-      Date.parse(goldenMarketAsOf) - 60 * 60_000,
-    ).toISOString();
     const publicBitqueryHeaders = {
       "X-Programmable-Data-Quality": "stale",
       "X-Programmable-Market-As-Of": publicMarketAsOf,

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   getOnchainDeployment: vi.fn(),
   readDurableExploreModel: vi.fn(),
   readBitqueryTokenMarketDataV1: vi.fn(),
+  hydrateMissingCanonicalTokenSupplyV1: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
 }));
 
@@ -66,6 +67,11 @@ vi.mock("../lib/onchain/durable-model", () => ({
 
 vi.mock("../lib/market-data/bitquery.server", () => ({
   readBitqueryTokenMarketDataV1: mocks.readBitqueryTokenMarketDataV1,
+}));
+
+vi.mock("../lib/market-data/canonical-token-supply.server", () => ({
+  hydrateMissingCanonicalTokenSupplyV1:
+    mocks.hydrateMissingCanonicalTokenSupplyV1,
 }));
 
 import {
@@ -243,6 +249,9 @@ describe("Explore API Bitquery market boundary", () => {
     mocks.readBitqueryTokenMarketDataV1.mockImplementation(
       async (identities: readonly MarketDataIdentityV1[]) =>
         bitqueryMarketData(identities),
+    );
+    mocks.hydrateMissingCanonicalTokenSupplyV1.mockImplementation(
+      async (entries: readonly ExploreEntry[]) => [...entries],
     );
   });
 
@@ -616,6 +625,67 @@ describe("Explore API Bitquery market boundary", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
+    expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.readBitqueryTokenMarketDataV1.mock.calls[0]?.[0],
+    ).toHaveLength(30);
+  });
+
+  it.each([
+    ["newest", [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]],
+    ["oldest", [21, 22, 23, 24, 25, 26, 27, 28, 29, 30]],
+  ] as const)(
+    "values only the requested identity page for %s ordering",
+    async (sort, expectedIndexes) => {
+      const response = await GET(
+        new NextRequest(
+          `http://localhost/api/explore?sort=${sort}&page=3&limit=10`,
+        ),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        status: "ready",
+        page: 3,
+        pageSize: 10,
+        total: 30,
+        totalPages: 3,
+      });
+      expect(body.tokens.map((entry: LauncherToken) => entry.symbol)).toEqual(
+        expectedIndexes.map((index) => `T${index}`),
+      );
+      expect(mocks.hydrateMissingCanonicalTokenSupplyV1).toHaveBeenCalledTimes(1);
+      expect(
+        mocks.hydrateMissingCanonicalTokenSupplyV1.mock.calls[0]?.[0],
+      ).toHaveLength(10);
+      expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledTimes(1);
+      expect(
+        mocks.readBitqueryTokenMarketDataV1.mock.calls[0]?.[0],
+      ).toHaveLength(10);
+    },
+  );
+
+  it("briefly edge caches explicitly stale market data", async () => {
+    mocks.readBitqueryTokenMarketDataV1.mockImplementation(
+      async (identities: readonly MarketDataIdentityV1[]) =>
+        bitqueryMarketData(identities, { freshness: "stale" }),
+    );
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/explore?sort=market-cap"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.dataQuality).toMatchObject({
+      status: "stale",
+      valuation: { status: "stale", stale: 30 },
+    });
+    expect(response.headers.get("X-Programmable-Data-Quality")).toBe("stale");
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
+    );
   });
 
   it("binds current FDV to Bitquery time instead of the lagging identity snapshot", async () => {
@@ -838,7 +908,6 @@ describe("Explore API Bitquery market boundary", () => {
   });
 
   it.each([
-    ["newest", "sort=newest&page=3&limit=10"],
     ["lowest FDV", "sort=lowest-market-cap&page=3&limit=10"],
     ["social filter", "socials=yes&page=3&limit=10"],
     ["search", "q=token&page=3&limit=10"],

--- a/tests/explore-page-ssr.test.ts
+++ b/tests/explore-page-ssr.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/api/explore/route", () => ({ GET: vi.fn() }));
+vi.mock("@/components/explore-view", () => ({ ExploreView: () => null }));
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
+
+import { readInitialExploreWithinDeadline } from "../app/explore/page";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Explore initial server read", () => {
+  it("returns at the total deadline and safely consumes the aborted read", async () => {
+    vi.useFakeTimers();
+    let readSignal: AbortSignal | undefined;
+    const result = readInitialExploreWithinDeadline(
+      (signal) => {
+        readSignal = signal;
+        return new Promise((_, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => reject(new Error("late provider failure")),
+            { once: true },
+          );
+        });
+      },
+      25,
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(result).resolves.toEqual({
+      ok: false,
+      body: { error: "Tokens are temporarily unavailable" },
+    });
+    expect(readSignal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the deadline and aborts the request signal after success", async () => {
+    vi.useFakeTimers();
+    let readSignal: AbortSignal | undefined;
+
+    await expect(
+      readInitialExploreWithinDeadline(async (signal) => {
+        readSignal = signal;
+        return { ok: true, body: { status: "ready" } };
+      }, 25),
+    ).resolves.toEqual({ ok: true, body: { status: "ready" } });
+
+    expect(readSignal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/tests/explore-public-visibility.test.ts
+++ b/tests/explore-public-visibility.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import classicV3Release from
+  "../contracts/deployments/mainnet-classic-v3.json";
+import deepV1Release from
+  "../contracts/deployments/mainnet-deep-full-range-v1.json";
+import stockPairedV1Release from
+  "../contracts/deployments/mainnet-stock-paired-v1.json";
+import stockPairedV2Release from
+  "../contracts/deployments/mainnet-stock-paired-v2.json";
+import stockPairedV3Release from
+  "../contracts/deployments/mainnet-stock-paired-v3.json";
+import { PROGRAMMABLE_LAUNCH_STAMP_MANIFEST } from
+  "../components/launch-stamp-docs-contract";
+import {
+  isPublicExploreIdentityV1,
+  NON_PUBLIC_EXPLORE_IDENTITIES_V1,
+} from "../lib/explore-public-visibility";
+
+function sorted(values: readonly string[]) {
+  return [...values].map((value) => value.toLowerCase()).sort();
+}
+
+describe("public Explore visibility", () => {
+  it("binds every excluded token to canonical repository canary evidence", () => {
+    const evidencedCanaryTokens = [
+      classicV3Release.lifecycleEvidence.canaryToken,
+      deepV1Release.lifecycleEvidence.canaryToken,
+      stockPairedV1Release.lifecycleEvidence.canaryToken,
+      stockPairedV2Release.lifecycleEvidence.canaryToken,
+      stockPairedV3Release.lifecycleEvidence.canaryToken,
+      PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter.canaryEvidence
+        .components.token,
+    ];
+
+    expect(sorted(NON_PUBLIC_EXPLORE_IDENTITIES_V1.tokens.map(
+      ({ identity }) => identity,
+    ))).toEqual(sorted(evidencedCanaryTokens));
+    expect(NON_PUBLIC_EXPLORE_IDENTITIES_V1.tokens.every(
+      ({ kind, evidence }) => kind === "release-canary-token" && evidence.length > 0,
+    )).toBe(true);
+  });
+
+  it("excludes only exact identities and ignores names, creators, and metadata", () => {
+    const canary = classicV3Release.lifecycleEvidence.canaryToken;
+    expect(isPublicExploreIdentityV1({ tokenAddress: canary })).toBe(false);
+    expect(isPublicExploreIdentityV1({ tokenAddress: canary.toLowerCase() })).toBe(
+      false,
+    );
+    expect(isPublicExploreIdentityV1({
+      tokenAddress: "0x1111111111111111111111111111111111111111",
+    })).toBe(true);
+    expect(isPublicExploreIdentityV1({})).toBe(true);
+  });
+
+});

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -17,10 +17,16 @@ describe("Explore UI contract", () => {
       'import { GET as readExploreResponse } from "@/app/api/explore/route"',
     );
     expect(page).toContain("await readExploreResponse(new NextRequest(");
+    expect(page).toContain("return await Promise.race([guardedRead, deadline])");
+    expect(page).toContain("controller.abort()");
+    expect(page).not.toContain("AbortSignal.timeout(");
     expect(page).not.toContain('fetch("https://programmable.market');
     expect(page).toContain("<ExploreView initialResponse={initialResponse} />");
     expect(source).toContain(
       "if (handledRequestKey.current === requestKey)",
+    );
+    expect(source).toContain(
+      "handledInitialExploreRequestKey(initialState, requestKey)",
     );
     expect(source).toContain("enabled: !preview && !loadingOnly");
   });

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -13,7 +13,11 @@ describe("Explore UI contract", () => {
     );
 
     expect(page).toContain("<Suspense fallback={<ExploreView loadingOnly />}>");
-    expect(page).toContain('"https://programmable.market/api/explore"');
+    expect(page).toContain(
+      'import { GET as readExploreResponse } from "@/app/api/explore/route"',
+    );
+    expect(page).toContain("await readExploreResponse(new NextRequest(");
+    expect(page).not.toContain('fetch("https://programmable.market');
     expect(page).toContain("<ExploreView initialResponse={initialResponse} />");
     expect(source).toContain(
       "if (handledRequestKey.current === requestKey)",

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -5,6 +5,22 @@ import { describe, expect, it } from "vitest";
 const root = process.cwd();
 
 describe("Explore UI contract", () => {
+  it("streams the initial Explore response and suppresses the hydration refetch", () => {
+    const page = readFileSync(join(root, "app/explore/page.tsx"), "utf8");
+    const source = readFileSync(
+      join(root, "components/explore-view.tsx"),
+      "utf8",
+    );
+
+    expect(page).toContain("<Suspense fallback={<ExploreView loadingOnly />}>");
+    expect(page).toContain('"https://programmable.market/api/explore"');
+    expect(page).toContain("<ExploreView initialResponse={initialResponse} />");
+    expect(source).toContain(
+      "if (handledRequestKey.current === requestKey)",
+    );
+    expect(source).toContain("enabled: !preview && !loadingOnly");
+  });
+
   it("keeps sort, socials and model choices in one persistent disclosure", () => {
     const source = readFileSync(
       join(root, "components/explore-view.tsx"),

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -4,6 +4,7 @@ import {
   EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
   EXPLORE_TOKENS_PER_PAGE,
   EXPLORE_REFRESH_INTERVAL_MS,
+  createExploreInitialState,
   filterTokensByLaunchModel,
   filterTokensBySocialPresence,
   getTokenCards,
@@ -111,6 +112,46 @@ afterEach(() => {
 });
 
 describe("Explore refresh state", () => {
+  it("hydrates the first server page without waiting for a client request", () => {
+    expect(
+      createExploreInitialState(
+        {
+          ok: true,
+          body: payload,
+        },
+        {
+          contentKey: "initial-content",
+          requestKey: "initial-request",
+        },
+      ),
+    ).toEqual({
+      phase: "ready",
+      payload,
+      contentKey: "initial-content",
+      requestKey: "initial-request",
+    });
+  });
+
+  it("keeps a server-side Explore failure retryable without inventing data", () => {
+    expect(
+      createExploreInitialState(
+        {
+          ok: false,
+          body: { error: "Launch index is catching up" },
+        },
+        {
+          contentKey: "initial-content-error",
+          requestKey: "initial-request-error",
+        },
+      ),
+    ).toEqual({
+      phase: "error",
+      message: "Launch index is catching up",
+      contentKey: "initial-content-error",
+      requestKey: "initial-request-error",
+    });
+  });
+
   it("uses a balanced nine-card page and compact desktop pagination", () => {
     expect(EXPLORE_TOKENS_PER_PAGE).toBe(9);
     expect(getExplorePaginationItems(1, 10)).toEqual([

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -5,6 +5,7 @@ import {
   EXPLORE_TOKENS_PER_PAGE,
   EXPLORE_REFRESH_INTERVAL_MS,
   createExploreInitialState,
+  handledInitialExploreRequestKey,
   filterTokensByLaunchModel,
   filterTokensBySocialPresence,
   getTokenCards,
@@ -133,8 +134,7 @@ describe("Explore refresh state", () => {
   });
 
   it("keeps a server-side Explore failure retryable without inventing data", () => {
-    expect(
-      createExploreInitialState(
+    const initialState = createExploreInitialState(
         {
           ok: false,
           body: { error: "Launch index is catching up" },
@@ -143,13 +143,31 @@ describe("Explore refresh state", () => {
           contentKey: "initial-content-error",
           requestKey: "initial-request-error",
         },
-      ),
-    ).toEqual({
+      );
+
+    expect(initialState).toEqual({
       phase: "error",
       message: "Launch index is catching up",
       contentKey: "initial-content-error",
       requestKey: "initial-request-error",
     });
+    expect(
+      handledInitialExploreRequestKey(initialState, "initial-request-error"),
+    ).toBeNull();
+  });
+
+  it("suppresses only the successful server response hydration request", () => {
+    const initialState = createExploreInitialState(
+      { ok: true, body: payload },
+      { contentKey: "initial-content", requestKey: "initial-request" },
+    );
+
+    expect(
+      handledInitialExploreRequestKey(initialState, "initial-request"),
+    ).toBe("initial-request");
+    expect(
+      handledInitialExploreRequestKey(null, "initial-request"),
+    ).toBeNull();
   });
 
   it("uses a balanced nine-card page and compact desktop pagination", () => {

--- a/tests/onchain-query.test.ts
+++ b/tests/onchain-query.test.ts
@@ -5,6 +5,7 @@ import {
   filterAndSortTokens,
   paginateExplore,
   parseExploreSort,
+  visibleExploreTokens,
 } from "../lib/onchain/query";
 import type { ExploreReadModel } from "../lib/onchain/types";
 
@@ -321,6 +322,39 @@ describe("Explore query", () => {
     expect(page.total).toBe(1);
     expect(page.tokens.map((entry) => entry.id)).toEqual([
       "first-public-launch",
+    ]);
+  });
+
+  it("keeps evidence-bound canaries out without guessing from display metadata", () => {
+    const canonicalCanary = {
+      ...tokens[0],
+      id: "canonical-canary",
+      tokenAddress:
+        "0xFA5D9694D9f8fa47b8A6c15Df4510b76cb844e2c" as const,
+      launchBlockNumber: "25639700",
+    };
+    const similarlyNamedPublicLaunch = {
+      ...tokens[1],
+      id: "public-canary-name",
+      name: "Community Canary",
+      launchBlockNumber: "25639701",
+    };
+    const model: ExploreReadModel = {
+      status: "ready",
+      tokens: [canonicalCanary, similarlyNamedPublicLaunch],
+      snapshot: {
+        chainId: 1,
+        blockNumber: "25639720",
+        blockHash: `0x${"55".repeat(32)}`,
+        confirmations: 12,
+      },
+      creatorClaims: [],
+      launcherFeesAccruedWei: "0",
+      launcherFeesAccruedEth: "0",
+    };
+
+    expect(visibleExploreTokens(model).map(({ id }) => id)).toEqual([
+      "public-canary-name",
     ]);
   });
 });

--- a/tests/onchain-query.test.ts
+++ b/tests/onchain-query.test.ts
@@ -162,7 +162,7 @@ describe("Explore query", () => {
   });
 
   it("supports the public sort aliases and bounded pagination", () => {
-    expect(parseExploreSort(null)).toBe("market-cap");
+    expect(parseExploreSort(null)).toBe("newest");
     expect(parseExploreSort("newest")).toBe("newest");
     expect(parseExploreSort("highest-market-cap")).toBe("market-cap");
     expect(parseExploreSort("lowest-market-cap")).toBe("market-cap-asc");

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   readAlchemyExploreModel: vi.fn(),
   readBitqueryMarketChartV1: vi.fn(),
   readBitqueryTokenMarketDataV1: vi.fn(),
+  hydrateMissingCanonicalTokenSupplyV1: vi.fn(),
   readDurableExploreModel: vi.fn(),
   readProductionCustomExploreDirectoryV1: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
@@ -29,6 +30,11 @@ vi.mock("../lib/alchemy/explore.server", () => ({
 vi.mock("../lib/market-data/bitquery.server", () => ({
   readBitqueryMarketChartV1: mocks.readBitqueryMarketChartV1,
   readBitqueryTokenMarketDataV1: mocks.readBitqueryTokenMarketDataV1,
+}));
+
+vi.mock("../lib/market-data/canonical-token-supply.server", () => ({
+  hydrateMissingCanonicalTokenSupplyV1:
+    mocks.hydrateMissingCanonicalTokenSupplyV1,
 }));
 
 vi.mock("../lib/onchain/chart", () => ({
@@ -58,6 +64,8 @@ const token = {
   hookAddress: "0x2222222222222222222222222222222222222222",
   poolId: `0x${"33".repeat(32)}`,
   launchedAt: "2026-07-29T00:00:00.000Z",
+  totalSupplyRaw: "1000000000000000000000000",
+  tokenDecimals: 18,
   totalSwapFeeBps: 100,
   liquidityPath: "meme",
 } as const;
@@ -103,6 +111,15 @@ function tokenMarketData(
         time: "2026-08-11T14:02:00.000Z",
         tokenSide: "buy",
         priceUsdWad: "2000000000000000000",
+        priceUsdAsOfTime: "2026-08-11T14:02:00.000Z",
+        priceUsdSource: "bitquery-token-price-index-v1",
+        rawPriceUsdWad: "2000000000000000000",
+      },
+      liquidity: {
+        asOfTime: "2026-08-11T14:02:00.000Z",
+        asOfBlock: "25740002",
+        valueUsdWad: "20000000000000000000000",
+        freshness: "current",
       },
       valuation: {
         status: "available",
@@ -192,6 +209,9 @@ describe("token chart Bitquery API", () => {
       new Map([[token.tokenAddress, tokenMarketData()]]),
     );
     mocks.readBitqueryMarketChartV1.mockResolvedValue(chart());
+    mocks.hydrateMissingCanonicalTokenSupplyV1.mockImplementation(
+      async (entries) => entries,
+    );
   });
 
   it("forwards the exact v4 identity and selected range to Bitquery", async () => {
@@ -206,7 +226,12 @@ describe("token chart Bitquery API", () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledWith(
-      expect.objectContaining({ identity, range: "1h", signal: expect.any(AbortSignal) }),
+      expect.objectContaining({
+        identity,
+        range: "1h",
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+        signal: expect.any(AbortSignal),
+      }),
     );
     expect(body).toMatchObject({
       schemaVersion: "programmable.market-chart.v1",
@@ -225,6 +250,65 @@ describe("token chart Bitquery API", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
+  });
+
+  it("starts a single-pool chart without waiting for market enrichment", async () => {
+    let resolveMarket: ((value: ReadonlyMap<string, TokenMarketDataV1>) => void)
+      | undefined;
+    mocks.readBitqueryTokenMarketDataV1.mockReturnValue(new Promise((resolve) => {
+      resolveMarket = resolve;
+    }));
+    mocks.readBitqueryMarketChartV1.mockResolvedValue(chart({
+      valuation: {
+        status: "available",
+        metric: "fdv",
+        supplyBasis: "total",
+        valueUsdWad: "999",
+        fdvUsdWad: "999",
+        totalSupply: "1",
+        asOfTime: "2026-08-11T14:02:00.000Z",
+        freshness: "current",
+      },
+    }));
+
+    const responsePromise = GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+    ));
+    await vi.waitFor(() => {
+      expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledTimes(1);
+    });
+    expect(resolveMarket).toBeTypeOf("function");
+    resolveMarket?.(new Map([[token.tokenAddress, tokenMarketData()]]));
+    const response = await responsePromise;
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.valuation).toMatchObject({
+      status: "available",
+      fdvUsdWad: "2000000000000000000000000",
+    });
+    expect(body.fdvUsdWad).toBe("2000000000000000000000000");
+  });
+
+  it("starts a single-pool chart without waiting for supply hydration", async () => {
+    let resolveSupply: ((value: readonly typeof token[]) => void) | undefined;
+    mocks.hydrateMissingCanonicalTokenSupplyV1.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSupply = resolve;
+      }),
+    );
+
+    const responsePromise = GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+    ));
+    await vi.waitFor(() => {
+      expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledTimes(1);
+      expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledTimes(1);
+    });
+    expect(resolveSupply).toBeTypeOf("function");
+    resolveSupply?.([token]);
+
+    expect((await responsePromise).status).toBe(200);
   });
 
   it("uses a verified durable identity when the primary identity source fails", async () => {
@@ -341,6 +425,40 @@ describe("token chart Bitquery API", () => {
       source: "bitquery",
       points: [],
       error: "Price history is temporarily unavailable",
+    });
+  });
+
+  it("does not relabel a chart cache fallback with a current market valuation", async () => {
+    mocks.readBitqueryMarketChartV1.mockResolvedValue(chart({
+      readStatus: "cache-fallback",
+      status: "partial",
+      valuation: {
+        status: "available",
+        metric: "fdv",
+        supplyBasis: "total",
+        valueUsdWad: "1500000000000000000000000",
+        fdvUsdWad: "1500000000000000000000000",
+        totalSupply: "1000000",
+        asOfTime: "2026-08-11T13:00:00.000Z",
+        freshness: "stale",
+      },
+    }));
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
+    ));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body).toMatchObject({
+      readStatus: "cache-fallback",
+      status: "partial",
+      valuation: {
+        fdvUsdWad: "1500000000000000000000000",
+        freshness: "stale",
+      },
+      fdvUsdWad: "1500000000000000000000000",
     });
   });
 

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -252,6 +252,28 @@ describe("token chart Bitquery API", () => {
     );
   });
 
+  it("briefly reuses authoritative current one-point history", async () => {
+    mocks.readBitqueryMarketChartV1.mockResolvedValue(chart({
+      status: "insufficient-history",
+      points: [{
+        blockNumber: "25740002",
+        time: "2026-08-11T14:02:00.000Z",
+        priceUsd: "2",
+        tradeCount: 1,
+      }],
+      swapCount: 1,
+    }));
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token/chart?address=${token.tokenAddress}&range=1h`,
+    ));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
+    );
+  });
+
   it("starts a single-pool chart without waiting for market enrichment", async () => {
     let resolveMarket: ((value: ReadonlyMap<string, TokenMarketDataV1>) => void)
       | undefined;

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   getOnchainDeployment: vi.fn(),
   readDurableExploreModel: vi.fn(),
   readBitqueryTokenMarketDataV1: vi.fn(),
+  hydrateMissingCanonicalTokenSupplyV1: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
 }));
 
@@ -66,6 +67,11 @@ vi.mock("../lib/onchain/durable-model", () => ({
 
 vi.mock("../lib/market-data/bitquery.server", () => ({
   readBitqueryTokenMarketDataV1: mocks.readBitqueryTokenMarketDataV1,
+}));
+
+vi.mock("../lib/market-data/canonical-token-supply.server", () => ({
+  hydrateMissingCanonicalTokenSupplyV1:
+    mocks.hydrateMissingCanonicalTokenSupplyV1,
 }));
 
 import { GET } from "../app/api/explore/token/route";
@@ -189,6 +195,9 @@ describe("token detail Bitquery market read", () => {
       async (identities: readonly MarketDataIdentityV1[]) =>
         bitqueryMarketData(identities),
     );
+    mocks.hydrateMissingCanonicalTokenSupplyV1.mockImplementation(
+      async (entries: readonly unknown[]) => [...entries],
+    );
   });
 
   it("reads Bitquery market data only for the canonical token PoolId", async () => {
@@ -291,6 +300,42 @@ describe("token detail Bitquery market read", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, s-maxage=2, stale-while-revalidate=5",
     );
+  });
+
+  it("starts the independent market read while supply hydration is pending", async () => {
+    const canonical = token(TOKEN_ADDRESS);
+    mocks.readAlchemyExploreModel.mockResolvedValue({
+      status: "ready",
+      tokens: [canonical],
+      snapshot,
+      launchDiscoverySnapshot,
+      creatorClaims: [],
+      launcherFeesAccruedWei: "0",
+      launcherFeesAccruedEth: "0",
+    } satisfies ExploreReadModel);
+    let releaseHydration: ((entries: readonly LauncherToken[]) => void)
+      | undefined;
+    mocks.hydrateMissingCanonicalTokenSupplyV1.mockReturnValue(
+      new Promise((resolve) => {
+        releaseHydration = resolve;
+      }),
+    );
+
+    const responseRead = GET(
+      new NextRequest(
+        `http://localhost/api/explore/token?address=${TOKEN_ADDRESS}`,
+      ),
+    );
+    try {
+      await vi.waitFor(() => {
+        expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      releaseHydration?.([canonical]);
+    }
+
+    const response = await responseRead;
+    expect(response.status).toBe(200);
   });
 
   it("reports detail FDV at the verified Bitquery time, not the stale launch snapshot", async () => {

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -24,6 +24,17 @@ describe("token detail layout", () => {
     expect(chartSource).not.toContain(': "Onchain"');
   });
 
+  it("preloads the initial chart once per token instead of on every detail refresh", () => {
+    const viewSource = detailSource.slice(
+      detailSource.indexOf("export function TokenDetailView"),
+    );
+
+    expect(viewSource.match(/preloadTokenChart/g)).toHaveLength(1);
+    expect(viewSource).toMatch(
+      /void preloadTokenChart\(normalizedAddress, "1d"\);\s*\}, \[normalizedAddress, preview\]\);/,
+    );
+  });
+
   it("announces the exact inspected chart point without duplicating the visual tooltip", () => {
     const activeValueIdIndex = chartSource.indexOf("id={activeValueId}");
     const liveRegion = chartSource.slice(

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -139,8 +139,13 @@ describe("token detail layout", () => {
   });
 
   it("uses only typed chart FDV while labeling total-supply value as FDV", () => {
-    expect(detailSource).toContain(': "FDV",');
+    expect(detailSource).toContain(
+      'const currentLabel = isMarketCap ? "Market cap" : "FDV";',
+    );
     expect(detailSource).toContain('valuation.metric === "market-cap"');
+    expect(detailSource).toContain(
+      'valuation.supplyBasis === "circulating"',
+    );
     expect(detailSource).not.toContain("fdvEthWei={");
     expect(detailSource).not.toContain("fdvUsdWad={");
     expect(chartSource).not.toContain("payload.marketCap");

--- a/tests/token-detail-view.test.ts
+++ b/tests/token-detail-view.test.ts
@@ -6,6 +6,7 @@ import {
   buildTokenDetailMetrics,
   formatPreparedMinimum,
   formatStockPairedGrossVolume,
+  getValuationMetricLabel,
   parseDetailPayload,
 } from "../components/token-detail-view";
 import type { PreparedTokenTrade } from "../components/token-trade";
@@ -48,9 +49,44 @@ const canonicalToken = {
 } satisfies CanonicalTokenExploreEntry;
 
 describe("token detail metrics", () => {
+  it("reserves market cap for circulating supply and qualifies non-current values", () => {
+    expect(getValuationMetricLabel({
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      currency: "usd",
+      valueWad: "1",
+      freshness: "current",
+    })).toBe("FDV");
+    expect(getValuationMetricLabel({
+      status: "available",
+      metric: "market-cap",
+      supplyBasis: "circulating",
+      currency: "usd",
+      valueWad: "1",
+      freshness: "current",
+    })).toBe("Market cap");
+    expect(getValuationMetricLabel({
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      currency: "usd",
+      valueWad: "1",
+      freshness: "stale",
+    })).toBe("Last verified FDV");
+    expect(getValuationMetricLabel({
+      status: "available",
+      metric: "market-cap",
+      supplyBasis: "circulating",
+      currency: "usd",
+      valueWad: "1",
+      freshness: "unknown",
+    })).toBe("Unverified market cap");
+  });
+
   it("ignores legacy market volume without Bitquery provenance", () => {
     expect(buildTokenDetailMetrics(token)).toEqual([
-      { label: "FDV", value: "$168.56K" },
+      { label: "Unverified FDV", value: "$168.56K" },
       { label: "Category", value: "Classic" },
       { label: "Swap fee", value: "1%" },
     ]);
@@ -86,14 +122,14 @@ describe("token detail metrics", () => {
 
   it("uses the chart-point FDV while the chart is inspected", () => {
     expect(buildTokenDetailMetrics(token, "$212.4K")[0]).toEqual({
-      label: "FDV",
+      label: "Unverified FDV",
       value: "$212.4K",
     });
   });
 
   it("shows unavailable for a historical point without evidenced USD or ETH FDV", () => {
     expect(buildTokenDetailMetrics(token, "Unavailable")[0]).toEqual({
-      label: "FDV",
+      label: "Unverified FDV",
       value: "Unavailable",
     });
   });
@@ -125,7 +161,7 @@ describe("token detail metrics", () => {
         indexedMarketCapUsdWad: parseEther("43750").toString(),
       })[0],
     ).toEqual({
-      label: "FDV",
+      label: "Unverified FDV",
       value: "$43.75K",
     });
   });
@@ -139,7 +175,7 @@ describe("token detail metrics", () => {
     });
 
     expect(buildTokenDetailMetrics(token, null, volume)).toEqual([
-      { label: "FDV", value: "$168.56K" },
+      { label: "Unverified FDV", value: "$168.56K" },
       { label: "Category", value: "Classic" },
       { label: "Volume 1H", value: "$43.8K" },
       { label: "Swap fee", value: "1%" },
@@ -195,7 +231,7 @@ describe("token detail metrics", () => {
     } satisfies LauncherToken;
 
     expect(buildTokenDetailMetrics(enriched)).toEqual([
-      { label: "FDV", value: "$168.56K" },
+      { label: "Unverified FDV", value: "$168.56K" },
       { label: "Category", value: "Classic" },
       { label: "Swap fee", value: "1%" },
     ]);


### PR DESCRIPTION
## Outcome

Makes the public Explore and token market-data paths materially faster and more accurate without inventing values or weakening provider provenance.

## Changes

- pre-paginates newest/oldest Explore results before supply and Bitquery enrichment, reducing the default page from 342 identities to 9 while preserving global FDV ranking
- runs independent supply, market and chart reads concurrently and removes a redundant Bitquery valuation query from single-pool charts
- adds a two-second in-memory reuse window only for populated, canonically valued charts
- streams the initial Explore payload from the same deployment and suppresses the hydration duplicate request
- briefly edge-caches honest stale/partial Explore responses while keeping source failures and stale launch identity `no-store`
- removes six exact release-canary token identities from public discovery while preserving direct address lookup
- labels market cap only when circulating supply is evidenced; total-supply valuation remains FDV and stale/unknown values are qualified

## Safety

- no contracts, onchain state, dependencies, package lock, workflow, database schema or environment configuration changes
- no name/symbol/creator/liquidity heuristics for token visibility
- no fabricated chart points, prices, volume or market caps
- Bitquery/provider fallback remains stale and `no-store`

## Validation

- targeted ESLint passed
- TypeScript passed
- 138 focused tests passed
- Next.js production build passed
- `git diff --check` passed
