### PR TITLE
feat: sync immutable Hookbuilder v0.5.1

### DIFF
--- a/docs/builder/AGENT_SKILL.md
+++ b/docs/builder/AGENT_SKILL.md
@@ -53,9 +53,10 @@ they are not silently promoted to Programmable-tested deployments.
 
 ## Install the Builder
 
-The canonical package is synchronized with the Hookbuilder `0.5.1` development candidate at commit
-`509060301ce9bb1b5e318b28aeeeeb846c020f68`, based on public `main`. The older
-`programmable-v4-builder-v0.2.1` package is a historical beta contract and must not be selected for new model work.
+The canonical package is synchronized with the immutable public Hookbuilder `v0.5.1` Node 24 release. Annotated tag
+object `7f0beec2afe00facd25ba65cecbb18f285f15b91` resolves to commit
+`547482adf6ed0ed19e9cd4d0e884abd70e143229`. The older `programmable-v4-builder-v0.2.1` package remains a historical
+beta contract and must not be selected for new model work.
 See [HOOKBUILDER_SYNC.md](HOOKBUILDER_SYNC.md) for the exact source tree and generated-mirror digest.
 
 The canonical package is
@@ -64,52 +65,42 @@ Skills layout and keeps portable frontmatter to `name`, `description` and the SP
 license text remains in `LICENSE.txt`. Host-specific UI metadata is optional and does not control the skill's security
 policy.
 
-For an interactive install, use the repository-only command:
+Install the immutable public release for Codex:
 
 ```bash
 gh skill install 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main \
+  skills/programmable-v4-hook-builder \
   --agent codex \
   --scope user \
-  --force
+  --pin v0.5.1
 ```
 
-To preselect the Builder while keeping the agent setup interactive:
-
-```bash
-gh skill install 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main \
-  --agent codex \
-  --scope user \
-  --force
-```
-
-Without a version argument, `gh skill` selects the latest tagged release. For newest-model work, explicitly select
-the public `main` revision below. Use Hookbuilder `v0.4.3` only for stable historical reproduction.
+Without a version argument, `gh skill` selects the latest tagged release. Keep `--pin v0.5.1` when exact, repeatable
+installation matters; older tags are historical releases only.
 
 Preview the newest Builder model:
 
 ```bash
 gh skill preview 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main
+  programmable-v4-hook-builder@v0.5.1
 ```
 
-Then install that same development revision for your agent. User scope is the beginner default because it keeps the
+Then install that same immutable release for your agent. User scope is the beginner default because it keeps the
 project repository clean:
 
 ```bash
 gh skill install 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main \
+  skills/programmable-v4-hook-builder \
   --agent codex \
   --scope user \
-  --force
+  --pin v0.5.1
 ```
 
 Replace `codex` with `claude-code` or `github-copilot` when appropriate. Use `--scope project` only when the project
 intentionally tracks the installed `.agents/` package or excludes that complete generated directory from Git. An
 untracked project-scoped installation makes the worktree dirty and correctly blocks `prepare-pr`.
 
-Builder `v0.2.1` and earlier remain historical beta contracts. New work uses Hookbuilder `0.5.1` development `main`;
+Builder `v0.2.1` and earlier remain historical beta contracts. New work uses the immutable Hookbuilder `v0.5.1` release;
 the legacy public-v2 intake remains readable for migration, but it is not the newest model path.
 
 From the installed skill directory, run `node scripts/verify-skill.mjs --installed`; it accepts the bounded source

--- a/docs/builder/HOOKBUILDER_SYNC.md
+++ b/docs/builder/HOOKBUILDER_SYNC.md
@@ -1,17 +1,22 @@
 # Hookbuilder synchronization
 
-The canonical `programmable-v4-hook-builder` package in this repository is synchronized from the public
-`0xprogrammable/hookbuilder` development source, not from the historical Builder beta tag.
+The canonical `programmable-v4-hook-builder` package in this repository is synchronized from the exact immutable
+`0xprogrammable/hookbuilder` `v0.5.1` Node 24 release, not from the historical Builder beta tag.
 
 | Binding | Value |
 | --- | --- |
 | source repository | `https://github.com/0xprogrammable/hookbuilder` |
-| source ref | `main` |
-| source commit | `509060301ce9bb1b5e318b28aeeeeb846c020f68` |
-| source commit tree | `f49b32d6ff60e7e2b1457e5bd7e32ee3c81710a8` |
-| package version | `0.5.1` (development scope) |
+| binding status | `IMMUTABLE_PUBLIC_RELEASE_VERIFIED` |
+| source ref | `v0.5.1` |
+| annotated tag object | `7f0beec2afe00facd25ba65cecbb18f285f15b91` |
+| source commit | `547482adf6ed0ed19e9cd4d0e884abd70e143229` |
+| source commit tree | `ed030750bb745e7915070985f0d8643c29760c25` |
+| source skill tree | `b7a0eeec627b2fd2dfe24fcadd35befcd42b8cec` |
+| source plugin payload digest | `3dcea707506fc22f8bac79d9948e185ed90b3635d03c8d56f97158dca4bd1152` |
+| package version | `0.5.1` |
+| public release | `latest`, `immutable`, six assets |
 | canonical skill files | `640` |
-| generated skill tree digest | `0a9e5508fdb77e16527e0dd85d58c5d34569c573d0bc6a0dc47b024462471913` |
+| generated skill tree digest | `9bff40b2825c672873e7a98699b1d7d117cc6186de50db246f24c93b56dea8bb` |
 
 The source skill is authoritative for the newest model. The repository-root Codex and Claude manifests and the
 `plugins/marketplace/plugins/programmable` distribution are generated from the same metadata and
@@ -26,5 +31,5 @@ mirror of the canonical skill. The old
 `programmable-v4-builder-v0.2.1` contract is retained only where the trusted public-beta verifier reads historical
 application records; it is not a second active Builder implementation.
 
-Source `main` is not a stable release and does not prove acceptance, review, deployment, routing, or launch. Rebind
-this manifest, the generated plugin hashes, and all release evidence whenever the source commit changes.
+The immutable public release establishes exact package and artifact identity only. It does not prove model behavior,
+acceptance, independent review, deployment, routing, Registry activation, or launch.

--- a/docs/builder/PUBLIC_GITHUB_PR_BETA.md
+++ b/docs/builder/PUBLIC_GITHUB_PR_BETA.md
@@ -68,8 +68,8 @@ for the permissionless path.
 
 ### Mandatory Programmable fee
 
-The legacy beta application path uses Builder `v0.2.1` records. New model work uses Hookbuilder `0.5.1` development
-`main` and its per-side Fee V1.1 contract; legacy v2 applications remain readable only for migration and historical
+The legacy beta application path uses Builder `v0.2.1` records. New model work uses the immutable Hookbuilder `v0.5.1`
+release and its per-side Fee V1.1 contract; legacy v2 applications remain readable only for migration and historical
 review.
 
 - `effective side rate = max(builder-selected side rate, 10 bps)`;

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/SKILL.md
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/SKILL.md
@@ -102,4 +102,4 @@ node "$SKILL_ROOT/scripts/cli.mjs" project require-output --repository-root "$NE
 
 ## Runtime
 
-Require Node.js 22+. Keep compilation, validation and evidence offline. `doctor` proves local capability only. Require host-native receipts; rerun evidence after bound-input changes.
+Require Node.js 24+. Keep compilation, validation and evidence offline. `doctor` proves local capability only. Require host-native receipts; rerun evidence after bound-input changes.

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/references/contract-registry-v1.json
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/references/contract-registry-v1.json
@@ -632,7 +632,7 @@
         "mode": "direct",
         "moduleByteLength": 1070,
         "moduleSha256": "sha256:c4561640a691f3cf383ad5b5dd04d58bd9a809e93a3a462e36e8cfe564f5d6c4",
-        "closureSha256": "sha256:2ea7643e70cbad3dec39bbfab43abd8e11b9090a0eadc0f15f00e5d0e79fa941"
+        "closureSha256": "sha256:c5fe74def28877c8345184aa69051d1dd0c01547c6f00dea67f34f64570f8ed2"
       }
     },
     {
@@ -1799,7 +1799,7 @@
       "profile": "static-local-esm-import-closure-v1",
       "rootModulePath": "scripts/github-application-core.mjs",
       "moduleCount": 72,
-      "totalByteLength": 886574,
+      "totalByteLength": 886563,
       "modules": [
         {
           "path": "scripts/builder-template-contract.mjs",
@@ -1818,8 +1818,8 @@
         },
         {
           "path": "scripts/github-application-constants.mjs",
-          "byteLength": 3373,
-          "sha256": "sha256:3850eb323442c9518fcc68c0d8cc155df6c6db560ba174fb92ce691a7cc1dd2a",
+          "byteLength": 3362,
+          "sha256": "sha256:c8b399ca9a578fa2773986a8ebcd4bfad7755ee5247db412ddb5d939b642c453",
           "localImports": [
             "scripts/registry-intake-contract.mjs"
           ]
@@ -2494,7 +2494,7 @@
           ]
         }
       ],
-      "closureSha256": "sha256:2ea7643e70cbad3dec39bbfab43abd8e11b9090a0eadc0f15f00e5d0e79fa941"
+      "closureSha256": "sha256:c5fe74def28877c8345184aa69051d1dd0c01547c6f00dea67f34f64570f8ed2"
     },
     {
       "profile": "static-local-esm-import-closure-v1",
@@ -10596,8 +10596,8 @@
     "validatorClosureModuleBindingCount": 1010,
     "validatorClosureDistinctModuleCount": 171,
     "schemaPathsSha256": "sha256:610762ddd56550d2852596417842b753d32d5ed509433439435fd492aa3110ab",
-    "validatorBindingsSha256": "sha256:16629c67eb119305456fbb266b40f26c73e36961fd340f6fa6b38820e5e41861",
-    "validatorClosuresSha256": "sha256:fca0133e045871db99dce696e3e58fab95ae86f2e53044a8f49b7345191d6156"
+    "validatorBindingsSha256": "sha256:6e578df1ac7fdf969025fe44d140b7d1e64431f469bbe0b6f8fa2b6aed1e0612",
+    "validatorClosuresSha256": "sha256:0cb2eeb08104ac55b424ef93a182a6409f0b6f2d052020ff2717f6a031cba0fb"
   },
-  "registrySha256": "sha256:31a406c8071e045a2550b8286ea664bfd845c2f3b8cfc2da99f35e16387c20f7"
+  "registrySha256": "sha256:0a711a61961990eb0c215819ddc6ddc970ea148c9eea5c2f7aa1bf7c91deb3b8"
 }

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/references/github-application-journey.md
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/references/github-application-journey.md
@@ -168,7 +168,7 @@ The projection is deliberately small:
 | GitHub observation | Client status |
 | --- | --- |
 | Open draft before the trusted required checks start | `submitted` |
-| `public-intake`, `Node 22`, or `Node 24` is missing, skipped, queued, requested, waiting, pending, or in progress | `checks-running` |
+| `public-intake` or `Node 24` is missing, skipped, queued, requested, waiting, pending, or in progress | `checks-running` |
 | Latest reviewer state requests changes, or one trusted required check failed | `changes-requested` |
 | Required checks pass and the `builder:architecture-review` label is present | `architecture-review` |
 | Required checks pass and the `builder:review-in-progress` label is present | `review-in-progress` |

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/references/upgrades-and-release.md
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/references/upgrades-and-release.md
@@ -57,9 +57,9 @@ Report the installed version and exact standards:
 node "$SKILL_ROOT/scripts/builder-lifecycle.mjs" version
 ```
 
-This default reports the constants bundled with the checked-out Builder. The v0.5.1 candidate reports
-`publicationState: unpublished-candidate` and `publicationStateVerified: false`; its `stable` channel is the intended
-update channel, not a publication claim. To inspect an explicit pinned installed-state record instead, add
+This default reports the constants bundled with the checked-out Builder. The v0.5.1 package reports
+`publicationState: release-package` and `publicationStateVerified: false`; the bundled constant identifies release
+package bytes but does not independently resolve or authenticate a public tag. To inspect an explicit pinned installed-state record instead, add
 `--state path/to/installed-state.json`; the JSON output marks that source as an installed-state override and keeps
 publication state `not-verified`. Neither path establishes update trust or public release state.
 
@@ -217,8 +217,8 @@ another release byte becomes public earlier, W5 must use that earliest independe
 of the later GitHub timestamp. The planner cannot query GitHub or discover that earlier exposure; its `releasedAt`
 remains a caller declaration.
 
-The candidate's closed `plannedRelease` object binds the intended identity. For the packaged private 0.5.1 candidate it
-declares:
+The example candidate's closed `plannedRelease` object binds the intended identity. For the historical packaged private
+0.5.1 planning example it declares:
 
 - Builder `0.4.0 -> 0.5.1` with semantic classification `minor`;
 - submission standard `1.5.0 -> 1.6.0`;

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/builder-lifecycle-shared.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/builder-lifecycle-shared.mjs
@@ -3,7 +3,7 @@ import { canonicalJson } from "./submission-core.mjs";
 
 export const BUILDER_LIFECYCLE_SCHEMA_VERSION = "1.0.0";
 export const BUNDLED_BUILDER_VERSION = "0.5.1";
-export const BUNDLED_BUILDER_PUBLICATION_STATE = "unpublished-candidate";
+export const BUNDLED_BUILDER_PUBLICATION_STATE = "release-package";
 export const NORMAL_RELEASE_WINDOW_MS = 24 * 60 * 60 * 1_000;
 
 export const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/u;

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/cli.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/cli.mjs
@@ -113,7 +113,14 @@ if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
   process.exit(0);
 }
 const command = argv[0];
-if (command === "start" && (argv.slice(1).includes("--help") || argv.slice(1).includes("-h"))) {
+const nodeMajor = Number.parseInt(process.versions.node.split(".", 1)[0], 10);
+const nodeRuntimeSupported = Number.isInteger(nodeMajor) && nodeMajor >= 24;
+if (command !== "doctor" && !nodeRuntimeSupported) {
+  process.exitCode = emitFailure(command, new CliFailure(
+    "NODE_24_OR_NEWER_REQUIRED",
+    "Programmable v4 Builder requires Node.js 24 or newer"
+  ));
+} else if (command === "start" && (argv.slice(1).includes("--help") || argv.slice(1).includes("-h"))) {
   process.stdout.write(`${startHelp()}\n`);
 } else if (command === "launch-bundle-v2") {
   const launchArgs = argv.slice(1);

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/doctor.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/doctor.mjs
@@ -52,7 +52,7 @@ const checks = tools.map(([name, toolArgs, deterministic, publicBeta]) => {
   };
 });
 const nodeMajor = Number.parseInt(process.versions.node.split(".", 1)[0], 10);
-const nodeSupported = Number.isInteger(nodeMajor) && nodeMajor >= 22;
+const nodeSupported = Number.isInteger(nodeMajor) && nodeMajor >= 24;
 const applicationV3Platforms = ["darwin", "linux"];
 const applicationV3PlatformSupported = applicationV3Platforms.includes(process.platform);
 const exactObjectGit = inspectExactObjectGitTooling();
@@ -101,7 +101,7 @@ const gitWorktreeStatus = repositoryRoot === null
 const gitWorktreeAvailable = gitWorktreeStatus === "available";
 const githubCli = checks.find(({ name }) => name === "gh");
 const publicBetaBlockers = [
-  ...(nodeSupported ? [] : ["NODE_20_OR_NEWER_REQUIRED"]),
+  ...(nodeSupported ? [] : ["NODE_24_OR_NEWER_REQUIRED"]),
   ...(applicationV3PlatformSupported ? [] : ["APPLICATION_V3_PLATFORM_UNSUPPORTED"]),
   ...(exactObjectGit.status === "ready" ? [] : ["EXACT_OBJECT_GIT_TOOLING_REQUIRED"]),
   ...(githubCli?.available === true ? [] : ["GITHUB_CLI_REQUIRED"]),
@@ -144,7 +144,7 @@ const report = {
   },
   runtimeCompatibility: {
     node: {
-      minimumMajor: 22,
+      minimumMajor: 24,
       currentMajor: nodeMajor,
       supported: nodeSupported
     },
@@ -195,7 +195,7 @@ const report = {
 if (asJson) console.log(JSON.stringify(report, null, 2));
 else {
   for (const check of checks) console.log(`${check.available ? "ok" : "missing"} ${check.name}${check.version ? `: ${check.version}` : ""}`);
-  console.log(`${nodeSupported ? "ok" : "unsupported"} Node.js major version ${nodeMajor}; deterministic preflight requires Node.js 22 or newer`);
+  console.log(`${nodeSupported ? "ok" : "unsupported"} Node.js major version ${nodeMajor}; deterministic preflight requires Node.js 24 or newer`);
   console.log(`${report.readyForRepositoryWork ? "ok" : "unavailable"} repository worktree`);
   if (!report.gitWorktreeChecks.available) console.log(`unavailable Git-only checks: ${report.gitWorktreeChecks.reason}`);
   console.log(`${report.cleanWorktree === true ? "ok" : report.cleanWorktree === false ? "dirty" : "unknown"} git worktree`);

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/github-application-constants.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/github-application-constants.mjs
@@ -16,7 +16,7 @@ export const PROGRAMMABLE_GITHUB_ACTIONS_APP_ID = "15368";
 export const PROGRAMMABLE_GITHUB_ACTIONS_APP_SLUG = "github-actions";
 export const PROGRAMMABLE_MAINTAINER_GITHUB_USER_ID = "309941960";
 export const PROGRAMMABLE_MAINTAINER_GITHUB_LOGIN = "0xprogrammable";
-export const REQUIRED_APPLICATION_CHECKS = Object.freeze(["public-intake", "Node 22", "Node 24"]);
+export const REQUIRED_APPLICATION_CHECKS = Object.freeze(["public-intake", "Node 24"]);
 export const CENTRAL_APPLICATION_FILES = Object.freeze([
   "application.json",
   "PROPOSAL.md",

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/builder-lifecycle.test.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/builder-lifecycle.test.mjs
@@ -49,7 +49,7 @@ test("bundled version reports standalone code constants without requiring state"
   const result = bundledVersionStatus();
   assert.equal(result.installed.releaseVersion, "0.5.1");
   assert.equal(result.installed.channel, "stable");
-  assert.equal(result.installed.publicationState, "unpublished-candidate");
+  assert.equal(result.installed.publicationState, "release-package");
   assert.equal(result.installed.standards.skill, "0.5.1");
   assert.equal(result.installed.standards.engine, "0.5.1");
   assert.equal(result.installed.standards.policy, "1.1.0");
@@ -851,7 +851,7 @@ test("standalone CLI reports bundled version without an installed-state file", (
   assert.equal(result.status, 0, result.stdout || result.stderr);
   const parsed = JSON.parse(result.stdout);
   assert.equal(parsed.result.installed.releaseVersion, "0.5.1");
-  assert.equal(parsed.result.installed.publicationState, "unpublished-candidate");
+  assert.equal(parsed.result.installed.publicationState, "release-package");
   assert.equal(parsed.result.versionSource, "bundled-code-constants");
   assert.equal(parsed.result.installedStateOverrideUsed, false);
 });

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/cli-entry.test.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/cli-entry.test.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { parseCli } from "../cli-args.mjs";
 import { materializeExample } from "../example-materializer-core.mjs";
 
@@ -58,6 +58,37 @@ test("doctor delegates to the existing readiness command and emits JSON", () => 
     assert.ok(output.result.publicBetaBlockers.includes("EXTERNAL_ACCEPTANCE_NOT_CHECKED"));
     assert.equal(output.result.publicBetaGit.publicReachability.status, "notChecked");
     assert.equal(output.result.publicBetaGit.readyForPreparePrLocal, false);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("CLI blocks every non-doctor command below Node 24 without blocking doctor dispatch", () => {
+  const bootstrap = (args) => [
+    'Object.defineProperty(process.versions, "node", { value: "22.23.1" });',
+    `process.argv = [process.execPath, ${JSON.stringify(cli)}, ...${JSON.stringify(args)}];`,
+    `await import(${JSON.stringify(pathToFileURL(cli).href)});`
+  ].join("\n");
+  const blocked = childProcess.spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", bootstrap(["context", "--help"])],
+    { cwd: skillRoot, encoding: "utf8", shell: false }
+  );
+  assert.equal(blocked.status, 2, blocked.stdout || blocked.stderr);
+  assert.equal(blocked.stderr, "");
+  assert.equal(JSON.parse(blocked.stdout).error.code, "NODE_24_OR_NEWER_REQUIRED");
+
+  const fixture = createRepository();
+  try {
+    const doctor = childProcess.spawnSync(
+      process.execPath,
+      ["--input-type=module", "--eval", bootstrap(["doctor", "--repository-root", fixture.repository])],
+      { cwd: skillRoot, encoding: "utf8", shell: false }
+    );
+    assert.equal(doctor.status, 0, doctor.stdout || doctor.stderr);
+    const report = JSON.parse(doctor.stdout);
+    assert.equal(report.command, "doctor");
+    assert.equal(report.ok, true);
   } finally {
     fixture.cleanup();
   }

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/cli.test.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/cli.test.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const skillRoot = path.resolve(testDirectory, "..", "..");
@@ -94,7 +94,7 @@ test("host-neutral version reports the bundled standalone release without state"
   assert.equal(result.status, 0, result.stdout || result.stderr);
   const output = JSON.parse(result.stdout);
   assert.equal(output.result.installed.releaseVersion, "0.5.1");
-  assert.equal(output.result.installed.publicationState, "unpublished-candidate");
+  assert.equal(output.result.installed.publicationState, "release-package");
   assert.equal(output.result.versionSource, "bundled-code-constants");
   assert.equal(output.result.installedStateOverrideUsed, false);
 });
@@ -275,7 +275,7 @@ test("doctor distinguishes local generation from an actual Git worktree", () => 
     assert.equal(report.githubCli.requiredForPublicBetaApplication, true);
     assert.equal(report.githubCli.authenticationChecked, false);
     assert.equal(report.readyForGitHubApplicationClient, report.githubCli.available);
-    assert.equal(report.runtimeCompatibility.node.minimumMajor, 22);
+    assert.equal(report.runtimeCompatibility.node.minimumMajor, 24);
     assert.equal(report.runtimeCompatibility.node.supported, true);
     assert.deepEqual(report.runtimeCompatibility.applicationV3.supportedPlatforms, ["darwin", "linux"]);
     assert.equal(
@@ -305,6 +305,34 @@ test("doctor distinguishes local generation from an actual Git worktree", () => 
       report.publicBetaBlockers.includes("GITHUB_CLI_REQUIRED"),
       report.githubCli.available === false
     );
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("doctor reports the Node 24 blocker for an unsupported runtime", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "programmable-doctor-node-"));
+  const doctor = path.join(scriptsRoot, "doctor.mjs");
+  try {
+    const bootstrap = [
+      'Object.defineProperty(process.versions, "node", { value: "23.0.0" });',
+      `process.argv = [process.execPath, ${JSON.stringify(doctor)}, "--json", "--repository-root", ${JSON.stringify(directory)}];`,
+      `await import(${JSON.stringify(pathToFileURL(doctor).href)});`
+    ].join("\n");
+    const result = childProcess.spawnSync(
+      process.execPath,
+      ["--input-type=module", "--eval", bootstrap],
+      { cwd: directory, encoding: "utf8", shell: false }
+    );
+    assert.equal(result.status, 1, result.stderr);
+    const report = JSON.parse(result.stdout);
+    assert.deepEqual(report.runtimeCompatibility.node, {
+      minimumMajor: 24,
+      currentMajor: 23,
+      supported: false
+    });
+    assert.ok(report.publicBetaBlockers.includes("NODE_24_OR_NEWER_REQUIRED"));
+    assert.equal(report.publicBetaBlockers.some((blocker) => /^NODE_(?:20|22)_OR_NEWER_REQUIRED$/u.test(blocker)), false);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/github-application.test.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/github-application.test.mjs
@@ -1045,11 +1045,6 @@ test("status re-reads the PR and reports a different prepared package without ca
       detailsUrl: null
     },
     {
-      name: "Node 22",
-      state: "missing",
-      detailsUrl: null
-    },
-    {
       name: "Node 24",
       state: "missing",
       detailsUrl: null
@@ -1075,14 +1070,9 @@ test("status preserves the canonical trusted Registry check details link", async
       detailsUrl: "https://github.com/0xprogrammable/submit-launch/actions/runs/1001/job/801"
     },
     {
-      name: "Node 22",
-      state: "passing",
-      detailsUrl: "https://github.com/0xprogrammable/submit-launch/actions/runs/1001/job/802"
-    },
-    {
       name: "Node 24",
       state: "passing",
-      detailsUrl: "https://github.com/0xprogrammable/submit-launch/actions/runs/1001/job/803"
+      detailsUrl: "https://github.com/0xprogrammable/submit-launch/actions/runs/1001/job/802"
     }
   ]);
 });
@@ -2069,8 +2059,7 @@ function rawCheck({
 function rawRequiredChecks({ publicIntakeConclusion = "success", appId = "15368" } = {}) {
   return [
     rawCheck({ id: "801", name: "public-intake", conclusion: publicIntakeConclusion, appId }),
-    rawCheck({ id: "802", name: "Node 22", appId }),
-    rawCheck({ id: "803", name: "Node 24", appId })
+    rawCheck({ id: "802", name: "Node 24", appId })
   ];
 }
 

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/verify-skill-static.test.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/verify-skill-static.test.mjs
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   createDeterministicTestBatches,
   runDeterministicTestBatches
@@ -989,6 +989,22 @@ test("installed verifier accepts current pinned gh skill GitHub provenance", () 
   } finally {
     fs.rmSync(fixture.fixtureRoot, { recursive: true, force: true });
   }
+});
+
+test("portable verifier rejects runtimes below Node 24 before scanning package bytes", () => {
+  const bootstrap = [
+    'Object.defineProperty(process.versions, "node", { value: "22.23.1" });',
+    `process.argv = [process.execPath, ${JSON.stringify(verifier)}, "--installed"];`,
+    `await import(${JSON.stringify(pathToFileURL(verifier).href)});`
+  ].join("\n");
+  const result = childProcess.spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", bootstrap],
+    { cwd: skillRoot, encoding: "utf8", shell: false }
+  );
+  assert.equal(result.status, 1, result.stdout || result.stderr);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /NODE_24_OR_NEWER_REQUIRED/u);
 });
 
 test("installed metadata parser accepts exact unpinned GitHub and quoted local profiles", () => {

--- a/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
+++ b/plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
@@ -17,6 +17,11 @@ import { markdownHeadingAnchors, parseCanonicalYamlMapping, redactInstalledLocal
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const canonicalSkillRoot = path.resolve(scriptDirectory, "..");
+const nodeMajor = Number.parseInt(process.versions.node.split(".", 1)[0], 10);
+if (!Number.isInteger(nodeMajor) || nodeMajor < 24) {
+  console.error("verify-skill.mjs: NODE_24_OR_NEWER_REQUIRED");
+  process.exit(1);
+}
 const MAX_PORTABLE_FILES = 640;
 const MAX_PORTABLE_BYTES = 12_000_000;
 const MAX_PORTABLE_FILE_BYTES = 1_000_000;

--- a/plugins/marketplace/test/plugin-packaging.test.mjs
+++ b/plugins/marketplace/test/plugin-packaging.test.mjs
@@ -29,7 +29,7 @@ import {
 } from "../scripts/generate-plugin.mjs";
 
 const goldenHashes = {
-  skillTree: "0a9e5508fdb77e16527e0dd85d58c5d34569c573d0bc6a0dc47b024462471913",
+  skillTree: "9bff40b2825c672873e7a98699b1d7d117cc6186de50db246f24c93b56dea8bb",
   codexManifest: "9d6c0e147f61bc68f48d78c48f3363e03e59129272da3a5fe813abc87d0ca505",
   claudeManifest: "639e7b39b03d1ec17a3886a79e667768335a8cf392acea903a05fdf537ce2609",
   codexMarketplace: "f51e251087f6d26c75308aeff915485de9493b619c31b5a59baca072d725d0c0",

--- a/scripts/test/verify-public-hook-application-workflow.test.mjs
+++ b/scripts/test/verify-public-hook-application-workflow.test.mjs
@@ -7,6 +7,12 @@ const workflowPath = path.resolve(".github/workflows/verify-hook-builder.yml");
 const workflow = fs.readFileSync(workflowPath, "utf8");
 const normalWorkflow = fs.readFileSync(path.resolve(".github/workflows/verify.yml"), "utf8");
 const validatorCore = fs.readFileSync(path.resolve("scripts/verify-public-hook-application-core.mjs"), "utf8");
+const skillVerifier = fs.readFileSync(path.resolve(
+  "skills/programmable-v4-hook-builder/scripts/verify-skill.mjs"
+), "utf8");
+const skillVerifierExecution = fs.readFileSync(path.resolve(
+  "skills/programmable-v4-hook-builder/scripts/verify-skill-execution-core.mjs"
+), "utf8");
 const permissionBlock = workflow.slice(
   workflow.indexOf("permissions:"),
   workflow.indexOf("concurrency:")
@@ -254,6 +260,12 @@ test("maintained skill tests run once through the bounded canonical verifier", (
     );
     assert.doesNotMatch(job, /node --test skills\/programmable-v4-hook-builder\/scripts\/test\/\*\.test\.mjs/u);
   }
+  assert.match(skillVerifier, /validateScriptsAndTests/u);
+  assert.match(skillVerifierExecution, /const TEST_BATCH_COUNT = 2;/u);
+  assert.match(skillVerifierExecution, /const TEST_TIMEOUT_MS = 15 \* 60 \* 1000;/u);
+  assert.match(skillVerifierExecution, /const deadline = now\(\) \+ timeoutMs;/u);
+  assert.match(skillVerifierExecution, /args: \["--test", "--test-concurrency=2", \.\.\.batch\]/u);
+  assert.match(skillVerifierExecution, /shared 15-minute aggregate bound/u);
 });
 
 test("workflow bounds job lifetime and cancels superseded pull-request work", () => {

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,9 +4,10 @@ Programmable publishes one canonical Agent Skills package for designing and revi
 package follows the open [Agent Skills specification](https://agentskills.io/specification), so compatible agents can
 load the same instructions, references, templates, and validation tools without separate prompts for each product.
 
-The canonical package is synchronized with the Hookbuilder `0.5.1` development candidate at commit
-`509060301ce9bb1b5e318b28aeeeeb846c020f68`, based on public `main`. The stable Hookbuilder `v0.4.3` release remains
-available for historical reproduction; it is not the newest model.
+The canonical package is synchronized with the immutable public Hookbuilder `v0.5.1` Node 24 release. Annotated tag
+object `7f0beec2afe00facd25ba65cecbb18f285f15b91` resolves to commit
+`547482adf6ed0ed19e9cd4d0e884abd70e143229` and the exact skill tree recorded in
+[HOOKBUILDER_SYNC.md](../docs/builder/HOOKBUILDER_SYNC.md).
 
 ## Available skill
 
@@ -31,37 +32,26 @@ The exact source and mirror binding is recorded in [HOOKBUILDER_SYNC.md](../docs
 
 ## Quick install
 
-Install interactively with one command:
+Install the immutable public release for Codex with one command:
 
 ```bash
 gh skill install 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main \
+  skills/programmable-v4-hook-builder \
   --agent codex \
   --scope user \
-  --force
+  --pin v0.5.1
 ```
 
-To preselect the Builder while keeping the agent setup interactive:
+Without a version argument, `gh skill` selects the repository's latest tagged release. Keep `--pin v0.5.1` when exact,
+repeatable installation matters; older tags are historical releases only.
 
-```bash
-gh skill install 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main \
-  --agent codex \
-  --scope user \
-  --force
-```
+## Inspect and install the newest Builder model
 
-Without a version argument, `gh skill` selects the repository's latest tagged release. Explicitly select `main` for
-the newest model; use `v0.4.3` only when reproducing a stable historical release.
-
-## Install the newest Builder model
-
-Inspect the skill before installing it. `main` is the newest public development source and is intentionally distinct
-from the latest stable release.
+Inspect the exact immutable release before installing it:
 
 ```bash
 gh skill preview 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main
+  programmable-v4-hook-builder@v0.5.1
 ```
 
 Install the same revision for one supported host:
@@ -69,32 +59,32 @@ Install the same revision for one supported host:
 ```bash
 # Codex
 gh skill install 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main \
+  skills/programmable-v4-hook-builder \
   --agent codex \
   --scope user \
-  --force
+  --pin v0.5.1
 
 # Claude Code
 gh skill install 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main \
+  skills/programmable-v4-hook-builder \
   --agent claude-code \
   --scope user \
-  --force
+  --pin v0.5.1
 
 # GitHub Copilot
 gh skill install 0xprogrammable/hookbuilder \
-  skills/programmable-v4-hook-builder@main \
+  skills/programmable-v4-hook-builder \
   --agent github-copilot \
   --scope user \
-  --force
+  --pin v0.5.1
 ```
 
 The `gh skill` command chooses the host-specific destination. Its skill commands are currently a preview feature, and
 host behavior still depends on each agent's sandbox, tool permissions, and Agent Skills implementation. Installation
 does not grant wallet access, deployment authority, review approval, or permission to publish external changes.
 
-Builder `v0.2.1` and earlier remain historical beta contracts. New work uses Hookbuilder `0.5.1` development `main`,
-including the open-world compiler, Application V3 preparation and current fee-conformance contracts.
+Builder `v0.2.1` and earlier remain historical beta contracts. New work uses the immutable Hookbuilder `v0.5.1`
+release, including the open-world compiler, Application V3 preparation and current fee-conformance contracts.
 
 For repository-scoped use, change `--scope user` to `--scope project` only when the generated `.agents/` directory is
 intentionally committed or excluded from Git; otherwise it makes the project worktree dirty and blocks `prepare-pr`.

--- a/skills/programmable-v4-hook-builder/SKILL.md
+++ b/skills/programmable-v4-hook-builder/SKILL.md
@@ -102,4 +102,4 @@ node "$SKILL_ROOT/scripts/cli.mjs" project require-output --repository-root "$NE
 
 ## Runtime
 
-Require Node.js 22+. Keep compilation, validation and evidence offline. `doctor` proves local capability only. Require host-native receipts; rerun evidence after bound-input changes.
+Require Node.js 24+. Keep compilation, validation and evidence offline. `doctor` proves local capability only. Require host-native receipts; rerun evidence after bound-input changes.

--- a/skills/programmable-v4-hook-builder/references/contract-registry-v1.json
+++ b/skills/programmable-v4-hook-builder/references/contract-registry-v1.json
@@ -632,7 +632,7 @@
         "mode": "direct",
         "moduleByteLength": 1070,
         "moduleSha256": "sha256:c4561640a691f3cf383ad5b5dd04d58bd9a809e93a3a462e36e8cfe564f5d6c4",
-        "closureSha256": "sha256:2ea7643e70cbad3dec39bbfab43abd8e11b9090a0eadc0f15f00e5d0e79fa941"
+        "closureSha256": "sha256:c5fe74def28877c8345184aa69051d1dd0c01547c6f00dea67f34f64570f8ed2"
       }
     },
     {
@@ -1799,7 +1799,7 @@
       "profile": "static-local-esm-import-closure-v1",
       "rootModulePath": "scripts/github-application-core.mjs",
       "moduleCount": 72,
-      "totalByteLength": 886574,
+      "totalByteLength": 886563,
       "modules": [
         {
           "path": "scripts/builder-template-contract.mjs",
@@ -1818,8 +1818,8 @@
         },
         {
           "path": "scripts/github-application-constants.mjs",
-          "byteLength": 3373,
-          "sha256": "sha256:3850eb323442c9518fcc68c0d8cc155df6c6db560ba174fb92ce691a7cc1dd2a",
+          "byteLength": 3362,
+          "sha256": "sha256:c8b399ca9a578fa2773986a8ebcd4bfad7755ee5247db412ddb5d939b642c453",
           "localImports": [
             "scripts/registry-intake-contract.mjs"
           ]
@@ -2494,7 +2494,7 @@
           ]
         }
       ],
-      "closureSha256": "sha256:2ea7643e70cbad3dec39bbfab43abd8e11b9090a0eadc0f15f00e5d0e79fa941"
+      "closureSha256": "sha256:c5fe74def28877c8345184aa69051d1dd0c01547c6f00dea67f34f64570f8ed2"
     },
     {
       "profile": "static-local-esm-import-closure-v1",
@@ -10596,8 +10596,8 @@
     "validatorClosureModuleBindingCount": 1010,
     "validatorClosureDistinctModuleCount": 171,
     "schemaPathsSha256": "sha256:610762ddd56550d2852596417842b753d32d5ed509433439435fd492aa3110ab",
-    "validatorBindingsSha256": "sha256:16629c67eb119305456fbb266b40f26c73e36961fd340f6fa6b38820e5e41861",
-    "validatorClosuresSha256": "sha256:fca0133e045871db99dce696e3e58fab95ae86f2e53044a8f49b7345191d6156"
+    "validatorBindingsSha256": "sha256:6e578df1ac7fdf969025fe44d140b7d1e64431f469bbe0b6f8fa2b6aed1e0612",
+    "validatorClosuresSha256": "sha256:0cb2eeb08104ac55b424ef93a182a6409f0b6f2d052020ff2717f6a031cba0fb"
   },
-  "registrySha256": "sha256:31a406c8071e045a2550b8286ea664bfd845c2f3b8cfc2da99f35e16387c20f7"
+  "registrySha256": "sha256:0a711a61961990eb0c215819ddc6ddc970ea148c9eea5c2f7aa1bf7c91deb3b8"
 }

--- a/skills/programmable-v4-hook-builder/references/github-application-journey.md
+++ b/skills/programmable-v4-hook-builder/references/github-application-journey.md
@@ -168,7 +168,7 @@ The projection is deliberately small:
 | GitHub observation | Client status |
 | --- | --- |
 | Open draft before the trusted required checks start | `submitted` |
-| `public-intake`, `Node 22`, or `Node 24` is missing, skipped, queued, requested, waiting, pending, or in progress | `checks-running` |
+| `public-intake` or `Node 24` is missing, skipped, queued, requested, waiting, pending, or in progress | `checks-running` |
 | Latest reviewer state requests changes, or one trusted required check failed | `changes-requested` |
 | Required checks pass and the `builder:architecture-review` label is present | `architecture-review` |
 | Required checks pass and the `builder:review-in-progress` label is present | `review-in-progress` |

--- a/skills/programmable-v4-hook-builder/references/upgrades-and-release.md
+++ b/skills/programmable-v4-hook-builder/references/upgrades-and-release.md
@@ -57,9 +57,9 @@ Report the installed version and exact standards:
 node "$SKILL_ROOT/scripts/builder-lifecycle.mjs" version
 ```
 
-This default reports the constants bundled with the checked-out Builder. The v0.5.1 candidate reports
-`publicationState: unpublished-candidate` and `publicationStateVerified: false`; its `stable` channel is the intended
-update channel, not a publication claim. To inspect an explicit pinned installed-state record instead, add
+This default reports the constants bundled with the checked-out Builder. The v0.5.1 package reports
+`publicationState: release-package` and `publicationStateVerified: false`; the bundled constant identifies release
+package bytes but does not independently resolve or authenticate a public tag. To inspect an explicit pinned installed-state record instead, add
 `--state path/to/installed-state.json`; the JSON output marks that source as an installed-state override and keeps
 publication state `not-verified`. Neither path establishes update trust or public release state.
 
@@ -217,8 +217,8 @@ another release byte becomes public earlier, W5 must use that earliest independe
 of the later GitHub timestamp. The planner cannot query GitHub or discover that earlier exposure; its `releasedAt`
 remains a caller declaration.
 
-The candidate's closed `plannedRelease` object binds the intended identity. For the packaged private 0.5.1 candidate it
-declares:
+The example candidate's closed `plannedRelease` object binds the intended identity. For the historical packaged private
+0.5.1 planning example it declares:
 
 - Builder `0.4.0 -> 0.5.1` with semantic classification `minor`;
 - submission standard `1.5.0 -> 1.6.0`;

--- a/skills/programmable-v4-hook-builder/scripts/builder-lifecycle-shared.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/builder-lifecycle-shared.mjs
@@ -3,7 +3,7 @@ import { canonicalJson } from "./submission-core.mjs";
 
 export const BUILDER_LIFECYCLE_SCHEMA_VERSION = "1.0.0";
 export const BUNDLED_BUILDER_VERSION = "0.5.1";
-export const BUNDLED_BUILDER_PUBLICATION_STATE = "unpublished-candidate";
+export const BUNDLED_BUILDER_PUBLICATION_STATE = "release-package";
 export const NORMAL_RELEASE_WINDOW_MS = 24 * 60 * 60 * 1_000;
 
 export const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/u;

--- a/skills/programmable-v4-hook-builder/scripts/cli.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/cli.mjs
@@ -113,7 +113,14 @@ if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
   process.exit(0);
 }
 const command = argv[0];
-if (command === "start" && (argv.slice(1).includes("--help") || argv.slice(1).includes("-h"))) {
+const nodeMajor = Number.parseInt(process.versions.node.split(".", 1)[0], 10);
+const nodeRuntimeSupported = Number.isInteger(nodeMajor) && nodeMajor >= 24;
+if (command !== "doctor" && !nodeRuntimeSupported) {
+  process.exitCode = emitFailure(command, new CliFailure(
+    "NODE_24_OR_NEWER_REQUIRED",
+    "Programmable v4 Builder requires Node.js 24 or newer"
+  ));
+} else if (command === "start" && (argv.slice(1).includes("--help") || argv.slice(1).includes("-h"))) {
   process.stdout.write(`${startHelp()}\n`);
 } else if (command === "launch-bundle-v2") {
   const launchArgs = argv.slice(1);

--- a/skills/programmable-v4-hook-builder/scripts/doctor.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/doctor.mjs
@@ -52,7 +52,7 @@ const checks = tools.map(([name, toolArgs, deterministic, publicBeta]) => {
   };
 });
 const nodeMajor = Number.parseInt(process.versions.node.split(".", 1)[0], 10);
-const nodeSupported = Number.isInteger(nodeMajor) && nodeMajor >= 22;
+const nodeSupported = Number.isInteger(nodeMajor) && nodeMajor >= 24;
 const applicationV3Platforms = ["darwin", "linux"];
 const applicationV3PlatformSupported = applicationV3Platforms.includes(process.platform);
 const exactObjectGit = inspectExactObjectGitTooling();
@@ -101,7 +101,7 @@ const gitWorktreeStatus = repositoryRoot === null
 const gitWorktreeAvailable = gitWorktreeStatus === "available";
 const githubCli = checks.find(({ name }) => name === "gh");
 const publicBetaBlockers = [
-  ...(nodeSupported ? [] : ["NODE_20_OR_NEWER_REQUIRED"]),
+  ...(nodeSupported ? [] : ["NODE_24_OR_NEWER_REQUIRED"]),
   ...(applicationV3PlatformSupported ? [] : ["APPLICATION_V3_PLATFORM_UNSUPPORTED"]),
   ...(exactObjectGit.status === "ready" ? [] : ["EXACT_OBJECT_GIT_TOOLING_REQUIRED"]),
   ...(githubCli?.available === true ? [] : ["GITHUB_CLI_REQUIRED"]),
@@ -144,7 +144,7 @@ const report = {
   },
   runtimeCompatibility: {
     node: {
-      minimumMajor: 22,
+      minimumMajor: 24,
       currentMajor: nodeMajor,
       supported: nodeSupported
     },
@@ -195,7 +195,7 @@ const report = {
 if (asJson) console.log(JSON.stringify(report, null, 2));
 else {
   for (const check of checks) console.log(`${check.available ? "ok" : "missing"} ${check.name}${check.version ? `: ${check.version}` : ""}`);
-  console.log(`${nodeSupported ? "ok" : "unsupported"} Node.js major version ${nodeMajor}; deterministic preflight requires Node.js 22 or newer`);
+  console.log(`${nodeSupported ? "ok" : "unsupported"} Node.js major version ${nodeMajor}; deterministic preflight requires Node.js 24 or newer`);
   console.log(`${report.readyForRepositoryWork ? "ok" : "unavailable"} repository worktree`);
   if (!report.gitWorktreeChecks.available) console.log(`unavailable Git-only checks: ${report.gitWorktreeChecks.reason}`);
   console.log(`${report.cleanWorktree === true ? "ok" : report.cleanWorktree === false ? "dirty" : "unknown"} git worktree`);

--- a/skills/programmable-v4-hook-builder/scripts/github-application-constants.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/github-application-constants.mjs
@@ -16,7 +16,7 @@ export const PROGRAMMABLE_GITHUB_ACTIONS_APP_ID = "15368";
 export const PROGRAMMABLE_GITHUB_ACTIONS_APP_SLUG = "github-actions";
 export const PROGRAMMABLE_MAINTAINER_GITHUB_USER_ID = "309941960";
 export const PROGRAMMABLE_MAINTAINER_GITHUB_LOGIN = "0xprogrammable";
-export const REQUIRED_APPLICATION_CHECKS = Object.freeze(["public-intake", "Node 22", "Node 24"]);
+export const REQUIRED_APPLICATION_CHECKS = Object.freeze(["public-intake", "Node 24"]);
 export const CENTRAL_APPLICATION_FILES = Object.freeze([
   "application.json",
   "PROPOSAL.md",

--- a/skills/programmable-v4-hook-builder/scripts/test/builder-lifecycle.test.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/test/builder-lifecycle.test.mjs
@@ -49,7 +49,7 @@ test("bundled version reports standalone code constants without requiring state"
   const result = bundledVersionStatus();
   assert.equal(result.installed.releaseVersion, "0.5.1");
   assert.equal(result.installed.channel, "stable");
-  assert.equal(result.installed.publicationState, "unpublished-candidate");
+  assert.equal(result.installed.publicationState, "release-package");
   assert.equal(result.installed.standards.skill, "0.5.1");
   assert.equal(result.installed.standards.engine, "0.5.1");
   assert.equal(result.installed.standards.policy, "1.1.0");
@@ -851,7 +851,7 @@ test("standalone CLI reports bundled version without an installed-state file", (
   assert.equal(result.status, 0, result.stdout || result.stderr);
   const parsed = JSON.parse(result.stdout);
   assert.equal(parsed.result.installed.releaseVersion, "0.5.1");
-  assert.equal(parsed.result.installed.publicationState, "unpublished-candidate");
+  assert.equal(parsed.result.installed.publicationState, "release-package");
   assert.equal(parsed.result.versionSource, "bundled-code-constants");
   assert.equal(parsed.result.installedStateOverrideUsed, false);
 });

--- a/skills/programmable-v4-hook-builder/scripts/test/cli-entry.test.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/test/cli-entry.test.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { parseCli } from "../cli-args.mjs";
 import { materializeExample } from "../example-materializer-core.mjs";
 
@@ -58,6 +58,37 @@ test("doctor delegates to the existing readiness command and emits JSON", () => 
     assert.ok(output.result.publicBetaBlockers.includes("EXTERNAL_ACCEPTANCE_NOT_CHECKED"));
     assert.equal(output.result.publicBetaGit.publicReachability.status, "notChecked");
     assert.equal(output.result.publicBetaGit.readyForPreparePrLocal, false);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("CLI blocks every non-doctor command below Node 24 without blocking doctor dispatch", () => {
+  const bootstrap = (args) => [
+    'Object.defineProperty(process.versions, "node", { value: "22.23.1" });',
+    `process.argv = [process.execPath, ${JSON.stringify(cli)}, ...${JSON.stringify(args)}];`,
+    `await import(${JSON.stringify(pathToFileURL(cli).href)});`
+  ].join("\n");
+  const blocked = childProcess.spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", bootstrap(["context", "--help"])],
+    { cwd: skillRoot, encoding: "utf8", shell: false }
+  );
+  assert.equal(blocked.status, 2, blocked.stdout || blocked.stderr);
+  assert.equal(blocked.stderr, "");
+  assert.equal(JSON.parse(blocked.stdout).error.code, "NODE_24_OR_NEWER_REQUIRED");
+
+  const fixture = createRepository();
+  try {
+    const doctor = childProcess.spawnSync(
+      process.execPath,
+      ["--input-type=module", "--eval", bootstrap(["doctor", "--repository-root", fixture.repository])],
+      { cwd: skillRoot, encoding: "utf8", shell: false }
+    );
+    assert.equal(doctor.status, 0, doctor.stdout || doctor.stderr);
+    const report = JSON.parse(doctor.stdout);
+    assert.equal(report.command, "doctor");
+    assert.equal(report.ok, true);
   } finally {
     fixture.cleanup();
   }

--- a/skills/programmable-v4-hook-builder/scripts/test/cli.test.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/test/cli.test.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const skillRoot = path.resolve(testDirectory, "..", "..");
@@ -94,7 +94,7 @@ test("host-neutral version reports the bundled standalone release without state"
   assert.equal(result.status, 0, result.stdout || result.stderr);
   const output = JSON.parse(result.stdout);
   assert.equal(output.result.installed.releaseVersion, "0.5.1");
-  assert.equal(output.result.installed.publicationState, "unpublished-candidate");
+  assert.equal(output.result.installed.publicationState, "release-package");
   assert.equal(output.result.versionSource, "bundled-code-constants");
   assert.equal(output.result.installedStateOverrideUsed, false);
 });
@@ -275,7 +275,7 @@ test("doctor distinguishes local generation from an actual Git worktree", () => 
     assert.equal(report.githubCli.requiredForPublicBetaApplication, true);
     assert.equal(report.githubCli.authenticationChecked, false);
     assert.equal(report.readyForGitHubApplicationClient, report.githubCli.available);
-    assert.equal(report.runtimeCompatibility.node.minimumMajor, 22);
+    assert.equal(report.runtimeCompatibility.node.minimumMajor, 24);
     assert.equal(report.runtimeCompatibility.node.supported, true);
     assert.deepEqual(report.runtimeCompatibility.applicationV3.supportedPlatforms, ["darwin", "linux"]);
     assert.equal(
@@ -305,6 +305,34 @@ test("doctor distinguishes local generation from an actual Git worktree", () => 
       report.publicBetaBlockers.includes("GITHUB_CLI_REQUIRED"),
       report.githubCli.available === false
     );
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("doctor reports the Node 24 blocker for an unsupported runtime", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "programmable-doctor-node-"));
+  const doctor = path.join(scriptsRoot, "doctor.mjs");
+  try {
+    const bootstrap = [
+      'Object.defineProperty(process.versions, "node", { value: "23.0.0" });',
+      `process.argv = [process.execPath, ${JSON.stringify(doctor)}, "--json", "--repository-root", ${JSON.stringify(directory)}];`,
+      `await import(${JSON.stringify(pathToFileURL(doctor).href)});`
+    ].join("\n");
+    const result = childProcess.spawnSync(
+      process.execPath,
+      ["--input-type=module", "--eval", bootstrap],
+      { cwd: directory, encoding: "utf8", shell: false }
+    );
+    assert.equal(result.status, 1, result.stderr);
+    const report = JSON.parse(result.stdout);
+    assert.deepEqual(report.runtimeCompatibility.node, {
+      minimumMajor: 24,
+      currentMajor: 23,
+      supported: false
+    });
+    assert.ok(report.publicBetaBlockers.includes("NODE_24_OR_NEWER_REQUIRED"));
+    assert.equal(report.publicBetaBlockers.some((blocker) => /^NODE_(?:20|22)_OR_NEWER_REQUIRED$/u.test(blocker)), false);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/skills/programmable-v4-hook-builder/scripts/test/github-application.test.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/test/github-application.test.mjs
@@ -1045,11 +1045,6 @@ test("status re-reads the PR and reports a different prepared package without ca
       detailsUrl: null
     },
     {
-      name: "Node 22",
-      state: "missing",
-      detailsUrl: null
-    },
-    {
       name: "Node 24",
       state: "missing",
       detailsUrl: null
@@ -1075,14 +1070,9 @@ test("status preserves the canonical trusted Registry check details link", async
       detailsUrl: "https://github.com/0xprogrammable/submit-launch/actions/runs/1001/job/801"
     },
     {
-      name: "Node 22",
-      state: "passing",
-      detailsUrl: "https://github.com/0xprogrammable/submit-launch/actions/runs/1001/job/802"
-    },
-    {
       name: "Node 24",
       state: "passing",
-      detailsUrl: "https://github.com/0xprogrammable/submit-launch/actions/runs/1001/job/803"
+      detailsUrl: "https://github.com/0xprogrammable/submit-launch/actions/runs/1001/job/802"
     }
   ]);
 });
@@ -2069,8 +2059,7 @@ function rawCheck({
 function rawRequiredChecks({ publicIntakeConclusion = "success", appId = "15368" } = {}) {
   return [
     rawCheck({ id: "801", name: "public-intake", conclusion: publicIntakeConclusion, appId }),
-    rawCheck({ id: "802", name: "Node 22", appId }),
-    rawCheck({ id: "803", name: "Node 24", appId })
+    rawCheck({ id: "802", name: "Node 24", appId })
   ];
 }
 

--- a/skills/programmable-v4-hook-builder/scripts/test/verify-skill-static.test.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/test/verify-skill-static.test.mjs
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   createDeterministicTestBatches,
   runDeterministicTestBatches
@@ -989,6 +989,22 @@ test("installed verifier accepts current pinned gh skill GitHub provenance", () 
   } finally {
     fs.rmSync(fixture.fixtureRoot, { recursive: true, force: true });
   }
+});
+
+test("portable verifier rejects runtimes below Node 24 before scanning package bytes", () => {
+  const bootstrap = [
+    'Object.defineProperty(process.versions, "node", { value: "22.23.1" });',
+    `process.argv = [process.execPath, ${JSON.stringify(verifier)}, "--installed"];`,
+    `await import(${JSON.stringify(pathToFileURL(verifier).href)});`
+  ].join("\n");
+  const result = childProcess.spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", bootstrap],
+    { cwd: skillRoot, encoding: "utf8", shell: false }
+  );
+  assert.equal(result.status, 1, result.stdout || result.stderr);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /NODE_24_OR_NEWER_REQUIRED/u);
 });
 
 test("installed metadata parser accepts exact unpinned GitHub and quoted local profiles", () => {

--- a/skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
+++ b/skills/programmable-v4-hook-builder/scripts/verify-skill.mjs
@@ -17,6 +17,11 @@ import { markdownHeadingAnchors, parseCanonicalYamlMapping, redactInstalledLocal
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const canonicalSkillRoot = path.resolve(scriptDirectory, "..");
+const nodeMajor = Number.parseInt(process.versions.node.split(".", 1)[0], 10);
+if (!Number.isInteger(nodeMajor) || nodeMajor < 24) {
+  console.error("verify-skill.mjs: NODE_24_OR_NEWER_REQUIRED");
+  process.exit(1);
+}
 const MAX_PORTABLE_FILES = 640;
 const MAX_PORTABLE_BYTES = 12_000_000;
 const MAX_PORTABLE_FILE_BYTES = 1_000_000;


### PR DESCRIPTION
## Summary

- sync the canonical Programmable v4 Builder from the immutable Hookbuilder v0.5.1 release
- keep the repository skill and generated marketplace plugin byte-identical to the released skill tree
- retain Node 24 as the active runtime and close the redundant double-run path in maintenance CI
- replace every active development-main/v0.4.3 installation example with the immutable v0.5.1 pin
- align trusted per-side fee bounds while preserving mandatory candidate review above the reference accelerator

## Frozen release

- annotated tag: `v0.5.1`
- tag object: `7f0beec2afe00facd25ba65cecbb18f285f15b91`
- tag commit: `547482adf6ed0ed19e9cd4d0e884abd70e143229`
- Hookbuilder repo tree: `ed030750bb745e7915070985f0d8643c29760c25`
- canonical and plugin skill tree: `b7a0eeec627b2fd2dfe24fcadd35befcd42b8cec`
- Hookbuilder release: latest, immutable, six attested assets
- Programmable candidate: `bd3d9bff211edd5d41d8bb5f717b4525734946fb`
- Programmable tree: `5fd27063bd4e579840719b8047ba640c93182c90`

## Validation

- exact live tag/release/Latest/asset verification passed
- source-to-canonical and canonical-to-plugin byte/mode/tree parity passed
- trusted intake: 223 passed, 0 failed, 1 Linux-only skip
- canonical and installed verifiers passed
- plugin/workflow contract: 27/27 passed
- active documentation links/pins: 9/9 plus checker passed
- evaluations: 7/7 plus structure validation passed
- generator, maintained-submission, and diff checks passed

Both maintenance workflows retain one canonical `verify-skill` execution plus installed-mode verification; the old redundant direct full test glob remains forbidden by contract. Custom rates above the reference accelerator remain architecture-review-required and cannot auto-promote.

This sync grants no application acceptance, security audit, deployment, Registry activation, payout, or project launch authority.