### PR TITLE
chore: align production indexer with Node 24 and Hookbuilder v0.5.1

### DIFF
--- a/docs/public/creators/launch.md
+++ b/docs/public/creators/launch.md
@@ -8,7 +8,7 @@ Custom projects use a public, exact revision workflow. The project stays in its 
 
 ## Prepare the source
 
-Start from a public GitHub repository that contains the code, tests, deployment logic and material project information needed to understand the release. Use the latest stable [Programmable v4 Builder release](https://github.com/0xprogrammable/hookbuilder/releases/latest), currently `v0.4.3`, rather than the moving development branch.
+Start from a public GitHub repository that contains the code, tests, deployment logic and material project information needed to understand the release. Use the latest stable [Programmable v4 Builder release](https://github.com/0xprogrammable/hookbuilder/releases/latest), currently `v0.5.1`, rather than the moving development branch.
 
 The Builder preserves the product intent, chooses the smallest complete architecture and runs the checks that apply to that project. It freezes the repository id, commit and tree used by the application so a later commit cannot be mistaken for the reviewed revision.
 

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -33,7 +33,7 @@ systems. Beneficiary seed hydration is a separate block-pinned dual-RPC worker.
 
 Requirements:
 
-- Node.js 22 or newer
+- Node.js 24.14 or newer, below Node 25
 - pnpm 10.32.0
 - Docker for a full local Envio stack
 

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.14.0 <25"
   },
   "packageManager": "pnpm@10.32.0",
   "scripts": {


### PR DESCRIPTION
## Summary

- align the production indexer engine and operator documentation with Node.js 24.14
- update the active creator-facing stable Builder reference to immutable Hookbuilder v0.5.1
- preserve the production legacy ten-file compatibility validator byte-for-byte

## Frozen identity

- production base: `5697c214dd74a9254d55d0912b8c3a73094dc6ab`
- candidate: `f40dce9d2e47310e73788de848e751058773bdff`
- candidate tree: `bb55a4c65b7446b0e892fd3b036ce1643bd490ce`
- Hookbuilder release: `v0.5.1` at `547482adf6ed0ed19e9cd4d0e884abd70e143229`, latest and immutable
- retained legacy validator tree: `4b130ae184c6c6cec8e511c85b286aa372245e62`

## Validation

- Node 24.14.0 frozen pnpm install passed
- Envio codegen and typecheck passed
- Vitest: 8/8 files, 81/81 tests passed
- engine parity and `git diff --check` passed
- only three paths change: `indexer/package.json`, `indexer/README.md`, and `docs/public/creators/launch.md`

This PR does not deploy or promote production. A separate staged deployment must pass exact binding and live market-data freshness gates before any alias move.