### PR TITLE
fix: bound stale FDV on public Explore

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -16,7 +16,7 @@ import {
   buildExploreDataQuality,
   publicExploreEntryV1,
   valuationSortValue,
-  withBitqueryMarketData,
+  withPublicExploreBitqueryMarketData,
   type ValuedExploreEntry,
 } from "../../../lib/explore-financial-data";
 import { readBitqueryTokenMarketDataV1 } from
@@ -300,11 +300,14 @@ export function dedupeExploreEntriesV1(
 function valueExploreEntriesWithMarketData(
   entries: readonly ExploreEntry[],
   marketByToken: ReadonlyMap<string, TokenMarketDataV1>,
+  nowMs: number,
 ): ValuedExploreEntry[] {
   return entries.map((entry) => {
     const address = entry.tokenAddress?.toLowerCase();
     const marketData = address ? marketByToken.get(address) : undefined;
-    if (marketData) return withBitqueryMarketData(entry, marketData);
+    if (marketData) {
+      return withPublicExploreBitqueryMarketData(entry, marketData, nowMs);
+    }
     return {
       ...entry,
       valuation: {
@@ -434,6 +437,7 @@ async function valueExplorePage(input: Readonly<{
   const valuedEntries = valueExploreEntriesWithMarketData(
     hydratedEntries,
     marketByToken,
+    Date.now(),
   );
   if (identityPage !== null) {
     return {

--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -17,6 +17,11 @@ import {
 export const EXPLORE_DATA_QUALITY_SCHEMA_VERSION =
   "programmable.explore-data-quality.v1" as const;
 export const EXPLORE_VALUATION_MAX_LAG_BLOCKS = 64n;
+// This mirrors the fail-closed general stale ceiling in the production release
+// gate. The direct token-detail path deliberately keeps its separate exact
+// historical PCAN evidence contract.
+export const PUBLIC_EXPLORE_MAXIMUM_STALE_FDV_AGE_MS =
+  24 * 60 * 60_000;
 
 const UINT_256_MAX = (1n << 256n) - 1n;
 const WAD = 10n ** 18n;
@@ -123,6 +128,11 @@ export type ExploreSourceStatus =
 type ValuationContext = Readonly<{
   referenceBlock?: string | null;
   forceStale?: boolean;
+}>;
+
+type BitqueryValuationContext = Readonly<{
+  maximumStaleAgeMs?: number;
+  nowMs?: number;
 }>;
 
 function uint256(value: unknown): bigint | null {
@@ -302,7 +312,30 @@ export function withBitqueryMarketData<T extends ExploreEntry>(
   entry: T,
   marketData: TokenMarketDataV1,
 ): ValuedExploreEntry<T> {
-  const reconciledMarketData = reconcileBitqueryValuations(entry, marketData);
+  return withReconciledBitqueryMarketData(entry, marketData, {});
+}
+
+export function withPublicExploreBitqueryMarketData<T extends ExploreEntry>(
+  entry: T,
+  marketData: TokenMarketDataV1,
+  nowMs = Date.now(),
+): ValuedExploreEntry<T> {
+  return withReconciledBitqueryMarketData(entry, marketData, {
+    maximumStaleAgeMs: PUBLIC_EXPLORE_MAXIMUM_STALE_FDV_AGE_MS,
+    nowMs,
+  });
+}
+
+function withReconciledBitqueryMarketData<T extends ExploreEntry>(
+  entry: T,
+  marketData: TokenMarketDataV1,
+  context: BitqueryValuationContext,
+): ValuedExploreEntry<T> {
+  const reconciledMarketData = reconcileBitqueryValuations(
+    entry,
+    marketData,
+    context,
+  );
   const primary = reconciledMarketData.pools.find(
     (pool) => pool.identity.poolId === reconciledMarketData.primaryPoolId,
   );
@@ -338,6 +371,7 @@ export function withBitqueryMarketData<T extends ExploreEntry>(
 function reconcileBitqueryValuations<T extends ExploreEntry>(
   entry: T,
   marketData: TokenMarketDataV1,
+  context: BitqueryValuationContext,
 ): TokenMarketDataV1 {
   // Bitquery owns the market price, but Router/Registry owns the token
   // identity and canonical fixed supply. Its third-party circulating-supply
@@ -440,6 +474,13 @@ function reconcileBitqueryValuations<T extends ExploreEntry>(
       ? [tradeTime, priceTime]
       : [tradeTime, priceTime, liquidityTime];
     const asOfTime = new Date(Math.min(...evidenceTimes)).toISOString();
+    if (!marketValuationWithinMaximumAge(asOfTime, context)) {
+      return {
+        ...pool,
+        quality: "partial",
+        valuation: { status: "unavailable", reason: "price-unavailable" },
+      };
+    }
     const evidenceIsCurrent = pool.liquidity !== undefined &&
       evidenceTimes.every(
       (time) => generatedTime - time <= MARKET_DATA_CURRENT_MAX_AGE_MS,
@@ -467,6 +508,21 @@ function reconcileBitqueryValuations<T extends ExploreEntry>(
     };
   });
   return { ...marketData, pools };
+}
+
+function marketValuationWithinMaximumAge(
+  asOfTime: string,
+  context: BitqueryValuationContext,
+): boolean {
+  if (context.maximumStaleAgeMs === undefined) return true;
+  const nowMs = context.nowMs ?? Date.now();
+  const asOfMs = Date.parse(asOfTime);
+  return Number.isSafeInteger(context.maximumStaleAgeMs) &&
+    context.maximumStaleAgeMs >= 0 &&
+    Number.isSafeInteger(nowMs) &&
+    Number.isFinite(asOfMs) &&
+    asOfMs <= nowMs + MAXIMUM_MARKET_FUTURE_SKEW_MS &&
+    nowMs - asOfMs <= context.maximumStaleAgeMs;
 }
 
 function usdPricesWithinConfidence(rawPrice: bigint, indexedPrice: bigint): boolean {

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -82,6 +82,7 @@ import {
 
 const HOOK_ADDRESS =
   "0x3333333333333333333333333333333333333333" as const;
+const MARKET_OBSERVATION_TIME = new Date().toISOString();
 
 function token(index: number): LauncherToken {
   const tokenAddress = `0x${index.toString(16).padStart(40, "0")}` as const;
@@ -109,15 +110,21 @@ function token(index: number): LauncherToken {
 
 function bitqueryMarketData(
   identities: readonly MarketDataIdentityV1[],
-  options: Readonly<{ freshness?: "current" | "stale" }> = {},
+  options: Readonly<{
+    freshness?: "current" | "stale";
+    generatedAt?: string;
+    asOfTime?: string;
+  }> = {},
 ): ReadonlyMap<string, TokenMarketDataV1> {
+  const generatedAt = options.generatedAt ?? MARKET_OBSERVATION_TIME;
+  const asOfTime = options.asOfTime ?? MARKET_OBSERVATION_TIME;
   return new Map(identities.map((identity) => {
     const value = (BigInt(identity.tokenAddress) * 10n ** 18n).toString();
     const priceUsdWad = (BigInt(identity.tokenAddress) * 10n ** 9n).toString();
     return [identity.tokenAddress, {
       schemaVersion: "programmable.market-data.v1",
       source: "bitquery",
-      generatedAt: "2026-08-11T14:00:00.000Z",
+      generatedAt,
       status: options.freshness === "stale" ? "stale" : "current",
       primaryPoolId: identity.poolId,
       pools: [{
@@ -125,20 +132,20 @@ function bitqueryMarketData(
         source: "bitquery",
         status: options.freshness === "stale" ? "stale" : "current",
         quality: "complete",
-        asOfTime: "2026-08-11T14:00:00.000Z",
+        asOfTime,
         latestTrade: {
           transactionHash: `0x${"aa".repeat(32)}`,
           logIndex: 1,
           blockNumber: "25740000",
-          time: "2026-08-11T14:00:00.000Z",
+          time: asOfTime,
           tokenSide: "buy",
           priceUsdWad,
-          priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
+          priceUsdAsOfTime: asOfTime,
           priceUsdSource: "bitquery-token-price-index-v1",
           rawPriceUsdWad: priceUsdWad,
         },
         liquidity: {
-          asOfTime: "2026-08-11T14:00:00.000Z",
+          asOfTime,
           asOfBlock: "25740000",
           valueUsdWad: "100000000000000000000000",
           freshness: options.freshness ?? "current",
@@ -150,7 +157,7 @@ function bitqueryMarketData(
           valueUsdWad: value,
           fdvUsdWad: value,
           totalSupply: "1000000",
-          asOfTime: "2026-08-11T14:00:00.000Z",
+          asOfTime,
           freshness: options.freshness ?? "current",
         },
       }],
@@ -570,7 +577,7 @@ describe("Explore API Bitquery market boundary", () => {
           stale: 0,
           unknown: 0,
           asOfBlock: null,
-          asOfTime: "2026-08-11T14:00:00.000Z",
+          asOfTime: MARKET_OBSERVATION_TIME,
         },
       },
     });
@@ -581,7 +588,7 @@ describe("Explore API Bitquery market boundary", () => {
       currency: "usd",
       freshness: "current",
       source: "bitquery",
-      asOfTime: "2026-08-11T14:00:00.000Z",
+      asOfTime: MARKET_OBSERVATION_TIME,
     });
     expect(body.tokens[0].fdvUsdWad).toBe(
       body.tokens[0].valuation.valueWad,
@@ -688,6 +695,50 @@ describe("Explore API Bitquery market boundary", () => {
     );
   });
 
+  it("removes public FDV when a fresh response contains a trade older than 24 hours", async () => {
+    const generatedAt = new Date().toISOString();
+    const asOfTime = new Date(
+      Date.now() - 24 * 60 * 60_000 - 1,
+    ).toISOString();
+    mocks.readBitqueryTokenMarketDataV1.mockImplementation(
+      async (identities: readonly MarketDataIdentityV1[]) =>
+        bitqueryMarketData(identities, {
+          freshness: "stale",
+          generatedAt,
+          asOfTime,
+        }),
+    );
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/explore?sort=market-cap&limit=100"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.tokens).toHaveLength(30);
+    expect(body.tokens.every((entry: {
+      fdvUsdWad?: string;
+      valuation: { status: string; reason?: string };
+      marketData?: {
+        pools?: Array<{
+          valuation?: { status?: string; reason?: string };
+        }>;
+      };
+    }) => {
+      const poolValuation = entry.marketData?.pools?.[0]?.valuation;
+      return entry.fdvUsdWad === undefined &&
+        entry.valuation.status === "unavailable" &&
+        entry.valuation.reason === "price-unavailable" &&
+        poolValuation?.status === "unavailable" &&
+        poolValuation.reason === "price-unavailable";
+    })).toBe(true);
+    expect(body.dataQuality.valuation).toMatchObject({
+      status: "unavailable",
+      available: 0,
+      unavailable: 30,
+    });
+  });
+
   it("binds current FDV to Bitquery time instead of the lagging identity snapshot", async () => {
     const staleModelSnapshot = {
       ...snapshot,
@@ -746,7 +797,7 @@ describe("Explore API Bitquery market boundary", () => {
       status: "available",
       freshness: "current",
       source: "bitquery",
-      asOfTime: "2026-08-11T14:00:00.000Z",
+      asOfTime: MARKET_OBSERVATION_TIME,
     });
     expect(body.dataQuality).toMatchObject({
       launchIdentity: {
@@ -756,7 +807,7 @@ describe("Explore API Bitquery market boundary", () => {
       valuation: {
         status: "current",
         asOfBlock: null,
-        asOfTime: "2026-08-11T14:00:00.000Z",
+        asOfTime: MARKET_OBSERVATION_TIME,
       },
     });
   });

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -9,6 +9,7 @@ import {
   type ValuedExploreEntry,
   withBitqueryMarketData,
   withExploreValuation,
+  withPublicExploreBitqueryMarketData,
 } from "../lib/explore-financial-data";
 import type { TokenMarketDataV1 } from
   "../lib/market-data/market-data-v1";
@@ -197,7 +198,7 @@ describe("Explore financial-data semantics", () => {
     expect(published).not.toHaveProperty("tokenPriceQuoteWad");
   });
 
-  it("publishes an exact-pool last-trade FDV as stale when liquidity is unavailable", () => {
+  it("preserves exact historical detail but removes FDV beyond the public stale ceiling", () => {
     const poolId = `0x${"34".repeat(32)}` as const;
     const marketData = {
       schemaVersion: "programmable.market-data.v1",
@@ -244,6 +245,21 @@ describe("Explore financial-data semantics", () => {
     });
     expect(valuationSortValue(entry)).toBeNull();
     expect(publicExploreEntryV1(entry)).not.toHaveProperty("fdvUsdWad");
+
+    const publicEntry = withPublicExploreBitqueryMarketData(
+      canonicalTokenExploreEntryV1(goldenToken()),
+      marketData,
+      Date.parse(marketData.generatedAt),
+    );
+    expect(publicEntry.valuation).toEqual({
+      status: "unavailable",
+      reason: "price-unavailable",
+    });
+    expect(publicEntry.marketData?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "price-unavailable",
+    });
+    expect(valuationSortValue(publicEntry)).toBeNull();
   });
 
   it("keeps the indexed USD timestamp authoritative for public freshness", () => {


### PR DESCRIPTION
## Summary

- cap numeric FDV on the public Explore list at the existing 24-hour production release ceiling
- downgrade older last-trade valuations to typed `price-unavailable` before sorting and serialization
- preserve direct token detail and chart reconciliation for the separately bounded exact PCAN historical evidence path

## Root cause

Production Stage run 31653544290 served a freshly generated Bitquery response whose latest BWETH trade was about 58 hours old. Public Explore kept that value as numeric `available/stale` FDV, while the fail-closed release contract correctly rejects general stale FDV older than 24 hours. Independent onchain log reads found no newer swap, so the repair belongs at the public response boundary rather than in the provider or release gate.

## Validation

- Node.js 24.14.0
- focused Vitest: 4 files, 115 tests
- interface CI suite: 284 files passed, 1 skipped; 2840 tests passed, 7 skipped
- CI scope: 13 tests
- TypeScript and changed-file ESLint
- read-model smoke: 18 checks
- read-model operations source contract: 39 checks
- Next.js production build

No release gate, workflow, provider configuration, token-detail route, chart route, deployment, or promotion is changed by this PR.