### PR TITLE
Fix and accelerate public market data

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -597,18 +597,20 @@ jobs:
           node scripts/verify-manual-applicant-staged-runtime.mjs
           --target-url "$STAGED_TARGET_URL"
 
-      - name: Smoke staged Bitquery market APIs
+      - name: Smoke staged public market APIs
         if: needs.release-gate.outputs.verified_read_model == 'true'
         env:
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
-          node --input-type=module <<'NODE'
+          node --env-file=.vercel/.env.production.local --input-type=module <<'NODE'
+          const { verifyCurrentPublicOnchainEvidenceV1 } = await import(
+            "./scripts/perf/read-model-post-promotion.mjs"
+          );
           const { verifyBitqueryGoldenMarketParityV1 } = await import(
             "./scripts/perf/bitquery-golden-market-parity.mjs"
           );
           const {
-            boundedStaleMarketTimeV1,
             verifyBitqueryHistoricalGoldenReleaseV1,
           } = await import(
             "./scripts/perf/bitquery-historical-release-gate.mjs"
@@ -619,6 +621,24 @@ jobs:
             "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
           const goldenQuoteAddress =
             "0x0000000000000000000000000000000000000000";
+          const nativeCurrency =
+            "0x0000000000000000000000000000000000000000";
+          const mainnetStateView =
+            "0x7ffe42c4a5deea5b0fec41c94c136cf115597227";
+          const mainnetStateViewRuntimeCodeHash =
+            "0xd7947778589cf4aac9a092a4451292a2056380941635ab7006d3c691d8dfd878";
+          const mainnetEthUsdFeed =
+            "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419";
+          const officialV4SubgraphDeployment =
+            "QmZsgJLiLQKpb8hxTmQ5LWyrFVvfWzVaL4WK8dfFBn7EeK";
+          const officialV4SubgraphId =
+            "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G";
+          const currentPublicMarketSource =
+            "stateview-chainlink+official-uniswap-v4-subgraph+bitquery";
+          const minimumPublicFdvLiquidityUsdWad =
+            10_000n * 10n ** 18n;
+          const marketCapPageSize = 100;
+          const maximumMarketCapTokens = 400;
           const origin = new URL(process.env.STAGED_TARGET_URL);
           if (
             origin.protocol !== "https:" ||
@@ -647,10 +667,27 @@ jobs:
             Accept: "application/json",
             "x-vercel-protection-bypass": automationBypassSecret,
           });
-          const bitqueryMarketContract = Object.freeze({
+          const publicMarketContract = Object.freeze({
+            readSources: Object.freeze(["operational+durable+postgres"]),
+            rpcProviders: null,
+            marketSources: Object.freeze([
+              "bitquery",
+              currentPublicMarketSource,
+            ]),
+            dataQualities: Object.freeze(["complete", "partial", "stale"]),
+          });
+          const currentPublicMarketContract = Object.freeze({
+            readSources: Object.freeze(["operational+durable+postgres"]),
+            rpcProviders: null,
+            marketSources: Object.freeze([currentPublicMarketSource]),
+            priceSources: Object.freeze(["stateview-chainlink"]),
+            dataQualities: Object.freeze(["complete", "partial", "stale"]),
+          });
+          const historicalBitqueryMarketContract = Object.freeze({
             readSources: Object.freeze(["operational+durable+postgres"]),
             rpcProviders: null,
             marketSources: Object.freeze(["bitquery"]),
+            priceSources: null,
             dataQualities: Object.freeze(["complete", "partial", "stale"]),
           });
           const bitqueryChartContract = Object.freeze({
@@ -678,7 +715,58 @@ jobs:
               ? value === null
               : expected.includes(value ?? "");
           const positiveInteger = (value) =>
-            typeof value === "string" && /^[1-9][0-9]*$/.test(value);
+            typeof value === "string" &&
+            value.length <= 78 &&
+            /^[1-9][0-9]*$/.test(value);
+          const unsignedInteger = (value) =>
+            typeof value === "string" &&
+            value.length <= 78 &&
+            /^(?:0|[1-9][0-9]*)$/.test(value);
+          const unsignedDecimal = (value) =>
+            typeof value === "string" &&
+            value.length <= 160 &&
+            /^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/.test(value);
+          const positiveDecimal = (value) =>
+            unsignedDecimal(value) && !/^0(?:\.0+)?$/.test(value);
+          const exactAddress = (value) =>
+            typeof value === "string" &&
+            /^0x[0-9a-f]{40}$/i.test(value);
+          const exactBytes32 = (value) =>
+            typeof value === "string" &&
+            /^0x[0-9a-f]{64}$/i.test(value);
+          const sameAddress = (left, right) =>
+            exactAddress(left) &&
+            exactAddress(right) &&
+            left.toLowerCase() === right.toLowerCase();
+          const sameBytes32 = (left, right) =>
+            exactBytes32(left) &&
+            exactBytes32(right) &&
+            left.toLowerCase() === right.toLowerCase();
+          const exactCanonicalClassicNativeToken = (
+            token,
+            tokenAddress,
+            poolId,
+          ) => {
+            if (
+              token?.exploreKind !== "token" ||
+              token.launchModel !== "classic"
+            ) return false;
+            if (token.liquidityPath === "meme") {
+              return token.launchStampProvenance === undefined;
+            }
+            const stamp = token.launchStampProvenance;
+            return token.liquidityPath === "programmable-v4" &&
+              stamp?.schemaVersion ===
+                "programmable.launch-stamp-provenance.v1" &&
+              stamp.kind === "classic" &&
+              stamp.chainId === 1 &&
+              sameBytes32(stamp.poolId, poolId) &&
+              sameAddress(stamp.poolKey?.currency0, nativeCurrency) &&
+              sameAddress(stamp.poolKey?.currency1, tokenAddress) &&
+              sameAddress(stamp.poolKey?.hooks, token?.hookAddress);
+          };
+          const exactUnixTimestamp = (value) =>
+            positiveInteger(value) && BigInt(value) <= 8_640_000_000n;
           const positiveDecimalToWad = (value) => {
             const match = /^(0|[1-9][0-9]*)(?:\.([0-9]+))?$/.exec(
               String(value ?? ""),
@@ -696,7 +784,34 @@ jobs:
           const currentMarketTime = (value) =>
             validMarketTime(value) &&
             Date.now() - Date.parse(value) <= 6 * 60_000;
-          const boundedStaleMarketTime = boundedStaleMarketTimeV1;
+          const currentMarketEvidenceTime = (value) =>
+            validMarketTime(value) &&
+            Date.now() - Date.parse(value) <= 5 * 60_000;
+          const hasUnevidencedBitqueryFdv = (
+            value,
+            depth = 0,
+            seen = new Set(),
+          ) => {
+            if (depth > 12) return true;
+            if (value === null || typeof value !== "object") return false;
+            if (seen.has(value)) return true;
+            seen.add(value);
+            if (Array.isArray(value)) {
+              return value.some((entry) =>
+                hasUnevidencedBitqueryFdv(entry, depth + 1, seen)
+              );
+            }
+            if (
+              value.fdvUsdWad !== undefined ||
+              value.marketCapUsdWad !== undefined ||
+              (value.metric === "fdv" &&
+                (value.status === "available" ||
+                  value.valueUsdWad !== undefined))
+            ) return true;
+            return Object.values(value).some((entry) =>
+              hasUnevidencedBitqueryFdv(entry, depth + 1, seen)
+            );
+          };
 
           const requestJson = async (path, contract) => {
             let lastError;
@@ -729,6 +844,9 @@ jobs:
                 const marketAsOf = response.headers.get(
                   "x-programmable-market-as-of",
                 );
+                const valuationBlock = response.headers.get(
+                  "x-programmable-valuation-block",
+                );
                 const dataQuality = response.headers.get(
                   "x-programmable-data-quality",
                 );
@@ -755,6 +873,7 @@ jobs:
                     marketAsOf,
                     marketSource,
                     priceSource,
+                    valuationBlock,
                   }),
                   enumerable: false,
                 });
@@ -769,25 +888,236 @@ jobs:
             throw lastError ?? new Error(`${path} failed`);
           };
 
+          const exactCurrentPublicFdvLiquidity = (token) => {
+            const tokenAddress = token?.tokenAddress?.toLowerCase();
+            const valuation = token?.valuation;
+            const market = token?.marketData;
+            const primary = market?.pools?.find(
+              (pool) => sameBytes32(
+                pool?.identity?.poolId,
+                market?.primaryPoolId,
+              ),
+            );
+            const price = valuation?.priceEvidence;
+            const quote = price?.ethUsdQuote;
+            const liquidity = token?.liquidityEvidence;
+            const provenance = liquidity?.provenance;
+            if (
+              !exactAddress(tokenAddress) ||
+              tokenAddress === goldenTokenAddress ||
+              valuation?.status !== "available" ||
+              valuation.metric !== "fdv" ||
+              valuation.supplyBasis !== "total" ||
+              valuation.currency !== "usd" ||
+              valuation.source !== "stateview-chainlink" ||
+              valuation.freshness !== "current" ||
+              !positiveInteger(valuation.valueWad) ||
+              token.fdvUsdWad !== valuation.valueWad ||
+              !positiveInteger(valuation.asOfBlock) ||
+              !exactBytes32(valuation.asOfBlockHash) ||
+              !currentMarketEvidenceTime(valuation.asOfTime) ||
+              valuation.lagBlocks !== "0" ||
+              price?.schemaVersion !==
+                "programmable.stateview-chainlink-price-evidence.v1" ||
+              price?.source !== "uniswap-v4-stateview-chainlink-v1" ||
+              price.chainId !== "1" ||
+              !sameAddress(price.tokenAddress, tokenAddress) ||
+              !sameAddress(price.quoteAddress, nativeCurrency) ||
+              !sameBytes32(price.poolId, market?.primaryPoolId) ||
+              price.stateViewAddress?.toLowerCase() !== mainnetStateView ||
+              price.stateViewRuntimeCodeHash !==
+                mainnetStateViewRuntimeCodeHash ||
+              price.blockNumber !== valuation.asOfBlock ||
+              !sameBytes32(price.blockHash, valuation.asOfBlockHash) ||
+              !exactUnixTimestamp(price.blockTimestamp) ||
+              price.blockTime !== valuation.asOfTime ||
+              price.blockTime !==
+                new Date(
+                  Number(BigInt(price.blockTimestamp)) * 1_000,
+                ).toISOString() ||
+              !positiveInteger(price.sqrtPriceX96) ||
+              !positiveInteger(price.activeLiquidity) ||
+              !positiveInteger(price.activeVirtualToken0Wei) ||
+              !positiveInteger(price.activeVirtualLiquidityUsdWad) ||
+              price.activeVirtualLiquidityValueBasis !==
+                "stateview-active-liquidity-virtual-depth-usd" ||
+              !positiveInteger(price.tokenPriceEthWei) ||
+              !positiveInteger(price.tokenPriceUsdWad) ||
+              price.totalSupplyRaw !== token.totalSupplyRaw ||
+              price.tokenDecimals !== token.tokenDecimals ||
+              price.fdvUsdWad !== valuation.valueWad ||
+              quote?.feedAddress?.toLowerCase() !== mainnetEthUsdFeed ||
+              !positiveInteger(quote.roundId) ||
+              !positiveInteger(quote.answeredInRound) ||
+              BigInt(quote.answeredInRound) < BigInt(quote.roundId) ||
+              !positiveInteger(quote.answer) ||
+              quote.decimals !== 8 ||
+              !exactUnixTimestamp(quote.updatedAt) ||
+              quote.updatedAtTime !==
+                new Date(Number(BigInt(quote.updatedAt)) * 1_000).toISOString() ||
+              !positiveInteger(token.totalSupplyRaw) ||
+              !exactCanonicalClassicNativeToken(
+                token,
+                tokenAddress,
+                market?.primaryPoolId,
+              ) ||
+              !Number.isSafeInteger(token.tokenDecimals) ||
+              token.tokenDecimals < 0 ||
+              token.tokenDecimals > 255 ||
+              market?.schemaVersion !== "programmable.market-data.v1" ||
+              market.source !== "bitquery" ||
+              market.status !== "current" ||
+              !currentMarketTime(market.generatedAt) ||
+              !exactBytes32(market.primaryPoolId) ||
+              !sameBytes32(token.poolId, market.primaryPoolId) ||
+              primary?.identity?.chainId !== "1" ||
+              !sameAddress(primary.identity.tokenAddress, tokenAddress) ||
+              !sameBytes32(primary.identity.poolId, market.primaryPoolId) ||
+              primary.identity.protocol !== "uniswap_v4" ||
+              primary.source !== "bitquery" ||
+              primary.status !== "current" ||
+              hasUnevidencedBitqueryFdv(market) ||
+              liquidity?.source !== "official-uniswap-v4-subgraph" ||
+              liquidity.identity?.chainId !== "1" ||
+              liquidity.identity.protocol !== "uniswap_v4" ||
+              !sameBytes32(liquidity.identity.poolId, market.primaryPoolId) ||
+              !sameAddress(liquidity.identity.tokenAddress, tokenAddress) ||
+              !sameAddress(
+                liquidity.identity.quoteAddress,
+                price.quoteAddress,
+              ) ||
+              liquidity.valueBasis !== "official-subgraph-pool-tvl-usd" ||
+              !sameAddress(
+                liquidity.reportedPoolBalances?.token0?.address,
+                price.quoteAddress,
+              ) ||
+              !sameAddress(
+                liquidity.reportedPoolBalances?.token1?.address,
+                tokenAddress,
+              ) ||
+              !Number.isSafeInteger(
+                liquidity.reportedPoolBalances.token0.decimals,
+              ) ||
+              liquidity.reportedPoolBalances.token0.decimals !== 18 ||
+              !Number.isSafeInteger(
+                liquidity.reportedPoolBalances.token1.decimals,
+              ) ||
+              liquidity.reportedPoolBalances.token1.decimals !==
+                token.tokenDecimals ||
+              !unsignedDecimal(
+                liquidity.reportedPoolBalances.token0.amountDecimal,
+              ) ||
+              !unsignedDecimal(
+                liquidity.reportedPoolBalances.token1.amountDecimal,
+              ) ||
+              (!positiveDecimal(
+                  liquidity.reportedPoolBalances.token0.amountDecimal,
+                ) &&
+                !positiveDecimal(
+                  liquidity.reportedPoolBalances.token1.amountDecimal,
+                )) ||
+              !positiveInteger(liquidity.tvlUsdWad) ||
+              BigInt(liquidity.tvlUsdWad) <
+                minimumPublicFdvLiquidityUsdWad ||
+              liquidity.freshness !== "current" ||
+              provenance?.subgraphId !== officialV4SubgraphId ||
+              provenance?.deployment !== officialV4SubgraphDeployment ||
+              !positiveInteger(provenance.indexedBlockNumber) ||
+              !exactBytes32(provenance.indexedBlockHash) ||
+              !exactUnixTimestamp(provenance.indexedBlockTimestamp) ||
+              !currentMarketEvidenceTime(provenance.indexedBlockTime) ||
+              !positiveInteger(provenance.referenceHeadBlockNumber) ||
+              !exactBytes32(provenance.referenceHeadBlockHash) ||
+              !unsignedInteger(provenance.lagBlocks)
+            ) return false;
+
+            const valuationTimeSeconds = BigInt(
+              Math.floor(Date.parse(valuation.asOfTime) / 1_000),
+            );
+            const indexedBlock = BigInt(provenance.indexedBlockNumber);
+            const referenceBlock = BigInt(provenance.referenceHeadBlockNumber);
+            const indexedTimestamp = BigInt(provenance.indexedBlockTimestamp);
+            const feedUpdatedAt = BigInt(quote.updatedAt);
+            const lagBlocks = BigInt(provenance.lagBlocks);
+            const totalSupplyRaw = BigInt(token.totalSupplyRaw);
+            const sqrtPriceX96 = BigInt(price.sqrtPriceX96);
+            const activeLiquidity = BigInt(price.activeLiquidity);
+            const marketCapNativeWad =
+              (totalSupplyRaw * (1n << 192n) * 10n ** 18n) /
+              (sqrtPriceX96 * sqrtPriceX96 * 10n ** 18n);
+            const expectedFdvUsdWad =
+              (marketCapNativeWad * BigInt(quote.answer)) /
+              10n ** BigInt(quote.decimals);
+            const expectedTokenPriceEthWei =
+              ((1n << 192n) * 10n ** BigInt(token.tokenDecimals) *
+                10n ** 18n) /
+              (sqrtPriceX96 * sqrtPriceX96 * 10n ** 18n);
+            const expectedTokenPriceUsdWad =
+              (expectedTokenPriceEthWei * BigInt(quote.answer)) /
+              10n ** BigInt(quote.decimals);
+            const activeVirtualToken0Wei =
+              (activeLiquidity * (1n << 96n)) / sqrtPriceX96;
+            const expectedActiveVirtualLiquidityUsdWad =
+              (2n * activeVirtualToken0Wei * BigInt(quote.answer)) /
+              10n ** BigInt(quote.decimals);
+            return indexedBlock <= referenceBlock &&
+              valuation.asOfBlock === provenance.referenceHeadBlockNumber &&
+              sameBytes32(
+                valuation.asOfBlockHash,
+                provenance.referenceHeadBlockHash,
+              ) &&
+              lagBlocks === referenceBlock - indexedBlock &&
+              lagBlocks <= 64n &&
+              (lagBlocks !== 0n ||
+                sameBytes32(
+                  provenance.indexedBlockHash,
+                  provenance.referenceHeadBlockHash,
+                )) &&
+              provenance.indexedBlockTime ===
+                new Date(Number(indexedTimestamp) * 1_000).toISOString() &&
+              indexedTimestamp <= valuationTimeSeconds &&
+              feedUpdatedAt <= valuationTimeSeconds &&
+              valuationTimeSeconds - feedUpdatedAt <= 7_200n &&
+              expectedFdvUsdWad > 0n &&
+              expectedFdvUsdWad.toString() === valuation.valueWad &&
+              expectedTokenPriceEthWei.toString() ===
+                price.tokenPriceEthWei &&
+              expectedTokenPriceUsdWad.toString() ===
+                price.tokenPriceUsdWad &&
+              activeVirtualToken0Wei.toString() ===
+                price.activeVirtualToken0Wei &&
+              expectedActiveVirtualLiquidityUsdWad >=
+                minimumPublicFdvLiquidityUsdWad &&
+              expectedActiveVirtualLiquidityUsdWad.toString() ===
+                price.activeVirtualLiquidityUsdWad;
+          };
+
           const explore = await requestJson(
-            "/api/explore?limit=20&page=1&sort=market-cap",
-            bitqueryMarketContract,
+            `/api/explore?limit=${marketCapPageSize}&page=1&sort=market-cap`,
+            currentPublicMarketContract,
           );
+          const marketCapTotal = Number(explore.total);
+          const marketCapTotalPages = Number(explore.totalPages);
           if (
-            explore.status !== "ready" ||
-            !Array.isArray(explore.tokens) ||
-            explore.tokens.length < 1 ||
-            explore.tokens.length > 20
+            !Number.isSafeInteger(marketCapTotal) ||
+            marketCapTotal < 1 ||
+            marketCapTotal > maximumMarketCapTokens ||
+            !Number.isSafeInteger(marketCapTotalPages) ||
+            marketCapTotalPages !==
+              Math.ceil(marketCapTotal / marketCapPageSize)
           ) {
-            throw new Error("staged Bitquery Explore is not a populated bounded page");
+            throw new Error("staged global market-cap ranking is not bounded");
           }
-          const releaseToken = explore.tokens.find(
-            (token) =>
-              /^0x[0-9a-fA-F]{40}$/.test(token?.tokenAddress ?? ""),
-          );
-          if (!releaseToken) {
-            throw new Error("staged Bitquery Explore has no token identity");
+          const marketCapPages = [explore];
+          for (let pageNumber = 2; pageNumber <= marketCapTotalPages; pageNumber += 1) {
+            marketCapPages.push(await requestJson(
+              `/api/explore?limit=${marketCapPageSize}&page=${pageNumber}&sort=market-cap`,
+              publicMarketContract,
+            ));
           }
+          const marketCapTokens = [];
+          const seenMarketCapIds = new Set();
+          const seenMarketCapAddresses = new Set();
           let previousCurrentFdv = null;
           let currentFdvCount = 0;
           let availableFdvCount = 0;
@@ -795,7 +1125,113 @@ jobs:
           let waitingForFirstTradeCount = 0;
           let sawNonCurrentFdv = false;
           let currentFdvToken = null;
-          for (const token of explore.tokens) {
+          for (let pageIndex = 0; pageIndex < marketCapPages.length; pageIndex += 1) {
+            const page = marketCapPages[pageIndex];
+            const expectedPageLength = Math.min(
+              marketCapPageSize,
+              marketCapTotal - pageIndex * marketCapPageSize,
+            );
+            const valuationQuality = page.dataQuality?.valuation;
+            const pageCurrentTokens = Array.isArray(page.tokens)
+              ? page.tokens.filter((token) =>
+                  token?.valuation?.status === "available" &&
+                  token.valuation.source === "stateview-chainlink" &&
+                  token.valuation.freshness === "current"
+                )
+              : [];
+            if (
+              page.status !== "ready" ||
+              page.sort !== "market-cap" ||
+              page.page !== pageIndex + 1 ||
+              page.pageSize !== marketCapPageSize ||
+              page.total !== marketCapTotal ||
+              page.totalPages !== marketCapTotalPages ||
+              !Array.isArray(page.tokens) ||
+              page.tokens.length !== expectedPageLength ||
+              page.dataQuality?.schemaVersion !==
+                "programmable.explore-data-quality.v1" ||
+              page.__marketHeaders?.dataQuality !== page.dataQuality.status ||
+              !["complete", "partial", "stale"].includes(
+                page.dataQuality.status,
+              ) ||
+              valuationQuality?.metric !== "fdv" ||
+              !Number.isSafeInteger(valuationQuality.available) ||
+              !Number.isSafeInteger(valuationQuality.unavailable) ||
+              valuationQuality.available + valuationQuality.unavailable !==
+                page.tokens.length ||
+              !Number.isSafeInteger(valuationQuality.stale) ||
+              valuationQuality.stale < 0 ||
+              valuationQuality.stale > valuationQuality.available ||
+              valuationQuality.unknown !== 0 ||
+              page.__marketHeaders?.marketAsOf !==
+                (valuationQuality.asOfTime ?? null)
+            ) {
+              throw new Error(
+                "staged global market-cap ranking has missing or inconsistent pages",
+              );
+            }
+            if (pageCurrentTokens.length > 0) {
+              if (
+                page.__marketHeaders?.marketSource !==
+                  currentPublicMarketSource ||
+                page.__marketHeaders?.priceSource !==
+                  "stateview-chainlink" ||
+                page.__marketHeaders?.valuationBlock !==
+                  valuationQuality.asOfBlock ||
+                !positiveInteger(valuationQuality.asOfBlock) ||
+                !currentMarketEvidenceTime(valuationQuality.asOfTime) ||
+                pageCurrentTokens.some((token) =>
+                  token.valuation.asOfTime !== valuationQuality.asOfTime ||
+                  token.valuation.asOfBlock !== valuationQuality.asOfBlock
+                )
+              ) {
+                throw new Error(
+                  "staged current ranking page has inconsistent market provenance",
+                );
+              }
+            } else if (
+              page.__marketHeaders?.marketSource !== "bitquery" ||
+              ![null, "bitquery"].includes(
+                page.__marketHeaders?.priceSource,
+              ) ||
+              page.__marketHeaders?.valuationBlock !== null
+            ) {
+              throw new Error(
+                "staged non-current ranking page forged current market provenance",
+              );
+            }
+            for (const token of page.tokens) {
+              if (
+                typeof token?.id !== "string" ||
+                token.id.length === 0 ||
+                seenMarketCapIds.has(token.id)
+              ) {
+                throw new Error("staged global market-cap ranking is not unique");
+              }
+              seenMarketCapIds.add(token.id);
+              if (token?.tokenAddress !== undefined) {
+                if (typeof token.tokenAddress !== "string") {
+                  throw new Error("staged global market-cap token has no address");
+                }
+                const address = token.tokenAddress.toLowerCase();
+                if (!exactAddress(address) || seenMarketCapAddresses.has(address)) {
+                  throw new Error("staged global market-cap ranking repeats a token");
+                }
+                seenMarketCapAddresses.add(address);
+              }
+              marketCapTokens.push(token);
+            }
+          }
+          if (marketCapTokens.length !== marketCapTotal) {
+            throw new Error("staged global market-cap ranking is incomplete");
+          }
+          const releaseToken = marketCapTokens.find(
+            (token) => exactAddress(token?.tokenAddress?.toLowerCase?.()),
+          );
+          if (!releaseToken) {
+            throw new Error("staged Bitquery Explore has no token identity");
+          }
+          for (const token of marketCapTokens) {
             const valuation = token?.valuation;
             if (valuation?.status === "unavailable") {
               if (!unavailableValuationReasons.has(valuation.reason)) {
@@ -805,9 +1241,12 @@ jobs:
                 waitingForFirstTradeCount += 1;
               }
               sawNonCurrentFdv = true;
-              if (token?.fdvUsdWad !== undefined) {
+              if (
+                token?.fdvUsdWad !== undefined ||
+                hasUnevidencedBitqueryFdv(token?.marketData)
+              ) {
                 throw new Error(
-                  "staged Bitquery Explore exposed stale or unavailable FDV as current",
+                  "staged Bitquery Explore exposed unevidenced numeric FDV",
                 );
               }
               continue;
@@ -818,31 +1257,21 @@ jobs:
               valuation.supplyBasis !== "total" ||
               valuation.currency !== "usd" ||
               !["current", "stale"].includes(valuation.freshness) ||
-              valuation.source !== "bitquery" ||
               !positiveInteger(valuation.valueWad) ||
               !validMarketTime(valuation.asOfTime)
             ) {
               throw new Error("staged Bitquery Explore has an invalid typed FDV");
             }
             availableFdvCount += 1;
-            if (valuation.freshness === "stale") {
-              if (!boundedStaleMarketTime(valuation.asOfTime)) {
-                throw new Error("staged Bitquery Explore stale FDV is too old");
-              }
-              staleFdvCount += 1;
-              sawNonCurrentFdv = true;
-              if (token?.fdvUsdWad !== undefined) {
-                throw new Error(
-                  "staged Bitquery Explore exposed stale or unavailable FDV as current",
-                );
-              }
-              continue;
+            if (valuation.source === "bitquery") {
+              throw new Error(
+                "staged Bitquery Explore exposed unevidenced top-level FDV",
+              );
             }
-            if (token.fdvUsdWad !== valuation.valueWad) {
-              throw new Error("staged Bitquery Explore did not expose its current FDV");
-            }
-            if (!currentMarketTime(valuation.asOfTime)) {
-              throw new Error("staged Bitquery Explore mislabeled stale FDV as current");
+            if (!exactCurrentPublicFdvLiquidity(token)) {
+              throw new Error(
+                "staged public current FDV lacks exact StateView, Chainlink and official v4 liquidity evidence",
+              );
             }
             if (sawNonCurrentFdv) {
               throw new Error(
@@ -855,87 +1284,19 @@ jobs:
                 "staged Bitquery Highest FDV is not monotonically descending",
               );
             }
-            const tokenAddress = token?.tokenAddress?.toLowerCase();
-            const primary = token.marketData?.pools?.find(
-              (pool) => pool.identity?.poolId === token.marketData?.primaryPoolId,
-            );
-            if (
-              !/^0x[0-9a-f]{40}$/.test(tokenAddress ?? "") ||
-              tokenAddress === goldenTokenAddress ||
-              token.marketData?.schemaVersion !==
-                "programmable.market-data.v1" ||
-              token.marketData.source !== "bitquery" ||
-              !currentMarketTime(token.marketData.generatedAt) ||
-              !/^0x[0-9a-f]{64}$/.test(
-                token.marketData.primaryPoolId ?? "",
-              ) ||
-              !primary ||
-              primary.identity?.chainId !== "1" ||
-              primary.identity?.tokenAddress !== tokenAddress ||
-              primary.identity?.poolId !== token.marketData.primaryPoolId ||
-              primary.identity?.protocol !== "uniswap_v4" ||
-              primary.source !== "bitquery" ||
-              primary.status !== "current" ||
-              primary.liquidity?.freshness !== "current" ||
-              !positiveInteger(primary.liquidity?.valueUsdWad) ||
-              !positiveInteger(primary.liquidity?.asOfBlock) ||
-              primary.liquidity?.asOfTime !== valuation.asOfTime ||
-              !currentMarketTime(primary.liquidity?.asOfTime) ||
-              primary.valuation?.status !== "available" ||
-              primary.valuation.metric !== "fdv" ||
-              primary.valuation.supplyBasis !== "total" ||
-              primary.valuation.freshness !== "current" ||
-              primary.valuation.valueUsdWad !== valuation.valueWad ||
-              primary.valuation.asOfTime !== valuation.asOfTime
-            ) {
-              throw new Error(
-                "staged Bitquery current public FDV lacks exact primary-pool liquidity evidence",
-              );
-            }
             previousCurrentFdv = value;
             currentFdvCount += 1;
             currentFdvToken ??= token;
           }
-          const exploreMarketAsOf =
-            explore.dataQuality?.valuation?.asOfTime ?? null;
-          const valuationQuality = explore.dataQuality?.valuation;
-          if (
-            explore.dataQuality?.schemaVersion !==
-              "programmable.explore-data-quality.v1" ||
-            explore.__marketHeaders?.dataQuality !== explore.dataQuality.status ||
-            !["complete", "partial", "stale"].includes(
-              explore.dataQuality.status,
-            ) ||
-            valuationQuality?.metric !== "fdv" ||
-            !Number.isSafeInteger(valuationQuality.available) ||
-            !Number.isSafeInteger(valuationQuality.unavailable) ||
-            valuationQuality.available + valuationQuality.unavailable !==
-              explore.total ||
-            !Number.isSafeInteger(valuationQuality.stale) ||
-            valuationQuality.stale > valuationQuality.available ||
-            valuationQuality.unknown !== 0 ||
-            ![null, "bitquery"].includes(
-              explore.__marketHeaders?.priceSource ?? null,
-            ) ||
-            (currentFdvCount > 0 &&
-              explore.__marketHeaders?.priceSource !== "bitquery") ||
-            explore.__marketHeaders?.marketAsOf !== exploreMarketAsOf ||
-            (exploreMarketAsOf !== null &&
-              !boundedStaleMarketTime(exploreMarketAsOf))
-          ) {
-            throw new Error(
-              "staged Bitquery Explore has inconsistent market provenance",
-            );
-          }
           if (currentFdvCount < 1) {
             throw new Error(
-              "staged Bitquery market path has no current public non-PCAN FDV with exact primary-pool liquidity evidence",
+              "staged public market path has no current non-PCAN FDV bound to fresh official v4 liquidity",
             );
           }
           const newestPageSize = 100;
           const newest = await requestJson(
             `/api/explore?limit=${newestPageSize}&page=1&sort=newest`,
-            bitqueryMarketContract,
+            publicMarketContract,
           );
           const newestTotal = Number(newest.total);
           const newestTotalPages = Number(newest.totalPages);
@@ -962,7 +1323,7 @@ jobs:
               ? newest
               : await requestJson(
                    `/api/explore?limit=${newestPageSize}&page=${pageNumber}&sort=newest`,
-                   bitqueryMarketContract,
+                   publicMarketContract,
                  );
             if (
               page.status !== "ready" ||
@@ -1066,7 +1427,7 @@ jobs:
           }
           const oldest = await requestJson(
             `/api/explore?limit=${newestPageSize}&page=1&sort=oldest`,
-            bitqueryMarketContract,
+            publicMarketContract,
           );
           const expectedOldestIds = newestTokens
             .slice(-newestPageSize)
@@ -1086,7 +1447,7 @@ jobs:
             "0x468505087c2dfec4779f2d6a5f8481f03e32e905";
           const incrementalDetail = await requestJson(
             `/api/explore/token?address=${encodeURIComponent(incrementalLaunchAddress)}`,
-            bitqueryMarketContract,
+            publicMarketContract,
           );
           const incrementalLaunch = incrementalDetail.token;
           const incrementalLaunchBlock = BigInt(
@@ -1115,7 +1476,7 @@ jobs:
           }
           const tokenDetail = await requestJson(
             `/api/explore/token?address=${encodeURIComponent(releaseToken.tokenAddress)}`,
-            bitqueryMarketContract,
+            publicMarketContract,
           );
           if (
             tokenDetail.status !== "ready" ||
@@ -1127,31 +1488,207 @@ jobs:
           if (currentFdvToken !== null) {
             const currentFdvDetail = await requestJson(
               `/api/explore/token?address=${encodeURIComponent(currentFdvToken.tokenAddress)}`,
-              bitqueryMarketContract,
+              currentPublicMarketContract,
             );
+            const exploreValuationBlock = BigInt(
+              currentFdvToken.valuation.asOfBlock,
+            );
+            const detailValuationBlock = positiveInteger(
+                currentFdvDetail.token?.valuation?.asOfBlock,
+              )
+              ? BigInt(currentFdvDetail.token.valuation.asOfBlock)
+              : null;
+            const sameValuationSnapshot =
+              detailValuationBlock === exploreValuationBlock;
             if (
-              currentFdvDetail.token?.valuation?.status !== "available" ||
-              currentFdvDetail.token.valuation.metric !== "fdv" ||
-              currentFdvDetail.token.valuation.supplyBasis !== "total" ||
-              currentFdvDetail.token.valuation.freshness !== "current" ||
-              currentFdvDetail.token.valuation.valueWad !==
-                currentFdvToken.valuation.valueWad ||
-              currentFdvDetail.token.valuation.asOfTime !==
-                currentFdvToken.valuation.asOfTime ||
-              currentFdvDetail.token.fdvUsdWad !==
-                currentFdvToken.fdvUsdWad ||
+              currentFdvDetail.status !== "ready" ||
+              !exactCurrentPublicFdvLiquidity(currentFdvDetail.token) ||
+              !sameAddress(
+                currentFdvDetail.token?.tokenAddress,
+                currentFdvToken.tokenAddress,
+              ) ||
+              !sameAddress(
+                currentFdvDetail.token?.hookAddress,
+                currentFdvToken.hookAddress,
+              ) ||
+              currentFdvDetail.token?.launchModel !==
+                currentFdvToken.launchModel ||
+              currentFdvDetail.token?.liquidityPath !==
+                currentFdvToken.liquidityPath ||
+              !sameBytes32(
+                currentFdvDetail.token?.marketData?.primaryPoolId,
+                currentFdvToken.marketData.primaryPoolId,
+              ) ||
+              !sameAddress(
+                currentFdvDetail.token?.valuation?.priceEvidence?.quoteAddress,
+                currentFdvToken.valuation.priceEvidence.quoteAddress,
+              ) ||
+              detailValuationBlock === null ||
+              detailValuationBlock < exploreValuationBlock ||
+              Date.parse(currentFdvDetail.token.valuation.asOfTime) <
+                Date.parse(currentFdvToken.valuation.asOfTime) ||
+              (sameValuationSnapshot &&
+                (!sameBytes32(
+                    currentFdvDetail.token.valuation.asOfBlockHash,
+                    currentFdvToken.valuation.asOfBlockHash,
+                  ) ||
+                  JSON.stringify(currentFdvDetail.token.valuation) !==
+                    JSON.stringify(currentFdvToken.valuation) ||
+                  JSON.stringify(currentFdvDetail.token.liquidityEvidence) !==
+                    JSON.stringify(currentFdvToken.liquidityEvidence))) ||
               currentFdvDetail.__marketHeaders?.marketAsOf !==
                 currentFdvDetail.token.valuation.asOfTime ||
-              currentFdvDetail.__marketHeaders?.priceSource !== "bitquery"
+              currentFdvDetail.__marketHeaders?.valuationBlock !==
+                currentFdvDetail.token.valuation.asOfBlock ||
+              currentFdvDetail.__marketHeaders?.marketSource !==
+                currentPublicMarketSource ||
+              currentFdvDetail.__marketHeaders?.priceSource !==
+                "stateview-chainlink"
             ) {
               throw new Error(
-                "staged Bitquery current Explore and detail FDV are not identical",
+                "staged current detail does not independently prove an equal or newer evidence bundle",
               );
+            }
+            const independentCurrentProof =
+              await verifyCurrentPublicOnchainEvidenceV1({
+                token: currentFdvDetail.token,
+                rpcUrls: [
+                  process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
+                  process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
+                ],
+              });
+            if (
+              independentCurrentProof.schemaVersion !==
+                "programmable.current-market-independent-proof.v1" ||
+              independentCurrentProof.providerCount !== 2
+            ) {
+              throw new Error(
+                "staged current detail lacks two independent exact-block readers",
+              );
+            }
+            for (const range of ["1h", "1d", "1w", "all"]) {
+              const currentChart = await requestJson(
+                `/api/explore/token/chart?address=${encodeURIComponent(
+                  currentFdvToken.tokenAddress,
+                )}&range=${range}`,
+                bitqueryChartContract,
+              );
+              const chartPoints = currentChart.points;
+              if (
+                currentChart.schemaVersion !==
+                  "programmable.market-chart.v1" ||
+                currentChart.source !== "bitquery" ||
+                currentChart.readStatus !== "live" ||
+                !["ready", "insufficient-history"].includes(
+                  currentChart.status,
+                ) ||
+                currentChart.truncated !== false ||
+                currentChart.range !== range ||
+                !sameAddress(
+                  currentChart.address,
+                  currentFdvToken.tokenAddress,
+                ) ||
+                currentChart.identity?.chainId !== "1" ||
+                !sameAddress(
+                  currentChart.identity.tokenAddress,
+                  currentFdvToken.tokenAddress,
+                ) ||
+                !sameBytes32(
+                  currentChart.identity.poolId,
+                  currentFdvToken.marketData.primaryPoolId,
+                ) ||
+                !sameAddress(
+                  currentChart.identity.quoteAddress,
+                  currentFdvToken.valuation.priceEvidence.quoteAddress,
+                ) ||
+                currentChart.identity.protocol !== "uniswap_v4" ||
+                !Number.isSafeInteger(currentChart.swapCount) ||
+                currentChart.swapCount < 0 ||
+                !Array.isArray(chartPoints) ||
+                currentChart.valuation?.status !== "unavailable" ||
+                currentChart.valuation?.reason !== "source-unavailable" ||
+                "fdvUsdWad" in currentChart ||
+                "valuationMetric" in currentChart ||
+                currentChart.__marketHeaders?.priceSource !== "bitquery" ||
+                (currentChart.status === "ready"
+                  ? currentChart.swapCount <= 1 ||
+                    chartPoints.length < 2 ||
+                    currentChart.asOfTime !==
+                      chartPoints.at(-1)?.observedAt ||
+                    currentChart.__marketHeaders?.marketAsOf !==
+                      currentChart.asOfTime ||
+                    !currentMarketTime(currentChart.asOfTime)
+                  : currentChart.swapCount !== 1 ||
+                    chartPoints.length !== 1 ||
+                    currentChart.asOfTime !== chartPoints[0]?.observedAt ||
+                    currentChart.__marketHeaders?.marketAsOf !==
+                      currentChart.asOfTime ||
+                    !currentMarketTime(currentChart.asOfTime))
+              ) {
+                throw new Error(
+                  `staged current public ${range} chart is not live and untruncated`,
+                );
+              }
+              let previousTime = null;
+              let previousBucketEnd = null;
+              let previousBlock = null;
+              let observedTrades = 0;
+              for (const point of chartPoints) {
+                const pointTime = Date.parse(point?.time ?? "");
+                const bucketStart = Date.parse(point?.bucketStart ?? "");
+                const bucketEnd = Date.parse(point?.bucketEnd ?? "");
+                const observedAt = Date.parse(point?.observedAt ?? "");
+                const pointBlock = positiveInteger(point?.blockNumber)
+                  ? BigInt(point.blockNumber)
+                  : null;
+                if (
+                  !Number.isFinite(pointTime) ||
+                  point?.valueSemantics !== "period-median" ||
+                  !Number.isFinite(bucketStart) ||
+                  !Number.isFinite(bucketEnd) ||
+                  !Number.isFinite(observedAt) ||
+                  pointTime !== bucketEnd ||
+                  bucketStart >= bucketEnd ||
+                  observedAt < bucketStart ||
+                  observedAt > bucketEnd ||
+                  pointBlock === null ||
+                  !positiveDecimal(point?.priceQuote) ||
+                  typeof point?.quoteSymbol !== "string" ||
+                  point.quoteSymbol.trim().length === 0 ||
+                  point?.priceUsd !== undefined ||
+                  point?.ohlcUsd !== undefined ||
+                  point?.ohlcQuote !== undefined ||
+                  !Number.isSafeInteger(point?.tradeCount) ||
+                  point.tradeCount < 1 ||
+                  (previousTime !== null && pointTime <= previousTime) ||
+                  (previousBucketEnd !== null &&
+                    bucketStart < previousBucketEnd) ||
+                  (previousBlock !== null && pointBlock <= previousBlock)
+                ) {
+                  throw new Error(
+                    `staged current public ${range} chart is not strictly ordered`,
+                  );
+                }
+                observedTrades += point.tradeCount;
+                if (!Number.isSafeInteger(observedTrades)) {
+                  throw new Error(
+                    `staged current public ${range} chart trade count overflowed`,
+                  );
+                }
+                previousTime = pointTime;
+                previousBucketEnd = bucketEnd;
+                previousBlock = pointBlock;
+              }
+              if (observedTrades !== currentChart.swapCount) {
+                throw new Error(
+                  `staged current public ${range} chart trade count is inconsistent`,
+                );
+              }
             }
           }
           const goldenSearch = await requestJson(
             `/api/explore?limit=20&page=1&q=${goldenTokenAddress}&sort=market-cap`,
-            bitqueryMarketContract,
+            historicalBitqueryMarketContract,
           );
           if (
             goldenSearch.status !== "ready" ||
@@ -1165,7 +1702,7 @@ jobs:
           }
           const goldenDetail = await requestJson(
             `/api/explore/token?address=${goldenTokenAddress}`,
-            bitqueryMarketContract,
+            historicalBitqueryMarketContract,
           );
           const goldenMarket = goldenDetail.token?.marketData;
           const goldenPool = goldenMarket?.pools?.find(
@@ -1220,9 +1757,7 @@ jobs:
             (goldenValuation.freshness === "current"
               ? goldenDetail.__marketHeaders?.priceSource !== "bitquery"
               : goldenDetail.__marketHeaders?.priceSource !== null) ||
-            (goldenValuation.freshness === "current"
-              ? goldenDetail.token.fdvUsdWad !== goldenValuation.valueWad
-              : goldenDetail.token.fdvUsdWad !== undefined)
+            goldenDetail.token.fdvUsdWad !== undefined
           ) {
             throw new Error("staged PCAN market valuation is not Bitquery-bound");
           }
@@ -1238,23 +1773,35 @@ jobs:
             goldenChart.source !== "bitquery" ||
             goldenChart.readStatus !== "live" ||
             !currentMarketTime(goldenChart.generatedAt) ||
-            goldenChart.address?.toLowerCase() !== goldenTokenAddress ||
+            !sameAddress(goldenChart.address, goldenTokenAddress) ||
             goldenChart.identity?.chainId !== "1" ||
-            goldenChart.identity?.tokenAddress?.toLowerCase() !==
-              goldenTokenAddress ||
-            goldenChart.identity?.poolId !== goldenPoolId ||
-            goldenChart.identity?.quoteAddress !== goldenQuoteAddress ||
+            !sameAddress(
+              goldenChart.identity?.tokenAddress,
+              goldenTokenAddress,
+            ) ||
+            !sameBytes32(goldenChart.identity?.poolId, goldenPoolId) ||
+            !sameAddress(
+              goldenChart.identity?.quoteAddress,
+              goldenQuoteAddress,
+            ) ||
             goldenChart.identity?.protocol !== "uniswap_v4" ||
-            !["ready", "insufficient-history", "partial"].includes(
+            goldenChart.range !== "all" ||
+            !["ready", "insufficient-history"].includes(
               goldenChart.status,
             ) ||
             !Array.isArray(goldenChart.points) ||
-            goldenChart.points.length < 1 ||
+            !Number.isSafeInteger(goldenChart.swapCount) ||
+            goldenChart.swapCount < 1 ||
+            (goldenChart.status === "ready"
+              ? goldenChart.points.length < 2 || goldenChart.swapCount < 2
+              : goldenChart.points.length !== 1 ||
+                goldenChart.swapCount !== 1) ||
             goldenChart.valuation?.status !== "unavailable" ||
             goldenChart.valuation?.reason !== "source-unavailable" ||
             "fdvUsdWad" in goldenChart ||
             "valuationMetric" in goldenChart ||
             goldenChart.asOfTime !== goldenChart.points.at(-1)?.observedAt ||
+            goldenChart.truncated !== false ||
             goldenChart.__marketHeaders?.marketAsOf !== goldenChart.asOfTime ||
             goldenChart.__marketHeaders?.dataQuality !== goldenChart.status ||
             goldenChart.__marketHeaders?.priceSource !== "bitquery" ||
@@ -1263,7 +1810,9 @@ jobs:
             throw new Error("staged PCAN price history is not Bitquery-bound");
           }
           let previousChartTime = null;
+          let previousChartBucketEnd = null;
           let previousChartBlock = null;
+          let goldenObservedTrades = 0;
           for (const point of goldenChart.points) {
             const time = Date.parse(point?.time ?? "");
             const bucketStart = Date.parse(point?.bucketStart ?? "");
@@ -1272,8 +1821,6 @@ jobs:
             const block = positiveInteger(point?.blockNumber)
               ? BigInt(point.blockNumber)
               : null;
-            const price = point?.priceUsd ?? point?.priceQuote;
-            const numericPrice = Number(price);
             if (
               !Number.isFinite(time) ||
               point?.valueSemantics !== "period-median" ||
@@ -1285,17 +1832,33 @@ jobs:
               observedAt < bucketStart ||
               observedAt > bucketEnd ||
               block === null ||
-              !Number.isFinite(numericPrice) ||
-              numericPrice <= 0 ||
+              !positiveDecimal(point?.priceQuote) ||
+              typeof point?.quoteSymbol !== "string" ||
+              point.quoteSymbol.trim().length === 0 ||
+              point?.priceUsd !== undefined ||
+              point?.ohlcUsd !== undefined ||
+              point?.ohlcQuote !== undefined ||
+              !Number.isSafeInteger(point?.tradeCount) ||
+              point.tradeCount < 1 ||
               (previousChartTime !== null && time <= previousChartTime) ||
-              (previousChartBlock !== null && block < previousChartBlock)
+              (previousChartBucketEnd !== null &&
+                bucketStart < previousChartBucketEnd) ||
+              (previousChartBlock !== null && block <= previousChartBlock)
             ) {
               throw new Error(
                 "staged PCAN chart is not a strictly ordered positive history",
               );
             }
+            goldenObservedTrades += point.tradeCount;
+            if (!Number.isSafeInteger(goldenObservedTrades)) {
+              throw new Error("staged PCAN chart trade count overflowed");
+            }
             previousChartTime = time;
+            previousChartBucketEnd = bucketEnd;
             previousChartBlock = block;
+          }
+          if (goldenObservedTrades !== goldenChart.swapCount) {
+            throw new Error("staged PCAN chart trade count is inconsistent");
           }
           const historicalGoldenRelease =
             verifyBitqueryHistoricalGoldenReleaseV1({
@@ -1321,7 +1884,7 @@ jobs:
             goldenChart.__marketHeaders?.priceSource === "bitquery";
           process.stdout.write(
             `${JSON.stringify({
-              status: "verified-bitquery-staged-market-apis",
+              status: "verified-combined-staged-market-apis",
               tokenAddress: releaseToken.tokenAddress,
               goldenTokenAddress,
               goldenPoolId,
@@ -1339,14 +1902,14 @@ jobs:
           );
           NODE
 
-      - name: Record registry identity and Bitquery market path
+      - name: Record registry identity and combined market path
         if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.mode == 'alchemy-only'
         run: |
           {
             echo "## Read-model release policy"
             echo
             echo "Router and Registry remain the launch-identity authority."
-            echo "Explore, token detail and charts use verified Bitquery market data; token identities do not disappear when market data is unavailable."
+            echo "Current public FDV uses exact-block StateView and Chainlink evidence, liquidity uses the official Uniswap v4 subgraph, and Bitquery remains the trade, volume and chart source; token identities do not disappear when market data is unavailable."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Capture staged read-model evidence

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -617,6 +617,8 @@ jobs:
             "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
           const goldenPoolId =
             "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+          const goldenQuoteAddress =
+            "0x0000000000000000000000000000000000000000";
           const origin = new URL(process.env.STAGED_TARGET_URL);
           if (
             origin.protocol !== "https:" ||
@@ -1237,17 +1239,21 @@ jobs:
             goldenChart.readStatus !== "live" ||
             !currentMarketTime(goldenChart.generatedAt) ||
             goldenChart.address?.toLowerCase() !== goldenTokenAddress ||
+            goldenChart.identity?.chainId !== "1" ||
+            goldenChart.identity?.tokenAddress?.toLowerCase() !==
+              goldenTokenAddress ||
             goldenChart.identity?.poolId !== goldenPoolId ||
+            goldenChart.identity?.quoteAddress !== goldenQuoteAddress ||
+            goldenChart.identity?.protocol !== "uniswap_v4" ||
             !["ready", "insufficient-history", "partial"].includes(
               goldenChart.status,
             ) ||
             !Array.isArray(goldenChart.points) ||
             goldenChart.points.length < 1 ||
-            goldenChart.valuation?.metric !== "fdv" ||
-            goldenChart.valuation?.supplyBasis !== "total" ||
-            !["current", "stale"].includes(goldenChart.valuation?.freshness) ||
-            (goldenChart.valuation?.freshness === "current" &&
-              !currentMarketTime(goldenChart.valuation?.asOfTime)) ||
+            goldenChart.valuation?.status !== "unavailable" ||
+            goldenChart.valuation?.reason !== "source-unavailable" ||
+            "fdvUsdWad" in goldenChart ||
+            "valuationMetric" in goldenChart ||
             goldenChart.asOfTime !== goldenChart.points.at(-1)?.observedAt ||
             goldenChart.__marketHeaders?.marketAsOf !== goldenChart.asOfTime ||
             goldenChart.__marketHeaders?.dataQuality !== goldenChart.status ||

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1248,7 +1248,7 @@ jobs:
             !["current", "stale"].includes(goldenChart.valuation?.freshness) ||
             (goldenChart.valuation?.freshness === "current" &&
               !currentMarketTime(goldenChart.valuation?.asOfTime)) ||
-            goldenChart.asOfTime !== goldenChart.points.at(-1)?.time ||
+            goldenChart.asOfTime !== goldenChart.points.at(-1)?.observedAt ||
             goldenChart.__marketHeaders?.marketAsOf !== goldenChart.asOfTime ||
             goldenChart.__marketHeaders?.dataQuality !== goldenChart.status ||
             goldenChart.__marketHeaders?.priceSource !== "bitquery" ||
@@ -1260,6 +1260,9 @@ jobs:
           let previousChartBlock = null;
           for (const point of goldenChart.points) {
             const time = Date.parse(point?.time ?? "");
+            const bucketStart = Date.parse(point?.bucketStart ?? "");
+            const bucketEnd = Date.parse(point?.bucketEnd ?? "");
+            const observedAt = Date.parse(point?.observedAt ?? "");
             const block = positiveInteger(point?.blockNumber)
               ? BigInt(point.blockNumber)
               : null;
@@ -1267,6 +1270,14 @@ jobs:
             const numericPrice = Number(price);
             if (
               !Number.isFinite(time) ||
+              point?.valueSemantics !== "period-median" ||
+              !Number.isFinite(bucketStart) ||
+              !Number.isFinite(bucketEnd) ||
+              !Number.isFinite(observedAt) ||
+              time !== bucketEnd ||
+              bucketStart >= bucketEnd ||
+              observedAt < bucketStart ||
+              observedAt > bucketEnd ||
               block === null ||
               !Number.isFinite(numericPrice) ||
               numericPrice <= 0 ||

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import {
+  getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../lib/alchemy/explore.server";
+import { readVerifiedOperationalMarketSnapshot } from
+  "../../../lib/alchemy/live-market.server";
 import { suppressRouterBoundCustomProjectDuplicates } from "../../../lib/alchemy/router-custom-collision";
 import {
   createExploreConsumerSource,
@@ -13,10 +16,10 @@ import {
 } from "../../../lib/explore-consumer.server";
 import { canonicalTokenExploreEntryV1 } from "../../../lib/explore-entry-v1";
 import {
+  EXPLORE_MAXIMUM_STALE_VALUATION_AGE_MS,
   buildExploreDataQuality,
   publicExploreEntryV1,
   valuationSortValue,
-  withPublicExploreBitqueryMarketData,
   type ValuedExploreEntry,
 } from "../../../lib/explore-financial-data";
 import { readBitqueryTokenMarketDataV1 } from
@@ -25,8 +28,12 @@ import { hydrateMissingCanonicalTokenSupplyV1 } from
   "../../../lib/market-data/canonical-token-supply.server";
 import { exploreEntriesMarketIdentitiesV1 } from
   "../../../lib/market-data/explore-market-identities";
-import type { TokenMarketDataV1 } from
-  "../../../lib/market-data/market-data-v1";
+import {
+  CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
+  settleCurrentEvidenceSnapshot,
+  type CurrentEvidenceSnapshotOutcome,
+  valueExploreEntriesWithCurrentEvidence,
+} from "../../../lib/market-data/current-valuation.server";
 import { readExploreReferenceHeadWithinRouteBudget } from "../../../lib/explore-reference-head.server";
 import { getOnchainDeployment } from "../../../lib/onchain/config";
 import { readDurableExploreModel } from "../../../lib/onchain/durable-model";
@@ -54,7 +61,6 @@ const EXPLORE_QUERY_PARAMETERS = new Set([
   "socials",
   "sort",
 ]);
-const TOP_VALUATION_LIMIT = 20;
 const readCanonicalExploreSource = createExploreConsumerSource<ExploreReadModel>({});
 const readCustomExploreSource = createExploreConsumerSource<
   readonly CustomProjectExploreEntry[]
@@ -130,6 +136,10 @@ function integerQuery(value: string | null, fallback: number) {
 function positiveInteger(value: number, fallback: number, maximum: number) {
   if (!Number.isSafeInteger(value) || value < 1) return fallback;
   return Math.min(value, maximum);
+}
+
+function requiresCompleteCurrentValuation(sort: ExploreSort): boolean {
+  return sort === "market-cap" || sort === "market-cap-asc";
 }
 
 function entryLaunchTime(entry: ExploreEntry): number {
@@ -297,30 +307,6 @@ export function dedupeExploreEntriesV1(
   return output;
 }
 
-function valueExploreEntriesWithMarketData(
-  entries: readonly ExploreEntry[],
-  marketByToken: ReadonlyMap<string, TokenMarketDataV1>,
-  nowMs: number,
-): ValuedExploreEntry[] {
-  return entries.map((entry) => {
-    const address = entry.tokenAddress?.toLowerCase();
-    const marketData = address ? marketByToken.get(address) : undefined;
-    if (marketData) {
-      return withPublicExploreBitqueryMarketData(entry, marketData, nowMs);
-    }
-    return {
-      ...entry,
-      valuation: {
-        status: "unavailable" as const,
-        reason:
-          entry.exploreKind === "custom-project" && entry.markets.length === 0
-            ? "no-market" as const
-            : "source-unavailable" as const,
-      },
-    };
-  });
-}
-
 function hasVerifiedBitqueryPrice(entries: readonly ValuedExploreEntry[]): boolean {
   return entries.some((entry) => {
     const primary = entry.marketData?.pools.find(
@@ -389,19 +375,10 @@ export function paginateExploreEntriesV1(
     query: string;
     socials: "yes" | "no" | null;
     sort: ExploreSort;
-    topThenNewest: boolean;
   }>,
 ) {
   const filtered = filterExploreEntries(entries, input.query, input.socials);
-  if (!input.topThenNewest) {
-    return paginateEntries(sortExploreEntries(filtered, input.sort), input);
-  }
-  const top = sortExploreEntries(filtered, "market-cap")
-    .slice(0, TOP_VALUATION_LIMIT);
-  const topIds = new Set(top.map(({ id }) => id));
-  const newest = sortExploreEntries(filtered, "newest")
-    .filter(({ id }) => !topIds.has(id));
-  return paginateEntries([...top, ...newest], input);
+  return paginateEntries(sortExploreEntries(filtered, input.sort), input);
 }
 
 async function valueExplorePage(input: Readonly<{
@@ -414,48 +391,50 @@ async function valueExplorePage(input: Readonly<{
     sort: ExploreSort;
   }>;
   signal: AbortSignal;
+  deployment: ReturnType<typeof getAlchemyOnchainDeployment>;
+  operationalSnapshot: Promise<CurrentEvidenceSnapshotOutcome>;
+  currentEvidenceDeadlineAt: number;
 }>) {
   const requiresGlobalMarketRanking =
-    input.options.sort === "market-cap" ||
-    input.options.sort === "market-cap-asc";
+    requiresCompleteCurrentValuation(input.options.sort);
   const identityPage = requiresGlobalMarketRanking
     ? null
     : paginateExploreEntriesV1(input.identityEntries, {
         ...input.options,
         query: "",
         socials: null,
-        topThenNewest: false,
       });
   const entriesToValue = identityPage?.tokens ?? input.identityEntries;
-  const [hydratedEntries, marketByToken] = await Promise.all([
-    hydrateMissingCanonicalTokenSupplyV1(entriesToValue),
-    readBitqueryTokenMarketDataV1(
-      exploreEntriesMarketIdentitiesV1(entriesToValue),
-      { signal: input.signal },
-    ),
-  ]);
-  const valuedEntries = valueExploreEntriesWithMarketData(
-    hydratedEntries,
-    marketByToken,
-    Date.now(),
+  const marketByToken = readBitqueryTokenMarketDataV1(
+    exploreEntriesMarketIdentitiesV1(entriesToValue),
+    { signal: input.signal },
   );
+  const hydratedEntries = await hydrateMissingCanonicalTokenSupplyV1(
+    entriesToValue,
+  );
+  const valuedEntries = await valueExploreEntriesWithCurrentEvidence({
+    entries: hydratedEntries,
+    marketByToken,
+    deployment: input.deployment.status === "ready" ? input.deployment : null,
+    operationalSnapshot: input.operationalSnapshot,
+    maximumValuationAgeMs: EXPLORE_MAXIMUM_STALE_VALUATION_AGE_MS,
+    now: new Date(),
+    requireCompleteLiquidityCoverage:
+      requiresCompleteCurrentValuation(input.options.sort),
+    timeoutMs: Math.max(0, input.currentEvidenceDeadlineAt - Date.now()),
+  });
   if (identityPage !== null) {
     return {
       entries: valuedEntries,
       paginated: { ...identityPage, tokens: valuedEntries },
     };
   }
-  const useTopValuationView =
-    input.options.sort === "market-cap" &&
-    input.options.query.length === 0 &&
-    input.options.socials === null;
   return {
     entries: valuedEntries,
     paginated: paginateExploreEntriesV1(valuedEntries, {
       ...input.options,
       query: "",
       socials: null,
-      topThenNewest: useTopValuationView,
     }),
   };
 }
@@ -495,6 +474,25 @@ export async function GET(request: NextRequest) {
       readCustomExploreSource({
         primary: () => readProductionCustomExploreDirectoryV1(request.signal),
       }),
+    );
+    const deployment = getAlchemyOnchainDeployment();
+    const currentEvidenceDeadlineAt =
+      Date.now() + CURRENT_EVIDENCE_ROUTE_DEADLINE_MS;
+    const requireCompleteCurrentValuation =
+      requiresCompleteCurrentValuation(options.sort);
+    const operationalSnapshotRead = deployment.status === "ready"
+      ? settleCurrentEvidenceSnapshot({
+          read: readVerifiedOperationalMarketSnapshot(deployment),
+          requireComplete: requireCompleteCurrentValuation,
+          timeoutMs: CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
+        })
+      : Promise.resolve(null);
+    // Attach a rejection handler immediately; global ranking rethrows the
+    // settled error inside the valuation orchestrator rather than leaking an
+    // unhandled promise while identity reads complete.
+    const operationalSnapshotOutcome = operationalSnapshotRead.then(
+      (value) => ({ status: "fulfilled" as const, value }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
     );
     const [
       canonicalAttempt,
@@ -541,14 +539,26 @@ export async function GET(request: NextRequest) {
       identityEntries: requestedIdentityEntries,
       options,
       signal: request.signal,
+      deployment,
+      operationalSnapshot: operationalSnapshotOutcome,
+      currentEvidenceDeadlineAt,
     });
     const pageEntries = paginated.tokens as ValuedExploreEntry[];
+    const currentOnchainEntry = pageEntries.find(
+      (entry) => entry.valuation.status === "available" &&
+        entry.valuation.source === "stateview-chainlink" &&
+        entry.valuation.freshness === "current",
+    );
+    const currentOnchainValuation =
+      currentOnchainEntry?.valuation.status === "available"
+        ? currentOnchainEntry.valuation
+        : null;
 
     const sourceAges = [canonicalSource?.ageMs, customSource?.ageMs].filter(
       (value): value is number => value !== undefined,
     );
     const dataQuality = buildExploreDataQuality({
-      entries,
+      entries: pageEntries,
       canonicalStatus: canonicalSource?.status ?? "unavailable",
       customStatus: customSource?.status ?? "unavailable",
       identityAsOfBlock,
@@ -617,19 +627,27 @@ export async function GET(request: NextRequest) {
           "Cache-Control":
             exploreResponseCacheControl({
               dataQuality,
-              entries,
+              entries: pageEntries,
               status: page.status,
             }),
           "X-Programmable-Data-Quality": dataQuality.status,
-          "X-Programmable-Market-Source": "bitquery",
+          "X-Programmable-Market-Source": currentOnchainValuation
+            ? "stateview-chainlink+official-uniswap-v4-subgraph+bitquery"
+            : "bitquery",
           ...(dataQuality.valuation.asOfTime
             ? {
                 "X-Programmable-Market-As-Of":
                   dataQuality.valuation.asOfTime,
               }
             : {}),
-          ...(hasVerifiedBitqueryPrice(entries)
-            ? { "X-Programmable-Price-Source": "bitquery" }
+          ...(currentOnchainValuation?.status === "available"
+            ? {
+                "X-Programmable-Price-Source": "stateview-chainlink",
+                "X-Programmable-Valuation-Block":
+                  currentOnchainValuation.asOfBlock ?? "",
+              }
+            : hasVerifiedBitqueryPrice(pageEntries)
+              ? { "X-Programmable-Price-Source": "bitquery" }
             : {}),
           ...sourceHeaders,
         },

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -13,14 +13,10 @@ import {
 } from "../../../../../lib/explore-consumer.server";
 import { canonicalTokenExploreEntryV1 } from
   "../../../../../lib/explore-entry-v1";
-import { withBitqueryMarketData } from
-  "../../../../../lib/explore-financial-data";
 import {
   readBitqueryMarketChartV1,
   readBitqueryTokenMarketDataV1,
 } from "../../../../../lib/market-data/bitquery.server";
-import { hydrateMissingCanonicalTokenSupplyV1 } from
-  "../../../../../lib/market-data/canonical-token-supply.server";
 import { exploreEntryMarketIdentitiesV1 } from
   "../../../../../lib/market-data/explore-market-identities";
 import type { MarketChartV1, MarketValuationV1 } from
@@ -57,9 +53,7 @@ function chartResponseCacheControl(chart: MarketChartV1): string {
   const hasReusableHistory =
     chart.status === "ready" || chart.status === "insufficient-history";
   return chart.readStatus === "live" &&
-      hasReusableHistory &&
-      chart.valuation.status === "available" &&
-      chart.valuation.freshness === "current"
+      hasReusableHistory
     ? REUSABLE_CHART_CACHE_CONTROL
     : "no-store";
 }
@@ -188,64 +182,34 @@ export async function GET(request: NextRequest) {
         "Price history is unavailable for this market",
       );
     }
-    const entryPromise = hydrateMissingCanonicalTokenSupplyV1([
-      unresolvedEntry,
-    ]).then((entries) => entries[0] ?? unresolvedEntry);
     let chart: MarketChartV1;
     if (identities.length === 1) {
       const identity = identities[0];
-      const [entry, marketByToken, chartRead] = await Promise.all([
-        entryPromise,
-        readBitqueryTokenMarketDataV1(identities, {
-          signal: request.signal,
-        }),
-        readBitqueryMarketChartV1({
-          identity,
-          range,
-          historyStart: unresolvedEntry.launchedAt,
-          valuation: UNAVAILABLE_CANONICAL_VALUATION,
-          signal: request.signal,
-        }),
-      ]);
-      const marketDataRead = marketByToken.get(address.toLowerCase());
-      const marketData = marketDataRead
-        ? withBitqueryMarketData(entry, marketDataRead).marketData
-        : undefined;
-      const primaryMarket = marketData?.pools.find(
-        (candidate) => candidate.identity.poolId === identity.poolId,
-      );
-      chart = {
-        ...chartRead,
-        valuation:
-          chartRead.readStatus === "live" && chartRead.points.length > 0
-            ? primaryMarket?.valuation ?? UNAVAILABLE_CANONICAL_VALUATION
-            : chartRead.valuation,
-      };
-    } else {
-      const [entry, marketByToken] = await Promise.all([
-        entryPromise,
-        readBitqueryTokenMarketDataV1(identities, {
-          signal: request.signal,
-        }),
-      ]);
-      const marketDataRead = marketByToken.get(address.toLowerCase());
-      const marketData = marketDataRead
-        ? withBitqueryMarketData(entry, marketDataRead).marketData
-        : undefined;
-      const identity = identities.find(
-        (candidate) => candidate.poolId === marketData?.primaryPoolId,
-      ) ?? identities[0];
-      const primaryMarket = marketData?.pools.find(
-        (candidate) => candidate.identity.poolId === identity.poolId,
-      );
       chart = await readBitqueryMarketChartV1({
         identity,
         range,
         historyStart: unresolvedEntry.launchedAt,
-        valuation: primaryMarket?.valuation ?? UNAVAILABLE_CANONICAL_VALUATION,
+        signal: request.signal,
+      });
+    } else {
+      const marketByToken = await readBitqueryTokenMarketDataV1(identities, {
+        signal: request.signal,
+      });
+      const marketDataRead = marketByToken.get(address.toLowerCase());
+      const identity = identities.find(
+        (candidate) => candidate.poolId === marketDataRead?.primaryPoolId,
+      ) ?? identities[0];
+      chart = await readBitqueryMarketChartV1({
+        identity,
+        range,
+        historyStart: unresolvedEntry.launchedAt,
         signal: request.signal,
       });
     }
+    chart = {
+      ...chart,
+      valuation: UNAVAILABLE_CANONICAL_VALUATION,
+    };
     if (chart.status === "unavailable") {
       return unavailable(
         address,
@@ -256,9 +220,6 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const fdvUsdWad = chart.valuation.status === "available"
-      ? chart.valuation.fdvUsdWad
-      : undefined;
     const hasVerifiedPrice = chart.points.some(
       (point) => point.priceUsd !== undefined || point.priceQuote !== undefined,
     );
@@ -266,10 +227,6 @@ export async function GET(request: NextRequest) {
       {
         ...chart,
         address,
-        ...(fdvUsdWad ? { fdvUsdWad } : {}),
-        valuationMetric: chart.valuation.status === "available"
-          ? chart.valuation.metric
-          : null,
       },
       {
         headers: {

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -202,6 +202,7 @@ export async function GET(request: NextRequest) {
         readBitqueryMarketChartV1({
           identity,
           range,
+          historyStart: unresolvedEntry.launchedAt,
           valuation: UNAVAILABLE_CANONICAL_VALUATION,
           signal: request.signal,
         }),
@@ -240,6 +241,7 @@ export async function GET(request: NextRequest) {
       chart = await readBitqueryMarketChartV1({
         identity,
         range,
+        historyStart: unresolvedEntry.launchedAt,
         valuation: primaryMarket?.valuation ?? UNAVAILABLE_CANONICAL_VALUATION,
         signal: request.signal,
       });

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -2,9 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
 import {
+  getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../../lib/alchemy/explore.server";
+import { readVerifiedOperationalMarketSnapshot } from
+  "../../../../lib/alchemy/live-market.server";
 import { suppressRouterBoundCustomProjectDuplicates } from "../../../../lib/alchemy/router-custom-collision";
 import {
   createExploreConsumerSource,
@@ -16,7 +19,6 @@ import { canonicalTokenExploreEntryV1 } from "../../../../lib/explore-entry-v1";
 import {
   buildExploreDataQuality,
   publicExploreEntryV1,
-  withBitqueryMarketData,
   type ValuedExploreEntry,
 } from "../../../../lib/explore-financial-data";
 import { readBitqueryTokenMarketDataV1 } from
@@ -25,6 +27,11 @@ import { hydrateMissingCanonicalTokenSupplyV1 } from
   "../../../../lib/market-data/canonical-token-supply.server";
 import { exploreEntryMarketIdentitiesV1 } from
   "../../../../lib/market-data/explore-market-identities";
+import {
+  CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
+  settleCurrentEvidenceSnapshot,
+  valueExploreEntriesWithCurrentEvidence,
+} from "../../../../lib/market-data/current-valuation.server";
 import type { TokenMarketDataV1 } from
   "../../../../lib/market-data/market-data-v1";
 import { readExploreReferenceHeadWithinRouteBudget } from "../../../../lib/explore-reference-head.server";
@@ -110,6 +117,16 @@ export async function GET(request: NextRequest) {
 
   try {
     const address = getAddress(input);
+    const deployment = getAlchemyOnchainDeployment();
+    const currentEvidenceDeadlineAt =
+      Date.now() + CURRENT_EVIDENCE_ROUTE_DEADLINE_MS;
+    const operationalSnapshotRead = deployment.status === "ready"
+      ? settleCurrentEvidenceSnapshot({
+          read: readVerifiedOperationalMarketSnapshot(deployment),
+          requireComplete: false,
+          timeoutMs: CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
+        })
+      : Promise.resolve(null);
     const [
       canonicalAttempt,
       customAttempt,
@@ -202,41 +219,34 @@ export async function GET(request: NextRequest) {
     const unresolvedIdentityEntry = token
       ? canonicalTokenExploreEntryV1(token)
       : customProject ?? null;
-    const [identityEntry, marketByToken] = unresolvedIdentityEntry
-      ? await Promise.all([
-          hydrateMissingCanonicalTokenSupplyV1([
-            unresolvedIdentityEntry,
-          ]).then((entries) => entries[0] ?? unresolvedIdentityEntry),
-          readBitqueryTokenMarketDataV1(
-            exploreEntryMarketIdentitiesV1(unresolvedIdentityEntry),
-            { signal: request.signal },
-          ),
-        ])
-      : [null, new Map<string, TokenMarketDataV1>()] as const;
-    const marketData = identityEntry?.tokenAddress
-      ? marketByToken.get(identityEntry.tokenAddress.toLowerCase())
-      : undefined;
-    const primaryMarket = marketData?.pools.find(
-      (pool) => pool.identity.poolId === marketData.primaryPoolId,
+    const marketByToken = unresolvedIdentityEntry
+      ? readBitqueryTokenMarketDataV1(
+          exploreEntryMarketIdentitiesV1(unresolvedIdentityEntry),
+          { signal: request.signal },
+        )
+      : Promise.resolve(new Map<string, TokenMarketDataV1>());
+    const identityEntry = unresolvedIdentityEntry
+      ? await hydrateMissingCanonicalTokenSupplyV1([
+          unresolvedIdentityEntry,
+        ]).then((entries) => entries[0] ?? unresolvedIdentityEntry)
+      : null;
+    const valuedEntry: ValuedExploreEntry | null = identityEntry
+      ? (await valueExploreEntriesWithCurrentEvidence({
+          entries: [identityEntry],
+          marketByToken,
+          deployment: deployment.status === "ready" ? deployment : null,
+          operationalSnapshot: operationalSnapshotRead,
+          now: new Date(),
+          allowHistoricalBitqueryFallback: true,
+          timeoutMs: Math.max(0, currentEvidenceDeadlineAt - Date.now()),
+        }))[0] ?? null
+      : null;
+    const primaryMarket = valuedEntry?.marketData?.pools.find(
+      (pool) => pool.identity.poolId === valuedEntry.marketData?.primaryPoolId,
     );
     const hasVerifiedPrice = primaryMarket?.status === "current" &&
       (primaryMarket.latestTrade?.priceUsdWad !== undefined ||
         primaryMarket.latestTrade?.priceQuoteWad !== undefined);
-    const valuedEntry: ValuedExploreEntry | null = identityEntry
-      ? marketData
-        ? withBitqueryMarketData(identityEntry, marketData)
-        : {
-            ...identityEntry,
-            valuation: {
-              status: "unavailable",
-              reason:
-                identityEntry.exploreKind === "custom-project" &&
-                    identityEntry.markets.length === 0
-                  ? "no-market"
-                  : "source-unavailable",
-            },
-          }
-      : null;
     const valuedToken = valuedEntry?.exploreKind === "token"
       ? valuedEntry
       : null;
@@ -263,6 +273,12 @@ export async function GET(request: NextRequest) {
     const publicValuedCustomProject = valuedCustomProject
       ? publicExploreEntryV1(valuedCustomProject)
       : null;
+    const currentOnchainValuation =
+      valuedEntry?.valuation.status === "available" &&
+        valuedEntry.valuation.source === "stateview-chainlink" &&
+        valuedEntry.valuation.freshness === "current"
+        ? valuedEntry.valuation
+        : null;
     const status = "ready" as const;
     return NextResponse.json(
       {
@@ -285,15 +301,23 @@ export async function GET(request: NextRequest) {
               ? "public, max-age=0, s-maxage=2, stale-while-revalidate=5"
               : "public, max-age=0, s-maxage=30",
           "X-Programmable-Data-Quality": dataQuality.status,
-          "X-Programmable-Market-Source": "bitquery",
+          "X-Programmable-Market-Source": currentOnchainValuation
+            ? "stateview-chainlink+official-uniswap-v4-subgraph+bitquery"
+            : "bitquery",
           ...(dataQuality.valuation.asOfTime
             ? {
                 "X-Programmable-Market-As-Of":
                   dataQuality.valuation.asOfTime,
               }
             : {}),
-          ...(hasVerifiedPrice
-            ? { "X-Programmable-Price-Source": "bitquery" }
+          ...(currentOnchainValuation
+            ? {
+                "X-Programmable-Price-Source": "stateview-chainlink",
+                "X-Programmable-Valuation-Block":
+                  currentOnchainValuation.asOfBlock ?? "",
+              }
+            : hasVerifiedPrice
+              ? { "X-Programmable-Price-Source": "bitquery" }
             : {}),
           ...sourceHeaders,
         },

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -25,7 +25,6 @@ import {
 import {
   TokenPriceChart,
   preloadTokenChart,
-  type TokenChartFdv,
   type TokenChartVolume,
 } from "@/components/token-price-chart";
 import { CustomMarketTrade } from "@/components/custom-market-trade";
@@ -1219,7 +1218,6 @@ function TokenDetailContent({
   const [copied, setCopied] = useState(false);
   const [copyError, setCopyError] = useState("");
   const [chartVolume, setChartVolume] = useState<TokenChartVolume | null>(null);
-  const [chartFdv, setChartFdv] = useState<TokenChartFdv | null>(null);
   const [tradeFlow, setTradeFlow] = useState<TradeFlow>({
     phase: "form",
   });
@@ -1257,14 +1255,10 @@ function TokenDetailContent({
   const metrics = useMemo(() => {
     return buildTokenDetailMetrics(
       token,
-      chartFdv
-        ? (formatUsdWadAmount(chartFdv.fdvUsdWad) ??
-          formatEth(chartFdv.fdvEth, "amount") ??
-          "Unavailable")
-        : null,
+      null,
       buildChartVolumeMetric(chartVolume),
     );
-  }, [chartFdv, chartVolume, token]);
+  }, [chartVolume, token]);
 
   const explorerBase =
     chainId === 1
@@ -1564,7 +1558,6 @@ function TokenDetailContent({
               launchModel={classicTradeLaunchModel}
               preview={preview}
               onVolumeChange={setChartVolume}
-              onFdvChange={setChartFdv}
             />
             <MetricGrid metrics={metrics} />
           </div>

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -32,34 +32,6 @@ export type TokenChartPoint = {
   quoteSymbol?: string;
 };
 
-export type TokenChartDataQuality = Readonly<{
-  schemaVersion: "programmable.explore-chart-data-quality.v1";
-  status: "current" | "partial";
-  asOfBlock: string;
-  blockHash: `0x${string}`;
-  finality: "confirmed" | "latest";
-  history: Readonly<{ status: "current"; throughBlock: string }>;
-  price: Readonly<{
-    status: "current" | "stale";
-    asOfBlock: string;
-    lagBlocks: string;
-  }>;
-  valuation:
-    | Readonly<{
-        status: "current";
-        metric: "fdv";
-        asOfBlock: string;
-        lagBlocks: "0";
-      }>
-    | Readonly<{
-        status: "stale";
-        metric: "fdv";
-        asOfBlock: string;
-        lagBlocks: string;
-      }>
-    | Readonly<{ status: "unavailable"; metric: "fdv" }>;
-}>;
-
 export type TokenChartPayload = {
   status:
     | "ready"
@@ -71,11 +43,6 @@ export type TokenChartPayload = {
   volumeWei?: string;
   volumeEth?: string;
   volumeUsdWad?: string;
-  fdvEthWei?: string;
-  fdvEth?: string;
-  fdvUsdWad?: string;
-  valuationMetric?: "market-cap" | "fdv";
-  dataQuality?: TokenChartDataQuality;
   marketData?: MarketChartV1;
 };
 type ChartPayload = TokenChartPayload;
@@ -98,143 +65,6 @@ export type TokenChartVolume = {
   volumeEth?: string;
   volumeUsdWad?: string;
 };
-export type TokenChartFdv = {
-  fdvEthWei?: string;
-  fdvEth?: string;
-  fdvUsdWad?: string;
-};
-
-type PositiveDecimal = {
-  coefficient: bigint;
-  scale: bigint;
-};
-
-function parsePositiveDecimal(value?: string): PositiveDecimal | null {
-  if (!value) return null;
-  const match = /^(\d+)(?:\.(\d+))?$/.exec(value.trim());
-  if (!match) return null;
-  const fraction = match[2] ?? "";
-  const coefficient = BigInt(`${match[1]}${fraction}`);
-  if (coefficient <= 0n) return null;
-  return {
-    coefficient,
-    scale: 10n ** BigInt(fraction.length),
-  };
-}
-
-function scaleIntegerByPriceRatio(
-  value: string | undefined,
-  inspectedPrice: string | undefined,
-  latestPrice: string | undefined,
-) {
-  if (!value || !/^\d+$/.test(value)) return undefined;
-  const inspected = parsePositiveDecimal(inspectedPrice);
-  const latest = parsePositiveDecimal(latestPrice);
-  if (!inspected || !latest) return undefined;
-  const scaled =
-    (BigInt(value) * inspected.coefficient * latest.scale) /
-    (latest.coefficient * inspected.scale);
-  return scaled > 0n ? scaled.toString() : undefined;
-}
-
-function formatFixedInteger(value: bigint, decimals: number) {
-  const raw = value.toString().padStart(decimals + 1, "0");
-  const whole = raw.slice(0, -decimals);
-  const fraction = raw.slice(-decimals).replace(/0+$/, "");
-  return fraction ? `${whole}.${fraction}` : whole;
-}
-
-function scaleDecimalByPriceRatio(
-  value: string | undefined,
-  inspectedPrice: string | undefined,
-  latestPrice: string | undefined,
-) {
-  const source = parsePositiveDecimal(value);
-  const inspected = parsePositiveDecimal(inspectedPrice);
-  const latest = parsePositiveDecimal(latestPrice);
-  if (!source || !inspected || !latest) return undefined;
-  const precision = 18;
-  const numerator =
-    source.coefficient *
-    inspected.coefficient *
-    latest.scale *
-    10n ** BigInt(precision);
-  const denominator =
-    source.scale * inspected.scale * latest.coefficient;
-  const scaled = numerator / denominator;
-  return scaled > 0n ? formatFixedInteger(scaled, precision) : undefined;
-}
-
-export function getChartFdvAtPoint(
-  payload: TokenChartPayload,
-  inspectedPoint?: TokenChartPoint,
-  latestPoint?: TokenChartPoint,
-): TokenChartFdv {
-  if (inspectedPoint?.valueSemantics === "period-median") return {};
-  if (!inspectedPoint || !latestPoint || inspectedPoint === latestPoint) {
-    return {
-      fdvEthWei: payload.fdvEthWei,
-      fdvEth: payload.fdvEth,
-      fdvUsdWad: payload.fdvUsdWad,
-    };
-  }
-
-  const ethPrice = exactEthChartPricePair(inspectedPoint, latestPoint);
-  const usdPrice = exactChartPricePair(
-    inspectedPoint.priceUsd,
-    latestPoint.priceUsd,
-  );
-
-  const fdvEthWei = scaleIntegerByPriceRatio(
-    payload.fdvEthWei,
-    ethPrice?.inspected,
-    ethPrice?.latest,
-  );
-  const fdvEth = fdvEthWei
-    ? formatFixedInteger(BigInt(fdvEthWei), 18)
-    : scaleDecimalByPriceRatio(
-        payload.fdvEth,
-        ethPrice?.inspected,
-        ethPrice?.latest,
-      );
-  const fdvUsdWad = scaleIntegerByPriceRatio(
-    payload.fdvUsdWad,
-    usdPrice?.inspected,
-    usdPrice?.latest,
-  );
-
-  return {
-    ...(fdvEthWei === undefined ? {} : { fdvEthWei }),
-    ...(fdvEth === undefined ? {} : { fdvEth }),
-    ...(fdvUsdWad === undefined ? {} : { fdvUsdWad }),
-  };
-}
-
-function exactChartPricePair(
-  inspected: string | undefined,
-  latest: string | undefined,
-): Readonly<{ inspected: string; latest: string }> | null {
-  return inspected && latest ? { inspected, latest } : null;
-}
-
-function exactEthChartPricePair(
-  inspected: TokenChartPoint,
-  latest: TokenChartPoint,
-): Readonly<{ inspected: string; latest: string }> | null {
-  const direct = exactChartPricePair(inspected.priceEth, latest.priceEth);
-  if (direct) return direct;
-  const inspectedQuote = inspected.quoteSymbol?.trim().toUpperCase();
-  const latestQuote = latest.quoteSymbol?.trim().toUpperCase();
-  if (
-    inspectedQuote &&
-    latestQuote &&
-    ["ETH", "WETH"].includes(inspectedQuote) &&
-    ["ETH", "WETH"].includes(latestQuote)
-  ) {
-    return exactChartPricePair(inspected.priceQuote, latest.priceQuote);
-  }
-  return null;
-}
 type ChartLaunchModel = "classic" | "adaptive" | "deep" | "stock-paired";
 
 const chartPayloadCache = new Map<
@@ -263,256 +93,26 @@ export function isAuthoritativeChartPayloadStatus(status: unknown) {
   );
 }
 
-function isUnsignedIntegerString(value: unknown): value is string {
-  return typeof value === "string" && /^\d+$/.test(value);
-}
-
-function isCanonicalUnsignedIntegerString(value: unknown): value is string {
-  return typeof value === "string" && /^(?:0|[1-9]\d*)$/.test(value);
-}
-
-function isUnsignedDecimalString(value: unknown): value is string {
-  return (
-    typeof value === "string" &&
-    /^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value)
-  );
-}
-
-function isPositiveDecimalString(value: unknown): value is string {
-  if (!isUnsignedDecimalString(value)) return false;
-  const [whole, fraction = ""] = value.split(".");
-  return BigInt(`${whole}${fraction}`) > 0n;
-}
-
-function hasOptionalUnsignedInteger(value: unknown) {
-  return value === undefined || isUnsignedIntegerString(value);
-}
-
-function hasOptionalPositiveUnsignedInteger(value: unknown) {
-  return (
-    value === undefined ||
-    (isUnsignedIntegerString(value) && BigInt(value) > 0n)
-  );
-}
-
-function hasOptionalPositiveDecimal(value: unknown) {
-  return value === undefined || isPositiveDecimalString(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isBytes32(value: unknown): value is `0x${string}` {
-  return typeof value === "string" && /^0x[0-9a-f]{64}$/iu.test(value);
-}
-
-function parseChartDataQuality(value: unknown): TokenChartDataQuality | null {
-  if (!isRecord(value)) return null;
-  if (
-    value.schemaVersion !== "programmable.explore-chart-data-quality.v1" ||
-    (value.status !== "current" && value.status !== "partial") ||
-    !isCanonicalUnsignedIntegerString(value.asOfBlock) ||
-    !isBytes32(value.blockHash) ||
-    BigInt(value.blockHash) === 0n ||
-    (value.finality !== "confirmed" && value.finality !== "latest") ||
-    !isRecord(value.history) ||
-    value.history.status !== "current" ||
-    value.history.throughBlock !== value.asOfBlock ||
-    !isRecord(value.price) ||
-    !isCanonicalUnsignedIntegerString(value.price.asOfBlock) ||
-    !isCanonicalUnsignedIntegerString(value.price.lagBlocks) ||
-    !isRecord(value.valuation) ||
-    value.valuation.metric !== "fdv"
-  ) {
-    return null;
-  }
-
-  const snapshotBlock = BigInt(value.asOfBlock);
-  const priceBlock = BigInt(value.price.asOfBlock);
-  const priceLag = BigInt(value.price.lagBlocks);
-  if (value.price.status === "current") {
-    if (priceBlock !== snapshotBlock || priceLag !== 0n) return null;
-  } else if (value.price.status === "stale") {
-    if (
-      value.status !== "partial" ||
-      priceBlock >= snapshotBlock ||
-      priceLag === 0n ||
-      snapshotBlock - priceBlock !== priceLag
-    ) {
-      return null;
-    }
-  } else {
-    return null;
-  }
-
-  if (value.valuation.status === "current") {
-    if (
-      value.status !== "current" ||
-      value.valuation.asOfBlock !== value.asOfBlock ||
-      value.valuation.lagBlocks !== "0"
-    ) {
-      return null;
-    }
-  } else if (value.valuation.status === "stale") {
-    if (
-      value.status !== "partial" ||
-      !isCanonicalUnsignedIntegerString(value.valuation.asOfBlock) ||
-      !isCanonicalUnsignedIntegerString(value.valuation.lagBlocks)
-    ) {
-      return null;
-    }
-    const asOfBlock = BigInt(value.asOfBlock);
-    const valuationBlock = BigInt(value.valuation.asOfBlock);
-    const lagBlocks = BigInt(value.valuation.lagBlocks);
-    if (
-      valuationBlock >= asOfBlock ||
-      lagBlocks === 0n ||
-      asOfBlock - valuationBlock !== lagBlocks
-    ) {
-      return null;
-    }
-  } else if (
-    value.valuation.status !== "unavailable" ||
-    value.status !== "partial"
-  ) {
-    return null;
-  }
-
-  return value as TokenChartDataQuality;
-}
-
-function hasValidChartCardinality(
-  status: TokenChartPayload["status"],
-  pointCount: number,
-) {
-  return status === "ready"
-    ? pointCount >= 2
-    : status === "insufficient-history"
-      ? pointCount === 1
-      : status === "partial"
-        ? pointCount >= 1
-        : status === "waiting-for-first-trade" && pointCount === 0;
-}
-
-function hasValidChartPointBlocks(
-  points: TokenChartPoint[],
-  asOfBlock: string,
-  priceAsOfBlock: string,
-) {
-  const snapshotBlock = BigInt(asOfBlock);
-  let previousBlock: bigint | null = null;
-  for (const point of points) {
-    const currentBlock = BigInt(point.blockNumber);
-    if (
-      currentBlock > snapshotBlock ||
-      (previousBlock !== null && currentBlock <= previousBlock)
-    ) {
-      return false;
-    }
-    previousBlock = currentBlock;
-  }
-  return previousBlock === BigInt(priceAsOfBlock);
-}
-
-function withoutNonCurrentFdv(payload: ChartPayload): ChartPayload {
-  if (
-    payload.marketData?.valuation.status === "available" &&
-    payload.marketData.valuation.freshness === "current"
-  ) return payload;
-  if (payload.dataQuality?.valuation.status === "current") return payload;
-  const sanitized = { ...payload };
-  delete sanitized.fdvEthWei;
-  delete sanitized.fdvEth;
-  delete sanitized.fdvUsdWad;
-  return sanitized;
-}
-
 export function parseAuthoritativeChartPayload(
   value: unknown,
 ): ChartPayload | null {
-  if (isMarketChartV1(value)) {
-    if (value.status === "unavailable") return null;
-    const fdvUsdWad = value.valuation.status === "available"
-      ? value.valuation.fdvUsdWad
-      : undefined;
-    return withoutNonCurrentFdv({
-      status: value.status,
-      points: [...value.points],
-      swapCount: value.swapCount,
-      ...(value.volumeUsdWad ? { volumeUsdWad: value.volumeUsdWad } : {}),
-      ...(fdvUsdWad ? { fdvUsdWad } : {}),
-      ...(value.valuation.status === "available"
-        ? { valuationMetric: value.valuation.metric }
-        : {}),
-      marketData: value,
-    });
-  }
-  if (!isRecord(value)) return null;
   if (
-    "marketCapEthWei" in value ||
-    "marketCapEth" in value ||
-    "marketCapUsdWad" in value ||
-    value.valuationMetric !== "fdv"
-  ) {
-    return null;
-  }
-  const dataQuality = parseChartDataQuality(value.dataQuality);
-  if (dataQuality === null) return null;
-  const payload = value as Partial<ChartPayload>;
-  if (
-    !isAuthoritativeChartPayloadStatus(payload.status) ||
-    !Array.isArray(payload.points) ||
-    !hasValidChartCardinality(payload.status, payload.points.length) ||
-    !Number.isSafeInteger(payload.swapCount) ||
-    (payload.swapCount ?? -1) < 0 ||
-    !isUnsignedIntegerString(payload.volumeWei) ||
-    !isUnsignedDecimalString(payload.volumeEth) ||
-    !hasOptionalUnsignedInteger(payload.volumeUsdWad) ||
-    !hasOptionalPositiveUnsignedInteger(payload.fdvEthWei) ||
-    !hasOptionalPositiveDecimal(payload.fdvEth) ||
-    !hasOptionalPositiveUnsignedInteger(payload.fdvUsdWad) ||
-    !payload.points.every(
-      (point) =>
-        isRecord(point) &&
-        isCanonicalUnsignedIntegerString(point.blockNumber) &&
-        (point.priceEth === undefined ||
-          isPositiveDecimalString(point.priceEth)) &&
-        (point.priceUsd === undefined ||
-          isPositiveDecimalString(point.priceUsd)) &&
-        (point.priceQuote === undefined ||
-          isPositiveDecimalString(point.priceQuote)) &&
-        (isPositiveDecimalString(point.priceUsd) ||
-          isPositiveDecimalString(point.priceEth) ||
-          isPositiveDecimalString(point.priceQuote)),
-    )
-  ) {
-    return null;
-  }
-  const points = payload.points as TokenChartPoint[];
-  if (
-    !hasValidChartPointBlocks(
-      points,
-      dataQuality.asOfBlock,
-      dataQuality.price.asOfBlock,
-    )
+    !isMarketChartV1(value) ||
+    value.status === "unavailable" ||
+    value.valuation.status !== "unavailable" ||
+    value.valuation.reason !== "source-unavailable" ||
+    "fdvEthWei" in value ||
+    "fdvEth" in value ||
+    "fdvUsdWad" in value ||
+    "valuationMetric" in value
   ) return null;
-
-  return withoutNonCurrentFdv({
-    status: payload.status,
-    points,
-    swapCount: payload.swapCount as number,
-    volumeWei: payload.volumeWei as string,
-    volumeEth: payload.volumeEth as string,
-    ...(payload.volumeUsdWad === undefined
-      ? {}
-      : { volumeUsdWad: payload.volumeUsdWad }),
-    ...(payload.fdvEthWei === undefined ? {} : { fdvEthWei: payload.fdvEthWei }),
-    ...(payload.fdvEth === undefined ? {} : { fdvEth: payload.fdvEth }),
-    ...(payload.fdvUsdWad === undefined ? {} : { fdvUsdWad: payload.fdvUsdWad }),
-    valuationMetric: "fdv",
-    dataQuality,
-  });
+  return {
+    status: value.status,
+    points: [...value.points],
+    swapCount: value.swapCount,
+    ...(value.volumeUsdWad ? { volumeUsdWad: value.volumeUsdWad } : {}),
+    marketData: value,
+  };
 }
 
 export function isAuthoritativeChartPayload(
@@ -539,7 +139,7 @@ export function acceptChartPayload(
   key: string,
   payload: ChartPayload,
 ): ChartRequestState {
-  return { key, payload: withoutNonCurrentFdv(payload), failed: false };
+  return { key, payload, failed: false };
 }
 
 async function requestTokenChartPayload(
@@ -869,14 +469,12 @@ export function TokenPriceChart({
   launchModel,
   preview = false,
   onVolumeChange,
-  onFdvChange,
 }: {
   tokenAddress: `0x${string}`;
   tokenName: string;
   launchModel?: ChartLaunchModel;
   preview?: boolean;
   onVolumeChange?: (volume: TokenChartVolume | null) => void;
-  onFdvChange?: (fdv: TokenChartFdv | null) => void;
 }) {
   const [request, setRequest] = useState<ChartRequestState | null>(null);
   const [range, setRange] = useState<ChartRange>("1d");
@@ -967,11 +565,7 @@ export function TokenPriceChart({
   const chart = useMemo(() => {
     return payload ? createChartGeometry(payload.points) : null;
   }, [payload]);
-  const hasLimitedHistory =
-    payload?.status === "partial" && (
-      payload.marketData !== undefined ||
-      payload.dataQuality?.price.status === "stale"
-    );
+  const hasLimitedHistory = payload?.status === "partial";
 
   const emptyMessage = getPriceHistoryEmptyMessage(
     launchModel,
@@ -986,15 +580,6 @@ export function TokenPriceChart({
     (point) => point.valueSemantics === "period-median",
   ) ?? false;
   const displayedPrice = activePoint?.value ?? chart?.latestValue;
-  const inspectedFdv = useMemo(() => {
-    if (!payload) return null;
-    const latestPoint = chart?.points.at(-1);
-    return getChartFdvAtPoint(
-      payload,
-      activePoint ?? undefined,
-      latestPoint,
-    );
-  }, [activePoint, chart, payload]);
   const chartStatus =
     !payload && !failed
       ? "Loading price history"
@@ -1031,10 +616,6 @@ export function TokenPriceChart({
       volumeUsdWad: payload.volumeUsdWad,
     });
   }, [failed, launchModel, onVolumeChange, payload, range]);
-
-  useEffect(() => {
-    onFdvChange?.(inspectedFdv);
-  }, [inspectedFdv, onFdvChange]);
 
   function inspectPointer(event: PointerEvent<HTMLDivElement>) {
     if (!chart) return;

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -22,6 +22,10 @@ import styles from "./token-price-chart.module.css";
 export type TokenChartPoint = {
   blockNumber: string;
   time?: string;
+  bucketStart?: string;
+  bucketEnd?: string;
+  observedAt?: string;
+  valueSemantics?: "period-median";
   priceEth?: string;
   priceUsd?: string;
   priceQuote?: string;
@@ -166,6 +170,7 @@ export function getChartFdvAtPoint(
   inspectedPoint?: TokenChartPoint,
   latestPoint?: TokenChartPoint,
 ): TokenChartFdv {
+  if (inspectedPoint?.valueSemantics === "period-median") return {};
   if (!inspectedPoint || !latestPoint || inspectedPoint === latestPoint) {
     return {
       fdvEthWei: payload.fdvEthWei,
@@ -697,6 +702,23 @@ function formatPrice(value: number, unit: string) {
 }
 
 function chartPointContext(point: TokenChartPoint): string {
+  if (
+    point.valueSemantics === "period-median" &&
+    point.bucketStart &&
+    point.bucketEnd &&
+    Number.isFinite(Date.parse(point.bucketStart)) &&
+    Number.isFinite(Date.parse(point.bucketEnd))
+  ) {
+    const formatter = new Intl.DateTimeFormat("en", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "UTC",
+      timeZoneName: "short",
+    });
+    return `Period median, ${formatter.format(new Date(point.bucketStart))} to ${formatter.format(new Date(point.bucketEnd))}`;
+  }
   if (point.time && Number.isFinite(Date.parse(point.time))) {
     return new Intl.DateTimeFormat("en", {
       month: "short",
@@ -775,7 +797,7 @@ export function createChartGeometry(points: readonly TokenChartPoint[]) {
         (PLOT_BOTTOM - PLOT_TOP),
   }));
   const path = singlePoint ? "" : linePath(plottedPoints);
-  const last = plottedPoints.at(-1)?.value ?? plottedPoints[0].value;
+  const latestValue = plottedPoints.at(-1)?.value ?? plottedPoints[0].value;
 
   return {
     unit,
@@ -784,7 +806,7 @@ export function createChartGeometry(points: readonly TokenChartPoint[]) {
     areaPath: path
       ? `${path} L${PLOT_RIGHT},${VIEWBOX_HEIGHT} L${PLOT_LEFT},${VIEWBOX_HEIGHT} Z`
       : "",
-    current: last,
+    latestValue,
   } as const;
 }
 
@@ -960,13 +982,16 @@ export function TokenPriceChart({
     chart && activePointIndex !== null
       ? chart.points[Math.min(activePointIndex, chart.points.length - 1)]
       : null;
-  const displayedPrice = activePoint?.value ?? chart?.current;
+  const usesPeriodMedians = chart?.points.every(
+    (point) => point.valueSemantics === "period-median",
+  ) ?? false;
+  const displayedPrice = activePoint?.value ?? chart?.latestValue;
   const inspectedFdv = useMemo(() => {
     if (!payload) return null;
     const latestPoint = chart?.points.at(-1);
     return getChartFdvAtPoint(
       payload,
-      activePoint ?? latestPoint,
+      activePoint ?? undefined,
       latestPoint,
     );
   }, [activePoint, chart, payload]);
@@ -975,10 +1000,14 @@ export function TokenPriceChart({
       ? "Loading price history"
       : chart
         ? chart.points.length === 1
-          ? hasLimitedHistory
-            ? "Last verified price loaded from 1 point"
-            : "Current price loaded from 1 point"
-          : `Price history loaded with ${chart.points.length} points`
+          ? usesPeriodMedians
+            ? "One period median loaded"
+            : hasLimitedHistory
+              ? "Last verified price loaded from 1 point"
+              : "Current price loaded from 1 point"
+          : usesPeriodMedians
+            ? `Price history loaded with ${chart.points.length} period medians`
+            : `Price history loaded with ${chart.points.length} points`
         : emptyMessage;
 
   useEffect(() => {
@@ -1058,14 +1087,17 @@ export function TokenPriceChart({
         {chartStatus}
       </span>
       <span className="sr-only" id={instructionId}>
-        Use the left and right arrow keys to inspect each recorded price. Press
-        Home or End for the first or latest point, and Escape to return to the
-        latest price.
+        Use the left and right arrow keys to inspect each chart value. Press
+        Home or End for the first or last value, and Escape to stop inspecting.
       </span>
       <div className={styles.header}>
         <div>
           <p className={styles.eyebrow}>
-            {hasLimitedHistory ? "Last verified price" : "Price"}
+            {usesPeriodMedians
+              ? "Median price"
+              : hasLimitedHistory
+                ? "Last verified price"
+                : "Price"}
           </p>
           <p className={styles.value}>
             {chart && displayedPrice !== undefined
@@ -1108,7 +1140,7 @@ export function TokenPriceChart({
           className={styles.plot}
           role="group"
           tabIndex={0}
-          aria-label={`${tokenName} interactive price chart. Move the pointer or use arrow keys to inspect exact prices.`}
+          aria-label={`${tokenName} interactive price chart. Move the pointer or use arrow keys to inspect chart values.`}
           aria-describedby={`${instructionId} ${activeValueId}`}
           onBlur={() => setActivePointIndex(null)}
           onFocus={(event) => {

--- a/lib/alchemy/live-market.server.ts
+++ b/lib/alchemy/live-market.server.ts
@@ -14,7 +14,10 @@ import {
   marketCapNativeWadFromSqrtPriceX96,
   nativePriceWadFromSqrtPriceX96,
 } from "../onchain/math";
-import { withOperationalRpcFailover } from "../onchain/operational-rpc-failover.server";
+import {
+  OperationalRpcUnavailableError,
+  withOperationalRpcFailover,
+} from "../onchain/operational-rpc-failover.server";
 import { readOperationalRpcHealth } from "../onchain/rpc-health";
 import type { ExploreSnapshot, ReadyOnchainDeployment } from "../onchain/types";
 import {
@@ -37,6 +40,7 @@ type LivePoolState = Readonly<{
   lpFeePips: number;
   activeLiquidity: bigint;
   blockNumber: bigint;
+  blockHash: Hex;
 }>;
 
 const livePoolStateCache = new Map<
@@ -64,6 +68,7 @@ function trimPoolStateCache() {
 }
 
 const NATIVE_CURRENCY = "0x0000000000000000000000000000000000000000";
+const Q96 = 1n << 96n;
 const ethUsdReadAbi = parseAbi([
   "function decimals() view returns (uint8)",
   "function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)",
@@ -126,6 +131,8 @@ function validValuationToken(token: LauncherToken) {
 
 function withoutNativeValuation(token: LauncherToken): LauncherToken {
   const withoutValuation = { ...token };
+  delete withoutValuation.liveMarketStateEvidence;
+  delete withoutValuation.liveMarketPriceEvidence;
   delete withoutValuation.tokenPriceEth;
   delete withoutValuation.tokenPriceEthWei;
   delete withoutValuation.tokenPriceUsdWad;
@@ -150,6 +157,17 @@ function snapshotBlock(snapshot: ExploreSnapshot) {
   return BigInt(snapshot.blockNumber);
 }
 
+function unixTimestampIso(value: string): string | undefined {
+  if (!/^(?:0|[1-9]\d*)$/u.test(value)) return undefined;
+  try {
+    const seconds = BigInt(value);
+    if (seconds > 8_640_000_000_000n) return undefined;
+    return new Date(Number(seconds) * 1_000).toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * A launch-discovery snapshot may be newer than the durable market snapshot.
  * Never carry the durable ETH/USD quote across that block boundary: doing so
@@ -161,6 +179,7 @@ export function withoutUnboundEthUsdQuote(
 ): ExploreSnapshot {
   const withoutQuote = { ...snapshot };
   delete withoutQuote.ethUsdQuote;
+  delete withoutQuote.blockTimestamp;
   return withoutQuote;
 }
 
@@ -236,12 +255,19 @@ export async function withSameBlockEthUsdQuote(input: {
         answer,
         updatedAt,
       });
-      return { roundId, answer, decimals, updatedAt };
+      return {
+        roundId,
+        answer,
+        decimals,
+        updatedAt,
+        blockTimestamp: block.timestamp,
+      };
     },
   );
 
   return {
     ...snapshot,
+    blockTimestamp: quote.blockTimestamp.toString(),
     ethUsdQuote: {
       feedAddress: ETH_USD_FEED_ADDRESS,
       roundId: quote.roundId.toString(),
@@ -256,11 +282,13 @@ function poolStateCacheKey(input: {
   deployment: ReadyOnchainDeployment;
   blockNumber: bigint;
   poolId: string;
+  blockHash: Hex;
 }) {
   return [
     input.deployment.chainId,
     input.deployment.stateView.toLowerCase(),
     input.blockNumber.toString(),
+    input.blockHash.toLowerCase(),
     input.poolId.toLowerCase(),
   ].join(":");
 }
@@ -269,12 +297,21 @@ function applyLivePoolState(
   token: LauncherToken,
   state: LivePoolState | null,
   snapshot: ExploreSnapshot,
+  deployment: ReadyOnchainDeployment,
 ) {
   if (!validPoolStateToken(token)) return token;
   // Preserve a last-known-good valuation with its original indexed block. The
   // chart consumer treats that provenance as stale/partial and never relabels
   // it as the current snapshot while the live read is unavailable.
-  if (!state) return token;
+  if (!state) {
+    const withoutEvidence = { ...token };
+    delete withoutEvidence.liveMarketStateEvidence;
+    delete withoutEvidence.liveMarketPriceEvidence;
+    return withoutEvidence;
+  }
+  if (state.blockHash.toLowerCase() !== snapshot.blockHash.toLowerCase()) {
+    return withoutNativeValuation(token);
+  }
 
   const currentState = {
     // A successful live read starts a new, single-block valuation set. Never
@@ -284,9 +321,19 @@ function applyLivePoolState(
     activeLiquidity: state.activeLiquidity.toString(),
     protocolFeePips: state.protocolFeePips,
     lpFeePips: state.lpFeePips,
+    liveMarketStateEvidence: {
+      source: "uniswap-v4-stateview-v1",
+      blockNumber: state.blockNumber.toString(),
+      blockHash: state.blockHash,
+      sqrtPriceX96: state.sqrtPriceX96.toString(),
+      activeLiquidity: state.activeLiquidity.toString(),
+    },
   } satisfies LauncherToken;
   if (state.activeLiquidity <= 0n || !validValuationToken(token)) {
-    return withoutNativeValuation(currentState);
+    return {
+      ...withoutNativeValuation(currentState),
+      liveMarketStateEvidence: currentState.liveMarketStateEvidence,
+    };
   }
 
   const tokenDecimals = token.tokenDecimals as number;
@@ -313,6 +360,23 @@ function applyLivePoolState(
         snapshot.ethUsdQuote.decimals,
       )
     : undefined;
+  const activeVirtualToken0Wei =
+    (state.activeLiquidity * Q96) / state.sqrtPriceX96;
+  const activeVirtualLiquidityUsdWad = snapshot.ethUsdQuote
+    ? usdValueFromWei(
+        (2n * activeVirtualToken0Wei).toString(),
+        BigInt(snapshot.ethUsdQuote.answer),
+        snapshot.ethUsdQuote.decimals,
+      )
+    : undefined;
+  const blockTimestamp = snapshot.blockTimestamp;
+  const blockTime = blockTimestamp
+    ? unixTimestampIso(blockTimestamp)
+    : undefined;
+  const quoteUpdatedAt = snapshot.ethUsdQuote?.updatedAt;
+  const quoteUpdatedAtTime = quoteUpdatedAt
+    ? unixTimestampIso(quoteUpdatedAt)
+    : undefined;
 
   return {
     ...currentState,
@@ -327,6 +391,48 @@ function applyLivePoolState(
     ...(marketCapUsdWad === undefined
       ? {}
       : { fdvUsdWad: marketCapUsdWad.toString() }),
+    ...(tokenPriceUsdWad === undefined ||
+      marketCapUsdWad === undefined ||
+      activeVirtualLiquidityUsdWad === undefined ||
+      !snapshot.ethUsdQuote ||
+      !blockTimestamp ||
+      !blockTime ||
+      !quoteUpdatedAtTime ||
+      deployment.chainId !== 1
+      ? {}
+      : {
+          liveMarketPriceEvidence: {
+            schemaVersion:
+              "programmable.stateview-chainlink-price-evidence.v1",
+            source: "uniswap-v4-stateview-chainlink-v1",
+            chainId: "1",
+            poolId: token.poolId,
+            tokenAddress: token.tokenAddress,
+            quoteAddress: NATIVE_CURRENCY,
+            stateViewAddress: deployment.stateView,
+            stateViewRuntimeCodeHash: deployment.stateViewRuntimeCodeHash,
+            blockNumber: state.blockNumber.toString(),
+            blockHash: snapshot.blockHash,
+            blockTimestamp,
+            blockTime,
+            sqrtPriceX96: state.sqrtPriceX96.toString(),
+            activeLiquidity: state.activeLiquidity.toString(),
+            activeVirtualToken0Wei: activeVirtualToken0Wei.toString(),
+            activeVirtualLiquidityUsdWad:
+              activeVirtualLiquidityUsdWad.toString(),
+            activeVirtualLiquidityValueBasis:
+              "stateview-active-liquidity-virtual-depth-usd",
+            tokenPriceEthWei: tokenPriceEthWei.toString(),
+            tokenPriceUsdWad: tokenPriceUsdWad.toString(),
+            totalSupplyRaw: totalSupplyRaw.toString(),
+            tokenDecimals,
+            fdvUsdWad: marketCapUsdWad.toString(),
+            ethUsdQuote: {
+              ...snapshot.ethUsdQuote,
+              updatedAtTime: quoteUpdatedAtTime,
+            },
+          },
+        }),
   } satisfies LauncherToken;
 }
 
@@ -347,6 +453,7 @@ export async function enrichTokensWithAlchemyPoolState(input: {
       deployment: input.deployment,
       blockNumber,
       poolId,
+      blockHash: input.snapshot.blockHash,
     });
     const cached = currentCacheEntry(cacheKey);
     if (cached) states.set(poolId, cached);
@@ -364,7 +471,7 @@ export async function enrichTokensWithAlchemyPoolState(input: {
             timeout: 12_000,
           }),
         });
-        const [slot0Results, liquidityResults] = await Promise.all([
+        const [slot0Results, liquidityResults, block] = await Promise.all([
           client.multicall({
             allowFailure: true,
             blockNumber,
@@ -385,7 +492,11 @@ export async function enrichTokensWithAlchemyPoolState(input: {
               args: [token.poolId as Hex],
             })),
           }),
+          client.getBlock({ blockNumber }),
         ]);
+        if (block.hash.toLowerCase() !== input.snapshot.blockHash.toLowerCase()) {
+          throw new OperationalRpcUnavailableError();
+        }
         return missing.map((_, index): LivePoolState | null => {
           const slot0 = slot0Results[index];
           const liquidity = liquidityResults[index];
@@ -404,6 +515,7 @@ export async function enrichTokensWithAlchemyPoolState(input: {
             lpFeePips,
             activeLiquidity: liquidity.result,
             blockNumber,
+            blockHash: block.hash,
           };
         });
       },
@@ -416,6 +528,7 @@ export async function enrichTokensWithAlchemyPoolState(input: {
         deployment: input.deployment,
         blockNumber,
         poolId,
+        blockHash: input.snapshot.blockHash,
       });
       const value = batch.then((results) => results[index] ?? null);
       livePoolStateCache.set(cacheKey, {
@@ -434,6 +547,7 @@ export async function enrichTokensWithAlchemyPoolState(input: {
         token,
         state ? await state : null,
         input.snapshot,
+        input.deployment,
       );
     }),
   );

--- a/lib/alchemy/live-market.server.ts
+++ b/lib/alchemy/live-market.server.ts
@@ -246,17 +246,19 @@ export async function withSameBlockEthUsdQuote(input: {
         }),
         client.getBlock({ blockNumber }),
       ]);
-      const [roundId, answer, , updatedAt] = roundData;
+      const [roundId, answer, , updatedAt, answeredInRound] = roundData;
       assertValidEthUsdSnapshot({
         expectedBlockHash: snapshot.blockHash,
         actualBlockHash: block.hash,
         blockTimestamp: block.timestamp,
         roundId,
+        answeredInRound,
         answer,
         updatedAt,
       });
       return {
         roundId,
+        answeredInRound,
         answer,
         decimals,
         updatedAt,
@@ -271,6 +273,7 @@ export async function withSameBlockEthUsdQuote(input: {
     ethUsdQuote: {
       feedAddress: ETH_USD_FEED_ADDRESS,
       roundId: quote.roundId.toString(),
+      answeredInRound: quote.answeredInRound.toString(),
       answer: quote.answer.toString(),
       decimals: quote.decimals,
       updatedAt: quote.updatedAt.toString(),
@@ -395,6 +398,7 @@ function applyLivePoolState(
       marketCapUsdWad === undefined ||
       activeVirtualLiquidityUsdWad === undefined ||
       !snapshot.ethUsdQuote ||
+      !snapshot.ethUsdQuote.answeredInRound ||
       !blockTimestamp ||
       !blockTime ||
       !quoteUpdatedAtTime ||
@@ -429,6 +433,7 @@ function applyLivePoolState(
             fdvUsdWad: marketCapUsdWad.toString(),
             ethUsdQuote: {
               ...snapshot.ethUsdQuote,
+              answeredInRound: snapshot.ethUsdQuote.answeredInRound,
               updatedAtTime: quoteUpdatedAtTime,
             },
           },

--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -4,12 +4,18 @@ import type {
   ExploreEntry,
   LauncherToken,
 } from "./tokens";
+import type { OfficialV4LiquidityEvidenceV1 } from
+  "./onchain/uniswap-v4-subgraph";
+import {
+  marketCapNativeWadFromSqrtPriceX96,
+  nativePriceWadFromSqrtPriceX96,
+} from "./onchain/math";
+import { usdValueFromWei } from "./onchain/usd";
 import {
   MARKET_DATA_CURRENT_MAX_AGE_MS,
   MARKET_DATA_MAXIMUM_RAW_INDEXED_PRICE_DEVIATION_BPS,
   MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD,
   MARKET_DATA_USD_PRICE_SOURCE,
-  isTokenMarketDataV1,
   type MarketPoolDataV1,
   type TokenMarketDataV1,
 } from "./market-data/market-data-v1";
@@ -17,15 +23,33 @@ import {
 export const EXPLORE_DATA_QUALITY_SCHEMA_VERSION =
   "programmable.explore-data-quality.v1" as const;
 export const EXPLORE_VALUATION_MAX_LAG_BLOCKS = 64n;
-// This mirrors the fail-closed general stale ceiling in the production release
-// gate. The direct token-detail path deliberately keeps its separate exact
-// historical PCAN evidence contract.
-export const PUBLIC_EXPLORE_MAXIMUM_STALE_FDV_AGE_MS =
-  24 * 60 * 60_000;
+export const EXPLORE_MAXIMUM_STALE_VALUATION_AGE_MS =
+  24 * 60 * 60 * 1_000;
 
 const UINT_256_MAX = (1n << 256n) - 1n;
 const WAD = 10n ** 18n;
 const MAXIMUM_MARKET_FUTURE_SKEW_MS = 60_000;
+const NATIVE_CURRENCY_ADDRESS =
+  "0x0000000000000000000000000000000000000000";
+
+export function isCanonicalClassicNativeTokenEntry(
+  entry: ExploreEntry,
+): entry is CanonicalTokenExploreEntry {
+  if (entry.exploreKind !== "token" || entry.launchModel !== "classic") {
+    return false;
+  }
+  if (entry.liquidityPath === "meme") {
+    return entry.launchStampProvenance === undefined;
+  }
+  const stamp = entry.launchStampProvenance;
+  return entry.liquidityPath === "programmable-v4" &&
+    stamp?.kind === "classic" &&
+    stamp.chainId === 1 &&
+    stamp.poolId.toLowerCase() === entry.poolId.toLowerCase() &&
+    stamp.poolKey.currency0.toLowerCase() === NATIVE_CURRENCY_ADDRESS &&
+    stamp.poolKey.currency1.toLowerCase() === entry.tokenAddress.toLowerCase() &&
+    stamp.poolKey.hooks.toLowerCase() === entry.hookAddress.toLowerCase();
+}
 
 export type ExploreValuation =
   | Readonly<{
@@ -36,10 +60,12 @@ export type ExploreValuation =
       valueWad: string;
       quoteSymbol?: string;
       freshness: "current" | "stale" | "unknown";
-      source?: "bitquery";
+      source?: "bitquery" | "stateview-chainlink";
       asOfTime?: string;
       asOfBlock?: string;
+      asOfBlockHash?: `0x${string}`;
       lagBlocks?: string;
+      priceEvidence?: NonNullable<LauncherToken["liveMarketPriceEvidence"]>;
     }>
   | Readonly<{
       status: "unavailable";
@@ -57,6 +83,7 @@ export type ValuedExploreEntry<T extends ExploreEntry = ExploreEntry> =
   T & Readonly<{
     valuation: ExploreValuation;
     marketData?: TokenMarketDataV1;
+    liquidityEvidence?: OfficialV4LiquidityEvidenceV1;
   }>;
 
 const LEGACY_MARKET_CAP_FIELDS = [
@@ -131,8 +158,8 @@ type ValuationContext = Readonly<{
 }>;
 
 type BitqueryValuationContext = Readonly<{
-  maximumStaleAgeMs?: number;
-  nowMs?: number;
+  maximumValuationAgeMs?: number;
+  now?: Date;
 }>;
 
 function uint256(value: unknown): bigint | null {
@@ -172,6 +199,21 @@ function decimalToWad(value: unknown): bigint | null {
 
 function blockNumber(value: unknown): bigint | null {
   return positiveUint256(value);
+}
+
+function unixTimestampMatchesIso(value: unknown, iso: unknown): boolean {
+  if (
+    typeof value !== "string" ||
+    !/^(?:0|[1-9]\d*)$/u.test(value) ||
+    typeof iso !== "string"
+  ) return false;
+  try {
+    const seconds = BigInt(value);
+    return seconds <= 8_640_000_000_000n &&
+      new Date(Number(seconds) * 1_000).toISOString() === iso;
+  } catch {
+    return false;
+  }
 }
 
 function valuationFreshness(
@@ -311,25 +353,7 @@ export function withExploreValuation<T extends ExploreEntry>(
 export function withBitqueryMarketData<T extends ExploreEntry>(
   entry: T,
   marketData: TokenMarketDataV1,
-): ValuedExploreEntry<T> {
-  return withReconciledBitqueryMarketData(entry, marketData, {});
-}
-
-export function withPublicExploreBitqueryMarketData<T extends ExploreEntry>(
-  entry: T,
-  marketData: TokenMarketDataV1,
-  nowMs = Date.now(),
-): ValuedExploreEntry<T> {
-  return withReconciledBitqueryMarketData(entry, marketData, {
-    maximumStaleAgeMs: PUBLIC_EXPLORE_MAXIMUM_STALE_FDV_AGE_MS,
-    nowMs,
-  });
-}
-
-function withReconciledBitqueryMarketData<T extends ExploreEntry>(
-  entry: T,
-  marketData: TokenMarketDataV1,
-  context: BitqueryValuationContext,
+  context: BitqueryValuationContext = {},
 ): ValuedExploreEntry<T> {
   const reconciledMarketData = reconcileBitqueryValuations(
     entry,
@@ -366,6 +390,179 @@ function withReconciledBitqueryMarketData<T extends ExploreEntry>(
                     : "inconsistent-snapshot",
         };
   return { ...entry, valuation, marketData: reconciledMarketData };
+}
+
+function matchingCurrentLiquidityEvidence(
+  entry: CanonicalTokenExploreEntry,
+  evidence: OfficialV4LiquidityEvidenceV1 | undefined,
+  price: NonNullable<LauncherToken["liveMarketPriceEvidence"]> | undefined,
+): price is NonNullable<LauncherToken["liveMarketPriceEvidence"]> {
+  return evidence !== undefined &&
+    price !== undefined &&
+    isCanonicalClassicNativeTokenEntry(entry) &&
+    evidence.source === "official-uniswap-v4-subgraph" &&
+    evidence.valueBasis === "official-subgraph-pool-tvl-usd" &&
+    evidence.freshness === "current" &&
+    evidence.identity.chainId === "1" &&
+    evidence.identity.protocol === "uniswap_v4" &&
+    evidence.identity.poolId.toLowerCase() === entry.poolId.toLowerCase() &&
+    evidence.identity.tokenAddress.toLowerCase() ===
+      entry.tokenAddress.toLowerCase() &&
+    evidence.identity.quoteAddress.toLowerCase() ===
+      price.quoteAddress.toLowerCase() &&
+    evidence.identity.quoteAddress.toLowerCase() === NATIVE_CURRENCY_ADDRESS &&
+    evidence.reportedPoolBalances.token0.address.toLowerCase() ===
+      NATIVE_CURRENCY_ADDRESS &&
+    evidence.reportedPoolBalances.token0.decimals === 18 &&
+    evidence.reportedPoolBalances.token1.address.toLowerCase() ===
+      entry.tokenAddress.toLowerCase() &&
+    evidence.reportedPoolBalances.token1.decimals === entry.tokenDecimals &&
+    evidence.provenance.referenceHeadBlockNumber === price.blockNumber &&
+    evidence.provenance.referenceHeadBlockHash.toLowerCase() ===
+      price.blockHash.toLowerCase();
+}
+
+function validCurrentPriceEvidence(
+  entry: CanonicalTokenExploreEntry,
+): NonNullable<LauncherToken["liveMarketPriceEvidence"]> | undefined {
+  const price = entry.liveMarketPriceEvidence;
+  let recomputedTokenEth: bigint;
+  let recomputedFdvEth: bigint;
+  let recomputedTokenUsd: bigint;
+  let recomputedFdvUsd: bigint;
+  let recomputedActiveVirtualToken0: bigint;
+  let recomputedActiveVirtualUsd: bigint;
+  try {
+    const sqrtPriceX96 = BigInt(price?.sqrtPriceX96 ?? "");
+    const totalSupplyRaw = BigInt(price?.totalSupplyRaw ?? "");
+    const quoteAnswer = BigInt(price?.ethUsdQuote.answer ?? "");
+    recomputedTokenEth = nativePriceWadFromSqrtPriceX96(
+      sqrtPriceX96,
+      price?.tokenDecimals ?? -1,
+    );
+    recomputedFdvEth = marketCapNativeWadFromSqrtPriceX96(
+      totalSupplyRaw,
+      sqrtPriceX96,
+    );
+    const tokenUsd = usdValueFromWei(
+      recomputedTokenEth.toString(),
+      quoteAnswer,
+      price?.ethUsdQuote.decimals ?? -1,
+    );
+    const fdvUsd = usdValueFromWei(
+      recomputedFdvEth.toString(),
+      quoteAnswer,
+      price?.ethUsdQuote.decimals ?? -1,
+    );
+    recomputedActiveVirtualToken0 =
+      (BigInt(price?.activeLiquidity ?? "") * (1n << 96n)) /
+      sqrtPriceX96;
+    const activeVirtualUsd = usdValueFromWei(
+      (2n * recomputedActiveVirtualToken0).toString(),
+      quoteAnswer,
+      price?.ethUsdQuote.decimals ?? -1,
+    );
+    if (
+      tokenUsd === undefined ||
+      fdvUsd === undefined ||
+      activeVirtualUsd === undefined
+    ) return undefined;
+    recomputedTokenUsd = BigInt(tokenUsd);
+    recomputedFdvUsd = BigInt(fdvUsd);
+    recomputedActiveVirtualUsd = BigInt(activeVirtualUsd);
+  } catch {
+    return undefined;
+  }
+  const blockTime = Date.parse(price?.blockTime ?? "");
+  const now = Date.now();
+  if (
+    !price ||
+    price.schemaVersion !==
+      "programmable.stateview-chainlink-price-evidence.v1" ||
+    price.source !== "uniswap-v4-stateview-chainlink-v1" ||
+    price.chainId !== "1" ||
+    price.quoteAddress.toLowerCase() !== NATIVE_CURRENCY_ADDRESS ||
+    !/^0x[0-9a-f]{40}$/iu.test(price.stateViewAddress) ||
+    !/^0x[0-9a-f]{64}$/iu.test(price.stateViewRuntimeCodeHash) ||
+    !/^0x[0-9a-f]{64}$/iu.test(price.blockHash) ||
+    price.poolId.toLowerCase() !== entry.poolId.toLowerCase() ||
+    price.tokenAddress.toLowerCase() !== entry.tokenAddress.toLowerCase() ||
+    price.totalSupplyRaw !== entry.totalSupplyRaw ||
+    price.tokenDecimals !== entry.tokenDecimals ||
+    price.blockNumber !== entry.indexedValuationBlockNumber ||
+    price.fdvUsdWad !== entry.fdvUsdWad ||
+    price.tokenPriceUsdWad !== entry.tokenPriceUsdWad ||
+    positiveUint256(price.sqrtPriceX96) === null ||
+    positiveUint256(price.activeLiquidity) === null ||
+    positiveUint256(price.activeVirtualToken0Wei) === null ||
+    positiveUint256(price.activeVirtualLiquidityUsdWad) === null ||
+    price.activeVirtualLiquidityValueBasis !==
+      "stateview-active-liquidity-virtual-depth-usd" ||
+    positiveUint256(price.tokenPriceEthWei) === null ||
+    positiveUint256(price.tokenPriceUsdWad) === null ||
+    positiveUint256(price.fdvUsdWad) === null ||
+    positiveUint256(price.ethUsdQuote.answer) === null ||
+    positiveUint256(price.ethUsdQuote.roundId) === null ||
+    !/^0x[0-9a-f]{40}$/iu.test(price.ethUsdQuote.feedAddress) ||
+    !Number.isInteger(price.ethUsdQuote.decimals) ||
+    price.ethUsdQuote.decimals < 0 ||
+    price.ethUsdQuote.decimals > 255 ||
+    !unixTimestampMatchesIso(price.blockTimestamp, price.blockTime) ||
+    !unixTimestampMatchesIso(
+      price.ethUsdQuote.updatedAt,
+      price.ethUsdQuote.updatedAtTime,
+    ) ||
+    recomputedTokenEth.toString() !== price.tokenPriceEthWei ||
+    recomputedTokenUsd.toString() !== price.tokenPriceUsdWad ||
+    recomputedFdvUsd.toString() !== price.fdvUsdWad ||
+    recomputedActiveVirtualToken0.toString() !==
+      price.activeVirtualToken0Wei ||
+    recomputedActiveVirtualUsd.toString() !==
+      price.activeVirtualLiquidityUsdWad ||
+    recomputedActiveVirtualUsd <
+      BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD) ||
+    !Number.isFinite(blockTime) ||
+    blockTime > now + MAXIMUM_MARKET_FUTURE_SKEW_MS ||
+    now - blockTime > MARKET_DATA_CURRENT_MAX_AGE_MS ||
+    !Number.isFinite(Date.parse(price.ethUsdQuote.updatedAtTime))
+  ) {
+    return undefined;
+  }
+  return price;
+}
+
+/**
+ * Promotes a current FDV only when an exact StateView/Chainlink price and an
+ * independently attributed official-v4 pool TVL observation bind to the same
+ * canonical Classic pool and confirmed RPC reference block.
+ */
+export function withCurrentOnchainValuation<T extends ExploreEntry>(
+  entry: ValuedExploreEntry<T>,
+  liquidityEvidence?: OfficialV4LiquidityEvidenceV1,
+): ValuedExploreEntry<T> {
+  if (entry.exploreKind !== "token") return entry;
+  const priceEvidence = validCurrentPriceEvidence(entry);
+  if (!matchingCurrentLiquidityEvidence(entry, liquidityEvidence, priceEvidence)) {
+    return entry;
+  }
+  return {
+    ...entry,
+    valuation: {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      currency: "usd",
+      valueWad: priceEvidence.fdvUsdWad,
+      freshness: "current",
+      source: "stateview-chainlink",
+      asOfTime: priceEvidence.blockTime,
+      asOfBlock: priceEvidence.blockNumber,
+      asOfBlockHash: priceEvidence.blockHash,
+      lagBlocks: "0",
+      priceEvidence,
+    },
+    liquidityEvidence,
+  };
 }
 
 function reconcileBitqueryValuations<T extends ExploreEntry>(
@@ -473,8 +670,13 @@ function reconcileBitqueryValuations<T extends ExploreEntry>(
     const evidenceTimes = liquidityTime === null
       ? [tradeTime, priceTime]
       : [tradeTime, priceTime, liquidityTime];
-    const asOfTime = new Date(Math.min(...evidenceTimes)).toISOString();
-    if (!marketValuationWithinMaximumAge(asOfTime, context)) {
+    const asOfTimestamp = Math.min(...evidenceTimes);
+    const asOfTime = new Date(asOfTimestamp).toISOString();
+    const valuationReferenceTime = context.now?.getTime() ?? generatedTime;
+    if (
+      context.maximumValuationAgeMs !== undefined &&
+      valuationReferenceTime - asOfTimestamp > context.maximumValuationAgeMs
+    ) {
       return {
         ...pool,
         quality: "partial",
@@ -508,21 +710,6 @@ function reconcileBitqueryValuations<T extends ExploreEntry>(
     };
   });
   return { ...marketData, pools };
-}
-
-function marketValuationWithinMaximumAge(
-  asOfTime: string,
-  context: BitqueryValuationContext,
-): boolean {
-  if (context.maximumStaleAgeMs === undefined) return true;
-  const nowMs = context.nowMs ?? Date.now();
-  const asOfMs = Date.parse(asOfTime);
-  return Number.isSafeInteger(context.maximumStaleAgeMs) &&
-    context.maximumStaleAgeMs >= 0 &&
-    Number.isSafeInteger(nowMs) &&
-    Number.isFinite(asOfMs) &&
-    asOfMs <= nowMs + MAXIMUM_MARKET_FUTURE_SKEW_MS &&
-    nowMs - asOfMs <= context.maximumStaleAgeMs;
 }
 
 function usdPricesWithinConfidence(rawPrice: bigint, indexedPrice: bigint): boolean {
@@ -563,47 +750,32 @@ export function publicExploreEntryV1(
   if (entry.exploreKind === "custom-project") return entry;
 
   const output = { ...entry } as Record<string, unknown>;
+  delete output.liveMarketStateEvidence;
+  delete output.liveMarketPriceEvidence;
   for (const field of LEGACY_MARKET_CAP_FIELDS) delete output[field];
   for (const field of LEGACY_EXTERNAL_MARKET_FIELDS) delete output[field];
-  const primaryMarket = entry.marketData?.pools.find(
-    (pool) => pool.identity.poolId === entry.marketData?.primaryPoolId,
-  );
-  const bitqueryFdv = primaryMarket?.valuation.status === "available"
-      && primaryMarket.valuation.freshness === "current"
-    ? primaryMarket.valuation.fdvUsdWad
-    : undefined;
-  if (bitqueryFdv !== undefined) {
-    output.fdvUsdWad = bitqueryFdv;
-  } else if (
+  if (
     entry.valuation.status === "available" &&
     entry.valuation.metric === "fdv" &&
     entry.valuation.currency === "usd" &&
-    entry.valuation.freshness === "current"
+    entry.valuation.freshness === "current" &&
+    entry.valuation.source !== "bitquery"
   ) {
     output.fdvUsdWad = entry.valuation.valueWad;
   } else {
     delete output.fdvUsdWad;
   }
-  const latestTrade = primaryMarket?.status === "current"
-    ? primaryMarket.latestTrade
-    : undefined;
   if (
-    latestTrade?.priceUsdWad &&
-    latestTrade.priceUsdSource === MARKET_DATA_USD_PRICE_SOURCE &&
-    primaryMarket?.valuation.status === "available" &&
-    primaryMarket.valuation.freshness === "current"
+    entry.valuation.status === "available" &&
+    entry.valuation.source === "stateview-chainlink" &&
+    entry.valuation.priceEvidence
   ) {
-    output.tokenPriceUsdWad = latestTrade.priceUsdWad;
-  }
-  if (latestTrade?.priceQuoteWad) {
-    output.tokenPriceQuoteWad = latestTrade.priceQuoteWad;
-    output.tokenPriceQuote = wadToDecimal(BigInt(latestTrade.priceQuoteWad));
-    if (latestTrade.quoteSymbol) output.quoteAssetSymbol = latestTrade.quoteSymbol;
-    if (latestTrade.quoteAddress) output.quoteAssetAddress = latestTrade.quoteAddress;
-    if (["ETH", "WETH"].includes(latestTrade.quoteSymbol?.toUpperCase() ?? "")) {
-      output.tokenPriceEthWei = latestTrade.priceQuoteWad;
-      output.tokenPriceEth = wadToDecimal(BigInt(latestTrade.priceQuoteWad));
-    }
+    const price = entry.valuation.priceEvidence;
+    output.tokenPriceUsdWad = price.tokenPriceUsdWad;
+    output.tokenPriceEthWei = price.tokenPriceEthWei;
+    output.tokenPriceEth = wadToDecimal(BigInt(price.tokenPriceEthWei));
+    output.quoteAssetAddress = price.quoteAddress;
+    output.quoteAssetSymbol = "ETH";
   }
   return output as PublicCanonicalExploreEntry;
 }
@@ -617,23 +789,11 @@ function wadToDecimal(value: bigint): string {
 
 export function valuationSortValue(entry: ExploreEntry): bigint | null {
   const value = (entry as Partial<ValuedExploreEntry>).valuation;
-  const marketData = (entry as Partial<ValuedExploreEntry>).marketData;
-  if (marketData && isTokenMarketDataV1(marketData)) {
-    const primary = marketData.pools.find(
-      (pool) => pool.identity.poolId === marketData.primaryPoolId,
-    );
-    const fdv = primary?.valuation.status === "available"
-        && primary.valuation.metric === "fdv"
-        && primary.valuation.supplyBasis === "total"
-        && primary.valuation.freshness === "current"
-      ? primary.valuation.fdvUsdWad
-      : undefined;
-    return positiveUint256(fdv);
-  }
   return value?.status === "available" &&
     value.metric === "fdv" &&
     value.currency === "usd" &&
-    value.freshness === "current"
+    value.freshness === "current" &&
+    value.source !== "bitquery"
     ? positiveUint256(value.valueWad)
     : null;
 }
@@ -781,12 +941,17 @@ export function isExploreValuation(value: unknown): value is ExploreValuation {
     (candidate.currency !== "quote" ||
       (typeof candidate.quoteSymbol === "string" &&
         candidate.quoteSymbol.trim().length > 0)) &&
-    (candidate.source === undefined || candidate.source === "bitquery") &&
+    (candidate.source === undefined ||
+      candidate.source === "bitquery" ||
+      candidate.source === "stateview-chainlink") &&
     (candidate.asOfTime === undefined ||
       (typeof candidate.asOfTime === "string" &&
         Number.isFinite(Date.parse(candidate.asOfTime)))) &&
     (candidate.asOfBlock === undefined ||
       blockNumber(candidate.asOfBlock) !== null) &&
+    (candidate.asOfBlockHash === undefined ||
+      (typeof candidate.asOfBlockHash === "string" &&
+        /^0x[0-9a-f]{64}$/iu.test(candidate.asOfBlockHash))) &&
     (candidate.lagBlocks === undefined || uint256(candidate.lagBlocks) !== null);
 }
 

--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -10,7 +10,7 @@ import {
   marketCapNativeWadFromSqrtPriceX96,
   nativePriceWadFromSqrtPriceX96,
 } from "./onchain/math";
-import { usdValueFromWei } from "./onchain/usd";
+import { ETH_USD_FEED_ADDRESS, usdValueFromWei } from "./onchain/usd";
 import {
   MARKET_DATA_CURRENT_MAX_AGE_MS,
   MARKET_DATA_MAXIMUM_RAW_INDEXED_PRICE_DEVIATION_BPS,
@@ -503,7 +503,11 @@ function validCurrentPriceEvidence(
     positiveUint256(price.fdvUsdWad) === null ||
     positiveUint256(price.ethUsdQuote.answer) === null ||
     positiveUint256(price.ethUsdQuote.roundId) === null ||
-    !/^0x[0-9a-f]{40}$/iu.test(price.ethUsdQuote.feedAddress) ||
+    positiveUint256(price.ethUsdQuote.answeredInRound) === null ||
+    BigInt(price.ethUsdQuote.answeredInRound) <
+      BigInt(price.ethUsdQuote.roundId) ||
+    price.ethUsdQuote.feedAddress.toLowerCase() !==
+      ETH_USD_FEED_ADDRESS.toLowerCase() ||
     !Number.isInteger(price.ethUsdQuote.decimals) ||
     price.ethUsdQuote.decimals < 0 ||
     price.ethUsdQuote.decimals > 255 ||

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -15,7 +15,6 @@ import {
   type MarketChartV1,
   type MarketDataIdentityV1,
   type MarketLiquidityV1,
-  type MarketOhlcV1,
   type MarketPoolDataV1,
   type MarketTradeV1,
   type MarketValuationV1,
@@ -40,8 +39,6 @@ const MARKET_CACHE_MAX_AGE_MS = 15 * 60 * 1_000;
 const DURABLE_MARKET_CACHE_SECONDS = 5 * 60;
 const CHART_CACHE_CURRENT_MAX_AGE_MS = 2_000;
 const CHART_CACHE_MAX_AGE_MS = 2 * 60 * 1_000;
-const MAXIMUM_CHART_TRADES = 2_000;
-const CHART_TRADE_PAGE_SIZE = 500;
 const CHART_READ_TIMEOUT_MS = 12_000;
 const MAXIMUM_CHART_POINTS = 80;
 const SUPPLY_PRICE_MAXIMUM_DISTANCE_MS = 24 * 60 * 60 * 1_000;
@@ -80,12 +77,6 @@ type MarketCacheEntry = Readonly<{
 type ChartCacheEntry = Readonly<{
   storedAt: number;
   value: MarketChartV1;
-}>;
-
-type ChartTradeCursor = Readonly<{
-  blockNumber: string;
-  transactionIndex: number;
-  logIndex: number;
 }>;
 
 const marketCache = new Map<string, MarketCacheEntry>();
@@ -305,12 +296,20 @@ async function mapWithConcurrency<T>(
 export async function readBitqueryMarketChartV1(input: Readonly<{
   identity: MarketDataIdentityV1;
   range: "1h" | "1d" | "1w" | "all";
+  historyStart?: string;
   valuation?: MarketValuationV1;
 }> & BitqueryReaderOptions): Promise<MarketChartV1> {
   const now = input.now ?? new Date();
   const identity = canonicalMarketIdentities([input.identity])[0];
   if (!identity) throw new BitqueryMarketDataError("integrity");
-  const cacheKey = chartCacheKey(identity, input.range, input.valuation);
+  const since = chartRangeStart(input.range, now, input.historyStart);
+  if (since === null) throw new BitqueryMarketDataError("integrity");
+  const cacheKey = chartCacheKey(
+    identity,
+    input.range,
+    input.valuation,
+    input.range === "all" ? since.toISOString() : null,
+  );
   const token = resolveToken(input.token);
   if (token === null) {
     return cachedChartOrUnavailable(identity, input.range, cacheKey, now);
@@ -318,7 +317,6 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
   const currentCached = currentCachedChart(cacheKey, now);
   if (currentCached !== null) return currentCached;
 
-  const since = chartRangeStart(input.range, now);
   const deriveValuation = input.valuation === undefined;
   const chartController = new AbortController();
   const abortChartRead = () => chartController.abort();
@@ -326,66 +324,72 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
   input.signal?.addEventListener("abort", abortChartRead, { once: true });
   const chartTimeout = setTimeout(abortChartRead, CHART_READ_TIMEOUT_MS);
   try {
-    const rows: MarketTradeV1[] = [];
-    let trading: Record<string, unknown> | null = null;
-    let responseWasPartial = false;
-    let cursor: ChartTradeCursor | null = null;
-    for (
-      let pageIndex = 0;
-      pageIndex * CHART_TRADE_PAGE_SIZE < MAXIMUM_CHART_TRADES;
-      pageIndex += 1
-    ) {
-      const withValuation = deriveValuation && pageIndex === 0;
-      const query = marketChartQuery(
-        input.range,
-        since !== null,
-        withValuation,
-        cursor,
+    const interval = chartInterval(input.range, since, now);
+    const query = marketChartQuery(
+      input.range,
+      deriveValuation,
+      interval,
+    );
+    const variables: Record<string, unknown> = {
+      poolId: identity.poolId,
+      tokenAddress: identity.tokenAddress,
+      till: now.toISOString(),
+      since: since.toISOString(),
+    };
+    const response = await executeBitqueryGraphql(query, variables, {
+      ...input,
+      token,
+      signal: chartController.signal,
+    });
+    const evm = record(response.data.EVM);
+    const trading = deriveValuation ? record(response.data.Trading) : null;
+    if (evm === null || (deriveValuation && trading === null)) {
+      throw new BitqueryMarketDataError("response");
+    }
+    const rows = array(evm.chart);
+    const points = rows.flatMap((row) => {
+      const point = parseMarketChartPoint(
+        row,
+        identity,
+        interval,
+        since,
+        now,
       );
-      const variables: Record<string, unknown> = {
-        poolId: identity.poolId,
-        till: now.toISOString(),
-        ...(withValuation ? { tokenAddress: identity.tokenAddress } : {}),
-        ...(since === null ? {} : { since: since.toISOString() }),
-      };
-      const response = await executeBitqueryGraphql(query, variables, {
-        ...input,
-        token,
-        signal: chartController.signal,
-      });
-      const evm = record(response.data.EVM);
-      if (evm === null) throw new BitqueryMarketDataError("response");
-      const pageRows = array(evm.DEXTrades);
-      const page = pageRows.flatMap((row) => {
-        const trade = parseTrade(row, identity);
-        return trade === null ? [] : [trade];
-      });
-      if (page.length !== pageRows.length) {
+      return point === null ? [] : [point];
+    });
+    if (points.length !== rows.length) {
+      throw new BitqueryMarketDataError("integrity");
+    }
+    points.sort((first, second) => {
+      const block = BigInt(first.blockNumber) - BigInt(second.blockNumber);
+      if (block !== 0n) return block < 0n ? -1 : 1;
+      return Date.parse(first.time) - Date.parse(second.time);
+    });
+    const totalRows = array(evm.chartTotal);
+    if (totalRows.length !== 1) throw new BitqueryMarketDataError("response");
+    const total = nonNegativeSafeInteger(record(totalRows[0])?.count);
+    if (total === null) throw new BitqueryMarketDataError("integrity");
+    const observed = points.reduce((sum, point) => {
+      const next = sum + point.tradeCount;
+      if (!Number.isSafeInteger(next)) {
         throw new BitqueryMarketDataError("integrity");
       }
-      assertDescendingChartPage(page, cursor);
-      if (withValuation) {
-        trading = record(response.data.Trading);
-        if (trading === null) throw new BitqueryMarketDataError("response");
-      }
-      rows.push(...page);
-      responseWasPartial ||= response.partial;
-      if (page.length < CHART_TRADE_PAGE_SIZE) break;
-      cursor = chartTradeCursor(page.at(-1) as MarketTradeV1);
+      return next;
+    }, 0);
+    if (observed > total || (total > 0 && points.length === 0)) {
+      throw new BitqueryMarketDataError("integrity");
     }
     const indexedPrice = deriveValuation
       ? parseTokenPriceObservation(array(trading?.Tokens)[0], identity)
       : null;
-    const trades = canonicalTrades(rows);
     const supply = deriveValuation
       ? parseSupply(array(trading?.Tokens)[0], identity)
       : null;
 
-    if (rows.length !== trades.length) {
-      throw new BitqueryMarketDataError("integrity");
-    }
-    if (trades.length === 0) {
-      if (responseWasPartial) throw new BitqueryMarketDataError("response");
+    if (total === 0) {
+      if (response.partial || points.length > 0) {
+        throw new BitqueryMarketDataError("response");
+      }
       const waiting: MarketChartV1 = {
         schemaVersion: PROGRAMMABLE_MARKET_CHART_SCHEMA_VERSION,
         source: "bitquery",
@@ -406,30 +410,14 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       return waiting;
     }
 
-    const truncated = rows.length >= MAXIMUM_CHART_TRADES;
-    const points = chartPoints(trades, input.range);
-    const latest = trades.at(-1) as MarketTradeV1;
-    const latestForValuation = enrichTradeWithIndexedUsd(
-      latest,
+    const truncated = observed < total;
+    const latest = points.at(-1) as MarketChartPointV1;
+    const valuation = input.valuation ?? valuationFromIndexedObservation(
       indexedPrice,
-      now,
-    );
-    const valuation = input.valuation ?? valuationFrom(
-      latestForValuation,
       supply,
       now,
     );
-    const volumeComplete = trades.every(
-      (trade) => trade.amountUsdWad !== undefined,
-    );
-    const volume = volumeComplete
-      ? sumPositiveIntegers(trades.map((trade) => trade.amountUsdWad))
-      : null;
-    const quotePriceComplete = trades.every(
-      (trade) =>
-        trade.priceQuoteWad !== undefined && trade.quoteSymbol !== undefined,
-    );
-    const partial = truncated || responseWasPartial || !quotePriceComplete;
+    const partial = truncated || response.partial;
     const status = partial
       ? "partial" as const
       : points.length === 1
@@ -444,10 +432,9 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       identity,
       range: input.range,
       points,
-      swapCount: trades.length,
-      ...(volume === null ? {} : { volumeUsdWad: volume.toString() }),
+      swapCount: observed,
       valuation,
-      asOfTime: latest.time,
+      asOfTime: latest.observedAt,
       truncated,
     };
     if (!isMarketChartV1(chart)) {
@@ -1083,50 +1070,53 @@ function marketStatsQuery(identities: readonly MarketDataIdentityV1[]) {
 
 function marketChartQuery(
   range: MarketChartV1["range"],
-  withSince: boolean,
   withValuation: boolean,
-  cursor: ChartTradeCursor | null,
+  interval: Readonly<{
+    count: number;
+    unit: "minutes" | "hours" | "days";
+  }>,
 ) {
   const definitions = [
     "$poolId: String!",
+    "$tokenAddress: String!",
     "$till: DateTime!",
-    ...(withValuation ? ["$tokenAddress: String!"] : []),
-    ...(withSince ? ["$since: DateTime!"] : []),
+    "$since: DateTime!",
   ].join(", ");
-  const blockFilter = withSince
-    ? "Block: { Time: { since: $since, till: $till } }"
-    : "Block: { Time: { till: $till } }";
-  const cursorFilter = cursor === null
-    ? ""
-    : `any: [
-            { Block: { Number: { lt: "${cursor.blockNumber}" } } }
-            {
-              Block: { Number: { eq: "${cursor.blockNumber}" } }
-              Transaction: { Index: { lt: ${cursor.transactionIndex} } }
+  const blockFilter = "Block: { Time: { since: $since, till: $till } }";
+  const where = `{
+            TransactionStatus: { Success: true }
+            ${blockFilter}
+            Trade: {
+              Dex: { ProtocolName: { is: "uniswap_v4" } }
+              PoolId: { is: $poolId }
+              Currency: { SmartContract: { is: $tokenAddress } }
             }
-            {
-              Block: { Number: { eq: "${cursor.blockNumber}" } }
-              Transaction: { Index: { eq: ${cursor.transactionIndex} } }
-              Log: { Index: { lt: ${cursor.logIndex} } }
-            }
-          ]`;
+          }`;
   const dataset = range === "1h" ? "" : ", dataset: combined";
   return `query ProgrammableMarketChart(${definitions}) {
     EVM(network: eth${dataset}) {
-      DEXTrades(
-        limit: { count: ${CHART_TRADE_PAGE_SIZE} }
-        orderBy: [
-          { descending: Block_Number }
-          { descending: Transaction_Index }
-          { descending: Log_Index }
-        ]
-        where: {
-          TransactionStatus: { Success: true }
-          ${blockFilter}
-          ${cursorFilter}
-          Trade: { Dex: { ProtocolName: { is: "uniswap_v4" } }, PoolId: { is: $poolId } }
+      chart: DEXTradeByTokens(
+        limit: { count: ${MAXIMUM_CHART_POINTS} }
+        orderBy: { descendingByField: "Block_Bucket" }
+        where: ${where}
+      ) {
+        Block {
+          Bucket: Time(interval: { count: ${interval.count}, in: ${interval.unit} })
+          Number(maximum: Block_Number)
+          Time(maximum: Block_Time)
         }
-      ) { ${tradeSelection()} }
+        Trade {
+          PoolId
+          Currency { SmartContract }
+          Side { Currency { SmartContract Symbol } }
+        }
+        price: median(of: Trade_Price)
+        count
+      }
+      chartTotal: DEXTradeByTokens(
+        limit: { count: 1 }
+        where: ${where}
+      ) { count }
     }
     ${withValuation ? `Trading {
       Tokens(
@@ -1136,6 +1126,123 @@ function marketChartQuery(
       ) { ${supplySelection()} }
     }` : ""}
   }`;
+}
+
+function chartInterval(
+  range: MarketChartV1["range"],
+  since: Date,
+  now: Date,
+): Readonly<{
+  count: number;
+  unit: "minutes" | "hours" | "days";
+}> {
+  if (range === "1h") return { count: 1, unit: "minutes" };
+  if (range === "1d") return { count: 20, unit: "minutes" };
+  if (range === "1w") return { count: 3, unit: "hours" };
+  const duration = now.getTime() - since.getTime();
+  const minimumBucketMs = Math.floor(
+    duration / (MAXIMUM_CHART_POINTS - 1),
+  ) + 1;
+  if (minimumBucketMs <= 60 * 60 * 1_000) {
+    return {
+      count: Math.max(1, Math.ceil(minimumBucketMs / (60 * 1_000))),
+      unit: "minutes",
+    };
+  }
+  if (minimumBucketMs <= 24 * 60 * 60 * 1_000) {
+    return {
+      count: Math.ceil(minimumBucketMs / (60 * 60 * 1_000)),
+      unit: "hours",
+    };
+  }
+  return {
+    count: Math.ceil(minimumBucketMs / (24 * 60 * 60 * 1_000)),
+    unit: "days",
+  };
+}
+
+function parseMarketChartPoint(
+  value: unknown,
+  identity: MarketDataIdentityV1,
+  interval: Readonly<{
+    count: number;
+    unit: "minutes" | "hours" | "days";
+  }>,
+  since: Date,
+  till: Date,
+): MarketChartPointV1 | null {
+  const row = record(value);
+  const block = record(row?.Block);
+  const trade = record(row?.Trade);
+  const currency = record(trade?.Currency);
+  const side = record(trade?.Side);
+  const quoteCurrency = record(side?.Currency);
+  const blockNumber = typeof block?.Number === "number" &&
+      Number.isSafeInteger(block.Number)
+    ? String(block.Number)
+    : block?.Number;
+  const bucket = isoTime(block?.Bucket);
+  const observedAt = isoTime(block?.Time);
+  const quoteAddress = canonicalCurrencyAddress(quoteCurrency?.SmartContract);
+  const quoteSymbol = nonEmptyString(quoteCurrency?.Symbol);
+  const price = positiveDecimal(row?.price);
+  const tradeCount = nonNegativeSafeInteger(row?.count);
+  if (
+    !row ||
+    !block ||
+    !trade ||
+    !currency ||
+    !side ||
+    !quoteCurrency ||
+    canonicalBytes32(trade.PoolId) !== identity.poolId ||
+    canonicalAddress(currency.SmartContract) !== identity.tokenAddress ||
+    quoteAddress === null ||
+    quoteAddress === identity.tokenAddress ||
+    quoteSymbol === null ||
+    !canonicalUnsignedInteger(blockNumber) ||
+    bucket === null ||
+    observedAt === null ||
+    price === null ||
+    tradeCount === null ||
+    tradeCount === 0
+  ) return null;
+  const providerBucketStart = Date.parse(bucket);
+  const bucketStartMs = Math.max(providerBucketStart, since.getTime());
+  const bucketEndMs = Math.min(
+    providerBucketStart + chartIntervalDurationMs(interval),
+    till.getTime(),
+  );
+  const observedAtMs = Date.parse(observedAt);
+  if (
+    bucketStartMs >= bucketEndMs ||
+    observedAtMs < bucketStartMs ||
+    observedAtMs > bucketEndMs
+  ) return null;
+  const bucketStart = new Date(bucketStartMs).toISOString();
+  const bucketEnd = new Date(bucketEndMs).toISOString();
+  return {
+    blockNumber: String(blockNumber),
+    time: bucketEnd,
+    bucketStart,
+    bucketEnd,
+    observedAt,
+    valueSemantics: "period-median",
+    priceQuote: price,
+    quoteSymbol,
+    tradeCount,
+  };
+}
+
+function chartIntervalDurationMs(interval: Readonly<{
+  count: number;
+  unit: "minutes" | "hours" | "days";
+}>): number {
+  const unitMs = interval.unit === "minutes"
+    ? 60 * 1_000
+    : interval.unit === "hours"
+      ? 60 * 60 * 1_000
+      : 24 * 60 * 60 * 1_000;
+  return interval.count * unitMs;
 }
 
 function tradeSelection() {
@@ -1666,6 +1773,54 @@ function valuationFrom(
   return { status: "unavailable", reason: "supply-unavailable" };
 }
 
+function valuationFromIndexedObservation(
+  observation: TokenPriceObservation | null,
+  supply: ParsedSupply,
+  now: Date,
+): MarketValuationV1 {
+  if (observation === null) {
+    return { status: "unavailable", reason: "price-unavailable" };
+  }
+  if (supply === null) {
+    return { status: "unavailable", reason: "supply-unavailable" };
+  }
+  const priceTime = Date.parse(observation.time);
+  const supplyTime = Date.parse(supply.asOfTime);
+  if (
+    !Number.isFinite(priceTime) ||
+    !Number.isFinite(supplyTime) ||
+    Math.abs(priceTime - supplyTime) > SUPPLY_PRICE_MAXIMUM_DISTANCE_MS ||
+    priceTime > now.getTime() + MAXIMUM_FUTURE_SKEW_MS ||
+    supplyTime > now.getTime() + MAXIMUM_FUTURE_SKEW_MS ||
+    (supply.maxSupply !== undefined &&
+      supply.totalSupply !== undefined &&
+      comparePositiveDecimals(supply.totalSupply, supply.maxSupply) > 0)
+  ) {
+    return { status: "unavailable", reason: "inconsistent-market-data" };
+  }
+  const priceUsdWad = BigInt(observation.priceUsdWad);
+  const fdv = supply.totalSupply === undefined
+    ? null
+    : multiplyWadByDecimal(priceUsdWad, supply.totalSupply);
+  if (fdv === null || supply.totalSupply === undefined) {
+    return { status: "unavailable", reason: "supply-unavailable" };
+  }
+  const valuationTime = Math.min(priceTime, supplyTime);
+  return {
+    status: "available",
+    metric: "fdv",
+    supplyBasis: "total",
+    valueUsdWad: fdv.toString(),
+    fdvUsdWad: fdv.toString(),
+    totalSupply: supply.totalSupply,
+    ...(supply.maxSupply === undefined ? {} : { maxSupply: supply.maxSupply }),
+    asOfTime: new Date(valuationTime).toISOString(),
+    freshness: now.getTime() - valuationTime > MARKET_DATA_CURRENT_MAX_AGE_MS
+      ? "stale"
+      : "current",
+  };
+}
+
 function supplyFromValuation(
   value: MarketValuationV1 | undefined,
 ): ParsedSupply {
@@ -1852,6 +2007,7 @@ function chartCacheKey(
   identity: MarketDataIdentityV1,
   range: MarketChartV1["range"],
   valuation: MarketValuationV1 | undefined,
+  historyStart: string | null,
 ): string {
   const valuationKey = valuation === undefined
     ? "derived"
@@ -1870,10 +2026,14 @@ function chartCacheKey(
           valuation.asOfTime,
           valuation.freshness,
         ].join(":");
-  return `${marketCacheKey(identity)}:${range}:${valuationKey}`;
+  return `${marketCacheKey(identity)}:${range}:${historyStart ?? "bounded"}:${valuationKey}`;
 }
 
-function chartRangeStart(range: MarketChartV1["range"], now: Date): Date | null {
+function chartRangeStart(
+  range: MarketChartV1["range"],
+  now: Date,
+  historyStart: string | undefined,
+): Date | null {
   const duration = range === "1h"
     ? 60 * 60 * 1_000
     : range === "1d"
@@ -1881,7 +2041,11 @@ function chartRangeStart(range: MarketChartV1["range"], now: Date): Date | null 
       : range === "1w"
         ? 7 * 24 * 60 * 60 * 1_000
         : null;
-  return duration === null ? null : new Date(now.getTime() - duration);
+  if (duration !== null) return new Date(now.getTime() - duration);
+  const parsed = historyStart === undefined ? Number.NaN : Date.parse(historyStart);
+  return Number.isFinite(parsed) && parsed <= now.getTime()
+    ? new Date(parsed)
+    : null;
 }
 
 function canonicalTrades(trades: readonly MarketTradeV1[]): MarketTradeV1[] {
@@ -1907,140 +2071,6 @@ function canonicalTrades(trades: readonly MarketTradeV1[]): MarketTradeV1[] {
     byKey.set(key, trade);
   }
   return [...byKey.values()];
-}
-
-function chartTradeCursor(trade: MarketTradeV1): ChartTradeCursor {
-  if (trade.transactionIndex === undefined) {
-    throw new BitqueryMarketDataError("integrity");
-  }
-  return {
-    blockNumber: trade.blockNumber,
-    transactionIndex: trade.transactionIndex,
-    logIndex: trade.logIndex,
-  };
-}
-
-function compareChartTradePosition(
-  first: ChartTradeCursor,
-  second: ChartTradeCursor,
-): number {
-  const firstBlock = BigInt(first.blockNumber);
-  const secondBlock = BigInt(second.blockNumber);
-  if (firstBlock !== secondBlock) return firstBlock < secondBlock ? -1 : 1;
-  if (first.transactionIndex !== second.transactionIndex) {
-    return first.transactionIndex < second.transactionIndex ? -1 : 1;
-  }
-  if (first.logIndex !== second.logIndex) {
-    return first.logIndex < second.logIndex ? -1 : 1;
-  }
-  return 0;
-}
-
-function assertDescendingChartPage(
-  trades: readonly MarketTradeV1[],
-  previousPageCursor: ChartTradeCursor | null,
-): void {
-  let previous = previousPageCursor;
-  for (const trade of trades) {
-    const current = chartTradeCursor(trade);
-    if (
-      previous !== null &&
-      compareChartTradePosition(current, previous) >= 0
-    ) {
-      throw new BitqueryMarketDataError("integrity");
-    }
-    previous = current;
-  }
-}
-
-function chartPoints(
-  trades: readonly MarketTradeV1[],
-  range: MarketChartV1["range"],
-): MarketChartPointV1[] {
-  const duration = chartBucketDurationMs(trades, range);
-  const buckets = new Map<number, MarketTradeV1[]>();
-  for (const trade of trades) {
-    const time = Date.parse(trade.time);
-    const key = Math.floor(time / duration);
-    const values = buckets.get(key) ?? [];
-    values.push(trade);
-    buckets.set(key, values);
-  }
-  return [...buckets.values()].map(chartPoint);
-}
-
-function chartBucketDurationMs(
-  trades: readonly MarketTradeV1[],
-  range: MarketChartV1["range"],
-): number {
-  if (range === "1h") return 60_000;
-  if (range === "1d") return 20 * 60_000;
-  if (range === "1w") return 3 * 60 * 60_000;
-  const first = Date.parse(trades[0]?.time ?? "");
-  const last = Date.parse(trades.at(-1)?.time ?? "");
-  if (!Number.isFinite(first) || !Number.isFinite(last) || last <= first) {
-    return 1;
-  }
-  return Math.max(1, Math.ceil((last - first + 1) / MAXIMUM_CHART_POINTS));
-}
-
-function chartPoint(trades: readonly MarketTradeV1[]): MarketChartPointV1 {
-  const trade = trades.at(-1) as MarketTradeV1;
-  const usdComplete = trades.every((value) => value.priceUsdWad !== undefined);
-  const quoteComplete = trades.every(
-    (value) =>
-      value.priceQuoteWad !== undefined && value.quoteSymbol !== undefined,
-  );
-  const volumeComplete = trades.every(
-    (value) => value.amountUsdWad !== undefined,
-  );
-  const usd = usdComplete
-    ? trades.map((value) => BigInt(value.priceUsdWad as string))
-    : [];
-  const quote = quoteComplete
-    ? trades.map((value) => BigInt(value.priceQuoteWad as string))
-    : [];
-  const quoteSymbols = new Set(
-    trades.map((value) => value.quoteSymbol).filter(
-      (value): value is string => Boolean(value),
-    ),
-  );
-  const ohlcUsd = marketOhlc(usd);
-  const ohlcQuote = quoteSymbols.size === 1 ? marketOhlc(quote) : null;
-  const volume = volumeComplete
-    ? sumPositiveIntegers(trades.map((value) => value.amountUsdWad))
-    : null;
-  return {
-    blockNumber: trade.blockNumber,
-    time: trade.time,
-    ...(ohlcUsd
-      ? { priceUsd: ohlcUsd.close, ohlcUsd }
-      : {}),
-    ...(ohlcQuote
-      ? { priceQuote: ohlcQuote.close, ohlcQuote }
-      : {}),
-    ...(quoteSymbols.size === 1
-      ? { quoteSymbol: [...quoteSymbols][0] }
-      : {}),
-    ...(volume === null ? {} : { volumeUsdWad: volume.toString() }),
-    tradeCount: trades.length,
-  };
-}
-
-function marketOhlc(values: readonly bigint[]): MarketOhlcV1 | null {
-  if (values.length === 0) return null;
-  let high = values[0];
-  let low = values[0];
-  for (const value of values.slice(1)) {
-    if (value > high) high = value;
-    if (value < low) low = value;
-  }
-  return {
-    open: wadToDecimal(values[0]),
-    high: wadToDecimal(high),
-    low: wadToDecimal(low),
-    close: wadToDecimal(values.at(-1) as bigint),
-  };
 }
 
 function marketCacheKey(identity: MarketDataIdentityV1): string {
@@ -2145,26 +2175,6 @@ function comparePositiveDecimals(first: string, second: string): number {
   const b = decimalParts(second);
   const comparison = a.coefficient * b.scale - b.coefficient * a.scale;
   return comparison === 0n ? 0 : comparison > 0n ? 1 : -1;
-}
-
-function wadToDecimal(value: bigint): string {
-  const raw = value.toString().padStart(19, "0");
-  const whole = raw.slice(0, -18);
-  const fraction = raw.slice(-18).replace(/0+$/u, "");
-  return fraction ? `${whole}.${fraction}` : whole;
-}
-
-function sumPositiveIntegers(
-  values: readonly (string | undefined)[],
-): bigint | null {
-  let found = false;
-  let total = 0n;
-  for (const value of values) {
-    if (!value || !CANONICAL_UNSIGNED_INTEGER.test(value)) continue;
-    total += BigInt(value);
-    found = true;
-  }
-  return found && total > 0n ? total : null;
 }
 
 function isoTime(value: unknown): string | null {

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -11,6 +11,7 @@ import {
   PROGRAMMABLE_MARKET_DATA_SCHEMA_VERSION,
   isMarketChartV1,
   selectPrimaryMarketPoolV1,
+  type MarketChartIdentityV1,
   type MarketChartPointV1,
   type MarketChartV1,
   type MarketDataIdentityV1,
@@ -294,20 +295,17 @@ async function mapWithConcurrency<T>(
 }
 
 export async function readBitqueryMarketChartV1(input: Readonly<{
-  identity: MarketDataIdentityV1;
+  identity: MarketChartIdentityV1;
   range: "1h" | "1d" | "1w" | "all";
   historyStart?: string;
-  valuation?: MarketValuationV1;
 }> & BitqueryReaderOptions): Promise<MarketChartV1> {
   const now = input.now ?? new Date();
-  const identity = canonicalMarketIdentities([input.identity])[0];
-  if (!identity) throw new BitqueryMarketDataError("integrity");
+  const identity = canonicalMarketChartIdentity(input.identity);
   const since = chartRangeStart(input.range, now, input.historyStart);
   if (since === null) throw new BitqueryMarketDataError("integrity");
   const cacheKey = chartCacheKey(
     identity,
     input.range,
-    input.valuation,
     input.range === "all" ? since.toISOString() : null,
   );
   const token = resolveToken(input.token);
@@ -317,7 +315,6 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
   const currentCached = currentCachedChart(cacheKey, now);
   if (currentCached !== null) return currentCached;
 
-  const deriveValuation = input.valuation === undefined;
   const chartController = new AbortController();
   const abortChartRead = () => chartController.abort();
   if (input.signal?.aborted) abortChartRead();
@@ -327,12 +324,12 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
     const interval = chartInterval(input.range, since, now);
     const query = marketChartQuery(
       input.range,
-      deriveValuation,
       interval,
     );
     const variables: Record<string, unknown> = {
       poolId: identity.poolId,
       tokenAddress: identity.tokenAddress,
+      quoteAddress: bitqueryCurrencyAddress(identity.quoteAddress),
       till: now.toISOString(),
       since: since.toISOString(),
     };
@@ -342,8 +339,7 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       signal: chartController.signal,
     });
     const evm = record(response.data.EVM);
-    const trading = deriveValuation ? record(response.data.Trading) : null;
-    if (evm === null || (deriveValuation && trading === null)) {
+    if (evm === null) {
       throw new BitqueryMarketDataError("response");
     }
     const rows = array(evm.chart);
@@ -379,13 +375,6 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
     if (observed > total || (total > 0 && points.length === 0)) {
       throw new BitqueryMarketDataError("integrity");
     }
-    const indexedPrice = deriveValuation
-      ? parseTokenPriceObservation(array(trading?.Tokens)[0], identity)
-      : null;
-    const supply = deriveValuation
-      ? parseSupply(array(trading?.Tokens)[0], identity)
-      : null;
-
     if (total === 0) {
       if (response.partial || points.length > 0) {
         throw new BitqueryMarketDataError("response");
@@ -402,7 +391,7 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
         swapCount: 0,
         valuation: {
           status: "unavailable",
-          reason: "waiting-for-first-trade",
+          reason: "source-unavailable",
         },
         truncated: false,
       };
@@ -412,11 +401,6 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
 
     const truncated = observed < total;
     const latest = points.at(-1) as MarketChartPointV1;
-    const valuation = input.valuation ?? valuationFromIndexedObservation(
-      indexedPrice,
-      supply,
-      now,
-    );
     const partial = truncated || response.partial;
     const status = partial
       ? "partial" as const
@@ -433,7 +417,7 @@ export async function readBitqueryMarketChartV1(input: Readonly<{
       range: input.range,
       points,
       swapCount: observed,
-      valuation,
+      valuation: { status: "unavailable", reason: "source-unavailable" },
       asOfTime: latest.observedAt,
       truncated,
     };
@@ -750,29 +734,6 @@ type TokenPriceObservation = Readonly<{
   priceUsdWad: string;
 }>;
 
-function parseTokenPriceObservation(
-  value: unknown,
-  identity: MarketDataIdentityV1,
-): TokenPriceObservation | null {
-  const row = record(value);
-  const token = record(row?.Token);
-  const block = record(row?.Block);
-  const price = record(row?.Price);
-  const ohlc = record(price?.Ohlc);
-  const id = nonEmptyString(token?.Id)?.toLowerCase();
-  if (
-    canonicalAddress(token?.Address) !== identity.tokenAddress ||
-    (id !== `eth:${identity.tokenAddress}` &&
-      id !== `bid:eth:${identity.tokenAddress}`) ||
-    price?.IsQuotedInUsd !== true
-  ) return null;
-  const time = isoTime(block?.Time);
-  const priceUsdWad = decimalToWad(ohlc?.Close);
-  return time === null || priceUsdWad === null
-    ? null
-    : { time, priceUsdWad: priceUsdWad.toString() };
-}
-
 function parseNativeQuotePriceObservation(
   value: unknown,
   trade: MarketTradeV1,
@@ -1070,7 +1031,6 @@ function marketStatsQuery(identities: readonly MarketDataIdentityV1[]) {
 
 function marketChartQuery(
   range: MarketChartV1["range"],
-  withValuation: boolean,
   interval: Readonly<{
     count: number;
     unit: "minutes" | "hours" | "days";
@@ -1079,6 +1039,7 @@ function marketChartQuery(
   const definitions = [
     "$poolId: String!",
     "$tokenAddress: String!",
+    "$quoteAddress: String!",
     "$till: DateTime!",
     "$since: DateTime!",
   ].join(", ");
@@ -1090,6 +1051,7 @@ function marketChartQuery(
               Dex: { ProtocolName: { is: "uniswap_v4" } }
               PoolId: { is: $poolId }
               Currency: { SmartContract: { is: $tokenAddress } }
+              Side: { Currency: { SmartContract: { is: $quoteAddress } } }
             }
           }`;
   const dataset = range === "1h" ? "" : ", dataset: combined";
@@ -1118,13 +1080,6 @@ function marketChartQuery(
         where: ${where}
       ) { count }
     }
-    ${withValuation ? `Trading {
-      Tokens(
-        limit: { count: 1 }
-        orderBy: { descending: Block_Time }
-        where: { Token: { Address: { is: $tokenAddress } } }
-      ) { ${supplySelection()} }
-    }` : ""}
   }`;
 }
 
@@ -1163,7 +1118,7 @@ function chartInterval(
 
 function parseMarketChartPoint(
   value: unknown,
-  identity: MarketDataIdentityV1,
+  identity: MarketChartIdentityV1,
   interval: Readonly<{
     count: number;
     unit: "minutes" | "hours" | "days";
@@ -1196,8 +1151,7 @@ function parseMarketChartPoint(
     !quoteCurrency ||
     canonicalBytes32(trade.PoolId) !== identity.poolId ||
     canonicalAddress(currency.SmartContract) !== identity.tokenAddress ||
-    quoteAddress === null ||
-    quoteAddress === identity.tokenAddress ||
+    quoteAddress !== identity.quoteAddress ||
     quoteSymbol === null ||
     !canonicalUnsignedInteger(blockNumber) ||
     bucket === null ||
@@ -1773,54 +1727,6 @@ function valuationFrom(
   return { status: "unavailable", reason: "supply-unavailable" };
 }
 
-function valuationFromIndexedObservation(
-  observation: TokenPriceObservation | null,
-  supply: ParsedSupply,
-  now: Date,
-): MarketValuationV1 {
-  if (observation === null) {
-    return { status: "unavailable", reason: "price-unavailable" };
-  }
-  if (supply === null) {
-    return { status: "unavailable", reason: "supply-unavailable" };
-  }
-  const priceTime = Date.parse(observation.time);
-  const supplyTime = Date.parse(supply.asOfTime);
-  if (
-    !Number.isFinite(priceTime) ||
-    !Number.isFinite(supplyTime) ||
-    Math.abs(priceTime - supplyTime) > SUPPLY_PRICE_MAXIMUM_DISTANCE_MS ||
-    priceTime > now.getTime() + MAXIMUM_FUTURE_SKEW_MS ||
-    supplyTime > now.getTime() + MAXIMUM_FUTURE_SKEW_MS ||
-    (supply.maxSupply !== undefined &&
-      supply.totalSupply !== undefined &&
-      comparePositiveDecimals(supply.totalSupply, supply.maxSupply) > 0)
-  ) {
-    return { status: "unavailable", reason: "inconsistent-market-data" };
-  }
-  const priceUsdWad = BigInt(observation.priceUsdWad);
-  const fdv = supply.totalSupply === undefined
-    ? null
-    : multiplyWadByDecimal(priceUsdWad, supply.totalSupply);
-  if (fdv === null || supply.totalSupply === undefined) {
-    return { status: "unavailable", reason: "supply-unavailable" };
-  }
-  const valuationTime = Math.min(priceTime, supplyTime);
-  return {
-    status: "available",
-    metric: "fdv",
-    supplyBasis: "total",
-    valueUsdWad: fdv.toString(),
-    fdvUsdWad: fdv.toString(),
-    totalSupply: supply.totalSupply,
-    ...(supply.maxSupply === undefined ? {} : { maxSupply: supply.maxSupply }),
-    asOfTime: new Date(valuationTime).toISOString(),
-    freshness: now.getTime() - valuationTime > MARKET_DATA_CURRENT_MAX_AGE_MS
-      ? "stale"
-      : "current",
-  };
-}
-
 function supplyFromValuation(
   value: MarketValuationV1 | undefined,
 ): ParsedSupply {
@@ -1942,7 +1848,7 @@ function cachedOrUnavailable(
 }
 
 function cachedChartOrUnavailable(
-  identity: MarketDataIdentityV1,
+  identity: MarketChartIdentityV1,
   range: MarketChartV1["range"],
   key: string,
   now: Date,
@@ -1961,9 +1867,7 @@ function cachedChartOrUnavailable(
       ...cached.value,
       readStatus: "cache-fallback",
       status: "partial",
-      valuation: cached.value.valuation.status === "available"
-        ? { ...cached.value.valuation, freshness: "stale" }
-        : cached.value.valuation,
+      valuation: { status: "unavailable", reason: "source-unavailable" },
     };
   }
   return {
@@ -1993,40 +1897,42 @@ function currentCachedChart(
   ) {
     return null;
   }
-  const valuation = cached.value.valuation.status === "available" &&
-      now.getTime() - Date.parse(cached.value.valuation.asOfTime) >
-        MARKET_DATA_CURRENT_MAX_AGE_MS
-    ? { ...cached.value.valuation, freshness: "stale" as const }
-    : cached.value.valuation;
-  return valuation === cached.value.valuation
-    ? cached.value
-    : { ...cached.value, valuation };
+  return cached.value;
 }
 
 function chartCacheKey(
-  identity: MarketDataIdentityV1,
+  identity: MarketChartIdentityV1,
   range: MarketChartV1["range"],
-  valuation: MarketValuationV1 | undefined,
   historyStart: string | null,
 ): string {
-  const valuationKey = valuation === undefined
-    ? "derived"
-    : valuation.status === "unavailable"
-      ? `unavailable:${valuation.reason}`
-      : [
-          "available",
-          valuation.metric,
-          valuation.supplyBasis,
-          valuation.valueUsdWad,
-          valuation.fdvUsdWad ?? "",
-          valuation.marketCapUsdWad ?? "",
-          valuation.totalSupply ?? "",
-          valuation.circulatingSupply ?? "",
-          valuation.maxSupply ?? "",
-          valuation.asOfTime,
-          valuation.freshness,
-        ].join(":");
-  return `${marketCacheKey(identity)}:${range}:${historyStart ?? "bounded"}:${valuationKey}`;
+  return `${marketCacheKey(identity)}:${identity.quoteAddress}:${range}:${historyStart ?? "bounded"}`;
+}
+
+function canonicalMarketChartIdentity(
+  identity: MarketChartIdentityV1,
+): MarketChartIdentityV1 {
+  const tokenAddress = canonicalAddress(identity.tokenAddress);
+  const quoteAddress = canonicalCurrencyAddress(identity.quoteAddress);
+  const poolId = canonicalBytes32(identity.poolId);
+  if (
+    identity.chainId !== "1" ||
+    identity.protocol !== "uniswap_v4" ||
+    tokenAddress === null ||
+    quoteAddress === null ||
+    quoteAddress === tokenAddress ||
+    poolId === null
+  ) throw new BitqueryMarketDataError("integrity");
+  return {
+    chainId: "1",
+    tokenAddress,
+    quoteAddress,
+    poolId,
+    protocol: "uniswap_v4",
+  };
+}
+
+function bitqueryCurrencyAddress(value: `0x${string}`): string {
+  return value === NATIVE_ETH_ADDRESS ? "0x" : value;
 }
 
 function chartRangeStart(

--- a/lib/market-data/current-valuation.server.ts
+++ b/lib/market-data/current-valuation.server.ts
@@ -1,0 +1,364 @@
+import "server-only";
+
+import {
+  enrichTokensWithAlchemyPoolState,
+  withSameBlockEthUsdQuote,
+} from "../alchemy/live-market.server";
+import {
+  isCanonicalClassicNativeTokenEntry,
+  withBitqueryMarketData,
+  withCurrentOnchainValuation,
+  type ValuedExploreEntry,
+} from "../explore-financial-data";
+import {
+  readOfficialV4LiquidityEvidence,
+  type OfficialV4LiquidityEvidenceV1,
+} from "../onchain/uniswap-v4-subgraph";
+import type {
+  ExploreSnapshot,
+  ReadyOnchainDeployment,
+} from "../onchain/types";
+import type { ExploreEntry, LauncherToken } from "../tokens";
+import {
+  MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD,
+  type TokenMarketDataV1,
+} from "./market-data-v1";
+
+const HISTORICAL_BITQUERY_DETAIL_TOKEN_ADDRESS =
+  "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"; // gitleaks:allow -- public Ethereum token address
+export const CURRENT_EVIDENCE_ROUTE_DEADLINE_MS = 4_500;
+
+export type CurrentEvidenceSnapshotOutcome =
+  | Readonly<{ status: "fulfilled"; value: ExploreSnapshot | null }>
+  | Readonly<{ status: "rejected"; error: unknown }>;
+
+function withoutUnevidencedCurrentBitqueryValuation(
+  entry: ValuedExploreEntry,
+  allowHistoricalBitqueryFallback: boolean,
+  reason: "source-unavailable" | "liquidity-unavailable" =
+    "source-unavailable",
+) {
+  if (
+    allowHistoricalBitqueryFallback &&
+    entry.exploreKind === "token" &&
+    entry.tokenAddress.toLowerCase() === HISTORICAL_BITQUERY_DETAIL_TOKEN_ADDRESS &&
+    entry.valuation.status === "available" &&
+    entry.valuation.source === "bitquery" &&
+    entry.valuation.freshness === "stale" &&
+    (entry.marketData?.pools.every((pool) =>
+      pool.valuation.status !== "available" ||
+      pool.valuation.freshness === "stale"
+    ) ?? true)
+  ) return entry;
+  const marketData = entry.marketData
+    ? {
+        ...entry.marketData,
+        pools: entry.marketData.pools.map((pool) => ({
+          ...pool,
+          valuation: pool.valuation.status === "available"
+            ? {
+                status: "unavailable" as const,
+                reason: reason === "source-unavailable"
+                  ? "source-unavailable" as const
+                  : "inconsistent-market-data" as const,
+              }
+            : pool.valuation,
+        })),
+      }
+    : undefined;
+  if (
+    entry.valuation.status === "available" &&
+    entry.valuation.source === "bitquery"
+  ) {
+    return {
+      ...entry,
+      ...(marketData ? { marketData } : {}),
+      valuation: {
+        status: "unavailable" as const,
+        reason,
+      },
+    };
+  }
+  return marketData ? { ...entry, marketData } : entry;
+}
+
+function deadline<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("Current market evidence deadline exceeded")),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function settleCurrentEvidenceSnapshot<T>(input: Readonly<{
+  read: Promise<T | null>;
+  requireComplete: boolean;
+  timeoutMs?: number;
+}>): Promise<T | null> {
+  try {
+    const snapshot = await deadline(
+      input.read,
+      input.timeoutMs ?? CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
+    );
+    if (snapshot === null && input.requireComplete) {
+      throw new Error("Current market evidence reference head is unavailable");
+    }
+    return snapshot;
+  } catch (error) {
+    if (input.requireComplete) throw error;
+    return null;
+  }
+}
+
+function knownLiquidityIneligible(token: LauncherToken | undefined): boolean {
+  const stateLiquidity = token?.liveMarketStateEvidence?.activeLiquidity;
+  if (stateLiquidity === "0") return true;
+  const activeDepth = token?.liveMarketPriceEvidence
+    ?.activeVirtualLiquidityUsdWad;
+  if (!activeDepth || !/^(?:0|[1-9]\d*)$/u.test(activeDepth)) return false;
+  return BigInt(activeDepth) <
+    BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD);
+}
+
+function baseValuedEntry(
+  entry: ExploreEntry,
+  marketByToken: ReadonlyMap<string, TokenMarketDataV1>,
+  context: Readonly<{ maximumValuationAgeMs?: number; now?: Date }>,
+): ValuedExploreEntry {
+  const marketData = entry.tokenAddress
+    ? marketByToken.get(entry.tokenAddress.toLowerCase())
+    : undefined;
+  if (marketData) {
+    return withBitqueryMarketData(entry, marketData, context);
+  }
+  return {
+    ...entry,
+    valuation: {
+      status: "unavailable",
+      reason:
+        entry.exploreKind === "custom-project" && entry.markets.length === 0
+          ? "no-market"
+          : "source-unavailable",
+    },
+  };
+}
+
+function classicNativeToken(entry: ExploreEntry): entry is Extract<
+  ExploreEntry,
+  { exploreKind: "token" }
+> {
+  return isCanonicalClassicNativeTokenEntry(entry);
+}
+
+/**
+ * Keeps Bitquery attached for trades, volume and charts, but promotes a public
+ * current FDV only from the independently bound StateView/Chainlink and
+ * official-v4 liquidity evidence paths.
+ */
+export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
+  entries: readonly ExploreEntry[];
+  marketByToken:
+    | ReadonlyMap<string, TokenMarketDataV1>
+    | Promise<ReadonlyMap<string, TokenMarketDataV1>>;
+  deployment: ReadyOnchainDeployment | null;
+  operationalSnapshot:
+    | ExploreSnapshot
+    | null
+    | Promise<ExploreSnapshot | null | CurrentEvidenceSnapshotOutcome>;
+  maximumValuationAgeMs?: number;
+  now?: Date;
+  requireCompleteLiquidityCoverage?: boolean;
+  allowHistoricalBitqueryFallback?: boolean;
+  timeoutMs?: number;
+}>): Promise<ValuedExploreEntry[]> {
+  const candidates = input.entries.filter(classicNativeToken);
+  const timeoutMs = input.timeoutMs ?? CURRENT_EVIDENCE_ROUTE_DEADLINE_MS;
+  const deployment = input.deployment?.chainId === 1
+    ? input.deployment
+    : null;
+  const operationalSnapshotRead = Promise.resolve(input.operationalSnapshot)
+    .then(
+      (value): CurrentEvidenceSnapshotOutcome =>
+        typeof value === "object" && value !== null &&
+          "status" in value &&
+          (value.status === "fulfilled" || value.status === "rejected")
+          ? value as CurrentEvidenceSnapshotOutcome
+          : { status: "fulfilled", value: value as ExploreSnapshot | null },
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    );
+  const canReadCurrentEvidence = candidates.length > 0 &&
+    timeoutMs > 0 &&
+    deployment !== null;
+
+  const currentEvidenceOutcome = canReadCurrentEvidence
+    ? deadline((async () => {
+        const operationalSnapshotOutcome = await operationalSnapshotRead;
+        if (operationalSnapshotOutcome.status === "rejected") {
+          throw operationalSnapshotOutcome.error;
+        }
+        const operationalSnapshot = operationalSnapshotOutcome.value;
+        if (operationalSnapshot === null) {
+          throw new Error(
+            "Current market evidence reference head is unavailable",
+          );
+        }
+        const liquidityRead = readOfficialV4LiquidityEvidence({
+          tokens: candidates,
+          referenceHead: {
+            chainId: 1,
+            blockNumber: operationalSnapshot.blockNumber,
+            blockHash: operationalSnapshot.blockHash,
+          },
+          now: input.now,
+        });
+        const pricedSnapshotRead = withSameBlockEthUsdQuote({
+          deployment,
+          snapshot: operationalSnapshot,
+        });
+        let liquidityCoverageFailed = false;
+        const [liquidityEvidence, pricedSnapshot] = await Promise.all([
+          input.requireCompleteLiquidityCoverage
+            ? liquidityRead
+            : liquidityRead.catch(
+                () => {
+                  liquidityCoverageFailed = true;
+                  return [] as readonly OfficialV4LiquidityEvidenceV1[];
+                },
+              ),
+          input.requireCompleteLiquidityCoverage
+            ? pricedSnapshotRead
+            : pricedSnapshotRead.catch(() => null),
+        ]);
+        if (liquidityCoverageFailed) {
+          return { status: "source-unavailable" as const };
+        }
+        const liquidityByPool = new Map(
+          liquidityEvidence.map((evidence) => [
+            evidence.identity.poolId.toLowerCase(),
+            evidence,
+          ]),
+        );
+        const priceCandidates = candidates.filter((entry) =>
+          liquidityByPool.has(entry.poolId.toLowerCase()),
+        );
+        const pricedTokens = pricedSnapshot && priceCandidates.length > 0
+          ? await enrichTokensWithAlchemyPoolState({
+              deployment,
+              snapshot: pricedSnapshot,
+              tokens: priceCandidates,
+            }).catch((error) => {
+              if (input.requireCompleteLiquidityCoverage) throw error;
+              return [] as LauncherToken[];
+            })
+          : [];
+        const pricedByToken = new Map(
+          pricedTokens.map((token) => [
+            token.tokenAddress.toLowerCase(),
+            token,
+          ]),
+        );
+        const stateCoverageIncomplete =
+          input.requireCompleteLiquidityCoverage &&
+          priceCandidates.some((candidate) => {
+            const priced = pricedByToken.get(
+              candidate.tokenAddress.toLowerCase(),
+            );
+            const state = priced?.liveMarketStateEvidence;
+            const price = priced?.liveMarketPriceEvidence;
+            const exactState = state !== undefined &&
+              state.blockNumber === operationalSnapshot.blockNumber &&
+              state.blockHash.toLowerCase() ===
+                operationalSnapshot.blockHash.toLowerCase();
+            const exactPrice = price !== undefined &&
+              price.blockNumber === operationalSnapshot.blockNumber &&
+              price.blockHash.toLowerCase() ===
+                operationalSnapshot.blockHash.toLowerCase();
+            return !exactState ||
+              (state.activeLiquidity !== "0" && !exactPrice);
+          });
+        if (stateCoverageIncomplete) {
+          throw new Error("Current StateView market evidence is incomplete");
+        }
+        return {
+          status: "complete" as const,
+          liquidityByPool,
+          pricedByToken,
+        };
+      })(), timeoutMs).then(
+      (value) => ({ status: "fulfilled" as const, value }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    )
+    : null;
+
+  const marketByToken = await input.marketByToken;
+  const marketEntries = input.entries.map((entry) =>
+    baseValuedEntry(entry, marketByToken, {
+      maximumValuationAgeMs: input.maximumValuationAgeMs,
+      now: input.now,
+    }),
+  );
+  const baseEntries = marketEntries.map((entry) =>
+    withoutUnevidencedCurrentBitqueryValuation(
+      entry,
+      input.allowHistoricalBitqueryFallback === true,
+    ),
+  );
+  if (candidates.length === 0) return baseEntries;
+  if (!canReadCurrentEvidence || currentEvidenceOutcome === null) {
+    if (input.requireCompleteLiquidityCoverage) {
+      throw new Error(timeoutMs <= 0
+        ? "Current market evidence deadline exceeded"
+        : "Current market evidence reference head is unavailable");
+    }
+    return baseEntries;
+  }
+
+  const outcome = await currentEvidenceOutcome;
+  if (outcome.status === "rejected") {
+    if (input.requireCompleteLiquidityCoverage) throw outcome.error;
+    return baseEntries;
+  }
+  if (outcome.value.status === "source-unavailable") return baseEntries;
+  const { liquidityByPool, pricedByToken } = outcome.value;
+  return marketEntries.map((entry) => {
+    if (entry.exploreKind !== "token") return entry;
+    const priced = pricedByToken.get(entry.tokenAddress.toLowerCase());
+    const currentEntry = priced
+      ? ({ ...entry, ...priced } as typeof entry)
+      : entry;
+    const valued = withCurrentOnchainValuation(
+      currentEntry,
+      liquidityByPool.get(entry.poolId.toLowerCase()),
+    );
+    if (!liquidityByPool.has(entry.poolId.toLowerCase())) {
+      return withoutUnevidencedCurrentBitqueryValuation(
+        valued,
+        input.allowHistoricalBitqueryFallback === true,
+        "liquidity-unavailable",
+      );
+    }
+    if (knownLiquidityIneligible(priced)) {
+      return withoutUnevidencedCurrentBitqueryValuation(
+        valued,
+        input.allowHistoricalBitqueryFallback === true,
+        "liquidity-unavailable",
+      );
+    }
+    return withoutUnevidencedCurrentBitqueryValuation(
+      valued,
+      input.allowHistoricalBitqueryFallback === true,
+      "source-unavailable",
+    );
+  });
+}

--- a/lib/market-data/explore-market-identities.ts
+++ b/lib/market-data/explore-market-identities.ts
@@ -1,39 +1,50 @@
-import type { ExploreEntry } from "../tokens";
-import type { MarketDataIdentityV1 } from "./market-data-v1";
+import { isLaunchStampProvenanceV1, type ExploreEntry } from "../tokens";
+import type { MarketChartIdentityV1 } from "./market-data-v1";
 
 const ADDRESS = /^0x[0-9a-f]{40}$/u;
 const BYTES32 = /^0x[0-9a-f]{64}$/u;
+const NATIVE_ETH_ADDRESS =
+  "0x0000000000000000000000000000000000000000" as const;
 
 export function exploreEntryMarketIdentitiesV1(
   entry: ExploreEntry,
-): readonly MarketDataIdentityV1[] {
+): readonly MarketChartIdentityV1[] {
   const tokenAddress = canonicalAddress(entry.tokenAddress);
   if (tokenAddress === null) return [];
   if (entry.exploreKind === "token") {
     const chainId = entry.launchStampProvenance?.chainId ??
       parseChainIdFromTokenId(entry.id);
     const poolId = canonicalPoolId(entry.poolId);
-    return chainId === 1 && poolId !== null
+    const quoteAddress = poolId === null
+      ? null
+      : canonicalTokenQuoteAddress(entry, tokenAddress, poolId);
+    return chainId === 1 && poolId !== null && quoteAddress !== null
       ? [{
           chainId: "1",
           tokenAddress,
           poolId,
+          quoteAddress,
           protocol: "uniswap_v4",
         }]
       : [];
   }
   if (entry.chainId !== "1") return [];
-  const byPool = new Map<string, MarketDataIdentityV1>();
+  const byPool = new Map<string, MarketChartIdentityV1>();
   for (const market of entry.markets) {
     const poolId = canonicalPoolId(market.poolId);
     if (poolId === null || market.status === "verification_pending") continue;
     const base = canonicalAddress(market.baseAsset.identity.value);
     const quote = canonicalAddress(market.quoteAsset.identity.value);
     if (base !== tokenAddress && quote !== tokenAddress) continue;
+    const oppositeAddress: `0x${string}` | null = base === tokenAddress
+      ? quote
+      : base;
+    if (oppositeAddress === null || oppositeAddress === tokenAddress) continue;
     byPool.set(poolId, {
       chainId: "1",
       tokenAddress,
       poolId,
+      quoteAddress: oppositeAddress,
       protocol: "uniswap_v4",
     });
   }
@@ -44,14 +55,18 @@ export function exploreEntryMarketIdentitiesV1(
 
 export function exploreEntriesMarketIdentitiesV1(
   entries: readonly ExploreEntry[],
-): readonly MarketDataIdentityV1[] {
-  const byPool = new Map<string, MarketDataIdentityV1>();
+): readonly MarketChartIdentityV1[] {
+  const byPool = new Map<string, MarketChartIdentityV1>();
   const conflictedPools = new Set<string>();
   for (const entry of entries) {
     for (const identity of exploreEntryMarketIdentitiesV1(entry)) {
       if (conflictedPools.has(identity.poolId)) continue;
       const existing = byPool.get(identity.poolId);
-      if (existing && existing.tokenAddress !== identity.tokenAddress) {
+      if (
+        existing &&
+        (existing.tokenAddress !== identity.tokenAddress ||
+          existing.quoteAddress !== identity.quoteAddress)
+      ) {
         byPool.delete(identity.poolId);
         conflictedPools.add(identity.poolId);
         continue;
@@ -62,6 +77,39 @@ export function exploreEntriesMarketIdentitiesV1(
   return [...byPool.values()].sort((first, second) =>
     first.poolId.localeCompare(second.poolId)
   );
+}
+
+function canonicalTokenQuoteAddress(
+  entry: Extract<ExploreEntry, { exploreKind: "token" }>,
+  tokenAddress: `0x${string}`,
+  poolId: `0x${string}`,
+): `0x${string}` | null {
+  const stamp = entry.launchStampProvenance;
+  if (stamp) {
+    if (!isLaunchStampProvenanceV1(stamp, {
+      chainId: 1,
+      tokenAddress,
+      hookAddress: entry.hookAddress,
+      poolId,
+    })) return null;
+    const currency0 = canonicalAddress(stamp.poolKey.currency0);
+    const currency1 = canonicalAddress(stamp.poolKey.currency1);
+    if (currency0 === tokenAddress && currency1 !== tokenAddress) {
+      return currency1;
+    }
+    if (currency1 === tokenAddress && currency0 !== tokenAddress) {
+      return currency0;
+    }
+    return null;
+  }
+  const configuredQuote = canonicalAddress(entry.quoteAssetAddress);
+  if (configuredQuote !== null && configuredQuote !== tokenAddress) {
+    return configuredQuote;
+  }
+  return entry.launchModel === "stock-paired" ||
+      entry.launchModel === "custom-graph"
+    ? null
+    : NATIVE_ETH_ADDRESS;
 }
 
 function parseChainIdFromTokenId(value: string): number | null {

--- a/lib/market-data/market-data-v1.ts
+++ b/lib/market-data/market-data-v1.ts
@@ -26,6 +26,10 @@ export type MarketDataIdentityV1 = Readonly<{
   protocol: "uniswap_v4";
 }>;
 
+export type MarketChartIdentityV1 = MarketDataIdentityV1 & Readonly<{
+  quoteAddress: `0x${string}`;
+}>;
+
 export type MarketDataFreshnessV1 = "current" | "stale";
 
 export type MarketValuationV1 =
@@ -142,12 +146,12 @@ export type MarketChartV1 = Readonly<{
     | "waiting-for-first-trade"
     | "unavailable";
   generatedAt: string;
-  identity: MarketDataIdentityV1;
+  identity: MarketChartIdentityV1;
   range: "1h" | "1d" | "1w" | "all";
   points: readonly MarketChartPointV1[];
   swapCount: number;
   volumeUsdWad?: string;
-  valuation: MarketValuationV1;
+  valuation: Extract<MarketValuationV1, { status: "unavailable" }>;
   asOfTime?: string;
   truncated: boolean;
 }>;
@@ -180,6 +184,19 @@ export function isMarketDataIdentityV1(
     BYTES32.test(value.poolId) &&
     value.poolId === value.poolId.toLowerCase() &&
     value.protocol === "uniswap_v4";
+}
+
+export function isMarketChartIdentityV1(
+  value: unknown,
+): value is MarketChartIdentityV1 {
+  if (!isMarketDataIdentityV1(value) || !("quoteAddress" in value)) {
+    return false;
+  }
+  const quoteAddress = value.quoteAddress;
+  return typeof quoteAddress === "string" &&
+    ADDRESS.test(quoteAddress) &&
+    quoteAddress === quoteAddress.toLowerCase() &&
+    quoteAddress !== value.tokenAddress;
 }
 
 export function isMarketValuationV1(
@@ -265,7 +282,7 @@ export function isMarketChartV1(value: unknown): value is MarketChartV1 {
       "unavailable",
     ].includes(String(value.status)) ||
     !validIsoTime(value.generatedAt) ||
-    !isMarketDataIdentityV1(value.identity) ||
+    !isMarketChartIdentityV1(value.identity) ||
     !["1h", "1d", "1w", "all"].includes(String(value.range)) ||
     !Array.isArray(value.points) ||
     !Number.isSafeInteger(value.swapCount) ||

--- a/lib/market-data/market-data-v1.ts
+++ b/lib/market-data/market-data-v1.ts
@@ -111,6 +111,10 @@ export type TokenMarketDataV1 = Readonly<{
 export type MarketChartPointV1 = Readonly<{
   blockNumber: string;
   time: string;
+  bucketStart: string;
+  bucketEnd: string;
+  observedAt: string;
+  valueSemantics: "period-median";
   priceUsd?: string;
   priceQuote?: string;
   quoteSymbol?: string;
@@ -278,15 +282,19 @@ export function isMarketChartV1(value: unknown): value is MarketChartV1 {
   const typedPoints = points as MarketChartPointV1[];
   let previousBlock: bigint | null = null;
   let previousTime = Number.NEGATIVE_INFINITY;
+  let previousBucketEnd = Number.NEGATIVE_INFINITY;
   for (const point of typedPoints) {
     const block = BigInt(point.blockNumber);
     const time = Date.parse(point.time);
+    const bucketStart = Date.parse(point.bucketStart);
     if (
       (previousBlock !== null && block <= previousBlock) ||
-      time < previousTime
+      time < previousTime ||
+      bucketStart < previousBucketEnd
     ) return false;
     previousBlock = block;
     previousTime = time;
+    previousBucketEnd = Date.parse(point.bucketEnd);
   }
   const observedTrades = typedPoints.reduce(
     (total, point) => total + point.tradeCount,
@@ -309,7 +317,7 @@ export function isMarketChartV1(value: unknown): value is MarketChartV1 {
       value.volumeUsdWad !== undefined ||
       value.asOfTime !== undefined
     ) return false;
-  } else if (value.asOfTime !== typedPoints.at(-1)?.time) {
+  } else if (value.asOfTime !== typedPoints.at(-1)?.observedAt) {
     return false;
   }
   if (value.status === "ready") {
@@ -453,7 +461,18 @@ function isMarketLiquidityV1(value: unknown): value is MarketLiquidityV1 {
 }
 
 function isMarketChartPointV1(value: unknown): value is MarketChartPointV1 {
-  return isRecord(value) &&
+  if (!isRecord(value)) return false;
+  if (
+    value.valueSemantics !== "period-median" ||
+    !validIsoTime(value.bucketStart) ||
+    !validIsoTime(value.bucketEnd) ||
+    !validIsoTime(value.observedAt) ||
+    value.time !== value.bucketEnd ||
+    Date.parse(value.bucketStart) >= Date.parse(value.bucketEnd) ||
+    Date.parse(value.observedAt) < Date.parse(value.bucketStart) ||
+    Date.parse(value.observedAt) > Date.parse(value.bucketEnd)
+  ) return false;
+  return (
     CANONICAL_UNSIGNED_INTEGER.test(String(value.blockNumber)) &&
     validIsoTime(value.time) &&
     optionalPositiveDecimal(value.priceUsd) &&
@@ -468,7 +487,8 @@ function isMarketChartPointV1(value: unknown): value is MarketChartPointV1 {
     Number.isSafeInteger(value.tradeCount) &&
     Number(value.tradeCount) > 0 &&
     (value.quoteSymbol === undefined ||
-      (typeof value.quoteSymbol === "string" && value.quoteSymbol.trim() !== ""));
+      (typeof value.quoteSymbol === "string" && value.quoteSymbol.trim() !== ""))
+  );
 }
 
 function isMarketOhlcV1(value: unknown): value is MarketOhlcV1 {

--- a/lib/market-data/market-data-v1.ts
+++ b/lib/market-data/market-data-v1.ts
@@ -9,10 +9,8 @@ export const PROGRAMMABLE_MARKET_CHART_ERROR_SCHEMA_VERSION =
 
 export const MARKET_DATA_CURRENT_MAX_AGE_MS = 5 * 60 * 1_000;
 
-// A public current FDV needs enough exact-pool depth to make a single dust
-// trade an insufficient price signal. This is deliberately conservative: a
-// launch remains discoverable when it is below the threshold, but its USD FDV
-// is unavailable instead of being ranked from an unsafe observation.
+// This threshold is an eligibility rule for publishing a current FDV. It does
+// not claim executable depth, manipulation resistance or price-impact bounds.
 export const MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD =
   "10000000000000000000000" as const;
 export const MARKET_DATA_MAXIMUM_RAW_INDEXED_PRICE_DEVIATION_BPS = 1_000 as const;

--- a/lib/onchain/config.ts
+++ b/lib/onchain/config.ts
@@ -3,6 +3,8 @@ import { getAddress, isAddress, isHex, type Address, type Hex } from "viem";
 import appDeploymentsJson from "../../contracts/config/app-deployments.v1.json";
 import mainnetDependencies from "../../contracts/dependencies/ethereum-mainnet.json";
 import sepoliaDependencies from "../../contracts/dependencies/ethereum-sepolia.json";
+import { rpcProviderCommitment } from
+  "../data-pipeline/rpc-provider-commitments";
 
 import type {
   DeploymentEnvironment,
@@ -79,10 +81,108 @@ function productionSecondaryRpc() {
   );
 }
 
-const WEBSITE_MAINNET_RPC_PRIMARY =
-  "https://ethereum-rpc.publicnode.com";
-const WEBSITE_MAINNET_RPC_SECONDARY = "https://eth.drpc.org";
-const WEBSITE_MAINNET_CHART_RPC_SECONDARY = "https://rpc.mevblocker.io";
+const ALCHEMY_MAINNET_RPC_HOST = "eth-mainnet.g.alchemy.com";
+const ALCHEMY_MAINNET_RPC_PATH = /^\/v2\/[A-Za-z0-9_-]{8,256}$/u;
+const QUICKNODE_MAINNET_RPC_HOST =
+  /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+quiknode\.pro$/u;
+const QUICKNODE_MAINNET_RPC_PATH = /^\/[A-Za-z0-9_-]{8,256}\/?$/u;
+const RPC_ENDPOINT_COMMITMENT = /^0x[0-9a-f]{64}$/u;
+
+type WebsiteRpcProvider = "Alchemy" | "QuickNode";
+
+function selectedWebsiteRpcValue(
+  preferred: string | undefined,
+  legacy: string | undefined,
+) {
+  return preferred === undefined || preferred === ""
+    ? legacy
+    : preferred;
+}
+
+function strictWebsiteRpcUrl(
+  value: string | undefined,
+  provider: WebsiteRpcProvider,
+) {
+  if (
+    typeof value !== "string" ||
+    value.length < 1 ||
+    value.length > 1_024 ||
+    value !== value.trim()
+  ) {
+    throw new Error(`Website ${provider} RPC binding is unavailable`);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`Website ${provider} RPC binding is invalid`);
+  }
+  const validProvider = provider === "Alchemy"
+    ? parsed.hostname === ALCHEMY_MAINNET_RPC_HOST &&
+      ALCHEMY_MAINNET_RPC_PATH.test(parsed.pathname)
+    : QUICKNODE_MAINNET_RPC_HOST.test(parsed.hostname) &&
+      QUICKNODE_MAINNET_RPC_PATH.test(parsed.pathname);
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.port !== "" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    !validProvider
+  ) {
+    throw new Error(`Website ${provider} RPC binding is invalid`);
+  }
+  return parsed.href;
+}
+
+function requiredWebsiteRpcCommitment(
+  value: string | undefined,
+  provider: WebsiteRpcProvider,
+) {
+  if (!value || !RPC_ENDPOINT_COMMITMENT.test(value)) {
+    throw new Error(
+      `Website ${provider} RPC endpoint commitment is unavailable`,
+    );
+  }
+  return value;
+}
+
+function websiteMainnetRpcPair() {
+  const alchemyUrl = strictWebsiteRpcUrl(
+    selectedWebsiteRpcValue(
+      process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
+      process.env.ETHEREUM_RPC_URL,
+    ),
+    "Alchemy",
+  );
+  const quickNodeUrl = strictWebsiteRpcUrl(
+    selectedWebsiteRpcValue(
+      process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
+      process.env.ETHEREUM_RPC_URL_B,
+    ),
+    "QuickNode",
+  );
+  const alchemyCommitment = requiredWebsiteRpcCommitment(
+    process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT,
+    "Alchemy",
+  );
+  const quickNodeCommitment = requiredWebsiteRpcCommitment(
+    process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT,
+    "QuickNode",
+  );
+  if (
+    alchemyCommitment === quickNodeCommitment ||
+    rpcProviderCommitment("endpoint", alchemyUrl) !==
+      alchemyCommitment ||
+    rpcProviderCommitment("endpoint", quickNodeUrl) !==
+      quickNodeCommitment
+  ) {
+    throw new Error("Website RPC endpoint commitment mismatch");
+  }
+  return { alchemyUrl, quickNodeUrl } as const;
+}
 
 export function selectedDeploymentEnvironment(
   value = process.env.PROGRAMMABLE_ONCHAIN_NETWORK,
@@ -247,29 +347,24 @@ export function getWebsiteReadOnchainDeployment(
 ): OnchainDeployment {
   const deployment = resolveOnchainDeployment(environment, true);
   if (deployment.environment !== "production") return deployment;
+  const rpc = websiteMainnetRpcPair();
 
   return {
     ...deployment,
-    rpcUrl: WEBSITE_MAINNET_RPC_PRIMARY,
-    rpcUrlSecondary: WEBSITE_MAINNET_RPC_SECONDARY,
+    rpcUrl: rpc.alchemyUrl,
+    rpcUrlSecondary: rpc.quickNodeUrl,
   };
 }
 
 /**
- * Historical log reads need one fixed archive-capable fallback. Current
- * Website reads use the independently verified PublicNode + dRPC pair above;
- * charts keep MEV Blocker as their narrow, fixed archive secondary.
+ * Historical reads use the same commitment-bound pair. The shared failover
+ * runner permits one complete QuickNode attempt only after an eligible
+ * Alchemy transport, capacity or archive failure.
  */
 export function getWebsiteChartOnchainDeployment(
   environment = selectedDeploymentEnvironment(),
 ): OnchainDeployment {
-  const deployment = getWebsiteReadOnchainDeployment(environment);
-  if (deployment.environment !== "production") return deployment;
-
-  return {
-    ...deployment,
-    rpcUrlSecondary: WEBSITE_MAINNET_CHART_RPC_SECONDARY,
-  };
+  return getWebsiteReadOnchainDeployment(environment);
 }
 
 export function getPublicOnchainDeployment(

--- a/lib/onchain/explore-read-source.ts
+++ b/lib/onchain/explore-read-source.ts
@@ -32,7 +32,9 @@ async function enrichOrReturn(
   try {
     return await dependencies.enrichWithUsd(model, config);
   } catch (cause) {
-    dependencies.error("ETH/USD enrichment failed", cause);
+    dependencies.error("ETH/USD enrichment failed", {
+      name: cause instanceof Error ? cause.name : "UnknownError",
+    });
     return model;
   }
 }

--- a/lib/onchain/operational-rpc-failover.server.ts
+++ b/lib/onchain/operational-rpc-failover.server.ts
@@ -13,6 +13,8 @@ const CAPACITY_MESSAGE =
   /(?:monthly[_\s-]*capacity[_\s-]*(?:exceeded|reached)|capacity[_\s-]*(?:exceeded|reached)|rate[_\s-]*limit(?:ed)?|too many requests)/iu;
 const ARCHIVE_LIMITATION_MESSAGE =
   /archive requests require a personal token/iu;
+const PROVIDER_ROUTING_UNAVAILABLE_MESSAGE =
+  /can't route your request to suitable provider/iu;
 
 function errorChain(error: unknown) {
   const chain: unknown[] = [];
@@ -27,6 +29,16 @@ function errorChain(error: unknown) {
         : undefined;
   }
   return chain;
+}
+
+function containsRpcEndpointError(error: unknown) {
+  return errorChain(error).some(
+    (candidate) =>
+      candidate instanceof HttpRequestError ||
+      candidate instanceof RpcRequestError ||
+      candidate instanceof SocketClosedError ||
+      candidate instanceof TimeoutError,
+  );
 }
 
 function rpcCapacityMessage(error: RpcRequestError) {
@@ -47,11 +59,23 @@ function rpcArchiveLimitationMessage(error: RpcRequestError) {
   return details.some((value) => ARCHIVE_LIMITATION_MESSAGE.test(value));
 }
 
+function rpcProviderRoutingUnavailable(error: RpcRequestError) {
+  const details = [
+    error.details,
+    typeof error.data === "string" ? error.data : undefined,
+    error.cause instanceof Error ? error.cause.message : undefined,
+  ].filter((value): value is string => Boolean(value));
+  return error.code === 12 && details.some(
+    (value) => PROVIDER_ROUTING_UNAVAILABLE_MESSAGE.test(value),
+  );
+}
+
 /**
  * Provider failover is intentionally narrower than a generic retry. A
  * secondary RPC is eligible only when the primary transport is unavailable or
- * explicitly rejects capacity. Contract, chain, decoding and integrity errors
- * stay on the primary path and remain visible to the caller.
+ * explicitly rejects capacity. Other failures stay on the primary path;
+ * provider-independent integrity errors remain intact while endpoint-bearing
+ * viem errors are redacted before they reach framework logging.
  */
 export function isOperationalRpcFailoverEligible(error: unknown) {
   return errorChain(error).some((candidate) => {
@@ -75,7 +99,8 @@ export function isOperationalRpcFailoverEligible(error: unknown) {
         candidate.code === 429 ||
         candidate.code === -32_005 ||
         rpcCapacityMessage(candidate) ||
-        rpcArchiveLimitationMessage(candidate)
+        rpcArchiveLimitationMessage(candidate) ||
+        rpcProviderRoutingUnavailable(candidate)
       );
     }
     return false;
@@ -101,6 +126,20 @@ export class OperationalRpcUnavailableError extends Error {
   }
 }
 
+export class OperationalRpcReadError extends Error {
+  override name = "OperationalRpcReadError";
+
+  constructor() {
+    super("Operational RPC read failed");
+  }
+}
+
+function redactRpcEndpointError(error: unknown) {
+  return containsRpcEndpointError(error)
+    ? new OperationalRpcReadError()
+    : error;
+}
+
 /**
  * Runs one complete read against the configured primary. The fixed secondary
  * receives exactly one attempt only after an eligible transport/capacity
@@ -123,7 +162,7 @@ export async function withOperationalRpcFailover<
       secondaryUrl === deployment.rpcUrl ||
       !isOperationalRpcFailoverEligible(primaryError)
     ) {
-      throw primaryError;
+      throw redactRpcEndpointError(primaryError);
     }
 
     try {
@@ -134,7 +173,7 @@ export async function withOperationalRpcFailover<
         // nested causes and can otherwise expose authenticated RPC URLs.
         throw new OperationalRpcUnavailableError();
       }
-      throw secondaryError;
+      throw redactRpcEndpointError(secondaryError);
     }
   }
 }

--- a/lib/onchain/types.ts
+++ b/lib/onchain/types.ts
@@ -128,6 +128,7 @@ export type ExploreSnapshot = {
   ethUsdQuote?: {
     feedAddress: Address;
     roundId: string;
+    answeredInRound?: string;
     answer: string;
     decimals: number;
     updatedAt: string;

--- a/lib/onchain/types.ts
+++ b/lib/onchain/types.ts
@@ -123,6 +123,7 @@ export type ExploreSnapshot = {
   chainId: number;
   blockNumber: string;
   blockHash: Hex;
+  blockTimestamp?: string;
   confirmations: number;
   ethUsdQuote?: {
     feedAddress: Address;

--- a/lib/onchain/uniswap-v4-subgraph.ts
+++ b/lib/onchain/uniswap-v4-subgraph.ts
@@ -2,17 +2,28 @@ import "server-only";
 
 import { formatUnits } from "viem";
 
+import {
+  MARKET_DATA_CURRENT_MAX_AGE_MS,
+  MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD,
+} from "../market-data/market-data-v1";
 import type { LauncherToken } from "../tokens";
 import { computeOfficialV4PoolId } from "../uniswap/liquidity-launcher-sdk";
 import { marketCapNativeWadFromSqrtPriceX96 } from "./math";
 import type { ExplorePage } from "./types";
 import { usdValueFromWei } from "./usd";
 
+export const OFFICIAL_MAINNET_V4_SUBGRAPH_ID =
+  "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G";
 const OFFICIAL_MAINNET_V4_SUBGRAPH_URL =
-  "https://gateway.thegraph.com/api/subgraphs/id/DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G";
-const OFFICIAL_MAINNET_V4_SUBGRAPH_DEPLOYMENT =
+  `https://gateway.thegraph.com/api/subgraphs/id/${OFFICIAL_MAINNET_V4_SUBGRAPH_ID}`;
+export const OFFICIAL_MAINNET_V4_SUBGRAPH_DEPLOYMENT =
   "QmZsgJLiLQKpb8hxTmQ5LWyrFVvfWzVaL4WK8dfFBn7EeK";
+export const OFFICIAL_V4_LIQUIDITY_EVIDENCE_SOURCE =
+  "official-uniswap-v4-subgraph" as const;
+export const OFFICIAL_V4_POOL_TVL_ELIGIBILITY_MINIMUM_USD_WAD =
+  MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD;
 export const OFFICIAL_V4_SUBGRAPH_MAXIMUM_POOL_IDS = 24;
+export const OFFICIAL_V4_LIQUIDITY_MAXIMUM_POOL_IDS_PER_READ = 384;
 const MAXIMUM_RESPONSE_BYTES = 128 * 1024;
 const DEFAULT_TIMEOUT_MS = 2_500;
 const SERVER_CACHE_TTL_MS = 15_000;
@@ -32,6 +43,7 @@ const POOL_ANALYTICS_QUERY = `
       block {
         number
         hash
+        timestamp
       }
       hasIndexingErrors
     }
@@ -42,8 +54,8 @@ const POOL_ANALYTICS_QUERY = `
       orderDirection: asc
     ) {
       id
-      token0 { id }
-      token1 { id }
+      token0 { id decimals }
+      token1 { id decimals }
       hooks
       feeTier
       tickSpacing
@@ -52,6 +64,8 @@ const POOL_ANALYTICS_QUERY = `
       tick
       txCount
       volumeUSD
+      totalValueLockedToken0
+      totalValueLockedToken1
       totalValueLockedUSD
     }
   }
@@ -62,7 +76,9 @@ type Fetcher = (input: string, init?: RequestInit) => Promise<Response>;
 type ParsedPool = {
   id: `0x${string}`;
   token0: `0x${string}`;
+  token0Decimals: number;
   token1: `0x${string}`;
+  token1Decimals: number;
   hooks: `0x${string}`;
   feeTierPips: string;
   tickSpacing: number;
@@ -71,6 +87,8 @@ type ParsedPool = {
   tick?: number;
   transactionCount: string;
   volumeUsdWad: string;
+  totalValueLockedToken0: string;
+  totalValueLockedToken1: string;
   tvlUsdWad: string;
 };
 
@@ -78,15 +96,73 @@ type ParsedResponse = {
   deployment: string;
   indexedBlockNumber: string;
   indexedBlockHash: `0x${string}`;
+  indexedBlockTimestamp: string;
+  indexedBlockTime: string;
   pools: ParsedPool[];
 };
 
-type EnrichmentOptions = {
+export type OfficialV4SubgraphOptions = {
   apiKey?: string;
   endpoint?: string;
   timeoutMs?: number;
   fetcher?: Fetcher;
 };
+
+export type OfficialV4LiquidityEvidenceV1 = Readonly<{
+  source: typeof OFFICIAL_V4_LIQUIDITY_EVIDENCE_SOURCE;
+  identity: Readonly<{
+    chainId: "1";
+    protocol: "uniswap_v4";
+    poolId: `0x${string}`;
+    tokenAddress: `0x${string}`;
+    quoteAddress: `0x${string}`;
+  }>;
+  valueBasis: "official-subgraph-pool-tvl-usd";
+  tvlUsdWad: string;
+  reportedPoolBalances: Readonly<{
+    token0: Readonly<{
+      address: `0x${string}`;
+      decimals: number;
+      amountDecimal: string;
+    }>;
+    token1: Readonly<{
+      address: `0x${string}`;
+      decimals: number;
+      amountDecimal: string;
+    }>;
+  }>;
+  freshness: "current";
+  provenance: Readonly<{
+    subgraphId: typeof OFFICIAL_MAINNET_V4_SUBGRAPH_ID;
+    deployment: typeof OFFICIAL_MAINNET_V4_SUBGRAPH_DEPLOYMENT;
+    indexedBlockNumber: string;
+    indexedBlockHash: `0x${string}`;
+    indexedBlockTimestamp: string;
+    indexedBlockTime: string;
+    referenceHeadBlockNumber: string;
+    referenceHeadBlockHash: `0x${string}`;
+    lagBlocks: string;
+  }>;
+}>;
+
+export type OfficialV4LiquidityReferenceHeadV1 = Readonly<{
+  chainId: 1;
+  blockNumber: string;
+  blockHash: `0x${string}`;
+}>;
+
+export class OfficialV4LiquidityEvidenceReadError extends Error {
+  readonly code:
+    | "invalid-input"
+    | "invalid-config"
+    | "coverage-incomplete";
+
+  constructor(code: OfficialV4LiquidityEvidenceReadError["code"]) {
+    super(`Official Uniswap v4 liquidity evidence read failed: ${code}`);
+    this.name = "OfficialV4LiquidityEvidenceReadError";
+    this.code = code;
+  }
+}
 
 type FetcherState = {
   cache: Map<string, { expiresAt: number; response: ParsedResponse }>;
@@ -189,7 +265,20 @@ function strictTickSpacing(value: unknown): number {
   return parsed;
 }
 
-function decimalToWad(value: unknown): string {
+function strictDecimals(value: unknown): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && /^(0|[1-9]\d*)$/.test(value)
+        ? Number(value)
+        : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > 255) {
+    return invalidResponse();
+  }
+  return parsed;
+}
+
+function strictUnsignedDecimal(value: unknown): string {
   if (
     typeof value !== "string" ||
     value.length > 160 ||
@@ -201,11 +290,31 @@ function decimalToWad(value: unknown): string {
   if (integerPart.length > 78 || fractionalPart.length > 78) {
     return invalidResponse();
   }
+  return value;
+}
+
+function decimalToWad(value: unknown): string {
+  const decimal = strictUnsignedDecimal(value);
+  const [integerPart, fractionalPart = ""] = decimal.split(".");
   const fraction = `${fractionalPart}000000000000000000`.slice(0, 18);
   return (
     BigInt(integerPart) * 10n ** 18n +
     BigInt(fraction || "0")
   ).toString();
+}
+
+function strictBlockTimestamp(value: unknown): {
+  timestamp: string;
+  time: string;
+} {
+  const timestamp = strictBlockNumber(value);
+  if (timestamp > 8_640_000_000_000n) return invalidResponse();
+  const milliseconds = Number(timestamp) * 1_000;
+  const date = new Date(milliseconds);
+  if (!Number.isFinite(milliseconds) || Number.isNaN(date.getTime())) {
+    return invalidResponse();
+  }
+  return { timestamp: timestamp.toString(), time: date.toISOString() };
 }
 
 function parsePool(value: unknown): ParsedPool {
@@ -223,12 +332,14 @@ function parsePool(value: unknown): ParsedPool {
       "tick",
       "txCount",
       "volumeUSD",
+      "totalValueLockedToken0",
+      "totalValueLockedToken1",
       "totalValueLockedUSD",
     ]) ||
     !isRecord(value.token0) ||
-    !hasOnlyKeys(value.token0, ["id"]) ||
+    !hasOnlyKeys(value.token0, ["id", "decimals"]) ||
     !isRecord(value.token1) ||
-    !hasOnlyKeys(value.token1, ["id"])
+    !hasOnlyKeys(value.token1, ["id", "decimals"])
   ) {
     return invalidResponse();
   }
@@ -263,7 +374,9 @@ function parsePool(value: unknown): ParsedPool {
   return {
     id,
     token0,
+    token0Decimals: strictDecimals(value.token0.decimals),
     token1,
+    token1Decimals: strictDecimals(value.token1.decimals),
     hooks,
     feeTierPips,
     tickSpacing,
@@ -272,6 +385,12 @@ function parsePool(value: unknown): ParsedPool {
     tick: strictTick(value.tick),
     transactionCount: strictUnsignedInteger(value.txCount),
     volumeUsdWad: decimalToWad(value.volumeUSD),
+    totalValueLockedToken0: strictUnsignedDecimal(
+      value.totalValueLockedToken0,
+    ),
+    totalValueLockedToken1: strictUnsignedDecimal(
+      value.totalValueLockedToken1,
+    ),
     tvlUsdWad: decimalToWad(value.totalValueLockedUSD),
   };
 }
@@ -293,7 +412,7 @@ export function parseOfficialV4SubgraphResponse(
     value.data._meta.deployment !== OFFICIAL_MAINNET_V4_SUBGRAPH_DEPLOYMENT ||
     value.data._meta.hasIndexingErrors !== false ||
     !isRecord(value.data._meta.block) ||
-    !hasOnlyKeys(value.data._meta.block, ["number", "hash"]) ||
+    !hasOnlyKeys(value.data._meta.block, ["number", "hash", "timestamp"]) ||
     !Array.isArray(value.data.pools) ||
     value.data.pools.length > OFFICIAL_V4_SUBGRAPH_MAXIMUM_POOL_IDS
   ) {
@@ -301,6 +420,9 @@ export function parseOfficialV4SubgraphResponse(
   }
 
   const indexedBlockNumber = strictBlockNumber(value.data._meta.block.number);
+  const indexedBlockTimestamp = strictBlockTimestamp(
+    value.data._meta.block.timestamp,
+  );
   const pools = value.data.pools.map(parsePool);
   const uniquePoolIds = new Set(pools.map((pool) => pool.id));
   if (uniquePoolIds.size !== pools.length) {
@@ -311,6 +433,8 @@ export function parseOfficialV4SubgraphResponse(
     deployment: OFFICIAL_MAINNET_V4_SUBGRAPH_DEPLOYMENT,
     indexedBlockNumber: indexedBlockNumber.toString(),
     indexedBlockHash: strictBytes32(value.data._meta.block.hash),
+    indexedBlockTimestamp: indexedBlockTimestamp.timestamp,
+    indexedBlockTime: indexedBlockTimestamp.time,
     pools,
   };
 }
@@ -345,7 +469,10 @@ function boundedTimeout(value: number | undefined) {
     : DEFAULT_TIMEOUT_MS;
 }
 
-function canonicalPoolIds(tokens: readonly LauncherToken[]) {
+function canonicalPoolIds(
+  tokens: readonly LauncherToken[],
+  maximum = OFFICIAL_V4_SUBGRAPH_MAXIMUM_POOL_IDS,
+) {
   const poolIds: string[] = [];
   const seen = new Set<string>();
   for (const token of tokens) {
@@ -353,7 +480,7 @@ function canonicalPoolIds(tokens: readonly LauncherToken[]) {
     if (!/^0x[0-9a-f]{64}$/.test(poolId) || seen.has(poolId)) continue;
     seen.add(poolId);
     poolIds.push(poolId);
-    if (poolIds.length === OFFICIAL_V4_SUBGRAPH_MAXIMUM_POOL_IDS) break;
+    if (poolIds.length === maximum) break;
   }
   return poolIds;
 }
@@ -533,6 +660,42 @@ function matchesCanonicalToken(pool: ParsedPool, token: LauncherToken) {
   );
 }
 
+function matchesCanonicalLiquidityEvidence(
+  pool: ParsedPool,
+  token: LauncherToken,
+) {
+  if (
+    !matchesCanonicalToken(pool, token) ||
+    typeof token.tokenDecimals !== "number" ||
+    !Number.isInteger(token.tokenDecimals) ||
+    token.tokenDecimals < 0 ||
+    token.tokenDecimals > 255
+  ) {
+    return false;
+  }
+
+  const tokenAddress = token.tokenAddress.toLowerCase();
+  const tokenIsCurrency0 = pool.token0 === tokenAddress;
+  const tokenDecimals = tokenIsCurrency0
+    ? pool.token0Decimals
+    : pool.token1Decimals;
+  const counterCurrencyDecimals = tokenIsCurrency0
+    ? pool.token1Decimals
+    : pool.token0Decimals;
+  if (
+    tokenDecimals !== token.tokenDecimals ||
+    counterCurrencyDecimals !== 18
+  ) {
+    return false;
+  }
+
+  if (token.launchModel !== "stock-paired") return true;
+  return (
+    typeof token.quoteIsCurrency0 === "boolean" &&
+    token.quoteIsCurrency0 === !tokenIsCurrency0
+  );
+}
+
 function snapshotIsCompatible(
   indexedBlockNumber: string,
   indexedBlockHash: `0x${string}`,
@@ -555,6 +718,272 @@ function snapshotIsCompatible(
     (indexed !== canonical ||
       indexedBlockHash.toLowerCase() === canonicalBlockHash.toLowerCase())
   );
+}
+
+function canonicalReferenceHead(
+  value: unknown,
+): OfficialV4LiquidityReferenceHeadV1 | undefined {
+  if (
+    !isRecord(value) ||
+    value.chainId !== 1 ||
+    typeof value.blockNumber !== "string" ||
+    !/^(0|[1-9]\d*)$/.test(value.blockNumber) ||
+    value.blockNumber.length > 78 ||
+    typeof value.blockHash !== "string" ||
+    !/^0x[0-9a-fA-F]{64}$/.test(value.blockHash)
+  ) {
+    return undefined;
+  }
+  return {
+    chainId: 1,
+    blockNumber: BigInt(value.blockNumber).toString(),
+    blockHash: value.blockHash.toLowerCase() as `0x${string}`,
+  };
+}
+
+function positiveDecimal(value: string) {
+  const [integerPart, fractionalPart = ""] = value.split(".");
+  return BigInt(integerPart) > 0n || /[1-9]/.test(fractionalPart);
+}
+
+function supportsOfficialPoolTvlEvidence(token: LauncherToken) {
+  return (
+    token.launchModel === "classic" ||
+    token.launchModel === "adaptive" ||
+    token.launchModel === "deep" ||
+    token.launchModel === "stock-paired"
+  );
+}
+
+function referenceHeadLag(
+  response: ParsedResponse,
+  referenceHead: OfficialV4LiquidityReferenceHeadV1,
+): string | undefined {
+  const indexed = BigInt(response.indexedBlockNumber);
+  const reference = BigInt(referenceHead.blockNumber);
+  if (indexed > reference) return undefined;
+  const lag = reference - indexed;
+  if (
+    lag > MAXIMUM_SUBGRAPH_LAG_BLOCKS ||
+    (lag === 0n &&
+      response.indexedBlockHash !== referenceHead.blockHash.toLowerCase())
+  ) {
+    return undefined;
+  }
+  return lag.toString();
+}
+
+function isCurrentIndexedTime(response: ParsedResponse, now: Date) {
+  const nowMs = now.getTime();
+  const indexedMs = Number(BigInt(response.indexedBlockTimestamp)) * 1_000;
+  return (
+    Number.isFinite(nowMs) &&
+    Number.isFinite(indexedMs) &&
+    indexedMs <= nowMs &&
+    nowMs - indexedMs <= MARKET_DATA_CURRENT_MAX_AGE_MS
+  );
+}
+
+function liquidityEvidence(
+  token: LauncherToken,
+  pool: ParsedPool,
+  response: ParsedResponse,
+  referenceHead: OfficialV4LiquidityReferenceHeadV1,
+  lagBlocks: string,
+): OfficialV4LiquidityEvidenceV1 | undefined {
+  if (
+    BigInt(pool.tvlUsdWad) <
+    BigInt(OFFICIAL_V4_POOL_TVL_ELIGIBILITY_MINIMUM_USD_WAD)
+  ) {
+    return undefined;
+  }
+  if (
+    !positiveDecimal(pool.totalValueLockedToken0) &&
+    !positiveDecimal(pool.totalValueLockedToken1)
+  ) {
+    throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
+  }
+  const tokenAddress = token.tokenAddress.toLowerCase() as `0x${string}`;
+  const quoteAddress = (
+    pool.token0 === tokenAddress ? pool.token1 : pool.token0
+  ) as `0x${string}`;
+  return {
+    source: OFFICIAL_V4_LIQUIDITY_EVIDENCE_SOURCE,
+    identity: {
+      chainId: "1",
+      protocol: "uniswap_v4",
+      poolId: pool.id,
+      tokenAddress,
+      quoteAddress,
+    },
+    valueBasis: "official-subgraph-pool-tvl-usd",
+    tvlUsdWad: pool.tvlUsdWad,
+    reportedPoolBalances: {
+      token0: {
+        address: pool.token0,
+        decimals: pool.token0Decimals,
+        amountDecimal: pool.totalValueLockedToken0,
+      },
+      token1: {
+        address: pool.token1,
+        decimals: pool.token1Decimals,
+        amountDecimal: pool.totalValueLockedToken1,
+      },
+    },
+    freshness: "current",
+    provenance: {
+      subgraphId: OFFICIAL_MAINNET_V4_SUBGRAPH_ID,
+      deployment: OFFICIAL_MAINNET_V4_SUBGRAPH_DEPLOYMENT,
+      indexedBlockNumber: response.indexedBlockNumber,
+      indexedBlockHash: response.indexedBlockHash,
+      indexedBlockTimestamp: response.indexedBlockTimestamp,
+      indexedBlockTime: response.indexedBlockTime,
+      referenceHeadBlockNumber: referenceHead.blockNumber,
+      referenceHeadBlockHash: referenceHead.blockHash,
+      lagBlocks,
+    },
+  };
+}
+
+/**
+ * Reads independently attributable official Uniswap v4 subgraph pool TVL.
+ *
+ * Evidence is returned only for a canonical PoolKey, a fresh indexed block at
+ * or behind the supplied reference head, and at least the public pool-TVL
+ * eligibility floor. This aggregate TVL does not prove current-tick USD depth
+ * or manipulation resistance. StateView's active-liquidity scalar is
+ * deliberately not interpreted as reserves or TVL, and a missing or rejected
+ * entry must stay unavailable.
+ * An empty result means every eligible requested pool was covered but none
+ * qualified. Invalid configuration or any failed batch rejects the whole read
+ * so global ordering can never mistake partial coverage for complete coverage.
+ */
+export async function readOfficialV4LiquidityEvidence(
+  input: {
+    tokens: readonly LauncherToken[];
+    referenceHead: OfficialV4LiquidityReferenceHeadV1;
+    now?: Date;
+  },
+  options: OfficialV4SubgraphOptions = {},
+): Promise<readonly OfficialV4LiquidityEvidenceV1[]> {
+  const eligibleTokens = input.tokens.filter(supportsOfficialPoolTvlEvidence);
+  if (eligibleTokens.length === 0) return [];
+
+  const referenceHead = canonicalReferenceHead(input.referenceHead);
+  const now = input.now ?? new Date();
+  if (!referenceHead || !Number.isFinite(now.getTime())) {
+    throw new OfficialV4LiquidityEvidenceReadError("invalid-input");
+  }
+
+  const apiKey =
+    options.apiKey ?? process.env.UNISWAP_V4_SUBGRAPH_API_KEY ?? "";
+  const endpoint =
+    options.endpoint ??
+    process.env.UNISWAP_V4_SUBGRAPH_URL ??
+    OFFICIAL_MAINNET_V4_SUBGRAPH_URL;
+  if (!validApiKey(apiKey) || !validEndpoint(endpoint)) {
+    throw new OfficialV4LiquidityEvidenceReadError("invalid-config");
+  }
+
+  const poolIds = canonicalPoolIds(
+    eligibleTokens,
+    OFFICIAL_V4_LIQUIDITY_MAXIMUM_POOL_IDS_PER_READ + 1,
+  );
+  if (poolIds.length === 0) return [];
+  if (poolIds.length > OFFICIAL_V4_LIQUIDITY_MAXIMUM_POOL_IDS_PER_READ) {
+    throw new OfficialV4LiquidityEvidenceReadError("invalid-input");
+  }
+
+  const fetcher = options.fetcher ?? fetch;
+  const requests: string[][] = [];
+  for (
+    let index = 0;
+    index < poolIds.length;
+    index += OFFICIAL_V4_SUBGRAPH_MAXIMUM_POOL_IDS
+  ) {
+    requests.push(
+      poolIds.slice(index, index + OFFICIAL_V4_SUBGRAPH_MAXIMUM_POOL_IDS),
+    );
+  }
+
+  const responses: ParsedResponse[] = [];
+  for (
+    let index = 0;
+    index < requests.length;
+    index += MAXIMUM_IN_FLIGHT_REQUESTS
+  ) {
+    let completed: {
+      response: ParsedResponse;
+      requestedPoolIds: string[];
+    }[];
+    try {
+      completed = await Promise.all(
+        requests
+          .slice(index, index + MAXIMUM_IN_FLIGHT_REQUESTS)
+          .map((requestedPoolIds) =>
+            fetchPoolAnalyticsCached({
+              endpoint,
+              apiKey,
+              poolIds: requestedPoolIds,
+              timeoutMs: boundedTimeout(options.timeoutMs),
+              fetcher,
+            }).then((response) => ({ response, requestedPoolIds })),
+          ),
+      );
+    } catch {
+      throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
+    }
+    for (const result of completed) {
+      const requested = new Set<string>(result.requestedPoolIds);
+      const returned = new Set<string>(
+        result.response.pools.map((pool) => pool.id),
+      );
+      if (
+        returned.size !== requested.size ||
+        [...requested].some((poolId) => !returned.has(poolId)) ||
+        [...returned].some((poolId) => !requested.has(poolId))
+      ) {
+        throw new OfficialV4LiquidityEvidenceReadError(
+          "coverage-incomplete",
+        );
+      }
+      responses.push(result.response);
+    }
+  }
+
+  const responseByPoolId = new Map<
+    string,
+    { pool: ParsedPool; response: ParsedResponse; lagBlocks: string }
+  >();
+  for (const response of responses) {
+    const lagBlocks = referenceHeadLag(response, referenceHead);
+    if (lagBlocks === undefined || !isCurrentIndexedTime(response, now)) {
+      throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
+    }
+    for (const pool of response.pools) {
+      responseByPoolId.set(pool.id, { pool, response, lagBlocks });
+    }
+  }
+
+  const evidence: OfficialV4LiquidityEvidenceV1[] = [];
+  for (const token of eligibleTokens) {
+    const matched = responseByPoolId.get(token.poolId.toLowerCase());
+    if (
+      !matched ||
+      !matchesCanonicalLiquidityEvidence(matched.pool, token)
+    ) {
+      throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
+    }
+    const item = liquidityEvidence(
+      token,
+      matched.pool,
+      matched.response,
+      referenceHead,
+      matched.lagBlocks,
+    );
+    if (item) evidence.push(item);
+  }
+  return evidence;
 }
 
 function indexedMarketCap(
@@ -615,7 +1044,7 @@ function indexedMarketCap(
  */
 export async function enrichExplorePageWithOfficialV4Subgraph(
   page: ExplorePage,
-  options: EnrichmentOptions = {},
+  options: OfficialV4SubgraphOptions = {},
 ): Promise<ExplorePage> {
   if (
     page.status !== "ready" ||

--- a/lib/onchain/usd.ts
+++ b/lib/onchain/usd.ts
@@ -26,6 +26,7 @@ const priceFeedAbi = parseAbi([
 
 type EthUsdQuote = {
   roundId: bigint;
+  answeredInRound: bigint;
   answer: bigint;
   decimals: number;
   updatedAt: bigint;
@@ -47,12 +48,14 @@ export function assertValidEthUsdSnapshot(input: {
   actualBlockHash: `0x${string}` | null;
   blockTimestamp: bigint;
   roundId: bigint;
+  answeredInRound: bigint;
   answer: bigint;
   updatedAt: bigint;
 }) {
   if (
     input.actualBlockHash !== input.expectedBlockHash ||
     input.roundId === 0n ||
+    input.answeredInRound < input.roundId ||
     input.answer <= 0n ||
     input.updatedAt <= 0n ||
     input.updatedAt > input.blockTimestamp ||
@@ -93,19 +96,21 @@ async function readQuoteSnapshot(
     }),
     client.getBlock({ blockNumber }),
   ]);
-  const [roundId, answer, , updatedAt] = roundData;
+  const [roundId, answer, , updatedAt, answeredInRound] = roundData;
 
   assertValidEthUsdSnapshot({
     expectedBlockHash,
     actualBlockHash: block.hash,
     blockTimestamp: block.timestamp,
     roundId,
+    answeredInRound,
     answer,
     updatedAt,
   });
 
   return {
     roundId,
+    answeredInRound,
     answer,
     decimals,
     updatedAt,
@@ -146,6 +151,7 @@ async function readEthUsdQuote(
       snapshots.some(
         (snapshot) =>
           snapshot.roundId !== reference.roundId ||
+          snapshot.answeredInRound !== reference.answeredInRound ||
           snapshot.answer !== reference.answer ||
           snapshot.decimals !== reference.decimals ||
           snapshot.updatedAt !== reference.updatedAt ||
@@ -159,6 +165,7 @@ async function readEthUsdQuote(
 
     return {
       roundId: reference.roundId,
+      answeredInRound: reference.answeredInRound,
       answer: reference.answer,
       decimals: reference.decimals,
       updatedAt: reference.updatedAt,
@@ -234,6 +241,7 @@ export async function enrichExploreModelWithUsd(
       ethUsdQuote: {
         feedAddress: ETH_USD_FEED_ADDRESS,
         roundId: quote.roundId.toString(),
+        answeredInRound: quote.answeredInRound.toString(),
         answer: quote.answer.toString(),
         decimals: quote.decimals,
         updatedAt: quote.updatedAt.toString(),

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -476,6 +476,7 @@ export type LauncherToken = {
     ethUsdQuote: Readonly<{
       feedAddress: `0x${string}`;
       roundId: string;
+      answeredInRound: string;
       answer: string;
       decimals: number;
       updatedAt: string;

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -442,6 +442,46 @@ export type LauncherToken = {
   creatorFeesAccruedQuote?: string;
   creatorFeesAccruedQuoteRaw?: string;
   fdvUsdWad?: string;
+  liveMarketStateEvidence?: Readonly<{
+    source: "uniswap-v4-stateview-v1";
+    blockNumber: string;
+    blockHash: `0x${string}`;
+    sqrtPriceX96: string;
+    activeLiquidity: string;
+  }>;
+  liveMarketPriceEvidence?: Readonly<{
+    schemaVersion: "programmable.stateview-chainlink-price-evidence.v1";
+    source: "uniswap-v4-stateview-chainlink-v1";
+    chainId: "1";
+    poolId: `0x${string}`;
+    tokenAddress: `0x${string}`;
+    quoteAddress: `0x${string}`;
+    stateViewAddress: `0x${string}`;
+    stateViewRuntimeCodeHash: `0x${string}`;
+    blockNumber: string;
+    blockHash: `0x${string}`;
+    blockTimestamp: string;
+    blockTime: string;
+    sqrtPriceX96: string;
+    activeLiquidity: string;
+    activeVirtualToken0Wei: string;
+    activeVirtualLiquidityUsdWad: string;
+    activeVirtualLiquidityValueBasis:
+      "stateview-active-liquidity-virtual-depth-usd";
+    tokenPriceEthWei: string;
+    tokenPriceUsdWad: string;
+    totalSupplyRaw: string;
+    tokenDecimals: number;
+    fdvUsdWad: string;
+    ethUsdQuote: Readonly<{
+      feedAddress: `0x${string}`;
+      roundId: string;
+      answer: string;
+      decimals: number;
+      updatedAt: string;
+      updatedAtTime: string;
+    }>;
+  }>;
   grossVolumeEth?: string;
   grossVolumeWei?: string;
   creatorFeesGeneratedEth?: string;

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -373,7 +373,7 @@ export function evaluateAlchemyExploreSourceContracts(
       exploreConsumerSource.includes('return "last-known-good"') &&
       exploreConsumerSource.includes('"registry.custom-launched"') &&
       exploreConsumerSource.includes('?? "partial"') &&
-      deployWorkflowSource.includes("Smoke staged Bitquery market APIs") &&
+      deployWorkflowSource.includes("Smoke staged public market APIs") &&
       deployWorkflowSource.includes(
         '"0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"',
       ) &&

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -276,6 +276,7 @@ export function evaluateAlchemyExploreSourceContracts(
           );
           const inputEnd = Math.max(supplyHydration, marketRead);
           const reconciliation = [
+            "valueExploreEntriesWithCurrentEvidence({",
             "valueExploreEntriesWithMarketData(",
             "withBitqueryMarketData(",
           ]
@@ -287,9 +288,11 @@ export function evaluateAlchemyExploreSourceContracts(
             reconciliation,
           );
           const supplyCompletesFirst =
-            source.slice(Math.max(0, supplyHydration - 16), supplyHydration)
-              .includes("await") &&
-            marketRead > supplyHydration;
+            source.slice(Math.max(0, supplyHydration - 96), supplyHydration)
+                .includes("await") &&
+              marketRead < supplyHydration &&
+              source.slice(marketRead, supplyHydration)
+                .includes("readBitqueryTokenMarketDataV1(");
           const inputsJoinBeforeValuation = inputWindow.includes("Promise.all");
           return supplyHydration >= 0 &&
             marketRead >= 0 &&
@@ -350,8 +353,12 @@ export function evaluateAlchemyExploreSourceContracts(
     routeSources
       .filter(({ id }) => id !== "token-list")
       .every(
-        ({ source }) =>
-          source.includes('"X-Programmable-Market-Source": "bitquery"') &&
+        ({ id, source }) =>
+          (id === "token-chart"
+            ? source.includes('"X-Programmable-Market-Source": "bitquery"')
+            : source.includes(
+                '"stateview-chainlink+official-uniswap-v4-subgraph+bitquery"',
+              ) && source.includes('"X-Programmable-Price-Source": "stateview-chainlink"')) &&
           !source.includes('"X-Programmable-Rpc-Provider"'),
       ) &&
       routeSources

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -266,7 +266,7 @@ export function evaluateAlchemyExploreSourceContracts(
       canonicalSupplySource.includes("group.length >= 2") &&
       canonicalSupplySource.includes("if (!agreed) return entry;") &&
       routeSources
-        .filter(({ id }) => id !== "token-list")
+        .filter(({ id }) => ["explore", "token-detail"].includes(id))
         .every(({ source }) => {
           const supplyHydration = source.indexOf(
             "hydrateMissingCanonicalTokenSupplyV1(",
@@ -296,7 +296,7 @@ export function evaluateAlchemyExploreSourceContracts(
             reconciliation > inputEnd &&
             (supplyCompletesFirst || inputsJoinBeforeValuation);
         }),
-    "missing supply is hydrated before market valuation only after fixed readers agree on block hash, decimals and total supply",
+    "missing supply is hydrated on valuation-bearing routes only after fixed readers agree on block hash, decimals and total supply",
   );
 
   for (const route of routeSources) {

--- a/scripts/perf/bitquery-historical-release-gate.mjs
+++ b/scripts/perf/bitquery-historical-release-gate.mjs
@@ -2,6 +2,8 @@ const GOLDEN_TOKEN_ADDRESS =
   "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
 const GOLDEN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const GOLDEN_QUOTE_ADDRESS =
+  "0x0000000000000000000000000000000000000000";
 const MAXIMUM_FUTURE_SKEW_MS = 60_000;
 const MAXIMUM_STALE_AGE_MS = 24 * 60 * 60_000;
 const MAXIMUM_DEFERRED_PCAN_AGE_MS = 96 * 60 * 60_000;
@@ -114,7 +116,6 @@ export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
   const detailPool = exactGoldenPool(detailToken);
   const detailValuation = detailToken?.valuation;
   const poolValuation = detailPool?.valuation;
-  const chartValuation = chart?.valuation;
   const trade = detailPool?.latestTrade;
   const lastPoint = Array.isArray(chart?.points) ? chart.points.at(-1) : null;
   const expectedValue = detailValuation?.valueWad;
@@ -151,18 +152,15 @@ export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
     poolValuation.metric !== "fdv" ||
     poolValuation.supplyBasis !== "total" ||
     poolValuation.freshness !== detailValuation.freshness ||
-    chartValuation?.status !== "available" ||
-    chartValuation.metric !== "fdv" ||
-    chartValuation.supplyBasis !== "total" ||
-    chartValuation.freshness !== detailValuation.freshness ||
     !positiveInteger(expectedValue) ||
     !validMarketTime(expectedTime, nowMs) ||
     poolValuation.valueUsdWad !== expectedValue ||
     poolValuation.fdvUsdWad !== expectedValue ||
     poolValuation.asOfTime !== expectedTime ||
-    chartValuation.valueUsdWad !== expectedValue ||
-    chartValuation.fdvUsdWad !== expectedValue ||
-    chartValuation.asOfTime !== expectedTime ||
+    chart?.valuation?.status !== "unavailable" ||
+    chart.valuation.reason !== "source-unavailable" ||
+    "fdvUsdWad" in chart ||
+    "valuationMetric" in chart ||
     chart?.schemaVersion !== "programmable.market-chart.v1" ||
     chart.source !== "bitquery" ||
     chart.readStatus !== "live" ||
@@ -172,6 +170,7 @@ export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
     chart?.identity?.chainId !== "1" ||
     chart?.identity?.tokenAddress?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
     chart?.identity?.poolId !== GOLDEN_POOL_ID ||
+    chart?.identity?.quoteAddress !== GOLDEN_QUOTE_ADDRESS ||
     chart?.identity?.protocol !== "uniswap_v4" ||
     !Array.isArray(chart?.points) ||
     chart.points.length < 1 ||
@@ -221,6 +220,7 @@ export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
 export const BITQUERY_HISTORICAL_RELEASE_V1 = Object.freeze({
   tokenAddress: GOLDEN_TOKEN_ADDRESS,
   poolId: GOLDEN_POOL_ID,
+  quoteAddress: GOLDEN_QUOTE_ADDRESS,
   maximumStaleAgeMs: MAXIMUM_STALE_AGE_MS,
   maximumDeferredPcanAgeMs: MAXIMUM_DEFERRED_PCAN_AGE_MS,
   minimumConfirmations: MINIMUM_CONFIRMATIONS,

--- a/scripts/perf/bitquery-historical-release-gate.mjs
+++ b/scripts/perf/bitquery-historical-release-gate.mjs
@@ -100,8 +100,10 @@ export function classifyBitqueryStaleMarketReleaseV1(input) {
 /**
  * Resolve the direct-address PCAN canary after the independent parity read.
  * PCAN is intentionally absent from public Explore discovery. Its detail,
- * exact-pool valuation, chart close and parity receipt are bound to one token,
- * pool, block, time, price and FDV. The only older-than-24h value admitted by
+ * exact-pool valuation, chart observation and parity receipt are bound to one
+ * token, pool, block, observation time and FDV. The chart value remains an
+ * explicitly labelled period median and is never treated as the latest trade.
+ * The only older-than-24h value admitted by
  * this function is the exact PCAN candidate classified above.
  */
 export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
@@ -121,7 +123,9 @@ export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
   const expectedPrice = positiveInteger(trade?.priceUsdWad)
     ? BigInt(trade.priceUsdWad)
     : null;
-  const chartPrice = positiveDecimalToWad(lastPoint?.priceUsd);
+  const periodMedian = positiveDecimalToWad(
+    lastPoint?.priceUsd ?? lastPoint?.priceQuote,
+  );
   let temporalStatus;
   if (detailValuation?.freshness === "current") {
     if (!currentMarketTime(detailValuation.asOfTime, nowMs)) {
@@ -171,11 +175,18 @@ export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
     chart?.identity?.protocol !== "uniswap_v4" ||
     !Array.isArray(chart?.points) ||
     chart.points.length < 1 ||
-    chart.asOfTime !== lastPoint?.time ||
-    lastPoint?.time !== trade?.time ||
+    chart.asOfTime !== lastPoint?.observedAt ||
+    lastPoint?.observedAt !== trade?.time ||
+    lastPoint?.valueSemantics !== "period-median" ||
+    lastPoint?.time !== lastPoint?.bucketEnd ||
+    !validMarketTime(lastPoint?.bucketStart, nowMs) ||
+    !validMarketTime(lastPoint?.bucketEnd, nowMs) ||
+    Date.parse(lastPoint.bucketStart) >= Date.parse(lastPoint.bucketEnd) ||
+    Date.parse(lastPoint.observedAt) < Date.parse(lastPoint.bucketStart) ||
+    Date.parse(lastPoint.observedAt) > Date.parse(lastPoint.bucketEnd) ||
     lastPoint?.blockNumber !== expectedBlock ||
     expectedPrice === null ||
-    chartPrice !== expectedPrice ||
+    periodMedian === null ||
     parity?.schemaVersion !== "programmable.bitquery-golden-market-parity.v1" ||
     parity.tokenAddress !== GOLDEN_TOKEN_ADDRESS ||
     parity.poolId !== GOLDEN_POOL_ID ||

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -309,6 +309,390 @@ function exactJson(left, right) {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
+function includesEverySourceFragment(source, fragments) {
+  return typeof source === "string" &&
+    fragments.every((fragment) => source.includes(fragment));
+}
+
+export const POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS = Object.freeze([
+  "function hasUnevidencedBitqueryFdv",
+  "if (depth > 12) return true",
+  "if (seen.has(value)) return true",
+  "object.fdvUsdWad !== undefined",
+  "object.marketCapUsdWad !== undefined",
+  'object.metric === "fdv"',
+  'object.status === "available" || object.valueUsdWad !== undefined',
+  "function exactCanonicalClassicNativeToken",
+  'token?.exploreKind !== "token"',
+  'token.launchModel !== "classic"',
+  'token.liquidityPath === "meme"',
+  "token.launchStampProvenance === undefined",
+  'token.liquidityPath === "programmable-v4"',
+  'stamp?.schemaVersion === "programmable.launch-stamp-provenance.v1"',
+  'stamp.kind === "classic"',
+  "stamp.chainId === 1",
+  "sameBytes32(stamp.poolId, poolId)",
+  "sameAddress(stamp.poolKey?.currency0, NATIVE_CURRENCY)",
+  "sameAddress(stamp.poolKey?.currency1, tokenAddress)",
+  "sameAddress(stamp.poolKey?.hooks, token?.hookAddress)",
+  "tokenAddress === GOLDEN_TOKEN_ADDRESS",
+  'valuation?.status !== "available"',
+  'valuation.metric !== "fdv"',
+  'valuation.supplyBasis !== "total"',
+  'valuation.currency !== "usd"',
+  'valuation.source !== "stateview-chainlink"',
+  'valuation.freshness !== "current"',
+  "token.fdvUsdWad !== valuation.valueWad",
+  "!positiveInteger(valuation.asOfBlock)",
+  "!exactBytes32(valuation.asOfBlockHash)",
+  "!currentMarketEvidenceTime(valuation.asOfTime)",
+  'valuation.lagBlocks !== "0"',
+  '"programmable.stateview-chainlink-price-evidence.v1"',
+  'price?.source !== "uniswap-v4-stateview-chainlink-v1"',
+  'price.chainId !== "1"',
+  "!sameAddress(price.tokenAddress, tokenAddress)",
+  "!sameAddress(price.quoteAddress, NATIVE_CURRENCY)",
+  "!sameBytes32(price.poolId, market?.primaryPoolId)",
+  "price.stateViewAddress?.toLowerCase() !== MAINNET_STATE_VIEW",
+  "MAINNET_STATE_VIEW_RUNTIME_CODE_HASH",
+  "price.blockNumber !== valuation.asOfBlock",
+  "!sameBytes32(price.blockHash, valuation.asOfBlockHash)",
+  "!exactUnixTimestamp(price.blockTimestamp)",
+  "price.blockTime !== valuation.asOfTime",
+  "Number(BigInt(price.blockTimestamp)) * 1_000",
+  "!positiveInteger(price.sqrtPriceX96)",
+  "!positiveInteger(price.activeLiquidity)",
+  "!positiveInteger(price.activeVirtualToken0Wei)",
+  "!positiveInteger(price.activeVirtualLiquidityUsdWad)",
+  '"stateview-active-liquidity-virtual-depth-usd"',
+  "!positiveInteger(price.tokenPriceEthWei)",
+  "!positiveInteger(price.tokenPriceUsdWad)",
+  "price.totalSupplyRaw !== token.totalSupplyRaw",
+  "price.tokenDecimals !== token.tokenDecimals",
+  "price.fdvUsdWad !== valuation.valueWad",
+  "quote?.feedAddress?.toLowerCase() !== MAINNET_ETH_USD_FEED",
+  "!positiveInteger(quote.roundId)",
+  "!positiveInteger(quote.answeredInRound)",
+  "BigInt(quote.answeredInRound) < BigInt(quote.roundId)",
+  "!positiveInteger(quote.answer)",
+  "quote.decimals !== 8",
+  "!exactUnixTimestamp(quote.updatedAt)",
+  "Number(BigInt(quote.updatedAt)) * 1_000",
+  "!positiveInteger(token.totalSupplyRaw)",
+  "token.tokenDecimals < 0",
+  "token.tokenDecimals > 255",
+  'market?.schemaVersion !== "programmable.market-data.v1"',
+  'market.source !== "bitquery"',
+  'market.status !== "current"',
+  "!currentMarketTime(market.generatedAt)",
+  "!exactBytes32(market.primaryPoolId)",
+  "!sameBytes32(token.poolId, market.primaryPoolId)",
+  'primary?.identity?.chainId !== "1"',
+  "!sameAddress(primary.identity.tokenAddress, tokenAddress)",
+  "!sameBytes32(primary.identity.poolId, market.primaryPoolId)",
+  'primary.identity.protocol !== "uniswap_v4"',
+  'primary.source !== "bitquery"',
+  'primary.status !== "current"',
+  "hasUnevidencedBitqueryFdv(market)",
+  'liquidity?.source !== "official-uniswap-v4-subgraph"',
+  'liquidity.identity?.chainId !== "1"',
+  'liquidity.identity.protocol !== "uniswap_v4"',
+  "!sameBytes32(liquidity.identity.poolId, market.primaryPoolId)",
+  "!sameAddress(liquidity.identity.tokenAddress, tokenAddress)",
+  "liquidity.identity.quoteAddress, price.quoteAddress",
+  'liquidity.valueBasis !== "official-subgraph-pool-tvl-usd"',
+  "liquidity.reportedPoolBalances?.token0?.address",
+  "liquidity.reportedPoolBalances?.token1?.address",
+  "liquidity.reportedPoolBalances.token0.decimals !== 18",
+  "liquidity.reportedPoolBalances.token1.decimals !== token.tokenDecimals",
+  "!unsignedDecimal(liquidity.reportedPoolBalances.token0.amountDecimal)",
+  "!unsignedDecimal(liquidity.reportedPoolBalances.token1.amountDecimal)",
+  "!positiveDecimal(liquidity.reportedPoolBalances.token0.amountDecimal)",
+  "!positiveDecimal(liquidity.reportedPoolBalances.token1.amountDecimal)",
+  "BigInt(liquidity.tvlUsdWad) < MINIMUM_PUBLIC_FDV_LIQUIDITY_USD_WAD",
+  'liquidity.freshness !== "current"',
+  "provenance?.subgraphId !== OFFICIAL_V4_SUBGRAPH_ID",
+  "provenance?.deployment !== OFFICIAL_V4_SUBGRAPH_DEPLOYMENT",
+  "!positiveInteger(provenance.indexedBlockNumber)",
+  "!exactBytes32(provenance.indexedBlockHash)",
+  "!exactUnixTimestamp(provenance.indexedBlockTimestamp)",
+  "!currentMarketEvidenceTime(provenance.indexedBlockTime)",
+  "!positiveInteger(provenance.referenceHeadBlockNumber)",
+  "!exactBytes32(provenance.referenceHeadBlockHash)",
+  "!unsignedInteger(provenance.lagBlocks)",
+  "valuation.asOfBlock === provenance.referenceHeadBlockNumber",
+  "valuation.asOfBlockHash, provenance.referenceHeadBlockHash",
+  "lagBlocks === referenceBlock - indexedBlock",
+  "lagBlocks <= OFFICIAL_V4_LIQUIDITY_MAXIMUM_LAG_BLOCKS",
+  "provenance.indexedBlockHash,",
+  "provenance.indexedBlockTime ===",
+  "indexedTimestamp <= valuationTimeSeconds",
+  "feedUpdatedAt <= valuationTimeSeconds",
+  "valuationTimeSeconds - feedUpdatedAt <= 7_200n",
+  "expectedFdvUsdWad.toString() === valuation.valueWad",
+  "expectedTokenPriceEthWei.toString() === price.tokenPriceEthWei",
+  "expectedTokenPriceUsdWad.toString() === price.tokenPriceUsdWad",
+  "activeVirtualToken0Wei.toString() === price.activeVirtualToken0Wei",
+  "expectedActiveVirtualLiquidityUsdWad >=",
+  "price.activeVirtualLiquidityUsdWad",
+  "verifyCurrentPublicOnchainEvidenceV1",
+  '"eth_getBlockByNumber"',
+  '"eth_getCode"',
+  '"eth_call"',
+  "requireCanonical: true",
+  "keccak256(stateViewCode)",
+  "sameCurrentEvidenceObservation(first, second)",
+  "first.blockHash !== valuation.asOfBlockHash.toLowerCase()",
+  "first.stateViewRuntimeCodeHash !== MAINNET_STATE_VIEW_RUNTIME_CODE_HASH",
+  "first.sqrtPriceX96.toString() !== price.sqrtPriceX96",
+  "first.activeLiquidity.toString() !== price.activeLiquidity",
+  "first.totalSupplyRaw.toString() !== price.totalSupplyRaw",
+  "first.feedDecimals !== quote.decimals",
+  "first.roundId.toString() !== quote.roundId",
+  "first.answeredInRound.toString() !== quote.answeredInRound",
+  "providerCount: observations.length",
+]);
+
+export const POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS = Object.freeze([
+  "total > MAXIMUM_EXPLORE_TOKENS",
+  "totalPages !== Math.ceil(total / EXPLORE_PAGE_SIZE)",
+  "responses.length !== totalPages",
+  'page?.status !== "ready"',
+  'page?.sort !== "market-cap"',
+  "page?.page !== index + 1",
+  "page?.pageSize !== EXPLORE_PAGE_SIZE",
+  "page?.total !== total",
+  "page?.totalPages !== totalPages",
+  "pageTokens.length !== expectedLength",
+  '"programmable.explore-data-quality.v1"',
+  "quality.available + quality.unavailable !== pageTokens.length",
+  "quality.stale > quality.available",
+  "quality.unknown !== 0",
+  'response.headers.readSource !== "operational+durable+postgres"',
+  "response.headers.rpcProvider !== null",
+  "response.headers.marketAsOf !== (quality.asOfTime ?? null)",
+  "!exactCurrentPublicMarketHeaders(response)",
+  "!currentMarketEvidenceTime(quality.asOfTime)",
+  "token.valuation.asOfBlock !== quality.asOfBlock",
+  'response.headers.marketSource !== "bitquery"',
+  "response.headers.valuationBlock !== null",
+  "ids.has(token.id)",
+  "addresses.has(address)",
+  "tokens.length !== total",
+  "!UNAVAILABLE_VALUATION_REASONS.has(valuation.reason)",
+  "token?.fdvUsdWad !== undefined",
+  "hasUnevidencedBitqueryFdv(token?.marketData)",
+  'valuation.source === "bitquery"',
+  "return null;",
+  'valuation.source !== "stateview-chainlink"',
+  "sawNonCurrent",
+  "!exactCurrentPublicFdvLiquidity(token)",
+  "value > previousCurrentFdv",
+  "return currentCount > 0 ? { currentToken, tokens } : null;",
+]);
+
+export const POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS = Object.freeze([
+  "!sameAddress(detailToken?.tokenAddress, exploreToken?.tokenAddress)",
+  "!sameAddress(detailToken?.hookAddress, exploreToken?.hookAddress)",
+  "detailToken?.launchModel !== exploreToken?.launchModel",
+  "detailToken?.liquidityPath !== exploreToken?.liquidityPath",
+  "detailToken?.marketData?.primaryPoolId,",
+  "exploreToken?.marketData?.primaryPoolId,",
+  "detailToken?.valuation?.priceEvidence?.quoteAddress,",
+  "exploreToken?.valuation?.priceEvidence?.quoteAddress,",
+  "!exactCurrentPublicMarketHeaders(response)",
+  "!exactCurrentPublicFdvLiquidity(detailToken)",
+  "detailBlock < exploreBlock",
+  "Date.parse(detailToken.valuation.asOfTime) <",
+  "detailBlock !== exploreBlock",
+  "JSON.stringify(detailToken.valuation)",
+  "JSON.stringify(detailToken.liquidityEvidence)",
+  'response.headers.marketSource !== "bitquery"',
+  'response.headers.priceSource !== "bitquery"',
+  'chart.readStatus !== "live"',
+  '["ready", "insufficient-history"].includes(chart.status)',
+  "chart.truncated !== false",
+  "chart.identity?.chainId !== \"1\"",
+  "!sameAddress(chart.identity?.tokenAddress, tokenAddress)",
+  "!sameBytes32(chart.identity?.poolId, poolId)",
+  "!sameAddress(chart.identity?.quoteAddress, quoteAddress)",
+  'chart.identity?.protocol !== "uniswap_v4"',
+  "chart.range !== range",
+  "chart.points.length < 2 || chart.swapCount < 2",
+  "chart.points.length !== 1 || chart.swapCount !== 1",
+  'chart.valuation?.status !== "unavailable"',
+  'chart.valuation?.reason !== "source-unavailable"',
+  '"fdvUsdWad" in chart',
+  '"valuationMetric" in chart',
+  "chart.asOfTime !== chart.points.at(-1)?.observedAt",
+  "response.headers.marketAsOf !== chart.asOfTime",
+  "requireCurrentAsOf && !currentMarketTime(chart.asOfTime)",
+  'point?.valueSemantics !== "period-median"',
+  "time !== bucketEnd",
+  "bucketStart >= bucketEnd",
+  "observedAt < bucketStart",
+  "observedAt > bucketEnd",
+  "!positiveDecimal(point?.priceQuote)",
+  'typeof point?.quoteSymbol !== "string"',
+  "point?.priceUsd !== undefined",
+  "point?.ohlcUsd !== undefined",
+  "point?.ohlcQuote !== undefined",
+  "point.tradeCount < 1",
+  "bucketStart < previousBucketEnd",
+  "block <= previousBlock",
+  "totalTrades === chart.swapCount",
+]);
+
+export const STAGED_MARKET_EVIDENCE_SOURCE_GUARDS = Object.freeze([
+  "const hasUnevidencedBitqueryFdv = (",
+  "if (depth > 12) return true",
+  "if (seen.has(value)) return true",
+  "value.fdvUsdWad !== undefined",
+  "value.marketCapUsdWad !== undefined",
+  'value.metric === "fdv"',
+  'value.status === "available" ||',
+  "const exactCanonicalClassicNativeToken = (",
+  'token?.exploreKind !== "token"',
+  'token.launchModel !== "classic"',
+  'token.liquidityPath === "meme"',
+  "token.launchStampProvenance === undefined",
+  'token.liquidityPath === "programmable-v4"',
+  '"programmable.launch-stamp-provenance.v1"',
+  'stamp.kind === "classic"',
+  "stamp.chainId === 1",
+  "sameBytes32(stamp.poolId, poolId)",
+  "sameAddress(stamp.poolKey?.currency0, nativeCurrency)",
+  "sameAddress(stamp.poolKey?.currency1, tokenAddress)",
+  "sameAddress(stamp.poolKey?.hooks, token?.hookAddress)",
+  'valuation.source !== "stateview-chainlink"',
+  'valuation.freshness !== "current"',
+  "token.fdvUsdWad !== valuation.valueWad",
+  "!positiveInteger(valuation.asOfBlock)",
+  "!exactBytes32(valuation.asOfBlockHash)",
+  "!currentMarketEvidenceTime(valuation.asOfTime)",
+  'valuation.lagBlocks !== "0"',
+  '"programmable.stateview-chainlink-price-evidence.v1"',
+  'price?.source !== "uniswap-v4-stateview-chainlink-v1"',
+  "!sameAddress(price.tokenAddress, tokenAddress)",
+  "!sameAddress(price.quoteAddress, nativeCurrency)",
+  "!sameBytes32(price.poolId, market?.primaryPoolId)",
+  "price.stateViewAddress?.toLowerCase() !== mainnetStateView",
+  "mainnetStateViewRuntimeCodeHash",
+  "price.blockNumber !== valuation.asOfBlock",
+  "!sameBytes32(price.blockHash, valuation.asOfBlockHash)",
+  "!exactUnixTimestamp(price.blockTimestamp)",
+  "price.blockTime !== valuation.asOfTime",
+  "!positiveInteger(price.sqrtPriceX96)",
+  "!positiveInteger(price.activeLiquidity)",
+  "!positiveInteger(price.activeVirtualToken0Wei)",
+  "!positiveInteger(price.activeVirtualLiquidityUsdWad)",
+  '"stateview-active-liquidity-virtual-depth-usd"',
+  "!positiveInteger(price.tokenPriceEthWei)",
+  "!positiveInteger(price.tokenPriceUsdWad)",
+  "price.totalSupplyRaw !== token.totalSupplyRaw",
+  "price.tokenDecimals !== token.tokenDecimals",
+  "price.fdvUsdWad !== valuation.valueWad",
+  "quote?.feedAddress?.toLowerCase() !== mainnetEthUsdFeed",
+  "!positiveInteger(quote.roundId)",
+  "!positiveInteger(quote.answeredInRound)",
+  "BigInt(quote.answeredInRound) < BigInt(quote.roundId)",
+  "!positiveInteger(quote.answer)",
+  "quote.decimals !== 8",
+  "quote.updatedAtTime !==",
+  "!exactCanonicalClassicNativeToken(",
+  'market.source !== "bitquery"',
+  'market.status !== "current"',
+  "!currentMarketTime(market.generatedAt)",
+  "!sameBytes32(token.poolId, market.primaryPoolId)",
+  "!sameAddress(primary.identity.tokenAddress, tokenAddress)",
+  "!sameBytes32(primary.identity.poolId, market.primaryPoolId)",
+  'primary.identity.protocol !== "uniswap_v4"',
+  'primary.source !== "bitquery"',
+  'primary.status !== "current"',
+  "hasUnevidencedBitqueryFdv(market)",
+  'liquidity?.source !== "official-uniswap-v4-subgraph"',
+  'liquidity.identity.protocol !== "uniswap_v4"',
+  "!sameBytes32(liquidity.identity.poolId, market.primaryPoolId)",
+  "!sameAddress(liquidity.identity.tokenAddress, tokenAddress)",
+  'liquidity.valueBasis !== "official-subgraph-pool-tvl-usd"',
+  "liquidity.reportedPoolBalances?.token0?.address",
+  "liquidity.reportedPoolBalances?.token1?.address",
+  "BigInt(liquidity.tvlUsdWad) <",
+  'liquidity.freshness !== "current"',
+  "provenance?.subgraphId !== officialV4SubgraphId",
+  "provenance?.deployment !== officialV4SubgraphDeployment",
+  "!currentMarketEvidenceTime(provenance.indexedBlockTime)",
+  "valuation.asOfBlock === provenance.referenceHeadBlockNumber",
+  "valuation.asOfBlockHash,",
+  "lagBlocks === referenceBlock - indexedBlock",
+  "lagBlocks <= 64n",
+  "indexedTimestamp <= valuationTimeSeconds",
+  "feedUpdatedAt <= valuationTimeSeconds",
+  "valuationTimeSeconds - feedUpdatedAt <= 7_200n",
+  "expectedFdvUsdWad.toString() === valuation.valueWad",
+  "expectedTokenPriceEthWei.toString() ===",
+  "expectedTokenPriceUsdWad.toString() ===",
+  "activeVirtualToken0Wei.toString() ===",
+  "expectedActiveVirtualLiquidityUsdWad >=",
+  "marketCapTotal > maximumMarketCapTokens",
+  "marketCapTotalPages !==",
+  "marketCapPages.push(await requestJson(",
+  "page.total !== marketCapTotal",
+  "page.totalPages !== marketCapTotalPages",
+  "page.tokens.length !== expectedPageLength",
+  "valuationQuality.available + valuationQuality.unavailable !==",
+  "valuationQuality.unknown !== 0",
+  "page.__marketHeaders?.marketSource !==",
+  "page.__marketHeaders?.valuationBlock !== null",
+  "seenMarketCapIds.has(token.id)",
+  "seenMarketCapAddresses.has(address)",
+  "marketCapTokens.length !== marketCapTotal",
+  "hasUnevidencedBitqueryFdv(token?.marketData)",
+  'valuation.source === "bitquery"',
+  "sawNonCurrentFdv",
+  "value > previousCurrentFdv",
+  "if (currentFdvCount < 1) {",
+  "!sameAddress(",
+  "currentFdvDetail.token?.hookAddress",
+  "currentFdvDetail.token?.launchModel !==",
+  "currentFdvDetail.token?.liquidityPath !==",
+  "currentFdvDetail.token?.marketData?.primaryPoolId",
+  "currentFdvDetail.token?.valuation?.priceEvidence?.quoteAddress",
+  "detailValuationBlock < exploreValuationBlock",
+  "Date.parse(currentFdvDetail.token.valuation.asOfTime) <",
+  "sameValuationSnapshot",
+  "JSON.stringify(currentFdvDetail.token.valuation)",
+  "JSON.stringify(currentFdvDetail.token.liquidityEvidence)",
+  'for (const range of ["1h", "1d", "1w", "all"])',
+  "verifyCurrentPublicOnchainEvidenceV1({",
+  "process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+  "process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
+  '"programmable.current-market-independent-proof.v1"',
+  "independentCurrentProof.providerCount !== 2",
+  'currentChart.readStatus !== "live"',
+  '["ready", "insufficient-history"].includes(',
+  "currentChart.truncated !== false",
+  "currentChart.identity.quoteAddress",
+  "currentFdvToken.valuation.priceEvidence.quoteAddress",
+  'currentChart.valuation?.status !== "unavailable"',
+  'currentChart.valuation?.reason !== "source-unavailable"',
+  '"fdvUsdWad" in currentChart',
+  '"valuationMetric" in currentChart',
+  "chartPoints.at(-1)?.observedAt",
+  "!currentMarketTime(currentChart.asOfTime)",
+  'point?.valueSemantics !== "period-median"',
+  "pointTime !== bucketEnd",
+  "observedAt < bucketStart",
+  "observedAt > bucketEnd",
+  "!positiveDecimal(point?.priceQuote)",
+  'typeof point?.quoteSymbol !== "string"',
+  "point?.priceUsd !== undefined",
+  "point?.ohlcUsd !== undefined",
+  "point?.ohlcQuote !== undefined",
+  "bucketStart < previousBucketEnd",
+  "observedTrades !== currentChart.swapCount",
+]);
+
 function expectedDigest(path, approved, overrides) {
   return overrides?.[path] ?? approved;
 }
@@ -974,6 +1358,30 @@ export function evaluateReadModelOperationsSourceContracts(
     "scripts/perf/read-model-real-block-sla-operator.mjs",
   ) ?? "";
   const postPromotion = source("scripts/perf/read-model-post-promotion.mjs") ?? "";
+  const postCurrentEvidenceStart = postPromotion.indexOf(
+    "function exactCanonicalClassicNativeToken",
+  );
+  const postCurrentEvidenceEnd = postPromotion.indexOf(
+    "function exactExploreRanking",
+  );
+  const postCurrentEvidenceBlock =
+    postCurrentEvidenceStart >= 0 &&
+      postCurrentEvidenceEnd > postCurrentEvidenceStart
+      ? postPromotion.slice(postCurrentEvidenceStart, postCurrentEvidenceEnd)
+      : "";
+  const postGlobalRankingEnd = postPromotion.indexOf(
+    "function exactCurrentPublicDetail",
+  );
+  const postGlobalRankingBlock =
+    postCurrentEvidenceEnd >= 0 &&
+      postGlobalRankingEnd > postCurrentEvidenceEnd
+      ? postPromotion.slice(postCurrentEvidenceEnd, postGlobalRankingEnd)
+      : "";
+  const postDetailChartEnd = postPromotion.indexOf("function publicChecks");
+  const postDetailChartBlock =
+    postGlobalRankingEnd >= 0 && postDetailChartEnd > postGlobalRankingEnd
+      ? postPromotion.slice(postGlobalRankingEnd, postDetailChartEnd)
+      : "";
   const bitqueryGoldenParity = source(
     "scripts/perf/bitquery-golden-market-parity.mjs",
   ) ?? "";
@@ -1116,10 +1524,10 @@ export function evaluateReadModelOperationsSourceContracts(
     "an active fast lane must pass the exact unaliased staged wake canary before attestation",
   );
   const stagedBitquerySmoke = deployWorkflow.indexOf(
-    "Smoke staged Bitquery market APIs",
+    "Smoke staged public market APIs",
   );
   const stagedBitquerySmokeEnd = deployWorkflow.indexOf(
-    "Record registry identity and Bitquery market path",
+    "Record registry identity and combined market path",
   );
   const stagedBitquerySmokeBlock =
     stagedBitquerySmoke >= 0 && stagedBitquerySmokeEnd > stagedBitquerySmoke
@@ -1128,6 +1536,10 @@ export function evaluateReadModelOperationsSourceContracts(
   check(
     "ops-protected-bitquery-stage-smoke",
     stagedBitquerySmoke > stagedWakeGateEnd &&
+      includesEverySourceFragment(
+        stagedBitquerySmokeBlock,
+        STAGED_MARKET_EVIDENCE_SOURCE_GUARDS,
+      ) &&
       stagedBitquerySmokeBlock.includes(
         "if: needs.release-gate.outputs.verified_read_model == 'true'",
       ) &&
@@ -1157,7 +1569,10 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       stagedBitquerySmokeBlock.includes("rpcProviders: null") &&
       stagedBitquerySmokeBlock.includes(
-        'marketSources: Object.freeze(["bitquery"]),',
+        'marketSources: Object.freeze([currentPublicMarketSource]),',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'priceSources: Object.freeze(["stateview-chainlink"]),',
       ) &&
       stagedBitquerySmokeBlock.includes(
         'dataQualities: Object.freeze(["complete", "partial", "stale"]),',
@@ -1189,10 +1604,19 @@ export function evaluateReadModelOperationsSourceContracts(
       !stagedBitquerySmokeBlock.includes("alchemyIdentityContract") &&
       !stagedBitquerySmokeBlock.includes("/api/indexers/v1/token-list") &&
       stagedBitquerySmokeBlock.includes(
-        '"/api/explore?limit=20&page=1&sort=market-cap",\n            bitqueryMarketContract,',
+        '`/api/explore?limit=${marketCapPageSize}&page=1&sort=market-cap`,\n            currentPublicMarketContract,',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '"/api/explore?limit=20&page=1&sort=market-cap"',
+        "marketCapTotal > maximumMarketCapTokens",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "marketCapTokens.length !== marketCapTotal",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "seenMarketCapIds.has(token.id)",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "seenMarketCapAddresses.has(address)",
       ) &&
       stagedBitquerySmokeBlock.includes(
         "entry.launchCategoryProvenance.blockNumber",
@@ -1242,19 +1666,13 @@ export function evaluateReadModelOperationsSourceContracts(
         'goldenChart.schemaVersion !== "programmable.market-chart.v1"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        "goldenChart.identity?.quoteAddress !== goldenQuoteAddress",
+        "goldenChart.identity?.quoteAddress,\n              goldenQuoteAddress",
       ) &&
       stagedBitquerySmokeBlock.includes(
         '"staged Bitquery Highest FDV is not monotonically descending"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '"staged Bitquery Explore exposed stale or unavailable FDV as current"',
-      ) &&
-      stagedBitquerySmokeBlock.includes(
-        '"staged Bitquery Explore mislabeled stale FDV as current"',
-      ) &&
-      stagedBitquerySmokeBlock.includes(
-        'valuation.freshness === "stale"',
+        '"staged Bitquery Explore exposed unevidenced numeric FDV"',
       ) &&
       stagedBitquerySmokeBlock.includes(
         'valuation.reason === "waiting-for-first-trade"',
@@ -1263,41 +1681,62 @@ export function evaluateReadModelOperationsSourceContracts(
         'tokenAddress === goldenTokenAddress',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '!/^0x[0-9a-f]{64}$/.test(',
+        'valuation.source !== "stateview-chainlink"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        'token.marketData.primaryPoolId ?? ""',
+        'price?.source !== "uniswap-v4-stateview-chainlink-v1"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        'primary.identity?.poolId !== token.marketData.primaryPoolId',
+        'liquidity?.source !== "official-uniswap-v4-subgraph"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        'primary.identity?.protocol !== "uniswap_v4"',
+        "provenance?.subgraphId !== officialV4SubgraphId",
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '!positiveInteger(primary.liquidity?.valueUsdWad)',
+        "provenance?.deployment !== officialV4SubgraphDeployment",
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '!positiveInteger(primary.liquidity?.asOfBlock)',
+        "BigInt(liquidity.tvlUsdWad) <",
       ) &&
       stagedBitquerySmokeBlock.includes(
-        'primary.valuation.valueUsdWad !== valuation.valueWad',
+        "minimumPublicFdvLiquidityUsdWad",
       ) &&
       stagedBitquerySmokeBlock.includes(
-        'primary.liquidity?.asOfTime !== valuation.asOfTime',
+        'token.launchModel !== "classic"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '!currentMarketTime(primary.liquidity?.asOfTime)',
+        'liquidity.valueBasis !== "official-subgraph-pool-tvl-usd"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '"staged Bitquery current public FDV lacks exact primary-pool liquidity evidence"',
+        "lagBlocks <= 64n",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "valuation.asOfBlock === provenance.referenceHeadBlockNumber",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "expectedFdvUsdWad.toString() === valuation.valueWad",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "expectedActiveVirtualLiquidityUsdWad >=",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "price.activeVirtualLiquidityUsdWad",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "price.activeVirtualToken0Wei",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"stateview-active-liquidity-virtual-depth-usd"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"staged public current FDV lacks exact StateView, Chainlink and official v4 liquidity evidence"',
       ) &&
       stagedBitquerySmokeBlock.includes("if (currentFdvCount < 1) {") &&
       stagedBitquerySmokeBlock.includes(
-        '"staged Bitquery market path has no current public non-PCAN FDV with exact primary-pool liquidity evidence"',
+        '"staged public market path has no current non-PCAN FDV bound to fresh official v4 liquidity"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '"staged Bitquery current Explore and detail FDV are not identical"',
+        '"staged current detail does not independently prove an equal or newer evidence bundle"',
       ) &&
       stagedBitquerySmokeBlock.includes(
         'goldenValuation.metric !== "fdv"',
@@ -1310,9 +1749,6 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       stagedBitquerySmokeBlock.includes(
         '"./scripts/perf/bitquery-historical-release-gate.mjs"',
-      ) &&
-      stagedBitquerySmokeBlock.includes(
-        "const boundedStaleMarketTime = boundedStaleMarketTimeV1",
       ) &&
       stagedBitquerySmokeBlock.includes(
         "await verifyBitqueryGoldenMarketParityV1({",
@@ -1422,9 +1858,6 @@ export function evaluateReadModelOperationsSourceContracts(
         "currentFdvCount < 1 && !historicalPaidPathVerified",
       ) &&
       stagedBitquerySmokeBlock.includes(
-        "staged Bitquery Explore stale FDV is too old",
-      ) &&
-      stagedBitquerySmokeBlock.includes(
         "goldenChart.asOfTime !== goldenChart.points.at(-1)?.observedAt",
       ) &&
       stagedBitquerySmokeBlock.includes(
@@ -1444,7 +1877,7 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       !stagedBitquerySmokeBlock.includes("${automationBypassSecret}") &&
       !stagedBitquerySmokeBlock.includes("console."),
-    "the staged API smoke proves registry identity plus Bitquery-only market provenance without exposing its deployment bypass",
+    "the staged API smoke binds current StateView and Chainlink FDV to official v4 liquidity while retaining Bitquery trade and chart provenance",
   );
   const stagedReadModelCapture = deployWorkflow.indexOf(
     "Capture staged read-model evidence",
@@ -1577,7 +2010,9 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes("verifyProductionDeploymentBinding") &&
       productionBinding.includes("resolveProductionBinding") &&
       postPromotion.includes('"/api/ops/health"') &&
-      postPromotion.includes('"/api/explore?limit=6&page=1&sort=market-cap"') &&
+      postPromotion.includes(
+        "`/api/explore?limit=${EXPLORE_PAGE_SIZE}&page=1&sort=market-cap`",
+      ) &&
       postPromotion.includes(
         '"0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"',
       ) &&
@@ -1585,50 +2020,98 @@ export function evaluateReadModelOperationsSourceContracts(
         '"0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229"',
       ) &&
       postPromotion.includes("exactBitqueryHeaders") &&
-      postPromotion.includes("honestExploreValuations") &&
+      postPromotion.includes("exactExploreRanking") &&
       postPromotion.includes("exactCurrentPublicFdvLiquidity") &&
       postPromotion.includes("exactGoldenDetail") &&
       postPromotion.includes("exactGoldenSearch") &&
       postPromotion.includes("exactGoldenChart") &&
+      postPromotion.includes("quoteAddress: GOLDEN_QUOTE_ADDRESS") &&
       postPromotion.includes(
-        "chart.identity?.quoteAddress !== GOLDEN_QUOTE_ADDRESS",
+        'Object.freeze(["1h", "1d", "1w", "all"])',
       ) &&
-      postPromotion.includes(
-        "const boundedStaleMarketTime = boundedStaleMarketTimeV1",
+      includesEverySourceFragment(
+        postCurrentEvidenceBlock,
+        POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS,
+      ) &&
+      includesEverySourceFragment(
+        postGlobalRankingBlock,
+        POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS,
+      ) &&
+      includesEverySourceFragment(
+        postDetailChartBlock,
+        POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS,
       ) &&
       postPromotion.includes('chart.readStatus !== "live"') &&
       postPromotion.includes("verifyBitqueryGoldenMarketParityV1") &&
       postPromotion.includes("verifyBitqueryHistoricalGoldenReleaseV1") &&
       postPromotion.includes('id: "production-bitquery-canary-hidden"') &&
       postPromotion.includes(
-        "return currentCount > 0 &&",
+        "return currentCount > 0 ? { currentToken, tokens } : null;",
       ) &&
       postPromotion.includes(
-        'tokenAddress !== GOLDEN_TOKEN_ADDRESS',
+        'tokenAddress === GOLDEN_TOKEN_ADDRESS',
       ) &&
       postPromotion.includes(
-        'primary.identity.poolId === market.primaryPoolId',
+        '!sameBytes32(primary.identity.poolId, market.primaryPoolId)',
       ) &&
       postPromotion.includes(
-        'primary.identity.protocol === "uniswap_v4"',
+        'primary.identity.protocol !== "uniswap_v4"',
       ) &&
       postPromotion.includes(
-        'positiveInteger(liquidity.valueUsdWad)',
+        'liquidity?.source !== "official-uniswap-v4-subgraph"',
       ) &&
       postPromotion.includes(
-        'positiveInteger(liquidity.asOfBlock)',
+        "provenance?.subgraphId !== OFFICIAL_V4_SUBGRAPH_ID",
       ) &&
       postPromotion.includes(
-        'poolValuation.valueUsdWad === valuation.valueWad',
+        "provenance?.deployment !== OFFICIAL_V4_SUBGRAPH_DEPLOYMENT",
       ) &&
       postPromotion.includes(
-        'liquidity.asOfTime === valuation.asOfTime',
+        "BigInt(liquidity.tvlUsdWad) < MINIMUM_PUBLIC_FDV_LIQUIDITY_USD_WAD",
       ) &&
       postPromotion.includes(
-        'currentMarketTime(liquidity.asOfTime)',
+        'token.launchModel !== "classic"',
       ) &&
       postPromotion.includes(
-        'currentMarketTime(marketAsOf)',
+        'liquidity.valueBasis !== "official-subgraph-pool-tvl-usd"',
+      ) &&
+      postPromotion.includes(
+        "lagBlocks <= OFFICIAL_V4_LIQUIDITY_MAXIMUM_LAG_BLOCKS",
+      ) &&
+      postPromotion.includes(
+        "valuation.asOfBlock === provenance.referenceHeadBlockNumber",
+      ) &&
+      postPromotion.includes(
+        "expectedFdvUsdWad.toString() === valuation.valueWad",
+      ) &&
+      postPromotion.includes(
+        "expectedActiveVirtualLiquidityUsdWad >=",
+      ) &&
+      postPromotion.includes(
+        "price.activeVirtualLiquidityUsdWad",
+      ) &&
+      postPromotion.includes(
+        "price.activeVirtualToken0Wei",
+      ) &&
+      postPromotion.includes(
+        '"stateview-active-liquidity-virtual-depth-usd"',
+      ) &&
+      postPromotion.includes(
+        'id: "production-current-public-detail"',
+      ) &&
+      postPromotion.includes(
+        'id: "production-current-public-bitquery-charts"',
+      ) &&
+      postPromotion.includes("MAXIMUM_EXPLORE_TOKENS") &&
+      postPromotion.includes("responses.length !== totalPages") &&
+      postPromotion.includes(
+        'valuation.source !== "stateview-chainlink"',
+      ) &&
+      postPromotion.includes(
+        'price?.source !== "uniswap-v4-stateview-chainlink-v1"',
+      ) &&
+      postPromotion.includes(
+        'currentMarketEvidenceTime(quality.asOfTime)',
       ) &&
       postPromotion.includes(
         'id: "production-bitquery-golden-independent-parity"',
@@ -1636,6 +2119,7 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes('response.headers.get("x-programmable-market-source")') &&
       postPromotion.includes('response.headers.get("x-programmable-price-source")') &&
       postPromotion.includes('response.headers.get("x-programmable-market-as-of")') &&
+      postPromotion.includes('"x-programmable-valuation-block"') &&
       postPromotion.includes('response.headers.get("x-programmable-data-quality")') &&
       !postPromotion.includes("/api/indexers/v1/token-list") &&
       postPromotion.includes("verifyLiveCacheAndKeyContracts"),

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1242,6 +1242,9 @@ export function evaluateReadModelOperationsSourceContracts(
         'goldenChart.schemaVersion !== "programmable.market-chart.v1"',
       ) &&
       stagedBitquerySmokeBlock.includes(
+        "goldenChart.identity?.quoteAddress !== goldenQuoteAddress",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
         '"staged Bitquery Highest FDV is not monotonically descending"',
       ) &&
       stagedBitquerySmokeBlock.includes(
@@ -1366,7 +1369,16 @@ export function evaluateReadModelOperationsSourceContracts(
         "poolValuation.valueUsdWad !== expectedValue",
       ) &&
       bitqueryHistoricalRelease.includes(
-        "chartValuation.valueUsdWad !== expectedValue",
+        'chart?.valuation?.status !== "unavailable"',
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        'chart.valuation.reason !== "source-unavailable"',
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        '"fdvUsdWad" in chart',
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        '"valuationMetric" in chart',
       ) &&
       bitqueryHistoricalRelease.includes(
         "!positiveInteger(parity.historicalPoolLiquidity)",
@@ -1375,7 +1387,13 @@ export function evaluateReadModelOperationsSourceContracts(
         "chart?.identity?.poolId !== GOLDEN_POOL_ID",
       ) &&
       bitqueryHistoricalRelease.includes(
+        "chart?.identity?.quoteAddress !== GOLDEN_QUOTE_ADDRESS",
+      ) &&
+      bitqueryHistoricalRelease.includes(
         "lastPoint?.blockNumber !== expectedBlock",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "chart.asOfTime !== lastPoint?.observedAt",
       ) &&
       bitqueryHistoricalRelease.includes("periodMedian === null") &&
       bitqueryHistoricalRelease.includes(
@@ -1572,6 +1590,9 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes("exactGoldenDetail") &&
       postPromotion.includes("exactGoldenSearch") &&
       postPromotion.includes("exactGoldenChart") &&
+      postPromotion.includes(
+        "chart.identity?.quoteAddress !== GOLDEN_QUOTE_ADDRESS",
+      ) &&
       postPromotion.includes(
         "const boundedStaleMarketTime = boundedStaleMarketTimeV1",
       ) &&

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1377,7 +1377,10 @@ export function evaluateReadModelOperationsSourceContracts(
       bitqueryHistoricalRelease.includes(
         "lastPoint?.blockNumber !== expectedBlock",
       ) &&
-      bitqueryHistoricalRelease.includes("chartPrice !== expectedPrice") &&
+      bitqueryHistoricalRelease.includes("periodMedian === null") &&
+      bitqueryHistoricalRelease.includes(
+        'lastPoint?.valueSemantics !== "period-median"',
+      ) &&
       bitqueryHistoricalRelease.includes("parity.confirmations < MINIMUM_CONFIRMATIONS") &&
       stagedBitquerySmokeBlock.includes(
         "const historicalPaidPathVerified =",
@@ -1404,7 +1407,10 @@ export function evaluateReadModelOperationsSourceContracts(
         "staged Bitquery Explore stale FDV is too old",
       ) &&
       stagedBitquerySmokeBlock.includes(
-        "goldenChart.asOfTime !== goldenChart.points.at(-1)?.time",
+        "goldenChart.asOfTime !== goldenChart.points.at(-1)?.observedAt",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'point?.valueSemantics !== "period-median"',
       ) &&
       stagedBitquerySmokeBlock.includes(
         '"staged PCAN chart is not a strictly ordered positive history"',

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -4,6 +4,13 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import {
+  decodeFunctionResult,
+  encodeFunctionData,
+  keccak256,
+  parseAbi,
+} from "viem";
+
+import {
   loadReadModelReleaseEvidence,
   parseReadModelLoadProfile,
 } from "./read-model-gate-core.mjs";
@@ -14,12 +21,14 @@ import {
 } from "./read-model-live-verifier.mjs";
 import { verifyBitqueryGoldenMarketParityV1 } from "./bitquery-golden-market-parity.mjs";
 import {
-  boundedStaleMarketTimeV1,
   verifyBitqueryHistoricalGoldenReleaseV1,
 } from "./bitquery-historical-release-gate.mjs";
 
 const HEALTH_PATH = "/api/ops/health";
-const EXPLORE_PATH = "/api/explore?limit=6&page=1&sort=market-cap";
+const EXPLORE_PAGE_SIZE = 100;
+const MAXIMUM_EXPLORE_TOKENS = 400;
+const EXPLORE_PATH =
+  `/api/explore?limit=${EXPLORE_PAGE_SIZE}&page=1&sort=market-cap`;
 const GOLDEN_TOKEN_ADDRESS =
   "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
 const GOLDEN_POOL_ID =
@@ -31,7 +40,37 @@ const GOLDEN_SEARCH_PATH =
   `/api/explore?limit=20&page=1&q=${GOLDEN_TOKEN_ADDRESS}&sort=market-cap`;
 const GOLDEN_CHART_PATH =
   `/api/explore/token/chart?address=${GOLDEN_TOKEN_ADDRESS}&range=all`;
+const CURRENT_PUBLIC_CHART_RANGES = Object.freeze(["1h", "1d", "1w", "all"]);
 const MAXIMUM_RESPONSE_BYTES = 2 * 1024 * 1024;
+const CURRENT_MARKET_EVIDENCE_MAXIMUM_AGE_MS = 5 * 60_000;
+const OFFICIAL_V4_LIQUIDITY_MAXIMUM_LAG_BLOCKS = 64n;
+const MINIMUM_PUBLIC_FDV_LIQUIDITY_USD_WAD =
+  10_000n * 10n ** 18n;
+const MAINNET_STATE_VIEW =
+  "0x7ffe42c4a5deea5b0fec41c94c136cf115597227";
+const MAINNET_STATE_VIEW_RUNTIME_CODE_HASH =
+  "0xd7947778589cf4aac9a092a4451292a2056380941635ab7006d3c691d8dfd878";
+const MAINNET_ETH_USD_FEED =
+  "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419";
+const NATIVE_CURRENCY = "0x0000000000000000000000000000000000000000";
+const OFFICIAL_V4_SUBGRAPH_DEPLOYMENT =
+  "QmZsgJLiLQKpb8hxTmQ5LWyrFVvfWzVaL4WK8dfFBn7EeK";
+const OFFICIAL_V4_SUBGRAPH_ID =
+  "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G";
+const CURRENT_PUBLIC_MARKET_SOURCE =
+  "stateview-chainlink+official-uniswap-v4-subgraph+bitquery";
+const currentStateViewAbi = parseAbi([
+  "function getSlot0(bytes32 poolId) view returns (uint160 sqrtPriceX96,int24 tick,uint24 protocolFee,uint24 lpFee)",
+  "function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)",
+]);
+const currentErc20Abi = parseAbi([
+  "function decimals() view returns (uint8)",
+  "function totalSupply() view returns (uint256)",
+]);
+const currentFeedAbi = parseAbi([
+  "function decimals() view returns (uint8)",
+  "function latestRoundData() view returns (uint80 roundId,int256 answer,uint256 startedAt,uint256 updatedAt,uint80 answeredInRound)",
+]);
 const UNAVAILABLE_VALUATION_REASONS = new Set([
   "no-market",
   "supply-unavailable",
@@ -90,6 +129,9 @@ async function request(fetchImpl, targetUrl, path, json = true) {
     body: json ? safeJson(text, url.pathname) : text,
     headers: Object.freeze({
       marketAsOf: response.headers.get("x-programmable-market-as-of"),
+      valuationBlock: response.headers.get(
+        "x-programmable-valuation-block",
+      ),
       dataQuality: response.headers.get("x-programmable-data-quality"),
       marketSource: response.headers.get("x-programmable-market-source"),
       priceSource: response.headers.get("x-programmable-price-source"),
@@ -117,7 +159,70 @@ async function retry(operation, attempts = 12, delayMs = 5_000) {
 }
 
 function positiveInteger(value) {
-  return typeof value === "string" && /^[1-9][0-9]*$/u.test(value);
+  return typeof value === "string" &&
+    value.length <= 78 &&
+    /^[1-9][0-9]*$/u.test(value);
+}
+
+function unsignedInteger(value) {
+  return typeof value === "string" &&
+    value.length <= 78 &&
+    /^(?:0|[1-9][0-9]*)$/u.test(value);
+}
+
+function unsignedDecimal(value) {
+  return typeof value === "string" &&
+    value.length <= 160 &&
+    /^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/u.test(value);
+}
+
+function positiveDecimal(value) {
+  return unsignedDecimal(value) && !/^0(?:\.0+)?$/u.test(value);
+}
+
+function exactUnixTimestamp(value) {
+  return positiveInteger(value) && BigInt(value) <= 8_640_000_000n;
+}
+
+function exactAddress(value) {
+  return typeof value === "string" &&
+    /^0x[0-9a-f]{40}$/iu.test(value);
+}
+
+function exactBytes32(value) {
+  return typeof value === "string" &&
+    /^0x[0-9a-f]{64}$/iu.test(value);
+}
+
+function sameAddress(left, right) {
+  return exactAddress(left) &&
+    exactAddress(right) &&
+    left.toLowerCase() === right.toLowerCase();
+}
+
+function sameBytes32(left, right) {
+  return exactBytes32(left) &&
+    exactBytes32(right) &&
+    left.toLowerCase() === right.toLowerCase();
+}
+
+function exactCanonicalClassicNativeToken(token, tokenAddress, poolId) {
+  if (
+    token?.exploreKind !== "token" ||
+    token.launchModel !== "classic"
+  ) return false;
+  if (token.liquidityPath === "meme") {
+    return token.launchStampProvenance === undefined;
+  }
+  const stamp = token.launchStampProvenance;
+  return token.liquidityPath === "programmable-v4" &&
+    stamp?.schemaVersion === "programmable.launch-stamp-provenance.v1" &&
+    stamp.kind === "classic" &&
+    stamp.chainId === 1 &&
+    sameBytes32(stamp.poolId, poolId) &&
+    sameAddress(stamp.poolKey?.currency0, NATIVE_CURRENCY) &&
+    sameAddress(stamp.poolKey?.currency1, tokenAddress) &&
+    sameAddress(stamp.poolKey?.hooks, token?.hookAddress);
 }
 
 function validMarketTime(value) {
@@ -130,7 +235,11 @@ function currentMarketTime(value) {
     Date.now() - Date.parse(value) <= 6 * 60_000;
 }
 
-const boundedStaleMarketTime = boundedStaleMarketTimeV1;
+function currentMarketEvidenceTime(value) {
+  return validMarketTime(value) &&
+    Date.now() - Date.parse(value) <=
+      CURRENT_MARKET_EVIDENCE_MAXIMUM_AGE_MS;
+}
 
 function exactBitqueryHeaders(response) {
   return response.headers.marketSource === "bitquery" &&
@@ -139,62 +248,574 @@ function exactBitqueryHeaders(response) {
     response.headers.dataQuality === response.body?.dataQuality?.status;
 }
 
-function exactCurrentPublicFdvLiquidity(token) {
+function hasUnevidencedBitqueryFdv(value, depth = 0, seen = new Set()) {
+  if (depth > 12) return true;
+  if (value === null || typeof value !== "object") return false;
+  if (seen.has(value)) return true;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.some((entry) =>
+      hasUnevidencedBitqueryFdv(entry, depth + 1, seen)
+    );
+  }
+  const object = value;
+  if (
+    object.fdvUsdWad !== undefined ||
+    object.marketCapUsdWad !== undefined ||
+    (object.metric === "fdv" &&
+      (object.status === "available" || object.valueUsdWad !== undefined))
+  ) return true;
+  return Object.values(object).some((entry) =>
+    hasUnevidencedBitqueryFdv(entry, depth + 1, seen)
+  );
+}
+
+function exactCurrentPublicMarketHeaders(response) {
+  return response.headers.marketSource === CURRENT_PUBLIC_MARKET_SOURCE &&
+    response.headers.priceSource === "stateview-chainlink" &&
+    response.headers.readSource === "operational+durable+postgres" &&
+    response.headers.rpcProvider === null &&
+    response.headers.dataQuality === response.body?.dataQuality?.status &&
+    response.headers.marketAsOf ===
+      response.body?.dataQuality?.valuation?.asOfTime &&
+    response.headers.valuationBlock ===
+      response.body?.dataQuality?.valuation?.asOfBlock;
+}
+
+export function exactCurrentPublicFdvLiquidity(token) {
   const tokenAddress = token?.tokenAddress?.toLowerCase();
   const valuation = token?.valuation;
   const market = token?.marketData;
   const primary = market?.pools?.find(
-    (pool) => pool?.identity?.poolId === market?.primaryPoolId,
+    (pool) => sameBytes32(pool?.identity?.poolId, market?.primaryPoolId),
   );
-  const liquidity = primary?.liquidity;
-  const poolValuation = primary?.valuation;
-  return /^0x[0-9a-f]{40}$/u.test(tokenAddress ?? "") &&
-    tokenAddress !== GOLDEN_TOKEN_ADDRESS &&
-    valuation?.status === "available" &&
-    valuation.metric === "fdv" &&
-    valuation.supplyBasis === "total" &&
-    valuation.currency === "usd" &&
-    valuation.source === "bitquery" &&
-    valuation.freshness === "current" &&
-    positiveInteger(valuation.valueWad) &&
-    token.fdvUsdWad === valuation.valueWad &&
-    currentMarketTime(valuation.asOfTime) &&
-    market?.schemaVersion === "programmable.market-data.v1" &&
-    market.source === "bitquery" &&
-    currentMarketTime(market.generatedAt) &&
-    /^0x[0-9a-f]{64}$/u.test(market.primaryPoolId ?? "") &&
-    primary?.identity?.chainId === "1" &&
-    primary.identity.tokenAddress === tokenAddress &&
-    primary.identity.poolId === market.primaryPoolId &&
-    primary.identity.protocol === "uniswap_v4" &&
-    primary.source === "bitquery" &&
-    primary.status === "current" &&
-    liquidity?.freshness === "current" &&
-    positiveInteger(liquidity.valueUsdWad) &&
-    positiveInteger(liquidity.asOfBlock) &&
-    liquidity.asOfTime === valuation.asOfTime &&
-    currentMarketTime(liquidity.asOfTime) &&
-    poolValuation?.status === "available" &&
-    poolValuation.metric === "fdv" &&
-    poolValuation.supplyBasis === "total" &&
-    poolValuation.freshness === "current" &&
-    poolValuation.valueUsdWad === valuation.valueWad &&
-    poolValuation.asOfTime === valuation.asOfTime;
+  const price = valuation?.priceEvidence;
+  const quote = price?.ethUsdQuote;
+  const liquidity = token?.liquidityEvidence;
+  const provenance = liquidity?.provenance;
+  if (
+    !exactAddress(tokenAddress) ||
+    tokenAddress === GOLDEN_TOKEN_ADDRESS ||
+    valuation?.status !== "available" ||
+    valuation.metric !== "fdv" ||
+    valuation.supplyBasis !== "total" ||
+    valuation.currency !== "usd" ||
+    valuation.source !== "stateview-chainlink" ||
+    valuation.freshness !== "current" ||
+    !positiveInteger(valuation.valueWad) ||
+    token.fdvUsdWad !== valuation.valueWad ||
+    !positiveInteger(valuation.asOfBlock) ||
+    !exactBytes32(valuation.asOfBlockHash) ||
+    !currentMarketEvidenceTime(valuation.asOfTime) ||
+    valuation.lagBlocks !== "0" ||
+    price?.schemaVersion !==
+      "programmable.stateview-chainlink-price-evidence.v1" ||
+    price?.source !== "uniswap-v4-stateview-chainlink-v1" ||
+    price.chainId !== "1" ||
+    !sameAddress(price.tokenAddress, tokenAddress) ||
+    !sameAddress(price.quoteAddress, NATIVE_CURRENCY) ||
+    !sameBytes32(price.poolId, market?.primaryPoolId) ||
+    price.stateViewAddress?.toLowerCase() !== MAINNET_STATE_VIEW ||
+    price.stateViewRuntimeCodeHash !==
+      MAINNET_STATE_VIEW_RUNTIME_CODE_HASH ||
+    price.blockNumber !== valuation.asOfBlock ||
+    !sameBytes32(price.blockHash, valuation.asOfBlockHash) ||
+    !exactUnixTimestamp(price.blockTimestamp) ||
+    price.blockTime !== valuation.asOfTime ||
+    price.blockTime !==
+      new Date(Number(BigInt(price.blockTimestamp)) * 1_000).toISOString() ||
+    !positiveInteger(price.sqrtPriceX96) ||
+    !positiveInteger(price.activeLiquidity) ||
+    !positiveInteger(price.activeVirtualToken0Wei) ||
+    !positiveInteger(price.activeVirtualLiquidityUsdWad) ||
+    price.activeVirtualLiquidityValueBasis !==
+      "stateview-active-liquidity-virtual-depth-usd" ||
+    !positiveInteger(price.tokenPriceEthWei) ||
+    !positiveInteger(price.tokenPriceUsdWad) ||
+    price.totalSupplyRaw !== token.totalSupplyRaw ||
+    price.tokenDecimals !== token.tokenDecimals ||
+    price.fdvUsdWad !== valuation.valueWad ||
+    quote?.feedAddress?.toLowerCase() !== MAINNET_ETH_USD_FEED ||
+    !positiveInteger(quote.roundId) ||
+    !positiveInteger(quote.answeredInRound) ||
+    BigInt(quote.answeredInRound) < BigInt(quote.roundId) ||
+    !positiveInteger(quote.answer) ||
+    quote.decimals !== 8 ||
+    !exactUnixTimestamp(quote.updatedAt) ||
+    quote.updatedAtTime !==
+      new Date(Number(BigInt(quote.updatedAt)) * 1_000).toISOString() ||
+    !positiveInteger(token.totalSupplyRaw) ||
+    !exactCanonicalClassicNativeToken(
+      token,
+      tokenAddress,
+      market?.primaryPoolId,
+    ) ||
+    !Number.isSafeInteger(token.tokenDecimals) ||
+    token.tokenDecimals < 0 ||
+    token.tokenDecimals > 255 ||
+    market?.schemaVersion !== "programmable.market-data.v1" ||
+    market.source !== "bitquery" ||
+    market.status !== "current" ||
+    !currentMarketTime(market.generatedAt) ||
+    !exactBytes32(market.primaryPoolId) ||
+    !sameBytes32(token.poolId, market.primaryPoolId) ||
+    primary?.identity?.chainId !== "1" ||
+    !sameAddress(primary.identity.tokenAddress, tokenAddress) ||
+    !sameBytes32(primary.identity.poolId, market.primaryPoolId) ||
+    primary.identity.protocol !== "uniswap_v4" ||
+    primary.source !== "bitquery" ||
+    primary.status !== "current" ||
+    hasUnevidencedBitqueryFdv(market) ||
+    liquidity?.source !== "official-uniswap-v4-subgraph" ||
+    liquidity.identity?.chainId !== "1" ||
+    liquidity.identity.protocol !== "uniswap_v4" ||
+    !sameBytes32(liquidity.identity.poolId, market.primaryPoolId) ||
+    !sameAddress(liquidity.identity.tokenAddress, tokenAddress) ||
+    !sameAddress(liquidity.identity.quoteAddress, price.quoteAddress) ||
+    liquidity.valueBasis !== "official-subgraph-pool-tvl-usd" ||
+    !sameAddress(
+      liquidity.reportedPoolBalances?.token0?.address,
+      price.quoteAddress,
+    ) ||
+    !sameAddress(
+      liquidity.reportedPoolBalances?.token1?.address,
+      tokenAddress,
+    ) ||
+    !Number.isSafeInteger(liquidity.reportedPoolBalances.token0.decimals) ||
+    liquidity.reportedPoolBalances.token0.decimals !== 18 ||
+    !Number.isSafeInteger(liquidity.reportedPoolBalances.token1.decimals) ||
+    liquidity.reportedPoolBalances.token1.decimals !== token.tokenDecimals ||
+    !unsignedDecimal(liquidity.reportedPoolBalances.token0.amountDecimal) ||
+    !unsignedDecimal(liquidity.reportedPoolBalances.token1.amountDecimal) ||
+    (!positiveDecimal(liquidity.reportedPoolBalances.token0.amountDecimal) &&
+      !positiveDecimal(liquidity.reportedPoolBalances.token1.amountDecimal)) ||
+    !positiveInteger(liquidity.tvlUsdWad) ||
+    BigInt(liquidity.tvlUsdWad) < MINIMUM_PUBLIC_FDV_LIQUIDITY_USD_WAD ||
+    liquidity.freshness !== "current" ||
+    provenance?.subgraphId !== OFFICIAL_V4_SUBGRAPH_ID ||
+    provenance?.deployment !== OFFICIAL_V4_SUBGRAPH_DEPLOYMENT ||
+    !positiveInteger(provenance.indexedBlockNumber) ||
+    !exactBytes32(provenance.indexedBlockHash) ||
+    !exactUnixTimestamp(provenance.indexedBlockTimestamp) ||
+    !currentMarketEvidenceTime(provenance.indexedBlockTime) ||
+    !positiveInteger(provenance.referenceHeadBlockNumber) ||
+    !exactBytes32(provenance.referenceHeadBlockHash) ||
+    !unsignedInteger(provenance.lagBlocks)
+  ) return false;
+
+  const valuationTimeSeconds = BigInt(
+    Math.floor(Date.parse(valuation.asOfTime) / 1_000),
+  );
+  const indexedBlock = BigInt(provenance.indexedBlockNumber);
+  const referenceBlock = BigInt(provenance.referenceHeadBlockNumber);
+  const indexedTimestamp = BigInt(provenance.indexedBlockTimestamp);
+  const feedUpdatedAt = BigInt(quote.updatedAt);
+  const lagBlocks = BigInt(provenance.lagBlocks);
+  const totalSupplyRaw = BigInt(token.totalSupplyRaw);
+  const sqrtPriceX96 = BigInt(price.sqrtPriceX96);
+  const activeLiquidity = BigInt(price.activeLiquidity);
+  const marketCapNativeWad =
+    (totalSupplyRaw * (1n << 192n) * 10n ** 18n) /
+    (sqrtPriceX96 * sqrtPriceX96 * 10n ** 18n);
+  const expectedFdvUsdWad =
+    (marketCapNativeWad * BigInt(quote.answer)) /
+    10n ** BigInt(quote.decimals);
+  const expectedTokenPriceEthWei =
+    ((1n << 192n) * 10n ** BigInt(token.tokenDecimals) * 10n ** 18n) /
+    (sqrtPriceX96 * sqrtPriceX96 * 10n ** 18n);
+  const expectedTokenPriceUsdWad =
+    (expectedTokenPriceEthWei * BigInt(quote.answer)) /
+    10n ** BigInt(quote.decimals);
+  const activeVirtualToken0Wei =
+    (activeLiquidity * (1n << 96n)) / sqrtPriceX96;
+  const expectedActiveVirtualLiquidityUsdWad =
+    (2n * activeVirtualToken0Wei * BigInt(quote.answer)) /
+    10n ** BigInt(quote.decimals);
+  return indexedBlock <= referenceBlock &&
+    valuation.asOfBlock === provenance.referenceHeadBlockNumber &&
+    sameBytes32(valuation.asOfBlockHash, provenance.referenceHeadBlockHash) &&
+    lagBlocks === referenceBlock - indexedBlock &&
+    lagBlocks <= OFFICIAL_V4_LIQUIDITY_MAXIMUM_LAG_BLOCKS &&
+    (lagBlocks !== 0n ||
+      sameBytes32(
+        provenance.indexedBlockHash,
+        provenance.referenceHeadBlockHash,
+      )) &&
+    provenance.indexedBlockTime ===
+      new Date(Number(indexedTimestamp) * 1_000).toISOString() &&
+    indexedTimestamp <= valuationTimeSeconds &&
+    feedUpdatedAt <= valuationTimeSeconds &&
+    valuationTimeSeconds - feedUpdatedAt <= 7_200n &&
+    expectedFdvUsdWad > 0n &&
+    expectedFdvUsdWad.toString() === valuation.valueWad &&
+    expectedTokenPriceEthWei.toString() === price.tokenPriceEthWei &&
+    expectedTokenPriceUsdWad.toString() === price.tokenPriceUsdWad &&
+    activeVirtualToken0Wei.toString() === price.activeVirtualToken0Wei &&
+    expectedActiveVirtualLiquidityUsdWad >=
+      MINIMUM_PUBLIC_FDV_LIQUIDITY_USD_WAD &&
+    expectedActiveVirtualLiquidityUsdWad.toString() ===
+      price.activeVirtualLiquidityUsdWad;
 }
 
-function honestExploreValuations(response) {
-  const tokens = response.body?.tokens;
-  if (!Array.isArray(tokens) || tokens.length === 0) return false;
+async function currentEvidenceJsonRpc(fetchImpl, rpcUrl, method, params, id) {
+  const response = await fetchImpl(rpcUrl, {
+    method: "POST",
+    redirect: "error",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const text = await response.text();
+  if (!response.ok || Buffer.byteLength(text, "utf8") > 128 * 1024) {
+    throw new Error("independent current market RPC was unavailable");
+  }
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error("independent current market RPC returned invalid JSON");
+  }
+  if (
+    body?.jsonrpc !== "2.0" ||
+    body?.id !== id ||
+    body.error !== undefined ||
+    body.result === undefined
+  ) {
+    throw new Error("independent current market RPC rejected an exact read");
+  }
+  return body.result;
+}
+
+async function readCurrentEvidenceProvider(
+  fetchImpl,
+  rpcUrl,
+  tokenAddress,
+  poolId,
+  blockHex,
+  blockHash,
+) {
+  const exactBlock = Object.freeze({
+    blockHash,
+    requireCanonical: true,
+  });
+  const call = (to, data, id) => currentEvidenceJsonRpc(
+    fetchImpl,
+    rpcUrl,
+    "eth_call",
+    [{ to, data }, exactBlock],
+    id,
+  );
+  const [
+    block,
+    stateViewCode,
+    slot0Hex,
+    liquidityHex,
+    tokenDecimalsHex,
+    totalSupplyHex,
+    feedDecimalsHex,
+    feedRoundHex,
+  ] = await Promise.all([
+    currentEvidenceJsonRpc(
+      fetchImpl,
+      rpcUrl,
+      "eth_getBlockByNumber",
+      [blockHex, false],
+      101,
+    ),
+    currentEvidenceJsonRpc(
+      fetchImpl,
+      rpcUrl,
+      "eth_getCode",
+      [MAINNET_STATE_VIEW, exactBlock],
+      102,
+    ),
+    call(MAINNET_STATE_VIEW, encodeFunctionData({
+      abi: currentStateViewAbi,
+      functionName: "getSlot0",
+      args: [poolId],
+    }), 103),
+    call(MAINNET_STATE_VIEW, encodeFunctionData({
+      abi: currentStateViewAbi,
+      functionName: "getLiquidity",
+      args: [poolId],
+    }), 104),
+    call(tokenAddress, encodeFunctionData({
+      abi: currentErc20Abi,
+      functionName: "decimals",
+    }), 105),
+    call(tokenAddress, encodeFunctionData({
+      abi: currentErc20Abi,
+      functionName: "totalSupply",
+    }), 106),
+    call(MAINNET_ETH_USD_FEED, encodeFunctionData({
+      abi: currentFeedAbi,
+      functionName: "decimals",
+    }), 107),
+    call(MAINNET_ETH_USD_FEED, encodeFunctionData({
+      abi: currentFeedAbi,
+      functionName: "latestRoundData",
+    }), 108),
+  ]);
+  if (
+    block === null ||
+    !/^0x[0-9a-f]+$/iu.test(block?.number ?? "") ||
+    !exactBytes32(block?.hash?.toLowerCase?.()) ||
+    !/^0x[0-9a-f]+$/iu.test(block?.timestamp ?? "") ||
+    !/^0x(?:[0-9a-f]{2})+$/iu.test(stateViewCode ?? "")
+  ) {
+    throw new Error("independent current market block proof is malformed");
+  }
+  const [sqrtPriceX96, tick, protocolFee, lpFee] = decodeFunctionResult({
+    abi: currentStateViewAbi,
+    functionName: "getSlot0",
+    data: slot0Hex,
+  });
+  const activeLiquidity = decodeFunctionResult({
+    abi: currentStateViewAbi,
+    functionName: "getLiquidity",
+    data: liquidityHex,
+  });
+  const tokenDecimals = Number(decodeFunctionResult({
+    abi: currentErc20Abi,
+    functionName: "decimals",
+    data: tokenDecimalsHex,
+  }));
+  const totalSupplyRaw = decodeFunctionResult({
+    abi: currentErc20Abi,
+    functionName: "totalSupply",
+    data: totalSupplyHex,
+  });
+  const feedDecimals = Number(decodeFunctionResult({
+    abi: currentFeedAbi,
+    functionName: "decimals",
+    data: feedDecimalsHex,
+  }));
+  const [roundId, answer, startedAt, updatedAt, answeredInRound] =
+    decodeFunctionResult({
+      abi: currentFeedAbi,
+      functionName: "latestRoundData",
+      data: feedRoundHex,
+    });
+  return Object.freeze({
+    blockNumber: BigInt(block.number),
+    blockHash: block.hash.toLowerCase(),
+    blockTimestamp: BigInt(block.timestamp),
+    stateViewRuntimeCodeHash: keccak256(stateViewCode),
+    sqrtPriceX96,
+    tick,
+    protocolFee,
+    lpFee,
+    activeLiquidity,
+    tokenDecimals,
+    totalSupplyRaw,
+    feedDecimals,
+    roundId,
+    answer,
+    startedAt,
+    updatedAt,
+    answeredInRound,
+  });
+}
+
+function sameCurrentEvidenceObservation(left, right) {
+  return [
+    "blockNumber",
+    "blockHash",
+    "blockTimestamp",
+    "stateViewRuntimeCodeHash",
+    "sqrtPriceX96",
+    "tick",
+    "protocolFee",
+    "lpFee",
+    "activeLiquidity",
+    "tokenDecimals",
+    "totalSupplyRaw",
+    "feedDecimals",
+    "roundId",
+    "answer",
+    "startedAt",
+    "updatedAt",
+    "answeredInRound",
+  ].every((key) => left[key] === right[key]);
+}
+
+export async function verifyCurrentPublicOnchainEvidenceV1(input) {
+  const token = input?.token;
+  const fetchImpl = input?.fetchImpl ?? fetch;
+  const rpcUrls = input?.rpcUrls;
+  if (
+    !exactCurrentPublicFdvLiquidity(token) ||
+    !Array.isArray(rpcUrls) ||
+    rpcUrls.length !== 2 ||
+    rpcUrls[0] === rpcUrls[1] ||
+    rpcUrls.some((value) => {
+      try {
+        return new URL(value).protocol !== "https:";
+      } catch {
+        return true;
+      }
+    })
+  ) {
+    throw new Error("two independent current market RPC readers are required");
+  }
+  const valuation = token.valuation;
+  const price = valuation.priceEvidence;
+  const quote = price.ethUsdQuote;
+  const block = BigInt(valuation.asOfBlock);
+  const blockHex = `0x${block.toString(16)}`;
+  const observations = await Promise.all(rpcUrls.map((rpcUrl) =>
+    readCurrentEvidenceProvider(
+      fetchImpl,
+      rpcUrl,
+      token.tokenAddress,
+      token.marketData.primaryPoolId,
+      blockHex,
+      valuation.asOfBlockHash,
+    )
+  ));
+  const [first, second] = observations;
+  if (
+    !sameCurrentEvidenceObservation(first, second) ||
+    first.blockNumber !== block ||
+    first.blockHash !== valuation.asOfBlockHash.toLowerCase() ||
+    first.blockTimestamp.toString() !== price.blockTimestamp ||
+    new Date(Number(first.blockTimestamp) * 1_000).toISOString() !==
+      valuation.asOfTime ||
+    first.stateViewRuntimeCodeHash !== MAINNET_STATE_VIEW_RUNTIME_CODE_HASH ||
+    first.stateViewRuntimeCodeHash !== price.stateViewRuntimeCodeHash ||
+    first.sqrtPriceX96.toString() !== price.sqrtPriceX96 ||
+    first.activeLiquidity.toString() !== price.activeLiquidity ||
+    first.tokenDecimals !== token.tokenDecimals ||
+    first.tokenDecimals !== price.tokenDecimals ||
+    first.totalSupplyRaw.toString() !== token.totalSupplyRaw ||
+    first.totalSupplyRaw.toString() !== price.totalSupplyRaw ||
+    first.feedDecimals !== quote.decimals ||
+    first.roundId.toString() !== quote.roundId ||
+    first.answer.toString() !== quote.answer ||
+    first.updatedAt.toString() !== quote.updatedAt ||
+    first.answeredInRound.toString() !== quote.answeredInRound ||
+    first.answeredInRound < first.roundId ||
+    first.updatedAt > first.blockTimestamp ||
+    first.blockTimestamp - first.updatedAt > 7_200n
+  ) {
+    throw new Error("independent current market readers did not match the public evidence");
+  }
+  return Object.freeze({
+    schemaVersion: "programmable.current-market-independent-proof.v1",
+    tokenAddress: token.tokenAddress.toLowerCase(),
+    poolId: token.marketData.primaryPoolId.toLowerCase(),
+    blockNumber: first.blockNumber.toString(),
+    blockHash: first.blockHash,
+    stateViewRuntimeCodeHash: first.stateViewRuntimeCodeHash,
+    providerCount: observations.length,
+  });
+}
+
+function exactExploreRanking(responses) {
+  if (!Array.isArray(responses) || responses.length === 0) return null;
+  const first = responses[0]?.body;
+  const total = first?.total;
+  const totalPages = first?.totalPages;
+  if (
+    !Number.isSafeInteger(total) ||
+    total < 1 ||
+    total > MAXIMUM_EXPLORE_TOKENS ||
+    !Number.isSafeInteger(totalPages) ||
+    totalPages !== Math.ceil(total / EXPLORE_PAGE_SIZE) ||
+    responses.length !== totalPages
+  ) return null;
+
+  const tokens = [];
+  const ids = new Set();
+  const addresses = new Set();
+  for (let index = 0; index < responses.length; index += 1) {
+    const response = responses[index];
+    const page = response?.body;
+    const pageTokens = page?.tokens;
+    const expectedLength = Math.min(
+      EXPLORE_PAGE_SIZE,
+      total - index * EXPLORE_PAGE_SIZE,
+    );
+    const quality = page?.dataQuality?.valuation;
+    const currentTokens = Array.isArray(pageTokens)
+      ? pageTokens.filter((token) =>
+          token?.valuation?.status === "available" &&
+          token.valuation.source === "stateview-chainlink" &&
+          token.valuation.freshness === "current"
+        )
+      : [];
+    if (
+      !response?.ok ||
+      page?.status !== "ready" ||
+      page?.sort !== "market-cap" ||
+      page?.page !== index + 1 ||
+      page?.pageSize !== EXPLORE_PAGE_SIZE ||
+      page?.total !== total ||
+      page?.totalPages !== totalPages ||
+      !Array.isArray(pageTokens) ||
+      pageTokens.length !== expectedLength ||
+      page?.dataQuality?.schemaVersion !==
+        "programmable.explore-data-quality.v1" ||
+      response.headers.dataQuality !== page.dataQuality.status ||
+      quality?.metric !== "fdv" ||
+      !Number.isSafeInteger(quality.available) ||
+      !Number.isSafeInteger(quality.unavailable) ||
+      quality.available + quality.unavailable !== pageTokens.length ||
+      !Number.isSafeInteger(quality.stale) ||
+      quality.stale < 0 ||
+      quality.stale > quality.available ||
+      quality.unknown !== 0 ||
+      response.headers.readSource !== "operational+durable+postgres" ||
+      response.headers.rpcProvider !== null ||
+      response.headers.marketAsOf !== (quality.asOfTime ?? null)
+    ) return null;
+    if (currentTokens.length > 0) {
+      if (
+        !exactCurrentPublicMarketHeaders(response) ||
+        !currentMarketEvidenceTime(quality.asOfTime) ||
+        !positiveInteger(quality.asOfBlock) ||
+        currentTokens.some((token) =>
+          token.valuation.asOfTime !== quality.asOfTime ||
+          token.valuation.asOfBlock !== quality.asOfBlock
+        )
+      ) return null;
+    } else if (
+      response.headers.marketSource !== "bitquery" ||
+      ![null, "bitquery"].includes(response.headers.priceSource) ||
+      response.headers.valuationBlock !== null
+    ) return null;
+
+    for (const token of pageTokens) {
+      if (typeof token?.id !== "string" || token.id.length === 0 || ids.has(token.id)) {
+        return null;
+      }
+      ids.add(token.id);
+      if (token?.tokenAddress !== undefined) {
+        if (typeof token.tokenAddress !== "string") return null;
+        const address = token.tokenAddress.toLowerCase();
+        if (!exactAddress(address) || addresses.has(address)) return null;
+        addresses.add(address);
+      }
+      tokens.push(token);
+    }
+  }
+  if (tokens.length !== total) return null;
+
   let previousCurrentFdv = null;
   let sawNonCurrent = false;
   let currentCount = 0;
+  let currentToken = null;
   for (const token of tokens) {
     const valuation = token?.valuation;
     if (valuation?.status === "unavailable") {
       if (
         !UNAVAILABLE_VALUATION_REASONS.has(valuation.reason) ||
-        token?.fdvUsdWad !== undefined
-      ) return false;
+        token?.fdvUsdWad !== undefined ||
+        hasUnevidencedBitqueryFdv(token?.marketData)
+      ) return null;
       sawNonCurrent = true;
       continue;
     }
@@ -203,35 +824,65 @@ function honestExploreValuations(response) {
       valuation.metric !== "fdv" ||
       valuation.supplyBasis !== "total" ||
       valuation.currency !== "usd" ||
-      valuation.source !== "bitquery" ||
       !["current", "stale"].includes(valuation.freshness) ||
       !positiveInteger(valuation.valueWad) ||
       !validMarketTime(valuation.asOfTime)
-    ) return false;
-    if (valuation.freshness === "stale") {
-      if (
-        token?.fdvUsdWad !== undefined ||
-        !boundedStaleMarketTime(valuation.asOfTime)
-      ) return false;
-      sawNonCurrent = true;
-      continue;
+    ) return null;
+    if (valuation.source === "bitquery") {
+      return null;
     }
     if (
+      valuation.source !== "stateview-chainlink" ||
       sawNonCurrent ||
       token.fdvUsdWad !== valuation.valueWad ||
       !currentMarketTime(valuation.asOfTime) ||
       !exactCurrentPublicFdvLiquidity(token)
-    ) return false;
+    ) return null;
     const value = BigInt(valuation.valueWad);
-    if (previousCurrentFdv !== null && value > previousCurrentFdv) return false;
+    if (previousCurrentFdv !== null && value > previousCurrentFdv) return null;
     previousCurrentFdv = value;
     currentCount += 1;
+    currentToken ??= token;
   }
-  const marketAsOf = response.body?.dataQuality?.valuation?.asOfTime ?? null;
-  return currentCount > 0 &&
-    response.headers.priceSource === "bitquery" &&
-    response.headers.marketAsOf === marketAsOf &&
-    currentMarketTime(marketAsOf);
+  return currentCount > 0 ? { currentToken, tokens } : null;
+}
+
+function exactCurrentPublicDetail(response, exploreToken) {
+  const detailToken = response?.body?.token;
+  if (
+    !response?.ok ||
+    response.body?.status !== "ready" ||
+    !sameAddress(detailToken?.tokenAddress, exploreToken?.tokenAddress) ||
+    !sameAddress(detailToken?.hookAddress, exploreToken?.hookAddress) ||
+    detailToken?.launchModel !== exploreToken?.launchModel ||
+    detailToken?.liquidityPath !== exploreToken?.liquidityPath ||
+    !sameBytes32(
+      detailToken?.marketData?.primaryPoolId,
+      exploreToken?.marketData?.primaryPoolId,
+    ) ||
+    !sameAddress(
+      detailToken?.valuation?.priceEvidence?.quoteAddress,
+      exploreToken?.valuation?.priceEvidence?.quoteAddress,
+    ) ||
+    !exactCurrentPublicMarketHeaders(response) ||
+    !exactCurrentPublicFdvLiquidity(detailToken)
+  ) return false;
+  const exploreBlock = BigInt(exploreToken.valuation.asOfBlock);
+  const detailBlock = BigInt(detailToken.valuation.asOfBlock);
+  if (detailBlock < exploreBlock) return false;
+  if (
+    Date.parse(detailToken.valuation.asOfTime) <
+      Date.parse(exploreToken.valuation.asOfTime)
+  ) return false;
+  if (detailBlock !== exploreBlock) return true;
+  return sameBytes32(
+      detailToken.valuation.asOfBlockHash,
+      exploreToken.valuation.asOfBlockHash,
+    ) &&
+    JSON.stringify(detailToken.valuation) ===
+      JSON.stringify(exploreToken.valuation) &&
+    JSON.stringify(detailToken.liquidityEvidence) ===
+      JSON.stringify(exploreToken.liquidityEvidence);
 }
 
 function exactGoldenDetail(response) {
@@ -266,7 +917,7 @@ function exactGoldenDetail(response) {
     (valuation.freshness !== "current" || currentMarketTime(valuation.asOfTime)) &&
     response.headers.dataQuality === response.body?.dataQuality?.status &&
     (valuation.freshness === "current"
-      ? token.fdvUsdWad === valuation.valueWad &&
+      ? token.fdvUsdWad === undefined &&
         response.headers.priceSource === "bitquery"
       : valuation.freshness === "stale" &&
         token.fdvUsdWad === undefined &&
@@ -284,7 +935,10 @@ function exactGoldenSearch(response) {
     response.body.total === 0;
 }
 
-function exactGoldenChart(response) {
+function exactObservedBitqueryChart(
+  response,
+  { tokenAddress, poolId, quoteAddress, range, requireCurrentAsOf = false },
+) {
   const chart = response.body;
   if (
     !response.ok ||
@@ -297,25 +951,34 @@ function exactGoldenChart(response) {
     chart.source !== "bitquery" ||
     chart.readStatus !== "live" ||
     !currentMarketTime(chart.generatedAt) ||
-    chart.address?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
+    !sameAddress(chart.address, tokenAddress) ||
     chart.identity?.chainId !== "1" ||
-    chart.identity?.tokenAddress?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
-    chart.identity?.poolId !== GOLDEN_POOL_ID ||
-    chart.identity?.quoteAddress !== GOLDEN_QUOTE_ADDRESS ||
+    !sameAddress(chart.identity?.tokenAddress, tokenAddress) ||
+    !sameBytes32(chart.identity?.poolId, poolId) ||
+    !sameAddress(chart.identity?.quoteAddress, quoteAddress) ||
     chart.identity?.protocol !== "uniswap_v4" ||
-    !["ready", "insufficient-history", "partial"].includes(chart.status) ||
+    chart.range !== range ||
+    !["ready", "insufficient-history"].includes(chart.status) ||
     !Array.isArray(chart.points) ||
-    chart.points.length < 1 ||
+    !Number.isSafeInteger(chart.swapCount) ||
+    chart.swapCount < 1 ||
+    (chart.status === "ready"
+      ? chart.points.length < 2 || chart.swapCount < 2
+      : chart.points.length !== 1 || chart.swapCount !== 1) ||
     chart.valuation?.status !== "unavailable" ||
     chart.valuation?.reason !== "source-unavailable" ||
     "fdvUsdWad" in chart ||
     "valuationMetric" in chart ||
     chart.asOfTime !== chart.points.at(-1)?.observedAt ||
+    chart.truncated !== false ||
     response.headers.marketAsOf !== chart.asOfTime ||
-    !validMarketTime(chart.asOfTime)
+    !validMarketTime(chart.asOfTime) ||
+    (requireCurrentAsOf && !currentMarketTime(chart.asOfTime))
   ) return false;
   let previousTime = null;
+  let previousBucketEnd = null;
   let previousBlock = null;
+  let totalTrades = 0;
   for (const point of chart.points) {
     const time = Date.parse(point?.time ?? "");
     const bucketStart = Date.parse(point?.bucketStart ?? "");
@@ -324,7 +987,6 @@ function exactGoldenChart(response) {
     const block = positiveInteger(point?.blockNumber)
       ? BigInt(point.blockNumber)
       : null;
-    const price = Number(point?.priceUsd ?? point?.priceQuote);
     if (
       !Number.isFinite(time) ||
       point?.valueSemantics !== "period-median" ||
@@ -336,18 +998,47 @@ function exactGoldenChart(response) {
       observedAt < bucketStart ||
       observedAt > bucketEnd ||
       block === null ||
-      !Number.isFinite(price) ||
-      price <= 0 ||
+      !positiveDecimal(point?.priceQuote) ||
+      typeof point?.quoteSymbol !== "string" ||
+      point.quoteSymbol.trim().length === 0 ||
+      point?.priceUsd !== undefined ||
+      point?.ohlcUsd !== undefined ||
+      point?.ohlcQuote !== undefined ||
+      !Number.isSafeInteger(point?.tradeCount) ||
+      point.tradeCount < 1 ||
       (previousTime !== null && time <= previousTime) ||
-      (previousBlock !== null && block < previousBlock)
+      (previousBucketEnd !== null && bucketStart < previousBucketEnd) ||
+      (previousBlock !== null && block <= previousBlock)
     ) return false;
+    totalTrades += point.tradeCount;
+    if (!Number.isSafeInteger(totalTrades)) return false;
     previousTime = time;
+    previousBucketEnd = bucketEnd;
     previousBlock = block;
   }
-  return true;
+  return totalTrades === chart.swapCount;
 }
 
-function publicChecks(responses) {
+function exactGoldenChart(response) {
+  return exactObservedBitqueryChart(response, {
+    tokenAddress: GOLDEN_TOKEN_ADDRESS,
+    poolId: GOLDEN_POOL_ID,
+    quoteAddress: GOLDEN_QUOTE_ADDRESS,
+    range: "all",
+  });
+}
+
+function exactCurrentPublicChart(response, token, range) {
+  return exactObservedBitqueryChart(response, {
+    tokenAddress: token?.tokenAddress,
+    poolId: token?.marketData?.primaryPoolId,
+    quoteAddress: token?.valuation?.priceEvidence?.quoteAddress,
+    range,
+    requireCurrentAsOf: true,
+  });
+}
+
+function publicChecks(responses, exploreRanking) {
   return [
     {
       id: "production-root",
@@ -366,11 +1057,9 @@ function publicChecks(responses) {
     {
       id: "production-explore",
       condition:
-        responses.explore.ok &&
-        responses.explore.body?.status === "ready" &&
-        exactBitqueryHeaders(responses.explore) &&
-        honestExploreValuations(responses.explore),
-      detail: "the production Explore route returns honest Bitquery FDV freshness",
+        exploreRanking !== null &&
+        exploreRanking !== false,
+      detail: "the complete production ranking binds every current StateView and Chainlink FDV to fresh official v4 liquidity while retaining Bitquery trades",
     },
     {
       id: "production-bitquery-canary-hidden",
@@ -469,21 +1158,102 @@ export async function verifyPostPromotion(input) {
     request(fetchImpl, targetUrl, GOLDEN_DETAIL_PATH),
     request(fetchImpl, targetUrl, GOLDEN_CHART_PATH),
   ]);
+  const firstExplore = responses[2];
+  const expectedExplorePages = Number.isSafeInteger(firstExplore.body?.totalPages) &&
+      firstExplore.body.totalPages > 0 &&
+      firstExplore.body.totalPages <=
+        Math.ceil(MAXIMUM_EXPLORE_TOKENS / EXPLORE_PAGE_SIZE)
+    ? firstExplore.body.totalPages
+    : 1;
+  const remainingExplorePages = await Promise.all(
+    Array.from({ length: expectedExplorePages - 1 }, (_, index) =>
+      request(
+        fetchImpl,
+        targetUrl,
+        `/api/explore?limit=${EXPLORE_PAGE_SIZE}&page=${index + 2}&sort=market-cap`,
+      )
+    ),
+  );
+  const exploreRanking = exactExploreRanking([
+    firstExplore,
+    ...remainingExplorePages,
+  ]);
   const checks = [...deploymentChecks, ...publicChecks({
     root: responses[0],
     health: responses[1],
-    explore: responses[2],
     goldenSearch: responses[3],
     goldenDetail: responses[4],
     goldenChart: responses[5],
-  })];
+  }, exploreRanking)];
+  const currentPublicToken = exploreRanking?.currentToken ?? null;
+  let currentPublicDetail = null;
+  let currentPublicCharts = [];
+  if (currentPublicToken?.tokenAddress) {
+    [currentPublicDetail, currentPublicCharts] = await Promise.all([
+      request(
+        fetchImpl,
+        targetUrl,
+        `/api/explore/token?address=${encodeURIComponent(
+          currentPublicToken.tokenAddress,
+        )}`,
+      ),
+      Promise.all(CURRENT_PUBLIC_CHART_RANGES.map(async (range) => ({
+        range,
+        response: await request(
+          fetchImpl,
+          targetUrl,
+          `/api/explore/token/chart?address=${encodeURIComponent(
+            currentPublicToken.tokenAddress,
+          )}&range=${range}`,
+        ),
+      }))),
+    ]);
+  }
+  checks.push({
+    id: "production-current-public-detail",
+    condition: exactCurrentPublicDetail(
+      currentPublicDetail,
+      currentPublicToken,
+    ),
+    detail: "the selected current public token detail independently proves an equal or newer exact current evidence bundle",
+  });
+  checks.push({
+    id: "production-current-public-bitquery-charts",
+    condition: currentPublicCharts.length === CURRENT_PUBLIC_CHART_RANGES.length &&
+      currentPublicCharts.every(({ range, response }) =>
+        exactCurrentPublicChart(response, currentPublicToken, range)
+      ),
+    detail: "the current public FDV token has live, untruncated Bitquery history for every public range",
+  });
+  const marketParityRpcUrls = input.marketParityRpcUrls ?? [
+    process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
+    process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
+  ];
+  let currentOnchainProof = null;
+  try {
+    currentOnchainProof = await verifyCurrentPublicOnchainEvidenceV1({
+      token: currentPublicDetail?.body?.token,
+      fetchImpl,
+      rpcUrls: marketParityRpcUrls,
+    });
+  } catch {
+    // Only the typed failure is public; provider URLs and errors stay private.
+  }
+  checks.push({
+    id: "production-current-public-independent-onchain-proof",
+    condition:
+      currentOnchainProof?.schemaVersion ===
+        "programmable.current-market-independent-proof.v1" &&
+      currentOnchainProof.providerCount === 2,
+    detail: "two independent exact-block readers reproduce the selected current StateView, Chainlink and token evidence",
+  });
   let goldenParity = null;
   let historicalGoldenRelease = null;
   try {
     goldenParity = await verifyBitqueryGoldenMarketParityV1({
       token: responses[4].body?.token,
       fetchImpl,
-      rpcUrls: input.marketParityRpcUrls,
+      rpcUrls: marketParityRpcUrls,
     });
     historicalGoldenRelease = verifyBitqueryHistoricalGoldenReleaseV1({
       detailToken: responses[4].body?.token,

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -305,7 +305,7 @@ function exactGoldenChart(response) {
     !["current", "stale"].includes(chart.valuation?.freshness) ||
     (chart.valuation?.freshness === "current" &&
       !currentMarketTime(chart.valuation?.asOfTime)) ||
-    chart.asOfTime !== chart.points.at(-1)?.time ||
+    chart.asOfTime !== chart.points.at(-1)?.observedAt ||
     response.headers.marketAsOf !== chart.asOfTime ||
     !validMarketTime(chart.asOfTime)
   ) return false;
@@ -313,12 +313,23 @@ function exactGoldenChart(response) {
   let previousBlock = null;
   for (const point of chart.points) {
     const time = Date.parse(point?.time ?? "");
+    const bucketStart = Date.parse(point?.bucketStart ?? "");
+    const bucketEnd = Date.parse(point?.bucketEnd ?? "");
+    const observedAt = Date.parse(point?.observedAt ?? "");
     const block = positiveInteger(point?.blockNumber)
       ? BigInt(point.blockNumber)
       : null;
     const price = Number(point?.priceUsd ?? point?.priceQuote);
     if (
       !Number.isFinite(time) ||
+      point?.valueSemantics !== "period-median" ||
+      !Number.isFinite(bucketStart) ||
+      !Number.isFinite(bucketEnd) ||
+      !Number.isFinite(observedAt) ||
+      time !== bucketEnd ||
+      bucketStart >= bucketEnd ||
+      observedAt < bucketStart ||
+      observedAt > bucketEnd ||
       block === null ||
       !Number.isFinite(price) ||
       price <= 0 ||

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -24,6 +24,8 @@ const GOLDEN_TOKEN_ADDRESS =
   "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
 const GOLDEN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const GOLDEN_QUOTE_ADDRESS =
+  "0x0000000000000000000000000000000000000000";
 const GOLDEN_DETAIL_PATH = `/api/explore/token?address=${GOLDEN_TOKEN_ADDRESS}`;
 const GOLDEN_SEARCH_PATH =
   `/api/explore?limit=20&page=1&q=${GOLDEN_TOKEN_ADDRESS}&sort=market-cap`;
@@ -296,15 +298,18 @@ function exactGoldenChart(response) {
     chart.readStatus !== "live" ||
     !currentMarketTime(chart.generatedAt) ||
     chart.address?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
+    chart.identity?.chainId !== "1" ||
+    chart.identity?.tokenAddress?.toLowerCase() !== GOLDEN_TOKEN_ADDRESS ||
     chart.identity?.poolId !== GOLDEN_POOL_ID ||
+    chart.identity?.quoteAddress !== GOLDEN_QUOTE_ADDRESS ||
+    chart.identity?.protocol !== "uniswap_v4" ||
     !["ready", "insufficient-history", "partial"].includes(chart.status) ||
     !Array.isArray(chart.points) ||
     chart.points.length < 1 ||
-    chart.valuation?.metric !== "fdv" ||
-    chart.valuation?.supplyBasis !== "total" ||
-    !["current", "stale"].includes(chart.valuation?.freshness) ||
-    (chart.valuation?.freshness === "current" &&
-      !currentMarketTime(chart.valuation?.asOfTime)) ||
+    chart.valuation?.status !== "unavailable" ||
+    chart.valuation?.reason !== "source-unavailable" ||
+    "fdvUsdWad" in chart ||
+    "valuationMetric" in chart ||
     chart.asOfTime !== chart.points.at(-1)?.observedAt ||
     response.headers.marketAsOf !== chart.asOfTime ||
     !validMarketTime(chart.asOfTime)

--- a/tests/alchemy-live-market.test.ts
+++ b/tests/alchemy-live-market.test.ts
@@ -54,6 +54,19 @@ const deployment = {
 describe("Alchemy live pool market state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    const hashes = new Map<bigint, `0x${string}`>([
+      [25_680_000n, `0x${"77".repeat(32)}`],
+      [25_730_555n, "0x88e3bc3a2ffed82bf413cd16c2bad04d8e5482306b55398ceb791285ff5248b1"],
+      [25_680_001n, `0x${"88".repeat(32)}`],
+      [25_680_002n, `0x${"dd".repeat(32)}`],
+      [25_680_003n, `0x${"78".repeat(32)}`],
+    ]);
+    mocks.getBlock.mockImplementation(
+      async ({ blockNumber }: { blockNumber: bigint }) => ({
+        hash: hashes.get(blockNumber) ?? `0x${"00".repeat(32)}`,
+        timestamp: 1_786_400_100n,
+      }),
+    );
   });
 
   it("replaces an older ETH/USD quote with a verified same-block quote", async () => {
@@ -521,5 +534,163 @@ describe("Alchemy live pool market state", () => {
     expect(enriched).toEqual(staleToken);
     expect(enriched?.indexedValuationBlockNumber).toBe("25680001");
     expect(mocks.multicall).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse same-height pool state across a block-hash change", async () => {
+    const token = {
+      id: "1:reorg-cache",
+      name: "Reorg cache",
+      symbol: "REORG",
+      tokenAddress: "0x1313131313131313131313131313131313131313",
+      hookAddress: "0x2424242424242424242424242424242424242424",
+      poolId: `0x${"35".repeat(32)}`,
+      launchedAt: "2026-08-13T00:00:00.000Z",
+      totalSupplyRaw: "1000000000000000000000",
+      tokenDecimals: 18,
+      launchModel: "classic",
+      totalSwapFeeBps: 100,
+      liquidityPath: "meme",
+    } satisfies LauncherToken;
+    const firstHash = `0x${"41".repeat(32)}` as const;
+    const secondHash = `0x${"42".repeat(32)}` as const;
+    mocks.multicall
+      .mockResolvedValueOnce([{ status: "success", result: [1n << 96n, 1, 0, 0] }])
+      .mockResolvedValueOnce([{ status: "success", result: 1_000_000n }])
+      .mockResolvedValueOnce([{ status: "success", result: [1n << 96n, 2, 0, 0] }])
+      .mockResolvedValueOnce([{ status: "success", result: 2_000_000n }]);
+    mocks.getBlock
+      .mockResolvedValueOnce({ hash: firstHash, timestamp: 1_786_400_100n })
+      .mockResolvedValueOnce({ hash: secondHash, timestamp: 1_786_400_101n });
+
+    const [first] = await enrichTokensWithAlchemyPoolState({
+      deployment,
+      snapshot: {
+        chainId: 1,
+        blockNumber: "25690000",
+        blockHash: firstHash,
+        confirmations: 12,
+      },
+      tokens: [token],
+    });
+    const [second] = await enrichTokensWithAlchemyPoolState({
+      deployment,
+      snapshot: {
+        chainId: 1,
+        blockNumber: "25690000",
+        blockHash: secondHash,
+        confirmations: 12,
+      },
+      tokens: [token],
+    });
+
+    expect(first).toMatchObject({
+      currentTick: 1,
+      liveMarketStateEvidence: { blockHash: firstHash },
+    });
+    expect(second).toMatchObject({
+      currentTick: 2,
+      liveMarketStateEvidence: { blockHash: secondHash },
+    });
+    expect(mocks.multicall).toHaveBeenCalledTimes(4);
+  });
+
+  it("replays StateView on the secondary when the primary block hash mismatches", async () => {
+    const expectedHash = `0x${"51".repeat(32)}` as const;
+    const token = {
+      id: "1:hash-failover",
+      name: "Hash failover",
+      symbol: "HASH",
+      tokenAddress: "0x1414141414141414141414141414141414141414",
+      hookAddress: "0x2525252525252525252525252525252525252525",
+      poolId: `0x${"36".repeat(32)}`,
+      launchedAt: "2026-08-13T00:00:00.000Z",
+      totalSupplyRaw: "1000000000000000000000",
+      tokenDecimals: 18,
+      launchModel: "classic",
+      totalSwapFeeBps: 100,
+      liquidityPath: "meme",
+    } satisfies LauncherToken;
+    mocks.multicall
+      .mockResolvedValueOnce([{ status: "success", result: [1n << 96n, 1, 0, 0] }])
+      .mockResolvedValueOnce([{ status: "success", result: 10n }])
+      .mockResolvedValueOnce([{ status: "success", result: [1n << 96n, 2, 0, 0] }])
+      .mockResolvedValueOnce([{ status: "success", result: 20n }]);
+    mocks.getBlock
+      .mockResolvedValueOnce({
+        hash: `0x${"52".repeat(32)}`,
+        timestamp: 1_786_400_100n,
+      })
+      .mockResolvedValueOnce({ hash: expectedHash, timestamp: 1_786_400_100n });
+
+    const [enriched] = await enrichTokensWithAlchemyPoolState({
+      deployment: {
+        ...deployment,
+        rpcUrlSecondary: "https://secondary.example",
+      },
+      snapshot: {
+        chainId: 1,
+        blockNumber: "25690001",
+        blockHash: expectedHash,
+        confirmations: 12,
+      },
+      tokens: [token],
+    });
+
+    expect(enriched).toMatchObject({
+      currentTick: 2,
+      activeLiquidity: "20",
+      liveMarketStateEvidence: { blockHash: expectedHash },
+    });
+    expect(mocks.multicall).toHaveBeenCalledTimes(4);
+  });
+
+  it("publishes no evidence when both StateView providers disagree on the hash", async () => {
+    const expectedHash = `0x${"61".repeat(32)}` as const;
+    const token = {
+      id: "1:hash-fail-closed",
+      name: "Hash fail closed",
+      symbol: "CLOSED",
+      tokenAddress: "0x1515151515151515151515151515151515151515",
+      hookAddress: "0x2626262626262626262626262626262626262626",
+      poolId: `0x${"37".repeat(32)}`,
+      launchedAt: "2026-08-13T00:00:00.000Z",
+      totalSupplyRaw: "1000000000000000000000",
+      tokenDecimals: 18,
+      launchModel: "classic",
+      totalSwapFeeBps: 100,
+      liquidityPath: "meme",
+    } satisfies LauncherToken;
+    mocks.multicall
+      .mockResolvedValueOnce([{ status: "success", result: [1n << 96n, 1, 0, 0] }])
+      .mockResolvedValueOnce([{ status: "success", result: 10n }])
+      .mockResolvedValueOnce([{ status: "success", result: [1n << 96n, 2, 0, 0] }])
+      .mockResolvedValueOnce([{ status: "success", result: 20n }]);
+    mocks.getBlock
+      .mockResolvedValueOnce({
+        hash: `0x${"62".repeat(32)}`,
+        timestamp: 1_786_400_100n,
+      })
+      .mockResolvedValueOnce({
+        hash: `0x${"63".repeat(32)}`,
+        timestamp: 1_786_400_100n,
+      });
+
+    const [enriched] = await enrichTokensWithAlchemyPoolState({
+      deployment: {
+        ...deployment,
+        rpcUrlSecondary: "https://secondary.example",
+      },
+      snapshot: {
+        chainId: 1,
+        blockNumber: "25690002",
+        blockHash: expectedHash,
+        confirmations: 12,
+      },
+      tokens: [token],
+    });
+
+    expect(enriched).not.toHaveProperty("liveMarketStateEvidence");
+    expect(enriched).not.toHaveProperty("liveMarketPriceEvidence");
+    expect(mocks.multicall).toHaveBeenCalledTimes(4);
   });
 });

--- a/tests/alchemy-live-market.test.ts
+++ b/tests/alchemy-live-market.test.ts
@@ -105,6 +105,7 @@ describe("Alchemy live pool market state", () => {
     expect(snapshot.ethUsdQuote).toEqual({
       feedAddress: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
       roundId: "12",
+      answeredInRound: "12",
       answer: "300000000000",
       decimals: 8,
       updatedAt: "1786400000",

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -18,6 +18,7 @@ import {
   isTokenMarketDataV1,
   marketDataStatusLabel,
   selectPrimaryMarketPoolV1,
+  type MarketChartIdentityV1,
   type MarketDataIdentityV1,
 } from "../lib/market-data/market-data-v1";
 import { exploreEntriesMarketIdentitiesV1 } from
@@ -26,31 +27,47 @@ import type { ExploreEntry } from "../lib/tokens";
 
 const OAUTH_TOKEN = "ory_at_test_market_data_token_123456";
 const WETH = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
-const PCAN: MarketDataIdentityV1 = {
+const NATIVE_ETH = "0x0000000000000000000000000000000000000000";
+const PCAN: MarketChartIdentityV1 = {
   chainId: "1",
   tokenAddress: "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce",
+  quoteAddress: NATIVE_ETH,
   poolId: "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229",
   protocol: "uniswap_v4",
 };
-const CLASSIC: MarketDataIdentityV1 = {
+const CLASSIC: MarketChartIdentityV1 = {
   chainId: "1",
   tokenAddress: "0x3f2a426365e7a438a7f9f758766cff419d207d51",
+  quoteAddress: NATIVE_ETH,
   poolId: "0x9b8b0aa54cbf844b8534cfb817a0da47c039e67e472d239308f6a47e487e0619",
   protocol: "uniswap_v4",
 };
-const SECOND_CUSTOM: MarketDataIdentityV1 = {
+const SECOND_CUSTOM: MarketChartIdentityV1 = {
   chainId: "1",
   tokenAddress: "0x1111111111111111111111111111111111111111",
+  quoteAddress: WETH,
   poolId: `0x${"33".repeat(32)}`,
   protocol: "uniswap_v4",
 };
 
-function generatedIdentity(index: number): MarketDataIdentityV1 {
+function generatedIdentity(index: number): MarketChartIdentityV1 {
   return {
     chainId: "1",
     tokenAddress: `0x${index.toString(16).padStart(40, "0")}`,
+    quoteAddress: WETH,
     poolId: `0x${index.toString(16).padStart(64, "0")}`,
     protocol: "uniswap_v4",
+  };
+}
+
+function marketIdentity(
+  identity: MarketChartIdentityV1,
+): MarketDataIdentityV1 {
+  return {
+    chainId: identity.chainId,
+    tokenAddress: identity.tokenAddress,
+    poolId: identity.poolId,
+    protocol: identity.protocol,
   };
 }
 
@@ -112,7 +129,7 @@ function tradeRow(input: Readonly<{
 }
 
 function chartBucketRow(input: Readonly<{
-  identity?: MarketDataIdentityV1;
+  identity?: MarketChartIdentityV1;
   block?: string;
   bucket?: string;
   time?: string;
@@ -133,8 +150,9 @@ function chartBucketRow(input: Readonly<{
       Currency: { SmartContract: identity.tokenAddress },
       Side: {
         Currency: {
-          SmartContract: input.quoteAddress ?? WETH,
-          Symbol: input.quoteSymbol ?? "WETH",
+          SmartContract: input.quoteAddress ?? identity.quoteAddress,
+          Symbol: input.quoteSymbol ??
+            (identity.quoteAddress === NATIVE_ETH ? "ETH" : "WETH"),
         },
       },
     },
@@ -164,7 +182,7 @@ function chartResponse(input: Readonly<{
 }
 
 function liquidityRow(
-  identity = PCAN,
+  identity: MarketDataIdentityV1 = PCAN,
   options: Readonly<{
     omitFirstUsd?: boolean;
     omitSecondUsd?: boolean;
@@ -445,7 +463,7 @@ describe("Bitquery-only market data", () => {
       status: "current",
       primaryPoolId: PCAN.poolId,
       pools: [{
-        identity: PCAN,
+        identity: marketIdentity(PCAN),
         status: "current",
         latestTrade: {
           priceUsdWad: "250000000000000000",
@@ -616,7 +634,7 @@ describe("Bitquery-only market data", () => {
     });
     const pool = values.get(PCAN.tokenAddress)?.pools[0];
 
-    expect(pool?.identity).toEqual(PCAN);
+    expect(pool?.identity).toEqual(marketIdentity(PCAN));
     expect(pool?.liquidity?.valueUsdWad).toBe("9999000000000000000000");
     expect(pool?.valuation).toEqual({
       status: "unavailable",
@@ -886,7 +904,7 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
     expect(values.get(identity.tokenAddress)?.pools[0]?.identity).toEqual(
-      identity,
+      marketIdentity(identity),
     );
   });
 
@@ -953,8 +971,12 @@ describe("Bitquery-only market data", () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledTimes(3);
-    expect(values.get(PCAN.tokenAddress)?.pools[0]?.identity).toEqual(PCAN);
-    expect(values.get(CLASSIC.tokenAddress)?.pools[0]?.identity).toEqual(CLASSIC);
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.identity).toEqual(
+      marketIdentity(PCAN),
+    );
+    expect(values.get(CLASSIC.tokenAddress)?.pools[0]?.identity).toEqual(
+      marketIdentity(CLASSIC),
+    );
   });
 
   it("bounds historical USD price aliases without dropping later pools", async () => {
@@ -1382,7 +1404,7 @@ describe("Bitquery-only market data", () => {
 
   it("prefers a traded pool over a higher-liquidity pool with no trades", () => {
     const traded = {
-      identity: PCAN,
+      identity: marketIdentity(PCAN),
       source: "bitquery" as const,
       status: "current" as const,
       quality: "partial" as const,
@@ -1413,7 +1435,9 @@ describe("Bitquery-only market data", () => {
         reason: "waiting-for-first-trade" as const,
       },
     };
-    expect(selectPrimaryMarketPoolV1([waiting, traded])?.identity).toEqual(PCAN);
+    expect(selectPrimaryMarketPoolV1([waiting, traded])?.identity).toEqual(
+      marketIdentity(PCAN),
+    );
   });
 
   it("omits a conflicted PoolId from market reads without deleting launch identities", () => {
@@ -1465,9 +1489,13 @@ describe("Bitquery OHLCV chart and server stream", () => {
         expect(request.query).toContain(
           "Currency: { SmartContract: { is: $tokenAddress } }",
         );
+        expect(request.query).toContain(
+          "Side: { Currency: { SmartContract: { is: $quoteAddress } } }",
+        );
         expect(request.variables).toMatchObject({
           poolId: PCAN.poolId,
           tokenAddress: PCAN.tokenAddress,
+          quoteAddress: "0x",
         });
         expect(request.variables.since).toMatch(/^2026-0[78]-/u);
         return jsonResponse(chartResponse({ points: [], total: "0" }));
@@ -1521,6 +1549,7 @@ describe("Bitquery OHLCV chart and server stream", () => {
       expect(request.variables).toMatchObject({
         poolId: PCAN.poolId,
         tokenAddress: PCAN.tokenAddress,
+        quoteAddress: "0x",
         till: "2026-08-11T14:02:00.000Z",
       });
       expect(request.query).not.toContain("Trading {");
@@ -1530,7 +1559,6 @@ describe("Bitquery OHLCV chart and server stream", () => {
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
       range: "1h",
-      valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl,
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
@@ -1558,6 +1586,35 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(isMarketChartV1(chart)).toBe(true);
   });
 
+  it("fails closed when a provider row carries a different quote currency", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(chartResponse({
+      points: [chartBucketRow({
+        quoteAddress: WETH,
+        quoteSymbol: "WETH",
+      })],
+      total: "3",
+    }))) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(chart).toMatchObject({
+      readStatus: "cache-fallback",
+      status: "unavailable",
+      identity: PCAN,
+      points: [],
+      swapCount: 0,
+      truncated: false,
+    });
+    expect(isMarketChartV1(chart)).toBe(true);
+  });
+
   it("uses order-independent bucket prices when multiple swaps share a block", async () => {
     const fetchImpl = vi.fn(async (
       _url: string | URL | Request,
@@ -1581,7 +1638,6 @@ describe("Bitquery OHLCV chart and server stream", () => {
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
       range: "1h",
-      valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl,
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
@@ -1634,7 +1690,6 @@ describe("Bitquery OHLCV chart and server stream", () => {
       identity: PCAN,
       range: "all",
       historyStart,
-      valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl,
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
@@ -1669,7 +1724,6 @@ describe("Bitquery OHLCV chart and server stream", () => {
     await expect(readBitqueryMarketChartV1({
       identity: PCAN,
       range: "all",
-      valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl: vi.fn() as typeof fetch,
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
@@ -1686,7 +1740,6 @@ describe("Bitquery OHLCV chart and server stream", () => {
       identity: PCAN,
       range: "all",
       historyStart: "2026-07-29T00:00:00.000Z",
-      valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl,
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
@@ -1712,7 +1765,6 @@ describe("Bitquery OHLCV chart and server stream", () => {
       identity: PCAN,
       range: "all",
       historyStart: "2026-07-29T00:00:00.000Z",
-      valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl,
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
@@ -1736,7 +1788,6 @@ describe("Bitquery OHLCV chart and server stream", () => {
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
       range: "1d",
-      valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl,
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
@@ -1778,7 +1829,6 @@ describe("Bitquery OHLCV chart and server stream", () => {
       const pending = readBitqueryMarketChartV1({
         identity: PCAN,
         range: "1d",
-        valuation: { status: "unavailable", reason: "source-unavailable" },
         fetchImpl,
         token: OAUTH_TOKEN,
         now: new Date("2026-08-11T14:02:00.000Z"),
@@ -1869,7 +1919,7 @@ describe("Bitquery OHLCV chart and server stream", () => {
       readStatus: "cache-fallback",
       status: "partial",
       generatedAt: live.generatedAt,
-      valuation: { status: "available", freshness: "stale" },
+      valuation: { status: "unavailable", reason: "source-unavailable" },
     });
     expect(fallback.points).toHaveLength(1);
     expect(isMarketChartV1(fallback)).toBe(true);
@@ -1904,58 +1954,7 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(second).toEqual(first);
   });
 
-  it("does not reuse a chart across different canonical valuations", async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse(chartResponse({
-      points: [chartBucketRow({
-        block: "25740000",
-        time: "2026-08-11T14:01:00.000Z",
-        price: "1",
-        count: "1",
-      })],
-      total: "1",
-    }))) as typeof fetch;
-    const firstValuation = {
-      status: "available",
-      metric: "fdv",
-      supplyBasis: "total",
-      valueUsdWad: "100",
-      fdvUsdWad: "100",
-      totalSupply: "1000",
-      asOfTime: "2026-08-11T14:01:00.000Z",
-      freshness: "current",
-    } as const;
-    const secondValuation = {
-      ...firstValuation,
-      valueUsdWad: "200",
-      fdvUsdWad: "200",
-    } as const;
-    const first = await readBitqueryMarketChartV1({
-      identity: PCAN,
-      range: "1h",
-      valuation: firstValuation,
-      fetchImpl,
-      token: OAUTH_TOKEN,
-      now: new Date("2026-08-11T14:02:00.000Z"),
-    });
-    const second = await readBitqueryMarketChartV1({
-      identity: PCAN,
-      range: "1h",
-      valuation: secondValuation,
-      fetchImpl,
-      token: OAUTH_TOKEN,
-      now: new Date("2026-08-11T14:02:01.000Z"),
-    });
-
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(first.valuation).toEqual(firstValuation);
-    expect(second.valuation).toEqual(secondValuation);
-  });
-
-  it("omits redundant supply pricing when canonical valuation is provided", async () => {
-    const valuation = {
-      status: "unavailable",
-      reason: "source-unavailable",
-    } as const;
+  it("never queries supply or owns a current valuation", async () => {
     const fetchImpl = vi.fn(async (
       _url: string | URL | Request,
       init?: RequestInit,
@@ -1977,14 +1976,16 @@ describe("Bitquery OHLCV chart and server stream", () => {
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
       range: "1h",
-      valuation,
       fetchImpl,
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect(chart.valuation).toEqual(valuation);
+    expect(chart.valuation).toEqual({
+      status: "unavailable",
+      reason: "source-unavailable",
+    });
     expect(chart.points).toHaveLength(1);
   });
 
@@ -2194,7 +2195,7 @@ describe("Bitquery OHLCV chart and server stream", () => {
       }),
     });
     expect(onData).toHaveBeenCalledWith(expect.objectContaining({
-      identity: PCAN,
+      identity: marketIdentity(PCAN),
       market: expect.objectContaining({ source: "bitquery", status: "current" }),
     }));
     expect(onData).toHaveBeenCalledTimes(1);

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -111,6 +111,58 @@ function tradeRow(input: Readonly<{
   };
 }
 
+function chartBucketRow(input: Readonly<{
+  identity?: MarketDataIdentityV1;
+  block?: string;
+  bucket?: string;
+  time?: string;
+  quoteAddress?: string;
+  quoteSymbol?: string;
+  price?: string;
+  count?: string | number;
+}> = {}) {
+  const identity = input.identity ?? PCAN;
+  return {
+    Block: {
+      Bucket: input.bucket ?? "2026-08-11T14:00:00.000Z",
+      Number: input.block ?? "25740000",
+      Time: input.time ?? "2026-08-11T14:00:59.000Z",
+    },
+    Trade: {
+      PoolId: identity.poolId,
+      Currency: { SmartContract: identity.tokenAddress },
+      Side: {
+        Currency: {
+          SmartContract: input.quoteAddress ?? WETH,
+          Symbol: input.quoteSymbol ?? "WETH",
+        },
+      },
+    },
+    price: input.price ?? "0.0002",
+    count: input.count ?? "3",
+  };
+}
+
+function chartResponse(input: Readonly<{
+  points?: unknown[];
+  total?: string | number;
+  supply?: unknown;
+  errors?: unknown[];
+}> = {}) {
+  return {
+    data: {
+      EVM: {
+        chart: input.points ?? [chartBucketRow()],
+        chartTotal: [{ count: input.total ?? "3" }],
+      },
+      Trading: {
+        Tokens: [input.supply ?? supplyRow()],
+      },
+    },
+    ...(input.errors === undefined ? {} : { errors: input.errors }),
+  };
+}
+
 function liquidityRow(
   identity = PCAN,
   options: Readonly<{
@@ -1407,29 +1459,24 @@ describe("Bitquery OHLCV chart and server stream", () => {
       ) => {
         const request = JSON.parse(String(init?.body));
         expect(request.query).toContain("EVM(network: eth, dataset: combined)");
-        expect(request.query).toContain("{ descending: Block_Number }");
-        expect(request.query).toContain("{ descending: Transaction_Index }");
-        expect(request.query).toContain("{ descending: Log_Index }");
+        expect(request.query).toContain("chart: DEXTradeByTokens(");
+        expect(request.query).toContain("chartTotal: DEXTradeByTokens(");
+        expect(request.query).toContain("PoolId: { is: $poolId }");
+        expect(request.query).toContain(
+          "Currency: { SmartContract: { is: $tokenAddress } }",
+        );
         expect(request.variables).toMatchObject({
           poolId: PCAN.poolId,
           tokenAddress: PCAN.tokenAddress,
         });
-        if (range === "all") {
-          expect(request.variables).not.toHaveProperty("since");
-        } else {
-          expect(request.variables.since).toMatch(/^2026-08-/u);
-        }
-        return jsonResponse({
-          data: {
-            EVM: { DEXTrades: [] },
-            Trading: { Tokens: [supplyRow()] },
-          },
-        });
+        expect(request.variables.since).toMatch(/^2026-0[78]-/u);
+        return jsonResponse(chartResponse({ points: [], total: "0" }));
       }) as typeof fetch;
 
       const chart = await readBitqueryMarketChartV1({
         identity: PCAN,
         range,
+        historyStart: "2026-07-29T00:00:00.000Z",
         fetchImpl,
         token: OAUTH_TOKEN,
         now: new Date("2026-08-11T14:02:00.000Z"),
@@ -1440,110 +1487,212 @@ describe("Bitquery OHLCV chart and server stream", () => {
     },
   );
 
-  it("pages active exact-pool history within the provider response bound", async () => {
-    const now = new Date("2026-08-11T14:02:00.000Z");
-    const trades = Array.from({ length: 1_228 }, (_, index) => tradeRow({
-      block: String(25_750_000 - index),
-      time: new Date(now.getTime() - (index + 1) * 60_000).toISOString(),
-      transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
-      transactionIndex: index % 200,
-      logIndex: index % 1_000,
-    }));
-    const pageIndexes: number[] = [];
+  it("reads active exact-pool history as bounded provider-side median points", async () => {
+    const points = [
+      chartBucketRow({
+        block: "25740002",
+        bucket: "2026-08-11T14:01:00.000Z",
+        time: "2026-08-11T14:01:59.000Z",
+        price: "0.0003",
+        count: "2",
+      }),
+      chartBucketRow({
+        block: "25740000",
+        bucket: "2026-08-11T14:00:00.000Z",
+        time: "2026-08-11T14:00:59.000Z",
+        count: "3",
+      }),
+    ];
     const fetchImpl = vi.fn(async (
       _url: string | URL | Request,
       init?: RequestInit,
     ) => {
       const request = JSON.parse(String(init?.body));
-      const pageIndex = pageIndexes.length;
-      pageIndexes.push(pageIndex);
-      expect(request.query).toContain("limit: { count: 500 }");
+      expect(request.query).toContain("limit: { count: 80 }");
       expect(request.query).not.toContain("offset");
-      expect(request.query).toContain("dataset: combined");
+      expect(request.query).not.toContain("dataset: combined");
+      expect(request.query).toContain(
+        "Bucket: Time(interval: { count: 1, in: minutes })",
+      );
+      expect(request.query).toContain("price: median(of: Trade_Price)");
+      expect(request.query).not.toContain("Price(minimum: Block_Number)");
+      expect(request.query).not.toContain("Price(maximum: Block_Number)");
       expect(request.query).toContain("since: $since, till: $till");
       expect(request.variables).toMatchObject({
         poolId: PCAN.poolId,
-        till: now.toISOString(),
+        tokenAddress: PCAN.tokenAddress,
+        till: "2026-08-11T14:02:00.000Z",
       });
-      if (pageIndex === 0) {
-        expect(request.query).not.toContain("any: [");
-      } else {
-        const prior = trades[pageIndex * 500 - 1];
-        expect(request.query).toContain("any: [");
-        expect(request.query).toContain(
-          `Number: { lt: "${prior.Block.Number}" }`,
-        );
-        expect(request.query).toContain(
-          `Transaction: { Index: { eq: ${prior.Transaction.Index} } }`,
-        );
-        expect(request.query).toContain(
-          `Log: { Index: { lt: ${prior.Log.Index} } }`,
-        );
-      }
       expect(request.query).not.toContain("Trading {");
-      return jsonResponse({
-        data: {
-          EVM: {
-            DEXTrades: trades.slice(pageIndex * 500, (pageIndex + 1) * 500),
-          },
-        },
-      });
+      return jsonResponse(chartResponse({ points, total: "5" }));
     }) as typeof fetch;
 
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
-      range: "1d",
+      range: "1h",
       valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl,
       token: OAUTH_TOKEN,
-      now,
+      now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(pageIndexes).toEqual([0, 1, 2]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(chart).toMatchObject({
       readStatus: "live",
       status: "ready",
-      swapCount: 1_228,
-      volumeUsdWad: (25n * 1_228n * 10n ** 18n).toString(),
+      swapCount: 5,
       truncated: false,
+      points: [
+        {
+          blockNumber: "25740000",
+          priceQuote: "0.0002",
+          tradeCount: 3,
+        },
+        {
+          blockNumber: "25740002",
+          priceQuote: "0.0003",
+          tradeCount: 2,
+        },
+      ],
     });
-    expect(chart.points.length).toBeGreaterThan(1);
-    expect(chart.points.every((point, index) =>
-      index === 0 || Date.parse(chart.points[index - 1].time) <= Date.parse(point.time)
-    )).toBe(true);
     expect(isMarketChartV1(chart)).toBe(true);
   });
 
-  it("fails closed when a provider page overlaps the prior keyset boundary", async () => {
-    const now = new Date("2026-08-11T14:02:00.000Z");
-    const trades = Array.from({ length: 1_000 }, (_, index) => tradeRow({
-      block: String(25_750_000 - index),
-      time: new Date(now.getTime() - (index + 1) * 60_000).toISOString(),
-      transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
-      transactionIndex: index % 200,
-      logIndex: index % 1_000,
-    }));
-    const pages = [
-      trades.slice(0, 500),
-      [trades[499], ...trades.slice(500, 727)],
-    ];
-    let pageIndex = 0;
-    const fetchImpl = vi.fn(async () => {
-      return jsonResponse({
-        data: { EVM: { DEXTrades: pages[pageIndex++] } },
-      });
+  it("uses order-independent bucket prices when multiple swaps share a block", async () => {
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      expect(request.query).toContain("price: median(of: Trade_Price)");
+      expect(request.query).not.toContain("open: Price");
+      expect(request.query).not.toContain("close: Price");
+      return jsonResponse(chartResponse({
+        points: [chartBucketRow({
+          block: "25740000",
+          time: "2026-08-11T14:00:12.000Z",
+          price: "2",
+          count: "2",
+        })],
+        total: "2",
+      }));
+    }) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "1h",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(chart.points[0]).toMatchObject({
+      blockNumber: "25740000",
+      bucketStart: "2026-08-11T14:00:00.000Z",
+      bucketEnd: "2026-08-11T14:01:00.000Z",
+      observedAt: "2026-08-11T14:00:12.000Z",
+      time: "2026-08-11T14:01:00.000Z",
+      valueSemantics: "period-median",
+      priceQuote: "2",
+      tradeCount: 2,
+    });
+    expect(chart.points[0]).not.toHaveProperty("ohlcQuote");
+  });
+
+  it("adapts the all-history interval beyond 80 days without dropping its start", async () => {
+    const historyStart = "2025-07-01T00:00:00.000Z";
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      expect(request.variables.since).toBe(historyStart);
+      expect(request.variables.till).toBe("2026-08-11T14:02:00.000Z");
+      expect(request.query).toContain(
+        "Bucket: Time(interval: { count: 6, in: days })",
+      );
+      return jsonResponse(chartResponse({
+        points: [chartBucketRow({
+          bucket: "2025-07-01T00:00:00.000Z",
+          block: "22740000",
+          time: "2025-07-01T01:00:00.000Z",
+          price: "1",
+          count: "1",
+        }), chartBucketRow({
+          bucket: "2026-08-10T00:00:00.000Z",
+          block: "25740000",
+          time: "2026-08-11T14:00:00.000Z",
+          price: "2",
+          count: "1",
+        })],
+        total: "2",
+      }));
     }) as typeof fetch;
 
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
       range: "all",
+      historyStart,
       valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl,
       token: OAUTH_TOKEN,
-      now,
+      now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(chart).toMatchObject({
+      status: "ready",
+      truncated: false,
+      swapCount: 2,
+      asOfTime: "2026-08-11T14:00:00.000Z",
+      points: [
+        {
+          bucketStart: historyStart,
+          bucketEnd: "2025-07-07T00:00:00.000Z",
+          time: "2025-07-07T00:00:00.000Z",
+          observedAt: "2025-07-01T01:00:00.000Z",
+          valueSemantics: "period-median",
+        },
+        {
+          bucketStart: "2026-08-10T00:00:00.000Z",
+          bucketEnd: "2026-08-11T14:02:00.000Z",
+          time: "2026-08-11T14:02:00.000Z",
+          observedAt: "2026-08-11T14:00:00.000Z",
+          valueSemantics: "period-median",
+        },
+      ],
+    });
+    expect(chart.points).toHaveLength(2);
+  });
+
+  it("fails closed when all-history has no canonical launch time", async () => {
+    await expect(readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "all",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+      fetchImpl: vi.fn() as typeof fetch,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    })).rejects.toMatchObject({ category: "integrity" });
+  });
+
+  it("fails closed when an aggregate row is not bound to the exact market", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(chartResponse({
+      points: [chartBucketRow({ identity: CLASSIC })],
+      total: "3",
+    }))) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "all",
+      historyStart: "2026-07-29T00:00:00.000Z",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(chart).toMatchObject({
       readStatus: "cache-fallback",
       status: "unavailable",
@@ -1553,63 +1702,36 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(isMarketChartV1(chart)).toBe(true);
   });
 
-  it("marks an exact keyset cap as truncated without inventing completeness", async () => {
-    const now = new Date("2026-08-11T14:02:00.000Z");
-    const trades = Array.from({ length: 2_000 }, (_, index) => tradeRow({
-      block: String(25_750_000 - index),
-      time: new Date(now.getTime() - (index + 1) * 60_000).toISOString(),
-      transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
-      transactionIndex: index % 200,
-      logIndex: index % 1_000,
-    }));
-    let pageIndex = 0;
-    const fetchImpl = vi.fn(async () => {
-      const offset = pageIndex * 500;
-      pageIndex += 1;
-      return jsonResponse({
-        data: {
-          EVM: {
-            DEXTrades: trades.slice(offset, offset + 500),
-          },
-        },
-      });
-    }) as typeof fetch;
+  it("marks aggregate coverage as truncated without inventing completeness", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(chartResponse({
+      points: [chartBucketRow({ count: "5" })],
+      total: "6",
+    }))) as typeof fetch;
 
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
       range: "all",
+      historyStart: "2026-07-29T00:00:00.000Z",
       valuation: { status: "unavailable", reason: "source-unavailable" },
       fetchImpl,
       token: OAUTH_TOKEN,
-      now,
+      now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(chart).toMatchObject({
       readStatus: "live",
       status: "partial",
-      swapCount: 2_000,
-      volumeUsdWad: (25n * 2_000n * 10n ** 18n).toString(),
+      swapCount: 5,
       truncated: true,
     });
     expect(isMarketChartV1(chart)).toBe(true);
   });
 
-  it("does not publish an incomplete chart when a later history page fails", async () => {
-    const firstPage = Array.from({ length: 500 }, (_, index) => tradeRow({
-      block: String(25_750_000 - index),
-      transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
-      transactionIndex: index % 200,
-      logIndex: index,
-    }));
-    let requestCount = 0;
-    const fetchImpl = vi.fn(async () => {
-      requestCount += 1;
-      if (requestCount === 1) {
-        return jsonResponse({ data: { EVM: { DEXTrades: firstPage } } });
-      }
-      throw new Error("provider page failed");
-    }) as typeof fetch;
+  it("does not publish a partial provider aggregate as complete", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(chartResponse({
+      errors: [{ message: "bounded aggregate was partial" }],
+    }))) as typeof fetch;
 
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
@@ -1620,35 +1742,23 @@ describe("Bitquery OHLCV chart and server stream", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(chart).toMatchObject({
-      readStatus: "cache-fallback",
-      status: "unavailable",
-      points: [],
-      swapCount: 0,
+      readStatus: "live",
+      status: "partial",
+      swapCount: 3,
+      truncated: false,
     });
     expect(isMarketChartV1(chart)).toBe(true);
   });
 
-  it("bounds all history pages by one twelve-second read deadline", async () => {
+  it("bounds the aggregate history read within the twelve-second deadline", async () => {
     vi.useFakeTimers();
     try {
-      const firstPage = Array.from({ length: 500 }, (_, index) => tradeRow({
-        block: String(25_750_000 - index),
-        transaction: `0x${(index + 1).toString(16).padStart(64, "0")}`,
-        transactionIndex: index % 200,
-        logIndex: index,
-      }));
-      let callCount = 0;
       const fetchImpl = vi.fn((
         _url: string | URL | Request,
         init?: RequestInit,
       ) => {
-        callCount += 1;
-        const response = callCount === 1
-          ? jsonResponse({ data: { EVM: { DEXTrades: firstPage } } })
-          : null;
-        const delay = callCount === 1 ? 7_000 : 20_000;
         return new Promise<Response>((resolve, reject) => {
           const signal = init?.signal;
           const onAbort = () => {
@@ -1657,12 +1767,8 @@ describe("Bitquery OHLCV chart and server stream", () => {
           };
           const timer = setTimeout(() => {
             signal?.removeEventListener("abort", onAbort);
-            if (response === null) {
-              reject(new Error("unexpected late response"));
-            } else {
-              resolve(response);
-            }
-          }, delay);
+            resolve(jsonResponse(chartResponse()));
+          }, 20_000);
           if (signal?.aborted) onAbort();
           else signal?.addEventListener("abort", onAbort, { once: true });
         });
@@ -1681,9 +1787,8 @@ describe("Bitquery OHLCV chart and server stream", () => {
         return value;
       });
 
-      await vi.advanceTimersByTimeAsync(7_000);
-      expect(fetchImpl).toHaveBeenCalledTimes(2);
-      await vi.advanceTimersByTimeAsync(4_999);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(7_999);
       expect(settled).toBe(false);
       await vi.advanceTimersByTimeAsync(1);
 
@@ -1693,19 +1798,16 @@ describe("Bitquery OHLCV chart and server stream", () => {
         status: "unavailable",
         swapCount: 0,
       });
-      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
   });
 
   it("does not preserve a cached empty chart as confirmed through failure", async () => {
-    const success = vi.fn(async () => jsonResponse({
-      data: {
-        EVM: { DEXTrades: [] },
-        Trading: { Tokens: [supplyRow()] },
-      },
-    })) as typeof fetch;
+    const success = vi.fn(async () => jsonResponse(
+      chartResponse({ points: [], total: "0" }),
+    )) as typeof fetch;
     await readBitqueryMarketChartV1({
       identity: PCAN,
       range: "1h",
@@ -1734,19 +1836,15 @@ describe("Bitquery OHLCV chart and server stream", () => {
   });
 
   it("never presents a populated chart fallback as a live provider read", async () => {
-    const success = vi.fn(async () => jsonResponse({
-      data: {
-        EVM: {
-          DEXTrades: [tradeRow({
-            block: "25740000",
-            time: "2026-08-11T14:01:00.000Z",
-            transaction: `0x${"44".repeat(32)}`,
-            priceQuote: "1",
-          })],
-        },
-        Trading: { Tokens: [supplyRow()] },
-      },
-    })) as typeof fetch;
+    const success = vi.fn(async () => jsonResponse(chartResponse({
+      points: [chartBucketRow({
+        block: "25740000",
+        time: "2026-08-11T14:01:00.000Z",
+        price: "1",
+        count: "1",
+      })],
+      total: "1",
+    }))) as typeof fetch;
     const live = await readBitqueryMarketChartV1({
       identity: PCAN,
       range: "1h",
@@ -1778,19 +1876,15 @@ describe("Bitquery OHLCV chart and server stream", () => {
   });
 
   it("reuses a populated chart for the two-second server cache window", async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse({
-      data: {
-        EVM: {
-          DEXTrades: [tradeRow({
-            block: "25740000",
-            time: "2026-08-11T14:01:00.000Z",
-            transaction: `0x${"45".repeat(32)}`,
-            priceQuote: "1",
-          })],
-        },
-        Trading: { Tokens: [supplyRow()] },
-      },
-    })) as typeof fetch;
+    const fetchImpl = vi.fn(async () => jsonResponse(chartResponse({
+      points: [chartBucketRow({
+        block: "25740000",
+        time: "2026-08-11T14:01:00.000Z",
+        price: "1",
+        count: "1",
+      })],
+      total: "1",
+    }))) as typeof fetch;
     const first = await readBitqueryMarketChartV1({
       identity: PCAN,
       range: "1h",
@@ -1811,19 +1905,15 @@ describe("Bitquery OHLCV chart and server stream", () => {
   });
 
   it("does not reuse a chart across different canonical valuations", async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse({
-      data: {
-        EVM: {
-          DEXTrades: [tradeRow({
-            block: "25740000",
-            time: "2026-08-11T14:01:00.000Z",
-            transaction: `0x${"46".repeat(32)}`,
-            priceQuote: "1",
-          })],
-        },
-        Trading: { Tokens: [supplyRow()] },
-      },
-    })) as typeof fetch;
+    const fetchImpl = vi.fn(async () => jsonResponse(chartResponse({
+      points: [chartBucketRow({
+        block: "25740000",
+        time: "2026-08-11T14:01:00.000Z",
+        price: "1",
+        count: "1",
+      })],
+      total: "1",
+    }))) as typeof fetch;
     const firstValuation = {
       status: "available",
       metric: "fdv",
@@ -1872,20 +1962,16 @@ describe("Bitquery OHLCV chart and server stream", () => {
     ) => {
       const request = JSON.parse(String(init?.body));
       expect(request.query).not.toContain("Trading {");
-      expect(request.query).not.toContain("Tokens(");
-      expect(request.variables).not.toHaveProperty("tokenAddress");
-      return jsonResponse({
-        data: {
-          EVM: {
-            DEXTrades: [tradeRow({
-              block: "25740000",
-              time: "2026-08-11T14:01:00.000Z",
-              transaction: `0x${"47".repeat(32)}`,
-              priceQuote: "1",
-            })],
-          },
-        },
-      });
+      expect(request.variables.tokenAddress).toBe(PCAN.tokenAddress);
+      return jsonResponse(chartResponse({
+        points: [chartBucketRow({
+          block: "25740000",
+          time: "2026-08-11T14:01:00.000Z",
+          price: "1",
+          count: "1",
+        })],
+        total: "1",
+      }));
     }) as typeof fetch;
 
     const chart = await readBitqueryMarketChartV1({
@@ -1902,58 +1988,32 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(chart.points).toHaveLength(1);
   });
 
-  it("builds exact-pool quote candles without promoting raw DEX USD", async () => {
-    const trades = [
-      tradeRow({
-        block: "25740000",
-        time: "2026-08-11T14:00:01.000Z",
-        transaction: `0x${"01".repeat(32)}`,
-        priceUsd: "1",
-        priceQuote: "1",
-        amountUsd: "10",
+  it("builds exact-pool median quote points without promoting raw DEX USD", async () => {
+    const points = [
+      chartBucketRow({
+        block: "25740003",
+        bucket: "2026-08-11T14:01:00.000Z",
+        time: "2026-08-11T14:01:10.000Z",
+        price: "4",
+        count: "1",
       }),
-      tradeRow({
-        block: "25740001",
-        time: "2026-08-11T14:00:20.000Z",
-        transaction: `0x${"02".repeat(32)}`,
-        priceUsd: "3",
-        priceQuote: "3",
-        amountUsd: "20",
-      }),
-      tradeRow({
+      chartBucketRow({
         block: "25740002",
         time: "2026-08-11T14:00:40.000Z",
-        transaction: `0x${"03".repeat(32)}`,
-        priceUsd: "2",
-        priceQuote: "2",
-        amountUsd: "30",
+        price: "2",
+        count: "3",
       }),
-      tradeRow({
-        block: "25740003",
-        time: "2026-08-11T14:01:10.000Z",
-        transaction: `0x${"04".repeat(32)}`,
-        priceUsd: "4",
-        priceQuote: "4",
-        amountUsd: "40",
-      }),
-    ].reverse();
+    ];
     const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       const request = JSON.parse(String(init?.body));
       expect(request.variables.poolId).toBe(PCAN.poolId);
-      expect(request.query).toContain("DEXTrades(");
+      expect(request.variables.tokenAddress).toBe(PCAN.tokenAddress);
+      expect(request.query).toContain("DEXTradeByTokens(");
       expect(request.query).not.toContain("dataset: combined");
       expect(request.query).toContain("PoolId: { is: $poolId }");
-      expect(request.query).toContain("{ descending: Block_Number }");
-      expect(request.query).toContain("{ descending: Transaction_Index }");
-      expect(request.query).toContain("{ descending: Log_Index }");
-      expect(request.query).toContain("Transaction { Hash Index }");
       expect(request.query).toContain("TransactionStatus: { Success: true }");
-      return jsonResponse({
-        data: {
-          EVM: { DEXTrades: trades },
-          Trading: { Tokens: [supplyRow()] },
-        },
-      });
+      expect(request.query).not.toContain("PriceInUSD");
+      return jsonResponse(chartResponse({ points, total: "4" }));
     }) as typeof fetch;
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
@@ -1973,13 +2033,11 @@ describe("Bitquery OHLCV chart and server stream", () => {
         {
           blockNumber: "25740002",
           priceQuote: "2",
-          ohlcQuote: { open: "1", high: "3", low: "1", close: "2" },
           tradeCount: 3,
         },
         {
           blockNumber: "25740003",
           priceQuote: "4",
-          ohlcQuote: { open: "4", high: "4", low: "4", close: "4" },
           tradeCount: 1,
         },
       ],
@@ -1988,35 +2046,16 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(chart.points.every((point) => point.priceUsd === undefined)).toBe(true);
   });
 
-  it("keeps distinct v4 swaps from the same transaction by log index", async () => {
-    const transaction = `0x${"21".repeat(32)}`;
-    const fetchImpl = vi.fn(async () => jsonResponse({
-      data: {
-        EVM: {
-          DEXTrades: [
-            tradeRow({
-              block: "25740000",
-              time: "2026-08-11T14:00:02.000Z",
-              transaction,
-              logIndex: 2,
-              priceUsd: "2",
-              priceQuote: "2",
-              amountUsd: "20",
-            }),
-            tradeRow({
-              block: "25740000",
-              time: "2026-08-11T14:00:01.000Z",
-              transaction,
-              logIndex: 1,
-              priceUsd: "1",
-              priceQuote: "1",
-              amountUsd: "10",
-            }),
-          ],
-        },
-        Trading: { Tokens: [supplyRow()] },
-      },
-    })) as typeof fetch;
+  it("keeps all swaps represented in the provider bucket count", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(chartResponse({
+      points: [chartBucketRow({
+        block: "25740000",
+        time: "2026-08-11T14:00:02.000Z",
+        price: "1.5",
+        count: "2",
+      })],
+      total: "2",
+    }))) as typeof fetch;
 
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
@@ -2031,8 +2070,7 @@ describe("Bitquery OHLCV chart and server stream", () => {
       swapCount: 2,
       points: [{
         blockNumber: "25740000",
-        priceQuote: "2",
-        ohlcQuote: { open: "1", high: "2", low: "1", close: "2" },
+        priceQuote: "1.5",
         tradeCount: 2,
       }],
     });
@@ -2040,80 +2078,17 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(isMarketChartV1(chart)).toBe(true);
   });
 
-  it("orders same-block swaps by transaction index and then log index, never hash", async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse({
-      data: {
-        EVM: {
-          DEXTrades: [
-            tradeRow({
-              block: "25740000",
-              time: "2026-08-11T14:00:01.000Z",
-              transaction: `0x${"00".repeat(32)}`,
-              transactionIndex: 2,
-              logIndex: 1,
-              priceQuote: "2",
-            }),
-            tradeRow({
-              block: "25740000",
-              time: "2026-08-11T14:00:01.000Z",
-              transaction: `0x${"ff".repeat(32)}`,
-              transactionIndex: 1,
-              logIndex: 9,
-              priceQuote: "1",
-            }),
-          ],
-        },
-        Trading: { Tokens: [supplyRow()] },
-      },
-    })) as typeof fetch;
-
-    const chart = await readBitqueryMarketChartV1({
-      identity: PCAN,
-      range: "1h",
-      fetchImpl,
-      token: OAUTH_TOKEN,
-      now: new Date("2026-08-11T14:02:00.000Z"),
-    });
-
-    expect(chart.points[0]).toMatchObject({
-      priceQuote: "2",
-      ohlcQuote: { open: "1", close: "2" },
-    });
-  });
-
   it("never promotes raw DEX USD into chart prices or volume", async () => {
-    const trades = [
-      tradeRow({
-        block: "25740002",
-        time: "2026-08-11T14:01:10.000Z",
-        transaction: `0x${"13".repeat(32)}`,
-        priceUsd: "2",
-        priceQuote: "2",
-        amountUsd: "20",
-      }),
-      tradeRow({
+    const fetchImpl = vi.fn(async () => jsonResponse(chartResponse({
+      points: [chartBucketRow({
         block: "25740001",
         time: "2026-08-11T14:00:20.000Z",
-        transaction: `0x${"12".repeat(32)}`,
-        omitPriceUsd: true,
-        omitAmountUsd: true,
-        priceQuote: "1.5",
-      }),
-      tradeRow({
-        block: "25740000",
-        time: "2026-08-11T14:00:01.000Z",
-        transaction: `0x${"11".repeat(32)}`,
-        priceUsd: "1",
-        priceQuote: "1",
-        amountUsd: "10",
-      }),
-    ];
-    const fetchImpl = vi.fn(async () => jsonResponse({
-      data: {
-        EVM: { DEXTrades: trades },
-        Trading: { Tokens: [supplyRow({ indexedPrice: null })] },
-      },
-    })) as typeof fetch;
+        price: "1.25",
+        count: "2",
+      })],
+      total: "2",
+      supply: supplyRow({ indexedPrice: null }),
+    }))) as typeof fetch;
 
     const chart = await readBitqueryMarketChartV1({
       identity: PCAN,
@@ -2124,11 +2099,10 @@ describe("Bitquery OHLCV chart and server stream", () => {
     });
 
     expect(isMarketChartV1(chart)).toBe(true);
-    expect(chart.status).toBe("ready");
+    expect(chart.status).toBe("insufficient-history");
     expect(chart).not.toHaveProperty("volumeUsdWad");
     expect(chart.points[0]).toMatchObject({
-      priceQuote: "1.5",
-      ohlcQuote: { open: "1", high: "1.5", low: "1", close: "1.5" },
+      priceQuote: "1.25",
       tradeCount: 2,
     });
     expect(chart.points[0]).not.toHaveProperty("priceUsd");

--- a/tests/classic-v3-action-activation.test.ts
+++ b/tests/classic-v3-action-activation.test.ts
@@ -2,6 +2,9 @@ import { NextRequest } from "next/server";
 import { getAddress, type Address, type Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { rpcProviderCommitment } from
+  "../lib/data-pipeline/rpc-provider-commitments";
+
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
@@ -27,6 +30,10 @@ const factory = getAddress("0xf28967f9dfac3ca21384b59d6d75c8106b3eab2a");
 const poolId = `0x${"44".repeat(32)}` as Hex;
 const blockHash = `0x${"55".repeat(32)}` as Hex;
 const launchTransactionHash = `0x${"66".repeat(32)}` as Hex;
+const alchemyRpcUrl =
+  "https://eth-mainnet.g.alchemy.com/v2/alchemy-classic-key";
+const quickNodeRpcUrl =
+  "https://classic-mainnet.quiknode.pro/quicknode-classic-key/";
 
 const indexedToken = {
   chainId: 1 as const,
@@ -215,13 +222,17 @@ function request() {
 describe("Classic V3 action identity activation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("ETHEREUM_RPC_URL", alchemyRpcUrl);
+    vi.stubEnv("ETHEREUM_RPC_URL_B", quickNodeRpcUrl);
+    vi.stubEnv("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL", alchemyRpcUrl);
+    vi.stubEnv("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL", quickNodeRpcUrl);
     vi.stubEnv(
-      "ETHEREUM_RPC_URL",
-      "https://mainnet.infura.io/v3/infura-classic-key",
+      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT",
+      rpcProviderCommitment("endpoint", alchemyRpcUrl),
     );
     vi.stubEnv(
-      "ETHEREUM_RPC_URL_B",
-      "https://classic-node.quiknode.pro/quicknode-classic-key/",
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+      rpcProviderCommitment("endpoint", quickNodeRpcUrl),
     );
     mocks.lookup.mockResolvedValue(actionReward);
     const legacyClient = identityClient();
@@ -270,7 +281,7 @@ describe("Classic V3 action identity activation", () => {
       mocks.indexedEnabled = indexedEnabled;
       vi.stubEnv(
         "ETHEREUM_RPC_URL_B",
-        "https://mainnet.infura.io/v3/second-classic-secret",
+        "https://eth-mainnet.g.alchemy.com/v2/second-classic-secret",
       );
 
       const response = await POST(request());
@@ -280,7 +291,7 @@ describe("Classic V3 action identity activation", () => {
       expect(mocks.createPublicClient).toHaveBeenCalledTimes(
         indexedEnabled ? 0 : 1,
       );
-      expect(serialized).not.toContain("infura-classic-key");
+      expect(serialized).not.toContain("alchemy-classic-key");
       expect(serialized).not.toContain("second-classic-secret");
     },
   );

--- a/tests/classic-v3-profile-route.test.ts
+++ b/tests/classic-v3-profile-route.test.ts
@@ -2,6 +2,9 @@ import { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HttpRequestError } from "viem";
 
+import { rpcProviderCommitment } from
+  "../lib/data-pipeline/rpc-provider-commitments";
+
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => {
@@ -67,13 +70,27 @@ import {
 
 const account = "0x1111111111111111111111111111111111111111";
 const vault = "0x2222222222222222222222222222222222222222";
+const alchemyRpcUrl =
+  "https://eth-mainnet.g.alchemy.com/v2/alchemy-classic-key";
+const quickNodeRpcUrl =
+  "https://classic-mainnet.quiknode.pro/quicknode-classic-key/";
 
 describe("Classic profile release gate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.createPublicClient.mockReturnValue(mocks.client);
-    vi.stubEnv("ETHEREUM_RPC_URL", "https://primary.example/rpc-key");
-    vi.stubEnv("ETHEREUM_RPC_URL_B", "https://secondary.example/rpc-key");
+    vi.stubEnv("ETHEREUM_RPC_URL", alchemyRpcUrl);
+    vi.stubEnv("ETHEREUM_RPC_URL_B", quickNodeRpcUrl);
+    vi.stubEnv("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL", alchemyRpcUrl);
+    vi.stubEnv("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL", quickNodeRpcUrl);
+    vi.stubEnv(
+      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT",
+      rpcProviderCommitment("endpoint", alchemyRpcUrl),
+    );
+    vi.stubEnv(
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+      rpcProviderCommitment("endpoint", quickNodeRpcUrl),
+    );
   });
 
   afterEach(() => {

--- a/tests/current-valuation-server.test.ts
+++ b/tests/current-valuation-server.test.ts
@@ -1,0 +1,434 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  readOfficialV4LiquidityEvidence: vi.fn(),
+  withSameBlockEthUsdQuote: vi.fn(),
+  enrichTokensWithAlchemyPoolState: vi.fn(),
+}));
+
+vi.mock("../lib/onchain/uniswap-v4-subgraph", () => ({
+  readOfficialV4LiquidityEvidence:
+    mocks.readOfficialV4LiquidityEvidence,
+}));
+vi.mock("../lib/alchemy/live-market.server", () => ({
+  withSameBlockEthUsdQuote: mocks.withSameBlockEthUsdQuote,
+  enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
+}));
+
+import { valueExploreEntriesWithCurrentEvidence } from
+  "../lib/market-data/current-valuation.server";
+import type { TokenMarketDataV1 } from
+  "../lib/market-data/market-data-v1";
+import type { ExploreEntry } from "../lib/tokens";
+
+const tokenAddress = "0x1111111111111111111111111111111111111111";
+const poolId = `0x${"22".repeat(32)}` as const;
+const token = {
+  exploreKind: "token",
+  id: `1:${tokenAddress}`,
+  name: "Current",
+  symbol: "CUR",
+  tokenAddress,
+  hookAddress: "0x3333333333333333333333333333333333333333",
+  poolId,
+  launchedAt: "2026-08-13T00:00:00.000Z",
+  totalSupplyRaw: "1000000000000000000000000",
+  tokenDecimals: 18,
+  launchModel: "classic",
+  totalSwapFeeBps: 100,
+  liquidityPath: "meme",
+  launchCategoryProvenance: {
+    source: "meme-launcher",
+    category: "classic",
+    reference: "meme-launcher-v1",
+  },
+} as unknown as ExploreEntry;
+
+const marketData = {
+  schemaVersion: "programmable.market-data.v1",
+  source: "bitquery",
+  generatedAt: "2026-08-13T00:02:00.000Z",
+  status: "current",
+  primaryPoolId: poolId,
+  pools: [{
+    identity: {
+      chainId: "1",
+      tokenAddress,
+      poolId,
+      protocol: "uniswap_v4",
+    },
+    source: "bitquery",
+    status: "current",
+    quality: "complete",
+    asOfTime: "2026-08-13T00:02:00.000Z",
+    latestTrade: {
+      transactionHash: `0x${"44".repeat(32)}`,
+      logIndex: 1,
+      blockNumber: "25750000",
+      time: "2026-08-13T00:02:00.000Z",
+      tokenSide: "buy",
+      priceUsdWad: "2000000000000000000",
+      rawPriceUsdWad: "2000000000000000000",
+      priceUsdSource: "bitquery-token-price-index-v1",
+      priceUsdAsOfTime: "2026-08-13T00:02:00.000Z",
+    },
+    liquidity: {
+      asOfTime: "2026-08-13T00:02:00.000Z",
+      asOfBlock: "25750000",
+      valueUsdWad: "10000000000000000000000",
+      freshness: "current",
+    },
+    valuation: {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      valueUsdWad: "2000000000000000000000000",
+      fdvUsdWad: "2000000000000000000000000",
+      totalSupply: "1000000",
+      asOfTime: "2026-08-13T00:02:00.000Z",
+      freshness: "current",
+    },
+  }],
+} satisfies TokenMarketDataV1;
+
+const deployment = {
+  status: "ready",
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  stateView: "0x4444444444444444444444444444444444444444",
+  stateViewRuntimeCodeHash: `0x${"55".repeat(32)}`,
+  rpcUrl: "https://primary.example",
+  rpcUrlSecondary: "https://secondary.example",
+  confirmations: 12n,
+  logBlockRange: 5_000n,
+  launcher: "0x6666666666666666666666666666666666666666",
+  feeHook: "0x7777777777777777777777777777777777777777",
+  launcherRuntimeCodeHash: `0x${"88".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"99".repeat(32)}`,
+  deploymentBlock: 1n,
+} as const;
+const snapshot = {
+  chainId: 1,
+  blockNumber: "25750000",
+  blockHash: `0x${"aa".repeat(32)}`,
+  confirmations: 12,
+} as const;
+
+describe("current Explore valuation orchestration", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("keeps current Bitquery nested but unavailable at top level when dual evidence fails", async () => {
+    mocks.readOfficialV4LiquidityEvidence.mockResolvedValue([]);
+    mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+
+    const [valued] = await valueExploreEntriesWithCurrentEvidence({
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+    });
+
+    expect(valued?.valuation).toEqual({
+      status: "unavailable",
+      reason: "liquidity-unavailable",
+    });
+    expect(valued?.marketData?.pools[0]?.latestTrade).toBeDefined();
+    expect(valued?.marketData?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "inconsistent-market-data",
+    });
+  });
+
+  it("degrades on its deadline for discovery but fails closed for global ranking", async () => {
+    mocks.readOfficialV4LiquidityEvidence.mockImplementation(
+      () => new Promise(() => undefined),
+    );
+    mocks.withSameBlockEthUsdQuote.mockImplementation(
+      () => new Promise(() => undefined),
+    );
+    const input = {
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+      timeoutMs: 1,
+    } as const;
+
+    await expect(valueExploreEntriesWithCurrentEvidence(input)).resolves
+      .toMatchObject([{
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+        marketData: {
+          pools: [{
+            valuation: {
+              status: "unavailable",
+              reason: "source-unavailable",
+            },
+          }],
+        },
+      }]);
+    await expect(valueExploreEntriesWithCurrentEvidence({
+      ...input,
+      requireCompleteLiquidityCoverage: true,
+    })).rejects.toThrow("deadline exceeded");
+  });
+
+  it("bounds an unresolved operational snapshot and never starts downstream reads", async () => {
+    const unresolvedSnapshot = new Promise<null>(() => undefined);
+    const input = {
+      entries: [token],
+      marketByToken: Promise.resolve(new Map([[tokenAddress, marketData]])),
+      deployment,
+      operationalSnapshot: unresolvedSnapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+      timeoutMs: 1,
+    } as const;
+
+    await expect(valueExploreEntriesWithCurrentEvidence(input)).resolves
+      .toMatchObject([{
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+      }]);
+    await expect(valueExploreEntriesWithCurrentEvidence({
+      ...input,
+      requireCompleteLiquidityCoverage: true,
+    })).rejects.toThrow("deadline exceeded");
+    expect(mocks.readOfficialV4LiquidityEvidence).not.toHaveBeenCalled();
+    expect(mocks.withSameBlockEthUsdQuote).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for global ranking when the same-block quote is unavailable", async () => {
+    mocks.readOfficialV4LiquidityEvidence.mockResolvedValue([]);
+    mocks.withSameBlockEthUsdQuote.mockRejectedValue(
+      new Error("quote unavailable"),
+    );
+
+    await expect(valueExploreEntriesWithCurrentEvidence({
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+      requireCompleteLiquidityCoverage: true,
+    })).rejects.toThrow("quote unavailable");
+  });
+
+  it("starts current evidence while the Bitquery market read is still pending", async () => {
+    let resolveMarket!: (value: ReadonlyMap<string, TokenMarketDataV1>) => void;
+    const pendingMarket = new Promise<ReadonlyMap<string, TokenMarketDataV1>>(
+      (resolve) => {
+        resolveMarket = resolve;
+      },
+    );
+    mocks.readOfficialV4LiquidityEvidence.mockResolvedValue([]);
+    mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+
+    const read = valueExploreEntriesWithCurrentEvidence({
+      entries: [token],
+      marketByToken: pendingMarket,
+      deployment,
+      operationalSnapshot: Promise.resolve(snapshot),
+      now: new Date("2026-08-13T00:02:00.000Z"),
+    });
+    await vi.waitFor(() => {
+      expect(mocks.readOfficialV4LiquidityEvidence).toHaveBeenCalledOnce();
+      expect(mocks.withSameBlockEthUsdQuote).toHaveBeenCalledOnce();
+    });
+    resolveMarket(new Map([[tokenAddress, marketData]]));
+
+    await expect(read).resolves.toHaveLength(1);
+  });
+
+  it("treats exact zero active liquidity as known ineligibility, not missing coverage", async () => {
+    const blockTimestamp = "1786579320";
+    mocks.readOfficialV4LiquidityEvidence.mockResolvedValue([{
+      source: "official-uniswap-v4-subgraph",
+      identity: {
+        chainId: "1",
+        protocol: "uniswap_v4",
+        poolId,
+        tokenAddress,
+        quoteAddress: "0x0000000000000000000000000000000000000000",
+      },
+      valueBasis: "official-subgraph-pool-tvl-usd",
+      tvlUsdWad: "10000000000000000000000",
+      reportedPoolBalances: {
+        token0: {
+          address: "0x0000000000000000000000000000000000000000",
+          decimals: 18,
+          amountDecimal: "10",
+        },
+        token1: { address: tokenAddress, decimals: 18, amountDecimal: "10" },
+      },
+      freshness: "current",
+      provenance: {
+        subgraphId: "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G",
+        deployment: "QmZsgJLiLQKpb8hxTmQ5LWyrFVvfWzVaL4WK8dfFBn7EeK",
+        indexedBlockNumber: snapshot.blockNumber,
+        indexedBlockHash: snapshot.blockHash,
+        indexedBlockTimestamp: blockTimestamp,
+        indexedBlockTime: new Date(Number(blockTimestamp) * 1_000).toISOString(),
+        referenceHeadBlockNumber: snapshot.blockNumber,
+        referenceHeadBlockHash: snapshot.blockHash,
+        lagBlocks: "0",
+      },
+    }]);
+    mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([{
+      ...token,
+      liveMarketStateEvidence: {
+        source: "uniswap-v4-stateview-v1",
+        blockNumber: snapshot.blockNumber,
+        blockHash: snapshot.blockHash,
+        sqrtPriceX96: (1n << 96n).toString(),
+        activeLiquidity: "0",
+      },
+    }]);
+
+    const [valued] = await valueExploreEntriesWithCurrentEvidence({
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+      requireCompleteLiquidityCoverage: true,
+    });
+
+    expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalledOnce();
+    expect(valued?.exploreKind === "token" && valued.liveMarketStateEvidence)
+      .toMatchObject({
+      activeLiquidity: "0",
+    });
+    expect(valued?.valuation).toEqual({
+      status: "unavailable",
+      reason: "liquidity-unavailable",
+    });
+  });
+
+  it("fails global ranking when positive active liquidity lacks price evidence", async () => {
+    const blockTimestamp = "1786579320";
+    mocks.readOfficialV4LiquidityEvidence.mockResolvedValue([{
+      source: "official-uniswap-v4-subgraph",
+      identity: {
+        chainId: "1",
+        protocol: "uniswap_v4",
+        poolId,
+        tokenAddress,
+        quoteAddress: "0x0000000000000000000000000000000000000000",
+      },
+      valueBasis: "official-subgraph-pool-tvl-usd",
+      tvlUsdWad: "10000000000000000000000",
+      reportedPoolBalances: {
+        token0: {
+          address: "0x0000000000000000000000000000000000000000",
+          decimals: 18,
+          amountDecimal: "10",
+        },
+        token1: { address: tokenAddress, decimals: 18, amountDecimal: "10" },
+      },
+      freshness: "current",
+      provenance: {
+        subgraphId: "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G",
+        deployment: "QmZsgJLiLQKpb8hxTmQ5LWyrFVvfWzVaL4WK8dfFBn7EeK",
+        indexedBlockNumber: snapshot.blockNumber,
+        indexedBlockHash: snapshot.blockHash,
+        indexedBlockTimestamp: blockTimestamp,
+        indexedBlockTime: new Date(Number(blockTimestamp) * 1_000).toISOString(),
+        referenceHeadBlockNumber: snapshot.blockNumber,
+        referenceHeadBlockHash: snapshot.blockHash,
+        lagBlocks: "0",
+      },
+    }]);
+    mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([{
+      ...token,
+      liveMarketStateEvidence: {
+        source: "uniswap-v4-stateview-v1",
+        blockNumber: snapshot.blockNumber,
+        blockHash: snapshot.blockHash,
+        sqrtPriceX96: (1n << 96n).toString(),
+        activeLiquidity: "1",
+      },
+    }]);
+
+    await expect(valueExploreEntriesWithCurrentEvidence({
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+      requireCompleteLiquidityCoverage: true,
+    })).rejects.toThrow("StateView market evidence is incomplete");
+  });
+
+  it("preserves only the exact stale historical PCAN detail valuation", async () => {
+    const historicalAddress =
+      "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
+    const historicalToken = {
+      ...token,
+      id: `1:${historicalAddress}`,
+      tokenAddress: historicalAddress,
+    } as ExploreEntry;
+    const historicalMarketData = {
+      ...marketData,
+      status: "stale",
+      pools: marketData.pools.map((pool) => ({
+        ...pool,
+        identity: { ...pool.identity, tokenAddress: historicalAddress },
+        status: "stale" as const,
+        liquidity: { ...pool.liquidity, freshness: "stale" as const },
+        valuation: { ...pool.valuation, freshness: "stale" as const },
+      })),
+    } satisfies TokenMarketDataV1;
+
+    const [valued] = await valueExploreEntriesWithCurrentEvidence({
+      entries: [historicalToken],
+      marketByToken: new Map([[historicalAddress, historicalMarketData]]),
+      deployment: null,
+      operationalSnapshot: null,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+      allowHistoricalBitqueryFallback: true,
+    });
+
+    expect(valued?.valuation).toMatchObject({
+      status: "available",
+      source: "bitquery",
+      freshness: "stale",
+    });
+  });
+
+  it("removes stale Bitquery FDV from ordinary public entries", async () => {
+    const staleMarketData = {
+      ...marketData,
+      status: "stale",
+      pools: marketData.pools.map((pool) => ({
+        ...pool,
+        status: "stale" as const,
+        liquidity: { ...pool.liquidity, freshness: "stale" as const },
+        valuation: { ...pool.valuation, freshness: "stale" as const },
+      })),
+    } satisfies TokenMarketDataV1;
+
+    const [valued] = await valueExploreEntriesWithCurrentEvidence({
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, staleMarketData]]),
+      deployment: null,
+      operationalSnapshot: null,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+    });
+
+    expect(valued?.valuation).toEqual({
+      status: "unavailable",
+      reason: "source-unavailable",
+    });
+    expect(valued?.marketData?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "source-unavailable",
+    });
+  });
+});

--- a/tests/data-pipeline/bitquery-historical-release-gate.test.ts
+++ b/tests/data-pipeline/bitquery-historical-release-gate.test.ts
@@ -84,8 +84,24 @@ function chart() {
       protocol: "uniswap_v4",
     },
     points: [
-      { blockNumber: "25730000", time: "2026-08-10T10:50:47.000Z", priceUsd: "1900" },
-      { blockNumber: BLOCK, time: TIME, priceUsd: "2000" },
+      {
+        blockNumber: "25730000",
+        time: "2026-08-10T11:00:00.000Z",
+        bucketStart: "2026-08-10T10:00:00.000Z",
+        bucketEnd: "2026-08-10T11:00:00.000Z",
+        observedAt: "2026-08-10T10:50:47.000Z",
+        valueSemantics: "period-median",
+        priceUsd: "1900",
+      },
+      {
+        blockNumber: BLOCK,
+        time: "2026-08-10T12:00:00.000Z",
+        bucketStart: "2026-08-10T11:00:00.000Z",
+        bucketEnd: "2026-08-10T12:00:00.000Z",
+        observedAt: TIME,
+        valueSemantics: "period-median",
+        priceUsd: "2000",
+      },
     ],
     valuation: {
       status: "available",
@@ -184,7 +200,7 @@ describe("Bitquery historical release gate", () => {
     })).toThrow("historical PCAN release evidence is not exactly bound");
   });
 
-  it("fails closed when the direct chart close is not the exact trade block", () => {
+  it("fails closed when the last chart observation is not the exact trade block", () => {
     const driftedChart = chart();
     driftedChart.points[1].blockNumber = "25731001";
     expect(() => verifyBitqueryHistoricalGoldenReleaseV1({

--- a/tests/data-pipeline/bitquery-historical-release-gate.test.ts
+++ b/tests/data-pipeline/bitquery-historical-release-gate.test.ts
@@ -12,6 +12,7 @@ const {
 const TOKEN = "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
 const POOL =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const QUOTE = "0x0000000000000000000000000000000000000000";
 const BLOCK = "25731000";
 const TIME = "2026-08-10T11:50:47.000Z";
 const NOW = Date.parse("2026-08-13T00:00:00.000Z");
@@ -81,6 +82,7 @@ function chart() {
       chainId: "1",
       tokenAddress: TOKEN,
       poolId: POOL,
+      quoteAddress: QUOTE,
       protocol: "uniswap_v4",
     },
     points: [
@@ -104,13 +106,8 @@ function chart() {
       },
     ],
     valuation: {
-      status: "available",
-      metric: "fdv",
-      supplyBasis: "total",
-      freshness: "stale",
-      valueUsdWad: FDV,
-      fdvUsdWad: FDV,
-      asOfTime: TIME,
+      status: "unavailable",
+      reason: "source-unavailable",
     },
     asOfTime: TIME,
   };
@@ -203,6 +200,18 @@ describe("Bitquery historical release gate", () => {
   it("fails closed when the last chart observation is not the exact trade block", () => {
     const driftedChart = chart();
     driftedChart.points[1].blockNumber = "25731001";
+    expect(() => verifyBitqueryHistoricalGoldenReleaseV1({
+      detailToken: detailToken(),
+      chart: driftedChart,
+      parity: parity(),
+      nowMs: NOW,
+    })).toThrow("historical PCAN release evidence is not exactly bound");
+  });
+
+  it("fails closed when the chart quote identity is not canonical native ETH", () => {
+    const driftedChart = chart();
+    driftedChart.identity.quoteAddress =
+      "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
     expect(() => verifyBitqueryHistoricalGoldenReleaseV1({
       detailToken: detailToken(),
       chart: driftedChart,

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -1305,7 +1305,7 @@ describe("read-model performance contract", () => {
         {
           sourceOverrides: {
             [exploreRoutePath]: exploreRouteSource.replaceAll(
-              '"X-Programmable-Market-Source": "bitquery"',
+              '"stateview-chainlink+official-uniswap-v4-subgraph+bitquery"',
               '"X-Programmable-Market-Source": "alchemy"',
             ),
           },

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -729,6 +729,9 @@ describe("read-model production deploy policy", () => {
       'goldenChart.schemaVersion !== "programmable.market-chart.v1"',
     );
     expect(workflow).toContain(
+      "goldenChart.identity?.quoteAddress !== goldenQuoteAddress",
+    );
+    expect(workflow).toContain(
       "staged Bitquery Highest FDV is not monotonically descending",
     );
     expect(workflow).toContain(
@@ -800,6 +803,14 @@ describe("read-model production deploy policy", () => {
     expect(workflow).toContain(
       "goldenChart.asOfTime !== goldenChart.points.at(-1)?.observedAt",
     );
+    expect(workflow).toContain(
+      'goldenChart.valuation?.status !== "unavailable"',
+    );
+    expect(workflow).toContain(
+      'goldenChart.valuation?.reason !== "source-unavailable"',
+    );
+    expect(workflow).toContain('"fdvUsdWad" in goldenChart');
+    expect(workflow).toContain('"valuationMetric" in goldenChart');
     expect(workflow).toContain(
       'point?.valueSemantics !== "period-median"',
     );

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -637,7 +637,7 @@ describe("read-model production deploy policy", () => {
     expect(PROJECTOR_WAKE_ROUTE).toBe("/api/ops/projector-wake");
   });
 
-  it("smokes registry identity plus Bitquery market APIs and stops at a staged candidate", () => {
+  it("smokes combined current market evidence and stops at a staged candidate", () => {
     const workflow = readFileSync(
       resolve(ROOT, ".github/workflows/deploy-production.yml"),
       "utf8",
@@ -652,7 +652,7 @@ describe("read-model production deploy policy", () => {
     expect(workflow.match(/--sensitive-env-metadata/g)).toHaveLength(2);
     expect(workflow).toContain("staged-release-attestation.json");
     expect(workflow).toContain("attestation_sha256");
-    expect(workflow).toContain("Smoke staged Bitquery market APIs");
+    expect(workflow).toContain("Smoke staged public market APIs");
     expect(workflow).toContain(
       "if: needs.release-gate.outputs.verified_read_model == 'true' && steps.read-model-policy.outputs.mode == 'alchemy-only'",
     );
@@ -664,7 +664,10 @@ describe("read-model production deploy policy", () => {
       'readSources: Object.freeze(["operational+durable+postgres"]),',
     );
     expect(workflow).toContain(
-      'marketSources: Object.freeze(["bitquery"]),',
+      'marketSources: Object.freeze([currentPublicMarketSource]),',
+    );
+    expect(workflow).toContain(
+      'priceSources: Object.freeze(["stateview-chainlink"]),',
     );
     expect(workflow).toContain(
       'dataQualities: Object.freeze(["complete", "partial", "stale"]),',
@@ -689,8 +692,12 @@ describe("read-model production deploy policy", () => {
     );
     expect(workflow).not.toContain('"/api/indexers/v1/token-list"');
     expect(workflow).toContain(
-      '"/api/explore?limit=20&page=1&sort=market-cap",\n            bitqueryMarketContract,',
+      '`/api/explore?limit=${marketCapPageSize}&page=1&sort=market-cap`,\n            currentPublicMarketContract,',
     );
+    expect(workflow).toContain("marketCapTotal > maximumMarketCapTokens");
+    expect(workflow).toContain("marketCapTokens.length !== marketCapTotal");
+    expect(workflow).toContain("seenMarketCapIds.has(token.id)");
+    expect(workflow).toContain("seenMarketCapAddresses.has(address)");
     expect(workflow).toContain("entry.launchCategoryProvenance.blockNumber");
     expect(workflow).toContain(
       "entry.launchCategoryProvenance.transactionIndex",
@@ -729,49 +736,48 @@ describe("read-model production deploy policy", () => {
       'goldenChart.schemaVersion !== "programmable.market-chart.v1"',
     );
     expect(workflow).toContain(
-      "goldenChart.identity?.quoteAddress !== goldenQuoteAddress",
+      "goldenChart.identity?.quoteAddress,\n              goldenQuoteAddress",
     );
     expect(workflow).toContain(
       "staged Bitquery Highest FDV is not monotonically descending",
     );
     expect(workflow).toContain(
-      "staged Bitquery Explore exposed stale or unavailable FDV as current",
+      "staged Bitquery Explore exposed unevidenced numeric FDV",
     );
-    expect(workflow).toContain(
-      "staged Bitquery Explore mislabeled stale FDV as current",
-    );
-    expect(workflow).toContain('valuation.freshness === "stale"');
     expect(workflow).toContain(
       'valuation.reason === "waiting-for-first-trade"',
     );
     expect(workflow).toContain("if (currentFdvCount < 1) {");
     expect(workflow).toContain(
-      "staged Bitquery market path has no current public non-PCAN FDV with exact primary-pool liquidity evidence",
+      "staged public market path has no current non-PCAN FDV bound to fresh official v4 liquidity",
     );
     expect(workflow).toContain(
-      "primary.liquidity?.asOfTime !== valuation.asOfTime",
-    );
-    expect(workflow).toContain('!/^0x[0-9a-f]{64}$/.test(');
-    expect(workflow).toContain(
-      'token.marketData.primaryPoolId ?? ""',
+      'valuation.source !== "stateview-chainlink"',
     );
     expect(workflow).toContain(
-      "primary.identity?.poolId !== token.marketData.primaryPoolId",
+      'price?.source !== "uniswap-v4-stateview-chainlink-v1"',
     );
     expect(workflow).toContain(
-      'primary.identity?.protocol !== "uniswap_v4"',
+      'liquidity?.source !== "official-uniswap-v4-subgraph"',
     );
     expect(workflow).toContain(
-      "!positiveInteger(primary.liquidity?.valueUsdWad)",
+      "provenance?.subgraphId !== officialV4SubgraphId",
     );
     expect(workflow).toContain(
-      "!positiveInteger(primary.liquidity?.asOfBlock)",
+      "provenance?.deployment !== officialV4SubgraphDeployment",
     );
     expect(workflow).toContain(
-      "!currentMarketTime(primary.liquidity?.asOfTime)",
+      "BigInt(liquidity.tvlUsdWad) <",
     );
     expect(workflow).toContain(
-      "staged Bitquery current Explore and detail FDV are not identical",
+      'token.launchModel !== "classic"',
+    );
+    expect(workflow).toContain(
+      "staged current detail does not independently prove an equal or newer evidence bundle",
+    );
+    expect(workflow).toContain("price.activeVirtualToken0Wei");
+    expect(workflow).toContain(
+      '"stateview-active-liquidity-virtual-depth-usd"',
     );
     expect(workflow).toContain(
       'goldenValuation.metric !== "fdv"',
@@ -818,14 +824,14 @@ describe("read-model production deploy policy", () => {
       "staged PCAN chart is not a strictly ordered positive history",
     );
     const bitquerySmoke = workflow.slice(
-      workflow.indexOf("Smoke staged Bitquery market APIs"),
-      workflow.indexOf("Record registry identity and Bitquery market path"),
+      workflow.indexOf("Smoke staged public market APIs"),
+      workflow.indexOf("Record registry identity and combined market path"),
     );
     expect(bitquerySmoke).toContain(
       "/api/explore?limit=20&page=1&q=${goldenTokenAddress}&sort=market-cap",
     );
-    expect(bitquerySmoke.match(/bitqueryMarketContract/g)).toHaveLength(10);
-    expect(bitquerySmoke.match(/bitqueryChartContract/g)).toHaveLength(2);
+    expect(bitquerySmoke.match(/historicalBitqueryMarketContract/g)).toHaveLength(3);
+    expect(bitquerySmoke.match(/bitqueryChartContract/g)).toHaveLength(3);
     expect(bitquerySmoke).not.toContain("alchemyIdentityContract");
     expect(bitquerySmoke).not.toContain("/api/ops/health");
     expect(bitquerySmoke).not.toContain("/api/explore/profile");

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -798,7 +798,10 @@ describe("read-model production deploy policy", () => {
       "currentFdvCount < 1 && !historicalPaidPathVerified",
     );
     expect(workflow).toContain(
-      "goldenChart.asOfTime !== goldenChart.points.at(-1)?.time",
+      "goldenChart.asOfTime !== goldenChart.points.at(-1)?.observedAt",
+    );
+    expect(workflow).toContain(
+      'point?.valueSemantics !== "period-median"',
     );
     expect(workflow).toContain(
       "staged PCAN chart is not a strictly ordered positive history",

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -1129,12 +1129,24 @@ function publicFetch(
         points: [
           {
             blockNumber: "25730000",
-            time: earlierMarketTime,
+            time: goldenMarketAsOf,
+            bucketStart: earlierMarketTime,
+            bucketEnd: goldenMarketAsOf,
+            observedAt: earlierMarketTime,
+            valueSemantics: "period-median",
             priceUsd: "1900",
           },
           {
             blockNumber: "25731000",
-            time: goldenMarketAsOf,
+            time: new Date(
+              Date.parse(goldenMarketAsOf) + 60 * 60_000,
+            ).toISOString(),
+            bucketStart: goldenMarketAsOf,
+            bucketEnd: new Date(
+              Date.parse(goldenMarketAsOf) + 60 * 60_000,
+            ).toISOString(),
+            observedAt: goldenMarketAsOf,
+            valueSemantics: "period-median",
             priceUsd: "2000",
           },
         ],

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -6,9 +6,9 @@ import { encodeFunctionData, encodeFunctionResult, parseAbi } from "viem";
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
-import { evaluateReadModelOperationsSourceContracts } from "../../scripts/perf/read-model-ops-source-contracts.mjs";
+import { evaluateReadModelOperationsSourceContracts, POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS, POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS, POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS, STAGED_MARKET_EVIDENCE_SOURCE_GUARDS } from "../../scripts/perf/read-model-ops-source-contracts.mjs";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
-import { verifyPostPromotion } from "../../scripts/perf/read-model-post-promotion.mjs";
+import { exactCurrentPublicFdvLiquidity, verifyCurrentPublicOnchainEvidenceV1, verifyPostPromotion } from "../../scripts/perf/read-model-post-promotion.mjs";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import { resolveProductionBinding } from "../../scripts/perf/read-model-production-binding.mjs";
 
@@ -25,12 +25,106 @@ const GOLDEN_QUOTE_ADDRESS =
 const PUBLIC_TOKEN_ADDRESS =
   "0x1111111111111111111111111111111111111111";
 const PUBLIC_POOL_ID = `0x${"44".repeat(32)}`;
+const PUBLIC_HOOK_ADDRESS = "0x2222222222222222222222222222222222222222";
 const TEST_STATE_VIEW = "0x7fFE42C4a5DEeA5b0feC41C94C136Cf115597227";
+const TEST_STATE_VIEW_RUNTIME_CODE_HASH =
+  "0xd7947778589cf4aac9a092a4451292a2056380941635ab7006d3c691d8dfd878";
+const TEST_STATE_VIEW_RUNTIME_CODE =
+  "0x60806040526004361015610011575f80fd5b5f3560e01c80631c7ccb4c146108ac57806353e9c1fb146107c95780637c40"
+  + "f1fe146106ab5780638a2bb9e61461064657806397fd7b421461060b5780639ec538c8146105a2578063c815641c1461050b"
+  + "578063caedab54146103f6578063dacf1d2f146102ff578063dc4c90d314610291578063f0928f29146101e65763fa6793d5"
+  + "1461009d575f80fd5b346101a25760207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc36"
+  + "01126101a2576100d7600435610d2f565b600381018091116101b957604051907f1e2eaeaf00000000000000000000000000"
+  + "0000000000000000000000000000008252600482015260208160248173ffffffffffffffffffffffffffffffffffffffff7f"
+  + "000000000000000000000000000000000004444c5dc75cb358380d2e3de08a90165afa80156101ae575f90610177575b6020"
+  + "906fffffffffffffffffffffffffffffffff60405191168152f35b506020813d6020116101a6575b8161019160209383610a"
+  + "2b565b810103126101a2576020905161015a565b5f80fd5b3d9150610184565b6040513d5f823e3d90fd5b7f4e487b710000"
+  + "00000000000000000000000000000000000000000000000000005f52601160045260245ffd5b346101a2576101fd6101f736"
+  + "6109f7565b90610d8b565b604051907f1e2eaeaf000000000000000000000000000000000000000000000000000000008252"
+  + "600482015260208160248173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000"
+  + "04444c5dc75cb358380d2e3de08a90165afa80156101ae575f90610177576020906fffffffffffffffffffffffffffffffff"
+  + "60405191168152f35b346101a2575f7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc3601"
+  + "126101a257602060405173ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000004"
+  + "444c5dc75cb358380d2e3de08a90168152f35b346101a25760a07fffffffffffffffffffffffffffffffffffffffffffffff"
+  + "fffffffffffffffffc3601126101a25760243573ffffffffffffffffffffffffffffffffffffffff811681036101a2576103"
+  + "566109e7565b6064358060020b81036101a2576103f2926103c2926040519260843560268501526006840152600383015281"
+  + "525f603a600c83012091816040820152816020820152526004357f000000000000000000000000000000000004444c5dc75c"
+  + "b358380d2e3de08a90610bc0565b604080516fffffffffffffffffffffffffffffffff909416845260208401929092529082"
+  + "01529081906060820190565b0390f35b346101a25760407fffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  + "fffffffffffc3601126101a2576104386104306109d7565b600435610d55565b604051907f1e2eaeaf000000000000000000"
+  + "000000000000000000000000000000000000008252600482015260208160248173ffffffffffffffffffffffffffffffffff"
+  + "ffffff7f000000000000000000000000000000000004444c5dc75cb358380d2e3de08a90165afa80156101ae575f906104d8"
+  + "575b6040908151906fffffffffffffffffffffffffffffffff8116825260801d600f0b6020820152f35b506020813d602011"
+  + "610503575b816104f260209383610a2b565b810103126101a257604090516104b0565b3d91506104e5565b346101a2576020"
+  + "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc3601126101a257608062ffffff8061056d"
+  + "6004357f000000000000000000000000000000000004444c5dc75cb358380d2e3de08a90610c63565b92949173ffffffffff"
+  + "ffffffffffffffffffffffffffffff6040519616865260020b6020860152166040840152166060820152f35b346101a25760"
+  + "207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc3601126101a25760406105ff6004357f"
+  + "000000000000000000000000000000000004444c5dc75cb358380d2e3de08a90610c58565b82519182526020820152f35b34"
+  + "6101a2576103f26103c261061f366109f7565b907f000000000000000000000000000000000004444c5dc75cb358380d2e3d"
+  + "e08a90610bc0565b346101a25760407ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc3601"
+  + "126101a25760406105ff6106826109d7565b6004357f000000000000000000000000000000000004444c5dc75cb358380d2e"
+  + "3de08a90610b1e565b346101a25760407ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc36"
+  + "01126101a2576106e56104306109d7565b604051907f35fd631a000000000000000000000000000000000000000000000000"
+  + "0000000082526004820152600360248201525f8160448173ffffffffffffffffffffffffffffffffffffffff7f0000000000"
+  + "00000000000000000000000004444c5dc75cb358380d2e3de08a90165afa80156101ae576080915f916107a7575b50602081"
+  + "0151906060604082015191015190604051926fffffffffffffffffffffffffffffffff81168452841d600f0b602084015260"
+  + "408301526060820152f35b6107c391503d805f833e6107bb8183610a2b565b810190610a99565b82610766565b346101a257"
+  + "60607ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc3601126101a2576040600435610805"
+  + "6109d7565b9061080e6109e7565b7f000000000000000000000000000000000004444c5dc75cb358380d2e3de08a90906108"
+  + "3a8383610c58565b90610846868686610b1e565b96909361085f610857828989610b1e565b989097610c63565b5050905060"
+  + "020b9160020b82125f14610885575050505003910382519182526020820152f35b95969593949360020b1361089d57505003"
+  + "91036105ff565b949392909403039203036105ff565b346101a25760407fffffffffffffffffffffffffffffffffffffffff"
+  + "fffffffffffffffffffffffc3601126101a2576024358060010b8091036101a2576108f4600435610d2f565b600581018091"
+  + "116101b957604051906020820192835260408201526040815261091e606082610a2b565b519020604051907f1e2eaeaf0000"
+  + "00000000000000000000000000000000000000000000000000008252600482015260208160248173ffffffffffffffffffff"
+  + "ffffffffffffffffffff7f000000000000000000000000000000000004444c5dc75cb358380d2e3de08a90165afa80156101"
+  + "ae575f906109a4575b602090604051908152f35b506020813d6020116109cf575b816109be60209383610a2b565b81010312"
+  + "6101a25760209051610999565b3d91506109b1565b602435908160020b82036101a257565b604435908160020b82036101a2"
+  + "57565b7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc60409101126101a2576004359060"
+  + "243590565b90601f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0910116810190811067"
+  + "ffffffffffffffff821117610a6c57604052565b7f4e487b7100000000000000000000000000000000000000000000000000"
+  + "0000005f52604160045260245ffd5b6020818303126101a25780519067ffffffffffffffff82116101a257019080601f8301"
+  + "12156101a25781519167ffffffffffffffff8311610a6c578260051b9060405193610aea6020840186610a2b565b84526020"
+  + "808501928201019283116101a257602001905b828210610b0e5750505090565b8151815260209182019101610b01565b9291"
+  + "610b2991610d55565b600181018091116101b95773ffffffffffffffffffffffffffffffffffffffff9260445f9260405195"
+  + "869384927f35fd631a0000000000000000000000000000000000000000000000000000000084526004840152600260248401"
+  + "52165afa9182156101ae575f92610ba4575b506040602083015192015190565b610bb99192503d805f833e6107bb8183610a"
+  + "2b565b905f610b96565b6044610be273ffffffffffffffffffffffffffffffffffffffff945f94610d8b565b604051948593"
+  + "84927f35fd631a00000000000000000000000000000000000000000000000000000000845260048401526003602484015216"
+  + "5afa9081156101ae575f91610c3e575b506020810151916060604083015192015190565b610c5291503d805f833e6107bb81"
+  + "83610a2b565b5f610c2a565b9190610b2990610d2f565b6020906024610c8773ffffffffffffffffffffffffffffffffffff"
+  + "ffff9594610d2f565b60405195869384927f1e2eaeaf00000000000000000000000000000000000000000000000000000000"
+  + "84526004840152165afa9182156101ae575f92610cfb575b5073ffffffffffffffffffffffffffffffffffffffff82169180"
+  + "60a01c60020b9162ffffff808360b81c169260d01c1690565b9091506020813d602011610d27575b81610d1760209383610a"
+  + "2b565b810103126101a25751905f610cc8565b3d9150610d0a565b604051602081019182526006604082015260408152610d"
+  + "4f606082610a2b565b51902090565b610d5e90610d2f565b600481018091116101b95760405190602082019260020b835260"
+  + "4082015260408152610d4f606082610a2b565b610d9490610d2f565b600681018091116101b9576040519060208201928352"
+  + "604082015260408152610d4f606082610a2b56fea164736f6c634300081a000a";
 const TEST_ETH_USD_FEED = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
+const TEST_NATIVE_CURRENCY = "0x0000000000000000000000000000000000000000";
+const TEST_SUBGRAPH_ID =
+  "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G";
+const TEST_SUBGRAPH_DEPLOYMENT =
+  "QmZsgJLiLQKpb8hxTmQ5LWyrFVvfWzVaL4WK8dfFBn7EeK";
+const TEST_PUBLIC_BLOCK_HASH = `0x${"55".repeat(32)}`;
+const TEST_PUBLIC_INDEXED_BLOCK_HASH = `0x${"66".repeat(32)}`;
 const TEST_PARITY_BLOCK = 25_731_000n;
+const TEST_CURRENT_BLOCK = TEST_PARITY_BLOCK + 10n;
 const TEST_TOTAL_SUPPLY_RAW = 1_000n * 10n ** 18n;
 const TEST_PRICE_USD_WAD = 2_000n * 10n ** 18n;
 const TEST_FDV_USD_WAD = 2_000_000n * 10n ** 18n;
+const TEST_ACTIVE_LIQUIDITY = 3n * 10n ** 18n;
+const TEST_ACTIVE_VIRTUAL_LIQUIDITY_USD_WAD = 12_000n * 10n ** 18n;
+const stagedMarketEvidenceGuardCases: ReadonlyArray<readonly [number, string]> =
+  (STAGED_MARKET_EVIDENCE_SOURCE_GUARDS as readonly string[]).map(
+    (needle: string, index: number) => [index, needle] as const,
+  );
+const postPromotionGuardCases: ReadonlyArray<readonly [number, string]> = [
+  ...(POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS as readonly string[]),
+  ...(POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS as readonly string[]),
+  ...(POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS as readonly string[]),
+].map((needle: string, index: number) => [index, needle] as const);
 const testStateViewAbi = parseAbi([
   "function getSlot0(bytes32 poolId) view returns (uint160 sqrtPriceX96,int24 tick,uint24 protocolFee,uint24 lpFee)",
   "function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)",
@@ -305,10 +399,10 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("fails closed when the protected Bitquery staged smoke bypass is missing", () => {
+  it("fails closed when the protected market staged smoke bypass is missing", () => {
     const workflowPath = ".github/workflows/deploy-production.yml";
     const bitqueryStep =
-      "      - name: Smoke staged Bitquery market APIs\n" +
+      "      - name: Smoke staged public market APIs\n" +
       "        if: needs.release-gate.outputs.verified_read_model == 'true'\n" +
       "        env:\n" +
       "          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}\n" +
@@ -379,13 +473,12 @@ describe("read-model operations source contract", () => {
   });
 
   it.each([
-    ["positive liquidity", "!positiveInteger(primary.liquidity?.valueUsdWad)"],
-    ["liquidity block", "!positiveInteger(primary.liquidity?.asOfBlock)"],
-    ["Uniswap v4 protocol", 'primary.identity?.protocol !== "uniswap_v4"'],
-    [
-      "canonical primary pool identity",
-      "primary.identity?.poolId !== token.marketData.primaryPoolId",
-    ],
+    ["StateView price source", 'price?.source !== "uniswap-v4-stateview-chainlink-v1"'],
+    ["official liquidity source", 'liquidity?.source !== "official-uniswap-v4-subgraph"'],
+    ["official subgraph deployment", "provenance?.deployment !== officialV4SubgraphDeployment"],
+    ["minimum liquidity", "BigInt(liquidity.tvlUsdWad) <"],
+    ["exact reference head", "valuation.asOfBlock === provenance.referenceHeadBlockNumber"],
+    ["recomputed FDV", "expectedFdvUsdWad.toString() === valuation.valueWad"],
   ])("fails closed when staged release drops %s binding", (_label, needle) => {
     const workflowPath = ".github/workflows/deploy-production.yml";
     const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
@@ -403,6 +496,28 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it.each(stagedMarketEvidenceGuardCases)(
+    "mutation %i removes required staged market guard %s",
+    (_index, needle) => {
+      const workflowPath = ".github/workflows/deploy-production.yml";
+      const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+      expect(workflow).toContain(needle);
+      const unsafeWorkflow = workflow
+        .split(needle)
+        .join("MUTATED_RELEASE_GUARD");
+      const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+        sourceOverrides: {
+          ...integratedOverrides(),
+          [workflowPath]: unsafeWorkflow,
+        },
+        expectedSha256Overrides: fixtureDigests(),
+      });
+      expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+        "ops-protected-bitquery-stage-smoke",
+      );
+    },
+  );
+
   it("fails closed when post-promotion permits zero current public FDVs", () => {
     const postPromotionPath =
       "scripts/perf/read-model-post-promotion.mjs";
@@ -411,8 +526,8 @@ describe("read-model operations source contract", () => {
       "utf8",
     );
     const unsafePostPromotion = postPromotion.replace(
-      "  return currentCount > 0 &&",
-      "  return currentCount >= 0 &&",
+      "  return currentCount > 0 ? { currentToken, tokens } : null;",
+      "  return currentCount >= 0 ? { currentToken, tokens } : null;",
     );
     expect(unsafePostPromotion).not.toBe(postPromotion);
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
@@ -428,17 +543,12 @@ describe("read-model operations source contract", () => {
   });
 
   it.each([
-    ["positive liquidity", "positiveInteger(liquidity.valueUsdWad)"],
-    ["liquidity block", "positiveInteger(liquidity.asOfBlock)"],
-    ["Uniswap v4 protocol", 'primary.identity.protocol === "uniswap_v4"'],
-    [
-      "canonical primary pool identity",
-      "primary.identity.poolId === market.primaryPoolId",
-    ],
-    [
-      "valuation equality",
-      "poolValuation.valueUsdWad === valuation.valueWad",
-    ],
+    ["StateView price source", 'price?.source !== "uniswap-v4-stateview-chainlink-v1"'],
+    ["official liquidity source", 'liquidity?.source !== "official-uniswap-v4-subgraph"'],
+    ["official subgraph deployment", "provenance?.deployment !== OFFICIAL_V4_SUBGRAPH_DEPLOYMENT"],
+    ["minimum liquidity", "BigInt(liquidity.tvlUsdWad) < MINIMUM_PUBLIC_FDV_LIQUIDITY_USD_WAD"],
+    ["exact reference head", "valuation.asOfBlock === provenance.referenceHeadBlockNumber"],
+    ["recomputed FDV", "expectedFdvUsdWad.toString() === valuation.valueWad"],
   ])("fails closed when post-promotion drops %s binding", (_label, needle) => {
     const postPromotionPath =
       "scripts/perf/read-model-post-promotion.mjs";
@@ -459,6 +569,32 @@ describe("read-model operations source contract", () => {
       "ops-post-promotion-binding",
     );
   });
+
+  it.each(postPromotionGuardCases)(
+    "mutation %i removes required post-promotion guard %s",
+    (_index, needle) => {
+      const postPromotionPath =
+        "scripts/perf/read-model-post-promotion.mjs";
+      const postPromotion = readFileSync(
+        resolve(ROOT, postPromotionPath),
+        "utf8",
+      );
+      expect(postPromotion).toContain(needle);
+      const unsafePostPromotion = postPromotion
+        .split(needle)
+        .join("MUTATED_RELEASE_GUARD");
+      const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+        sourceOverrides: {
+          ...integratedOverrides(),
+          [postPromotionPath]: unsafePostPromotion,
+        },
+        expectedSha256Overrides: fixtureDigests(),
+      });
+      expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+        "ops-post-promotion-binding",
+      );
+    },
+  );
 
   it("fails closed when the historical PCAN gate widens the general stale ceiling", () => {
     const helperPath = "scripts/perf/bitquery-historical-release-gate.mjs";
@@ -543,16 +679,16 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("rejects a Bitquery staged smoke bypass relocated to another workflow step", () => {
+  it("rejects a public market staged smoke bypass relocated to another workflow step", () => {
     const workflowPath = ".github/workflows/deploy-production.yml";
     const secretLine =
       "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}\n";
     const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
     const bitqueryStepStart = workflow.indexOf(
-      "      - name: Smoke staged Bitquery market APIs",
+      "      - name: Smoke staged public market APIs",
     );
     const bitqueryStepEnd = workflow.indexOf(
-      "      - name: Record registry identity and Bitquery market path",
+      "      - name: Record registry identity and combined market path",
     );
     expect(bitqueryStepStart).toBeGreaterThanOrEqual(0);
     expect(bitqueryStepEnd).toBeGreaterThan(bitqueryStepStart);
@@ -565,8 +701,8 @@ describe("read-model operations source contract", () => {
       workflow
         .slice(bitqueryStepEnd)
         .replace(
-          "      - name: Record registry identity and Bitquery market path\n",
-          `      - name: Record registry identity and Bitquery market path\n        env:\n${secretLine}`,
+          "      - name: Record registry identity and combined market path\n",
+          `      - name: Record registry identity and combined market path\n        env:\n${secretLine}`,
         );
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: {
@@ -843,6 +979,287 @@ describe("read-model operations source contract", () => {
   });
 });
 
+function currentPublicTokenFixture(publicMarketAsOf: string) {
+  const blockTimestamp = String(
+    Math.floor(Date.parse(publicMarketAsOf) / 1_000),
+  );
+  const indexedBlockTimestamp = String(BigInt(blockTimestamp) - 12n);
+  const indexedBlockTime = new Date(
+    Number(BigInt(indexedBlockTimestamp)) * 1_000,
+  ).toISOString();
+  return {
+    id: `1:${PUBLIC_TOKEN_ADDRESS}`,
+    exploreKind: "token",
+    tokenAddress: PUBLIC_TOKEN_ADDRESS,
+    hookAddress: PUBLIC_HOOK_ADDRESS,
+    poolId: PUBLIC_POOL_ID,
+    launchModel: "classic",
+    liquidityPath: "meme",
+    totalSupplyRaw: TEST_TOTAL_SUPPLY_RAW.toString(),
+    tokenDecimals: 18,
+    fdvUsdWad: TEST_FDV_USD_WAD.toString(),
+    valuation: {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      currency: "usd",
+      source: "stateview-chainlink",
+      freshness: "current",
+      valueWad: TEST_FDV_USD_WAD.toString(),
+      asOfTime: publicMarketAsOf,
+      asOfBlock: TEST_CURRENT_BLOCK.toString(),
+      asOfBlockHash: TEST_PUBLIC_BLOCK_HASH,
+      lagBlocks: "0",
+      priceEvidence: {
+        schemaVersion: "programmable.stateview-chainlink-price-evidence.v1",
+        source: "uniswap-v4-stateview-chainlink-v1",
+        chainId: "1",
+        poolId: PUBLIC_POOL_ID,
+        tokenAddress: PUBLIC_TOKEN_ADDRESS,
+        quoteAddress: TEST_NATIVE_CURRENCY,
+        stateViewAddress: TEST_STATE_VIEW.toLowerCase(),
+        stateViewRuntimeCodeHash: TEST_STATE_VIEW_RUNTIME_CODE_HASH,
+        blockNumber: TEST_CURRENT_BLOCK.toString(),
+        blockHash: TEST_PUBLIC_BLOCK_HASH,
+        blockTimestamp,
+        blockTime: publicMarketAsOf,
+        sqrtPriceX96: (2n ** 96n).toString(),
+        activeLiquidity: TEST_ACTIVE_LIQUIDITY.toString(),
+        activeVirtualToken0Wei: TEST_ACTIVE_LIQUIDITY.toString(),
+        activeVirtualLiquidityUsdWad:
+          TEST_ACTIVE_VIRTUAL_LIQUIDITY_USD_WAD.toString(),
+        activeVirtualLiquidityValueBasis:
+          "stateview-active-liquidity-virtual-depth-usd",
+        tokenPriceEthWei: (10n ** 18n).toString(),
+        tokenPriceUsdWad: TEST_PRICE_USD_WAD.toString(),
+        totalSupplyRaw: TEST_TOTAL_SUPPLY_RAW.toString(),
+        tokenDecimals: 18,
+        fdvUsdWad: TEST_FDV_USD_WAD.toString(),
+        ethUsdQuote: {
+          feedAddress: TEST_ETH_USD_FEED.toLowerCase(),
+          roundId: "1",
+          answeredInRound: "1",
+          answer: "200000000000",
+          decimals: 8,
+          updatedAt: blockTimestamp,
+          updatedAtTime: publicMarketAsOf,
+        },
+      },
+    },
+    liquidityEvidence: {
+      source: "official-uniswap-v4-subgraph",
+      identity: {
+        chainId: "1",
+        protocol: "uniswap_v4",
+        poolId: PUBLIC_POOL_ID,
+        tokenAddress: PUBLIC_TOKEN_ADDRESS,
+        quoteAddress: TEST_NATIVE_CURRENCY,
+      },
+      valueBasis: "official-subgraph-pool-tvl-usd",
+      tvlUsdWad: (50_000n * 10n ** 18n).toString(),
+      reportedPoolBalances: {
+        token0: {
+          address: TEST_NATIVE_CURRENCY,
+          decimals: 18,
+          amountDecimal: "10",
+        },
+        token1: {
+          address: PUBLIC_TOKEN_ADDRESS,
+          decimals: 18,
+          amountDecimal: "100000",
+        },
+      },
+      freshness: "current",
+      provenance: {
+        subgraphId: TEST_SUBGRAPH_ID,
+        deployment: TEST_SUBGRAPH_DEPLOYMENT,
+        indexedBlockNumber: (TEST_CURRENT_BLOCK - 1n).toString(),
+        indexedBlockHash: TEST_PUBLIC_INDEXED_BLOCK_HASH,
+        indexedBlockTimestamp,
+        indexedBlockTime,
+        referenceHeadBlockNumber: TEST_CURRENT_BLOCK.toString(),
+        referenceHeadBlockHash: TEST_PUBLIC_BLOCK_HASH,
+        lagBlocks: "1",
+      },
+    },
+    marketData: {
+      schemaVersion: "programmable.market-data.v1",
+      source: "bitquery",
+      generatedAt: new Date().toISOString(),
+      status: "current",
+      primaryPoolId: PUBLIC_POOL_ID,
+      pools: [{
+        identity: {
+          chainId: "1",
+          tokenAddress: PUBLIC_TOKEN_ADDRESS,
+          poolId: PUBLIC_POOL_ID,
+          protocol: "uniswap_v4",
+        },
+        source: "bitquery",
+        status: "current",
+        quality: "complete",
+        asOfTime: publicMarketAsOf,
+        latestTrade: {
+          transactionHash: `0x${"77".repeat(32)}`,
+          logIndex: 1,
+          blockNumber: TEST_CURRENT_BLOCK.toString(),
+          time: publicMarketAsOf,
+          tokenSide: "buy",
+          priceUsdWad: TEST_PRICE_USD_WAD.toString(),
+        },
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+      }],
+    },
+  };
+}
+
+function currentExploreDataQuality(
+  publicMarketAsOf: string,
+  available = 1,
+  unavailable = 0,
+) {
+  return {
+    schemaVersion: "programmable.explore-data-quality.v1",
+    status: unavailable > 0 ? "partial" : "complete",
+    valuation: {
+      status: unavailable > 0 ? "partial" : "current",
+      metric: "fdv",
+      available,
+      unavailable,
+      stale: 0,
+      unknown: 0,
+      asOfTime: publicMarketAsOf,
+      asOfBlock: TEST_CURRENT_BLOCK.toString(),
+    },
+  };
+}
+
+function currentPublicHeaders(
+  publicMarketAsOf: string,
+  dataQuality = "complete",
+) {
+  return {
+    "X-Programmable-Data-Quality": dataQuality,
+    "X-Programmable-Market-As-Of": publicMarketAsOf,
+    "X-Programmable-Valuation-Block": TEST_CURRENT_BLOCK.toString(),
+    "X-Programmable-Market-Source":
+      "stateview-chainlink+official-uniswap-v4-subgraph+bitquery",
+    "X-Programmable-Price-Source": "stateview-chainlink",
+    "X-Programmable-Read-Source": "operational+durable+postgres",
+  };
+}
+
+function unavailablePublicTokenFixture(index: number) {
+  const address = `0x${index.toString(16).padStart(40, "0")}`;
+  return {
+    id: `1:${address}`,
+    exploreKind: "token",
+    tokenAddress: address,
+    valuation: { status: "unavailable", reason: "source-unavailable" },
+  };
+}
+
+function paginatedMarketCapFetch(
+  mode: "complete" | "hidden-current" | "missing-page" = "complete",
+) {
+  const base = publicFetch();
+  const publicMarketAsOf = new Date(
+    Math.floor((Date.now() - 2 * 60_000) / 1_000) * 1_000,
+  ).toISOString();
+  const publicToken = currentPublicTokenFixture(publicMarketAsOf);
+  const unavailable = Array.from(
+    { length: 100 },
+    (_, index) => unavailablePublicTokenFixture(index + 10),
+  );
+  const firstPageTokens = mode === "hidden-current"
+    ? unavailable
+    : [publicToken, ...unavailable.slice(0, 99)];
+  const secondPageToken = mode === "hidden-current"
+    ? publicToken
+    : unavailable[99];
+  return async (input: URL | RequestInfo, init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (
+      url.pathname !== "/api/explore" ||
+      url.searchParams.has("q")
+    ) return base(input, init);
+    const page = Number(url.searchParams.get("page") ?? "1");
+    if (page === 1) {
+      const hasCurrent = mode !== "hidden-current";
+      return Response.json({
+        status: "ready",
+        tokens: firstPageTokens,
+        page: 1,
+        pageSize: 100,
+        total: 101,
+        totalPages: 2,
+        sort: "market-cap",
+        dataQuality: hasCurrent
+          ? currentExploreDataQuality(publicMarketAsOf, 1, 99)
+          : {
+              schemaVersion: "programmable.explore-data-quality.v1",
+              status: "partial",
+              valuation: {
+                status: "unavailable",
+                metric: "fdv",
+                available: 0,
+                unavailable: 100,
+                stale: 0,
+                unknown: 0,
+                asOfTime: null,
+                asOfBlock: null,
+              },
+            },
+      }, {
+        headers: hasCurrent
+          ? currentPublicHeaders(publicMarketAsOf, "partial")
+          : {
+              "X-Programmable-Data-Quality": "partial",
+              "X-Programmable-Market-Source": "bitquery",
+              "X-Programmable-Read-Source":
+                "operational+durable+postgres",
+            },
+      });
+    }
+    const pageTokens = mode === "missing-page" ? [] : [secondPageToken];
+    const hasCurrent = mode === "hidden-current";
+    return Response.json({
+      status: "ready",
+      tokens: pageTokens,
+      page: 2,
+      pageSize: 100,
+      total: 101,
+      totalPages: 2,
+      sort: "market-cap",
+      dataQuality: hasCurrent
+        ? currentExploreDataQuality(publicMarketAsOf, 1, 0)
+        : {
+            schemaVersion: "programmable.explore-data-quality.v1",
+            status: "partial",
+            valuation: {
+              status: "unavailable",
+              metric: "fdv",
+              available: 0,
+              unavailable: pageTokens.length,
+              stale: 0,
+              unknown: 0,
+              asOfTime: null,
+              asOfBlock: null,
+            },
+          },
+    }, {
+      headers: hasCurrent
+        ? currentPublicHeaders(publicMarketAsOf)
+        : {
+            "X-Programmable-Data-Quality": "partial",
+            "X-Programmable-Market-Source": "bitquery",
+            "X-Programmable-Read-Source":
+              "operational+durable+postgres",
+          },
+    });
+  };
+}
+
 function publicFetch(
   healthStatus = "healthy",
   goldenMarketAgeMs = 60 * 60_000,
@@ -857,16 +1274,22 @@ function publicFetch(
   const earlierMarketTime = new Date(
     Date.parse(goldenMarketAsOf) - 60 * 60_000,
   ).toISOString();
+  const earlierPublicMarketTime = new Date(
+    Date.parse(publicMarketAsOf) - 60_000,
+  ).toISOString();
+  const earliestPublicMarketTime = new Date(
+    Date.parse(publicMarketAsOf) - 120_000,
+  ).toISOString();
+  const firstPublicObservedAt = new Date(
+    Date.parse(publicMarketAsOf) - 90_000,
+  ).toISOString();
+  const laterPublicBucketEnd = new Date(
+    Date.parse(publicMarketAsOf) + 60_000,
+  ).toISOString();
+  const publicToken = currentPublicTokenFixture(publicMarketAsOf);
 
   return async (input: URL | RequestInfo, init?: RequestInit) => {
     const url = new URL(String(input));
-    const publicBitqueryHeaders = {
-      "X-Programmable-Data-Quality": "complete",
-      "X-Programmable-Market-As-Of": publicMarketAsOf,
-      "X-Programmable-Market-Source": "bitquery",
-      "X-Programmable-Price-Source": "bitquery",
-      "X-Programmable-Read-Source": "operational+durable+postgres",
-    };
     if (url.hostname === "rpc-a.invalid" || url.hostname === "rpc-b.invalid") {
       const request = JSON.parse(String(init?.body ?? "{}")) as {
         id: number;
@@ -877,13 +1300,26 @@ function publicFetch(
       if (request.method === "eth_blockNumber") {
         result = `0x${(TEST_PARITY_BLOCK + 20n).toString(16)}`;
       } else if (request.method === "eth_getBlockByNumber") {
+        const requestedBlock = BigInt(String(request.params[0]));
+        const current = requestedBlock === TEST_CURRENT_BLOCK;
         result = {
-          number: `0x${TEST_PARITY_BLOCK.toString(16)}`,
-          hash: `0x${"11".repeat(32)}`,
-          timestamp: `0x${BigInt(Math.floor(Date.parse(goldenMarketAsOf) / 1_000)).toString(16)}`,
+          number: `0x${requestedBlock.toString(16)}`,
+          hash: current ? TEST_PUBLIC_BLOCK_HASH : `0x${"11".repeat(32)}`,
+          timestamp: `0x${BigInt(Math.floor(Date.parse(
+            current ? publicMarketAsOf : goldenMarketAsOf,
+          ) / 1_000)).toString(16)}`,
         };
+      } else if (request.method === "eth_getCode") {
+        result = TEST_STATE_VIEW_RUNTIME_CODE;
       } else if (request.method === "eth_call") {
         const call = request.params[0] as { to: string; data: string };
+        const blockTag = request.params[1] as
+          | string
+          | { blockHash?: string; requireCanonical?: boolean };
+        const current = typeof blockTag === "object"
+          ? blockTag.blockHash?.toLowerCase() === TEST_PUBLIC_BLOCK_HASH &&
+            blockTag.requireCanonical === true
+          : BigInt(blockTag) === TEST_CURRENT_BLOCK;
         const target = call.to.toLowerCase();
         if (target === TEST_STATE_VIEW.toLowerCase()) {
           const liquiditySelector = encodeFunctionData({
@@ -895,7 +1331,7 @@ function publicFetch(
             ? encodeFunctionResult({
                 abi: testStateViewAbi,
                 functionName: "getLiquidity",
-                result: 1_000_000n,
+                result: current ? TEST_ACTIVE_LIQUIDITY : 1_000_000n,
               })
             : encodeFunctionResult({
                 abi: testStateViewAbi,
@@ -903,7 +1339,8 @@ function publicFetch(
                 result: [2n ** 96n, 0, 0, 0],
               });
         } else if (
-          target === GOLDEN_TOKEN_ADDRESS &&
+          (target === GOLDEN_TOKEN_ADDRESS ||
+            target === PUBLIC_TOKEN_ADDRESS) &&
           call.data.startsWith("0x313ce567")
         ) {
           result = encodeFunctionResult({
@@ -912,7 +1349,8 @@ function publicFetch(
             result: 18,
           });
         } else if (
-          target === GOLDEN_TOKEN_ADDRESS &&
+          (target === GOLDEN_TOKEN_ADDRESS ||
+            target === PUBLIC_TOKEN_ADDRESS) &&
           call.data.startsWith("0x18160ddd")
         ) {
           result = encodeFunctionResult({
@@ -931,7 +1369,9 @@ function publicFetch(
           });
         } else {
           const timestamp = BigInt(
-            Math.floor(Date.parse(goldenMarketAsOf) / 1_000),
+            Math.floor(Date.parse(
+              current ? publicMarketAsOf : goldenMarketAsOf,
+            ) / 1_000),
           );
           result = encodeFunctionResult({
             abi: testFeedAbi,
@@ -987,62 +1427,23 @@ function publicFetch(
       }
       return Response.json({
         status: "ready",
-        tokens: [{
-          tokenAddress: PUBLIC_TOKEN_ADDRESS,
-          fdvUsdWad: TEST_FDV_USD_WAD.toString(),
-          valuation: {
-            status: "available",
-            metric: "fdv",
-            supplyBasis: "total",
-            currency: "usd",
-            source: "bitquery",
-            freshness: "current",
-            valueWad: TEST_FDV_USD_WAD.toString(),
-            asOfTime: publicMarketAsOf,
-          },
-          marketData: {
-            schemaVersion: "programmable.market-data.v1",
-            source: "bitquery",
-            generatedAt: new Date(fixtureNow).toISOString(),
-            status: "current",
-            primaryPoolId: PUBLIC_POOL_ID,
-            pools: [{
-              identity: {
-                chainId: "1",
-                tokenAddress: PUBLIC_TOKEN_ADDRESS,
-                poolId: PUBLIC_POOL_ID,
-                protocol: "uniswap_v4",
-              },
-              source: "bitquery",
-              status: "current",
-              quality: "complete",
-              asOfTime: publicMarketAsOf,
-              liquidity: {
-                asOfTime: publicMarketAsOf,
-                asOfBlock: TEST_PARITY_BLOCK.toString(),
-                valueUsdWad: (50_000n * 10n ** 18n).toString(),
-                freshness: "current",
-              },
-              valuation: {
-                status: "available",
-                metric: "fdv",
-                supplyBasis: "total",
-                valueUsdWad: TEST_FDV_USD_WAD.toString(),
-                fdvUsdWad: TEST_FDV_USD_WAD.toString(),
-                totalSupply: "1000",
-                asOfTime: publicMarketAsOf,
-                freshness: "current",
-              },
-            }],
-          },
-        }],
-        dataQuality: {
-          status: "complete",
-          valuation: { asOfTime: publicMarketAsOf },
-        },
-      }, { headers: publicBitqueryHeaders });
+        tokens: [publicToken],
+        page: 1,
+        pageSize: 100,
+        total: 1,
+        totalPages: 1,
+        sort: "market-cap",
+        dataQuality: currentExploreDataQuality(publicMarketAsOf),
+      }, { headers: currentPublicHeaders(publicMarketAsOf) });
     }
     if (url.pathname === "/api/explore/token") {
+      if (url.searchParams.get("address")?.toLowerCase() === PUBLIC_TOKEN_ADDRESS) {
+        return Response.json({
+          status: "ready",
+          token: publicToken,
+          dataQuality: currentExploreDataQuality(publicMarketAsOf),
+        }, { headers: currentPublicHeaders(publicMarketAsOf) });
+      }
       return Response.json({
         status: "ready",
         token: {
@@ -1114,6 +1515,63 @@ function publicFetch(
       });
     }
     if (url.pathname === "/api/explore/token/chart") {
+      if (url.searchParams.get("address")?.toLowerCase() === PUBLIC_TOKEN_ADDRESS) {
+        const range = url.searchParams.get("range") ?? "all";
+        return Response.json({
+          schemaVersion: "programmable.market-chart.v1",
+          source: "bitquery",
+          readStatus: "live",
+          status: "ready",
+          range,
+          generatedAt: new Date().toISOString(),
+          address: PUBLIC_TOKEN_ADDRESS,
+          identity: {
+            chainId: "1",
+            tokenAddress: PUBLIC_TOKEN_ADDRESS,
+            poolId: PUBLIC_POOL_ID,
+            quoteAddress: TEST_NATIVE_CURRENCY,
+            protocol: "uniswap_v4",
+          },
+          points: [
+            {
+              blockNumber: (TEST_CURRENT_BLOCK - 1n).toString(),
+              time: earlierPublicMarketTime,
+              bucketStart: earliestPublicMarketTime,
+              bucketEnd: earlierPublicMarketTime,
+              observedAt: firstPublicObservedAt,
+              valueSemantics: "period-median",
+              priceQuote: "0.95",
+              quoteSymbol: "ETH",
+              tradeCount: 1,
+            },
+            {
+              blockNumber: TEST_CURRENT_BLOCK.toString(),
+              time: laterPublicBucketEnd,
+              bucketStart: earlierPublicMarketTime,
+              bucketEnd: laterPublicBucketEnd,
+              observedAt: publicMarketAsOf,
+              valueSemantics: "period-median",
+              priceQuote: "1",
+              quoteSymbol: "ETH",
+              tradeCount: 1,
+            },
+          ],
+          swapCount: 2,
+          valuation: {
+            status: "unavailable",
+            reason: "source-unavailable",
+          },
+          asOfTime: publicMarketAsOf,
+          truncated: false,
+        }, {
+          headers: {
+            "X-Programmable-Data-Quality": "ready",
+            "X-Programmable-Market-As-Of": publicMarketAsOf,
+            "X-Programmable-Market-Source": "bitquery",
+            "X-Programmable-Price-Source": "bitquery",
+          },
+        });
+      }
       return Response.json({
         schemaVersion: "programmable.market-chart.v1",
         source: "bitquery",
@@ -1137,7 +1595,9 @@ function publicFetch(
             bucketEnd: goldenMarketAsOf,
             observedAt: earlierMarketTime,
             valueSemantics: "period-median",
-            priceUsd: "1900",
+            priceQuote: "0.95",
+            quoteSymbol: "ETH",
+            tradeCount: 1,
           },
           {
             blockNumber: "25731000",
@@ -1150,14 +1610,18 @@ function publicFetch(
             ).toISOString(),
             observedAt: goldenMarketAsOf,
             valueSemantics: "period-median",
-            priceUsd: "2000",
+            priceQuote: "1",
+            quoteSymbol: "ETH",
+            tradeCount: 1,
           },
         ],
+        swapCount: 2,
         valuation: {
           status: "unavailable",
           reason: "source-unavailable",
         },
         asOfTime: goldenMarketAsOf,
+        truncated: false,
       }, {
         headers: {
           "X-Programmable-Data-Quality": "ready",
@@ -1186,6 +1650,190 @@ function postPromotionInput(fetchImpl = publicFetch()) {
 }
 
 describe("post-promotion route verification", () => {
+  it("accepts the exact legacy and stamped Classic native/token branches", () => {
+    const asOfTime = new Date(
+      Math.floor((Date.now() - 2 * 60_000) / 1_000) * 1_000,
+    ).toISOString();
+    const legacy = currentPublicTokenFixture(asOfTime);
+    expect(exactCurrentPublicFdvLiquidity(legacy)).toBe(true);
+    const stamped = {
+      ...currentPublicTokenFixture(asOfTime),
+      hookAddress: PUBLIC_HOOK_ADDRESS.toUpperCase().replace("0X", "0x"),
+      liquidityPath: "programmable-v4",
+      launchStampProvenance: {
+        schemaVersion: "programmable.launch-stamp-provenance.v1",
+        kind: "classic",
+        chainId: 1,
+        poolId: PUBLIC_POOL_ID.toUpperCase().replace("0X", "0x"),
+        poolKey: {
+          currency0: TEST_NATIVE_CURRENCY,
+          currency1: PUBLIC_TOKEN_ADDRESS.toUpperCase().replace("0X", "0x"),
+          hooks: PUBLIC_HOOK_ADDRESS,
+        },
+      },
+    };
+    expect(exactCurrentPublicFdvLiquidity(stamped)).toBe(true);
+  });
+
+  it("rejects stale Chainlink rounds and nested Bitquery numeric FDVs", () => {
+    const asOfTime = new Date(
+      Math.floor((Date.now() - 2 * 60_000) / 1_000) * 1_000,
+    ).toISOString();
+    const staleRound = currentPublicTokenFixture(asOfTime);
+    staleRound.valuation.priceEvidence.ethUsdQuote.roundId = "2";
+    staleRound.valuation.priceEvidence.ethUsdQuote.answeredInRound = "1";
+    expect(exactCurrentPublicFdvLiquidity(staleRound)).toBe(false);
+
+    const nestedBitqueryFdv = currentPublicTokenFixture(asOfTime);
+    (nestedBitqueryFdv.marketData.pools[0] as { valuation: unknown }).valuation = {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      valueUsdWad: TEST_FDV_USD_WAD.toString(),
+      fdvUsdWad: TEST_FDV_USD_WAD.toString(),
+      totalSupply: "1000",
+      asOfTime,
+      freshness: "current",
+    };
+    expect(exactCurrentPublicFdvLiquidity(nestedBitqueryFdv)).toBe(false);
+
+    const deeplyNestedBitqueryFdv = currentPublicTokenFixture(asOfTime);
+    (deeplyNestedBitqueryFdv.marketData as Record<string, unknown>).future = {
+      extension: {
+        valuation: {
+          status: "available",
+          metric: "fdv",
+          valueUsdWad: TEST_FDV_USD_WAD.toString(),
+        },
+      },
+    };
+    expect(exactCurrentPublicFdvLiquidity(deeplyNestedBitqueryFdv)).toBe(false);
+  });
+
+  it("rejects stamped Custom Graph and mismatched Classic PoolKey evidence", () => {
+    const asOfTime = new Date(
+      Math.floor((Date.now() - 2 * 60_000) / 1_000) * 1_000,
+    ).toISOString();
+    const stamped = {
+      ...currentPublicTokenFixture(asOfTime),
+      hookAddress: PUBLIC_HOOK_ADDRESS,
+      liquidityPath: "programmable-v4",
+      launchStampProvenance: {
+        schemaVersion: "programmable.launch-stamp-provenance.v1",
+        kind: "classic",
+        chainId: 1,
+        poolId: PUBLIC_POOL_ID,
+        poolKey: {
+          currency0: TEST_NATIVE_CURRENCY,
+          currency1: PUBLIC_TOKEN_ADDRESS,
+          hooks: PUBLIC_HOOK_ADDRESS,
+        },
+      },
+    };
+    expect(exactCurrentPublicFdvLiquidity({
+      ...stamped,
+      launchModel: "custom-graph",
+      launchStampProvenance: {
+        ...stamped.launchStampProvenance,
+        kind: "custom-graph",
+      },
+    })).toBe(false);
+    expect(exactCurrentPublicFdvLiquidity({
+      ...stamped,
+      launchStampProvenance: {
+        ...stamped.launchStampProvenance,
+        poolKey: {
+          ...stamped.launchStampProvenance.poolKey,
+          currency0: PUBLIC_HOOK_ADDRESS,
+        },
+      },
+    })).toBe(false);
+  });
+
+  it("rejects divergent independent current block, runtime, StateView and Chainlink reads", async () => {
+    const base = publicFetch();
+    const asOfTime = new Date(
+      Math.floor((Date.now() - 2 * 60_000) / 1_000) * 1_000,
+    ).toISOString();
+    const token = currentPublicTokenFixture(asOfTime);
+    const mutations = ["runtime", "slot0", "liquidity", "feed", "block"] as const;
+    for (const mutation of mutations) {
+      const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+        const url = new URL(String(input));
+        if (url.hostname !== "rpc-b.invalid") return base(input, init);
+        const request = JSON.parse(String(init?.body ?? "{}")) as {
+          id: number;
+          method: string;
+          params: readonly unknown[];
+        };
+        if (mutation === "runtime" && request.method === "eth_getCode") {
+          return Response.json({ jsonrpc: "2.0", id: request.id, result: "0x6000" });
+        }
+        if (mutation === "block" && request.method === "eth_getBlockByNumber") {
+          const response = await base(input, init);
+          const body = await response.json();
+          body.result.hash = `0x${"99".repeat(32)}`;
+          return Response.json(body);
+        }
+        if (request.method === "eth_call") {
+          const call = request.params[0] as { to: string; data: string };
+          if (
+            mutation === "slot0" &&
+            call.to.toLowerCase() === TEST_STATE_VIEW.toLowerCase() &&
+            call.data.startsWith("0xc815641c")
+          ) {
+            return Response.json({
+              jsonrpc: "2.0",
+              id: request.id,
+              result: encodeFunctionResult({
+                abi: testStateViewAbi,
+                functionName: "getSlot0",
+                result: [2n ** 96n + 1n, 0, 0, 0],
+              }),
+            });
+          }
+          if (
+            mutation === "liquidity" &&
+            call.to.toLowerCase() === TEST_STATE_VIEW.toLowerCase() &&
+            !call.data.startsWith("0xc815641c")
+          ) {
+            return Response.json({
+              jsonrpc: "2.0",
+              id: request.id,
+              result: encodeFunctionResult({
+                abi: testStateViewAbi,
+                functionName: "getLiquidity",
+                result: TEST_ACTIVE_LIQUIDITY + 1n,
+              }),
+            });
+          }
+          if (
+            mutation === "feed" &&
+            call.to.toLowerCase() === TEST_ETH_USD_FEED.toLowerCase() &&
+            !call.data.startsWith("0x313ce567")
+          ) {
+            const timestamp = BigInt(Math.floor(Date.parse(asOfTime) / 1_000));
+            return Response.json({
+              jsonrpc: "2.0",
+              id: request.id,
+              result: encodeFunctionResult({
+                abi: testFeedAbi,
+                functionName: "latestRoundData",
+                result: [2n, 200_000_000_000n, timestamp, timestamp, 2n],
+              }),
+            });
+          }
+        }
+        return base(input, init);
+      };
+      await expect(verifyCurrentPublicOnchainEvidenceV1({
+        token,
+        fetchImpl,
+        rpcUrls: ["https://rpc-a.invalid", "https://rpc-b.invalid"],
+      })).rejects.toThrow();
+    }
+  });
+
   it("accepts a healthy public production surface", async () => {
     const result = await verifyPostPromotion(postPromotionInput());
     expect(result.ok).toBe(true);
@@ -1200,8 +1848,39 @@ describe("post-promotion route verification", () => {
       "production-bitquery-canary-hidden",
       "production-bitquery-detail",
       "production-bitquery-chart",
+      "production-current-public-detail",
+      "production-current-public-bitquery-charts",
+      "production-current-public-independent-onchain-proof",
       "production-bitquery-golden-independent-parity",
     ]);
+  });
+
+  it("accepts complete stable market-cap coverage across every page", async () => {
+    const result = await verifyPostPromotion(
+      postPromotionInput(paginatedMarketCapFetch()),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("rejects a higher current FDV hidden after unavailable page-one entries", async () => {
+    const result = await verifyPostPromotion(
+      postPromotionInput(paginatedMarketCapFetch("hidden-current")),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-explore" }),
+    );
+  });
+
+  it("rejects a missing page from the declared global ranking", async () => {
+    const result = await verifyPostPromotion(
+      postPromotionInput(paginatedMarketCapFetch("missing-page")),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-explore" }),
+    );
   });
 
   it("rejects zero current public FDVs even when exact PCAN history passes", async () => {
@@ -1241,7 +1920,7 @@ describe("post-promotion route verification", () => {
         url.searchParams.has("q")
       ) return response;
       const body = await response.json();
-      body.tokens[0].marketData.pools[0].liquidity.valueUsdWad = "0";
+      body.tokens[0].liquidityEvidence.tvlUsdWad = "0";
       return Response.json(body, { headers: response.headers });
     };
     const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
@@ -1261,8 +1940,10 @@ describe("post-promotion route verification", () => {
         url.searchParams.has("q")
       ) return response;
       const body = await response.json();
-      body.tokens[0].marketData.pools[0].liquidity.asOfTime = new Date(
-        Date.parse(body.tokens[0].valuation.asOfTime) - 1_000,
+      body.tokens[0].liquidityEvidence.provenance.indexedBlockTime = new Date(
+        Date.parse(
+          body.tokens[0].liquidityEvidence.provenance.indexedBlockTime,
+        ) - 1_000,
       ).toISOString();
       return Response.json(body, { headers: response.headers });
     };
@@ -1577,8 +2258,6 @@ describe("post-promotion route verification", () => {
       body.tokens[0].valuation.freshness = "current";
       body.tokens[0].valuation.asOfTime = tooOld;
       body.tokens[0].fdvUsdWad = body.tokens[0].valuation.valueWad;
-      body.tokens[0].marketData.pools[0].liquidity.asOfTime = tooOld;
-      body.tokens[0].marketData.pools[0].valuation.asOfTime = tooOld;
       body.dataQuality.valuation.asOfTime = tooOld;
       const headers = new Headers(response.headers);
       headers.set("X-Programmable-Market-As-Of", tooOld);

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -20,6 +20,8 @@ const GOLDEN_TOKEN_ADDRESS =
   "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
 const GOLDEN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const GOLDEN_QUOTE_ADDRESS =
+  "0x0000000000000000000000000000000000000000";
 const PUBLIC_TOKEN_ADDRESS =
   "0x1111111111111111111111111111111111111111";
 const PUBLIC_POOL_ID = `0x${"44".repeat(32)}`;
@@ -1124,6 +1126,7 @@ function publicFetch(
           chainId: "1",
           tokenAddress: GOLDEN_TOKEN_ADDRESS,
           poolId: GOLDEN_POOL_ID,
+          quoteAddress: GOLDEN_QUOTE_ADDRESS,
           protocol: "uniswap_v4",
         },
         points: [
@@ -1151,13 +1154,8 @@ function publicFetch(
           },
         ],
         valuation: {
-          status: "available",
-          metric: "fdv",
-          supplyBasis: "total",
-          freshness: "stale",
-          valueUsdWad: TEST_FDV_USD_WAD.toString(),
-          fdvUsdWad: TEST_FDV_USD_WAD.toString(),
-          asOfTime: goldenMarketAsOf,
+          status: "unavailable",
+          reason: "source-unavailable",
         },
         asOfTime: goldenMarketAsOf,
       }, {
@@ -1516,6 +1514,24 @@ describe("post-promotion route verification", () => {
       if (url.pathname !== "/api/explore/token/chart") return response;
       const body = await response.json();
       body.readStatus = "cache-fallback";
+      return Response.json(body, { headers: response.headers });
+    };
+    const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "production-bitquery-chart" }),
+    );
+  });
+
+  it("rejects a chart whose quote identity is not canonical native ETH", async () => {
+    const base = publicFetch();
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const response = await base(input, init);
+      if (url.pathname !== "/api/explore/token/chart") return response;
+      const body = await response.json();
+      body.identity.quoteAddress =
+        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
       return Response.json(body, { headers: response.headers });
     };
     const result = await verifyPostPromotion(postPromotionInput(fetchImpl));

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -23,6 +23,8 @@ const mocks = vi.hoisted(() => ({
   readDurableExploreModel: vi.fn(),
   readBitqueryTokenMarketDataV1: vi.fn(),
   hydrateMissingCanonicalTokenSupplyV1: vi.fn(),
+  valueExploreEntriesWithCurrentEvidence: vi.fn(),
+  settleCurrentEvidenceSnapshot: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
 }));
 
@@ -73,6 +75,18 @@ vi.mock("../lib/market-data/canonical-token-supply.server", () => ({
   hydrateMissingCanonicalTokenSupplyV1:
     mocks.hydrateMissingCanonicalTokenSupplyV1,
 }));
+
+vi.mock("../lib/market-data/current-valuation.server", () => ({
+  CURRENT_EVIDENCE_ROUTE_DEADLINE_MS: 4_500,
+  settleCurrentEvidenceSnapshot: mocks.settleCurrentEvidenceSnapshot,
+  valueExploreEntriesWithCurrentEvidence:
+    mocks.valueExploreEntriesWithCurrentEvidence,
+}));
+
+import {
+  valuationSortValue,
+  withBitqueryMarketData,
+} from "../lib/explore-financial-data";
 
 import {
   dedupeExploreEntriesV1,
@@ -247,6 +261,9 @@ describe("Explore API Bitquery market boundary", () => {
       rpcUrlSecondary: "https://secondary.example",
     });
     mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(snapshot);
+    mocks.settleCurrentEvidenceSnapshot.mockImplementation(
+      async ({ read }: { read: Promise<unknown> }) => await read,
+    );
     mocks.withSameBlockEthUsdQuote.mockImplementation(
       async ({ snapshot: value }) => value,
     );
@@ -259,6 +276,28 @@ describe("Explore API Bitquery market boundary", () => {
     );
     mocks.hydrateMissingCanonicalTokenSupplyV1.mockImplementation(
       async (entries: readonly ExploreEntry[]) => [...entries],
+    );
+    mocks.valueExploreEntriesWithCurrentEvidence.mockImplementation(
+      async ({ entries, marketByToken }: {
+        entries: readonly ExploreEntry[];
+        marketByToken: Promise<ReadonlyMap<string, TokenMarketDataV1>>;
+      }) => {
+        const markets = await marketByToken;
+        return entries.map((entry) => {
+          const market = entry.tokenAddress
+            ? markets.get(entry.tokenAddress.toLowerCase())
+            : undefined;
+          return market
+            ? withBitqueryMarketData(entry, market)
+            : {
+                ...entry,
+                valuation: {
+                  status: "unavailable" as const,
+                  reason: "source-unavailable" as const,
+                },
+              };
+        });
+      },
     );
   });
 
@@ -307,7 +346,6 @@ describe("Explore API Bitquery market boundary", () => {
         query: "",
         socials: null,
         sort,
-        topThenNewest: false,
       }).tokens.map(({ id }) => id);
 
     const newest = [
@@ -376,7 +414,6 @@ describe("Explore API Bitquery market boundary", () => {
           query: "",
           socials: null,
           sort: "newest",
-          topThenNewest: false,
         }).tokens.map(({ id }) => id),
       ).toEqual(expected);
     }
@@ -443,7 +480,6 @@ describe("Explore API Bitquery market boundary", () => {
         query: "",
         socials: null,
         sort,
-        topThenNewest: false,
       }).tokens.map(({ id }) => id);
 
     expect(paginate("market-cap")).toEqual([
@@ -460,6 +496,41 @@ describe("Explore API Bitquery market boundary", () => {
       "1:eth",
       "1:quote",
     ]);
+  });
+
+  it("keeps explicit market-cap pagination globally monotonic beyond 20 entries", () => {
+    const entries = Array.from({ length: 25 }, (_, index) => ({
+      ...orderedEntry({
+        id: `1:global-${index}`,
+        kind: "token",
+        block: String(1_000 + index),
+        transaction: 0,
+        log: 0,
+      }),
+      valuation: {
+        status: "available" as const,
+        metric: "fdv" as const,
+        supplyBasis: "total" as const,
+        currency: "usd" as const,
+        valueWad: String((index * 17) % 25 + 1),
+        freshness: "current" as const,
+        source: "stateview-chainlink" as const,
+      },
+    }));
+    const pages = [1, 2, 3].flatMap((page) =>
+      paginateExploreEntriesV1(entries, {
+        page,
+        pageSize: 10,
+        query: "",
+        socials: null,
+        sort: "market-cap",
+      }).tokens,
+    );
+    const values = pages.map((entry) => valuationSortValue(entry)!);
+
+    expect(new Set(pages.map(({ id }) => id)).size).toBe(25);
+    expect(values).toEqual([...values].sort((left, right) =>
+      left === right ? 0 : left > right ? -1 : 1));
   });
 
   it("deduplicates exact canonical records but fails closed on conflicts", () => {
@@ -590,9 +661,7 @@ describe("Explore API Bitquery market boundary", () => {
       source: "bitquery",
       asOfTime: MARKET_OBSERVATION_TIME,
     });
-    expect(body.tokens[0].fdvUsdWad).toBe(
-      body.tokens[0].valuation.valueWad,
-    );
+    expect(body.tokens[0]).not.toHaveProperty("fdvUsdWad");
     for (const field of [
       "marketCapEth",
       "marketCapEthWei",
@@ -687,7 +756,7 @@ describe("Explore API Bitquery market boundary", () => {
     expect(response.status).toBe(200);
     expect(body.dataQuality).toMatchObject({
       status: "stale",
-      valuation: { status: "stale", stale: 30 },
+      valuation: { status: "stale", stale: 9 },
     });
     expect(response.headers.get("X-Programmable-Data-Quality")).toBe("stale");
     expect(response.headers.get("Cache-Control")).toBe(

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -278,9 +278,16 @@ describe("Explore API Bitquery market boundary", () => {
       async (entries: readonly ExploreEntry[]) => [...entries],
     );
     mocks.valueExploreEntriesWithCurrentEvidence.mockImplementation(
-      async ({ entries, marketByToken }: {
+      async ({
+        entries,
+        marketByToken,
+        maximumValuationAgeMs,
+        now,
+      }: {
         entries: readonly ExploreEntry[];
         marketByToken: Promise<ReadonlyMap<string, TokenMarketDataV1>>;
+        maximumValuationAgeMs?: number;
+        now?: Date;
       }) => {
         const markets = await marketByToken;
         return entries.map((entry) => {
@@ -288,7 +295,10 @@ describe("Explore API Bitquery market boundary", () => {
             ? markets.get(entry.tokenAddress.toLowerCase())
             : undefined;
           return market
-            ? withBitqueryMarketData(entry, market)
+            ? withBitqueryMarketData(entry, market, {
+                maximumValuationAgeMs,
+                now,
+              })
             : {
                 ...entry,
                 valuation: {
@@ -958,6 +968,7 @@ describe("Explore API Bitquery market boundary", () => {
       chainId: "1",
       tokenAddress: target.tokenAddress,
       poolId: target.poolId,
+      quoteAddress: "0x0000000000000000000000000000000000000000",
       protocol: "uniswap_v4",
     });
   });

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { canonicalTokenExploreEntryV1 } from "../lib/explore-entry-v1";
 import {
+  EXPLORE_MAXIMUM_STALE_VALUATION_AGE_MS,
   buildExploreDataQuality,
   exploreValuation,
   publicExploreEntryV1,
@@ -10,7 +11,6 @@ import {
   withBitqueryMarketData,
   withCurrentOnchainValuation,
   withExploreValuation,
-  withPublicExploreBitqueryMarketData,
 } from "../lib/explore-financial-data";
 import type { OfficialV4LiquidityEvidenceV1 } from
   "../lib/onchain/uniswap-v4-subgraph";
@@ -505,10 +505,13 @@ describe("Explore financial-data semantics", () => {
     expect(valuationSortValue(entry)).toBeNull();
     expect(publicExploreEntryV1(entry)).not.toHaveProperty("fdvUsdWad");
 
-    const publicEntry = withPublicExploreBitqueryMarketData(
+    const publicEntry = withBitqueryMarketData(
       canonicalTokenExploreEntryV1(goldenToken()),
       marketData,
-      Date.parse(marketData.generatedAt),
+      {
+        maximumValuationAgeMs: EXPLORE_MAXIMUM_STALE_VALUATION_AGE_MS,
+        now: new Date(marketData.generatedAt),
+      },
     );
     expect(publicEntry.valuation).toEqual({
       status: "unavailable",

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -91,6 +91,7 @@ function currentEvidenceFixture(
       ethUsdQuote: {
         feedAddress: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
         roundId: "1",
+        answeredInRound: "1",
         answer: "250000000000",
         decimals: 8,
         updatedAt: blockTimestamp,
@@ -217,6 +218,36 @@ describe("Explore financial-data semantics", () => {
       status: "unavailable",
       reason: "source-unavailable",
     });
+  });
+
+  it("rejects incomplete or non-canonical Chainlink provenance", () => {
+    const { valued, liquidityEvidence } = currentEvidenceFixture();
+    const price = valued.liveMarketPriceEvidence!;
+    const incompleteRound = {
+      ...valued,
+      liveMarketPriceEvidence: {
+        ...price,
+        ethUsdQuote: {
+          ...price.ethUsdQuote,
+          answeredInRound: "0",
+        },
+      },
+    };
+    const wrongFeed = {
+      ...valued,
+      liveMarketPriceEvidence: {
+        ...price,
+        ethUsdQuote: {
+          ...price.ethUsdQuote,
+          feedAddress: "0x1111111111111111111111111111111111111111" as const,
+        },
+      },
+    };
+
+    expect(withCurrentOnchainValuation(incompleteRound, liquidityEvidence)
+      .valuation).toEqual(valued.valuation);
+    expect(withCurrentOnchainValuation(wrongFeed, liquidityEvidence).valuation)
+      .toEqual(valued.valuation);
   });
 
   it("promotes a canonical Router-stamped Classic native/token pool", () => {

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -8,12 +8,17 @@ import {
   valuationSortValue,
   type ValuedExploreEntry,
   withBitqueryMarketData,
+  withCurrentOnchainValuation,
   withExploreValuation,
   withPublicExploreBitqueryMarketData,
 } from "../lib/explore-financial-data";
+import type { OfficialV4LiquidityEvidenceV1 } from
+  "../lib/onchain/uniswap-v4-subgraph";
 import type { TokenMarketDataV1 } from
   "../lib/market-data/market-data-v1";
 import type { LauncherToken } from "../lib/tokens";
+import { stampedClassicExploreEntry } from
+  "./launch-stamp-surface-fixture";
 
 const TOKEN_ADDRESS =
   "0x79870000000000000000000000000000000024ee" as const;
@@ -40,7 +45,230 @@ function goldenToken(
   };
 }
 
+function currentEvidenceFixture(
+  activeLiquidity = 2_000_000_000_000_000_000n,
+) {
+  const blockTimestamp = Math.floor(Date.now() / 1_000).toString();
+  const blockTime = new Date(Number(blockTimestamp) * 1_000).toISOString();
+  const tokenPriceUsdWad = "2500000000000000000000";
+  const fdvUsdWad = "2500000000000000000000000000000";
+  const activeVirtualToken0Wei = activeLiquidity.toString();
+  const activeVirtualLiquidityUsdWad =
+    (activeLiquidity * 2n * 2_500n).toString();
+  const token = canonicalTokenExploreEntryV1(goldenToken({
+    launchModel: "classic",
+    totalSupplyRaw: "1000000000000000000000000000",
+    tokenDecimals: 18,
+    activeLiquidity: activeLiquidity.toString(),
+    tokenPriceEthWei: "1000000000000000000",
+    tokenPriceUsdWad,
+    fdvUsdWad,
+    indexedValuationBlockNumber: "25750000",
+    liveMarketPriceEvidence: {
+      schemaVersion: "programmable.stateview-chainlink-price-evidence.v1",
+      source: "uniswap-v4-stateview-chainlink-v1",
+      chainId: "1",
+      poolId: `0x${"33".repeat(32)}`,
+      tokenAddress: TOKEN_ADDRESS,
+      quoteAddress: "0x0000000000000000000000000000000000000000",
+      stateViewAddress: "0x7fFE42C4a5DEeA5b0feC41C94C136Cf115597227",
+      stateViewRuntimeCodeHash: `0x${"44".repeat(32)}`,
+      blockNumber: "25750000",
+      blockHash: `0x${"55".repeat(32)}`,
+      blockTimestamp,
+      blockTime,
+      sqrtPriceX96: (1n << 96n).toString(),
+      activeLiquidity: activeLiquidity.toString(),
+      activeVirtualToken0Wei,
+      activeVirtualLiquidityUsdWad,
+      activeVirtualLiquidityValueBasis:
+        "stateview-active-liquidity-virtual-depth-usd",
+      tokenPriceEthWei: "1000000000000000000",
+      tokenPriceUsdWad,
+      totalSupplyRaw: "1000000000000000000000000000",
+      tokenDecimals: 18,
+      fdvUsdWad,
+      ethUsdQuote: {
+        feedAddress: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+        roundId: "1",
+        answer: "250000000000",
+        decimals: 8,
+        updatedAt: blockTimestamp,
+        updatedAtTime: blockTime,
+      },
+    },
+  }));
+  const liquidityEvidence = {
+    source: "official-uniswap-v4-subgraph",
+    identity: {
+      chainId: "1",
+      protocol: "uniswap_v4",
+      poolId: token.poolId,
+      tokenAddress: token.tokenAddress,
+      quoteAddress: "0x0000000000000000000000000000000000000000",
+    },
+    valueBasis: "official-subgraph-pool-tvl-usd",
+    tvlUsdWad: "10000000000000000000000",
+    reportedPoolBalances: {
+      token0: {
+        address: "0x0000000000000000000000000000000000000000",
+        decimals: 18,
+        amountDecimal: "2",
+      },
+      token1: {
+        address: TOKEN_ADDRESS,
+        decimals: 18,
+        amountDecimal: "4000000",
+      },
+    },
+    freshness: "current",
+    provenance: {
+      subgraphId: "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G",
+      deployment: "QmZsgJLiLQKpb8hxTmQ5LWyrFVvfWzVaL4WK8dfFBn7EeK",
+      indexedBlockNumber: "25749999",
+      indexedBlockHash: `0x${"66".repeat(32)}`,
+      indexedBlockTimestamp: blockTimestamp,
+      indexedBlockTime: blockTime,
+      referenceHeadBlockNumber: "25750000",
+      referenceHeadBlockHash: `0x${"55".repeat(32)}`,
+      lagBlocks: "1",
+    },
+  } satisfies OfficialV4LiquidityEvidenceV1;
+  const valued = {
+    ...token,
+    valuation: { status: "unavailable", reason: "source-unavailable" },
+  } satisfies ValuedExploreEntry<typeof token>;
+  return { valued, liquidityEvidence };
+}
+
 describe("Explore financial-data semantics", () => {
+  it("promotes trade-independent current FDV only at the dual liquidity threshold", () => {
+    const { valued, liquidityEvidence } = currentEvidenceFixture();
+    const current = withCurrentOnchainValuation(valued, liquidityEvidence);
+
+    expect(current).not.toHaveProperty("marketData");
+    expect(current.valuation).toMatchObject({
+      status: "available",
+      source: "stateview-chainlink",
+      valueWad: "2500000000000000000000000000000",
+      asOfBlock: "25750000",
+      asOfBlockHash: `0x${"55".repeat(32)}`,
+      priceEvidence: {
+        activeVirtualLiquidityUsdWad: "10000000000000000000000",
+        activeVirtualLiquidityValueBasis:
+          "stateview-active-liquidity-virtual-depth-usd",
+      },
+    });
+    expect(publicExploreEntryV1(current)).toMatchObject({
+      fdvUsdWad: "2500000000000000000000000000000",
+      tokenPriceUsdWad: "2500000000000000000000",
+    });
+  });
+
+  it("rejects inactive-TVL plus dust active virtual depth below the threshold", () => {
+    const { valued, liquidityEvidence } = currentEvidenceFixture(
+      1_999_999_999_999_999_999n,
+    );
+    const rejected = withCurrentOnchainValuation(
+      valued,
+      { ...liquidityEvidence, tvlUsdWad: "999999999999999999999999999" },
+    );
+
+    expect(rejected.valuation).toEqual({
+      status: "unavailable",
+      reason: "source-unavailable",
+    });
+    expect(publicExploreEntryV1(rejected)).not.toHaveProperty("fdvUsdWad");
+  });
+
+  it("rejects non-native currency0 orientation even with matching pool TVL", () => {
+    const { valued, liquidityEvidence } = currentEvidenceFixture();
+    const rejected = withCurrentOnchainValuation(valued, {
+      ...liquidityEvidence,
+      reportedPoolBalances: {
+        ...liquidityEvidence.reportedPoolBalances,
+        token0: {
+          ...liquidityEvidence.reportedPoolBalances.token0,
+          address: TOKEN_ADDRESS,
+        },
+      },
+    });
+
+    expect(rejected.valuation).toEqual({
+      status: "unavailable",
+      reason: "source-unavailable",
+    });
+  });
+
+  it("rejects mismatched official pool decimals", () => {
+    const { valued, liquidityEvidence } = currentEvidenceFixture();
+    const rejected = withCurrentOnchainValuation(valued, {
+      ...liquidityEvidence,
+      reportedPoolBalances: {
+        ...liquidityEvidence.reportedPoolBalances,
+        token1: {
+          ...liquidityEvidence.reportedPoolBalances.token1,
+          decimals: 17,
+        },
+      },
+    });
+
+    expect(rejected.valuation).toEqual({
+      status: "unavailable",
+      reason: "source-unavailable",
+    });
+  });
+
+  it("promotes a canonical Router-stamped Classic native/token pool", () => {
+    const { valued, liquidityEvidence } = currentEvidenceFixture();
+    const price = valued.liveMarketPriceEvidence!;
+    const stamped = {
+      ...stampedClassicExploreEntry,
+      totalSupplyRaw: valued.totalSupplyRaw!,
+      tokenDecimals: 18,
+      indexedValuationBlockNumber: valued.indexedValuationBlockNumber!,
+      tokenPriceUsdWad: valued.tokenPriceUsdWad!,
+      fdvUsdWad: valued.fdvUsdWad!,
+      liveMarketPriceEvidence: {
+        ...price,
+        poolId: stampedClassicExploreEntry.poolId,
+        tokenAddress: stampedClassicExploreEntry.tokenAddress,
+      },
+      valuation: valued.valuation,
+    } as unknown as ValuedExploreEntry<typeof stampedClassicExploreEntry>;
+    const stampedLiquidity = {
+      ...liquidityEvidence,
+      identity: {
+        ...liquidityEvidence.identity,
+        poolId: stamped.poolId,
+        tokenAddress: stamped.tokenAddress,
+      },
+      reportedPoolBalances: {
+        ...liquidityEvidence.reportedPoolBalances,
+        token1: {
+          ...liquidityEvidence.reportedPoolBalances.token1,
+          address: stamped.tokenAddress,
+        },
+      },
+    } satisfies OfficialV4LiquidityEvidenceV1;
+
+    expect(withCurrentOnchainValuation(stamped, stampedLiquidity).valuation)
+      .toMatchObject({ status: "available", source: "stateview-chainlink" });
+
+    const malformed = {
+      ...stamped,
+      launchStampProvenance: {
+        ...stamped.launchStampProvenance,
+        poolKey: {
+          ...stamped.launchStampProvenance.poolKey,
+          currency0: stamped.tokenAddress,
+          currency1: "0xffffffffffffffffffffffffffffffffffffffff",
+        },
+      },
+    } as unknown as typeof stamped;
+    expect(withCurrentOnchainValuation(malformed, stampedLiquidity).valuation)
+      .toEqual(valued.valuation);
+  });
   it("labels a positive-liquidity total-supply valuation only as FDV", () => {
     expect(
       exploreValuation(goldenToken(), { referenceBlock: "25725569" }),

--- a/tests/onchain-config.test.ts
+++ b/tests/onchain-config.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { rpcProviderCommitment } from
+  "../lib/data-pipeline/rpc-provider-commitments";
 import {
   getOnchainDeployment,
   getOperationalOnchainDeployment,
@@ -7,6 +9,24 @@ import {
   getWebsiteChartOnchainDeployment,
   getWebsiteReadOnchainDeployment,
 } from "../lib/onchain/config";
+
+const ALCHEMY_RPC_URL =
+  "https://eth-mainnet.g.alchemy.com/v2/alchemy-test-key";
+const QUICKNODE_RPC_URL =
+  "https://programmable-mainnet.quiknode.pro/quicknode-test-key/";
+
+function stubWebsiteRpcBindings() {
+  vi.stubEnv("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL", ALCHEMY_RPC_URL);
+  vi.stubEnv("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL", QUICKNODE_RPC_URL);
+  vi.stubEnv(
+    "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT",
+    rpcProviderCommitment("endpoint", ALCHEMY_RPC_URL),
+  );
+  vi.stubEnv(
+    "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+    rpcProviderCommitment("endpoint", QUICKNODE_RPC_URL),
+  );
+}
 
 describe("onchain deployment manifest boundary", () => {
   afterEach(() => {
@@ -94,22 +114,23 @@ describe("onchain deployment manifest boundary", () => {
     });
   });
 
-  it("uses the fixed independent Website read quorum without changing the operational bindings", () => {
+  it("uses the commitment-bound Alchemy and QuickNode Website pair without changing the operational bindings", () => {
     vi.stubEnv("ETHEREUM_RPC_URL", "https://operational-primary.example");
     vi.stubEnv(
       "ETHEREUM_RPC_URL_B",
       "https://operational-secondary.example",
     );
+    stubWebsiteRpcBindings();
 
     expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
       status: "ready",
-      rpcUrl: "https://ethereum-rpc.publicnode.com",
-      rpcUrlSecondary: "https://eth.drpc.org",
+      rpcUrl: ALCHEMY_RPC_URL,
+      rpcUrlSecondary: QUICKNODE_RPC_URL,
     });
     expect(getWebsiteChartOnchainDeployment("production")).toMatchObject({
       status: "ready",
-      rpcUrl: "https://ethereum-rpc.publicnode.com",
-      rpcUrlSecondary: "https://rpc.mevblocker.io",
+      rpcUrl: ALCHEMY_RPC_URL,
+      rpcUrlSecondary: QUICKNODE_RPC_URL,
     });
     expect(getOperationalOnchainDeployment("production")).toMatchObject({
       rpcUrl: "https://operational-primary.example",
@@ -120,6 +141,7 @@ describe("onchain deployment manifest boundary", () => {
   it("rejects production operations without an independent RPC", () => {
     vi.stubEnv("ETHEREUM_RPC_URL", "https://rpc-a.example");
     vi.stubEnv("ETHEREUM_RPC_URL_B", "https://rpc-a.example");
+    stubWebsiteRpcBindings();
 
     expect(() =>
       getOperationalOnchainDeployment("production"),
@@ -128,12 +150,12 @@ describe("onchain deployment manifest boundary", () => {
     );
     expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
       status: "ready",
-      rpcUrl: "https://ethereum-rpc.publicnode.com",
-      rpcUrlSecondary: "https://eth.drpc.org",
+      rpcUrl: ALCHEMY_RPC_URL,
+      rpcUrlSecondary: QUICKNODE_RPC_URL,
     });
   });
 
-  it("rejects an implicit public fallback for production operations", () => {
+  it("rejects an implicit public fallback for production operations and Website reads", () => {
     vi.stubEnv("ETHEREUM_RPC_URL", "");
     vi.stubEnv("ETHEREUM_RPC_URL_B", "https://rpc-b.example");
     vi.stubEnv("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL", "");
@@ -144,11 +166,65 @@ describe("onchain deployment manifest boundary", () => {
     ).toThrow(
       "Production operations require two distinct authenticated RPC URLs",
     );
+    expect(() =>
+      getWebsiteReadOnchainDeployment("production"),
+    ).toThrow("Website Alchemy RPC binding is unavailable");
+  });
+
+  it("accepts only the bounded legacy aliases when they match both provider commitments", () => {
+    vi.stubEnv("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL", "");
+    vi.stubEnv("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL", "");
+    vi.stubEnv("ETHEREUM_RPC_URL", ALCHEMY_RPC_URL);
+    vi.stubEnv("ETHEREUM_RPC_URL_B", QUICKNODE_RPC_URL);
+    vi.stubEnv(
+      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT",
+      rpcProviderCommitment("endpoint", ALCHEMY_RPC_URL),
+    );
+    vi.stubEnv(
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+      rpcProviderCommitment("endpoint", QUICKNODE_RPC_URL),
+    );
+
     expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
-      status: "ready",
-      rpcUrl: "https://ethereum-rpc.publicnode.com",
-      rpcUrlSecondary: "https://eth.drpc.org",
+      rpcUrl: ALCHEMY_RPC_URL,
+      rpcUrlSecondary: QUICKNODE_RPC_URL,
     });
+  });
+
+  it("does not bypass an invalid provider-specific binding with a valid legacy alias", () => {
+    stubWebsiteRpcBindings();
+    vi.stubEnv("ETHEREUM_RPC_URL", ALCHEMY_RPC_URL);
+    vi.stubEnv(
+      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+      "https://ethereum-rpc.publicnode.com",
+    );
+
+    expect(() =>
+      getWebsiteReadOnchainDeployment("production"),
+    ).toThrow("Website Alchemy RPC binding is invalid");
+  });
+
+  it("fails closed on a mismatched commitment without retaining endpoint secrets", () => {
+    stubWebsiteRpcBindings();
+    vi.stubEnv(
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+      `0x${"ab".repeat(32)}`,
+    );
+
+    const error = (() => {
+      try {
+        getWebsiteReadOnchainDeployment("production");
+      } catch (candidate) {
+        return candidate;
+      }
+      return null;
+    })();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      "Website RPC endpoint commitment mismatch",
+    );
+    expect(JSON.stringify(error)).not.toContain("alchemy-test-key");
+    expect(JSON.stringify(error)).not.toContain("quicknode-test-key");
   });
 
   it("keeps public reads fail-closed when the dual-RPC environment is absent", () => {

--- a/tests/onchain-explore-read-source.test.ts
+++ b/tests/onchain-explore-read-source.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { HttpRequestError } from "viem";
 
 import { resolveExploreReadSource } from "../lib/onchain/explore-read-source";
 import type {
@@ -129,5 +130,40 @@ describe("Explore read source", () => {
     expect(result).toBe(liveModel);
     expect(readLive).not.toHaveBeenCalled();
     expect(enrichWithUsd).toHaveBeenCalledWith(liveModel, config);
+  });
+
+  it("does not retain authenticated RPC details when USD enrichment fails", async () => {
+    const error = vi.fn();
+    const sentinel = "FAKE_SECRET_SENTINEL";
+    const enrichWithUsd = vi.fn().mockRejectedValue(
+      new HttpRequestError({
+        status: 503,
+        url: `https://eth-mainnet.g.alchemy.com/v2/${sentinel}`,
+        body: { method: "eth_call", params: [] },
+      }),
+    );
+
+    const result = await resolveExploreReadSource(config, {
+      readDurable: vi.fn().mockResolvedValue({
+        status: "ready",
+        envelope: {} as never,
+        ageMs: 1_000,
+      }),
+      selectFreshDurable: vi.fn().mockReturnValue(liveModel),
+      readLive: vi.fn(),
+      enrichWithUsd,
+      warn: vi.fn(),
+      error,
+    });
+
+    expect(result).toBe(liveModel);
+    expect(error).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith("ETH/USD enrichment failed", {
+      name: "HttpRequestError",
+    });
+    const serialized = JSON.stringify(error.mock.calls);
+    expect(serialized).not.toContain(sentinel);
+    expect(serialized).not.toContain("eth-mainnet.g.alchemy.com");
+    expect(serialized).not.toContain("eth_call");
   });
 });

--- a/tests/onchain-usd.test.ts
+++ b/tests/onchain-usd.test.ts
@@ -53,10 +53,14 @@ describe("ETH/USD display enrichment", () => {
       actualBlockHash: `0x${"11".repeat(32)}` as `0x${string}`,
       blockTimestamp: 10_000n,
       roundId: 2n,
+      answeredInRound: 2n,
       answer: 3_500_00000000n,
       updatedAt: 9_000n,
     };
     expect(() => assertValidEthUsdSnapshot(valid)).not.toThrow();
+    expect(() =>
+      assertValidEthUsdSnapshot({ ...valid, answeredInRound: 1n }),
+    ).toThrow("invalid or stale");
     expect(() =>
       assertValidEthUsdSnapshot({ ...valid, updatedAt: 10_001n }),
     ).toThrow("invalid or stale");

--- a/tests/operational-rpc-failover.test.ts
+++ b/tests/operational-rpc-failover.test.ts
@@ -9,6 +9,7 @@ vi.mock("server-only", () => ({}));
 
 import {
   isOperationalRpcFailoverEligible,
+  OperationalRpcReadError,
   OperationalRpcUnavailableError,
   safeOperationalRpcError,
   withOperationalRpcFailover,
@@ -41,11 +42,15 @@ function httpFailure(status: number | undefined, url = deployment.rpcUrl) {
   });
 }
 
-function rpcFailure(message: string, code = -32_000) {
+function rpcFailure(
+  message: string,
+  code = -32_000,
+  url = deployment.rpcUrl,
+) {
   return new RpcRequestError({
     body: { method: "eth_blockNumber" },
     error: { code, message },
-    url: deployment.rpcUrl,
+    url,
   });
 }
 
@@ -124,12 +129,48 @@ describe("operational RPC failover", () => {
     ]);
   });
 
+  it("uses the fixed secondary after dRPC reports code 12 routing unavailability", async () => {
+    const calls: string[] = [];
+    const read = vi.fn(async (candidate: ReadyOnchainDeployment) => {
+      calls.push(candidate.rpcUrl);
+      if (candidate.rpcUrl === deployment.rpcUrl) {
+        throw rpcFailure(
+          "Can't route your request to suitable provider, if you specified certain providers revise the list",
+          12,
+        );
+      }
+      return "secondary-ready";
+    });
+
+    await expect(
+      withOperationalRpcFailover(deployment, read),
+    ).resolves.toBe("secondary-ready");
+    expect(calls).toEqual([
+      deployment.rpcUrl,
+      deployment.rpcUrlSecondary,
+    ]);
+  });
+
   it.each([
     httpFailure(400),
     rpcFailure("execution reverted"),
     rpcFailure("Invalid parameters were provided", -32602),
-    new Error("Pool identity mismatch"),
-  ])("does not rotate providers for a non-transport read error", async (error) => {
+  ])("redacts a non-failover RPC error without rotating providers", async (error) => {
+    const read = vi.fn(async () => {
+      throw error;
+    });
+
+    const received = await withOperationalRpcFailover(deployment, read).catch(
+      (candidate) => candidate,
+    );
+    expect(received).toBeInstanceOf(OperationalRpcReadError);
+    expect(JSON.stringify(received)).not.toContain("primary.example");
+    expect(JSON.stringify(received)).not.toContain("eth_blockNumber");
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a provider-independent integrity error without rotating", async () => {
+    const error = new Error("Pool identity mismatch");
     const read = vi.fn(async () => {
       throw error;
     });
@@ -155,6 +196,25 @@ describe("operational RPC failover", () => {
     await expect(promise).rejects.toThrow(
       "Operational RPC reads are temporarily unavailable",
     );
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it("redacts a code 12 routing failure from the fixed secondary", async () => {
+    const read = vi.fn(async (candidate: ReadyOnchainDeployment) => {
+      throw rpcFailure(
+        "Can't route your request to suitable provider, if you specified certain providers revise the list",
+        12,
+        candidate.rpcUrl,
+      );
+    });
+
+    const error = await withOperationalRpcFailover(deployment, read).catch(
+      (candidate) => candidate,
+    );
+    expect(error).toBeInstanceOf(OperationalRpcUnavailableError);
+    expect(JSON.stringify(error)).not.toContain("primary.example");
+    expect(JSON.stringify(error)).not.toContain("secondary.example");
+    expect(JSON.stringify(error)).not.toContain("eth_blockNumber");
     expect(read).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -151,16 +151,22 @@ function chart(
       {
         blockNumber: "25740001",
         time: "2026-08-11T14:01:00.000Z",
+        bucketStart: "2026-08-11T14:00:00.000Z",
+        bucketEnd: "2026-08-11T14:01:00.000Z",
+        observedAt: "2026-08-11T14:00:59.000Z",
+        valueSemantics: "period-median",
         priceUsd: "1.5",
-        ohlcUsd: { open: "1.4", high: "1.6", low: "1.3", close: "1.5" },
         volumeUsdWad: "150000000000000000000",
         tradeCount: 3,
       },
       {
         blockNumber: "25740002",
         time: "2026-08-11T14:02:00.000Z",
+        bucketStart: "2026-08-11T14:01:00.000Z",
+        bucketEnd: "2026-08-11T14:02:00.000Z",
+        observedAt: "2026-08-11T14:01:59.000Z",
+        valueSemantics: "period-median",
         priceUsd: "2",
-        ohlcUsd: { open: "1.5", high: "2.1", low: "1.5", close: "2" },
         volumeUsdWad: "250000000000000000000",
         tradeCount: 4,
       },
@@ -177,7 +183,7 @@ function chart(
       asOfTime: "2026-08-11T14:02:00.000Z",
       freshness: "current",
     },
-    asOfTime: "2026-08-11T14:02:00.000Z",
+    asOfTime: "2026-08-11T14:01:59.000Z",
     truncated: false,
     ...overrides,
   };
@@ -229,6 +235,7 @@ describe("token chart Bitquery API", () => {
       expect.objectContaining({
         identity,
         range: "1h",
+        historyStart: token.launchedAt,
         valuation: { status: "unavailable", reason: "source-unavailable" },
         signal: expect.any(AbortSignal),
       }),
@@ -258,6 +265,10 @@ describe("token chart Bitquery API", () => {
       points: [{
         blockNumber: "25740002",
         time: "2026-08-11T14:02:00.000Z",
+        bucketStart: "2026-08-11T14:01:00.000Z",
+        bucketEnd: "2026-08-11T14:02:00.000Z",
+        observedAt: "2026-08-11T14:01:59.000Z",
+        valueSemantics: "period-median",
         priceUsd: "2",
         tradeCount: 1,
       }],
@@ -513,7 +524,10 @@ describe("token chart Bitquery API", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledWith(
-      expect.objectContaining({ identity: customIdentity }),
+      expect.objectContaining({
+        identity: customIdentity,
+        historyStart: customGraphToken.launchedAt,
+      }),
     );
   });
 

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import type {
+  MarketChartIdentityV1,
   MarketChartV1,
   MarketDataIdentityV1,
   TokenMarketDataV1,
@@ -73,9 +74,10 @@ const token = {
 const identity = {
   chainId: "1",
   tokenAddress: token.tokenAddress,
+  quoteAddress: "0x0000000000000000000000000000000000000000",
   poolId: token.poolId,
   protocol: "uniswap_v4",
-} as const satisfies MarketDataIdentityV1;
+} as const satisfies MarketChartIdentityV1;
 
 const snapshot = {
   chainId: 1,
@@ -137,7 +139,7 @@ function tokenMarketData(
 
 function chart(
   overrides: Partial<MarketChartV1> = {},
-  marketIdentity: MarketDataIdentityV1 = identity,
+  marketIdentity: MarketChartIdentityV1 = identity,
 ): MarketChartV1 {
   return {
     schemaVersion: "programmable.market-chart.v1",
@@ -174,14 +176,8 @@ function chart(
     swapCount: 7,
     volumeUsdWad: "400000000000000000000",
     valuation: {
-      status: "available",
-      metric: "fdv",
-      supplyBasis: "total",
-      valueUsdWad: "2000000000000000000000000",
-      fdvUsdWad: "2000000000000000000000000",
-      totalSupply: "1000000",
-      asOfTime: "2026-08-11T14:02:00.000Z",
-      freshness: "current",
+      status: "unavailable",
+      reason: "source-unavailable",
     },
     asOfTime: "2026-08-11T14:01:59.000Z",
     truncated: false,
@@ -227,16 +223,12 @@ describe("token chart Bitquery API", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledWith(
-      [identity],
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
-    );
+    expect(mocks.readBitqueryTokenMarketDataV1).not.toHaveBeenCalled();
     expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledWith(
       expect.objectContaining({
         identity,
         range: "1h",
         historyStart: token.launchedAt,
-        valuation: { status: "unavailable", reason: "source-unavailable" },
         signal: expect.any(AbortSignal),
       }),
     );
@@ -245,13 +237,14 @@ describe("token chart Bitquery API", () => {
       source: "bitquery",
       status: "ready",
       address: token.tokenAddress,
-      fdvUsdWad: "2000000000000000000000000",
-      valuationMetric: "fdv",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
       points: [
         { priceUsd: "1.5", tradeCount: 3 },
         { priceUsd: "2", tradeCount: 4 },
       ],
     });
+    expect(body).not.toHaveProperty("fdvUsdWad");
+    expect(body).not.toHaveProperty("valuationMetric");
     expect(response.headers.get("X-Programmable-Market-Source")).toBe("bitquery");
     expect(response.headers.get("X-Programmable-Price-Source")).toBe("bitquery");
     expect(response.headers.get("Cache-Control")).toBe(
@@ -285,13 +278,9 @@ describe("token chart Bitquery API", () => {
     );
   });
 
-  it("starts a single-pool chart without waiting for market enrichment", async () => {
-    let resolveMarket: ((value: ReadonlyMap<string, TokenMarketDataV1>) => void)
-      | undefined;
-    mocks.readBitqueryTokenMarketDataV1.mockReturnValue(new Promise((resolve) => {
-      resolveMarket = resolve;
-    }));
-    mocks.readBitqueryMarketChartV1.mockResolvedValue(chart({
+  it("does not let single-pool chart reads own current valuation", async () => {
+    mocks.readBitqueryMarketChartV1.mockResolvedValue({
+      ...chart(),
       valuation: {
         status: "available",
         metric: "fdv",
@@ -302,46 +291,29 @@ describe("token chart Bitquery API", () => {
         asOfTime: "2026-08-11T14:02:00.000Z",
         freshness: "current",
       },
-    }));
+    } as unknown as MarketChartV1);
 
-    const responsePromise = GET(new NextRequest(
+    const response = await GET(new NextRequest(
       `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
     ));
-    await vi.waitFor(() => {
-      expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledTimes(1);
-    });
-    expect(resolveMarket).toBeTypeOf("function");
-    resolveMarket?.(new Map([[token.tokenAddress, tokenMarketData()]]));
-    const response = await responsePromise;
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.valuation).toMatchObject({
-      status: "available",
-      fdvUsdWad: "2000000000000000000000000",
+    expect(mocks.readBitqueryTokenMarketDataV1).not.toHaveBeenCalled();
+    expect(body.valuation).toEqual({
+      status: "unavailable",
+      reason: "source-unavailable",
     });
-    expect(body.fdvUsdWad).toBe("2000000000000000000000000");
+    expect(body).not.toHaveProperty("fdvUsdWad");
+    expect(body).not.toHaveProperty("valuationMetric");
   });
 
-  it("starts a single-pool chart without waiting for supply hydration", async () => {
-    let resolveSupply: ((value: readonly typeof token[]) => void) | undefined;
-    mocks.hydrateMissingCanonicalTokenSupplyV1.mockReturnValue(
-      new Promise((resolve) => {
-        resolveSupply = resolve;
-      }),
-    );
-
-    const responsePromise = GET(new NextRequest(
+  it("does not hydrate supply for a history-only chart", async () => {
+    const response = await GET(new NextRequest(
       `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
     ));
-    await vi.waitFor(() => {
-      expect(mocks.readBitqueryMarketChartV1).toHaveBeenCalledTimes(1);
-      expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledTimes(1);
-    });
-    expect(resolveSupply).toBeTypeOf("function");
-    resolveSupply?.([token]);
-
-    expect((await responsePromise).status).toBe(200);
+    expect(response.status).toBe(200);
+    expect(mocks.hydrateMissingCanonicalTokenSupplyV1).not.toHaveBeenCalled();
   });
 
   it("uses a verified durable identity when the primary identity source fails", async () => {
@@ -429,7 +401,7 @@ describe("token chart Bitquery API", () => {
       status: "waiting-for-first-trade",
       points: [],
       swapCount: 0,
-      valuation: { reason: "waiting-for-first-trade" },
+      valuation: { status: "unavailable", reason: "source-unavailable" },
     });
     expect(body).not.toHaveProperty("fdvUsdWad");
     expect(response.headers.get("X-Programmable-Price-Source")).toBeNull();
@@ -462,7 +434,8 @@ describe("token chart Bitquery API", () => {
   });
 
   it("does not relabel a chart cache fallback with a current market valuation", async () => {
-    mocks.readBitqueryMarketChartV1.mockResolvedValue(chart({
+    mocks.readBitqueryMarketChartV1.mockResolvedValue({
+      ...chart(),
       readStatus: "cache-fallback",
       status: "partial",
       valuation: {
@@ -475,7 +448,7 @@ describe("token chart Bitquery API", () => {
         asOfTime: "2026-08-11T13:00:00.000Z",
         freshness: "stale",
       },
-    }));
+    } as unknown as MarketChartV1);
 
     const response = await GET(new NextRequest(
       `http://localhost/api/explore/token/chart?address=${token.tokenAddress}`,
@@ -487,21 +460,21 @@ describe("token chart Bitquery API", () => {
     expect(body).toMatchObject({
       readStatus: "cache-fallback",
       status: "partial",
-      valuation: {
-        fdvUsdWad: "1500000000000000000000000",
-        freshness: "stale",
-      },
-      fdvUsdWad: "1500000000000000000000000",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
     });
+    expect(body).not.toHaveProperty("fdvUsdWad");
   });
 
   it("supports a Router-stamped Custom v4 pool", async () => {
     const customIdentity = {
       chainId: "1",
       tokenAddress: customGraphToken.tokenAddress.toLowerCase() as `0x${string}`,
+      quoteAddress:
+        customGraphToken.launchStampProvenance.poolKey.currency0.toLowerCase() as
+          `0x${string}`,
       poolId: customGraphToken.poolId,
       protocol: "uniswap_v4",
-    } as const satisfies MarketDataIdentityV1;
+    } as const satisfies MarketChartIdentityV1;
     mocks.readAlchemyExploreModel.mockResolvedValue({
       status: "ready",
       tokens: [customGraphToken],

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -274,6 +274,7 @@ describe("token detail Bitquery market read", () => {
           chainId: "1",
           tokenAddress: TOKEN_ADDRESS,
           poolId: POOL_ID,
+          quoteAddress: "0x0000000000000000000000000000000000000000",
           protocol: "uniswap_v4",
         },
       ],

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -8,7 +8,7 @@ import type {
   MarketDataIdentityV1,
   TokenMarketDataV1,
 } from "../lib/market-data/market-data-v1";
-import type { LauncherToken } from "../lib/tokens";
+import type { ExploreEntry, LauncherToken } from "../lib/tokens";
 import { customGraphToken } from "./launch-stamp-surface-fixture";
 
 const mocks = vi.hoisted(() => ({
@@ -23,6 +23,8 @@ const mocks = vi.hoisted(() => ({
   readDurableExploreModel: vi.fn(),
   readBitqueryTokenMarketDataV1: vi.fn(),
   hydrateMissingCanonicalTokenSupplyV1: vi.fn(),
+  valueExploreEntriesWithCurrentEvidence: vi.fn(),
+  settleCurrentEvidenceSnapshot: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
 }));
 
@@ -73,6 +75,15 @@ vi.mock("../lib/market-data/canonical-token-supply.server", () => ({
   hydrateMissingCanonicalTokenSupplyV1:
     mocks.hydrateMissingCanonicalTokenSupplyV1,
 }));
+
+vi.mock("../lib/market-data/current-valuation.server", () => ({
+  CURRENT_EVIDENCE_ROUTE_DEADLINE_MS: 4_500,
+  settleCurrentEvidenceSnapshot: mocks.settleCurrentEvidenceSnapshot,
+  valueExploreEntriesWithCurrentEvidence:
+    mocks.valueExploreEntriesWithCurrentEvidence,
+}));
+
+import { withBitqueryMarketData } from "../lib/explore-financial-data";
 
 import { GET } from "../app/api/explore/token/route";
 
@@ -179,6 +190,9 @@ describe("token detail Bitquery market read", () => {
     mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(
       launchDiscoverySnapshot,
     );
+    mocks.settleCurrentEvidenceSnapshot.mockImplementation(
+      async ({ read }: { read: Promise<unknown> }) => await read,
+    );
     mocks.withSameBlockEthUsdQuote.mockImplementation(
       async ({ snapshot: value }) => value,
     );
@@ -197,6 +211,28 @@ describe("token detail Bitquery market read", () => {
     );
     mocks.hydrateMissingCanonicalTokenSupplyV1.mockImplementation(
       async (entries: readonly unknown[]) => [...entries],
+    );
+    mocks.valueExploreEntriesWithCurrentEvidence.mockImplementation(
+      async ({ entries, marketByToken }: {
+        entries: readonly ExploreEntry[];
+        marketByToken: Promise<ReadonlyMap<string, TokenMarketDataV1>>;
+      }) => {
+        const markets = await marketByToken;
+        return entries.map((entry) => {
+          const market = entry.tokenAddress
+            ? markets.get(entry.tokenAddress.toLowerCase())
+            : undefined;
+          return market
+            ? withBitqueryMarketData(entry, market)
+            : {
+                ...entry,
+                valuation: {
+                  status: "unavailable" as const,
+                  reason: "source-unavailable" as const,
+                },
+              };
+        });
+      },
     );
   });
 
@@ -248,7 +284,6 @@ describe("token detail Bitquery market read", () => {
       name: canonical.name,
       symbol: canonical.symbol,
       tokenAddress: canonical.tokenAddress,
-      fdvUsdWad: "1250000000000000000000000",
       valuation: {
         status: "available",
         metric: "fdv",
@@ -371,7 +406,6 @@ describe("token detail Bitquery market read", () => {
     expect(mocks.withSameBlockEthUsdQuote).not.toHaveBeenCalled();
     expect(mocks.enrichTokensWithAlchemyPoolState).not.toHaveBeenCalled();
     expect(body.token).toMatchObject({
-      fdvUsdWad: "2334305942998987256000000",
       valuation: {
         status: "available",
         freshness: "current",

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -35,7 +35,7 @@ describe("token detail layout", () => {
     );
   });
 
-  it("announces the exact inspected chart point without duplicating the visual tooltip", () => {
+  it("announces the inspected chart value without duplicating the visual tooltip", () => {
     const activeValueIdIndex = chartSource.indexOf("id={activeValueId}");
     const liveRegion = chartSource.slice(
       chartSource.lastIndexOf("<span", activeValueIdIndex),
@@ -65,7 +65,9 @@ describe("token detail layout", () => {
     expect(chartSource).toContain("aria-busy={loading}");
     expect(chartSource).toContain('role="status"');
     expect(chartSource).toContain("{chartStatus}");
-    expect(chartSource).toContain('"Current price loaded from 1 point"');
+    expect(chartSource).toContain('"One period median loaded"');
+    expect(chartSource).toContain('point.valueSemantics === "period-median"');
+    expect(chartSource).not.toContain("inspect exact prices");
     expect(chartSource).not.toContain("payload.points.length < 2");
     expect(chartSource).toContain("tabIndex={0}");
     expect(chartSource).toMatch(

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -151,7 +151,7 @@ describe("token detail layout", () => {
     expect(detailSource).not.toMatch(/<h2>\s*Trade \$/i);
   });
 
-  it("uses only typed chart FDV while labeling total-supply value as FDV", () => {
+  it("keeps canonical detail valuation independent from chart history", () => {
     expect(detailSource).toContain(
       'const currentLabel = isMarketCap ? "Market cap" : "FDV";',
     );
@@ -164,6 +164,18 @@ describe("token detail layout", () => {
     expect(chartSource).not.toContain("payload.marketCap");
     expect(chartSource).not.toContain("payload.fdvUsdWad ?? fdvUsdWad");
     expect(chartSource).not.toMatch(/marketCap(?:Eth|Usd)\w*\?: string/);
+    expect(detailSource).not.toContain("chartFdv");
+    expect(detailSource).not.toContain("setChartFdv");
+    expect(detailSource).not.toContain("onFdvChange");
+    expect(chartSource).not.toContain("onFdvChange");
+    expect(chartSource).not.toContain("getChartFdvAtPoint");
+    expect(chartSource).not.toContain("function withoutChartFdv");
+    expect(chartSource).not.toContain("fdvUsdWad?: string");
+    expect(chartSource).not.toContain("valuationMetric?:");
+    expect(chartSource).toContain('"fdvUsdWad" in value');
+    expect(chartSource).toContain(
+      'value.valuation.reason !== "source-unavailable"',
+    );
   });
 
   it("omits empty team-profile filler copy", () => {

--- a/tests/token-price-chart-refresh.test.ts
+++ b/tests/token-price-chart-refresh.test.ts
@@ -5,56 +5,55 @@ import {
   createSerializedChartRefresh,
   createChartGeometry,
   getChartKeyboardInspectionIndex,
-  getChartFdvAtPoint,
   isAuthoritativeChartPayload,
   isAuthoritativeChartPayloadStatus,
   nearestChartPointIndex,
+  parseAuthoritativeChartPayload,
   preserveChartPayloadOnFailure,
   shouldClearChartInspectionAfterPointerUp,
 } from "../components/token-price-chart";
+import type { MarketChartV1 } from "../lib/market-data/market-data-v1";
 
-const CURRENT_DATA_QUALITY = {
-  schemaVersion: "programmable.explore-chart-data-quality.v1",
-  status: "current",
-  asOfBlock: "100",
-  blockHash: `0x${"11".repeat(32)}`,
-  finality: "confirmed",
-  history: { status: "current", throughBlock: "100" },
-  price: { status: "current", asOfBlock: "100", lagBlocks: "0" },
-  valuation: {
-    status: "current",
-    metric: "fdv",
-    asOfBlock: "100",
-    lagBlocks: "0",
+const MARKET_CHART = {
+  schemaVersion: "programmable.market-chart.v1",
+  source: "bitquery",
+  readStatus: "live",
+  status: "ready",
+  generatedAt: "2026-08-11T14:02:00.000Z",
+  identity: {
+    chainId: "1",
+    tokenAddress: "0x1111111111111111111111111111111111111111",
+    quoteAddress: "0x0000000000000000000000000000000000000000",
+    poolId: `0x${"22".repeat(32)}`,
+    protocol: "uniswap_v4",
   },
-} as const;
-
-const STALE_VALUATION_DATA_QUALITY = {
-  ...CURRENT_DATA_QUALITY,
-  status: "partial",
-  valuation: {
-    status: "stale",
-    metric: "fdv",
-    asOfBlock: "99",
-    lagBlocks: "1",
-  },
-} as const;
-
-const UNAVAILABLE_VALUATION_DATA_QUALITY = {
-  ...CURRENT_DATA_QUALITY,
-  status: "partial",
-  valuation: {
-    status: "unavailable",
-    metric: "fdv",
-  },
-} as const;
-
-const STALE_PRICE_DATA_QUALITY = {
-  ...CURRENT_DATA_QUALITY,
-  status: "partial",
-  price: { status: "stale", asOfBlock: "99", lagBlocks: "1" },
-  valuation: { status: "unavailable", metric: "fdv" },
-} as const;
+  range: "1d",
+  points: [{
+    blockNumber: "99",
+    time: "2026-08-11T14:01:00.000Z",
+    bucketStart: "2026-08-11T14:00:00.000Z",
+    bucketEnd: "2026-08-11T14:01:00.000Z",
+    observedAt: "2026-08-11T14:00:59.000Z",
+    valueSemantics: "period-median",
+    priceQuote: "0.1",
+    quoteSymbol: "ETH",
+    tradeCount: 1,
+  }, {
+    blockNumber: "100",
+    time: "2026-08-11T14:02:00.000Z",
+    bucketStart: "2026-08-11T14:01:00.000Z",
+    bucketEnd: "2026-08-11T14:02:00.000Z",
+    observedAt: "2026-08-11T14:01:59.000Z",
+    valueSemantics: "period-median",
+    priceQuote: "0.2",
+    quoteSymbol: "ETH",
+    tradeCount: 1,
+  }],
+  swapCount: 2,
+  valuation: { status: "unavailable", reason: "source-unavailable" },
+  asOfTime: "2026-08-11T14:01:59.000Z",
+  truncated: false,
+} as const satisfies MarketChartV1;
 
 describe("token price chart inspection", () => {
   it("maps the pointer to the nearest plotted price point", () => {
@@ -90,94 +89,6 @@ describe("token price chart inspection", () => {
     expect(shouldClearChartInspectionAfterPointerUp("")).toBe(true);
   });
 
-  it("updates historical FDV only from matching ETH and USD evidence", () => {
-    expect(
-      getChartFdvAtPoint(
-        {
-          status: "ready",
-          points: [],
-          swapCount: 2,
-          volumeWei: "0",
-          volumeEth: "0",
-          fdvEthWei: "1000000000000000000000",
-          fdvEth: "1000",
-          fdvUsdWad: "2000000000000000000000000",
-        },
-        { blockNumber: "1", priceEth: "0.5", priceUsd: "1250" },
-        { blockNumber: "2", priceEth: "1", priceUsd: "2500" },
-      ),
-    ).toEqual({
-      fdvEthWei: "500000000000000000000",
-      fdvEth: "500",
-      fdvUsdWad: "1000000000000000000000000",
-    });
-  });
-
-  it("does not substitute current FDV when historical scaling underflows", () => {
-    expect(
-      getChartFdvAtPoint(
-        {
-          status: "ready",
-          points: [],
-          swapCount: 2,
-          volumeWei: "0",
-          volumeEth: "0",
-          fdvEthWei: "1",
-          fdvEth: "0.000000000000000001",
-          fdvUsdWad: "1",
-        },
-        { blockNumber: "1", priceEth: "0.5" },
-        { blockNumber: "2", priceEth: "1" },
-      ),
-    ).toEqual({});
-  });
-
-  it("never derives an inspected FDV from a period median", () => {
-    expect(getChartFdvAtPoint(
-      {
-        status: "ready",
-        points: [],
-        swapCount: 2,
-        fdvUsdWad: "2000000000000000000000000",
-      },
-      {
-        blockNumber: "1",
-        priceUsd: "1250",
-        valueSemantics: "period-median",
-      },
-      {
-        blockNumber: "2",
-        priceUsd: "2500",
-        valueSemantics: "period-median",
-      },
-    )).toEqual({});
-  });
-
-  it("never derives historical USD FDV from ETH or arbitrary quote ratios", () => {
-    const payload = {
-      status: "ready" as const,
-      points: [],
-      swapCount: 2,
-      fdvEthWei: "1000000000000000000000",
-      fdvEth: "1000",
-      fdvUsdWad: "2000000000000000000000000",
-    };
-
-    expect(getChartFdvAtPoint(
-      payload,
-      { blockNumber: "1", priceQuote: "5", quoteSymbol: "USDC" },
-      { blockNumber: "2", priceQuote: "10", quoteSymbol: "USDC" },
-    )).toEqual({});
-    expect(getChartFdvAtPoint(
-      payload,
-      { blockNumber: "1", priceEth: "0.5" },
-      { blockNumber: "2", priceEth: "1", priceUsd: "2500" },
-    )).toEqual({
-      fdvEthWei: "500000000000000000000",
-      fdvEth: "500",
-    });
-  });
-
   it("keeps a one-point series as an accessible inspectable value", () => {
     const chart = createChartGeometry([
       { blockNumber: "100", priceEth: "1", priceUsd: "3500" },
@@ -206,293 +117,50 @@ describe("token price chart refresh", () => {
     vi.useRealTimers();
   });
 
-  it("treats source readiness as unavailable instead of authoritative zero data", () => {
+  it("accepts only quote-bound period-median chart DTOs", () => {
     expect(isAuthoritativeChartPayloadStatus("ready")).toBe(true);
     expect(isAuthoritativeChartPayloadStatus("insufficient-history")).toBe(true);
-    expect(isAuthoritativeChartPayloadStatus("not-deployed")).toBe(false);
     expect(isAuthoritativeChartPayloadStatus("partial")).toBe(true);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "ready",
-        points: [
-          { blockNumber: "99", priceEth: "0.1", priceUsd: "350" },
-          { blockNumber: "100", priceEth: "0.2", priceUsd: "700" },
-        ],
-        swapCount: 2,
-        volumeWei: "3",
-        volumeEth: "0.000000000000000003",
-        fdvEthWei: "1000000000000000000000",
-        fdvEth: "1000",
-        fdvUsdWad: "3000000000000000000000000",
-        valuationMetric: "fdv",
-        dataQuality: CURRENT_DATA_QUALITY,
-      }),
-    ).toBe(true);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "ready",
-        points: [{ blockNumber: "1", priceEth: "0.1" }],
-        swapCount: 1,
-        volumeWei: "1",
-        volumeEth: "0.000000000000000001",
-        marketCapEthWei: "1000000000000000000000",
-        marketCapEth: "1000",
-        marketCapUsdWad: "3000000000000000000000000",
-      }),
-    ).toBe(false);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "insufficient-history",
-        points: [{ blockNumber: "100", priceEth: "0.1" }],
-        swapCount: 1,
-        volumeWei: "1",
-        volumeEth: "0.000000000000000001",
-        valuationMetric: "fdv",
-        dataQuality: CURRENT_DATA_QUALITY,
-      }),
-    ).toBe(true);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "ready",
-        points: [{ blockNumber: "1", priceEth: "0.1" }],
-        swapCount: 1,
-        volumeWei: "1",
-        volumeEth: "0.000000000000000001",
-        valuationMetric: "fdv",
-        dataQuality: CURRENT_DATA_QUALITY,
-      }),
-    ).toBe(false);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "ready",
-        points: [
-          { blockNumber: "99", priceEth: "0.1" },
-          { blockNumber: "100", priceEth: "0.2" },
-        ],
-        swapCount: 2,
-        volumeWei: "3",
-        volumeEth: "0.000000000000000003",
-        valuationMetric: "fdv",
-      }),
-    ).toBe(false);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "insufficient-history",
-        points: [
-          { blockNumber: "1", priceEth: "0.1" },
-          { blockNumber: "2", priceEth: "0.2" },
-        ],
-        swapCount: 2,
-        volumeWei: "2",
-        volumeEth: "0.000000000000000002",
-        valuationMetric: "fdv",
-        dataQuality: CURRENT_DATA_QUALITY,
-      }),
-    ).toBe(false);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "ready",
-        points: [{ blockNumber: "1", priceEth: "0" }],
-        swapCount: 1,
-        volumeWei: "0",
-        volumeEth: "0",
-        fdvEthWei: "0",
-        fdvEth: "0",
-        fdvUsdWad: "0",
-      }),
-    ).toBe(false);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "not-deployed",
-        points: [],
-        swapCount: 0,
-        volumeWei: "0",
-        volumeEth: "0",
-      }),
-    ).toBe(false);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "partial",
-        points: [],
-        swapCount: 0,
-        volumeWei: "0",
-        volumeEth: "0",
-      }),
-    ).toBe(false);
-    expect(
-      isAuthoritativeChartPayload({
-        status: "ready",
-        points: [{ blockNumber: "2", priceEth: "NaN" }],
-        swapCount: 1,
-        volumeWei: "0",
-        volumeEth: "Infinity",
-      }),
-    ).toBe(false);
-  });
+    expect(isAuthoritativeChartPayloadStatus("not-deployed")).toBe(false);
+    expect(isAuthoritativeChartPayload(MARKET_CHART)).toBe(true);
 
-  it("keeps current history but strips stale FDV before acceptance", () => {
-    const partialValuation = {
-      status: "ready" as const,
-      points: [
-        { blockNumber: "99", priceEth: "0.1" },
-        { blockNumber: "100", priceEth: "0.2" },
-      ],
-      swapCount: 2,
-      volumeWei: "3",
-      volumeEth: "0.000000000000000003",
-      fdvEthWei: "1000000000000000000000",
-      fdvEth: "1000",
-      fdvUsdWad: "3000000000000000000000000",
-      valuationMetric: "fdv" as const,
-      dataQuality: STALE_VALUATION_DATA_QUALITY,
-    };
-
-    expect(isAuthoritativeChartPayload(partialValuation)).toBe(true);
-    expect(acceptChartPayload("token:1d", partialValuation)).toEqual({
-      key: "token:1d",
-      payload: {
-        status: "ready",
-        points: partialValuation.points,
-        swapCount: 2,
-        volumeWei: "3",
-        volumeEth: "0.000000000000000003",
-        valuationMetric: "fdv",
-        dataQuality: STALE_VALUATION_DATA_QUALITY,
-      },
-      failed: false,
-    });
-  });
-
-  it("keeps current history but strips unavailable FDV before acceptance", () => {
-    const partialValuation = {
-      status: "ready" as const,
-      points: [
-        { blockNumber: "99", priceEth: "0.1" },
-        { blockNumber: "100", priceEth: "0.2" },
-      ],
-      swapCount: 2,
-      volumeWei: "3",
-      volumeEth: "0.000000000000000003",
-      fdvEthWei: "1000000000000000000000",
-      fdvEth: "1000",
-      fdvUsdWad: "3000000000000000000000000",
-      valuationMetric: "fdv" as const,
-      dataQuality: UNAVAILABLE_VALUATION_DATA_QUALITY,
-    };
-
-    expect(isAuthoritativeChartPayload(partialValuation)).toBe(true);
-    expect(acceptChartPayload("token:1d", partialValuation).payload).toEqual({
+    const payload = parseAuthoritativeChartPayload(MARKET_CHART);
+    expect(payload).toMatchObject({
       status: "ready",
-      points: partialValuation.points,
+      points: MARKET_CHART.points,
       swapCount: 2,
-      volumeWei: "3",
-      volumeEth: "0.000000000000000003",
-      valuationMetric: "fdv",
-      dataQuality: UNAVAILABLE_VALUATION_DATA_QUALITY,
+      marketData: MARKET_CHART,
     });
+    expect(acceptChartPayload("token:1d", payload!).payload).toBe(payload);
   });
 
-  it("accepts an exact stale price as limited history without caching FDV", () => {
-    expect(
-      isAuthoritativeChartPayload({
-        status: "partial",
-        points: [
-          { blockNumber: "98", priceEth: "0.1" },
-          { blockNumber: "99", priceEth: "0.2" },
-        ],
-        swapCount: 2,
-        volumeWei: "3",
-        volumeEth: "0.000000000000000003",
-        valuationMetric: "fdv",
-        dataQuality: STALE_PRICE_DATA_QUALITY,
-      }),
-    ).toBe(true);
-  });
-
-  it("rejects forged stale-price provenance", () => {
-    expect(
-      isAuthoritativeChartPayload({
-        status: "partial",
-        points: [
-          { blockNumber: "98", priceEth: "0.1" },
-          { blockNumber: "99", priceEth: "0.2" },
-        ],
-        swapCount: 2,
-        volumeWei: "3",
-        volumeEth: "0.000000000000000003",
-        valuationMetric: "fdv",
-        dataQuality: {
-          ...STALE_PRICE_DATA_QUALITY,
-          price: { status: "stale", asOfBlock: "99", lagBlocks: "2" },
-        },
-      }),
-    ).toBe(false);
-  });
-
-  it("rejects unordered, duplicate, future, or noncanonical points before caching", () => {
-    for (const points of [
-      [
-        { blockNumber: "100", priceEth: "0.1" },
-        { blockNumber: "99", priceEth: "0.2" },
-      ],
-      [
-        { blockNumber: "100", priceEth: "0.1" },
-        { blockNumber: "100", priceEth: "0.2" },
-      ],
-      [
-        { blockNumber: "99", priceEth: "0.1" },
-        { blockNumber: "101", priceEth: "0.2" },
-      ],
-      [
-        { blockNumber: "099", priceEth: "0.1" },
-        { blockNumber: "100", priceEth: "0.2" },
-      ],
-    ]) {
-      expect(
-        isAuthoritativeChartPayload({
-          status: "ready",
-          points,
-          swapCount: 2,
-          volumeWei: "3",
-          volumeEth: "0.000000000000000003",
-          valuationMetric: "fdv",
-          dataQuality: CURRENT_DATA_QUALITY,
-        }),
-      ).toBe(false);
-    }
-  });
-
-  it("rejects noncanonical quality block numbers before caching", () => {
-    const noncanonicalBlock = "0100";
-    expect(
-      isAuthoritativeChartPayload({
-        status: "ready",
-        points: [
-          { blockNumber: "99", priceEth: "0.1" },
-          { blockNumber: noncanonicalBlock, priceEth: "0.2" },
-        ],
-        swapCount: 2,
-        volumeWei: "3",
-        volumeEth: "0.000000000000000003",
-        valuationMetric: "fdv",
-        dataQuality: {
-          ...CURRENT_DATA_QUALITY,
-          asOfBlock: noncanonicalBlock,
-          history: { status: "current", throughBlock: noncanonicalBlock },
-          price: {
-            status: "current",
-            asOfBlock: noncanonicalBlock,
-            lagBlocks: "0",
-          },
-          valuation: {
-            status: "current",
-            metric: "fdv",
-            asOfBlock: noncanonicalBlock,
-            lagBlocks: "0",
-          },
-        },
-      }),
-    ).toBe(false);
+  it("rejects every chart-owned valuation path", () => {
+    expect(isAuthoritativeChartPayload({
+      ...MARKET_CHART,
+      fdvUsdWad: "3000000000000000000000000",
+    })).toBe(false);
+    expect(isAuthoritativeChartPayload({
+      ...MARKET_CHART,
+      valuationMetric: "fdv",
+    })).toBe(false);
+    expect(isAuthoritativeChartPayload({
+      ...MARKET_CHART,
+      valuation: {
+        status: "available",
+        metric: "fdv",
+        supplyBasis: "total",
+        valueUsdWad: "3000000000000000000000000",
+        fdvUsdWad: "3000000000000000000000000",
+        totalSupply: "1000000",
+        asOfTime: MARKET_CHART.asOfTime,
+        freshness: "current",
+      },
+    })).toBe(false);
+    expect(isAuthoritativeChartPayload({
+      status: "ready",
+      points: MARKET_CHART.points,
+      swapCount: 2,
+    })).toBe(false);
   });
 
   it("preserves last-known-good data through failure and replaces it on recovery", () => {

--- a/tests/token-price-chart-refresh.test.ts
+++ b/tests/token-price-chart-refresh.test.ts
@@ -132,6 +132,27 @@ describe("token price chart inspection", () => {
     ).toEqual({});
   });
 
+  it("never derives an inspected FDV from a period median", () => {
+    expect(getChartFdvAtPoint(
+      {
+        status: "ready",
+        points: [],
+        swapCount: 2,
+        fdvUsdWad: "2000000000000000000000000",
+      },
+      {
+        blockNumber: "1",
+        priceUsd: "1250",
+        valueSemantics: "period-median",
+      },
+      {
+        blockNumber: "2",
+        priceUsd: "2500",
+        valueSemantics: "period-median",
+      },
+    )).toEqual({});
+  });
+
   it("never derives historical USD FDV from ETH or arbitrary quote ratios", () => {
     const payload = {
       status: "ready" as const,
@@ -157,14 +178,14 @@ describe("token price chart inspection", () => {
     });
   });
 
-  it("keeps a current one-point series as an accessible inspectable value", () => {
+  it("keeps a one-point series as an accessible inspectable value", () => {
     const chart = createChartGeometry([
       { blockNumber: "100", priceEth: "1", priceUsd: "3500" },
     ]);
 
     expect(chart).toMatchObject({
       unit: "USD",
-      current: 3500,
+      latestValue: 3500,
       path: "",
       areaPath: "",
       points: [

--- a/tests/uniswap-v4-subgraph.test.ts
+++ b/tests/uniswap-v4-subgraph.test.ts
@@ -9,6 +9,7 @@ import { computeOfficialV4PoolId } from "../lib/uniswap/liquidity-launcher-sdk";
 import {
   enrichExplorePageWithOfficialV4Subgraph,
   parseOfficialV4SubgraphResponse,
+  readOfficialV4LiquidityEvidence,
 } from "../lib/onchain/uniswap-v4-subgraph";
 
 const POOL_ID =
@@ -31,7 +32,9 @@ function canonicalToken(overrides: Partial<LauncherToken> = {}): LauncherToken {
     grossVolumeWei: "900",
     grossVolumeEth: "0.0000000000000009",
     activeLiquidity: "700",
+    tokenDecimals: 18,
     totalSwapFeeBps: 100,
+    launchModel: "classic",
     liquidityPath: "meme",
     ...overrides,
   };
@@ -58,7 +61,10 @@ function page(tokens = [canonicalToken()]): ExplorePage {
   };
 }
 
-function officialResponse(indexedBlockNumber: number | string = 25_629_999) {
+function officialResponse(
+  indexedBlockNumber: number | string = 25_629_999,
+  indexedBlockTimestamp: number | string = 1_786_576_740,
+) {
   return {
     data: {
       _meta: {
@@ -66,6 +72,7 @@ function officialResponse(indexedBlockNumber: number | string = 25_629_999) {
         block: {
           number: indexedBlockNumber,
           hash: `0x${"55".repeat(32)}`,
+          timestamp: indexedBlockTimestamp,
         },
         hasIndexingErrors: false,
       },
@@ -74,8 +81,9 @@ function officialResponse(indexedBlockNumber: number | string = 25_629_999) {
           id: POOL_ID,
           token0: {
             id: "0x0000000000000000000000000000000000000000",
+            decimals: "18",
           },
-          token1: { id: TOKEN_ADDRESS },
+          token1: { id: TOKEN_ADDRESS, decimals: "18" },
           hooks: HOOK_ADDRESS,
           feeTier: "0",
           tickSpacing: "60",
@@ -84,6 +92,8 @@ function officialResponse(indexedBlockNumber: number | string = 25_629_999) {
           tick: "-120",
           txCount: "42",
           volumeUSD: "1234.56789012345678912345",
+          totalValueLockedToken0: "0.0141",
+          totalValueLockedToken1: "32100.25",
           totalValueLockedUSD: "98.7",
         },
       ],
@@ -104,8 +114,8 @@ function officialPool(input: {
       tickSpacing: 60,
       hooks: input.hooks,
     }),
-    token0: { id: input.token0 },
-    token1: { id: input.token1 },
+    token0: { id: input.token0, decimals: "18" },
+    token1: { id: input.token1, decimals: "18" },
     hooks: input.hooks,
     feeTier: "0",
     tickSpacing: "60",
@@ -114,6 +124,8 @@ function officialPool(input: {
     tick: "-120",
     txCount: "42",
     volumeUSD: "1234.56789012345678912345",
+    totalValueLockedToken0: "0.0141",
+    totalValueLockedToken1: "32100.25",
     totalValueLockedUSD: "98.7",
   };
 }
@@ -123,6 +135,26 @@ function jsonResponse(body: unknown, init?: ResponseInit) {
     status: 200,
     headers: { "content-type": "application/json" },
     ...init,
+  });
+}
+
+function batchedTokensAndPools(count: number) {
+  return Array.from({ length: count }, (_, index) => {
+    const tokenAddress = `0x${(index + 1).toString(16).padStart(40, "0")}` as const;
+    const pool = officialPool({
+      token0: "0x0000000000000000000000000000000000000000",
+      token1: tokenAddress,
+      hooks: HOOK_ADDRESS,
+    });
+    pool.totalValueLockedUSD = "10000";
+    return {
+      token: canonicalToken({
+        id: `1:batch-${index}`,
+        tokenAddress,
+        poolId: pool.id,
+      }),
+      pool,
+    };
   });
 }
 
@@ -138,6 +170,8 @@ describe("official Uniswap v4 subgraph adapter", () => {
       expect(request.query).toContain("feeTier");
       expect(request.query).toContain("sqrtPrice");
       expect(request.query).toContain("tickSpacing");
+      expect(request.query).toContain("timestamp");
+      expect(request.query).toContain("totalValueLockedToken0");
       expect(request.query).not.toContain("isExternalLiquidity");
       expect(request.variables).toEqual({
         first: 24,
@@ -181,6 +215,366 @@ describe("official Uniswap v4 subgraph adapter", () => {
     expect(enriched.tokens[0]?.grossVolumeWei).toBe("900");
     expect(enriched.tokens[0]?.activeLiquidity).toBe("700");
     expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns current exact-pool TVL with independent provenance", async () => {
+    const response = officialResponse();
+    response.data.pools[0].totalValueLockedUSD = "12500.5";
+    const evidence = await readOfficialV4LiquidityEvidence(
+      {
+        tokens: [canonicalToken()],
+        referenceHead: {
+          chainId: 1,
+          blockNumber: "25630000",
+          blockHash: `0x${"44".repeat(32)}`,
+        },
+        now: new Date("2026-08-12T23:21:00.000Z"),
+      },
+      {
+        apiKey: "graph-secret",
+        endpoint: OFFICIAL_ENDPOINT,
+        fetcher: async () => jsonResponse(response),
+      },
+    );
+
+    expect(evidence).toEqual([
+      {
+        source: "official-uniswap-v4-subgraph",
+        identity: {
+          chainId: "1",
+          protocol: "uniswap_v4",
+          poolId: POOL_ID,
+          tokenAddress: TOKEN_ADDRESS,
+          quoteAddress: "0x0000000000000000000000000000000000000000",
+        },
+        valueBasis: "official-subgraph-pool-tvl-usd",
+        tvlUsdWad: "12500500000000000000000",
+        reportedPoolBalances: {
+          token0: {
+            address: "0x0000000000000000000000000000000000000000",
+            decimals: 18,
+            amountDecimal: "0.0141",
+          },
+          token1: {
+            address: TOKEN_ADDRESS,
+            decimals: 18,
+            amountDecimal: "32100.25",
+          },
+        },
+        freshness: "current",
+        provenance: {
+          subgraphId: "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G",
+          deployment: OFFICIAL_DEPLOYMENT,
+          indexedBlockNumber: "25629999",
+          indexedBlockHash: `0x${"55".repeat(32)}`,
+          indexedBlockTimestamp: "1786576740",
+          indexedBlockTime: "2026-08-12T23:19:00.000Z",
+          referenceHeadBlockNumber: "25630000",
+          referenceHeadBlockHash: `0x${"44".repeat(32)}`,
+          lagBlocks: "1",
+        },
+      },
+    ]);
+  });
+
+  it("distinguishes shallow pools from stale or internally conflicting evidence", async () => {
+    async function read(
+      response: unknown,
+      token = canonicalToken(),
+    ) {
+      return readOfficialV4LiquidityEvidence(
+        {
+          tokens: [token],
+          referenceHead: {
+            chainId: 1,
+            blockNumber: "25630000",
+            blockHash: `0x${"44".repeat(32)}`,
+          },
+          now: new Date("2026-08-12T23:21:00.000Z"),
+        },
+        {
+          apiKey: "graph-secret",
+          endpoint: OFFICIAL_ENDPOINT,
+          fetcher: async () => jsonResponse(response),
+        },
+      );
+    }
+
+    const shallow = officialResponse();
+    shallow.data.pools[0].totalValueLockedUSD = "9999.999999999999999999";
+    await expect(read(shallow)).resolves.toEqual([]);
+
+    const stale = officialResponse(25_629_999, 1_786_576_499);
+    stale.data.pools[0].totalValueLockedUSD = "10000";
+    await expect(read(stale)).rejects.toMatchObject({
+      code: "coverage-incomplete",
+    });
+
+    const futureTime = officialResponse(25_629_999, 1_786_577_101);
+    futureTime.data.pools[0].totalValueLockedUSD = "10000";
+    await expect(read(futureTime)).rejects.toMatchObject({
+      code: "coverage-incomplete",
+    });
+
+    const ahead = officialResponse(25_630_001);
+    ahead.data.pools[0].totalValueLockedUSD = "10000";
+    await expect(read(ahead)).rejects.toMatchObject({
+      code: "coverage-incomplete",
+    });
+
+    const lagged = officialResponse(25_629_935);
+    lagged.data.pools[0].totalValueLockedUSD = "10000";
+    await expect(read(lagged)).rejects.toMatchObject({
+      code: "coverage-incomplete",
+    });
+
+    const conflicting = officialResponse(25_630_000);
+    conflicting.data.pools[0].totalValueLockedUSD = "10000";
+    await expect(read(conflicting)).rejects.toMatchObject({
+      code: "coverage-incomplete",
+    });
+
+    const emptyPrincipal = officialResponse();
+    emptyPrincipal.data.pools[0].totalValueLockedUSD = "10000";
+    emptyPrincipal.data.pools[0].totalValueLockedToken0 = "0";
+    emptyPrincipal.data.pools[0].totalValueLockedToken1 = "0.000";
+    await expect(read(emptyPrincipal)).rejects.toMatchObject({
+      code: "coverage-incomplete",
+    });
+
+    const exactPool = officialResponse();
+    exactPool.data.pools[0].totalValueLockedUSD = "10000";
+    await expect(
+      read(
+        exactPool,
+        canonicalToken({
+          tokenAddress: "0x4444444444444444444444444444444444444444",
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "coverage-incomplete" });
+    await expect(
+      read(
+        exactPool,
+        canonicalToken({
+          hookAddress: "0x4444444444444444444444444444444444444444",
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "coverage-incomplete" });
+    await expect(
+      read(exactPool, canonicalToken({ tokenDecimals: 17 })),
+    ).rejects.toMatchObject({ code: "coverage-incomplete" });
+
+    const quoteAsset =
+      "0x1111111111111111111111111111111111111111" as const;
+    const stockPool = officialPool({
+      token0: quoteAsset,
+      token1: TOKEN_ADDRESS,
+      hooks: HOOK_ADDRESS,
+    });
+    stockPool.totalValueLockedUSD = "10000";
+    await expect(
+      read(
+        {
+          data: {
+            ...officialResponse().data,
+            pools: [stockPool],
+          },
+        },
+        canonicalToken({
+          launchModel: "stock-paired",
+          poolId: stockPool.id,
+          quoteAssetAddress: quoteAsset,
+          quoteIsCurrency0: false,
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "coverage-incomplete" });
+
+    const fetcher = vi.fn(async () => jsonResponse(officialResponse()));
+    await expect(
+      readOfficialV4LiquidityEvidence(
+        {
+          tokens: [canonicalToken()],
+          referenceHead: {
+            chainId: 1,
+            blockNumber: "025630000",
+            blockHash: `0x${"44".repeat(32)}`,
+          },
+        },
+        {
+          apiKey: "graph-secret",
+          endpoint: OFFICIAL_ENDPOINT,
+          fetcher,
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "OfficialV4LiquidityEvidenceReadError",
+      code: "invalid-input",
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+
+    const unsupportedFetcher = vi.fn(async () => jsonResponse(officialResponse()));
+    await expect(
+      readOfficialV4LiquidityEvidence(
+        {
+          tokens: [canonicalToken({ launchModel: "custom-graph" })],
+          referenceHead: {
+            chainId: 1,
+            blockNumber: "25630000",
+            blockHash: `0x${"44".repeat(32)}`,
+          },
+        },
+        {
+          apiKey: "graph-secret",
+          endpoint: OFFICIAL_ENDPOINT,
+          fetcher: unsupportedFetcher,
+        },
+      ),
+    ).resolves.toEqual([]);
+    expect(unsupportedFetcher).not.toHaveBeenCalled();
+  });
+
+  it("batches more than 24 exact pools without silently truncating evidence", async () => {
+    const tokensAndPools = batchedTokensAndPools(25);
+    const pools = new Map(tokensAndPools.map(({ pool }) => [pool.id, pool]));
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        variables: { poolIds: string[] };
+      };
+      return jsonResponse({
+        data: {
+          ...officialResponse().data,
+          pools: request.variables.poolIds.map((poolId) =>
+            pools.get(poolId as `0x${string}`),
+          ),
+        },
+      });
+    });
+
+    const evidence = await readOfficialV4LiquidityEvidence(
+      {
+        tokens: tokensAndPools.map(({ token }) => token),
+        referenceHead: {
+          chainId: 1,
+          blockNumber: "25630000",
+          blockHash: `0x${"44".repeat(32)}`,
+        },
+        now: new Date("2026-08-12T23:21:00.000Z"),
+      },
+      {
+        apiKey: "graph-secret",
+        endpoint: OFFICIAL_ENDPOINT,
+        fetcher,
+      },
+    );
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(evidence).toHaveLength(25);
+  });
+
+  it("rejects the whole read when one of multiple pool batches fails", async () => {
+    const tokensAndPools = batchedTokensAndPools(25);
+    const pools = new Map(tokensAndPools.map(({ pool }) => [pool.id, pool]));
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        variables: { poolIds: string[] };
+      };
+      if (request.variables.poolIds.length === 1) {
+        return new Response("unavailable", { status: 503 });
+      }
+      return jsonResponse({
+        data: {
+          ...officialResponse().data,
+          pools: request.variables.poolIds.map((poolId) =>
+            pools.get(poolId as `0x${string}`),
+          ),
+        },
+      });
+    });
+
+    await expect(
+      readOfficialV4LiquidityEvidence(
+        {
+          tokens: tokensAndPools.map(({ token }) => token),
+          referenceHead: {
+            chainId: 1,
+            blockNumber: "25630000",
+            blockHash: `0x${"44".repeat(32)}`,
+          },
+          now: new Date("2026-08-12T23:21:00.000Z"),
+        },
+        {
+          apiKey: "graph-secret",
+          endpoint: OFFICIAL_ENDPOINT,
+          fetcher,
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "OfficialV4LiquidityEvidenceReadError",
+      code: "coverage-incomplete",
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects coverage when a successful batch omits a requested canonical pool", async () => {
+    const tokensAndPools = batchedTokensAndPools(2);
+    await expect(
+      readOfficialV4LiquidityEvidence(
+        {
+          tokens: tokensAndPools.map(({ token }) => token),
+          referenceHead: {
+            chainId: 1,
+            blockNumber: "25630000",
+            blockHash: `0x${"44".repeat(32)}`,
+          },
+          now: new Date("2026-08-12T23:21:00.000Z"),
+        },
+        {
+          apiKey: "graph-secret",
+          endpoint: OFFICIAL_ENDPOINT,
+          fetcher: async () =>
+            jsonResponse({
+              data: {
+                ...officialResponse().data,
+                pools: [tokensAndPools[0]!.pool],
+              },
+            }),
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "OfficialV4LiquidityEvidenceReadError",
+      code: "coverage-incomplete",
+    });
+  });
+
+  it("accepts complete pool coverage while omitting a returned shallow pool", async () => {
+    const tokensAndPools = batchedTokensAndPools(2);
+    tokensAndPools[1]!.pool.totalValueLockedUSD = "9999.99";
+
+    const evidence = await readOfficialV4LiquidityEvidence(
+      {
+        tokens: tokensAndPools.map(({ token }) => token),
+        referenceHead: {
+          chainId: 1,
+          blockNumber: "25630000",
+          blockHash: `0x${"44".repeat(32)}`,
+        },
+        now: new Date("2026-08-12T23:21:00.000Z"),
+      },
+      {
+        apiKey: "graph-secret",
+        endpoint: OFFICIAL_ENDPOINT,
+        fetcher: async () =>
+          jsonResponse({
+            data: {
+              ...officialResponse().data,
+              pools: tokensAndPools.map(({ pool }) => pool),
+            },
+          }),
+      },
+    );
+
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0]?.identity.poolId).toBe(tokensAndPools[0]!.pool.id);
   });
 
   it("adds an indexed display valuation from the compatible official pool snapshot", async () => {


### PR DESCRIPTION
## What changed

This release replaces the unreliable public market-data path with exact, fail-closed evidence:

- binds public registry and chart reads to the existing commitment-bound Alchemy and QuickNode production RPC pair
- publishes current spot FDV only from an exact-block Uniswap v4 StateView and canonical Chainlink ETH/USD round
- requires exact, fresh official Uniswap v4 subgraph pool coverage and explicit pool-TVL eligibility
- keeps Bitquery for trades, volume, and bounded period-median charts while preventing chart data from overwriting canonical FDV
- globally sorts the complete eligible token set before pagination
- removes stale or unevidenced Bitquery FDV from ordinary public discovery while preserving the exact historical PCAN release receipt
- strengthens staged and post-promotion gates with independent two-provider EIP-1898 reproduction, complete pagination, recursive provenance checks, and all chart ranges

## Root cause

Public Explore identity reads were still using unauthenticated PublicNode and dRPC endpoints even though paid Alchemy and QuickNode bindings already existed. dRPC returned routing failures. Bitquery valuations were stale or missing liquidity evidence, and the historical chart query failed for active pools and longer ranges.

## User impact

Explore and token detail can now return an honestly evidenced current spot FDV when the exact pool, supply, Chainlink round, StateView state, official pool TVL, and freshness requirements all agree. Unknown or incomplete evidence remains unavailable instead of displaying a plausible but incorrect number. Charts use bounded, explicitly labeled period medians and cannot replace the canonical detail valuation.

## Validation

- 17 focused files, 701 tests passed
- TypeScript passed
- changed-file ESLint passed
- Alchemy and Bitquery source contracts 18 of 18 passed
- release operations contract 39 of 39 passed
- workflow Actionlint and Node syntax checks passed
- exact commit-range Gitleaks scan passed with no leaks
- independent component and gate reviews found no remaining P0 or P1 findings

No indexed-read, projector, database, onchain transaction, or paid-account activation is included in this PR.