### PR TITLE
Bind staged market RPC witnesses

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -602,10 +602,17 @@ jobs:
         env:
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          MAINNET_RPC_URL_A: ${{ secrets.MAINNET_RPC_URL_A }}
+          MAINNET_RPC_URL_B: ${{ secrets.MAINNET_RPC_URL_B }}
+          PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}
+          PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}
         run: |
           node --env-file=.vercel/.env.production.local --input-type=module <<'NODE'
           const { verifyCurrentPublicOnchainEvidenceV1 } = await import(
             "./scripts/perf/read-model-post-promotion.mjs"
+          );
+          const { runtimeProductionProviderBindingsFromUrls } = await import(
+            "./scripts/perf/read-model-provider-binding.mjs"
           );
           const { verifyBitqueryGoldenMarketParityV1 } = await import(
             "./scripts/perf/bitquery-golden-market-parity.mjs"
@@ -635,6 +642,26 @@ jobs:
             "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G";
           const currentPublicMarketSource =
             "stateview-chainlink+official-uniswap-v4-subgraph+bitquery";
+          const independentRpcUrls = Object.freeze([
+            process.env.MAINNET_RPC_URL_A,
+            process.env.MAINNET_RPC_URL_B,
+          ]);
+          const independentRpcBindings =
+            runtimeProductionProviderBindingsFromUrls({
+              ETHEREUM_RPC_URL: independentRpcUrls[0],
+              ETHEREUM_RPC_URL_B: independentRpcUrls[1],
+            });
+          for (const binding of independentRpcBindings) {
+            const expectedCommitment =
+              binding.vendorGroup === "alchemy"
+                ? process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT
+                : process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT;
+            if (binding.endpointCommitment !== expectedCommitment) {
+              throw new Error(
+                "staged independent RPC witness does not match its pinned production commitment",
+              );
+            }
+          }
           const minimumPublicFdvLiquidityUsdWad =
             10_000n * 10n ** 18n;
           const marketCapPageSize = 100;
@@ -1552,10 +1579,7 @@ jobs:
             const independentCurrentProof =
               await verifyCurrentPublicOnchainEvidenceV1({
                 token: currentFdvDetail.token,
-                rpcUrls: [
-                  process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
-                  process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
-                ],
+                rpcUrls: independentRpcUrls,
               });
             if (
               independentCurrentProof.schemaVersion !==

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -665,8 +665,8 @@ export const STAGED_MARKET_EVIDENCE_SOURCE_GUARDS = Object.freeze([
   "JSON.stringify(currentFdvDetail.token.liquidityEvidence)",
   'for (const range of ["1h", "1d", "1w", "all"])',
   "verifyCurrentPublicOnchainEvidenceV1({",
-  "process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
-  "process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
+  "process.env.MAINNET_RPC_URL_A",
+  "process.env.MAINNET_RPC_URL_B",
   '"programmable.current-market-independent-proof.v1"',
   "independentCurrentProof.providerCount !== 2",
   'currentChart.readStatus !== "live"',
@@ -1546,6 +1546,37 @@ export function evaluateReadModelOperationsSourceContracts(
       stagedBitquerySmokeBlock.includes(
         "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
       ) &&
+      stagedBitquerySmokeBlock.includes(
+        "MAINNET_RPC_URL_A: ${{ secrets.MAINNET_RPC_URL_A }}",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "MAINNET_RPC_URL_B: ${{ secrets.MAINNET_RPC_URL_B }}",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        '"./scripts/perf/read-model-provider-binding.mjs"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "runtimeProductionProviderBindingsFromUrls({",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "ETHEREUM_RPC_URL: independentRpcUrls[0]",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "ETHEREUM_RPC_URL_B: independentRpcUrls[1]",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "binding.endpointCommitment !== expectedCommitment",
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        "staged independent RPC witness does not match its pinned production commitment",
+      ) &&
+      stagedBitquerySmokeBlock.includes("rpcUrls: independentRpcUrls") &&
       stagedBitquerySmokeBlock.includes(
         "process.env.VERCEL_AUTOMATION_BYPASS_SECRET",
       ) &&

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -828,6 +828,28 @@ describe("read-model production deploy policy", () => {
       workflow.indexOf("Record registry identity and combined market path"),
     );
     expect(bitquerySmoke).toContain(
+      "MAINNET_RPC_URL_A: ${{ secrets.MAINNET_RPC_URL_A }}",
+    );
+    expect(bitquerySmoke).toContain(
+      "MAINNET_RPC_URL_B: ${{ secrets.MAINNET_RPC_URL_B }}",
+    );
+    expect(bitquerySmoke).toContain(
+      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}",
+    );
+    expect(bitquerySmoke).toContain(
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}",
+    );
+    expect(bitquerySmoke).toContain(
+      '"./scripts/perf/read-model-provider-binding.mjs"',
+    );
+    expect(bitquerySmoke).toContain(
+      "runtimeProductionProviderBindingsFromUrls({",
+    );
+    expect(bitquerySmoke).toContain(
+      "binding.endpointCommitment !== expectedCommitment",
+    );
+    expect(bitquerySmoke).toContain("rpcUrls: independentRpcUrls");
+    expect(bitquerySmoke).toContain(
       "/api/explore?limit=20&page=1&q=${goldenTokenAddress}&sort=market-cap",
     );
     expect(bitquerySmoke.match(/historicalBitqueryMarketContract/g)).toHaveLength(3);
@@ -836,7 +858,7 @@ describe("read-model production deploy policy", () => {
     expect(bitquerySmoke).not.toContain("/api/ops/health");
     expect(bitquerySmoke).not.toContain("/api/explore/profile");
     expect(bitquerySmoke).not.toMatch(
-      /\b(?:database|projector|quicknode|envio|real-block|sla)\b/iu,
+      /\b(?:database|projector|envio|real-block|sla)\b/iu,
     );
     expect(workflow).toContain("Reverify staged candidate binding");
     expect(workflow).toContain("Record staged candidate handoff");

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -432,6 +432,62 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it.each([
+    [
+      "first independent RPC secret",
+      "          MAINNET_RPC_URL_A: ${{ secrets.MAINNET_RPC_URL_A }}\n",
+    ],
+    [
+      "second independent RPC secret",
+      "          MAINNET_RPC_URL_B: ${{ secrets.MAINNET_RPC_URL_B }}\n",
+    ],
+    [
+      "Alchemy commitment",
+      "          PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}\n",
+    ],
+    [
+      "QuickNode commitment",
+      "          PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}\n",
+    ],
+    [
+      "provider binding",
+      "            runtimeProductionProviderBindingsFromUrls({\n",
+    ],
+    [
+      "commitment comparison",
+      "            if (binding.endpointCommitment !== expectedCommitment) {\n",
+    ],
+    ["independent reader handoff", "                rpcUrls: independentRpcUrls,\n"],
+  ])("fails closed when staged market proof drops the %s", (_label, needle) => {
+    const workflowPath = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const stepStart = workflow.indexOf(
+      "      - name: Smoke staged public market APIs",
+    );
+    const stepEnd = workflow.indexOf(
+      "      - name: Record registry identity and combined market path",
+    );
+    expect(stepStart).toBeGreaterThanOrEqual(0);
+    expect(stepEnd).toBeGreaterThan(stepStart);
+    const step = workflow.slice(stepStart, stepEnd);
+    expect(step).toContain(needle);
+    const unsafeStep = step.replace(needle, "");
+    const unsafeWorkflow =
+      workflow.slice(0, stepStart) +
+      unsafeStep +
+      workflow.slice(stepEnd);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
   it("fails closed when the Bitquery staged smoke stops proving current FDV order", () => {
     const workflowPath = ".github/workflows/deploy-production.yml";
     const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");


### PR DESCRIPTION
## Summary

- inject the existing private GitHub RPC witnesses only into the staged public-market proof step
- verify both endpoints are approved Alchemy and QuickNode endpoints whose commitments exactly match the pinned production commitments
- pass the verified pair to the independent exact-block StateView and Chainlink evidence check
- extend source-contract and mutation coverage so removing either secret, commitment, binding, comparison, or handoff fails closed

## Validation

- 454 focused Vitest tests
- TypeScript typecheck
- targeted ESLint
- Actionlint and Node syntax check
- read-model operations gate 39/39
- staged diff check and Gitleaks

This remains a stage-only workflow. It does not promote or change production aliases.