### PR TITLE
Restore the production read-model watchdog

### DIFF
--- a/.github/workflows/refresh-production-read-model.yml
+++ b/.github/workflows/refresh-production-read-model.yml
@@ -5,8 +5,7 @@ on:
     - cron: "2-57/5 * * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: production-read-model-refresh
@@ -41,6 +40,8 @@ jobs:
           const HEALTH_ATTEMPTS = 18;
           const HEALTH_RETRY_DELAY_MS = 5_000;
           const CANONICAL_UINT = /^(?:0|[1-9][0-9]{0,77})$/u;
+          const HEX32 = /^0x[0-9a-f]{64}$/u;
+          const MAXIMUM_UINT64 = (1n << 64n) - 1n;
 
           const targetOrigin = process.env.TARGET_ORIGIN;
           const cronSecret = process.env.CRON_SECRET;
@@ -169,6 +170,21 @@ jobs:
             const healthBlock = CANONICAL_UINT.test(index?.blockNumber)
               ? BigInt(index.blockNumber)
               : null;
+            const rpc = health.body?.rpc;
+            const confirmedBlock = rpc?.confirmedBlock;
+            const confirmedBlockNumber = CANONICAL_UINT.test(
+              confirmedBlock?.number,
+            )
+              ? BigInt(confirmedBlock.number)
+              : null;
+            const primary = rpc?.providers?.primary;
+            const secondary = rpc?.providers?.secondary;
+            const primaryHead = CANONICAL_UINT.test(primary?.head)
+              ? BigInt(primary.head)
+              : null;
+            const secondaryHead = CANONICAL_UINT.test(secondary?.head)
+              ? BigInt(secondary.head)
+              : null;
             if (
               health.response.status === 200 &&
               health.body?.status === "healthy" &&
@@ -176,21 +192,45 @@ jobs:
               health.body.indexSource === "durable" &&
               health.body.indexedReadModel?.status === "disabled" &&
               healthBlock !== null &&
+              healthBlock <= MAXIMUM_UINT64 &&
               healthBlock >= refreshBlock &&
               Number.isSafeInteger(index?.ageSeconds) &&
               index.ageSeconds >= 0 &&
               index.ageSeconds <= MAXIMUM_FRESH_AGE_SECONDS &&
               Number.isSafeInteger(index?.tokenCount) &&
               index.tokenCount >= 0 &&
-              health.body.rpc?.status === "healthy" &&
-              health.body.rpc?.chainId === 1 &&
-              health.body.rpc?.read?.status === "available" &&
-              health.body.rpc?.quorum?.status === "verified"
+              rpc?.status === "healthy" &&
+              rpc?.chainId === 1 &&
+              rpc?.read?.status === "available" &&
+              rpc?.quorum?.status === "verified" &&
+              confirmedBlockNumber !== null &&
+              confirmedBlockNumber <= MAXIMUM_UINT64 &&
+              confirmedBlockNumber >= healthBlock &&
+              confirmedBlockNumber >= refreshBlock &&
+              HEX32.test(confirmedBlock?.hash) &&
+              confirmedBlock.hash !== `0x${"00".repeat(32)}` &&
+              rpc?.freshness?.maxHeadAgeSeconds === 300 &&
+              primary?.status === "available" &&
+              secondary?.status === "available" &&
+              primaryHead !== null &&
+              secondaryHead !== null &&
+              primaryHead <= MAXIMUM_UINT64 &&
+              secondaryHead <= MAXIMUM_UINT64 &&
+              primaryHead >= confirmedBlockNumber &&
+              secondaryHead >= confirmedBlockNumber &&
+              Number.isSafeInteger(primary?.headAgeSeconds) &&
+              Number.isSafeInteger(secondary?.headAgeSeconds) &&
+              primary.headAgeSeconds >= 0 &&
+              secondary.headAgeSeconds >= 0 &&
+              primary.headAgeSeconds <= rpc.freshness.maxHeadAgeSeconds &&
+              secondary.headAgeSeconds <= rpc.freshness.maxHeadAgeSeconds
             ) {
               proof = {
                 blockNumber: index.blockNumber,
                 tokenCount: index.tokenCount,
                 ageSeconds: index.ageSeconds,
+                confirmedBlockNumber: confirmedBlock.number,
+                confirmedBlockHash: confirmedBlock.hash,
               };
               break;
             }
@@ -208,6 +248,8 @@ jobs:
             target: targetOrigin,
             refreshBlockNumber: refresh.body.blockNumber,
             visibleBlockNumber: proof.blockNumber,
+            confirmedBlockNumber: proof.confirmedBlockNumber,
+            confirmedBlockHash: proof.confirmedBlockHash,
             tokenCount: proof.tokenCount,
             ageSeconds: proof.ageSeconds,
             updated: refresh.body.updated,
@@ -223,6 +265,8 @@ jobs:
                 `- Target: \`${safeResult.target}\``,
                 `- Refreshed block: \`${safeResult.refreshBlockNumber}\``,
                 `- Visible block: \`${safeResult.visibleBlockNumber}\``,
+                `- RPC-confirmed block: \`${safeResult.confirmedBlockNumber}\``,
+                `- RPC-confirmed hash: \`${safeResult.confirmedBlockHash}\``,
                 `- Freshness: \`${safeResult.ageSeconds}s\``,
                 `- Tokens: \`${safeResult.tokenCount}\``,
                 `- Durable write advanced: \`${safeResult.updated}\``,

--- a/.github/workflows/refresh-production-read-model.yml
+++ b/.github/workflows/refresh-production-read-model.yml
@@ -1,0 +1,235 @@
+name: Refresh production read model
+
+on:
+  schedule:
+    - cron: "2-57/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-read-model-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh durable production read model
+    if: >-
+      github.repository == '0xprogrammable/programmable' &&
+      github.ref == 'refs/heads/production'
+    runs-on: ubuntu-latest
+    timeout-minutes: 9
+    environment:
+      name: production
+
+    steps:
+      - name: Refresh and prove durable freshness
+        shell: bash
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          TARGET_ORIGIN: https://programmable.market
+          SCHEDULER_RUN_ID: ${{ github.run_id }}
+          SCHEDULER_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { appendFile } from "node:fs/promises";
+
+          const MAXIMUM_JSON_BYTES = 64 * 1024;
+          const MAXIMUM_FRESH_AGE_SECONDS = 10 * 60;
+          const HEALTH_ATTEMPTS = 18;
+          const HEALTH_RETRY_DELAY_MS = 5_000;
+          const CANONICAL_UINT = /^(?:0|[1-9][0-9]{0,77})$/u;
+
+          const targetOrigin = process.env.TARGET_ORIGIN;
+          const cronSecret = process.env.CRON_SECRET;
+          const runId = process.env.SCHEDULER_RUN_ID;
+          const runAttempt = process.env.SCHEDULER_RUN_ATTEMPT;
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+          if (targetOrigin !== "https://programmable.market") {
+            throw new Error("production read-model target is invalid");
+          }
+          const secretBytes = Buffer.byteLength(cronSecret ?? "", "utf8");
+          if (
+            secretBytes < 32 ||
+            secretBytes > 1_024 ||
+            /[\r\n]/u.test(cronSecret ?? "")
+          ) {
+            throw new Error("production cron credential is unavailable");
+          }
+          if (
+            !/^[1-9][0-9]*$/u.test(runId ?? "") ||
+            !/^[1-9][0-9]*$/u.test(runAttempt ?? "")
+          ) {
+            throw new Error("scheduler run identity is invalid");
+          }
+
+          async function boundedJson(response) {
+            const contentType = response.headers.get("content-type") ?? "";
+            if (!contentType.toLowerCase().startsWith("application/json")) {
+              throw new Error(`unexpected response content type (${response.status})`);
+            }
+            const declaredLength = response.headers.get("content-length");
+            if (
+              declaredLength !== null &&
+              (!/^(?:0|[1-9][0-9]*)$/u.test(declaredLength) ||
+                BigInt(declaredLength) > BigInt(MAXIMUM_JSON_BYTES))
+            ) {
+              throw new Error(`response exceeded size limit (${response.status})`);
+            }
+            if (!response.body) {
+              throw new Error(`response body is missing (${response.status})`);
+            }
+            const reader = response.body.getReader();
+            const chunks = [];
+            let bytes = 0;
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              bytes += value.byteLength;
+              if (bytes > MAXIMUM_JSON_BYTES) {
+                await reader.cancel();
+                throw new Error(`response exceeded size limit (${response.status})`);
+              }
+              chunks.push(value);
+            }
+            const payload = Buffer.concat(
+              chunks.map((chunk) => Buffer.from(chunk)),
+              bytes,
+            ).toString("utf8");
+            try {
+              return JSON.parse(payload);
+            } catch {
+              throw new Error(`response was not valid JSON (${response.status})`);
+            }
+          }
+
+          async function getJson(path, { authorized = false, timeoutMs }) {
+            const headers = {
+              accept: "application/json",
+              "cache-control": "no-cache",
+              "user-agent": "programmable-production-read-model-scheduler/1",
+            };
+            if (authorized) headers.authorization = `Bearer ${cronSecret}`;
+            const response = await fetch(new URL(path, targetOrigin), {
+              method: "GET",
+              headers,
+              redirect: "error",
+              signal: AbortSignal.timeout(timeoutMs),
+            });
+            const body = await boundedJson(response);
+            return { response, body };
+          }
+
+          const refresh = await getJson("/api/ops/index-v2", {
+            authorized: true,
+            timeoutMs: 330_000,
+          });
+          if (
+            refresh.response.status !== 200 ||
+            !refresh.response.headers
+              .get("cache-control")
+              ?.toLowerCase()
+              .includes("no-store") ||
+            refresh.body?.ok !== true ||
+            !CANONICAL_UINT.test(refresh.body.blockNumber) ||
+            !Number.isSafeInteger(refresh.body.tokenCount) ||
+            refresh.body.tokenCount < 0 ||
+            typeof refresh.body.updated !== "boolean" ||
+            !["recorded", "already-recorded", "empty"].includes(
+              refresh.body.portfolioHistory?.status,
+            ) ||
+            !CANONICAL_UINT.test(refresh.body.portfolioHistory?.blockNumber) ||
+            refresh.body.portfolioHistory.blockNumber !==
+              refresh.body.blockNumber ||
+            !Number.isSafeInteger(refresh.body.portfolioHistory?.tokenCount) ||
+            refresh.body.portfolioHistory.tokenCount !==
+              refresh.body.tokenCount ||
+            (refresh.body.portfolioHistory.status === "empty"
+              ? refresh.body.tokenCount !== 0 ||
+                refresh.body.portfolioHistory.path !== null
+              : typeof refresh.body.portfolioHistory.path !== "string" ||
+                refresh.body.portfolioHistory.path.length < 1 ||
+                refresh.body.portfolioHistory.path.length > 1_024)
+          ) {
+            throw new Error(`production read-model refresh failed (${refresh.response.status})`);
+          }
+
+          const refreshBlock = BigInt(refresh.body.blockNumber);
+          let proof = null;
+          for (let attempt = 1; attempt <= HEALTH_ATTEMPTS; attempt += 1) {
+            const nonce = encodeURIComponent(`${runId}-${runAttempt}-${attempt}`);
+            const health = await getJson(
+              `/api/ops/health?scheduler_proof=${nonce}`,
+              { authorized: false, timeoutMs: 30_000 },
+            );
+            const index = health.body?.index;
+            const healthBlock = CANONICAL_UINT.test(index?.blockNumber)
+              ? BigInt(index.blockNumber)
+              : null;
+            if (
+              health.response.status === 200 &&
+              health.body?.status === "healthy" &&
+              health.body.chainId === 1 &&
+              health.body.indexSource === "durable" &&
+              health.body.indexedReadModel?.status === "disabled" &&
+              healthBlock !== null &&
+              healthBlock >= refreshBlock &&
+              Number.isSafeInteger(index?.ageSeconds) &&
+              index.ageSeconds >= 0 &&
+              index.ageSeconds <= MAXIMUM_FRESH_AGE_SECONDS &&
+              Number.isSafeInteger(index?.tokenCount) &&
+              index.tokenCount >= 0 &&
+              health.body.rpc?.status === "healthy" &&
+              health.body.rpc?.chainId === 1 &&
+              health.body.rpc?.read?.status === "available" &&
+              health.body.rpc?.quorum?.status === "verified"
+            ) {
+              proof = {
+                blockNumber: index.blockNumber,
+                tokenCount: index.tokenCount,
+                ageSeconds: index.ageSeconds,
+              };
+              break;
+            }
+            if (attempt < HEALTH_ATTEMPTS) {
+              await new Promise((resolve) =>
+                setTimeout(resolve, HEALTH_RETRY_DELAY_MS),
+              );
+            }
+          }
+          if (proof === null) {
+            throw new Error("production read-model freshness proof failed");
+          }
+
+          const safeResult = {
+            target: targetOrigin,
+            refreshBlockNumber: refresh.body.blockNumber,
+            visibleBlockNumber: proof.blockNumber,
+            tokenCount: proof.tokenCount,
+            ageSeconds: proof.ageSeconds,
+            updated: refresh.body.updated,
+            portfolioHistoryStatus: refresh.body.portfolioHistory.status,
+          };
+          console.log(JSON.stringify(safeResult));
+          if (summaryPath) {
+            await appendFile(
+              summaryPath,
+              [
+                "## Production read-model refresh",
+                "",
+                `- Target: \`${safeResult.target}\``,
+                `- Refreshed block: \`${safeResult.refreshBlockNumber}\``,
+                `- Visible block: \`${safeResult.visibleBlockNumber}\``,
+                `- Freshness: \`${safeResult.ageSeconds}s\``,
+                `- Tokens: \`${safeResult.tokenCount}\``,
+                `- Durable write advanced: \`${safeResult.updated}\``,
+                `- Portfolio history: \`${safeResult.portfolioHistoryStatus}\``,
+                "",
+              ].join("\n"),
+              "utf8",
+            );
+          }
+          NODE

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -6,6 +6,19 @@
     "retainedUntil": "indexed-read-cutover",
     "route": "app/api/ops/index-v2/route.ts",
     "sha256": "38593eaa836e88400311e8a585079a6a81fa84f115d93a72a6ac0fefa01cef43",
+    "schedulerWatchdog": {
+      "provider": "github-actions",
+      "workflow": {
+        "path": ".github/workflows/refresh-production-read-model.yml",
+        "sha256": "7fbaef1b69b72a1d75c3fb876b2fb4961a10e177623d2c15f138978c03568355"
+      },
+      "schedule": "2-57/5 * * * *",
+      "targetOrigin": "https://programmable.market",
+      "environment": "production",
+      "secretEnvironment": "CRON_SECRET",
+      "concurrencyGroup": "production-read-model-refresh",
+      "freshnessMaximumAgeSeconds": 600
+    },
     "closedAlias": {
       "path": "/api/ops/index",
       "route": "app/api/ops/index/route.ts",

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -10,14 +10,27 @@
       "provider": "github-actions",
       "workflow": {
         "path": ".github/workflows/refresh-production-read-model.yml",
-        "sha256": "7fbaef1b69b72a1d75c3fb876b2fb4961a10e177623d2c15f138978c03568355"
+        "sha256": "e4dd949194ef4046382e9930fe66bd3f63195578b63ed970b0e9ae2a421d2a9d"
       },
       "schedule": "2-57/5 * * * *",
       "targetOrigin": "https://programmable.market",
       "environment": "production",
       "secretEnvironment": "CRON_SECRET",
       "concurrencyGroup": "production-read-model-refresh",
-      "freshnessMaximumAgeSeconds": 600
+      "freshnessMaximumAgeSeconds": 600,
+      "rpcProof": {
+        "confirmedBlockRequired": true,
+        "providerPairRequired": true,
+        "maximumHeadAgeSeconds": 300,
+        "healthRoute": {
+          "path": "app/api/ops/health/route.ts",
+          "sha256": "fda037f55c3c633a860c11eb65a160eaffc77e66489f803e9933ad3b02926f3f"
+        },
+        "rpcRuntime": {
+          "path": "lib/onchain/rpc-health.ts",
+          "sha256": "4c8e5fb0f879ef72f2e8d742886b61b004de55fc59a440ef34893b352c33f865"
+        }
+      }
     },
     "closedAlias": {
       "path": "/api/ops/index",

--- a/docs/operations/read-model-scheduler-cutover.md
+++ b/docs/operations/read-model-scheduler-cutover.md
@@ -22,10 +22,16 @@ concurrency group prevents two watchdog runs from overlapping.
 
 The watchdog succeeds only after the public health route exposes a durable
 snapshot at the same or a newer block, no more than ten minutes old, while the
-Ethereum RPC read and independent quorum are healthy. The target origin is
+Ethereum RPC read and independent quorum are healthy. It additionally requires
+the concrete nonzero hash of an RPC-confirmed block at or beyond the durable
+snapshot, plus both independent provider heads at or beyond that confirmed
+block and no more than five minutes old. A status-only quorum response is not
+accepted. The target origin is
 fixed in reviewed source, redirects and oversized or non-JSON responses are
-rejected, and no Vercel token or deployment-protection bypass is available to
-the job. This repairs delivery of the existing generic public read model; it
+rejected, and the exact health route plus its dual-RPC implementation are
+content-bound in the operations manifest. No Vercel token or
+deployment-protection bypass is available to the job. This repairs delivery of
+the existing generic public read model; it
 does not activate the staged Postgres projectors, promote a deployment, or
 publish any third-party submission.
 

--- a/docs/operations/read-model-scheduler-cutover.md
+++ b/docs/operations/read-model-scheduler-cutover.md
@@ -13,6 +13,22 @@ during backfill and parity checks.
 | Market projector | `/api/ops/market-projector` | Every minute | `PROGRAMMABLE_MARKET_PROJECTOR_ACTIVE=true` |
 | QuickNode stream wake | `POST /api/ops/projector-wake` | Every delivered block | `PROGRAMMABLE_QUICKNODE_STREAM_SECRET` configured |
 
+The legacy index also has a GitHub Actions watchdog at minutes `2-57/5` on
+the protected `production` branch. It calls the same canonical
+`/api/ops/index-v2` route on `https://programmable.market` with the existing
+`CRON_SECRET`; it is not a second writer implementation. The offset avoids
+deliberately duplicating the nominal Vercel invocation, while the workflow
+concurrency group prevents two watchdog runs from overlapping.
+
+The watchdog succeeds only after the public health route exposes a durable
+snapshot at the same or a newer block, no more than ten minutes old, while the
+Ethereum RPC read and independent quorum are healthy. The target origin is
+fixed in reviewed source, redirects and oversized or non-JSON responses are
+rejected, and no Vercel token or deployment-protection bypass is available to
+the job. This repairs delivery of the existing generic public read model; it
+does not activate the staged Postgres projectors, promote a deployment, or
+publish any third-party submission.
+
 Each projector has its own singleton execution guard. A second invocation
 returns busy instead of overlapping an unfinished run. The market projector
 only reads the last fully committed source checkpoint, never in-flight source

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -15,7 +15,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       provider: "github-actions",
       workflow: Object.freeze({
         path: ".github/workflows/refresh-production-read-model.yml",
-        sha256: "7fbaef1b69b72a1d75c3fb876b2fb4961a10e177623d2c15f138978c03568355",
+        sha256: "e4dd949194ef4046382e9930fe66bd3f63195578b63ed970b0e9ae2a421d2a9d",
       }),
       schedule: "2-57/5 * * * *",
       targetOrigin: "https://programmable.market",
@@ -23,6 +23,19 @@ const APPROVED_OPERATIONS = Object.freeze({
       secretEnvironment: "CRON_SECRET",
       concurrencyGroup: "production-read-model-refresh",
       freshnessMaximumAgeSeconds: 600,
+      rpcProof: Object.freeze({
+        confirmedBlockRequired: true,
+        providerPairRequired: true,
+        maximumHeadAgeSeconds: 300,
+        healthRoute: Object.freeze({
+          path: "app/api/ops/health/route.ts",
+          sha256: "fda037f55c3c633a860c11eb65a160eaffc77e66489f803e9933ad3b02926f3f",
+        }),
+        rpcRuntime: Object.freeze({
+          path: "lib/onchain/rpc-health.ts",
+          sha256: "4c8e5fb0f879ef72f2e8d742886b61b004de55fc59a440ef34893b352c33f865",
+        }),
+      }),
     }),
     closedAlias: Object.freeze({
       path: "/api/ops/index",
@@ -767,9 +780,14 @@ function routeIsPermanentlyClosed(source, binding) {
   );
 }
 
-function legacySchedulerWatchdogIsFailClosed(source, binding) {
+function legacySchedulerWatchdogIsFailClosed(
+  workflowSource,
+  binding,
+  source,
+  expectedSha256Overrides,
+) {
   return (
-    typeof source === "string" &&
+    typeof workflowSource === "string" &&
     binding?.provider === "github-actions" &&
     binding.schedule === "2-57/5 * * * *" &&
     binding.targetOrigin === "https://programmable.market" &&
@@ -777,48 +795,62 @@ function legacySchedulerWatchdogIsFailClosed(source, binding) {
     binding.secretEnvironment === "CRON_SECRET" &&
     binding.concurrencyGroup === "production-read-model-refresh" &&
     binding.freshnessMaximumAgeSeconds === 600 &&
-    source.includes('name: Refresh production read model') &&
-    source.includes('    - cron: "2-57/5 * * * *"') &&
-    source.includes("  workflow_dispatch:") &&
-    source.includes("permissions:\n  contents: read") &&
-    source.includes("  group: production-read-model-refresh") &&
-    source.includes("  cancel-in-progress: false") &&
-    source.includes("github.repository == '0xprogrammable/programmable'") &&
-    source.includes("github.ref == 'refs/heads/production'") &&
-    source.includes("    timeout-minutes: 9") &&
-    source.includes("      name: production") &&
-    source.includes("CRON_SECRET: ${{ secrets.CRON_SECRET }}") &&
-    source.includes("TARGET_ORIGIN: https://programmable.market") &&
-    source.includes('targetOrigin !== "https://programmable.market"') &&
-    source.includes("secretBytes < 32") &&
-    source.includes("secretBytes > 1_024") &&
-    source.includes('/[\\r\\n]/u.test(cronSecret ?? "")') &&
-    source.includes('"/api/ops/index-v2"') &&
-    source.includes("headers.authorization = `Bearer ${cronSecret}`") &&
-    source.includes('redirect: "error"') &&
-    source.includes("signal: AbortSignal.timeout(timeoutMs)") &&
-    source.includes("const MAXIMUM_JSON_BYTES = 64 * 1024") &&
-    source.includes("bytes > MAXIMUM_JSON_BYTES") &&
-    source.includes("refresh.response.status !== 200") &&
-    source.includes('includes("no-store")') &&
-    source.includes("refresh.body?.ok !== true") &&
-    source.includes("refresh.body.portfolioHistory.blockNumber !==") &&
-    source.includes("refresh.body.portfolioHistory.tokenCount !==") &&
-    source.includes('refresh.body.portfolioHistory.status === "empty"') &&
-    source.includes("health.response.status === 200") &&
-    source.includes('health.body?.status === "healthy"') &&
-    source.includes('health.body.indexSource === "durable"') &&
-    source.includes('health.body.indexedReadModel?.status === "disabled"') &&
-    source.includes("healthBlock >= refreshBlock") &&
-    source.includes("index.ageSeconds <= MAXIMUM_FRESH_AGE_SECONDS") &&
-    source.includes('health.body.rpc?.status === "healthy"') &&
-    source.includes('health.body.rpc?.read?.status === "available"') &&
-    source.includes('health.body.rpc?.quorum?.status === "verified"') &&
-    !source.includes("actions/checkout") &&
-    !source.includes("VERCEL_TOKEN") &&
-    !source.includes("VERCEL_AUTOMATION_BYPASS_SECRET") &&
-    !source.includes("pull_request") &&
-    !source.includes("contents: write")
+    binding.rpcProof?.confirmedBlockRequired === true &&
+    binding.rpcProof?.providerPairRequired === true &&
+    binding.rpcProof?.maximumHeadAgeSeconds === 300 &&
+    sourceBindingMatches(source, binding.rpcProof?.healthRoute, expectedSha256Overrides) &&
+    sourceBindingMatches(source, binding.rpcProof?.rpcRuntime, expectedSha256Overrides) &&
+    workflowSource.includes('name: Refresh production read model') &&
+    workflowSource.includes('    - cron: "2-57/5 * * * *"') &&
+    workflowSource.includes("  workflow_dispatch:") &&
+    workflowSource.includes("permissions: {}") &&
+    workflowSource.includes("  group: production-read-model-refresh") &&
+    workflowSource.includes("  cancel-in-progress: false") &&
+    workflowSource.includes("github.repository == '0xprogrammable/programmable'") &&
+    workflowSource.includes("github.ref == 'refs/heads/production'") &&
+    workflowSource.includes("    timeout-minutes: 9") &&
+    workflowSource.includes("      name: production") &&
+    workflowSource.includes("CRON_SECRET: ${{ secrets.CRON_SECRET }}") &&
+    workflowSource.includes("TARGET_ORIGIN: https://programmable.market") &&
+    workflowSource.includes('targetOrigin !== "https://programmable.market"') &&
+    workflowSource.includes("secretBytes < 32") &&
+    workflowSource.includes("secretBytes > 1_024") &&
+    workflowSource.includes('/[\\r\\n]/u.test(cronSecret ?? "")') &&
+    workflowSource.includes('"/api/ops/index-v2"') &&
+    workflowSource.includes("headers.authorization = `Bearer ${cronSecret}`") &&
+    workflowSource.includes('redirect: "error"') &&
+    workflowSource.includes("signal: AbortSignal.timeout(timeoutMs)") &&
+    workflowSource.includes("const MAXIMUM_JSON_BYTES = 64 * 1024") &&
+    workflowSource.includes("bytes > MAXIMUM_JSON_BYTES") &&
+    workflowSource.includes("refresh.response.status !== 200") &&
+    workflowSource.includes('includes("no-store")') &&
+    workflowSource.includes("refresh.body?.ok !== true") &&
+    workflowSource.includes("refresh.body.portfolioHistory.blockNumber !==") &&
+    workflowSource.includes("refresh.body.portfolioHistory.tokenCount !==") &&
+    workflowSource.includes('refresh.body.portfolioHistory.status === "empty"') &&
+    workflowSource.includes("health.response.status === 200") &&
+    workflowSource.includes('health.body?.status === "healthy"') &&
+    workflowSource.includes('health.body.indexSource === "durable"') &&
+    workflowSource.includes('health.body.indexedReadModel?.status === "disabled"') &&
+    workflowSource.includes("healthBlock >= refreshBlock") &&
+    workflowSource.includes("index.ageSeconds <= MAXIMUM_FRESH_AGE_SECONDS") &&
+    workflowSource.includes('rpc?.status === "healthy"') &&
+    workflowSource.includes('rpc?.read?.status === "available"') &&
+    workflowSource.includes('rpc?.quorum?.status === "verified"') &&
+    workflowSource.includes("confirmedBlockNumber >= healthBlock") &&
+    workflowSource.includes("confirmedBlockNumber >= refreshBlock") &&
+    workflowSource.includes("HEX32.test(confirmedBlock?.hash)") &&
+    workflowSource.includes('confirmedBlock.hash !== `0x${"00".repeat(32)}`') &&
+    workflowSource.includes('rpc?.freshness?.maxHeadAgeSeconds === 300') &&
+    workflowSource.includes('primary?.status === "available"') &&
+    workflowSource.includes('secondary?.status === "available"') &&
+    workflowSource.includes("primaryHead >= confirmedBlockNumber") &&
+    workflowSource.includes("secondaryHead >= confirmedBlockNumber") &&
+    !workflowSource.includes("actions/checkout") &&
+    !workflowSource.includes("VERCEL_TOKEN") &&
+    !workflowSource.includes("VERCEL_AUTOMATION_BYPASS_SECRET") &&
+    !workflowSource.includes("pull_request") &&
+    !workflowSource.includes("contents: write")
   );
 }
 
@@ -1222,6 +1254,8 @@ export function evaluateReadModelOperationsSourceContracts(
       legacySchedulerWatchdogIsFailClosed(
         source(APPROVED_OPERATIONS.legacyIndexer.schedulerWatchdog.workflow.path),
         schedulerWatchdog,
+        source,
+        expectedSha256Overrides,
       ),
     "the generic GitHub watchdog refreshes only the public durable read model and proves freshness plus RPC quorum",
   );

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -11,6 +11,19 @@ const APPROVED_OPERATIONS = Object.freeze({
     retainedUntil: "indexed-read-cutover",
     route: "app/api/ops/index-v2/route.ts",
     sha256: "38593eaa836e88400311e8a585079a6a81fa84f115d93a72a6ac0fefa01cef43",
+    schedulerWatchdog: Object.freeze({
+      provider: "github-actions",
+      workflow: Object.freeze({
+        path: ".github/workflows/refresh-production-read-model.yml",
+        sha256: "7fbaef1b69b72a1d75c3fb876b2fb4961a10e177623d2c15f138978c03568355",
+      }),
+      schedule: "2-57/5 * * * *",
+      targetOrigin: "https://programmable.market",
+      environment: "production",
+      secretEnvironment: "CRON_SECRET",
+      concurrencyGroup: "production-read-model-refresh",
+      freshnessMaximumAgeSeconds: 600,
+    }),
     closedAlias: Object.freeze({
       path: "/api/ops/index",
       route: "app/api/ops/index/route.ts",
@@ -754,6 +767,61 @@ function routeIsPermanentlyClosed(source, binding) {
   );
 }
 
+function legacySchedulerWatchdogIsFailClosed(source, binding) {
+  return (
+    typeof source === "string" &&
+    binding?.provider === "github-actions" &&
+    binding.schedule === "2-57/5 * * * *" &&
+    binding.targetOrigin === "https://programmable.market" &&
+    binding.environment === "production" &&
+    binding.secretEnvironment === "CRON_SECRET" &&
+    binding.concurrencyGroup === "production-read-model-refresh" &&
+    binding.freshnessMaximumAgeSeconds === 600 &&
+    source.includes('name: Refresh production read model') &&
+    source.includes('    - cron: "2-57/5 * * * *"') &&
+    source.includes("  workflow_dispatch:") &&
+    source.includes("permissions:\n  contents: read") &&
+    source.includes("  group: production-read-model-refresh") &&
+    source.includes("  cancel-in-progress: false") &&
+    source.includes("github.repository == '0xprogrammable/programmable'") &&
+    source.includes("github.ref == 'refs/heads/production'") &&
+    source.includes("    timeout-minutes: 9") &&
+    source.includes("      name: production") &&
+    source.includes("CRON_SECRET: ${{ secrets.CRON_SECRET }}") &&
+    source.includes("TARGET_ORIGIN: https://programmable.market") &&
+    source.includes('targetOrigin !== "https://programmable.market"') &&
+    source.includes("secretBytes < 32") &&
+    source.includes("secretBytes > 1_024") &&
+    source.includes('/[\\r\\n]/u.test(cronSecret ?? "")') &&
+    source.includes('"/api/ops/index-v2"') &&
+    source.includes("headers.authorization = `Bearer ${cronSecret}`") &&
+    source.includes('redirect: "error"') &&
+    source.includes("signal: AbortSignal.timeout(timeoutMs)") &&
+    source.includes("const MAXIMUM_JSON_BYTES = 64 * 1024") &&
+    source.includes("bytes > MAXIMUM_JSON_BYTES") &&
+    source.includes("refresh.response.status !== 200") &&
+    source.includes('includes("no-store")') &&
+    source.includes("refresh.body?.ok !== true") &&
+    source.includes("refresh.body.portfolioHistory.blockNumber !==") &&
+    source.includes("refresh.body.portfolioHistory.tokenCount !==") &&
+    source.includes('refresh.body.portfolioHistory.status === "empty"') &&
+    source.includes("health.response.status === 200") &&
+    source.includes('health.body?.status === "healthy"') &&
+    source.includes('health.body.indexSource === "durable"') &&
+    source.includes('health.body.indexedReadModel?.status === "disabled"') &&
+    source.includes("healthBlock >= refreshBlock") &&
+    source.includes("index.ageSeconds <= MAXIMUM_FRESH_AGE_SECONDS") &&
+    source.includes('health.body.rpc?.status === "healthy"') &&
+    source.includes('health.body.rpc?.read?.status === "available"') &&
+    source.includes('health.body.rpc?.quorum?.status === "verified"') &&
+    !source.includes("actions/checkout") &&
+    !source.includes("VERCEL_TOKEN") &&
+    !source.includes("VERCEL_AUTOMATION_BYPASS_SECRET") &&
+    !source.includes("pull_request") &&
+    !source.includes("contents: write")
+  );
+}
+
 function activationIsExplicitAndSafe(source, environmentName) {
   return (
     typeof source === "string" &&
@@ -1138,6 +1206,24 @@ export function evaluateReadModelOperationsSourceContracts(
           expectedSha256Overrides,
         ),
     "the five-minute legacy route remains byte-bound until indexed-read cutover",
+  );
+  const schedulerWatchdog = operations?.legacyIndexer?.schedulerWatchdog;
+  check(
+    "ops-legacy-scheduler-watchdog",
+    exactJson(
+      schedulerWatchdog,
+      APPROVED_OPERATIONS.legacyIndexer.schedulerWatchdog,
+    ) &&
+      sourceBindingMatches(
+        source,
+        schedulerWatchdog?.workflow,
+        expectedSha256Overrides,
+      ) &&
+      legacySchedulerWatchdogIsFailClosed(
+        source(APPROVED_OPERATIONS.legacyIndexer.schedulerWatchdog.workflow.path),
+        schedulerWatchdog,
+      ),
+    "the generic GitHub watchdog refreshes only the public durable read model and proves freshness plus RPC quorum",
   );
   const closedLegacyAlias = APPROVED_OPERATIONS.legacyIndexer.closedAlias;
   check(

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -194,6 +194,58 @@ const SAFE_MARKET_ACTIVATION = `
   }
 `;
 
+function watchdogProgram() {
+  const workflow = readFileSync(
+    resolve(ROOT, ".github/workflows/refresh-production-read-model.yml"),
+    "utf8",
+  );
+  const startMarker = "          node --input-type=module <<'NODE'\n";
+  const endMarker = "\n          NODE\n";
+  const start = workflow.indexOf(startMarker);
+  const end = workflow.indexOf(endMarker, start + startMarker.length);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  const inlineProgram = workflow
+    .slice(start + startMarker.length, end)
+    .replace(
+      '          import { appendFile } from "node:fs/promises";',
+      "          const appendFile = async () => undefined;",
+    );
+  const AsyncFunction = Object.getPrototypeOf(async () => undefined)
+    .constructor as new (...args: string[]) => (...values: unknown[]) => Promise<void>;
+  return new AsyncFunction(
+    "process",
+    "fetch",
+    "Buffer",
+    "AbortSignal",
+    "URL",
+    "setTimeout",
+    "console",
+    inlineProgram,
+  );
+}
+
+function watchdogProcessEnvironment() {
+  return {
+    env: {
+      TARGET_ORIGIN: "https://programmable.market",
+      CRON_SECRET: "test-production-cron-secret-32-characters",
+      SCHEDULER_RUN_ID: "1234",
+      SCHEDULER_RUN_ATTEMPT: "1",
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/json; charset=utf-8",
+    },
+  });
+}
+
 const PROVIDER_EVIDENCE_MIGRATION = `
   create table programmable_private.projection_provider_execution_evidence();
   create table programmable_private.reward_snapshot_provider_evidence();
@@ -239,6 +291,155 @@ function fixtureDigests() {
 }
 
 describe("read-model operations source contract", () => {
+  it("executes the exact watchdog program only after block-bound freshness and quorum proof", async () => {
+    const requests: Array<{ authorization: string | null; url: string }> = [];
+    const fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const headers = new Headers(init?.headers);
+      requests.push({
+        authorization: headers.get("authorization"),
+        url,
+      });
+      if (url.endsWith("/api/ops/index-v2")) {
+        return jsonResponse({
+          ok: true,
+          blockNumber: "25740000",
+          tokenCount: 343,
+          updated: true,
+          portfolioHistory: {
+            status: "recorded",
+            blockNumber: "25740000",
+            tokenCount: 343,
+            path: "portfolio-history/1/2026-08-13T05.json",
+          },
+        });
+      }
+      return jsonResponse({
+        status: "healthy",
+        chainId: 1,
+        index: {
+          ageSeconds: 2,
+          blockNumber: "25740001",
+          tokenCount: 343,
+        },
+        indexSource: "durable",
+        indexedReadModel: { status: "disabled" },
+        rpc: {
+          status: "healthy",
+          chainId: 1,
+          read: { status: "available" },
+          quorum: { status: "verified" },
+        },
+      });
+    };
+    const logged: string[] = [];
+    await watchdogProgram()(
+      watchdogProcessEnvironment(),
+      fetch,
+      Buffer,
+      AbortSignal,
+      URL,
+      setTimeout,
+      { log: (value: string) => logged.push(value) },
+    );
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.url).toBe(
+      "https://programmable.market/api/ops/index-v2",
+    );
+    expect(requests[0]?.authorization).toBe(
+      "Bearer test-production-cron-secret-32-characters",
+    );
+    expect(requests[1]?.url).toContain(
+      "https://programmable.market/api/ops/health?scheduler_proof=1234-1-1",
+    );
+    expect(requests[1]?.authorization).toBeNull();
+    expect(JSON.parse(logged.at(-1) ?? "{}")).toMatchObject({
+      refreshBlockNumber: "25740000",
+      visibleBlockNumber: "25740001",
+      ageSeconds: 2,
+    });
+  });
+
+  it("executes the exact watchdog program fail-closed on stale public health", async () => {
+    let attempts = 0;
+    const fetch = async (input: string | URL | Request) => {
+      if (String(input).endsWith("/api/ops/index-v2")) {
+        return jsonResponse({
+          ok: true,
+          blockNumber: "25740000",
+          tokenCount: 343,
+          updated: false,
+          portfolioHistory: {
+            status: "already-recorded",
+            blockNumber: "25740000",
+            tokenCount: 343,
+            path: "portfolio-history/1/2026-08-13T05.json",
+          },
+        });
+      }
+      attempts += 1;
+      return jsonResponse({
+        status: "healthy",
+        chainId: 1,
+        index: {
+          ageSeconds: 601,
+          blockNumber: "25740000",
+          tokenCount: 343,
+        },
+        indexSource: "durable",
+        indexedReadModel: { status: "disabled" },
+        rpc: {
+          status: "healthy",
+          chainId: 1,
+          read: { status: "available" },
+          quorum: { status: "verified" },
+        },
+      });
+    };
+    await expect(
+      watchdogProgram()(
+        watchdogProcessEnvironment(),
+        fetch,
+        Buffer,
+        AbortSignal,
+        URL,
+        (callback: () => void) => {
+          callback();
+          return 0;
+        },
+        { log: () => undefined },
+      ),
+    ).rejects.toThrow("production read-model freshness proof failed");
+    expect(attempts).toBe(18);
+  });
+
+  it("executes the exact watchdog program fail-closed on unbound portfolio history", async () => {
+    const fetch = async () =>
+      jsonResponse({
+        ok: true,
+        blockNumber: "25740000",
+        tokenCount: 343,
+        updated: true,
+        portfolioHistory: {
+          status: "recorded",
+          blockNumber: "25739999",
+          tokenCount: 343,
+          path: "portfolio-history/1/2026-08-13T05.json",
+        },
+      });
+    await expect(
+      watchdogProgram()(
+        watchdogProcessEnvironment(),
+        fetch,
+        Buffer,
+        AbortSignal,
+        URL,
+        setTimeout,
+        { log: () => undefined },
+      ),
+    ).rejects.toThrow("production read-model refresh failed (200)");
+  });
+
   it("binds the per-minute schedulers, activation gates and release workflow", () => {
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: integratedOverrides(),
@@ -313,6 +514,65 @@ describe("read-model operations source contract", () => {
         "ops-market-projector-activation",
         "ops-reconciler-unscheduled",
       ]),
+    );
+  });
+
+  it.each([
+    ["unprotected branch", "github.ref == 'refs/heads/production'"],
+    ["fixed public origin", 'targetOrigin !== "https://programmable.market"'],
+    ["bounded cron secret", "secretBytes < 32"],
+    ["canonical writer route", '"/api/ops/index-v2"'],
+    ["no-store writer response", 'includes("no-store")'],
+    [
+      "portfolio history block binding",
+      "refresh.body.portfolioHistory.blockNumber !==",
+    ],
+    ["durable public source", 'health.body.indexSource === "durable"'],
+    ["visible block binding", "healthBlock >= refreshBlock"],
+    ["freshness ceiling", "index.ageSeconds <= MAXIMUM_FRESH_AGE_SECONDS"],
+    ["healthy RPC read", 'health.body.rpc?.read?.status === "available"'],
+    ["verified RPC quorum", 'health.body.rpc?.quorum?.status === "verified"'],
+  ])("rejects a production watchdog missing %s", (_label, needle) => {
+    const workflowPath =
+      ".github/workflows/refresh-production-read-model.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    expect(workflow).toContain(needle);
+    const unsafeWorkflow = workflow.replace(needle, "REMOVED_WATCHDOG_GATE");
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-legacy-scheduler-watchdog",
+    );
+  });
+
+  it.each([
+    ["repository checkout", "      - uses: actions/checkout@v5\n"],
+    ["Vercel account credential", "          VERCEL_TOKEN: unsafe\n"],
+    [
+      "deployment protection bypass",
+      "          VERCEL_AUTOMATION_BYPASS_SECRET: unsafe\n",
+    ],
+    ["write permission", "  contents: write\n"],
+    ["pull-request trigger", "  pull_request:\n"],
+  ])("rejects watchdog privilege expansion through %s", (_label, addition) => {
+    const workflowPath =
+      ".github/workflows/refresh-production-read-model.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const unsafeWorkflow = `${workflow}\n${addition}`;
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-legacy-scheduler-watchdog",
     );
   });
 

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -328,7 +328,24 @@ describe("read-model operations source contract", () => {
           status: "healthy",
           chainId: 1,
           read: { status: "available" },
+          providers: {
+            primary: {
+              status: "available",
+              head: "25740014",
+              headAgeSeconds: 3,
+            },
+            secondary: {
+              status: "available",
+              head: "25740013",
+              headAgeSeconds: 4,
+            },
+          },
+          freshness: { maxHeadAgeSeconds: 300 },
           quorum: { status: "verified" },
+          confirmedBlock: {
+            number: "25740012",
+            hash: `0x${"12".repeat(32)}`,
+          },
         },
       });
     };
@@ -356,8 +373,105 @@ describe("read-model operations source contract", () => {
     expect(JSON.parse(logged.at(-1) ?? "{}")).toMatchObject({
       refreshBlockNumber: "25740000",
       visibleBlockNumber: "25740001",
+      confirmedBlockNumber: "25740012",
+      confirmedBlockHash: `0x${"12".repeat(32)}`,
       ageSeconds: 2,
     });
+  });
+
+  it.each([
+    ["missing confirmed block", (rpc: Record<string, unknown>) => {
+      const { confirmedBlock: _removed, ...remaining } = rpc;
+      return remaining;
+    }],
+    ["zero confirmed block hash", (rpc: Record<string, unknown>) => ({
+      ...rpc,
+      confirmedBlock: { number: "25740012", hash: `0x${"00".repeat(32)}` },
+    })],
+    ["confirmed block behind visible index", (rpc: Record<string, unknown>) => ({
+      ...rpc,
+      confirmedBlock: { number: "25740000", hash: `0x${"12".repeat(32)}` },
+    })],
+    ["secondary provider behind confirmed block", (rpc: Record<string, unknown>) => ({
+      ...rpc,
+      providers: {
+        ...(rpc.providers as Record<string, unknown>),
+        secondary: {
+          status: "available",
+          head: "25740011",
+          headAgeSeconds: 4,
+        },
+      },
+    })],
+  ])("fails closed on %s", async (_label, mutateRpc) => {
+    let attempts = 0;
+    const validRpc = {
+      status: "healthy",
+      chainId: 1,
+      read: { status: "available" },
+      providers: {
+        primary: {
+          status: "available",
+          head: "25740014",
+          headAgeSeconds: 3,
+        },
+        secondary: {
+          status: "available",
+          head: "25740013",
+          headAgeSeconds: 4,
+        },
+      },
+      freshness: { maxHeadAgeSeconds: 300 },
+      quorum: { status: "verified" },
+      confirmedBlock: {
+        number: "25740012",
+        hash: `0x${"12".repeat(32)}`,
+      },
+    };
+    const fetch = async (input: string | URL | Request) => {
+      if (String(input).endsWith("/api/ops/index-v2")) {
+        return jsonResponse({
+          ok: true,
+          blockNumber: "25740000",
+          tokenCount: 343,
+          updated: true,
+          portfolioHistory: {
+            status: "recorded",
+            blockNumber: "25740000",
+            tokenCount: 343,
+            path: "portfolio-history/1/2026-08-13T05.json",
+          },
+        });
+      }
+      attempts += 1;
+      return jsonResponse({
+        status: "healthy",
+        chainId: 1,
+        index: {
+          ageSeconds: 2,
+          blockNumber: "25740001",
+          tokenCount: 343,
+        },
+        indexSource: "durable",
+        indexedReadModel: { status: "disabled" },
+        rpc: mutateRpc(validRpc),
+      });
+    };
+    await expect(
+      watchdogProgram()(
+        watchdogProcessEnvironment(),
+        fetch,
+        Buffer,
+        AbortSignal,
+        URL,
+        (callback: () => void) => {
+          callback();
+          return 0;
+        },
+        { log: () => undefined },
+      ),
+    ).rejects.toThrow("production read-model freshness proof failed");
+    expect(attempts).toBe(18);
   });
 
   it("executes the exact watchdog program fail-closed on stale public health", async () => {
@@ -530,8 +644,12 @@ describe("read-model operations source contract", () => {
     ["durable public source", 'health.body.indexSource === "durable"'],
     ["visible block binding", "healthBlock >= refreshBlock"],
     ["freshness ceiling", "index.ageSeconds <= MAXIMUM_FRESH_AGE_SECONDS"],
-    ["healthy RPC read", 'health.body.rpc?.read?.status === "available"'],
-    ["verified RPC quorum", 'health.body.rpc?.quorum?.status === "verified"'],
+    ["healthy RPC read", 'rpc?.read?.status === "available"'],
+    ["verified RPC quorum", 'rpc?.quorum?.status === "verified"'],
+    ["confirmed RPC block number", "confirmedBlockNumber >= healthBlock"],
+    ["confirmed RPC block hash", "HEX32.test(confirmedBlock?.hash)"],
+    ["primary provider head", "primaryHead >= confirmedBlockNumber"],
+    ["secondary provider head", "secondaryHead >= confirmedBlockNumber"],
   ])("rejects a production watchdog missing %s", (_label, needle) => {
     const workflowPath =
       ".github/workflows/refresh-production-read-model.yml";
@@ -568,6 +686,22 @@ describe("read-model operations source contract", () => {
       sourceOverrides: {
         ...integratedOverrides(),
         [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-legacy-scheduler-watchdog",
+    );
+  });
+
+  it.each([
+    ["health route", "app/api/ops/health/route.ts"],
+    ["RPC health runtime", "lib/onchain/rpc-health.ts"],
+  ])("rejects unreviewed %s bytes", (_label, path) => {
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [path]: `${readFileSync(resolve(ROOT, path), "utf8")}\n// drift`,
       },
       expectedSha256Overrides: fixtureDigests(),
     });


### PR DESCRIPTION
## Outcome

Adds a candidate-neutral production watchdog that refreshes the public read model every five minutes and fails closed unless the public health response proves freshness and two-provider RPC agreement.

## Safety boundary

- fixed `https://programmable.market` target
- `production` environment and ref only
- `CRON_SECRET` only; no checkout, Vercel token, bypass token, or write permissions
- exact health-route and RPC-runtime source digests
- confirmed block must have a nonzero canonical hash, be at or ahead of the visible refresh block, and be supported by both fresh provider heads
- no applicant, Shards, Hookemon, approval, signing, funds, or publication authority

## Evidence

- independent exact-head audit: GO, no P0/P1
- focused watchdog/source-contract tests: 468/468
- operations gate: 40/40
- actionlint: pass
- typecheck: pass
- complete `npm run verify`: pass, including 3,280 interface tests, DB/runtime gates, and Next.js production build

The existing Vercel cron path remains in place as a secondary liveness mechanism.
