### PR TITLE
Harden production read-model RPC retries

### DIFF
--- a/app/api/ops/index-v2/route.ts
+++ b/app/api/ops/index-v2/route.ts
@@ -13,23 +13,31 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 export const runtime = "nodejs";
 
-const INDEX_READ_ATTEMPTS = 2;
+const INDEX_READ_ATTEMPTS = 4;
+const INDEX_READ_RETRY_DELAY_MS = 1_500;
 
 function errorClassChain(error: unknown) {
-  const names: string[] = [];
+  const classes: Array<{ name: string; code?: number }> = [];
   const seen = new Set<unknown>();
   let current = error;
-  while (current && !seen.has(current) && names.length < 6) {
+  while (current && !seen.has(current) && classes.length < 6) {
     seen.add(current);
-    names.push(
-      current instanceof Error ? current.name : "UnknownIndexError",
-    );
+    const code =
+      typeof current === "object" &&
+        "code" in current &&
+        typeof (current as { code?: unknown }).code === "number"
+        ? (current as { code: number }).code
+        : undefined;
+    classes.push({
+      name: current instanceof Error ? current.name : "UnknownIndexError",
+      ...(code === undefined ? {} : { code }),
+    });
     current =
       typeof current === "object" && "cause" in current
         ? (current as { cause?: unknown }).cause
         : undefined;
   }
-  return names;
+  return classes;
 }
 
 function isAuthorized(request: NextRequest) {
@@ -90,6 +98,9 @@ export async function GET(request: NextRequest) {
               error instanceof Error ? error.name : "UnknownIndexError",
             errorClassChain: errorClassChain(error),
           });
+          await new Promise((resolve) =>
+            setTimeout(resolve, INDEX_READ_RETRY_DELAY_MS * attempt),
+          );
         }
       }
     }

--- a/app/api/ops/index-v2/route.ts
+++ b/app/api/ops/index-v2/route.ts
@@ -98,9 +98,11 @@ export async function GET(request: NextRequest) {
               error instanceof Error ? error.name : "UnknownIndexError",
             errorClassChain: errorClassChain(error),
           });
-          await new Promise((resolve) =>
-            setTimeout(resolve, INDEX_READ_RETRY_DELAY_MS * attempt),
-          );
+          if (attempt < INDEX_READ_ATTEMPTS) {
+            await new Promise((resolve) =>
+              setTimeout(resolve, INDEX_READ_RETRY_DELAY_MS * attempt),
+            );
+          }
         }
       }
     }

--- a/app/api/ops/index-v2/route.ts
+++ b/app/api/ops/index-v2/route.ts
@@ -15,6 +15,23 @@ export const runtime = "nodejs";
 
 const INDEX_READ_ATTEMPTS = 2;
 
+function errorClassChain(error: unknown) {
+  const names: string[] = [];
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current && !seen.has(current) && names.length < 6) {
+    seen.add(current);
+    names.push(
+      current instanceof Error ? current.name : "UnknownIndexError",
+    );
+    current =
+      typeof current === "object" && "cause" in current
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+  return names;
+}
+
 function isAuthorized(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
   const authorization = request.headers.get("authorization");
@@ -71,6 +88,7 @@ export async function GET(request: NextRequest) {
             attempt,
             errorName:
               error instanceof Error ? error.name : "UnknownIndexError",
+            errorClassChain: errorClassChain(error),
           });
         }
       }
@@ -118,6 +136,7 @@ export async function GET(request: NextRequest) {
     console.error("Programmable index refresh failed", {
       errorName:
         error instanceof Error ? error.name : "UnknownIndexError",
+      errorClassChain: errorClassChain(error),
       durationMs: Date.now() - startedAt,
     });
     return NextResponse.json(

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -5,7 +5,7 @@
     "schedule": "*/5 * * * *",
     "retainedUntil": "indexed-read-cutover",
     "route": "app/api/ops/index-v2/route.ts",
-    "sha256": "38593eaa836e88400311e8a585079a6a81fa84f115d93a72a6ac0fefa01cef43",
+    "sha256": "2d0731780d7c1eba7bbb087ffabb751f1e948783d84954c4041a9f342abcfce0",
     "schedulerWatchdog": {
       "provider": "github-actions",
       "workflow": {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -10,7 +10,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     schedule: "*/5 * * * *",
     retainedUntil: "indexed-read-cutover",
     route: "app/api/ops/index-v2/route.ts",
-    sha256: "38593eaa836e88400311e8a585079a6a81fa84f115d93a72a6ac0fefa01cef43",
+    sha256: "2d0731780d7c1eba7bbb087ffabb751f1e948783d84954c4041a9f342abcfce0",
     schedulerWatchdog: Object.freeze({
       provider: "github-actions",
       workflow: Object.freeze({

--- a/tests/data-pipeline/legacy-index-ops-route.test.ts
+++ b/tests/data-pipeline/legacy-index-ops-route.test.ts
@@ -53,6 +53,7 @@ describe("legacy index operations routes", () => {
 
   afterEach(() => {
     delete process.env.CRON_SECRET;
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -88,6 +89,58 @@ describe("legacy index operations routes", () => {
     expect(mocks.readLiveExploreModel).toHaveBeenCalledTimes(1);
     expect(mocks.writeDurableExploreModel).toHaveBeenCalledTimes(1);
     expect(mocks.writePortfolioHistorySnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient read failures and persists only the successful model", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    mocks.readLiveExploreModel
+      .mockRejectedValueOnce(
+        Object.assign(new Error("sensitive provider response"), { code: 429 }),
+      )
+      .mockRejectedValueOnce(new Error("temporary provider failure"))
+      .mockRejectedValueOnce(new Error("temporary provider failure"))
+      .mockResolvedValueOnce({ status: "ready" });
+
+    const responsePromise = getCanonicalIndex(request());
+    await vi.runAllTimersAsync();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(mocks.readLiveExploreModel).toHaveBeenCalledTimes(4);
+    expect(mocks.writeDurableExploreModel).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Programmable index read will retry",
+      expect.objectContaining({
+        attempt: 1,
+        errorClassChain: expect.arrayContaining([
+          expect.objectContaining({ name: "Error", code: 429 }),
+        ]),
+      }),
+    );
+    expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain(
+      "sensitive provider response",
+    );
+  });
+
+  it("returns 503 after four failed reads without starting a write", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.readLiveExploreModel.mockRejectedValue(new Error("provider offline"));
+
+    const responsePromise = getCanonicalIndex(request());
+    await vi.runAllTimersAsync();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      error: "Index refresh failed",
+    });
+    expect(mocks.readLiveExploreModel).toHaveBeenCalledTimes(4);
+    expect(mocks.writeDurableExploreModel).not.toHaveBeenCalled();
   });
 
   it("keeps the old writer alias permanently closed", async () => {


### PR DESCRIPTION
## What changed

- retries transient production read-model RPC failures up to four times with bounded backoff
- logs only redacted error classes and numeric codes, never provider messages or endpoints
- avoids delaying the terminal failed attempt
- rebinds the operations manifest and verifier to the exact route bytes
- adds deterministic success-after-retry and terminal-failure tests

## Why

The production watchdog correctly exposed that the primary RPC was unavailable. The route previously made only two immediate attempts and provided too little redacted diagnostic context. This change makes transient failures observable and recoverable without weakening the two-provider quorum or the fail-closed `503` response.

This PR does not claim to fix the separate Alchemy account spending-cap incident or the underlying historical-rescan CU amplification. Those remain fail-closed and are being addressed independently.

## Validation

- `npm run verify` — passed
- interface suite: 285 files passed, 1 skipped; 3282 tests passed, 7 skipped
- contract release, database runtime, read-model smoke and operations gates — passed
- Next.js production build — passed
- focused operations tests — 473 passed
- TypeScript and `git diff --check` — passed
