### PR TITLE
Fix and verify live market data paths

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -602,23 +602,16 @@ jobs:
         env:
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          MAINNET_RPC_URL_A: ${{ secrets.MAINNET_RPC_URL_A }}
-          MAINNET_RPC_URL_B: ${{ secrets.MAINNET_RPC_URL_B }}
-          PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}
-          PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}
         run: |
           node --env-file=.vercel/.env.production.local --input-type=module <<'NODE'
           const { verifyCurrentPublicOnchainEvidenceV1 } = await import(
             "./scripts/perf/read-model-post-promotion.mjs"
           );
-          const { runtimeProductionProviderBindingsFromUrls } = await import(
-            "./scripts/perf/read-model-provider-binding.mjs"
-          );
-          const { verifyBitqueryGoldenMarketParityV1 } = await import(
+          const { verifyBitqueryGoldenMarketExecutionV1 } = await import(
             "./scripts/perf/bitquery-golden-market-parity.mjs"
           );
           const {
-            verifyBitqueryHistoricalGoldenReleaseV1,
+            verifyBitqueryHistoricalGoldenReleaseV2,
           } = await import(
             "./scripts/perf/bitquery-historical-release-gate.mjs"
           );
@@ -643,25 +636,9 @@ jobs:
           const currentPublicMarketSource =
             "stateview-chainlink+official-uniswap-v4-subgraph+bitquery";
           const independentRpcUrls = Object.freeze([
-            process.env.MAINNET_RPC_URL_A,
-            process.env.MAINNET_RPC_URL_B,
+            "https://ethereum-rpc.publicnode.com",
+            "https://rpc.mevblocker.io",
           ]);
-          const independentRpcBindings =
-            runtimeProductionProviderBindingsFromUrls({
-              ETHEREUM_RPC_URL: independentRpcUrls[0],
-              ETHEREUM_RPC_URL_B: independentRpcUrls[1],
-            });
-          for (const binding of independentRpcBindings) {
-            const expectedCommitment =
-              binding.vendorGroup === "alchemy"
-                ? process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT
-                : process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT;
-            if (binding.endpointCommitment !== expectedCommitment) {
-              throw new Error(
-                "staged independent RPC witness does not match its pinned production commitment",
-              );
-            }
-          }
           const minimumPublicFdvLiquidityUsdWad =
             10_000n * 10n ** 18n;
           const marketCapPageSize = 100;
@@ -1785,7 +1762,7 @@ jobs:
           ) {
             throw new Error("staged PCAN market valuation is not Bitquery-bound");
           }
-          const goldenParity = await verifyBitqueryGoldenMarketParityV1({
+          const goldenParity = await verifyBitqueryGoldenMarketExecutionV1({
             token: goldenDetail.token,
           });
           const goldenChart = await requestJson(
@@ -1885,14 +1862,14 @@ jobs:
             throw new Error("staged PCAN chart trade count is inconsistent");
           }
           const historicalGoldenRelease =
-            verifyBitqueryHistoricalGoldenReleaseV1({
+            verifyBitqueryHistoricalGoldenReleaseV2({
               detailToken: goldenDetail.token,
               chart: goldenChart,
               parity: goldenParity,
             });
           const historicalPaidPathVerified =
             historicalGoldenRelease.schemaVersion ===
-              "programmable.bitquery-historical-release.v1" &&
+              "programmable.bitquery-historical-release.v2" &&
             historicalGoldenRelease.tokenAddress === goldenTokenAddress &&
             historicalGoldenRelease.poolId === goldenPoolId &&
             historicalGoldenRelease.blockNumber ===

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -24,12 +24,15 @@ import {
 } from "../../../lib/explore-financial-data";
 import { readBitqueryTokenMarketDataV1 } from
   "../../../lib/market-data/bitquery.server";
+import { currentMarketOnchainDeployment } from
+  "../../../lib/market-data/current-market-rpc.server";
 import { hydrateMissingCanonicalTokenSupplyV1 } from
   "../../../lib/market-data/canonical-token-supply.server";
 import { exploreEntriesMarketIdentitiesV1 } from
   "../../../lib/market-data/explore-market-identities";
 import {
   CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
+  attachBitqueryMarketDataToValuedEntries,
   settleCurrentEvidenceSnapshot,
   type CurrentEvidenceSnapshotOutcome,
   valueExploreEntriesWithCurrentEvidence,
@@ -391,7 +394,7 @@ async function valueExplorePage(input: Readonly<{
     sort: ExploreSort;
   }>;
   signal: AbortSignal;
-  deployment: ReturnType<typeof getAlchemyOnchainDeployment>;
+  deployment: ReturnType<typeof currentMarketOnchainDeployment> | null;
   operationalSnapshot: Promise<CurrentEvidenceSnapshotOutcome>;
   currentEvidenceDeadlineAt: number;
 }>) {
@@ -405,6 +408,40 @@ async function valueExplorePage(input: Readonly<{
         socials: null,
       });
   const entriesToValue = identityPage?.tokens ?? input.identityEntries;
+  if (requiresGlobalMarketRanking) {
+    const hydratedEntries = await hydrateMissingCanonicalTokenSupplyV1(
+      entriesToValue,
+    );
+    const currentEntries = await valueExploreEntriesWithCurrentEvidence({
+      entries: hydratedEntries,
+      marketByToken: new Map(),
+      deployment: input.deployment,
+      operationalSnapshot: input.operationalSnapshot,
+      maximumValuationAgeMs: EXPLORE_MAXIMUM_STALE_VALUATION_AGE_MS,
+      now: new Date(),
+      requireCompleteLiquidityCoverage: true,
+      timeoutMs: Math.max(0, input.currentEvidenceDeadlineAt - Date.now()),
+    });
+    const currentPage = paginateExploreEntriesV1(currentEntries, {
+      ...input.options,
+      query: "",
+      socials: null,
+    });
+    const marketByToken = readBitqueryTokenMarketDataV1(
+      exploreEntriesMarketIdentitiesV1(currentPage.tokens),
+      { signal: input.signal },
+    );
+    const pageEntries = await attachBitqueryMarketDataToValuedEntries({
+      entries: currentPage.tokens as ValuedExploreEntry[],
+      marketByToken,
+      maximumValuationAgeMs: EXPLORE_MAXIMUM_STALE_VALUATION_AGE_MS,
+      now: new Date(),
+    });
+    return {
+      entries: currentEntries,
+      paginated: { ...currentPage, tokens: pageEntries },
+    };
+  }
   const marketByToken = readBitqueryTokenMarketDataV1(
     exploreEntriesMarketIdentitiesV1(entriesToValue),
     { signal: input.signal },
@@ -415,27 +452,19 @@ async function valueExplorePage(input: Readonly<{
   const valuedEntries = await valueExploreEntriesWithCurrentEvidence({
     entries: hydratedEntries,
     marketByToken,
-    deployment: input.deployment.status === "ready" ? input.deployment : null,
+    deployment: input.deployment,
     operationalSnapshot: input.operationalSnapshot,
     maximumValuationAgeMs: EXPLORE_MAXIMUM_STALE_VALUATION_AGE_MS,
     now: new Date(),
-    requireCompleteLiquidityCoverage:
-      requiresCompleteCurrentValuation(input.options.sort),
+    requireCompleteLiquidityCoverage: false,
     timeoutMs: Math.max(0, input.currentEvidenceDeadlineAt - Date.now()),
   });
-  if (identityPage !== null) {
-    return {
-      entries: valuedEntries,
-      paginated: { ...identityPage, tokens: valuedEntries },
-    };
+  if (identityPage === null) {
+    throw new Error("Explore identity page is unavailable");
   }
   return {
     entries: valuedEntries,
-    paginated: paginateExploreEntriesV1(valuedEntries, {
-      ...input.options,
-      query: "",
-      socials: null,
-    }),
+    paginated: { ...identityPage, tokens: valuedEntries },
   };
 }
 
@@ -476,13 +505,18 @@ export async function GET(request: NextRequest) {
       }),
     );
     const deployment = getAlchemyOnchainDeployment();
+    const currentMarketDeployment = deployment.status === "ready"
+      ? currentMarketOnchainDeployment(deployment)
+      : null;
     const currentEvidenceDeadlineAt =
       Date.now() + CURRENT_EVIDENCE_ROUTE_DEADLINE_MS;
     const requireCompleteCurrentValuation =
       requiresCompleteCurrentValuation(options.sort);
-    const operationalSnapshotRead = deployment.status === "ready"
+    const operationalSnapshotRead = currentMarketDeployment
       ? settleCurrentEvidenceSnapshot({
-          read: readVerifiedOperationalMarketSnapshot(deployment),
+          read: readVerifiedOperationalMarketSnapshot(
+            currentMarketDeployment,
+          ),
           requireComplete: requireCompleteCurrentValuation,
           timeoutMs: CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
         })
@@ -539,7 +573,7 @@ export async function GET(request: NextRequest) {
       identityEntries: requestedIdentityEntries,
       options,
       signal: request.signal,
-      deployment,
+      deployment: currentMarketDeployment,
       operationalSnapshot: operationalSnapshotOutcome,
       currentEvidenceDeadlineAt,
     });

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import {
-  getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../lib/alchemy/explore.server";
@@ -421,6 +420,7 @@ async function valueExplorePage(input: Readonly<{
       now: new Date(),
       requireCompleteLiquidityCoverage: true,
       timeoutMs: Math.max(0, input.currentEvidenceDeadlineAt - Date.now()),
+      signal: input.signal,
     });
     const currentPage = paginateExploreEntriesV1(currentEntries, {
       ...input.options,
@@ -458,6 +458,7 @@ async function valueExplorePage(input: Readonly<{
     now: new Date(),
     requireCompleteLiquidityCoverage: false,
     timeoutMs: Math.max(0, input.currentEvidenceDeadlineAt - Date.now()),
+    signal: input.signal,
   });
   if (identityPage === null) {
     throw new Error("Explore identity page is unavailable");
@@ -504,7 +505,7 @@ export async function GET(request: NextRequest) {
         primary: () => readProductionCustomExploreDirectoryV1(request.signal),
       }),
     );
-    const deployment = getAlchemyOnchainDeployment();
+    const deployment = getOnchainDeployment("production");
     const currentMarketDeployment = deployment.status === "ready"
       ? currentMarketOnchainDeployment(deployment)
       : null;
@@ -514,11 +515,13 @@ export async function GET(request: NextRequest) {
       requiresCompleteCurrentValuation(options.sort);
     const operationalSnapshotRead = currentMarketDeployment
       ? settleCurrentEvidenceSnapshot({
-          read: readVerifiedOperationalMarketSnapshot(
+          read: (signal) => readVerifiedOperationalMarketSnapshot(
             currentMarketDeployment,
+            { signal },
           ),
           requireComplete: requireCompleteCurrentValuation,
           timeoutMs: CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
+          signal: request.signal,
         })
       : Promise.resolve(null);
     // Attach a rejection handler immediately; global ranking rethrows the

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -23,6 +23,8 @@ import {
 } from "../../../../lib/explore-financial-data";
 import { readBitqueryTokenMarketDataV1 } from
   "../../../../lib/market-data/bitquery.server";
+import { currentMarketOnchainDeployment } from
+  "../../../../lib/market-data/current-market-rpc.server";
 import { hydrateMissingCanonicalTokenSupplyV1 } from
   "../../../../lib/market-data/canonical-token-supply.server";
 import { exploreEntryMarketIdentitiesV1 } from
@@ -118,11 +120,16 @@ export async function GET(request: NextRequest) {
   try {
     const address = getAddress(input);
     const deployment = getAlchemyOnchainDeployment();
+    const currentMarketDeployment = deployment.status === "ready"
+      ? currentMarketOnchainDeployment(deployment)
+      : null;
     const currentEvidenceDeadlineAt =
       Date.now() + CURRENT_EVIDENCE_ROUTE_DEADLINE_MS;
-    const operationalSnapshotRead = deployment.status === "ready"
+    const operationalSnapshotRead = currentMarketDeployment
       ? settleCurrentEvidenceSnapshot({
-          read: readVerifiedOperationalMarketSnapshot(deployment),
+          read: readVerifiedOperationalMarketSnapshot(
+            currentMarketDeployment,
+          ),
           requireComplete: false,
           timeoutMs: CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
         })
@@ -234,7 +241,7 @@ export async function GET(request: NextRequest) {
       ? (await valueExploreEntriesWithCurrentEvidence({
           entries: [identityEntry],
           marketByToken,
-          deployment: deployment.status === "ready" ? deployment : null,
+          deployment: currentMarketDeployment,
           operationalSnapshot: operationalSnapshotRead,
           now: new Date(),
           allowHistoricalBitqueryFallback: true,

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
 import {
-  getAlchemyOnchainDeployment,
   readAlchemyExploreModel,
   safeAlchemyError,
 } from "../../../../lib/alchemy/explore.server";
@@ -119,7 +118,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const address = getAddress(input);
-    const deployment = getAlchemyOnchainDeployment();
+    const deployment = getOnchainDeployment("production");
     const currentMarketDeployment = deployment.status === "ready"
       ? currentMarketOnchainDeployment(deployment)
       : null;
@@ -127,11 +126,13 @@ export async function GET(request: NextRequest) {
       Date.now() + CURRENT_EVIDENCE_ROUTE_DEADLINE_MS;
     const operationalSnapshotRead = currentMarketDeployment
       ? settleCurrentEvidenceSnapshot({
-          read: readVerifiedOperationalMarketSnapshot(
+          read: (signal) => readVerifiedOperationalMarketSnapshot(
             currentMarketDeployment,
+            { signal },
           ),
           requireComplete: false,
           timeoutMs: CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
+          signal: request.signal,
         })
       : Promise.resolve(null);
     const [
@@ -246,6 +247,7 @@ export async function GET(request: NextRequest) {
           now: new Date(),
           allowHistoricalBitqueryFallback: true,
           timeoutMs: Math.max(0, currentEvidenceDeadlineAt - Date.now()),
+          signal: request.signal,
         }))[0] ?? null
       : null;
     const primaryMarket = valuedEntry?.marketData?.pools.find(

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -28,7 +28,7 @@
         },
         "rpcRuntime": {
           "path": "lib/onchain/rpc-health.ts",
-          "sha256": "4c8e5fb0f879ef72f2e8d742886b61b004de55fc59a440ef34893b352c33f865"
+          "sha256": "48449348b4d7d91bea96ae583010a299e7c1a08ae04a3b50d28a28c8b5f495e3"
         }
       }
     },

--- a/lib/alchemy/live-market.server.ts
+++ b/lib/alchemy/live-market.server.ts
@@ -191,8 +191,13 @@ export function withoutUnboundEthUsdQuote(
  */
 export async function readVerifiedOperationalMarketSnapshot(
   deployment: ReadyOnchainDeployment,
+  options: Readonly<{ signal?: AbortSignal }> = {},
 ): Promise<ExploreSnapshot | null> {
-  const health = await readOperationalRpcHealth(deployment);
+  const health = await readOperationalRpcHealth(
+    deployment,
+    undefined,
+    options.signal,
+  );
   if (
     health.status !== "healthy" ||
     health.read.status !== "available" ||
@@ -217,7 +222,9 @@ export async function readVerifiedOperationalMarketSnapshot(
 export async function withSameBlockEthUsdQuote(input: {
   deployment: ReadyOnchainDeployment;
   snapshot: ExploreSnapshot;
+  signal?: AbortSignal;
 }): Promise<ExploreSnapshot> {
+  input.signal?.throwIfAborted();
   const snapshot = withoutUnboundEthUsdQuote(input.snapshot);
   if (input.deployment.chainId !== 1) return snapshot;
   const blockNumber = snapshotBlock(snapshot);
@@ -229,6 +236,7 @@ export async function withSameBlockEthUsdQuote(input: {
         transport: http(rpcDeployment.rpcUrl, {
           retryCount: 1,
           timeout: 12_000,
+          fetchOptions: { signal: input.signal },
         }),
       });
       const [decimals, roundData, block] = await Promise.all([
@@ -247,6 +255,7 @@ export async function withSameBlockEthUsdQuote(input: {
         client.getBlock({ blockNumber }),
       ]);
       const [roundId, answer, , updatedAt, answeredInRound] = roundData;
+      input.signal?.throwIfAborted();
       assertValidEthUsdSnapshot({
         expectedBlockHash: snapshot.blockHash,
         actualBlockHash: block.hash,
@@ -445,7 +454,9 @@ export async function enrichTokensWithAlchemyPoolState(input: {
   deployment: ReadyOnchainDeployment;
   snapshot: ExploreSnapshot;
   tokens: readonly LauncherToken[];
+  signal?: AbortSignal;
 }) {
+  input.signal?.throwIfAborted();
   const eligible = input.tokens.filter(validPoolStateToken);
   if (eligible.length === 0) return [...input.tokens];
 
@@ -474,6 +485,7 @@ export async function enrichTokensWithAlchemyPoolState(input: {
           transport: http(rpcDeployment.rpcUrl, {
             retryCount: 1,
             timeout: 12_000,
+            fetchOptions: { signal: input.signal },
           }),
         });
         const [slot0Results, liquidityResults, block] = await Promise.all([
@@ -499,6 +511,7 @@ export async function enrichTokensWithAlchemyPoolState(input: {
           }),
           client.getBlock({ blockNumber }),
         ]);
+        input.signal?.throwIfAborted();
         if (block.hash.toLowerCase() !== input.snapshot.blockHash.toLowerCase()) {
           throw new OperationalRpcUnavailableError();
         }
@@ -525,7 +538,10 @@ export async function enrichTokensWithAlchemyPoolState(input: {
         });
       },
     )
-      .catch(() => missing.map(() => null));
+      .catch(() => {
+        input.signal?.throwIfAborted();
+        return missing.map(() => null);
+      });
 
     missing.forEach((token, index) => {
       const poolId = token.poolId.toLowerCase();
@@ -539,6 +555,11 @@ export async function enrichTokensWithAlchemyPoolState(input: {
       livePoolStateCache.set(cacheKey, {
         expiresAt: Date.now() + LIVE_POOL_STATE_TTL_MS,
         value,
+      });
+      void value.catch(() => {
+        if (livePoolStateCache.get(cacheKey)?.value === value) {
+          livePoolStateCache.delete(cacheKey);
+        }
       });
       states.set(poolId, value);
     });

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -42,6 +42,7 @@ const CHART_CACHE_CURRENT_MAX_AGE_MS = 2_000;
 const CHART_CACHE_MAX_AGE_MS = 2 * 60 * 1_000;
 const CHART_READ_TIMEOUT_MS = 12_000;
 const MAXIMUM_CHART_POINTS = 80;
+const MAXIMUM_ALL_HISTORY_CHART_POINTS = 32;
 const SUPPLY_PRICE_MAXIMUM_DISTANCE_MS = 24 * 60 * 60 * 1_000;
 const INDEXED_PRICE_MAXIMUM_DISTANCE_MS = MARKET_DATA_CURRENT_MAX_AGE_MS;
 const MAXIMUM_FUTURE_SKEW_MS = 60_000;
@@ -1036,6 +1037,7 @@ function marketChartQuery(
     unit: "minutes" | "hours" | "days";
   }>,
 ) {
+  const pointLimit = chartPointLimit(range);
   const definitions = [
     "$poolId: String!",
     "$tokenAddress: String!",
@@ -1058,7 +1060,7 @@ function marketChartQuery(
   return `query ProgrammableMarketChart(${definitions}) {
     EVM(network: eth${dataset}) {
       chart: DEXTradeByTokens(
-        limit: { count: ${MAXIMUM_CHART_POINTS} }
+        limit: { count: ${pointLimit} }
         orderBy: { descendingByField: "Block_Bucket" }
         where: ${where}
       ) {
@@ -1096,7 +1098,7 @@ function chartInterval(
   if (range === "1w") return { count: 3, unit: "hours" };
   const duration = now.getTime() - since.getTime();
   const minimumBucketMs = Math.floor(
-    duration / (MAXIMUM_CHART_POINTS - 1),
+    duration / (chartPointLimit(range) - 1),
   ) + 1;
   if (minimumBucketMs <= 60 * 60 * 1_000) {
     return {
@@ -1114,6 +1116,12 @@ function chartInterval(
     count: Math.ceil(minimumBucketMs / (24 * 60 * 60 * 1_000)),
     unit: "days",
   };
+}
+
+function chartPointLimit(range: MarketChartV1["range"]): number {
+  return range === "all"
+    ? MAXIMUM_ALL_HISTORY_CHART_POINTS
+    : MAXIMUM_CHART_POINTS;
 }
 
 function parseMarketChartPoint(

--- a/lib/market-data/current-market-rpc.server.ts
+++ b/lib/market-data/current-market-rpc.server.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import type { ReadyOnchainDeployment } from "../onchain/types";
+import { createActionRpcQuorum } from
+  "../server/action-rpc-quorum.server";
+
+const CURRENT_MARKET_RPC_SECONDARY = "https://rpc.mevblocker.io/";
+const RPC_ENDPOINT_COMMITMENT = /^0x[0-9a-f]{64}$/u;
+
+export class CurrentMarketRpcBindingError extends Error {
+  override name = "CurrentMarketRpcBindingError";
+
+  constructor() {
+    super("Current market RPC quorum is unavailable");
+  }
+}
+
+/**
+ * Derives a current-market-only quorum from the Website deployment. The
+ * Website deployment has already commitment-verified its Alchemy/QuickNode
+ * pair; only its QuickNode secondary is eligible here. A fixed, independently
+ * operated MEV Blocker endpoint supplies the second exact-block observation.
+ */
+export function currentMarketOnchainDeployment(
+  websiteDeployment: ReadyOnchainDeployment,
+): ReadyOnchainDeployment {
+  const expectedQuickNodeCommitment =
+    process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT;
+  if (
+    websiteDeployment.chainId !== 1 ||
+    !expectedQuickNodeCommitment ||
+    !RPC_ENDPOINT_COMMITMENT.test(expectedQuickNodeCommitment)
+  ) {
+    throw new CurrentMarketRpcBindingError();
+  }
+
+  try {
+    const providers = createActionRpcQuorum({
+      chainId: 1,
+      primary: websiteDeployment.rpcUrlSecondary,
+      secondary: CURRENT_MARKET_RPC_SECONDARY,
+      maximumProviders: 2,
+    });
+    const [primary, secondary] = providers;
+    if (
+      providers.length !== 2 ||
+      primary?.vendorGroup !== "quicknode" ||
+      secondary?.vendorGroup !== "mevblocker" ||
+      primary.endpointCommitment !== expectedQuickNodeCommitment
+    ) {
+      throw new CurrentMarketRpcBindingError();
+    }
+
+    return {
+      ...websiteDeployment,
+      rpcUrl: primary.endpoint,
+      rpcUrlSecondary: secondary.endpoint,
+    };
+  } catch {
+    throw new CurrentMarketRpcBindingError();
+  }
+}

--- a/lib/market-data/current-market-rpc.server.ts
+++ b/lib/market-data/current-market-rpc.server.ts
@@ -15,19 +15,27 @@ export class CurrentMarketRpcBindingError extends Error {
   }
 }
 
+function quickNodeRpcUrl() {
+  const preferred = process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL;
+  return preferred === undefined || preferred === ""
+    ? process.env.ETHEREUM_RPC_URL_B
+    : preferred;
+}
+
 /**
- * Derives a current-market-only quorum from the Website deployment. The
- * Website deployment has already commitment-verified its Alchemy/QuickNode
- * pair; only its QuickNode secondary is eligible here. A fixed, independently
- * operated MEV Blocker endpoint supplies the second exact-block observation.
+ * Derives a current-market-only quorum from the production deployment
+ * manifest. Its QuickNode endpoint is independently configured and
+ * commitment-verified here; current evidence therefore does not depend on an
+ * Alchemy endpoint being configured. A fixed, independently operated MEV
+ * Blocker endpoint supplies the second exact-block observation.
  */
 export function currentMarketOnchainDeployment(
-  websiteDeployment: ReadyOnchainDeployment,
+  baseDeployment: ReadyOnchainDeployment,
 ): ReadyOnchainDeployment {
   const expectedQuickNodeCommitment =
     process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT;
   if (
-    websiteDeployment.chainId !== 1 ||
+    baseDeployment.chainId !== 1 ||
     !expectedQuickNodeCommitment ||
     !RPC_ENDPOINT_COMMITMENT.test(expectedQuickNodeCommitment)
   ) {
@@ -37,7 +45,7 @@ export function currentMarketOnchainDeployment(
   try {
     const providers = createActionRpcQuorum({
       chainId: 1,
-      primary: websiteDeployment.rpcUrlSecondary,
+      primary: quickNodeRpcUrl(),
       secondary: CURRENT_MARKET_RPC_SECONDARY,
       maximumProviders: 2,
     });
@@ -52,7 +60,7 @@ export function currentMarketOnchainDeployment(
     }
 
     return {
-      ...websiteDeployment,
+      ...baseDeployment,
       rpcUrl: primary.endpoint,
       rpcUrlSecondary: secondary.endpoint,
     };

--- a/lib/market-data/current-valuation.server.ts
+++ b/lib/market-data/current-valuation.server.ts
@@ -131,6 +131,30 @@ function knownLiquidityIneligible(token: LauncherToken | undefined): boolean {
     BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD);
 }
 
+function exactStateAtSnapshot(
+  token: LauncherToken | undefined,
+  snapshot: ExploreSnapshot,
+) {
+  const state = token?.liveMarketStateEvidence;
+  return state !== undefined &&
+    state.blockNumber === snapshot.blockNumber &&
+    state.blockHash.toLowerCase() === snapshot.blockHash.toLowerCase()
+    ? state
+    : undefined;
+}
+
+function exactPriceAtSnapshot(
+  token: LauncherToken | undefined,
+  snapshot: ExploreSnapshot,
+) {
+  const price = token?.liveMarketPriceEvidence;
+  return price !== undefined &&
+    price.blockNumber === snapshot.blockNumber &&
+    price.blockHash.toLowerCase() === snapshot.blockHash.toLowerCase()
+    ? price
+    : undefined;
+}
+
 function baseValuedEntry(
   entry: ExploreEntry,
   marketByToken: ReadonlyMap<string, TokenMarketDataV1>,
@@ -152,6 +176,41 @@ function baseValuedEntry(
           : "source-unavailable",
     },
   };
+}
+
+/**
+ * Adds Bitquery trades, volume and chart data after a page has already been
+ * ordered from exact current evidence. The independently proven valuation is
+ * preserved, while every numeric Bitquery valuation remains sanitized.
+ */
+export async function attachBitqueryMarketDataToValuedEntries(input: Readonly<{
+  entries: readonly ValuedExploreEntry[];
+  marketByToken:
+    | ReadonlyMap<string, TokenMarketDataV1>
+    | Promise<ReadonlyMap<string, TokenMarketDataV1>>;
+  maximumValuationAgeMs?: number;
+  now?: Date;
+}>): Promise<ValuedExploreEntry[]> {
+  const marketByToken = await input.marketByToken;
+  return input.entries.map((entry) => {
+    const withMarketData = baseValuedEntry(entry, marketByToken, {
+      maximumValuationAgeMs: input.maximumValuationAgeMs,
+      now: input.now,
+    });
+    const withPreservedValuation = {
+      ...withMarketData,
+      valuation: entry.valuation,
+    } as ValuedExploreEntry;
+    const reason = entry.valuation.status === "unavailable" &&
+        entry.valuation.reason === "liquidity-unavailable"
+      ? "liquidity-unavailable" as const
+      : "source-unavailable" as const;
+    return withoutUnevidencedCurrentBitqueryValuation(
+      withPreservedValuation,
+      false,
+      reason,
+    );
+  });
 }
 
 function classicNativeToken(entry: ExploreEntry): entry is Extract<
@@ -213,33 +272,100 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
             "Current market evidence reference head is unavailable",
           );
         }
-        const liquidityRead = readOfficialV4LiquidityEvidence({
-          tokens: candidates,
-          referenceHead: {
-            chainId: 1,
-            blockNumber: operationalSnapshot.blockNumber,
-            blockHash: operationalSnapshot.blockHash,
-          },
-          now: input.now,
-        });
         const pricedSnapshotRead = withSameBlockEthUsdQuote({
           deployment,
           snapshot: operationalSnapshot,
         });
-        let liquidityCoverageFailed = false;
-        const [liquidityEvidence, pricedSnapshot] = await Promise.all([
-          input.requireCompleteLiquidityCoverage
-            ? liquidityRead
-            : liquidityRead.catch(
-                () => {
-                  liquidityCoverageFailed = true;
-                  return [] as readonly OfficialV4LiquidityEvidenceV1[];
-                },
-              ),
+        // StateView and Chainlink are both bound to the same confirmed block.
+        // Start them together; the first StateView pass deliberately carries
+        // no quote, then the exact-block cache applies the verified quote
+        // without another provider read.
+        const stateSnapshotRead = enrichTokensWithAlchemyPoolState({
+          deployment,
+          snapshot: operationalSnapshot,
+          tokens: candidates,
+        });
+        const [pricedSnapshot, stateTokens] = await Promise.all([
           input.requireCompleteLiquidityCoverage
             ? pricedSnapshotRead
             : pricedSnapshotRead.catch(() => null),
+          input.requireCompleteLiquidityCoverage
+            ? stateSnapshotRead
+            : stateSnapshotRead.catch(() => [] as LauncherToken[]),
         ]);
+        if (!pricedSnapshot) {
+          return { status: "source-unavailable" as const };
+        }
+        const stateByToken = new Map(
+          stateTokens.map((token) => [token.tokenAddress.toLowerCase(), token]),
+        );
+        const stateCoverageIncomplete = candidates.some((candidate) =>
+          exactStateAtSnapshot(
+            stateByToken.get(candidate.tokenAddress.toLowerCase()),
+            operationalSnapshot,
+          ) === undefined
+        );
+        if (stateCoverageIncomplete) {
+          if (input.requireCompleteLiquidityCoverage) {
+            throw new Error("Current StateView market evidence is incomplete");
+          }
+          return { status: "source-unavailable" as const };
+        }
+
+        const pricedTokens = await enrichTokensWithAlchemyPoolState({
+          deployment,
+          snapshot: pricedSnapshot,
+          tokens: candidates,
+        }).catch((error) => {
+          if (input.requireCompleteLiquidityCoverage) throw error;
+          return [] as LauncherToken[];
+        });
+        const pricedByToken = new Map(
+          pricedTokens.map((token) => [
+            token.tokenAddress.toLowerCase(),
+            token,
+          ]),
+        );
+        const priceCoverageIncomplete = candidates.some((candidate) => {
+          const priced = pricedByToken.get(
+            candidate.tokenAddress.toLowerCase(),
+          );
+          const state = exactStateAtSnapshot(priced, operationalSnapshot);
+          return state === undefined ||
+            (state.activeLiquidity !== "0" &&
+              exactPriceAtSnapshot(priced, operationalSnapshot) === undefined);
+        });
+        if (priceCoverageIncomplete) {
+          if (input.requireCompleteLiquidityCoverage) {
+            throw new Error("Current StateView market evidence is incomplete");
+          }
+          return { status: "source-unavailable" as const };
+        }
+
+        const liquidityCandidates = candidates.filter((candidate) => {
+          const priced = pricedByToken.get(candidate.tokenAddress.toLowerCase());
+          return exactPriceAtSnapshot(priced, operationalSnapshot) !== undefined &&
+            !knownLiquidityIneligible(priced);
+        });
+        const liquidityRequestedPools = new Set(
+          liquidityCandidates.map((candidate) => candidate.poolId.toLowerCase()),
+        );
+        let liquidityCoverageFailed = false;
+        const liquidityEvidence = liquidityCandidates.length === 0
+          ? [] as readonly OfficialV4LiquidityEvidenceV1[]
+          : await readOfficialV4LiquidityEvidence({
+              tokens: liquidityCandidates,
+              referenceHead: {
+                chainId: 1,
+                blockNumber: operationalSnapshot.blockNumber,
+                blockHash: operationalSnapshot.blockHash,
+              },
+              now: input.now,
+            }).catch((error) => {
+              if (input.requireCompleteLiquidityCoverage) throw error;
+              liquidityCoverageFailed = true;
+              return [] as readonly OfficialV4LiquidityEvidenceV1[];
+            });
         if (liquidityCoverageFailed) {
           return { status: "source-unavailable" as const };
         }
@@ -249,50 +375,10 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
             evidence,
           ]),
         );
-        const priceCandidates = candidates.filter((entry) =>
-          liquidityByPool.has(entry.poolId.toLowerCase()),
-        );
-        const pricedTokens = pricedSnapshot && priceCandidates.length > 0
-          ? await enrichTokensWithAlchemyPoolState({
-              deployment,
-              snapshot: pricedSnapshot,
-              tokens: priceCandidates,
-            }).catch((error) => {
-              if (input.requireCompleteLiquidityCoverage) throw error;
-              return [] as LauncherToken[];
-            })
-          : [];
-        const pricedByToken = new Map(
-          pricedTokens.map((token) => [
-            token.tokenAddress.toLowerCase(),
-            token,
-          ]),
-        );
-        const stateCoverageIncomplete =
-          input.requireCompleteLiquidityCoverage &&
-          priceCandidates.some((candidate) => {
-            const priced = pricedByToken.get(
-              candidate.tokenAddress.toLowerCase(),
-            );
-            const state = priced?.liveMarketStateEvidence;
-            const price = priced?.liveMarketPriceEvidence;
-            const exactState = state !== undefined &&
-              state.blockNumber === operationalSnapshot.blockNumber &&
-              state.blockHash.toLowerCase() ===
-                operationalSnapshot.blockHash.toLowerCase();
-            const exactPrice = price !== undefined &&
-              price.blockNumber === operationalSnapshot.blockNumber &&
-              price.blockHash.toLowerCase() ===
-                operationalSnapshot.blockHash.toLowerCase();
-            return !exactState ||
-              (state.activeLiquidity !== "0" && !exactPrice);
-          });
-        if (stateCoverageIncomplete) {
-          throw new Error("Current StateView market evidence is incomplete");
-        }
         return {
           status: "complete" as const,
           liquidityByPool,
+          liquidityRequestedPools,
           pricedByToken,
         };
       })(), timeoutMs).then(
@@ -330,7 +416,8 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
     return baseEntries;
   }
   if (outcome.value.status === "source-unavailable") return baseEntries;
-  const { liquidityByPool, pricedByToken } = outcome.value;
+  const { liquidityByPool, liquidityRequestedPools, pricedByToken } =
+    outcome.value;
   return marketEntries.map((entry) => {
     if (entry.exploreKind !== "token") return entry;
     const priced = pricedByToken.get(entry.tokenAddress.toLowerCase());
@@ -341,14 +428,17 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
       currentEntry,
       liquidityByPool.get(entry.poolId.toLowerCase()),
     );
-    if (!liquidityByPool.has(entry.poolId.toLowerCase())) {
+    if (knownLiquidityIneligible(priced)) {
       return withoutUnevidencedCurrentBitqueryValuation(
         valued,
         input.allowHistoricalBitqueryFallback === true,
         "liquidity-unavailable",
       );
     }
-    if (knownLiquidityIneligible(priced)) {
+    if (
+      liquidityRequestedPools.has(entry.poolId.toLowerCase()) &&
+      !liquidityByPool.has(entry.poolId.toLowerCase())
+    ) {
       return withoutUnevidencedCurrentBitqueryValuation(
         valued,
         input.allowHistoricalBitqueryFallback === true,

--- a/lib/market-data/current-valuation.server.ts
+++ b/lib/market-data/current-valuation.server.ts
@@ -82,34 +82,70 @@ function withoutUnevidencedCurrentBitqueryValuation(
   return marketData ? { ...entry, marketData } : entry;
 }
 
-function deadline<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+function deadline<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  upstreamSignal?: AbortSignal,
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error("Current market evidence deadline exceeded")),
-      timeoutMs,
+    const controller = new AbortController();
+    let settled = false;
+    const cleanup = () => {
+      clearTimeout(timer);
+      upstreamSignal?.removeEventListener("abort", abortFromUpstream);
+    };
+    const settle = (
+      complete: (value: T | PromiseLike<T>) => void,
+      value: T,
+    ) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      complete(value);
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const abort = (reason: unknown) => {
+      if (!controller.signal.aborted) controller.abort(reason);
+      fail(reason);
+    };
+    const abortFromUpstream = () => abort(
+      upstreamSignal?.reason ?? new Error("Current market evidence aborted"),
     );
-    promise.then(
+    const timer = setTimeout(() => abort(
+      new Error("Current market evidence deadline exceeded"),
+    ), timeoutMs);
+    if (upstreamSignal?.aborted) {
+      abortFromUpstream();
+      return;
+    }
+    upstreamSignal?.addEventListener("abort", abortFromUpstream, { once: true });
+    Promise.resolve().then(() => operation(controller.signal)).then(
       (value) => {
-        clearTimeout(timer);
-        resolve(value);
+        settle(resolve, value);
       },
       (error) => {
-        clearTimeout(timer);
-        reject(error);
+        fail(error);
       },
     );
   });
 }
 
 export async function settleCurrentEvidenceSnapshot<T>(input: Readonly<{
-  read: Promise<T | null>;
+  read: (signal: AbortSignal) => Promise<T | null>;
   requireComplete: boolean;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }>): Promise<T | null> {
   try {
     const snapshot = await deadline(
       input.read,
       input.timeoutMs ?? CURRENT_EVIDENCE_ROUTE_DEADLINE_MS,
+      input.signal,
     );
     if (snapshot === null && input.requireComplete) {
       throw new Error("Current market evidence reference head is unavailable");
@@ -240,6 +276,7 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
   requireCompleteLiquidityCoverage?: boolean;
   allowHistoricalBitqueryFallback?: boolean;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }>): Promise<ValuedExploreEntry[]> {
   const candidates = input.entries.filter(classicNativeToken);
   const timeoutMs = input.timeoutMs ?? CURRENT_EVIDENCE_ROUTE_DEADLINE_MS;
@@ -261,7 +298,7 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
     deployment !== null;
 
   const currentEvidenceOutcome = canReadCurrentEvidence
-    ? deadline((async () => {
+    ? deadline(async (signal) => {
         const operationalSnapshotOutcome = await operationalSnapshotRead;
         if (operationalSnapshotOutcome.status === "rejected") {
           throw operationalSnapshotOutcome.error;
@@ -275,6 +312,7 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
         const pricedSnapshotRead = withSameBlockEthUsdQuote({
           deployment,
           snapshot: operationalSnapshot,
+          signal,
         });
         // StateView and Chainlink are both bound to the same confirmed block.
         // Start them together; the first StateView pass deliberately carries
@@ -284,6 +322,7 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
           deployment,
           snapshot: operationalSnapshot,
           tokens: candidates,
+          signal,
         });
         const [pricedSnapshot, stateTokens] = await Promise.all([
           input.requireCompleteLiquidityCoverage
@@ -316,6 +355,7 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
           deployment,
           snapshot: pricedSnapshot,
           tokens: candidates,
+          signal,
         }).catch((error) => {
           if (input.requireCompleteLiquidityCoverage) throw error;
           return [] as LauncherToken[];
@@ -361,7 +401,7 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
                 blockHash: operationalSnapshot.blockHash,
               },
               now: input.now,
-            }).catch((error) => {
+            }, { signal }).catch((error) => {
               if (input.requireCompleteLiquidityCoverage) throw error;
               liquidityCoverageFailed = true;
               return [] as readonly OfficialV4LiquidityEvidenceV1[];
@@ -381,7 +421,7 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
           liquidityRequestedPools,
           pricedByToken,
         };
-      })(), timeoutMs).then(
+      }, timeoutMs, input.signal).then(
       (value) => ({ status: "fulfilled" as const, value }),
       (error: unknown) => ({ status: "rejected" as const, error }),
     )

--- a/lib/onchain/rpc-health.ts
+++ b/lib/onchain/rpc-health.ts
@@ -30,7 +30,7 @@ type RpcHealthClient = Readonly<{
 }>;
 
 export type OperationalRpcHealthDependencies = Readonly<{
-  createClient: (rpcUrl: string) => RpcHealthClient;
+  createClient: (rpcUrl: string, signal?: AbortSignal) => RpcHealthClient;
   nowMs: () => number;
 }>;
 
@@ -88,6 +88,7 @@ class RpcHealthIntegrityError extends Error {
 
 function defaultDependencies(
   deployment: ReadyOnchainDeployment,
+  signal?: AbortSignal,
 ): OperationalRpcHealthDependencies {
   const chain = deployment.chainId === 1 ? mainnet : sepolia;
   return {
@@ -98,6 +99,7 @@ function defaultDependencies(
         transport: http(rpcUrl, {
           retryCount: 0,
           timeout: 12_000,
+          fetchOptions: { signal },
         }),
       }),
   };
@@ -157,8 +159,12 @@ function validBlockHash(hash: unknown): hash is Hex {
  */
 export async function readOperationalRpcHealth(
   deployment: ReadyOnchainDeployment,
-  dependencies = defaultDependencies(deployment),
+  dependencies?: OperationalRpcHealthDependencies,
+  signal?: AbortSignal,
 ): Promise<OperationalRpcHealth> {
+  signal?.throwIfAborted();
+  const resolvedDependencies = dependencies ??
+    defaultDependencies(deployment, signal);
   const probes: Record<RpcRole, ProviderProbe> = {
     primary: {
       status: "unknown",
@@ -182,7 +188,7 @@ export async function readOperationalRpcHealth(
       quorumStatus: "unavailable",
     });
   }
-  const nowMs = dependencies.nowMs();
+  const nowMs = resolvedDependencies.nowMs();
   if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
     return result(deployment, probes, {
       status: "unhealthy",
@@ -200,13 +206,15 @@ export async function readOperationalRpcHealth(
   };
 
   const probeProvider = async (role: RpcRole, rpcUrl: string) => {
-    const client = dependencies.createClient(rpcUrl);
+    signal?.throwIfAborted();
+    const client = resolvedDependencies.createClient(rpcUrl, signal);
     probes[role].client = client;
     try {
       const [chainId, head] = await Promise.all([
         client.getChainId(),
         client.getBlockNumber(),
       ]);
+      signal?.throwIfAborted();
       if (chainId !== deployment.chainId || head < 0n) {
         probes[role].status = "invalid";
         probes[role].head = head;
@@ -214,6 +222,7 @@ export async function readOperationalRpcHealth(
       }
       probes[role].head = head;
       const headBlock = await client.getBlock({ blockNumber: head });
+      signal?.throwIfAborted();
       if (
         headBlock.number !== head ||
         !validBlockHash(headBlock.hash) ||
@@ -237,6 +246,7 @@ export async function readOperationalRpcHealth(
           : "available";
       return role;
     } catch (error) {
+      signal?.throwIfAborted();
       if (error instanceof RpcHealthIntegrityError) throw error;
       if (isOperationalRpcFailoverEligible(error)) {
         probes[role].status = "unavailable";
@@ -257,6 +267,7 @@ export async function readOperationalRpcHealth(
       },
     );
   } catch (error) {
+    signal?.throwIfAborted();
     if (
       error instanceof OperationalRpcUnavailableError ||
       isOperationalRpcFailoverEligible(error)
@@ -280,6 +291,7 @@ export async function readOperationalRpcHealth(
     try {
       await probeProvider("secondary", secondaryUrl);
     } catch (error) {
+      signal?.throwIfAborted();
       if (!isOperationalRpcFailoverEligible(error)) {
         return result(deployment, probes, {
           status: "unhealthy",
@@ -305,6 +317,7 @@ export async function readOperationalRpcHealth(
     }
     try {
       const block = await probe.client.getBlock({ blockNumber });
+      signal?.throwIfAborted();
       if (
         block.number !== blockNumber ||
         !validBlockHash(block.hash)
@@ -314,6 +327,7 @@ export async function readOperationalRpcHealth(
       }
       return { status: "available", hash: block.hash } as const;
     } catch (error) {
+      signal?.throwIfAborted();
       if (isOperationalRpcFailoverEligible(error)) {
         probe.status = "unavailable";
         return { status: "unavailable", hash: null } as const;

--- a/lib/onchain/uniswap-v4-subgraph.ts
+++ b/lib/onchain/uniswap-v4-subgraph.ts
@@ -106,6 +106,7 @@ export type OfficialV4SubgraphOptions = {
   endpoint?: string;
   timeoutMs?: number;
   fetcher?: Fetcher;
+  signal?: AbortSignal;
 };
 
 export type OfficialV4LiquidityEvidenceV1 = Readonly<{
@@ -531,10 +532,18 @@ async function fetchPoolAnalytics(input: {
   poolIds: string[];
   timeoutMs: number;
   fetcher: Fetcher;
+  signal?: AbortSignal;
 }) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), input.timeoutMs);
+  const abortFromCaller = () => controller.abort(input.signal?.reason);
+  const timeout = setTimeout(
+    () => controller.abort(new Error("Uniswap v4 subgraph request timed out")),
+    input.timeoutMs,
+  );
+  if (input.signal?.aborted) abortFromCaller();
+  else input.signal?.addEventListener("abort", abortFromCaller, { once: true });
   try {
+    controller.signal.throwIfAborted();
     const response = await input.fetcher(input.endpoint, {
       method: "POST",
       headers: {
@@ -558,6 +567,7 @@ async function fetchPoolAnalytics(input: {
     return parseOfficialV4SubgraphResponse(JSON.parse(body));
   } finally {
     clearTimeout(timeout);
+    input.signal?.removeEventListener("abort", abortFromCaller);
   }
 }
 
@@ -595,7 +605,9 @@ async function fetchPoolAnalyticsCached(input: {
   poolIds: string[];
   timeoutMs: number;
   fetcher: Fetcher;
+  signal?: AbortSignal;
 }) {
+  input.signal?.throwIfAborted();
   const state = stateFor(input.fetcher);
   const now = Date.now();
   const key = cacheKey(input.poolIds);
@@ -625,6 +637,7 @@ async function fetchPoolAnalyticsCached(input: {
       return response;
     })
     .catch((error: unknown) => {
+      if (input.signal?.aborted) throw error;
       state.consecutiveFailures += 1;
       if (state.consecutiveFailures >= CIRCUIT_FAILURE_THRESHOLD) {
         state.openUntil = Date.now() + CIRCUIT_OPEN_MS;
@@ -866,6 +879,7 @@ export async function readOfficialV4LiquidityEvidence(
   },
   options: OfficialV4SubgraphOptions = {},
 ): Promise<readonly OfficialV4LiquidityEvidenceV1[]> {
+  options.signal?.throwIfAborted();
   const eligibleTokens = input.tokens.filter(supportsOfficialPoolTvlEvidence);
   if (eligibleTokens.length === 0) return [];
 
@@ -927,10 +941,12 @@ export async function readOfficialV4LiquidityEvidence(
               poolIds: requestedPoolIds,
               timeoutMs: boundedTimeout(options.timeoutMs),
               fetcher,
+              signal: options.signal,
             }).then((response) => ({ response, requestedPoolIds })),
           ),
       );
     } catch {
+      options.signal?.throwIfAborted();
       throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
     }
     for (const result of completed) {

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -128,6 +128,13 @@ export function evaluateAlchemyExploreSourceContracts(
     "lib/market-data/bitquery.server.ts",
     sourceOverrides,
   );
+  const currentMarketRpcPath =
+    "lib/market-data/current-market-rpc.server.ts";
+  const currentMarketRpcSource = readSource(
+    rootDirectory,
+    currentMarketRpcPath,
+    sourceOverrides,
+  );
   const canonicalSupplyPath =
     "lib/market-data/canonical-token-supply.server.ts";
   const canonicalSupplySource = readSource(
@@ -267,7 +274,41 @@ export function evaluateAlchemyExploreSourceContracts(
       canonicalSupplySource.includes("if (!agreed) return entry;") &&
       routeSources
         .filter(({ id }) => ["explore", "token-detail"].includes(id))
-        .every(({ source }) => {
+        .every(({ id, source }) => {
+          if (id === "explore") {
+            const globalHydration = source.indexOf(
+              "const hydratedEntries = await hydrateMissingCanonicalTokenSupplyV1(",
+            );
+            const globalValuation = source.indexOf(
+              "const currentEntries = await valueExploreEntriesWithCurrentEvidence({",
+              globalHydration,
+            );
+            const globalMarketRead = source.indexOf(
+              "const marketByToken = readBitqueryTokenMarketDataV1(",
+              globalValuation,
+            );
+            const pageMarketRead = source.indexOf(
+              "const marketByToken = readBitqueryTokenMarketDataV1(",
+              globalMarketRead + 1,
+            );
+            const pageHydration = source.indexOf(
+              "const hydratedEntries = await hydrateMissingCanonicalTokenSupplyV1(",
+              pageMarketRead,
+            );
+            const pageValuation = source.indexOf(
+              "const valuedEntries = await valueExploreEntriesWithCurrentEvidence({",
+              pageHydration,
+            );
+            return globalHydration >= 0 &&
+              globalValuation > globalHydration &&
+              source.slice(globalValuation, globalMarketRead).includes(
+                "marketByToken: new Map()",
+              ) &&
+              globalMarketRead > globalValuation &&
+              pageMarketRead > globalMarketRead &&
+              pageHydration > pageMarketRead &&
+              pageValuation > pageHydration;
+          }
           const supplyHydration = source.indexOf(
             "hydrateMissingCanonicalTokenSupplyV1(",
           );
@@ -300,6 +341,48 @@ export function evaluateAlchemyExploreSourceContracts(
             (supplyCompletesFirst || inputsJoinBeforeValuation);
         }),
     "missing supply is hydrated on valuation-bearing routes only after fixed readers agree on block hash, decimals and total supply",
+  );
+
+  check(
+    "current-market-rpc-quorum",
+    currentMarketRpcSource.includes('import "server-only"') &&
+      currentMarketRpcSource.includes(
+        'const CURRENT_MARKET_RPC_SECONDARY = "https://rpc.mevblocker.io/";',
+      ) &&
+      currentMarketRpcSource.includes("createActionRpcQuorum({") &&
+      currentMarketRpcSource.includes(
+        "primary: websiteDeployment.rpcUrlSecondary",
+      ) &&
+      currentMarketRpcSource.includes(
+        "secondary: CURRENT_MARKET_RPC_SECONDARY",
+      ) &&
+      currentMarketRpcSource.includes("maximumProviders: 2") &&
+      currentMarketRpcSource.includes(
+        'primary?.vendorGroup !== "quicknode"',
+      ) &&
+      currentMarketRpcSource.includes(
+        'secondary?.vendorGroup !== "mevblocker"',
+      ) &&
+      currentMarketRpcSource.includes(
+        "primary.endpointCommitment !== expectedQuickNodeCommitment",
+      ) &&
+      routeSources
+        .filter(({ id }) => ["explore", "token-detail"].includes(id))
+        .every(
+          ({ source }) =>
+            source.includes("currentMarketOnchainDeployment(deployment)") &&
+            source.includes(
+              "readVerifiedOperationalMarketSnapshot(\n            currentMarketDeployment,",
+            ) &&
+            source.includes("deployment: currentMarketDeployment"),
+        ) &&
+      routeSources
+        .filter(({ id }) => ["token-chart", "token-list"].includes(id))
+        .every(
+          ({ source }) =>
+            !source.includes("currentMarketOnchainDeployment"),
+        ),
+    "current StateView and Chainlink evidence alone uses commitment-bound QuickNode plus fixed independent MEV Blocker",
   );
 
   for (const route of routeSources) {

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -351,8 +351,16 @@ export function evaluateAlchemyExploreSourceContracts(
       ) &&
       currentMarketRpcSource.includes("createActionRpcQuorum({") &&
       currentMarketRpcSource.includes(
-        "primary: websiteDeployment.rpcUrlSecondary",
+        "primary: quickNodeRpcUrl()",
       ) &&
+      currentMarketRpcSource.includes(
+        "process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
+      ) &&
+      currentMarketRpcSource.includes("process.env.ETHEREUM_RPC_URL_B") &&
+      !currentMarketRpcSource.includes(
+        "process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
+      ) &&
+      !/\bprocess\.env\.ETHEREUM_RPC_URL(?!_B)/u.test(currentMarketRpcSource) &&
       currentMarketRpcSource.includes(
         "secondary: CURRENT_MARKET_RPC_SECONDARY",
       ) &&

--- a/scripts/perf/bitquery-golden-market-parity.mjs
+++ b/scripts/perf/bitquery-golden-market-parity.mjs
@@ -21,6 +21,7 @@ const MINIMUM_CONFIRMATIONS = 12n;
 const MAXIMUM_FEED_AGE_SECONDS = 7_200n;
 const MAXIMUM_EXECUTION_USD_DEVIATION_BPS = 25n;
 const RUNTIME_CONFIDENCE_DEVIATION_BPS = 1_000n;
+const MAXIMUM_RPC_RESPONSE_BYTES = 128 * 1024;
 
 const poolManagerSwapAbi = parseAbi([
   "event Swap(bytes32 indexed id,address indexed sender,int128 amount0,int128 amount1,uint160 sqrtPriceX96,uint128 liquidity,int24 tick,uint24 fee)",
@@ -103,21 +104,91 @@ function withinDeviation(reference, observed, maximumBps) {
   return difference * 10_000n <= reference * maximumBps;
 }
 
-async function jsonRpc(fetchImpl, rpcUrl, method, params, id) {
-  const response = await fetchImpl(rpcUrl, {
-    method: "POST",
-    redirect: "error",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
-    signal: AbortSignal.timeout(15_000),
-  });
-  const text = await response.text();
-  if (!response.ok || Buffer.byteLength(text, "utf8") > 128 * 1024) {
-    throw new Error("independent execution witness RPC was unavailable");
+class RetryableExecutionWitnessRpcError extends Error {
+  constructor() {
+    super("independent execution witness RPC was unavailable");
+    this.name = "RetryableExecutionWitnessRpcError";
   }
+}
+
+function declaredResponseBytes(response) {
+  const value = response.headers.get("content-length");
+  if (value === null) return null;
+  if (!/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    throw new Error("independent execution witness RPC returned invalid framing");
+  }
+  const bytes = Number(value);
+  if (!Number.isSafeInteger(bytes) || bytes > MAXIMUM_RPC_RESPONSE_BYTES) {
+    throw new Error("independent execution witness RPC returned an oversized body");
+  }
+  return bytes;
+}
+
+async function readBoundedResponseBody(response) {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("independent execution witness RPC returned no body");
+  }
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  const chunks = [];
+  let bytesRead = 0;
+  let completed = false;
+  try {
+    declaredResponseBytes(response);
+    while (true) {
+      let chunk;
+      try {
+        chunk = await reader.read();
+      } catch {
+        throw new RetryableExecutionWitnessRpcError();
+      }
+      if (chunk.done) break;
+      bytesRead += chunk.value.byteLength;
+      if (bytesRead > MAXIMUM_RPC_RESPONSE_BYTES) {
+        throw new Error(
+          "independent execution witness RPC returned an oversized body",
+        );
+      }
+      try {
+        chunks.push(decoder.decode(chunk.value, { stream: true }));
+      } catch {
+        throw new Error("independent execution witness RPC returned invalid JSON");
+      }
+    }
+    try {
+      chunks.push(decoder.decode());
+    } catch {
+      throw new Error("independent execution witness RPC returned invalid JSON");
+    }
+    completed = true;
+    return chunks.join("");
+  } finally {
+    if (!completed) await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}
+
+async function jsonRpc(fetchImpl, rpcUrl, method, params, id) {
+  let response;
+  try {
+    response = await fetchImpl(rpcUrl, {
+      method: "POST",
+      redirect: "error",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch {
+    throw new RetryableExecutionWitnessRpcError();
+  }
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new RetryableExecutionWitnessRpcError();
+  }
+  const text = await readBoundedResponseBody(response);
   let body;
   try {
     body = JSON.parse(text);
@@ -368,6 +439,7 @@ async function readProviderWithRetry(fetchImpl, rpcUrl, input) {
     try {
       return await readProvider(fetchImpl, rpcUrl, input);
     } catch (error) {
+      if (!(error instanceof RetryableExecutionWitnessRpcError)) throw error;
       lastError = error;
       if (attempt < 3) await new Promise((resolve) => setTimeout(resolve, 500));
     }

--- a/scripts/perf/bitquery-golden-market-parity.mjs
+++ b/scripts/perf/bitquery-golden-market-parity.mjs
@@ -1,30 +1,31 @@
 import {
+  decodeEventLog,
   decodeFunctionResult,
   encodeFunctionData,
   parseAbi,
+  toEventSelector,
 } from "viem";
 
 const PCAN_TOKEN_ADDRESS =
   "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
 const PCAN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
-const MAINNET_STATE_VIEW = "0x7fFE42C4a5DEeA5b0feC41C94C136Cf115597227";
+const NATIVE_CURRENCY = "0x0000000000000000000000000000000000000000";
+const MAINNET_POOL_MANAGER = "0x000000000004444c5dc75cb358380d2e3de08a90";
 const MAINNET_ETH_USD_FEED = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
-const DEFAULT_RPC_URLS = Object.freeze([
-  "https://ethereum-rpc.publicnode.com",
+const DEFAULT_ARCHIVE_RPC_URLS = Object.freeze([
   "https://rpc.mevblocker.io",
+  "https://mainnet.gateway.tenderly.co",
 ]);
 const MINIMUM_CONFIRMATIONS = 12n;
 const MAXIMUM_FEED_AGE_SECONDS = 7_200n;
-const MAXIMUM_DEVIATION_BPS = 1_500n;
+const MAXIMUM_EXECUTION_USD_DEVIATION_BPS = 25n;
 const RUNTIME_CONFIDENCE_DEVIATION_BPS = 1_000n;
-const WAD = 10n ** 18n;
-const Q192 = 1n << 192n;
 
-const stateViewAbi = parseAbi([
-  "function getSlot0(bytes32 poolId) view returns (uint160 sqrtPriceX96,int24 tick,uint24 protocolFee,uint24 lpFee)",
-  "function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)",
+const poolManagerSwapAbi = parseAbi([
+  "event Swap(bytes32 indexed id,address indexed sender,int128 amount0,int128 amount1,uint160 sqrtPriceX96,uint128 liquidity,int24 tick,uint24 fee)",
 ]);
+const poolManagerSwapTopic = toEventSelector(poolManagerSwapAbi[0]);
 const erc20Abi = parseAbi([
   "function decimals() view returns (uint8)",
   "function totalSupply() view returns (uint256)",
@@ -52,6 +53,48 @@ function validTime(value, label) {
   return parsed;
 }
 
+function canonicalBytes32(value, label) {
+  if (typeof value !== "string" || !/^0x[0-9a-f]{64}$/iu.test(value)) {
+    throw new Error(`${label} is not canonical bytes32`);
+  }
+  return value.toLowerCase();
+}
+
+function canonicalAddress(value, label) {
+  if (typeof value !== "string" || !/^0x[0-9a-f]{40}$/iu.test(value)) {
+    throw new Error(`${label} is not a canonical address`);
+  }
+  return value.toLowerCase();
+}
+
+function rpcQuantity(value, label) {
+  if (typeof value !== "string" || !/^0x(?:0|[1-9a-f][0-9a-f]*)$/iu.test(value)) {
+    throw new Error(`${label} is not a canonical RPC quantity`);
+  }
+  return BigInt(value);
+}
+
+function nonNegativeSafeInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} is not a non-negative safe integer`);
+  }
+  return value;
+}
+
+function decimalToRaw(value, decimals, label) {
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 255) {
+    throw new Error(`${label} decimals are invalid`);
+  }
+  const match = /^(0|[1-9][0-9]*)(?:\.([0-9]+))?$/u.exec(value ?? "");
+  if (match === null || (match[2]?.length ?? 0) > decimals) {
+    throw new Error(`${label} is not an exact token decimal`);
+  }
+  const raw = BigInt(match[1]) * 10n ** BigInt(decimals) +
+    BigInt((match[2] ?? "").padEnd(decimals, "0") || "0");
+  if (raw <= 0n) throw new Error(`${label} is not positive`);
+  return raw;
+}
+
 function withinDeviation(reference, observed, maximumBps) {
   if (reference <= 0n || observed <= 0n) return false;
   const difference = reference > observed
@@ -73,13 +116,13 @@ async function jsonRpc(fetchImpl, rpcUrl, method, params, id) {
   });
   const text = await response.text();
   if (!response.ok || Buffer.byteLength(text, "utf8") > 128 * 1024) {
-    throw new Error("independent market parity RPC was unavailable");
+    throw new Error("independent execution witness RPC was unavailable");
   }
   let body;
   try {
     body = JSON.parse(text);
   } catch {
-    throw new Error("independent market parity RPC returned invalid JSON");
+    throw new Error("independent execution witness RPC returned invalid JSON");
   }
   if (
     body?.jsonrpc !== "2.0" ||
@@ -87,25 +130,92 @@ async function jsonRpc(fetchImpl, rpcUrl, method, params, id) {
     body.error !== undefined ||
     body.result === undefined
   ) {
-    throw new Error("independent market parity RPC rejected a canonical read");
+    throw new Error("independent execution witness RPC rejected a canonical read");
   }
   return body.result;
 }
 
-async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
-  const slot0Data = encodeFunctionData({
-    abi: stateViewAbi,
-    functionName: "getSlot0",
-    args: [poolId],
+function exactSwapFromReceipt(receipt, expected) {
+  if (
+    receipt === null ||
+    canonicalBytes32(receipt?.transactionHash, "receipt transaction hash") !==
+      expected.transactionHash ||
+    rpcQuantity(receipt?.transactionIndex, "receipt transaction index") !==
+      BigInt(expected.transactionIndex) ||
+    rpcQuantity(receipt?.blockNumber, "receipt block number") !== expected.block ||
+    canonicalBytes32(receipt?.blockHash, "receipt block hash") !==
+      expected.blockHash ||
+    rpcQuantity(receipt?.status, "receipt status") !== 1n ||
+    !Array.isArray(receipt?.logs) ||
+    receipt.logs.length < 1 ||
+    receipt.logs.length > 1_024
+  ) {
+    throw new Error("independent execution receipt is malformed or reverted");
+  }
+  const swapLogs = receipt.logs.filter((log) =>
+    canonicalAddress(log?.address, "receipt log address") === MAINNET_POOL_MANAGER &&
+    Array.isArray(log?.topics) &&
+    log.topics[0]?.toLowerCase() === poolManagerSwapTopic.toLowerCase()
+  );
+  if (swapLogs.length !== 1) {
+    throw new Error("independent execution receipt has ambiguous v4 swaps");
+  }
+  const log = swapLogs[0];
+  if (
+    log?.removed !== false ||
+    canonicalBytes32(log?.transactionHash, "swap transaction hash") !==
+      expected.transactionHash ||
+    rpcQuantity(log?.transactionIndex, "swap transaction index") !==
+      BigInt(expected.transactionIndex) ||
+    rpcQuantity(log?.blockNumber, "swap block number") !== expected.block ||
+    canonicalBytes32(log?.blockHash, "swap block hash") !== expected.blockHash
+  ) {
+    throw new Error("independent v4 swap log is not receipt-bound");
+  }
+  const decoded = decodeEventLog({
+    abi: poolManagerSwapAbi,
+    eventName: "Swap",
+    topics: log.topics,
+    data: log.data,
+    strict: true,
   });
+  const args = decoded.args;
+  const fee = Number(args.fee);
+  const tick = Number(args.tick);
+  const observation = Object.freeze({
+    logIndex: rpcQuantity(log.logIndex, "swap log index"),
+    sender: canonicalAddress(args.sender, "swap sender"),
+    poolId: canonicalBytes32(args.id, "swap pool id"),
+    amount0: args.amount0,
+    amount1: args.amount1,
+    sqrtPriceX96: args.sqrtPriceX96,
+    liquidity: args.liquidity,
+    tick,
+    fee,
+  });
+  if (
+    observation.poolId !== expected.poolId ||
+    observation.logIndex > BigInt(Number.MAX_SAFE_INTEGER) ||
+    observation.amount0 === 0n ||
+    observation.amount1 === 0n ||
+    observation.sqrtPriceX96 <= 0n ||
+    observation.liquidity <= 0n ||
+    !Number.isInteger(observation.tick) ||
+    observation.tick < -(2 ** 23) ||
+    observation.tick >= 2 ** 23 ||
+    !Number.isInteger(observation.fee) ||
+    observation.fee < 0 ||
+    observation.fee >= 2 ** 24
+  ) {
+    throw new Error("independent v4 swap execution is invalid");
+  }
+  return observation;
+}
+
+async function readProvider(fetchImpl, rpcUrl, input) {
   const decimalsData = encodeFunctionData({
     abi: erc20Abi,
     functionName: "decimals",
-  });
-  const liquidityData = encodeFunctionData({
-    abi: stateViewAbi,
-    functionName: "getLiquidity",
-    args: [poolId],
   });
   const totalSupplyData = encodeFunctionData({
     abi: erc20Abi,
@@ -119,52 +229,57 @@ async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
     abi: feedAbi,
     functionName: "latestRoundData",
   });
+  const [headHex, block, receipt] = await Promise.all([
+    jsonRpc(fetchImpl, rpcUrl, "eth_blockNumber", [], 1),
+    jsonRpc(
+      fetchImpl,
+      rpcUrl,
+      "eth_getBlockByNumber",
+      [input.blockHex, false],
+      2,
+    ),
+    jsonRpc(
+      fetchImpl,
+      rpcUrl,
+      "eth_getTransactionReceipt",
+      [input.transactionHash],
+      3,
+    ),
+  ]);
+  if (
+    block === null ||
+    rpcQuantity(block?.number, "execution block number") !== input.block
+  ) {
+    throw new Error("independent execution block proof is malformed");
+  }
+  const blockHash = canonicalBytes32(block.hash, "execution block hash");
+  const blockTimestamp = rpcQuantity(block.timestamp, "execution block timestamp");
+  const head = rpcQuantity(headHex, "execution witness head");
+  const swap = exactSwapFromReceipt(receipt, {
+    block: input.block,
+    blockHash,
+    transactionHash: input.transactionHash,
+    transactionIndex: input.transactionIndex,
+    poolId: input.poolId,
+  });
+  const blockReference = Object.freeze({
+    blockHash,
+    requireCanonical: true,
+  });
   const call = (to, data, id) => jsonRpc(
     fetchImpl,
     rpcUrl,
     "eth_call",
-    [{ to, data }, blockHex],
+    [{ to, data }, blockReference],
     id,
   );
-  const [
-    headHex,
-    block,
-    slot0Hex,
-    liquidityHex,
-    decimalsHex,
-    supplyHex,
-    feedDecimalsHex,
-    roundHex,
-  ] =
+  const [decimalsHex, supplyHex, feedDecimalsHex, roundHex] =
     await Promise.all([
-      jsonRpc(fetchImpl, rpcUrl, "eth_blockNumber", [], 1),
-      jsonRpc(fetchImpl, rpcUrl, "eth_getBlockByNumber", [blockHex, false], 2),
-      call(MAINNET_STATE_VIEW, slot0Data, 3),
-      call(MAINNET_STATE_VIEW, liquidityData, 4),
-      call(tokenAddress, decimalsData, 5),
-      call(tokenAddress, totalSupplyData, 6),
-      call(MAINNET_ETH_USD_FEED, feedDecimalsData, 7),
-      call(MAINNET_ETH_USD_FEED, roundData, 8),
+      call(input.tokenAddress, decimalsData, 4),
+      call(input.tokenAddress, totalSupplyData, 5),
+      call(MAINNET_ETH_USD_FEED, feedDecimalsData, 6),
+      call(MAINNET_ETH_USD_FEED, roundData, 7),
     ]);
-  if (
-    !/^0x[0-9a-f]+$/iu.test(headHex ?? "") ||
-    block === null ||
-    !/^0x[0-9a-f]{64}$/iu.test(block?.hash ?? "") ||
-    !/^0x[0-9a-f]+$/iu.test(block?.number ?? "") ||
-    !/^0x[0-9a-f]+$/iu.test(block?.timestamp ?? "")
-  ) {
-    throw new Error("independent market parity block proof is malformed");
-  }
-  const [sqrtPriceX96] = decodeFunctionResult({
-    abi: stateViewAbi,
-    functionName: "getSlot0",
-    data: slot0Hex,
-  });
-  const poolLiquidity = decodeFunctionResult({
-    abi: stateViewAbi,
-    functionName: "getLiquidity",
-    data: liquidityHex,
-  });
   const tokenDecimals = Number(decodeFunctionResult({
     abi: erc20Abi,
     functionName: "decimals",
@@ -186,12 +301,13 @@ async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
     data: roundHex,
   });
   const observation = Object.freeze({
-    head: BigInt(headHex),
-    blockNumber: BigInt(block.number),
-    blockHash: block.hash.toLowerCase(),
-    blockTimestamp: BigInt(block.timestamp),
-    sqrtPriceX96,
-    poolLiquidity,
+    head,
+    blockNumber: input.block,
+    blockHash,
+    blockTimestamp,
+    transactionHash: input.transactionHash,
+    transactionIndex: input.transactionIndex,
+    ...swap,
     tokenDecimals,
     totalSupplyRaw,
     feedDecimals,
@@ -201,8 +317,6 @@ async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
     answeredInRound,
   });
   if (
-    observation.sqrtPriceX96 <= 0n ||
-    observation.poolLiquidity <= 0n ||
     !Number.isInteger(observation.tokenDecimals) ||
     observation.tokenDecimals < 0 ||
     observation.tokenDecimals > 255 ||
@@ -217,7 +331,7 @@ async function readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
     observation.updatedAt > observation.blockTimestamp ||
     observation.blockTimestamp - observation.updatedAt > MAXIMUM_FEED_AGE_SECONDS
   ) {
-    throw new Error("independent market parity state is invalid or stale");
+    throw new Error("independent execution supply or Chainlink state is invalid");
   }
   return observation;
 }
@@ -227,8 +341,17 @@ function sameObservation(left, right) {
     "blockNumber",
     "blockHash",
     "blockTimestamp",
+    "transactionHash",
+    "transactionIndex",
+    "logIndex",
+    "sender",
+    "poolId",
+    "amount0",
+    "amount1",
     "sqrtPriceX96",
-    "poolLiquidity",
+    "liquidity",
+    "tick",
+    "fee",
     "tokenDecimals",
     "totalSupplyRaw",
     "feedDecimals",
@@ -239,129 +362,209 @@ function sameObservation(left, right) {
   ].every((key) => left[key] === right[key]);
 }
 
-async function readProviderWithRetry(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex) {
+async function readProviderWithRetry(fetchImpl, rpcUrl, input) {
   let lastError;
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     try {
-      return await readProvider(fetchImpl, rpcUrl, tokenAddress, poolId, blockHex);
+      return await readProvider(fetchImpl, rpcUrl, input);
     } catch (error) {
       lastError = error;
       if (attempt < 3) await new Promise((resolve) => setTimeout(resolve, 500));
     }
   }
-  throw lastError ?? new Error("independent market parity provider failed");
+  throw lastError ?? new Error("independent execution witness provider failed");
 }
 
 /**
- * Release-only independent correctness proof. Bitquery remains the runtime
- * market source; two fixed public Ethereum readers only verify that the
- * golden Bitquery observation has the right units, orientation and scale.
- * StateView liquidity is read at that historical block only to prove the pool
- * was active; it is neither a current-liquidity nor a USD-liquidity claim.
+ * Release-only historical execution proof. Bitquery remains the runtime trade
+ * and chart source. Two fixed archive witnesses reproduce the exact successful
+ * PoolManager Swap and same-block token supply plus Chainlink ETH/USD round.
+ * This proves execution-price units; it deliberately does not compare the
+ * executed trade with a StateView spot price after that price-moving swap.
  */
-export async function verifyBitqueryGoldenMarketParityV1(input) {
+export async function verifyBitqueryGoldenMarketExecutionV1(input) {
   const token = input?.token;
   const fetchImpl = input?.fetchImpl ?? fetch;
-  const rpcUrls = input?.rpcUrls ?? DEFAULT_RPC_URLS;
-  if (!Array.isArray(rpcUrls) || rpcUrls.length !== 2 || rpcUrls[0] === rpcUrls[1]) {
-    throw new Error("exactly two independent market parity readers are required");
-  }
   if (token?.tokenAddress?.toLowerCase() !== PCAN_TOKEN_ADDRESS) {
-    throw new Error("golden market parity token identity is invalid");
+    throw new Error("golden execution token identity is invalid");
   }
-  const pool = token?.marketData?.pools?.find(
+  const market = token?.marketData;
+  const pool = market?.pools?.find(
     (candidate) => candidate?.identity?.poolId === PCAN_POOL_ID,
   );
   if (
-    token?.marketData?.primaryPoolId !== PCAN_POOL_ID ||
+    market?.schemaVersion !== "programmable.market-data.v1" ||
+    market?.source !== "bitquery" ||
+    market?.primaryPoolId !== PCAN_POOL_ID ||
+    pool?.source !== "bitquery" ||
+    pool?.identity?.chainId !== "1" ||
     pool?.identity?.tokenAddress?.toLowerCase() !== PCAN_TOKEN_ADDRESS ||
     pool?.identity?.protocol !== "uniswap_v4"
   ) {
-    throw new Error("golden market parity pool identity is invalid");
+    throw new Error("golden execution pool identity is invalid");
   }
   const trade = pool.latestTrade;
   const priceUsdWad = positiveInteger(trade?.priceUsdWad, "indexed USD price");
   const rawPriceUsdWad = positiveInteger(trade?.rawPriceUsdWad, "raw USD price");
-  const totalSupplyRaw = positiveInteger(token?.totalSupplyRaw, "canonical total supply");
+  const priceQuoteWad = positiveInteger(trade?.priceQuoteWad, "execution quote price");
+  const totalSupplyRaw = positiveInteger(
+    token?.totalSupplyRaw,
+    "canonical total supply",
+  );
   const tokenDecimals = token?.tokenDecimals;
   const { block, hex: blockHex } = canonicalBlockNumber(trade?.blockNumber);
+  const transactionHash = canonicalBytes32(
+    trade?.transactionHash,
+    "golden execution transaction hash",
+  );
+  const transactionIndex = nonNegativeSafeInteger(
+    trade?.transactionIndex,
+    "golden execution transaction index",
+  );
+  // Bitquery's DEXTrades Log.Index is a provider-local trade ordinal. It is
+  // not Ethereum's receipt-global logIndex, which is proven independently.
+  const bitqueryTradeOrdinal = nonNegativeSafeInteger(
+    trade?.logIndex,
+    "golden Bitquery trade ordinal",
+  );
   const tradeTime = validTime(trade?.time, "golden trade time");
   const priceTime = validTime(trade?.priceUsdAsOfTime, "indexed USD price time");
   if (
     trade?.priceUsdSource !== "bitquery-token-price-index-v1" ||
+    trade?.tokenSide !== "sell" ||
+    trade?.quoteAddress?.toLowerCase() !== NATIVE_CURRENCY ||
+    trade?.quoteSymbol !== "ETH" ||
     !Number.isInteger(tokenDecimals) ||
     tokenDecimals < 0 ||
     tokenDecimals > 255 ||
     Math.abs(tradeTime - priceTime) > 5 * 60_000 ||
     !withinDeviation(priceUsdWad, rawPriceUsdWad, RUNTIME_CONFIDENCE_DEVIATION_BPS)
   ) {
-    throw new Error("golden Bitquery confidence contract is not satisfied");
+    throw new Error("golden Bitquery execution contract is not satisfied");
   }
-  const [first, second] = await Promise.all(rpcUrls.map((rpcUrl) =>
-    readProviderWithRetry(
-      fetchImpl,
-      rpcUrl,
-      PCAN_TOKEN_ADDRESS,
-      PCAN_POOL_ID,
+  const tokenAmountRaw = decimalToRaw(
+    trade?.tokenAmount,
+    tokenDecimals,
+    "golden execution token amount",
+  );
+  const [first, second] = await Promise.all(DEFAULT_ARCHIVE_RPC_URLS.map(
+    (rpcUrl) => readProviderWithRetry(fetchImpl, rpcUrl, {
+      tokenAddress: PCAN_TOKEN_ADDRESS,
+      poolId: PCAN_POOL_ID,
+      transactionHash,
+      transactionIndex,
+      block,
       blockHex,
-    )));
+    }),
+  ));
   if (
     !sameObservation(first, second) ||
     first.blockNumber !== block ||
+    first.blockTimestamp > BigInt(Math.floor(Number.MAX_SAFE_INTEGER / 1_000)) ||
     tradeTime !== Number(first.blockTimestamp) * 1_000 ||
     first.head < block + MINIMUM_CONFIRMATIONS ||
     second.head < block + MINIMUM_CONFIRMATIONS ||
     first.tokenDecimals !== tokenDecimals ||
-    first.totalSupplyRaw !== totalSupplyRaw
+    first.totalSupplyRaw !== totalSupplyRaw ||
+    first.amount0 >= 0n ||
+    first.amount1 <= 0n ||
+    first.amount1 !== tokenAmountRaw
   ) {
-    throw new Error("independent market parity readers did not agree");
+    throw new Error("independent execution witnesses did not agree");
   }
-  const nativeFdvWad =
-    (totalSupplyRaw * Q192 * WAD) /
-    (first.sqrtPriceX96 * first.sqrtPriceX96 * 10n ** 18n);
-  const onchainFdvUsdWad =
-    (nativeFdvWad * first.answer) / 10n ** BigInt(first.feedDecimals);
+  const executionNativeAmountWei = -first.amount0;
+  const executionTokenAmountRaw = first.amount1;
+  const executionPriceQuoteWad =
+    executionNativeAmountWei * 10n ** BigInt(tokenDecimals) /
+    executionTokenAmountRaw;
+  const chainlinkExecutionPriceUsdWad =
+    executionPriceQuoteWad * first.answer /
+    10n ** BigInt(first.feedDecimals);
   const bitqueryFdvUsdWad =
-    (priceUsdWad * totalSupplyRaw) / 10n ** BigInt(tokenDecimals);
+    priceUsdWad * totalSupplyRaw / 10n ** BigInt(tokenDecimals);
   const rawFdvUsdWad =
-    (rawPriceUsdWad * totalSupplyRaw) / 10n ** BigInt(tokenDecimals);
+    rawPriceUsdWad * totalSupplyRaw / 10n ** BigInt(tokenDecimals);
+  const chainlinkExecutionFdvUsdWad =
+    chainlinkExecutionPriceUsdWad * totalSupplyRaw /
+    10n ** BigInt(tokenDecimals);
   const publicValuation = positiveInteger(
     token?.valuation?.valueWad,
     "public golden FDV",
   );
   if (
+    executionPriceQuoteWad !== priceQuoteWad ||
     token?.valuation?.status !== "available" ||
+    token.valuation.source !== "bitquery" ||
     token.valuation.metric !== "fdv" ||
     token.valuation.supplyBasis !== "total" ||
+    token.valuation.currency !== "usd" ||
     publicValuation !== bitqueryFdvUsdWad ||
-    !withinDeviation(onchainFdvUsdWad, bitqueryFdvUsdWad, MAXIMUM_DEVIATION_BPS) ||
-    !withinDeviation(onchainFdvUsdWad, rawFdvUsdWad, MAXIMUM_DEVIATION_BPS)
+    !withinDeviation(
+      chainlinkExecutionFdvUsdWad,
+      bitqueryFdvUsdWad,
+      MAXIMUM_EXECUTION_USD_DEVIATION_BPS,
+    ) ||
+    !withinDeviation(
+      chainlinkExecutionFdvUsdWad,
+      rawFdvUsdWad,
+      MAXIMUM_EXECUTION_USD_DEVIATION_BPS,
+    )
   ) {
-    throw new Error("Bitquery golden price is outside independent onchain tolerance");
+    throw new Error("Bitquery golden execution does not match its receipt witness");
   }
-  const deviation = onchainFdvUsdWad > bitqueryFdvUsdWad
-    ? onchainFdvUsdWad - bitqueryFdvUsdWad
-    : bitqueryFdvUsdWad - onchainFdvUsdWad;
+  const deviation = chainlinkExecutionFdvUsdWad > bitqueryFdvUsdWad
+    ? chainlinkExecutionFdvUsdWad - bitqueryFdvUsdWad
+    : bitqueryFdvUsdWad - chainlinkExecutionFdvUsdWad;
   return Object.freeze({
-    schemaVersion: "programmable.bitquery-golden-market-parity.v1",
+    schemaVersion: "programmable.bitquery-golden-market-execution.v1",
+    providerCount: DEFAULT_ARCHIVE_RPC_URLS.length,
     tokenAddress: PCAN_TOKEN_ADDRESS,
     poolId: PCAN_POOL_ID,
+    quoteAddress: NATIVE_CURRENCY,
+    poolManager: MAINNET_POOL_MANAGER,
+    transactionHash,
+    transactionIndex,
+    bitqueryTradeOrdinal,
+    receiptLogIndex: Number(first.logIndex),
     blockNumber: block.toString(),
     blockHash: first.blockHash,
     blockTime: new Date(Number(first.blockTimestamp) * 1_000).toISOString(),
-    historicalPoolLiquidity: first.poolLiquidity.toString(),
+    executionTokenSide: "sell",
+    executionAmount0: first.amount0.toString(),
+    executionAmount1: first.amount1.toString(),
+    executionNativeAmountWei: executionNativeAmountWei.toString(),
+    executionTokenAmountRaw: executionTokenAmountRaw.toString(),
+    executionPriceQuoteWad: executionPriceQuoteWad.toString(),
+    executionSqrtPriceX96: first.sqrtPriceX96.toString(),
+    executionLiquidity: first.liquidity.toString(),
     confirmations: Number(
       (first.head < second.head ? first.head : second.head) - block,
     ),
+    chainlink: Object.freeze({
+      feedAddress: MAINNET_ETH_USD_FEED.toLowerCase(),
+      decimals: first.feedDecimals,
+      roundId: first.roundId.toString(),
+      answer: first.answer.toString(),
+      updatedAt: first.updatedAt.toString(),
+      answeredInRound: first.answeredInRound.toString(),
+    }),
     bitqueryFdvUsdWad: bitqueryFdvUsdWad.toString(),
-    onchainFdvUsdWad: onchainFdvUsdWad.toString(),
-    deviationBps: Number((deviation * 10_000n) / onchainFdvUsdWad),
+    chainlinkExecutionFdvUsdWad: chainlinkExecutionFdvUsdWad.toString(),
+    executionUsdDeviationBps: Number(
+      deviation * 10_000n / chainlinkExecutionFdvUsdWad,
+    ),
   });
 }
 
-export const BITQUERY_GOLDEN_MARKET_PARITY_V1 = Object.freeze({
+export const BITQUERY_GOLDEN_MARKET_EXECUTION_V1 = Object.freeze({
   tokenAddress: PCAN_TOKEN_ADDRESS,
   poolId: PCAN_POOL_ID,
-  rpcReaderCount: DEFAULT_RPC_URLS.length,
-  maximumDeviationBps: Number(MAXIMUM_DEVIATION_BPS),
+  quoteAddress: NATIVE_CURRENCY,
+  poolManager: MAINNET_POOL_MANAGER,
+  chainlinkFeedAddress: MAINNET_ETH_USD_FEED.toLowerCase(),
+  archiveRpcReaderCount: DEFAULT_ARCHIVE_RPC_URLS.length,
+  minimumConfirmations: Number(MINIMUM_CONFIRMATIONS),
+  maximumExecutionUsdDeviationBps: Number(
+    MAXIMUM_EXECUTION_USD_DEVIATION_BPS,
+  ),
 });

--- a/scripts/perf/bitquery-historical-release-gate.mjs
+++ b/scripts/perf/bitquery-historical-release-gate.mjs
@@ -8,7 +8,9 @@ const MAXIMUM_FUTURE_SKEW_MS = 60_000;
 const MAXIMUM_STALE_AGE_MS = 24 * 60 * 60_000;
 const MAXIMUM_DEFERRED_PCAN_AGE_MS = 96 * 60 * 60_000;
 const MINIMUM_CONFIRMATIONS = 12;
-const MAXIMUM_DEVIATION_BPS = 1_500;
+const MAXIMUM_EXECUTION_USD_DEVIATION_BPS = 25;
+const MAINNET_POOL_MANAGER = "0x000000000004444c5dc75cb358380d2e3de08a90";
+const MAINNET_ETH_USD_FEED = "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419";
 
 function validMarketTime(value, nowMs) {
   const parsed = Date.parse(value ?? "");
@@ -19,14 +21,11 @@ function positiveInteger(value) {
   return typeof value === "string" && /^[1-9][0-9]*$/u.test(value);
 }
 
-function positiveDecimalToWad(value) {
-  const match = /^(0|[1-9][0-9]*)(?:\.([0-9]{1,18}))?$/u.exec(
-    String(value ?? ""),
-  );
-  if (!match) return null;
-  const wad = BigInt(match[1]) * 10n ** 18n +
-    BigInt((match[2] ?? "").slice(0, 18).padEnd(18, "0") || "0");
-  return wad > 0n ? wad : null;
+function positiveDecimal(value) {
+  return typeof value === "string" &&
+    value.length <= 160 &&
+    /^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/u.test(value) &&
+    !/^0(?:\.0+)?$/u.test(value);
 }
 
 function exactGoldenPool(token) {
@@ -66,7 +65,7 @@ function currentMarketTime(value, nowMs) {
  * pool identity and is capped at 96 hours. That fixed window keeps this
  * historical correctness canary finite; it is never evidence that the current
  * provider path is fresh. Deferral is not acceptance: the release must
- * subsequently pass verifyBitqueryHistoricalGoldenReleaseV1.
+ * subsequently pass verifyBitqueryHistoricalGoldenReleaseV2.
  */
 export function classifyBitqueryStaleMarketReleaseV1(input) {
   const nowMs = input?.nowMs ?? Date.now();
@@ -100,15 +99,15 @@ export function classifyBitqueryStaleMarketReleaseV1(input) {
 }
 
 /**
- * Resolve the direct-address PCAN canary after the independent parity read.
+ * Resolve the direct-address PCAN canary after the independent execution read.
  * PCAN is intentionally absent from public Explore discovery. Its detail,
- * exact-pool valuation, chart observation and parity receipt are bound to one
+ * exact-pool valuation, chart observation and execution receipt are bound to one
  * token, pool, block, observation time and FDV. The chart value remains an
  * explicitly labelled period median and is never treated as the latest trade.
  * The only older-than-24h value admitted by
  * this function is the exact PCAN candidate classified above.
  */
-export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
+export function verifyBitqueryHistoricalGoldenReleaseV2(input) {
   const nowMs = input?.nowMs ?? Date.now();
   const detailToken = input?.detailToken;
   const chart = input?.chart;
@@ -124,7 +123,7 @@ export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
   const expectedPrice = positiveInteger(trade?.priceUsdWad)
     ? BigInt(trade.priceUsdWad)
     : null;
-  const periodMedian = positiveDecimalToWad(
+  const periodMedianIsPositive = positiveDecimal(
     lastPoint?.priceUsd ?? lastPoint?.priceQuote,
   );
   let temporalStatus;
@@ -185,44 +184,70 @@ export function verifyBitqueryHistoricalGoldenReleaseV1(input) {
     Date.parse(lastPoint.observedAt) > Date.parse(lastPoint.bucketEnd) ||
     lastPoint?.blockNumber !== expectedBlock ||
     expectedPrice === null ||
-    periodMedian === null ||
-    parity?.schemaVersion !== "programmable.bitquery-golden-market-parity.v1" ||
+    !periodMedianIsPositive ||
+    parity?.schemaVersion !== "programmable.bitquery-golden-market-execution.v1" ||
+    parity.providerCount !== 2 ||
     parity.tokenAddress !== GOLDEN_TOKEN_ADDRESS ||
     parity.poolId !== GOLDEN_POOL_ID ||
+    parity.quoteAddress !== GOLDEN_QUOTE_ADDRESS ||
+    parity.poolManager !== MAINNET_POOL_MANAGER ||
+    parity.transactionHash !== trade?.transactionHash?.toLowerCase() ||
+    parity.transactionIndex !== trade?.transactionIndex ||
+    parity.bitqueryTradeOrdinal !== trade?.logIndex ||
+    !Number.isSafeInteger(parity.receiptLogIndex) ||
+    parity.receiptLogIndex < 0 ||
     parity.blockNumber !== expectedBlock ||
     parity.blockTime !== trade?.time ||
     !/^0x[0-9a-f]{64}$/u.test(parity.blockHash ?? "") ||
-    !positiveInteger(parity.historicalPoolLiquidity) ||
+    parity.executionTokenSide !== trade?.tokenSide ||
+    !/^-?[1-9][0-9]*$/u.test(parity.executionAmount0 ?? "") ||
+    !positiveInteger(parity.executionAmount1) ||
+    !positiveInteger(parity.executionNativeAmountWei) ||
+    !positiveInteger(parity.executionTokenAmountRaw) ||
+    parity.executionPriceQuoteWad !== trade?.priceQuoteWad ||
+    !positiveInteger(parity.executionSqrtPriceX96) ||
+    !positiveInteger(parity.executionLiquidity) ||
+    parity.chainlink?.feedAddress !== MAINNET_ETH_USD_FEED ||
+    !Number.isSafeInteger(parity.chainlink?.decimals) ||
+    parity.chainlink.decimals < 0 ||
+    parity.chainlink.decimals > 36 ||
+    !positiveInteger(parity.chainlink?.roundId) ||
+    !positiveInteger(parity.chainlink?.answer) ||
+    !positiveInteger(parity.chainlink?.updatedAt) ||
+    !positiveInteger(parity.chainlink?.answeredInRound) ||
+    BigInt(parity.chainlink.answeredInRound) < BigInt(parity.chainlink.roundId) ||
     !Number.isSafeInteger(parity.confirmations) ||
     parity.confirmations < MINIMUM_CONFIRMATIONS ||
     parity.bitqueryFdvUsdWad !== expectedValue ||
-    !positiveInteger(parity.onchainFdvUsdWad) ||
-    !Number.isSafeInteger(parity.deviationBps) ||
-    parity.deviationBps < 0 ||
-    parity.deviationBps > MAXIMUM_DEVIATION_BPS
+    !positiveInteger(parity.chainlinkExecutionFdvUsdWad) ||
+    !Number.isSafeInteger(parity.executionUsdDeviationBps) ||
+    parity.executionUsdDeviationBps < 0 ||
+    parity.executionUsdDeviationBps > MAXIMUM_EXECUTION_USD_DEVIATION_BPS
   ) {
     throw new Error("historical PCAN release evidence is not exactly bound");
   }
 
   return Object.freeze({
-    schemaVersion: "programmable.bitquery-historical-release.v1",
+    schemaVersion: "programmable.bitquery-historical-release.v2",
     tokenAddress: GOLDEN_TOKEN_ADDRESS,
     poolId: GOLDEN_POOL_ID,
+    transactionHash: parity.transactionHash,
+    receiptLogIndex: parity.receiptLogIndex,
     blockNumber: expectedBlock,
     asOfTime: expectedTime,
     bitqueryFdvUsdWad: expectedValue,
-    historicalPoolLiquidity: parity.historicalPoolLiquidity,
+    chainlinkExecutionFdvUsdWad: parity.chainlinkExecutionFdvUsdWad,
     confirmations: parity.confirmations,
     temporalStatus,
   });
 }
 
-export const BITQUERY_HISTORICAL_RELEASE_V1 = Object.freeze({
+export const BITQUERY_HISTORICAL_RELEASE_V2 = Object.freeze({
   tokenAddress: GOLDEN_TOKEN_ADDRESS,
   poolId: GOLDEN_POOL_ID,
   quoteAddress: GOLDEN_QUOTE_ADDRESS,
   maximumStaleAgeMs: MAXIMUM_STALE_AGE_MS,
   maximumDeferredPcanAgeMs: MAXIMUM_DEFERRED_PCAN_AGE_MS,
   minimumConfirmations: MINIMUM_CONFIRMATIONS,
-  maximumDeviationBps: MAXIMUM_DEVIATION_BPS,
+  maximumExecutionUsdDeviationBps: MAXIMUM_EXECUTION_USD_DEVIATION_BPS,
 });

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -691,8 +691,8 @@ export const STAGED_MARKET_EVIDENCE_SOURCE_GUARDS = Object.freeze([
   "JSON.stringify(currentFdvDetail.token.liquidityEvidence)",
   'for (const range of ["1h", "1d", "1w", "all"])',
   "verifyCurrentPublicOnchainEvidenceV1({",
-  "process.env.MAINNET_RPC_URL_A",
-  "process.env.MAINNET_RPC_URL_B",
+  '"https://ethereum-rpc.publicnode.com"',
+  '"https://rpc.mevblocker.io"',
   '"programmable.current-market-independent-proof.v1"',
   "independentCurrentProof.providerCount !== 2",
   'currentChart.readStatus !== "live"',
@@ -1667,36 +1667,24 @@ export function evaluateReadModelOperationsSourceContracts(
         "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
       ) &&
       stagedBitquerySmokeBlock.includes(
-        "MAINNET_RPC_URL_A: ${{ secrets.MAINNET_RPC_URL_A }}",
+        '"https://ethereum-rpc.publicnode.com"',
       ) &&
-      stagedBitquerySmokeBlock.includes(
-        "MAINNET_RPC_URL_B: ${{ secrets.MAINNET_RPC_URL_B }}",
+      stagedBitquerySmokeBlock.includes('"https://rpc.mevblocker.io"') &&
+      stagedBitquerySmokeBlock.includes("rpcUrls: independentRpcUrls") &&
+      !stagedBitquerySmokeBlock.includes("MAINNET_RPC_URL_A") &&
+      !stagedBitquerySmokeBlock.includes("MAINNET_RPC_URL_B") &&
+      !stagedBitquerySmokeBlock.includes(
+        "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT",
       ) &&
-      stagedBitquerySmokeBlock.includes(
-        "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}",
+      !stagedBitquerySmokeBlock.includes(
+        "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
       ) &&
-      stagedBitquerySmokeBlock.includes(
-        "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}",
+      !stagedBitquerySmokeBlock.includes(
+        "runtimeProductionProviderBindingsFromUrls",
       ) &&
-      stagedBitquerySmokeBlock.includes(
+      !stagedBitquerySmokeBlock.includes(
         '"./scripts/perf/read-model-provider-binding.mjs"',
       ) &&
-      stagedBitquerySmokeBlock.includes(
-        "runtimeProductionProviderBindingsFromUrls({",
-      ) &&
-      stagedBitquerySmokeBlock.includes(
-        "ETHEREUM_RPC_URL: independentRpcUrls[0]",
-      ) &&
-      stagedBitquerySmokeBlock.includes(
-        "ETHEREUM_RPC_URL_B: independentRpcUrls[1]",
-      ) &&
-      stagedBitquerySmokeBlock.includes(
-        "binding.endpointCommitment !== expectedCommitment",
-      ) &&
-      stagedBitquerySmokeBlock.includes(
-        "staged independent RPC witness does not match its pinned production commitment",
-      ) &&
-      stagedBitquerySmokeBlock.includes("rpcUrls: independentRpcUrls") &&
       stagedBitquerySmokeBlock.includes(
         "process.env.VERCEL_AUTOMATION_BYPASS_SECRET",
       ) &&
@@ -1902,28 +1890,71 @@ export function evaluateReadModelOperationsSourceContracts(
         '"./scripts/perf/bitquery-historical-release-gate.mjs"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        "await verifyBitqueryGoldenMarketParityV1({",
+        "await verifyBitqueryGoldenMarketExecutionV1({",
       ) &&
       bitqueryGoldenParity.includes(
-        '"https://ethereum-rpc.publicnode.com"',
+        '"https://rpc.mevblocker.io"',
       ) &&
-      bitqueryGoldenParity.includes('"https://rpc.mevblocker.io"') &&
-      bitqueryGoldenParity.includes("const MAXIMUM_DEVIATION_BPS = 1_500n") &&
+      bitqueryGoldenParity.includes(
+        '"https://mainnet.gateway.tenderly.co"',
+      ) &&
+      !bitqueryGoldenParity.includes("ethereum-rpc.publicnode.com") &&
+      !bitqueryGoldenParity.includes("MAINNET_STATE_VIEW") &&
+      !bitqueryGoldenParity.includes("Q192") &&
+      bitqueryGoldenParity.includes(
+        "const MAXIMUM_EXECUTION_USD_DEVIATION_BPS = 25n",
+      ) &&
       bitqueryGoldenParity.includes("const MINIMUM_CONFIRMATIONS = 12n") &&
+      bitqueryGoldenParity.includes(
+        '"event Swap(bytes32 indexed id,address indexed sender,int128 amount0,int128 amount1,uint160 sqrtPriceX96,uint128 liquidity,int24 tick,uint24 fee)"',
+      ) &&
+      bitqueryGoldenParity.includes(
+        'const MAINNET_POOL_MANAGER = "0x000000000004444c5dc75cb358380d2e3de08a90"',
+      ) &&
+      bitqueryGoldenParity.includes(
+        '"eth_getTransactionReceipt"',
+      ) &&
+      bitqueryGoldenParity.includes("swapLogs.length !== 1") &&
+      bitqueryGoldenParity.includes('eventName: "Swap"') &&
+      bitqueryGoldenParity.includes("strict: true") &&
+      bitqueryGoldenParity.includes(
+        "observation.poolId !== expected.poolId",
+      ) &&
+      bitqueryGoldenParity.includes(
+        "rpcQuantity(receipt?.status, \"receipt status\") !== 1n",
+      ) &&
+      bitqueryGoldenParity.includes("blockHash,") &&
+      bitqueryGoldenParity.includes("requireCanonical: true") &&
       bitqueryGoldenParity.includes("sameObservation(first, second)") &&
       bitqueryGoldenParity.includes(
-        'function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)',
+        "first.amount0 >= 0n",
       ) &&
-      bitqueryGoldenParity.includes("observation.poolLiquidity <= 0n") &&
       bitqueryGoldenParity.includes(
-        "historicalPoolLiquidity: first.poolLiquidity.toString()",
+        "first.amount1 !== tokenAmountRaw",
+      ) &&
+      bitqueryGoldenParity.includes("provider-local trade ordinal") &&
+      bitqueryGoldenParity.includes("bitqueryTradeOrdinal,") &&
+      bitqueryGoldenParity.includes(
+        "receiptLogIndex: Number(first.logIndex)",
+      ) &&
+      bitqueryGoldenParity.includes(
+        "executionPriceQuoteWad !== priceQuoteWad",
+      ) &&
+      bitqueryGoldenParity.includes(
+        "executionNativeAmountWei * 10n ** BigInt(tokenDecimals)",
+      ) &&
+      bitqueryGoldenParity.includes(
+        "executionPriceQuoteWad * first.answer",
+      ) &&
+      bitqueryGoldenParity.includes(
+        "observation.answeredInRound < observation.roundId",
       ) &&
       bitqueryGoldenParity.includes(
         "tradeTime !== Number(first.blockTimestamp) * 1_000",
       ) &&
       !bitqueryGoldenParity.includes("pool?.liquidity?.valueUsdWad") &&
       bitqueryGoldenParity.includes(
-        "Bitquery golden price is outside independent onchain tolerance",
+        "Bitquery golden execution does not match its receipt witness",
       ) &&
       bitqueryHistoricalRelease.includes(
         "const MAXIMUM_STALE_AGE_MS = 24 * 60 * 60_000",
@@ -1944,10 +1975,10 @@ export function evaluateReadModelOperationsSourceContracts(
         "export function classifyBitqueryStaleMarketReleaseV1",
       ) &&
       bitqueryHistoricalRelease.includes(
-        "export function verifyBitqueryHistoricalGoldenReleaseV1",
+        "export function verifyBitqueryHistoricalGoldenReleaseV2",
       ) &&
       bitqueryHistoricalRelease.includes(
-        'parity?.schemaVersion !== "programmable.bitquery-golden-market-parity.v1"',
+        'parity?.schemaVersion !== "programmable.bitquery-golden-market-execution.v1"',
       ) &&
       bitqueryHistoricalRelease.includes(
         'market?.schemaVersion !== "programmable.market-data.v1"',
@@ -1968,7 +1999,19 @@ export function evaluateReadModelOperationsSourceContracts(
         '"valuationMetric" in chart',
       ) &&
       bitqueryHistoricalRelease.includes(
-        "!positiveInteger(parity.historicalPoolLiquidity)",
+        "parity.transactionHash !== trade?.transactionHash?.toLowerCase()",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "parity.bitqueryTradeOrdinal !== trade?.logIndex",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "parity.executionPriceQuoteWad !== trade?.priceQuoteWad",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "parity.chainlink?.feedAddress !== MAINNET_ETH_USD_FEED",
+      ) &&
+      bitqueryHistoricalRelease.includes(
+        "BigInt(parity.chainlink.answeredInRound) < BigInt(parity.chainlink.roundId)",
       ) &&
       bitqueryHistoricalRelease.includes(
         "chart?.identity?.poolId !== GOLDEN_POOL_ID",
@@ -1982,7 +2025,7 @@ export function evaluateReadModelOperationsSourceContracts(
       bitqueryHistoricalRelease.includes(
         "chart.asOfTime !== lastPoint?.observedAt",
       ) &&
-      bitqueryHistoricalRelease.includes("periodMedian === null") &&
+      bitqueryHistoricalRelease.includes("!periodMedianIsPositive") &&
       bitqueryHistoricalRelease.includes(
         'lastPoint?.valueSemantics !== "period-median"',
       ) &&
@@ -1991,10 +2034,10 @@ export function evaluateReadModelOperationsSourceContracts(
         "const historicalPaidPathVerified =",
       ) &&
       stagedBitquerySmokeBlock.includes(
-        "verifyBitqueryHistoricalGoldenReleaseV1({",
+        "verifyBitqueryHistoricalGoldenReleaseV2({",
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '"programmable.bitquery-historical-release.v1"',
+        '"programmable.bitquery-historical-release.v2"',
       ) &&
       stagedBitquerySmokeBlock.includes(
         "historicalGoldenRelease.confirmations >= 12",
@@ -2193,8 +2236,11 @@ export function evaluateReadModelOperationsSourceContracts(
         POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS,
       ) &&
       postPromotion.includes('chart.readStatus !== "live"') &&
-      postPromotion.includes("verifyBitqueryGoldenMarketParityV1") &&
-      postPromotion.includes("verifyBitqueryHistoricalGoldenReleaseV1") &&
+      postPromotion.includes("verifyBitqueryGoldenMarketExecutionV1") &&
+      postPromotion.includes("verifyBitqueryHistoricalGoldenReleaseV2") &&
+      !postPromotion.includes(
+        "verifyBitqueryGoldenMarketExecutionV1({\n      token: responses[4].body?.token,\n      fetchImpl,\n      rpcUrls:",
+      ) &&
       postPromotion.includes('id: "production-bitquery-canary-hidden"') &&
       postPromotion.includes(
         "return currentCount > 0 ? { currentToken, tokens } : null;",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -33,7 +33,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
         rpcRuntime: Object.freeze({
           path: "lib/onchain/rpc-health.ts",
-          sha256: "4c8e5fb0f879ef72f2e8d742886b61b004de55fc59a440ef34893b352c33f865",
+          sha256: "48449348b4d7d91bea96ae583010a299e7c1a08ae04a3b50d28a28c8b5f495e3",
         }),
       }),
     }),

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -19,9 +19,9 @@ import {
   fetchVercelDeployment,
   verifyLiveCacheAndKeyContracts,
 } from "./read-model-live-verifier.mjs";
-import { verifyBitqueryGoldenMarketParityV1 } from "./bitquery-golden-market-parity.mjs";
+import { verifyBitqueryGoldenMarketExecutionV1 } from "./bitquery-golden-market-parity.mjs";
 import {
-  verifyBitqueryHistoricalGoldenReleaseV1,
+  verifyBitqueryHistoricalGoldenReleaseV2,
 } from "./bitquery-historical-release-gate.mjs";
 
 const HEALTH_PATH = "/api/ops/health";
@@ -1250,12 +1250,11 @@ export async function verifyPostPromotion(input) {
   let goldenParity = null;
   let historicalGoldenRelease = null;
   try {
-    goldenParity = await verifyBitqueryGoldenMarketParityV1({
+    goldenParity = await verifyBitqueryGoldenMarketExecutionV1({
       token: responses[4].body?.token,
       fetchImpl,
-      rpcUrls: marketParityRpcUrls,
     });
-    historicalGoldenRelease = verifyBitqueryHistoricalGoldenReleaseV1({
+    historicalGoldenRelease = verifyBitqueryHistoricalGoldenReleaseV2({
       detailToken: responses[4].body?.token,
       chart: responses[5].body,
       parity: goldenParity,
@@ -1266,9 +1265,9 @@ export async function verifyPostPromotion(input) {
   checks.push({
     id: "production-bitquery-golden-independent-parity",
     condition: historicalGoldenRelease?.schemaVersion ===
-        "programmable.bitquery-historical-release.v1" &&
+        "programmable.bitquery-historical-release.v2" &&
       historicalGoldenRelease.confirmations >= 12,
-    detail: "the direct PCAN history matches two independent same-block price, supply and liquidity reads",
+    detail: "the direct PCAN history matches two fixed archive receipts and same-block Chainlink execution pricing",
   });
 
   if (input.evidencePath) {

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -1656,7 +1656,69 @@ describe("Bitquery OHLCV chart and server stream", () => {
     expect(chart.points[0]).not.toHaveProperty("ohlcQuote");
   });
 
-  it("adapts the all-history interval beyond 80 days without dropping its start", async () => {
+  it("bounds the observed 17-day all-history query without dropping its start", async () => {
+    const historyStart = "2026-07-27T00:00:00.000Z";
+    const now = new Date("2026-08-13T00:00:00.000Z");
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      expect(request.variables.since).toBe(historyStart);
+      expect(request.variables.till).toBe(now.toISOString());
+      expect(request.query).toContain("limit: { count: 32 }");
+      expect(request.query).toContain(
+        "Bucket: Time(interval: { count: 14, in: hours })",
+      );
+      return jsonResponse(chartResponse({
+        points: [chartBucketRow({
+          bucket: historyStart,
+          block: "23040000",
+          time: "2026-07-27T01:00:00.000Z",
+          price: "1",
+          count: "1",
+        }), chartBucketRow({
+          bucket: "2026-08-12T20:00:00.000Z",
+          block: "25740000",
+          time: "2026-08-12T23:00:00.000Z",
+          price: "2",
+          count: "1",
+        })],
+        total: "2",
+      }));
+    }) as typeof fetch;
+
+    const chart = await readBitqueryMarketChartV1({
+      identity: PCAN,
+      range: "all",
+      historyStart,
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now,
+    });
+
+    expect(chart).toMatchObject({
+      status: "ready",
+      truncated: false,
+      swapCount: 2,
+      points: [
+        {
+          bucketStart: historyStart,
+          bucketEnd: "2026-07-27T14:00:00.000Z",
+          observedAt: "2026-07-27T01:00:00.000Z",
+          valueSemantics: "period-median",
+        },
+        {
+          bucketStart: "2026-08-12T20:00:00.000Z",
+          bucketEnd: now.toISOString(),
+          observedAt: "2026-08-12T23:00:00.000Z",
+          valueSemantics: "period-median",
+        },
+      ],
+    });
+  });
+
+  it("adapts a 406-day all-history interval without dropping its start", async () => {
     const historyStart = "2025-07-01T00:00:00.000Z";
     const fetchImpl = vi.fn(async (
       _url: string | URL | Request,
@@ -1665,8 +1727,9 @@ describe("Bitquery OHLCV chart and server stream", () => {
       const request = JSON.parse(String(init?.body));
       expect(request.variables.since).toBe(historyStart);
       expect(request.variables.till).toBe("2026-08-11T14:02:00.000Z");
+      expect(request.query).toContain("limit: { count: 32 }");
       expect(request.query).toContain(
-        "Bucket: Time(interval: { count: 6, in: days })",
+        "Bucket: Time(interval: { count: 14, in: days })",
       );
       return jsonResponse(chartResponse({
         points: [chartBucketRow({
@@ -1703,8 +1766,8 @@ describe("Bitquery OHLCV chart and server stream", () => {
       points: [
         {
           bucketStart: historyStart,
-          bucketEnd: "2025-07-07T00:00:00.000Z",
-          time: "2025-07-07T00:00:00.000Z",
+          bucketEnd: "2025-07-15T00:00:00.000Z",
+          time: "2025-07-15T00:00:00.000Z",
           observedAt: "2025-07-01T01:00:00.000Z",
           valueSemantics: "period-median",
         },

--- a/tests/current-market-rpc-server.test.ts
+++ b/tests/current-market-rpc-server.test.ts
@@ -40,6 +40,7 @@ function websiteDeployment(
 }
 
 function stubQuickNodeCommitment(value = QUICKNODE_RPC_URL) {
+  vi.stubEnv("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL", value);
   vi.stubEnv(
     "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
     rpcProviderCommitment("endpoint", value),
@@ -51,7 +52,7 @@ describe("current market RPC deployment", () => {
     vi.unstubAllEnvs();
   });
 
-  it("uses only the commitment-bound Website QuickNode and fixed MEV Blocker pair", () => {
+  it("uses only the commitment-bound QuickNode and fixed MEV Blocker pair", () => {
     stubQuickNodeCommitment();
     const website = websiteDeployment();
 
@@ -66,6 +67,20 @@ describe("current market RPC deployment", () => {
     expect(website).toMatchObject({
       rpcUrl: ALCHEMY_RPC_URL,
       rpcUrlSecondary: QUICKNODE_RPC_URL,
+    });
+  });
+
+  it("does not require or retain an Alchemy endpoint for current evidence", () => {
+    stubQuickNodeCommitment();
+    vi.stubEnv("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL", "");
+    vi.stubEnv("ETHEREUM_RPC_URL", "");
+
+    expect(currentMarketOnchainDeployment(websiteDeployment({
+      rpcUrl: "https://eth.drpc.org",
+      rpcUrlSecondary: null,
+    }))).toMatchObject({
+      rpcUrl: QUICKNODE_RPC_URL,
+      rpcUrlSecondary: MEV_BLOCKER_RPC_URL,
     });
   });
 
@@ -94,29 +109,26 @@ describe("current market RPC deployment", () => {
     expect(JSON.stringify(error)).not.toContain("quicknode-test-key");
   });
 
-  it("does not let a legacy or reordered Website endpoint bypass QuickNode", () => {
+  it("does not let a base deployment endpoint bypass configured QuickNode", () => {
     stubQuickNodeCommitment();
 
-    expect(() =>
-      currentMarketOnchainDeployment(websiteDeployment({
-        rpcUrlSecondary: "https://ethereum-rpc.publicnode.com",
-      })),
-    ).toThrow(CurrentMarketRpcBindingError);
-    expect(() =>
-      currentMarketOnchainDeployment(websiteDeployment({
-        rpcUrl: QUICKNODE_RPC_URL,
-        rpcUrlSecondary: ALCHEMY_RPC_URL,
-      })),
-    ).toThrow(CurrentMarketRpcBindingError);
+    expect(currentMarketOnchainDeployment(websiteDeployment({
+      rpcUrl: "https://ethereum-rpc.publicnode.com",
+      rpcUrlSecondary: MEV_BLOCKER_RPC_URL,
+    }))).toMatchObject({
+      rpcUrl: QUICKNODE_RPC_URL,
+      rpcUrlSecondary: MEV_BLOCKER_RPC_URL,
+    });
+
+    vi.stubEnv("PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL", "");
+    vi.stubEnv("ETHEREUM_RPC_URL_B", "https://ethereum-rpc.publicnode.com");
+    expect(() => currentMarketOnchainDeployment(websiteDeployment()))
+      .toThrow(CurrentMarketRpcBindingError);
   });
 
   it("requires independent providers in the fixed QuickNode-first order", () => {
     stubQuickNodeCommitment(MEV_BLOCKER_RPC_URL);
-
-    expect(() =>
-      currentMarketOnchainDeployment(websiteDeployment({
-        rpcUrlSecondary: MEV_BLOCKER_RPC_URL,
-      })),
-    ).toThrow(CurrentMarketRpcBindingError);
+    expect(() => currentMarketOnchainDeployment(websiteDeployment()))
+      .toThrow(CurrentMarketRpcBindingError);
   });
 });

--- a/tests/current-market-rpc-server.test.ts
+++ b/tests/current-market-rpc-server.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { rpcProviderCommitment } from
+  "../lib/data-pipeline/rpc-provider-commitments";
+import {
+  CurrentMarketRpcBindingError,
+  currentMarketOnchainDeployment,
+} from "../lib/market-data/current-market-rpc.server";
+import type { ReadyOnchainDeployment } from "../lib/onchain/types";
+
+const ALCHEMY_RPC_URL =
+  "https://eth-mainnet.g.alchemy.com/v2/alchemy-test-key";
+const QUICKNODE_RPC_URL =
+  "https://programmable-mainnet.quiknode.pro/quicknode-test-key/";
+const MEV_BLOCKER_RPC_URL = "https://rpc.mevblocker.io/";
+
+function websiteDeployment(
+  overrides: Partial<ReadyOnchainDeployment> = {},
+): ReadyOnchainDeployment {
+  return {
+    environment: "production",
+    releaseVersion: "classic-v2",
+    chainId: 1,
+    status: "ready",
+    stateView: "0x1111111111111111111111111111111111111111",
+    stateViewRuntimeCodeHash: `0x${"11".repeat(32)}`,
+    rpcUrl: ALCHEMY_RPC_URL,
+    rpcUrlSecondary: QUICKNODE_RPC_URL,
+    confirmations: 12n,
+    logBlockRange: 5_000n,
+    launcher: "0x2222222222222222222222222222222222222222",
+    feeHook: "0x3333333333333333333333333333333333333333",
+    launcherRuntimeCodeHash: `0x${"22".repeat(32)}`,
+    feeHookRuntimeCodeHash: `0x${"33".repeat(32)}`,
+    deploymentBlock: 25_000_000n,
+    ...overrides,
+  };
+}
+
+function stubQuickNodeCommitment(value = QUICKNODE_RPC_URL) {
+  vi.stubEnv(
+    "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+    rpcProviderCommitment("endpoint", value),
+  );
+}
+
+describe("current market RPC deployment", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses only the commitment-bound Website QuickNode and fixed MEV Blocker pair", () => {
+    stubQuickNodeCommitment();
+    const website = websiteDeployment();
+
+    const current = currentMarketOnchainDeployment(website);
+
+    expect(current).toMatchObject({
+      status: "ready",
+      rpcUrl: QUICKNODE_RPC_URL,
+      rpcUrlSecondary: MEV_BLOCKER_RPC_URL,
+    });
+    expect(current.rpcUrl).not.toBe(ALCHEMY_RPC_URL);
+    expect(website).toMatchObject({
+      rpcUrl: ALCHEMY_RPC_URL,
+      rpcUrlSecondary: QUICKNODE_RPC_URL,
+    });
+  });
+
+  it("rejects a missing or mismatched QuickNode commitment without retaining secrets", () => {
+    vi.stubEnv(
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+      "",
+    );
+    expect(() =>
+      currentMarketOnchainDeployment(websiteDeployment()),
+    ).toThrow(CurrentMarketRpcBindingError);
+
+    vi.stubEnv(
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+      `0x${"ab".repeat(32)}`,
+    );
+    const error = (() => {
+      try {
+        currentMarketOnchainDeployment(websiteDeployment());
+      } catch (candidate) {
+        return candidate;
+      }
+      return null;
+    })();
+    expect(error).toBeInstanceOf(CurrentMarketRpcBindingError);
+    expect(JSON.stringify(error)).not.toContain("quicknode-test-key");
+  });
+
+  it("does not let a legacy or reordered Website endpoint bypass QuickNode", () => {
+    stubQuickNodeCommitment();
+
+    expect(() =>
+      currentMarketOnchainDeployment(websiteDeployment({
+        rpcUrlSecondary: "https://ethereum-rpc.publicnode.com",
+      })),
+    ).toThrow(CurrentMarketRpcBindingError);
+    expect(() =>
+      currentMarketOnchainDeployment(websiteDeployment({
+        rpcUrl: QUICKNODE_RPC_URL,
+        rpcUrlSecondary: ALCHEMY_RPC_URL,
+      })),
+    ).toThrow(CurrentMarketRpcBindingError);
+  });
+
+  it("requires independent providers in the fixed QuickNode-first order", () => {
+    stubQuickNodeCommitment(MEV_BLOCKER_RPC_URL);
+
+    expect(() =>
+      currentMarketOnchainDeployment(websiteDeployment({
+        rpcUrlSecondary: MEV_BLOCKER_RPC_URL,
+      })),
+    ).toThrow(CurrentMarketRpcBindingError);
+  });
+});

--- a/tests/current-valuation-server.test.ts
+++ b/tests/current-valuation-server.test.ts
@@ -242,6 +242,70 @@ describe("current Explore valuation orchestration", () => {
     })).rejects.toThrow("deadline exceeded");
   });
 
+  it("actively aborts pending StateView and Chainlink work at the deadline", async () => {
+    const observedSignals: AbortSignal[] = [];
+    const pendingUntilAbort = ({ signal }: { signal?: AbortSignal }) => {
+      expect(signal).toBeInstanceOf(AbortSignal);
+      observedSignals.push(signal!);
+      return new Promise<never>((_resolve, reject) => {
+        signal!.addEventListener("abort", () => reject(signal!.reason), {
+          once: true,
+        });
+      });
+    };
+    mocks.withSameBlockEthUsdQuote.mockImplementation(pendingUntilAbort);
+    mocks.enrichTokensWithAlchemyPoolState.mockImplementation(pendingUntilAbort);
+
+    await expect(valueExploreEntriesWithCurrentEvidence({
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+      timeoutMs: 5,
+    })).resolves.toMatchObject([{
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    }]);
+
+    expect(observedSignals).toHaveLength(2);
+    expect(observedSignals.every((signal) => signal.aborted)).toBe(true);
+    expect(mocks.readOfficialV4LiquidityEvidence).not.toHaveBeenCalled();
+  });
+
+  it("actively aborts a pending official subgraph read at the deadline", async () => {
+    let subgraphSignal: AbortSignal | undefined;
+    mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([
+      tokenWithState("2000000000000000000", "10000000000000000000000"),
+    ]);
+    mocks.readOfficialV4LiquidityEvidence.mockImplementation(
+      (_input: unknown, options?: { signal?: AbortSignal }) => {
+        subgraphSignal = options?.signal;
+        return new Promise<never>((_resolve, reject) => {
+          subgraphSignal?.addEventListener(
+            "abort",
+            () => reject(subgraphSignal?.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+
+    await expect(valueExploreEntriesWithCurrentEvidence({
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+      timeoutMs: 5,
+    })).resolves.toMatchObject([{
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    }]);
+
+    expect(subgraphSignal).toBeInstanceOf(AbortSignal);
+    expect(subgraphSignal?.aborted).toBe(true);
+  });
+
   it("bounds an unresolved operational snapshot and never starts downstream reads", async () => {
     const unresolvedSnapshot = new Promise<null>(() => undefined);
     const input = {

--- a/tests/current-valuation-server.test.ts
+++ b/tests/current-valuation-server.test.ts
@@ -17,11 +17,14 @@ vi.mock("../lib/alchemy/live-market.server", () => ({
   enrichTokensWithAlchemyPoolState: mocks.enrichTokensWithAlchemyPoolState,
 }));
 
-import { valueExploreEntriesWithCurrentEvidence } from
+import {
+  attachBitqueryMarketDataToValuedEntries,
+  valueExploreEntriesWithCurrentEvidence,
+} from
   "../lib/market-data/current-valuation.server";
 import type { TokenMarketDataV1 } from
   "../lib/market-data/market-data-v1";
-import type { ExploreEntry } from "../lib/tokens";
+import type { ExploreEntry, LauncherToken } from "../lib/tokens";
 
 const tokenAddress = "0x1111111111111111111111111111111111111111";
 const poolId = `0x${"22".repeat(32)}` as const;
@@ -117,6 +120,63 @@ const snapshot = {
   confirmations: 12,
 } as const;
 
+function tokenWithState(
+  activeLiquidity: string,
+  activeVirtualLiquidityUsdWad?: string,
+): LauncherToken {
+  const blockTimestamp = "1786579320";
+  const blockTime = new Date(Number(blockTimestamp) * 1_000).toISOString();
+  return {
+    ...token,
+    liveMarketStateEvidence: {
+      source: "uniswap-v4-stateview-v1",
+      blockNumber: snapshot.blockNumber,
+      blockHash: snapshot.blockHash,
+      sqrtPriceX96: (1n << 96n).toString(),
+      activeLiquidity,
+    },
+    ...(activeVirtualLiquidityUsdWad === undefined
+      ? {}
+      : {
+          liveMarketPriceEvidence: {
+            schemaVersion:
+              "programmable.stateview-chainlink-price-evidence.v1",
+            source: "uniswap-v4-stateview-chainlink-v1",
+            chainId: "1",
+            poolId,
+            tokenAddress,
+            quoteAddress: "0x0000000000000000000000000000000000000000",
+            stateViewAddress: deployment.stateView,
+            stateViewRuntimeCodeHash: deployment.stateViewRuntimeCodeHash,
+            blockNumber: snapshot.blockNumber,
+            blockHash: snapshot.blockHash,
+            blockTimestamp,
+            blockTime,
+            sqrtPriceX96: (1n << 96n).toString(),
+            activeLiquidity,
+            activeVirtualToken0Wei: activeLiquidity,
+            activeVirtualLiquidityUsdWad,
+            activeVirtualLiquidityValueBasis:
+              "stateview-active-liquidity-virtual-depth-usd",
+            tokenPriceEthWei: "1000000000000000000",
+            tokenPriceUsdWad: "2500000000000000000000",
+            totalSupplyRaw: "1000000000000000000000000",
+            tokenDecimals: 18,
+            fdvUsdWad: "2500000000000000000000000000",
+            ethUsdQuote: {
+              feedAddress: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+              roundId: "1",
+              answeredInRound: "1",
+              answer: "250000000000",
+              decimals: 8,
+              updatedAt: blockTimestamp,
+              updatedAtTime: blockTime,
+            },
+          },
+        }),
+  } as LauncherToken;
+}
+
 describe("current Explore valuation orchestration", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -125,6 +185,9 @@ describe("current Explore valuation orchestration", () => {
   it("keeps current Bitquery nested but unavailable at top level when dual evidence fails", async () => {
     mocks.readOfficialV4LiquidityEvidence.mockResolvedValue([]);
     mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([
+      tokenWithState("2000000000000000000", "10000000000000000000000"),
+    ]);
 
     const [valued] = await valueExploreEntriesWithCurrentEvidence({
       entries: [token],
@@ -227,6 +290,9 @@ describe("current Explore valuation orchestration", () => {
     );
     mocks.readOfficialV4LiquidityEvidence.mockResolvedValue([]);
     mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([
+      tokenWithState("2000000000000000000", "10000000000000000000000"),
+    ]);
 
     const read = valueExploreEntriesWithCurrentEvidence({
       entries: [token],
@@ -236,59 +302,20 @@ describe("current Explore valuation orchestration", () => {
       now: new Date("2026-08-13T00:02:00.000Z"),
     });
     await vi.waitFor(() => {
-      expect(mocks.readOfficialV4LiquidityEvidence).toHaveBeenCalledOnce();
       expect(mocks.withSameBlockEthUsdQuote).toHaveBeenCalledOnce();
+      expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalled();
     });
     resolveMarket(new Map([[tokenAddress, marketData]]));
 
     await expect(read).resolves.toHaveLength(1);
+    expect(mocks.readOfficialV4LiquidityEvidence).toHaveBeenCalledOnce();
   });
 
   it("treats exact zero active liquidity as known ineligibility, not missing coverage", async () => {
-    const blockTimestamp = "1786579320";
-    mocks.readOfficialV4LiquidityEvidence.mockResolvedValue([{
-      source: "official-uniswap-v4-subgraph",
-      identity: {
-        chainId: "1",
-        protocol: "uniswap_v4",
-        poolId,
-        tokenAddress,
-        quoteAddress: "0x0000000000000000000000000000000000000000",
-      },
-      valueBasis: "official-subgraph-pool-tvl-usd",
-      tvlUsdWad: "10000000000000000000000",
-      reportedPoolBalances: {
-        token0: {
-          address: "0x0000000000000000000000000000000000000000",
-          decimals: 18,
-          amountDecimal: "10",
-        },
-        token1: { address: tokenAddress, decimals: 18, amountDecimal: "10" },
-      },
-      freshness: "current",
-      provenance: {
-        subgraphId: "DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G",
-        deployment: "QmZsgJLiLQKpb8hxTmQ5LWyrFVvfWzVaL4WK8dfFBn7EeK",
-        indexedBlockNumber: snapshot.blockNumber,
-        indexedBlockHash: snapshot.blockHash,
-        indexedBlockTimestamp: blockTimestamp,
-        indexedBlockTime: new Date(Number(blockTimestamp) * 1_000).toISOString(),
-        referenceHeadBlockNumber: snapshot.blockNumber,
-        referenceHeadBlockHash: snapshot.blockHash,
-        lagBlocks: "0",
-      },
-    }]);
     mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
-    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([{
-      ...token,
-      liveMarketStateEvidence: {
-        source: "uniswap-v4-stateview-v1",
-        blockNumber: snapshot.blockNumber,
-        blockHash: snapshot.blockHash,
-        sqrtPriceX96: (1n << 96n).toString(),
-        activeLiquidity: "0",
-      },
-    }]);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([
+      tokenWithState("0"),
+    ]);
 
     const [valued] = await valueExploreEntriesWithCurrentEvidence({
       entries: [token],
@@ -299,7 +326,8 @@ describe("current Explore valuation orchestration", () => {
       requireCompleteLiquidityCoverage: true,
     });
 
-    expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalledOnce();
+    expect(mocks.enrichTokensWithAlchemyPoolState).toHaveBeenCalledTimes(2);
+    expect(mocks.readOfficialV4LiquidityEvidence).not.toHaveBeenCalled();
     expect(valued?.exploreKind === "token" && valued.liveMarketStateEvidence)
       .toMatchObject({
       activeLiquidity: "0",
@@ -364,6 +392,52 @@ describe("current Explore valuation orchestration", () => {
       now: new Date("2026-08-13T00:02:00.000Z"),
       requireCompleteLiquidityCoverage: true,
     })).rejects.toThrow("StateView market evidence is incomplete");
+    expect(mocks.readOfficialV4LiquidityEvidence).not.toHaveBeenCalled();
+  });
+
+  it("does not query the subgraph for exact active depth below the floor", async () => {
+    mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([
+      tokenWithState("1", "9999999999999999999999"),
+    ]);
+
+    const [valued] = await valueExploreEntriesWithCurrentEvidence({
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+      requireCompleteLiquidityCoverage: true,
+    });
+
+    expect(mocks.readOfficialV4LiquidityEvidence).not.toHaveBeenCalled();
+    expect(valued?.valuation).toEqual({
+      status: "unavailable",
+      reason: "liquidity-unavailable",
+    });
+  });
+
+  it("attaches page market data without replacing the exact sort valuation", async () => {
+    const currentEntry = {
+      ...token,
+      valuation: {
+        status: "unavailable" as const,
+        reason: "liquidity-unavailable" as const,
+      },
+    };
+
+    const [attached] = await attachBitqueryMarketDataToValuedEntries({
+      entries: [currentEntry],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      now: new Date("2026-08-13T00:02:00.000Z"),
+    });
+
+    expect(attached?.valuation).toEqual(currentEntry.valuation);
+    expect(attached?.marketData?.pools[0]?.latestTrade).toBeDefined();
+    expect(attached?.marketData?.pools[0]?.valuation).toEqual({
+      status: "unavailable",
+      reason: "inconsistent-market-data",
+    });
   });
 
   it("preserves only the exact stale historical PCAN detail valuation", async () => {

--- a/tests/data-pipeline/bitquery-golden-market-parity.test.ts
+++ b/tests/data-pipeline/bitquery-golden-market-parity.test.ts
@@ -1,0 +1,316 @@
+import {
+  encodeFunctionResult,
+  parseAbi,
+} from "viem";
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error Operational JavaScript modules intentionally have no declarations.
+import * as executionProof from "../../scripts/perf/bitquery-golden-market-parity.mjs";
+
+const { verifyBitqueryGoldenMarketExecutionV1 } = executionProof;
+
+const PCAN_ADDRESS = "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
+const POOL =
+  "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
+const QUOTE = "0x0000000000000000000000000000000000000000";
+const POOL_MANAGER = "0x000000000004444c5dc75cb358380d2e3de08a90";
+const ETH_USD_FEED = "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419";
+const TRANSACTION_HASH =
+  "0x4fd96879a7f273eb2626a09f9afa0a08a835c8d65dae2faea985f0d1967b1c75";
+const BLOCK_HASH =
+  "0x3d24f1013c5dce2b0bf473a5ad73b09c804d49343c8a4c1c4c89b1b8b06738a5";
+const BLOCK_NUMBER = "25724408";
+const BLOCK_HEX = "0x18885f8";
+const BLOCK_TIME = "2026-08-10T11:50:47.000Z";
+const SWAP_TOPIC =
+  "0x40e9cecb9f5f1f1c5b9c97dec2917b7ee92e57ba5563708daca94dd84ad7112f";
+const SWAP_DATA =
+  "0xfffffffffffffffffffffffffffffffffffffffffffffffffff572ccfd04600000000000000000000000000000000000000000000000392189b6eb5680215c2d000000000000000000000000000000000000182cf40505ad9fe965947c04960f000000000000000000000000000000000000000000000001b6c9b5b10533227c000000000000000000000000000000000000000000000000000000000002aa1b0000000000000000000000000000000000000000000000000000000000000bb8";
+const MUTATED_SWAP_DATA =
+  "0xfffffffffffffffffffffffffffffffffffffffffffffffffff572ccfd04600000000000000000000000000000000000000000000000392189b6eb5680215c2d000000000000000000000000000000000000182cf40505ad9fe965947c04960f000000000000000000000000000000000000000000000001b6c9b5b10533227c000000000000000000000000000000000000000000000000000000000002aa1b0000000000000000000000000000000000000000000000000000000000000bb9";
+const TOKEN_AMOUNT_RAW = "269793555455587899235373";
+const EXECUTION_QUOTE_WAD = "11008417139";
+const BITQUERY_PRICE_USD_WAD = "21113176432735";
+const BITQUERY_FDV_USD_WAD = "21113176432735000000";
+const CHAINLINK_EXECUTION_FDV_USD_WAD = "21094317527929000000";
+const MEV_BLOCKER = "https://rpc.mevblocker.io";
+const TENDERLY = "https://mainnet.gateway.tenderly.co";
+
+const erc20Abi = parseAbi([
+  "function decimals() view returns (uint8)",
+  "function totalSupply() view returns (uint256)",
+]);
+const feedAbi = parseAbi([
+  "function decimals() view returns (uint8)",
+  "function latestRoundData() view returns (uint80 roundId,int256 answer,uint256 startedAt,uint256 updatedAt,uint80 answeredInRound)",
+]);
+
+function token(overrides: Record<string, unknown> = {}) {
+  return {
+    tokenAddress: PCAN_ADDRESS,
+    tokenDecimals: 18,
+    totalSupplyRaw: "1000000000000000000000000",
+    valuation: {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      currency: "usd",
+      valueWad: BITQUERY_FDV_USD_WAD,
+      freshness: "stale",
+      source: "bitquery",
+      asOfTime: BLOCK_TIME,
+    },
+    marketData: {
+      schemaVersion: "programmable.market-data.v1",
+      source: "bitquery",
+      primaryPoolId: POOL,
+      pools: [{
+        identity: {
+          chainId: "1",
+          tokenAddress: PCAN_ADDRESS,
+          poolId: POOL,
+          protocol: "uniswap_v4",
+        },
+        source: "bitquery",
+        latestTrade: {
+          transactionHash: TRANSACTION_HASH,
+          transactionIndex: 66,
+          logIndex: 0,
+          blockNumber: BLOCK_NUMBER,
+          time: BLOCK_TIME,
+          tokenSide: "sell",
+          tokenAmount: "269793.555455587899235373",
+          priceQuoteWad: EXECUTION_QUOTE_WAD,
+          quoteAddress: QUOTE,
+          quoteSymbol: "ETH",
+          priceUsdWad: BITQUERY_PRICE_USD_WAD,
+          priceUsdAsOfTime: BLOCK_TIME,
+          priceUsdSource: "bitquery-token-price-index-v1",
+          rawPriceUsdWad: BITQUERY_PRICE_USD_WAD,
+        },
+      }],
+    },
+    ...overrides,
+  };
+}
+
+function swapLog(data = SWAP_DATA) {
+  return {
+    address: POOL_MANAGER,
+    topics: [
+      SWAP_TOPIC,
+      POOL,
+      "0x00000000000000000000000066a9893cc07d91d95644aedd05d03f95e1dba8af",
+    ],
+    data,
+    blockNumber: BLOCK_HEX,
+    transactionHash: TRANSACTION_HASH,
+    transactionIndex: "0x42",
+    blockHash: BLOCK_HASH,
+    logIndex: "0x7a",
+    removed: false,
+  };
+}
+
+type WitnessMutation = Readonly<{
+  receiptStatus?: string;
+  duplicateSwap?: boolean;
+  secondProviderSwapData?: string;
+  secondProviderBlockHash?: string;
+  feedUpdatedAt?: bigint;
+  answeredInRound?: bigint;
+  tokenSupply?: bigint;
+}>;
+
+function witnessFetch(mutation: WitnessMutation = {}) {
+  const calls: Array<{
+    readonly rpcUrl: string;
+    readonly method: string;
+    readonly params: unknown[];
+  }> = [];
+  const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+    const rpcUrl = String(input);
+    const request = JSON.parse(String(init?.body)) as {
+      readonly jsonrpc: string;
+      readonly id: number;
+      readonly method: string;
+      readonly params: unknown[];
+    };
+    calls.push({ rpcUrl, method: request.method, params: request.params });
+    const second = rpcUrl === TENDERLY;
+    const blockHash = second && mutation.secondProviderBlockHash
+      ? mutation.secondProviderBlockHash
+      : BLOCK_HASH;
+    let result: unknown;
+    if (request.method === "eth_blockNumber") {
+      result = "0x188860c";
+    } else if (request.method === "eth_getBlockByNumber") {
+      result = {
+        number: BLOCK_HEX,
+        hash: blockHash,
+        timestamp: "0x6a79bb17",
+      };
+    } else if (request.method === "eth_getTransactionReceipt") {
+      const log = swapLog(
+        second && mutation.secondProviderSwapData
+          ? mutation.secondProviderSwapData
+          : SWAP_DATA,
+      );
+      result = {
+        transactionHash: TRANSACTION_HASH,
+        transactionIndex: "0x42",
+        blockHash,
+        blockNumber: BLOCK_HEX,
+        status: mutation.receiptStatus ?? "0x1",
+        logs: mutation.duplicateSwap ? [log, { ...log, logIndex: "0x7b" }] : [log],
+      };
+    } else if (request.method === "eth_call") {
+      const [call, reference] = request.params as [
+        { readonly to: string; readonly data: string },
+        { readonly blockHash: string; readonly requireCanonical: boolean },
+      ];
+      expect(reference).toEqual({ blockHash, requireCanonical: true });
+      const to = call.to.toLowerCase();
+      if (to === PCAN_ADDRESS && call.data === "0x313ce567") {
+        result = encodeFunctionResult({
+          abi: erc20Abi,
+          functionName: "decimals",
+          result: 18,
+        });
+      } else if (to === PCAN_ADDRESS && call.data === "0x18160ddd") {
+        result = encodeFunctionResult({
+          abi: erc20Abi,
+          functionName: "totalSupply",
+          result: mutation.tokenSupply ?? 1_000_000n * 10n ** 18n,
+        });
+      } else if (to === ETH_USD_FEED && call.data === "0x313ce567") {
+        result = encodeFunctionResult({
+          abi: feedAbi,
+          functionName: "decimals",
+          result: 8,
+        });
+      } else if (to === ETH_USD_FEED && call.data === "0xfeaf968c") {
+        result = encodeFunctionResult({
+          abi: feedAbi,
+          functionName: "latestRoundData",
+          result: [
+            129127208515966893670n,
+            191619896499n,
+            1786359267n,
+            mutation.feedUpdatedAt ?? 1786359287n,
+            mutation.answeredInRound ?? 129127208515966893670n,
+          ],
+        });
+      } else {
+        throw new Error(`unexpected eth_call ${call.to} ${call.data}`);
+      }
+    } else {
+      throw new Error(`unexpected method ${request.method}`);
+    }
+    return new Response(JSON.stringify({
+      jsonrpc: "2.0",
+      id: request.id,
+      result,
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { calls, fetchImpl };
+}
+
+describe("Bitquery golden execution proof", () => {
+  it("reproduces the exact receipt execution through fixed archive witnesses", async () => {
+    const witness = witnessFetch();
+    const result = await verifyBitqueryGoldenMarketExecutionV1({
+      token: token(),
+      fetchImpl: witness.fetchImpl,
+    });
+    expect(result).toMatchObject({
+      schemaVersion: "programmable.bitquery-golden-market-execution.v1",
+      providerCount: 2,
+      tokenAddress: PCAN_ADDRESS,
+      poolId: POOL,
+      quoteAddress: QUOTE,
+      poolManager: POOL_MANAGER,
+      transactionHash: TRANSACTION_HASH,
+      transactionIndex: 66,
+      bitqueryTradeOrdinal: 0,
+      receiptLogIndex: 122,
+      blockNumber: BLOCK_NUMBER,
+      blockHash: BLOCK_HASH,
+      blockTime: BLOCK_TIME,
+      executionTokenSide: "sell",
+      executionAmount0: "-2970000000000000",
+      executionAmount1: TOKEN_AMOUNT_RAW,
+      executionNativeAmountWei: "2970000000000000",
+      executionTokenAmountRaw: TOKEN_AMOUNT_RAW,
+      executionPriceQuoteWad: EXECUTION_QUOTE_WAD,
+      bitqueryFdvUsdWad: BITQUERY_FDV_USD_WAD,
+      chainlinkExecutionFdvUsdWad: CHAINLINK_EXECUTION_FDV_USD_WAD,
+      executionUsdDeviationBps: 8,
+      confirmations: 20,
+      chainlink: {
+        feedAddress: ETH_USD_FEED,
+        decimals: 8,
+        answeredInRound: "129127208515966893670",
+      },
+    });
+    expect(new Set(witness.calls.map(({ rpcUrl }) => rpcUrl))).toEqual(
+      new Set([MEV_BLOCKER, TENDERLY]),
+    );
+    expect(witness.calls.filter(({ method }) => method === "eth_call"))
+      .toHaveLength(8);
+  });
+
+  it.each([
+    ["reverted receipt", { receiptStatus: "0x0" }],
+    ["ambiguous swap logs", { duplicateSwap: true }],
+    ["provider swap disagreement", { secondProviderSwapData: MUTATED_SWAP_DATA }],
+    ["provider block disagreement", { secondProviderBlockHash: `0x${"22".repeat(32)}` }],
+    ["stale Chainlink round", { feedUpdatedAt: 1786350000n }],
+    ["incomplete Chainlink round", { answeredInRound: 129127208515966893669n }],
+    ["wrong historical supply", { tokenSupply: 999_999n * 10n ** 18n }],
+  ] satisfies ReadonlyArray<readonly [string, WitnessMutation]>) (
+    "fails closed on %s",
+    async (_label, mutation) => {
+      const witness = witnessFetch(mutation);
+      await expect(verifyBitqueryGoldenMarketExecutionV1({
+        token: token(),
+        fetchImpl: witness.fetchImpl,
+      })).rejects.toThrow();
+    },
+  );
+
+  it("fails before RPC when the Bitquery execution amount or quote drifts", async () => {
+    const wrongAmount = token();
+    wrongAmount.marketData.pools[0].latestTrade.tokenAmount = "1";
+    const amountWitness = witnessFetch();
+    await expect(verifyBitqueryGoldenMarketExecutionV1({
+      token: wrongAmount,
+      fetchImpl: amountWitness.fetchImpl,
+    })).rejects.toThrow("independent execution witnesses did not agree");
+
+    const wrongQuote = token();
+    wrongQuote.marketData.pools[0].latestTrade.priceQuoteWad = "11008417140";
+    const quoteWitness = witnessFetch();
+    await expect(verifyBitqueryGoldenMarketExecutionV1({
+      token: wrongQuote,
+      fetchImpl: quoteWitness.fetchImpl,
+    })).rejects.toThrow("does not match its receipt witness");
+  });
+
+  it("rejects a self-consistent Bitquery USD value outside the Chainlink bound", async () => {
+    const wrongUsd = token();
+    const wrongPrice = "22000000000000";
+    const wrongFdv = "22000000000000000000";
+    wrongUsd.marketData.pools[0].latestTrade.priceUsdWad = wrongPrice;
+    wrongUsd.marketData.pools[0].latestTrade.rawPriceUsdWad = wrongPrice;
+    wrongUsd.valuation.valueWad = wrongFdv;
+    const witness = witnessFetch();
+    await expect(verifyBitqueryGoldenMarketExecutionV1({
+      token: wrongUsd,
+      fetchImpl: witness.fetchImpl,
+    })).rejects.toThrow("does not match its receipt witness");
+  });
+});

--- a/tests/data-pipeline/bitquery-golden-market-parity.test.ts
+++ b/tests/data-pipeline/bitquery-golden-market-parity.test.ts
@@ -313,4 +313,70 @@ describe("Bitquery golden execution proof", () => {
       fetchImpl: witness.fetchImpl,
     })).rejects.toThrow("does not match its receipt witness");
   });
+
+  it("rejects an oversized declared body without retrying deterministic framing", async () => {
+    let calls = 0;
+    let cancellations = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      const body = new ReadableStream<Uint8Array>({
+        pull() {
+          throw new Error("oversized declared responses must not be read");
+        },
+        cancel() {
+          cancellations += 1;
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { "content-length": String(128 * 1024 + 1) },
+      });
+    };
+
+    await expect(verifyBitqueryGoldenMarketExecutionV1({
+      token: token(),
+      fetchImpl,
+    })).rejects.toThrow("oversized body");
+    expect(calls).toBe(6);
+    expect(cancellations).toBe(6);
+  });
+
+  it("cancels an oversized streaming body at the hard byte limit without retrying", async () => {
+    let calls = 0;
+    let cancellations = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(96 * 1024));
+          controller.enqueue(new Uint8Array(40 * 1024));
+        },
+        cancel() {
+          cancellations += 1;
+        },
+      });
+      return new Response(body, { status: 200 });
+    };
+
+    await expect(verifyBitqueryGoldenMarketExecutionV1({
+      token: token(),
+      fetchImpl,
+    })).rejects.toThrow("oversized body");
+    expect(calls).toBe(6);
+    expect(cancellations).toBe(6);
+  });
+
+  it("does not retry a deterministic invalid JSON-RPC response", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return new Response("not-json", { status: 200 });
+    };
+
+    await expect(verifyBitqueryGoldenMarketExecutionV1({
+      token: token(),
+      fetchImpl,
+    })).rejects.toThrow("invalid JSON");
+    expect(calls).toBe(6);
+  });
 });

--- a/tests/data-pipeline/bitquery-historical-release-gate.test.ts
+++ b/tests/data-pipeline/bitquery-historical-release-gate.test.ts
@@ -6,7 +6,7 @@ import * as historicalReleaseGate from "../../scripts/perf/bitquery-historical-r
 const {
   boundedStaleMarketTimeV1,
   classifyBitqueryStaleMarketReleaseV1,
-  verifyBitqueryHistoricalGoldenReleaseV1,
+  verifyBitqueryHistoricalGoldenReleaseV2,
 } = historicalReleaseGate;
 
 const TOKEN = "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce";
@@ -18,6 +18,9 @@ const TIME = "2026-08-10T11:50:47.000Z";
 const NOW = Date.parse("2026-08-13T00:00:00.000Z");
 const PRICE = "2000000000000000000000";
 const FDV = "2000000000000000000000000";
+const TRANSACTION_HASH = `0x${"33".repeat(32)}`;
+const POOL_MANAGER = "0x000000000004444c5dc75cb358380d2e3de08a90";
+const ETH_USD_FEED = "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419";
 const MAXIMUM_DEFERRED_PCAN_AGE_MS = 96 * 60 * 60_000;
 
 function detailToken(overrides: Record<string, unknown> = {}) {
@@ -51,8 +54,15 @@ function detailToken(overrides: Record<string, unknown> = {}) {
         quality: "partial",
         asOfTime: TIME,
         latestTrade: {
+          transactionHash: TRANSACTION_HASH,
+          transactionIndex: 66,
+          logIndex: 0,
           blockNumber: BLOCK,
           time: TIME,
+          tokenSide: "sell",
+          tokenAmount: "1",
+          priceQuoteWad: "1000000000000",
+          quoteAddress: QUOTE,
           priceUsdWad: PRICE,
         },
         valuation: {
@@ -115,17 +125,39 @@ function chart() {
 
 function parity(overrides: Record<string, unknown> = {}) {
   return {
-    schemaVersion: "programmable.bitquery-golden-market-parity.v1",
+    schemaVersion: "programmable.bitquery-golden-market-execution.v1",
+    providerCount: 2,
     tokenAddress: TOKEN,
     poolId: POOL,
+    quoteAddress: QUOTE,
+    poolManager: POOL_MANAGER,
+    transactionHash: TRANSACTION_HASH,
+    transactionIndex: 66,
+    bitqueryTradeOrdinal: 0,
+    receiptLogIndex: 122,
     blockNumber: BLOCK,
     blockHash: `0x${"11".repeat(32)}`,
     blockTime: TIME,
-    historicalPoolLiquidity: "1000000",
+    executionTokenSide: "sell",
+    executionAmount0: "-1000000000000",
+    executionAmount1: "1000000000000000000",
+    executionNativeAmountWei: "1000000000000",
+    executionTokenAmountRaw: "1000000000000000000",
+    executionPriceQuoteWad: "1000000000000",
+    executionSqrtPriceX96: "1000000000000000000",
+    executionLiquidity: "1000000",
     confirmations: 20,
+    chainlink: {
+      feedAddress: ETH_USD_FEED,
+      decimals: 8,
+      roundId: "100",
+      answer: "200000000000",
+      updatedAt: "1786359287",
+      answeredInRound: "100",
+    },
     bitqueryFdvUsdWad: FDV,
-    onchainFdvUsdWad: FDV,
-    deviationBps: 0,
+    chainlinkExecutionFdvUsdWad: FDV,
+    executionUsdDeviationBps: 0,
     ...overrides,
   };
 }
@@ -133,7 +165,7 @@ function parity(overrides: Record<string, unknown> = {}) {
 describe("Bitquery historical release gate", () => {
   it("publishes the finite deferred PCAN evidence ceiling", () => {
     expect(
-      historicalReleaseGate.BITQUERY_HISTORICAL_RELEASE_V1
+      historicalReleaseGate.BITQUERY_HISTORICAL_RELEASE_V2
         .maximumDeferredPcanAgeMs,
     ).toBe(MAXIMUM_DEFERRED_PCAN_AGE_MS);
   });
@@ -146,18 +178,39 @@ describe("Bitquery historical release gate", () => {
       tokenAddress: TOKEN,
       poolId: POOL,
     });
-    expect(verifyBitqueryHistoricalGoldenReleaseV1({
+    expect(verifyBitqueryHistoricalGoldenReleaseV2({
       detailToken: token,
       chart: chart(),
       parity: parity(),
       nowMs: NOW,
     })).toMatchObject({
-      schemaVersion: "programmable.bitquery-historical-release.v1",
+      schemaVersion: "programmable.bitquery-historical-release.v2",
       temporalStatus: "deferred-pcan",
+      transactionHash: TRANSACTION_HASH,
+      receiptLogIndex: 122,
       blockNumber: BLOCK,
       bitqueryFdvUsdWad: FDV,
-      historicalPoolLiquidity: "1000000",
+      chainlinkExecutionFdvUsdWad: FDV,
       confirmations: 20,
+    });
+  });
+
+  it("accepts the canonical high precision period median emitted by PCAN", () => {
+    const highPrecisionChart = chart();
+    const lastPoint = highPrecisionChart.points[1] as {
+      priceUsd?: string;
+      priceQuote?: string;
+    };
+    delete lastPoint.priceUsd;
+    lastPoint.priceQuote = "0.00000001100841713949";
+    expect(verifyBitqueryHistoricalGoldenReleaseV2({
+      detailToken: detailToken(),
+      chart: highPrecisionChart,
+      parity: parity(),
+      nowMs: NOW,
+    })).toMatchObject({
+      schemaVersion: "programmable.bitquery-historical-release.v2",
+      receiptLogIndex: 122,
     });
   });
 
@@ -172,7 +225,7 @@ describe("Bitquery historical release gate", () => {
       token,
       nowMs: boundaryNow + 1,
     })).toThrow("historical PCAN release evidence exceeds the 96 hour ceiling");
-    expect(() => verifyBitqueryHistoricalGoldenReleaseV1({
+    expect(() => verifyBitqueryHistoricalGoldenReleaseV2({
       detailToken: token,
       chart: chart(),
       parity: parity(),
@@ -181,15 +234,21 @@ describe("Bitquery historical release gate", () => {
   });
 
   it.each([
-    ["schema", { schemaVersion: "programmable.bitquery-golden-market-parity.v2" }],
+    ["schema", { schemaVersion: "programmable.bitquery-golden-market-execution.v2" }],
     ["token", { tokenAddress: "0x1111111111111111111111111111111111111111" }],
     ["pool", { poolId: `0x${"22".repeat(32)}` }],
+    ["transaction", { transactionHash: `0x${"44".repeat(32)}` }],
+    ["receipt log", { receiptLogIndex: -1 }],
+    ["execution quote", { executionPriceQuoteWad: "1000000000001" }],
+    ["Chainlink feed", { chainlink: { ...parity().chainlink, feedAddress: TOKEN } }],
+    ["Chainlink round", { chainlink: { ...parity().chainlink, answeredInRound: "99" } }],
     ["block", { blockNumber: "25731001" }],
     ["value", { bitqueryFdvUsdWad: (BigInt(FDV) + 1n).toString() }],
     ["confirmations", { confirmations: 11 }],
-    ["historical liquidity", { historicalPoolLiquidity: "0" }],
+    ["execution liquidity", { executionLiquidity: "0" }],
+    ["execution USD deviation", { executionUsdDeviationBps: 26 }],
   ])("fails closed when the deferred PCAN parity drifts in %s", (_field, drift) => {
-    expect(() => verifyBitqueryHistoricalGoldenReleaseV1({
+    expect(() => verifyBitqueryHistoricalGoldenReleaseV2({
       detailToken: detailToken(),
       chart: chart(),
       parity: parity(drift),
@@ -200,7 +259,7 @@ describe("Bitquery historical release gate", () => {
   it("fails closed when the last chart observation is not the exact trade block", () => {
     const driftedChart = chart();
     driftedChart.points[1].blockNumber = "25731001";
-    expect(() => verifyBitqueryHistoricalGoldenReleaseV1({
+    expect(() => verifyBitqueryHistoricalGoldenReleaseV2({
       detailToken: detailToken(),
       chart: driftedChart,
       parity: parity(),
@@ -212,7 +271,7 @@ describe("Bitquery historical release gate", () => {
     const driftedChart = chart();
     driftedChart.identity.quoteAddress =
       "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
-    expect(() => verifyBitqueryHistoricalGoldenReleaseV1({
+    expect(() => verifyBitqueryHistoricalGoldenReleaseV2({
       detailToken: detailToken(),
       chart: driftedChart,
       parity: parity(),

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -1292,7 +1292,7 @@ describe("read-model performance contract", () => {
         process.cwd(),
       );
     expect(alchemyResult.ok).toBe(true);
-    expect(alchemyResult.checks).toHaveLength(18);
+    expect(alchemyResult.checks).toHaveLength(19);
 
     const exploreRoutePath = "app/api/explore/route.ts";
     const exploreRouteSource = readFileSync(
@@ -1340,6 +1340,42 @@ describe("read-model performance contract", () => {
         (failure: { id: string }) => failure.id,
       ),
     ).toContain("canonical-token-supply-quorum");
+
+    const currentMarketRpcPath =
+      "lib/market-data/current-market-rpc.server.ts";
+    const currentMarketRpcSource = readFileSync(
+      resolve(process.cwd(), currentMarketRpcPath),
+      "utf8",
+    );
+    for (const mutation of [
+      currentMarketRpcSource.replace(
+        '"https://rpc.mevblocker.io/"',
+        '"https://ethereum-rpc.publicnode.com/"',
+      ),
+      currentMarketRpcSource.replace(
+        "primary: websiteDeployment.rpcUrlSecondary",
+        "primary: websiteDeployment.rpcUrl",
+      ),
+      currentMarketRpcSource.replace(
+        'primary?.vendorGroup !== "quicknode"',
+        'primary?.vendorGroup !== "alchemy"',
+      ),
+      currentMarketRpcSource.replace(
+        "primary.endpointCommitment !== expectedQuickNodeCommitment",
+        "false",
+      ),
+    ]) {
+      const mutatedCurrentMarket =
+        alchemySourceContracts.evaluateAlchemyExploreSourceContracts(
+          process.cwd(),
+          { sourceOverrides: { [currentMarketRpcPath]: mutation } },
+        );
+      expect(
+        mutatedCurrentMarket.failures.map(
+          (failure: { id: string }) => failure.id,
+        ),
+      ).toContain("current-market-rpc-quorum");
+    }
 
     const result = sourceContracts.evaluateReadModelSourceContracts(
       process.cwd(),

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -1353,8 +1353,8 @@ describe("read-model performance contract", () => {
         '"https://ethereum-rpc.publicnode.com/"',
       ),
       currentMarketRpcSource.replace(
-        "primary: websiteDeployment.rpcUrlSecondary",
-        "primary: websiteDeployment.rpcUrl",
+        "primary: quickNodeRpcUrl()",
+        "primary: baseDeployment.rpcUrl",
       ),
       currentMarketRpcSource.replace(
         'primary?.vendorGroup !== "quicknode"',

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -792,11 +792,11 @@ describe("read-model production deploy policy", () => {
       '"./scripts/perf/bitquery-historical-release-gate.mjs"',
     );
     expect(workflow).toContain(
-      "await verifyBitqueryGoldenMarketParityV1({",
+      "await verifyBitqueryGoldenMarketExecutionV1({",
     );
     expect(workflow).toContain("const historicalPaidPathVerified =");
     expect(workflow).toContain(
-      "verifyBitqueryHistoricalGoldenReleaseV1({",
+      "verifyBitqueryHistoricalGoldenReleaseV2({",
     );
     expect(workflow).toContain(
       "historicalGoldenRelease.confirmations >= 12",
@@ -828,27 +828,26 @@ describe("read-model production deploy policy", () => {
       workflow.indexOf("Record registry identity and combined market path"),
     );
     expect(bitquerySmoke).toContain(
-      "MAINNET_RPC_URL_A: ${{ secrets.MAINNET_RPC_URL_A }}",
+      '"https://ethereum-rpc.publicnode.com"',
     );
     expect(bitquerySmoke).toContain(
-      "MAINNET_RPC_URL_B: ${{ secrets.MAINNET_RPC_URL_B }}",
-    );
-    expect(bitquerySmoke).toContain(
-      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}",
-    );
-    expect(bitquerySmoke).toContain(
-      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}",
-    );
-    expect(bitquerySmoke).toContain(
-      '"./scripts/perf/read-model-provider-binding.mjs"',
-    );
-    expect(bitquerySmoke).toContain(
-      "runtimeProductionProviderBindingsFromUrls({",
-    );
-    expect(bitquerySmoke).toContain(
-      "binding.endpointCommitment !== expectedCommitment",
+      '"https://rpc.mevblocker.io"',
     );
     expect(bitquerySmoke).toContain("rpcUrls: independentRpcUrls");
+    expect(bitquerySmoke).not.toContain("MAINNET_RPC_URL_A");
+    expect(bitquerySmoke).not.toContain("MAINNET_RPC_URL_B");
+    expect(bitquerySmoke).not.toContain(
+      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT",
+    );
+    expect(bitquerySmoke).not.toContain(
+      "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT",
+    );
+    expect(bitquerySmoke).not.toContain(
+      "runtimeProductionProviderBindingsFromUrls",
+    );
+    expect(bitquerySmoke).not.toContain(
+      '"./scripts/perf/read-model-provider-binding.mjs"',
+    );
     expect(bitquerySmoke).toContain(
       "/api/explore?limit=20&page=1&q=${goldenTokenAddress}&sort=market-cap",
     );
@@ -858,7 +857,7 @@ describe("read-model production deploy policy", () => {
     expect(bitquerySmoke).not.toContain("/api/ops/health");
     expect(bitquerySmoke).not.toContain("/api/explore/profile");
     expect(bitquerySmoke).not.toMatch(
-      /\b(?:database|projector|envio|real-block|sla)\b/iu,
+      /\b(?:database|projector|quicknode|envio|real-block|sla)\b/iu,
     );
     expect(workflow).toContain("Reverify staged candidate binding");
     expect(workflow).toContain("Record staged candidate handoff");

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -2,7 +2,13 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { encodeFunctionData, encodeFunctionResult, parseAbi } from "viem";
+import {
+  encodeAbiParameters,
+  encodeFunctionData,
+  encodeFunctionResult,
+  parseAbi,
+  parseAbiParameters,
+} from "viem";
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
@@ -22,6 +28,10 @@ const GOLDEN_POOL_ID =
   "0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229";
 const GOLDEN_QUOTE_ADDRESS =
   "0x0000000000000000000000000000000000000000";
+const GOLDEN_POOL_MANAGER = "0x000000000004444c5dc75cb358380d2e3de08a90";
+const GOLDEN_SWAP_TOPIC =
+  "0x40e9cecb9f5f1f1c5b9c97dec2917b7ee92e57ba5563708daca94dd84ad7112f";
+const GOLDEN_TRANSACTION_HASH = `0x${"22".repeat(32)}`;
 const PUBLIC_TOKEN_ADDRESS =
   "0x1111111111111111111111111111111111111111";
 const PUBLIC_POOL_ID = `0x${"44".repeat(32)}`;
@@ -828,28 +838,12 @@ describe("read-model operations source contract", () => {
 
   it.each([
     [
-      "first independent RPC secret",
-      "          MAINNET_RPC_URL_A: ${{ secrets.MAINNET_RPC_URL_A }}\n",
+      "PublicNode witness",
+      '            "https://ethereum-rpc.publicnode.com",\n',
     ],
     [
-      "second independent RPC secret",
-      "          MAINNET_RPC_URL_B: ${{ secrets.MAINNET_RPC_URL_B }}\n",
-    ],
-    [
-      "Alchemy commitment",
-      "          PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT }}\n",
-    ],
-    [
-      "QuickNode commitment",
-      "          PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT: ${{ vars.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT }}\n",
-    ],
-    [
-      "provider binding",
-      "            runtimeProductionProviderBindingsFromUrls({\n",
-    ],
-    [
-      "commitment comparison",
-      "            if (binding.endpointCommitment !== expectedCommitment) {\n",
+      "MEV Blocker witness",
+      '            "https://rpc.mevblocker.io",\n',
     ],
     ["independent reader handoff", "                rpcUrls: independentRpcUrls,\n"],
   ])("fails closed when staged market proof drops the %s", (_label, needle) => {
@@ -1086,18 +1080,53 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("fails closed when independent PCAN parity drops exact-block liquidity", () => {
+  it.each([
+    '"https://mainnet.gateway.tenderly.co"',
+    '"eth_getTransactionReceipt"',
+    '"event Swap(bytes32 indexed id,address indexed sender,int128 amount0,int128 amount1,uint160 sqrtPriceX96,uint128 liquidity,int24 tick,uint24 fee)"',
+    "swapLogs.length !== 1",
+    'rpcQuantity(receipt?.status, "receipt status") !== 1n',
+    "requireCanonical: true",
+    "sameObservation(first, second)",
+    "first.amount0 >= 0n",
+    "first.amount1 !== tokenAmountRaw",
+    "executionPriceQuoteWad !== priceQuoteWad",
+    "executionPriceQuoteWad * first.answer",
+    "observation.answeredInRound < observation.roundId",
+    "const MAXIMUM_EXECUTION_USD_DEVIATION_BPS = 25n",
+  ])("fails closed when the PCAN execution proof drops %s", (needle) => {
     const parityPath = "scripts/perf/bitquery-golden-market-parity.mjs";
     const parity = readFileSync(resolve(ROOT, parityPath), "utf8");
-    const unsafeParity = parity.replace(
-      '  "function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)",\n',
-      "",
-    );
+    expect(parity).toContain(needle);
+    const unsafeParity = parity.replace(needle, "MUTATED_EXECUTION_PROOF");
     expect(unsafeParity).not.toBe(parity);
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: {
         ...integratedOverrides(),
         [parityPath]: unsafeParity,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-bitquery-stage-smoke",
+    );
+  });
+
+  it.each([
+    "parity.transactionHash !== trade?.transactionHash?.toLowerCase()",
+    "parity.bitqueryTradeOrdinal !== trade?.logIndex",
+    "parity.executionPriceQuoteWad !== trade?.priceQuoteWad",
+    "parity.chainlink?.feedAddress !== MAINNET_ETH_USD_FEED",
+    "BigInt(parity.chainlink.answeredInRound) < BigInt(parity.chainlink.roundId)",
+  ])("fails closed when historical PCAN binding drops %s", (needle) => {
+    const helperPath = "scripts/perf/bitquery-historical-release-gate.mjs";
+    const helper = readFileSync(resolve(ROOT, helperPath), "utf8");
+    expect(helper).toContain(needle);
+    const unsafeHelper = helper.replace(needle, "MUTATED_EXECUTION_BINDING");
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [helperPath]: unsafeHelper,
       },
       expectedSha256Overrides: fixtureDigests(),
     });
@@ -1740,7 +1769,12 @@ function publicFetch(
 
   return async (input: URL | RequestInfo, init?: RequestInit) => {
     const url = new URL(String(input));
-    if (url.hostname === "rpc-a.invalid" || url.hostname === "rpc-b.invalid") {
+    if (
+      url.hostname === "rpc-a.invalid" ||
+      url.hostname === "rpc-b.invalid" ||
+      url.hostname === "rpc.mevblocker.io" ||
+      url.hostname === "mainnet.gateway.tenderly.co"
+    ) {
       const request = JSON.parse(String(init?.body ?? "{}")) as {
         id: number;
         method: string;
@@ -1758,6 +1792,34 @@ function publicFetch(
           timestamp: `0x${BigInt(Math.floor(Date.parse(
             current ? publicMarketAsOf : goldenMarketAsOf,
           ) / 1_000)).toString(16)}`,
+        };
+      } else if (request.method === "eth_getTransactionReceipt") {
+        result = {
+          transactionHash: GOLDEN_TRANSACTION_HASH,
+          transactionIndex: "0x1",
+          blockHash: `0x${"11".repeat(32)}`,
+          blockNumber: `0x${TEST_PARITY_BLOCK.toString(16)}`,
+          status: "0x1",
+          logs: [{
+            address: GOLDEN_POOL_MANAGER,
+            topics: [
+              GOLDEN_SWAP_TOPIC,
+              GOLDEN_POOL_ID,
+              `0x${"0".repeat(24)}${"33".repeat(20)}`,
+            ],
+            data: encodeAbiParameters(
+              parseAbiParameters(
+                "int128 amount0,int128 amount1,uint160 sqrtPriceX96,uint128 liquidity,int24 tick,uint24 fee",
+              ),
+              [-(10n ** 18n), 10n ** 18n, 2n ** 96n, 1_000_000n, 0, 3_000],
+            ),
+            blockNumber: `0x${TEST_PARITY_BLOCK.toString(16)}`,
+            transactionHash: GOLDEN_TRANSACTION_HASH,
+            transactionIndex: "0x1",
+            blockHash: `0x${"11".repeat(32)}`,
+            logIndex: "0x7a",
+            removed: false,
+          }],
         };
       } else if (request.method === "eth_getCode") {
         result = TEST_STATE_VIEW_RUNTIME_CODE;
@@ -1928,11 +1990,16 @@ function publicFetch(
               quality: "partial",
               asOfTime: goldenMarketAsOf,
               latestTrade: {
-                transactionHash: `0x${"22".repeat(32)}`,
+                transactionHash: GOLDEN_TRANSACTION_HASH,
+                transactionIndex: 1,
                 logIndex: 1,
                 blockNumber: TEST_PARITY_BLOCK.toString(),
                 time: goldenMarketAsOf,
-                tokenSide: "buy",
+                tokenSide: "sell",
+                tokenAmount: "1",
+                priceQuoteWad: (10n ** 18n).toString(),
+                quoteAddress: GOLDEN_QUOTE_ADDRESS,
+                quoteSymbol: "ETH",
                 priceUsdWad: TEST_PRICE_USD_WAD.toString(),
                 rawPriceUsdWad: TEST_PRICE_USD_WAD.toString(),
                 priceUsdAsOfTime: goldenMarketAsOf,
@@ -2440,38 +2507,21 @@ describe("post-promotion route verification", () => {
     );
   });
 
-  it("rejects historical PCAN evidence when exact-block pool liquidity is zero", async () => {
+  it("rejects historical PCAN evidence when its archive receipt reverted", async () => {
     const base = publicFetch("healthy", 58 * 60 * 60_000);
-    const liquiditySelector = encodeFunctionData({
-      abi: testStateViewAbi,
-      functionName: "getLiquidity",
-      args: [GOLDEN_POOL_ID],
-    }).slice(0, 10);
     const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
       const url = new URL(String(input));
-      if (url.hostname !== "rpc-a.invalid" && url.hostname !== "rpc-b.invalid") {
-        return base(input, init);
-      }
-      const request = JSON.parse(String(init?.body ?? "{}")) as {
-        id: number;
-        method: string;
-        params: readonly [{ data?: string }];
-      };
+      const response = await base(input, init);
       if (
-        request.method === "eth_call" &&
-        request.params[0]?.data?.startsWith(liquiditySelector)
-      ) {
-        return Response.json({
-          jsonrpc: "2.0",
-          id: request.id,
-          result: encodeFunctionResult({
-            abi: testStateViewAbi,
-            functionName: "getLiquidity",
-            result: 0n,
-          }),
-        });
-      }
-      return base(input, init);
+        !["rpc.mevblocker.io", "mainnet.gateway.tenderly.co"].includes(
+          url.hostname,
+        )
+      ) return response;
+      const request = JSON.parse(String(init?.body ?? "{}")) as { method: string };
+      if (request.method !== "eth_getTransactionReceipt") return response;
+      const body = await response.json();
+      body.result.status = "0x0";
+      return Response.json(body);
     };
     const result = await verifyPostPromotion(postPromotionInput(fetchImpl));
     expect(result.ok).toBe(false);
@@ -2552,12 +2602,12 @@ describe("post-promotion route verification", () => {
     );
   });
 
-  it("rejects two market parity readers that disagree on the exact block", async () => {
+  it("rejects two archive execution witnesses that disagree on the exact block", async () => {
     const base = publicFetch();
     const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
       const url = new URL(String(input));
       const response = await base(input, init);
-      if (url.hostname !== "rpc-b.invalid") return response;
+      if (url.hostname !== "mainnet.gateway.tenderly.co") return response;
       const request = JSON.parse(String(init?.body ?? "{}")) as { method: string };
       if (request.method !== "eth_getBlockByNumber") return response;
       const body = await response.json();

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -22,7 +22,9 @@ const mocks = vi.hoisted(() => ({
   getOnchainDeployment: vi.fn(),
   readDurableExploreModel: vi.fn(),
   readBitqueryTokenMarketDataV1: vi.fn(),
+  currentMarketOnchainDeployment: vi.fn(),
   hydrateMissingCanonicalTokenSupplyV1: vi.fn(),
+  attachBitqueryMarketDataToValuedEntries: vi.fn(),
   valueExploreEntriesWithCurrentEvidence: vi.fn(),
   settleCurrentEvidenceSnapshot: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
@@ -71,6 +73,11 @@ vi.mock("../lib/market-data/bitquery.server", () => ({
   readBitqueryTokenMarketDataV1: mocks.readBitqueryTokenMarketDataV1,
 }));
 
+vi.mock("../lib/market-data/current-market-rpc.server", () => ({
+  currentMarketOnchainDeployment:
+    mocks.currentMarketOnchainDeployment,
+}));
+
 vi.mock("../lib/market-data/canonical-token-supply.server", () => ({
   hydrateMissingCanonicalTokenSupplyV1:
     mocks.hydrateMissingCanonicalTokenSupplyV1,
@@ -78,6 +85,8 @@ vi.mock("../lib/market-data/canonical-token-supply.server", () => ({
 
 vi.mock("../lib/market-data/current-valuation.server", () => ({
   CURRENT_EVIDENCE_ROUTE_DEADLINE_MS: 4_500,
+  attachBitqueryMarketDataToValuedEntries:
+    mocks.attachBitqueryMarketDataToValuedEntries,
   settleCurrentEvidenceSnapshot: mocks.settleCurrentEvidenceSnapshot,
   valueExploreEntriesWithCurrentEvidence:
     mocks.valueExploreEntriesWithCurrentEvidence,
@@ -86,6 +95,7 @@ vi.mock("../lib/market-data/current-valuation.server", () => ({
 import {
   valuationSortValue,
   withBitqueryMarketData,
+  type ValuedExploreEntry,
 } from "../lib/explore-financial-data";
 
 import {
@@ -260,6 +270,11 @@ describe("Explore API Bitquery market boundary", () => {
       status: "ready",
       rpcUrlSecondary: "https://secondary.example",
     });
+    mocks.currentMarketOnchainDeployment.mockReturnValue({
+      status: "ready",
+      rpcUrl: "https://current-primary.example",
+      rpcUrlSecondary: "https://current-secondary.example",
+    });
     mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(snapshot);
     mocks.settleCurrentEvidenceSnapshot.mockImplementation(
       async ({ read }: { read: Promise<unknown> }) => await read,
@@ -277,6 +292,46 @@ describe("Explore API Bitquery market boundary", () => {
     mocks.hydrateMissingCanonicalTokenSupplyV1.mockImplementation(
       async (entries: readonly ExploreEntry[]) => [...entries],
     );
+    mocks.attachBitqueryMarketDataToValuedEntries.mockImplementation(
+      async ({
+        entries,
+        marketByToken,
+        maximumValuationAgeMs,
+        now,
+      }: {
+        entries: readonly ValuedExploreEntry[];
+        marketByToken: Promise<ReadonlyMap<string, TokenMarketDataV1>>;
+        maximumValuationAgeMs?: number;
+        now?: Date;
+      }) => {
+        const markets = await marketByToken;
+        return entries.map((entry) => {
+          const market = entry.tokenAddress
+            ? markets.get(entry.tokenAddress.toLowerCase())
+            : undefined;
+          if (!market) {
+            return entry.valuation.status === "available" &&
+                entry.valuation.source === "bitquery"
+              ? {
+                  ...entry,
+                  valuation: {
+                    status: "unavailable" as const,
+                    reason: "source-unavailable" as const,
+                  },
+                }
+              : entry;
+          }
+          const withMarketData = withBitqueryMarketData(entry, market, {
+            maximumValuationAgeMs,
+            now,
+          });
+          return entry.valuation.status === "available" &&
+              entry.valuation.source !== "bitquery"
+            ? { ...withMarketData, valuation: entry.valuation }
+            : withMarketData;
+        });
+      },
+    );
     mocks.valueExploreEntriesWithCurrentEvidence.mockImplementation(
       async ({
         entries,
@@ -289,7 +344,21 @@ describe("Explore API Bitquery market boundary", () => {
         maximumValuationAgeMs?: number;
         now?: Date;
       }) => {
-        const markets = await marketByToken;
+        const receivedMarkets = await marketByToken;
+        const markets = receivedMarkets.size > 0
+          ? receivedMarkets
+          : bitqueryMarketData(entries.flatMap((entry) =>
+              entry.exploreKind === "token"
+                ? [{
+                    chainId: "1" as const,
+                    tokenAddress: entry.tokenAddress,
+                    poolId: entry.poolId,
+                    quoteAddress:
+                      "0x0000000000000000000000000000000000000000" as const,
+                    protocol: "uniswap_v4" as const,
+                  }]
+                : []
+            ));
         return entries.map((entry) => {
           const market = entry.tokenAddress
             ? markets.get(entry.tokenAddress.toLowerCase())
@@ -631,6 +700,26 @@ describe("Explore API Bitquery market boundary", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(mocks.currentMarketOnchainDeployment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "ready",
+        rpcUrlSecondary: "https://secondary.example",
+      }),
+    );
+    expect(mocks.readVerifiedOperationalMarketSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpcUrl: "https://current-primary.example",
+        rpcUrlSecondary: "https://current-secondary.example",
+      }),
+    );
+    expect(mocks.valueExploreEntriesWithCurrentEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deployment: expect.objectContaining({
+          rpcUrl: "https://current-primary.example",
+          rpcUrlSecondary: "https://current-secondary.example",
+        }),
+      }),
+    );
     expect(body).toMatchObject({
       status: "ready",
       page: 1,
@@ -715,6 +804,67 @@ describe("Explore API Bitquery market boundary", () => {
     expect(
       mocks.readBitqueryTokenMarketDataV1.mock.calls[0]?.[0],
     ).toHaveLength(30);
+  });
+
+  it("sorts global current evidence before reading Bitquery for only the page", async () => {
+    let currentInputEntries: readonly ExploreEntry[] = [];
+    let resolveCurrent!: (value: ValuedExploreEntry[]) => void;
+    mocks.valueExploreEntriesWithCurrentEvidence.mockImplementationOnce(
+      ({
+        entries,
+        marketByToken,
+        requireCompleteLiquidityCoverage,
+      }: {
+        entries: readonly ExploreEntry[];
+        marketByToken: ReadonlyMap<string, TokenMarketDataV1>;
+        requireCompleteLiquidityCoverage: boolean;
+      }) => {
+        currentInputEntries = entries;
+        expect(marketByToken.size).toBe(0);
+        expect(requireCompleteLiquidityCoverage).toBe(true);
+        return new Promise<ValuedExploreEntry[]>((resolve) => {
+          resolveCurrent = resolve;
+        });
+      },
+    );
+
+    const responseRead = GET(
+      new NextRequest("http://localhost/api/explore?sort=market-cap"),
+    );
+    await vi.waitFor(() => {
+      expect(mocks.valueExploreEntriesWithCurrentEvidence).toHaveBeenCalledOnce();
+    });
+    expect(currentInputEntries).toHaveLength(30);
+    expect(mocks.readBitqueryTokenMarketDataV1).not.toHaveBeenCalled();
+
+    resolveCurrent(currentInputEntries.map((entry) => ({
+      ...entry,
+      valuation: {
+        status: "unavailable" as const,
+        reason: "liquidity-unavailable" as const,
+      },
+    })));
+    const response = await responseRead;
+
+    expect(response.status).toBe(200);
+    expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledOnce();
+    expect(
+      mocks.readBitqueryTokenMarketDataV1.mock.calls[0]?.[0],
+    ).toHaveLength(9);
+  });
+
+  it("fails a global current-evidence read before starting Bitquery", async () => {
+    mocks.valueExploreEntriesWithCurrentEvidence.mockRejectedValueOnce(
+      new Error("Current market evidence reference head is unavailable"),
+    );
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/explore?sort=market-cap"),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mocks.readBitqueryTokenMarketDataV1).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -277,7 +277,13 @@ describe("Explore API Bitquery market boundary", () => {
     });
     mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(snapshot);
     mocks.settleCurrentEvidenceSnapshot.mockImplementation(
-      async ({ read }: { read: Promise<unknown> }) => await read,
+      async ({
+        read,
+        signal,
+      }: {
+        read: (signal: AbortSignal) => Promise<unknown>;
+        signal?: AbortSignal;
+      }) => await read(signal ?? new AbortController().signal),
     );
     mocks.withSameBlockEthUsdQuote.mockImplementation(
       async ({ snapshot: value }) => value,
@@ -703,14 +709,15 @@ describe("Explore API Bitquery market boundary", () => {
     expect(mocks.currentMarketOnchainDeployment).toHaveBeenCalledWith(
       expect.objectContaining({
         status: "ready",
-        rpcUrlSecondary: "https://secondary.example",
       }),
     );
+    expect(mocks.getAlchemyOnchainDeployment).not.toHaveBeenCalled();
     expect(mocks.readVerifiedOperationalMarketSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({
         rpcUrl: "https://current-primary.example",
         rpcUrlSecondary: "https://current-secondary.example",
       }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(mocks.valueExploreEntriesWithCurrentEvidence).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/onchain-rpc-health.test.ts
+++ b/tests/onchain-rpc-health.test.ts
@@ -94,6 +94,36 @@ function dependencies(
 }
 
 describe("operational RPC health", () => {
+  it("propagates caller aborts into the active health transport without failover", async () => {
+    const controller = new AbortController();
+    let observedSignal: AbortSignal | undefined;
+    const pending = (signal?: AbortSignal) => new Promise<never>(
+      (_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason), {
+          once: true,
+        });
+      },
+    );
+    const createClient = vi.fn((_rpcUrl: string, signal?: AbortSignal) => {
+      observedSignal = signal;
+      return {
+        getChainId: () => pending(signal),
+        getBlockNumber: () => pending(signal),
+        getBlock: () => pending(signal),
+      };
+    });
+    const read = readOperationalRpcHealth(deployment, {
+      createClient,
+      nowMs: () => NOW_MS,
+    }, controller.signal);
+
+    await vi.waitFor(() => expect(observedSignal).toBe(controller.signal));
+    controller.abort(new Error("current evidence deadline"));
+
+    await expect(read).rejects.toThrow("current evidence deadline");
+    expect(createClient).toHaveBeenCalledTimes(1);
+  });
+
   it("reports healthy only when both fixed providers agree", async () => {
     const primary = client({
       head: 100n,

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   getOnchainDeployment: vi.fn(),
   readDurableExploreModel: vi.fn(),
   readBitqueryTokenMarketDataV1: vi.fn(),
+  currentMarketOnchainDeployment: vi.fn(),
   hydrateMissingCanonicalTokenSupplyV1: vi.fn(),
   valueExploreEntriesWithCurrentEvidence: vi.fn(),
   settleCurrentEvidenceSnapshot: vi.fn(),
@@ -69,6 +70,11 @@ vi.mock("../lib/onchain/durable-model", () => ({
 
 vi.mock("../lib/market-data/bitquery.server", () => ({
   readBitqueryTokenMarketDataV1: mocks.readBitqueryTokenMarketDataV1,
+}));
+
+vi.mock("../lib/market-data/current-market-rpc.server", () => ({
+  currentMarketOnchainDeployment:
+    mocks.currentMarketOnchainDeployment,
 }));
 
 vi.mock("../lib/market-data/canonical-token-supply.server", () => ({
@@ -179,6 +185,11 @@ describe("token detail Bitquery market read", () => {
       status: "ready",
       rpcUrlSecondary: "https://secondary.example",
     });
+    mocks.currentMarketOnchainDeployment.mockReturnValue({
+      status: "ready",
+      rpcUrl: "https://current-primary.example",
+      rpcUrlSecondary: "https://current-secondary.example",
+    });
     mocks.getOnchainDeployment.mockReturnValue({ status: "ready" });
     mocks.readProductionCustomExploreDirectoryV1.mockResolvedValue([]);
     mocks.readExploreReferenceHeadWithinRouteBudget.mockResolvedValue({
@@ -266,6 +277,26 @@ describe("token detail Bitquery market read", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(mocks.currentMarketOnchainDeployment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "ready",
+        rpcUrlSecondary: "https://secondary.example",
+      }),
+    );
+    expect(mocks.readVerifiedOperationalMarketSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpcUrl: "https://current-primary.example",
+        rpcUrlSecondary: "https://current-secondary.example",
+      }),
+    );
+    expect(mocks.valueExploreEntriesWithCurrentEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deployment: expect.objectContaining({
+          rpcUrl: "https://current-primary.example",
+          rpcUrlSecondary: "https://current-secondary.example",
+        }),
+      }),
+    );
     expect(mocks.readAlchemyExploreModel).toHaveBeenCalledTimes(1);
     expect(mocks.enrichTokensWithAlchemyPoolState).not.toHaveBeenCalled();
     expect(mocks.readBitqueryTokenMarketDataV1).toHaveBeenCalledWith(

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -202,7 +202,13 @@ describe("token detail Bitquery market read", () => {
       launchDiscoverySnapshot,
     );
     mocks.settleCurrentEvidenceSnapshot.mockImplementation(
-      async ({ read }: { read: Promise<unknown> }) => await read,
+      async ({
+        read,
+        signal,
+      }: {
+        read: (signal: AbortSignal) => Promise<unknown>;
+        signal?: AbortSignal;
+      }) => await read(signal ?? new AbortController().signal),
     );
     mocks.withSameBlockEthUsdQuote.mockImplementation(
       async ({ snapshot: value }) => value,
@@ -280,14 +286,15 @@ describe("token detail Bitquery market read", () => {
     expect(mocks.currentMarketOnchainDeployment).toHaveBeenCalledWith(
       expect.objectContaining({
         status: "ready",
-        rpcUrlSecondary: "https://secondary.example",
       }),
     );
+    expect(mocks.getAlchemyOnchainDeployment).not.toHaveBeenCalled();
     expect(mocks.readVerifiedOperationalMarketSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({
         rpcUrl: "https://current-primary.example",
         rpcUrlSecondary: "https://current-secondary.example",
       }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(mocks.valueExploreEntriesWithCurrentEvidence).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/uniswap-v4-subgraph.test.ts
+++ b/tests/uniswap-v4-subgraph.test.ts
@@ -277,6 +277,43 @@ describe("official Uniswap v4 subgraph adapter", () => {
     ]);
   });
 
+  it("propagates a caller deadline into the active subgraph fetch", async () => {
+    const controller = new AbortController();
+    let observedSignal: AbortSignal | null | undefined;
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      observedSignal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(init.signal?.reason),
+          { once: true },
+        );
+      });
+    });
+    const read = readOfficialV4LiquidityEvidence(
+      {
+        tokens: [canonicalToken()],
+        referenceHead: {
+          chainId: 1,
+          blockNumber: "25630000",
+          blockHash: `0x${"44".repeat(32)}`,
+        },
+      },
+      {
+        apiKey: "graph-secret",
+        endpoint: OFFICIAL_ENDPOINT,
+        fetcher,
+        signal: controller.signal,
+      },
+    );
+
+    await vi.waitFor(() => expect(observedSignal).toBeInstanceOf(AbortSignal));
+    controller.abort(new Error("current evidence deadline"));
+
+    await expect(read).rejects.toThrow("current evidence deadline");
+    expect(observedSignal?.aborted).toBe(true);
+  });
+
   it("distinguishes shallow pools from stale or internally conflicting evidence", async () => {
     async function read(
       response: unknown,


### PR DESCRIPTION
## What changed

- moves complete market-cap valuation ahead of Bitquery page enrichment so global failures return inside the current-evidence budget
- loads Bitquery only for the selected page and keeps exact StateView plus Chainlink valuation intact
- isolates current public market evidence onto commitment-bound QuickNode plus a fixed independent MEVBlocker witness without changing Discovery, Ops, indexed or historical bindings
- reduces all-range chart aggregation to a complete bounded 32-period query
- replaces the historical PCAN spot comparison with two independent exact receipt and execution witnesses

## Root causes

The previous global path waited for all-token Bitquery enrichment even after current evidence had already failed. The staged Alchemy side of the public current-evidence quorum was also unavailable, and the historical PCAN gate compared execution data with post-swap spot state.

## Validation

- interface CI: 3319 passed, 7 skipped
- TypeScript passed
- operations source gate passed
- Alchemy and market source gate 19 of 19 passed
- Actionlint and script syntax passed
- Gitleaks found no leaks
- diff check clean

This PR remains fail-closed: no indexed or projector flags are enabled, and promotion still requires the exact staged API, chart, current valuation, liquidity and historical receipt gates.