### PR TITLE
Pin production read-model watchdog to Node 24

### DIFF
--- a/.github/workflows/refresh-production-read-model.yml
+++ b/.github/workflows/refresh-production-read-model.yml
@@ -23,6 +23,12 @@ jobs:
       name: production
 
     steps:
+      - name: Install pinned Node.js runtime
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+          cache: false
+
       - name: Refresh and prove durable freshness
         shell: bash
         env:

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -10,7 +10,14 @@
       "provider": "github-actions",
       "workflow": {
         "path": ".github/workflows/refresh-production-read-model.yml",
-        "sha256": "e4dd949194ef4046382e9930fe66bd3f63195578b63ed970b0e9ae2a421d2a9d"
+        "sha256": "3da07d2ec2ae59991aea77da64c0552e8d9fc7ed96a7d6b9130bdc469d7cc9c6"
+      },
+      "nodeRuntime": {
+        "setupAction": "actions/setup-node",
+        "setupActionSha": "820762786026740c76f36085b0efc47a31fe5020",
+        "setupActionRelease": "v7.0.0",
+        "version": "24.14.0",
+        "dependencyCache": false
       },
       "schedule": "2-57/5 * * * *",
       "targetOrigin": "https://programmable.market",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -15,7 +15,14 @@ const APPROVED_OPERATIONS = Object.freeze({
       provider: "github-actions",
       workflow: Object.freeze({
         path: ".github/workflows/refresh-production-read-model.yml",
-        sha256: "e4dd949194ef4046382e9930fe66bd3f63195578b63ed970b0e9ae2a421d2a9d",
+        sha256: "3da07d2ec2ae59991aea77da64c0552e8d9fc7ed96a7d6b9130bdc469d7cc9c6",
+      }),
+      nodeRuntime: Object.freeze({
+        setupAction: "actions/setup-node",
+        setupActionSha: "820762786026740c76f36085b0efc47a31fe5020",
+        setupActionRelease: "v7.0.0",
+        version: "24.14.0",
+        dependencyCache: false,
       }),
       schedule: "2-57/5 * * * *",
       targetOrigin: "https://programmable.market",
@@ -786,6 +793,16 @@ function legacySchedulerWatchdogIsFailClosed(
   source,
   expectedSha256Overrides,
 ) {
+  const pinnedNodeSetup = [
+    "      - name: Install pinned Node.js runtime",
+    `        uses: ${binding?.nodeRuntime?.setupAction}@${binding?.nodeRuntime?.setupActionSha} # ${binding?.nodeRuntime?.setupActionRelease}`,
+    "        with:",
+    `          node-version: ${binding?.nodeRuntime?.version}`,
+    `          cache: ${binding?.nodeRuntime?.dependencyCache}`,
+  ].join("\n");
+  const pinnedNodeSetupIndex = workflowSource?.indexOf(pinnedNodeSetup) ?? -1;
+  const watchdogStepIndex =
+    workflowSource?.indexOf("      - name: Refresh and prove durable freshness") ?? -1;
   return (
     typeof workflowSource === "string" &&
     binding?.provider === "github-actions" &&
@@ -795,6 +812,12 @@ function legacySchedulerWatchdogIsFailClosed(
     binding.secretEnvironment === "CRON_SECRET" &&
     binding.concurrencyGroup === "production-read-model-refresh" &&
     binding.freshnessMaximumAgeSeconds === 600 &&
+    binding.nodeRuntime?.setupAction === "actions/setup-node" &&
+    binding.nodeRuntime?.setupActionSha ===
+      "820762786026740c76f36085b0efc47a31fe5020" &&
+    binding.nodeRuntime?.setupActionRelease === "v7.0.0" &&
+    binding.nodeRuntime?.version === "24.14.0" &&
+    binding.nodeRuntime?.dependencyCache === false &&
     binding.rpcProof?.confirmedBlockRequired === true &&
     binding.rpcProof?.providerPairRequired === true &&
     binding.rpcProof?.maximumHeadAgeSeconds === 300 &&
@@ -810,6 +833,9 @@ function legacySchedulerWatchdogIsFailClosed(
     workflowSource.includes("github.ref == 'refs/heads/production'") &&
     workflowSource.includes("    timeout-minutes: 9") &&
     workflowSource.includes("      name: production") &&
+    pinnedNodeSetupIndex >= 0 &&
+    pinnedNodeSetupIndex < watchdogStepIndex &&
+    workflowSource.match(/uses:\s*actions\/setup-node@/gu)?.length === 1 &&
     workflowSource.includes("CRON_SECRET: ${{ secrets.CRON_SECRET }}") &&
     workflowSource.includes("TARGET_ORIGIN: https://programmable.market") &&
     workflowSource.includes('targetOrigin !== "https://programmable.market"') &&

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -633,6 +633,12 @@ describe("read-model operations source contract", () => {
 
   it.each([
     ["unprotected branch", "github.ref == 'refs/heads/production'"],
+    [
+      "pinned Node setup action",
+      "uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0",
+    ],
+    ["Node 24 runtime", "node-version: 24.14.0"],
+    ["disabled dependency cache", "cache: false"],
     ["fixed public origin", 'targetOrigin !== "https://programmable.market"'],
     ["bounded cron secret", "secretBytes < 32"],
     ["canonical writer route", '"/api/ops/index-v2"'],
@@ -656,6 +662,66 @@ describe("read-model operations source contract", () => {
     const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
     expect(workflow).toContain(needle);
     const unsafeWorkflow = workflow.replace(needle, "REMOVED_WATCHDOG_GATE");
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-legacy-scheduler-watchdog",
+    );
+  });
+
+  it("rejects a production watchdog that installs Node after executing it", () => {
+    const workflowPath =
+      ".github/workflows/refresh-production-read-model.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const setupStart = workflow.indexOf(
+      "      - name: Install pinned Node.js runtime\n",
+    );
+    const watchdogStart = workflow.indexOf(
+      "      - name: Refresh and prove durable freshness\n",
+    );
+    expect(setupStart).toBeGreaterThanOrEqual(0);
+    expect(watchdogStart).toBeGreaterThan(setupStart);
+    const setupBlock = workflow.slice(setupStart, watchdogStart);
+    const unsafeWorkflow = `${workflow.slice(0, setupStart)}${workflow.slice(
+      watchdogStart,
+    )}\n${setupBlock}`;
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: unsafeWorkflow,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-legacy-scheduler-watchdog",
+    );
+  });
+
+  it.each([
+    [
+      "Node 22",
+      (workflow: string) =>
+        workflow.replace("node-version: 24.14.0", "node-version: 22.22.0"),
+    ],
+    [
+      "the runner default",
+      (workflow: string) =>
+        workflow.replace(
+          /      - name: Install pinned Node\.js runtime\n[\s\S]*?\n\n(?=      - name: Refresh and prove durable freshness)/u,
+          "",
+        ),
+    ],
+  ])("rejects %s for the production watchdog", (_label, mutateWorkflow) => {
+    const workflowPath =
+      ".github/workflows/refresh-production-read-model.yml";
+    const workflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const unsafeWorkflow = mutateWorkflow(workflow);
+    expect(unsafeWorkflow).not.toBe(workflow);
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: {
         ...integratedOverrides(),


### PR DESCRIPTION
## Summary

- install the immutable `actions/setup-node` v7 action before the production read-model watchdog
- pin the watchdog runtime to Node `24.14.0` with dependency caching disabled
- bind the runtime, action SHA, execution order, and updated workflow digest in the reviewed operations source contract
- reject Node 22, the runner-default Node runtime, and setup that occurs after watchdog execution

## Exact candidate

- base: `0d27dfdbb7d8b34674de5e2268177fee83790505`
- head: `f54f667eba948898c3b4f24bfc455bc66c541b05`
- tree: `baea5a33a7721132bcf6af444c55d93adb697d7b`

## Validation

- focused operations contract: 474 passed
- read-model operations gate: 40/40 passed
- CI scope: 13/13 passed
- `actionlint` passed
- focused ESLint exited 0 (one pre-existing warning)
- `git diff --check` passed

This does not change the refresh endpoint, freshness bound, provider quorum, credentials, deploy path, aliases, or promotion authority. The current live 503/provider-quorum incident remains fail-closed and separate.
