### PR TITLE
Fix Node 24 watchdog cache input

### DIFF
--- a/.github/workflows/refresh-production-read-model.yml
+++ b/.github/workflows/refresh-production-read-model.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.14.0
-          cache: false
+          package-manager-cache: false
 
       - name: Refresh and prove durable freshness
         shell: bash

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -10,14 +10,14 @@
       "provider": "github-actions",
       "workflow": {
         "path": ".github/workflows/refresh-production-read-model.yml",
-        "sha256": "3da07d2ec2ae59991aea77da64c0552e8d9fc7ed96a7d6b9130bdc469d7cc9c6"
+        "sha256": "778f68df03c9a66a17c5f58643940e0beb2e4090eacd5f126a5feb9a0ed6b616"
       },
       "nodeRuntime": {
         "setupAction": "actions/setup-node",
         "setupActionSha": "820762786026740c76f36085b0efc47a31fe5020",
         "setupActionRelease": "v7.0.0",
         "version": "24.14.0",
-        "dependencyCache": false
+        "packageManagerCache": false
       },
       "schedule": "2-57/5 * * * *",
       "targetOrigin": "https://programmable.market",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -15,14 +15,14 @@ const APPROVED_OPERATIONS = Object.freeze({
       provider: "github-actions",
       workflow: Object.freeze({
         path: ".github/workflows/refresh-production-read-model.yml",
-        sha256: "3da07d2ec2ae59991aea77da64c0552e8d9fc7ed96a7d6b9130bdc469d7cc9c6",
+        sha256: "778f68df03c9a66a17c5f58643940e0beb2e4090eacd5f126a5feb9a0ed6b616",
       }),
       nodeRuntime: Object.freeze({
         setupAction: "actions/setup-node",
         setupActionSha: "820762786026740c76f36085b0efc47a31fe5020",
         setupActionRelease: "v7.0.0",
         version: "24.14.0",
-        dependencyCache: false,
+        packageManagerCache: false,
       }),
       schedule: "2-57/5 * * * *",
       targetOrigin: "https://programmable.market",
@@ -798,7 +798,7 @@ function legacySchedulerWatchdogIsFailClosed(
     `        uses: ${binding?.nodeRuntime?.setupAction}@${binding?.nodeRuntime?.setupActionSha} # ${binding?.nodeRuntime?.setupActionRelease}`,
     "        with:",
     `          node-version: ${binding?.nodeRuntime?.version}`,
-    `          cache: ${binding?.nodeRuntime?.dependencyCache}`,
+    `          package-manager-cache: ${binding?.nodeRuntime?.packageManagerCache}`,
   ].join("\n");
   const pinnedNodeSetupIndex = workflowSource?.indexOf(pinnedNodeSetup) ?? -1;
   const watchdogStepIndex =
@@ -817,7 +817,7 @@ function legacySchedulerWatchdogIsFailClosed(
       "820762786026740c76f36085b0efc47a31fe5020" &&
     binding.nodeRuntime?.setupActionRelease === "v7.0.0" &&
     binding.nodeRuntime?.version === "24.14.0" &&
-    binding.nodeRuntime?.dependencyCache === false &&
+    binding.nodeRuntime?.packageManagerCache === false &&
     binding.rpcProof?.confirmedBlockRequired === true &&
     binding.rpcProof?.providerPairRequired === true &&
     binding.rpcProof?.maximumHeadAgeSeconds === 300 &&

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -638,7 +638,7 @@ describe("read-model operations source contract", () => {
       "uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0",
     ],
     ["Node 24 runtime", "node-version: 24.14.0"],
-    ["disabled dependency cache", "cache: false"],
+    ["disabled package-manager auto-cache", "package-manager-cache: false"],
     ["fixed public origin", 'targetOrigin !== "https://programmable.market"'],
     ["bounded cron secret", "secretBytes < 32"],
     ["canonical writer route", '"/api/ops/index-v2"'],


### PR DESCRIPTION
## Summary

- replace unsupported `cache: false` in `actions/setup-node` v7 with its correct `package-manager-cache: false` input
- keep Node pinned to `24.14.0` and automatic package-manager caching disabled
- update the reviewed workflow digest and fail-closed source contract terminology

## Exact candidate

- base: `844ea0f9a5f7e4f12d4e9a90df7e95ee0b7a458c`
- head: `6aaabd8e8eade75ea500f0e588e5e8b831d256f3`
- tree: `bfde97335ed496fa616a84f3306a3797c370a99a`

## Evidence

Watchdog run `31670126023` proved Node `v24.14.0` downloaded successfully but setup-node then rejected `cache: false` with `Caching for 'false' is not supported`; the refresh step never executed.

Local checks on this exact candidate:

- focused operations contract: 474 passed
- read-model operations gate: 40/40 passed
- CI scope: 13/13 passed
- `actionlint` passed
- workflow SHA-256 binding passed
- `git diff --check` passed

The refresh endpoint, freshness bound, two-provider quorum, credentials, deploy path, aliases, and promotion authority are unchanged.
