### PR TITLE
Add provider-neutral production RPC quorum

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,15 @@ ETHEREUM_RPC_URL_B=
 # Required by the manual Applicant Router lane. Both are server-only.
 PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL=
 PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL=
+# Preferred fixed Website read quorum. Configure all six fields together;
+# once any is present, legacy Alchemy/QuickNode values are ignored. URLs are
+# server-only sensitive values. Provider IDs are exact: alchemy, drpc, quicknode.
+PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER=
+PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL=
+PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT=
+PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_PROVIDER=
+PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_URL=
+PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT=
 # Server-only signing key for authenticating raw Alchemy webhook payloads.
 # Copy it from the Alchemy webhook dashboard and never expose it via NEXT_PUBLIC_.
 ALCHEMY_WEBHOOK_SIGNING_KEY=

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -35,7 +35,15 @@
         },
         "rpcRuntime": {
           "path": "lib/onchain/rpc-health.ts",
-          "sha256": "4c8e5fb0f879ef72f2e8d742886b61b004de55fc59a440ef34893b352c33f865"
+          "sha256": "b88c14b6e537c04acc1684157c0e801b457f97205300fb1847f72865d30bdecd"
+        },
+        "deploymentConfig": {
+          "path": "lib/onchain/config.ts",
+          "sha256": "715ee5b492d8ec7ed9d3870286f09debb344f9cdb05556a41ab8e50d0aa23cb2"
+        },
+        "providerConfig": {
+          "path": "lib/onchain/website-rpc-providers.server.ts",
+          "sha256": "12018bf29c2521b3fbae2c64ba2e93d586e0f9978c36403f24249becb71f07ed"
         }
       }
     },

--- a/lib/onchain/config.ts
+++ b/lib/onchain/config.ts
@@ -3,13 +3,12 @@ import { getAddress, isAddress, isHex, type Address, type Hex } from "viem";
 import appDeploymentsJson from "../../contracts/config/app-deployments.v1.json";
 import mainnetDependencies from "../../contracts/dependencies/ethereum-mainnet.json";
 import sepoliaDependencies from "../../contracts/dependencies/ethereum-sepolia.json";
-import { rpcProviderCommitment } from
-  "../data-pipeline/rpc-provider-commitments";
-
 import type {
   DeploymentEnvironment,
   OnchainDeployment,
 } from "./types";
+import { websiteMainnetRpcPair } from
+  "./website-rpc-providers.server";
 
 type DeploymentEntry = {
   chainId: number;
@@ -79,109 +78,6 @@ function productionSecondaryRpc() {
     process.env.ETHEREUM_RPC_URL_B,
     process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
   );
-}
-
-const ALCHEMY_MAINNET_RPC_HOST = "eth-mainnet.g.alchemy.com";
-const ALCHEMY_MAINNET_RPC_PATH = /^\/v2\/[A-Za-z0-9_-]{8,256}$/u;
-const QUICKNODE_MAINNET_RPC_HOST =
-  /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+quiknode\.pro$/u;
-const QUICKNODE_MAINNET_RPC_PATH = /^\/[A-Za-z0-9_-]{8,256}\/?$/u;
-const RPC_ENDPOINT_COMMITMENT = /^0x[0-9a-f]{64}$/u;
-
-type WebsiteRpcProvider = "Alchemy" | "QuickNode";
-
-function selectedWebsiteRpcValue(
-  preferred: string | undefined,
-  legacy: string | undefined,
-) {
-  return preferred === undefined || preferred === ""
-    ? legacy
-    : preferred;
-}
-
-function strictWebsiteRpcUrl(
-  value: string | undefined,
-  provider: WebsiteRpcProvider,
-) {
-  if (
-    typeof value !== "string" ||
-    value.length < 1 ||
-    value.length > 1_024 ||
-    value !== value.trim()
-  ) {
-    throw new Error(`Website ${provider} RPC binding is unavailable`);
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    throw new Error(`Website ${provider} RPC binding is invalid`);
-  }
-  const validProvider = provider === "Alchemy"
-    ? parsed.hostname === ALCHEMY_MAINNET_RPC_HOST &&
-      ALCHEMY_MAINNET_RPC_PATH.test(parsed.pathname)
-    : QUICKNODE_MAINNET_RPC_HOST.test(parsed.hostname) &&
-      QUICKNODE_MAINNET_RPC_PATH.test(parsed.pathname);
-  if (
-    parsed.protocol !== "https:" ||
-    parsed.username !== "" ||
-    parsed.password !== "" ||
-    parsed.port !== "" ||
-    parsed.search !== "" ||
-    parsed.hash !== "" ||
-    !validProvider
-  ) {
-    throw new Error(`Website ${provider} RPC binding is invalid`);
-  }
-  return parsed.href;
-}
-
-function requiredWebsiteRpcCommitment(
-  value: string | undefined,
-  provider: WebsiteRpcProvider,
-) {
-  if (!value || !RPC_ENDPOINT_COMMITMENT.test(value)) {
-    throw new Error(
-      `Website ${provider} RPC endpoint commitment is unavailable`,
-    );
-  }
-  return value;
-}
-
-function websiteMainnetRpcPair() {
-  const alchemyUrl = strictWebsiteRpcUrl(
-    selectedWebsiteRpcValue(
-      process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
-      process.env.ETHEREUM_RPC_URL,
-    ),
-    "Alchemy",
-  );
-  const quickNodeUrl = strictWebsiteRpcUrl(
-    selectedWebsiteRpcValue(
-      process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
-      process.env.ETHEREUM_RPC_URL_B,
-    ),
-    "QuickNode",
-  );
-  const alchemyCommitment = requiredWebsiteRpcCommitment(
-    process.env.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT,
-    "Alchemy",
-  );
-  const quickNodeCommitment = requiredWebsiteRpcCommitment(
-    process.env.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT,
-    "QuickNode",
-  );
-  if (
-    alchemyCommitment === quickNodeCommitment ||
-    rpcProviderCommitment("endpoint", alchemyUrl) !==
-      alchemyCommitment ||
-    rpcProviderCommitment("endpoint", quickNodeUrl) !==
-      quickNodeCommitment
-  ) {
-    throw new Error("Website RPC endpoint commitment mismatch");
-  }
-  return { alchemyUrl, quickNodeUrl } as const;
 }
 
 export function selectedDeploymentEnvironment(
@@ -351,15 +247,19 @@ export function getWebsiteReadOnchainDeployment(
 
   return {
     ...deployment,
-    rpcUrl: rpc.alchemyUrl,
-    rpcUrlSecondary: rpc.quickNodeUrl,
+    rpcUrl: rpc.primary.url,
+    rpcUrlSecondary: rpc.secondary.url,
+    rpcProviderIds: {
+      primary: rpc.primary.provider,
+      secondary: rpc.secondary.provider,
+    },
   };
 }
 
 /**
  * Historical reads use the same commitment-bound pair. The shared failover
- * runner permits one complete QuickNode attempt only after an eligible
- * Alchemy transport, capacity or archive failure.
+ * runner permits one complete secondary attempt only after an eligible
+ * primary transport, capacity or archive failure.
  */
 export function getWebsiteChartOnchainDeployment(
   environment = selectedDeploymentEnvironment(),

--- a/lib/onchain/rpc-health.ts
+++ b/lib/onchain/rpc-health.ts
@@ -6,7 +6,10 @@ import {
   OperationalRpcUnavailableError,
   withOperationalRpcFailover,
 } from "./operational-rpc-failover.server";
-import type { ReadyOnchainDeployment } from "./types";
+import type {
+  MainnetRpcProviderId,
+  ReadyOnchainDeployment,
+} from "./types";
 
 type RpcRole = "primary" | "secondary";
 type ProviderStatus =
@@ -44,11 +47,13 @@ export type OperationalRpcHealth = Readonly<{
   }>;
   providers: Readonly<{
     primary: Readonly<{
+      provider?: MainnetRpcProviderId;
       status: ProviderStatus;
       head: string | null;
       headAgeSeconds: number | null;
     }>;
     secondary: Readonly<{
+      provider?: MainnetRpcProviderId;
       status: ProviderStatus;
       head: string | null;
       headAgeSeconds: number | null;
@@ -103,8 +108,12 @@ function defaultDependencies(
   };
 }
 
-function publicProvider(probe: ProviderProbe) {
+function publicProvider(
+  probe: ProviderProbe,
+  provider: MainnetRpcProviderId | undefined,
+) {
   return {
+    ...(provider ? { provider } : {}),
     status: probe.status,
     head: probe.head?.toString() ?? null,
     headAgeSeconds: probe.headAgeSeconds,
@@ -131,8 +140,14 @@ function result(
       failoverUsed: input.servedBy === "secondary",
     },
     providers: {
-      primary: publicProvider(probes.primary),
-      secondary: publicProvider(probes.secondary),
+      primary: publicProvider(
+        probes.primary,
+        deployment.rpcProviderIds?.primary,
+      ),
+      secondary: publicProvider(
+        probes.secondary,
+        deployment.rpcProviderIds?.secondary,
+      ),
     },
     freshness: {
       maxHeadAgeSeconds: OPERATIONAL_RPC_MAX_HEAD_AGE_SECONDS,

--- a/lib/onchain/types.ts
+++ b/lib/onchain/types.ts
@@ -4,6 +4,7 @@ import type { LauncherToken } from "../tokens";
 
 export type DeploymentEnvironment = "production" | "rehearsal";
 export type ClassicReleaseVersion = "classic-v1" | "classic-v2";
+export type MainnetRpcProviderId = "alchemy" | "drpc" | "quicknode";
 
 type OnchainDeploymentBase = {
   environment: DeploymentEnvironment;
@@ -13,6 +14,10 @@ type OnchainDeploymentBase = {
   stateViewRuntimeCodeHash: Hex;
   rpcUrl: string;
   rpcUrlSecondary: string | null;
+  rpcProviderIds?: Readonly<{
+    primary: MainnetRpcProviderId;
+    secondary: MainnetRpcProviderId;
+  }>;
   confirmations: bigint;
   logBlockRange: bigint;
 };

--- a/lib/onchain/website-rpc-providers.server.ts
+++ b/lib/onchain/website-rpc-providers.server.ts
@@ -1,0 +1,217 @@
+import { rpcProviderCommitment } from
+  "../data-pipeline/rpc-provider-commitments";
+
+import type { MainnetRpcProviderId } from "./types";
+
+const RPC_ENDPOINT_COMMITMENT = /^0x[0-9a-f]{64}$/u;
+const ALCHEMY_MAINNET_RPC_HOST = "eth-mainnet.g.alchemy.com";
+const ALCHEMY_MAINNET_RPC_PATH = /^\/v2\/[A-Za-z0-9_-]{8,256}$/u;
+const DRPC_MAINNET_RPC_HOST = "lb.drpc.live";
+const DRPC_MAINNET_RPC_PATH = /^\/ethereum\/[A-Za-z0-9_-]{8,512}\/?$/u;
+const QUICKNODE_MAINNET_RPC_HOST =
+  /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.quiknode\.pro$/u;
+const QUICKNODE_MAINNET_RPC_PATH = /^\/[A-Za-z0-9_-]{8,256}\/?$/u;
+
+export const WEBSITE_MAINNET_RPC_ENV = Object.freeze({
+  primaryProvider: "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER",
+  primaryUrl: "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL",
+  primaryCommitment:
+    "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
+  secondaryProvider: "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_PROVIDER",
+  secondaryUrl: "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_URL",
+  secondaryCommitment:
+    "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT",
+} as const);
+
+type WebsiteRpcBinding = Readonly<{
+  provider: MainnetRpcProviderId;
+  url: string;
+  endpointCommitment: string;
+}>;
+
+type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
+
+export type WebsiteMainnetRpcPair = Readonly<{
+  source: "role-bound-v1" | "legacy-alchemy-quicknode";
+  primary: WebsiteRpcBinding;
+  secondary: WebsiteRpcBinding;
+}>;
+
+function selectedLegacyValue(
+  preferred: string | undefined,
+  legacy: string | undefined,
+) {
+  return preferred === undefined || preferred === ""
+    ? legacy
+    : preferred;
+}
+
+function providerId(
+  value: string | undefined,
+  role: "primary" | "secondary",
+): MainnetRpcProviderId {
+  if (value === "alchemy" || value === "drpc" || value === "quicknode") {
+    return value;
+  }
+  throw new Error(`Website ${role} RPC provider binding is invalid`);
+}
+
+function providerPathIsValid(parsed: URL, provider: MainnetRpcProviderId) {
+  if (provider === "alchemy") {
+    return parsed.hostname === ALCHEMY_MAINNET_RPC_HOST &&
+      ALCHEMY_MAINNET_RPC_PATH.test(parsed.pathname) &&
+      parsed.pathname.slice("/v2/".length) !== "docs-demo";
+  }
+  if (provider === "drpc") {
+    return parsed.hostname === DRPC_MAINNET_RPC_HOST &&
+      DRPC_MAINNET_RPC_PATH.test(parsed.pathname) &&
+      parsed.pathname
+        .replace(/^\/ethereum\//u, "")
+        .replace(/\/$/u, "") !== "docs-demo";
+  }
+  return QUICKNODE_MAINNET_RPC_HOST.test(parsed.hostname) &&
+    QUICKNODE_MAINNET_RPC_PATH.test(parsed.pathname) &&
+    parsed.pathname.replace(/^\//u, "").replace(/\/$/u, "") !==
+      "docs-demo";
+}
+
+function strictRpcUrl(
+  value: string | undefined,
+  provider: MainnetRpcProviderId,
+  role: "primary" | "secondary",
+) {
+  if (
+    typeof value !== "string" ||
+    value.length < 1 ||
+    value.length > 1_024 ||
+    value !== value.trim()
+  ) {
+    throw new Error(`Website ${role} RPC binding is unavailable`);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`Website ${role} RPC binding is invalid`);
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.port !== "" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    !providerPathIsValid(parsed, provider)
+  ) {
+    throw new Error(`Website ${role} RPC binding is invalid`);
+  }
+  return parsed.href;
+}
+
+function requiredCommitment(
+  value: string | undefined,
+  role: "primary" | "secondary",
+) {
+  if (!value || !RPC_ENDPOINT_COMMITMENT.test(value)) {
+    throw new Error(
+      `Website ${role} RPC endpoint commitment is unavailable`,
+    );
+  }
+  return value;
+}
+
+function binding(
+  provider: MainnetRpcProviderId,
+  rawUrl: string | undefined,
+  rawCommitment: string | undefined,
+  role: "primary" | "secondary",
+): WebsiteRpcBinding {
+  const url = strictRpcUrl(rawUrl, provider, role);
+  const endpointCommitment = requiredCommitment(rawCommitment, role);
+  if (rpcProviderCommitment("endpoint", url) !== endpointCommitment) {
+    throw new Error(`Website ${role} RPC endpoint commitment mismatch`);
+  }
+  return Object.freeze({ provider, url, endpointCommitment });
+}
+
+function pair(
+  source: WebsiteMainnetRpcPair["source"],
+  primary: WebsiteRpcBinding,
+  secondary: WebsiteRpcBinding,
+): WebsiteMainnetRpcPair {
+  if (
+    primary.provider === secondary.provider ||
+    primary.url === secondary.url ||
+    primary.endpointCommitment === secondary.endpointCommitment
+  ) {
+    throw new Error("Website RPC providers are not independent");
+  }
+  return Object.freeze({ source, primary, secondary });
+}
+
+function roleBoundPair(environment: RuntimeEnvironment) {
+  const primaryProvider = providerId(
+    environment[WEBSITE_MAINNET_RPC_ENV.primaryProvider],
+    "primary",
+  );
+  const secondaryProvider = providerId(
+    environment[WEBSITE_MAINNET_RPC_ENV.secondaryProvider],
+    "secondary",
+  );
+  return pair(
+    "role-bound-v1",
+    binding(
+      primaryProvider,
+      environment[WEBSITE_MAINNET_RPC_ENV.primaryUrl],
+      environment[WEBSITE_MAINNET_RPC_ENV.primaryCommitment],
+      "primary",
+    ),
+    binding(
+      secondaryProvider,
+      environment[WEBSITE_MAINNET_RPC_ENV.secondaryUrl],
+      environment[WEBSITE_MAINNET_RPC_ENV.secondaryCommitment],
+      "secondary",
+    ),
+  );
+}
+
+function legacyPair(environment: RuntimeEnvironment) {
+  return pair(
+    "legacy-alchemy-quicknode",
+    binding(
+      "alchemy",
+      selectedLegacyValue(
+        environment.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
+        environment.ETHEREUM_RPC_URL,
+      ),
+      environment.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT,
+      "primary",
+    ),
+    binding(
+      "quicknode",
+      selectedLegacyValue(
+        environment.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
+        environment.ETHEREUM_RPC_URL_B,
+      ),
+      environment.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT,
+      "secondary",
+    ),
+  );
+}
+
+/**
+ * Resolves the fixed Website read quorum. Once any role-bound v1 field is
+ * configured, all six fields become mandatory and legacy values are ignored.
+ * This prevents a partial provider migration from silently mixing releases.
+ */
+export function websiteMainnetRpcPair(
+  environment: RuntimeEnvironment = process.env,
+): WebsiteMainnetRpcPair {
+  const roleBoundConfigured = Object.values(WEBSITE_MAINNET_RPC_ENV).some(
+    (name) => environment[name] !== undefined && environment[name] !== "",
+  );
+  return roleBoundConfigured
+    ? roleBoundPair(environment)
+    : legacyPair(environment);
+}

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -40,7 +40,15 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
         rpcRuntime: Object.freeze({
           path: "lib/onchain/rpc-health.ts",
-          sha256: "4c8e5fb0f879ef72f2e8d742886b61b004de55fc59a440ef34893b352c33f865",
+          sha256: "b88c14b6e537c04acc1684157c0e801b457f97205300fb1847f72865d30bdecd",
+        }),
+        deploymentConfig: Object.freeze({
+          path: "lib/onchain/config.ts",
+          sha256: "715ee5b492d8ec7ed9d3870286f09debb344f9cdb05556a41ab8e50d0aa23cb2",
+        }),
+        providerConfig: Object.freeze({
+          path: "lib/onchain/website-rpc-providers.server.ts",
+          sha256: "12018bf29c2521b3fbae2c64ba2e93d586e0f9978c36403f24249becb71f07ed",
         }),
       }),
     }),
@@ -823,6 +831,16 @@ function legacySchedulerWatchdogIsFailClosed(
     binding.rpcProof?.maximumHeadAgeSeconds === 300 &&
     sourceBindingMatches(source, binding.rpcProof?.healthRoute, expectedSha256Overrides) &&
     sourceBindingMatches(source, binding.rpcProof?.rpcRuntime, expectedSha256Overrides) &&
+    sourceBindingMatches(
+      source,
+      binding.rpcProof?.deploymentConfig,
+      expectedSha256Overrides,
+    ) &&
+    sourceBindingMatches(
+      source,
+      binding.rpcProof?.providerConfig,
+      expectedSha256Overrides,
+    ) &&
     workflowSource.includes('name: Refresh production read model') &&
     workflowSource.includes('    - cron: "2-57/5 * * * *"') &&
     workflowSource.includes("  workflow_dispatch:") &&

--- a/tests/data-pipeline/legacy-index-ops-route.test.ts
+++ b/tests/data-pipeline/legacy-index-ops-route.test.ts
@@ -23,6 +23,13 @@ import { GET as getClosedAlias } from "../../app/api/ops/index/route";
 import { GET as getCanonicalIndex } from "../../app/api/ops/index-v2/route";
 
 const SECRET = "legacy-index-test-secret-32-characters";
+const deployment = Object.freeze({
+  status: "ready" as const,
+  rpcProviderIds: Object.freeze({
+    primary: "drpc" as const,
+    secondary: "quicknode" as const,
+  }),
+});
 
 function request(secret = SECRET) {
   return new NextRequest("https://programmable.family/api/ops/index-v2", {
@@ -34,7 +41,7 @@ describe("legacy index operations routes", () => {
   beforeEach(() => {
     process.env.CRON_SECRET = SECRET;
     Object.values(mocks).forEach((mock) => mock.mockReset());
-    mocks.getOperationalOnchainDeployment.mockReturnValue({ status: "ready" });
+    mocks.getOperationalOnchainDeployment.mockReturnValue(deployment);
     mocks.readLiveExploreModel.mockResolvedValue({ status: "ready" });
     mocks.writeDurableExploreModel.mockResolvedValue({
       blockNumber: "25600000",
@@ -87,7 +94,12 @@ describe("legacy index operations routes", () => {
       tokenCount: 265,
     });
     expect(mocks.readLiveExploreModel).toHaveBeenCalledTimes(1);
+    expect(mocks.readLiveExploreModel).toHaveBeenCalledWith(deployment);
     expect(mocks.writeDurableExploreModel).toHaveBeenCalledTimes(1);
+    expect(mocks.writeDurableExploreModel).toHaveBeenCalledWith(
+      deployment,
+      { status: "ready" },
+    );
     expect(mocks.writePortfolioHistorySnapshot).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -763,6 +763,11 @@ describe("read-model operations source contract", () => {
   it.each([
     ["health route", "app/api/ops/health/route.ts"],
     ["RPC health runtime", "lib/onchain/rpc-health.ts"],
+    ["RPC deployment config", "lib/onchain/config.ts"],
+    [
+      "RPC provider config",
+      "lib/onchain/website-rpc-providers.server.ts",
+    ],
   ])("rejects unreviewed %s bytes", (_label, path) => {
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: {

--- a/tests/onchain-config.test.ts
+++ b/tests/onchain-config.test.ts
@@ -14,6 +14,7 @@ const ALCHEMY_RPC_URL =
   "https://eth-mainnet.g.alchemy.com/v2/alchemy-test-key";
 const QUICKNODE_RPC_URL =
   "https://programmable-mainnet.quiknode.pro/quicknode-test-key/";
+const DRPC_RPC_URL = "https://lb.drpc.live/ethereum/drpc-test-key";
 
 function stubWebsiteRpcBindings() {
   vi.stubEnv("PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL", ALCHEMY_RPC_URL);
@@ -126,6 +127,10 @@ describe("onchain deployment manifest boundary", () => {
       status: "ready",
       rpcUrl: ALCHEMY_RPC_URL,
       rpcUrlSecondary: QUICKNODE_RPC_URL,
+      rpcProviderIds: {
+        primary: "alchemy",
+        secondary: "quicknode",
+      },
     });
     expect(getWebsiteChartOnchainDeployment("production")).toMatchObject({
       status: "ready",
@@ -168,7 +173,7 @@ describe("onchain deployment manifest boundary", () => {
     );
     expect(() =>
       getWebsiteReadOnchainDeployment("production"),
-    ).toThrow("Website Alchemy RPC binding is unavailable");
+    ).toThrow("Website primary RPC binding is unavailable");
   });
 
   it("accepts only the bounded legacy aliases when they match both provider commitments", () => {
@@ -201,7 +206,7 @@ describe("onchain deployment manifest boundary", () => {
 
     expect(() =>
       getWebsiteReadOnchainDeployment("production"),
-    ).toThrow("Website Alchemy RPC binding is invalid");
+    ).toThrow("Website primary RPC binding is invalid");
   });
 
   it("fails closed on a mismatched commitment without retaining endpoint secrets", () => {
@@ -221,10 +226,45 @@ describe("onchain deployment manifest boundary", () => {
     })();
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toBe(
-      "Website RPC endpoint commitment mismatch",
+      "Website secondary RPC endpoint commitment mismatch",
     );
     expect(JSON.stringify(error)).not.toContain("alchemy-test-key");
     expect(JSON.stringify(error)).not.toContain("quicknode-test-key");
+  });
+
+  it("uses a complete role-bound dRPC and QuickNode pair for Website reads", () => {
+    stubWebsiteRpcBindings();
+    vi.stubEnv(
+      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER",
+      "drpc",
+    );
+    vi.stubEnv("PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL", DRPC_RPC_URL);
+    vi.stubEnv(
+      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
+      rpcProviderCommitment("endpoint", DRPC_RPC_URL),
+    );
+    vi.stubEnv(
+      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_PROVIDER",
+      "quicknode",
+    );
+    vi.stubEnv(
+      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_URL",
+      QUICKNODE_RPC_URL,
+    );
+    vi.stubEnv(
+      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT",
+      rpcProviderCommitment("endpoint", QUICKNODE_RPC_URL),
+    );
+
+    expect(getWebsiteReadOnchainDeployment("production")).toMatchObject({
+      status: "ready",
+      rpcUrl: DRPC_RPC_URL,
+      rpcUrlSecondary: QUICKNODE_RPC_URL,
+      rpcProviderIds: {
+        primary: "drpc",
+        secondary: "quicknode",
+      },
+    });
   });
 
   it("keeps public reads fail-closed when the dual-RPC environment is absent", () => {

--- a/tests/onchain-rpc-health.test.ts
+++ b/tests/onchain-rpc-health.test.ts
@@ -137,6 +137,25 @@ describe("operational RPC health", () => {
     expect(secondary.getBlock).toHaveBeenCalledWith({ blockNumber: 88n });
   });
 
+  it("reports the public provider identities without exposing endpoints", async () => {
+    const primary = client({ head: 100n });
+    const secondary = client({ head: 101n });
+    const health = await readOperationalRpcHealth(
+      {
+        ...deployment,
+        rpcProviderIds: { primary: "drpc", secondary: "quicknode" },
+      },
+      dependencies(primary, secondary),
+    );
+
+    expect(health.providers).toMatchObject({
+      primary: { provider: "drpc", status: "available" },
+      secondary: { provider: "quicknode", status: "available" },
+    });
+    expect(JSON.stringify(health)).not.toContain("rpc-key");
+    expect(JSON.stringify(health)).not.toContain("example");
+  });
+
   it("keeps reads available through the fixed secondary after primary 429", async () => {
     const primary = client({
       chainError: httpFailure(429, PRIMARY_URL),

--- a/tests/website-rpc-providers.test.ts
+++ b/tests/website-rpc-providers.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import { rpcProviderCommitment } from
+  "../lib/data-pipeline/rpc-provider-commitments";
+import {
+  WEBSITE_MAINNET_RPC_ENV,
+  websiteMainnetRpcPair,
+} from "../lib/onchain/website-rpc-providers.server";
+
+const ALCHEMY_URL =
+  "https://eth-mainnet.g.alchemy.com/v2/alchemy-test-key";
+const DRPC_URL = "https://lb.drpc.live/ethereum/drpc-test-key";
+const QUICKNODE_URL =
+  "https://programmable-mainnet.quiknode.pro/quicknode-test-key/";
+
+function environment(input?: Readonly<{
+  primaryProvider?: string;
+  primaryUrl?: string;
+  primaryCommitment?: string;
+  secondaryProvider?: string;
+  secondaryUrl?: string;
+  secondaryCommitment?: string;
+}>) {
+  return {
+    [WEBSITE_MAINNET_RPC_ENV.primaryProvider]:
+      input?.primaryProvider ?? "drpc",
+    [WEBSITE_MAINNET_RPC_ENV.primaryUrl]:
+      input?.primaryUrl ?? DRPC_URL,
+    [WEBSITE_MAINNET_RPC_ENV.primaryCommitment]:
+      input?.primaryCommitment ??
+      rpcProviderCommitment("endpoint", input?.primaryUrl ?? DRPC_URL),
+    [WEBSITE_MAINNET_RPC_ENV.secondaryProvider]:
+      input?.secondaryProvider ?? "quicknode",
+    [WEBSITE_MAINNET_RPC_ENV.secondaryUrl]:
+      input?.secondaryUrl ?? QUICKNODE_URL,
+    [WEBSITE_MAINNET_RPC_ENV.secondaryCommitment]:
+      input?.secondaryCommitment ??
+      rpcProviderCommitment(
+        "endpoint",
+        input?.secondaryUrl ?? QUICKNODE_URL,
+      ),
+  };
+}
+
+describe("Website Mainnet RPC provider bindings", () => {
+  it("binds a dRPC primary and QuickNode secondary by explicit roles", () => {
+    expect(websiteMainnetRpcPair(environment())).toEqual({
+      source: "role-bound-v1",
+      primary: {
+        provider: "drpc",
+        url: DRPC_URL,
+        endpointCommitment: rpcProviderCommitment("endpoint", DRPC_URL),
+      },
+      secondary: {
+        provider: "quicknode",
+        url: QUICKNODE_URL,
+        endpointCommitment:
+          rpcProviderCommitment("endpoint", QUICKNODE_URL),
+      },
+    });
+  });
+
+  it("keeps provider roles interchangeable across the reviewed vendors", () => {
+    const selected = websiteMainnetRpcPair(environment({
+      primaryProvider: "quicknode",
+      primaryUrl: QUICKNODE_URL,
+      secondaryProvider: "alchemy",
+      secondaryUrl: ALCHEMY_URL,
+    }));
+
+    expect(selected).toMatchObject({
+      source: "role-bound-v1",
+      primary: { provider: "quicknode", url: QUICKNODE_URL },
+      secondary: { provider: "alchemy", url: ALCHEMY_URL },
+    });
+  });
+
+  it("ignores legacy bindings only after a complete role-bound pair is valid", () => {
+    const selected = websiteMainnetRpcPair({
+      ...environment(),
+      PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL: ALCHEMY_URL,
+      PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL: QUICKNODE_URL,
+      PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT:
+        rpcProviderCommitment("endpoint", ALCHEMY_URL),
+      PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT:
+        rpcProviderCommitment("endpoint", QUICKNODE_URL),
+    });
+
+    expect(selected.source).toBe("role-bound-v1");
+    expect(selected.primary.provider).toBe("drpc");
+  });
+
+  it("fails closed on partial role configuration", () => {
+    expect(() => websiteMainnetRpcPair({
+      PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER: "drpc",
+      PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL: ALCHEMY_URL,
+      PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL: QUICKNODE_URL,
+    })).toThrow("Website secondary RPC provider binding is invalid");
+  });
+
+  it("rejects unknown providers, provider-host drift and public fallbacks", () => {
+    expect(() => websiteMainnetRpcPair(environment({
+      primaryProvider: "generic",
+    }))).toThrow("Website primary RPC provider binding is invalid");
+    expect(() => websiteMainnetRpcPair(environment({
+      primaryProvider: "drpc",
+      primaryUrl: ALCHEMY_URL,
+    }))).toThrow("Website primary RPC binding is invalid");
+    expect(() => websiteMainnetRpcPair(environment({
+      primaryProvider: "drpc",
+      primaryUrl: "https://eth.drpc.org/",
+    }))).toThrow("Website primary RPC binding is invalid");
+    expect(() => websiteMainnetRpcPair(environment({
+      secondaryProvider: "quicknode",
+      secondaryUrl:
+        "https://programmable.base-mainnet.quiknode.pro/quicknode-test-key/",
+    }))).toThrow("Website secondary RPC binding is invalid");
+  });
+
+  it("requires independent vendor identities, not only distinct URLs", () => {
+    const secondary =
+      "https://lb.drpc.live/ethereum/second-drpc-test-key";
+    expect(() => websiteMainnetRpcPair(environment({
+      secondaryProvider: "drpc",
+      secondaryUrl: secondary,
+    }))).toThrow("Website RPC providers are not independent");
+  });
+
+  it("rejects endpoint drift without retaining credentials in errors", () => {
+    const candidate = environment({
+      primaryCommitment: `0x${"ab".repeat(32)}`,
+    });
+    const error = (() => {
+      try {
+        websiteMainnetRpcPair(candidate);
+      } catch (value) {
+        return value;
+      }
+      return null;
+    })();
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      "Website primary RPC endpoint commitment mismatch",
+    );
+    const serialized = JSON.stringify(error);
+    expect(serialized).not.toContain("drpc-test-key");
+    expect(serialized).not.toContain("quicknode-test-key");
+  });
+});


### PR DESCRIPTION
## Outcome

Adds a strictly bound Website mainnet RPC pair that can use Alchemy, dRPC, or QuickNode in distinct primary/secondary roles. This is configuration capability only: no provider credentials are added and production behavior remains on the complete legacy pair until all six new fields are configured.

## Safety boundary

- all six role-bound fields are required together; partial configuration fails closed
- providers, HTTPS hosts/paths, endpoint commitments, and vendor diversity are verified
- writer and health resolve the same deployment
- health exposes provider IDs and quorum evidence, never endpoint URLs or keys
- complete Alchemy+QuickNode legacy fallback remains unchanged
- includes the current production Node 24 watchdog pins from #278
- no Applicant, Custom Launch, deployment, or activation changes

## Exact candidate

- base: `844ea0f9a5f7e4f12d4e9a90df7e95ee0b7a458c`
- head: `4e7c58233f17fcae0afc95a4ac446ab2bbffde2f`
- tree: `5a3c837d0de795144ba41a911370fd36d4010f49`

## Validation

- independent read-only audit: GO, no P0/P1/P2
- focused regression: 546/546
- TypeScript typecheck: pass
- operations source gate: 40/40 pass
- production Next build: pass
- changed-scope ESLint: 0 errors
- diff check: pass

No live provider values were read or changed and this PR does not activate dRPC.