### PR TITLE
Harden market pagination and release handoff

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1964,6 +1964,19 @@ jobs:
           grep -Fx "deployment_id=$EXPECTED_DEPLOYMENT_ID" "$binding_output"
           grep -Fx "target_url=$STAGED_TARGET_URL" "$binding_output"
 
+      - name: Gate exact staged operational health
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          STAGED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}
+          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
+          EXPECTED_GIT_HEAD: ${{ github.sha }}
+        run: >-
+          npm run perf:read-model:staged-health --
+          --target-url "$STAGED_TARGET_URL"
+          --deployment-id "$STAGED_DEPLOYMENT_ID"
+          --git-head "$EXPECTED_GIT_HEAD"
+
       - name: Record staged candidate handoff
         env:
           DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -1,3 +1,5 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
 import { NextRequest, NextResponse } from "next/server";
 
 import {
@@ -35,6 +37,7 @@ import {
   settleCurrentEvidenceSnapshot,
   type CurrentEvidenceSnapshotOutcome,
   valueExploreEntriesWithCurrentEvidence,
+  valueExploreEntriesWithCurrentEvidenceSnapshot,
 } from "../../../lib/market-data/current-valuation.server";
 import { readExploreReferenceHeadWithinRouteBudget } from "../../../lib/explore-reference-head.server";
 import { getOnchainDeployment } from "../../../lib/onchain/config";
@@ -62,7 +65,15 @@ const EXPLORE_QUERY_PARAMETERS = new Set([
   "q",
   "socials",
   "sort",
+  "valuationBlock",
+  "valuationBlockHash",
+  "liquidityBlock",
+  "liquidityBlockHash",
+  "rankingCommitment",
 ]);
+const EXPLORE_RANKING_COMMITMENT = /^sha256:[0-9a-f]{64}$/u;
+const EXPLORE_BLOCK_HASH = /^0x[0-9a-f]{64}$/u;
+const GRAPHQL_INT_MAXIMUM = 2_147_483_647n;
 const readCanonicalExploreSource = createExploreConsumerSource<ExploreReadModel>({});
 const readCustomExploreSource = createExploreConsumerSource<
   readonly CustomProjectExploreEntry[]
@@ -129,6 +140,15 @@ function hasCanonicalQueryShape(search: URLSearchParams) {
   return true;
 }
 
+function hasCanonicalPaginationShape(search: URLSearchParams) {
+  return ["page", "limit"].every((parameter) => {
+    const value = search.get(parameter);
+    if (value === null) return true;
+    if (!/^[1-9]\d*$/u.test(value)) return false;
+    return Number.isSafeInteger(Number(value));
+  });
+}
+
 function integerQuery(value: string | null, fallback: number) {
   if (!value || !/^\d+$/u.test(value)) return fallback;
   const parsed = Number(value);
@@ -142,6 +162,134 @@ function positiveInteger(value: number, fallback: number, maximum: number) {
 
 function requiresCompleteCurrentValuation(sort: ExploreSort): boolean {
   return sort === "market-cap" || sort === "market-cap-asc";
+}
+
+type RequestedExploreValuationSnapshotV1 = Readonly<{
+  blockNumber: string;
+  blockHash: `0x${string}`;
+  liquidityBlockNumber: string;
+  liquidityBlockHash: `0x${string}` | "none";
+  rankingCommitment: `sha256:${string}`;
+}>;
+
+function requestedValuationSnapshot(
+  search: URLSearchParams,
+  options: Readonly<{
+    page: number;
+    pageSize: number;
+    query: string;
+    socials: "yes" | "no" | null;
+    sort: ExploreSort;
+  }>,
+): RequestedExploreValuationSnapshotV1 | null | undefined {
+  const blockNumber = search.get("valuationBlock");
+  const blockHash = search.get("valuationBlockHash");
+  const liquidityBlockNumber = search.get("liquidityBlock");
+  const liquidityBlockHash = search.get("liquidityBlockHash");
+  const rankingCommitment = search.get("rankingCommitment");
+  const supplied = [
+    blockNumber,
+    blockHash,
+    liquidityBlockNumber,
+    liquidityBlockHash,
+    rankingCommitment,
+  ]
+    .filter((value) => value !== null).length;
+  if (!requiresCompleteCurrentValuation(options.sort)) {
+    if (supplied > 0) return null;
+    return undefined;
+  }
+  if (options.page === 1) {
+    if (supplied > 0) return null;
+    return undefined;
+  }
+  const canonicalLiquiditySnapshot =
+    liquidityBlockNumber === "none" && liquidityBlockHash === "none" ||
+    liquidityBlockNumber !== null &&
+      /^[1-9]\d*$/u.test(liquidityBlockNumber) &&
+      liquidityBlockNumber.length <= 10 &&
+      BigInt(liquidityBlockNumber) <= GRAPHQL_INT_MAXIMUM &&
+      liquidityBlockHash !== null &&
+      EXPLORE_BLOCK_HASH.test(liquidityBlockHash);
+  if (
+    supplied !== 5 ||
+    search.get("sort") !== options.sort ||
+    search.get("q") !== null && search.get("q") !== options.query ||
+    options.pageSize > 100 ||
+    !blockNumber ||
+    !/^[1-9]\d*$/u.test(blockNumber) ||
+    blockNumber.length > 78 ||
+    !blockHash ||
+    !EXPLORE_BLOCK_HASH.test(blockHash) ||
+    !canonicalLiquiditySnapshot ||
+    !liquidityBlockNumber ||
+    !liquidityBlockHash ||
+    !rankingCommitment ||
+    !EXPLORE_RANKING_COMMITMENT.test(rankingCommitment)
+  ) return null;
+  return {
+    blockNumber,
+    blockHash: blockHash as `0x${string}`,
+    liquidityBlockNumber,
+    liquidityBlockHash: liquidityBlockHash as `0x${string}` | "none",
+    rankingCommitment: rankingCommitment as `sha256:${string}`,
+  };
+}
+
+function exploreRankingCommitment(
+  entries: readonly ValuedExploreEntry[],
+  input: Readonly<{
+    snapshot: Readonly<{
+      blockNumber: string;
+      blockHash: string;
+      liquidityBlockNumber: string;
+      liquidityBlockHash: string;
+    }>;
+    sort: ExploreSort;
+    query: string;
+    socials: "yes" | "no" | null;
+    pageSize: number;
+  }>,
+): `sha256:${string}` {
+  const ordered = sortExploreEntries(entries, input.sort);
+  const ranking = ordered.map((entry) => ({
+    id: entry.id,
+    tokenAddress: entry.tokenAddress?.toLowerCase() ?? null,
+    valueWad: valuationSortValue(entry)?.toString() ?? null,
+    availability: valuationSortValue(entry) === undefined
+      ? "unavailable"
+      : "available",
+    launchTime: entry.launchedAt,
+    launchOrder: entryLaunchOrder(entry)?.map(String) ?? null,
+  }));
+  const hash = createHash("sha256");
+  hash.update("programmable.explore-market-ranking.v1", "utf8");
+  hash.update(Uint8Array.of(0));
+  hash.update(JSON.stringify({
+    schemaVersion: "programmable.explore-valuation-snapshot.v1",
+    chainId: 1,
+    blockNumber: input.snapshot.blockNumber,
+    blockHash: input.snapshot.blockHash.toLowerCase(),
+    liquidityBlockNumber: input.snapshot.liquidityBlockNumber,
+    liquidityBlockHash: input.snapshot.liquidityBlockHash.toLowerCase(),
+    sort: input.sort,
+    query: input.query,
+    socials: input.socials,
+    pageSize: input.pageSize,
+    total: ordered.length,
+    ranking,
+  }), "utf8");
+  return `sha256:${hash.digest("hex")}`;
+}
+
+function matchingRankingCommitment(
+  supplied: `sha256:${string}`,
+  expected: `sha256:${string}`,
+) {
+  const suppliedBytes = Buffer.from(supplied.slice(7), "hex");
+  const expectedBytes = Buffer.from(expected.slice(7), "hex");
+  return suppliedBytes.length === expectedBytes.length &&
+    timingSafeEqual(suppliedBytes, expectedBytes);
 }
 
 function entryLaunchTime(entry: ExploreEntry): number {
@@ -396,6 +544,7 @@ async function valueExplorePage(input: Readonly<{
   deployment: ReturnType<typeof currentMarketOnchainDeployment> | null;
   operationalSnapshot: Promise<CurrentEvidenceSnapshotOutcome>;
   currentEvidenceDeadlineAt: number;
+  requestedSnapshot?: RequestedExploreValuationSnapshotV1;
 }>) {
   const requiresGlobalMarketRanking =
     requiresCompleteCurrentValuation(input.options.sort);
@@ -408,25 +557,80 @@ async function valueExplorePage(input: Readonly<{
       });
   const entriesToValue = identityPage?.tokens ?? input.identityEntries;
   if (requiresGlobalMarketRanking) {
+    const operationalSnapshotOutcome = await input.operationalSnapshot;
+    if (operationalSnapshotOutcome.status === "rejected") {
+      throw operationalSnapshotOutcome.error;
+    }
+    const operationalSnapshot = operationalSnapshotOutcome.value;
+    if (!operationalSnapshot) {
+      throw new Error("Current market evidence snapshot is unavailable");
+    }
     const hydratedEntries = await hydrateMissingCanonicalTokenSupplyV1(
       entriesToValue,
+      {
+        deployment: input.deployment ?? undefined,
+        snapshot: {
+          blockNumber: operationalSnapshot.blockNumber,
+          blockHash: operationalSnapshot.blockHash,
+        },
+      },
     );
-    const currentEntries = await valueExploreEntriesWithCurrentEvidence({
+    const currentValuation = await valueExploreEntriesWithCurrentEvidenceSnapshot({
       entries: hydratedEntries,
       marketByToken: new Map(),
       deployment: input.deployment,
-      operationalSnapshot: input.operationalSnapshot,
+      operationalSnapshot,
       maximumValuationAgeMs: EXPLORE_MAXIMUM_STALE_VALUATION_AGE_MS,
       now: new Date(),
-      requireCompleteLiquidityCoverage: true,
+      ...(input.requestedSnapshot
+        ? {
+            liquiditySnapshot:
+              input.requestedSnapshot.liquidityBlockNumber === "none"
+                ? {
+                    chainId: 1 as const,
+                    blockNumber: "none" as const,
+                    blockHash: "none" as const,
+                  }
+                : {
+                    chainId: 1 as const,
+                    blockNumber:
+                      input.requestedSnapshot.liquidityBlockNumber,
+                    blockHash: input.requestedSnapshot.liquidityBlockHash as
+                      `0x${string}`,
+                  },
+          }
+        : {}),
       timeoutMs: Math.max(0, input.currentEvidenceDeadlineAt - Date.now()),
       signal: input.signal,
     });
+    const currentEntries = currentValuation.entries;
     const currentPage = paginateExploreEntriesV1(currentEntries, {
       ...input.options,
       query: "",
       socials: null,
     });
+    const rankingCommitment = exploreRankingCommitment(currentEntries, {
+      snapshot: {
+        ...operationalSnapshot,
+        liquidityBlockNumber: currentValuation.liquiditySnapshot.blockNumber,
+        liquidityBlockHash: currentValuation.liquiditySnapshot.blockHash,
+      },
+      sort: input.options.sort,
+      query: input.options.query,
+      socials: input.options.socials,
+      pageSize: currentPage.pageSize,
+    });
+    if (
+      input.requestedSnapshot &&
+      !matchingRankingCommitment(
+        input.requestedSnapshot.rankingCommitment,
+        rankingCommitment,
+      )
+    ) throw new Error("Explore ranking snapshot changed");
+    if (
+      input.requestedSnapshot &&
+      input.options.page > currentPage.totalPages
+    ) throw new Error("Explore ranking page is outside the snapshot");
     const marketByToken = readBitqueryTokenMarketDataV1(
       exploreEntriesMarketIdentitiesV1(currentPage.tokens),
       { signal: input.signal },
@@ -440,6 +644,19 @@ async function valueExplorePage(input: Readonly<{
     return {
       entries: currentEntries,
       paginated: { ...currentPage, tokens: pageEntries },
+      valuationSnapshot: {
+        schemaVersion: "programmable.explore-valuation-snapshot.v1" as const,
+        chainId: 1 as const,
+        blockNumber: operationalSnapshot.blockNumber,
+        blockHash: operationalSnapshot.blockHash,
+        liquidityBlockNumber: currentValuation.liquiditySnapshot.blockNumber,
+        liquidityBlockHash: currentValuation.liquiditySnapshot.blockHash,
+        rankingCommitment,
+        sort: input.options.sort as "market-cap" | "market-cap-asc",
+        query: input.options.query,
+        socials: input.options.socials,
+        pageSize: currentPage.pageSize,
+      },
     };
   }
   const marketByToken = readBitqueryTokenMarketDataV1(
@@ -466,12 +683,13 @@ async function valueExplorePage(input: Readonly<{
   return {
     entries: valuedEntries,
     paginated: { ...identityPage, tokens: valuedEntries },
+    valuationSnapshot: undefined,
   };
 }
 
 export async function GET(request: NextRequest) {
   const search = request.nextUrl.searchParams;
-  if (!hasCanonicalQueryShape(search)) {
+  if (!hasCanonicalQueryShape(search) || !hasCanonicalPaginationShape(search)) {
     return NextResponse.json(
       { error: "Unsupported query parameters" },
       { status: 400, headers: { "Cache-Control": "no-store" } },
@@ -494,6 +712,13 @@ export async function GET(request: NextRequest) {
       pageSize: integerQuery(search.get("limit"), 9),
       socials,
     } as const;
+    const replaySnapshot = requestedValuationSnapshot(search, options);
+    if (replaySnapshot === null) {
+      return NextResponse.json(
+        { error: "A complete valuation snapshot is required" },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
     const canonicalRead = settleExploreSource(
       readCanonicalExploreSource({
         primary: readPrimaryExploreModel,
@@ -517,6 +742,12 @@ export async function GET(request: NextRequest) {
       ? settleCurrentEvidenceSnapshot({
           read: (signal) => readVerifiedOperationalMarketSnapshot(
             currentMarketDeployment,
+            replaySnapshot
+              ? {
+                  blockNumber: replaySnapshot.blockNumber,
+                  blockHash: replaySnapshot.blockHash,
+                }
+              : undefined,
             { signal },
           ),
           requireComplete: requireCompleteCurrentValuation,
@@ -572,13 +803,14 @@ export async function GET(request: NextRequest) {
       options.query,
       options.socials,
     );
-    const { entries, paginated } = await valueExplorePage({
+    const { entries, paginated, valuationSnapshot } = await valueExplorePage({
       identityEntries: requestedIdentityEntries,
       options,
       signal: request.signal,
       deployment: currentMarketDeployment,
       operationalSnapshot: operationalSnapshotOutcome,
       currentEvidenceDeadlineAt,
+      requestedSnapshot: replaySnapshot,
     });
     const pageEntries = paginated.tokens as ValuedExploreEntry[];
     const currentOnchainEntry = pageEntries.find(
@@ -644,6 +876,7 @@ export async function GET(request: NextRequest) {
       query: options.query,
       sortMetric: "fdv" as const,
       dataQuality,
+      ...(valuationSnapshot ? { valuationSnapshot } : {}),
       snapshot: identityModel?.snapshot ?? null,
       launchDiscoverySnapshot:
         identityModel?.status === "ready"

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -128,6 +128,7 @@ export async function GET(request: NextRequest) {
       ? settleCurrentEvidenceSnapshot({
           read: (signal) => readVerifiedOperationalMarketSnapshot(
             currentMarketDeployment,
+            undefined,
             { signal },
           ),
           requireComplete: false,

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -40,6 +40,7 @@ import {
   isTokenMarketDataV1,
   marketDataStatusLabel,
 } from "@/lib/market-data/market-data-v1";
+import { parseExploreSort } from "@/lib/onchain/query";
 import {
   canOptimizeTokenImage,
   getTokenCardImageSource,
@@ -102,6 +103,20 @@ type TokenSort = "newest" | "oldest" | "market-cap" | "market-cap-asc";
 export type ExploreSocialFilter = "all" | "yes" | "no";
 export type ExploreModelFilter = "all" | "classic" | "custom-hook";
 
+type ExploreValuationSnapshotV1 = Readonly<{
+  schemaVersion: "programmable.explore-valuation-snapshot.v1";
+  chainId: 1;
+  blockNumber: string;
+  blockHash: `0x${string}`;
+  liquidityBlockNumber: string | "none";
+  liquidityBlockHash: `0x${string}` | "none";
+  rankingCommitment: `sha256:${string}`;
+  sort: "market-cap" | "market-cap-asc";
+  query: string;
+  socials: "yes" | "no" | null;
+  pageSize: number;
+}>;
+
 type ExplorePayload = {
   status: "ready" | "not-deployed";
   tokens: ValuedExploreEntry[];
@@ -110,6 +125,7 @@ type ExplorePayload = {
   total: number;
   totalPages: number;
   dataQuality?: ExploreDataQuality;
+  valuationSnapshot?: ExploreValuationSnapshotV1;
 };
 
 type ExploreState =
@@ -699,6 +715,83 @@ function positiveInteger(value: unknown, fallback: number) {
     : fallback;
 }
 
+const MAX_VALUATION_BLOCK_DIGITS = 78;
+const GRAPHQL_INT_MAXIMUM = 2_147_483_647n;
+
+function isCanonicalValuationBlockNumber(value: unknown): value is string {
+  return typeof value === "string" &&
+    value.length <= MAX_VALUATION_BLOCK_DIGITS &&
+    /^[1-9][0-9]*$/u.test(value);
+}
+
+function isCanonicalLiquidityBlockNumber(value: unknown): value is string {
+  return typeof value === "string" &&
+    value.length <= 10 &&
+    /^[1-9][0-9]*$/u.test(value) &&
+    BigInt(value) <= GRAPHQL_INT_MAXIMUM;
+}
+
+function parseExploreValuationSnapshot(
+  value: unknown,
+): ExploreValuationSnapshotV1 | null {
+  const fields = [
+    "schemaVersion",
+    "chainId",
+    "blockNumber",
+    "blockHash",
+    "liquidityBlockNumber",
+    "liquidityBlockHash",
+    "rankingCommitment",
+    "sort",
+    "query",
+    "socials",
+    "pageSize",
+  ];
+  if (
+    !isRecord(value) ||
+    Object.keys(value).length !== fields.length ||
+    fields.some((field) => !Object.hasOwn(value, field)) ||
+    value.schemaVersion !== "programmable.explore-valuation-snapshot.v1" ||
+    value.chainId !== 1 ||
+    !isCanonicalValuationBlockNumber(value.blockNumber) ||
+    typeof value.blockHash !== "string" ||
+    !/^0x[0-9a-f]{64}$/u.test(value.blockHash) ||
+    !(
+      (value.liquidityBlockNumber === "none" &&
+        value.liquidityBlockHash === "none") ||
+      (isCanonicalLiquidityBlockNumber(value.liquidityBlockNumber) &&
+        typeof value.liquidityBlockHash === "string" &&
+        /^0x[0-9a-f]{64}$/u.test(value.liquidityBlockHash))
+    ) ||
+    typeof value.rankingCommitment !== "string" ||
+    !/^sha256:[0-9a-f]{64}$/u.test(value.rankingCommitment) ||
+    (value.sort !== "market-cap" && value.sort !== "market-cap-asc") ||
+    typeof value.query !== "string" ||
+    (value.socials !== null && value.socials !== "yes" &&
+      value.socials !== "no") ||
+    !Number.isSafeInteger(value.pageSize) ||
+    Number(value.pageSize) < 1
+  ) return null;
+  return value as unknown as ExploreValuationSnapshotV1;
+}
+
+function sameExploreValuationSnapshot(
+  left: ExploreValuationSnapshotV1,
+  right: ExploreValuationSnapshotV1,
+) {
+  return left.schemaVersion === right.schemaVersion &&
+    left.chainId === right.chainId &&
+    left.blockNumber === right.blockNumber &&
+    left.blockHash === right.blockHash &&
+    left.liquidityBlockNumber === right.liquidityBlockNumber &&
+    left.liquidityBlockHash === right.liquidityBlockHash &&
+    left.rankingCommitment === right.rankingCommitment &&
+    left.sort === right.sort &&
+    left.query === right.query &&
+    left.socials === right.socials &&
+    left.pageSize === right.pageSize;
+}
+
 function parseExplorePayload(value: unknown): ExplorePayload {
   if (!isRecord(value)) {
     throw new Error("The token registry returned an invalid response");
@@ -721,6 +814,36 @@ function parseExplorePayload(value: unknown): ExplorePayload {
     throw new Error("The token registry returned an invalid token record");
   }
 
+  const valuationSnapshot = value.valuationSnapshot === undefined
+    ? undefined
+    : parseExploreValuationSnapshot(value.valuationSnapshot);
+  if (valuationSnapshot === null) {
+    throw new Error("The token registry returned an invalid valuation snapshot");
+  }
+
+  if (valuationSnapshot !== undefined) {
+    if (
+      typeof value.page !== "number" ||
+      !Number.isSafeInteger(value.page) ||
+      value.page < 1 ||
+      typeof value.pageSize !== "number" ||
+      !Number.isSafeInteger(value.pageSize) ||
+      value.pageSize < 1 ||
+      typeof value.total !== "number" ||
+      !Number.isSafeInteger(value.total) ||
+      value.total < 0 ||
+      typeof value.totalPages !== "number" ||
+      !Number.isSafeInteger(value.totalPages) ||
+      value.totalPages < 0 ||
+      value.totalPages !== Math.ceil(value.total / value.pageSize) ||
+      (value.totalPages === 0
+        ? value.page !== 1
+        : value.page > value.totalPages)
+    ) {
+      throw new Error("The token registry returned invalid pagination data");
+    }
+  }
+
   return {
     status: value.status,
     tokens: tokens as ValuedExploreEntry[],
@@ -731,6 +854,9 @@ function parseExplorePayload(value: unknown): ExplorePayload {
     ),
     total: positiveInteger(value.total, tokens.length),
     totalPages: positiveInteger(value.totalPages, 0),
+    ...(valuationSnapshot === undefined
+      ? {}
+      : { valuationSnapshot }),
     ...(value.dataQuality === undefined
       ? {}
       : { dataQuality: value.dataQuality }),
@@ -763,7 +889,8 @@ export function createExploreInitialState(
     const payload = parseExplorePayload(response.body);
     if (
       payload.page !== 1 ||
-      payload.pageSize !== EXPLORE_TOKENS_PER_PAGE
+      payload.pageSize !== EXPLORE_TOKENS_PER_PAGE ||
+      payload.valuationSnapshot !== undefined
     ) {
       throw new Error("The token registry returned an unexpected first page");
     }
@@ -794,6 +921,7 @@ export function handledInitialExploreRequestKey(
 type PendingExploreRequest = {
   controller: AbortController;
   promise: Promise<ExplorePayload>;
+  requestIdentity: string;
 };
 
 const pendingExploreRequests = new Map<string, PendingExploreRequest>();
@@ -803,6 +931,229 @@ const resolvedExplorePayloads = new Map<
 >();
 const RESOLVED_EXPLORE_PAYLOAD_TTL_MS = 4_500;
 const MAX_RESOLVED_EXPLORE_PAYLOADS = 24;
+const EXPLORE_VALUATION_CONTINUATION_PARAMETERS = [
+  "valuationBlock",
+  "valuationBlockHash",
+  "liquidityBlock",
+  "liquidityBlockHash",
+  "rankingCommitment",
+] as const;
+
+type ExploreValuationRequestContract = Readonly<{
+  marketCapSort: boolean;
+  page: number;
+  pageSize: number;
+  query: string;
+  socials: "yes" | "no" | null;
+  sort: string;
+  continuation: Readonly<{
+    blockNumber: string;
+    blockHash: `0x${string}`;
+    liquidityBlockNumber: string | "none";
+    liquidityBlockHash: `0x${string}` | "none";
+    rankingCommitment: `sha256:${string}`;
+  }> | null;
+}>;
+
+function canonicalExploreSearchIdentity(search: URLSearchParams) {
+  const canonical = new URLSearchParams(search);
+  canonical.sort();
+  return canonical.toString();
+}
+
+function exactPositiveSearchInteger(
+  value: string | null,
+  fallback: number,
+  label: string,
+) {
+  const normalized = value ?? String(fallback);
+  if (!/^[1-9][0-9]*$/u.test(normalized)) {
+    throw new Error(`The token registry request has an invalid ${label}`);
+  }
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`The token registry request has an invalid ${label}`);
+  }
+  return parsed;
+}
+
+function exploreValuationRequestContract(
+  search: URLSearchParams,
+): ExploreValuationRequestContract {
+  for (const parameter of EXPLORE_VALUATION_CONTINUATION_PARAMETERS) {
+    if (search.getAll(parameter).length > 1) {
+      throw new Error("The token registry request has duplicate valuation snapshot fields");
+    }
+  }
+  const sort = parseExploreSort(search.get("sort"));
+  const marketCapSort = sort === "market-cap" || sort === "market-cap-asc";
+  const page = exactPositiveSearchInteger(search.get("page"), 1, "page");
+  const pageSize = Math.min(
+    exactPositiveSearchInteger(
+      search.get("limit"),
+      EXPLORE_TOKENS_PER_PAGE,
+      "page size",
+    ),
+    EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
+  );
+  const supplied = EXPLORE_VALUATION_CONTINUATION_PARAMETERS.filter(
+    (parameter) => search.has(parameter),
+  ).length;
+  if (!marketCapSort) {
+    if (supplied > 0) {
+      throw new Error("A valuation snapshot is not allowed for this sort");
+    }
+    return {
+      marketCapSort,
+      page,
+      pageSize,
+      query: (search.get("q") ?? "").trim(),
+      socials:
+        search.get("socials") === "yes" || search.get("socials") === "no"
+          ? search.get("socials") as "yes" | "no"
+          : null,
+      sort,
+      continuation: null,
+    };
+  }
+  if (page === 1) {
+    if (supplied > 0) {
+      throw new Error("A valuation continuation is not allowed on page one");
+    }
+  } else if (supplied !== EXPLORE_VALUATION_CONTINUATION_PARAMETERS.length) {
+    throw new Error("A complete valuation snapshot is required for this page");
+  }
+
+  const valuationBlock = search.get("valuationBlock");
+  const valuationBlockHash = search.get("valuationBlockHash");
+  const liquidityBlock = search.get("liquidityBlock");
+  const liquidityBlockHash = search.get("liquidityBlockHash");
+  const rankingCommitment = search.get("rankingCommitment");
+  const continuation = page === 1
+    ? null
+    : valuationBlock &&
+        isCanonicalValuationBlockNumber(valuationBlock) &&
+        valuationBlockHash &&
+        /^0x[0-9a-f]{64}$/u.test(valuationBlockHash) &&
+        liquidityBlock &&
+        liquidityBlockHash &&
+        ((liquidityBlock === "none" && liquidityBlockHash === "none") ||
+          (isCanonicalLiquidityBlockNumber(liquidityBlock) &&
+            /^0x[0-9a-f]{64}$/u.test(liquidityBlockHash))) &&
+        rankingCommitment &&
+        /^sha256:[0-9a-f]{64}$/u.test(rankingCommitment)
+      ? {
+          blockNumber: valuationBlock,
+          blockHash: valuationBlockHash as `0x${string}`,
+          liquidityBlockNumber: liquidityBlock,
+          liquidityBlockHash: liquidityBlockHash as `0x${string}` | "none",
+          rankingCommitment: rankingCommitment as `sha256:${string}`,
+        }
+      : null;
+  if (page > 1 && continuation === null) {
+    throw new Error("The valuation snapshot continuation is malformed");
+  }
+  return {
+    marketCapSort,
+    page,
+    pageSize,
+    query: (search.get("q") ?? "").trim(),
+    socials:
+      search.get("socials") === "yes" || search.get("socials") === "no"
+        ? search.get("socials") as "yes" | "no"
+        : null,
+    sort,
+    continuation,
+  };
+}
+
+function assertExploreValuationResponseContract(
+  payload: ExplorePayload,
+  contract: ExploreValuationRequestContract,
+) {
+  const snapshot = payload.valuationSnapshot;
+  if (!contract.marketCapSort) {
+    if (snapshot !== undefined) {
+      throw new Error("The token registry returned an unexpected valuation snapshot");
+    }
+    return;
+  }
+  if (
+    payload.page !== contract.page ||
+    snapshot === undefined ||
+    snapshot.sort !== contract.sort ||
+    snapshot.query !== contract.query ||
+    snapshot.socials !== contract.socials ||
+    snapshot.pageSize !== contract.pageSize ||
+    payload.pageSize !== contract.pageSize
+  ) {
+    throw new Error("The token registry returned an inconsistent valuation snapshot");
+  }
+  const continuation = contract.continuation;
+  if (
+    continuation &&
+    (snapshot.blockNumber !== continuation.blockNumber ||
+      snapshot.blockHash !== continuation.blockHash ||
+      snapshot.liquidityBlockNumber !== continuation.liquidityBlockNumber ||
+      snapshot.liquidityBlockHash !== continuation.liquidityBlockHash ||
+      snapshot.rankingCommitment !== continuation.rankingCommitment)
+  ) {
+    throw new Error("The token registry changed the valuation snapshot");
+  }
+}
+
+function assertUniqueExploreDatasetEntries(
+  entries: readonly ValuedExploreEntry[],
+) {
+  const ids = new Set<string>();
+  const tokenAddresses = new Set<string>();
+  for (const entry of entries) {
+    if (ids.has(entry.id)) {
+      throw new Error("The token registry repeated an entry while filters were loading");
+    }
+    ids.add(entry.id);
+    if (entry.exploreKind !== "token") continue;
+    const tokenAddress = entry.tokenAddress.toLowerCase();
+    if (tokenAddresses.has(tokenAddress)) {
+      throw new Error("The token registry repeated a token while filters were loading");
+    }
+    tokenAddresses.add(tokenAddress);
+  }
+}
+
+function valuationSnapshotMatchesSearch(
+  snapshot: ExploreValuationSnapshotV1,
+  search: URLSearchParams,
+) {
+  const firstPageSearch = new URLSearchParams(search);
+  firstPageSearch.set("page", "1");
+  for (const parameter of EXPLORE_VALUATION_CONTINUATION_PARAMETERS) {
+    firstPageSearch.delete(parameter);
+  }
+  const contract = exploreValuationRequestContract(firstPageSearch);
+  return contract.marketCapSort &&
+    snapshot.sort === contract.sort &&
+    snapshot.query === contract.query &&
+    snapshot.socials === contract.socials &&
+    snapshot.pageSize === contract.pageSize;
+}
+
+function applyExploreValuationContinuation(
+  search: URLSearchParams,
+  snapshot: ExploreValuationSnapshotV1,
+) {
+  search.set("sort", snapshot.sort);
+  if (snapshot.query === "") search.delete("q");
+  else search.set("q", snapshot.query);
+  if (snapshot.socials === null) search.delete("socials");
+  else search.set("socials", snapshot.socials);
+  search.set("limit", String(snapshot.pageSize));
+  search.set("valuationBlock", snapshot.blockNumber);
+  search.set("valuationBlockHash", snapshot.blockHash);
+  search.set("liquidityBlock", snapshot.liquidityBlockNumber);
+  search.set("liquidityBlockHash", snapshot.liquidityBlockHash);
+  search.set("rankingCommitment", snapshot.rankingCommitment);
+}
 
 function readResolvedExplorePayload(contentKey: string) {
   const cached = resolvedExplorePayloads.get(contentKey);
@@ -835,6 +1186,7 @@ function cacheResolvedExplorePayload(
 async function fetchExplorePayload(
   search: URLSearchParams,
   signal: AbortSignal,
+  contract: ExploreValuationRequestContract,
 ) {
   const response = await fetch(`/api/explore?${search.toString()}`, {
     headers: { Accept: "application/json" },
@@ -844,17 +1196,39 @@ async function fetchExplorePayload(
   if (!response.ok) {
     throw new Error(readApiError(body));
   }
-  return parseExplorePayload(body);
+  const payload = parseExplorePayload(body);
+  assertExploreValuationResponseContract(payload, contract);
+  return payload;
 }
 
 export function loadExplorePayload(
   contentKey: string,
   search: URLSearchParams,
 ) {
+  let contract: ExploreValuationRequestContract;
+  try {
+    contract = exploreValuationRequestContract(search);
+  } catch (error) {
+    return Promise.reject(error);
+  }
   const resolved = readResolvedExplorePayload(contentKey);
-  if (resolved) return Promise.resolve(resolved);
+  if (resolved) {
+    try {
+      assertExploreValuationResponseContract(resolved, contract);
+      return Promise.resolve(resolved);
+    } catch {
+      resolvedExplorePayloads.delete(contentKey);
+    }
+  }
+  const requestIdentity = canonicalExploreSearchIdentity(search);
   const pendingRequest = pendingExploreRequests.get(contentKey);
-  if (pendingRequest) return pendingRequest.promise;
+  if (pendingRequest?.requestIdentity === requestIdentity) {
+    return pendingRequest.promise;
+  }
+  if (pendingRequest) {
+    pendingExploreRequests.delete(contentKey);
+    pendingRequest.controller.abort();
+  }
 
   const controller = new AbortController();
   let timedOut = false;
@@ -864,7 +1238,11 @@ export function loadExplorePayload(
   }, EXPLORE_REQUEST_TIMEOUT_MS);
   const request = (async (): Promise<ExplorePayload> => {
     try {
-      const payload = await fetchExplorePayload(search, controller.signal);
+      const payload = await fetchExplorePayload(
+        search,
+        controller.signal,
+        contract,
+      );
       cacheResolvedExplorePayload(contentKey, payload);
       return payload;
     } catch (error) {
@@ -877,7 +1255,7 @@ export function loadExplorePayload(
     }
   })();
 
-  const entry = { controller, promise: request };
+  const entry = { controller, promise: request, requestIdentity };
   pendingExploreRequests.set(contentKey, entry);
   const clearPendingRequest = () => {
     if (pendingExploreRequests.get(contentKey) === entry) {
@@ -891,11 +1269,81 @@ export function loadExplorePayload(
 
 function abortExplorePayload(contentKey: string) {
   const modelPagePrefix = `${contentKey}\u0000model-page:`;
+  const snapshotBootstrapPrefix = `${contentKey}\u0000snapshot-bootstrap:`;
   for (const [key, pendingRequest] of pendingExploreRequests) {
-    if (key !== contentKey && !key.startsWith(modelPagePrefix)) continue;
+    if (
+      key !== contentKey &&
+      !key.startsWith(modelPagePrefix) &&
+      !key.startsWith(snapshotBootstrapPrefix)
+    ) continue;
     pendingExploreRequests.delete(key);
     pendingRequest.controller.abort();
   }
+}
+
+export async function loadExplorePageWithValuationSnapshot(
+  contentKey: string,
+  search: URLSearchParams,
+  cachedSnapshot: ExploreValuationSnapshotV1 | null = null,
+) {
+  const requestedSearch = new URLSearchParams(search);
+  const requestedPage = exactPositiveSearchInteger(
+    requestedSearch.get("page"),
+    1,
+    "page",
+  );
+  const contextSearch = new URLSearchParams(requestedSearch);
+  contextSearch.set("page", "1");
+  for (const parameter of EXPLORE_VALUATION_CONTINUATION_PARAMETERS) {
+    contextSearch.delete(parameter);
+  }
+  const contextContract = exploreValuationRequestContract(contextSearch);
+  if (!contextContract.marketCapSort || requestedPage === 1) {
+    const payload = await loadExplorePayload(contentKey, requestedSearch);
+    return {
+      payload,
+      valuationSnapshot: payload.valuationSnapshot ?? null,
+    };
+  }
+  if (
+    EXPLORE_VALUATION_CONTINUATION_PARAMETERS.some((parameter) =>
+      requestedSearch.has(parameter)
+    )
+  ) {
+    throw new Error("The valuation continuation must be bound by the client");
+  }
+
+  let valuationSnapshot =
+    cachedSnapshot && valuationSnapshotMatchesSearch(cachedSnapshot, search)
+      ? cachedSnapshot
+      : null;
+  if (valuationSnapshot === null) {
+    const firstPageSearch = new URLSearchParams(requestedSearch);
+    firstPageSearch.set("page", "1");
+    for (const parameter of EXPLORE_VALUATION_CONTINUATION_PARAMETERS) {
+      firstPageSearch.delete(parameter);
+    }
+    const firstPage = await loadExplorePayload(
+      `${contentKey}\u0000snapshot-bootstrap:${canonicalExploreSearchIdentity(firstPageSearch)}`,
+      firstPageSearch,
+    );
+    valuationSnapshot = firstPage.valuationSnapshot ?? null;
+    if (valuationSnapshot === null) {
+      throw new Error("The token registry did not bind the valuation snapshot");
+    }
+  }
+  applyExploreValuationContinuation(requestedSearch, valuationSnapshot);
+  const payload = await loadExplorePayload(contentKey, requestedSearch);
+  if (
+    !payload.valuationSnapshot ||
+    !sameExploreValuationSnapshot(
+      valuationSnapshot,
+      payload.valuationSnapshot,
+    )
+  ) {
+    throw new Error("The token registry changed the valuation snapshot");
+  }
+  return { payload, valuationSnapshot: payload.valuationSnapshot };
 }
 
 export async function loadExploreModelDataset(
@@ -905,10 +1353,22 @@ export async function loadExploreModelDataset(
   const firstPageSearch = new URLSearchParams(search);
   firstPageSearch.set("page", "1");
   firstPageSearch.set("limit", String(EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE));
+  for (const parameter of EXPLORE_VALUATION_CONTINUATION_PARAMETERS) {
+    if (firstPageSearch.has(parameter)) {
+      throw new Error("The model dataset request carried a valuation continuation");
+    }
+  }
   const firstPage = await loadExplorePayload(
     `${contentKey}\u0000model-page:1`,
     firstPageSearch,
   );
+  const marketCapSort =
+    firstPageSearch.get("sort") === "market-cap" ||
+    firstPageSearch.get("sort") === "market-cap-asc";
+  const valuationSnapshot = firstPage.valuationSnapshot;
+  if (marketCapSort !== (valuationSnapshot !== undefined)) {
+    throw new Error("The token registry returned an inconsistent valuation snapshot");
+  }
   if (firstPage.totalPages <= 1) {
     return firstPage;
   }
@@ -918,6 +1378,9 @@ export async function loadExploreModelDataset(
       const page = index + 2;
       const pageSearch = new URLSearchParams(firstPageSearch);
       pageSearch.set("page", String(page));
+      if (valuationSnapshot) {
+        applyExploreValuationContinuation(pageSearch, valuationSnapshot);
+      }
       const payload = await loadExplorePayload(
         `${contentKey}\u0000model-page:${page}`,
         pageSearch,
@@ -931,13 +1394,27 @@ export async function loadExploreModelDataset(
       ) {
         throw new Error("Tokens changed while filters were loading");
       }
+      if (
+        valuationSnapshot &&
+        (!payload.valuationSnapshot ||
+          !sameExploreValuationSnapshot(
+            valuationSnapshot,
+            payload.valuationSnapshot,
+          ))
+      ) {
+        throw new Error("Token ranking changed while filters were loading");
+      }
       return payload;
     }),
   );
 
+  const tokens = [firstPage, ...remainingPages].flatMap(
+    (payload) => payload.tokens,
+  );
+  assertUniqueExploreDatasetEntries(tokens);
   return {
     ...firstPage,
-    tokens: [firstPage, ...remainingPages].flatMap((payload) => payload.tokens),
+    tokens,
   };
 }
 
@@ -1231,7 +1708,12 @@ export function ExploreView({
     key: string;
     payload: ExplorePayload;
   } | null>(null);
+  const visibleValuationSnapshot = useRef<{
+    epoch: string;
+    snapshot: ExploreValuationSnapshotV1;
+  } | null>(null);
   const filterRef = useRef<HTMLDetailsElement>(null);
+  const valuationSnapshotEpoch = `${retryKey}\u0000${refreshKey}`;
   const contentKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}`;
   const requestKey = `${contentKey}\u0000${retryKey}\u0000${refreshKey}`;
   const modelDatasetKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}\u0000${refreshKey}`;
@@ -1338,7 +1820,23 @@ export function ExploreView({
       try {
         let payload: ExplorePayload;
         if (modelFilter === "all") {
-          payload = await loadExplorePayload(activeRequestContentKey, search);
+          const loaded = await loadExplorePageWithValuationSnapshot(
+            activeRequestContentKey,
+            search,
+            visibleValuationSnapshot.current?.epoch ===
+                valuationSnapshotEpoch
+              ? visibleValuationSnapshot.current.snapshot
+              : null,
+          );
+          payload = loaded.payload;
+          if (!ignore) {
+            visibleValuationSnapshot.current = loaded.valuationSnapshot
+              ? {
+                  epoch: valuationSnapshotEpoch,
+                  snapshot: loaded.valuationSnapshot,
+                }
+              : null;
+          }
         } else {
           let dataset =
             modelDatasetCache.current?.key === modelDatasetKey
@@ -1409,6 +1907,7 @@ export function ExploreView({
     requestKey,
     socialFilter,
     sort,
+    valuationSnapshotEpoch,
   ]);
 
   const previewPayload = useMemo<ExplorePayload>(() => {

--- a/lib/alchemy/live-market.server.ts
+++ b/lib/alchemy/live-market.server.ts
@@ -191,8 +191,10 @@ export function withoutUnboundEthUsdQuote(
  */
 export async function readVerifiedOperationalMarketSnapshot(
   deployment: ReadyOnchainDeployment,
+  expected?: Readonly<{ blockNumber: string; blockHash: Hex }>,
   options: Readonly<{ signal?: AbortSignal }> = {},
 ): Promise<ExploreSnapshot | null> {
+  options.signal?.throwIfAborted();
   const health = await readOperationalRpcHealth(
     deployment,
     undefined,
@@ -205,10 +207,55 @@ export async function readVerifiedOperationalMarketSnapshot(
     health.confirmedBlock === null
   ) return null;
 
-  return {
+  const snapshot = {
     chainId: deployment.chainId,
     blockNumber: health.confirmedBlock.number,
-    blockHash: health.confirmedBlock.hash,
+    blockHash: health.confirmedBlock.hash.toLowerCase() as Hex,
+    confirmations: Number(deployment.confirmations),
+  };
+  const target = expected ?? snapshot;
+  if (
+    !/^(?:0|[1-9]\d*)$/u.test(target.blockNumber) ||
+    target.blockNumber.length > 78 ||
+    !/^0x[0-9a-f]{64}$/u.test(target.blockHash) ||
+    BigInt(target.blockNumber) > BigInt(snapshot.blockNumber)
+  ) return null;
+
+  const blockNumber = BigInt(target.blockNumber);
+  const observations = await Promise.allSettled(
+    [deployment.rpcUrl, deployment.rpcUrlSecondary].map(async (rpcUrl) => {
+      if (!rpcUrl) throw new OperationalRpcUnavailableError();
+      const client = createPublicClient({
+        chain: deployment.chainId === 1 ? mainnet : sepolia,
+        transport: http(rpcUrl, {
+          retryCount: 0,
+          timeout: 12_000,
+          fetchOptions: { signal: options.signal },
+        }),
+      });
+      const block = await client.getBlock({ blockNumber });
+      options.signal?.throwIfAborted();
+      if (
+        block.number !== blockNumber ||
+        !block.hash ||
+        block.hash.toLowerCase() !== target.blockHash
+      ) throw new OperationalRpcUnavailableError();
+      return block.timestamp;
+    }),
+  );
+  options.signal?.throwIfAborted();
+  const timestamps = observations.flatMap((observation) =>
+    observation.status === "fulfilled" ? [observation.value] : []
+  );
+  if (timestamps.length !== 2 || timestamps[0] !== timestamps[1]) return null;
+  const nowSeconds = BigInt(Math.floor(Date.now() / 1_000));
+  const timestamp = timestamps[0]!;
+  if (timestamp > nowSeconds + 60n || nowSeconds - timestamp > 300n) return null;
+  return {
+    chainId: deployment.chainId,
+    blockNumber: target.blockNumber,
+    blockHash: target.blockHash,
+    blockTimestamp: timestamp.toString(),
     confirmations: Number(deployment.confirmations),
   };
 }

--- a/lib/market-data/canonical-token-supply.server.ts
+++ b/lib/market-data/canonical-token-supply.server.ts
@@ -35,6 +35,10 @@ export type CanonicalTokenSupplyDependencies = Readonly<{
   deployment?: ReadyOnchainDeployment;
   additionalRpcUrls?: readonly string[];
   createClient?: (rpcUrl: string) => SupplyClient;
+  snapshot?: Readonly<{
+    blockNumber: string;
+    blockHash: Hex;
+  }>;
 }>;
 
 function needsCanonicalSupply(entry: ExploreEntry): boolean {
@@ -124,17 +128,28 @@ export async function hydrateMissingCanonicalTokenSupplyV1<T extends ExploreEntr
     ])];
     if (rpcUrls.length < 2) return [...entries];
     const clients = rpcUrls.map(createClient);
-    const heads = (await Promise.allSettled(clients.map((client) =>
-      client.getBlockNumber())))
-      .flatMap((result) => result.status === "fulfilled" && result.value >= 0n
-        ? [result.value]
-        : []);
-    if (heads.length < 2) return [...entries];
-    const lowestHead = heads.reduce((lowest, head) =>
-      head < lowest ? head : lowest);
-    const blockNumber = lowestHead > deployment.confirmations
-      ? lowestHead - deployment.confirmations
-      : 0n;
+    const requestedSnapshot = dependencies.snapshot;
+    if (
+      requestedSnapshot &&
+      (!/^(?:0|[1-9]\d*)$/u.test(requestedSnapshot.blockNumber) ||
+        !/^0x[0-9a-f]{64}$/u.test(requestedSnapshot.blockHash))
+    ) return [...entries];
+    let blockNumber: bigint;
+    if (requestedSnapshot) {
+      blockNumber = BigInt(requestedSnapshot.blockNumber);
+    } else {
+      const heads = (await Promise.allSettled(clients.map((client) =>
+        client.getBlockNumber())))
+        .flatMap((result) => result.status === "fulfilled" && result.value >= 0n
+          ? [result.value]
+          : []);
+      if (heads.length < 2) return [...entries];
+      const lowestHead = heads.reduce((lowest, head) =>
+        head < lowest ? head : lowest);
+      blockNumber = lowestHead > deployment.confirmations
+        ? lowestHead - deployment.confirmations
+        : 0n;
+    }
 
     return await Promise.all(entries.map(async (entry) => {
       if (!needsCanonicalSupply(entry) || entry.exploreKind !== "token") {
@@ -154,7 +169,11 @@ export async function hydrateMissingCanonicalTokenSupplyV1<T extends ExploreEntr
           groups.set(key, [...(groups.get(key) ?? []), observation]);
         }
         const agreed = [...groups.values()].find((group) => group.length >= 2)?.[0];
-        if (!agreed) return entry;
+        if (
+          !agreed ||
+          (requestedSnapshot &&
+            agreed.blockHash.toLowerCase() !== requestedSnapshot.blockHash)
+        ) return entry;
         return {
           ...entry,
           totalSupplyRaw: agreed.totalSupplyRaw,

--- a/lib/market-data/current-valuation.server.ts
+++ b/lib/market-data/current-valuation.server.ts
@@ -11,8 +11,9 @@ import {
   type ValuedExploreEntry,
 } from "../explore-financial-data";
 import {
-  readOfficialV4LiquidityEvidence,
+  readOfficialV4LiquidityEvidenceSnapshot,
   type OfficialV4LiquidityEvidenceV1,
+  type OfficialV4LiquiditySnapshotV1,
 } from "../onchain/uniswap-v4-subgraph";
 import type {
   ExploreSnapshot,
@@ -31,6 +32,22 @@ export const CURRENT_EVIDENCE_ROUTE_DEADLINE_MS = 4_500;
 export type CurrentEvidenceSnapshotOutcome =
   | Readonly<{ status: "fulfilled"; value: ExploreSnapshot | null }>
   | Readonly<{ status: "rejected"; error: unknown }>;
+
+export type ExploreLiquiditySnapshotV1 =
+  | OfficialV4LiquiditySnapshotV1
+  | Readonly<{ chainId: 1; blockNumber: "none"; blockHash: "none" }>;
+
+const NO_LIQUIDITY_SNAPSHOT = {
+  chainId: 1,
+  blockNumber: "none",
+  blockHash: "none",
+} as const satisfies ExploreLiquiditySnapshotV1;
+
+function concreteLiquiditySnapshot(
+  snapshot: ExploreLiquiditySnapshotV1 | undefined,
+): snapshot is OfficialV4LiquiditySnapshotV1 {
+  return snapshot !== undefined && snapshot.blockNumber !== "none";
+}
 
 function withoutUnevidencedCurrentBitqueryValuation(
   entry: ValuedExploreEntry,
@@ -261,7 +278,7 @@ function classicNativeToken(entry: ExploreEntry): entry is Extract<
  * current FDV only from the independently bound StateView/Chainlink and
  * official-v4 liquidity evidence paths.
  */
-export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
+type ValueExploreEntriesWithCurrentEvidenceInput = Readonly<{
   entries: readonly ExploreEntry[];
   marketByToken:
     | ReadonlyMap<string, TokenMarketDataV1>
@@ -277,7 +294,16 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
   allowHistoricalBitqueryFallback?: boolean;
   timeoutMs?: number;
   signal?: AbortSignal;
-}>): Promise<ValuedExploreEntry[]> {
+  liquiditySnapshot?: ExploreLiquiditySnapshotV1;
+}>;
+
+async function valueExploreEntriesWithCurrentEvidenceInternal(
+  input: ValueExploreEntriesWithCurrentEvidenceInput & Readonly<{
+    captureLiquiditySnapshot?: (
+      snapshot: ExploreLiquiditySnapshotV1,
+    ) => void;
+  }>,
+): Promise<ValuedExploreEntry[]> {
   const candidates = input.entries.filter(classicNativeToken);
   const timeoutMs = input.timeoutMs ?? CURRENT_EVIDENCE_ROUTE_DEADLINE_MS;
   const deployment = input.deployment?.chainId === 1
@@ -293,7 +319,8 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
           : { status: "fulfilled", value: value as ExploreSnapshot | null },
       (error: unknown) => ({ status: "rejected" as const, error }),
     );
-  const canReadCurrentEvidence = candidates.length > 0 &&
+  const canReadCurrentEvidence =
+    (candidates.length > 0 || input.requireCompleteLiquidityCoverage === true) &&
     timeoutMs > 0 &&
     deployment !== null;
 
@@ -308,6 +335,26 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
           throw new Error(
             "Current market evidence reference head is unavailable",
           );
+        }
+        const referenceHead = {
+          chainId: 1 as const,
+          blockNumber: operationalSnapshot.blockNumber,
+          blockHash: operationalSnapshot.blockHash,
+        };
+        if (candidates.length === 0) {
+          if (
+            input.liquiditySnapshot &&
+            input.liquiditySnapshot.blockNumber !== "none"
+          ) {
+            throw new Error("Explore liquidity snapshot changed");
+          }
+          return {
+            status: "complete" as const,
+            liquidityByPool: new Map(),
+            liquidityRequestedPools: new Set<string>(),
+            pricedByToken: new Map<string, LauncherToken>(),
+            liquiditySnapshot: NO_LIQUIDITY_SNAPSHOT,
+          };
         }
         const pricedSnapshotRead = withSameBlockEthUsdQuote({
           deployment,
@@ -390,27 +437,53 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
         const liquidityRequestedPools = new Set(
           liquidityCandidates.map((candidate) => candidate.poolId.toLowerCase()),
         );
+        if (liquidityCandidates.length === 0) {
+          if (
+            input.liquiditySnapshot &&
+            input.liquiditySnapshot.blockNumber !== "none"
+          ) {
+            throw new Error("Explore liquidity snapshot changed");
+          }
+          return {
+            status: "complete" as const,
+            liquidityByPool: new Map(),
+            liquidityRequestedPools,
+            pricedByToken,
+            liquiditySnapshot: NO_LIQUIDITY_SNAPSHOT,
+          };
+        }
+        if (input.liquiditySnapshot?.blockNumber === "none") {
+          throw new Error("Explore liquidity snapshot changed");
+        }
+        const requestedLiquiditySnapshot = concreteLiquiditySnapshot(
+            input.liquiditySnapshot,
+          )
+          ? input.liquiditySnapshot
+          : undefined;
         let liquidityCoverageFailed = false;
-        const liquidityEvidence = liquidityCandidates.length === 0
-          ? [] as readonly OfficialV4LiquidityEvidenceV1[]
-          : await readOfficialV4LiquidityEvidence({
+        const liquidityRead = await readOfficialV4LiquidityEvidenceSnapshot({
               tokens: liquidityCandidates,
-              referenceHead: {
-                chainId: 1,
-                blockNumber: operationalSnapshot.blockNumber,
-                blockHash: operationalSnapshot.blockHash,
-              },
+              referenceHead,
+              ...(requestedLiquiditySnapshot
+                ? { liquiditySnapshot: requestedLiquiditySnapshot }
+                : {}),
               now: input.now,
             }, { signal }).catch((error) => {
               if (input.requireCompleteLiquidityCoverage) throw error;
               liquidityCoverageFailed = true;
-              return [] as readonly OfficialV4LiquidityEvidenceV1[];
+              return {
+                evidence: [] as readonly OfficialV4LiquidityEvidenceV1[],
+                snapshot: null,
+              };
             });
         if (liquidityCoverageFailed) {
           return { status: "source-unavailable" as const };
         }
+        if (input.requireCompleteLiquidityCoverage && !liquidityRead.snapshot) {
+          throw new Error("Current liquidity snapshot is unavailable");
+        }
         const liquidityByPool = new Map(
-          liquidityEvidence.map((evidence) => [
+          liquidityRead.evidence.map((evidence) => [
             evidence.identity.poolId.toLowerCase(),
             evidence,
           ]),
@@ -420,6 +493,7 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
           liquidityByPool,
           liquidityRequestedPools,
           pricedByToken,
+          liquiditySnapshot: liquidityRead.snapshot,
         };
       }, timeoutMs, input.signal).then(
       (value) => ({ status: "fulfilled" as const, value }),
@@ -440,7 +514,10 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
       input.allowHistoricalBitqueryFallback === true,
     ),
   );
-  if (candidates.length === 0) return baseEntries;
+  if (
+    candidates.length === 0 &&
+    input.requireCompleteLiquidityCoverage !== true
+  ) return baseEntries;
   if (!canReadCurrentEvidence || currentEvidenceOutcome === null) {
     if (input.requireCompleteLiquidityCoverage) {
       throw new Error(timeoutMs <= 0
@@ -456,8 +533,14 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
     return baseEntries;
   }
   if (outcome.value.status === "source-unavailable") return baseEntries;
-  const { liquidityByPool, liquidityRequestedPools, pricedByToken } =
+  const {
+    liquidityByPool,
+    liquidityRequestedPools,
+    pricedByToken,
+    liquiditySnapshot,
+  } =
     outcome.value;
+  if (liquiditySnapshot) input.captureLiquiditySnapshot?.(liquiditySnapshot);
   return marketEntries.map((entry) => {
     if (entry.exploreKind !== "token") return entry;
     const priced = pricedByToken.get(entry.tokenAddress.toLowerCase());
@@ -491,4 +574,30 @@ export async function valueExploreEntriesWithCurrentEvidence(input: Readonly<{
       "source-unavailable",
     );
   });
+}
+
+export async function valueExploreEntriesWithCurrentEvidence(
+  input: ValueExploreEntriesWithCurrentEvidenceInput,
+): Promise<ValuedExploreEntry[]> {
+  return valueExploreEntriesWithCurrentEvidenceInternal(input);
+}
+
+export async function valueExploreEntriesWithCurrentEvidenceSnapshot(
+  input: ValueExploreEntriesWithCurrentEvidenceInput,
+): Promise<Readonly<{
+  entries: ValuedExploreEntry[];
+  liquiditySnapshot: ExploreLiquiditySnapshotV1;
+}>> {
+  let liquiditySnapshot: ExploreLiquiditySnapshotV1 | null = null;
+  const entries = await valueExploreEntriesWithCurrentEvidenceInternal({
+    ...input,
+    requireCompleteLiquidityCoverage: true,
+    captureLiquiditySnapshot: (snapshot) => {
+      liquiditySnapshot = snapshot;
+    },
+  });
+  if (liquiditySnapshot === null) {
+    throw new Error("Current liquidity snapshot is unavailable");
+  }
+  return { entries, liquiditySnapshot };
 }

--- a/lib/onchain/uniswap-v4-subgraph.ts
+++ b/lib/onchain/uniswap-v4-subgraph.ts
@@ -71,6 +71,74 @@ const POOL_ANALYTICS_QUERY = `
   }
 `;
 
+const POOL_ANALYTICS_AT_BLOCK_QUERY = `
+  query ProgrammableExplorePoolsAtBlock(
+    $poolIds: [ID!]!
+    $first: Int!
+    $blockNumber: Int!
+  ) {
+    _meta(block: { number: $blockNumber }) {
+      deployment
+      block {
+        number
+        hash
+        timestamp
+      }
+      hasIndexingErrors
+    }
+    pools(
+      first: $first
+      where: { id_in: $poolIds }
+      orderBy: id
+      orderDirection: asc
+      block: { number: $blockNumber }
+    ) {
+      id
+      token0 { id decimals }
+      token1 { id decimals }
+      hooks
+      feeTier
+      tickSpacing
+      liquidity
+      sqrtPrice
+      tick
+      txCount
+      volumeUSD
+      totalValueLockedToken0
+      totalValueLockedToken1
+      totalValueLockedUSD
+    }
+  }
+`;
+
+const POOL_SNAPSHOT_QUERY = `
+  query ProgrammableExplorePoolSnapshot {
+    _meta {
+      deployment
+      block {
+        number
+        hash
+        timestamp
+      }
+      hasIndexingErrors
+    }
+  }
+`;
+
+const POOL_SNAPSHOT_AT_BLOCK_QUERY = `
+  query ProgrammableExplorePoolSnapshotAtBlock($blockNumber: Int!) {
+    _meta(block: { number: $blockNumber }) {
+      deployment
+      block {
+        number
+        hash
+        timestamp
+      }
+      hasIndexingErrors
+    }
+  }
+`;
+
 type Fetcher = (input: string, init?: RequestInit) => Promise<Response>;
 
 type ParsedPool = {
@@ -150,6 +218,14 @@ export type OfficialV4LiquidityReferenceHeadV1 = Readonly<{
   chainId: 1;
   blockNumber: string;
   blockHash: `0x${string}`;
+}>;
+
+export type OfficialV4LiquiditySnapshotV1 =
+  OfficialV4LiquidityReferenceHeadV1;
+
+export type OfficialV4LiquidityEvidenceSnapshotReadV1 = Readonly<{
+  evidence: readonly OfficialV4LiquidityEvidenceV1[];
+  snapshot: OfficialV4LiquiditySnapshotV1;
 }>;
 
 export class OfficialV4LiquidityEvidenceReadError extends Error {
@@ -440,6 +516,20 @@ export function parseOfficialV4SubgraphResponse(
   };
 }
 
+function parseOfficialV4SubgraphSnapshotResponse(value: unknown) {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, ["data"]) ||
+    !isRecord(value.data) ||
+    !hasOnlyKeys(value.data, ["_meta"])
+  ) {
+    return invalidResponse();
+  }
+  return parseOfficialV4SubgraphResponse({
+    data: { _meta: value.data._meta, pools: [] },
+  });
+}
+
 function validEndpoint(value: string) {
   try {
     const url = new URL(value);
@@ -530,6 +620,9 @@ async function fetchPoolAnalytics(input: {
   endpoint: string;
   apiKey: string;
   poolIds: string[];
+  referenceSnapshot?: OfficialV4LiquidityReferenceHeadV1;
+  cacheNamespace?: "display" | "liquidity";
+  metaOnly?: boolean;
   timeoutMs: number;
   fetcher: Fetcher;
   signal?: AbortSignal;
@@ -550,13 +643,27 @@ async function fetchPoolAnalytics(input: {
         authorization: `Bearer ${input.apiKey}`,
         "content-type": "application/json",
       },
-      body: JSON.stringify({
-        query: POOL_ANALYTICS_QUERY,
-        variables: {
-          poolIds: input.poolIds,
-          first: OFFICIAL_V4_SUBGRAPH_MAXIMUM_POOL_IDS,
-        },
-      }),
+      body: JSON.stringify(input.metaOnly
+        ? {
+            query: input.referenceSnapshot
+              ? POOL_SNAPSHOT_AT_BLOCK_QUERY
+              : POOL_SNAPSHOT_QUERY,
+            variables: input.referenceSnapshot
+              ? { blockNumber: Number(input.referenceSnapshot.blockNumber) }
+              : {},
+          }
+        : {
+            query: input.referenceSnapshot
+              ? POOL_ANALYTICS_AT_BLOCK_QUERY
+              : POOL_ANALYTICS_QUERY,
+            variables: {
+              poolIds: input.poolIds,
+              first: OFFICIAL_V4_SUBGRAPH_MAXIMUM_POOL_IDS,
+              ...(input.referenceSnapshot
+                ? { blockNumber: Number(input.referenceSnapshot.blockNumber) }
+                : {}),
+            },
+          }),
       cache: "no-store",
       signal: controller.signal,
     });
@@ -564,7 +671,10 @@ async function fetchPoolAnalytics(input: {
       throw new Error("Uniswap v4 subgraph request failed");
     }
     const body = await readBoundedResponseBody(response);
-    return parseOfficialV4SubgraphResponse(JSON.parse(body));
+    const parsed: unknown = JSON.parse(body);
+    return input.metaOnly
+      ? parseOfficialV4SubgraphSnapshotResponse(parsed)
+      : parseOfficialV4SubgraphResponse(parsed);
   } finally {
     clearTimeout(timeout);
     input.signal?.removeEventListener("abort", abortFromCaller);
@@ -584,8 +694,15 @@ function stateFor(fetcher: Fetcher) {
   return created;
 }
 
-function cacheKey(poolIds: readonly string[]) {
-  return [...poolIds].sort().join(",");
+function cacheKey(
+  poolIds: readonly string[],
+  referenceSnapshot?: OfficialV4LiquidityReferenceHeadV1,
+  cacheNamespace: "display" | "liquidity" = "display",
+) {
+  const pools = [...poolIds].sort().join(",");
+  return referenceSnapshot
+    ? `snapshot:${referenceSnapshot.blockNumber}:${referenceSnapshot.blockHash}:${pools}`
+    : `${cacheNamespace}:latest:${pools}`;
 }
 
 function pruneCache(state: FetcherState, now: number) {
@@ -603,6 +720,9 @@ async function fetchPoolAnalyticsCached(input: {
   endpoint: string;
   apiKey: string;
   poolIds: string[];
+  referenceSnapshot?: OfficialV4LiquidityReferenceHeadV1;
+  cacheNamespace?: "display" | "liquidity";
+  metaOnly?: boolean;
   timeoutMs: number;
   fetcher: Fetcher;
   signal?: AbortSignal;
@@ -610,7 +730,11 @@ async function fetchPoolAnalyticsCached(input: {
   input.signal?.throwIfAborted();
   const state = stateFor(input.fetcher);
   const now = Date.now();
-  const key = cacheKey(input.poolIds);
+  const key = cacheKey(
+    input.poolIds,
+    input.referenceSnapshot,
+    input.cacheNamespace,
+  );
   const cached = state.cache.get(key);
   if (cached && cached.expiresAt > now) return cached.response;
   if (cached) state.cache.delete(key);
@@ -742,6 +866,7 @@ function canonicalReferenceHead(
     typeof value.blockNumber !== "string" ||
     !/^(0|[1-9]\d*)$/.test(value.blockNumber) ||
     value.blockNumber.length > 78 ||
+    BigInt(value.blockNumber) > 2_147_483_647n ||
     typeof value.blockHash !== "string" ||
     !/^0x[0-9a-fA-F]{64}$/.test(value.blockHash)
   ) {
@@ -778,12 +903,38 @@ function referenceHeadLag(
   const lag = reference - indexed;
   if (
     lag > MAXIMUM_SUBGRAPH_LAG_BLOCKS ||
-    (lag === 0n &&
-      response.indexedBlockHash !== referenceHead.blockHash.toLowerCase())
+    (lag === 0n && response.indexedBlockHash !== referenceHead.blockHash)
   ) {
     return undefined;
   }
   return lag.toString();
+}
+
+function responseIsAheadOfReferenceHead(
+  response: ParsedResponse,
+  referenceHead: OfficialV4LiquidityReferenceHeadV1,
+) {
+  return BigInt(response.indexedBlockNumber) >
+    BigInt(referenceHead.blockNumber);
+}
+
+function responseMatchesLiquiditySnapshot(
+  response: ParsedResponse,
+  snapshot: OfficialV4LiquiditySnapshotV1,
+) {
+  return response.indexedBlockNumber === snapshot.blockNumber &&
+    response.indexedBlockHash === snapshot.blockHash;
+}
+
+function responseCoversExactly(
+  response: ParsedResponse,
+  requestedPoolIds: readonly string[],
+) {
+  const requested = new Set<string>(requestedPoolIds);
+  const returned = new Set<string>(response.pools.map((pool) => pool.id));
+  return returned.size === requested.size &&
+    [...requested].every((poolId) => returned.has(poolId)) &&
+    [...returned].every((poolId) => requested.has(poolId));
 }
 
 function isCurrentIndexedTime(response: ParsedResponse, now: Date) {
@@ -861,32 +1012,53 @@ function liquidityEvidence(
 /**
  * Reads independently attributable official Uniswap v4 subgraph pool TVL.
  *
- * Evidence is returned only for a canonical PoolKey, a fresh indexed block at
- * or behind the supplied reference head, and at least the public pool-TVL
- * eligibility floor. This aggregate TVL does not prove current-tick USD depth
- * or manipulation resistance. StateView's active-liquidity scalar is
- * deliberately not interpreted as reserves or TVL, and a missing or rejected
- * entry must stay unavailable.
+ * The first read selects one fresh Graph snapshot at or behind the supplied
+ * RPC reference head. Every later batch is pinned to that exact Graph block
+ * number, and its returned hash must match. A caller can supply the selected
+ * snapshot again to replay a continuation without mixing Graph states.
+ * Evidence is returned only for a canonical PoolKey and at least the public
+ * pool-TVL eligibility floor. This aggregate TVL does not prove current-tick
+ * USD depth or manipulation resistance. StateView's active-liquidity scalar
+ * is deliberately not interpreted as reserves or TVL, and a missing or
+ * rejected entry must stay unavailable.
  * An empty result means every eligible requested pool was covered but none
  * qualified. Invalid configuration or any failed batch rejects the whole read
  * so global ordering can never mistake partial coverage for complete coverage.
  */
-export async function readOfficialV4LiquidityEvidence(
+export async function readOfficialV4LiquidityEvidenceSnapshot(
   input: {
     tokens: readonly LauncherToken[];
     referenceHead: OfficialV4LiquidityReferenceHeadV1;
+    liquiditySnapshot?: OfficialV4LiquiditySnapshotV1;
     now?: Date;
   },
   options: OfficialV4SubgraphOptions = {},
-): Promise<readonly OfficialV4LiquidityEvidenceV1[]> {
+): Promise<OfficialV4LiquidityEvidenceSnapshotReadV1> {
   options.signal?.throwIfAborted();
   const eligibleTokens = input.tokens.filter(supportsOfficialPoolTvlEvidence);
-  if (eligibleTokens.length === 0) return [];
-
   const referenceHead = canonicalReferenceHead(input.referenceHead);
+  const requestedSnapshot = input.liquiditySnapshot === undefined
+    ? undefined
+    : canonicalReferenceHead(input.liquiditySnapshot);
   const now = input.now ?? new Date();
-  if (!referenceHead || !Number.isFinite(now.getTime())) {
+  if (
+    !referenceHead ||
+    (input.liquiditySnapshot !== undefined && !requestedSnapshot) ||
+    !Number.isFinite(now.getTime())
+  ) {
     throw new OfficialV4LiquidityEvidenceReadError("invalid-input");
+  }
+  if (requestedSnapshot) {
+    const requestedBlock = BigInt(requestedSnapshot.blockNumber);
+    const referenceBlock = BigInt(referenceHead.blockNumber);
+    if (
+      requestedBlock > referenceBlock ||
+      referenceBlock - requestedBlock > MAXIMUM_SUBGRAPH_LAG_BLOCKS ||
+      (requestedBlock === referenceBlock &&
+        requestedSnapshot.blockHash !== referenceHead.blockHash)
+    ) {
+      throw new OfficialV4LiquidityEvidenceReadError("invalid-input");
+    }
   }
 
   const apiKey =
@@ -898,17 +1070,83 @@ export async function readOfficialV4LiquidityEvidence(
   if (!validApiKey(apiKey) || !validEndpoint(endpoint)) {
     throw new OfficialV4LiquidityEvidenceReadError("invalid-config");
   }
+  const fetcher = options.fetcher ?? fetch;
+
+  if (eligibleTokens.length === 0) {
+    let response: ParsedResponse;
+    try {
+      response = await fetchPoolAnalyticsCached({
+        endpoint,
+        apiKey,
+        poolIds: [],
+        referenceSnapshot: requestedSnapshot,
+        cacheNamespace: "liquidity",
+        metaOnly: true,
+        timeoutMs: boundedTimeout(options.timeoutMs),
+        fetcher,
+        signal: options.signal,
+      });
+    } catch {
+      options.signal?.throwIfAborted();
+      throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
+    }
+    if (
+      requestedSnapshot === undefined &&
+      responseIsAheadOfReferenceHead(response, referenceHead)
+    ) {
+      try {
+        response = await fetchPoolAnalyticsCached({
+          endpoint,
+          apiKey,
+          poolIds: [],
+          referenceSnapshot: referenceHead,
+          cacheNamespace: "liquidity",
+          metaOnly: true,
+          timeoutMs: boundedTimeout(options.timeoutMs),
+          fetcher,
+          signal: options.signal,
+        });
+      } catch {
+        options.signal?.throwIfAborted();
+        throw new OfficialV4LiquidityEvidenceReadError(
+          "coverage-incomplete",
+        );
+      }
+      if (!responseMatchesLiquiditySnapshot(response, referenceHead)) {
+        throw new OfficialV4LiquidityEvidenceReadError(
+          "coverage-incomplete",
+        );
+      }
+    }
+    if (
+      referenceHeadLag(response, referenceHead) === undefined ||
+      (requestedSnapshot !== undefined &&
+        !responseMatchesLiquiditySnapshot(response, requestedSnapshot)) ||
+      !isCurrentIndexedTime(response, now)
+    ) {
+      throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
+    }
+    return {
+      evidence: [],
+      snapshot: {
+        chainId: 1,
+        blockNumber: response.indexedBlockNumber,
+        blockHash: response.indexedBlockHash,
+      },
+    };
+  }
 
   const poolIds = canonicalPoolIds(
     eligibleTokens,
     OFFICIAL_V4_LIQUIDITY_MAXIMUM_POOL_IDS_PER_READ + 1,
   );
-  if (poolIds.length === 0) return [];
+  if (poolIds.length === 0) {
+    throw new OfficialV4LiquidityEvidenceReadError("invalid-input");
+  }
   if (poolIds.length > OFFICIAL_V4_LIQUIDITY_MAXIMUM_POOL_IDS_PER_READ) {
     throw new OfficialV4LiquidityEvidenceReadError("invalid-input");
   }
 
-  const fetcher = options.fetcher ?? fetch;
   const requests: string[][] = [];
   for (
     let index = 0;
@@ -921,8 +1159,67 @@ export async function readOfficialV4LiquidityEvidence(
   }
 
   const responses: ParsedResponse[] = [];
+  let liquiditySnapshot = requestedSnapshot;
+  let requestIndex = 0;
+  if (!liquiditySnapshot) {
+    const requestedPoolIds = requests[0]!;
+    let response: ParsedResponse;
+    try {
+      response = await fetchPoolAnalyticsCached({
+        endpoint,
+        apiKey,
+        poolIds: requestedPoolIds,
+        cacheNamespace: "liquidity",
+        timeoutMs: boundedTimeout(options.timeoutMs),
+        fetcher,
+        signal: options.signal,
+      });
+    } catch {
+      options.signal?.throwIfAborted();
+      throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
+    }
+    if (responseIsAheadOfReferenceHead(response, referenceHead)) {
+      try {
+        response = await fetchPoolAnalyticsCached({
+          endpoint,
+          apiKey,
+          poolIds: requestedPoolIds,
+          referenceSnapshot: referenceHead,
+          cacheNamespace: "liquidity",
+          timeoutMs: boundedTimeout(options.timeoutMs),
+          fetcher,
+          signal: options.signal,
+        });
+      } catch {
+        options.signal?.throwIfAborted();
+        throw new OfficialV4LiquidityEvidenceReadError(
+          "coverage-incomplete",
+        );
+      }
+      if (!responseMatchesLiquiditySnapshot(response, referenceHead)) {
+        throw new OfficialV4LiquidityEvidenceReadError(
+          "coverage-incomplete",
+        );
+      }
+    }
+    if (
+      referenceHeadLag(response, referenceHead) === undefined ||
+      !responseCoversExactly(response, requestedPoolIds) ||
+      !isCurrentIndexedTime(response, now)
+    ) {
+      throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
+    }
+    liquiditySnapshot = {
+      chainId: 1,
+      blockNumber: response.indexedBlockNumber,
+      blockHash: response.indexedBlockHash,
+    };
+    responses.push(response);
+    requestIndex = 1;
+  }
+
   for (
-    let index = 0;
+    let index = requestIndex;
     index < requests.length;
     index += MAXIMUM_IN_FLIGHT_REQUESTS
   ) {
@@ -939,6 +1236,8 @@ export async function readOfficialV4LiquidityEvidence(
               endpoint,
               apiKey,
               poolIds: requestedPoolIds,
+              referenceSnapshot: liquiditySnapshot,
+              cacheNamespace: "liquidity",
               timeoutMs: boundedTimeout(options.timeoutMs),
               fetcher,
               signal: options.signal,
@@ -950,15 +1249,7 @@ export async function readOfficialV4LiquidityEvidence(
       throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
     }
     for (const result of completed) {
-      const requested = new Set<string>(result.requestedPoolIds);
-      const returned = new Set<string>(
-        result.response.pools.map((pool) => pool.id),
-      );
-      if (
-        returned.size !== requested.size ||
-        [...requested].some((poolId) => !returned.has(poolId)) ||
-        [...returned].some((poolId) => !requested.has(poolId))
-      ) {
+      if (!responseCoversExactly(result.response, result.requestedPoolIds)) {
         throw new OfficialV4LiquidityEvidenceReadError(
           "coverage-incomplete",
         );
@@ -967,13 +1258,21 @@ export async function readOfficialV4LiquidityEvidence(
     }
   }
 
+  if (!liquiditySnapshot) {
+    throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
+  }
+
   const responseByPoolId = new Map<
     string,
     { pool: ParsedPool; response: ParsedResponse; lagBlocks: string }
   >();
   for (const response of responses) {
     const lagBlocks = referenceHeadLag(response, referenceHead);
-    if (lagBlocks === undefined || !isCurrentIndexedTime(response, now)) {
+    if (
+      lagBlocks === undefined ||
+      !responseMatchesLiquiditySnapshot(response, liquiditySnapshot) ||
+      !isCurrentIndexedTime(response, now)
+    ) {
       throw new OfficialV4LiquidityEvidenceReadError("coverage-incomplete");
     }
     for (const pool of response.pools) {
@@ -999,7 +1298,22 @@ export async function readOfficialV4LiquidityEvidence(
     );
     if (item) evidence.push(item);
   }
-  return evidence;
+  return { evidence, snapshot: liquiditySnapshot };
+}
+
+export async function readOfficialV4LiquidityEvidence(
+  input: {
+    tokens: readonly LauncherToken[];
+    referenceHead: OfficialV4LiquidityReferenceHeadV1;
+    now?: Date;
+  },
+  options: OfficialV4SubgraphOptions = {},
+): Promise<readonly OfficialV4LiquidityEvidenceV1[]> {
+  if (input.tokens.filter(supportsOfficialPoolTvlEvidence).length === 0) {
+    return [];
+  }
+  return (await readOfficialV4LiquidityEvidenceSnapshot(input, options))
+    .evidence;
 }
 
 function indexedMarketCap(

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "perf:read-model:real-block-sla-operator": "node scripts/perf/read-model-real-block-sla-operator.mjs",
     "perf:read-model:real-block-sla": "node scripts/perf/read-model-real-block-sla-gate.mjs",
     "perf:read-model:staged-deployment": "node scripts/perf/read-model-staged-deployment.mjs",
+    "perf:read-model:staged-health": "node scripts/perf/read-model-staged-health.mjs",
     "perf:read-model:ops-gate": "node scripts/perf/read-model-ops-source-contracts.mjs",
     "perf:read-model:production-binding": "node scripts/perf/read-model-production-binding.mjs",
     "perf:read-model:post-promotion": "node scripts/perf/read-model-post-promotion.mjs"

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -271,7 +271,10 @@ export function evaluateAlchemyExploreSourceContracts(
       canonicalSupplySource.includes("observation.decimals") &&
       canonicalSupplySource.includes("observation.totalSupplyRaw") &&
       canonicalSupplySource.includes("group.length >= 2") &&
-      canonicalSupplySource.includes("if (!agreed) return entry;") &&
+      canonicalSupplySource.includes("!agreed ||") &&
+      canonicalSupplySource.includes(
+        "agreed.blockHash.toLowerCase() !== requestedSnapshot.blockHash",
+      ) &&
       routeSources
         .filter(({ id }) => ["explore", "token-detail"].includes(id))
         .every(({ id, source }) => {
@@ -280,7 +283,7 @@ export function evaluateAlchemyExploreSourceContracts(
               "const hydratedEntries = await hydrateMissingCanonicalTokenSupplyV1(",
             );
             const globalValuation = source.indexOf(
-              "const currentEntries = await valueExploreEntriesWithCurrentEvidence({",
+              "const currentValuation = await valueExploreEntriesWithCurrentEvidenceSnapshot({",
               globalHydration,
             );
             const globalMarketRead = source.indexOf(
@@ -301,8 +304,20 @@ export function evaluateAlchemyExploreSourceContracts(
             );
             return globalHydration >= 0 &&
               globalValuation > globalHydration &&
+              source.slice(globalHydration, globalValuation).includes(
+                "deployment: input.deployment ?? undefined",
+              ) &&
+              source.slice(globalHydration, globalValuation).includes(
+                "blockNumber: operationalSnapshot.blockNumber",
+              ) &&
+              source.slice(globalHydration, globalValuation).includes(
+                "blockHash: operationalSnapshot.blockHash",
+              ) &&
               source.slice(globalValuation, globalMarketRead).includes(
                 "marketByToken: new Map()",
+              ) &&
+              source.slice(globalValuation, globalMarketRead).includes(
+                "operationalSnapshot,",
               ) &&
               globalMarketRead > globalValuation &&
               pageMarketRead > globalMarketRead &&

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -734,6 +734,23 @@ export const STAGED_MARKET_EVIDENCE_SOURCE_GUARDS = Object.freeze([
   "observedTrades !== currentChart.swapCount",
 ]);
 
+export const STAGED_HEALTH_HANDOFF_SOURCE_GUARDS = Object.freeze([
+  'const HEALTH_PATH = "/api/ops/health";',
+  '!target.hostname.endsWith(".vercel.app")',
+  "fetchVercelDeployment({",
+  "idOrUrl: target.hostname",
+  "deployment.id === input.expectedDeploymentId",
+  "deploymentHost === target.hostname",
+  "deployment.projectId === input.projectId ||",
+  'deployment.readyState === "READY"',
+  "deploymentCommit(deployment) === input.expectedGitHead",
+  '"x-vercel-protection-bypass": automationBypassSecret',
+  'redirect: "error"',
+  'response.ok && response.body?.status === "healthy"',
+]);
+const STAGED_HEALTH_HANDOFF_SCRIPT_SHA256 =
+  "b94c538699c23ad0099a177b3323a4bc055410d2c3ddd79b6bee44b84f51c0b1";
+
 function expectedDigest(path, approved, overrides) {
   return overrides?.[path] ?? approved;
 }
@@ -1521,6 +1538,9 @@ export function evaluateReadModelOperationsSourceContracts(
   const realBlockSlaOperator = source(
     "scripts/perf/read-model-real-block-sla-operator.mjs",
   ) ?? "";
+  const stagedHealth = source(
+    "scripts/perf/read-model-staged-health.mjs",
+  ) ?? "";
   const postPromotion = source("scripts/perf/read-model-post-promotion.mjs") ?? "";
   const postCurrentEvidenceStart = postPromotion.indexOf(
     "function exactCanonicalClassicNativeToken",
@@ -2146,6 +2166,58 @@ export function evaluateReadModelOperationsSourceContracts(
         "NEXT_PUBLIC_VERCEL_AUTOMATION_BYPASS_SECRET",
       ),
     "the indexed staged capture receives the protected deployment bypass only inside its exact step",
+  );
+  const stagedBindingReverification = deployWorkflow.indexOf(
+    "Reverify staged candidate binding",
+  );
+  const stagedHealthGate = deployWorkflow.indexOf(
+    "Gate exact staged operational health",
+  );
+  const stagedCandidateHandoff = deployWorkflow.indexOf(
+    "Record staged candidate handoff",
+  );
+  const stagedHealthGateBlock =
+    stagedHealthGate >= 0 && stagedCandidateHandoff > stagedHealthGate
+      ? deployWorkflow.slice(stagedHealthGate, stagedCandidateHandoff)
+      : "";
+  check(
+    "ops-staged-health-handoff-gate",
+    packageJson?.scripts?.["perf:read-model:staged-health"] ===
+      "node scripts/perf/read-model-staged-health.mjs" &&
+      sha256(stagedHealth) === STAGED_HEALTH_HANDOFF_SCRIPT_SHA256 &&
+      includesEverySourceFragment(
+        stagedHealth,
+        STAGED_HEALTH_HANDOFF_SOURCE_GUARDS,
+      ) &&
+      stagedBindingReverification >= 0 &&
+      stagedHealthGate > stagedBindingReverification &&
+      stagedCandidateHandoff > stagedHealthGate &&
+      stagedHealthGateBlock.includes(
+        "VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}",
+      ) &&
+      stagedHealthGateBlock.includes(
+        "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
+      ) &&
+      stagedHealthGateBlock.includes(
+        "STAGED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}",
+      ) &&
+      stagedHealthGateBlock.includes(
+        "STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
+      ) &&
+      stagedHealthGateBlock.includes("EXPECTED_GIT_HEAD: ${{ github.sha }}") &&
+      stagedHealthGateBlock.includes(
+        "npm run perf:read-model:staged-health --",
+      ) &&
+      stagedHealthGateBlock.includes('--target-url "$STAGED_TARGET_URL"') &&
+      stagedHealthGateBlock.includes(
+        '--deployment-id "$STAGED_DEPLOYMENT_ID"',
+      ) &&
+      stagedHealthGateBlock.includes('--git-head "$EXPECTED_GIT_HEAD"') &&
+      !stagedHealthGateBlock.includes("\n        if:") &&
+      !stagedHealthGateBlock.includes(
+        "NEXT_PUBLIC_VERCEL_AUTOMATION_BYPASS_SECRET",
+      ),
+    "the exact staged deployment must report healthy immediately before its stage-only handoff",
   );
   const exactVerifyProofGateStart = deployWorkflow.indexOf("  release-gate:");
   const exactVerifyProofGateEnd = deployWorkflow.indexOf("  deploy:");

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -750,6 +750,42 @@ export const STAGED_HEALTH_HANDOFF_SOURCE_GUARDS = Object.freeze([
 ]);
 const STAGED_HEALTH_HANDOFF_SCRIPT_SHA256 =
   "b94c538699c23ad0099a177b3323a4bc055410d2c3ddd79b6bee44b84f51c0b1";
+const STAGED_HEALTH_HANDOFF_WORKFLOW_STEP = [
+  "      - name: Gate exact staged operational health",
+  "        env:",
+  "          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}",
+  "          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
+  "          STAGED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}",
+  "          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
+  "          EXPECTED_GIT_HEAD: ${{ github.sha }}",
+  "        run: >-",
+  "          npm run perf:read-model:staged-health --",
+  '          --target-url "$STAGED_TARGET_URL"',
+  '          --deployment-id "$STAGED_DEPLOYMENT_ID"',
+  '          --git-head "$EXPECTED_GIT_HEAD"',
+].join("\n");
+const POST_PROMOTION_PRODUCTION_ORIGIN_GUARD = [
+  "  if (target.origin !== PRODUCTION_ORIGIN) {",
+  "    throw new Error(",
+  '      "post-promotion target must be the programmable.market production origin",',
+  "    );",
+  "  }",
+].join("\n");
+const POST_PROMOTION_TARGET_GUARD_PREFIX = [
+  "export async function verifyPostPromotion(input) {",
+  "  const target = new URL(input.targetUrl);",
+  "  if (",
+  '    target.protocol !== "https:" ||',
+  '    target.username !== "" ||',
+  '    target.password !== "" ||',
+  '    target.pathname !== "/" ||',
+  '    target.search !== "" ||',
+  '    target.hash !== ""',
+  "  ) {",
+  '    throw new Error("post-promotion target must be an HTTPS origin");',
+  "  }",
+  POST_PROMOTION_PRODUCTION_ORIGIN_GUARD,
+].join("\n");
 
 function expectedDigest(path, approved, overrides) {
   return overrides?.[path] ?? approved;
@@ -1542,6 +1578,25 @@ export function evaluateReadModelOperationsSourceContracts(
     "scripts/perf/read-model-staged-health.mjs",
   ) ?? "";
   const postPromotion = source("scripts/perf/read-model-post-promotion.mjs") ?? "";
+  const postPromotionVerifierStart = postPromotion.indexOf(
+    "export async function verifyPostPromotion(input) {",
+  );
+  const postPromotionOriginGuardStart = postPromotion.indexOf(
+    POST_PROMOTION_PRODUCTION_ORIGIN_GUARD,
+    postPromotionVerifierStart,
+  );
+  const postPromotionBindingGuardStart = postPromotion.indexOf(
+    "  if (\n    !/^dpl_",
+    postPromotionOriginGuardStart + POST_PROMOTION_PRODUCTION_ORIGIN_GUARD.length,
+  );
+  const postPromotionOriginGuardBlock =
+    postPromotionVerifierStart >= 0 &&
+      postPromotionOriginGuardStart > postPromotionVerifierStart &&
+      postPromotionBindingGuardStart > postPromotionOriginGuardStart
+      ? postPromotion
+        .slice(postPromotionOriginGuardStart, postPromotionBindingGuardStart)
+        .trimEnd()
+      : "";
   const postCurrentEvidenceStart = postPromotion.indexOf(
     "function exactCanonicalClassicNativeToken",
   );
@@ -2171,14 +2226,14 @@ export function evaluateReadModelOperationsSourceContracts(
     "Reverify staged candidate binding",
   );
   const stagedHealthGate = deployWorkflow.indexOf(
-    "Gate exact staged operational health",
+    "      - name: Gate exact staged operational health",
   );
   const stagedCandidateHandoff = deployWorkflow.indexOf(
-    "Record staged candidate handoff",
+    "      - name: Record staged candidate handoff",
   );
   const stagedHealthGateBlock =
     stagedHealthGate >= 0 && stagedCandidateHandoff > stagedHealthGate
-      ? deployWorkflow.slice(stagedHealthGate, stagedCandidateHandoff)
+      ? deployWorkflow.slice(stagedHealthGate, stagedCandidateHandoff).trimEnd()
       : "";
   check(
     "ops-staged-health-handoff-gate",
@@ -2192,6 +2247,7 @@ export function evaluateReadModelOperationsSourceContracts(
       stagedBindingReverification >= 0 &&
       stagedHealthGate > stagedBindingReverification &&
       stagedCandidateHandoff > stagedHealthGate &&
+      stagedHealthGateBlock === STAGED_HEALTH_HANDOFF_WORKFLOW_STEP &&
       stagedHealthGateBlock.includes(
         "VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}",
       ) &&
@@ -2432,7 +2488,11 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes(
         'const PRODUCTION_ORIGIN = "https://programmable.market";',
       ) &&
-      postPromotion.includes("target.origin !== PRODUCTION_ORIGIN") &&
+      postPromotion.startsWith(
+        POST_PROMOTION_TARGET_GUARD_PREFIX,
+        postPromotionVerifierStart,
+      ) &&
+      postPromotionOriginGuardBlock === POST_PROMOTION_PRODUCTION_ORIGIN_GUARD &&
       postPromotion.includes('response.headers.get("x-programmable-market-source")') &&
       postPromotion.includes('response.headers.get("x-programmable-price-source")') &&
       postPromotion.includes('response.headers.get("x-programmable-market-as-of")') &&

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -805,12 +805,14 @@ export const STAGED_HEALTH_HANDOFF_SOURCE_GUARDS = Object.freeze([
   "deployment.projectId === input.projectId ||",
   'deployment.readyState === "READY"',
   "deploymentCommit(deployment) === input.expectedGitHead",
+  "if (deploymentFailures.length > 0) {",
+  "const response = await requestHealth(",
   '"x-vercel-protection-bypass": automationBypassSecret',
   'redirect: "error"',
   'response.ok && response.body?.status === "healthy"',
 ]);
 const STAGED_HEALTH_HANDOFF_SCRIPT_SHA256 =
-  "b94c538699c23ad0099a177b3323a4bc055410d2c3ddd79b6bee44b84f51c0b1";
+  "853e49a15d1d056f538a7451c5fc67829056c6e48bebd4a6aa791242a61b9d73";
 const STAGED_HEALTH_HANDOFF_WORKFLOW_STEP = [
   "      - name: Gate exact staged operational health",
   "        env:",
@@ -2296,6 +2298,15 @@ export function evaluateReadModelOperationsSourceContracts(
     stagedHealthGate >= 0 && stagedCandidateHandoff > stagedHealthGate
       ? deployWorkflow.slice(stagedHealthGate, stagedCandidateHandoff).trimEnd()
       : "";
+  const stagedHealthDeploymentLookup = stagedHealth.indexOf(
+    "const deployment = await fetchVercelDeployment(",
+  );
+  const stagedHealthIdentityFailureGuard = stagedHealth.indexOf(
+    "if (deploymentFailures.length > 0) {",
+  );
+  const stagedHealthProtectedRequest = stagedHealth.indexOf(
+    "const response = await requestHealth(",
+  );
   check(
     "ops-staged-health-handoff-gate",
     packageJson?.scripts?.["perf:read-model:staged-health"] ===
@@ -2305,6 +2316,9 @@ export function evaluateReadModelOperationsSourceContracts(
         stagedHealth,
         STAGED_HEALTH_HANDOFF_SOURCE_GUARDS,
       ) &&
+      stagedHealthDeploymentLookup >= 0 &&
+      stagedHealthIdentityFailureGuard > stagedHealthDeploymentLookup &&
+      stagedHealthProtectedRequest > stagedHealthIdentityFailureGuard &&
       stagedBindingReverification >= 0 &&
       stagedHealthGate > stagedBindingReverification &&
       stagedCandidateHandoff > stagedHealthGate &&

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -495,13 +495,35 @@ export const POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS = Object.freeze([
 ]);
 
 export const POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS = Object.freeze([
+  "exactExploreValuationSnapshot(",
+  'value.schemaVersion !== "programmable.explore-valuation-snapshot.v1"',
+  "Object.keys(value).length !== 11",
+  "value.chainId !== 1",
+  "!positiveInteger(value.blockNumber)",
+  "!exactBytes32(value.blockHash)",
+  "value.blockHash !== value.blockHash.toLowerCase()",
+  'value?.liquidityBlockNumber === "none"',
+  'value?.liquidityBlockHash === "none"',
+  "positiveInteger(value?.liquidityBlockNumber)",
+  "exactBytes32(value?.liquidityBlockHash)",
+  "value.liquidityBlockHash === value.liquidityBlockHash.toLowerCase()",
+  "(!noLiquiditySnapshot &&",
+  "!concreteLiquiditySnapshot ||",
+  "BigInt(value.liquidityBlockNumber) > BigInt(value.blockNumber)",
+  "!/^sha256:[0-9a-f]{64}$/u.test(value.rankingCommitment)",
+  'value.sort !== "market-cap"',
+  'value.query !== ""',
+  "value.socials !== null",
+  "value.pageSize !== EXPLORE_PAGE_SIZE",
+  "!sameValuationSnapshot(valuationSnapshot, pageSnapshot)",
   "total > MAXIMUM_EXPLORE_TOKENS",
   "totalPages !== Math.ceil(total / EXPLORE_PAGE_SIZE)",
   "responses.length !== totalPages",
   'page?.status !== "ready"',
-  'page?.sort !== "market-cap"',
+  "page?.sort !== valuationSnapshot.sort",
+  "page?.query !== valuationSnapshot.query",
   "page?.page !== index + 1",
-  "page?.pageSize !== EXPLORE_PAGE_SIZE",
+  "page?.pageSize !== valuationSnapshot.pageSize",
   "page?.total !== total",
   "page?.totalPages !== totalPages",
   "pageTokens.length !== expectedLength",
@@ -515,6 +537,15 @@ export const POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS = Object.freeze([
   "!exactCurrentPublicMarketHeaders(response)",
   "!currentMarketEvidenceTime(quality.asOfTime)",
   "token.valuation.asOfBlock !== quality.asOfBlock",
+  "token.valuation.asOfBlock !== valuationSnapshot.blockNumber",
+  "token.valuation.asOfBlockHash,",
+  "valuationSnapshot.blockHash,",
+  "token.liquidityEvidence?.provenance?.referenceHeadBlockNumber !==",
+  "token.liquidityEvidence?.provenance?.referenceHeadBlockHash,",
+  "token.liquidityEvidence?.provenance?.indexedBlockNumber !==",
+  "valuationSnapshot.liquidityBlockNumber",
+  "token.liquidityEvidence?.provenance?.indexedBlockHash,",
+  "valuationSnapshot.liquidityBlockHash,",
   'response.headers.marketSource !== "bitquery"',
   "response.headers.valuationBlock !== null",
   "ids.has(token.id)",
@@ -529,7 +560,37 @@ export const POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS = Object.freeze([
   "sawNonCurrent",
   "!exactCurrentPublicFdvLiquidity(token)",
   "value > previousCurrentFdv",
-  "return currentCount > 0 ? { currentToken, tokens } : null;",
+  "return currentCount > 0 ? { currentToken, tokens, valuationSnapshot } : null;",
+  "left.schemaVersion === right.schemaVersion",
+  "left.chainId === right.chainId",
+  "left.blockNumber === right.blockNumber",
+  "left.blockHash === right.blockHash",
+  "left.liquidityBlockNumber === right.liquidityBlockNumber",
+  "left.liquidityBlockHash === right.liquidityBlockHash",
+  "left.rankingCommitment === right.rankingCommitment",
+  "left.sort === right.sort",
+  "left.query === right.query",
+  "left.socials === right.socials",
+  "left.pageSize === right.pageSize",
+  'search.set("valuationBlock", snapshot.blockNumber)',
+  'search.set("valuationBlockHash", snapshot.blockHash)',
+  'search.set("liquidityBlock", snapshot.liquidityBlockNumber)',
+  'search.set("liquidityBlockHash", snapshot.liquidityBlockHash)',
+  'search.set("rankingCommitment", snapshot.rankingCommitment)',
+]);
+
+export const POST_PROMOTION_PAGINATION_SOURCE_GUARDS = Object.freeze([
+  "const firstExploreSnapshot = exactExploreValuationSnapshot(",
+  "firstExplore.body?.valuationSnapshot,",
+  "firstExploreSnapshot !== null &&",
+  "firstExploreSnapshot === null",
+  "Array.from({ length: expectedExplorePages - 1 }, (_, index) =>",
+  "exploreContinuationPath(firstExploreSnapshot, index + 2)",
+  'search.set("valuationBlock", snapshot.blockNumber)',
+  'search.set("valuationBlockHash", snapshot.blockHash)',
+  'search.set("liquidityBlock", snapshot.liquidityBlockNumber)',
+  'search.set("liquidityBlockHash", snapshot.liquidityBlockHash)',
+  'search.set("rankingCommitment", snapshot.rankingCommitment)',
 ]);
 
 export const POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS = Object.freeze([
@@ -2387,6 +2448,9 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       postPromotion.includes("exactBitqueryHeaders") &&
       postPromotion.includes("exactExploreRanking") &&
+      postPromotion.includes(
+        "exploreContinuationPath(firstExploreSnapshot, index + 2)",
+      ) &&
       postPromotion.includes("exactCurrentPublicFdvLiquidity") &&
       postPromotion.includes("exactGoldenDetail") &&
       postPromotion.includes("exactGoldenSearch") &&
@@ -2404,6 +2468,10 @@ export function evaluateReadModelOperationsSourceContracts(
         POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS,
       ) &&
       includesEverySourceFragment(
+        postPromotion,
+        POST_PROMOTION_PAGINATION_SOURCE_GUARDS,
+      ) &&
+      includesEverySourceFragment(
         postDetailChartBlock,
         POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS,
       ) &&
@@ -2415,7 +2483,7 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       postPromotion.includes('id: "production-bitquery-canary-hidden"') &&
       postPromotion.includes(
-        "return currentCount > 0 ? { currentToken, tokens } : null;",
+        "return currentCount > 0 ? { currentToken, tokens, valuationSnapshot } : null;",
       ) &&
       postPromotion.includes(
         'tokenAddress === GOLDEN_TOKEN_ADDRESS',

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2357,6 +2357,10 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes(
         'id: "production-bitquery-golden-independent-parity"',
       ) &&
+      postPromotion.includes(
+        'const PRODUCTION_ORIGIN = "https://programmable.market";',
+      ) &&
+      postPromotion.includes("target.origin !== PRODUCTION_ORIGIN") &&
       postPromotion.includes('response.headers.get("x-programmable-market-source")') &&
       postPromotion.includes('response.headers.get("x-programmable-price-source")') &&
       postPromotion.includes('response.headers.get("x-programmable-market-as-of")') &&

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -718,9 +718,13 @@ export async function verifyCurrentPublicOnchainEvidenceV1(input) {
 function exactExploreRanking(responses) {
   if (!Array.isArray(responses) || responses.length === 0) return null;
   const first = responses[0]?.body;
+  const valuationSnapshot = exactExploreValuationSnapshot(
+    first?.valuationSnapshot,
+  );
   const total = first?.total;
   const totalPages = first?.totalPages;
   if (
+    valuationSnapshot === null ||
     !Number.isSafeInteger(total) ||
     total < 1 ||
     total > MAXIMUM_EXPLORE_TOKENS ||
@@ -740,6 +744,9 @@ function exactExploreRanking(responses) {
       EXPLORE_PAGE_SIZE,
       total - index * EXPLORE_PAGE_SIZE,
     );
+    const pageSnapshot = exactExploreValuationSnapshot(
+      page?.valuationSnapshot,
+    );
     const quality = page?.dataQuality?.valuation;
     const currentTokens = Array.isArray(pageTokens)
       ? pageTokens.filter((token) =>
@@ -750,10 +757,12 @@ function exactExploreRanking(responses) {
       : [];
     if (
       !response?.ok ||
+      !sameValuationSnapshot(valuationSnapshot, pageSnapshot) ||
       page?.status !== "ready" ||
-      page?.sort !== "market-cap" ||
+      page?.sort !== valuationSnapshot.sort ||
+      page?.query !== valuationSnapshot.query ||
       page?.page !== index + 1 ||
-      page?.pageSize !== EXPLORE_PAGE_SIZE ||
+      page?.pageSize !== valuationSnapshot.pageSize ||
       page?.total !== total ||
       page?.totalPages !== totalPages ||
       !Array.isArray(pageTokens) ||
@@ -780,7 +789,24 @@ function exactExploreRanking(responses) {
         !positiveInteger(quality.asOfBlock) ||
         currentTokens.some((token) =>
           token.valuation.asOfTime !== quality.asOfTime ||
-          token.valuation.asOfBlock !== quality.asOfBlock
+          token.valuation.asOfBlock !== quality.asOfBlock ||
+          token.valuation.asOfBlock !== valuationSnapshot.blockNumber ||
+          !sameBytes32(
+            token.valuation.asOfBlockHash,
+            valuationSnapshot.blockHash,
+          ) ||
+          token.liquidityEvidence?.provenance?.referenceHeadBlockNumber !==
+            valuationSnapshot.blockNumber ||
+          !sameBytes32(
+            token.liquidityEvidence?.provenance?.referenceHeadBlockHash,
+            valuationSnapshot.blockHash,
+          ) ||
+          token.liquidityEvidence?.provenance?.indexedBlockNumber !==
+            valuationSnapshot.liquidityBlockNumber ||
+          !sameBytes32(
+            token.liquidityEvidence?.provenance?.indexedBlockHash,
+            valuationSnapshot.liquidityBlockHash,
+          )
         )
       ) return null;
     } else if (
@@ -845,7 +871,94 @@ function exactExploreRanking(responses) {
     currentCount += 1;
     currentToken ??= token;
   }
-  return currentCount > 0 ? { currentToken, tokens } : null;
+  return currentCount > 0 ? { currentToken, tokens, valuationSnapshot } : null;
+}
+
+export function exactExploreValuationSnapshot(value) {
+  const noLiquiditySnapshot =
+    value?.liquidityBlockNumber === "none" &&
+    value?.liquidityBlockHash === "none";
+  const concreteLiquiditySnapshot =
+    positiveInteger(value?.liquidityBlockNumber) &&
+    exactBytes32(value?.liquidityBlockHash) &&
+    value.liquidityBlockHash === value.liquidityBlockHash.toLowerCase();
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.keys(value).length !== 11 ||
+    ![
+      "schemaVersion",
+      "chainId",
+      "blockNumber",
+      "blockHash",
+      "liquidityBlockNumber",
+      "liquidityBlockHash",
+      "rankingCommitment",
+      "sort",
+      "query",
+      "socials",
+      "pageSize",
+    ].every((key) => Object.prototype.hasOwnProperty.call(value, key)) ||
+    value.schemaVersion !== "programmable.explore-valuation-snapshot.v1" ||
+    value.chainId !== 1 ||
+    !positiveInteger(value.blockNumber) ||
+    !exactBytes32(value.blockHash) ||
+    value.blockHash !== value.blockHash.toLowerCase() ||
+    (!noLiquiditySnapshot &&
+      (!concreteLiquiditySnapshot ||
+        BigInt(value.liquidityBlockNumber) > BigInt(value.blockNumber))) ||
+    !/^sha256:[0-9a-f]{64}$/u.test(value.rankingCommitment) ||
+    value.sort !== "market-cap" ||
+    value.query !== "" ||
+    value.socials !== null ||
+    value.pageSize !== EXPLORE_PAGE_SIZE
+  ) return null;
+  return Object.freeze({
+    schemaVersion: value.schemaVersion,
+    chainId: value.chainId,
+    blockNumber: value.blockNumber,
+    blockHash: value.blockHash,
+    liquidityBlockNumber: value.liquidityBlockNumber,
+    liquidityBlockHash: value.liquidityBlockHash,
+    rankingCommitment: value.rankingCommitment,
+    sort: value.sort,
+    query: value.query,
+    socials: value.socials,
+    pageSize: value.pageSize,
+  });
+}
+
+function sameValuationSnapshot(left, right) {
+  return left !== null &&
+    right !== null &&
+    left.schemaVersion === right.schemaVersion &&
+    left.chainId === right.chainId &&
+    left.blockNumber === right.blockNumber &&
+    left.blockHash === right.blockHash &&
+    left.liquidityBlockNumber === right.liquidityBlockNumber &&
+    left.liquidityBlockHash === right.liquidityBlockHash &&
+    left.rankingCommitment === right.rankingCommitment &&
+    left.sort === right.sort &&
+    left.query === right.query &&
+    left.socials === right.socials &&
+    left.pageSize === right.pageSize;
+}
+
+export function exploreContinuationPath(snapshot, page) {
+  const search = new URLSearchParams({
+    limit: String(snapshot.pageSize),
+    page: String(page),
+    sort: snapshot.sort,
+  });
+  if (snapshot.query !== "") search.set("q", snapshot.query);
+  if (snapshot.socials !== null) search.set("socials", snapshot.socials);
+  search.set("valuationBlock", snapshot.blockNumber);
+  search.set("valuationBlockHash", snapshot.blockHash);
+  search.set("liquidityBlock", snapshot.liquidityBlockNumber);
+  search.set("liquidityBlockHash", snapshot.liquidityBlockHash);
+  search.set("rankingCommitment", snapshot.rankingCommitment);
+  return `/api/explore?${search.toString()}`;
 }
 
 function exactCurrentPublicDetail(response, exploreToken) {
@@ -1165,21 +1278,27 @@ export async function verifyPostPromotion(input) {
     request(fetchImpl, targetUrl, GOLDEN_CHART_PATH),
   ]);
   const firstExplore = responses[2];
-  const expectedExplorePages = Number.isSafeInteger(firstExplore.body?.totalPages) &&
+  const firstExploreSnapshot = exactExploreValuationSnapshot(
+    firstExplore.body?.valuationSnapshot,
+  );
+  const expectedExplorePages = firstExploreSnapshot !== null &&
+      Number.isSafeInteger(firstExplore.body?.totalPages) &&
       firstExplore.body.totalPages > 0 &&
       firstExplore.body.totalPages <=
         Math.ceil(MAXIMUM_EXPLORE_TOKENS / EXPLORE_PAGE_SIZE)
     ? firstExplore.body.totalPages
     : 1;
-  const remainingExplorePages = await Promise.all(
-    Array.from({ length: expectedExplorePages - 1 }, (_, index) =>
-      request(
-        fetchImpl,
-        targetUrl,
-        `/api/explore?limit=${EXPLORE_PAGE_SIZE}&page=${index + 2}&sort=market-cap`,
-      )
-    ),
-  );
+  const remainingExplorePages = firstExploreSnapshot === null
+    ? []
+    : await Promise.all(
+      Array.from({ length: expectedExplorePages - 1 }, (_, index) =>
+        request(
+          fetchImpl,
+          targetUrl,
+          exploreContinuationPath(firstExploreSnapshot, index + 2),
+        )
+      ),
+    );
   const exploreRanking = exactExploreRanking([
     firstExplore,
     ...remainingExplorePages,

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -25,6 +25,7 @@ import {
 } from "./bitquery-historical-release-gate.mjs";
 
 const HEALTH_PATH = "/api/ops/health";
+const PRODUCTION_ORIGIN = "https://programmable.market";
 const EXPLORE_PAGE_SIZE = 100;
 const MAXIMUM_EXPLORE_TOKENS = 400;
 const EXPLORE_PATH =
@@ -1129,6 +1130,11 @@ export async function verifyPostPromotion(input) {
     target.hash !== ""
   ) {
     throw new Error("post-promotion target must be an HTTPS origin");
+  }
+  if (target.origin !== PRODUCTION_ORIGIN) {
+    throw new Error(
+      "post-promotion target must be the programmable.market production origin",
+    );
   }
   if (
     !/^dpl_[A-Za-z0-9]{20,80}$/u.test(input.expectedDeploymentId ?? "") ||

--- a/scripts/perf/read-model-staged-health.mjs
+++ b/scripts/perf/read-model-staged-health.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import {
+  deploymentCommit,
+  fetchVercelDeployment,
+} from "./read-model-live-verifier.mjs";
+
+const HEALTH_PATH = "/api/ops/health";
+const MAXIMUM_RESPONSE_BYTES = 2 * 1024 * 1024;
+
+function argumentsFrom(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || !value || value.startsWith("--")) {
+      throw new Error("arguments must be --name value pairs");
+    }
+    result[name.slice(2)] = value;
+  }
+  if (
+    !result["target-url"] ||
+    !result["deployment-id"] ||
+    !result["git-head"]
+  ) {
+    throw new Error(
+      "--target-url, --deployment-id and --git-head are required",
+    );
+  }
+  return result;
+}
+
+function exactStagedTarget(value) {
+  const target = new URL(value);
+  if (
+    target.protocol !== "https:" ||
+    target.username !== "" ||
+    target.password !== "" ||
+    target.pathname !== "/" ||
+    target.search !== "" ||
+    target.hash !== "" ||
+    !target.hostname.endsWith(".vercel.app")
+  ) {
+    throw new Error("staged health target must be an exact Vercel origin");
+  }
+  return target;
+}
+
+function exactAutomationBypassSecret(value) {
+  const length = Buffer.byteLength(value ?? "", "utf8");
+  return (
+    typeof value === "string" &&
+    length >= 32 &&
+    length <= 512 &&
+    !/[\r\n]/u.test(value)
+  );
+}
+
+function safeJson(text) {
+  if (
+    text.length < 2 ||
+    Buffer.byteLength(text, "utf8") > MAXIMUM_RESPONSE_BYTES
+  ) {
+    throw new Error("staged health returned an invalid response size");
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error("staged health did not return JSON");
+  }
+}
+
+async function requestHealth(fetchImpl, target, automationBypassSecret) {
+  const response = await fetchImpl(new URL(HEALTH_PATH, target), {
+    redirect: "error",
+    headers: {
+      Accept: "application/json",
+      "x-vercel-protection-bypass": automationBypassSecret,
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+  return {
+    ok: response.ok,
+    status: response.status,
+    body: safeJson(await response.text()),
+  };
+}
+
+export async function verifyStagedHealth(input) {
+  const target = exactStagedTarget(input.targetUrl);
+  if (
+    !/^dpl_[A-Za-z0-9]{20,80}$/u.test(input.expectedDeploymentId ?? "") ||
+    !/^[0-9a-f]{40}$/u.test(input.expectedGitHead ?? "") ||
+    !input.token ||
+    !input.teamId ||
+    !input.projectId ||
+    !exactAutomationBypassSecret(input.automationBypassSecret)
+  ) {
+    throw new Error(
+      "exact staged deployment and health credentials are required",
+    );
+  }
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const [deployment, response] = await Promise.all([
+    fetchVercelDeployment({
+      idOrUrl: target.hostname,
+      token: input.token,
+      teamId: input.teamId,
+      fetchImpl,
+    }),
+    requestHealth(fetchImpl, target, input.automationBypassSecret),
+  ]);
+  const deploymentHost = String(deployment.url ?? "")
+    .replace(/^https?:\/\//u, "")
+    .replace(/\/$/u, "");
+  const checks = [
+    {
+      id: "staged-health-deployment-id",
+      condition: deployment.id === input.expectedDeploymentId,
+      detail: "the health target resolves to the exact staged deployment id",
+    },
+    {
+      id: "staged-health-deployment-url",
+      condition: deploymentHost === target.hostname,
+      detail: "the health request uses the immutable staged deployment origin",
+    },
+    {
+      id: "staged-health-deployment-project",
+      condition:
+        deployment.projectId === input.projectId ||
+        deployment.project?.id === input.projectId,
+      detail: "the staged deployment belongs to the configured Vercel project",
+    },
+    {
+      id: "staged-health-deployment-ready",
+      condition: deployment.readyState === "READY",
+      detail: "the exact staged deployment is READY",
+    },
+    {
+      id: "staged-health-deployment-commit",
+      condition: deploymentCommit(deployment) === input.expectedGitHead,
+      detail: "the staged deployment is bound to the exact reviewed Git commit",
+    },
+    {
+      id: "staged-health-response",
+      condition: response.ok && response.body?.status === "healthy",
+      detail: "the exact staged deployment operational health route is healthy",
+    },
+  ];
+  const normalizedChecks = checks.map(({ id, condition, detail }) => ({
+    id,
+    status: condition ? "pass" : "fail",
+    detail,
+  }));
+  const failures = normalizedChecks.filter(({ status }) => status === "fail");
+  return {
+    ok: failures.length === 0,
+    targetUrl: target.toString(),
+    deploymentId: input.expectedDeploymentId,
+    gitHead: input.expectedGitHead,
+    checks: normalizedChecks,
+    failures,
+  };
+}
+
+async function retry(operation, attempts = 12, delayMs = 5_000) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const value = await operation();
+      if (value.ok) return value;
+      lastError = new Error(`staged health attempt ${attempt} failed`);
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < attempts) {
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, delayMs));
+    }
+  }
+  throw lastError ?? new Error("staged health verification failed");
+}
+
+async function main() {
+  const args = argumentsFrom(process.argv.slice(2));
+  const result = await retry(() =>
+    verifyStagedHealth({
+      targetUrl: args["target-url"],
+      expectedDeploymentId: args["deployment-id"],
+      expectedGitHead: args["git-head"],
+      token: process.env.VERCEL_TOKEN,
+      teamId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+      automationBypassSecret: process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+    }),
+  );
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === new URL(process.argv[1], "file:").href
+) {
+  main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "staged health verification failed"}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/perf/read-model-staged-health.mjs
+++ b/scripts/perf/read-model-staged-health.mjs
@@ -101,19 +101,16 @@ export async function verifyStagedHealth(input) {
     );
   }
   const fetchImpl = input.fetchImpl ?? fetch;
-  const [deployment, response] = await Promise.all([
-    fetchVercelDeployment({
-      idOrUrl: target.hostname,
-      token: input.token,
-      teamId: input.teamId,
-      fetchImpl,
-    }),
-    requestHealth(fetchImpl, target, input.automationBypassSecret),
-  ]);
+  const deployment = await fetchVercelDeployment({
+    idOrUrl: target.hostname,
+    token: input.token,
+    teamId: input.teamId,
+    fetchImpl,
+  });
   const deploymentHost = String(deployment.url ?? "")
     .replace(/^https?:\/\//u, "")
     .replace(/\/$/u, "");
-  const checks = [
+  const deploymentChecks = [
     {
       id: "staged-health-deployment-id",
       condition: deployment.id === input.expectedDeploymentId,
@@ -141,17 +138,47 @@ export async function verifyStagedHealth(input) {
       condition: deploymentCommit(deployment) === input.expectedGitHead,
       detail: "the staged deployment is bound to the exact reviewed Git commit",
     },
-    {
-      id: "staged-health-response",
-      condition: response.ok && response.body?.status === "healthy",
-      detail: "the exact staged deployment operational health route is healthy",
-    },
   ];
-  const normalizedChecks = checks.map(({ id, condition, detail }) => ({
-    id,
-    status: condition ? "pass" : "fail",
-    detail,
-  }));
+  const normalizedDeploymentChecks = deploymentChecks.map(
+    ({ id, condition, detail }) => ({
+      id,
+      status: condition ? "pass" : "fail",
+      detail,
+    }),
+  );
+  const deploymentFailures = normalizedDeploymentChecks.filter(
+    ({ status }) => status === "fail",
+  );
+  if (deploymentFailures.length > 0) {
+    return {
+      ok: false,
+      targetUrl: target.toString(),
+      deploymentId: input.expectedDeploymentId,
+      gitHead: input.expectedGitHead,
+      checks: normalizedDeploymentChecks,
+      failures: deploymentFailures,
+    };
+  }
+
+  const response = await requestHealth(
+    fetchImpl,
+    target,
+    input.automationBypassSecret,
+  );
+  const responseCheck = {
+    id: "staged-health-response",
+    condition: response.ok && response.body?.status === "healthy",
+    detail: "the exact staged deployment operational health route is healthy",
+  };
+  const normalizedResponseCheck = {
+    id: responseCheck.id,
+    status: responseCheck.condition ? "pass" : "fail",
+    detail: responseCheck.detail,
+  };
+  const normalizedChecks = [
+    ...normalizedDeploymentChecks,
+    normalizedResponseCheck,
+  ];
   const failures = normalizedChecks.filter(({ status }) => status === "fail");
   return {
     ok: failures.length === 0,

--- a/tests/alchemy-live-market-snapshot.test.ts
+++ b/tests/alchemy-live-market-snapshot.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  createPublicClient: vi.fn(),
+  getBlock: vi.fn(),
+  readOperationalRpcHealth: vi.fn(),
+}));
+
+vi.mock("viem", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("viem")>();
+  return {
+    ...actual,
+    createPublicClient: mocks.createPublicClient,
+  };
+});
+
+vi.mock("../lib/onchain/rpc-health", () => ({
+  readOperationalRpcHealth: mocks.readOperationalRpcHealth,
+}));
+
+import { readVerifiedOperationalMarketSnapshot } from
+  "../lib/alchemy/live-market.server";
+import type { ReadyOnchainDeployment } from "../lib/onchain/types";
+
+const BLOCK_HASH = `0x${"55".repeat(32)}` as const;
+const deployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: "0x1111111111111111111111111111111111111111",
+  feeHook: "0x2222222222222222222222222222222222222222",
+  launcherRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  deploymentBlock: 1n,
+  stateView: "0x3333333333333333333333333333333333333333",
+  stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  rpcUrl: "https://primary.example/rpc",
+  rpcUrlSecondary: "https://secondary.example/rpc",
+  confirmations: 12n,
+  logBlockRange: 5_000n,
+} satisfies ReadyOnchainDeployment;
+
+describe("operational market snapshot replay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T08:00:00.000Z"));
+    mocks.createPublicClient.mockReturnValue({ getBlock: mocks.getBlock });
+    mocks.readOperationalRpcHealth.mockResolvedValue({
+      status: "healthy",
+      read: { status: "available" },
+      quorum: { status: "verified" },
+      confirmedBlock: { number: "25630000", hash: BLOCK_HASH },
+    });
+    mocks.getBlock.mockResolvedValue({
+      number: 25_630_000n,
+      hash: BLOCK_HASH,
+      timestamp: BigInt(Math.floor(Date.now() / 1_000) - 60),
+    });
+  });
+
+  it("exact-verifies the selected first-page block through both providers", async () => {
+    await expect(
+      readVerifiedOperationalMarketSnapshot(deployment),
+    ).resolves.toMatchObject({
+      blockNumber: "25630000",
+      blockHash: BLOCK_HASH,
+      blockTimestamp: String(Math.floor(Date.now() / 1_000) - 60),
+    });
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(2);
+    expect(mocks.getBlock).toHaveBeenCalledTimes(2);
+    expect(mocks.getBlock).toHaveBeenCalledWith({ blockNumber: 25_630_000n });
+  });
+
+  it("normalizes an uppercase health hash before exact verification", async () => {
+    const canonicalHash = `0x${"ab".repeat(32)}` as const;
+    mocks.readOperationalRpcHealth.mockResolvedValue({
+      status: "healthy",
+      read: { status: "available" },
+      quorum: { status: "verified" },
+      confirmedBlock: {
+        number: "25630000",
+        hash: `0x${"AB".repeat(32)}`,
+      },
+    });
+    mocks.getBlock.mockResolvedValue({
+      number: 25_630_000n,
+      hash: canonicalHash,
+      timestamp: BigInt(Math.floor(Date.now() / 1_000) - 60),
+    });
+
+    await expect(
+      readVerifiedOperationalMarketSnapshot(deployment),
+    ).resolves.toMatchObject({ blockHash: canonicalHash });
+  });
+
+  it("rejects an oversized replay block before exact provider reads", async () => {
+    await expect(readVerifiedOperationalMarketSnapshot(deployment, {
+      blockNumber: "1".repeat(79),
+      blockHash: BLOCK_HASH,
+    })).resolves.toBeNull();
+    expect(mocks.createPublicClient).not.toHaveBeenCalled();
+    expect(mocks.getBlock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["stale", -301, -301],
+    ["future", 61, 61],
+    ["timestamp disagreement", -60, -61],
+  ] as const)("rejects a %s first-page block", async (_label, first, second) => {
+    const now = Math.floor(Date.now() / 1_000);
+    mocks.getBlock
+      .mockResolvedValueOnce({
+        number: 25_630_000n,
+        hash: BLOCK_HASH,
+        timestamp: BigInt(now + first),
+      })
+      .mockResolvedValueOnce({
+        number: 25_630_000n,
+        hash: BLOCK_HASH,
+        timestamp: BigInt(now + second),
+      });
+
+    await expect(
+      readVerifiedOperationalMarketSnapshot(deployment),
+    ).resolves.toBeNull();
+  });
+});

--- a/tests/canonical-token-supply.test.ts
+++ b/tests/canonical-token-supply.test.ts
@@ -74,6 +74,46 @@ describe("canonical token supply hydration", () => {
     expect(secondary.readContract).toHaveBeenCalledTimes(2);
   });
 
+  it("binds replay hydration to the requested valuation block and hash", async () => {
+    const primary = supplyClient();
+    const secondary = supplyClient();
+
+    const [hydrated] = await hydrateMissingCanonicalTokenSupplyV1([entry], {
+      deployment,
+      snapshot: {
+        blockNumber: "100",
+        blockHash: BLOCK_HASH,
+      },
+      createClient: (rpcUrl) =>
+        rpcUrl === deployment.rpcUrl ? primary : secondary,
+    });
+
+    expect(hydrated).toMatchObject({
+      tokenDecimals: 18,
+      totalSupplyRaw: SUPPLY.toString(),
+    });
+    expect(primary.getBlockNumber).not.toHaveBeenCalled();
+    expect(secondary.getBlockNumber).not.toHaveBeenCalled();
+    expect(primary.getBlock).toHaveBeenCalledWith({ blockNumber: 100n });
+    expect(secondary.getBlock).toHaveBeenCalledWith({ blockNumber: 100n });
+  });
+
+  it("fails closed when replay readers agree on a different block hash", async () => {
+    const driftedHash = `0x${"22".repeat(32)}` as const;
+    const primary = supplyClient({ blockHash: driftedHash });
+    const secondary = supplyClient({ blockHash: driftedHash });
+
+    await expect(hydrateMissingCanonicalTokenSupplyV1([entry], {
+      deployment,
+      snapshot: {
+        blockNumber: "100",
+        blockHash: BLOCK_HASH,
+      },
+      createClient: (rpcUrl) =>
+        rpcUrl === deployment.rpcUrl ? primary : secondary,
+    })).resolves.toEqual([entry]);
+  });
+
   it("leaves identity unchanged when the two readers disagree", async () => {
     const primary = supplyClient();
     const secondary = supplyClient({ totalSupply: SUPPLY - 1n });

--- a/tests/current-valuation-server.test.ts
+++ b/tests/current-valuation-server.test.ts
@@ -4,13 +4,14 @@ vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
   readOfficialV4LiquidityEvidence: vi.fn(),
+  readOfficialV4LiquidityEvidenceSnapshot: vi.fn(),
   withSameBlockEthUsdQuote: vi.fn(),
   enrichTokensWithAlchemyPoolState: vi.fn(),
 }));
 
 vi.mock("../lib/onchain/uniswap-v4-subgraph", () => ({
-  readOfficialV4LiquidityEvidence:
-    mocks.readOfficialV4LiquidityEvidence,
+  readOfficialV4LiquidityEvidenceSnapshot:
+    mocks.readOfficialV4LiquidityEvidenceSnapshot,
 }));
 vi.mock("../lib/alchemy/live-market.server", () => ({
   withSameBlockEthUsdQuote: mocks.withSameBlockEthUsdQuote,
@@ -20,6 +21,7 @@ vi.mock("../lib/alchemy/live-market.server", () => ({
 import {
   attachBitqueryMarketDataToValuedEntries,
   valueExploreEntriesWithCurrentEvidence,
+  valueExploreEntriesWithCurrentEvidenceSnapshot,
 } from
   "../lib/market-data/current-valuation.server";
 import type { TokenMarketDataV1 } from
@@ -180,6 +182,26 @@ function tokenWithState(
 describe("current Explore valuation orchestration", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    mocks.readOfficialV4LiquidityEvidenceSnapshot.mockImplementation(
+      async (input: {
+        tokens: readonly unknown[];
+        referenceHead: {
+          chainId: 1;
+          blockNumber: string;
+          blockHash: `0x${string}`;
+        };
+        liquiditySnapshot?: {
+          chainId: 1;
+          blockNumber: string;
+          blockHash: `0x${string}`;
+        };
+      }, options?: unknown) => ({
+        evidence: input.tokens.length === 0
+          ? []
+          : await mocks.readOfficialV4LiquidityEvidence(input, options),
+        snapshot: input.liquiditySnapshot ?? input.referenceHead,
+      }),
+    );
   });
 
   it("keeps current Bitquery nested but unavailable at top level when dual evidence fails", async () => {
@@ -400,6 +422,69 @@ describe("current Explore valuation orchestration", () => {
       status: "unavailable",
       reason: "liquidity-unavailable",
     });
+  });
+
+  it("replays the explicit-none liquidity snapshot with zero Graph calls", async () => {
+    mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([
+      tokenWithState("0"),
+    ]);
+    const input = {
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+    } as const;
+
+    const first = await valueExploreEntriesWithCurrentEvidenceSnapshot(input);
+    const replay = await valueExploreEntriesWithCurrentEvidenceSnapshot({
+      ...input,
+      liquiditySnapshot: first.liquiditySnapshot,
+    });
+
+    expect(first.liquiditySnapshot).toEqual({
+      chainId: 1,
+      blockNumber: "none",
+      blockHash: "none",
+    });
+    expect(replay.liquiditySnapshot).toEqual(first.liquiditySnapshot);
+    expect(mocks.readOfficialV4LiquidityEvidenceSnapshot).not.toHaveBeenCalled();
+    expect(mocks.readOfficialV4LiquidityEvidence).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "none becomes Graph-eligible",
+      tokenWithState("1", "10000000000000000000000"),
+      { chainId: 1 as const, blockNumber: "none" as const, blockHash: "none" as const },
+    ],
+    [
+      "pinned Graph snapshot becomes ineligible",
+      tokenWithState("0"),
+      {
+        chainId: 1 as const,
+        blockNumber: "25749999",
+        blockHash: `0x${"bb".repeat(32)}` as const,
+      },
+    ],
+  ])("fails closed when replay liquidity mode changes: %s", async (
+    _label,
+    stateToken,
+    requestedLiquiditySnapshot,
+  ) => {
+    mocks.withSameBlockEthUsdQuote.mockResolvedValue(snapshot);
+    mocks.enrichTokensWithAlchemyPoolState.mockResolvedValue([stateToken]);
+
+    await expect(valueExploreEntriesWithCurrentEvidenceSnapshot({
+      entries: [token],
+      marketByToken: new Map([[tokenAddress, marketData]]),
+      deployment,
+      operationalSnapshot: snapshot,
+      liquiditySnapshot: requestedLiquiditySnapshot,
+      now: new Date("2026-08-13T00:02:00.000Z"),
+    })).rejects.toThrow("Explore liquidity snapshot changed");
+    expect(mocks.readOfficialV4LiquidityEvidenceSnapshot).not.toHaveBeenCalled();
   });
 
   it("fails global ranking when positive active liquidity lacks price evidence", async () => {

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -1323,23 +1323,49 @@ describe("read-model performance contract", () => {
       resolve(process.cwd(), canonicalSupplyPath),
       "utf8",
     );
-    const singleProviderSupply =
-      alchemySourceContracts.evaluateAlchemyExploreSourceContracts(
-        process.cwd(),
-        {
-          sourceOverrides: {
-            [canonicalSupplyPath]: canonicalSupplySource.replace(
-              "group.length >= 2",
-              "group.length >= 1",
-            ),
-          },
-        },
-      );
-    expect(
-      singleProviderSupply.failures.map(
-        (failure: { id: string }) => failure.id,
+    for (const unsafeSupply of [
+      canonicalSupplySource.replace(
+        "group.length >= 2",
+        "group.length >= 1",
       ),
-    ).toContain("canonical-token-supply-quorum");
+      canonicalSupplySource.replace(
+        "agreed.blockHash.toLowerCase() !== requestedSnapshot.blockHash",
+        "false",
+      ),
+    ]) {
+      const unboundSupply =
+        alchemySourceContracts.evaluateAlchemyExploreSourceContracts(
+          process.cwd(),
+          { sourceOverrides: { [canonicalSupplyPath]: unsafeSupply } },
+        );
+      expect(
+        unboundSupply.failures.map(
+          (failure: { id: string }) => failure.id,
+        ),
+      ).toContain("canonical-token-supply-quorum");
+    }
+
+    for (const unsafeExploreRoute of [
+      exploreRouteSource.replace(
+        "valueExploreEntriesWithCurrentEvidenceSnapshot({",
+        "valueExploreEntriesWithCurrentEvidence({",
+      ),
+      exploreRouteSource.replace(
+        "blockHash: operationalSnapshot.blockHash",
+        "blockHash: referenceHead.blockHash",
+      ),
+    ]) {
+      const unboundSupply =
+        alchemySourceContracts.evaluateAlchemyExploreSourceContracts(
+          process.cwd(),
+          { sourceOverrides: { [exploreRoutePath]: unsafeExploreRoute } },
+        );
+      expect(
+        unboundSupply.failures.map(
+          (failure: { id: string }) => failure.id,
+        ),
+      ).toContain("canonical-token-supply-quorum");
+    }
 
     const currentMarketRpcPath =
       "lib/market-data/current-market-rpc.server.ts";

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -1057,6 +1057,30 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it("fails closed when post-promotion drops the fixed production origin", () => {
+    const postPromotionPath =
+      "scripts/perf/read-model-post-promotion.mjs";
+    const postPromotion = readFileSync(
+      resolve(ROOT, postPromotionPath),
+      "utf8",
+    );
+    const unsafePostPromotion = postPromotion.replace(
+      "target.origin !== PRODUCTION_ORIGIN",
+      "false",
+    );
+    expect(unsafePostPromotion).not.toBe(postPromotion);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [postPromotionPath]: unsafePostPromotion,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-post-promotion-binding",
+    );
+  });
+
   it.each([
     ["StateView price source", 'price?.source !== "uniswap-v4-stateview-chainlink-v1"'],
     ["official liquidity source", 'liquidity?.source !== "official-uniswap-v4-subgraph"'],
@@ -2711,6 +2735,16 @@ describe("post-promotion route verification", () => {
         targetUrl: "https://programmable.market/untrusted",
       }),
     ).rejects.toThrow("HTTPS origin");
+  });
+
+  it("rejects an exact staged origin before any production proof runs", async () => {
+    await expect(
+      verifyPostPromotion({
+        ...postPromotionInput(),
+        targetUrl:
+          "https://launcher-v4-example-aficialais-projects.vercel.app",
+      }),
+    ).rejects.toThrow("programmable.market production origin");
   });
 
   it("fails if production does not resolve to the staged deployment", async () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -12,9 +12,9 @@ import {
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
-import { evaluateReadModelOperationsSourceContracts, POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS, POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS, POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS, STAGED_MARKET_EVIDENCE_SOURCE_GUARDS } from "../../scripts/perf/read-model-ops-source-contracts.mjs";
+import { evaluateReadModelOperationsSourceContracts, POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS, POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS, POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS, POST_PROMOTION_PAGINATION_SOURCE_GUARDS, STAGED_MARKET_EVIDENCE_SOURCE_GUARDS } from "../../scripts/perf/read-model-ops-source-contracts.mjs";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
-import { exactCurrentPublicFdvLiquidity, verifyCurrentPublicOnchainEvidenceV1, verifyPostPromotion } from "../../scripts/perf/read-model-post-promotion.mjs";
+import { exactCurrentPublicFdvLiquidity, exactExploreValuationSnapshot, exploreContinuationPath, verifyCurrentPublicOnchainEvidenceV1, verifyPostPromotion } from "../../scripts/perf/read-model-post-promotion.mjs";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import { resolveProductionBinding } from "../../scripts/perf/read-model-production-binding.mjs";
 
@@ -133,6 +133,7 @@ const stagedMarketEvidenceGuardCases: ReadonlyArray<readonly [number, string]> =
 const postPromotionGuardCases: ReadonlyArray<readonly [number, string]> = [
   ...(POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS as readonly string[]),
   ...(POST_PROMOTION_GLOBAL_RANKING_SOURCE_GUARDS as readonly string[]),
+  ...(POST_PROMOTION_PAGINATION_SOURCE_GUARDS as readonly string[]),
   ...(POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS as readonly string[]),
 ].map((needle: string, index: number) => [index, needle] as const);
 const testStateViewAbi = parseAbi([
@@ -1041,8 +1042,8 @@ describe("read-model operations source contract", () => {
       "utf8",
     );
     const unsafePostPromotion = postPromotion.replace(
-      "  return currentCount > 0 ? { currentToken, tokens } : null;",
-      "  return currentCount >= 0 ? { currentToken, tokens } : null;",
+      "  return currentCount > 0 ? { currentToken, tokens, valuationSnapshot } : null;",
+      "  return currentCount >= 0 ? { currentToken, tokens, valuationSnapshot } : null;",
     );
     expect(unsafePostPromotion).not.toBe(postPromotion);
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
@@ -1785,6 +1786,73 @@ function currentPublicHeaders(
   };
 }
 
+const EXPLORE_VALUATION_SNAPSHOT_FIELDS = [
+  "schemaVersion",
+  "chainId",
+  "blockNumber",
+  "blockHash",
+  "liquidityBlockNumber",
+  "liquidityBlockHash",
+  "rankingCommitment",
+  "sort",
+  "query",
+  "socials",
+  "pageSize",
+] as const;
+type ExploreValuationSnapshotField =
+  typeof EXPLORE_VALUATION_SNAPSHOT_FIELDS[number];
+type ExploreValuationSnapshotMutation = Readonly<{
+  page: 1 | 2;
+  field: ExploreValuationSnapshotField;
+  operation: "removed" | "changed";
+}>;
+
+function valuationSnapshotFixture() {
+  return {
+    schemaVersion: "programmable.explore-valuation-snapshot.v1",
+    chainId: 1,
+    blockNumber: TEST_CURRENT_BLOCK.toString(),
+    blockHash: TEST_PUBLIC_BLOCK_HASH,
+    liquidityBlockNumber: (TEST_CURRENT_BLOCK - 1n).toString(),
+    liquidityBlockHash: TEST_PUBLIC_INDEXED_BLOCK_HASH,
+    rankingCommitment: `sha256:${"88".repeat(32)}`,
+    sort: "market-cap",
+    query: "",
+    socials: null,
+    pageSize: 100,
+  } as const;
+}
+
+const EXPLORE_VALUATION_SNAPSHOT_CHANGED_VALUES = {
+  schemaVersion: "programmable.explore-valuation-snapshot.v2",
+  chainId: 2,
+  blockNumber: (TEST_CURRENT_BLOCK + 1n).toString(),
+  blockHash: `0x${"77".repeat(32)}`,
+  liquidityBlockNumber: (TEST_CURRENT_BLOCK - 2n).toString(),
+  liquidityBlockHash: `0x${"99".repeat(32)}`,
+  rankingCommitment: `sha256:${"aa".repeat(32)}`,
+  sort: "market-cap-asc",
+  query: "changed",
+  socials: "yes",
+  pageSize: 99,
+} satisfies Readonly<Record<ExploreValuationSnapshotField, unknown>>;
+
+function mutateValuationSnapshot(
+  mutation?: Pick<ExploreValuationSnapshotMutation, "field" | "operation">,
+) {
+  const snapshot: Record<string, unknown> = {
+    ...valuationSnapshotFixture(),
+  };
+  if (!mutation) return snapshot;
+  if (mutation.operation === "removed") {
+    delete snapshot[mutation.field];
+  } else {
+    snapshot[mutation.field] =
+      EXPLORE_VALUATION_SNAPSHOT_CHANGED_VALUES[mutation.field];
+  }
+  return snapshot;
+}
+
 function unavailablePublicTokenFixture(index: number) {
   const address = `0x${index.toString(16).padStart(40, "0")}`;
   return {
@@ -1797,6 +1865,7 @@ function unavailablePublicTokenFixture(index: number) {
 
 function paginatedMarketCapFetch(
   mode: "complete" | "hidden-current" | "missing-page" = "complete",
+  mutation?: ExploreValuationSnapshotMutation,
 ) {
   const base = publicFetch();
   const publicMarketAsOf = new Date(
@@ -1813,6 +1882,12 @@ function paginatedMarketCapFetch(
   const secondPageToken = mode === "hidden-current"
     ? publicToken
     : unavailable[99];
+  const firstPageSnapshot = mutateValuationSnapshot(
+    mutation?.page === 1 ? mutation : undefined,
+  );
+  const secondPageSnapshot = mutateValuationSnapshot(
+    mutation?.page === 2 ? mutation : undefined,
+  );
   return async (input: URL | RequestInfo, init?: RequestInit) => {
     const url = new URL(String(input));
     if (
@@ -1830,6 +1905,8 @@ function paginatedMarketCapFetch(
         total: 101,
         totalPages: 2,
         sort: "market-cap",
+        query: "",
+        valuationSnapshot: firstPageSnapshot,
         dataQuality: hasCurrent
           ? currentExploreDataQuality(publicMarketAsOf, 1, 99)
           : {
@@ -1857,6 +1934,28 @@ function paginatedMarketCapFetch(
             },
       });
     }
+    const expectedContinuationParameters = [
+      ["valuationBlock", firstPageSnapshot.blockNumber],
+      ["valuationBlockHash", firstPageSnapshot.blockHash],
+      ["liquidityBlock", firstPageSnapshot.liquidityBlockNumber],
+      ["liquidityBlockHash", firstPageSnapshot.liquidityBlockHash],
+      ["rankingCommitment", firstPageSnapshot.rankingCommitment],
+    ] as const;
+    if (
+      url.searchParams.get("limit") !== "100" ||
+      url.searchParams.get("page") !== "2" ||
+      url.searchParams.get("sort") !== "market-cap" ||
+      expectedContinuationParameters.some(([name, value]) =>
+        typeof value !== "string" ||
+        url.searchParams.get(name) !== value ||
+        url.searchParams.getAll(name).length !== 1
+      )
+    ) {
+      return Response.json(
+        { error: "incomplete valuation snapshot continuation" },
+        { status: 400 },
+      );
+    }
     const pageTokens = mode === "missing-page" ? [] : [secondPageToken];
     const hasCurrent = mode === "hidden-current";
     return Response.json({
@@ -1867,6 +1966,8 @@ function paginatedMarketCapFetch(
       total: 101,
       totalPages: 2,
       sort: "market-cap",
+      query: "",
+      valuationSnapshot: secondPageSnapshot,
       dataQuality: hasCurrent
         ? currentExploreDataQuality(publicMarketAsOf, 1, 0)
         : {
@@ -1895,6 +1996,13 @@ function paginatedMarketCapFetch(
     });
   };
 }
+
+const exploreValuationSnapshotMutationCases: ReadonlyArray<
+  readonly [ExploreValuationSnapshotField, "removed" | "changed"]
+> = EXPLORE_VALUATION_SNAPSHOT_FIELDS.flatMap((field) => [
+  [field, "removed"] as const,
+  [field, "changed"] as const,
+]);
 
 function publicFetch(
   healthStatus = "healthy",
@@ -2102,6 +2210,8 @@ function publicFetch(
         total: 1,
         totalPages: 1,
         sort: "market-cap",
+        query: "",
+        valuationSnapshot: valuationSnapshotFixture(),
         dataQuality: currentExploreDataQuality(publicMarketAsOf),
       }, { headers: currentPublicHeaders(publicMarketAsOf) });
     }
@@ -2324,6 +2434,40 @@ function postPromotionInput(fetchImpl = publicFetch()) {
 }
 
 describe("post-promotion route verification", () => {
+  it("accepts only paired concrete or none liquidity snapshot commitments", () => {
+    const concrete = valuationSnapshotFixture();
+    expect(exactExploreValuationSnapshot(concrete)).toEqual(concrete);
+    const none = {
+      ...concrete,
+      liquidityBlockNumber: "none",
+      liquidityBlockHash: "none",
+    };
+    expect(exactExploreValuationSnapshot(none)).toEqual(none);
+    expect(exactExploreValuationSnapshot({
+      ...none,
+      liquidityBlockHash: concrete.liquidityBlockHash,
+    })).toBeNull();
+    expect(exactExploreValuationSnapshot({
+      ...none,
+      liquidityBlockNumber: concrete.liquidityBlockNumber,
+    })).toBeNull();
+
+    const continuation = new URL(
+      exploreContinuationPath(none, 2),
+      "https://programmable.test",
+    );
+    expect([...continuation.searchParams.entries()]).toEqual([
+      ["limit", "100"],
+      ["page", "2"],
+      ["sort", "market-cap"],
+      ["valuationBlock", concrete.blockNumber],
+      ["valuationBlockHash", concrete.blockHash],
+      ["liquidityBlock", "none"],
+      ["liquidityBlockHash", "none"],
+      ["rankingCommitment", concrete.rankingCommitment],
+    ]);
+  });
+
   it("accepts the exact legacy and stamped Classic native/token branches", () => {
     const asOfTime = new Date(
       Math.floor((Date.now() - 2 * 60_000) / 1_000) * 1_000,
@@ -2536,6 +2680,40 @@ describe("post-promotion route verification", () => {
     expect(result.ok).toBe(true);
     expect(result.failures).toEqual([]);
   });
+
+  it.each(exploreValuationSnapshotMutationCases)(
+    "rejects page-one valuation snapshot field %s when %s",
+    async (field, operation) => {
+      const result = await verifyPostPromotion(
+        postPromotionInput(paginatedMarketCapFetch("complete", {
+          page: 1,
+          field,
+          operation,
+        })),
+      );
+      expect(result.ok).toBe(false);
+      expect(result.failures).toContainEqual(
+        expect.objectContaining({ id: "production-explore" }),
+      );
+    },
+  );
+
+  it.each(exploreValuationSnapshotMutationCases)(
+    "rejects page-two valuation snapshot field %s when %s",
+    async (field, operation) => {
+      const result = await verifyPostPromotion(
+        postPromotionInput(paginatedMarketCapFetch("complete", {
+          page: 2,
+          field,
+          operation,
+        })),
+      );
+      expect(result.ok).toBe(false);
+      expect(result.failures).toContainEqual(
+        expect.objectContaining({ id: "production-explore" }),
+      );
+    },
+  );
 
   it("rejects a higher current FDV hidden after unavailable page-one entries", async () => {
     const result = await verifyPostPromotion(

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -1082,6 +1082,68 @@ describe("read-model operations source contract", () => {
   });
 
   it.each([
+    "  if (false && target.origin !== PRODUCTION_ORIGIN) {",
+    "  if (target.origin !== PRODUCTION_ORIGIN && false) {",
+    "  if (Boolean(0) && target.origin !== PRODUCTION_ORIGIN) {",
+  ])(
+    "fails closed when post-promotion disables the production-origin guard as %s",
+    (disabledGuard) => {
+      const postPromotionPath =
+        "scripts/perf/read-model-post-promotion.mjs";
+      const postPromotion = readFileSync(
+        resolve(ROOT, postPromotionPath),
+        "utf8",
+      );
+      const unsafePostPromotion = postPromotion.replace(
+        "  if (target.origin !== PRODUCTION_ORIGIN) {",
+        disabledGuard,
+      );
+      expect(unsafePostPromotion).not.toBe(postPromotion);
+      const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+        sourceOverrides: {
+          ...integratedOverrides(),
+          [postPromotionPath]: unsafePostPromotion,
+        },
+        expectedSha256Overrides: fixtureDigests(),
+      });
+      expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+        "ops-post-promotion-binding",
+      );
+    },
+  );
+
+  it("fails closed when the exact production-origin throw is wrapped in a disabled branch", () => {
+    const postPromotionPath =
+      "scripts/perf/read-model-post-promotion.mjs";
+    const postPromotion = readFileSync(
+      resolve(ROOT, postPromotionPath),
+      "utf8",
+    );
+    const exactGuard = [
+      "  if (target.origin !== PRODUCTION_ORIGIN) {",
+      "    throw new Error(",
+      '      "post-promotion target must be the programmable.market production origin",',
+      "    );",
+      "  }",
+    ].join("\n");
+    const unsafePostPromotion = postPromotion.replace(
+      exactGuard,
+      ["  if (false) {", exactGuard, "  }"].join("\n"),
+    );
+    expect(unsafePostPromotion).not.toBe(postPromotion);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [postPromotionPath]: unsafePostPromotion,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-post-promotion-binding",
+    );
+  });
+
+  it.each([
     ["StateView price source", 'price?.source !== "uniswap-v4-stateview-chainlink-v1"'],
     ["official liquidity source", 'liquidity?.source !== "official-uniswap-v4-subgraph"'],
     ["official subgraph deployment", "provenance?.deployment !== OFFICIAL_V4_SUBGRAPH_DEPLOYMENT"],

--- a/tests/data-pipeline/read-model-staged-health.test.ts
+++ b/tests/data-pipeline/read-model-staged-health.test.ts
@@ -1,0 +1,250 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error Operational JavaScript modules intentionally have no declarations.
+import * as operationsSourceContracts from "../../scripts/perf/read-model-ops-source-contracts.mjs";
+const {
+  evaluateReadModelOperationsSourceContracts,
+  STAGED_HEALTH_HANDOFF_SOURCE_GUARDS,
+} = operationsSourceContracts;
+// @ts-expect-error Operational JavaScript modules intentionally have no declarations.
+import { verifyStagedHealth } from "../../scripts/perf/read-model-staged-health.mjs";
+
+const ROOT = process.cwd();
+const TARGET_URL = "https://programmable-candidate-test.vercel.app/";
+const DEPLOYMENT_ID = "dpl_aaaaaaaaaaaaaaaaaaaaaaaa";
+const GIT_HEAD = "b".repeat(40);
+const PROJECT_ID = "prj_programmable_test";
+const TEAM_ID = "team_programmable_test";
+const TOKEN = "vercel-test-token";
+const AUTOMATION_BYPASS_SECRET = "stage-bypass-secret-at-least-32-bytes";
+
+function deploymentFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DEPLOYMENT_ID,
+    url: new URL(TARGET_URL).hostname,
+    readyState: "READY",
+    projectId: PROJECT_ID,
+    meta: { githubCommitSha: GIT_HEAD },
+    ...overrides,
+  };
+}
+
+function stagedFetch(
+  input: {
+    deployment?: Record<string, unknown>;
+    healthBody?: Record<string, unknown>;
+    healthStatus?: number;
+    requests?: Array<{ headers: Headers; url: URL }>;
+  } = {},
+) {
+  return async (request: URL | RequestInfo, init?: RequestInit) => {
+    const url = new URL(String(request));
+    input.requests?.push({ headers: new Headers(init?.headers), url });
+    if (url.hostname === "api.vercel.com") {
+      return Response.json(input.deployment ?? deploymentFixture());
+    }
+    if (
+      url.origin === new URL(TARGET_URL).origin &&
+      url.pathname === "/api/ops/health" &&
+      url.search === ""
+    ) {
+      return Response.json(input.healthBody ?? { status: "healthy" }, {
+        status: input.healthStatus ?? 200,
+      });
+    }
+    throw new Error(`unexpected staged health request: ${url.toString()}`);
+  };
+}
+
+function stagedHealthInput(
+  fetchImpl: ReturnType<typeof stagedFetch>,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    targetUrl: TARGET_URL,
+    expectedDeploymentId: DEPLOYMENT_ID,
+    expectedGitHead: GIT_HEAD,
+    token: TOKEN,
+    teamId: TEAM_ID,
+    projectId: PROJECT_ID,
+    automationBypassSecret: AUTOMATION_BYPASS_SECRET,
+    fetchImpl,
+    ...overrides,
+  };
+}
+
+describe("staged health handoff runtime", () => {
+  it("accepts only the exact healthy staged deployment binding", async () => {
+    const requests: Array<{ headers: Headers; url: URL }> = [];
+    const result = await verifyStagedHealth(
+      stagedHealthInput(stagedFetch({ requests })),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.checks.map(({ id }: { id: string }) => id)).toEqual([
+      "staged-health-deployment-id",
+      "staged-health-deployment-url",
+      "staged-health-deployment-project",
+      "staged-health-deployment-ready",
+      "staged-health-deployment-commit",
+      "staged-health-response",
+    ]);
+    const healthRequest = requests.find(
+      ({ url }) => url.hostname !== "api.vercel.com",
+    );
+    expect(healthRequest?.url.toString()).toBe(
+      `${new URL(TARGET_URL).origin}/api/ops/health`,
+    );
+    expect(healthRequest?.headers.get("x-vercel-protection-bypass")).toBe(
+      AUTOMATION_BYPASS_SECRET,
+    );
+    const vercelRequest = requests.find(
+      ({ url }) => url.hostname === "api.vercel.com",
+    );
+    expect(vercelRequest?.headers.get("authorization")).toBe(`Bearer ${TOKEN}`);
+    expect(vercelRequest?.url.searchParams.get("teamId")).toBe(TEAM_ID);
+  });
+
+  it.each([
+    [
+      "deployment id",
+      { id: "dpl_cccccccccccccccccccccccc" },
+      "staged-health-deployment-id",
+    ],
+    [
+      "deployment origin",
+      { url: "another-candidate.vercel.app" },
+      "staged-health-deployment-url",
+    ],
+    [
+      "project",
+      { projectId: "prj_another_project" },
+      "staged-health-deployment-project",
+    ],
+    ["READY state", { readyState: "ERROR" }, "staged-health-deployment-ready"],
+    [
+      "Git commit",
+      { meta: { githubCommitSha: "c".repeat(40) } },
+      "staged-health-deployment-commit",
+    ],
+  ])("fails closed on a mismatched %s", async (_label, mutation, failureId) => {
+    const result = await verifyStagedHealth(
+      stagedHealthInput(
+        stagedFetch({ deployment: deploymentFixture(mutation) }),
+      ),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: failureId }),
+    );
+  });
+
+  it.each([
+    ["unhealthy body", 200, { status: "degraded" }],
+    ["failed HTTP response", 503, { status: "healthy" }],
+  ])("fails closed on %s", async (_label, healthStatus, healthBody) => {
+    const result = await verifyStagedHealth(
+      stagedHealthInput(stagedFetch({ healthBody, healthStatus })),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ id: "staged-health-response" }),
+    );
+  });
+
+  it("rejects a non-deployment origin and an unavailable bypass secret", async () => {
+    await expect(
+      verifyStagedHealth(
+        stagedHealthInput(stagedFetch(), {
+          targetUrl: "https://programmable.market/",
+        }),
+      ),
+    ).rejects.toThrow("exact Vercel origin");
+    await expect(
+      verifyStagedHealth(
+        stagedHealthInput(stagedFetch(), {
+          automationBypassSecret: "too-short",
+        }),
+      ),
+    ).rejects.toThrow("exact staged deployment and health credentials");
+  });
+});
+
+describe("staged health handoff source contract", () => {
+  it("rejects any unreviewed staged health verifier bytes", () => {
+    const path = "scripts/perf/read-model-staged-health.mjs";
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: `${source}\n// unreviewed drift\n` },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-staged-health-handoff-gate",
+    );
+  });
+
+  it.each(
+    (STAGED_HEALTH_HANDOFF_SOURCE_GUARDS as readonly string[]).map(
+      (needle, index) => [index, needle] as const,
+    ),
+  )("mutation %i removes required staged health guard %s", (_index, needle) => {
+    const path = "scripts/perf/read-model-staged-health.mjs";
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    expect(source).toContain(needle);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        [path]: source.split(needle).join("MUTATED_STAGED_HEALTH_GUARD"),
+      },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-staged-health-handoff-gate",
+    );
+  });
+
+  it("fails when the workflow drops exact Git binding from the pre-handoff health gate", () => {
+    const path = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, path), "utf8");
+    const stepStart = workflow.indexOf(
+      "      - name: Gate exact staged operational health",
+    );
+    const stepEnd = workflow.indexOf(
+      "      - name: Record staged candidate handoff",
+    );
+    expect(stepStart).toBeGreaterThanOrEqual(0);
+    expect(stepEnd).toBeGreaterThan(stepStart);
+    const step = workflow.slice(stepStart, stepEnd);
+    const unsafeStep = step.replace(
+      "          EXPECTED_GIT_HEAD: ${{ github.sha }}\n",
+      "",
+    );
+    expect(unsafeStep).not.toBe(step);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        [path]:
+          workflow.slice(0, stepStart) + unsafeStep + workflow.slice(stepEnd),
+      },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-staged-health-handoff-gate",
+    );
+  });
+
+  it("fails when the staged health gate is conditional", () => {
+    const path = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, path), "utf8");
+    const conditional = workflow.replace(
+      "      - name: Gate exact staged operational health\n        env:\n",
+      "      - name: Gate exact staged operational health\n        if: false\n        env:\n",
+    );
+    expect(conditional).not.toBe(workflow);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: conditional },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-staged-health-handoff-gate",
+    );
+  });
+});

--- a/tests/data-pipeline/read-model-staged-health.test.ts
+++ b/tests/data-pipeline/read-model-staged-health.test.ts
@@ -107,6 +107,10 @@ describe("staged health handoff runtime", () => {
     );
     expect(vercelRequest?.headers.get("authorization")).toBe(`Bearer ${TOKEN}`);
     expect(vercelRequest?.url.searchParams.get("teamId")).toBe(TEAM_ID);
+    expect(requests.map(({ url }) => url.hostname)).toEqual([
+      "api.vercel.com",
+      new URL(TARGET_URL).hostname,
+    ]);
   });
 
   it.each([
@@ -132,15 +136,24 @@ describe("staged health handoff runtime", () => {
       "staged-health-deployment-commit",
     ],
   ])("fails closed on a mismatched %s", async (_label, mutation, failureId) => {
+    const requests: Array<{ headers: Headers; url: URL }> = [];
     const result = await verifyStagedHealth(
       stagedHealthInput(
-        stagedFetch({ deployment: deploymentFixture(mutation) }),
+        stagedFetch({ deployment: deploymentFixture(mutation), requests }),
       ),
     );
     expect(result.ok).toBe(false);
     expect(result.failures).toContainEqual(
       expect.objectContaining({ id: failureId }),
     );
+    expect(requests.map(({ url }) => url.hostname)).toEqual(["api.vercel.com"]);
+    expect(
+      requests.some(
+        ({ headers }) =>
+          headers.get("x-vercel-protection-bypass") ===
+          AUTOMATION_BYPASS_SECRET,
+      ),
+    ).toBe(false);
   });
 
   it.each([

--- a/tests/data-pipeline/read-model-staged-health.test.ts
+++ b/tests/data-pipeline/read-model-staged-health.test.ts
@@ -247,4 +247,98 @@ describe("staged health handoff source contract", () => {
       "ops-staged-health-handoff-gate",
     );
   });
+
+  it.each([
+    [
+      "continues on error",
+      (workflow: string) =>
+        workflow.replace(
+          "      - name: Gate exact staged operational health\n        env:\n",
+          "      - name: Gate exact staged operational health\n        continue-on-error: true\n        env:\n",
+        ),
+    ],
+    [
+      "masks the command with OR true",
+      (workflow: string) =>
+        workflow.replace(
+          '          --git-head "$EXPECTED_GIT_HEAD"\n',
+          '          --git-head "$EXPECTED_GIT_HEAD" || true\n',
+        ),
+    ],
+    [
+      "masks the command with a successful final command",
+      (workflow: string) =>
+        workflow.replace(
+          '          --git-head "$EXPECTED_GIT_HEAD"\n',
+          '          --git-head "$EXPECTED_GIT_HEAD"; true\n',
+        ),
+    ],
+    [
+      "changes an exact environment binding",
+      (workflow: string) =>
+        workflow.replace(
+          "          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
+          "          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.deployment_id }}",
+        ),
+    ],
+    [
+      "reorders the exact environment",
+      (workflow: string) =>
+        workflow.replace(
+          [
+            "          STAGED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}",
+            "          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
+          ].join("\n"),
+          [
+            "          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}",
+            "          STAGED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}",
+          ].join("\n"),
+        ),
+    ],
+    [
+      "reorders the exact arguments",
+      (workflow: string) =>
+        workflow.replace(
+          [
+            '          --target-url "$STAGED_TARGET_URL"',
+            '          --deployment-id "$STAGED_DEPLOYMENT_ID"',
+          ].join("\n"),
+          [
+            '          --deployment-id "$STAGED_DEPLOYMENT_ID"',
+            '          --target-url "$STAGED_TARGET_URL"',
+          ].join("\n"),
+        ),
+    ],
+    [
+      "changes an exact argument binding",
+      (workflow: string) =>
+        workflow.replace(
+          '          --git-head "$EXPECTED_GIT_HEAD"',
+          '          --git-head "$STAGED_DEPLOYMENT_ID"',
+        ),
+    ],
+  ] as const)("fails when the workflow %s", (_label, mutate) => {
+    const path = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, path), "utf8");
+    const stepStart = workflow.indexOf(
+      "      - name: Gate exact staged operational health",
+    );
+    const stepEnd = workflow.indexOf(
+      "      - name: Record staged candidate handoff",
+    );
+    expect(stepStart).toBeGreaterThanOrEqual(0);
+    expect(stepEnd).toBeGreaterThan(stepStart);
+    const step = workflow.slice(stepStart, stepEnd);
+    const unsafeStep = mutate(step);
+    expect(unsafeStep).not.toBe(step);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        [path]:
+          workflow.slice(0, stepStart) + unsafeStep + workflow.slice(stepEnd),
+      },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-staged-health-handoff-gate",
+    );
+  });
 });

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   hydrateMissingCanonicalTokenSupplyV1: vi.fn(),
   attachBitqueryMarketDataToValuedEntries: vi.fn(),
   valueExploreEntriesWithCurrentEvidence: vi.fn(),
+  valueExploreEntriesWithCurrentEvidenceSnapshot: vi.fn(),
   settleCurrentEvidenceSnapshot: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
 }));
@@ -90,6 +91,8 @@ vi.mock("../lib/market-data/current-valuation.server", () => ({
   settleCurrentEvidenceSnapshot: mocks.settleCurrentEvidenceSnapshot,
   valueExploreEntriesWithCurrentEvidence:
     mocks.valueExploreEntriesWithCurrentEvidence,
+  valueExploreEntriesWithCurrentEvidenceSnapshot:
+    mocks.valueExploreEntriesWithCurrentEvidenceSnapshot,
 }));
 
 import {
@@ -195,6 +198,57 @@ const snapshot = {
   blockHash: `0x${"55".repeat(32)}` as const,
   confirmations: 12,
 };
+const liquiditySnapshot = {
+  chainId: 1 as const,
+  blockNumber: "25629999",
+  blockHash: `0x${"44".repeat(32)}` as const,
+};
+
+type ValuationSnapshotBody = Readonly<{
+  schemaVersion: "programmable.explore-valuation-snapshot.v1";
+  chainId: 1;
+  blockNumber: string;
+  blockHash: string;
+  liquidityBlockNumber: string;
+  liquidityBlockHash: string;
+  rankingCommitment: string;
+  sort: "market-cap" | "market-cap-asc";
+  query: string;
+  socials: "yes" | "no" | null;
+  pageSize: number;
+}>;
+
+function valuationReplayQuery(
+  valuationSnapshot: ValuationSnapshotBody,
+  input: Readonly<{ page: number; limit: number; sort?: string }>,
+) {
+  return new URLSearchParams({
+    sort: input.sort ?? valuationSnapshot.sort,
+    page: String(input.page),
+    limit: String(input.limit),
+    valuationBlock: valuationSnapshot.blockNumber,
+    valuationBlockHash: valuationSnapshot.blockHash,
+    liquidityBlock: valuationSnapshot.liquidityBlockNumber,
+    liquidityBlockHash: valuationSnapshot.liquidityBlockHash,
+    rankingCommitment: valuationSnapshot.rankingCommitment,
+  }).toString();
+}
+
+function fixedValuationReplayQuery(
+  overrides: Readonly<Record<string, string>> = {},
+) {
+  return new URLSearchParams({
+    sort: "market-cap",
+    page: "2",
+    limit: "10",
+    valuationBlock: snapshot.blockNumber,
+    valuationBlockHash: snapshot.blockHash,
+    liquidityBlock: liquiditySnapshot.blockNumber,
+    liquidityBlockHash: liquiditySnapshot.blockHash,
+    rankingCommitment: `sha256:${"aa".repeat(32)}`,
+    ...overrides,
+  }).toString();
+}
 
 function readyModel(): ExploreReadModel {
   return {
@@ -275,7 +329,18 @@ describe("Explore API Bitquery market boundary", () => {
       rpcUrl: "https://current-primary.example",
       rpcUrlSecondary: "https://current-secondary.example",
     });
-    mocks.readVerifiedOperationalMarketSnapshot.mockResolvedValue(snapshot);
+    mocks.readVerifiedOperationalMarketSnapshot.mockImplementation(
+      async (_deployment, expected?: {
+        blockNumber: string;
+        blockHash: `0x${string}`;
+      }) => expected
+        ? {
+            ...snapshot,
+            blockNumber: expected.blockNumber,
+            blockHash: expected.blockHash,
+          }
+        : snapshot,
+    );
     mocks.settleCurrentEvidenceSnapshot.mockImplementation(
       async ({
         read,
@@ -383,6 +448,17 @@ describe("Explore API Bitquery market boundary", () => {
               };
         });
       },
+    );
+    mocks.valueExploreEntriesWithCurrentEvidenceSnapshot.mockImplementation(
+      async (input: Parameters<
+        typeof mocks.valueExploreEntriesWithCurrentEvidence
+      >[0]) => ({
+        entries: await mocks.valueExploreEntriesWithCurrentEvidence({
+          ...input,
+          requireCompleteLiquidityCoverage: true,
+        }),
+        liquiditySnapshot: input.liquiditySnapshot ?? liquiditySnapshot,
+      }),
     );
   });
 
@@ -642,6 +718,9 @@ describe("Explore API Bitquery market boundary", () => {
     "q=token&q=other",
     "sort=newest&extra=1",
     "socials=maybe",
+    "page=02",
+    "page=0",
+    "limit=00",
   ])("rejects non-canonical query shapes before identity or market reads: %s", async (query) => {
     const response = await GET(
       new NextRequest(`http://localhost/api/explore?${query}`),
@@ -649,6 +728,33 @@ describe("Explore API Bitquery market boundary", () => {
 
     expect(response.status).toBe(400);
     expect(mocks.readAlchemyExploreModel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    `sort=market-cap&page=2&valuationBlock=${snapshot.blockNumber}`,
+    `sort=market-cap&page=2&valuationBlockHash=${snapshot.blockHash}`,
+    `sort=market-cap&page=2&rankingCommitment=sha256:${"aa".repeat(32)}`,
+    `sort=market-cap&page=1&valuationBlock=${snapshot.blockNumber}` +
+      `&valuationBlockHash=${snapshot.blockHash}` +
+      `&rankingCommitment=sha256:${"aa".repeat(32)}`,
+    `sort=newest&page=2&valuationBlock=${snapshot.blockNumber}` +
+      `&valuationBlockHash=${snapshot.blockHash}` +
+      `&rankingCommitment=sha256:${"aa".repeat(32)}`,
+    fixedValuationReplayQuery({ valuationBlock: "1".repeat(79) }),
+    fixedValuationReplayQuery({ liquidityBlock: "2147483648" }),
+    fixedValuationReplayQuery({
+      liquidityBlock: "none",
+      liquidityBlockHash: liquiditySnapshot.blockHash,
+    }),
+  ])("rejects incomplete or inapplicable valuation snapshots: %s", async (query) => {
+    const response = await GET(
+      new NextRequest(`http://localhost/api/explore?${query}`),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mocks.readAlchemyExploreModel).not.toHaveBeenCalled();
+    expect(mocks.readVerifiedOperationalMarketSnapshot).not.toHaveBeenCalled();
   });
 
   it("fails closed when the canonical source and durable fallback are unavailable", async () => {
@@ -717,6 +823,7 @@ describe("Explore API Bitquery market boundary", () => {
         rpcUrl: "https://current-primary.example",
         rpcUrlSecondary: "https://current-secondary.example",
       }),
+      undefined,
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(mocks.valueExploreEntriesWithCurrentEvidence).toHaveBeenCalledWith(
@@ -735,6 +842,19 @@ describe("Explore API Bitquery market boundary", () => {
       totalPages: 1,
       sort: "market-cap",
       sortMetric: "fdv",
+      valuationSnapshot: {
+        schemaVersion: "programmable.explore-valuation-snapshot.v1",
+        chainId: 1,
+        blockNumber: snapshot.blockNumber,
+        blockHash: snapshot.blockHash,
+        liquidityBlockNumber: liquiditySnapshot.blockNumber,
+        liquidityBlockHash: liquiditySnapshot.blockHash,
+        rankingCommitment: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+        sort: "market-cap",
+        query: "",
+        socials: null,
+        pageSize: 100,
+      },
       dataQuality: {
         schemaVersion: "programmable.explore-data-quality.v1",
         status: "complete",
@@ -811,6 +931,259 @@ describe("Explore API Bitquery market boundary", () => {
     expect(
       mocks.readBitqueryTokenMarketDataV1.mock.calls[0]?.[0],
     ).toHaveLength(30);
+  });
+
+  it("replays later market-cap pages against the exact first-page ranking", async () => {
+    const firstResponse = await GET(new NextRequest(
+      "http://localhost/api/explore?sort=market-cap&page=1&limit=10",
+    ));
+    const firstBody = await firstResponse.json();
+    const valuationSnapshot = firstBody.valuationSnapshot as
+      ValuationSnapshotBody;
+
+    const secondResponse = await GET(new NextRequest(
+      `http://localhost/api/explore?${valuationReplayQuery(
+        valuationSnapshot,
+        { page: 2, limit: 10 },
+      )}`,
+    ));
+    const secondBody = await secondResponse.json();
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(secondBody).toMatchObject({
+      page: 2,
+      total: 30,
+      totalPages: 3,
+      valuationSnapshot,
+    });
+    expect(mocks.readVerifiedOperationalMarketSnapshot).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rpcUrl: "https://current-primary.example",
+        rpcUrlSecondary: "https://current-secondary.example",
+      }),
+      {
+        blockNumber: valuationSnapshot.blockNumber,
+        blockHash: valuationSnapshot.blockHash,
+      },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(mocks.hydrateMissingCanonicalTokenSupplyV1).toHaveBeenLastCalledWith(
+      expect.any(Array),
+      {
+        deployment: expect.objectContaining({
+          rpcUrl: "https://current-primary.example",
+          rpcUrlSecondary: "https://current-secondary.example",
+        }),
+        snapshot: {
+          blockNumber: valuationSnapshot.blockNumber,
+          blockHash: valuationSnapshot.blockHash,
+        },
+      },
+    );
+    const ids = [...firstBody.tokens, ...secondBody.tokens].map(
+      (entry: { id: string }) => entry.id,
+    );
+    expect(new Set(ids).size).toBe(20);
+  });
+
+  it("returns and replays the explicit-none liquidity mode", async () => {
+    mocks.valueExploreEntriesWithCurrentEvidenceSnapshot.mockImplementation(
+      async (input: Parameters<
+        typeof mocks.valueExploreEntriesWithCurrentEvidence
+      >[0]) => ({
+        entries: await mocks.valueExploreEntriesWithCurrentEvidence({
+          ...input,
+          requireCompleteLiquidityCoverage: true,
+        }),
+        liquiditySnapshot: input.liquiditySnapshot ?? {
+          chainId: 1,
+          blockNumber: "none",
+          blockHash: "none",
+        },
+      }),
+    );
+    const firstResponse = await GET(new NextRequest(
+      "http://localhost/api/explore?sort=market-cap&page=1&limit=10",
+    ));
+    const firstBody = await firstResponse.json();
+    const valuationSnapshot = firstBody.valuationSnapshot as
+      ValuationSnapshotBody;
+    const secondResponse = await GET(new NextRequest(
+      `http://localhost/api/explore?${valuationReplayQuery(
+        valuationSnapshot,
+        { page: 2, limit: 10 },
+      )}`,
+    ));
+    const secondBody = await secondResponse.json();
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(valuationSnapshot).toMatchObject({
+      liquidityBlockNumber: "none",
+      liquidityBlockHash: "none",
+    });
+    expect(secondBody.valuationSnapshot).toEqual(valuationSnapshot);
+    expect(
+      mocks.valueExploreEntriesWithCurrentEvidenceSnapshot.mock.calls[1]?.[0],
+    ).toMatchObject({
+      liquiditySnapshot: {
+        chainId: 1,
+        blockNumber: "none",
+        blockHash: "none",
+      },
+    });
+  });
+
+  it.each([
+    ["adds", (tokens: LauncherToken[]) => [...tokens, token(31)]],
+    ["removes", (tokens: LauncherToken[]) => tokens.slice(0, -1)],
+    ["changes", (tokens: LauncherToken[]) => tokens.map((entry, index) =>
+      index === 0
+        ? { ...entry, launchedAt: "2026-08-01T12:34:56.000Z" }
+        : entry)],
+  ] as const)("fails closed before Bitquery when identity projection %s", async (
+    _label,
+    mutate,
+  ) => {
+    const firstResponse = await GET(new NextRequest(
+      "http://localhost/api/explore?sort=market-cap&page=1&limit=10",
+    ));
+    const firstBody = await firstResponse.json();
+    const valuationSnapshot = firstBody.valuationSnapshot as
+      ValuationSnapshotBody;
+    const nextModel = readyModel();
+    mocks.readAlchemyExploreModel.mockResolvedValue({
+      ...nextModel,
+      tokens: mutate([...nextModel.tokens]),
+    });
+    mocks.readBitqueryTokenMarketDataV1.mockClear();
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore?${valuationReplayQuery(
+        valuationSnapshot,
+        { page: 2, limit: 10 },
+      )}`,
+    ));
+
+    expect(firstResponse.status).toBe(200);
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mocks.readBitqueryTokenMarketDataV1).not.toHaveBeenCalled();
+  });
+
+  it("rejects a replay page beyond the recomputed snapshot before Bitquery", async () => {
+    const firstResponse = await GET(new NextRequest(
+      "http://localhost/api/explore?sort=market-cap&page=1&limit=10",
+    ));
+    const firstBody = await firstResponse.json();
+    const valuationSnapshot = firstBody.valuationSnapshot as
+      ValuationSnapshotBody;
+    mocks.readBitqueryTokenMarketDataV1.mockClear();
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore?${valuationReplayQuery(
+        valuationSnapshot,
+        { page: 4, limit: 10 },
+      )}`,
+    ));
+
+    expect(firstResponse.status).toBe(200);
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mocks.readBitqueryTokenMarketDataV1).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["block hash", { blockHash: `0x${"66".repeat(32)}` }],
+    ["block number", { blockNumber: "25629999" }],
+    ["liquidity block hash", {
+      liquidityBlockHash: `0x${"77".repeat(32)}`,
+    }],
+    ["liquidity block number", { liquidityBlockNumber: "25629998" }],
+    ["ranking commitment", {
+      rankingCommitment: `sha256:${"aa".repeat(32)}`,
+    }],
+  ] as const)("fails closed when replay %s is mutated", async (_label, mutation) => {
+    const firstResponse = await GET(new NextRequest(
+      "http://localhost/api/explore?sort=market-cap&page=1&limit=10",
+    ));
+    const firstBody = await firstResponse.json();
+    const valuationSnapshot = {
+      ...(firstBody.valuationSnapshot as ValuationSnapshotBody),
+      ...mutation,
+    };
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore?${valuationReplayQuery(
+        valuationSnapshot,
+        { page: 2, limit: 10 },
+      )}`,
+    ));
+
+    expect(firstResponse.status).toBe(200);
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("fails closed when an otherwise valid replay snapshot is no longer available", async () => {
+    const firstResponse = await GET(new NextRequest(
+      "http://localhost/api/explore?sort=market-cap&page=1&limit=10",
+    ));
+    const firstBody = await firstResponse.json();
+    const valuationSnapshot = firstBody.valuationSnapshot as
+      ValuationSnapshotBody;
+    mocks.readVerifiedOperationalMarketSnapshot.mockImplementationOnce(
+      async () => null,
+    );
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore?${valuationReplayQuery(
+        valuationSnapshot,
+        { page: 2, limit: 10 },
+      )}`,
+    ));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("keeps a 125-token market-cap traversal complete and duplicate-free", async () => {
+    mocks.readAlchemyExploreModel.mockResolvedValue({
+      ...readyModel(),
+      tokens: Array.from({ length: 125 }, (_, index) => ({
+        ...token(index + 1),
+        launchedAt: new Date(Date.UTC(2026, 6, 1, 0, 0, index)).toISOString(),
+      })),
+    });
+    const firstResponse = await GET(new NextRequest(
+      "http://localhost/api/explore?sort=market-cap&page=1&limit=100",
+    ));
+    const firstBody = await firstResponse.json();
+    const valuationSnapshot = firstBody.valuationSnapshot as
+      ValuationSnapshotBody;
+    const secondResponse = await GET(new NextRequest(
+      `http://localhost/api/explore?${valuationReplayQuery(
+        valuationSnapshot,
+        { page: 2, limit: 100 },
+      )}`,
+    ));
+    const secondBody = await secondResponse.json();
+    const symbols = [...firstBody.tokens, ...secondBody.tokens].map(
+      (entry: LauncherToken) => entry.symbol,
+    );
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(firstBody).toMatchObject({ page: 1, total: 125, totalPages: 2 });
+    expect(secondBody).toMatchObject({ page: 2, total: 125, totalPages: 2 });
+    expect(symbols).toEqual(
+      Array.from({ length: 125 }, (_, index) => `T${125 - index}`),
+    );
+    expect(new Set(symbols).size).toBe(125);
+    expect(mocks.readBitqueryTokenMarketDataV1.mock.calls.map(
+      ([identities]) => identities.length,
+    )).toEqual([100, 25]);
   });
 
   it("sorts global current evidence before reading Bitquery for only the page", async () => {
@@ -1196,7 +1569,6 @@ describe("Explore API Bitquery market boundary", () => {
   });
 
   it.each([
-    ["lowest FDV", "sort=lowest-market-cap&page=3&limit=10"],
     ["social filter", "socials=yes&page=3&limit=10"],
     ["search", "q=token&page=3&limit=10"],
   ])("keeps all matching tokens paginated for %s", async (_label, query) => {
@@ -1218,6 +1590,40 @@ describe("Explore API Bitquery market boundary", () => {
       "operational+durable+postgres",
     );
     expect(response.headers.get("X-Programmable-Rpc-Provider")).toBeNull();
+    expect(response.headers.get("X-Programmable-Price-Source")).toBe(
+      "bitquery",
+    );
+  });
+
+  it("keeps all matching tokens paginated for lowest FDV with snapshot replay", async () => {
+    const firstResponse = await GET(new NextRequest(
+      "http://localhost/api/explore?sort=lowest-market-cap&page=1&limit=10",
+    ));
+    const firstBody = await firstResponse.json();
+    const valuationSnapshot = firstBody.valuationSnapshot as
+      ValuationSnapshotBody;
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore?${valuationReplayQuery(
+        valuationSnapshot,
+        { page: 3, limit: 10, sort: "market-cap-asc" },
+      )}`,
+    ));
+    const body = await response.json();
+
+    expect(firstResponse.status).toBe(200);
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "ready",
+      page: 3,
+      pageSize: 10,
+      total: 30,
+      totalPages: 3,
+      valuationSnapshot,
+    });
+    expect(body.tokens).toHaveLength(10);
+    expect(response.headers.get("X-Programmable-Read-Source")).toBe(
+      "operational+durable+postgres",
+    );
     expect(response.headers.get("X-Programmable-Price-Source")).toBe(
       "bitquery",
     );

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -12,6 +12,7 @@ import {
   getExplorePaginationItems,
   getExploreValuationMetric,
   loadExploreModelDataset,
+  loadExplorePageWithValuationSnapshot,
   loadExplorePayload,
   paginateTokensByExploreFilters,
   paginateTokensBySocialPresence,
@@ -103,9 +104,38 @@ const payload = {
   tokens: [],
   page: 1,
   pageSize: 9,
-  total: 1,
-  totalPages: 1,
+  total: 18,
+  totalPages: 2,
 };
+
+function valuationSnapshot(
+  overrides: Partial<{
+    blockNumber: string;
+    blockHash: `0x${string}`;
+    liquidityBlockNumber: string;
+    liquidityBlockHash: `0x${string}` | "none";
+    rankingCommitment: `sha256:${string}`;
+    sort: "market-cap" | "market-cap-asc";
+    query: string;
+    socials: "yes" | "no" | null;
+    pageSize: number;
+  }> = {},
+) {
+  return {
+    schemaVersion: "programmable.explore-valuation-snapshot.v1" as const,
+    chainId: 1 as const,
+    blockNumber: "25740001",
+    blockHash: `0x${"11".repeat(32)}` as `0x${string}`,
+    liquidityBlockNumber: "25739999",
+    liquidityBlockHash: `0x${"22".repeat(32)}` as `0x${string}`,
+    rankingCommitment: `sha256:${"33".repeat(32)}` as `sha256:${string}`,
+    sort: "market-cap" as const,
+    query: "",
+    socials: null,
+    pageSize: EXPLORE_TOKENS_PER_PAGE,
+    ...overrides,
+  };
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -432,6 +462,615 @@ describe("Explore refresh state", () => {
     });
   });
 
+  it("never sends an unbound market-cap continuation request", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    await expect(loadExplorePayload(
+      "unbound-visible-market-page",
+      new URLSearchParams({
+        q: "",
+        sort: "market-cap",
+        page: "2",
+        limit: "9",
+      }),
+    )).rejects.toThrow("complete valuation snapshot");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("records page one and carries all five bindings through visible pagination", async () => {
+    const snapshot = valuationSnapshot({
+      sort: "market-cap-asc",
+      query: "ranked",
+      socials: "no",
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input), "https://example.test");
+        const page = Number(url.searchParams.get("page"));
+        if (page === 1) {
+          for (const parameter of [
+            "valuationBlock",
+            "valuationBlockHash",
+            "liquidityBlock",
+            "liquidityBlockHash",
+            "rankingCommitment",
+          ]) {
+            expect(url.searchParams.has(parameter)).toBe(false);
+          }
+        } else {
+          expect(page).toBe(12);
+          expect(url.searchParams.get("valuationBlock")).toBe(
+            snapshot.blockNumber,
+          );
+          expect(url.searchParams.get("valuationBlockHash")).toBe(
+            snapshot.blockHash,
+          );
+          expect(url.searchParams.get("liquidityBlock")).toBe(
+            snapshot.liquidityBlockNumber,
+          );
+          expect(url.searchParams.get("liquidityBlockHash")).toBe(
+            snapshot.liquidityBlockHash,
+          );
+          expect(url.searchParams.get("rankingCommitment")).toBe(
+            snapshot.rankingCommitment,
+          );
+        }
+        return new Response(JSON.stringify({
+          ...payload,
+          page,
+          total: 108,
+          totalPages: 12,
+          valuationSnapshot: snapshot,
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+    const firstSearch = new URLSearchParams({
+      q: "ranked",
+      sort: "market-cap-asc",
+      socials: "no",
+      page: "1",
+      limit: "9",
+    });
+    const first = await loadExplorePageWithValuationSnapshot(
+      "visible-ranked-page-one",
+      firstSearch,
+    );
+    const secondSearch = new URLSearchParams(firstSearch);
+    secondSearch.set("page", "12");
+    const twelfth = await loadExplorePageWithValuationSnapshot(
+      "visible-ranked-page-twelve",
+      secondSearch,
+      first.valuationSnapshot,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(twelfth.payload.page).toBe(12);
+    expect(twelfth.valuationSnapshot).toEqual(snapshot);
+  });
+
+  it("carries the exact paired none liquidity sentinel for zero-candidate rankings", async () => {
+    const snapshot = valuationSnapshot({
+      liquidityBlockNumber: "none",
+      liquidityBlockHash: "none",
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input), "https://example.test");
+        expect(url.searchParams.get("liquidityBlock")).toBe("none");
+        expect(url.searchParams.get("liquidityBlockHash")).toBe("none");
+        return new Response(JSON.stringify({
+          ...payload,
+          page: 2,
+          valuationSnapshot: snapshot,
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    const loaded = await loadExplorePageWithValuationSnapshot(
+      "zero-candidate-visible-page-two",
+      new URLSearchParams({
+        sort: "market-cap",
+        page: "2",
+        limit: "9",
+      }),
+      snapshot,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(loaded.valuationSnapshot).toEqual(snapshot);
+  });
+
+  it("canonicalizes market-cap aliases and the API page-size ceiling", async () => {
+    const snapshot = valuationSnapshot({ pageSize: 100 });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        ...payload,
+        pageSize: 100,
+        totalPages: 1,
+        valuationSnapshot: snapshot,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(loadExplorePayload(
+      "aliased-market-cap-clamped-page-size",
+      new URLSearchParams({
+        sort: "highest-market-cap",
+        page: "1",
+        limit: "999",
+      }),
+    )).resolves.toMatchObject({
+      pageSize: 100,
+      valuationSnapshot: snapshot,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("canonicalizes a deep market-cap continuation from its page-one snapshot", async () => {
+    const snapshot = valuationSnapshot({
+      query: "focused",
+      socials: "yes",
+      pageSize: 100,
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input), "https://example.test");
+        const page = Number(url.searchParams.get("page"));
+        if (page === 1) {
+          expect(url.searchParams.get("sort")).toBe("highest-market-cap");
+          expect(url.searchParams.get("q")).toBe("  focused  ");
+          expect(url.searchParams.get("limit")).toBe("999");
+        } else {
+          expect(url.searchParams.get("sort")).toBe("market-cap");
+          expect(url.searchParams.get("q")).toBe("focused");
+          expect(url.searchParams.get("socials")).toBe("yes");
+          expect(url.searchParams.get("limit")).toBe("100");
+          expect(url.searchParams.get("rankingCommitment")).toBe(
+            snapshot.rankingCommitment,
+          );
+        }
+        return new Response(JSON.stringify({
+          ...payload,
+          page,
+          pageSize: 100,
+          total: 200,
+          totalPages: 2,
+          valuationSnapshot: snapshot,
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    const loaded = await loadExplorePageWithValuationSnapshot(
+      "deep-canonical-continuation",
+      new URLSearchParams({
+        sort: "highest-market-cap",
+        q: "  focused  ",
+        socials: "yes",
+        page: "2",
+        limit: "999",
+      }),
+    );
+
+    expect(loaded.payload.page).toBe(2);
+    expect(loaded.valuationSnapshot).toEqual(snapshot);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("bootstraps a fresh page-one snapshot after refresh or filter drift", async () => {
+    const oldSnapshot = valuationSnapshot({
+      query: "old",
+      rankingCommitment: `sha256:${"44".repeat(32)}`,
+    });
+    const refreshedSnapshot = valuationSnapshot({
+      query: "fresh",
+      socials: "yes",
+      rankingCommitment: `sha256:${"55".repeat(32)}`,
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input), "https://example.test");
+        const page = Number(url.searchParams.get("page"));
+        if (page === 1) {
+          expect(url.searchParams.has("rankingCommitment")).toBe(false);
+        } else {
+          expect(url.searchParams.get("rankingCommitment")).toBe(
+            refreshedSnapshot.rankingCommitment,
+          );
+          expect(url.searchParams.get("rankingCommitment")).not.toBe(
+            oldSnapshot.rankingCommitment,
+          );
+        }
+        return new Response(JSON.stringify({
+          ...payload,
+          page,
+          total: 18,
+          totalPages: 2,
+          valuationSnapshot: refreshedSnapshot,
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    const loaded = await loadExplorePageWithValuationSnapshot(
+      "visible-refresh-filter-drift",
+      new URLSearchParams({
+        q: "fresh",
+        sort: "market-cap",
+        socials: "yes",
+        page: "2",
+        limit: "9",
+      }),
+      oldSnapshot,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(loaded.valuationSnapshot).toEqual(refreshedSnapshot);
+  });
+
+  it("binds every market-cap model page across more than one hundred results", async () => {
+    const tokens = Array.from({ length: 230 }, (_, index) => classicEntry({
+      id: `1:ranked-${index}`,
+      name: `Ranked ${index}`,
+      symbol: `R${index}`,
+      tokenAddress: `0x${(index + 1).toString(16).padStart(40, "0")}`,
+      hookAddress: "0x2222222222222222222222222222222222222222",
+      poolId: `0x${(index + 1).toString(16).padStart(64, "0")}`,
+      launchedAt: "2026-08-03T00:00:00.000Z",
+      totalSwapFeeBps: 100,
+      liquidityPath: "meme" as const,
+    } satisfies LauncherToken));
+    const snapshot = valuationSnapshot({
+      query: "ranked",
+      pageSize: EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
+    });
+    const totalPages = Math.ceil(
+      tokens.length / EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
+    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input), "https://example.test");
+        const page = Number(url.searchParams.get("page"));
+        const offset = (page - 1) * EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE;
+        if (page === 1) {
+          expect(url.searchParams.has("valuationBlock")).toBe(false);
+          expect(url.searchParams.has("liquidityBlock")).toBe(false);
+        } else {
+          expect(url.searchParams.get("valuationBlock")).toBe(
+            snapshot.blockNumber,
+          );
+          expect(url.searchParams.get("valuationBlockHash")).toBe(
+            snapshot.blockHash,
+          );
+          expect(url.searchParams.get("liquidityBlock")).toBe(
+            snapshot.liquidityBlockNumber,
+          );
+          expect(url.searchParams.get("liquidityBlockHash")).toBe(
+            snapshot.liquidityBlockHash,
+          );
+          expect(url.searchParams.get("rankingCommitment")).toBe(
+            snapshot.rankingCommitment,
+          );
+        }
+        return new Response(JSON.stringify({
+          status: "ready",
+          tokens: tokens.slice(
+            offset,
+            offset + EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
+          ),
+          page,
+          pageSize: EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
+          total: tokens.length,
+          totalPages,
+          valuationSnapshot: snapshot,
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    const dataset = await loadExploreModelDataset(
+      "complete-ranked-model-dataset",
+      new URLSearchParams({
+        q: "ranked",
+        sort: "market-cap",
+        page: "17",
+        limit: "9",
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(dataset.tokens.map((token) => token.id)).toEqual(
+      tokens.map((token) => token.id),
+    );
+    expect(dataset.valuationSnapshot).toEqual(snapshot);
+  });
+
+  it("rejects duplicate identities after traversing a multi-page model dataset", async () => {
+    const tokens = Array.from({ length: 101 }, (_, index) => customEntry(index));
+    const snapshot = valuationSnapshot({
+      pageSize: EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(String(input), "https://example.test");
+      const page = Number(url.searchParams.get("page"));
+      return new Response(JSON.stringify({
+        status: "ready",
+        tokens: page === 1 ? tokens.slice(0, 100) : [tokens[0]],
+        page,
+        pageSize: EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
+        total: tokens.length,
+        totalPages: 2,
+        valuationSnapshot: snapshot,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    await expect(loadExploreModelDataset(
+      "duplicate-ranked-model-dataset",
+      new URLSearchParams({
+        sort: "market-cap",
+        page: "1",
+        limit: "9",
+      }),
+    )).rejects.toThrow("repeated an entry");
+  });
+
+  it("scopes resolved page caches to all five continuation fields", async () => {
+    const firstSnapshot = valuationSnapshot();
+    const secondSnapshot = valuationSnapshot({
+      blockNumber: "25740002",
+      blockHash: `0x${"44".repeat(32)}`,
+      liquidityBlockNumber: "25740000",
+      liquidityBlockHash: `0x${"55".repeat(32)}`,
+      rankingCommitment: `sha256:${"66".repeat(32)}`,
+    });
+    const responses = [firstSnapshot, secondSnapshot];
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => {
+        const snapshot = responses.shift();
+        return new Response(JSON.stringify({
+          ...payload,
+          page: 2,
+          valuationSnapshot: snapshot,
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+    const continuationSearch = (
+      snapshot: ReturnType<typeof valuationSnapshot>,
+    ) => new URLSearchParams({
+      sort: "market-cap",
+      page: "2",
+      limit: "9",
+      valuationBlock: snapshot.blockNumber,
+      valuationBlockHash: snapshot.blockHash,
+      liquidityBlock: snapshot.liquidityBlockNumber,
+      liquidityBlockHash: snapshot.liquidityBlockHash,
+      rankingCommitment: snapshot.rankingCommitment,
+    });
+
+    await loadExplorePayload(
+      "same-content-different-continuation",
+      continuationSearch(firstSnapshot),
+    );
+    await loadExplorePayload(
+      "same-content-different-continuation",
+      continuationSearch(secondSnapshot),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects malformed, drifting, and non-market valuation snapshots", async () => {
+    const malformed = valuationSnapshot() as Record<string, unknown>;
+    delete malformed.liquidityBlockHash;
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        ...payload,
+        valuationSnapshot: malformed,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(loadExplorePayload(
+      "malformed-market-snapshot",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).rejects.toThrow("invalid valuation snapshot");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        ...payload,
+        valuationSnapshot: {
+          ...valuationSnapshot(),
+          extra: "not-canonical",
+        },
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(loadExplorePayload(
+      "extra-field-market-snapshot",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).rejects.toThrow("invalid valuation snapshot");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        ...payload,
+        valuationSnapshot: valuationSnapshot({
+          liquidityBlockNumber: "none",
+        }),
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(loadExplorePayload(
+      "mixed-none-market-snapshot",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).rejects.toThrow("invalid valuation snapshot");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        ...payload,
+        valuationSnapshot: valuationSnapshot(),
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(loadExplorePayload(
+      "snapshot-on-newest-sort",
+      new URLSearchParams({ sort: "newest", page: "1", limit: "9" }),
+    )).rejects.toThrow("unexpected valuation snapshot");
+
+    const requestedSnapshot = valuationSnapshot();
+    const changedSnapshot = valuationSnapshot({
+      rankingCommitment: `sha256:${"99".repeat(32)}`,
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        ...payload,
+        page: 2,
+        valuationSnapshot: changedSnapshot,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(loadExplorePayload(
+      "drifting-market-snapshot",
+      new URLSearchParams({
+        sort: "market-cap",
+        page: "2",
+        limit: "9",
+        valuationBlock: requestedSnapshot.blockNumber,
+        valuationBlockHash: requestedSnapshot.blockHash,
+        liquidityBlock: requestedSnapshot.liquidityBlockNumber,
+        liquidityBlockHash: requestedSnapshot.liquidityBlockHash,
+        rankingCommitment: requestedSnapshot.rankingCommitment,
+      }),
+    )).rejects.toThrow("changed the valuation snapshot");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        ...payload,
+        page: 3,
+        total: 27,
+        totalPages: 3,
+        valuationSnapshot: requestedSnapshot,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(loadExplorePayload(
+      "clamped-market-page",
+      new URLSearchParams({
+        sort: "market-cap",
+        page: "2",
+        limit: "9",
+        valuationBlock: requestedSnapshot.blockNumber,
+        valuationBlockHash: requestedSnapshot.blockHash,
+        liquidityBlock: requestedSnapshot.liquidityBlockNumber,
+        liquidityBlockHash: requestedSnapshot.liquidityBlockHash,
+        rankingCommitment: requestedSnapshot.rankingCommitment,
+      }),
+    )).rejects.toThrow("inconsistent valuation snapshot");
+  });
+
+  it.each([
+    ["page", { page: undefined }],
+    ["pageSize", { pageSize: undefined }],
+    ["total", { total: undefined }],
+    ["totalPages", { totalPages: undefined }],
+  ])("rejects a market-cap response missing raw %s", async (field, mutation) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        ...payload,
+        ...mutation,
+        valuationSnapshot: valuationSnapshot(),
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(loadExplorePayload(
+      `missing-market-${field}`,
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).rejects.toThrow("invalid pagination data");
+  });
+
+  it.each([
+    ["valuation block", { blockNumber: "1".repeat(79) }],
+    ["liquidity block", { liquidityBlockNumber: "2147483648" }],
+  ])("rejects an oversized response %s", async (field, snapshotMutation) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        ...payload,
+        valuationSnapshot: valuationSnapshot(snapshotMutation),
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(loadExplorePayload(
+      `oversized-market-${field}`,
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).rejects.toThrow("invalid valuation snapshot");
+  });
+
+  it.each([
+    ["valuation block", { valuationBlock: "1".repeat(79) }],
+    ["liquidity block", { liquidityBlock: "2147483648" }],
+  ])("rejects an oversized continuation %s before fetch", async (
+    _field,
+    continuationMutation,
+  ) => {
+    const requestedSnapshot = valuationSnapshot();
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const search = new URLSearchParams({
+      sort: "market-cap",
+      page: "2",
+      limit: "9",
+      valuationBlock: requestedSnapshot.blockNumber,
+      valuationBlockHash: requestedSnapshot.blockHash,
+      liquidityBlock: requestedSnapshot.liquidityBlockNumber,
+      liquidityBlockHash: requestedSnapshot.liquidityBlockHash,
+      rankingCommitment: requestedSnapshot.rankingCommitment,
+    });
+    for (const [key, value] of Object.entries(continuationMutation)) {
+      if (value !== undefined) search.set(key, value);
+    }
+
+    await expect(loadExplorePayload(
+      `oversized-market-continuation-${_field}`,
+      search,
+    )).rejects.toThrow("continuation is malformed");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("refreshes only visible Explore content after the freshness interval", () => {
     expect(EXPLORE_REFRESH_INTERVAL_MS).toBe(5_000);
     expect(
@@ -541,8 +1180,12 @@ describe("Explore refresh state", () => {
   });
 
   it("shares one in-flight request for repeated refreshes of the same content", async () => {
+    const marketPayload = {
+      ...payload,
+      valuationSnapshot: valuationSnapshot(),
+    };
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(payload), {
+      new Response(JSON.stringify(marketPayload), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),
@@ -558,7 +1201,7 @@ describe("Explore refresh state", () => {
     const second = loadExplorePayload("same-content-dedupe", search);
 
     expect(second).toBe(first);
-    await expect(first).resolves.toEqual(payload);
+    await expect(first).resolves.toEqual(marketPayload);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -294,6 +294,7 @@ describe("token detail Bitquery market read", () => {
         rpcUrl: "https://current-primary.example",
         rpcUrlSecondary: "https://current-secondary.example",
       }),
+      undefined,
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(mocks.valueExploreEntriesWithCurrentEvidence).toHaveBeenCalledWith(

--- a/tests/uniswap-v4-subgraph.test.ts
+++ b/tests/uniswap-v4-subgraph.test.ts
@@ -10,6 +10,7 @@ import {
   enrichExplorePageWithOfficialV4Subgraph,
   parseOfficialV4SubgraphResponse,
   readOfficialV4LiquidityEvidence,
+  readOfficialV4LiquidityEvidenceSnapshot,
 } from "../lib/onchain/uniswap-v4-subgraph";
 
 const POOL_ID =
@@ -19,6 +20,8 @@ const HOOK_ADDRESS = "0x3333333333333333333333333333333333333333" as const;
 const OFFICIAL_DEPLOYMENT = "QmZsgJLiLQKpb8hxTmQ5LWyrFVvfWzVaL4WK8dfFBn7EeK";
 const OFFICIAL_ENDPOINT =
   "https://gateway.thegraph.com/api/subgraphs/id/DiYPVdygkfjDWhbxGSqAQxwBKmfKnkWQojqeM2rkLb3G";
+const REFERENCE_BLOCK_NUMBER = "25630000";
+const REFERENCE_BLOCK_HASH = `0x${"44".repeat(32)}` as const;
 
 function canonicalToken(overrides: Partial<LauncherToken> = {}): LauncherToken {
   return {
@@ -99,6 +102,17 @@ function officialResponse(
       ],
     },
   };
+}
+
+function exactOfficialResponse(
+  indexedBlockTimestamp: number | string = 1_786_576_740,
+) {
+  const response = officialResponse(
+    REFERENCE_BLOCK_NUMBER,
+    indexedBlockTimestamp,
+  );
+  response.data._meta.block.hash = REFERENCE_BLOCK_HASH;
+  return response;
 }
 
 function officialPool(input: {
@@ -220,22 +234,44 @@ describe("official Uniswap v4 subgraph adapter", () => {
   it("returns current exact-pool TVL with independent provenance", async () => {
     const response = officialResponse();
     response.data.pools[0].totalValueLockedUSD = "12500.5";
-    const evidence = await readOfficialV4LiquidityEvidence(
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables: {
+          first: number;
+          poolIds: string[];
+        };
+      };
+      expect(request.query).not.toContain("$blockNumber");
+      expect(request.variables).toEqual({
+        first: 24,
+        poolIds: [POOL_ID],
+      });
+      return jsonResponse(response);
+    });
+    const result = await readOfficialV4LiquidityEvidenceSnapshot(
       {
         tokens: [canonicalToken()],
         referenceHead: {
           chainId: 1,
-          blockNumber: "25630000",
-          blockHash: `0x${"44".repeat(32)}`,
+          blockNumber: REFERENCE_BLOCK_NUMBER,
+          blockHash: REFERENCE_BLOCK_HASH,
         },
         now: new Date("2026-08-12T23:21:00.000Z"),
       },
       {
         apiKey: "graph-secret",
         endpoint: OFFICIAL_ENDPOINT,
-        fetcher: async () => jsonResponse(response),
+        fetcher,
       },
     );
+    const { evidence } = result;
+
+    expect(result.snapshot).toEqual({
+      chainId: 1,
+      blockNumber: "25629999",
+      blockHash: `0x${"55".repeat(32)}`,
+    });
 
     expect(evidence).toEqual([
       {
@@ -269,8 +305,8 @@ describe("official Uniswap v4 subgraph adapter", () => {
           indexedBlockHash: `0x${"55".repeat(32)}`,
           indexedBlockTimestamp: "1786576740",
           indexedBlockTime: "2026-08-12T23:19:00.000Z",
-          referenceHeadBlockNumber: "25630000",
-          referenceHeadBlockHash: `0x${"44".repeat(32)}`,
+          referenceHeadBlockNumber: REFERENCE_BLOCK_NUMBER,
+          referenceHeadBlockHash: REFERENCE_BLOCK_HASH,
           lagBlocks: "1",
         },
       },
@@ -295,8 +331,8 @@ describe("official Uniswap v4 subgraph adapter", () => {
         tokens: [canonicalToken()],
         referenceHead: {
           chainId: 1,
-          blockNumber: "25630000",
-          blockHash: `0x${"44".repeat(32)}`,
+          blockNumber: REFERENCE_BLOCK_NUMBER,
+          blockHash: REFERENCE_BLOCK_HASH,
         },
       },
       {
@@ -314,6 +350,306 @@ describe("official Uniswap v4 subgraph adapter", () => {
     expect(observedSignal?.aborted).toBe(true);
   });
 
+  it("pins an ahead latest pool read to the confirmed RPC reference head", async () => {
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables: { blockNumber?: number };
+      };
+      const response = request.variables.blockNumber === undefined
+        ? officialResponse(25_630_012)
+        : exactOfficialResponse();
+      response.data.pools[0].totalValueLockedUSD = "10000";
+      return jsonResponse(response);
+    });
+
+    const result = await readOfficialV4LiquidityEvidenceSnapshot(
+      {
+        tokens: [canonicalToken()],
+        referenceHead: {
+          chainId: 1,
+          blockNumber: REFERENCE_BLOCK_NUMBER,
+          blockHash: REFERENCE_BLOCK_HASH,
+        },
+        now: new Date("2026-08-12T23:21:00.000Z"),
+      },
+      {
+        apiKey: "graph-secret",
+        endpoint: OFFICIAL_ENDPOINT,
+        fetcher,
+      },
+    );
+
+    expect(result.snapshot).toEqual({
+      chainId: 1,
+      blockNumber: REFERENCE_BLOCK_NUMBER,
+      blockHash: REFERENCE_BLOCK_HASH,
+    });
+    expect(result.evidence).toHaveLength(1);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(
+      fetcher.mock.calls.map(
+        ([, init]) => JSON.parse(String(init?.body)).variables.blockNumber,
+      ),
+    ).toEqual([undefined, 25_630_000]);
+
+    const mismatchFetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        variables: { blockNumber?: number };
+      };
+      return jsonResponse(
+        request.variables.blockNumber === undefined
+          ? officialResponse(25_630_012)
+          : officialResponse(25_630_000),
+      );
+    });
+    await expect(
+      readOfficialV4LiquidityEvidenceSnapshot(
+        {
+          tokens: [canonicalToken()],
+          referenceHead: {
+            chainId: 1,
+            blockNumber: REFERENCE_BLOCK_NUMBER,
+            blockHash: REFERENCE_BLOCK_HASH,
+          },
+          now: new Date("2026-08-12T23:21:00.000Z"),
+        },
+        {
+          apiKey: "graph-secret",
+          endpoint: OFFICIAL_ENDPOINT,
+          fetcher: mismatchFetcher,
+        },
+      ),
+    ).rejects.toMatchObject({ code: "coverage-incomplete" });
+    expect(mismatchFetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("establishes and replays a Graph snapshot without liquidity pools", async () => {
+    const meta = officialResponse().data._meta;
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables: { blockNumber?: number };
+      };
+      expect(request.query).not.toContain("pools(");
+      if (fetcher.mock.calls.length === 1) {
+        expect(request.query).not.toContain("$blockNumber");
+        expect(request.variables).toEqual({});
+      } else {
+        expect(request.query).toContain(
+          "_meta(block: { number: $blockNumber })",
+        );
+        expect(request.variables).toEqual({ blockNumber: 25_629_999 });
+      }
+      return jsonResponse({ data: { _meta: meta } });
+    });
+    const options = {
+      apiKey: "graph-secret",
+      endpoint: OFFICIAL_ENDPOINT,
+      fetcher,
+    };
+    const first = await readOfficialV4LiquidityEvidenceSnapshot(
+      {
+        tokens: [],
+        referenceHead: {
+          chainId: 1,
+          blockNumber: REFERENCE_BLOCK_NUMBER,
+          blockHash: REFERENCE_BLOCK_HASH,
+        },
+        now: new Date("2026-08-12T23:21:00.000Z"),
+      },
+      options,
+    );
+    expect(first).toEqual({
+      evidence: [],
+      snapshot: {
+        chainId: 1,
+        blockNumber: "25629999",
+        blockHash: `0x${"55".repeat(32)}`,
+      },
+    });
+
+    await expect(
+      readOfficialV4LiquidityEvidenceSnapshot(
+        {
+          tokens: [],
+          referenceHead: {
+            chainId: 1,
+            blockNumber: REFERENCE_BLOCK_NUMBER,
+            blockHash: REFERENCE_BLOCK_HASH,
+          },
+          liquiditySnapshot: first.snapshot,
+          now: new Date("2026-08-12T23:21:00.000Z"),
+        },
+        options,
+      ),
+    ).resolves.toEqual(first);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    const legacyFetcher = vi.fn();
+    await expect(
+      readOfficialV4LiquidityEvidence(
+        {
+          tokens: [],
+          referenceHead: {
+            chainId: 1,
+            blockNumber: REFERENCE_BLOCK_NUMBER,
+            blockHash: REFERENCE_BLOCK_HASH,
+          },
+        },
+        { fetcher: legacyFetcher },
+      ),
+    ).resolves.toEqual([]);
+    expect(legacyFetcher).not.toHaveBeenCalled();
+  });
+
+  it("pins an ahead latest meta-only read to the confirmed RPC reference head", async () => {
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables: { blockNumber?: number };
+      };
+      expect(request.query).not.toContain("pools(");
+      const response = request.variables.blockNumber === undefined
+        ? officialResponse(25_630_012)
+        : exactOfficialResponse();
+      return jsonResponse({ data: { _meta: response.data._meta } });
+    });
+    const input = {
+      tokens: [],
+      referenceHead: {
+        chainId: 1 as const,
+        blockNumber: REFERENCE_BLOCK_NUMBER,
+        blockHash: REFERENCE_BLOCK_HASH,
+      },
+      now: new Date("2026-08-12T23:21:00.000Z"),
+    };
+    const options = {
+      apiKey: "graph-secret",
+      endpoint: OFFICIAL_ENDPOINT,
+      fetcher,
+    };
+
+    await expect(
+      readOfficialV4LiquidityEvidenceSnapshot(input, options),
+    ).resolves.toEqual({
+      evidence: [],
+      snapshot: {
+        chainId: 1,
+        blockNumber: REFERENCE_BLOCK_NUMBER,
+        blockHash: REFERENCE_BLOCK_HASH,
+      },
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    const mismatchFetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        variables: { blockNumber?: number };
+      };
+      const response = request.variables.blockNumber === undefined
+        ? officialResponse(25_630_012)
+        : officialResponse(25_630_000);
+      return jsonResponse({ data: { _meta: response.data._meta } });
+    });
+    await expect(
+      readOfficialV4LiquidityEvidenceSnapshot(input, {
+        ...options,
+        fetcher: mismatchFetcher,
+      }),
+    ).rejects.toMatchObject({ code: "coverage-incomplete" });
+    expect(mismatchFetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse liquidity evidence cache entries across exact snapshots", async () => {
+    const firstHash = `0x${"55".repeat(32)}` as const;
+    const secondHash = `0x${"66".repeat(32)}` as const;
+    const thirdHash = `0x${"77".repeat(32)}` as const;
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables: { blockNumber: number };
+      };
+      expect(
+        request.query.match(/block: \{ number: \$blockNumber \}/g),
+      ).toHaveLength(2);
+      expect(request.query).toContain("$blockNumber: Int!");
+      const call = fetcher.mock.calls.length;
+      const response = officialResponse(request.variables.blockNumber);
+      response.data._meta.block.hash =
+        call === 1 ? firstHash : call === 2 ? secondHash : thirdHash;
+      response.data.pools[0].totalValueLockedUSD = "10000";
+      return jsonResponse(response);
+    });
+    const read = (blockNumber: string, blockHash: `0x${string}`) =>
+      readOfficialV4LiquidityEvidenceSnapshot(
+        {
+          tokens: [canonicalToken()],
+          referenceHead: {
+            chainId: 1,
+            blockNumber: REFERENCE_BLOCK_NUMBER,
+            blockHash: REFERENCE_BLOCK_HASH,
+          },
+          liquiditySnapshot: { chainId: 1, blockNumber, blockHash },
+          now: new Date("2026-08-12T23:21:00.000Z"),
+        },
+        {
+          apiKey: "graph-secret",
+          endpoint: OFFICIAL_ENDPOINT,
+          fetcher,
+        },
+      );
+
+    await expect(
+      read("25629999", firstHash),
+    ).resolves.toMatchObject({ evidence: [{}] });
+    await expect(
+      read("25629999", secondHash),
+    ).resolves.toMatchObject({ evidence: [{}] });
+    await expect(read("25629998", thirdHash)).resolves.toMatchObject({
+      evidence: [{}],
+    });
+    await expect(
+      read("25629999", firstHash),
+    ).resolves.toMatchObject({ evidence: [{}] });
+
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(
+      fetcher.mock.calls.map(
+        ([, init]) => JSON.parse(String(init?.body)).variables.blockNumber,
+      ),
+    ).toEqual([25_629_999, 25_629_999, 25_629_998]);
+
+    const mismatchFetcher = vi.fn(async () => {
+      const response = officialResponse(25_629_999);
+      response.data._meta.block.hash = secondHash;
+      response.data.pools[0].totalValueLockedUSD = "10000";
+      return jsonResponse(response);
+    });
+    await expect(
+      readOfficialV4LiquidityEvidenceSnapshot(
+        {
+          tokens: [canonicalToken()],
+          referenceHead: {
+            chainId: 1,
+            blockNumber: REFERENCE_BLOCK_NUMBER,
+            blockHash: REFERENCE_BLOCK_HASH,
+          },
+          liquiditySnapshot: {
+            chainId: 1,
+            blockNumber: "25629999",
+            blockHash: firstHash,
+          },
+          now: new Date("2026-08-12T23:21:00.000Z"),
+        },
+        {
+          apiKey: "graph-secret",
+          endpoint: OFFICIAL_ENDPOINT,
+          fetcher: mismatchFetcher,
+        },
+      ),
+    ).rejects.toMatchObject({ code: "coverage-incomplete" });
+  });
+
   it("distinguishes shallow pools from stale or internally conflicting evidence", async () => {
     async function read(
       response: unknown,
@@ -324,8 +660,8 @@ describe("official Uniswap v4 subgraph adapter", () => {
           tokens: [token],
           referenceHead: {
             chainId: 1,
-            blockNumber: "25630000",
-            blockHash: `0x${"44".repeat(32)}`,
+            blockNumber: REFERENCE_BLOCK_NUMBER,
+            blockHash: REFERENCE_BLOCK_HASH,
           },
           now: new Date("2026-08-12T23:21:00.000Z"),
         },
@@ -337,17 +673,17 @@ describe("official Uniswap v4 subgraph adapter", () => {
       );
     }
 
-    const shallow = officialResponse();
+    const shallow = exactOfficialResponse();
     shallow.data.pools[0].totalValueLockedUSD = "9999.999999999999999999";
     await expect(read(shallow)).resolves.toEqual([]);
 
-    const stale = officialResponse(25_629_999, 1_786_576_499);
+    const stale = exactOfficialResponse(1_786_576_499);
     stale.data.pools[0].totalValueLockedUSD = "10000";
     await expect(read(stale)).rejects.toMatchObject({
       code: "coverage-incomplete",
     });
 
-    const futureTime = officialResponse(25_629_999, 1_786_577_101);
+    const futureTime = exactOfficialResponse(1_786_577_101);
     futureTime.data.pools[0].totalValueLockedUSD = "10000";
     await expect(read(futureTime)).rejects.toMatchObject({
       code: "coverage-incomplete",
@@ -371,7 +707,7 @@ describe("official Uniswap v4 subgraph adapter", () => {
       code: "coverage-incomplete",
     });
 
-    const emptyPrincipal = officialResponse();
+    const emptyPrincipal = exactOfficialResponse();
     emptyPrincipal.data.pools[0].totalValueLockedUSD = "10000";
     emptyPrincipal.data.pools[0].totalValueLockedToken0 = "0";
     emptyPrincipal.data.pools[0].totalValueLockedToken1 = "0.000";
@@ -379,7 +715,7 @@ describe("official Uniswap v4 subgraph adapter", () => {
       code: "coverage-incomplete",
     });
 
-    const exactPool = officialResponse();
+    const exactPool = exactOfficialResponse();
     exactPool.data.pools[0].totalValueLockedUSD = "10000";
     await expect(
       read(
@@ -413,7 +749,7 @@ describe("official Uniswap v4 subgraph adapter", () => {
       read(
         {
           data: {
-            ...officialResponse().data,
+            ...exactOfficialResponse().data,
             pools: [stockPool],
           },
         },
@@ -473,10 +809,21 @@ describe("official Uniswap v4 subgraph adapter", () => {
   it("batches more than 24 exact pools without silently truncating evidence", async () => {
     const tokensAndPools = batchedTokensAndPools(25);
     const pools = new Map(tokensAndPools.map(({ pool }) => [pool.id, pool]));
+    const requestedBlocks: Array<number | undefined> = [];
     const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
       const request = JSON.parse(String(init?.body)) as {
-        variables: { poolIds: string[] };
+        query: string;
+        variables: { blockNumber?: number; poolIds: string[] };
       };
+      requestedBlocks.push(request.variables.blockNumber);
+      if (request.variables.blockNumber === undefined) {
+        expect(request.query).not.toContain("$blockNumber");
+      } else {
+        expect(request.query).toContain("$blockNumber: Int!");
+        expect(
+          request.query.match(/block: \{ number: \$blockNumber \}/g),
+        ).toHaveLength(2);
+      }
       return jsonResponse({
         data: {
           ...officialResponse().data,
@@ -492,8 +839,8 @@ describe("official Uniswap v4 subgraph adapter", () => {
         tokens: tokensAndPools.map(({ token }) => token),
         referenceHead: {
           chainId: 1,
-          blockNumber: "25630000",
-          blockHash: `0x${"44".repeat(32)}`,
+          blockNumber: REFERENCE_BLOCK_NUMBER,
+          blockHash: REFERENCE_BLOCK_HASH,
         },
         now: new Date("2026-08-12T23:21:00.000Z"),
       },
@@ -505,6 +852,7 @@ describe("official Uniswap v4 subgraph adapter", () => {
     );
 
     expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(requestedBlocks).toEqual([undefined, 25_629_999]);
     expect(evidence).toHaveLength(25);
   });
 
@@ -520,7 +868,7 @@ describe("official Uniswap v4 subgraph adapter", () => {
       }
       return jsonResponse({
         data: {
-          ...officialResponse().data,
+          ...exactOfficialResponse().data,
           pools: request.variables.poolIds.map((poolId) =>
             pools.get(poolId as `0x${string}`),
           ),
@@ -534,8 +882,8 @@ describe("official Uniswap v4 subgraph adapter", () => {
           tokens: tokensAndPools.map(({ token }) => token),
           referenceHead: {
             chainId: 1,
-            blockNumber: "25630000",
-            blockHash: `0x${"44".repeat(32)}`,
+            blockNumber: REFERENCE_BLOCK_NUMBER,
+            blockHash: REFERENCE_BLOCK_HASH,
           },
           now: new Date("2026-08-12T23:21:00.000Z"),
         },
@@ -571,7 +919,7 @@ describe("official Uniswap v4 subgraph adapter", () => {
           fetcher: async () =>
             jsonResponse({
               data: {
-                ...officialResponse().data,
+                ...exactOfficialResponse().data,
                 pools: [tokensAndPools[0]!.pool],
               },
             }),
@@ -592,8 +940,8 @@ describe("official Uniswap v4 subgraph adapter", () => {
         tokens: tokensAndPools.map(({ token }) => token),
         referenceHead: {
           chainId: 1,
-          blockNumber: "25630000",
-          blockHash: `0x${"44".repeat(32)}`,
+          blockNumber: REFERENCE_BLOCK_NUMBER,
+          blockHash: REFERENCE_BLOCK_HASH,
         },
         now: new Date("2026-08-12T23:21:00.000Z"),
       },
@@ -603,7 +951,7 @@ describe("official Uniswap v4 subgraph adapter", () => {
         fetcher: async () =>
           jsonResponse({
             data: {
-              ...officialResponse().data,
+              ...exactOfficialResponse().data,
               pools: tokensAndPools.map(({ pool }) => pool),
             },
           }),


### PR DESCRIPTION
## Outcome

- bind market-cap pagination to one exact valuation and Graph snapshot
- preserve exact current-market provider quorum and supply evidence across replay
- require staged health before handoff
- bind post-promotion verification to https://programmable.market
- harden release/source mutation contracts

## Validation

- `npm run test:interface:ci` — 3,544 passed, 7 skipped
- `npm run perf:read-model:ops-gate` — 41/41
- `npm run typecheck -- --pretty false`
- focused ESLint — 0 errors
- `actionlint .github/workflows/deploy-production.yml`
- gitleaks on `origin/production..HEAD` — no leaks
- `git diff --check`

All indexed/projector activation flags remain untouched and false. No deployment or promotion is performed by this PR.