### PR TITLE
Accept commitment-bound multi-label QuickNode endpoints

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -734,6 +734,19 @@ export async function GET(request: NextRequest) {
     const currentMarketDeployment = deployment.status === "ready"
       ? currentMarketOnchainDeployment(deployment)
       : null;
+    const [
+      canonicalAttempt,
+      customAttempt,
+      referenceHead,
+    ] = await Promise.all([
+      canonicalRead,
+      customRead,
+      readExploreReferenceHeadWithinRouteBudget(),
+    ]);
+    // Identity discovery has its own bounded reads. Start the current-market
+    // budget only after those reads settle so a cold canonical cache cannot
+    // consume the entire StateView, Chainlink and official-v4 evidence window
+    // before the evidence operation begins.
     const currentEvidenceDeadlineAt =
       Date.now() + CURRENT_EVIDENCE_ROUTE_DEADLINE_MS;
     const requireCompleteCurrentValuation =
@@ -757,20 +770,11 @@ export async function GET(request: NextRequest) {
       : Promise.resolve(null);
     // Attach a rejection handler immediately; global ranking rethrows the
     // settled error inside the valuation orchestrator rather than leaking an
-    // unhandled promise while identity reads complete.
+    // unhandled promise.
     const operationalSnapshotOutcome = operationalSnapshotRead.then(
       (value) => ({ status: "fulfilled" as const, value }),
       (error: unknown) => ({ status: "rejected" as const, error }),
     );
-    const [
-      canonicalAttempt,
-      customAttempt,
-      referenceHead,
-    ] = await Promise.all([
-      canonicalRead,
-      customRead,
-      readExploreReferenceHeadWithinRouteBudget(),
-    ]);
     if (canonicalAttempt.source === null && customAttempt.source === null) {
       throw canonicalAttempt.error ?? customAttempt.error;
     }

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -43,7 +43,7 @@
         },
         "providerConfig": {
           "path": "lib/onchain/website-rpc-providers.server.ts",
-          "sha256": "12018bf29c2521b3fbae2c64ba2e93d586e0f9978c36403f24249becb71f07ed"
+          "sha256": "b6c35adf7598b53989fc68e82affcdc5b75559125e387a03afd6468933888fb3"
         }
       }
     },

--- a/lib/onchain/website-rpc-providers.server.ts
+++ b/lib/onchain/website-rpc-providers.server.ts
@@ -9,7 +9,7 @@ const ALCHEMY_MAINNET_RPC_PATH = /^\/v2\/[A-Za-z0-9_-]{8,256}$/u;
 const DRPC_MAINNET_RPC_HOST = "lb.drpc.live";
 const DRPC_MAINNET_RPC_PATH = /^\/ethereum\/[A-Za-z0-9_-]{8,512}\/?$/u;
 const QUICKNODE_MAINNET_RPC_HOST =
-  /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.quiknode\.pro$/u;
+  /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+quiknode\.pro$/u;
 const QUICKNODE_MAINNET_RPC_PATH = /^\/[A-Za-z0-9_-]{8,256}\/?$/u;
 
 export const WEBSITE_MAINNET_RPC_ENV = Object.freeze({

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -48,7 +48,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
         providerConfig: Object.freeze({
           path: "lib/onchain/website-rpc-providers.server.ts",
-          sha256: "12018bf29c2521b3fbae2c64ba2e93d586e0f9978c36403f24249becb71f07ed",
+          sha256: "b6c35adf7598b53989fc68e82affcdc5b75559125e387a03afd6468933888fb3",
         }),
       }),
     }),

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -933,6 +933,42 @@ describe("Explore API Bitquery market boundary", () => {
     ).toHaveLength(30);
   });
 
+  it("starts the current-evidence budget after identity reads settle", async () => {
+    let resolveCanonical!: (model: ExploreReadModel) => void;
+    mocks.readAlchemyExploreModel.mockReturnValueOnce(
+      new Promise<ExploreReadModel>((resolve) => {
+        resolveCanonical = resolve;
+      }),
+    );
+
+    const responseRead = GET(
+      new NextRequest("http://localhost/api/explore?sort=market-cap"),
+    );
+    await vi.waitFor(() => {
+      expect(mocks.readAlchemyExploreModel).toHaveBeenCalledOnce();
+    });
+    expect(mocks.settleCurrentEvidenceSnapshot).not.toHaveBeenCalled();
+    expect(
+      mocks.valueExploreEntriesWithCurrentEvidenceSnapshot,
+    ).not.toHaveBeenCalled();
+
+    resolveCanonical(readyModel());
+    const response = await responseRead;
+
+    expect(response.status).toBe(200);
+    expect(mocks.settleCurrentEvidenceSnapshot).toHaveBeenCalledOnce();
+    expect(
+      mocks.valueExploreEntriesWithCurrentEvidenceSnapshot,
+    ).toHaveBeenCalledWith(expect.objectContaining({
+      timeoutMs: expect.any(Number),
+    }));
+    const timeoutMs =
+      mocks.valueExploreEntriesWithCurrentEvidenceSnapshot.mock.calls[0]?.[0]
+        .timeoutMs;
+    expect(timeoutMs).toBeGreaterThan(0);
+    expect(timeoutMs).toBeLessThanOrEqual(4_500);
+  });
+
   it("replays later market-cap pages against the exact first-page ranking", async () => {
     const firstResponse = await GET(new NextRequest(
       "http://localhost/api/explore?sort=market-cap&page=1&limit=10",

--- a/tests/website-rpc-providers.test.ts
+++ b/tests/website-rpc-providers.test.ts
@@ -12,6 +12,8 @@ const ALCHEMY_URL =
 const DRPC_URL = "https://lb.drpc.live/ethereum/drpc-test-key";
 const QUICKNODE_URL =
   "https://programmable-mainnet.quiknode.pro/quicknode-test-key/";
+const MULTI_LABEL_QUICKNODE_URL =
+  "https://programmable.base-mainnet.quiknode.pro/quicknode-test-key/";
 
 function environment(input?: Readonly<{
   primaryProvider?: string;
@@ -75,6 +77,20 @@ describe("Website Mainnet RPC provider bindings", () => {
     });
   });
 
+  it("accepts commitment-bound QuickNode endpoints with valid subdomains", () => {
+    const selected = websiteMainnetRpcPair(environment({
+      secondaryProvider: "quicknode",
+      secondaryUrl: MULTI_LABEL_QUICKNODE_URL,
+    }));
+
+    expect(selected.secondary).toEqual({
+      provider: "quicknode",
+      url: MULTI_LABEL_QUICKNODE_URL,
+      endpointCommitment:
+        rpcProviderCommitment("endpoint", MULTI_LABEL_QUICKNODE_URL),
+    });
+  });
+
   it("ignores legacy bindings only after a complete role-bound pair is valid", () => {
     const selected = websiteMainnetRpcPair({
       ...environment(),
@@ -110,11 +126,16 @@ describe("Website Mainnet RPC provider bindings", () => {
       primaryProvider: "drpc",
       primaryUrl: "https://eth.drpc.org/",
     }))).toThrow("Website primary RPC binding is invalid");
-    expect(() => websiteMainnetRpcPair(environment({
-      secondaryProvider: "quicknode",
-      secondaryUrl:
-        "https://programmable.base-mainnet.quiknode.pro/quicknode-test-key/",
-    }))).toThrow("Website secondary RPC binding is invalid");
+    for (const secondaryUrl of [
+      "https://quiknode.pro/quicknode-test-key/",
+      "https://programmable.quiknode.pro.evil.example/quicknode-test-key/",
+      "https://evilquiknode.pro/quicknode-test-key/",
+    ]) {
+      expect(() => websiteMainnetRpcPair(environment({
+        secondaryProvider: "quicknode",
+        secondaryUrl,
+      }))).toThrow("Website secondary RPC binding is invalid");
+    }
   });
 
   it("requires independent vendor identities, not only distinct URLs", () => {


### PR DESCRIPTION
Fixes the fail-closed staged Website RPC binding regression for valid multi-label QuickNode hosts while preserving exact HTTPS host/path and endpoint-commitment validation.\n\nValidation: full interface CI (3562 pass, 7 skipped), 628 focused tests, 41/41 operations gates, typecheck, ESLint, diff/digest checks.