### PR TITLE
Bound full staged read-model refresh below runtime timeout

### DIFF
--- a/app/api/ops/index-v2/route.ts
+++ b/app/api/ops/index-v2/route.ts
@@ -14,8 +14,30 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 export const runtime = "nodejs";
 
-const INDEX_READ_ATTEMPTS = 4;
-const INDEX_READ_RETRY_DELAY_MS = 1_500;
+const INDEX_REFRESH_DEADLINE_MS = 270_000;
+
+class IndexRefreshDeadlineError extends Error {
+  override name = "IndexRefreshDeadlineError";
+}
+
+async function withIndexRefreshDeadline<Output>(
+  read: () => Promise<Output>,
+) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      read(),
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new IndexRefreshDeadlineError()),
+          INDEX_REFRESH_DEADLINE_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
 
 function errorClassChain(error: unknown) {
   const classes: Array<{ name: string; code?: number }> = [];
@@ -84,33 +106,9 @@ export async function GET(request: NextRequest) {
       );
     }
     const durableRefreshDeployment = currentMarketOnchainDeployment(deployment);
-    let model: Awaited<ReturnType<typeof readLiveExploreModel>> | null =
-      null;
-    let lastReadError: unknown;
-    for (let attempt = 1; attempt <= INDEX_READ_ATTEMPTS; attempt += 1) {
-      try {
-        model = await readLiveExploreModel(durableRefreshDeployment);
-        break;
-      } catch (error) {
-        lastReadError = error;
-        if (attempt < INDEX_READ_ATTEMPTS) {
-          console.warn("Programmable index read will retry", {
-            attempt,
-            errorName:
-              error instanceof Error ? error.name : "UnknownIndexError",
-            errorClassChain: errorClassChain(error),
-          });
-          if (attempt < INDEX_READ_ATTEMPTS) {
-            await new Promise((resolve) =>
-              setTimeout(resolve, INDEX_READ_RETRY_DELAY_MS * attempt),
-            );
-          }
-        }
-      }
-    }
-    if (!model) {
-      throw lastReadError ?? new Error("Index read failed");
-    }
+    const model = await withIndexRefreshDeadline(() =>
+      readLiveExploreModel(durableRefreshDeployment),
+    );
     if (model.status !== "ready") {
       throw new Error("The live Explore model is not ready");
     }

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -5,7 +5,15 @@
     "schedule": "*/5 * * * *",
     "retainedUntil": "indexed-read-cutover",
     "route": "app/api/ops/index-v2/route.ts",
-    "sha256": "f28fb7054e0bb4670b3d0aa1c2f2b7362085dcf0390fc19eb0b5eb26be464ef7",
+    "sha256": "06235ff68203da970d51022fe0a9bbe3a7d0096c547ecd7fc31b1ce1d4f1da52",
+    "boundedRefresh": {
+      "runtime": {
+        "path": "lib/onchain/read-model.ts",
+        "sha256": "5f0c5c23582a48fc7995cc4fcba865a9c20199418c0b7a0b7f9b687b2ae8717d"
+      },
+      "eventFiltersPerRange": 5,
+      "requestDeadlineMs": 270000
+    },
     "schedulerWatchdog": {
       "provider": "github-actions",
       "workflow": {

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -6,6 +6,7 @@ import {
   http,
   keccak256,
   ResponseBodyTooLargeError,
+  TimeoutError,
   type Address,
   type Hex,
   type PublicClient,
@@ -176,6 +177,22 @@ async function mapInBatches<Input, Output>(
   return output;
 }
 
+async function allSettledOrThrow<
+  const Values extends readonly unknown[],
+>(
+  values: Values,
+): Promise<{ -readonly [Key in keyof Values]: Awaited<Values[Key]> }> {
+  const results = await Promise.allSettled(values);
+  const failure = results.find(
+    (result): result is PromiseRejectedResult =>
+      result.status === "rejected",
+  );
+  if (failure) throw failure.reason;
+  return results.map(
+    (result) => (result as PromiseFulfilledResult<unknown>).value,
+  ) as { -readonly [Key in keyof Values]: Awaited<Values[Key]> };
+}
+
 async function withReadStage<Output>(
   stage: string,
   read: () => Promise<Output>,
@@ -226,7 +243,7 @@ function indexedEventsFingerprint(events: IndexedEvents) {
   );
 }
 
-async function indexVerifiedEvents(
+export async function indexVerifiedEvents(
   client: PublicClient,
   config: ReadyOnchainDeployment,
   toBlock: bigint,
@@ -244,56 +261,51 @@ async function indexVerifiedEvents(
       toBlock,
       fromBlock + logBlockRange - 1n,
     );
-    const readLogs = async () => {
-      const launchLogs = await client.getLogs({
-        address: config.launcher,
-        event: memeTokenLaunchedEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      });
-      const liquidityLogs = await client.getLogs({
-        address: config.launcher,
-        event: memeLiquidityConfiguredEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      });
-      const initialBuyLogs = await client.getLogs({
-        address: config.launcher,
-        event: memeCreatorInitialBuyEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      });
-      const feeLogs = await client.getLogs({
-        address: config.feeHook,
-        event: nativeSwapFeesAccruedEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      });
-      const claimLogs = await client.getLogs({
-        address: config.feeHook,
-        event: creatorFeesClaimedEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      });
-      return [
-        launchLogs,
-        liquidityLogs,
-        initialBuyLogs,
-        feeLogs,
-        claimLogs,
-      ] as const;
-    };
+    const readLogs = () =>
+      allSettledOrThrow([
+        client.getLogs({
+          address: config.launcher,
+          event: memeTokenLaunchedEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+        client.getLogs({
+          address: config.launcher,
+          event: memeLiquidityConfiguredEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+        client.getLogs({
+          address: config.launcher,
+          event: memeCreatorInitialBuyEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+        client.getLogs({
+          address: config.feeHook,
+          event: nativeSwapFeesAccruedEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+        client.getLogs({
+          address: config.feeHook,
+          event: creatorFeesClaimedEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+      ] as const);
     let logs: Awaited<ReturnType<typeof readLogs>>;
     try {
       logs = await readLogs();
     } catch (error) {
       if (
-        (error instanceof ResponseBodyTooLargeError ||
+        (error instanceof TimeoutError ||
+          error instanceof ResponseBodyTooLargeError ||
           error instanceof HttpRequestError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -10,7 +10,15 @@ const APPROVED_OPERATIONS = Object.freeze({
     schedule: "*/5 * * * *",
     retainedUntil: "indexed-read-cutover",
     route: "app/api/ops/index-v2/route.ts",
-    sha256: "f28fb7054e0bb4670b3d0aa1c2f2b7362085dcf0390fc19eb0b5eb26be464ef7",
+    sha256: "06235ff68203da970d51022fe0a9bbe3a7d0096c547ecd7fc31b1ce1d4f1da52",
+    boundedRefresh: Object.freeze({
+      runtime: Object.freeze({
+        path: "lib/onchain/read-model.ts",
+        sha256: "5f0c5c23582a48fc7995cc4fcba865a9c20199418c0b7a0b7f9b687b2ae8717d",
+      }),
+      eventFiltersPerRange: 5,
+      requestDeadlineMs: 270_000,
+    }),
     schedulerWatchdog: Object.freeze({
       provider: "github-actions",
       workflow: Object.freeze({
@@ -1457,6 +1465,32 @@ export function evaluateReadModelOperationsSourceContracts(
           expectedSha256Overrides,
         ),
     "the five-minute legacy route remains byte-bound until indexed-read cutover",
+  );
+  const boundedRefresh = operations?.legacyIndexer?.boundedRefresh;
+  const legacyRouteSource = source(APPROVED_OPERATIONS.legacyIndexer.route);
+  const refreshRuntimeSource = source(boundedRefresh?.runtime?.path);
+  check(
+    "ops-legacy-bounded-refresh",
+    exactJson(
+      boundedRefresh,
+      APPROVED_OPERATIONS.legacyIndexer.boundedRefresh,
+    ) &&
+      sourceBindingMatches(
+        source,
+        boundedRefresh?.runtime,
+        expectedSha256Overrides,
+      ) &&
+      legacyRouteSource?.includes(
+        "const INDEX_REFRESH_DEADLINE_MS = 270_000;",
+      ) &&
+      legacyRouteSource?.includes("withIndexRefreshDeadline(() =>") &&
+      !legacyRouteSource?.includes("INDEX_READ_ATTEMPTS") &&
+      refreshRuntimeSource?.includes("TimeoutError,") &&
+      refreshRuntimeSource?.includes("error instanceof TimeoutError ||") &&
+      refreshRuntimeSource?.includes(
+        "const readLogs = () =>\n      allSettledOrThrow([",
+      ),
+    "the canonical refresh scans five disjoint event filters concurrently, bisects timeouts and fails before the platform deadline",
   );
   const schedulerWatchdog = operations?.legacyIndexer?.schedulerWatchdog;
   check(

--- a/tests/data-pipeline/legacy-index-ops-route.test.ts
+++ b/tests/data-pipeline/legacy-index-ops-route.test.ts
@@ -122,56 +122,45 @@ describe("legacy index operations routes", () => {
     expect(mocks.writePortfolioHistorySnapshot).toHaveBeenCalledTimes(1);
   });
 
-  it("retries transient read failures and persists only the successful model", async () => {
-    vi.useFakeTimers();
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    vi.spyOn(console, "info").mockImplementation(() => undefined);
-    mocks.readLiveExploreModel
-      .mockRejectedValueOnce(
-        Object.assign(new Error("sensitive provider response"), { code: 429 }),
-      )
-      .mockRejectedValueOnce(new Error("temporary provider failure"))
-      .mockRejectedValueOnce(new Error("temporary provider failure"))
-      .mockResolvedValueOnce({ status: "ready" });
-
-    const responsePromise = getCanonicalIndex(request());
-    await vi.runAllTimersAsync();
-    const response = await responsePromise;
-
-    expect(response.status).toBe(200);
-    expect(mocks.readLiveExploreModel).toHaveBeenCalledTimes(4);
-    expect(mocks.writeDurableExploreModel).toHaveBeenCalledTimes(1);
-    expect(console.warn).toHaveBeenCalledWith(
-      "Programmable index read will retry",
-      expect.objectContaining({
-        attempt: 1,
-        errorClassChain: expect.arrayContaining([
-          expect.objectContaining({ name: "Error", code: 429 }),
-        ]),
-      }),
-    );
-    expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain(
-      "sensitive provider response",
-    );
-  });
-
-  it("returns 503 after four failed reads without starting a write", async () => {
-    vi.useFakeTimers();
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  it("fails fast after one full read failure without starting a write", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.readLiveExploreModel.mockRejectedValue(new Error("provider offline"));
+    mocks.readLiveExploreModel.mockRejectedValue(
+      Object.assign(new Error("sensitive provider response"), { code: 429 }),
+    );
 
-    const responsePromise = getCanonicalIndex(request());
-    await vi.runAllTimersAsync();
-    const response = await responsePromise;
+    const response = await getCanonicalIndex(request());
 
     expect(response.status).toBe(503);
     expect(response.headers.get("cache-control")).toBe("no-store");
     await expect(response.json()).resolves.toEqual({
       error: "Index refresh failed",
     });
-    expect(mocks.readLiveExploreModel).toHaveBeenCalledTimes(4);
+    expect(mocks.readLiveExploreModel).toHaveBeenCalledTimes(1);
     expect(mocks.writeDurableExploreModel).not.toHaveBeenCalled();
+    expect(JSON.stringify(vi.mocked(console.error).mock.calls)).not.toContain(
+      "sensitive provider response",
+    );
+  });
+
+  it("returns a controlled 503 before the Vercel hard timeout", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.readLiveExploreModel.mockReturnValue(new Promise(() => undefined));
+
+    const responsePromise = getCanonicalIndex(request());
+    await vi.advanceTimersByTimeAsync(270_000);
+    const response = await responsePromise;
+
+    expect(response.status).toBe(503);
+    expect(mocks.readLiveExploreModel).toHaveBeenCalledTimes(1);
+    expect(mocks.writeDurableExploreModel).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Programmable index refresh failed",
+      expect.objectContaining({
+        errorName: "IndexRefreshDeadlineError",
+        durationMs: 270_000,
+      }),
+    );
   });
 
   it("keeps the old writer alias permanently closed", async () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -643,6 +643,43 @@ describe("read-model operations source contract", () => {
   });
 
   it.each([
+    [
+      "the pre-platform deadline",
+      "app/api/ops/index-v2/route.ts",
+      "const INDEX_REFRESH_DEADLINE_MS = 270_000;",
+      "const INDEX_REFRESH_DEADLINE_MS = 300_000;",
+    ],
+    [
+      "settled concurrent event filters",
+      "lib/onchain/read-model.ts",
+      "const readLogs = () =>\n      allSettledOrThrow([",
+      "const readLogs = () =>\n      Promise.all([",
+    ],
+    [
+      "timeout range bisection",
+      "lib/onchain/read-model.ts",
+      "error instanceof TimeoutError ||",
+      "false ||",
+    ],
+  ])(
+    "rejects a legacy refresh missing %s",
+    (_label, path, needle, replacement) => {
+      const source = readFileSync(resolve(ROOT, path), "utf8");
+      expect(source).toContain(needle);
+      const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+        sourceOverrides: {
+          ...integratedOverrides(),
+          [path]: source.replace(needle, replacement),
+        },
+        expectedSha256Overrides: fixtureDigests(),
+      });
+      expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+        "ops-legacy-bounded-refresh",
+      );
+    },
+  );
+
+  it.each([
     ["unprotected branch", "github.ref == 'refs/heads/production'"],
     [
       "pinned Node setup action",

--- a/tests/onchain-read-model.test.ts
+++ b/tests/onchain-read-model.test.ts
@@ -1,7 +1,36 @@
-import { describe, expect, it } from "vitest";
+import { TimeoutError, type PublicClient } from "viem";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { readExploreModel } from "../lib/onchain/read-model";
-import type { OnchainDeployment } from "../lib/onchain/types";
+import {
+  indexVerifiedEvents,
+  readExploreModel,
+} from "../lib/onchain/read-model";
+import type {
+  OnchainDeployment,
+  ReadyOnchainDeployment,
+} from "../lib/onchain/types";
+
+const readyDeployment: ReadyOnchainDeployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: "0x1111111111111111111111111111111111111111",
+  feeHook: "0x2222222222222222222222222222222222222222",
+  launcherRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  deploymentBlock: 1n,
+  stateView: "0x3333333333333333333333333333333333333333",
+  stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  rpcUrl: "https://primary.example.invalid",
+  rpcUrlSecondary: "https://secondary.example.invalid",
+  confirmations: 12n,
+  logBlockRange: 1_000n,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("Explore read model deployment boundary", () => {
   it("returns an honest empty result without touching RPC when undeployed", async () => {
@@ -31,5 +60,81 @@ describe("Explore read model deployment boundary", () => {
       launcherFeesAccruedWei: "0",
       launcherFeesAccruedEth: "0",
     });
+  });
+});
+
+describe("Explore verified event indexing", () => {
+  it("reads the five disjoint event filters concurrently within each range", async () => {
+    const resolvers: Array<(logs: readonly []) => void> = [];
+    const getLogs = vi.fn(
+      (input: { fromBlock: bigint; toBlock: bigint }) => {
+        void input;
+        return new Promise<readonly []>((resolve) =>
+          resolvers.push(resolve)
+        );
+      },
+    );
+    const pending = indexVerifiedEvents(
+      { getLogs } as unknown as PublicClient,
+      readyDeployment,
+      1_000n,
+    );
+
+    await vi.waitFor(() => expect(getLogs).toHaveBeenCalledTimes(5));
+    expect(
+      getLogs.mock.calls.map(([input]) => [input.fromBlock, input.toBlock]),
+    ).toEqual(Array.from({ length: 5 }, () => [1n, 1_000n]));
+    for (const resolve of resolvers) resolve([]);
+
+    await expect(pending).resolves.toMatchObject({
+      launches: [],
+      liquidities: [],
+      initialBuys: [],
+      creatorClaims: [],
+    });
+  });
+
+  it("bisects and retries the complete range after a transport timeout", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let firstRequest = true;
+    const getLogs = vi.fn(async (
+      input: { fromBlock: bigint; toBlock: bigint },
+    ) => {
+      void input;
+      if (firstRequest) {
+        firstRequest = false;
+        throw new TimeoutError({
+          body: { method: "eth_getLogs" },
+          url: readyDeployment.rpcUrl,
+        });
+      }
+      return [];
+    });
+
+    await expect(
+      indexVerifiedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        1_000n,
+      ),
+    ).resolves.toMatchObject({ launches: [], creatorClaims: [] });
+
+    expect(getLogs).toHaveBeenCalledTimes(15);
+    expect(
+      getLogs.mock.calls.map(([input]) => [input.fromBlock, input.toBlock]),
+    ).toEqual([
+      ...Array.from({ length: 5 }, () => [1n, 1_000n]),
+      ...Array.from({ length: 5 }, () => [1n, 500n]),
+      ...Array.from({ length: 5 }, () => [501n, 1_000n]),
+    ]);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Explore log range reduced after RPC rejection",
+      expect.objectContaining({
+        fromBlock: "1",
+        attemptedToBlock: "1000",
+        nextRange: "500",
+        errorName: "TimeoutError",
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Outcome

Keeps the staged durable refresh complete and fail-closed while preventing the classic-events scan from exhausting Vercel’s 300 second runtime.

## Changes

- execute the five disjoint classic event filters concurrently per exact block range and wait for every request to settle
- bisect and retry the same exact range on viem timeout or bounded provider rejection
- retain sequential two-provider reads plus the existing full fingerprint/quorum equality check
- remove whole-history route retries and return a controlled 503 after 270 seconds
- bind the changed runtime bytes and downgrade-sensitive wiring in the operations manifest/source-contract mutation gates

## Validation

- `tsc --noEmit`
- focused route/read-model tests: 8/8
- operations contract suites: 610/610
- operations source-contract gate: pass
- ESLint: 0 errors
- diff check: pass
- gitleaks exact commit range: no leaks

No evidence, freshness, completeness, RPC quorum, or release gate was weakened.