### PR TITLE
Bound all active release event scans

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -9,9 +9,24 @@
     "boundedRefresh": {
       "runtime": {
         "path": "lib/onchain/read-model.ts",
-        "sha256": "5f0c5c23582a48fc7995cc4fcba865a9c20199418c0b7a0b7f9b687b2ae8717d"
+        "sha256": "654eb383431ce6518deda90db07b2c083be0bc7bfb5f66c80b476dd853120244"
       },
-      "eventFiltersPerRange": 5,
+      "releaseRuntimes": [
+        {
+          "release": "classic-v3",
+          "path": "lib/onchain/classic-v3-read-model.ts",
+          "sha256": "1f9c711c8df4159a7b391e95880f7a9e5aa88191572d043b86fba9baa2b3f11b",
+          "eventFiltersPerRange": 2
+        },
+        {
+          "release": "stock-paired-v1-v3",
+          "path": "lib/onchain/stock-paired-read-model.ts",
+          "sha256": "6b5b5def718509f954e54a11849daf4584e3e048a3607b0a0126b5fe61ac7ec2",
+          "eventFiltersPerRange": 3
+        }
+      ],
+      "eventFiltersPerRange": 2,
+      "providerPasses": 2,
       "requestDeadlineMs": 270000
     },
     "schedulerWatchdog": {

--- a/lib/onchain/classic-v3-read-model.ts
+++ b/lib/onchain/classic-v3-read-model.ts
@@ -5,8 +5,10 @@ import {
   HttpRequestError,
   http,
   keccak256,
+  LimitExceededRpcError,
   parseAbiItem,
   ResponseBodyTooLargeError,
+  TimeoutError,
   type Address,
   type Hex,
   type PublicClient,
@@ -38,7 +40,7 @@ const feeEvent = parseAbiItem(
   "event NativeSwapFeesAccrued(bytes32 indexed poolId,address indexed swapSender,bool indexed isBuy,uint16 appliedTotalSwapFeeBps,uint256 grossNativeAmount,uint256 creatorFee,uint256 launcherFee)",
 );
 
-type ClassicV3Release = {
+export type ClassicV3Release = {
   launcher: Address;
   hook: Address;
   rewardVaultFactory: Address;
@@ -110,6 +112,22 @@ async function mapInBatches<Input, Output>(
   return output;
 }
 
+async function allSettledOrThrow<
+  const Values extends readonly unknown[],
+>(
+  values: Values,
+): Promise<{ -readonly [Key in keyof Values]: Awaited<Values[Key]> }> {
+  const results = await Promise.allSettled(values);
+  const failure = results.find(
+    (result): result is PromiseRejectedResult =>
+      result.status === "rejected",
+  );
+  if (failure) throw failure.reason;
+  return results.map(
+    (result) => (result as PromiseFulfilledResult<unknown>).value,
+  ) as { -readonly [Key in keyof Values]: Awaited<Values[Key]> };
+}
+
 function sameHex(left: string, right: string) {
   return left.toLowerCase() === right.toLowerCase();
 }
@@ -168,7 +186,30 @@ async function assertRuntime(
   }
 }
 
-async function readEvents(
+function assertCanonicalClassicV3EventSource(
+  eventName: string,
+  actualAddress: Address,
+  release: ClassicV3Release,
+) {
+  const expectedAddress =
+    eventName === "MemeTokenLaunchedV2"
+      ? release.launcher
+      : eventName === "NativeSwapFeesAccrued"
+        ? release.hook
+        : null;
+  if (expectedAddress === null) {
+    throw new Error(
+      `RPC returned event outside the canonical Classic V3 filter: ${eventName}`,
+    );
+  }
+  if (!sameHex(actualAddress, expectedAddress)) {
+    throw new Error(
+      `RPC returned ${eventName} from a non-canonical Classic V3 contract`,
+    );
+  }
+}
+
+export async function readClassicV3Events(
   client: PublicClient,
   config: ReadyOnchainDeployment,
   release: ClassicV3Release,
@@ -187,29 +228,31 @@ async function readEvents(
       toBlock,
       fromBlock + logBlockRange - 1n,
     );
-    const readLogs = async () => {
-      const launchLogs = await client.getLogs({
-        address: release.launcher,
-        event: launchedEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      });
-      const feeLogs = await client.getLogs({
-        address: release.hook,
-        event: feeEvent,
-        fromBlock,
-        toBlock: rangeEnd,
-        strict: true,
-      });
-      return [launchLogs, feeLogs] as const;
-    };
+    const readLogs = () =>
+      allSettledOrThrow([
+        client.getLogs({
+          address: release.launcher,
+          event: launchedEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+        client.getLogs({
+          address: release.hook,
+          event: feeEvent,
+          fromBlock,
+          toBlock: rangeEnd,
+          strict: true,
+        }),
+      ] as const);
     let logs: Awaited<ReturnType<typeof readLogs>>;
     try {
       logs = await readLogs();
     } catch (error) {
       if (
-        (error instanceof HttpRequestError ||
+        (error instanceof TimeoutError ||
+          error instanceof LimitExceededRpcError ||
+          error instanceof HttpRequestError ||
           error instanceof ResponseBodyTooLargeError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
@@ -234,6 +277,11 @@ async function readEvents(
     }
     const [launchLogs, feeLogs] = logs;
     for (const log of launchLogs) {
+      assertCanonicalClassicV3EventSource(
+        log.eventName,
+        log.address,
+        release,
+      );
       if (log.removed || log.blockNumber === null) continue;
       launches.push({
         deployer: getAddress(log.args.deployer),
@@ -254,6 +302,11 @@ async function readEvents(
       });
     }
     for (const log of feeLogs) {
+      assertCanonicalClassicV3EventSource(
+        log.eventName,
+        log.address,
+        release,
+      );
       if (log.removed) continue;
       const key = log.args.poolId.toLowerCase();
       const current = volumes.get(key) ?? { ...EMPTY_VOLUME };
@@ -268,7 +321,9 @@ async function readEvents(
   return { launches, volumes };
 }
 
-function eventFingerprint(value: Awaited<ReturnType<typeof readEvents>>) {
+function eventFingerprint(
+  value: Awaited<ReturnType<typeof readClassicV3Events>>,
+) {
   return JSON.stringify(
     {
       launches: value.launches,
@@ -502,17 +557,15 @@ export async function readClassicV3ExploreModel(
           ),
       ),
   );
-  const eventSets = await mapInBatches(
-    clients,
-    RPC_PROVENANCE_BATCH_SIZE,
-    (client) =>
-      readEvents(
+  const eventSets = await allSettledOrThrow(
+    clients.map((client) =>
+      readClassicV3Events(
         client,
         config,
         release,
         toBlock,
         options.fromBlock ?? release.startBlock,
-      ),
+      )),
   );
   const launcherFees = await mapInBatches(
     clients,

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -5,6 +5,7 @@ import {
   HttpRequestError,
   http,
   keccak256,
+  LimitExceededRpcError,
   ResponseBodyTooLargeError,
   TimeoutError,
   type Address,
@@ -88,6 +89,15 @@ const TOKEN_HYDRATION_BATCH_SIZE = 12;
 const BLOCK_TIMESTAMP_BATCH_SIZE = 4;
 const RPC_PROVENANCE_BATCH_SIZE = 1;
 const MINIMUM_LOG_BLOCK_RANGE = 100n;
+const CLASSIC_LAUNCHER_EVENTS = [
+  memeTokenLaunchedEvent,
+  memeLiquidityConfiguredEvent,
+  memeCreatorInitialBuyEvent,
+] as const;
+const CLASSIC_FEE_HOOK_EVENTS = [
+  nativeSwapFeesAccruedEvent,
+  creatorFeesClaimedEvent,
+] as const;
 
 type FeeDisclosure = readonly [
   buySwapFeeBps: number,
@@ -219,7 +229,7 @@ async function assertRuntimeCode(
   }
 }
 
-type IndexedEvents = {
+export type IndexedEvents = {
   launches: LaunchEventRecord[];
   liquidities: LiquidityEventRecord[];
   initialBuys: InitialBuyEventRecord[];
@@ -227,7 +237,7 @@ type IndexedEvents = {
   creatorClaims: CreatorClaimEventRecord[];
 };
 
-function indexedEventsFingerprint(events: IndexedEvents) {
+export function indexedEventsFingerprint(events: IndexedEvents) {
   return JSON.stringify(
     {
       launches: events.launches,
@@ -241,6 +251,32 @@ function indexedEventsFingerprint(events: IndexedEvents) {
     (_, value) =>
       typeof value === "bigint" ? value.toString() : value,
   );
+}
+
+function assertCanonicalClassicEventSource(
+  eventName: string,
+  actualAddress: Address,
+  config: ReadyOnchainDeployment,
+) {
+  const expectedAddress =
+    eventName === "MemeTokenLaunched" ||
+    eventName === "MemeLiquidityConfigured" ||
+    eventName === "MemeCreatorInitialBuy"
+      ? config.launcher
+      : eventName === "NativeSwapFeesAccrued" ||
+          eventName === "CreatorFeesClaimed"
+        ? config.feeHook
+        : null;
+  if (expectedAddress === null) {
+    throw new Error(
+      `RPC returned event outside the canonical Classic filter: ${eventName}`,
+    );
+  }
+  if (actualAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
+    throw new Error(
+      `RPC returned ${eventName} from a non-canonical contract`,
+    );
+  }
 }
 
 export async function indexVerifiedEvents(
@@ -265,35 +301,14 @@ export async function indexVerifiedEvents(
       allSettledOrThrow([
         client.getLogs({
           address: config.launcher,
-          event: memeTokenLaunchedEvent,
-          fromBlock,
-          toBlock: rangeEnd,
-          strict: true,
-        }),
-        client.getLogs({
-          address: config.launcher,
-          event: memeLiquidityConfiguredEvent,
-          fromBlock,
-          toBlock: rangeEnd,
-          strict: true,
-        }),
-        client.getLogs({
-          address: config.launcher,
-          event: memeCreatorInitialBuyEvent,
+          events: CLASSIC_LAUNCHER_EVENTS,
           fromBlock,
           toBlock: rangeEnd,
           strict: true,
         }),
         client.getLogs({
           address: config.feeHook,
-          event: nativeSwapFeesAccruedEvent,
-          fromBlock,
-          toBlock: rangeEnd,
-          strict: true,
-        }),
-        client.getLogs({
-          address: config.feeHook,
-          event: creatorFeesClaimedEvent,
+          events: CLASSIC_FEE_HOOK_EVENTS,
           fromBlock,
           toBlock: rangeEnd,
           strict: true,
@@ -305,6 +320,7 @@ export async function indexVerifiedEvents(
     } catch (error) {
       if (
         (error instanceof TimeoutError ||
+          error instanceof LimitExceededRpcError ||
           error instanceof ResponseBodyTooLargeError ||
           error instanceof HttpRequestError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
@@ -325,93 +341,94 @@ export async function indexVerifiedEvents(
       }
       throw error;
     }
-    const [
-      launchLogs,
-      liquidityLogs,
-      initialBuyLogs,
-      feeLogs,
-      claimLogs,
-    ] = logs;
-
-    for (const log of launchLogs) {
-      if (log.removed || log.blockNumber === null) continue;
-      launches.push({
-        creator: getAddress(log.args.creator),
-        token: getAddress(log.args.token),
-        poolId: log.args.poolId,
-        feeHook: getAddress(log.args.feeHook),
-        positionRecipient: getAddress(log.args.positionRecipient),
-        positionTokenId: log.args.positionTokenId,
-        totalSwapFeeBps: log.args.totalSwapFeeBps,
-        launchHash: log.args.launchHash,
-        blockNumber: log.blockNumber,
-        transactionHash: log.transactionHash,
-        transactionIndex: log.transactionIndex,
-        logIndex: log.logIndex,
-      });
-    }
-
-    for (const log of liquidityLogs) {
-      if (log.removed || log.blockNumber === null) continue;
-      liquidities.push({
-        token: getAddress(log.args.token),
-        totalSupply: log.args.totalSupply,
-        tokenLiquidityAmount: log.args.tokenLiquidityAmount,
-        lockedTokenDust: log.args.lockedTokenDust,
-        initialTick: log.args.initialTick,
-        tickLower: log.args.tickLower,
-        tickUpper: log.args.tickUpper,
-        lpFeePips: log.args.lpFeePips,
-        launchHash: log.args.launchHash,
-        blockNumber: log.blockNumber,
-        transactionHash: log.transactionHash,
-        transactionIndex: log.transactionIndex,
-        logIndex: log.logIndex,
-      });
-    }
-
-    for (const log of initialBuyLogs) {
-      if (log.removed || log.blockNumber === null) continue;
-      initialBuys.push({
-        creator: getAddress(log.args.creator),
-        token: getAddress(log.args.token),
-        poolId: log.args.poolId,
-        nativeAmount: log.args.nativeAmount,
-        tokenAmount: log.args.tokenAmount,
-        launchHash: log.args.launchHash,
-        blockNumber: log.blockNumber,
-        transactionHash: log.transactionHash,
-        transactionIndex: log.transactionIndex,
-        logIndex: log.logIndex,
-      });
-    }
-
-    for (const log of feeLogs) {
+    for (const log of logs.flat()) {
+      assertCanonicalClassicEventSource(
+        log.eventName,
+        log.address,
+        config,
+      );
       if (log.removed) continue;
-      const poolKey = log.args.poolId.toLowerCase();
-      const current = volumes.get(poolKey) ?? ZERO_FEE_VOLUME;
-      volumes.set(poolKey, {
-        grossNativeAmount:
-          current.grossNativeAmount + log.args.grossNativeAmount,
-        creatorFees: current.creatorFees + log.args.creatorFee,
-        launcherFees: current.launcherFees + log.args.launcherFee,
-        swapCount: current.swapCount + 1,
-      });
-    }
 
-    for (const log of claimLogs) {
-      if (log.removed || log.blockNumber === null) continue;
-      creatorClaims.push({
-        poolId: log.args.poolId,
-        creator: getAddress(log.args.creator),
-        recipient: getAddress(log.args.recipient),
-        caller: getAddress(log.args.caller),
-        amount: log.args.amount,
-        blockNumber: log.blockNumber,
-        transactionHash: log.transactionHash,
-        transactionIndex: log.transactionIndex,
-        logIndex: log.logIndex,
-      });
+      switch (log.eventName) {
+        case "MemeTokenLaunched":
+          if (log.blockNumber === null) continue;
+          launches.push({
+            creator: getAddress(log.args.creator),
+            token: getAddress(log.args.token),
+            poolId: log.args.poolId,
+            feeHook: getAddress(log.args.feeHook),
+            positionRecipient: getAddress(log.args.positionRecipient),
+            positionTokenId: log.args.positionTokenId,
+            totalSwapFeeBps: log.args.totalSwapFeeBps,
+            launchHash: log.args.launchHash,
+            blockNumber: log.blockNumber,
+            transactionHash: log.transactionHash,
+            transactionIndex: log.transactionIndex,
+            logIndex: log.logIndex,
+          });
+          break;
+        case "MemeLiquidityConfigured":
+          if (log.blockNumber === null) continue;
+          liquidities.push({
+            token: getAddress(log.args.token),
+            totalSupply: log.args.totalSupply,
+            tokenLiquidityAmount: log.args.tokenLiquidityAmount,
+            lockedTokenDust: log.args.lockedTokenDust,
+            initialTick: log.args.initialTick,
+            tickLower: log.args.tickLower,
+            tickUpper: log.args.tickUpper,
+            lpFeePips: log.args.lpFeePips,
+            launchHash: log.args.launchHash,
+            blockNumber: log.blockNumber,
+            transactionHash: log.transactionHash,
+            transactionIndex: log.transactionIndex,
+            logIndex: log.logIndex,
+          });
+          break;
+        case "MemeCreatorInitialBuy":
+          if (log.blockNumber === null) continue;
+          initialBuys.push({
+            creator: getAddress(log.args.creator),
+            token: getAddress(log.args.token),
+            poolId: log.args.poolId,
+            nativeAmount: log.args.nativeAmount,
+            tokenAmount: log.args.tokenAmount,
+            launchHash: log.args.launchHash,
+            blockNumber: log.blockNumber,
+            transactionHash: log.transactionHash,
+            transactionIndex: log.transactionIndex,
+            logIndex: log.logIndex,
+          });
+          break;
+        case "NativeSwapFeesAccrued": {
+          const poolKey = log.args.poolId.toLowerCase();
+          const current = volumes.get(poolKey) ?? ZERO_FEE_VOLUME;
+          volumes.set(poolKey, {
+            grossNativeAmount:
+              current.grossNativeAmount + log.args.grossNativeAmount,
+            creatorFees: current.creatorFees + log.args.creatorFee,
+            launcherFees: current.launcherFees + log.args.launcherFee,
+            swapCount: current.swapCount + 1,
+          });
+          break;
+        }
+        case "CreatorFeesClaimed":
+          if (log.blockNumber === null) continue;
+          creatorClaims.push({
+            poolId: log.args.poolId,
+            creator: getAddress(log.args.creator),
+            recipient: getAddress(log.args.recipient),
+            caller: getAddress(log.args.caller),
+            amount: log.args.amount,
+            blockNumber: log.blockNumber,
+            transactionHash: log.transactionHash,
+            transactionIndex: log.transactionIndex,
+            logIndex: log.logIndex,
+          });
+          break;
+        default:
+          throw new Error("RPC returned an undecodable Classic event");
+      }
     }
     fromBlock = rangeEnd + 1n;
   }
@@ -725,13 +742,11 @@ async function readReadyModel(
     ),
   );
 
-  const indexedEventSets = await mapInBatches(
-    clients,
-    RPC_PROVENANCE_BATCH_SIZE,
-    (candidate) =>
+  const indexedEventSets = await allSettledOrThrow(
+    clients.map((candidate) =>
       withReadStage("classic-events", () =>
         indexVerifiedEvents(candidate, config, toBlock),
-      ),
+      )),
   );
   const launcherFeeValues = await withReadStage(
     "launcher-fee-accounting",

--- a/lib/onchain/stock-paired-read-model.ts
+++ b/lib/onchain/stock-paired-read-model.ts
@@ -5,8 +5,10 @@ import {
   HttpRequestError,
   http,
   keccak256,
+  LimitExceededRpcError,
   parseAbiItem,
   ResponseBodyTooLargeError,
+  TimeoutError,
   type Address,
   type Hex,
   type PublicClient,
@@ -52,6 +54,11 @@ const initialBuyEvent = parseAbiItem(
 const feeEvent = parseAbiItem(
   "event QuoteSwapFeesAccrued(bytes32 indexed poolId,address indexed swapSender,address indexed quoteAsset,bool isBuy,uint256 grossQuoteAmount,uint256 creatorFee,uint256 launcherFee)",
 );
+const STOCK_LAUNCHER_EVENTS = [
+  launchedEvent,
+  liquidityEvent,
+  initialBuyEvent,
+] as const;
 
 type StockLaunch = {
   deployer: Address;
@@ -150,6 +157,22 @@ async function mapInBatches<Input, Output>(
   return output;
 }
 
+async function allSettledOrThrow<
+  const Values extends readonly unknown[],
+>(
+  values: Values,
+): Promise<{ -readonly [Key in keyof Values]: Awaited<Values[Key]> }> {
+  const results = await Promise.allSettled(values);
+  const failure = results.find(
+    (result): result is PromiseRejectedResult =>
+      result.status === "rejected",
+  );
+  if (failure) throw failure.reason;
+  return results.map(
+    (result) => (result as PromiseFulfilledResult<unknown>).value,
+  ) as { -readonly [Key in keyof Values]: Awaited<Values[Key]> };
+}
+
 function sameHex(left: string, right: string) {
   return left.toLowerCase() === right.toLowerCase();
 }
@@ -198,7 +221,34 @@ function stockPriceQuoteWad(input: {
     : (squared * tokenScale * WAD) / (Q192 * quoteScale);
 }
 
-async function readEvents(
+function assertCanonicalStockEventSource(
+  eventName: string,
+  actualAddress: Address,
+  release: VerifiedStockPairedRelease,
+) {
+  const expectedAddress =
+    eventName === "StockPairedTokenLaunched" ||
+    eventName === "StockPairedLiquidityConfigured" ||
+    eventName === "StockPairedCreatorInitialBuy"
+      ? release.addresses.launcher
+      : eventName === "StockPairedEthTokenLaunched"
+        ? release.addresses.ethLaunchCoordinator
+        : eventName === "QuoteSwapFeesAccrued"
+          ? release.addresses.feeHook
+          : null;
+  if (expectedAddress === null) {
+    throw new Error(
+      `RPC returned event outside the canonical ${release.internalContractRelease} filter: ${eventName}`,
+    );
+  }
+  if (!sameHex(actualAddress, expectedAddress)) {
+    throw new Error(
+      `RPC returned ${eventName} from a non-canonical ${release.internalContractRelease} contract`,
+    );
+  }
+}
+
+export async function readStockPairedEvents(
   client: PublicClient,
   config: ReadyOnchainDeployment,
   release: VerifiedStockPairedRelease,
@@ -223,10 +273,10 @@ async function readEvents(
       fromBlock + logBlockRange - 1n,
     );
     const readLogs = () =>
-      Promise.all([
+      allSettledOrThrow([
         client.getLogs({
           address: release.addresses.launcher,
-          event: launchedEvent,
+          events: STOCK_LAUNCHER_EVENTS,
           fromBlock,
           toBlock: rangeEnd,
           strict: true,
@@ -239,33 +289,21 @@ async function readEvents(
           strict: true,
         }),
         client.getLogs({
-          address: release.addresses.launcher,
-          event: liquidityEvent,
-          fromBlock,
-          toBlock: rangeEnd,
-          strict: true,
-        }),
-        client.getLogs({
-          address: release.addresses.launcher,
-          event: initialBuyEvent,
-          fromBlock,
-          toBlock: rangeEnd,
-          strict: true,
-        }),
-        client.getLogs({
           address: release.addresses.feeHook,
           event: feeEvent,
           fromBlock,
           toBlock: rangeEnd,
           strict: true,
         }),
-      ]);
+      ] as const);
     let logs: Awaited<ReturnType<typeof readLogs>>;
     try {
       logs = await readLogs();
     } catch (error) {
       if (
-        (error instanceof HttpRequestError ||
+        (error instanceof TimeoutError ||
+          error instanceof LimitExceededRpcError ||
+          error instanceof HttpRequestError ||
           error instanceof ResponseBodyTooLargeError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
@@ -289,32 +327,63 @@ async function readEvents(
       }
       throw error;
     }
-    const [
-      launchLogs,
-      ethLaunchLogs,
-      liquidityLogs,
-      initialBuyLogs,
-      feeLogs,
-    ] = logs;
+    const [launcherLogs, ethLaunchLogs, feeLogs] = logs;
 
-    for (const log of launchLogs) {
+    for (const log of launcherLogs) {
+      assertCanonicalStockEventSource(log.eventName, log.address, release);
       if (log.removed || log.blockNumber === null) continue;
-      launches.push({
-        deployer: getAddress(log.args.deployer),
-        token: getAddress(log.args.token),
-        quoteAsset: getAddress(log.args.quoteAsset),
-        poolId: log.args.poolId,
-        rewardVault: getAddress(log.args.rewardVault),
-        positionRecipient: getAddress(log.args.positionRecipient),
-        positionTokenId: log.args.positionTokenId,
-        launchHash: log.args.launchHash,
-        blockNumber: log.blockNumber,
-        transactionHash: log.transactionHash,
-        transactionIndex: log.transactionIndex,
-        logIndex: log.logIndex,
-      });
+      switch (log.eventName) {
+        case "StockPairedTokenLaunched":
+          launches.push({
+            deployer: getAddress(log.args.deployer),
+            token: getAddress(log.args.token),
+            quoteAsset: getAddress(log.args.quoteAsset),
+            poolId: log.args.poolId,
+            rewardVault: getAddress(log.args.rewardVault),
+            positionRecipient: getAddress(log.args.positionRecipient),
+            positionTokenId: log.args.positionTokenId,
+            launchHash: log.args.launchHash,
+            blockNumber: log.blockNumber,
+            transactionHash: log.transactionHash,
+            transactionIndex: log.transactionIndex,
+            logIndex: log.logIndex,
+          });
+          break;
+        case "StockPairedLiquidityConfigured":
+          liquidities.push({
+            token: getAddress(log.args.token),
+            quoteAsset: getAddress(log.args.quoteAsset),
+            totalSupply: log.args.totalSupply,
+            tokenLiquidityAmount: log.args.tokenLiquidityAmount,
+            lockedTokenDust: log.args.lockedTokenDust,
+            initialTick: log.args.initialTick,
+            tickLower: log.args.tickLower,
+            tickUpper: log.args.tickUpper,
+            lpFeePips: log.args.lpFeePips,
+            launchHash: log.args.launchHash,
+            blockNumber: log.blockNumber,
+            transactionHash: log.transactionHash,
+          });
+          break;
+        case "StockPairedCreatorInitialBuy":
+          initialBuys.push({
+            deployer: getAddress(log.args.deployer),
+            token: getAddress(log.args.token),
+            quoteAsset: getAddress(log.args.quoteAsset),
+            poolId: log.args.poolId,
+            quoteAmount: log.args.quoteAmount,
+            tokenAmount: log.args.tokenAmount,
+            launchHash: log.args.launchHash,
+            blockNumber: log.blockNumber,
+            transactionHash: log.transactionHash,
+          });
+          break;
+        default:
+          throw new Error("RPC returned an undecodable Stock-Paired event");
+      }
     }
     for (const log of ethLaunchLogs) {
+      assertCanonicalStockEventSource(log.eventName, log.address, release);
       if (log.removed || log.blockNumber === null) continue;
       ethLaunches.push({
         creator: getAddress(log.args.creator),
@@ -330,38 +399,8 @@ async function readEvents(
         logIndex: log.logIndex,
       });
     }
-    for (const log of liquidityLogs) {
-      if (log.removed || log.blockNumber === null) continue;
-      liquidities.push({
-        token: getAddress(log.args.token),
-        quoteAsset: getAddress(log.args.quoteAsset),
-        totalSupply: log.args.totalSupply,
-        tokenLiquidityAmount: log.args.tokenLiquidityAmount,
-        lockedTokenDust: log.args.lockedTokenDust,
-        initialTick: log.args.initialTick,
-        tickLower: log.args.tickLower,
-        tickUpper: log.args.tickUpper,
-        lpFeePips: log.args.lpFeePips,
-        launchHash: log.args.launchHash,
-        blockNumber: log.blockNumber,
-        transactionHash: log.transactionHash,
-      });
-    }
-    for (const log of initialBuyLogs) {
-      if (log.removed || log.blockNumber === null) continue;
-      initialBuys.push({
-        deployer: getAddress(log.args.deployer),
-        token: getAddress(log.args.token),
-        quoteAsset: getAddress(log.args.quoteAsset),
-        poolId: log.args.poolId,
-        quoteAmount: log.args.quoteAmount,
-        tokenAmount: log.args.tokenAmount,
-        launchHash: log.args.launchHash,
-        blockNumber: log.blockNumber,
-        transactionHash: log.transactionHash,
-      });
-    }
     for (const log of feeLogs) {
+      assertCanonicalStockEventSource(log.eventName, log.address, release);
       if (log.removed || log.blockNumber === null) continue;
       const key = log.args.poolId.toLowerCase();
       const current = volumes.get(key) ?? { ...EMPTY_VOLUME };
@@ -377,7 +416,9 @@ async function readEvents(
   return { launches, ethLaunches, liquidities, initialBuys, volumes };
 }
 
-function eventFingerprint(value: Awaited<ReturnType<typeof readEvents>>) {
+function eventFingerprint(
+  value: Awaited<ReturnType<typeof readStockPairedEvents>>,
+) {
   return JSON.stringify(
     {
       launches: value.launches,
@@ -393,7 +434,7 @@ function eventFingerprint(value: Awaited<ReturnType<typeof readEvents>>) {
 }
 
 export function pairStockPairedLaunches(
-  events: Awaited<ReturnType<typeof readEvents>>,
+  events: Awaited<ReturnType<typeof readStockPairedEvents>>,
 ) {
   if (
     events.launches.length !== events.liquidities.length ||
@@ -790,17 +831,15 @@ export async function readStockPairedExploreModel(
     activeReleases,
     1,
     async (release) => {
-      const eventSets = await mapInBatches(
-        clients,
-        RPC_PROVENANCE_BATCH_SIZE,
-        (candidate) =>
-          readEvents(
+      const eventSets = await allSettledOrThrow(
+        clients.map((candidate) =>
+          readStockPairedEvents(
             candidate,
             config,
             release,
             toBlock,
             options.fromBlock ?? BigInt(release.startBlock),
-          ),
+          )),
       );
       const fingerprint = eventFingerprint(eventSets[0]);
       if (

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -14,9 +14,24 @@ const APPROVED_OPERATIONS = Object.freeze({
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
-        sha256: "5f0c5c23582a48fc7995cc4fcba865a9c20199418c0b7a0b7f9b687b2ae8717d",
+        sha256: "654eb383431ce6518deda90db07b2c083be0bc7bfb5f66c80b476dd853120244",
       }),
-      eventFiltersPerRange: 5,
+      releaseRuntimes: Object.freeze([
+        Object.freeze({
+          release: "classic-v3",
+          path: "lib/onchain/classic-v3-read-model.ts",
+          sha256: "1f9c711c8df4159a7b391e95880f7a9e5aa88191572d043b86fba9baa2b3f11b",
+          eventFiltersPerRange: 2,
+        }),
+        Object.freeze({
+          release: "stock-paired-v1-v3",
+          path: "lib/onchain/stock-paired-read-model.ts",
+          sha256: "6b5b5def718509f954e54a11849daf4584e3e048a3607b0a0126b5fe61ac7ec2",
+          eventFiltersPerRange: 3,
+        }),
+      ]),
+      eventFiltersPerRange: 2,
+      providerPasses: 2,
       requestDeadlineMs: 270_000,
     }),
     schedulerWatchdog: Object.freeze({
@@ -1469,6 +1484,17 @@ export function evaluateReadModelOperationsSourceContracts(
   const boundedRefresh = operations?.legacyIndexer?.boundedRefresh;
   const legacyRouteSource = source(APPROVED_OPERATIONS.legacyIndexer.route);
   const refreshRuntimeSource = source(boundedRefresh?.runtime?.path);
+  const releaseRuntimes = boundedRefresh?.releaseRuntimes;
+  const classicV3RefreshSource = source(releaseRuntimes?.[0]?.path);
+  const stockPairedRefreshSource = source(releaseRuntimes?.[1]?.path);
+  const hasAdaptiveCompleteRangeScan = (runtimeSource) =>
+    runtimeSource?.includes("allSettledOrThrow([") &&
+    runtimeSource?.includes("error instanceof TimeoutError") &&
+    runtimeSource?.includes("error instanceof LimitExceededRpcError") &&
+    runtimeSource?.includes("error instanceof HttpRequestError") &&
+    runtimeSource?.includes("error instanceof ResponseBodyTooLargeError") &&
+    runtimeSource?.includes("logBlockRange > MINIMUM_LOG_BLOCK_RANGE") &&
+    runtimeSource?.includes("continue;");
   check(
     "ops-legacy-bounded-refresh",
     exactJson(
@@ -1480,17 +1506,44 @@ export function evaluateReadModelOperationsSourceContracts(
         boundedRefresh?.runtime,
         expectedSha256Overrides,
       ) &&
+      Array.isArray(releaseRuntimes) &&
+      releaseRuntimes.length === 2 &&
+      releaseRuntimes[0]?.release === "classic-v3" &&
+      releaseRuntimes[0]?.eventFiltersPerRange === 2 &&
+      sourceBindingMatches(
+        source,
+        releaseRuntimes[0],
+        expectedSha256Overrides,
+      ) &&
+      releaseRuntimes[1]?.release === "stock-paired-v1-v3" &&
+      releaseRuntimes[1]?.eventFiltersPerRange === 3 &&
+      sourceBindingMatches(
+        source,
+        releaseRuntimes[1],
+        expectedSha256Overrides,
+      ) &&
+      boundedRefresh?.eventFiltersPerRange === 2 &&
+      boundedRefresh?.providerPasses === 2 &&
       legacyRouteSource?.includes(
         "const INDEX_REFRESH_DEADLINE_MS = 270_000;",
       ) &&
       legacyRouteSource?.includes("withIndexRefreshDeadline(() =>") &&
       !legacyRouteSource?.includes("INDEX_READ_ATTEMPTS") &&
-      refreshRuntimeSource?.includes("TimeoutError,") &&
-      refreshRuntimeSource?.includes("error instanceof TimeoutError ||") &&
-      refreshRuntimeSource?.includes(
-        "const readLogs = () =>\n      allSettledOrThrow([",
-      ),
-    "the canonical refresh scans five disjoint event filters concurrently, bisects timeouts and fails before the platform deadline",
+      hasAdaptiveCompleteRangeScan(refreshRuntimeSource) &&
+      refreshRuntimeSource?.includes("events: CLASSIC_LAUNCHER_EVENTS") &&
+      refreshRuntimeSource?.includes("events: CLASSIC_FEE_HOOK_EVENTS") &&
+      refreshRuntimeSource?.includes("assertCanonicalClassicEventSource(") &&
+      refreshRuntimeSource?.includes("clients.map((candidate) =>") &&
+      hasAdaptiveCompleteRangeScan(classicV3RefreshSource) &&
+      classicV3RefreshSource?.includes(
+        "assertCanonicalClassicV3EventSource(",
+      ) &&
+      classicV3RefreshSource?.includes("clients.map((client) =>") &&
+      hasAdaptiveCompleteRangeScan(stockPairedRefreshSource) &&
+      stockPairedRefreshSource?.includes("events: STOCK_LAUNCHER_EVENTS") &&
+      stockPairedRefreshSource?.includes("assertCanonicalStockEventSource(") &&
+      stockPairedRefreshSource?.includes("clients.map((candidate) =>"),
+    "all active release scanners use minimal canonical filters, settle complete ranges, adapt exact RPC rejections and compare two provider passes before the platform deadline",
   );
   const schedulerWatchdog = operations?.legacyIndexer?.schedulerWatchdog;
   check(

--- a/tests/classic-v3-read-model.test.ts
+++ b/tests/classic-v3-read-model.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
+import {
+  LimitExceededRpcError,
+  type PublicClient,
+} from "viem";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { mergeClassicV3ExploreModel } from "../lib/onchain/classic-v3-read-model";
-import type { ExploreReadModel } from "../lib/onchain/types";
+import {
+  mergeClassicV3ExploreModel,
+  readClassicV3Events,
+  type ClassicV3Release,
+} from "../lib/onchain/classic-v3-read-model";
+import type {
+  ExploreReadModel,
+  ReadyOnchainDeployment,
+} from "../lib/onchain/types";
 import type { LauncherToken } from "../lib/tokens";
 
 const token: LauncherToken = {
@@ -32,6 +43,117 @@ const model: ExploreReadModel = {
   launcherFeesAccruedWei: "5",
   launcherFeesAccruedEth: "0.000000000000000005",
 };
+
+const readyDeployment: ReadyOnchainDeployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: "0x1111111111111111111111111111111111111111",
+  feeHook: "0x2222222222222222222222222222222222222222",
+  launcherRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  deploymentBlock: 1n,
+  stateView: "0x3333333333333333333333333333333333333333",
+  stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  rpcUrl: "https://primary.example.invalid",
+  rpcUrlSecondary: "https://secondary.example.invalid",
+  confirmations: 12n,
+  logBlockRange: 1_000n,
+};
+
+const release: ClassicV3Release = {
+  launcher: "0x4444444444444444444444444444444444444444",
+  hook: "0x5555555555555555555555555555555555555555",
+  rewardVaultFactory:
+    "0x6666666666666666666666666666666666666666",
+  launcherRuntimeCodeHash: `0x${"44".repeat(32)}`,
+  hookRuntimeCodeHash: `0x${"55".repeat(32)}`,
+  rewardVaultFactoryRuntimeCodeHash: `0x${"66".repeat(32)}`,
+  startBlock: 1n,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Classic V3 event scan", () => {
+  it("settles the two scalar canonical contract filters concurrently", async () => {
+    const resolvers: Array<(logs: readonly []) => void> = [];
+    const getLogs = vi.fn(
+      (input: { address: string; strict: boolean }) => {
+        void input;
+        return new Promise<readonly []>((resolve) => resolvers.push(resolve));
+      },
+    );
+    const pending = readClassicV3Events(
+      { getLogs } as unknown as PublicClient,
+      readyDeployment,
+      release,
+      1_000n,
+      1n,
+    );
+
+    await vi.waitFor(() => expect(getLogs).toHaveBeenCalledTimes(2));
+    expect(getLogs.mock.calls.map(([input]) => input.address)).toEqual([
+      release.launcher,
+      release.hook,
+    ]);
+    expect(getLogs.mock.calls.every(([input]) => input.strict)).toBe(true);
+    for (const resolve of resolvers) resolve([]);
+    await expect(pending).resolves.toEqual({
+      launches: [],
+      volumes: new Map(),
+    });
+  });
+
+  it("bisects the same complete range on an RPC result limit", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
+      if (firstRequest) {
+        firstRequest = false;
+        throw new LimitExceededRpcError(new Error("too many results"));
+      }
+      return [];
+    });
+
+    await expect(
+      readClassicV3Events(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_000n,
+        1n,
+      ),
+    ).resolves.toEqual({ launches: [], volumes: new Map() });
+    expect(getLogs).toHaveBeenCalledTimes(6);
+  });
+
+  it("fails closed on a decoded event from the wrong contract", async () => {
+    const getLogs = vi.fn(async (input: { address: string }) =>
+      input.address === release.launcher
+        ? [
+            {
+              eventName: "MemeTokenLaunchedV2",
+              address: release.hook,
+              removed: true,
+              blockNumber: null,
+            },
+          ]
+        : [],
+    );
+    await expect(
+      readClassicV3Events(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_000n,
+        1n,
+      ),
+    ).rejects.toThrow(/non-canonical Classic V3 contract/);
+  });
+});
 
 describe("Classic V3 Explore merge", () => {
   it("adds the release once and remains idempotent", () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -661,6 +661,36 @@ describe("read-model operations source contract", () => {
       "error instanceof TimeoutError ||",
       "false ||",
     ],
+    [
+      "Classic V2 result-limit range bisection",
+      "lib/onchain/read-model.ts",
+      "error instanceof LimitExceededRpcError ||",
+      "false ||",
+    ],
+    [
+      "Classic V3 complete-range settlement",
+      "lib/onchain/classic-v3-read-model.ts",
+      "allSettledOrThrow([",
+      "Promise.all([",
+    ],
+    [
+      "Classic V3 result-limit range bisection",
+      "lib/onchain/classic-v3-read-model.ts",
+      "error instanceof LimitExceededRpcError ||",
+      "false ||",
+    ],
+    [
+      "Stock launcher topic-OR filtering",
+      "lib/onchain/stock-paired-read-model.ts",
+      "events: STOCK_LAUNCHER_EVENTS",
+      "event: launchedEvent",
+    ],
+    [
+      "Stock result-limit range bisection",
+      "lib/onchain/stock-paired-read-model.ts",
+      "error instanceof LimitExceededRpcError ||",
+      "false ||",
+    ],
   ])(
     "rejects a legacy refresh missing %s",
     (_label, path, needle, replacement) => {

--- a/tests/onchain-read-model.test.ts
+++ b/tests/onchain-read-model.test.ts
@@ -1,9 +1,16 @@
-import { TimeoutError, type PublicClient } from "viem";
+import {
+  LimitExceededRpcError,
+  TimeoutError,
+  type Hex,
+  type PublicClient,
+} from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  indexedEventsFingerprint,
   indexVerifiedEvents,
   readExploreModel,
+  type IndexedEvents,
 } from "../lib/onchain/read-model";
 import type {
   OnchainDeployment,
@@ -27,6 +34,32 @@ const readyDeployment: ReadyOnchainDeployment = {
   confirmations: 12n,
   logBlockRange: 1_000n,
 };
+
+const POOL_ID: Hex = `0x${"44".repeat(32)}`;
+const LAUNCH_HASH: Hex = `0x${"55".repeat(32)}`;
+const BLOCK_HASH: Hex = `0x${"66".repeat(32)}`;
+const TRANSACTION_HASH: Hex = `0x${"77".repeat(32)}`;
+
+function rpcLog(
+  eventName: string,
+  address: string,
+  args: Record<string, unknown>,
+  logIndex: number,
+) {
+  return {
+    address,
+    blockHash: BLOCK_HASH,
+    blockNumber: 100n,
+    data: "0x",
+    eventName,
+    args,
+    logIndex,
+    removed: false,
+    topics: [],
+    transactionHash: TRANSACTION_HASH,
+    transactionIndex: 2,
+  };
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -64,49 +97,281 @@ describe("Explore read model deployment boundary", () => {
 });
 
 describe("Explore verified event indexing", () => {
-  it("reads the five disjoint event filters concurrently within each range", async () => {
-    const resolvers: Array<(logs: readonly []) => void> = [];
+  it("uses two concurrent strict topic-OR queries on scalar canonical addresses per range", async () => {
     const getLogs = vi.fn(
-      (input: { fromBlock: bigint; toBlock: bigint }) => {
+      async (input: {
+        address: string;
+        events: ReadonlyArray<{ name: string }>;
+        fromBlock: bigint;
+        toBlock: bigint;
+        strict: boolean;
+      }) => {
         void input;
-        return new Promise<readonly []>((resolve) =>
-          resolvers.push(resolve)
-        );
+        return [];
       },
     );
-    const pending = indexVerifiedEvents(
+
+    await expect(
+      indexVerifiedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        1_000n,
+      ),
+    ).resolves.toMatchObject({ launches: [], creatorClaims: [] });
+
+    expect(getLogs).toHaveBeenCalledTimes(2);
+    const [[launcherInput], [feeHookInput]] = getLogs.mock.calls;
+    expect(launcherInput).toMatchObject({
+      address: readyDeployment.launcher,
+      fromBlock: 1n,
+      toBlock: 1_000n,
+      strict: true,
+    });
+    expect(launcherInput.events.map((event) => event.name)).toEqual([
+      "MemeTokenLaunched",
+      "MemeLiquidityConfigured",
+      "MemeCreatorInitialBuy",
+    ]);
+    expect(feeHookInput).toMatchObject({
+      address: readyDeployment.feeHook,
+      fromBlock: 1n,
+      toBlock: 1_000n,
+      strict: true,
+    });
+    expect(feeHookInput.events.map((event) => event.name)).toEqual([
+      "NativeSwapFeesAccrued",
+      "CreatorFeesClaimed",
+    ]);
+  });
+
+  it("dispatches all five allowed events without changing their record semantics", async () => {
+    const logs = [
+      rpcLog(
+        "NativeSwapFeesAccrued",
+        readyDeployment.feeHook,
+        {
+          poolId: POOL_ID,
+          swapSender: "0x8888888888888888888888888888888888888888",
+          grossNativeAmount: 100n,
+          creatorFee: 3n,
+          launcherFee: 2n,
+        },
+        3,
+      ),
+      rpcLog(
+        "MemeTokenLaunched",
+        readyDeployment.launcher,
+        {
+          creator: "0x9999999999999999999999999999999999999999",
+          token: "0x3333333333333333333333333333333333333333",
+          poolId: POOL_ID,
+          feeHook: readyDeployment.feeHook,
+          positionRecipient:
+            "0x4444444444444444444444444444444444444444",
+          positionTokenId: 12n,
+          totalSwapFeeBps: 100,
+          launchHash: LAUNCH_HASH,
+        },
+        0,
+      ),
+      rpcLog(
+        "CreatorFeesClaimed",
+        readyDeployment.feeHook,
+        {
+          poolId: POOL_ID,
+          creator: "0x9999999999999999999999999999999999999999",
+          recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          caller: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          amount: 3n,
+        },
+        4,
+      ),
+      rpcLog(
+        "MemeLiquidityConfigured",
+        readyDeployment.launcher,
+        {
+          token: "0x3333333333333333333333333333333333333333",
+          totalSupply: 1_000n,
+          tokenLiquidityAmount: 900n,
+          lockedTokenDust: 100n,
+          initialTick: 1,
+          tickLower: -2,
+          tickUpper: 3,
+          lpFeePips: 10_000,
+          launchHash: LAUNCH_HASH,
+        },
+        1,
+      ),
+      rpcLog(
+        "MemeCreatorInitialBuy",
+        readyDeployment.launcher,
+        {
+          creator: "0x9999999999999999999999999999999999999999",
+          token: "0x3333333333333333333333333333333333333333",
+          poolId: POOL_ID,
+          nativeAmount: 20n,
+          tokenAmount: 40n,
+          launchHash: LAUNCH_HASH,
+        },
+        2,
+      ),
+    ];
+    const getLogs = vi.fn(async (input: { address: string }) =>
+      logs.filter(
+        (log) =>
+          log.address.toLowerCase() === input.address.toLowerCase(),
+      ),
+    );
+
+    const result = await indexVerifiedEvents(
       { getLogs } as unknown as PublicClient,
       readyDeployment,
       1_000n,
     );
 
-    await vi.waitFor(() => expect(getLogs).toHaveBeenCalledTimes(5));
-    expect(
-      getLogs.mock.calls.map(([input]) => [input.fromBlock, input.toBlock]),
-    ).toEqual(Array.from({ length: 5 }, () => [1n, 1_000n]));
-    for (const resolve of resolvers) resolve([]);
-
-    await expect(pending).resolves.toMatchObject({
-      launches: [],
-      liquidities: [],
-      initialBuys: [],
-      creatorClaims: [],
+    expect(result.launches).toHaveLength(1);
+    expect(result.liquidities).toHaveLength(1);
+    expect(result.initialBuys).toHaveLength(1);
+    expect(result.creatorClaims).toHaveLength(1);
+    expect(result.volumes.get(POOL_ID)).toEqual({
+      grossNativeAmount: 100n,
+      creatorFees: 3n,
+      launcherFees: 2n,
+      swapCount: 1,
+    });
+    expect(result.launches[0]).toMatchObject({
+      poolId: POOL_ID,
+      logIndex: 0,
+      positionTokenId: 12n,
+    });
+    expect(result.liquidities[0]).toMatchObject({
+      logIndex: 1,
+      tokenLiquidityAmount: 900n,
+    });
+    expect(result.initialBuys[0]).toMatchObject({
+      logIndex: 2,
+      nativeAmount: 20n,
+    });
+    expect(result.creatorClaims[0]).toMatchObject({
+      logIndex: 4,
+      amount: 3n,
     });
   });
 
-  it("bisects and retries the complete range after a transport timeout", async () => {
+  it("fails closed on decoded events outside the canonical five-topic filter", async () => {
+    const getLogs = vi.fn(async (input: { address: string }) =>
+      input.address === readyDeployment.launcher
+        ? [
+            rpcLog(
+              "UnexpectedEvent",
+              readyDeployment.launcher,
+              {},
+              0,
+            ),
+          ]
+        : [],
+    );
+
+    await expect(
+      indexVerifiedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        1_000n,
+      ),
+    ).rejects.toThrow(
+      "RPC returned event outside the canonical Classic filter",
+    );
+  });
+
+  it("fails closed when an allowed event is returned by the wrong contract", async () => {
+    const getLogs = vi.fn(async (input: { address: string }) =>
+      input.address === readyDeployment.launcher
+        ? [
+            rpcLog(
+              "MemeTokenLaunched",
+              readyDeployment.feeHook,
+              {},
+              0,
+            ),
+          ]
+        : [],
+    );
+
+    await expect(
+      indexVerifiedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        1_000n,
+      ),
+    ).rejects.toThrow(
+      "RPC returned MemeTokenLaunched from a non-canonical contract",
+    );
+  });
+
+  it("bisects and retries the same complete range after a transport timeout", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     let firstRequest = true;
-    const getLogs = vi.fn(async (
-      input: { fromBlock: bigint; toBlock: bigint },
-    ) => {
-      void input;
+    const getLogs = vi.fn(
+      async (input: {
+        address: string;
+        fromBlock: bigint;
+        toBlock: bigint;
+      }) => {
+        void input;
+        if (firstRequest) {
+          firstRequest = false;
+          throw new TimeoutError({
+            body: { method: "eth_getLogs" },
+            url: readyDeployment.rpcUrl,
+          });
+        }
+        return [];
+      },
+    );
+
+    await expect(
+      indexVerifiedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        1_000n,
+      ),
+    ).resolves.toMatchObject({ launches: [], creatorClaims: [] });
+
+    expect(getLogs).toHaveBeenCalledTimes(6);
+    expect(
+      getLogs.mock.calls.map(([input]) => [
+        input.address,
+        input.fromBlock,
+        input.toBlock,
+      ]),
+    ).toEqual([
+      [readyDeployment.launcher, 1n, 1_000n],
+      [readyDeployment.feeHook, 1n, 1_000n],
+      [readyDeployment.launcher, 1n, 500n],
+      [readyDeployment.feeHook, 1n, 500n],
+      [readyDeployment.launcher, 501n, 1_000n],
+      [readyDeployment.feeHook, 501n, 1_000n],
+    ]);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Explore log range reduced after RPC rejection",
+      expect.objectContaining({
+        fromBlock: "1",
+        attemptedToBlock: "1000",
+        nextRange: "500",
+        errorName: "TimeoutError",
+      }),
+    );
+  });
+
+  it("bisects and retries the complete range after an RPC result limit", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
       if (firstRequest) {
         firstRequest = false;
-        throw new TimeoutError({
-          body: { method: "eth_getLogs" },
-          url: readyDeployment.rpcUrl,
-        });
+        throw new LimitExceededRpcError(
+          new Error("query returned more than 10000 results"),
+        );
       }
       return [];
     });
@@ -119,22 +384,77 @@ describe("Explore verified event indexing", () => {
       ),
     ).resolves.toMatchObject({ launches: [], creatorClaims: [] });
 
-    expect(getLogs).toHaveBeenCalledTimes(15);
-    expect(
-      getLogs.mock.calls.map(([input]) => [input.fromBlock, input.toBlock]),
-    ).toEqual([
-      ...Array.from({ length: 5 }, () => [1n, 1_000n]),
-      ...Array.from({ length: 5 }, () => [1n, 500n]),
-      ...Array.from({ length: 5 }, () => [501n, 1_000n]),
-    ]);
+    expect(getLogs).toHaveBeenCalledTimes(6);
     expect(console.warn).toHaveBeenCalledWith(
       "Explore log range reduced after RPC rejection",
       expect.objectContaining({
         fromBlock: "1",
         attemptedToBlock: "1000",
         nextRange: "500",
-        errorName: "TimeoutError",
+        errorName: "LimitExceededRpcError",
       }),
     );
+  });
+
+  it("fails closed when a result limit persists at the minimum range", async () => {
+    const getLogs = vi.fn(async () => {
+      throw new LimitExceededRpcError(
+        new Error("query returned more than 10000 results"),
+      );
+    });
+
+    await expect(
+      indexVerifiedEvents(
+        { getLogs } as unknown as PublicClient,
+        { ...readyDeployment, logBlockRange: 100n },
+        100n,
+      ),
+    ).rejects.toBeInstanceOf(LimitExceededRpcError);
+    expect(getLogs).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps provider fingerprints sensitive to duplicates and per-event order", () => {
+    const firstLaunch: IndexedEvents["launches"][number] = {
+      creator: "0x9999999999999999999999999999999999999999",
+      token: "0x3333333333333333333333333333333333333333",
+      poolId: POOL_ID,
+      feeHook: readyDeployment.feeHook,
+      positionRecipient:
+        "0x4444444444444444444444444444444444444444",
+      positionTokenId: 12n,
+      totalSwapFeeBps: 100,
+      launchHash: LAUNCH_HASH,
+      blockNumber: 100n,
+      transactionHash: TRANSACTION_HASH,
+      transactionIndex: 2,
+      logIndex: 0,
+    };
+    const secondLaunch: IndexedEvents["launches"][number] = {
+      ...firstLaunch,
+      token: "0x8888888888888888888888888888888888888888",
+      positionTokenId: 13n,
+      logIndex: 5,
+    };
+    const base: IndexedEvents = {
+      launches: [firstLaunch, secondLaunch],
+      liquidities: [],
+      initialBuys: [],
+      volumes: new Map(),
+      creatorClaims: [],
+    };
+    const fingerprint = indexedEventsFingerprint(base);
+
+    expect(
+      indexedEventsFingerprint({
+        ...base,
+        launches: [firstLaunch, secondLaunch, firstLaunch],
+      }),
+    ).not.toBe(fingerprint);
+    expect(
+      indexedEventsFingerprint({
+        ...base,
+        launches: [secondLaunch, firstLaunch],
+      }),
+    ).not.toBe(fingerprint);
   });
 });

--- a/tests/stock-paired-read-model.test.ts
+++ b/tests/stock-paired-read-model.test.ts
@@ -1,11 +1,20 @@
-import { getAddress, type Hex } from "viem";
-import { describe, expect, it } from "vitest";
+import {
+  getAddress,
+  LimitExceededRpcError,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   mergeStockPairedExploreModel,
   pairStockPairedLaunches,
+  readStockPairedEvents,
 } from "../lib/onchain/stock-paired-read-model";
-import type { ExploreReadModel } from "../lib/onchain/types";
+import type {
+  ExploreReadModel,
+  ReadyOnchainDeployment,
+} from "../lib/onchain/types";
 import {
   getStockPairedExpectedInitialTickForRelease,
   STOCK_QUOTE_ASSETS,
@@ -27,6 +36,117 @@ const vault = getAddress(
 const positionRecipient = getAddress(
   "0x6666666666666666666666666666666666666666",
 );
+
+const readyDeployment: ReadyOnchainDeployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher: "0x1111111111111111111111111111111111111111",
+  feeHook: "0x2222222222222222222222222222222222222222",
+  launcherRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  deploymentBlock: 1n,
+  stateView: "0x3333333333333333333333333333333333333333",
+  stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  rpcUrl: "https://primary.example.invalid",
+  rpcUrlSecondary: "https://secondary.example.invalid",
+  confirmations: 12n,
+  logBlockRange: 1_000n,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Stock-Paired event scan", () => {
+  it("combines launcher events into three concurrent scalar-address filters", async () => {
+    const release = stockPairedReleaseFixture();
+    const getLogs = vi.fn(
+      async (input: {
+        address: string;
+        events?: readonly { name: string }[];
+        strict: boolean;
+      }) => {
+        void input;
+        return [];
+      },
+    );
+    await expect(
+      readStockPairedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_099n,
+        100n,
+      ),
+    ).resolves.toMatchObject({ launches: [], ethLaunches: [] });
+
+    expect(getLogs).toHaveBeenCalledTimes(3);
+    const [[launcher], [coordinator], [feeHook]] = getLogs.mock.calls;
+    expect(launcher).toMatchObject({
+      address: release.addresses.launcher,
+      strict: true,
+    });
+    expect(launcher.events?.map((event) => event.name)).toEqual([
+      "StockPairedTokenLaunched",
+      "StockPairedLiquidityConfigured",
+      "StockPairedCreatorInitialBuy",
+    ]);
+    expect(coordinator.address).toBe(
+      release.addresses.ethLaunchCoordinator,
+    );
+    expect(feeHook.address).toBe(release.addresses.feeHook);
+  });
+
+  it("bisects the same complete Stock range on an RPC result limit", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const release = stockPairedReleaseFixture();
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
+      if (firstRequest) {
+        firstRequest = false;
+        throw new LimitExceededRpcError(new Error("too many results"));
+      }
+      return [];
+    });
+    await expect(
+      readStockPairedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_099n,
+        100n,
+      ),
+    ).resolves.toMatchObject({ launches: [], volumes: new Map() });
+    expect(getLogs).toHaveBeenCalledTimes(9);
+  });
+
+  it("fails closed on a decoded Stock event from the wrong contract", async () => {
+    const release = stockPairedReleaseFixture();
+    const getLogs = vi.fn(async (input: { address: string }) =>
+      input.address === release.addresses.launcher
+        ? [
+            {
+              eventName: "StockPairedTokenLaunched",
+              address: release.addresses.feeHook,
+              removed: true,
+              blockNumber: null,
+            },
+          ]
+        : [],
+    );
+    await expect(
+      readStockPairedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_099n,
+        100n,
+      ),
+    ).rejects.toThrow(/non-canonical stock-paired-v1 contract/);
+  });
+});
 
 function events() {
   const coordinator =


### PR DESCRIPTION
## Outcome

Closes the exact provider-capacity failure found in the staged full durable refresh, while preserving complete dual-provider reconstruction and fail-closed publication.

## Changes

- Classic V2 uses two canonical scalar-address topic-OR reads per range instead of five independent reads
- Classic V3 reads its two canonical streams concurrently
- Stock V1-V3 use three canonical reads with launcher events combined
- strictly bind every decoded event to its expected contract
- bisect and retry the same complete range for TimeoutError, LimitExceededRpcError, body-size and transport rejection
- execute the two independent provider event passes concurrently, then retain exact fingerprint/quorum comparison
- rebind all changed scanner bytes in the operations manifest and source-contract mutation gates

## Live evidence

A real dense Mainnet range produced 3,484 identical canonical events before and after aggregation. A later range deterministically exceeded 10,000 fee logs and returned viem LimitExceededRpcError (-32005); this patch now bisects exactly that range instead of failing the full refresh.

## Validation

- TypeScript: pass
- scanner and operations tests: 631/631
- operations source contract: 42/42
- ESLint: zero errors
- diff check: pass
- gitleaks exact commit range: no leaks

No completeness, freshness, provenance, RPC quorum, durable write, or release gate was weakened.