### PR TITLE
Retry transient minimum release-log windows

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -9,19 +9,19 @@
     "boundedRefresh": {
       "runtime": {
         "path": "lib/onchain/read-model.ts",
-        "sha256": "654eb383431ce6518deda90db07b2c083be0bc7bfb5f66c80b476dd853120244"
+        "sha256": "c3207b24610229a044ed886dc20654b57c1121e448e4a18c440b82c8d1d59015"
       },
       "releaseRuntimes": [
         {
           "release": "classic-v3",
           "path": "lib/onchain/classic-v3-read-model.ts",
-          "sha256": "1f9c711c8df4159a7b391e95880f7a9e5aa88191572d043b86fba9baa2b3f11b",
+          "sha256": "8659e109910f89e7f67ab48772e1c88854757b3cd443119bb01410f46da17d15",
           "eventFiltersPerRange": 2
         },
         {
           "release": "stock-paired-v1-v3",
           "path": "lib/onchain/stock-paired-read-model.ts",
-          "sha256": "6b5b5def718509f954e54a11849daf4584e3e048a3607b0a0126b5fe61ac7ec2",
+          "sha256": "02530f837f91c7bacb8922397d7f16bfbb773166ad4992186b15eacfd43125c7",
           "eventFiltersPerRange": 3
         }
       ],

--- a/lib/onchain/classic-v3-read-model.ts
+++ b/lib/onchain/classic-v3-read-model.ts
@@ -8,6 +8,7 @@ import {
   LimitExceededRpcError,
   parseAbiItem,
   ResponseBodyTooLargeError,
+  RpcRequestError,
   TimeoutError,
   type Address,
   type Hex,
@@ -90,7 +91,27 @@ const EMPTY_VOLUME: FeeVolume = {
 const RPC_PROVENANCE_BATCH_SIZE = 1;
 const TOKEN_HYDRATION_BATCH_SIZE = 6;
 const BLOCK_TIMESTAMP_BATCH_SIZE = 4;
-const MINIMUM_LOG_BLOCK_RANGE = 100n;
+const MINIMUM_LOG_BLOCK_RANGE = 1n;
+const TRANSIENT_RETRIES_PER_WINDOW = 1;
+const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;
+
+function isTransientLogReadError(error: unknown) {
+  if (error instanceof TimeoutError) return true;
+  if (error instanceof HttpRequestError) {
+    return (
+      error.status === undefined ||
+      error.status === 408 ||
+      error.status === 425 ||
+      error.status === 429 ||
+      error.status >= 500
+    );
+  }
+  return (
+    error instanceof RpcRequestError &&
+    error.code === -32603 &&
+    error.details.trim().toLowerCase() === "service temporarily unavailable"
+  );
+}
 
 function minimum(left: bigint, right: bigint) {
   return left < right ? left : right;
@@ -222,7 +243,9 @@ export async function readClassicV3Events(
     fromBlockFloor > release.startBlock
       ? fromBlockFloor
       : release.startBlock;
-  let logBlockRange = config.logBlockRange;
+  const configuredLogBlockRange = config.logBlockRange;
+  let logBlockRange = configuredLogBlockRange;
+  let transientRetries = 0;
   while (fromBlock <= toBlock) {
     const rangeEnd = minimum(
       toBlock,
@@ -249,10 +272,25 @@ export async function readClassicV3Events(
     try {
       logs = await readLogs();
     } catch (error) {
+      const transient = isTransientLogReadError(error);
+      const transientRetryLimit =
+        logBlockRange === MINIMUM_LOG_BLOCK_RANGE
+          ? MINIMUM_RANGE_TRANSIENT_RETRIES
+          : TRANSIENT_RETRIES_PER_WINDOW;
+      if (transient && transientRetries < transientRetryLimit) {
+        transientRetries += 1;
+        console.warn("Classic V3 log window retried after transient RPC rejection", {
+          fromBlock: fromBlock.toString(),
+          attemptedToBlock: rangeEnd.toString(),
+          retry: transientRetries,
+          retryLimit: transientRetryLimit,
+          errorName: error instanceof Error ? error.name : "UnknownError",
+        });
+        continue;
+      }
       if (
-        (error instanceof TimeoutError ||
+        (transient ||
           error instanceof LimitExceededRpcError ||
-          error instanceof HttpRequestError ||
           error instanceof ResponseBodyTooLargeError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
@@ -262,13 +300,14 @@ export async function readClassicV3Events(
           reducedRange < MINIMUM_LOG_BLOCK_RANGE
             ? MINIMUM_LOG_BLOCK_RANGE
             : reducedRange;
+        transientRetries = 0;
         console.warn(
           "Classic V3 log range reduced after RPC rejection",
           {
             fromBlock: fromBlock.toString(),
             attemptedToBlock: rangeEnd.toString(),
             nextRange: logBlockRange.toString(),
-            errorName: error.name,
+            errorName: error instanceof Error ? error.name : "UnknownError",
           },
         );
         continue;
@@ -317,6 +356,13 @@ export async function readClassicV3Events(
       volumes.set(key, current);
     }
     fromBlock = rangeEnd + 1n;
+    transientRetries = 0;
+    if (logBlockRange < configuredLogBlockRange) {
+      logBlockRange = minimum(
+        configuredLogBlockRange,
+        logBlockRange * 2n,
+      );
+    }
   }
   return { launches, volumes };
 }

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -7,6 +7,7 @@ import {
   keccak256,
   LimitExceededRpcError,
   ResponseBodyTooLargeError,
+  RpcRequestError,
   TimeoutError,
   type Address,
   type Hex,
@@ -88,7 +89,9 @@ const ZERO_FEE_VOLUME: FeeVolume = {
 const TOKEN_HYDRATION_BATCH_SIZE = 12;
 const BLOCK_TIMESTAMP_BATCH_SIZE = 4;
 const RPC_PROVENANCE_BATCH_SIZE = 1;
-const MINIMUM_LOG_BLOCK_RANGE = 100n;
+const MINIMUM_LOG_BLOCK_RANGE = 1n;
+const TRANSIENT_RETRIES_PER_WINDOW = 1;
+const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;
 const CLASSIC_LAUNCHER_EVENTS = [
   memeTokenLaunchedEvent,
   memeLiquidityConfiguredEvent,
@@ -98,6 +101,24 @@ const CLASSIC_FEE_HOOK_EVENTS = [
   nativeSwapFeesAccruedEvent,
   creatorFeesClaimedEvent,
 ] as const;
+
+function isTransientLogReadError(error: unknown) {
+  if (error instanceof TimeoutError) return true;
+  if (error instanceof HttpRequestError) {
+    return (
+      error.status === undefined ||
+      error.status === 408 ||
+      error.status === 425 ||
+      error.status === 429 ||
+      error.status >= 500
+    );
+  }
+  return (
+    error instanceof RpcRequestError &&
+    error.code === -32603 &&
+    error.details.trim().toLowerCase() === "service temporarily unavailable"
+  );
+}
 
 type FeeDisclosure = readonly [
   buySwapFeeBps: number,
@@ -291,7 +312,9 @@ export async function indexVerifiedEvents(
   const creatorClaims: CreatorClaimEventRecord[] = [];
 
   let fromBlock = config.deploymentBlock;
-  let logBlockRange = config.logBlockRange;
+  const configuredLogBlockRange = config.logBlockRange;
+  let logBlockRange = configuredLogBlockRange;
+  let transientRetries = 0;
   while (fromBlock <= toBlock) {
     const rangeEnd = minimum(
       toBlock,
@@ -318,11 +341,26 @@ export async function indexVerifiedEvents(
     try {
       logs = await readLogs();
     } catch (error) {
+      const transient = isTransientLogReadError(error);
+      const transientRetryLimit =
+        logBlockRange === MINIMUM_LOG_BLOCK_RANGE
+          ? MINIMUM_RANGE_TRANSIENT_RETRIES
+          : TRANSIENT_RETRIES_PER_WINDOW;
+      if (transient && transientRetries < transientRetryLimit) {
+        transientRetries += 1;
+        console.warn("Explore log window retried after transient RPC rejection", {
+          fromBlock: fromBlock.toString(),
+          attemptedToBlock: rangeEnd.toString(),
+          retry: transientRetries,
+          retryLimit: transientRetryLimit,
+          errorName: error instanceof Error ? error.name : "UnknownError",
+        });
+        continue;
+      }
       if (
-        (error instanceof TimeoutError ||
+        (transient ||
           error instanceof LimitExceededRpcError ||
-          error instanceof ResponseBodyTooLargeError ||
-          error instanceof HttpRequestError) &&
+          error instanceof ResponseBodyTooLargeError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
       ) {
@@ -331,11 +369,12 @@ export async function indexVerifiedEvents(
           reducedRange < MINIMUM_LOG_BLOCK_RANGE
             ? MINIMUM_LOG_BLOCK_RANGE
             : reducedRange;
+        transientRetries = 0;
         console.warn("Explore log range reduced after RPC rejection", {
           fromBlock: fromBlock.toString(),
           attemptedToBlock: rangeEnd.toString(),
           nextRange: logBlockRange.toString(),
-          errorName: error.name,
+          errorName: error instanceof Error ? error.name : "UnknownError",
         });
         continue;
       }
@@ -431,6 +470,13 @@ export async function indexVerifiedEvents(
       }
     }
     fromBlock = rangeEnd + 1n;
+    transientRetries = 0;
+    if (logBlockRange < configuredLogBlockRange) {
+      logBlockRange = minimum(
+        configuredLogBlockRange,
+        logBlockRange * 2n,
+      );
+    }
   }
 
   return {

--- a/lib/onchain/stock-paired-read-model.ts
+++ b/lib/onchain/stock-paired-read-model.ts
@@ -8,6 +8,7 @@ import {
   LimitExceededRpcError,
   parseAbiItem,
   ResponseBodyTooLargeError,
+  RpcRequestError,
   TimeoutError,
   type Address,
   type Hex,
@@ -135,7 +136,27 @@ const RPC_PROVENANCE_BATCH_SIZE = 1;
 const TOKEN_HYDRATION_BATCH_SIZE = 6;
 const BLOCK_TIMESTAMP_BATCH_SIZE = 4;
 const QUOTE_PRICE_BATCH_SIZE = 2;
-const MINIMUM_LOG_BLOCK_RANGE = 100n;
+const MINIMUM_LOG_BLOCK_RANGE = 1n;
+const TRANSIENT_RETRIES_PER_WINDOW = 1;
+const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;
+
+function isTransientLogReadError(error: unknown) {
+  if (error instanceof TimeoutError) return true;
+  if (error instanceof HttpRequestError) {
+    return (
+      error.status === undefined ||
+      error.status === 408 ||
+      error.status === 425 ||
+      error.status === 429 ||
+      error.status >= 500
+    );
+  }
+  return (
+    error instanceof RpcRequestError &&
+    error.code === -32603 &&
+    error.details.trim().toLowerCase() === "service temporarily unavailable"
+  );
+}
 
 function minimum(left: bigint, right: bigint) {
   return left < right ? left : right;
@@ -266,7 +287,9 @@ export async function readStockPairedEvents(
     fromBlockFloor > releaseStartBlock
       ? fromBlockFloor
       : releaseStartBlock;
-  let logBlockRange = config.logBlockRange;
+  const configuredLogBlockRange = config.logBlockRange;
+  let logBlockRange = configuredLogBlockRange;
+  let transientRetries = 0;
   while (fromBlock <= toBlock) {
     const rangeEnd = minimum(
       toBlock,
@@ -300,10 +323,26 @@ export async function readStockPairedEvents(
     try {
       logs = await readLogs();
     } catch (error) {
+      const transient = isTransientLogReadError(error);
+      const transientRetryLimit =
+        logBlockRange === MINIMUM_LOG_BLOCK_RANGE
+          ? MINIMUM_RANGE_TRANSIENT_RETRIES
+          : TRANSIENT_RETRIES_PER_WINDOW;
+      if (transient && transientRetries < transientRetryLimit) {
+        transientRetries += 1;
+        console.warn("Stock-Paired log window retried after transient RPC rejection", {
+          release: release.internalContractRelease,
+          fromBlock: fromBlock.toString(),
+          attemptedToBlock: rangeEnd.toString(),
+          retry: transientRetries,
+          retryLimit: transientRetryLimit,
+          errorName: error instanceof Error ? error.name : "UnknownError",
+        });
+        continue;
+      }
       if (
-        (error instanceof TimeoutError ||
+        (transient ||
           error instanceof LimitExceededRpcError ||
-          error instanceof HttpRequestError ||
           error instanceof ResponseBodyTooLargeError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
@@ -313,6 +352,7 @@ export async function readStockPairedEvents(
           reducedRange < MINIMUM_LOG_BLOCK_RANGE
             ? MINIMUM_LOG_BLOCK_RANGE
             : reducedRange;
+        transientRetries = 0;
         console.warn(
           "Stock-Paired log range reduced after RPC rejection",
           {
@@ -320,7 +360,7 @@ export async function readStockPairedEvents(
             fromBlock: fromBlock.toString(),
             attemptedToBlock: rangeEnd.toString(),
             nextRange: logBlockRange.toString(),
-            errorName: error.name,
+            errorName: error instanceof Error ? error.name : "UnknownError",
           },
         );
         continue;
@@ -411,6 +451,13 @@ export async function readStockPairedEvents(
       volumes.set(key, current);
     }
     fromBlock = rangeEnd + 1n;
+    transientRetries = 0;
+    if (logBlockRange < configuredLogBlockRange) {
+      logBlockRange = minimum(
+        configuredLogBlockRange,
+        logBlockRange * 2n,
+      );
+    }
   }
 
   return { launches, ethLaunches, liquidities, initialBuys, volumes };

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -14,19 +14,19 @@ const APPROVED_OPERATIONS = Object.freeze({
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
-        sha256: "654eb383431ce6518deda90db07b2c083be0bc7bfb5f66c80b476dd853120244",
+        sha256: "c3207b24610229a044ed886dc20654b57c1121e448e4a18c440b82c8d1d59015",
       }),
       releaseRuntimes: Object.freeze([
         Object.freeze({
           release: "classic-v3",
           path: "lib/onchain/classic-v3-read-model.ts",
-          sha256: "1f9c711c8df4159a7b391e95880f7a9e5aa88191572d043b86fba9baa2b3f11b",
+          sha256: "8659e109910f89e7f67ab48772e1c88854757b3cd443119bb01410f46da17d15",
           eventFiltersPerRange: 2,
         }),
         Object.freeze({
           release: "stock-paired-v1-v3",
           path: "lib/onchain/stock-paired-read-model.ts",
-          sha256: "6b5b5def718509f954e54a11849daf4584e3e048a3607b0a0126b5fe61ac7ec2",
+          sha256: "02530f837f91c7bacb8922397d7f16bfbb773166ad4992186b15eacfd43125c7",
           eventFiltersPerRange: 3,
         }),
       ]),
@@ -1489,11 +1489,15 @@ export function evaluateReadModelOperationsSourceContracts(
   const stockPairedRefreshSource = source(releaseRuntimes?.[1]?.path);
   const hasAdaptiveCompleteRangeScan = (runtimeSource) =>
     runtimeSource?.includes("allSettledOrThrow([") &&
+    runtimeSource?.includes("const MINIMUM_LOG_BLOCK_RANGE = 1n;") &&
+    runtimeSource?.includes("const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;") &&
+    runtimeSource?.includes("transientRetries < transientRetryLimit") &&
     runtimeSource?.includes("error instanceof TimeoutError") &&
     runtimeSource?.includes("error instanceof LimitExceededRpcError") &&
     runtimeSource?.includes("error instanceof HttpRequestError") &&
     runtimeSource?.includes("error instanceof ResponseBodyTooLargeError") &&
     runtimeSource?.includes("logBlockRange > MINIMUM_LOG_BLOCK_RANGE") &&
+    runtimeSource?.includes("logBlockRange * 2n") &&
     runtimeSource?.includes("continue;");
   check(
     "ops-legacy-bounded-refresh",

--- a/tests/classic-v3-read-model.test.ts
+++ b/tests/classic-v3-read-model.test.ts
@@ -1,5 +1,6 @@
 import {
   LimitExceededRpcError,
+  TimeoutError,
   type PublicClient,
 } from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -128,6 +129,31 @@ describe("Classic V3 event scan", () => {
       ),
     ).resolves.toEqual({ launches: [], volumes: new Map() });
     expect(getLogs).toHaveBeenCalledTimes(6);
+  });
+
+  it("retries the same complete Classic V3 window after a transient", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
+      if (firstRequest) {
+        firstRequest = false;
+        throw new TimeoutError({
+          body: { method: "eth_getLogs" },
+          url: readyDeployment.rpcUrl,
+        });
+      }
+      return [];
+    });
+    await expect(
+      readClassicV3Events(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_000n,
+        1n,
+      ),
+    ).resolves.toEqual({ launches: [], volumes: new Map() });
+    expect(getLogs).toHaveBeenCalledTimes(4);
   });
 
   it("fails closed on a decoded event from the wrong contract", async () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -658,8 +658,26 @@ describe("read-model operations source contract", () => {
     [
       "timeout range bisection",
       "lib/onchain/read-model.ts",
-      "error instanceof TimeoutError ||",
-      "false ||",
+      "error instanceof TimeoutError",
+      "false",
+    ],
+    [
+      "single-block adaptive floor",
+      "lib/onchain/read-model.ts",
+      "const MINIMUM_LOG_BLOCK_RANGE = 1n;",
+      "const MINIMUM_LOG_BLOCK_RANGE = 100n;",
+    ],
+    [
+      "bounded minimum-window retries",
+      "lib/onchain/read-model.ts",
+      "const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;",
+      "const MINIMUM_RANGE_TRANSIENT_RETRIES = 0;",
+    ],
+    [
+      "post-success range recovery",
+      "lib/onchain/read-model.ts",
+      "logBlockRange * 2n",
+      "logBlockRange",
     ],
     [
       "Classic V2 result-limit range bisection",

--- a/tests/onchain-read-model.test.ts
+++ b/tests/onchain-read-model.test.ts
@@ -308,7 +308,7 @@ describe("Explore verified event indexing", () => {
     );
   });
 
-  it("bisects and retries the same complete range after a transport timeout", async () => {
+  it("retries the same complete range after a transient transport timeout", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     let firstRequest = true;
     const getLogs = vi.fn(
@@ -337,7 +337,7 @@ describe("Explore verified event indexing", () => {
       ),
     ).resolves.toMatchObject({ launches: [], creatorClaims: [] });
 
-    expect(getLogs).toHaveBeenCalledTimes(6);
+    expect(getLogs).toHaveBeenCalledTimes(4);
     expect(
       getLogs.mock.calls.map(([input]) => [
         input.address,
@@ -347,20 +347,76 @@ describe("Explore verified event indexing", () => {
     ).toEqual([
       [readyDeployment.launcher, 1n, 1_000n],
       [readyDeployment.feeHook, 1n, 1_000n],
-      [readyDeployment.launcher, 1n, 500n],
-      [readyDeployment.feeHook, 1n, 500n],
-      [readyDeployment.launcher, 501n, 1_000n],
-      [readyDeployment.feeHook, 501n, 1_000n],
+      [readyDeployment.launcher, 1n, 1_000n],
+      [readyDeployment.feeHook, 1n, 1_000n],
     ]);
     expect(console.warn).toHaveBeenCalledWith(
-      "Explore log range reduced after RPC rejection",
+      "Explore log window retried after transient RPC rejection",
       expect.objectContaining({
         fromBlock: "1",
         attemptedToBlock: "1000",
-        nextRange: "500",
+        retry: 1,
         errorName: "TimeoutError",
       }),
     );
+  });
+
+  it("halves after the bounded retry and grows after a successful window", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let launcherFailures = 2;
+    const getLogs = vi.fn(async (input: {
+      address: string;
+      fromBlock: bigint;
+      toBlock: bigint;
+    }) => {
+      if (input.address === readyDeployment.launcher && launcherFailures > 0) {
+        launcherFailures -= 1;
+        throw new TimeoutError({
+          body: { method: "eth_getLogs" },
+          url: readyDeployment.rpcUrl,
+        });
+      }
+      return [];
+    });
+
+    await indexVerifiedEvents(
+      { getLogs } as unknown as PublicClient,
+      readyDeployment,
+      1_000n,
+    );
+
+    expect(
+      getLogs.mock.calls
+        .filter(([input]) => input.address === readyDeployment.launcher)
+        .map(([input]) => [input.fromBlock, input.toBlock]),
+    ).toEqual([
+      [1n, 1_000n],
+      [1n, 1_000n],
+      [1n, 500n],
+      [501n, 1_000n],
+    ]);
+  });
+
+  it("retries a one-block window twice before failing closed", async () => {
+    let launcherFailures = 2;
+    const getLogs = vi.fn(async (input: { address: string }) => {
+      if (input.address === readyDeployment.launcher && launcherFailures > 0) {
+        launcherFailures -= 1;
+        throw new TimeoutError({
+          body: { method: "eth_getLogs" },
+          url: readyDeployment.rpcUrl,
+        });
+      }
+      return [];
+    });
+    await expect(
+      indexVerifiedEvents(
+        { getLogs } as unknown as PublicClient,
+        { ...readyDeployment, logBlockRange: 1n },
+        1n,
+      ),
+    ).resolves.toMatchObject({ launches: [] });
+    expect(getLogs).toHaveBeenCalledTimes(6);
   });
 
   it("bisects and retries the complete range after an RPC result limit", async () => {
@@ -406,8 +462,8 @@ describe("Explore verified event indexing", () => {
     await expect(
       indexVerifiedEvents(
         { getLogs } as unknown as PublicClient,
-        { ...readyDeployment, logBlockRange: 100n },
-        100n,
+        { ...readyDeployment, logBlockRange: 1n },
+        1n,
       ),
     ).rejects.toBeInstanceOf(LimitExceededRpcError);
     expect(getLogs).toHaveBeenCalledTimes(2);

--- a/tests/stock-paired-read-model.test.ts
+++ b/tests/stock-paired-read-model.test.ts
@@ -1,6 +1,7 @@
 import {
   getAddress,
   LimitExceededRpcError,
+  TimeoutError,
   type Hex,
   type PublicClient,
 } from "viem";
@@ -120,6 +121,32 @@ describe("Stock-Paired event scan", () => {
       ),
     ).resolves.toMatchObject({ launches: [], volumes: new Map() });
     expect(getLogs).toHaveBeenCalledTimes(9);
+  });
+
+  it("retries the same complete Stock window after a transient", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const release = stockPairedReleaseFixture();
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
+      if (firstRequest) {
+        firstRequest = false;
+        throw new TimeoutError({
+          body: { method: "eth_getLogs" },
+          url: readyDeployment.rpcUrl,
+        });
+      }
+      return [];
+    });
+    await expect(
+      readStockPairedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_099n,
+        100n,
+      ),
+    ).resolves.toMatchObject({ launches: [], volumes: new Map() });
+    expect(getLogs).toHaveBeenCalledTimes(6);
   });
 
   it("fails closed on a decoded Stock event from the wrong contract", async () => {


### PR DESCRIPTION
## Outcome

Closes the exact intermittent transport failure from Stage run 31694277820 without accepting partial data or weakening the dual-provider model.

## Exact diagnosis

The failing Classic V2 range 25,722,131..25,722,230 is valid and contains 84 canonical fee events. Repeated identical reads succeeded before and after one approximately 10 second temporary provider failure. The old minimum range of 100 converted that one transient into a permanent refresh failure.

## Changes

- bounded retry of the exact complete window for TimeoutError, eligible HttpRequestError, or exact -32603 temporary-unavailable
- range floor 1 for genuine capacity/result-size bisection
- two bounded retries at the single-block floor, then fail closed
- geometric range recovery after every successful reduced window
- same fromBlock, all filters fully settled, no partial incorporation
- identical behavior across Classic V2, Classic V3, and Stock
- exact runtime-byte and source-contract bindings updated

## Validation

- 638/638 focused and operations tests
- TypeScript pass
- operations gate pass
- ESLint zero errors
- diff check pass
- exact gitleaks commit range: no leaks

Quorum, fingerprints, freshness, durable writes, and release gates remain unchanged.