### PR TITLE
Retry transient log windows and parallelize registry refresh

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -9,8 +9,14 @@
     "boundedRefresh": {
       "runtime": {
         "path": "lib/onchain/read-model.ts",
-        "sha256": "c3207b24610229a044ed886dc20654b57c1121e448e4a18c440b82c8d1d59015"
+        "sha256": "7533f391d67c75a040032c36f5ade5525ee81febabcfb01afe5cebb68e32049a"
       },
+      "dependencies": [
+        {
+          "path": "lib/onchain/parallel-reads.ts",
+          "sha256": "ef2bf54f390dca210dfdb3b5ba29c4cf8f6eaea2574c9be219a5410dbf8fb64e"
+        }
+      ],
       "releaseRuntimes": [
         {
           "release": "classic-v3",

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -9,19 +9,19 @@
     "boundedRefresh": {
       "runtime": {
         "path": "lib/onchain/read-model.ts",
-        "sha256": "654eb383431ce6518deda90db07b2c083be0bc7bfb5f66c80b476dd853120244"
+        "sha256": "c3207b24610229a044ed886dc20654b57c1121e448e4a18c440b82c8d1d59015"
       },
       "releaseRuntimes": [
         {
           "release": "classic-v3",
           "path": "lib/onchain/classic-v3-read-model.ts",
-          "sha256": "1f9c711c8df4159a7b391e95880f7a9e5aa88191572d043b86fba9baa2b3f11b",
+          "sha256": "8659e109910f89e7f67ab48772e1c88854757b3cd443119bb01410f46da17d15",
           "eventFiltersPerRange": 2
         },
         {
           "release": "stock-paired-v1-v3",
           "path": "lib/onchain/stock-paired-read-model.ts",
-          "sha256": "6b5b5def718509f954e54a11849daf4584e3e048a3607b0a0126b5fe61ac7ec2",
+          "sha256": "02530f837f91c7bacb8922397d7f16bfbb773166ad4992186b15eacfd43125c7",
           "eventFiltersPerRange": 3
         }
       ],

--- a/lib/onchain/classic-v3-read-model.ts
+++ b/lib/onchain/classic-v3-read-model.ts
@@ -8,6 +8,7 @@ import {
   LimitExceededRpcError,
   parseAbiItem,
   ResponseBodyTooLargeError,
+  RpcRequestError,
   TimeoutError,
   type Address,
   type Hex,
@@ -90,7 +91,27 @@ const EMPTY_VOLUME: FeeVolume = {
 const RPC_PROVENANCE_BATCH_SIZE = 1;
 const TOKEN_HYDRATION_BATCH_SIZE = 6;
 const BLOCK_TIMESTAMP_BATCH_SIZE = 4;
-const MINIMUM_LOG_BLOCK_RANGE = 100n;
+const MINIMUM_LOG_BLOCK_RANGE = 1n;
+const TRANSIENT_RETRIES_PER_WINDOW = 1;
+const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;
+
+function isTransientLogReadError(error: unknown) {
+  if (error instanceof TimeoutError) return true;
+  if (error instanceof HttpRequestError) {
+    return (
+      error.status === undefined ||
+      error.status === 408 ||
+      error.status === 425 ||
+      error.status === 429 ||
+      error.status >= 500
+    );
+  }
+  return (
+    error instanceof RpcRequestError &&
+    error.code === -32603 &&
+    error.details.trim().toLowerCase() === "service temporarily unavailable"
+  );
+}
 
 function minimum(left: bigint, right: bigint) {
   return left < right ? left : right;
@@ -222,7 +243,9 @@ export async function readClassicV3Events(
     fromBlockFloor > release.startBlock
       ? fromBlockFloor
       : release.startBlock;
-  let logBlockRange = config.logBlockRange;
+  const configuredLogBlockRange = config.logBlockRange;
+  let logBlockRange = configuredLogBlockRange;
+  let transientRetries = 0;
   while (fromBlock <= toBlock) {
     const rangeEnd = minimum(
       toBlock,
@@ -249,10 +272,25 @@ export async function readClassicV3Events(
     try {
       logs = await readLogs();
     } catch (error) {
+      const transient = isTransientLogReadError(error);
+      const transientRetryLimit =
+        logBlockRange === MINIMUM_LOG_BLOCK_RANGE
+          ? MINIMUM_RANGE_TRANSIENT_RETRIES
+          : TRANSIENT_RETRIES_PER_WINDOW;
+      if (transient && transientRetries < transientRetryLimit) {
+        transientRetries += 1;
+        console.warn("Classic V3 log window retried after transient RPC rejection", {
+          fromBlock: fromBlock.toString(),
+          attemptedToBlock: rangeEnd.toString(),
+          retry: transientRetries,
+          retryLimit: transientRetryLimit,
+          errorName: error instanceof Error ? error.name : "UnknownError",
+        });
+        continue;
+      }
       if (
-        (error instanceof TimeoutError ||
+        (transient ||
           error instanceof LimitExceededRpcError ||
-          error instanceof HttpRequestError ||
           error instanceof ResponseBodyTooLargeError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
@@ -262,13 +300,14 @@ export async function readClassicV3Events(
           reducedRange < MINIMUM_LOG_BLOCK_RANGE
             ? MINIMUM_LOG_BLOCK_RANGE
             : reducedRange;
+        transientRetries = 0;
         console.warn(
           "Classic V3 log range reduced after RPC rejection",
           {
             fromBlock: fromBlock.toString(),
             attemptedToBlock: rangeEnd.toString(),
             nextRange: logBlockRange.toString(),
-            errorName: error.name,
+            errorName: error instanceof Error ? error.name : "UnknownError",
           },
         );
         continue;
@@ -317,6 +356,13 @@ export async function readClassicV3Events(
       volumes.set(key, current);
     }
     fromBlock = rangeEnd + 1n;
+    transientRetries = 0;
+    if (logBlockRange < configuredLogBlockRange) {
+      logBlockRange = minimum(
+        configuredLogBlockRange,
+        logBlockRange * 2n,
+      );
+    }
   }
   return { launches, volumes };
 }

--- a/lib/onchain/parallel-reads.ts
+++ b/lib/onchain/parallel-reads.ts
@@ -1,0 +1,17 @@
+type ParallelRead = () => Promise<unknown>;
+
+type ParallelReadValues<Reads extends readonly ParallelRead[]> = {
+  -readonly [Index in keyof Reads]: Awaited<ReturnType<Reads[Index]>>;
+};
+
+export async function settleParallelReadsInOrder<
+  const Reads extends readonly ParallelRead[],
+>(reads: Reads): Promise<ParallelReadValues<Reads>> {
+  const results = await Promise.allSettled(reads.map((read) => read()));
+  for (const result of results) {
+    if (result.status === "rejected") throw result.reason;
+  }
+  return results.map((result) =>
+    result.status === "fulfilled" ? result.value : undefined,
+  ) as ParallelReadValues<Reads>;
+}

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -7,6 +7,7 @@ import {
   keccak256,
   LimitExceededRpcError,
   ResponseBodyTooLargeError,
+  RpcRequestError,
   TimeoutError,
   type Address,
   type Hex,
@@ -88,7 +89,9 @@ const ZERO_FEE_VOLUME: FeeVolume = {
 const TOKEN_HYDRATION_BATCH_SIZE = 12;
 const BLOCK_TIMESTAMP_BATCH_SIZE = 4;
 const RPC_PROVENANCE_BATCH_SIZE = 1;
-const MINIMUM_LOG_BLOCK_RANGE = 100n;
+const MINIMUM_LOG_BLOCK_RANGE = 1n;
+const TRANSIENT_RETRIES_PER_WINDOW = 1;
+const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;
 const CLASSIC_LAUNCHER_EVENTS = [
   memeTokenLaunchedEvent,
   memeLiquidityConfiguredEvent,
@@ -98,6 +101,24 @@ const CLASSIC_FEE_HOOK_EVENTS = [
   nativeSwapFeesAccruedEvent,
   creatorFeesClaimedEvent,
 ] as const;
+
+function isTransientLogReadError(error: unknown) {
+  if (error instanceof TimeoutError) return true;
+  if (error instanceof HttpRequestError) {
+    return (
+      error.status === undefined ||
+      error.status === 408 ||
+      error.status === 425 ||
+      error.status === 429 ||
+      error.status >= 500
+    );
+  }
+  return (
+    error instanceof RpcRequestError &&
+    error.code === -32603 &&
+    error.details.trim().toLowerCase() === "service temporarily unavailable"
+  );
+}
 
 type FeeDisclosure = readonly [
   buySwapFeeBps: number,
@@ -291,7 +312,9 @@ export async function indexVerifiedEvents(
   const creatorClaims: CreatorClaimEventRecord[] = [];
 
   let fromBlock = config.deploymentBlock;
-  let logBlockRange = config.logBlockRange;
+  const configuredLogBlockRange = config.logBlockRange;
+  let logBlockRange = configuredLogBlockRange;
+  let transientRetries = 0;
   while (fromBlock <= toBlock) {
     const rangeEnd = minimum(
       toBlock,
@@ -318,11 +341,26 @@ export async function indexVerifiedEvents(
     try {
       logs = await readLogs();
     } catch (error) {
+      const transient = isTransientLogReadError(error);
+      const transientRetryLimit =
+        logBlockRange === MINIMUM_LOG_BLOCK_RANGE
+          ? MINIMUM_RANGE_TRANSIENT_RETRIES
+          : TRANSIENT_RETRIES_PER_WINDOW;
+      if (transient && transientRetries < transientRetryLimit) {
+        transientRetries += 1;
+        console.warn("Explore log window retried after transient RPC rejection", {
+          fromBlock: fromBlock.toString(),
+          attemptedToBlock: rangeEnd.toString(),
+          retry: transientRetries,
+          retryLimit: transientRetryLimit,
+          errorName: error instanceof Error ? error.name : "UnknownError",
+        });
+        continue;
+      }
       if (
-        (error instanceof TimeoutError ||
+        (transient ||
           error instanceof LimitExceededRpcError ||
-          error instanceof ResponseBodyTooLargeError ||
-          error instanceof HttpRequestError) &&
+          error instanceof ResponseBodyTooLargeError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
       ) {
@@ -331,11 +369,12 @@ export async function indexVerifiedEvents(
           reducedRange < MINIMUM_LOG_BLOCK_RANGE
             ? MINIMUM_LOG_BLOCK_RANGE
             : reducedRange;
+        transientRetries = 0;
         console.warn("Explore log range reduced after RPC rejection", {
           fromBlock: fromBlock.toString(),
           attemptedToBlock: rangeEnd.toString(),
           nextRange: logBlockRange.toString(),
-          errorName: error.name,
+          errorName: error instanceof Error ? error.name : "UnknownError",
         });
         continue;
       }
@@ -431,6 +470,13 @@ export async function indexVerifiedEvents(
       }
     }
     fromBlock = rangeEnd + 1n;
+    transientRetries = 0;
+    if (logBlockRange < configuredLogBlockRange) {
+      logBlockRange = minimum(
+        configuredLogBlockRange,
+        logBlockRange * 2n,
+      );
+    }
   }
 
   return {

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -78,6 +78,7 @@ import {
   mergeStockPairedExploreModel,
   readStockPairedExploreModel,
 } from "./stock-paired-read-model";
+import { settleParallelReadsInOrder } from "./parallel-reads";
 
 const ZERO_FEE_VOLUME: FeeVolume = {
   grossNativeAmount: 0n,
@@ -1107,45 +1108,54 @@ async function readReadyRegistryModel(
     throw new Error("The Classic registry has no confirmed snapshot");
   }
   const snapshotBlockNumber = registry.snapshot.blockNumber;
-  if (isClassicV3ExploreReleaseReady(config)) {
-    registry = mergeClassicV3ExploreModel(
-      registry,
-      await withReadStage("classic-v3", () =>
-        readClassicV3ExploreModel(config, snapshotBlockNumber),
-      ),
-    );
+  const [classicV3, deepV1, deepV2, deepV3, stockPaired] =
+    await settleParallelReadsInOrder([
+      () =>
+        isClassicV3ExploreReleaseReady(config)
+          ? withReadStage("classic-v3", () =>
+              readClassicV3ExploreModel(config, snapshotBlockNumber),
+            )
+          : Promise.resolve(null),
+      () =>
+        isDeepExploreReleaseReady(config)
+          ? withReadStage("deep-v1", () =>
+              readDeepExploreModel(config, snapshotBlockNumber),
+            )
+          : Promise.resolve(null),
+      () =>
+        isDeepV2ExploreReleaseReady(config)
+          ? withReadStage("deep-v2", () =>
+              readDeepV2ExploreModel(config, snapshotBlockNumber),
+            )
+          : Promise.resolve(null),
+      () =>
+        isDeepV3ExploreReleaseReady(config)
+          ? withReadStage("deep-v3", () =>
+              readDeepV3ExploreModel(config, snapshotBlockNumber),
+            )
+          : Promise.resolve(null),
+      () =>
+        isStockPairedExploreReleaseReady(config)
+          ? withReadStage("stock-paired", () =>
+              readStockPairedExploreModel(config, snapshotBlockNumber),
+            )
+          : Promise.resolve(null),
+    ] as const);
+
+  if (classicV3 !== null) {
+    registry = mergeClassicV3ExploreModel(registry, classicV3);
   }
-  if (isDeepExploreReleaseReady(config)) {
-    registry = mergeDeepExploreModel(
-      registry,
-      await withReadStage("deep-v1", () =>
-        readDeepExploreModel(config, snapshotBlockNumber),
-      ),
-    );
+  if (deepV1 !== null) {
+    registry = mergeDeepExploreModel(registry, deepV1);
   }
-  if (isDeepV2ExploreReleaseReady(config)) {
-    registry = mergeDeepExploreModel(
-      registry,
-      await withReadStage("deep-v2", () =>
-        readDeepV2ExploreModel(config, snapshotBlockNumber),
-      ),
-    );
+  if (deepV2 !== null) {
+    registry = mergeDeepExploreModel(registry, deepV2);
   }
-  if (isDeepV3ExploreReleaseReady(config)) {
-    registry = mergeDeepV3ExploreModel(
-      registry,
-      await withReadStage("deep-v3", () =>
-        readDeepV3ExploreModel(config, snapshotBlockNumber),
-      ),
-    );
+  if (deepV3 !== null) {
+    registry = mergeDeepV3ExploreModel(registry, deepV3);
   }
-  if (isStockPairedExploreReleaseReady(config)) {
-    registry = mergeStockPairedExploreModel(
-      registry,
-      await withReadStage("stock-paired", () =>
-        readStockPairedExploreModel(config, snapshotBlockNumber),
-      ),
-    );
+  if (stockPaired !== null) {
+    registry = mergeStockPairedExploreModel(registry, stockPaired);
   }
   return registry;
 }

--- a/lib/onchain/stock-paired-read-model.ts
+++ b/lib/onchain/stock-paired-read-model.ts
@@ -8,6 +8,7 @@ import {
   LimitExceededRpcError,
   parseAbiItem,
   ResponseBodyTooLargeError,
+  RpcRequestError,
   TimeoutError,
   type Address,
   type Hex,
@@ -135,7 +136,27 @@ const RPC_PROVENANCE_BATCH_SIZE = 1;
 const TOKEN_HYDRATION_BATCH_SIZE = 6;
 const BLOCK_TIMESTAMP_BATCH_SIZE = 4;
 const QUOTE_PRICE_BATCH_SIZE = 2;
-const MINIMUM_LOG_BLOCK_RANGE = 100n;
+const MINIMUM_LOG_BLOCK_RANGE = 1n;
+const TRANSIENT_RETRIES_PER_WINDOW = 1;
+const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;
+
+function isTransientLogReadError(error: unknown) {
+  if (error instanceof TimeoutError) return true;
+  if (error instanceof HttpRequestError) {
+    return (
+      error.status === undefined ||
+      error.status === 408 ||
+      error.status === 425 ||
+      error.status === 429 ||
+      error.status >= 500
+    );
+  }
+  return (
+    error instanceof RpcRequestError &&
+    error.code === -32603 &&
+    error.details.trim().toLowerCase() === "service temporarily unavailable"
+  );
+}
 
 function minimum(left: bigint, right: bigint) {
   return left < right ? left : right;
@@ -266,7 +287,9 @@ export async function readStockPairedEvents(
     fromBlockFloor > releaseStartBlock
       ? fromBlockFloor
       : releaseStartBlock;
-  let logBlockRange = config.logBlockRange;
+  const configuredLogBlockRange = config.logBlockRange;
+  let logBlockRange = configuredLogBlockRange;
+  let transientRetries = 0;
   while (fromBlock <= toBlock) {
     const rangeEnd = minimum(
       toBlock,
@@ -300,10 +323,26 @@ export async function readStockPairedEvents(
     try {
       logs = await readLogs();
     } catch (error) {
+      const transient = isTransientLogReadError(error);
+      const transientRetryLimit =
+        logBlockRange === MINIMUM_LOG_BLOCK_RANGE
+          ? MINIMUM_RANGE_TRANSIENT_RETRIES
+          : TRANSIENT_RETRIES_PER_WINDOW;
+      if (transient && transientRetries < transientRetryLimit) {
+        transientRetries += 1;
+        console.warn("Stock-Paired log window retried after transient RPC rejection", {
+          release: release.internalContractRelease,
+          fromBlock: fromBlock.toString(),
+          attemptedToBlock: rangeEnd.toString(),
+          retry: transientRetries,
+          retryLimit: transientRetryLimit,
+          errorName: error instanceof Error ? error.name : "UnknownError",
+        });
+        continue;
+      }
       if (
-        (error instanceof TimeoutError ||
+        (transient ||
           error instanceof LimitExceededRpcError ||
-          error instanceof HttpRequestError ||
           error instanceof ResponseBodyTooLargeError) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
@@ -313,6 +352,7 @@ export async function readStockPairedEvents(
           reducedRange < MINIMUM_LOG_BLOCK_RANGE
             ? MINIMUM_LOG_BLOCK_RANGE
             : reducedRange;
+        transientRetries = 0;
         console.warn(
           "Stock-Paired log range reduced after RPC rejection",
           {
@@ -320,7 +360,7 @@ export async function readStockPairedEvents(
             fromBlock: fromBlock.toString(),
             attemptedToBlock: rangeEnd.toString(),
             nextRange: logBlockRange.toString(),
-            errorName: error.name,
+            errorName: error instanceof Error ? error.name : "UnknownError",
           },
         );
         continue;
@@ -411,6 +451,13 @@ export async function readStockPairedEvents(
       volumes.set(key, current);
     }
     fromBlock = rangeEnd + 1n;
+    transientRetries = 0;
+    if (logBlockRange < configuredLogBlockRange) {
+      logBlockRange = minimum(
+        configuredLogBlockRange,
+        logBlockRange * 2n,
+      );
+    }
   }
 
   return { launches, ethLaunches, liquidities, initialBuys, volumes };

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -14,8 +14,14 @@ const APPROVED_OPERATIONS = Object.freeze({
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
-        sha256: "c3207b24610229a044ed886dc20654b57c1121e448e4a18c440b82c8d1d59015",
+        sha256: "7533f391d67c75a040032c36f5ade5525ee81febabcfb01afe5cebb68e32049a",
       }),
+      dependencies: Object.freeze([
+        Object.freeze({
+          path: "lib/onchain/parallel-reads.ts",
+          sha256: "ef2bf54f390dca210dfdb3b5ba29c4cf8f6eaea2574c9be219a5410dbf8fb64e",
+        }),
+      ]),
       releaseRuntimes: Object.freeze([
         Object.freeze({
           release: "classic-v3",
@@ -1484,6 +1490,7 @@ export function evaluateReadModelOperationsSourceContracts(
   const boundedRefresh = operations?.legacyIndexer?.boundedRefresh;
   const legacyRouteSource = source(APPROVED_OPERATIONS.legacyIndexer.route);
   const refreshRuntimeSource = source(boundedRefresh?.runtime?.path);
+  const parallelReadsSource = source(boundedRefresh?.dependencies?.[0]?.path);
   const releaseRuntimes = boundedRefresh?.releaseRuntimes;
   const classicV3RefreshSource = source(releaseRuntimes?.[0]?.path);
   const stockPairedRefreshSource = source(releaseRuntimes?.[1]?.path);
@@ -1510,6 +1517,20 @@ export function evaluateReadModelOperationsSourceContracts(
         boundedRefresh?.runtime,
         expectedSha256Overrides,
       ) &&
+      boundedRefresh?.dependencies?.length === 1 &&
+      sourceBindingMatches(
+        source,
+        boundedRefresh.dependencies[0],
+        expectedSha256Overrides,
+      ) &&
+      refreshRuntimeSource?.includes(
+        'import { settleParallelReadsInOrder } from "./parallel-reads";',
+      ) &&
+      refreshRuntimeSource?.includes(
+        "await settleParallelReadsInOrder([",
+      ) &&
+      parallelReadsSource?.includes("Promise.allSettled(") &&
+      parallelReadsSource?.includes("for (const result of results)") &&
       Array.isArray(releaseRuntimes) &&
       releaseRuntimes.length === 2 &&
       releaseRuntimes[0]?.release === "classic-v3" &&
@@ -1547,7 +1568,7 @@ export function evaluateReadModelOperationsSourceContracts(
       stockPairedRefreshSource?.includes("events: STOCK_LAUNCHER_EVENTS") &&
       stockPairedRefreshSource?.includes("assertCanonicalStockEventSource(") &&
       stockPairedRefreshSource?.includes("clients.map((candidate) =>"),
-    "all active release scanners use minimal canonical filters, settle complete ranges, adapt exact RPC rejections and compare two provider passes before the platform deadline",
+    "all active release scanners use minimal canonical filters, settle complete ranges, adapt exact RPC rejections, compare two provider passes and settle registry slices in parallel before deterministic merging and the platform deadline",
   );
   const schedulerWatchdog = operations?.legacyIndexer?.schedulerWatchdog;
   check(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -14,19 +14,19 @@ const APPROVED_OPERATIONS = Object.freeze({
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
-        sha256: "654eb383431ce6518deda90db07b2c083be0bc7bfb5f66c80b476dd853120244",
+        sha256: "c3207b24610229a044ed886dc20654b57c1121e448e4a18c440b82c8d1d59015",
       }),
       releaseRuntimes: Object.freeze([
         Object.freeze({
           release: "classic-v3",
           path: "lib/onchain/classic-v3-read-model.ts",
-          sha256: "1f9c711c8df4159a7b391e95880f7a9e5aa88191572d043b86fba9baa2b3f11b",
+          sha256: "8659e109910f89e7f67ab48772e1c88854757b3cd443119bb01410f46da17d15",
           eventFiltersPerRange: 2,
         }),
         Object.freeze({
           release: "stock-paired-v1-v3",
           path: "lib/onchain/stock-paired-read-model.ts",
-          sha256: "6b5b5def718509f954e54a11849daf4584e3e048a3607b0a0126b5fe61ac7ec2",
+          sha256: "02530f837f91c7bacb8922397d7f16bfbb773166ad4992186b15eacfd43125c7",
           eventFiltersPerRange: 3,
         }),
       ]),
@@ -1489,11 +1489,15 @@ export function evaluateReadModelOperationsSourceContracts(
   const stockPairedRefreshSource = source(releaseRuntimes?.[1]?.path);
   const hasAdaptiveCompleteRangeScan = (runtimeSource) =>
     runtimeSource?.includes("allSettledOrThrow([") &&
+    runtimeSource?.includes("const MINIMUM_LOG_BLOCK_RANGE = 1n;") &&
+    runtimeSource?.includes("const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;") &&
+    runtimeSource?.includes("transientRetries < transientRetryLimit") &&
     runtimeSource?.includes("error instanceof TimeoutError") &&
     runtimeSource?.includes("error instanceof LimitExceededRpcError") &&
     runtimeSource?.includes("error instanceof HttpRequestError") &&
     runtimeSource?.includes("error instanceof ResponseBodyTooLargeError") &&
     runtimeSource?.includes("logBlockRange > MINIMUM_LOG_BLOCK_RANGE") &&
+    runtimeSource?.includes("logBlockRange * 2n") &&
     runtimeSource?.includes("continue;");
   check(
     "ops-legacy-bounded-refresh",

--- a/tests/classic-v3-read-model.test.ts
+++ b/tests/classic-v3-read-model.test.ts
@@ -1,5 +1,6 @@
 import {
   LimitExceededRpcError,
+  TimeoutError,
   type PublicClient,
 } from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -128,6 +129,31 @@ describe("Classic V3 event scan", () => {
       ),
     ).resolves.toEqual({ launches: [], volumes: new Map() });
     expect(getLogs).toHaveBeenCalledTimes(6);
+  });
+
+  it("retries the same complete Classic V3 window after a transient", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
+      if (firstRequest) {
+        firstRequest = false;
+        throw new TimeoutError({
+          body: { method: "eth_getLogs" },
+          url: readyDeployment.rpcUrl,
+        });
+      }
+      return [];
+    });
+    await expect(
+      readClassicV3Events(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_000n,
+        1n,
+      ),
+    ).resolves.toEqual({ launches: [], volumes: new Map() });
+    expect(getLogs).toHaveBeenCalledTimes(4);
   });
 
   it("fails closed on a decoded event from the wrong contract", async () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -658,8 +658,26 @@ describe("read-model operations source contract", () => {
     [
       "timeout range bisection",
       "lib/onchain/read-model.ts",
-      "error instanceof TimeoutError ||",
-      "false ||",
+      "error instanceof TimeoutError",
+      "false",
+    ],
+    [
+      "single-block adaptive floor",
+      "lib/onchain/read-model.ts",
+      "const MINIMUM_LOG_BLOCK_RANGE = 1n;",
+      "const MINIMUM_LOG_BLOCK_RANGE = 100n;",
+    ],
+    [
+      "bounded minimum-window retries",
+      "lib/onchain/read-model.ts",
+      "const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;",
+      "const MINIMUM_RANGE_TRANSIENT_RETRIES = 0;",
+    ],
+    [
+      "post-success range recovery",
+      "lib/onchain/read-model.ts",
+      "logBlockRange * 2n",
+      "logBlockRange",
     ],
     [
       "Classic V2 result-limit range bisection",

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -656,6 +656,18 @@ describe("read-model operations source contract", () => {
       "const readLogs = () =>\n      Promise.all([",
     ],
     [
+      "parallel registry slices",
+      "lib/onchain/read-model.ts",
+      "await settleParallelReadsInOrder([",
+      "await Promise.all([",
+    ],
+    [
+      "settled registry orchestration",
+      "lib/onchain/parallel-reads.ts",
+      "Promise.allSettled(",
+      "Promise.all(",
+    ],
+    [
       "timeout range bisection",
       "lib/onchain/read-model.ts",
       "error instanceof TimeoutError",

--- a/tests/onchain-parallel-reads.test.ts
+++ b/tests/onchain-parallel-reads.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { settleParallelReadsInOrder } from "../lib/onchain/parallel-reads";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("parallel registry reads", () => {
+  it("starts every enabled read together and preserves declaration order", async () => {
+    const first = deferred<string>();
+    const second = deferred<number>();
+    const third = deferred<boolean>();
+    const started: string[] = [];
+
+    const result = settleParallelReadsInOrder([
+      () => {
+        started.push("classic-v3");
+        return first.promise;
+      },
+      () => {
+        started.push("deep-v1");
+        return second.promise;
+      },
+      () => {
+        started.push("stock-paired");
+        return third.promise;
+      },
+    ] as const);
+
+    expect(started).toEqual(["classic-v3", "deep-v1", "stock-paired"]);
+    third.resolve(true);
+    second.resolve(2);
+    first.resolve("one");
+    await expect(result).resolves.toEqual(["one", 2, true]);
+  });
+
+  it("finishes on the slowest read instead of the sum of read durations", async () => {
+    vi.useFakeTimers();
+    try {
+      const completed = vi.fn();
+      const delayedRead = <T>(value: T, delayMs: number) => () =>
+        new Promise<T>((resolve) => {
+          setTimeout(() => resolve(value), delayMs);
+        });
+      const startedAt = Date.now();
+      const result = settleParallelReadsInOrder([
+        delayedRead("classic-v3", 30),
+        delayedRead("deep-v1", 50),
+        delayedRead("stock-paired", 80),
+      ] as const).then((values) => {
+        completed();
+        return values;
+      });
+
+      await vi.advanceTimersByTimeAsync(79);
+      expect(completed).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expect(result).resolves.toEqual([
+        "classic-v3",
+        "deep-v1",
+        "stock-paired",
+      ]);
+      expect(Date.now() - startedAt).toBe(80);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("settles every read, reports the first failure and merges nothing", async () => {
+    const first = deferred<string>();
+    const second = deferred<number>();
+    const lateReadCompleted = vi.fn();
+    const merged: Array<string | number> = [];
+    const result = settleParallelReadsInOrder([
+      () => first.promise,
+      () => second.promise.finally(lateReadCompleted),
+    ] as const).then((values) => {
+      merged.push(...values);
+      return values;
+    });
+    const firstFailure = new Error("classic-v3 failed");
+
+    first.reject(firstFailure);
+    await Promise.resolve();
+    expect(lateReadCompleted).not.toHaveBeenCalled();
+    expect(merged).toEqual([]);
+    second.reject(new Error("deep-v1 failed"));
+
+    await expect(result).rejects.toBe(firstFailure);
+    expect(lateReadCompleted).toHaveBeenCalledOnce();
+    expect(merged).toEqual([]);
+  });
+});

--- a/tests/onchain-read-model.test.ts
+++ b/tests/onchain-read-model.test.ts
@@ -308,7 +308,7 @@ describe("Explore verified event indexing", () => {
     );
   });
 
-  it("bisects and retries the same complete range after a transport timeout", async () => {
+  it("retries the same complete range after a transient transport timeout", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     let firstRequest = true;
     const getLogs = vi.fn(
@@ -337,7 +337,7 @@ describe("Explore verified event indexing", () => {
       ),
     ).resolves.toMatchObject({ launches: [], creatorClaims: [] });
 
-    expect(getLogs).toHaveBeenCalledTimes(6);
+    expect(getLogs).toHaveBeenCalledTimes(4);
     expect(
       getLogs.mock.calls.map(([input]) => [
         input.address,
@@ -347,20 +347,76 @@ describe("Explore verified event indexing", () => {
     ).toEqual([
       [readyDeployment.launcher, 1n, 1_000n],
       [readyDeployment.feeHook, 1n, 1_000n],
-      [readyDeployment.launcher, 1n, 500n],
-      [readyDeployment.feeHook, 1n, 500n],
-      [readyDeployment.launcher, 501n, 1_000n],
-      [readyDeployment.feeHook, 501n, 1_000n],
+      [readyDeployment.launcher, 1n, 1_000n],
+      [readyDeployment.feeHook, 1n, 1_000n],
     ]);
     expect(console.warn).toHaveBeenCalledWith(
-      "Explore log range reduced after RPC rejection",
+      "Explore log window retried after transient RPC rejection",
       expect.objectContaining({
         fromBlock: "1",
         attemptedToBlock: "1000",
-        nextRange: "500",
+        retry: 1,
         errorName: "TimeoutError",
       }),
     );
+  });
+
+  it("halves after the bounded retry and grows after a successful window", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let launcherFailures = 2;
+    const getLogs = vi.fn(async (input: {
+      address: string;
+      fromBlock: bigint;
+      toBlock: bigint;
+    }) => {
+      if (input.address === readyDeployment.launcher && launcherFailures > 0) {
+        launcherFailures -= 1;
+        throw new TimeoutError({
+          body: { method: "eth_getLogs" },
+          url: readyDeployment.rpcUrl,
+        });
+      }
+      return [];
+    });
+
+    await indexVerifiedEvents(
+      { getLogs } as unknown as PublicClient,
+      readyDeployment,
+      1_000n,
+    );
+
+    expect(
+      getLogs.mock.calls
+        .filter(([input]) => input.address === readyDeployment.launcher)
+        .map(([input]) => [input.fromBlock, input.toBlock]),
+    ).toEqual([
+      [1n, 1_000n],
+      [1n, 1_000n],
+      [1n, 500n],
+      [501n, 1_000n],
+    ]);
+  });
+
+  it("retries a one-block window twice before failing closed", async () => {
+    let launcherFailures = 2;
+    const getLogs = vi.fn(async (input: { address: string }) => {
+      if (input.address === readyDeployment.launcher && launcherFailures > 0) {
+        launcherFailures -= 1;
+        throw new TimeoutError({
+          body: { method: "eth_getLogs" },
+          url: readyDeployment.rpcUrl,
+        });
+      }
+      return [];
+    });
+    await expect(
+      indexVerifiedEvents(
+        { getLogs } as unknown as PublicClient,
+        { ...readyDeployment, logBlockRange: 1n },
+        1n,
+      ),
+    ).resolves.toMatchObject({ launches: [] });
+    expect(getLogs).toHaveBeenCalledTimes(6);
   });
 
   it("bisects and retries the complete range after an RPC result limit", async () => {
@@ -406,8 +462,8 @@ describe("Explore verified event indexing", () => {
     await expect(
       indexVerifiedEvents(
         { getLogs } as unknown as PublicClient,
-        { ...readyDeployment, logBlockRange: 100n },
-        100n,
+        { ...readyDeployment, logBlockRange: 1n },
+        1n,
       ),
     ).rejects.toBeInstanceOf(LimitExceededRpcError);
     expect(getLogs).toHaveBeenCalledTimes(2);

--- a/tests/stock-paired-read-model.test.ts
+++ b/tests/stock-paired-read-model.test.ts
@@ -1,6 +1,7 @@
 import {
   getAddress,
   LimitExceededRpcError,
+  TimeoutError,
   type Hex,
   type PublicClient,
 } from "viem";
@@ -120,6 +121,32 @@ describe("Stock-Paired event scan", () => {
       ),
     ).resolves.toMatchObject({ launches: [], volumes: new Map() });
     expect(getLogs).toHaveBeenCalledTimes(9);
+  });
+
+  it("retries the same complete Stock window after a transient", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const release = stockPairedReleaseFixture();
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
+      if (firstRequest) {
+        firstRequest = false;
+        throw new TimeoutError({
+          body: { method: "eth_getLogs" },
+          url: readyDeployment.rpcUrl,
+        });
+      }
+      return [];
+    });
+    await expect(
+      readStockPairedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_099n,
+        100n,
+      ),
+    ).resolves.toMatchObject({ launches: [], volumes: new Map() });
+    expect(getLogs).toHaveBeenCalledTimes(6);
   });
 
   it("fails closed on a decoded Stock event from the wrong contract", async () => {


### PR DESCRIPTION
## Outcome

Makes the exact staged full durable refresh resilient to transient RPC failures and removes the remaining sequential registry critical path without weakening any integrity or publication gate.

## Exact evidence

- Stage 31694277820 failed after an intermittent transport error escaped at the old 100-block floor; the identical 100-block query is valid and returned 84 canonical fee events before and after one temporary provider failure.
- Stage 31695105528 then reached the controlled 270-second deadline, proving the remaining optional registry slices must not run serially.

## Changes

- bounded same-window retry for exact transient failures across Classic V2, Classic V3, and Stock
- capacity/result-size bisection to one block with bounded floor retries and geometric range recovery
- all event filters settle before retry; no partial incorporation
- run Classic V3, Deep V1/V2/V3, and Stock concurrently against the same exact Classic snapshot
- await all slices, then merge only after complete success in the unchanged deterministic order
- update exact runtime-byte/source-contract bindings

## Validation

- 648 focused scanner, route, helper, and operations tests
- TypeScript pass
- affected ESLint pass
- operations source contract pass
- diff check pass
- gitleaks exact 2-commit range: no leaks

Dual-provider fingerprints, state comparison, freshness, writes, and release gates remain fail-closed.