### PR TITLE
Keep staged Vercel metadata value-free

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -243,8 +243,8 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           umask 077
-          vercel env ls production --format json --token="$VERCEL_TOKEN" > "$RUNNER_TEMP/vercel-production-env-metadata.json"
-          node scripts/bind-vercel-sensitive-production-metadata.mjs \
+          test ! -e "$RUNNER_TEMP/vercel-production-env-metadata.json"
+          vercel env ls production --format json --token="$VERCEL_TOKEN" | node scripts/bind-vercel-sensitive-production-metadata.mjs \
             --metadata-file "$RUNNER_TEMP/vercel-production-env-metadata.json" \
             --vercel-project-id "$VERCEL_PROJECT_ID"
 

--- a/scripts/bind-vercel-sensitive-production-metadata.mjs
+++ b/scripts/bind-vercel-sensitive-production-metadata.mjs
@@ -1,10 +1,32 @@
 #!/usr/bin/env node
 
-import { readFile, rename, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
 export const VERCEL_SENSITIVE_PRODUCTION_METADATA_SCHEMA =
   "programmable.vercel-sensitive-production-metadata.v1";
+
+export function omitVercelEnvironmentValues(metadata) {
+  if (
+    metadata === null
+    || typeof metadata !== "object"
+    || Array.isArray(metadata)
+    || Object.keys(metadata).sort().join("\0") !== "envs"
+    || !Array.isArray(metadata.envs)
+  ) {
+    throw new Error("Vercel environment metadata is invalid");
+  }
+  return Object.freeze({
+    envs: metadata.envs.map((entry) => {
+      if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new Error("Vercel environment metadata is invalid");
+      }
+      const valueFreeEntry = { ...entry };
+      delete valueFreeEntry.value;
+      return Object.freeze(valueFreeEntry);
+    }),
+  });
+}
 
 export function bindVercelSensitiveProductionMetadata({
   metadata,
@@ -56,20 +78,24 @@ function argumentsFrom(argv) {
   return result;
 }
 
+async function readStandardInput() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf8");
+}
+
 async function main(argv) {
   const args = argumentsFrom(argv);
-  const source = JSON.parse(await readFile(args["metadata-file"], "utf8"));
+  const source = JSON.parse(await readStandardInput());
   const bound = bindVercelSensitiveProductionMetadata({
-    metadata: source,
+    metadata: omitVercelEnvironmentValues(source),
     vercelProjectId: args["vercel-project-id"],
   });
-  const replacement = `${args["metadata-file"]}.bound`;
-  await writeFile(replacement, `${JSON.stringify(bound)}\n`, {
+  await writeFile(args["metadata-file"], `${JSON.stringify(bound)}\n`, {
     encoding: "utf8",
     flag: "wx",
     mode: 0o600,
   });
-  await rename(replacement, args["metadata-file"]);
   process.stdout.write(`${JSON.stringify({
     status: "bound",
     schemaVersion: bound.schemaVersion,

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1980,7 +1980,10 @@ export function evaluateReadModelOperationsSourceContracts(
       "Capture sensitive production environment metadata",
     ) &&
       deployWorkflow.includes(
-        'vercel env ls production --format json --token="$VERCEL_TOKEN" > "$RUNNER_TEMP/vercel-production-env-metadata.json"',
+        'test ! -e "$RUNNER_TEMP/vercel-production-env-metadata.json"',
+      ) &&
+      deployWorkflow.includes(
+        'vercel env ls production --format json --token="$VERCEL_TOKEN" | node scripts/bind-vercel-sensitive-production-metadata.mjs',
       ) &&
       (deployWorkflow.match(/--sensitive-env-metadata/gu) ?? []).length === 2 &&
       deployPolicy.includes(

--- a/tests/bind-vercel-sensitive-production-metadata.test.ts
+++ b/tests/bind-vercel-sensitive-production-metadata.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error The production helper is an executable ESM script.
+import { bindVercelSensitiveProductionMetadata, omitVercelEnvironmentValues } from "../scripts/bind-vercel-sensitive-production-metadata.mjs";
+
+describe("Vercel sensitive production metadata binding", () => {
+  it("removes CLI-returned plain values before binding metadata", () => {
+    const metadata = omitVercelEnvironmentValues({
+      envs: [
+        {
+          key: "PUBLIC_CONFIGURATION",
+          value: "must-not-be-preserved",
+          type: "plain",
+          target: ["production"],
+        },
+        {
+          key: "BITQUERY_OAUTH_TOKEN",
+          type: "sensitive",
+          target: ["production"],
+        },
+      ],
+    });
+
+    expect(JSON.stringify(metadata)).not.toContain("must-not-be-preserved");
+    expect(
+      metadata.envs.every(
+        (entry: Record<string, unknown>) => !("value" in entry),
+      ),
+    ).toBe(true);
+    expect(
+      bindVercelSensitiveProductionMetadata({
+        metadata,
+        vercelProjectId: "prj_12345678",
+      }),
+    ).toMatchObject({ target: "production", envs: metadata.envs });
+  });
+
+  it("still rejects values at the strict binding boundary", () => {
+    expect(() =>
+      bindVercelSensitiveProductionMetadata({
+        metadata: {
+          envs: [{ key: "UNSAFE", value: "secret" }],
+        },
+        vercelProjectId: "prj_12345678",
+      }),
+    ).toThrow("must not contain values");
+  });
+});

--- a/tests/data-pipeline/read-model-deploy-policy.test.ts
+++ b/tests/data-pipeline/read-model-deploy-policy.test.ts
@@ -659,7 +659,10 @@ describe("read-model production deploy policy", () => {
       "Capture sensitive production environment metadata",
     );
     expect(workflow).toContain(
-      'vercel env ls production --format json --token="$VERCEL_TOKEN"',
+      'vercel env ls production --format json --token="$VERCEL_TOKEN" | node scripts/bind-vercel-sensitive-production-metadata.mjs',
+    );
+    expect(workflow).not.toContain(
+      'vercel env ls production --format json --token="$VERCEL_TOKEN" >',
     );
     expect(workflow.match(/--sensitive-env-metadata/g)).toHaveLength(2);
     expect(workflow).toContain("staged-release-attestation.json");


### PR DESCRIPTION
Fixes the production Stage failure caused by Vercel CLI 54 including values for plain environment entries in JSON metadata.

The workflow now streams CLI JSON directly into the binder without writing the raw response. The binder removes every value field in memory, writes only the bound value-free metadata with exclusive file creation, and retains the strict downstream rejection of any value-bearing metadata.

Validation: real production metadata stream sanitized to 98 entries with zero value fields; 629 focused tests; TypeScript; ESLint; actionlint; operations source gate 40/40; node syntax; diff check; gitleaks.