### PR TITLE
Isolate current persistent RPC cache generation

### DIFF
--- a/lib/onchain/persistent-rpc-cache.server.ts
+++ b/lib/onchain/persistent-rpc-cache.server.ts
@@ -1651,14 +1651,14 @@ function blobToken(environment: NodeJS.ProcessEnv = process.env) {
   );
 }
 
-function cachePathByteLimit(path: string) {
+export function persistentRpcCachePathByteLimit(path: string) {
   if (path.endsWith("/cursor.json")) {
     return PERSISTENT_RPC_CACHE_LIMITS.maxCursorBytes;
   }
   if (path.includes("/segments/")) {
     return PERSISTENT_RPC_CACHE_LIMITS.maxSegmentBytes;
   }
-  if (path.includes("/runtime/")) {
+  if (path.includes("/runtime-v2/")) {
     return PERSISTENT_RPC_CACHE_LIMITS.maxRuntimeBytes;
   }
   if (path.includes("/integrity/")) {
@@ -1768,7 +1768,7 @@ function blobStore(token: string): PersistentRpcCacheStore {
         useCache: false,
       });
       if (!result || result.statusCode !== 200 || !result.stream) return null;
-      const maximumBytes = cachePathByteLimit(path);
+      const maximumBytes = persistentRpcCachePathByteLimit(path);
       return {
         etag: result.blob.etag,
         value: await readBoundedBlobJson({

--- a/lib/onchain/persistent-rpc-cache.server.ts
+++ b/lib/onchain/persistent-rpc-cache.server.ts
@@ -9,8 +9,8 @@ import {
   type Transport,
 } from "viem";
 
-const CACHE_SCHEMA = "programmable-rpc-log-cursor-v2";
-const CACHE_DIRECTORY = "indexes/rpc-log-cursors/v2";
+const CACHE_SCHEMA = "programmable-rpc-log-cursor-v3";
+const CACHE_DIRECTORY = "indexes/rpc-log-cursors/v3";
 const HEX_QUANTITY = /^0x(?:0|[1-9a-f][0-9a-f]*)$/iu;
 const BYTES32 = /^0x[0-9a-f]{64}$/iu;
 const ADDRESS = /^0x[0-9a-f]{40}$/iu;

--- a/tests/persistent-rpc-cache.test.ts
+++ b/tests/persistent-rpc-cache.test.ts
@@ -829,7 +829,7 @@ describe("persistent RPC log cursor", () => {
     ).rejects.toBeInstanceOf(PersistentRpcCacheReorgError);
   });
 
-  it("isolates current runtime proofs from legacy runtime cache entries", async () => {
+  it("isolates the current cache generation from legacy cache entries", async () => {
     const code = "0x6001600055" as const;
     const expectedRuntimeCodeHash = keccak256(code);
     const backing = createMemoryPersistentRpcCacheStore();
@@ -874,6 +874,8 @@ describe("persistent RPC log cursor", () => {
     await expect(
       request({ method: "eth_getCode", params: [ADDRESS, quantity(100)] }),
     ).resolves.toBe(code);
+    expect(paths.every((path) => path.includes("/rpc-log-cursors/v3/"))).toBe(true);
+    expect(paths.some((path) => path.includes("/rpc-log-cursors/v2/"))).toBe(false);
     expect(paths.some((path) => path.includes("/runtime-v2/"))).toBe(true);
     expect(paths.some((path) => path.includes("/runtime/"))).toBe(false);
   });

--- a/tests/persistent-rpc-cache.test.ts
+++ b/tests/persistent-rpc-cache.test.ts
@@ -6,6 +6,7 @@ vi.mock("server-only", () => ({}));
 import {
   createMemoryPersistentRpcCacheStore,
   createPersistentRpcRequest,
+  persistentRpcCachePathByteLimit,
   PERSISTENT_RPC_CACHE_LIMITS,
   PersistentRpcCacheError,
   PersistentRpcCacheReorgError,
@@ -878,6 +879,19 @@ describe("persistent RPC log cursor", () => {
     expect(paths.some((path) => path.includes("/rpc-log-cursors/v2/"))).toBe(false);
     expect(paths.some((path) => path.includes("/runtime-v2/"))).toBe(true);
     expect(paths.some((path) => path.includes("/runtime/"))).toBe(false);
+  });
+
+  it("bounds runtime-v2 Blob reads in the current cache generation", () => {
+    expect(
+      persistentRpcCachePathByteLimit(
+        "indexes/rpc-log-cursors/v3/1/provider/runtime-v2/address/release.json",
+      ),
+    ).toBe(PERSISTENT_RPC_CACHE_LIMITS.maxRuntimeBytes);
+    expect(() =>
+      persistentRpcCachePathByteLimit(
+        "indexes/rpc-log-cursors/v2/1/provider/runtime/address/release.json",
+      )
+    ).toThrow(PersistentRpcCacheError);
   });
 
   it("does not persist runtime code across a changing canonical anchor", async () => {


### PR DESCRIPTION
## Outcome

Isolates the current durable RPC cache from malformed legacy log cursors that fail the exact staged refresh after runtime-code validation.

- bumps the cache envelope and full Blob directory from v2 to v3
- leaves all prior cache objects untouched and unreachable
- preserves strict content, block-anchor, provider and code-hash verification
- adds a regression assertion that no v2 cache path is read or written

## Exact failure

Stage run 31711285587 at `d276f09c81fc4b182ad98cf96980a27c37d68643` reached `ExploreReadStage:classic-events -> PersistentRpcCacheError` after the clean private Blob store binding made runtime-code pass. Independent dRPC and QuickNode reads agreed on the confirmed block and all three manifest runtime hashes.

## Validation

- focused persistent/read-model tests: 56/56
- TypeScript
- ESLint
- operations source gate: 40/40
- candidate-neutral source gate
- retired read-model cutover tests: 6/6
- production verifier script tests: 15/15
- `git diff --check`
