### PR TITLE
Fix live market, trade, and creator reward reliability

### DIFF
--- a/app/api/explore/profile/claim/route.ts
+++ b/app/api/explore/profile/claim/route.ts
@@ -12,6 +12,7 @@ import {
 } from "viem";
 import { mainnet, sepolia } from "viem/chains";
 
+import { readAlchemyExploreModel } from "../../../../../lib/alchemy/explore.server";
 import {
   CreatorClaimInputError,
   CreatorClaimUnavailableError,
@@ -27,6 +28,7 @@ import {
   type ActionTokenLookup,
 } from "../../../../../lib/data-pipeline/action-lookup";
 import { indexedLaunchLookupEnabled } from "../../../../../lib/data-pipeline/route-activation.server";
+import { currentMarketOnchainDeployment } from "../../../../../lib/market-data/current-market-rpc.server";
 import {
   ActionRpcQuorumError,
   creatorClaimRpcProviders,
@@ -96,6 +98,20 @@ function claimRpcUnavailable() {
     "rpc-unavailable",
     CLAIM_RPC_UNAVAILABLE_MESSAGE,
   );
+}
+
+function claimReadDeployment(
+  deployment: Extract<
+    ReturnType<typeof getWebsiteReadOnchainDeployment>,
+    { status: "ready" }
+  >,
+) {
+  if (deployment.chainId !== 1) return deployment;
+  try {
+    return currentMarketOnchainDeployment(deployment);
+  } catch {
+    throw claimRpcUnavailable();
+  }
 }
 
 async function sharedVerifiedBlock(clients: readonly PublicClient[]) {
@@ -393,7 +409,17 @@ async function legacyClaimToken(
   request: ReturnType<typeof parseCreatorClaimRequest>,
   deployment: Extract<ReturnType<typeof getWebsiteReadOnchainDeployment>, { status: "ready" }>,
 ): Promise<CreatorClaimTokenIdentity> {
-  const model = await readExploreModel(deployment);
+  let model: Awaited<ReturnType<typeof readExploreModel>>;
+  try {
+    model = deployment.chainId === 1
+      ? await readAlchemyExploreModel()
+      : await readExploreModel(deployment);
+  } catch {
+    throw new CreatorClaimUnavailableError(
+      "registry-unavailable",
+      "The verified Programmable launch registry is temporarily unavailable",
+    );
+  }
   if (model.status !== "ready" || model.snapshot.chainId !== deployment.chainId) {
     throw new CreatorClaimUnavailableError(
       "registry-unavailable",
@@ -560,13 +586,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const clients = creatorClaimRpcProviders(deployment).map((provider) =>
-      claimClient(deployment, provider.endpoint),
+    const claimDeployment = claimReadDeployment(deployment);
+    const clients = creatorClaimRpcProviders(claimDeployment).map((provider) =>
+      claimClient(claimDeployment, provider.endpoint),
     );
     const snapshot = await sharedVerifiedBlock(clients);
     const state = await sharedCurrentClaimState({
       clients: snapshot.clients,
-      deployment,
+      deployment: claimDeployment,
       token,
       blockNumber: snapshot.blockNumber,
     });
@@ -660,7 +687,8 @@ export async function POST(request: NextRequest) {
           : error;
       const retryable =
         unavailable.code === "rpc-unavailable" ||
-        unavailable.code === "rpc-disagreement";
+        unavailable.code === "rpc-disagreement" ||
+        unavailable.code === "registry-unavailable";
       return json(
         blockedResponse(
           unavailable.code === "not-deployed" ? "not-deployed" : "blocked",

--- a/app/api/trade/prepare/route.ts
+++ b/app/api/trade/prepare/route.ts
@@ -12,6 +12,8 @@ import {
   actionTokenAsExploreModel,
   lookupActionTokenByAddress,
 } from "../../../../lib/data-pipeline/action-lookup";
+import { readAlchemyExploreModel } from
+  "../../../../lib/alchemy/explore.server";
 import { indexedLaunchLookupEnabled } from "../../../../lib/data-pipeline/route-activation.server";
 import {
   getWebsiteReadOnchainDeployment,
@@ -165,11 +167,11 @@ export async function POST(request: NextRequest) {
             token: tradeRequest.token,
           }),
         )
-      : await readExploreModel(
-          getWebsiteReadOnchainDeployment(
-            tradeRequest.chainId === 1 ? "production" : "rehearsal",
-          ),
-        );
+      : tradeRequest.chainId === 1
+        ? await readAlchemyExploreModel()
+        : await readExploreModel(
+            getWebsiteReadOnchainDeployment("rehearsal"),
+          );
     const indexedToken = registry.tokens.find(
       (candidate) =>
         candidate.tokenAddress.toLowerCase() ===

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -177,6 +177,7 @@ export const EXPLORE_TOKENS_PER_PAGE = 9;
 export const EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE = 100;
 const QUERY_DEBOUNCE_MS = 200;
 const EXPLORE_REQUEST_TIMEOUT_MS = 12_000;
+const EXPLORE_MARKET_CAP_TRANSIENT_RETRY_LIMIT = 1;
 export const EXPLORE_REFRESH_INTERVAL_MS = LIVE_DATA_REFRESH_INTERVAL_MS;
 const fallbackTokenImages = [
   "/brand/programmable-token-fallback-01-dawn.webp",
@@ -1188,17 +1189,30 @@ async function fetchExplorePayload(
   signal: AbortSignal,
   contract: ExploreValuationRequestContract,
 ) {
-  const response = await fetch(`/api/explore?${search.toString()}`, {
-    headers: { Accept: "application/json" },
-    signal,
-  });
-  const body: unknown = await response.json().catch(() => null);
-  if (!response.ok) {
-    throw new Error(readApiError(body));
+  const requestUrl = `/api/explore?${search.toString()}`;
+  let transientRetries = 0;
+  while (true) {
+    const response = await fetch(requestUrl, {
+      headers: { Accept: "application/json" },
+      signal,
+    });
+    const body: unknown = await response.json().catch(() => null);
+    if (!response.ok) {
+      if (
+        response.status === 503 &&
+        contract.sort === "market-cap" &&
+        transientRetries < EXPLORE_MARKET_CAP_TRANSIENT_RETRY_LIMIT &&
+        !signal.aborted
+      ) {
+        transientRetries += 1;
+        continue;
+      }
+      throw new Error(readApiError(body));
+    }
+    const payload = parseExplorePayload(body);
+    assertExploreValuationResponseContract(payload, contract);
+    return payload;
   }
-  const payload = parseExplorePayload(body);
-  assertExploreValuationResponseContract(payload, contract);
-  return payload;
 }
 
 export function loadExplorePayload(

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -3766,8 +3766,13 @@ function ProfileAccountWorkspace({
     deepV3Profile.status,
     stockPairedRewards.status,
   ] as const;
+  const nativeRewardSourceStatuses = [
+    data.status,
+    classicV3Rewards.status,
+    deepRewards.status,
+  ] as const;
   const rewardDataQuality = getProfileRewardDataQuality(
-    sourceStatuses,
+    nativeRewardSourceStatuses,
     classicV3SourceState.quality,
     data.sourceQuality ?? "current",
   );

--- a/tests/creator-claim-action-activation.test.ts
+++ b/tests/creator-claim-action-activation.test.ts
@@ -14,7 +14,9 @@ vi.mock("server-only", () => ({}));
 const mocks = vi.hoisted(() => ({
   indexedEnabled: true,
   lookup: vi.fn(),
+  readAlchemy: vi.fn(),
   readLegacy: vi.fn(),
+  currentMarketDeployment: vi.fn(),
   createPublicClient: vi.fn(),
 }));
 
@@ -173,6 +175,14 @@ vi.mock("../lib/onchain", async (importOriginal) => {
   };
 });
 
+vi.mock("../lib/alchemy/explore.server", () => ({
+  readAlchemyExploreModel: mocks.readAlchemy,
+}));
+
+vi.mock("../lib/market-data/current-market-rpc.server", () => ({
+  currentMarketOnchainDeployment: mocks.currentMarketDeployment,
+}));
+
 vi.mock("viem", async (importOriginal) => {
   const actual = await importOriginal<typeof import("viem")>();
   return {
@@ -199,7 +209,14 @@ describe("creator claim action identity activation", () => {
     deployment.rpcUrlSecondary =
       "https://claim-node.ethereum-mainnet.quiknode.pro/quicknode-claim-key/";
     mocks.lookup.mockResolvedValue(indexedToken);
+    mocks.readAlchemy.mockResolvedValue(legacyModel);
     mocks.readLegacy.mockResolvedValue(legacyModel);
+    mocks.currentMarketDeployment.mockImplementation((value) => ({
+      ...value,
+      rpcUrl: "https://lb.drpc.live/ethereum/drpc-claim-key",
+      rpcUrlSecondary:
+        "https://claim-node.ethereum-mainnet.quiknode.pro/quicknode-claim-key/",
+    }));
     const clients = [
       rpcClient(100_000n, 2_000_000_000n, 10n ** 18n),
       rpcClient(110_000n, 3_000_000_000n, 9n * 10n ** 17n),
@@ -233,7 +250,9 @@ describe("creator claim action identity activation", () => {
       });
       expect(mocks.createPublicClient).toHaveBeenCalledTimes(2);
       expect(mocks.lookup).toHaveBeenCalledTimes(indexedEnabled ? 1 : 0);
-      expect(mocks.readLegacy).toHaveBeenCalledTimes(indexedEnabled ? 0 : 1);
+      expect(mocks.readAlchemy).toHaveBeenCalledTimes(indexedEnabled ? 0 : 1);
+      expect(mocks.readLegacy).not.toHaveBeenCalled();
+      expect(mocks.currentMarketDeployment).toHaveBeenCalledWith(deployment);
     },
   );
 
@@ -261,6 +280,29 @@ describe("creator claim action identity activation", () => {
     });
   });
 
+  it("reports a mainnet registry outage before starting any claim RPC read", async () => {
+    mocks.indexedEnabled = false;
+    mocks.readAlchemy.mockRejectedValueOnce(
+      new Error("Vercel Blob: failed with a private detail"),
+    );
+
+    const response = await POST(request());
+    const serialized = JSON.stringify(await response.json());
+
+    expect(response.status).toBe(503);
+    expect(JSON.parse(serialized)).toMatchObject({
+      status: "blocked",
+      error: {
+        code: "registry-unavailable",
+        message:
+          "The verified Programmable launch registry is temporarily unavailable",
+      },
+    });
+    expect(mocks.createPublicClient).not.toHaveBeenCalled();
+    expect(serialized).not.toContain("Vercel Blob");
+    expect(serialized).not.toContain("private detail");
+  });
+
   it("returns a retryable typed error when fewer than two providers can be verified", async () => {
     mocks.createPublicClient.mockReset();
     for (let index = 0; index < 4; index += 1) {
@@ -284,11 +326,12 @@ describe("creator claim action identity activation", () => {
   });
 
   it.each([true, false])(
-    "fails closed before simulation for same-provider aliases with indexed lookup %s",
+    "fails closed before simulation when the committed production pair is unavailable with indexed lookup %s",
     async (indexedEnabled) => {
       mocks.indexedEnabled = indexedEnabled;
-      deployment.rpcUrlSecondary =
-        "https://eth-mainnet.g.alchemy.com/v2/second-claim-secret";
+      mocks.currentMarketDeployment.mockImplementationOnce(() => {
+        throw new Error("production RPC binding unavailable");
+      });
 
       const response = await POST(request());
       const serialized = JSON.stringify(await response.json());
@@ -299,7 +342,7 @@ describe("creator claim action identity activation", () => {
       });
       expect(mocks.createPublicClient).not.toHaveBeenCalled();
       expect(serialized).not.toContain("alchemy-claim-key");
-      expect(serialized).not.toContain("second-claim-secret");
+      expect(serialized).not.toContain("production RPC binding");
     },
   );
 });

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -1205,6 +1205,122 @@ describe("Explore refresh state", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("retries one transient market-cap 503 before exposing an error", async () => {
+    const marketPayload = {
+      ...payload,
+      valuationSnapshot: valuationSnapshot(),
+    };
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          status: "unavailable",
+          error: "Current market data is temporarily unavailable",
+          retryable: true,
+          tokens: [{ id: "unverified-partial-data" }],
+        }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(marketPayload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    const search = new URLSearchParams({
+      q: "",
+      sort: "market-cap",
+      page: "1",
+      limit: "9",
+    });
+
+    await expect(
+      loadExplorePayload("transient-market-cap-retry", search),
+    ).resolves.toEqual(marketPayload);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(fetchMock.mock.calls[0]?.[0]);
+    expect(fetchMock.mock.calls[1]?.[1]?.signal).toBe(
+      fetchMock.mock.calls[0]?.[1]?.signal,
+    );
+  });
+
+  it.each(["newest", "market-cap-asc"])(
+    "does not retry a 503 for the %s sort",
+    async (sort) => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({
+          status: "unavailable",
+          error: "Launch data is temporarily unavailable",
+          retryable: true,
+        }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(loadExplorePayload(
+        `${sort}-does-not-retry`,
+        new URLSearchParams({ sort, page: "1", limit: "9" }),
+      )).rejects.toThrow("Launch data is temporarily unavailable");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("stops after one market-cap 503 retry", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => new Response(JSON.stringify({
+        status: "unavailable",
+        error: "Current market data is temporarily unavailable",
+        retryable: true,
+      }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(loadExplorePayload(
+      "bounded-market-cap-retry",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).rejects.toThrow("Current market data is temporarily unavailable");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the retry inside the original abort deadline", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          status: "unavailable",
+          error: "Current market data is temporarily unavailable",
+          retryable: true,
+        }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockImplementationOnce((_url, init) => {
+        const signal = init?.signal;
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        });
+      });
+    const request = loadExplorePayload(
+      "retry-stalled-content-timeout",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    );
+    const rejection = expect(request).rejects.toThrow(
+      "Tokens took too long to respond",
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(12_000);
+    await rejection;
+  });
+
   it("rejects Router provenance on a custom project without a complete stamp", async () => {
     const project = customEntry(91);
     const forged = {

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -288,6 +288,15 @@ describe("profile workspace loading state", () => {
     );
   });
 
+  it("keeps verified native ETH totals when only Stock-Paired rewards fail", () => {
+    expect(profileViewSource).toContain(
+      'const nativeRewardSourceStatuses = [\n    data.status,\n    classicV3Rewards.status,\n    deepRewards.status,\n  ] as const;',
+    );
+    expect(profileViewSource).toContain(
+      "getProfileRewardDataQuality(\n    nativeRewardSourceStatuses,",
+    );
+  });
+
   it("uses LKG only for typed temporary creator reads and marks it stale", () => {
     const current = {
       account: firstAddress,

--- a/tests/trade-action-activation.test.ts
+++ b/tests/trade-action-activation.test.ts
@@ -65,6 +65,10 @@ vi.mock("../lib/onchain", async (importOriginal) => {
   };
 });
 
+vi.mock("../lib/alchemy/explore.server", () => ({
+  readAlchemyExploreModel: mocks.readLegacy,
+}));
+
 vi.mock("../lib/trade/server", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/trade/server")>();
   return {


### PR DESCRIPTION
Fixes the three user-visible production failures without weakening fail-closed verification:

- retry Highest FDV once only for the same HTTP 503 request within the original deadline
- prepare mainnet trades from the verified current registry path
- keep verified native ETH totals visible when only Stock-Paired rewards are unavailable
- prepare creator claims from the verified current registry and commitment-bound dRPC + QuickNode pair
- classify registry outages separately from simulation failures

Validation:
- Vercel production build passed
- 92 focused profile/claim tests passed
- 48 focused Highest FDV client tests passed
- live Canary and public production claim preparation passed 6 consecutive times
- public Highest FDV rendered 339 launches
- connected profile rendered 81.041328 ETH on desktop and mobile
- no application console errors observed

No transaction was submitted.