### PR TITLE
Bind compressed private Blob reads safely

### DIFF
--- a/lib/onchain/persistent-rpc-cache.server.ts
+++ b/lib/onchain/persistent-rpc-cache.server.ts
@@ -1680,6 +1680,33 @@ function contentLength(headers: Readonly<{ get(name: string): string | null }>) 
   return parsed;
 }
 
+function normalizedBlobEtag(value: string) {
+  return value.trim().replace(/^W\//u, "");
+}
+
+export function bindPrivateBlobReadMetadata(input: Readonly<{
+  responseEtag: string;
+  headEtag: string;
+  headSize: number;
+}>) {
+  const responseEtag = normalizedBlobEtag(input.responseEtag);
+  const headEtag = normalizedBlobEtag(input.headEtag);
+  if (
+    responseEtag.length < 1 ||
+    headEtag.length < 1 ||
+    responseEtag !== headEtag
+  ) {
+    fail("Persistent RPC Blob changed while it was being read");
+  }
+  if (!Number.isSafeInteger(input.headSize) || input.headSize < 0) {
+    fail("Persistent RPC Blob HEAD size is invalid");
+  }
+  return {
+    etag: input.headEtag,
+    declaredSize: input.headSize,
+  } as const;
+}
+
 export async function readBoundedBlobJson(input: Readonly<{
   stream: ReadableStream<Uint8Array>;
   maximumBytes: number;
@@ -1761,7 +1788,7 @@ export async function readBoundedBlobJson(input: Readonly<{
 function blobStore(token: string): PersistentRpcCacheStore {
   return {
     async read(path) {
-      const { get } = await import("@vercel/blob");
+      const { get, head } = await import("@vercel/blob");
       const result = await get(path, {
         access: "private",
         token,
@@ -1769,13 +1796,29 @@ function blobStore(token: string): PersistentRpcCacheStore {
       });
       if (!result || result.statusCode !== 200 || !result.stream) return null;
       const maximumBytes = persistentRpcCachePathByteLimit(path);
+      let metadata;
+      try {
+        const current = await head(path, { token });
+        metadata = bindPrivateBlobReadMetadata({
+          responseEtag: result.blob.etag,
+          headEtag: current.etag,
+          headSize: current.size,
+        });
+      } catch (error) {
+        await result.stream.cancel(
+          "Persistent RPC Blob metadata could not be bound",
+        );
+        throw error;
+      }
       return {
-        etag: result.blob.etag,
+        etag: metadata.etag,
         value: await readBoundedBlobJson({
           stream: result.stream,
           maximumBytes,
-          declaredSize: result.blob.size,
-          declaredContentLength: contentLength(result.headers),
+          declaredSize: metadata.declaredSize,
+          declaredContentLength: result.headers.get("content-encoding")
+            ? null
+            : contentLength(result.headers),
         }),
       };
     },

--- a/tests/persistent-rpc-cache.test.ts
+++ b/tests/persistent-rpc-cache.test.ts
@@ -4,6 +4,7 @@ import { keccak256, type EIP1193RequestFn } from "viem";
 vi.mock("server-only", () => ({}));
 
 import {
+  bindPrivateBlobReadMetadata,
   createMemoryPersistentRpcCacheStore,
   createPersistentRpcRequest,
   persistentRpcCachePathByteLimit,
@@ -1186,6 +1187,29 @@ describe("persistent RPC log cursor", () => {
         declaredContentLength: 3,
       }),
     ).rejects.toThrow(/does not match/u);
+  });
+
+  it("binds a compressed private Blob response to its authenticated HEAD metadata", () => {
+    expect(
+      bindPrivateBlobReadMetadata({
+        responseEtag: 'W/"a51ca021c9c058ed68999c1ef7728007"',
+        headEtag: '"a51ca021c9c058ed68999c1ef7728007"',
+        headSize: 23_849,
+      }),
+    ).toEqual({
+      etag: '"a51ca021c9c058ed68999c1ef7728007"',
+      declaredSize: 23_849,
+    });
+  });
+
+  it("rejects a private Blob that changes between GET and HEAD", () => {
+    expect(() =>
+      bindPrivateBlobReadMetadata({
+        responseEtag: 'W/"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
+        headEtag: '"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"',
+        headSize: 23_849,
+      }),
+    ).toThrow(/changed while it was being read/u);
   });
 
   it("reduces total steady-state RPC requests and conservative Alchemy CU by at least 80 percent", async () => {


### PR DESCRIPTION
Fixes the production durable read-model refresh against Vercel Private Blob. Private compressed GET responses report a zero body size and a weak ETag; bind each GET to authenticated HEAD metadata, normalize strong/weak ETags, preserve the exact bounded stream limit, and fail closed on concurrent change. Includes focused regressions and a live private-store compressed-read proof.