### PR TITLE
Normalize Vercel Blob ETags for cache CAS

### DIFF
--- a/lib/onchain/persistent-rpc-cache.server.ts
+++ b/lib/onchain/persistent-rpc-cache.server.ts
@@ -1680,8 +1680,14 @@ function contentLength(headers: Readonly<{ get(name: string): string | null }>) 
   return parsed;
 }
 
-function normalizedBlobEtag(value: string) {
-  return value.trim().replace(/^W\//u, "");
+const VERCEL_BLOB_STRONG_ETAG = /^"[0-9a-f]{32}"$/iu;
+
+export function normalizePersistentRpcBlobEtag(value: string) {
+  const normalized = value.trim().replace(/^W\//u, "");
+  if (!VERCEL_BLOB_STRONG_ETAG.test(normalized)) {
+    fail("Persistent RPC Blob ETag is invalid");
+  }
+  return normalized;
 }
 
 export function bindPrivateBlobReadMetadata(input: Readonly<{
@@ -1689,8 +1695,8 @@ export function bindPrivateBlobReadMetadata(input: Readonly<{
   headEtag: string;
   headSize: number;
 }>) {
-  const responseEtag = normalizedBlobEtag(input.responseEtag);
-  const headEtag = normalizedBlobEtag(input.headEtag);
+  const responseEtag = normalizePersistentRpcBlobEtag(input.responseEtag);
+  const headEtag = normalizePersistentRpcBlobEtag(input.headEtag);
   if (
     responseEtag.length < 1 ||
     headEtag.length < 1 ||
@@ -1702,7 +1708,7 @@ export function bindPrivateBlobReadMetadata(input: Readonly<{
     fail("Persistent RPC Blob HEAD size is invalid");
   }
   return {
-    etag: input.headEtag,
+    etag: headEtag,
     declaredSize: input.headSize,
   } as const;
 }
@@ -1785,10 +1791,63 @@ export async function readBoundedBlobJson(input: Readonly<{
   }
 }
 
-function blobStore(token: string): PersistentRpcCacheStore {
+type PersistentRpcBlobGetResult =
+  | Readonly<{
+      statusCode: 200;
+      stream: ReadableStream<Uint8Array>;
+      headers: Readonly<{ get(name: string): string | null }>;
+      blob: Readonly<{ etag: string; size: number }>;
+    }>
+  | Readonly<{
+      statusCode: 304;
+      stream: null;
+      headers: Readonly<{ get(name: string): string | null }>;
+      blob: Readonly<{ etag: string; size: null }>;
+    }>
+  | null;
+
+type PersistentRpcBlobClient = Readonly<{
+  get(
+    path: string,
+    options: Readonly<{
+      access: "private";
+      token: string;
+      useCache: false;
+    }>,
+  ): Promise<PersistentRpcBlobGetResult>;
+  head(
+    path: string,
+    options: Readonly<{ token: string }>,
+  ): Promise<Readonly<{ etag: string; size: number }>>;
+  put(
+    path: string,
+    value: string,
+    options: Readonly<{
+      access: "private";
+      contentType: "application/json";
+      addRandomSuffix: false;
+      allowOverwrite: boolean;
+      cacheControlMaxAge: 60;
+      ifMatch?: string;
+      token: string;
+    }>,
+  ): Promise<unknown>;
+}>;
+
+type PersistentRpcBlobClientLoader = () => Promise<PersistentRpcBlobClient>;
+
+async function loadPersistentRpcBlobClient(): Promise<PersistentRpcBlobClient> {
+  const { get, head, put } = await import("@vercel/blob");
+  return { get, head, put };
+}
+
+export function createVercelBlobPersistentRpcCacheStore(
+  token: string,
+  loadClient: PersistentRpcBlobClientLoader = loadPersistentRpcBlobClient,
+): PersistentRpcCacheStore {
   return {
     async read(path) {
-      const { get, head } = await import("@vercel/blob");
+      const { get, head } = await loadClient();
       const result = await get(path, {
         access: "private",
         token,
@@ -1823,7 +1882,7 @@ function blobStore(token: string): PersistentRpcCacheStore {
       };
     },
     async create(path, value) {
-      const { get, put } = await import("@vercel/blob");
+      const { get, put } = await loadClient();
       try {
         await put(path, JSON.stringify(value), {
           access: "private",
@@ -1845,7 +1904,7 @@ function blobStore(token: string): PersistentRpcCacheStore {
       }
     },
     async replace(path, value, expectedEtag) {
-      const { get, put } = await import("@vercel/blob");
+      const { get, put } = await loadClient();
       try {
         await put(path, JSON.stringify(value), {
           access: "private",
@@ -1863,7 +1922,10 @@ function blobStore(token: string): PersistentRpcCacheStore {
           token,
           useCache: false,
         });
-        if (current?.statusCode === 200 && current.blob.etag !== expectedEtag) {
+        if (
+          current?.statusCode === 200 &&
+          normalizePersistentRpcBlobEtag(current.blob.etag) !== expectedEtag
+        ) {
           return "conflict";
         }
         throw error;
@@ -1920,7 +1982,7 @@ export function persistentRpcHttp(
         immutableCodeBindings: input.immutableCodeBindings,
         store: input.store === undefined
           ? token
-            ? blobStore(token)
+            ? createVercelBlobPersistentRpcCacheStore(token)
             : null
           : input.store,
       }),

--- a/tests/persistent-rpc-cache.test.ts
+++ b/tests/persistent-rpc-cache.test.ts
@@ -7,6 +7,7 @@ import {
   bindPrivateBlobReadMetadata,
   createMemoryPersistentRpcCacheStore,
   createPersistentRpcRequest,
+  createVercelBlobPersistentRpcCacheStore,
   persistentRpcCachePathByteLimit,
   PERSISTENT_RPC_CACHE_LIMITS,
   PersistentRpcCacheError,
@@ -172,7 +173,130 @@ function reorgOnCreateStore(
   };
 }
 
+function weakEtagBlobClient() {
+  const values = new Map<string, { body: string; etag: string }>();
+  let generation = 0;
+  const nextEtag = () => {
+    generation += 1;
+    return `"${generation.toString(16).padStart(32, "0")}"`;
+  };
+  const client = {
+    async get(path: string) {
+      const current = values.get(path);
+      if (!current) return null;
+      const bytes = new TextEncoder().encode(current.body);
+      return {
+        statusCode: 200 as const,
+        stream: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(bytes);
+            controller.close();
+          },
+        }),
+        headers: new Headers({
+          "content-encoding": "gzip",
+          "content-length": "0",
+        }),
+        blob: {
+          etag: `W/${current.etag}`,
+          size: 0,
+        },
+      };
+    },
+    async head(path: string) {
+      const current = values.get(path);
+      if (!current) throw new Error("Vercel Blob: object is missing");
+      return {
+        etag: current.etag,
+        size: new TextEncoder().encode(current.body).byteLength,
+      };
+    },
+    async put(
+      path: string,
+      body: string,
+      options: Readonly<{ allowOverwrite: boolean; ifMatch?: string }>,
+    ) {
+      const current = values.get(path);
+      if (!options.allowOverwrite && current) {
+        throw new Error("Vercel Blob: object already exists");
+      }
+      if (
+        options.ifMatch !== undefined &&
+        current?.etag !== options.ifMatch
+      ) {
+        throw new Error("Vercel Blob: Precondition failed: ETag mismatch.");
+      }
+      const etag = nextEtag();
+      values.set(path, { body, etag });
+      return { etag };
+    },
+  };
+  return {
+    client,
+    paths: () => [...values.keys()],
+    value(path: string) {
+      const current = values.get(path);
+      return current ? JSON.parse(current.body) as unknown : null;
+    },
+  };
+}
+
 describe("persistent RPC log cursor", () => {
+  it("commits both provider cursors through weak Blob ETags and rejects a stale writer", async () => {
+    const blob = weakEtagBlobClient();
+    const store = createVercelBlobPersistentRpcCacheStore(
+      "test-read-write-token",
+      async () => blob.client,
+    );
+
+    for (const providerId of ["provider-primary", "provider-secondary"]) {
+      const rpc = mockRpc();
+      const cached = cachedRequest(rpc, store, providerId, 5n);
+      await withPersistentRpcIntegrityScope(() =>
+        Promise.all([
+          logRequest(cached.request, 0, 9, bytes32(101)),
+          logRequest(cached.request, 0, 9, bytes32(102)),
+        ]),
+      );
+
+      const providerPaths = blob.paths().filter((path) =>
+        path.includes(`/${providerId}/`),
+      );
+      const cursorPaths = providerPaths.filter((path) =>
+        path.endsWith("/cursor.json"),
+      );
+      const integrityPaths = providerPaths.filter((path) =>
+        path.includes("/integrity/"),
+      );
+      expect(cursorPaths).toHaveLength(2);
+      expect(integrityPaths).toHaveLength(1);
+      for (const path of cursorPaths) {
+        expect(
+          (blob.value(path) as { payload: { segments: unknown[] } }).payload
+            .segments,
+        ).toHaveLength(2);
+      }
+      expect(
+        (blob.value(integrityPaths[0] as string) as {
+          payload: { status: string };
+        }).payload.status,
+      ).toBe("committed");
+    }
+
+    const cursorPath = blob.paths().find(
+      (path) =>
+        path.includes("/provider-primary/") && path.endsWith("/cursor.json"),
+    ) as string;
+    const stale = await store.read(cursorPath);
+    expect(stale).not.toBeNull();
+    expect(
+      await store.replace(cursorPath, stale?.value, stale?.etag as string),
+    ).toBe("replaced");
+    expect(
+      await store.replace(cursorPath, stale?.value, stale?.etag as string),
+    ).toBe("conflict");
+  });
+
   it("survives a process restart and serves a canonical cursor without rescanning", async () => {
     const rpc = mockRpc();
     const first = cachedRequest(rpc);


### PR DESCRIPTION
## Summary
- normalize Vercel private Blob weak ETags to their strong validator before conditional cache writes
- preserve fail-closed validation and stale-writer conflicts
- cover two providers, multi-segment cursor replacement, integrity commits, and stale CAS rejection with an SDK-shaped regression

## Evidence
- exact live store reproduced `W/"…"` reads causing `ifMatch` precondition failures with no ETag drift
- normalized adapter completed both role-bound providers and committed integrity markers
- focused 59 tests, typecheck, ESLint, and diff-check pass locally

No Custom Launch criteria, policies, approval semantics, V1 public bindings, or submission paths are changed.