### PR TITLE
Retry transient private Blob reads safely

### DIFF
--- a/lib/onchain/persistent-rpc-cache.server.ts
+++ b/lib/onchain/persistent-rpc-cache.server.ts
@@ -1836,6 +1836,8 @@ type PersistentRpcBlobClient = Readonly<{
 
 type PersistentRpcBlobClientLoader = () => Promise<PersistentRpcBlobClient>;
 
+const PRIVATE_BLOB_READ_ATTEMPTS = 3;
+
 async function loadPersistentRpcBlobClient(): Promise<PersistentRpcBlobClient> {
   const { get, head, put } = await import("@vercel/blob");
   return { get, head, put };
@@ -1848,38 +1850,49 @@ export function createVercelBlobPersistentRpcCacheStore(
   return {
     async read(path) {
       const { get, head } = await loadClient();
-      const result = await get(path, {
-        access: "private",
-        token,
-        useCache: false,
-      });
-      if (!result || result.statusCode !== 200 || !result.stream) return null;
       const maximumBytes = persistentRpcCachePathByteLimit(path);
-      let metadata;
-      try {
-        const current = await head(path, { token });
-        metadata = bindPrivateBlobReadMetadata({
-          responseEtag: result.blob.etag,
-          headEtag: current.etag,
-          headSize: current.size,
+      for (let attempt = 1; attempt <= PRIVATE_BLOB_READ_ATTEMPTS; attempt += 1) {
+        const result = await get(path, {
+          access: "private",
+          token,
+          useCache: false,
         });
-      } catch (error) {
-        await result.stream.cancel(
-          "Persistent RPC Blob metadata could not be bound",
-        );
-        throw error;
+        if (!result || result.statusCode !== 200 || !result.stream) return null;
+        try {
+          const current = await head(path, { token });
+          const metadata = bindPrivateBlobReadMetadata({
+            responseEtag: result.blob.etag,
+            headEtag: current.etag,
+            headSize: current.size,
+          });
+          return {
+            etag: metadata.etag,
+            value: await readBoundedBlobJson({
+              stream: result.stream,
+              maximumBytes,
+              declaredSize: metadata.declaredSize,
+              declaredContentLength: result.headers.get("content-encoding")
+                ? null
+                : contentLength(result.headers),
+            }),
+          };
+        } catch (error) {
+          try {
+            await result.stream.cancel(
+              "Persistent RPC Blob read could not be bound",
+            );
+          } catch {
+            // The original bounded-read failure remains authoritative.
+          }
+          if (
+            !(error instanceof PersistentRpcCacheError) ||
+            attempt === PRIVATE_BLOB_READ_ATTEMPTS
+          ) {
+            throw error;
+          }
+        }
       }
-      return {
-        etag: metadata.etag,
-        value: await readBoundedBlobJson({
-          stream: result.stream,
-          maximumBytes,
-          declaredSize: metadata.declaredSize,
-          declaredContentLength: result.headers.get("content-encoding")
-            ? null
-            : contentLength(result.headers),
-        }),
-      };
+      fail("Persistent RPC Blob read retry budget was exhausted");
     },
     async create(path, value) {
       const { get, put } = await loadClient();

--- a/tests/persistent-rpc-cache.test.ts
+++ b/tests/persistent-rpc-cache.test.ts
@@ -175,6 +175,8 @@ function reorgOnCreateStore(
 
 function weakEtagBlobClient() {
   const values = new Map<string, { body: string; etag: string }>();
+  const readCounts = new Map<string, number>();
+  const truncatedReads = new Map<string, number>();
   let generation = 0;
   const nextEtag = () => {
     generation += 1;
@@ -184,7 +186,15 @@ function weakEtagBlobClient() {
     async get(path: string) {
       const current = values.get(path);
       if (!current) return null;
-      const bytes = new TextEncoder().encode(current.body);
+      readCounts.set(path, (readCounts.get(path) ?? 0) + 1);
+      const encoded = new TextEncoder().encode(current.body);
+      const remainingTruncations = truncatedReads.get(path) ?? 0;
+      if (remainingTruncations > 0) {
+        truncatedReads.set(path, remainingTruncations - 1);
+      }
+      const bytes = remainingTruncations > 0
+        ? encoded.slice(0, Math.max(0, encoded.byteLength - 1))
+        : encoded;
       return {
         statusCode: 200 as const,
         stream: new ReadableStream<Uint8Array>({
@@ -238,10 +248,35 @@ function weakEtagBlobClient() {
       const current = values.get(path);
       return current ? JSON.parse(current.body) as unknown : null;
     },
+    readCount(path: string) {
+      return readCounts.get(path) ?? 0;
+    },
+    truncateReads(path: string, count: number) {
+      truncatedReads.set(path, count);
+    },
   };
 }
 
 describe("persistent RPC log cursor", () => {
+  it("retries transient truncated private Blob reads within a strict budget", async () => {
+    const blob = weakEtagBlobClient();
+    const store = createVercelBlobPersistentRpcCacheStore(
+      "test-read-write-token",
+      async () => blob.client,
+    );
+    const path = "indexes/rpc-log-cursors/v3/1/provider/stream/cursor.json";
+    const value = { status: "complete", blockNumber: "0x1" };
+
+    await expect(store.create(path, value)).resolves.toBe("created");
+    blob.truncateReads(path, 2);
+    await expect(store.read(path)).resolves.toMatchObject({ value });
+    expect(blob.readCount(path)).toBe(3);
+
+    blob.truncateReads(path, 3);
+    await expect(store.read(path)).rejects.toThrow(/does not match/u);
+    expect(blob.readCount(path)).toBe(6);
+  });
+
   it("commits both provider cursors through weak Blob ETags and rejects a stale writer", async () => {
     const blob = weakEtagBlobClient();
     const store = createVercelBlobPersistentRpcCacheStore(


### PR DESCRIPTION
## Outcome
- retries a freshly written private Blob read at most three times when strict bounded metadata/body validation sees a transient inconsistency
- preserves private GET plus authenticated HEAD binding, byte limits, ETag equality, JSON validation, and fail-closed exhaustion
- adds success-on-third-read and exhaustion regression coverage

## Validation
- persistent RPC cache: 41/41
- TypeScript: pass
- ESLint changed files: pass
- read-model ops gate: 41/41
- diff check: pass

Exact head: d84b2395d10bb61c2185e3f192395109fba39e1e
Exact tree: caeb7c11d916aa327bce927e69160e2050e75fcf