### PR TITLE
Use archive quorum for durable refresh

### DIFF
--- a/app/api/ops/index-v2/route.ts
+++ b/app/api/ops/index-v2/route.ts
@@ -7,7 +7,7 @@ import {
   readLiveExploreModel,
   writeDurableExploreModel,
 } from "../../../../lib/onchain";
-import { currentMarketOnchainDeployment } from "../../../../lib/market-data/current-market-rpc.server";
+import { historicalReadOnchainDeployment } from "../../../../lib/onchain/historical-read-rpc.server";
 import { writePortfolioHistorySnapshot } from "../../../../lib/profile/portfolio-history-storage.server";
 
 export const dynamic = "force-dynamic";
@@ -105,7 +105,7 @@ export async function GET(request: NextRequest) {
         "The verified production release is not operationally eligible",
       );
     }
-    const durableRefreshDeployment = currentMarketOnchainDeployment(deployment);
+    const durableRefreshDeployment = historicalReadOnchainDeployment(deployment);
     const model = await withIndexRefreshDeadline(() =>
       readLiveExploreModel(durableRefreshDeployment),
     );

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -5,7 +5,7 @@
     "schedule": "*/5 * * * *",
     "retainedUntil": "indexed-read-cutover",
     "route": "app/api/ops/index-v2/route.ts",
-    "sha256": "06235ff68203da970d51022fe0a9bbe3a7d0096c547ecd7fc31b1ce1d4f1da52",
+    "sha256": "763f093b6138bbb7bfaa175f2192798cabd9debbca641f4aefd14d59aff9ff55",
     "boundedRefresh": {
       "runtime": {
         "path": "lib/onchain/read-model.ts",
@@ -15,6 +15,10 @@
         {
           "path": "lib/onchain/parallel-reads.ts",
           "sha256": "ef2bf54f390dca210dfdb3b5ba29c4cf8f6eaea2574c9be219a5410dbf8fb64e"
+        },
+        {
+          "path": "lib/onchain/historical-read-rpc.server.ts",
+          "sha256": "98ccb2a6471a4e38ef521b1fd7e41d55bb19b904a9c1d5e8d6948976a628d63e"
         }
       ],
       "releaseRuntimes": [

--- a/lib/onchain/historical-read-rpc.server.ts
+++ b/lib/onchain/historical-read-rpc.server.ts
@@ -1,0 +1,60 @@
+import "server-only";
+
+import { createActionRpcQuorum } from
+  "../server/action-rpc-quorum.server";
+import type { ReadyOnchainDeployment } from "./types";
+import { productionMainnetRpcPair } from
+  "./website-rpc-providers.server";
+
+const INDEPENDENT_ARCHIVE_WITNESS = "https://rpc.mevblocker.io/";
+
+export class HistoricalReadRpcBindingError extends Error {
+  override name = "HistoricalReadRpcBindingError";
+
+  constructor() {
+    super("Historical read RPC quorum is unavailable");
+  }
+}
+
+/**
+ * Historical registry reconstruction requires two archive-capable readers.
+ * The private QuickNode endpoint remains commitment-bound; MEV Blocker is a
+ * fixed, independent witness. Current-market reads keep their separate private
+ * dRPC + QuickNode quorum.
+ */
+export function historicalReadOnchainDeployment(
+  baseDeployment: ReadyOnchainDeployment,
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): ReadyOnchainDeployment {
+  if (baseDeployment.chainId !== 1) {
+    throw new HistoricalReadRpcBindingError();
+  }
+
+  try {
+    const binding = productionMainnetRpcPair(environment);
+    const providers = createActionRpcQuorum({
+      chainId: 1,
+      primary: binding.secondary.url,
+      secondary: INDEPENDENT_ARCHIVE_WITNESS,
+      maximumProviders: 2,
+    });
+    const [primary, secondary] = providers;
+    if (
+      providers.length !== 2 ||
+      primary?.vendorGroup !== "quicknode" ||
+      secondary?.vendorGroup !== "mevblocker" ||
+      primary.endpointCommitment !== binding.secondary.endpointCommitment
+    ) {
+      throw new HistoricalReadRpcBindingError();
+    }
+
+    return {
+      ...baseDeployment,
+      rpcUrl: primary.endpoint,
+      rpcUrlSecondary: secondary.endpoint,
+      rpcProviderIds: undefined,
+    };
+  } catch {
+    throw new HistoricalReadRpcBindingError();
+  }
+}

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -10,7 +10,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     schedule: "*/5 * * * *",
     retainedUntil: "indexed-read-cutover",
     route: "app/api/ops/index-v2/route.ts",
-    sha256: "06235ff68203da970d51022fe0a9bbe3a7d0096c547ecd7fc31b1ce1d4f1da52",
+    sha256: "763f093b6138bbb7bfaa175f2192798cabd9debbca641f4aefd14d59aff9ff55",
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
@@ -20,6 +20,10 @@ const APPROVED_OPERATIONS = Object.freeze({
         Object.freeze({
           path: "lib/onchain/parallel-reads.ts",
           sha256: "ef2bf54f390dca210dfdb3b5ba29c4cf8f6eaea2574c9be219a5410dbf8fb64e",
+        }),
+        Object.freeze({
+          path: "lib/onchain/historical-read-rpc.server.ts",
+          sha256: "98ccb2a6471a4e38ef521b1fd7e41d55bb19b904a9c1d5e8d6948976a628d63e",
         }),
       ]),
       releaseRuntimes: Object.freeze([
@@ -1010,7 +1014,7 @@ function legacySchedulerWatchdogIsFailClosed(
       "currentMarketOnchainDeployment(deployment)",
     ) &&
     source(APPROVED_OPERATIONS.legacyIndexer.route)?.includes(
-      "currentMarketOnchainDeployment(deployment)",
+      "historicalReadOnchainDeployment(deployment)",
     ) &&
     workflowSource.includes('name: Refresh production read model') &&
     workflowSource.includes('    - cron: "2-57/5 * * * *"') &&
@@ -1493,6 +1497,7 @@ export function evaluateReadModelOperationsSourceContracts(
   const legacyRouteSource = source(APPROVED_OPERATIONS.legacyIndexer.route);
   const refreshRuntimeSource = source(boundedRefresh?.runtime?.path);
   const parallelReadsSource = source(boundedRefresh?.dependencies?.[0]?.path);
+  const historicalRpcSource = source(boundedRefresh?.dependencies?.[1]?.path);
   const releaseRuntimes = boundedRefresh?.releaseRuntimes;
   const classicV3RefreshSource = source(releaseRuntimes?.[0]?.path);
   const stockPairedRefreshSource = source(releaseRuntimes?.[1]?.path);
@@ -1519,10 +1524,15 @@ export function evaluateReadModelOperationsSourceContracts(
         boundedRefresh?.runtime,
         expectedSha256Overrides,
       ) &&
-      boundedRefresh?.dependencies?.length === 1 &&
+      boundedRefresh?.dependencies?.length === 2 &&
       sourceBindingMatches(
         source,
         boundedRefresh.dependencies[0],
+        expectedSha256Overrides,
+      ) &&
+      sourceBindingMatches(
+        source,
+        boundedRefresh.dependencies[1],
         expectedSha256Overrides,
       ) &&
       refreshRuntimeSource?.includes(
@@ -1533,6 +1543,24 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       parallelReadsSource?.includes("Promise.allSettled(") &&
       parallelReadsSource?.includes("for (const result of results)") &&
+      legacyRouteSource?.includes(
+        "historicalReadOnchainDeployment(deployment)",
+      ) &&
+      historicalRpcSource?.includes(
+        'const INDEPENDENT_ARCHIVE_WITNESS = "https://rpc.mevblocker.io/";',
+      ) &&
+      historicalRpcSource?.includes(
+        "primary: binding.secondary.url",
+      ) &&
+      historicalRpcSource?.includes(
+        'primary?.vendorGroup !== "quicknode"',
+      ) &&
+      historicalRpcSource?.includes(
+        'secondary?.vendorGroup !== "mevblocker"',
+      ) &&
+      historicalRpcSource?.includes(
+        "primary.endpointCommitment !== binding.secondary.endpointCommitment",
+      ) &&
       Array.isArray(releaseRuntimes) &&
       releaseRuntimes.length === 2 &&
       releaseRuntimes[0]?.release === "classic-v3" &&

--- a/tests/data-pipeline/legacy-index-ops-route.test.ts
+++ b/tests/data-pipeline/legacy-index-ops-route.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getOperationalOnchainDeployment: vi.fn(),
-  currentMarketOnchainDeployment: vi.fn(),
+  historicalReadOnchainDeployment: vi.fn(),
   readLiveExploreModel: vi.fn(),
   writeDurableExploreModel: vi.fn(),
   writePortfolioHistorySnapshot: vi.fn(),
@@ -14,8 +14,8 @@ vi.mock("../../lib/onchain", () => ({
   writeDurableExploreModel: mocks.writeDurableExploreModel,
 }));
 
-vi.mock("../../lib/market-data/current-market-rpc.server", () => ({
-  currentMarketOnchainDeployment: mocks.currentMarketOnchainDeployment,
+vi.mock("../../lib/onchain/historical-read-rpc.server", () => ({
+  historicalReadOnchainDeployment: mocks.historicalReadOnchainDeployment,
 }));
 
 vi.mock("../../lib/profile/portfolio-history-storage.server", () => ({
@@ -53,7 +53,7 @@ describe("legacy index operations routes", () => {
     process.env.CRON_SECRET = SECRET;
     Object.values(mocks).forEach((mock) => mock.mockReset());
     mocks.getOperationalOnchainDeployment.mockReturnValue(deployment);
-    mocks.currentMarketOnchainDeployment.mockReturnValue(
+    mocks.historicalReadOnchainDeployment.mockReturnValue(
       durableRefreshDeployment,
     );
     mocks.readLiveExploreModel.mockResolvedValue({ status: "ready" });
@@ -108,7 +108,7 @@ describe("legacy index operations routes", () => {
       tokenCount: 265,
     });
     expect(mocks.readLiveExploreModel).toHaveBeenCalledTimes(1);
-    expect(mocks.currentMarketOnchainDeployment).toHaveBeenCalledWith(
+    expect(mocks.historicalReadOnchainDeployment).toHaveBeenCalledWith(
       deployment,
     );
     expect(mocks.readLiveExploreModel).toHaveBeenCalledWith(

--- a/tests/historical-read-rpc-server.test.ts
+++ b/tests/historical-read-rpc-server.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  HistoricalReadRpcBindingError,
+  historicalReadOnchainDeployment,
+} from "../lib/onchain/historical-read-rpc.server";
+import type { ReadyOnchainDeployment } from "../lib/onchain/types";
+import { productionMainnetRpcEnvironment } from
+  "../lib/onchain/website-rpc-providers.server";
+
+const DRPC_RPC_URL = "https://lb.drpc.live/ethereum/drpc-test-key";
+const QUICKNODE_RPC_URL =
+  "https://programmable-mainnet.ethereum-mainnet.quiknode.pro/quicknode-test-key/";
+
+const deployment: ReadyOnchainDeployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  stateView: "0x1111111111111111111111111111111111111111",
+  stateViewRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  rpcUrl: DRPC_RPC_URL,
+  rpcUrlSecondary: QUICKNODE_RPC_URL,
+  confirmations: 12n,
+  logBlockRange: 5_000n,
+  launcher: "0x2222222222222222222222222222222222222222",
+  feeHook: "0x3333333333333333333333333333333333333333",
+  launcherRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  deploymentBlock: 25_000_000n,
+};
+
+function stubProductionPair() {
+  for (const [name, value] of Object.entries(
+    productionMainnetRpcEnvironment(DRPC_RPC_URL, QUICKNODE_RPC_URL),
+  )) vi.stubEnv(name, value);
+}
+
+describe("historical read RPC deployment", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses commitment-bound QuickNode plus the fixed archive witness", () => {
+    stubProductionPair();
+
+    expect(historicalReadOnchainDeployment(deployment)).toMatchObject({
+      rpcUrl: QUICKNODE_RPC_URL,
+      rpcUrlSecondary: "https://rpc.mevblocker.io/",
+      rpcProviderIds: undefined,
+    });
+  });
+
+  it("does not retain the non-archive dRPC reader", () => {
+    stubProductionPair();
+
+    const historical = historicalReadOnchainDeployment({
+      ...deployment,
+      rpcUrl: "https://eth.drpc.org",
+      rpcUrlSecondary: null,
+    });
+
+    expect(historical.rpcUrl).toBe(QUICKNODE_RPC_URL);
+    expect(historical.rpcUrlSecondary).toBe("https://rpc.mevblocker.io/");
+    expect(historical.rpcUrl).not.toContain("drpc");
+  });
+
+  it("fails closed when the private QuickNode commitment is missing", () => {
+    stubProductionPair();
+    vi.stubEnv(
+      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT",
+      "",
+    );
+
+    expect(() => historicalReadOnchainDeployment(deployment))
+      .toThrow(HistoricalReadRpcBindingError);
+  });
+});


### PR DESCRIPTION
## Outcome
- routes only the historical durable reconstruction through commitment-bound QuickNode plus fixed independent MEV Blocker
- keeps current market, trade, claim, health and Website reads on the existing private dRPC plus QuickNode quorum
- prevents deterministic historical dRPC routing failures from collapsing launches, profiles and creator actions
- binds the new archive quorum source in the operations manifest and mutation-sensitive source contract

## Evidence
- dRPC public historical single-block getLogs: deterministic no suitable provider
- MEV Blocker same historical single-block read: success
- focused runtime and operations tests: 626/626
- TypeScript, ESLint, ops gate 41/41, diff check, gitleaks: pass

Exact head: 33c23f155a107c77734d2fa02bd9cc4083d92359
Exact tree: 841efe19587bf13e78c0439db8bedd38c109f40d