### PR TITLE
Use fixed archive witnesses for durable refresh

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -18,7 +18,7 @@
         },
         {
           "path": "lib/onchain/historical-read-rpc.server.ts",
-          "sha256": "98ccb2a6471a4e38ef521b1fd7e41d55bb19b904a9c1d5e8d6948976a628d63e"
+          "sha256": "725bde4016b635c77ed996e8b6d574b589f3cccd5778a7ed63ea9afbde4e77b7"
         }
       ],
       "releaseRuntimes": [

--- a/lib/onchain/historical-read-rpc.server.ts
+++ b/lib/onchain/historical-read-rpc.server.ts
@@ -3,10 +3,10 @@ import "server-only";
 import { createActionRpcQuorum } from
   "../server/action-rpc-quorum.server";
 import type { ReadyOnchainDeployment } from "./types";
-import { productionMainnetRpcPair } from
-  "./website-rpc-providers.server";
-
-const INDEPENDENT_ARCHIVE_WITNESS = "https://rpc.mevblocker.io/";
+const ARCHIVE_WITNESSES = Object.freeze([
+  "https://rpc.mevblocker.io/",
+  "https://mainnet.gateway.tenderly.co/",
+] as const);
 
 export class HistoricalReadRpcBindingError extends Error {
   override name = "HistoricalReadRpcBindingError";
@@ -18,32 +18,29 @@ export class HistoricalReadRpcBindingError extends Error {
 
 /**
  * Historical registry reconstruction requires two archive-capable readers.
- * The private QuickNode endpoint remains commitment-bound; MEV Blocker is a
- * fixed, independent witness. Current-market reads keep their separate private
- * dRPC + QuickNode quorum.
+ * MEV Blocker and Tenderly are fixed independent archive witnesses. Current-
+ * market reads keep their separate commitment-bound private dRPC + QuickNode
+ * quorum.
  */
 export function historicalReadOnchainDeployment(
   baseDeployment: ReadyOnchainDeployment,
-  environment: Readonly<Record<string, string | undefined>> = process.env,
 ): ReadyOnchainDeployment {
   if (baseDeployment.chainId !== 1) {
     throw new HistoricalReadRpcBindingError();
   }
 
   try {
-    const binding = productionMainnetRpcPair(environment);
     const providers = createActionRpcQuorum({
       chainId: 1,
-      primary: binding.secondary.url,
-      secondary: INDEPENDENT_ARCHIVE_WITNESS,
+      primary: ARCHIVE_WITNESSES[0],
+      secondary: ARCHIVE_WITNESSES[1],
       maximumProviders: 2,
     });
     const [primary, secondary] = providers;
     if (
       providers.length !== 2 ||
-      primary?.vendorGroup !== "quicknode" ||
-      secondary?.vendorGroup !== "mevblocker" ||
-      primary.endpointCommitment !== binding.secondary.endpointCommitment
+      primary?.vendorGroup !== "mevblocker" ||
+      secondary?.vendorGroup !== "tenderly"
     ) {
       throw new HistoricalReadRpcBindingError();
     }

--- a/lib/server/action-rpc-quorum.server.ts
+++ b/lib/server/action-rpc-quorum.server.ts
@@ -15,6 +15,7 @@ type ActionRpcVendor =
   | "drpc"
   | "publicnode"
   | "mevblocker"
+  | "tenderly"
   | "sepolia-org"
   | "blastapi"
   | "ankr";
@@ -145,6 +146,14 @@ function providerVendor(
     noQuery
   ) {
     return "mevblocker";
+  }
+  if (
+    chainId === 1 &&
+    value.hostname === "mainnet.gateway.tenderly.co" &&
+    rootPath &&
+    noQuery
+  ) {
+    return "tenderly";
   }
   if (
     chainId === 11_155_111 &&

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -23,7 +23,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
         Object.freeze({
           path: "lib/onchain/historical-read-rpc.server.ts",
-          sha256: "98ccb2a6471a4e38ef521b1fd7e41d55bb19b904a9c1d5e8d6948976a628d63e",
+          sha256: "725bde4016b635c77ed996e8b6d574b589f3cccd5778a7ed63ea9afbde4e77b7",
         }),
       ]),
       releaseRuntimes: Object.freeze([
@@ -113,7 +113,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       dependencies: Object.freeze([
         Object.freeze({
           path: "lib/server/action-rpc-quorum.server.ts",
-          sha256: "398de34ff2965d89ee2c4b1cffeba043ebe2586eb08685e2a0ea7ff0d6cf18b9",
+          sha256: "1f48c805536ff4824658c31650435eb56d30b730f9dc4d9ed0279040f8b52993",
         }),
       ]),
       policy: Object.freeze({
@@ -1547,19 +1547,22 @@ export function evaluateReadModelOperationsSourceContracts(
         "historicalReadOnchainDeployment(deployment)",
       ) &&
       historicalRpcSource?.includes(
-        'const INDEPENDENT_ARCHIVE_WITNESS = "https://rpc.mevblocker.io/";',
+        '"https://rpc.mevblocker.io/",',
       ) &&
       historicalRpcSource?.includes(
-        "primary: binding.secondary.url",
+        '"https://mainnet.gateway.tenderly.co/",',
       ) &&
       historicalRpcSource?.includes(
-        'primary?.vendorGroup !== "quicknode"',
+        "primary: ARCHIVE_WITNESSES[0]",
       ) &&
       historicalRpcSource?.includes(
-        'secondary?.vendorGroup !== "mevblocker"',
+        "secondary: ARCHIVE_WITNESSES[1]",
       ) &&
       historicalRpcSource?.includes(
-        "primary.endpointCommitment !== binding.secondary.endpointCommitment",
+        'primary?.vendorGroup !== "mevblocker"',
+      ) &&
+      historicalRpcSource?.includes(
+        'secondary?.vendorGroup !== "tenderly"',
       ) &&
       Array.isArray(releaseRuntimes) &&
       releaseRuntimes.length === 2 &&

--- a/tests/action-rpc-quorum.test.ts
+++ b/tests/action-rpc-quorum.test.ts
@@ -154,6 +154,20 @@ describe("action RPC provider identity", () => {
       "publicnode",
     ]);
   });
+
+  it("accepts the fixed independent Mainnet archive witnesses", () => {
+    const providers = createActionRpcQuorum({
+      chainId: 1,
+      primary: "https://rpc.mevblocker.io",
+      secondary: "https://mainnet.gateway.tenderly.co",
+    });
+
+    expectIndependent(providers);
+    expect(providers.map((provider) => provider.vendorGroup)).toEqual([
+      "mevblocker",
+      "tenderly",
+    ]);
+  });
 });
 
 describe("action-route RPC quorums", () => {

--- a/tests/historical-read-rpc-server.test.ts
+++ b/tests/historical-read-rpc-server.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -7,9 +7,6 @@ import {
   historicalReadOnchainDeployment,
 } from "../lib/onchain/historical-read-rpc.server";
 import type { ReadyOnchainDeployment } from "../lib/onchain/types";
-import { productionMainnetRpcEnvironment } from
-  "../lib/onchain/website-rpc-providers.server";
-
 const DRPC_RPC_URL = "https://lb.drpc.live/ethereum/drpc-test-key";
 const QUICKNODE_RPC_URL =
   "https://programmable-mainnet.ethereum-mainnet.quiknode.pro/quicknode-test-key/";
@@ -32,49 +29,35 @@ const deployment: ReadyOnchainDeployment = {
   deploymentBlock: 25_000_000n,
 };
 
-function stubProductionPair() {
-  for (const [name, value] of Object.entries(
-    productionMainnetRpcEnvironment(DRPC_RPC_URL, QUICKNODE_RPC_URL),
-  )) vi.stubEnv(name, value);
-}
-
 describe("historical read RPC deployment", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it("uses commitment-bound QuickNode plus the fixed archive witness", () => {
-    stubProductionPair();
-
+  it("uses two fixed independent archive witnesses", () => {
     expect(historicalReadOnchainDeployment(deployment)).toMatchObject({
-      rpcUrl: QUICKNODE_RPC_URL,
-      rpcUrlSecondary: "https://rpc.mevblocker.io/",
+      rpcUrl: "https://rpc.mevblocker.io/",
+      rpcUrlSecondary: "https://mainnet.gateway.tenderly.co/",
       rpcProviderIds: undefined,
     });
   });
 
-  it("does not retain the non-archive dRPC reader", () => {
-    stubProductionPair();
-
+  it("does not retain either private current-market reader", () => {
     const historical = historicalReadOnchainDeployment({
       ...deployment,
       rpcUrl: "https://eth.drpc.org",
       rpcUrlSecondary: null,
     });
 
-    expect(historical.rpcUrl).toBe(QUICKNODE_RPC_URL);
-    expect(historical.rpcUrlSecondary).toBe("https://rpc.mevblocker.io/");
+    expect(historical.rpcUrl).toBe("https://rpc.mevblocker.io/");
+    expect(historical.rpcUrlSecondary).toBe(
+      "https://mainnet.gateway.tenderly.co/",
+    );
     expect(historical.rpcUrl).not.toContain("drpc");
+    expect(historical.rpcUrl).not.toContain("quicknode");
   });
 
-  it("fails closed when the private QuickNode commitment is missing", () => {
-    stubProductionPair();
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT",
-      "",
-    );
-
-    expect(() => historicalReadOnchainDeployment(deployment))
+  it("fails closed outside Ethereum Mainnet", () => {
+    expect(() => historicalReadOnchainDeployment({
+      ...deployment,
+      chainId: 11_155_111,
+    }))
       .toThrow(HistoricalReadRpcBindingError);
   });
 });


### PR DESCRIPTION
## Outcome
- uses fixed MEV Blocker plus Tenderly archive witnesses only for historical durable reconstruction
- removes both current-market private readers from the full-history scanner after dRPC and QuickNode each failed deterministic Stage archive reads
- keeps current market, trade, claim and health on the existing commitment-bound dRPC plus QuickNode pair
- preserves two independent full-model fingerprints and all fail-closed integrity checks

## Evidence
- same historical block/filter: MEV Blocker success; Tenderly success; dRPC no suitable provider
- focused runtime and operations tests: 633/633
- TypeScript, ESLint, ops gate 41/41, diff check, gitleaks: pass

Exact head/tree in commit.