### PR TITLE
Fix atomic read-model RPC cache checkpoints

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -18,18 +18,18 @@
         },
         {
           "path": "lib/onchain/historical-read-rpc.server.ts",
-          "sha256": "725bde4016b635c77ed996e8b6d574b589f3cccd5778a7ed63ea9afbde4e77b7"
+          "sha256": "0a68b8388003cea8c59c11790f7255df00c94ab773339850ce41c0e1b4c3aa0d"
         },
         {
           "path": "lib/onchain/persistent-rpc-cache.server.ts",
-          "sha256": "867df30838d51522f677751b0238afe10c1db2949c53c89549ca0f3c46ede02f"
+          "sha256": "4556161d79d49914f064a4df5ad2eb7f9777dfe1b3d188cf36a1e5b434b38f9b"
         }
       ],
       "releaseRuntimes": [
         {
           "release": "classic-v3",
           "path": "lib/onchain/classic-v3-read-model.ts",
-          "sha256": "28fbbbacb927f966639d16b8c3adcde33ba9eaf309eef8ef90a130295b75ce82",
+          "sha256": "4921b6869284d405976bc00f9426f1dbf05c5cf02f0354746a57c6ee8631cddd",
           "eventFiltersPerRange": 2
         },
         {

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -9,7 +9,7 @@
     "boundedRefresh": {
       "runtime": {
         "path": "lib/onchain/read-model.ts",
-        "sha256": "73c99640515732c975600b5e9a8cd4ffb7fafbc04536a563126c76ea60b27fe6"
+        "sha256": "f787ca685a1168a119137dc42894b86a0843ec339e9e380be2b32070d256c1a8"
       },
       "dependencies": [
         {
@@ -19,19 +19,23 @@
         {
           "path": "lib/onchain/historical-read-rpc.server.ts",
           "sha256": "725bde4016b635c77ed996e8b6d574b589f3cccd5778a7ed63ea9afbde4e77b7"
+        },
+        {
+          "path": "lib/onchain/persistent-rpc-cache.server.ts",
+          "sha256": "867df30838d51522f677751b0238afe10c1db2949c53c89549ca0f3c46ede02f"
         }
       ],
       "releaseRuntimes": [
         {
           "release": "classic-v3",
           "path": "lib/onchain/classic-v3-read-model.ts",
-          "sha256": "c97c6f5875bf089b8545bfc55bd20f26c1520bdbe0c640e873f70ca08b4cc4a3",
+          "sha256": "28fbbbacb927f966639d16b8c3adcde33ba9eaf309eef8ef90a130295b75ce82",
           "eventFiltersPerRange": 2
         },
         {
           "release": "stock-paired-v1-v3",
           "path": "lib/onchain/stock-paired-read-model.ts",
-          "sha256": "9c9badce8d6dfb000a29fd4abcc013701f5a81736ce9ad9fd1e72816b3a75b2f",
+          "sha256": "749399f6b360fdcbebf3d2632d82409aba00dcbb3367538c89941a81532cce67",
           "eventFiltersPerRange": 3
         }
       ],

--- a/docs/operations/evidence/read-model-v4-private-blob-backfill-2026-08-13.json
+++ b/docs/operations/evidence/read-model-v4-private-blob-backfill-2026-08-13.json
@@ -2,12 +2,18 @@
   "schemaVersion": "programmable.read-model-private-blob-backfill-evidence.v1",
   "environment": "production-private-blob",
   "cacheSchema": "programmable-rpc-log-cursor-v4",
-  "sourceBaseCommit": "dd536a90439665ac63a426207abc460902d1ee52",
+  "sourceBaseCommit": "be0b5fdb1d0b7ab50bd16657db8677c29c4eab19",
+  "sourceBindings": {
+    "lib/onchain/classic-v3-read-model.ts": "4921b6869284d405976bc00f9426f1dbf05c5cf02f0354746a57c6ee8631cddd",
+    "lib/onchain/persistent-rpc-cache.server.ts": "4556161d79d49914f064a4df5ad2eb7f9777dfe1b3d188cf36a1e5b434b38f9b",
+    "lib/onchain/historical-read-rpc.server.ts": "0a68b8388003cea8c59c11790f7255df00c94ab773339850ce41c0e1b4c3aa0d"
+  },
   "checkpoint": {
     "chainId": 1,
     "groupDomain": "classic-v3-events-v2",
     "groupId": "417e71f686d80738a617f5904c22bea74e9b50694ba346b618b15aa53346cdfe",
-    "headCommitId": "c82a7ed0-a648-43a0-981b-f0f0216c657f",
+    "headCommitId": "60ae5fae-445f-40af-b871-b17242a89f70",
+    "providerRoles": ["drpc", "quicknode"],
     "providerIds": [
       "1ea1c2f6afc5dfeb337015523196009c66e4bd70aca6cc1f2b5f845126bcfbdf",
       "aff9065b48df62a3041df32ee22a260e6c5f14ce722042185f60fd4c237614d2"
@@ -16,18 +22,24 @@
     "streamIdentitiesPerProvider": 2,
     "cursorCount": 4
   },
+  "archiveProbe": {
+    "releaseStartBlock": "25639596",
+    "currentProbeBlock": "25747953",
+    "providerCount": 2,
+    "matchingBlockNumberAndHash": true
+  },
   "lineage": {
     "startBlock": "25639596",
-    "targetBlock": "25747604",
+    "targetBlock": "25747986",
     "maximumWindowBlocks": 1000,
-    "committedWindows": 109,
+    "committedWindows": 110,
     "firstWindow": {
       "fromBlock": "25639596",
       "toBlock": "25640595"
     },
     "lastWindow": {
-      "fromBlock": "25747596",
-      "toBlock": "25747604"
+      "fromBlock": "25747605",
+      "toBlock": "25747986"
     },
     "gaps": 0,
     "overlaps": 0,
@@ -37,36 +49,40 @@
   "activeReferences": {
     "segmentsPerCursor": [8, 8, 8, 8],
     "uniqueSegments": 32,
-    "declaredBytes": 18649356
+    "declaredBytes": 18651152
   },
-  "restartReplay": {
-    "windows": 109,
-    "blobReads": 1744,
-    "blobCreates": 0,
-    "blobReplaces": 0,
-    "rpcGetLogs": 0,
-    "rpcGetBlockByNumber": 654,
-    "otherRpcRequests": 0
+  "fullReplayAndPartialTailExtension": {
+    "requestedWindows": 109,
+    "blobReads": 1757,
+    "blobCreates": 13,
+    "blobReplaces": 2,
+    "rpcGetLogs": 4,
+    "rpcGetBlockByNumber": 668,
+    "otherRpcRequests": 0,
+    "committedTailFromBlock": "25747605",
+    "committedTailToBlock": "25747986"
   },
   "freshProcessResume": {
     "windowsWritten": 0,
     "blobReads": 2,
     "blobCreates": 0,
-    "blobReplaces": 0
+    "blobReplaces": 0,
+    "rpcRequests": 0
   },
   "physicalInventory": {
-    "objects": 1996,
-    "bytes": 130370497,
-    "checkpointHeads": 2,
-    "integrityMarkers": 214,
-    "cursorVersions": 890,
-    "segments": 890,
+    "objects": 2049,
+    "bytes": 131700430,
+    "checkpointHeads": 3,
+    "integrityMarkers": 219,
+    "cursorVersions": 913,
+    "segments": 914,
     "scope": "all v4 objects, including unreachable experimental checkpoint domains"
   },
   "safety": {
     "rpcUrlsRecorded": false,
     "credentialsRecorded": false,
     "retiredV3ReadDuringProof": false,
+    "publicRpcFallbackAllowed": false,
     "productionAliasChanged": false
   }
 }

--- a/docs/operations/evidence/read-model-v4-private-blob-backfill-2026-08-13.json
+++ b/docs/operations/evidence/read-model-v4-private-blob-backfill-2026-08-13.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": "programmable.read-model-private-blob-backfill-evidence.v1",
+  "environment": "production-private-blob",
+  "cacheSchema": "programmable-rpc-log-cursor-v4",
+  "sourceBaseCommit": "dd536a90439665ac63a426207abc460902d1ee52",
+  "checkpoint": {
+    "chainId": 1,
+    "groupDomain": "classic-v3-events-v2",
+    "groupId": "417e71f686d80738a617f5904c22bea74e9b50694ba346b618b15aa53346cdfe",
+    "headCommitId": "c82a7ed0-a648-43a0-981b-f0f0216c657f",
+    "providerIds": [
+      "1ea1c2f6afc5dfeb337015523196009c66e4bd70aca6cc1f2b5f845126bcfbdf",
+      "aff9065b48df62a3041df32ee22a260e6c5f14ce722042185f60fd4c237614d2"
+    ],
+    "providerCount": 2,
+    "streamIdentitiesPerProvider": 2,
+    "cursorCount": 4
+  },
+  "lineage": {
+    "startBlock": "25639596",
+    "targetBlock": "25747604",
+    "maximumWindowBlocks": 1000,
+    "committedWindows": 109,
+    "firstWindow": {
+      "fromBlock": "25639596",
+      "toBlock": "25640595"
+    },
+    "lastWindow": {
+      "fromBlock": "25747596",
+      "toBlock": "25747604"
+    },
+    "gaps": 0,
+    "overlaps": 0,
+    "allMarkersCommitted": true,
+    "allEnvelopeContentHashesVerified": true
+  },
+  "activeReferences": {
+    "segmentsPerCursor": [8, 8, 8, 8],
+    "uniqueSegments": 32,
+    "declaredBytes": 18649356
+  },
+  "restartReplay": {
+    "windows": 109,
+    "blobReads": 1744,
+    "blobCreates": 0,
+    "blobReplaces": 0,
+    "rpcGetLogs": 0,
+    "rpcGetBlockByNumber": 654,
+    "otherRpcRequests": 0
+  },
+  "freshProcessResume": {
+    "windowsWritten": 0,
+    "blobReads": 2,
+    "blobCreates": 0,
+    "blobReplaces": 0
+  },
+  "physicalInventory": {
+    "objects": 1996,
+    "bytes": 130370497,
+    "checkpointHeads": 2,
+    "integrityMarkers": 214,
+    "cursorVersions": 890,
+    "segments": 890,
+    "scope": "all v4 objects, including unreachable experimental checkpoint domains"
+  },
+  "safety": {
+    "rpcUrlsRecorded": false,
+    "credentialsRecorded": false,
+    "retiredV3ReadDuringProof": false,
+    "productionAliasChanged": false
+  }
+}

--- a/lib/onchain/classic-v3-read-model.ts
+++ b/lib/onchain/classic-v3-read-model.ts
@@ -530,6 +530,7 @@ export async function readClassicV3EventsQuorum(
         requireCheckpointWindow: true,
         requiredInitialFromBlock: release.startBlock,
         requireContiguousCheckpointWindow: true,
+        allowCheckpointWindowExtension: true,
       },
     );
     let eventSets: Awaited<ReturnType<typeof readCheckpoint>> | null = null;

--- a/lib/onchain/classic-v3-read-model.ts
+++ b/lib/onchain/classic-v3-read-model.ts
@@ -9,6 +9,7 @@ import {
   ResponseBodyTooLargeError,
   RpcRequestError,
   TimeoutError,
+  toEventSelector,
   type Address,
   type Hex,
   type PublicClient,
@@ -32,7 +33,12 @@ import {
 } from "./math";
 import { buildTokenLinks, sanitizeImageUrl } from "./metadata";
 import {
+  bindPersistentRpcIntegrityCheckpointWindow,
+  createEnvironmentPersistentRpcCacheStore,
   persistentRpcHttp,
+  persistentRpcProviderId,
+  PersistentRpcCacheError,
+  type PersistentRpcCacheStore,
   withPersistentRpcIntegrityScope,
 } from "./persistent-rpc-cache.server";
 import type { ExploreReadModel, ReadyOnchainDeployment } from "./types";
@@ -95,6 +101,7 @@ const RPC_PROVENANCE_BATCH_SIZE = 1;
 const TOKEN_HYDRATION_BATCH_SIZE = 6;
 const BLOCK_TIMESTAMP_BATCH_SIZE = 4;
 const MINIMUM_LOG_BLOCK_RANGE = 1n;
+const MAXIMUM_CHECKPOINT_BLOCK_RANGE = 1_000n;
 const TRANSIENT_RETRIES_PER_WINDOW = 1;
 const MINIMUM_RANGE_TRANSIENT_RETRIES = 2;
 
@@ -113,6 +120,13 @@ function isTransientLogReadError(error: unknown) {
     error instanceof RpcRequestError &&
     error.code === -32603 &&
     error.details.trim().toLowerCase() === "service temporarily unavailable"
+  );
+}
+
+function isPersistentCacheRangeLimitError(error: unknown) {
+  return (
+    error instanceof PersistentRpcCacheError &&
+    /^Persistent RPC cache log segment exceeds \d+ bytes$/u.test(error.message)
   );
 }
 
@@ -160,6 +174,7 @@ function clientFor(
   config: ReadyOnchainDeployment,
   endpoint: string,
   release: ClassicV3Release,
+  store?: PersistentRpcCacheStore | null,
 ) {
   return createPublicClient({
     chain: config.chainId === 1 ? mainnet : sepolia,
@@ -167,6 +182,7 @@ function clientFor(
     transport: persistentRpcHttp(endpoint, {
       chainId: config.chainId,
       maxLogBlockRange: config.logBlockRange,
+      ...(store !== undefined ? { store } : {}),
       http: { retryCount: 1, timeout: 10_000 },
       immutableCodeBindings: [
         {
@@ -273,6 +289,7 @@ export async function readClassicV3Events(
 ) {
   const launches: LaunchRecord[] = [];
   const volumes = new Map<string, FeeVolume>();
+  const eventProvenance: string[] = [];
   let fromBlock =
     fromBlockFloor > release.startBlock
       ? fromBlockFloor
@@ -327,7 +344,8 @@ export async function readClassicV3Events(
       if (
         (transient ||
           error instanceof LimitExceededRpcError ||
-          error instanceof ResponseBodyTooLargeError) &&
+          error instanceof ResponseBodyTooLargeError ||
+          isPersistentCacheRangeLimitError(error)) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
       ) {
@@ -351,6 +369,13 @@ export async function readClassicV3Events(
       throw error;
     }
     const [launchLogs, feeLogs] = logs;
+    eventProvenance.push(
+      ...[...launchLogs, ...feeLogs].map((log) =>
+        JSON.stringify(log, (_, item) =>
+          typeof item === "bigint" ? item.toString() : item
+        )
+      ),
+    );
     for (const log of launchLogs) {
       assertCanonicalClassicV3EventSource(
         log.eventName,
@@ -400,7 +425,7 @@ export async function readClassicV3Events(
       );
     }
   }
-  return { launches, volumes };
+  return { launches, volumes, eventProvenance };
 }
 
 function eventFingerprint(
@@ -412,9 +437,133 @@ function eventFingerprint(
       volumes: [...value.volumes.entries()].sort(([left], [right]) =>
         left.localeCompare(right),
       ),
+      eventProvenance: value.eventProvenance,
     },
     (_, item) => (typeof item === "bigint" ? item.toString() : item),
   );
+}
+
+export async function readClassicV3EventsQuorum(
+  clients: readonly PublicClient[],
+  config: ReadyOnchainDeployment,
+  release: ClassicV3Release,
+  toBlock: bigint,
+  fromBlockFloor: bigint,
+) {
+  if (clients.length !== 2) {
+    throw new Error("Classic V3 checkpoints require exactly two independent RPCs");
+  }
+  const launches: LaunchRecord[] = [];
+  const volumes = new Map<string, FeeVolume>();
+  const eventProvenance: string[] = [];
+  let fromBlock = fromBlockFloor > release.startBlock
+    ? fromBlockFloor
+    : release.startBlock;
+  while (fromBlock <= toBlock) {
+    const checkpointBlockRange = minimum(
+      config.logBlockRange,
+      MAXIMUM_CHECKPOINT_BLOCK_RANGE,
+    );
+    const rangeEnd = minimum(
+      toBlock,
+      fromBlock + checkpointBlockRange - 1n,
+    );
+    const readCheckpoint = () => withPersistentRpcIntegrityScope(
+      async () => {
+        const [sets, boundaries] = await Promise.all([
+          allSettledOrThrow(
+            clients.map((client) =>
+              readClassicV3Events(
+                client,
+                config,
+                release,
+                rangeEnd,
+                fromBlock,
+              )
+            ),
+          ),
+          allSettledOrThrow(
+            clients.map((client) =>
+              client.getBlock({ blockNumber: rangeEnd })
+            ),
+          ),
+        ]);
+        const fingerprint = eventFingerprint(sets[0]);
+        if (
+          sets.some((candidate) => eventFingerprint(candidate) !== fingerprint) ||
+          boundaries.some(
+            (candidate) =>
+              candidate.number !== rangeEnd ||
+              typeof candidate.hash !== "string" ||
+              !/^0x[0-9a-f]{64}$/iu.test(candidate.hash) ||
+              candidate.hash?.toLowerCase() !== boundaries[0].hash?.toLowerCase(),
+          )
+        ) {
+          throw new Error(
+            "Independent RPCs disagree on the Classic V3 checkpoint window",
+          );
+        }
+        bindPersistentRpcIntegrityCheckpointWindow({
+          fromBlock,
+          toBlock: rangeEnd,
+          boundaryBlockHash: boundaries[0].hash,
+        });
+        return sets;
+      },
+      {
+        checkpointGroup: [
+          "classic-v3-events-v2",
+          config.chainId,
+          release.startBlock.toString(),
+          release.launcher.toLowerCase(),
+          release.hook.toLowerCase(),
+          toEventSelector(launchedEvent),
+          toEventSelector(feeEvent),
+          ...[
+            config.rpcUrl,
+            ...(config.rpcUrlSecondary ? [config.rpcUrlSecondary] : []),
+          ].map(persistentRpcProviderId).sort(),
+        ].join(":"),
+        expectedCursorBindings: clients.length * 2,
+        expectedProviderCount: clients.length,
+        expectedStreamsPerProvider: 2,
+        requireCheckpointWindow: true,
+        requiredInitialFromBlock: release.startBlock,
+        requireContiguousCheckpointWindow: true,
+      },
+    );
+    let eventSets: Awaited<ReturnType<typeof readCheckpoint>> | null = null;
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      try {
+        eventSets = await readCheckpoint();
+        break;
+      } catch (error) {
+        if (
+          attempt === 3 ||
+          !(error instanceof PersistentRpcCacheError) ||
+          error.message !== "Persistent RPC integrity checkpoint publish conflicted"
+        ) {
+          throw error;
+        }
+      }
+    }
+    if (!eventSets) {
+      throw new Error("Classic V3 checkpoint retry exhausted");
+    }
+    const agreed = eventSets[0];
+    launches.push(...agreed.launches);
+    eventProvenance.push(...agreed.eventProvenance);
+    for (const [poolId, value] of agreed.volumes) {
+      const current = volumes.get(poolId) ?? { ...EMPTY_VOLUME };
+      current.grossNativeAmount += value.grossNativeAmount;
+      current.creatorFees += value.creatorFees;
+      current.launcherFees += value.launcherFees;
+      current.swapCount += value.swapCount;
+      volumes.set(poolId, current);
+    }
+    fromBlock = rangeEnd + 1n;
+  }
+  return { launches, volumes, eventProvenance };
 }
 
 function assertUniqueLaunches(
@@ -595,10 +744,11 @@ export async function readClassicV3ExploreModel(
   if (toBlock < release.startBlock) {
     return { tokens: [], launcherFeesAccrued: 0n };
   }
+  const persistentStore = createEnvironmentPersistentRpcCacheStore();
   const clients = [
-    clientFor(config, config.rpcUrl, release),
+    clientFor(config, config.rpcUrl, release, persistentStore),
     ...(config.rpcUrlSecondary
-      ? [clientFor(config, config.rpcUrlSecondary, release)]
+      ? [clientFor(config, config.rpcUrlSecondary, release, persistentStore)]
       : []),
   ];
   await mapInBatches(
@@ -639,17 +789,12 @@ export async function readClassicV3ExploreModel(
           ),
       ),
   );
-  const eventSets = await allSettledOrThrow(
-    clients.map((client) =>
-      withPersistentRpcIntegrityScope(() =>
-        readClassicV3Events(
-          client,
-          config,
-          release,
-          toBlock,
-          options.fromBlock ?? release.startBlock,
-        ),
-      )),
+  const agreedEvents = await readClassicV3EventsQuorum(
+    clients,
+    config,
+    release,
+    toBlock,
+    options.fromBlock ?? release.startBlock,
   );
   const launcherFees = await mapInBatches(
     clients,
@@ -662,14 +807,12 @@ export async function readClassicV3ExploreModel(
           blockNumber: toBlock,
         }),
   );
-  const fingerprint = eventFingerprint(eventSets[0]);
   if (
-    eventSets.some((candidate) => eventFingerprint(candidate) !== fingerprint) ||
     launcherFees.some((value) => value !== launcherFees[0])
   ) {
     throw new Error("Independent RPCs disagree on Classic V3 state");
   }
-  const { launches, volumes } = eventSets[0];
+  const { launches, volumes } = agreedEvents;
   assertUniqueLaunches(launches, release);
   const timestamps = new Map<string, bigint>();
   await mapInBatches(

--- a/lib/onchain/historical-read-rpc.server.ts
+++ b/lib/onchain/historical-read-rpc.server.ts
@@ -3,10 +3,8 @@ import "server-only";
 import { createActionRpcQuorum } from
   "../server/action-rpc-quorum.server";
 import type { ReadyOnchainDeployment } from "./types";
-const ARCHIVE_WITNESSES = Object.freeze([
-  "https://rpc.mevblocker.io/",
-  "https://mainnet.gateway.tenderly.co/",
-] as const);
+import { productionMainnetRpcPair } from
+  "./website-rpc-providers.server";
 
 export class HistoricalReadRpcBindingError extends Error {
   override name = "HistoricalReadRpcBindingError";
@@ -18,29 +16,34 @@ export class HistoricalReadRpcBindingError extends Error {
 
 /**
  * Historical registry reconstruction requires two archive-capable readers.
- * MEV Blocker and Tenderly are fixed independent archive witnesses. Current-
- * market reads keep their separate commitment-bound private dRPC + QuickNode
- * quorum.
+ * It reuses the exact commitment-bound production dRPC + QuickNode pair: this
+ * creates a deliberate correlation with current-market reads, but preserves
+ * independent vendors, exact endpoint commitments and operational capacity.
+ * No public or anonymous fallback may substitute either provider.
  */
 export function historicalReadOnchainDeployment(
   baseDeployment: ReadyOnchainDeployment,
+  environment: Readonly<Record<string, string | undefined>> = process.env,
 ): ReadyOnchainDeployment {
   if (baseDeployment.chainId !== 1) {
     throw new HistoricalReadRpcBindingError();
   }
 
   try {
+    const binding = productionMainnetRpcPair(environment);
     const providers = createActionRpcQuorum({
       chainId: 1,
-      primary: ARCHIVE_WITNESSES[0],
-      secondary: ARCHIVE_WITNESSES[1],
+      primary: binding.primary.url,
+      secondary: binding.secondary.url,
       maximumProviders: 2,
     });
     const [primary, secondary] = providers;
     if (
       providers.length !== 2 ||
-      primary?.vendorGroup !== "mevblocker" ||
-      secondary?.vendorGroup !== "tenderly"
+      primary?.vendorGroup !== "drpc" ||
+      secondary?.vendorGroup !== "quicknode" ||
+      primary.endpointCommitment !== binding.primary.endpointCommitment ||
+      secondary.endpointCommitment !== binding.secondary.endpointCommitment
     ) {
       throw new HistoricalReadRpcBindingError();
     }
@@ -49,7 +52,10 @@ export function historicalReadOnchainDeployment(
       ...baseDeployment,
       rpcUrl: primary.endpoint,
       rpcUrlSecondary: secondary.endpoint,
-      rpcProviderIds: undefined,
+      rpcProviderIds: {
+        primary: "drpc",
+        secondary: "quicknode",
+      },
     };
   } catch {
     throw new HistoricalReadRpcBindingError();

--- a/lib/onchain/persistent-rpc-cache.server.ts
+++ b/lib/onchain/persistent-rpc-cache.server.ts
@@ -621,6 +621,7 @@ type IntegrityScope = {
   requireCheckpointWindow: boolean;
   requiredInitialFromBlock?: string;
   requireContiguousCheckpointWindow: boolean;
+  allowCheckpointWindowExtension: boolean;
   checkpointGroupId: string;
   checkpointWindow?: IntegrityCheckpointWindow;
   cursorDrafts: Map<string, CursorReference>;
@@ -948,6 +949,7 @@ export async function withPersistentRpcIntegrityScope<T>(
     requireCheckpointWindow?: boolean;
     requiredInitialFromBlock?: bigint;
     requireContiguousCheckpointWindow?: boolean;
+    allowCheckpointWindowExtension?: boolean;
   }> = {},
 ) {
   if (integrityScopes.getStore()) return operation();
@@ -987,6 +989,8 @@ export async function withPersistentRpcIntegrityScope<T>(
       : {}),
     requireContiguousCheckpointWindow:
       input.requireContiguousCheckpointWindow === true,
+    allowCheckpointWindowExtension:
+      input.allowCheckpointWindowExtension === true,
     checkpointGroupId: digest({
       checkpointGroup: input.checkpointGroup ?? "isolated",
     }),
@@ -1084,7 +1088,20 @@ export async function withPersistentRpcIntegrityScope<T>(
           BigInt(scope.checkpointWindow.fromBlock) !==
             BigInt(previousWindow.toBlock) + 1n
         ) {
-          fail("Persistent RPC checkpoint window is not contiguous with its committed baseline");
+          const previousToBlock = BigInt(previousWindow.toBlock);
+          const requestedFromBlock = BigInt(scope.checkpointWindow.fromBlock);
+          const requestedToBlock = BigInt(scope.checkpointWindow.toBlock);
+          if (
+            !scope.allowCheckpointWindowExtension ||
+            requestedFromBlock > previousToBlock ||
+            requestedToBlock <= previousToBlock
+          ) {
+            fail("Persistent RPC checkpoint window is not contiguous with its committed baseline");
+          }
+          scope.checkpointWindow = {
+            ...scope.checkpointWindow,
+            fromBlock: (previousToBlock + 1n).toString(),
+          };
         }
       }
       if (scope.checkpointWindow) {
@@ -1101,6 +1118,20 @@ export async function withPersistentRpcIntegrityScope<T>(
             requestInput,
             binding.streamId,
           );
+          if (scope.requiredInitialFromBlock !== undefined) {
+            let nextCoveredBlock = BigInt(scope.requiredInitialFromBlock);
+            for (const segment of cursor.segments) {
+              if (BigInt(segment.fromBlock) !== nextCoveredBlock) {
+                fail("Persistent RPC checkpoint cursor has incomplete historical coverage");
+              }
+              nextCoveredBlock = BigInt(segment.toBlock) + 1n;
+            }
+            if (
+              nextCoveredBlock !== BigInt(scope.checkpointWindow.toBlock) + 1n
+            ) {
+              fail("Persistent RPC checkpoint cursor has incomplete historical coverage");
+            }
+          }
           if (
             BigInt(cursor.cursorBlock) !==
               BigInt(scope.checkpointWindow.toBlock) ||

--- a/lib/onchain/persistent-rpc-cache.server.ts
+++ b/lib/onchain/persistent-rpc-cache.server.ts
@@ -9,9 +9,10 @@ import {
   type Transport,
 } from "viem";
 
-const CACHE_SCHEMA = "programmable-rpc-log-cursor-v3";
-const CACHE_DIRECTORY = "indexes/rpc-log-cursors/v3";
+const CACHE_SCHEMA = "programmable-rpc-log-cursor-v4";
+const CACHE_DIRECTORY = "indexes/rpc-log-cursors/v4";
 const HEX_QUANTITY = /^0x(?:0|[1-9a-f][0-9a-f]*)$/iu;
+const DECIMAL = /^(?:0|[1-9]\d*)$/u;
 const BYTES32 = /^0x[0-9a-f]{64}$/iu;
 const ADDRESS = /^0x[0-9a-f]{40}$/iu;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
@@ -61,6 +62,33 @@ type LogCursorPayload = Readonly<{
   cursorBlockHash: string;
   integrityCommitId?: string;
   segments: readonly LogSegment[];
+}>;
+
+type CursorReference = Readonly<{
+  path: string;
+  contentHash: string;
+}>;
+
+type IntegrityCheckpointHeadPayload = Readonly<{
+  chainId: number;
+  checkpointGroupId: string;
+  integrityCommitId: string;
+  previousIntegrityCommitId: string | null;
+}>;
+
+type IntegrityCheckpointWindow = Readonly<{
+  fromBlock: string;
+  toBlock: string;
+  boundaryBlockHash: string;
+}>;
+
+type IntegrityCursorBinding = Readonly<{
+  providerId: string;
+  streamId: string;
+  streamIdentity: string;
+  cursorKey: string;
+  cursorPath: string;
+  cursorContentHash: string;
 }>;
 
 type LogSegmentPayload = Readonly<{
@@ -236,15 +264,35 @@ function streamId(input: PersistentRequestInput, filter: LogFilter) {
   });
 }
 
-function cursorPath(input: PersistentRequestInput, id: string) {
-  return `${CACHE_DIRECTORY}/${input.chainId}/${input.providerId}/${id}/cursor.json`;
+function streamIdentity(input: PersistentRequestInput, filter: LogFilter) {
+  return digest({
+    schemaVersion: CACHE_SCHEMA,
+    chainId: input.chainId,
+    filter: normalizedStreamFilter(filter),
+  });
+}
+
+function cursorKey(input: PersistentRequestInput, id: string) {
+  return `${input.providerId}:${id}`;
+}
+
+function checkpointHeadPath(chainId: number, checkpointGroupId: string) {
+  return `${CACHE_DIRECTORY}/${chainId}/checkpoints/${checkpointGroupId}.json`;
 }
 
 function integrityCommitPath(
-  input: PersistentRequestInput,
+  chainId: number,
   integrityCommitId: string,
 ) {
-  return `${CACHE_DIRECTORY}/${input.chainId}/${input.providerId}/integrity/${integrityCommitId}.json`;
+  return `${CACHE_DIRECTORY}/${chainId}/integrity/${integrityCommitId}.json`;
+}
+
+function cursorVersionPath(
+  input: PersistentRequestInput,
+  id: string,
+  contentHash: string,
+) {
+  return `${CACHE_DIRECTORY}/${input.chainId}/${input.providerId}/${id}/cursors/${contentHash}.json`;
 }
 
 function segmentPath(
@@ -355,6 +403,39 @@ function parseCursor(
     "cursor",
   );
   return cursor;
+}
+
+function parseCheckpointHead(
+  value: unknown,
+  chainId: number,
+  checkpointGroupId: string,
+) {
+  const payload = unwrapEnvelope(value);
+  if (
+    !isRecord(payload) ||
+    payload.chainId !== chainId ||
+    payload.checkpointGroupId !== checkpointGroupId ||
+    typeof payload.integrityCommitId !== "string" ||
+    !UUID.test(payload.integrityCommitId) ||
+    (payload.previousIntegrityCommitId !== null &&
+      (typeof payload.previousIntegrityCommitId !== "string" ||
+        !UUID.test(payload.previousIntegrityCommitId) ||
+        payload.previousIntegrityCommitId === payload.integrityCommitId))
+  ) {
+    fail("Persistent RPC integrity checkpoint is invalid");
+  }
+  const head: IntegrityCheckpointHeadPayload = {
+    chainId,
+    checkpointGroupId,
+    integrityCommitId: payload.integrityCommitId,
+    previousIntegrityCommitId: payload.previousIntegrityCommitId as string | null,
+  };
+  assertByteLimit(
+    envelope(head),
+    PERSISTENT_RPC_CACHE_LIMITS.maxCursorBytes,
+    "integrity checkpoint",
+  );
+  return head;
 }
 
 function allowedAddresses(filter: LogFilter) {
@@ -534,12 +615,30 @@ type IntegrityScope = {
   phase: "open" | "finalizing" | "closed";
   bindings: Map<string, IntegrityScopeBinding>;
   prechecks: Map<string, Promise<void>>;
+  expectedCursorBindings?: number;
+  expectedProviderCount?: number;
+  expectedStreamsPerProvider?: number;
+  requireCheckpointWindow: boolean;
+  requiredInitialFromBlock?: string;
+  requireContiguousCheckpointWindow: boolean;
+  checkpointGroupId: string;
+  checkpointWindow?: IntegrityCheckpointWindow;
+  cursorDrafts: Map<string, CursorReference>;
+  checkpoint?: Readonly<{
+    store: PersistentRpcCacheStore;
+    chainId: number;
+    path: string;
+    etag: string | null;
+    pointedIntegrityCommitId: string | null;
+    integrityCommitId: string | null;
+    checkpointWindow: IntegrityCheckpointWindow | null;
+  }>;
   persistenceBindings: Array<
-    Readonly<{
+    {
       input: PersistentRequestInput;
       store: PersistentRpcCacheStore;
-      cursorDigests: Set<string>;
-    }>
+      cursors: Map<string, IntegrityCursorBinding>;
+    }
   >;
 };
 
@@ -565,59 +664,111 @@ function integrityProofKey(input: PersistentRequestInput, blockNumber: bigint) {
 type IntegrityMarkerStatus = "pending" | "committed" | "aborted";
 
 function integrityMarker(
-  input: PersistentRequestInput,
+  chainId: number,
+  checkpointGroupId: string,
   integrityCommitId: string,
   status: IntegrityMarkerStatus,
-  cursorDigests: ReadonlySet<string>,
+  previousIntegrityCommitId: string | null,
+  checkpointWindow: IntegrityCheckpointWindow | null,
+  cursors: readonly IntegrityCursorBinding[],
 ) {
   return envelope({
-    chainId: input.chainId,
-    providerId: input.providerId,
+    chainId,
+    checkpointGroupId,
     integrityCommitId,
     status,
-    cursorDigests: [...cursorDigests].sort(),
+    previousIntegrityCommitId,
+    checkpointWindow,
+    cursors: [...cursors].sort((left, right) =>
+      left.cursorPath.localeCompare(right.cursorPath)
+    ),
   });
 }
 
 function parseIntegrityMarker(
   value: unknown,
-  input: PersistentRequestInput,
+  chainId: number,
+  checkpointGroupId: string,
   integrityCommitId: string,
 ) {
   const payload = unwrapEnvelope(value);
   if (
     !isRecord(payload) ||
-    payload.chainId !== input.chainId ||
-    payload.providerId !== input.providerId ||
+    payload.chainId !== chainId ||
+    payload.checkpointGroupId !== checkpointGroupId ||
     payload.integrityCommitId !== integrityCommitId ||
     (payload.status !== "pending" &&
       payload.status !== "committed" &&
       payload.status !== "aborted") ||
-    !Array.isArray(payload.cursorDigests) ||
-    payload.cursorDigests.length === 0 ||
-    payload.cursorDigests.length > 128 ||
-    payload.cursorDigests.some(
-      (candidate) =>
-        typeof candidate !== "string" || !/^[0-9a-f]{64}$/u.test(candidate),
-    ) ||
-    new Set(payload.cursorDigests).size !== payload.cursorDigests.length
+    (payload.previousIntegrityCommitId !== null &&
+      (typeof payload.previousIntegrityCommitId !== "string" ||
+        !UUID.test(payload.previousIntegrityCommitId))) ||
+    (payload.checkpointWindow !== null &&
+      (!isRecord(payload.checkpointWindow) ||
+        typeof payload.checkpointWindow.fromBlock !== "string" ||
+        !DECIMAL.test(payload.checkpointWindow.fromBlock) ||
+        typeof payload.checkpointWindow.toBlock !== "string" ||
+        !DECIMAL.test(payload.checkpointWindow.toBlock) ||
+        BigInt(payload.checkpointWindow.fromBlock) >
+          BigInt(payload.checkpointWindow.toBlock) ||
+        typeof payload.checkpointWindow.boundaryBlockHash !== "string" ||
+        !BYTES32.test(payload.checkpointWindow.boundaryBlockHash))) ||
+    !Array.isArray(payload.cursors) ||
+    payload.cursors.length === 0 ||
+    payload.cursors.length > 32
   ) {
     fail("Persistent RPC integrity commit is invalid");
   }
+  const cursors = new Map<string, IntegrityCursorBinding>();
+  for (const candidate of payload.cursors) {
+    if (
+      !isRecord(candidate) ||
+      typeof candidate.providerId !== "string" ||
+      candidate.providerId.length < 1 ||
+      typeof candidate.streamId !== "string" ||
+      !/^[0-9a-f]{64}$/u.test(candidate.streamId) ||
+      typeof candidate.streamIdentity !== "string" ||
+      !/^[0-9a-f]{64}$/u.test(candidate.streamIdentity) ||
+      typeof candidate.cursorKey !== "string" ||
+      candidate.cursorKey !== `${candidate.providerId}:${candidate.streamId}` ||
+      typeof candidate.cursorPath !== "string" ||
+      !candidate.cursorPath.startsWith(
+        `${CACHE_DIRECTORY}/${chainId}/${candidate.providerId}/${candidate.streamId}/cursors/`,
+      ) ||
+      typeof candidate.cursorContentHash !== "string" ||
+      !/^[0-9a-f]{64}$/u.test(candidate.cursorContentHash) ||
+      cursors.has(candidate.cursorKey)
+    ) {
+      fail("Persistent RPC integrity commit cursor binding is invalid");
+    }
+    cursors.set(candidate.cursorKey, {
+      providerId: candidate.providerId,
+      streamId: candidate.streamId,
+      streamIdentity: candidate.streamIdentity,
+      cursorKey: candidate.cursorKey,
+      cursorPath: candidate.cursorPath,
+      cursorContentHash: candidate.cursorContentHash,
+    });
+  }
   return {
     status: payload.status,
-    cursorDigests: new Set(payload.cursorDigests as string[]),
+    previousIntegrityCommitId: payload.previousIntegrityCommitId as string | null,
+    checkpointWindow: payload.checkpointWindow as IntegrityCheckpointWindow | null,
+    cursors,
   };
 }
 
 async function transitionIntegrityMarker(
-  input: PersistentRequestInput,
+  chainId: number,
+  checkpointGroupId: string,
   store: PersistentRpcCacheStore,
   integrityCommitId: string,
   status: Exclude<IntegrityMarkerStatus, "pending">,
-  cursorDigests: ReadonlySet<string>,
+  previousIntegrityCommitId: string | null,
+  checkpointWindow: IntegrityCheckpointWindow | null,
+  cursors: readonly IntegrityCursorBinding[],
 ) {
-  const path = integrityCommitPath(input, integrityCommitId);
+  const path = integrityCommitPath(chainId, integrityCommitId);
   for (let attempt = 0; attempt < 4; attempt += 1) {
     const record = await store.read(path);
     if (!record) {
@@ -626,13 +777,18 @@ async function transitionIntegrityMarker(
     }
     const current = parseIntegrityMarker(
       record.value,
-      input,
+      chainId,
+      checkpointGroupId,
       integrityCommitId,
     );
+    const expected = new Map(cursors.map((candidate) => [candidate.cursorKey, candidate]));
     if (
-      current.cursorDigests.size !== cursorDigests.size ||
-      [...cursorDigests].some(
-        (candidate) => !current.cursorDigests.has(candidate),
+      current.previousIntegrityCommitId !== previousIntegrityCommitId ||
+      canonicalJson(current.checkpointWindow) !== canonicalJson(checkpointWindow) ||
+      current.cursors.size !== expected.size ||
+      [...expected].some(
+        ([pathKey, binding]) =>
+          canonicalJson(current.cursors.get(pathKey)) !== canonicalJson(binding),
       )
     ) {
       fail("Persistent RPC integrity commit cursor set changed");
@@ -647,10 +803,13 @@ async function transitionIntegrityMarker(
       fail("Persistent RPC integrity commit cannot be promoted");
     }
     const marker = integrityMarker(
-      input,
+      chainId,
+      checkpointGroupId,
       integrityCommitId,
       status,
-      cursorDigests,
+      previousIntegrityCommitId,
+      checkpointWindow,
+      cursors,
     );
     assertByteLimit(
       marker,
@@ -748,16 +907,90 @@ async function registerScopedBlockProofs(
   return true;
 }
 
+export function bindPersistentRpcIntegrityCheckpointWindow(
+  input: Readonly<{
+    fromBlock: bigint;
+    toBlock: bigint;
+    boundaryBlockHash: string;
+  }>,
+) {
+  const scope = integrityScopes.getStore();
+  if (!scope || scope.phase !== "open") {
+    fail("Persistent RPC checkpoint window requires an open integrity scope");
+  }
+  if (input.fromBlock > input.toBlock) {
+    fail("Persistent RPC checkpoint window is inverted");
+  }
+  const checkpointWindow: IntegrityCheckpointWindow = {
+    fromBlock: input.fromBlock.toString(),
+    toBlock: input.toBlock.toString(),
+    boundaryBlockHash: requireBytes32(
+      input.boundaryBlockHash,
+      "checkpoint boundary block hash",
+    ),
+  };
+  if (
+    scope.checkpointWindow &&
+    canonicalJson(scope.checkpointWindow) !== canonicalJson(checkpointWindow)
+  ) {
+    fail("Persistent RPC integrity scope has conflicting checkpoint windows");
+  }
+  scope.checkpointWindow = checkpointWindow;
+}
+
 export async function withPersistentRpcIntegrityScope<T>(
   operation: () => Promise<T>,
+  input: Readonly<{
+    checkpointGroup?: string;
+    expectedCursorBindings?: number;
+    expectedProviderCount?: number;
+    expectedStreamsPerProvider?: number;
+    requireCheckpointWindow?: boolean;
+    requiredInitialFromBlock?: bigint;
+    requireContiguousCheckpointWindow?: boolean;
+  }> = {},
 ) {
   if (integrityScopes.getStore()) return operation();
+  for (const value of [
+    input.expectedCursorBindings,
+    input.expectedProviderCount,
+    input.expectedStreamsPerProvider,
+  ]) {
+    if (
+      value !== undefined &&
+      (!Number.isSafeInteger(value) || value < 1 || value > 32)
+    ) {
+      fail("Persistent RPC integrity scope expectation is invalid");
+    }
+  }
+  if (
+    input.expectedCursorBindings !== undefined &&
+    input.expectedProviderCount !== undefined &&
+    input.expectedStreamsPerProvider !== undefined &&
+    input.expectedProviderCount * input.expectedStreamsPerProvider !==
+      input.expectedCursorBindings
+  ) {
+    fail("Persistent RPC integrity scope expectations disagree");
+  }
   const scope: IntegrityScope = {
     id: nextIntegrityScopeId,
     commitId: randomUUID(),
     phase: "open",
     bindings: new Map(),
     prechecks: new Map(),
+    expectedCursorBindings: input.expectedCursorBindings,
+    expectedProviderCount: input.expectedProviderCount,
+    expectedStreamsPerProvider: input.expectedStreamsPerProvider,
+    requireCheckpointWindow: input.requireCheckpointWindow === true,
+    ...(input.requiredInitialFromBlock !== undefined
+      ? { requiredInitialFromBlock: input.requiredInitialFromBlock.toString() }
+      : {}),
+    requireContiguousCheckpointWindow:
+      input.requireContiguousCheckpointWindow === true,
+    checkpointGroupId: digest({
+      checkpointGroup: input.checkpointGroup ?? "isolated",
+    }),
+    cursorDrafts: new Map(),
     persistenceBindings: [],
   };
   nextIntegrityScopeId += 1;
@@ -791,40 +1024,173 @@ export async function withPersistentRpcIntegrityScope<T>(
           binding.options,
         );
       }
-      try {
-        for (const { input, store, cursorDigests } of scope.persistenceBindings) {
-          const path = integrityCommitPath(input, scope.commitId);
-          const marker = integrityMarker(
-            input,
-            scope.commitId,
-            "pending",
-            cursorDigests,
+      const persistence = scope.persistenceBindings[0];
+      if (!persistence) return result;
+      const cursorBindings = scope.persistenceBindings.flatMap(
+        (binding) => [...binding.cursors.values()],
+      );
+      if (
+        scope.expectedCursorBindings !== undefined &&
+        cursorBindings.length !== scope.expectedCursorBindings
+      ) {
+        fail("Persistent RPC integrity scope has incomplete cursor coverage");
+      }
+      const providerStreams = new Map<string, Set<string>>();
+      for (const binding of cursorBindings) {
+        const streams = providerStreams.get(binding.providerId) ?? new Set();
+        streams.add(binding.streamIdentity);
+        providerStreams.set(binding.providerId, streams);
+      }
+      if (
+        scope.expectedProviderCount !== undefined &&
+        providerStreams.size !== scope.expectedProviderCount
+      ) {
+        fail("Persistent RPC integrity scope has incomplete provider coverage");
+      }
+      if (
+        scope.expectedStreamsPerProvider !== undefined &&
+        [...providerStreams.values()].some(
+          (streams) => streams.size !== scope.expectedStreamsPerProvider,
+        )
+      ) {
+        fail("Persistent RPC integrity scope has incomplete stream coverage");
+      }
+      const canonicalStreams = [...providerStreams.values()][0];
+      if (
+        canonicalStreams &&
+        [...providerStreams.values()].some(
+          (streams) =>
+            streams.size !== canonicalStreams.size ||
+            [...canonicalStreams].some((stream) => !streams.has(stream)),
+        )
+      ) {
+        fail("Persistent RPC providers do not cover the same event streams");
+      }
+      if (scope.requireCheckpointWindow && !scope.checkpointWindow) {
+        fail("Persistent RPC integrity scope has no checkpoint window");
+      }
+      if (scope.checkpointWindow) {
+        const previousWindow = scope.checkpoint?.checkpointWindow ?? null;
+        if (
+          previousWindow === null &&
+          scope.requiredInitialFromBlock !== undefined &&
+          scope.checkpointWindow.fromBlock !== scope.requiredInitialFromBlock
+        ) {
+          fail("Persistent RPC checkpoint baseline does not start at its release boundary");
+        }
+        if (
+          previousWindow !== null &&
+          scope.requireContiguousCheckpointWindow &&
+          BigInt(scope.checkpointWindow.fromBlock) !==
+            BigInt(previousWindow.toBlock) + 1n
+        ) {
+          fail("Persistent RPC checkpoint window is not contiguous with its committed baseline");
+        }
+      }
+      if (scope.checkpointWindow) {
+        for (const binding of cursorBindings) {
+          const requestInput = scope.persistenceBindings.find(
+            (candidate) => candidate.input.providerId === binding.providerId,
+          )?.input;
+          const cursorRecord = await persistence.store.read(binding.cursorPath);
+          if (!requestInput || !cursorRecord) {
+            fail("Persistent RPC checkpoint cursor is missing");
+          }
+          const cursor = parseCursor(
+            cursorRecord.value,
+            requestInput,
+            binding.streamId,
           );
-          assertByteLimit(
-            marker,
-            PERSISTENT_RPC_CACHE_LIMITS.maxCursorBytes,
-            "integrity commit",
-          );
-          const created = await store.create(path, marker);
-          if (created !== "created") {
-            const record = await store.read(path);
-            if (
-              !record ||
-              parseIntegrityMarker(record.value, input, scope.commitId).status !==
-                "pending"
-            ) {
-              fail("Persistent RPC integrity commit already exists");
-            }
+          if (
+            BigInt(cursor.cursorBlock) !==
+              BigInt(scope.checkpointWindow.toBlock) ||
+            cursor.cursorBlockHash.toLowerCase() !==
+              scope.checkpointWindow.boundaryBlockHash.toLowerCase()
+          ) {
+            fail(
+              `Persistent RPC checkpoint cursors do not share its boundary: expected ${scope.checkpointWindow.toBlock}:${scope.checkpointWindow.boundaryBlockHash}, received ${cursor.cursorBlock}:${cursor.cursorBlockHash}`,
+            );
           }
         }
-        for (const { input, store, cursorDigests } of scope.persistenceBindings) {
-          await transitionIntegrityMarker(
-            input,
-            store,
-            scope.commitId,
-            "committed",
-            cursorDigests,
-          );
+      }
+      const path = integrityCommitPath(
+        persistence.input.chainId,
+        scope.commitId,
+      );
+      try {
+        const marker = integrityMarker(
+          persistence.input.chainId,
+          scope.checkpointGroupId,
+          scope.commitId,
+          "pending",
+          scope.checkpoint?.integrityCommitId ?? null,
+          scope.checkpointWindow ?? null,
+          cursorBindings,
+        );
+        assertByteLimit(
+          marker,
+          PERSISTENT_RPC_CACHE_LIMITS.maxCursorBytes,
+          "integrity commit",
+        );
+        const created = await persistence.store.create(path, marker);
+        if (created !== "created") {
+          const record = await persistence.store.read(path);
+          const existing = record
+            ? parseIntegrityMarker(
+                record.value,
+                persistence.input.chainId,
+                scope.checkpointGroupId,
+                scope.commitId,
+              )
+            : null;
+          if (
+            !existing ||
+            existing.status !== "pending" ||
+            existing.previousIntegrityCommitId !==
+              (scope.checkpoint?.integrityCommitId ?? null) ||
+            canonicalJson(existing.checkpointWindow) !==
+              canonicalJson(scope.checkpointWindow ?? null) ||
+            existing.cursors.size !== cursorBindings.length ||
+            cursorBindings.some(
+              (binding) =>
+                canonicalJson(existing.cursors.get(binding.cursorKey)) !==
+                canonicalJson(binding),
+            )
+          ) {
+            fail("Persistent RPC integrity commit already exists");
+          }
+        }
+        const checkpoint = scope.checkpoint;
+        if (
+          !checkpoint ||
+          checkpoint.store !== persistence.store ||
+          checkpoint.chainId !== persistence.input.chainId
+        ) {
+          fail("Persistent RPC integrity scope has no stable checkpoint base");
+        }
+        const nextCheckpoint = envelope({
+          chainId: checkpoint.chainId,
+          checkpointGroupId: scope.checkpointGroupId,
+          integrityCommitId: scope.commitId,
+          previousIntegrityCommitId: checkpoint.integrityCommitId,
+        } satisfies IntegrityCheckpointHeadPayload);
+        assertByteLimit(
+          nextCheckpoint,
+          PERSISTENT_RPC_CACHE_LIMITS.maxCursorBytes,
+          "integrity checkpoint",
+        );
+        const published = checkpoint.etag === null
+          ? await checkpoint.store.create(checkpoint.path, nextCheckpoint)
+          : await checkpoint.store.replace(
+              checkpoint.path,
+              nextCheckpoint,
+              checkpoint.etag,
+            );
+        if (
+          (checkpoint.etag === null && published !== "created") ||
+          (checkpoint.etag !== null && published !== "replaced")
+        ) {
+          fail("Persistent RPC integrity checkpoint publish conflicted");
         }
         for (const [key, binding] of finalBindings) {
           if (!commitProofKeys.has(key)) continue;
@@ -834,16 +1200,27 @@ export async function withPersistentRpcIntegrityScope<T>(
             binding.options,
           );
         }
+        await transitionIntegrityMarker(
+          persistence.input.chainId,
+          scope.checkpointGroupId,
+          persistence.store,
+          scope.commitId,
+          "committed",
+          scope.checkpoint?.integrityCommitId ?? null,
+          scope.checkpointWindow ?? null,
+          cursorBindings,
+        );
       } catch (error) {
-        for (const { input, store, cursorDigests } of scope.persistenceBindings) {
-          await transitionIntegrityMarker(
-            input,
-            store,
-            scope.commitId,
-            "aborted",
-            cursorDigests,
-          );
-        }
+        await transitionIntegrityMarker(
+          persistence.input.chainId,
+          scope.checkpointGroupId,
+          persistence.store,
+          scope.commitId,
+          "aborted",
+          scope.checkpoint?.integrityCommitId ?? null,
+          scope.checkpointWindow ?? null,
+          cursorBindings,
+        );
         throw error;
       }
       return result;
@@ -983,39 +1360,216 @@ function logsInRequestedRange(
   });
 }
 
+function recordScopedCursorPersistence(
+  store: PersistentRpcCacheStore,
+  input: PersistentRequestInput,
+  binding: IntegrityCursorBinding,
+) {
+  const scope = integrityScopes.getStore();
+  if (!scope) {
+    fail("Persistent RPC cursor persistence requires an integrity scope");
+  }
+  if (scope.phase !== "open") {
+    fail("Persistent RPC integrity scope is already sealed");
+  }
+  const existing = scope.persistenceBindings.find(
+    (candidate) =>
+      candidate.store === store &&
+      candidate.input === input,
+  );
+  if (existing) {
+    existing.cursors.set(binding.cursorKey, binding);
+    return;
+  }
+  if (
+    scope.persistenceBindings.some(
+      (candidate) =>
+        candidate.input.chainId !== input.chainId ||
+        candidate.store !== store,
+    )
+  ) {
+    fail("Persistent RPC integrity scope cannot span chains or stores");
+  }
+  scope.persistenceBindings.push({
+    input,
+    store,
+    cursors: new Map([[binding.cursorKey, binding]]),
+  });
+}
+
 async function loadCursor(
   store: PersistentRpcCacheStore,
   input: PersistentRequestInput,
   id: string,
-  acceptedIntegrityCommitId?: string,
+  filter: LogFilter,
 ) {
-  const path = cursorPath(input, id);
-  const record = await store.read(path);
-  if (!record) return { path, etag: null, cursor: null };
-  const cursor = parseCursor(record.value, input, id);
+  const scope = integrityScopes.getStore();
+  const key = cursorKey(input, id);
   if (
-    cursor.integrityCommitId &&
-    cursor.integrityCommitId !== acceptedIntegrityCommitId
+    scope?.checkpoint &&
+    (scope.checkpoint.store !== store ||
+      scope.checkpoint.chainId !== input.chainId)
   ) {
-    const commit = await store.read(
-      integrityCommitPath(input, cursor.integrityCommitId),
-    );
-    if (!commit) {
-      return { path, etag: record.etag, cursor: null };
+    fail("Persistent RPC integrity scope cannot span chains or stores");
+  }
+  const draft = scope?.cursorDrafts.get(key);
+  if (draft) {
+    const cursorRecord = await store.read(draft.path);
+    if (!cursorRecord || digest(cursorRecord.value) !== draft.contentHash) {
+      fail("Persistent RPC draft cursor binding is invalid");
     }
-    const marker = parseIntegrityMarker(
-      commit.value,
-      input,
-      cursor.integrityCommitId,
+    return {
+      cursor: parseCursor(cursorRecord.value, input, id),
+      reference: draft,
+    };
+  }
+
+  const path = checkpointHeadPath(
+    input.chainId,
+    scope?.checkpointGroupId ?? digest({ cursorKey: key }),
+  );
+  const record = await store.read(path);
+  const checkpointGroupId = scope?.checkpointGroupId ?? digest({ cursorKey: key });
+  const head = record
+    ? parseCheckpointHead(record.value, input.chainId, checkpointGroupId)
+    : null;
+  if (!head) {
+    if (scope) {
+      if (scope.checkpoint) {
+        if (
+          scope.checkpoint.store !== store ||
+          scope.checkpoint.chainId !== input.chainId ||
+          scope.checkpoint.etag !== null ||
+          scope.checkpoint.pointedIntegrityCommitId !== null ||
+          scope.checkpoint.integrityCommitId !== null
+        ) {
+          fail("Persistent RPC integrity scope checkpoint changed during its read");
+        }
+      } else {
+        scope.checkpoint = {
+          store,
+          chainId: input.chainId,
+          path,
+          etag: null,
+          pointedIntegrityCommitId: null,
+          integrityCommitId: null,
+          checkpointWindow: null,
+        };
+      }
+    }
+    return { cursor: null };
+  }
+  const pointedCommit = await store.read(
+    integrityCommitPath(input.chainId, head.integrityCommitId),
+  );
+  if (!pointedCommit) fail("Persistent RPC integrity checkpoint marker is missing");
+  const pointedMarker = parseIntegrityMarker(
+    pointedCommit.value,
+    input.chainId,
+    checkpointGroupId,
+    head.integrityCommitId,
+  );
+  if (pointedMarker.previousIntegrityCommitId !== head.previousIntegrityCommitId) {
+    fail("Persistent RPC checkpoint lineage is invalid");
+  }
+  let acceptedIntegrityCommitId: string | null = head.integrityCommitId;
+  let marker = pointedMarker;
+  if (pointedMarker.status !== "committed") {
+    acceptedIntegrityCommitId = head.previousIntegrityCommitId;
+    if (acceptedIntegrityCommitId === null) {
+      if (scope) {
+        const nextCheckpoint = {
+          store,
+          chainId: input.chainId,
+          path,
+          etag: record?.etag ?? null,
+          pointedIntegrityCommitId: head.integrityCommitId,
+          integrityCommitId: null,
+          checkpointWindow: null,
+        };
+        if (
+          scope.checkpoint &&
+          (scope.checkpoint.store !== nextCheckpoint.store ||
+            scope.checkpoint.chainId !== nextCheckpoint.chainId ||
+            scope.checkpoint.path !== nextCheckpoint.path ||
+            scope.checkpoint.etag !== nextCheckpoint.etag ||
+            scope.checkpoint.pointedIntegrityCommitId !==
+              nextCheckpoint.pointedIntegrityCommitId ||
+            scope.checkpoint.integrityCommitId !== null)
+        ) {
+          fail("Persistent RPC integrity scope checkpoint changed during its read");
+        }
+        scope.checkpoint = nextCheckpoint;
+      }
+      return { cursor: null };
+    }
+    const previousCommit = await store.read(
+      integrityCommitPath(input.chainId, acceptedIntegrityCommitId),
     );
-    if (
-      marker.status !== "committed" ||
-      !marker.cursorDigests.has(digest(record.value))
-    ) {
-      return { path, etag: record.etag, cursor: null };
+    if (!previousCommit) {
+      fail("Persistent RPC previous checkpoint marker is missing");
+    }
+    marker = parseIntegrityMarker(
+      previousCommit.value,
+      input.chainId,
+      checkpointGroupId,
+      acceptedIntegrityCommitId,
+    );
+    if (marker.status !== "committed") {
+      fail("Persistent RPC previous checkpoint is not committed");
     }
   }
-  return { path, etag: record.etag, cursor };
+  if (scope) {
+    if (scope.checkpoint) {
+      if (
+        scope.checkpoint.store !== store ||
+        scope.checkpoint.chainId !== input.chainId ||
+        scope.checkpoint.etag !== (record?.etag ?? null) ||
+        scope.checkpoint.pointedIntegrityCommitId !== head.integrityCommitId ||
+        scope.checkpoint.integrityCommitId !== acceptedIntegrityCommitId
+      ) {
+        fail("Persistent RPC integrity scope checkpoint changed during its read");
+      }
+    } else {
+      scope.checkpoint = {
+        store,
+        chainId: input.chainId,
+        path,
+        etag: record?.etag ?? null,
+        pointedIntegrityCommitId: head.integrityCommitId,
+        integrityCommitId: acceptedIntegrityCommitId,
+        checkpointWindow: marker.checkpointWindow,
+      };
+    }
+  }
+  const binding = marker.cursors.get(key);
+  if (
+    marker.status !== "committed" ||
+    !binding ||
+    binding.providerId !== input.providerId ||
+    binding.streamId !== id ||
+    binding.streamIdentity !== streamIdentity(input, filter)
+  ) {
+    fail("Persistent RPC integrity checkpoint cursor binding is missing");
+  }
+  const cursorRecord = await store.read(binding.cursorPath);
+  if (
+    !cursorRecord ||
+    digest(cursorRecord.value) !== binding.cursorContentHash
+  ) {
+    fail("Persistent RPC integrity checkpoint cursor is invalid");
+  }
+  const cursor = parseCursor(cursorRecord.value, input, id);
+  if (cursor.integrityCommitId !== acceptedIntegrityCommitId) {
+    fail("Persistent RPC cursor is bound to the wrong integrity checkpoint");
+  }
+  return {
+    cursor,
+    reference: {
+      path: binding.cursorPath,
+      contentHash: binding.cursorContentHash,
+    },
+  };
 }
 
 async function assertCanonicalCursor(
@@ -1215,6 +1769,7 @@ async function persistSegment(
   logs: readonly unknown[],
 ) {
   const integrityScope = integrityScopes.getStore();
+  const key = cursorKey(input, id);
   const descriptor = await createSegment(
     store,
     input,
@@ -1226,103 +1781,90 @@ async function persistSegment(
     logs,
   );
 
-  const recordScopedPersistence = (cursorDigest: string) => {
-    if (!integrityScope) return;
-    if (integrityScope.phase !== "open") {
-      fail("Persistent RPC integrity scope is already sealed");
-    }
-    const exists = integrityScope.persistenceBindings.some(
-      (binding) =>
-        binding.store === store &&
-        binding.input === input,
+  const current = integrityScope?.cursorDrafts.has(key)
+    ? await loadCursor(store, input, id, filter)
+    : loaded;
+  if (current.cursor) {
+    const exact = current.cursor.segments.find(
+      (candidate) =>
+        BigInt(candidate.fromBlock) === fromBlock &&
+        BigInt(candidate.toBlock) === toBlock,
     );
-    if (exists) {
-      integrityScope.persistenceBindings[0]?.cursorDigests.add(cursorDigest);
-      return;
-    }
-    if (integrityScope.persistenceBindings.length !== 0) {
-      fail("Persistent RPC integrity scope cannot span request/store domains");
-    }
-    integrityScope.persistenceBindings.push({
-      input,
-      store,
-      cursorDigests: new Set([cursorDigest]),
-    });
-  };
-
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    const current = attempt === 0
-      ? loaded
-      : await loadCursor(store, input, id, integrityScope?.commitId);
-    if (current.cursor) {
-      const exact = current.cursor.segments.find(
-        (candidate) =>
-          BigInt(candidate.fromBlock) === fromBlock &&
-          BigInt(candidate.toBlock) === toBlock,
-      );
-      if (exact) {
-        if (
-          exact.contentHash !== descriptor.contentHash ||
-          exact.blockHash.toLowerCase() !== descriptor.blockHash.toLowerCase()
-        ) {
-          fail("Persistent RPC log segment range changed content");
-        }
-        return;
-      }
+    if (exact) {
       if (
-        current.cursor.segments.some(
-          (candidate) =>
-            fromBlock <= BigInt(candidate.toBlock) &&
-            toBlock >= BigInt(candidate.fromBlock),
-        )
+        exact.contentHash !== descriptor.contentHash ||
+        exact.blockHash.toLowerCase() !== descriptor.blockHash.toLowerCase()
       ) {
-        fail("Persistent RPC log segment overlaps concurrent coverage");
+        fail("Persistent RPC log segment range changed content");
       }
-    }
-    const segments = await compactSegments(
-      store,
-      input,
-      id,
-      filter,
-      [...(current.cursor?.segments ?? []), descriptor],
-    );
-    const first = segments[0] as LogSegment;
-    const last = segments.at(-1) as LogSegment;
-    const next: LogCursorPayload = {
-      chainId: input.chainId,
-      providerId: input.providerId,
-      streamId: id,
-      startBlock: first.fromBlock,
-      cursorBlock: last.toBlock,
-      cursorBlockHash: last.blockHash,
-      ...(integrityScope
-        ? { integrityCommitId: integrityScope.commitId }
-        : {}),
-      segments,
-    };
-    const nextEnvelope = envelope(next);
-    assertByteLimit(
-      nextEnvelope,
-      PERSISTENT_RPC_CACHE_LIMITS.maxCursorBytes,
-      "cursor",
-    );
-    if (current.etag === null) {
-      if (await store.create(current.path, nextEnvelope) === "created") {
-        recordScopedPersistence(digest(nextEnvelope));
-        return;
-      }
-    } else if (
-      await store.replace(current.path, nextEnvelope, current.etag) ===
-        "replaced"
-    ) {
-      recordScopedPersistence(digest(nextEnvelope));
       return;
+    }
+    if (
+      current.cursor.segments.some(
+        (candidate) =>
+          fromBlock <= BigInt(candidate.toBlock) &&
+          toBlock >= BigInt(candidate.fromBlock),
+      )
+    ) {
+      fail("Persistent RPC log segment overlaps concurrent coverage");
     }
   }
-  fail("Persistent RPC log cursor advance conflicted repeatedly");
+  const segments = await compactSegments(
+    store,
+    input,
+    id,
+    filter,
+    [...(current.cursor?.segments ?? []), descriptor],
+  );
+  const first = segments[0] as LogSegment;
+  const last = segments.at(-1) as LogSegment;
+  const next: LogCursorPayload = {
+    chainId: input.chainId,
+    providerId: input.providerId,
+    streamId: id,
+    startBlock: first.fromBlock,
+    cursorBlock: last.toBlock,
+    cursorBlockHash: last.blockHash,
+    ...(integrityScope
+      ? { integrityCommitId: integrityScope.commitId }
+      : {}),
+    segments,
+  };
+  const nextEnvelope = envelope(next);
+  assertByteLimit(
+    nextEnvelope,
+    PERSISTENT_RPC_CACHE_LIMITS.maxCursorBytes,
+    "cursor",
+  );
+  const cursorContentHash = digest(nextEnvelope);
+  const versionPath = cursorVersionPath(input, id, cursorContentHash);
+  const createdVersion = await store.create(versionPath, nextEnvelope);
+  if (createdVersion === "exists") {
+    const version = await store.read(versionPath);
+    if (!version || digest(version.value) !== cursorContentHash) {
+      fail("Persistent RPC cursor version binding is invalid");
+    }
+    parseCursor(version.value, input, id);
+  }
+  const nextReference: CursorReference = {
+    path: versionPath,
+    contentHash: cursorContentHash,
+  };
+  const binding: IntegrityCursorBinding = {
+    providerId: input.providerId,
+    streamId: id,
+    streamIdentity: streamIdentity(input, filter),
+    cursorKey: key,
+    cursorPath: versionPath,
+    cursorContentHash,
+  };
+  if (!integrityScope) fail("Persistent RPC cursor persistence requires an integrity scope");
+  integrityScope.cursorDrafts.set(key, nextReference);
+  recordScopedCursorPersistence(store, input, binding);
 }
 
 const requestFlights = new Map<string, Promise<JsonRpcResult>>();
+const automaticScopeFlights = new Map<string, Promise<JsonRpcResult>>();
 
 export function createPersistentRpcRequest(
   input: PersistentRequestInput,
@@ -1429,6 +1971,51 @@ export function createPersistentRpcRequest(
       assertScopeLease();
       return result;
     }
+    if (input.store && !integrityScope) {
+      const automaticFlightKey = digest({
+        requestDomainId: requestDomainId(input),
+        providerId: input.providerId,
+        filter,
+      });
+      const existing = automaticScopeFlights.get(automaticFlightKey);
+      if (existing) return existing;
+      const automatic = (async () => {
+        for (let attempt = 0; attempt < 4; attempt += 1) {
+          try {
+            return await withPersistentRpcIntegrityScope(
+              () => wrapped(request, options),
+              {
+                checkpointGroup: `isolated:${cursorKey(
+                  input,
+                  streamId(input, filter),
+                )}`,
+                expectedCursorBindings: 1,
+                expectedProviderCount: 1,
+                expectedStreamsPerProvider: 1,
+              },
+            );
+          } catch (error) {
+            if (
+              attempt === 3 ||
+              !(error instanceof PersistentRpcCacheError) ||
+              error.message !==
+                "Persistent RPC integrity checkpoint publish conflicted"
+            ) {
+              throw error;
+            }
+          }
+        }
+        fail("Persistent RPC automatic checkpoint retry exhausted");
+      })();
+      automaticScopeFlights.set(automaticFlightKey, automatic);
+      try {
+        return await automatic;
+      } finally {
+        if (automaticScopeFlights.get(automaticFlightKey) === automatic) {
+          automaticScopeFlights.delete(automaticFlightKey);
+        }
+      }
+    }
     const fromBlock = BigInt(filter.fromBlock);
     const toBlock = BigInt(filter.toBlock);
     if (!input.store) {
@@ -1497,7 +2084,7 @@ export function createPersistentRpcRequest(
         input.store as PersistentRpcCacheStore,
         input,
         id,
-        integrityScope?.commitId,
+        filter,
       );
       assertScopeLease();
       let logs: unknown[] = [];
@@ -1651,8 +2238,18 @@ function blobToken(environment: NodeJS.ProcessEnv = process.env) {
   );
 }
 
+export function createEnvironmentPersistentRpcCacheStore(
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const token = blobToken(environment);
+  return token ? createVercelBlobPersistentRpcCacheStore(token) : null;
+}
+
 export function persistentRpcCachePathByteLimit(path: string) {
-  if (path.endsWith("/cursor.json")) {
+  if (!path.startsWith(`${CACHE_DIRECTORY}/`)) {
+    fail("Persistent RPC cache path uses a retired namespace");
+  }
+  if (path.includes("/checkpoints/") || path.includes("/cursors/")) {
     return PERSISTENT_RPC_CACHE_LIMITS.maxCursorBytes;
   }
   if (path.includes("/segments/")) {
@@ -1665,6 +2262,10 @@ export function persistentRpcCachePathByteLimit(path: string) {
     return PERSISTENT_RPC_CACHE_LIMITS.maxCursorBytes;
   }
   fail("Persistent RPC cache path has no byte limit");
+}
+
+export function persistentRpcProviderId(rpcUrl: string) {
+  return digest({ rpcUrl });
 }
 
 function contentLength(headers: Readonly<{ get(name: string): string | null }>) {
@@ -1858,13 +2459,21 @@ export function createVercelBlobPersistentRpcCacheStore(
           useCache: false,
         });
         if (!result || result.statusCode !== 200 || !result.stream) return null;
+        let metadata;
         try {
           const current = await head(path, { token });
-          const metadata = bindPrivateBlobReadMetadata({
+          metadata = bindPrivateBlobReadMetadata({
             responseEtag: result.blob.etag,
             headEtag: current.etag,
             headSize: current.size,
           });
+        } catch (error) {
+          await result.stream.cancel(
+            "Persistent RPC Blob metadata could not be bound",
+          );
+          throw error;
+        }
+        try {
           return {
             etag: metadata.etag,
             value: await readBoundedBlobJson({
@@ -1886,7 +2495,9 @@ export function createVercelBlobPersistentRpcCacheStore(
           }
           if (
             !(error instanceof PersistentRpcCacheError) ||
-            attempt === PRIVATE_BLOB_READ_ATTEMPTS
+            attempt === PRIVATE_BLOB_READ_ATTEMPTS ||
+            error.message !==
+              "Persistent RPC Blob stream length does not match its declaration"
           ) {
             throw error;
           }
@@ -1981,7 +2592,7 @@ export function persistentRpcHttp(
   }>,
 ): Transport {
   const underlying = http(rpcUrl, input.http);
-  const providerId = digest({ rpcUrl });
+  const providerId = persistentRpcProviderId(rpcUrl);
   return (transportInput) => {
     const transport = underlying(transportInput);
     const token = blobToken();

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -38,6 +38,7 @@ import {
 } from "./metadata";
 import {
   persistentRpcHttp,
+  persistentRpcProviderId,
   withPersistentRpcIntegrityScope,
 } from "./persistent-rpc-cache.server";
 import { enrichExploreModelWithUsd } from "./usd";
@@ -717,12 +718,13 @@ async function readReadyModel(
   config: ReadyOnchainDeployment,
 ): Promise<ExploreReadModel> {
   const client = createOnchainClient(config);
-  const clients = [
-    client,
-    ...(config.rpcUrlSecondary
-      ? [createOnchainClient(config, config.rpcUrlSecondary)]
-      : []),
+  const providerEndpoints = [
+    config.rpcUrl,
+    ...(config.rpcUrlSecondary ? [config.rpcUrlSecondary] : []),
   ];
+  const clients = providerEndpoints.map((endpoint, index) =>
+    index === 0 ? client : createOnchainClient(config, endpoint)
+  );
   const chainStates = await withReadStage("chain-heads", () =>
     mapInBatches(
       clients,
@@ -820,10 +822,21 @@ async function readReadyModel(
   );
 
   const indexedEventSets = await allSettledOrThrow(
-    clients.map((candidate) =>
+    clients.map((candidate, providerIndex) =>
       withReadStage("classic-events", () =>
-        withPersistentRpcIntegrityScope(() =>
-          indexVerifiedEvents(candidate, config, toBlock),
+        withPersistentRpcIntegrityScope(
+          () => indexVerifiedEvents(candidate, config, toBlock),
+          {
+            checkpointGroup: [
+              "classic-events",
+              config.chainId,
+              config.deploymentBlock.toString(),
+              config.launcher.toLowerCase(),
+              config.feeHook.toLowerCase(),
+              persistentRpcProviderId(providerEndpoints[providerIndex]),
+            ].join(":"),
+            expectedCursorBindings: 2,
+          },
         ),
       ),
     ),

--- a/lib/onchain/stock-paired-read-model.ts
+++ b/lib/onchain/stock-paired-read-model.ts
@@ -32,6 +32,7 @@ import { stateViewReadAbi, uerc20ReadAbi } from "./abis";
 import { buildTokenLinks, sanitizeImageUrl } from "./metadata";
 import {
   persistentRpcHttp,
+  persistentRpcProviderId,
   withPersistentRpcIntegrityScope,
 } from "./persistent-rpc-cache.server";
 import {
@@ -866,12 +867,13 @@ export async function readStockPairedExploreModel(
   );
   if (activeReleases.length === 0) return [];
 
-  const clients = [
-    clientFor(config.rpcUrl, config, activeReleases),
-    ...(config.rpcUrlSecondary
-      ? [clientFor(config.rpcUrlSecondary, config, activeReleases)]
-      : []),
+  const providerEndpoints = [
+    config.rpcUrl,
+    ...(config.rpcUrlSecondary ? [config.rpcUrlSecondary] : []),
   ];
+  const clients = providerEndpoints.map((endpoint) =>
+    clientFor(endpoint, config, activeReleases)
+  );
   await mapInBatches(
     clients,
     RPC_PROVENANCE_BATCH_SIZE,
@@ -930,15 +932,26 @@ export async function readStockPairedExploreModel(
     1,
     async (release) => {
       const eventSets = await allSettledOrThrow(
-        clients.map((candidate) =>
-          withPersistentRpcIntegrityScope(() =>
-            readStockPairedEvents(
-              candidate,
-              config,
-              release,
-              toBlock,
-              options.fromBlock ?? BigInt(release.startBlock),
-            ),
+        clients.map((candidate, providerIndex) =>
+          withPersistentRpcIntegrityScope(
+            () =>
+              readStockPairedEvents(
+                candidate,
+                config,
+                release,
+                toBlock,
+                options.fromBlock ?? BigInt(release.startBlock),
+              ),
+            {
+              checkpointGroup: [
+                "stock-paired-events",
+                config.chainId,
+                release.internalContractRelease,
+                release.startBlock,
+                persistentRpcProviderId(providerEndpoints[providerIndex]),
+              ].join(":"),
+              expectedCursorBindings: 3,
+            },
           )),
       );
       const fingerprint = eventFingerprint(eventSets[0]);

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -23,18 +23,18 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
         Object.freeze({
           path: "lib/onchain/historical-read-rpc.server.ts",
-          sha256: "725bde4016b635c77ed996e8b6d574b589f3cccd5778a7ed63ea9afbde4e77b7",
+          sha256: "0a68b8388003cea8c59c11790f7255df00c94ab773339850ce41c0e1b4c3aa0d",
         }),
         Object.freeze({
           path: "lib/onchain/persistent-rpc-cache.server.ts",
-          sha256: "867df30838d51522f677751b0238afe10c1db2949c53c89549ca0f3c46ede02f",
+          sha256: "4556161d79d49914f064a4df5ad2eb7f9777dfe1b3d188cf36a1e5b434b38f9b",
         }),
       ]),
       releaseRuntimes: Object.freeze([
         Object.freeze({
           release: "classic-v3",
           path: "lib/onchain/classic-v3-read-model.ts",
-          sha256: "28fbbbacb927f966639d16b8c3adcde33ba9eaf309eef8ef90a130295b75ce82",
+          sha256: "4921b6869284d405976bc00f9426f1dbf05c5cf02f0354746a57c6ee8631cddd",
           eventFiltersPerRange: 2,
         }),
         Object.freeze({
@@ -1557,22 +1557,22 @@ export function evaluateReadModelOperationsSourceContracts(
         "historicalReadOnchainDeployment(deployment)",
       ) &&
       historicalRpcSource?.includes(
-        '"https://rpc.mevblocker.io/",',
+        "productionMainnetRpcPair(environment)",
       ) &&
       historicalRpcSource?.includes(
-        '"https://mainnet.gateway.tenderly.co/",',
+        "primary: binding.primary.url",
       ) &&
       historicalRpcSource?.includes(
-        "primary: ARCHIVE_WITNESSES[0]",
+        "secondary: binding.secondary.url",
       ) &&
       historicalRpcSource?.includes(
-        "secondary: ARCHIVE_WITNESSES[1]",
+        'primary?.vendorGroup !== "drpc"',
       ) &&
       historicalRpcSource?.includes(
-        'primary?.vendorGroup !== "mevblocker"',
+        'secondary?.vendorGroup !== "quicknode"',
       ) &&
       historicalRpcSource?.includes(
-        'secondary?.vendorGroup !== "tenderly"',
+        "primary.endpointCommitment !== binding.primary.endpointCommitment",
       ) &&
       persistentCacheSource?.includes(
         'const CACHE_SCHEMA = "programmable-rpc-log-cursor-v4";',
@@ -1596,6 +1596,7 @@ export function evaluateReadModelOperationsSourceContracts(
       persistentCacheSource?.includes("requireCheckpointWindow") &&
       persistentCacheSource?.includes("requiredInitialFromBlock") &&
       persistentCacheSource?.includes("requireContiguousCheckpointWindow") &&
+      persistentCacheSource?.includes("allowCheckpointWindowExtension") &&
       persistentCacheSource?.includes(
         "bindPersistentRpcIntegrityCheckpointWindow",
       ) &&
@@ -1666,6 +1667,9 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       classicV3RefreshSource?.includes(
         "requireContiguousCheckpointWindow: true",
+      ) &&
+      classicV3RefreshSource?.includes(
+        "allowCheckpointWindowExtension: true",
       ) &&
       classicV3RefreshSource?.includes(
         "const MAXIMUM_CHECKPOINT_BLOCK_RANGE = 1_000n",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -14,7 +14,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
-        sha256: "73c99640515732c975600b5e9a8cd4ffb7fafbc04536a563126c76ea60b27fe6",
+        sha256: "f787ca685a1168a119137dc42894b86a0843ec339e9e380be2b32070d256c1a8",
       }),
       dependencies: Object.freeze([
         Object.freeze({
@@ -25,18 +25,22 @@ const APPROVED_OPERATIONS = Object.freeze({
           path: "lib/onchain/historical-read-rpc.server.ts",
           sha256: "725bde4016b635c77ed996e8b6d574b589f3cccd5778a7ed63ea9afbde4e77b7",
         }),
+        Object.freeze({
+          path: "lib/onchain/persistent-rpc-cache.server.ts",
+          sha256: "867df30838d51522f677751b0238afe10c1db2949c53c89549ca0f3c46ede02f",
+        }),
       ]),
       releaseRuntimes: Object.freeze([
         Object.freeze({
           release: "classic-v3",
           path: "lib/onchain/classic-v3-read-model.ts",
-          sha256: "c97c6f5875bf089b8545bfc55bd20f26c1520bdbe0c640e873f70ca08b4cc4a3",
+          sha256: "28fbbbacb927f966639d16b8c3adcde33ba9eaf309eef8ef90a130295b75ce82",
           eventFiltersPerRange: 2,
         }),
         Object.freeze({
           release: "stock-paired-v1-v3",
           path: "lib/onchain/stock-paired-read-model.ts",
-          sha256: "9c9badce8d6dfb000a29fd4abcc013701f5a81736ce9ad9fd1e72816b3a75b2f",
+          sha256: "749399f6b360fdcbebf3d2632d82409aba00dcbb3367538c89941a81532cce67",
           eventFiltersPerRange: 3,
         }),
       ]),
@@ -1498,6 +1502,7 @@ export function evaluateReadModelOperationsSourceContracts(
   const refreshRuntimeSource = source(boundedRefresh?.runtime?.path);
   const parallelReadsSource = source(boundedRefresh?.dependencies?.[0]?.path);
   const historicalRpcSource = source(boundedRefresh?.dependencies?.[1]?.path);
+  const persistentCacheSource = source(boundedRefresh?.dependencies?.[2]?.path);
   const releaseRuntimes = boundedRefresh?.releaseRuntimes;
   const classicV3RefreshSource = source(releaseRuntimes?.[0]?.path);
   const stockPairedRefreshSource = source(releaseRuntimes?.[1]?.path);
@@ -1524,7 +1529,7 @@ export function evaluateReadModelOperationsSourceContracts(
         boundedRefresh?.runtime,
         expectedSha256Overrides,
       ) &&
-      boundedRefresh?.dependencies?.length === 2 &&
+      boundedRefresh?.dependencies?.length === 3 &&
       sourceBindingMatches(
         source,
         boundedRefresh.dependencies[0],
@@ -1533,6 +1538,11 @@ export function evaluateReadModelOperationsSourceContracts(
       sourceBindingMatches(
         source,
         boundedRefresh.dependencies[1],
+        expectedSha256Overrides,
+      ) &&
+      sourceBindingMatches(
+        source,
+        boundedRefresh.dependencies[2],
         expectedSha256Overrides,
       ) &&
       refreshRuntimeSource?.includes(
@@ -1564,6 +1574,38 @@ export function evaluateReadModelOperationsSourceContracts(
       historicalRpcSource?.includes(
         'secondary?.vendorGroup !== "tenderly"',
       ) &&
+      persistentCacheSource?.includes(
+        'const CACHE_SCHEMA = "programmable-rpc-log-cursor-v4";',
+      ) &&
+      !persistentCacheSource?.includes(
+        'const CACHE_SCHEMA = "programmable-rpc-log-cursor-v3";',
+      ) &&
+      persistentCacheSource?.includes(
+        "Persistent RPC cache path uses a retired namespace",
+      ) &&
+      persistentCacheSource?.includes("previousIntegrityCommitId") &&
+      persistentCacheSource?.includes("pointedMarker.status !== \"committed\"") &&
+      persistentCacheSource?.includes(
+        "Persistent RPC providers do not cover the same event streams",
+      ) &&
+      persistentCacheSource?.includes(
+        "Persistent RPC checkpoint cursors do not share its boundary",
+      ) &&
+      persistentCacheSource?.includes("expectedProviderCount") &&
+      persistentCacheSource?.includes("expectedStreamsPerProvider") &&
+      persistentCacheSource?.includes("requireCheckpointWindow") &&
+      persistentCacheSource?.includes("requiredInitialFromBlock") &&
+      persistentCacheSource?.includes("requireContiguousCheckpointWindow") &&
+      persistentCacheSource?.includes(
+        "bindPersistentRpcIntegrityCheckpointWindow",
+      ) &&
+      persistentCacheSource?.indexOf(
+        'scope.commitId,\n          "pending",',
+      ) < persistentCacheSource?.indexOf("const published =") &&
+      persistentCacheSource?.indexOf("const published =") <
+        persistentCacheSource?.indexOf(
+          'scope.commitId,\n          "committed",',
+        ) &&
       Array.isArray(releaseRuntimes) &&
       releaseRuntimes.length === 2 &&
       releaseRuntimes[0]?.release === "classic-v3" &&
@@ -1591,17 +1633,64 @@ export function evaluateReadModelOperationsSourceContracts(
       refreshRuntimeSource?.includes("events: CLASSIC_LAUNCHER_EVENTS") &&
       refreshRuntimeSource?.includes("events: CLASSIC_FEE_HOOK_EVENTS") &&
       refreshRuntimeSource?.includes("assertCanonicalClassicEventSource(") &&
-      refreshRuntimeSource?.includes("clients.map((candidate) =>") &&
+      refreshRuntimeSource?.includes(
+        "clients.map((candidate, providerIndex) =>",
+      ) &&
+      refreshRuntimeSource?.includes(
+        "persistentRpcProviderId(providerEndpoints[providerIndex])",
+      ) &&
+      refreshRuntimeSource?.includes("expectedCursorBindings: 2") &&
       hasAdaptiveCompleteRangeScan(classicV3RefreshSource) &&
       classicV3RefreshSource?.includes(
         "assertCanonicalClassicV3EventSource(",
       ) &&
-      classicV3RefreshSource?.includes("clients.map((client) =>") &&
+      classicV3RefreshSource?.includes("readClassicV3EventsQuorum(") &&
+      classicV3RefreshSource?.includes('"classic-v3-events-v2"') &&
+      classicV3RefreshSource?.includes("clients.length !== 2") &&
+      classicV3RefreshSource?.includes(
+        "createEnvironmentPersistentRpcCacheStore()",
+      ) &&
+      classicV3RefreshSource?.includes(
+        "bindPersistentRpcIntegrityCheckpointWindow({",
+      ) &&
+      classicV3RefreshSource?.includes(
+        "expectedCursorBindings: clients.length * 2",
+      ) &&
+      classicV3RefreshSource?.includes(
+        "expectedProviderCount: clients.length",
+      ) &&
+      classicV3RefreshSource?.includes("expectedStreamsPerProvider: 2") &&
+      classicV3RefreshSource?.includes("requireCheckpointWindow: true") &&
+      classicV3RefreshSource?.includes(
+        "requiredInitialFromBlock: release.startBlock",
+      ) &&
+      classicV3RefreshSource?.includes(
+        "requireContiguousCheckpointWindow: true",
+      ) &&
+      classicV3RefreshSource?.includes(
+        "const MAXIMUM_CHECKPOINT_BLOCK_RANGE = 1_000n",
+      ) &&
+      classicV3RefreshSource?.includes(
+        "config.logBlockRange,\n      MAXIMUM_CHECKPOINT_BLOCK_RANGE",
+      ) &&
+      classicV3RefreshSource?.includes("eventProvenance") &&
+      classicV3RefreshSource?.includes("toEventSelector(launchedEvent)") &&
+      classicV3RefreshSource?.includes("toEventSelector(feeEvent)") &&
+      classicV3RefreshSource?.includes(".map(persistentRpcProviderId).sort()") &&
+      classicV3RefreshSource?.includes(
+        "Independent RPCs disagree on the Classic V3 checkpoint window",
+      ) &&
       hasAdaptiveCompleteRangeScan(stockPairedRefreshSource) &&
       stockPairedRefreshSource?.includes("events: STOCK_LAUNCHER_EVENTS") &&
       stockPairedRefreshSource?.includes("assertCanonicalStockEventSource(") &&
-      stockPairedRefreshSource?.includes("clients.map((candidate) =>"),
-    "all active release scanners use minimal canonical filters, settle complete ranges, adapt exact RPC rejections, compare two provider passes and settle registry slices in parallel before deterministic merging and the platform deadline",
+      stockPairedRefreshSource?.includes(
+        "clients.map((candidate, providerIndex) =>",
+      ) &&
+      stockPairedRefreshSource?.includes(
+        "persistentRpcProviderId(providerEndpoints[providerIndex])",
+      ) &&
+      stockPairedRefreshSource?.includes("expectedCursorBindings: 3"),
+    "all active release scanners use minimal canonical filters, settle complete ranges, adapt exact RPC rejections, compare two provider passes, atomically publish Classic V3 provider-stream checkpoints in a fail-closed v4 namespace and settle registry slices in parallel before deterministic merging and the platform deadline",
   );
   const schedulerWatchdog = operations?.legacyIndexer?.schedulerWatchdog;
   check(

--- a/tests/classic-v3-read-model.test.ts
+++ b/tests/classic-v3-read-model.test.ts
@@ -8,8 +8,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   mergeClassicV3ExploreModel,
   readClassicV3Events,
+  readClassicV3EventsQuorum,
   type ClassicV3Release,
 } from "../lib/onchain/classic-v3-read-model";
+import { PersistentRpcCacheError } from
+  "../lib/onchain/persistent-rpc-cache.server";
 import type {
   ExploreReadModel,
   ReadyOnchainDeployment,
@@ -79,6 +82,18 @@ afterEach(() => {
 });
 
 describe("Classic V3 event scan", () => {
+  it("requires exactly two independent providers for a checkpoint", async () => {
+    await expect(
+      readClassicV3EventsQuorum(
+        [{ getLogs: vi.fn(), getBlock: vi.fn() } as unknown as PublicClient],
+        readyDeployment,
+        release,
+        1_000n,
+        1n,
+      ),
+    ).rejects.toThrow("exactly two independent RPCs");
+  });
+
   it("settles the two scalar canonical contract filters concurrently", async () => {
     const resolvers: Array<(logs: readonly []) => void> = [];
     const getLogs = vi.fn(
@@ -103,6 +118,7 @@ describe("Classic V3 event scan", () => {
     expect(getLogs.mock.calls.every(([input]) => input.strict)).toBe(true);
     for (const resolve of resolvers) resolve([]);
     await expect(pending).resolves.toEqual({
+      eventProvenance: [],
       launches: [],
       volumes: new Map(),
     });
@@ -127,7 +143,32 @@ describe("Classic V3 event scan", () => {
         1_000n,
         1n,
       ),
-    ).resolves.toEqual({ launches: [], volumes: new Map() });
+    ).resolves.toEqual({ eventProvenance: [], launches: [], volumes: new Map() });
+    expect(getLogs).toHaveBeenCalledTimes(6);
+  });
+
+  it("bisects a complete range when its durable segment exceeds the byte cap", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
+      if (firstRequest) {
+        firstRequest = false;
+        throw new PersistentRpcCacheError(
+          "Persistent RPC cache log segment exceeds 4194304 bytes",
+        );
+      }
+      return [];
+    });
+
+    await expect(
+      readClassicV3Events(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_000n,
+        1n,
+      ),
+    ).resolves.toEqual({ eventProvenance: [], launches: [], volumes: new Map() });
     expect(getLogs).toHaveBeenCalledTimes(6);
   });
 
@@ -152,7 +193,7 @@ describe("Classic V3 event scan", () => {
         1_000n,
         1n,
       ),
-    ).resolves.toEqual({ launches: [], volumes: new Map() });
+    ).resolves.toEqual({ eventProvenance: [], launches: [], volumes: new Map() });
     expect(getLogs).toHaveBeenCalledTimes(4);
   });
 
@@ -178,6 +219,95 @@ describe("Classic V3 event scan", () => {
         1n,
       ),
     ).rejects.toThrow(/non-canonical Classic V3 contract/);
+  });
+
+  it("requires both providers to agree on every raw fee-log provenance record", async () => {
+    const feeLog = (transactionHash: string) => ({
+      eventName: "NativeSwapFeesAccrued",
+      address: release.hook,
+      removed: false,
+      blockNumber: 1n,
+      blockHash: `0x${"77".repeat(32)}`,
+      transactionHash,
+      transactionIndex: 0,
+      logIndex: 0,
+      args: {
+        poolId: `0x${"88".repeat(32)}`,
+        grossNativeAmount: 100n,
+        creatorFee: 10n,
+        launcherFee: 1n,
+      },
+    });
+    const client = (transactionHash: string) => ({
+      async getLogs(input: { address: string }) {
+        return input.address === release.hook ? [feeLog(transactionHash)] : [];
+      },
+      async getBlock() {
+        return { number: 1_000n, hash: `0x${"99".repeat(32)}` };
+      },
+    }) as unknown as PublicClient;
+    await expect(
+      readClassicV3EventsQuorum(
+        [
+          client(`0x${"aa".repeat(32)}`),
+          client(`0x${"bb".repeat(32)}`),
+        ],
+        readyDeployment,
+        release,
+        1_000n,
+        1n,
+      ),
+    ).rejects.toThrow(/disagree on the Classic V3 checkpoint window/);
+  });
+
+  it("requires both providers to agree on the checkpoint boundary hash", async () => {
+    const client = (hash: string) => ({
+      async getLogs() {
+        return [];
+      },
+      async getBlock() {
+        return { number: 1_000n, hash };
+      },
+    }) as unknown as PublicClient;
+    await expect(
+      readClassicV3EventsQuorum(
+        [
+          client(`0x${"aa".repeat(32)}`),
+          client(`0x${"bb".repeat(32)}`),
+        ],
+        readyDeployment,
+        release,
+        1_000n,
+        1n,
+      ),
+    ).rejects.toThrow(/disagree on the Classic V3 checkpoint window/);
+  });
+
+  it("publishes at most 1,000 blocks in one provider-group checkpoint", async () => {
+    const boundaryReads: bigint[] = [];
+    const client = {
+      async getLogs() {
+        return [];
+      },
+      async getBlock(input: { blockNumber: bigint }) {
+        boundaryReads.push(input.blockNumber);
+        return {
+          number: input.blockNumber,
+          hash: `0x${input.blockNumber.toString(16).padStart(64, "0")}`,
+        };
+      },
+    } as unknown as PublicClient;
+
+    await expect(
+      readClassicV3EventsQuorum(
+        [client, client],
+        { ...readyDeployment, logBlockRange: 5_000n },
+        release,
+        2_000n,
+        1n,
+      ),
+    ).resolves.toEqual({ eventProvenance: [], launches: [], volumes: new Map() });
+    expect(boundaryReads).toEqual([1_000n, 1_000n, 2_000n, 2_000n]);
   });
 });
 

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -392,7 +392,8 @@ describe("read-model operations source contract", () => {
 
   it.each([
     ["missing confirmed block", (rpc: Record<string, unknown>) => {
-      const { confirmedBlock: _removed, ...remaining } = rpc;
+      const remaining = { ...rpc };
+      delete remaining.confirmedBlock;
       return remaining;
     }],
     ["zero confirmed block hash", (rpc: Record<string, unknown>) => ({
@@ -674,6 +675,60 @@ describe("read-model operations source contract", () => {
       "lib/onchain/classic-v3-read-model.ts",
       "error instanceof LimitExceededRpcError ||",
       "false ||",
+    ],
+    [
+      "Classic V3 shared four-cursor checkpoint",
+      "lib/onchain/classic-v3-read-model.ts",
+      "expectedCursorBindings: clients.length * 2",
+      "expectedCursorBindings: clients.length",
+    ],
+    [
+      "Classic V3 symmetric provider streams",
+      "lib/onchain/classic-v3-read-model.ts",
+      "expectedStreamsPerProvider: 2",
+      "expectedStreamsPerProvider: 1",
+    ],
+    [
+      "Classic V3 bounded checkpoint window",
+      "lib/onchain/classic-v3-read-model.ts",
+      "bindPersistentRpcIntegrityCheckpointWindow({",
+      "void ({",
+    ],
+    [
+      "Classic V3 raw event provenance quorum",
+      "lib/onchain/classic-v3-read-model.ts",
+      "eventProvenance: value.eventProvenance",
+      "eventProvenance: []",
+    ],
+    [
+      "v4 cache namespace",
+      "lib/onchain/persistent-rpc-cache.server.ts",
+      'const CACHE_SCHEMA = "programmable-rpc-log-cursor-v4";',
+      'const CACHE_SCHEMA = "programmable-rpc-log-cursor-v3";',
+    ],
+    [
+      "single group-head CAS",
+      "lib/onchain/persistent-rpc-cache.server.ts",
+      "const published = checkpoint.etag === null",
+      "const published = \"created\"",
+    ],
+    [
+      "post-publish marker activation",
+      "lib/onchain/persistent-rpc-cache.server.ts",
+      'scope.commitId,\n          "committed",',
+      'scope.commitId,\n          "pending",',
+    ],
+    [
+      "previous whole-generation fallback",
+      "lib/onchain/persistent-rpc-cache.server.ts",
+      'pointedMarker.status !== "committed"',
+      'pointedMarker.status === "committed"',
+    ],
+    [
+      "retired namespace rejection",
+      "lib/onchain/persistent-rpc-cache.server.ts",
+      "Persistent RPC cache path uses a retired namespace",
+      "Persistent RPC cache path is accepted",
     ],
     [
       "Stock launcher topic-OR filtering",

--- a/tests/historical-read-rpc-server.test.ts
+++ b/tests/historical-read-rpc-server.test.ts
@@ -7,9 +7,15 @@ import {
   historicalReadOnchainDeployment,
 } from "../lib/onchain/historical-read-rpc.server";
 import type { ReadyOnchainDeployment } from "../lib/onchain/types";
+import { productionMainnetRpcEnvironment } from
+  "../lib/onchain/website-rpc-providers.server";
 const DRPC_RPC_URL = "https://lb.drpc.live/ethereum/drpc-test-key";
 const QUICKNODE_RPC_URL =
   "https://programmable-mainnet.ethereum-mainnet.quiknode.pro/quicknode-test-key/";
+const environment = productionMainnetRpcEnvironment(
+  DRPC_RPC_URL,
+  QUICKNODE_RPC_URL,
+);
 
 const deployment: ReadyOnchainDeployment = {
   environment: "production",
@@ -30,34 +36,30 @@ const deployment: ReadyOnchainDeployment = {
 };
 
 describe("historical read RPC deployment", () => {
-  it("uses two fixed independent archive witnesses", () => {
-    expect(historicalReadOnchainDeployment(deployment)).toMatchObject({
-      rpcUrl: "https://rpc.mevblocker.io/",
-      rpcUrlSecondary: "https://mainnet.gateway.tenderly.co/",
-      rpcProviderIds: undefined,
+  it("uses the exact commitment-bound production dRPC and QuickNode pair", () => {
+    expect(historicalReadOnchainDeployment(deployment, environment)).toMatchObject({
+      rpcUrl: DRPC_RPC_URL,
+      rpcUrlSecondary: QUICKNODE_RPC_URL,
+      rpcProviderIds: { primary: "drpc", secondary: "quicknode" },
     });
   });
 
-  it("does not retain either private current-market reader", () => {
+  it("rejects the base deployment as authority and restores the bound pair", () => {
     const historical = historicalReadOnchainDeployment({
       ...deployment,
       rpcUrl: "https://eth.drpc.org",
       rpcUrlSecondary: null,
-    });
+    }, environment);
 
-    expect(historical.rpcUrl).toBe("https://rpc.mevblocker.io/");
-    expect(historical.rpcUrlSecondary).toBe(
-      "https://mainnet.gateway.tenderly.co/",
-    );
-    expect(historical.rpcUrl).not.toContain("drpc");
-    expect(historical.rpcUrl).not.toContain("quicknode");
+    expect(historical.rpcUrl).toBe(DRPC_RPC_URL);
+    expect(historical.rpcUrlSecondary).toBe(QUICKNODE_RPC_URL);
   });
 
   it("fails closed outside Ethereum Mainnet", () => {
     expect(() => historicalReadOnchainDeployment({
       ...deployment,
       chainId: 11_155_111,
-    }))
+    }, environment))
       .toThrow(HistoricalReadRpcBindingError);
   });
 });

--- a/tests/persistent-rpc-cache.test.ts
+++ b/tests/persistent-rpc-cache.test.ts
@@ -4,6 +4,7 @@ import { keccak256, type EIP1193RequestFn } from "viem";
 vi.mock("server-only", () => ({}));
 
 import {
+  bindPersistentRpcIntegrityCheckpointWindow,
   bindPrivateBlobReadMetadata,
   createMemoryPersistentRpcCacheStore,
   createPersistentRpcRequest,
@@ -154,6 +155,30 @@ function countingStore(base = createMemoryPersistentRpcCacheStore()) {
   return { store, counts };
 }
 
+function inspectableMemoryStore() {
+  const values = new Map<string, { etag: string; value: unknown }>();
+  let generation = 0;
+  const store: PersistentRpcCacheStore = {
+    async read(path) {
+      return values.get(path) ?? null;
+    },
+    async create(path, value) {
+      if (values.has(path)) return "exists";
+      generation += 1;
+      values.set(path, { etag: `inspect-${generation}`, value });
+      return "created";
+    },
+    async replace(path, value, expectedEtag) {
+      const current = values.get(path);
+      if (!current || current.etag !== expectedEtag) return "conflict";
+      generation += 1;
+      values.set(path, { etag: `inspect-${generation}`, value });
+      return "replaced";
+    },
+  };
+  return { store, values };
+}
+
 function reorgOnCreateStore(
   onCreate: () => void,
   base = createMemoryPersistentRpcCacheStore(),
@@ -264,7 +289,7 @@ describe("persistent RPC log cursor", () => {
       "test-read-write-token",
       async () => blob.client,
     );
-    const path = "indexes/rpc-log-cursors/v3/1/provider/stream/cursor.json";
+    const path = "indexes/rpc-log-cursors/v4/1/provider/stream/cursors/test.json";
     const value = { status: "complete", blockNumber: "0x1" };
 
     await expect(store.create(path, value)).resolves.toBe("created");
@@ -284,52 +309,410 @@ describe("persistent RPC log cursor", () => {
       async () => blob.client,
     );
 
-    for (const providerId of ["provider-primary", "provider-secondary"]) {
-      const rpc = mockRpc();
-      const cached = cachedRequest(rpc, store, providerId, 5n);
-      await withPersistentRpcIntegrityScope(() =>
-        Promise.all([
+    const requests = ["provider-primary", "provider-secondary"].map(
+      (providerId) => cachedRequest(mockRpc(), store, providerId, 5n),
+    );
+    await withPersistentRpcIntegrityScope(
+      () => Promise.all(
+        requests.flatMap((cached) => [
           logRequest(cached.request, 0, 9, bytes32(101)),
           logRequest(cached.request, 0, 9, bytes32(102)),
         ]),
-      );
+      ),
+      { checkpointGroup: "dual-provider-test", expectedCursorBindings: 4 },
+    );
 
-      const providerPaths = blob.paths().filter((path) =>
-        path.includes(`/${providerId}/`),
-      );
-      const cursorPaths = providerPaths.filter((path) =>
-        path.endsWith("/cursor.json"),
-      );
-      const integrityPaths = providerPaths.filter((path) =>
-        path.includes("/integrity/"),
-      );
-      expect(cursorPaths).toHaveLength(2);
-      expect(integrityPaths).toHaveLength(1);
-      for (const path of cursorPaths) {
-        expect(
-          (blob.value(path) as { payload: { segments: unknown[] } }).payload
-            .segments,
-        ).toHaveLength(2);
-      }
-      expect(
-        (blob.value(integrityPaths[0] as string) as {
-          payload: { status: string };
-        }).payload.status,
-      ).toBe("committed");
-    }
+    const cursorPaths = blob.paths().filter((path) => path.includes("/cursors/"));
+    const integrityPaths = blob.paths().filter((path) => path.includes("/integrity/"));
+    const checkpointPaths = blob.paths().filter((path) => path.includes("/checkpoints/"));
+    expect(cursorPaths).toHaveLength(8);
+    expect(integrityPaths).toHaveLength(1);
+    expect(checkpointPaths).toHaveLength(1);
+    expect(
+      (blob.value(integrityPaths[0] as string) as {
+        payload: { cursors: unknown[]; status: string };
+      }).payload,
+    ).toMatchObject({ status: "committed", cursors: expect.arrayContaining([]) });
+    expect(
+      (blob.value(integrityPaths[0] as string) as {
+        payload: { cursors: unknown[] };
+      }).payload.cursors,
+    ).toHaveLength(4);
 
-    const cursorPath = blob.paths().find(
-      (path) =>
-        path.includes("/provider-primary/") && path.endsWith("/cursor.json"),
-    ) as string;
-    const stale = await store.read(cursorPath);
+    const checkpointPath = checkpointPaths[0] as string;
+    const stale = await store.read(checkpointPath);
     expect(stale).not.toBeNull();
     expect(
-      await store.replace(cursorPath, stale?.value, stale?.etag as string),
+      await store.replace(checkpointPath, stale?.value, stale?.etag as string),
     ).toBe("replaced");
     expect(
-      await store.replace(cursorPath, stale?.value, stale?.etag as string),
+      await store.replace(checkpointPath, stale?.value, stale?.etag as string),
     ).toBe("conflict");
+  });
+
+  it("retries a truncated authenticated Blob stream without accepting partial JSON", async () => {
+    const value = { schemaVersion: "test", payload: { ok: true } };
+    const bytes = new TextEncoder().encode(JSON.stringify(value));
+    let reads = 0;
+    const store = createVercelBlobPersistentRpcCacheStore(
+      "test-read-write-token",
+      async () => ({
+        async get() {
+          reads += 1;
+          const body = reads === 1 ? bytes.slice(0, bytes.length - 1) : bytes;
+          return {
+            statusCode: 200,
+            stream: new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(body);
+                controller.close();
+              },
+            }),
+            headers: new Headers({
+              "content-encoding": "gzip",
+              "content-length": String(body.length),
+            }),
+            blob: { etag: 'W/"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"', size: body.length },
+          };
+        },
+        async head() {
+          return {
+            etag: '"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
+            size: bytes.length,
+          };
+        },
+        async put() {
+          throw new Error("unexpected write");
+        },
+      }),
+    );
+
+    await expect(
+      store.read("indexes/rpc-log-cursors/v4/1/checkpoints/retry.json"),
+    ).resolves.toEqual({
+      etag: '"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
+      value,
+    });
+    expect(reads).toBe(2);
+  });
+
+  it("keeps exactly four stable cursor bindings across more than 128 checkpoints", async () => {
+    const inspected = inspectableMemoryStore();
+    const providers = ["provider-many-a", "provider-many-b"].map(
+      (providerId) => cachedRequest(mockRpc(), inspected.store, providerId),
+    );
+    for (let block = 0; block < 129; block += 1) {
+      await withPersistentRpcIntegrityScope(
+        async () => {
+          await Promise.all(
+            providers.flatMap((cached) => [
+              logRequest(cached.request, block, block, bytes32(201)),
+              logRequest(cached.request, block, block, bytes32(202)),
+            ]),
+          );
+          bindPersistentRpcIntegrityCheckpointWindow({
+            fromBlock: BigInt(block),
+            toBlock: BigInt(block),
+            boundaryBlockHash: bytes32(10_000 + block),
+          });
+        },
+        {
+          checkpointGroup: "more-than-128-checkpoints",
+          expectedCursorBindings: 4,
+          expectedProviderCount: 2,
+          expectedStreamsPerProvider: 2,
+          requireCheckpointWindow: true,
+        },
+      );
+    }
+    const markers = [...inspected.values]
+      .filter(([path]) => path.includes("/integrity/"))
+      .map(([, record]) => record.value as {
+        payload: {
+          checkpointWindow: unknown;
+          cursors: unknown[];
+          previousIntegrityCommitId: string | null;
+          status: string;
+        };
+      });
+    expect(markers).toHaveLength(129);
+    expect(
+      markers.every(
+        (marker) =>
+          marker.payload.status === "committed" &&
+          marker.payload.checkpointWindow !== null &&
+          marker.payload.cursors.length === 4,
+      ),
+    ).toBe(true);
+    expect(
+      markers.filter(
+        (marker) => marker.payload.previousIntegrityCommitId === null,
+      ),
+    ).toHaveLength(1);
+  }, 20_000);
+
+  it("replays committed historical windows read-only and checkpoints only the new tail", async () => {
+    const inspected = inspectableMemoryStore();
+    const rpcs = [mockRpc(), mockRpc()];
+    const providers = rpcs.map((rpc, index) =>
+      cachedRequest(rpc, inspected.store, `provider-restart-${index}`)
+    );
+    const readWindow = (fromBlock: number, toBlock: number) =>
+      withPersistentRpcIntegrityScope(
+        async () => {
+          const result = await Promise.all(
+            providers.flatMap((cached) => [
+              logRequest(cached.request, fromBlock, toBlock, bytes32(701)),
+              logRequest(cached.request, fromBlock, toBlock, bytes32(702)),
+            ]),
+          );
+          bindPersistentRpcIntegrityCheckpointWindow({
+            fromBlock: BigInt(fromBlock),
+            toBlock: BigInt(toBlock),
+            boundaryBlockHash: bytes32(10_000 + toBlock),
+          });
+          return result;
+        },
+        {
+          checkpointGroup: "restart-tail-resume",
+          expectedCursorBindings: 4,
+          expectedProviderCount: 2,
+          expectedStreamsPerProvider: 2,
+          requireCheckpointWindow: true,
+        },
+      );
+
+    await readWindow(0, 9);
+    await readWindow(10, 19);
+    const markerCount = () =>
+      [...inspected.values.keys()].filter((path) => path.includes("/integrity/"))
+        .length;
+    expect(markerCount()).toBe(2);
+    const logReadsBeforeRestart = rpcs.map((rpc) => rpc.counts.logs);
+    await readWindow(0, 9);
+    await readWindow(10, 19);
+    expect(markerCount()).toBe(2);
+    expect(rpcs.map((rpc) => rpc.counts.logs)).toEqual(logReadsBeforeRestart);
+
+    await readWindow(20, 29);
+    expect(markerCount()).toBe(3);
+    const checkpointRecord = [...inspected.values]
+      .find(([path]) => path.includes("/checkpoints/"))?.[1].value as {
+        payload: { integrityCommitId: string };
+      };
+    const marker = [...inspected.values]
+      .find(([path]) =>
+        path.endsWith(`/${checkpointRecord.payload.integrityCommitId}.json`)
+      )?.[1].value as {
+        payload: { cursors: Array<{ cursorPath: string }> };
+      };
+    const boundaries = marker.payload.cursors.map((binding) => {
+      const cursor = inspected.values.get(binding.cursorPath)?.value as {
+        payload: { cursorBlock: string };
+      };
+      return BigInt(cursor.payload.cursorBlock);
+    });
+    expect(boundaries).toEqual([29n, 29n, 29n, 29n]);
+  });
+
+  it("requires a genesis-first contiguous baseline before admitting a live tail", async () => {
+    const inspected = inspectableMemoryStore();
+    const rpcs = [mockRpc(), mockRpc()];
+    const providers = rpcs.map((rpc, index) =>
+      cachedRequest(rpc, inspected.store, `provider-baseline-${index}`)
+    );
+    const readWindow = (fromBlock: number, toBlock: number) =>
+      withPersistentRpcIntegrityScope(
+        async () => {
+          const result = await Promise.all(
+            providers.flatMap((cached) => [
+              logRequest(cached.request, fromBlock, toBlock, bytes32(711)),
+              logRequest(cached.request, fromBlock, toBlock, bytes32(712)),
+            ]),
+          );
+          bindPersistentRpcIntegrityCheckpointWindow({
+            fromBlock: BigInt(fromBlock),
+            toBlock: BigInt(toBlock),
+            boundaryBlockHash: bytes32(10_000 + toBlock),
+          });
+          return result;
+        },
+        {
+          checkpointGroup: "genesis-first-contiguous-baseline",
+          expectedCursorBindings: 4,
+          expectedProviderCount: 2,
+          expectedStreamsPerProvider: 2,
+          requireCheckpointWindow: true,
+          requiredInitialFromBlock: 0n,
+          requireContiguousCheckpointWindow: true,
+        },
+      );
+
+    await expect(readWindow(10, 19)).rejects.toThrow(
+      "baseline does not start at its release boundary",
+    );
+    await expect(readWindow(0, 9)).resolves.toHaveLength(4);
+    await expect(readWindow(20, 29)).rejects.toThrow(
+      "window is not contiguous with its committed baseline",
+    );
+    await expect(readWindow(10, 19)).resolves.toHaveLength(4);
+
+    const markersBeforeReplay = [...inspected.values.keys()].filter((path) =>
+      path.includes("/integrity/")
+    ).length;
+    await expect(readWindow(0, 9)).resolves.toHaveLength(4);
+    await expect(readWindow(10, 19)).resolves.toHaveLength(4);
+    expect(
+      [...inspected.values.keys()].filter((path) =>
+        path.includes("/integrity/")
+      ).length,
+    ).toBe(markersBeforeReplay);
+  });
+
+  it("keeps the previous complete checkpoint when one of four participants fails", async () => {
+    const inspected = inspectableMemoryStore();
+    const primaryRpc = mockRpc();
+    const secondaryRpc = mockRpc();
+    const providers = [
+      cachedRequest(primaryRpc, inspected.store, "provider-group-a"),
+      cachedRequest(secondaryRpc, inspected.store, "provider-group-b"),
+    ];
+    const readWindow = (from: number, to: number) =>
+      Promise.all(
+        providers.flatMap((cached) => [
+          logRequest(cached.request, from, to, bytes32(301)),
+          logRequest(cached.request, from, to, bytes32(302)),
+        ]),
+      );
+    await withPersistentRpcIntegrityScope(
+      () => readWindow(0, 9),
+      { checkpointGroup: "four-way-abort", expectedCursorBindings: 4 },
+    );
+    const checkpointPath = [...inspected.values.keys()].find((path) =>
+      path.includes("/checkpoints/")
+    ) as string;
+    const checkpointBefore = inspected.values.get(checkpointPath)?.value;
+    secondaryRpc.failRange(10n, 19n);
+    await expect(
+      withPersistentRpcIntegrityScope(
+        () => readWindow(10, 19),
+        { checkpointGroup: "four-way-abort", expectedCursorBindings: 4 },
+      ),
+    ).rejects.toThrow("injected partial failure");
+    expect(inspected.values.get(checkpointPath)?.value).toEqual(checkpointBefore);
+  });
+
+  it("requires the exact symmetric provider and stream set for a group checkpoint", async () => {
+    const store = createMemoryPersistentRpcCacheStore();
+    const primary = cachedRequest(mockRpc(), store, "provider-symmetric-a");
+    const secondary = cachedRequest(mockRpc(), store, "provider-symmetric-b");
+    await expect(
+      withPersistentRpcIntegrityScope(
+        async () => {
+          await Promise.all([
+            logRequest(primary.request, 0, 9, bytes32(501)),
+            logRequest(primary.request, 0, 9, bytes32(502)),
+            logRequest(secondary.request, 0, 9, bytes32(501)),
+            logRequest(secondary.request, 0, 9, bytes32(503)),
+          ]);
+          bindPersistentRpcIntegrityCheckpointWindow({
+            fromBlock: 0n,
+            toBlock: 9n,
+            boundaryBlockHash: bytes32(10_009),
+          });
+        },
+        {
+          checkpointGroup: "asymmetric-streams",
+          expectedCursorBindings: 4,
+          expectedProviderCount: 2,
+          expectedStreamsPerProvider: 2,
+          requireCheckpointWindow: true,
+        },
+      ),
+    ).rejects.toThrow("do not cover the same event streams");
+  });
+
+  it("rejects a group checkpoint whose cursor boundary differs from its window", async () => {
+    const store = createMemoryPersistentRpcCacheStore();
+    const primary = cachedRequest(mockRpc(), store, "provider-window-a");
+    const secondary = cachedRequest(mockRpc(), store, "provider-window-b");
+    await expect(
+      withPersistentRpcIntegrityScope(
+        async () => {
+          await Promise.all([
+            logRequest(primary.request, 0, 9, bytes32(601)),
+            logRequest(primary.request, 0, 9, bytes32(602)),
+            logRequest(secondary.request, 0, 9, bytes32(601)),
+            logRequest(secondary.request, 0, 9, bytes32(602)),
+          ]);
+          bindPersistentRpcIntegrityCheckpointWindow({
+            fromBlock: 0n,
+            toBlock: 8n,
+            boundaryBlockHash: bytes32(10_008),
+          });
+        },
+        {
+          checkpointGroup: "wrong-window-boundary",
+          expectedCursorBindings: 4,
+          expectedProviderCount: 2,
+          expectedStreamsPerProvider: 2,
+          requireCheckpointWindow: true,
+        },
+      ),
+    ).rejects.toThrow("do not share its boundary");
+  });
+
+  it("never publishes a mixed generation from competing four-way checkpoints", async () => {
+    const inspected = inspectableMemoryStore();
+    const providers = ["provider-race-a", "provider-race-b"].map(
+      (providerId) => cachedRequest(mockRpc({ delayMs: 2 }), inspected.store, providerId),
+    );
+    const checkpoint = (from: number, to: number) =>
+      withPersistentRpcIntegrityScope(
+        () => Promise.all(
+          providers.flatMap((cached) => [
+            logRequest(cached.request, from, to, bytes32(401)),
+            logRequest(cached.request, from, to, bytes32(402)),
+          ]),
+        ),
+        { checkpointGroup: "four-way-race", expectedCursorBindings: 4 },
+      );
+    const raced = await Promise.allSettled([
+      checkpoint(0, 9),
+      checkpoint(10, 19),
+    ]);
+    expect(raced.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const checkpointRecord = [...inspected.values]
+      .find(([path]) => path.includes("/checkpoints/"))?.[1].value as {
+        payload: { integrityCommitId: string };
+      };
+    const marker = [...inspected.values]
+      .find(([path]) =>
+        path.endsWith(`/${checkpointRecord.payload.integrityCommitId}.json`)
+      )?.[1].value as {
+        payload: { cursors: Array<{ cursorPath: string }> };
+      };
+    const boundaries = marker.payload.cursors.map((binding) => {
+      const cursor = inspected.values.get(binding.cursorPath)?.value as {
+        payload: { cursorBlock: string };
+      };
+      return cursor.payload.cursorBlock;
+    });
+    expect(new Set(boundaries).size).toBe(1);
+    expect(boundaries).toHaveLength(4);
+  });
+
+  it("fails closed when an authoritative checkpoint marker is missing", async () => {
+    const inspected = inspectableMemoryStore();
+    const cached = cachedRequest(mockRpc(), inspected.store, "provider-missing-marker");
+    await logRequest(cached.request, 0, 9);
+    const markerPath = [...inspected.values.keys()].find((path) =>
+      path.includes("/integrity/")
+    ) as string;
+    inspected.values.delete(markerPath);
+    await expect(logRequest(cached.request, 0, 9)).rejects.toThrow(
+      "checkpoint marker is missing",
+    );
   });
 
   it("survives a process restart and serves a canonical cursor without rescanning", async () => {
@@ -489,7 +872,7 @@ describe("persistent RPC log cursor", () => {
       log(0),
       log(5),
     ]);
-    expect(rpc.counts.logs).toBe(3);
+    expect(rpc.counts.logs).toBe(4);
   });
 
   it("keeps the configured provider chunk bound without a persistent store", async () => {
@@ -595,6 +978,42 @@ describe("persistent RPC log cursor", () => {
     ).rejects.toBeInstanceOf(PersistentRpcCacheReorgError);
   });
 
+  it("falls back to the previous whole checkpoint after a post-publish reorg", async () => {
+    const rpc = mockRpc();
+    const base = createMemoryPersistentRpcCacheStore();
+    let injectPostPublishReorg = false;
+    const store: PersistentRpcCacheStore = {
+      read: base.read,
+      create: base.create,
+      async replace(path, value, expectedEtag) {
+        const result = await base.replace(path, value, expectedEtag);
+        if (
+          injectPostPublishReorg &&
+          result === "replaced" &&
+          path.includes("/checkpoints/")
+        ) {
+          rpc.reorg(19n);
+        }
+        return result;
+      },
+    };
+    const first = cachedRequest(rpc, store, "provider-post-publish-reorg");
+    await logRequest(first.request, 0, 9);
+    injectPostPublishReorg = true;
+    await expect(logRequest(first.request, 10, 19)).rejects.toBeInstanceOf(
+      PersistentRpcCacheReorgError,
+    );
+
+    const healthy = mockRpc();
+    const restarted = cachedRequest(
+      healthy,
+      store,
+      "provider-post-publish-reorg",
+    );
+    expect(await logRequest(restarted.request, 0, 9)).toEqual([log(0)]);
+    expect(healthy.counts.logs).toBe(0);
+  });
+
   it("rejects multiple request/store domains before admitting either cursor", async () => {
     const rpc = mockRpc();
     const storeA = createMemoryPersistentRpcCacheStore();
@@ -606,14 +1025,14 @@ describe("persistent RPC log cursor", () => {
         await logRequest(firstA.request, 0, 9);
         await logRequest(firstB.request, 0, 9);
       }),
-    ).rejects.toThrow("cannot span request/store domains");
-    expect(rpc.counts.logs).toBe(2);
+    ).rejects.toThrow("cannot span chains or stores");
+    expect(rpc.counts.logs).toBe(1);
 
     const restartedA = cachedRequest(rpc, storeA, "provider-shared");
     const restartedB = cachedRequest(rpc, storeB, "provider-shared");
     expect(await logRequest(restartedA.request, 0, 9)).toEqual([log(0)]);
     expect(await logRequest(restartedB.request, 0, 9)).toEqual([log(0)]);
-    expect(rpc.counts.logs).toBe(4);
+    expect(rpc.counts.logs).toBe(3);
   });
 
   it("does not share proofs across request backends with the same provider id", async () => {
@@ -688,7 +1107,7 @@ describe("persistent RPC log cursor", () => {
     expect(await logRequest(restarted.request, 0, 9, bytes32(2))).toEqual([
       log(0),
     ]);
-    expect(rpc.counts.logs).toBe(2);
+    expect(rpc.counts.logs).toBe(3);
   });
 
   it("rejects a detached covered read released after the scope closes", async () => {
@@ -735,7 +1154,7 @@ describe("persistent RPC log cursor", () => {
     });
     release();
     await expect(detached).rejects.toThrow("already sealed");
-    expect(rpc.counts.logs).toBe(2);
+    expect(rpc.counts.logs).toBe(4);
   });
 
   it("rejects and leaves uncovered a detached cursor write after scope close", async () => {
@@ -758,7 +1177,7 @@ describe("persistent RPC log cursor", () => {
         if (
           pauseCursorCreate &&
           !paused &&
-          path.endsWith("/cursor.json")
+          path.includes("/cursors/")
         ) {
           paused = true;
           entered();
@@ -795,7 +1214,7 @@ describe("persistent RPC log cursor", () => {
     expect(await logRequest(restarted.request, 0, 9, bytes32(2))).toEqual([
       log(0),
     ]);
-    expect(rpc.counts.logs).toBe(3);
+    expect(rpc.counts.logs).toBe(4);
   });
 
   it("extends an existing prefix by fetching only the new tail", async () => {
@@ -831,7 +1250,7 @@ describe("persistent RPC log cursor", () => {
     expect(rpc.counts.logs).toBe(2);
   });
 
-  it("fails closed on overlapping CAS races without corrupting later coverage", async () => {
+  it("retries overlapping checkpoint CAS races without corrupting later coverage", async () => {
     const rpc = mockRpc({ delayMs: 5 });
     const cached = cachedRequest(rpc);
     const raced = await Promise.allSettled([
@@ -840,12 +1259,7 @@ describe("persistent RPC log cursor", () => {
     ]);
     expect(
       raced.filter((result) => result.status === "fulfilled"),
-    ).toHaveLength(1);
-    const rejection = raced.find((result) => result.status === "rejected");
-    expect(rejection).toMatchObject({
-      status: "rejected",
-      reason: expect.any(PersistentRpcCacheError),
-    });
+    ).toHaveLength(2);
 
     const restarted = cachedRequest(rpc, cached.store);
     expect(await logRequest(restarted.request, 0, 14)).toHaveLength(2);
@@ -1035,7 +1449,7 @@ describe("persistent RPC log cursor", () => {
     await expect(
       request({ method: "eth_getCode", params: [ADDRESS, quantity(100)] }),
     ).resolves.toBe(code);
-    expect(paths.every((path) => path.includes("/rpc-log-cursors/v3/"))).toBe(true);
+    expect(paths.every((path) => path.includes("/rpc-log-cursors/v4/"))).toBe(true);
     expect(paths.some((path) => path.includes("/rpc-log-cursors/v2/"))).toBe(false);
     expect(paths.some((path) => path.includes("/runtime-v2/"))).toBe(true);
     expect(paths.some((path) => path.includes("/runtime/"))).toBe(false);
@@ -1044,9 +1458,14 @@ describe("persistent RPC log cursor", () => {
   it("bounds runtime-v2 Blob reads in the current cache generation", () => {
     expect(
       persistentRpcCachePathByteLimit(
-        "indexes/rpc-log-cursors/v3/1/provider/runtime-v2/address/release.json",
+        "indexes/rpc-log-cursors/v4/1/provider/runtime-v2/address/release.json",
       ),
     ).toBe(PERSISTENT_RPC_CACHE_LIMITS.maxRuntimeBytes);
+    expect(() =>
+      persistentRpcCachePathByteLimit(
+        "indexes/rpc-log-cursors/v3/1/provider/runtime-v2/address/release.json",
+      )
+    ).toThrow(PersistentRpcCacheError);
     expect(() =>
       persistentRpcCachePathByteLimit(
         "indexes/rpc-log-cursors/v2/1/provider/runtime/address/release.json",
@@ -1191,7 +1610,7 @@ describe("persistent RPC log cursor", () => {
     );
     expect(rpc.counts.logs).toBe(chunkCount);
     expect(counted.counts.reads).toBeLessThanOrEqual(
-      1 + PERSISTENT_RPC_CACHE_LIMITS.maxSegmentReadsPerOperation,
+      4 + PERSISTENT_RPC_CACHE_LIMITS.maxSegmentReadsPerOperation,
     );
 
     rpc.reorg(1_999n);
@@ -1200,7 +1619,7 @@ describe("persistent RPC log cursor", () => {
     await expect(logRequest(afterReorg.request, 0, 1_999)).rejects.toBeInstanceOf(
       PersistentRpcCacheReorgError,
     );
-    expect(counted.counts.reads).toBe(1);
+    expect(counted.counts.reads).toBe(3);
   });
 
   it("keeps concurrent CAS appends bounded when compaction is required", async () => {
@@ -1219,7 +1638,7 @@ describe("persistent RPC log cursor", () => {
     const restarted = cachedRequest(rpc, counted.store);
     expect(await logRequest(restarted.request, 0, 99)).toHaveLength(10);
     expect(counted.counts.reads).toBeLessThanOrEqual(
-      1 + PERSISTENT_RPC_CACHE_LIMITS.maxSegmentReadsPerOperation,
+      4 + PERSISTENT_RPC_CACHE_LIMITS.maxSegmentReadsPerOperation,
     );
   });
 

--- a/tests/persistent-rpc-cache.test.ts
+++ b/tests/persistent-rpc-cache.test.ts
@@ -569,6 +569,64 @@ describe("persistent RPC log cursor", () => {
     ).toBe(markersBeforeReplay);
   });
 
+  it("publishes repeated extensions of a partial final window as contiguous tails", async () => {
+    const inspected = inspectableMemoryStore();
+    const providers = [mockRpc(), mockRpc()].map((rpc, index) =>
+      cachedRequest(rpc, inspected.store, `provider-partial-${index}`)
+    );
+    const readWindow = (toBlock: number) =>
+      withPersistentRpcIntegrityScope(
+        async () => {
+          const result = await Promise.all(
+            providers.flatMap((cached) => [
+              logRequest(cached.request, 0, toBlock, bytes32(721)),
+              logRequest(cached.request, 0, toBlock, bytes32(722)),
+            ]),
+          );
+          bindPersistentRpcIntegrityCheckpointWindow({
+            fromBlock: 0n,
+            toBlock: BigInt(toBlock),
+            boundaryBlockHash: bytes32(10_000 + toBlock),
+          });
+          return result;
+        },
+        {
+          checkpointGroup: "partial-final-window-extension",
+          expectedCursorBindings: 4,
+          expectedProviderCount: 2,
+          expectedStreamsPerProvider: 2,
+          requireCheckpointWindow: true,
+          requiredInitialFromBlock: 0n,
+          requireContiguousCheckpointWindow: true,
+          allowCheckpointWindowExtension: true,
+        },
+      );
+
+    await expect(readWindow(4)).resolves.toHaveLength(4);
+    await expect(readWindow(9)).resolves.toHaveLength(4);
+    await expect(readWindow(14)).resolves.toHaveLength(4);
+
+    const windows = [...inspected.values]
+      .filter(([path]) => path.includes("/integrity/"))
+      .map(([, record]) => record.value as {
+        payload: {
+          status: string;
+          checkpointWindow: { fromBlock: string; toBlock: string };
+        };
+      })
+      .filter((marker) => marker.payload.status === "committed")
+      .map((marker) => ({
+        fromBlock: marker.payload.checkpointWindow.fromBlock,
+        toBlock: marker.payload.checkpointWindow.toBlock,
+      }))
+      .sort((left, right) => BigInt(left.fromBlock) < BigInt(right.fromBlock) ? -1 : 1);
+    expect(windows).toEqual([
+      { fromBlock: "0", toBlock: "4" },
+      { fromBlock: "5", toBlock: "9" },
+      { fromBlock: "10", toBlock: "14" },
+    ]);
+  });
+
   it("keeps the previous complete checkpoint when one of four participants fails", async () => {
     const inspected = inspectableMemoryStore();
     const primaryRpc = mockRpc();


### PR DESCRIPTION
## Summary
- publish Classic V3 two-provider/two-stream cache windows through one atomic group checkpoint
- require genesis-first contiguous v4 initialization and bind checkpoint domains to provider identities
- keep Blob reads bounded and retry only exact truncated transfers
- record non-secret private-Blob backfill/restart evidence

## Verification
- focused current-base suite: 89/89
- typecheck and changed-file ESLint
- read-model ops source gate: 40/40
- private Blob: 109 contiguous windows, restart eth_getLogs=0 and writes=0
- full local verify running on the exact pushed revision