### PR TITLE
Serialize independent archive provider scans

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -9,7 +9,7 @@
     "boundedRefresh": {
       "runtime": {
         "path": "lib/onchain/read-model.ts",
-        "sha256": "f787ca685a1168a119137dc42894b86a0843ec339e9e380be2b32070d256c1a8"
+        "sha256": "168e440ffbaa78f24c55cf4a484c8735443251071eb2794ccc3321d0b708f0cb"
       },
       "dependencies": [
         {
@@ -29,13 +29,13 @@
         {
           "release": "classic-v3",
           "path": "lib/onchain/classic-v3-read-model.ts",
-          "sha256": "4921b6869284d405976bc00f9426f1dbf05c5cf02f0354746a57c6ee8631cddd",
+          "sha256": "da6b9cb5e938435010e7a2c0f6ea9a597e7f04257570bd243e368f68c2d28188",
           "eventFiltersPerRange": 2
         },
         {
           "release": "stock-paired-v1-v3",
           "path": "lib/onchain/stock-paired-read-model.ts",
-          "sha256": "749399f6b360fdcbebf3d2632d82409aba00dcbb3367538c89941a81532cce67",
+          "sha256": "2074bff385c644f6bd9dfb2879e52e713457a3b04cedfe858dc297ad19baee74",
           "eventFiltersPerRange": 3
         }
       ],

--- a/lib/onchain/classic-v3-read-model.ts
+++ b/lib/onchain/classic-v3-read-model.ts
@@ -470,24 +470,23 @@ export async function readClassicV3EventsQuorum(
     );
     const readCheckpoint = () => withPersistentRpcIntegrityScope(
       async () => {
-        const [sets, boundaries] = await Promise.all([
-          allSettledOrThrow(
-            clients.map((client) =>
-              readClassicV3Events(
-                client,
-                config,
-                release,
-                rangeEnd,
-                fromBlock,
-              )
+        const sets = await mapInBatches(
+          clients,
+          RPC_PROVENANCE_BATCH_SIZE,
+          (client) =>
+            readClassicV3Events(
+              client,
+              config,
+              release,
+              rangeEnd,
+              fromBlock,
             ),
+        );
+        const boundaries = await allSettledOrThrow(
+          clients.map((client) =>
+            client.getBlock({ blockNumber: rangeEnd })
           ),
-          allSettledOrThrow(
-            clients.map((client) =>
-              client.getBlock({ blockNumber: rangeEnd })
-            ),
-          ),
-        ]);
+        );
         const fingerprint = eventFingerprint(sets[0]);
         if (
           sets.some((candidate) => eventFingerprint(candidate) !== fingerprint) ||

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -821,8 +821,13 @@ async function readReadyModel(
     ),
   );
 
-  const indexedEventSets = await allSettledOrThrow(
-    clients.map((candidate, providerIndex) =>
+  const indexedEventSets = await mapInBatches(
+    clients.map((candidate, providerIndex) => ({
+      candidate,
+      providerIndex,
+    })),
+    RPC_PROVENANCE_BATCH_SIZE,
+    ({ candidate, providerIndex }) =>
       withReadStage("classic-events", () =>
         withPersistentRpcIntegrityScope(
           () => indexVerifiedEvents(candidate, config, toBlock),
@@ -839,7 +844,6 @@ async function readReadyModel(
           },
         ),
       ),
-    ),
   );
   const launcherFeeValues = await withReadStage(
     "launcher-fee-accounting",

--- a/lib/onchain/stock-paired-read-model.ts
+++ b/lib/onchain/stock-paired-read-model.ts
@@ -931,8 +931,13 @@ export async function readStockPairedExploreModel(
     activeReleases,
     1,
     async (release) => {
-      const eventSets = await allSettledOrThrow(
-        clients.map((candidate, providerIndex) =>
+      const eventSets = await mapInBatches(
+        clients.map((candidate, providerIndex) => ({
+          candidate,
+          providerIndex,
+        })),
+        RPC_PROVENANCE_BATCH_SIZE,
+        ({ candidate, providerIndex }) =>
           withPersistentRpcIntegrityScope(
             () =>
               readStockPairedEvents(
@@ -952,7 +957,7 @@ export async function readStockPairedExploreModel(
               ].join(":"),
               expectedCursorBindings: 3,
             },
-          )),
+          ),
       );
       const fingerprint = eventFingerprint(eventSets[0]);
       if (

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -14,7 +14,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
-        sha256: "f787ca685a1168a119137dc42894b86a0843ec339e9e380be2b32070d256c1a8",
+        sha256: "168e440ffbaa78f24c55cf4a484c8735443251071eb2794ccc3321d0b708f0cb",
       }),
       dependencies: Object.freeze([
         Object.freeze({
@@ -34,13 +34,13 @@ const APPROVED_OPERATIONS = Object.freeze({
         Object.freeze({
           release: "classic-v3",
           path: "lib/onchain/classic-v3-read-model.ts",
-          sha256: "4921b6869284d405976bc00f9426f1dbf05c5cf02f0354746a57c6ee8631cddd",
+          sha256: "da6b9cb5e938435010e7a2c0f6ea9a597e7f04257570bd243e368f68c2d28188",
           eventFiltersPerRange: 2,
         }),
         Object.freeze({
           release: "stock-paired-v1-v3",
           path: "lib/onchain/stock-paired-read-model.ts",
-          sha256: "749399f6b360fdcbebf3d2632d82409aba00dcbb3367538c89941a81532cce67",
+          sha256: "2074bff385c644f6bd9dfb2879e52e713457a3b04cedfe858dc297ad19baee74",
           eventFiltersPerRange: 3,
         }),
       ]),
@@ -1635,6 +1635,9 @@ export function evaluateReadModelOperationsSourceContracts(
       refreshRuntimeSource?.includes("events: CLASSIC_FEE_HOOK_EVENTS") &&
       refreshRuntimeSource?.includes("assertCanonicalClassicEventSource(") &&
       refreshRuntimeSource?.includes(
+        "const indexedEventSets = await mapInBatches(",
+      ) &&
+      refreshRuntimeSource?.includes(
         "clients.map((candidate, providerIndex) =>",
       ) &&
       refreshRuntimeSource?.includes(
@@ -1645,6 +1648,7 @@ export function evaluateReadModelOperationsSourceContracts(
       classicV3RefreshSource?.includes(
         "assertCanonicalClassicV3EventSource(",
       ) &&
+      classicV3RefreshSource?.includes("const sets = await mapInBatches(") &&
       classicV3RefreshSource?.includes("readClassicV3EventsQuorum(") &&
       classicV3RefreshSource?.includes('"classic-v3-events-v2"') &&
       classicV3RefreshSource?.includes("clients.length !== 2") &&
@@ -1688,13 +1692,16 @@ export function evaluateReadModelOperationsSourceContracts(
       stockPairedRefreshSource?.includes("events: STOCK_LAUNCHER_EVENTS") &&
       stockPairedRefreshSource?.includes("assertCanonicalStockEventSource(") &&
       stockPairedRefreshSource?.includes(
+        "const eventSets = await mapInBatches(",
+      ) &&
+      stockPairedRefreshSource?.includes(
         "clients.map((candidate, providerIndex) =>",
       ) &&
       stockPairedRefreshSource?.includes(
         "persistentRpcProviderId(providerEndpoints[providerIndex])",
       ) &&
       stockPairedRefreshSource?.includes("expectedCursorBindings: 3"),
-    "all active release scanners use minimal canonical filters, settle complete ranges, adapt exact RPC rejections, compare two provider passes, atomically publish Classic V3 provider-stream checkpoints in a fail-closed v4 namespace and settle registry slices in parallel before deterministic merging and the platform deadline",
+    "all active release scanners use minimal canonical filters, settle complete ranges, adapt exact RPC rejections, compare two serialized provider passes, atomically publish Classic V3 provider-stream checkpoints in a fail-closed v4 namespace and settle registry slices in parallel before deterministic merging and the platform deadline",
   );
   const schedulerWatchdog = operations?.legacyIndexer?.schedulerWatchdog;
   check(

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -623,6 +623,12 @@ describe("read-model operations source contract", () => {
       "const readLogs = () =>\n      Promise.all([",
     ],
     [
+      "serialized Classic V2 provider passes",
+      "lib/onchain/read-model.ts",
+      "const indexedEventSets = await mapInBatches(",
+      "const indexedEventSets = await allSettledOrThrow(",
+    ],
+    [
       "parallel registry slices",
       "lib/onchain/read-model.ts",
       "await settleParallelReadsInOrder([",
@@ -669,6 +675,12 @@ describe("read-model operations source contract", () => {
       "lib/onchain/classic-v3-read-model.ts",
       "allSettledOrThrow([",
       "Promise.all([",
+    ],
+    [
+      "serialized Classic V3 provider passes",
+      "lib/onchain/classic-v3-read-model.ts",
+      "const sets = await mapInBatches(",
+      "const sets = await allSettledOrThrow(",
     ],
     [
       "Classic V3 result-limit range bisection",
@@ -735,6 +747,12 @@ describe("read-model operations source contract", () => {
       "lib/onchain/stock-paired-read-model.ts",
       "events: STOCK_LAUNCHER_EVENTS",
       "event: launchedEvent",
+    ],
+    [
+      "serialized Stock-Paired provider passes",
+      "lib/onchain/stock-paired-read-model.ts",
+      "const eventSets = await mapInBatches(",
+      "const eventSets = await allSettledOrThrow(",
     ],
     [
       "Stock result-limit range bisection",


### PR DESCRIPTION
## Summary
- serialize the two complete historical provider passes for Classic V2, Classic V3, and Stock-Paired scans
- retain exact dual-provider fingerprints and fail-closed equality while avoiding simultaneous full-history load
- bind the new runtime bytes and fail closed if provider pass serialization is removed

## Evidence
- 645 focused tests pass
- typecheck passes
- scoped ESLint passes with one pre-existing warning
- read-model operations gate passes all checks
- gitleaks exact commit reports no leaks

No RPC quorum, freshness, coverage, or evidence gate is weakened.