### PR TITLE
Handle dense durable RPC log segments

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -9,7 +9,7 @@
     "boundedRefresh": {
       "runtime": {
         "path": "lib/onchain/read-model.ts",
-        "sha256": "168e440ffbaa78f24c55cf4a484c8735443251071eb2794ccc3321d0b708f0cb"
+        "sha256": "76e5c5a6bebb697e842572a730e38e3423d6448f661119a2b31a0760b64ace58"
       },
       "dependencies": [
         {
@@ -22,7 +22,7 @@
         },
         {
           "path": "lib/onchain/persistent-rpc-cache.server.ts",
-          "sha256": "4556161d79d49914f064a4df5ad2eb7f9777dfe1b3d188cf36a1e5b434b38f9b"
+          "sha256": "11cdf402ccb7985a215064dc445ca638bf597eb0c4949a000a0ce509642ae459"
         }
       ],
       "releaseRuntimes": [
@@ -35,7 +35,7 @@
         {
           "release": "stock-paired-v1-v3",
           "path": "lib/onchain/stock-paired-read-model.ts",
-          "sha256": "2074bff385c644f6bd9dfb2879e52e713457a3b04cedfe858dc297ad19baee74",
+          "sha256": "0f1a0713aa02b617f1ae9df6463140640d1217cdbb38964b56fc9d2b59e1d054",
           "eventFiltersPerRange": 3
         }
       ],

--- a/lib/onchain/persistent-rpc-cache.server.ts
+++ b/lib/onchain/persistent-rpc-cache.server.ts
@@ -18,11 +18,11 @@ const ADDRESS = /^0x[0-9a-f]{40}$/iu;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 
 export const PERSISTENT_RPC_CACHE_LIMITS = Object.freeze({
-  maxCursorSegments: 8,
+  maxCursorSegments: 16,
   maxSegmentBytes: 4 * 1024 * 1024,
   maxCursorBytes: 64 * 1024,
   maxRuntimeBytes: 256 * 1024,
-  maxSegmentReadsPerOperation: 8,
+  maxSegmentReadsPerOperation: 16,
 });
 
 type JsonRpcRequest = Parameters<EIP1193RequestFn>[0];

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -37,6 +37,7 @@ import {
   sanitizeImageUrl,
 } from "./metadata";
 import {
+  PersistentRpcCacheError,
   persistentRpcHttp,
   persistentRpcProviderId,
   withPersistentRpcIntegrityScope,
@@ -330,6 +331,13 @@ function assertCanonicalClassicEventSource(
   }
 }
 
+function isPersistentCacheRangeLimitError(error: unknown) {
+  return (
+    error instanceof PersistentRpcCacheError &&
+    /^Persistent RPC cache log segment exceeds \d+ bytes$/u.test(error.message)
+  );
+}
+
 export async function indexVerifiedEvents(
   client: PublicClient,
   config: ReadyOnchainDeployment,
@@ -392,7 +400,8 @@ export async function indexVerifiedEvents(
       if (
         (transient ||
           error instanceof LimitExceededRpcError ||
-          error instanceof ResponseBodyTooLargeError) &&
+          error instanceof ResponseBodyTooLargeError ||
+          isPersistentCacheRangeLimitError(error)) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
       ) {

--- a/lib/onchain/stock-paired-read-model.ts
+++ b/lib/onchain/stock-paired-read-model.ts
@@ -31,6 +31,7 @@ import type { LauncherToken } from "../tokens";
 import { stateViewReadAbi, uerc20ReadAbi } from "./abis";
 import { buildTokenLinks, sanitizeImageUrl } from "./metadata";
 import {
+  PersistentRpcCacheError,
   persistentRpcHttp,
   persistentRpcProviderId,
   withPersistentRpcIntegrityScope,
@@ -159,6 +160,13 @@ function isTransientLogReadError(error: unknown) {
     error instanceof RpcRequestError &&
     error.code === -32603 &&
     error.details.trim().toLowerCase() === "service temporarily unavailable"
+  );
+}
+
+function isPersistentCacheRangeLimitError(error: unknown) {
+  return (
+    error instanceof PersistentRpcCacheError &&
+    /^Persistent RPC cache log segment exceeds \d+ bytes$/u.test(error.message)
   );
 }
 
@@ -393,7 +401,8 @@ export async function readStockPairedEvents(
       if (
         (transient ||
           error instanceof LimitExceededRpcError ||
-          error instanceof ResponseBodyTooLargeError) &&
+          error instanceof ResponseBodyTooLargeError ||
+          isPersistentCacheRangeLimitError(error)) &&
         logBlockRange > MINIMUM_LOG_BLOCK_RANGE &&
         rangeEnd > fromBlock
       ) {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -14,7 +14,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
-        sha256: "168e440ffbaa78f24c55cf4a484c8735443251071eb2794ccc3321d0b708f0cb",
+        sha256: "76e5c5a6bebb697e842572a730e38e3423d6448f661119a2b31a0760b64ace58",
       }),
       dependencies: Object.freeze([
         Object.freeze({
@@ -27,7 +27,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
         Object.freeze({
           path: "lib/onchain/persistent-rpc-cache.server.ts",
-          sha256: "4556161d79d49914f064a4df5ad2eb7f9777dfe1b3d188cf36a1e5b434b38f9b",
+          sha256: "11cdf402ccb7985a215064dc445ca638bf597eb0c4949a000a0ce509642ae459",
         }),
       ]),
       releaseRuntimes: Object.freeze([
@@ -40,7 +40,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         Object.freeze({
           release: "stock-paired-v1-v3",
           path: "lib/onchain/stock-paired-read-model.ts",
-          sha256: "2074bff385c644f6bd9dfb2879e52e713457a3b04cedfe858dc297ad19baee74",
+          sha256: "0f1a0713aa02b617f1ae9df6463140640d1217cdbb38964b56fc9d2b59e1d054",
           eventFiltersPerRange: 3,
         }),
       ]),
@@ -1515,6 +1515,10 @@ export function evaluateReadModelOperationsSourceContracts(
     runtimeSource?.includes("error instanceof LimitExceededRpcError") &&
     runtimeSource?.includes("error instanceof HttpRequestError") &&
     runtimeSource?.includes("error instanceof ResponseBodyTooLargeError") &&
+    runtimeSource?.includes("isPersistentCacheRangeLimitError(error)") &&
+    runtimeSource?.includes(
+      "Persistent RPC cache log segment exceeds \\d+ bytes",
+    ) &&
     runtimeSource?.includes("logBlockRange > MINIMUM_LOG_BLOCK_RANGE") &&
     runtimeSource?.includes("logBlockRange * 2n") &&
     runtimeSource?.includes("continue;");
@@ -1577,6 +1581,8 @@ export function evaluateReadModelOperationsSourceContracts(
       persistentCacheSource?.includes(
         'const CACHE_SCHEMA = "programmable-rpc-log-cursor-v4";',
       ) &&
+      persistentCacheSource?.includes("maxCursorSegments: 16,") &&
+      persistentCacheSource?.includes("maxSegmentReadsPerOperation: 16,") &&
       !persistentCacheSource?.includes(
         'const CACHE_SCHEMA = "programmable-rpc-log-cursor-v3";',
       ) &&

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -671,6 +671,12 @@ describe("read-model operations source contract", () => {
       "false ||",
     ],
     [
+      "Classic V2 durable segment range bisection",
+      "lib/onchain/read-model.ts",
+      "isPersistentCacheRangeLimitError(error)",
+      "false",
+    ],
+    [
       "Classic V3 complete-range settlement",
       "lib/onchain/classic-v3-read-model.ts",
       "allSettledOrThrow([",
@@ -719,6 +725,18 @@ describe("read-model operations source contract", () => {
       'const CACHE_SCHEMA = "programmable-rpc-log-cursor-v3";',
     ],
     [
+      "bounded dense-stream cursor capacity",
+      "lib/onchain/persistent-rpc-cache.server.ts",
+      "maxCursorSegments: 16,",
+      "maxCursorSegments: 8,",
+    ],
+    [
+      "bounded dense-stream replay budget",
+      "lib/onchain/persistent-rpc-cache.server.ts",
+      "maxSegmentReadsPerOperation: 16,",
+      "maxSegmentReadsPerOperation: 8,",
+    ],
+    [
       "single group-head CAS",
       "lib/onchain/persistent-rpc-cache.server.ts",
       "const published = checkpoint.etag === null",
@@ -759,6 +777,12 @@ describe("read-model operations source contract", () => {
       "lib/onchain/stock-paired-read-model.ts",
       "error instanceof LimitExceededRpcError ||",
       "false ||",
+    ],
+    [
+      "Stock durable segment range bisection",
+      "lib/onchain/stock-paired-read-model.ts",
+      "isPersistentCacheRangeLimitError(error)",
+      "false",
     ],
   ])(
     "rejects a legacy refresh missing %s",

--- a/tests/onchain-read-model.test.ts
+++ b/tests/onchain-read-model.test.ts
@@ -496,6 +496,29 @@ describe("Explore verified event indexing", () => {
     );
   });
 
+  it("bisects the complete range when its durable segment exceeds the byte cap", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
+      if (firstRequest) {
+        firstRequest = false;
+        throw new PersistentRpcCacheError(
+          "Persistent RPC cache log segment exceeds 4194304 bytes",
+        );
+      }
+      return [];
+    });
+
+    await expect(
+      indexVerifiedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        1_000n,
+      ),
+    ).resolves.toMatchObject({ launches: [], creatorClaims: [] });
+    expect(getLogs).toHaveBeenCalledTimes(6);
+  });
+
   it("fails closed when a result limit persists at the minimum range", async () => {
     const getLogs = vi.fn(async () => {
       throw new LimitExceededRpcError(

--- a/tests/persistent-rpc-cache.test.ts
+++ b/tests/persistent-rpc-cache.test.ts
@@ -283,6 +283,14 @@ function weakEtagBlobClient() {
 }
 
 describe("persistent RPC log cursor", () => {
+  it("keeps a bounded sixteen-segment replay budget for the measured Classic fee stream", () => {
+    expect(PERSISTENT_RPC_CACHE_LIMITS).toMatchObject({
+      maxCursorSegments: 16,
+      maxSegmentBytes: 4 * 1024 * 1024,
+      maxSegmentReadsPerOperation: 16,
+    });
+  });
+
   it("retries transient truncated private Blob reads within a strict budget", async () => {
     const blob = weakEtagBlobClient();
     const store = createVercelBlobPersistentRpcCacheStore(

--- a/tests/stock-paired-read-model.test.ts
+++ b/tests/stock-paired-read-model.test.ts
@@ -12,6 +12,8 @@ import {
   pairStockPairedLaunches,
   readStockPairedEvents,
 } from "../lib/onchain/stock-paired-read-model";
+import { PersistentRpcCacheError } from
+  "../lib/onchain/persistent-rpc-cache.server";
 import type {
   ExploreReadModel,
   ReadyOnchainDeployment,
@@ -108,6 +110,31 @@ describe("Stock-Paired event scan", () => {
       if (firstRequest) {
         firstRequest = false;
         throw new LimitExceededRpcError(new Error("too many results"));
+      }
+      return [];
+    });
+    await expect(
+      readStockPairedEvents(
+        { getLogs } as unknown as PublicClient,
+        readyDeployment,
+        release,
+        1_099n,
+        100n,
+      ),
+    ).resolves.toMatchObject({ launches: [], volumes: new Map() });
+    expect(getLogs).toHaveBeenCalledTimes(9);
+  });
+
+  it("bisects the complete Stock range when its durable segment exceeds the byte cap", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const release = stockPairedReleaseFixture();
+    let firstRequest = true;
+    const getLogs = vi.fn(async () => {
+      if (firstRequest) {
+        firstRequest = false;
+        throw new PersistentRpcCacheError(
+          "Persistent RPC cache log segment exceeds 4194304 bytes",
+        );
       }
       return [];
     });


### PR DESCRIPTION
Fixes the exact staged durable-refresh failure on the measured Classic fee stream.

- bisects only the fixed `PersistentRpcCacheError` segment-size category
- retains the 4 MiB per-segment cap
- raises the bounded cursor/replay budget from 8 to 16 segments (64 MiB maximum)
- preserves complete two-provider fingerprints and all fail-closed cache errors

Measured read-only mainnet evidence: 58,109 canonical fee/claim logs, 42.30 MiB total, maximum 1,000-block result 5.56 MiB.

Validation: 707 focused/ops tests, typecheck, ESLint, 41/41 ops source gates, diff-check, staged gitleaks.