### PR TITLE
Prewarm staged Classic event caches

### DIFF
--- a/app/api/ops/index-v2/route.ts
+++ b/app/api/ops/index-v2/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import {
   getWebsiteReadOnchainDeployment,
+  prewarmClassicEventCache,
   readLiveExploreModel,
   writeDurableExploreModel,
 } from "../../../../lib/onchain";
@@ -99,6 +100,19 @@ export async function GET(request: NextRequest) {
 
   const startedAt = Date.now();
   try {
+    const phaseValues = request.nextUrl.searchParams.getAll("phase");
+    const queryKeys = [...request.nextUrl.searchParams.keys()];
+    const phase = phaseValues[0] ?? "refresh";
+    if (
+      queryKeys.some((key) => key !== "phase") ||
+      phaseValues.length > 1 ||
+      !["refresh", "classic-primary", "classic-secondary"].includes(phase)
+    ) {
+      return NextResponse.json(
+        { error: "Invalid index refresh phase" },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
     const deployment = getWebsiteReadOnchainDeployment("production");
     if (deployment.status !== "ready") {
       throw new Error(
@@ -106,6 +120,23 @@ export async function GET(request: NextRequest) {
       );
     }
     const durableRefreshDeployment = historicalReadOnchainDeployment(deployment);
+    if (phase === "classic-primary" || phase === "classic-secondary") {
+      const result = await withIndexRefreshDeadline(() =>
+        prewarmClassicEventCache(
+          durableRefreshDeployment,
+          phase === "classic-primary" ? "primary" : "secondary",
+        )
+      );
+      console.info("Programmable classic event cache prewarm completed", {
+        phase,
+        blockNumber: result.blockNumber,
+        durationMs: Date.now() - startedAt,
+      });
+      return NextResponse.json(
+        { ok: true, phase, ...result },
+        { headers: { "Cache-Control": "no-store" } },
+      );
+    }
     const model = await withIndexRefreshDeadline(() =>
       readLiveExploreModel(durableRefreshDeployment),
     );

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -5,11 +5,11 @@
     "schedule": "*/5 * * * *",
     "retainedUntil": "indexed-read-cutover",
     "route": "app/api/ops/index-v2/route.ts",
-    "sha256": "763f093b6138bbb7bfaa175f2192798cabd9debbca641f4aefd14d59aff9ff55",
+    "sha256": "c3096ba966fe940e695c6b347dbbedcb7f568352de429a7abd18bf506c7fd26d",
     "boundedRefresh": {
       "runtime": {
         "path": "lib/onchain/read-model.ts",
-        "sha256": "76e5c5a6bebb697e842572a730e38e3423d6448f661119a2b31a0760b64ace58"
+        "sha256": "41cc8023775c09a3ca48825f1e19c2f6342f6c4b04855803b15ca3d77be6fa69"
       },
       "dependencies": [
         {

--- a/lib/onchain/index.ts
+++ b/lib/onchain/index.ts
@@ -6,6 +6,7 @@ export {
   getWebsiteReadOnchainDeployment,
 } from "./config";
 export {
+  prewarmClassicEventCache,
   readExploreModel,
   readLiveExploreModel,
 } from "./read-model";

--- a/lib/onchain/read-model.ts
+++ b/lib/onchain/read-model.ts
@@ -1002,6 +1002,95 @@ async function readReadyModel(
   };
 }
 
+export type ClassicEventCacheProvider = "primary" | "secondary";
+
+export async function prewarmClassicEventCache(
+  config: OnchainDeployment,
+  provider: ClassicEventCacheProvider,
+) {
+  if (config.status !== "ready") {
+    throw new Error("Classic event cache prewarm requires a ready deployment");
+  }
+  const providerEndpoints = [
+    config.rpcUrl,
+    ...(config.rpcUrlSecondary ? [config.rpcUrlSecondary] : []),
+  ];
+  if (providerEndpoints.length !== 2) {
+    throw new Error("Classic event cache prewarm requires two independent RPCs");
+  }
+  const clients = providerEndpoints.map((endpoint, index) =>
+    index === 0
+      ? createOnchainClient(config)
+      : createOnchainClient(config, endpoint)
+  );
+  const chainStates = await withReadStage("classic-prewarm-chain-heads", () =>
+    mapInBatches(
+      clients,
+      RPC_PROVENANCE_BATCH_SIZE,
+      async (candidate) => ({
+        chainId: await candidate.getChainId(),
+        head: await candidate.getBlockNumber(),
+      }),
+    )
+  );
+  if (chainStates.some((state) => state.chainId !== config.chainId)) {
+    throw new Error("RPC chain does not match the deployment manifest");
+  }
+  const head = chainStates.reduce(
+    (lowest, state) => minimum(lowest, state.head),
+    chainStates[0].head,
+  );
+  const toBlock = head > config.confirmations
+    ? head - config.confirmations
+    : 0n;
+  const snapshotBlocks = await withReadStage(
+    "classic-prewarm-snapshot-blocks",
+    () =>
+      mapInBatches(
+        clients,
+        RPC_PROVENANCE_BATCH_SIZE,
+        (candidate) => candidate.getBlock({ blockNumber: toBlock }),
+      ),
+  );
+  const snapshotBlock = snapshotBlocks[0];
+  if (
+    !snapshotBlock.hash ||
+    snapshotBlocks.some(
+      (block) =>
+        !block.hash ||
+        block.hash.toLowerCase() !== snapshotBlock.hash?.toLowerCase(),
+    )
+  ) {
+    throw new Error(
+      "Independent RPCs disagree on the confirmed snapshot block",
+    );
+  }
+  if (toBlock >= config.deploymentBlock) {
+    const providerIndex = provider === "primary" ? 0 : 1;
+    await withReadStage(`classic-prewarm-${provider}`, () =>
+      withPersistentRpcIntegrityScope(
+        () => indexVerifiedEvents(clients[providerIndex], config, toBlock),
+        {
+          checkpointGroup: [
+            "classic-events",
+            config.chainId,
+            config.deploymentBlock.toString(),
+            config.launcher.toLowerCase(),
+            config.feeHook.toLowerCase(),
+            persistentRpcProviderId(providerEndpoints[providerIndex]),
+          ].join(":"),
+          expectedCursorBindings: 2,
+        },
+      )
+    );
+  }
+  return {
+    provider,
+    blockNumber: toBlock.toString(),
+    blockHash: snapshotBlock.hash,
+  };
+}
+
 type ReadyExploreModel = Extract<ExploreReadModel, { status: "ready" }>;
 
 function launchIdentity(token: LauncherToken) {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -10,11 +10,11 @@ const APPROVED_OPERATIONS = Object.freeze({
     schedule: "*/5 * * * *",
     retainedUntil: "indexed-read-cutover",
     route: "app/api/ops/index-v2/route.ts",
-    sha256: "763f093b6138bbb7bfaa175f2192798cabd9debbca641f4aefd14d59aff9ff55",
+    sha256: "c3096ba966fe940e695c6b347dbbedcb7f568352de429a7abd18bf506c7fd26d",
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
-        sha256: "76e5c5a6bebb697e842572a730e38e3423d6448f661119a2b31a0760b64ace58",
+        sha256: "41cc8023775c09a3ca48825f1e19c2f6342f6c4b04855803b15ca3d77be6fa69",
       }),
       dependencies: Object.freeze([
         Object.freeze({
@@ -835,6 +835,9 @@ export const STAGED_DURABLE_REFRESH_SOURCE_GUARDS = Object.freeze([
   "Authorization: `Bearer ${input.cronSecret}`",
   '"x-vercel-protection-bypass": input.automationBypassSecret',
   'redirect: "error"',
+  'const PREWARM_PHASES = ["classic-primary", "classic-secondary"]',
+  'prewarmUrl.searchParams.set("phase", phase)',
+  "if (!exactPrewarmResponse(prewarm, phase)) {",
   "if (!exactRefreshResponse(refresh)) {",
   'value.body.indexSource === "durable"',
   'value.body.indexedReadModel?.status === "disabled"',
@@ -847,7 +850,7 @@ export const STAGED_DURABLE_REFRESH_SOURCE_GUARDS = Object.freeze([
   '"stage_refresh_proof"',
 ]);
 const STAGED_DURABLE_REFRESH_SCRIPT_SHA256 =
-  "989495b90b8f8ebb549da1e869116d9dc3373567d8bff721285ced702271d68e";
+  "2f0f7d575b5d8bd34ae8a5fc3cec3ad775d097171ae903c9aa6c4f3ce2cb5385";
 const STAGED_DURABLE_REFRESH_WORKFLOW_STEP = [
   "      - name: Refresh and prove exact staged durable read model",
   "        if: needs.release-gate.outputs.verified_read_model == 'true'",

--- a/scripts/perf/read-model-staged-refresh.mjs
+++ b/scripts/perf/read-model-staged-refresh.mjs
@@ -12,6 +12,7 @@ const MAXIMUM_FRESH_AGE_SECONDS = 10 * 60;
 const CANONICAL_UINT = /^(?:0|[1-9][0-9]{0,77})$/u;
 const HEX32 = /^0x[0-9a-f]{64}$/u;
 const MAXIMUM_UINT64 = (1n << 64n) - 1n;
+const PREWARM_PHASES = ["classic-primary", "classic-secondary"];
 
 function argumentsFrom(argv) {
   const result = {};
@@ -149,6 +150,23 @@ function exactRefreshResponse(value) {
   );
 }
 
+function exactPrewarmResponse(value, phase) {
+  const provider = phase === "classic-primary" ? "primary" : "secondary";
+  return (
+    value.response.status === 200 &&
+    value.response.headers
+      .get("cache-control")
+      ?.toLowerCase()
+      .includes("no-store") === true &&
+    value.body?.ok === true &&
+    value.body.phase === phase &&
+    value.body.provider === provider &&
+    CANONICAL_UINT.test(value.body.blockNumber) &&
+    HEX32.test(value.body.blockHash) &&
+    value.body.blockHash !== `0x${"00".repeat(32)}`
+  );
+}
+
 function exactHealthProof(value, refresh) {
   const index = value.body?.index;
   const rpc = value.body?.rpc;
@@ -247,16 +265,33 @@ export async function refreshExactStagedReadModel(input) {
     throw new Error("exact staged deployment binding verification failed");
   }
 
+  const protectedHeaders = {
+    Accept: "application/json",
+    Authorization: `Bearer ${input.cronSecret}`,
+    "Cache-Control": "no-cache",
+    "User-Agent": "programmable-staged-read-model-refresh/1",
+    "x-vercel-protection-bypass": input.automationBypassSecret,
+  };
+  for (const phase of PREWARM_PHASES) {
+    const prewarmUrl = new URL(REFRESH_PATH, target);
+    prewarmUrl.searchParams.set("phase", phase);
+    const prewarm = await requestJson(
+      fetchImpl,
+      prewarmUrl,
+      protectedHeaders,
+      330_000,
+    );
+    if (!exactPrewarmResponse(prewarm, phase)) {
+      throw new Error(
+        `exact staged ${phase} prewarm failed (${prewarm.response.status})`,
+      );
+    }
+  }
+
   const refresh = await requestJson(
     fetchImpl,
     new URL(REFRESH_PATH, target),
-    {
-      Accept: "application/json",
-      Authorization: `Bearer ${input.cronSecret}`,
-      "Cache-Control": "no-cache",
-      "User-Agent": "programmable-staged-read-model-refresh/1",
-      "x-vercel-protection-bypass": input.automationBypassSecret,
-    },
+    protectedHeaders,
     330_000,
   );
   if (!exactRefreshResponse(refresh)) {

--- a/tests/data-pipeline/legacy-index-ops-route.test.ts
+++ b/tests/data-pipeline/legacy-index-ops-route.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getOperationalOnchainDeployment: vi.fn(),
   historicalReadOnchainDeployment: vi.fn(),
+  prewarmClassicEventCache: vi.fn(),
   readLiveExploreModel: vi.fn(),
   writeDurableExploreModel: vi.fn(),
   writePortfolioHistorySnapshot: vi.fn(),
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../../lib/onchain", () => ({
   getWebsiteReadOnchainDeployment: mocks.getOperationalOnchainDeployment,
+  prewarmClassicEventCache: mocks.prewarmClassicEventCache,
   readLiveExploreModel: mocks.readLiveExploreModel,
   writeDurableExploreModel: mocks.writeDurableExploreModel,
 }));
@@ -57,6 +59,13 @@ describe("legacy index operations routes", () => {
       durableRefreshDeployment,
     );
     mocks.readLiveExploreModel.mockResolvedValue({ status: "ready" });
+    mocks.prewarmClassicEventCache.mockImplementation(
+      async (_deployment, provider: "primary" | "secondary") => ({
+        provider,
+        blockNumber: "25600000",
+        blockHash: `0x${"11".repeat(32)}`,
+      }),
+    );
     mocks.writeDurableExploreModel.mockResolvedValue({
       blockNumber: "25600000",
       tokenCount: 265,
@@ -120,6 +129,48 @@ describe("legacy index operations routes", () => {
       { status: "ready" },
     );
     expect(mocks.writePortfolioHistorySnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["classic-primary", "primary"],
+    ["classic-secondary", "secondary"],
+  ] as const)(
+    "prewarms the exact %s event cache without publishing a model",
+    async (phase, provider) => {
+      vi.spyOn(console, "info").mockImplementation(() => undefined);
+      const response = await getCanonicalIndex(
+        new NextRequest(
+          `https://programmable.family/api/ops/index-v2?phase=${phase}`,
+          { headers: { authorization: `Bearer ${SECRET}` } },
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        ok: true,
+        phase,
+        provider,
+        blockNumber: "25600000",
+      });
+      expect(mocks.prewarmClassicEventCache).toHaveBeenCalledWith(
+        durableRefreshDeployment,
+        provider,
+      );
+      expect(mocks.readLiveExploreModel).not.toHaveBeenCalled();
+      expect(mocks.writeDurableExploreModel).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects malformed prewarm phases before reading providers", async () => {
+    const response = await getCanonicalIndex(
+      new NextRequest(
+        "https://programmable.family/api/ops/index-v2?phase=classic-primary&phase=classic-secondary",
+        { headers: { authorization: `Bearer ${SECRET}` } },
+      ),
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.getOperationalOnchainDeployment).not.toHaveBeenCalled();
+    expect(mocks.prewarmClassicEventCache).not.toHaveBeenCalled();
   });
 
   it("fails fast after one full read failure without starting a write", async () => {

--- a/tests/data-pipeline/read-model-staged-refresh.test.ts
+++ b/tests/data-pipeline/read-model-staged-refresh.test.ts
@@ -51,6 +51,20 @@ function refreshFixture(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function prewarmFixture(
+  phase: "classic-primary" | "classic-secondary",
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    ok: true,
+    phase,
+    provider: phase === "classic-primary" ? "primary" : "secondary",
+    blockNumber: BLOCK_NUMBER,
+    blockHash: BLOCK_HASH,
+    ...overrides,
+  };
+}
+
 function healthFixture(overrides: Record<string, unknown> = {}) {
   return {
     status: "healthy",
@@ -106,6 +120,13 @@ function stagedFetch(
       url.origin === new URL(TARGET_URL).origin &&
       url.pathname === "/api/ops/index-v2"
     ) {
+      const phase = url.searchParams.get("phase");
+      if (phase === "classic-primary" || phase === "classic-secondary") {
+        return Response.json(prewarmFixture(phase), {
+          status: 200,
+          headers: { "cache-control": "no-store" },
+        });
+      }
       return Response.json(input.refreshBody ?? refreshFixture(), {
         status: input.refreshStatus ?? 200,
         headers: { "cache-control": "no-store" },
@@ -166,16 +187,20 @@ describe("exact staged durable refresh runtime", () => {
     expect(requests.map(({ url }) => url.pathname)).toEqual([
       `/v13/deployments/${new URL(TARGET_URL).hostname}`,
       "/api/ops/index-v2",
+      "/api/ops/index-v2",
+      "/api/ops/index-v2",
       "/api/ops/health",
     ]);
-    const refreshRequest = requests[1]!;
+    expect(requests.slice(1, 3).map(({ url }) => url.searchParams.get("phase")))
+      .toEqual(["classic-primary", "classic-secondary"]);
+    const refreshRequest = requests[3]!;
     expect(refreshRequest.headers.get("authorization")).toBe(
       `Bearer ${CRON_SECRET}`,
     );
     expect(refreshRequest.headers.get("x-vercel-protection-bypass")).toBe(
       AUTOMATION_BYPASS_SECRET,
     );
-    const healthRequest = requests[2]!;
+    const healthRequest = requests[4]!;
     expect(healthRequest.headers.get("authorization")).toBeNull();
     expect(healthRequest.url.searchParams.get("stage_refresh_proof")).toBe(
       `${GIT_HEAD}-${DEPLOYMENT_ID}`,


### PR DESCRIPTION
Splits the staged cold Classic event-cache seed into exact primary and secondary authorized prewarm requests before the unchanged full two-RPC refresh. Each prewarm selects a head and block hash agreed by both archive RPCs and commits only a complete provider cache scope. The final refresh still requires full provider fingerprint agreement, durable publication, health, market smoke, and handoff gates.\n\nLocal: typecheck; 788 focused tests; ESLint; ops source gate 41/41; diff check; gitleaks.