### PR TITLE
Add fail-closed Custom Registry V2 public surface

### DIFF
--- a/app/api/custom-launch/generic/v2/launches/[recordHash]/route.ts
+++ b/app/api/custom-launch/generic/v2/launches/[recordHash]/route.ts
@@ -1,0 +1,14 @@
+import { handleProductionGenericLaunchDetailV2 } from
+  "@/lib/server/custom-launch/generic-launch-read-v2";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 10;
+export const runtime = "nodejs";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ recordHash: string }> },
+) {
+  const { recordHash } = await context.params;
+  return handleProductionGenericLaunchDetailV2(request, recordHash);
+}

--- a/app/api/custom-launch/generic/v2/launches/route.ts
+++ b/app/api/custom-launch/generic/v2/launches/route.ts
@@ -1,0 +1,8 @@
+import { handleProductionGenericLaunchFeedV2 } from
+  "@/lib/server/custom-launch/generic-launch-read-v2";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 10;
+export const runtime = "nodejs";
+
+export const GET = handleProductionGenericLaunchFeedV2;

--- a/app/api/custom-launch/registry/v2/manifest/route.ts
+++ b/app/api/custom-launch/registry/v2/manifest/route.ts
@@ -1,0 +1,9 @@
+import { handleProductionCustomRegistryManifestV2 } from
+  "@/lib/server/custom-launch/registry-manifest-v2";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export function GET(request: Request): Response {
+  return handleProductionCustomRegistryManifestV2(request);
+}

--- a/app/api/custom-launch/registry/v2/readiness/route.ts
+++ b/app/api/custom-launch/registry/v2/readiness/route.ts
@@ -1,0 +1,10 @@
+import { handleProductionCustomRegistryReadinessV2 } from
+  "@/lib/server/custom-launch/registry-manifest-v2";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 10;
+export const runtime = "nodejs";
+
+export function GET(request: Request): Promise<Response> {
+  return handleProductionCustomRegistryReadinessV2(request);
+}

--- a/config/generic-launch-public.v2.schema.json
+++ b/config/generic-launch-public.v2.schema.json
@@ -1,0 +1,461 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://programmable.market/schemas/generic-launch-public.v2.schema.json",
+  "$ref": "#/$defs/genericLaunchRecord",
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "hash32": {
+      "type": "string",
+      "pattern": "^0x(?!0{64}$)[0-9a-f]{64}$"
+    },
+    "address": {
+      "type": "string",
+      "pattern": "^0x(?!0{40}$)[0-9a-f]{40}$"
+    },
+    "decimal": {
+      "type": "string",
+      "pattern": "^(?:0|[1-9][0-9]{0,77})$"
+    },
+    "positiveDecimal": {
+      "type": "string",
+      "pattern": "^[1-9][0-9]{0,77}$"
+    },
+    "gitObjectId": {
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+    },
+    "registryEventEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eventName",
+        "transactionHash",
+        "blockHash",
+        "blockNumber",
+        "transactionIndex",
+        "logIndex",
+        "removed"
+      ],
+      "properties": {
+        "eventName": { "type": "string", "minLength": 1 },
+        "transactionHash": { "$ref": "#/$defs/hash32" },
+        "blockHash": { "$ref": "#/$defs/hash32" },
+        "blockNumber": { "$ref": "#/$defs/decimal" },
+        "transactionIndex": { "$ref": "#/$defs/decimal" },
+        "logIndex": { "$ref": "#/$defs/decimal" },
+        "removed": { "const": false }
+      }
+    },
+    "approvalAuthorizationEvidence": {
+      "allOf": [
+        { "$ref": "#/$defs/registryEventEvidence" },
+        {
+          "type": "object",
+          "properties": {
+            "eventName": { "const": "CustomLaunchApprovalAuthorizedV2" }
+          }
+        }
+      ]
+    },
+    "registeredEvidence": {
+      "allOf": [
+        { "$ref": "#/$defs/registryEventEvidence" },
+        {
+          "type": "object",
+          "properties": {
+            "eventName": { "const": "CustomLaunchRegisteredV2" }
+          }
+        }
+      ]
+    },
+    "descriptorCommittedEvidence": {
+      "allOf": [
+        { "$ref": "#/$defs/registryEventEvidence" },
+        {
+          "type": "object",
+          "properties": {
+            "eventName": { "const": "CustomLaunchDescriptorCommittedV2" }
+          }
+        }
+      ]
+    },
+    "descriptorEvidenceCommittedEvidence": {
+      "allOf": [
+        { "$ref": "#/$defs/registryEventEvidence" },
+        {
+          "type": "object",
+          "properties": {
+            "eventName": {
+              "const": "CustomLaunchDescriptorEvidenceCommittedV2"
+            }
+          }
+        }
+      ]
+    },
+    "finalizedEvidence": {
+      "allOf": [
+        { "$ref": "#/$defs/registryEventEvidence" },
+        {
+          "type": "object",
+          "properties": {
+            "eventName": { "const": "CustomLaunchFinalizedV2" }
+          }
+        }
+      ]
+    },
+    "genericLaunchSourceProjection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "sourceRevision",
+        "approval",
+        "descriptor",
+        "lifecycle"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.generic-launch-source-projection.v2"
+        },
+        "sourceRevision": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "repositoryId",
+            "repositoryFullName",
+            "commitObjectId",
+            "treeObjectId"
+          ],
+          "properties": {
+            "repositoryId": { "$ref": "#/$defs/positiveDecimal" },
+            "repositoryFullName": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}$"
+            },
+            "commitObjectId": { "$ref": "#/$defs/gitObjectId" },
+            "treeObjectId": { "$ref": "#/$defs/gitObjectId" }
+          }
+        },
+        "approval": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "approvalRevision",
+            "approvalId",
+            "approvalEvidenceHash",
+            "signedReceiptArtifactHash"
+          ],
+          "properties": {
+            "approvalRevision": { "$ref": "#/$defs/positiveDecimal" },
+            "approvalId": { "$ref": "#/$defs/hash32" },
+            "approvalEvidenceHash": { "$ref": "#/$defs/hash32" },
+            "signedReceiptArtifactHash": { "$ref": "#/$defs/sha256" }
+          }
+        },
+        "descriptor": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "descriptorHash",
+            "launchId",
+            "launchWallet",
+            "primaryContract",
+            "primaryRuntimeCodeHash",
+            "componentSetHash",
+            "sourceArtifactHash",
+            "configurationHash",
+            "launchPlanHash",
+            "projectCommitment",
+            "marketMode",
+            "marketModeValue",
+            "protocolFeeBps"
+          ],
+          "properties": {
+            "descriptorHash": { "$ref": "#/$defs/hash32" },
+            "launchId": { "$ref": "#/$defs/hash32" },
+            "launchWallet": { "$ref": "#/$defs/address" },
+            "primaryContract": { "$ref": "#/$defs/address" },
+            "primaryRuntimeCodeHash": { "$ref": "#/$defs/hash32" },
+            "componentSetHash": { "$ref": "#/$defs/hash32" },
+            "sourceArtifactHash": { "$ref": "#/$defs/hash32" },
+            "configurationHash": { "$ref": "#/$defs/hash32" },
+            "launchPlanHash": { "$ref": "#/$defs/hash32" },
+            "projectCommitment": { "$ref": "#/$defs/hash32" },
+            "marketMode": { "enum": ["NoMarket0", "Standard10"] },
+            "marketModeValue": { "enum": [0, 1] },
+            "protocolFeeBps": { "enum": [0, 10] }
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "marketMode": { "const": "NoMarket0" },
+                "marketModeValue": { "const": 0 },
+                "protocolFeeBps": { "const": 0 }
+              }
+            },
+            {
+              "properties": {
+                "marketMode": { "const": "Standard10" },
+                "marketModeValue": { "const": 1 },
+                "protocolFeeBps": { "const": 10 }
+              }
+            }
+          ]
+        },
+        "lifecycle": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "chainId",
+            "generation",
+            "registryAddress",
+            "registryRuntimeCodeKeccak256",
+            "registryPolicyCommitment",
+            "minimumFinalityBlocks",
+            "primaryLaunch",
+            "authorization",
+            "registration",
+            "finalization",
+            "latestCommonHead",
+            "latestCommonHeadHash",
+            "latestStatus",
+            "revokedAtBlock",
+            "revocationEvidenceHash"
+          ],
+          "properties": {
+            "chainId": { "const": "1" },
+            "generation": { "const": "2" },
+            "registryAddress": { "$ref": "#/$defs/address" },
+            "registryRuntimeCodeKeccak256": { "$ref": "#/$defs/hash32" },
+            "registryPolicyCommitment": { "$ref": "#/$defs/hash32" },
+            "minimumFinalityBlocks": { "$ref": "#/$defs/positiveDecimal" },
+            "primaryLaunch": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "transactionHash",
+                "sender",
+                "blockHash",
+                "blockNumber",
+                "transactionIndex",
+                "status"
+              ],
+              "properties": {
+                "transactionHash": { "$ref": "#/$defs/hash32" },
+                "sender": { "$ref": "#/$defs/address" },
+                "blockHash": { "$ref": "#/$defs/hash32" },
+                "blockNumber": { "$ref": "#/$defs/decimal" },
+                "transactionIndex": { "$ref": "#/$defs/decimal" },
+                "status": { "const": "success" }
+              }
+            },
+            "authorization": {
+              "$ref": "#/$defs/approvalAuthorizationEvidence"
+            },
+            "registration": {
+              "type": "array",
+              "prefixItems": [
+                { "$ref": "#/$defs/registeredEvidence" },
+                { "$ref": "#/$defs/descriptorCommittedEvidence" },
+                { "$ref": "#/$defs/descriptorEvidenceCommittedEvidence" }
+              ],
+              "items": false,
+              "minItems": 3,
+              "maxItems": 3
+            },
+            "finalization": { "$ref": "#/$defs/finalizedEvidence" },
+            "latestCommonHead": { "$ref": "#/$defs/decimal" },
+            "latestCommonHeadHash": { "$ref": "#/$defs/hash32" },
+            "latestStatus": { "const": "finalized" },
+            "revokedAtBlock": { "const": "0" },
+            "revocationEvidenceHash": {
+              "const": "0x0000000000000000000000000000000000000000000000000000000000000000"
+            }
+          }
+        }
+      }
+    },
+    "genericLaunchRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "sourceProjection",
+        "sourceProjectionHash",
+        "readModelBindingHash",
+        "recordHash"
+      ],
+      "properties": {
+        "schemaVersion": { "const": "programmable.generic-launch-record.v2" },
+        "sourceProjection": {
+          "$ref": "#/$defs/genericLaunchSourceProjection"
+        },
+        "sourceProjectionHash": { "$ref": "#/$defs/sha256" },
+        "readModelBindingHash": { "$ref": "#/$defs/sha256" },
+        "recordHash": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "genericLaunchFeed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "records",
+        "nextCursor",
+        "total"
+      ],
+      "properties": {
+        "schemaVersion": { "const": "programmable.generic-launch-feed.v2" },
+        "records": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/genericLaunchRecord" },
+          "maxItems": 100
+        },
+        "nextCursor": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]{1,1024}$"
+            }
+          ]
+        },
+        "total": { "$ref": "#/$defs/decimal" }
+      }
+    },
+    "genericLaunchView": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "record"],
+      "properties": {
+        "schemaVersion": { "const": "programmable.generic-launch-view.v2" },
+        "record": { "$ref": "#/$defs/genericLaunchRecord" }
+      }
+    },
+    "genericLaunchReadModelContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "sourceLane",
+        "implementationBindingHash",
+        "persistenceBindingHash",
+        "queryContractBindingHash",
+        "approvalArtifactSchemaBindingHash",
+        "approvalReleaseBindingHash",
+        "registryProjectionBindingHash"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.generic-launch-read-model-contract.v2"
+        },
+        "sourceLane": { "const": "generic.finalized-launch-v2" },
+        "implementationBindingHash": { "$ref": "#/$defs/sha256" },
+        "persistenceBindingHash": { "$ref": "#/$defs/sha256" },
+        "queryContractBindingHash": { "$ref": "#/$defs/sha256" },
+        "approvalArtifactSchemaBindingHash": { "$ref": "#/$defs/sha256" },
+        "approvalReleaseBindingHash": { "$ref": "#/$defs/sha256" },
+        "registryProjectionBindingHash": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "genericLaunchReadBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "activationBindingHash",
+        "activatedAt",
+        "readModelBindingHash",
+        "readModelVerifier",
+        "registryIdentity",
+        "api"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.generic-launch-read-binding.v2"
+        },
+        "activationBindingHash": { "$ref": "#/$defs/sha256" },
+        "activatedAt": { "type": "string", "format": "date-time" },
+        "readModelBindingHash": { "$ref": "#/$defs/sha256" },
+        "readModelVerifier": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "algorithm",
+            "publicKeySpkiBase64Url",
+            "publicKeySha256"
+          ],
+          "properties": {
+            "algorithm": { "const": "ed25519" },
+            "publicKeySpkiBase64Url": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]+$"
+            },
+            "publicKeySha256": { "$ref": "#/$defs/sha256" }
+          }
+        },
+        "registryIdentity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "chainId",
+            "generation",
+            "registryAddress",
+            "registryRuntimeCodeKeccak256",
+            "registryPolicyCommitment",
+            "minimumFinalityBlocks"
+          ],
+          "properties": {
+            "chainId": { "const": "1" },
+            "generation": { "const": "2" },
+            "registryAddress": { "$ref": "#/$defs/address" },
+            "registryRuntimeCodeKeccak256": { "$ref": "#/$defs/hash32" },
+            "registryPolicyCommitment": { "$ref": "#/$defs/hash32" },
+            "minimumFinalityBlocks": { "$ref": "#/$defs/positiveDecimal" }
+          }
+        },
+        "api": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["feedPath", "detailPathTemplate"],
+          "properties": {
+            "feedPath": {
+              "const": "/api/custom-launch/generic/v2/launches"
+            },
+            "detailPathTemplate": {
+              "const": "/api/custom-launch/generic/v2/launches/{recordHash}"
+            }
+          }
+        }
+      }
+    },
+    "signedGenericLaunchReadEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "activationBindingHash",
+        "readModelBindingHash",
+        "requestBindingHash",
+        "payload",
+        "signatureBase64Url"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "programmable.signed-generic-launch-read-envelope.v2"
+        },
+        "activationBindingHash": { "$ref": "#/$defs/sha256" },
+        "readModelBindingHash": { "$ref": "#/$defs/sha256" },
+        "requestBindingHash": { "$ref": "#/$defs/sha256" },
+        "payload": true,
+        "signatureBase64Url": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]{86}$"
+        }
+      }
+    }
+  }
+}

--- a/lib/custom-launch/registry-public-manifest-v2.ts
+++ b/lib/custom-launch/registry-public-manifest-v2.ts
@@ -1,0 +1,101 @@
+export const CUSTOM_REGISTRY_PUBLIC_MANIFEST_PATH_V2 =
+  "/api/custom-launch/registry/v2/manifest" as const;
+
+export const CUSTOM_REGISTRY_PUBLIC_READINESS_PATH_V2 =
+  "/api/custom-launch/registry/v2/readiness" as const;
+
+export type CustomRegistryV2DeploymentEvidence = Readonly<{
+  address: `0x${string}`;
+  runtimeCodeKeccak256: `0x${string}`;
+  deploymentTransactionHash: `0x${string}`;
+  deploymentBlock: string;
+  deploymentBlockHash: `0x${string}`;
+}>;
+
+export type CustomRegistryV2ReleaseEvidence = Readonly<{
+  sourceCommit: string;
+  sourceTree: string;
+  sourceArtifactSha256: `sha256:${string}`;
+  abiArtifactSha256: `sha256:${string}`;
+  eventSetSha256: `sha256:${string}`;
+}>;
+
+export type CustomRegistryV2FinalityBinding = Readonly<{
+  minimumConfirmations: string;
+  policyBindingHash: `0x${string}`;
+}>;
+
+type CustomRegistryPublicManifestBaseV2 = Readonly<{
+  schemaVersion: "programmable.custom-registry-public-manifest.v2";
+  generation: "2";
+  chainId: "1";
+  caip2: "eip155:1";
+}>;
+
+export type CustomRegistryPrelaunchPublicManifestV2 =
+  CustomRegistryPublicManifestBaseV2 & Readonly<{
+    status: "prelaunch";
+    publicReadEnabled: false;
+    indexingEnabled: false;
+    registry: Readonly<{
+      address: null;
+      runtimeCodeKeccak256: null;
+      deploymentTransactionHash: null;
+      deploymentBlock: null;
+      deploymentBlockHash: null;
+    }>;
+    release: Readonly<{
+      sourceCommit: null;
+      sourceTree: null;
+      sourceArtifactSha256: null;
+      abiArtifactSha256: null;
+      eventSetSha256: null;
+    }>;
+    finality: Readonly<{
+      minimumConfirmations: null;
+      policyBindingHash: null;
+    }>;
+  }>;
+
+export type CustomRegistryLivePublicManifestV2 =
+  CustomRegistryPublicManifestBaseV2 & Readonly<{
+    status: "live";
+    publicReadEnabled: true;
+    indexingEnabled: true;
+    registry: CustomRegistryV2DeploymentEvidence;
+    release: CustomRegistryV2ReleaseEvidence;
+    finality: CustomRegistryV2FinalityBinding;
+  }>;
+
+export type CustomRegistryPublicManifestV2 =
+  | CustomRegistryPrelaunchPublicManifestV2
+  | CustomRegistryLivePublicManifestV2;
+
+export const PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V2:
+CustomRegistryPublicManifestV2 = Object.freeze({
+  schemaVersion: "programmable.custom-registry-public-manifest.v2",
+  status: "prelaunch",
+  generation: "2",
+  chainId: "1",
+  caip2: "eip155:1",
+  publicReadEnabled: false,
+  indexingEnabled: false,
+  registry: Object.freeze({
+    address: null,
+    runtimeCodeKeccak256: null,
+    deploymentTransactionHash: null,
+    deploymentBlock: null,
+    deploymentBlockHash: null,
+  }),
+  release: Object.freeze({
+    sourceCommit: null,
+    sourceTree: null,
+    sourceArtifactSha256: null,
+    abiArtifactSha256: null,
+    eventSetSha256: null,
+  }),
+  finality: Object.freeze({
+    minimumConfirmations: null,
+    policyBindingHash: null,
+  }),
+});

--- a/lib/server/custom-launch/approval-runtime-readiness-v1.ts
+++ b/lib/server/custom-launch/approval-runtime-readiness-v1.ts
@@ -1,0 +1,443 @@
+import "server-only";
+
+import {
+  createHash,
+  createPublicKey,
+  randomBytes,
+  verify as verifySignature,
+} from "node:crypto";
+
+import { isReviewAuthorityModeV1 } from
+  "@/lib/custom-launch/review-authority-v1";
+import {
+  canonicalizeJson,
+  parseStrictJson,
+} from "../projection-target/canonical-json";
+
+export const APPROVAL_RUNTIME_AGGREGATE_PATH_V1 =
+  "/readyz/custom-launch/v2" as const;
+export const APPROVAL_RUNTIME_AGGREGATE_AUDIENCE_V1 =
+  "programmable.website.custom-launch.v2" as const;
+export const APPROVAL_DESCRIPTOR_AUDIENCE_V2 =
+  "programmable.custom-registry.v2" as const;
+
+const RESPONSE_SCHEMA =
+  "programmable.approval-runtime-aggregate-readiness.v1" as const;
+const SIGNATURE_SCHEMA =
+  "programmable.approval-runtime-aggregate-readiness-signature.v1" as const;
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/+\-]{0,255}$/u;
+const POSITIVE_EPOCH = /^[1-9][0-9]{0,19}$/u;
+const SHA256 = /^sha256:[0-9a-f]{64}$/u;
+const HASH32 = /^0x[0-9a-f]{64}$/u;
+const GIT_OBJECT_ID = /^[0-9a-f]{40}$/u;
+const BASE64URL = /^[A-Za-z0-9_-]+$/u;
+const SIGNATURE = /^[A-Za-z0-9_-]{86}$/u;
+const MAXIMUM_RESPONSE_BYTES = 65_536;
+const REQUEST_TIMEOUT_MS = 5_000;
+const MAXIMUM_CLOCK_SKEW_MS = 5_000;
+const MAXIMUM_ATTESTATION_LIFETIME_MS = 60_000;
+
+export type ApprovalRuntimeServiceBindingV1 = Readonly<{
+  serviceId: string;
+  deploymentId: string;
+  imageDigest: `sha256:${string}`;
+  configurationBindingHash: `sha256:${string}`;
+  status: "ready";
+}>;
+
+export type ExpectedApprovalRuntimeAggregateBindingV1 = Readonly<{
+  packageArtifactHash: `sha256:${string}`;
+  sourceCommit: string;
+  sourceTree: string;
+  reviewAuthorityMode: "manual_review" | "autonomous_ai";
+  policyCommitment: `0x${string}`;
+  acceptanceSchemaSha256: `sha256:${string}`;
+  descriptorAuthority: Readonly<{
+    audience: typeof APPROVAL_DESCRIPTOR_AUDIENCE_V2;
+    keyId: string;
+    keyEpoch: string;
+    publicKeySpkiSha256: `sha256:${string}`;
+  }>;
+  readinessAuthority: Readonly<{
+    algorithm: "ed25519";
+    keyId: string;
+    keyEpoch: string;
+    publicKeySpkiBase64Url: string;
+    publicKeySpkiSha256: `sha256:${string}`;
+  }>;
+  services: readonly ApprovalRuntimeServiceBindingV1[];
+}>;
+
+export async function assertApprovalRuntimeAggregateReadinessV1(input: Readonly<{
+  origin: URL;
+  expected: ExpectedApprovalRuntimeAggregateBindingV1;
+  serviceFetch: typeof fetch;
+  now: () => Date;
+}>): Promise<void> {
+  const origin = exactOrigin(input.origin);
+  parseExpectedBinding(input.expected);
+  const challenge = randomBytes(32).toString("base64url");
+  const url = new URL(APPROVAL_RUNTIME_AGGREGATE_PATH_V1, origin);
+  url.searchParams.set("audience", APPROVAL_RUNTIME_AGGREGATE_AUDIENCE_V1);
+  url.searchParams.set("challenge", challenge);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await input.serviceFetch(url, {
+      method: "GET",
+      headers: { accept: "application/json" },
+      cache: "no-store",
+      credentials: "omit",
+      redirect: "error",
+      signal: controller.signal,
+    });
+    const contentType = response.headers.get("content-type")
+      ?.split(";", 1)[0]?.trim().toLowerCase();
+    const declaredLength = response.headers.get("content-length");
+    if (
+      response.status !== 200
+      || contentType !== "application/json"
+      || (declaredLength !== null && (!/^\d+$/u.test(declaredLength)
+        || Number(declaredLength) > MAXIMUM_RESPONSE_BYTES))
+    ) {
+      await response.body?.cancel();
+      throw new TypeError("Approval aggregate readiness response is invalid");
+    }
+    const raw = await readBoundedResponse(response, MAXIMUM_RESPONSE_BYTES);
+    verifyAggregateReadinessEnvelope(
+      new TextDecoder("utf-8", { fatal: true }).decode(raw),
+      challenge,
+      input.expected,
+      input.now(),
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function verifyAggregateReadinessEnvelope(
+  raw: string,
+  expectedChallenge: string,
+  expectedInput: ExpectedApprovalRuntimeAggregateBindingV1,
+  now: Date,
+): void {
+  if (!BASE64URL.test(expectedChallenge) || expectedChallenge.length !== 43) {
+    throw new TypeError("Approval aggregate readiness challenge is invalid");
+  }
+  const expected = parseExpectedBinding(expectedInput);
+  const parsed = parseStrictJson(raw, {
+    maximumBytes: MAXIMUM_RESPONSE_BYTES,
+    maximumDepth: 16,
+  });
+  if (canonicalizeJson(parsed) !== raw) {
+    throw new TypeError("Approval aggregate readiness response is not canonical");
+  }
+  const value = exactObject(parsed, "Approval aggregate readiness envelope", [
+    "audience", "challengeBase64Url", "checkedAt", "descriptorAuthority",
+    "expiresAt", "readinessAuthority", "release", "schemaVersion", "services",
+    "signatureBase64Url", "status",
+  ]);
+  if (
+    value.schemaVersion !== RESPONSE_SCHEMA
+    || value.audience !== APPROVAL_RUNTIME_AGGREGATE_AUDIENCE_V1
+    || value.challengeBase64Url !== expectedChallenge
+    || value.status !== "ready"
+    || typeof value.signatureBase64Url !== "string"
+    || !SIGNATURE.test(value.signatureBase64Url)
+  ) throw new TypeError("Approval aggregate readiness identity is invalid");
+
+  const checkedAt = instant(value.checkedAt, "checkedAt");
+  const expiresAt = instant(value.expiresAt, "expiresAt");
+  const nowMs = validNow(now);
+  if (
+    checkedAt > nowMs + MAXIMUM_CLOCK_SKEW_MS
+    || checkedAt < nowMs - MAXIMUM_ATTESTATION_LIFETIME_MS
+    || expiresAt < nowMs
+    || expiresAt <= checkedAt
+    || expiresAt - checkedAt > MAXIMUM_ATTESTATION_LIFETIME_MS
+  ) throw new TypeError("Approval aggregate readiness validity is invalid");
+
+  const release = parseRelease(value.release);
+  const descriptorAuthority = parseDescriptorAuthority(value.descriptorAuthority);
+  const readinessAuthority = parseReadinessAuthority(value.readinessAuthority);
+  const services = parseServices(value.services);
+  if (
+    canonicalizeJson(release) !== canonicalizeJson(expected.release)
+    || canonicalizeJson(descriptorAuthority)
+      !== canonicalizeJson(expected.descriptorAuthority)
+    || canonicalizeJson(readinessAuthority.publicIdentity)
+      !== canonicalizeJson(expected.readinessAuthority.publicIdentity)
+    || canonicalizeJson(services) !== canonicalizeJson(expected.services)
+  ) throw new TypeError("Approval aggregate readiness binding is invalid");
+
+  const core = Object.freeze({
+    schemaVersion: RESPONSE_SCHEMA,
+    audience: APPROVAL_RUNTIME_AGGREGATE_AUDIENCE_V1,
+    challengeBase64Url: expectedChallenge,
+    checkedAt: value.checkedAt,
+    expiresAt: value.expiresAt,
+    status: "ready" as const,
+    release,
+    descriptorAuthority,
+    readinessAuthority: readinessAuthority.publicIdentity,
+    services,
+  });
+  const signed = canonicalizeJson(Object.freeze({
+    schemaVersion: SIGNATURE_SCHEMA,
+    payload: core,
+  }));
+  if (!verifySignature(
+    null,
+    Buffer.from(signed, "utf8"),
+    expected.readinessAuthority.publicKey,
+    Buffer.from(value.signatureBase64Url, "base64url"),
+  )) throw new TypeError("Approval aggregate readiness signature is invalid");
+}
+
+function parseExpectedBinding(value: ExpectedApprovalRuntimeAggregateBindingV1) {
+  const object = exactObject(value, "expected Approval aggregate binding", [
+    "acceptanceSchemaSha256", "descriptorAuthority", "packageArtifactHash",
+    "policyCommitment", "readinessAuthority", "reviewAuthorityMode",
+    "services", "sourceCommit", "sourceTree",
+  ]);
+  const release = parseRelease({
+    packageArtifactHash: object.packageArtifactHash,
+    sourceCommit: object.sourceCommit,
+    sourceTree: object.sourceTree,
+    reviewAuthorityMode: object.reviewAuthorityMode,
+    policyCommitment: object.policyCommitment,
+    acceptanceSchemaSha256: object.acceptanceSchemaSha256,
+  });
+  const descriptorAuthority = parseDescriptorAuthority(object.descriptorAuthority);
+  const readinessAuthority = parseReadinessAuthority(object.readinessAuthority);
+  const services = parseServices(object.services);
+  return Object.freeze({ release, descriptorAuthority, readinessAuthority, services });
+}
+
+function parseRelease(value: unknown) {
+  const object = exactObject(value, "Approval aggregate release", [
+    "acceptanceSchemaSha256", "packageArtifactHash", "policyCommitment",
+    "reviewAuthorityMode", "sourceCommit", "sourceTree",
+  ]);
+  if (!isReviewAuthorityModeV1(object.reviewAuthorityMode)) {
+    throw new TypeError("Approval aggregate review authority mode is invalid");
+  }
+  return Object.freeze({
+    packageArtifactHash: sha256(object.packageArtifactHash, "package artifact"),
+    sourceCommit: gitObject(object.sourceCommit, "source commit"),
+    sourceTree: gitObject(object.sourceTree, "source tree"),
+    reviewAuthorityMode: object.reviewAuthorityMode,
+    policyCommitment: hash32(object.policyCommitment, "policy commitment"),
+    acceptanceSchemaSha256: sha256(
+      object.acceptanceSchemaSha256,
+      "acceptance schema",
+    ),
+  });
+}
+
+function parseDescriptorAuthority(value: unknown) {
+  const object = exactObject(value, "Approval descriptor authority", [
+    "audience", "keyEpoch", "keyId", "publicKeySpkiSha256",
+  ]);
+  if (object.audience !== APPROVAL_DESCRIPTOR_AUDIENCE_V2) {
+    throw new TypeError("Approval descriptor audience is invalid");
+  }
+  return Object.freeze({
+    audience: APPROVAL_DESCRIPTOR_AUDIENCE_V2,
+    keyId: safeId(object.keyId, "descriptor key ID"),
+    keyEpoch: epoch(object.keyEpoch, "descriptor key epoch"),
+    publicKeySpkiSha256: sha256(
+      object.publicKeySpkiSha256,
+      "descriptor public key",
+    ),
+  });
+}
+
+function parseReadinessAuthority(value: unknown) {
+  const object = exactObject(value, "Approval readiness authority", [
+    "algorithm", "keyEpoch", "keyId", "publicKeySpkiBase64Url",
+    "publicKeySpkiSha256",
+  ]);
+  if (
+    object.algorithm !== "ed25519"
+    || typeof object.publicKeySpkiBase64Url !== "string"
+    || !BASE64URL.test(object.publicKeySpkiBase64Url)
+  ) throw new TypeError("Approval readiness authority is invalid");
+  const publicKeyBytes = Buffer.from(object.publicKeySpkiBase64Url, "base64url");
+  if (publicKeyBytes.toString("base64url") !== object.publicKeySpkiBase64Url) {
+    throw new TypeError("Approval readiness authority key is invalid");
+  }
+  const publicKeySpkiSha256 = sha256(
+    object.publicKeySpkiSha256,
+    "readiness public key",
+  );
+  if (
+    `sha256:${createHash("sha256").update(publicKeyBytes).digest("hex")}`
+      !== publicKeySpkiSha256
+  ) throw new TypeError("Approval readiness authority key binding is invalid");
+  const publicKey = createPublicKey({ key: publicKeyBytes, format: "der", type: "spki" });
+  if (publicKey.asymmetricKeyType !== "ed25519") {
+    throw new TypeError("Approval readiness authority key is invalid");
+  }
+  return Object.freeze({
+    publicIdentity: Object.freeze({
+      algorithm: "ed25519" as const,
+      keyId: safeId(object.keyId, "readiness key ID"),
+      keyEpoch: epoch(object.keyEpoch, "readiness key epoch"),
+      publicKeySpkiBase64Url: object.publicKeySpkiBase64Url,
+      publicKeySpkiSha256,
+    }),
+    publicKey,
+  });
+}
+
+function parseServices(value: unknown): readonly ApprovalRuntimeServiceBindingV1[] {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 32) {
+    throw new TypeError("Approval runtime service set is invalid");
+  }
+  const identities = new Set<string>();
+  const services = value.map((candidate) => {
+    const object = exactObject(candidate, "Approval runtime service", [
+      "configurationBindingHash", "deploymentId", "imageDigest", "serviceId",
+      "status",
+    ]);
+    if (object.status !== "ready") {
+      throw new TypeError("Approval runtime service is not ready");
+    }
+    const service = Object.freeze({
+      serviceId: safeId(object.serviceId, "service ID"),
+      deploymentId: safeId(object.deploymentId, "deployment ID"),
+      imageDigest: sha256(object.imageDigest, "service image"),
+      configurationBindingHash: sha256(
+        object.configurationBindingHash,
+        "service configuration",
+      ),
+      status: "ready" as const,
+    });
+    if (identities.has(service.serviceId)) {
+      throw new TypeError("Approval runtime service set contains duplicates");
+    }
+    identities.add(service.serviceId);
+    return service;
+  });
+  if (services.some((service, index) => index > 0
+    && services[index - 1]!.serviceId.localeCompare(service.serviceId) >= 0)) {
+    throw new TypeError("Approval runtime service set is not ordered");
+  }
+  return Object.freeze(services);
+}
+
+function exactObject(
+  value: unknown,
+  label: string,
+  keys: readonly string[],
+): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length
+    || actual.some((key, index) => key !== expected[index])
+  ) throw new TypeError(`${label} keys are invalid`);
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function sha256(value: unknown, label: string): `sha256:${string}` {
+  if (typeof value !== "string" || !SHA256.test(value)) {
+    throw new TypeError(`Approval aggregate ${label} is invalid`);
+  }
+  return value as `sha256:${string}`;
+}
+
+function hash32(value: unknown, label: string): `0x${string}` {
+  if (
+    typeof value !== "string"
+    || !HASH32.test(value)
+    || value === `0x${"00".repeat(32)}`
+  ) throw new TypeError(`Approval aggregate ${label} is invalid`);
+  return value as `0x${string}`;
+}
+
+function gitObject(value: unknown, label: string): string {
+  if (typeof value !== "string" || !GIT_OBJECT_ID.test(value)) {
+    throw new TypeError(`Approval aggregate ${label} is invalid`);
+  }
+  return value;
+}
+
+function safeId(value: unknown, label: string): string {
+  if (typeof value !== "string" || !SAFE_ID.test(value)) {
+    throw new TypeError(`Approval aggregate ${label} is invalid`);
+  }
+  return value;
+}
+
+function epoch(value: unknown, label: string): string {
+  if (typeof value !== "string" || !POSITIVE_EPOCH.test(value)) {
+    throw new TypeError(`Approval aggregate ${label} is invalid`);
+  }
+  return value;
+}
+
+function instant(value: unknown, label: string): number {
+  if (typeof value !== "string") {
+    throw new TypeError(`Approval aggregate ${label} is invalid`);
+  }
+  const time = Date.parse(value);
+  if (!Number.isFinite(time) || new Date(time).toISOString() !== value) {
+    throw new TypeError(`Approval aggregate ${label} is invalid`);
+  }
+  return time;
+}
+
+function validNow(value: Date): number {
+  const time = value.getTime();
+  if (!Number.isFinite(time)) throw new TypeError("Approval readiness clock is invalid");
+  return time;
+}
+
+function exactOrigin(value: URL): URL {
+  if (
+    !(value instanceof URL)
+    || value.protocol !== "https:"
+    || value.username !== ""
+    || value.password !== ""
+    || value.pathname !== "/"
+    || value.search !== ""
+    || value.hash !== ""
+  ) throw new TypeError("Approval aggregate origin is invalid");
+  return new URL(value.origin);
+}
+
+async function readBoundedResponse(
+  response: Response,
+  maximumBytes: number,
+): Promise<Uint8Array> {
+  if (response.body === null) throw new TypeError("Approval readiness body is missing");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      length += next.value.byteLength;
+      if (length > maximumBytes) throw new TypeError("Approval readiness body is too large");
+      chunks.push(next.value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}

--- a/lib/server/custom-launch/generic-launch-contract-v2.ts
+++ b/lib/server/custom-launch/generic-launch-contract-v2.ts
@@ -1,0 +1,356 @@
+import "server-only";
+
+import { canonicalSha256, type Sha256Digest } from
+  "../projection-target/hashing";
+
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const HASH32 = /^0x[0-9a-f]{64}$/u;
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const DECIMAL = /^(?:0|[1-9][0-9]*)$/u;
+const POSITIVE_DECIMAL = /^[1-9][0-9]*$/u;
+const GIT_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const REPOSITORY_FULL_NAME = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/u;
+const ZERO_HASH32 = `0x${"00".repeat(32)}` as const;
+
+export interface GenericLaunchSourceProjectionV2 {
+  readonly schemaVersion: "programmable.generic-launch-source-projection.v2";
+  readonly sourceRevision: Readonly<{
+    repositoryId: string;
+    repositoryFullName: string;
+    commitObjectId: string;
+    treeObjectId: string;
+  }>;
+  readonly approval: Readonly<{
+    approvalRevision: string;
+    approvalId: `0x${string}`;
+    approvalEvidenceHash: `0x${string}`;
+    signedReceiptArtifactHash: Sha256Digest;
+  }>;
+  readonly descriptor: Readonly<{
+    descriptorHash: `0x${string}`;
+    launchId: `0x${string}`;
+    launchWallet: `0x${string}`;
+    primaryContract: `0x${string}`;
+    primaryRuntimeCodeHash: `0x${string}`;
+    componentSetHash: `0x${string}`;
+    sourceArtifactHash: `0x${string}`;
+    configurationHash: `0x${string}`;
+    launchPlanHash: `0x${string}`;
+    projectCommitment: `0x${string}`;
+    marketMode: "NoMarket0" | "Standard10";
+    marketModeValue: 0 | 1;
+    protocolFeeBps: 0 | 10;
+  }>;
+  readonly lifecycle: Readonly<{
+    chainId: "1";
+    generation: "2";
+    registryAddress: `0x${string}`;
+    registryRuntimeCodeKeccak256: `0x${string}`;
+    registryPolicyCommitment: `0x${string}`;
+    minimumFinalityBlocks: string;
+    primaryLaunchTransactionHash: `0x${string}`;
+    authorizationTransactionHash: `0x${string}`;
+    registrationTransactionHash: `0x${string}`;
+    finalizationTransactionHash: `0x${string}`;
+    finalizedAtBlock: string;
+    finalizedBlockHash: `0x${string}`;
+    finalizationLogIndex: string;
+    latestCommonHead: string;
+    latestCommonHeadHash: `0x${string}`;
+    latestStatus: "finalized";
+    revokedAtBlock: "0";
+    revocationEvidenceHash: typeof ZERO_HASH32;
+  }>;
+}
+
+export interface GenericLaunchRecordV2 {
+  readonly schemaVersion: "programmable.generic-launch-record.v2";
+  readonly sourceProjection: GenericLaunchSourceProjectionV2;
+  readonly sourceProjectionHash: Sha256Digest;
+  readonly readModelBindingHash: Sha256Digest;
+  readonly recordHash: Sha256Digest;
+}
+
+export function createGenericLaunchRecordV2(input: Readonly<{
+  sourceProjection: GenericLaunchSourceProjectionV2;
+  readModelBindingHash: Sha256Digest;
+}>): GenericLaunchRecordV2 {
+  const sourceProjection = parseSourceProjectionV2(input.sourceProjection);
+  const sourceProjectionHash = canonicalSha256(
+    sourceProjection.schemaVersion,
+    sourceProjection,
+  );
+  const core = Object.freeze({
+    schemaVersion: "programmable.generic-launch-record.v2" as const,
+    sourceProjection,
+    sourceProjectionHash,
+    readModelBindingHash: digest(
+      input.readModelBindingHash,
+      "read model binding hash",
+    ),
+  });
+  return Object.freeze({
+    ...core,
+    recordHash: canonicalSha256(core.schemaVersion, core),
+  });
+}
+
+export function parseGenericLaunchRecordV2(raw: unknown): GenericLaunchRecordV2 {
+  const value = exactObject(raw, "Generic launch record V2", [
+    "readModelBindingHash", "recordHash", "schemaVersion", "sourceProjection",
+    "sourceProjectionHash",
+  ]);
+  if (value.schemaVersion !== "programmable.generic-launch-record.v2") {
+    throw new TypeError("Generic launch record V2 schema is invalid");
+  }
+  const record = createGenericLaunchRecordV2({
+    sourceProjection: value.sourceProjection as GenericLaunchSourceProjectionV2,
+    readModelBindingHash: value.readModelBindingHash as Sha256Digest,
+  });
+  if (
+    record.sourceProjectionHash !== value.sourceProjectionHash
+    || record.recordHash !== value.recordHash
+  ) throw new TypeError("Generic launch record V2 hash is invalid");
+  return record;
+}
+
+export function parseSourceProjectionV2(
+  raw: unknown,
+): GenericLaunchSourceProjectionV2 {
+  const value = exactObject(raw, "Generic launch source projection V2", [
+    "approval", "descriptor", "lifecycle", "schemaVersion", "sourceRevision",
+  ]);
+  if (value.schemaVersion !== "programmable.generic-launch-source-projection.v2") {
+    throw new TypeError("Generic launch source projection V2 schema is invalid");
+  }
+  const sourceRevisionValue = exactObject(value.sourceRevision, "source revision", [
+    "commitObjectId", "repositoryFullName", "repositoryId", "treeObjectId",
+  ]);
+  const approvalValue = exactObject(value.approval, "approval identity", [
+    "approvalEvidenceHash", "approvalId", "approvalRevision",
+    "signedReceiptArtifactHash",
+  ]);
+  const descriptorValue = exactObject(value.descriptor, "descriptor identity", [
+    "componentSetHash", "configurationHash", "descriptorHash", "launchId",
+    "launchPlanHash", "launchWallet", "marketMode", "marketModeValue",
+    "primaryContract", "primaryRuntimeCodeHash", "projectCommitment",
+    "protocolFeeBps", "sourceArtifactHash",
+  ]);
+  const lifecycleValue = exactObject(value.lifecycle, "registry lifecycle", [
+    "authorizationTransactionHash", "chainId", "finalizationLogIndex",
+    "finalizationTransactionHash", "finalizedAtBlock", "finalizedBlockHash",
+    "generation", "latestCommonHead", "latestCommonHeadHash", "latestStatus",
+    "minimumFinalityBlocks", "primaryLaunchTransactionHash", "registryAddress",
+    "registrationTransactionHash", "registryPolicyCommitment",
+    "registryRuntimeCodeKeccak256", "revocationEvidenceHash", "revokedAtBlock",
+  ]);
+
+  const signedReceiptArtifactHash = digest(
+    approvalValue.signedReceiptArtifactHash,
+    "signed receipt artifact hash",
+  );
+  const approvalEvidenceHash = hash32(
+    approvalValue.approvalEvidenceHash,
+    "approval evidence hash",
+  );
+  if (`sha256:${approvalEvidenceHash.slice(2)}` !== signedReceiptArtifactHash) {
+    throw new TypeError("Approval artifact/evidence join is invalid");
+  }
+  if (
+    lifecycleValue.chainId !== "1"
+    || lifecycleValue.generation !== "2"
+    || lifecycleValue.latestStatus !== "finalized"
+    || lifecycleValue.revokedAtBlock !== "0"
+    || lifecycleValue.revocationEvidenceHash !== ZERO_HASH32
+  ) throw new TypeError("Registry lifecycle state is not finalized and non-revoked");
+  const market = exactMarketIdentity(
+    descriptorValue.marketMode,
+    descriptorValue.marketModeValue,
+    descriptorValue.protocolFeeBps,
+  );
+
+  const minimumFinalityBlocks = positiveDecimal(
+    lifecycleValue.minimumFinalityBlocks,
+    "minimum finality blocks",
+  );
+  const finalizedAtBlock = decimal(
+    lifecycleValue.finalizedAtBlock,
+    "finalized block",
+  );
+  const latestCommonHead = decimal(
+    lifecycleValue.latestCommonHead,
+    "latest common head",
+  );
+  if (
+    BigInt(latestCommonHead)
+      < BigInt(finalizedAtBlock) + BigInt(minimumFinalityBlocks)
+  ) throw new TypeError("Registry lifecycle finality is insufficient");
+
+  return Object.freeze({
+    schemaVersion: "programmable.generic-launch-source-projection.v2" as const,
+    sourceRevision: Object.freeze({
+      repositoryId: positiveDecimal(sourceRevisionValue.repositoryId, "repository ID"),
+      repositoryFullName: repositoryFullName(sourceRevisionValue.repositoryFullName),
+      commitObjectId: gitObject(sourceRevisionValue.commitObjectId, "commit object ID"),
+      treeObjectId: gitObject(sourceRevisionValue.treeObjectId, "tree object ID"),
+    }),
+    approval: Object.freeze({
+      approvalRevision: positiveDecimal(
+        approvalValue.approvalRevision,
+        "approval revision",
+      ),
+      approvalId: hash32(approvalValue.approvalId, "approval ID"),
+      approvalEvidenceHash,
+      signedReceiptArtifactHash,
+    }),
+    descriptor: Object.freeze({
+      descriptorHash: hash32(descriptorValue.descriptorHash, "descriptor hash"),
+      launchId: hash32(descriptorValue.launchId, "launch ID"),
+      launchWallet: address(descriptorValue.launchWallet, "launch wallet"),
+      primaryContract: address(descriptorValue.primaryContract, "primary contract"),
+      primaryRuntimeCodeHash: hash32(
+        descriptorValue.primaryRuntimeCodeHash,
+        "primary runtime code hash",
+      ),
+      componentSetHash: hash32(descriptorValue.componentSetHash, "component set hash"),
+      sourceArtifactHash: hash32(descriptorValue.sourceArtifactHash, "source artifact hash"),
+      configurationHash: hash32(descriptorValue.configurationHash, "configuration hash"),
+      launchPlanHash: hash32(descriptorValue.launchPlanHash, "launch plan hash"),
+      projectCommitment: hash32(descriptorValue.projectCommitment, "project commitment"),
+      ...market,
+    }),
+    lifecycle: Object.freeze({
+      chainId: "1" as const,
+      generation: "2" as const,
+      registryAddress: address(lifecycleValue.registryAddress, "registry address"),
+      registryRuntimeCodeKeccak256: hash32(
+        lifecycleValue.registryRuntimeCodeKeccak256,
+        "registry runtime code hash",
+      ),
+      registryPolicyCommitment: hash32(
+        lifecycleValue.registryPolicyCommitment,
+        "registry policy commitment",
+      ),
+      minimumFinalityBlocks,
+      primaryLaunchTransactionHash: hash32(
+        lifecycleValue.primaryLaunchTransactionHash,
+        "primary launch transaction hash",
+      ),
+      authorizationTransactionHash: hash32(
+        lifecycleValue.authorizationTransactionHash,
+        "authorization transaction hash",
+      ),
+      registrationTransactionHash: hash32(
+        lifecycleValue.registrationTransactionHash,
+        "registration transaction hash",
+      ),
+      finalizationTransactionHash: hash32(
+        lifecycleValue.finalizationTransactionHash,
+        "finalization transaction hash",
+      ),
+      finalizedAtBlock,
+      finalizedBlockHash: hash32(
+        lifecycleValue.finalizedBlockHash,
+        "finalized block hash",
+      ),
+      finalizationLogIndex: decimal(
+        lifecycleValue.finalizationLogIndex,
+        "finalization log index",
+      ),
+      latestCommonHead,
+      latestCommonHeadHash: hash32(
+        lifecycleValue.latestCommonHeadHash,
+        "latest common head hash",
+      ),
+      latestStatus: "finalized" as const,
+      revokedAtBlock: "0" as const,
+      revocationEvidenceHash: ZERO_HASH32,
+    }),
+  });
+}
+
+function exactObject(
+  value: unknown,
+  label: string,
+  keys: readonly string[],
+): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length
+    || actual.some((key, index) => key !== expected[index])
+  ) throw new TypeError(`${label} keys are invalid`);
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function digest(value: unknown, label: string): Sha256Digest {
+  if (typeof value !== "string" || !DIGEST.test(value)) {
+    throw new TypeError(`Generic launch ${label} is invalid`);
+  }
+  return value as Sha256Digest;
+}
+
+function hash32(value: unknown, label: string): `0x${string}` {
+  if (
+    typeof value !== "string"
+    || !HASH32.test(value)
+    || value === ZERO_HASH32
+  ) throw new TypeError(`Generic launch ${label} is invalid`);
+  return value as `0x${string}`;
+}
+
+function address(value: unknown, label: string): `0x${string}` {
+  if (typeof value !== "string" || !ADDRESS.test(value)) {
+    throw new TypeError(`Generic launch ${label} is invalid`);
+  }
+  return value as `0x${string}`;
+}
+
+function decimal(value: unknown, label: string): string {
+  if (typeof value !== "string" || !DECIMAL.test(value)) {
+    throw new TypeError(`Generic launch ${label} is invalid`);
+  }
+  return value;
+}
+
+function positiveDecimal(value: unknown, label: string): string {
+  if (typeof value !== "string" || !POSITIVE_DECIMAL.test(value)) {
+    throw new TypeError(`Generic launch ${label} is invalid`);
+  }
+  return value;
+}
+
+function gitObject(value: unknown, label: string): string {
+  if (typeof value !== "string" || !GIT_OBJECT_ID.test(value)) {
+    throw new TypeError(`Generic launch ${label} is invalid`);
+  }
+  return value;
+}
+
+function repositoryFullName(value: unknown): string {
+  if (typeof value !== "string" || !REPOSITORY_FULL_NAME.test(value)) {
+    throw new TypeError("Generic launch repository full name is invalid");
+  }
+  return value;
+}
+
+function exactMarketIdentity(
+  mode: unknown,
+  modeValue: unknown,
+  feeBps: unknown,
+): Readonly<{
+  marketMode: "NoMarket0" | "Standard10";
+  marketModeValue: 0 | 1;
+  protocolFeeBps: 0 | 10;
+}> {
+  if (mode === "NoMarket0" && modeValue === 0 && feeBps === 0) {
+    return Object.freeze({ marketMode: mode, marketModeValue: 0, protocolFeeBps: 0 });
+  }
+  if (mode === "Standard10" && modeValue === 1 && feeBps === 10) {
+    return Object.freeze({ marketMode: mode, marketModeValue: 1, protocolFeeBps: 10 });
+  }
+  throw new TypeError("Generic launch descriptor market identity is invalid");
+}

--- a/lib/server/custom-launch/generic-launch-contract-v2.ts
+++ b/lib/server/custom-launch/generic-launch-contract-v2.ts
@@ -48,19 +48,37 @@ export interface GenericLaunchSourceProjectionV2 {
     registryRuntimeCodeKeccak256: `0x${string}`;
     registryPolicyCommitment: `0x${string}`;
     minimumFinalityBlocks: string;
-    primaryLaunchTransactionHash: `0x${string}`;
-    authorizationTransactionHash: `0x${string}`;
-    registrationTransactionHash: `0x${string}`;
-    finalizationTransactionHash: `0x${string}`;
-    finalizedAtBlock: string;
-    finalizedBlockHash: `0x${string}`;
-    finalizationLogIndex: string;
+    primaryLaunch: Readonly<{
+      transactionHash: `0x${string}`;
+      sender: `0x${string}`;
+      blockHash: `0x${string}`;
+      blockNumber: string;
+      transactionIndex: string;
+      status: "success";
+    }>;
+    authorization: RegistryEventEvidenceV2<"CustomLaunchApprovalAuthorizedV2">;
+    registration: readonly [
+      RegistryEventEvidenceV2<"CustomLaunchRegisteredV2">,
+      RegistryEventEvidenceV2<"CustomLaunchDescriptorCommittedV2">,
+      RegistryEventEvidenceV2<"CustomLaunchDescriptorEvidenceCommittedV2">,
+    ];
+    finalization: RegistryEventEvidenceV2<"CustomLaunchFinalizedV2">;
     latestCommonHead: string;
     latestCommonHeadHash: `0x${string}`;
     latestStatus: "finalized";
     revokedAtBlock: "0";
     revocationEvidenceHash: typeof ZERO_HASH32;
   }>;
+}
+
+export interface RegistryEventEvidenceV2<EventName extends string> {
+  readonly eventName: EventName;
+  readonly transactionHash: `0x${string}`;
+  readonly blockHash: `0x${string}`;
+  readonly blockNumber: string;
+  readonly transactionIndex: string;
+  readonly logIndex: string;
+  readonly removed: false;
 }
 
 export interface GenericLaunchRecordV2 {
@@ -137,11 +155,10 @@ export function parseSourceProjectionV2(
     "protocolFeeBps", "sourceArtifactHash",
   ]);
   const lifecycleValue = exactObject(value.lifecycle, "registry lifecycle", [
-    "authorizationTransactionHash", "chainId", "finalizationLogIndex",
-    "finalizationTransactionHash", "finalizedAtBlock", "finalizedBlockHash",
-    "generation", "latestCommonHead", "latestCommonHeadHash", "latestStatus",
-    "minimumFinalityBlocks", "primaryLaunchTransactionHash", "registryAddress",
-    "registrationTransactionHash", "registryPolicyCommitment",
+    "authorization", "chainId", "finalization", "generation",
+    "latestCommonHead", "latestCommonHeadHash", "latestStatus",
+    "minimumFinalityBlocks", "primaryLaunch", "registryAddress",
+    "registration", "registryPolicyCommitment",
     "registryRuntimeCodeKeccak256", "revocationEvidenceHash", "revokedAtBlock",
   ]);
 
@@ -168,22 +185,101 @@ export function parseSourceProjectionV2(
     descriptorValue.marketModeValue,
     descriptorValue.protocolFeeBps,
   );
+  const launchWallet = address(descriptorValue.launchWallet, "launch wallet");
+
+  const primaryLaunchValue = exactObject(
+    lifecycleValue.primaryLaunch,
+    "primary launch receipt",
+    [
+      "blockHash", "blockNumber", "sender", "status", "transactionHash",
+      "transactionIndex",
+    ],
+  );
+  if (primaryLaunchValue.status !== "success") {
+    throw new TypeError("Primary launch receipt status is invalid");
+  }
+  const primaryLaunch = Object.freeze({
+    transactionHash: hash32(
+      primaryLaunchValue.transactionHash,
+      "primary launch transaction hash",
+    ),
+    sender: address(primaryLaunchValue.sender, "primary launch sender"),
+    blockHash: hash32(primaryLaunchValue.blockHash, "primary launch block hash"),
+    blockNumber: decimal(primaryLaunchValue.blockNumber, "primary launch block"),
+    transactionIndex: decimal(
+      primaryLaunchValue.transactionIndex,
+      "primary launch transaction index",
+    ),
+    status: "success" as const,
+  });
+  if (primaryLaunch.sender !== launchWallet) {
+    throw new TypeError("primary launch sender is not the descriptor launch wallet");
+  }
+  const authorization = registryEvent(
+    lifecycleValue.authorization,
+    "CustomLaunchApprovalAuthorizedV2",
+  );
+  if (!Array.isArray(lifecycleValue.registration)
+    || lifecycleValue.registration.length !== 3) {
+    throw new TypeError("Registry registration evidence is invalid");
+  }
+  if (lifecycleValue.registration.some((entry, index) =>
+    entry === null || typeof entry !== "object" || Array.isArray(entry)
+    || (entry as { eventName?: unknown }).eventName !== [
+      "CustomLaunchRegisteredV2",
+      "CustomLaunchDescriptorCommittedV2",
+      "CustomLaunchDescriptorEvidenceCommittedV2",
+    ][index])) {
+    throw new TypeError("Registry registration evidence is invalid");
+  }
+  const registration = Object.freeze([
+    registryEvent(
+      lifecycleValue.registration[0],
+      "CustomLaunchRegisteredV2",
+    ),
+    registryEvent(
+      lifecycleValue.registration[1],
+      "CustomLaunchDescriptorCommittedV2",
+    ),
+    registryEvent(
+      lifecycleValue.registration[2],
+      "CustomLaunchDescriptorEvidenceCommittedV2",
+    ),
+  ] as const);
+  const [registered, descriptorCommitted, descriptorEvidenceCommitted] =
+    registration;
+  if (!sameRegistryReceipt(registered, descriptorCommitted)
+    || !sameRegistryReceipt(registered, descriptorEvidenceCommitted)
+    || BigInt(registered.logIndex) >= BigInt(descriptorCommitted.logIndex)
+    || BigInt(descriptorCommitted.logIndex)
+      >= BigInt(descriptorEvidenceCommitted.logIndex)) {
+    throw new TypeError("Registry registration evidence is invalid");
+  }
+  const finalization = registryEvent(
+    lifecycleValue.finalization,
+    "CustomLaunchFinalizedV2",
+  );
 
   const minimumFinalityBlocks = positiveDecimal(
     lifecycleValue.minimumFinalityBlocks,
     "minimum finality blocks",
   );
-  const finalizedAtBlock = decimal(
-    lifecycleValue.finalizedAtBlock,
-    "finalized block",
-  );
   const latestCommonHead = decimal(
     lifecycleValue.latestCommonHead,
     "latest common head",
   );
+  if (compareTransactionPosition(primaryLaunch, authorization) >= 0
+    || compareEventPosition(authorization, registered) >= 0
+    || compareEventPosition(
+      descriptorEvidenceCommitted,
+      finalization,
+    ) >= 0
+    || BigInt(finalization.blockNumber) > BigInt(latestCommonHead)) {
+    throw new TypeError("Registry lifecycle order is invalid");
+  }
   if (
     BigInt(latestCommonHead)
-      < BigInt(finalizedAtBlock) + BigInt(minimumFinalityBlocks)
+      < BigInt(finalization.blockNumber) + BigInt(minimumFinalityBlocks)
   ) throw new TypeError("Registry lifecycle finality is insufficient");
 
   return Object.freeze({
@@ -206,7 +302,7 @@ export function parseSourceProjectionV2(
     descriptor: Object.freeze({
       descriptorHash: hash32(descriptorValue.descriptorHash, "descriptor hash"),
       launchId: hash32(descriptorValue.launchId, "launch ID"),
-      launchWallet: address(descriptorValue.launchWallet, "launch wallet"),
+      launchWallet,
       primaryContract: address(descriptorValue.primaryContract, "primary contract"),
       primaryRuntimeCodeHash: hash32(
         descriptorValue.primaryRuntimeCodeHash,
@@ -232,31 +328,10 @@ export function parseSourceProjectionV2(
         "registry policy commitment",
       ),
       minimumFinalityBlocks,
-      primaryLaunchTransactionHash: hash32(
-        lifecycleValue.primaryLaunchTransactionHash,
-        "primary launch transaction hash",
-      ),
-      authorizationTransactionHash: hash32(
-        lifecycleValue.authorizationTransactionHash,
-        "authorization transaction hash",
-      ),
-      registrationTransactionHash: hash32(
-        lifecycleValue.registrationTransactionHash,
-        "registration transaction hash",
-      ),
-      finalizationTransactionHash: hash32(
-        lifecycleValue.finalizationTransactionHash,
-        "finalization transaction hash",
-      ),
-      finalizedAtBlock,
-      finalizedBlockHash: hash32(
-        lifecycleValue.finalizedBlockHash,
-        "finalized block hash",
-      ),
-      finalizationLogIndex: decimal(
-        lifecycleValue.finalizationLogIndex,
-        "finalization log index",
-      ),
+      primaryLaunch,
+      authorization,
+      registration,
+      finalization,
       latestCommonHead,
       latestCommonHeadHash: hash32(
         lifecycleValue.latestCommonHeadHash,
@@ -267,6 +342,67 @@ export function parseSourceProjectionV2(
       revocationEvidenceHash: ZERO_HASH32,
     }),
   });
+}
+
+function registryEvent<EventName extends string>(
+  raw: unknown,
+  expectedEventName: EventName,
+): RegistryEventEvidenceV2<EventName> {
+  const value = exactObject(raw, "Registry event evidence", [
+    "blockHash", "blockNumber", "eventName", "logIndex", "removed",
+    "transactionHash", "transactionIndex",
+  ]);
+  if (value.eventName !== expectedEventName || value.removed !== false) {
+    throw new TypeError("Registry event evidence is invalid");
+  }
+  return Object.freeze({
+    eventName: expectedEventName,
+    transactionHash: hash32(value.transactionHash, "Registry transaction hash"),
+    blockHash: hash32(value.blockHash, "Registry block hash"),
+    blockNumber: decimal(value.blockNumber, "Registry block number"),
+    transactionIndex: decimal(
+      value.transactionIndex,
+      "Registry transaction index",
+    ),
+    logIndex: decimal(value.logIndex, "Registry log index"),
+    removed: false as const,
+  });
+}
+
+function sameRegistryReceipt(
+  left: RegistryEventEvidenceV2<string>,
+  right: RegistryEventEvidenceV2<string>,
+): boolean {
+  return left.transactionHash === right.transactionHash
+    && left.blockHash === right.blockHash
+    && left.blockNumber === right.blockNumber
+    && left.transactionIndex === right.transactionIndex;
+}
+
+function compareTransactionPosition(
+  left: Readonly<{ blockNumber: string; transactionIndex: string }>,
+  right: Readonly<{ blockNumber: string; transactionIndex: string }>,
+): number {
+  const blockOrder = compareDecimal(left.blockNumber, right.blockNumber);
+  return blockOrder === 0
+    ? compareDecimal(left.transactionIndex, right.transactionIndex)
+    : blockOrder;
+}
+
+function compareEventPosition(
+  left: RegistryEventEvidenceV2<string>,
+  right: RegistryEventEvidenceV2<string>,
+): number {
+  const transactionOrder = compareTransactionPosition(left, right);
+  return transactionOrder === 0
+    ? compareDecimal(left.logIndex, right.logIndex)
+    : transactionOrder;
+}
+
+function compareDecimal(left: string, right: string): number {
+  const leftValue = BigInt(left);
+  const rightValue = BigInt(right);
+  return leftValue < rightValue ? -1 : leftValue > rightValue ? 1 : 0;
 }
 
 function exactObject(
@@ -303,7 +439,8 @@ function hash32(value: unknown, label: string): `0x${string}` {
 }
 
 function address(value: unknown, label: string): `0x${string}` {
-  if (typeof value !== "string" || !ADDRESS.test(value)) {
+  if (typeof value !== "string" || !ADDRESS.test(value)
+    || value === `0x${"00".repeat(20)}`) {
     throw new TypeError(`Generic launch ${label} is invalid`);
   }
   return value as `0x${string}`;

--- a/lib/server/custom-launch/generic-launch-contract-v2.ts
+++ b/lib/server/custom-launch/generic-launch-contract-v2.ts
@@ -6,8 +6,8 @@ import { canonicalSha256, type Sha256Digest } from
 const DIGEST = /^sha256:[0-9a-f]{64}$/u;
 const HASH32 = /^0x[0-9a-f]{64}$/u;
 const ADDRESS = /^0x[0-9a-f]{40}$/u;
-const DECIMAL = /^(?:0|[1-9][0-9]*)$/u;
-const POSITIVE_DECIMAL = /^[1-9][0-9]*$/u;
+const DECIMAL = /^(?:0|[1-9][0-9]{0,77})$/u;
+const POSITIVE_DECIMAL = /^[1-9][0-9]{0,77}$/u;
 const GIT_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
 const REPOSITORY_FULL_NAME = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/u;
 const ZERO_HASH32 = `0x${"00".repeat(32)}` as const;

--- a/lib/server/custom-launch/generic-launch-read-v2.ts
+++ b/lib/server/custom-launch/generic-launch-read-v2.ts
@@ -1,0 +1,743 @@
+import "server-only";
+
+import {
+  createHash,
+  createPublicKey,
+  randomBytes,
+  verify as verifySignature,
+} from "node:crypto";
+import {
+  canonicalizeJson,
+  parseStrictJson,
+  type JsonValue,
+} from "../projection-target/canonical-json";
+import {
+  canonicalSha256,
+  type Sha256Digest,
+} from "../projection-target/hashing";
+import {
+  parseGenericLaunchRecordV2,
+  type GenericLaunchRecordV2,
+} from "./generic-launch-contract-v2";
+
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const HASH32 = /^0x[0-9a-f]{64}$/u;
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const BASE64URL_SIGNATURE = /^[A-Za-z0-9_-]{86}$/u;
+const BASE64URL = /^[A-Za-z0-9_-]+$/u;
+const CURSOR = /^[A-Za-z0-9_-]{1,1024}$/u;
+const DECIMAL = /^(?:0|[1-9][0-9]{0,77})$/u;
+const POSITIVE_DECIMAL = /^[1-9][0-9]{0,77}$/u;
+const MAX_SIGNED_MESSAGE_BYTES = 2_097_152;
+
+export const GENERIC_LAUNCH_FEED_PATH_V2 =
+  "/api/custom-launch/generic/v2/launches" as const;
+export const GENERIC_LAUNCH_DETAIL_PATH_TEMPLATE_V2 =
+  "/api/custom-launch/generic/v2/launches/{recordHash}" as const;
+
+export interface GenericLaunchReadModelContractV2 {
+  readonly schemaVersion: "programmable.generic-launch-read-model-contract.v2";
+  readonly sourceLane: "generic.finalized-launch-v2";
+  readonly implementationBindingHash: Sha256Digest;
+  readonly persistenceBindingHash: Sha256Digest;
+  readonly queryContractBindingHash: Sha256Digest;
+  readonly approvalArtifactSchemaBindingHash: Sha256Digest;
+  readonly approvalReleaseBindingHash: Sha256Digest;
+  readonly registryProjectionBindingHash: Sha256Digest;
+}
+
+export interface GenericLaunchReadBindingV2 {
+  readonly schemaVersion: "programmable.generic-launch-read-binding.v2";
+  readonly activationBindingHash: Sha256Digest;
+  readonly activatedAt: string;
+  readonly readModelBindingHash: Sha256Digest;
+  readonly readModelVerifier: Readonly<{
+    algorithm: "ed25519";
+    publicKeySpkiBase64Url: string;
+    publicKeySha256: Sha256Digest;
+  }>;
+  readonly registryIdentity: Readonly<{
+    chainId: "1";
+    generation: "2";
+    registryAddress: `0x${string}`;
+    registryRuntimeCodeKeccak256: `0x${string}`;
+    registryPolicyCommitment: `0x${string}`;
+    minimumFinalityBlocks: string;
+  }>;
+  readonly api: Readonly<{
+    feedPath: typeof GENERIC_LAUNCH_FEED_PATH_V2;
+    detailPathTemplate: typeof GENERIC_LAUNCH_DETAIL_PATH_TEMPLATE_V2;
+  }>;
+}
+
+export interface GenericLaunchReadPageV2 {
+  readonly records: readonly GenericLaunchRecordV2[];
+  readonly nextCursor: string | null;
+  readonly total: string;
+}
+
+export interface SignedGenericLaunchReadEnvelopeV2 {
+  readonly schemaVersion: "programmable.signed-generic-launch-read-envelope.v2";
+  readonly activationBindingHash: Sha256Digest;
+  readonly readModelBindingHash: Sha256Digest;
+  readonly requestBindingHash: Sha256Digest;
+  readonly payload: unknown;
+  readonly signatureBase64Url: string;
+}
+
+export interface GenericLaunchReadStoreV2 {
+  readonly sourceLane: "generic.finalized-launch-v2";
+  readonly readModelContract: GenericLaunchReadModelContractV2;
+  findFinalizedLaunches(input: Readonly<{
+    limit: number;
+    cursor?: string;
+    requestBindingHash: Sha256Digest;
+    signal: AbortSignal;
+  }>): Promise<string>;
+  findFinalizedLaunchByRecordHash(input: Readonly<{
+    recordHash: Sha256Digest;
+    requestBindingHash: Sha256Digest;
+    signal: AbortSignal;
+  }>): Promise<string>;
+}
+
+export function createActiveGenericLaunchReadBindingV2(
+  input: Omit<GenericLaunchReadBindingV2, "schemaVersion" | "activationBindingHash">,
+): GenericLaunchReadBindingV2 {
+  const activatedAt = canonicalTimestamp(input.activatedAt);
+  const verifierValue = exactObject(input.readModelVerifier, [
+    "algorithm", "publicKeySha256", "publicKeySpkiBase64Url",
+  ], "generic launch V2 read verifier");
+  if (verifierValue.algorithm !== "ed25519"
+    || typeof verifierValue.publicKeySpkiBase64Url !== "string"
+    || !BASE64URL.test(verifierValue.publicKeySpkiBase64Url)) {
+    throw new TypeError("generic launch V2 read verifier is invalid");
+  }
+  const verifier = Object.freeze({
+    algorithm: "ed25519" as const,
+    publicKeySpkiBase64Url: verifierValue.publicKeySpkiBase64Url,
+    publicKeySha256: digest(
+      verifierValue.publicKeySha256,
+      "generic launch V2 read verifier public key hash",
+    ),
+  });
+  const registryValue = exactObject(input.registryIdentity, [
+    "chainId", "generation", "minimumFinalityBlocks", "registryAddress",
+    "registryPolicyCommitment", "registryRuntimeCodeKeccak256",
+  ], "generic launch V2 registry identity");
+  if (registryValue.chainId !== "1" || registryValue.generation !== "2") {
+    throw new TypeError("generic launch V2 registry identity is invalid");
+  }
+  const registryIdentity = Object.freeze({
+    chainId: "1" as const,
+    generation: "2" as const,
+    registryAddress: evmAddress(
+      registryValue.registryAddress,
+      "generic launch V2 registry address",
+    ),
+    registryRuntimeCodeKeccak256: hash32(
+      registryValue.registryRuntimeCodeKeccak256,
+      "generic launch V2 registry runtime hash",
+    ),
+    registryPolicyCommitment: hash32(
+      registryValue.registryPolicyCommitment,
+      "generic launch V2 registry policy commitment",
+    ),
+    minimumFinalityBlocks: positiveDecimal(
+      registryValue.minimumFinalityBlocks,
+      "generic launch V2 registry minimum finality",
+    ),
+  });
+  const apiValue = exactObject(input.api, [
+    "detailPathTemplate", "feedPath",
+  ], "generic launch V2 API binding");
+  if (apiValue.feedPath !== GENERIC_LAUNCH_FEED_PATH_V2
+    || apiValue.detailPathTemplate !== GENERIC_LAUNCH_DETAIL_PATH_TEMPLATE_V2) {
+    throw new TypeError("generic launch V2 API binding is invalid");
+  }
+  const core = Object.freeze({
+    schemaVersion: "programmable.generic-launch-read-binding.v2" as const,
+    activatedAt,
+    readModelBindingHash: digest(
+      input.readModelBindingHash,
+      "generic launch V2 read model binding",
+    ),
+    readModelVerifier: verifier,
+    registryIdentity,
+    api: Object.freeze({
+      feedPath: GENERIC_LAUNCH_FEED_PATH_V2,
+      detailPathTemplate: GENERIC_LAUNCH_DETAIL_PATH_TEMPLATE_V2,
+    }),
+  });
+  return Object.freeze({
+    ...core,
+    activationBindingHash: canonicalSha256(core.schemaVersion, core),
+  });
+}
+
+export function parseGenericLaunchReadBindingV2(
+  raw: unknown,
+): GenericLaunchReadBindingV2 {
+  const value = exactObject(raw, [
+    "activatedAt", "activationBindingHash", "api", "readModelBindingHash",
+    "readModelVerifier", "registryIdentity", "schemaVersion",
+  ], "generic launch V2 read binding");
+  if (value.schemaVersion !== "programmable.generic-launch-read-binding.v2") {
+    throw new TypeError("generic launch V2 read binding schema is invalid");
+  }
+  const binding = createActiveGenericLaunchReadBindingV2({
+    activatedAt: value.activatedAt as string,
+    readModelBindingHash: value.readModelBindingHash as Sha256Digest,
+    readModelVerifier:
+      value.readModelVerifier as GenericLaunchReadBindingV2["readModelVerifier"],
+    registryIdentity:
+      value.registryIdentity as GenericLaunchReadBindingV2["registryIdentity"],
+    api: value.api as GenericLaunchReadBindingV2["api"],
+  });
+  if (binding.activationBindingHash !== value.activationBindingHash) {
+    throw new TypeError("generic launch V2 activation binding is invalid");
+  }
+  return binding;
+}
+
+export function createGenericLaunchReadHandlersV2(input: Readonly<{
+  binding: GenericLaunchReadBindingV2 | null;
+  store: GenericLaunchReadStoreV2 | null;
+}>) {
+  if (input.binding === null) {
+    if (input.store !== null) {
+      throw new TypeError("inactive generic launch V2 cannot bind a read store");
+    }
+    return inactiveHandlers();
+  }
+  const binding = parseGenericLaunchReadBindingV2(input.binding);
+  const readModel = prepareActiveReadModel(binding, input.store);
+  return Object.freeze({
+    async feed(request: Request): Promise<Response> {
+      const query = parseFeedRequest(request);
+      if (query === null) {
+        return errorResponse(400, "invalid_generic_launch_v2_feed_request");
+      }
+      try {
+        const requestBindingHash = canonicalSha256(
+          "programmable.generic-launch-feed-request.v2",
+          Object.freeze({
+            limit: query.limit,
+            cursor: query.cursor ?? null,
+            requestChallengeBase64Url: randomBytes(32).toString("base64url"),
+          }),
+        );
+        const envelope = await readModel.store.findFinalizedLaunches({
+          limit: query.limit,
+          ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
+          requestBindingHash,
+          signal: request.signal,
+        });
+        const payload = verifySignedEnvelope(
+          binding,
+          readModel,
+          envelope,
+          requestBindingHash,
+        );
+        const page = assertPage(
+          binding,
+          readModel.readModelBindingHash,
+          payload,
+          query.limit,
+          query.cursor ?? null,
+        );
+        return jsonResponse(200, {
+          schemaVersion: "programmable.generic-launch-feed.v2",
+          records: page.records,
+          nextCursor: page.nextCursor,
+          total: page.total,
+        });
+      } catch {
+        return errorResponse(503, "generic_launch_v2_read_model_unavailable");
+      }
+    },
+
+    async detail(request: Request, recordHash: string): Promise<Response> {
+      if (!validBaseReadRequest(request) || new URL(request.url).search !== ""
+        || !DIGEST.test(recordHash)) {
+        return errorResponse(400, "invalid_generic_launch_v2_detail_request");
+      }
+      try {
+        const requestBindingHash = canonicalSha256(
+          "programmable.generic-launch-detail-request.v2",
+          Object.freeze({
+            recordHash,
+            requestChallengeBase64Url: randomBytes(32).toString("base64url"),
+          }),
+        );
+        const envelope = await readModel.store.findFinalizedLaunchByRecordHash({
+          recordHash: recordHash as Sha256Digest,
+          requestBindingHash,
+          signal: request.signal,
+        });
+        const payload = verifySignedEnvelope(
+          binding,
+          readModel,
+          envelope,
+          requestBindingHash,
+        );
+        if (payload === null) {
+          return errorResponse(404, "generic_launch_v2_not_found");
+        }
+        const record = assertBindingBoundRecord(
+          binding,
+          readModel.readModelBindingHash,
+          payload,
+        );
+        if (record.recordHash !== recordHash) {
+          throw new TypeError("generic launch V2 read key does not match record");
+        }
+        return jsonResponse(200, {
+          schemaVersion: "programmable.generic-launch-view.v2",
+          record,
+        });
+      } catch {
+        return errorResponse(503, "generic_launch_v2_read_model_unavailable");
+      }
+    },
+  });
+}
+
+const productionHandlers = createGenericLaunchReadHandlersV2({
+  binding: null,
+  store: null,
+});
+
+export function handleProductionGenericLaunchFeedV2(
+  request: Request,
+): Promise<Response> {
+  return productionHandlers.feed(request);
+}
+
+export function handleProductionGenericLaunchDetailV2(
+  request: Request,
+  recordHash: string,
+): Promise<Response> {
+  return productionHandlers.detail(request, recordHash);
+}
+
+function inactiveHandlers() {
+  return Object.freeze({
+    async feed(request: Request): Promise<Response> {
+      if (parseFeedRequest(request) === null) {
+        return errorResponse(400, "invalid_generic_launch_v2_feed_request");
+      }
+      return errorResponse(503, "generic_launch_v2_not_active");
+    },
+    async detail(request: Request, recordHash: string): Promise<Response> {
+      if (!validBaseReadRequest(request) || new URL(request.url).search !== ""
+        || !DIGEST.test(recordHash)) {
+        return errorResponse(400, "invalid_generic_launch_v2_detail_request");
+      }
+      return errorResponse(503, "generic_launch_v2_not_active");
+    },
+  });
+}
+
+function prepareActiveReadModel(
+  binding: GenericLaunchReadBindingV2,
+  store: GenericLaunchReadStoreV2 | null,
+): Readonly<{
+  store: GenericLaunchReadStoreV2;
+  readModelBindingHash: Sha256Digest;
+  publicKey: ReturnType<typeof createPublicKey>;
+}> {
+  const capturedStore = captureReadStore(store);
+  const contract = parseGenericLaunchReadModelContractV2(
+    capturedStore.readModelContract,
+  );
+  const readModelBindingHash = canonicalSha256(contract.schemaVersion, contract);
+  if (readModelBindingHash !== binding.readModelBindingHash) {
+    throw new TypeError("generic launch V2 read model is not activation-bound");
+  }
+  const spki = Buffer.from(
+    binding.readModelVerifier.publicKeySpkiBase64Url,
+    "base64url",
+  );
+  const publicKeySha256 =
+    `sha256:${createHash("sha256").update(spki).digest("hex")}`;
+  if (publicKeySha256 !== binding.readModelVerifier.publicKeySha256) {
+    throw new TypeError("generic launch V2 read public key hash is invalid");
+  }
+  const publicKey = createPublicKey({ key: spki, format: "der", type: "spki" });
+  if (publicKey.asymmetricKeyType !== "ed25519") {
+    throw new TypeError("generic launch V2 read public key is not Ed25519");
+  }
+  return Object.freeze({
+    store: Object.freeze({
+      sourceLane: "generic.finalized-launch-v2" as const,
+      readModelContract: contract,
+      findFinalizedLaunches: capturedStore.findFinalizedLaunches,
+      findFinalizedLaunchByRecordHash:
+        capturedStore.findFinalizedLaunchByRecordHash,
+    }),
+    readModelBindingHash,
+    publicKey,
+  });
+}
+
+function verifySignedEnvelope(
+  binding: GenericLaunchReadBindingV2,
+  readModel: Readonly<{
+    readModelBindingHash: Sha256Digest;
+    publicKey: ReturnType<typeof createPublicKey>;
+  }>,
+  raw: string,
+  requestBindingHash: Sha256Digest,
+): unknown {
+  if (typeof raw !== "string"
+    || Buffer.byteLength(raw, "utf8") > MAX_SIGNED_MESSAGE_BYTES) {
+    throw new TypeError("signed generic launch V2 read envelope exceeds its bound");
+  }
+  const envelopeSnapshot = parseStrictJson(raw, {
+    maximumBytes: MAX_SIGNED_MESSAGE_BYTES,
+    maximumDepth: 128,
+  });
+  if (canonicalizeJson(envelopeSnapshot) !== raw) {
+    throw new TypeError("signed generic launch V2 read envelope is not canonical");
+  }
+  const value = exactObject(envelopeSnapshot, [
+    "activationBindingHash", "payload", "readModelBindingHash",
+    "requestBindingHash", "schemaVersion", "signatureBase64Url",
+  ], "signed generic launch V2 read envelope");
+  if (value.schemaVersion !== "programmable.signed-generic-launch-read-envelope.v2"
+    || value.activationBindingHash !== binding.activationBindingHash
+    || value.readModelBindingHash !== readModel.readModelBindingHash
+    || value.requestBindingHash !== requestBindingHash
+    || typeof value.signatureBase64Url !== "string"
+    || !BASE64URL_SIGNATURE.test(value.signatureBase64Url)) {
+    throw new TypeError("signed generic launch V2 read envelope is invalid");
+  }
+  const message = Object.freeze({
+    schemaVersion: "programmable.generic-launch-read-signature-message.v2" as const,
+    activationBindingHash: binding.activationBindingHash,
+    readModelBindingHash: readModel.readModelBindingHash,
+    requestBindingHash,
+    payload: value.payload,
+  });
+  const canonicalMessage = canonicalizeJson(message as unknown as JsonValue);
+  if (!verifySignature(
+    null,
+    Buffer.from(canonicalMessage, "utf8"),
+    readModel.publicKey,
+    Buffer.from(value.signatureBase64Url, "base64url"),
+  )) throw new TypeError("generic launch V2 read signature is invalid");
+  const snapshot = exactObject(parseStrictJson(canonicalMessage, {
+    maximumBytes: MAX_SIGNED_MESSAGE_BYTES,
+    maximumDepth: 128,
+  }), [
+    "activationBindingHash", "payload", "readModelBindingHash",
+    "requestBindingHash", "schemaVersion",
+  ], "verified generic launch V2 read message");
+  if (snapshot.schemaVersion
+      !== "programmable.generic-launch-read-signature-message.v2"
+    || snapshot.activationBindingHash !== binding.activationBindingHash
+    || snapshot.readModelBindingHash !== readModel.readModelBindingHash
+    || snapshot.requestBindingHash !== requestBindingHash) {
+    throw new TypeError("verified generic launch V2 read message is invalid");
+  }
+  return snapshot.payload;
+}
+
+function captureReadStore(
+  raw: GenericLaunchReadStoreV2 | null,
+): GenericLaunchReadStoreV2 {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new TypeError("active generic launch V2 read store is invalid");
+  }
+  const prototype = Object.getPrototypeOf(raw) as object | null;
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError("active generic launch V2 read store must be a plain object");
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(raw);
+  const keys = Reflect.ownKeys(descriptors);
+  const expected = [
+    "findFinalizedLaunchByRecordHash", "findFinalizedLaunches",
+    "readModelContract", "sourceLane",
+  ];
+  if (keys.some((key) => typeof key !== "string")) {
+    throw new TypeError("active generic launch V2 read store contains symbols");
+  }
+  const sortedKeys = (keys as string[]).sort();
+  if (sortedKeys.length !== expected.length
+    || sortedKeys.some((key, index) => key !== expected[index])) {
+    throw new TypeError("active generic launch V2 read store has unexpected properties");
+  }
+  const captured: Record<string, unknown> = Object.create(null);
+  for (const key of sortedKeys) {
+    const descriptor = descriptors[key];
+    if (descriptor === undefined || descriptor.get !== undefined
+      || descriptor.set !== undefined || !descriptor.enumerable
+      || !("value" in descriptor)) {
+      throw new TypeError(
+        "active generic launch V2 read store contains non-data properties",
+      );
+    }
+    captured[key] = descriptor.value;
+  }
+  if (captured.sourceLane !== "generic.finalized-launch-v2"
+    || typeof captured.findFinalizedLaunches !== "function"
+    || typeof captured.findFinalizedLaunchByRecordHash !== "function") {
+    throw new TypeError("active generic launch V2 read store is invalid");
+  }
+  const findFinalizedLaunches = captured.findFinalizedLaunches as
+    GenericLaunchReadStoreV2["findFinalizedLaunches"];
+  const findFinalizedLaunchByRecordHash =
+    captured.findFinalizedLaunchByRecordHash as
+      GenericLaunchReadStoreV2["findFinalizedLaunchByRecordHash"];
+  return Object.freeze({
+    sourceLane: "generic.finalized-launch-v2" as const,
+    readModelContract:
+      captured.readModelContract as GenericLaunchReadModelContractV2,
+    findFinalizedLaunches: (
+      input: Parameters<GenericLaunchReadStoreV2["findFinalizedLaunches"]>[0],
+    ) => findFinalizedLaunches(input),
+    findFinalizedLaunchByRecordHash: (
+      input: Parameters<
+        GenericLaunchReadStoreV2["findFinalizedLaunchByRecordHash"]
+      >[0],
+    ) => findFinalizedLaunchByRecordHash(input),
+  });
+}
+
+function parseGenericLaunchReadModelContractV2(
+  raw: unknown,
+): GenericLaunchReadModelContractV2 {
+  const value = exactObject(raw, [
+    "approvalArtifactSchemaBindingHash", "approvalReleaseBindingHash",
+    "implementationBindingHash", "persistenceBindingHash",
+    "queryContractBindingHash", "registryProjectionBindingHash",
+    "schemaVersion", "sourceLane",
+  ], "generic launch V2 read model contract");
+  if (value.schemaVersion !== "programmable.generic-launch-read-model-contract.v2"
+    || value.sourceLane !== "generic.finalized-launch-v2") {
+    throw new TypeError("generic launch V2 read model contract is invalid");
+  }
+  return Object.freeze({
+    schemaVersion: "programmable.generic-launch-read-model-contract.v2" as const,
+    sourceLane: "generic.finalized-launch-v2" as const,
+    implementationBindingHash: digest(
+      value.implementationBindingHash,
+      "generic launch V2 read model implementation binding",
+    ),
+    persistenceBindingHash: digest(
+      value.persistenceBindingHash,
+      "generic launch V2 read model persistence binding",
+    ),
+    queryContractBindingHash: digest(
+      value.queryContractBindingHash,
+      "generic launch V2 read model query binding",
+    ),
+    approvalArtifactSchemaBindingHash: digest(
+      value.approvalArtifactSchemaBindingHash,
+      "generic launch V2 Approval schema binding",
+    ),
+    approvalReleaseBindingHash: digest(
+      value.approvalReleaseBindingHash,
+      "generic launch V2 Approval release binding",
+    ),
+    registryProjectionBindingHash: digest(
+      value.registryProjectionBindingHash,
+      "generic launch V2 Registry projection binding",
+    ),
+  });
+}
+
+function assertPage(
+  binding: GenericLaunchReadBindingV2,
+  readModelBindingHash: Sha256Digest,
+  raw: unknown,
+  limit: number,
+  currentCursor: string | null,
+): GenericLaunchReadPageV2 {
+  const value = exactObject(raw, ["nextCursor", "records", "total"],
+    "generic launch V2 page");
+  if (!Array.isArray(value.records) || value.records.length > limit) {
+    throw new TypeError("generic launch V2 page exceeds its bound");
+  }
+  const records = value.records.map((candidate) =>
+    assertBindingBoundRecord(binding, readModelBindingHash, candidate));
+  if (new Set(records.map(({ recordHash }) => recordHash)).size !== records.length) {
+    throw new TypeError("generic launch V2 page contains duplicate records");
+  }
+  const nextCursor = value.nextCursor === null
+    ? null
+    : cursor(value.nextCursor, "generic launch V2 next cursor");
+  if (nextCursor !== null
+    && (records.length === 0 || nextCursor === currentCursor)) {
+    throw new TypeError("generic launch V2 page cannot advance its cursor");
+  }
+  const total = decimal(value.total, "generic launch V2 total");
+  if (BigInt(total) < BigInt(records.length)) {
+    throw new TypeError("generic launch V2 total is invalid");
+  }
+  return Object.freeze({ records: Object.freeze(records), nextCursor, total });
+}
+
+function assertBindingBoundRecord(
+  binding: GenericLaunchReadBindingV2,
+  readModelBindingHash: Sha256Digest,
+  raw: unknown,
+): GenericLaunchRecordV2 {
+  const record = parseGenericLaunchRecordV2(raw);
+  const registry = record.sourceProjection.lifecycle;
+  if (record.readModelBindingHash !== readModelBindingHash
+    || registry.chainId !== binding.registryIdentity.chainId
+    || registry.generation !== binding.registryIdentity.generation
+    || registry.registryAddress !== binding.registryIdentity.registryAddress
+    || registry.registryRuntimeCodeKeccak256
+      !== binding.registryIdentity.registryRuntimeCodeKeccak256
+    || registry.registryPolicyCommitment
+      !== binding.registryIdentity.registryPolicyCommitment
+    || registry.minimumFinalityBlocks
+      !== binding.registryIdentity.minimumFinalityBlocks) {
+    throw new TypeError("generic launch V2 record is not activation-bound");
+  }
+  return record;
+}
+
+function parseFeedRequest(
+  request: Request,
+): Readonly<{ limit: number; cursor?: string }> | null {
+  if (!validBaseReadRequest(request)) return null;
+  const url = new URL(request.url);
+  if (url.search === "") return Object.freeze({ limit: 100 });
+  const keys = [...url.searchParams.keys()];
+  if (keys.length < 1 || keys.length > 2 || keys[0] !== "limit"
+    || (keys.length === 2 && keys[1] !== "cursor")) return null;
+  const limitValue = url.searchParams.get("limit");
+  if (limitValue === null || !/^(?:[1-9]|[1-9][0-9]|100)$/u.test(limitValue)) {
+    return null;
+  }
+  const limit = Number(limitValue);
+  const cursorValue = url.searchParams.get("cursor");
+  if (cursorValue !== null && !CURSOR.test(cursorValue)) return null;
+  const canonical = `?limit=${limit}${cursorValue === null
+    ? ""
+    : `&cursor=${cursorValue}`}`;
+  if (url.search !== canonical) return null;
+  return Object.freeze({
+    limit,
+    ...(cursorValue === null ? {} : { cursor: cursorValue }),
+  });
+}
+
+function validBaseReadRequest(request: Request): boolean {
+  if (request.method !== "GET" || request.body !== null
+    || request.headers.has("content-type")
+    || request.headers.get("accept")?.trim().toLowerCase()
+      !== "application/json") return false;
+  const url = new URL(request.url);
+  return url.username === "" && url.password === "" && url.hash === "";
+}
+
+function exactObject(
+  raw: unknown,
+  expectedKeys: readonly string[],
+  label: string,
+): Readonly<Record<string, unknown>> {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new TypeError(`${label} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(raw) as object | null;
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError(`${label} must be a plain object`);
+  }
+  const keys = Reflect.ownKeys(raw);
+  if (keys.some((key) => typeof key !== "string")) {
+    throw new TypeError(`${label} contains symbols`);
+  }
+  const sorted = (keys as string[]).sort();
+  const expected = [...expectedKeys].sort();
+  if (sorted.length !== expected.length
+    || sorted.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${label} has unexpected properties`);
+  }
+  for (const key of sorted) {
+    const descriptor = Object.getOwnPropertyDescriptor(raw, key);
+    if (descriptor === undefined || descriptor.get !== undefined
+      || descriptor.set !== undefined || !descriptor.enumerable
+      || !("value" in descriptor)) {
+      throw new TypeError(`${label} contains non-data properties`);
+    }
+  }
+  return raw as Readonly<Record<string, unknown>>;
+}
+
+function digest(value: unknown, label: string): Sha256Digest {
+  if (typeof value !== "string" || !DIGEST.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Sha256Digest;
+}
+
+function hash32(value: unknown, label: string): `0x${string}` {
+  if (typeof value !== "string" || !HASH32.test(value)
+    || /^0x0{64}$/u.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as `0x${string}`;
+}
+
+function evmAddress(value: unknown, label: string): `0x${string}` {
+  if (typeof value !== "string" || !ADDRESS.test(value)
+    || /^0x0{40}$/u.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as `0x${string}`;
+}
+
+function decimal(value: unknown, label: string): string {
+  if (typeof value !== "string" || !DECIMAL.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function positiveDecimal(value: unknown, label: string): string {
+  if (typeof value !== "string" || !POSITIVE_DECIMAL.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function cursor(value: unknown, label: string): string {
+  if (typeof value !== "string" || !CURSOR.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function canonicalTimestamp(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new TypeError("generic launch V2 activation timestamp is invalid");
+  }
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime()) || date.toISOString() !== value) {
+    throw new TypeError("generic launch V2 activation timestamp is invalid");
+  }
+  return value;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/json; charset=utf-8",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+function errorResponse(status: number, code: string): Response {
+  return jsonResponse(status, {
+    schemaVersion: "programmable.custom-launch-error.v1",
+    code,
+  });
+}

--- a/lib/server/custom-launch/registry-manifest-v2.ts
+++ b/lib/server/custom-launch/registry-manifest-v2.ts
@@ -1,0 +1,518 @@
+import "server-only";
+
+import { keccak256, toFunctionSelector, type Hex } from "viem";
+
+import deploymentSource from
+  "@/config/custom-registry-v2.deployment.prelaunch.json";
+import {
+  CUSTOM_REGISTRY_PUBLIC_MANIFEST_PATH_V2,
+  PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V2,
+  type CustomRegistryLivePublicManifestV2,
+  type CustomRegistryPublicManifestV2,
+  type CustomRegistryV2DeploymentEvidence,
+  type CustomRegistryV2FinalityBinding,
+  type CustomRegistryV2ReleaseEvidence,
+} from "@/lib/custom-launch/registry-public-manifest-v2";
+import { productionMainnetRpcPair } from
+  "@/lib/onchain/website-rpc-providers.server";
+import { parseStrictJson } from "../projection-target/canonical-json";
+
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const HASH32 = /^0x[0-9a-f]{64}$/u;
+const SHA256 = /^sha256:[0-9a-f]{64}$/u;
+const GIT_OBJECT_ID = /^[0-9a-f]{40}$/u;
+const DECIMAL = /^(?:0|[1-9][0-9]*)$/u;
+const QUANTITY = /^0x(?:0|[1-9a-f][0-9a-f]*)$/u;
+const ABI_WORD = /^0x[0-9a-f]{64}$/u;
+const MAXIMUM_RPC_RESPONSE_BYTES = 262_144;
+const RPC_TIMEOUT_MS = 5_000;
+
+const MANIFEST_HEADERS = Object.freeze({
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=60, stale-while-revalidate=300",
+  "content-type": "application/json; charset=utf-8",
+  "x-content-type-options": "nosniff",
+});
+
+const READINESS_HEADERS = Object.freeze({
+  "access-control-allow-origin": "*",
+  "cache-control": "no-store, max-age=0",
+  "content-type": "application/json; charset=utf-8",
+  "x-content-type-options": "nosniff",
+});
+
+export function resolveCustomRegistryPublicManifestV2(
+  source: unknown = deploymentSource,
+): CustomRegistryPublicManifestV2 {
+  const value = exactObject(source, "Custom Registry V2 deployment", [
+    "caip2", "chainId", "finality", "generation", "indexingEnabled",
+    "profiles", "publicReadEnabled", "registry", "release", "schemaVersion",
+    "status",
+  ]);
+  if (
+    value.schemaVersion !== "programmable.custom-registry-v2-deployment.v1"
+    || value.generation !== "2"
+    || value.chainId !== "1"
+    || value.caip2 !== "eip155:1"
+  ) throw new TypeError("Custom Registry V2 deployment identity is invalid");
+
+  const registry = exactObject(value.registry, "Custom Registry V2 registry", [
+    "address", "deploymentBlock", "deploymentBlockHash",
+    "deploymentTransactionHash", "runtimeCodeKeccak256",
+  ]);
+  const release = exactObject(value.release, "Custom Registry V2 release", [
+    "abiArtifactSha256", "eventSetSha256", "sourceArtifactSha256",
+    "sourceCommit", "sourceTree",
+  ]);
+  const finality = exactObject(value.finality, "Custom Registry V2 finality", [
+    "minimumConfirmations", "policyBindingHash",
+  ]);
+  assertProfilePayloadIsOpaque(value.profiles);
+
+  if (value.status === "prelaunch") {
+    if (
+      value.publicReadEnabled !== false
+      || value.indexingEnabled !== false
+      || Object.values(registry).some((entry) => entry !== null)
+      || Object.values(release).some((entry) => entry !== null)
+      || Object.values(finality).some((entry) => entry !== null)
+    ) throw new TypeError("Custom Registry V2 prelaunch binding is invalid");
+    return PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V2;
+  }
+
+  if (
+    value.status !== "live"
+    || value.publicReadEnabled !== true
+    || value.indexingEnabled !== true
+  ) throw new TypeError("Custom Registry V2 live binding is invalid");
+
+  const registryEvidence = parseRegistryEvidence(registry);
+  const releaseEvidence = parseReleaseEvidence(release);
+  const finalityBinding = parseFinalityBinding(finality);
+  return Object.freeze({
+    schemaVersion: "programmable.custom-registry-public-manifest.v2" as const,
+    status: "live" as const,
+    generation: "2" as const,
+    chainId: "1" as const,
+    caip2: "eip155:1" as const,
+    publicReadEnabled: true,
+    indexingEnabled: true,
+    registry: registryEvidence,
+    release: releaseEvidence,
+    finality: finalityBinding,
+  });
+}
+
+export function createCustomRegistryManifestHandlerV2(
+  source: unknown,
+): (request: Request) => Response {
+  return function customRegistryManifest(request: Request): Response {
+    if (!validReadRequest(request)) {
+      return Response.json({
+        schemaVersion: "programmable.custom-registry-public-manifest-error.v2",
+        status: "error",
+        code: "invalid_manifest_request",
+      }, { status: 400, headers: READINESS_HEADERS });
+    }
+    try {
+      return Response.json(resolveCustomRegistryPublicManifestV2(source), {
+        status: 200,
+        headers: MANIFEST_HEADERS,
+      });
+    } catch {
+      return Response.json({
+        schemaVersion: "programmable.custom-registry-public-manifest-error.v2",
+        status: "error",
+        code: "custom_registry_manifest_invalid",
+      }, { status: 503, headers: READINESS_HEADERS });
+    }
+  };
+}
+
+export function createCustomRegistryReadinessHandlerV2(input: Readonly<{
+  deploymentSource: unknown;
+  rpcUrls: () => readonly [URL, URL];
+  rpcFetch: typeof fetch;
+  now: () => Date;
+}>): (request: Request) => Promise<Response> {
+  return async function customRegistryReadiness(request: Request): Promise<Response> {
+    let manifest: CustomRegistryPublicManifestV2;
+    try {
+      manifest = resolveCustomRegistryPublicManifestV2(input.deploymentSource);
+    } catch {
+      return readinessError(503, "custom_registry_manifest_invalid", "prelaunch", input.now);
+    }
+    if (!validReadRequest(request)) {
+      return readinessError(400, "invalid_readiness_request", manifest.status, input.now);
+    }
+    if (manifest.status !== "live") {
+      return readinessError(503, "custom_registry_prelaunch", manifest.status, input.now);
+    }
+    try {
+      await assertCustomRegistryV2DeploymentReadiness({
+        deploymentSource: input.deploymentSource,
+        rpcUrls: input.rpcUrls(),
+        rpcFetch: input.rpcFetch,
+      });
+      return Response.json({
+        schemaVersion: "programmable.custom-registry-readiness.v2",
+        status: "ready",
+        registryStatus: "live",
+        generation: "2",
+        chainId: "1",
+        manifestPath: CUSTOM_REGISTRY_PUBLIC_MANIFEST_PATH_V2,
+        runtimeBindings: "verified",
+        providerQuorum: "verified",
+        checkedAt: input.now().toISOString(),
+      }, { status: 200, headers: READINESS_HEADERS });
+    } catch {
+      return readinessError(503, "custom_registry_not_ready", manifest.status, input.now);
+    }
+  };
+}
+
+export async function assertCustomRegistryV2DeploymentReadiness(input: Readonly<{
+  deploymentSource: unknown;
+  rpcUrls: readonly [URL, URL];
+  rpcFetch: typeof fetch;
+}>): Promise<CustomRegistryLivePublicManifestV2> {
+  const manifest = resolveCustomRegistryPublicManifestV2(input.deploymentSource);
+  if (manifest.status !== "live") {
+    throw new TypeError("Custom Registry V2 deployment is not live");
+  }
+  if (
+    input.rpcUrls.length !== 2
+    || input.rpcUrls[0].toString() === input.rpcUrls[1].toString()
+  ) throw new TypeError("Custom Registry V2 RPC quorum is invalid");
+  await Promise.all(input.rpcUrls.map((url) => verifyRegistryDeploymentWithProvider(
+    manifest,
+    url,
+    input.rpcFetch,
+  )));
+  return manifest;
+}
+
+async function verifyRegistryDeploymentWithProvider(
+  manifest: CustomRegistryLivePublicManifestV2,
+  rpcUrl: URL,
+  rpcFetch: typeof fetch,
+): Promise<void> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RPC_TIMEOUT_MS);
+  try {
+    const response = await rpcFetch(rpcUrl, {
+      method: "POST",
+      headers: { accept: "application/json", "content-type": "application/json" },
+      body: JSON.stringify([
+        { jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] },
+        { jsonrpc: "2.0", id: 2, method: "eth_getCode", params: [manifest.registry.address, "latest"] },
+        { jsonrpc: "2.0", id: 3, method: "eth_getTransactionReceipt", params: [manifest.registry.deploymentTransactionHash] },
+        { jsonrpc: "2.0", id: 4, method: "eth_getBlockByNumber", params: [decimalToQuantity(manifest.registry.deploymentBlock), false] },
+        { jsonrpc: "2.0", id: 5, method: "eth_blockNumber", params: [] },
+        { jsonrpc: "2.0", id: 6, method: "eth_call", params: [{
+          to: manifest.registry.address,
+          data: toFunctionSelector("REGISTRY_POLICY_COMMITMENT()"),
+        }, "latest"] },
+        { jsonrpc: "2.0", id: 7, method: "eth_call", params: [{
+          to: manifest.registry.address,
+          data: toFunctionSelector("MINIMUM_FINALITY_BLOCKS()"),
+        }, "latest"] },
+        { jsonrpc: "2.0", id: 8, method: "eth_call", params: [{
+          to: manifest.registry.address,
+          data: toFunctionSelector("REGISTRY_GENERATION()"),
+        }, "latest"] },
+      ]),
+      cache: "no-store",
+      credentials: "omit",
+      redirect: "error",
+      signal: controller.signal,
+    });
+    const contentType = response.headers.get("content-type")
+      ?.split(";", 1)[0]?.trim().toLowerCase();
+    const declaredLength = response.headers.get("content-length");
+    if (
+      response.status !== 200
+      || contentType !== "application/json"
+      || (declaredLength !== null && (!/^\d+$/u.test(declaredLength)
+        || Number(declaredLength) > MAXIMUM_RPC_RESPONSE_BYTES))
+    ) {
+      await response.body?.cancel();
+      throw new TypeError("Custom Registry V2 RPC response is invalid");
+    }
+    const bytes = await readBoundedResponse(response, MAXIMUM_RPC_RESPONSE_BYTES);
+    const parsed = parseStrictJson(new TextDecoder("utf-8", { fatal: true }).decode(bytes), {
+      maximumBytes: MAXIMUM_RPC_RESPONSE_BYTES,
+      maximumDepth: 16,
+    });
+    assertRegistryDeploymentRpcResults(parsed, manifest);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function assertRegistryDeploymentRpcResults(
+  raw: unknown,
+  manifest: CustomRegistryLivePublicManifestV2,
+): void {
+  if (!Array.isArray(raw) || raw.length !== 8) {
+    throw new TypeError("Custom Registry V2 RPC response is invalid");
+  }
+  const results = new Map<number, unknown>();
+  for (const candidate of raw) {
+    const value = exactObject(candidate, "Custom Registry V2 RPC result", [
+      "id", "jsonrpc", "result",
+    ]);
+    if (
+      value.jsonrpc !== "2.0"
+      || !Number.isSafeInteger(value.id)
+      || results.has(value.id as number)
+    ) throw new TypeError("Custom Registry V2 RPC response is invalid");
+    results.set(value.id as number, value.result);
+  }
+  if (results.get(1) !== "0x1") {
+    throw new TypeError("Custom Registry V2 RPC chain is invalid");
+  }
+  const code = results.get(2);
+  if (
+    typeof code !== "string"
+    || !/^0x(?:[0-9a-f]{2})+$/u.test(code)
+    || keccak256(code as Hex) !== manifest.registry.runtimeCodeKeccak256
+  ) throw new TypeError("Custom Registry V2 runtime binding is invalid");
+
+  const receipt = exactOpenObject(results.get(3), "Custom Registry V2 receipt");
+  if (
+    receipt.status !== "0x1"
+    || receipt.contractAddress !== manifest.registry.address
+    || receipt.transactionHash !== manifest.registry.deploymentTransactionHash
+    || receipt.blockHash !== manifest.registry.deploymentBlockHash
+    || quantityToDecimal(receipt.blockNumber) !== manifest.registry.deploymentBlock
+  ) throw new TypeError("Custom Registry V2 receipt binding is invalid");
+
+  const block = exactOpenObject(results.get(4), "Custom Registry V2 block");
+  if (
+    block.hash !== manifest.registry.deploymentBlockHash
+    || quantityToDecimal(block.number) !== manifest.registry.deploymentBlock
+  ) throw new TypeError("Custom Registry V2 block binding is invalid");
+  const head = quantityToDecimal(results.get(5));
+  if (
+    BigInt(head) < BigInt(manifest.registry.deploymentBlock)
+      + BigInt(manifest.finality.minimumConfirmations)
+  ) throw new TypeError("Custom Registry V2 deployment is not final");
+  if (results.get(6) !== manifest.finality.policyBindingHash) {
+    throw new TypeError("Custom Registry V2 policy binding is invalid");
+  }
+  if (
+    abiWordToDecimal(results.get(7)) !== manifest.finality.minimumConfirmations
+    || abiWordToDecimal(results.get(8)) !== "2"
+  ) throw new TypeError("Custom Registry V2 contract identity is invalid");
+}
+
+function parseRegistryEvidence(
+  value: Readonly<Record<string, unknown>>,
+): CustomRegistryV2DeploymentEvidence {
+  return Object.freeze({
+    address: address(value.address, "registry address"),
+    runtimeCodeKeccak256: hash32(value.runtimeCodeKeccak256, "registry runtime"),
+    deploymentTransactionHash: hash32(value.deploymentTransactionHash, "deployment transaction"),
+    deploymentBlock: decimal(value.deploymentBlock, "deployment block"),
+    deploymentBlockHash: hash32(value.deploymentBlockHash, "deployment block hash"),
+  });
+}
+
+function parseReleaseEvidence(
+  value: Readonly<Record<string, unknown>>,
+): CustomRegistryV2ReleaseEvidence {
+  return Object.freeze({
+    sourceCommit: gitObject(value.sourceCommit, "source commit"),
+    sourceTree: gitObject(value.sourceTree, "source tree"),
+    sourceArtifactSha256: sha256(value.sourceArtifactSha256, "source artifact"),
+    abiArtifactSha256: sha256(value.abiArtifactSha256, "ABI artifact"),
+    eventSetSha256: sha256(value.eventSetSha256, "event-set artifact"),
+  });
+}
+
+function parseFinalityBinding(
+  value: Readonly<Record<string, unknown>>,
+): CustomRegistryV2FinalityBinding {
+  const minimumConfirmations = decimal(
+    value.minimumConfirmations,
+    "minimum confirmations",
+  );
+  if (BigInt(minimumConfirmations) < 1n || BigInt(minimumConfirmations) > 255n) {
+    throw new TypeError("Custom Registry V2 minimum confirmations are invalid");
+  }
+  return Object.freeze({
+    minimumConfirmations,
+    policyBindingHash: hash32(value.policyBindingHash, "policy binding"),
+  });
+}
+
+function assertProfilePayloadIsOpaque(value: unknown): void {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Custom Registry V2 profile payload is invalid");
+  }
+}
+
+function exactObject(
+  value: unknown,
+  label: string,
+  keys: readonly string[],
+): Readonly<Record<string, unknown>> {
+  const object = exactOpenObject(value, label);
+  const actual = Object.keys(object).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length
+    || actual.some((key, index) => key !== expected[index])
+  ) throw new TypeError(`${label} keys are invalid`);
+  return object;
+}
+
+function exactOpenObject(
+  value: unknown,
+  label: string,
+): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function address(value: unknown, label: string): `0x${string}` {
+  if (typeof value !== "string" || !ADDRESS.test(value)) {
+    throw new TypeError(`Custom Registry V2 ${label} is invalid`);
+  }
+  return value as `0x${string}`;
+}
+
+function hash32(value: unknown, label: string): `0x${string}` {
+  if (
+    typeof value !== "string"
+    || !HASH32.test(value)
+    || value === `0x${"00".repeat(32)}`
+  ) throw new TypeError(`Custom Registry V2 ${label} is invalid`);
+  return value as `0x${string}`;
+}
+
+function sha256(value: unknown, label: string): `sha256:${string}` {
+  if (typeof value !== "string" || !SHA256.test(value)) {
+    throw new TypeError(`Custom Registry V2 ${label} is invalid`);
+  }
+  return value as `sha256:${string}`;
+}
+
+function gitObject(value: unknown, label: string): string {
+  if (typeof value !== "string" || !GIT_OBJECT_ID.test(value)) {
+    throw new TypeError(`Custom Registry V2 ${label} is invalid`);
+  }
+  return value;
+}
+
+function decimal(value: unknown, label: string): string {
+  if (typeof value !== "string" || !DECIMAL.test(value)) {
+    throw new TypeError(`Custom Registry V2 ${label} is invalid`);
+  }
+  return value;
+}
+
+function decimalToQuantity(value: string): `0x${string}` {
+  return `0x${BigInt(value).toString(16)}`;
+}
+
+function quantityToDecimal(value: unknown): string {
+  if (typeof value !== "string" || !QUANTITY.test(value)) {
+    throw new TypeError("Custom Registry V2 RPC quantity is invalid");
+  }
+  return BigInt(value).toString(10);
+}
+
+function abiWordToDecimal(value: unknown): string {
+  if (typeof value !== "string" || !ABI_WORD.test(value)) {
+    throw new TypeError("Custom Registry V2 ABI word is invalid");
+  }
+  return BigInt(value).toString(10);
+}
+
+async function readBoundedResponse(
+  response: Response,
+  maximumBytes: number,
+): Promise<Uint8Array> {
+  if (response.body === null) throw new TypeError("RPC response body is missing");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      length += next.value.byteLength;
+      if (length > maximumBytes) throw new TypeError("RPC response body is too large");
+      chunks.push(next.value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+function validReadRequest(request: Request): boolean {
+  const url = new URL(request.url);
+  const accept = request.headers.get("accept")?.trim().toLowerCase();
+  return request.method === "GET"
+    && request.body === null
+    && (accept === "application/json" || accept === "*/*")
+    && !request.headers.has("content-type")
+    && url.username === ""
+    && url.password === ""
+    && url.search === ""
+    && url.hash === "";
+}
+
+function readinessError(
+  status: 400 | 503,
+  code: string,
+  registryStatus: CustomRegistryPublicManifestV2["status"],
+  now: () => Date,
+): Response {
+  return Response.json({
+    schemaVersion: "programmable.custom-registry-readiness.v2",
+    status: "unready",
+    registryStatus,
+    generation: "2",
+    chainId: "1",
+    code,
+    manifestPath: CUSTOM_REGISTRY_PUBLIC_MANIFEST_PATH_V2,
+    runtimeBindings: "not-run",
+    providerQuorum: "not-run",
+    checkedAt: now().toISOString(),
+  }, { status, headers: READINESS_HEADERS });
+}
+
+export function handleProductionCustomRegistryManifestV2(
+  request: Request,
+): Response {
+  return createCustomRegistryManifestHandlerV2(deploymentSource)(request);
+}
+
+export function handleProductionCustomRegistryReadinessV2(
+  request: Request,
+): Promise<Response> {
+  return createCustomRegistryReadinessHandlerV2({
+    deploymentSource,
+    rpcUrls: () => {
+      const pair = productionMainnetRpcPair();
+      return [new URL(pair.primary.url), new URL(pair.secondary.url)] as const;
+    },
+    rpcFetch: globalThis.fetch.bind(globalThis),
+    now: () => new Date(),
+  })(request);
+}

--- a/tests/custom-launch-approval-runtime-readiness.test.ts
+++ b/tests/custom-launch-approval-runtime-readiness.test.ts
@@ -1,0 +1,175 @@
+import {
+  createHash,
+  generateKeyPairSync,
+  sign,
+} from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  APPROVAL_DESCRIPTOR_AUDIENCE_V2,
+  APPROVAL_RUNTIME_AGGREGATE_AUDIENCE_V1,
+  APPROVAL_RUNTIME_AGGREGATE_PATH_V1,
+  assertApprovalRuntimeAggregateReadinessV1,
+  verifyAggregateReadinessEnvelope,
+  type ExpectedApprovalRuntimeAggregateBindingV1,
+} from "../lib/server/custom-launch/approval-runtime-readiness-v1";
+import { canonicalizeJson } from
+  "../lib/server/projection-target/canonical-json";
+
+const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+const publicKeySpki = publicKey.export({ format: "der", type: "spki" });
+const publicKeySpkiBase64Url = publicKeySpki.toString("base64url");
+const publicKeySpkiSha256 = `sha256:${createHash("sha256")
+  .update(publicKeySpki)
+  .digest("hex")}` as const;
+const NOW = new Date("2026-08-13T12:00:00.000Z");
+
+const expected: ExpectedApprovalRuntimeAggregateBindingV1 = Object.freeze({
+  packageArtifactHash: `sha256:${"1".repeat(64)}`,
+  sourceCommit: "2".repeat(40),
+  sourceTree: "3".repeat(40),
+  reviewAuthorityMode: "autonomous_ai",
+  policyCommitment: `0x${"4".repeat(64)}`,
+  acceptanceSchemaSha256: `sha256:${"5".repeat(64)}`,
+  descriptorAuthority: Object.freeze({
+    audience: APPROVAL_DESCRIPTOR_AUDIENCE_V2,
+    keyId: "registry-projection-delivery",
+    keyEpoch: "7",
+    publicKeySpkiSha256: `sha256:${"6".repeat(64)}`,
+  }),
+  readinessAuthority: Object.freeze({
+    algorithm: "ed25519",
+    keyId: "approval-runtime-aggregate",
+    keyEpoch: "3",
+    publicKeySpkiBase64Url,
+    publicKeySpkiSha256,
+  }),
+  services: Object.freeze([
+    Object.freeze({
+      serviceId: "autonomous-authority",
+      deploymentId: "fly-machine-autonomous-v1",
+      imageDigest: `sha256:${"7".repeat(64)}`,
+      configurationBindingHash: `sha256:${"8".repeat(64)}`,
+      status: "ready",
+    }),
+    Object.freeze({
+      serviceId: "manual-authority",
+      deploymentId: "fly-machine-manual-v1",
+      imageDigest: `sha256:${"9".repeat(64)}`,
+      configurationBindingHash: `sha256:${"a".repeat(64)}`,
+      status: "ready",
+    }),
+  ]),
+});
+
+function signedEnvelope(challenge: string, mutate?: (core: Record<string, unknown>) => void) {
+  const core: Record<string, unknown> = {
+    schemaVersion: "programmable.approval-runtime-aggregate-readiness.v1",
+    audience: APPROVAL_RUNTIME_AGGREGATE_AUDIENCE_V1,
+    challengeBase64Url: challenge,
+    checkedAt: NOW.toISOString(),
+    expiresAt: new Date(NOW.getTime() + 30_000).toISOString(),
+    status: "ready",
+    release: {
+      packageArtifactHash: expected.packageArtifactHash,
+      sourceCommit: expected.sourceCommit,
+      sourceTree: expected.sourceTree,
+      reviewAuthorityMode: expected.reviewAuthorityMode,
+      policyCommitment: expected.policyCommitment,
+      acceptanceSchemaSha256: expected.acceptanceSchemaSha256,
+    },
+    descriptorAuthority: expected.descriptorAuthority,
+    readinessAuthority: expected.readinessAuthority,
+    services: expected.services,
+  };
+  mutate?.(core);
+  const signature = sign(null, Buffer.from(canonicalizeJson({
+    schemaVersion:
+      "programmable.approval-runtime-aggregate-readiness-signature.v1",
+    payload: core,
+  }), "utf8"), privateKey).toString("base64url");
+  return canonicalizeJson({ ...core, signatureBase64Url: signature });
+}
+
+describe("Approval runtime aggregate readiness contract", () => {
+  it("accepts only a fresh challenge-bound signed exact release and service set", () => {
+    const challenge = Buffer.alloc(32, 1).toString("base64url");
+    expect(() => verifyAggregateReadinessEnvelope(
+      signedEnvelope(challenge),
+      challenge,
+      expected,
+      NOW,
+    )).not.toThrow();
+  });
+
+  it("fetches only the exact aggregate route and binds its generated challenge", async () => {
+    const serviceFetch = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = new URL(String(input));
+      expect(url.pathname).toBe(APPROVAL_RUNTIME_AGGREGATE_PATH_V1);
+      expect(url.searchParams.get("audience"))
+        .toBe(APPROVAL_RUNTIME_AGGREGATE_AUDIENCE_V1);
+      const challenge = url.searchParams.get("challenge")!;
+      return new Response(signedEnvelope(challenge), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    await expect(assertApprovalRuntimeAggregateReadinessV1({
+      origin: new URL("https://approval-readiness.programmable.example"),
+      expected,
+      serviceFetch,
+      now: () => NOW,
+    })).resolves.toBeUndefined();
+    expect(serviceFetch).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["replayed challenge", (core: Record<string, unknown>) => {
+      core.challengeBase64Url = Buffer.alloc(32, 2).toString("base64url");
+    }],
+    ["release drift", (core: Record<string, unknown>) => {
+      core.release = { ...(core.release as object), packageArtifactHash: `sha256:${"f".repeat(64)}` };
+    }],
+    ["policy drift", (core: Record<string, unknown>) => {
+      core.release = { ...(core.release as object), policyCommitment: `0x${"f".repeat(64)}` };
+    }],
+    ["descriptor key drift", (core: Record<string, unknown>) => {
+      core.descriptorAuthority = {
+        ...(core.descriptorAuthority as object),
+        keyEpoch: "8",
+      };
+    }],
+    ["service image drift", (core: Record<string, unknown>) => {
+      const services = [...(core.services as readonly Record<string, unknown>[])];
+      services[0] = { ...services[0], imageDigest: `sha256:${"f".repeat(64)}` };
+      core.services = services;
+    }],
+    ["expired attestation", (core: Record<string, unknown>) => {
+      core.checkedAt = new Date(NOW.getTime() - 90_000).toISOString();
+      core.expiresAt = new Date(NOW.getTime() - 30_000).toISOString();
+    }],
+  ])("rejects %s even when the response is freshly signed", (_label, mutate) => {
+    const challenge = Buffer.alloc(32, 1).toString("base64url");
+    expect(() => verifyAggregateReadinessEnvelope(
+      signedEnvelope(challenge, mutate),
+      challenge,
+      expected,
+      NOW,
+    )).toThrow();
+  });
+
+  it("rejects a substituted readiness signature", () => {
+    const challenge = Buffer.alloc(32, 1).toString("base64url");
+    const parsed = JSON.parse(signedEnvelope(challenge));
+    parsed.signatureBase64Url = Buffer.alloc(64, 9).toString("base64url");
+    expect(() => verifyAggregateReadinessEnvelope(
+      canonicalizeJson(parsed),
+      challenge,
+      expected,
+      NOW,
+    )).toThrow(/signature/u);
+  });
+});

--- a/tests/custom-registry-v2-public-release.test.ts
+++ b/tests/custom-registry-v2-public-release.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it, vi } from "vitest";
+import { keccak256, toFunctionSelector } from "viem";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  CUSTOM_REGISTRY_PUBLIC_MANIFEST_PATH_V2,
+  PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V2,
+} from "../lib/custom-launch/registry-public-manifest-v2";
+import {
+  createCustomRegistryManifestHandlerV2,
+  createCustomRegistryReadinessHandlerV2,
+  resolveCustomRegistryPublicManifestV2,
+} from "../lib/server/custom-launch/registry-manifest-v2";
+
+const runtimeCode = "0x6000" as const;
+const address = `0x${"12".repeat(20)}` as const;
+const transactionHash = `0x${"34".repeat(32)}` as const;
+const blockHash = `0x${"56".repeat(32)}` as const;
+const policyBindingHash = `0x${"78".repeat(32)}` as const;
+const now = () => new Date("2026-08-13T00:00:00.000Z");
+
+function prelaunchSource() {
+  return {
+    schemaVersion: "programmable.custom-registry-v2-deployment.v1",
+    status: "prelaunch",
+    generation: "2",
+    chainId: "1",
+    caip2: "eip155:1",
+    publicReadEnabled: false,
+    indexingEnabled: false,
+    registry: {
+      address: null,
+      runtimeCodeKeccak256: null,
+      deploymentTransactionHash: null,
+      deploymentBlock: null,
+      deploymentBlockHash: null,
+    },
+    release: {
+      sourceCommit: null,
+      sourceTree: null,
+      sourceArtifactSha256: null,
+      abiArtifactSha256: null,
+      eventSetSha256: null,
+    },
+    finality: {
+      minimumConfirmations: null,
+      policyBindingHash: null,
+    },
+    profiles: {
+      descriptorFieldsRemainOpaqueToWebsiteReadiness: true,
+    },
+  };
+}
+
+function liveSource() {
+  return {
+    ...prelaunchSource(),
+    status: "live",
+    publicReadEnabled: true,
+    indexingEnabled: true,
+    registry: {
+      address,
+      runtimeCodeKeccak256: keccak256(runtimeCode),
+      deploymentTransactionHash: transactionHash,
+      deploymentBlock: "100",
+      deploymentBlockHash: blockHash,
+    },
+    release: {
+      sourceCommit: "a".repeat(40),
+      sourceTree: "b".repeat(40),
+      sourceArtifactSha256: `sha256:${"c".repeat(64)}`,
+      abiArtifactSha256: `sha256:${"d".repeat(64)}`,
+      eventSetSha256: `sha256:${"e".repeat(64)}`,
+    },
+    finality: {
+      minimumConfirmations: "12",
+      policyBindingHash,
+    },
+  };
+}
+
+function request(path: string) {
+  return new Request(`https://programmable.market${path}`, {
+    headers: { accept: "application/json" },
+  });
+}
+
+function rpcResponse(input?: Readonly<{
+  code?: string;
+  head?: string;
+  contractAddress?: string;
+}>) {
+  return new Response(JSON.stringify([
+    { jsonrpc: "2.0", id: 1, result: "0x1" },
+    { jsonrpc: "2.0", id: 2, result: input?.code ?? runtimeCode },
+    {
+      jsonrpc: "2.0",
+      id: 3,
+      result: {
+        status: "0x1",
+        contractAddress: input?.contractAddress ?? address,
+        transactionHash,
+        blockHash,
+        blockNumber: "0x64",
+      },
+    },
+    {
+      jsonrpc: "2.0",
+      id: 4,
+      result: { hash: blockHash, number: "0x64" },
+    },
+    { jsonrpc: "2.0", id: 5, result: input?.head ?? "0x70" },
+    { jsonrpc: "2.0", id: 6, result: policyBindingHash },
+    { jsonrpc: "2.0", id: 7, result: `0x${"0".repeat(63)}c` },
+    { jsonrpc: "2.0", id: 8, result: `0x${"0".repeat(63)}2` },
+  ]), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("Custom Registry V2 public release binding", () => {
+  it("publishes the exact null prelaunch identity without profile semantics", () => {
+    expect(resolveCustomRegistryPublicManifestV2(prelaunchSource())).toEqual(
+      PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V2,
+    );
+    expect(resolveCustomRegistryPublicManifestV2(prelaunchSource()))
+      .not.toHaveProperty("profiles");
+  });
+
+  it("rejects partial activation and unknown deployment fields", () => {
+    expect(() => resolveCustomRegistryPublicManifestV2({
+      ...prelaunchSource(),
+      publicReadEnabled: true,
+    })).toThrow(/prelaunch binding/u);
+    expect(() => resolveCustomRegistryPublicManifestV2({
+      ...liveSource(),
+      registry: { ...liveSource().registry, runtimeCodeKeccak256: null },
+    })).toThrow(/registry runtime/u);
+    expect(() => resolveCustomRegistryPublicManifestV2({
+      ...liveSource(),
+      surprise: true,
+    })).toThrow(/keys/u);
+  });
+
+  it("maps only exact finalized deployment and artifact bindings to live", () => {
+    expect(resolveCustomRegistryPublicManifestV2(liveSource())).toEqual({
+      schemaVersion: "programmable.custom-registry-public-manifest.v2",
+      status: "live",
+      generation: "2",
+      chainId: "1",
+      caip2: "eip155:1",
+      publicReadEnabled: true,
+      indexingEnabled: true,
+      registry: liveSource().registry,
+      release: liveSource().release,
+      finality: liveSource().finality,
+    });
+  });
+
+  it("serves an explicit prelaunch manifest and rejects malformed requests", async () => {
+    const handler = createCustomRegistryManifestHandlerV2(prelaunchSource());
+    const response = handler(request(CUSTOM_REGISTRY_PUBLIC_MANIFEST_PATH_V2));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V2);
+
+    const invalid = handler(new Request(
+      `https://programmable.market${CUSTOM_REGISTRY_PUBLIC_MANIFEST_PATH_V2}?drift=1`,
+      { headers: { accept: "application/json" } },
+    ));
+    expect(invalid.status).toBe(400);
+  });
+
+  it("keeps readiness closed before the Registry deployment is live", async () => {
+    const rpcFetch = vi.fn<typeof fetch>();
+    const handler = createCustomRegistryReadinessHandlerV2({
+      deploymentSource: prelaunchSource(),
+      rpcUrls: () => [new URL("https://primary.invalid"), new URL("https://secondary.invalid")],
+      rpcFetch,
+      now,
+    });
+    const response = await handler(request("/api/custom-launch/registry/v2/readiness"));
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      status: "unready",
+      registryStatus: "prelaunch",
+      runtimeBindings: "not-run",
+      providerQuorum: "not-run",
+    });
+    expect(rpcFetch).not.toHaveBeenCalled();
+  });
+
+  it("requires exact deployment, runtime and finality evidence from both providers", async () => {
+    const rpcFetch = vi.fn<typeof fetch>().mockImplementation(async () => rpcResponse());
+    const handler = createCustomRegistryReadinessHandlerV2({
+      deploymentSource: liveSource(),
+      rpcUrls: () => [new URL("https://primary.invalid"), new URL("https://secondary.invalid")],
+      rpcFetch,
+      now,
+    });
+    const response = await handler(request("/api/custom-launch/registry/v2/readiness"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      schemaVersion: "programmable.custom-registry-readiness.v2",
+      status: "ready",
+      registryStatus: "live",
+      generation: "2",
+      chainId: "1",
+      manifestPath: CUSTOM_REGISTRY_PUBLIC_MANIFEST_PATH_V2,
+      runtimeBindings: "verified",
+      providerQuorum: "verified",
+      checkedAt: now().toISOString(),
+    });
+    expect(rpcFetch).toHaveBeenCalledTimes(2);
+    for (const [, requestInit] of rpcFetch.mock.calls) {
+      const calls = JSON.parse(String(requestInit?.body));
+      expect(calls.map((call: { method: string }) => call.method)).toEqual([
+        "eth_chainId",
+        "eth_getCode",
+        "eth_getTransactionReceipt",
+        "eth_getBlockByNumber",
+        "eth_blockNumber",
+        "eth_call",
+        "eth_call",
+        "eth_call",
+      ]);
+      expect(calls.slice(5).map((call: { params: [{ data: string }] }) =>
+        call.params[0].data)).toEqual([
+        toFunctionSelector("REGISTRY_POLICY_COMMITMENT()"),
+        toFunctionSelector("MINIMUM_FINALITY_BLOCKS()"),
+        toFunctionSelector("REGISTRY_GENERATION()"),
+      ]);
+    }
+  });
+
+  it.each([
+    ["runtime drift", { code: "0x6001" }],
+    ["receipt drift", { contractAddress: `0x${"99".repeat(20)}` }],
+    ["insufficient finality", { head: "0x6f" }],
+  ])("fails closed on one provider %s", async (_label, mutation) => {
+    let call = 0;
+    const rpcFetch = vi.fn<typeof fetch>().mockImplementation(async () => {
+      call += 1;
+      return call === 1 ? rpcResponse() : rpcResponse(mutation);
+    });
+    const handler = createCustomRegistryReadinessHandlerV2({
+      deploymentSource: liveSource(),
+      rpcUrls: () => [new URL("https://primary.invalid"), new URL("https://secondary.invalid")],
+      rpcFetch,
+      now,
+    });
+    const response = await handler(request("/api/custom-launch/registry/v2/readiness"));
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      status: "unready",
+      code: "custom_registry_not_ready",
+      runtimeBindings: "not-run",
+      providerQuorum: "not-run",
+    });
+  });
+});

--- a/tests/generic-launch-read-v2.test.ts
+++ b/tests/generic-launch-read-v2.test.ts
@@ -1,0 +1,467 @@
+import {
+  createHash,
+  generateKeyPairSync,
+  sign,
+  type KeyObject,
+} from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { canonicalizeJson, type JsonValue } from
+  "../lib/server/projection-target/canonical-json";
+import { canonicalSha256, type Sha256Digest } from
+  "../lib/server/projection-target/hashing";
+import {
+  createGenericLaunchRecordV2,
+  type GenericLaunchRecordV2,
+  type GenericLaunchSourceProjectionV2,
+} from "../lib/server/custom-launch/generic-launch-contract-v2";
+import {
+  createActiveGenericLaunchReadBindingV2,
+  createGenericLaunchReadHandlersV2,
+  type GenericLaunchReadBindingV2,
+  type GenericLaunchReadModelContractV2,
+  type GenericLaunchReadStoreV2,
+  type SignedGenericLaunchReadEnvelopeV2,
+} from "../lib/server/custom-launch/generic-launch-read-v2";
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import publicSchema from "../config/generic-launch-public.v2.schema.json";
+
+const sha = (character: string) => `sha256:${character.repeat(64)}` as const;
+const hash = (character: string) => `0x${character.repeat(64)}` as const;
+const address = (character: string) => `0x${character.repeat(40)}` as const;
+const signingKeys = generateKeyPairSync("ed25519");
+const publicKeySpki = signingKeys.publicKey.export({ format: "der", type: "spki" });
+
+const READ_MODEL_CONTRACT: GenericLaunchReadModelContractV2 = {
+  schemaVersion: "programmable.generic-launch-read-model-contract.v2",
+  sourceLane: "generic.finalized-launch-v2",
+  implementationBindingHash: sha("1"),
+  persistenceBindingHash: sha("2"),
+  queryContractBindingHash: sha("3"),
+  approvalArtifactSchemaBindingHash: sha("4"),
+  approvalReleaseBindingHash: sha("5"),
+  registryProjectionBindingHash: sha("6"),
+};
+const READ_MODEL_BINDING = canonicalSha256(
+  READ_MODEL_CONTRACT.schemaVersion,
+  READ_MODEL_CONTRACT,
+);
+
+function projection(seed = "3"): GenericLaunchSourceProjectionV2 {
+  return {
+    schemaVersion: "programmable.generic-launch-source-projection.v2",
+    sourceRevision: {
+      repositoryId: seed === "3" ? "123456789" : "987654321",
+      repositoryFullName: `alice/example-hook-${seed}`,
+      commitObjectId: seed.repeat(40),
+      treeObjectId: (seed === "3" ? "4" : "5").repeat(40),
+    },
+    approval: {
+      approvalRevision: "7",
+      approvalId: hash("1"),
+      approvalEvidenceHash: hash("2"),
+      signedReceiptArtifactHash: sha("2"),
+    },
+    descriptor: {
+      descriptorHash: hash("3"),
+      launchId: hash(seed === "3" ? "4" : "5"),
+      launchWallet: address("5"),
+      primaryContract: address("7"),
+      primaryRuntimeCodeHash: hash("8"),
+      componentSetHash: hash("9"),
+      sourceArtifactHash: hash("a"),
+      configurationHash: hash("b"),
+      launchPlanHash: hash("c"),
+      projectCommitment: hash("d"),
+      marketMode: "Standard10",
+      marketModeValue: 1,
+      protocolFeeBps: 10,
+    },
+    lifecycle: {
+      chainId: "1",
+      generation: "2",
+      registryAddress: address("6"),
+      registryRuntimeCodeKeccak256: hash("7"),
+      registryPolicyCommitment: hash("8"),
+      minimumFinalityBlocks: "12",
+      primaryLaunch: {
+        transactionHash: hash("9"),
+        sender: address("5"),
+        blockHash: hash("a"),
+        blockNumber: "88",
+        transactionIndex: "2",
+        status: "success",
+      },
+      authorization: {
+        eventName: "CustomLaunchApprovalAuthorizedV2",
+        transactionHash: hash("a"),
+        blockHash: hash("b"),
+        blockNumber: "90",
+        transactionIndex: "3",
+        logIndex: "4",
+        removed: false,
+      },
+      registration: [
+        {
+          eventName: "CustomLaunchRegisteredV2",
+          transactionHash: hash("b"),
+          blockHash: hash("c"),
+          blockNumber: "95",
+          transactionIndex: "4",
+          logIndex: "5",
+          removed: false,
+        },
+        {
+          eventName: "CustomLaunchDescriptorCommittedV2",
+          transactionHash: hash("b"),
+          blockHash: hash("c"),
+          blockNumber: "95",
+          transactionIndex: "4",
+          logIndex: "6",
+          removed: false,
+        },
+        {
+          eventName: "CustomLaunchDescriptorEvidenceCommittedV2",
+          transactionHash: hash("b"),
+          blockHash: hash("c"),
+          blockNumber: "95",
+          transactionIndex: "4",
+          logIndex: "7",
+          removed: false,
+        },
+      ],
+      finalization: {
+        eventName: "CustomLaunchFinalizedV2",
+        transactionHash: hash("c"),
+        blockHash: hash("d"),
+        blockNumber: "100",
+        transactionIndex: "5",
+        logIndex: "8",
+        removed: false,
+      },
+      latestCommonHead: "112",
+      latestCommonHeadHash: hash("e"),
+      latestStatus: "finalized",
+      revokedAtBlock: "0",
+      revocationEvidenceHash: hash("0"),
+    },
+  };
+}
+
+function record(seed = "3"): GenericLaunchRecordV2 {
+  return createGenericLaunchRecordV2({
+    sourceProjection: projection(seed),
+    readModelBindingHash: READ_MODEL_BINDING,
+  });
+}
+
+function activeBinding(): GenericLaunchReadBindingV2 {
+  return createActiveGenericLaunchReadBindingV2({
+    activatedAt: "2026-08-13T20:00:00.000Z",
+    readModelBindingHash: READ_MODEL_BINDING,
+    readModelVerifier: {
+      algorithm: "ed25519",
+      publicKeySpkiBase64Url: publicKeySpki.toString("base64url"),
+      publicKeySha256:
+        `sha256:${createHash("sha256").update(publicKeySpki).digest("hex")}`,
+    },
+    registryIdentity: {
+      chainId: "1",
+      generation: "2",
+      registryAddress: address("6"),
+      registryRuntimeCodeKeccak256: hash("7"),
+      registryPolicyCommitment: hash("8"),
+      minimumFinalityBlocks: "12",
+    },
+    api: {
+      feedPath: "/api/custom-launch/generic/v2/launches",
+      detailPathTemplate:
+        "/api/custom-launch/generic/v2/launches/{recordHash}",
+    },
+  });
+}
+
+function signedEnvelope(
+  binding: GenericLaunchReadBindingV2,
+  requestBindingHash: Sha256Digest,
+  payload: unknown,
+  privateKey: KeyObject = signingKeys.privateKey,
+): SignedGenericLaunchReadEnvelopeV2 {
+  if (binding.activationBindingHash === null
+    || binding.readModelBindingHash === null) {
+    throw new TypeError("test binding must be active");
+  }
+  const message = Object.freeze({
+    schemaVersion: "programmable.generic-launch-read-signature-message.v2" as const,
+    activationBindingHash: binding.activationBindingHash,
+    readModelBindingHash: binding.readModelBindingHash,
+    requestBindingHash,
+    payload,
+  });
+  return Object.freeze({
+    schemaVersion: "programmable.signed-generic-launch-read-envelope.v2" as const,
+    activationBindingHash: binding.activationBindingHash,
+    readModelBindingHash: binding.readModelBindingHash,
+    requestBindingHash,
+    payload,
+    signatureBase64Url: sign(
+      null,
+      Buffer.from(canonicalizeJson(message as unknown as JsonValue), "utf8"),
+      privateKey,
+    ).toString("base64url"),
+  });
+}
+
+function envelopeBytes(
+  binding: GenericLaunchReadBindingV2,
+  requestBindingHash: Sha256Digest,
+  payload: unknown,
+  privateKey: KeyObject = signingKeys.privateKey,
+): string {
+  return canonicalizeJson(signedEnvelope(
+    binding,
+    requestBindingHash,
+    payload,
+    privateKey,
+  ) as unknown as JsonValue);
+}
+
+function store(
+  binding: GenericLaunchReadBindingV2,
+  records: readonly GenericLaunchRecordV2[],
+  contract: GenericLaunchReadModelContractV2 = READ_MODEL_CONTRACT,
+  privateKey: KeyObject = signingKeys.privateKey,
+): GenericLaunchReadStoreV2 {
+  return {
+    sourceLane: "generic.finalized-launch-v2",
+    readModelContract: contract,
+    async findFinalizedLaunches({ limit, cursor, requestBindingHash }) {
+      const offset = cursor === undefined ? 0 : Number(cursor.slice(1));
+      const page = records.slice(offset, offset + limit);
+      const nextOffset = offset + page.length;
+      return envelopeBytes(binding, requestBindingHash, {
+        records: page,
+        nextCursor: nextOffset < records.length ? `c${nextOffset}` : null,
+        total: String(records.length),
+      }, privateKey);
+    },
+    async findFinalizedLaunchByRecordHash({ recordHash, requestBindingHash }) {
+      return envelopeBytes(
+        binding,
+        requestBindingHash,
+        records.find((candidate) => candidate.recordHash === recordHash) ?? null,
+        privateKey,
+      );
+    },
+  };
+}
+
+function request(path: string, accept = "application/json"): Request {
+  return new Request(`https://programmable.market${path}`, {
+    headers: { accept },
+  });
+}
+
+describe("Generic launch V2 signed read adapter", () => {
+  it("keeps the public JSON schema aligned with records and read contracts", () => {
+    const binding = activeBinding();
+    const envelope = signedEnvelope(binding, sha("f"), {
+      records: [record()], nextCursor: null, total: "1",
+    });
+    const ajv = new Ajv2020({ allErrors: true, strict: true });
+    addFormats(ajv);
+    const validate = ajv.compile(publicSchema);
+    for (const [definition, value] of [
+      ["genericLaunchRecord", record()],
+      ["genericLaunchReadModelContract", READ_MODEL_CONTRACT],
+      ["genericLaunchReadBinding", binding],
+      ["signedGenericLaunchReadEnvelope", envelope],
+      ["genericLaunchFeed", {
+        schemaVersion: "programmable.generic-launch-feed.v2",
+        records: [record()],
+        nextCursor: null,
+        total: "1",
+      }],
+      ["genericLaunchView", {
+        schemaVersion: "programmable.generic-launch-view.v2",
+        record: record(),
+      }],
+    ] as const) {
+      const component = ajv.compile({
+        $ref: `${publicSchema.$id}#/$defs/${definition}`,
+      });
+      expect(component(value), JSON.stringify(component.errors)).toBe(true);
+    }
+    expect(validate({ ...record(), criteria: [] })).toBe(false);
+  });
+
+  it("keeps production routes dark without an exact activation and store", async () => {
+    const handlers = createGenericLaunchReadHandlersV2({ binding: null, store: null });
+    const feed = await handlers.feed(request(
+      "/api/custom-launch/generic/v2/launches",
+    ));
+    const detail = await handlers.detail(
+      request(`/api/custom-launch/generic/v2/launches/${sha("1")}`),
+      sha("1"),
+    );
+
+    expect(feed.status).toBe(503);
+    expect(detail.status).toBe(503);
+    expect(feed.headers.get("cache-control")).toBe("no-store");
+    await expect(feed.json()).resolves.toEqual({
+      schemaVersion: "programmable.custom-launch-error.v1",
+      code: "generic_launch_v2_not_active",
+    });
+    expect(() => createGenericLaunchReadHandlersV2({
+      binding: null,
+      store: store(activeBinding(), []),
+    })).toThrow(/cannot bind a read store/u);
+  });
+
+  it("serves identical signed V2 records from feed and detail", async () => {
+    const binding = activeBinding();
+    const records = [record("3"), record("a")];
+    const handlers = createGenericLaunchReadHandlersV2({
+      binding,
+      store: store(binding, records),
+    });
+
+    const feed = await handlers.feed(request(
+      "/api/custom-launch/generic/v2/launches?limit=1",
+    ));
+    const detail = await handlers.detail(
+      request(`/api/custom-launch/generic/v2/launches/${records[0].recordHash}`),
+      records[0].recordHash,
+    );
+
+    expect(feed.status).toBe(200);
+    expect(detail.status).toBe(200);
+    await expect(feed.json()).resolves.toEqual({
+      schemaVersion: "programmable.generic-launch-feed.v2",
+      records: [records[0]],
+      nextCursor: "c1",
+      total: "2",
+    });
+    await expect(detail.json()).resolves.toEqual({
+      schemaVersion: "programmable.generic-launch-view.v2",
+      record: records[0],
+    });
+  });
+
+  it("rejects a store contract or record outside the exact activation", async () => {
+    const binding = activeBinding();
+    expect(() => createGenericLaunchReadHandlersV2({
+      binding,
+      store: store(binding, [], {
+        ...READ_MODEL_CONTRACT,
+        registryProjectionBindingHash: sha("f"),
+      }),
+    })).toThrow(/not activation-bound/u);
+
+    const sourceProjection = projection();
+    const changedProjection = {
+      ...sourceProjection,
+      lifecycle: {
+        ...sourceProjection.lifecycle,
+        registryPolicyCommitment: hash("f"),
+      },
+    };
+    const unbound = createGenericLaunchRecordV2({
+      sourceProjection: changedProjection,
+      readModelBindingHash: READ_MODEL_BINDING,
+    });
+    const handlers = createGenericLaunchReadHandlersV2({
+      binding,
+      store: store(binding, [unbound]),
+    });
+    expect((await handlers.feed(request(
+      "/api/custom-launch/generic/v2/launches?limit=1",
+    ))).status).toBe(503);
+  });
+
+  it("rejects forged signatures, request replay and detail substitution", async () => {
+    const binding = activeBinding();
+    const value = record();
+    const attacker = generateKeyPairSync("ed25519");
+    const forged = createGenericLaunchReadHandlersV2({
+      binding,
+      store: store(binding, [value], READ_MODEL_CONTRACT, attacker.privateKey),
+    });
+    expect((await forged.feed(request(
+      "/api/custom-launch/generic/v2/launches?limit=1",
+    ))).status).toBe(503);
+
+    const replayStore = store(binding, [value]);
+    let replayed: string | null = null;
+    replayStore.findFinalizedLaunches = async ({ requestBindingHash }) => {
+      replayed ??= envelopeBytes(binding, requestBindingHash, {
+        records: [value], nextCursor: null, total: "1",
+      });
+      return replayed;
+    };
+    const replay = createGenericLaunchReadHandlersV2({ binding, store: replayStore });
+    expect((await replay.feed(request(
+      "/api/custom-launch/generic/v2/launches?limit=1",
+    ))).status).toBe(200);
+    expect((await replay.feed(request(
+      "/api/custom-launch/generic/v2/launches?limit=1",
+    ))).status).toBe(503);
+
+    const substitutedStore = store(binding, [value]);
+    substitutedStore.findFinalizedLaunchByRecordHash = async ({
+      requestBindingHash,
+    }) => envelopeBytes(binding, requestBindingHash, value);
+    const substituted = createGenericLaunchReadHandlersV2({
+      binding,
+      store: substitutedStore,
+    });
+    expect((await substituted.detail(
+      request(`/api/custom-launch/generic/v2/launches/${sha("f")}`),
+      sha("f"),
+    )).status).toBe(503);
+  });
+
+  it("rejects invalid pages and captures exact own data methods once", async () => {
+    const binding = activeBinding();
+    const value = record();
+    const mutableStore = store(binding, [value]);
+    const handlers = createGenericLaunchReadHandlersV2({
+      binding,
+      store: mutableStore,
+    });
+    mutableStore.findFinalizedLaunches = async () => {
+      throw new TypeError("substituted after capture");
+    };
+    expect((await handlers.feed(request(
+      "/api/custom-launch/generic/v2/launches?limit=1",
+    ))).status).toBe(200);
+
+    const duplicateStore = store(binding, [value]);
+    duplicateStore.findFinalizedLaunches = async ({ requestBindingHash }) =>
+      envelopeBytes(binding, requestBindingHash, {
+        records: [value, value], nextCursor: null, total: "2",
+      });
+    const duplicate = createGenericLaunchReadHandlersV2({
+      binding,
+      store: duplicateStore,
+    });
+    expect((await duplicate.feed(request(
+      "/api/custom-launch/generic/v2/launches?limit=2",
+    ))).status).toBe(503);
+
+    const getterStore = store(binding, [value]);
+    const getter = getterStore.findFinalizedLaunches;
+    Object.defineProperty(getterStore, "findFinalizedLaunches", {
+      get: () => getter,
+      enumerable: true,
+      configurable: true,
+    });
+    expect(() => createGenericLaunchReadHandlersV2({
+      binding,
+      store: getterStore,
+    })).toThrow(/non-data properties/u);
+  });
+});

--- a/tests/generic-launch-record-v2.test.ts
+++ b/tests/generic-launch-record-v2.test.ts
@@ -352,6 +352,27 @@ describe("Generic launch record V2", () => {
     )).toThrow(/invalid/u);
   });
 
+  it.each([
+    ["approval revision", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      approval: { ...candidate.approval, approvalRevision: "1".repeat(79) },
+    })],
+    ["log index", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      lifecycle: {
+        ...candidate.lifecycle,
+        finalization: {
+          ...candidate.lifecycle.finalization,
+          logIndex: "1".repeat(79),
+        },
+      },
+    })],
+  ])("rejects a decimal wider than uint256 for %s", (_label, mutate) => {
+    expect(() => record(
+      mutate(projection()) as GenericLaunchSourceProjectionV2,
+    )).toThrow(/invalid/u);
+  });
+
   it("rejects any added field and any hash mutation", () => {
     const value = record();
     expect(() => parseGenericLaunchRecordV2({ ...value, criteria: [] }))

--- a/tests/generic-launch-record-v2.test.ts
+++ b/tests/generic-launch-record-v2.test.ts
@@ -57,13 +57,61 @@ function projection(): GenericLaunchSourceProjectionV2 {
       registryRuntimeCodeKeccak256: hash("7"),
       registryPolicyCommitment: hash("8"),
       minimumFinalityBlocks: "12",
-      primaryLaunchTransactionHash: hash("9"),
-      authorizationTransactionHash: hash("a"),
-      registrationTransactionHash: hash("b"),
-      finalizationTransactionHash: hash("c"),
-      finalizedAtBlock: "100",
-      finalizedBlockHash: hash("d"),
-      finalizationLogIndex: "4",
+      primaryLaunch: {
+        transactionHash: hash("9"),
+        sender: address("5"),
+        blockHash: hash("a"),
+        blockNumber: "88",
+        transactionIndex: "2",
+        status: "success",
+      },
+      authorization: {
+        eventName: "CustomLaunchApprovalAuthorizedV2",
+        transactionHash: hash("a"),
+        blockHash: hash("b"),
+        blockNumber: "90",
+        transactionIndex: "3",
+        logIndex: "4",
+        removed: false,
+      },
+      registration: [
+        {
+          eventName: "CustomLaunchRegisteredV2",
+          transactionHash: hash("b"),
+          blockHash: hash("c"),
+          blockNumber: "95",
+          transactionIndex: "4",
+          logIndex: "5",
+          removed: false,
+        },
+        {
+          eventName: "CustomLaunchDescriptorCommittedV2",
+          transactionHash: hash("b"),
+          blockHash: hash("c"),
+          blockNumber: "95",
+          transactionIndex: "4",
+          logIndex: "6",
+          removed: false,
+        },
+        {
+          eventName: "CustomLaunchDescriptorEvidenceCommittedV2",
+          transactionHash: hash("b"),
+          blockHash: hash("c"),
+          blockNumber: "95",
+          transactionIndex: "4",
+          logIndex: "7",
+          removed: false,
+        },
+      ],
+      finalization: {
+        eventName: "CustomLaunchFinalizedV2",
+        transactionHash: hash("c"),
+        blockHash: hash("d"),
+        blockNumber: "100",
+        transactionIndex: "5",
+        logIndex: "8",
+        removed: false,
+      },
       latestCommonHead: "112",
       latestCommonHeadHash: hash("e"),
       latestStatus: "finalized",
@@ -124,6 +172,131 @@ describe("Generic launch record V2", () => {
     })).toThrow(/finality is insufficient/u);
   });
 
+  it("binds the independently verified primary receipt sender to the launch wallet", () => {
+    const sourceProjection = projection();
+    expect(() => record({
+      ...sourceProjection,
+      lifecycle: {
+        ...sourceProjection.lifecycle,
+        primaryLaunch: {
+          ...sourceProjection.lifecycle.primaryLaunch,
+          sender: address("f"),
+        },
+      },
+    })).toThrow(/primary launch sender/u);
+  });
+
+  it.each([
+    ["launch wallet", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      descriptor: { ...candidate.descriptor, launchWallet: address("0") },
+    })],
+    ["primary contract", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      descriptor: { ...candidate.descriptor, primaryContract: address("0") },
+    })],
+    ["registry address", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      lifecycle: { ...candidate.lifecycle, registryAddress: address("0") },
+    })],
+  ])("rejects a zero %s", (_label, mutate) => {
+    expect(() => record(
+      mutate(projection()) as GenericLaunchSourceProjectionV2,
+    )).toThrow(/invalid/u);
+  });
+
+  it.each([
+    ["primary after authorization", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      lifecycle: {
+        ...candidate.lifecycle,
+        primaryLaunch: {
+          ...candidate.lifecycle.primaryLaunch,
+          blockNumber: "91",
+        },
+      },
+    })],
+    ["primary later in authorization block", (
+      candidate: GenericLaunchSourceProjectionV2,
+    ) => ({
+      ...candidate,
+      lifecycle: {
+        ...candidate.lifecycle,
+        primaryLaunch: {
+          ...candidate.lifecycle.primaryLaunch,
+          blockNumber: "90",
+          transactionIndex: "3",
+        },
+      },
+    })],
+    ["authorization after registration", (
+      candidate: GenericLaunchSourceProjectionV2,
+    ) => ({
+      ...candidate,
+      lifecycle: {
+        ...candidate.lifecycle,
+        authorization: {
+          ...candidate.lifecycle.authorization,
+          blockNumber: "96",
+        },
+      },
+    })],
+    ["finalization before registration", (
+      candidate: GenericLaunchSourceProjectionV2,
+    ) => ({
+      ...candidate,
+      lifecycle: {
+        ...candidate.lifecycle,
+        finalization: {
+          ...candidate.lifecycle.finalization,
+          blockNumber: "94",
+        },
+      },
+    })],
+    ["finalization after common head", (
+      candidate: GenericLaunchSourceProjectionV2,
+    ) => ({
+      ...candidate,
+      lifecycle: {
+        ...candidate.lifecycle,
+        finalization: {
+          ...candidate.lifecycle.finalization,
+          blockNumber: "113",
+        },
+        latestCommonHead: "112",
+      },
+    })],
+  ])("rejects invalid lifecycle order: %s", (_label, mutate) => {
+    expect(() => record(
+      mutate(projection()) as GenericLaunchSourceProjectionV2,
+    )).toThrow(/lifecycle order/u);
+  });
+
+  it("requires the exact ordered same-receipt Registry registration logs", () => {
+    const sourceProjection = projection();
+    const [registered, descriptor, evidence] =
+      sourceProjection.lifecycle.registration;
+    expect(() => record({
+      ...sourceProjection,
+      lifecycle: {
+        ...sourceProjection.lifecycle,
+        registration: [registered, evidence, descriptor],
+      },
+    } as unknown as GenericLaunchSourceProjectionV2))
+      .toThrow(/registration evidence/u);
+    expect(() => record({
+      ...sourceProjection,
+      lifecycle: {
+        ...sourceProjection.lifecycle,
+        registration: [
+          registered,
+          { ...descriptor, transactionHash: hash("f") },
+          evidence,
+        ],
+      },
+    } as GenericLaunchSourceProjectionV2)).toThrow(/registration evidence/u);
+  });
+
   it("treats descriptor market fields as exact authenticated data", () => {
     const sourceProjection = projection();
     expect(() => record({
@@ -165,7 +338,13 @@ describe("Generic launch record V2", () => {
     })],
     ["transaction", (candidate: GenericLaunchSourceProjectionV2) => ({
       ...candidate,
-      lifecycle: { ...candidate.lifecycle, registrationTransactionHash: "0x1234" },
+      lifecycle: {
+        ...candidate.lifecycle,
+        finalization: {
+          ...candidate.lifecycle.finalization,
+          transactionHash: "0x1234",
+        },
+      },
     })],
   ])("rejects invalid %s identity", (_label, mutate) => {
     expect(() => record(

--- a/tests/generic-launch-record-v2.test.ts
+++ b/tests/generic-launch-record-v2.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createGenericLaunchRecordV2,
+  parseGenericLaunchRecordV2,
+  type GenericLaunchSourceProjectionV2,
+} from "../lib/server/custom-launch/generic-launch-contract-v2";
+
+const sha = (character: string) => `sha256:${character.repeat(64)}` as const;
+const hash = (character: string) => `0x${character.repeat(64)}` as const;
+const address = (character: string) => `0x${character.repeat(40)}` as const;
+const READ_MODEL_BINDING = sha("f");
+
+function record(sourceProjection = projection()) {
+  return createGenericLaunchRecordV2({
+    sourceProjection,
+    readModelBindingHash: READ_MODEL_BINDING,
+  });
+}
+
+function projection(): GenericLaunchSourceProjectionV2 {
+  return {
+    schemaVersion: "programmable.generic-launch-source-projection.v2",
+    sourceRevision: {
+      repositoryId: "123456789",
+      repositoryFullName: "alice/example-hook",
+      commitObjectId: "a".repeat(40),
+      treeObjectId: "b".repeat(40),
+    },
+    approval: {
+      approvalRevision: "7",
+      approvalId: hash("1"),
+      approvalEvidenceHash: hash("2"),
+      signedReceiptArtifactHash: sha("2"),
+    },
+    descriptor: {
+      descriptorHash: hash("3"),
+      launchId: hash("4"),
+      launchWallet: address("5"),
+      primaryContract: address("7"),
+      primaryRuntimeCodeHash: hash("8"),
+      componentSetHash: hash("9"),
+      sourceArtifactHash: hash("a"),
+      configurationHash: hash("b"),
+      launchPlanHash: hash("c"),
+      projectCommitment: hash("d"),
+      marketMode: "Standard10",
+      marketModeValue: 1,
+      protocolFeeBps: 10,
+    },
+    lifecycle: {
+      chainId: "1",
+      generation: "2",
+      registryAddress: address("6"),
+      registryRuntimeCodeKeccak256: hash("7"),
+      registryPolicyCommitment: hash("8"),
+      minimumFinalityBlocks: "12",
+      primaryLaunchTransactionHash: hash("9"),
+      authorizationTransactionHash: hash("a"),
+      registrationTransactionHash: hash("b"),
+      finalizationTransactionHash: hash("c"),
+      finalizedAtBlock: "100",
+      finalizedBlockHash: hash("d"),
+      finalizationLogIndex: "4",
+      latestCommonHead: "112",
+      latestCommonHeadHash: hash("e"),
+      latestStatus: "finalized",
+      revokedAtBlock: "0",
+      revocationEvidenceHash: hash("0"),
+    },
+  };
+}
+
+describe("Generic launch record V2", () => {
+  it("content-addresses the exact public Approval and Registry projection", () => {
+    const value = record();
+    expect(parseGenericLaunchRecordV2(value)).toEqual(value);
+    expect(value.sourceProjectionHash).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    expect(value.recordHash).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    expect(value.sourceProjection).toEqual(projection());
+  });
+
+  it("rejects an approval artifact that does not join raw to onchain evidence", () => {
+    const sourceProjection = projection();
+    expect(() => record({
+      ...sourceProjection,
+      approval: {
+        ...sourceProjection.approval,
+        signedReceiptArtifactHash: sha("f"),
+      },
+    })).toThrow(/artifact\/evidence join/u);
+  });
+
+  it.each([
+    ["revoked status", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      lifecycle: { ...candidate.lifecycle, latestStatus: "revoked" },
+    })],
+    ["revoked block", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      lifecycle: { ...candidate.lifecycle, revokedAtBlock: "111" },
+    })],
+    ["revocation evidence", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      lifecycle: { ...candidate.lifecycle, revocationEvidenceHash: hash("f") },
+    })],
+    ["wrong generation", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      lifecycle: { ...candidate.lifecycle, generation: "1" },
+    })],
+  ])("rejects %s", (_label, mutate) => {
+    expect(() => record(
+      mutate(projection()) as GenericLaunchSourceProjectionV2,
+    )).toThrow(/finalized and non-revoked/u);
+  });
+
+  it("requires the common finalized head to cover the exact finality depth", () => {
+    const sourceProjection = projection();
+    expect(() => record({
+      ...sourceProjection,
+      lifecycle: { ...sourceProjection.lifecycle, latestCommonHead: "111" },
+    })).toThrow(/finality is insufficient/u);
+  });
+
+  it("treats descriptor market fields as exact authenticated data", () => {
+    const sourceProjection = projection();
+    expect(() => record({
+      ...sourceProjection,
+      descriptor: { ...sourceProjection.descriptor, protocolFeeBps: 0 },
+    } as GenericLaunchSourceProjectionV2)).toThrow(/market identity/u);
+    const noMarket = record({
+      ...sourceProjection,
+      descriptor: {
+        ...sourceProjection.descriptor,
+        marketMode: "NoMarket0",
+        marketModeValue: 0,
+        protocolFeeBps: 0,
+      },
+    });
+    expect(noMarket.sourceProjection.descriptor).toMatchObject({
+      marketMode: "NoMarket0",
+      marketModeValue: 0,
+      protocolFeeBps: 0,
+    });
+  });
+
+  it.each([
+    ["repository", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      sourceRevision: { ...candidate.sourceRevision, repositoryId: "01" },
+    })],
+    ["commit", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      sourceRevision: { ...candidate.sourceRevision, commitObjectId: "A".repeat(40) },
+    })],
+    ["wallet", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      descriptor: { ...candidate.descriptor, launchWallet: address("F") },
+    })],
+    ["approval id", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      approval: { ...candidate.approval, approvalId: hash("0") },
+    })],
+    ["transaction", (candidate: GenericLaunchSourceProjectionV2) => ({
+      ...candidate,
+      lifecycle: { ...candidate.lifecycle, registrationTransactionHash: "0x1234" },
+    })],
+  ])("rejects invalid %s identity", (_label, mutate) => {
+    expect(() => record(
+      mutate(projection()) as GenericLaunchSourceProjectionV2,
+    )).toThrow(/invalid/u);
+  });
+
+  it("rejects any added field and any hash mutation", () => {
+    const value = record();
+    expect(() => parseGenericLaunchRecordV2({ ...value, criteria: [] }))
+      .toThrow(/keys/u);
+    expect(() => parseGenericLaunchRecordV2({
+      ...value,
+      sourceProjectionHash: sha("f"),
+    })).toThrow(/hash/u);
+    expect(() => parseGenericLaunchRecordV2({
+      ...value,
+      recordHash: sha("f"),
+    })).toThrow(/hash/u);
+  });
+
+  it("changes both hashes for every public identity class mutation", () => {
+    const original = record();
+    const mutations: GenericLaunchSourceProjectionV2[] = [
+      {
+        ...projection(),
+        sourceRevision: { ...projection().sourceRevision, repositoryId: "987654321" },
+      },
+      {
+        ...projection(),
+        approval: { ...projection().approval, approvalRevision: "8" },
+      },
+      {
+        ...projection(),
+        descriptor: { ...projection().descriptor, descriptorHash: hash("f") },
+      },
+      {
+        ...projection(),
+        lifecycle: { ...projection().lifecycle, latestCommonHead: "113" },
+      },
+    ];
+    for (const sourceProjection of mutations) {
+      const mutated = record(sourceProjection);
+      expect(mutated.sourceProjectionHash).not.toBe(original.sourceProjectionHash);
+      expect(mutated.recordHash).not.toBe(original.recordHash);
+    }
+  });
+});


### PR DESCRIPTION
## Outcome

Adds the versioned Custom Registry V2 manifest/readiness and Generic Launch V2 public identity/read APIs while keeping production deliberately fail-closed. No Registry address, Approval origin, verifier key, or read store is bound by this PR.

## Scope

- strict Registry V2 prelaunch/live manifest parser and dual-provider readiness verifier
- strict signed Approval aggregate-readiness consumer contract
- content-addressed `GenericLaunchRecordV2` joining verified Approval identity to finalized/non-revoked Registry lifecycle evidence
- signed, request-bound V2 feed/detail store boundary and machine-checkable public schemas
- production V2 feed/detail handlers remain `binding: null, store: null` and return 503
- no approval criteria, fee-policy interpretation, Classic, Stock, or global Explore changes

## Exact evidence

- base `4445d815ff2421fb066f3118e76835d43cf7ebdc` / tree `11be50b07bf600161cc3af02c24c94d285dda444`
- head `404cbc6590995a31e6e7c7867b914e5bdab6511d` / tree `a2fa2246e383f2f6b37329071a37facc4aa73142`
- focused Custom suite: 115/115 passed
- Generic V2 parser/store: 33/33 passed
- typecheck, focused ESLint, candidate-neutrality, diff-check passed
- exact Turbopack production build passed; V2 routes present; production bundle scan passed
- independent source audit before rebase: GO, no P0-P3; narrow rebase composition audit pending terminal report

## Activation boundary

A separate exact-revision activation change must bind the finalized Approval aggregate origin/release/key, finalized Registry deployment/runtime/policy/finality matrix, and signed durable read store. This PR does not claim Custom Launch is live.
