### PR TITLE
Materialize verified Generic V2 custom launches

### DIFF
--- a/app/api/custom-launch/generic/v2/launches/[recordHash]/route.ts
+++ b/app/api/custom-launch/generic/v2/launches/[recordHash]/route.ts
@@ -1,5 +1,5 @@
 import { handleProductionGenericLaunchDetailV2 } from
-  "@/lib/server/custom-launch/generic-launch-read-v2";
+  "@/lib/server/custom-launch/generic-launch-production-v2";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 10;

--- a/app/api/custom-launch/generic/v2/launches/route.ts
+++ b/app/api/custom-launch/generic/v2/launches/route.ts
@@ -1,5 +1,5 @@
 import { handleProductionGenericLaunchFeedV2 } from
-  "@/lib/server/custom-launch/generic-launch-read-v2";
+  "@/lib/server/custom-launch/generic-launch-production-v2";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 10;

--- a/app/api/custom-launch/generic/v2/readiness/route.ts
+++ b/app/api/custom-launch/generic/v2/readiness/route.ts
@@ -1,0 +1,8 @@
+import { handleProductionGenericLaunchReadinessV2 } from
+  "@/lib/server/custom-launch/generic-launch-production-v2";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 15;
+export const runtime = "nodejs";
+
+export const GET = handleProductionGenericLaunchReadinessV2;

--- a/app/api/ops/custom-launch/generic-v2-projector/route.ts
+++ b/app/api/ops/custom-launch/generic-v2-projector/route.ts
@@ -1,0 +1,72 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { parseStrictJson } from
+  "@/lib/server/projection-target/canonical-json";
+import {
+  parseGenericProjectorApprovalId,
+  projectProductionGenericLaunchV2,
+} from "@/lib/server/custom-launch/generic-launch-production-v2";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+export const runtime = "nodejs";
+
+const MAXIMUM_BODY_BYTES = 4_096;
+
+export async function POST(request: Request): Promise<Response> {
+  if (!authorized(request.headers)) return response(401, "unauthorized");
+  try {
+    const text = await request.text();
+    if (Buffer.byteLength(text, "utf8") > MAXIMUM_BODY_BYTES) {
+      return response(400, "invalid_request");
+    }
+    const parsed = parseStrictJson(text, {
+      maximumBytes: MAXIMUM_BODY_BYTES,
+      maximumDepth: 2,
+    });
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return response(400, "invalid_request");
+    }
+    const body = parsed as Readonly<Record<string, unknown>>;
+    if (Object.keys(body).join(",") !== "approvalId") {
+      return response(400, "invalid_request");
+    }
+    const result = await projectProductionGenericLaunchV2({
+      approvalId: parseGenericProjectorApprovalId(body.approvalId),
+      signal: request.signal,
+    });
+    return Response.json({
+      schemaVersion: "programmable.generic-launch-projector-result.v2",
+      status: "ok",
+      ...result,
+    }, { status: 200, headers: headers() });
+  } catch {
+    return response(503, "projection_unavailable");
+  }
+}
+
+function authorized(headersValue: Headers): boolean {
+  const expectedValue = process.env.PROGRAMMABLE_GENERIC_LAUNCH_PROJECTOR_TOKEN;
+  const authorization = headersValue.get("authorization");
+  if (!expectedValue || expectedValue.length < 32 || expectedValue.length > 4096
+    || !authorization?.startsWith("Bearer ")) return false;
+  const expected = Buffer.from(expectedValue, "utf8");
+  const actual = Buffer.from(authorization.slice("Bearer ".length), "utf8");
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
+
+function response(status: number, code: string): Response {
+  return Response.json({
+    schemaVersion: "programmable.generic-launch-projector-error.v2",
+    status: "error",
+    code,
+  }, { status, headers: headers() });
+}
+
+function headers(): HeadersInit {
+  return {
+    "cache-control": "no-store",
+    "content-type": "application/json; charset=utf-8",
+    "x-content-type-options": "nosniff",
+  };
+}

--- a/app/api/ops/custom-launch/generic-v2-projector/route.ts
+++ b/app/api/ops/custom-launch/generic-v2-projector/route.ts
@@ -59,14 +59,14 @@ export async function GET(request: Request): Promise<Response> {
   }
   try {
     const result = await reconcileProductionGenericLaunchesV2({
-      limit: 8,
+      limit: 16,
       signal: request.signal,
     });
     return Response.json({
       schemaVersion: "programmable.generic-launch-reconciliation-result.v2",
-      status: "ok",
+      status: result.failed === 0 ? "ok" : "partial",
       ...result,
-    }, { status: 200, headers: headers() });
+    }, { status: result.failed === 0 ? 200 : 503, headers: headers() });
   } catch {
     return response(503, "reconciliation_unavailable");
   }

--- a/app/api/ops/custom-launch/generic-v2-projector/route.ts
+++ b/app/api/ops/custom-launch/generic-v2-projector/route.ts
@@ -5,6 +5,7 @@ import { parseStrictJson } from
 import {
   parseGenericProjectorApprovalId,
   projectProductionGenericLaunchV2,
+  reconcileProductionGenericLaunchesV2,
 } from "@/lib/server/custom-launch/generic-launch-production-v2";
 
 export const dynamic = "force-dynamic";
@@ -14,7 +15,10 @@ export const runtime = "nodejs";
 const MAXIMUM_BODY_BYTES = 4_096;
 
 export async function POST(request: Request): Promise<Response> {
-  if (!authorized(request.headers)) return response(401, "unauthorized");
+  if (!authorized(
+    request.headers,
+    process.env.PROGRAMMABLE_GENERIC_LAUNCH_PROJECTOR_TOKEN,
+  )) return response(401, "unauthorized");
   try {
     const text = await request.text();
     if (Buffer.byteLength(text, "utf8") > MAXIMUM_BODY_BYTES) {
@@ -45,10 +49,33 @@ export async function POST(request: Request): Promise<Response> {
   }
 }
 
-function authorized(headersValue: Headers): boolean {
-  const expectedValue = process.env.PROGRAMMABLE_GENERIC_LAUNCH_PROJECTOR_TOKEN;
+export async function GET(request: Request): Promise<Response> {
+  if (!authorized(request.headers, process.env.CRON_SECRET)) {
+    return response(401, "unauthorized");
+  }
+  const url = new URL(request.url);
+  if (url.search !== "" || request.body !== null) {
+    return response(400, "invalid_request");
+  }
+  try {
+    const result = await reconcileProductionGenericLaunchesV2({
+      limit: 8,
+      signal: request.signal,
+    });
+    return Response.json({
+      schemaVersion: "programmable.generic-launch-reconciliation-result.v2",
+      status: "ok",
+      ...result,
+    }, { status: 200, headers: headers() });
+  } catch {
+    return response(503, "reconciliation_unavailable");
+  }
+}
+
+function authorized(headersValue: Headers, expectedValue: string | undefined): boolean {
   const authorization = headersValue.get("authorization");
-  if (!expectedValue || expectedValue.length < 32 || expectedValue.length > 4096
+  if (!expectedValue || Buffer.byteLength(expectedValue, "utf8") < 32
+    || Buffer.byteLength(expectedValue, "utf8") > 1_024
     || !authorization?.startsWith("Bearer ")) return false;
   const expected = Buffer.from(expectedValue, "utf8");
   const actual = Buffer.from(authorization.slice("Bearer ".length), "utf8");

--- a/app/custom-launches/[recordHash]/page.tsx
+++ b/app/custom-launches/[recordHash]/page.tsx
@@ -1,0 +1,11 @@
+import { GenericLaunchDetailV2 } from
+  "@/components/generic-launch-directory-v2";
+
+export const dynamic = "force-dynamic";
+
+export default async function CustomLaunchDetailPage({ params }: Readonly<{
+  params: Promise<{ recordHash: string }>;
+}>) {
+  const { recordHash } = await params;
+  return <GenericLaunchDetailV2 recordHash={recordHash} />;
+}

--- a/app/custom-launches/page.tsx
+++ b/app/custom-launches/page.tsx
@@ -1,0 +1,8 @@
+import { GenericLaunchDirectoryV2 } from
+  "@/components/generic-launch-directory-v2";
+
+export const dynamic = "force-dynamic";
+
+export default function CustomLaunchesPage() {
+  return <GenericLaunchDirectoryV2 />;
+}

--- a/app/v2/internal/projections/approval-descriptors/[projectionKey]/route.ts
+++ b/app/v2/internal/projections/approval-descriptors/[projectionKey]/route.ts
@@ -1,0 +1,15 @@
+import {
+  handleProductionApprovalV3ProjectionTargetV1,
+} from "@/lib/server/projection-target/approval-v3-target";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 10;
+export const runtime = "nodejs";
+
+export const GET = handleProductionApprovalV3ProjectionTargetV1;
+export const PUT = handleProductionApprovalV3ProjectionTargetV1;
+export const POST = handleProductionApprovalV3ProjectionTargetV1;
+export const PATCH = handleProductionApprovalV3ProjectionTargetV1;
+export const DELETE = handleProductionApprovalV3ProjectionTargetV1;
+export const HEAD = handleProductionApprovalV3ProjectionTargetV1;
+export const OPTIONS = handleProductionApprovalV3ProjectionTargetV1;

--- a/components/generic-launch-directory-v2.module.css
+++ b/components/generic-launch-directory-v2.module.css
@@ -1,0 +1,24 @@
+.page { min-height: 100vh; padding: 9rem max(1.25rem, 6vw) 5rem; background: #f5f2e9; color: #11110f; }
+.header { max-width: 56rem; margin-bottom: 3.5rem; }
+.eyebrow, .cardState { margin: 0 0 .8rem; font: 600 .75rem/1.2 var(--font-mono, monospace); letter-spacing: .12em; text-transform: uppercase; color: #5d5a50; }
+.header h1, .detail h1 { max-width: 14ch; margin: 0; font-size: clamp(2.7rem, 7vw, 6.6rem); line-height: .92; letter-spacing: -.065em; }
+.intro { max-width: 46rem; margin: 1.5rem 0 0; font-size: clamp(1rem, 2vw, 1.3rem); line-height: 1.5; color: #555248; }
+.status { padding: 2rem 0; font-size: 1rem; color: #5d5a50; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 19rem), 1fr)); gap: 1px; border: 1px solid #cac5b8; background: #cac5b8; }
+.card { min-height: 20rem; padding: 1.5rem; background: #fbf9f3; display: flex; flex-direction: column; }
+.card h2 { margin: 1.2rem 0 .55rem; font-size: 1.4rem; line-height: 1.1; overflow-wrap: anywhere; }
+.card > p:not(.cardState) { margin: 0; color: #6b675d; }
+.cardFacts, .facts { margin: 2rem 0; display: grid; gap: 1rem; }
+.cardFacts div, .facts div { min-width: 0; }
+.cardFacts dt, .facts dt { margin-bottom: .25rem; font-size: .72rem; text-transform: uppercase; letter-spacing: .08em; color: #78746a; }
+.cardFacts dd, .facts dd { margin: 0; font-family: var(--font-mono, monospace); font-size: .82rem; overflow-wrap: anywhere; }
+.cardLink { margin-top: auto; color: inherit; font-weight: 650; text-decoration-thickness: 1px; text-underline-offset: .25em; }
+.back { display: inline-block; margin-bottom: 3rem; color: inherit; }
+.detail { max-width: 72rem; }
+.facts { grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: 3.5rem; padding: 1.5rem 0; border-block: 1px solid #cac5b8; }
+.actions { display: flex; flex-wrap: wrap; gap: .75rem; margin-top: 2rem; }
+.actions a { display: inline-flex; min-height: 2.9rem; align-items: center; padding: .65rem 1rem; border: 1px solid #11110f; color: inherit; text-decoration: none; }
+.actions a:first-child { background: #11110f; color: #f5f2e9; }
+.actions a:focus-visible, .cardLink:focus-visible, .back:focus-visible { outline: 3px solid #6e5cff; outline-offset: 3px; }
+.srOnly { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+@media (max-width: 42rem) { .page { padding-top: 6.5rem; } .facts { grid-template-columns: 1fr; } .card { min-height: 17rem; } }

--- a/components/generic-launch-directory-v2.tsx
+++ b/components/generic-launch-directory-v2.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import type { GenericLaunchRecordV2 } from
+  "@/lib/server/custom-launch/generic-launch-contract-v2";
+import styles from "./generic-launch-directory-v2.module.css";
+
+type FeedState =
+  | Readonly<{ status: "loading" }>
+  | Readonly<{ status: "error" }>
+  | Readonly<{ status: "ready"; records: readonly GenericLaunchRecordV2[] }>;
+
+export function GenericLaunchDirectoryV2() {
+  const [state, setState] = useState<FeedState>({ status: "loading" });
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch("/api/custom-launch/generic/v2/launches?limit=24", {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    }).then(async (response) => {
+      if (!response.ok) throw new TypeError("launch feed unavailable");
+      const value = await response.json() as Readonly<{
+        schemaVersion?: unknown;
+        records?: unknown;
+      }>;
+      if (value.schemaVersion !== "programmable.generic-launch-feed.v2"
+        || !Array.isArray(value.records)) throw new TypeError("launch feed invalid");
+      setState({
+        status: "ready",
+        records: value.records as readonly GenericLaunchRecordV2[],
+      });
+    }).catch((error: unknown) => {
+      if (!controller.signal.aborted) setState({ status: "error" });
+      void error;
+    });
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <p className={styles.eyebrow}>Custom launches</p>
+        <h1>Launched from an approved revision.</h1>
+        <p className={styles.intro}>
+          Each record joins the signed source revision to its finalized,
+          non-revoked Registry lifecycle.
+        </p>
+      </header>
+      {state.status === "loading" ? (
+        <p role="status" className={styles.status}>Loading launch records…</p>
+      ) : state.status === "error" ? (
+        <p role="status" className={styles.status}>
+          Custom launch records are not active yet.
+        </p>
+      ) : state.records.length === 0 ? (
+        <p role="status" className={styles.status}>No finalized launches yet.</p>
+      ) : (
+        <section aria-label="Finalized custom launches" className={styles.grid}>
+          {state.records.map((record) => (
+            <LaunchCard key={record.recordHash} record={record} />
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}
+
+export function GenericLaunchDetailV2({ recordHash }: { recordHash: string }) {
+  const [record, setRecord] = useState<GenericLaunchRecordV2 | null | undefined>();
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch(`/api/custom-launch/generic/v2/launches/${encodeURIComponent(recordHash)}`, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    }).then(async (response) => {
+      if (!response.ok) throw new TypeError("launch unavailable");
+      const value = await response.json() as Readonly<{
+        schemaVersion?: unknown;
+        record?: GenericLaunchRecordV2;
+      }>;
+      if (value.schemaVersion !== "programmable.generic-launch-view.v2"
+        || value.record === undefined) throw new TypeError("launch invalid");
+      setRecord(value.record);
+    }).catch(() => {
+      if (!controller.signal.aborted) setRecord(null);
+    });
+    return () => controller.abort();
+  }, [recordHash]);
+  if (record === undefined) {
+    return <main className={styles.page}><p role="status" className={styles.status}>Loading launch…</p></main>;
+  }
+  if (record === null) {
+    return <main className={styles.page}><p role="status" className={styles.status}>This launch record is unavailable.</p></main>;
+  }
+  const source = record.sourceProjection;
+  return (
+    <main className={styles.page}>
+      <Link className={styles.back} href="/custom-launches">← Custom launches</Link>
+      <article className={styles.detail} aria-labelledby="launch-title">
+        <p className={styles.eyebrow}>Finalized custom launch</p>
+        <h1 id="launch-title">{source.sourceRevision.repositoryFullName}</h1>
+        <p className={styles.intro}>
+          Approval revision {source.approval.approvalRevision} · source {short(source.sourceRevision.commitObjectId)}
+        </p>
+        <dl className={styles.facts}>
+          <Fact label="Launch ID" value={source.descriptor.launchId} />
+          <Fact label="Descriptor" value={source.descriptor.descriptorHash} />
+          <Fact label="Launch wallet" value={source.descriptor.launchWallet} />
+          <Fact label="Primary contract" value={source.descriptor.primaryContract} />
+          <Fact label="Source tree" value={source.sourceRevision.treeObjectId} />
+          <Fact label="Finalized block" value={source.lifecycle.finalization.blockNumber} />
+          <Fact label="Common verified head" value={source.lifecycle.latestCommonHead} />
+          <Fact label="Record hash" value={record.recordHash} />
+        </dl>
+        <div className={styles.actions}>
+          <a href={`https://etherscan.io/address/${source.descriptor.primaryContract}`} target="_blank" rel="noreferrer">
+            View contract<span className={styles.srOnly}> on Etherscan</span>
+          </a>
+          <a href={`https://github.com/${source.sourceRevision.repositoryFullName}/tree/${source.sourceRevision.commitObjectId}`} target="_blank" rel="noreferrer">
+            View source revision
+          </a>
+          <Link href="/launch">Launch a project</Link>
+        </div>
+      </article>
+    </main>
+  );
+}
+
+function LaunchCard({ record }: { record: GenericLaunchRecordV2 }) {
+  const source = record.sourceProjection;
+  return (
+    <article className={styles.card}>
+      <p className={styles.cardState}>Finalized · non-revoked</p>
+      <h2>{source.sourceRevision.repositoryFullName}</h2>
+      <p>Revision {source.approval.approvalRevision} · {short(source.sourceRevision.commitObjectId)}</p>
+      <dl className={styles.cardFacts}>
+        <Fact label="Launch ID" value={short(source.descriptor.launchId)} />
+        <Fact label="Wallet" value={short(source.descriptor.launchWallet)} />
+      </dl>
+      <Link className={styles.cardLink} href={`/custom-launches/${record.recordHash}`}>
+        View verified launch<span aria-hidden="true"> ↗</span>
+      </Link>
+    </article>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return <div><dt>{label}</dt><dd title={value}>{value}</dd></div>;
+}
+
+function short(value: string): string {
+  return value.length <= 18 ? value : `${value.slice(0, 10)}…${value.slice(-6)}`;
+}

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -120,7 +120,7 @@
     },
     "store": {
       "path": "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      "sha256": "5cdc8a5765816c3336d7af0aa490aaf420ec59ed65ffd16e8af25f170c8696c7"
+      "sha256": "a35d911098359f970c4f49007760c8081fc0cbb94c45bdaa73a7884968c907c5"
     },
     "registryReader": {
       "path": "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -120,7 +120,7 @@
     },
     "store": {
       "path": "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      "sha256": "042bce5970388dfcde25ee8d5d70a04ef9072e8168e3efc83890e1c418a11c0c"
+      "sha256": "80e9bbd9446b0bd4e7b9607fccacf3b7b42470b12ac0abd3b7638f693df5d16e"
     },
     "registryReader": {
       "path": "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -108,7 +108,8 @@
     "maximumApprovalInventory": 48,
     "batchLimit": 16,
     "concurrency": 8,
-    "maximumInitialLogBlocks": 250000,
+    "maximumInitialLogBlocks": 20000,
+    "maximumConcurrentLogRequests": 24,
     "route": {
       "path": "app/api/ops/custom-launch/generic-v2-projector/route.ts",
       "sha256": "d2f6509eba91dd5690e58d121daf4802aa1367b3807da31ed7ec060ba84b1f14"
@@ -119,15 +120,15 @@
     },
     "store": {
       "path": "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      "sha256": "8874c3277a518c189c000d05cddef400d2cb0b7884fa7d730e2c5b3456cf438f"
+      "sha256": "5cdc8a5765816c3336d7af0aa490aaf420ec59ed65ffd16e8af25f170c8696c7"
     },
     "registryReader": {
       "path": "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",
-      "sha256": "08be733d2f6735d3198ec078b22d365e36f783d7ca4e7c11b804aaad04760898"
+      "sha256": "a8b6607c641949ad384def4cb9b808233fecea37aadcd9517da69c9845a3dafd"
     },
     "migration": {
       "path": "ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql",
-      "sha256": "cbc8140b7956f5abb6631a608f4e919102b468faac8c0efe9ad6802354e69f8f"
+      "sha256": "695328763c639b7d11562c394183864998e532eb6cc38d341020e8843de213b8"
     }
   },
   "workers": [

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -102,27 +102,32 @@
     "path": "/api/ops/custom-launch/generic-v2-projector",
     "schedule": "* * * * *",
     "authEnvironment": "CRON_SECRET",
-    "maximumLifecycleAgeMs": 180000,
-    "batchLimit": 8,
+    "maximumLifecycleAgeMs": 300000,
+    "refreshAfterMs": 60000,
+    "leaseMs": 55000,
+    "maximumApprovalInventory": 48,
+    "batchLimit": 16,
+    "concurrency": 8,
+    "maximumInitialLogBlocks": 250000,
     "route": {
       "path": "app/api/ops/custom-launch/generic-v2-projector/route.ts",
-      "sha256": "ccf313d6f324391430d081254e4efa5cf7182ebbb812e2888dfd5d0add9bcc5e"
+      "sha256": "d2f6509eba91dd5690e58d121daf4802aa1367b3807da31ed7ec060ba84b1f14"
     },
     "runtime": {
       "path": "lib/server/custom-launch/generic-launch-production-v2.ts",
-      "sha256": "0eafd50e7d224302d8c2202c637c9571b4e3a5e31623a3b36de175f281bc3517"
+      "sha256": "b70e8d1a904ed09b1161269b182af7b4e18c93d552acb6e94a5cc66d9d76a19b"
     },
     "store": {
       "path": "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      "sha256": "5cbf187e029154dc23f0fcb1002602772494676560e79f596169ca5897718d21"
+      "sha256": "8874c3277a518c189c000d05cddef400d2cb0b7884fa7d730e2c5b3456cf438f"
     },
     "registryReader": {
       "path": "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",
-      "sha256": "fb3cd5afe33795385bdf0c598687b3cea7cc99788275fca06c7b65529d8950a6"
+      "sha256": "08be733d2f6735d3198ec078b22d365e36f783d7ca4e7c11b804aaad04760898"
     },
     "migration": {
       "path": "ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql",
-      "sha256": "65d2fcb192f56ab29f9621a3df19e79fcf9eaea7a5b6ec31d1b856124fc611d1"
+      "sha256": "cbc8140b7956f5abb6631a608f4e919102b468faac8c0efe9ad6802354e69f8f"
     }
   },
   "workers": [

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -98,6 +98,33 @@
       "sha256": "bb498b00334df908029a588bec552516f281fdc0dfc3185bc5cd820984a9ee1f"
     }
   },
+  "customLaunchReconciler": {
+    "path": "/api/ops/custom-launch/generic-v2-projector",
+    "schedule": "* * * * *",
+    "authEnvironment": "CRON_SECRET",
+    "maximumLifecycleAgeMs": 180000,
+    "batchLimit": 8,
+    "route": {
+      "path": "app/api/ops/custom-launch/generic-v2-projector/route.ts",
+      "sha256": "ccf313d6f324391430d081254e4efa5cf7182ebbb812e2888dfd5d0add9bcc5e"
+    },
+    "runtime": {
+      "path": "lib/server/custom-launch/generic-launch-production-v2.ts",
+      "sha256": "0eafd50e7d224302d8c2202c637c9571b4e3a5e31623a3b36de175f281bc3517"
+    },
+    "store": {
+      "path": "lib/server/custom-launch/generic-launch-postgres-v2.ts",
+      "sha256": "5cbf187e029154dc23f0fcb1002602772494676560e79f596169ca5897718d21"
+    },
+    "registryReader": {
+      "path": "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",
+      "sha256": "fb3cd5afe33795385bdf0c598687b3cea7cc99788275fca06c7b65529d8950a6"
+    },
+    "migration": {
+      "path": "ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql",
+      "sha256": "65d2fcb192f56ab29f9621a3df19e79fcf9eaea7a5b6ec31d1b856124fc611d1"
+    }
+  },
   "workers": [
     {
       "id": "source-projector",

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -120,7 +120,7 @@
     },
     "store": {
       "path": "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      "sha256": "a35d911098359f970c4f49007760c8081fc0cbb94c45bdaa73a7884968c907c5"
+      "sha256": "042bce5970388dfcde25ee8d5d70a04ef9072e8168e3efc83890e1c418a11c0c"
     },
     "registryReader": {
       "path": "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -120,7 +120,7 @@
     },
     "store": {
       "path": "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      "sha256": "80e9bbd9446b0bd4e7b9607fccacf3b7b42470b12ac0abd3b7638f693df5d16e"
+      "sha256": "d542726f80bd816387240f1707e5934946b5dcf1cc9d69a015e08f3bb2d904be"
     },
     "registryReader": {
       "path": "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",

--- a/lib/server/custom-launch/generic-launch-postgres-v2.ts
+++ b/lib/server/custom-launch/generic-launch-postgres-v2.ts
@@ -222,6 +222,7 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
           SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
         `, [launchId]);
         await assertMonotonicObservation(client, {
+          approvalId,
           launchId,
           observationCommonHead: head,
           observationCommonHeadHash: headHash,
@@ -304,6 +305,7 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
           SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
         `, [launchId]);
         await assertMonotonicObservation(client, {
+          approvalId,
           launchId,
           observationCommonHead,
           observationCommonHeadHash,
@@ -393,6 +395,7 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
 async function assertMonotonicObservation(
   client: ProjectionTargetPostgresClientV1,
   input: Readonly<{
+    approvalId: `0x${string}`;
     launchId: `0x${string}`;
     observationCommonHead: string;
     observationCommonHeadHash: `0x${string}`;
@@ -405,8 +408,9 @@ async function assertMonotonicObservation(
     SELECT observation_common_head::text, observation_common_head_hash
       FROM programmable_website_projection_v1.generic_launch_reconciliations_v2
      WHERE launch_id = $1
+       AND approval_id = $2
      LIMIT 1
-  `, [input.launchId]);
+  `, [input.launchId, input.approvalId]);
   const row = result.rows[0];
   if (row === undefined) return;
   const storedHead = decimal(
@@ -774,6 +778,7 @@ async function assertGenericLaunchMaterializationStorageV2(
          AND trigger.tgname = 'projection_records_approval_v3_capacity_v1'
          AND trigger.tgenabled = 'O'
          AND trigger.tgtype = 7
+         AND trigger.tgqual IS NULL
          AND function_schema.nspname = 'programmable_website_projection_v1'
          AND function.proname = 'enforce_approval_v3_capacity_v1'
          AND pg_get_function_identity_arguments(function.oid) = ''
@@ -784,6 +789,7 @@ async function assertGenericLaunchMaterializationStorageV2(
       SELECT count(*)::text
         FROM pg_proc function
         JOIN pg_namespace function_schema ON function_schema.oid = function.pronamespace
+        JOIN pg_language function_language ON function_language.oid = function.prolang
         JOIN pg_class owner_table
           ON owner_table.relname = 'generic_launch_materializations_v2'
         JOIN pg_namespace owner_schema ON owner_schema.oid = owner_table.relnamespace
@@ -791,6 +797,7 @@ async function assertGenericLaunchMaterializationStorageV2(
          AND function.proname = 'enforce_approval_v3_capacity_v1'
          AND pg_get_function_identity_arguments(function.oid) = ''
          AND function.prorettype = 'trigger'::regtype
+         AND function_language.lanname = 'plpgsql'
          AND owner_schema.nspname = 'programmable_website_projection_v1'
          AND function.proowner = owner_table.relowner
          AND function.prosecdef = false

--- a/lib/server/custom-launch/generic-launch-postgres-v2.ts
+++ b/lib/server/custom-launch/generic-launch-postgres-v2.ts
@@ -2,7 +2,10 @@ import "server-only";
 
 import { canonicalizeJson, parseStrictJson, type JsonValue } from
   "../projection-target/canonical-json";
-import type { ProjectionTargetPostgresPoolV1 } from
+import type {
+  ProjectionTargetPostgresClientV1,
+  ProjectionTargetPostgresPoolV1,
+} from
   "../projection-target/postgres-store";
 import type { Sha256Digest } from "../projection-target/hashing";
 import {
@@ -37,6 +40,7 @@ interface LifecycleRow extends Record<string, unknown> {
   lifecycle_state: unknown;
   record_hash: unknown;
   canonical_record: unknown;
+  last_finalized_record: unknown;
   observation_common_head: unknown;
   observation_common_head_hash: unknown;
 }
@@ -93,6 +97,16 @@ interface StorageProviderPostureRow extends Record<string, unknown> {
   provider_access_count: unknown;
 }
 
+interface StorageMembershipPostureRow extends Record<string, unknown> {
+  reachable_membership_count: unknown;
+}
+
+interface StorageAdmissionPostureRow extends Record<string, unknown> {
+  trigger_count: unknown;
+  function_count: unknown;
+  provider_execute_count: unknown;
+}
+
 export function createPostgresGenericLaunchMaterializationStoreV2(
   pool: ProjectionTargetPostgresPoolV1,
 ): GenericLaunchMaterializationStoreV2 {
@@ -135,13 +149,22 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
         SELECT m.approval_id, m.descriptor_hash,
                m.lifecycle_generation::text, m.lifecycle_evidence_hash,
                m.lifecycle_state, m.record_hash, m.canonical_record,
+               finalized.canonical_record AS last_finalized_record,
                r.observation_common_head::text, r.observation_common_head_hash
           FROM programmable_website_projection_v1.generic_launch_materializations_v2 m
-          JOIN programmable_website_projection_v1.generic_launch_reconciliations_v2 r
+          LEFT JOIN programmable_website_projection_v1.generic_launch_reconciliations_v2 r
             ON r.launch_id = m.launch_id
            AND r.approval_id = m.approval_id
            AND r.descriptor_hash = m.descriptor_hash
            AND r.outcome = 'consumed'
+          LEFT JOIN LATERAL (
+            SELECT canonical_record
+              FROM programmable_website_projection_v1.generic_launch_materializations_v2 f
+             WHERE f.launch_id = m.launch_id
+               AND f.lifecycle_state = 'finalized'
+             ORDER BY f.lifecycle_generation DESC
+             LIMIT 1
+          ) finalized ON true
          WHERE m.launch_id = $1
          ORDER BY m.lifecycle_generation DESC
          LIMIT 1
@@ -167,12 +190,15 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
            observation_common_head, observation_common_head_hash)
         VALUES ($1, $2, $3, $4, $5::numeric, $6)
         ON CONFLICT (approval_id) DO UPDATE SET
+          outcome = EXCLUDED.outcome,
           observation_common_head = EXCLUDED.observation_common_head,
           observation_common_head_hash = EXCLUDED.observation_common_head_hash,
           observed_at = clock_timestamp()
         WHERE generic_launch_reconciliations_v2.launch_id = EXCLUDED.launch_id
           AND generic_launch_reconciliations_v2.descriptor_hash = EXCLUDED.descriptor_hash
-          AND generic_launch_reconciliations_v2.outcome = EXCLUDED.outcome
+          AND (generic_launch_reconciliations_v2.outcome = EXCLUDED.outcome
+            OR (generic_launch_reconciliations_v2.outcome = 'unconsumed'
+              AND EXCLUDED.outcome = 'consumed'))
         RETURNING approval_id
       `, [approvalId, launchId, descriptorHash, input.outcome, head, headHash]);
       input.signal.throwIfAborted();
@@ -190,6 +216,14 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
       const lifecycleEvidenceHash = digest(
         input.lifecycleEvidenceHash,
         "lifecycle evidence",
+      );
+      const observationCommonHead = decimal(
+        input.observationCommonHead,
+        "observation common head",
+      );
+      const observationCommonHeadHash = hash32(
+        input.observationCommonHeadHash,
+        "observation common head hash",
       );
       const record = input.record === null
         ? null
@@ -245,6 +279,10 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
               !== (record?.recordHash ?? null)) {
             throw new TypeError("Generic launch lifecycle idempotency conflicted");
           }
+          await putConsumedReconciliation(client, {
+            approvalId, launchId, descriptorHash,
+            observationCommonHead, observationCommonHeadHash,
+          });
           await client.query("COMMIT");
           open = false;
           return Object.freeze({ kind: "existing" as const });
@@ -277,12 +315,16 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
           record?.sourceProjectionHash ?? null,
           record?.sourceProjection.lifecycle.finalization.blockNumber ?? null,
         ]);
-        if (inserted.rowCount === 1) {
-          await client.query("COMMIT");
-          open = false;
-          return Object.freeze({ kind: "created" as const });
+        if (inserted.rowCount !== 1) {
+          throw new TypeError("Generic launch lifecycle insert failed");
         }
-        throw new TypeError("Generic launch lifecycle insert failed");
+        await putConsumedReconciliation(client, {
+          approvalId, launchId, descriptorHash,
+          observationCommonHead, observationCommonHeadHash,
+        });
+        await client.query("COMMIT");
+        open = false;
+        return Object.freeze({ kind: "created" as const });
       } catch (error) {
         if (open) await client.query("ROLLBACK").catch(() => undefined);
         throw error;
@@ -291,6 +333,39 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
       }
     },
   });
+}
+
+async function putConsumedReconciliation(
+  client: ProjectionTargetPostgresClientV1,
+  input: Readonly<{
+    approvalId: `0x${string}`;
+    launchId: `0x${string}`;
+    descriptorHash: `0x${string}`;
+    observationCommonHead: string;
+    observationCommonHeadHash: `0x${string}`;
+  }>,
+): Promise<void> {
+  const result = await client.query(`
+    INSERT INTO programmable_website_projection_v1.generic_launch_reconciliations_v2
+      (approval_id, launch_id, descriptor_hash, outcome,
+       observation_common_head, observation_common_head_hash)
+    VALUES ($1, $2, $3, 'consumed', $4::numeric, $5)
+    ON CONFLICT (approval_id) DO UPDATE SET
+      outcome = 'consumed',
+      observation_common_head = EXCLUDED.observation_common_head,
+      observation_common_head_hash = EXCLUDED.observation_common_head_hash,
+      observed_at = clock_timestamp()
+    WHERE generic_launch_reconciliations_v2.launch_id = EXCLUDED.launch_id
+      AND generic_launch_reconciliations_v2.descriptor_hash = EXCLUDED.descriptor_hash
+      AND generic_launch_reconciliations_v2.outcome IN ('unconsumed', 'consumed')
+    RETURNING approval_id
+  `, [
+    input.approvalId, input.launchId, input.descriptorHash,
+    input.observationCommonHead, input.observationCommonHeadHash,
+  ]);
+  if (result.rowCount !== 1) {
+    throw new TypeError("Generic launch reconciliation identity conflicted");
+  }
 }
 
 export function createPostgresGenericLaunchReadStoreV2(input: Readonly<{
@@ -537,6 +612,7 @@ async function assertGenericLaunchMaterializationStorageV2(
     "generic_launch_reconciliations_v2|observation_common_head|programmable_website_projection_runtime|UPDATE|false",
     "generic_launch_reconciliations_v2|observation_common_head_hash|programmable_website_projection_runtime|UPDATE|false",
     "generic_launch_reconciliations_v2|observed_at|programmable_website_projection_runtime|UPDATE|false",
+    "generic_launch_reconciliations_v2|outcome|programmable_website_projection_runtime|UPDATE|false",
   ];
   if (actualColumnAcl.length !== expectedColumnAcl.length
     || actualColumnAcl.some((value, index) => value !== expectedColumnAcl[index])) {
@@ -568,6 +644,90 @@ async function assertGenericLaunchMaterializationStorageV2(
     providerPosture.rows[0]?.provider_access_count,
     "Generic launch provider role access count",
   ) !== "0") {
+    throw new TypeError("Generic launch materialization storage posture is invalid");
+  }
+  const membershipPosture = await pool.query<StorageMembershipPostureRow>(`
+    WITH RECURSIVE roots(root_oid, role_oid) AS (
+      SELECT oid, oid FROM pg_roles
+       WHERE rolname IN (
+         current_user, 'anon', 'authenticated', 'service_role'
+       )
+    ), reachable(root_oid, role_oid) AS (
+      SELECT root_oid, role_oid FROM roots
+      UNION
+      SELECT reachable.root_oid, memberships.roleid
+        FROM reachable
+        JOIN pg_auth_members memberships
+          ON memberships.member = reachable.role_oid
+    )
+    SELECT count(*) FILTER (WHERE root_oid <> role_oid)::text
+      AS reachable_membership_count
+      FROM reachable
+  `);
+  if (decimal(
+    membershipPosture.rows[0]?.reachable_membership_count,
+    "Generic launch reachable role membership count",
+  ) !== "0") {
+    throw new TypeError("Generic launch materialization storage posture is invalid");
+  }
+  const admissionPosture = await pool.query<StorageAdmissionPostureRow>(`
+    SELECT (
+      SELECT count(*)::text
+        FROM pg_trigger trigger
+        JOIN pg_class table_class ON table_class.oid = trigger.tgrelid
+        JOIN pg_namespace table_schema ON table_schema.oid = table_class.relnamespace
+        JOIN pg_proc function ON function.oid = trigger.tgfoid
+       WHERE table_schema.nspname = 'programmable_website_projection_v1'
+         AND table_class.relname = 'projection_records'
+         AND trigger.tgname = 'projection_records_approval_v3_capacity_v1'
+         AND trigger.tgenabled = 'O'
+         AND trigger.tgtype = 7
+         AND function.proname = 'enforce_approval_v3_capacity_v1'
+    ) AS trigger_count,
+    (
+      SELECT count(*)::text
+        FROM pg_proc function
+        JOIN pg_namespace function_schema ON function_schema.oid = function.pronamespace
+        JOIN pg_class owner_table
+          ON owner_table.relname = 'generic_launch_materializations_v2'
+        JOIN pg_namespace owner_schema ON owner_schema.oid = owner_table.relnamespace
+       WHERE function_schema.nspname = 'programmable_website_projection_v1'
+         AND function.proname = 'enforce_approval_v3_capacity_v1'
+         AND owner_schema.nspname = 'programmable_website_projection_v1'
+         AND function.proowner = owner_table.relowner
+         AND function.prosecdef = false
+         AND function.proconfig = ARRAY['search_path=pg_catalog']::text[]
+         AND position('website.approval-v3' in function.prosrc) > 0
+         AND position('>= 48' in function.prosrc) > 0
+         AND position('pg_advisory_xact_lock' in function.prosrc) > 0
+         AND has_function_privilege(current_user, function.oid, 'EXECUTE')
+         AND NOT EXISTS (
+           SELECT 1 FROM aclexplode(function.proacl) acl
+            WHERE acl.grantee <> function.proowner
+              AND (acl.grantee = 0
+                OR pg_get_userbyid(acl.grantee)
+                  <> 'programmable_website_projection_runtime'
+                OR acl.privilege_type <> 'EXECUTE'
+                OR acl.is_grantable)
+         )
+    ) AS function_count,
+    (
+      SELECT count(*)::text
+        FROM pg_roles provider
+        JOIN pg_proc function
+          ON function.proname = 'enforce_approval_v3_capacity_v1'
+        JOIN pg_namespace function_schema ON function_schema.oid = function.pronamespace
+       WHERE provider.rolname IN ('anon', 'authenticated', 'service_role')
+         AND function_schema.nspname = 'programmable_website_projection_v1'
+         AND has_function_privilege(provider.rolname, function.oid, 'EXECUTE')
+    ) AS provider_execute_count
+  `);
+  if (decimal(admissionPosture.rows[0]?.trigger_count,
+      "Generic launch capacity trigger count") !== "1"
+    || decimal(admissionPosture.rows[0]?.function_count,
+      "Generic launch capacity function count") !== "1"
+    || decimal(admissionPosture.rows[0]?.provider_execute_count,
+      "Generic launch provider capacity execute count") !== "0") {
     throw new TypeError("Generic launch materialization storage posture is invalid");
   }
 }
@@ -655,6 +815,31 @@ function lifecycleRow(row: LifecycleRow) {
   if (state !== "finalized" && state !== "revoked" && state !== "invalidated") {
     throw new TypeError("stored lifecycle state is invalid");
   }
+  const record = row.canonical_record === null
+    ? null
+    : parseGenericLaunchRecordV2(canonicalObject(
+      row.canonical_record,
+      "stored lifecycle record",
+    ));
+  const lastFinalizedRecord = row.last_finalized_record === null
+    ? null
+    : parseGenericLaunchRecordV2(canonicalObject(
+      row.last_finalized_record,
+      "last finalized lifecycle record",
+    ));
+  const observationCommonHead = row.observation_common_head === null
+    ? record?.sourceProjection.lifecycle.latestCommonHead
+    : decimal(row.observation_common_head, "lifecycle observation common head");
+  const observationCommonHeadHash = row.observation_common_head_hash === null
+    ? record?.sourceProjection.lifecycle.latestCommonHeadHash
+    : hash32(
+      row.observation_common_head_hash,
+      "lifecycle observation common head hash",
+    );
+  if (observationCommonHead === undefined
+    || observationCommonHeadHash === undefined) {
+    throw new TypeError("stored lifecycle observation is unavailable");
+  }
   return Object.freeze({
     approvalId: hash32(row.approval_id, "lifecycle Approval ID"),
     descriptorHash: hash32(row.descriptor_hash, "lifecycle descriptor hash"),
@@ -664,20 +849,10 @@ function lifecycleRow(row: LifecycleRow) {
     recordHash: row.record_hash === null
       ? null
       : digest(row.record_hash, "lifecycle record hash"),
-    record: row.canonical_record === null
-      ? null
-      : parseGenericLaunchRecordV2(canonicalObject(
-        row.canonical_record,
-        "stored lifecycle record",
-      )),
-    observationCommonHead: decimal(
-      row.observation_common_head,
-      "lifecycle observation common head",
-    ),
-    observationCommonHeadHash: hash32(
-      row.observation_common_head_hash,
-      "lifecycle observation common head hash",
-    ),
+    record,
+    lastFinalizedRecord,
+    observationCommonHead,
+    observationCommonHeadHash,
   });
 }
 

--- a/lib/server/custom-launch/generic-launch-postgres-v2.ts
+++ b/lib/server/custom-launch/generic-launch-postgres-v2.ts
@@ -576,9 +576,49 @@ export async function assertPostgresGenericLaunchReadStoreReadyV2(
   );
 }
 
+export async function assertPostgresGenericLaunchAdmissionReadyV2(
+  pool: ProjectionTargetPostgresPoolV1,
+): Promise<void> {
+  const policies = await pool.query<StoragePolicyPostureRow>(`
+    SELECT tablename, policyname, permissive,
+           array_to_string(roles, ',') AS roles, cmd,
+           COALESCE(qual, '') AS qual,
+           COALESCE(with_check, '') AS with_check
+      FROM pg_policies
+     WHERE schemaname = 'programmable_website_projection_v1'
+       AND tablename = 'projection_records'
+     ORDER BY policyname
+  `);
+  const actualPolicies = policies.rows.map((row) => [
+    row.tablename, row.policyname, row.permissive, row.roles, row.cmd,
+    row.qual, row.with_check,
+  ].join("|"));
+  const expectedPolicies = [
+    "projection_records|projection_records_runtime_insert|PERMISSIVE|programmable_website_projection_runtime|INSERT||true",
+    "projection_records|projection_records_runtime_select|PERMISSIVE|programmable_website_projection_runtime|SELECT|true|",
+  ];
+  if (actualPolicies.length !== expectedPolicies.length
+    || actualPolicies.some((value, index) => value !== expectedPolicies[index])) {
+    throw new TypeError("Generic launch Approval admission posture is invalid");
+  }
+  await assertGenericLaunchApprovalAdmissionFunctionV2(pool);
+  const inventory = await pool.query<{ total: unknown }>(`
+    SELECT count(*)::text AS total
+      FROM programmable_website_projection_v1.projection_records
+     WHERE lane = 'website.approval-v3'
+  `);
+  if (BigInt(decimal(
+    inventory.rows[0]?.total,
+    "Generic launch Approval inventory",
+  )) > MAXIMUM_SUPPORTED_APPROVAL_INVENTORY) {
+    throw new TypeError("Generic launch reconciliation capacity is exceeded");
+  }
+}
+
 async function assertGenericLaunchMaterializationStorageV2(
   pool: ProjectionTargetPostgresPoolV1,
 ): Promise<void> {
+  await assertPostgresGenericLaunchAdmissionReadyV2(pool);
   const tables = await pool.query<StorageTablePostureRow>(`
     SELECT c.relname, c.relrowsecurity, c.relforcerowsecurity,
            owner.rolname AS owner_name,
@@ -765,6 +805,11 @@ async function assertGenericLaunchMaterializationStorageV2(
   ) !== "0") {
     throw new TypeError("Generic launch materialization storage posture is invalid");
   }
+}
+
+async function assertGenericLaunchApprovalAdmissionFunctionV2(
+  pool: ProjectionTargetPostgresPoolV1,
+): Promise<void> {
   const admissionPosture = await pool.query<StorageAdmissionPostureRow>(`
     SELECT (
       SELECT count(*)::text

--- a/lib/server/custom-launch/generic-launch-postgres-v2.ts
+++ b/lib/server/custom-launch/generic-launch-postgres-v2.ts
@@ -26,6 +26,32 @@ const DIGEST = /^sha256:[0-9a-f]{64}$/u;
 const DECIMAL = /^(?:0|[1-9][0-9]{0,77})$/u;
 const MAXIMUM_CANONICAL_RECORD_BYTES = 2_097_152;
 const MAXIMUM_SUPPORTED_APPROVAL_INVENTORY = 48n;
+const APPROVAL_V3_CAPACITY_FUNCTION_SOURCE = `
+BEGIN
+  IF NEW.lane <> 'website.approval-v3' THEN
+    RETURN NEW;
+  END IF;
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('programmable.website.approval-v3.capacity.v1', 0)
+  );
+  IF EXISTS (
+    SELECT 1
+      FROM programmable_website_projection_v1.projection_records existing
+     WHERE (existing.lane = NEW.lane
+       AND existing.projection_key = NEW.projection_key)
+        OR existing.idempotency_key = NEW.idempotency_key
+  ) THEN
+    RETURN NEW;
+  END IF;
+  IF (SELECT count(*)
+        FROM programmable_website_projection_v1.projection_records existing
+       WHERE existing.lane = 'website.approval-v3') >= 48 THEN
+    RAISE EXCEPTION 'website Approval v3 release capacity is exhausted'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END
+`;
 
 interface ApprovalRow extends Record<string, unknown> {
   canonical_readback: unknown;
@@ -41,6 +67,7 @@ interface LifecycleRow extends Record<string, unknown> {
   record_hash: unknown;
   canonical_record: unknown;
   last_finalized_record: unknown;
+  last_finalized_lifecycle_evidence_hash: unknown;
   observation_common_head: unknown;
   observation_common_head_hash: unknown;
 }
@@ -150,6 +177,8 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
                m.lifecycle_generation::text, m.lifecycle_evidence_hash,
                m.lifecycle_state, m.record_hash, m.canonical_record,
                finalized.canonical_record AS last_finalized_record,
+               finalized.lifecycle_evidence_hash
+                 AS last_finalized_lifecycle_evidence_hash,
                r.observation_common_head::text, r.observation_common_head_hash
           FROM programmable_website_projection_v1.generic_launch_materializations_v2 m
           LEFT JOIN programmable_website_projection_v1.generic_launch_reconciliations_v2 r
@@ -158,7 +187,7 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
            AND r.descriptor_hash = m.descriptor_hash
            AND r.outcome = 'consumed'
           LEFT JOIN LATERAL (
-            SELECT canonical_record
+            SELECT canonical_record, lifecycle_evidence_hash
               FROM programmable_website_projection_v1.generic_launch_materializations_v2 f
              WHERE f.launch_id = m.launch_id
                AND f.lifecycle_state = 'finalized'
@@ -184,27 +213,48 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
         input.observationCommonHeadHash,
         "observation common head hash",
       );
-      const result = await pool.query(`
-        INSERT INTO programmable_website_projection_v1.generic_launch_reconciliations_v2
-          (approval_id, launch_id, descriptor_hash, outcome,
-           observation_common_head, observation_common_head_hash)
-        VALUES ($1, $2, $3, $4, $5::numeric, $6)
-        ON CONFLICT (approval_id) DO UPDATE SET
-          outcome = EXCLUDED.outcome,
-          observation_common_head = EXCLUDED.observation_common_head,
-          observation_common_head_hash = EXCLUDED.observation_common_head_hash,
-          observed_at = clock_timestamp()
-        WHERE generic_launch_reconciliations_v2.launch_id = EXCLUDED.launch_id
-          AND generic_launch_reconciliations_v2.descriptor_hash = EXCLUDED.descriptor_hash
-          AND (generic_launch_reconciliations_v2.outcome = EXCLUDED.outcome
-            OR (generic_launch_reconciliations_v2.outcome = 'unconsumed'
-              AND EXCLUDED.outcome = 'consumed'))
-        RETURNING approval_id
-      `, [approvalId, launchId, descriptorHash, input.outcome, head, headHash]);
-      input.signal.throwIfAborted();
-      if (result.rowCount !== 1) {
-        throw new TypeError("Generic launch reconciliation identity conflicted");
+      const client = await pool.connect();
+      let open = false;
+      try {
+        await client.query("BEGIN");
+        open = true;
+        await client.query(`
+          SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
+        `, [launchId]);
+        await assertMonotonicObservation(client, {
+          launchId,
+          observationCommonHead: head,
+          observationCommonHeadHash: headHash,
+        });
+        const result = await client.query(`
+          INSERT INTO programmable_website_projection_v1.generic_launch_reconciliations_v2
+            (approval_id, launch_id, descriptor_hash, outcome,
+             observation_common_head, observation_common_head_hash)
+          VALUES ($1, $2, $3, $4, $5::numeric, $6)
+          ON CONFLICT (approval_id) DO UPDATE SET
+            outcome = EXCLUDED.outcome,
+            observation_common_head = EXCLUDED.observation_common_head,
+            observation_common_head_hash = EXCLUDED.observation_common_head_hash,
+            observed_at = clock_timestamp()
+          WHERE generic_launch_reconciliations_v2.launch_id = EXCLUDED.launch_id
+            AND generic_launch_reconciliations_v2.descriptor_hash = EXCLUDED.descriptor_hash
+            AND (generic_launch_reconciliations_v2.outcome = EXCLUDED.outcome
+              OR (generic_launch_reconciliations_v2.outcome = 'unconsumed'
+                AND EXCLUDED.outcome = 'consumed'))
+          RETURNING approval_id
+        `, [approvalId, launchId, descriptorHash, input.outcome, head, headHash]);
+        if (result.rowCount !== 1) {
+          throw new TypeError("Generic launch reconciliation identity conflicted");
+        }
+        await client.query("COMMIT");
+        open = false;
+      } catch (error) {
+        if (open) await client.query("ROLLBACK").catch(() => undefined);
+        throw error;
+      } finally {
+        client.release();
       }
+      input.signal.throwIfAborted();
     },
     async putIfNewLifecycle(
       input: Parameters<GenericLaunchMaterializationStoreV2["putIfNewLifecycle"]>[0],
@@ -253,6 +303,11 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
         await client.query(`
           SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
         `, [launchId]);
+        await assertMonotonicObservation(client, {
+          launchId,
+          observationCommonHead,
+          observationCommonHeadHash,
+        });
         const already = await client.query<LifecycleIdentityRow>(`
           SELECT approval_id, descriptor_hash, lifecycle_evidence_hash,
                  lifecycle_state, record_hash
@@ -333,6 +388,42 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
       }
     },
   });
+}
+
+async function assertMonotonicObservation(
+  client: ProjectionTargetPostgresClientV1,
+  input: Readonly<{
+    launchId: `0x${string}`;
+    observationCommonHead: string;
+    observationCommonHeadHash: `0x${string}`;
+  }>,
+): Promise<void> {
+  const result = await client.query<{
+    observation_common_head: unknown;
+    observation_common_head_hash: unknown;
+  }>(`
+    SELECT observation_common_head::text, observation_common_head_hash
+      FROM programmable_website_projection_v1.generic_launch_reconciliations_v2
+     WHERE launch_id = $1
+     LIMIT 1
+  `, [input.launchId]);
+  const row = result.rows[0];
+  if (row === undefined) return;
+  const storedHead = decimal(
+    row.observation_common_head,
+    "stored observation common head",
+  );
+  const storedHash = hash32(
+    row.observation_common_head_hash,
+    "stored observation common head hash",
+  );
+  if (BigInt(input.observationCommonHead) < BigInt(storedHead)) {
+    throw new TypeError("Generic launch observation head regressed");
+  }
+  if (input.observationCommonHead === storedHead
+    && input.observationCommonHeadHash !== storedHash) {
+    throw new TypeError("Generic launch observation head conflicted");
+  }
 }
 
 async function putConsumedReconciliation(
@@ -677,12 +768,17 @@ async function assertGenericLaunchMaterializationStorageV2(
         JOIN pg_class table_class ON table_class.oid = trigger.tgrelid
         JOIN pg_namespace table_schema ON table_schema.oid = table_class.relnamespace
         JOIN pg_proc function ON function.oid = trigger.tgfoid
+        JOIN pg_namespace function_schema ON function_schema.oid = function.pronamespace
        WHERE table_schema.nspname = 'programmable_website_projection_v1'
          AND table_class.relname = 'projection_records'
          AND trigger.tgname = 'projection_records_approval_v3_capacity_v1'
          AND trigger.tgenabled = 'O'
          AND trigger.tgtype = 7
+         AND function_schema.nspname = 'programmable_website_projection_v1'
          AND function.proname = 'enforce_approval_v3_capacity_v1'
+         AND pg_get_function_identity_arguments(function.oid) = ''
+         AND function.prorettype = 'trigger'::regtype
+         AND function.prosrc = $1
     ) AS trigger_count,
     (
       SELECT count(*)::text
@@ -691,15 +787,15 @@ async function assertGenericLaunchMaterializationStorageV2(
         JOIN pg_class owner_table
           ON owner_table.relname = 'generic_launch_materializations_v2'
         JOIN pg_namespace owner_schema ON owner_schema.oid = owner_table.relnamespace
-       WHERE function_schema.nspname = 'programmable_website_projection_v1'
+         WHERE function_schema.nspname = 'programmable_website_projection_v1'
          AND function.proname = 'enforce_approval_v3_capacity_v1'
+         AND pg_get_function_identity_arguments(function.oid) = ''
+         AND function.prorettype = 'trigger'::regtype
          AND owner_schema.nspname = 'programmable_website_projection_v1'
          AND function.proowner = owner_table.relowner
          AND function.prosecdef = false
          AND function.proconfig = ARRAY['search_path=pg_catalog']::text[]
-         AND position('website.approval-v3' in function.prosrc) > 0
-         AND position('>= 48' in function.prosrc) > 0
-         AND position('pg_advisory_xact_lock' in function.prosrc) > 0
+         AND function.prosrc = $1
          AND has_function_privilege(current_user, function.oid, 'EXECUTE')
          AND NOT EXISTS (
            SELECT 1 FROM aclexplode(function.proacl) acl
@@ -721,7 +817,7 @@ async function assertGenericLaunchMaterializationStorageV2(
          AND function_schema.nspname = 'programmable_website_projection_v1'
          AND has_function_privilege(provider.rolname, function.oid, 'EXECUTE')
     ) AS provider_execute_count
-  `);
+  `, [APPROVAL_V3_CAPACITY_FUNCTION_SOURCE]);
   if (decimal(admissionPosture.rows[0]?.trigger_count,
       "Generic launch capacity trigger count") !== "1"
     || decimal(admissionPosture.rows[0]?.function_count,
@@ -827,6 +923,17 @@ function lifecycleRow(row: LifecycleRow) {
       row.last_finalized_record,
       "last finalized lifecycle record",
     ));
+  const lastFinalizedLifecycleEvidenceHash =
+    row.last_finalized_lifecycle_evidence_hash === null
+      ? null
+      : digest(
+        row.last_finalized_lifecycle_evidence_hash,
+        "last finalized lifecycle evidence",
+      );
+  if ((lastFinalizedRecord === null)
+    !== (lastFinalizedLifecycleEvidenceHash === null)) {
+    throw new TypeError("stored finalized lifecycle evidence is inconsistent");
+  }
   const observationCommonHead = row.observation_common_head === null
     ? record?.sourceProjection.lifecycle.latestCommonHead
     : decimal(row.observation_common_head, "lifecycle observation common head");
@@ -851,6 +958,7 @@ function lifecycleRow(row: LifecycleRow) {
       : digest(row.record_hash, "lifecycle record hash"),
     record,
     lastFinalizedRecord,
+    lastFinalizedLifecycleEvidenceHash,
     observationCommonHead,
     observationCommonHeadHash,
   });

--- a/lib/server/custom-launch/generic-launch-postgres-v2.ts
+++ b/lib/server/custom-launch/generic-launch-postgres-v2.ts
@@ -130,6 +130,7 @@ interface StorageMembershipPostureRow extends Record<string, unknown> {
 
 interface StorageAdmissionPostureRow extends Record<string, unknown> {
   trigger_count: unknown;
+  total_trigger_count: unknown;
   function_count: unknown;
   provider_execute_count: unknown;
 }
@@ -601,6 +602,30 @@ export async function assertPostgresGenericLaunchAdmissionReadyV2(
     || actualPolicies.some((value, index) => value !== expectedPolicies[index])) {
     throw new TypeError("Generic launch Approval admission posture is invalid");
   }
+  const membershipPosture = await pool.query<StorageMembershipPostureRow>(`
+    WITH RECURSIVE roots(root_oid, role_oid) AS (
+      SELECT oid, oid FROM pg_roles
+       WHERE rolname IN (
+         current_user, 'anon', 'authenticated', 'service_role'
+       )
+    ), reachable(root_oid, role_oid) AS (
+      SELECT root_oid, role_oid FROM roots
+      UNION
+      SELECT reachable.root_oid, memberships.roleid
+        FROM reachable
+        JOIN pg_auth_members memberships
+          ON memberships.member = reachable.role_oid
+    )
+    SELECT count(*) FILTER (WHERE root_oid <> role_oid)::text
+      AS reachable_membership_count
+      FROM reachable
+  `);
+  if (decimal(
+    membershipPosture.rows[0]?.reachable_membership_count,
+    "Generic launch reachable role membership count",
+  ) !== "0") {
+    throw new TypeError("Generic launch Approval admission posture is invalid");
+  }
   await assertGenericLaunchApprovalAdmissionFunctionV2(pool);
   const inventory = await pool.query<{ total: unknown }>(`
     SELECT count(*)::text AS total
@@ -781,30 +806,6 @@ async function assertGenericLaunchMaterializationStorageV2(
   ) !== "0") {
     throw new TypeError("Generic launch materialization storage posture is invalid");
   }
-  const membershipPosture = await pool.query<StorageMembershipPostureRow>(`
-    WITH RECURSIVE roots(root_oid, role_oid) AS (
-      SELECT oid, oid FROM pg_roles
-       WHERE rolname IN (
-         current_user, 'anon', 'authenticated', 'service_role'
-       )
-    ), reachable(root_oid, role_oid) AS (
-      SELECT root_oid, role_oid FROM roots
-      UNION
-      SELECT reachable.root_oid, memberships.roleid
-        FROM reachable
-        JOIN pg_auth_members memberships
-          ON memberships.member = reachable.role_oid
-    )
-    SELECT count(*) FILTER (WHERE root_oid <> role_oid)::text
-      AS reachable_membership_count
-      FROM reachable
-  `);
-  if (decimal(
-    membershipPosture.rows[0]?.reachable_membership_count,
-    "Generic launch reachable role membership count",
-  ) !== "0") {
-    throw new TypeError("Generic launch materialization storage posture is invalid");
-  }
 }
 
 async function assertGenericLaunchApprovalAdmissionFunctionV2(
@@ -830,6 +831,15 @@ async function assertGenericLaunchApprovalAdmissionFunctionV2(
          AND function.prorettype = 'trigger'::regtype
          AND function.prosrc = $1
     ) AS trigger_count,
+    (
+      SELECT count(*)::text
+        FROM pg_trigger trigger
+        JOIN pg_class table_class ON table_class.oid = trigger.tgrelid
+        JOIN pg_namespace table_schema ON table_schema.oid = table_class.relnamespace
+       WHERE table_schema.nspname = 'programmable_website_projection_v1'
+         AND table_class.relname = 'projection_records'
+         AND NOT trigger.tgisinternal
+    ) AS total_trigger_count,
     (
       SELECT count(*)::text
         FROM pg_proc function
@@ -872,6 +882,8 @@ async function assertGenericLaunchApprovalAdmissionFunctionV2(
   `, [APPROVAL_V3_CAPACITY_FUNCTION_SOURCE]);
   if (decimal(admissionPosture.rows[0]?.trigger_count,
       "Generic launch capacity trigger count") !== "1"
+    || decimal(admissionPosture.rows[0]?.total_trigger_count,
+      "Generic launch total projection trigger count") !== "1"
     || decimal(admissionPosture.rows[0]?.function_count,
       "Generic launch capacity function count") !== "1"
     || decimal(admissionPosture.rows[0]?.provider_execute_count,

--- a/lib/server/custom-launch/generic-launch-postgres-v2.ts
+++ b/lib/server/custom-launch/generic-launch-postgres-v2.ts
@@ -70,6 +70,7 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
       }
       return readback.authorization ?? null;
     },
+
     async getLatestLifecycle(
       input: Parameters<GenericLaunchMaterializationStoreV2["getLatestLifecycle"]>[0],
     ) {
@@ -121,21 +122,48 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
       try {
         await client.query("BEGIN");
         open = true;
+        await client.query(`
+          SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
+        `, [launchId]);
+        const already = await client.query<LifecycleRow>(`
+          SELECT lifecycle_generation::text, lifecycle_evidence_hash,
+                 lifecycle_state, record_hash
+            FROM programmable_website_projection_v1.generic_launch_materializations_v2
+           WHERE launch_id = $1 AND lifecycle_evidence_hash = $2
+           LIMIT 1
+        `, [launchId, lifecycleEvidenceHash]);
+        const alreadyRow = already.rows[0];
+        if (alreadyRow !== undefined) {
+          const parsed = lifecycleRow(alreadyRow);
+          if (parsed.state !== input.state
+            || parsed.recordHash !== (record?.recordHash ?? null)) {
+            throw new TypeError("Generic launch lifecycle idempotency conflicted");
+          }
+          await client.query("COMMIT");
+          open = false;
+          return Object.freeze({ kind: "existing" as const });
+        }
+        const next = await client.query<{ generation: unknown }>(`
+          SELECT (COALESCE(MAX(lifecycle_generation), 0) + 1)::text AS generation
+            FROM programmable_website_projection_v1.generic_launch_materializations_v2
+           WHERE launch_id = $1
+        `, [launchId]);
+        const generation = decimal(
+          next.rows[0]?.generation,
+          "next lifecycle generation",
+        );
         const inserted = await client.query(`
           INSERT INTO programmable_website_projection_v1.generic_launch_materializations_v2
             (approval_id, launch_id, descriptor_hash, lifecycle_generation,
              lifecycle_state, lifecycle_evidence_hash, canonical_record,
              record_hash, source_projection_hash, finalization_block)
-          SELECT $1, $2, $3, COALESCE(MAX(lifecycle_generation), 0) + 1,
-                 $4, $5, $6, $7, $8, $9::numeric
-            FROM programmable_website_projection_v1.generic_launch_materializations_v2
-           WHERE launch_id = $2
-          ON CONFLICT DO NOTHING
+          VALUES ($1, $2, $3, $4::numeric, $5, $6, $7, $8, $9, $10::numeric)
           RETURNING lifecycle_generation
         `, [
           approvalId,
           launchId,
           descriptorHash,
+          generation,
           input.state,
           lifecycleEvidenceHash,
           canonicalRecord,
@@ -148,25 +176,7 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
           open = false;
           return Object.freeze({ kind: "created" as const });
         }
-        const existing = await client.query<LifecycleRow>(`
-          SELECT lifecycle_generation::text, lifecycle_evidence_hash,
-                 lifecycle_state, record_hash
-            FROM programmable_website_projection_v1.generic_launch_materializations_v2
-           WHERE launch_id = $1 AND lifecycle_evidence_hash = $2
-           LIMIT 1
-        `, [launchId, lifecycleEvidenceHash]);
-        await client.query("COMMIT");
-        open = false;
-        const row = existing.rows[0];
-        if (row === undefined) {
-          throw new TypeError("Generic launch lifecycle generation conflicted");
-        }
-        const parsed = lifecycleRow(row);
-        if (parsed.state !== input.state
-          || parsed.recordHash !== (record?.recordHash ?? null)) {
-          throw new TypeError("Generic launch lifecycle idempotency conflicted");
-        }
-        return Object.freeze({ kind: "existing" as const });
+        throw new TypeError("Generic launch lifecycle insert failed");
       } catch (error) {
         if (open) await client.query("ROLLBACK").catch(() => undefined);
         throw error;

--- a/lib/server/custom-launch/generic-launch-postgres-v2.ts
+++ b/lib/server/custom-launch/generic-launch-postgres-v2.ts
@@ -1,0 +1,384 @@
+import "server-only";
+
+import { canonicalizeJson, parseStrictJson, type JsonValue } from
+  "../projection-target/canonical-json";
+import type { ProjectionTargetPostgresPoolV1 } from
+  "../projection-target/postgres-store";
+import type { Sha256Digest } from "../projection-target/hashing";
+import {
+  parseGenericLaunchRecordV2,
+  type GenericLaunchRecordV2,
+} from "./generic-launch-contract-v2";
+import type { GenericLaunchReadSignerV2 } from
+  "./generic-launch-read-signer-v2";
+import type {
+  GenericLaunchReadModelContractV2,
+  GenericLaunchReadStoreV2,
+} from "./generic-launch-read-v2";
+import type { GenericLaunchMaterializationStoreV2 } from
+  "./generic-launch-projector-v2";
+
+const HASH32 = /^0x[0-9a-f]{64}$/u;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const DECIMAL = /^(?:0|[1-9][0-9]{0,77})$/u;
+const MAXIMUM_CANONICAL_RECORD_BYTES = 2_097_152;
+
+interface ApprovalRow extends Record<string, unknown> {
+  canonical_readback: unknown;
+}
+
+interface LifecycleRow extends Record<string, unknown> {
+  lifecycle_generation: unknown;
+  lifecycle_evidence_hash: unknown;
+  lifecycle_state: unknown;
+  record_hash: unknown;
+}
+
+interface ReadRow extends Record<string, unknown> {
+  canonical_record: unknown;
+  finalization_block: unknown;
+  record_hash: unknown;
+}
+
+export function createPostgresGenericLaunchMaterializationStoreV2(
+  pool: ProjectionTargetPostgresPoolV1,
+): GenericLaunchMaterializationStoreV2 {
+  return Object.freeze({
+    async getApprovalAuthorization(
+      input: Parameters<GenericLaunchMaterializationStoreV2["getApprovalAuthorization"]>[0],
+    ) {
+      input.signal.throwIfAborted();
+      const approvalId = hash32(input.approvalId, "Approval ID");
+      const result = await pool.query<ApprovalRow>(`
+        SELECT canonical_readback
+          FROM programmable_website_projection_v1.projection_records
+         WHERE lane = 'website.approval-v3'
+           AND projection_key = $1
+         LIMIT 1
+      `, [`approval:${approvalId}`]);
+      input.signal.throwIfAborted();
+      const row = result.rows[0];
+      if (row === undefined) return null;
+      const readback = canonicalObject(
+        row.canonical_readback,
+        "stored Approval readback",
+      );
+      if (readback.schemaVersion
+        !== "programmable.approval-v3-artifact-projection-readback.v1"
+        || readback.approvalId !== approvalId) {
+        throw new TypeError("stored Approval readback identity is invalid");
+      }
+      return readback.authorization ?? null;
+    },
+    async getLatestLifecycle(
+      input: Parameters<GenericLaunchMaterializationStoreV2["getLatestLifecycle"]>[0],
+    ) {
+      input.signal.throwIfAborted();
+      const result = await pool.query<LifecycleRow>(`
+        SELECT lifecycle_generation::text, lifecycle_evidence_hash,
+               lifecycle_state, record_hash
+          FROM programmable_website_projection_v1.generic_launch_materializations_v2
+         WHERE launch_id = $1
+         ORDER BY lifecycle_generation DESC
+         LIMIT 1
+      `, [hash32(input.launchId, "launch ID")]);
+      input.signal.throwIfAborted();
+      return result.rows[0] === undefined ? null : lifecycleRow(result.rows[0]);
+    },
+    async putIfNewLifecycle(
+      input: Parameters<GenericLaunchMaterializationStoreV2["putIfNewLifecycle"]>[0],
+    ) {
+      input.signal.throwIfAborted();
+      const approvalId = hash32(input.approvalId, "Approval ID");
+      const launchId = hash32(input.launchId, "launch ID");
+      const descriptorHash = hash32(input.descriptorHash, "descriptor hash");
+      const lifecycleEvidenceHash = digest(
+        input.lifecycleEvidenceHash,
+        "lifecycle evidence",
+      );
+      const record = input.record === null
+        ? null
+        : parseGenericLaunchRecordV2(input.record);
+      if ((input.state === "finalized") !== (record !== null)) {
+        throw new TypeError("Generic launch lifecycle record/state is invalid");
+      }
+      if (record !== null
+        && (record.sourceProjection.approval.approvalId !== approvalId
+          || record.sourceProjection.descriptor.launchId !== launchId
+          || record.sourceProjection.descriptor.descriptorHash !== descriptorHash)) {
+        throw new TypeError("Generic launch materialization identity is invalid");
+      }
+      const canonicalRecord = record === null
+        ? null
+        : canonicalizeJson(record as unknown as JsonValue);
+      if (canonicalRecord !== null
+        && Buffer.byteLength(canonicalRecord, "utf8")
+          > MAXIMUM_CANONICAL_RECORD_BYTES) {
+        throw new TypeError("Generic launch materialization is too large");
+      }
+      const client = await pool.connect();
+      let open = false;
+      try {
+        await client.query("BEGIN");
+        open = true;
+        const inserted = await client.query(`
+          INSERT INTO programmable_website_projection_v1.generic_launch_materializations_v2
+            (approval_id, launch_id, descriptor_hash, lifecycle_generation,
+             lifecycle_state, lifecycle_evidence_hash, canonical_record,
+             record_hash, source_projection_hash, finalization_block)
+          SELECT $1, $2, $3, COALESCE(MAX(lifecycle_generation), 0) + 1,
+                 $4, $5, $6, $7, $8, $9::numeric
+            FROM programmable_website_projection_v1.generic_launch_materializations_v2
+           WHERE launch_id = $2
+          ON CONFLICT DO NOTHING
+          RETURNING lifecycle_generation
+        `, [
+          approvalId,
+          launchId,
+          descriptorHash,
+          input.state,
+          lifecycleEvidenceHash,
+          canonicalRecord,
+          record?.recordHash ?? null,
+          record?.sourceProjectionHash ?? null,
+          record?.sourceProjection.lifecycle.finalization.blockNumber ?? null,
+        ]);
+        if (inserted.rowCount === 1) {
+          await client.query("COMMIT");
+          open = false;
+          return Object.freeze({ kind: "created" as const });
+        }
+        const existing = await client.query<LifecycleRow>(`
+          SELECT lifecycle_generation::text, lifecycle_evidence_hash,
+                 lifecycle_state, record_hash
+            FROM programmable_website_projection_v1.generic_launch_materializations_v2
+           WHERE launch_id = $1 AND lifecycle_evidence_hash = $2
+           LIMIT 1
+        `, [launchId, lifecycleEvidenceHash]);
+        await client.query("COMMIT");
+        open = false;
+        const row = existing.rows[0];
+        if (row === undefined) {
+          throw new TypeError("Generic launch lifecycle generation conflicted");
+        }
+        const parsed = lifecycleRow(row);
+        if (parsed.state !== input.state
+          || parsed.recordHash !== (record?.recordHash ?? null)) {
+          throw new TypeError("Generic launch lifecycle idempotency conflicted");
+        }
+        return Object.freeze({ kind: "existing" as const });
+      } catch (error) {
+        if (open) await client.query("ROLLBACK").catch(() => undefined);
+        throw error;
+      } finally {
+        client.release();
+      }
+    },
+  });
+}
+
+export function createPostgresGenericLaunchReadStoreV2(input: Readonly<{
+  pool: ProjectionTargetPostgresPoolV1;
+  signer: GenericLaunchReadSignerV2;
+  readModelContract: GenericLaunchReadModelContractV2;
+}>): GenericLaunchReadStoreV2 {
+  const readModelContract = Object.freeze({ ...input.readModelContract });
+  const findFinalizedLaunches: GenericLaunchReadStoreV2["findFinalizedLaunches"] =
+    async ({ limit, cursor, requestBindingHash, signal }) => {
+      signal.throwIfAborted();
+      const after = cursor === undefined ? null : decodeCursor(cursor);
+      const rows = await input.pool.query<ReadRow>(`
+        WITH latest AS (
+          SELECT DISTINCT ON (launch_id)
+                 launch_id, lifecycle_generation, lifecycle_state,
+                 canonical_record, finalization_block, record_hash
+            FROM programmable_website_projection_v1.generic_launch_materializations_v2
+           ORDER BY launch_id, lifecycle_generation DESC
+        )
+        SELECT canonical_record, finalization_block::text, record_hash
+          FROM latest
+         WHERE lifecycle_state = 'finalized'
+           AND ($1::numeric IS NULL
+             OR (finalization_block, record_hash) < ($1::numeric, $2))
+         ORDER BY finalization_block DESC, record_hash DESC
+         LIMIT $3
+      `, [after?.finalizationBlock ?? null, after?.recordHash ?? null, limit + 1]);
+      const count = await input.pool.query<{ total: unknown }>(`
+        WITH latest AS (
+          SELECT DISTINCT ON (launch_id) launch_id, lifecycle_state
+            FROM programmable_website_projection_v1.generic_launch_materializations_v2
+           ORDER BY launch_id, lifecycle_generation DESC
+        )
+        SELECT count(*)::text AS total FROM latest
+         WHERE lifecycle_state = 'finalized'
+      `);
+      signal.throwIfAborted();
+      const hasNext = rows.rows.length > limit;
+      const page = rows.rows.slice(0, limit).map(readRecord);
+      const tail = rows.rows[Math.min(limit, rows.rows.length) - 1];
+      const payload = Object.freeze({
+        records: Object.freeze(page),
+        nextCursor: hasNext && tail !== undefined
+          ? encodeCursor({
+            finalizationBlock: decimal(tail.finalization_block, "cursor block"),
+            recordHash: digest(tail.record_hash, "cursor record"),
+          })
+          : null,
+        total: decimal(count.rows[0]?.total, "Generic launch total"),
+      });
+      return await input.signer.sign({
+        requestBindingHash,
+        payload: payload as unknown as JsonValue,
+        signal,
+      });
+    };
+  const findFinalizedLaunchByRecordHash:
+    GenericLaunchReadStoreV2["findFinalizedLaunchByRecordHash"] =
+    async ({ recordHash, requestBindingHash, signal }) => {
+      signal.throwIfAborted();
+      const result = await input.pool.query<ReadRow>(`
+        SELECT candidate.canonical_record, candidate.finalization_block::text,
+               candidate.record_hash
+          FROM programmable_website_projection_v1.generic_launch_materializations_v2 candidate
+         WHERE candidate.record_hash = $1
+           AND candidate.lifecycle_state = 'finalized'
+           AND NOT EXISTS (
+             SELECT 1
+               FROM programmable_website_projection_v1.generic_launch_materializations_v2 newer
+              WHERE newer.launch_id = candidate.launch_id
+                AND newer.lifecycle_generation > candidate.lifecycle_generation
+           )
+         LIMIT 1
+      `, [digest(recordHash, "Generic launch record hash")]);
+      signal.throwIfAborted();
+      const payload = result.rows[0] === undefined ? null : readRecord(result.rows[0]);
+      return await input.signer.sign({
+        requestBindingHash,
+        payload: payload as unknown as JsonValue,
+        signal,
+      });
+    };
+  return Object.freeze({
+    sourceLane: "generic.finalized-launch-v2" as const,
+    readModelContract,
+    findFinalizedLaunches,
+    findFinalizedLaunchByRecordHash,
+  });
+}
+
+export async function assertPostgresGenericLaunchReadStoreReadyV2(
+  pool: ProjectionTargetPostgresPoolV1,
+): Promise<void> {
+  const result = await pool.query<{ total: unknown }>(`
+    WITH latest AS (
+      SELECT DISTINCT ON (launch_id) launch_id, lifecycle_state
+        FROM programmable_website_projection_v1.generic_launch_materializations_v2
+       ORDER BY launch_id, lifecycle_generation DESC
+    )
+    SELECT count(*)::text AS total FROM latest
+     WHERE lifecycle_state = 'finalized'
+  `);
+  if (decimal(result.rows[0]?.total, "Generic launch ready count") === "0") {
+    throw new TypeError("Generic launch read store has no finalized record");
+  }
+}
+
+function lifecycleRow(row: LifecycleRow) {
+  const state = row.lifecycle_state;
+  if (state !== "finalized" && state !== "revoked") {
+    throw new TypeError("stored lifecycle state is invalid");
+  }
+  return Object.freeze({
+    lifecycleGeneration: decimal(row.lifecycle_generation, "lifecycle generation"),
+    lifecycleEvidenceHash: digest(row.lifecycle_evidence_hash, "lifecycle evidence"),
+    state,
+    recordHash: row.record_hash === null
+      ? null
+      : digest(row.record_hash, "lifecycle record hash"),
+  });
+}
+
+function readRecord(row: ReadRow): GenericLaunchRecordV2 {
+  const value = canonicalObject(row.canonical_record, "Generic launch record");
+  const record = parseGenericLaunchRecordV2(value);
+  if (record.recordHash !== digest(row.record_hash, "Generic launch record hash")
+    || record.sourceProjection.lifecycle.finalization.blockNumber
+      !== decimal(row.finalization_block, "Generic launch finalization block")) {
+    throw new TypeError("Generic launch row index is inconsistent");
+  }
+  return record;
+}
+
+function canonicalObject(value: unknown, label: string): Readonly<Record<string, unknown>> {
+  if (typeof value !== "string"
+    || Buffer.byteLength(value, "utf8") > MAXIMUM_CANONICAL_RECORD_BYTES) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  const parsed = parseStrictJson(value, {
+    maximumBytes: MAXIMUM_CANONICAL_RECORD_BYTES,
+    maximumDepth: 128,
+  });
+  if (canonicalizeJson(parsed) !== value || parsed === null
+    || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new TypeError(`${label} is not canonical`);
+  }
+  return parsed as Readonly<Record<string, unknown>>;
+}
+
+function encodeCursor(value: Readonly<{
+  finalizationBlock: string;
+  recordHash: Sha256Digest;
+}>): string {
+  return Buffer.from(canonicalizeJson(value as unknown as JsonValue), "utf8")
+    .toString("base64url");
+}
+
+function decodeCursor(value: string): Readonly<{
+  finalizationBlock: string;
+  recordHash: Sha256Digest;
+}> {
+  if (!/^[A-Za-z0-9_-]{1,1024}$/u.test(value)) {
+    throw new TypeError("Generic launch cursor is invalid");
+  }
+  const bytes = Buffer.from(value, "base64url");
+  if (bytes.toString("base64url") !== value) {
+    throw new TypeError("Generic launch cursor is not canonical");
+  }
+  const parsed = parseStrictJson(bytes.toString("utf8"), {
+    maximumBytes: 1024,
+    maximumDepth: 4,
+  });
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new TypeError("Generic launch cursor is invalid");
+  }
+  const source = parsed as Readonly<Record<string, unknown>>;
+  if (Object.keys(source).sort().join(",") !== "finalizationBlock,recordHash") {
+    throw new TypeError("Generic launch cursor keys are invalid");
+  }
+  return Object.freeze({
+    finalizationBlock: decimal(source.finalizationBlock, "cursor block"),
+    recordHash: digest(source.recordHash, "cursor record hash"),
+  });
+}
+
+function hash32(value: unknown, label: string): `0x${string}` {
+  if (typeof value !== "string" || !HASH32.test(value)
+    || value === `0x${"00".repeat(32)}`) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as `0x${string}`;
+}
+
+function digest(value: unknown, label: string): Sha256Digest {
+  if (typeof value !== "string" || !DIGEST.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Sha256Digest;
+}
+
+function decimal(value: unknown, label: string): string {
+  if (typeof value !== "string" || !DECIMAL.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}

--- a/lib/server/custom-launch/generic-launch-postgres-v2.ts
+++ b/lib/server/custom-launch/generic-launch-postgres-v2.ts
@@ -22,13 +22,28 @@ const HASH32 = /^0x[0-9a-f]{64}$/u;
 const DIGEST = /^sha256:[0-9a-f]{64}$/u;
 const DECIMAL = /^(?:0|[1-9][0-9]{0,77})$/u;
 const MAXIMUM_CANONICAL_RECORD_BYTES = 2_097_152;
+const MAXIMUM_SUPPORTED_APPROVAL_INVENTORY = 48n;
 
 interface ApprovalRow extends Record<string, unknown> {
   canonical_readback: unknown;
+  created_at: unknown;
 }
 
 interface LifecycleRow extends Record<string, unknown> {
+  approval_id: unknown;
+  descriptor_hash: unknown;
   lifecycle_generation: unknown;
+  lifecycle_evidence_hash: unknown;
+  lifecycle_state: unknown;
+  record_hash: unknown;
+  canonical_record: unknown;
+  observation_common_head: unknown;
+  observation_common_head_hash: unknown;
+}
+
+interface LifecycleIdentityRow extends Record<string, unknown> {
+  approval_id: unknown;
+  descriptor_hash: unknown;
   lifecycle_evidence_hash: unknown;
   lifecycle_state: unknown;
   record_hash: unknown;
@@ -44,11 +59,38 @@ interface ReadRow extends Record<string, unknown> {
   record_hash: unknown;
 }
 
-interface StoragePostureRow extends Record<string, unknown> {
+interface StorageTablePostureRow extends Record<string, unknown> {
+  relname: unknown;
   relrowsecurity: unknown;
   relforcerowsecurity: unknown;
-  policies: unknown;
-  privileges: unknown;
+  owner_name: unknown;
+  runtime_is_owner_member: unknown;
+  runtime_overprivileged: unknown;
+}
+
+interface StoragePolicyPostureRow extends Record<string, unknown> {
+  tablename: unknown;
+  policyname: unknown;
+  permissive: unknown;
+  roles: unknown;
+  cmd: unknown;
+  qual: unknown;
+  with_check: unknown;
+}
+
+interface StorageAclPostureRow extends Record<string, unknown> {
+  relname: unknown;
+  grantee: unknown;
+  privilege_type: unknown;
+  is_grantable: unknown;
+}
+
+interface StorageColumnAclPostureRow extends StorageAclPostureRow {
+  attname: unknown;
+}
+
+interface StorageProviderPostureRow extends Record<string, unknown> {
+  provider_access_count: unknown;
 }
 
 export function createPostgresGenericLaunchMaterializationStoreV2(
@@ -61,7 +103,7 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
       input.signal.throwIfAborted();
       const approvalId = hash32(input.approvalId, "Approval ID");
       const result = await pool.query<ApprovalRow>(`
-        SELECT canonical_readback
+        SELECT canonical_readback, created_at
           FROM programmable_website_projection_v1.projection_records
          WHERE lane = 'website.approval-v3'
            AND projection_key = $1
@@ -79,7 +121,10 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
         || readback.approvalId !== approvalId) {
         throw new TypeError("stored Approval readback identity is invalid");
       }
-      return readback.authorization ?? null;
+      return Object.freeze({
+        authorization: readback.authorization ?? null,
+        receivedAt: databaseTimestamp(row.created_at, "Approval delivery timestamp"),
+      });
     },
 
     async getLatestLifecycle(
@@ -87,15 +132,53 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
     ) {
       input.signal.throwIfAborted();
       const result = await pool.query<LifecycleRow>(`
-        SELECT lifecycle_generation::text, lifecycle_evidence_hash,
-               lifecycle_state, record_hash
-          FROM programmable_website_projection_v1.generic_launch_materializations_v2
-         WHERE launch_id = $1
-         ORDER BY lifecycle_generation DESC
+        SELECT m.approval_id, m.descriptor_hash,
+               m.lifecycle_generation::text, m.lifecycle_evidence_hash,
+               m.lifecycle_state, m.record_hash, m.canonical_record,
+               r.observation_common_head::text, r.observation_common_head_hash
+          FROM programmable_website_projection_v1.generic_launch_materializations_v2 m
+          JOIN programmable_website_projection_v1.generic_launch_reconciliations_v2 r
+            ON r.launch_id = m.launch_id
+           AND r.approval_id = m.approval_id
+           AND r.descriptor_hash = m.descriptor_hash
+           AND r.outcome = 'consumed'
+         WHERE m.launch_id = $1
+         ORDER BY m.lifecycle_generation DESC
          LIMIT 1
       `, [hash32(input.launchId, "launch ID")]);
       input.signal.throwIfAborted();
       return result.rows[0] === undefined ? null : lifecycleRow(result.rows[0]);
+    },
+    async putApprovalReconciliation(
+      input: Parameters<GenericLaunchMaterializationStoreV2["putApprovalReconciliation"]>[0],
+    ) {
+      input.signal.throwIfAborted();
+      const approvalId = hash32(input.approvalId, "Approval ID");
+      const launchId = hash32(input.launchId, "launch ID");
+      const descriptorHash = hash32(input.descriptorHash, "descriptor hash");
+      const head = decimal(input.observationCommonHead, "observation common head");
+      const headHash = hash32(
+        input.observationCommonHeadHash,
+        "observation common head hash",
+      );
+      const result = await pool.query(`
+        INSERT INTO programmable_website_projection_v1.generic_launch_reconciliations_v2
+          (approval_id, launch_id, descriptor_hash, outcome,
+           observation_common_head, observation_common_head_hash)
+        VALUES ($1, $2, $3, $4, $5::numeric, $6)
+        ON CONFLICT (approval_id) DO UPDATE SET
+          observation_common_head = EXCLUDED.observation_common_head,
+          observation_common_head_hash = EXCLUDED.observation_common_head_hash,
+          observed_at = clock_timestamp()
+        WHERE generic_launch_reconciliations_v2.launch_id = EXCLUDED.launch_id
+          AND generic_launch_reconciliations_v2.descriptor_hash = EXCLUDED.descriptor_hash
+          AND generic_launch_reconciliations_v2.outcome = EXCLUDED.outcome
+        RETURNING approval_id
+      `, [approvalId, launchId, descriptorHash, input.outcome, head, headHash]);
+      input.signal.throwIfAborted();
+      if (result.rowCount !== 1) {
+        throw new TypeError("Generic launch reconciliation identity conflicted");
+      }
     },
     async putIfNewLifecycle(
       input: Parameters<GenericLaunchMaterializationStoreV2["putIfNewLifecycle"]>[0],
@@ -136,18 +219,30 @@ export function createPostgresGenericLaunchMaterializationStoreV2(
         await client.query(`
           SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
         `, [launchId]);
-        const already = await client.query<LifecycleRow>(`
-          SELECT lifecycle_generation::text, lifecycle_evidence_hash,
+        const already = await client.query<LifecycleIdentityRow>(`
+          SELECT approval_id, descriptor_hash, lifecycle_evidence_hash,
                  lifecycle_state, record_hash
             FROM programmable_website_projection_v1.generic_launch_materializations_v2
-           WHERE launch_id = $1 AND lifecycle_evidence_hash = $2
+           WHERE launch_id = $1
+           ORDER BY lifecycle_generation DESC
            LIMIT 1
-        `, [launchId, lifecycleEvidenceHash]);
+        `, [launchId]);
         const alreadyRow = already.rows[0];
-        if (alreadyRow !== undefined) {
-          const parsed = lifecycleRow(alreadyRow);
-          if (parsed.state !== input.state
-            || parsed.recordHash !== (record?.recordHash ?? null)) {
+        if (alreadyRow !== undefined
+          && (hash32(alreadyRow.approval_id, "stored lifecycle Approval ID")
+              !== approvalId
+            || hash32(alreadyRow.descriptor_hash, "stored descriptor hash")
+              !== descriptorHash)) {
+          throw new TypeError("Generic launch canonical lifecycle identity conflicted");
+        }
+        if (alreadyRow !== undefined
+          && digest(alreadyRow.lifecycle_evidence_hash,
+            "stored lifecycle evidence") === lifecycleEvidenceHash) {
+          if (alreadyRow.lifecycle_state !== input.state
+            || (alreadyRow.record_hash === null
+              ? null
+              : digest(alreadyRow.record_hash, "stored lifecycle record hash"))
+              !== (record?.recordHash ?? null)) {
             throw new TypeError("Generic launch lifecycle idempotency conflicted");
           }
           await client.query("COMMIT");
@@ -309,49 +404,170 @@ export async function assertPostgresGenericLaunchReadStoreReadyV2(
     lifecycleAge(maximumLifecycleAgeMs),
     new AbortController().signal,
   );
-  const result = await pool.query<{ total: unknown }>(`
-    WITH latest AS (
-      SELECT DISTINCT ON (launch_id) launch_id, lifecycle_state
-        FROM programmable_website_projection_v1.generic_launch_materializations_v2
-       ORDER BY launch_id, lifecycle_generation DESC
-    )
-    SELECT count(*)::text AS total FROM latest
-     WHERE lifecycle_state = 'finalized'
-  `);
-  if (decimal(result.rows[0]?.total, "Generic launch ready count") === "0") {
-    throw new TypeError("Generic launch read store has no finalized record");
-  }
 }
 
 async function assertGenericLaunchMaterializationStorageV2(
   pool: ProjectionTargetPostgresPoolV1,
 ): Promise<void> {
-  const result = await pool.query<StoragePostureRow>(`
-    SELECT c.relrowsecurity, c.relforcerowsecurity,
-           COALESCE((
-             SELECT string_agg(p.policyname || ':' || p.cmd, ',' ORDER BY p.policyname)
-               FROM pg_policies p
-              WHERE p.schemaname = 'programmable_website_projection_v1'
-                AND p.tablename = 'generic_launch_materializations_v2'
-           ), '') AS policies,
-           COALESCE((
-             SELECT string_agg(g.privilege_type, ',' ORDER BY g.privilege_type)
-               FROM information_schema.role_table_grants g
-              WHERE g.table_schema = 'programmable_website_projection_v1'
-                AND g.table_name = 'generic_launch_materializations_v2'
-                AND g.grantee = 'programmable_website_projection_runtime'
-           ), '') AS privileges
+  const tables = await pool.query<StorageTablePostureRow>(`
+    SELECT c.relname, c.relrowsecurity, c.relforcerowsecurity,
+           owner.rolname AS owner_name,
+           pg_has_role(current_user, owner.oid, 'MEMBER') AS runtime_is_owner_member,
+           (runtime.rolsuper OR runtime.rolcreaterole OR runtime.rolcreatedb
+             OR runtime.rolreplication OR runtime.rolbypassrls) AS runtime_overprivileged
       FROM pg_class c
       JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_roles owner ON owner.oid = c.relowner
+      JOIN pg_roles runtime ON runtime.rolname = current_user
      WHERE n.nspname = 'programmable_website_projection_v1'
-       AND c.relname = 'generic_launch_materializations_v2'
+       AND c.relname IN (
+         'generic_launch_materializations_v2',
+         'generic_launch_reconciliations_v2',
+         'generic_launch_reconciliation_attempts_v2'
+       )
        AND c.relkind = 'r'
+     ORDER BY c.relname
   `);
-  const row = result.rows[0];
-  if (result.rows.length !== 1 || row?.relrowsecurity !== true
-    || row.relforcerowsecurity !== true
-    || row.policies !== "generic_launch_materializations_v2_runtime_insert:INSERT,generic_launch_materializations_v2_runtime_select:SELECT"
-    || row.privileges !== "INSERT,SELECT") {
+  const expectedTables = [
+    "generic_launch_materializations_v2",
+    "generic_launch_reconciliation_attempts_v2",
+    "generic_launch_reconciliations_v2",
+  ];
+  const expectedOwner = tables.rows[0]?.owner_name;
+  if (tables.rows.length !== expectedTables.length
+    || tables.rows.some((row, index) => row.relname !== expectedTables[index]
+      || row.relrowsecurity !== true || row.relforcerowsecurity !== true
+      || typeof row.owner_name !== "string" || row.owner_name !== expectedOwner
+      || ["anon", "authenticated", "service_role"].includes(row.owner_name)
+      || row.runtime_is_owner_member !== false
+      || row.runtime_overprivileged !== false)) {
+    throw new TypeError("Generic launch materialization storage posture is invalid");
+  }
+  const policies = await pool.query<StoragePolicyPostureRow>(`
+    SELECT tablename, policyname, permissive,
+           array_to_string(roles, ',') AS roles, cmd,
+           COALESCE(qual, '') AS qual,
+           COALESCE(with_check, '') AS with_check
+      FROM pg_policies
+     WHERE schemaname = 'programmable_website_projection_v1'
+       AND tablename IN (
+         'generic_launch_materializations_v2',
+         'generic_launch_reconciliations_v2',
+         'generic_launch_reconciliation_attempts_v2'
+       )
+     ORDER BY tablename, policyname
+  `);
+  const actualPolicies = policies.rows.map((row) => [
+    row.tablename, row.policyname, row.permissive, row.roles, row.cmd,
+    row.qual, row.with_check,
+  ].join("|"));
+  const expectedPolicies = [
+    "generic_launch_materializations_v2|generic_launch_materializations_v2_runtime_insert|PERMISSIVE|programmable_website_projection_runtime|INSERT||true",
+    "generic_launch_materializations_v2|generic_launch_materializations_v2_runtime_select|PERMISSIVE|programmable_website_projection_runtime|SELECT|true|",
+    "generic_launch_reconciliation_attempts_v2|generic_launch_reconciliation_attempts_v2_runtime_insert|PERMISSIVE|programmable_website_projection_runtime|INSERT||true",
+    "generic_launch_reconciliation_attempts_v2|generic_launch_reconciliation_attempts_v2_runtime_select|PERMISSIVE|programmable_website_projection_runtime|SELECT|true|",
+    "generic_launch_reconciliation_attempts_v2|generic_launch_reconciliation_attempts_v2_runtime_update|PERMISSIVE|programmable_website_projection_runtime|UPDATE|true|true",
+    "generic_launch_reconciliations_v2|generic_launch_reconciliations_v2_runtime_insert|PERMISSIVE|programmable_website_projection_runtime|INSERT||true",
+    "generic_launch_reconciliations_v2|generic_launch_reconciliations_v2_runtime_select|PERMISSIVE|programmable_website_projection_runtime|SELECT|true|",
+    "generic_launch_reconciliations_v2|generic_launch_reconciliations_v2_runtime_update|PERMISSIVE|programmable_website_projection_runtime|UPDATE|true|true",
+  ];
+  if (actualPolicies.length !== expectedPolicies.length
+    || actualPolicies.some((value, index) => value !== expectedPolicies[index])) {
+    throw new TypeError("Generic launch materialization storage posture is invalid");
+  }
+  const acl = await pool.query<StorageAclPostureRow>(`
+    SELECT c.relname,
+           COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee,
+           acl.privilege_type, acl.is_grantable
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      CROSS JOIN LATERAL aclexplode(
+        COALESCE(c.relacl, acldefault('r', c.relowner))
+      ) acl
+      LEFT JOIN pg_roles grantee_role ON grantee_role.oid = acl.grantee
+     WHERE n.nspname = 'programmable_website_projection_v1'
+       AND c.relname IN (
+         'generic_launch_materializations_v2',
+         'generic_launch_reconciliations_v2',
+         'generic_launch_reconciliation_attempts_v2'
+       )
+       AND acl.grantee <> c.relowner
+     ORDER BY c.relname, grantee, acl.privilege_type
+  `);
+  const actualAcl = acl.rows.map((row) => [
+    row.relname, row.grantee, row.privilege_type, String(row.is_grantable),
+  ].join("|"));
+  const expectedAcl = [
+    "generic_launch_materializations_v2|programmable_website_projection_runtime|INSERT|false",
+    "generic_launch_materializations_v2|programmable_website_projection_runtime|SELECT|false",
+    "generic_launch_reconciliation_attempts_v2|programmable_website_projection_runtime|INSERT|false",
+    "generic_launch_reconciliation_attempts_v2|programmable_website_projection_runtime|SELECT|false",
+    "generic_launch_reconciliations_v2|programmable_website_projection_runtime|INSERT|false",
+    "generic_launch_reconciliations_v2|programmable_website_projection_runtime|SELECT|false",
+  ];
+  if (actualAcl.length !== expectedAcl.length
+    || actualAcl.some((value, index) => value !== expectedAcl[index])) {
+    throw new TypeError("Generic launch materialization storage posture is invalid");
+  }
+  const columnAcl = await pool.query<StorageColumnAclPostureRow>(`
+    SELECT c.relname, a.attname,
+           COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee,
+           acl.privilege_type, acl.is_grantable
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_attribute a ON a.attrelid = c.oid
+      CROSS JOIN LATERAL aclexplode(a.attacl) acl
+      LEFT JOIN pg_roles grantee_role ON grantee_role.oid = acl.grantee
+     WHERE n.nspname = 'programmable_website_projection_v1'
+       AND c.relname IN (
+         'generic_launch_materializations_v2',
+         'generic_launch_reconciliations_v2',
+         'generic_launch_reconciliation_attempts_v2'
+       )
+       AND a.attnum > 0 AND NOT a.attisdropped
+       AND acl.grantee <> c.relowner
+     ORDER BY c.relname, a.attname, grantee, acl.privilege_type
+  `);
+  const actualColumnAcl = columnAcl.rows.map((row) => [
+    row.relname, row.attname, row.grantee, row.privilege_type,
+    String(row.is_grantable),
+  ].join("|"));
+  const expectedColumnAcl = [
+    "generic_launch_reconciliation_attempts_v2|attempted_at|programmable_website_projection_runtime|UPDATE|false",
+    "generic_launch_reconciliations_v2|observation_common_head|programmable_website_projection_runtime|UPDATE|false",
+    "generic_launch_reconciliations_v2|observation_common_head_hash|programmable_website_projection_runtime|UPDATE|false",
+    "generic_launch_reconciliations_v2|observed_at|programmable_website_projection_runtime|UPDATE|false",
+  ];
+  if (actualColumnAcl.length !== expectedColumnAcl.length
+    || actualColumnAcl.some((value, index) => value !== expectedColumnAcl[index])) {
+    throw new TypeError("Generic launch materialization storage posture is invalid");
+  }
+  const providerPosture = await pool.query<StorageProviderPostureRow>(`
+    SELECT count(*)::text AS provider_access_count
+      FROM pg_roles provider
+     WHERE provider.rolname IN ('anon', 'authenticated', 'service_role')
+       AND (
+         has_table_privilege(provider.rolname,
+           'programmable_website_projection_v1.generic_launch_materializations_v2',
+           'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+         OR has_table_privilege(provider.rolname,
+           'programmable_website_projection_v1.generic_launch_reconciliations_v2',
+           'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+         OR has_table_privilege(provider.rolname,
+           'programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2',
+           'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+         OR has_any_column_privilege(provider.rolname,
+           'programmable_website_projection_v1.generic_launch_reconciliations_v2',
+           'SELECT,INSERT,UPDATE,REFERENCES')
+         OR has_any_column_privilege(provider.rolname,
+           'programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2',
+           'SELECT,INSERT,UPDATE,REFERENCES')
+       )
+  `);
+  if (decimal(
+    providerPosture.rows[0]?.provider_access_count,
+    "Generic launch provider role access count",
+  ) !== "0") {
     throw new TypeError("Generic launch materialization storage posture is invalid");
   }
 }
@@ -359,33 +575,46 @@ async function assertGenericLaunchMaterializationStorageV2(
 export async function listStaleGenericLaunchApprovalsV2(
   pool: ProjectionTargetPostgresPoolV1,
   input: Readonly<{
-    maximumLifecycleAgeMs: number;
+    refreshAfterMs: number;
+    leaseMs: number;
     limit: number;
     signal: AbortSignal;
   }>,
 ): Promise<readonly `0x${string}`[]> {
   input.signal.throwIfAborted();
-  const maximumLifecycleAgeMs = lifecycleAge(input.maximumLifecycleAgeMs);
+  const refreshAfterMs = lifecycleAge(input.refreshAfterMs);
+  const leaseMs = lifecycleAge(input.leaseMs);
   if (!Number.isSafeInteger(input.limit) || input.limit < 1 || input.limit > 32) {
     throw new TypeError("Generic launch reconciliation limit is invalid");
   }
   const result = await pool.query<ApprovalIdRow>(`
-    WITH latest AS (
-      SELECT DISTINCT ON (launch_id)
-             approval_id, launch_id, lifecycle_generation, created_at
-        FROM programmable_website_projection_v1.generic_launch_materializations_v2
-       ORDER BY launch_id, lifecycle_generation DESC
+    WITH candidates AS MATERIALIZED (
+      SELECT substring(p.projection_key FROM 10) AS approval_id
+        FROM programmable_website_projection_v1.projection_records p
+        LEFT JOIN programmable_website_projection_v1.generic_launch_reconciliations_v2 r
+          ON r.approval_id = substring(p.projection_key FROM 10)
+        LEFT JOIN programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2 a
+          ON a.approval_id = substring(p.projection_key FROM 10)
+       WHERE p.lane = 'website.approval-v3'
+         AND (r.approval_id IS NULL OR r.observed_at < clock_timestamp()
+           - ($1::bigint * interval '1 millisecond'))
+         AND (a.approval_id IS NULL OR a.attempted_at < clock_timestamp()
+           - ($2::bigint * interval '1 millisecond'))
+       ORDER BY a.attempted_at ASC NULLS FIRST,
+                r.observed_at ASC NULLS FIRST, p.projection_key ASC
+       LIMIT $3
+    ), claimed AS (
+      INSERT INTO programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
+        (approval_id, attempted_at)
+      SELECT approval_id, clock_timestamp() FROM candidates
+      ON CONFLICT (approval_id) DO UPDATE
+        SET attempted_at = EXCLUDED.attempted_at
+      WHERE generic_launch_reconciliation_attempts_v2.attempted_at
+        < clock_timestamp() - ($2::bigint * interval '1 millisecond')
+      RETURNING approval_id
     )
-    SELECT substring(p.projection_key FROM 10) AS approval_id
-      FROM programmable_website_projection_v1.projection_records p
-      LEFT JOIN latest l
-        ON l.approval_id = substring(p.projection_key FROM 10)
-     WHERE p.lane = 'website.approval-v3'
-       AND (l.approval_id IS NULL OR l.created_at < clock_timestamp()
-         - ($1::bigint * interval '1 millisecond'))
-     ORDER BY l.created_at ASC NULLS FIRST, p.projection_key ASC
-     LIMIT $2
-  `, [maximumLifecycleAgeMs, input.limit]);
+    SELECT approval_id FROM claimed ORDER BY approval_id
+  `, [refreshAfterMs, leaseMs, input.limit]);
   input.signal.throwIfAborted();
   return Object.freeze(result.rows.map((row) =>
     hash32(row.approval_id, "stale Generic launch Approval ID")));
@@ -397,20 +626,26 @@ async function assertFreshGenericLaunchLifecyclesV2(
   signal: AbortSignal,
 ): Promise<void> {
   signal.throwIfAborted();
-  const result = await pool.query<{ stale: unknown }>(`
-    WITH latest AS (
-      SELECT DISTINCT ON (launch_id)
-             launch_id, lifecycle_generation, created_at
-        FROM programmable_website_projection_v1.generic_launch_materializations_v2
-       ORDER BY launch_id, lifecycle_generation DESC
-    )
-    SELECT count(*)::text AS stale
-      FROM latest
-     WHERE created_at < clock_timestamp()
-       - ($1::bigint * interval '1 millisecond')
+  const result = await pool.query<{ stale: unknown; total: unknown }>(`
+    SELECT count(*) FILTER (
+             WHERE (r.approval_id IS NULL AND p.created_at < clock_timestamp()
+               - ($1::bigint * interval '1 millisecond'))
+                OR r.observed_at < clock_timestamp()
+               - ($1::bigint * interval '1 millisecond')
+           )::text AS stale,
+           count(*)::text AS total
+      FROM programmable_website_projection_v1.projection_records p
+      LEFT JOIN programmable_website_projection_v1.generic_launch_reconciliations_v2 r
+        ON r.approval_id = substring(p.projection_key FROM 10)
+     WHERE p.lane = 'website.approval-v3'
   `, [maximumLifecycleAgeMs]);
   signal.throwIfAborted();
-  if (decimal(result.rows[0]?.stale, "stale Generic launch count") !== "0") {
+  const stale = decimal(result.rows[0]?.stale, "stale Generic launch count");
+  const total = decimal(result.rows[0]?.total, "Generic launch Approval count");
+  if (BigInt(total) > MAXIMUM_SUPPORTED_APPROVAL_INVENTORY) {
+    throw new TypeError("Generic launch reconciliation capacity is exceeded");
+  }
+  if (stale !== "0") {
     throw new TypeError("Generic launch lifecycle snapshot is stale");
   }
 }
@@ -421,12 +656,28 @@ function lifecycleRow(row: LifecycleRow) {
     throw new TypeError("stored lifecycle state is invalid");
   }
   return Object.freeze({
+    approvalId: hash32(row.approval_id, "lifecycle Approval ID"),
+    descriptorHash: hash32(row.descriptor_hash, "lifecycle descriptor hash"),
     lifecycleGeneration: decimal(row.lifecycle_generation, "lifecycle generation"),
     lifecycleEvidenceHash: digest(row.lifecycle_evidence_hash, "lifecycle evidence"),
     state,
     recordHash: row.record_hash === null
       ? null
       : digest(row.record_hash, "lifecycle record hash"),
+    record: row.canonical_record === null
+      ? null
+      : parseGenericLaunchRecordV2(canonicalObject(
+        row.canonical_record,
+        "stored lifecycle record",
+      )),
+    observationCommonHead: decimal(
+      row.observation_common_head,
+      "lifecycle observation common head",
+    ),
+    observationCommonHeadHash: hash32(
+      row.observation_common_head_hash,
+      "lifecycle observation common head hash",
+    ),
   });
 }
 
@@ -520,4 +771,12 @@ function lifecycleAge(value: number): number {
     throw new TypeError("Generic launch lifecycle maximum age is invalid");
   }
   return value;
+}
+
+function databaseTimestamp(value: unknown, label: string): Date {
+  const parsed = value instanceof Date
+    ? new Date(value.getTime())
+    : typeof value === "string" ? new Date(value) : new Date(Number.NaN);
+  if (!Number.isFinite(parsed.getTime())) throw new TypeError(`${label} is invalid`);
+  return parsed;
 }

--- a/lib/server/custom-launch/generic-launch-postgres-v2.ts
+++ b/lib/server/custom-launch/generic-launch-postgres-v2.ts
@@ -34,10 +34,21 @@ interface LifecycleRow extends Record<string, unknown> {
   record_hash: unknown;
 }
 
+interface ApprovalIdRow extends Record<string, unknown> {
+  approval_id: unknown;
+}
+
 interface ReadRow extends Record<string, unknown> {
   canonical_record: unknown;
   finalization_block: unknown;
   record_hash: unknown;
+}
+
+interface StoragePostureRow extends Record<string, unknown> {
+  relrowsecurity: unknown;
+  relforcerowsecurity: unknown;
+  policies: unknown;
+  privileges: unknown;
 }
 
 export function createPostgresGenericLaunchMaterializationStoreV2(
@@ -191,11 +202,18 @@ export function createPostgresGenericLaunchReadStoreV2(input: Readonly<{
   pool: ProjectionTargetPostgresPoolV1;
   signer: GenericLaunchReadSignerV2;
   readModelContract: GenericLaunchReadModelContractV2;
+  maximumLifecycleAgeMs: number;
 }>): GenericLaunchReadStoreV2 {
+  const maximumLifecycleAgeMs = lifecycleAge(input.maximumLifecycleAgeMs);
   const readModelContract = Object.freeze({ ...input.readModelContract });
   const findFinalizedLaunches: GenericLaunchReadStoreV2["findFinalizedLaunches"] =
     async ({ limit, cursor, requestBindingHash, signal }) => {
       signal.throwIfAborted();
+      await assertFreshGenericLaunchLifecyclesV2(
+        input.pool,
+        maximumLifecycleAgeMs,
+        signal,
+      );
       const after = cursor === undefined ? null : decodeCursor(cursor);
       const rows = await input.pool.query<ReadRow>(`
         WITH latest AS (
@@ -246,6 +264,11 @@ export function createPostgresGenericLaunchReadStoreV2(input: Readonly<{
     GenericLaunchReadStoreV2["findFinalizedLaunchByRecordHash"] =
     async ({ recordHash, requestBindingHash, signal }) => {
       signal.throwIfAborted();
+      await assertFreshGenericLaunchLifecyclesV2(
+        input.pool,
+        maximumLifecycleAgeMs,
+        signal,
+      );
       const result = await input.pool.query<ReadRow>(`
         SELECT candidate.canonical_record, candidate.finalization_block::text,
                candidate.record_hash
@@ -278,7 +301,14 @@ export function createPostgresGenericLaunchReadStoreV2(input: Readonly<{
 
 export async function assertPostgresGenericLaunchReadStoreReadyV2(
   pool: ProjectionTargetPostgresPoolV1,
+  maximumLifecycleAgeMs: number,
 ): Promise<void> {
+  await assertGenericLaunchMaterializationStorageV2(pool);
+  await assertFreshGenericLaunchLifecyclesV2(
+    pool,
+    lifecycleAge(maximumLifecycleAgeMs),
+    new AbortController().signal,
+  );
   const result = await pool.query<{ total: unknown }>(`
     WITH latest AS (
       SELECT DISTINCT ON (launch_id) launch_id, lifecycle_state
@@ -293,9 +323,101 @@ export async function assertPostgresGenericLaunchReadStoreReadyV2(
   }
 }
 
+async function assertGenericLaunchMaterializationStorageV2(
+  pool: ProjectionTargetPostgresPoolV1,
+): Promise<void> {
+  const result = await pool.query<StoragePostureRow>(`
+    SELECT c.relrowsecurity, c.relforcerowsecurity,
+           COALESCE((
+             SELECT string_agg(p.policyname || ':' || p.cmd, ',' ORDER BY p.policyname)
+               FROM pg_policies p
+              WHERE p.schemaname = 'programmable_website_projection_v1'
+                AND p.tablename = 'generic_launch_materializations_v2'
+           ), '') AS policies,
+           COALESCE((
+             SELECT string_agg(g.privilege_type, ',' ORDER BY g.privilege_type)
+               FROM information_schema.role_table_grants g
+              WHERE g.table_schema = 'programmable_website_projection_v1'
+                AND g.table_name = 'generic_launch_materializations_v2'
+                AND g.grantee = 'programmable_website_projection_runtime'
+           ), '') AS privileges
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'programmable_website_projection_v1'
+       AND c.relname = 'generic_launch_materializations_v2'
+       AND c.relkind = 'r'
+  `);
+  const row = result.rows[0];
+  if (result.rows.length !== 1 || row?.relrowsecurity !== true
+    || row.relforcerowsecurity !== true
+    || row.policies !== "generic_launch_materializations_v2_runtime_insert:INSERT,generic_launch_materializations_v2_runtime_select:SELECT"
+    || row.privileges !== "INSERT,SELECT") {
+    throw new TypeError("Generic launch materialization storage posture is invalid");
+  }
+}
+
+export async function listStaleGenericLaunchApprovalsV2(
+  pool: ProjectionTargetPostgresPoolV1,
+  input: Readonly<{
+    maximumLifecycleAgeMs: number;
+    limit: number;
+    signal: AbortSignal;
+  }>,
+): Promise<readonly `0x${string}`[]> {
+  input.signal.throwIfAborted();
+  const maximumLifecycleAgeMs = lifecycleAge(input.maximumLifecycleAgeMs);
+  if (!Number.isSafeInteger(input.limit) || input.limit < 1 || input.limit > 32) {
+    throw new TypeError("Generic launch reconciliation limit is invalid");
+  }
+  const result = await pool.query<ApprovalIdRow>(`
+    WITH latest AS (
+      SELECT DISTINCT ON (launch_id)
+             approval_id, launch_id, lifecycle_generation, created_at
+        FROM programmable_website_projection_v1.generic_launch_materializations_v2
+       ORDER BY launch_id, lifecycle_generation DESC
+    )
+    SELECT substring(p.projection_key FROM 10) AS approval_id
+      FROM programmable_website_projection_v1.projection_records p
+      LEFT JOIN latest l
+        ON l.approval_id = substring(p.projection_key FROM 10)
+     WHERE p.lane = 'website.approval-v3'
+       AND (l.approval_id IS NULL OR l.created_at < clock_timestamp()
+         - ($1::bigint * interval '1 millisecond'))
+     ORDER BY l.created_at ASC NULLS FIRST, p.projection_key ASC
+     LIMIT $2
+  `, [maximumLifecycleAgeMs, input.limit]);
+  input.signal.throwIfAborted();
+  return Object.freeze(result.rows.map((row) =>
+    hash32(row.approval_id, "stale Generic launch Approval ID")));
+}
+
+async function assertFreshGenericLaunchLifecyclesV2(
+  pool: ProjectionTargetPostgresPoolV1,
+  maximumLifecycleAgeMs: number,
+  signal: AbortSignal,
+): Promise<void> {
+  signal.throwIfAborted();
+  const result = await pool.query<{ stale: unknown }>(`
+    WITH latest AS (
+      SELECT DISTINCT ON (launch_id)
+             launch_id, lifecycle_generation, created_at
+        FROM programmable_website_projection_v1.generic_launch_materializations_v2
+       ORDER BY launch_id, lifecycle_generation DESC
+    )
+    SELECT count(*)::text AS stale
+      FROM latest
+     WHERE created_at < clock_timestamp()
+       - ($1::bigint * interval '1 millisecond')
+  `, [maximumLifecycleAgeMs]);
+  signal.throwIfAborted();
+  if (decimal(result.rows[0]?.stale, "stale Generic launch count") !== "0") {
+    throw new TypeError("Generic launch lifecycle snapshot is stale");
+  }
+}
+
 function lifecycleRow(row: LifecycleRow) {
   const state = row.lifecycle_state;
-  if (state !== "finalized" && state !== "revoked") {
+  if (state !== "finalized" && state !== "revoked" && state !== "invalidated") {
     throw new TypeError("stored lifecycle state is invalid");
   }
   return Object.freeze({
@@ -389,6 +511,13 @@ function digest(value: unknown, label: string): Sha256Digest {
 function decimal(value: unknown, label: string): string {
   if (typeof value !== "string" || !DECIMAL.test(value)) {
     throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function lifecycleAge(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 30_000 || value > 900_000) {
+    throw new TypeError("Generic launch lifecycle maximum age is invalid");
   }
   return value;
 }

--- a/lib/server/custom-launch/generic-launch-production-v2.ts
+++ b/lib/server/custom-launch/generic-launch-production-v2.ts
@@ -23,6 +23,7 @@ import {
   assertPostgresGenericLaunchReadStoreReadyV2,
   createPostgresGenericLaunchMaterializationStoreV2,
   createPostgresGenericLaunchReadStoreV2,
+  listStaleGenericLaunchApprovalsV2,
 } from "./generic-launch-postgres-v2";
 import {
   createGenericLaunchReadHandlersV2,
@@ -34,6 +35,7 @@ import { createProductionGenericLaunchReadSignerV2 } from
 
 const MAXIMUM_CONFIGURATION_BYTES = 65_536;
 const HASH32 = /^0x[0-9a-f]{64}$/u;
+const GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS = 180_000;
 
 export async function projectProductionGenericLaunchV2(input: Readonly<{
   approvalId: `0x${string}`;
@@ -74,6 +76,26 @@ export async function projectProductionGenericLaunchV2(input: Readonly<{
     readModelBindingHash,
   });
   return await projector.project(input);
+}
+
+export async function reconcileProductionGenericLaunchesV2(input: Readonly<{
+  limit: number;
+  signal?: AbortSignal;
+}>) {
+  const signal = input.signal ?? new AbortController().signal;
+  const pool = getProductionApprovalV3ProjectionPoolV1();
+  await pool.assertProductionReadiness();
+  const approvalIds = await listStaleGenericLaunchApprovalsV2(pool, {
+    maximumLifecycleAgeMs: GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS,
+    limit: input.limit,
+    signal,
+  });
+  const results = [];
+  for (const approvalId of approvalIds) {
+    signal.throwIfAborted();
+    results.push(await projectProductionGenericLaunchV2({ approvalId, signal }));
+  }
+  return Object.freeze({ scanned: approvalIds.length, results: Object.freeze(results) });
 }
 
 export async function handleProductionGenericLaunchFeedV2(
@@ -163,7 +185,10 @@ async function productionReadHandlers() {
   });
   const pool = getProductionApprovalV3ProjectionPoolV1();
   await pool.assertProductionReadiness();
-  await assertPostgresGenericLaunchReadStoreReadyV2(pool);
+  await assertPostgresGenericLaunchReadStoreReadyV2(
+    pool,
+    GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS,
+  );
   const pair = productionMainnetRpcPair();
   await assertCustomRegistryV2DeploymentReadiness({
     deploymentSource,
@@ -176,6 +201,7 @@ async function productionReadHandlers() {
       pool,
       signer,
       readModelContract,
+      maximumLifecycleAgeMs: GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS,
     }),
   });
 }

--- a/lib/server/custom-launch/generic-launch-production-v2.ts
+++ b/lib/server/custom-launch/generic-launch-production-v2.ts
@@ -35,7 +35,10 @@ import { createProductionGenericLaunchReadSignerV2 } from
 
 const MAXIMUM_CONFIGURATION_BYTES = 65_536;
 const HASH32 = /^0x[0-9a-f]{64}$/u;
-const GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS = 180_000;
+const GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS = 300_000;
+const GENERIC_LAUNCH_LIFECYCLE_REFRESH_AFTER_MS = 60_000;
+const GENERIC_LAUNCH_RECONCILIATION_LEASE_MS = 55_000;
+const GENERIC_LAUNCH_RECONCILIATION_CONCURRENCY = 8;
 
 export async function projectProductionGenericLaunchV2(input: Readonly<{
   approvalId: `0x${string}`;
@@ -86,16 +89,31 @@ export async function reconcileProductionGenericLaunchesV2(input: Readonly<{
   const pool = getProductionApprovalV3ProjectionPoolV1();
   await pool.assertProductionReadiness();
   const approvalIds = await listStaleGenericLaunchApprovalsV2(pool, {
-    maximumLifecycleAgeMs: GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS,
+    refreshAfterMs: GENERIC_LAUNCH_LIFECYCLE_REFRESH_AFTER_MS,
+    leaseMs: GENERIC_LAUNCH_RECONCILIATION_LEASE_MS,
     limit: input.limit,
     signal,
   });
-  const results = [];
-  for (const approvalId of approvalIds) {
+  const results: Awaited<ReturnType<typeof projectProductionGenericLaunchV2>>[] = [];
+  let failed = 0;
+  for (let offset = 0; offset < approvalIds.length;
+    offset += GENERIC_LAUNCH_RECONCILIATION_CONCURRENCY) {
     signal.throwIfAborted();
-    results.push(await projectProductionGenericLaunchV2({ approvalId, signal }));
+    const settled = await Promise.allSettled(approvalIds.slice(
+      offset,
+      offset + GENERIC_LAUNCH_RECONCILIATION_CONCURRENCY,
+    ).map((approvalId) => projectProductionGenericLaunchV2({ approvalId, signal })));
+    for (const result of settled) {
+      if (result.status === "fulfilled") results.push(result.value);
+      else failed += 1;
+    }
   }
-  return Object.freeze({ scanned: approvalIds.length, results: Object.freeze(results) });
+  return Object.freeze({
+    scanned: approvalIds.length,
+    succeeded: results.length,
+    failed,
+    results: Object.freeze(results),
+  });
 }
 
 export async function handleProductionGenericLaunchFeedV2(
@@ -141,7 +159,7 @@ export async function handleProductionGenericLaunchReadinessV2(
     }>;
     if (feed.status !== 200
       || payload.schemaVersion !== "programmable.generic-launch-feed.v2"
-      || !Array.isArray(payload.records) || payload.records.length < 1) {
+      || !Array.isArray(payload.records)) {
       throw new TypeError("Generic launch feed is not materialized");
     }
     return Response.json({

--- a/lib/server/custom-launch/generic-launch-production-v2.ts
+++ b/lib/server/custom-launch/generic-launch-production-v2.ts
@@ -1,0 +1,234 @@
+import "server-only";
+
+import deploymentSource from
+  "@/config/custom-registry-v2.deployment.prelaunch.json";
+import { parseStrictJson } from "../projection-target/canonical-json";
+import { canonicalSha256 } from "../projection-target/hashing";
+import { getProductionApprovalV3ProjectionPoolV1 } from
+  "../projection-target/approval-v3-target";
+import { productionMainnetRpcPair } from
+  "../../onchain/website-rpc-providers.server";
+import {
+  assertCustomRegistryV2DeploymentReadiness,
+  resolveCustomRegistryPublicManifestV2,
+} from "./registry-manifest-v2";
+import {
+  createApprovalArtifactVerifierV3,
+  createGenericLaunchProjectorV2,
+  type ApprovalArtifactVerifierBindingV3,
+} from "./generic-launch-projector-v2";
+import { createDualRpcGenericLaunchRegistryReaderV2 } from
+  "./generic-launch-registry-reader-v2";
+import {
+  assertPostgresGenericLaunchReadStoreReadyV2,
+  createPostgresGenericLaunchMaterializationStoreV2,
+  createPostgresGenericLaunchReadStoreV2,
+} from "./generic-launch-postgres-v2";
+import {
+  createGenericLaunchReadHandlersV2,
+  parseGenericLaunchReadBindingV2,
+  type GenericLaunchReadModelContractV2,
+} from "./generic-launch-read-v2";
+import { createProductionGenericLaunchReadSignerV2 } from
+  "./generic-launch-read-signer-v2";
+
+const MAXIMUM_CONFIGURATION_BYTES = 65_536;
+const HASH32 = /^0x[0-9a-f]{64}$/u;
+
+export async function projectProductionGenericLaunchV2(input: Readonly<{
+  approvalId: `0x${string}`;
+  signal?: AbortSignal;
+}>) {
+  const manifest = resolveCustomRegistryPublicManifestV2();
+  if (manifest.status !== "live") {
+    throw new TypeError("Custom Registry V2 is not live");
+  }
+  const readModelContract = productionReadModelContract();
+  const readModelBindingHash = canonicalSha256(
+    readModelContract.schemaVersion,
+    readModelContract,
+  );
+  const pool = getProductionApprovalV3ProjectionPoolV1();
+  await pool.assertProductionReadiness();
+  const pair = productionMainnetRpcPair();
+  await assertCustomRegistryV2DeploymentReadiness({
+    deploymentSource,
+    rpcUrls: [new URL(pair.primary.url), new URL(pair.secondary.url)],
+    rpcFetch: globalThis.fetch.bind(globalThis),
+  });
+  const projector = createGenericLaunchProjectorV2({
+    store: createPostgresGenericLaunchMaterializationStoreV2(pool),
+    verifyApprovalArtifact: createApprovalArtifactVerifierV3(
+      productionApprovalVerifierBinding(),
+    ),
+    readRegistryLifecycle: createDualRpcGenericLaunchRegistryReaderV2({
+      release: {
+        registryAddress: manifest.registry.address,
+        registryRuntimeCodeKeccak256: manifest.registry.runtimeCodeKeccak256,
+        registryPolicyCommitment: manifest.finality.policyBindingHash,
+        deploymentBlock: manifest.registry.deploymentBlock,
+        minimumFinalityBlocks: manifest.finality.minimumConfirmations,
+      },
+      rpcUrls: [pair.primary.url, pair.secondary.url],
+    }),
+    readModelBindingHash,
+  });
+  return await projector.project(input);
+}
+
+export async function handleProductionGenericLaunchFeedV2(
+  request: Request,
+): Promise<Response> {
+  try {
+    return await (await productionReadHandlers()).feed(request);
+  } catch {
+    return unavailable("generic_launch_v2_not_active");
+  }
+}
+
+export async function handleProductionGenericLaunchDetailV2(
+  request: Request,
+  recordHash: string,
+): Promise<Response> {
+  try {
+    return await (await productionReadHandlers()).detail(request, recordHash);
+  } catch {
+    return unavailable("generic_launch_v2_not_active");
+  }
+}
+
+export async function handleProductionGenericLaunchReadinessV2(
+  request: Request,
+): Promise<Response> {
+  const url = new URL(request.url);
+  if (request.method !== "GET" || url.search !== "" || request.body !== null) {
+    return Response.json({
+      schemaVersion: "programmable.generic-launch-readiness.v2",
+      status: "unready",
+      code: "invalid_request",
+    }, { status: 400, headers: readinessHeaders() });
+  }
+  try {
+    const feed = await handleProductionGenericLaunchFeedV2(new Request(
+      `${url.origin}/api/custom-launch/generic/v2/launches?limit=1`,
+      { headers: { accept: "application/json" } },
+    ));
+    const payload = await feed.json() as Readonly<{
+      schemaVersion?: unknown;
+      records?: unknown;
+    }>;
+    if (feed.status !== 200
+      || payload.schemaVersion !== "programmable.generic-launch-feed.v2"
+      || !Array.isArray(payload.records) || payload.records.length < 1) {
+      throw new TypeError("Generic launch feed is not materialized");
+    }
+    return Response.json({
+      schemaVersion: "programmable.generic-launch-readiness.v2",
+      status: "ready",
+      generation: "2",
+      chainId: "1",
+      feedPath: "/api/custom-launch/generic/v2/launches",
+      detailPathTemplate:
+        "/api/custom-launch/generic/v2/launches/{recordHash}",
+      checkedAt: new Date().toISOString(),
+    }, { status: 200, headers: readinessHeaders() });
+  } catch {
+    return Response.json({
+      schemaVersion: "programmable.generic-launch-readiness.v2",
+      status: "unready",
+      code: "generic_launch_v2_not_active",
+      checkedAt: new Date().toISOString(),
+    }, { status: 503, headers: readinessHeaders() });
+  }
+}
+
+async function productionReadHandlers() {
+  const binding = parseGenericLaunchReadBindingV2(
+    configuration("PROGRAMMABLE_GENERIC_LAUNCH_READ_BINDING_V2_JSON"),
+  );
+  const manifest = resolveCustomRegistryPublicManifestV2();
+  if (manifest.status !== "live"
+    || binding.registryIdentity.registryAddress !== manifest.registry.address
+    || binding.registryIdentity.registryRuntimeCodeKeccak256
+      !== manifest.registry.runtimeCodeKeccak256
+    || binding.registryIdentity.registryPolicyCommitment
+      !== manifest.finality.policyBindingHash
+    || binding.registryIdentity.minimumFinalityBlocks
+      !== manifest.finality.minimumConfirmations) {
+    throw new TypeError("Generic launch read binding is not the live Registry");
+  }
+  const readModelContract = productionReadModelContract();
+  const signer = await createProductionGenericLaunchReadSignerV2({
+    activeReadBinding: binding,
+  });
+  const pool = getProductionApprovalV3ProjectionPoolV1();
+  await pool.assertProductionReadiness();
+  await assertPostgresGenericLaunchReadStoreReadyV2(pool);
+  const pair = productionMainnetRpcPair();
+  await assertCustomRegistryV2DeploymentReadiness({
+    deploymentSource,
+    rpcUrls: [new URL(pair.primary.url), new URL(pair.secondary.url)],
+    rpcFetch: globalThis.fetch.bind(globalThis),
+  });
+  return createGenericLaunchReadHandlersV2({
+    binding,
+    store: createPostgresGenericLaunchReadStoreV2({
+      pool,
+      signer,
+      readModelContract,
+    }),
+  });
+}
+
+function productionReadModelContract(): GenericLaunchReadModelContractV2 {
+  return configuration(
+    "PROGRAMMABLE_GENERIC_LAUNCH_READ_MODEL_CONTRACT_V2_JSON",
+  ) as unknown as GenericLaunchReadModelContractV2;
+}
+
+function productionApprovalVerifierBinding(): ApprovalArtifactVerifierBindingV3 {
+  return configuration(
+    "PROGRAMMABLE_APPROVAL_V3_ARTIFACT_VERIFIER_BINDING_JSON",
+  ) as unknown as ApprovalArtifactVerifierBindingV3;
+}
+
+function configuration(name: string): unknown {
+  const source = process.env[name]?.trim();
+  if (!source || Buffer.byteLength(source, "utf8") > MAXIMUM_CONFIGURATION_BYTES) {
+    throw new TypeError(`${name} is not configured`);
+  }
+  return parseStrictJson(source, {
+    maximumBytes: MAXIMUM_CONFIGURATION_BYTES,
+    maximumDepth: 64,
+  });
+}
+
+function unavailable(code: string): Response {
+  return Response.json({
+    schemaVersion: "programmable.custom-launch-error.v1",
+    code,
+  }, {
+    status: 503,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/json; charset=utf-8",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+function readinessHeaders(): HeadersInit {
+  return {
+    "cache-control": "no-store",
+    "content-type": "application/json; charset=utf-8",
+    "x-content-type-options": "nosniff",
+  };
+}
+
+export function parseGenericProjectorApprovalId(value: unknown): `0x${string}` {
+  if (typeof value !== "string" || !HASH32.test(value)
+    || value === `0x${"00".repeat(32)}`) {
+    throw new TypeError("Generic launch projector Approval ID is invalid");
+  }
+  return value as `0x${string}`;
+}

--- a/lib/server/custom-launch/generic-launch-projector-v2.ts
+++ b/lib/server/custom-launch/generic-launch-projector-v2.ts
@@ -67,7 +67,11 @@ export type VerifiedRegistryLifecycleV2 =
   | (GenericLaunchSourceProjectionV2["lifecycle"] extends infer Lifecycle
     ? Lifecycle extends Readonly<Record<string, unknown>>
       ? Omit<Lifecycle, "chainId" | "generation" | "latestStatus">
-        & Readonly<{ status: "finalized" }>
+        & Readonly<{
+          status: "finalized";
+          observationCommonHead: string;
+          observationCommonHeadHash: `0x${string}`;
+        }>
       : never
     : never)
   | Readonly<{
@@ -76,6 +80,8 @@ export type VerifiedRegistryLifecycleV2 =
     latestCommonHeadHash: `0x${string}`;
     revokedAtBlock: string;
     revocationEvidenceHash: `0x${string}`;
+    observationCommonHead: string;
+    observationCommonHeadHash: `0x${string}`;
   }>
   | Readonly<{
     status: "invalidated";
@@ -83,22 +89,48 @@ export type VerifiedRegistryLifecycleV2 =
     latestCommonHeadHash: `0x${string}`;
     registryStatus: string;
     invalidationEvidenceHash: Sha256Digest;
+    observationCommonHead: string;
+    observationCommonHeadHash: `0x${string}`;
+  }>
+  | Readonly<{
+    status: "unconsumed";
+    latestCommonHead: string;
+    latestCommonHeadHash: `0x${string}`;
+    observationCommonHead: string;
+    observationCommonHeadHash: `0x${string}`;
   }>;
 
 export interface GenericLaunchMaterializationStoreV2 {
   getApprovalAuthorization(input: Readonly<{
     approvalId: `0x${string}`;
     signal: AbortSignal;
-  }>): Promise<unknown | null>;
+  }>): Promise<Readonly<{
+    authorization: unknown;
+    receivedAt: Date;
+  }> | null>;
   getLatestLifecycle(input: Readonly<{
     launchId: `0x${string}`;
     signal: AbortSignal;
   }>): Promise<Readonly<{
     lifecycleGeneration: string;
+    approvalId: `0x${string}`;
+    descriptorHash: `0x${string}`;
     lifecycleEvidenceHash: Sha256Digest;
     state: "finalized" | "revoked" | "invalidated";
     recordHash: Sha256Digest | null;
+    record: GenericLaunchRecordV2 | null;
+    observationCommonHead: string;
+    observationCommonHeadHash: `0x${string}`;
   }> | null>;
+  putApprovalReconciliation(input: Readonly<{
+    approvalId: `0x${string}`;
+    launchId: `0x${string}`;
+    descriptorHash: `0x${string}`;
+    outcome: "consumed" | "unconsumed";
+    observationCommonHead: string;
+    observationCommonHeadHash: `0x${string}`;
+    signal: AbortSignal;
+  }>): Promise<void>;
   putIfNewLifecycle(input: Readonly<{
     approvalId: `0x${string}`;
     launchId: `0x${string}`;
@@ -116,7 +148,7 @@ export interface GenericLaunchProjectorV2 {
     signal?: AbortSignal;
   }>): Promise<Readonly<{
     kind: "created" | "existing";
-    state: "finalized" | "revoked" | "invalidated";
+    state: "finalized" | "revoked" | "invalidated" | "unconsumed";
     launchId: `0x${string}`;
     recordHash: Sha256Digest | null;
     lifecycleEvidenceHash: Sha256Digest;
@@ -131,6 +163,9 @@ export function createGenericLaunchProjectorV2(input: Readonly<{
   ) => VerifiedApprovalArtifactV3 | Promise<VerifiedApprovalArtifactV3>;
   readRegistryLifecycle: (input: Readonly<{
     approval: VerifiedApprovalArtifactV3;
+    previous: Awaited<ReturnType<
+      GenericLaunchMaterializationStoreV2["getLatestLifecycle"]
+    >>;
     signal: AbortSignal;
   }>) => Promise<VerifiedRegistryLifecycleV2>;
   readModelBindingHash: Sha256Digest;
@@ -149,23 +184,72 @@ export function createGenericLaunchProjectorV2(input: Readonly<{
       const signal = request.signal ?? new AbortController().signal;
       signal.throwIfAborted();
       const approvalId = nonzeroHash32(request.approvalId, "Approval identity");
-      const raw = await input.store.getApprovalAuthorization({ approvalId, signal });
-      if (raw === null) throw new TypeError("Approval artifact is unavailable");
-      const approval = await input.verifyApprovalArtifact(raw, now());
+      const stored = await input.store.getApprovalAuthorization({ approvalId, signal });
+      if (stored === null) throw new TypeError("Approval artifact is unavailable");
+      const receivedAt = new Date(stored.receivedAt);
+      if (!Number.isFinite(receivedAt.getTime()) || receivedAt > now()) {
+        throw new TypeError("Approval delivery timestamp is invalid");
+      }
+      const approval = await input.verifyApprovalArtifact(
+        stored.authorization,
+        receivedAt,
+      );
       if (approval.approvalId !== approvalId) {
         throw new TypeError("Approval identity does not match the stored artifact");
       }
-      const lifecycle = await input.readRegistryLifecycle({ approval, signal });
+      const previous = await input.store.getLatestLifecycle({
+        launchId: approval.launchId,
+        signal,
+      });
+      const lifecycle = await input.readRegistryLifecycle({
+        approval,
+        previous,
+        signal,
+      });
+      if (lifecycle.status === "unconsumed") {
+        await input.store.putApprovalReconciliation({
+          approvalId,
+          launchId: approval.launchId,
+          descriptorHash: approval.descriptorHash,
+          outcome: "unconsumed",
+          observationCommonHead: lifecycle.observationCommonHead,
+          observationCommonHeadHash: lifecycle.observationCommonHeadHash,
+          signal,
+        });
+        return Object.freeze({
+          kind: "existing" as const,
+          state: "unconsumed" as const,
+          launchId: approval.launchId,
+          recordHash: null,
+          lifecycleEvidenceHash: canonicalSha256(
+            "programmable.generic-launch-unconsumed-evidence.v2",
+            {
+              approvalId,
+              launchId: approval.launchId,
+              descriptorHash: approval.descriptorHash,
+              status: "unconsumed",
+            } as unknown as JsonValue,
+          ),
+        });
+      }
       const lifecycleEvidenceHash = canonicalSha256(
         "programmable.generic-launch-registry-lifecycle-evidence.v2",
-        lifecycle as unknown as JsonValue,
+        stableLifecycleEvidence({
+          lifecycle,
+          approvalId,
+          launchId: approval.launchId,
+          descriptorHash: approval.descriptorHash,
+        }),
       );
       let record: GenericLaunchRecordV2 | null = null;
       if (lifecycle.status === "finalized") {
-        const { chainId: _chainId, ...publicDescriptor } = approval.descriptor;
-        void _chainId;
-        record = createGenericLaunchRecordV2({
-          sourceProjection: {
+        if (previous?.state === "finalized" && previous.record !== null) {
+          record = previous.record;
+        } else {
+          const { chainId: _chainId, ...publicDescriptor } = approval.descriptor;
+          void _chainId;
+          record = createGenericLaunchRecordV2({
+            sourceProjection: {
             schemaVersion: "programmable.generic-launch-source-projection.v2",
             sourceRevision: {
               repositoryId: approval.sourceRevision.repositoryId,
@@ -202,9 +286,10 @@ export function createGenericLaunchProjectorV2(input: Readonly<{
               revokedAtBlock: "0",
               revocationEvidenceHash: lifecycle.revocationEvidenceHash,
             },
-          },
-          readModelBindingHash,
-        });
+            },
+            readModelBindingHash,
+          });
+        }
       } else if (lifecycle.status === "revoked") {
         nonzeroHash32(lifecycle.revocationEvidenceHash, "revocation evidence");
         positiveDecimal(lifecycle.revokedAtBlock, "revocation block");
@@ -225,6 +310,15 @@ export function createGenericLaunchProjectorV2(input: Readonly<{
         record,
         signal,
       });
+      await input.store.putApprovalReconciliation({
+        approvalId,
+        launchId: approval.launchId,
+        descriptorHash: approval.descriptorHash,
+        outcome: "consumed",
+        observationCommonHead: lifecycle.observationCommonHead,
+        observationCommonHeadHash: lifecycle.observationCommonHeadHash,
+        signal,
+      });
       return Object.freeze({
         kind: persisted.kind,
         state: lifecycle.status,
@@ -234,6 +328,42 @@ export function createGenericLaunchProjectorV2(input: Readonly<{
       });
     },
   });
+}
+
+function stableLifecycleEvidence(input: Readonly<{
+  lifecycle: Exclude<VerifiedRegistryLifecycleV2, Readonly<{ status: "unconsumed" }>>;
+  approvalId: `0x${string}`;
+  launchId: `0x${string}`;
+  descriptorHash: `0x${string}`;
+}>): JsonValue {
+  const identity = Object.freeze({
+    approvalId: input.approvalId,
+    launchId: input.launchId,
+    descriptorHash: input.descriptorHash,
+  });
+  if (input.lifecycle.status === "finalized") {
+    return Object.freeze({
+      ...identity,
+      status: "finalized",
+      authorization: input.lifecycle.authorization,
+      registration: input.lifecycle.registration,
+      finalization: input.lifecycle.finalization,
+    }) as unknown as JsonValue;
+  }
+  if (input.lifecycle.status === "revoked") {
+    return Object.freeze({
+      ...identity,
+      status: "revoked",
+      revokedAtBlock: input.lifecycle.revokedAtBlock,
+      revocationEvidenceHash: input.lifecycle.revocationEvidenceHash,
+    }) as unknown as JsonValue;
+  }
+  return Object.freeze({
+    ...identity,
+    status: "invalidated",
+    registryStatus: input.lifecycle.registryStatus,
+    invalidationEvidenceHash: input.lifecycle.invalidationEvidenceHash,
+  }) as unknown as JsonValue;
 }
 
 export interface ApprovalArtifactVerifierBindingV3 {

--- a/lib/server/custom-launch/generic-launch-projector-v2.ts
+++ b/lib/server/custom-launch/generic-launch-projector-v2.ts
@@ -76,6 +76,13 @@ export type VerifiedRegistryLifecycleV2 =
     latestCommonHeadHash: `0x${string}`;
     revokedAtBlock: string;
     revocationEvidenceHash: `0x${string}`;
+  }>
+  | Readonly<{
+    status: "invalidated";
+    latestCommonHead: string;
+    latestCommonHeadHash: `0x${string}`;
+    registryStatus: string;
+    invalidationEvidenceHash: Sha256Digest;
   }>;
 
 export interface GenericLaunchMaterializationStoreV2 {
@@ -89,7 +96,7 @@ export interface GenericLaunchMaterializationStoreV2 {
   }>): Promise<Readonly<{
     lifecycleGeneration: string;
     lifecycleEvidenceHash: Sha256Digest;
-    state: "finalized" | "revoked";
+    state: "finalized" | "revoked" | "invalidated";
     recordHash: Sha256Digest | null;
   }> | null>;
   putIfNewLifecycle(input: Readonly<{
@@ -97,7 +104,7 @@ export interface GenericLaunchMaterializationStoreV2 {
     launchId: `0x${string}`;
     descriptorHash: `0x${string}`;
     lifecycleEvidenceHash: Sha256Digest;
-    state: "finalized" | "revoked";
+    state: "finalized" | "revoked" | "invalidated";
     record: GenericLaunchRecordV2 | null;
     signal: AbortSignal;
   }>): Promise<Readonly<{ kind: "created" | "existing" }>>;
@@ -109,7 +116,7 @@ export interface GenericLaunchProjectorV2 {
     signal?: AbortSignal;
   }>): Promise<Readonly<{
     kind: "created" | "existing";
-    state: "finalized" | "revoked";
+    state: "finalized" | "revoked" | "invalidated";
     launchId: `0x${string}`;
     recordHash: Sha256Digest | null;
     lifecycleEvidenceHash: Sha256Digest;
@@ -198,11 +205,16 @@ export function createGenericLaunchProjectorV2(input: Readonly<{
           },
           readModelBindingHash,
         });
-      } else {
+      } else if (lifecycle.status === "revoked") {
         nonzeroHash32(lifecycle.revocationEvidenceHash, "revocation evidence");
         positiveDecimal(lifecycle.revokedAtBlock, "revocation block");
         decimal(lifecycle.latestCommonHead, "revocation common head");
         hash32(lifecycle.latestCommonHeadHash, "revocation common head hash");
+      } else {
+        decimal(lifecycle.latestCommonHead, "invalidation common head");
+        hash32(lifecycle.latestCommonHeadHash, "invalidation common head hash");
+        decimal(lifecycle.registryStatus, "invalidated Registry status");
+        digest(lifecycle.invalidationEvidenceHash, "invalidation evidence");
       }
       const persisted = await input.store.putIfNewLifecycle({
         approvalId,

--- a/lib/server/custom-launch/generic-launch-projector-v2.ts
+++ b/lib/server/custom-launch/generic-launch-projector-v2.ts
@@ -119,6 +119,7 @@ export interface GenericLaunchMaterializationStoreV2 {
     state: "finalized" | "revoked" | "invalidated";
     recordHash: Sha256Digest | null;
     record: GenericLaunchRecordV2 | null;
+    lastFinalizedRecord: GenericLaunchRecordV2 | null;
     observationCommonHead: string;
     observationCommonHeadHash: `0x${string}`;
   }> | null>;
@@ -138,6 +139,8 @@ export interface GenericLaunchMaterializationStoreV2 {
     lifecycleEvidenceHash: Sha256Digest;
     state: "finalized" | "revoked" | "invalidated";
     record: GenericLaunchRecordV2 | null;
+    observationCommonHead: string;
+    observationCommonHeadHash: `0x${string}`;
     signal: AbortSignal;
   }>): Promise<Readonly<{ kind: "created" | "existing" }>>;
 }
@@ -243,8 +246,9 @@ export function createGenericLaunchProjectorV2(input: Readonly<{
       );
       let record: GenericLaunchRecordV2 | null = null;
       if (lifecycle.status === "finalized") {
-        if (previous?.state === "finalized" && previous.record !== null) {
-          record = previous.record;
+        if (previous?.lastFinalizedRecord !== null
+          && previous?.lastFinalizedRecord !== undefined) {
+          record = previous.lastFinalizedRecord;
         } else {
           const { chainId: _chainId, ...publicDescriptor } = approval.descriptor;
           void _chainId;
@@ -308,13 +312,6 @@ export function createGenericLaunchProjectorV2(input: Readonly<{
         lifecycleEvidenceHash,
         state: lifecycle.status,
         record,
-        signal,
-      });
-      await input.store.putApprovalReconciliation({
-        approvalId,
-        launchId: approval.launchId,
-        descriptorHash: approval.descriptorHash,
-        outcome: "consumed",
         observationCommonHead: lifecycle.observationCommonHead,
         observationCommonHeadHash: lifecycle.observationCommonHeadHash,
         signal,

--- a/lib/server/custom-launch/generic-launch-projector-v2.ts
+++ b/lib/server/custom-launch/generic-launch-projector-v2.ts
@@ -36,6 +36,11 @@ export interface VerifiedApprovalArtifactV3 {
     treeOid: string;
   }>;
   readonly approvalId: `0x${string}`;
+  readonly authorization: Readonly<{
+    approvalId: `0x${string}`;
+    validAfterBlock: string;
+    expiresAtBlock: string;
+  }>;
   readonly approvalEvidenceHash: `0x${string}`;
   readonly signedReceiptArtifactHash: Sha256Digest;
   readonly descriptorHash: `0x${string}`;
@@ -48,6 +53,14 @@ export interface VerifiedApprovalArtifactV3 {
   readonly descriptor:
     Omit<GenericLaunchSourceProjectionV2["descriptor"], "descriptorHash" | "launchId">
     & Readonly<{ chainId: "1" }>;
+  readonly registry: Readonly<{
+    chainId: "1";
+    generation: "2";
+    address: `0x${string}`;
+    runtimeCodeKeccak256: `0x${string}`;
+    minimumFinalityBlocks: string;
+  }>;
+  readonly registryOnchainPolicyCommitment: `0x${string}`;
 }
 
 export type VerifiedRegistryLifecycleV2 =
@@ -331,6 +344,8 @@ function parseVerifiedApprovalPayload(
   const descriptor = object(payload.descriptor, "Approval descriptor");
   const approvedWallet = object(payload.approvedWallet, "Approval wallet");
   const finality = object(payload.finality, "Approval primary finality");
+  const registry = object(payload.registry, "Approval Registry release");
+  const policies = object(payload.policyCommitments, "Approval policy commitments");
   const approvalId = nonzeroHash32(authorization.approvalId, "Approval ID");
   const descriptorHash = nonzeroHash32(payload.descriptorHash, "descriptor hash");
   const launchId = nonzeroHash32(payload.launchId, "launch ID");
@@ -357,6 +372,17 @@ function parseVerifiedApprovalPayload(
       treeOid: gitObject(source.treeOid, "source tree"),
     }),
     approvalId,
+    authorization: Object.freeze({
+      approvalId,
+      validAfterBlock: decimal(
+        authorization.validAfterBlock,
+        "authorization valid-after block",
+      ),
+      expiresAtBlock: positiveDecimal(
+        authorization.expiresAtBlock,
+        "authorization expiration block",
+      ),
+    }),
     approvalEvidenceHash,
     signedReceiptArtifactHash,
     descriptorHash,
@@ -384,6 +410,25 @@ function parseVerifiedApprovalPayload(
       projectCommitment: nonzeroHash32(descriptor.projectCommitment, "project commitment"),
       ...market,
     }),
+    registry: Object.freeze({
+      chainId: registry.chainId === "1" ? "1" as const
+        : invalidLiteral("Registry chain ID"),
+      generation: registry.generation === "2" ? "2" as const
+        : invalidLiteral("Registry generation"),
+      address: nonzeroAddress(registry.address, "Registry address"),
+      runtimeCodeKeccak256: nonzeroHash32(
+        registry.runtimeCodeKeccak256,
+        "Registry runtime hash",
+      ),
+      minimumFinalityBlocks: positiveDecimal(
+        registry.minimumFinalityBlocks,
+        "Registry minimum finality",
+      ),
+    }),
+    registryOnchainPolicyCommitment: nonzeroHash32(
+      policies.registryOnchainPolicyCommitment,
+      "Registry onchain policy commitment",
+    ),
   });
 }
 
@@ -488,6 +533,10 @@ function timestamp(value: unknown, label: string): number {
 function safeId(value: unknown): value is string {
   return typeof value === "string"
     && /^[A-Za-z0-9][A-Za-z0-9._:@/+~-]{0,255}$/u.test(value);
+}
+
+function invalidLiteral(label: string): never {
+  throw new TypeError(`${label} is invalid`);
 }
 
 // Keep strict JSON parser in the production bundle; callers use it before this

--- a/lib/server/custom-launch/generic-launch-projector-v2.ts
+++ b/lib/server/custom-launch/generic-launch-projector-v2.ts
@@ -120,6 +120,7 @@ export interface GenericLaunchMaterializationStoreV2 {
     recordHash: Sha256Digest | null;
     record: GenericLaunchRecordV2 | null;
     lastFinalizedRecord: GenericLaunchRecordV2 | null;
+    lastFinalizedLifecycleEvidenceHash: Sha256Digest | null;
     observationCommonHead: string;
     observationCommonHeadHash: `0x${string}`;
   }> | null>;
@@ -247,7 +248,8 @@ export function createGenericLaunchProjectorV2(input: Readonly<{
       let record: GenericLaunchRecordV2 | null = null;
       if (lifecycle.status === "finalized") {
         if (previous?.lastFinalizedRecord !== null
-          && previous?.lastFinalizedRecord !== undefined) {
+          && previous?.lastFinalizedRecord !== undefined
+          && previous.lastFinalizedLifecycleEvidenceHash === lifecycleEvidenceHash) {
           record = previous.lastFinalizedRecord;
         } else {
           const { chainId: _chainId, ...publicDescriptor } = approval.descriptor;

--- a/lib/server/custom-launch/generic-launch-projector-v2.ts
+++ b/lib/server/custom-launch/generic-launch-projector-v2.ts
@@ -1,0 +1,495 @@
+import "server-only";
+
+import {
+  createHash,
+  createPublicKey,
+  verify as verifySignature,
+} from "node:crypto";
+
+import { canonicalizeJson, parseStrictJson, type JsonValue } from
+  "../projection-target/canonical-json";
+import { canonicalSha256, type Sha256Digest } from
+  "../projection-target/hashing";
+import {
+  createGenericLaunchRecordV2,
+  type GenericLaunchRecordV2,
+  type GenericLaunchSourceProjectionV2,
+} from "./generic-launch-contract-v2";
+
+const HASH32 = /^0x[0-9a-f]{64}$/u;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const DECIMAL = /^(?:0|[1-9][0-9]{0,77})$/u;
+const POSITIVE_DECIMAL = /^[1-9][0-9]{0,77}$/u;
+const GIT_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const REPOSITORY_FULL_NAME =
+  /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/u;
+const BASE64URL = /^[A-Za-z0-9_-]+$/u;
+const TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+
+export interface VerifiedApprovalArtifactV3 {
+  readonly approvalRevision: string;
+  readonly sourceRevision: Readonly<{
+    repositoryId: string;
+    repositoryFullName: string;
+    commitOid: string;
+    treeOid: string;
+  }>;
+  readonly approvalId: `0x${string}`;
+  readonly approvalEvidenceHash: `0x${string}`;
+  readonly signedReceiptArtifactHash: Sha256Digest;
+  readonly descriptorHash: `0x${string}`;
+  readonly launchId: `0x${string}`;
+  readonly primaryFinality: Readonly<{
+    transactionHash: `0x${string}`;
+    blockHash: `0x${string}`;
+    blockNumber: string;
+  }>;
+  readonly descriptor:
+    Omit<GenericLaunchSourceProjectionV2["descriptor"], "descriptorHash" | "launchId">
+    & Readonly<{ chainId: "1" }>;
+}
+
+export type VerifiedRegistryLifecycleV2 =
+  | (GenericLaunchSourceProjectionV2["lifecycle"] extends infer Lifecycle
+    ? Lifecycle extends Readonly<Record<string, unknown>>
+      ? Omit<Lifecycle, "chainId" | "generation" | "latestStatus">
+        & Readonly<{ status: "finalized" }>
+      : never
+    : never)
+  | Readonly<{
+    status: "revoked";
+    latestCommonHead: string;
+    latestCommonHeadHash: `0x${string}`;
+    revokedAtBlock: string;
+    revocationEvidenceHash: `0x${string}`;
+  }>;
+
+export interface GenericLaunchMaterializationStoreV2 {
+  getApprovalAuthorization(input: Readonly<{
+    approvalId: `0x${string}`;
+    signal: AbortSignal;
+  }>): Promise<unknown | null>;
+  getLatestLifecycle(input: Readonly<{
+    launchId: `0x${string}`;
+    signal: AbortSignal;
+  }>): Promise<Readonly<{
+    lifecycleGeneration: string;
+    lifecycleEvidenceHash: Sha256Digest;
+    state: "finalized" | "revoked";
+    recordHash: Sha256Digest | null;
+  }> | null>;
+  putIfNewLifecycle(input: Readonly<{
+    approvalId: `0x${string}`;
+    launchId: `0x${string}`;
+    descriptorHash: `0x${string}`;
+    lifecycleEvidenceHash: Sha256Digest;
+    state: "finalized" | "revoked";
+    record: GenericLaunchRecordV2 | null;
+    signal: AbortSignal;
+  }>): Promise<Readonly<{ kind: "created" | "existing" }>>;
+}
+
+export interface GenericLaunchProjectorV2 {
+  project(input: Readonly<{
+    approvalId: `0x${string}`;
+    signal?: AbortSignal;
+  }>): Promise<Readonly<{
+    kind: "created" | "existing";
+    state: "finalized" | "revoked";
+    launchId: `0x${string}`;
+    recordHash: Sha256Digest | null;
+    lifecycleEvidenceHash: Sha256Digest;
+  }>>;
+}
+
+export function createGenericLaunchProjectorV2(input: Readonly<{
+  store: GenericLaunchMaterializationStoreV2;
+  verifyApprovalArtifact: (
+    raw: unknown,
+    now: Date,
+  ) => VerifiedApprovalArtifactV3 | Promise<VerifiedApprovalArtifactV3>;
+  readRegistryLifecycle: (input: Readonly<{
+    approval: VerifiedApprovalArtifactV3;
+    signal: AbortSignal;
+  }>) => Promise<VerifiedRegistryLifecycleV2>;
+  readModelBindingHash: Sha256Digest;
+  now?: () => Date;
+}>): GenericLaunchProjectorV2 {
+  const readModelBindingHash = digest(
+    input.readModelBindingHash,
+    "Generic launch read model binding",
+  );
+  const now = input.now ?? (() => new Date());
+  return Object.freeze({
+    async project(request: Readonly<{
+      approvalId: `0x${string}`;
+      signal?: AbortSignal;
+    }>) {
+      const signal = request.signal ?? new AbortController().signal;
+      signal.throwIfAborted();
+      const approvalId = nonzeroHash32(request.approvalId, "Approval identity");
+      const raw = await input.store.getApprovalAuthorization({ approvalId, signal });
+      if (raw === null) throw new TypeError("Approval artifact is unavailable");
+      const approval = await input.verifyApprovalArtifact(raw, now());
+      if (approval.approvalId !== approvalId) {
+        throw new TypeError("Approval identity does not match the stored artifact");
+      }
+      const lifecycle = await input.readRegistryLifecycle({ approval, signal });
+      const lifecycleEvidenceHash = canonicalSha256(
+        "programmable.generic-launch-registry-lifecycle-evidence.v2",
+        lifecycle as unknown as JsonValue,
+      );
+      let record: GenericLaunchRecordV2 | null = null;
+      if (lifecycle.status === "finalized") {
+        const { chainId: _chainId, ...publicDescriptor } = approval.descriptor;
+        void _chainId;
+        record = createGenericLaunchRecordV2({
+          sourceProjection: {
+            schemaVersion: "programmable.generic-launch-source-projection.v2",
+            sourceRevision: {
+              repositoryId: approval.sourceRevision.repositoryId,
+              repositoryFullName: approval.sourceRevision.repositoryFullName,
+              commitObjectId: approval.sourceRevision.commitOid,
+              treeObjectId: approval.sourceRevision.treeOid,
+            },
+            approval: {
+              approvalRevision: approval.approvalRevision,
+              approvalId: approval.approvalId,
+              approvalEvidenceHash: approval.approvalEvidenceHash,
+              signedReceiptArtifactHash: approval.signedReceiptArtifactHash,
+            },
+            descriptor: {
+              descriptorHash: approval.descriptorHash,
+              launchId: approval.launchId,
+              ...publicDescriptor,
+            },
+            lifecycle: {
+              chainId: "1",
+              generation: "2",
+              registryAddress: lifecycle.registryAddress,
+              registryRuntimeCodeKeccak256:
+                lifecycle.registryRuntimeCodeKeccak256,
+              registryPolicyCommitment: lifecycle.registryPolicyCommitment,
+              minimumFinalityBlocks: lifecycle.minimumFinalityBlocks,
+              primaryLaunch: lifecycle.primaryLaunch,
+              authorization: lifecycle.authorization,
+              registration: lifecycle.registration,
+              finalization: lifecycle.finalization,
+              latestCommonHead: lifecycle.latestCommonHead,
+              latestCommonHeadHash: lifecycle.latestCommonHeadHash,
+              latestStatus: "finalized",
+              revokedAtBlock: "0",
+              revocationEvidenceHash: lifecycle.revocationEvidenceHash,
+            },
+          },
+          readModelBindingHash,
+        });
+      } else {
+        nonzeroHash32(lifecycle.revocationEvidenceHash, "revocation evidence");
+        positiveDecimal(lifecycle.revokedAtBlock, "revocation block");
+        decimal(lifecycle.latestCommonHead, "revocation common head");
+        hash32(lifecycle.latestCommonHeadHash, "revocation common head hash");
+      }
+      const persisted = await input.store.putIfNewLifecycle({
+        approvalId,
+        launchId: approval.launchId,
+        descriptorHash: approval.descriptorHash,
+        lifecycleEvidenceHash,
+        state: lifecycle.status,
+        record,
+        signal,
+      });
+      return Object.freeze({
+        kind: persisted.kind,
+        state: lifecycle.status,
+        launchId: approval.launchId,
+        recordHash: record?.recordHash ?? null,
+        lifecycleEvidenceHash,
+      });
+    },
+  });
+}
+
+export interface ApprovalArtifactVerifierBindingV3 {
+  readonly keyId: string;
+  readonly keyEpoch: string;
+  readonly publicKeySpkiBase64Url: string;
+  readonly publicKeySha256: Sha256Digest;
+  /** Hash of the exact release-owned payload binding fields named below. */
+  readonly currentReleaseBindingHash: Sha256Digest;
+}
+
+export function createApprovalArtifactVerifierV3(
+  binding: ApprovalArtifactVerifierBindingV3,
+): (raw: unknown, now: Date) => VerifiedApprovalArtifactV3 {
+  if (!safeId(binding.keyId) || !POSITIVE_DECIMAL.test(binding.keyEpoch)
+    || !BASE64URL.test(binding.publicKeySpkiBase64Url)) {
+    throw new TypeError("Approval verifier identity is invalid");
+  }
+  const spki = Buffer.from(binding.publicKeySpkiBase64Url, "base64url");
+  if (`sha256:${createHash("sha256").update(spki).digest("hex")}`
+    !== digest(binding.publicKeySha256, "Approval verifier public key")) {
+    throw new TypeError("Approval verifier public key binding is invalid");
+  }
+  const publicKey = createPublicKey({ key: spki, format: "der", type: "spki" });
+  if (publicKey.asymmetricKeyType !== "ed25519") {
+    throw new TypeError("Approval verifier public key is not Ed25519");
+  }
+  const currentReleaseBindingHash = digest(
+    binding.currentReleaseBindingHash,
+    "Approval current release binding",
+  );
+  return (raw, now) => {
+    if (!(now instanceof Date) || !Number.isFinite(now.getTime())) {
+      throw new TypeError("Approval verification time is invalid");
+    }
+    const authorization = exactObject(raw, [
+      "approvalEvidenceHash", "artifact", "signedReceiptArtifactHash",
+    ], "Approval signed authorization");
+    const artifact = exactObject(authorization.artifact, [
+      "envelope", "payload",
+    ], "Approval signed artifact");
+    const envelope = exactObject(artifact.envelope, [
+      "algorithm", "audience", "domain", "issuedAt", "keyId", "payloadHash",
+      "schemaVersion", "signature", "validUntil",
+    ], "Approval signed envelope");
+    const payload = object(artifact.payload, "Approval descriptor payload");
+    const issuedAt = timestamp(envelope.issuedAt, "Approval issued time");
+    const validUntil = timestamp(envelope.validUntil, "Approval valid-until time");
+    if (
+      envelope.schemaVersion !== "1.0.0"
+      || envelope.domain !== "programmable.approval-registry-descriptor-binding.v3"
+      || envelope.audience !== "programmable.custom-registry.v2"
+      || envelope.algorithm !== "Ed25519"
+      || envelope.keyId !== binding.keyId
+      || validUntil <= issuedAt
+      || now.getTime() < issuedAt
+      || now.getTime() >= validUntil
+      || envelope.payloadHash !== canonicalSha256(
+        "programmable.approval-registry-descriptor-binding.v3",
+        payload as JsonValue,
+      )
+    ) throw new TypeError("Approval signed envelope is not current");
+    if (typeof envelope.signature !== "string"
+      || !/^[A-Za-z0-9_-]{86}$/u.test(envelope.signature)) {
+      throw new TypeError("Approval signature is invalid");
+    }
+    const { signature: _signature, ...unsignedEnvelope } = envelope;
+    void _signature;
+    if (!verifySignature(
+      null,
+      Buffer.from(canonicalizeJson(unsignedEnvelope as JsonValue), "utf8"),
+      publicKey,
+      Buffer.from(envelope.signature, "base64url"),
+    )) throw new TypeError("Approval signature verification failed");
+    const signedReceiptArtifactHash = rawCanonicalSha256(artifact);
+    const approvalEvidenceHash = hash32(
+      authorization.approvalEvidenceHash,
+      "Approval evidence hash",
+    );
+    if (
+      authorization.signedReceiptArtifactHash !== signedReceiptArtifactHash
+      || approvalEvidenceHash !== `0x${signedReceiptArtifactHash.slice(7)}`
+    ) throw new TypeError("Approval artifact hash binding is invalid");
+    const authority = object(payload.authority, "Approval authority");
+    if (authority.keyId !== binding.keyId
+      || authority.keyEpoch !== binding.keyEpoch) {
+      throw new TypeError("Approval authority epoch is invalid");
+    }
+    const releaseProjection = Object.freeze({
+      registry: payload.registry,
+      policyCommitments: payload.policyCommitments,
+      authority: payload.authority,
+      routeAdapterRelease: payload.routeAdapterRelease,
+    });
+    if (canonicalSha256(
+      "programmable.approval-registry-v3-current-release-binding.v1",
+      releaseProjection as JsonValue,
+    ) !== currentReleaseBindingHash) {
+      throw new TypeError("Approval artifact is not bound to the current release");
+    }
+    return parseVerifiedApprovalPayload(
+      payload,
+      signedReceiptArtifactHash,
+      approvalEvidenceHash,
+    );
+  };
+}
+
+function parseVerifiedApprovalPayload(
+  payload: Readonly<Record<string, unknown>>,
+  signedReceiptArtifactHash: Sha256Digest,
+  approvalEvidenceHash: `0x${string}`,
+): VerifiedApprovalArtifactV3 {
+  if (payload.schemaVersion
+    !== "programmable.approval-registry-descriptor-binding.v3") {
+    throw new TypeError("Approval payload schema is invalid");
+  }
+  const source = object(payload.sourceRevision, "Approval source revision");
+  const authorization = object(payload.authorization, "Approval authorization");
+  const descriptor = object(payload.descriptor, "Approval descriptor");
+  const approvedWallet = object(payload.approvedWallet, "Approval wallet");
+  const finality = object(payload.finality, "Approval primary finality");
+  const approvalId = nonzeroHash32(authorization.approvalId, "Approval ID");
+  const descriptorHash = nonzeroHash32(payload.descriptorHash, "descriptor hash");
+  const launchId = nonzeroHash32(payload.launchId, "launch ID");
+  const chainId = positiveDecimal(descriptor.chainId, "descriptor chain ID");
+  if (chainId !== "1" || approvedWallet.chainId !== "1"
+    || approvedWallet.namespace !== "eip155:1") {
+    throw new TypeError("Approval chain identity is invalid");
+  }
+  const launchWallet = nonzeroAddress(descriptor.launchWallet, "launch wallet");
+  if (approvedWallet.value !== launchWallet) {
+    throw new TypeError("Approval wallet binding is invalid");
+  }
+  const market = marketIdentity(
+    descriptor.marketMode,
+    descriptor.marketModeValue,
+    descriptor.protocolFeeBps,
+  );
+  return Object.freeze({
+    approvalRevision: positiveDecimal(payload.approvalRevision, "approval revision"),
+    sourceRevision: Object.freeze({
+      repositoryId: positiveDecimal(source.repositoryId, "source repository ID"),
+      repositoryFullName: repositoryName(source.repositoryFullName),
+      commitOid: gitObject(source.commitOid, "source commit"),
+      treeOid: gitObject(source.treeOid, "source tree"),
+    }),
+    approvalId,
+    approvalEvidenceHash,
+    signedReceiptArtifactHash,
+    descriptorHash,
+    launchId,
+    primaryFinality: Object.freeze({
+      transactionHash: nonzeroHash32(
+        finality.transactionHash,
+        "primary transaction hash",
+      ),
+      blockHash: nonzeroHash32(finality.blockHash, "primary block hash"),
+      blockNumber: positiveDecimal(finality.blockNumber, "primary block number"),
+    }),
+    descriptor: Object.freeze({
+      chainId: "1" as const,
+      launchWallet,
+      primaryContract: nonzeroAddress(descriptor.primaryContract, "primary contract"),
+      primaryRuntimeCodeHash: nonzeroHash32(
+        descriptor.primaryRuntimeCodeHash,
+        "primary runtime code hash",
+      ),
+      componentSetHash: nonzeroHash32(descriptor.componentSetHash, "component set hash"),
+      sourceArtifactHash: nonzeroHash32(descriptor.sourceArtifactHash, "source artifact hash"),
+      configurationHash: nonzeroHash32(descriptor.configurationHash, "configuration hash"),
+      launchPlanHash: nonzeroHash32(descriptor.launchPlanHash, "launch plan hash"),
+      projectCommitment: nonzeroHash32(descriptor.projectCommitment, "project commitment"),
+      ...market,
+    }),
+  });
+}
+
+function marketIdentity(mode: unknown, value: unknown, bps: unknown) {
+  if (mode === "NoMarket0" && value === 0 && bps === 0) {
+    return { marketMode: mode, marketModeValue: value, protocolFeeBps: bps } as const;
+  }
+  if (mode === "Standard10" && value === 1 && bps === 10) {
+    return { marketMode: mode, marketModeValue: value, protocolFeeBps: bps } as const;
+  }
+  throw new TypeError("Approval market identity is invalid");
+}
+
+function rawCanonicalSha256(value: unknown): Sha256Digest {
+  return `sha256:${createHash("sha256")
+    .update(canonicalizeJson(value as JsonValue), "utf8").digest("hex")}`;
+}
+
+function exactObject(value: unknown, keys: readonly string[], label: string) {
+  const result = object(value, label);
+  const actual = Object.keys(result).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length
+    || actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${label} keys are invalid`);
+  }
+  return result;
+}
+
+function object(value: unknown, label: string): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function digest(value: unknown, label: string): Sha256Digest {
+  if (typeof value !== "string" || !DIGEST.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Sha256Digest;
+}
+
+function hash32(value: unknown, label: string): `0x${string}` {
+  if (typeof value !== "string" || !HASH32.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as `0x${string}`;
+}
+
+function nonzeroHash32(value: unknown, label: string): `0x${string}` {
+  const result = hash32(value, label);
+  if (result === `0x${"00".repeat(32)}`) throw new TypeError(`${label} is zero`);
+  return result;
+}
+
+function nonzeroAddress(value: unknown, label: string): `0x${string}` {
+  if (typeof value !== "string" || !ADDRESS.test(value)
+    || value === `0x${"00".repeat(20)}`) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as `0x${string}`;
+}
+
+function decimal(value: unknown, label: string): string {
+  if (typeof value !== "string" || !DECIMAL.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function positiveDecimal(value: unknown, label: string): string {
+  if (typeof value !== "string" || !POSITIVE_DECIMAL.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function gitObject(value: unknown, label: string): string {
+  if (typeof value !== "string" || !GIT_OBJECT_ID.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function repositoryName(value: unknown): string {
+  if (typeof value !== "string" || !REPOSITORY_FULL_NAME.test(value)) {
+    throw new TypeError("source repository name is invalid");
+  }
+  return value;
+}
+
+function timestamp(value: unknown, label: string): number {
+  if (typeof value !== "string" || !TIMESTAMP.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) throw new TypeError(`${label} is invalid`);
+  return milliseconds;
+}
+
+function safeId(value: unknown): value is string {
+  return typeof value === "string"
+    && /^[A-Za-z0-9][A-Za-z0-9._:@/+~-]{0,255}$/u.test(value);
+}
+
+// Keep strict JSON parser in the production bundle; callers use it before this
+// verifier when reading canonical Postgres text.
+void parseStrictJson;

--- a/lib/server/custom-launch/generic-launch-read-signer-v2.ts
+++ b/lib/server/custom-launch/generic-launch-read-signer-v2.ts
@@ -1,0 +1,647 @@
+import "server-only";
+
+import {
+  createHash,
+  createPublicKey,
+  verify as verifySignature,
+  type KeyObject,
+} from "node:crypto";
+import { getVercelOidcToken } from "@vercel/oidc";
+
+import {
+  canonicalizeJson,
+  parseStrictJson,
+  type JsonValue,
+} from "../projection-target/canonical-json";
+import {
+  canonicalSha256,
+  type Sha256Digest,
+} from "../projection-target/hashing";
+import {
+  parseGenericLaunchReadBindingV2,
+  type GenericLaunchReadBindingV2,
+} from "./generic-launch-read-v2";
+
+export const GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2 =
+  "programmable.generic-launch-read.v2" as const;
+export const GENERIC_LAUNCH_READ_SIGNER_BINDING_ENV_V2 =
+  "PROGRAMMABLE_GENERIC_LAUNCH_READ_SIGNER_V2_JSON" as const;
+
+const MAXIMUM_CONFIGURATION_BYTES = 16_384;
+const MAXIMUM_RESPONSE_BYTES = 65_536;
+const MAXIMUM_SIGNED_ENVELOPE_BYTES = 2_097_152;
+const MAXIMUM_PROVIDER_RECEIPT_AGE_MS = 300_000;
+const MAXIMUM_TIMEOUT_MS = 10_000;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,127}$/u;
+const BASE64URL_SIGNATURE = /^[A-Za-z0-9_-]{86}$/u;
+const BASE64URL_SPKI = /^[A-Za-z0-9_-]{59}$/u;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const VERCEL_OIDC = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/u;
+const moduleFetch = globalThis.fetch.bind(globalThis);
+
+export type GenericLaunchReadSignerBindingV2 = Readonly<{
+  schemaVersion: "programmable.generic-launch-read-signer-binding.v2";
+  endpoint: string;
+  audience: typeof GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2;
+  keyId: string;
+  keyEpoch: string;
+  publicKeySpkiBase64Url: string;
+  publicKeySpkiSha256: Sha256Digest;
+  providerIdentityHash: Sha256Digest;
+  credentialMode: "vercel-oidc-bearer";
+}>;
+
+export interface GenericLaunchReadSignerV2 {
+  readonly binding: GenericLaunchReadSignerBindingV2;
+  sign(input: Readonly<{
+    requestBindingHash: Sha256Digest;
+    payload: JsonValue;
+    signal?: AbortSignal;
+  }>): Promise<string>;
+}
+
+type ProviderReceiptV2 = Readonly<{
+  schemaVersion: "programmable.remote-signing-provider-receipt.v2";
+  outcome: "completed";
+  audience: typeof GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2;
+  keyId: string;
+  keyEpoch: string;
+  algorithm: "Ed25519";
+  providerIdentityHash: Sha256Digest;
+  idempotencyKey: Sha256Digest;
+  messageSha256: Sha256Digest;
+  requestDigest: Sha256Digest;
+  signature: string;
+  observedAt: string;
+  expiresAt: string;
+}>;
+
+export function parseGenericLaunchReadSignerBindingV2(
+  value: unknown,
+): GenericLaunchReadSignerBindingV2 {
+  const parsed = record(value, "Generic launch V2 signer binding");
+  exactKeys(parsed, [
+    "audience", "credentialMode", "endpoint", "keyEpoch", "keyId",
+    "providerIdentityHash", "publicKeySpkiBase64Url", "publicKeySpkiSha256",
+    "schemaVersion",
+  ], "Generic launch V2 signer binding");
+  if (
+    parsed.schemaVersion !== "programmable.generic-launch-read-signer-binding.v2"
+    || parsed.audience !== GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2
+    || parsed.credentialMode !== "vercel-oidc-bearer"
+  ) throw new TypeError("Generic launch V2 signer binding schema is invalid");
+  const endpoint = endpointUrl(parsed.endpoint);
+  const keyId = safeId(parsed.keyId, "Generic launch V2 signer key id");
+  const keyEpoch = safeId(parsed.keyEpoch, "Generic launch V2 signer key epoch");
+  const publicKeySpkiBase64Url = spkiBase64Url(parsed.publicKeySpkiBase64Url);
+  const spki = Buffer.from(publicKeySpkiBase64Url, "base64url");
+  publicKeyFromSpki(spki);
+  const publicKeySpkiSha256 = digest(
+    parsed.publicKeySpkiSha256,
+    "Generic launch V2 signer public key hash",
+  );
+  if (rawDigest(spki) !== publicKeySpkiSha256) {
+    throw new TypeError("Generic launch V2 signer public key binding is invalid");
+  }
+  const providerIdentityHash = canonicalSha256(
+    "programmable.remote-ed25519-provider-identity.v2",
+    Object.freeze({
+      schemaVersion: "programmable.remote-ed25519-provider-identity.v2" as const,
+      endpoint,
+      audience: GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2,
+      keyId,
+      keyEpoch,
+      publicKeySpkiSha256,
+    }),
+  );
+  if (digest(
+    parsed.providerIdentityHash,
+    "Generic launch V2 signer provider identity",
+  ) !== providerIdentityHash) {
+    throw new TypeError("Generic launch V2 signer provider identity is invalid");
+  }
+  return Object.freeze({
+    schemaVersion: "programmable.generic-launch-read-signer-binding.v2" as const,
+    endpoint,
+    audience: GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2,
+    keyId,
+    keyEpoch,
+    publicKeySpkiBase64Url,
+    publicKeySpkiSha256,
+    providerIdentityHash,
+    credentialMode: "vercel-oidc-bearer" as const,
+  });
+}
+
+export function productionGenericLaunchReadSignerBindingV2(
+  activeReadBinding: GenericLaunchReadBindingV2,
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): GenericLaunchReadSignerBindingV2 {
+  const source = environment[GENERIC_LAUNCH_READ_SIGNER_BINDING_ENV_V2]?.trim();
+  if (!source) throw new TypeError("Generic launch V2 signer is not configured");
+  if (Buffer.byteLength(source, "utf8") > MAXIMUM_CONFIGURATION_BYTES) {
+    throw new TypeError("Generic launch V2 signer configuration is too large");
+  }
+  const signerBinding = parseGenericLaunchReadSignerBindingV2(
+    parseStrictJson(source, {
+      maximumBytes: MAXIMUM_CONFIGURATION_BYTES,
+      maximumDepth: 4,
+    }),
+  );
+  assertActiveVerifierMatch(activeReadBinding, signerBinding);
+  return signerBinding;
+}
+
+export async function createProductionGenericLaunchReadSignerV2(
+  options: Readonly<{
+    activeReadBinding: GenericLaunchReadBindingV2;
+    environment?: Readonly<Record<string, string | undefined>>;
+    credentialProvider?: () => Promise<string>;
+    fetch?: typeof fetch;
+    now?: () => Date;
+    timeoutMs?: number;
+  }>,
+): Promise<GenericLaunchReadSignerV2> {
+  const binding = productionGenericLaunchReadSignerBindingV2(
+    options.activeReadBinding,
+    options.environment ?? process.env,
+  );
+  const credential = (await (
+    options.credentialProvider ?? getVercelOidcToken
+  )()).trim();
+  if (
+    credential.length < 20
+    || credential.length > 131_072
+    || !VERCEL_OIDC.test(credential)
+  ) throw new TypeError("Vercel workload identity is unavailable");
+  return createRemoteGenericLaunchReadSignerV2({
+    binding,
+    activeReadBinding: options.activeReadBinding,
+    credential,
+    fetch: options.fetch ?? moduleFetch,
+    ...(options.now === undefined ? {} : { now: options.now }),
+    ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
+  });
+}
+
+export function createRemoteGenericLaunchReadSignerV2(input: Readonly<{
+  binding: GenericLaunchReadSignerBindingV2;
+  activeReadBinding: GenericLaunchReadBindingV2;
+  credential: string;
+  fetch: typeof fetch;
+  now?: () => Date;
+  timeoutMs?: number;
+}>): GenericLaunchReadSignerV2 {
+  const binding = parseGenericLaunchReadSignerBindingV2(input.binding);
+  const activeReadBinding = assertActiveVerifierMatch(
+    input.activeReadBinding,
+    binding,
+  );
+  if (
+    typeof input.credential !== "string"
+    || input.credential.length < 20
+    || input.credential.length > 131_072
+    || !VERCEL_OIDC.test(input.credential)
+  ) throw new TypeError("Generic launch V2 signer credential is invalid");
+  if (typeof input.fetch !== "function") {
+    throw new TypeError("Generic launch V2 signer transport is invalid");
+  }
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(timeoutMs)
+    || timeoutMs < 500
+    || timeoutMs > MAXIMUM_TIMEOUT_MS
+  ) throw new TypeError("Generic launch V2 signer timeout is invalid");
+  const now = input.now ?? (() => new Date());
+  const fetchTransport = input.fetch;
+  const credential = input.credential;
+  const publicKey = publicKeyFromSpki(
+    Buffer.from(binding.publicKeySpkiBase64Url, "base64url"),
+  );
+
+  return Object.freeze({
+    binding,
+    async sign(
+      signingInput: Parameters<GenericLaunchReadSignerV2["sign"]>[0],
+    ): Promise<string> {
+      signingInput.signal?.throwIfAborted();
+      const requestBindingHash = digest(
+        signingInput.requestBindingHash,
+        "Generic launch V2 signing request binding",
+      );
+      const canonicalMessage = canonicalizeJson(Object.freeze({
+        schemaVersion:
+          "programmable.generic-launch-read-signature-message.v2" as const,
+        activationBindingHash: activeReadBinding.activationBindingHash,
+        readModelBindingHash: activeReadBinding.readModelBindingHash,
+        requestBindingHash,
+        payload: signingInput.payload,
+      }));
+      if (Buffer.byteLength(canonicalMessage, "utf8") > MAXIMUM_SIGNED_ENVELOPE_BYTES) {
+        throw new TypeError("Generic launch V2 signing message is too large");
+      }
+      const messageSnapshot = parseStrictJson(canonicalMessage, {
+        maximumBytes: MAXIMUM_SIGNED_ENVELOPE_BYTES,
+        maximumDepth: 128,
+      });
+      const snapshot = record(messageSnapshot, "Generic launch V2 signing message");
+      exactKeys(snapshot, [
+        "activationBindingHash", "payload", "readModelBindingHash",
+        "requestBindingHash", "schemaVersion",
+      ], "Generic launch V2 signing message");
+      const message = Buffer.from(canonicalMessage, "utf8");
+      const messageSha256 = rawDigest(message);
+      const idempotencyKey = canonicalSha256(
+        "programmable.generic-launch-read-signing-idempotency.v2",
+        Object.freeze({
+          schemaVersion:
+            "programmable.generic-launch-read-signing-idempotency.v2" as const,
+          activationBindingHash: activeReadBinding.activationBindingHash,
+          readModelBindingHash: activeReadBinding.readModelBindingHash,
+          requestBindingHash,
+          messageSha256,
+        }),
+      );
+      const unsignedRequest = Object.freeze({
+        schemaVersion: "programmable.remote-signing-request.v2" as const,
+        audience: binding.audience,
+        keyId: binding.keyId,
+        keyEpoch: binding.keyEpoch,
+        algorithm: "Ed25519" as const,
+        providerIdentityHash: binding.providerIdentityHash,
+        idempotencyKey,
+        messageEncoding: "base64url" as const,
+        message: message.toString("base64url"),
+        messageSha256,
+      });
+      const requestDigest = canonicalSha256(
+        "programmable.remote-signing-request.v2",
+        unsignedRequest,
+      );
+      const controller = new AbortController();
+      const timeout = setTimeout(
+        () => controller.abort(
+          new Error("Generic launch V2 signer deadline exceeded"),
+        ),
+        timeoutMs,
+      );
+      const signal = signingInput.signal === undefined
+        ? controller.signal
+        : AbortSignal.any([controller.signal, signingInput.signal]);
+      let response: Response;
+      try {
+        response = await fetchTransport(new URL(binding.endpoint), {
+          method: "POST",
+          redirect: "error",
+          cache: "no-store",
+          credentials: "omit",
+          signal,
+          headers: {
+            accept: "application/json",
+            authorization: `Bearer ${credential}`,
+            "content-type": "application/json",
+            "idempotency-key": idempotencyKey,
+            "x-programmable-operation": "sign-v2",
+            "x-programmable-request-digest": requestDigest,
+          },
+          body: canonicalizeJson({ ...unsignedRequest, requestDigest }),
+        });
+      } catch (error) {
+        if (controller.signal.aborted && !signingInput.signal?.aborted) {
+          throw new TypeError("Generic launch V2 signer deadline exceeded");
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
+      if (response.redirected || response.status !== 200) {
+        throw new TypeError("Generic launch V2 signer rejected the request");
+      }
+      const contentType = response.headers.get("content-type")
+        ?.split(";", 1)[0]?.trim().toLowerCase();
+      if (contentType !== "application/json") {
+        throw new TypeError("Generic launch V2 signer response is invalid");
+      }
+      const authenticated = parseAuthenticatedResponse(
+        await readBoundedResponse(response, MAXIMUM_RESPONSE_BYTES),
+      );
+      const providerReceipt = authenticated.providerReceipt;
+      if (
+        providerReceipt.audience !== binding.audience
+        || providerReceipt.keyId !== binding.keyId
+        || providerReceipt.keyEpoch !== binding.keyEpoch
+        || providerReceipt.providerIdentityHash !== binding.providerIdentityHash
+        || providerReceipt.idempotencyKey !== idempotencyKey
+        || providerReceipt.messageSha256 !== messageSha256
+        || providerReceipt.requestDigest !== requestDigest
+      ) throw new TypeError("Generic launch V2 signer response binding is invalid");
+      validateProviderWindow(providerReceipt, now());
+      const providerReceiptBytes = Buffer.from(
+        canonicalizeJson(providerReceipt),
+        "utf8",
+      );
+      if (rawDigest(providerReceiptBytes) !== authenticated.providerReceiptDigest) {
+        throw new TypeError("Generic launch V2 signer evidence hash is invalid");
+      }
+      const signature = signatureBytes(providerReceipt.signature);
+      const providerReceiptSignature = signatureBytes(
+        authenticated.providerReceiptSignature,
+      );
+      if (
+        !verifySignature(null, message, publicKey, signature)
+        || !verifySignature(
+          null,
+          providerReceiptBytes,
+          publicKey,
+          providerReceiptSignature,
+        )
+      ) throw new TypeError("Generic launch V2 signer signature is invalid");
+      const envelope = canonicalizeJson(Object.freeze({
+        schemaVersion: "programmable.signed-generic-launch-read-envelope.v2" as const,
+        activationBindingHash: activeReadBinding.activationBindingHash,
+        readModelBindingHash: activeReadBinding.readModelBindingHash,
+        requestBindingHash,
+        payload: snapshot.payload as JsonValue,
+        signatureBase64Url: providerReceipt.signature,
+      }));
+      if (Buffer.byteLength(envelope, "utf8") > MAXIMUM_SIGNED_ENVELOPE_BYTES) {
+        throw new TypeError("Generic launch V2 signed envelope is too large");
+      }
+      return envelope;
+    },
+  });
+}
+
+function assertActiveVerifierMatch(
+  rawReadBinding: GenericLaunchReadBindingV2,
+  signerBinding: GenericLaunchReadSignerBindingV2,
+): GenericLaunchReadBindingV2 {
+  const readBinding = parseGenericLaunchReadBindingV2(rawReadBinding);
+  const verifier = readBinding.readModelVerifier;
+  const verifierSpki = Buffer.from(verifier.publicKeySpkiBase64Url, "base64url");
+  if (
+    verifierSpki.toString("base64url") !== verifier.publicKeySpkiBase64Url
+    || rawDigest(verifierSpki) !== verifier.publicKeySha256
+    || verifier.publicKeySpkiBase64Url !== signerBinding.publicKeySpkiBase64Url
+    || verifier.publicKeySha256 !== signerBinding.publicKeySpkiSha256
+  ) throw new TypeError(
+    "Generic launch V2 signer does not match the active Generic V2 verifier",
+  );
+  publicKeyFromSpki(verifierSpki);
+  return readBinding;
+}
+
+function parseAuthenticatedResponse(bytes: Uint8Array): Readonly<{
+  providerReceipt: ProviderReceiptV2;
+  providerReceiptDigest: Sha256Digest;
+  providerReceiptSignature: string;
+}> {
+  const parsed = record(parseStrictJson(Buffer.from(bytes).toString("utf8"), {
+    maximumBytes: MAXIMUM_RESPONSE_BYTES,
+    maximumDepth: 8,
+  }), "Generic launch V2 signer response");
+  exactKeys(parsed, [
+    "providerReceipt", "providerReceiptDigest", "providerReceiptSignature",
+    "schemaVersion",
+  ], "Generic launch V2 signer response");
+  if (parsed.schemaVersion
+      !== "programmable.remote-signing-authenticated-response.v2") {
+    throw new TypeError("Generic launch V2 signer response schema is invalid");
+  }
+  const receipt = record(
+    parsed.providerReceipt,
+    "Generic launch V2 signer provider receipt",
+  );
+  exactKeys(receipt, [
+    "algorithm", "audience", "expiresAt", "idempotencyKey", "keyEpoch",
+    "keyId", "messageSha256", "observedAt", "outcome", "providerIdentityHash",
+    "requestDigest", "schemaVersion", "signature",
+  ], "Generic launch V2 signer provider receipt");
+  if (
+    receipt.schemaVersion !== "programmable.remote-signing-provider-receipt.v2"
+    || receipt.outcome !== "completed"
+    || receipt.audience !== GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2
+    || receipt.algorithm !== "Ed25519"
+  ) throw new TypeError("Generic launch V2 signer provider receipt is invalid");
+  return Object.freeze({
+    providerReceipt: Object.freeze({
+      schemaVersion: receipt.schemaVersion,
+      outcome: receipt.outcome,
+      audience: receipt.audience,
+      keyId: safeId(receipt.keyId, "Generic launch V2 signer receipt key id"),
+      keyEpoch: safeId(
+        receipt.keyEpoch,
+        "Generic launch V2 signer receipt key epoch",
+      ),
+      algorithm: receipt.algorithm,
+      providerIdentityHash: digest(
+        receipt.providerIdentityHash,
+        "Generic launch V2 signer receipt provider identity",
+      ),
+      idempotencyKey: digest(
+        receipt.idempotencyKey,
+        "Generic launch V2 signer idempotency key",
+      ),
+      messageSha256: digest(
+        receipt.messageSha256,
+        "Generic launch V2 signer message hash",
+      ),
+      requestDigest: digest(
+        receipt.requestDigest,
+        "Generic launch V2 signer request hash",
+      ),
+      signature: canonicalSignature(receipt.signature),
+      observedAt: canonicalTimestamp(receipt.observedAt),
+      expiresAt: canonicalTimestamp(receipt.expiresAt),
+    }),
+    providerReceiptDigest: digest(
+      parsed.providerReceiptDigest,
+      "Generic launch V2 signer provider receipt hash",
+    ),
+    providerReceiptSignature: canonicalSignature(
+      parsed.providerReceiptSignature,
+    ),
+  });
+}
+
+async function readBoundedResponse(
+  response: Response,
+  maximumBytes: number,
+): Promise<Uint8Array> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(contentLength)) {
+      throw new TypeError("Generic launch V2 signer response length is invalid");
+    }
+    const declared = Number(contentLength);
+    if (!Number.isSafeInteger(declared) || declared > maximumBytes) {
+      throw new TypeError("Generic launch V2 signer response is too large");
+    }
+  }
+  if (response.body === null) {
+    throw new TypeError("Generic launch V2 signer response is empty");
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maximumBytes) {
+        throw new TypeError("Generic launch V2 signer response is too large");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+function validateProviderWindow(receipt: ProviderReceiptV2, now: Date): void {
+  const observedMs = Date.parse(receipt.observedAt);
+  const expiresMs = Date.parse(receipt.expiresAt);
+  const nowMs = now.getTime();
+  if (
+    !Number.isFinite(nowMs)
+    || observedMs > nowMs
+    || nowMs >= expiresMs
+    || expiresMs - observedMs > MAXIMUM_PROVIDER_RECEIPT_AGE_MS
+  ) throw new TypeError("Generic launch V2 signer provider window is invalid");
+}
+
+function publicKeyFromSpki(spki: Uint8Array): KeyObject {
+  const publicKey = createPublicKey({ key: spki, format: "der", type: "spki" });
+  if (publicKey.asymmetricKeyType !== "ed25519") {
+    throw new TypeError("Generic launch V2 signer public key is not Ed25519");
+  }
+  const normalized = publicKey.export({ format: "der", type: "spki" });
+  if (!Buffer.from(normalized).equals(Buffer.from(spki))) {
+    throw new TypeError("Generic launch V2 signer SPKI is not canonical");
+  }
+  return publicKey;
+}
+
+function endpointUrl(value: unknown): string {
+  if (typeof value !== "string" || value.length > 2_048) {
+    throw new TypeError("Generic launch V2 signer endpoint is invalid");
+  }
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:"
+    || url.username !== ""
+    || url.password !== ""
+    || url.port !== ""
+    || url.search !== ""
+    || url.hash !== ""
+    || url.pathname === "/"
+  ) throw new TypeError("Generic launch V2 signer endpoint is invalid");
+  return url.toString();
+}
+
+function spkiBase64Url(value: unknown): string {
+  if (typeof value !== "string" || !BASE64URL_SPKI.test(value)) {
+    throw new TypeError("Generic launch V2 signer SPKI is invalid");
+  }
+  const bytes = Buffer.from(value, "base64url");
+  if (bytes.byteLength !== 44 || bytes.toString("base64url") !== value) {
+    throw new TypeError("Generic launch V2 signer SPKI is invalid");
+  }
+  return value;
+}
+
+function safeId(value: unknown, label: string): string {
+  if (typeof value !== "string" || !SAFE_ID.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function digest(value: unknown, label: string): Sha256Digest {
+  if (typeof value !== "string" || !DIGEST.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value as Sha256Digest;
+}
+
+function canonicalSignature(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new TypeError("Generic launch V2 signer signature is invalid");
+  }
+  signatureBytes(value);
+  return value;
+}
+
+function signatureBytes(value: string): Buffer {
+  if (!BASE64URL_SIGNATURE.test(value)) {
+    throw new TypeError("Generic launch V2 signer signature is invalid");
+  }
+  const bytes = Buffer.from(value, "base64url");
+  if (bytes.byteLength !== 64 || bytes.toString("base64url") !== value) {
+    throw new TypeError("Generic launch V2 signer signature is invalid");
+  }
+  return bytes;
+}
+
+function canonicalTimestamp(value: unknown): string {
+  if (
+    typeof value !== "string"
+    || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || new Date(value).toISOString() !== value
+  ) throw new TypeError("Generic launch V2 signer timestamp is invalid");
+  return value;
+}
+
+function rawDigest(bytes: Uint8Array): Sha256Digest {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function record(
+  value: unknown,
+  label: string,
+): Readonly<Record<string, unknown>> {
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    throw new TypeError(`${label} is invalid`);
+  }
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError(`${label} must be a plain object`);
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (typeof key !== "string") {
+      throw new TypeError(`${label} contains symbols`);
+    }
+    const descriptor = descriptors[key];
+    if (
+      descriptor === undefined
+      || descriptor.get !== undefined
+      || descriptor.set !== undefined
+      || !descriptor.enumerable
+      || !("value" in descriptor)
+    ) throw new TypeError(`${label} contains non-data properties`);
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function exactKeys(
+  value: Readonly<Record<string, unknown>>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (
+    actual.length !== wanted.length
+    || actual.some((key, index) => key !== wanted[index])
+  ) throw new TypeError(`${label} has unknown or missing fields`);
+}

--- a/lib/server/custom-launch/generic-launch-read-signer-v2.ts
+++ b/lib/server/custom-launch/generic-launch-read-signer-v2.ts
@@ -289,9 +289,8 @@ export function createRemoteGenericLaunchReadSignerV2(input: Readonly<{
       const signal = signingInput.signal === undefined
         ? controller.signal
         : AbortSignal.any([controller.signal, signingInput.signal]);
-      let response: Response;
       try {
-        response = await fetchTransport(new URL(binding.endpoint), {
+        const response = await fetchTransport(new URL(binding.endpoint), {
           method: "POST",
           redirect: "error",
           cache: "no-store",
@@ -307,25 +306,17 @@ export function createRemoteGenericLaunchReadSignerV2(input: Readonly<{
           },
           body: canonicalizeJson({ ...unsignedRequest, requestDigest }),
         });
-      } catch (error) {
-        if (controller.signal.aborted && !signingInput.signal?.aborted) {
-          throw new TypeError("Generic launch V2 signer deadline exceeded");
+        if (response.redirected || response.status !== 200) {
+          throw new TypeError("Generic launch V2 signer rejected the request");
         }
-        throw error;
-      } finally {
-        clearTimeout(timeout);
-      }
-      if (response.redirected || response.status !== 200) {
-        throw new TypeError("Generic launch V2 signer rejected the request");
-      }
-      const contentType = response.headers.get("content-type")
-        ?.split(";", 1)[0]?.trim().toLowerCase();
-      if (contentType !== "application/json") {
-        throw new TypeError("Generic launch V2 signer response is invalid");
-      }
-      const authenticated = parseAuthenticatedResponse(
-        await readBoundedResponse(response, MAXIMUM_RESPONSE_BYTES),
-      );
+        const contentType = response.headers.get("content-type")
+          ?.split(";", 1)[0]?.trim().toLowerCase();
+        if (contentType !== "application/json") {
+          throw new TypeError("Generic launch V2 signer response is invalid");
+        }
+        const authenticated = parseAuthenticatedResponse(
+          await readBoundedResponse(response, MAXIMUM_RESPONSE_BYTES, signal),
+        );
       const providerReceipt = authenticated.providerReceipt;
       if (
         providerReceipt.audience !== binding.audience
@@ -369,6 +360,14 @@ export function createRemoteGenericLaunchReadSignerV2(input: Readonly<{
         throw new TypeError("Generic launch V2 signed envelope is too large");
       }
       return envelope;
+      } catch (error) {
+        if (controller.signal.aborted && !signingInput.signal?.aborted) {
+          throw new TypeError("Generic launch V2 signer deadline exceeded");
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
     },
   });
 }
@@ -468,6 +467,7 @@ function parseAuthenticatedResponse(bytes: Uint8Array): Readonly<{
 async function readBoundedResponse(
   response: Response,
   maximumBytes: number,
+  signal: AbortSignal,
 ): Promise<Uint8Array> {
   const contentLength = response.headers.get("content-length");
   if (contentLength !== null) {
@@ -487,7 +487,7 @@ async function readBoundedResponse(
   let total = 0;
   try {
     for (;;) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithAbort(reader, signal);
       if (done) break;
       total += value.byteLength;
       if (total > maximumBytes) {
@@ -496,6 +496,7 @@ async function readBoundedResponse(
       chunks.push(value);
     }
   } finally {
+    if (signal.aborted) await reader.cancel(signal.reason).catch(() => undefined);
     reader.releaseLock();
   }
   const result = new Uint8Array(total);
@@ -505,6 +506,20 @@ async function readBoundedResponse(
     offset += chunk.byteLength;
   }
   return result;
+}
+
+async function readWithAbort(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal: AbortSignal,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  signal.throwIfAborted();
+  return await new Promise((resolve, reject) => {
+    const aborted = () => reject(signal.reason);
+    signal.addEventListener("abort", aborted, { once: true });
+    void reader.read().then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", aborted);
+    });
+  });
 }
 
 function validateProviderWindow(receipt: ProviderReceiptV2, now: Date): void {

--- a/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
+++ b/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
@@ -13,6 +13,8 @@ import { mainnet } from "viem/chains";
 
 import registryAbiArtifact from
   "@/docs/security/abi/ProgrammableCustomRegistryV2.json";
+import { CUSTOM_REGISTRY_V2_EVENT_ABI } from
+  "@/lib/data-pipeline/custom-registry-v2-event-manifest";
 import { canonicalizeJson, type JsonValue } from
   "../projection-target/canonical-json";
 import type {
@@ -178,6 +180,8 @@ async function observeProvider(
       !== input.approval.primaryFinality.transactionHash
     || primaryReceipt.blockHash.toLowerCase() !== input.approval.primaryFinality.blockHash
     || primaryReceipt.blockNumber.toString() !== input.approval.primaryFinality.blockNumber
+    || primaryReceipt.contractAddress?.toLowerCase()
+      !== input.approval.descriptor.primaryContract
     || primaryBlock.hash?.toLowerCase() !== input.approval.primaryFinality.blockHash
     || primaryCode === undefined
     || keccak256(primaryCode) !== input.approval.descriptor.primaryRuntimeCodeHash) {
@@ -290,7 +294,10 @@ function decodeLifecycleLogs(
     let decoded: Readonly<{ eventName: string; args: unknown }>;
     try {
       decoded = decodeEventLog({
-        abi: ABI, data: log.data, topics: log.topics, strict: true,
+        abi: CUSTOM_REGISTRY_V2_EVENT_ABI,
+        data: log.data,
+        topics: log.topics,
+        strict: true,
       }) as Readonly<{ eventName: string; args: unknown }>;
     } catch {
       continue;

--- a/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
+++ b/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
@@ -2,10 +2,14 @@ import "server-only";
 
 import {
   createPublicClient,
+  BlockNotFoundError,
   decodeEventLog,
   http,
   keccak256,
+  TransactionNotFoundError,
+  TransactionReceiptNotFoundError,
   type Abi,
+  type AbiEvent,
   type Hex,
   type PublicClient,
 } from "viem";
@@ -17,6 +21,7 @@ import { CUSTOM_REGISTRY_V2_EVENT_ABI } from
   "@/lib/data-pipeline/custom-registry-v2-event-manifest";
 import { canonicalizeJson, type JsonValue } from
   "../projection-target/canonical-json";
+import { canonicalSha256 } from "../projection-target/hashing";
 import type {
   VerifiedApprovalArtifactV3,
   VerifiedRegistryLifecycleV2,
@@ -24,6 +29,7 @@ import type {
 
 const ABI = registryAbiArtifact.abi as Abi;
 const ZERO_HASH32 = `0x${"00".repeat(32)}` as const;
+const MAXIMUM_LOG_WINDOW_BLOCKS = 5_000n;
 
 export interface GenericLaunchRegistryReleaseV2 {
   readonly registryAddress: `0x${string}`;
@@ -156,9 +162,8 @@ async function observeProvider(
     throw new TypeError("Approval artifact is not bound to the Registry release");
   }
   const fromBlock = BigInt(input.release.deploymentBlock);
-  const [logs, approvalStateRaw, launchStateRaw, descriptorRaw, primaryTx,
+  const [approvalStateRaw, launchStateRaw, descriptorRaw, primaryTx,
     primaryReceipt, primaryBlock, primaryCode] = await Promise.all([
-    client.getLogs({ address, fromBlock, toBlock: input.commonHead }),
     client.readContract({
       address, abi: ABI, functionName: "approvalState",
       args: [input.approval.approvalId], blockNumber: input.commonHead,
@@ -171,21 +176,49 @@ async function observeProvider(
       address, abi: ABI, functionName: "launchDescriptor",
       args: [input.approval.launchId], blockNumber: input.commonHead,
     }),
-    client.getTransaction({ hash: input.approval.primaryFinality.transactionHash }),
-    client.getTransactionReceipt({
+    missingOnReorg(client.getTransaction({
       hash: input.approval.primaryFinality.transactionHash,
-    }),
-    client.getBlock({
+    })),
+    missingOnReorg(client.getTransactionReceipt({
+      hash: input.approval.primaryFinality.transactionHash,
+    })),
+    missingOnReorg(client.getBlock({
       blockNumber: BigInt(input.approval.primaryFinality.blockNumber),
       includeTransactions: false,
-    }),
+    })),
     client.getBytecode({
       address: input.approval.descriptor.primaryContract,
       blockNumber: input.commonHead,
     }),
   ]);
+  const logs = await readBoundedLifecycleLogs(
+    client,
+    address,
+    BigInt(input.approval.primaryFinality.blockNumber) > fromBlock
+      ? BigInt(input.approval.primaryFinality.blockNumber)
+      : fromBlock,
+    input.commonHead,
+    input.approval,
+    input.signal,
+  );
   input.signal.throwIfAborted();
-  if (primaryReceipt.status !== "success"
+  const approvalState = approvalStateEvidence(approvalStateRaw);
+  const launchState = launchStateEvidence(launchStateRaw);
+  const launchDescriptor = descriptorEvidence(descriptorRaw);
+  const events = decodeLifecycleLogs(logs, input.approval);
+  const primaryObservation = Object.freeze({
+    transactionHash: primaryTx?.hash.toLowerCase() ?? null,
+    sender: primaryTx?.from.toLowerCase() ?? null,
+    receiptTransactionHash: primaryReceipt?.transactionHash.toLowerCase() ?? null,
+    receiptBlockHash: primaryReceipt?.blockHash.toLowerCase() ?? null,
+    receiptBlockNumber: primaryReceipt?.blockNumber.toString() ?? null,
+    receiptContractAddress: primaryReceipt?.contractAddress?.toLowerCase() ?? null,
+    receiptStatus: primaryReceipt?.status ?? null,
+    blockHash: primaryBlock?.hash?.toLowerCase() ?? null,
+    runtimeCodeKeccak256: primaryCode === undefined ? null : keccak256(primaryCode),
+  });
+  if (primaryReceipt === null || primaryTx === null || primaryBlock === null
+    || primaryReceipt.status !== "success"
     || primaryTx.from.toLowerCase() !== input.approval.descriptor.launchWallet
     || primaryReceipt.transactionHash.toLowerCase()
       !== input.approval.primaryFinality.transactionHash
@@ -196,14 +229,14 @@ async function observeProvider(
     || primaryBlock.hash?.toLowerCase() !== input.approval.primaryFinality.blockHash
     || primaryCode === undefined
     || keccak256(primaryCode) !== input.approval.descriptor.primaryRuntimeCodeHash) {
-    throw new TypeError("Primary launch receipt/runtime evidence is invalid");
+    return invalidatedObservation(input, {
+      approvalState,
+      launchState,
+      launchDescriptor,
+      eventArguments: events.arguments,
+      primaryObservation,
+    });
   }
-  const events = decodeLifecycleLogs(logs, input.approval);
-  const approvalState = approvalStateEvidence(approvalStateRaw);
-  const launchState = launchStateEvidence(launchStateRaw);
-  const launchDescriptor = descriptorEvidence(descriptorRaw);
-  assertApprovalState(approvalState, input.approval);
-  assertDescriptor(launchDescriptor, input.approval);
   const primaryLaunch = Object.freeze({
     transactionHash: primaryReceipt.transactionHash.toLowerCase() as `0x${string}`,
     sender: primaryTx.from.toLowerCase() as `0x${string}`,
@@ -213,6 +246,8 @@ async function observeProvider(
     status: "success" as const,
   });
   if (events.revocation !== null || launchState.status === "3") {
+    assertApprovalState(approvalState, input.approval);
+    assertDescriptor(launchDescriptor, input.approval);
     if (events.revocation === null || launchState.status !== "3"
       || launchState.revokedAtBlock === "0"
       || launchState.revocationEvidenceHash === ZERO_HASH32
@@ -241,8 +276,16 @@ async function observeProvider(
     || events.authorization === null || events.registration === null
     || events.descriptor === null || events.descriptorEvidence === null
     || events.finalization === null) {
-    throw new TypeError("Registry lifecycle is not finalized and non-revoked");
+    return invalidatedObservation(input, {
+      approvalState,
+      launchState,
+      launchDescriptor,
+      eventArguments: events.arguments,
+      primaryObservation,
+    });
   }
+  assertApprovalState(approvalState, input.approval);
+  assertDescriptor(launchDescriptor, input.approval);
   assertFinalizedEventJoins(events, input.approval, launchState, approvalState);
   const finalizedLog = events.finalization!;
   const finalityArgs = finalizedLog.args;
@@ -302,6 +345,122 @@ async function observeProvider(
       eventArguments: events.arguments,
     }),
   });
+}
+
+function invalidatedObservation(
+  input: Readonly<{
+    commonHead: bigint;
+    commonHeadHash: `0x${string}`;
+  }>,
+  bindingEvidence: ProviderObservationV2["bindingEvidence"] & Readonly<{
+    primaryObservation?: unknown;
+  }>,
+): ProviderObservationV2 {
+  const invalidationEvidenceHash = canonicalSha256(
+    "programmable.generic-launch-registry-invalidation-evidence.v2",
+    bindingEvidence as unknown as JsonValue,
+  );
+  const launchState = bindingEvidence.launchState as Readonly<{
+    status?: unknown;
+  }>;
+  const registryStatus = typeof launchState.status === "string"
+    ? launchState.status
+    : "0";
+  return Object.freeze({
+    lifecycle: Object.freeze({
+      status: "invalidated" as const,
+      latestCommonHead: input.commonHead.toString(),
+      latestCommonHeadHash: input.commonHeadHash,
+      registryStatus,
+      invalidationEvidenceHash,
+    }),
+    bindingEvidence: Object.freeze(bindingEvidence),
+  });
+}
+
+async function missingOnReorg<T>(promise: Promise<T>): Promise<T | null> {
+  try {
+    return await promise;
+  } catch (error) {
+    if (error instanceof TransactionNotFoundError
+      || error instanceof TransactionReceiptNotFoundError
+      || error instanceof BlockNotFoundError) return null;
+    throw error;
+  }
+}
+
+async function readBoundedLifecycleLogs(
+  client: PublicClient,
+  address: `0x${string}`,
+  fromBlock: bigint,
+  toBlock: bigint,
+  approval: VerifiedApprovalArtifactV3,
+  signal: AbortSignal,
+) {
+  if (fromBlock > toBlock) {
+    throw new TypeError("Registry lifecycle log range is invalid");
+  }
+  const logs: Awaited<ReturnType<PublicClient["getLogs"]>> = [];
+  for (let start = fromBlock; start <= toBlock;) {
+    signal.throwIfAborted();
+    const end = start + MAXIMUM_LOG_WINDOW_BLOCKS - 1n < toBlock
+      ? start + MAXIMUM_LOG_WINDOW_BLOCKS - 1n
+      : toBlock;
+    const filters = [
+      ["CustomLaunchApprovalAuthorizedV2", {
+        approvalId: approval.approvalId,
+        descriptorHash: approval.descriptorHash,
+      }],
+      ["CustomLaunchRegisteredV2", {
+        launchId: approval.launchId,
+        descriptorHash: approval.descriptorHash,
+        primaryContract: approval.descriptor.primaryContract,
+      }],
+      ["CustomLaunchDescriptorCommittedV2", {
+        launchId: approval.launchId,
+        descriptorHash: approval.descriptorHash,
+        primaryContract: approval.descriptor.primaryContract,
+      }],
+      ["CustomLaunchDescriptorEvidenceCommittedV2", {
+        launchId: approval.launchId,
+        sourceArtifactHash: approval.descriptor.sourceArtifactHash,
+        configurationHash: approval.descriptor.configurationHash,
+      }],
+      ["CustomLaunchFinalizedV2", {
+        launchId: approval.launchId,
+        descriptorHash: approval.descriptorHash,
+      }],
+      ["CustomLaunchRevokedV2", {
+        launchId: approval.launchId,
+        descriptorHash: approval.descriptorHash,
+      }],
+    ] as const;
+    for (const [name, args] of filters) {
+      const event = registryEvent(name);
+      const window = await client.getLogs({
+        address,
+        event,
+        args,
+        fromBlock: start,
+        toBlock: end,
+        strict: true,
+      });
+      if (window.length > 1) {
+        throw new TypeError(`Registry ${name} evidence exceeds its bound`);
+      }
+      logs.push(...window);
+    }
+    start = end + 1n;
+  }
+  signal.throwIfAborted();
+  return logs;
+}
+
+function registryEvent(name: string): AbiEvent {
+  const event = CUSTOM_REGISTRY_V2_EVENT_ABI.find((candidate) =>
+    candidate.type === "event" && candidate.name === name);
+  if (event === undefined) throw new TypeError("Registry event ABI is unavailable");
+  return event as AbiEvent;
 }
 
 type DecodedLifecycleLog = Readonly<{

--- a/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
+++ b/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
@@ -31,7 +31,8 @@ import type {
 const ABI = registryAbiArtifact.abi as Abi;
 const ZERO_HASH32 = `0x${"00".repeat(32)}` as const;
 const MAXIMUM_LOG_WINDOW_BLOCKS = 5_000n;
-const MAXIMUM_INITIAL_LOG_BLOCKS = 250_000n;
+const MAXIMUM_INITIAL_LOG_BLOCKS = 20_000n;
+const MAXIMUM_CONCURRENT_LOG_REQUESTS = 24;
 
 export interface GenericLaunchRegistryReleaseV2 {
   readonly registryAddress: `0x${string}`;
@@ -567,8 +568,11 @@ async function readBoundedLifecycleLogs(
   if (!incremental && toBlock - fromBlock + 1n > MAXIMUM_INITIAL_LOG_BLOCKS) {
     throw new TypeError("Registry initial lifecycle evidence exceeds its bound");
   }
+  const requests: Array<() => Promise<Awaited<ReturnType<PublicClient["getLogs"]>>>>
+    = [];
   for (let start = fromBlock; start <= toBlock;) {
     signal.throwIfAborted();
+    const windowStart = start;
     const end = start + MAXIMUM_LOG_WINDOW_BLOCKS - 1n < toBlock
       ? start + MAXIMUM_LOG_WINDOW_BLOCKS - 1n
       : toBlock;
@@ -608,20 +612,31 @@ async function readBoundedLifecycleLogs(
     ]) as readonly (readonly [string, Readonly<Record<string, `0x${string}`>>])[];
     for (const [name, args] of filters) {
       const event = registryEvent(name);
-      const window = await client.getLogs({
-        address,
-        event,
-        args,
-        fromBlock: start,
-        toBlock: end,
-        strict: true,
+      requests.push(async () => {
+        const window = await client.getLogs({
+          address,
+          event,
+          args,
+          fromBlock: windowStart,
+          toBlock: end,
+          strict: true,
+        });
+        if (window.length > 1) {
+          throw new TypeError(`Registry ${name} evidence exceeds its bound`);
+        }
+        return window;
       });
-      if (window.length > 1) {
-        throw new TypeError(`Registry ${name} evidence exceeds its bound`);
-      }
-      logs.push(...window);
     }
     start = end + 1n;
+  }
+  for (let offset = 0; offset < requests.length;
+    offset += MAXIMUM_CONCURRENT_LOG_REQUESTS) {
+    signal.throwIfAborted();
+    const windows = await Promise.all(requests.slice(
+      offset,
+      offset + MAXIMUM_CONCURRENT_LOG_REQUESTS,
+    ).map(async (request) => await request()));
+    windows.forEach((window) => logs.push(...window));
   }
   signal.throwIfAborted();
   return logs;

--- a/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
+++ b/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
@@ -1,0 +1,538 @@
+import "server-only";
+
+import {
+  createPublicClient,
+  decodeEventLog,
+  http,
+  keccak256,
+  type Abi,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { mainnet } from "viem/chains";
+
+import registryAbiArtifact from
+  "@/docs/security/abi/ProgrammableCustomRegistryV2.json";
+import { canonicalizeJson, type JsonValue } from
+  "../projection-target/canonical-json";
+import type {
+  VerifiedApprovalArtifactV3,
+  VerifiedRegistryLifecycleV2,
+} from "./generic-launch-projector-v2";
+
+const ABI = registryAbiArtifact.abi as Abi;
+const ZERO_HASH32 = `0x${"00".repeat(32)}` as const;
+
+export interface GenericLaunchRegistryReleaseV2 {
+  readonly registryAddress: `0x${string}`;
+  readonly registryRuntimeCodeKeccak256: `0x${string}`;
+  readonly registryPolicyCommitment: `0x${string}`;
+  readonly deploymentBlock: string;
+  readonly minimumFinalityBlocks: string;
+}
+
+interface ProviderObservationV2 {
+  readonly lifecycle: VerifiedRegistryLifecycleV2;
+  readonly bindingEvidence: Readonly<{
+    approvalState: unknown;
+    launchState: unknown;
+    launchDescriptor: unknown;
+    eventArguments: readonly unknown[];
+  }>;
+}
+
+interface RegistryProviderReaderV2 {
+  head(): Promise<bigint>;
+  blockHash(blockNumber: bigint): Promise<`0x${string}`>;
+  observe(input: Readonly<{
+    approval: VerifiedApprovalArtifactV3;
+    release: GenericLaunchRegistryReleaseV2;
+    commonHead: bigint;
+    commonHeadHash: `0x${string}`;
+    signal: AbortSignal;
+  }>): Promise<ProviderObservationV2>;
+}
+
+export function createDualRpcGenericLaunchRegistryReaderV2(input: Readonly<{
+  release: GenericLaunchRegistryReleaseV2;
+  rpcUrls: readonly [string, string];
+  providerFactory?: (url: string) => RegistryProviderReaderV2;
+}>): (request: Readonly<{
+  approval: VerifiedApprovalArtifactV3;
+  signal: AbortSignal;
+}>) => Promise<VerifiedRegistryLifecycleV2> {
+  validateRelease(input.release);
+  if (input.rpcUrls.length !== 2 || input.rpcUrls[0] === input.rpcUrls[1]) {
+    throw new TypeError("Generic launch Registry RPC quorum is invalid");
+  }
+  const factory = input.providerFactory ?? createViemRegistryProviderV2;
+  const providers = input.rpcUrls.map(factory) as
+    [RegistryProviderReaderV2, RegistryProviderReaderV2];
+  return async (request) => {
+    request.signal.throwIfAborted();
+    const heads = await Promise.all(providers.map((provider) => provider.head()));
+    const commonHead = heads[0] < heads[1] ? heads[0] : heads[1];
+    if (commonHead < BigInt(input.release.deploymentBlock)) {
+      throw new TypeError("Generic launch Registry common head predates deployment");
+    }
+    const hashes = await Promise.all(
+      providers.map((provider) => provider.blockHash(commonHead)),
+    );
+    if (hashes[0] !== hashes[1]) {
+      throw new TypeError("Generic launch Registry common head quorum disagrees");
+    }
+    const observations = await Promise.all(providers.map((provider) =>
+      provider.observe({
+        approval: request.approval,
+        release: input.release,
+        commonHead,
+        commonHeadHash: hashes[0],
+        signal: request.signal,
+      })));
+    if (canonicalizeJson(observations[0] as unknown as JsonValue)
+      !== canonicalizeJson(observations[1] as unknown as JsonValue)) {
+      throw new TypeError("Generic launch Registry provider evidence disagrees");
+    }
+    return observations[0].lifecycle;
+  };
+}
+
+function createViemRegistryProviderV2(url: string): RegistryProviderReaderV2 {
+  const endpoint = new URL(url);
+  if (endpoint.protocol !== "https:" || endpoint.username !== ""
+    || endpoint.password !== "" || endpoint.hash !== "") {
+    throw new TypeError("Generic launch Registry RPC endpoint is invalid");
+  }
+  const client = createPublicClient({
+    chain: mainnet,
+    transport: http(endpoint.toString(), {
+      batch: false,
+      retryCount: 0,
+      timeout: 15_000,
+    }),
+  });
+  return Object.freeze({
+    async head() { return await client.getBlockNumber(); },
+    async blockHash(blockNumber: bigint) {
+      const block = await client.getBlock({ blockNumber, includeTransactions: false });
+      if (block.hash === null) throw new TypeError("Registry block is not canonical");
+      return block.hash.toLowerCase() as `0x${string}`;
+    },
+    async observe(request: Readonly<{
+      approval: VerifiedApprovalArtifactV3;
+      release: GenericLaunchRegistryReleaseV2;
+      commonHead: bigint;
+      commonHeadHash: `0x${string}`;
+      signal: AbortSignal;
+    }>) {
+      return await observeProvider(client, request);
+    },
+  });
+}
+
+async function observeProvider(
+  client: PublicClient,
+  input: Readonly<{
+    approval: VerifiedApprovalArtifactV3;
+    release: GenericLaunchRegistryReleaseV2;
+    commonHead: bigint;
+    commonHeadHash: `0x${string}`;
+    signal: AbortSignal;
+  }>,
+): Promise<ProviderObservationV2> {
+  input.signal.throwIfAborted();
+  const address = input.release.registryAddress;
+  const fromBlock = BigInt(input.release.deploymentBlock);
+  const [logs, approvalStateRaw, launchStateRaw, descriptorRaw, primaryTx,
+    primaryReceipt, primaryBlock, primaryCode] = await Promise.all([
+    client.getLogs({ address, fromBlock, toBlock: input.commonHead }),
+    client.readContract({
+      address, abi: ABI, functionName: "approvalState",
+      args: [input.approval.approvalId], blockNumber: input.commonHead,
+    }),
+    client.readContract({
+      address, abi: ABI, functionName: "launchState",
+      args: [input.approval.launchId], blockNumber: input.commonHead,
+    }),
+    client.readContract({
+      address, abi: ABI, functionName: "launchDescriptor",
+      args: [input.approval.launchId], blockNumber: input.commonHead,
+    }),
+    client.getTransaction({ hash: input.approval.primaryFinality.transactionHash }),
+    client.getTransactionReceipt({
+      hash: input.approval.primaryFinality.transactionHash,
+    }),
+    client.getBlock({
+      blockNumber: BigInt(input.approval.primaryFinality.blockNumber),
+      includeTransactions: false,
+    }),
+    client.getBytecode({
+      address: input.approval.descriptor.primaryContract,
+      blockNumber: input.commonHead,
+    }),
+  ]);
+  input.signal.throwIfAborted();
+  if (primaryReceipt.status !== "success"
+    || primaryTx.from.toLowerCase() !== input.approval.descriptor.launchWallet
+    || primaryReceipt.transactionHash.toLowerCase()
+      !== input.approval.primaryFinality.transactionHash
+    || primaryReceipt.blockHash.toLowerCase() !== input.approval.primaryFinality.blockHash
+    || primaryReceipt.blockNumber.toString() !== input.approval.primaryFinality.blockNumber
+    || primaryBlock.hash?.toLowerCase() !== input.approval.primaryFinality.blockHash
+    || primaryCode === undefined
+    || keccak256(primaryCode) !== input.approval.descriptor.primaryRuntimeCodeHash) {
+    throw new TypeError("Primary launch receipt/runtime evidence is invalid");
+  }
+  const events = decodeLifecycleLogs(logs, input.approval);
+  const approvalState = approvalStateEvidence(approvalStateRaw);
+  const launchState = launchStateEvidence(launchStateRaw);
+  const launchDescriptor = descriptorEvidence(descriptorRaw);
+  assertApprovalState(approvalState, input.approval);
+  assertDescriptor(launchDescriptor, input.approval);
+  const primaryLaunch = Object.freeze({
+    transactionHash: primaryReceipt.transactionHash.toLowerCase() as `0x${string}`,
+    sender: primaryTx.from.toLowerCase() as `0x${string}`,
+    blockHash: primaryReceipt.blockHash.toLowerCase() as `0x${string}`,
+    blockNumber: primaryReceipt.blockNumber.toString(),
+    transactionIndex: primaryReceipt.transactionIndex.toString(),
+    status: "success" as const,
+  });
+  if (events.revocation !== null || launchState.status === "3") {
+    if (events.revocation === null || launchState.status !== "3"
+      || launchState.revokedAtBlock === "0"
+      || launchState.revocationEvidenceHash === ZERO_HASH32
+      || events.revocation.args.revocationEvidenceHash
+        !== launchState.revocationEvidenceHash
+      || events.revocation.args.revokedAtBlock !== launchState.revokedAtBlock) {
+      throw new TypeError("Registry revocation evidence is inconsistent");
+    }
+    return Object.freeze({
+      lifecycle: Object.freeze({
+        status: "revoked" as const,
+        latestCommonHead: input.commonHead.toString(),
+        latestCommonHeadHash: input.commonHeadHash,
+        revokedAtBlock: launchState.revokedAtBlock,
+        revocationEvidenceHash:
+          launchState.revocationEvidenceHash as `0x${string}`,
+      }),
+      bindingEvidence: Object.freeze({
+        approvalState, launchState, launchDescriptor,
+        eventArguments: events.arguments,
+      }),
+    });
+  }
+  if (launchState.status !== "2" || launchState.revokedAtBlock !== "0"
+    || launchState.revocationEvidenceHash !== ZERO_HASH32
+    || events.authorization === null || events.registration === null
+    || events.descriptor === null || events.descriptorEvidence === null
+    || events.finalization === null) {
+    throw new TypeError("Registry lifecycle is not finalized and non-revoked");
+  }
+  assertFinalizedEventJoins(events, input.approval, launchState, approvalState);
+  const auth = evidence(events.authorization, "CustomLaunchApprovalAuthorizedV2");
+  const registered = evidence(events.registration, "CustomLaunchRegisteredV2");
+  const descriptor = evidence(events.descriptor, "CustomLaunchDescriptorCommittedV2");
+  const descriptorEvidenceEvent = evidence(
+    events.descriptorEvidence,
+    "CustomLaunchDescriptorEvidenceCommittedV2",
+  );
+  const finalized = evidence(events.finalization, "CustomLaunchFinalizedV2");
+  assertLifecycleOrder(primaryLaunch, auth, [
+    registered, descriptor, descriptorEvidenceEvent,
+  ], finalized, input.commonHead, BigInt(input.release.minimumFinalityBlocks));
+  return Object.freeze({
+    lifecycle: Object.freeze({
+      status: "finalized" as const,
+      registryAddress: address,
+      registryRuntimeCodeKeccak256: input.release.registryRuntimeCodeKeccak256,
+      registryPolicyCommitment: input.release.registryPolicyCommitment,
+      minimumFinalityBlocks: input.release.minimumFinalityBlocks,
+      primaryLaunch,
+      authorization: auth,
+      registration: Object.freeze([
+        registered, descriptor, descriptorEvidenceEvent,
+      ]) as readonly [
+        typeof registered, typeof descriptor, typeof descriptorEvidenceEvent,
+      ],
+      finalization: finalized,
+      latestCommonHead: input.commonHead.toString(),
+      latestCommonHeadHash: input.commonHeadHash,
+      revokedAtBlock: "0" as const,
+      revocationEvidenceHash: ZERO_HASH32,
+    }),
+    bindingEvidence: Object.freeze({
+      approvalState, launchState, launchDescriptor,
+      eventArguments: events.arguments,
+    }),
+  });
+}
+
+type DecodedLifecycleLog = Readonly<{
+  eventName: string;
+  transactionHash: `0x${string}`;
+  blockHash: `0x${string}`;
+  blockNumber: string;
+  transactionIndex: string;
+  logIndex: string;
+  removed: false;
+  args: Readonly<Record<string, string>>;
+}>;
+
+function decodeLifecycleLogs(
+  logs: Awaited<ReturnType<PublicClient["getLogs"]>>,
+  approval: VerifiedApprovalArtifactV3,
+) {
+  const selected: DecodedLifecycleLog[] = [];
+  for (const log of logs) {
+    if (log.blockHash === null || log.blockNumber === null
+      || log.transactionHash === null || log.transactionIndex === null
+      || log.logIndex === null || log.removed) continue;
+    let decoded: Readonly<{ eventName: string; args: unknown }>;
+    try {
+      decoded = decodeEventLog({
+        abi: ABI, data: log.data, topics: log.topics, strict: true,
+      }) as Readonly<{ eventName: string; args: unknown }>;
+    } catch {
+      continue;
+    }
+    if (!decoded.eventName.startsWith("CustomLaunch")) continue;
+    const args = normalizeArgs(decoded.args);
+    if (args.approvalId !== approval.approvalId
+      && args.launchId !== approval.launchId) continue;
+    selected.push(Object.freeze({
+      eventName: decoded.eventName,
+      transactionHash: log.transactionHash.toLowerCase() as `0x${string}`,
+      blockHash: log.blockHash.toLowerCase() as `0x${string}`,
+      blockNumber: log.blockNumber.toString(),
+      transactionIndex: log.transactionIndex.toString(),
+      logIndex: log.logIndex.toString(),
+      removed: false,
+      args,
+    }));
+  }
+  selected.sort(compareLog);
+  const one = (name: string) => {
+    const matches = selected.filter((entry) => entry.eventName === name);
+    if (matches.length > 1) throw new TypeError(`Registry ${name} is duplicated`);
+    return matches[0] ?? null;
+  };
+  return Object.freeze({
+    authorization: one("CustomLaunchApprovalAuthorizedV2"),
+    registration: one("CustomLaunchRegisteredV2"),
+    descriptor: one("CustomLaunchDescriptorCommittedV2"),
+    descriptorEvidence: one("CustomLaunchDescriptorEvidenceCommittedV2"),
+    finalization: one("CustomLaunchFinalizedV2"),
+    revocation: one("CustomLaunchRevokedV2"),
+    arguments: Object.freeze(selected.map((entry) => Object.freeze({
+      eventName: entry.eventName,
+      transactionHash: entry.transactionHash,
+      blockHash: entry.blockHash,
+      blockNumber: entry.blockNumber,
+      transactionIndex: entry.transactionIndex,
+      logIndex: entry.logIndex,
+      args: entry.args,
+    }))),
+  });
+}
+
+function normalizeArgs(value: unknown): Readonly<Record<string, string>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Registry event arguments are invalid");
+  }
+  const output: Record<string, string> = {};
+  for (const [key, candidate] of Object.entries(value)) {
+    if (typeof candidate === "bigint") output[key] = candidate.toString();
+    else if (typeof candidate === "number") output[key] = String(candidate);
+    else if (typeof candidate === "string") output[key] = candidate.toLowerCase();
+    else throw new TypeError("Registry event argument is invalid");
+  }
+  return Object.freeze(output);
+}
+
+function tuple(value: unknown, names: readonly string[]): Readonly<Record<string, string>> {
+  if (value === null || typeof value !== "object") {
+    throw new TypeError("Registry state tuple is invalid");
+  }
+  const source = value as Readonly<Record<string, unknown>>;
+  const output: Record<string, string> = {};
+  names.forEach((name, index) => {
+    const candidate = source[name] ?? source[String(index)];
+    if (typeof candidate === "bigint" || typeof candidate === "number") {
+      output[name] = String(candidate);
+    } else if (typeof candidate === "boolean") {
+      output[name] = candidate ? "true" : "false";
+    } else if (typeof candidate === "string") {
+      output[name] = candidate.toLowerCase();
+    } else throw new TypeError(`Registry state ${name} is invalid`);
+  });
+  return Object.freeze(output);
+}
+
+function approvalStateEvidence(value: unknown) {
+  return tuple(value, [
+    "descriptorHash", "validAfterBlock", "expiresAtBlock",
+    "approvalEvidenceHash", "consumed",
+  ]);
+}
+
+function launchStateEvidence(value: unknown) {
+  return tuple(value, [
+    "status", "observedAtBlock", "finalizedAtBlock", "revokedAtBlock",
+    "transitionSequence", "descriptorHash", "approvalId",
+    "approvalEvidenceHash", "registrationEvidenceHash",
+    "finalityEvidenceHash", "revocationEvidenceHash",
+  ]);
+}
+
+function descriptorEvidence(value: unknown) {
+  return tuple(value, [
+    "chainId", "launchWallet", "primaryContract", "primaryRuntimeCodeHash",
+    "componentSetHash", "sourceArtifactHash", "configurationHash",
+    "launchPlanHash", "projectCommitment", "marketMode", "protocolFeeBps",
+  ]);
+}
+
+function assertApprovalState(
+  state: Readonly<Record<string, string>>,
+  approval: VerifiedApprovalArtifactV3,
+) {
+  if (state.descriptorHash !== approval.descriptorHash
+    || state.approvalEvidenceHash !== approval.approvalEvidenceHash
+    || state.consumed !== "true") {
+    throw new TypeError("Registry approval state does not match Approval artifact");
+  }
+}
+
+function assertDescriptor(
+  state: Readonly<Record<string, string>>,
+  approval: VerifiedApprovalArtifactV3,
+) {
+  const descriptor = approval.descriptor;
+  if (state.chainId !== "1" || state.launchWallet !== descriptor.launchWallet
+    || state.primaryContract !== descriptor.primaryContract
+    || state.primaryRuntimeCodeHash !== descriptor.primaryRuntimeCodeHash
+    || state.componentSetHash !== descriptor.componentSetHash
+    || state.sourceArtifactHash !== descriptor.sourceArtifactHash
+    || state.configurationHash !== descriptor.configurationHash
+    || state.launchPlanHash !== descriptor.launchPlanHash
+    || state.projectCommitment !== descriptor.projectCommitment
+    || state.marketMode !== String(descriptor.marketModeValue)
+    || state.protocolFeeBps !== String(descriptor.protocolFeeBps)) {
+    throw new TypeError("Registry descriptor state does not match Approval artifact");
+  }
+}
+
+function assertFinalizedEventJoins(
+  events: ReturnType<typeof decodeLifecycleLogs>,
+  approval: VerifiedApprovalArtifactV3,
+  launchState: Readonly<Record<string, string>>,
+  approvalState: Readonly<Record<string, string>>,
+) {
+  const auth = events.authorization!;
+  const registered = events.registration!;
+  const descriptor = events.descriptor!;
+  const evidenceEvent = events.descriptorEvidence!;
+  const finalization = events.finalization!;
+  if (auth.args.approvalId !== approval.approvalId
+    || auth.args.descriptorHash !== approval.descriptorHash
+    || auth.args.approvalEvidenceHash !== approval.approvalEvidenceHash
+    || auth.args.validAfterBlock !== approvalState.validAfterBlock
+    || auth.args.expiresAtBlock !== approvalState.expiresAtBlock
+    || registered.args.launchId !== approval.launchId
+    || registered.args.descriptorHash !== approval.descriptorHash
+    || registered.args.primaryContract !== approval.descriptor.primaryContract
+    || registered.args.approvalId !== approval.approvalId
+    || registered.args.approvalEvidenceHash !== approval.approvalEvidenceHash
+    || descriptor.args.launchId !== approval.launchId
+    || descriptor.args.descriptorHash !== approval.descriptorHash
+    || descriptor.args.primaryContract !== approval.descriptor.primaryContract
+    || descriptor.args.launchWallet !== approval.descriptor.launchWallet
+    || descriptor.args.primaryRuntimeCodeHash
+      !== approval.descriptor.primaryRuntimeCodeHash
+    || descriptor.args.componentSetHash !== approval.descriptor.componentSetHash
+    || descriptor.args.projectCommitment !== approval.descriptor.projectCommitment
+    || descriptor.args.marketMode !== String(approval.descriptor.marketModeValue)
+    || descriptor.args.protocolFeeBps !== String(approval.descriptor.protocolFeeBps)
+    || evidenceEvent.args.launchId !== approval.launchId
+    || evidenceEvent.args.sourceArtifactHash !== approval.descriptor.sourceArtifactHash
+    || evidenceEvent.args.configurationHash !== approval.descriptor.configurationHash
+    || evidenceEvent.args.launchPlanHash !== approval.descriptor.launchPlanHash
+    || finalization.args.launchId !== approval.launchId
+    || finalization.args.descriptorHash !== approval.descriptorHash
+    || launchState.descriptorHash !== approval.descriptorHash
+    || launchState.approvalId !== approval.approvalId
+    || launchState.approvalEvidenceHash !== approval.approvalEvidenceHash
+    || launchState.registrationEvidenceHash
+      !== registered.args.registrationEvidenceHash
+    || launchState.finalityEvidenceHash !== finalization.args.finalityEvidenceHash) {
+    throw new TypeError("Registry lifecycle evidence does not join Approval artifact");
+  }
+}
+
+function evidence<Name extends string>(log: DecodedLifecycleLog, eventName: Name) {
+  if (log.eventName !== eventName) throw new TypeError("Registry event name is invalid");
+  return Object.freeze({
+    eventName,
+    transactionHash: log.transactionHash,
+    blockHash: log.blockHash,
+    blockNumber: log.blockNumber,
+    transactionIndex: log.transactionIndex,
+    logIndex: log.logIndex,
+    removed: false as const,
+  });
+}
+
+function assertLifecycleOrder(
+  primary: Readonly<{ blockNumber: string; transactionIndex: string }>,
+  authorization: Readonly<{ blockNumber: string; transactionIndex: string; logIndex: string }>,
+  registration: readonly Readonly<{
+    transactionHash: string; blockHash: string; blockNumber: string;
+    transactionIndex: string; logIndex: string;
+  }>[],
+  finalization: Readonly<{ blockNumber: string; transactionIndex: string; logIndex: string }>,
+  commonHead: bigint,
+  minimumFinality: bigint,
+) {
+  if (comparePosition(primary, authorization) > 0
+    || comparePosition(authorization, registration[0]!) >= 0
+    || registration.some((value) => value.transactionHash !== registration[0]!.transactionHash
+      || value.blockHash !== registration[0]!.blockHash
+      || value.blockNumber !== registration[0]!.blockNumber
+      || value.transactionIndex !== registration[0]!.transactionIndex)
+    || BigInt(registration[0]!.logIndex) >= BigInt(registration[1]!.logIndex)
+    || BigInt(registration[1]!.logIndex) >= BigInt(registration[2]!.logIndex)
+    || comparePosition(registration[2]!, finalization) >= 0
+    || commonHead < BigInt(finalization.blockNumber) + minimumFinality) {
+    throw new TypeError("Registry lifecycle chronology/finality is invalid");
+  }
+}
+
+function comparePosition(
+  left: Readonly<{ blockNumber: string; transactionIndex: string; logIndex?: string }>,
+  right: Readonly<{ blockNumber: string; transactionIndex: string; logIndex?: string }>,
+) {
+  for (const key of ["blockNumber", "transactionIndex", "logIndex"] as const) {
+    const a = BigInt(left[key] ?? "0");
+    const b = BigInt(right[key] ?? "0");
+    if (a < b) return -1;
+    if (a > b) return 1;
+  }
+  return 0;
+}
+
+function compareLog(left: DecodedLifecycleLog, right: DecodedLifecycleLog) {
+  return comparePosition(left, right);
+}
+
+function validateRelease(value: GenericLaunchRegistryReleaseV2) {
+  if (!/^0x[0-9a-f]{40}$/u.test(value.registryAddress)
+    || value.registryAddress === `0x${"00".repeat(20)}`
+    || !/^0x[0-9a-f]{64}$/u.test(value.registryRuntimeCodeKeccak256)
+    || !/^0x[0-9a-f]{64}$/u.test(value.registryPolicyCommitment)
+    || !/^[1-9][0-9]{0,77}$/u.test(value.deploymentBlock)
+    || !/^[1-9][0-9]{0,2}$/u.test(value.minimumFinalityBlocks)) {
+    throw new TypeError("Generic launch Registry release is invalid");
+  }
+}
+
+void (null as unknown as Hex);

--- a/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
+++ b/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
@@ -144,6 +144,17 @@ async function observeProvider(
 ): Promise<ProviderObservationV2> {
   input.signal.throwIfAborted();
   const address = input.release.registryAddress;
+  if (input.approval.registry.chainId !== "1"
+    || input.approval.registry.generation !== "2"
+    || input.approval.registry.address !== address
+    || input.approval.registry.runtimeCodeKeccak256
+      !== input.release.registryRuntimeCodeKeccak256
+    || input.approval.registry.minimumFinalityBlocks
+      !== input.release.minimumFinalityBlocks
+    || input.approval.registryOnchainPolicyCommitment
+      !== input.release.registryPolicyCommitment) {
+    throw new TypeError("Approval artifact is not bound to the Registry release");
+  }
   const fromBlock = BigInt(input.release.deploymentBlock);
   const [logs, approvalStateRaw, launchStateRaw, descriptorRaw, primaryTx,
     primaryReceipt, primaryBlock, primaryCode] = await Promise.all([
@@ -233,6 +244,28 @@ async function observeProvider(
     throw new TypeError("Registry lifecycle is not finalized and non-revoked");
   }
   assertFinalizedEventJoins(events, input.approval, launchState, approvalState);
+  const finalizedLog = events.finalization!;
+  const finalityArgs = finalizedLog.args;
+  const [observedBlock, confirmedBlock] = await Promise.all([
+    client.getBlock({
+      blockNumber: BigInt(finalityArgs.observedAtBlock),
+      includeTransactions: false,
+    }),
+    client.getBlock({
+      blockNumber: BigInt(finalityArgs.confirmedHeadBlock),
+      includeTransactions: false,
+    }),
+  ]);
+  if (observedBlock.hash?.toLowerCase() !== finalityArgs.observedBlockHash
+    || confirmedBlock.hash?.toLowerCase() !== finalityArgs.confirmedHeadBlockHash
+    || finalityArgs.observedAtBlock !== launchState.observedAtBlock
+    || finalityArgs.finalizedAtBlock !== launchState.finalizedAtBlock
+    || finalityArgs.finalizedAtBlock !== finalizedLog.blockNumber
+    || BigInt(finalityArgs.confirmedHeadBlock)
+      < BigInt(finalityArgs.observedAtBlock)
+        + BigInt(input.release.minimumFinalityBlocks)) {
+    throw new TypeError("Registry finalized block evidence is invalid");
+  }
   const auth = evidence(events.authorization, "CustomLaunchApprovalAuthorizedV2");
   const registered = evidence(events.registration, "CustomLaunchRegisteredV2");
   const descriptor = evidence(events.descriptor, "CustomLaunchDescriptorCommittedV2");
@@ -405,6 +438,8 @@ function assertApprovalState(
 ) {
   if (state.descriptorHash !== approval.descriptorHash
     || state.approvalEvidenceHash !== approval.approvalEvidenceHash
+    || state.validAfterBlock !== approval.authorization.validAfterBlock
+    || state.expiresAtBlock !== approval.authorization.expiresAtBlock
     || state.consumed !== "true") {
     throw new TypeError("Registry approval state does not match Approval artifact");
   }

--- a/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
+++ b/lib/server/custom-launch/generic-launch-registry-reader-v2.ts
@@ -23,6 +23,7 @@ import { canonicalizeJson, type JsonValue } from
   "../projection-target/canonical-json";
 import { canonicalSha256 } from "../projection-target/hashing";
 import type {
+  GenericLaunchMaterializationStoreV2,
   VerifiedApprovalArtifactV3,
   VerifiedRegistryLifecycleV2,
 } from "./generic-launch-projector-v2";
@@ -30,6 +31,7 @@ import type {
 const ABI = registryAbiArtifact.abi as Abi;
 const ZERO_HASH32 = `0x${"00".repeat(32)}` as const;
 const MAXIMUM_LOG_WINDOW_BLOCKS = 5_000n;
+const MAXIMUM_INITIAL_LOG_BLOCKS = 250_000n;
 
 export interface GenericLaunchRegistryReleaseV2 {
   readonly registryAddress: `0x${string}`;
@@ -57,6 +59,9 @@ interface RegistryProviderReaderV2 {
     release: GenericLaunchRegistryReleaseV2;
     commonHead: bigint;
     commonHeadHash: `0x${string}`;
+    previous: Awaited<ReturnType<
+      GenericLaunchMaterializationStoreV2["getLatestLifecycle"]
+    >>;
     signal: AbortSignal;
   }>): Promise<ProviderObservationV2>;
 }
@@ -67,6 +72,9 @@ export function createDualRpcGenericLaunchRegistryReaderV2(input: Readonly<{
   providerFactory?: (url: string) => RegistryProviderReaderV2;
 }>): (request: Readonly<{
   approval: VerifiedApprovalArtifactV3;
+  previous: Awaited<ReturnType<
+    GenericLaunchMaterializationStoreV2["getLatestLifecycle"]
+  >>;
   signal: AbortSignal;
 }>) => Promise<VerifiedRegistryLifecycleV2> {
   validateRelease(input.release);
@@ -95,6 +103,7 @@ export function createDualRpcGenericLaunchRegistryReaderV2(input: Readonly<{
         release: input.release,
         commonHead,
         commonHeadHash: hashes[0],
+        previous: request.previous,
         signal: request.signal,
       })));
     if (canonicalizeJson(observations[0] as unknown as JsonValue)
@@ -131,6 +140,9 @@ function createViemRegistryProviderV2(url: string): RegistryProviderReaderV2 {
       release: GenericLaunchRegistryReleaseV2;
       commonHead: bigint;
       commonHeadHash: `0x${string}`;
+      previous: Awaited<ReturnType<
+        GenericLaunchMaterializationStoreV2["getLatestLifecycle"]
+      >>;
       signal: AbortSignal;
     }>) {
       return await observeProvider(client, request);
@@ -145,6 +157,9 @@ async function observeProvider(
     release: GenericLaunchRegistryReleaseV2;
     commonHead: bigint;
     commonHeadHash: `0x${string}`;
+    previous: Awaited<ReturnType<
+      GenericLaunchMaterializationStoreV2["getLatestLifecycle"]
+    >>;
     signal: AbortSignal;
   }>,
 ): Promise<ProviderObservationV2> {
@@ -162,6 +177,15 @@ async function observeProvider(
     throw new TypeError("Approval artifact is not bound to the Registry release");
   }
   const fromBlock = BigInt(input.release.deploymentBlock);
+  const previousHead = input.previous === null
+    ? null
+    : BigInt(input.previous.observationCommonHead);
+  const previousBlock = previousHead === null || previousHead > input.commonHead
+    ? null
+    : await client.getBlock({
+      blockNumber: previousHead,
+      includeTransactions: false,
+    });
   const [approvalStateRaw, launchStateRaw, descriptorRaw, primaryTx,
     primaryReceipt, primaryBlock, primaryCode] = await Promise.all([
     client.readContract({
@@ -191,21 +215,70 @@ async function observeProvider(
       blockNumber: input.commonHead,
     }),
   ]);
-  const logs = await readBoundedLifecycleLogs(
+  const initialFromBlock = BigInt(input.approval.primaryFinality.blockNumber)
+    > fromBlock ? BigInt(input.approval.primaryFinality.blockNumber) : fromBlock;
+  let logs = await readBoundedLifecycleLogs(
     client,
     address,
-    BigInt(input.approval.primaryFinality.blockNumber) > fromBlock
-      ? BigInt(input.approval.primaryFinality.blockNumber)
-      : fromBlock,
+    previousHead === null
+      ? initialFromBlock
+      : previousHead + 1n,
     input.commonHead,
     input.approval,
+    previousHead !== null,
     input.signal,
   );
   input.signal.throwIfAborted();
   const approvalState = approvalStateEvidence(approvalStateRaw);
   const launchState = launchStateEvidence(launchStateRaw);
   const launchDescriptor = descriptorEvidence(descriptorRaw);
-  const events = decodeLifecycleLogs(logs, input.approval);
+  let events = decodeLifecycleLogs(logs, input.approval);
+  if (input.previous !== null
+    && input.previous.approvalId !== input.approval.approvalId
+    && approvalState.consumed === "true"
+    && launchState.approvalId === input.approval.approvalId) {
+    throw new TypeError("Canonical consumed Registry Approval identity changed");
+  }
+  if (approvalState.consumed !== "true"
+    || launchState.approvalId !== input.approval.approvalId) {
+    if (input.previous?.approvalId === input.approval.approvalId) {
+      return invalidatedObservation(input, {
+        approvalState,
+        launchState,
+        launchDescriptor,
+        eventArguments: events.arguments,
+        previousCanonicalApprovalId: input.previous.approvalId,
+      });
+    }
+    return Object.freeze({
+      lifecycle: Object.freeze({
+        status: "unconsumed" as const,
+        latestCommonHead: input.commonHead.toString(),
+        latestCommonHeadHash: input.commonHeadHash,
+        observationCommonHead: input.commonHead.toString(),
+        observationCommonHeadHash: input.commonHeadHash,
+      }),
+      bindingEvidence: Object.freeze({
+        approvalState, launchState, launchDescriptor,
+        eventArguments: events.arguments,
+      }),
+    });
+  }
+  if (input.previous !== null && (previousHead! > input.commonHead
+    || previousBlock?.hash?.toLowerCase()
+      !== input.previous.observationCommonHeadHash)) {
+    return invalidatedObservation(input, {
+      approvalState,
+      launchState,
+      launchDescriptor,
+      eventArguments: events.arguments,
+      previousObservation: {
+        blockNumber: input.previous.observationCommonHead,
+        expectedBlockHash: input.previous.observationCommonHeadHash,
+        actualBlockHash: previousBlock?.hash?.toLowerCase() ?? null,
+      },
+    });
+  }
   const primaryObservation = Object.freeze({
     transactionHash: primaryTx?.hash.toLowerCase() ?? null,
     sender: primaryTx?.from.toLowerCase() ?? null,
@@ -237,6 +310,19 @@ async function observeProvider(
       primaryObservation,
     });
   }
+  if (input.previous?.state === "invalidated"
+    && (launchState.status === "2" || launchState.status === "3")) {
+    logs = await readBoundedLifecycleLogs(
+      client,
+      address,
+      initialFromBlock,
+      input.commonHead,
+      input.approval,
+      false,
+      input.signal,
+    );
+    events = decodeLifecycleLogs(logs, input.approval);
+  }
   const primaryLaunch = Object.freeze({
     transactionHash: primaryReceipt.transactionHash.toLowerCase() as `0x${string}`,
     sender: primaryTx.from.toLowerCase() as `0x${string}`,
@@ -245,6 +331,45 @@ async function observeProvider(
     transactionIndex: primaryReceipt.transactionIndex.toString(),
     status: "success" as const,
   });
+  if (input.previous?.state === "revoked" && events.revocation === null
+    && launchState.status === "3"
+    && input.previous.approvalId === input.approval.approvalId
+    && input.previous.descriptorHash === input.approval.descriptorHash) {
+    assertApprovalState(approvalState, input.approval);
+    assertDescriptor(launchDescriptor, input.approval);
+    const stableEvidenceHash = canonicalSha256(
+      "programmable.generic-launch-registry-lifecycle-evidence.v2",
+      {
+        approvalId: input.approval.approvalId,
+        launchId: input.approval.launchId,
+        descriptorHash: input.approval.descriptorHash,
+        status: "revoked",
+        revokedAtBlock: launchState.revokedAtBlock,
+        revocationEvidenceHash: launchState.revocationEvidenceHash,
+      },
+    );
+    if (stableEvidenceHash !== input.previous.lifecycleEvidenceHash
+      || launchState.revokedAtBlock === "0"
+      || launchState.revocationEvidenceHash === ZERO_HASH32) {
+      throw new TypeError("Stored Registry revocation evidence is inconsistent");
+    }
+    return Object.freeze({
+      lifecycle: Object.freeze({
+        status: "revoked" as const,
+        latestCommonHead: input.previous.observationCommonHead,
+        latestCommonHeadHash: input.previous.observationCommonHeadHash,
+        revokedAtBlock: launchState.revokedAtBlock,
+        revocationEvidenceHash:
+          launchState.revocationEvidenceHash as `0x${string}`,
+        observationCommonHead: input.commonHead.toString(),
+        observationCommonHeadHash: input.commonHeadHash,
+      }),
+      bindingEvidence: Object.freeze({
+        approvalState, launchState, launchDescriptor,
+        eventArguments: events.arguments,
+      }),
+    });
+  }
   if (events.revocation !== null || launchState.status === "3") {
     assertApprovalState(approvalState, input.approval);
     assertDescriptor(launchDescriptor, input.approval);
@@ -264,6 +389,39 @@ async function observeProvider(
         revokedAtBlock: launchState.revokedAtBlock,
         revocationEvidenceHash:
           launchState.revocationEvidenceHash as `0x${string}`,
+        observationCommonHead: input.commonHead.toString(),
+        observationCommonHeadHash: input.commonHeadHash,
+      }),
+      bindingEvidence: Object.freeze({
+        approvalState, launchState, launchDescriptor,
+        eventArguments: events.arguments,
+      }),
+    });
+  }
+  if (input.previous?.state === "finalized" && input.previous.record !== null
+    && launchState.status === "2" && launchState.revokedAtBlock === "0"
+    && launchState.revocationEvidenceHash === ZERO_HASH32
+    && events.revocation === null) {
+    assertApprovalState(approvalState, input.approval);
+    assertDescriptor(launchDescriptor, input.approval);
+    const prior = input.previous.record.sourceProjection.lifecycle;
+    return Object.freeze({
+      lifecycle: Object.freeze({
+        status: "finalized" as const,
+        registryAddress: prior.registryAddress,
+        registryRuntimeCodeKeccak256: prior.registryRuntimeCodeKeccak256,
+        registryPolicyCommitment: prior.registryPolicyCommitment,
+        minimumFinalityBlocks: prior.minimumFinalityBlocks,
+        primaryLaunch: prior.primaryLaunch,
+        authorization: prior.authorization,
+        registration: prior.registration,
+        finalization: prior.finalization,
+        latestCommonHead: prior.latestCommonHead,
+        latestCommonHeadHash: prior.latestCommonHeadHash,
+        revokedAtBlock: "0" as const,
+        revocationEvidenceHash: ZERO_HASH32,
+        observationCommonHead: input.commonHead.toString(),
+        observationCommonHeadHash: input.commonHeadHash,
       }),
       bindingEvidence: Object.freeze({
         approvalState, launchState, launchDescriptor,
@@ -339,6 +497,8 @@ async function observeProvider(
       latestCommonHeadHash: input.commonHeadHash,
       revokedAtBlock: "0" as const,
       revocationEvidenceHash: ZERO_HASH32,
+      observationCommonHead: input.commonHead.toString(),
+      observationCommonHeadHash: input.commonHeadHash,
     }),
     bindingEvidence: Object.freeze({
       approvalState, launchState, launchDescriptor,
@@ -354,6 +514,8 @@ function invalidatedObservation(
   }>,
   bindingEvidence: ProviderObservationV2["bindingEvidence"] & Readonly<{
     primaryObservation?: unknown;
+    previousObservation?: unknown;
+    previousCanonicalApprovalId?: unknown;
   }>,
 ): ProviderObservationV2 {
   const invalidationEvidenceHash = canonicalSha256(
@@ -373,6 +535,8 @@ function invalidatedObservation(
       latestCommonHeadHash: input.commonHeadHash,
       registryStatus,
       invalidationEvidenceHash,
+      observationCommonHead: input.commonHead.toString(),
+      observationCommonHeadHash: input.commonHeadHash,
     }),
     bindingEvidence: Object.freeze(bindingEvidence),
   });
@@ -395,18 +559,25 @@ async function readBoundedLifecycleLogs(
   fromBlock: bigint,
   toBlock: bigint,
   approval: VerifiedApprovalArtifactV3,
+  incremental: boolean,
   signal: AbortSignal,
 ) {
-  if (fromBlock > toBlock) {
-    throw new TypeError("Registry lifecycle log range is invalid");
-  }
   const logs: Awaited<ReturnType<PublicClient["getLogs"]>> = [];
+  if (fromBlock > toBlock) return logs;
+  if (!incremental && toBlock - fromBlock + 1n > MAXIMUM_INITIAL_LOG_BLOCKS) {
+    throw new TypeError("Registry initial lifecycle evidence exceeds its bound");
+  }
   for (let start = fromBlock; start <= toBlock;) {
     signal.throwIfAborted();
     const end = start + MAXIMUM_LOG_WINDOW_BLOCKS - 1n < toBlock
       ? start + MAXIMUM_LOG_WINDOW_BLOCKS - 1n
       : toBlock;
-    const filters = [
+    const filters = (incremental ? [
+      ["CustomLaunchRevokedV2", {
+        launchId: approval.launchId,
+        descriptorHash: approval.descriptorHash,
+      }],
+    ] : [
       ["CustomLaunchApprovalAuthorizedV2", {
         approvalId: approval.approvalId,
         descriptorHash: approval.descriptorHash,
@@ -434,7 +605,7 @@ async function readBoundedLifecycleLogs(
         launchId: approval.launchId,
         descriptorHash: approval.descriptorHash,
       }],
-    ] as const;
+    ]) as readonly (readonly [string, Readonly<Record<string, `0x${string}`>>])[];
     for (const [name, args] of filters) {
       const event = registryEvent(name);
       const window = await client.getLogs({

--- a/lib/server/projection-target/approval-v3-target.ts
+++ b/lib/server/projection-target/approval-v3-target.ts
@@ -19,6 +19,22 @@ const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/+~-]{0,255}$/u;
 const DIGEST = /^sha256:[0-9a-f]{64}$/u;
 
 let productionTarget: ProjectionTargetReferenceHandlerV1 | null = null;
+let productionPool:
+ReturnType<typeof createProductionProjectionTargetPostgresPoolV1> | null = null;
+
+export function getProductionApprovalV3ProjectionPoolV1():
+ReturnType<typeof createProductionProjectionTargetPostgresPoolV1> {
+  if (productionPool !== null) return productionPool;
+  productionPool = createProductionProjectionTargetPostgresPoolV1(
+    environmentValue("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL"),
+    environmentPem(
+      "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM",
+      "CERTIFICATE",
+    ),
+    environmentId("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE"),
+  );
+  return productionPool;
+}
 
 export function getProductionApprovalV3ProjectionTargetV1():
 ProjectionTargetReferenceHandlerV1 {
@@ -27,14 +43,7 @@ ProjectionTargetReferenceHandlerV1 {
   const targetBindingHash = environmentDigest(
     "PROGRAMMABLE_WEBSITE_APPROVAL_V3_TARGET_BINDING_HASH",
   );
-  const pool = createProductionProjectionTargetPostgresPoolV1(
-    environmentValue("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL"),
-    environmentPem(
-      "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM",
-      "CERTIFICATE",
-    ),
-    environmentId("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE"),
-  );
+  const pool = getProductionApprovalV3ProjectionPoolV1();
   const credentialVerifier =
     createEd25519ProjectionWorkloadCredentialVerifierV1({
       issuer: environmentId("PROGRAMMABLE_APPROVAL_V3_WORKLOAD_ISSUER"),

--- a/lib/server/projection-target/approval-v3-target.ts
+++ b/lib/server/projection-target/approval-v3-target.ts
@@ -14,6 +14,8 @@ import {
 import {
   createProductionProjectionTargetPostgresPoolV1,
 } from "./website-target";
+import { assertPostgresGenericLaunchAdmissionReadyV2 } from
+  "../custom-launch/generic-launch-postgres-v2";
 
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/+~-]{0,255}$/u;
 const DIGEST = /^sha256:[0-9a-f]{64}$/u;
@@ -68,11 +70,18 @@ ProjectionTargetReferenceHandlerV1 {
   productionTarget = Object.freeze({
     contract: handler.contract,
     async handle(request: Request) {
-      await pool.assertProductionReadiness();
+      await assertApprovalV3ProjectionAdmissionReadyV1(pool);
       return await handler.handle(request);
     },
   });
   return productionTarget;
+}
+
+export async function assertApprovalV3ProjectionAdmissionReadyV1(
+  pool: ReturnType<typeof createProductionProjectionTargetPostgresPoolV1>,
+): Promise<void> {
+  await pool.assertProductionReadiness();
+  await assertPostgresGenericLaunchAdmissionReadyV2(pool);
 }
 
 export async function handleProductionApprovalV3ProjectionTargetV1(

--- a/lib/server/projection-target/approval-v3-target.ts
+++ b/lib/server/projection-target/approval-v3-target.ts
@@ -1,0 +1,114 @@
+import "server-only";
+
+import { canonicalizeJson } from "./canonical-json";
+import {
+  PostgresProjectionTargetAtomicStoreV1,
+} from "./postgres-store";
+import {
+  createProjectionTargetReferenceHandlerV1,
+  type ProjectionTargetReferenceHandlerV1,
+} from "./protocol";
+import {
+  createEd25519ProjectionWorkloadCredentialVerifierV1,
+} from "./workload-credential";
+import {
+  createProductionProjectionTargetPostgresPoolV1,
+} from "./website-target";
+
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/+~-]{0,255}$/u;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+
+let productionTarget: ProjectionTargetReferenceHandlerV1 | null = null;
+
+export function getProductionApprovalV3ProjectionTargetV1():
+ProjectionTargetReferenceHandlerV1 {
+  if (productionTarget !== null) return productionTarget;
+  const audience = environmentId("PROGRAMMABLE_WEBSITE_APPROVAL_V3_AUDIENCE");
+  const targetBindingHash = environmentDigest(
+    "PROGRAMMABLE_WEBSITE_APPROVAL_V3_TARGET_BINDING_HASH",
+  );
+  const pool = createProductionProjectionTargetPostgresPoolV1(
+    environmentValue("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL"),
+    environmentPem(
+      "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM",
+      "CERTIFICATE",
+    ),
+    environmentId("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE"),
+  );
+  const credentialVerifier =
+    createEd25519ProjectionWorkloadCredentialVerifierV1({
+      issuer: environmentId("PROGRAMMABLE_APPROVAL_V3_WORKLOAD_ISSUER"),
+      subject: environmentId("PROGRAMMABLE_APPROVAL_V3_WORKLOAD_SUBJECT"),
+      audience,
+      keyId: environmentId("PROGRAMMABLE_APPROVAL_V3_WORKLOAD_KEY_ID"),
+      publicKeyPem: environmentPem(
+        "PROGRAMMABLE_APPROVAL_V3_WORKLOAD_PUBLIC_KEY_PEM",
+        "PUBLIC KEY",
+      ),
+      targetBindings: Object.freeze({ "website.approval-v3": targetBindingHash }),
+    });
+  const handler = createProjectionTargetReferenceHandlerV1({
+    lanes: Object.freeze([Object.freeze({
+      lane: "website.approval-v3" as const,
+      audience,
+      targetBindingHash,
+    })]),
+    credentialVerifier,
+    store: new PostgresProjectionTargetAtomicStoreV1(pool),
+  });
+  productionTarget = Object.freeze({
+    contract: handler.contract,
+    async handle(request: Request) {
+      await pool.assertProductionReadiness();
+      return await handler.handle(request);
+    },
+  });
+  return productionTarget;
+}
+
+export async function handleProductionApprovalV3ProjectionTargetV1(
+  request: Request,
+): Promise<Response> {
+  try {
+    return await getProductionApprovalV3ProjectionTargetV1().handle(request);
+  } catch {
+    return new Response(canonicalizeJson({
+      schemaVersion: "programmable.projection-target-error.v1",
+      code: "target_unavailable",
+    }), {
+      status: 503,
+      headers: {
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+        "x-content-type-options": "nosniff",
+      },
+    });
+  }
+}
+
+function environmentValue(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new TypeError(`${name} is not configured`);
+  return value;
+}
+
+function environmentId(name: string): string {
+  const value = environmentValue(name);
+  if (!SAFE_ID.test(value)) throw new TypeError(`${name} is invalid`);
+  return value;
+}
+
+function environmentDigest(name: string): `sha256:${string}` {
+  const value = environmentValue(name);
+  if (!DIGEST.test(value)) throw new TypeError(`${name} is invalid`);
+  return value as `sha256:${string}`;
+}
+
+function environmentPem(name: string, kind: "CERTIFICATE" | "PUBLIC KEY"): string {
+  const value = environmentValue(name).replaceAll("\\n", "\n");
+  if (!value.includes(`-----BEGIN ${kind}-----`)
+    || !value.includes(`-----END ${kind}-----`)) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  return value;
+}

--- a/lib/server/projection-target/conformance.ts
+++ b/lib/server/projection-target/conformance.ts
@@ -235,7 +235,8 @@ function fixtureMap(
   const result = new Map<ProjectionTargetLaneV1, Readonly<NormalizedFixtureV1>>();
   const idempotency = new Set<string>();
   for (const value of values) {
-    if (!LANES.includes(value.lane) || result.has(value.lane)) {
+    if (!(LANES as readonly ProjectionTargetLaneV1[]).includes(value.lane)
+      || result.has(value.lane)) {
       throw new TypeError("projection target conformance fixture lane is invalid or duplicated");
     }
     if (typeof value.canonicalWrite !== "string" || Buffer.byteLength(value.canonicalWrite) > 4_194_304) {
@@ -278,7 +279,8 @@ function laneMap(
 ): ReadonlyMap<ProjectionTargetLaneV1, ProjectionTargetLaneConfigurationV1> {
   const result = new Map<ProjectionTargetLaneV1, ProjectionTargetLaneConfigurationV1>();
   for (const value of values) {
-    if (!LANES.includes(value.lane) || result.has(value.lane)
+    if (!(LANES as readonly ProjectionTargetLaneV1[]).includes(value.lane)
+      || result.has(value.lane)
       || typeof value.audience !== "string" || value.audience.length < 1
       || value.audience.length > 256 || /[\u0000-\u001f\u007f]/u.test(value.audience)) {
       throw new TypeError("projection target conformance lane is invalid or duplicated");

--- a/lib/server/projection-target/postgres-store.ts
+++ b/lib/server/projection-target/postgres-store.ts
@@ -553,7 +553,11 @@ function storedRecordFromRow(
   row: StoredProjectionRowV1,
 ): ProjectionTargetStoredRecordV1 {
   const lane = row.lane;
-  if (lane !== "website.entitlement" && lane !== "website.custom-launched") {
+  if (
+    lane !== "website.entitlement"
+    && lane !== "website.custom-launched"
+    && lane !== "website.approval-v3"
+  ) {
     throw new TypeError("stored projection lane is invalid");
   }
   return Object.freeze({

--- a/lib/server/projection-target/protocol.ts
+++ b/lib/server/projection-target/protocol.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   canonicalizeJson,
   parseStrictJson,
@@ -16,12 +18,15 @@ const DEFAULT_MAXIMUM_DEPTH = 128;
 const V1_REGISTRY_ROUTE = "/v1/internal/projections/registry";
 const V1_WEBSITE_ROUTE = "/v1/internal/projections/website-entitlements";
 const V2_WEBSITE_ROUTE = "/v2/internal/projections/custom-launches";
+const V2_APPROVAL_V3_ROUTE = "/v2/internal/projections/approval-descriptors";
+const HASH32 = /^0x[0-9a-f]{64}$/u;
 
 export type ProjectionTargetLaneV1 =
   | "registry.publication"
   | "website.entitlement"
   | "registry.custom-launched"
-  | "website.custom-launched";
+  | "website.custom-launched"
+  | "website.approval-v3";
 
 export const PROJECTION_TARGET_REFERENCE_CONTRACT_V1 = Object.freeze({
   schemaVersion: "programmable.projection-target-reference-contract.v1",
@@ -30,6 +35,7 @@ export const PROJECTION_TARGET_REFERENCE_CONTRACT_V1 = Object.freeze({
     "website.entitlement": `${V1_WEBSITE_ROUTE}/{projectionKey}`,
     "registry.custom-launched": "{configuredRegistryEndpointPath}/v2/custom-launches/{projectionKey}",
     "website.custom-launched": `${V2_WEBSITE_ROUTE}/{projectionKey}`,
+    "website.approval-v3": `${V2_APPROVAL_V3_ROUTE}/{projectionKey}`,
   }),
   methods: Object.freeze(["GET", "PUT"] as const),
   createdStatus: 201,
@@ -581,7 +587,7 @@ function resolveRoute(
 }
 
 interface ValidatedProjectionWriteV1 {
-  readonly version: 1 | 2;
+  readonly version: 1 | 2 | 3;
   readonly value: Readonly<Record<string, JsonValue>>;
   readonly idempotencyKey: Sha256Digest;
   readonly requestDigest: Sha256Digest;
@@ -630,6 +636,103 @@ function validateProjectionWrite(
       withoutRequestDigest,
     )) throw httpError(400, "write_digest_mismatch");
     return Object.freeze({ version: 1, value: write, idempotencyKey, requestDigest, recordDigest: projectionDigest });
+  }
+
+  if (route.lane === "website.approval-v3") {
+    exactKeys(write, [
+      "approvalEvidenceHash", "approvalId", "authorization",
+      "authorizationDigest", "descriptorHash", "idempotencyKey", "launchId",
+      "projectionKey", "projectionKind", "registryObservationDigest",
+      "requestDigest", "schemaVersion", "signedReceiptArtifactHash",
+      "targetBindingHash",
+    ], "Approval v3 artifact projection write");
+    if (
+      write.schemaVersion
+        !== "programmable.approval-v3-artifact-projection-write.v1"
+      || write.targetBindingHash !== route.targetBindingHash
+      || write.projectionKind !== route.lane
+      || write.projectionKey !== route.projectionKey
+      || write.idempotencyKey !== headerIdempotencyKey
+    ) throw httpError(400, "write_contract_mismatch");
+    const approvalId = nonzeroHash32(write.approvalId, "Approval v3 approval ID");
+    const descriptorHash = nonzeroHash32(
+      write.descriptorHash,
+      "Approval v3 descriptor hash",
+    );
+    const launchId = nonzeroHash32(write.launchId, "Approval v3 launch ID");
+    const signedReceiptArtifactHash = digest(
+      write.signedReceiptArtifactHash,
+      "Approval v3 signed artifact hash",
+    );
+    const approvalEvidenceHash = nonzeroHash32(
+      write.approvalEvidenceHash,
+      "Approval v3 evidence hash",
+    );
+    const authorizationDigest = digest(
+      write.authorizationDigest,
+      "Approval v3 authorization digest",
+    );
+    digest(write.registryObservationDigest, "Approval v3 Registry observation");
+    const idempotencyKey = digest(
+      write.idempotencyKey,
+      "Approval v3 idempotency key",
+    );
+    const requestDigest = digest(
+      write.requestDigest,
+      "Approval v3 request digest",
+    );
+    const authorization = jsonRecord(
+      write.authorization,
+      "Approval v3 authorization",
+    );
+    exactKeys(authorization, [
+      "approvalEvidenceHash", "artifact", "signedReceiptArtifactHash",
+    ], "Approval v3 authorization");
+    const artifact = jsonRecord(
+      authorization.artifact,
+      "Approval v3 signed artifact",
+    );
+    exactKeys(artifact, ["envelope", "payload"], "Approval v3 signed artifact");
+    const payload = jsonRecord(artifact.payload, "Approval v3 artifact payload");
+    const envelope = jsonRecord(artifact.envelope, "Approval v3 artifact envelope");
+    const payloadAuthorization = jsonRecord(
+      payload.authorization,
+      "Approval v3 payload authorization",
+    );
+    if (
+      write.projectionKey !== `approval:${approvalId}`
+      || payload.schemaVersion
+        !== "programmable.approval-registry-descriptor-binding.v3"
+      || payloadAuthorization.approvalId !== approvalId
+      || payload.descriptorHash !== descriptorHash
+      || payload.launchId !== launchId
+      || envelope.schemaVersion !== "1.0.0"
+      || envelope.domain
+        !== "programmable.approval-registry-descriptor-binding.v3"
+      || envelope.audience !== "programmable.custom-registry.v2"
+      || authorization.signedReceiptArtifactHash !== signedReceiptArtifactHash
+      || authorization.approvalEvidenceHash !== approvalEvidenceHash
+      || rawCanonicalSha256(artifact) !== signedReceiptArtifactHash
+      || approvalEvidenceHash !== `0x${signedReceiptArtifactHash.slice(7)}`
+      || rawCanonicalSha256(authorization) !== authorizationDigest
+      || canonicalSha256(
+        "programmable.approval-v3-website-artifact-idempotency.v1",
+        { approvalId, descriptorHash, launchId, signedReceiptArtifactHash },
+      ) !== idempotencyKey
+    ) throw httpError(400, "write_digest_mismatch");
+    const { requestDigest: _ignored, ...withoutRequestDigest } = write;
+    void _ignored;
+    if (canonicalSha256(
+      "programmable.approval-v3-artifact-projection-write.v1",
+      withoutRequestDigest,
+    ) !== requestDigest) throw httpError(400, "write_digest_mismatch");
+    return Object.freeze({
+      version: 3,
+      value: write,
+      idempotencyKey,
+      requestDigest,
+      recordDigest: authorizationDigest,
+    });
   }
 
   exactKeys(write, [
@@ -712,6 +815,41 @@ function buildResponseMaterial(
       payloadDigest: value.payloadDigest!,
       projectionDigest: value.projectionDigest!,
       projection: value.projection!,
+      externalReference,
+      targetRevision,
+      observedAt: now,
+    }) as JsonValue;
+    return Object.freeze({ acknowledgement, readback });
+  }
+  if (write.version === 3) {
+    const value = write.value;
+    const common = Object.freeze({
+      targetBindingHash: value.targetBindingHash!,
+      projectionKind: value.projectionKind!,
+      projectionKey: value.projectionKey!,
+      approvalId: value.approvalId!,
+      descriptorHash: value.descriptorHash!,
+      launchId: value.launchId!,
+      signedReceiptArtifactHash: value.signedReceiptArtifactHash!,
+      approvalEvidenceHash: value.approvalEvidenceHash!,
+      authorizationDigest: value.authorizationDigest!,
+      registryObservationDigest: value.registryObservationDigest!,
+      idempotencyKey: value.idempotencyKey!,
+      requestDigest: value.requestDigest!,
+    });
+    const acknowledgement = Object.freeze({
+      schemaVersion:
+        "programmable.approval-v3-artifact-projection-write-ack.v1",
+      ...common,
+      externalReference,
+      targetRevision,
+      acknowledgedAt: now,
+    }) as JsonValue;
+    const readback = Object.freeze({
+      schemaVersion:
+        "programmable.approval-v3-artifact-projection-readback.v1",
+      ...common,
+      authorization: value.authorization!,
       externalReference,
       targetRevision,
       observedAt: now,
@@ -875,6 +1013,7 @@ function validateHandlerOptions(input: Readonly<{
   const supported = new Set<ProjectionTargetLaneV1>([
     "registry.publication", "website.entitlement",
     "registry.custom-launched", "website.custom-launched",
+    "website.approval-v3",
   ]);
   const lanes = new Map<ProjectionTargetLaneV1, Readonly<ValidatedLaneV1>>();
   for (const value of input.lanes) {
@@ -888,6 +1027,8 @@ function validateHandlerOptions(input: Readonly<{
       ? V1_REGISTRY_ROUTE
       : value.lane === "website.entitlement"
         ? V1_WEBSITE_ROUTE
+        : value.lane === "website.approval-v3"
+          ? V2_APPROVAL_V3_ROUTE
         : value.lane === "website.custom-launched"
           ? V2_WEBSITE_ROUTE
           : `${registryV2EndpointPath!}/v2/custom-launches`;
@@ -1060,7 +1201,10 @@ function assertRouteHeaders(
     || headers.get("x-programmable-target-binding") !== route.targetBindingHash
   ) throw httpError(403, "target_binding_rejected");
   const kind = headers.get("x-programmable-projection-kind");
-  if (route.lane.endsWith(".custom-launched")) {
+  if (
+    route.lane.endsWith(".custom-launched")
+    || route.lane === "website.approval-v3"
+  ) {
     if (headers.get("x-programmable-projection-kind") !== route.lane) {
       throw httpError(403, "projection_lane_rejected");
     }
@@ -1209,6 +1353,21 @@ function digest(value: unknown, label: string): Sha256Digest {
   return value as Sha256Digest;
 }
 
+function nonzeroHash32(value: unknown, label: string): string {
+  if (
+    typeof value !== "string"
+    || !HASH32.test(value)
+    || value === `0x${"0".repeat(64)}`
+  ) throw new TypeError(`${label} is invalid`);
+  return value;
+}
+
+function rawCanonicalSha256(value: JsonValue): Sha256Digest {
+  return `sha256:${createHash("sha256")
+    .update(canonicalizeJson(value), "utf8")
+    .digest("hex")}`;
+}
+
 function identityKey(lane: ProjectionTargetLaneV1, projectionKey: string): string {
   return `${lane}\u0000${projectionKey}`;
 }
@@ -1217,5 +1376,6 @@ function isLane(value: unknown): value is ProjectionTargetLaneV1 {
   return value === "registry.publication"
     || value === "website.entitlement"
     || value === "registry.custom-launched"
-    || value === "website.custom-launched";
+    || value === "website.custom-launched"
+    || value === "website.approval-v3";
 }

--- a/lib/server/projection-target/workload-credential.ts
+++ b/lib/server/projection-target/workload-credential.ts
@@ -342,5 +342,6 @@ function isLane(value: string): value is ProjectionTargetLaneV1 {
   return value === "registry.publication"
     || value === "website.entitlement"
     || value === "registry.custom-launched"
-    || value === "website.custom-launched";
+    || value === "website.custom-launched"
+    || value === "website.approval-v3";
 }

--- a/ops/website-projection-target/migrations/0004_approval_v3_artifacts_v1.sql
+++ b/ops/website-projection-target/migrations/0004_approval_v3_artifacts_v1.sql
@@ -1,0 +1,78 @@
+BEGIN;
+
+ALTER TABLE programmable_website_projection_v1.projection_records
+  DROP CONSTRAINT projection_records_lane_check;
+
+ALTER TABLE programmable_website_projection_v1.projection_records
+  ADD CONSTRAINT projection_records_lane_check CHECK (
+    lane IN (
+      'website.entitlement',
+      'website.custom-launched',
+      'website.approval-v3'
+    )
+  );
+
+ALTER TABLE programmable_website_projection_v1.projection_records
+  DROP CONSTRAINT projection_records_lane_metadata_check;
+
+ALTER TABLE programmable_website_projection_v1.projection_records
+  ADD CONSTRAINT projection_records_lane_metadata_check CHECK (
+    (
+      lane = 'website.entitlement'
+      AND github_user_id ~ '^[1-9][0-9]{0,63}$'
+      AND github_principal_hash ~ '^sha256:[0-9a-f]{64}$'
+      AND length(application_id) BETWEEN 1 AND 512
+      AND length(application_revision) BETWEEN 1 AND 512
+      AND github_repository_id ~ '^[1-9][0-9]{0,63}$'
+      AND launch_entitlement_binding_hash ~ '^sha256:[0-9a-f]{64}$'
+      AND valid_from IS NOT NULL
+      AND valid_until IS NOT NULL
+      AND valid_from < valid_until
+      AND custom_project_id IS NULL
+      AND custom_launch_id IS NULL
+      AND custom_github_principal_hash IS NULL
+      AND custom_finalized_at IS NULL
+      AND custom_launching_wallet_namespace IS NULL
+      AND custom_launching_wallet_value IS NULL
+      AND custom_post_launch_authority_inventory_hash IS NULL
+    )
+    OR (
+      lane = 'website.custom-launched'
+      AND github_user_id IS NULL
+      AND github_principal_hash IS NULL
+      AND application_id IS NULL
+      AND application_revision IS NULL
+      AND github_repository_id IS NULL
+      AND launch_entitlement_binding_hash IS NULL
+      AND valid_from IS NULL
+      AND valid_until IS NULL
+      AND custom_project_id ~ '^sha256:[0-9a-f]{64}$'
+      AND custom_launch_id ~ '^sha256:[0-9a-f]{64}$'
+      AND custom_github_principal_hash ~ '^sha256:[0-9a-f]{64}$'
+      AND custom_finalized_at IS NOT NULL
+      AND custom_launching_wallet_namespace ~ '^eip155:[1-9][0-9]*$'
+      AND custom_launching_wallet_value ~ '^0x[0-9a-f]{40}$'
+      AND custom_post_launch_authority_inventory_hash ~ '^sha256:[0-9a-f]{64}$'
+    )
+    OR (
+      lane = 'website.approval-v3'
+      AND projection_key ~ '^approval:0x[0-9a-f]{64}$'
+      AND github_user_id IS NULL
+      AND github_principal_hash IS NULL
+      AND application_id IS NULL
+      AND application_revision IS NULL
+      AND github_repository_id IS NULL
+      AND launch_entitlement_binding_hash IS NULL
+      AND valid_from IS NULL
+      AND valid_until IS NULL
+      AND custom_project_id IS NULL
+      AND custom_launch_id IS NULL
+      AND custom_github_principal_hash IS NULL
+      AND custom_finalized_at IS NULL
+      AND custom_launching_wallet_namespace IS NULL
+      AND custom_launching_wallet_value IS NULL
+      AND custom_post_launch_authority_inventory_hash IS NULL
+    )
+  );
+
+COMMIT;

--- a/ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql
+++ b/ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql
@@ -97,6 +97,65 @@ CREATE INDEX generic_launch_reconciliation_attempts_v2_attempt_idx
   ON programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
   (attempted_at, approval_id);
 
+CREATE FUNCTION programmable_website_projection_v1.enforce_approval_v3_capacity_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog
+AS $capacity$
+BEGIN
+  IF NEW.lane <> 'website.approval-v3' THEN
+    RETURN NEW;
+  END IF;
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('programmable.website.approval-v3.capacity.v1', 0)
+  );
+  IF EXISTS (
+    SELECT 1
+      FROM programmable_website_projection_v1.projection_records existing
+     WHERE (existing.lane = NEW.lane
+       AND existing.projection_key = NEW.projection_key)
+        OR existing.idempotency_key = NEW.idempotency_key
+  ) THEN
+    RETURN NEW;
+  END IF;
+  IF (SELECT count(*)
+        FROM programmable_website_projection_v1.projection_records existing
+       WHERE existing.lane = 'website.approval-v3') >= 48 THEN
+    RAISE EXCEPTION 'website Approval v3 release capacity is exhausted'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END
+$capacity$;
+
+REVOKE ALL ON FUNCTION
+  programmable_website_projection_v1.enforce_approval_v3_capacity_v1()
+  FROM PUBLIC;
+
+DO $function_roles$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION programmable_website_projection_v1.enforce_approval_v3_capacity_v1() FROM anon';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION programmable_website_projection_v1.enforce_approval_v3_capacity_v1() FROM authenticated';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION programmable_website_projection_v1.enforce_approval_v3_capacity_v1() FROM service_role';
+  END IF;
+END
+$function_roles$;
+
+GRANT EXECUTE ON FUNCTION
+  programmable_website_projection_v1.enforce_approval_v3_capacity_v1()
+  TO programmable_website_projection_runtime;
+
+CREATE TRIGGER projection_records_approval_v3_capacity_v1
+BEFORE INSERT ON programmable_website_projection_v1.projection_records
+FOR EACH ROW EXECUTE FUNCTION
+  programmable_website_projection_v1.enforce_approval_v3_capacity_v1();
+
 ALTER TABLE programmable_website_projection_v1.generic_launch_materializations_v2
   ENABLE ROW LEVEL SECURITY;
 ALTER TABLE programmable_website_projection_v1.generic_launch_materializations_v2
@@ -178,7 +237,7 @@ GRANT SELECT, INSERT
 GRANT SELECT, INSERT
   ON programmable_website_projection_v1.generic_launch_reconciliations_v2
   TO programmable_website_projection_runtime;
-GRANT UPDATE (observation_common_head, observation_common_head_hash, observed_at)
+GRANT UPDATE (outcome, observation_common_head, observation_common_head_hash, observed_at)
   ON programmable_website_projection_v1.generic_launch_reconciliations_v2
   TO programmable_website_projection_runtime;
 

--- a/ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql
+++ b/ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql
@@ -34,7 +34,7 @@ CREATE TABLE programmable_website_projection_v1.generic_launch_materializations_
         AND source_projection_hash ~ '^sha256:[0-9a-f]{64}$'
         AND finalization_block IS NOT NULL)
       OR
-      (lifecycle_state = 'revoked'
+      (lifecycle_state IN ('revoked', 'invalidated')
         AND canonical_record IS NULL
         AND record_hash IS NULL
         AND source_projection_hash IS NULL

--- a/ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql
+++ b/ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql
@@ -1,0 +1,78 @@
+BEGIN;
+
+CREATE TABLE programmable_website_projection_v1.generic_launch_materializations_v2 (
+  approval_id text NOT NULL,
+  launch_id text NOT NULL,
+  descriptor_hash text NOT NULL,
+  lifecycle_generation numeric(78, 0) NOT NULL,
+  lifecycle_state text NOT NULL,
+  lifecycle_evidence_hash text NOT NULL,
+  canonical_record text,
+  record_hash text,
+  source_projection_hash text,
+  finalization_block numeric(78, 0),
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT generic_launch_materializations_v2_pk
+    PRIMARY KEY (launch_id, lifecycle_generation),
+  CONSTRAINT generic_launch_materializations_v2_lifecycle_unique
+    UNIQUE (launch_id, lifecycle_evidence_hash),
+  CONSTRAINT generic_launch_materializations_v2_approval_check
+    CHECK (approval_id ~ '^0x[0-9a-f]{64}$' AND approval_id !~ '^0x0{64}$'),
+  CONSTRAINT generic_launch_materializations_v2_launch_check
+    CHECK (launch_id ~ '^0x[0-9a-f]{64}$' AND launch_id !~ '^0x0{64}$'),
+  CONSTRAINT generic_launch_materializations_v2_descriptor_check
+    CHECK (descriptor_hash ~ '^0x[0-9a-f]{64}$' AND descriptor_hash !~ '^0x0{64}$'),
+  CONSTRAINT generic_launch_materializations_v2_generation_check
+    CHECK (lifecycle_generation >= 1),
+  CONSTRAINT generic_launch_materializations_v2_evidence_check
+    CHECK (lifecycle_evidence_hash ~ '^sha256:[0-9a-f]{64}$'),
+  CONSTRAINT generic_launch_materializations_v2_state_check
+    CHECK (
+      (lifecycle_state = 'finalized'
+        AND canonical_record IS NOT NULL
+        AND record_hash ~ '^sha256:[0-9a-f]{64}$'
+        AND source_projection_hash ~ '^sha256:[0-9a-f]{64}$'
+        AND finalization_block IS NOT NULL)
+      OR
+      (lifecycle_state = 'revoked'
+        AND canonical_record IS NULL
+        AND record_hash IS NULL
+        AND source_projection_hash IS NULL
+        AND finalization_block IS NULL)
+    )
+);
+
+CREATE UNIQUE INDEX generic_launch_materializations_v2_record_hash_unique
+  ON programmable_website_projection_v1.generic_launch_materializations_v2
+  (record_hash)
+  WHERE record_hash IS NOT NULL;
+
+CREATE INDEX generic_launch_materializations_v2_latest_idx
+  ON programmable_website_projection_v1.generic_launch_materializations_v2
+  (launch_id, lifecycle_generation DESC);
+
+CREATE INDEX generic_launch_materializations_v2_feed_idx
+  ON programmable_website_projection_v1.generic_launch_materializations_v2
+  (finalization_block DESC, record_hash DESC)
+  WHERE lifecycle_state = 'finalized';
+
+ALTER TABLE programmable_website_projection_v1.generic_launch_materializations_v2
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE programmable_website_projection_v1.generic_launch_materializations_v2
+  FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY generic_launch_materializations_v2_runtime_select
+  ON programmable_website_projection_v1.generic_launch_materializations_v2
+  FOR SELECT TO programmable_website_projection_runtime
+  USING (true);
+
+CREATE POLICY generic_launch_materializations_v2_runtime_insert
+  ON programmable_website_projection_v1.generic_launch_materializations_v2
+  FOR INSERT TO programmable_website_projection_runtime
+  WITH CHECK (true);
+
+GRANT SELECT, INSERT
+  ON programmable_website_projection_v1.generic_launch_materializations_v2
+  TO programmable_website_projection_runtime;
+
+COMMIT;

--- a/ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql
+++ b/ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql
@@ -14,8 +14,6 @@ CREATE TABLE programmable_website_projection_v1.generic_launch_materializations_
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   CONSTRAINT generic_launch_materializations_v2_pk
     PRIMARY KEY (launch_id, lifecycle_generation),
-  CONSTRAINT generic_launch_materializations_v2_lifecycle_unique
-    UNIQUE (launch_id, lifecycle_evidence_hash),
   CONSTRAINT generic_launch_materializations_v2_approval_check
     CHECK (approval_id ~ '^0x[0-9a-f]{64}$' AND approval_id !~ '^0x0{64}$'),
   CONSTRAINT generic_launch_materializations_v2_launch_check
@@ -42,7 +40,7 @@ CREATE TABLE programmable_website_projection_v1.generic_launch_materializations_
     )
 );
 
-CREATE UNIQUE INDEX generic_launch_materializations_v2_record_hash_unique
+CREATE INDEX generic_launch_materializations_v2_record_hash_idx
   ON programmable_website_projection_v1.generic_launch_materializations_v2
   (record_hash)
   WHERE record_hash IS NOT NULL;
@@ -56,23 +54,139 @@ CREATE INDEX generic_launch_materializations_v2_feed_idx
   (finalization_block DESC, record_hash DESC)
   WHERE lifecycle_state = 'finalized';
 
+CREATE TABLE programmable_website_projection_v1.generic_launch_reconciliations_v2 (
+  approval_id text PRIMARY KEY,
+  launch_id text NOT NULL,
+  descriptor_hash text NOT NULL,
+  outcome text NOT NULL,
+  observation_common_head numeric(78, 0) NOT NULL,
+  observation_common_head_hash text NOT NULL,
+  observed_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT generic_launch_reconciliations_v2_identity_check CHECK (
+    approval_id ~ '^0x[0-9a-f]{64}$' AND approval_id !~ '^0x0{64}$'
+    AND launch_id ~ '^0x[0-9a-f]{64}$' AND launch_id !~ '^0x0{64}$'
+    AND descriptor_hash ~ '^0x[0-9a-f]{64}$' AND descriptor_hash !~ '^0x0{64}$'
+  ),
+  CONSTRAINT generic_launch_reconciliations_v2_outcome_check CHECK (
+    outcome IN ('consumed', 'unconsumed')
+  ),
+  CONSTRAINT generic_launch_reconciliations_v2_observation_check CHECK (
+    observation_common_head >= 1
+    AND observation_common_head_hash ~ '^0x[0-9a-f]{64}$'
+  )
+);
+
+CREATE UNIQUE INDEX generic_launch_reconciliations_v2_consumed_launch_unique
+  ON programmable_website_projection_v1.generic_launch_reconciliations_v2
+  (launch_id)
+  WHERE outcome = 'consumed';
+
+CREATE INDEX generic_launch_reconciliations_v2_refresh_idx
+  ON programmable_website_projection_v1.generic_launch_reconciliations_v2
+  (observed_at, approval_id);
+
+CREATE TABLE programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2 (
+  approval_id text PRIMARY KEY,
+  attempted_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT generic_launch_reconciliation_attempts_v2_identity_check CHECK (
+    approval_id ~ '^0x[0-9a-f]{64}$' AND approval_id !~ '^0x0{64}$'
+  )
+);
+
+CREATE INDEX generic_launch_reconciliation_attempts_v2_attempt_idx
+  ON programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
+  (attempted_at, approval_id);
+
 ALTER TABLE programmable_website_projection_v1.generic_launch_materializations_v2
   ENABLE ROW LEVEL SECURITY;
 ALTER TABLE programmable_website_projection_v1.generic_launch_materializations_v2
   FORCE ROW LEVEL SECURITY;
+ALTER TABLE programmable_website_projection_v1.generic_launch_reconciliations_v2
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE programmable_website_projection_v1.generic_launch_reconciliations_v2
+  FORCE ROW LEVEL SECURITY;
+ALTER TABLE programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
+  FORCE ROW LEVEL SECURITY;
+
+REVOKE ALL ON programmable_website_projection_v1.generic_launch_materializations_v2
+  FROM PUBLIC;
+REVOKE ALL ON programmable_website_projection_v1.generic_launch_reconciliations_v2
+  FROM PUBLIC;
+REVOKE ALL ON programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
+  FROM PUBLIC;
+
+DO $roles$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    EXECUTE 'REVOKE ALL ON programmable_website_projection_v1.generic_launch_materializations_v2, programmable_website_projection_v1.generic_launch_reconciliations_v2, programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2 FROM anon';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    EXECUTE 'REVOKE ALL ON programmable_website_projection_v1.generic_launch_materializations_v2, programmable_website_projection_v1.generic_launch_reconciliations_v2, programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2 FROM authenticated';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    EXECUTE 'REVOKE ALL ON programmable_website_projection_v1.generic_launch_materializations_v2, programmable_website_projection_v1.generic_launch_reconciliations_v2, programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2 FROM service_role';
+  END IF;
+END
+$roles$;
 
 CREATE POLICY generic_launch_materializations_v2_runtime_select
   ON programmable_website_projection_v1.generic_launch_materializations_v2
-  FOR SELECT TO programmable_website_projection_runtime
+  AS PERMISSIVE FOR SELECT TO programmable_website_projection_runtime
   USING (true);
 
 CREATE POLICY generic_launch_materializations_v2_runtime_insert
   ON programmable_website_projection_v1.generic_launch_materializations_v2
-  FOR INSERT TO programmable_website_projection_runtime
+  AS PERMISSIVE FOR INSERT TO programmable_website_projection_runtime
   WITH CHECK (true);
+
+CREATE POLICY generic_launch_reconciliations_v2_runtime_select
+  ON programmable_website_projection_v1.generic_launch_reconciliations_v2
+  AS PERMISSIVE FOR SELECT TO programmable_website_projection_runtime
+  USING (true);
+
+CREATE POLICY generic_launch_reconciliations_v2_runtime_insert
+  ON programmable_website_projection_v1.generic_launch_reconciliations_v2
+  AS PERMISSIVE FOR INSERT TO programmable_website_projection_runtime
+  WITH CHECK (true);
+
+CREATE POLICY generic_launch_reconciliations_v2_runtime_update
+  ON programmable_website_projection_v1.generic_launch_reconciliations_v2
+  AS PERMISSIVE FOR UPDATE TO programmable_website_projection_runtime
+  USING (true) WITH CHECK (true);
+
+CREATE POLICY generic_launch_reconciliation_attempts_v2_runtime_select
+  ON programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
+  AS PERMISSIVE FOR SELECT TO programmable_website_projection_runtime
+  USING (true);
+
+CREATE POLICY generic_launch_reconciliation_attempts_v2_runtime_insert
+  ON programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
+  AS PERMISSIVE FOR INSERT TO programmable_website_projection_runtime
+  WITH CHECK (true);
+
+CREATE POLICY generic_launch_reconciliation_attempts_v2_runtime_update
+  ON programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
+  AS PERMISSIVE FOR UPDATE TO programmable_website_projection_runtime
+  USING (true) WITH CHECK (true);
 
 GRANT SELECT, INSERT
   ON programmable_website_projection_v1.generic_launch_materializations_v2
+  TO programmable_website_projection_runtime;
+
+GRANT SELECT, INSERT
+  ON programmable_website_projection_v1.generic_launch_reconciliations_v2
+  TO programmable_website_projection_runtime;
+GRANT UPDATE (observation_common_head, observation_common_head_hash, observed_at)
+  ON programmable_website_projection_v1.generic_launch_reconciliations_v2
+  TO programmable_website_projection_runtime;
+
+GRANT SELECT, INSERT
+  ON programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
+  TO programmable_website_projection_runtime;
+GRANT UPDATE (attempted_at)
+  ON programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2
   TO programmable_website_projection_runtime;
 
 COMMIT;

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -125,7 +125,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     }),
     store: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      sha256: "a35d911098359f970c4f49007760c8081fc0cbb94c45bdaa73a7884968c907c5",
+      sha256: "042bce5970388dfcde25ee8d5d70a04ef9072e8168e3efc83890e1c418a11c0c",
     }),
     registryReader: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -103,6 +103,33 @@ const APPROVED_OPERATIONS = Object.freeze({
       sha256: "bb498b00334df908029a588bec552516f281fdc0dfc3185bc5cd820984a9ee1f",
     }),
   }),
+  customLaunchReconciler: Object.freeze({
+    path: "/api/ops/custom-launch/generic-v2-projector",
+    schedule: "* * * * *",
+    authEnvironment: "CRON_SECRET",
+    maximumLifecycleAgeMs: 180_000,
+    batchLimit: 8,
+    route: Object.freeze({
+      path: "app/api/ops/custom-launch/generic-v2-projector/route.ts",
+      sha256: "ccf313d6f324391430d081254e4efa5cf7182ebbb812e2888dfd5d0add9bcc5e",
+    }),
+    runtime: Object.freeze({
+      path: "lib/server/custom-launch/generic-launch-production-v2.ts",
+      sha256: "0eafd50e7d224302d8c2202c637c9571b4e3a5e31623a3b36de175f281bc3517",
+    }),
+    store: Object.freeze({
+      path: "lib/server/custom-launch/generic-launch-postgres-v2.ts",
+      sha256: "5cbf187e029154dc23f0fcb1002602772494676560e79f596169ca5897718d21",
+    }),
+    registryReader: Object.freeze({
+      path: "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",
+      sha256: "fb3cd5afe33795385bdf0c598687b3cea7cc99788275fca06c7b65529d8950a6",
+    }),
+    migration: Object.freeze({
+      path: "ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql",
+      sha256: "65d2fcb192f56ab29f9621a3df19e79fcf9eaea7a5b6ec31d1b856124fc611d1",
+    }),
+  }),
   independentCrons: Object.freeze([
     Object.freeze({
       id: "protocol-revenue",
@@ -1441,11 +1468,14 @@ export function evaluateReadModelOperationsSourceContracts(
     ? operations.eventTriggers
     : [];
   const releaseGates = operations?.releaseGates;
+  const customLaunchReconciler = operations?.customLaunchReconciler;
   const unscheduled = Array.isArray(operations?.unscheduled)
     ? operations.unscheduled
     : [];
   const approvedCrons = new Map([
     [APPROVED_OPERATIONS.legacyIndexer.path, APPROVED_OPERATIONS.legacyIndexer.schedule],
+    [APPROVED_OPERATIONS.customLaunchReconciler.path,
+      APPROVED_OPERATIONS.customLaunchReconciler.schedule],
     ...APPROVED_OPERATIONS.workers.map((worker) => [worker.path, worker.schedule]),
     ...APPROVED_OPERATIONS.independentCrons.map((cron) => [cron.path, cron.schedule]),
   ]);
@@ -1454,10 +1484,50 @@ export function evaluateReadModelOperationsSourceContracts(
     "ops-config-schema",
     operations?.schemaVersion === 1 &&
       exactJson(operations?.legacyIndexer, APPROVED_OPERATIONS.legacyIndexer) &&
+      exactJson(customLaunchReconciler, APPROVED_OPERATIONS.customLaunchReconciler) &&
       exactJson(workers, APPROVED_OPERATIONS.workers) &&
       exactJson(eventTriggers, APPROVED_OPERATIONS.eventTriggers) &&
       exactJson(releaseGates, APPROVED_OPERATIONS.releaseGates),
     "the manifest exactly binds the reviewed indexers, workers, event trigger and release gates",
+  );
+  const customReconciler = APPROVED_OPERATIONS.customLaunchReconciler;
+  const customReconcilerRoute = source(customReconciler.route.path);
+  const customReconcilerRuntime = source(customReconciler.runtime.path);
+  check(
+    "ops-custom-launch-reconciler-schedule",
+    crons?.get(customReconciler.path) === customReconciler.schedule,
+    "Custom Launch V2 reconciliation has its fixed production schedule",
+  );
+  check(
+    "ops-custom-launch-reconciler-source-digests",
+    [customReconciler.route, customReconciler.runtime, customReconciler.store,
+      customReconciler.registryReader, customReconciler.migration].every(
+      (binding) => sourceBindingMatches(source, binding, expectedSha256Overrides),
+    ),
+    "Custom Launch V2 reconciler is byte-bound to route, runtime, store, Registry reader and migration",
+  );
+  check(
+    "ops-custom-launch-reconciler-route-auth",
+    customReconcilerRoute.includes(
+      `authorized(request.headers, process.env.${customReconciler.authEnvironment})`,
+    ) && /Buffer\.byteLength\(expectedValue,\s*["']utf8["']\)\s*<\s*32/u
+      .test(customReconcilerRoute) &&
+      /Buffer\.byteLength\(expectedValue,\s*["']utf8["']\)\s*>\s*1_024/u
+        .test(customReconcilerRoute) &&
+      /timingSafeEqual\(expected,\s*actual\)/u.test(customReconcilerRoute) &&
+      /response\(401,\s*["']unauthorized["']\)/u.test(customReconcilerRoute) &&
+      /response\(503,\s*["']reconciliation_unavailable["']\)/u
+        .test(customReconcilerRoute) &&
+      /["']cache-control["']:\s*["']no-store["']/u.test(customReconcilerRoute),
+    "Custom Launch V2 cron requires the bounded timing-safe cron secret",
+  );
+  check(
+    "ops-custom-launch-reconciler-freshness",
+    /GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS\s*=\s*180_000/u
+      .test(customReconcilerRuntime) &&
+      customReconciler.maximumLifecycleAgeMs === 180_000 &&
+      customReconcilerRoute.includes(`limit: ${customReconciler.batchLimit}`),
+    "Custom Launch V2 public reads fail closed on the reviewed lifecycle age and bounded sweep",
   );
   check(
     "ops-cron-exact-set",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -107,27 +107,32 @@ const APPROVED_OPERATIONS = Object.freeze({
     path: "/api/ops/custom-launch/generic-v2-projector",
     schedule: "* * * * *",
     authEnvironment: "CRON_SECRET",
-    maximumLifecycleAgeMs: 180_000,
-    batchLimit: 8,
+    maximumLifecycleAgeMs: 300_000,
+    refreshAfterMs: 60_000,
+    leaseMs: 55_000,
+    maximumApprovalInventory: 48,
+    batchLimit: 16,
+    concurrency: 8,
+    maximumInitialLogBlocks: 250_000,
     route: Object.freeze({
       path: "app/api/ops/custom-launch/generic-v2-projector/route.ts",
-      sha256: "ccf313d6f324391430d081254e4efa5cf7182ebbb812e2888dfd5d0add9bcc5e",
+      sha256: "d2f6509eba91dd5690e58d121daf4802aa1367b3807da31ed7ec060ba84b1f14",
     }),
     runtime: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-production-v2.ts",
-      sha256: "0eafd50e7d224302d8c2202c637c9571b4e3a5e31623a3b36de175f281bc3517",
+      sha256: "b70e8d1a904ed09b1161269b182af7b4e18c93d552acb6e94a5cc66d9d76a19b",
     }),
     store: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      sha256: "5cbf187e029154dc23f0fcb1002602772494676560e79f596169ca5897718d21",
+      sha256: "8874c3277a518c189c000d05cddef400d2cb0b7884fa7d730e2c5b3456cf438f",
     }),
     registryReader: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",
-      sha256: "fb3cd5afe33795385bdf0c598687b3cea7cc99788275fca06c7b65529d8950a6",
+      sha256: "08be733d2f6735d3198ec078b22d365e36f783d7ca4e7c11b804aaad04760898",
     }),
     migration: Object.freeze({
       path: "ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql",
-      sha256: "65d2fcb192f56ab29f9621a3df19e79fcf9eaea7a5b6ec31d1b856124fc611d1",
+      sha256: "cbc8140b7956f5abb6631a608f4e919102b468faac8c0efe9ad6802354e69f8f",
     }),
   }),
   independentCrons: Object.freeze([
@@ -1523,9 +1528,20 @@ export function evaluateReadModelOperationsSourceContracts(
   );
   check(
     "ops-custom-launch-reconciler-freshness",
-    /GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS\s*=\s*180_000/u
+    /GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS\s*=\s*300_000/u
       .test(customReconcilerRuntime) &&
-      customReconciler.maximumLifecycleAgeMs === 180_000 &&
+      /GENERIC_LAUNCH_LIFECYCLE_REFRESH_AFTER_MS\s*=\s*60_000/u
+        .test(customReconcilerRuntime) &&
+      /GENERIC_LAUNCH_RECONCILIATION_LEASE_MS\s*=\s*55_000/u
+        .test(customReconcilerRuntime) &&
+      /GENERIC_LAUNCH_RECONCILIATION_CONCURRENCY\s*=\s*8/u
+        .test(customReconcilerRuntime) &&
+      customReconciler.maximumLifecycleAgeMs === 300_000 &&
+      customReconciler.refreshAfterMs === 60_000 &&
+      customReconciler.leaseMs === 55_000 &&
+      customReconciler.maximumApprovalInventory === 48 &&
+      customReconciler.concurrency === 8 &&
+      customReconciler.maximumInitialLogBlocks === 250_000 &&
       customReconcilerRoute.includes(`limit: ${customReconciler.batchLimit}`),
     "Custom Launch V2 public reads fail closed on the reviewed lifecycle age and bounded sweep",
   );

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -125,7 +125,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     }),
     store: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      sha256: "80e9bbd9446b0bd4e7b9607fccacf3b7b42470b12ac0abd3b7638f693df5d16e",
+      sha256: "d542726f80bd816387240f1707e5934946b5dcf1cc9d69a015e08f3bb2d904be",
     }),
     registryReader: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -125,7 +125,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     }),
     store: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      sha256: "042bce5970388dfcde25ee8d5d70a04ef9072e8168e3efc83890e1c418a11c0c",
+      sha256: "80e9bbd9446b0bd4e7b9607fccacf3b7b42470b12ac0abd3b7638f693df5d16e",
     }),
     registryReader: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -125,7 +125,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     }),
     store: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      sha256: "5cdc8a5765816c3336d7af0aa490aaf420ec59ed65ffd16e8af25f170c8696c7",
+      sha256: "a35d911098359f970c4f49007760c8081fc0cbb94c45bdaa73a7884968c907c5",
     }),
     registryReader: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -113,7 +113,8 @@ const APPROVED_OPERATIONS = Object.freeze({
     maximumApprovalInventory: 48,
     batchLimit: 16,
     concurrency: 8,
-    maximumInitialLogBlocks: 250_000,
+    maximumInitialLogBlocks: 20_000,
+    maximumConcurrentLogRequests: 24,
     route: Object.freeze({
       path: "app/api/ops/custom-launch/generic-v2-projector/route.ts",
       sha256: "d2f6509eba91dd5690e58d121daf4802aa1367b3807da31ed7ec060ba84b1f14",
@@ -124,15 +125,15 @@ const APPROVED_OPERATIONS = Object.freeze({
     }),
     store: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      sha256: "8874c3277a518c189c000d05cddef400d2cb0b7884fa7d730e2c5b3456cf438f",
+      sha256: "5cdc8a5765816c3336d7af0aa490aaf420ec59ed65ffd16e8af25f170c8696c7",
     }),
     registryReader: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",
-      sha256: "08be733d2f6735d3198ec078b22d365e36f783d7ca4e7c11b804aaad04760898",
+      sha256: "a8b6607c641949ad384def4cb9b808233fecea37aadcd9517da69c9845a3dafd",
     }),
     migration: Object.freeze({
       path: "ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql",
-      sha256: "cbc8140b7956f5abb6631a608f4e919102b468faac8c0efe9ad6802354e69f8f",
+      sha256: "695328763c639b7d11562c394183864998e532eb6cc38d341020e8843de213b8",
     }),
   }),
   independentCrons: Object.freeze([
@@ -1541,7 +1542,12 @@ export function evaluateReadModelOperationsSourceContracts(
       customReconciler.leaseMs === 55_000 &&
       customReconciler.maximumApprovalInventory === 48 &&
       customReconciler.concurrency === 8 &&
-      customReconciler.maximumInitialLogBlocks === 250_000 &&
+      customReconciler.maximumInitialLogBlocks === 20_000 &&
+      customReconciler.maximumConcurrentLogRequests === 24 &&
+      /MAXIMUM_INITIAL_LOG_BLOCKS\s*=\s*20_000n/u
+        .test(source(customReconciler.registryReader.path)) &&
+      /MAXIMUM_CONCURRENT_LOG_REQUESTS\s*=\s*24/u
+        .test(source(customReconciler.registryReader.path)) &&
       customReconcilerRoute.includes(`limit: ${customReconciler.batchLimit}`),
     "Custom Launch V2 public reads fail closed on the reviewed lifecycle age and bounded sweep",
   );

--- a/tests/approval-v3-artifact-projection-target.test.ts
+++ b/tests/approval-v3-artifact-projection-target.test.ts
@@ -46,6 +46,14 @@ describe("Approval v3 Website artifact projection target", () => {
         .resolves.toBeUndefined();
       await database.exec(`
         RESET ROLE;
+        GRANT postgres TO service_role;
+        SET ROLE programmable_website_projection_runtime;
+      `);
+      await expect(assertApprovalV3ProjectionAdmissionReadyV1(pool))
+        .rejects.toThrow(/admission posture/u);
+      await database.exec(`
+        RESET ROLE;
+        REVOKE postgres FROM service_role;
         DROP TRIGGER projection_records_approval_v3_capacity_v1
           ON programmable_website_projection_v1.projection_records;
         SET ROLE programmable_website_projection_runtime;

--- a/tests/approval-v3-artifact-projection-target.test.ts
+++ b/tests/approval-v3-artifact-projection-target.test.ts
@@ -26,6 +26,8 @@ import {
   type ProjectionTargetPostgresPoolV1,
   type ProjectionTargetPostgresQueryResultV1,
 } from "../lib/server/projection-target/postgres-store";
+import { assertApprovalV3ProjectionAdmissionReadyV1 } from
+  "../lib/server/projection-target/approval-v3-target";
 
 const TARGET = digest("approval-v3-target");
 const AUDIENCE = "programmable.website.approval-v3";
@@ -35,6 +37,26 @@ const DESCRIPTOR_HASH = hash("2");
 const LAUNCH_ID = hash("3");
 
 describe("Approval v3 Website artifact projection target", () => {
+  it("fails ingress readiness when the exact Approval capacity fence is absent", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      await expect(assertApprovalV3ProjectionAdmissionReadyV1(pool))
+        .resolves.toBeUndefined();
+      await database.exec(`
+        RESET ROLE;
+        DROP TRIGGER projection_records_approval_v3_capacity_v1
+          ON programmable_website_projection_v1.projection_records;
+        SET ROLE programmable_website_projection_runtime;
+      `);
+      await expect(assertApprovalV3ProjectionAdmissionReadyV1(pool))
+        .rejects.toThrow(/storage posture/u);
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+
   it("durably acknowledges, exactly replays, and reads one authenticated artifact", async () => {
     const store = createInMemoryProjectionTargetAtomicStoreV1();
     const handler = target(store);
@@ -208,6 +230,8 @@ class TestPool implements ProjectionTargetPostgresPoolV1 {
       release() {},
     });
   }
+
+  async assertProductionReadiness(): Promise<void> {}
 
   async query<Row extends Record<string, unknown> = Record<string, unknown>>(
     text: string,

--- a/tests/approval-v3-artifact-projection-target.test.ts
+++ b/tests/approval-v3-artifact-projection-target.test.ts
@@ -181,6 +181,7 @@ async function migrate(database: PGlite): Promise<void> {
     "../ops/website-projection-target/migrations/0002_custom_launch_wallet_profile_v2.sql",
     "../ops/website-projection-target/migrations/0003_registry_custom_public_read_v1.sql",
     "../ops/website-projection-target/migrations/0004_approval_v3_artifacts_v1.sql",
+    "../ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql",
   ]) {
     await database.exec(await readFile(new URL(path, import.meta.url), "utf8"));
   }

--- a/tests/approval-v3-artifact-projection-target.test.ts
+++ b/tests/approval-v3-artifact-projection-target.test.ts
@@ -1,0 +1,355 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  canonicalizeJson,
+  type JsonValue,
+} from "../lib/server/projection-target/canonical-json";
+import {
+  canonicalSha256,
+  type Sha256Digest,
+} from "../lib/server/projection-target/hashing";
+import {
+  createInMemoryProjectionTargetAtomicStoreV1,
+  createProjectionTargetCredentialVerifierV1,
+  createProjectionTargetReferenceHandlerV1,
+  type ProjectionTargetCredentialVerificationRequestV1,
+  type ProjectionTargetAtomicStoreV1,
+} from "../lib/server/projection-target/protocol";
+import {
+  PostgresProjectionTargetAtomicStoreV1,
+  type ProjectionTargetPostgresClientV1,
+  type ProjectionTargetPostgresPoolV1,
+  type ProjectionTargetPostgresQueryResultV1,
+} from "../lib/server/projection-target/postgres-store";
+
+const TARGET = digest("approval-v3-target");
+const AUDIENCE = "programmable.website.approval-v3";
+const NOW = new Date("2026-08-13T22:00:00.000Z");
+const APPROVAL_ID = hash("1");
+const DESCRIPTOR_HASH = hash("2");
+const LAUNCH_ID = hash("3");
+
+describe("Approval v3 Website artifact projection target", () => {
+  it("durably acknowledges, exactly replays, and reads one authenticated artifact", async () => {
+    const store = createInMemoryProjectionTargetAtomicStoreV1();
+    const handler = target(store);
+    const write = projectionWrite();
+
+    const created = await handler.handle(putRequest(write, "put-created"));
+    const replayed = await handler.handle(putRequest(write, "put-created"));
+    const read = await handler.handle(getRequest(write.projectionKey, "get-readback"));
+
+    expect(created.status).toBe(201);
+    expect(replayed.status).toBe(200);
+    expect(await replayed.text()).toBe(await created.text());
+    expect(read.status).toBe(200);
+    await expect(read.json()).resolves.toEqual(expect.objectContaining({
+      schemaVersion: "programmable.approval-v3-artifact-projection-readback.v1",
+      projectionKind: "website.approval-v3",
+      projectionKey: write.projectionKey,
+      approvalId: APPROVAL_ID,
+      descriptorHash: DESCRIPTOR_HASH,
+      launchId: LAUNCH_ID,
+      authorization: write.authorization,
+      idempotencyKey: write.idempotencyKey,
+      requestDigest: write.requestDigest,
+    }));
+  });
+
+  it("conflicts when the same approval tuple is delivered with different bytes", async () => {
+    const store = createInMemoryProjectionTargetAtomicStoreV1();
+    const handler = target(store);
+    const original = projectionWrite();
+    const changed = projectionWrite({
+      registryObservationDigest: digest("changed-observation"),
+    });
+
+    expect((await handler.handle(putRequest(original, "put-original"))).status)
+      .toBe(201);
+    expect((await handler.handle(putRequest(changed, "put-conflict"))).status)
+      .toBe(409);
+  });
+
+  it("rejects artifact, evidence, tuple, and request hash substitution before persistence", async () => {
+    const store = createInMemoryProjectionTargetAtomicStoreV1();
+    const handler = target(store);
+    const valid = projectionWrite();
+    const mutations = [
+      { ...valid, approvalEvidenceHash: hash("f") },
+      { ...valid, descriptorHash: hash("e") },
+      { ...valid, launchId: hash("d") },
+      { ...valid, authorizationDigest: digest("forged-authorization") },
+      { ...valid, requestDigest: digest("forged-request") },
+      {
+        ...valid,
+        authorization: {
+          ...valid.authorization,
+          signedReceiptArtifactHash: digest("forged-artifact"),
+        },
+      },
+    ] as const;
+
+    for (const [index, mutation] of mutations.entries()) {
+      const response = await handler.handle(putRequest(
+        mutation as ApprovalV3ProjectionWrite,
+        `put-invalid-${index}`,
+      ));
+      expect(response.status).toBe(400);
+    }
+    const absent = await handler.handle(getRequest(valid.projectionKey, "get-absent"));
+    expect(absent.status).toBe(404);
+  });
+
+  it("requires the exact Approval workload principal and request-bound JWT", async () => {
+    const handler = target(createInMemoryProjectionTargetAtomicStoreV1());
+    const write = projectionWrite();
+    const forged = putRequest(write, "put-forged", "forged-approval-service");
+
+    expect((await handler.handle(forged)).status).toBe(401);
+  });
+
+  it("survives a Postgres store restart with an append-only exact readback", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      const write = projectionWrite();
+      const first = target(new PostgresProjectionTargetAtomicStoreV1(pool));
+      const created = await first.handle(putRequest(write, "postgres-put"));
+      expect(created.status).toBe(201);
+
+      const restarted = target(new PostgresProjectionTargetAtomicStoreV1(pool));
+      expect((await restarted.handle(putRequest(write, "postgres-put"))).status)
+        .toBe(200);
+      const read = await restarted.handle(getRequest(
+        write.projectionKey,
+        "postgres-get",
+      ));
+      expect(read.status).toBe(200);
+      expect((await read.json()).authorization).toEqual(write.authorization);
+      await expect(pool.query(`
+        UPDATE programmable_website_projection_v1.projection_records
+           SET canonical_readback = '{}'
+      `)).rejects.toThrow();
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+});
+
+type ApprovalV3ProjectionWrite = ReturnType<typeof projectionWrite>;
+
+function target(store: ProjectionTargetAtomicStoreV1) {
+  const verifier = createProjectionTargetCredentialVerifierV1({
+    verifierBindingHash: digest("approval-v3-verifier"),
+    async preflightBearer(input) {
+      return input.bearerToken.startsWith("approval-service:");
+    },
+    async verifyBearer(input) {
+      const [principalId, credentialId] = input.bearerToken.split(":");
+      if (principalId !== "approval-service" || !credentialId) return null;
+      return claims(input, principalId, credentialId);
+    },
+    now: () => NOW,
+  });
+  return createProjectionTargetReferenceHandlerV1({
+    lanes: [{
+      lane: "website.approval-v3",
+      targetBindingHash: TARGET,
+      audience: AUDIENCE,
+    }],
+    credentialVerifier: verifier,
+    store,
+    now: () => NOW,
+  });
+}
+
+async function migrate(database: PGlite): Promise<void> {
+  await database.exec(`
+    CREATE ROLE programmable_website_projection_runtime NOLOGIN;
+    CREATE ROLE anon NOLOGIN;
+    CREATE ROLE authenticated NOLOGIN;
+    CREATE ROLE service_role NOLOGIN;
+  `);
+  for (const path of [
+    "../ops/website-projection-target/migrations/0001_projection_records_v1.sql",
+    "../ops/website-projection-target/migrations/0002_custom_launch_wallet_profile_v2.sql",
+    "../ops/website-projection-target/migrations/0003_registry_custom_public_read_v1.sql",
+    "../ops/website-projection-target/migrations/0004_approval_v3_artifacts_v1.sql",
+  ]) {
+    await database.exec(await readFile(new URL(path, import.meta.url), "utf8"));
+  }
+  await database.exec(`
+    GRANT USAGE ON SCHEMA programmable_website_projection_v1
+      TO programmable_website_projection_runtime;
+    GRANT SELECT, INSERT
+      ON programmable_website_projection_v1.projection_records,
+         programmable_website_projection_v1.credential_uses
+      TO programmable_website_projection_runtime;
+    SET ROLE programmable_website_projection_runtime;
+  `);
+}
+
+class TestPool implements ProjectionTargetPostgresPoolV1 {
+  constructor(private readonly database: PGlite) {}
+
+  async connect(): Promise<ProjectionTargetPostgresClientV1> {
+    return Object.freeze({
+      query: <Row extends Record<string, unknown>>(
+        text: string,
+        values: readonly unknown[] = [],
+      ) => this.query<Row>(text, values),
+      release() {},
+    });
+  }
+
+  async query<Row extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    const result = await this.database.query<Row>(text, [...values]);
+    return Object.freeze({
+      rows: result.rows,
+      rowCount: result.affectedRows ?? result.rows.length,
+    });
+  }
+}
+
+function claims(
+  input: ProjectionTargetCredentialVerificationRequestV1,
+  principalId: string,
+  credentialId: string,
+) {
+  return {
+    schemaVersion: "programmable.projection-target-credential-claims.v2" as const,
+    principalId,
+    credentialId,
+    credentialTokenHash: digest(`credential:${credentialId}`),
+    method: input.method,
+    lane: input.lane,
+    audience: input.audience,
+    targetBindingHash: input.targetBindingHash,
+    projectionKey: input.projectionKey,
+    idempotencyKey: input.idempotencyKey,
+    requestDigest: input.requestDigest,
+    issuedAt: "2026-08-13T21:59:30.000Z",
+    expiresAt: "2026-08-13T22:05:00.000Z",
+  };
+}
+
+function projectionWrite(overrides: Readonly<{
+  registryObservationDigest?: Sha256Digest;
+}> = {}) {
+  const authorization = approvalAuthorization();
+  const signedReceiptArtifactHash = authorization.signedReceiptArtifactHash;
+  const approvalEvidenceHash = authorization.approvalEvidenceHash;
+  const authorizationDigest = rawDigest(authorization);
+  const registryObservationDigest =
+    overrides.registryObservationDigest ?? digest("registry-observation");
+  const idempotencyKey = canonicalSha256(
+    "programmable.approval-v3-website-artifact-idempotency.v1",
+    {
+      approvalId: APPROVAL_ID,
+      descriptorHash: DESCRIPTOR_HASH,
+      launchId: LAUNCH_ID,
+      signedReceiptArtifactHash,
+    },
+  );
+  const preimage = {
+    schemaVersion: "programmable.approval-v3-artifact-projection-write.v1" as const,
+    targetBindingHash: TARGET,
+    projectionKind: "website.approval-v3" as const,
+    projectionKey: `approval:${APPROVAL_ID}`,
+    approvalId: APPROVAL_ID,
+    descriptorHash: DESCRIPTOR_HASH,
+    launchId: LAUNCH_ID,
+    signedReceiptArtifactHash,
+    approvalEvidenceHash,
+    authorizationDigest,
+    registryObservationDigest,
+    idempotencyKey,
+    authorization,
+  };
+  return {
+    ...preimage,
+    requestDigest: canonicalSha256(preimage.schemaVersion, preimage),
+  };
+}
+
+function approvalAuthorization() {
+  const artifact = {
+    payload: {
+      schemaVersion: "programmable.approval-registry-descriptor-binding.v3",
+      authorization: { approvalId: APPROVAL_ID },
+      descriptorHash: DESCRIPTOR_HASH,
+      launchId: LAUNCH_ID,
+    },
+    envelope: {
+      schemaVersion: "1.0.0",
+      domain: "programmable.approval-registry-descriptor-binding.v3",
+      audience: "programmable.custom-registry.v2",
+    },
+  };
+  return {
+    artifact,
+    signedReceiptArtifactHash: rawDigest(artifact),
+    approvalEvidenceHash: `0x${rawDigest(artifact).slice(7)}`,
+  };
+}
+
+function putRequest(
+  write: ApprovalV3ProjectionWrite,
+  credentialId: string,
+  principal = "approval-service",
+): Request {
+  return new Request(
+    `https://website.invalid/v2/internal/projections/approval-descriptors/${encodeURIComponent(write.projectionKey)}`,
+    {
+      method: "PUT",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${principal}:${credentialId}`,
+        "content-type": "application/json; charset=utf-8",
+        "idempotency-key": write.idempotencyKey,
+        "x-programmable-audience": AUDIENCE,
+        "x-programmable-projection-kind": "website.approval-v3",
+        "x-programmable-target-binding": TARGET,
+      },
+      body: canonicalizeJson(write as unknown as JsonValue),
+    },
+  );
+}
+
+function getRequest(projectionKey: string, credentialId: string): Request {
+  return new Request(
+    `https://website.invalid/v2/internal/projections/approval-descriptors/${encodeURIComponent(projectionKey)}`,
+    {
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer approval-service:${credentialId}`,
+        "x-programmable-audience": AUDIENCE,
+        "x-programmable-projection-kind": "website.approval-v3",
+        "x-programmable-target-binding": TARGET,
+      },
+    },
+  );
+}
+
+function digest(label: string): Sha256Digest {
+  return canonicalSha256("programmable.approval-v3-target-test.v1", { label });
+}
+
+function hash(character: string): `0x${string}` {
+  return `0x${character.repeat(64)}`;
+}
+
+function rawDigest(value: unknown): Sha256Digest {
+  return `sha256:${createHash("sha256")
+    .update(canonicalizeJson(value as JsonValue), "utf8")
+    .digest("hex")}`;
+}

--- a/tests/generic-launch-postgres-v2.test.ts
+++ b/tests/generic-launch-postgres-v2.test.ts
@@ -329,7 +329,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         SET ROLE programmable_website_projection_runtime;
       `);
       await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
-        .rejects.toThrow(/storage posture/u);
+        .rejects.toThrow(/posture/u);
       await database.exec(`
         RESET ROLE;
         REVOKE TRUNCATE
@@ -340,7 +340,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         SET ROLE programmable_website_projection_runtime;
       `);
       await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
-        .rejects.toThrow(/storage posture/u);
+        .rejects.toThrow(/posture/u);
       await database.exec(`
         RESET ROLE;
         REVOKE hidden_bypass FROM programmable_website_projection_runtime;
@@ -401,6 +401,24 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
           AS RESTRICTIVE FOR SELECT TO programmable_website_projection_runtime
           USING (false);
       `,
+      `
+        CREATE FUNCTION programmable_website_projection_v1.mutate_approval_lane_v1()
+        RETURNS trigger LANGUAGE plpgsql AS $mutate$
+        BEGIN
+          NEW.lane := CASE WHEN NEW.lane = 'website.approval-v3'
+            THEN 'website.entitlement' ELSE 'website.approval-v3' END;
+          RETURN NEW;
+        END
+        $mutate$;
+        CREATE TRIGGER aaa_hide_approval_lane_v1
+        BEFORE INSERT ON programmable_website_projection_v1.projection_records
+        FOR EACH ROW EXECUTE FUNCTION
+          programmable_website_projection_v1.mutate_approval_lane_v1();
+        CREATE TRIGGER zzz_restore_approval_lane_v1
+        BEFORE INSERT ON programmable_website_projection_v1.projection_records
+        FOR EACH ROW EXECUTE FUNCTION
+          programmable_website_projection_v1.mutate_approval_lane_v1();
+      `,
     ];
     for (const mutation of mutations) {
       const database = new PGlite();
@@ -417,7 +435,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         await database.close();
       }
     }
-  }, 30_000);
+  }, 60_000);
 
   it("repairs a legacy partial lifecycle commit without changing its record", async () => {
     const database = new PGlite();

--- a/tests/generic-launch-postgres-v2.test.ts
+++ b/tests/generic-launch-postgres-v2.test.ts
@@ -51,6 +51,25 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         observationCommonHeadHash: hash("e"),
         signal,
       });
+      const competingApprovalId = hash("2");
+      await store.putApprovalReconciliation({
+        approvalId: competingApprovalId,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "unconsumed",
+        observationCommonHead: "80",
+        observationCommonHeadHash: hash("a"),
+        signal,
+      });
+      await store.putApprovalReconciliation({
+        approvalId: competingApprovalId,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "unconsumed",
+        observationCommonHead: "122",
+        observationCommonHeadHash: hash("b"),
+        signal,
+      });
       await expect(store.putApprovalReconciliation({
         approvalId: APPROVAL_ID,
         launchId: LAUNCH_ID,
@@ -313,48 +332,6 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         .rejects.toThrow(/storage posture/u);
       await database.exec(`
         RESET ROLE;
-        CREATE SCHEMA alternate_capacity;
-        CREATE FUNCTION alternate_capacity.enforce_approval_v3_capacity_v1()
-        RETURNS trigger LANGUAGE plpgsql AS $alternate$
-        BEGIN
-          RETURN NEW;
-        END
-        $alternate$;
-        DROP TRIGGER projection_records_approval_v3_capacity_v1
-          ON programmable_website_projection_v1.projection_records;
-        CREATE TRIGGER projection_records_approval_v3_capacity_v1
-        BEFORE INSERT ON programmable_website_projection_v1.projection_records
-        FOR EACH ROW EXECUTE FUNCTION
-          alternate_capacity.enforce_approval_v3_capacity_v1();
-        SET ROLE programmable_website_projection_runtime;
-      `);
-      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
-        .rejects.toThrow(/storage posture/u);
-      await database.exec(`
-        RESET ROLE;
-        DROP TRIGGER projection_records_approval_v3_capacity_v1
-          ON programmable_website_projection_v1.projection_records;
-        DROP FUNCTION alternate_capacity.enforce_approval_v3_capacity_v1();
-        DROP SCHEMA alternate_capacity;
-        CREATE OR REPLACE FUNCTION
-          programmable_website_projection_v1.enforce_approval_v3_capacity_v1()
-        RETURNS trigger LANGUAGE plpgsql SECURITY INVOKER
-        SET search_path = pg_catalog AS $no_op$
-        BEGIN
-          -- website.approval-v3 >= 48 pg_advisory_xact_lock
-          RETURN NEW;
-        END
-        $no_op$;
-        CREATE TRIGGER projection_records_approval_v3_capacity_v1
-        BEFORE INSERT ON programmable_website_projection_v1.projection_records
-        FOR EACH ROW EXECUTE FUNCTION
-          programmable_website_projection_v1.enforce_approval_v3_capacity_v1();
-        SET ROLE programmable_website_projection_runtime;
-      `);
-      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
-        .rejects.toThrow(/storage posture/u);
-      await database.exec(`
-        RESET ROLE;
         REVOKE TRUNCATE
           ON programmable_website_projection_v1.generic_launch_materializations_v2
           FROM PUBLIC;
@@ -378,6 +355,58 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
       await database.close();
     }
   }, 20_000);
+
+  it("binds the Approval capacity trigger to its exact function and no-WHEN execution", async () => {
+    const mutations = [
+      `
+        CREATE SCHEMA alternate_capacity;
+        CREATE FUNCTION alternate_capacity.enforce_approval_v3_capacity_v1()
+        RETURNS trigger LANGUAGE plpgsql AS $alternate$
+        BEGIN RETURN NEW; END
+        $alternate$;
+        DROP TRIGGER projection_records_approval_v3_capacity_v1
+          ON programmable_website_projection_v1.projection_records;
+        CREATE TRIGGER projection_records_approval_v3_capacity_v1
+        BEFORE INSERT ON programmable_website_projection_v1.projection_records
+        FOR EACH ROW EXECUTE FUNCTION
+          alternate_capacity.enforce_approval_v3_capacity_v1();
+      `,
+      `
+        CREATE OR REPLACE FUNCTION
+          programmable_website_projection_v1.enforce_approval_v3_capacity_v1()
+        RETURNS trigger LANGUAGE plpgsql SECURITY INVOKER
+        SET search_path = pg_catalog AS $no_op$
+        BEGIN
+          -- website.approval-v3 >= 48 pg_advisory_xact_lock
+          RETURN NEW;
+        END
+        $no_op$;
+      `,
+      `
+        DROP TRIGGER projection_records_approval_v3_capacity_v1
+          ON programmable_website_projection_v1.projection_records;
+        CREATE TRIGGER projection_records_approval_v3_capacity_v1
+        BEFORE INSERT ON programmable_website_projection_v1.projection_records
+        FOR EACH ROW WHEN (false) EXECUTE FUNCTION
+          programmable_website_projection_v1.enforce_approval_v3_capacity_v1();
+      `,
+    ];
+    for (const mutation of mutations) {
+      const database = new PGlite();
+      try {
+        await migrate(database);
+        const pool = new TestPool(database);
+        await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+          .resolves.toBeUndefined();
+        await database.exec(`RESET ROLE; ${mutation}
+          SET ROLE programmable_website_projection_runtime;`);
+        await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+          .rejects.toThrow(/storage posture/u);
+      } finally {
+        await database.close();
+      }
+    }
+  }, 30_000);
 
   it("repairs a legacy partial lifecycle commit without changing its record", async () => {
     const database = new PGlite();

--- a/tests/generic-launch-postgres-v2.test.ts
+++ b/tests/generic-launch-postgres-v2.test.ts
@@ -16,8 +16,10 @@ import type {
 import { createGenericLaunchRecordV2 } from
   "../lib/server/custom-launch/generic-launch-contract-v2";
 import {
+  assertPostgresGenericLaunchReadStoreReadyV2,
   createPostgresGenericLaunchMaterializationStoreV2,
   createPostgresGenericLaunchReadStoreV2,
+  listStaleGenericLaunchApprovalsV2,
 } from "../lib/server/custom-launch/generic-launch-postgres-v2";
 
 const sha = (value: string) => `sha256:${value.repeat(64)}` as const;
@@ -58,10 +60,13 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         record,
         signal,
       })).kind).toBe("existing");
+      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+        .resolves.toBeUndefined();
 
       const signedPayloads: JsonValue[] = [];
       const readStore = createPostgresGenericLaunchReadStoreV2({
         pool,
+        maximumLifecycleAgeMs: 180_000,
         signer: {
           binding: {} as never,
           async sign({ payload }) {
@@ -104,6 +109,107 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         UPDATE programmable_website_projection_v1.generic_launch_materializations_v2
            SET lifecycle_state = 'finalized'
       `)).rejects.toThrow();
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+
+  it("rejects hosted RLS, policy or grant drift", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      await insertApproval(pool);
+      const store = createPostgresGenericLaunchMaterializationStoreV2(pool);
+      await store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("a"),
+        state: "finalized",
+        record: launchRecord(),
+        signal: new AbortController().signal,
+      });
+      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+        .resolves.toBeUndefined();
+      await database.exec(`
+        RESET ROLE;
+        DROP POLICY generic_launch_materializations_v2_runtime_insert
+          ON programmable_website_projection_v1.generic_launch_materializations_v2;
+        SET ROLE programmable_website_projection_runtime;
+      `);
+      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+        .rejects.toThrow(/storage posture/u);
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+
+  it("fails closed on a stale lifecycle until the approval is reconciled", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      await insertApproval(pool);
+      const store = createPostgresGenericLaunchMaterializationStoreV2(pool);
+      const record = launchRecord();
+      const signal = new AbortController().signal;
+      await store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("a"),
+        state: "finalized",
+        record,
+        signal,
+      });
+      await database.exec(`
+        RESET ROLE;
+        UPDATE programmable_website_projection_v1.generic_launch_materializations_v2
+           SET created_at = clock_timestamp() - interval '4 minutes';
+        SET ROLE programmable_website_projection_runtime;
+      `);
+      const readStore = createPostgresGenericLaunchReadStoreV2({
+        pool,
+        maximumLifecycleAgeMs: 180_000,
+        signer: {
+          binding: {} as never,
+          async sign({ payload }) { return canonicalizeJson(payload); },
+        },
+        readModelContract: readContract(),
+      });
+
+      await expect(readStore.findFinalizedLaunches({
+        limit: 10, requestBindingHash: sha("b"), signal,
+      })).rejects.toThrow(/stale/u);
+      await expect(readStore.findFinalizedLaunchByRecordHash({
+        recordHash: record.recordHash, requestBindingHash: sha("c"), signal,
+      })).rejects.toThrow(/stale/u);
+      expect(await listStaleGenericLaunchApprovalsV2(pool, {
+        maximumLifecycleAgeMs: 180_000,
+        limit: 8,
+        signal,
+      })).toEqual([APPROVAL_ID]);
+
+      await store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("d"),
+        state: "revoked",
+        record: null,
+        signal,
+      });
+      expect(await listStaleGenericLaunchApprovalsV2(pool, {
+        maximumLifecycleAgeMs: 180_000,
+        limit: 8,
+        signal,
+      })).toEqual([]);
+      await expect(readStore.findFinalizedLaunches({
+        limit: 10, requestBindingHash: sha("e"), signal,
+      })).resolves.toBe(canonicalizeJson({
+        records: [], nextCursor: null, total: "0",
+      }));
     } finally {
       await database.close();
     }

--- a/tests/generic-launch-postgres-v2.test.ts
+++ b/tests/generic-launch-postgres-v2.test.ts
@@ -34,6 +34,83 @@ const LIFECYCLE_OBSERVATION = Object.freeze({
 });
 
 describe("Generic launch V2 Postgres materialization/read store", () => {
+  it("rejects regressed or conflicting observation heads under the lifecycle lock", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      await insertApproval(pool);
+      const store = createPostgresGenericLaunchMaterializationStoreV2(pool);
+      const signal = new AbortController().signal;
+      await store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "unconsumed",
+        observationCommonHead: "120",
+        observationCommonHeadHash: hash("e"),
+        signal,
+      });
+      await expect(store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "unconsumed",
+        observationCommonHead: "119",
+        observationCommonHeadHash: hash("d"),
+        signal,
+      })).rejects.toThrow(/observation head regressed/u);
+      await expect(store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "unconsumed",
+        observationCommonHead: "120",
+        observationCommonHeadHash: hash("f"),
+        signal,
+      })).rejects.toThrow(/observation head conflicted/u);
+
+      await store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("a"),
+        state: "finalized",
+        record: launchRecord(),
+        observationCommonHead: "121",
+        observationCommonHeadHash: hash("1"),
+        signal,
+      });
+      await expect(store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("b"),
+        state: "revoked",
+        record: null,
+        observationCommonHead: "120",
+        observationCommonHeadHash: hash("e"),
+        signal,
+      })).rejects.toThrow(/observation head regressed/u);
+      await expect(store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("b"),
+        state: "revoked",
+        record: null,
+        observationCommonHead: "121",
+        observationCommonHeadHash: hash("2"),
+        signal,
+      })).rejects.toThrow(/observation head conflicted/u);
+
+      expect(await store.getLatestLifecycle({ launchId: LAUNCH_ID, signal }))
+        .toMatchObject({ state: "finalized", lifecycleEvidenceHash: sha("a") });
+    } finally {
+      await database.close();
+    }
+  });
+
   it("appends lifecycle generations and hides finalized bytes after revocation", async () => {
     const database = new PGlite();
     try {
@@ -230,6 +307,48 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         GRANT TRUNCATE
           ON programmable_website_projection_v1.generic_launch_materializations_v2
           TO PUBLIC;
+        SET ROLE programmable_website_projection_runtime;
+      `);
+      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+        .rejects.toThrow(/storage posture/u);
+      await database.exec(`
+        RESET ROLE;
+        CREATE SCHEMA alternate_capacity;
+        CREATE FUNCTION alternate_capacity.enforce_approval_v3_capacity_v1()
+        RETURNS trigger LANGUAGE plpgsql AS $alternate$
+        BEGIN
+          RETURN NEW;
+        END
+        $alternate$;
+        DROP TRIGGER projection_records_approval_v3_capacity_v1
+          ON programmable_website_projection_v1.projection_records;
+        CREATE TRIGGER projection_records_approval_v3_capacity_v1
+        BEFORE INSERT ON programmable_website_projection_v1.projection_records
+        FOR EACH ROW EXECUTE FUNCTION
+          alternate_capacity.enforce_approval_v3_capacity_v1();
+        SET ROLE programmable_website_projection_runtime;
+      `);
+      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+        .rejects.toThrow(/storage posture/u);
+      await database.exec(`
+        RESET ROLE;
+        DROP TRIGGER projection_records_approval_v3_capacity_v1
+          ON programmable_website_projection_v1.projection_records;
+        DROP FUNCTION alternate_capacity.enforce_approval_v3_capacity_v1();
+        DROP SCHEMA alternate_capacity;
+        CREATE OR REPLACE FUNCTION
+          programmable_website_projection_v1.enforce_approval_v3_capacity_v1()
+        RETURNS trigger LANGUAGE plpgsql SECURITY INVOKER
+        SET search_path = pg_catalog AS $no_op$
+        BEGIN
+          -- website.approval-v3 >= 48 pg_advisory_xact_lock
+          RETURN NEW;
+        END
+        $no_op$;
+        CREATE TRIGGER projection_records_approval_v3_capacity_v1
+        BEFORE INSERT ON programmable_website_projection_v1.projection_records
+        FOR EACH ROW EXECUTE FUNCTION
+          programmable_website_projection_v1.enforce_approval_v3_capacity_v1();
         SET ROLE programmable_website_projection_runtime;
       `);
       await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))

--- a/tests/generic-launch-postgres-v2.test.ts
+++ b/tests/generic-launch-postgres-v2.test.ts
@@ -28,6 +28,10 @@ const address = (value: string) => `0x${value.repeat(40)}` as const;
 const APPROVAL_ID = hash("1");
 const LAUNCH_ID = hash("4");
 const DESCRIPTOR_HASH = hash("3");
+const LIFECYCLE_OBSERVATION = Object.freeze({
+  observationCommonHead: "112",
+  observationCommonHeadHash: hash("e"),
+});
 
 describe("Generic launch V2 Postgres materialization/read store", () => {
   it("appends lifecycle generations and hides finalized bytes after revocation", async () => {
@@ -45,6 +49,15 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
           authorization: { artifact: { accepted: true } },
           receivedAt: expect.any(Date),
         });
+      await store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "unconsumed",
+        observationCommonHead: "90",
+        observationCommonHeadHash: hash("d"),
+        signal,
+      });
       expect((await store.putIfNewLifecycle({
         approvalId: APPROVAL_ID,
         launchId: LAUNCH_ID,
@@ -52,6 +65,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         lifecycleEvidenceHash: sha("a"),
         state: "finalized",
         record,
+        ...LIFECYCLE_OBSERVATION,
         signal,
       })).kind).toBe("created");
       expect((await store.putIfNewLifecycle({
@@ -61,6 +75,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         lifecycleEvidenceHash: sha("a"),
         state: "finalized",
         record,
+        ...LIFECYCLE_OBSERVATION,
         signal,
       })).kind).toBe("existing");
       await store.putApprovalReconciliation({
@@ -72,6 +87,15 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         observationCommonHeadHash: hash("e"),
         signal,
       });
+      await expect(store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "unconsumed",
+        observationCommonHead: "113",
+        observationCommonHeadHash: hash("f"),
+        signal,
+      })).rejects.toThrow(/identity conflicted/u);
       await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
         .resolves.toBeUndefined();
 
@@ -104,6 +128,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         lifecycleEvidenceHash: sha("f"),
         state: "revoked",
         record: null,
+        ...LIFECYCLE_OBSERVATION,
         signal,
       })).rejects.toThrow(/canonical lifecycle identity/u);
 
@@ -114,6 +139,8 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         lifecycleEvidenceHash: sha("d"),
         state: "revoked",
         record: null,
+        observationCommonHead: "120",
+        observationCommonHeadHash: hash("f"),
         signal,
       })).kind).toBe("created");
       await store.putApprovalReconciliation({
@@ -143,6 +170,8 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         lifecycleEvidenceHash: sha("a"),
         state: "finalized",
         record,
+        observationCommonHead: "124",
+        observationCommonHeadHash: hash("9"),
         signal,
       })).kind).toBe("created");
       await store.putApprovalReconciliation({
@@ -182,6 +211,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         lifecycleEvidenceHash: sha("a"),
         state: "finalized",
         record: launchRecord(),
+        ...LIFECYCLE_OBSERVATION,
         signal: new AbortController().signal,
       });
       await store.putApprovalReconciliation({
@@ -209,12 +239,101 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         REVOKE TRUNCATE
           ON programmable_website_projection_v1.generic_launch_materializations_v2
           FROM PUBLIC;
+        CREATE ROLE hidden_bypass NOLOGIN BYPASSRLS;
+        GRANT hidden_bypass TO programmable_website_projection_runtime;
+        SET ROLE programmable_website_projection_runtime;
+      `);
+      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+        .rejects.toThrow(/storage posture/u);
+      await database.exec(`
+        RESET ROLE;
+        REVOKE hidden_bypass FROM programmable_website_projection_runtime;
+        DROP ROLE hidden_bypass;
         DROP POLICY generic_launch_materializations_v2_runtime_insert
           ON programmable_website_projection_v1.generic_launch_materializations_v2;
         SET ROLE programmable_website_projection_runtime;
       `);
       await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
         .rejects.toThrow(/storage posture/u);
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+
+  it("repairs a legacy partial lifecycle commit without changing its record", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      await insertApproval(pool);
+      const record = launchRecord();
+      await database.exec("RESET ROLE");
+      await pool.query(`
+        INSERT INTO programmable_website_projection_v1.generic_launch_materializations_v2
+          (approval_id, launch_id, descriptor_hash, lifecycle_generation,
+           lifecycle_state, lifecycle_evidence_hash, canonical_record,
+           record_hash, source_projection_hash, finalization_block)
+        VALUES ($1, $2, $3, 1, 'finalized', $4, $5, $6, $7, 100)
+      `, [APPROVAL_ID, LAUNCH_ID, DESCRIPTOR_HASH, sha("a"),
+        canonicalizeJson(record as unknown as JsonValue), record.recordHash,
+        record.sourceProjectionHash]);
+      await database.exec("SET ROLE programmable_website_projection_runtime");
+      const store = createPostgresGenericLaunchMaterializationStoreV2(pool);
+      const signal = new AbortController().signal;
+      expect(await store.getLatestLifecycle({ launchId: LAUNCH_ID, signal }))
+        .toMatchObject({
+          recordHash: record.recordHash,
+          observationCommonHead: "112",
+          observationCommonHeadHash: hash("e"),
+        });
+      expect((await store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("a"),
+        state: "finalized",
+        record,
+        ...LIFECYCLE_OBSERVATION,
+        signal,
+      })).kind).toBe("existing");
+      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+        .resolves.toBeUndefined();
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+
+  it("rolls back materialization when its consumed checkpoint conflicts", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      await insertApproval(pool);
+      const store = createPostgresGenericLaunchMaterializationStoreV2(pool);
+      const signal = new AbortController().signal;
+      await store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: hash("8"),
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "unconsumed",
+        ...LIFECYCLE_OBSERVATION,
+        signal,
+      });
+      await expect(store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("a"),
+        state: "finalized",
+        record: launchRecord(),
+        ...LIFECYCLE_OBSERVATION,
+        signal,
+      })).rejects.toThrow(/identity conflicted/u);
+      const rows = await pool.query<{ total: unknown }>(`
+        SELECT count(*)::text AS total
+          FROM programmable_website_projection_v1.generic_launch_materializations_v2
+      `);
+      expect(rows.rows[0]?.total).toBe("0");
     } finally {
       await database.close();
     }
@@ -235,6 +354,21 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
       `);
       await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
         .rejects.toThrow(/stale/u);
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+
+  it("rejects delivery before exceeding the explicit release inventory", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      for (let index = 1; index <= 48; index += 1) {
+        await insertApproval(pool, hexHash(index), String(100 + index));
+      }
+      await expect(insertApproval(pool, hexHash(49), "149"))
+        .rejects.toThrow(/capacity is exhausted/u);
     } finally {
       await database.close();
     }
@@ -282,6 +416,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         lifecycleEvidenceHash: sha("a"),
         state: "finalized",
         record,
+        ...LIFECYCLE_OBSERVATION,
         signal,
       });
       await store.putApprovalReconciliation({
@@ -329,6 +464,8 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         lifecycleEvidenceHash: sha("d"),
         state: "revoked",
         record: null,
+        observationCommonHead: "120",
+        observationCommonHeadHash: hash("f"),
         signal,
       });
       await store.putApprovalReconciliation({
@@ -448,8 +585,18 @@ async function insertApproval(
        request_digest, canonical_write, canonical_acknowledgement,
        canonical_readback, record_binding_hash)
     VALUES ('website.approval-v3', $1, 'approval', $2, $3, $4, $5, $6, $7, $8)
-  `, [sha("1"), `approval:${approvalId}`, sha(salt), sha(`${Number(salt) + 1}`), write,
-    acknowledgement, readback, sha(`${Number(salt) + 2}`)]);
+  `, [sha("1"), `approval:${approvalId}`, uniqueDigest(salt, 0),
+    uniqueDigest(salt, 1), write, acknowledgement, readback,
+    uniqueDigest(salt, 2)]);
+}
+
+function uniqueDigest(salt: string, offset: number): `sha256:${string}` {
+  const value = BigInt(salt) + BigInt(offset);
+  return `sha256:${value.toString(16).padStart(64, "0")}`;
+}
+
+function hexHash(value: number): `0x${string}` {
+  return `0x${value.toString(16).padStart(64, "0")}`;
 }
 
 async function migrate(database: PGlite) {

--- a/tests/generic-launch-postgres-v2.test.ts
+++ b/tests/generic-launch-postgres-v2.test.ts
@@ -41,7 +41,10 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
       const signal = new AbortController().signal;
 
       expect(await store.getApprovalAuthorization({ approvalId: APPROVAL_ID, signal }))
-        .toEqual({ artifact: { accepted: true } });
+        .toMatchObject({
+          authorization: { artifact: { accepted: true } },
+          receivedAt: expect.any(Date),
+        });
       expect((await store.putIfNewLifecycle({
         approvalId: APPROVAL_ID,
         launchId: LAUNCH_ID,
@@ -60,6 +63,15 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         record,
         signal,
       })).kind).toBe("existing");
+      await store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "consumed",
+        observationCommonHead: "112",
+        observationCommonHeadHash: hash("e"),
+        signal,
+      });
       await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
         .resolves.toBeUndefined();
 
@@ -85,6 +97,16 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
       expect(signedPayloads[0]).toMatchObject({ records: [record], total: "1" });
       expect(signedPayloads[1]).toEqual(record);
 
+      await expect(store.putIfNewLifecycle({
+        approvalId: hash("f"),
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("f"),
+        state: "revoked",
+        record: null,
+        signal,
+      })).rejects.toThrow(/canonical lifecycle identity/u);
+
       expect((await store.putIfNewLifecycle({
         approvalId: APPROVAL_ID,
         launchId: LAUNCH_ID,
@@ -94,6 +116,15 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         record: null,
         signal,
       })).kind).toBe("created");
+      await store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "consumed",
+        observationCommonHead: "120",
+        observationCommonHeadHash: hash("f"),
+        signal,
+      });
       signedPayloads.length = 0;
       await readStore.findFinalizedLaunches({
         limit: 10, requestBindingHash: sha("e"), signal,
@@ -105,6 +136,29 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         { records: [], nextCursor: null, total: "0" },
         null,
       ]);
+      expect((await store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("a"),
+        state: "finalized",
+        record,
+        signal,
+      })).kind).toBe("created");
+      await store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "consumed",
+        observationCommonHead: "124",
+        observationCommonHeadHash: hash("9"),
+        signal,
+      });
+      signedPayloads.length = 0;
+      await readStore.findFinalizedLaunchByRecordHash({
+        recordHash: record.recordHash, requestBindingHash: sha("9"), signal,
+      });
+      expect(signedPayloads).toEqual([record]);
       await expect(pool.query(`
         UPDATE programmable_website_projection_v1.generic_launch_materializations_v2
            SET lifecycle_state = 'finalized'
@@ -130,16 +184,83 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         record: launchRecord(),
         signal: new AbortController().signal,
       });
+      await store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "consumed",
+        observationCommonHead: "112",
+        observationCommonHeadHash: hash("e"),
+        signal: new AbortController().signal,
+      });
       await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
         .resolves.toBeUndefined();
       await database.exec(`
         RESET ROLE;
+        GRANT TRUNCATE
+          ON programmable_website_projection_v1.generic_launch_materializations_v2
+          TO PUBLIC;
+        SET ROLE programmable_website_projection_runtime;
+      `);
+      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+        .rejects.toThrow(/storage posture/u);
+      await database.exec(`
+        RESET ROLE;
+        REVOKE TRUNCATE
+          ON programmable_website_projection_v1.generic_launch_materializations_v2
+          FROM PUBLIC;
         DROP POLICY generic_launch_materializations_v2_runtime_insert
           ON programmable_website_projection_v1.generic_launch_materializations_v2;
         SET ROLE programmable_website_projection_runtime;
       `);
       await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
         .rejects.toThrow(/storage posture/u);
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+
+  it("fails closed on an old delivered Approval with no materialization", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      await insertApproval(pool);
+      await database.exec(`
+        RESET ROLE;
+        UPDATE programmable_website_projection_v1.projection_records
+           SET created_at = clock_timestamp() - interval '4 minutes'
+         WHERE lane = 'website.approval-v3';
+        SET ROLE programmable_website_projection_runtime;
+      `);
+      await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
+        .rejects.toThrow(/stale/u);
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+
+  it("claims due Approvals fairly even when the first attempt fails", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      const secondApprovalId = hash("2");
+      await insertApproval(pool);
+      await insertApproval(pool, secondApprovalId, "5");
+      const signal = new AbortController().signal;
+      expect(await listStaleGenericLaunchApprovalsV2(pool, {
+        refreshAfterMs: 60_000,
+        leaseMs: 55_000,
+        limit: 1,
+        signal,
+      })).toEqual([APPROVAL_ID]);
+      expect(await listStaleGenericLaunchApprovalsV2(pool, {
+        refreshAfterMs: 60_000,
+        leaseMs: 55_000,
+        limit: 1,
+        signal,
+      })).toEqual([secondApprovalId]);
     } finally {
       await database.close();
     }
@@ -163,10 +284,19 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         record,
         signal,
       });
+      await store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "consumed",
+        observationCommonHead: "112",
+        observationCommonHeadHash: hash("e"),
+        signal,
+      });
       await database.exec(`
         RESET ROLE;
-        UPDATE programmable_website_projection_v1.generic_launch_materializations_v2
-           SET created_at = clock_timestamp() - interval '4 minutes';
+        UPDATE programmable_website_projection_v1.generic_launch_reconciliations_v2
+           SET observed_at = clock_timestamp() - interval '4 minutes';
         SET ROLE programmable_website_projection_runtime;
       `);
       const readStore = createPostgresGenericLaunchReadStoreV2({
@@ -186,7 +316,8 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         recordHash: record.recordHash, requestBindingHash: sha("c"), signal,
       })).rejects.toThrow(/stale/u);
       expect(await listStaleGenericLaunchApprovalsV2(pool, {
-        maximumLifecycleAgeMs: 180_000,
+        refreshAfterMs: 60_000,
+        leaseMs: 55_000,
         limit: 8,
         signal,
       })).toEqual([APPROVAL_ID]);
@@ -200,8 +331,18 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         record: null,
         signal,
       });
+      await store.putApprovalReconciliation({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        outcome: "consumed",
+        observationCommonHead: "120",
+        observationCommonHeadHash: hash("f"),
+        signal,
+      });
       expect(await listStaleGenericLaunchApprovalsV2(pool, {
-        maximumLifecycleAgeMs: 180_000,
+        refreshAfterMs: 60_000,
+        leaseMs: 55_000,
         limit: 8,
         signal,
       })).toEqual([]);
@@ -289,10 +430,14 @@ function readContract() {
   };
 }
 
-async function insertApproval(pool: TestPool) {
+async function insertApproval(
+  pool: TestPool,
+  approvalId: `0x${string}` = APPROVAL_ID,
+  salt = "2",
+) {
   const readback = canonicalizeJson({
     schemaVersion: "programmable.approval-v3-artifact-projection-readback.v1",
-    approvalId: APPROVAL_ID,
+    approvalId,
     authorization: { artifact: { accepted: true } },
   });
   const acknowledgement = canonicalizeJson({ acknowledged: true });
@@ -303,8 +448,8 @@ async function insertApproval(pool: TestPool) {
        request_digest, canonical_write, canonical_acknowledgement,
        canonical_readback, record_binding_hash)
     VALUES ('website.approval-v3', $1, 'approval', $2, $3, $4, $5, $6, $7, $8)
-  `, [sha("1"), `approval:${APPROVAL_ID}`, sha("2"), sha("3"), write,
-    acknowledgement, readback, sha("4")]);
+  `, [sha("1"), `approval:${approvalId}`, sha(salt), sha(`${Number(salt) + 1}`), write,
+    acknowledgement, readback, sha(`${Number(salt) + 2}`)]);
 }
 
 async function migrate(database: PGlite) {

--- a/tests/generic-launch-postgres-v2.test.ts
+++ b/tests/generic-launch-postgres-v2.test.ts
@@ -1,0 +1,245 @@
+import { readFile } from "node:fs/promises";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { canonicalizeJson, type JsonValue } from
+  "../lib/server/projection-target/canonical-json";
+import { canonicalSha256 } from
+  "../lib/server/projection-target/hashing";
+import type {
+  ProjectionTargetPostgresClientV1,
+  ProjectionTargetPostgresPoolV1,
+  ProjectionTargetPostgresQueryResultV1,
+} from "../lib/server/projection-target/postgres-store";
+import { createGenericLaunchRecordV2 } from
+  "../lib/server/custom-launch/generic-launch-contract-v2";
+import {
+  createPostgresGenericLaunchMaterializationStoreV2,
+  createPostgresGenericLaunchReadStoreV2,
+} from "../lib/server/custom-launch/generic-launch-postgres-v2";
+
+const sha = (value: string) => `sha256:${value.repeat(64)}` as const;
+const hash = (value: string) => `0x${value.repeat(64)}` as const;
+const address = (value: string) => `0x${value.repeat(40)}` as const;
+const APPROVAL_ID = hash("1");
+const LAUNCH_ID = hash("4");
+const DESCRIPTOR_HASH = hash("3");
+
+describe("Generic launch V2 Postgres materialization/read store", () => {
+  it("appends lifecycle generations and hides finalized bytes after revocation", async () => {
+    const database = new PGlite();
+    try {
+      await migrate(database);
+      const pool = new TestPool(database);
+      await insertApproval(pool);
+      const store = createPostgresGenericLaunchMaterializationStoreV2(pool);
+      const record = launchRecord();
+      const signal = new AbortController().signal;
+
+      expect(await store.getApprovalAuthorization({ approvalId: APPROVAL_ID, signal }))
+        .toEqual({ artifact: { accepted: true } });
+      expect((await store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("a"),
+        state: "finalized",
+        record,
+        signal,
+      })).kind).toBe("created");
+      expect((await store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("a"),
+        state: "finalized",
+        record,
+        signal,
+      })).kind).toBe("existing");
+
+      const signedPayloads: JsonValue[] = [];
+      const readStore = createPostgresGenericLaunchReadStoreV2({
+        pool,
+        signer: {
+          binding: {} as never,
+          async sign({ payload }) {
+            signedPayloads.push(payload);
+            return canonicalizeJson(payload);
+          },
+        },
+        readModelContract: readContract(),
+      });
+      await readStore.findFinalizedLaunches({
+        limit: 10, requestBindingHash: sha("b"), signal,
+      });
+      await readStore.findFinalizedLaunchByRecordHash({
+        recordHash: record.recordHash, requestBindingHash: sha("c"), signal,
+      });
+      expect(signedPayloads[0]).toMatchObject({ records: [record], total: "1" });
+      expect(signedPayloads[1]).toEqual(record);
+
+      expect((await store.putIfNewLifecycle({
+        approvalId: APPROVAL_ID,
+        launchId: LAUNCH_ID,
+        descriptorHash: DESCRIPTOR_HASH,
+        lifecycleEvidenceHash: sha("d"),
+        state: "revoked",
+        record: null,
+        signal,
+      })).kind).toBe("created");
+      signedPayloads.length = 0;
+      await readStore.findFinalizedLaunches({
+        limit: 10, requestBindingHash: sha("e"), signal,
+      });
+      await readStore.findFinalizedLaunchByRecordHash({
+        recordHash: record.recordHash, requestBindingHash: sha("f"), signal,
+      });
+      expect(signedPayloads).toEqual([
+        { records: [], nextCursor: null, total: "0" },
+        null,
+      ]);
+      await expect(pool.query(`
+        UPDATE programmable_website_projection_v1.generic_launch_materializations_v2
+           SET lifecycle_state = 'finalized'
+      `)).rejects.toThrow();
+    } finally {
+      await database.close();
+    }
+  }, 20_000);
+});
+
+function launchRecord() {
+  return createGenericLaunchRecordV2({
+    readModelBindingHash: canonicalSha256(
+      "programmable.generic-launch-read-model-contract.v2",
+      readContract(),
+    ),
+    sourceProjection: {
+      schemaVersion: "programmable.generic-launch-source-projection.v2",
+      sourceRevision: {
+        repositoryId: "123", repositoryFullName: "alice/example-hook",
+        commitObjectId: "3".repeat(40), treeObjectId: "4".repeat(40),
+      },
+      approval: {
+        approvalRevision: "7", approvalId: APPROVAL_ID,
+        approvalEvidenceHash: hash("2"), signedReceiptArtifactHash: sha("2"),
+      },
+      descriptor: {
+        descriptorHash: DESCRIPTOR_HASH, launchId: LAUNCH_ID,
+        launchWallet: address("5"), primaryContract: address("7"),
+        primaryRuntimeCodeHash: hash("8"), componentSetHash: hash("9"),
+        sourceArtifactHash: hash("a"), configurationHash: hash("b"),
+        launchPlanHash: hash("c"), projectCommitment: hash("d"),
+        marketMode: "Standard10", marketModeValue: 1, protocolFeeBps: 10,
+      },
+      lifecycle: {
+        chainId: "1", generation: "2", registryAddress: address("6"),
+        registryRuntimeCodeKeccak256: hash("7"),
+        registryPolicyCommitment: hash("8"), minimumFinalityBlocks: "12",
+        primaryLaunch: {
+          transactionHash: hash("9"), sender: address("5"), blockHash: hash("a"),
+          blockNumber: "88", transactionIndex: "2", status: "success",
+        },
+        authorization: event("CustomLaunchApprovalAuthorizedV2", "a", "b", "90", "3", "4"),
+        registration: [
+          event("CustomLaunchRegisteredV2", "b", "c", "95", "4", "5"),
+          event("CustomLaunchDescriptorCommittedV2", "b", "c", "95", "4", "6"),
+          event("CustomLaunchDescriptorEvidenceCommittedV2", "b", "c", "95", "4", "7"),
+        ],
+        finalization: event("CustomLaunchFinalizedV2", "c", "d", "100", "5", "8"),
+        latestCommonHead: "112", latestCommonHeadHash: hash("e"),
+        latestStatus: "finalized", revokedAtBlock: "0",
+        revocationEvidenceHash: hash("0"),
+      },
+    },
+  });
+}
+
+function event<Name extends string>(
+  eventName: Name,
+  transaction: string,
+  block: string,
+  blockNumber: string,
+  transactionIndex: string,
+  logIndex: string,
+) {
+  return {
+    eventName, transactionHash: hash(transaction), blockHash: hash(block),
+    blockNumber, transactionIndex, logIndex, removed: false as const,
+  };
+}
+
+function readContract() {
+  return {
+    schemaVersion: "programmable.generic-launch-read-model-contract.v2" as const,
+    sourceLane: "generic.finalized-launch-v2" as const,
+    implementationBindingHash: sha("1"), persistenceBindingHash: sha("2"),
+    queryContractBindingHash: sha("3"),
+    approvalArtifactSchemaBindingHash: sha("4"),
+    approvalReleaseBindingHash: sha("5"),
+    registryProjectionBindingHash: sha("6"),
+  };
+}
+
+async function insertApproval(pool: TestPool) {
+  const readback = canonicalizeJson({
+    schemaVersion: "programmable.approval-v3-artifact-projection-readback.v1",
+    approvalId: APPROVAL_ID,
+    authorization: { artifact: { accepted: true } },
+  });
+  const acknowledgement = canonicalizeJson({ acknowledged: true });
+  const write = canonicalizeJson({ write: true });
+  await pool.query(`
+    INSERT INTO programmable_website_projection_v1.projection_records
+      (lane, target_binding_hash, audience, projection_key, idempotency_key,
+       request_digest, canonical_write, canonical_acknowledgement,
+       canonical_readback, record_binding_hash)
+    VALUES ('website.approval-v3', $1, 'approval', $2, $3, $4, $5, $6, $7, $8)
+  `, [sha("1"), `approval:${APPROVAL_ID}`, sha("2"), sha("3"), write,
+    acknowledgement, readback, sha("4")]);
+}
+
+async function migrate(database: PGlite) {
+  await database.exec(`
+    CREATE ROLE programmable_website_projection_runtime NOLOGIN;
+    CREATE ROLE anon NOLOGIN;
+    CREATE ROLE authenticated NOLOGIN;
+    CREATE ROLE service_role NOLOGIN;
+  `);
+  for (const path of [
+    "../ops/website-projection-target/migrations/0001_projection_records_v1.sql",
+    "../ops/website-projection-target/migrations/0002_custom_launch_wallet_profile_v2.sql",
+    "../ops/website-projection-target/migrations/0003_registry_custom_public_read_v1.sql",
+    "../ops/website-projection-target/migrations/0004_approval_v3_artifacts_v1.sql",
+    "../ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql",
+  ]) await database.exec(await readFile(new URL(path, import.meta.url), "utf8"));
+  await database.exec(`
+    GRANT USAGE ON SCHEMA programmable_website_projection_v1
+      TO programmable_website_projection_runtime;
+    GRANT SELECT, INSERT
+      ON programmable_website_projection_v1.projection_records
+      TO programmable_website_projection_runtime;
+    SET ROLE programmable_website_projection_runtime;
+  `);
+}
+
+class TestPool implements ProjectionTargetPostgresPoolV1 {
+  constructor(private readonly database: PGlite) {}
+  async connect(): Promise<ProjectionTargetPostgresClientV1> {
+    return {
+      query: <Row extends Record<string, unknown>>(
+        text: string, values: readonly unknown[] = [],
+      ) => this.query<Row>(text, values),
+      release() {},
+    };
+  }
+  async query<Row extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    const result = await this.database.query<Row>(text, [...values]);
+    return { rows: result.rows, rowCount: result.affectedRows ?? result.rows.length };
+  }
+}

--- a/tests/generic-launch-postgres-v2.test.ts
+++ b/tests/generic-launch-postgres-v2.test.ts
@@ -390,6 +390,17 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         FOR EACH ROW WHEN (false) EXECUTE FUNCTION
           programmable_website_projection_v1.enforce_approval_v3_capacity_v1();
       `,
+      `
+        ALTER POLICY projection_records_runtime_select
+          ON programmable_website_projection_v1.projection_records
+          USING (created_at > clock_timestamp() - interval '20 milliseconds');
+      `,
+      `
+        CREATE POLICY projection_records_hidden_restrictive
+          ON programmable_website_projection_v1.projection_records
+          AS RESTRICTIVE FOR SELECT TO programmable_website_projection_runtime
+          USING (false);
+      `,
     ];
     for (const mutation of mutations) {
       const database = new PGlite();
@@ -401,7 +412,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
         await database.exec(`RESET ROLE; ${mutation}
           SET ROLE programmable_website_projection_runtime;`);
         await expect(assertPostgresGenericLaunchReadStoreReadyV2(pool, 180_000))
-          .rejects.toThrow(/storage posture/u);
+          .rejects.toThrow(/posture/u);
       } finally {
         await database.close();
       }

--- a/tests/generic-launch-projector-v2.test.ts
+++ b/tests/generic-launch-projector-v2.test.ts
@@ -30,6 +30,9 @@ const approval: VerifiedApprovalArtifactV3 = {
     treeOid: "4".repeat(40),
   },
   approvalId: hash("1"),
+  authorization: {
+    approvalId: hash("1"), validAfterBlock: "80", expiresAtBlock: "120",
+  },
   approvalEvidenceHash: hash("2"),
   signedReceiptArtifactHash: sha("2"),
   descriptorHash: hash("3"),
@@ -51,6 +54,11 @@ const approval: VerifiedApprovalArtifactV3 = {
     marketModeValue: 1,
     protocolFeeBps: 10,
   },
+  registry: {
+    chainId: "1", generation: "2", address: address("6"),
+    runtimeCodeKeccak256: hash("7"), minimumFinalityBlocks: "12",
+  },
+  registryOnchainPolicyCommitment: hash("8"),
 };
 
 const lifecycle: VerifiedRegistryLifecycleV2 = {
@@ -242,7 +250,10 @@ describe("Generic launch V2 Registry projector", () => {
     const keys = generateKeyPairSync("ed25519");
     const spki = keys.publicKey.export({ format: "der", type: "spki" });
     const releaseProjection = {
-      registry: { address: address("6") },
+      registry: {
+        chainId: "1", generation: "2", address: address("6"),
+        runtimeCodeKeccak256: hash("7"), minimumFinalityBlocks: "12",
+      },
       policyCommitments: { registryOnchainPolicyCommitment: hash("8") },
       authority: { keyId: "approval-key", keyEpoch: "7" },
       routeAdapterRelease: { commitOid: "3".repeat(40) },
@@ -255,7 +266,9 @@ describe("Generic launch V2 Registry projector", () => {
         commitOid: "3".repeat(40), treeOid: "4".repeat(40),
       },
       approvedWallet: { chainId: "1", namespace: "eip155:1", value: address("5") },
-      authorization: { approvalId: hash("1") },
+      authorization: {
+        approvalId: hash("1"), validAfterBlock: "80", expiresAtBlock: "120",
+      },
       descriptorHash: hash("3"),
       launchId: hash("4"),
       descriptor: approval.descriptor,

--- a/tests/generic-launch-projector-v2.test.ts
+++ b/tests/generic-launch-projector-v2.test.ts
@@ -123,6 +123,9 @@ function memoryStore(): GenericLaunchMaterializationStoreV2 & {
         record: row.record,
         lastFinalizedRecord: rows.findLast((candidate) =>
           candidate.launchId === launchId && candidate.record !== null)?.record ?? null,
+        lastFinalizedLifecycleEvidenceHash: rows.findLast((candidate) =>
+          candidate.launchId === launchId && candidate.record !== null)
+          ?.lifecycleEvidenceHash ?? null,
         observationCommonHead: observation?.observationCommonHead ?? "112",
         observationCommonHeadHash:
           observation?.observationCommonHeadHash ?? hash("e"),
@@ -334,6 +337,46 @@ describe("Generic launch V2 Registry projector", () => {
     expect(recovered.recordHash).toBe(first.recordHash);
     expect(store.rows).toHaveLength(2);
     expect(store.rows[0]?.record?.recordHash).toBe(first.recordHash);
+  });
+
+  it("does not reuse stale finalized evidence after a lifecycle reorg", async () => {
+    const store = memoryStore();
+    let current: VerifiedRegistryLifecycleV2 = lifecycle;
+    const projector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => approval,
+      readRegistryLifecycle: async () => current,
+      readModelBindingHash: sha("f"),
+    });
+    const first = await projector.project({ approvalId: approval.approvalId });
+    current = {
+      status: "invalidated",
+      latestCommonHead: "121",
+      latestCommonHeadHash: hash("f"),
+      registryStatus: "1",
+      invalidationEvidenceHash: sha("e"),
+      observationCommonHead: "121",
+      observationCommonHeadHash: hash("f"),
+    };
+    await projector.project({ approvalId: approval.approvalId });
+    current = {
+      ...lifecycle,
+      finalization: {
+        ...lifecycle.finalization,
+        transactionHash: hash("d"),
+        blockHash: hash("1"),
+      },
+      latestCommonHead: "130",
+      latestCommonHeadHash: hash("9"),
+      observationCommonHead: "130",
+      observationCommonHeadHash: hash("9"),
+    };
+    const recovered = await projector.project({ approvalId: approval.approvalId });
+    expect(recovered.kind).toBe("created");
+    expect(recovered.recordHash).not.toBe(first.recordHash);
+    expect(store.rows).toHaveLength(3);
+    expect(store.rows[2]?.record?.sourceProjection.lifecycle.finalization)
+      .toMatchObject({ transactionHash: hash("d"), blockHash: hash("1") });
   });
 
   it("fails closed on approval identity or lifecycle drift", async () => {

--- a/tests/generic-launch-projector-v2.test.ts
+++ b/tests/generic-launch-projector-v2.test.ts
@@ -121,6 +121,8 @@ function memoryStore(): GenericLaunchMaterializationStoreV2 & {
         state: row.state,
         recordHash: row.record?.recordHash ?? null,
         record: row.record,
+        lastFinalizedRecord: rows.findLast((candidate) =>
+          candidate.launchId === launchId && candidate.record !== null)?.record ?? null,
         observationCommonHead: observation?.observationCommonHead ?? "112",
         observationCommonHeadHash:
           observation?.observationCommonHeadHash ?? hash("e"),
@@ -298,6 +300,40 @@ describe("Generic launch V2 Registry projector", () => {
       .toBe("created");
     expect(store.rows).toHaveLength(2);
     expect(store.rows[1]).toMatchObject({ state: "invalidated", record: null });
+  });
+
+  it("restores the original public identity after a transient invalidation", async () => {
+    const store = memoryStore();
+    let current: VerifiedRegistryLifecycleV2 = lifecycle;
+    const projector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => approval,
+      readRegistryLifecycle: async () => current,
+      readModelBindingHash: sha("f"),
+    });
+    const first = await projector.project({ approvalId: approval.approvalId });
+    current = {
+      status: "invalidated",
+      latestCommonHead: "121",
+      latestCommonHeadHash: hash("f"),
+      registryStatus: "1",
+      invalidationEvidenceHash: sha("e"),
+      observationCommonHead: "121",
+      observationCommonHeadHash: hash("f"),
+    };
+    await projector.project({ approvalId: approval.approvalId });
+    current = {
+      ...lifecycle,
+      latestCommonHead: "130",
+      latestCommonHeadHash: hash("9"),
+      observationCommonHead: "130",
+      observationCommonHeadHash: hash("9"),
+    };
+    const recovered = await projector.project({ approvalId: approval.approvalId });
+    expect(recovered.kind).toBe("existing");
+    expect(recovered.recordHash).toBe(first.recordHash);
+    expect(store.rows).toHaveLength(2);
+    expect(store.rows[0]?.record?.recordHash).toBe(first.recordHash);
   });
 
   it("fails closed on approval identity or lifecycle drift", async () => {

--- a/tests/generic-launch-projector-v2.test.ts
+++ b/tests/generic-launch-projector-v2.test.ts
@@ -1,0 +1,314 @@
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { canonicalSha256 } from
+  "../lib/server/projection-target/hashing";
+import { canonicalizeJson, type JsonValue } from
+  "../lib/server/projection-target/canonical-json";
+import {
+  createGenericLaunchProjectorV2,
+  createApprovalArtifactVerifierV3,
+  type GenericLaunchMaterializationStoreV2,
+  type VerifiedApprovalArtifactV3,
+  type VerifiedRegistryLifecycleV2,
+} from "../lib/server/custom-launch/generic-launch-projector-v2";
+import { createDualRpcGenericLaunchRegistryReaderV2 } from
+  "../lib/server/custom-launch/generic-launch-registry-reader-v2";
+
+const sha = (value: string) => `sha256:${value.repeat(64)}` as const;
+const hash = (value: string) => `0x${value.repeat(64)}` as const;
+const address = (value: string) => `0x${value.repeat(40)}` as const;
+
+const approval: VerifiedApprovalArtifactV3 = {
+  approvalRevision: "7",
+  sourceRevision: {
+    repositoryId: "123456789",
+    repositoryFullName: "alice/example-hook",
+    commitOid: "3".repeat(40),
+    treeOid: "4".repeat(40),
+  },
+  approvalId: hash("1"),
+  approvalEvidenceHash: hash("2"),
+  signedReceiptArtifactHash: sha("2"),
+  descriptorHash: hash("3"),
+  launchId: hash("4"),
+  primaryFinality: {
+    transactionHash: hash("9"), blockHash: hash("a"), blockNumber: "88",
+  },
+  descriptor: {
+    chainId: "1",
+    launchWallet: address("5"),
+    primaryContract: address("7"),
+    primaryRuntimeCodeHash: hash("8"),
+    componentSetHash: hash("9"),
+    sourceArtifactHash: hash("a"),
+    configurationHash: hash("b"),
+    launchPlanHash: hash("c"),
+    projectCommitment: hash("d"),
+    marketMode: "Standard10",
+    marketModeValue: 1,
+    protocolFeeBps: 10,
+  },
+};
+
+const lifecycle: VerifiedRegistryLifecycleV2 = {
+  status: "finalized",
+  registryAddress: address("6"),
+  registryRuntimeCodeKeccak256: hash("7"),
+  registryPolicyCommitment: hash("8"),
+  minimumFinalityBlocks: "12",
+  primaryLaunch: {
+    transactionHash: hash("9"), sender: address("5"), blockHash: hash("a"),
+    blockNumber: "88", transactionIndex: "2", status: "success",
+  },
+  authorization: {
+    eventName: "CustomLaunchApprovalAuthorizedV2", transactionHash: hash("a"),
+    blockHash: hash("b"), blockNumber: "90", transactionIndex: "3",
+    logIndex: "4", removed: false,
+  },
+  registration: [
+    { eventName: "CustomLaunchRegisteredV2", transactionHash: hash("b"), blockHash: hash("c"), blockNumber: "95", transactionIndex: "4", logIndex: "5", removed: false },
+    { eventName: "CustomLaunchDescriptorCommittedV2", transactionHash: hash("b"), blockHash: hash("c"), blockNumber: "95", transactionIndex: "4", logIndex: "6", removed: false },
+    { eventName: "CustomLaunchDescriptorEvidenceCommittedV2", transactionHash: hash("b"), blockHash: hash("c"), blockNumber: "95", transactionIndex: "4", logIndex: "7", removed: false },
+  ],
+  finalization: {
+    eventName: "CustomLaunchFinalizedV2", transactionHash: hash("c"),
+    blockHash: hash("d"), blockNumber: "100", transactionIndex: "5",
+    logIndex: "8", removed: false,
+  },
+  latestCommonHead: "112",
+  latestCommonHeadHash: hash("e"),
+  revokedAtBlock: "0",
+  revocationEvidenceHash: hash("0"),
+};
+
+function memoryStore(): GenericLaunchMaterializationStoreV2 & {
+  rows: Array<Parameters<GenericLaunchMaterializationStoreV2["putIfNewLifecycle"]>[0]>;
+} {
+  const rows: Array<Parameters<GenericLaunchMaterializationStoreV2["putIfNewLifecycle"]>[0]> = [];
+  return {
+    rows,
+    async getApprovalAuthorization() { return { accepted: true }; },
+    async getLatestLifecycle({ launchId }) {
+      const row = rows.findLast((candidate) => candidate.launchId === launchId);
+      return row === undefined ? null : {
+        lifecycleGeneration: String(rows.indexOf(row) + 1),
+        lifecycleEvidenceHash: row.lifecycleEvidenceHash,
+        state: row.state,
+        recordHash: row.record?.recordHash ?? null,
+      };
+    },
+    async putIfNewLifecycle(input) {
+      const existing = rows.find((candidate) =>
+        candidate.launchId === input.launchId
+        && candidate.lifecycleEvidenceHash === input.lifecycleEvidenceHash);
+      if (existing !== undefined) return { kind: "existing" };
+      rows.push(input);
+      return { kind: "created" };
+    },
+  };
+}
+
+describe("Generic launch V2 Registry projector", () => {
+  it("materializes a finalized record once and replays idempotently", async () => {
+    const store = memoryStore();
+    const projector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => approval,
+      readRegistryLifecycle: async () => lifecycle,
+      readModelBindingHash: sha("f"),
+    });
+
+    const first = await projector.project({ approvalId: approval.approvalId });
+    const replay = await projector.project({ approvalId: approval.approvalId });
+
+    expect(first.kind).toBe("created");
+    expect(replay.kind).toBe("existing");
+    expect(store.rows).toHaveLength(1);
+    expect(store.rows[0]?.record?.sourceProjection.sourceRevision).toEqual({
+      repositoryId: "123456789",
+      repositoryFullName: "alice/example-hook",
+      commitObjectId: "3".repeat(40),
+      treeObjectId: "4".repeat(40),
+    });
+    expect(store.rows[0]?.record?.sourceProjection.lifecycle.latestStatus)
+      .toBe("finalized");
+  });
+
+  it("appends a revocation tombstone and never publishes it as a record", async () => {
+    const store = memoryStore();
+    let current: VerifiedRegistryLifecycleV2 = lifecycle;
+    const projector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => approval,
+      readRegistryLifecycle: async () => current,
+      readModelBindingHash: sha("f"),
+    });
+    await projector.project({ approvalId: approval.approvalId });
+    current = {
+      status: "revoked",
+      latestCommonHead: "120",
+      latestCommonHeadHash: hash("f"),
+      revokedAtBlock: "118",
+      revocationEvidenceHash: hash("a"),
+    };
+
+    expect((await projector.project({ approvalId: approval.approvalId })).kind)
+      .toBe("created");
+    expect(store.rows).toHaveLength(2);
+    expect(store.rows[1]).toMatchObject({ state: "revoked", record: null });
+  });
+
+  it("fails closed on approval identity or lifecycle drift", async () => {
+    const store = memoryStore();
+    const mismatch = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => ({ ...approval, approvalId: hash("f") }),
+      readRegistryLifecycle: async () => lifecycle,
+      readModelBindingHash: sha("f"),
+    });
+    await expect(mismatch.project({ approvalId: approval.approvalId }))
+      .rejects.toThrow(/Approval identity/u);
+    expect(store.rows).toHaveLength(0);
+
+    const malformed = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => approval,
+      readRegistryLifecycle: async () => ({
+        ...lifecycle,
+        primaryLaunch: { ...lifecycle.primaryLaunch, sender: address("f") },
+      }),
+      readModelBindingHash: sha("f"),
+    });
+    await expect(malformed.project({ approvalId: approval.approvalId }))
+      .rejects.toThrow(/sender/u);
+    expect(store.rows).toHaveLength(0);
+  });
+
+  it("binds lifecycle idempotency to the exact verified evidence", async () => {
+    const store = memoryStore();
+    const projector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => approval,
+      readRegistryLifecycle: async () => lifecycle,
+      readModelBindingHash: sha("f"),
+    });
+    await projector.project({ approvalId: approval.approvalId });
+    expect(store.rows[0]?.lifecycleEvidenceHash).toBe(canonicalSha256(
+      "programmable.generic-launch-registry-lifecycle-evidence.v2",
+      lifecycle,
+    ));
+  });
+
+  it("requires byte-identical lifecycle evidence from two RPC providers", async () => {
+    let secondary: VerifiedRegistryLifecycleV2 = lifecycle;
+    const reader = createDualRpcGenericLaunchRegistryReaderV2({
+      release: {
+        registryAddress: address("6"),
+        registryRuntimeCodeKeccak256: hash("7"),
+        registryPolicyCommitment: hash("8"),
+        deploymentBlock: "80",
+        minimumFinalityBlocks: "12",
+      },
+      rpcUrls: ["https://primary.invalid", "https://secondary.invalid"],
+      providerFactory: (url) => ({
+        async head() { return 112n; },
+        async blockHash() { return hash("e"); },
+        async observe() {
+          return {
+            lifecycle: url.includes("secondary") ? secondary : lifecycle,
+            bindingEvidence: {
+              approvalState: { consumed: true },
+              launchState: { status: "2" },
+              launchDescriptor: { launchId: approval.launchId },
+              eventArguments: [],
+            },
+          };
+        },
+      }),
+    });
+    const signal = new AbortController().signal;
+    await expect(reader({ approval, signal })).resolves.toEqual(lifecycle);
+    secondary = {
+      ...lifecycle,
+      latestCommonHeadHash: hash("f"),
+    };
+    await expect(reader({ approval, signal })).rejects.toThrow(/disagrees/u);
+  });
+
+  it("verifies the exact Approval Ed25519 artifact and current release epoch", () => {
+    const keys = generateKeyPairSync("ed25519");
+    const spki = keys.publicKey.export({ format: "der", type: "spki" });
+    const releaseProjection = {
+      registry: { address: address("6") },
+      policyCommitments: { registryOnchainPolicyCommitment: hash("8") },
+      authority: { keyId: "approval-key", keyEpoch: "7" },
+      routeAdapterRelease: { commitOid: "3".repeat(40) },
+    };
+    const payload = {
+      schemaVersion: "programmable.approval-registry-descriptor-binding.v3",
+      approvalRevision: "7",
+      sourceRevision: {
+        repositoryId: "123456789", repositoryFullName: "alice/example-hook",
+        commitOid: "3".repeat(40), treeOid: "4".repeat(40),
+      },
+      approvedWallet: { chainId: "1", namespace: "eip155:1", value: address("5") },
+      authorization: { approvalId: hash("1") },
+      descriptorHash: hash("3"),
+      launchId: hash("4"),
+      descriptor: approval.descriptor,
+      finality: { transactionHash: hash("9"), blockHash: hash("a"), blockNumber: "88" },
+      ...releaseProjection,
+    };
+    const unsigned = {
+      schemaVersion: "1.0.0",
+      domain: "programmable.approval-registry-descriptor-binding.v3",
+      audience: "programmable.custom-registry.v2",
+      keyId: "approval-key",
+      algorithm: "Ed25519",
+      issuedAt: "2026-08-13T21:55:00.000Z",
+      validUntil: "2026-08-13T22:05:00.000Z",
+      payloadHash: canonicalSha256(
+        "programmable.approval-registry-descriptor-binding.v3",
+        payload,
+      ),
+    };
+    const artifact = {
+      payload,
+      envelope: {
+        ...unsigned,
+        signature: sign(null, Buffer.from(canonicalizeJson(
+          unsigned as unknown as JsonValue,
+        ), "utf8"), keys.privateKey).toString("base64url"),
+      },
+    };
+    const signedReceiptArtifactHash = rawSha(artifact);
+    const authorization = {
+      artifact,
+      signedReceiptArtifactHash,
+      approvalEvidenceHash: `0x${signedReceiptArtifactHash.slice(7)}`,
+    };
+    const verify = createApprovalArtifactVerifierV3({
+      keyId: "approval-key",
+      keyEpoch: "7",
+      publicKeySpkiBase64Url: spki.toString("base64url"),
+      publicKeySha256: `sha256:${createHash("sha256").update(spki).digest("hex")}`,
+      currentReleaseBindingHash: canonicalSha256(
+        "programmable.approval-registry-v3-current-release-binding.v1",
+        releaseProjection,
+      ),
+    });
+    expect(verify(authorization, new Date("2026-08-13T22:00:00.000Z")))
+      .toMatchObject({ approvalId: hash("1"), launchId: hash("4") });
+    expect(() => verify(authorization, new Date("2026-08-13T22:06:00.000Z")))
+      .toThrow(/current/u);
+  });
+});
+
+function rawSha(value: unknown): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(canonicalizeJson(
+    value as JsonValue,
+  )).digest("hex")}`;
+}

--- a/tests/generic-launch-projector-v2.test.ts
+++ b/tests/generic-launch-projector-v2.test.ts
@@ -169,6 +169,30 @@ describe("Generic launch V2 Registry projector", () => {
     expect(store.rows[1]).toMatchObject({ state: "revoked", record: null });
   });
 
+  it("appends an invalidation tombstone when finality disappears after a reorg", async () => {
+    const store = memoryStore();
+    let current: VerifiedRegistryLifecycleV2 = lifecycle;
+    const projector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => approval,
+      readRegistryLifecycle: async () => current,
+      readModelBindingHash: sha("f"),
+    });
+    await projector.project({ approvalId: approval.approvalId });
+    current = {
+      status: "invalidated",
+      latestCommonHead: "121",
+      latestCommonHeadHash: hash("f"),
+      registryStatus: "1",
+      invalidationEvidenceHash: sha("e"),
+    };
+
+    expect((await projector.project({ approvalId: approval.approvalId })).kind)
+      .toBe("created");
+    expect(store.rows).toHaveLength(2);
+    expect(store.rows[1]).toMatchObject({ state: "invalidated", record: null });
+  });
+
   it("fails closed on approval identity or lifecycle drift", async () => {
     const store = memoryStore();
     const mismatch = createGenericLaunchProjectorV2({

--- a/tests/generic-launch-projector-v2.test.ts
+++ b/tests/generic-launch-projector-v2.test.ts
@@ -90,23 +90,47 @@ const lifecycle: VerifiedRegistryLifecycleV2 = {
   latestCommonHeadHash: hash("e"),
   revokedAtBlock: "0",
   revocationEvidenceHash: hash("0"),
+  observationCommonHead: "112",
+  observationCommonHeadHash: hash("e"),
 };
 
 function memoryStore(): GenericLaunchMaterializationStoreV2 & {
   rows: Array<Parameters<GenericLaunchMaterializationStoreV2["putIfNewLifecycle"]>[0]>;
 } {
   const rows: Array<Parameters<GenericLaunchMaterializationStoreV2["putIfNewLifecycle"]>[0]> = [];
+  const observations = new Map<string, Readonly<{
+    observationCommonHead: string;
+    observationCommonHeadHash: `0x${string}`;
+  }>>();
   return {
     rows,
-    async getApprovalAuthorization() { return { accepted: true }; },
+    async getApprovalAuthorization() {
+      return {
+        authorization: { accepted: true },
+        receivedAt: new Date("2026-08-13T22:00:00.000Z"),
+      };
+    },
     async getLatestLifecycle({ launchId }) {
       const row = rows.findLast((candidate) => candidate.launchId === launchId);
+      const observation = observations.get(launchId);
       return row === undefined ? null : {
         lifecycleGeneration: String(rows.indexOf(row) + 1),
+        approvalId: row.approvalId,
+        descriptorHash: row.descriptorHash,
         lifecycleEvidenceHash: row.lifecycleEvidenceHash,
         state: row.state,
         recordHash: row.record?.recordHash ?? null,
+        record: row.record,
+        observationCommonHead: observation?.observationCommonHead ?? "112",
+        observationCommonHeadHash:
+          observation?.observationCommonHeadHash ?? hash("e"),
       };
+    },
+    async putApprovalReconciliation(input) {
+      observations.set(input.launchId, {
+        observationCommonHead: input.observationCommonHead,
+        observationCommonHeadHash: input.observationCommonHeadHash,
+      });
     },
     async putIfNewLifecycle(input) {
       const existing = rows.find((candidate) =>
@@ -145,6 +169,85 @@ describe("Generic launch V2 Registry projector", () => {
       .toBe("finalized");
   });
 
+  it("keeps the public record identity stable while advancing observation", async () => {
+    const store = memoryStore();
+    let current = lifecycle;
+    const projector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => approval,
+      readRegistryLifecycle: async () => current,
+      readModelBindingHash: sha("f"),
+    });
+    const first = await projector.project({ approvalId: approval.approvalId });
+    current = {
+      ...lifecycle,
+      latestCommonHead: "120",
+      latestCommonHeadHash: hash("f"),
+      observationCommonHead: "120",
+      observationCommonHeadHash: hash("f"),
+    };
+    const refreshed = await projector.project({ approvalId: approval.approvalId });
+    expect(refreshed).toMatchObject({
+      kind: "existing",
+      recordHash: first.recordHash,
+      lifecycleEvidenceHash: first.lifecycleEvidenceHash,
+    });
+    expect(store.rows).toHaveLength(1);
+  });
+
+  it("reuses delivery-time Approval validity after the envelope expires", async () => {
+    const store = memoryStore();
+    const verifyApprovalArtifact = vi.fn((_raw: unknown, verifiedAt: Date) => {
+      expect(verifiedAt.toISOString()).toBe("2026-08-13T22:00:00.000Z");
+      return approval;
+    });
+    const projector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact,
+      readRegistryLifecycle: async () => lifecycle,
+      readModelBindingHash: sha("f"),
+      now: () => new Date("2026-08-14T22:00:00.000Z"),
+    });
+    await expect(projector.project({ approvalId: approval.approvalId }))
+      .resolves.toMatchObject({ state: "finalized" });
+    expect(verifyApprovalArtifact).toHaveBeenCalledOnce();
+  });
+
+  it("records an unconsumed competing Approval without hiding the launch", async () => {
+    const store = memoryStore();
+    const canonicalProjector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => approval,
+      readRegistryLifecycle: async () => lifecycle,
+      readModelBindingHash: sha("f"),
+    });
+    const canonical = await canonicalProjector.project({
+      approvalId: approval.approvalId,
+    });
+    const competingApproval = {
+      ...approval,
+      approvalId: hash("f"),
+      authorization: { ...approval.authorization, approvalId: hash("f") },
+    };
+    const competingProjector = createGenericLaunchProjectorV2({
+      store,
+      verifyApprovalArtifact: () => competingApproval,
+      readRegistryLifecycle: async () => ({
+        status: "unconsumed",
+        latestCommonHead: "120",
+        latestCommonHeadHash: hash("f"),
+        observationCommonHead: "120",
+        observationCommonHeadHash: hash("f"),
+      }),
+      readModelBindingHash: sha("f"),
+    });
+    await expect(competingProjector.project({
+      approvalId: competingApproval.approvalId,
+    })).resolves.toMatchObject({ state: "unconsumed", recordHash: null });
+    expect(store.rows).toHaveLength(1);
+    expect(store.rows[0]?.record?.recordHash).toBe(canonical.recordHash);
+  });
+
   it("appends a revocation tombstone and never publishes it as a record", async () => {
     const store = memoryStore();
     let current: VerifiedRegistryLifecycleV2 = lifecycle;
@@ -161,6 +264,8 @@ describe("Generic launch V2 Registry projector", () => {
       latestCommonHeadHash: hash("f"),
       revokedAtBlock: "118",
       revocationEvidenceHash: hash("a"),
+      observationCommonHead: "120",
+      observationCommonHeadHash: hash("f"),
     };
 
     expect((await projector.project({ approvalId: approval.approvalId })).kind)
@@ -185,6 +290,8 @@ describe("Generic launch V2 Registry projector", () => {
       latestCommonHeadHash: hash("f"),
       registryStatus: "1",
       invalidationEvidenceHash: sha("e"),
+      observationCommonHead: "121",
+      observationCommonHeadHash: hash("f"),
     };
 
     expect((await projector.project({ approvalId: approval.approvalId })).kind)
@@ -205,12 +312,15 @@ describe("Generic launch V2 Registry projector", () => {
       .rejects.toThrow(/Approval identity/u);
     expect(store.rows).toHaveLength(0);
 
+    const finalizedLifecycle = lifecycle.status === "finalized"
+      ? lifecycle
+      : (() => { throw new TypeError("fixture is not finalized"); })();
     const malformed = createGenericLaunchProjectorV2({
       store,
       verifyApprovalArtifact: () => approval,
       readRegistryLifecycle: async () => ({
         ...lifecycle,
-        primaryLaunch: { ...lifecycle.primaryLaunch, sender: address("f") },
+        primaryLaunch: { ...finalizedLifecycle.primaryLaunch, sender: address("f") },
       }),
       readModelBindingHash: sha("f"),
     });
@@ -230,7 +340,18 @@ describe("Generic launch V2 Registry projector", () => {
     await projector.project({ approvalId: approval.approvalId });
     expect(store.rows[0]?.lifecycleEvidenceHash).toBe(canonicalSha256(
       "programmable.generic-launch-registry-lifecycle-evidence.v2",
-      lifecycle,
+      {
+        approvalId: approval.approvalId,
+        launchId: approval.launchId,
+        descriptorHash: approval.descriptorHash,
+        status: "finalized",
+        authorization: lifecycle.status === "finalized"
+          ? lifecycle.authorization : null,
+        registration: lifecycle.status === "finalized"
+          ? lifecycle.registration : null,
+        finalization: lifecycle.status === "finalized"
+          ? lifecycle.finalization : null,
+      },
     ));
   });
 
@@ -262,12 +383,13 @@ describe("Generic launch V2 Registry projector", () => {
       }),
     });
     const signal = new AbortController().signal;
-    await expect(reader({ approval, signal })).resolves.toEqual(lifecycle);
+    await expect(reader({ approval, previous: null, signal })).resolves.toEqual(lifecycle);
     secondary = {
       ...lifecycle,
       latestCommonHeadHash: hash("f"),
     };
-    await expect(reader({ approval, signal })).rejects.toThrow(/disagrees/u);
+    await expect(reader({ approval, previous: null, signal }))
+      .rejects.toThrow(/disagrees/u);
   });
 
   it("verifies the exact Approval Ed25519 artifact and current release epoch", () => {

--- a/tests/generic-launch-read-signer-v2.test.ts
+++ b/tests/generic-launch-read-signer-v2.test.ts
@@ -1,0 +1,437 @@
+import {
+  createHash,
+  generateKeyPairSync,
+  sign as signBytes,
+  verify as verifyBytes,
+  type KeyObject,
+} from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createActiveGenericLaunchReadBindingV2,
+  createGenericLaunchReadHandlersV2,
+  GENERIC_LAUNCH_DETAIL_PATH_TEMPLATE_V2,
+  GENERIC_LAUNCH_FEED_PATH_V2,
+  type GenericLaunchReadBindingV2,
+  type GenericLaunchReadModelContractV2,
+  type GenericLaunchReadStoreV2,
+} from "../lib/server/custom-launch/generic-launch-read-v2";
+import {
+  createProductionGenericLaunchReadSignerV2,
+  createRemoteGenericLaunchReadSignerV2,
+  GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2,
+  GENERIC_LAUNCH_READ_SIGNER_BINDING_ENV_V2,
+  parseGenericLaunchReadSignerBindingV2,
+  type GenericLaunchReadSignerBindingV2,
+} from "../lib/server/custom-launch/generic-launch-read-signer-v2";
+import {
+  canonicalizeJson,
+  type JsonValue,
+} from "../lib/server/projection-target/canonical-json";
+import {
+  canonicalSha256,
+  type Sha256Digest,
+} from "../lib/server/projection-target/hashing";
+
+const NOW = new Date("2026-08-14T00:00:00.000Z");
+const REQUEST_HASH = digest("a");
+const RECORD_HASH = digest("b");
+const CREDENTIAL = "vercel-context-header.payload.signature";
+
+const READ_MODEL_CONTRACT = Object.freeze({
+  schemaVersion: "programmable.generic-launch-read-model-contract.v2" as const,
+  sourceLane: "generic.finalized-launch-v2" as const,
+  implementationBindingHash: digest("1"),
+  persistenceBindingHash: digest("2"),
+  queryContractBindingHash: digest("3"),
+  approvalArtifactSchemaBindingHash: digest("4"),
+  approvalReleaseBindingHash: digest("5"),
+  registryProjectionBindingHash: digest("6"),
+}) satisfies GenericLaunchReadModelContractV2;
+
+describe("Generic launch V2 remote read signer", () => {
+  it("produces the exact signed envelope consumed by the active Generic V2 read adapter", async () => {
+    const harness = signerHarness();
+    const signer = createRemoteGenericLaunchReadSignerV2({
+      binding: harness.signerBinding,
+      activeReadBinding: harness.readBinding,
+      credential: CREDENTIAL,
+      fetch: harness.fetch,
+      now: () => NOW,
+    });
+    const handlers = createGenericLaunchReadHandlersV2({
+      binding: harness.readBinding,
+      store: Object.freeze({
+        sourceLane: "generic.finalized-launch-v2" as const,
+        readModelContract: READ_MODEL_CONTRACT,
+        findFinalizedLaunches: async ({ requestBindingHash, signal }) =>
+          signer.sign({
+            requestBindingHash,
+            payload: Object.freeze({ records: [], nextCursor: null, total: "0" }),
+            signal,
+          }),
+        findFinalizedLaunchByRecordHash: async ({ requestBindingHash, signal }) =>
+          signer.sign({ requestBindingHash, payload: null, signal }),
+      } satisfies GenericLaunchReadStoreV2),
+    });
+
+    const response = await handlers.detail(
+      new Request(`https://programmable.example${
+        GENERIC_LAUNCH_DETAIL_PATH_TEMPLATE_V2.replace("{recordHash}", RECORD_HASH)
+      }`, { headers: { accept: "application/json" } }),
+      RECORD_HASH,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      schemaVersion: "programmable.custom-launch-error.v1",
+      code: "generic_launch_v2_not_found",
+    });
+  });
+
+  it("binds the remote-signing-v2 request to its dedicated audience, key epoch and provider", async () => {
+    const harness = signerHarness();
+    let capturedUrl = "";
+    let capturedAuthorization = "";
+    let capturedBody: Readonly<Record<string, string>> | null = null;
+    const signer = createRemoteGenericLaunchReadSignerV2({
+      binding: harness.signerBinding,
+      activeReadBinding: harness.readBinding,
+      credential: CREDENTIAL,
+      now: () => NOW,
+      fetch: async (url, init) => {
+        capturedUrl = String(url);
+        capturedAuthorization = new Headers(init?.headers).get("authorization") ?? "";
+        capturedBody = JSON.parse(String(init?.body)) as Record<string, string>;
+        return harness.fetch(url, init);
+      },
+    });
+    const payload = Object.freeze({ records: [], nextCursor: null, total: "0" });
+
+    const encodedEnvelope = await signer.sign({
+      requestBindingHash: REQUEST_HASH,
+      payload,
+    });
+
+    expect(capturedUrl).toBe("https://signer.example/v2/sign");
+    expect(capturedAuthorization).toBe(`Bearer ${CREDENTIAL}`);
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody).toMatchObject({
+      schemaVersion: "programmable.remote-signing-request.v2",
+      audience: GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2,
+      keyId: "generic-launch-read",
+      keyEpoch: "epoch-7",
+      algorithm: "Ed25519",
+      providerIdentityHash: harness.signerBinding.providerIdentityHash,
+      messageEncoding: "base64url",
+    });
+    const message = JSON.parse(Buffer.from(
+      capturedBody!.message!,
+      "base64url",
+    ).toString("utf8"));
+    expect(message).toEqual({
+      schemaVersion: "programmable.generic-launch-read-signature-message.v2",
+      activationBindingHash: harness.readBinding.activationBindingHash,
+      readModelBindingHash: harness.readBinding.readModelBindingHash,
+      requestBindingHash: REQUEST_HASH,
+      payload,
+    });
+    const envelope = JSON.parse(encodedEnvelope) as Record<string, unknown>;
+    expect(envelope).toMatchObject({
+      activationBindingHash: message.activationBindingHash,
+      readModelBindingHash: message.readModelBindingHash,
+      requestBindingHash: message.requestBindingHash,
+      payload: message.payload,
+    });
+    expect(envelope.schemaVersion).toBe(
+      "programmable.signed-generic-launch-read-envelope.v2",
+    );
+    expect(Object.keys(envelope).sort()).toEqual([
+      "activationBindingHash",
+      "payload",
+      "readModelBindingHash",
+      "requestBindingHash",
+      "schemaVersion",
+      "signatureBase64Url",
+    ]);
+    expect(verifyBytes(
+      null,
+      Buffer.from(canonicalizeJson(message), "utf8"),
+      harness.publicKey,
+      Buffer.from(String(envelope.signatureBase64Url), "base64url"),
+    )).toBe(true);
+  });
+
+  it("rejects any signer SPKI that is not the active Generic V2 verifier", () => {
+    const active = signerHarness();
+    const foreign = signerHarness();
+
+    expect(() => createRemoteGenericLaunchReadSignerV2({
+      binding: foreign.signerBinding,
+      activeReadBinding: active.readBinding,
+      credential: CREDENTIAL,
+      fetch: foreign.fetch,
+      now: () => NOW,
+    })).toThrow("does not match the active Generic V2 verifier");
+
+    const wrongVerifierHash = createActiveGenericLaunchReadBindingV2({
+      activatedAt: active.readBinding.activatedAt,
+      readModelBindingHash: active.readBinding.readModelBindingHash,
+      readModelVerifier: {
+        ...active.readBinding.readModelVerifier,
+        publicKeySha256: digest("f"),
+      },
+      registryIdentity: active.readBinding.registryIdentity,
+      api: active.readBinding.api,
+    });
+    expect(() => createRemoteGenericLaunchReadSignerV2({
+      binding: active.signerBinding,
+      activeReadBinding: wrongVerifierHash,
+      credential: CREDENTIAL,
+      fetch: active.fetch,
+      now: () => NOW,
+    })).toThrow("does not match the active Generic V2 verifier");
+  });
+
+  it("uses only Vercel OIDC in production and fails closed without the exact public binding", async () => {
+    const harness = signerHarness();
+    await expect(createProductionGenericLaunchReadSignerV2({
+      activeReadBinding: harness.readBinding,
+      environment: {},
+      credentialProvider: async () => CREDENTIAL,
+      fetch: harness.fetch,
+      now: () => NOW,
+    })).rejects.toThrow("is not configured");
+
+    await expect(createProductionGenericLaunchReadSignerV2({
+      activeReadBinding: harness.readBinding,
+      environment: {
+        [GENERIC_LAUNCH_READ_SIGNER_BINDING_ENV_V2]: canonicalizeJson({
+          ...harness.signerBinding,
+          privateKeyBase64Url: "forbidden-local-fallback",
+        } as unknown as JsonValue),
+      },
+      credentialProvider: async () => CREDENTIAL,
+      fetch: harness.fetch,
+      now: () => NOW,
+    })).rejects.toThrow("unknown or missing fields");
+
+    let authorization = "";
+    const signer = await createProductionGenericLaunchReadSignerV2({
+      activeReadBinding: harness.readBinding,
+      environment: {
+        [GENERIC_LAUNCH_READ_SIGNER_BINDING_ENV_V2]:
+          canonicalizeJson(harness.signerBinding as unknown as JsonValue),
+      },
+      credentialProvider: async () => CREDENTIAL,
+      fetch: async (url, init) => {
+        authorization = new Headers(init?.headers).get("authorization") ?? "";
+        return harness.fetch(url, init);
+      },
+      now: () => NOW,
+    });
+    await signer.sign({ requestBindingHash: REQUEST_HASH, payload: null });
+    expect(authorization).toBe(`Bearer ${CREDENTIAL}`);
+  });
+
+  it("fails closed on timeout, redirects and unauthenticated provider responses", async () => {
+    const harness = signerHarness();
+    const common = {
+      binding: harness.signerBinding,
+      activeReadBinding: harness.readBinding,
+      credential: CREDENTIAL,
+      now: () => NOW,
+    } as const;
+    const timedOut = createRemoteGenericLaunchReadSignerV2({
+      ...common,
+      timeoutMs: 500,
+      fetch: async (_url, init) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+          once: true,
+        });
+      }),
+    });
+    await expect(timedOut.sign({
+      requestBindingHash: REQUEST_HASH,
+      payload: null,
+    })).rejects.toThrow("deadline");
+
+    const redirected = createRemoteGenericLaunchReadSignerV2({
+      ...common,
+      fetch: async () => ({ redirected: true, status: 200 }) as Response,
+    });
+    await expect(redirected.sign({
+      requestBindingHash: REQUEST_HASH,
+      payload: null,
+    })).rejects.toThrow("rejected");
+
+    const forged = createRemoteGenericLaunchReadSignerV2({
+      ...common,
+      fetch: signerTransport(harness.privateKey, {
+        providerReceiptSignature: "A".repeat(86),
+      }),
+    });
+    await expect(forged.sign({
+      requestBindingHash: REQUEST_HASH,
+      payload: null,
+    })).rejects.toThrow("signature is invalid");
+
+    const mismatched = createRemoteGenericLaunchReadSignerV2({
+      ...common,
+      fetch: signerTransport(harness.privateKey, {
+        keyEpoch: "epoch-8",
+      }),
+    });
+    await expect(mismatched.sign({
+      requestBindingHash: REQUEST_HASH,
+      payload: null,
+    })).rejects.toThrow("response binding is invalid");
+
+    const missingField = createRemoteGenericLaunchReadSignerV2({
+      ...common,
+      fetch: async (url, init) => {
+        const response = await harness.fetch(url, init);
+        const malformed = await response.json() as {
+          providerReceipt: Record<string, JsonValue>;
+        };
+        delete malformed.providerReceipt.expiresAt;
+        return new Response(canonicalizeJson(malformed), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+    await expect(missingField.sign({
+      requestBindingHash: REQUEST_HASH,
+      payload: null,
+    })).rejects.toThrow("unknown or missing fields");
+  });
+});
+
+type SignerHarness = Readonly<{
+  privateKey: KeyObject;
+  publicKey: KeyObject;
+  readBinding: GenericLaunchReadBindingV2;
+  signerBinding: GenericLaunchReadSignerBindingV2;
+  fetch: typeof fetch;
+}>;
+
+function signerHarness(): SignerHarness {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const readBinding = readBindingForPublicKey(publicKey);
+  const signerBinding = signerBindingForPublicKey(publicKey);
+  return Object.freeze({
+    privateKey,
+    publicKey,
+    readBinding,
+    signerBinding,
+    fetch: signerTransport(privateKey),
+  });
+}
+
+function readBindingForPublicKey(publicKey: KeyObject): GenericLaunchReadBindingV2 {
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  return createActiveGenericLaunchReadBindingV2({
+    activatedAt: NOW.toISOString(),
+    readModelBindingHash: canonicalSha256(
+      READ_MODEL_CONTRACT.schemaVersion,
+      READ_MODEL_CONTRACT,
+    ),
+    readModelVerifier: {
+      algorithm: "ed25519",
+      publicKeySpkiBase64Url: spki.toString("base64url"),
+      publicKeySha256: rawDigest(spki),
+    },
+    registryIdentity: {
+      chainId: "1",
+      generation: "2",
+      registryAddress: `0x${"1".repeat(40)}`,
+      registryRuntimeCodeKeccak256: `0x${"2".repeat(64)}`,
+      registryPolicyCommitment: `0x${"3".repeat(64)}`,
+      minimumFinalityBlocks: "64",
+    },
+    api: {
+      feedPath: GENERIC_LAUNCH_FEED_PATH_V2,
+      detailPathTemplate: GENERIC_LAUNCH_DETAIL_PATH_TEMPLATE_V2,
+    },
+  });
+}
+
+function signerBindingForPublicKey(
+  publicKey: KeyObject,
+): GenericLaunchReadSignerBindingV2 {
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  const endpoint = "https://signer.example/v2/sign";
+  const publicKeySpkiBase64Url = spki.toString("base64url");
+  const publicKeySpkiSha256 = rawDigest(spki);
+  const identity = Object.freeze({
+    schemaVersion: "programmable.remote-ed25519-provider-identity.v2" as const,
+    endpoint,
+    audience: GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2,
+    keyId: "generic-launch-read",
+    keyEpoch: "epoch-7",
+    publicKeySpkiSha256,
+  });
+  return parseGenericLaunchReadSignerBindingV2({
+    schemaVersion: "programmable.generic-launch-read-signer-binding.v2",
+    endpoint,
+    audience: GENERIC_LAUNCH_READ_SIGNER_AUDIENCE_V2,
+    keyId: identity.keyId,
+    keyEpoch: identity.keyEpoch,
+    publicKeySpkiBase64Url,
+    publicKeySpkiSha256,
+    providerIdentityHash: canonicalSha256(identity.schemaVersion, identity),
+    credentialMode: "vercel-oidc-bearer",
+  });
+}
+
+function signerTransport(
+  privateKey: KeyObject,
+  override: Readonly<{
+    keyEpoch?: string;
+    providerReceiptSignature?: string;
+  }> = {},
+): typeof fetch {
+  return async (_url, init) => {
+    const request = JSON.parse(String(init?.body)) as Record<string, string>;
+    const message = Buffer.from(request.message!, "base64url");
+    const signature = signBytes(null, message, privateKey).toString("base64url");
+    const providerReceipt = Object.freeze({
+      schemaVersion: "programmable.remote-signing-provider-receipt.v2",
+      outcome: "completed",
+      audience: request.audience,
+      keyId: request.keyId,
+      keyEpoch: override.keyEpoch ?? request.keyEpoch,
+      algorithm: "Ed25519",
+      providerIdentityHash: request.providerIdentityHash,
+      idempotencyKey: request.idempotencyKey,
+      messageSha256: request.messageSha256,
+      requestDigest: request.requestDigest,
+      signature,
+      observedAt: NOW.toISOString(),
+      expiresAt: new Date(NOW.getTime() + 300_000).toISOString(),
+    });
+    const receiptBytes = Buffer.from(canonicalizeJson(providerReceipt), "utf8");
+    return new Response(canonicalizeJson({
+      schemaVersion: "programmable.remote-signing-authenticated-response.v2",
+      providerReceipt,
+      providerReceiptDigest: rawDigest(receiptBytes),
+      providerReceiptSignature: override.providerReceiptSignature
+        ?? signBytes(null, receiptBytes, privateKey).toString("base64url"),
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+}
+
+function digest(nibble: string): Sha256Digest {
+  return `sha256:${nibble.repeat(64)}` as Sha256Digest;
+}
+
+function rawDigest(bytes: Uint8Array): Sha256Digest {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}

--- a/tests/generic-launch-read-signer-v2.test.ts
+++ b/tests/generic-launch-read-signer-v2.test.ts
@@ -259,6 +259,23 @@ describe("Generic launch V2 remote read signer", () => {
       payload: null,
     })).rejects.toThrow("deadline");
 
+    const stalledBody = createRemoteGenericLaunchReadSignerV2({
+      ...common,
+      timeoutMs: 500,
+      fetch: async () => new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("{"));
+        },
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    });
+    await expect(stalledBody.sign({
+      requestBindingHash: REQUEST_HASH,
+      payload: null,
+    })).rejects.toThrow("deadline");
+
     const redirected = createRemoteGenericLaunchReadSignerV2({
       ...common,
       fetch: async () => ({ redirected: true, status: 200 }) as Response,

--- a/vercel.json
+++ b/vercel.json
@@ -26,6 +26,10 @@
     {
       "path": "/api/ops/protocol-revenue",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/ops/custom-launch/generic-v2-projector",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Scope\n- add exact authenticated Approval v3 artifact ingress and immutable Postgres replay\n- project finalized/non-revoked Registry V2 lifecycle through two role-bound RPC providers\n- append lifecycle generations and hide superseded/revoked records\n- add dedicated remote Generic V2 read signer, feed/detail/readiness, and Custom-only UI\n\n## Safety\n- remains fail-closed without final Approval, Registry, signer, read-model, and database bindings\n- no criteria, policy interpretation, Classic, Stock, global Explore, or fee logic changed\n\n## Verification\n- focused Custom/Registry/projection suites: 59/59\n- Website projection target regression: 26/26\n- TypeScript and focused ESLint clean\n- exact independent audit in progress on tree 677ca2fabd2134ea1e38db5d38b184c61ee466f1