### PR TITLE
Use dRPC identity with Bitquery market data

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -629,6 +629,18 @@ jobs:
               headers: response.headers,
             };
           }
+          const address = /^0x[0-9a-f]{40}$/u;
+          const positiveInteger = /^[1-9][0-9]*$/u;
+          function exactExploreSources(response) {
+            return response.headers.get("x-programmable-launch-source") ===
+                "drpc" &&
+              response.headers.get("x-programmable-read-source") ===
+                "drpc+bitquery" &&
+              response.headers.get("x-programmable-market-source") ===
+                "bitquery" &&
+              response.headers.get("x-programmable-price-source") ===
+                "bitquery";
+          }
           const health = await requestJson("/api/ops/health");
           if (
             health.body?.status !== "ready" ||
@@ -637,28 +649,72 @@ jobs:
           ) {
             throw new Error("Bitquery health is not ready");
           }
-          const explore = await requestJson(
+          const highest = await requestJson(
             "/api/explore?limit=20&page=1&sort=market-cap",
           );
-          const tokens = Array.isArray(explore.body?.tokens)
-            ? explore.body.tokens
+          const highestTokens = Array.isArray(highest.body?.tokens)
+            ? highest.body.tokens
             : [];
           if (
-            explore.body?.status !== "ready" ||
-            tokens.length < 1 ||
-            explore.headers.get("x-programmable-market-source") !== "bitquery" ||
-            explore.headers.get("x-programmable-rpc-provider") !== null
+            highest.body?.status !== "ready" ||
+            highest.body?.sort !== "market-cap" ||
+            highest.body?.sortMetric !== "fdv" ||
+            highestTokens.length < 1 ||
+            !exactExploreSources(highest)
           ) {
-            throw new Error("Bitquery Explore is not ready");
+            throw new Error("Highest FDV is not ready");
           }
-          const tokenAddress = tokens.find(
-            (token) => /^0x[0-9a-f]{40}$/u.test(
-              String(token?.tokenAddress ?? "").toLowerCase(),
-            ),
-          )?.tokenAddress;
-          if (!tokenAddress) {
-            throw new Error("Bitquery Explore returned no token identity");
+          const valuedHighest = highestTokens.filter(
+            (token) =>
+              token?.valuation?.status === "available" &&
+              token.valuation.source === "bitquery" &&
+              positiveInteger.test(String(token.valuation.valueWad ?? "")),
+          );
+          if (valuedHighest.length < 1) {
+            throw new Error("Highest FDV returned no Bitquery valuation");
           }
+          for (let index = 1; index < valuedHighest.length; index += 1) {
+            if (
+              BigInt(valuedHighest[index - 1].valuation.valueWad) <
+                BigInt(valuedHighest[index].valuation.valueWad)
+            ) {
+              throw new Error("Highest FDV is not ordered descending");
+            }
+          }
+          const newest = await requestJson(
+            "/api/explore?limit=20&page=1&sort=newest",
+          );
+          const newestTokens = Array.isArray(newest.body?.tokens)
+            ? newest.body.tokens
+            : [];
+          if (
+            newest.body?.status !== "ready" ||
+            newest.body?.sort !== "newest" ||
+            newestTokens.length < 1 ||
+            !exactExploreSources(newest)
+          ) {
+            throw new Error("Newest launches are not ready");
+          }
+          for (let index = 1; index < newestTokens.length; index += 1) {
+            const previous = Date.parse(newestTokens[index - 1]?.launchedAt ?? "");
+            const current = Date.parse(newestTokens[index]?.launchedAt ?? "");
+            if (
+              !Number.isFinite(previous) ||
+              !Number.isFinite(current) ||
+              previous < current
+            ) {
+              throw new Error("Newest launches are not ordered descending");
+            }
+          }
+          const marketToken = valuedHighest.find(
+            (token) =>
+              address.test(String(token?.tokenAddress ?? "").toLowerCase()) &&
+              token?.marketData?.source === "bitquery",
+          );
+          if (!marketToken) {
+            throw new Error("Highest FDV returned no canonical market token");
+          }
+          const tokenAddress = marketToken.tokenAddress;
           const detail = await requestJson(
             "/api/explore/token?address=" + encodeURIComponent(tokenAddress),
           );
@@ -666,10 +722,12 @@ jobs:
             detail.body?.status !== "ready" ||
             detail.body?.token?.tokenAddress?.toLowerCase() !==
               tokenAddress.toLowerCase() ||
+            detail.body?.token?.marketData?.source !== "bitquery" ||
+            detail.body?.token?.valuation?.source !== "bitquery" ||
             detail.headers.get("x-programmable-market-source") !== "bitquery" ||
-            detail.headers.get("x-programmable-rpc-provider") !== null
+            detail.headers.get("x-programmable-price-source") !== "bitquery"
           ) {
-            throw new Error("Bitquery token detail is not ready");
+            throw new Error("Token detail market data is not ready");
           }
           const chart = await requestJson(
             "/api/explore/token/chart?address=" +
@@ -678,17 +736,50 @@ jobs:
           );
           if (
             chart.body?.source !== "bitquery" ||
+            chart.body?.readStatus !== "live" ||
             !["ready", "insufficient-history"].includes(chart.body?.status) ||
             chart.headers.get("x-programmable-market-source") !== "bitquery" ||
-            chart.headers.get("x-programmable-rpc-provider") !== null
+            chart.headers.get("x-programmable-price-source") !== "bitquery"
           ) {
             throw new Error("Bitquery chart is not ready");
           }
+          const profileToken = [...newestTokens, ...highestTokens].find(
+            (token) =>
+              address.test(String(token?.creatorAddress ?? "").toLowerCase()),
+          );
+          if (!profileToken) {
+            throw new Error("Launches returned no creator profile identity");
+          }
+          const profileAccount = profileToken.creatorAddress;
+          const profile = await requestJson(
+            "/api/explore/profile?account=" +
+              encodeURIComponent(profileAccount),
+          );
+          if (
+            profile.body?.status !== "ready" ||
+            profile.body?.account?.toLowerCase() !==
+              profileAccount.toLowerCase() ||
+            !Array.isArray(profile.body?.tokens) ||
+            !Array.isArray(profile.body?.pools) ||
+            !Array.isArray(profile.body?.claims) ||
+            !/^(?:0|[1-9][0-9]*)$/u.test(
+              String(profile.body?.totals?.claimableWei ?? ""),
+            ) ||
+            profile.headers.get("x-programmable-launch-source") !== "drpc" ||
+            profile.headers.get("x-programmable-read-source") !== "drpc" ||
+            profile.headers.get("x-programmable-rpc-provider") !==
+              "drpc-primary"
+          ) {
+            throw new Error("Creator profile is not ready");
+          }
           process.stdout.write(
             JSON.stringify({
-              status: "verified-bitquery-only-staged-public-apis",
+              status: "verified-staged-drpc-bitquery-public-apis",
               tokenAddress,
+              profileAccount,
               chartStatus: chart.body.status,
+              creatorClaimPrepare: "separate-live-probe-required",
+              tradePrepare: "separate-live-probe-required",
             }) + "\n",
           );
           NODE
@@ -723,7 +814,8 @@ jobs:
             echo "- Target: $STAGED_TARGET_URL"
             echo "- Previous production deployment: \`$PREVIOUS_DEPLOYMENT_ID\`"
             echo "- Previous production commit: \`$PREVIOUS_GIT_HEAD\`"
-            echo "- Website data provider: Bitquery"
+            echo "- Launch identity provider: commitment-bound dRPC primary"
+            echo "- Market data provider: Bitquery"
             echo "- Custom V2 verification required by this commit: \`$CUSTOM_V2_REQUIRED\`"
             if [ "$CUSTOM_V2_REQUIRED" = true ]; then
               echo "- Custom V2 evidence: \`${{ steps.custom-v2-stage.outputs.evidence_sha256 }}\`"

--- a/app/api/explore/profile/claim/route.ts
+++ b/app/api/explore/profile/claim/route.ts
@@ -20,8 +20,11 @@ import {
   parseCreatorClaimRequest,
 } from "../../../../../lib/onchain";
 import { creatorFeeHookReadAbi } from "../../../../../lib/onchain/abis";
-import { readBitqueryExploreModelV1 } from
-  "../../../../../lib/market-data/bitquery-explore-model.server";
+import {
+  ActionRpcIdentityError,
+  readCreatorClaimIdentityFromRpc,
+  type CreatorClaimTokenIdentity,
+} from "../../../../../lib/server/action-rpc-identity.server";
 import {
   ActionRpcProviderError,
   creatorClaimRpcProvider,
@@ -30,43 +33,14 @@ import {
   errorChainIncludesData,
   safeServerErrorSummary,
 } from "../../../../../lib/server/safe-error";
-import { computeOfficialV4PoolId } from "../../../../../lib/uniswap/liquidity-launcher-sdk";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const MAX_REQUEST_BYTES = 2_048;
 const NO_FEES_TO_CLAIM_SELECTOR = "0x846d8c5c";
-const NATIVE_ETH = "0x0000000000000000000000000000000000000000" as Address;
 const CLAIM_RPC_UNAVAILABLE_MESSAGE =
   "Creator claim reads are temporarily unavailable. Try again";
-
-type CreatorClaimTokenIdentity = Readonly<{
-  tokenAddress: Address;
-  hookAddress: Address;
-  poolId: Hex;
-  creatorAddress: Address;
-  totalSwapFeeBps: number;
-  buySwapFeeBps: number;
-  sellSwapFeeBps: number;
-  creatorFeeBps: number;
-  launcherFeeBps: number;
-  transferTaxBps: number;
-  lpFeePips: number;
-}>;
-
-function canonicalClaimPoolId(
-  tokenAddress: Address,
-  hookAddress: Address,
-) {
-  return computeOfficialV4PoolId({
-    currency0: NATIVE_ETH,
-    currency1: tokenAddress,
-    fee: 0,
-    tickSpacing: 200,
-    hooks: hookAddress,
-  });
-}
 
 function claimClient(
   deployment: ReturnType<typeof getOnchainDeployment>,
@@ -166,104 +140,21 @@ async function readCurrentClaimState(input: {
     );
   }
   const [creator, registrar, totalSwapFeeBps, registered, claimable] = config;
-  const [buyFee, sellFee, creatorFee, launcherFee, transferTax, lpFee] =
-    disclosure;
   if (
     !registered ||
     getAddress(creator).toLowerCase() !== token.creatorAddress.toLowerCase() ||
     getAddress(registrar).toLowerCase() !== deployment.launcher.toLowerCase() ||
     Number(totalSwapFeeBps) !== token.totalSwapFeeBps ||
-    Number(buyFee) !== token.buySwapFeeBps ||
-    Number(sellFee) !== token.sellSwapFeeBps ||
-    Number(creatorFee) !== token.creatorFeeBps ||
-    Number(launcherFee) !== token.launcherFeeBps ||
-    Number(transferTax) !== token.transferTaxBps ||
-    Number(lpFee) !== token.lpFeePips
-  ) {
-    throw new CreatorClaimUnavailableError(
-      "identity-mismatch",
-      "The current creator fee state does not match the indexed launch",
-    );
-  }
-  return { claimable };
-}
-
-async function bitqueryClaimToken(
-  request: ReturnType<typeof parseCreatorClaimRequest>,
-  deployment: Extract<ReturnType<typeof getOnchainDeployment>, { status: "ready" }>,
-  signal?: AbortSignal,
-): Promise<CreatorClaimTokenIdentity> {
-  let model: Awaited<ReturnType<typeof readBitqueryExploreModelV1>>;
-  try {
-    if (deployment.chainId !== 1) throw new Error("unsupported chain");
-    model = await readBitqueryExploreModelV1({ signal });
-  } catch {
-    throw new CreatorClaimUnavailableError(
-      "registry-unavailable",
-      "The verified Programmable launch registry is temporarily unavailable",
-    );
-  }
-  if (model.status !== "ready" || model.snapshot.chainId !== deployment.chainId) {
-    throw new CreatorClaimUnavailableError(
-      "registry-unavailable",
-      "The verified Programmable launch registry is unavailable",
-    );
-  }
-  const token = model.tokens.find(
-    (candidate) =>
-      candidate.poolId.toLowerCase() === request.poolId.toLowerCase(),
-  );
-  if (!token) {
-    throw new CreatorClaimUnavailableError(
-      "unknown-pool",
-      "This pool is not a verified Programmable launch",
-    );
-  }
-  const feeValues = [
-    token.buyHookFeeBps,
-    token.sellHookFeeBps,
-    token.creatorFeeBps,
-    token.launcherFeeBps,
-    token.transferTaxBps,
-    token.lpFeePips,
-  ];
-  if (
-    token.launchModel !== "classic" ||
-    token.launchStampProvenance !== undefined ||
-    token.hookAddress.toLowerCase() !== deployment.feeHook.toLowerCase() ||
-    !token.creatorAddress ||
-    typeof token.totalSwapFeeBps !== "number" ||
-    !Number.isSafeInteger(token.totalSwapFeeBps) ||
-    token.totalSwapFeeBps < 0 ||
-    canonicalClaimPoolId(
-      getAddress(token.tokenAddress),
-      getAddress(token.hookAddress),
-    ).toLowerCase() !== request.poolId.toLowerCase() ||
-    feeValues.some(
-      (value) =>
-        typeof value !== "number" ||
-        !Number.isSafeInteger(value) ||
-        value < 0,
+    disclosure.some(
+      (value) => !Number.isSafeInteger(Number(value)) || Number(value) < 0,
     )
   ) {
     throw new CreatorClaimUnavailableError(
-      "noncanonical-hook",
-      "The pool does not use the canonical creator fee hook",
+      "identity-mismatch",
+      "The current creator fee state does not match the requested launch",
     );
   }
-  return {
-    tokenAddress: getAddress(token.tokenAddress),
-    hookAddress: getAddress(token.hookAddress),
-    poolId: request.poolId,
-    creatorAddress: getAddress(token.creatorAddress),
-    totalSwapFeeBps: token.totalSwapFeeBps,
-    buySwapFeeBps: token.buyHookFeeBps!,
-    sellSwapFeeBps: token.sellHookFeeBps!,
-    creatorFeeBps: token.creatorFeeBps!,
-    launcherFeeBps: token.launcherFeeBps!,
-    transferTaxBps: token.transferTaxBps!,
-    lpFeePips: token.lpFeePips!,
-  };
+  return { claimable };
 }
 
 function json(body: unknown, status = 200) {
@@ -351,11 +242,15 @@ export async function POST(request: NextRequest) {
         `Switch to chain ${deployment.chainId}`,
       );
     }
-    const token = await bitqueryClaimToken(
-      claimRequest,
+    const provider = creatorClaimRpcProvider(deployment);
+    const client = claimClient(deployment, provider.endpoint);
+    const snapshot = await currentClaimSnapshot(client);
+    const token = await readCreatorClaimIdentityFromRpc({
+      client,
       deployment,
-      request.signal,
-    );
+      poolId: claimRequest.poolId,
+      blockNumber: snapshot.blockNumber,
+    });
     if (
       token.creatorAddress.toLowerCase() !== claimRequest.account.toLowerCase()
     ) {
@@ -364,10 +259,6 @@ export async function POST(request: NextRequest) {
         "This account is not the recorded creator for the pool",
       );
     }
-
-    const provider = creatorClaimRpcProvider(deployment);
-    const client = claimClient(deployment, provider.endpoint);
-    const snapshot = await currentClaimSnapshot(client);
     const state = await readCurrentClaimState({
       client,
       deployment,
@@ -435,15 +326,16 @@ export async function POST(request: NextRequest) {
     }
     if (
       error instanceof CreatorClaimUnavailableError ||
-      error instanceof ActionRpcProviderError
+      error instanceof ActionRpcProviderError ||
+      error instanceof ActionRpcIdentityError
     ) {
       const unavailable =
         error instanceof ActionRpcProviderError
           ? claimRpcUnavailable()
-          : error;
-      const retryable =
-        unavailable.code === "rpc-unavailable" ||
-        unavailable.code === "registry-unavailable";
+          : error instanceof ActionRpcIdentityError
+            ? new CreatorClaimUnavailableError(error.code, error.message)
+            : error;
+      const retryable = unavailable.code === "rpc-unavailable";
       return json(
         blockedResponse(
           unavailable.code === "not-deployed" ? "not-deployed" : "blocked",

--- a/app/api/explore/profile/route.ts
+++ b/app/api/explore/profile/route.ts
@@ -1,14 +1,433 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAddress, isAddress } from "viem";
-
 import {
-  readBitqueryCreatorProfile,
-  safeBitqueryProfileError,
-} from "@/lib/market-data/bitquery-profile.server";
+  createPublicClient,
+  formatUnits,
+  getAddress,
+  http,
+  isAddress,
+  keccak256,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { mainnet } from "viem/chains";
+
+import appDeployments from "@/contracts/config/app-deployments.v1.json";
+import {
+  creatorFeeHookReadAbi,
+  creatorFeesClaimedEvent,
+  memeTokenLaunchedEvent,
+  uerc20ReadAbi,
+} from "@/lib/onchain/abis";
+import type {
+  CreatorClaim,
+  CreatorProfile,
+} from "@/lib/onchain/types";
+import { productionMainnetRpcPrimary } from
+  "@/lib/onchain/website-rpc-providers.server";
 import { creatorProfileApiError } from "@/lib/profile/onchain-profile";
+import type { LauncherToken } from "@/lib/tokens";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+const CONFIRMATIONS = 12n;
+const LOG_RANGE = 10_000n;
+const TOTAL_SUPPLY_RAW = "1000000000000000000000000000";
+
+type Release = Readonly<{
+  launcher: Address;
+  hook: Address;
+  launcherRuntimeCodeHash: Hex;
+  hookRuntimeCodeHash: Hex;
+  startBlock: bigint;
+}>;
+
+type ProfileLaunch = Readonly<{
+  release: Release;
+  creator: Address;
+  token: Address;
+  poolId: Hex;
+  positionRecipient: Address;
+  positionTokenId: bigint;
+  totalSwapFeeBps: number;
+  launchHash: Hex;
+  blockNumber: bigint;
+  transactionHash: Hex;
+  transactionIndex: number;
+  logIndex: number;
+}>;
+
+type DeploymentShape = Readonly<{
+  production: Readonly<{
+    memeLaunch: string;
+    ethCreatorFeeHook: string;
+    runtimeCodeHashes: Readonly<{
+      memeLaunch: string;
+      ethCreatorFeeHook: string;
+    }>;
+    deploymentBlocks: Readonly<{ memeLaunch: number }>;
+    historicalV1Deployment: Readonly<{
+      memeLaunch: string;
+      ethCreatorFeeHook: string;
+      runtimeCodeHashes: Readonly<{
+        memeLaunch: string;
+        ethCreatorFeeHook: string;
+      }>;
+      deploymentBlocks: Readonly<{ memeLaunch: number }>;
+    }>;
+  }>;
+}>;
+
+function releases(): readonly Release[] {
+  const production = (appDeployments as unknown as DeploymentShape).production;
+  const historical = production.historicalV1Deployment;
+  return [
+    {
+      launcher: getAddress(historical.memeLaunch),
+      hook: getAddress(historical.ethCreatorFeeHook),
+      launcherRuntimeCodeHash: historical.runtimeCodeHashes.memeLaunch as Hex,
+      hookRuntimeCodeHash: historical.runtimeCodeHashes.ethCreatorFeeHook as Hex,
+      startBlock: BigInt(historical.deploymentBlocks.memeLaunch),
+    },
+    {
+      launcher: getAddress(production.memeLaunch),
+      hook: getAddress(production.ethCreatorFeeHook),
+      launcherRuntimeCodeHash: production.runtimeCodeHashes.memeLaunch as Hex,
+      hookRuntimeCodeHash: production.runtimeCodeHashes.ethCreatorFeeHook as Hex,
+      startBlock: BigInt(production.deploymentBlocks.memeLaunch),
+    },
+  ];
+}
+
+function profileClient() {
+  const provider = productionMainnetRpcPrimary();
+  return createPublicClient({
+    chain: mainnet,
+    batch: { multicall: true },
+    transport: http(provider.url, { retryCount: 1, timeout: 12_000 }),
+  });
+}
+
+function minimum(left: bigint, right: bigint) {
+  return left < right ? left : right;
+}
+
+async function assertRuntime(
+  client: PublicClient,
+  address: Address,
+  expectedHash: Hex,
+  blockNumber: bigint,
+) {
+  const code = await client.getCode({ address, blockNumber });
+  if (
+    !code || code === "0x" ||
+    keccak256(code).toLowerCase() !== expectedHash.toLowerCase()
+  ) {
+    throw new Error("Creator profile runtime does not match its manifest");
+  }
+}
+
+async function readLaunches(
+  client: PublicClient,
+  release: Release,
+  account: Address,
+  toBlock: bigint,
+) {
+  const launches: ProfileLaunch[] = [];
+  for (
+    let fromBlock = release.startBlock;
+    fromBlock <= toBlock;
+    fromBlock += LOG_RANGE
+  ) {
+    const logs = await client.getLogs({
+      address: release.launcher,
+      event: memeTokenLaunchedEvent,
+      args: { creator: account },
+      fromBlock,
+      toBlock: minimum(toBlock, fromBlock + LOG_RANGE - 1n),
+      strict: true,
+    });
+    for (const log of logs) {
+      if (log.removed) continue;
+      if (
+        log.blockNumber === null ||
+        log.transactionHash === null || log.transactionIndex === null ||
+        log.logIndex === null
+      ) {
+        throw new Error("Creator launch identity is incomplete");
+      }
+      if (
+        log.args.creator.toLowerCase() !== account.toLowerCase() ||
+        log.args.feeHook.toLowerCase() !== release.hook.toLowerCase()
+      ) {
+        throw new Error("Creator launch identity does not match its manifest");
+      }
+      launches.push({
+        release,
+        creator: getAddress(log.args.creator),
+        token: getAddress(log.args.token),
+        poolId: log.args.poolId,
+        positionRecipient: getAddress(log.args.positionRecipient),
+        positionTokenId: log.args.positionTokenId,
+        totalSwapFeeBps: log.args.totalSwapFeeBps,
+        launchHash: log.args.launchHash,
+        blockNumber: log.blockNumber,
+        transactionHash: log.transactionHash,
+        transactionIndex: log.transactionIndex,
+        logIndex: log.logIndex,
+      });
+    }
+  }
+  return launches;
+}
+
+async function readClaims(
+  client: PublicClient,
+  release: Release,
+  account: Address,
+  launches: readonly ProfileLaunch[],
+  toBlock: bigint,
+) {
+  if (launches.length === 0) return [];
+  const poolIds = launches.map((launch) => launch.poolId);
+  const tokenByPool = new Map(
+    launches.map((launch) => [launch.poolId.toLowerCase(), launch.token]),
+  );
+  const claims = [];
+  for (
+    let fromBlock = release.startBlock;
+    fromBlock <= toBlock;
+    fromBlock += LOG_RANGE
+  ) {
+    const logs = await client.getLogs({
+      address: release.hook,
+      event: creatorFeesClaimedEvent,
+      args: { poolId: poolIds, creator: account },
+      fromBlock,
+      toBlock: minimum(toBlock, fromBlock + LOG_RANGE - 1n),
+      strict: true,
+    });
+    for (const log of logs) {
+      if (log.removed) continue;
+      if (
+        log.blockNumber === null ||
+        log.transactionHash === null || log.transactionIndex === null ||
+        log.logIndex === null
+      ) {
+        throw new Error("Creator claim identity is incomplete");
+      }
+      if (
+        log.args.creator.toLowerCase() !== account.toLowerCase() ||
+        !tokenByPool.has(log.args.poolId.toLowerCase())
+      ) {
+        throw new Error("Creator claim is outside its verified profile");
+      }
+      claims.push({ log, token: tokenByPool.get(log.args.poolId.toLowerCase())! });
+    }
+  }
+  return claims;
+}
+
+async function readCreatorProfile(
+  account: Address,
+  client: PublicClient,
+): Promise<CreatorProfile> {
+  const head = await client.getBlockNumber();
+  const snapshotBlock = head > CONFIRMATIONS ? head - CONFIRMATIONS : head;
+  const snapshot = await client.getBlock({ blockNumber: snapshotBlock });
+  if (!snapshot.hash) throw new Error("Creator profile snapshot has no block hash");
+
+  const releaseValues = releases();
+  await Promise.all(releaseValues.flatMap((release) => [
+    assertRuntime(
+      client,
+      release.launcher,
+      release.launcherRuntimeCodeHash,
+      snapshotBlock,
+    ),
+    assertRuntime(
+      client,
+      release.hook,
+      release.hookRuntimeCodeHash,
+      snapshotBlock,
+    ),
+  ]));
+  const launchesByRelease = await Promise.all(
+    releaseValues.map((release) =>
+      snapshotBlock < release.startBlock
+        ? Promise.resolve([])
+        : readLaunches(client, release, account, snapshotBlock)
+    ),
+  );
+  const claimGroups = await Promise.all(
+    releaseValues.map((release, index) =>
+      readClaims(
+        client,
+        release,
+        account,
+        launchesByRelease[index]!,
+        snapshotBlock,
+      )
+    ),
+  );
+  const launches = launchesByRelease.flat();
+  if (
+    new Set(launches.map((launch) => launch.poolId.toLowerCase())).size !==
+      launches.length ||
+    new Set(launches.map((launch) => launch.token.toLowerCase())).size !==
+      launches.length
+  ) {
+    throw new Error("Creator profile contains duplicate launch identity");
+  }
+
+  const relevantBlocks = [...new Set([
+    ...launches.map((launch) => launch.blockNumber.toString()),
+    ...claimGroups.flat().map(({ log }) => log.blockNumber!.toString()),
+  ])];
+  const timestamps = new Map<string, bigint>();
+  await Promise.all(relevantBlocks.map(async (blockNumber) => {
+    const block = await client.getBlock({ blockNumber: BigInt(blockNumber) });
+    timestamps.set(blockNumber, block.timestamp);
+  }));
+
+  const claims: CreatorClaim[] = claimGroups.flat()
+    .map(({ log, token }) => {
+      const timestamp = timestamps.get(log.blockNumber!.toString());
+      if (timestamp === undefined) {
+        throw new Error("Creator claim time is unavailable");
+      }
+      return {
+        poolId: log.args.poolId,
+        tokenAddress: token,
+        creatorAddress: getAddress(log.args.creator),
+        recipientAddress: getAddress(log.args.recipient),
+        callerAddress: getAddress(log.args.caller),
+        amountWei: log.args.amount.toString(),
+        amountEth: formatUnits(log.args.amount, 18),
+        blockNumber: log.blockNumber!.toString(),
+        transactionHash: log.transactionHash!,
+        transactionIndex: log.transactionIndex!,
+        logIndex: log.logIndex!,
+        claimedAt: new Date(Number(timestamp) * 1_000).toISOString(),
+      };
+    })
+    .sort((left, right) => {
+      const blockDifference = BigInt(right.blockNumber) - BigInt(left.blockNumber);
+      if (blockDifference !== 0n) return blockDifference < 0n ? -1 : 1;
+      if (left.transactionIndex !== right.transactionIndex) {
+        return right.transactionIndex - left.transactionIndex;
+      }
+      return right.logIndex - left.logIndex;
+    });
+  const claimedByPool = new Map<string, bigint>();
+  for (const claim of claims) {
+    const key = claim.poolId.toLowerCase();
+    claimedByPool.set(key, (claimedByPool.get(key) ?? 0n) + BigInt(claim.amountWei));
+  }
+
+  const hydrated = await Promise.all(launches.map(async (launch) => {
+    const [name, symbol, poolConfig] = await Promise.all([
+      client.readContract({
+        address: launch.token,
+        abi: uerc20ReadAbi,
+        functionName: "name",
+        blockNumber: snapshotBlock,
+      }),
+      client.readContract({
+        address: launch.token,
+        abi: uerc20ReadAbi,
+        functionName: "symbol",
+        blockNumber: snapshotBlock,
+      }),
+      client.readContract({
+        address: launch.release.hook,
+        abi: creatorFeeHookReadAbi,
+        functionName: "poolFeeConfig",
+        args: [launch.poolId],
+        blockNumber: snapshotBlock,
+      }),
+    ]);
+    const [creator, registrar, totalSwapFeeBps, registered, accrued] = poolConfig;
+    if (
+      !registered || creator.toLowerCase() !== account.toLowerCase() ||
+      registrar.toLowerCase() !== launch.release.launcher.toLowerCase() ||
+      totalSwapFeeBps !== launch.totalSwapFeeBps
+    ) {
+      throw new Error("Creator reward pool does not match its launch identity");
+    }
+    const claimed = claimedByPool.get(launch.poolId.toLowerCase()) ?? 0n;
+    const timestamp = timestamps.get(launch.blockNumber.toString());
+    if (timestamp === undefined) throw new Error("Creator launch time is unavailable");
+    const token: LauncherToken = {
+      id: launch.token.toLowerCase(),
+      name,
+      symbol,
+      tokenAddress: launch.token,
+      hookAddress: launch.release.hook,
+      poolId: launch.poolId,
+      creatorAddress: launch.creator,
+      positionRecipient: launch.positionRecipient,
+      positionTokenId: launch.positionTokenId.toString(),
+      launchHash: launch.launchHash,
+      launchBlockNumber: launch.blockNumber.toString(),
+      launchTransactionHash: launch.transactionHash,
+      launchTransactionIndex: launch.transactionIndex,
+      launchLogIndex: launch.logIndex,
+      launchedAt: new Date(Number(timestamp) * 1_000).toISOString(),
+      totalSupply: "1000000000",
+      totalSupplyRaw: TOTAL_SUPPLY_RAW,
+      tokenDecimals: 18,
+      totalSwapFeeBps: launch.totalSwapFeeBps,
+      buyHookFeeBps: launch.totalSwapFeeBps,
+      sellHookFeeBps: launch.totalSwapFeeBps,
+      creatorFeesAccruedWei: accrued.toString(),
+      creatorFeesAccruedEth: formatUnits(accrued, 18),
+      creatorFeesGeneratedWei: (accrued + claimed).toString(),
+      creatorFeesGeneratedEth: formatUnits(accrued + claimed, 18),
+      launchModel: "classic",
+      liquidityPath: "meme",
+    };
+    return { token, accrued, claimed };
+  }));
+
+  const pools = hydrated.map(({ token }) => ({
+    tokenAddress: getAddress(token.tokenAddress),
+    name: token.name,
+    symbol: token.symbol,
+    poolId: token.poolId as Hex,
+    totalSwapFeeBps: token.totalSwapFeeBps!,
+    launchModel: "classic" as const,
+    claimableCreatorFeesWei: token.creatorFeesAccruedWei!,
+    claimableCreatorFeesEth: token.creatorFeesAccruedEth!,
+    generatedCreatorFeesWei: token.creatorFeesGeneratedWei!,
+    generatedCreatorFeesEth: token.creatorFeesGeneratedEth!,
+  }));
+  const claimable = hydrated.reduce((sum, value) => sum + value.accrued, 0n);
+  const claimed = hydrated.reduce((sum, value) => sum + value.claimed, 0n);
+  return {
+    status: "ready",
+    account,
+    tokens: hydrated.map(({ token }) => token),
+    pools,
+    claims,
+    totals: {
+      claimableWei: claimable.toString(),
+      claimableEth: formatUnits(claimable, 18),
+      generatedWei: (claimable + claimed).toString(),
+      generatedEth: formatUnits(claimable + claimed, 18),
+      claimedWei: claimed.toString(),
+      claimedEth: formatUnits(claimed, 18),
+    },
+    snapshot: {
+      chainId: 1,
+      blockNumber: snapshotBlock.toString(),
+      blockHash: snapshot.hash,
+      blockTimestamp: new Date(Number(snapshot.timestamp) * 1_000).toISOString(),
+      confirmations: Number(head - snapshotBlock),
+    },
+  };
+}
 
 export async function GET(request: NextRequest) {
   const search = request.nextUrl.searchParams;
@@ -30,16 +449,23 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const profile = await readBitqueryCreatorProfile(getAddress(input));
+    const profile = await readCreatorProfile(getAddress(input), profileClient());
     return NextResponse.json(profile, {
       headers: {
         "Cache-Control": "private, max-age=0, s-maxage=15",
-        "X-Programmable-Launch-Source": "bitquery-events",
-        "X-Programmable-Read-Source": "bitquery",
+        "X-Programmable-Launch-Source": "drpc",
+        "X-Programmable-Read-Source": "drpc",
+        "X-Programmable-Rpc-Provider": "drpc-primary",
       },
     });
   } catch (error) {
-    console.error("Bitquery creator profile read failed", safeBitqueryProfileError(error));
+    console.error(
+      "dRPC creator profile read failed",
+      {
+        name: error instanceof Error ? error.name : "UnknownError",
+        category: "read-failed",
+      },
+    );
     return NextResponse.json(creatorProfileApiError("temporary"), {
       status: 503,
       headers: { "Cache-Control": "no-store" },

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -277,7 +277,7 @@ export async function GET(request: NextRequest) {
     const identityEntries = dedupeExploreEntriesV1(launches.entries);
     const marketByToken = await readBitqueryTokenMarketDataStrictV1(
       exploreEntriesMarketIdentitiesV1(identityEntries),
-      { signal: request.signal },
+      { signal: request.signal, includeStats: false },
     );
     const now = new Date();
     const valuedEntries: ValuedExploreEntry[] = identityEntries.map((entry) => {

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -11,10 +11,15 @@ import {
   readBitqueryTokenMarketDataStrictV1,
   safeBitqueryMarketDataError,
 } from "../../../lib/market-data/bitquery.server";
-import { readBitqueryExploreEntriesV1 } from
-  "../../../lib/market-data/bitquery-launches.server";
-import { exploreEntriesMarketIdentitiesV1 } from
+import {
+  exploreEntriesMarketIdentitiesV1,
+  exploreEntryMarketIdentitiesV1,
+} from
   "../../../lib/market-data/explore-market-identities";
+import {
+  readPrimaryRpcExploreEntriesV1,
+  safePrimaryRpcLaunchCatalogError,
+} from "../../../lib/market-data/primary-rpc-launches.server";
 import { parseExploreSort } from "../../../lib/onchain/query";
 import type { ExploreSort } from "../../../lib/onchain/types";
 import type { ExploreEntry } from "../../../lib/tokens";
@@ -189,13 +194,13 @@ export function dedupeExploreEntriesV1(
     const existingId = byId.get(entry.id);
     if (existingId !== undefined) {
       if (JSON.stringify(existingId) === JSON.stringify(entry)) continue;
-      throw new Error(`Bitquery returned conflicting launch ${entry.id}`);
+      throw new Error(`Launch catalog returned conflicting launch ${entry.id}`);
     }
     const address = entry.tokenAddress?.toLowerCase();
     const existingAddress = address ? byTokenAddress.get(address) : undefined;
     if (existingAddress !== undefined) {
       if (JSON.stringify(existingAddress) === JSON.stringify(entry)) continue;
-      throw new Error(`Bitquery returned conflicting token ${entry.tokenAddress}`);
+      throw new Error(`Launch catalog returned conflicting token ${entry.tokenAddress}`);
     }
     byId.set(entry.id, entry);
     if (address) byTokenAddress.set(address, entry);
@@ -266,7 +271,7 @@ export async function GET(request: NextRequest) {
       pageSize: integerQuery(search.get("limit"), 9),
       socials,
     } as const;
-    const launches = await readBitqueryExploreEntriesV1({
+    const launches = await readPrimaryRpcExploreEntriesV1({
       signal: request.signal,
     });
     const identityEntries = dedupeExploreEntriesV1(launches.entries);
@@ -279,6 +284,10 @@ export async function GET(request: NextRequest) {
       const marketData = entry.tokenAddress
         ? marketByToken.get(entry.tokenAddress.toLowerCase())
         : undefined;
+      const marketIsRequired = exploreEntryMarketIdentitiesV1(entry).length > 0;
+      if (marketIsRequired && marketData === undefined) {
+        throw new Error("Bitquery market response is incomplete");
+      }
       return marketData
         ? withBitqueryMarketData(entry, marketData, { now })
         : {
@@ -318,8 +327,8 @@ export async function GET(request: NextRequest) {
         headers: {
           "Cache-Control": "public, max-age=0, s-maxage=2",
           "X-Programmable-Data-Quality": dataQuality.status,
-          "X-Programmable-Launch-Source": "bitquery",
-          "X-Programmable-Read-Source": "bitquery",
+          "X-Programmable-Launch-Source": "drpc",
+          "X-Programmable-Read-Source": "drpc+bitquery",
           "X-Programmable-Market-Source": "bitquery",
           "X-Programmable-Price-Source": "bitquery",
           ...(dataQuality.valuation.asOfTime
@@ -329,7 +338,10 @@ export async function GET(request: NextRequest) {
       },
     );
   } catch (error) {
-    console.error("Bitquery Explore read failed", safeBitqueryMarketDataError(error));
+    console.error("Explore read failed", {
+      launch: safePrimaryRpcLaunchCatalogError(error),
+      market: safeBitqueryMarketDataError(error),
+    });
     return NextResponse.json(
       { error: "Token data is temporarily unavailable" },
       {
@@ -337,8 +349,8 @@ export async function GET(request: NextRequest) {
         headers: {
           "Cache-Control": "no-store",
           "Retry-After": "5",
-          "X-Programmable-Launch-Source": "bitquery",
-          "X-Programmable-Read-Source": "bitquery",
+          "X-Programmable-Launch-Source": "drpc",
+          "X-Programmable-Read-Source": "drpc+bitquery",
           "X-Programmable-Market-Source": "bitquery",
         },
       },

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -8,6 +8,7 @@ import {
   type ValuedExploreEntry,
 } from "../../../lib/explore-financial-data";
 import {
+  readBitqueryTokenFdvRankingStrictV1,
   readBitqueryTokenMarketDataStrictV1,
   safeBitqueryMarketDataError,
 } from "../../../lib/market-data/bitquery.server";
@@ -16,6 +17,8 @@ import {
   exploreEntryMarketIdentitiesV1,
 } from
   "../../../lib/market-data/explore-market-identities";
+import type { TokenMarketDataV1 } from
+  "../../../lib/market-data/market-data-v1";
 import {
   readPrimaryRpcExploreEntriesV1,
   safePrimaryRpcLaunchCatalogError,
@@ -184,6 +187,35 @@ function filterExploreEntries(
   });
 }
 
+function withBitqueryRankingData(
+  entry: ExploreEntry,
+  marketData: TokenMarketDataV1,
+): ValuedExploreEntry {
+  const primary = marketData.pools.find(
+    (pool) => pool.identity.poolId === marketData.primaryPoolId,
+  );
+  const value = primary?.valuation;
+  return {
+    ...entry,
+    marketData,
+    valuation: value?.status === "available"
+      ? {
+          status: "available",
+          metric: "fdv",
+          supplyBasis: "total",
+          currency: "usd",
+          valueWad: value.valueUsdWad,
+          freshness: value.freshness,
+          source: "bitquery",
+          asOfTime: value.asOfTime,
+        }
+      : {
+          status: "unavailable",
+          reason: "source-unavailable",
+        },
+  };
+}
+
 export function dedupeExploreEntriesV1(
   entries: readonly ExploreEntry[],
 ): ExploreEntry[] {
@@ -275,33 +307,63 @@ export async function GET(request: NextRequest) {
       signal: request.signal,
     });
     const identityEntries = dedupeExploreEntriesV1(launches.entries);
-    const marketByToken = await readBitqueryTokenMarketDataStrictV1(
-      exploreEntriesMarketIdentitiesV1(identityEntries),
-      { signal: request.signal, includeStats: false },
-    );
     const now = new Date();
-    const valuedEntries: ValuedExploreEntry[] = identityEntries.map((entry) => {
-      const marketData = entry.tokenAddress
-        ? marketByToken.get(entry.tokenAddress.toLowerCase())
-        : undefined;
-      const marketIsRequired = exploreEntryMarketIdentitiesV1(entry).length > 0;
-      if (marketIsRequired && marketData === undefined) {
-        throw new Error("Bitquery market response is incomplete");
-      }
-      return marketData
-        ? withBitqueryMarketData(entry, marketData, { now })
-        : {
-            ...entry,
-            valuation: {
-              status: "unavailable" as const,
-              reason: entry.exploreKind === "custom-project" &&
-                  entry.markets.length === 0
-                ? "no-market" as const
-                : "source-unavailable" as const,
-            },
-          };
-    });
-    const paginated = paginateExploreEntriesV1(valuedEntries, options);
+    let paginated: ReturnType<typeof paginateExploreEntriesV1>;
+    if (options.sort === "market-cap" || options.sort === "market-cap-asc") {
+      const filtered = filterExploreEntries(
+        identityEntries,
+        options.query,
+        options.socials,
+      );
+      const marketByToken = await readBitqueryTokenFdvRankingStrictV1(
+        exploreEntriesMarketIdentitiesV1(filtered),
+        { signal: request.signal },
+      );
+      const valued = filtered.map((entry): ValuedExploreEntry => {
+        const marketData = entry.tokenAddress
+          ? marketByToken.get(entry.tokenAddress.toLowerCase())
+          : undefined;
+        return marketData
+          ? withBitqueryRankingData(entry, marketData)
+          : {
+              ...entry,
+              valuation: { status: "unavailable", reason: "source-unavailable" },
+            };
+      });
+      paginated = paginateExploreEntriesV1(valued, {
+        ...options,
+        query: "",
+        socials: null,
+      });
+    } else {
+      const identityPage = paginateExploreEntriesV1(identityEntries, options);
+      const marketByToken = await readBitqueryTokenMarketDataStrictV1(
+        exploreEntriesMarketIdentitiesV1(identityPage.tokens),
+        { signal: request.signal, includeStats: false },
+      );
+      const valued = identityPage.tokens.map((entry): ValuedExploreEntry => {
+        const marketData = entry.tokenAddress
+          ? marketByToken.get(entry.tokenAddress.toLowerCase())
+          : undefined;
+        const marketIsRequired = exploreEntryMarketIdentitiesV1(entry).length > 0;
+        if (marketIsRequired && marketData === undefined) {
+          throw new Error("Bitquery market response is incomplete");
+        }
+        return marketData
+          ? withBitqueryMarketData(entry, marketData, { now })
+          : {
+              ...entry,
+              valuation: {
+                status: "unavailable",
+                reason: entry.exploreKind === "custom-project" &&
+                    entry.markets.length === 0
+                  ? "no-market"
+                  : "source-unavailable",
+              },
+            };
+      });
+      paginated = { ...identityPage, tokens: valued };
+    }
     const pageEntries = paginated.tokens as ValuedExploreEntry[];
     const dataQuality = buildExploreDataQuality({
       entries: pageEntries,

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -48,6 +48,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const catalog = await readPrimaryRpcExploreEntriesV1({
+      requestedTokenAddress: address,
       signal: request.signal,
     });
     const entry = catalog.entries.find((candidate) =>

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -2,16 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
 import {
-  readBitqueryExploreEntriesV1,
-  safeBitqueryLaunchCatalogError,
-} from "../../../../../lib/market-data/bitquery-launches.server";
-import {
   readBitqueryMarketChartStrictV1,
   readBitqueryTokenMarketDataStrictV1,
   safeBitqueryMarketDataError,
 } from "../../../../../lib/market-data/bitquery.server";
 import { exploreEntryMarketIdentitiesV1 } from
   "../../../../../lib/market-data/explore-market-identities";
+import {
+  readPrimaryRpcExploreEntriesV1,
+  safePrimaryRpcLaunchCatalogError,
+} from "../../../../../lib/market-data/primary-rpc-launches.server";
 import {
   PROGRAMMABLE_MARKET_CHART_ERROR_SCHEMA_VERSION,
   type MarketChartV1,
@@ -47,7 +47,7 @@ export async function GET(request: NextRequest) {
   const address = getAddress(rawAddress);
 
   try {
-    const catalog = await readBitqueryExploreEntriesV1({
+    const catalog = await readPrimaryRpcExploreEntriesV1({
       signal: request.signal,
     });
     const entry = catalog.entries.find((candidate) =>
@@ -93,6 +93,8 @@ export async function GET(request: NextRequest) {
       headers: {
         "Cache-Control": "no-store",
         "X-Programmable-Data-Quality": chart.status,
+        "X-Programmable-Launch-Source": "drpc",
+        "X-Programmable-Read-Source": "drpc+bitquery",
         "X-Programmable-Market-Source": "bitquery",
         ...(hasPrice ? { "X-Programmable-Price-Source": "bitquery" } : {}),
         ...(chart.asOfTime
@@ -102,7 +104,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error("Bitquery token chart read failed", {
-      catalog: safeBitqueryLaunchCatalogError(error),
+      catalog: safePrimaryRpcLaunchCatalogError(error),
       market: safeBitqueryMarketDataError(error),
     });
     return unavailable(address, range, "Price history is temporarily unavailable");
@@ -138,6 +140,8 @@ function unavailable(
         "Cache-Control": "no-store",
         "Retry-After": "5",
         "X-Programmable-Data-Quality": "unavailable",
+        "X-Programmable-Launch-Source": "drpc",
+        "X-Programmable-Read-Source": "drpc+bitquery",
         "X-Programmable-Market-Source": "bitquery",
       },
     },

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -1,25 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
-import { suppressRouterBoundCustomProjectDuplicates } from
-  "../../../../lib/alchemy/router-custom-collision";
 import {
   publicExploreEntryV1,
   withBitqueryMarketData,
   type ValuedExploreEntry,
 } from "../../../../lib/explore-financial-data";
-import { readBitqueryExploreEntriesV1 } from
-  "../../../../lib/market-data/bitquery-launches.server";
-import { readBitqueryTokenMarketDataStrictV1 } from
-  "../../../../lib/market-data/bitquery.server";
+import {
+  readBitqueryTokenMarketDataStrictV1,
+  safeBitqueryMarketDataError,
+} from "../../../../lib/market-data/bitquery.server";
 import { exploreEntryMarketIdentitiesV1 } from
   "../../../../lib/market-data/explore-market-identities";
-import { readProductionCustomExploreDirectoryV1 } from
-  "../../../../lib/server/custom-launch/explore-directory-v1";
-import type {
-  CustomProjectExploreEntry,
-  ExploreEntry,
-} from "../../../../lib/tokens";
+import {
+  readPrimaryRpcExploreEntriesV1,
+  safePrimaryRpcLaunchCatalogError,
+} from "../../../../lib/market-data/primary-rpc-launches.server";
+import type { ExploreEntry } from "../../../../lib/tokens";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -28,16 +25,6 @@ const SUCCESS_CACHE_CONTROL = "public, max-age=0, s-maxage=2";
 
 function tokenAddress(entry: ExploreEntry): string | null {
   return entry.tokenAddress?.toLowerCase() ?? null;
-}
-
-async function readOptionalCustomProjects(
-  signal: AbortSignal,
-): Promise<readonly CustomProjectExploreEntry[]> {
-  try {
-    return await readProductionCustomExploreDirectoryV1(signal);
-  } catch {
-    return [];
-  }
 }
 
 function unavailableValuation(
@@ -54,14 +41,13 @@ function unavailableValuation(
 }
 
 function responseHeaders(input: Readonly<{
-  launchSource: "bitquery" | "registry.custom-launched";
   marketAsOf?: string;
   hasBitqueryPrice: boolean;
 }>) {
   return {
     "Cache-Control": SUCCESS_CACHE_CONTROL,
-    "X-Programmable-Launch-Source": input.launchSource,
-    "X-Programmable-Read-Source": "bitquery",
+    "X-Programmable-Launch-Source": "drpc",
+    "X-Programmable-Read-Source": "drpc+bitquery",
     "X-Programmable-Market-Source": "bitquery",
     ...(input.marketAsOf
       ? { "X-Programmable-Market-As-Of": input.marketAsOf }
@@ -94,38 +80,13 @@ export async function GET(request: NextRequest) {
 
   try {
     const address = getAddress(input).toLowerCase();
-    const [catalog, registryProjects] = await Promise.all([
-      readBitqueryExploreEntriesV1({ signal: request.signal }),
-      readOptionalCustomProjects(request.signal),
-    ]);
-    const canonicalEntries = catalog.entries.filter(
-      (entry) => entry.exploreKind === "token",
-    );
-    const catalogCustomEntries = catalog.entries.filter(
-      (entry): entry is CustomProjectExploreEntry =>
-        entry.exploreKind === "custom-project",
-    );
-    const customEntries = suppressRouterBoundCustomProjectDuplicates(
-      canonicalEntries,
-      [...catalogCustomEntries, ...registryProjects],
-    );
-    const canonicalEntry = canonicalEntries.find(
-      (entry) => tokenAddress(entry) === address,
+    const catalog = await readPrimaryRpcExploreEntriesV1({
+      signal: request.signal,
+    });
+    const entry = catalog.entries.find(
+      (candidate) => candidate.exploreKind === "token" &&
+        tokenAddress(candidate) === address,
     ) ?? null;
-    const customEntry = customEntries.find(
-      (entry) => tokenAddress(entry) === address,
-    ) ?? null;
-
-    if (canonicalEntry && customEntry) {
-      throw new Error("Bitquery and Custom Registry disagree on launch category");
-    }
-
-    const entry = canonicalEntry ?? customEntry;
-    const customEntryComesFromCatalog = customEntry !== null &&
-      catalogCustomEntries.some((candidate) => candidate.id === customEntry.id);
-    const launchSource = canonicalEntry || customEntryComesFromCatalog
-      ? "bitquery" as const
-      : "registry.custom-launched" as const;
 
     if (!entry) {
       return NextResponse.json(
@@ -138,7 +99,6 @@ export async function GET(request: NextRequest) {
         {
           status: 404,
           headers: responseHeaders({
-            launchSource: "bitquery",
             hasBitqueryPrice: false,
           }),
         },
@@ -152,6 +112,9 @@ export async function GET(request: NextRequest) {
     const marketData = entry.tokenAddress
       ? marketByToken.get(entry.tokenAddress.toLowerCase())
       : undefined;
+    if (identities.length > 0 && marketData === undefined) {
+      throw new Error("Bitquery market response is incomplete");
+    }
     const valuedEntry = marketData
       ? withBitqueryMarketData(entry, marketData)
       : unavailableValuation(entry, identities.length > 0);
@@ -176,15 +139,15 @@ export async function GET(request: NextRequest) {
       },
       {
         headers: responseHeaders({
-          launchSource,
           hasBitqueryPrice,
           ...(marketAsOf ? { marketAsOf } : {}),
         }),
       },
     );
   } catch (error) {
-    console.error("Bitquery token detail read failed", {
-      name: error instanceof Error ? error.name : "Error",
+    console.error("Token detail read failed", {
+      launch: safePrimaryRpcLaunchCatalogError(error),
+      market: safeBitqueryMarketDataError(error),
     });
     return NextResponse.json(
       { error: "Token data is temporarily unavailable" },

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -7,6 +7,7 @@ import {
   type ValuedExploreEntry,
 } from "../../../../lib/explore-financial-data";
 import {
+  BitqueryMarketDataError,
   readBitqueryTokenMarketDataStrictV1,
   safeBitqueryMarketDataError,
 } from "../../../../lib/market-data/bitquery.server";
@@ -16,6 +17,8 @@ import {
   readPrimaryRpcExploreEntriesV1,
   safePrimaryRpcLaunchCatalogError,
 } from "../../../../lib/market-data/primary-rpc-launches.server";
+import { readProductionCustomExploreDirectoryV1 } from
+  "../../../../lib/server/custom-launch/explore-directory-v1";
 import type { ExploreEntry } from "../../../../lib/tokens";
 
 export const dynamic = "force-dynamic";
@@ -35,20 +38,26 @@ function unavailableValuation(
     ...entry,
     valuation: {
       status: "unavailable",
-      reason: hadMarketIdentity ? "source-unavailable" : "no-market",
+      reason: hadMarketIdentity || entry.exploreKind === "token" ||
+          entry.markets.length > 0
+        ? "source-unavailable"
+        : "no-market",
     },
   };
 }
 
-function responseHeaders(input: Readonly<{
+function canonicalResponseHeaders(input: Readonly<{
   marketAsOf?: string;
   hasBitqueryPrice: boolean;
+  marketRead: boolean;
 }>) {
   return {
     "Cache-Control": SUCCESS_CACHE_CONTROL,
     "X-Programmable-Launch-Source": "drpc",
-    "X-Programmable-Read-Source": "drpc+bitquery",
-    "X-Programmable-Market-Source": "bitquery",
+    "X-Programmable-Read-Source": input.marketRead ? "drpc+bitquery" : "drpc",
+    ...(input.marketRead
+      ? { "X-Programmable-Market-Source": "bitquery" }
+      : {}),
     ...(input.marketAsOf
       ? { "X-Programmable-Market-As-Of": input.marketAsOf }
       : {}),
@@ -56,6 +65,45 @@ function responseHeaders(input: Readonly<{
       ? { "X-Programmable-Price-Source": "bitquery" }
       : {}),
   };
+}
+
+function customResponseHeaders(input: Readonly<{
+  marketAsOf?: string;
+  hasBitqueryPrice: boolean;
+  marketRead: boolean;
+}>) {
+  return {
+    "Cache-Control": SUCCESS_CACHE_CONTROL,
+    "X-Programmable-Launch-Source": "registry.custom-launched",
+    "X-Programmable-Read-Source": input.marketRead
+      ? "drpc+registry.custom-launched+bitquery"
+      : "drpc+registry.custom-launched",
+    ...(input.marketRead
+      ? { "X-Programmable-Market-Source": "bitquery" }
+      : {}),
+    ...(input.marketAsOf
+      ? { "X-Programmable-Market-As-Of": input.marketAsOf }
+      : {}),
+    ...(input.hasBitqueryPrice
+      ? { "X-Programmable-Price-Source": "bitquery" }
+      : {}),
+  };
+}
+
+function unavailableResponse(
+  headers: Record<string, string>,
+) {
+  return NextResponse.json(
+    { error: "Token data is temporarily unavailable" },
+    {
+      status: 503,
+      headers: {
+        ...headers,
+        "Cache-Control": "no-store",
+        "Retry-After": "5",
+      },
+    },
+  );
 }
 
 export async function GET(request: NextRequest) {
@@ -78,42 +126,88 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  const requestedTokenAddress = getAddress(input);
+  const address = requestedTokenAddress.toLowerCase();
+  let catalog;
   try {
-    const address = getAddress(input).toLowerCase();
-    const catalog = await readPrimaryRpcExploreEntriesV1({
+    catalog = await readPrimaryRpcExploreEntriesV1({
+      requestedTokenAddress,
       signal: request.signal,
     });
-    const entry = catalog.entries.find(
-      (candidate) => candidate.exploreKind === "token" &&
-        tokenAddress(candidate) === address,
-    ) ?? null;
+  } catch (error) {
+    console.error("Token detail identity read failed", {
+      launch: safePrimaryRpcLaunchCatalogError(error),
+    });
+    return unavailableResponse(canonicalResponseHeaders({
+      hasBitqueryPrice: false,
+      marketRead: false,
+    }));
+  }
 
-    if (!entry) {
-      return NextResponse.json(
-        {
-          status: "ready",
-          token: null,
-          customProject: null,
-          snapshot: null,
-        },
-        {
-          status: 404,
-          headers: responseHeaders({
-            hasBitqueryPrice: false,
-          }),
-        },
+  const canonicalEntry = catalog.entries.find(
+    (candidate) => candidate.exploreKind === "token" &&
+      tokenAddress(candidate) === address,
+  ) ?? null;
+  let entry: ExploreEntry | null = canonicalEntry;
+  let isCustom = false;
+
+  if (entry === null) {
+    let customProjects;
+    try {
+      customProjects = await readProductionCustomExploreDirectoryV1(
+        request.signal,
       );
+    } catch {
+      console.error("Token detail Custom Registry read failed", {
+        launch: {
+          name: "CustomRegistryReadError",
+          category: "unexpected",
+        },
+      });
+      return unavailableResponse(customResponseHeaders({
+        hasBitqueryPrice: false,
+        marketRead: false,
+      }));
     }
+    entry = customProjects.find(
+      (candidate) => tokenAddress(candidate) === address,
+    ) ?? null;
+    isCustom = entry !== null;
+  }
 
-    const identities = exploreEntryMarketIdentitiesV1(entry);
-    const marketByToken = await readBitqueryTokenMarketDataStrictV1(identities, {
-      signal: request.signal,
-    });
+  if (!entry) {
+    return NextResponse.json(
+      {
+        status: "ready",
+        token: null,
+        customProject: null,
+        snapshot: null,
+      },
+      {
+        status: 404,
+        headers: customResponseHeaders({
+          hasBitqueryPrice: false,
+          marketRead: false,
+        }),
+      },
+    );
+  }
+
+  const identities = exploreEntryMarketIdentitiesV1(entry);
+  let marketByToken: Awaited<
+    ReturnType<typeof readBitqueryTokenMarketDataStrictV1>
+  > = new Map();
+  try {
+    if (identities.length > 0) {
+      marketByToken = await readBitqueryTokenMarketDataStrictV1(identities, {
+        signal: request.signal,
+      });
+    }
     const marketData = entry.tokenAddress
       ? marketByToken.get(entry.tokenAddress.toLowerCase())
       : undefined;
     if (identities.length > 0 && marketData === undefined) {
-      throw new Error("Bitquery market response is incomplete");
+      throw new BitqueryMarketDataError("integrity");
     }
     const valuedEntry = marketData
       ? withBitqueryMarketData(entry, marketData)
@@ -138,20 +232,24 @@ export async function GET(request: NextRequest) {
           publicEntry.exploreKind === "token" ? { chainId: 1 } : null,
       },
       {
-        headers: responseHeaders({
+        headers: (isCustom
+          ? customResponseHeaders
+          : canonicalResponseHeaders)({
           hasBitqueryPrice,
+          marketRead: identities.length > 0,
           ...(marketAsOf ? { marketAsOf } : {}),
         }),
       },
     );
   } catch (error) {
-    console.error("Token detail read failed", {
-      launch: safePrimaryRpcLaunchCatalogError(error),
+    console.error("Token detail market read failed", {
       market: safeBitqueryMarketDataError(error),
     });
-    return NextResponse.json(
-      { error: "Token data is temporarily unavailable" },
-      { status: 503, headers: { "Cache-Control": "no-store" } },
-    );
+    return unavailableResponse((isCustom
+      ? customResponseHeaders
+      : canonicalResponseHeaders)({
+      hasBitqueryPrice: false,
+      marketRead: true,
+    }));
   }
 }

--- a/app/api/profile/classic-v3/route.ts
+++ b/app/api/profile/classic-v3/route.ts
@@ -27,9 +27,7 @@ import {
 } from "@/lib/classic-v3-release";
 import { uerc20ReadAbi } from "@/lib/onchain/abis";
 import {
-  readBitqueryClassicV3Launch,
   readBitqueryClassicV3Profile,
-  safeBitqueryProfileError,
 } from "@/lib/market-data/bitquery-profile.server";
 import { safeOperationalRpcError } from
   "@/lib/onchain/operational-rpc-failover.server";
@@ -144,6 +142,7 @@ async function readLaunchLogs(
   launcher: Address,
   fromBlock: bigint,
   toBlock: bigint,
+  deployer?: Address,
 ) {
   const logs = [];
   for (
@@ -155,6 +154,7 @@ async function readLaunchLogs(
       ...(await client.getLogs({
         address: launcher,
         event: classicV3LaunchEvent,
+        ...(deployer ? { args: { deployer } } : {}),
         fromBlock: rangeStart,
         toBlock: minimum(toBlock, rangeStart + LOG_RANGE - 1n),
         strict: true,
@@ -162,6 +162,69 @@ async function readLaunchLogs(
     );
   }
   return logs;
+}
+
+async function readLaunchByTransactionFromClient(
+  account: Address,
+  transactionHash: Hex,
+  client: PublicClient,
+) {
+  if (!isClassicV3ReleaseVerified(manifest, releaseManifest, chain.id)) {
+    return { status: "not-deployed" as const, launch: null };
+  }
+  const launcher = getAddress(manifest.memeLaunchV2 as string);
+  await assertCodeHash(
+    client,
+    launcher,
+    manifest.runtimeCodeHashes?.memeLaunchV2 as string,
+    "Classic launcher",
+  );
+  const latestBlock = await client.getBlockNumber();
+  const snapshotBlock = latestBlock > CONFIRMATIONS
+    ? latestBlock - CONFIRMATIONS
+    : latestBlock;
+  const deploymentBlock = BigInt(
+    manifest.deploymentBlocks?.memeLaunchV2 as number,
+  );
+  const logs = deploymentBlock <= snapshotBlock
+    ? await readLaunchLogs(
+        client,
+        launcher,
+        deploymentBlock,
+        snapshotBlock,
+        account,
+      )
+    : [];
+  const launch = logs.find(
+    (candidate) =>
+      !candidate.removed &&
+      candidate.transactionHash.toLowerCase() === transactionHash.toLowerCase(),
+  );
+  if (!launch) return { status: "ready" as const, launch: null };
+  const tokenAddress = getAddress(launch.args.token);
+  const [name, symbol] = await Promise.all([
+    client.readContract({
+      address: tokenAddress,
+      abi: uerc20ReadAbi,
+      functionName: "name",
+      blockNumber: snapshotBlock,
+    }),
+    client.readContract({
+      address: tokenAddress,
+      abi: uerc20ReadAbi,
+      functionName: "symbol",
+      blockNumber: snapshotBlock,
+    }),
+  ]);
+  return {
+    status: "ready" as const,
+    launch: {
+      tokenAddress,
+      name,
+      symbol,
+      launchTransactionHash: launch.transactionHash,
+    },
+  };
 }
 
 function prospectiveAllocation(
@@ -614,10 +677,6 @@ async function readRewardsFromClient(
   };
 }
 
-// Kept as a pure legacy-accounting verifier for focused fixtures; production
-// GET and POST identity reads use Bitquery directly.
-void readRewardsFromClient;
-
 export async function GET(request: NextRequest) {
   const search = request.nextUrl.searchParams;
   if (
@@ -639,26 +698,37 @@ export async function GET(request: NextRequest) {
       if (!isHex(launch, { strict: true }) || launch.length !== 66) {
         return json({ error: "Enter a valid launch transaction hash" }, 400);
       }
-      return json(
-        await readBitqueryClassicV3Launch(
+      const client = createActionClients()[0]!;
+      return NextResponse.json(
+        await readLaunchByTransactionFromClient(
           getAddress(input),
           launch as Hex,
+          client,
         ),
+        {
+          headers: {
+            "Cache-Control": "private, max-age=0, s-maxage=15",
+            "X-Programmable-Read-Source": "rpc",
+            "X-Programmable-Rpc-Provider": "drpc-primary",
+          },
+        },
       );
     }
+    const client = createActionClients()[0]!;
     return NextResponse.json(
-      await readBitqueryClassicV3Profile(getAddress(input)),
+      await readRewardsFromClient(getAddress(input), client),
       {
         headers: {
           "Cache-Control": "private, max-age=0, s-maxage=15",
-          "X-Programmable-Read-Source": "bitquery",
+          "X-Programmable-Read-Source": "rpc",
+          "X-Programmable-Rpc-Provider": "drpc-primary",
         },
       },
     );
   } catch (error) {
     console.error(
-      "Bitquery Classic profile read failed",
-      safeBitqueryProfileError(error),
+      "dRPC Classic profile read failed",
+      safeOperationalRpcError(error),
     );
     return json(classicV3ProfileApiError("temporary"), 503);
   }

--- a/app/api/profile/stock-paired/route.ts
+++ b/app/api/profile/stock-paired/route.ts
@@ -8,6 +8,7 @@ import {
   isAddress,
   isHex,
   keccak256,
+  parseAbiItem,
   type Address,
   type Hex,
   type PublicClient,
@@ -17,6 +18,7 @@ import { mainnet } from "viem/chains";
 import {
   type ExploreReadModel,
 } from "@/lib/onchain";
+import { uerc20ReadAbi } from "@/lib/onchain/abis";
 import { readBitqueryExploreModelV1 } from
   "@/lib/market-data/bitquery-explore-model.server";
 import { safeServerErrorSummary } from "@/lib/server/safe-error";
@@ -33,12 +35,9 @@ import {
 } from "@/lib/stock-paired";
 import {
   getConfiguredStockPairedReleaseByHookAndVersion,
+  getConfiguredStockPairedReleases,
 } from "@/lib/stock-paired-release";
 import type { LauncherToken } from "@/lib/tokens";
-import {
-  readBitqueryStockPairedProfile,
-  safeBitqueryProfileError,
-} from "@/lib/market-data/bitquery-profile.server";
 import { ClassicTradeInputError } from "@/lib/trade/classic";
 import {
   prepareStockPairedRewardConversion,
@@ -53,6 +52,33 @@ export const runtime = "nodejs";
 const MAX_REQUEST_BYTES = 2_048;
 const ZERO_HASH = `0x${"0".repeat(64)}`;
 const CONVERSION_SLIPPAGE_BPS = 100;
+const PROFILE_LOG_RANGE = 10_000n;
+const stockPairedLaunchEvent = parseAbiItem(
+  "event StockPairedTokenLaunched(address indexed deployer,address indexed token,address indexed quoteAsset,bytes32 poolId,address rewardVault,address positionRecipient,uint256 positionTokenId,bytes32 launchHash)",
+);
+
+type StockRewardIdentity = Readonly<
+  Pick<
+    LauncherToken,
+    | "name"
+    | "symbol"
+    | "tokenAddress"
+    | "hookAddress"
+    | "poolId"
+    | "launchModel"
+  > &
+    Partial<
+      Pick<
+        LauncherToken,
+        | "imageUrl"
+        | "creatorAddress"
+        | "rewardVaultAddress"
+        | "quoteAssetAddress"
+        | "launchTransactionHash"
+        | "launchModelVersion"
+      >
+    >
+>;
 
 function json(body: unknown, status = 200) {
   return NextResponse.json(body, {
@@ -142,7 +168,7 @@ function entitlement(
 
 async function readVaultReward(
   client: PublicClient,
-  token: LauncherToken,
+  token: StockRewardIdentity,
   account: Address,
   snapshotBlock: bigint,
 ) {
@@ -441,6 +467,124 @@ async function readStockActionReward(
   return { reward, rpcClient };
 }
 
+async function readStockLaunchLogs(
+  client: PublicClient,
+  launcher: Address,
+  fromBlock: bigint,
+  toBlock: bigint,
+) {
+  const logs = [];
+  for (
+    let rangeStart = fromBlock;
+    rangeStart <= toBlock;
+    rangeStart += PROFILE_LOG_RANGE
+  ) {
+    const rangeEnd = rangeStart + PROFILE_LOG_RANGE - 1n;
+    logs.push(...await client.getLogs({
+      address: launcher,
+      event: stockPairedLaunchEvent,
+      fromBlock: rangeStart,
+      toBlock: rangeEnd < toBlock ? rangeEnd : toBlock,
+      strict: true,
+    }));
+  }
+  return logs;
+}
+
+async function readStockProfileFromClient(
+  account: Address,
+  client: PublicClient,
+) {
+  const releases = getConfiguredStockPairedReleases();
+  if (releases.length === 0) {
+    return {
+      status: "not-deployed" as const,
+      account,
+      chainId: 1 as const,
+      rewards: [],
+    };
+  }
+  const snapshotBlock = await client.getBlockNumber();
+  const launchGroups = await Promise.all(releases.map(async (release) => {
+    await Promise.all([
+      assertRuntime(
+        client,
+        release.addresses.feeHook,
+        release.runtimeCodeHashes.feeHook,
+        snapshotBlock,
+        `${release.internalContractRelease} hook`,
+      ),
+      assertRuntime(
+        client,
+        release.addresses.feeSplitVaultFactory,
+        release.runtimeCodeHashes.feeSplitVaultFactory,
+        snapshotBlock,
+        `${release.internalContractRelease} reward-vault factory`,
+      ),
+    ]);
+    const logs = snapshotBlock < BigInt(release.startBlock)
+      ? []
+      : await readStockLaunchLogs(
+          client,
+          release.addresses.launcher,
+          BigInt(release.startBlock),
+          snapshotBlock,
+        );
+    return Promise.all(logs.flatMap((log) => {
+      if (log.removed) return [];
+      return [async () => {
+        const vaultAddress = getAddress(log.args.rewardVault);
+        const accountShare = await client.readContract({
+          address: vaultAddress,
+          abi: stockFeeSplitVaultAbi,
+          functionName: "shareBpsOf",
+          args: [account],
+          blockNumber: snapshotBlock,
+        });
+        if (accountShare === 0) return null;
+        const tokenAddress = getAddress(log.args.token);
+        const [name, symbol] = await Promise.all([
+          client.readContract({
+            address: tokenAddress,
+            abi: uerc20ReadAbi,
+            functionName: "name",
+            blockNumber: snapshotBlock,
+          }),
+          client.readContract({
+            address: tokenAddress,
+            abi: uerc20ReadAbi,
+            functionName: "symbol",
+            blockNumber: snapshotBlock,
+          }),
+        ]);
+        const identity: StockRewardIdentity = {
+          name,
+          symbol,
+          tokenAddress,
+          hookAddress: release.addresses.feeHook,
+          poolId: log.args.poolId,
+          creatorAddress: getAddress(log.args.deployer),
+          launchTransactionHash: log.transactionHash,
+          quoteAssetAddress: getAddress(log.args.quoteAsset),
+          rewardVaultAddress: vaultAddress,
+          launchModel: "stock-paired",
+          launchModelVersion: release.internalContractRelease,
+        };
+        return readVaultReward(client, identity, account, snapshotBlock);
+      }];
+    }).map((read) => read()));
+  }));
+  return {
+    status: "ready" as const,
+    account,
+    chainId: 1 as const,
+    snapshotBlock: snapshotBlock.toString(),
+    rewards: launchGroups.flat().filter(
+      (reward): reward is NonNullable<typeof reward> => reward !== null,
+    ),
+  };
+}
+
 export async function GET(request: NextRequest) {
   const search = request.nextUrl.searchParams;
   if (
@@ -455,16 +599,19 @@ export async function GET(request: NextRequest) {
   }
   try {
     const account = getAddress(accountInput);
-    return NextResponse.json(await readBitqueryStockPairedProfile(account), {
+    return NextResponse.json(
+      await readStockProfileFromClient(account, actionClient()),
+      {
       headers: {
         "Cache-Control": "private, max-age=0, s-maxage=15",
-        "X-Programmable-Read-Source": "bitquery",
+        "X-Programmable-Read-Source": "rpc",
+        "X-Programmable-Rpc-Provider": "drpc-primary",
       },
     });
   } catch (error) {
     console.error(
-      "Bitquery Stock-Paired profile read failed",
-      safeBitqueryProfileError(error),
+      "dRPC Stock-Paired profile read failed",
+      safeServerErrorSummary(error),
     );
     return json(
       { error: "Stock-Paired rewards are temporarily unavailable" },

--- a/app/api/trade/prepare/route.ts
+++ b/app/api/trade/prepare/route.ts
@@ -4,11 +4,10 @@ import {
   http,
   type Address,
   type Hex,
+  type PublicClient,
 } from "viem";
 import { mainnet, sepolia } from "viem/chains";
 
-import { readBitqueryExploreModelV1 } from
-  "../../../../lib/market-data/bitquery-explore-model.server";
 import {
   ClassicTradeInputError,
 } from "../../../../lib/trade/classic";
@@ -25,6 +24,10 @@ import {
   resolveStockPairedTradeDeployment,
   StockPairedTradeUnavailableError,
 } from "../../../../lib/trade/stock-paired";
+import {
+  ActionRpcIdentityError,
+  readTradeActionModelFromRpc,
+} from "../../../../lib/server/action-rpc-identity.server";
 import { tradeActionRpcProvider } from "../../../../lib/server/action-rpc-quorum.server";
 import { safeServerErrorSummary } from "../../../../lib/server/safe-error";
 
@@ -43,18 +46,8 @@ function json(body: unknown, status = 200) {
 }
 
 function runtimeClient(
-  chainId: number,
-  endpoint: string,
+  client: PublicClient,
 ): ClassicTradeRuntimeClient {
-  const chain = chainId === 1 ? mainnet : sepolia;
-  const client = createPublicClient({
-    chain,
-    transport: http(endpoint, {
-      retryCount: 1,
-      timeout: 12_000,
-    }),
-  });
-
   return {
     getChainId: () => client.getChainId(),
     async getBlock() {
@@ -131,11 +124,26 @@ export async function POST(request: NextRequest) {
           })();
     if (actionChainId !== 1) {
       throw new ClassicTradeUnavailableError(
-        "Bitquery trading identity is only available on Ethereum mainnet",
+        "Trading identity is only available on Ethereum mainnet",
       );
     }
-    const registry = await readBitqueryExploreModelV1({
-      signal: request.signal,
+    const provider = tradeActionRpcProvider(actionChainId);
+    const client = createPublicClient({
+      chain: actionChainId === 1 ? mainnet : sepolia,
+      transport: http(provider.endpoint, {
+        retryCount: 1,
+        timeout: 12_000,
+      }),
+    });
+    const blockNumber = await client.getBlockNumber();
+    const block = await client.getBlock({ blockNumber });
+    if (!block.hash) throw new Error("The action snapshot has no block hash");
+    const registry = await readTradeActionModelFromRpc({
+      client,
+      chainId: actionChainId,
+      token: tradeRequest.token,
+      blockNumber,
+      blockHash: block.hash,
     });
     const indexedToken = registry.tokens.find(
       (candidate) =>
@@ -148,9 +156,8 @@ export async function POST(request: NextRequest) {
         registry,
         tradeRequest.token,
       );
-      const provider = tradeActionRpcProvider(tradeRequest.chainId);
       const prepared = await prepareStockPairedTrade(
-        runtimeClient(tradeRequest.chainId, provider.endpoint),
+        runtimeClient(client),
         deployment,
         tradeRequest,
       );
@@ -161,9 +168,8 @@ export async function POST(request: NextRequest) {
       registry,
       tradeRequest.token,
     );
-    const provider = tradeActionRpcProvider(tradeRequest.chainId);
     const prepared = await prepareClassicTrade(
-      runtimeClient(tradeRequest.chainId, provider.endpoint),
+      runtimeClient(client),
       deployment,
       tradeRequest,
       registry,
@@ -175,7 +181,8 @@ export async function POST(request: NextRequest) {
     }
     if (
       error instanceof ClassicTradeUnavailableError ||
-      error instanceof StockPairedTradeUnavailableError
+      error instanceof StockPairedTradeUnavailableError ||
+      error instanceof ActionRpcIdentityError
     ) {
       return json({ error: error.message }, 409);
     }

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -330,9 +330,28 @@
       "/api/ops/health",
       "/api/explore?limit=6&page=1&sort=market-cap",
       "/api/explore/token",
-      "/api/explore/token/chart"
+      "/api/explore/token/chart",
+      "/api/explore/profile",
+      "/api/profile/classic-v3",
+      "/api/profile/stock-paired",
+      "/api/explore/profile/claim",
+      "/api/trade/prepare"
     ],
-    "publicDataProvider": "bitquery",
-    "fallbacks": false
+    "sources": {
+      "launchIdentity": "commitment-bound-drpc-primary",
+      "creatorIdentity": "commitment-bound-drpc-primary",
+      "actionState": "commitment-bound-drpc-primary",
+      "market": "bitquery",
+      "fdv": "bitquery",
+      "chart": "bitquery"
+    },
+    "rpc": {
+      "provider": "drpc",
+      "role": "primary",
+      "endpointCommitmentRequired": true,
+      "secondaryRequired": false
+    },
+    "fallbacks": false,
+    "providerUrlExposure": false
   }
 }

--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -612,10 +612,19 @@ function reconcileBitqueryValuations<T extends ExploreEntry>(
         },
       };
     }
+    if (!pool.liquidity) {
+      return {
+        ...pool,
+        quality: "partial",
+        valuation: {
+          status: "unavailable",
+          reason: "source-unavailable",
+        },
+      };
+    }
     if (
-      pool.liquidity &&
-      (liquidity === null ||
-        liquidity < BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD))
+      liquidity === null ||
+      liquidity < BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD)
     ) {
       return {
         ...pool,

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -586,7 +586,6 @@ async function readMarketBatch(
   }>,
 ): Promise<readonly MarketPoolDataV1[]> {
   const coreRequest = marketBatchQuery(identities);
-  const liquidityRequest = marketLiquidityQuery(identities);
   const statsRequest = marketStatsQuery(identities);
   const coreRead = executeBitqueryGraphql(
     coreRequest.query,
@@ -594,11 +593,6 @@ async function readMarketBatch(
     options,
   );
   const supplementaryOperations = [
-    executeBitqueryGraphql(
-      liquidityRequest.query,
-      liquidityRequest.variables,
-      options,
-    ),
     executeBitqueryGraphql(
       statsRequest.query,
       statsRequest.variables,
@@ -612,10 +606,10 @@ async function readMarketBatch(
   ]);
   if (coreResult.status === "rejected") throw coreResult.reason;
   const response = coreResult.value;
-  const [liquidityResult, statsResult] = supplementaryResults.status ===
+  const [statsResult] = supplementaryResults.status ===
       "fulfilled"
     ? supplementaryResults.value
-    : [supplementaryResults, supplementaryResults];
+    : [supplementaryResults];
   if (options.strict && response.partial) {
     throw new BitqueryMarketDataError("response");
   }
@@ -649,24 +643,15 @@ async function readMarketBatch(
   if (options.strict && priceLookupWasPartial) {
     throw new BitqueryMarketDataError("response");
   }
-  const liquidityEvm = liquidityResult.status === "fulfilled"
-    ? record(liquidityResult.value.data.EVM)
-    : null;
   const statsEvm = statsResult.status === "fulfilled"
     ? record(statsResult.value.data.EVM)
     : null;
   if (
     options.strict &&
-    (liquidityEvm === null || statsEvm === null ||
-      liquidityResult.status !== "fulfilled" ||
-      statsResult.status !== "fulfilled" ||
-      liquidityResult.value.partial || statsResult.value.partial)
+    (statsEvm === null || statsResult.status !== "fulfilled" ||
+      statsResult.value.partial)
   ) throw new BitqueryMarketDataError("response");
 
-  const liquidityByPool = indexUniqueRows(
-    array(liquidityEvm?.latestLiquidity),
-    liquidityRowPoolId,
-  );
   const statsByMarket = indexUniqueRows(
     array(statsEvm?.stats),
     (row) => {
@@ -704,8 +689,6 @@ async function readMarketBatch(
       identity,
       latestTradeRows,
       latestTrade,
-      liquidityPriceTrade: parsedTrade,
-      liquidityRow: liquidityByPool.get(identity.poolId),
       stats: parseStats(statsByMarket.get(
         marketStatsKey(identity.poolId, identity.tokenAddress),
       )),
@@ -714,25 +697,17 @@ async function readMarketBatch(
   });
 
   return parsed.map((value) => {
-    const liquidity = parseLiquidity(
-      value.liquidityRow,
-      value.identity,
-      options.now,
-      value.liquidityPriceTrade,
-    );
     return marketPoolData({
       identity: value.identity,
       latestTrade: value.latestTrade,
       tradeObserved: value.latestTradeRows.length > 0,
-      liquidity,
+      liquidity: null,
       stats: value.stats,
       supply: value.supply,
       now: options.now,
       partialResponse:
         response.partial ||
         priceLookupWasPartial ||
-        liquidityResult.status !== "fulfilled" ||
-        liquidityResult.value.partial ||
         statsResult.status !== "fulfilled" ||
         statsResult.value.partial,
     });
@@ -982,11 +957,6 @@ function tradeRowPoolId(row: unknown): `0x${string}` | null {
   return canonicalBytes32(record(record(row)?.Trade)?.PoolId);
 }
 
-function liquidityRowPoolId(row: unknown): `0x${string}` | null {
-  const event = record(record(row)?.PoolEvent);
-  return canonicalBytes32(record(event?.Pool)?.PoolId);
-}
-
 function marketStatsKey(
   poolId: `0x${string}`,
   tokenAddress: `0x${string}`,
@@ -1059,34 +1029,6 @@ function marketPriceQuery(trades: readonly MarketTradeV1[]) {
       Trading { ${selections} }
     }`,
     variables: {},
-  };
-}
-
-function marketLiquidityQuery(identities: readonly MarketDataIdentityV1[]) {
-  const pools = identities.map(({ poolId }) => poolId);
-  const rowLimit = Math.max(1, identities.length);
-  return {
-    query: `query ProgrammableMarketLiquidity($pools: [String!]!) {
-      EVM(network: eth, dataset: combined) {
-        latestLiquidity: DEXPoolEvents(
-          limit: { count: ${rowLimit} }
-          limitBy: { by: PoolEvent_Pool_PoolId, count: 1 }
-          orderBy: [
-            { descending: Block_Number }
-            { descending: Transaction_Index }
-            { descending: Log_Index }
-          ]
-          where: {
-            TransactionStatus: { Success: true }
-            PoolEvent: {
-              Dex: { ProtocolName: { is: "uniswap_v4" } }
-              Pool: { PoolId: { in: $pools } }
-            }
-          }
-        ) { ${liquiditySelection()} }
-      }
-    }`,
-    variables: { pools },
   };
 }
 
@@ -1311,27 +1253,6 @@ function tradeSelection() {
       Sell { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
     }
     Transaction { Hash Index }
-  `;
-}
-
-function liquiditySelection() {
-  return `
-    Block { Number Time }
-    Log { Index }
-    Transaction { Hash Index }
-    PoolEvent {
-      Pool {
-        PoolId
-        CurrencyA { SmartContract Symbol }
-        CurrencyB { SmartContract Symbol }
-      }
-      Liquidity {
-        AmountCurrencyA
-        AmountCurrencyAInUSD
-        AmountCurrencyB
-        AmountCurrencyBInUSD
-      }
-    }
   `;
 }
 
@@ -1719,8 +1640,8 @@ function marketPoolData(input: Readonly<{
     ? null
     : BigInt(input.liquidity.valueUsdWad);
   const valuation = sourceValuation.status === "available" &&
-      (liquidityValue === null ||
-        liquidityValue < BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD))
+      liquidityValue !== null &&
+      liquidityValue < BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD)
     ? { status: "unavailable" as const, reason: "inconsistent-market-data" as const }
     : sourceValuation.status === "available" && input.liquidity !== null
       ? {

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -275,20 +275,20 @@ export async function readBitqueryTokenFdvRankingStrictV1(
     throw new BitqueryMarketDataError("response", "market-core");
   }
 
-  const expectedTokenIds = new Set(
-    unique.map(({ tokenAddress }) => ethereumTokenId(tokenAddress)),
+  const expectedTokenAddresses = new Set(
+    unique.map(({ tokenAddress }) => tokenAddress),
   );
   let tokenRows: ReadonlyMap<string, unknown>;
   try {
     tokenRows = indexUniqueRows(
       array(trading.rankingTokens),
-      (row) => canonicalEthereumTokenId(record(record(row)?.Token)?.Id),
+      rankingTokenRowAddress,
     );
   } catch {
     throw new BitqueryMarketDataError("integrity", "market-core");
   }
-  for (const tokenId of tokenRows.keys()) {
-    if (!expectedTokenIds.has(tokenId)) {
+  for (const tokenAddress of tokenRows.keys()) {
+    if (!expectedTokenAddresses.has(tokenAddress as `0x${string}`)) {
       throw new BitqueryMarketDataError("integrity", "market-core");
     }
   }
@@ -312,7 +312,7 @@ export async function readBitqueryTokenFdvRankingStrictV1(
   const pools = new Map<string, MarketPoolDataV1>();
   for (const identity of unique) {
     const tokenValue = parseFdvRankingToken(
-      tokenRows.get(ethereumTokenId(identity.tokenAddress)),
+      tokenRows.get(identity.tokenAddress),
       identity,
       now,
     );
@@ -1227,13 +1227,13 @@ function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
 function marketFdvRankingQuery(
   identities: readonly MarketDataIdentityV1[],
 ) {
-  const tokenIds = [...new Set(
-    identities.map(({ tokenAddress }) => ethereumTokenId(tokenAddress)),
+  const tokenAddresses = [...new Set(
+    identities.map(({ tokenAddress }) => tokenAddress),
   )].sort();
-  const rowLimit = Math.max(1, tokenIds.length);
+  const rowLimit = Math.max(1, tokenAddresses.length);
   return {
     query: `query ProgrammableExploreFdvRanking(
-      $tokenIds: [String!]!
+      $tokenAddresses: [String!]!
     ) {
       Trading {
         rankingTokens: Tokens(
@@ -1241,12 +1241,15 @@ function marketFdvRankingQuery(
           limitBy: { by: Token_Id, count: 1 }
           orderBy: { descending: Block_Time }
           where: {
-            Token: { Id: { in: $tokenIds } }
+            Token: {
+              Address: { in: $tokenAddresses }
+              Network: { is: "Ethereum" }
+            }
             Interval: { Time: { Duration: { eq: 1 } } }
             Price: { IsQuotedInUsd: true }
           }
         ) {
-          Token { Id Address }
+          Token { Id Address Network }
           Block { Time }
           Supply {
             TotalSupply
@@ -1256,7 +1259,7 @@ function marketFdvRankingQuery(
         }
       }
     }`,
-    variables: { tokenIds },
+    variables: { tokenAddresses },
   };
 }
 
@@ -1889,7 +1892,9 @@ function parseFdvRankingToken(
   const id = nonEmptyString(token.Id)?.toLowerCase();
   if (
     address !== identity.tokenAddress ||
-    id !== ethereumTokenId(identity.tokenAddress)
+    token.Network !== "Ethereum" ||
+    (id !== ethereumTokenId(identity.tokenAddress) &&
+      id !== bidEthereumTokenId(identity.tokenAddress))
   ) {
     return { reason: "inconsistent-market-data" };
   }
@@ -2472,13 +2477,21 @@ function resolveToken(explicit: string | null | undefined): string | null {
 }
 
 function ethereumTokenId(address: `0x${string}`): string {
+  return `eth:${address}`;
+}
+
+function bidEthereumTokenId(address: `0x${string}`): string {
   return `bid:eth:${address}`;
 }
 
-function canonicalEthereumTokenId(value: unknown): string | null {
-  if (typeof value !== "string" || value !== value.toLowerCase()) return null;
-  const address = canonicalAddress(value.slice("bid:eth:".length));
-  return address !== null && value === ethereumTokenId(address) ? value : null;
+function rankingTokenRowAddress(value: unknown): `0x${string}` | null {
+  const token = record(record(value)?.Token);
+  const address = canonicalAddress(token?.Address);
+  const id = nonEmptyString(token?.Id)?.toLowerCase();
+  return address !== null && token?.Network === "Ethereum" &&
+      (id === ethereumTokenId(address) || id === bidEthereumTokenId(address))
+    ? address
+    : null;
 }
 
 function canonicalAddress(value: unknown): `0x${string}` | null {

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -31,6 +31,8 @@ const REQUEST_TIMEOUT_MS = 8_000;
 const MAXIMUM_RESPONSE_BYTES = 1_500_000;
 const MARKET_BATCH_SIZE = 100;
 const MARKET_BATCH_CONCURRENCY = 2;
+const MARKET_LIST_BATCH_SIZE = 384;
+const MARKET_LIST_BATCH_CONCURRENCY = 1;
 const INDEXED_PRICE_BATCH_SIZE = 20;
 const INDEXED_PRICE_BATCH_CONCURRENCY = 2;
 const INDEXED_PRICE_RECOVERY_CONCURRENCY = 4;
@@ -64,11 +66,21 @@ type GraphqlResponse = Readonly<{
   partial: boolean;
 }>;
 
+type BitqueryMarketDataPhase =
+  | "configuration"
+  | "market-core"
+  | "market-liquidity"
+  | "market-price"
+  | "market-stats"
+  | "chart"
+  | "unspecified";
+
 type BitqueryReaderOptions = Readonly<{
   fetchImpl?: FetchImplementation;
   token?: string | null;
   now?: Date;
   signal?: AbortSignal;
+  includeStats?: boolean;
 }>;
 
 type MarketCacheEntry = Readonly<{
@@ -93,6 +105,7 @@ export class BitqueryMarketDataError extends Error {
       | "transport"
       | "response"
       | "integrity",
+    readonly phase: BitqueryMarketDataPhase = "unspecified",
   ) {
     super("Market data is temporarily unavailable");
   }
@@ -101,10 +114,24 @@ export class BitqueryMarketDataError extends Error {
 export function safeBitqueryMarketDataError(error: unknown): Readonly<{
   name: string;
   category: string;
+  phase: string;
 }> {
   return error instanceof BitqueryMarketDataError
-    ? { name: error.name, category: error.category }
-    : { name: "MarketDataError", category: "unexpected" };
+    ? { name: error.name, category: error.category, phase: error.phase }
+    : {
+        name: "MarketDataError",
+        category: "unexpected",
+        phase: "unspecified",
+      };
+}
+
+function marketDataErrorAtPhase(
+  error: unknown,
+  phase: BitqueryMarketDataPhase,
+): BitqueryMarketDataError {
+  return error instanceof BitqueryMarketDataError
+    ? new BitqueryMarketDataError(error.category, phase)
+    : new BitqueryMarketDataError("transport", phase);
 }
 
 export function bitqueryMarketDataConfigured(
@@ -124,7 +151,8 @@ export async function readBitqueryTokenMarketDataV1(
     process.env.NODE_ENV !== "test" &&
     options.fetchImpl === undefined &&
     options.token === undefined &&
-    options.now === undefined
+    options.now === undefined &&
+    options.includeStats === undefined
   ) {
     const entries = await readDurablyCachedBitqueryMarketData(
       JSON.stringify(unique),
@@ -148,13 +176,21 @@ export async function readBitqueryTokenMarketDataStrictV1(
   const unique = canonicalMarketIdentities(identities);
   if (unique.length === 0) return new Map();
   const token = resolveToken(options.token);
-  if (token === null) throw new BitqueryMarketDataError("configuration");
+  if (token === null) {
+    throw new BitqueryMarketDataError("configuration", "configuration");
+  }
   const pools = new Map<string, MarketPoolDataV1>();
   const batches: MarketDataIdentityV1[][] = [];
-  for (let offset = 0; offset < unique.length; offset += MARKET_BATCH_SIZE) {
-    batches.push(unique.slice(offset, offset + MARKET_BATCH_SIZE));
+  const batchSize = options.includeStats === false
+    ? MARKET_LIST_BATCH_SIZE
+    : MARKET_BATCH_SIZE;
+  const batchConcurrency = options.includeStats === false
+    ? MARKET_LIST_BATCH_CONCURRENCY
+    : MARKET_BATCH_CONCURRENCY;
+  for (let offset = 0; offset < unique.length; offset += batchSize) {
+    batches.push(unique.slice(offset, offset + batchSize));
   }
-  await mapWithConcurrency(batches, MARKET_BATCH_CONCURRENCY, async (batch) => {
+  await mapWithConcurrency(batches, batchConcurrency, async (batch) => {
     const result = await readMarketBatch(batch, {
       ...options,
       token,
@@ -163,7 +199,7 @@ export async function readBitqueryTokenMarketDataStrictV1(
     });
     for (const value of result) {
       if (value.status === "unavailable") {
-        throw new BitqueryMarketDataError("integrity");
+        throw new BitqueryMarketDataError("integrity", "market-core");
       }
       pools.set(value.identity.poolId, value);
     }
@@ -493,7 +529,7 @@ async function readBitqueryMarketChart(
     }
     return chart;
   } catch (error) {
-    if (strict) throw error;
+    if (strict) throw marketDataErrorAtPhase(error, "chart");
     return cachedChartOrUnavailable(identity, input.range, cacheKey, now);
   } finally {
     clearTimeout(chartTimeout);
@@ -586,36 +622,44 @@ async function readMarketBatch(
   }>,
 ): Promise<readonly MarketPoolDataV1[]> {
   const coreRequest = marketBatchQuery(identities);
-  const statsRequest = marketStatsQuery(identities);
+  const liquidityRequest = marketLiquidityQuery(identities);
   const coreRead = executeBitqueryGraphql(
     coreRequest.query,
     coreRequest.variables,
     options,
   );
-  const supplementaryOperations = [
-    executeBitqueryGraphql(
-      statsRequest.query,
-      statsRequest.variables,
-      options,
-    ),
-  ] as const;
-  const supplementaryReads = Promise.allSettled(supplementaryOperations);
-  const [coreResult, supplementaryResults] = await Promise.allSettled([
+  const liquidityRead = executeBitqueryGraphql(
+    liquidityRequest.query,
+    liquidityRequest.variables,
+    options,
+  );
+  const statsRead: Promise<GraphqlResponse | null> = options.includeStats === false
+    ? Promise.resolve(null)
+    : (() => {
+        const statsRequest = marketStatsQuery(identities);
+        return executeBitqueryGraphql(
+          statsRequest.query,
+          statsRequest.variables,
+          options,
+        );
+      })();
+  const [coreResult, liquidityResult, statsResult] = await Promise.allSettled([
     coreRead,
-    supplementaryReads,
+    liquidityRead,
+    statsRead,
   ]);
-  if (coreResult.status === "rejected") throw coreResult.reason;
+  if (coreResult.status === "rejected") {
+    throw marketDataErrorAtPhase(coreResult.reason, "market-core");
+  }
   const response = coreResult.value;
-  const [statsResult] = supplementaryResults.status ===
-      "fulfilled"
-    ? supplementaryResults.value
-    : [supplementaryResults];
   if (options.strict && response.partial) {
-    throw new BitqueryMarketDataError("response");
+    throw new BitqueryMarketDataError("response", "market-core");
   }
   const evm = record(response.data.EVM);
   const trading = record(response.data.Trading);
-  if (evm === null) throw new BitqueryMarketDataError("response");
+  if (evm === null) {
+    throw new BitqueryMarketDataError("response", "market-core");
+  }
   const tradesByPool = indexUniqueRows(array(evm.latestTrades), tradeRowPoolId);
   const parsedTrades = identities.map((identity) => {
     const row = tradesByPool.get(identity.poolId);
@@ -640,18 +684,47 @@ async function readMarketBatch(
     : new Map<number, TokenPriceObservation | null>();
   const priceLookupWasPartial = priceResult.status !== "fulfilled" ||
     priceResult.value.partial;
-  if (options.strict && priceLookupWasPartial) {
-    throw new BitqueryMarketDataError("response");
+  if (options.strict && priceResult.status === "rejected") {
+    throw marketDataErrorAtPhase(priceResult.reason, "market-price");
   }
-  const statsEvm = statsResult.status === "fulfilled"
+  if (
+    options.strict && priceResult.status === "fulfilled" &&
+    priceResult.value.partial
+  ) {
+    throw new BitqueryMarketDataError("response", "market-price");
+  }
+  const liquidityEvm = liquidityResult.status === "fulfilled" &&
+      !liquidityResult.value.partial
+    ? record(liquidityResult.value.data.EVM)
+    : null;
+  const statsEvm = statsResult.status === "fulfilled" && statsResult.value !== null
     ? record(statsResult.value.data.EVM)
     : null;
   if (
-    options.strict &&
+    options.strict && options.includeStats !== false &&
+    statsResult.status === "rejected"
+  ) throw marketDataErrorAtPhase(statsResult.reason, "market-stats");
+  if (
+    options.strict && options.includeStats !== false &&
     (statsEvm === null || statsResult.status !== "fulfilled" ||
-      statsResult.value.partial)
-  ) throw new BitqueryMarketDataError("response");
+      statsResult.value === null || statsResult.value.partial)
+  ) throw new BitqueryMarketDataError("response", "market-stats");
 
+  let liquidityReadPartial = liquidityResult.status !== "fulfilled" ||
+    liquidityResult.value.partial || liquidityEvm === null;
+  let liquidityByPool: ReadonlyMap<string, unknown> = new Map();
+  if (!liquidityReadPartial && liquidityEvm !== null) {
+    try {
+      liquidityByPool = indexUniqueRows(
+        array(liquidityEvm.latestLiquidity),
+        liquidityRowPoolId,
+      );
+    } catch {
+      // Liquidity is eligibility evidence, not launch discovery. A malformed
+      // optional row removes FDV eligibility without taking down the catalog.
+      liquidityReadPartial = true;
+    }
+  }
   const statsByMarket = indexUniqueRows(
     array(statsEvm?.stats),
     (row) => {
@@ -689,6 +762,8 @@ async function readMarketBatch(
       identity,
       latestTradeRows,
       latestTrade,
+      liquidityPriceTrade: parsedTrade,
+      liquidityRow: liquidityByPool.get(identity.poolId),
       stats: parseStats(statsByMarket.get(
         marketStatsKey(identity.poolId, identity.tokenAddress),
       )),
@@ -697,19 +772,27 @@ async function readMarketBatch(
   });
 
   return parsed.map((value) => {
+    const liquidity = parseLiquidity(
+      value.liquidityRow,
+      value.identity,
+      options.now,
+      value.liquidityPriceTrade,
+    );
     return marketPoolData({
       identity: value.identity,
       latestTrade: value.latestTrade,
       tradeObserved: value.latestTradeRows.length > 0,
-      liquidity: null,
+      liquidity,
       stats: value.stats,
       supply: value.supply,
       now: options.now,
       partialResponse:
         response.partial ||
         priceLookupWasPartial ||
-        statsResult.status !== "fulfilled" ||
-        statsResult.value.partial,
+        liquidityReadPartial ||
+        (options.includeStats !== false &&
+          (statsResult.status !== "fulfilled" ||
+            statsResult.value === null || statsResult.value.partial)),
     });
   });
 }
@@ -763,11 +846,20 @@ async function readIndexedPriceObservations(
           }
         }
       } catch (error) {
-        if (options.strict) throw error;
+        if (options.strict) {
+          throw marketDataErrorAtPhase(error, "market-price");
+        }
         partial = true;
       }
     },
   );
+
+  if (options.strict) {
+    for (const { index } of candidates) {
+      if (!observations.has(index)) observations.set(index, null);
+    }
+    return { observations, partial };
+  }
 
   const missing = candidates.filter(
     ({ index }) => !observations.has(index),
@@ -957,6 +1049,11 @@ function tradeRowPoolId(row: unknown): `0x${string}` | null {
   return canonicalBytes32(record(record(row)?.Trade)?.PoolId);
 }
 
+function liquidityRowPoolId(row: unknown): `0x${string}` | null {
+  const event = record(record(row)?.PoolEvent);
+  return canonicalBytes32(record(event?.Pool)?.PoolId);
+}
+
 function marketStatsKey(
   poolId: `0x${string}`,
   tokenAddress: `0x${string}`,
@@ -1029,6 +1126,34 @@ function marketPriceQuery(trades: readonly MarketTradeV1[]) {
       Trading { ${selections} }
     }`,
     variables: {},
+  };
+}
+
+function marketLiquidityQuery(identities: readonly MarketDataIdentityV1[]) {
+  const pools = identities.map(({ poolId }) => poolId);
+  const rowLimit = Math.max(1, identities.length);
+  return {
+    query: `query ProgrammableMarketLiquidity($pools: [String!]!) {
+      EVM(network: eth) {
+        latestLiquidity: DEXPoolEvents(
+          limit: { count: ${rowLimit} }
+          limitBy: { by: PoolEvent_Pool_PoolId, count: 1 }
+          orderBy: [
+            { descending: Block_Number }
+            { descending: Transaction_Index }
+            { descending: Log_Index }
+          ]
+          where: {
+            TransactionStatus: { Success: true }
+            PoolEvent: {
+              Dex: { ProtocolName: { is: "uniswap_v4" } }
+              Pool: { PoolId: { in: $pools } }
+            }
+          }
+        ) { ${liquiditySelection()} }
+      }
+    }`,
+    variables: { pools },
   };
 }
 
@@ -1253,6 +1378,27 @@ function tradeSelection() {
       Sell { Currency { SmartContract Symbol } Amount AmountInUSD Price PriceInUSD }
     }
     Transaction { Hash Index }
+  `;
+}
+
+function liquiditySelection() {
+  return `
+    Block { Number Time }
+    Log { Index }
+    Transaction { Hash Index }
+    PoolEvent {
+      Pool {
+        PoolId
+        CurrencyA { SmartContract Symbol }
+        CurrencyB { SmartContract Symbol }
+      }
+      Liquidity {
+        AmountCurrencyA
+        AmountCurrencyAInUSD
+        AmountCurrencyB
+        AmountCurrencyBInUSD
+      }
+    }
   `;
 }
 
@@ -1640,6 +1786,9 @@ function marketPoolData(input: Readonly<{
     ? null
     : BigInt(input.liquidity.valueUsdWad);
   const valuation = sourceValuation.status === "available" &&
+      liquidityValue === null
+    ? { status: "unavailable" as const, reason: "source-unavailable" as const }
+    : sourceValuation.status === "available" &&
       liquidityValue !== null &&
       liquidityValue < BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD)
     ? { status: "unavailable" as const, reason: "inconsistent-market-data" as const }

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -93,6 +93,25 @@ type ChartCacheEntry = Readonly<{
   value: MarketChartV1;
 }>;
 
+type BitqueryFdvRankingObservation = Readonly<{
+  asOfTime: string;
+  priceUsdWad: string;
+  fdvUsdWad: string;
+  totalSupply: string;
+  maxSupply?: string;
+  freshness: "current" | "stale";
+}>;
+
+type BitqueryFdvRankingParseResult =
+  | Readonly<{ observation: BitqueryFdvRankingObservation; reason?: never }>
+  | Readonly<{
+      observation?: never;
+      reason: Extract<
+        MarketValuationV1,
+        { status: "unavailable" }
+      >["reason"];
+    }>;
+
 const marketCache = new Map<string, MarketCacheEntry>();
 const chartCache = new Map<string, ChartCacheEntry>();
 
@@ -204,6 +223,102 @@ export async function readBitqueryTokenMarketDataStrictV1(
       pools.set(value.identity.poolId, value);
     }
   });
+  return groupTokenMarketData(unique, pools, now);
+}
+
+/**
+ * Reads only the bounded data needed to rank Explore entries by current FDV.
+ *
+ * Token price, supply and provider-computed FDV come from `Trading.Tokens`.
+ * Pool liquidity comes from the realtime `EVM(network: eth)` dataset. The
+ * token read is strict, while absent or malformed liquidity fails closed for
+ * that valuation without taking down launch discovery. This path never reads
+ * DEX trades, statistics, caches or another provider.
+ */
+export async function readBitqueryTokenFdvRankingStrictV1(
+  identities: readonly MarketDataIdentityV1[],
+  options: BitqueryReaderOptions = {},
+): Promise<ReadonlyMap<string, TokenMarketDataV1>> {
+  const now = options.now ?? new Date();
+  const unique = canonicalMarketIdentities(identities);
+  if (unique.length === 0) return new Map();
+  if (unique.length > MARKET_LIST_BATCH_SIZE) {
+    throw new BitqueryMarketDataError("integrity", "market-core");
+  }
+  const token = resolveToken(options.token);
+  if (token === null) {
+    throw new BitqueryMarketDataError("configuration", "configuration");
+  }
+
+  const tokenRequest = marketFdvRankingQuery(unique);
+  const liquidityRequest = marketLiquidityQuery(unique);
+  const [tokenResult, liquidityResult] = await Promise.allSettled([
+    executeBitqueryGraphql(
+      tokenRequest.query,
+      tokenRequest.variables,
+      { ...options, token },
+    ),
+    executeBitqueryGraphql(
+      liquidityRequest.query,
+      liquidityRequest.variables,
+      { ...options, token },
+    ),
+  ]);
+  if (tokenResult.status === "rejected") {
+    throw marketDataErrorAtPhase(tokenResult.reason, "market-core");
+  }
+  if (tokenResult.value.partial) {
+    throw new BitqueryMarketDataError("response", "market-core");
+  }
+  const trading = record(tokenResult.value.data.Trading);
+  if (trading === null) {
+    throw new BitqueryMarketDataError("response", "market-core");
+  }
+
+  const expectedTokens = new Set(unique.map(({ tokenAddress }) => tokenAddress));
+  const tokenRows = indexUniqueRows(
+    array(trading.rankingTokens),
+    (row) => canonicalAddress(record(record(row)?.Token)?.Address),
+  );
+  for (const tokenAddress of tokenRows.keys()) {
+    if (!expectedTokens.has(tokenAddress as `0x${string}`)) {
+      throw new BitqueryMarketDataError("integrity", "market-core");
+    }
+  }
+
+  let liquidityRows: ReadonlyMap<string, unknown> = new Map();
+  if (liquidityResult.status === "fulfilled" && !liquidityResult.value.partial) {
+    const evm = record(liquidityResult.value.data.EVM);
+    if (evm !== null) {
+      try {
+        liquidityRows = indexUniqueRows(
+          array(evm.latestLiquidity),
+          liquidityRowPoolId,
+        );
+      } catch {
+        // Liquidity gates FDV publication, but never launch discovery.
+        liquidityRows = new Map();
+      }
+    }
+  }
+
+  const pools = new Map<string, MarketPoolDataV1>();
+  for (const identity of unique) {
+    const tokenValue = parseFdvRankingToken(
+      tokenRows.get(identity.tokenAddress),
+      identity,
+      now,
+    );
+    const liquidity = parseLiquidity(
+      liquidityRows.get(identity.poolId),
+      identity,
+      now,
+    );
+    pools.set(
+      identity.poolId,
+      fdvRankingPoolData(identity, tokenValue, liquidity),
+    );
+  }
   return groupTokenMarketData(unique, pools, now);
 }
 
@@ -1102,6 +1217,42 @@ function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
   };
 }
 
+function marketFdvRankingQuery(
+  identities: readonly MarketDataIdentityV1[],
+) {
+  const tokenAddresses = [...new Set(
+    identities.map(({ tokenAddress }) => tokenAddress),
+  )].sort();
+  const rowLimit = Math.max(1, tokenAddresses.length);
+  return {
+    query: `query ProgrammableExploreFdvRanking(
+      $tokenAddresses: [String!]!
+    ) {
+      Trading {
+        rankingTokens: Tokens(
+          limit: { count: ${rowLimit} }
+          limitBy: { by: Token_Address, count: 1 }
+          orderBy: { descending: Block_Time }
+          where: {
+            Token: { Address: { in: $tokenAddresses } }
+            Price: { IsQuotedInUsd: true }
+          }
+        ) {
+          Token { Id Address }
+          Block { Time }
+          Supply {
+            TotalSupply
+            MaxSupply
+            FullyDilutedValuationUsd
+          }
+          Price { IsQuotedInUsd Ohlc { Close } }
+        }
+      }
+    }`,
+    variables: { tokenAddresses },
+  };
+}
+
 function marketPriceQuery(trades: readonly MarketTradeV1[]) {
   // The legacy Trades filter `Token: { Id: { is: "bid:eth" } }` did not
   // provide a reliable USD observation. The Tokens price index requires the
@@ -1709,6 +1860,156 @@ type ParsedSupply = Readonly<{
   circulatingSupply?: string;
   maxSupply?: string;
 }> | null;
+
+function parseFdvRankingToken(
+  value: unknown,
+  identity: MarketDataIdentityV1,
+  now: Date,
+): BitqueryFdvRankingParseResult {
+  if (value === undefined) {
+    return { reason: "source-unavailable" };
+  }
+  const row = record(value);
+  const token = record(row?.Token);
+  const block = record(row?.Block);
+  const supply = record(row?.Supply);
+  const price = record(row?.Price);
+  const ohlc = record(price?.Ohlc);
+  if (!row || !token || !block || !supply || !price || !ohlc) {
+    return { reason: "source-unavailable" };
+  }
+  const address = canonicalAddress(token.Address);
+  const id = nonEmptyString(token.Id)?.toLowerCase();
+  if (
+    address !== identity.tokenAddress ||
+    (id !== `eth:${identity.tokenAddress}` &&
+      id !== `bid:eth:${identity.tokenAddress}`)
+  ) {
+    return { reason: "inconsistent-market-data" };
+  }
+  const asOfTime = isoTime(block.Time);
+  const totalSupply = positiveDecimal(supply.TotalSupply);
+  const maxSupply = positiveDecimal(supply.MaxSupply);
+  const priceUsdWad = price.IsQuotedInUsd === true
+    ? decimalToWad(ohlc.Close)
+    : null;
+  const fdvUsdWad = decimalToWad(supply.FullyDilutedValuationUsd);
+  if (asOfTime === null) return { reason: "inconsistent-market-data" };
+  if (priceUsdWad === null) return { reason: "price-unavailable" };
+  if (totalSupply === null || fdvUsdWad === null) {
+    return { reason: "supply-unavailable" };
+  }
+  if (
+    maxSupply !== null && comparePositiveDecimals(totalSupply, maxSupply) > 0
+  ) {
+    return { reason: "inconsistent-market-data" };
+  }
+  const computedFdvUsdWad = multiplyWadByDecimal(priceUsdWad, totalSupply);
+  if (
+    computedFdvUsdWad === null ||
+    !usdPricesWithinConfidence(fdvUsdWad, computedFdvUsdWad)
+  ) {
+    return { reason: "inconsistent-market-data" };
+  }
+  const age = now.getTime() - Date.parse(asOfTime);
+  if (age < -MAXIMUM_FUTURE_SKEW_MS) {
+    return { reason: "inconsistent-market-data" };
+  }
+  return {
+    observation: {
+      asOfTime,
+      priceUsdWad: priceUsdWad.toString(),
+      fdvUsdWad: fdvUsdWad.toString(),
+      totalSupply,
+      ...(maxSupply === null ? {} : { maxSupply }),
+      freshness: age > MARKET_DATA_CURRENT_MAX_AGE_MS ? "stale" : "current",
+    },
+  };
+}
+
+function fdvRankingPoolData(
+  identity: MarketDataIdentityV1,
+  tokenValue: BitqueryFdvRankingParseResult,
+  liquidity: MarketLiquidityV1 | null,
+): MarketPoolDataV1 {
+  if (tokenValue.observation === undefined) {
+    return unavailablePool(identity, tokenValue.reason);
+  }
+  const observation = tokenValue.observation;
+  const status = observation.freshness === "current" &&
+      liquidity?.freshness !== "stale"
+    ? "current" as const
+    : "stale" as const;
+  if (liquidity === null) {
+    return {
+      identity,
+      source: "bitquery",
+      status,
+      quality: "partial",
+      asOfTime: observation.asOfTime,
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    };
+  }
+  if (
+    observation.freshness !== "current" ||
+    liquidity.freshness !== "current"
+  ) {
+    return {
+      identity,
+      source: "bitquery",
+      status: "stale",
+      quality: "partial",
+      asOfTime: new Date(Math.min(
+        Date.parse(observation.asOfTime),
+        Date.parse(liquidity.asOfTime),
+      )).toISOString(),
+      liquidity,
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    };
+  }
+  if (
+    BigInt(liquidity.valueUsdWad) <
+      BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD)
+  ) {
+    return {
+      identity,
+      source: "bitquery",
+      status: "current",
+      quality: "partial",
+      asOfTime: observation.asOfTime,
+      liquidity,
+      valuation: {
+        status: "unavailable",
+        reason: "inconsistent-market-data",
+      },
+    };
+  }
+  const asOfTime = new Date(Math.min(
+    Date.parse(observation.asOfTime),
+    Date.parse(liquidity.asOfTime),
+  )).toISOString();
+  return {
+    identity,
+    source: "bitquery",
+    status: "current",
+    quality: "complete",
+    asOfTime,
+    liquidity,
+    valuation: {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      valueUsdWad: observation.fdvUsdWad,
+      fdvUsdWad: observation.fdvUsdWad,
+      totalSupply: observation.totalSupply,
+      ...(observation.maxSupply === undefined
+        ? {}
+        : { maxSupply: observation.maxSupply }),
+      asOfTime,
+      freshness: "current",
+    },
+  };
+}
 
 function parseSupply(
   value: unknown,

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -275,13 +275,20 @@ export async function readBitqueryTokenFdvRankingStrictV1(
     throw new BitqueryMarketDataError("response", "market-core");
   }
 
-  const expectedTokens = new Set(unique.map(({ tokenAddress }) => tokenAddress));
-  const tokenRows = indexUniqueRows(
-    array(trading.rankingTokens),
-    (row) => canonicalAddress(record(record(row)?.Token)?.Address),
+  const expectedTokenIds = new Set(
+    unique.map(({ tokenAddress }) => ethereumTokenId(tokenAddress)),
   );
-  for (const tokenAddress of tokenRows.keys()) {
-    if (!expectedTokens.has(tokenAddress as `0x${string}`)) {
+  let tokenRows: ReadonlyMap<string, unknown>;
+  try {
+    tokenRows = indexUniqueRows(
+      array(trading.rankingTokens),
+      (row) => canonicalEthereumTokenId(record(record(row)?.Token)?.Id),
+    );
+  } catch {
+    throw new BitqueryMarketDataError("integrity", "market-core");
+  }
+  for (const tokenId of tokenRows.keys()) {
+    if (!expectedTokenIds.has(tokenId)) {
       throw new BitqueryMarketDataError("integrity", "market-core");
     }
   }
@@ -305,7 +312,7 @@ export async function readBitqueryTokenFdvRankingStrictV1(
   const pools = new Map<string, MarketPoolDataV1>();
   for (const identity of unique) {
     const tokenValue = parseFdvRankingToken(
-      tokenRows.get(identity.tokenAddress),
+      tokenRows.get(ethereumTokenId(identity.tokenAddress)),
       identity,
       now,
     );
@@ -1220,21 +1227,22 @@ function marketBatchQuery(identities: readonly MarketDataIdentityV1[]) {
 function marketFdvRankingQuery(
   identities: readonly MarketDataIdentityV1[],
 ) {
-  const tokenAddresses = [...new Set(
-    identities.map(({ tokenAddress }) => tokenAddress),
+  const tokenIds = [...new Set(
+    identities.map(({ tokenAddress }) => ethereumTokenId(tokenAddress)),
   )].sort();
-  const rowLimit = Math.max(1, tokenAddresses.length);
+  const rowLimit = Math.max(1, tokenIds.length);
   return {
     query: `query ProgrammableExploreFdvRanking(
-      $tokenAddresses: [String!]!
+      $tokenIds: [String!]!
     ) {
       Trading {
         rankingTokens: Tokens(
           limit: { count: ${rowLimit} }
-          limitBy: { by: Token_Address, count: 1 }
+          limitBy: { by: Token_Id, count: 1 }
           orderBy: { descending: Block_Time }
           where: {
-            Token: { Address: { in: $tokenAddresses } }
+            Token: { Id: { in: $tokenIds } }
+            Interval: { Time: { Duration: { eq: 1 } } }
             Price: { IsQuotedInUsd: true }
           }
         ) {
@@ -1242,14 +1250,13 @@ function marketFdvRankingQuery(
           Block { Time }
           Supply {
             TotalSupply
-            MaxSupply
             FullyDilutedValuationUsd
           }
           Price { IsQuotedInUsd Ohlc { Close } }
         }
       }
     }`,
-    variables: { tokenAddresses },
+    variables: { tokenIds },
   };
 }
 
@@ -1882,8 +1889,7 @@ function parseFdvRankingToken(
   const id = nonEmptyString(token.Id)?.toLowerCase();
   if (
     address !== identity.tokenAddress ||
-    (id !== `eth:${identity.tokenAddress}` &&
-      id !== `bid:eth:${identity.tokenAddress}`)
+    id !== ethereumTokenId(identity.tokenAddress)
   ) {
     return { reason: "inconsistent-market-data" };
   }
@@ -2463,6 +2469,16 @@ function resolveToken(explicit: string | null | undefined): string | null {
   return typeof value === "string" && value.trim().length >= 16
     ? value.trim()
     : null;
+}
+
+function ethereumTokenId(address: `0x${string}`): string {
+  return `eth:${address}`;
+}
+
+function canonicalEthereumTokenId(value: unknown): string | null {
+  if (typeof value !== "string" || value !== value.toLowerCase()) return null;
+  const address = canonicalAddress(value.slice("eth:".length));
+  return address !== null && value === ethereumTokenId(address) ? value : null;
 }
 
 function canonicalAddress(value: unknown): `0x${string}` | null {

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -2472,12 +2472,12 @@ function resolveToken(explicit: string | null | undefined): string | null {
 }
 
 function ethereumTokenId(address: `0x${string}`): string {
-  return `eth:${address}`;
+  return `bid:eth:${address}`;
 }
 
 function canonicalEthereumTokenId(value: unknown): string | null {
   if (typeof value !== "string" || value !== value.toLowerCase()) return null;
-  const address = canonicalAddress(value.slice("eth:".length));
+  const address = canonicalAddress(value.slice("bid:eth:".length));
   return address !== null && value === ethereumTokenId(address) ? value : null;
 }
 

--- a/lib/market-data/primary-rpc-launches.server.ts
+++ b/lib/market-data/primary-rpc-launches.server.ts
@@ -1,0 +1,1010 @@
+import "server-only";
+
+import { mainnet } from "viem/chains";
+import {
+  createPublicClient,
+  formatUnits,
+  http,
+  parseAbiItem,
+  type AbiEvent,
+  type Address,
+  type Hex,
+} from "viem";
+
+import classicV2Manifest from
+  "../../contracts/deployments/mainnet-classic-v2.json";
+import classicV3Manifest from
+  "../../contracts/deployments/mainnet-classic-v3.json";
+import stockV1Manifest from
+  "../../contracts/deployments/mainnet-stock-paired-v1.json";
+import stockV2Manifest from
+  "../../contracts/deployments/mainnet-stock-paired-v2.json";
+import stockV3Manifest from
+  "../../contracts/deployments/mainnet-stock-paired-v3.json";
+import { canonicalTokenExploreEntryV1 } from "../explore-entry-v1";
+import {
+  memeLiquidityConfiguredEvent,
+  memeTokenLaunchedEvent,
+  uerc20ReadAbi,
+} from "../onchain/abis";
+import { buildTokenLinks, sanitizeImageUrl } from "../onchain/metadata";
+import { productionMainnetRpcPrimary } from
+  "../onchain/website-rpc-providers.server";
+import {
+  STOCK_PAIRED_CREATOR_FEE_BPS,
+  STOCK_PAIRED_PROGRAMMABLE_FEE_BPS,
+  STOCK_PAIRED_TOTAL_SWAP_FEE_BPS,
+} from "../stock-paired";
+import type { ExploreEntry, LauncherToken } from "../tokens";
+
+const REQUEST_TIMEOUT_MS = 12_000;
+const INITIAL_LOG_RANGE = 8_192n;
+const MAXIMUM_LOG_RANGE = 8_192n;
+const MINIMUM_LOG_RANGE = 128n;
+const MAXIMUM_LOGS = 10_000;
+const MAXIMUM_LAUNCHES = 5_000;
+const MAXIMUM_CONCURRENT_RPC_READS = 20;
+
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const BYTES32 = /^0x[0-9a-f]{64}$/u;
+
+const memeTokenLaunchedV2Event = parseAbiItem(
+  "event MemeTokenLaunchedV2(address indexed deployer,address indexed token,bytes32 indexed poolId,address feeHook,address rewardVault,address positionRecipient,uint256 positionTokenId,uint16 buySwapFeeBps,uint16 sellSwapFeeBps,bytes32 rewardConfigurationHash,bytes32 launchHash)",
+);
+const memeLiquidityConfiguredV2Event = parseAbiItem(
+  "event MemeLiquidityConfiguredV2(address indexed token,uint256 totalSupply,uint256 tokenLiquidityAmount,uint256 lockedTokenDust,int24 initialTick,int24 tickLower,int24 tickUpper,uint24 lpFeePips,bytes32 launchHash)",
+);
+const stockPairedTokenLaunchedEvent = parseAbiItem(
+  "event StockPairedTokenLaunched(address indexed deployer,address indexed token,address indexed quoteAsset,bytes32 poolId,address rewardVault,address positionRecipient,uint256 positionTokenId,bytes32 launchHash)",
+);
+const stockPairedLiquidityConfiguredEvent = parseAbiItem(
+  "event StockPairedLiquidityConfigured(address indexed token,address indexed quoteAsset,uint256 totalSupply,uint256 tokenLiquidityAmount,uint256 lockedTokenDust,int24 initialTick,int24 tickLower,int24 tickUpper,uint24 lpFeePips,bytes32 launchHash)",
+);
+
+const SPARSE_LAUNCH_EVENTS = Object.freeze([
+  memeTokenLaunchedEvent,
+  memeLiquidityConfiguredEvent,
+  memeTokenLaunchedV2Event,
+  memeLiquidityConfiguredV2Event,
+  stockPairedTokenLaunchedEvent,
+  stockPairedLiquidityConfiguredEvent,
+] satisfies readonly AbiEvent[]);
+
+type ReleaseDefinition = Readonly<{
+  releaseId:
+    | "classic-v2"
+    | "classic-v3"
+    | "stock-paired-v1"
+    | "stock-paired-v2"
+    | "stock-paired-v3";
+  model: "classic" | "stock-paired";
+  launcher: Address;
+  hook: Address;
+  startBlock: bigint;
+  launchEvent:
+    | "MemeTokenLaunched"
+    | "MemeTokenLaunchedV2"
+    | "StockPairedTokenLaunched";
+  liquidityEvent:
+    | "MemeLiquidityConfigured"
+    | "MemeLiquidityConfiguredV2"
+    | "StockPairedLiquidityConfigured";
+}>;
+
+const RELEASES = Object.freeze([
+  releaseDefinition({
+    releaseId: "classic-v2",
+    model: "classic",
+    manifest: classicV2Manifest,
+    launcherKey: "memeLauncher",
+    startBlock: classicV2Manifest.deploymentBlock,
+    launchEvent: "MemeTokenLaunched",
+    liquidityEvent: "MemeLiquidityConfigured",
+  }),
+  releaseDefinition({
+    releaseId: "classic-v3",
+    model: "classic",
+    manifest: classicV3Manifest,
+    launcherKey: "launcher",
+    startBlock:
+      classicV3Manifest.sourceVerification.contracts.launcher.deploymentBlock,
+    launchEvent: "MemeTokenLaunchedV2",
+    liquidityEvent: "MemeLiquidityConfiguredV2",
+  }),
+  releaseDefinition({
+    releaseId: "stock-paired-v1",
+    model: "stock-paired",
+    manifest: stockV1Manifest,
+    launcherKey: "launcher",
+    startBlock: stockV1Manifest.startBlock,
+    launchEvent: "StockPairedTokenLaunched",
+    liquidityEvent: "StockPairedLiquidityConfigured",
+  }),
+  releaseDefinition({
+    releaseId: "stock-paired-v2",
+    model: "stock-paired",
+    manifest: stockV2Manifest,
+    launcherKey: "launcher",
+    startBlock: stockV2Manifest.startBlock,
+    launchEvent: "StockPairedTokenLaunched",
+    liquidityEvent: "StockPairedLiquidityConfigured",
+  }),
+  releaseDefinition({
+    releaseId: "stock-paired-v3",
+    model: "stock-paired",
+    manifest: stockV3Manifest,
+    launcherKey: "launcher",
+    startBlock: stockV3Manifest.startBlock,
+    launchEvent: "StockPairedTokenLaunched",
+    liquidityEvent: "StockPairedLiquidityConfigured",
+  }),
+] satisfies readonly ReleaseDefinition[]);
+
+const RELEASE_BY_LAUNCHER = new Map(
+  RELEASES.map((release) => [release.launcher, release] as const),
+);
+const EARLIEST_START_BLOCK = RELEASES.reduce(
+  (minimum, release) => release.startBlock < minimum
+    ? release.startBlock
+    : minimum,
+  RELEASES[0]!.startBlock,
+);
+
+export type PrimaryRpcExploreEntriesV1 = Readonly<{
+  source: "drpc";
+  generatedAt: string;
+  asOfBlock: string | null;
+  asOfBlockHash: Hex | null;
+  entries: readonly ExploreEntry[];
+}>;
+
+export type PrimaryRpcLaunchCatalogErrorCategory =
+  | "configuration"
+  | "transport"
+  | "response"
+  | "integrity";
+
+export class PrimaryRpcLaunchCatalogError extends Error {
+  override name = "PrimaryRpcLaunchCatalogError";
+
+  constructor(readonly category: PrimaryRpcLaunchCatalogErrorCategory) {
+    super("Launch catalog is temporarily unavailable");
+  }
+}
+
+export function safePrimaryRpcLaunchCatalogError(error: unknown): Readonly<{
+  name: string;
+  category: PrimaryRpcLaunchCatalogErrorCategory | "unexpected";
+  status: 500 | 503;
+}> {
+  return error instanceof PrimaryRpcLaunchCatalogError
+    ? { name: error.name, category: error.category, status: 503 }
+    : { name: "LaunchCatalogError", category: "unexpected", status: 500 };
+}
+
+export type PrimaryRpcLogQuery = Readonly<{
+  address: readonly Address[];
+  events: readonly AbiEvent[];
+  fromBlock: bigint;
+  toBlock: bigint;
+  strict: true;
+}>;
+
+export type PrimaryRpcContractRead = Readonly<{
+  address: Address;
+  functionName: "name" | "symbol" | "decimals" | "metadata";
+  blockNumber: bigint;
+}>;
+
+export type PrimaryRpcLaunchCatalogClient = Readonly<{
+  getBlockNumber(): Promise<bigint>;
+  getBlock(input: Readonly<{ blockNumber: bigint }>): Promise<unknown>;
+  getLogs(input: PrimaryRpcLogQuery): Promise<readonly unknown[]>;
+  readContract(input: PrimaryRpcContractRead): Promise<unknown>;
+}>;
+
+export type PrimaryRpcLaunchCatalogReaderOptions = Readonly<{
+  signal?: AbortSignal;
+  now?: Date;
+  environment?: Readonly<Record<string, string | undefined>>;
+  client?: PrimaryRpcLaunchCatalogClient;
+}>;
+
+type RpcEvent = Readonly<{
+  release: ReleaseDefinition;
+  name: string;
+  blockNumber: bigint;
+  blockHash: Hex;
+  transactionHash: Hex;
+  transactionIndex: number;
+  logIndex: number;
+  args: Readonly<Record<string, unknown>>;
+}>;
+
+type ParsedLaunch = Readonly<{
+  release: ReleaseDefinition;
+  event: RpcEvent;
+  token: Address;
+  poolId: Hex;
+  creator?: Address;
+  hook: Address;
+  quoteAsset?: Address;
+  rewardVault?: Address;
+  positionRecipient: Address;
+  positionTokenId: string;
+  launchHash: Hex;
+  buySwapFeeBps?: number;
+  sellSwapFeeBps?: number;
+  totalSwapFeeBps: number;
+}>;
+
+type ParsedLiquidity = Readonly<{
+  event: RpcEvent;
+  token: Address;
+  quoteAsset?: Address;
+  totalSupplyRaw: string;
+  tokenLiquidityAmountRaw: string;
+  lockedTokenDustRaw: string;
+  initialTick: number;
+  tickLower: number;
+  tickUpper: number;
+  lpFeePips: number;
+  launchHash: Hex;
+}>;
+
+type TokenMetadata = Readonly<{
+  name: string;
+  symbol: string;
+  decimals: number;
+  description?: string;
+  imageUrl?: string;
+  links?: LauncherToken["links"];
+  extraData?: Hex;
+}>;
+
+type BoundBlock = Readonly<{
+  number: bigint;
+  hash: Hex;
+  timestamp: bigint;
+}>;
+
+export async function readPrimaryRpcExploreEntriesV1(
+  options: PrimaryRpcLaunchCatalogReaderOptions = {},
+): Promise<PrimaryRpcExploreEntriesV1> {
+  const client = options.client ?? createPrimaryRpcClient(options.environment);
+  const now = options.now ?? new Date();
+  const headNumber = await providerCall(() => client.getBlockNumber());
+  if (typeof headNumber !== "bigint" || headNumber < EARLIEST_START_BLOCK) {
+    throw new PrimaryRpcLaunchCatalogError("response");
+  }
+  const head = parseBlock(
+    await providerCall(() => client.getBlock({ blockNumber: headNumber })),
+    headNumber,
+  );
+  const rawLogs = await scanSparseLogs(client, head.number, options.signal);
+  const events = rawLogs.map(parseRpcEvent);
+  const { launches, liquidities } = parseLaunchEvents(events);
+  if (launches.length > MAXIMUM_LAUNCHES) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  if (launches.length === 0) {
+    if (liquidities.length !== 0) {
+      throw new PrimaryRpcLaunchCatalogError("integrity");
+    }
+    return {
+      source: "drpc",
+      generatedAt: now.toISOString(),
+      asOfBlock: head.number.toString(),
+      asOfBlockHash: head.hash,
+      entries: [],
+    };
+  }
+
+  const metadata = await readMetadata(
+    client,
+    [...new Set(launches.map((launch) => launch.token))],
+    [...new Set(launches.flatMap((launch) =>
+      launch.quoteAsset ? [launch.quoteAsset] : []
+    ))],
+    head.number,
+    options.signal,
+  );
+  const launchBlocks = await readLaunchBlocks(
+    client,
+    launches,
+    options.signal,
+  );
+  const entries = launches.map((launch) => buildExploreEntry(
+    launch,
+    requireLiquidity(launch, liquidities),
+    requireLaunchBlock(launch, launchBlocks),
+    metadata,
+  ));
+  if (liquidities.length !== launches.length) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  assertUniqueCatalog(entries);
+  return {
+    source: "drpc",
+    generatedAt: now.toISOString(),
+    asOfBlock: head.number.toString(),
+    asOfBlockHash: head.hash,
+    entries: entries.sort(compareEntries),
+  };
+}
+
+function createPrimaryRpcClient(
+  environment: Readonly<Record<string, string | undefined>> | undefined,
+): PrimaryRpcLaunchCatalogClient {
+  let binding;
+  try {
+    binding = productionMainnetRpcPrimary(environment);
+  } catch {
+    throw new PrimaryRpcLaunchCatalogError("configuration");
+  }
+  const publicClient = createPublicClient({
+    chain: mainnet,
+    transport: http(binding.url, {
+      batch: true,
+      retryCount: 0,
+      timeout: REQUEST_TIMEOUT_MS,
+    }),
+  });
+  return {
+    getBlockNumber: () => publicClient.getBlockNumber(),
+    getBlock: ({ blockNumber }) => publicClient.getBlock({ blockNumber }),
+    getLogs: async (query) => publicClient.getLogs({
+      address: [...query.address],
+      events: [...query.events],
+      fromBlock: query.fromBlock,
+      toBlock: query.toBlock,
+      strict: query.strict,
+    }) as unknown as readonly unknown[],
+    readContract: ({ address, functionName, blockNumber }) => {
+      if (functionName === "name") {
+        return publicClient.readContract({
+          address,
+          abi: uerc20ReadAbi,
+          functionName: "name",
+          blockNumber,
+        });
+      }
+      if (functionName === "symbol") {
+        return publicClient.readContract({
+          address,
+          abi: uerc20ReadAbi,
+          functionName: "symbol",
+          blockNumber,
+        });
+      }
+      if (functionName === "decimals") {
+        return publicClient.readContract({
+          address,
+          abi: uerc20ReadAbi,
+          functionName: "decimals",
+          blockNumber,
+        });
+      }
+      return publicClient.readContract({
+        address,
+        abi: uerc20ReadAbi,
+        functionName: "metadata",
+        blockNumber,
+      });
+    },
+  };
+}
+
+async function scanSparseLogs(
+  client: PrimaryRpcLaunchCatalogClient,
+  head: bigint,
+  signal: AbortSignal | undefined,
+): Promise<readonly unknown[]> {
+  const logs: unknown[] = [];
+  let fromBlock = EARLIEST_START_BLOCK;
+  let range = INITIAL_LOG_RANGE;
+  while (fromBlock <= head) {
+    assertNotAborted(signal);
+    const toBlock = minBigInt(head, fromBlock + range - 1n);
+    try {
+      const page = await client.getLogs({
+        address: RELEASES.map((release) => release.launcher),
+        events: SPARSE_LAUNCH_EVENTS,
+        fromBlock,
+        toBlock,
+        strict: true,
+      });
+      if (!Array.isArray(page)) {
+        throw new PrimaryRpcLaunchCatalogError("response");
+      }
+      logs.push(...page);
+      if (logs.length > MAXIMUM_LOGS) {
+        throw new PrimaryRpcLaunchCatalogError("integrity");
+      }
+      fromBlock = toBlock + 1n;
+      range = minBigInt(MAXIMUM_LOG_RANGE, range * 2n);
+    } catch (error) {
+      if (error instanceof PrimaryRpcLaunchCatalogError) throw error;
+      assertNotAborted(signal);
+      if (range <= MINIMUM_LOG_RANGE) {
+        throw new PrimaryRpcLaunchCatalogError("transport");
+      }
+      range = maxBigInt(MINIMUM_LOG_RANGE, range / 2n);
+    }
+  }
+  return logs;
+}
+
+function parseRpcEvent(value: unknown): RpcEvent {
+  const row = record(value);
+  const address = canonicalAddress(row?.address);
+  const release = address === null ? undefined : RELEASE_BY_LAUNCHER.get(address);
+  const name = nonEmptyString(row?.eventName);
+  const blockNumber = unsignedBigInt(row?.blockNumber);
+  const blockHash = canonicalBytes32(row?.blockHash);
+  const transactionHash = canonicalBytes32(row?.transactionHash);
+  const transactionIndex = nonNegativeSafeInteger(row?.transactionIndex);
+  const logIndex = nonNegativeSafeInteger(row?.logIndex);
+  const args = record(row?.args);
+  if (
+    release === undefined || name === null || blockNumber === null ||
+    blockHash === null || transactionHash === null ||
+    transactionIndex === null || logIndex === null || args === null ||
+    row?.removed === true || blockNumber < release.startBlock ||
+    (name !== release.launchEvent && name !== release.liquidityEvent)
+  ) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  return {
+    release,
+    name,
+    blockNumber,
+    blockHash,
+    transactionHash,
+    transactionIndex,
+    logIndex,
+    args,
+  };
+}
+
+function parseLaunchEvents(events: readonly RpcEvent[]): Readonly<{
+  launches: ParsedLaunch[];
+  liquidities: ParsedLiquidity[];
+}> {
+  const launches: ParsedLaunch[] = [];
+  const liquidities: ParsedLiquidity[] = [];
+  const coordinates = new Set<string>();
+  for (const event of events) {
+    const coordinate = `${event.blockNumber}:${event.transactionIndex}:${event.logIndex}`;
+    if (coordinates.has(coordinate)) {
+      throw new PrimaryRpcLaunchCatalogError("integrity");
+    }
+    coordinates.add(coordinate);
+    if (event.name === event.release.launchEvent) {
+      launches.push(parseLaunch(event));
+    } else {
+      liquidities.push(parseLiquidity(event));
+    }
+  }
+  return { launches, liquidities };
+}
+
+function parseLaunch(event: RpcEvent): ParsedLaunch {
+  const { args, release } = event;
+  const token = requiredAddress(args, "token");
+  const poolId = requiredBytes32(args, "poolId");
+  const positionRecipient = requiredAddress(args, "positionRecipient");
+  const positionTokenId = requiredUnsigned(args, "positionTokenId");
+  const launchHash = requiredBytes32(args, "launchHash");
+  if (release.releaseId === "classic-v2") {
+    const hook = requiredAddress(args, "feeHook");
+    if (hook !== release.hook) {
+      throw new PrimaryRpcLaunchCatalogError("integrity");
+    }
+    return {
+      release,
+      event,
+      token,
+      poolId,
+      creator: requiredAddress(args, "creator"),
+      hook,
+      positionRecipient,
+      positionTokenId,
+      launchHash,
+      totalSwapFeeBps: requiredSmallUnsigned(args, "totalSwapFeeBps", 10_000),
+    };
+  }
+  if (release.releaseId === "classic-v3") {
+    const hook = requiredAddress(args, "feeHook");
+    const buySwapFeeBps = requiredSmallUnsigned(args, "buySwapFeeBps", 10_000);
+    const sellSwapFeeBps = requiredSmallUnsigned(
+      args,
+      "sellSwapFeeBps",
+      10_000,
+    );
+    if (hook !== release.hook) {
+      throw new PrimaryRpcLaunchCatalogError("integrity");
+    }
+    return {
+      release,
+      event,
+      token,
+      poolId,
+      creator: requiredAddress(args, "deployer"),
+      hook,
+      rewardVault: requiredAddress(args, "rewardVault"),
+      positionRecipient,
+      positionTokenId,
+      launchHash,
+      buySwapFeeBps,
+      sellSwapFeeBps,
+      totalSwapFeeBps: Math.max(buySwapFeeBps, sellSwapFeeBps),
+    };
+  }
+  return {
+    release,
+    event,
+    token,
+    poolId,
+    hook: release.hook,
+    quoteAsset: requiredAddress(args, "quoteAsset"),
+    rewardVault: requiredAddress(args, "rewardVault"),
+    positionRecipient,
+    positionTokenId,
+    launchHash,
+    totalSwapFeeBps: STOCK_PAIRED_TOTAL_SWAP_FEE_BPS,
+  };
+}
+
+function parseLiquidity(event: RpcEvent): ParsedLiquidity {
+  return {
+    event,
+    token: requiredAddress(event.args, "token"),
+    ...(event.release.model === "stock-paired"
+      ? { quoteAsset: requiredAddress(event.args, "quoteAsset") }
+      : {}),
+    totalSupplyRaw: requiredUnsigned(event.args, "totalSupply"),
+    tokenLiquidityAmountRaw: requiredUnsigned(
+      event.args,
+      "tokenLiquidityAmount",
+    ),
+    lockedTokenDustRaw: requiredUnsigned(event.args, "lockedTokenDust"),
+    initialTick: requiredSignedSafeInteger(event.args, "initialTick"),
+    tickLower: requiredSignedSafeInteger(event.args, "tickLower"),
+    tickUpper: requiredSignedSafeInteger(event.args, "tickUpper"),
+    lpFeePips: requiredSmallUnsigned(event.args, "lpFeePips", 1_000_000),
+    launchHash: requiredBytes32(event.args, "launchHash"),
+  };
+}
+
+function requireLiquidity(
+  launch: ParsedLaunch,
+  liquidities: readonly ParsedLiquidity[],
+): ParsedLiquidity {
+  const matches = liquidities.filter((liquidity) =>
+    liquidity.event.release.launcher === launch.release.launcher &&
+    liquidity.event.transactionHash === launch.event.transactionHash &&
+    liquidity.token === launch.token &&
+    liquidity.launchHash === launch.launchHash &&
+    liquidity.quoteAsset === launch.quoteAsset
+  );
+  if (matches.length !== 1) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  return matches[0]!;
+}
+
+async function readMetadata(
+  client: PrimaryRpcLaunchCatalogClient,
+  tokenAddresses: readonly Address[],
+  quoteAddresses: readonly Address[],
+  blockNumber: bigint,
+  signal: AbortSignal | undefined,
+): Promise<ReadonlyMap<Address, TokenMetadata>> {
+  const tokenSet = new Set(tokenAddresses);
+  const addresses = [...new Set([...tokenAddresses, ...quoteAddresses])];
+  const rows = await mapBounded(addresses, async (address) => {
+    assertNotAborted(signal);
+    const [name, symbol, decimals] = await providerCall(() =>
+      Promise.all([
+        client.readContract({ address, functionName: "name", blockNumber }),
+        client.readContract({ address, functionName: "symbol", blockNumber }),
+        client.readContract({ address, functionName: "decimals", blockNumber }),
+      ]));
+    const rawMetadata = tokenSet.has(address)
+      ? await providerCall(() => client.readContract({
+          address,
+          functionName: "metadata",
+          blockNumber,
+        }))
+      : null;
+    return [
+      address,
+      parseMetadata(name, symbol, decimals, rawMetadata, tokenSet.has(address)),
+    ] as const;
+  });
+  return new Map(rows);
+}
+
+function parseMetadata(
+  rawName: unknown,
+  rawSymbol: unknown,
+  rawDecimals: unknown,
+  rawMetadata: unknown,
+  requireExtendedMetadata: boolean,
+): TokenMetadata {
+  const name = nonEmptyString(rawName);
+  const symbol = nonEmptyString(rawSymbol);
+  const decimals = nonNegativeSafeInteger(rawDecimals);
+  if (
+    name === null || symbol === null || decimals === null || decimals > 255
+  ) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  if (!requireExtendedMetadata) return { name, symbol, decimals };
+  if (!Array.isArray(rawMetadata) || rawMetadata.length !== 4) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  const [descriptionValue, website, image, extraDataValue] = rawMetadata;
+  const description = typeof descriptionValue === "string" &&
+      descriptionValue.trim().length > 0
+    ? descriptionValue.trim()
+    : null;
+  const extraData = canonicalHex(extraDataValue);
+  if (typeof website !== "string" || typeof image !== "string" || extraData === null) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  const imageUrl = sanitizeImageUrl(image);
+  const links = buildTokenLinks(website, extraData);
+  return {
+    name,
+    symbol,
+    decimals,
+    ...(description ? { description } : {}),
+    ...(imageUrl ? { imageUrl } : {}),
+    ...(links.length > 0 ? { links } : {}),
+    ...(extraData !== "0x" ? { extraData } : {}),
+  };
+}
+
+async function readLaunchBlocks(
+  client: PrimaryRpcLaunchCatalogClient,
+  launches: readonly ParsedLaunch[],
+  signal: AbortSignal | undefined,
+): Promise<ReadonlyMap<string, BoundBlock>> {
+  const numbers = [...new Set(launches.map((launch) => launch.event.blockNumber))];
+  const blocks = await mapBounded(numbers, async (blockNumber) => {
+    assertNotAborted(signal);
+    const block = parseBlock(
+      await providerCall(() => client.getBlock({ blockNumber })),
+      blockNumber,
+    );
+    return [blockNumber.toString(), block] as const;
+  });
+  return new Map(blocks);
+}
+
+function requireLaunchBlock(
+  launch: ParsedLaunch,
+  blocks: ReadonlyMap<string, BoundBlock>,
+): BoundBlock {
+  const block = blocks.get(launch.event.blockNumber.toString());
+  if (block === undefined || block.hash !== launch.event.blockHash) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  return block;
+}
+
+function buildExploreEntry(
+  launch: ParsedLaunch,
+  liquidity: ParsedLiquidity,
+  block: BoundBlock,
+  metadata: ReadonlyMap<Address, TokenMetadata>,
+): ExploreEntry {
+  const tokenMetadata = metadata.get(launch.token);
+  const quoteMetadata = launch.quoteAsset
+    ? metadata.get(launch.quoteAsset)
+    : undefined;
+  if (tokenMetadata === undefined || (launch.quoteAsset && !quoteMetadata)) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  const token: LauncherToken = {
+    id: `1:${launch.token}`,
+    name: tokenMetadata.name,
+    symbol: tokenMetadata.symbol,
+    ...(tokenMetadata.description
+      ? { description: tokenMetadata.description }
+      : {}),
+    ...(tokenMetadata.imageUrl ? { imageUrl: tokenMetadata.imageUrl } : {}),
+    ...(tokenMetadata.links ? { links: tokenMetadata.links } : {}),
+    ...(tokenMetadata.extraData
+      ? { metadataExtraData: tokenMetadata.extraData }
+      : {}),
+    tokenAddress: launch.token,
+    hookAddress: launch.hook,
+    poolId: launch.poolId,
+    ...(launch.creator ? { creatorAddress: launch.creator } : {}),
+    ...(launch.rewardVault ? { rewardVaultAddress: launch.rewardVault } : {}),
+    positionRecipient: launch.positionRecipient,
+    positionTokenId: launch.positionTokenId,
+    launchHash: launch.launchHash,
+    launchBlockNumber: launch.event.blockNumber.toString(),
+    launchTransactionHash: launch.event.transactionHash,
+    launchTransactionIndex: launch.event.transactionIndex,
+    launchLogIndex: launch.event.logIndex,
+    launchedAt: timestampToIso(block.timestamp),
+    totalSupply: formatUnits(
+      BigInt(liquidity.totalSupplyRaw),
+      tokenMetadata.decimals,
+    ),
+    totalSupplyRaw: liquidity.totalSupplyRaw,
+    tokenDecimals: tokenMetadata.decimals,
+    tokenLiquidityAmountRaw: liquidity.tokenLiquidityAmountRaw,
+    lockedTokenDustRaw: liquidity.lockedTokenDustRaw,
+    initialTick: liquidity.initialTick,
+    tickLower: liquidity.tickLower,
+    tickUpper: liquidity.tickUpper,
+    lpFeePips: liquidity.lpFeePips,
+    ...(launch.quoteAsset && quoteMetadata
+      ? {
+          quoteAssetAddress: launch.quoteAsset,
+          quoteAssetName: quoteMetadata.name,
+          quoteAssetSymbol: quoteMetadata.symbol,
+        }
+      : {}),
+    ...(launch.buySwapFeeBps === undefined
+      ? {}
+      : { buyHookFeeBps: launch.buySwapFeeBps }),
+    ...(launch.sellSwapFeeBps === undefined
+      ? {}
+      : { sellHookFeeBps: launch.sellSwapFeeBps }),
+    ...(launch.release.model === "stock-paired"
+      ? {
+          buyHookFeeBps: STOCK_PAIRED_TOTAL_SWAP_FEE_BPS,
+          sellHookFeeBps: STOCK_PAIRED_TOTAL_SWAP_FEE_BPS,
+          creatorFeeBps: STOCK_PAIRED_CREATOR_FEE_BPS,
+          programmableFeeBps: STOCK_PAIRED_PROGRAMMABLE_FEE_BPS,
+          launcherFeeBps: STOCK_PAIRED_PROGRAMMABLE_FEE_BPS,
+          transferTaxBps: 0,
+        }
+      : {}),
+    totalSwapFeeBps: launch.totalSwapFeeBps,
+    launchModel: launch.release.model,
+    ...modelVersionFields(launch.release),
+    liquidityPath: "meme",
+  };
+  return canonicalTokenExploreEntryV1(token);
+}
+
+function modelVersionFields(
+  release: ReleaseDefinition,
+): Pick<LauncherToken, "launchModelVersion"> | Record<string, never> {
+  switch (release.releaseId) {
+    case "classic-v3":
+    case "stock-paired-v1":
+    case "stock-paired-v2":
+    case "stock-paired-v3":
+      return { launchModelVersion: release.releaseId };
+    case "classic-v2":
+      return {};
+  }
+}
+
+function parseBlock(value: unknown, expectedNumber: bigint): BoundBlock {
+  const row = record(value);
+  const number = unsignedBigInt(row?.number);
+  const hash = canonicalBytes32(row?.hash);
+  const timestamp = unsignedBigInt(row?.timestamp);
+  if (number !== expectedNumber || hash === null || timestamp === null) {
+    throw new PrimaryRpcLaunchCatalogError("response");
+  }
+  return { number, hash, timestamp };
+}
+
+function releaseDefinition(input: Readonly<{
+  releaseId: ReleaseDefinition["releaseId"];
+  model: ReleaseDefinition["model"];
+  manifest: unknown;
+  launcherKey: "launcher" | "memeLauncher";
+  startBlock: unknown;
+  launchEvent: ReleaseDefinition["launchEvent"];
+  liquidityEvent: ReleaseDefinition["liquidityEvent"];
+}>): ReleaseDefinition {
+  const manifest = record(input.manifest);
+  const addresses = record(manifest?.addresses);
+  const launcher = canonicalAddress(addresses?.[input.launcherKey]);
+  const hook = canonicalAddress(addresses?.feeHook);
+  const startBlock = unsignedBigInt(input.startBlock);
+  if (
+    manifest?.chainId !== 1 || launcher === null || hook === null ||
+    startBlock === null
+  ) {
+    throw new PrimaryRpcLaunchCatalogError("configuration");
+  }
+  return {
+    releaseId: input.releaseId,
+    model: input.model,
+    launcher,
+    hook,
+    startBlock,
+    launchEvent: input.launchEvent,
+    liquidityEvent: input.liquidityEvent,
+  };
+}
+
+function assertUniqueCatalog(entries: readonly ExploreEntry[]): void {
+  const tokens = new Set<string>();
+  const pools = new Set<string>();
+  for (const entry of entries) {
+    const token = entry.tokenAddress?.toLowerCase();
+    if (
+      !token || tokens.has(token) || entry.exploreKind !== "token" ||
+      pools.has(entry.poolId)
+    ) {
+      throw new PrimaryRpcLaunchCatalogError("integrity");
+    }
+    tokens.add(token);
+    pools.add(entry.poolId);
+  }
+}
+
+function compareEntries(first: ExploreEntry, second: ExploreEntry): number {
+  if (first.launchedAt !== second.launchedAt) {
+    return second.launchedAt.localeCompare(first.launchedAt);
+  }
+  return first.id.localeCompare(second.id);
+}
+
+async function providerCall<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof PrimaryRpcLaunchCatalogError) throw error;
+    throw new PrimaryRpcLaunchCatalogError("transport");
+  }
+}
+
+async function mapBounded<T, R>(
+  values: readonly T[],
+  operation: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(MAXIMUM_CONCURRENT_RPC_READS, values.length) },
+    async () => {
+      while (nextIndex < values.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await operation(values[index]!);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function assertNotAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new PrimaryRpcLaunchCatalogError("transport");
+  }
+}
+
+function requiredAddress(
+  values: Readonly<Record<string, unknown>>,
+  name: string,
+): Address {
+  const value = canonicalAddress(values[name]);
+  if (value === null) throw new PrimaryRpcLaunchCatalogError("integrity");
+  return value;
+}
+
+function requiredBytes32(
+  values: Readonly<Record<string, unknown>>,
+  name: string,
+): Hex {
+  const value = canonicalBytes32(values[name]);
+  if (value === null) throw new PrimaryRpcLaunchCatalogError("integrity");
+  return value;
+}
+
+function requiredUnsigned(
+  values: Readonly<Record<string, unknown>>,
+  name: string,
+): string {
+  const value = unsignedBigInt(values[name]);
+  if (value === null) throw new PrimaryRpcLaunchCatalogError("integrity");
+  return value.toString();
+}
+
+function requiredSmallUnsigned(
+  values: Readonly<Record<string, unknown>>,
+  name: string,
+  maximum: number,
+): number {
+  const parsed = nonNegativeSafeInteger(values[name]);
+  if (parsed === null || parsed > maximum) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  return parsed;
+}
+
+function requiredSignedSafeInteger(
+  values: Readonly<Record<string, unknown>>,
+  name: string,
+): number {
+  const value = values[name];
+  const parsed = typeof value === "bigint" ? Number(value) : value;
+  if (typeof parsed !== "number" || !Number.isSafeInteger(parsed)) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  return parsed;
+}
+
+function canonicalAddress(value: unknown): Address | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return ADDRESS.test(normalized) ? normalized as Address : null;
+}
+
+function canonicalBytes32(value: unknown): Hex | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return BYTES32.test(normalized) ? normalized as Hex : null;
+}
+
+function canonicalHex(value: unknown): Hex | null {
+  if (
+    typeof value !== "string" || !/^0x(?:[0-9a-f]{2})*$/iu.test(value)
+  ) return null;
+  return value.toLowerCase() as Hex;
+}
+
+function unsignedBigInt(value: unknown): bigint | null {
+  if (typeof value === "bigint") return value >= 0n ? value : null;
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return BigInt(value);
+  }
+  if (typeof value === "string" && /^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    return BigInt(value);
+  }
+  return null;
+}
+
+function nonNegativeSafeInteger(value: unknown): number | null {
+  const parsed = unsignedBigInt(value);
+  if (parsed === null || parsed > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+  return Number(parsed);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function timestampToIso(timestamp: bigint): string {
+  if (timestamp > BigInt(Math.floor(Number.MAX_SAFE_INTEGER / 1_000))) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  const milliseconds = Number(timestamp) * 1_000;
+  const date = new Date(milliseconds);
+  if (!Number.isFinite(date.valueOf())) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  return date.toISOString();
+}
+
+function minBigInt(first: bigint, second: bigint): bigint {
+  return first < second ? first : second;
+}
+
+function maxBigInt(first: bigint, second: bigint): bigint {
+  return first > second ? first : second;
+}

--- a/lib/market-data/primary-rpc-launches.server.ts
+++ b/lib/market-data/primary-rpc-launches.server.ts
@@ -37,10 +37,12 @@ import {
 } from "../stock-paired";
 import type { ExploreEntry, LauncherToken } from "../tokens";
 
-const REQUEST_TIMEOUT_MS = 12_000;
-const INITIAL_LOG_RANGE = 8_192n;
-const MAXIMUM_LOG_RANGE = 8_192n;
-const MINIMUM_LOG_RANGE = 128n;
+export const PRIMARY_RPC_LAUNCH_CATALOG_BUDGET_MS = 18_000;
+
+const REQUEST_TIMEOUT_MS = 4_000;
+const LOG_WINDOW_RANGE = 4_096n;
+const MAXIMUM_CONCURRENT_LOG_WINDOWS = 6;
+const MAXIMUM_LOG_WINDOW_ATTEMPTS = 2;
 const MAXIMUM_LOGS = 10_000;
 const MAXIMUM_LAUNCHES = 5_000;
 const MAXIMUM_CONCURRENT_RPC_READS = 100;
@@ -57,6 +59,9 @@ const memeLiquidityConfiguredV2Event = parseAbiItem(
 const stockPairedTokenLaunchedEvent = parseAbiItem(
   "event StockPairedTokenLaunched(address indexed deployer,address indexed token,address indexed quoteAsset,bytes32 poolId,address rewardVault,address positionRecipient,uint256 positionTokenId,bytes32 launchHash)",
 );
+const stockPairedEthTokenLaunchedEvent = parseAbiItem(
+  "event StockPairedEthTokenLaunched(address indexed creator,address indexed token,address indexed quoteAsset,uint256 initialBuyEthAmount,uint256 initialBuyQuoteAmount,uint256 initialBuyTokenAmount,bytes32 launchHash)",
+);
 const stockPairedLiquidityConfiguredEvent = parseAbiItem(
   "event StockPairedLiquidityConfigured(address indexed token,address indexed quoteAsset,uint256 totalSupply,uint256 tokenLiquidityAmount,uint256 lockedTokenDust,int24 initialTick,int24 tickLower,int24 tickUpper,uint24 lpFeePips,bytes32 launchHash)",
 );
@@ -67,6 +72,7 @@ const SPARSE_LAUNCH_EVENTS = Object.freeze([
   memeTokenLaunchedV2Event,
   memeLiquidityConfiguredV2Event,
   stockPairedTokenLaunchedEvent,
+  stockPairedEthTokenLaunchedEvent,
   stockPairedLiquidityConfiguredEvent,
 ] satisfies readonly AbiEvent[]);
 
@@ -79,6 +85,7 @@ type ReleaseDefinition = Readonly<{
     | "stock-paired-v3";
   model: "classic" | "stock-paired";
   launcher: Address;
+  ethLaunchCoordinator: Address | null;
   hook: Address;
   startBlock: bigint;
   launchEvent:
@@ -143,6 +150,15 @@ const RELEASES = Object.freeze([
 const RELEASE_BY_LAUNCHER = new Map(
   RELEASES.map((release) => [release.launcher, release] as const),
 );
+const RELEASE_BY_ETH_LAUNCH_COORDINATOR = new Map(
+  RELEASES.flatMap((release) => release.ethLaunchCoordinator === null
+    ? []
+    : [[release.ethLaunchCoordinator, release] as const]),
+);
+const SPARSE_EVENT_ADDRESSES = Object.freeze([
+  ...RELEASE_BY_LAUNCHER.keys(),
+  ...RELEASE_BY_ETH_LAUNCH_COORDINATOR.keys(),
+]);
 const EARLIEST_START_BLOCK = RELEASES.reduce(
   (minimum, release) => release.startBlock < minimum
     ? release.startBlock
@@ -237,6 +253,7 @@ export type PrimaryRpcLaunchCatalogReaderOptions = Readonly<{
 
 type RpcEvent = Readonly<{
   release: ReleaseDefinition;
+  source: "launcher" | "eth-launch-coordinator";
   name: string;
   blockNumber: bigint;
   blockHash: Hex;
@@ -244,6 +261,15 @@ type RpcEvent = Readonly<{
   transactionIndex: number;
   logIndex: number;
   args: Readonly<Record<string, unknown>>;
+}>;
+
+type ParsedStockCreatorIdentity = Readonly<{
+  release: ReleaseDefinition;
+  event: RpcEvent;
+  creator: Address;
+  token: Address;
+  quoteAsset: Address;
+  launchHash: Hex;
 }>;
 
 type ParsedLaunch = Readonly<{
@@ -296,39 +322,55 @@ type BoundBlock = Readonly<{
 export async function readPrimaryRpcExploreEntriesV1(
   options: PrimaryRpcLaunchCatalogReaderOptions = {},
 ): Promise<PrimaryRpcExploreEntriesV1> {
+  const budget = createCatalogBudget(options.signal);
+  const signal = budget.signal;
   let phase: PrimaryRpcLaunchCatalogPhase = "initialization";
   try {
+    assertNotAborted(signal);
     const requestedToken = options.requestedTokenAddress === undefined
       ? null
       : canonicalAddress(options.requestedTokenAddress);
     if (options.requestedTokenAddress !== undefined && requestedToken === null) {
       throw new PrimaryRpcLaunchCatalogError("configuration");
     }
-    const client = options.client ?? createPrimaryRpcClient(options.environment);
+    const client = options.client ?? createPrimaryRpcClient(
+      options.environment,
+      signal,
+    );
     const now = options.now ?? new Date();
 
     phase = "head";
-    const headNumber = await providerCall(() => client.getBlockNumber());
+    const headNumber = await providerCall(
+      () => client.getBlockNumber(),
+      signal,
+    );
     if (typeof headNumber !== "bigint" || headNumber < EARLIEST_START_BLOCK) {
       throw new PrimaryRpcLaunchCatalogError("response");
     }
     const head = parseBlock(
-      await providerCall(() => client.getBlock({ blockNumber: headNumber })),
+      await providerCall(
+        () => client.getBlock({ blockNumber: headNumber }),
+        signal,
+      ),
       headNumber,
     );
 
     phase = "logs";
-    const rawLogs = await scanSparseLogs(client, head.number, options.signal);
-    const events = rawLogs.map(parseRpcEvent);
+    const rawLogs = await scanSparseLogs(client, head.number, signal);
+    const events = rawLogs.map(parseRpcEvent).sort(compareRpcEvents);
     const parsed = parseLaunchEvents(events);
-    if (parsed.launches.length > MAXIMUM_LAUNCHES) {
+    const boundLaunches = bindStockCreatorIdentities(
+      parsed.launches,
+      parsed.stockCreatorIdentities,
+    );
+    if (boundLaunches.length > MAXIMUM_LAUNCHES) {
       throw new PrimaryRpcLaunchCatalogError("integrity");
     }
 
     phase = "selection";
     const launches = requestedToken === null
-      ? parsed.launches
-      : parsed.launches.filter((launch) => launch.token === requestedToken);
+      ? boundLaunches
+      : boundLaunches.filter((launch) => launch.token === requestedToken);
     const liquidities = requestedToken === null
       ? parsed.liquidities
       : parsed.liquidities.filter((liquidity) =>
@@ -350,17 +392,18 @@ export async function readPrimaryRpcExploreEntriesV1(
         launch.quoteAsset ? [launch.quoteAsset] : []
       ))],
       head.number,
-      options.signal,
+      signal,
     );
 
     phase = "blocks";
     const launchBlocks = await readLaunchBlocks(
       client,
       launches,
-      options.signal,
+      signal,
     );
 
     phase = "entries";
+    assertNotAborted(signal);
     const entries = launches.map((launch) => buildExploreEntry(
       launch,
       requireLiquidity(launch, liquidities),
@@ -371,6 +414,7 @@ export async function readPrimaryRpcExploreEntriesV1(
       throw new PrimaryRpcLaunchCatalogError("integrity");
     }
     assertUniqueCatalog(entries);
+    assertNotAborted(signal);
     return {
       source: "drpc",
       generatedAt: now.toISOString(),
@@ -380,6 +424,8 @@ export async function readPrimaryRpcExploreEntriesV1(
     };
   } catch (error) {
     throw normalizedCatalogError(error, phase);
+  } finally {
+    budget.dispose();
   }
 }
 
@@ -395,6 +441,7 @@ function emptyCatalog(now: Date, head: BoundBlock): PrimaryRpcExploreEntriesV1 {
 
 function createPrimaryRpcClient(
   environment: Readonly<Record<string, string | undefined>> | undefined,
+  signal: AbortSignal,
 ): PrimaryRpcLaunchCatalogClient {
   let binding;
   try {
@@ -406,6 +453,7 @@ function createPrimaryRpcClient(
     chain: mainnet,
     transport: http(binding.url, {
       batch: { batchSize: 100, wait: 0 },
+      fetchOptions: { signal },
       retryCount: 0,
       timeout: REQUEST_TIMEOUT_MS,
     }),
@@ -460,45 +508,68 @@ async function scanSparseLogs(
   head: bigint,
   signal: AbortSignal | undefined,
 ): Promise<readonly unknown[]> {
-  const logs: unknown[] = [];
-  let fromBlock = EARLIEST_START_BLOCK;
-  let range = INITIAL_LOG_RANGE;
-  while (fromBlock <= head) {
+  const windows: Array<Readonly<{ fromBlock: bigint; toBlock: bigint }>> = [];
+  for (
+    let fromBlock = EARLIEST_START_BLOCK;
+    fromBlock <= head;
+    fromBlock += LOG_WINDOW_RANGE
+  ) {
+    windows.push({
+      fromBlock,
+      toBlock: minBigInt(head, fromBlock + LOG_WINDOW_RANGE - 1n),
+    });
+  }
+  const pages = await mapBounded(
+    windows,
+    (window) => readSparseLogWindow(client, window, signal),
+    MAXIMUM_CONCURRENT_LOG_WINDOWS,
+  );
+  const logs = pages.flat();
+  if (logs.length > MAXIMUM_LOGS) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  return logs;
+}
+
+async function readSparseLogWindow(
+  client: PrimaryRpcLaunchCatalogClient,
+  window: Readonly<{ fromBlock: bigint; toBlock: bigint }>,
+  signal: AbortSignal | undefined,
+): Promise<readonly unknown[]> {
+  for (let attempt = 1; attempt <= MAXIMUM_LOG_WINDOW_ATTEMPTS; attempt += 1) {
     assertNotAborted(signal);
-    const toBlock = minBigInt(head, fromBlock + range - 1n);
     try {
-      const page = await client.getLogs({
-        address: RELEASES.map((release) => release.launcher),
+      const page = await abortableCall(() => client.getLogs({
+        address: SPARSE_EVENT_ADDRESSES,
         events: SPARSE_LAUNCH_EVENTS,
-        fromBlock,
-        toBlock,
+        fromBlock: window.fromBlock,
+        toBlock: window.toBlock,
         strict: true,
-      });
+      }), signal);
       if (!Array.isArray(page)) {
         throw new PrimaryRpcLaunchCatalogError("response");
       }
-      logs.push(...page);
-      if (logs.length > MAXIMUM_LOGS) {
-        throw new PrimaryRpcLaunchCatalogError("integrity");
-      }
-      fromBlock = toBlock + 1n;
-      range = minBigInt(MAXIMUM_LOG_RANGE, range * 2n);
+      return page;
     } catch (error) {
       if (error instanceof PrimaryRpcLaunchCatalogError) throw error;
       assertNotAborted(signal);
-      if (range <= MINIMUM_LOG_RANGE) {
+      if (attempt === MAXIMUM_LOG_WINDOW_ATTEMPTS) {
         throw new PrimaryRpcLaunchCatalogError("transport");
       }
-      range = maxBigInt(MINIMUM_LOG_RANGE, range / 2n);
     }
   }
-  return logs;
+  throw new PrimaryRpcLaunchCatalogError("runtime");
 }
 
 function parseRpcEvent(value: unknown): RpcEvent {
   const row = record(value);
   const address = canonicalAddress(row?.address);
-  const release = address === null ? undefined : RELEASE_BY_LAUNCHER.get(address);
+  const launcherRelease = address === null
+    ? undefined
+    : RELEASE_BY_LAUNCHER.get(address);
+  const coordinatorRelease = address === null
+    ? undefined
+    : RELEASE_BY_ETH_LAUNCH_COORDINATOR.get(address);
   const name = nonEmptyString(row?.eventName);
   const blockNumber = unsignedBigInt(row?.blockNumber);
   const blockHash = canonicalBytes32(row?.blockHash);
@@ -506,17 +577,28 @@ function parseRpcEvent(value: unknown): RpcEvent {
   const transactionIndex = nonNegativeSafeInteger(row?.transactionIndex);
   const logIndex = nonNegativeSafeInteger(row?.logIndex);
   const args = record(row?.args);
+  const source = launcherRelease === undefined
+    ? coordinatorRelease === undefined ? null : "eth-launch-coordinator"
+    : coordinatorRelease === undefined ? "launcher" : null;
+  const release = launcherRelease ?? coordinatorRelease;
+  const expectedEvent = source === "launcher"
+    ? name === release?.launchEvent || name === release?.liquidityEvent
+    : source === "eth-launch-coordinator"
+      ? name === "StockPairedEthTokenLaunched" &&
+        release?.model === "stock-paired"
+      : false;
   if (
     release === undefined || name === null || blockNumber === null ||
     blockHash === null || transactionHash === null ||
     transactionIndex === null || logIndex === null || args === null ||
     row?.removed === true || blockNumber < release.startBlock ||
-    (name !== release.launchEvent && name !== release.liquidityEvent)
+    source === null || !expectedEvent
   ) {
     throw new PrimaryRpcLaunchCatalogError("integrity");
   }
   return {
     release,
+    source,
     name,
     blockNumber,
     blockHash,
@@ -530,23 +612,85 @@ function parseRpcEvent(value: unknown): RpcEvent {
 function parseLaunchEvents(events: readonly RpcEvent[]): Readonly<{
   launches: ParsedLaunch[];
   liquidities: ParsedLiquidity[];
+  stockCreatorIdentities: ParsedStockCreatorIdentity[];
 }> {
   const launches: ParsedLaunch[] = [];
   const liquidities: ParsedLiquidity[] = [];
+  const stockCreatorIdentities: ParsedStockCreatorIdentity[] = [];
   const coordinates = new Set<string>();
   for (const event of events) {
-    const coordinate = `${event.blockNumber}:${event.transactionIndex}:${event.logIndex}`;
+    const coordinate = eventCoordinate(event);
     if (coordinates.has(coordinate)) {
       throw new PrimaryRpcLaunchCatalogError("integrity");
     }
     coordinates.add(coordinate);
-    if (event.name === event.release.launchEvent) {
+    if (event.source === "eth-launch-coordinator") {
+      stockCreatorIdentities.push(parseStockCreatorIdentity(event));
+    } else if (event.name === event.release.launchEvent) {
       launches.push(parseLaunch(event));
     } else {
       liquidities.push(parseLiquidity(event));
     }
   }
-  return { launches, liquidities };
+  return { launches, liquidities, stockCreatorIdentities };
+}
+
+function parseStockCreatorIdentity(
+  event: RpcEvent,
+): ParsedStockCreatorIdentity {
+  if (
+    event.source !== "eth-launch-coordinator" ||
+    event.release.model !== "stock-paired" ||
+    event.release.ethLaunchCoordinator === null
+  ) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  return {
+    release: event.release,
+    event,
+    creator: requiredAddress(event.args, "creator"),
+    token: requiredAddress(event.args, "token"),
+    quoteAsset: requiredAddress(event.args, "quoteAsset"),
+    launchHash: requiredBytes32(event.args, "launchHash"),
+  };
+}
+
+function bindStockCreatorIdentities(
+  launches: readonly ParsedLaunch[],
+  identities: readonly ParsedStockCreatorIdentity[],
+): ParsedLaunch[] {
+  const consumedIdentities = new Set<string>();
+  const bound = launches.map((launch): ParsedLaunch => {
+    if (launch.release.model !== "stock-paired") return launch;
+    const coordinator = launch.release.ethLaunchCoordinator;
+    if (
+      coordinator === null ||
+      requiredAddress(launch.event.args, "deployer") !== coordinator ||
+      launch.quoteAsset === undefined
+    ) {
+      throw new PrimaryRpcLaunchCatalogError("integrity");
+    }
+    const matches = identities.filter((identity) =>
+      identity.release === launch.release &&
+      identity.event.blockNumber === launch.event.blockNumber &&
+      identity.event.blockHash === launch.event.blockHash &&
+      identity.event.transactionHash === launch.event.transactionHash &&
+      identity.event.transactionIndex === launch.event.transactionIndex &&
+      identity.token === launch.token &&
+      identity.quoteAsset === launch.quoteAsset &&
+      identity.launchHash === launch.launchHash
+    );
+    if (matches.length !== 1) {
+      throw new PrimaryRpcLaunchCatalogError("integrity");
+    }
+    const identity = matches[0]!;
+    consumedIdentities.add(eventCoordinate(identity.event));
+    return { ...launch, creator: identity.creator };
+  });
+  if (consumedIdentities.size !== identities.length) {
+    throw new PrimaryRpcLaunchCatalogError("integrity");
+  }
+  return bound;
 }
 
 function parseLaunch(event: RpcEvent): ParsedLaunch {
@@ -665,18 +809,23 @@ async function readMetadata(
   const addresses = [...new Set([...tokenAddresses, ...quoteAddresses])];
   const rows = await mapBounded(addresses, async (address) => {
     assertNotAborted(signal);
-    const [name, symbol, decimals] = await providerCall(() =>
-      Promise.all([
+    const [name, symbol, decimals] = await providerCall(
+      () => Promise.all([
         client.readContract({ address, functionName: "name", blockNumber }),
         client.readContract({ address, functionName: "symbol", blockNumber }),
         client.readContract({ address, functionName: "decimals", blockNumber }),
-      ]));
+      ]),
+      signal,
+    );
     const rawMetadata = tokenSet.has(address)
-      ? await providerCall(() => client.readContract({
-          address,
-          functionName: "metadata",
-          blockNumber,
-        }))
+      ? await providerCall(
+          () => client.readContract({
+            address,
+            functionName: "metadata",
+            blockNumber,
+          }),
+          signal,
+        )
       : null;
     return [
       address,
@@ -736,7 +885,10 @@ async function readLaunchBlocks(
   const blocks = await mapBounded(numbers, async (blockNumber) => {
     assertNotAborted(signal);
     const block = parseBlock(
-      await providerCall(() => client.getBlock({ blockNumber })),
+      await providerCall(
+        () => client.getBlock({ blockNumber }),
+        signal,
+      ),
       blockNumber,
     );
     return [blockNumber.toString(), block] as const;
@@ -873,11 +1025,15 @@ function releaseDefinition(input: Readonly<{
   const manifest = record(input.manifest);
   const addresses = record(manifest?.addresses);
   const launcher = canonicalAddress(addresses?.[input.launcherKey]);
+  const ethLaunchCoordinator = input.model === "stock-paired"
+    ? canonicalAddress(addresses?.ethLaunchCoordinator)
+    : null;
   const hook = canonicalAddress(addresses?.feeHook);
   const startBlock = unsignedBigInt(input.startBlock);
   if (
     manifest?.chainId !== 1 || launcher === null || hook === null ||
-    startBlock === null
+    startBlock === null ||
+    (input.model === "stock-paired" && ethLaunchCoordinator === null)
   ) {
     throw new PrimaryRpcLaunchCatalogError("configuration");
   }
@@ -885,6 +1041,7 @@ function releaseDefinition(input: Readonly<{
     releaseId: input.releaseId,
     model: input.model,
     launcher,
+    ethLaunchCoordinator,
     hook,
     startBlock,
     launchEvent: input.launchEvent,
@@ -915,13 +1072,75 @@ function compareEntries(first: ExploreEntry, second: ExploreEntry): number {
   return first.id.localeCompare(second.id);
 }
 
-async function providerCall<T>(operation: () => Promise<T>): Promise<T> {
+function compareRpcEvents(first: RpcEvent, second: RpcEvent): number {
+  if (first.blockNumber !== second.blockNumber) {
+    return first.blockNumber < second.blockNumber ? -1 : 1;
+  }
+  if (first.transactionIndex !== second.transactionIndex) {
+    return first.transactionIndex - second.transactionIndex;
+  }
+  if (first.logIndex !== second.logIndex) {
+    return first.logIndex - second.logIndex;
+  }
+  return first.transactionHash.localeCompare(second.transactionHash);
+}
+
+function eventCoordinate(event: RpcEvent): string {
+  return `${event.blockNumber}:${event.transactionIndex}:${event.logIndex}`;
+}
+
+async function providerCall<T>(
+  operation: () => Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
   try {
-    return await operation();
+    return await abortableCall(operation, signal);
   } catch (error) {
     if (error instanceof PrimaryRpcLaunchCatalogError) throw error;
     throw new PrimaryRpcLaunchCatalogError("transport");
   }
+}
+
+async function abortableCall<T>(
+  operation: () => Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  assertNotAborted(signal);
+  let pending: Promise<T>;
+  try {
+    pending = operation();
+  } catch (error) {
+    throw error;
+  }
+  if (signal === undefined) return pending;
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () => reject(new PrimaryRpcLaunchCatalogError("transport"));
+    signal.addEventListener("abort", abort, { once: true });
+    pending.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", abort);
+    });
+  });
+}
+
+function createCatalogBudget(externalSignal: AbortSignal | undefined): Readonly<{
+  signal: AbortSignal;
+  dispose(): void;
+}> {
+  const deadline = new AbortController();
+  const timeout = setTimeout(
+    () => deadline.abort(),
+    PRIMARY_RPC_LAUNCH_CATALOG_BUDGET_MS,
+  );
+  const signal = externalSignal === undefined
+    ? deadline.signal
+    : AbortSignal.any([externalSignal, deadline.signal]);
+  return {
+    signal,
+    dispose() {
+      clearTimeout(timeout);
+      deadline.abort();
+    },
+  };
 }
 
 function normalizedCatalogError(
@@ -939,11 +1158,12 @@ function normalizedCatalogError(
 async function mapBounded<T, R>(
   values: readonly T[],
   operation: (value: T) => Promise<R>,
+  maximumConcurrency = MAXIMUM_CONCURRENT_RPC_READS,
 ): Promise<R[]> {
   const results = new Array<R>(values.length);
   let nextIndex = 0;
   const workers = Array.from(
-    { length: Math.min(MAXIMUM_CONCURRENT_RPC_READS, values.length) },
+    { length: Math.min(maximumConcurrency, values.length) },
     async () => {
       while (nextIndex < values.length) {
         const index = nextIndex;
@@ -1075,8 +1295,4 @@ function timestampToIso(timestamp: bigint): string {
 
 function minBigInt(first: bigint, second: bigint): bigint {
   return first < second ? first : second;
-}
-
-function maxBigInt(first: bigint, second: bigint): bigint {
-  return first > second ? first : second;
 }

--- a/lib/market-data/primary-rpc-launches.server.ts
+++ b/lib/market-data/primary-rpc-launches.server.ts
@@ -43,7 +43,7 @@ const MAXIMUM_LOG_RANGE = 8_192n;
 const MINIMUM_LOG_RANGE = 128n;
 const MAXIMUM_LOGS = 10_000;
 const MAXIMUM_LAUNCHES = 5_000;
-const MAXIMUM_CONCURRENT_RPC_READS = 20;
+const MAXIMUM_CONCURRENT_RPC_READS = 100;
 
 const ADDRESS = /^0x[0-9a-f]{40}$/u;
 const BYTES32 = /^0x[0-9a-f]{64}$/u;
@@ -162,12 +162,25 @@ export type PrimaryRpcLaunchCatalogErrorCategory =
   | "configuration"
   | "transport"
   | "response"
-  | "integrity";
+  | "integrity"
+  | "runtime";
+
+export type PrimaryRpcLaunchCatalogPhase =
+  | "initialization"
+  | "head"
+  | "logs"
+  | "selection"
+  | "metadata"
+  | "blocks"
+  | "entries";
 
 export class PrimaryRpcLaunchCatalogError extends Error {
   override name = "PrimaryRpcLaunchCatalogError";
 
-  constructor(readonly category: PrimaryRpcLaunchCatalogErrorCategory) {
+  constructor(
+    readonly category: PrimaryRpcLaunchCatalogErrorCategory,
+    readonly phase: PrimaryRpcLaunchCatalogPhase | "unassigned" = "unassigned",
+  ) {
     super("Launch catalog is temporarily unavailable");
   }
 }
@@ -175,11 +188,22 @@ export class PrimaryRpcLaunchCatalogError extends Error {
 export function safePrimaryRpcLaunchCatalogError(error: unknown): Readonly<{
   name: string;
   category: PrimaryRpcLaunchCatalogErrorCategory | "unexpected";
-  status: 500 | 503;
+  phase: PrimaryRpcLaunchCatalogPhase | "unassigned" | "external";
+  status: 503;
 }> {
   return error instanceof PrimaryRpcLaunchCatalogError
-    ? { name: error.name, category: error.category, status: 503 }
-    : { name: "LaunchCatalogError", category: "unexpected", status: 500 };
+    ? {
+        name: error.name,
+        category: error.category,
+        phase: error.phase,
+        status: 503,
+      }
+    : {
+        name: "LaunchCatalogError",
+        category: "unexpected",
+        phase: "external",
+        status: 503,
+      };
 }
 
 export type PrimaryRpcLogQuery = Readonly<{
@@ -206,6 +230,7 @@ export type PrimaryRpcLaunchCatalogClient = Readonly<{
 export type PrimaryRpcLaunchCatalogReaderOptions = Readonly<{
   signal?: AbortSignal;
   now?: Date;
+  requestedTokenAddress?: Address;
   environment?: Readonly<Record<string, string | undefined>>;
   client?: PrimaryRpcLaunchCatalogClient;
 }>;
@@ -271,65 +296,100 @@ type BoundBlock = Readonly<{
 export async function readPrimaryRpcExploreEntriesV1(
   options: PrimaryRpcLaunchCatalogReaderOptions = {},
 ): Promise<PrimaryRpcExploreEntriesV1> {
-  const client = options.client ?? createPrimaryRpcClient(options.environment);
-  const now = options.now ?? new Date();
-  const headNumber = await providerCall(() => client.getBlockNumber());
-  if (typeof headNumber !== "bigint" || headNumber < EARLIEST_START_BLOCK) {
-    throw new PrimaryRpcLaunchCatalogError("response");
-  }
-  const head = parseBlock(
-    await providerCall(() => client.getBlock({ blockNumber: headNumber })),
-    headNumber,
-  );
-  const rawLogs = await scanSparseLogs(client, head.number, options.signal);
-  const events = rawLogs.map(parseRpcEvent);
-  const { launches, liquidities } = parseLaunchEvents(events);
-  if (launches.length > MAXIMUM_LAUNCHES) {
-    throw new PrimaryRpcLaunchCatalogError("integrity");
-  }
-  if (launches.length === 0) {
-    if (liquidities.length !== 0) {
+  let phase: PrimaryRpcLaunchCatalogPhase = "initialization";
+  try {
+    const requestedToken = options.requestedTokenAddress === undefined
+      ? null
+      : canonicalAddress(options.requestedTokenAddress);
+    if (options.requestedTokenAddress !== undefined && requestedToken === null) {
+      throw new PrimaryRpcLaunchCatalogError("configuration");
+    }
+    const client = options.client ?? createPrimaryRpcClient(options.environment);
+    const now = options.now ?? new Date();
+
+    phase = "head";
+    const headNumber = await providerCall(() => client.getBlockNumber());
+    if (typeof headNumber !== "bigint" || headNumber < EARLIEST_START_BLOCK) {
+      throw new PrimaryRpcLaunchCatalogError("response");
+    }
+    const head = parseBlock(
+      await providerCall(() => client.getBlock({ blockNumber: headNumber })),
+      headNumber,
+    );
+
+    phase = "logs";
+    const rawLogs = await scanSparseLogs(client, head.number, options.signal);
+    const events = rawLogs.map(parseRpcEvent);
+    const parsed = parseLaunchEvents(events);
+    if (parsed.launches.length > MAXIMUM_LAUNCHES) {
       throw new PrimaryRpcLaunchCatalogError("integrity");
     }
+
+    phase = "selection";
+    const launches = requestedToken === null
+      ? parsed.launches
+      : parsed.launches.filter((launch) => launch.token === requestedToken);
+    const liquidities = requestedToken === null
+      ? parsed.liquidities
+      : parsed.liquidities.filter((liquidity) =>
+          liquidity.token === requestedToken
+        );
+    if (launches.length === 0) {
+      if (liquidities.length !== 0 ||
+          (requestedToken === null && parsed.liquidities.length !== 0)) {
+        throw new PrimaryRpcLaunchCatalogError("integrity");
+      }
+      return emptyCatalog(now, head);
+    }
+
+    phase = "metadata";
+    const metadata = await readMetadata(
+      client,
+      [...new Set(launches.map((launch) => launch.token))],
+      [...new Set(launches.flatMap((launch) =>
+        launch.quoteAsset ? [launch.quoteAsset] : []
+      ))],
+      head.number,
+      options.signal,
+    );
+
+    phase = "blocks";
+    const launchBlocks = await readLaunchBlocks(
+      client,
+      launches,
+      options.signal,
+    );
+
+    phase = "entries";
+    const entries = launches.map((launch) => buildExploreEntry(
+      launch,
+      requireLiquidity(launch, liquidities),
+      requireLaunchBlock(launch, launchBlocks),
+      metadata,
+    ));
+    if (liquidities.length !== launches.length) {
+      throw new PrimaryRpcLaunchCatalogError("integrity");
+    }
+    assertUniqueCatalog(entries);
     return {
       source: "drpc",
       generatedAt: now.toISOString(),
       asOfBlock: head.number.toString(),
       asOfBlockHash: head.hash,
-      entries: [],
+      entries: entries.sort(compareEntries),
     };
+  } catch (error) {
+    throw normalizedCatalogError(error, phase);
   }
+}
 
-  const metadata = await readMetadata(
-    client,
-    [...new Set(launches.map((launch) => launch.token))],
-    [...new Set(launches.flatMap((launch) =>
-      launch.quoteAsset ? [launch.quoteAsset] : []
-    ))],
-    head.number,
-    options.signal,
-  );
-  const launchBlocks = await readLaunchBlocks(
-    client,
-    launches,
-    options.signal,
-  );
-  const entries = launches.map((launch) => buildExploreEntry(
-    launch,
-    requireLiquidity(launch, liquidities),
-    requireLaunchBlock(launch, launchBlocks),
-    metadata,
-  ));
-  if (liquidities.length !== launches.length) {
-    throw new PrimaryRpcLaunchCatalogError("integrity");
-  }
-  assertUniqueCatalog(entries);
+function emptyCatalog(now: Date, head: BoundBlock): PrimaryRpcExploreEntriesV1 {
   return {
     source: "drpc",
     generatedAt: now.toISOString(),
     asOfBlock: head.number.toString(),
     asOfBlockHash: head.hash,
-    entries: entries.sort(compareEntries),
+    entries: [],
   };
 }
 
@@ -345,7 +405,7 @@ function createPrimaryRpcClient(
   const publicClient = createPublicClient({
     chain: mainnet,
     transport: http(binding.url, {
-      batch: true,
+      batch: { batchSize: 100, wait: 0 },
       retryCount: 0,
       timeout: REQUEST_TIMEOUT_MS,
     }),
@@ -862,6 +922,18 @@ async function providerCall<T>(operation: () => Promise<T>): Promise<T> {
     if (error instanceof PrimaryRpcLaunchCatalogError) throw error;
     throw new PrimaryRpcLaunchCatalogError("transport");
   }
+}
+
+function normalizedCatalogError(
+  error: unknown,
+  phase: PrimaryRpcLaunchCatalogPhase,
+): PrimaryRpcLaunchCatalogError {
+  if (error instanceof PrimaryRpcLaunchCatalogError) {
+    return error.phase === "unassigned"
+      ? new PrimaryRpcLaunchCatalogError(error.category, phase)
+      : error;
+  }
+  return new PrimaryRpcLaunchCatalogError("runtime", phase);
 }
 
 async function mapBounded<T, R>(

--- a/lib/onchain/website-rpc-providers.server.ts
+++ b/lib/onchain/website-rpc-providers.server.ts
@@ -249,3 +249,26 @@ export function productionMainnetRpcPair(
   }
   return resolved;
 }
+
+/**
+ * Resolves only the commitment-bound production dRPC primary. Public read
+ * paths that intentionally use one provider must not require, inspect or
+ * retain a secondary binding.
+ */
+export function productionMainnetRpcPrimary(
+  environment: RuntimeEnvironment = process.env,
+): WebsiteRpcBinding {
+  const primary = binding(
+    providerId(
+      environment[WEBSITE_MAINNET_RPC_ENV.primaryProvider],
+      "primary",
+    ),
+    environment[WEBSITE_MAINNET_RPC_ENV.primaryUrl],
+    environment[WEBSITE_MAINNET_RPC_ENV.primaryCommitment],
+    "primary",
+  );
+  if (primary.provider !== "drpc") {
+    throw new Error("Production primary RPC provider role is invalid");
+  }
+  return primary;
+}

--- a/lib/server/action-rpc-identity.server.ts
+++ b/lib/server/action-rpc-identity.server.ts
@@ -1,0 +1,496 @@
+import "server-only";
+
+import {
+  getAddress,
+  keccak256,
+  parseAbi,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from "viem";
+
+import {
+  getConfiguredClassicV3Release,
+  isClassicV3ReleaseVerified,
+} from "../classic-v3-release";
+import {
+  memeTokenLaunchedEvent,
+  uerc20ReadAbi,
+} from "../onchain/abis";
+import { getOnchainDeployment } from "../onchain/config";
+import type { ExploreReadModel, ReadyOnchainDeployment } from "../onchain/types";
+import {
+  getConfiguredStockPairedReleases,
+  type VerifiedStockPairedRelease,
+} from "../stock-paired-release";
+import type { LauncherToken } from "../tokens";
+import { computeOfficialV4PoolId } from "../uniswap/liquidity-launcher-sdk";
+
+const ZERO_ADDRESS =
+  "0x0000000000000000000000000000000000000000" as Address;
+const ZERO_HASH = `0x${"00".repeat(32)}` as Hex;
+
+const classicLauncherStateAbi = parseAbi([
+  "function launchHashOf(address token) view returns (bytes32)",
+  "function poolKey(address token) view returns (address currency0,address currency1,uint24 fee,int24 tickSpacing,address hooks)",
+]);
+
+const stockLauncherStateAbi = parseAbi([
+  "function launchHashOf(address token) view returns (bytes32)",
+  "function quoteAssetOf(address token) view returns (address)",
+  "function rewardVaultOf(address token) view returns (address)",
+  "function poolKey(address token,address quoteAsset) view returns (address currency0,address currency1,uint24 fee,int24 tickSpacing,address hooks)",
+]);
+
+type ClassicPoolKeyState = readonly [Address, Address, number, number, Address];
+
+type ActionRelease =
+  | Readonly<{
+      kind: "classic-v2" | "classic-v3";
+      launcher: Address;
+      hook: Address;
+      launcherRuntimeCodeHash: Hex;
+      hookRuntimeCodeHash: Hex;
+    }>
+  | Readonly<{
+      kind: "stock-paired";
+      launcher: Address;
+      hook: Address;
+      launcherRuntimeCodeHash: Hex;
+      hookRuntimeCodeHash: Hex;
+      release: VerifiedStockPairedRelease;
+    }>;
+
+export class ActionRpcIdentityError extends Error {
+  readonly code:
+    | "unknown-token"
+    | "unknown-pool"
+    | "ambiguous-identity"
+    | "identity-mismatch"
+    | "runtime-mismatch";
+
+  constructor(code: ActionRpcIdentityError["code"], message: string) {
+    super(message);
+    this.name = "ActionRpcIdentityError";
+    this.code = code;
+  }
+
+  toJSON() {
+    return { name: this.name, code: this.code };
+  }
+}
+
+function sameHex(left: string, right: string) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function productionClassicV2Release(): ActionRelease {
+  const deployment = getOnchainDeployment("production");
+  if (deployment.status !== "ready" || deployment.chainId !== 1) {
+    throw new ActionRpcIdentityError(
+      "identity-mismatch",
+      "The canonical Classic release is not configured",
+    );
+  }
+  return {
+    kind: "classic-v2",
+    launcher: deployment.launcher,
+    hook: deployment.feeHook,
+    launcherRuntimeCodeHash: deployment.launcherRuntimeCodeHash,
+    hookRuntimeCodeHash: deployment.feeHookRuntimeCodeHash,
+  };
+}
+
+function productionClassicV3Release(): ActionRelease {
+  const { appManifest, releaseManifest } =
+    getConfiguredClassicV3Release("production");
+  if (
+    !isClassicV3ReleaseVerified(appManifest, releaseManifest, 1) ||
+    typeof appManifest.memeLaunchV2 !== "string" ||
+    typeof appManifest.ethCreatorFeeHookV3 !== "string" ||
+    typeof appManifest.runtimeCodeHashes?.memeLaunchV2 !== "string" ||
+    typeof appManifest.runtimeCodeHashes.ethCreatorFeeHookV3 !== "string"
+  ) {
+    throw new ActionRpcIdentityError(
+      "identity-mismatch",
+      "The canonical Classic V3 release is not configured",
+    );
+  }
+  return {
+    kind: "classic-v3",
+    launcher: getAddress(appManifest.memeLaunchV2),
+    hook: getAddress(appManifest.ethCreatorFeeHookV3),
+    launcherRuntimeCodeHash: appManifest.runtimeCodeHashes.memeLaunchV2 as Hex,
+    hookRuntimeCodeHash:
+      appManifest.runtimeCodeHashes.ethCreatorFeeHookV3 as Hex,
+  };
+}
+
+function productionActionReleases(): readonly ActionRelease[] {
+  return [
+    productionClassicV2Release(),
+    productionClassicV3Release(),
+    ...getConfiguredStockPairedReleases().map((release) => ({
+      kind: "stock-paired" as const,
+      launcher: release.addresses.launcher,
+      hook: release.addresses.feeHook,
+      launcherRuntimeCodeHash: release.runtimeCodeHashes.launcher,
+      hookRuntimeCodeHash: release.runtimeCodeHashes.feeHook,
+      release,
+    })),
+  ];
+}
+
+async function assertCurrentReleaseRuntime(
+  client: PublicClient,
+  release: ActionRelease,
+  blockNumber: bigint,
+) {
+  const [launcherCode, hookCode] = await Promise.all([
+    client.getCode({ address: release.launcher, blockNumber }),
+    client.getCode({ address: release.hook, blockNumber }),
+  ]);
+  if (
+    !launcherCode ||
+    launcherCode === "0x" ||
+    !sameHex(keccak256(launcherCode), release.launcherRuntimeCodeHash) ||
+    !hookCode ||
+    hookCode === "0x" ||
+    !sameHex(keccak256(hookCode), release.hookRuntimeCodeHash)
+  ) {
+    throw new ActionRpcIdentityError(
+      "runtime-mismatch",
+      "The launch release does not match its verified runtime",
+    );
+  }
+}
+
+function canonicalPoolId(
+  poolKey: ClassicPoolKeyState,
+  token: Address,
+  hook: Address,
+) {
+  const [currency0, currency1, fee, tickSpacing, hooks] = poolKey;
+  if (
+    !sameHex(currency0, ZERO_ADDRESS) ||
+    !sameHex(currency1, token) ||
+    fee !== 0 ||
+    tickSpacing !== 200 ||
+    !sameHex(hooks, hook)
+  ) {
+    throw new ActionRpcIdentityError(
+      "identity-mismatch",
+      "The token does not match the canonical launch pool",
+    );
+  }
+  return computeOfficialV4PoolId({
+    currency0: getAddress(currency0),
+    currency1: getAddress(currency1),
+    fee,
+    tickSpacing,
+    hooks: getAddress(hooks),
+  });
+}
+
+function actionModel(
+  token: LauncherToken,
+  blockNumber: bigint,
+  blockHash: Hex,
+): ExploreReadModel {
+  return {
+    status: "ready",
+    tokens: [token],
+    snapshot: {
+      chainId: 1,
+      blockNumber: blockNumber.toString(),
+      blockHash,
+      confirmations: 0,
+    },
+    creatorClaims: [],
+    launcherFeesAccruedWei: "0",
+    launcherFeesAccruedEth: "0",
+  };
+}
+
+async function tokenMetadata(
+  client: PublicClient,
+  token: Address,
+  blockNumber: bigint,
+) {
+  const [name, symbol, creator] = await Promise.all([
+    client.readContract({
+      address: token,
+      abi: uerc20ReadAbi,
+      functionName: "name",
+      blockNumber,
+    }),
+    client.readContract({
+      address: token,
+      abi: uerc20ReadAbi,
+      functionName: "symbol",
+      blockNumber,
+    }),
+    client.readContract({
+      address: token,
+      abi: uerc20ReadAbi,
+      functionName: "creator",
+      blockNumber,
+    }),
+  ]);
+  return { name, symbol, creator: getAddress(creator) };
+}
+
+export async function readTradeActionModelFromRpc(input: {
+  client: PublicClient;
+  chainId: number;
+  token: Address;
+  blockNumber: bigint;
+  blockHash: Hex;
+}): Promise<ExploreReadModel> {
+  if (input.chainId !== 1) {
+    throw new ActionRpcIdentityError(
+      "unknown-token",
+      "Trading identity is only available on Ethereum mainnet",
+    );
+  }
+  const token = getAddress(input.token);
+  const releases = productionActionReleases();
+  const launchHashes = await Promise.all(
+    releases.map((release) =>
+      input.client.readContract({
+        address: release.launcher,
+        abi: classicLauncherStateAbi,
+        functionName: "launchHashOf",
+        args: [token],
+        blockNumber: input.blockNumber,
+      }),
+    ),
+  );
+  const matches = releases.filter(
+    (_, index) => !sameHex(launchHashes[index] as Hex, ZERO_HASH),
+  );
+  if (matches.length === 0) {
+    throw new ActionRpcIdentityError(
+      "unknown-token",
+      "This token is not a verified Programmable launch",
+    );
+  }
+  if (matches.length !== 1) {
+    throw new ActionRpcIdentityError(
+      "ambiguous-identity",
+      "The token matches more than one launch release",
+    );
+  }
+  const release = matches[0];
+  const launchHash = launchHashes[releases.indexOf(release)] as Hex;
+  await assertCurrentReleaseRuntime(
+    input.client,
+    release,
+    input.blockNumber,
+  );
+  const metadata = await tokenMetadata(input.client, token, input.blockNumber);
+
+  if (release.kind === "stock-paired") {
+    const [quoteAsset, rewardVault] = await Promise.all([
+      input.client.readContract({
+        address: release.launcher,
+        abi: stockLauncherStateAbi,
+        functionName: "quoteAssetOf",
+        args: [token],
+        blockNumber: input.blockNumber,
+      }),
+      input.client.readContract({
+        address: release.launcher,
+        abi: stockLauncherStateAbi,
+        functionName: "rewardVaultOf",
+        args: [token],
+        blockNumber: input.blockNumber,
+      }),
+    ]);
+    const canonicalQuote = getAddress(quoteAsset);
+    const canonicalVault = getAddress(rewardVault);
+    if (
+      sameHex(canonicalQuote, ZERO_ADDRESS) ||
+      sameHex(canonicalVault, ZERO_ADDRESS)
+    ) {
+      throw new ActionRpcIdentityError(
+        "identity-mismatch",
+        "The Stock-Paired launch identity is incomplete",
+      );
+    }
+    const poolKey = (await input.client.readContract({
+      address: release.launcher,
+      abi: stockLauncherStateAbi,
+      functionName: "poolKey",
+      args: [token, canonicalQuote],
+      blockNumber: input.blockNumber,
+    })) as ClassicPoolKeyState;
+    const [currency0, currency1, fee, tickSpacing, hooks] = poolKey;
+    const expectedCurrency0 =
+      BigInt(token) < BigInt(canonicalQuote) ? token : canonicalQuote;
+    const expectedCurrency1 =
+      BigInt(token) < BigInt(canonicalQuote) ? canonicalQuote : token;
+    if (
+      !sameHex(currency0, expectedCurrency0) ||
+      !sameHex(currency1, expectedCurrency1) ||
+      fee !== 0 ||
+      tickSpacing !== 200 ||
+      !sameHex(hooks, release.hook)
+    ) {
+      throw new ActionRpcIdentityError(
+        "identity-mismatch",
+        "The token does not match its Stock-Paired launch pool",
+      );
+    }
+    const poolId = computeOfficialV4PoolId({
+      currency0: getAddress(currency0),
+      currency1: getAddress(currency1),
+      fee,
+      tickSpacing,
+      hooks: getAddress(hooks),
+    });
+    return actionModel(
+      {
+        id: `1:${token}`,
+        name: metadata.name,
+        symbol: metadata.symbol,
+        tokenAddress: token,
+        hookAddress: release.hook,
+        poolId,
+        creatorAddress: metadata.creator,
+        launchHash,
+        launchedAt: new Date(0).toISOString(),
+        totalSwapFeeBps: null,
+        quoteAssetAddress: canonicalQuote,
+        rewardVaultAddress: canonicalVault,
+        launchModel: "stock-paired",
+        launchModelVersion: release.release.internalContractRelease,
+        liquidityPath: "meme",
+      },
+      input.blockNumber,
+      input.blockHash,
+    );
+  }
+
+  const poolKey = (await input.client.readContract({
+    address: release.launcher,
+    abi: classicLauncherStateAbi,
+    functionName: "poolKey",
+    args: [token],
+    blockNumber: input.blockNumber,
+  })) as ClassicPoolKeyState;
+  const poolId = canonicalPoolId(poolKey, token, release.hook);
+  return actionModel(
+    {
+      id: `1:${token}`,
+      name: metadata.name,
+      symbol: metadata.symbol,
+      tokenAddress: token,
+      hookAddress: release.hook,
+      poolId,
+      creatorAddress: metadata.creator,
+      launchHash,
+      launchedAt: new Date(0).toISOString(),
+      totalSwapFeeBps: null,
+      launchModel: "classic",
+      ...(release.kind === "classic-v3"
+        ? { launchModelVersion: "classic-v3" as const }
+        : {}),
+      liquidityPath: "meme",
+    },
+    input.blockNumber,
+    input.blockHash,
+  );
+}
+
+export type CreatorClaimTokenIdentity = Readonly<{
+  tokenAddress: Address;
+  hookAddress: Address;
+  poolId: Hex;
+  creatorAddress: Address;
+  totalSwapFeeBps: number;
+}>;
+
+export async function readCreatorClaimIdentityFromRpc(input: {
+  client: PublicClient;
+  deployment: ReadyOnchainDeployment;
+  poolId: Hex;
+  blockNumber: bigint;
+}): Promise<CreatorClaimTokenIdentity> {
+  const logs = await input.client.getLogs({
+    address: input.deployment.launcher,
+    event: memeTokenLaunchedEvent,
+    args: { poolId: input.poolId },
+    fromBlock: input.deployment.deploymentBlock,
+    toBlock: input.blockNumber,
+    strict: true,
+  });
+  const matches = logs.filter(
+    (log) => !log.removed && log.blockNumber !== null,
+  );
+  if (matches.length === 0) {
+    throw new ActionRpcIdentityError(
+      "unknown-pool",
+      "This pool is not a verified Programmable launch",
+    );
+  }
+  if (matches.length !== 1) {
+    throw new ActionRpcIdentityError(
+      "ambiguous-identity",
+      "The pool matches more than one canonical launch",
+    );
+  }
+  const launch = matches[0];
+  const token = getAddress(launch.args.token);
+  const hook = getAddress(launch.args.feeHook);
+  if (!sameHex(hook, input.deployment.feeHook)) {
+    throw new ActionRpcIdentityError(
+      "identity-mismatch",
+      "The pool does not use the canonical creator fee hook",
+    );
+  }
+  const [launchHash, poolKey, creator] = await Promise.all([
+    input.client.readContract({
+      address: input.deployment.launcher,
+      abi: classicLauncherStateAbi,
+      functionName: "launchHashOf",
+      args: [token],
+      blockNumber: input.blockNumber,
+    }),
+    input.client.readContract({
+      address: input.deployment.launcher,
+      abi: classicLauncherStateAbi,
+      functionName: "poolKey",
+      args: [token],
+      blockNumber: input.blockNumber,
+    }),
+    input.client.readContract({
+      address: token,
+      abi: uerc20ReadAbi,
+      functionName: "creator",
+      blockNumber: input.blockNumber,
+    }),
+  ]);
+  const canonicalId = canonicalPoolId(
+    poolKey as ClassicPoolKeyState,
+    token,
+    hook,
+  );
+  if (
+    !sameHex(launchHash, launch.args.launchHash) ||
+    !sameHex(canonicalId, input.poolId) ||
+    !sameHex(creator, launch.args.creator)
+  ) {
+    throw new ActionRpcIdentityError(
+      "identity-mismatch",
+      "The current launch state does not match the requested pool",
+    );
+  }
+  return {
+    tokenAddress: token,
+    hookAddress: hook,
+    poolId: input.poolId,
+    creatorAddress: getAddress(creator),
+    totalSwapFeeBps: launch.args.totalSwapFeeBps,
+  };
+}

--- a/lib/server/action-rpc-identity.server.ts
+++ b/lib/server/action-rpc-identity.server.ts
@@ -443,13 +443,14 @@ export async function readCreatorClaimIdentityFromRpc(input: {
   const launch = matches[0];
   const token = getAddress(launch.args.token);
   const hook = getAddress(launch.args.feeHook);
+  const launchCreator = getAddress(launch.args.creator);
   if (!sameHex(hook, input.deployment.feeHook)) {
     throw new ActionRpcIdentityError(
       "identity-mismatch",
       "The pool does not use the canonical creator fee hook",
     );
   }
-  const [launchHash, poolKey, creator] = await Promise.all([
+  const [launchHash, poolKey, tokenCreator] = await Promise.all([
     input.client.readContract({
       address: input.deployment.launcher,
       abi: classicLauncherStateAbi,
@@ -476,10 +477,12 @@ export async function readCreatorClaimIdentityFromRpc(input: {
     token,
     hook,
   );
+  // Launcher-created UERC20s record the launcher as token creator; the fee
+  // recipient is the distinct creator committed by the launch event.
   if (
     !sameHex(launchHash, launch.args.launchHash) ||
     !sameHex(canonicalId, input.poolId) ||
-    !sameHex(creator, launch.args.creator)
+    !sameHex(tokenCreator, input.deployment.launcher)
   ) {
     throw new ActionRpcIdentityError(
       "identity-mismatch",
@@ -490,7 +493,7 @@ export async function readCreatorClaimIdentityFromRpc(input: {
     tokenAddress: token,
     hookAddress: hook,
     poolId: input.poolId,
-    creatorAddress: getAddress(creator),
+    creatorAddress: launchCreator,
     totalSwapFeeBps: launch.args.totalSwapFeeBps,
   };
 }

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2533,7 +2533,7 @@ export function evaluateReadModelOperationsSourceContracts(
           route.includes('"X-Programmable-Market-Source": "bitquery"'),
       ) &&
       publicCreatorProfile.includes("readCreatorProfile") &&
-      publicCreatorProfile.includes("creatorClaimRpcProvider") &&
+      publicCreatorProfile.includes("productionMainnetRpcPrimary") &&
       publicCreatorProfile.includes('"X-Programmable-Launch-Source": "drpc"') &&
       publicCreatorProfile.includes('"X-Programmable-Read-Source": "drpc"') &&
       publicCreatorProfile.includes(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2471,15 +2471,10 @@ export function evaluateReadModelOperationsSourceContracts(
     stockProfilePostStart >= 0
       ? publicStockProfile.slice(0, stockProfilePostStart)
       : publicStockProfile;
-  const publicCreatorRoutes = [
-    publicCreatorProfile,
-    publicClassicProfileGet,
-    publicStockProfileGet,
-  ];
   const publicActionRoutes = [creatorClaimPrepare, tradePrepare];
   const publicRuntimeRoutes = [
     ...publicIdentityAndMarketRoutes,
-    ...publicCreatorRoutes,
+    publicCreatorProfile,
     ...publicActionRoutes,
   ];
   const obsoletePublicBinding =

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2361,6 +2361,8 @@ export function evaluateReadModelOperationsSourceContracts(
     source("lib/onchain/website-rpc-providers.server.ts") ?? "";
   const actionRpcProviders =
     source("lib/server/action-rpc-quorum.server.ts") ?? "";
+  const actionRpcIdentity =
+    source("lib/server/action-rpc-identity.server.ts") ?? "";
   const retiredCandidateCutover = Object.freeze({
     productionRunbook: productionCutoverRunbook,
     envioRunbook: envioCandidateRunbook,
@@ -2556,6 +2558,11 @@ export function evaluateReadModelOperationsSourceContracts(
         'Object.defineProperty(provider, "endpoint"',
       ) &&
       actionRpcProviders.includes("enumerable: false") &&
+      actionRpcIdentity.includes("readTradeActionModelFromRpc") &&
+      actionRpcIdentity.includes("readCreatorClaimIdentityFromRpc") &&
+      !/bitquery|alchemy|durable|blob|secondary|fallback|quorum|subgraph|stateview|chainlink|envio/iu.test(
+        actionRpcIdentity,
+      ) &&
       tradePrepare.includes("tradeActionRpcProvider") &&
       !tradePrepare.includes("tradeActionRpcProviders") &&
       tradePrepare.includes('"Cache-Control": "no-store"') &&

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2471,6 +2471,89 @@ export function evaluateReadModelOperationsSourceContracts(
     stockProfilePostStart >= 0
       ? publicStockProfile.slice(0, stockProfilePostStart)
       : publicStockProfile;
+  const tokenCanonicalHeadersStart = publicToken.indexOf(
+    "function canonicalResponseHeaders(",
+  );
+  const tokenCustomHeadersStart = publicToken.indexOf(
+    "function customResponseHeaders(",
+    tokenCanonicalHeadersStart + 1,
+  );
+  const tokenUnavailableResponseStart = publicToken.indexOf(
+    "function unavailableResponse(",
+    tokenCustomHeadersStart + 1,
+  );
+  const tokenCanonicalHeaders =
+    tokenCanonicalHeadersStart >= 0 && tokenCustomHeadersStart >= 0
+      ? publicToken.slice(tokenCanonicalHeadersStart, tokenCustomHeadersStart)
+      : "";
+  const tokenCustomHeaders =
+    tokenCustomHeadersStart >= 0 && tokenUnavailableResponseStart >= 0
+      ? publicToken.slice(tokenCustomHeadersStart, tokenUnavailableResponseStart)
+      : "";
+  const tokenCatalogReadStart = publicToken.indexOf(
+    "catalog = await readPrimaryRpcExploreEntriesV1(",
+  );
+  const tokenCanonicalEntryStart = publicToken.indexOf(
+    "const canonicalEntry = catalog.entries.find(",
+    tokenCatalogReadStart + 1,
+  );
+  const tokenCatalogFailureStart = publicToken.indexOf(
+    "} catch (error) {",
+    tokenCatalogReadStart + 1,
+  );
+  const tokenCatalogFailure =
+    tokenCatalogFailureStart >= 0 && tokenCanonicalEntryStart >= 0
+      ? publicToken.slice(tokenCatalogFailureStart, tokenCanonicalEntryStart)
+      : "";
+  const tokenCustomMissStart = publicToken.indexOf(
+    "if (entry === null) {",
+    tokenCanonicalEntryStart + 1,
+  );
+  const tokenCustomMissEnd = publicToken.indexOf(
+    "if (!entry) {",
+    tokenCustomMissStart + 1,
+  );
+  const tokenCustomMiss =
+    tokenCustomMissStart >= 0 && tokenCustomMissEnd >= 0
+      ? publicToken.slice(tokenCustomMissStart, tokenCustomMissEnd)
+      : "";
+  const tokenCanonicalHeaderContract =
+    includesEverySourceFragment(tokenCanonicalHeaders, [
+      '"X-Programmable-Launch-Source": "drpc"',
+      '"X-Programmable-Read-Source": input.marketRead ? "drpc+bitquery" : "drpc"',
+      '? { "X-Programmable-Market-Source": "bitquery" }',
+      '? { "X-Programmable-Price-Source": "bitquery" }',
+    ]) && !tokenCanonicalHeaders.includes("registry.custom-launched");
+  const tokenCustomHeaderContract = includesEverySourceFragment(
+    tokenCustomHeaders,
+    [
+      '"X-Programmable-Launch-Source": "registry.custom-launched"',
+      '? "drpc+registry.custom-launched+bitquery"',
+      ': "drpc+registry.custom-launched"',
+      '? { "X-Programmable-Market-Source": "bitquery" }',
+      '? { "X-Programmable-Price-Source": "bitquery" }',
+    ],
+  );
+  const tokenCustomSourceContract =
+    tokenCatalogReadStart >= 0 &&
+    tokenCatalogFailureStart > tokenCatalogReadStart &&
+    tokenCanonicalEntryStart > tokenCatalogFailureStart &&
+    includesEverySourceFragment(tokenCatalogFailure, [
+      "safePrimaryRpcLaunchCatalogError(error)",
+      "return unavailableResponse(canonicalResponseHeaders({",
+    ]) &&
+    !tokenCatalogFailure.includes("readProductionCustomExploreDirectoryV1") &&
+    tokenCustomMissStart > tokenCanonicalEntryStart &&
+    tokenCustomMissEnd > tokenCustomMissStart &&
+    includesEverySourceFragment(tokenCustomMiss, [
+      "await readProductionCustomExploreDirectoryV1(",
+      "return unavailableResponse(customResponseHeaders({",
+      "isCustom = entry !== null",
+    ]) &&
+    publicToken.includes("let isCustom = false") &&
+    publicToken.includes(
+      "headers: (isCustom\n          ? customResponseHeaders\n          : canonicalResponseHeaders)(",
+    );
   const publicActionRoutes = [creatorClaimPrepare, tradePrepare];
   const publicRuntimeRoutes = [
     ...publicIdentityAndMarketRoutes,
@@ -2526,12 +2609,15 @@ export function evaluateReadModelOperationsSourceContracts(
       publicExplore.includes("readBitqueryTokenMarketDataStrictV1") &&
       publicToken.includes("readBitqueryTokenMarketDataStrictV1") &&
       publicChart.includes("readBitqueryMarketChartStrictV1") &&
-      publicIdentityAndMarketRoutes.every(
+      [publicExplore, publicChart].every(
         (route) =>
           route.includes('"X-Programmable-Launch-Source": "drpc"') &&
           route.includes('"X-Programmable-Read-Source": "drpc+bitquery"') &&
           route.includes('"X-Programmable-Market-Source": "bitquery"'),
       ) &&
+      tokenCanonicalHeaderContract &&
+      tokenCustomHeaderContract &&
+      tokenCustomSourceContract &&
       publicCreatorProfile.includes("readCreatorProfile") &&
       publicCreatorProfile.includes("productionMainnetRpcPrimary") &&
       publicCreatorProfile.includes('"X-Programmable-Launch-Source": "drpc"') &&
@@ -2580,7 +2666,7 @@ export function evaluateReadModelOperationsSourceContracts(
             route,
           ),
       ),
-    "public identity and action state use one commitment-bound dRPC primary while market, FDV and charts use strict Bitquery reads",
+    "public identity and action state use one commitment-bound dRPC primary, Custom Registry detail is a separate post-miss source, and market, FDV and charts use strict Bitquery reads",
   );
   check(
     "ops-protected-public-provider-stage-smoke",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -14,33 +14,39 @@ const APPROVED_OPERATIONS = Object.freeze({
     boundedRefresh: Object.freeze({
       runtime: Object.freeze({
         path: "lib/onchain/read-model.ts",
-        sha256: "a31450f6444e4d495ab2adb964bc713c2191723a5f62cc94d151c71e8627c6e4",
+        sha256:
+          "a31450f6444e4d495ab2adb964bc713c2191723a5f62cc94d151c71e8627c6e4",
       }),
       dependencies: Object.freeze([
         Object.freeze({
           path: "lib/onchain/parallel-reads.ts",
-          sha256: "ef2bf54f390dca210dfdb3b5ba29c4cf8f6eaea2574c9be219a5410dbf8fb64e",
+          sha256:
+            "ef2bf54f390dca210dfdb3b5ba29c4cf8f6eaea2574c9be219a5410dbf8fb64e",
         }),
         Object.freeze({
           path: "lib/onchain/historical-read-rpc.server.ts",
-          sha256: "0a68b8388003cea8c59c11790f7255df00c94ab773339850ce41c0e1b4c3aa0d",
+          sha256:
+            "0a68b8388003cea8c59c11790f7255df00c94ab773339850ce41c0e1b4c3aa0d",
         }),
         Object.freeze({
           path: "lib/onchain/persistent-rpc-cache.server.ts",
-          sha256: "5faaaeafffb837668c5759ff85f879721c6ac4fd41e0a49bf3ee6b615fbb3af4",
+          sha256:
+            "5faaaeafffb837668c5759ff85f879721c6ac4fd41e0a49bf3ee6b615fbb3af4",
         }),
       ]),
       releaseRuntimes: Object.freeze([
         Object.freeze({
           release: "classic-v3",
           path: "lib/onchain/classic-v3-read-model.ts",
-          sha256: "da6b9cb5e938435010e7a2c0f6ea9a597e7f04257570bd243e368f68c2d28188",
+          sha256:
+            "da6b9cb5e938435010e7a2c0f6ea9a597e7f04257570bd243e368f68c2d28188",
           eventFiltersPerRange: 2,
         }),
         Object.freeze({
           release: "stock-paired-v1-v3",
           path: "lib/onchain/stock-paired-read-model.ts",
-          sha256: "0f1a0713aa02b617f1ae9df6463140640d1217cdbb38964b56fc9d2b59e1d054",
+          sha256:
+            "0f1a0713aa02b617f1ae9df6463140640d1217cdbb38964b56fc9d2b59e1d054",
           eventFiltersPerRange: 3,
         }),
       ]),
@@ -55,7 +61,8 @@ const APPROVED_OPERATIONS = Object.freeze({
       provider: "github-actions",
       workflow: Object.freeze({
         path: ".github/workflows/refresh-production-read-model.yml",
-        sha256: "778f68df03c9a66a17c5f58643940e0beb2e4090eacd5f126a5feb9a0ed6b616",
+        sha256:
+          "778f68df03c9a66a17c5f58643940e0beb2e4090eacd5f126a5feb9a0ed6b616",
       }),
       nodeRuntime: Object.freeze({
         setupAction: "actions/setup-node",
@@ -76,23 +83,28 @@ const APPROVED_OPERATIONS = Object.freeze({
         maximumHeadAgeSeconds: 300,
         healthRoute: Object.freeze({
           path: "app/api/ops/health/route.ts",
-          sha256: "2dd1539b39761c0416991af20dcc7ab27b5855ba0dc456244bd218b157386f59",
+          sha256:
+            "2dd1539b39761c0416991af20dcc7ab27b5855ba0dc456244bd218b157386f59",
         }),
         rpcRuntime: Object.freeze({
           path: "lib/onchain/rpc-health.ts",
-          sha256: "7315f82e8d0904941c9cdd6840a79b6720e6a73a99edeb44ce71bb0486d8596e",
+          sha256:
+            "7315f82e8d0904941c9cdd6840a79b6720e6a73a99edeb44ce71bb0486d8596e",
         }),
         deploymentConfig: Object.freeze({
           path: "lib/onchain/config.ts",
-          sha256: "0e75c3d55b54933504c702977c0d7972a788fe89d63cc3c2a7d19138ae7fbcb7",
+          sha256:
+            "0e75c3d55b54933504c702977c0d7972a788fe89d63cc3c2a7d19138ae7fbcb7",
         }),
         providerConfig: Object.freeze({
           path: "lib/onchain/website-rpc-providers.server.ts",
-          sha256: "c0a6283dcb9a8dd2ccc153242436fcf25db24c4b57acb73148fd804b632057e7",
+          sha256:
+            "c0a6283dcb9a8dd2ccc153242436fcf25db24c4b57acb73148fd804b632057e7",
         }),
         currentMarketRpc: Object.freeze({
           path: "lib/market-data/current-market-rpc.server.ts",
-          sha256: "ef2e01d5a184839ce8c5bebe4ec8d05b374930be13ff16d65bccee12c7e96085",
+          sha256:
+            "ef2e01d5a184839ce8c5bebe4ec8d05b374930be13ff16d65bccee12c7e96085",
         }),
       }),
     }),
@@ -100,7 +112,8 @@ const APPROVED_OPERATIONS = Object.freeze({
       path: "/api/ops/index",
       route: "app/api/ops/index/route.ts",
       status: 410,
-      sha256: "bb498b00334df908029a588bec552516f281fdc0dfc3185bc5cd820984a9ee1f",
+      sha256:
+        "bb498b00334df908029a588bec552516f281fdc0dfc3185bc5cd820984a9ee1f",
     }),
   }),
   customLaunchReconciler: Object.freeze({
@@ -117,23 +130,28 @@ const APPROVED_OPERATIONS = Object.freeze({
     maximumConcurrentLogRequests: 24,
     route: Object.freeze({
       path: "app/api/ops/custom-launch/generic-v2-projector/route.ts",
-      sha256: "d2f6509eba91dd5690e58d121daf4802aa1367b3807da31ed7ec060ba84b1f14",
+      sha256:
+        "d2f6509eba91dd5690e58d121daf4802aa1367b3807da31ed7ec060ba84b1f14",
     }),
     runtime: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-production-v2.ts",
-      sha256: "b70e8d1a904ed09b1161269b182af7b4e18c93d552acb6e94a5cc66d9d76a19b",
+      sha256:
+        "b70e8d1a904ed09b1161269b182af7b4e18c93d552acb6e94a5cc66d9d76a19b",
     }),
     store: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-postgres-v2.ts",
-      sha256: "d542726f80bd816387240f1707e5934946b5dcf1cc9d69a015e08f3bb2d904be",
+      sha256:
+        "d542726f80bd816387240f1707e5934946b5dcf1cc9d69a015e08f3bb2d904be",
     }),
     registryReader: Object.freeze({
       path: "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",
-      sha256: "a8b6607c641949ad384def4cb9b808233fecea37aadcd9517da69c9845a3dafd",
+      sha256:
+        "a8b6607c641949ad384def4cb9b808233fecea37aadcd9517da69c9845a3dafd",
     }),
     migration: Object.freeze({
       path: "ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql",
-      sha256: "695328763c639b7d11562c394183864998e532eb6cc38d341020e8843de213b8",
+      sha256:
+        "695328763c639b7d11562c394183864998e532eb6cc38d341020e8843de213b8",
     }),
   }),
   independentCrons: Object.freeze([
@@ -144,21 +162,25 @@ const APPROVED_OPERATIONS = Object.freeze({
       activationEnvironment: "PROTOCOL_REVENUE_AUTOMATION_ENABLED",
       route: Object.freeze({
         path: "app/api/ops/protocol-revenue/route.ts",
-        sha256: "9a7012e88ec958c61db08295401cd1b9a932dce9bec14b85075f090782485726",
+        sha256:
+          "9a7012e88ec958c61db08295401cd1b9a932dce9bec14b85075f090782485726",
       }),
       runtime: Object.freeze({
         path: "lib/protocol-revenue/keeper-v2.server.ts",
-        sha256: "8a0b48fcc3cf3034c4be422cc6e9f35f5c7c224c2c45589b34b5798a3fd5a0d8",
+        sha256:
+          "8a0b48fcc3cf3034c4be422cc6e9f35f5c7c224c2c45589b34b5798a3fd5a0d8",
       }),
       dependencies: Object.freeze([
         Object.freeze({
           path: "lib/server/action-rpc-quorum.server.ts",
-          sha256: "83b57151b7e456a2856230b81588b4b3558026af075939a2dba13250af599ae9",
+          sha256:
+            "83b57151b7e456a2856230b81588b4b3558026af075939a2dba13250af599ae9",
         }),
       ]),
       policy: Object.freeze({
         path: "lib/protocol-revenue/keeper-policy.ts",
-        sha256: "bb39f651c11e49173e5b07e42edd2bfa4a1c0e78e5b0345a47b338751e451787",
+        sha256:
+          "bb39f651c11e49173e5b07e42edd2bfa4a1c0e78e5b0345a47b338751e451787",
       }),
     }),
   ]),
@@ -170,62 +192,76 @@ const APPROVED_OPERATIONS = Object.freeze({
       activationEnvironment: "PROGRAMMABLE_PROJECTOR_ACTIVE",
       route: Object.freeze({
         path: "app/api/ops/projector/route.ts",
-        sha256: "9b12168cbbadf0addac351c45f71931f3c04370bcd6cabe6174d21daeb00a94d",
+        sha256:
+          "9b12168cbbadf0addac351c45f71931f3c04370bcd6cabe6174d21daeb00a94d",
       }),
       runtime: Object.freeze({
         path: "lib/data-pipeline/projector-runtime-config.server.ts",
-        sha256: "25c5427bd24714262e04d3eb14b6b31c71820e9b4070817d4146fe1309bb7fb5",
+        sha256:
+          "25c5427bd24714262e04d3eb14b6b31c71820e9b4070817d4146fe1309bb7fb5",
       }),
       dependencies: Object.freeze([
         Object.freeze({
           path: "lib/data-pipeline/candidate-projector-runtime-binding.server.ts",
-          sha256: "014476a4f7b344b1d8a7c92aafab95d3e9efda1da4d2e323b83e838e8a068228",
+          sha256:
+            "014476a4f7b344b1d8a7c92aafab95d3e9efda1da4d2e323b83e838e8a068228",
         }),
       ]),
       migrations: Object.freeze([
         Object.freeze({
           path: "supabase/migrations/20260731203900_projector_runtime_singleton_lease.sql",
-          sha256: "068f27a70ec6df57b84bf336fc2c46b316a7d10d40b9d489fc47e95acb6f74b0",
+          sha256:
+            "068f27a70ec6df57b84bf336fc2c46b316a7d10d40b9d489fc47e95acb6f74b0",
         }),
         Object.freeze({
           path: "supabase/migrations/20260731224000_projector_provider_evidence_binding.sql",
-          sha256: "0404f7c610a34af23fe536f021927efec4e0aede235068b70be04331c58f03af",
+          sha256:
+            "0404f7c610a34af23fe536f021927efec4e0aede235068b70be04331c58f03af",
         }),
         Object.freeze({
           path: "supabase/migrations/20260801090000_bootstrap_dynamic_evidence_and_launch_requirements.sql",
-          sha256: "e095d128feb12c8962c81be003e693dd67417cfed209144c998ab57d5e8786aa",
+          sha256:
+            "e095d128feb12c8962c81be003e693dd67417cfed209144c998ab57d5e8786aa",
         }),
         Object.freeze({
           path: "supabase/migrations/20260801091000_candidate_projector_unpromoted_gate.sql",
-          sha256: "cd8b5a4aa4801ca773cb84047edbf05349288cada47d671bd47e7d997902c91f",
+          sha256:
+            "cd8b5a4aa4801ca773cb84047edbf05349288cada47d671bd47e7d997902c91f",
         }),
         Object.freeze({
           path: "supabase/migrations/20260801092000_verify_candidate_database_promoted.sql",
-          sha256: "ed5f54a374ad8178393e88a3948281ad9acba10aebbbd5209ea6793691b8c677",
+          sha256:
+            "ed5f54a374ad8178393e88a3948281ad9acba10aebbbd5209ea6793691b8c677",
         }),
         Object.freeze({
           path: "supabase/migrations/20260801093000_bind_candidate_promotion_to_product.sql",
-          sha256: "c6a032ef371b2211004c8d72c0a8c4eec4ba630776210aed48d2d054e642dbbe",
+          sha256:
+            "c6a032ef371b2211004c8d72c0a8c4eec4ba630776210aed48d2d054e642dbbe",
         }),
         Object.freeze({
           path: "supabase/migrations/20260801125441_reuse_safe_head_observations.sql",
-          sha256: "afbeea7bcf60e492e51bfd0c56517613f32a6f87a0182af00c48bdaef6569e74",
+          sha256:
+            "afbeea7bcf60e492e51bfd0c56517613f32a6f87a0182af00c48bdaef6569e74",
         }),
         Object.freeze({
           path: "supabase/migrations/20260801144403_accept_uuid_v8_dynamic_source_lineage.sql",
-          sha256: "85e0509d2a4fa49062a18d891e51cd0c64c1015926c3c3ef47a83ce16edb4170",
+          sha256:
+            "85e0509d2a4fa49062a18d891e51cd0c64c1015926c3c3ef47a83ce16edb4170",
         }),
         Object.freeze({
           path: "supabase/migrations/20260801155212_reuse_dual_rpc_block_evidence.sql",
-          sha256: "51142370cf7fdf2bd60c2812978fe2cbbacf99f42b87c72f0ad1ac61b303cf51",
+          sha256:
+            "51142370cf7fdf2bd60c2812978fe2cbbacf99f42b87c72f0ad1ac61b303cf51",
         }),
         Object.freeze({
           path: "supabase/migrations/20260801204500_reuse_dual_rpc_block_evidence_constraint.sql",
-          sha256: "92cc63189b41eda613ba9da21b7ef21bee650a93f1825f5ee063727ee6c06b11",
+          sha256:
+            "92cc63189b41eda613ba9da21b7ef21bee650a93f1825f5ee063727ee6c06b11",
         }),
         Object.freeze({
           path: "supabase/migrations/20260813083835_provider_neutral_drpc_quicknode.sql",
-          sha256: "ee6ae24120ad633509a1341f8995905dff19b66052a083588075517f1acbc9f0",
+          sha256:
+            "ee6ae24120ad633509a1341f8995905dff19b66052a083588075517f1acbc9f0",
         }),
       ]),
     }),
@@ -236,28 +272,34 @@ const APPROVED_OPERATIONS = Object.freeze({
       activationEnvironment: "PROGRAMMABLE_MARKET_PROJECTOR_ACTIVE",
       route: Object.freeze({
         path: "app/api/ops/market-projector/route.ts",
-        sha256: "73bf9299095cfdf75d5452513ee818e161297a83c6355760ab2f79a22a13edbd",
+        sha256:
+          "73bf9299095cfdf75d5452513ee818e161297a83c6355760ab2f79a22a13edbd",
       }),
       runtime: Object.freeze({
         path: "lib/data-pipeline/market-projector-runtime.server.ts",
-        sha256: "170138d1d3cc8de5cacb0b2b7a8f587d83e75d6e4031c314b226b673cc9dac6b",
+        sha256:
+          "170138d1d3cc8de5cacb0b2b7a8f587d83e75d6e4031c314b226b673cc9dac6b",
       }),
       migrations: Object.freeze([
         Object.freeze({
           path: "supabase/migrations/20260731223000_market_projector_contract.sql",
-          sha256: "ea73f4112a53b25e72aa697d3fc0679bf9c6e7f93a496edd167803d6a7f81a24",
+          sha256:
+            "ea73f4112a53b25e72aa697d3fc0679bf9c6e7f93a496edd167803d6a7f81a24",
         }),
         Object.freeze({
           path: "supabase/migrations/20260802092800_market_projector_fast_lane.sql",
-          sha256: "70c2719af30e0d3438e3de306376c7fa62d0196be98f81d7bd6b327559c14dc7",
+          sha256:
+            "70c2719af30e0d3438e3de306376c7fa62d0196be98f81d7bd6b327559c14dc7",
         }),
         Object.freeze({
           path: "supabase/migrations/20260803000100_market_projector_health_view.sql",
-          sha256: "946000d60600f8b144fb535579f6808b0acfd6da3331f17511f712e7bb24b2fd",
+          sha256:
+            "946000d60600f8b144fb535579f6808b0acfd6da3331f17511f712e7bb24b2fd",
         }),
         Object.freeze({
           path: "supabase/migrations/20260813083835_provider_neutral_drpc_quicknode.sql",
-          sha256: "ee6ae24120ad633509a1341f8995905dff19b66052a083588075517f1acbc9f0",
+          sha256:
+            "ee6ae24120ad633509a1341f8995905dff19b66052a083588075517f1acbc9f0",
         }),
       ]),
     }),
@@ -271,60 +313,74 @@ const APPROVED_OPERATIONS = Object.freeze({
       secretEnvironment: "PROGRAMMABLE_QUICKNODE_STREAM_SECRET",
       route: Object.freeze({
         path: "app/api/ops/projector-wake/route.ts",
-        sha256: "71549b17be233af2be052e1e4f948cbae37d804dc662354c6bfcd234bfdd266a",
+        sha256:
+          "71549b17be233af2be052e1e4f948cbae37d804dc662354c6bfcd234bfdd266a",
       }),
       verifier: Object.freeze({
         path: "lib/data-pipeline/quicknode-stream-wake.server.ts",
-        sha256: "b28af0bdd6860eb6f55b54ea4093a1ddbf9007667c3193f99061057e477c9153",
+        sha256:
+          "b28af0bdd6860eb6f55b54ea4093a1ddbf9007667c3193f99061057e477c9153",
       }),
       canary: Object.freeze({
         path: "scripts/perf/read-model-projector-wake-canary.mjs",
-        sha256: "6820b5bf29cdbf34ae7c5f1bfab55c7bccafb53a7989e09b87aad81cfa111db7",
+        sha256:
+          "6820b5bf29cdbf34ae7c5f1bfab55c7bccafb53a7989e09b87aad81cfa111db7",
       }),
       dependencies: Object.freeze([
         Object.freeze({
           path: "lib/data-pipeline/quicknode-wake-queue.server.ts",
-          sha256: "a3743900032ff2c7b4f4636d5731d6de1d680e1f49bd0cce2365c448ea1243d0",
+          sha256:
+            "a3743900032ff2c7b4f4636d5731d6de1d680e1f49bd0cce2365c448ea1243d0",
         }),
         Object.freeze({
           path: "lib/data-pipeline/optimistic-wake-runtime.server.ts",
-          sha256: "306a06191e2d6849d8d85f6a1cf79ed027ff3ff482b8e374755935d738fa4307",
+          sha256:
+            "306a06191e2d6849d8d85f6a1cf79ed027ff3ff482b8e374755935d738fa4307",
         }),
         Object.freeze({
           path: "lib/data-pipeline/optimistic-block-reader.server.ts",
-          sha256: "983080e347dd9fb90daf5696f096a446f3c119a250669545dcb2208ba639b161",
+          sha256:
+            "983080e347dd9fb90daf5696f096a446f3c119a250669545dcb2208ba639b161",
         }),
         Object.freeze({
           path: "lib/data-pipeline/optimistic-market-state.server.ts",
-          sha256: "e608497bc890bf2fbaf8f6af056fe91a5a4c84bae04c1a4fd80dccd04b779d9e",
+          sha256:
+            "e608497bc890bf2fbaf8f6af056fe91a5a4c84bae04c1a4fd80dccd04b779d9e",
         }),
         Object.freeze({
           path: "lib/data-pipeline/optimistic-live-runtime.server.ts",
-          sha256: "9cfc38593e10acdbb4206c93f7eea403ae32b944fd875cd2da8b330f6929bcd4",
+          sha256:
+            "9cfc38593e10acdbb4206c93f7eea403ae32b944fd875cd2da8b330f6929bcd4",
         }),
         Object.freeze({
           path: "lib/data-pipeline/read-model-real-block-sla-capture.server.ts",
-          sha256: "1cadb53abb9783204fc1a2cecc83abdfb1541225d46cea3e52ebc9411769dd32",
+          sha256:
+            "1cadb53abb9783204fc1a2cecc83abdfb1541225d46cea3e52ebc9411769dd32",
         }),
         Object.freeze({
           path: "lib/data-pipeline/dual-rpc.ts",
-          sha256: "12018866a1452d098d273e6e0f30274a4687f83a4fcba17764e2d88ca8093981",
+          sha256:
+            "12018866a1452d098d273e6e0f30274a4687f83a4fcba17764e2d88ca8093981",
         }),
         Object.freeze({
           path: "lib/data-pipeline/rpc-providers.server.ts",
-          sha256: "8901014d3f4beab60ff324efc90d2d57a3e034399942e9b42c2f01a0d7ef9b5d",
+          sha256:
+            "8901014d3f4beab60ff324efc90d2d57a3e034399942e9b42c2f01a0d7ef9b5d",
         }),
         Object.freeze({
           path: "app/api/ops/read-model-real-block-sla/route.ts",
-          sha256: "367140b12a27068c55f2a5881e27729fbab4d1d9a6187c2148fd29bc4f075946",
+          sha256:
+            "367140b12a27068c55f2a5881e27729fbab4d1d9a6187c2148fd29bc4f075946",
         }),
         Object.freeze({
           path: "supabase/migrations/20260802104211_real_block_sla_runtime_receipts.sql",
-          sha256: "0b9331f2b452084c4544b751ce1fbd41bba7e927ef81d6cddcb258c36f8729dc",
+          sha256:
+            "0b9331f2b452084c4544b751ce1fbd41bba7e927ef81d6cddcb258c36f8729dc",
         }),
         Object.freeze({
           path: "supabase/migrations/20260813083835_provider_neutral_drpc_quicknode.sql",
-          sha256: "ee6ae24120ad633509a1341f8995905dff19b66052a083588075517f1acbc9f0",
+          sha256:
+            "ee6ae24120ad633509a1341f8995905dff19b66052a083588075517f1acbc9f0",
         }),
       ]),
     }),
@@ -340,13 +396,45 @@ const APPROVED_OPERATIONS = Object.freeze({
       maximumDeliveryToFirstVisibleMs: 10_000,
       script: Object.freeze({
         path: "scripts/perf/read-model-real-block-sla-gate.mjs",
-        sha256: "c6fa20ec8f4bbc18dc15da91328329f1822db31df66d6bd02e403f06e93fc28f",
+        sha256:
+          "c6fa20ec8f4bbc18dc15da91328329f1822db31df66d6bd02e403f06e93fc28f",
       }),
       schema: Object.freeze({
         path: "config/read-model-real-block-sla-db-attestation.schema.json",
-        sha256: "73d78c27c6b8dc311dd50911bd4f1b4c2c44e967fd53aa5b415f566e264b69da",
+        sha256:
+          "73d78c27c6b8dc311dd50911bd4f1b4c2c44e967fd53aa5b415f566e264b69da",
       }),
     }),
+  }),
+  postPromotion: Object.freeze({
+    publicRoutes: Object.freeze([
+      "/",
+      "/api/ops/health",
+      "/api/explore?limit=6&page=1&sort=market-cap",
+      "/api/explore/token",
+      "/api/explore/token/chart",
+      "/api/explore/profile",
+      "/api/profile/classic-v3",
+      "/api/profile/stock-paired",
+      "/api/explore/profile/claim",
+      "/api/trade/prepare",
+    ]),
+    sources: Object.freeze({
+      launchIdentity: "commitment-bound-drpc-primary",
+      creatorIdentity: "commitment-bound-drpc-primary",
+      actionState: "commitment-bound-drpc-primary",
+      market: "bitquery",
+      fdv: "bitquery",
+      chart: "bitquery",
+    }),
+    rpc: Object.freeze({
+      provider: "drpc",
+      role: "primary",
+      endpointCommitmentRequired: true,
+      secondaryRequired: false,
+    }),
+    fallbacks: false,
+    providerUrlExposure: false,
   }),
 });
 
@@ -396,8 +484,10 @@ function exactJson(left, right) {
 }
 
 function includesEverySourceFragment(source, fragments) {
-  return typeof source === "string" &&
-    fragments.every((fragment) => source.includes(fragment));
+  return (
+    typeof source === "string" &&
+    fragments.every((fragment) => source.includes(fragment))
+  );
 }
 
 export const POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS = Object.freeze([
@@ -659,7 +749,7 @@ export const POST_PROMOTION_DETAIL_CHART_SOURCE_GUARDS = Object.freeze([
   'chart.readStatus !== "live"',
   '["ready", "insufficient-history"].includes(chart.status)',
   "chart.truncated !== false",
-  "chart.identity?.chainId !== \"1\"",
+  'chart.identity?.chainId !== "1"',
   "!sameAddress(chart.identity?.tokenAddress, tokenAddress)",
   "!sameBytes32(chart.identity?.poolId, poolId)",
   "!sameAddress(chart.identity?.quoteAddress, quoteAddress)",
@@ -972,7 +1062,9 @@ function routeIsAuthenticatedAndFailClosed(source, requireCutover = false) {
     /Buffer\.byteLength\(secret,\s*["']utf8["']\)\s*<\s*32/u.test(source) &&
     /Buffer\.byteLength\(secret,\s*["']utf8["']\)\s*>\s*1_024/u.test(source);
   const namedSecretBounds =
-    /const\s+secretLength\s*=\s*secret\s*\?\s*Buffer\.byteLength\(secret,\s*["']utf8["']\)\s*:\s*0/u.test(source) &&
+    /const\s+secretLength\s*=\s*secret\s*\?\s*Buffer\.byteLength\(secret,\s*["']utf8["']\)\s*:\s*0/u.test(
+      source,
+    ) &&
     /secretLength\s*<\s*32/u.test(source) &&
     /secretLength\s*>\s*1_024/u.test(source);
   const standardAuthorization =
@@ -993,8 +1085,7 @@ function routeIsAuthenticatedAndFailClosed(source, requireCutover = false) {
     /timingSafeEqual\(provided,\s*expected\)/u.test(source) &&
     standardAuthorization &&
     (!requireCutover ||
-      (cutoverAuthorization &&
-        /mode\s*===\s*["']cutover["']/u.test(source))) &&
+      (cutoverAuthorization && /mode\s*===\s*["']cutover["']/u.test(source))) &&
     (/if\s*\(\s*!isAuthorized\(request\)\s*\)/u.test(source) ||
       /if\s*\(\s*mode\s*===\s*null\s*\)/u.test(source)) &&
     /status\s*:\s*401\b/u.test(source) &&
@@ -1028,7 +1119,9 @@ function legacySchedulerWatchdogIsFailClosed(
   ].join("\n");
   const pinnedNodeSetupIndex = workflowSource?.indexOf(pinnedNodeSetup) ?? -1;
   const watchdogStepIndex =
-    workflowSource?.indexOf("      - name: Refresh and prove durable freshness") ?? -1;
+    workflowSource?.indexOf(
+      "      - name: Refresh and prove durable freshness",
+    ) ?? -1;
   return (
     typeof workflowSource === "string" &&
     binding?.provider === "github-actions" &&
@@ -1047,8 +1140,16 @@ function legacySchedulerWatchdogIsFailClosed(
     binding.rpcProof?.confirmedBlockRequired === true &&
     binding.rpcProof?.providerPairRequired === true &&
     binding.rpcProof?.maximumHeadAgeSeconds === 300 &&
-    sourceBindingMatches(source, binding.rpcProof?.healthRoute, expectedSha256Overrides) &&
-    sourceBindingMatches(source, binding.rpcProof?.rpcRuntime, expectedSha256Overrides) &&
+    sourceBindingMatches(
+      source,
+      binding.rpcProof?.healthRoute,
+      expectedSha256Overrides,
+    ) &&
+    sourceBindingMatches(
+      source,
+      binding.rpcProof?.rpcRuntime,
+      expectedSha256Overrides,
+    ) &&
     sourceBindingMatches(
       source,
       binding.rpcProof?.deploymentConfig,
@@ -1070,13 +1171,15 @@ function legacySchedulerWatchdogIsFailClosed(
     source(APPROVED_OPERATIONS.legacyIndexer.route)?.includes(
       "historicalReadOnchainDeployment(deployment)",
     ) &&
-    workflowSource.includes('name: Refresh production read model') &&
+    workflowSource.includes("name: Refresh production read model") &&
     workflowSource.includes('    - cron: "2-57/5 * * * *"') &&
     workflowSource.includes("  workflow_dispatch:") &&
     workflowSource.includes("permissions: {}") &&
     workflowSource.includes("  group: production-read-model-refresh") &&
     workflowSource.includes("  cancel-in-progress: false") &&
-    workflowSource.includes("github.repository == '0xprogrammable/programmable'") &&
+    workflowSource.includes(
+      "github.repository == '0xprogrammable/programmable'",
+    ) &&
     workflowSource.includes("github.ref == 'refs/heads/production'") &&
     workflowSource.includes("    timeout-minutes: 9") &&
     workflowSource.includes("      name: production") &&
@@ -1100,11 +1203,15 @@ function legacySchedulerWatchdogIsFailClosed(
     workflowSource.includes("refresh.body?.ok !== true") &&
     workflowSource.includes("refresh.body.portfolioHistory.blockNumber !==") &&
     workflowSource.includes("refresh.body.portfolioHistory.tokenCount !==") &&
-    workflowSource.includes('refresh.body.portfolioHistory.status === "empty"') &&
+    workflowSource.includes(
+      'refresh.body.portfolioHistory.status === "empty"',
+    ) &&
     workflowSource.includes("health.response.status === 200") &&
     workflowSource.includes('health.body?.status === "healthy"') &&
     workflowSource.includes('health.body.indexSource === "durable"') &&
-    workflowSource.includes('health.body.indexedReadModel?.status === "disabled"') &&
+    workflowSource.includes(
+      'health.body.indexedReadModel?.status === "disabled"',
+    ) &&
     workflowSource.includes("healthBlock >= refreshBlock") &&
     workflowSource.includes("index.ageSeconds <= MAXIMUM_FRESH_AGE_SECONDS") &&
     workflowSource.includes('rpc?.status === "healthy"') &&
@@ -1114,7 +1221,7 @@ function legacySchedulerWatchdogIsFailClosed(
     workflowSource.includes("confirmedBlockNumber >= refreshBlock") &&
     workflowSource.includes("HEX32.test(confirmedBlock?.hash)") &&
     workflowSource.includes('confirmedBlock.hash !== `0x${"00".repeat(32)}`') &&
-    workflowSource.includes('rpc?.freshness?.maxHeadAgeSeconds === 300') &&
+    workflowSource.includes("rpc?.freshness?.maxHeadAgeSeconds === 300") &&
     workflowSource.includes('primary?.status === "available"') &&
     workflowSource.includes('secondary?.status === "available"') &&
     workflowSource.includes("primaryHead >= confirmedBlockNumber") &&
@@ -1212,7 +1319,9 @@ function realBlockSlaGateIsFailClosed(source, schema, gate) {
     source.includes("API body digest") &&
     source.includes("real-block SLA latency") &&
     source.includes("maximumEvidenceAgeMs") &&
-    source.includes('evidence.kind !== "programmable-real-block-sla-db-attestation"') &&
+    source.includes(
+      'evidence.kind !== "programmable-real-block-sla-db-attestation"',
+    ) &&
     source.includes("evidence.schemaVersion !== 2") &&
     source.includes("initialNonceDigest") &&
     source.includes("duplicateNonceDigest") &&
@@ -1285,15 +1394,22 @@ function manualPromotionSequenceIsFailClosed(source) {
     previousIndex = commandIndex;
   }
   const activePromotionCommands = shellCommands.filter((line) =>
-    /\bvercel\s+promote(?:\s|$)/u.test(line)
+    /\bvercel\s+promote(?:\s|$)/u.test(line),
   );
-  return activePromotionCommands.length === 1 &&
-    activePromotionCommands[0] === EXACT_MANUAL_VERCEL_PROMOTION;
+  return (
+    activePromotionCommands.length === 1 &&
+    activePromotionCommands[0] === EXACT_MANUAL_VERCEL_PROMOTION
+  );
 }
 
 function retiredCandidateCutoverIsFailClosed(input) {
-  return input.productionRunbook.includes("# Historical candidate cutover retired") &&
-    input.productionRunbook.includes("This document no longer authorizes a production cutover.") &&
+  return (
+    input.productionRunbook.includes(
+      "# Historical candidate cutover retired",
+    ) &&
+    input.productionRunbook.includes(
+      "This document no longer authorizes a production cutover.",
+    ) &&
     input.productionRunbook.includes("historical evidence, not current") &&
     !input.productionRunbook.includes("```sh") &&
     !input.productionRunbook.includes("vercel promote") &&
@@ -1306,7 +1422,9 @@ function retiredCandidateCutoverIsFailClosed(input) {
     input.runtimeBinding.includes('mode: "release"') &&
     input.runtimeBinding.includes("production-92f6373") &&
     input.runtimeBinding.includes("f6714ef") &&
-    input.runtimeBinding.includes("retired-candidate-projector-runtime-binding") &&
+    input.runtimeBinding.includes(
+      "retired-candidate-projector-runtime-binding",
+    ) &&
     !input.runtimeBinding.includes("candidate-backfill") &&
     !input.runtimeBinding.includes("production-7f24e63") &&
     !input.runtimeBinding.includes("d7a39a2") &&
@@ -1314,7 +1432,9 @@ function retiredCandidateCutoverIsFailClosed(input) {
     input.cutoverOperator.includes("historical candidate cutover is retired") &&
     input.cutoverRuntime.includes("historical candidate cutover is retired") &&
     !input.cutoverRuntime.includes("PROGRAMMABLE_") &&
-    input.bootstrapRuntime.includes("historical candidate bootstrap is retired") &&
+    input.bootstrapRuntime.includes(
+      "historical candidate bootstrap is retired",
+    ) &&
     !input.bootstrapRuntime.includes("PROGRAMMABLE_") &&
     input.packageJson?.scripts?.["test:retired-read-model-cutover"] ===
       "node --test scripts/data-pipeline/cutover-operator.test.mjs scripts/data-pipeline/cutover-runtime.test.mjs scripts/data-pipeline/hosted-db-bootstrap.test.mjs" &&
@@ -1323,7 +1443,8 @@ function retiredCandidateCutoverIsFailClosed(input) {
     ) === true &&
     input.packageJson?.scripts?.["test:interface:ci"]?.includes(
       "npm run test:retired-read-model-cutover",
-    ) === true;
+    ) === true
+  );
 }
 
 function migrationContract(id, source) {
@@ -1350,7 +1471,9 @@ function migrationContract(id, source) {
         "safe_head_observations_epoch_id_content_fingerprint_key",
       ) &&
       source.includes("for key share") &&
-      source.includes("safe-head fingerprint replay conflicts with stored evidence") &&
+      source.includes(
+        "safe-head fingerprint replay conflicts with stored evidence",
+      ) &&
       /security definer/iu.test(source)
     );
   }
@@ -1368,7 +1491,9 @@ function migrationContract(id, source) {
       source.includes(
         "dual_rpc_block_evidence_epoch_id_content_fingerprint_key",
       ) &&
-      source.includes("block-evidence fingerprint replay conflicts with stored evidence") &&
+      source.includes(
+        "block-evidence fingerprint replay conflicts with stored evidence",
+      ) &&
       /security definer/iu.test(source)
     );
   }
@@ -1412,7 +1537,9 @@ function migrationContract(id, source) {
     return (
       source.includes("verify_candidate_database_unpromoted_v1") &&
       source.includes("envio:production-7f24e63") &&
-      source.includes("programmable_private.assert_caller('programmable_projector')") &&
+      source.includes(
+        "programmable_private.assert_caller('programmable_projector')",
+      ) &&
       /grant execute[\s\S]*to programmable_projector/iu.test(source)
     );
   }
@@ -1420,7 +1547,9 @@ function migrationContract(id, source) {
     return (
       source.includes("verify_candidate_database_promoted_v1") &&
       source.includes("envio:production-7f24e63") &&
-      source.includes("programmable_private.assert_caller('programmable_projector')") &&
+      source.includes(
+        "programmable_private.assert_caller('programmable_projector')",
+      ) &&
       /grant execute[\s\S]*to programmable_projector/iu.test(source)
     );
   }
@@ -1431,7 +1560,9 @@ function migrationContract(id, source) {
       source.includes("staged_deployment_id") &&
       source.includes("verify_candidate_database_promoted_v2") &&
       source.includes("candidate product-bound promotion CAS lost") &&
-      /validate constraint candidate_database_control_product_binding/iu.test(source)
+      /validate constraint candidate_database_control_product_binding/iu.test(
+        source,
+      )
     );
   }
   if (id === "market-projector") {
@@ -1474,27 +1605,43 @@ export function evaluateReadModelOperationsSourceContracts(
     ? operations.eventTriggers
     : [];
   const releaseGates = operations?.releaseGates;
+  const postPromotionContract = operations?.postPromotion;
   const customLaunchReconciler = operations?.customLaunchReconciler;
   const unscheduled = Array.isArray(operations?.unscheduled)
     ? operations.unscheduled
     : [];
   const approvedCrons = new Map([
-    [APPROVED_OPERATIONS.legacyIndexer.path, APPROVED_OPERATIONS.legacyIndexer.schedule],
-    [APPROVED_OPERATIONS.customLaunchReconciler.path,
-      APPROVED_OPERATIONS.customLaunchReconciler.schedule],
-    ...APPROVED_OPERATIONS.workers.map((worker) => [worker.path, worker.schedule]),
-    ...APPROVED_OPERATIONS.independentCrons.map((cron) => [cron.path, cron.schedule]),
+    [
+      APPROVED_OPERATIONS.legacyIndexer.path,
+      APPROVED_OPERATIONS.legacyIndexer.schedule,
+    ],
+    [
+      APPROVED_OPERATIONS.customLaunchReconciler.path,
+      APPROVED_OPERATIONS.customLaunchReconciler.schedule,
+    ],
+    ...APPROVED_OPERATIONS.workers.map((worker) => [
+      worker.path,
+      worker.schedule,
+    ]),
+    ...APPROVED_OPERATIONS.independentCrons.map((cron) => [
+      cron.path,
+      cron.schedule,
+    ]),
   ]);
 
   check(
     "ops-config-schema",
     operations?.schemaVersion === 1 &&
       exactJson(operations?.legacyIndexer, APPROVED_OPERATIONS.legacyIndexer) &&
-      exactJson(customLaunchReconciler, APPROVED_OPERATIONS.customLaunchReconciler) &&
+      exactJson(
+        customLaunchReconciler,
+        APPROVED_OPERATIONS.customLaunchReconciler,
+      ) &&
       exactJson(workers, APPROVED_OPERATIONS.workers) &&
       exactJson(eventTriggers, APPROVED_OPERATIONS.eventTriggers) &&
-      exactJson(releaseGates, APPROVED_OPERATIONS.releaseGates),
-    "the manifest exactly binds the reviewed indexers, workers, event trigger and release gates",
+      exactJson(releaseGates, APPROVED_OPERATIONS.releaseGates) &&
+      exactJson(postPromotionContract, APPROVED_OPERATIONS.postPromotion),
+    "the manifest exactly binds the reviewed operations and the public Website provider split",
   );
   const customReconciler = APPROVED_OPERATIONS.customLaunchReconciler;
   const customReconcilerRoute = source(customReconciler.route.path);
@@ -1506,9 +1653,14 @@ export function evaluateReadModelOperationsSourceContracts(
   );
   check(
     "ops-custom-launch-reconciler-source-digests",
-    [customReconciler.route, customReconciler.runtime, customReconciler.store,
-      customReconciler.registryReader, customReconciler.migration].every(
-      (binding) => sourceBindingMatches(source, binding, expectedSha256Overrides),
+    [
+      customReconciler.route,
+      customReconciler.runtime,
+      customReconciler.store,
+      customReconciler.registryReader,
+      customReconciler.migration,
+    ].every((binding) =>
+      sourceBindingMatches(source, binding, expectedSha256Overrides),
     ),
     "Custom Launch V2 reconciler is byte-bound to route, runtime, store, Registry reader and migration",
   );
@@ -1516,27 +1668,35 @@ export function evaluateReadModelOperationsSourceContracts(
     "ops-custom-launch-reconciler-route-auth",
     customReconcilerRoute.includes(
       `authorized(request.headers, process.env.${customReconciler.authEnvironment})`,
-    ) && /Buffer\.byteLength\(expectedValue,\s*["']utf8["']\)\s*<\s*32/u
-      .test(customReconcilerRoute) &&
-      /Buffer\.byteLength\(expectedValue,\s*["']utf8["']\)\s*>\s*1_024/u
-        .test(customReconcilerRoute) &&
+    ) &&
+      /Buffer\.byteLength\(expectedValue,\s*["']utf8["']\)\s*<\s*32/u.test(
+        customReconcilerRoute,
+      ) &&
+      /Buffer\.byteLength\(expectedValue,\s*["']utf8["']\)\s*>\s*1_024/u.test(
+        customReconcilerRoute,
+      ) &&
       /timingSafeEqual\(expected,\s*actual\)/u.test(customReconcilerRoute) &&
       /response\(401,\s*["']unauthorized["']\)/u.test(customReconcilerRoute) &&
-      /response\(503,\s*["']reconciliation_unavailable["']\)/u
-        .test(customReconcilerRoute) &&
+      /response\(503,\s*["']reconciliation_unavailable["']\)/u.test(
+        customReconcilerRoute,
+      ) &&
       /["']cache-control["']:\s*["']no-store["']/u.test(customReconcilerRoute),
     "Custom Launch V2 cron requires the bounded timing-safe cron secret",
   );
   check(
     "ops-custom-launch-reconciler-freshness",
-    /GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS\s*=\s*300_000/u
-      .test(customReconcilerRuntime) &&
-      /GENERIC_LAUNCH_LIFECYCLE_REFRESH_AFTER_MS\s*=\s*60_000/u
-        .test(customReconcilerRuntime) &&
-      /GENERIC_LAUNCH_RECONCILIATION_LEASE_MS\s*=\s*55_000/u
-        .test(customReconcilerRuntime) &&
-      /GENERIC_LAUNCH_RECONCILIATION_CONCURRENCY\s*=\s*8/u
-        .test(customReconcilerRuntime) &&
+    /GENERIC_LAUNCH_LIFECYCLE_MAXIMUM_AGE_MS\s*=\s*300_000/u.test(
+      customReconcilerRuntime,
+    ) &&
+      /GENERIC_LAUNCH_LIFECYCLE_REFRESH_AFTER_MS\s*=\s*60_000/u.test(
+        customReconcilerRuntime,
+      ) &&
+      /GENERIC_LAUNCH_RECONCILIATION_LEASE_MS\s*=\s*55_000/u.test(
+        customReconcilerRuntime,
+      ) &&
+      /GENERIC_LAUNCH_RECONCILIATION_CONCURRENCY\s*=\s*8/u.test(
+        customReconcilerRuntime,
+      ) &&
       customReconciler.maximumLifecycleAgeMs === 300_000 &&
       customReconciler.refreshAfterMs === 60_000 &&
       customReconciler.leaseMs === 55_000 &&
@@ -1544,10 +1704,12 @@ export function evaluateReadModelOperationsSourceContracts(
       customReconciler.concurrency === 8 &&
       customReconciler.maximumInitialLogBlocks === 20_000 &&
       customReconciler.maximumConcurrentLogRequests === 24 &&
-      /MAXIMUM_INITIAL_LOG_BLOCKS\s*=\s*20_000n/u
-        .test(source(customReconciler.registryReader.path)) &&
-      /MAXIMUM_CONCURRENT_LOG_REQUESTS\s*=\s*24/u
-        .test(source(customReconciler.registryReader.path)) &&
+      /MAXIMUM_INITIAL_LOG_BLOCKS\s*=\s*20_000n/u.test(
+        source(customReconciler.registryReader.path),
+      ) &&
+      /MAXIMUM_CONCURRENT_LOG_REQUESTS\s*=\s*24/u.test(
+        source(customReconciler.registryReader.path),
+      ) &&
       customReconcilerRoute.includes(`limit: ${customReconciler.batchLimit}`),
     "Custom Launch V2 public reads fail closed on the reviewed lifecycle age and bounded sweep",
   );
@@ -1571,14 +1733,30 @@ export function evaluateReadModelOperationsSourceContracts(
     );
     check(
       `ops-${approvedCron.id}-source-digests`,
-      sourceBindingMatches(source, approvedCron.route, expectedSha256Overrides) &&
-        (!approvedCron.auth
-          || sourceBindingMatches(source, approvedCron.auth, expectedSha256Overrides)) &&
-        sourceBindingMatches(source, approvedCron.runtime, expectedSha256Overrides) &&
-        (approvedCron.dependencies ?? []).every((binding) =>
-          sourceBindingMatches(source, binding, expectedSha256Overrides)
+      sourceBindingMatches(
+        source,
+        approvedCron.route,
+        expectedSha256Overrides,
+      ) &&
+        (!approvedCron.auth ||
+          sourceBindingMatches(
+            source,
+            approvedCron.auth,
+            expectedSha256Overrides,
+          )) &&
+        sourceBindingMatches(
+          source,
+          approvedCron.runtime,
+          expectedSha256Overrides,
         ) &&
-        sourceBindingMatches(source, approvedCron.policy, expectedSha256Overrides),
+        (approvedCron.dependencies ?? []).every((binding) =>
+          sourceBindingMatches(source, binding, expectedSha256Overrides),
+        ) &&
+        sourceBindingMatches(
+          source,
+          approvedCron.policy,
+          expectedSha256Overrides,
+        ),
       `${approvedCron.id} route, runtime and policy match reviewed bytes`,
     );
     check(
@@ -1589,8 +1767,13 @@ export function evaluateReadModelOperationsSourceContracts(
     check(
       `ops-${approvedCron.id}-activation`,
       runtime.includes(`env.${approvedCron.activationEnvironment}`) &&
-        runtime.includes(`env.${approvedCron.activationEnvironment} !== "true"`) &&
-        exactFalseEnvironmentKey(source(".env.example"), approvedCron.activationEnvironment),
+        runtime.includes(
+          `env.${approvedCron.activationEnvironment} !== "true"`,
+        ) &&
+        exactFalseEnvironmentKey(
+          source(".env.example"),
+          approvedCron.activationEnvironment,
+        ),
       `${approvedCron.id} is disabled by default behind one server-only activation flag`,
     );
   }
@@ -1661,29 +1844,17 @@ export function evaluateReadModelOperationsSourceContracts(
       refreshRuntimeSource?.includes(
         'import { settleParallelReadsInOrder } from "./parallel-reads";',
       ) &&
-      refreshRuntimeSource?.includes(
-        "await settleParallelReadsInOrder([",
-      ) &&
+      refreshRuntimeSource?.includes("await settleParallelReadsInOrder([") &&
       parallelReadsSource?.includes("Promise.allSettled(") &&
       parallelReadsSource?.includes("for (const result of results)") &&
       legacyRouteSource?.includes(
         "historicalReadOnchainDeployment(deployment)",
       ) &&
-      historicalRpcSource?.includes(
-        "productionMainnetRpcPair(environment)",
-      ) &&
-      historicalRpcSource?.includes(
-        "primary: binding.primary.url",
-      ) &&
-      historicalRpcSource?.includes(
-        "secondary: binding.secondary.url",
-      ) &&
-      historicalRpcSource?.includes(
-        'primary?.vendorGroup !== "drpc"',
-      ) &&
-      historicalRpcSource?.includes(
-        'secondary?.vendorGroup !== "quicknode"',
-      ) &&
+      historicalRpcSource?.includes("productionMainnetRpcPair(environment)") &&
+      historicalRpcSource?.includes("primary: binding.primary.url") &&
+      historicalRpcSource?.includes("secondary: binding.secondary.url") &&
+      historicalRpcSource?.includes('primary?.vendorGroup !== "drpc"') &&
+      historicalRpcSource?.includes('secondary?.vendorGroup !== "quicknode"') &&
       historicalRpcSource?.includes(
         "primary.endpointCommitment !== binding.primary.endpointCommitment",
       ) &&
@@ -1699,7 +1870,7 @@ export function evaluateReadModelOperationsSourceContracts(
         "Persistent RPC cache path uses a retired namespace",
       ) &&
       persistentCacheSource?.includes("previousIntegrityCommitId") &&
-      persistentCacheSource?.includes("pointedMarker.status !== \"committed\"") &&
+      persistentCacheSource?.includes('pointedMarker.status !== "committed"') &&
       persistentCacheSource?.includes(
         "Persistent RPC providers do not cover the same event streams",
       ) &&
@@ -1717,9 +1888,8 @@ export function evaluateReadModelOperationsSourceContracts(
       persistentCacheSource?.includes(
         "bindPersistentRpcIntegrityCheckpointWindow",
       ) &&
-      persistentCacheSource?.indexOf(
-        'scope.commitId,\n          "pending",',
-      ) < persistentCacheSource?.indexOf("const published =") &&
+      persistentCacheSource?.indexOf('scope.commitId,\n          "pending",') <
+        persistentCacheSource?.indexOf("const published =") &&
       persistentCacheSource?.indexOf("const published =") <
         persistentCacheSource?.indexOf(
           'scope.commitId,\n          "committed",',
@@ -1756,7 +1926,9 @@ export function evaluateReadModelOperationsSourceContracts(
       legacyRouteSource?.includes(
         "controller.abort(new IndexRefreshDeadlineError())",
       ) &&
-      legacyRouteSource?.includes("const output = await read(controller.signal)") &&
+      legacyRouteSource?.includes(
+        "const output = await read(controller.signal)",
+      ) &&
       legacyRouteSource?.indexOf("if (!isAuthorized(request))") <
         legacyRouteSource?.indexOf("const phaseValues =") &&
       legacyRouteSource?.includes("withIndexRefreshDeadline(() =>") &&
@@ -1818,7 +1990,9 @@ export function evaluateReadModelOperationsSourceContracts(
       classicV3RefreshSource?.includes("eventProvenance") &&
       classicV3RefreshSource?.includes("toEventSelector(launchedEvent)") &&
       classicV3RefreshSource?.includes("toEventSelector(feeEvent)") &&
-      classicV3RefreshSource?.includes(".map(persistentRpcProviderId).sort()") &&
+      classicV3RefreshSource?.includes(
+        ".map(persistentRpcProviderId).sort()",
+      ) &&
       classicV3RefreshSource?.includes(
         "Independent RPCs disagree on the Classic V3 checkpoint window",
       ) &&
@@ -1854,10 +2028,7 @@ export function evaluateReadModelOperationsSourceContracts(
   check(
     "ops-legacy-alias-closed",
     !crons?.has(closedLegacyAlias.path) &&
-      exactJson(
-        operations?.legacyIndexer?.closedAlias,
-        closedLegacyAlias,
-      ) &&
+      exactJson(operations?.legacyIndexer?.closedAlias, closedLegacyAlias) &&
       sha256(source(closedLegacyAlias.route)) === closedLegacyAlias.sha256 &&
       routeIsPermanentlyClosed(
         source(closedLegacyAlias.route),
@@ -1880,7 +2051,11 @@ export function evaluateReadModelOperationsSourceContracts(
     check(
       `ops-${approvedWorker.id}-source-digests`,
       sourceBindingMatches(source, worker?.route, expectedSha256Overrides) &&
-      sourceBindingMatches(source, worker?.runtime, expectedSha256Overrides) &&
+        sourceBindingMatches(
+          source,
+          worker?.runtime,
+          expectedSha256Overrides,
+        ) &&
         (approvedWorker.dependencies ?? []).every((binding, index) =>
           sourceBindingMatches(
             source,
@@ -1908,19 +2083,23 @@ export function evaluateReadModelOperationsSourceContracts(
     check(
       `ops-${approvedWorker.id}-activation`,
       worker?.activationEnvironment === approvedWorker.activationEnvironment &&
-        activationIsExplicitAndSafe(runtime, approvedWorker.activationEnvironment),
+        activationIsExplicitAndSafe(
+          runtime,
+          approvedWorker.activationEnvironment,
+        ),
       `${approvedWorker.id} is false by default and only exact true activates work`,
     );
-    const runtimeBinding = approvedWorker.id === "source-projector"
-      ? typeof runtime === "string" &&
-        runtime.includes("createProjectorRuntimeLeaseController") &&
-        /leaseController\.tryAcquire\(\)/u.test(runtime) &&
-        /acquisition\.status\s*===\s*["']busy["']/u.test(runtime)
-      : typeof runtime === "string" &&
-        /store\.tryAcquireLease\(\)/u.test(runtime) &&
-        /store\.releaseLease\(lease\)/u.test(runtime) &&
-        /status\s*:\s*["']busy["']/u.test(runtime) &&
-        runtime.includes("sourceCheckpointGeneration");
+    const runtimeBinding =
+      approvedWorker.id === "source-projector"
+        ? typeof runtime === "string" &&
+          runtime.includes("createProjectorRuntimeLeaseController") &&
+          /leaseController\.tryAcquire\(\)/u.test(runtime) &&
+          /acquisition\.status\s*===\s*["']busy["']/u.test(runtime)
+        : typeof runtime === "string" &&
+          /store\.tryAcquireLease\(\)/u.test(runtime) &&
+          /store\.releaseLease\(lease\)/u.test(runtime) &&
+          /status\s*:\s*["']busy["']/u.test(runtime) &&
+          runtime.includes("sourceCheckpointGeneration");
     check(
       `ops-${approvedWorker.id}-runtime-binding`,
       runtimeBinding,
@@ -1929,23 +2108,38 @@ export function evaluateReadModelOperationsSourceContracts(
   }
 
   const approvedTrigger = APPROVED_OPERATIONS.eventTriggers[0];
-  const eventTrigger = eventTriggers.find(({ id }) => id === approvedTrigger.id);
+  const eventTrigger = eventTriggers.find(
+    ({ id }) => id === approvedTrigger.id,
+  );
   check(
     "ops-quicknode-stream-wake-binding",
     eventTriggers.length === 1 &&
       eventTrigger?.path === approvedTrigger.path &&
       !crons?.has(approvedTrigger.path) &&
-      sourceBindingMatches(source, eventTrigger?.route, expectedSha256Overrides) &&
-      sourceBindingMatches(source, eventTrigger?.verifier, expectedSha256Overrides) &&
-      sourceBindingMatches(source, eventTrigger?.canary, expectedSha256Overrides) &&
+      sourceBindingMatches(
+        source,
+        eventTrigger?.route,
+        expectedSha256Overrides,
+      ) &&
+      sourceBindingMatches(
+        source,
+        eventTrigger?.verifier,
+        expectedSha256Overrides,
+      ) &&
+      sourceBindingMatches(
+        source,
+        eventTrigger?.canary,
+        expectedSha256Overrides,
+      ) &&
       (eventTrigger?.dependencies ?? []).length ===
         (approvedTrigger.dependencies ?? []).length &&
-      (approvedTrigger.dependencies ?? []).every((binding, index) =>
-        sourceBindingMatches(
-          source,
-          eventTrigger?.dependencies?.[index],
-          expectedSha256Overrides,
-        ) && exactJson(binding, eventTrigger?.dependencies?.[index])
+      (approvedTrigger.dependencies ?? []).every(
+        (binding, index) =>
+          sourceBindingMatches(
+            source,
+            eventTrigger?.dependencies?.[index],
+            expectedSha256Overrides,
+          ) && exactJson(binding, eventTrigger?.dependencies?.[index]),
       ) &&
       eventTriggerIsAuthenticatedAndBound(
         source(approvedTrigger.route.path),
@@ -1999,9 +2193,7 @@ export function evaluateReadModelOperationsSourceContracts(
       source(sourceWorker.dependencies[0]?.path)?.includes(
         "retired-candidate-projector-runtime-binding",
       ) &&
-      source(sourceWorker.dependencies[0]?.path)?.includes(
-        'mode: "release"',
-      ) &&
+      source(sourceWorker.dependencies[0]?.path)?.includes('mode: "release"') &&
       !source(sourceWorker.dependencies[0]?.path)?.includes(
         "candidate-backfill",
       ) &&
@@ -2071,22 +2263,22 @@ export function evaluateReadModelOperationsSourceContracts(
     "the market worker is bound to exact lineage, terminal checkpoint and lease SQL",
   );
 
-  const deployWorkflow = source(".github/workflows/deploy-production.yml") ?? "";
+  const deployWorkflow =
+    source(".github/workflows/deploy-production.yml") ?? "";
   const verifyWorkflow = source(".github/workflows/verify.yml") ?? "";
   const packageJson = parseJson(source("package.json"));
-  const deployPolicy = source("scripts/perf/read-model-deploy-policy.mjs") ?? "";
+  const deployPolicy =
+    source("scripts/perf/read-model-deploy-policy.mjs") ?? "";
   const wakeCanary = source(approvedTrigger.canary.path) ?? "";
   const environmentExample = source(".env.example") ?? "";
-  const realBlockSlaOperator = source(
-    "scripts/perf/read-model-real-block-sla-operator.mjs",
-  ) ?? "";
-  const stagedHealth = source(
-    "scripts/perf/read-model-staged-health.mjs",
-  ) ?? "";
-  const stagedDurableRefresh = source(
-    "scripts/perf/read-model-staged-refresh.mjs",
-  ) ?? "";
-  const postPromotion = source("scripts/perf/read-model-post-promotion.mjs") ?? "";
+  const realBlockSlaOperator =
+    source("scripts/perf/read-model-real-block-sla-operator.mjs") ?? "";
+  const stagedHealth =
+    source("scripts/perf/read-model-staged-health.mjs") ?? "";
+  const stagedDurableRefresh =
+    source("scripts/perf/read-model-staged-refresh.mjs") ?? "";
+  const postPromotion =
+    source("scripts/perf/read-model-post-promotion.mjs") ?? "";
   const postPromotionVerifierStart = postPromotion.indexOf(
     "export async function verifyPostPromotion(input) {",
   );
@@ -2096,15 +2288,16 @@ export function evaluateReadModelOperationsSourceContracts(
   );
   const postPromotionBindingGuardStart = postPromotion.indexOf(
     "  if (\n    !/^dpl_",
-    postPromotionOriginGuardStart + POST_PROMOTION_PRODUCTION_ORIGIN_GUARD.length,
+    postPromotionOriginGuardStart +
+      POST_PROMOTION_PRODUCTION_ORIGIN_GUARD.length,
   );
   const postPromotionOriginGuardBlock =
     postPromotionVerifierStart >= 0 &&
-      postPromotionOriginGuardStart > postPromotionVerifierStart &&
-      postPromotionBindingGuardStart > postPromotionOriginGuardStart
+    postPromotionOriginGuardStart > postPromotionVerifierStart &&
+    postPromotionBindingGuardStart > postPromotionOriginGuardStart
       ? postPromotion
-        .slice(postPromotionOriginGuardStart, postPromotionBindingGuardStart)
-        .trimEnd()
+          .slice(postPromotionOriginGuardStart, postPromotionBindingGuardStart)
+          .trimEnd()
       : "";
   const postCurrentEvidenceStart = postPromotion.indexOf(
     "function exactCanonicalClassicNativeToken",
@@ -2114,15 +2307,14 @@ export function evaluateReadModelOperationsSourceContracts(
   );
   const postCurrentEvidenceBlock =
     postCurrentEvidenceStart >= 0 &&
-      postCurrentEvidenceEnd > postCurrentEvidenceStart
+    postCurrentEvidenceEnd > postCurrentEvidenceStart
       ? postPromotion.slice(postCurrentEvidenceStart, postCurrentEvidenceEnd)
       : "";
   const postGlobalRankingEnd = postPromotion.indexOf(
     "function exactCurrentPublicDetail",
   );
   const postGlobalRankingBlock =
-    postCurrentEvidenceEnd >= 0 &&
-      postGlobalRankingEnd > postCurrentEvidenceEnd
+    postCurrentEvidenceEnd >= 0 && postGlobalRankingEnd > postCurrentEvidenceEnd
       ? postPromotion.slice(postCurrentEvidenceEnd, postGlobalRankingEnd)
       : "";
   const postDetailChartEnd = postPromotion.indexOf("function publicChecks");
@@ -2130,42 +2322,45 @@ export function evaluateReadModelOperationsSourceContracts(
     postGlobalRankingEnd >= 0 && postDetailChartEnd > postGlobalRankingEnd
       ? postPromotion.slice(postGlobalRankingEnd, postDetailChartEnd)
       : "";
-  const bitqueryGoldenParity = source(
-    "scripts/perf/bitquery-golden-market-parity.mjs",
-  ) ?? "";
-  const bitqueryHistoricalRelease = source(
-    "scripts/perf/bitquery-historical-release-gate.mjs",
-  ) ?? "";
-  const productionBinding = source(
-    "scripts/perf/read-model-production-binding.mjs",
-  ) ?? "";
-  const operationsRunbook = source(
-    "docs/operations/read-model-scheduler-cutover.md",
-  ) ?? "";
-  const productionCutoverRunbook = source(
-    "docs/data-pipeline/PRODUCTION-CUTOVER-OPERATOR.md",
-  ) ?? "";
-  const envioCandidateRunbook = source(
-    "docs/data-pipeline/ENVIO-CANDIDATE-RUNBOOK.md",
-  ) ?? "";
-  const candidateRuntimeBinding = source(
-    "lib/data-pipeline/candidate-projector-runtime-binding.server.ts",
-  ) ?? "";
-  const cutoverOperator = source(
-    "scripts/data-pipeline/cutover-operator.mjs",
-  ) ?? "";
-  const cutoverRuntime = source(
-    "scripts/data-pipeline/cutover-runtime.mjs",
-  ) ?? "";
-  const bootstrapRuntime = source(
-    "scripts/data-pipeline/hosted-db-bootstrap-runtime.mjs",
-  ) ?? "";
-  const bitqueryHealth = source("app/api/ops/health/route.ts") ?? "";
-  const bitqueryExplore = source("app/api/explore/route.ts") ?? "";
-  const bitqueryToken = source("app/api/explore/token/route.ts") ?? "";
-  const bitqueryLaunchCatalog = source(
-    "lib/market-data/bitquery-launches.server.ts",
-  ) ?? "";
+  const bitqueryGoldenParity =
+    source("scripts/perf/bitquery-golden-market-parity.mjs") ?? "";
+  const bitqueryHistoricalRelease =
+    source("scripts/perf/bitquery-historical-release-gate.mjs") ?? "";
+  const productionBinding =
+    source("scripts/perf/read-model-production-binding.mjs") ?? "";
+  const operationsRunbook =
+    source("docs/operations/read-model-scheduler-cutover.md") ?? "";
+  const productionCutoverRunbook =
+    source("docs/data-pipeline/PRODUCTION-CUTOVER-OPERATOR.md") ?? "";
+  const envioCandidateRunbook =
+    source("docs/data-pipeline/ENVIO-CANDIDATE-RUNBOOK.md") ?? "";
+  const candidateRuntimeBinding =
+    source("lib/data-pipeline/candidate-projector-runtime-binding.server.ts") ??
+    "";
+  const cutoverOperator =
+    source("scripts/data-pipeline/cutover-operator.mjs") ?? "";
+  const cutoverRuntime =
+    source("scripts/data-pipeline/cutover-runtime.mjs") ?? "";
+  const bootstrapRuntime =
+    source("scripts/data-pipeline/hosted-db-bootstrap-runtime.mjs") ?? "";
+  const publicHealth = source("app/api/ops/health/route.ts") ?? "";
+  const publicExplore = source("app/api/explore/route.ts") ?? "";
+  const publicToken = source("app/api/explore/token/route.ts") ?? "";
+  const publicChart = source("app/api/explore/token/chart/route.ts") ?? "";
+  const publicCreatorProfile = source("app/api/explore/profile/route.ts") ?? "";
+  const publicClassicProfile =
+    source("app/api/profile/classic-v3/route.ts") ?? "";
+  const publicStockProfile =
+    source("app/api/profile/stock-paired/route.ts") ?? "";
+  const creatorClaimPrepare =
+    source("app/api/explore/profile/claim/route.ts") ?? "";
+  const tradePrepare = source("app/api/trade/prepare/route.ts") ?? "";
+  const primaryRpcLaunchCatalog =
+    source("lib/market-data/primary-rpc-launches.server.ts") ?? "";
+  const websiteRpcProviders =
+    source("lib/onchain/website-rpc-providers.server.ts") ?? "";
+  const actionRpcProviders =
+    source("lib/server/action-rpc-quorum.server.ts") ?? "";
   const retiredCandidateCutover = Object.freeze({
     productionRunbook: productionCutoverRunbook,
     envioRunbook: envioCandidateRunbook,
@@ -2177,7 +2372,9 @@ export function evaluateReadModelOperationsSourceContracts(
   });
   check(
     "ops-package-verify-binding",
-    packageJson?.scripts?.verify?.includes("npm run perf:read-model:ops-gate") === true,
+    packageJson?.scripts?.verify?.includes(
+      "npm run perf:read-model:ops-gate",
+    ) === true,
     "the canonical local verification command runs the operations source contract",
   );
   check(
@@ -2193,12 +2390,18 @@ export function evaluateReadModelOperationsSourceContracts(
       realBlockSlaOperator.includes(
         "REAL_BLOCK_SLA_OPERATOR_MAXIMUM_WAIT_MS = 5 * 60 * 1_000",
       ) &&
-      realBlockSlaOperator.includes('body: { armId, challenge }') &&
+      realBlockSlaOperator.includes("body: { armId, challenge }") &&
       realBlockSlaOperator.includes('open(absolutePath, "wx", 0o600)') &&
       realBlockSlaOperator.includes("verifyRealBlockSlaDatabaseAttestation") &&
-      realBlockSlaOperator.includes("runtime.repositoryCommit !== input.expectedRepositoryCommit") &&
-      realBlockSlaOperator.includes("runtime.deploymentId !== input.deploymentId") &&
-      realBlockSlaOperator.includes("runtime.deploymentOrigin !== input.targetUrl") &&
+      realBlockSlaOperator.includes(
+        "runtime.repositoryCommit !== input.expectedRepositoryCommit",
+      ) &&
+      realBlockSlaOperator.includes(
+        "runtime.deploymentId !== input.deploymentId",
+      ) &&
+      realBlockSlaOperator.includes(
+        "runtime.deploymentOrigin !== input.targetUrl",
+      ) &&
       realBlockSlaOperator.includes("runtime.projectId !== input.projectId") &&
       realBlockSlaOperator.includes("runtime.streamId !== input.streamId") &&
       realBlockSlaOperator.includes("![0, 409, 503].includes(result.status)") &&
@@ -2207,12 +2410,8 @@ export function evaluateReadModelOperationsSourceContracts(
       operationsRunbook.includes(
         "npm run perf:read-model:real-block-sla-operator --",
       ) &&
-      operationsRunbook.includes(
-        `--output ${EXACT_REAL_BLOCK_SLA_OUTPUT}`,
-      ) &&
-      operationsRunbook.includes(
-        `--evidence ${EXACT_REAL_BLOCK_SLA_OUTPUT}`,
-      ),
+      operationsRunbook.includes(`--output ${EXACT_REAL_BLOCK_SLA_OUTPUT}`) &&
+      operationsRunbook.includes(`--evidence ${EXACT_REAL_BLOCK_SLA_OUTPUT}`),
     "the operator arms and polls the exact staged deployment before writing one private evidence file",
   );
   check(
@@ -2234,7 +2433,9 @@ export function evaluateReadModelOperationsSourceContracts(
       deployPolicy.includes("QUICKNODE_STREAM_SECRET_ENV_NAME") &&
       deployPolicy.includes('from "./read-model-projector-wake-canary.mjs"') &&
       deployPolicy.includes("wake_route=${result.wakeRoute}") &&
-      deployPolicy.includes("wake_canary_required=${result.wakeCanaryRequired}") &&
+      deployPolicy.includes(
+        "wake_canary_required=${result.wakeCanaryRequired}",
+      ) &&
       deployPolicy.includes("invalidServerSecretEnvironmentNames"),
     "the stream secret name is documented without a value and is fail-closed in deploy policy",
   );
@@ -2249,52 +2450,180 @@ export function evaluateReadModelOperationsSourceContracts(
     stagedBitquerySmoke >= 0 && stagedBitquerySmokeEnd > stagedBitquerySmoke
       ? deployWorkflow.slice(stagedBitquerySmoke, stagedBitquerySmokeEnd)
       : "";
+  const publicIdentityAndMarketRoutes = [
+    publicExplore,
+    publicToken,
+    publicChart,
+  ];
+  const classicProfilePostStart = publicClassicProfile.indexOf(
+    "export async function POST(",
+  );
+  const stockProfilePostStart = publicStockProfile.indexOf(
+    "export async function POST(",
+  );
+  const publicClassicProfileGet =
+    classicProfilePostStart >= 0
+      ? publicClassicProfile.slice(0, classicProfilePostStart)
+      : publicClassicProfile;
+  const publicStockProfileGet =
+    stockProfilePostStart >= 0
+      ? publicStockProfile.slice(0, stockProfilePostStart)
+      : publicStockProfile;
+  const publicCreatorRoutes = [
+    publicCreatorProfile,
+    publicClassicProfileGet,
+    publicStockProfileGet,
+  ];
+  const publicActionRoutes = [creatorClaimPrepare, tradePrepare];
+  const publicRuntimeRoutes = [
+    ...publicIdentityAndMarketRoutes,
+    ...publicCreatorRoutes,
+    ...publicActionRoutes,
+  ];
+  const obsoletePublicBinding =
+    /readAlchemy|readDurable|valuationSnapshot|readOfficialUniswap|StateView|Chainlink|Envio|readBitqueryExploreEntriesV1|readBitqueryCreatorProfile|readBitqueryClassicV3Profile|readBitqueryStockPairedProfile|readBitqueryExploreModelV1/u;
+  const primaryResolverStart = websiteRpcProviders.indexOf(
+    "export function productionMainnetRpcPrimary(",
+  );
+  const primaryResolverEnd = websiteRpcProviders.indexOf(
+    "\nexport function ",
+    primaryResolverStart + 1,
+  );
+  const primaryResolver =
+    primaryResolverStart >= 0
+      ? websiteRpcProviders.slice(
+          primaryResolverStart,
+          primaryResolverEnd >= 0 ? primaryResolverEnd : undefined,
+        )
+      : "";
   check(
-    "ops-bitquery-only-public-source-contract",
+    "ops-public-provider-split-source-contract",
     exactEmptyEnvironmentKey(environmentExample, "BITQUERY_OAUTH_TOKEN") &&
-      bitqueryHealth.includes("bitqueryMarketDataConfigured") &&
-      bitqueryHealth.includes('name: "bitquery"') &&
+      publicHealth.includes("bitqueryMarketDataConfigured") &&
       !/readDurableExploreModel|readOperationalRpcHealth|currentMarketOnchainDeployment/u.test(
-        bitqueryHealth,
+        publicHealth,
       ) &&
-      bitqueryExplore.includes("readBitqueryExploreEntriesV1") &&
-      bitqueryExplore.includes("readBitqueryTokenMarketDataStrictV1") &&
-      bitqueryToken.includes("readBitqueryExploreEntriesV1") &&
-      bitqueryToken.includes("readBitqueryTokenMarketDataStrictV1") &&
-      bitqueryLaunchCatalog.includes('source: "bitquery"') &&
-      !/readAlchemyExploreModel|readDurableExploreModel|readVerifiedOperationalMarketSnapshot|readOfficialUniswapV4|currentMarketOnchainDeployment|valuationSnapshot/u.test(
-        bitqueryExplore,
+      websiteRpcProviders.includes(
+        "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER",
       ) &&
-      !/readAlchemyExploreModel|readDurableExploreModel|readVerifiedOperationalMarketSnapshot|readOfficialUniswapV4|currentMarketOnchainDeployment/u.test(
-        bitqueryToken,
+      websiteRpcProviders.includes(
+        "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL",
+      ) &&
+      websiteRpcProviders.includes(
+        "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
+      ) &&
+      primaryResolver.includes("WEBSITE_MAINNET_RPC_ENV.primaryProvider") &&
+      primaryResolver.includes("WEBSITE_MAINNET_RPC_ENV.primaryUrl") &&
+      primaryResolver.includes("WEBSITE_MAINNET_RPC_ENV.primaryCommitment") &&
+      primaryResolver.includes('primary.provider !== "drpc"') &&
+      !/secondary|fallback|quorum/iu.test(primaryResolver) &&
+      primaryRpcLaunchCatalog.includes("readPrimaryRpcExploreEntriesV1") &&
+      primaryRpcLaunchCatalog.includes("productionMainnetRpcPrimary") &&
+      primaryRpcLaunchCatalog.includes('source: "drpc"') &&
+      !/bitquery|alchemy|durable|blob|secondary|fallback|quorum|subgraph|stateview|chainlink|envio/iu.test(
+        primaryRpcLaunchCatalog,
+      ) &&
+      publicIdentityAndMarketRoutes.every((route) =>
+        route.includes("readPrimaryRpcExploreEntriesV1"),
+      ) &&
+      publicExplore.includes("readBitqueryTokenMarketDataStrictV1") &&
+      publicToken.includes("readBitqueryTokenMarketDataStrictV1") &&
+      publicChart.includes("readBitqueryMarketChartStrictV1") &&
+      publicIdentityAndMarketRoutes.every(
+        (route) =>
+          route.includes('"X-Programmable-Launch-Source": "drpc"') &&
+          route.includes('"X-Programmable-Read-Source": "drpc+bitquery"') &&
+          route.includes('"X-Programmable-Market-Source": "bitquery"'),
+      ) &&
+      publicCreatorProfile.includes("readCreatorProfile") &&
+      publicCreatorProfile.includes("creatorClaimRpcProvider") &&
+      publicCreatorProfile.includes('"X-Programmable-Launch-Source": "drpc"') &&
+      publicCreatorProfile.includes('"X-Programmable-Read-Source": "drpc"') &&
+      publicCreatorProfile.includes(
+        '"X-Programmable-Rpc-Provider": "drpc-primary"',
+      ) &&
+      publicClassicProfileGet.includes("classicV3ActionRpcProvider") &&
+      publicStockProfileGet.includes("stockPairedActionRpcProvider") &&
+      [publicClassicProfileGet, publicStockProfileGet].every(
+        (route) =>
+          route.includes('"X-Programmable-Read-Source": "rpc"') &&
+          route.includes('"X-Programmable-Rpc-Provider": "drpc-primary"'),
+      ) &&
+      actionRpcProviders.includes("createCommittedActionRpcProvider") &&
+      actionRpcProviders.includes("tradeActionRpcProvider") &&
+      actionRpcProviders.includes("creatorClaimRpcProvider") &&
+      actionRpcProviders.includes(
+        'Object.defineProperty(provider, "endpoint"',
+      ) &&
+      actionRpcProviders.includes("enumerable: false") &&
+      tradePrepare.includes("tradeActionRpcProvider") &&
+      !tradePrepare.includes("tradeActionRpcProviders") &&
+      tradePrepare.includes('"Cache-Control": "no-store"') &&
+      creatorClaimPrepare.includes("creatorClaimRpcProvider") &&
+      !creatorClaimPrepare.includes("creatorClaimRpcProviders") &&
+      creatorClaimPrepare.includes('status: "not-submitted"') &&
+      creatorClaimPrepare.includes("transactionHash: null") &&
+      creatorClaimPrepare.includes("receipt: null") &&
+      creatorClaimPrepare.includes('"Cache-Control": "no-store"') &&
+      publicActionRoutes.every(
+        (route) =>
+          !/sendTransaction|writeContract|signTransaction|signTypedData|walletClient/u.test(
+            route,
+          ),
+      ) &&
+      publicRuntimeRoutes.every(
+        (route) =>
+          !obsoletePublicBinding.test(route) &&
+          !/Promise\.allSettled|secondaryProvider|fallbackProvider/u.test(
+            route,
+          ),
       ),
-    "public Website reads are bound only to Bitquery, with Registry metadata kept separate",
+    "public identity and action state use one commitment-bound dRPC primary while market, FDV and charts use strict Bitquery reads",
   );
   check(
-    "ops-protected-bitquery-stage-smoke",
-    stagedBitquerySmoke > deployWorkflow.indexOf("Resolve exact staged deployment") &&
+    "ops-protected-public-provider-stage-smoke",
+    stagedBitquerySmoke >
+      deployWorkflow.indexOf("Resolve exact staged deployment") &&
       stagedBitquerySmokeBlock.includes(
         "VERCEL_AUTOMATION_BYPASS_SECRET: $\{{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
       ) &&
       stagedBitquerySmokeBlock.includes('requestJson("/api/ops/health")') &&
+      stagedBitquerySmokeBlock.includes("sort=market-cap") &&
+      stagedBitquerySmokeBlock.includes("sort=newest") &&
+      stagedBitquerySmokeBlock.includes("/api/explore/token?address=") &&
+      stagedBitquerySmokeBlock.includes("/api/explore/token/chart?address=") &&
+      stagedBitquerySmokeBlock.includes("/api/explore/profile?account=") &&
+      stagedBitquerySmokeBlock.includes("x-programmable-launch-source") &&
+      stagedBitquerySmokeBlock.includes("x-programmable-read-source") &&
+      stagedBitquerySmokeBlock.includes("x-programmable-market-source") &&
+      stagedBitquerySmokeBlock.includes('"drpc"') &&
+      stagedBitquerySmokeBlock.includes('"drpc+bitquery"') &&
+      stagedBitquerySmokeBlock.includes('"bitquery"') &&
       stagedBitquerySmokeBlock.includes(
-        '"/api/explore?limit=20&page=1&sort=market-cap"',
-      ) &&
-      stagedBitquerySmokeBlock.includes('"/api/explore/token?address="') &&
-      stagedBitquerySmokeBlock.includes('"/api/explore/token/chart?address="') &&
-      stagedBitquerySmokeBlock.includes(
-        'get("x-programmable-market-source") !== "bitquery"',
+        'profile.headers.get("x-programmable-launch-source") !== "drpc"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        'get("x-programmable-rpc-provider") !== null',
+        'profile.headers.get("x-programmable-read-source") !== "drpc"',
       ) &&
       stagedBitquerySmokeBlock.includes(
-        '"verified-bitquery-only-staged-public-apis"',
+        'profile.headers.get("x-programmable-rpc-provider") !==',
       ) &&
-      !/stateview|chainlink|subgraph|quicknode|drpc|envio|durable/iu.test(
+      stagedBitquerySmokeBlock.includes('"drpc-primary"') &&
+      stagedBitquerySmokeBlock.includes(
+        'creatorClaimPrepare: "separate-live-probe-required"',
+      ) &&
+      stagedBitquerySmokeBlock.includes(
+        'tradePrepare: "separate-live-probe-required"',
+      ) &&
+      !stagedBitquerySmokeBlock.includes("/api/explore/profile/claim") &&
+      !stagedBitquerySmokeBlock.includes("/api/trade/prepare") &&
+      !/PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL|PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY|https?:\/\/[^"'\s]+rpc/iu.test(
+        stagedBitquerySmokeBlock,
+      ) &&
+      !/alchemy|blob|durable|graph|stateview|chainlink|envio|prewarm|secondary|fallback|quorum/iu.test(
         stagedBitquerySmokeBlock,
       ),
-    "the immutable staged candidate proves Bitquery-only health, Explore, detail and chart responses",
+    "the immutable staged candidate proves dRPC identity, Bitquery market and creator profile responses without exposing an RPC endpoint",
   );
   check(
     "ops-obsolete-public-read-gates-absent",
@@ -2305,13 +2634,17 @@ export function evaluateReadModelOperationsSourceContracts(
       !deployWorkflow.includes("Capture staged read-model evidence") &&
       !deployWorkflow.includes("Gate indexed or shadow read path") &&
       !deployWorkflow.includes("StateView") &&
-      !deployWorkflow.includes("official Uniswap v4 subgraph"),
-    "dual-RPC, durable refresh, indexed capture and Graph availability gates are absent from Website staging",
+      !deployWorkflow.includes("official Uniswap v4 subgraph") &&
+      !deployWorkflow.includes(
+        "Refresh and prove exact staged durable read model",
+      ),
+    "secondary RPC, prewarm, durable, indexed and Graph availability gates are absent from Website staging",
   );
   const exactVerifyProofGateStart = deployWorkflow.indexOf("  release-gate:");
   const exactVerifyProofGateEnd = deployWorkflow.indexOf("  deploy:");
   const exactVerifyProofGate =
-    exactVerifyProofGateStart >= 0 && exactVerifyProofGateEnd > exactVerifyProofGateStart
+    exactVerifyProofGateStart >= 0 &&
+    exactVerifyProofGateEnd > exactVerifyProofGateStart
       ? deployWorkflow.slice(exactVerifyProofGateStart, exactVerifyProofGateEnd)
       : "";
   check(
@@ -2356,8 +2689,9 @@ export function evaluateReadModelOperationsSourceContracts(
       deployWorkflow.includes(
         '--meta githubCommitSha="$GITHUB_SHA" --env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA"',
       ) &&
-      deployWorkflow.indexOf("Verify Sigstore provenance and exact proof contents") <
-        deployWorkflow.indexOf("vercel build --prod") &&
+      deployWorkflow.indexOf(
+        "Verify Sigstore provenance and exact proof contents",
+      ) < deployWorkflow.indexOf("vercel build --prod") &&
       deployWorkflow.indexOf(
         "Confirm consumed Verify proof identity after production approval",
       ) < deployWorkflow.indexOf("Pull production configuration"),
@@ -2393,17 +2727,21 @@ export function evaluateReadModelOperationsSourceContracts(
   );
   check(
     "ops-post-promotion-binding",
-    deployWorkflow.includes('id: production-before') &&
+    deployWorkflow.includes("id: production-before") &&
       deployWorkflow.includes('--reject-git-head "$GITHUB_SHA"') &&
       deployWorkflow.indexOf("id: production-before") <
         deployWorkflow.indexOf("id: deploy") &&
       deployWorkflow.includes(
         "DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}",
       ) &&
-      deployWorkflow.includes("Stage-only: no production promotion was attempted.") &&
+      deployWorkflow.includes(
+        "Stage-only: no production promotion was attempted.",
+      ) &&
       !deployWorkflow.includes("vercel promote") &&
       !deployWorkflow.includes("vercel rollback") &&
-      operationsRunbook.includes("stage-only and must never call `vercel promote`") &&
+      operationsRunbook.includes(
+        "stage-only and must never call `vercel promote`",
+      ) &&
       manualPromotionSequenceIsFailClosed(operationsRunbook) &&
       retiredCandidateCutoverIsFailClosed(retiredCandidateCutover) &&
       postPromotion.includes("verifyProductionDeploymentBinding") &&
@@ -2412,9 +2750,7 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes(
         "`/api/explore?limit=${EXPLORE_PAGE_SIZE}&page=1&sort=market-cap`",
       ) &&
-      postPromotion.includes(
-        '"0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"',
-      ) &&
+      postPromotion.includes('"0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce"') &&
       postPromotion.includes(
         '"0x5c5a3ebee6840640642ba2bea526621a4962d2c89c388c36a2edb4725802a229"',
       ) &&
@@ -2428,9 +2764,7 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes("exactGoldenSearch") &&
       postPromotion.includes("exactGoldenChart") &&
       postPromotion.includes("quoteAddress: GOLDEN_QUOTE_ADDRESS") &&
-      postPromotion.includes(
-        'Object.freeze(["1h", "1d", "1w", "all"])',
-      ) &&
+      postPromotion.includes('Object.freeze(["1h", "1d", "1w", "all"])') &&
       includesEverySourceFragment(
         postCurrentEvidenceBlock,
         POST_PROMOTION_CURRENT_EVIDENCE_SOURCE_GUARDS,
@@ -2457,15 +2791,11 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes(
         "return currentCount > 0 ? { currentToken, tokens, valuationSnapshot } : null;",
       ) &&
+      postPromotion.includes("tokenAddress === GOLDEN_TOKEN_ADDRESS") &&
       postPromotion.includes(
-        'tokenAddress === GOLDEN_TOKEN_ADDRESS',
+        "!sameBytes32(primary.identity.poolId, market.primaryPoolId)",
       ) &&
-      postPromotion.includes(
-        '!sameBytes32(primary.identity.poolId, market.primaryPoolId)',
-      ) &&
-      postPromotion.includes(
-        'primary.identity.protocol !== "uniswap_v4"',
-      ) &&
+      postPromotion.includes('primary.identity.protocol !== "uniswap_v4"') &&
       postPromotion.includes(
         'liquidity?.source !== "official-uniswap-v4-subgraph"',
       ) &&
@@ -2478,9 +2808,7 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes(
         "BigInt(liquidity.tvlUsdWad) < MINIMUM_PUBLIC_FDV_LIQUIDITY_USD_WAD",
       ) &&
-      postPromotion.includes(
-        'token.launchModel !== "classic"',
-      ) &&
+      postPromotion.includes('token.launchModel !== "classic"') &&
       postPromotion.includes(
         'liquidity.valueBasis !== "official-subgraph-pool-tvl-usd"',
       ) &&
@@ -2493,35 +2821,23 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes(
         "expectedFdvUsdWad.toString() === valuation.valueWad",
       ) &&
-      postPromotion.includes(
-        "expectedActiveVirtualLiquidityUsdWad >=",
-      ) &&
-      postPromotion.includes(
-        "price.activeVirtualLiquidityUsdWad",
-      ) &&
-      postPromotion.includes(
-        "price.activeVirtualToken0Wei",
-      ) &&
+      postPromotion.includes("expectedActiveVirtualLiquidityUsdWad >=") &&
+      postPromotion.includes("price.activeVirtualLiquidityUsdWad") &&
+      postPromotion.includes("price.activeVirtualToken0Wei") &&
       postPromotion.includes(
         '"stateview-active-liquidity-virtual-depth-usd"',
       ) &&
-      postPromotion.includes(
-        'id: "production-current-public-detail"',
-      ) &&
+      postPromotion.includes('id: "production-current-public-detail"') &&
       postPromotion.includes(
         'id: "production-current-public-bitquery-charts"',
       ) &&
       postPromotion.includes("MAXIMUM_EXPLORE_TOKENS") &&
       postPromotion.includes("responses.length !== totalPages") &&
-      postPromotion.includes(
-        'valuation.source !== "stateview-chainlink"',
-      ) &&
+      postPromotion.includes('valuation.source !== "stateview-chainlink"') &&
       postPromotion.includes(
         'price?.source !== "uniswap-v4-stateview-chainlink-v1"',
       ) &&
-      postPromotion.includes(
-        'currentMarketEvidenceTime(quality.asOfTime)',
-      ) &&
+      postPromotion.includes("currentMarketEvidenceTime(quality.asOfTime)") &&
       postPromotion.includes(
         'id: "production-bitquery-golden-independent-parity"',
       ) &&
@@ -2532,12 +2848,21 @@ export function evaluateReadModelOperationsSourceContracts(
         POST_PROMOTION_TARGET_GUARD_PREFIX,
         postPromotionVerifierStart,
       ) &&
-      postPromotionOriginGuardBlock === POST_PROMOTION_PRODUCTION_ORIGIN_GUARD &&
-      postPromotion.includes('response.headers.get("x-programmable-market-source")') &&
-      postPromotion.includes('response.headers.get("x-programmable-price-source")') &&
-      postPromotion.includes('response.headers.get("x-programmable-market-as-of")') &&
+      postPromotionOriginGuardBlock ===
+        POST_PROMOTION_PRODUCTION_ORIGIN_GUARD &&
+      postPromotion.includes(
+        'response.headers.get("x-programmable-market-source")',
+      ) &&
+      postPromotion.includes(
+        'response.headers.get("x-programmable-price-source")',
+      ) &&
+      postPromotion.includes(
+        'response.headers.get("x-programmable-market-as-of")',
+      ) &&
       postPromotion.includes('"x-programmable-valuation-block"') &&
-      postPromotion.includes('response.headers.get("x-programmable-data-quality")') &&
+      postPromotion.includes(
+        'response.headers.get("x-programmable-data-quality")',
+      ) &&
       !postPromotion.includes("/api/indexers/v1/token-list") &&
       postPromotion.includes("verifyLiveCacheAndKeyContracts"),
     "the workflow is stage-only, the current runbook requires exact SLA-gated promotion and the historical cutover stays retired",
@@ -2560,6 +2885,9 @@ function main() {
   if (!result.ok) process.exitCode = 1;
 }
 
-if (process.argv[1] && import.meta.url === new URL(process.argv[1], "file:").href) {
+if (
+  process.argv[1] &&
+  import.meta.url === new URL(process.argv[1], "file:").href
+) {
   main();
 }

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -78,15 +78,50 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
   );
 });
 
-test("Custom-only changes do not invoke the Bitquery Explore smoke", () => {
+test("Custom-only changes do not invoke the public data smoke", () => {
   const smoke = stepBlock(deploy, "Smoke staged Bitquery public APIs");
   assert.match(
     smoke,
     /if: >-[\s\S]*verified_custom_v2 != 'true'[\s\S]*verified_interface == 'true'[\s\S]*verified_read_model == 'true'/u,
   );
-  assert.match(smoke, /\/api\/explore/u);
+  assert.match(
+    smoke,
+    /\/api\/explore\?limit=20&page=1&sort=market-cap/u,
+  );
+  assert.match(smoke, /\/api\/explore\?limit=20&page=1&sort=newest/u);
   assert.match(smoke, /\/api\/explore\/token\?address=/u);
   assert.match(smoke, /\/api\/explore\/token\/chart\?address=/u);
+  assert.match(smoke, /\/api\/explore\/profile\?account=/u);
+  assert.match(
+    smoke,
+    /x-programmable-launch-source"\) ===[\s\S]*"drpc"/u,
+  );
+  assert.match(
+    smoke,
+    /x-programmable-read-source"\) ===[\s\S]*"drpc\+bitquery"/u,
+  );
+  assert.match(
+    smoke,
+    /x-programmable-market-source"\) ===[\s\S]*"bitquery"/u,
+  );
+  assert.match(
+    smoke,
+    /profile\.headers\.get\("x-programmable-launch-source"\) !== "drpc"/u,
+  );
+  assert.match(
+    smoke,
+    /profile\.headers\.get\("x-programmable-read-source"\) !== "drpc"/u,
+  );
+  assert.match(
+    smoke,
+    /profile\.headers\.get\("x-programmable-rpc-provider"\) !==[\s\S]*"drpc-primary"/u,
+  );
+  assert.match(smoke, /verified-staged-drpc-bitquery-public-apis/u);
+  assert.match(smoke, /creatorClaimPrepare: "separate-live-probe-required"/u);
+  assert.match(smoke, /tradePrepare: "separate-live-probe-required"/u);
+  assert.doesNotMatch(smoke, /\/api\/explore\/profile\/claim/u);
+  assert.doesNotMatch(smoke, /\/api\/trade\/prepare/u);
+  assert.doesNotMatch(smoke, /method:\s*"POST"/u);
 
   for (const retired of [
     "Resolve read-model release policy",

--- a/tests/action-rpc-identity.test.ts
+++ b/tests/action-rpc-identity.test.ts
@@ -1,0 +1,146 @@
+import {
+  getAddress,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ReadyOnchainDeployment } from "../lib/onchain/types";
+import {
+  readCreatorClaimIdentityFromRpc,
+  readTradeActionModelFromRpc,
+} from "../lib/server/action-rpc-identity.server";
+import { getConfiguredStockPairedReleases } from
+  "../lib/stock-paired-release";
+import { computeOfficialV4PoolId } from
+  "../lib/uniswap/liquidity-launcher-sdk";
+
+vi.mock("server-only", () => ({}));
+
+const ZERO = "0x0000000000000000000000000000000000000000" as Address;
+const creator = getAddress("0x1111111111111111111111111111111111111111");
+const token = getAddress("0x2222222222222222222222222222222222222222");
+const hook = getAddress("0x3333333333333333333333333333333333333333");
+const launcher = getAddress("0x4444444444444444444444444444444444444444");
+const blockHash = `0x${"55".repeat(32)}` as Hex;
+const launchHash = `0x${"66".repeat(32)}` as Hex;
+const poolId = computeOfficialV4PoolId({
+  currency0: ZERO,
+  currency1: token,
+  fee: 0,
+  tickSpacing: 200,
+  hooks: hook,
+});
+
+const deployment: ReadyOnchainDeployment = {
+  environment: "production",
+  releaseVersion: "classic-v2",
+  chainId: 1,
+  status: "ready",
+  launcher,
+  feeHook: hook,
+  launcherRuntimeCodeHash: `0x${"77".repeat(32)}`,
+  feeHookRuntimeCodeHash: `0x${"88".repeat(32)}`,
+  deploymentBlock: 10n,
+  stateView: getAddress("0x5555555555555555555555555555555555555555"),
+  stateViewRuntimeCodeHash: `0x${"99".repeat(32)}`,
+  rpcUrl: "https://lb.drpc.live/ethereum/test-identity-key",
+  rpcUrlSecondary: null,
+  confirmations: 0n,
+  logBlockRange: 10_000n,
+};
+
+describe("single-RPC action identity", () => {
+  it("fails closed after current launcher-state reads when a trade token is unknown", async () => {
+    const readContract = vi.fn().mockResolvedValue(`0x${"00".repeat(32)}`);
+    const client = { readContract } as unknown as PublicClient;
+
+    await expect(
+      readTradeActionModelFromRpc({
+        client,
+        chainId: 1,
+        token,
+        blockNumber: 100n,
+        blockHash,
+      }),
+    ).rejects.toMatchObject({
+      code: "unknown-token",
+    });
+
+    expect(readContract).toHaveBeenCalledTimes(
+      2 + getConfiguredStockPairedReleases().length,
+    );
+    expect(
+      readContract.mock.calls.every(
+        ([call]) =>
+          call.functionName === "launchHashOf" &&
+          call.blockNumber === 100n,
+      ),
+    ).toBe(true);
+  });
+
+  it("derives a claim identity from one filtered launcher log and current state", async () => {
+    const getLogs = vi.fn().mockResolvedValue([
+      {
+        address: launcher,
+        args: {
+          creator,
+          token,
+          poolId,
+          feeHook: hook,
+          positionRecipient: creator,
+          positionTokenId: 1n,
+          totalSwapFeeBps: 100,
+          launchHash,
+        },
+        blockNumber: 50n,
+        transactionHash: `0x${"aa".repeat(32)}`,
+        transactionIndex: 0,
+        logIndex: 0,
+        removed: false,
+      },
+    ]);
+    const readContract = vi.fn(
+      ({ functionName }: { functionName: string; blockNumber?: bigint }) => {
+        if (functionName === "launchHashOf") return Promise.resolve(launchHash);
+        if (functionName === "poolKey") {
+          return Promise.resolve([ZERO, token, 0, 200, hook]);
+        }
+        if (functionName === "creator") return Promise.resolve(creator);
+        throw new Error(`Unexpected function ${functionName}`);
+      },
+    );
+    const client = { getLogs, readContract } as unknown as PublicClient;
+
+    await expect(
+      readCreatorClaimIdentityFromRpc({
+        client,
+        deployment,
+        poolId,
+        blockNumber: 100n,
+      }),
+    ).resolves.toEqual({
+      tokenAddress: token,
+      hookAddress: hook,
+      poolId,
+      creatorAddress: creator,
+      totalSwapFeeBps: 100,
+    });
+    expect(getLogs).toHaveBeenCalledTimes(1);
+    expect(getLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: launcher,
+        args: { poolId },
+        fromBlock: 10n,
+        toBlock: 100n,
+        strict: true,
+      }),
+    );
+    expect(
+      readContract.mock.calls.every(
+        ([call]) => call.blockNumber === 100n,
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/action-rpc-identity.test.ts
+++ b/tests/action-rpc-identity.test.ts
@@ -80,7 +80,7 @@ describe("single-RPC action identity", () => {
     ).toBe(true);
   });
 
-  it("derives a claim identity from one filtered launcher log and current state", async () => {
+  it("derives the fee creator from the launch event instead of token deployment authority", async () => {
     const getLogs = vi.fn().mockResolvedValue([
       {
         address: launcher,
@@ -107,7 +107,7 @@ describe("single-RPC action identity", () => {
         if (functionName === "poolKey") {
           return Promise.resolve([ZERO, token, 0, 200, hook]);
         }
-        if (functionName === "creator") return Promise.resolve(creator);
+        if (functionName === "creator") return Promise.resolve(launcher);
         throw new Error(`Unexpected function ${functionName}`);
       },
     );
@@ -142,5 +142,13 @@ describe("single-RPC action identity", () => {
         ([call]) => call.blockNumber === 100n,
       ),
     ).toBe(true);
+    expect(readContract).toHaveBeenCalledTimes(3);
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: token,
+        functionName: "creator",
+        blockNumber: 100n,
+      }),
+    );
   });
 });

--- a/tests/bitquery-fdv-ranking.test.ts
+++ b/tests/bitquery-fdv-ranking.test.ts
@@ -31,6 +31,7 @@ function rankingToken() {
     Token: {
       Id: `bid:eth:${IDENTITY.tokenAddress}`,
       Address: IDENTITY.tokenAddress,
+      Network: "Ethereum",
     },
     Block: { Time: "2026-08-11T14:00:00.000Z" },
     Supply: {
@@ -80,19 +81,20 @@ describe("strict lightweight Bitquery FDV ranking", () => {
       expect(request.query).not.toContain("DEXTradeByTokens");
       if (request.query.includes("ProgrammableExploreFdvRanking")) {
         expect(request.variables).toEqual({
-          tokenIds: [`bid:eth:${IDENTITY.tokenAddress}`],
+          tokenAddresses: [IDENTITY.tokenAddress],
         });
         expect(request.query).toContain("rankingTokens: Tokens(");
         expect(request.query).toContain(
           "limitBy: { by: Token_Id, count: 1 }",
         );
-        expect(request.query).toContain("Token: { Id: { in: $tokenIds } }");
+        expect(request.query).toContain("Address: { in: $tokenAddresses }");
+        expect(request.query).toContain('Network: { is: "Ethereum" }');
         expect(request.query).toContain(
           "Interval: { Time: { Duration: { eq: 1 } } }",
         );
         expect(request.query).toContain("FullyDilutedValuationUsd");
         expect(request.query).toContain("Price { IsQuotedInUsd Ohlc { Close } }");
-        expect(request.query).not.toContain("Token_Address");
+        expect(request.query).not.toContain("Token: { Id: { in:");
         return json({ data: { Trading: { rankingTokens: [rankingToken()] } } });
       }
       expect(request.query).toContain("EVM(network: eth) {");
@@ -217,6 +219,7 @@ describe("strict lightweight Bitquery FDV ranking", () => {
                   Token: {
                     Id: `base:${IDENTITY.tokenAddress}`,
                     Address: IDENTITY.tokenAddress,
+                    Network: "Base",
                   },
                 }],
               },

--- a/tests/bitquery-fdv-ranking.test.ts
+++ b/tests/bitquery-fdv-ranking.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  BITQUERY_HTTP_ENDPOINT,
+  readBitqueryTokenFdvRankingStrictV1,
+} from "../lib/market-data/bitquery.server";
+import {
+  isTokenMarketDataV1,
+  type MarketDataIdentityV1,
+} from "../lib/market-data/market-data-v1";
+
+const TOKEN = "ory_at_test_market_data_token_123456";
+const IDENTITY: MarketDataIdentityV1 = {
+  chainId: "1",
+  tokenAddress: `0x${"11".repeat(20)}`,
+  poolId: `0x${"22".repeat(32)}`,
+  protocol: "uniswap_v4",
+};
+
+function json(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function rankingToken() {
+  return {
+    Token: {
+      Id: `bid:eth:${IDENTITY.tokenAddress}`,
+      Address: IDENTITY.tokenAddress,
+    },
+    Block: { Time: "2026-08-11T14:00:00.000Z" },
+    Supply: {
+      TotalSupply: "1000000",
+      MaxSupply: "1000000",
+      FullyDilutedValuationUsd: "250000",
+    },
+    Price: { IsQuotedInUsd: true, Ohlc: { Close: "0.25" } },
+  };
+}
+
+function liquidityRow(amountAUsd = "100000", amountBUsd = "50000") {
+  return {
+    Block: { Number: "25740000", Time: "2026-08-11T14:00:00.000Z" },
+    Log: { Index: 1 },
+    Transaction: { Hash: `0x${"aa".repeat(32)}`, Index: 7 },
+    PoolEvent: {
+      Pool: {
+        PoolId: IDENTITY.poolId,
+        CurrencyA: {
+          SmartContract: IDENTITY.tokenAddress,
+          Symbol: "PCAN",
+        },
+        CurrencyB: {
+          SmartContract: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+          Symbol: "WETH",
+        },
+      },
+      Liquidity: {
+        AmountCurrencyA: "100",
+        AmountCurrencyAInUSD: amountAUsd,
+        AmountCurrencyB: "20",
+        AmountCurrencyBInUSD: amountBUsd,
+      },
+    },
+  };
+}
+
+describe("strict lightweight Bitquery FDV ranking", () => {
+  it("uses only Trading.Tokens plus realtime exact-pool liquidity", async () => {
+    const fetchImpl = vi.fn(async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      expect(String(url)).toBe(BITQUERY_HTTP_ENDPOINT);
+      const request = JSON.parse(String(init?.body));
+      expect(request.query).not.toContain("DEXTrades");
+      expect(request.query).not.toContain("DEXTradeByTokens");
+      if (request.query.includes("ProgrammableExploreFdvRanking")) {
+        expect(request.variables).toEqual({
+          tokenAddresses: [IDENTITY.tokenAddress],
+        });
+        expect(request.query).toContain("rankingTokens: Tokens(");
+        expect(request.query).toContain("FullyDilutedValuationUsd");
+        expect(request.query).toContain("Price { IsQuotedInUsd Ohlc { Close } }");
+        return json({ data: { Trading: { rankingTokens: [rankingToken()] } } });
+      }
+      expect(request.query).toContain("EVM(network: eth) {");
+      expect(request.query).not.toContain("dataset: combined");
+      expect(request.query).toContain("latestLiquidity: DEXPoolEvents(");
+      expect(request.variables).toEqual({ pools: [IDENTITY.poolId] });
+      return json({ data: { EVM: { latestLiquidity: [liquidityRow()] } } });
+    }) as typeof fetch;
+
+    const values = await readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl,
+      token: TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+    const market = values.get(IDENTITY.tokenAddress);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(market && isTokenMarketDataV1(market)).toBe(true);
+    expect(market).toMatchObject({
+      status: "current",
+      primaryPoolId: IDENTITY.poolId,
+      pools: [{
+        identity: IDENTITY,
+        status: "current",
+        quality: "complete",
+        liquidity: {
+          valueUsdWad: "150000000000000000000000",
+          freshness: "current",
+        },
+        valuation: {
+          status: "available",
+          metric: "fdv",
+          supplyBasis: "total",
+          valueUsdWad: "250000000000000000000000",
+          fdvUsdWad: "250000000000000000000000",
+          totalSupply: "1000000",
+          freshness: "current",
+        },
+      }],
+    });
+    expect(market?.pools[0]).not.toHaveProperty("latestTrade");
+  });
+
+  it("degrades a liquidity transport failure without failing the token read", async () => {
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      if (request.query.includes("ProgrammableExploreFdvRanking")) {
+        return json({ data: { Trading: { rankingTokens: [rankingToken()] } } });
+      }
+      throw new Error("liquidity unavailable");
+    }) as typeof fetch;
+
+    const values = await readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl,
+      token: TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(IDENTITY.tokenAddress)?.pools[0]).toMatchObject({
+      identity: IDENTITY,
+      status: "current",
+      quality: "partial",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    });
+  });
+
+  it("keeps a low-liquidity pool but withholds its FDV", async () => {
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      return request.query.includes("ProgrammableExploreFdvRanking")
+        ? json({ data: { Trading: { rankingTokens: [rankingToken()] } } })
+        : json({
+            data: {
+              EVM: { latestLiquidity: [liquidityRow("4999", "5000")] },
+            },
+          });
+    }) as typeof fetch;
+
+    const values = await readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl,
+      token: TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(values.get(IDENTITY.tokenAddress)?.pools[0]).toMatchObject({
+      liquidity: { valueUsdWad: "9999000000000000000000" },
+      valuation: {
+        status: "unavailable",
+        reason: "inconsistent-market-data",
+      },
+    });
+  });
+
+  it("rejects the strict core read on provider failure", async () => {
+    await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl: vi.fn().mockRejectedValue(new Error("offline")),
+      token: TOKEN,
+    })).rejects.toMatchObject({
+      category: "transport",
+      phase: "market-core",
+    });
+  });
+});

--- a/tests/bitquery-fdv-ranking.test.ts
+++ b/tests/bitquery-fdv-ranking.test.ts
@@ -29,13 +29,12 @@ function json(value: unknown): Response {
 function rankingToken() {
   return {
     Token: {
-      Id: `bid:eth:${IDENTITY.tokenAddress}`,
+      Id: `eth:${IDENTITY.tokenAddress}`,
       Address: IDENTITY.tokenAddress,
     },
     Block: { Time: "2026-08-11T14:00:00.000Z" },
     Supply: {
       TotalSupply: "1000000",
-      MaxSupply: "1000000",
       FullyDilutedValuationUsd: "250000",
     },
     Price: { IsQuotedInUsd: true, Ohlc: { Close: "0.25" } },
@@ -81,11 +80,19 @@ describe("strict lightweight Bitquery FDV ranking", () => {
       expect(request.query).not.toContain("DEXTradeByTokens");
       if (request.query.includes("ProgrammableExploreFdvRanking")) {
         expect(request.variables).toEqual({
-          tokenAddresses: [IDENTITY.tokenAddress],
+          tokenIds: [`eth:${IDENTITY.tokenAddress}`],
         });
         expect(request.query).toContain("rankingTokens: Tokens(");
+        expect(request.query).toContain(
+          "limitBy: { by: Token_Id, count: 1 }",
+        );
+        expect(request.query).toContain("Token: { Id: { in: $tokenIds } }");
+        expect(request.query).toContain(
+          "Interval: { Time: { Duration: { eq: 1 } } }",
+        );
         expect(request.query).toContain("FullyDilutedValuationUsd");
         expect(request.query).toContain("Price { IsQuotedInUsd Ohlc { Close } }");
+        expect(request.query).not.toContain("Token_Address");
         return json({ data: { Trading: { rankingTokens: [rankingToken()] } } });
       }
       expect(request.query).toContain("EVM(network: eth) {");
@@ -191,6 +198,39 @@ describe("strict lightweight Bitquery FDV ranking", () => {
       token: TOKEN,
     })).rejects.toMatchObject({
       category: "transport",
+      phase: "market-core",
+    });
+  });
+
+  it("rejects a same-address row bound to another chain id", async () => {
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      return request.query.includes("ProgrammableExploreFdvRanking")
+        ? json({
+            data: {
+              Trading: {
+                rankingTokens: [{
+                  ...rankingToken(),
+                  Token: {
+                    Id: `base:${IDENTITY.tokenAddress}`,
+                    Address: IDENTITY.tokenAddress,
+                  },
+                }],
+              },
+            },
+          })
+        : json({ data: { EVM: { latestLiquidity: [liquidityRow()] } } });
+    }) as typeof fetch;
+
+    await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl,
+      token: TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    })).rejects.toMatchObject({
+      category: "integrity",
       phase: "market-core",
     });
   });

--- a/tests/bitquery-fdv-ranking.test.ts
+++ b/tests/bitquery-fdv-ranking.test.ts
@@ -29,7 +29,7 @@ function json(value: unknown): Response {
 function rankingToken() {
   return {
     Token: {
-      Id: `eth:${IDENTITY.tokenAddress}`,
+      Id: `bid:eth:${IDENTITY.tokenAddress}`,
       Address: IDENTITY.tokenAddress,
     },
     Block: { Time: "2026-08-11T14:00:00.000Z" },
@@ -80,7 +80,7 @@ describe("strict lightweight Bitquery FDV ranking", () => {
       expect(request.query).not.toContain("DEXTradeByTokens");
       if (request.query.includes("ProgrammableExploreFdvRanking")) {
         expect(request.variables).toEqual({
-          tokenIds: [`eth:${IDENTITY.tokenAddress}`],
+          tokenIds: [`bid:eth:${IDENTITY.tokenAddress}`],
         });
         expect(request.query).toContain("rankingTokens: Tokens(");
         expect(request.query).toContain(

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -374,7 +374,7 @@ describe("Bitquery-only market data", () => {
   });
 
   it("binds PCAN to its exact v4 PoolId and ignores Bitquery's cap estimates", async () => {
-    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       expect(String(url)).toBe(BITQUERY_HTTP_ENDPOINT);
       expect(init?.headers).toMatchObject({
         Accept: "application/json",
@@ -425,19 +425,6 @@ describe("Bitquery-only market data", () => {
           data: { Trading: { price0: [tradingPriceRow()] } },
         });
       }
-      if (request.query.includes("ProgrammableMarketLiquidity")) {
-        expect(request.variables).toEqual({ pools: [PCAN.poolId] });
-        expect(request.query).toContain("latestLiquidity: DEXPoolEvents(");
-        expect(request.query).toContain("CurrencyA { SmartContract Symbol }");
-        expect(request.query).toContain("AmountCurrencyA");
-        expect(request.query).toContain("AmountCurrencyB");
-        expect(request.query).toContain("Log { Index }");
-        expect(request.query).toContain("Transaction { Hash Index }");
-        expect(request.query).not.toContain("latestTrades: DEXTrades(");
-        return jsonResponse({
-          data: { EVM: { latestLiquidity: [liquidityRow(PCAN)] } },
-        });
-      }
       if (request.query.includes("ProgrammableMarketStats")) {
         expect(request.variables).toEqual({
           pools: [PCAN.poolId],
@@ -464,7 +451,8 @@ describe("Bitquery-only market data", () => {
         });
       }
       throw new Error("unexpected market request");
-    }) as typeof fetch;
+    });
+    const fetchImpl = fetchMock as typeof fetch;
 
     const values = await readBitqueryTokenMarketDataV1([PCAN], {
       fetchImpl,
@@ -473,15 +461,19 @@ describe("Bitquery-only market data", () => {
     });
     const market = values.get(PCAN.tokenAddress);
 
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(String(init?.body)).not.toContain("DEXPoolEvents");
+    }
     expect(market && isTokenMarketDataV1(market)).toBe(true);
     expect(market).toMatchObject({
       source: "bitquery",
-      status: "current",
+      status: "partial",
       primaryPoolId: PCAN.poolId,
       pools: [{
         identity: marketIdentity(PCAN),
         status: "current",
+        quality: "partial",
         latestTrade: {
           priceUsdWad: "250000000000000000",
           priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
@@ -490,7 +482,6 @@ describe("Bitquery-only market data", () => {
         },
         volume24hUsdWad: "12345670000000000000000",
         tradeCount24h: 42,
-        liquidity: { valueUsdWad: "150000000000000000000000" },
         valuation: {
           status: "available",
           metric: "fdv",
@@ -514,8 +505,6 @@ describe("Bitquery-only market data", () => {
       if (request.query.includes("ProgrammableMarketSnapshot")) {
         started.add("core");
         await corePending;
-      } else if (request.query.includes("ProgrammableMarketLiquidity")) {
-        started.add("liquidity");
       } else if (request.query.includes("ProgrammableMarketStats")) {
         started.add("stats");
       } else {
@@ -531,7 +520,7 @@ describe("Bitquery-only market data", () => {
     });
     try {
       await vi.waitFor(() => {
-        expect([...started].sort()).toEqual(["core", "liquidity", "stats"]);
+        expect([...started].sort()).toEqual(["core", "stats"]);
       });
     } finally {
       releaseCore?.();
@@ -539,7 +528,7 @@ describe("Bitquery-only market data", () => {
 
     const values = await read;
     expect(values.get(PCAN.tokenAddress)).toMatchObject({ source: "bitquery" });
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
   it.each([
@@ -575,7 +564,7 @@ describe("Bitquery-only market data", () => {
     });
     const pool = values.get(PCAN.tokenAddress)?.pools[0];
 
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(pool?.latestTrade).toMatchObject({
       priceUsdWad: "250000000000000000",
       priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
@@ -637,7 +626,7 @@ describe("Bitquery-only market data", () => {
     });
   });
 
-  it("keeps a dust-liquidity pool discoverable but makes its FDV unavailable", async () => {
+  it("does not require unsupported historical pool events to publish FDV", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       liquidity: liquidityRow(PCAN, {
         amountFirstUsd: "4999",
@@ -652,10 +641,11 @@ describe("Bitquery-only market data", () => {
     const pool = values.get(PCAN.tokenAddress)?.pools[0];
 
     expect(pool?.identity).toEqual(marketIdentity(PCAN));
-    expect(pool?.liquidity?.valueUsdWad).toBe("9999000000000000000000");
-    expect(pool?.valuation).toEqual({
-      status: "unavailable",
-      reason: "inconsistent-market-data",
+    expect(pool).not.toHaveProperty("liquidity");
+    expect(pool?.valuation).toMatchObject({
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
     });
   });
 
@@ -712,7 +702,7 @@ describe("Bitquery-only market data", () => {
     });
   });
 
-  it("derives exact-pool USD liquidity from event reserves and the bound native trade", async () => {
+  it("omits historical pool-event liquidity while retaining the bound trade", async () => {
     const nativeEth = "0x0000000000000000000000000000000000000000";
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       trade: tradeRow({
@@ -737,11 +727,10 @@ describe("Bitquery-only market data", () => {
         priceUsdWad: "250000000000000000",
         quoteAddress: nativeEth,
       },
-      liquidity: {
-        valueUsdWad: "50025000000000000000000",
-        asOfBlock: "25740000",
-      },
     });
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
+      "liquidity",
+    );
   });
 
   it("does not treat an indexed native price as transaction-bound liquidity evidence", async () => {
@@ -770,7 +759,7 @@ describe("Bitquery-only market data", () => {
     );
   });
 
-  it("keeps a legitimate zero reserve while requiring positive total liquidity", async () => {
+  it("does not expose liquidity from an unsupported pool-event dataset", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       liquidity: liquidityRow(PCAN, {
         amountFirst: "0",
@@ -785,10 +774,9 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(values.get(PCAN.tokenAddress)?.pools[0]?.liquidity).toMatchObject({
-      valueUsdWad: "50000000000000000000000",
-      freshness: "current",
-    });
+    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
+      "liquidity",
+    );
   });
 
   it("does not publish zero total liquidity", async () => {
@@ -987,7 +975,7 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.identity).toEqual(
       marketIdentity(PCAN),
     );
@@ -1054,7 +1042,7 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(6);
+    expect(fetchImpl).toHaveBeenCalledTimes(5);
     expect(priceBatchSizes.sort((first, second) => first - second)).toEqual([
       1,
       20,
@@ -1137,7 +1125,7 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(6);
+    expect(fetchImpl).toHaveBeenCalledTimes(5);
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade).toMatchObject({
       priceUsdWad: "250000000000000000",
       priceUsdSource: "bitquery-token-price-index-v1",
@@ -1207,7 +1195,7 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(5);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade).toMatchObject({
       priceUsdWad: "250000000000000000",
       priceUsdSource: "bitquery-token-price-index-v1",

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -425,6 +425,21 @@ describe("Bitquery-only market data", () => {
           data: { Trading: { price0: [tradingPriceRow()] } },
         });
       }
+      if (request.query.includes("ProgrammableMarketLiquidity")) {
+        expect(request.variables).toEqual({ pools: [PCAN.poolId] });
+        expect(request.query).toContain("EVM(network: eth) {");
+        expect(request.query).not.toContain("dataset: combined");
+        expect(request.query).toContain("latestLiquidity: DEXPoolEvents(");
+        expect(request.query).toContain("CurrencyA { SmartContract Symbol }");
+        expect(request.query).toContain("AmountCurrencyAInUSD");
+        expect(request.query).toContain("AmountCurrencyBInUSD");
+        expect(request.query).toContain("Log { Index }");
+        expect(request.query).toContain("Transaction { Hash Index }");
+        expect(request.query).not.toContain("latestTrades: DEXTrades(");
+        return jsonResponse({
+          data: { EVM: { latestLiquidity: [liquidityRow(PCAN)] } },
+        });
+      }
       if (request.query.includes("ProgrammableMarketStats")) {
         expect(request.variables).toEqual({
           pools: [PCAN.poolId],
@@ -461,19 +476,16 @@ describe("Bitquery-only market data", () => {
     });
     const market = values.get(PCAN.tokenAddress);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    for (const [, init] of fetchMock.mock.calls) {
-      expect(String(init?.body)).not.toContain("DEXPoolEvents");
-    }
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(market && isTokenMarketDataV1(market)).toBe(true);
     expect(market).toMatchObject({
       source: "bitquery",
-      status: "partial",
+      status: "current",
       primaryPoolId: PCAN.poolId,
       pools: [{
         identity: marketIdentity(PCAN),
         status: "current",
-        quality: "partial",
+        quality: "complete",
         latestTrade: {
           priceUsdWad: "250000000000000000",
           priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
@@ -482,6 +494,7 @@ describe("Bitquery-only market data", () => {
         },
         volume24hUsdWad: "12345670000000000000000",
         tradeCount24h: 42,
+        liquidity: { valueUsdWad: "150000000000000000000000" },
         valuation: {
           status: "available",
           metric: "fdv",
@@ -505,6 +518,8 @@ describe("Bitquery-only market data", () => {
       if (request.query.includes("ProgrammableMarketSnapshot")) {
         started.add("core");
         await corePending;
+      } else if (request.query.includes("ProgrammableMarketLiquidity")) {
+        started.add("liquidity");
       } else if (request.query.includes("ProgrammableMarketStats")) {
         started.add("stats");
       } else {
@@ -520,7 +535,7 @@ describe("Bitquery-only market data", () => {
     });
     try {
       await vi.waitFor(() => {
-        expect([...started].sort()).toEqual(["core", "stats"]);
+        expect([...started].sort()).toEqual(["core", "liquidity", "stats"]);
       });
     } finally {
       releaseCore?.();
@@ -528,7 +543,7 @@ describe("Bitquery-only market data", () => {
 
     const values = await read;
     expect(values.get(PCAN.tokenAddress)).toMatchObject({ source: "bitquery" });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
   it.each([
@@ -564,7 +579,7 @@ describe("Bitquery-only market data", () => {
     });
     const pool = values.get(PCAN.tokenAddress)?.pools[0];
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(pool?.latestTrade).toMatchObject({
       priceUsdWad: "250000000000000000",
       priceUsdAsOfTime: "2026-08-11T14:00:00.000Z",
@@ -626,7 +641,7 @@ describe("Bitquery-only market data", () => {
     });
   });
 
-  it("does not require unsupported historical pool events to publish FDV", async () => {
+  it("keeps a dust-liquidity pool discoverable but makes its FDV unavailable", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       liquidity: liquidityRow(PCAN, {
         amountFirstUsd: "4999",
@@ -641,11 +656,10 @@ describe("Bitquery-only market data", () => {
     const pool = values.get(PCAN.tokenAddress)?.pools[0];
 
     expect(pool?.identity).toEqual(marketIdentity(PCAN));
-    expect(pool).not.toHaveProperty("liquidity");
-    expect(pool?.valuation).toMatchObject({
-      status: "available",
-      metric: "fdv",
-      supplyBasis: "total",
+    expect(pool?.liquidity?.valueUsdWad).toBe("9999000000000000000000");
+    expect(pool?.valuation).toEqual({
+      status: "unavailable",
+      reason: "inconsistent-market-data",
     });
   });
 
@@ -702,7 +716,7 @@ describe("Bitquery-only market data", () => {
     });
   });
 
-  it("omits historical pool-event liquidity while retaining the bound trade", async () => {
+  it("uses a current realtime native pool event while retaining the bound trade", async () => {
     const nativeEth = "0x0000000000000000000000000000000000000000";
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       trade: tradeRow({
@@ -728,9 +742,10 @@ describe("Bitquery-only market data", () => {
         quoteAddress: nativeEth,
       },
     });
-    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
-      "liquidity",
-    );
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.liquidity).toMatchObject({
+      freshness: "current",
+      valueUsdWad: "50025000000000000000000",
+    });
   });
 
   it("does not treat an indexed native price as transaction-bound liquidity evidence", async () => {
@@ -759,7 +774,7 @@ describe("Bitquery-only market data", () => {
     );
   });
 
-  it("does not expose liquidity from an unsupported pool-event dataset", async () => {
+  it("keeps a legitimate zero reserve in the realtime liquidity total", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(marketResponse({
       liquidity: liquidityRow(PCAN, {
         amountFirst: "0",
@@ -774,9 +789,10 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(values.get(PCAN.tokenAddress)?.pools[0]).not.toHaveProperty(
-      "liquidity",
-    );
+    expect(values.get(PCAN.tokenAddress)?.pools[0]?.liquidity).toMatchObject({
+      freshness: "current",
+      valueUsdWad: "50000000000000000000000",
+    });
   });
 
   it("does not publish zero total liquidity", async () => {
@@ -975,7 +991,7 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.identity).toEqual(
       marketIdentity(PCAN),
     );
@@ -1042,7 +1058,7 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(5);
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
     expect(priceBatchSizes.sort((first, second) => first - second)).toEqual([
       1,
       20,
@@ -1125,7 +1141,7 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(5);
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade).toMatchObject({
       priceUsdWad: "250000000000000000",
       priceUsdSource: "bitquery-token-price-index-v1",
@@ -1195,11 +1211,128 @@ describe("Bitquery-only market data", () => {
       now: new Date("2026-08-11T14:02:00.000Z"),
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl).toHaveBeenCalledTimes(5);
     expect(values.get(PCAN.tokenAddress)?.pools[0]?.latestTrade).toMatchObject({
       priceUsdWad: "250000000000000000",
       priceUsdSource: "bitquery-token-price-index-v1",
     });
+  });
+
+  it("keeps missing strict prices unavailable without singleton retries", async () => {
+    let priceCalls = 0;
+    const identities = [PCAN, CLASSIC];
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      if (request.query.includes("ProgrammableMarketSnapshot")) {
+        return jsonResponse({
+          data: {
+            EVM: {
+              latestTrades: identities.map((identity) => tradeRow({
+                identity,
+                omitPriceUsd: true,
+                omitQuotePriceUsd: true,
+              })),
+            },
+            Trading: {
+              tokenSupplies: identities.map((identity) => supplyRow({ identity })),
+            },
+          },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketPrices")) {
+        priceCalls += 1;
+        expect(request.query.match(/price\d+: Tokens/gu)).toHaveLength(2);
+        return jsonResponse({
+          data: { Trading: { price0: [], price1: [] } },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketLiquidity")) {
+        return jsonResponse({
+          data: {
+            EVM: {
+              latestLiquidity: identities.map((identity) => liquidityRow(identity)),
+            },
+          },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketStats")) {
+        return jsonResponse({
+          data: {
+            EVM: {
+              stats: identities.map((identity) => ({
+                Trade: {
+                  PoolId: identity.poolId,
+                  Currency: { SmartContract: identity.tokenAddress },
+                },
+                count: "1",
+                volumeUsd: "10",
+              })),
+            },
+          },
+        });
+      }
+      throw new Error("unexpected market request");
+    }) as typeof fetch;
+
+    const values = await readBitqueryTokenMarketDataStrictV1(identities, {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    });
+
+    expect(priceCalls).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    for (const identity of identities) {
+      expect(values.get(identity.tokenAddress)?.pools[0]?.valuation).toEqual({
+        status: "unavailable",
+        reason: "price-unavailable",
+      });
+    }
+  });
+
+  it("uses one bounded 339-market list batch and skips 24h stats", async () => {
+    const identities = Array.from(
+      { length: 339 },
+      (_, index) => generatedIdentity(index + 1),
+    );
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      expect(request.query).not.toContain("ProgrammableMarketStats");
+      if (request.query.includes("ProgrammableMarketSnapshot")) {
+        expect(request.query).toContain("limit: { count: 339 }");
+        expect(request.variables.pools).toHaveLength(339);
+        return jsonResponse({
+          data: { EVM: { latestTrades: [] }, Trading: { tokenSupplies: [] } },
+        });
+      }
+      if (request.query.includes("ProgrammableMarketLiquidity")) {
+        expect(request.query).toContain("EVM(network: eth) {");
+        expect(request.query).not.toContain("dataset: combined");
+        expect(request.query).toContain("limit: { count: 339 }");
+        expect(request.variables.pools).toHaveLength(339);
+        return jsonResponse({ data: { EVM: { latestLiquidity: [] } } });
+      }
+      throw new Error("unexpected market request");
+    }) as typeof fetch;
+
+    const values = await readBitqueryTokenMarketDataStrictV1(identities, {
+      fetchImpl,
+      token: OAUTH_TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+      includeStats: false,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(values.size).toBe(339);
+    expect([...values.values()].every(
+      (value) => value.status === "waiting-for-first-trade",
+    )).toBe(true);
   });
 
   it("uses exact total supply when circulating supply is absent", async () => {

--- a/tests/classic-v3-profile-route.test.ts
+++ b/tests/classic-v3-profile-route.test.ts
@@ -134,7 +134,7 @@ describe("Classic profile release gate", () => {
     });
   });
 
-  it("does not instantiate an RPC client for the public GET", async () => {
+  it("uses exactly one commitment-bound dRPC client for the public GET", async () => {
     const response = await GET(
       new NextRequest(
         `http://localhost/api/profile/classic-v3?account=${account}`,
@@ -142,16 +142,19 @@ describe("Classic profile release gate", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.readBitqueryClassicV3Profile).toHaveBeenCalledWith(account);
-    expect(mocks.createPublicClient).not.toHaveBeenCalled();
+    expect(mocks.readBitqueryClassicV3Profile).not.toHaveBeenCalled();
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "bitquery",
+      "rpc",
+    );
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
+      "drpc-primary",
     );
   });
 
-  it("returns a temporary error when the Bitquery read fails", async () => {
-    mocks.readBitqueryClassicV3Profile.mockRejectedValue(
-      new Error("Bitquery unavailable"),
+  it("returns 503 without fallback when the sole dRPC read fails", async () => {
+    mocks.client.getBlockNumber.mockRejectedValueOnce(
+      new Error("dRPC unavailable"),
     );
 
     const response = await GET(
@@ -169,10 +172,11 @@ describe("Classic profile release gate", () => {
         message: "Classic rewards are temporarily unavailable",
       },
     });
-    expect(mocks.createPublicClient).not.toHaveBeenCalled();
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+    expect(mocks.readBitqueryClassicV3Profile).not.toHaveBeenCalled();
   });
 
-  it("rejects invalid launch lookup hashes before reading Bitquery", async () => {
+  it("rejects invalid launch lookup hashes before reading a provider", async () => {
     const response = await GET(
       new NextRequest(
         `http://localhost/api/profile/classic-v3?account=${account}&launch=bad`,
@@ -184,6 +188,7 @@ describe("Classic profile release gate", () => {
       error: "Enter a valid launch transaction hash",
     });
     expect(mocks.readBitqueryClassicV3Launch).not.toHaveBeenCalled();
+    expect(mocks.createPublicClient).not.toHaveBeenCalled();
   });
 
   it("rejects claims from a wallet that does not own the vault", async () => {

--- a/tests/creator-claim-action-activation.test.ts
+++ b/tests/creator-claim-action-activation.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   readAlchemy: vi.fn(),
   readLegacy: vi.fn(),
   readBitquery: vi.fn(),
+  readIdentity: vi.fn(),
   createPublicClient: vi.fn(),
 }));
 
@@ -186,6 +187,16 @@ vi.mock("../lib/market-data/bitquery-explore-model.server", () => ({
   readBitqueryExploreModelV1: mocks.readBitquery,
 }));
 
+vi.mock("../lib/server/action-rpc-identity.server", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../lib/server/action-rpc-identity.server")
+  >();
+  return {
+    ...actual,
+    readCreatorClaimIdentityFromRpc: mocks.readIdentity,
+  };
+});
+
 vi.mock("viem", async (importOriginal) => {
   const actual = await importOriginal<typeof import("viem")>();
   return {
@@ -226,6 +237,13 @@ describe("creator claim action identity activation", () => {
     mocks.readAlchemy.mockResolvedValue(legacyModel);
     mocks.readLegacy.mockResolvedValue(legacyModel);
     mocks.readBitquery.mockResolvedValue(legacyModel);
+    mocks.readIdentity.mockResolvedValue({
+      tokenAddress: token,
+      hookAddress: hook,
+      poolId,
+      creatorAddress: creator,
+      totalSwapFeeBps: 100,
+    });
     mocks.createPublicClient.mockImplementation(() =>
       rpcClient(100_000n, 2_000_000_000n, 10n ** 18n),
     );
@@ -248,9 +266,15 @@ describe("creator claim action identity activation", () => {
           gasPriceWei: "2000000000",
           accountBalanceWei: "1000000000000000000",
         },
+        submission: {
+          status: "not-submitted",
+          transactionHash: null,
+          receipt: null,
+        },
       });
       expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
-      expect(mocks.readBitquery).toHaveBeenCalledTimes(1);
+      expect(mocks.readIdentity).toHaveBeenCalledTimes(1);
+      expect(mocks.readBitquery).not.toHaveBeenCalled();
       expect(mocks.lookup).not.toHaveBeenCalled();
       expect(mocks.readAlchemy).not.toHaveBeenCalled();
       expect(mocks.readLegacy).not.toHaveBeenCalled();
@@ -275,25 +299,25 @@ describe("creator claim action identity activation", () => {
     });
   });
 
-  it("reports a mainnet registry outage before starting any claim RPC read", async () => {
-    mocks.readBitquery.mockRejectedValueOnce(
-      new Error("Bitquery provider failed with a private detail"),
+  it("does not expose a private RPC identity-read failure", async () => {
+    mocks.readIdentity.mockRejectedValueOnce(
+      new Error("dRPC provider failed with a private detail"),
     );
 
     const response = await POST(request());
     const serialized = JSON.stringify(await response.json());
 
-    expect(response.status).toBe(503);
+    expect(response.status).toBe(502);
     expect(JSON.parse(serialized)).toMatchObject({
       status: "blocked",
       error: {
-        code: "registry-unavailable",
+        code: "simulation-failed",
         message:
-          "The verified Programmable launch registry is temporarily unavailable",
+          "The configured RPC could not prepare the creator claim from the current onchain state",
       },
     });
-    expect(mocks.createPublicClient).not.toHaveBeenCalled();
-    expect(serialized).not.toContain("Bitquery provider");
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+    expect(serialized).not.toContain("dRPC provider");
     expect(serialized).not.toContain("private detail");
   });
 
@@ -332,6 +356,7 @@ describe("creator claim action identity activation", () => {
         error: { code: "rpc-unavailable" },
       });
       expect(mocks.createPublicClient).not.toHaveBeenCalled();
+      expect(mocks.readIdentity).not.toHaveBeenCalled();
       expect(serialized).not.toContain("drpc-claim-key");
     },
   );

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -14,7 +14,13 @@ import { describe, expect, it } from "vitest";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import { evaluateReadModelOperationsSourceContracts } from "../../scripts/perf/read-model-ops-source-contracts.mjs";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
-import { exactCurrentPublicFdvLiquidity, exactExploreValuationSnapshot, exploreContinuationPath, verifyCurrentPublicOnchainEvidenceV1, verifyPostPromotion } from "../../scripts/perf/read-model-post-promotion.mjs";
+import {
+  exactCurrentPublicFdvLiquidity,
+  exactExploreValuationSnapshot,
+  exploreContinuationPath,
+  verifyCurrentPublicOnchainEvidenceV1,
+  verifyPostPromotion,
+} from "../../scripts/perf/read-model-post-promotion.mjs";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import { resolveProductionBinding } from "../../scripts/perf/read-model-production-binding.mjs";
 
@@ -356,7 +362,9 @@ describe("read-model operations source contract", () => {
       AbortSignal,
       URL,
       setTimeout,
-      { log: (value: string) => logged.push(value) },
+      {
+        log: (value: string) => logged.push(value),
+      },
     );
     expect(requests).toHaveLength(2);
     expect(requests[0]?.url).toBe(
@@ -561,7 +569,9 @@ describe("read-model operations source contract", () => {
         AbortSignal,
         URL,
         setTimeout,
-        { log: () => undefined },
+        {
+          log: () => undefined,
+        },
       ),
     ).rejects.toThrow("production read-model refresh failed (200)");
   });
@@ -802,17 +812,17 @@ describe("read-model operations source contract", () => {
     },
   );
 
-  it("binds public Website releases to Bitquery without availability fallbacks", () => {
+  it("binds public identity to one dRPC primary and public market reads to Bitquery", () => {
     const result = evaluateReadModelOperationsSourceContracts(ROOT);
     expect(result.failures).toEqual([]);
     expect(result.checks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: "ops-bitquery-only-public-source-contract",
+          id: "ops-public-provider-split-source-contract",
           status: "pass",
         }),
         expect.objectContaining({
-          id: "ops-protected-bitquery-stage-smoke",
+          id: "ops-protected-public-provider-stage-smoke",
           status: "pass",
         }),
         expect.objectContaining({
@@ -823,7 +833,7 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("rejects a public route that restores durable or RPC availability reads", () => {
+  it("rejects a public route that restores a durable availability read", () => {
     const path = "app/api/explore/route.ts";
     const route = readFileSync(resolve(ROOT, path), "utf8");
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
@@ -832,7 +842,83 @@ describe("read-model operations source contract", () => {
       },
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
-      "ops-bitquery-only-public-source-contract",
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
+  it("rejects a public release manifest that requires a secondary RPC", () => {
+    const path = "config/read-model-operations.v1.json";
+    const manifest = JSON.parse(
+      readFileSync(resolve(ROOT, path), "utf8"),
+    ) as Record<string, unknown>;
+    const postPromotion = manifest.postPromotion as Record<string, unknown>;
+    const rpc = postPromotion.rpc as Record<string, unknown>;
+    const drifted = JSON.stringify(
+      {
+        ...manifest,
+        postPromotion: {
+          ...postPromotion,
+          rpc: { ...rpc, secondaryRequired: true },
+        },
+      },
+      null,
+      2,
+    );
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: drifted },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-config-schema",
+    );
+  });
+
+  it("rejects a public launch route that restores Bitquery identity discovery", () => {
+    const path = "app/api/explore/route.ts";
+    const route = readFileSync(resolve(ROOT, path), "utf8");
+    expect(route).toContain("readPrimaryRpcExploreEntriesV1");
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        [path]: route.replaceAll(
+          "readPrimaryRpcExploreEntriesV1",
+          "readBitqueryExploreEntriesV1",
+        ),
+      },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
+  it("rejects a public action route that restores RPC quorum selection", () => {
+    const path = "app/api/trade/prepare/route.ts";
+    const route = readFileSync(resolve(ROOT, path), "utf8");
+    expect(route).toContain("tradeActionRpcProvider");
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        [path]: route.replaceAll(
+          "tradeActionRpcProvider",
+          "tradeActionRpcProviders",
+        ),
+      },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
+  it("rejects a staged public smoke that exposes an RPC provider URL", () => {
+    const path = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, path), "utf8");
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        [path]: workflow.replace(
+          "Smoke staged Bitquery public APIs",
+          "Smoke staged Bitquery public APIs\n# PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL",
+        ),
+      },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-public-provider-stage-smoke",
     );
   });
 

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -14,13 +14,7 @@ import { describe, expect, it } from "vitest";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import { evaluateReadModelOperationsSourceContracts } from "../../scripts/perf/read-model-ops-source-contracts.mjs";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
-import {
-  exactCurrentPublicFdvLiquidity,
-  exactExploreValuationSnapshot,
-  exploreContinuationPath,
-  verifyCurrentPublicOnchainEvidenceV1,
-  verifyPostPromotion,
-} from "../../scripts/perf/read-model-post-promotion.mjs";
+import { exactCurrentPublicFdvLiquidity, exactExploreValuationSnapshot, exploreContinuationPath, verifyCurrentPublicOnchainEvidenceV1, verifyPostPromotion } from "../../scripts/perf/read-model-post-promotion.mjs";
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import { resolveProductionBinding } from "../../scripts/perf/read-model-production-binding.mjs";
 

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -883,6 +883,34 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it.each([
+    [
+      "canonical token detail headers that claim Custom Registry identity",
+      '"X-Programmable-Launch-Source": "drpc"',
+      '"X-Programmable-Launch-Source": "registry.custom-launched"',
+    ],
+    [
+      "Custom Registry token detail headers that claim canonical identity",
+      '"X-Programmable-Launch-Source": "registry.custom-launched"',
+      '"X-Programmable-Launch-Source": "drpc"',
+    ],
+    [
+      "a canonical dRPC failure that does not return before the Custom Registry path",
+      "return unavailableResponse(canonicalResponseHeaders({",
+      "unavailableResponse(canonicalResponseHeaders({",
+    ],
+  ])("rejects %s", (_label, needle, replacement) => {
+    const path = "app/api/explore/token/route.ts";
+    const route = readFileSync(resolve(ROOT, path), "utf8");
+    expect(route).toContain(needle);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: route.replace(needle, replacement) },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
   it("rejects a public action route that restores RPC quorum selection", () => {
     const path = "app/api/trade/prepare/route.ts";
     const route = readFileSync(resolve(ROOT, path), "utf8");

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -215,6 +215,11 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
     expect((body.tokens as ExploreEntry[]).map((entry) => entry.id)).toEqual(
       [1, 2, 3, 4].map((index) => entries[index - 1]!.id),
     );
+    expect(mocks.readBitqueryTokenFdvRankingStrictV1).toHaveBeenCalledOnce();
+    expect(
+      mocks.readBitqueryTokenFdvRankingStrictV1.mock.calls[0]?.[0],
+    ).toHaveLength(entries.length);
+    expect(mocks.readBitqueryTokenMarketDataStrictV1).not.toHaveBeenCalled();
   });
 
   it("sorts newest launches without a valuation snapshot", async () => {

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -294,7 +294,9 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
       expect(source).toContain("readPrimaryRpcExploreEntriesV1");
       expect(source).not.toContain("readBitqueryExploreEntriesV1");
       expect(source).not.toContain("bitquery-launches.server");
-      expect(source).not.toContain("readProductionCustomExploreDirectoryV1");
+      if (!relative.endsWith("/token/route.ts")) {
+        expect(source).not.toContain("readProductionCustomExploreDirectoryV1");
+      }
     }
   });
 });

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,7 +12,7 @@ import type {
 import type { ExploreEntry, LauncherToken } from "../lib/tokens";
 
 const mocks = vi.hoisted(() => ({
-  readBitqueryExploreEntriesV1: vi.fn(),
+  readPrimaryRpcExploreEntriesV1: vi.fn(),
   readBitqueryTokenMarketDataStrictV1: vi.fn(),
   safeBitqueryMarketDataError: vi.fn(() => ({
     name: "BitqueryMarketDataError",
@@ -18,8 +20,12 @@ const mocks = vi.hoisted(() => ({
   })),
 }));
 
-vi.mock("../lib/market-data/bitquery-launches.server", () => ({
-  readBitqueryExploreEntriesV1: mocks.readBitqueryExploreEntriesV1,
+vi.mock("../lib/market-data/primary-rpc-launches.server", () => ({
+  readPrimaryRpcExploreEntriesV1: mocks.readPrimaryRpcExploreEntriesV1,
+  safePrimaryRpcLaunchCatalogError: vi.fn(() => ({
+    name: "PrimaryRpcLaunchCatalogError",
+    category: "transport",
+  })),
 }));
 
 vi.mock("../lib/market-data/bitquery.server", () => ({
@@ -134,14 +140,14 @@ async function json(response: Response) {
   return await response.json() as Record<string, unknown>;
 }
 
-describe("Explore API strict Bitquery-only contract", () => {
+describe("Explore API strict dRPC identity and Bitquery market contract", () => {
   const entries = Array.from({ length: 12 }, (_, index) => token(index + 1));
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.readBitqueryExploreEntriesV1.mockResolvedValue({
-      source: "bitquery",
+    mocks.readPrimaryRpcExploreEntriesV1.mockResolvedValue({
+      source: "drpc",
       entries,
       generatedAt: NOW,
       asOfBlock: "25740000",
@@ -152,7 +158,7 @@ describe("Explore API strict Bitquery-only contract", () => {
     );
   });
 
-  it("serves launches and current FDV from Bitquery only", async () => {
+  it("serves dRPC launch identity with current Bitquery FDV", async () => {
     const response = await GET(request("sort=highest-market-cap&page=1&limit=5"));
     const body = await json(response);
 
@@ -177,14 +183,14 @@ describe("Explore API strict Bitquery-only contract", () => {
         valuation: expect.objectContaining({ source: "bitquery" }),
       }),
     ]));
-    expect(response.headers.get("x-programmable-launch-source")).toBe("bitquery");
-    expect(response.headers.get("x-programmable-read-source")).toBe("bitquery");
+    expect(response.headers.get("x-programmable-launch-source")).toBe("drpc");
+    expect(response.headers.get("x-programmable-read-source")).toBe("drpc+bitquery");
     expect(response.headers.get("x-programmable-market-source")).toBe("bitquery");
     expect(response.headers.get("x-programmable-price-source")).toBe("bitquery");
     expect([...response.headers.entries()].join(" ").toLowerCase()).not.toMatch(
-      /rpc|stateview|chainlink|subgraph|snapshot/u,
+      /quicknode|alchemy|stateview|chainlink|subgraph|snapshot/u,
     );
-    expect(mocks.readBitqueryExploreEntriesV1).toHaveBeenCalledOnce();
+    expect(mocks.readPrimaryRpcExploreEntriesV1).toHaveBeenCalledOnce();
     expect(mocks.readBitqueryTokenMarketDataStrictV1).toHaveBeenCalledOnce();
   });
 
@@ -238,11 +244,11 @@ describe("Explore API strict Bitquery-only contract", () => {
     const response = await GET(request(query));
     expect(response.status).toBe(400);
     expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(mocks.readBitqueryExploreEntriesV1).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryRpcExploreEntriesV1).not.toHaveBeenCalled();
   });
 
-  it("returns 503 directly when the Bitquery launch catalog fails", async () => {
-    mocks.readBitqueryExploreEntriesV1.mockRejectedValueOnce(
+  it("returns 503 directly when the primary dRPC launch catalog fails", async () => {
+    mocks.readPrimaryRpcExploreEntriesV1.mockRejectedValueOnce(
       new Error("catalog unavailable"),
     );
 
@@ -251,7 +257,7 @@ describe("Explore API strict Bitquery-only contract", () => {
     expect(await json(response)).toEqual({
       error: "Token data is temporarily unavailable",
     });
-    expect(response.headers.get("x-programmable-launch-source")).toBe("bitquery");
+    expect(response.headers.get("x-programmable-launch-source")).toBe("drpc");
     expect(response.headers.get("x-programmable-market-source")).toBe("bitquery");
     expect(mocks.readBitqueryTokenMarketDataStrictV1).not.toHaveBeenCalled();
   });
@@ -268,5 +274,27 @@ describe("Explore API strict Bitquery-only contract", () => {
     expect(await json(response)).toEqual({
       error: "Token data is temporarily unavailable",
     });
+  });
+
+  it("returns 503 when Bitquery omits a required dRPC launch market", async () => {
+    mocks.readBitqueryTokenMarketDataStrictV1.mockResolvedValueOnce(new Map());
+    const response = await GET(request("sort=market-cap"));
+    expect(response.status).toBe(503);
+    expect(response.headers.get("x-programmable-launch-source")).toBe("drpc");
+    expect(response.headers.get("x-programmable-market-source")).toBe("bitquery");
+  });
+
+  it("contains no historical Bitquery launch discovery or identity fallback", () => {
+    for (const relative of [
+      "../app/api/explore/route.ts",
+      "../app/api/explore/token/route.ts",
+      "../app/api/explore/token/chart/route.ts",
+    ]) {
+      const source = readFileSync(new URL(relative, import.meta.url), "utf8");
+      expect(source).toContain("readPrimaryRpcExploreEntriesV1");
+      expect(source).not.toContain("readBitqueryExploreEntriesV1");
+      expect(source).not.toContain("bitquery-launches.server");
+      expect(source).not.toContain("readProductionCustomExploreDirectoryV1");
+    }
   });
 });

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -310,7 +310,9 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
     const body = await json(response);
     expect(response.status).toBe(200);
     expect(body).toMatchObject({ total: 12, sort: "market-cap" });
-    expect((body.tokens as ExploreEntry[]).every(
+    expect((body.tokens as Array<ExploreEntry & {
+      valuation?: { status?: string };
+    }>).every(
       (entry) => entry.valuation?.status === "unavailable",
     )).toBe(true);
     expect(response.headers.get("x-programmable-launch-source")).toBe("drpc");

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -13,6 +13,7 @@ import type { ExploreEntry, LauncherToken } from "../lib/tokens";
 
 const mocks = vi.hoisted(() => ({
   readPrimaryRpcExploreEntriesV1: vi.fn(),
+  readBitqueryTokenFdvRankingStrictV1: vi.fn(),
   readBitqueryTokenMarketDataStrictV1: vi.fn(),
   safeBitqueryMarketDataError: vi.fn(() => ({
     name: "BitqueryMarketDataError",
@@ -29,6 +30,8 @@ vi.mock("../lib/market-data/primary-rpc-launches.server", () => ({
 }));
 
 vi.mock("../lib/market-data/bitquery.server", () => ({
+  readBitqueryTokenFdvRankingStrictV1:
+    mocks.readBitqueryTokenFdvRankingStrictV1,
   readBitqueryTokenMarketDataStrictV1:
     mocks.readBitqueryTokenMarketDataStrictV1,
   safeBitqueryMarketDataError: mocks.safeBitqueryMarketDataError,
@@ -156,6 +159,10 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
       async (identities: readonly MarketDataIdentityV1[]) =>
         marketData(identities),
     );
+    mocks.readBitqueryTokenFdvRankingStrictV1.mockImplementation(
+      async (identities: readonly MarketDataIdentityV1[]) =>
+        marketData(identities),
+    );
   });
 
   it("serves dRPC launch identity with current Bitquery FDV", async () => {
@@ -191,11 +198,12 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
       /quicknode|alchemy|stateview|chainlink|subgraph|snapshot/u,
     );
     expect(mocks.readPrimaryRpcExploreEntriesV1).toHaveBeenCalledOnce();
-    expect(mocks.readBitqueryTokenMarketDataStrictV1).toHaveBeenCalledOnce();
-    expect(mocks.readBitqueryTokenMarketDataStrictV1).toHaveBeenCalledWith(
+    expect(mocks.readBitqueryTokenFdvRankingStrictV1).toHaveBeenCalledOnce();
+    expect(mocks.readBitqueryTokenFdvRankingStrictV1).toHaveBeenCalledWith(
       expect.any(Array),
-      expect.objectContaining({ includeStats: false }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
+    expect(mocks.readBitqueryTokenMarketDataStrictV1).not.toHaveBeenCalled();
   });
 
   it("sorts the lowest-FDV alias directly from Bitquery", async () => {
@@ -218,6 +226,11 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
     expect((body.tokens as ExploreEntry[]).map((entry) => entry.id)).toEqual(
       [12, 11, 10].map((index) => entries[index - 1]!.id),
     );
+    expect(mocks.readBitqueryTokenMarketDataStrictV1).toHaveBeenCalledOnce();
+    expect(
+      mocks.readBitqueryTokenMarketDataStrictV1.mock.calls[0]?.[0],
+    ).toHaveLength(3);
+    expect(mocks.readBitqueryTokenFdvRankingStrictV1).not.toHaveBeenCalled();
   });
 
   it("applies search, social filtering, and direct pagination", async () => {
@@ -225,6 +238,9 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
     const focusedBody = await json(focused);
     expect(focusedBody).toMatchObject({ total: 1, totalPages: 1 });
     expect((focusedBody.tokens as ExploreEntry[])[0]?.id).toBe(entries[6]!.id);
+    expect(
+      mocks.readBitqueryTokenMarketDataStrictV1.mock.calls[0]?.[0],
+    ).toHaveLength(1);
 
     const socialPage = await GET(
       request("socials=yes&sort=oldest&page=2&limit=2"),
@@ -235,6 +251,9 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
       entries[5]!.id,
       entries[7]!.id,
     ]);
+    expect(
+      mocks.readBitqueryTokenMarketDataStrictV1.mock.calls[1]?.[0],
+    ).toHaveLength(2);
   });
 
   it.each([
@@ -267,7 +286,7 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
   });
 
   it("returns 503 directly when the strict Bitquery market read fails", async () => {
-    mocks.readBitqueryTokenMarketDataStrictV1.mockRejectedValueOnce(
+    mocks.readBitqueryTokenFdvRankingStrictV1.mockRejectedValueOnce(
       new Error("market unavailable"),
     );
 
@@ -280,10 +299,15 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
     });
   });
 
-  it("returns 503 when Bitquery omits a required dRPC launch market", async () => {
-    mocks.readBitqueryTokenMarketDataStrictV1.mockResolvedValueOnce(new Map());
+  it("keeps a missing ranked market unavailable without misranking it", async () => {
+    mocks.readBitqueryTokenFdvRankingStrictV1.mockResolvedValueOnce(new Map());
     const response = await GET(request("sort=market-cap"));
-    expect(response.status).toBe(503);
+    const body = await json(response);
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ total: 12, sort: "market-cap" });
+    expect((body.tokens as ExploreEntry[]).every(
+      (entry) => entry.valuation?.status === "unavailable",
+    )).toBe(true);
     expect(response.headers.get("x-programmable-launch-source")).toBe("drpc");
     expect(response.headers.get("x-programmable-market-source")).toBe("bitquery");
   });

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -192,6 +192,10 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
     );
     expect(mocks.readPrimaryRpcExploreEntriesV1).toHaveBeenCalledOnce();
     expect(mocks.readBitqueryTokenMarketDataStrictV1).toHaveBeenCalledOnce();
+    expect(mocks.readBitqueryTokenMarketDataStrictV1).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ includeStats: false }),
+    );
   });
 
   it("sorts the lowest-FDV alias directly from Bitquery", async () => {

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -457,7 +457,7 @@ describe("Explore financial-data semantics", () => {
     expect(published).not.toHaveProperty("tokenPriceQuoteWad");
   });
 
-  it("preserves exact historical detail but removes FDV beyond the public stale ceiling", () => {
+  it("keeps FDV unavailable when exact-pool liquidity evidence is absent", () => {
     const poolId = `0x${"34".repeat(32)}` as const;
     const marketData = {
       schemaVersion: "programmable.market-data.v1",
@@ -495,12 +495,9 @@ describe("Explore financial-data semantics", () => {
       marketData,
     );
 
-    expect(entry.valuation).toMatchObject({
-      status: "available",
-      source: "bitquery",
-      freshness: "stale",
-      metric: "fdv",
-      supplyBasis: "total",
+    expect(entry.valuation).toEqual({
+      status: "unavailable",
+      reason: "source-unavailable",
     });
     expect(valuationSortValue(entry)).toBeNull();
     expect(publicExploreEntryV1(entry)).not.toHaveProperty("fdvUsdWad");
@@ -515,11 +512,11 @@ describe("Explore financial-data semantics", () => {
     );
     expect(publicEntry.valuation).toEqual({
       status: "unavailable",
-      reason: "price-unavailable",
+      reason: "source-unavailable",
     });
     expect(publicEntry.marketData?.pools[0]?.valuation).toEqual({
       status: "unavailable",
-      reason: "price-unavailable",
+      reason: "source-unavailable",
     });
     expect(valuationSortValue(publicEntry)).toBeNull();
   });

--- a/tests/primary-rpc-launch-catalog.test.ts
+++ b/tests/primary-rpc-launch-catalog.test.ts
@@ -14,7 +14,10 @@ import stockV2Manifest from
   "../contracts/deployments/mainnet-stock-paired-v2.json";
 import stockV3Manifest from
   "../contracts/deployments/mainnet-stock-paired-v3.json";
+import { rpcProviderCommitment } from
+  "../lib/data-pipeline/rpc-provider-commitments";
 import {
+  PRIMARY_RPC_LAUNCH_CATALOG_BUDGET_MS,
   PrimaryRpcLaunchCatalogError,
   readPrimaryRpcExploreEntriesV1,
   safePrimaryRpcLaunchCatalogError,
@@ -33,6 +36,7 @@ const VAULT = address(903);
 
 type FixtureRelease = Readonly<{
   launcher: `0x${string}`;
+  ethLaunchCoordinator: `0x${string}` | null;
   hook: `0x${string}`;
   blockNumber: bigint;
   eventName:
@@ -103,16 +107,25 @@ describe("single-primary dRPC launch catalog", () => {
   it("reads all five canonical releases from bounded sparse log ranges", async () => {
     const queries: PrimaryRpcLogQuery[] = [];
     const logs = RELEASES.flatMap(releaseLogs);
+    let activeLogWindows = 0;
+    let maximumActiveLogWindows = 0;
     const client = mockClient({
       getLogs: async (query) => {
         queries.push(query);
-        if (query.toBlock - query.fromBlock + 1n > 4_096n) {
-          throw new Error("provider range limit");
-        }
-        return logs.filter((log) =>
-          log.blockNumber >= query.fromBlock &&
-          log.blockNumber <= query.toBlock
+        activeLogWindows += 1;
+        maximumActiveLogWindows = Math.max(
+          maximumActiveLogWindows,
+          activeLogWindows,
         );
+        try {
+          await Promise.resolve();
+          return logs.filter((log) =>
+            log.blockNumber >= query.fromBlock &&
+            log.blockNumber <= query.toBlock
+          ).reverse();
+        } finally {
+          activeLogWindows -= 1;
+        }
       },
     });
 
@@ -140,25 +153,39 @@ describe("single-primary dRPC launch catalog", () => {
     )).toHaveLength(3);
     expect(tokenEntries.filter((entry) =>
       entry.launchModel === "stock-paired"
-    ).every((entry) => entry.creatorAddress === undefined)).toBe(true);
-    expect(tokenEntries.filter((entry) =>
-      entry.launchModel === "classic"
     ).every((entry) => entry.creatorAddress === CREATOR)).toBe(true);
+    expect(tokenEntries.every((entry) => entry.creatorAddress === CREATOR))
+      .toBe(true);
     expect(queries.length).toBeGreaterThan(1);
+    expect(maximumActiveLogWindows).toBeGreaterThan(1);
+    expect(maximumActiveLogWindows).toBeLessThanOrEqual(6);
     expect(queries.some((query) =>
       query.toBlock - query.fromBlock + 1n === 4_096n
     )).toBe(true);
+    const orderedQueries = [...queries].sort((left, right) =>
+      left.fromBlock < right.fromBlock ? -1 : 1
+    );
+    for (let index = 1; index < orderedQueries.length; index += 1) {
+      expect(orderedQueries[index]!.fromBlock).toBe(
+        orderedQueries[index - 1]!.toBlock + 1n,
+      );
+    }
     for (const query of queries) {
-      expect(query.address).toHaveLength(5);
-      expect(query.events).toHaveLength(6);
+      expect(query.toBlock - query.fromBlock + 1n).toBeLessThanOrEqual(4_096n);
+      expect(query.address).toHaveLength(8);
+      expect(query.events).toHaveLength(7);
       expect(query.strict).toBe(true);
     }
   });
 
-  it("maps an exhausted primary-provider range failure to a safe 503", async () => {
+  it("bounds an exhausted primary-provider window to two attempts", async () => {
+    let attempts = 0;
+    const oneWindowHead = BigInt(classicV2Manifest.deploymentBlock + 100);
     const error = await readPrimaryRpcExploreEntriesV1({
       client: mockClient({
+        getBlockNumber: async () => oneWindowHead,
         getLogs: async () => {
+          attempts += 1;
           throw new Error("https://lb.drpc.live/ethereum/private-key");
         },
       }),
@@ -173,6 +200,7 @@ describe("single-primary dRPC launch catalog", () => {
       status: 503,
     });
     expect(JSON.stringify(error)).not.toContain("private-key");
+    expect(attempts).toBe(2);
   });
 
   it("fails configuration closed before making a public or secondary request", async () => {
@@ -220,7 +248,7 @@ describe("single-primary dRPC launch catalog", () => {
     expect(result.entries).toHaveLength(1);
     expect(result.entries[0]).toMatchObject({ tokenAddress: target.token });
     expect(queries.length).toBeGreaterThan(0);
-    expect(queries.every((query) => query.address.length === 5)).toBe(true);
+    expect(queries.every((query) => query.address.length === 8)).toBe(true);
     expect(blockReads).toEqual([HEAD, target.blockNumber]);
     expect(contractReads).toHaveLength(7);
     expect(new Set(contractReads.map((read) => read.address))).toEqual(
@@ -231,6 +259,154 @@ describe("single-primary dRPC launch catalog", () => {
     )).toEqual([
       expect.objectContaining({ address: target.token }),
     ]);
+  });
+
+  it("returns the same deterministic catalog when RPC pages arrive reversed", async () => {
+    const logs = RELEASES.flatMap(releaseLogs);
+    const read = (reverse: boolean) => readPrimaryRpcExploreEntriesV1({
+      client: mockClient({
+        getLogs: async (query) => {
+          const page = logs.filter((log) =>
+            log.blockNumber >= query.fromBlock &&
+            log.blockNumber <= query.toBlock
+          );
+          return reverse ? page.reverse() : page;
+        },
+      }),
+      now: new Date("2026-08-14T12:00:00.000Z"),
+    });
+
+    const [forward, reversed] = await Promise.all([read(false), read(true)]);
+
+    expect(reversed).toEqual(forward);
+  });
+
+  it("rejects a duplicate canonical event coordinate", async () => {
+    const logs = RELEASES.flatMap(releaseLogs);
+    const error = await readPrimaryRpcExploreEntriesV1({
+      client: mockClient({
+        getLogs: async (query) => logs.concat(logs[0]!).filter((log) =>
+          log.blockNumber >= query.fromBlock &&
+          log.blockNumber <= query.toBlock
+        ),
+      }),
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(PrimaryRpcLaunchCatalogError);
+    expect(safePrimaryRpcLaunchCatalogError(error)).toMatchObject({
+      category: "integrity",
+      phase: "logs",
+      status: 503,
+    });
+  });
+
+  it.each(["token", "quoteAsset", "launchHash"] as const)(
+    "fails closed when Stock-Paired creator identity %s mismatches",
+    async (field) => {
+      const target = RELEASES.find((release) => release.model === "stock")!;
+      const logs = RELEASES.flatMap(releaseLogs).map((log) =>
+        log.eventName === "StockPairedEthTokenLaunched" &&
+          log.args.token === target.token
+          ? {
+              ...log,
+              args: {
+                ...log.args,
+                [field]: field === "launchHash" ? bytes32(999) : address(999),
+              },
+            }
+          : log
+      );
+      const error = await readPrimaryRpcExploreEntriesV1({
+        client: mockClient({
+          getLogs: async (query) => logs.filter((log) =>
+            log.blockNumber >= query.fromBlock &&
+            log.blockNumber <= query.toBlock
+          ),
+        }),
+      }).catch((value: unknown) => value);
+
+      expect(error).toBeInstanceOf(PrimaryRpcLaunchCatalogError);
+      expect(safePrimaryRpcLaunchCatalogError(error)).toMatchObject({
+        category: "integrity",
+        phase: "logs",
+        status: 503,
+      });
+    },
+  );
+
+  it("enforces one hard end-to-end budget even when a client ignores aborts", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = readPrimaryRpcExploreEntriesV1({
+        client: mockClient({
+          getBlockNumber: () => new Promise<bigint>(() => {}),
+        }),
+      }).catch((value: unknown) => value);
+
+      await vi.advanceTimersByTimeAsync(
+        PRIMARY_RPC_LAUNCH_CATALOG_BUDGET_MS,
+      );
+      const error = await pending;
+
+      expect(error).toBeInstanceOf(PrimaryRpcLaunchCatalogError);
+      expect(safePrimaryRpcLaunchCatalogError(error)).toEqual({
+        name: "PrimaryRpcLaunchCatalogError",
+        category: "transport",
+        phase: "head",
+        status: 503,
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("passes cooperative cancellation into the viem HTTP fetch", async () => {
+    const rpcUrl = "https://lb.drpc.live/ethereum/test-key-12345678";
+    const environment = {
+      PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER: "drpc",
+      PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL: rpcUrl,
+      PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT:
+        rpcProviderCommitment("endpoint", rpcUrl),
+    };
+    let startFetch!: (signal: AbortSignal | null) => void;
+    const fetchStarted = new Promise<AbortSignal | null>((resolve) => {
+      startFetch = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn(
+      (_input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal ?? null;
+        startFetch(signal);
+        return new Promise<Response>((_resolve, reject) => {
+          const abort = () => reject(new Error("aborted"));
+          if (signal?.aborted) abort();
+          else signal?.addEventListener("abort", abort, { once: true });
+        });
+      },
+    ));
+    const controller = new AbortController();
+    try {
+      const pending = readPrimaryRpcExploreEntriesV1({
+        environment,
+        signal: controller.signal,
+      }).catch((value: unknown) => value);
+      const fetchSignal = await fetchStarted;
+
+      expect(fetchSignal).toBeInstanceOf(AbortSignal);
+      expect(fetchSignal?.aborted).toBe(false);
+      controller.abort();
+      const error = await pending;
+
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(safePrimaryRpcLaunchCatalogError(error)).toMatchObject({
+        category: "transport",
+        phase: "head",
+        status: 503,
+      });
+    } finally {
+      controller.abort();
+      vi.unstubAllGlobals();
+    }
   });
 
   it("normalizes synchronous runtime failures with a safe phase and 503", async () => {
@@ -320,6 +496,10 @@ function fixtureRelease(input: Readonly<{
   return {
     launcher: manifest.addresses[input.launcherKey]!.toLowerCase() as
       `0x${string}`,
+    ethLaunchCoordinator: input.model === "stock"
+      ? manifest.addresses.ethLaunchCoordinator!.toLowerCase() as
+        `0x${string}`
+      : null,
     hook: manifest.addresses.feeHook!.toLowerCase() as `0x${string}`,
     blockNumber: BigInt(input.startBlock + 10),
     eventName: input.eventName,
@@ -350,7 +530,7 @@ function releaseLogs(release: FixtureRelease) {
     positionTokenId: 7n,
     launchHash: release.launchHash,
     creator: CREATOR,
-    deployer: CREATOR,
+    deployer: release.ethLaunchCoordinator ?? CREATOR,
     quoteAsset: QUOTE,
     totalSwapFeeBps: 100n,
     buySwapFeeBps: 90n,
@@ -368,7 +548,7 @@ function releaseLogs(release: FixtureRelease) {
     lpFeePips: 3_000,
     launchHash: release.launchHash,
   };
-  return [
+  const launcherLogs = [
     { ...shared, eventName: release.eventName, logIndex: 5, args: launchArgs },
     {
       ...shared,
@@ -377,6 +557,26 @@ function releaseLogs(release: FixtureRelease) {
       args: liquidityArgs,
     },
   ];
+  return release.ethLaunchCoordinator === null
+    ? launcherLogs
+    : [
+        ...launcherLogs,
+        {
+          ...shared,
+          address: release.ethLaunchCoordinator,
+          eventName: "StockPairedEthTokenLaunched",
+          logIndex: 8,
+          args: {
+            creator: CREATOR,
+            token: release.token,
+            quoteAsset: QUOTE,
+            initialBuyEthAmount: 1n,
+            initialBuyQuoteAmount: 2n,
+            initialBuyTokenAmount: 3n,
+            launchHash: release.launchHash,
+          },
+        },
+      ];
 }
 
 function address(value: number): `0x${string}` {

--- a/tests/primary-rpc-launch-catalog.test.ts
+++ b/tests/primary-rpc-launch-catalog.test.ts
@@ -1,0 +1,319 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import classicV2Manifest from
+  "../contracts/deployments/mainnet-classic-v2.json";
+import classicV3Manifest from
+  "../contracts/deployments/mainnet-classic-v3.json";
+import stockV1Manifest from
+  "../contracts/deployments/mainnet-stock-paired-v1.json";
+import stockV2Manifest from
+  "../contracts/deployments/mainnet-stock-paired-v2.json";
+import stockV3Manifest from
+  "../contracts/deployments/mainnet-stock-paired-v3.json";
+import {
+  PrimaryRpcLaunchCatalogError,
+  readPrimaryRpcExploreEntriesV1,
+  safePrimaryRpcLaunchCatalogError,
+  type PrimaryRpcLaunchCatalogClient,
+  type PrimaryRpcLogQuery,
+} from "../lib/market-data/primary-rpc-launches.server";
+import type { CanonicalTokenExploreEntry } from "../lib/tokens";
+
+const HEAD = 25_650_000n;
+const HEAD_HASH = bytes32(HEAD);
+const QUOTE = address(900);
+const RECIPIENT = address(901);
+const CREATOR = address(902);
+const VAULT = address(903);
+
+type FixtureRelease = Readonly<{
+  launcher: `0x${string}`;
+  hook: `0x${string}`;
+  blockNumber: bigint;
+  eventName:
+    | "MemeTokenLaunched"
+    | "MemeTokenLaunchedV2"
+    | "StockPairedTokenLaunched";
+  liquidityEventName:
+    | "MemeLiquidityConfigured"
+    | "MemeLiquidityConfiguredV2"
+    | "StockPairedLiquidityConfigured";
+  model: "classic-v2" | "classic-v3" | "stock";
+  token: `0x${string}`;
+  poolId: `0x${string}`;
+  launchHash: `0x${string}`;
+  transactionHash: `0x${string}`;
+}>;
+
+const RELEASES: readonly FixtureRelease[] = [
+  fixtureRelease({
+    manifest: classicV2Manifest,
+    launcherKey: "memeLauncher",
+    startBlock: classicV2Manifest.deploymentBlock,
+    eventName: "MemeTokenLaunched",
+    liquidityEventName: "MemeLiquidityConfigured",
+    model: "classic-v2",
+    sequence: 1,
+  }),
+  fixtureRelease({
+    manifest: classicV3Manifest,
+    launcherKey: "launcher",
+    startBlock:
+      classicV3Manifest.sourceVerification.contracts.launcher.deploymentBlock,
+    eventName: "MemeTokenLaunchedV2",
+    liquidityEventName: "MemeLiquidityConfiguredV2",
+    model: "classic-v3",
+    sequence: 2,
+  }),
+  fixtureRelease({
+    manifest: stockV1Manifest,
+    launcherKey: "launcher",
+    startBlock: stockV1Manifest.startBlock,
+    eventName: "StockPairedTokenLaunched",
+    liquidityEventName: "StockPairedLiquidityConfigured",
+    model: "stock",
+    sequence: 3,
+  }),
+  fixtureRelease({
+    manifest: stockV2Manifest,
+    launcherKey: "launcher",
+    startBlock: stockV2Manifest.startBlock,
+    eventName: "StockPairedTokenLaunched",
+    liquidityEventName: "StockPairedLiquidityConfigured",
+    model: "stock",
+    sequence: 4,
+  }),
+  fixtureRelease({
+    manifest: stockV3Manifest,
+    launcherKey: "launcher",
+    startBlock: stockV3Manifest.startBlock,
+    eventName: "StockPairedTokenLaunched",
+    liquidityEventName: "StockPairedLiquidityConfigured",
+    model: "stock",
+    sequence: 5,
+  }),
+];
+
+describe("single-primary dRPC launch catalog", () => {
+  it("reads all five canonical releases from bounded sparse log ranges", async () => {
+    const queries: PrimaryRpcLogQuery[] = [];
+    const logs = RELEASES.flatMap(releaseLogs);
+    const client = mockClient({
+      getLogs: async (query) => {
+        queries.push(query);
+        if (query.toBlock - query.fromBlock + 1n > 4_096n) {
+          throw new Error("provider range limit");
+        }
+        return logs.filter((log) =>
+          log.blockNumber >= query.fromBlock &&
+          log.blockNumber <= query.toBlock
+        );
+      },
+    });
+
+    const result = await readPrimaryRpcExploreEntriesV1({
+      client,
+      now: new Date("2026-08-14T12:00:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      source: "drpc",
+      generatedAt: "2026-08-14T12:00:00.000Z",
+      asOfBlock: HEAD.toString(),
+      asOfBlockHash: HEAD_HASH,
+    });
+    expect(result.entries).toHaveLength(5);
+    const tokenEntries = result.entries.filter(
+      (entry): entry is CanonicalTokenExploreEntry =>
+        entry.exploreKind === "token",
+    );
+    expect(new Set(tokenEntries.map((entry) => entry.launchModel))).toEqual(
+      new Set(["classic", "stock-paired"]),
+    );
+    expect(tokenEntries.filter((entry) =>
+      entry.launchModel === "stock-paired"
+    )).toHaveLength(3);
+    expect(tokenEntries.filter((entry) =>
+      entry.launchModel === "stock-paired"
+    ).every((entry) => entry.creatorAddress === undefined)).toBe(true);
+    expect(tokenEntries.filter((entry) =>
+      entry.launchModel === "classic"
+    ).every((entry) => entry.creatorAddress === CREATOR)).toBe(true);
+    expect(queries.length).toBeGreaterThan(1);
+    expect(queries.some((query) =>
+      query.toBlock - query.fromBlock + 1n === 4_096n
+    )).toBe(true);
+    for (const query of queries) {
+      expect(query.address).toHaveLength(5);
+      expect(query.events).toHaveLength(6);
+      expect(query.strict).toBe(true);
+    }
+  });
+
+  it("maps an exhausted primary-provider range failure to a safe 503", async () => {
+    const error = await readPrimaryRpcExploreEntriesV1({
+      client: mockClient({
+        getLogs: async () => {
+          throw new Error("https://lb.drpc.live/ethereum/private-key");
+        },
+      }),
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(PrimaryRpcLaunchCatalogError);
+    expect((error as PrimaryRpcLaunchCatalogError).category).toBe("transport");
+    expect(safePrimaryRpcLaunchCatalogError(error)).toEqual({
+      name: "PrimaryRpcLaunchCatalogError",
+      category: "transport",
+      status: 503,
+    });
+    expect(JSON.stringify(error)).not.toContain("private-key");
+  });
+
+  it("fails configuration closed before making a public or secondary request", async () => {
+    const error = await readPrimaryRpcExploreEntriesV1({
+      environment: {},
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(PrimaryRpcLaunchCatalogError);
+    expect((error as PrimaryRpcLaunchCatalogError).category).toBe(
+      "configuration",
+    );
+    expect(safePrimaryRpcLaunchCatalogError(error).status).toBe(503);
+  });
+
+  it("contains no alternate catalog or secondary-provider dependency", () => {
+    const source = readFileSync(
+      new URL(
+        "../lib/market-data/primary-rpc-launches.server.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    for (const forbidden of [
+      "productionMainnetRpcPair",
+      "quicknode",
+      "alchemy",
+      "Bitquery",
+      "StateView",
+      "subgraph",
+      "@vercel/blob",
+    ]) {
+      expect(source).not.toContain(forbidden);
+    }
+  });
+});
+
+function mockClient(overrides: Partial<PrimaryRpcLaunchCatalogClient> = {}):
+  PrimaryRpcLaunchCatalogClient {
+  return {
+    getBlockNumber: async () => HEAD,
+    getBlock: async ({ blockNumber }) => ({
+      number: blockNumber,
+      hash: bytes32(blockNumber),
+      timestamp: 1_800_000_000n + blockNumber - 25_600_000n,
+    }),
+    getLogs: async () => [],
+    readContract: async ({ address: token, functionName }) => {
+      if (functionName === "name") return `Token ${token.slice(-4)}`;
+      if (functionName === "symbol") return `T${token.slice(-3)}`;
+      if (functionName === "decimals") return 18;
+      if (token === QUOTE) {
+        throw new Error("quote asset does not implement metadata()");
+      }
+      return [
+        `Description ${token.slice(-4)}`,
+        "https://programmable.sh/",
+        "https://programmable.sh/token.png",
+        "0x",
+      ];
+    },
+    ...overrides,
+  };
+}
+
+function fixtureRelease(input: Readonly<{
+  manifest: unknown;
+  launcherKey: "launcher" | "memeLauncher";
+  startBlock: number;
+  eventName: FixtureRelease["eventName"];
+  liquidityEventName: FixtureRelease["liquidityEventName"];
+  model: FixtureRelease["model"];
+  sequence: number;
+}>): FixtureRelease {
+  const manifest = input.manifest as Readonly<{
+    addresses: Readonly<Record<string, string>>;
+  }>;
+  return {
+    launcher: manifest.addresses[input.launcherKey]!.toLowerCase() as
+      `0x${string}`,
+    hook: manifest.addresses.feeHook!.toLowerCase() as `0x${string}`,
+    blockNumber: BigInt(input.startBlock + 10),
+    eventName: input.eventName,
+    liquidityEventName: input.liquidityEventName,
+    model: input.model,
+    token: address(100 + input.sequence),
+    poolId: bytes32(200 + input.sequence),
+    launchHash: bytes32(300 + input.sequence),
+    transactionHash: bytes32(400 + input.sequence),
+  };
+}
+
+function releaseLogs(release: FixtureRelease) {
+  const shared = {
+    address: release.launcher,
+    blockNumber: release.blockNumber,
+    blockHash: bytes32(release.blockNumber),
+    transactionHash: release.transactionHash,
+    transactionIndex: 1,
+    removed: false,
+  } as const;
+  const launchArgs = {
+    token: release.token,
+    poolId: release.poolId,
+    feeHook: release.hook,
+    rewardVault: VAULT,
+    positionRecipient: RECIPIENT,
+    positionTokenId: 7n,
+    launchHash: release.launchHash,
+    creator: CREATOR,
+    deployer: CREATOR,
+    quoteAsset: QUOTE,
+    totalSwapFeeBps: 100n,
+    buySwapFeeBps: 90n,
+    sellSwapFeeBps: 110n,
+  };
+  const liquidityArgs = {
+    token: release.token,
+    ...(release.model === "stock" ? { quoteAsset: QUOTE } : {}),
+    totalSupply: 1_000_000n * 10n ** 18n,
+    tokenLiquidityAmount: 500_000n * 10n ** 18n,
+    lockedTokenDust: 1n,
+    initialTick: -100,
+    tickLower: -200,
+    tickUpper: 200,
+    lpFeePips: 3_000,
+    launchHash: release.launchHash,
+  };
+  return [
+    { ...shared, eventName: release.eventName, logIndex: 5, args: launchArgs },
+    {
+      ...shared,
+      eventName: release.liquidityEventName,
+      logIndex: 6,
+      args: liquidityArgs,
+    },
+  ];
+}
+
+function address(value: number): `0x${string}` {
+  return `0x${value.toString(16).padStart(40, "0")}`;
+}
+
+function bytes32(value: bigint | number): `0x${string}` {
+  return `0x${BigInt(value).toString(16).padStart(64, "0")}`;
+}

--- a/tests/primary-rpc-launch-catalog.test.ts
+++ b/tests/primary-rpc-launch-catalog.test.ts
@@ -18,6 +18,7 @@ import {
   PrimaryRpcLaunchCatalogError,
   readPrimaryRpcExploreEntriesV1,
   safePrimaryRpcLaunchCatalogError,
+  type PrimaryRpcContractRead,
   type PrimaryRpcLaunchCatalogClient,
   type PrimaryRpcLogQuery,
 } from "../lib/market-data/primary-rpc-launches.server";
@@ -168,6 +169,7 @@ describe("single-primary dRPC launch catalog", () => {
     expect(safePrimaryRpcLaunchCatalogError(error)).toEqual({
       name: "PrimaryRpcLaunchCatalogError",
       category: "transport",
+      phase: "logs",
       status: 503,
     });
     expect(JSON.stringify(error)).not.toContain("private-key");
@@ -183,6 +185,73 @@ describe("single-primary dRPC launch catalog", () => {
       "configuration",
     );
     expect(safePrimaryRpcLaunchCatalogError(error).status).toBe(503);
+  });
+
+  it("hydrates only the requested token after the complete sparse log scan", async () => {
+    const target = RELEASES[3]!;
+    const logs = RELEASES.flatMap(releaseLogs);
+    const queries: PrimaryRpcLogQuery[] = [];
+    const blockReads: bigint[] = [];
+    const contractReads: PrimaryRpcContractRead[] = [];
+    const defaults = mockClient();
+    const client = mockClient({
+      getLogs: async (query) => {
+        queries.push(query);
+        return logs.filter((log) =>
+          log.blockNumber >= query.fromBlock &&
+          log.blockNumber <= query.toBlock
+        );
+      },
+      getBlock: async (input) => {
+        blockReads.push(input.blockNumber);
+        return defaults.getBlock(input);
+      },
+      readContract: async (input) => {
+        contractReads.push(input);
+        return defaults.readContract(input);
+      },
+    });
+
+    const result = await readPrimaryRpcExploreEntriesV1({
+      client,
+      requestedTokenAddress: target.token,
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({ tokenAddress: target.token });
+    expect(queries.length).toBeGreaterThan(0);
+    expect(queries.every((query) => query.address.length === 5)).toBe(true);
+    expect(blockReads).toEqual([HEAD, target.blockNumber]);
+    expect(contractReads).toHaveLength(7);
+    expect(new Set(contractReads.map((read) => read.address))).toEqual(
+      new Set([target.token, QUOTE]),
+    );
+    expect(contractReads.filter((read) =>
+      read.functionName === "metadata"
+    )).toEqual([
+      expect.objectContaining({ address: target.token }),
+    ]);
+  });
+
+  it("normalizes synchronous runtime failures with a safe phase and 503", async () => {
+    const error = await readPrimaryRpcExploreEntriesV1({
+      client: mockClient(),
+      now: new Date(Number.NaN),
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(PrimaryRpcLaunchCatalogError);
+    expect(safePrimaryRpcLaunchCatalogError(error)).toEqual({
+      name: "PrimaryRpcLaunchCatalogError",
+      category: "runtime",
+      phase: "selection",
+      status: 503,
+    });
+    expect(safePrimaryRpcLaunchCatalogError(new Error("foreign"))).toEqual({
+      name: "LaunchCatalogError",
+      category: "unexpected",
+      phase: "external",
+      status: 503,
+    });
   });
 
   it("contains no alternate catalog or secondary-provider dependency", () => {

--- a/tests/public-route-handler-wiring.test.ts
+++ b/tests/public-route-handler-wiring.test.ts
@@ -1,5 +1,8 @@
 import { NextRequest } from "next/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { rpcProviderCommitment } from
+  "../lib/data-pipeline/rpc-provider-commitments";
 
 vi.mock("server-only", () => ({}));
 
@@ -8,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     override name = "AlchemyCreatorProfileIntegrityError";
   },
   coordinatePublicRouteRead: vi.fn(),
+  createPublicClient: vi.fn(),
   getWebsiteChartOnchainDeployment: vi.fn(),
   preparePublicRouteRequest: vi.fn(
     async (value: URLSearchParams, headers: Headers, _route: string) => {
@@ -41,6 +45,48 @@ const mocks = vi.hoisted(() => ({
   readAlchemyExploreModel: vi.fn(),
   safeAlchemyError: vi.fn((error) => error),
 }));
+
+const rpcFixtures = vi.hoisted(() => {
+  const runtimeCodes = {
+    "0x01": "0xa459ee6574d8bbd40ddcf9737dc5d1063adb3abbc11d9f367350c7f2a3cf738b",
+    "0x02": "0x60fd96af952730792036d43d806046675817a5a2de609d87c06203a8d6037650",
+    "0x03": "0xd229555c79c61874549a1991c43df172104e1db3087ba8fca8804675b7440d36",
+    "0x04": "0x274e29fb8d19f0607533ac7582827db0236ab546bb393d52049229b2ffe74381",
+  } as const;
+  const codesByAddress = {
+    "0x51d702731db281ee223904a4663e05bfca26c775": "0x01",
+    "0x48bb2672c7fd2a12e7fb5d46c441ccd3726520cc": "0x02",
+    "0xd240d06f8586eb799f20056054e5b527405e6bad": "0x03",
+    "0x025a386eaa79f6067d29848fd05ccc71beab20cc": "0x04",
+  } as const;
+  const client = {
+    getBlockNumber: vi.fn(async () => 25_624_200n),
+    getBlock: vi.fn(async ({ blockNumber }: { blockNumber: bigint }) => ({
+      hash: `0x${blockNumber.toString(16).padStart(64, "0")}`,
+      timestamp: 1_786_704_000n,
+    })),
+    getCode: vi.fn(async ({ address }: { address: string }) =>
+      codesByAddress[address.toLowerCase() as keyof typeof codesByAddress] ?? "0x"
+    ),
+    getLogs: vi.fn(async (_input?: unknown) => {
+      void _input;
+      return [] as unknown[];
+    }),
+    readContract: vi.fn(),
+  };
+  return { client, runtimeCodes };
+});
+
+vi.mock("viem", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("viem")>();
+  return {
+    ...actual,
+    createPublicClient: mocks.createPublicClient,
+    keccak256: vi.fn((value: keyof typeof rpcFixtures.runtimeCodes) =>
+      rpcFixtures.runtimeCodes[value] ?? actual.keccak256(value)
+    ),
+  };
+});
 
 const fixtures = vi.hoisted(() => {
   const discoveryScope = [
@@ -96,15 +142,116 @@ const TRANSACTION = `0x${"22".repeat(32)}`;
 describe("public route coordinator wiring", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    rpcFixtures.client.getBlockNumber.mockResolvedValue(25_624_200n);
+    rpcFixtures.client.getBlock.mockImplementation(
+      async ({ blockNumber }: { blockNumber: bigint }) => ({
+        hash: `0x${blockNumber.toString(16).padStart(64, "0")}`,
+        timestamp: 1_786_704_000n,
+      }),
+    );
+    rpcFixtures.client.getLogs.mockResolvedValue([]);
+    mocks.createPublicClient.mockReturnValue(rpcFixtures.client);
+    const drpc = "https://lb.drpc.live/ethereum/drpc-profile-key";
+    vi.stubEnv("PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER", "drpc");
+    vi.stubEnv("PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL", drpc);
+    vi.stubEnv(
+      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
+      rpcProviderCommitment("endpoint", drpc),
+    );
   });
 
-  it("reports Bitquery as the sole creator profile read source", async () => {
-    mocks.readBitqueryCreatorProfile.mockResolvedValue({
-      status: "ready",
-      account: ACCOUNT,
-      tokens: [],
+  it("derives current, generated and claimed totals from sparse dRPC state", async () => {
+    const launcher = "0xD240D06f8586eB799f20056054e5b527405E6bAd";
+    const hook = "0x025a386eAa79f6067d29848FD05ccC71bEAb20CC";
+    const token = "0x3333333333333333333333333333333333333333";
+    const poolId = `0x${"44".repeat(32)}`;
+    const transactionHash = `0x${"55".repeat(32)}`;
+    rpcFixtures.client.getLogs.mockImplementation(async (inputValue?: unknown) => {
+      const input = inputValue as {
+        address: string;
+        event: { name: string };
+      };
+      if (
+        input.address.toLowerCase() === launcher.toLowerCase() &&
+        input.event.name === "MemeTokenLaunched"
+      ) {
+        return [{
+          removed: false,
+          blockNumber: 25_624_150n,
+          transactionHash,
+          transactionIndex: 2,
+          logIndex: 3,
+          args: {
+            creator: ACCOUNT,
+            token,
+            poolId,
+            feeHook: hook,
+            positionRecipient: ACCOUNT,
+            positionTokenId: 7n,
+            totalSwapFeeBps: 100,
+            launchHash: `0x${"66".repeat(32)}`,
+          },
+        }];
+      }
+      if (
+        input.address.toLowerCase() === hook.toLowerCase() &&
+        input.event.name === "CreatorFeesClaimed"
+      ) {
+        return [{
+          removed: false,
+          blockNumber: 25_624_160n,
+          transactionHash: `0x${"77".repeat(32)}`,
+          transactionIndex: 1,
+          logIndex: 4,
+          args: {
+            poolId,
+            creator: ACCOUNT,
+            recipient: ACCOUNT,
+            caller: ACCOUNT,
+            amount: 40n,
+          },
+        }];
+      }
+      return [];
+    });
+    rpcFixtures.client.readContract.mockImplementation(async (input: {
+      functionName: string;
+    }) => {
+      if (input.functionName === "name") return "dRPC Token";
+      if (input.functionName === "symbol") return "DRPC";
+      if (input.functionName === "poolFeeConfig") {
+        return [ACCOUNT, launcher, 100, true, 60n];
+      }
+      throw new Error(`Unexpected read ${input.functionName}`);
     });
 
+    const response = await creatorProfile(new NextRequest(
+      `http://localhost/api/explore/profile?account=${ACCOUNT}`,
+    ));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ready",
+      account: ACCOUNT,
+      tokens: [{ tokenAddress: token, creatorFeesAccruedWei: "60" }],
+      pools: [{
+        tokenAddress: token,
+        claimableCreatorFeesWei: "60",
+        generatedCreatorFeesWei: "100",
+      }],
+      claims: [{ amountWei: "40", tokenAddress: token }],
+      totals: {
+        claimableWei: "60",
+        generatedWei: "100",
+        claimedWei: "40",
+      },
+    });
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("reports the single committed dRPC creator profile source", async () => {
     const response = await creatorProfile(
       new NextRequest(
         `http://localhost/api/explore/profile?account=${ACCOUNT}`,
@@ -112,24 +259,27 @@ describe("public route coordinator wiring", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.readBitqueryCreatorProfile).toHaveBeenCalledWith(ACCOUNT);
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+    expect(mocks.readBitqueryCreatorProfile).not.toHaveBeenCalled();
     expect(mocks.readAlchemyCreatorProfile).not.toHaveBeenCalled();
     expect(mocks.coordinatePublicRouteRead).not.toHaveBeenCalled();
     expect(response.headers.get("Cache-Control")).toBe(
       "private, max-age=0, s-maxage=15",
     );
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
-      "bitquery-events",
+      "drpc",
     );
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "bitquery",
+      "drpc",
     );
-    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBeNull();
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
+      "drpc-primary",
+    );
   });
 
-  it("fails the route closed when the Bitquery read fails", async () => {
-    mocks.readBitqueryCreatorProfile.mockRejectedValue(
-      new Error("Bitquery unavailable"),
+  it("fails closed with 503 when the sole dRPC read fails", async () => {
+    rpcFixtures.client.getBlockNumber.mockRejectedValueOnce(
+      new Error("dRPC unavailable"),
     );
 
     const response = await creatorProfile(
@@ -147,11 +297,14 @@ describe("public route coordinator wiring", () => {
         message: "Onchain creator data is temporarily unavailable",
       },
     });
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+    expect(mocks.readBitqueryCreatorProfile).not.toHaveBeenCalled();
   });
 
-  it("keeps creator provider failures temporary", async () => {
-    mocks.readBitqueryCreatorProfile.mockRejectedValue(
-      new Error("operational provider unavailable"),
+  it("fails closed before transport on a primary commitment mismatch", async () => {
+    vi.stubEnv(
+      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
+      `0x${"00".repeat(32)}`,
     );
 
     const response = await creatorProfile(
@@ -169,6 +322,7 @@ describe("public route coordinator wiring", () => {
         message: "Onchain creator data is temporarily unavailable",
       },
     });
+    expect(mocks.createPublicClient).not.toHaveBeenCalled();
   });
 
   it("wires Stock-Paired confirmation through the shared launch lookup gate", async () => {

--- a/tests/stock-paired-action-activation.test.ts
+++ b/tests/stock-paired-action-activation.test.ts
@@ -45,6 +45,7 @@ const configurationHash = `0x${"bb".repeat(32)}` as Hex;
 
 const release = {
   internalContractRelease: "stock-paired-v1" as const,
+  startBlock: 100,
   addresses: {
     feeHook: hook,
     feeSplitVaultFactory: factory,
@@ -139,6 +140,7 @@ const legacyModel = {
 function rpcClient(index: number) {
   return {
     getBlockNumber: vi.fn().mockResolvedValue(120n),
+    getLogs: vi.fn().mockResolvedValue([]),
     getBlock: vi.fn().mockResolvedValue({ hash: blockHash }),
     getCode: vi.fn(({ address }: { address: Address }) => {
       const normalized = address.toLowerCase();
@@ -245,6 +247,7 @@ vi.mock("../lib/stock-paired-release", async (importOriginal) => {
   return {
     ...actual,
     getConfiguredStockPairedReleaseByHookAndVersion: () => release,
+    getConfiguredStockPairedReleases: () => [release],
   };
 });
 
@@ -281,7 +284,7 @@ vi.mock("viem", async (importOriginal) => {
   };
 });
 
-import { POST } from "../app/api/profile/stock-paired/route";
+import { GET, POST } from "../app/api/profile/stock-paired/route";
 import { StockPairedClaimReceiptError } from "../lib/server/stock-paired-claim-receipt";
 
 function request(action: "claim" | "convert-to-eth" = "claim") {
@@ -404,6 +407,43 @@ describe("Stock-Paired action identity activation", () => {
       expect(mocks.readLegacy).not.toHaveBeenCalled();
     },
   );
+
+  it("uses exactly one committed dRPC client for the public profile GET", async () => {
+    const response = await GET(new NextRequest(
+      `http://localhost/api/profile/stock-paired?account=${account}`,
+    ));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "ready",
+      account,
+      chainId: 1,
+      snapshotBlock: "120",
+      rewards: [],
+    });
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+    expect(mocks.readBitquery).not.toHaveBeenCalled();
+    expect(response.headers.get("X-Programmable-Read-Source")).toBe("rpc");
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
+      "drpc-primary",
+    );
+  });
+
+  it("returns 503 without fallback when the sole profile provider fails", async () => {
+    const failedClient = rpcClient(0);
+    failedClient.getBlockNumber.mockRejectedValueOnce(
+      new Error("dRPC unavailable"),
+    );
+    mocks.createPublicClient.mockReturnValueOnce(failedClient);
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/profile/stock-paired?account=${account}`,
+    ));
+
+    expect(response.status).toBe(503);
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+    expect(mocks.readBitquery).not.toHaveBeenCalled();
+  });
 
   it("returns a stable conflict before preparing a conversion for a pending claim receipt", async () => {
     mocks.indexedEnabled = true;

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -110,6 +110,10 @@ describe("dRPC identity and strict Bitquery token chart API", () => {
     expect(response.headers.get("x-programmable-market-source")).toBe("bitquery");
     expect(response.headers.get("x-programmable-launch-source")).toBe("drpc");
     expect(response.headers.get("x-programmable-read-source")).toBe("drpc+bitquery");
+    expect(mocks.catalog).toHaveBeenCalledWith({
+      requestedTokenAddress: address,
+      signal: expect.any(AbortSignal),
+    });
     expect(mocks.chart).toHaveBeenCalledWith(expect.objectContaining({
       identity,
       range: "1d",

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -42,10 +42,10 @@ const mocks = vi.hoisted(() => ({
   market: vi.fn(),
 }));
 
-vi.mock("../lib/market-data/bitquery-launches.server", () => ({
-  readBitqueryExploreEntriesV1: mocks.catalog,
-  safeBitqueryLaunchCatalogError: vi.fn(() => ({
-    name: "LaunchCatalogError",
+vi.mock("../lib/market-data/primary-rpc-launches.server", () => ({
+  readPrimaryRpcExploreEntriesV1: mocks.catalog,
+  safePrimaryRpcLaunchCatalogError: vi.fn(() => ({
+    name: "PrimaryRpcLaunchCatalogError",
     category: "unexpected",
   })),
 }));
@@ -90,11 +90,11 @@ function readyChart() {
   } as const;
 }
 
-describe("strict Bitquery token chart API", () => {
+describe("dRPC identity and strict Bitquery token chart API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.catalog.mockResolvedValue({
-      source: "bitquery",
+      source: "drpc",
       generatedAt: "2026-08-14T00:00:00.000Z",
       asOfBlock: "25740002",
       asOfBlockHash: `0x${"44".repeat(32)}`,
@@ -103,11 +103,13 @@ describe("strict Bitquery token chart API", () => {
     mocks.chart.mockResolvedValue(readyChart());
   });
 
-  it("reads identity and history directly from Bitquery with no cache fallback", async () => {
+  it("reads identity from dRPC and history directly from Bitquery", async () => {
     const response = await GET(request());
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("x-programmable-market-source")).toBe("bitquery");
+    expect(response.headers.get("x-programmable-launch-source")).toBe("drpc");
+    expect(response.headers.get("x-programmable-read-source")).toBe("drpc+bitquery");
     expect(mocks.chart).toHaveBeenCalledWith(expect.objectContaining({
       identity,
       range: "1d",
@@ -120,9 +122,9 @@ describe("strict Bitquery token chart API", () => {
     });
   });
 
-  it("returns 404 when the Bitquery catalog has no token", async () => {
+  it("returns 404 when the dRPC catalog has no token", async () => {
     mocks.catalog.mockResolvedValue({
-      source: "bitquery",
+      source: "drpc",
       generatedAt: "2026-08-14T00:00:00.000Z",
       asOfBlock: null,
       asOfBlockHash: null,
@@ -142,6 +144,15 @@ describe("strict Bitquery token chart API", () => {
       source: "bitquery",
       status: "unavailable",
     });
+  });
+
+  it("returns 503 when the primary dRPC identity read fails", async () => {
+    mocks.catalog.mockRejectedValue(new Error("drpc unavailable"));
+    const response = await GET(request());
+    expect(response.status).toBe(503);
+    expect(response.headers.get("x-programmable-launch-source")).toBe("drpc");
+    expect(response.headers.get("x-programmable-market-source")).toBe("bitquery");
+    expect(mocks.chart).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -9,11 +9,15 @@ import type {
   MarketDataIdentityV1,
   TokenMarketDataV1,
 } from "../lib/market-data/market-data-v1";
-import type { CanonicalTokenExploreEntry } from "../lib/tokens";
+import type {
+  CanonicalTokenExploreEntry,
+  CustomProjectExploreEntry,
+} from "../lib/tokens";
 
 const mocks = vi.hoisted(() => ({
   readPrimaryRpcExploreEntriesV1: vi.fn(),
   readBitqueryTokenMarketDataStrictV1: vi.fn(),
+  readProductionCustomExploreDirectoryV1: vi.fn(),
 }));
 
 vi.mock("../lib/market-data/primary-rpc-launches.server", () => ({
@@ -25,12 +29,24 @@ vi.mock("../lib/market-data/primary-rpc-launches.server", () => ({
 }));
 
 vi.mock("../lib/market-data/bitquery.server", () => ({
+  BitqueryMarketDataError: class BitqueryMarketDataError extends Error {
+    category: string;
+    constructor(category: string) {
+      super("Market data is temporarily unavailable");
+      this.category = category;
+    }
+  },
   readBitqueryTokenMarketDataStrictV1:
     mocks.readBitqueryTokenMarketDataStrictV1,
   safeBitqueryMarketDataError: vi.fn(() => ({
     name: "BitqueryMarketDataError",
     category: "transport",
   })),
+}));
+
+vi.mock("../lib/server/custom-launch/explore-directory-v1", () => ({
+  readProductionCustomExploreDirectoryV1:
+    mocks.readProductionCustomExploreDirectoryV1,
 }));
 
 import { GET } from "../app/api/explore/token/route";
@@ -67,6 +83,27 @@ const canonicalEntry = {
     modelVersion: null,
   },
 } as const satisfies CanonicalTokenExploreEntry;
+
+const customEntry = {
+  exploreKind: "custom-project",
+  id: `custom:sha256:${"55".repeat(32)}`,
+  name: "Custom Project",
+  symbol: "CUSTOM",
+  links: [],
+  launchedAt: "2026-08-14T09:00:00.000Z",
+  finalizedAt: "2026-08-14T09:05:00.000Z",
+  chainId: "1",
+  modelId: "custom-model",
+  customProjectId: `sha256:${"55".repeat(32)}`,
+  customLaunchId: `sha256:${"66".repeat(32)}`,
+  launchingWallet: { namespace: "eip155:1", value: HOOK_ADDRESS },
+  postLaunchAuthorityInventory: {},
+  postLaunchAuthorityInventoryHash: `sha256:${"77".repeat(32)}`,
+  tokenAddress: UNKNOWN_ADDRESS,
+  tokenDecimals: 18,
+  markets: [],
+  launchCategoryProvenance: {},
+} as unknown as CustomProjectExploreEntry;
 
 function bitqueryMarketData(
   identities: readonly MarketDataIdentityV1[],
@@ -123,6 +160,7 @@ describe("dRPC identity and Bitquery market token detail API", () => {
       generatedAt: NOW.toISOString(),
       asOfBlock: "25800000",
     });
+    mocks.readProductionCustomExploreDirectoryV1.mockResolvedValue([]);
     mocks.readBitqueryTokenMarketDataStrictV1.mockImplementation(
       async (identities: readonly MarketDataIdentityV1[]) =>
         bitqueryMarketData(identities),
@@ -137,8 +175,10 @@ describe("dRPC identity and Bitquery market token detail API", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.readPrimaryRpcExploreEntriesV1).toHaveBeenCalledWith({
+      requestedTokenAddress: TOKEN_ADDRESS,
       signal: expect.any(AbortSignal),
     });
+    expect(mocks.readProductionCustomExploreDirectoryV1).not.toHaveBeenCalled();
     expect(mocks.readBitqueryTokenMarketDataStrictV1).toHaveBeenCalledWith(
       [{
         chainId: "1",
@@ -194,6 +234,9 @@ describe("dRPC identity and Bitquery market token detail API", () => {
     ));
 
     expect(response.status).toBe(404);
+    expect(mocks.readProductionCustomExploreDirectoryV1).toHaveBeenCalledWith(
+      expect.any(AbortSignal),
+    );
     expect(mocks.readBitqueryTokenMarketDataStrictV1).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toEqual({
       status: "ready",
@@ -201,6 +244,63 @@ describe("dRPC identity and Bitquery market token detail API", () => {
       customProject: null,
       snapshot: null,
     });
+  });
+
+  it("serves a Custom Registry project only after a successful canonical miss", async () => {
+    mocks.readPrimaryRpcExploreEntriesV1.mockResolvedValue({
+      source: "drpc",
+      entries: [],
+      generatedAt: NOW.toISOString(),
+      asOfBlock: "25800000",
+    });
+    mocks.readProductionCustomExploreDirectoryV1.mockResolvedValue([
+      customEntry,
+    ]);
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token?address=${UNKNOWN_ADDRESS}`,
+    ));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      token: null,
+      customProject: {
+        tokenAddress: UNKNOWN_ADDRESS,
+        valuation: { status: "unavailable", reason: "no-market" },
+      },
+      snapshot: null,
+    });
+    expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
+      "registry.custom-launched",
+    );
+    expect(response.headers.get("X-Programmable-Read-Source")).toBe(
+      "drpc+registry.custom-launched",
+    );
+    expect(response.headers.get("X-Programmable-Market-Source")).toBeNull();
+    expect(mocks.readBitqueryTokenMarketDataStrictV1).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the Custom Registry read fails after a canonical miss", async () => {
+    mocks.readPrimaryRpcExploreEntriesV1.mockResolvedValue({
+      source: "drpc",
+      entries: [],
+      generatedAt: NOW.toISOString(),
+      asOfBlock: "25800000",
+    });
+    mocks.readProductionCustomExploreDirectoryV1.mockRejectedValue(
+      new Error("registry unavailable"),
+    );
+
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token?address=${UNKNOWN_ADDRESS}`,
+    ));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
+      "registry.custom-launched",
+    );
+    expect(response.headers.get("X-Programmable-Market-Source")).toBeNull();
+    expect(mocks.readBitqueryTokenMarketDataStrictV1).not.toHaveBeenCalled();
   });
 
   it("fails directly when primary dRPC identity fails", async () => {
@@ -213,6 +313,7 @@ describe("dRPC identity and Bitquery market token detail API", () => {
     ));
 
     expect(response.status).toBe(503);
+    expect(mocks.readProductionCustomExploreDirectoryV1).not.toHaveBeenCalled();
     expect(mocks.readBitqueryTokenMarketDataStrictV1).not.toHaveBeenCalled();
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
@@ -267,7 +368,6 @@ describe("dRPC identity and Bitquery market token detail API", () => {
       "readExploreReferenceHeadWithinRouteBudget",
       "valueExploreEntriesWithCurrentEvidence",
       "readBitqueryExploreEntriesV1",
-      "readProductionCustomExploreDirectoryV1",
       "stateview-chainlink",
       "official-uniswap-v4-subgraph",
       "fallback:",
@@ -275,5 +375,6 @@ describe("dRPC identity and Bitquery market token detail API", () => {
       expect(source).not.toContain(forbidden);
     }
     expect(source).toContain("readPrimaryRpcExploreEntriesV1");
+    expect(source).toContain("readProductionCustomExploreDirectoryV1");
   });
 });

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -12,23 +12,25 @@ import type {
 import type { CanonicalTokenExploreEntry } from "../lib/tokens";
 
 const mocks = vi.hoisted(() => ({
-  readBitqueryExploreEntriesV1: vi.fn(),
+  readPrimaryRpcExploreEntriesV1: vi.fn(),
   readBitqueryTokenMarketDataStrictV1: vi.fn(),
-  readProductionCustomExploreDirectoryV1: vi.fn(),
 }));
 
-vi.mock("../lib/market-data/bitquery-launches.server", () => ({
-  readBitqueryExploreEntriesV1: mocks.readBitqueryExploreEntriesV1,
+vi.mock("../lib/market-data/primary-rpc-launches.server", () => ({
+  readPrimaryRpcExploreEntriesV1: mocks.readPrimaryRpcExploreEntriesV1,
+  safePrimaryRpcLaunchCatalogError: vi.fn(() => ({
+    name: "PrimaryRpcLaunchCatalogError",
+    category: "transport",
+  })),
 }));
 
 vi.mock("../lib/market-data/bitquery.server", () => ({
   readBitqueryTokenMarketDataStrictV1:
     mocks.readBitqueryTokenMarketDataStrictV1,
-}));
-
-vi.mock("../lib/server/custom-launch/explore-directory-v1", () => ({
-  readProductionCustomExploreDirectoryV1:
-    mocks.readProductionCustomExploreDirectoryV1,
+  safeBitqueryMarketDataError: vi.fn(() => ({
+    name: "BitqueryMarketDataError",
+    category: "transport",
+  })),
 }));
 
 import { GET } from "../app/api/explore/token/route";
@@ -45,8 +47,8 @@ const NOW = new Date("2026-08-14T12:00:00.000Z");
 const canonicalEntry = {
   exploreKind: "token",
   id: `1:${TOKEN_ADDRESS}`,
-  name: "Bitquery Token",
-  symbol: "BITQ",
+  name: "dRPC Token",
+  symbol: "DRPC",
   tokenAddress: TOKEN_ADDRESS,
   hookAddress: HOOK_ADDRESS,
   poolId: POOL_ID,
@@ -112,30 +114,29 @@ function bitqueryMarketData(
   } satisfies TokenMarketDataV1]));
 }
 
-describe("Bitquery-only token detail API", () => {
+describe("dRPC identity and Bitquery market token detail API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.readBitqueryExploreEntriesV1.mockResolvedValue({
-      source: "bitquery",
+    mocks.readPrimaryRpcExploreEntriesV1.mockResolvedValue({
+      source: "drpc",
       entries: [canonicalEntry],
       generatedAt: NOW.toISOString(),
       asOfBlock: "25800000",
     });
-    mocks.readProductionCustomExploreDirectoryV1.mockResolvedValue([]);
     mocks.readBitqueryTokenMarketDataStrictV1.mockImplementation(
       async (identities: readonly MarketDataIdentityV1[]) =>
         bitqueryMarketData(identities),
     );
   });
 
-  it("serves launch identity and current market data exclusively from Bitquery", async () => {
+  it("serves dRPC launch identity with current Bitquery market data", async () => {
     const response = await GET(new NextRequest(
       `http://localhost/api/explore/token?address=${TOKEN_ADDRESS}`,
     ));
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mocks.readBitqueryExploreEntriesV1).toHaveBeenCalledWith({
+    expect(mocks.readPrimaryRpcExploreEntriesV1).toHaveBeenCalledWith({
       signal: expect.any(AbortSignal),
     });
     expect(mocks.readBitqueryTokenMarketDataStrictV1).toHaveBeenCalledWith(
@@ -166,10 +167,10 @@ describe("Bitquery-only token detail API", () => {
     expect(body).not.toHaveProperty("dataQuality");
     expect(body).not.toHaveProperty("launchDiscoverySnapshot");
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
-      "bitquery",
+      "drpc",
     );
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "bitquery",
+      "drpc+bitquery",
     );
     expect(response.headers.get("X-Programmable-Market-Source")).toBe(
       "bitquery",
@@ -180,22 +181,9 @@ describe("Bitquery-only token detail API", () => {
     expect(response.headers.get("X-Programmable-Rpc-Provider")).toBeNull();
   });
 
-  it("does not make the optional Custom Registry a Bitquery availability gate", async () => {
-    mocks.readProductionCustomExploreDirectoryV1.mockRejectedValue(
-      new Error("registry unavailable"),
-    );
-
-    const response = await GET(new NextRequest(
-      `http://localhost/api/explore/token?address=${TOKEN_ADDRESS}`,
-    ));
-
-    expect(response.status).toBe(200);
-    expect((await response.json()).token.tokenAddress).toBe(TOKEN_ADDRESS);
-  });
-
-  it("returns a definitive 404 from the Bitquery catalog without market reads", async () => {
-    mocks.readBitqueryExploreEntriesV1.mockResolvedValue({
-      source: "bitquery",
+  it("returns a definitive 404 from the dRPC catalog without market reads", async () => {
+    mocks.readPrimaryRpcExploreEntriesV1.mockResolvedValue({
+      source: "drpc",
       entries: [],
       generatedAt: NOW.toISOString(),
       asOfBlock: "25800000",
@@ -215,9 +203,9 @@ describe("Bitquery-only token detail API", () => {
     });
   });
 
-  it("fails directly when Bitquery fails instead of using another provider", async () => {
-    mocks.readBitqueryExploreEntriesV1.mockRejectedValue(
-      new Error("bitquery unavailable"),
+  it("fails directly when primary dRPC identity fails", async () => {
+    mocks.readPrimaryRpcExploreEntriesV1.mockRejectedValue(
+      new Error("drpc unavailable"),
     );
 
     const response = await GET(new NextRequest(
@@ -242,6 +230,14 @@ describe("Bitquery-only token detail API", () => {
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 
+  it("fails when Bitquery omits the required dRPC token market", async () => {
+    mocks.readBitqueryTokenMarketDataStrictV1.mockResolvedValue(new Map());
+    const response = await GET(new NextRequest(
+      `http://localhost/api/explore/token?address=${TOKEN_ADDRESS}`,
+    ));
+    expect(response.status).toBe(503);
+  });
+
   it.each([
     `address=${TOKEN_ADDRESS}&unused=random`,
     `address=${TOKEN_ADDRESS}&address=${UNKNOWN_ADDRESS}`,
@@ -252,8 +248,7 @@ describe("Bitquery-only token detail API", () => {
     );
 
     expect(response.status).toBe(400);
-    expect(mocks.readBitqueryExploreEntriesV1).not.toHaveBeenCalled();
-    expect(mocks.readProductionCustomExploreDirectoryV1).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryRpcExploreEntriesV1).not.toHaveBeenCalled();
     expect(mocks.readBitqueryTokenMarketDataStrictV1).not.toHaveBeenCalled();
   });
 
@@ -271,11 +266,14 @@ describe("Bitquery-only token detail API", () => {
       "hydrateMissingCanonicalTokenSupplyV1",
       "readExploreReferenceHeadWithinRouteBudget",
       "valueExploreEntriesWithCurrentEvidence",
+      "readBitqueryExploreEntriesV1",
+      "readProductionCustomExploreDirectoryV1",
       "stateview-chainlink",
       "official-uniswap-v4-subgraph",
       "fallback:",
     ]) {
       expect(source).not.toContain(forbidden);
     }
+    expect(source).toContain("readPrimaryRpcExploreEntriesV1");
   });
 });

--- a/tests/trade-action-activation.test.ts
+++ b/tests/trade-action-activation.test.ts
@@ -11,8 +11,12 @@ const mocks = vi.hoisted(() => ({
   lookup: vi.fn(),
   readLegacy: vi.fn(),
   readBitquery: vi.fn(),
+  readIdentity: vi.fn(),
   prepare: vi.fn(),
-  createPublicClient: vi.fn(() => ({})),
+  createPublicClient: vi.fn(() => ({
+    getBlockNumber: vi.fn().mockResolvedValue(100n),
+    getBlock: vi.fn().mockResolvedValue({ hash: `0x${"22".repeat(32)}` }),
+  })),
 }));
 
 const token = "0x1111111111111111111111111111111111111111";
@@ -73,6 +77,16 @@ vi.mock("../lib/alchemy/explore.server", () => ({
 vi.mock("../lib/market-data/bitquery-explore-model.server", () => ({
   readBitqueryExploreModelV1: mocks.readBitquery,
 }));
+
+vi.mock("../lib/server/action-rpc-identity.server", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../lib/server/action-rpc-identity.server")
+  >();
+  return {
+    ...actual,
+    readTradeActionModelFromRpc: mocks.readIdentity,
+  };
+});
 
 vi.mock("../lib/trade/server", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/trade/server")>();
@@ -139,6 +153,7 @@ describe("trade action identity activation", () => {
     mocks.lookup.mockResolvedValue({});
     mocks.readLegacy.mockResolvedValue(registry);
     mocks.readBitquery.mockResolvedValue(registry);
+    mocks.readIdentity.mockResolvedValue(registry);
     mocks.prepare.mockResolvedValue({
       quote: { amountOut: "100" },
       transaction: { kind: "swap" },
@@ -155,7 +170,8 @@ describe("trade action identity activation", () => {
       expect(response.status).toBe(200);
       expect(mocks.prepare).toHaveBeenCalledTimes(1);
       expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
-      expect(mocks.readBitquery).toHaveBeenCalledTimes(1);
+      expect(mocks.readIdentity).toHaveBeenCalledTimes(1);
+      expect(mocks.readBitquery).not.toHaveBeenCalled();
       expect(mocks.lookup).not.toHaveBeenCalled();
       expect(mocks.readLegacy).not.toHaveBeenCalled();
       await expect(response.json()).resolves.toMatchObject({
@@ -179,6 +195,8 @@ describe("trade action identity activation", () => {
       expect(response.status).toBe(200);
       expect(mocks.prepare).toHaveBeenCalledTimes(1);
       expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+      expect(mocks.readIdentity).toHaveBeenCalledTimes(1);
+      expect(mocks.readBitquery).not.toHaveBeenCalled();
       expect(serialized).not.toContain("drpc-action-key");
       expect(serialized).not.toContain("second-secret-key");
     },
@@ -200,5 +218,6 @@ describe("trade action identity activation", () => {
     });
     expect(mocks.prepare).not.toHaveBeenCalled();
     expect(mocks.createPublicClient).not.toHaveBeenCalled();
+    expect(mocks.readIdentity).not.toHaveBeenCalled();
   });
 });

--- a/tests/website-rpc-providers.test.ts
+++ b/tests/website-rpc-providers.test.ts
@@ -4,6 +4,7 @@ import { rpcProviderCommitment } from
   "../lib/data-pipeline/rpc-provider-commitments";
 import {
   WEBSITE_MAINNET_RPC_ENV,
+  productionMainnetRpcPrimary,
   productionMainnetRpcPair,
   websiteMainnetRpcPair,
 } from "../lib/onchain/website-rpc-providers.server";
@@ -72,6 +73,38 @@ describe("Website Mainnet RPC provider bindings", () => {
       secondaryProvider: "alchemy",
       secondaryUrl: ALCHEMY_URL,
     }))).toThrow("Production RPC provider roles are invalid");
+  });
+
+  it("binds only the committed dRPC primary without secondary configuration", () => {
+    const primaryOnly = {
+      [WEBSITE_MAINNET_RPC_ENV.primaryProvider]: "drpc",
+      [WEBSITE_MAINNET_RPC_ENV.primaryUrl]: DRPC_URL,
+      [WEBSITE_MAINNET_RPC_ENV.primaryCommitment]:
+        rpcProviderCommitment("endpoint", DRPC_URL),
+    };
+
+    expect(productionMainnetRpcPrimary(primaryOnly)).toEqual({
+      provider: "drpc",
+      url: DRPC_URL,
+      endpointCommitment: rpcProviderCommitment("endpoint", DRPC_URL),
+    });
+    expect(() => productionMainnetRpcPair(primaryOnly)).toThrow(
+      "Website secondary RPC provider binding is invalid",
+    );
+  });
+
+  it("rejects a non-dRPC or drifted production primary", () => {
+    expect(() => productionMainnetRpcPrimary({
+      [WEBSITE_MAINNET_RPC_ENV.primaryProvider]: "quicknode",
+      [WEBSITE_MAINNET_RPC_ENV.primaryUrl]: QUICKNODE_URL,
+      [WEBSITE_MAINNET_RPC_ENV.primaryCommitment]:
+        rpcProviderCommitment("endpoint", QUICKNODE_URL),
+    })).toThrow("Production primary RPC provider role is invalid");
+    expect(() => productionMainnetRpcPrimary({
+      [WEBSITE_MAINNET_RPC_ENV.primaryProvider]: "drpc",
+      [WEBSITE_MAINNET_RPC_ENV.primaryUrl]: DRPC_URL,
+      [WEBSITE_MAINNET_RPC_ENV.primaryCommitment]: `0x${"ab".repeat(32)}`,
+    })).toThrow("Website primary RPC endpoint commitment mismatch");
   });
 
   it("keeps provider roles interchangeable across the reviewed vendors", () => {


### PR DESCRIPTION
## Outcome
- reads launch, pool and creator identity from one commitment-bound dRPC primary
- keeps Bitquery strict for market, FDV, trades and charts
- removes Bitquery historical Events/Calls from public and action paths
- keeps claim and trade preparation on one simulated dRPC path without fallback, quorum, signing or submission
- expands staged candidate smoke for Highest FDV, Newest, detail, chart and profile

## Local evidence
- `npm run typecheck`
- `npm run perf:read-model:ops-gate`
- 161 focused API/source-contract tests
- scoped ESLint and `git diff --check`

## Release
Stage-only until exact protected checks pass; promote only after candidate API and read-only action probes succeed.