### PR TITLE
Add fail-closed Website projection schema adoption

### DIFF
--- a/docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md
+++ b/docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md
@@ -22,6 +22,72 @@ The operator refuses pooled endpoints, a different target, server major version
 below 15, session change, role/privilege/catalog drift, partial evidence, or any
 migration history other than the exact reviewed prefix.
 
+## One bounded existing-prefix adoption
+
+`adopt-existing` is a one-source recovery path, not a generic migration-history
+repair. It accepts only all of these exact facts:
+
+- source commit `76ebd54e2f0e31d055cfe6c36b7474b0e850de90`, tree
+  `8e4ddd9a73818ce70f1284f3b2731bc87b005f27`, and plan
+  `0xf0fc7bca18c16da02be83f75d25e404bfe0b7ec7f10c29ecfbea93fcb0d7e973`;
+- protected base snapshot
+  `0xac4a1fe60ebf677865a0f8ca6160162d9c457dc2bd401aa60fd820c8f2fdcc58`
+  and expanded snapshot
+  `0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284`;
+- the exact normalized catalog, RLS, policies, grants, functions and triggers
+  after `0001` through `0003`, including the captured schema `USAGE`, three
+  table `SELECT`/`INSERT` grants and eleven registry column `UPDATE` grants,
+  with no `0004` or `0005` object;
+- exactly zero rows in `credential_uses`, `projection_records`, and
+  `registry_custom_launch_records`;
+- no operator or adoption evidence schema/table/history;
+- the exact legacy `supabase_migrations` inventory: two allowlisted tables,
+  42 schema rows, 42 evidence rows, public canonical hash
+  `0x93e41eab957ab8add897a8b277bcaaa0a5f10eebeb27f47db5bc0e59640484a2`
+  and protected full-inventory hash
+  `0xd32953874c1466be82433d97e6532d0572ddcf80eed261efa119b25f17e0f5b3`;
+- the constrained runtime role with the sole accepted drift
+  `rolinherit = true`, plus exactly the provider-owned
+  `postgres -> programmable_website_projection_runtime WITH ADMIN OPTION`
+  membership with `INHERIT FALSE`, `SET FALSE`, grantor `supabase_admin`, and
+  no other runtime/provider edge.
+
+The protected operator checkout may be a clean reviewed successor commit only
+when all five migration file/execution hashes still equal the source plan. The
+command takes the migration advisory lock and one database transaction, locks
+all three application tables, then re-reads every precondition. It changes only
+the runtime role to `NOINHERIT`, creates private operator/adoption evidence, and
+records a distinct `adopted-existing-prefix-v1` prefix for `0001` through
+`0003`. Those records attest adoption; they do not claim that the DDL was
+replayed. The transaction records the protected snapshot, live pre/post catalog
+hashes, zero-row hash and counts, exact role delta, source and operator Git
+identities, plan, target and adoption attestation hash.
+
+Run only after independently reviewing the protected snapshot and exact target:
+
+```sh
+npm run --silent db:website-projection:operator -- adopt-existing \
+  --plan /secure/operator/website-projection-successor-plan.json \
+  --expected-project-ref 'mnnvlrqwhfoppogslsje' \
+  --source-base-snapshot \
+    /secure/operator/programmable-website-projection-hosted-catalog-snapshot-76ebd54.json \
+  --source-expanded-snapshot \
+    /secure/operator/programmable-website-projection-hosted-catalog-snapshot-v2-76ebd54.json \
+  --confirm-adopt-existing \
+    '<exact-successor-planSha256>' \
+  --confirm-target 'mnnvlrqwhfoppogslsje' \
+  --confirm-source-snapshot \
+    '0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284' \
+  --confirm-adopt-through '0003'
+```
+
+Any row, extra object, missing object, alternate membership, other role-bit
+drift, partial evidence, lock race, or re-read drift rolls the complete
+transaction back. After a successful adoption, retain its JSON result, run the
+normal `apply` command with the same exact successor plan to apply only `0004` and
+`0005`, then run `verify`. Adoption, apply, and verify remain database evidence
+only; they do not enable Custom or authorize a Website deployment.
+
 ## Secret-manager session
 
 Export without printing or placing values in shell history:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "launcher-v4",
       "version": "0.1.0",
       "dependencies": {
+        "@electric-sql/pglite": "0.5.4",
         "@metamask/delegation-abis": "1.1.0",
         "@metamask/delegation-core": "2.2.1",
         "@metamask/smart-accounts-kit": "1.7.0",
@@ -30,7 +31,6 @@
         "viem": "2.55.5"
       },
       "devDependencies": {
-        "@electric-sql/pglite": "0.5.4",
         "@playwright/test": "1.62.1",
         "@types/node": "26.1.1",
         "@types/pg": "8.20.4",
@@ -570,7 +570,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.4.tgz",
       "integrity": "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "@metamask/smart-accounts-kit": "1.7.0",
     "@privy-io/node": "^0.27.0",
     "@privy-io/react-auth": "3.35.2",
+    "@electric-sql/pglite": "0.5.4",
     "@uniswap/liquidity-launcher-sdk": "1.0.1",
     "@uniswap/sdk-core": "7.19.0",
     "@uniswap/universal-router-sdk": "5.11.1",
@@ -183,7 +184,6 @@
     "viem": "2.55.5"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "0.5.4",
     "@playwright/test": "1.62.1",
     "@types/node": "26.1.1",
     "@types/pg": "8.20.4",

--- a/scripts/website-projection-db-operator-core.mjs
+++ b/scripts/website-projection-db-operator-core.mjs
@@ -18,6 +18,25 @@ export const WEBSITE_PROJECTION_EVIDENCE_TABLE =
   `${WEBSITE_PROJECTION_EVIDENCE_SCHEMA}.migration_evidence_v1`;
 export const WEBSITE_PROJECTION_PLAN_KIND =
   "programmable-website-projection-migration-plan";
+export const WEBSITE_PROJECTION_ADOPTION_SOURCE_COMMIT =
+  "76ebd54e2f0e31d055cfe6c36b7474b0e850de90";
+export const WEBSITE_PROJECTION_ADOPTION_SOURCE_TREE =
+  "8e4ddd9a73818ce70f1284f3b2731bc87b005f27";
+export const WEBSITE_PROJECTION_ADOPTION_SOURCE_PLAN_SHA256 =
+  "0xf0fc7bca18c16da02be83f75d25e404bfe0b7ec7f10c29ecfbea93fcb0d7e973";
+export const WEBSITE_PROJECTION_ADOPTION_SOURCE_ORDER_SHA256 =
+  "0xce50954bfa6ff3b66b849bb5b53e8f1adf93abbe12cf865c19375100f2571cc2";
+export const WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256 =
+  "0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284";
+export const WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256 =
+  "0xac4a1fe60ebf677865a0f8ca6160162d9c457dc2bd401aa60fd820c8f2fdcc58";
+export const WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256 =
+  "0xd32953874c1466be82433d97e6532d0572ddcf80eed261efa119b25f17e0f5b3";
+export const WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256 =
+  "0x93e41eab957ab8add897a8b277bcaaa0a5f10eebeb27f47db5bc0e59640484a2";
+export const WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT = 3;
+export const WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF =
+  "mnnvlrqwhfoppogslsje";
 
 export const WEBSITE_PROJECTION_MIGRATION_FILES = Object.freeze([
   "0001_projection_records_v1.sql",
@@ -201,22 +220,99 @@ export function validateWebsiteProjectionPlan(value) {
   return value;
 }
 
+export function assertWebsiteProjectionAdoptionSourcePlan(plan) {
+  validateWebsiteProjectionPlan(plan);
+  if (plan.orderSha256 !== WEBSITE_PROJECTION_ADOPTION_SOURCE_ORDER_SHA256) {
+    throw new Error(
+      "adopt-existing successor must preserve the exact reviewed migration source",
+    );
+  }
+  return plan;
+}
+
+export function websiteProjectionAdoptionAttestationSha256({
+  plan,
+  expectedProjectRef,
+  sourceSnapshotSha256,
+  sourceCatalogSha256,
+  sourceDataSha256,
+  correctedCatalogSha256,
+  operatorCatalogSha256,
+  operatorCommit,
+  operatorTree,
+}) {
+  assertWebsiteProjectionAdoptionSourcePlan(plan);
+  if (!PROJECT_REF.test(expectedProjectRef ?? "")
+    || expectedProjectRef !== WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF
+    || sourceSnapshotSha256 !== WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256
+    || !HEX_SHA256.test(sourceCatalogSha256 ?? "")
+    || !HEX_SHA256.test(sourceDataSha256 ?? "")
+    || !HEX_SHA256.test(correctedCatalogSha256 ?? "")
+    || !HEX_SHA256.test(operatorCatalogSha256 ?? "")
+    || !GIT_OBJECT.test(operatorCommit ?? "")
+    || !GIT_OBJECT.test(operatorTree ?? "")
+    || operatorCommit !== plan.repositoryCommit
+    || operatorTree !== plan.repositoryTree) {
+    throw new Error("website projection adoption attestation input is invalid");
+  }
+  return sha256(canonicalJson({
+    kind: "programmable-website-projection-adopt-existing-attestation",
+    schemaVersion: 1,
+    targetProjectRef: expectedProjectRef,
+    sourceRepositoryCommit: WEBSITE_PROJECTION_ADOPTION_SOURCE_COMMIT,
+    sourceRepositoryTree: WEBSITE_PROJECTION_ADOPTION_SOURCE_TREE,
+    sourcePlanSha256: WEBSITE_PROJECTION_ADOPTION_SOURCE_PLAN_SHA256,
+    sourceOrderSha256: WEBSITE_PROJECTION_ADOPTION_SOURCE_ORDER_SHA256,
+    successorRepositoryCommit: plan.repositoryCommit,
+    successorRepositoryTree: plan.repositoryTree,
+    successorPlanSha256: plan.planSha256,
+    successorOrderSha256: plan.orderSha256,
+    adoptedMigrationCount: WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
+    adoptedThroughVersion: "0003",
+    sourceSnapshotSha256,
+    baseSnapshotSha256: WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
+    legacyInventorySha256:
+      WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256,
+    legacyPublicSha256: WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256,
+    sourceCatalogSha256,
+    sourceDataSha256,
+    correctedCatalogSha256,
+    operatorCatalogSha256,
+    operatorCommit,
+    operatorTree,
+    sourceRowCounts: {
+      credentialUses: 0,
+      projectionRecords: 0,
+      registryCustomLaunchRecords: 0,
+    },
+    runtimeRoleDelta: {
+      rolinheritBefore: true,
+      rolinheritAfter: false,
+    },
+  }));
+}
+
 export function compareWebsiteProjectionEvidence({
   plan,
   expectedProjectRef,
   evidenceTablePresent,
   applicationSchemaPresent,
   evidenceRows,
+  adoptionRows = [],
 }) {
   validateWebsiteProjectionPlan(plan);
   if (!PROJECT_REF.test(expectedProjectRef ?? "")
     || typeof evidenceTablePresent !== "boolean"
     || typeof applicationSchemaPresent !== "boolean"
-    || !Array.isArray(evidenceRows)) {
+    || !Array.isArray(evidenceRows)
+    || !Array.isArray(adoptionRows)) {
     throw new Error("website projection migration state is invalid");
   }
   if (!evidenceTablePresent && evidenceRows.length > 0) {
     throw new Error("website projection migration evidence state is invalid");
+  }
+  if (!evidenceTablePresent && adoptionRows.length > 0) {
+    throw new Error("website projection adoption evidence state is invalid");
   }
   if (evidenceTablePresent && evidenceRows.length === 0) {
     throw new Error("unproven operator evidence table exists without migration evidence");
@@ -227,6 +323,7 @@ export function compareWebsiteProjectionEvidence({
   if (evidenceRows.length > 0 && !applicationSchemaPresent) {
     throw new Error("migration evidence exists without the application schema");
   }
+  let adoption = null;
   for (const [index, row] of evidenceRows.entries()) {
     const migration = plan.migrations[index];
     if (!migration || !isPlainObject(row)
@@ -240,12 +337,117 @@ export function compareWebsiteProjectionEvidence({
       || row.repository_commit !== plan.repositoryCommit
       || row.repository_tree !== plan.repositoryTree
       || !HEX_SHA256.test(row.catalog_sha256 ?? "")
-      || !HEX_SHA256.test(row.operator_catalog_sha256 ?? "")) {
+      || !HEX_SHA256.test(row.operator_catalog_sha256 ?? "")
+      || !["applied", "adopted-existing-prefix-v1"].includes(
+        row.evidence_kind,
+      )) {
       throw new Error("remote migration evidence is not an exact plan prefix");
     }
     if (row.target_project_ref !== expectedProjectRef) {
       throw new Error("remote migration evidence target mismatch");
     }
+    const adoptionFields = [
+      row.adoption_source_snapshot_sha256,
+      row.adoption_source_catalog_sha256,
+      row.adoption_source_data_sha256,
+      row.adoption_attestation_sha256,
+      row.adoption_operator_commit,
+      row.adoption_operator_tree,
+    ];
+    if (row.evidence_kind === "applied") {
+      if (adoptionFields.some((value) => value !== null)) {
+        throw new Error("applied migration evidence contains adoption claims");
+      }
+      if (adoption !== null && index < WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT) {
+        throw new Error("remote adoption evidence is not the exact prefix");
+      }
+      continue;
+    }
+    if (index >= WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT
+      || row.adoption_source_snapshot_sha256
+        !== WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256
+      || !HEX_SHA256.test(row.adoption_source_catalog_sha256 ?? "")
+      || !HEX_SHA256.test(row.adoption_source_data_sha256 ?? "")
+      || !HEX_SHA256.test(row.adoption_attestation_sha256 ?? "")
+      || !GIT_OBJECT.test(row.adoption_operator_commit ?? "")
+      || !GIT_OBJECT.test(row.adoption_operator_tree ?? "")) {
+      throw new Error("remote adoption evidence is not the exact prefix");
+    }
+    const currentAdoption = {
+      sourceSnapshotSha256: row.adoption_source_snapshot_sha256,
+      sourceCatalogSha256: row.adoption_source_catalog_sha256,
+      sourceDataSha256: row.adoption_source_data_sha256,
+      attestationSha256: row.adoption_attestation_sha256,
+      operatorCommit: row.adoption_operator_commit,
+      operatorTree: row.adoption_operator_tree,
+      correctedCatalogSha256: row.catalog_sha256,
+      operatorCatalogSha256: row.operator_catalog_sha256,
+    };
+    if (adoption === null) {
+      adoption = currentAdoption;
+    } else if (canonicalJson(adoption) !== canonicalJson(currentAdoption)) {
+      throw new Error("remote adoption evidence is inconsistent");
+    }
+  }
+  if (adoption !== null) {
+    const adoptionRow = adoptionRows[0];
+    if (evidenceRows.length < WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT
+      || adoptionRows.length !== 1
+      || evidenceRows.slice(0, WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT)
+        .some(({ evidence_kind }) =>
+          evidence_kind !== "adopted-existing-prefix-v1")
+      || !isPlainObject(adoptionRow)
+      || adoptionRow.evidence_kind !== "adopted-existing-prefix-v1"
+      || adoptionRow.adopted_through_version !== "0003"
+      || adoptionRow.source_snapshot_sha256 !== adoption.sourceSnapshotSha256
+      || adoptionRow.base_snapshot_sha256
+        !== WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256
+      || adoptionRow.legacy_inventory_sha256
+        !== WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256
+      || adoptionRow.legacy_public_sha256
+        !== WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256
+      || adoptionRow.source_catalog_sha256 !== adoption.sourceCatalogSha256
+      || adoptionRow.corrected_catalog_sha256
+        !== adoption.correctedCatalogSha256
+      || adoptionRow.source_data_sha256 !== adoption.sourceDataSha256
+      || adoptionRow.operator_catalog_sha256
+        !== adoption.operatorCatalogSha256
+      || adoptionRow.attestation_sha256 !== adoption.attestationSha256
+      || adoptionRow.source_plan_sha256
+        !== WEBSITE_PROJECTION_ADOPTION_SOURCE_PLAN_SHA256
+      || adoptionRow.source_order_sha256
+        !== WEBSITE_PROJECTION_ADOPTION_SOURCE_ORDER_SHA256
+      || adoptionRow.source_repository_commit
+        !== WEBSITE_PROJECTION_ADOPTION_SOURCE_COMMIT
+      || adoptionRow.source_repository_tree
+        !== WEBSITE_PROJECTION_ADOPTION_SOURCE_TREE
+      || adoptionRow.successor_plan_sha256 !== plan.planSha256
+      || adoptionRow.successor_order_sha256 !== plan.orderSha256
+      || adoptionRow.successor_repository_commit !== plan.repositoryCommit
+      || adoptionRow.successor_repository_tree !== plan.repositoryTree
+      || adoptionRow.target_project_ref !== expectedProjectRef
+      || adoptionRow.operator_commit !== adoption.operatorCommit
+      || adoptionRow.operator_tree !== adoption.operatorTree
+      || Number(adoptionRow.credential_uses_count) !== 0
+      || Number(adoptionRow.projection_records_count) !== 0
+      || Number(adoptionRow.registry_custom_launch_records_count) !== 0
+      || adoptionRow.runtime_rolinherit_before !== true
+      || adoptionRow.runtime_rolinherit_after !== false
+      || websiteProjectionAdoptionAttestationSha256({
+        plan,
+        expectedProjectRef,
+        sourceSnapshotSha256: adoption.sourceSnapshotSha256,
+        sourceCatalogSha256: adoption.sourceCatalogSha256,
+        sourceDataSha256: adoption.sourceDataSha256,
+        correctedCatalogSha256: adoption.correctedCatalogSha256,
+        operatorCatalogSha256: adoption.operatorCatalogSha256,
+        operatorCommit: adoption.operatorCommit,
+        operatorTree: adoption.operatorTree,
+      }) !== adoption.attestationSha256) {
+      throw new Error("remote adoption evidence is not the exact prefix");
+    }
+  } else if (adoptionRows.length !== 0) {
+    throw new Error("adoption evidence exists without an adopted prefix");
   }
   const pending = plan.migrations.slice(evidenceRows.length).map(
     ({ ordinal, version, file }) => ({ ordinal, version, file }),
@@ -304,16 +506,27 @@ export function assertWebsiteProjectionRoleGraph({
     if (!isPlainObject(membership)
       || typeof membership.member_name !== "string"
       || typeof membership.role_name !== "string"
-      || typeof membership.admin_option !== "boolean") {
+      || typeof membership.grantor_name !== "string"
+      || typeof membership.admin_option !== "boolean"
+      || typeof membership.inherit_option !== "boolean"
+      || typeof membership.set_option !== "boolean") {
       throw new Error("website projection role graph is invalid");
     }
+    const allowedOwnerRuntimeEdge =
+      membership.member_name === "postgres"
+      && membership.role_name === WEBSITE_PROJECTION_RUNTIME_ROLE
+      && membership.grantor_name === "supabase_admin"
+      && membership.admin_option === true
+      && membership.inherit_option === false
+      && membership.set_option === false;
     if ([
       WEBSITE_PROJECTION_RUNTIME_ROLE,
       "anon",
       "authenticated",
       "service_role",
     ].includes(membership.member_name)
-      || membership.role_name === WEBSITE_PROJECTION_RUNTIME_ROLE) {
+      || (membership.role_name === WEBSITE_PROJECTION_RUNTIME_ROLE
+        && !allowedOwnerRuntimeEdge)) {
       throw new Error(
         "website projection runtime and provider outgoing role membership is forbidden",
       );
@@ -332,10 +545,58 @@ export function assertWebsiteProjectionRoleGraph({
     || runtime.rolcreaterole !== false
     || runtime.rolcreatedb !== false
     || runtime.rolreplication !== false
-    || runtime.rolbypassrls !== false) {
+    || runtime.rolbypassrls !== false
+    || Number(runtime.rolconnlimit) !== -1
+    || runtime.rolvaliduntil !== null
+    || !(runtime.rolconfig === null
+      || (Array.isArray(runtime.rolconfig) && runtime.rolconfig.length === 0))) {
     throw new Error("website projection runtime role posture is invalid");
   }
   return Object.freeze({ runtimeRoleStatus: "current" });
+}
+
+export function assertWebsiteProjectionAdoptionSourceRoleGraph({
+  roles,
+  memberships,
+}) {
+  const runtime = Array.isArray(roles)
+    ? roles.find(({ rolname }) =>
+      rolname === WEBSITE_PROJECTION_RUNTIME_ROLE)
+    : null;
+  if (!isPlainObject(runtime)
+    || runtime.rolcanlogin !== true
+    || runtime.rolinherit !== true
+    || runtime.rolsuper !== false
+    || runtime.rolcreaterole !== false
+    || runtime.rolcreatedb !== false
+    || runtime.rolreplication !== false
+    || runtime.rolbypassrls !== false
+    || Number(runtime.rolconnlimit) !== -1
+    || runtime.rolvaliduntil !== null
+    || !(runtime.rolconfig === null
+      || (Array.isArray(runtime.rolconfig) && runtime.rolconfig.length === 0))) {
+    throw new Error("adopt-existing source runtime role posture is invalid");
+  }
+  assertWebsiteProjectionRoleGraph({
+    roles: roles.map((role) => role === runtime
+      ? { ...role, rolinherit: false }
+      : role),
+    memberships,
+    appliedCount: WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
+  });
+  const ownerRuntimeEdges = memberships.filter(({ role_name: roleName }) =>
+    roleName === WEBSITE_PROJECTION_RUNTIME_ROLE);
+  if (ownerRuntimeEdges.length !== 1
+    || ownerRuntimeEdges[0].member_name !== "postgres"
+    || ownerRuntimeEdges[0].grantor_name !== "supabase_admin"
+    || ownerRuntimeEdges[0].admin_option !== true
+    || ownerRuntimeEdges[0].inherit_option !== false
+    || ownerRuntimeEdges[0].set_option !== false) {
+    throw new Error(
+      "adopt-existing requires the exact postgres runtime admin membership",
+    );
+  }
+  return Object.freeze({ runtimeRoleStatus: "adoptable-inherit-drift" });
 }
 
 export function catalogSnapshotSha256(snapshot) {
@@ -364,5 +625,39 @@ export function assertWebsiteProjectionApplyConfirmation({
   if (!PROJECT_REF.test(expectedProjectRef ?? "")
     || confirmTarget !== expectedProjectRef) {
     throw new Error("apply target confirmation must equal the verified project ref");
+  }
+}
+
+export function assertWebsiteProjectionAdoptExistingConfirmation({
+  plan,
+  expectedProjectRef,
+  expectedSourceSnapshotSha256,
+  confirmAdoptExisting,
+  confirmTarget,
+  confirmSourceSnapshot,
+  confirmAdoptThrough,
+}) {
+  assertWebsiteProjectionAdoptionSourcePlan(plan);
+  if (confirmAdoptExisting !== plan.planSha256) {
+    throw new Error(
+      "adopt-existing confirmation must equal the reviewed source plan commitment",
+    );
+  }
+  if (!PROJECT_REF.test(expectedProjectRef ?? "")
+    || expectedProjectRef !== WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF
+    || confirmTarget !== expectedProjectRef) {
+    throw new Error(
+      "adopt-existing target confirmation must equal the verified project ref",
+    );
+  }
+  if (expectedSourceSnapshotSha256
+      !== WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256
+    || confirmSourceSnapshot !== expectedSourceSnapshotSha256) {
+    throw new Error(
+      "adopt-existing source snapshot confirmation must equal the protected snapshot",
+    );
+  }
+  if (confirmAdoptThrough !== "0003") {
+    throw new Error("adopt-existing through confirmation must equal 0003");
   }
 }

--- a/scripts/website-projection-db-operator.mjs
+++ b/scripts/website-projection-db-operator.mjs
@@ -10,14 +10,18 @@ import {
   safeFailure,
 } from "./data-pipeline/hosted-db-operator-core.mjs";
 import {
+  assertWebsiteProjectionAdoptExistingConfirmation,
   assertWebsiteProjectionApplyConfirmation,
   assertWebsiteProjectionCheckoutClean,
   discoverWebsiteProjectionPlan,
   validateWebsiteProjectionPlan,
+  WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256,
 } from "./website-projection-db-operator-core.mjs";
 import {
+  adoptExistingWebsiteProjectionDatabase,
   applyWebsiteProjectionMigrations,
   inspectWebsiteProjectionDatabase,
+  readWebsiteProjectionAdoptionProtectedSnapshots,
 } from "./website-projection-db-postgres.mjs";
 import {
   closeHostedDatabase,
@@ -35,6 +39,7 @@ const HELP = `Usage:
   node scripts/website-projection-db-operator.mjs dry-run --plan FILE --expected-project-ref REF
   node scripts/website-projection-db-operator.mjs verify --plan FILE --expected-project-ref REF
   node scripts/website-projection-db-operator.mjs apply --plan FILE --expected-project-ref REF --confirm-apply PLAN_SHA256 --confirm-target REF
+  node scripts/website-projection-db-operator.mjs adopt-existing --plan FILE --expected-project-ref REF --source-base-snapshot FILE --source-expanded-snapshot FILE --confirm-adopt-existing PLAN_SHA256 --confirm-target REF --confirm-source-snapshot SNAPSHOT_SHA256 --confirm-adopt-through 0003
 
 Database credentials are accepted only through PROGRAMMABLE_MIGRATOR_DATABASE_URL.
 The CA certificate is accepted only through PROGRAMMABLE_POSTGRES_SSL_CA_PEM.
@@ -131,6 +136,16 @@ async function writeOutput(value, outputPath) {
 async function runDatabaseCommand(command, flags) {
   const allowed = ["--plan", "--expected-project-ref"];
   if (command === "apply") allowed.push("--confirm-apply", "--confirm-target");
+  if (command === "adopt-existing") {
+    allowed.push(
+      "--confirm-adopt-existing",
+      "--confirm-target",
+      "--confirm-source-snapshot",
+      "--confirm-adopt-through",
+      "--source-base-snapshot",
+      "--source-expanded-snapshot",
+    );
+  }
   exactFlags(flags, allowed);
   const plan = await readReviewedPlan(flags.get("--plan"));
   const expectedProjectRef = flags.get("--expected-project-ref");
@@ -142,6 +157,25 @@ async function runDatabaseCommand(command, flags) {
       confirmTarget: flags.get("--confirm-target"),
     });
   }
+  if (command === "adopt-existing") {
+    assertWebsiteProjectionAdoptExistingConfirmation({
+      plan,
+      expectedProjectRef,
+      expectedSourceSnapshotSha256:
+        WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256,
+      confirmAdoptExisting: flags.get("--confirm-adopt-existing"),
+      confirmTarget: flags.get("--confirm-target"),
+      confirmSourceSnapshot: flags.get("--confirm-source-snapshot"),
+      confirmAdoptThrough: flags.get("--confirm-adopt-through"),
+    });
+  }
+  const protectedSnapshots = command === "adopt-existing"
+    ? await readWebsiteProjectionAdoptionProtectedSnapshots({
+      baseSnapshotPath: flags.get("--source-base-snapshot"),
+      expandedSnapshotPath: flags.get("--source-expanded-snapshot"),
+      expectedProjectRef,
+    })
+    : null;
   const connection = await openHostedDatabase({
     databaseUrl: process.env.PROGRAMMABLE_MIGRATOR_DATABASE_URL,
     expectedProjectRef,
@@ -158,7 +192,20 @@ async function runDatabaseCommand(command, flags) {
           runtimePassword:
             process.env.PROGRAMMABLE_WEBSITE_PROJECTION_RUNTIME_PASSWORD,
         })
-      : await inspectWebsiteProjectionDatabase({
+      : command === "adopt-existing"
+        ? await adoptExistingWebsiteProjectionDatabase({
+          sql: connection.sql,
+          workspace,
+          plan,
+          expectedProjectRef,
+          sessionIdentity: connection.sessionIdentity,
+          expectedSourceSnapshotSha256:
+            WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256,
+          operatorCommit: await gitObject("HEAD"),
+          operatorTree: await gitObject("HEAD^{tree}"),
+          protectedSnapshots,
+        })
+        : await inspectWebsiteProjectionDatabase({
           sql: connection.sql,
           plan,
           expectedProjectRef,
@@ -172,7 +219,8 @@ async function runDatabaseCommand(command, flags) {
       target: connection.target,
       operatorIdentity: connection.operatorIdentity,
       state,
-      changed: command === "apply" && state.appliedThisRun.length > 0,
+      changed: (command === "apply" && state.appliedThisRun.length > 0)
+        || (command === "adopt-existing" && state.adoptedThisRun.length > 0),
     });
     if (command === "verify" && state.status !== "current") process.exitCode = 2;
   } finally {
@@ -194,7 +242,7 @@ async function main() {
     );
     return;
   }
-  if (["dry-run", "verify", "apply"].includes(command)) {
+  if (["dry-run", "verify", "apply", "adopt-existing"].includes(command)) {
     await runDatabaseCommand(command, flags);
     return;
   }

--- a/scripts/website-projection-db-operator.test.mjs
+++ b/scripts/website-projection-db-operator.test.mjs
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -22,8 +30,10 @@ import {
   adoptExistingWebsiteProjectionDatabase,
   applyWebsiteProjectionMigrations,
   assertWebsiteProjectionAdoptionLiveInventory,
+  assertWebsiteProjectionAdoptionProtectedSnapshots,
   buildCanonicalWebsiteProjectionAdoptionReference,
   inspectWebsiteProjectionDatabase,
+  readWebsiteProjectionAdoptionProtectedSnapshots,
 } from "./website-projection-db-postgres.mjs";
 
 const COMMIT = "76ebd54e2f0e31d055cfe6c36b7474b0e850de90";
@@ -501,6 +511,75 @@ test("protected adoption inventory validator rejects catalog, role, data and leg
       /adopt-existing/u,
     );
   }
+});
+
+test("protected snapshot reader rejects symlinks, broad modes, raw drift and target drift", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "website-projection-snapshot-test-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const target = path.join(root, "target.json");
+  const baseLink = path.join(root, "base-link.json");
+  const expandedLink = path.join(root, "expanded-link.json");
+  await writeFile(target, "{}\n", { mode: 0o600 });
+  await symlink(target, baseLink);
+  await symlink(target, expandedLink);
+  await assert.rejects(readWebsiteProjectionAdoptionProtectedSnapshots({
+    baseSnapshotPath: baseLink,
+    expandedSnapshotPath: expandedLink,
+    expectedProjectRef: PROJECT_REF,
+  }), /ELOOP|symbolic links/u);
+
+  const broadBase = path.join(root, "broad-base.json");
+  const broadExpanded = path.join(root, "broad-expanded.json");
+  await writeFile(broadBase, "{}\n", { mode: 0o600 });
+  await writeFile(broadExpanded, "{}\n", { mode: 0o600 });
+  await chmod(broadBase, 0o644);
+  await chmod(broadExpanded, 0o644);
+  await assert.rejects(readWebsiteProjectionAdoptionProtectedSnapshots({
+    baseSnapshotPath: broadBase,
+    expandedSnapshotPath: broadExpanded,
+    expectedProjectRef: PROJECT_REF,
+  }), /owner-only regular file/u);
+
+  const driftedBase = path.join(root, "drifted-base.json");
+  const driftedExpanded = path.join(root, "drifted-expanded.json");
+  await writeFile(driftedBase, "{}\n", { mode: 0o600 });
+  await writeFile(driftedExpanded, "{}\n", { mode: 0o600 });
+  await assert.rejects(readWebsiteProjectionAdoptionProtectedSnapshots({
+    baseSnapshotPath: driftedBase,
+    expandedSnapshotPath: driftedExpanded,
+    expectedProjectRef: PROJECT_REF,
+  }), /raw hash mismatch/u);
+
+  const source = {
+    repositoryCommit: COMMIT,
+    repositoryTree: TREE,
+    planSha256:
+      "0xf0fc7bca18c16da02be83f75d25e404bfe0b7ec7f10c29ecfbea93fcb0d7e973",
+  };
+  const targetIdentity = {
+    projectRef: PROJECT_REF,
+    host: `db.${PROJECT_REF}.supabase.co`,
+    port: 5432,
+    database: "postgres",
+    sslMode: "verify-full",
+  };
+  const baseSnapshot = {
+    kind: "programmable-website-projection-hosted-catalog-snapshot-v1",
+    source,
+    target: targetIdentity,
+  };
+  assert.throws(() => assertWebsiteProjectionAdoptionProtectedSnapshots({
+    baseSnapshot,
+    expandedSnapshot: {
+      kind: "programmable-website-projection-hosted-catalog-snapshot-v2",
+      schemaVersion: 2,
+      source,
+      target: targetIdentity,
+      baseSnapshot: { rawSha256: BASE_SNAPSHOT },
+      applicationCatalog: baseSnapshot,
+    },
+    expectedProjectRef: "z".repeat(20),
+  }), /protected snapshot identity mismatch/u);
 });
 
 test("irreversible apply confirmation binds both plan and target", async (t) => {
@@ -1061,6 +1140,12 @@ test("adopt-existing rolls back evidence DDL and rows on failure", async (t) => 
       AS evidence_schema
   `);
   assert.equal(evidenceSchema.rows[0].evidence_schema, null);
+  const runtimeRole = await fixture.database.query(`
+    SELECT rolinherit
+      FROM pg_roles
+     WHERE rolname = 'programmable_website_projection_runtime'
+  `);
+  assert.deepEqual(runtimeRole.rows, [{ rolinherit: true }]);
   const relations = await fixture.database.query(`
     SELECT count(*)::integer AS relation_count
       FROM pg_class class

--- a/scripts/website-projection-db-operator.test.mjs
+++ b/scripts/website-projection-db-operator.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -7,23 +7,32 @@ import test from "node:test";
 import { PGlite } from "@electric-sql/pglite";
 
 import {
+  assertWebsiteProjectionAdoptExistingConfirmation,
   assertWebsiteProjectionApplyConfirmation,
   assertWebsiteProjectionCheckoutClean,
   assertWebsiteProjectionRoleGraph,
   catalogSnapshotSha256,
   compareWebsiteProjectionEvidence,
   discoverWebsiteProjectionPlan,
+  unwrapWebsiteProjectionMigration,
   validateWebsiteProjectionPlan,
   validateWebsiteProjectionRuntimePassword,
 } from "./website-projection-db-operator-core.mjs";
 import {
+  adoptExistingWebsiteProjectionDatabase,
   applyWebsiteProjectionMigrations,
+  assertWebsiteProjectionAdoptionLiveInventory,
+  buildCanonicalWebsiteProjectionAdoptionReference,
   inspectWebsiteProjectionDatabase,
 } from "./website-projection-db-postgres.mjs";
 
-const COMMIT = "a".repeat(40);
-const TREE = "b".repeat(40);
-const PROJECT_REF = "abcdefghijklmnopqrst";
+const COMMIT = "76ebd54e2f0e31d055cfe6c36b7474b0e850de90";
+const TREE = "8e4ddd9a73818ce70f1284f3b2731bc87b005f27";
+const PROJECT_REF = "mnnvlrqwhfoppogslsje";
+const SOURCE_SNAPSHOT =
+  "0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284";
+const BASE_SNAPSHOT =
+  "0xac4a1fe60ebf677865a0f8ca6160162d9c457dc2bd401aa60fd820c8f2fdcc58";
 const MIGRATIONS = [
   "0001_projection_records_v1.sql",
   "0002_custom_launch_wallet_profile_v2.sql",
@@ -170,6 +179,13 @@ test("evidence comparison permits only an exact prefix on the exact target", asy
     target_project_ref: PROJECT_REF,
     catalog_sha256: `0x${"e".repeat(64)}`,
     operator_catalog_sha256: `0x${"f".repeat(64)}`,
+    evidence_kind: "applied",
+    adoption_source_snapshot_sha256: null,
+    adoption_source_catalog_sha256: null,
+    adoption_source_data_sha256: null,
+    adoption_attestation_sha256: null,
+    adoption_operator_commit: null,
+    adoption_operator_tree: null,
   };
   const state = compareWebsiteProjectionEvidence({
     plan,
@@ -263,6 +279,9 @@ function safeRole(name, overrides = {}) {
     rolcanlogin: false,
     rolreplication: false,
     rolbypassrls: false,
+    rolconnlimit: -1,
+    rolvaliduntil: null,
+    rolconfig: null,
     ...overrides,
   };
 }
@@ -285,11 +304,24 @@ test("role graph accepts only the constrained runtime and disconnected provider 
       safeRole("programmable_website_projection_runtime", { rolcanlogin: true }),
       ...providerRoles,
     ],
-    memberships: [{
-      member_name: "authenticator",
-      role_name: "authenticated",
-      admin_option: false,
-    }],
+    memberships: [
+      {
+        member_name: "authenticator",
+        role_name: "authenticated",
+        grantor_name: "postgres",
+        admin_option: false,
+        inherit_option: true,
+        set_option: true,
+      },
+      {
+        member_name: "postgres",
+        role_name: "programmable_website_projection_runtime",
+        grantor_name: "supabase_admin",
+        admin_option: true,
+        inherit_option: false,
+        set_option: false,
+      },
+    ],
     appliedCount: 5,
   });
   assert.equal(current.runtimeRoleStatus, "current");
@@ -320,7 +352,10 @@ test("role graph accepts only the constrained runtime and disconnected provider 
     memberships: [{
       member_name: "service_role",
       role_name: "postgres",
+      grantor_name: "postgres",
       admin_option: false,
+      inherit_option: true,
+      set_option: true,
     }],
     appliedCount: 0,
   }), /outgoing role membership/u);
@@ -333,7 +368,10 @@ test("role graph accepts only the constrained runtime and disconnected provider 
     memberships: [{
       member_name: "operator_helper",
       role_name: "programmable_website_projection_runtime",
+      grantor_name: "postgres",
       admin_option: false,
+      inherit_option: true,
+      set_option: true,
     }],
     appliedCount: 0,
   }), /outgoing role membership/u);
@@ -351,6 +389,118 @@ test("catalog fingerprints are canonical and reject non-row data", () => {
   assert.equal(left, right);
   assert.match(left, /^0x[0-9a-f]{64}$/u);
   assert.throws(() => catalogSnapshotSha256({ tables: "not rows" }), /catalog/u);
+});
+
+test("protected adoption inventory validator rejects catalog, role, data and legacy drift", () => {
+  const structure = {
+    namespaces: [{ nspname: "programmable_website_projection_v1", owner_name: "postgres" }],
+    relations: [],
+    columns: [],
+    constraints: [],
+    indexes: [],
+    policies: [],
+    triggers: [],
+    functions: [],
+    schemaAcl: [],
+    relationAcl: [],
+    columnAcl: [],
+    functionAcl: [],
+  };
+  const roles = [
+    safeRole("anon", { rolinherit: true }),
+    safeRole("authenticated", { rolinherit: true }),
+    safeRole("postgres", { rolinherit: true, rolcanlogin: true }),
+    safeRole("programmable_website_projection_runtime", {
+      rolinherit: true,
+      rolcanlogin: true,
+    }),
+    safeRole("service_role", { rolinherit: true, rolbypassrls: true }),
+    safeRole("supabase_admin", { rolinherit: true, rolcanlogin: true }),
+  ];
+  const memberships = [{
+    member_name: "postgres",
+    role_name: "programmable_website_projection_runtime",
+    grantor_name: "supabase_admin",
+    admin_option: true,
+    inherit_option: false,
+    set_option: false,
+  }];
+  const sourceData = { rowPresence: [
+    { relation_name: "credential_uses", has_rows: false },
+    { relation_name: "projection_records", has_rows: false },
+    { relation_name: "registry_custom_launch_records", has_rows: false },
+  ] };
+  const legacyInventory = {
+    relations: [
+      {
+        nspname: "supabase_migrations",
+        relname: "programmable_migration_evidence",
+        relkind: "r",
+      },
+      {
+        nspname: "supabase_migrations",
+        relname: "schema_migrations",
+        relkind: "r",
+      },
+    ],
+    columns: [],
+    schemaRows: [],
+    evidenceRows: [],
+    publicCanonicalSha256:
+      "0x93e41eab957ab8add897a8b277bcaaa0a5f10eebeb27f47db5bc0e59640484a2",
+  };
+  const protectedSnapshots = {
+    expandedSnapshot: {
+      applicationCatalog: {
+        schemas: structure.namespaces,
+        ...Object.fromEntries(Object.entries(structure).filter(([key]) =>
+          key !== "namespaces")),
+        applicationRowCounts: sourceData.rowPresence.map(
+          ({ relation_name: table_name }) => ({ table_name, row_count: "0" }),
+        ),
+      },
+      roleExtended: roles,
+      membershipExtended: memberships,
+      legacySupabaseInventory: {
+        columns: [],
+        schemaRows: [],
+        evidenceRows: [],
+      },
+    },
+  };
+  const valid = {
+    sourceCatalog: {
+      roles: roles.filter(({ rolname }) => rolname !== "supabase_admin"),
+      memberships,
+      ...structure,
+    },
+    sourceData,
+    extendedRoleInventory: { roles, memberships },
+    legacyInventory,
+    protectedSnapshots,
+  };
+  assert.equal(assertWebsiteProjectionAdoptionLiveInventory(valid), true);
+  for (const mutate of [
+    (value) => { value.sourceCatalog.relations.push({ relname: "extra" }); },
+    (value) => { value.sourceCatalog.roles[3].rolinherit = false; },
+    (value) => { value.sourceCatalog.memberships[0].grantor_name = "postgres"; },
+    (value) => { value.extendedRoleInventory.roles[3].rolconnlimit = 1; },
+    (value) => { value.extendedRoleInventory.memberships[0].set_option = true; },
+    (value) => { value.sourceData.rowPresence[0].has_rows = true; },
+    (value) => { value.legacyInventory.relations.push({ relname: "extra" }); },
+    (value) => { value.legacyInventory.columns.push({ column_name: "extra" }); },
+    (value) => { value.legacyInventory.schemaRows.push({ version: "extra" }); },
+    (value) => { value.legacyInventory.evidenceRows.push({ version: "extra" }); },
+    (value) => { value.legacyInventory.publicCanonicalSha256 = `0x${"0".repeat(64)}`; },
+  ]) {
+    const drifted = structuredClone(valid);
+    drifted.protectedSnapshots = structuredClone(protectedSnapshots);
+    mutate(drifted);
+    assert.throws(
+      () => assertWebsiteProjectionAdoptionLiveInventory(drifted),
+      /adopt-existing/u,
+    );
+  }
 });
 
 test("irreversible apply confirmation binds both plan and target", async (t) => {
@@ -381,7 +531,61 @@ test("irreversible apply confirmation binds both plan and target", async (t) => 
   }), /target/u);
 });
 
-function pgliteSql(client, { beforeStatement } = {}) {
+test("adopt-existing confirmation is distinct and binds plan and target", async () => {
+  const workspace = path.resolve(new URL("..", import.meta.url).pathname);
+  const plan = await discoverWebsiteProjectionPlan({
+    workspace,
+    repositoryCommit: COMMIT,
+    repositoryTree: TREE,
+  });
+  assert.doesNotThrow(() => assertWebsiteProjectionAdoptExistingConfirmation({
+    plan,
+    expectedProjectRef: PROJECT_REF,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+    confirmAdoptExisting: plan.planSha256,
+    confirmTarget: PROJECT_REF,
+    confirmSourceSnapshot: SOURCE_SNAPSHOT,
+    confirmAdoptThrough: "0003",
+  }));
+  assert.throws(() => assertWebsiteProjectionAdoptExistingConfirmation({
+    plan,
+    expectedProjectRef: PROJECT_REF,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+    confirmAdoptExisting: `0x${"f".repeat(64)}`,
+    confirmTarget: PROJECT_REF,
+    confirmSourceSnapshot: SOURCE_SNAPSHOT,
+    confirmAdoptThrough: "0003",
+  }), /adopt-existing confirmation/u);
+  assert.throws(() => assertWebsiteProjectionAdoptExistingConfirmation({
+    plan,
+    expectedProjectRef: PROJECT_REF,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+    confirmAdoptExisting: plan.planSha256,
+    confirmTarget: "z".repeat(20),
+    confirmSourceSnapshot: SOURCE_SNAPSHOT,
+    confirmAdoptThrough: "0003",
+  }), /adopt-existing target/u);
+  assert.throws(() => assertWebsiteProjectionAdoptExistingConfirmation({
+    plan,
+    expectedProjectRef: PROJECT_REF,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+    confirmAdoptExisting: plan.planSha256,
+    confirmTarget: PROJECT_REF,
+    confirmSourceSnapshot: `0x${"e".repeat(64)}`,
+    confirmAdoptThrough: "0003",
+  }), /source snapshot/u);
+  assert.throws(() => assertWebsiteProjectionAdoptExistingConfirmation({
+    plan,
+    expectedProjectRef: PROJECT_REF,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+    confirmAdoptExisting: plan.planSha256,
+    confirmTarget: PROJECT_REF,
+    confirmSourceSnapshot: SOURCE_SNAPSHOT,
+    confirmAdoptThrough: "0005",
+  }), /through confirmation/u);
+});
+
+function pgliteSql(client, { beforeStatement, afterRows } = {}) {
   const sql = {
     unsafe(statement, parameters = []) {
       beforeStatement?.(statement);
@@ -391,12 +595,14 @@ function pgliteSql(client, { beforeStatement } = {}) {
         || normalized.startsWith("with"))
         ? client.query(statement, parameters).then(({ rows }) => rows)
         : client.exec(statement).then((results) => results.at(-1)?.rows ?? []);
-      operation.simple = () => operation;
-      return operation;
+      const transformed = operation.then((resultRows) =>
+        afterRows?.(statement, resultRows) ?? resultRows);
+      transformed.simple = () => transformed;
+      return transformed;
     },
     async begin(callback) {
       return await client.transaction(async (transaction) =>
-        callback(pgliteSql(transaction, { beforeStatement })));
+        callback(pgliteSql(transaction, { beforeStatement, afterRows })));
     },
   };
   return sql;
@@ -406,6 +612,7 @@ async function pgliteOperatorFixture(t) {
   const database = new PGlite();
   t.after(() => database.close());
   await database.exec(`
+    CREATE ROLE supabase_admin SUPERUSER NOLOGIN;
     CREATE ROLE anon NOLOGIN;
     CREATE ROLE authenticated NOLOGIN;
     CREATE ROLE service_role NOLOGIN;
@@ -431,6 +638,101 @@ async function pgliteOperatorFixture(t) {
       backendPid: Number(identity.backend_pid),
       sessionUser: identity.session_user,
       currentRole: identity.current_role,
+    },
+  };
+}
+
+async function pgliteExistingApplicationFixture(t) {
+  const fixture = await pgliteOperatorFixture(t);
+  await fixture.database.exec(`
+    CREATE ROLE programmable_website_projection_runtime WITH
+      LOGIN INHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS
+      PASSWORD 'correct horse battery staple 2026';
+    SET ROLE supabase_admin;
+    GRANT programmable_website_projection_runtime TO postgres
+      WITH ADMIN TRUE, INHERIT FALSE, SET FALSE;
+    RESET ROLE;
+  `);
+  for (const migration of fixture.plan.migrations.slice(0, 3)) {
+    const source = await readFile(
+      path.join(fixture.workspace, migration.file),
+      "utf8",
+    );
+    await fixture.database.exec(unwrapWebsiteProjectionMigration(source));
+  }
+  await fixture.database.exec(`
+    REVOKE ALL ON SCHEMA programmable_website_projection_v1
+      FROM PUBLIC, anon, authenticated, service_role,
+           programmable_website_projection_runtime;
+    GRANT USAGE ON SCHEMA programmable_website_projection_v1
+      TO programmable_website_projection_runtime;
+    REVOKE ALL ON ALL TABLES IN SCHEMA programmable_website_projection_v1
+      FROM PUBLIC, anon, authenticated, service_role,
+           programmable_website_projection_runtime;
+    GRANT SELECT, INSERT
+      ON programmable_website_projection_v1.projection_records,
+         programmable_website_projection_v1.credential_uses,
+         programmable_website_projection_v1.registry_custom_launch_records
+      TO programmable_website_projection_runtime;
+    GRANT UPDATE (
+      lifecycle_generation, lifecycle_state, lifecycle_binding_hash,
+      observed_at, canonical_materialization, canonical_public_record,
+      record_binding_hash, launch_security_binding_hash,
+      launching_wallet_namespace, launching_wallet_value, updated_at
+    ) ON programmable_website_projection_v1.registry_custom_launch_records
+      TO programmable_website_projection_runtime;
+  `);
+  fixture.sql = pgliteSql(fixture.database, { afterRows: pgliteHostedRows });
+  return fixture;
+}
+
+function pgliteHostedRows(statement, resultRows) {
+  if (!statement.includes("/* website-projection:memberships */")) {
+    return resultRows;
+  }
+  return resultRows.map((row) =>
+    row.member_name === "postgres"
+      && row.role_name === "programmable_website_projection_runtime"
+      ? { ...row, grantor_name: "supabase_admin" }
+      : row);
+}
+
+function lockRejectedSql(sql, sessionIdentity) {
+  return {
+    ...sql,
+    unsafe(statement, parameters = []) {
+      if (statement.includes("/* website-projection:lock */")) {
+        const operation = Promise.resolve([{
+          acquired: false,
+          backend_pid: sessionIdentity.backendPid,
+          session_user: sessionIdentity.sessionUser,
+          current_role: sessionIdentity.currentRole,
+        }]);
+        operation.simple = () => operation;
+        return operation;
+      }
+      return sql.unsafe(statement, parameters);
+    },
+  };
+}
+
+function pgliteAdoptionAuditOptions() {
+  return {
+    protectedSnapshots: {
+      sourceSnapshotSha256: SOURCE_SNAPSHOT,
+      baseSnapshotSha256: BASE_SNAPSHOT,
+      expandedSnapshot: {},
+    },
+    legacyInventoryReader: async () => ({ fixture: true }),
+    liveInventoryValidator({ sourceData }) {
+      const expected = [
+        { relation_name: "credential_uses", has_rows: false },
+        { relation_name: "projection_records", has_rows: false },
+        { relation_name: "registry_custom_launch_records", has_rows: false },
+      ];
+      if (JSON.stringify(sourceData.rowPresence) !== JSON.stringify(expected)) {
+        throw new Error("adopt-existing rejects unproven application data");
+      }
     },
   };
 }
@@ -523,4 +825,248 @@ test("database operator bootstraps, applies, resumes and detects catalog drift",
     expectedProjectRef: PROJECT_REF,
     sessionIdentity,
   }), /catalog fingerprint mismatch/u);
+});
+
+test("adopt-existing records exact evidence atomically without replaying application DDL", async (t) => {
+  const fixture = await pgliteExistingApplicationFixture(t);
+  const targetStatements = [];
+  const trackedSql = pgliteSql(fixture.database, {
+    beforeStatement(statement) {
+      targetStatements.push(statement);
+    },
+    afterRows: pgliteHostedRows,
+  });
+  const reference = await buildCanonicalWebsiteProjectionAdoptionReference({
+    workspace: fixture.workspace,
+    plan: fixture.plan,
+  });
+  const adopted = await adoptExistingWebsiteProjectionDatabase({
+    ...pgliteAdoptionAuditOptions(),
+    sql: trackedSql,
+    workspace: fixture.workspace,
+    plan: fixture.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+    canonicalReference: reference,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+  });
+  assert.equal(adopted.status, "pending");
+  assert.equal(adopted.appliedCount, 3);
+  assert.equal(adopted.adoptedExisting, true);
+  assert.deepEqual(adopted.adoptedThisRun, [
+    "0001", "0002", "0003",
+  ]);
+  assert.match(adopted.catalogSha256, /^0x[0-9a-f]{64}$/u);
+  assert.match(adopted.adoptionDataSha256, /^0x[0-9a-f]{64}$/u);
+  assert.equal(targetStatements.some((statement) =>
+    /(?:CREATE|ALTER|DROP)\s+(?:TABLE|FUNCTION|TRIGGER|POLICY|INDEX)\s+programmable_website_projection_v1/iu
+      .test(statement)), false);
+
+  const evidence = await fixture.database.query(`
+    SELECT evidence_kind, adoption_source_catalog_sha256,
+           adoption_source_data_sha256, adoption_source_snapshot_sha256,
+           adoption_attestation_sha256
+      FROM programmable_website_projection_migrations.migration_evidence_v1
+     ORDER BY ordinal
+  `);
+  assert.equal(evidence.rows.length, 3);
+  assert.ok(evidence.rows.every(({ evidence_kind }) =>
+    evidence_kind === "adopted-existing-prefix-v1"));
+  assert.ok(evidence.rows.every(({ adoption_source_snapshot_sha256 }) =>
+    adoption_source_snapshot_sha256 === SOURCE_SNAPSHOT));
+  assert.ok(evidence.rows.every(({ adoption_source_catalog_sha256 }) =>
+    adoption_source_catalog_sha256 === adopted.adoptionSourceCatalogSha256));
+  assert.ok(evidence.rows.every(({ adoption_source_data_sha256 }) =>
+    adoption_source_data_sha256 === adopted.adoptionDataSha256));
+  assert.ok(evidence.rows.every(({ adoption_attestation_sha256 }) =>
+    adoption_attestation_sha256 === adopted.adoptionAttestationSha256));
+  const adoptionEvidence = await fixture.database.query(`
+    SELECT evidence_kind, adopted_through_version,
+           credential_uses_count, projection_records_count,
+           registry_custom_launch_records_count,
+           runtime_rolinherit_before, runtime_rolinherit_after
+      FROM programmable_website_projection_migrations.adoption_evidence_v1
+  `);
+  assert.deepEqual(adoptionEvidence.rows, [{
+    evidence_kind: "adopted-existing-prefix-v1",
+    adopted_through_version: "0003",
+    credential_uses_count: 0,
+    projection_records_count: 0,
+    registry_custom_launch_records_count: 0,
+    runtime_rolinherit_before: true,
+    runtime_rolinherit_after: false,
+  }]);
+
+  const continued = await applyWebsiteProjectionMigrations({
+    sql: fixture.sql,
+    workspace: fixture.workspace,
+    plan: fixture.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+  });
+  assert.equal(continued.status, "current");
+  assert.deepEqual(continued.appliedThisRun, ["0004", "0005"]);
+});
+
+test("adopt-existing rejects every nonempty unproven application state", async (t) => {
+  const fixture = await pgliteExistingApplicationFixture(t);
+  await fixture.database.exec(`
+    INSERT INTO programmable_website_projection_v1.credential_uses (
+      credential_id, request_binding_hash, canonical_use
+    ) VALUES (
+      'unproven-row',
+      'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '{}'
+    );
+  `);
+  await assert.rejects(adoptExistingWebsiteProjectionDatabase({
+    ...pgliteAdoptionAuditOptions(),
+    sql: fixture.sql,
+    workspace: fixture.workspace,
+    plan: fixture.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+  }), /unproven application data/u);
+  const evidenceSchema = await fixture.database.query(`
+    SELECT to_regnamespace('programmable_website_projection_migrations')::text
+      AS evidence_schema
+  `);
+  assert.equal(evidenceSchema.rows[0].evidence_schema, null);
+});
+
+test("adopt-existing rejects forbidden catalog extras", async (t) => {
+  const fixture = await pgliteExistingApplicationFixture(t);
+  await fixture.database.exec(`
+    CREATE TABLE programmable_website_projection_v1.unreviewed_extra (
+      id bigint PRIMARY KEY
+    );
+  `);
+  await assert.rejects(adoptExistingWebsiteProjectionDatabase({
+    ...pgliteAdoptionAuditOptions(),
+    sql: fixture.sql,
+    workspace: fixture.workspace,
+    plan: fixture.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+  }), /catalog does not exactly match/u);
+});
+
+test("adopt-existing rejects partial or existing operator evidence", async (t) => {
+  const partial = await pgliteExistingApplicationFixture(t);
+  await partial.database.exec(`
+    CREATE SCHEMA programmable_website_projection_migrations;
+  `);
+  await assert.rejects(adoptExistingWebsiteProjectionDatabase({
+    ...pgliteAdoptionAuditOptions(),
+    sql: partial.sql,
+    workspace: partial.workspace,
+    plan: partial.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: partial.sessionIdentity,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+  }), /evidence infrastructure is partial/u);
+
+  const existing = await pgliteOperatorFixture(t);
+  await applyWebsiteProjectionMigrations({
+    sql: existing.sql,
+    workspace: existing.workspace,
+    plan: existing.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: existing.sessionIdentity,
+    runtimePassword: "correct horse battery staple 2026",
+  });
+  await assert.rejects(adoptExistingWebsiteProjectionDatabase({
+    ...pgliteAdoptionAuditOptions(),
+    sql: existing.sql,
+    workspace: existing.workspace,
+    plan: existing.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: existing.sessionIdentity,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+  }), /operator evidence must be absent/u);
+});
+
+test("adopt-existing rejects grant drift before writing evidence", async (t) => {
+  const fixture = await pgliteExistingApplicationFixture(t);
+  await fixture.database.exec(`
+    GRANT UPDATE ON programmable_website_projection_v1.projection_records
+      TO programmable_website_projection_runtime;
+  `);
+  await assert.rejects(adoptExistingWebsiteProjectionDatabase({
+    ...pgliteAdoptionAuditOptions(),
+    sql: fixture.sql,
+    workspace: fixture.workspace,
+    plan: fixture.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+  }), /catalog does not exactly match/u);
+});
+
+test("adopt-existing permits only the reviewed runtime INHERIT drift", async (t) => {
+  const fixture = await pgliteExistingApplicationFixture(t);
+  await fixture.database.exec(`
+    ALTER ROLE programmable_website_projection_runtime CREATEDB;
+  `);
+  await assert.rejects(adoptExistingWebsiteProjectionDatabase({
+    ...pgliteAdoptionAuditOptions(),
+    sql: fixture.sql,
+    workspace: fixture.workspace,
+    plan: fixture.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+  }), /source runtime role posture/u);
+});
+
+test("adopt-existing fails closed when another operator owns the lock", async (t) => {
+  const fixture = await pgliteExistingApplicationFixture(t);
+  await assert.rejects(adoptExistingWebsiteProjectionDatabase({
+    ...pgliteAdoptionAuditOptions(),
+    sql: lockRejectedSql(fixture.sql, fixture.sessionIdentity),
+    workspace: fixture.workspace,
+    plan: fixture.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+  }), /another website projection migration operator holds the lock/u);
+});
+
+test("adopt-existing rolls back evidence DDL and rows on failure", async (t) => {
+  const fixture = await pgliteExistingApplicationFixture(t);
+  let insertObserved = false;
+  const failingSql = pgliteSql(fixture.database, {
+    beforeStatement(statement) {
+      if (statement.includes("INSERT INTO programmable_website_projection_migrations.migration_evidence_v1")) {
+        insertObserved = true;
+        throw new Error("injected adoption evidence failure");
+      }
+    },
+    afterRows: pgliteHostedRows,
+  });
+  await assert.rejects(adoptExistingWebsiteProjectionDatabase({
+    ...pgliteAdoptionAuditOptions(),
+    sql: failingSql,
+    workspace: fixture.workspace,
+    plan: fixture.plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+    expectedSourceSnapshotSha256: SOURCE_SNAPSHOT,
+  }), /injected adoption evidence failure/u);
+  assert.equal(insertObserved, true);
+  const evidenceSchema = await fixture.database.query(`
+    SELECT to_regnamespace('programmable_website_projection_migrations')::text
+      AS evidence_schema
+  `);
+  assert.equal(evidenceSchema.rows[0].evidence_schema, null);
+  const relations = await fixture.database.query(`
+    SELECT count(*)::integer AS relation_count
+      FROM pg_class class
+      JOIN pg_namespace namespace ON namespace.oid = class.relnamespace
+     WHERE namespace.nspname = 'programmable_website_projection_v1'
+       AND class.relkind = 'r'
+  `);
+  assert.equal(relations.rows[0].relation_count, 3);
 });

--- a/scripts/website-projection-db-postgres.mjs
+++ b/scripts/website-projection-db-postgres.mjs
@@ -1,19 +1,36 @@
-import { readFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { open, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
+  assertWebsiteProjectionAdoptionSourcePlan,
+  assertWebsiteProjectionAdoptionSourceRoleGraph,
   assertWebsiteProjectionRoleGraph,
   catalogSnapshotSha256,
   compareWebsiteProjectionEvidence,
   unwrapWebsiteProjectionMigration,
   validateWebsiteProjectionPlan,
   validateWebsiteProjectionRuntimePassword,
+  websiteProjectionAdoptionAttestationSha256,
+  WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
+  WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
+  WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256,
+  WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256,
+  WEBSITE_PROJECTION_ADOPTION_SOURCE_COMMIT,
+  WEBSITE_PROJECTION_ADOPTION_SOURCE_ORDER_SHA256,
+  WEBSITE_PROJECTION_ADOPTION_SOURCE_PLAN_SHA256,
+  WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256,
+  WEBSITE_PROJECTION_ADOPTION_SOURCE_TREE,
+  WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF,
   WEBSITE_PROJECTION_APPLICATION_SCHEMA,
   WEBSITE_PROJECTION_EVIDENCE_SCHEMA,
   WEBSITE_PROJECTION_EVIDENCE_TABLE,
   WEBSITE_PROJECTION_RUNTIME_ROLE,
 } from "./website-projection-db-operator-core.mjs";
-import { sha256 } from "./data-pipeline/hosted-db-operator-core.mjs";
+import {
+  canonicalJson,
+  sha256,
+} from "./data-pipeline/hosted-db-operator-core.mjs";
 
 const OPERATOR_LOCK = "programmable:website-projection-migrations:v1";
 const RELEVANT_ROLES = [
@@ -23,6 +40,26 @@ const RELEVANT_ROLES = [
   "authenticated",
   "service_role",
 ];
+const EXTENDED_ROLE_NAMES = [
+  "anon",
+  "authenticated",
+  "postgres",
+  WEBSITE_PROJECTION_RUNTIME_ROLE,
+  "service_role",
+  "supabase_admin",
+];
+const LEGACY_EVIDENCE_RELATIONS = Object.freeze([
+  {
+    nspname: "supabase_migrations",
+    relname: "programmable_migration_evidence",
+    relkind: "r",
+  },
+  {
+    nspname: "supabase_migrations",
+    relname: "schema_migrations",
+    relkind: "r",
+  },
+]);
 
 const EVIDENCE_DDL = `
 CREATE SCHEMA programmable_website_projection_migrations;
@@ -43,6 +80,13 @@ CREATE TABLE programmable_website_projection_migrations.migration_evidence_v1 (
   target_project_ref text NOT NULL,
   catalog_sha256 text NOT NULL,
   operator_catalog_sha256 text NOT NULL,
+  evidence_kind text NOT NULL,
+  adoption_source_snapshot_sha256 text,
+  adoption_source_catalog_sha256 text,
+  adoption_source_data_sha256 text,
+  adoption_attestation_sha256 text,
+  adoption_operator_commit text,
+  adoption_operator_tree text,
   applied_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
   CONSTRAINT migration_evidence_v1_pk PRIMARY KEY (ordinal),
   CONSTRAINT migration_evidence_v1_version_unique UNIQUE (version),
@@ -64,9 +108,123 @@ CREATE TABLE programmable_website_projection_migrations.migration_evidence_v1 (
   CONSTRAINT migration_evidence_v1_catalog_hash_check
     CHECK (catalog_sha256 ~ '^0x[0-9a-f]{64}$'),
   CONSTRAINT migration_evidence_v1_operator_catalog_hash_check
-    CHECK (operator_catalog_sha256 ~ '^0x[0-9a-f]{64}$')
+    CHECK (operator_catalog_sha256 ~ '^0x[0-9a-f]{64}$'),
+  CONSTRAINT migration_evidence_v1_kind_check CHECK (
+    evidence_kind IN ('applied', 'adopted-existing-prefix-v1')
+  ),
+  CONSTRAINT migration_evidence_v1_adoption_check CHECK (
+    (
+      evidence_kind = 'applied'
+      AND adoption_source_snapshot_sha256 IS NULL
+      AND adoption_source_catalog_sha256 IS NULL
+      AND adoption_source_data_sha256 IS NULL
+      AND adoption_attestation_sha256 IS NULL
+      AND adoption_operator_commit IS NULL
+      AND adoption_operator_tree IS NULL
+    ) OR (
+      evidence_kind = 'adopted-existing-prefix-v1'
+      AND ordinal BETWEEN 1 AND 3
+      AND adoption_source_snapshot_sha256 =
+        '0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284'
+      AND adoption_source_catalog_sha256 ~ '^0x[0-9a-f]{64}$'
+      AND adoption_source_data_sha256 ~ '^0x[0-9a-f]{64}$'
+      AND adoption_attestation_sha256 ~ '^0x[0-9a-f]{64}$'
+      AND adoption_operator_commit ~ '^[0-9a-f]{40}$'
+      AND adoption_operator_tree ~ '^[0-9a-f]{40}$'
+    )
+  )
+);
+
+CREATE TABLE programmable_website_projection_migrations.adoption_evidence_v1 (
+  singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+  evidence_kind text NOT NULL CHECK (
+    evidence_kind = 'adopted-existing-prefix-v1'
+  ),
+  adopted_through_version text NOT NULL CHECK (
+    adopted_through_version = '0003'
+  ),
+  source_snapshot_sha256 text NOT NULL CHECK (
+    source_snapshot_sha256 =
+      '0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284'
+  ),
+  base_snapshot_sha256 text NOT NULL CHECK (
+    base_snapshot_sha256 =
+      '0xac4a1fe60ebf677865a0f8ca6160162d9c457dc2bd401aa60fd820c8f2fdcc58'
+  ),
+  legacy_inventory_sha256 text NOT NULL CHECK (
+    legacy_inventory_sha256 =
+      '0xd32953874c1466be82433d97e6532d0572ddcf80eed261efa119b25f17e0f5b3'
+  ),
+  legacy_public_sha256 text NOT NULL CHECK (
+    legacy_public_sha256 =
+      '0x93e41eab957ab8add897a8b277bcaaa0a5f10eebeb27f47db5bc0e59640484a2'
+  ),
+  source_catalog_sha256 text NOT NULL CHECK (
+    source_catalog_sha256 ~ '^0x[0-9a-f]{64}$'
+  ),
+  corrected_catalog_sha256 text NOT NULL CHECK (
+    corrected_catalog_sha256 ~ '^0x[0-9a-f]{64}$'
+  ),
+  source_data_sha256 text NOT NULL CHECK (
+    source_data_sha256 ~ '^0x[0-9a-f]{64}$'
+  ),
+  operator_catalog_sha256 text NOT NULL CHECK (
+    operator_catalog_sha256 ~ '^0x[0-9a-f]{64}$'
+  ),
+  attestation_sha256 text NOT NULL CHECK (
+    attestation_sha256 ~ '^0x[0-9a-f]{64}$'
+  ),
+  source_plan_sha256 text NOT NULL CHECK (
+    source_plan_sha256 =
+      '0xf0fc7bca18c16da02be83f75d25e404bfe0b7ec7f10c29ecfbea93fcb0d7e973'
+  ),
+  source_order_sha256 text NOT NULL CHECK (
+    source_order_sha256 =
+      '0xce50954bfa6ff3b66b849bb5b53e8f1adf93abbe12cf865c19375100f2571cc2'
+  ),
+  source_repository_commit text NOT NULL CHECK (
+    source_repository_commit =
+      '76ebd54e2f0e31d055cfe6c36b7474b0e850de90'
+  ),
+  source_repository_tree text NOT NULL CHECK (
+    source_repository_tree =
+      '8e4ddd9a73818ce70f1284f3b2731bc87b005f27'
+  ),
+  successor_plan_sha256 text NOT NULL CHECK (
+    successor_plan_sha256 ~ '^0x[0-9a-f]{64}$'
+  ),
+  successor_order_sha256 text NOT NULL CHECK (
+    successor_order_sha256 =
+      '0xce50954bfa6ff3b66b849bb5b53e8f1adf93abbe12cf865c19375100f2571cc2'
+  ),
+  successor_repository_commit text NOT NULL CHECK (
+    successor_repository_commit ~ '^[0-9a-f]{40}$'
+  ),
+  successor_repository_tree text NOT NULL CHECK (
+    successor_repository_tree ~ '^[0-9a-f]{40}$'
+  ),
+  target_project_ref text NOT NULL CHECK (
+    target_project_ref ~ '^[a-z0-9]{20}$'
+  ),
+  operator_commit text NOT NULL CHECK (
+    operator_commit ~ '^[0-9a-f]{40}$'
+  ),
+  operator_tree text NOT NULL CHECK (
+    operator_tree ~ '^[0-9a-f]{40}$'
+  ),
+  credential_uses_count bigint NOT NULL CHECK (credential_uses_count = 0),
+  projection_records_count bigint NOT NULL CHECK (projection_records_count = 0),
+  registry_custom_launch_records_count bigint NOT NULL CHECK (
+    registry_custom_launch_records_count = 0
+  ),
+  runtime_rolinherit_before boolean NOT NULL CHECK (runtime_rolinherit_before),
+  runtime_rolinherit_after boolean NOT NULL CHECK (NOT runtime_rolinherit_after),
+  adopted_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp()
 );
 REVOKE ALL ON programmable_website_projection_migrations.migration_evidence_v1
+  FROM PUBLIC, anon, authenticated, service_role,
+       programmable_website_projection_runtime;
+REVOKE ALL ON programmable_website_projection_migrations.adoption_evidence_v1
   FROM PUBLIC, anon, authenticated, service_role,
        programmable_website_projection_runtime;
 `;
@@ -112,8 +270,191 @@ GRANT EXECUTE ON FUNCTION
   TO programmable_website_projection_runtime;
 `;
 
+// The already-hosted through-0003 source received this deliberately narrower
+// grant set after migration 0003. It is part of the protected source state,
+// not a sixth migration and not permission to install any 0004/0005 objects.
+const ADOPTION_PREFIX_PRIVILEGES = `
+REVOKE ALL ON SCHEMA programmable_website_projection_v1
+  FROM PUBLIC, anon, authenticated, service_role,
+       programmable_website_projection_runtime;
+GRANT USAGE ON SCHEMA programmable_website_projection_v1
+  TO programmable_website_projection_runtime;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA programmable_website_projection_v1
+  FROM PUBLIC, anon, authenticated, service_role,
+       programmable_website_projection_runtime;
+GRANT SELECT, INSERT
+  ON programmable_website_projection_v1.projection_records,
+     programmable_website_projection_v1.credential_uses,
+     programmable_website_projection_v1.registry_custom_launch_records
+  TO programmable_website_projection_runtime;
+GRANT UPDATE (
+  lifecycle_generation, lifecycle_state, lifecycle_binding_hash,
+  observed_at, canonical_materialization, canonical_public_record,
+  record_binding_hash, launch_security_binding_hash,
+  launching_wallet_namespace, launching_wallet_value, updated_at
+) ON programmable_website_projection_v1.registry_custom_launch_records
+  TO programmable_website_projection_runtime;
+`;
+
 function rows(value) {
   return Array.isArray(value) ? value.map((row) => ({ ...row })) : [];
+}
+
+function plainObject(value) {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function exactJson(actual, expected, message) {
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    throw new Error(message);
+  }
+}
+
+async function readProtectedSnapshotFile(filePath, expectedSha256, label) {
+  if (typeof filePath !== "string" || !path.isAbsolute(filePath)) {
+    throw new Error(`${label} path must be absolute`);
+  }
+  let handle;
+  try {
+    handle = await open(
+      filePath,
+      fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0),
+    );
+    const metadata = await handle.stat();
+    if (!metadata.isFile()
+      || (metadata.mode & 0o777) !== 0o600
+      || (typeof process.getuid === "function" && metadata.uid !== process.getuid())) {
+      throw new Error(`${label} must be an owner-only regular file`);
+    }
+    const contents = await handle.readFile();
+    if (sha256(contents) !== expectedSha256) {
+      throw new Error(`${label} raw hash mismatch`);
+    }
+    let value;
+    try {
+      value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(contents));
+    } catch {
+      throw new Error(`${label} must contain valid UTF-8 JSON`);
+    }
+    if (!plainObject(value)) throw new Error(`${label} JSON is invalid`);
+    return value;
+  } finally {
+    await handle?.close();
+  }
+}
+
+function expectedSourceIdentity(value) {
+  return plainObject(value)
+    && value.repositoryCommit === WEBSITE_PROJECTION_ADOPTION_SOURCE_COMMIT
+    && value.repositoryTree === WEBSITE_PROJECTION_ADOPTION_SOURCE_TREE
+    && value.planSha256 === WEBSITE_PROJECTION_ADOPTION_SOURCE_PLAN_SHA256;
+}
+
+function expectedTargetIdentity(value, expectedProjectRef) {
+  return plainObject(value)
+    && expectedProjectRef === WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF
+    && value.projectRef === expectedProjectRef
+    && value.host === `db.${expectedProjectRef}.supabase.co`
+    && Number(value.port) === 5432
+    && value.database === "postgres"
+    && value.sslMode === "verify-full";
+}
+
+export function assertWebsiteProjectionAdoptionProtectedSnapshots({
+  baseSnapshot,
+  expandedSnapshot,
+  expectedProjectRef,
+}) {
+  if (!plainObject(baseSnapshot)
+    || baseSnapshot.kind
+      !== "programmable-website-projection-hosted-catalog-snapshot-v1"
+    || !expectedSourceIdentity(baseSnapshot.source)
+    || !expectedTargetIdentity(baseSnapshot.target, expectedProjectRef)
+    || !plainObject(expandedSnapshot)
+    || expandedSnapshot.kind
+      !== "programmable-website-projection-hosted-catalog-snapshot-v2"
+    || expandedSnapshot.schemaVersion !== 2
+    || !expectedSourceIdentity(expandedSnapshot.source)
+    || !expectedTargetIdentity(expandedSnapshot.target, expectedProjectRef)
+    || expandedSnapshot.baseSnapshot?.rawSha256
+      !== WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256
+    || canonicalJson(expandedSnapshot.applicationCatalog)
+      !== canonicalJson(baseSnapshot)) {
+    throw new Error("adopt-existing protected snapshot identity mismatch");
+  }
+  const legacy = expandedSnapshot.legacySupabaseInventory;
+  if (!plainObject(legacy)
+    || legacy.fullCanonicalSha256
+      !== WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256
+    || legacy.publicCanonicalSha256
+      !== WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256
+    || legacy.rowCounts?.schemaMigrations !== 42
+    || legacy.rowCounts?.programmableMigrationEvidence !== 42
+    || !Array.isArray(legacy.columns)
+    || !Array.isArray(legacy.schemaRows)
+    || legacy.schemaRows.length !== 42
+    || !Array.isArray(legacy.evidenceRows)
+    || legacy.evidenceRows.length !== 42
+    || sha256(canonicalJson({
+      columns: legacy.columns,
+      schemaRows: legacy.schemaRows,
+      evidenceRows: legacy.evidenceRows,
+    })) !== WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256
+    || !Array.isArray(expandedSnapshot.roleExtended)
+    || expandedSnapshot.roleExtended.length !== EXTENDED_ROLE_NAMES.length
+    || !Array.isArray(expandedSnapshot.membershipExtended)) {
+    throw new Error("adopt-existing protected snapshot content mismatch");
+  }
+  exactJson(
+    expandedSnapshot.roleExtended.map(({ rolname }) => rolname),
+    EXTENDED_ROLE_NAMES,
+    "adopt-existing protected role inventory mismatch",
+  );
+  const runtimeEdges = expandedSnapshot.membershipExtended.filter(
+    ({ role_name: roleName }) => roleName === WEBSITE_PROJECTION_RUNTIME_ROLE,
+  );
+  exactJson(runtimeEdges, [{
+    member_name: "postgres",
+    role_name: WEBSITE_PROJECTION_RUNTIME_ROLE,
+    grantor_name: "supabase_admin",
+    admin_option: true,
+    inherit_option: false,
+    set_option: false,
+  }], "adopt-existing protected membership inventory mismatch");
+  return Object.freeze({
+    baseSnapshot,
+    expandedSnapshot,
+    sourceSnapshotSha256: WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256,
+    baseSnapshotSha256: WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
+  });
+}
+
+export async function readWebsiteProjectionAdoptionProtectedSnapshots({
+  baseSnapshotPath,
+  expandedSnapshotPath,
+  expectedProjectRef,
+}) {
+  const [baseSnapshot, expandedSnapshot] = await Promise.all([
+    readProtectedSnapshotFile(
+      baseSnapshotPath,
+      WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
+      "adopt-existing base snapshot",
+    ),
+    readProtectedSnapshotFile(
+      expandedSnapshotPath,
+      WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256,
+      "adopt-existing expanded snapshot",
+    ),
+  ]);
+  return assertWebsiteProjectionAdoptionProtectedSnapshots({
+    baseSnapshot,
+    expandedSnapshot,
+    expectedProjectRef,
+  });
 }
 
 async function queryRows(sql, statement, parameters = []) {
@@ -170,11 +511,14 @@ async function assertSession(sql, expected) {
   return actual;
 }
 
-async function readRoleGraph(sql, appliedCount) {
+async function readRoleGraph(sql, appliedCount, {
+  adoptionSource = false,
+} = {}) {
   const roles = await queryRows(sql, `
     /* website-projection:roles */
     SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb,
-           rolcanlogin, rolreplication, rolbypassrls
+           rolcanlogin, rolreplication, rolbypassrls, rolconnlimit,
+           rolvaliduntil::text AS rolvaliduntil, rolconfig
       FROM pg_catalog.pg_roles
      WHERE rolname IN (
        'postgres', 'programmable_website_projection_runtime',
@@ -186,10 +530,13 @@ async function readRoleGraph(sql, appliedCount) {
     /* website-projection:memberships */
     SELECT member.rolname AS member_name,
            granted.rolname AS role_name,
-           membership.admin_option
+           grantor.rolname AS grantor_name,
+           membership.admin_option, membership.inherit_option,
+           membership.set_option
       FROM pg_catalog.pg_auth_members membership
       JOIN pg_catalog.pg_roles member ON member.oid = membership.member
       JOIN pg_catalog.pg_roles granted ON granted.oid = membership.roleid
+      JOIN pg_catalog.pg_roles grantor ON grantor.oid = membership.grantor
      WHERE member.rolname IN (
        'programmable_website_projection_runtime',
        'anon', 'authenticated', 'service_role'
@@ -197,13 +544,186 @@ async function readRoleGraph(sql, appliedCount) {
        'programmable_website_projection_runtime',
        'anon', 'authenticated', 'service_role'
      )
-     ORDER BY member.rolname, granted.rolname
+     ORDER BY member.rolname, granted.rolname, grantor.rolname
   `);
   return {
     roles,
     memberships,
-    ...assertWebsiteProjectionRoleGraph({ roles, memberships, appliedCount }),
+    ...(adoptionSource
+      ? assertWebsiteProjectionAdoptionSourceRoleGraph({ roles, memberships })
+      : assertWebsiteProjectionRoleGraph({ roles, memberships, appliedCount })),
   };
+}
+
+async function readExtendedRoleInventory(sql) {
+  return {
+    roles: await queryRows(sql, `
+      /* website-projection:adoption-extended-roles */
+      SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb,
+             rolcanlogin, rolreplication, rolconnlimit,
+             rolvaliduntil::text AS rolvaliduntil, rolbypassrls, rolconfig
+        FROM pg_catalog.pg_roles
+       WHERE rolname IN (
+         'anon', 'authenticated', 'postgres',
+         'programmable_website_projection_runtime',
+         'service_role', 'supabase_admin'
+       )
+       ORDER BY rolname
+    `),
+    memberships: await queryRows(sql, `
+      /* website-projection:adoption-extended-memberships */
+      SELECT member.rolname AS member_name,
+             granted.rolname AS role_name,
+             grantor.rolname AS grantor_name,
+             membership.admin_option, membership.inherit_option,
+             membership.set_option
+        FROM pg_catalog.pg_auth_members membership
+        JOIN pg_catalog.pg_roles member ON member.oid = membership.member
+        JOIN pg_catalog.pg_roles granted ON granted.oid = membership.roleid
+        JOIN pg_catalog.pg_roles grantor ON grantor.oid = membership.grantor
+       ORDER BY member.rolname, granted.rolname, grantor.rolname
+    `),
+  };
+}
+
+async function readLegacySupabaseInventory(sql) {
+  const relations = await queryRows(sql, `
+    /* website-projection:adoption-legacy-relations */
+    SELECT namespace.nspname, class.relname, class.relkind
+      FROM pg_catalog.pg_class class
+      JOIN pg_catalog.pg_namespace namespace
+        ON namespace.oid = class.relnamespace
+     WHERE namespace.nspname = 'supabase_migrations'
+       AND class.relkind IN ('r', 'p', 'v', 'm', 'S')
+     ORDER BY namespace.nspname, class.relname
+  `);
+  const columns = await queryRows(sql, `
+    /* website-projection:adoption-legacy-columns */
+    SELECT table_name, ordinal_position::integer, column_name,
+           data_type, udt_name, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema = 'supabase_migrations'
+       AND table_name IN (
+         'programmable_migration_evidence', 'schema_migrations'
+       )
+     ORDER BY table_name, ordinal_position
+  `);
+  const schemaRowsRaw = await queryRows(sql, `
+    /* website-projection:adoption-legacy-schema-rows */
+    SELECT version, statements, name
+      FROM supabase_migrations.schema_migrations
+     ORDER BY version
+  `);
+  const evidenceRows = await queryRows(sql, `
+    /* website-projection:adoption-legacy-evidence-rows */
+    SELECT name, ordinal::integer, version, file_name,
+           pg_catalog.to_jsonb(applied_at) #>> '{}' AS applied_at,
+           file_sha256, plan_sha256, repository_commit
+      FROM supabase_migrations.programmable_migration_evidence
+     ORDER BY ordinal
+  `);
+  const schemaRows = schemaRowsRaw.map(({ version, statements, name }) => {
+    if (typeof version !== "string"
+      || !(statements === null || Array.isArray(statements))
+      || !(name === null || typeof name === "string")) {
+      throw new Error("adopt-existing legacy schema migration row is invalid");
+    }
+    const statementList = statements ?? [];
+    return {
+      version,
+      name,
+      statementCount: statementList.length,
+      statementsSha256: sha256(canonicalJson(statementList)),
+    };
+  });
+  return {
+    relations,
+    columns,
+    schemaRows,
+    evidenceRows,
+    publicCanonicalSha256: sha256(canonicalJson({
+      columns,
+      schemaRows,
+      evidenceRows,
+    })),
+  };
+}
+
+function protectedApplicationStructure(expandedSnapshot) {
+  const captured = expandedSnapshot.applicationCatalog;
+  const applicationCatalog = {
+    namespaces: captured.schemas.filter(({ nspname }) =>
+      nspname === WEBSITE_PROJECTION_APPLICATION_SCHEMA),
+    relations: captured.relations,
+    columns: captured.columns,
+    constraints: captured.constraints,
+    indexes: captured.indexes,
+    policies: captured.policies,
+    triggers: captured.triggers,
+    functions: captured.functions,
+    schemaAcl: captured.schemaAcl,
+    relationAcl: captured.relationAcl,
+    columnAcl: captured.columnAcl,
+    functionAcl: captured.functionAcl,
+  };
+  return applicationStructureSnapshot(applicationCatalog);
+}
+
+export function assertWebsiteProjectionAdoptionLiveInventory({
+  sourceCatalog,
+  sourceData,
+  extendedRoleInventory,
+  legacyInventory,
+  protectedSnapshots,
+}) {
+  const expanded = protectedSnapshots?.expandedSnapshot;
+  if (!plainObject(expanded)) {
+    throw new Error("adopt-existing protected snapshot is unavailable");
+  }
+  assertExactApplicationStructure(
+    applicationStructureSnapshot(sourceCatalog),
+    protectedApplicationStructure(expanded),
+  );
+  const expectedRoles = expanded.roleExtended.filter(({ rolname }) =>
+    RELEVANT_ROLES.includes(rolname));
+  const expectedMemberships = expanded.membershipExtended.filter(
+    ({ member_name: memberName, role_name: roleName }) =>
+      [WEBSITE_PROJECTION_RUNTIME_ROLE, "anon", "authenticated", "service_role"]
+        .includes(memberName)
+      || [WEBSITE_PROJECTION_RUNTIME_ROLE, "anon", "authenticated", "service_role"]
+        .includes(roleName),
+  );
+  exactJson(sourceCatalog.roles, expectedRoles,
+    "adopt-existing protected application role inventory mismatch");
+  exactJson(sourceCatalog.memberships, expectedMemberships,
+    "adopt-existing protected application membership inventory mismatch");
+  exactJson(extendedRoleInventory.roles, expanded.roleExtended,
+    "adopt-existing extended role inventory mismatch");
+  exactJson(extendedRoleInventory.memberships, expanded.membershipExtended,
+    "adopt-existing extended membership inventory mismatch");
+  assertEmptyAdoptionData(sourceData);
+  exactJson(
+    sourceData.rowPresence.map(({ relation_name: relationName, has_rows: hasRows }) => ({
+      table_name: relationName,
+      row_count: hasRows === false ? "0" : "unproven",
+    })),
+    expanded.applicationCatalog.applicationRowCounts,
+    "adopt-existing protected application rows mismatch",
+  );
+  exactJson(legacyInventory.relations, LEGACY_EVIDENCE_RELATIONS,
+    "adopt-existing legacy evidence relation inventory mismatch");
+  const expectedLegacy = expanded.legacySupabaseInventory;
+  exactJson(legacyInventory.columns, expectedLegacy.columns,
+    "adopt-existing legacy evidence columns mismatch");
+  exactJson(legacyInventory.schemaRows, expectedLegacy.schemaRows,
+    "adopt-existing legacy schema migration inventory mismatch");
+  exactJson(legacyInventory.evidenceRows, expectedLegacy.evidenceRows,
+    "adopt-existing legacy migration evidence inventory mismatch");
+  if (legacyInventory.publicCanonicalSha256
+      !== WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256) {
+    throw new Error("adopt-existing legacy inventory hash mismatch");
+  }
+  return true;
 }
 
 async function readPresenceAndEvidence(sql) {
@@ -217,7 +737,10 @@ async function readPresenceAndEvidence(sql) {
            )::text AS evidence_schema,
            pg_catalog.to_regclass(
              'programmable_website_projection_migrations.migration_evidence_v1'
-           )::text AS evidence_table
+           )::text AS evidence_table,
+           pg_catalog.to_regclass(
+             'programmable_website_projection_migrations.adoption_evidence_v1'
+           )::text AS adoption_table
   `);
   const applicationSchemaPresent =
     presence?.application_schema === WEBSITE_PROJECTION_APPLICATION_SCHEMA;
@@ -225,7 +748,10 @@ async function readPresenceAndEvidence(sql) {
     presence?.evidence_schema === WEBSITE_PROJECTION_EVIDENCE_SCHEMA;
   const evidenceTablePresent =
     presence?.evidence_table === WEBSITE_PROJECTION_EVIDENCE_TABLE;
-  if (evidenceSchemaPresent !== evidenceTablePresent) {
+  const adoptionTablePresent = presence?.adoption_table
+    === `${WEBSITE_PROJECTION_EVIDENCE_SCHEMA}.adoption_evidence_v1`;
+  if (evidenceSchemaPresent !== evidenceTablePresent
+    || evidenceSchemaPresent !== adoptionTablePresent) {
     throw new Error("website projection operator evidence infrastructure is partial");
   }
   const evidenceRows = evidenceTablePresent
@@ -234,16 +760,44 @@ async function readPresenceAndEvidence(sql) {
         SELECT ordinal, version, name, file_name, file_sha256,
                execution_sha256, plan_sha256, repository_commit,
                repository_tree, target_project_ref, catalog_sha256,
-               operator_catalog_sha256
+               operator_catalog_sha256, evidence_kind,
+               adoption_source_snapshot_sha256,
+               adoption_source_catalog_sha256,
+               adoption_source_data_sha256, adoption_attestation_sha256,
+               adoption_operator_commit, adoption_operator_tree
           FROM programmable_website_projection_migrations.migration_evidence_v1
          ORDER BY ordinal
+      `)
+    : [];
+  const adoptionRows = adoptionTablePresent
+    ? await queryRows(sql, `
+        /* website-projection:adoption-evidence */
+        SELECT evidence_kind, adopted_through_version,
+               source_snapshot_sha256, base_snapshot_sha256,
+               legacy_inventory_sha256, legacy_public_sha256,
+               source_catalog_sha256,
+               corrected_catalog_sha256, source_data_sha256,
+               operator_catalog_sha256, attestation_sha256,
+               source_plan_sha256, source_order_sha256,
+               source_repository_commit, source_repository_tree,
+               successor_plan_sha256, successor_order_sha256,
+               successor_repository_commit, successor_repository_tree,
+               target_project_ref,
+               operator_commit, operator_tree,
+               credential_uses_count, projection_records_count,
+               registry_custom_launch_records_count,
+               runtime_rolinherit_before, runtime_rolinherit_after
+          FROM programmable_website_projection_migrations.adoption_evidence_v1
+         ORDER BY singleton
       `)
     : [];
   return {
     applicationSchemaPresent,
     evidenceSchemaPresent,
     evidenceTablePresent,
+    adoptionTablePresent,
     evidenceRows,
+    adoptionRows,
   };
 }
 
@@ -551,6 +1105,173 @@ async function readApplicationCatalogSnapshot(sql, roleGraph) {
   };
 }
 
+function applicationStructureSnapshot(snapshot) {
+  const structure = { ...snapshot };
+  delete structure.roles;
+  delete structure.memberships;
+  return {
+    ...structure,
+    constraints: structure.constraints.filter(({ contype }) => contype !== "n"),
+  };
+}
+
+function assertExactApplicationStructure(actual, expected) {
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    throw new Error(
+      "adopt-existing application catalog does not exactly match reviewed 0001..0003",
+    );
+  }
+}
+
+async function lockAdoptionApplicationTables(transaction) {
+  await executeSimple(transaction, `
+    LOCK TABLE
+      programmable_website_projection_v1.credential_uses,
+      programmable_website_projection_v1.projection_records,
+      programmable_website_projection_v1.registry_custom_launch_records
+    IN ACCESS EXCLUSIVE MODE
+  `);
+}
+
+async function readAdoptionDataSnapshot(sql) {
+  return {
+    rowPresence: await queryRows(sql, `
+      /* website-projection:adoption-data */
+      SELECT relation_name, has_rows
+        FROM (
+          SELECT 'credential_uses'::text AS relation_name,
+                 EXISTS (
+                   SELECT 1
+                     FROM programmable_website_projection_v1.credential_uses
+                 ) AS has_rows
+          UNION ALL
+          SELECT 'projection_records'::text AS relation_name,
+                 EXISTS (
+                   SELECT 1
+                     FROM programmable_website_projection_v1.projection_records
+                 ) AS has_rows
+          UNION ALL
+          SELECT 'registry_custom_launch_records'::text AS relation_name,
+                 EXISTS (
+                   SELECT 1
+                     FROM programmable_website_projection_v1.registry_custom_launch_records
+                 ) AS has_rows
+        ) presence
+       ORDER BY relation_name
+    `),
+  };
+}
+
+function assertEmptyAdoptionData(snapshot) {
+  if (!Array.isArray(snapshot?.rowPresence)
+    || snapshot.rowPresence.length !== WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT
+    || snapshot.rowPresence.some(({ relation_name: relationName, has_rows: hasRows }) =>
+      typeof relationName !== "string" || hasRows !== false)) {
+    throw new Error("adopt-existing rejects unproven application data");
+  }
+}
+
+function pgliteSql(client) {
+  const sql = {
+    unsafe(statement, parameters = []) {
+      const normalized = statement.trimStart().toLowerCase();
+      const operation = (parameters.length > 0
+        || normalized.startsWith("select")
+        || normalized.startsWith("with"))
+        ? client.query(statement, parameters).then(({ rows: resultRows }) =>
+          resultRows)
+        : client.exec(statement).then((results) =>
+          results.at(-1)?.rows ?? []);
+      operation.simple = () => operation;
+      return operation;
+    },
+    async begin(callback) {
+      return await client.transaction(async (transaction) =>
+        callback(pgliteSql(transaction)));
+    },
+  };
+  return sql;
+}
+
+const canonicalAdoptionReferences = new Map();
+
+export async function buildCanonicalWebsiteProjectionAdoptionReference({
+  workspace,
+  plan,
+}) {
+  assertWebsiteProjectionAdoptionSourcePlan(plan);
+  const cacheKey = `${workspace}\0${plan.planSha256}`;
+  if (canonicalAdoptionReferences.has(cacheKey)) {
+    return await canonicalAdoptionReferences.get(cacheKey);
+  }
+  const referencePromise = (async () => {
+    const { PGlite } = await import("@electric-sql/pglite");
+    const database = new PGlite();
+    try {
+      await database.exec(`
+        CREATE ROLE anon NOLOGIN;
+        CREATE ROLE authenticated NOLOGIN;
+        CREATE ROLE service_role NOLOGIN;
+        CREATE ROLE authenticator NOLOGIN;
+        GRANT anon, authenticated, service_role TO authenticator;
+        CREATE ROLE programmable_website_projection_runtime WITH
+          LOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE
+          NOREPLICATION NOBYPASSRLS
+          PASSWORD 'local-reference-password-never-used-remotely';
+      `);
+      const sql = pgliteSql(database);
+      const [identity] = await queryRows(sql, `
+        SELECT pg_catalog.pg_backend_pid() AS backend_pid,
+               session_user::text AS session_user,
+               current_role::text AS current_role
+      `);
+      const session = expectedSession({
+        backendPid: Number(identity?.backend_pid),
+        sessionUser: identity?.session_user,
+        currentRole: identity?.current_role,
+      });
+      for (const migration of plan.migrations.slice(
+        0,
+        WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
+      )) {
+        await applyOneMigration({
+          sql,
+          workspace,
+          plan,
+          migration,
+          expectedProjectRef: "reference00000000000",
+          session,
+          bootstrapRuntimePassword: null,
+        });
+      }
+      await executeSimple(sql, ADOPTION_PREFIX_PRIVILEGES);
+      const roleGraph = await readRoleGraph(
+        sql,
+        WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
+      );
+      const catalog = await readApplicationCatalogSnapshot(sql, roleGraph);
+      const data = await readAdoptionDataSnapshot(sql);
+      assertEmptyAdoptionData(data);
+      return Object.freeze({
+        structure: Object.freeze(applicationStructureSnapshot(catalog)),
+        structureSha256: catalogSnapshotSha256(
+          applicationStructureSnapshot(catalog),
+        ),
+        dataSha256: catalogSnapshotSha256(data),
+      });
+    } finally {
+      await database.close();
+    }
+  })();
+  canonicalAdoptionReferences.set(cacheKey, referencePromise);
+  try {
+    return await referencePromise;
+  } catch (error) {
+    canonicalAdoptionReferences.delete(cacheKey);
+    throw error;
+  }
+}
+
 export async function inspectWebsiteProjectionDatabase({
   sql,
   plan,
@@ -567,6 +1288,7 @@ export async function inspectWebsiteProjectionDatabase({
     evidenceTablePresent: remote.evidenceTablePresent,
     applicationSchemaPresent: remote.applicationSchemaPresent,
     evidenceRows: remote.evidenceRows,
+    adoptionRows: remote.adoptionRows,
   });
   const roleGraph = await readRoleGraph(sql, state.appliedCount);
   if (state.appliedCount > 0) {
@@ -653,13 +1375,26 @@ async function insertEvidence(transaction, {
   expectedProjectRef,
   catalogSha256,
   operatorCatalogSha256,
+  evidenceKind = "applied",
+  adoptionSourceSnapshotSha256 = null,
+  adoptionSourceCatalogSha256 = null,
+  adoptionSourceDataSha256 = null,
+  adoptionAttestationSha256 = null,
+  adoptionOperatorCommit = null,
+  adoptionOperatorTree = null,
 }) {
   await queryRows(transaction, `
     INSERT INTO programmable_website_projection_migrations.migration_evidence_v1 (
       ordinal, version, name, file_name, file_sha256, execution_sha256,
       plan_sha256, repository_commit, repository_tree, target_project_ref,
-      catalog_sha256, operator_catalog_sha256
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      catalog_sha256, operator_catalog_sha256, evidence_kind,
+      adoption_source_snapshot_sha256, adoption_source_catalog_sha256,
+      adoption_source_data_sha256, adoption_attestation_sha256,
+      adoption_operator_commit, adoption_operator_tree
+    ) VALUES (
+      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+      $14, $15, $16, $17, $18, $19
+    )
   `, [
     migration.ordinal,
     migration.version,
@@ -673,6 +1408,67 @@ async function insertEvidence(transaction, {
     expectedProjectRef,
     catalogSha256,
     operatorCatalogSha256,
+    evidenceKind,
+    adoptionSourceSnapshotSha256,
+    adoptionSourceCatalogSha256,
+    adoptionSourceDataSha256,
+    adoptionAttestationSha256,
+    adoptionOperatorCommit,
+    adoptionOperatorTree,
+  ]);
+}
+
+async function insertAdoptionEvidence(transaction, {
+  plan,
+  expectedProjectRef,
+  sourceSnapshotSha256,
+  sourceCatalogSha256,
+  correctedCatalogSha256,
+  sourceDataSha256,
+  operatorCatalogSha256,
+  adoptionAttestationSha256,
+  operatorCommit,
+  operatorTree,
+}) {
+  await queryRows(transaction, `
+    INSERT INTO programmable_website_projection_migrations.adoption_evidence_v1 (
+      evidence_kind, adopted_through_version, source_snapshot_sha256,
+      base_snapshot_sha256, legacy_inventory_sha256, legacy_public_sha256,
+      source_catalog_sha256, corrected_catalog_sha256, source_data_sha256,
+      operator_catalog_sha256, attestation_sha256, source_plan_sha256,
+      source_order_sha256, source_repository_commit, source_repository_tree,
+      successor_plan_sha256, successor_order_sha256,
+      successor_repository_commit, successor_repository_tree,
+      target_project_ref, operator_commit, operator_tree, credential_uses_count,
+      projection_records_count, registry_custom_launch_records_count,
+      runtime_rolinherit_before, runtime_rolinherit_after
+    ) VALUES (
+      'adopted-existing-prefix-v1', '0003', $1, $2, $3, $4, $5, $6,
+      $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
+      $19, $20,
+      0, 0, 0, true, false
+    )
+  `, [
+    sourceSnapshotSha256,
+    WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
+    WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256,
+    WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256,
+    sourceCatalogSha256,
+    correctedCatalogSha256,
+    sourceDataSha256,
+    operatorCatalogSha256,
+    adoptionAttestationSha256,
+    WEBSITE_PROJECTION_ADOPTION_SOURCE_PLAN_SHA256,
+    WEBSITE_PROJECTION_ADOPTION_SOURCE_ORDER_SHA256,
+    WEBSITE_PROJECTION_ADOPTION_SOURCE_COMMIT,
+    WEBSITE_PROJECTION_ADOPTION_SOURCE_TREE,
+    plan.planSha256,
+    plan.orderSha256,
+    plan.repositoryCommit,
+    plan.repositoryTree,
+    expectedProjectRef,
+    operatorCommit,
+    operatorTree,
   ]);
 }
 
@@ -718,6 +1514,299 @@ async function applyOneMigration({
     await assertSession(transaction, session);
   });
   await assertSession(sql, session);
+}
+
+export async function adoptExistingWebsiteProjectionDatabase({
+  sql,
+  workspace,
+  plan,
+  expectedProjectRef,
+  sessionIdentity,
+  expectedSourceSnapshotSha256,
+  operatorCommit = plan?.repositoryCommit,
+  operatorTree = plan?.repositoryTree,
+  canonicalReference,
+  protectedSnapshots,
+  extendedRoleInventoryReader = readExtendedRoleInventory,
+  legacyInventoryReader = readLegacySupabaseInventory,
+  liveInventoryValidator = assertWebsiteProjectionAdoptionLiveInventory,
+}) {
+  assertWebsiteProjectionAdoptionSourcePlan(plan);
+  if (expectedSourceSnapshotSha256
+      !== WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256) {
+    throw new Error("adopt-existing protected source snapshot mismatch");
+  }
+  if (!plainObject(protectedSnapshots)
+    || protectedSnapshots.sourceSnapshotSha256
+      !== WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256
+    || protectedSnapshots.baseSnapshotSha256
+      !== WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256) {
+    throw new Error("adopt-existing protected snapshots were not verified");
+  }
+  const session = expectedSession(sessionIdentity);
+  const reference = canonicalReference
+    ?? await buildCanonicalWebsiteProjectionAdoptionReference({
+      workspace,
+      plan,
+    });
+  const [lock] = await queryRows(sql, `
+    /* website-projection:lock */
+    SELECT pg_catalog.pg_try_advisory_lock(
+             pg_catalog.hashtextextended('${OPERATOR_LOCK}', 0)
+           ) AS acquired,
+           pg_catalog.pg_backend_pid() AS backend_pid,
+           session_user::text AS session_user,
+           current_role::text AS current_role
+  `);
+  const lockSession = capturedSession(lock);
+  if (lockSession.backendPid !== session.backendPid
+    || lockSession.sessionUser !== session.sessionUser
+    || lockSession.currentRole !== session.currentRole) {
+    throw new Error("website projection database session changed unexpectedly");
+  }
+  if (lock?.acquired !== true) {
+    throw new Error("another website projection migration operator holds the lock");
+  }
+  try {
+    const adoption = await sql.begin(async (transaction) => {
+      await executeSimple(transaction,
+        "SET LOCAL lock_timeout = '4s'; SET LOCAL statement_timeout = '5min';");
+      await assertSession(transaction, session);
+      const beforePresence = await readPresenceAndEvidence(transaction);
+      if (!beforePresence.applicationSchemaPresent) {
+        throw new Error("adopt-existing application schema is absent");
+      }
+      if (beforePresence.evidenceSchemaPresent
+        || beforePresence.evidenceTablePresent
+        || beforePresence.evidenceRows.length > 0) {
+        throw new Error("adopt-existing operator evidence must be absent");
+      }
+      await lockAdoptionApplicationTables(transaction);
+      const frozenPresence = await readPresenceAndEvidence(transaction);
+      if (!frozenPresence.applicationSchemaPresent
+        || frozenPresence.evidenceSchemaPresent
+        || frozenPresence.evidenceTablePresent
+        || frozenPresence.evidenceRows.length > 0) {
+        throw new Error("adopt-existing preconditions changed while locking");
+      }
+      const sourceRoleGraph = await readRoleGraph(
+        transaction,
+        WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
+        { adoptionSource: true },
+      );
+      const sourceCatalog = await readApplicationCatalogSnapshot(
+        transaction,
+        sourceRoleGraph,
+      );
+      const sourceStructure = applicationStructureSnapshot(sourceCatalog);
+      assertExactApplicationStructure(sourceStructure, reference.structure);
+      const sourceData = await readAdoptionDataSnapshot(transaction);
+      const sourceExtendedRoleInventory = await extendedRoleInventoryReader(
+        transaction,
+      );
+      const sourceLegacyInventory = await legacyInventoryReader(transaction);
+      liveInventoryValidator({
+        sourceCatalog,
+        sourceData,
+        extendedRoleInventory: sourceExtendedRoleInventory,
+        legacyInventory: sourceLegacyInventory,
+        protectedSnapshots,
+      });
+      const sourceDataSha256 = catalogSnapshotSha256(sourceData);
+      if (sourceDataSha256 !== reference.dataSha256) {
+        throw new Error("adopt-existing source data snapshot mismatch");
+      }
+      const sourceCatalogSha256 = catalogSnapshotSha256(sourceCatalog);
+
+      await executeSimple(transaction, `
+        ALTER ROLE programmable_website_projection_runtime NOINHERIT
+      `);
+      const correctedRoleGraph = await readRoleGraph(
+        transaction,
+        WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
+      );
+      const correctedCatalog = await readApplicationCatalogSnapshot(
+        transaction,
+        correctedRoleGraph,
+      );
+      const expectedCorrectedCatalog = structuredClone(sourceCatalog);
+      const expectedRuntimeRole = expectedCorrectedCatalog.roles.find(
+        ({ rolname }) => rolname === WEBSITE_PROJECTION_RUNTIME_ROLE,
+      );
+      if (!expectedRuntimeRole) {
+        throw new Error("adopt-existing source runtime role disappeared");
+      }
+      expectedRuntimeRole.rolinherit = false;
+      if (canonicalJson(correctedCatalog)
+        !== canonicalJson(expectedCorrectedCatalog)) {
+        throw new Error("adopt-existing role correction changed forbidden state");
+      }
+      assertExactApplicationStructure(
+        applicationStructureSnapshot(correctedCatalog),
+        reference.structure,
+      );
+      const correctedExtendedRoleInventory = await extendedRoleInventoryReader(
+        transaction,
+      );
+      const expectedCorrectedExtendedRoleInventory = structuredClone(
+        sourceExtendedRoleInventory,
+      );
+      const correctedExtendedRuntime =
+        expectedCorrectedExtendedRoleInventory.roles.find(
+          ({ rolname }) => rolname === WEBSITE_PROJECTION_RUNTIME_ROLE,
+        );
+      if (!correctedExtendedRuntime) {
+        throw new Error("adopt-existing extended runtime role disappeared");
+      }
+      correctedExtendedRuntime.rolinherit = false;
+      exactJson(
+        correctedExtendedRoleInventory,
+        expectedCorrectedExtendedRoleInventory,
+        "adopt-existing role correction changed extended role inventory",
+      );
+      const correctedLegacyInventory = await legacyInventoryReader(transaction);
+      exactJson(
+        correctedLegacyInventory,
+        sourceLegacyInventory,
+        "adopt-existing role correction changed legacy inventory",
+      );
+      const correctedCatalogSha256 = catalogSnapshotSha256(correctedCatalog);
+      const correctedData = await readAdoptionDataSnapshot(transaction);
+      assertEmptyAdoptionData(correctedData);
+      if (catalogSnapshotSha256(correctedData) !== sourceDataSha256) {
+        throw new Error("adopt-existing data changed during role correction");
+      }
+
+      await executeSimple(transaction, EVIDENCE_DDL);
+      const operatorCatalogSha256 = catalogSnapshotSha256(
+        await readEvidenceCatalogSnapshot(transaction),
+      );
+      const adoptionAttestationSha256 =
+        websiteProjectionAdoptionAttestationSha256({
+          plan,
+          expectedProjectRef,
+          sourceSnapshotSha256: expectedSourceSnapshotSha256,
+          sourceCatalogSha256,
+          sourceDataSha256,
+          correctedCatalogSha256,
+          operatorCatalogSha256,
+          operatorCommit,
+          operatorTree,
+        });
+      for (const migration of plan.migrations.slice(
+        0,
+        WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
+      )) {
+        await insertEvidence(transaction, {
+          migration,
+          plan,
+          expectedProjectRef,
+          catalogSha256: correctedCatalogSha256,
+          operatorCatalogSha256,
+          evidenceKind: "adopted-existing-prefix-v1",
+          adoptionSourceSnapshotSha256: expectedSourceSnapshotSha256,
+          adoptionSourceCatalogSha256: sourceCatalogSha256,
+          adoptionSourceDataSha256: sourceDataSha256,
+          adoptionAttestationSha256,
+          adoptionOperatorCommit: operatorCommit,
+          adoptionOperatorTree: operatorTree,
+        });
+      }
+      await insertAdoptionEvidence(transaction, {
+        plan,
+        expectedProjectRef,
+        sourceSnapshotSha256: expectedSourceSnapshotSha256,
+        sourceCatalogSha256,
+        correctedCatalogSha256,
+        sourceDataSha256,
+        operatorCatalogSha256,
+        adoptionAttestationSha256,
+        operatorCommit,
+        operatorTree,
+      });
+
+      const afterPresence = await readPresenceAndEvidence(transaction);
+      const state = compareWebsiteProjectionEvidence({
+        plan,
+        expectedProjectRef,
+        evidenceTablePresent: afterPresence.evidenceTablePresent,
+        applicationSchemaPresent: afterPresence.applicationSchemaPresent,
+        evidenceRows: afterPresence.evidenceRows,
+        adoptionRows: afterPresence.adoptionRows,
+      });
+      if (state.appliedCount !== WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT
+        || state.pending.length !== 2) {
+        throw new Error("adopt-existing did not create the exact evidence prefix");
+      }
+      const finalRoleGraph = await readRoleGraph(
+        transaction,
+        WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
+      );
+      const finalCatalogSha256 = catalogSnapshotSha256(
+        await readApplicationCatalogSnapshot(transaction, finalRoleGraph),
+      );
+      const finalOperatorCatalogSha256 = catalogSnapshotSha256(
+        await readEvidenceCatalogSnapshot(transaction),
+      );
+      if (finalCatalogSha256 !== correctedCatalogSha256
+        || finalOperatorCatalogSha256 !== operatorCatalogSha256) {
+        throw new Error("adopt-existing catalog changed before evidence commit");
+      }
+      const finalData = await readAdoptionDataSnapshot(transaction);
+      assertEmptyAdoptionData(finalData);
+      if (catalogSnapshotSha256(finalData) !== sourceDataSha256) {
+        throw new Error("adopt-existing data changed before evidence commit");
+      }
+      exactJson(
+        await extendedRoleInventoryReader(transaction),
+        correctedExtendedRoleInventory,
+        "adopt-existing extended role inventory changed before evidence commit",
+      );
+      exactJson(
+        await legacyInventoryReader(transaction),
+        sourceLegacyInventory,
+        "adopt-existing legacy inventory changed before evidence commit",
+      );
+      await assertSession(transaction, session);
+      return Object.freeze({
+        ...state,
+        runtimeRoleStatus: finalRoleGraph.runtimeRoleStatus,
+        adoptedExisting: true,
+        adoptedThisRun: Object.freeze(
+          plan.migrations.slice(0, WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT)
+            .map(({ version }) => version),
+        ),
+        adoptionSourceCatalogSha256: sourceCatalogSha256,
+        adoptionDataSha256: sourceDataSha256,
+        adoptionAttestationSha256,
+      });
+    });
+    await assertSession(sql, session);
+    return adoption;
+  } finally {
+    const [unlock] = await queryRows(sql, `
+      /* website-projection:unlock */
+      SELECT pg_catalog.pg_backend_pid() AS backend_pid,
+             session_user::text AS session_user,
+             current_role::text AS current_role,
+             CASE
+               WHEN pg_catalog.pg_backend_pid() = $1
+                AND session_user::text = $2
+                AND current_role::text = $3
+               THEN pg_catalog.pg_advisory_unlock(
+                 pg_catalog.hashtextextended('${OPERATOR_LOCK}', 0)
+               )
+               ELSE false
+             END AS released
+    `, [session.backendPid, session.sessionUser, session.currentRole]);
+    const unlockSession = capturedSession(unlock);
+    if (unlockSession.backendPid !== session.backendPid
+      || unlockSession.sessionUser !== session.sessionUser
+      || unlockSession.currentRole !== session.currentRole
+      || unlock?.released !== true) {
+      throw new Error("website projection database migration lock was not released");
+    }
+  }
 }
 
 export async function applyWebsiteProjectionMigrations({


### PR DESCRIPTION
## Outcome

Adds an explicit fail-closed `adopt-existing` operator path for the verified empty Website projection 0001-0003 hosted state. It binds the protected catalog snapshots and legacy inventory, permits only the measured runtime role INHERIT to NOINHERIT correction, records distinct adoption provenance, and leaves 0004-0005 to the normal migration path.

## Exact identity

- Base: `03f412cf20e65458a2c9cf5665de245b3c0839e8`
- Head: `56cbc0119ff78a8a4240d46a40c07a2ac27a9fde`
- Tree: `b65e183f679c97b8152c779d9866aec53202bf4a`
- Plan: `0xbdc800d45a7ea64c1f8bc941c1891c2e50f54c3c2d3bf14df52ebebe73985792`
- Migration order: `0xce50954bfa6ff3b66b849bb5b53e8f1adf93abbe12cf865c19375100f2571cc2`

## Verification

- Operator tests: 23/23
- Website projection target: 26/26
- ESLint: zero warnings/errors
- Independent exact audit: P0/P1/P2/P3 none

No hosted database access, migration, deployment, activation, criteria, Classic, Stock, or Explore change is included in this PR.