### PR TITLE
fix(stage): prove inactive Approval V3 fail-closed

### DIFF
--- a/docs/operations/custom-v2-production-stage-gate.md
+++ b/docs/operations/custom-v2-production-stage-gate.md
@@ -84,7 +84,12 @@ The workflow performs this sequence:
 The Custom V2 probe verifies:
 
 - Registry V2 manifest and readiness in the selected prelaunch/live mode
-- unauthenticated Approval V3 GET and PUT rejection
+- unauthenticated Approval V3 GET and PUT rejection when its exact audience
+  and target binding are configured
+- exact `503 target_unavailable` responses for both Approval V3 methods when
+  the fully closed prelaunch/disabled matrix has no Approval V3 configuration;
+  partial configuration and every active matrix remain invalid without both
+  bindings
 - unauthenticated projector POST and reconciliation GET rejection
 - authenticated Approval V3 delivery, separate authenticated readback, and
   authenticated projection when digest-bound evidence is supplied

--- a/scripts/custom-v2-stage-gate.mjs
+++ b/scripts/custom-v2-stage-gate.mjs
@@ -36,12 +36,11 @@ export async function verifyCustomV2StageCandidateV1(input) {
     exact(input.detailRecordHash, DIGEST, "Generic V2 detail record hash");
   }
   const bypass = secret(input.automationBypassSecret, "Vercel automation bypass");
-  const audience = safeId(input.approvalAudience, "Approval V3 audience");
-  const targetBindingHash = exact(
-    input.approvalTargetBindingHash,
-    DIGEST,
-    "Approval V3 target binding",
-  );
+  const authenticated = authenticatedIngress(input);
+  if (authenticated !== null && input.registryMode !== "live") {
+    throw new Error("authenticated ingress evidence is forbidden in prelaunch mode");
+  }
+  const approvalBinding = approvalV3Binding(input, authenticated);
   const fetchImpl = input.fetchImpl ?? fetch;
   const checks = [];
   const add = (id, detail) => checks.push(Object.freeze({ id, status: "pass", detail }));
@@ -109,17 +108,17 @@ export async function verifyCustomV2StageCandidateV1(input) {
   const approvalPath = `/v2/internal/projections/approval-descriptors/${encodeURIComponent(
     `approval:${UNAUTHORIZED_APPROVAL_ID}`,
   )}`;
-  const approvalHeaders = {
-    "x-programmable-audience": audience,
+  const approvalHeaders = approvalBinding === null ? null : {
+    "x-programmable-audience": approvalBinding.audience,
     "x-programmable-projection-kind": "website.approval-v3",
-    "x-programmable-target-binding": targetBindingHash,
+    "x-programmable-target-binding": approvalBinding.targetBindingHash,
   };
   for (const [method, init] of [
-    ["GET", { headers: approvalHeaders }],
+    ["GET", { headers: approvalHeaders ?? {} }],
     ["PUT", {
       method: "PUT",
       headers: {
-        ...approvalHeaders,
+        ...(approvalHeaders ?? {}),
         "content-type": "application/json; charset=utf-8",
         "idempotency-key": `sha256:${"1".repeat(64)}`,
       },
@@ -127,13 +126,27 @@ export async function verifyCustomV2StageCandidateV1(input) {
     }],
   ]) {
     const result = await requestJson(approvalPath, init);
-    assertStatus(result, 401, `unauthorized Approval V3 ${method}`);
+    const approvalState = approvalHeaders === null
+      ? "unavailable Approval V3"
+      : "unauthorized Approval V3";
+    const expectedStatus = approvalHeaders === null ? 503 : 401;
+    const expectedCode = approvalHeaders === null
+      ? "target_unavailable"
+      : "credential_required";
+    assertStatus(result, expectedStatus, `${approvalState} ${method}`);
     assertObjectFields(result.body, {
       schemaVersion: "programmable.projection-target-error.v1",
-      code: "credential_required",
-    }, `unauthorized Approval V3 ${method}`);
+      code: expectedCode,
+    }, `${approvalState} ${method}`);
   }
-  add("approval-v3-unauthorized", "unauthenticated GET and PUT are both rejected");
+  if (approvalHeaders === null) {
+    add(
+      "approval-v3-unavailable",
+      "unconfigured Approval V3 GET and PUT fail closed",
+    );
+  } else {
+    add("approval-v3-unauthorized", "unauthenticated GET and PUT are both rejected");
+  }
 
   for (const [method, init] of [
     ["GET", {}],
@@ -156,12 +169,8 @@ export async function verifyCustomV2StageCandidateV1(input) {
   }
   add("generic-v2-projector-unauthorized", "projector and reconciliation reject missing credentials");
 
-  const authenticated = authenticatedIngress(input);
   let authenticatedApprovalId = null;
   if (authenticated !== null) {
-    if (input.registryMode !== "live") {
-      throw new Error("authenticated ingress evidence is forbidden in prelaunch mode");
-    }
     authenticatedApprovalId = await deliverAuthenticatedIngress({
       authenticated,
       requestJson,
@@ -413,6 +422,25 @@ function authenticatedIngress(input) {
     throw new Error("authenticated ingress evidence contract is invalid");
   }
   return value;
+}
+
+function approvalV3Binding(input, authenticated) {
+  const closed = input.registryMode === "prelaunch"
+    && input.genericMode === "disabled"
+    && authenticated === null;
+  const audienceAbsent = input.approvalAudience === undefined
+    || input.approvalAudience === "";
+  const targetBindingAbsent = input.approvalTargetBindingHash === undefined
+    || input.approvalTargetBindingHash === "";
+  if (closed && audienceAbsent && targetBindingAbsent) return null;
+  return Object.freeze({
+    audience: safeId(input.approvalAudience, "Approval V3 audience"),
+    targetBindingHash: exact(
+      input.approvalTargetBindingHash,
+      DIGEST,
+      "Approval V3 target binding",
+    ),
+  });
 }
 
 function assertRegistryManifest(value, expectedMode) {

--- a/scripts/test/custom-v2-stage-gate.test.mjs
+++ b/scripts/test/custom-v2-stage-gate.test.mjs
@@ -93,6 +93,8 @@ function fetchMatrix({
   ready = false,
   authenticated = false,
   emptyFeed = false,
+  approvalUnavailable = false,
+  approvalUnexpectedlyAvailable = false,
 } = {}) {
   return async (input, init = {}) => {
     const url = new URL(input);
@@ -122,6 +124,27 @@ function fetchMatrix({
         });
     }
     if (url.pathname.startsWith("/v2/internal/projections/approval-descriptors/")) {
+      if (approvalUnavailable) {
+        assert.equal(init.headers?.["x-programmable-audience"], undefined);
+        assert.equal(init.headers?.["x-programmable-target-binding"], undefined);
+        return json(503, {
+          schemaVersion: "programmable.projection-target-error.v1",
+          code: "target_unavailable",
+        });
+      }
+      if (approvalUnexpectedlyAvailable) {
+        assert.equal(init.headers?.["x-programmable-audience"], undefined);
+        assert.equal(init.headers?.["x-programmable-target-binding"], undefined);
+        return json(401, {
+          schemaVersion: "programmable.projection-target-error.v1",
+          code: "credential_required",
+        });
+      }
+      assert.equal(
+        init.headers?.["x-programmable-audience"],
+        "programmable.website.approval-v3",
+      );
+      assert.equal(init.headers?.["x-programmable-target-binding"], BINDING);
       if (!init.headers?.authorization) {
         return json(401, {
           schemaVersion: "programmable.projection-target-error.v1",
@@ -236,6 +259,18 @@ test("default prelaunch and disabled matrix proves every fail-closed surface", a
   assert.doesNotMatch(JSON.stringify(evidence), /bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/u);
 });
 
+test("closed matrix requires unconfigured Approval V3 to fail closed", async () => {
+  const evidence = await verifyCustomV2StageCandidateV1(baseInput(
+    fetchMatrix({ approvalUnavailable: true }),
+    {
+      approvalAudience: undefined,
+      approvalTargetBindingHash: undefined,
+    },
+  ));
+  assert.ok(evidence.checks.some(({ id }) => id === "approval-v3-unavailable"));
+  assert.ok(!evidence.checks.some(({ id }) => id === "approval-v3-unauthorized"));
+});
+
 test("explicit live and ready matrix proves Registry, DB, signer, feed and detail", async () => {
   const evidence = await verifyCustomV2StageCandidateV1(baseInput(
     fetchMatrix({ live: true, ready: true }),
@@ -311,5 +346,29 @@ test("candidate identity and activation matrix fail closed", async () => {
       genericMode: "ready",
     })),
     /cannot be ready before Registry V2 is live/u,
+  );
+  await assert.rejects(
+    verifyCustomV2StageCandidateV1(baseInput(fetchMatrix(), {
+      approvalAudience: undefined,
+    })),
+    /Approval V3 audience is invalid/u,
+  );
+  await assert.rejects(
+    verifyCustomV2StageCandidateV1(baseInput(fetchMatrix({ live: true }), {
+      registryMode: "live",
+      approvalAudience: undefined,
+      approvalTargetBindingHash: undefined,
+    })),
+    /Approval V3 audience is invalid/u,
+  );
+  await assert.rejects(
+    verifyCustomV2StageCandidateV1(baseInput(
+      fetchMatrix({ approvalUnexpectedlyAvailable: true }),
+      {
+        approvalAudience: undefined,
+        approvalTargetBindingHash: undefined,
+      },
+    )),
+    /returned 401, expected 503/u,
   );
 });


### PR DESCRIPTION
## Outcome

Allows only the exact `Registry prelaunch + Generic disabled + no authenticated ingress` matrix to prove Approval V3 is unavailable via exact GET and PUT `503 target_unavailable`. Active, live, authenticated, partial, and malformed configurations remain strictly blocked.

## Evidence

- Exact parent: `942d51d5ad78af64b5729894d4d7dffe4b467dc0`
- Stage failure reproduced before any HTTP call
- Exact staged inactive route verified as `503 target_unavailable`
- Custom V2 CI: 37/37 Node + 95/95 Vitest
- Typecheck, build, bundle scan, ops source contracts, ESLint, gitleaks, diff check green

No environment values, keys, bindings, public enablement, signing, or transaction changes.