### PR TITLE
fix(explore): retry transient provider failures once

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -931,17 +931,45 @@ async function fetchExplorePayload(
   contract: ExploreRequestContract,
 ) {
   const requestUrl = `/api/explore?${search.toString()}`;
-  const response = await fetch(requestUrl, {
-    headers: { Accept: "application/json" },
-    signal,
-  });
-  const body: unknown = await response.json().catch(() => null);
-  if (!response.ok) {
-    throw new Error(readApiError(body));
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    signal.throwIfAborted();
+    const attemptController = new AbortController();
+    let timedOut = false;
+    const abortAttempt = () => attemptController.abort(signal.reason);
+    signal.addEventListener("abort", abortAttempt, { once: true });
+    const timeout = globalThis.setTimeout(() => {
+      timedOut = true;
+      attemptController.abort();
+    }, EXPLORE_REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(requestUrl, {
+        headers: { Accept: "application/json" },
+        signal: attemptController.signal,
+      });
+      signal.throwIfAborted();
+      if (timedOut) throw new Error("Tokens took too long to respond");
+      if (response.status === 503 && attempt === 0) {
+        continue;
+      }
+      const body: unknown = await response.json().catch(() => null);
+      signal.throwIfAborted();
+      if (timedOut) throw new Error("Tokens took too long to respond");
+      if (response.status !== 200) {
+        throw new Error(readApiError(body));
+      }
+      const payload = parseExplorePayload(body);
+      assertExploreResponseContract(payload, contract);
+      return payload;
+    } catch (error) {
+      signal.throwIfAborted();
+      if (timedOut) throw new Error("Tokens took too long to respond");
+      throw error;
+    } finally {
+      globalThis.clearTimeout(timeout);
+      signal.removeEventListener("abort", abortAttempt);
+    }
   }
-  const payload = parseExplorePayload(body);
-  assertExploreResponseContract(payload, contract);
-  return payload;
+  throw new Error("Tokens are temporarily unavailable");
 }
 
 export function loadExplorePayload(
@@ -974,28 +1002,15 @@ export function loadExplorePayload(
   }
 
   const controller = new AbortController();
-  let timedOut = false;
-  const timeout = globalThis.setTimeout(() => {
-    timedOut = true;
-    controller.abort();
-  }, EXPLORE_REQUEST_TIMEOUT_MS);
   const request = (async (): Promise<ExplorePayload> => {
-    try {
-      const payload = await fetchExplorePayload(
-        search,
-        controller.signal,
-        contract,
-      );
-      cacheResolvedExplorePayload(contentKey, payload);
-      return payload;
-    } catch (error) {
-      if (timedOut) {
-        throw new Error("Tokens took too long to respond");
-      }
-      throw error;
-    } finally {
-      globalThis.clearTimeout(timeout);
-    }
+    const payload = await fetchExplorePayload(
+      search,
+      controller.signal,
+      contract,
+    );
+    controller.signal.throwIfAborted();
+    cacheResolvedExplorePayload(contentKey, payload);
+    return payload;
   })();
 
   const entry = { controller, promise: request, requestIdentity };

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -595,18 +595,21 @@ describe("Explore refresh state", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not retry a Bitquery 503", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(JSON.stringify({
-          status: "unavailable",
-          error: "Bitquery is temporarily unavailable",
-        }), {
-          status: 503,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
+  it("retries the identical Explore request once after a 503", async () => {
+    const first = new Response(JSON.stringify({
+      status: "ready",
+      tokens: [{ forged: "must-not-be-parsed" }],
+    }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    });
+    const firstJson = vi.spyOn(first, "json");
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }));
     const search = new URLSearchParams({
       q: "",
       sort: "market-cap",
@@ -614,32 +617,177 @@ describe("Explore refresh state", () => {
       limit: "9",
     });
 
-    await expect(loadExplorePayload("bitquery-no-retry", search))
-      .rejects.toThrow("Bitquery is temporarily unavailable");
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = loadExplorePayload("bitquery-one-retry", search);
+    expect(loadExplorePayload("bitquery-one-retry", search)).toBe(request);
+    await expect(request).resolves.toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(fetchMock.mock.calls[0]?.[0]);
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      headers: { Accept: "application/json" },
+    });
+    expect(fetchMock.mock.calls[1]?.[1]?.signal).not.toBe(
+      fetchMock.mock.calls[0]?.[1]?.signal,
+    );
+    expect(firstJson).not.toHaveBeenCalled();
   });
 
-  it.each(["newest", "market-cap", "market-cap-asc"])(
-    "does not retry a 503 for the %s sort",
+  it.each(["newest", "oldest", "market-cap", "market-cap-asc"])(
+    "stops after one automatic 503 retry for the %s sort",
     async (sort) => {
-      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({
+      const first = new Response("not launch data", { status: 503 });
+      const firstJson = vi.spyOn(first, "json");
+      const fetchMock = vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(first)
+        .mockResolvedValueOnce(new Response(JSON.stringify({
           status: "unavailable",
           error: "Launch data is temporarily unavailable",
           retryable: true,
         }), {
           status: 503,
           headers: { "Content-Type": "application/json" },
-        }),
-      );
+        }));
 
       await expect(loadExplorePayload(
-        `${sort}-does-not-retry`,
+        `${sort}-one-retry-terminal`,
         new URLSearchParams({ sort, page: "1", limit: "9" }),
       )).rejects.toThrow("Launch data is temporarily unavailable");
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1]?.[0]).toBe(fetchMock.mock.calls[0]?.[0]);
+      expect(firstJson).not.toHaveBeenCalled();
     },
   );
+
+  it("does not retry a non-503 response", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Invalid Explore request" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(loadExplorePayload(
+      "non-503-no-retry",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).rejects.toThrow("Invalid Explore request");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives a late 503 retry its own full twelve-second deadline", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => {
+        calls += 1;
+        if (calls === 1) {
+          return await new Promise<Response>((resolve) => {
+            globalThis.setTimeout(
+              () => resolve(new Response("ignored", { status: 503 })),
+              11_000,
+            );
+          });
+        }
+        return await new Promise<Response>((resolve) => {
+          globalThis.setTimeout(() => resolve(new Response(
+            JSON.stringify(payload),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          )), 6_000);
+        });
+      },
+    );
+    const request = loadExplorePayload(
+      "late-503-fresh-attempt-deadline",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    );
+
+    await vi.advanceTimersByTimeAsync(11_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(6_000);
+    await expect(request).resolves.toEqual(payload);
+  });
+
+  it("does not retry an aborted 503 request", async () => {
+    let resolveOld: ((response: Response) => void) | undefined;
+    let oldAttemptSignal: AbortSignal | undefined;
+    const requests: string[] = [];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input, init) => {
+        const url = String(input);
+        requests.push(url);
+        if (url.includes("page=1")) {
+          oldAttemptSignal = init?.signal ?? undefined;
+          return await new Promise<Response>((resolve) => {
+            resolveOld = resolve;
+          });
+        }
+        return new Response(JSON.stringify({ ...payload, page: 2 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    );
+    const first = loadExplorePayload(
+      "aborted-503-no-retry",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    );
+    await vi.waitFor(() => expect(resolveOld).toBeTypeOf("function"));
+    const current = loadExplorePayload(
+      "aborted-503-no-retry",
+      new URLSearchParams({ sort: "market-cap", page: "2", limit: "9" }),
+    );
+    resolveOld?.(new Response("ignored", { status: 503 }));
+
+    await expect(first).rejects.toMatchObject({ name: "AbortError" });
+    await expect(current).resolves.toMatchObject({ page: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requests.filter((url) => url.includes("page=1"))).toHaveLength(1);
+    expect(oldAttemptSignal?.aborted).toBe(true);
+  });
+
+  it("never caches a successful response from an aborted stale request", async () => {
+    let resolveOld: ((response: Response) => void) | undefined;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input) => {
+        const url = String(input);
+        if (url.includes("page=1")) {
+          return await new Promise<Response>((resolve) => {
+            resolveOld = resolve;
+          });
+        }
+        return new Response(JSON.stringify({ ...payload, page: 2 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    );
+    const first = loadExplorePayload(
+      "aborted-success-no-stale-cache",
+      new URLSearchParams({ sort: "newest", page: "1", limit: "9" }),
+    );
+    await vi.waitFor(() => expect(resolveOld).toBeTypeOf("function"));
+    const currentSearch = new URLSearchParams({
+      sort: "newest",
+      page: "2",
+      limit: "9",
+    });
+    const current = loadExplorePayload(
+      "aborted-success-no-stale-cache",
+      currentSearch,
+    );
+    await expect(current).resolves.toMatchObject({ page: 2 });
+    resolveOld?.(new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+    await expect(first).rejects.toMatchObject({ name: "AbortError" });
+    await expect(loadExplorePayload(
+      "aborted-success-no-stale-cache",
+      currentSearch,
+    )).resolves.toMatchObject({ page: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 
   it("rejects Router provenance on a custom project without a complete stamp", async () => {
     const project = customEntry(91);

--- a/tests/launch-stamp-surfaces.test.ts
+++ b/tests/launch-stamp-surfaces.test.ts
@@ -185,17 +185,20 @@ describe("canonical Router stamp surfaces", () => {
   });
 
   it("parses and labels both Router categories from the stamp", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
         status: "ready",
         tokens: [customGraphExploreEntry, stampedClassicExploreEntry],
         page: 1,
         pageSize: 9,
         total: 2,
         totalPages: 1,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
       }),
-    }));
+    );
+    vi.stubGlobal("fetch", fetchMock);
 
     const payload = await loadExplorePayload(
       `router-stamp-${Date.now()}`,
@@ -211,6 +214,7 @@ describe("canonical Router stamp surfaces", () => {
     expect(payload.tokens[0]).toMatchObject({
       launchStampProvenance: { kind: "custom-graph" },
     });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("fills missing Router card copy without inventing market data", () => {


### PR DESCRIPTION
## Summary
- retry the identical Explore request once after an HTTP 503
- give each attempt its own bounded 12-second deadline
- preserve abort, stale-request, cache, payload, valuation, and pagination validation
- keep the same Bitquery provider with no fallback or secondary source

## Verification
- 36 focused tests passed
- TypeScript passed
- scoped ESLint passed
- diff check passed

No wallet signing, transaction submission, provider fallback, or data-integrity relaxation is introduced.