### PR TITLE
fix(explore): retry incomplete Bitquery reads once

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -613,24 +613,44 @@ jobs:
             "x-vercel-protection-bypass": bypass,
             "x-vercel-set-bypass-cookie": "false",
           };
-          async function requestJson(path) {
-            const response = await fetch(new URL(path, target), {
-              headers,
-              redirect: "error",
-              signal: AbortSignal.timeout(30_000),
-            });
-            if (!response.ok) {
-              throw new Error(
-                "Bitquery public API returned HTTP " + response.status,
-              );
+          async function requestJson(path, retryWhen = null) {
+            const requestUrl = new URL(path, target);
+            for (let attempt = 0; attempt < 2; attempt += 1) {
+              const response = await fetch(requestUrl, {
+                headers,
+                redirect: "error",
+                signal: AbortSignal.timeout(30_000),
+              });
+              if (response.status === 503 && attempt === 0) continue;
+              if (!response.ok) {
+                throw new Error(
+                  "Bitquery public API returned HTTP " + response.status,
+                );
+              }
+              const result = {
+                body: await response.json(),
+                headers: response.headers,
+              };
+              if (
+                response.status === 200 &&
+                attempt === 0 &&
+                retryWhen?.(result) === true
+              ) continue;
+              return result;
             }
-            return {
-              body: await response.json(),
-              headers: response.headers,
-            };
+            throw new Error("Bitquery public API retry contract is unreachable");
           }
           const address = /^0x[0-9a-f]{40}$/u;
           const positiveInteger = /^[1-9][0-9]*$/u;
+          function integrityQualifiedBitqueryFdv(token) {
+            return token?.valuation?.status === "available" &&
+              token.valuation.metric === "fdv" &&
+              token.valuation.supplyBasis === "total" &&
+              token.valuation.currency === "usd" &&
+              token.valuation.freshness === "current" &&
+              token.valuation.source === "bitquery" &&
+              positiveInteger.test(String(token.valuation.valueWad ?? ""));
+          }
           function exactExploreSources(response) {
             return response.headers.get("x-programmable-launch-source") ===
                 "drpc" &&
@@ -640,6 +660,18 @@ jobs:
                 "bitquery" &&
               response.headers.get("x-programmable-price-source") ===
                 "bitquery";
+          }
+          function emptyCurrentBitqueryFdvRanking(response, expectedSort) {
+            const tokens = Array.isArray(response.body?.tokens)
+              ? response.body.tokens
+              : [];
+            return ["market-cap", "market-cap-asc"].includes(expectedSort) &&
+              response.body?.status === "ready" &&
+              response.body?.sort === expectedSort &&
+              response.body?.sortMetric === "fdv" &&
+              tokens.length > 0 &&
+              exactExploreSources(response) &&
+              !tokens.some(integrityQualifiedBitqueryFdv);
           }
           const health = await requestJson("/api/ops/health");
           if (
@@ -651,6 +683,8 @@ jobs:
           }
           const highest = await requestJson(
             "/api/explore?limit=20&page=1&sort=market-cap",
+            (response) =>
+              emptyCurrentBitqueryFdvRanking(response, "market-cap"),
           );
           const highestTokens = Array.isArray(highest.body?.tokens)
             ? highest.body.tokens
@@ -665,10 +699,7 @@ jobs:
             throw new Error("Highest FDV is not ready");
           }
           const valuedHighest = highestTokens.filter(
-            (token) =>
-              token?.valuation?.status === "available" &&
-              token.valuation.source === "bitquery" &&
-              positiveInteger.test(String(token.valuation.valueWad ?? "")),
+            integrityQualifiedBitqueryFdv,
           );
           if (valuedHighest.length < 1) {
             throw new Error("Highest FDV returned no Bitquery valuation");

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -878,6 +878,22 @@ function assertExploreResponseContract(
   }
 }
 
+function shouldRetryMissingBitqueryFdv(
+  search: URLSearchParams,
+  payload: ExplorePayload,
+) {
+  const sort = search.get("sort");
+  if (sort !== "market-cap" && sort !== "market-cap-asc") return false;
+  return !payload.tokens.some((token) => {
+    const valuation = token.valuation;
+    return valuation.status === "available" &&
+      valuation.metric === "fdv" &&
+      valuation.freshness === "current" &&
+      valuation.source === "bitquery" &&
+      BigInt(valuation.valueWad) > 0n;
+  });
+}
+
 function assertUniqueExploreDatasetEntries(
   entries: readonly ValuedExploreEntry[],
 ) {
@@ -959,6 +975,9 @@ async function fetchExplorePayload(
       }
       const payload = parseExplorePayload(body);
       assertExploreResponseContract(payload, contract);
+      if (attempt === 0 && shouldRetryMissingBitqueryFdv(search, payload)) {
+        continue;
+      }
       return payload;
     } catch (error) {
       signal.throwIfAborted();

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -888,6 +888,8 @@ function shouldRetryMissingBitqueryFdv(
     const valuation = token.valuation;
     return valuation.status === "available" &&
       valuation.metric === "fdv" &&
+      valuation.supplyBasis === "total" &&
+      valuation.currency === "usd" &&
       valuation.freshness === "current" &&
       valuation.source === "bitquery" &&
       BigInt(valuation.valueWad) > 0n;

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2452,6 +2452,40 @@ export function evaluateReadModelOperationsSourceContracts(
     stagedBitquerySmoke >= 0 && stagedBitquerySmokeEnd > stagedBitquerySmoke
       ? deployWorkflow.slice(stagedBitquerySmoke, stagedBitquerySmokeEnd)
       : "";
+  const stagedBitquery503Retry =
+    /const requestUrl = new URL\(path, target\);[\s\S]*for \(let attempt = 0; attempt < 2; attempt \+= 1\) \{[\s\S]*const response = await fetch\(requestUrl, \{[\s\S]*if \(response\.status === 503 && attempt === 0\) continue;[\s\S]*if \(!response\.ok\)/u.test(
+      stagedBitquerySmokeBlock,
+    );
+  const stagedBitqueryEmptyFdvRetry =
+    stagedBitquerySmokeBlock.includes(
+      "async function requestJson(path, retryWhen = null)",
+    ) &&
+    stagedBitquerySmokeBlock.includes("response.status === 200") &&
+    stagedBitquerySmokeBlock.includes("retryWhen?.(result) === true") &&
+    stagedBitquerySmokeBlock.includes(
+      '["market-cap", "market-cap-asc"].includes(expectedSort)',
+    ) &&
+    stagedBitquerySmokeBlock.includes(
+      "response.body?.sort === expectedSort",
+    ) &&
+    stagedBitquerySmokeBlock.includes(
+      'token.valuation.freshness === "current"',
+    ) &&
+    stagedBitquerySmokeBlock.includes('token.valuation.metric === "fdv"') &&
+    stagedBitquerySmokeBlock.includes(
+      'token.valuation.supplyBasis === "total"',
+    ) &&
+    stagedBitquerySmokeBlock.includes('token.valuation.currency === "usd"') &&
+    stagedBitquerySmokeBlock.includes('token.valuation.source === "bitquery"') &&
+    stagedBitquerySmokeBlock.includes(
+      "positiveInteger.test(String(token.valuation.valueWad ?? \"\"))",
+    ) &&
+    stagedBitquerySmokeBlock.includes(
+      '"/api/explore?limit=20&page=1&sort=market-cap",\n' +
+        "            (response) =>\n" +
+        '              emptyCurrentBitqueryFdvRanking(response, "market-cap"),',
+    ) &&
+    (stagedBitquerySmokeBlock.match(/emptyCurrentBitqueryFdvRanking/gu)?.length ?? 0) === 2;
   const publicIdentityAndMarketRoutes = [
     publicExplore,
     publicToken,
@@ -2676,6 +2710,8 @@ export function evaluateReadModelOperationsSourceContracts(
         "VERCEL_AUTOMATION_BYPASS_SECRET: $\{{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
       ) &&
       stagedBitquerySmokeBlock.includes('requestJson("/api/ops/health")') &&
+      stagedBitquery503Retry &&
+      stagedBitqueryEmptyFdvRetry &&
       stagedBitquerySmokeBlock.includes("sort=market-cap") &&
       stagedBitquerySmokeBlock.includes("sort=newest") &&
       stagedBitquerySmokeBlock.includes("/api/explore/token?address=") &&

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -94,6 +94,23 @@ test("Custom-only changes do not invoke the public data smoke", () => {
   assert.match(smoke, /\/api\/explore\/profile\?account=/u);
   assert.match(
     smoke,
+    /const requestUrl = new URL\(path, target\);[\s\S]*for \(let attempt = 0; attempt < 2; attempt \+= 1\) \{[\s\S]*const response = await fetch\(requestUrl, \{[\s\S]*if \(response\.status === 503 && attempt === 0\) continue;[\s\S]*if \(!response\.ok\)/u,
+  );
+  assert.match(
+    smoke,
+    /response\.status === 200[\s\S]*retryWhen\?\.\(result\) === true/u,
+  );
+  assert.match(
+    smoke,
+    /token\.valuation\.freshness === "current"[\s\S]*\["market-cap", "market-cap-asc"\]\.includes\(expectedSort\)[\s\S]*response\.body\?\.sort === expectedSort/u,
+  );
+  assert.match(
+    smoke,
+    /sort=market-cap",\s*\(response\) =>\s*emptyCurrentBitqueryFdvRanking\(response, "market-cap"\),/u,
+  );
+  assert.equal(smoke.match(/emptyCurrentBitqueryFdvRanking/gu)?.length, 2);
+  assert.match(
+    smoke,
     /x-programmable-launch-source"\) ===[\s\S]*"drpc"/u,
   );
   assert.match(

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -944,6 +944,64 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it.each([
+    ["more than one retry", "attempt < 2", "attempt < 3"],
+    [
+      "a response other than HTTP 503",
+      "response.status === 503 && attempt === 0",
+      "response.status >= 500 && attempt === 0",
+    ],
+    ["a rebuilt URL", "fetch(requestUrl, {", "fetch(new URL(path, target), {"],
+  ])("rejects staged Bitquery smoke retrying %s", (_label, needle, replacement) => {
+    const path = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, path), "utf8");
+    expect(workflow).toContain(needle);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: workflow.replace(needle, replacement) },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-public-provider-stage-smoke",
+    );
+  });
+
+  it.each([
+    [
+      "an FDV response other than HTTP 200",
+      "response.status === 200",
+      "response.ok",
+    ],
+    [
+      "a non-current valuation",
+      'token.valuation.freshness === "current"',
+      'token.valuation.freshness !== "unknown"',
+    ],
+    [
+      "the Newest route on empty FDV data",
+      '["market-cap", "market-cap-asc"].includes(expectedSort)',
+      '["market-cap", "market-cap-asc", "newest"].includes(expectedSort)',
+    ],
+    [
+      "a response sort different from the requested FDV sort",
+      "response.body?.sort === expectedSort",
+      '["market-cap", "market-cap-asc"].includes(response.body?.sort)',
+    ],
+    [
+      "without the exact Highest callback",
+      '              emptyCurrentBitqueryFdvRanking(response, "market-cap"),',
+      "              false,",
+    ],
+  ])("rejects staged Bitquery data retrying %s", (_label, needle, replacement) => {
+    const path = ".github/workflows/deploy-production.yml";
+    const workflow = readFileSync(resolve(ROOT, path), "utf8");
+    expect(workflow).toContain(needle);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: workflow.replace(needle, replacement) },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-public-provider-stage-smoke",
+    );
+  });
+
   it("rejects restored staged read-model availability gates", () => {
     const path = ".github/workflows/deploy-production.yml";
     const workflow = readFileSync(resolve(ROOT, path), "utf8");

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -148,6 +148,14 @@ const valuedMarketPayload = {
   totalPages: 1,
 };
 
+const wrongCurrencyMarketPayload = {
+  ...valuedMarketPayload,
+  tokens: valuedMarketPayload.tokens.map((token) => ({
+    ...token,
+    valuation: { ...token.valuation, currency: "eth" },
+  })),
+};
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
@@ -669,6 +677,36 @@ describe("Explore refresh state", () => {
       expect(fetchMock.mock.calls[1]?.[0]).toBe(fetchMock.mock.calls[0]?.[0]);
     },
   );
+
+  it("retries the first non-USD FDV and returns the second fail-closed", async () => {
+    const secondPayload = { ...wrongCurrencyMarketPayload, total: 2 };
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify(wrongCurrencyMarketPayload),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ))
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify(secondPayload),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ));
+
+    await expect(loadExplorePayload(
+      "market-cap-wrong-currency",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).resolves.toMatchObject({
+      total: 2,
+      tokens: [expect.objectContaining({
+        valuation: expect.objectContaining({ currency: "eth" }),
+      })],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 
   it("returns the second valid zero-valuation response without a third attempt", async () => {
     const secondPayload = { ...unvaluedMarketPayload, total: 2 };

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -108,6 +108,46 @@ const payload = {
   totalPages: 2,
 };
 
+const bitqueryMarketEntry = classicEntry({
+  id: "1:bitquery-market",
+  name: "Bitquery market",
+  symbol: "BQM",
+  tokenAddress: "0x1111111111111111111111111111111111111111",
+  hookAddress: "0x2222222222222222222222222222222222222222",
+  poolId: `0x${"33".repeat(32)}`,
+  launchedAt: "2026-08-11T14:00:00.000Z",
+  totalSwapFeeBps: 100,
+  liquidityPath: "meme",
+});
+
+const unvaluedMarketPayload = {
+  ...payload,
+  tokens: [{
+    ...bitqueryMarketEntry,
+    valuation: { status: "unavailable", reason: "source-unavailable" },
+  }],
+  total: 1,
+  totalPages: 1,
+};
+
+const valuedMarketPayload = {
+  ...payload,
+  tokens: [{
+    ...bitqueryMarketEntry,
+    valuation: {
+      status: "available",
+      metric: "fdv",
+      supplyBasis: "total",
+      currency: "usd",
+      valueWad: "125000000000000000000",
+      freshness: "current",
+      source: "bitquery",
+    },
+  }],
+  total: 1,
+  totalPages: 1,
+};
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
@@ -582,7 +622,7 @@ describe("Explore refresh state", () => {
     );
     const search = new URLSearchParams({
       q: "",
-      sort: "market-cap",
+      sort: "newest",
       page: "1",
       limit: "9",
     });
@@ -592,6 +632,91 @@ describe("Explore refresh state", () => {
 
     expect(second).toBe(first);
     await expect(first).resolves.toEqual(marketPayload);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["market-cap", "market-cap-asc"])(
+    "retries a valid zero-valuation %s response and returns the valued retry",
+    async (sort) => {
+      const first = new Response(JSON.stringify(unvaluedMarketPayload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      const firstJson = vi.spyOn(first, "json");
+      const fetchMock = vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(first)
+        .mockResolvedValueOnce(new Response(
+          JSON.stringify(valuedMarketPayload),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ));
+
+      const result = await loadExplorePayload(
+        `${sort}-zero-then-valued`,
+        new URLSearchParams({ sort, page: "1", limit: "9" }),
+      );
+
+      expect(result.tokens[0]?.valuation).toMatchObject({
+        status: "available",
+        metric: "fdv",
+        freshness: "current",
+        source: "bitquery",
+      });
+      expect(firstJson).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1]?.[0]).toBe(fetchMock.mock.calls[0]?.[0]);
+    },
+  );
+
+  it("returns the second valid zero-valuation response without a third attempt", async () => {
+    const secondPayload = { ...unvaluedMarketPayload, total: 2 };
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify(unvaluedMarketPayload),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ))
+      .mockResolvedValueOnce(new Response(JSON.stringify(secondPayload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }));
+
+    await expect(loadExplorePayload(
+      "market-cap-zero-twice",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).resolves.toMatchObject({ total: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a valid zero-valuation response for Newest", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify(unvaluedMarketPayload),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ))
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify(valuedMarketPayload),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ));
+
+    await expect(loadExplorePayload(
+      "newest-zero-no-retry",
+      new URLSearchParams({ sort: "newest", page: "1", limit: "9" }),
+    )).resolves.toMatchObject({
+      tokens: [expect.objectContaining({
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+      })],
+    });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -606,7 +731,7 @@ describe("Explore refresh state", () => {
     const firstJson = vi.spyOn(first, "json");
     const fetchMock = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(first)
-      .mockResolvedValueOnce(new Response(JSON.stringify(payload), {
+      .mockResolvedValueOnce(new Response(JSON.stringify(unvaluedMarketPayload), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }));
@@ -619,7 +744,11 @@ describe("Explore refresh state", () => {
 
     const request = loadExplorePayload("bitquery-one-retry", search);
     expect(loadExplorePayload("bitquery-one-retry", search)).toBe(request);
-    await expect(request).resolves.toEqual(payload);
+    await expect(request).resolves.toMatchObject({
+      tokens: [expect.objectContaining({
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+      })],
+    });
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[1]?.[0]).toBe(fetchMock.mock.calls[0]?.[0]);
     expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
@@ -722,7 +851,12 @@ describe("Explore refresh state", () => {
             resolveOld = resolve;
           });
         }
-        return new Response(JSON.stringify({ ...payload, page: 2 }), {
+        return new Response(JSON.stringify({
+          ...valuedMarketPayload,
+          page: 2,
+          total: 18,
+          totalPages: 2,
+        }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
@@ -787,6 +921,66 @@ describe("Explore refresh state", () => {
       currentSearch,
     )).resolves.toMatchObject({ page: 2 });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache an empty-FDV response when its retry is aborted as stale", async () => {
+    let resolveOldRetry: ((response: Response) => void) | undefined;
+    let oldRetrySignal: AbortSignal | undefined;
+    let pageOneCalls = 0;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input, init) => {
+        const url = new URL(String(input), "https://example.test");
+        if (url.searchParams.get("page") === "1") {
+          pageOneCalls += 1;
+          if (pageOneCalls === 1) {
+            return new Response(JSON.stringify(unvaluedMarketPayload), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+          oldRetrySignal = init?.signal ?? undefined;
+          return await new Promise<Response>((resolve) => {
+            resolveOldRetry = resolve;
+          });
+        }
+        return new Response(JSON.stringify({
+          ...valuedMarketPayload,
+          page: 2,
+          total: 18,
+          totalPages: 2,
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    );
+    const oldRequest = loadExplorePayload(
+      "aborted-empty-fdv-no-stale-cache",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    );
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const currentSearch = new URLSearchParams({
+      sort: "market-cap",
+      page: "2",
+      limit: "9",
+    });
+    const currentRequest = loadExplorePayload(
+      "aborted-empty-fdv-no-stale-cache",
+      currentSearch,
+    );
+    resolveOldRetry?.(new Response(JSON.stringify(valuedMarketPayload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    await expect(oldRequest).rejects.toMatchObject({ name: "AbortError" });
+    await expect(currentRequest).resolves.toMatchObject({ page: 2 });
+    await expect(loadExplorePayload(
+      "aborted-empty-fdv-no-stale-cache",
+      currentSearch,
+    )).resolves.toMatchObject({ page: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(oldRetrySignal?.aborted).toBe(true);
   });
 
   it("rejects Router provenance on a custom project without a complete stamp", async () => {


### PR DESCRIPTION
## Summary
- retry an identical Highest/Lowest request once when a fully validated response contains no current positive USD Bitquery FDV
- preserve the existing one-time HTTP 503 retry and per-attempt deadline
- retry staged public API smoke once for HTTP 503 and Highest without a qualified FDV
- keep the same Bitquery provider, same URL, exact assertions, and fail-closed second result

## Verification
- 184 integrated focused tests passed
- workflow contract tests passed
- operations source gate passed
- TypeScript, actionlint, scoped ESLint, diff check, and gitleaks passed

No provider fallback, data fabrication, signing, or transaction submission is introduced.