### PR TITLE
Bind Website projection adoption to full hosted role graph

### DIFF
--- a/docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md
+++ b/docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md
@@ -34,6 +34,10 @@ repair. It accepts only all of these exact facts:
   `0xac4a1fe60ebf677865a0f8ca6160162d9c457dc2bd401aa60fd820c8f2fdcc58`
   and expanded snapshot
   `0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284`;
+- protected current-role snapshot
+  `0x917afa0f6bcd19f00f5d2ce5cd0d8221ef00ad6716460af11bff0906e4b9a0f9`,
+  captured by commit `482aba91cd246d605ec0f98d0718dd5fff781d1f`,
+  with exactly 36 endpoint roles and all 50 membership rows;
 - the exact normalized catalog, RLS, policies, grants, functions and triggers
   after `0001` through `0003`, including the captured schema `USAGE`, three
   table `SELECT`/`INSERT` grants and eleven registry column `UPDATE` grants,
@@ -46,11 +50,11 @@ repair. It accepts only all of these exact facts:
   `0x93e41eab957ab8add897a8b277bcaaa0a5f10eebeb27f47db5bc0e59640484a2`
   and protected full-inventory hash
   `0xd32953874c1466be82433d97e6532d0572ddcf80eed261efa119b25f17e0f5b3`;
-- the constrained runtime role with the sole accepted drift
-  `rolinherit = true`, plus exactly the provider-owned
+- the exact full endpoint-role and membership inventory, including the
+  constrained runtime role with the sole accepted drift `rolinherit = true`
+  and the provider-owned
   `postgres -> programmable_website_projection_runtime WITH ADMIN OPTION`
-  membership with `INHERIT FALSE`, `SET FALSE`, grantor `supabase_admin`, and
-  no other runtime/provider edge.
+  membership with `INHERIT FALSE`, `SET FALSE`, and grantor `supabase_admin`.
 
 The protected operator checkout may be a clean reviewed successor commit only
 when all five migration file/execution hashes still equal the source plan. The
@@ -64,6 +68,7 @@ hashes, zero-row hash and counts, exact role delta, source and operator Git
 identities, plan, target and adoption attestation hash.
 
 Run only after independently reviewing the protected snapshot and exact target:
+all three snapshot inputs must be owner-only regular files with mode `0600`.
 
 ```sh
 npm run --silent db:website-projection:operator -- adopt-existing \
@@ -73,11 +78,13 @@ npm run --silent db:website-projection:operator -- adopt-existing \
     /secure/operator/programmable-website-projection-hosted-catalog-snapshot-76ebd54.json \
   --source-expanded-snapshot \
     /secure/operator/programmable-website-projection-hosted-catalog-snapshot-v2-76ebd54.json \
+  --source-current-snapshot \
+    /secure/operator/programmable-website-projection-hosted-catalog-snapshot-v3-482aba91.json \
   --confirm-adopt-existing \
     '<exact-successor-planSha256>' \
   --confirm-target 'mnnvlrqwhfoppogslsje' \
   --confirm-source-snapshot \
-    '0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284' \
+    '0x917afa0f6bcd19f00f5d2ce5cd0d8221ef00ad6716460af11bff0906e4b9a0f9' \
   --confirm-adopt-through '0003'
 ```
 

--- a/scripts/website-projection-db-operator-core.mjs
+++ b/scripts/website-projection-db-operator-core.mjs
@@ -27,6 +27,8 @@ export const WEBSITE_PROJECTION_ADOPTION_SOURCE_PLAN_SHA256 =
 export const WEBSITE_PROJECTION_ADOPTION_SOURCE_ORDER_SHA256 =
   "0xce50954bfa6ff3b66b849bb5b53e8f1adf93abbe12cf865c19375100f2571cc2";
 export const WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256 =
+  "0x917afa0f6bcd19f00f5d2ce5cd0d8221ef00ad6716460af11bff0906e4b9a0f9";
+export const WEBSITE_PROJECTION_ADOPTION_EXPANDED_SNAPSHOT_SHA256 =
   "0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284";
 export const WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256 =
   "0xac4a1fe60ebf677865a0f8ca6160162d9c457dc2bd401aa60fd820c8f2fdcc58";
@@ -37,6 +39,10 @@ export const WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256 =
 export const WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT = 3;
 export const WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF =
   "mnnvlrqwhfoppogslsje";
+export const WEBSITE_PROJECTION_ADOPTION_CURRENT_OPERATOR_COMMIT =
+  "482aba91cd246d605ec0f98d0718dd5fff781d1f";
+export const WEBSITE_PROJECTION_ADOPTION_CURRENT_OPERATOR_TREE =
+  "b65e183f679c97b8152c779d9866aec53202bf4a";
 
 export const WEBSITE_PROJECTION_MIGRATION_FILES = Object.freeze([
   "0001_projection_records_v1.sql",
@@ -270,6 +276,8 @@ export function websiteProjectionAdoptionAttestationSha256({
     adoptedMigrationCount: WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
     adoptedThroughVersion: "0003",
     sourceSnapshotSha256,
+    expandedSnapshotSha256:
+      WEBSITE_PROJECTION_ADOPTION_EXPANDED_SNAPSHOT_SHA256,
     baseSnapshotSha256: WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
     legacyInventorySha256:
       WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256,
@@ -402,6 +410,8 @@ export function compareWebsiteProjectionEvidence({
       || adoptionRow.source_snapshot_sha256 !== adoption.sourceSnapshotSha256
       || adoptionRow.base_snapshot_sha256
         !== WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256
+      || adoptionRow.expanded_snapshot_sha256
+        !== WEBSITE_PROJECTION_ADOPTION_EXPANDED_SNAPSHOT_SHA256
       || adoptionRow.legacy_inventory_sha256
         !== WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256
       || adoptionRow.legacy_public_sha256

--- a/scripts/website-projection-db-operator.mjs
+++ b/scripts/website-projection-db-operator.mjs
@@ -39,7 +39,7 @@ const HELP = `Usage:
   node scripts/website-projection-db-operator.mjs dry-run --plan FILE --expected-project-ref REF
   node scripts/website-projection-db-operator.mjs verify --plan FILE --expected-project-ref REF
   node scripts/website-projection-db-operator.mjs apply --plan FILE --expected-project-ref REF --confirm-apply PLAN_SHA256 --confirm-target REF
-  node scripts/website-projection-db-operator.mjs adopt-existing --plan FILE --expected-project-ref REF --source-base-snapshot FILE --source-expanded-snapshot FILE --confirm-adopt-existing PLAN_SHA256 --confirm-target REF --confirm-source-snapshot SNAPSHOT_SHA256 --confirm-adopt-through 0003
+  node scripts/website-projection-db-operator.mjs adopt-existing --plan FILE --expected-project-ref REF --source-base-snapshot FILE --source-expanded-snapshot FILE --source-current-snapshot FILE --confirm-adopt-existing PLAN_SHA256 --confirm-target REF --confirm-source-snapshot SNAPSHOT_SHA256 --confirm-adopt-through 0003
 
 Database credentials are accepted only through PROGRAMMABLE_MIGRATOR_DATABASE_URL.
 The CA certificate is accepted only through PROGRAMMABLE_POSTGRES_SSL_CA_PEM.
@@ -144,6 +144,7 @@ async function runDatabaseCommand(command, flags) {
       "--confirm-adopt-through",
       "--source-base-snapshot",
       "--source-expanded-snapshot",
+      "--source-current-snapshot",
     );
   }
   exactFlags(flags, allowed);
@@ -173,6 +174,7 @@ async function runDatabaseCommand(command, flags) {
     ? await readWebsiteProjectionAdoptionProtectedSnapshots({
       baseSnapshotPath: flags.get("--source-base-snapshot"),
       expandedSnapshotPath: flags.get("--source-expanded-snapshot"),
+      currentSnapshotPath: flags.get("--source-current-snapshot"),
       expectedProjectRef,
     })
     : null;

--- a/scripts/website-projection-db-operator.test.mjs
+++ b/scripts/website-projection-db-operator.test.mjs
@@ -40,6 +40,8 @@ const COMMIT = "76ebd54e2f0e31d055cfe6c36b7474b0e850de90";
 const TREE = "8e4ddd9a73818ce70f1284f3b2731bc87b005f27";
 const PROJECT_REF = "mnnvlrqwhfoppogslsje";
 const SOURCE_SNAPSHOT =
+  "0x917afa0f6bcd19f00f5d2ce5cd0d8221ef00ad6716460af11bff0906e4b9a0f9";
+const EXPANDED_SNAPSHOT =
   "0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284";
 const BASE_SNAPSHOT =
   "0xac4a1fe60ebf677865a0f8ca6160162d9c457dc2bd401aa60fd820c8f2fdcc58";
@@ -435,6 +437,23 @@ test("protected adoption inventory validator rejects catalog, role, data and leg
     inherit_option: false,
     set_option: false,
   }];
+  const currentRoles = [
+    roles[0],
+    roles[1],
+    safeRole("authenticator", { rolinherit: true, rolcanlogin: true }),
+    ...roles.slice(2),
+  ];
+  const currentMemberships = [
+    {
+      member_name: "authenticator",
+      role_name: "anon",
+      grantor_name: "supabase_admin",
+      admin_option: false,
+      inherit_option: false,
+      set_option: true,
+    },
+    ...memberships,
+  ];
   const sourceData = { rowPresence: [
     { relation_name: "credential_uses", has_rows: false },
     { relation_name: "projection_records", has_rows: false },
@@ -477,6 +496,10 @@ test("protected adoption inventory validator rejects catalog, role, data and leg
         evidenceRows: [],
       },
     },
+    currentSnapshot: {
+      roles: currentRoles,
+      memberships: currentMemberships,
+    },
   };
   const valid = {
     sourceCatalog: {
@@ -485,7 +508,10 @@ test("protected adoption inventory validator rejects catalog, role, data and leg
       ...structure,
     },
     sourceData,
-    extendedRoleInventory: { roles, memberships },
+    extendedRoleInventory: {
+      roles: currentRoles,
+      memberships: currentMemberships,
+    },
     legacyInventory,
     protectedSnapshots,
   };
@@ -495,7 +521,24 @@ test("protected adoption inventory validator rejects catalog, role, data and leg
     (value) => { value.sourceCatalog.roles[3].rolinherit = false; },
     (value) => { value.sourceCatalog.memberships[0].grantor_name = "postgres"; },
     (value) => { value.extendedRoleInventory.roles[3].rolconnlimit = 1; },
-    (value) => { value.extendedRoleInventory.memberships[0].set_option = true; },
+    (value) => { value.extendedRoleInventory.memberships[1].set_option = true; },
+    (value) => { value.extendedRoleInventory.memberships.shift(); },
+    (value) => { value.extendedRoleInventory.memberships[0].set_option = false; },
+    (value) => {
+      value.extendedRoleInventory.roles.splice(
+        2,
+        0,
+        safeRole("attacker_login", { rolcanlogin: true, rolinherit: true }),
+      );
+      value.extendedRoleInventory.memberships.unshift({
+        member_name: "attacker_login",
+        role_name: "authenticator",
+        grantor_name: "supabase_admin",
+        admin_option: false,
+        inherit_option: false,
+        set_option: true,
+      });
+    },
     (value) => { value.sourceData.rowPresence[0].has_rows = true; },
     (value) => { value.legacyInventory.relations.push({ relname: "extra" }); },
     (value) => { value.legacyInventory.columns.push({ column_name: "extra" }); },
@@ -519,34 +562,44 @@ test("protected snapshot reader rejects symlinks, broad modes, raw drift and tar
   const target = path.join(root, "target.json");
   const baseLink = path.join(root, "base-link.json");
   const expandedLink = path.join(root, "expanded-link.json");
+  const currentLink = path.join(root, "current-link.json");
   await writeFile(target, "{}\n", { mode: 0o600 });
   await symlink(target, baseLink);
   await symlink(target, expandedLink);
+  await symlink(target, currentLink);
   await assert.rejects(readWebsiteProjectionAdoptionProtectedSnapshots({
     baseSnapshotPath: baseLink,
     expandedSnapshotPath: expandedLink,
+    currentSnapshotPath: currentLink,
     expectedProjectRef: PROJECT_REF,
   }), /ELOOP|symbolic links/u);
 
   const broadBase = path.join(root, "broad-base.json");
   const broadExpanded = path.join(root, "broad-expanded.json");
+  const broadCurrent = path.join(root, "broad-current.json");
   await writeFile(broadBase, "{}\n", { mode: 0o600 });
   await writeFile(broadExpanded, "{}\n", { mode: 0o600 });
+  await writeFile(broadCurrent, "{}\n", { mode: 0o600 });
   await chmod(broadBase, 0o644);
   await chmod(broadExpanded, 0o644);
+  await chmod(broadCurrent, 0o644);
   await assert.rejects(readWebsiteProjectionAdoptionProtectedSnapshots({
     baseSnapshotPath: broadBase,
     expandedSnapshotPath: broadExpanded,
+    currentSnapshotPath: broadCurrent,
     expectedProjectRef: PROJECT_REF,
   }), /owner-only regular file/u);
 
   const driftedBase = path.join(root, "drifted-base.json");
   const driftedExpanded = path.join(root, "drifted-expanded.json");
+  const driftedCurrent = path.join(root, "drifted-current.json");
   await writeFile(driftedBase, "{}\n", { mode: 0o600 });
   await writeFile(driftedExpanded, "{}\n", { mode: 0o600 });
+  await writeFile(driftedCurrent, "{}\n", { mode: 0o600 });
   await assert.rejects(readWebsiteProjectionAdoptionProtectedSnapshots({
     baseSnapshotPath: driftedBase,
     expandedSnapshotPath: driftedExpanded,
+    currentSnapshotPath: driftedCurrent,
     expectedProjectRef: PROJECT_REF,
   }), /raw hash mismatch/u);
 
@@ -577,6 +630,29 @@ test("protected snapshot reader rejects symlinks, broad modes, raw drift and tar
       target: targetIdentity,
       baseSnapshot: { rawSha256: BASE_SNAPSHOT },
       applicationCatalog: baseSnapshot,
+    },
+    currentSnapshot: {
+      kind: "programmable-website-projection-hosted-catalog-snapshot-v3",
+      schemaVersion: 3,
+      target: targetIdentity,
+      operatorSource: {
+        repositoryCommit: "482aba91cd246d605ec0f98d0718dd5fff781d1f",
+        repositoryTree: "b65e183f679c97b8152c779d9866aec53202bf4a",
+      },
+      parentSnapshots: {
+        baseRawSha256: BASE_SNAPSHOT,
+        expandedRawSha256: EXPANDED_SNAPSHOT,
+      },
+      observation: {
+        databaseName: "postgres",
+        serverPort: 5432,
+        serverVersionNum: "170006",
+        sessionUser: "postgres",
+        currentRole: "postgres",
+        observedAt: "2026-08-14T05:28:42.903695+00:00",
+      },
+      roles: [],
+      memberships: [],
     },
     expectedProjectRef: "z".repeat(20),
   }), /protected snapshot identity mismatch/u);
@@ -799,8 +875,10 @@ function pgliteAdoptionAuditOptions() {
   return {
     protectedSnapshots: {
       sourceSnapshotSha256: SOURCE_SNAPSHOT,
+      expandedSnapshotSha256: EXPANDED_SNAPSHOT,
       baseSnapshotSha256: BASE_SNAPSHOT,
       expandedSnapshot: {},
+      currentSnapshot: {},
     },
     legacyInventoryReader: async () => ({ fixture: true }),
     liveInventoryValidator({ sourceData }) {
@@ -961,6 +1039,8 @@ test("adopt-existing records exact evidence atomically without replaying applica
     adoption_attestation_sha256 === adopted.adoptionAttestationSha256));
   const adoptionEvidence = await fixture.database.query(`
     SELECT evidence_kind, adopted_through_version,
+           source_snapshot_sha256, expanded_snapshot_sha256,
+           base_snapshot_sha256,
            credential_uses_count, projection_records_count,
            registry_custom_launch_records_count,
            runtime_rolinherit_before, runtime_rolinherit_after
@@ -969,6 +1049,9 @@ test("adopt-existing records exact evidence atomically without replaying applica
   assert.deepEqual(adoptionEvidence.rows, [{
     evidence_kind: "adopted-existing-prefix-v1",
     adopted_through_version: "0003",
+    source_snapshot_sha256: SOURCE_SNAPSHOT,
+    expanded_snapshot_sha256: EXPANDED_SNAPSHOT,
+    base_snapshot_sha256: BASE_SNAPSHOT,
     credential_uses_count: 0,
     projection_records_count: 0,
     registry_custom_launch_records_count: 0,

--- a/scripts/website-projection-db-postgres.mjs
+++ b/scripts/website-projection-db-postgres.mjs
@@ -14,6 +14,9 @@ import {
   websiteProjectionAdoptionAttestationSha256,
   WEBSITE_PROJECTION_ADOPTION_PREFIX_COUNT,
   WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
+  WEBSITE_PROJECTION_ADOPTION_CURRENT_OPERATOR_COMMIT,
+  WEBSITE_PROJECTION_ADOPTION_CURRENT_OPERATOR_TREE,
+  WEBSITE_PROJECTION_ADOPTION_EXPANDED_SNAPSHOT_SHA256,
   WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256,
   WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256,
   WEBSITE_PROJECTION_ADOPTION_SOURCE_COMMIT,
@@ -125,7 +128,7 @@ CREATE TABLE programmable_website_projection_migrations.migration_evidence_v1 (
       evidence_kind = 'adopted-existing-prefix-v1'
       AND ordinal BETWEEN 1 AND 3
       AND adoption_source_snapshot_sha256 =
-        '0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284'
+        '0x917afa0f6bcd19f00f5d2ce5cd0d8221ef00ad6716460af11bff0906e4b9a0f9'
       AND adoption_source_catalog_sha256 ~ '^0x[0-9a-f]{64}$'
       AND adoption_source_data_sha256 ~ '^0x[0-9a-f]{64}$'
       AND adoption_attestation_sha256 ~ '^0x[0-9a-f]{64}$'
@@ -145,6 +148,10 @@ CREATE TABLE programmable_website_projection_migrations.adoption_evidence_v1 (
   ),
   source_snapshot_sha256 text NOT NULL CHECK (
     source_snapshot_sha256 =
+      '0x917afa0f6bcd19f00f5d2ce5cd0d8221ef00ad6716460af11bff0906e4b9a0f9'
+  ),
+  expanded_snapshot_sha256 text NOT NULL CHECK (
+    expanded_snapshot_sha256 =
       '0x8cb9841f0131b48fb67eac0082d72f51158500a61482c0b21e0c7b7cc2f19284'
   ),
   base_snapshot_sha256 text NOT NULL CHECK (
@@ -364,9 +371,76 @@ function expectedTargetIdentity(value, expectedProjectRef) {
     && value.sslMode === "verify-full";
 }
 
+function assertCurrentSnapshotRoleAndMembershipInventory(currentSnapshot) {
+  if (!Array.isArray(currentSnapshot.roles)
+    || currentSnapshot.roles.length !== 36
+    || !Array.isArray(currentSnapshot.memberships)
+    || currentSnapshot.memberships.length !== 50) {
+    throw new Error("adopt-existing current snapshot inventory size mismatch");
+  }
+  const roleNames = [];
+  for (const role of currentSnapshot.roles) {
+    if (!plainObject(role)
+      || typeof role.rolname !== "string"
+      || role.rolname === ""
+      || typeof role.rolsuper !== "boolean"
+      || typeof role.rolinherit !== "boolean"
+      || typeof role.rolcreaterole !== "boolean"
+      || typeof role.rolcreatedb !== "boolean"
+      || typeof role.rolcanlogin !== "boolean"
+      || typeof role.rolreplication !== "boolean"
+      || !Number.isSafeInteger(role.rolconnlimit)
+      || !(role.rolvaliduntil === null
+        || typeof role.rolvaliduntil === "string")
+      || typeof role.rolbypassrls !== "boolean"
+      || !(role.rolconfig === null
+        || (Array.isArray(role.rolconfig)
+          && role.rolconfig.every((entry) => typeof entry === "string")))) {
+      throw new Error("adopt-existing current snapshot role inventory is invalid");
+    }
+    roleNames.push(role.rolname);
+  }
+  if (new Set(roleNames).size !== roleNames.length
+    || canonicalJson(roleNames) !== canonicalJson([...roleNames].sort())) {
+    throw new Error("adopt-existing current snapshot roles are not unique and sorted");
+  }
+  const roleNameSet = new Set(roleNames);
+  const membershipKeys = [];
+  for (const membership of currentSnapshot.memberships) {
+    if (!plainObject(membership)
+      || typeof membership.member_name !== "string"
+      || typeof membership.role_name !== "string"
+      || typeof membership.grantor_name !== "string"
+      || typeof membership.admin_option !== "boolean"
+      || typeof membership.inherit_option !== "boolean"
+      || typeof membership.set_option !== "boolean"
+      || !roleNameSet.has(membership.member_name)
+      || !roleNameSet.has(membership.role_name)
+      || !roleNameSet.has(membership.grantor_name)) {
+      throw new Error("adopt-existing current snapshot membership inventory is invalid");
+    }
+    membershipKeys.push([
+      membership.member_name,
+      membership.role_name,
+      membership.grantor_name,
+      String(membership.admin_option),
+      String(membership.inherit_option),
+      String(membership.set_option),
+    ].join("\0"));
+  }
+  if (new Set(membershipKeys).size !== membershipKeys.length
+    || canonicalJson(membershipKeys)
+      !== canonicalJson([...membershipKeys].sort())) {
+    throw new Error(
+      "adopt-existing current snapshot memberships are not unique and sorted",
+    );
+  }
+}
+
 export function assertWebsiteProjectionAdoptionProtectedSnapshots({
   baseSnapshot,
   expandedSnapshot,
+  currentSnapshot,
   expectedProjectRef,
 }) {
   if (!plainObject(baseSnapshot)
@@ -383,9 +457,31 @@ export function assertWebsiteProjectionAdoptionProtectedSnapshots({
     || expandedSnapshot.baseSnapshot?.rawSha256
       !== WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256
     || canonicalJson(expandedSnapshot.applicationCatalog)
-      !== canonicalJson(baseSnapshot)) {
+      !== canonicalJson(baseSnapshot)
+    || !plainObject(currentSnapshot)
+    || currentSnapshot.kind
+      !== "programmable-website-projection-hosted-catalog-snapshot-v3"
+    || currentSnapshot.schemaVersion !== 3
+    || !expectedTargetIdentity(currentSnapshot.target, expectedProjectRef)
+    || currentSnapshot.operatorSource?.repositoryCommit
+      !== WEBSITE_PROJECTION_ADOPTION_CURRENT_OPERATOR_COMMIT
+    || currentSnapshot.operatorSource?.repositoryTree
+      !== WEBSITE_PROJECTION_ADOPTION_CURRENT_OPERATOR_TREE
+    || currentSnapshot.parentSnapshots?.baseRawSha256
+      !== WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256
+    || currentSnapshot.parentSnapshots?.expandedRawSha256
+      !== WEBSITE_PROJECTION_ADOPTION_EXPANDED_SNAPSHOT_SHA256
+    || currentSnapshot.observation?.databaseName !== "postgres"
+    || Number(currentSnapshot.observation?.serverPort) !== 5432
+    || !/^\d{6}$/u.test(currentSnapshot.observation?.serverVersionNum ?? "")
+    || Number(currentSnapshot.observation.serverVersionNum) < 150000
+    || currentSnapshot.observation?.sessionUser !== "postgres"
+    || currentSnapshot.observation?.currentRole !== "postgres"
+    || typeof currentSnapshot.observation?.observedAt !== "string"
+    || !Number.isFinite(Date.parse(currentSnapshot.observation.observedAt))) {
     throw new Error("adopt-existing protected snapshot identity mismatch");
   }
+  assertCurrentSnapshotRoleAndMembershipInventory(currentSnapshot);
   const legacy = expandedSnapshot.legacySupabaseInventory;
   if (!plainObject(legacy)
     || legacy.fullCanonicalSha256
@@ -428,7 +524,10 @@ export function assertWebsiteProjectionAdoptionProtectedSnapshots({
   return Object.freeze({
     baseSnapshot,
     expandedSnapshot,
+    currentSnapshot,
     sourceSnapshotSha256: WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256,
+    expandedSnapshotSha256:
+      WEBSITE_PROJECTION_ADOPTION_EXPANDED_SNAPSHOT_SHA256,
     baseSnapshotSha256: WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
   });
 }
@@ -436,9 +535,10 @@ export function assertWebsiteProjectionAdoptionProtectedSnapshots({
 export async function readWebsiteProjectionAdoptionProtectedSnapshots({
   baseSnapshotPath,
   expandedSnapshotPath,
+  currentSnapshotPath,
   expectedProjectRef,
 }) {
-  const [baseSnapshot, expandedSnapshot] = await Promise.all([
+  const [baseSnapshot, expandedSnapshot, currentSnapshot] = await Promise.all([
     readProtectedSnapshotFile(
       baseSnapshotPath,
       WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
@@ -446,13 +546,19 @@ export async function readWebsiteProjectionAdoptionProtectedSnapshots({
     ),
     readProtectedSnapshotFile(
       expandedSnapshotPath,
-      WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256,
+      WEBSITE_PROJECTION_ADOPTION_EXPANDED_SNAPSHOT_SHA256,
       "adopt-existing expanded snapshot",
+    ),
+    readProtectedSnapshotFile(
+      currentSnapshotPath,
+      WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256,
+      "adopt-existing current snapshot",
     ),
   ]);
   return assertWebsiteProjectionAdoptionProtectedSnapshots({
     baseSnapshot,
     expandedSnapshot,
+    currentSnapshot,
     expectedProjectRef,
   });
 }
@@ -556,22 +662,8 @@ async function readRoleGraph(sql, appliedCount, {
 }
 
 async function readExtendedRoleInventory(sql) {
-  return {
-    roles: await queryRows(sql, `
-      /* website-projection:adoption-extended-roles */
-      SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb,
-             rolcanlogin, rolreplication, rolconnlimit,
-             rolvaliduntil::text AS rolvaliduntil, rolbypassrls, rolconfig
-        FROM pg_catalog.pg_roles
-       WHERE rolname IN (
-         'anon', 'authenticated', 'postgres',
-         'programmable_website_projection_runtime',
-         'service_role', 'supabase_admin'
-       )
-       ORDER BY rolname
-    `),
-    memberships: await queryRows(sql, `
-      /* website-projection:adoption-extended-memberships */
+  const memberships = await queryRows(sql, `
+    /* website-projection:adoption-extended-memberships */
       SELECT member.rolname AS member_name,
              granted.rolname AS role_name,
              grantor.rolname AS grantor_name,
@@ -582,7 +674,23 @@ async function readExtendedRoleInventory(sql) {
         JOIN pg_catalog.pg_roles granted ON granted.oid = membership.roleid
         JOIN pg_catalog.pg_roles grantor ON grantor.oid = membership.grantor
        ORDER BY member.rolname, granted.rolname, grantor.rolname
-    `),
+  `);
+  const endpointRoleNames = [...new Set(memberships.flatMap((membership) => [
+    membership.member_name,
+    membership.role_name,
+    membership.grantor_name,
+  ]))].sort();
+  return {
+    roles: await queryRows(sql, `
+      /* website-projection:adoption-extended-roles */
+      SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb,
+             rolcanlogin, rolreplication, rolconnlimit,
+             rolvaliduntil::text AS rolvaliduntil, rolbypassrls, rolconfig
+        FROM pg_catalog.pg_roles
+       WHERE rolname::text = ANY($1::text[])
+       ORDER BY rolname
+    `, [endpointRoleNames]),
+    memberships,
   };
 }
 
@@ -677,7 +785,8 @@ export function assertWebsiteProjectionAdoptionLiveInventory({
   protectedSnapshots,
 }) {
   const expanded = protectedSnapshots?.expandedSnapshot;
-  if (!plainObject(expanded)) {
+  const current = protectedSnapshots?.currentSnapshot;
+  if (!plainObject(expanded) || !plainObject(current)) {
     throw new Error("adopt-existing protected snapshot is unavailable");
   }
   assertExactApplicationStructure(
@@ -697,9 +806,9 @@ export function assertWebsiteProjectionAdoptionLiveInventory({
     "adopt-existing protected application role inventory mismatch");
   exactJson(sourceCatalog.memberships, expectedMemberships,
     "adopt-existing protected application membership inventory mismatch");
-  exactJson(extendedRoleInventory.roles, expanded.roleExtended,
+  exactJson(extendedRoleInventory.roles, current.roles,
     "adopt-existing extended role inventory mismatch");
-  exactJson(extendedRoleInventory.memberships, expanded.membershipExtended,
+  exactJson(extendedRoleInventory.memberships, current.memberships,
     "adopt-existing extended membership inventory mismatch");
   assertEmptyAdoptionData(sourceData);
   exactJson(
@@ -773,7 +882,8 @@ async function readPresenceAndEvidence(sql) {
     ? await queryRows(sql, `
         /* website-projection:adoption-evidence */
         SELECT evidence_kind, adopted_through_version,
-               source_snapshot_sha256, base_snapshot_sha256,
+               source_snapshot_sha256, expanded_snapshot_sha256,
+               base_snapshot_sha256,
                legacy_inventory_sha256, legacy_public_sha256,
                source_catalog_sha256,
                corrected_catalog_sha256, source_data_sha256,
@@ -1433,7 +1543,8 @@ async function insertAdoptionEvidence(transaction, {
   await queryRows(transaction, `
     INSERT INTO programmable_website_projection_migrations.adoption_evidence_v1 (
       evidence_kind, adopted_through_version, source_snapshot_sha256,
-      base_snapshot_sha256, legacy_inventory_sha256, legacy_public_sha256,
+      expanded_snapshot_sha256, base_snapshot_sha256,
+      legacy_inventory_sha256, legacy_public_sha256,
       source_catalog_sha256, corrected_catalog_sha256, source_data_sha256,
       operator_catalog_sha256, attestation_sha256, source_plan_sha256,
       source_order_sha256, source_repository_commit, source_repository_tree,
@@ -1445,11 +1556,12 @@ async function insertAdoptionEvidence(transaction, {
     ) VALUES (
       'adopted-existing-prefix-v1', '0003', $1, $2, $3, $4, $5, $6,
       $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
-      $19, $20,
+      $19, $20, $21,
       0, 0, 0, true, false
     )
   `, [
     sourceSnapshotSha256,
+    WEBSITE_PROJECTION_ADOPTION_EXPANDED_SNAPSHOT_SHA256,
     WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256,
     WEBSITE_PROJECTION_ADOPTION_LEGACY_INVENTORY_SHA256,
     WEBSITE_PROJECTION_ADOPTION_LEGACY_PUBLIC_SHA256,
@@ -1539,6 +1651,8 @@ export async function adoptExistingWebsiteProjectionDatabase({
   if (!plainObject(protectedSnapshots)
     || protectedSnapshots.sourceSnapshotSha256
       !== WEBSITE_PROJECTION_ADOPTION_SOURCE_SNAPSHOT_SHA256
+    || protectedSnapshots.expandedSnapshotSha256
+      !== WEBSITE_PROJECTION_ADOPTION_EXPANDED_SNAPSHOT_SHA256
     || protectedSnapshots.baseSnapshotSha256
       !== WEBSITE_PROJECTION_ADOPTION_BASE_SNAPSHOT_SHA256) {
     throw new Error("adopt-existing protected snapshots were not verified");


### PR DESCRIPTION
## Summary
- bind the one-time Website projection adoption to the protected v3 hosted snapshot
- compare all 50 memberships and all 36 endpoint/grantor role records without filters or allowlists
- retain the v1/v2 application, legacy, evidence, and migration bindings

## Exact evidence
- head: `26ca788c6cd4831047f0376a46674de070cb2d4c`
- tree: `8b39750245c4d990f37c55ced2ab5a0d03833783`
- parent production: `482aba91cd246d605ec0f98d0718dd5fff781d1f`
- v3 snapshot SHA-256: `0x917afa0f6bcd19f00f5d2ce5cd0d8221ef00ad6716460af11bff0906e4b9a0f9`
- plan: `0x4e599c538dba6bf77b8879318ca787b9f19b04f4017625e6e2fefa69cb635ec0`

## Validation
- operator tests: 23/23
- Website projection target: 26/26
- focused ESLint: clean
- independent exact audit: P0/P1/P2/P3 none

No hosted mutation, JIT access, public activation, or criteria change is included.