### PR TITLE
Bind finalized Custom Registry V2 while Generic reads stay dark

### DIFF
--- a/config/custom-registry-v2.deployment.prelaunch.json
+++ b/config/custom-registry-v2.deployment.prelaunch.json
@@ -1,28 +1,28 @@
 {
   "schemaVersion": "programmable.custom-registry-v2-deployment.v1",
-  "status": "prelaunch",
+  "status": "live",
   "generation": "2",
   "chainId": "1",
   "caip2": "eip155:1",
-  "publicReadEnabled": false,
-  "indexingEnabled": false,
+  "publicReadEnabled": true,
+  "indexingEnabled": true,
   "registry": {
-    "address": null,
-    "runtimeCodeKeccak256": null,
-    "deploymentTransactionHash": null,
-    "deploymentBlock": null,
-    "deploymentBlockHash": null
+    "address": "0x845506084a1AfB969fa4DeF444A2bdeEe794AAad",
+    "runtimeCodeKeccak256": "0x74d8196e2d40d030c66b147e835cbdf6dd0ab61c964fb3ef3890d86ed7daf074",
+    "deploymentTransactionHash": "0x49d3f19cf9f8afdc307892a95a880652ad7c6c4763458e5846eef78ef60b2ed5",
+    "deploymentBlock": "25749665",
+    "deploymentBlockHash": "0x84eeb4d264b75c2b89fb56ce5b941dfd8ef6de18181b6d2bff34fbb7c9692127"
   },
   "release": {
-    "sourceCommit": null,
-    "sourceTree": null,
-    "sourceArtifactSha256": null,
-    "abiArtifactSha256": null,
-    "eventSetSha256": null
+    "sourceCommit": "269ffbd4efc26f0f9c666b025a397b67c425b03f",
+    "sourceTree": "41a137ab93cc6ce9eff4f4d61d6d85581b8e5048",
+    "sourceArtifactSha256": "sha256:a456dd803d9322a886481cb31e066c60b02fd7d995ea32d6e5e20f034f16480a",
+    "abiArtifactSha256": "sha256:46d0aebd00c0eb7b9a152cb0e230f7777e367397e8c2f1b130c276c1309df4eb",
+    "eventSetSha256": "sha256:e6bf7f9affb1141bb2e4e1b347616e66ca8055aeb7e072ff600de85cfbeb1ef5"
   },
   "finality": {
-    "minimumConfirmations": null,
-    "policyBindingHash": null
+    "minimumConfirmations": "12",
+    "policyBindingHash": "0xa51733b58306cf89580bd3c4f39935583db3196c3ab62ecd73644fff2e13b892"
   },
   "profiles": {
     "NoMarket0": {

--- a/tests/custom-registry-v2-bindings.test.ts
+++ b/tests/custom-registry-v2-bindings.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -115,22 +116,40 @@ describe("Custom Registry V2 offchain bindings", () => {
     );
   });
 
-  it("keeps the deployment and index source fail closed", () => {
+  it("binds the finalized deployment and immutable release artifacts", () => {
     const deployment = JSON.parse(readFileSync(resolve(
       process.cwd(),
       "config/custom-registry-v2.deployment.prelaunch.json",
     ), "utf8"));
     expect(deployment).toMatchObject({
-      status: "prelaunch",
+      status: "live",
       generation: "2",
-      publicReadEnabled: false,
-      indexingEnabled: false,
+      publicReadEnabled: true,
+      indexingEnabled: true,
       registry: {
-        address: null,
-        runtimeCodeKeccak256: null,
-        deploymentTransactionHash: null,
-        deploymentBlock: null,
-        deploymentBlockHash: null,
+        address: "0x845506084a1AfB969fa4DeF444A2bdeEe794AAad",
+        runtimeCodeKeccak256:
+          "0x74d8196e2d40d030c66b147e835cbdf6dd0ab61c964fb3ef3890d86ed7daf074",
+        deploymentTransactionHash:
+          "0x49d3f19cf9f8afdc307892a95a880652ad7c6c4763458e5846eef78ef60b2ed5",
+        deploymentBlock: "25749665",
+        deploymentBlockHash:
+          "0x84eeb4d264b75c2b89fb56ce5b941dfd8ef6de18181b6d2bff34fbb7c9692127",
+      },
+      release: {
+        sourceCommit: "269ffbd4efc26f0f9c666b025a397b67c425b03f",
+        sourceTree: "41a137ab93cc6ce9eff4f4d61d6d85581b8e5048",
+        sourceArtifactSha256:
+          "sha256:a456dd803d9322a886481cb31e066c60b02fd7d995ea32d6e5e20f034f16480a",
+        abiArtifactSha256:
+          "sha256:46d0aebd00c0eb7b9a152cb0e230f7777e367397e8c2f1b130c276c1309df4eb",
+        eventSetSha256:
+          "sha256:e6bf7f9affb1141bb2e4e1b347616e66ca8055aeb7e072ff600de85cfbeb1ef5",
+      },
+      finality: {
+        minimumConfirmations: "12",
+        policyBindingHash:
+          "0xa51733b58306cf89580bd3c4f39935583db3196c3ab62ecd73644fff2e13b892",
       },
       profiles: {
         NoMarket0: { marketMode: 0, protocolFeeBps: 0 },
@@ -138,6 +157,23 @@ describe("Custom Registry V2 offchain bindings", () => {
       },
     });
 
+    for (const [path, expected] of [
+      [
+        "docs/security/abi/ProgrammableCustomRegistryV2.json",
+        "46d0aebd00c0eb7b9a152cb0e230f7777e367397e8c2f1b130c276c1309df4eb",
+      ],
+      [
+        "docs/security/CUSTOM_REGISTRY_EVENT_SET_V2.json",
+        "e6bf7f9affb1141bb2e4e1b347616e66ca8055aeb7e072ff600de85cfbeb1ef5",
+      ],
+    ] as const) {
+      expect(createHash("sha256").update(readFileSync(resolve(
+        process.cwd(), path,
+      ))).digest("hex")).toBe(expected);
+    }
+  });
+
+  it("keeps the separate indexer source fail closed", () => {
     const config = readFileSync(resolve(
       process.cwd(),
       "indexer/config.custom-registry-v2.prelaunch.yaml",

--- a/tests/generic-launch-read-v2.test.ts
+++ b/tests/generic-launch-read-v2.test.ts
@@ -25,6 +25,11 @@ import {
   type GenericLaunchReadStoreV2,
   type SignedGenericLaunchReadEnvelopeV2,
 } from "../lib/server/custom-launch/generic-launch-read-v2";
+import {
+  handleProductionGenericLaunchDetailV2,
+  handleProductionGenericLaunchFeedV2,
+  handleProductionGenericLaunchReadinessV2,
+} from "../lib/server/custom-launch/generic-launch-production-v2";
 import Ajv2020 from "ajv/dist/2020";
 import addFormats from "ajv-formats";
 import publicSchema from "../config/generic-launch-public.v2.schema.json";
@@ -319,6 +324,44 @@ describe("Generic launch V2 signed read adapter", () => {
       binding: null,
       store: store(activeBinding(), []),
     })).toThrow(/cannot bind a read store/u);
+  });
+
+  it("keeps production Generic V2 dark after Registry activation until every runtime binding exists", async () => {
+    const name = "PROGRAMMABLE_GENERIC_LAUNCH_READ_BINDING_V2_JSON";
+    const previous = process.env[name];
+    delete process.env[name];
+    try {
+      const feed = await handleProductionGenericLaunchFeedV2(request(
+        "/api/custom-launch/generic/v2/launches",
+      ));
+      const detail = await handleProductionGenericLaunchDetailV2(
+        request(`/api/custom-launch/generic/v2/launches/${sha("1")}`),
+        sha("1"),
+      );
+      const readiness = await handleProductionGenericLaunchReadinessV2(request(
+        "/api/custom-launch/generic/v2/readiness",
+      ));
+
+      expect(feed.status).toBe(503);
+      expect(detail.status).toBe(503);
+      expect(readiness.status).toBe(503);
+      await expect(feed.json()).resolves.toEqual({
+        schemaVersion: "programmable.custom-launch-error.v1",
+        code: "generic_launch_v2_not_active",
+      });
+      await expect(detail.json()).resolves.toEqual({
+        schemaVersion: "programmable.custom-launch-error.v1",
+        code: "generic_launch_v2_not_active",
+      });
+      await expect(readiness.json()).resolves.toMatchObject({
+        schemaVersion: "programmable.generic-launch-readiness.v2",
+        status: "unready",
+        code: "generic_launch_v2_not_active",
+      });
+    } finally {
+      if (previous === undefined) delete process.env[name];
+      else process.env[name] = previous;
+    }
   });
 
   it("serves identical signed V2 records from feed and detail", async () => {


### PR DESCRIPTION
## Outcome

Binds the finalized Custom Registry V2 deployment and its immutable release identities. Generic V2 feed, detail, and readiness remain fail-closed until every exact Approval, read-model, signer, and database runtime binding is configured.

## Scope

- replace the prelaunch Registry V2 deployment payload with the finalized live matrix
- assert the deployed ABI and event-set bytes
- prove production Generic V2 stays 503 when its activation binding is absent
- leave criteria, approval semantics, Classic, Stock, Explore, fee policy, and the separate indexer config unchanged

## Exact evidence

- base `aba60d5bfbd02df33f5a36911e3a954f5ad2e484` / tree `12e4c0e13ba5bd79c7affabb3f9af06064cb6008`
- head `97f5fcb6ee28a6050aedcfe3dbec9653371b5133` / tree `6bf69f0c31fc6f64c8f3f53898bb6390cda1d0ef`
- full `npm run verify:custom-v2:ci` green: Node 38/38, Custom Vitest 97/97, typecheck, build, neutrality and production-bundle checks
- independent audit GO: P0/P1/P2/P3 none

This PR does not configure Vercel, deliver an Approval artifact, activate Generic public reads, deploy, assign a domain, or promote production.