### PR TITLE
fix(registry): stage the live dark Custom V2 matrix

### DIFF
--- a/config/custom-registry-v2.deployment.prelaunch.json
+++ b/config/custom-registry-v2.deployment.prelaunch.json
@@ -7,7 +7,7 @@
   "publicReadEnabled": true,
   "indexingEnabled": true,
   "registry": {
-    "address": "0x845506084a1AfB969fa4DeF444A2bdeEe794AAad",
+    "address": "0x845506084a1afb969fa4def444a2bdeee794aaad",
     "runtimeCodeKeccak256": "0x74d8196e2d40d030c66b147e835cbdf6dd0ab61c964fb3ef3890d86ed7daf074",
     "deploymentTransactionHash": "0x49d3f19cf9f8afdc307892a95a880652ad7c6c4763458e5846eef78ef60b2ed5",
     "deploymentBlock": "25749665",

--- a/docs/operations/custom-v2-production-stage-gate.md
+++ b/docs/operations/custom-v2-production-stage-gate.md
@@ -87,13 +87,16 @@ The Custom V2 probe verifies:
 - unauthenticated Approval V3 GET and PUT rejection when its exact audience
   and target binding are configured
 - exact `503 target_unavailable` responses for both Approval V3 methods when
-  the fully closed prelaunch/disabled matrix has no Approval V3 configuration;
-  partial configuration and every active matrix remain invalid without both
-  bindings
+  Generic V2 is disabled, no authenticated evidence is supplied, and both
+  Approval V3 bindings are absent, whether Registry V2 is prelaunch or live;
+  partial configuration, authenticated evidence, and every Generic-ready
+  matrix remain invalid without both bindings
 - unauthenticated projector POST and reconciliation GET rejection
 - authenticated Approval V3 delivery, separate authenticated readback, and
   authenticated projection when digest-bound evidence is supplied
-- authenticated reconciliation with zero failed records in live mode
+- authenticated reconciliation with zero failed records in Generic-ready mode;
+  Registry-live candidates with Generic disabled require no reconciliation
+  credential and make no authenticated reconciliation request
 - Generic V2 readiness, feed and detail contracts, including the transitive
   Postgres posture, exact Registry binding, dual-RPC deployment check, and
   remote read-signer verification enforced by those handlers

--- a/scripts/custom-v2-stage-gate.mjs
+++ b/scripts/custom-v2-stage-gate.mjs
@@ -201,7 +201,7 @@ export async function verifyCustomV2StageCandidateV1(input) {
     add("generic-v2-projector-delivery", "authenticated Approval V3 artifact was projected");
   }
 
-  if (input.registryMode === "live") {
+  if (input.genericMode === "ready") {
     const reconciliation = await requestJson(
       "/api/ops/custom-launch/generic-v2-projector",
       { headers: { authorization: `Bearer ${secret(input.cronSecret, "reconciliation token")}` } },
@@ -425,9 +425,7 @@ function authenticatedIngress(input) {
 }
 
 function approvalV3Binding(input, authenticated) {
-  const closed = input.registryMode === "prelaunch"
-    && input.genericMode === "disabled"
-    && authenticated === null;
+  const closed = input.genericMode === "disabled" && authenticated === null;
   const audienceAbsent = input.approvalAudience === undefined
     || input.approvalAudience === "";
   const targetBindingAbsent = input.approvalTargetBindingHash === undefined

--- a/scripts/test/custom-v2-stage-gate.test.mjs
+++ b/scripts/test/custom-v2-stage-gate.test.mjs
@@ -95,6 +95,8 @@ function fetchMatrix({
   emptyFeed = false,
   approvalUnavailable = false,
   approvalUnexpectedlyAvailable = false,
+  approvalMethods = null,
+  projectorRequests = null,
 } = {}) {
   return async (input, init = {}) => {
     const url = new URL(input);
@@ -124,6 +126,7 @@ function fetchMatrix({
         });
     }
     if (url.pathname.startsWith("/v2/internal/projections/approval-descriptors/")) {
+      approvalMethods?.push(method);
       if (approvalUnavailable) {
         assert.equal(init.headers?.["x-programmable-audience"], undefined);
         assert.equal(init.headers?.["x-programmable-target-binding"], undefined);
@@ -171,6 +174,7 @@ function fetchMatrix({
         });
     }
     if (url.pathname === "/api/ops/custom-launch/generic-v2-projector") {
+      projectorRequests?.push([method, Boolean(init.headers?.authorization)]);
       if (!init.headers?.authorization) {
         return json(401, {
           schemaVersion: "programmable.generic-launch-projector-error.v2",
@@ -271,6 +275,35 @@ test("closed matrix requires unconfigured Approval V3 to fail closed", async () 
   assert.ok(!evidence.checks.some(({ id }) => id === "approval-v3-unauthorized"));
 });
 
+test("live Registry with disabled Generic proves unconfigured Approval V3 fail-closed", async () => {
+  const approvalMethods = [];
+  const projectorRequests = [];
+  const evidence = await verifyCustomV2StageCandidateV1(baseInput(
+    fetchMatrix({
+      live: true,
+      approvalUnavailable: true,
+      approvalMethods,
+      projectorRequests,
+    }),
+    {
+      registryMode: "live",
+      approvalAudience: undefined,
+      approvalTargetBindingHash: undefined,
+    },
+  ));
+  assert.deepEqual(evidence.matrix, {
+    registryMode: "live",
+    genericMode: "disabled",
+    authenticatedIngress: false,
+  });
+  assert.deepEqual(approvalMethods, ["GET", "PUT"]);
+  assert.deepEqual(projectorRequests, [["GET", false], ["POST", false]]);
+  assert.ok(evidence.checks.some(({ id }) => id === "registry-v2-readiness"));
+  assert.ok(evidence.checks.some(({ id }) => id === "approval-v3-unavailable"));
+  assert.ok(evidence.checks.some(({ id }) => id === "generic-v2-disabled"));
+  assert.ok(!evidence.checks.some(({ id }) => id === "generic-v2-reconciliation"));
+});
+
 test("explicit live and ready matrix proves Registry, DB, signer, feed and detail", async () => {
   const evidence = await verifyCustomV2StageCandidateV1(baseInput(
     fetchMatrix({ live: true, ready: true }),
@@ -356,9 +389,20 @@ test("candidate identity and activation matrix fail closed", async () => {
   await assert.rejects(
     verifyCustomV2StageCandidateV1(baseInput(fetchMatrix({ live: true }), {
       registryMode: "live",
+      genericMode: "ready",
       approvalAudience: undefined,
       approvalTargetBindingHash: undefined,
     })),
+    /Approval V3 audience is invalid/u,
+  );
+  await assert.rejects(
+    verifyCustomV2StageCandidateV1(baseInput(
+      fetchMatrix({ live: true, approvalUnavailable: true }),
+      {
+        registryMode: "live",
+        approvalAudience: undefined,
+      },
+    )),
     /Approval V3 audience is invalid/u,
   );
   await assert.rejects(

--- a/tests/custom-registry-v2-bindings.test.ts
+++ b/tests/custom-registry-v2-bindings.test.ts
@@ -127,7 +127,7 @@ describe("Custom Registry V2 offchain bindings", () => {
       publicReadEnabled: true,
       indexingEnabled: true,
       registry: {
-        address: "0x845506084a1AfB969fa4DeF444A2bdeEe794AAad",
+        address: "0x845506084a1afb969fa4def444a2bdeee794aaad",
         runtimeCodeKeccak256:
           "0x74d8196e2d40d030c66b147e835cbdf6dd0ab61c964fb3ef3890d86ed7daf074",
         deploymentTransactionHash:

--- a/tests/custom-registry-v2-public-release.test.ts
+++ b/tests/custom-registry-v2-public-release.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   createCustomRegistryManifestHandlerV2,
   createCustomRegistryReadinessHandlerV2,
+  handleProductionCustomRegistryManifestV2,
   resolveCustomRegistryPublicManifestV2,
 } from "../lib/server/custom-launch/registry-manifest-v2";
 
@@ -157,6 +158,23 @@ describe("Custom Registry V2 public release binding", () => {
       release: liveSource().release,
       finality: liveSource().finality,
     });
+  });
+
+  it("serves the imported finalized deployment as the canonical live manifest", async () => {
+    const manifest = resolveCustomRegistryPublicManifestV2();
+    expect(manifest).toMatchObject({
+      status: "live",
+      publicReadEnabled: true,
+      indexingEnabled: true,
+      registry: {
+        address: "0x845506084a1afb969fa4def444a2bdeee794aaad",
+      },
+    });
+    const response = handleProductionCustomRegistryManifestV2(
+      request(CUSTOM_REGISTRY_PUBLIC_MANIFEST_PATH_V2),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(manifest);
   });
 
   it("serves an explicit prelaunch manifest and rejects malformed requests", async () => {


### PR DESCRIPTION
## Outcome

Makes the finalized Registry V2 payload parseable by its own strict manifest contract and stages the intended live Registry plus disabled Generic matrix without weakening active Generic or authenticated Approval gates.

## Changes

- canonicalize the already deployed Registry address to the same lowercase 20-byte value required by the parser and Stage
- allow fully absent Approval bindings only while Generic remains disabled and no authenticated evidence is supplied; GET and PUT must still return exact target_unavailable responses
- run Generic reconciliation only when Generic public reads are expected ready
- add imported production manifest and live-dark matrix regressions

## Validation

- focused Stage gate tests 13/13
- focused Registry tests 27/27
- complete Custom V2 Node tests 39/39
- complete Custom V2 Vitest 98/98
- typecheck, neutrality, lint and diff check passed
- local Next build was not executed because the isolated worktree used an out-of-root node_modules link; remote CI provides the clean build proof
