### PR TITLE
Fix transient dRPC head reads and liquidity degradation

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -788,7 +788,9 @@ jobs:
               marketRead?.provider === "bitquery" &&
               marketRead.status === "unavailable" &&
               marketRead.category === "transport" &&
-              ["market-core", "market-price"].includes(marketRead.phase) &&
+              ["market-core", "market-liquidity", "market-price"].includes(
+                marketRead.phase,
+              ) &&
               valuation?.status === "unavailable" &&
               valuation.metric === "fdv" &&
               valuation.available === 0 &&

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -290,7 +290,9 @@ function isFailSoftMarketTransportFailure(
     !signal.aborted &&
     error instanceof BitqueryMarketDataError &&
     error.category === "transport" &&
-    (error.phase === "market-core" || error.phase === "market-price");
+    (error.phase === "market-core" ||
+      error.phase === "market-liquidity" ||
+      error.phase === "market-price");
 }
 
 export async function GET(request: NextRequest) {

--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -232,9 +232,10 @@ export async function readBitqueryTokenMarketDataStrictV1(
  *
  * Token price, supply and provider-computed FDV come from `Trading.Tokens`.
  * Pool liquidity comes from the realtime `EVM(network: eth)` dataset. The
- * token read is strict, while absent or malformed liquidity fails closed for
- * that valuation without taking down launch discovery. This path never reads
- * DEX trades, statistics, caches or another provider.
+ * token read is strict. A valid liquidity response without an exact pool row
+ * fails closed for that valuation, while provider and malformed-response
+ * failures reject with their exact taxonomy. This path never reads DEX trades,
+ * statistics, caches or another provider.
  */
 export async function readBitqueryTokenFdvRankingStrictV1(
   identities: readonly MarketDataIdentityV1[],
@@ -294,20 +295,27 @@ export async function readBitqueryTokenFdvRankingStrictV1(
     }
   }
 
-  let liquidityRows: ReadonlyMap<string, unknown> = new Map();
-  if (liquidityResult.status === "fulfilled" && !liquidityResult.value.partial) {
-    const evm = record(liquidityResult.value.data.EVM);
-    if (evm !== null) {
-      try {
-        liquidityRows = indexUniqueRows(
-          array(evm.latestLiquidity),
-          liquidityRowPoolId,
-        );
-      } catch {
-        // Liquidity gates FDV publication, but never launch discovery.
-        liquidityRows = new Map();
-      }
-    }
+  if (liquidityResult.status === "rejected") {
+    throw marketDataErrorAtPhase(
+      liquidityResult.reason,
+      "market-liquidity",
+    );
+  }
+  if (liquidityResult.value.partial) {
+    throw new BitqueryMarketDataError("response", "market-liquidity");
+  }
+  const evm = record(liquidityResult.value.data.EVM);
+  if (evm === null) {
+    throw new BitqueryMarketDataError("response", "market-liquidity");
+  }
+  let liquidityRows: ReadonlyMap<string, unknown>;
+  try {
+    liquidityRows = indexUniqueRows(
+      array(evm.latestLiquidity),
+      liquidityRowPoolId,
+    );
+  } catch (error) {
+    throw marketDataErrorAtPhase(error, "market-liquidity");
   }
 
   const pools = new Map<string, MarketPoolDataV1>();

--- a/lib/market-data/primary-rpc-launches.server.ts
+++ b/lib/market-data/primary-rpc-launches.server.ts
@@ -43,6 +43,7 @@ const REQUEST_TIMEOUT_MS = 4_000;
 const LOG_WINDOW_RANGE = 4_096n;
 const MAXIMUM_CONCURRENT_LOG_WINDOWS = 6;
 const MAXIMUM_LOG_WINDOW_ATTEMPTS = 2;
+const MAXIMUM_HEAD_READ_ATTEMPTS = 2;
 const MAXIMUM_LOGS = 10_000;
 const MAXIMUM_LAUNCHES = 5_000;
 const MAXIMUM_CONCURRENT_RPC_READS = 100;
@@ -340,7 +341,7 @@ export async function readPrimaryRpcExploreEntriesV1(
     const now = options.now ?? new Date();
 
     phase = "head";
-    const headNumber = await providerCall(
+    const headNumber = await readHeadWithRetry(
       () => client.getBlockNumber(),
       signal,
     );
@@ -348,7 +349,7 @@ export async function readPrimaryRpcExploreEntriesV1(
       throw new PrimaryRpcLaunchCatalogError("response");
     }
     const head = parseBlock(
-      await providerCall(
+      await readHeadWithRetry(
         () => client.getBlock({ blockNumber: headNumber }),
         signal,
       ),
@@ -1099,6 +1100,28 @@ async function providerCall<T>(
     if (error instanceof PrimaryRpcLaunchCatalogError) throw error;
     throw new PrimaryRpcLaunchCatalogError("transport");
   }
+}
+
+async function readHeadWithRetry<T>(
+  operation: () => Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  for (let attempt = 1; attempt <= MAXIMUM_HEAD_READ_ATTEMPTS; attempt += 1) {
+    assertNotAborted(signal);
+    try {
+      return await providerCall(operation, signal);
+    } catch (error) {
+      if (
+        !(error instanceof PrimaryRpcLaunchCatalogError) ||
+        error.category !== "transport" ||
+        attempt === MAXIMUM_HEAD_READ_ATTEMPTS
+      ) {
+        throw error;
+      }
+      assertNotAborted(signal);
+    }
+  }
+  throw new PrimaryRpcLaunchCatalogError("runtime");
 }
 
 async function abortableCall<T>(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2568,7 +2568,9 @@ export function evaluateReadModelOperationsSourceContracts(
       'marketRead?.provider === "bitquery"',
       'marketRead.status === "unavailable"',
       'marketRead.category === "transport"',
-      '["market-core", "market-price"].includes(marketRead.phase)',
+      '["market-core", "market-liquidity", "market-price"].includes(\n' +
+        "                marketRead.phase,\n" +
+        "              )",
       'valuation?.status === "unavailable"',
       'valuation.metric === "fdv"',
       "valuation.available === 0",
@@ -2750,7 +2752,9 @@ export function evaluateReadModelOperationsSourceContracts(
     includesEverySourceFragment(publicExplore, [
       "error instanceof BitqueryMarketDataError",
       'error.category === "transport"',
-      '(error.phase === "market-core" || error.phase === "market-price")',
+      '(error.phase === "market-core" ||\n' +
+        '      error.phase === "market-liquidity" ||\n' +
+        '      error.phase === "market-price")',
       "identityEntryCount > 0",
       "marketIdentityCount > 0",
       "!signal.aborted",

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -6,6 +6,8 @@ import { runInNewContext } from "node:vm";
 const deploy = readFileSync(".github/workflows/deploy-production.yml", "utf8");
 const verify = readFileSync(".github/workflows/verify.yml", "utf8");
 const proof = readFileSync("scripts/production-verify-proof.mjs", "utf8");
+const exactTransportUnavailableMarketPhases =
+  /\["market-core", "market-liquidity", "market-price"\]\.includes\(\s*marketRead\.phase,\s*\)/u;
 
 function stepBlock(source, name) {
   const start = source.indexOf(`      - name: ${name}`);
@@ -145,8 +147,9 @@ test("Custom-only changes do not invoke the public data smoke", () => {
   );
   assert.match(
     smoke,
-    /marketRead\?\.provider === "bitquery"[\s\S]*marketRead\.status === "unavailable"[\s\S]*marketRead\.category === "transport"[\s\S]*\["market-core", "market-price"\]\.includes\(marketRead\.phase\)/u,
+    /marketRead\?\.provider === "bitquery"[\s\S]*marketRead\.status === "unavailable"[\s\S]*marketRead\.category === "transport"/u,
   );
+  assert.match(smoke, exactTransportUnavailableMarketPhases);
   assert.match(
     smoke,
     /valuation\?\.status === "unavailable"[\s\S]*valuation\.available === 0[\s\S]*valuation\.unavailable === tokens\.length[\s\S]*tokens\.every\(exactUnavailableValuation\)/u,
@@ -214,6 +217,13 @@ test("Custom-only changes do not invoke the public data smoke", () => {
   ]) {
     assert.equal(deploy.includes(`      - name: ${retired}`), false);
   }
+});
+
+test("the staged transport contract rejects removal of exact-pool liquidity", () => {
+  const smoke = stepBlock(deploy, "Smoke staged Bitquery public APIs");
+  const mutated = smoke.replace('"market-liquidity", ', "");
+  assert.notEqual(mutated, smoke);
+  assert.doesNotMatch(mutated, exactTransportUnavailableMarketPhases);
 });
 
 test("degraded Highest must match the exact Newest launch identity order", () => {

--- a/tests/bitquery-fdv-ranking.test.ts
+++ b/tests/bitquery-fdv-ranking.test.ts
@@ -4,6 +4,7 @@ vi.mock("server-only", () => ({}));
 
 import {
   BITQUERY_HTTP_ENDPOINT,
+  BitqueryMarketDataError,
   readBitqueryTokenFdvRankingStrictV1,
 } from "../lib/market-data/bitquery.server";
 import {
@@ -138,7 +139,7 @@ describe("strict lightweight Bitquery FDV ranking", () => {
     expect(market?.pools[0]).not.toHaveProperty("latestTrade");
   });
 
-  it("degrades a liquidity transport failure without failing the token read", async () => {
+  it("propagates a genuine liquidity transport failure with its exact phase", async () => {
     const fetchImpl = vi.fn(async (
       _url: string | URL | Request,
       init?: RequestInit,
@@ -147,7 +148,28 @@ describe("strict lightweight Bitquery FDV ranking", () => {
       if (request.query.includes("ProgrammableExploreFdvRanking")) {
         return json({ data: { Trading: { rankingTokens: [rankingToken()] } } });
       }
-      throw new Error("liquidity unavailable");
+      throw new TypeError("fetch failed");
+    }) as typeof fetch;
+
+    await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl,
+      token: TOKEN,
+      now: new Date("2026-08-11T14:02:00.000Z"),
+    })).rejects.toMatchObject({
+      category: "transport",
+      phase: "market-liquidity",
+    });
+  });
+
+  it("keeps a successfully empty liquidity result unavailable", async () => {
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      return request.query.includes("ProgrammableExploreFdvRanking")
+        ? json({ data: { Trading: { rankingTokens: [rankingToken()] } } })
+        : json({ data: { EVM: { latestLiquidity: [] } } });
     }) as typeof fetch;
 
     const values = await readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
@@ -162,6 +184,92 @@ describe("strict lightweight Bitquery FDV ranking", () => {
       quality: "partial",
       valuation: { status: "unavailable", reason: "source-unavailable" },
     });
+  });
+
+  it.each([
+    [401, "configuration"],
+    [400, "response"],
+  ] as const)(
+    "keeps a liquidity HTTP %s failure fail-closed as %s",
+    async (status, category) => {
+      const fetchImpl = vi.fn(async (
+        _url: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const request = JSON.parse(String(init?.body));
+        return request.query.includes("ProgrammableExploreFdvRanking")
+          ? json({ data: { Trading: { rankingTokens: [rankingToken()] } } })
+          : new Response("provider error", { status });
+      }) as typeof fetch;
+
+      await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+        fetchImpl,
+        token: TOKEN,
+      })).rejects.toMatchObject({ category, phase: "market-liquidity" });
+    },
+  );
+
+  it("keeps a partial liquidity response fail-closed", async () => {
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      return request.query.includes("ProgrammableExploreFdvRanking")
+        ? json({ data: { Trading: { rankingTokens: [rankingToken()] } } })
+        : json({
+            data: { EVM: { latestLiquidity: [] } },
+            errors: [{ message: "partial liquidity" }],
+          });
+    }) as typeof fetch;
+
+    await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl,
+      token: TOKEN,
+    })).rejects.toMatchObject({
+      category: "response",
+      phase: "market-liquidity",
+    });
+  });
+
+  it("keeps malformed liquidity rows fail-closed", async () => {
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      return request.query.includes("ProgrammableExploreFdvRanking")
+        ? json({ data: { Trading: { rankingTokens: [rankingToken()] } } })
+        : json({ data: { EVM: { latestLiquidity: [{}] } } });
+    }) as typeof fetch;
+
+    await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl,
+      token: TOKEN,
+    })).rejects.toMatchObject({
+      category: "integrity",
+      phase: "market-liquidity",
+    });
+  });
+
+  it("does not relabel an unknown liquidity failure as transport", async () => {
+    const programmingError = new Error("unexpected liquidity failure");
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      if (request.query.includes("ProgrammableExploreFdvRanking")) {
+        return json({ data: { Trading: { rankingTokens: [rankingToken()] } } });
+      }
+      throw programmingError;
+    }) as typeof fetch;
+
+    await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl,
+      token: TOKEN,
+    })).rejects.toBe(programmingError);
+    expect(programmingError).not.toBeInstanceOf(BitqueryMarketDataError);
   });
 
   it("keeps a low-liquidity pool but withholds its FDV", async () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -830,6 +830,7 @@ describe("read-model operations source contract", () => {
   it("accepts the exact Explore transport-unavailable provider taxonomy", () => {
     const path = "app/api/explore/route.ts";
     const route = readFileSync(resolve(ROOT, path), "utf8");
+    expect(route).toContain('error.phase === "market-liquidity"');
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: { [path]: route },
     });
@@ -846,8 +847,13 @@ describe("read-model operations source contract", () => {
     ],
     [
       "an unbounded failure phase",
-      '(error.phase === "market-core" || error.phase === "market-price")',
+      '(error.phase === "market-core" ||\n      error.phase === "market-liquidity" ||\n      error.phase === "market-price")',
       "Boolean(error.phase)",
+    ],
+    [
+      "a bounded failure phase set without exact-pool liquidity",
+      '(error.phase === "market-core" ||\n      error.phase === "market-liquidity" ||\n      error.phase === "market-price")',
+      '(error.phase === "market-core" || error.phase === "market-price")',
     ],
     [
       "a combined degraded read source",
@@ -1141,8 +1147,13 @@ describe("read-model operations source contract", () => {
     ],
     [
       "an unbounded degraded failure phase",
-      '["market-core", "market-price"].includes(marketRead.phase)',
+      '["market-core", "market-liquidity", "market-price"].includes(\n                marketRead.phase,\n              )',
       "Boolean(marketRead.phase)",
+    ],
+    [
+      "a degraded phase set without exact-pool liquidity",
+      '["market-core", "market-liquidity", "market-price"].includes(\n                marketRead.phase,\n              )',
+      '["market-core", "market-price"].includes(marketRead.phase)',
     ],
     [
       "mixed available degraded valuations",

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -405,6 +405,40 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
     },
   );
 
+  it("serves verified launches when exact-pool liquidity transport fails", async () => {
+    mocks.readBitqueryTokenFdvRankingStrictV1.mockRejectedValueOnce(
+      new mocks.BitqueryMarketDataError("transport", "market-liquidity"),
+    );
+
+    const response = await GET(request("sort=market-cap&page=1&limit=9"));
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "ready",
+      marketRead: {
+        provider: "bitquery",
+        status: "unavailable",
+        category: "transport",
+        phase: "market-liquidity",
+      },
+      ranking: {
+        status: "unavailable",
+        requested: "fdv",
+        applied: "launch-order",
+      },
+      dataQuality: {
+        status: "partial",
+        launchIdentity: { status: "current" },
+        valuation: { status: "unavailable", available: 0, unavailable: 9 },
+      },
+    });
+    expect(response.headers.get("x-programmable-market-read-status")).toBe(
+      "transport-unavailable",
+    );
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
   it("serves the Newest identity page when the Bitquery price transport fails", async () => {
     mocks.readBitqueryTokenMarketDataStrictV1.mockRejectedValueOnce(
       new mocks.BitqueryMarketDataError("transport", "market-price"),
@@ -445,7 +479,6 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
     ["configuration", "configuration"],
     ["response", "market-core"],
     ["integrity", "market-core"],
-    ["transport", "market-liquidity"],
     ["transport", "market-stats"],
   ] as const)(
     "keeps Bitquery %s/%s failures fail-closed",

--- a/tests/primary-rpc-launch-catalog.test.ts
+++ b/tests/primary-rpc-launch-catalog.test.ts
@@ -104,6 +104,135 @@ const RELEASES: readonly FixtureRelease[] = [
 ];
 
 describe("single-primary dRPC launch catalog", () => {
+  it("retries the primary dRPC head number once after a transport failure", async () => {
+    let attempts = 0;
+    const result = await readPrimaryRpcExploreEntriesV1({
+      client: mockClient({
+        getBlockNumber: async () => {
+          attempts += 1;
+          if (attempts === 1) throw new Error("temporary dRPC failure");
+          return HEAD;
+        },
+      }),
+      now: new Date("2026-08-14T12:00:00.000Z"),
+    });
+
+    expect(attempts).toBe(2);
+    expect(result).toMatchObject({
+      source: "drpc",
+      asOfBlock: HEAD.toString(),
+      asOfBlockHash: HEAD_HASH,
+    });
+  });
+
+  it("retries the exact primary dRPC head block once after transport failure", async () => {
+    const defaults = mockClient();
+    let attempts = 0;
+    const requestedBlocks: bigint[] = [];
+    const result = await readPrimaryRpcExploreEntriesV1({
+      client: mockClient({
+        getBlock: async (input) => {
+          attempts += 1;
+          requestedBlocks.push(input.blockNumber);
+          if (attempts === 1) throw new Error("temporary dRPC failure");
+          return defaults.getBlock(input);
+        },
+      }),
+      now: new Date("2026-08-14T12:00:00.000Z"),
+    });
+
+    expect(attempts).toBe(2);
+    expect(requestedBlocks).toEqual([HEAD, HEAD]);
+    expect(result).toMatchObject({
+      source: "drpc",
+      asOfBlock: HEAD.toString(),
+      asOfBlockHash: HEAD_HASH,
+    });
+  });
+
+  it("bounds an exhausted primary dRPC head read to two attempts", async () => {
+    let attempts = 0;
+    const error = await readPrimaryRpcExploreEntriesV1({
+      client: mockClient({
+        getBlockNumber: async () => {
+          attempts += 1;
+          throw new Error("temporary dRPC failure");
+        },
+      }),
+    }).catch((value: unknown) => value);
+
+    expect(attempts).toBe(2);
+    expect(safePrimaryRpcLaunchCatalogError(error)).toEqual({
+      name: "PrimaryRpcLaunchCatalogError",
+      category: "transport",
+      phase: "head",
+      status: 503,
+    });
+  });
+
+  it.each(["configuration", "response", "integrity"] as const)(
+    "does not retry a typed %s head failure",
+    async (category) => {
+      let attempts = 0;
+      const error = await readPrimaryRpcExploreEntriesV1({
+        client: mockClient({
+          getBlockNumber: async () => {
+            attempts += 1;
+            throw new PrimaryRpcLaunchCatalogError(category);
+          },
+        }),
+      }).catch((value: unknown) => value);
+
+      expect(attempts).toBe(1);
+      expect(safePrimaryRpcLaunchCatalogError(error)).toMatchObject({
+        category,
+        phase: "head",
+        status: 503,
+      });
+    },
+  );
+
+  it("does not retry an invalid successful head response", async () => {
+    let attempts = 0;
+    const error = await readPrimaryRpcExploreEntriesV1({
+      client: mockClient({
+        getBlockNumber: async () => {
+          attempts += 1;
+          return 0n;
+        },
+      }),
+    }).catch((value: unknown) => value);
+
+    expect(attempts).toBe(1);
+    expect(safePrimaryRpcLaunchCatalogError(error)).toMatchObject({
+      category: "response",
+      phase: "head",
+      status: 503,
+    });
+  });
+
+  it("does not retry the dRPC head after outer cancellation", async () => {
+    const controller = new AbortController();
+    let attempts = 0;
+    const error = await readPrimaryRpcExploreEntriesV1({
+      signal: controller.signal,
+      client: mockClient({
+        getBlockNumber: async () => {
+          attempts += 1;
+          controller.abort();
+          throw new Error("temporary dRPC failure");
+        },
+      }),
+    }).catch((value: unknown) => value);
+
+    expect(attempts).toBe(1);
+    expect(safePrimaryRpcLaunchCatalogError(error)).toMatchObject({
+      category: "transport",
+      phase: "head",
+      status: 503,
+    });
+  });
+
   it("reads all five canonical releases from bounded sparse log ranges", async () => {
     const queries: PrimaryRpcLogQuery[] = [];
     const logs = RELEASES.flatMap(releaseLogs);
@@ -337,9 +466,13 @@ describe("single-primary dRPC launch catalog", () => {
   it("enforces one hard end-to-end budget even when a client ignores aborts", async () => {
     vi.useFakeTimers();
     try {
+      let attempts = 0;
       const pending = readPrimaryRpcExploreEntriesV1({
         client: mockClient({
-          getBlockNumber: () => new Promise<bigint>(() => {}),
+          getBlockNumber: () => {
+            attempts += 1;
+            return new Promise<bigint>(() => {});
+          },
         }),
       }).catch((value: unknown) => value);
 
@@ -355,6 +488,7 @@ describe("single-primary dRPC launch catalog", () => {
         phase: "head",
         status: 503,
       });
+      expect(attempts).toBe(1);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## Outcome
- retry each primary dRPC head operation at most once on transport failures within the existing 18s budget
- propagate genuine Bitquery liquidity transport failures into the existing honest transport-unavailable Explore response
- bind Stage and operations contracts to market-core, market-liquidity, and market-price without adding a provider, fallback, or cache

## Validation
- 304 focused Vitest tests
- workflow contract 7/7
- operations source gate
- TypeScript typecheck
- scoped ESLint, actionlint, candidate-neutrality, diff-check, and gitleaks
- independent exact-head review: no P0/P1