### PR TITLE
Bind the Generic V2 read model release contract

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -310,6 +310,10 @@ jobs:
         if: needs.scope.outputs.custom_v2 == 'true'
         run: node --test scripts/website-projection-db-operator.test.mjs
 
+      - name: Verify exact Generic V2 read-model contract derivation
+        if: needs.scope.outputs.custom_v2 == 'true'
+        run: node --test scripts/test/custom-v2-read-model-contract-v2.test.mjs
+
       - name: Verify exact Custom V2 surface
         if: needs.scope.outputs.custom_v2 == 'true'
         run: npm run verify:custom-v2:ci

--- a/scripts/ci/classify-verify-paths.mjs
+++ b/scripts/ci/classify-verify-paths.mjs
@@ -20,7 +20,9 @@ const CUSTOM_V2_EXACT_PATHS = new Set([
   "lib/data-pipeline/custom-registry-v2-event-manifest.ts",
   "lib/server/custom-launch/registry-manifest-v2.ts",
   "lib/server/projection-target/approval-v3-target.ts",
+  "scripts/custom-v2-read-model-contract-v2.mjs",
   "scripts/custom-v2-stage-gate.mjs",
+  "scripts/test/custom-v2-read-model-contract-v2.test.mjs",
   "scripts/test/custom-v2-stage-gate.test.mjs",
   "scripts/test/custom-v2-production-workflow-contract.test.mjs",
 ]);

--- a/scripts/ci/classify-verify-paths.test.mjs
+++ b/scripts/ci/classify-verify-paths.test.mjs
@@ -31,6 +31,8 @@ test("routes the versioned Custom V2 surface without legacy market lanes", () =>
     "components/generic-launch-directory-v2.tsx",
     "lib/server/custom-launch/generic-launch-production-v2.ts",
     "lib/server/custom-launch/registry-manifest-v2.ts",
+    "scripts/custom-v2-read-model-contract-v2.mjs",
+    "scripts/test/custom-v2-read-model-contract-v2.test.mjs",
     "tests/generic-launch-read-v2.test.ts",
   ]) {
     assert.deepEqual(classifyVerifyPaths([path]), {

--- a/scripts/custom-v2-read-model-contract-v2.mjs
+++ b/scripts/custom-v2-read-model-contract-v2.mjs
@@ -5,13 +5,77 @@ import { resolve, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 
+import {
+  validateWebsiteProjectionPlan,
+  WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF,
+  WEBSITE_PROJECTION_MIGRATION_FILES,
+  WEBSITE_PROJECTION_MIGRATION_ROOT,
+} from "./website-projection-db-operator-core.mjs";
+
 const SHA256 = /^sha256:[0-9a-f]{64}$/u;
+const HEX_SHA256 = /^0x[0-9a-f]{64}$/u;
 const GIT_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
 const POSITIVE_DECIMAL = /^[1-9][0-9]{0,77}$/u;
 const ADDRESS = /^0x[0-9a-fA-F]{40}$/u;
 const HASH32 = /^0x[0-9a-f]{64}$/u;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
-const ARTIFACT_PATH = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9_./-]+$/u;
+const ARTIFACT_PATH = /^(?!\/)(?!.*\/\/)[A-Za-z0-9_.\[\]/-]+$/u;
+
+const IMPLEMENTATION_ARTIFACTS = Object.freeze([
+  "app/api/ops/custom-launch/generic-v2-projector/route.ts",
+  "app/v2/internal/projections/approval-descriptors/[projectionKey]/route.ts",
+  "lib/server/custom-launch/generic-launch-contract-v2.ts",
+  "lib/server/custom-launch/generic-launch-production-v2.ts",
+  "lib/server/custom-launch/generic-launch-projector-v2.ts",
+  "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",
+  "lib/server/projection-target/approval-v3-target.ts",
+]);
+const PERSISTENCE_ARTIFACTS = Object.freeze([
+  "lib/server/custom-launch/generic-launch-postgres-v2.ts",
+  ...WEBSITE_PROJECTION_MIGRATION_FILES.map(
+    (file) => `${WEBSITE_PROJECTION_MIGRATION_ROOT}/${file}`,
+  ),
+]);
+const QUERY_ARTIFACTS = Object.freeze([
+  "app/api/custom-launch/generic/v2/launches/[recordHash]/route.ts",
+  "app/api/custom-launch/generic/v2/launches/route.ts",
+  "app/api/custom-launch/generic/v2/readiness/route.ts",
+  "config/generic-launch-public.v2.schema.json",
+  "lib/server/custom-launch/generic-launch-read-signer-v2.ts",
+  "lib/server/custom-launch/generic-launch-read-v2.ts",
+]);
+const REGISTRY_PROJECTION_ARTIFACTS = Object.freeze([
+  "config/custom-registry-v2.deployment.prelaunch.json",
+  "lib/server/custom-launch/generic-launch-contract-v2.ts",
+  "lib/server/custom-launch/generic-launch-projector-v2.ts",
+  "lib/server/custom-launch/generic-launch-registry-reader-v2.ts",
+]);
+const WEBSITE_REPOSITORY_IDENTITY = Object.freeze({
+  repositoryId: "1314365508",
+  repositoryFullName: "0xprogrammable/programmable",
+});
+const APPROVAL_REPOSITORY_IDENTITY = Object.freeze({
+  repositoryId: "1318883798",
+  repositoryFullName: "0xprogrammable/programmable-open-hook-v2-internal",
+});
+const HOSTED_PERSISTENCE_EVIDENCE_IDENTITY = Object.freeze({
+  planArtifactSha256:
+    "sha256:4bea658e36b40af2d4d6ee7e71039d302704e6ddc2f4ca8f4190a17c2ad50d57",
+  adoptionArtifactSha256:
+    "sha256:a38c37cf5b1dfe8526387c31d378c87bfd5f88bd4408ae91e56a549900622271",
+  applyArtifactSha256:
+    "sha256:954430a402a9b8de8352f915a97ae67de88cff513af9f0ee1d8a64238181930a",
+  verifyArtifactSha256:
+    "sha256:cb72cceff9376584c382b948be2229d74e591873dfe63852c59adcc3c1412f10",
+  planRepositoryCommit: "c235fbd55259f76d8356d6f07073c48b00eb294d",
+  planRepositoryTree: "57d09edb4793d6fe9f8a3bfad8e311accbb4caec",
+  planSha256:
+    "0xbcdb49c686413cd5eab15514e0182eb929f5771e58059ce0fe59f928c44e6f3f",
+  orderSha256:
+    "0xce50954bfa6ff3b66b849bb5b53e8f1adf93abbe12cf865c19375100f2571cc2",
+  finalCatalogSha256:
+    "0x92a17ae38c7562cea0609bc8a8263ff190486a389b886072fb9ef30f0cffc0c4",
+});
 
 const INPUT_KEYS = Object.freeze([
   "approvalArtifactSchema",
@@ -25,7 +89,11 @@ const INPUT_KEYS = Object.freeze([
 ]);
 
 export function canonicalJson(value) {
-  if (value === null || typeof value === "boolean" || typeof value === "string") {
+  if (value === null || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") {
+    assertWellFormedUnicode(value);
     return JSON.stringify(value);
   }
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -35,6 +103,7 @@ export function canonicalJson(value) {
     return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
   }
   if (typeof value === "object") {
+    Object.keys(value).forEach(assertWellFormedUnicode);
     return `{${Object.keys(value).sort().map(
       (key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`,
     ).join(",")}}`;
@@ -60,6 +129,9 @@ export function canonicalSha256(domain, value) {
 export async function deriveGenericLaunchReadModelContractV2(input, options) {
   const repoRoot = resolve(options?.repoRoot ?? process.cwd());
   const read = options?.readFile ?? readFile;
+  const gitBlobIdentity = options?.gitBlobIdentity ?? currentGitBlobIdentity;
+  const hostedEvidenceIdentity = options?.hostedEvidenceIdentity
+    ?? HOSTED_PERSISTENCE_EVIDENCE_IDENTITY;
   const value = exactObject(input, INPUT_KEYS, "derivation input");
   if (value.schemaVersion
     !== "programmable.generic-launch-read-model-contract-derivation-input.v1") {
@@ -67,6 +139,11 @@ export async function deriveGenericLaunchReadModelContractV2(input, options) {
   }
 
   const websiteSource = sourceIdentity(value.websiteSource, "Website source");
+  if (websiteSource.repositoryId !== WEBSITE_REPOSITORY_IDENTITY.repositoryId
+    || websiteSource.repositoryFullName
+      !== WEBSITE_REPOSITORY_IDENTITY.repositoryFullName) {
+    throw new TypeError("Website source is not the canonical repository");
+  }
   if (options?.gitIdentity) {
     const actual = options.gitIdentity(repoRoot);
     if (actual.commit !== websiteSource.commit || actual.tree !== websiteSource.tree) {
@@ -79,6 +156,7 @@ export async function deriveGenericLaunchReadModelContractV2(input, options) {
     websiteSource,
     repoRoot,
     read,
+    gitBlobIdentity,
     "implementation",
   );
   const persistence = await persistenceComponent(
@@ -86,12 +164,15 @@ export async function deriveGenericLaunchReadModelContractV2(input, options) {
     websiteSource,
     repoRoot,
     read,
+    gitBlobIdentity,
+    hostedEvidenceIdentity,
   );
   const queryContract = await queryComponent(
     value.queryContract,
     websiteSource,
     repoRoot,
     read,
+    gitBlobIdentity,
   );
   const approvalArtifactSchema = approvalSchemaComponent(value.approvalArtifactSchema);
   const approvalRelease = approvalReleaseComponent(
@@ -103,6 +184,7 @@ export async function deriveGenericLaunchReadModelContractV2(input, options) {
     websiteSource,
     repoRoot,
     read,
+    gitBlobIdentity,
   );
 
   const componentBindingHashes = Object.freeze({
@@ -158,44 +240,80 @@ export async function deriveGenericLaunchReadModelContractV2(input, options) {
   });
 }
 
-async function localArtifactComponent(raw, websiteSource, repoRoot, read, label) {
+async function localArtifactComponent(
+  raw,
+  websiteSource,
+  repoRoot,
+  read,
+  gitBlobIdentity,
+  label,
+) {
   const value = exactObject(raw, ["artifacts"], `${label} component`);
+  const artifacts = await localArtifacts(
+    value.artifacts,
+    websiteSource,
+    repoRoot,
+    read,
+    gitBlobIdentity,
+    label,
+  );
+  assertExactArtifactInventory(
+    artifacts,
+    label === "implementation" ? IMPLEMENTATION_ARTIFACTS : [],
+    label,
+  );
   return Object.freeze({
     source: websiteSource,
-    artifacts: await localArtifacts(value.artifacts, repoRoot, read, label),
+    artifacts,
   });
 }
 
-async function persistenceComponent(raw, websiteSource, repoRoot, read) {
+async function persistenceComponent(
+  raw,
+  websiteSource,
+  repoRoot,
+  read,
+  gitBlobIdentity,
+  hostedEvidenceIdentity,
+) {
   const value = exactObject(raw, ["artifacts", "hostedEvidence"],
     "persistence component");
-  const evidence = exactObject(value.hostedEvidence, [
-    "catalogSha256",
-    "executionEvidenceSha256",
-    "migrationPlanSha256",
-    "migratedThrough",
-    "targetBindingHash",
-  ], "hosted persistence evidence");
-  if (evidence.migratedThrough !== "0005") {
-    throw new TypeError("Hosted persistence is not migrated through 0005");
+  const artifacts = await localArtifacts(
+    value.artifacts,
+    websiteSource,
+    repoRoot,
+    read,
+    gitBlobIdentity,
+    "persistence",
+  );
+  const evidence = await hostedPersistenceEvidence(
+    value.hostedEvidence,
+    hostedEvidenceIdentity,
+  );
+  assertExactArtifactInventory(artifacts, PERSISTENCE_ARTIFACTS, "persistence");
+  for (const migration of evidence.plan.migrations) {
+    const artifact = artifacts.find(({ path }) => path === migration.file);
+    if (!artifact
+      || artifact.sha256 !== `sha256:${migration.fileSha256.slice(2)}`) {
+      throw new TypeError(
+        `Hosted migration evidence is not bound to ${migration.file}`,
+      );
+    }
   }
   return Object.freeze({
     source: websiteSource,
-    artifacts: await localArtifacts(value.artifacts, repoRoot, read, "persistence"),
-    hostedEvidence: Object.freeze({
-      targetBindingHash: digest(evidence.targetBindingHash, "persistence target"),
-      migrationPlanSha256: digest(evidence.migrationPlanSha256, "migration plan"),
-      executionEvidenceSha256: digest(
-        evidence.executionEvidenceSha256,
-        "migration execution evidence",
-      ),
-      catalogSha256: digest(evidence.catalogSha256, "hosted catalog"),
-      migratedThrough: "0005",
-    }),
+    artifacts,
+    hostedEvidence: evidence,
   });
 }
 
-async function queryComponent(raw, websiteSource, repoRoot, read) {
+async function queryComponent(
+  raw,
+  websiteSource,
+  repoRoot,
+  read,
+  gitBlobIdentity,
+) {
   const value = exactObject(raw, [
     "artifacts", "detailPathTemplate", "feedPath", "readinessPath",
   ], "query contract component");
@@ -207,7 +325,14 @@ async function queryComponent(raw, websiteSource, repoRoot, read) {
   }
   return Object.freeze({
     source: websiteSource,
-    artifacts: await localArtifacts(value.artifacts, repoRoot, read, "query contract"),
+    artifacts: assertExactArtifactInventory(await localArtifacts(
+      value.artifacts,
+      websiteSource,
+      repoRoot,
+      read,
+      gitBlobIdentity,
+      "query contract",
+    ), QUERY_ARTIFACTS, "query contract"),
     feedPath: value.feedPath,
     detailPathTemplate: value.detailPathTemplate,
     readinessPath: value.readinessPath,
@@ -219,15 +344,23 @@ function approvalSchemaComponent(raw) {
     "artifact", "audience", "domain", "handoffEvidenceSha256",
     "schemaVersion", "source", "status",
   ], "Approval artifact schema component");
+  const source = sourceIdentity(value.source, "Approval schema source");
   if (value.status !== "frozen"
+    || value.schemaVersion
+      !== "programmable.approval-registry-v2-descriptor-binding.v2"
     || value.domain !== "programmable.approval-registry-descriptor-binding.v3"
-    || value.audience !== "programmable.custom-registry.v2") {
+    || value.audience !== "programmable.custom-registry.v2"
+    || source.repositoryId !== APPROVAL_REPOSITORY_IDENTITY.repositoryId
+    || source.repositoryFullName
+      !== APPROVAL_REPOSITORY_IDENTITY.repositoryFullName
+    || value.artifact?.path
+      !== "services/autonomous-approval-v1/schemas/approval-registry-v2-descriptor-binding-v2.schema.json") {
     throw new TypeError("Approval artifact schema is not frozen for Registry V2");
   }
   return Object.freeze({
     status: "frozen",
-    source: sourceIdentity(value.source, "Approval schema source"),
-    schemaVersion: nonempty(value.schemaVersion, "Approval schema version"),
+    source,
+    schemaVersion: value.schemaVersion,
     domain: value.domain,
     audience: value.audience,
     artifact: externalArtifact(value.artifact, "Approval schema artifact"),
@@ -249,6 +382,7 @@ function approvalReleaseComponent(raw, schemaSource) {
   ], "Approval release component");
   const source = sourceIdentity(value.source, "Approval release source");
   if (value.status !== "live"
+    || source.repositoryId !== schemaSource.repositoryId
     || source.repositoryFullName !== schemaSource.repositoryFullName) {
     throw new TypeError("Approval release is not a live release of the frozen schema");
   }
@@ -274,7 +408,13 @@ function approvalReleaseComponent(raw, schemaSource) {
   });
 }
 
-async function registryComponent(raw, websiteSource, repoRoot, read) {
+async function registryComponent(
+  raw,
+  websiteSource,
+  repoRoot,
+  read,
+  gitBlobIdentity,
+) {
   const value = exactObject(raw, [
     "abiArtifactSha256", "artifacts", "deploymentArtifactSha256",
     "eventSetSha256", "liveVerificationEvidenceSha256",
@@ -285,8 +425,19 @@ async function registryComponent(raw, websiteSource, repoRoot, read) {
   if (value.status !== "live") {
     throw new TypeError("Registry projection is not live");
   }
-  const artifacts = await localArtifacts(value.artifacts, repoRoot, read,
-    "Registry projection");
+  const artifacts = await localArtifacts(
+    value.artifacts,
+    websiteSource,
+    repoRoot,
+    read,
+    gitBlobIdentity,
+    "Registry projection",
+  );
+  assertExactArtifactInventory(
+    artifacts,
+    REGISTRY_PROJECTION_ARTIFACTS,
+    "Registry projection",
+  );
   const deployment = artifacts.find(({ path }) =>
     path === "config/custom-registry-v2.deployment.prelaunch.json");
   if (!deployment
@@ -297,6 +448,10 @@ async function registryComponent(raw, websiteSource, repoRoot, read) {
     throw new TypeError("Registry deployment artifact is not in the projection closure");
   }
   const registrySource = sourceIdentity(value.source, "Registry source");
+  if (registrySource.repositoryId !== websiteSource.repositoryId
+    || registrySource.repositoryFullName !== websiteSource.repositoryFullName) {
+    throw new TypeError("Registry source is not the exact Website repository");
+  }
   const registryAddress = address(value.registryAddress, "Registry address");
   const registryRuntimeCodeKeccak256 = hash32(
     value.registryRuntimeCodeKeccak256,
@@ -319,6 +474,9 @@ async function registryComponent(raw, websiteSource, repoRoot, read) {
   const deploymentBytes = read === readFile
     ? await readRegularArtifact(resolve(repoRoot, deployment.path), "Registry deployment")
     : await read(resolve(repoRoot, deployment.path));
+  if (sha256Bytes(deploymentBytes) !== deployment.sha256) {
+    throw new TypeError("Registry deployment artifact changed during derivation");
+  }
   assertRegistryDeploymentConfig(JSON.parse(deploymentBytes.toString("utf8")), {
     registrySource,
     registryAddress,
@@ -370,10 +528,36 @@ function assertRegistryDeploymentConfig(raw, expected) {
   const finality = exactObject(value.finality, [
     "minimumConfirmations", "policyBindingHash",
   ], "Registry deployment finality");
+  const profiles = exactObject(value.profiles, [
+    "NoMarket0", "Standard10",
+  ], "Registry deployment profiles");
+  const noMarket = exactObject(profiles.NoMarket0, [
+    "marketMode", "protocolFeeBps",
+  ], "Registry NoMarket0 profile");
+  const standard = exactObject(profiles.Standard10, [
+    "marketMode", "protocolFeeBps",
+  ], "Registry Standard10 profile");
+  const deploymentTransactionHash = hash32(
+    registry.deploymentTransactionHash,
+    "Registry deployment transaction hash",
+  );
+  const deploymentBlock = positiveDecimal(
+    registry.deploymentBlock,
+    "Registry deployment block",
+  );
+  const deploymentBlockHash = hash32(
+    registry.deploymentBlockHash,
+    "Registry deployment block hash",
+  );
   if (value.schemaVersion !== "programmable.custom-registry-v2-deployment.v1"
     || value.status !== "live" || value.generation !== "2"
     || value.chainId !== "1" || value.caip2 !== "eip155:1"
     || value.publicReadEnabled !== true || value.indexingEnabled !== true
+    || noMarket.marketMode !== 0 || noMarket.protocolFeeBps !== 0
+    || standard.marketMode !== 1 || standard.protocolFeeBps !== 10
+    || /^0x0{64}$/u.test(deploymentTransactionHash)
+    || deploymentBlock === "0"
+    || /^0x0{64}$/u.test(deploymentBlockHash)
     || address(registry.address, "deployed Registry address")
       !== expected.registryAddress
     || registry.runtimeCodeKeccak256 !== expected.registryRuntimeCodeKeccak256
@@ -388,13 +572,22 @@ function assertRegistryDeploymentConfig(raw, expected) {
   }
 }
 
-async function localArtifacts(raw, repoRoot, read, label) {
+async function localArtifacts(
+  raw,
+  websiteSource,
+  repoRoot,
+  read,
+  gitBlobIdentity,
+  label,
+) {
   if (!Array.isArray(raw) || raw.length === 0 || raw.length > 64) {
     throw new TypeError(`${label} artifacts are invalid`);
   }
   const result = [];
   for (const candidate of raw) {
-    const value = exactObject(candidate, ["path", "sha256"], `${label} artifact`);
+    const value = exactObject(candidate, [
+      "gitBlobOid", "path", "sha256",
+    ], `${label} artifact`);
     const path = artifactPath(value.path, `${label} artifact path`);
     const fullPath = resolve(repoRoot, path);
     const rel = relative(repoRoot, fullPath);
@@ -402,6 +595,18 @@ async function localArtifacts(raw, repoRoot, read, label) {
       throw new TypeError(`${label} artifact escapes the repository`);
     }
     const expected = digest(value.sha256, `${label} artifact digest`);
+    const expectedGitBlobOid = match(
+      value.gitBlobOid,
+      GIT_OID,
+      `${label} artifact Git blob`,
+    );
+    const gitBlob = await gitBlobIdentity(repoRoot, websiteSource.commit, path);
+    if (gitBlob.type !== "blob"
+      || !["100644", "100755"].includes(gitBlob.mode)
+      || gitBlob.oid !== expectedGitBlobOid
+      || gitBlob.contentSha256 !== expected) {
+      throw new TypeError(`${label} artifact does not match the HEAD Git blob ${path}`);
+    }
     const bytes = read === readFile
       ? await readRegularArtifact(fullPath, label)
       : await read(fullPath);
@@ -409,7 +614,11 @@ async function localArtifacts(raw, repoRoot, read, label) {
       || sha256Bytes(bytes) !== expected) {
       throw new TypeError(`${label} artifact bytes do not match ${path}`);
     }
-    result.push(Object.freeze({ path, sha256: expected }));
+    result.push(Object.freeze({
+      path,
+      sha256: expected,
+      gitBlobOid: expectedGitBlobOid,
+    }));
   }
   const paths = result.map(({ path }) => path);
   if (new Set(paths).size !== paths.length
@@ -417,6 +626,206 @@ async function localArtifacts(raw, repoRoot, read, label) {
     throw new TypeError(`${label} artifacts must be unique and sorted`);
   }
   return Object.freeze(result);
+}
+
+function assertExactArtifactInventory(artifacts, expected, label) {
+  const paths = artifacts.map(({ path }) => path);
+  if (canonicalJson(paths) !== canonicalJson(expected)) {
+    throw new TypeError(`${label} artifact inventory is not exact`);
+  }
+  return artifacts;
+}
+
+async function hostedPersistenceEvidence(raw, expectedIdentity) {
+  const expected = exactObject(expectedIdentity, [
+    "adoptionArtifactSha256", "applyArtifactSha256", "finalCatalogSha256",
+    "orderSha256", "planArtifactSha256", "planRepositoryCommit",
+    "planRepositoryTree", "planSha256", "verifyArtifactSha256",
+  ], "hosted persistence expected identity");
+  const value = exactObject(raw, [
+    "adoption", "apply", "plan", "verify",
+  ], "hosted persistence evidence");
+  const [planArtifact, adoptionArtifact, applyArtifact, verifyArtifact] =
+    await Promise.all([
+      readProtectedEvidenceArtifact(value.plan, "hosted migration plan"),
+      readProtectedEvidenceArtifact(value.adoption, "hosted adoption evidence"),
+      readProtectedEvidenceArtifact(value.apply, "hosted apply evidence"),
+      readProtectedEvidenceArtifact(value.verify, "hosted verify evidence"),
+    ]);
+  const plan = validateWebsiteProjectionPlan(planArtifact.value);
+  const adoption = operatorResult(adoptionArtifact.value, "adopt-existing");
+  const apply = operatorResult(applyArtifact.value, "apply");
+  const verify = operatorResult(verifyArtifact.value, "verify");
+  const resultArtifacts = [adoption, apply, verify];
+  if (planArtifact.sha256 !== digest(
+    expected.planArtifactSha256,
+    "expected hosted plan artifact",
+  )
+    || adoptionArtifact.sha256 !== digest(
+      expected.adoptionArtifactSha256,
+      "expected hosted adoption artifact",
+    )
+    || applyArtifact.sha256 !== digest(
+      expected.applyArtifactSha256,
+      "expected hosted apply artifact",
+    )
+    || verifyArtifact.sha256 !== digest(
+      expected.verifyArtifactSha256,
+      "expected hosted verify artifact",
+    )
+    || plan.repositoryCommit !== expected.planRepositoryCommit
+    || plan.repositoryTree !== expected.planRepositoryTree
+    || plan.planSha256 !== expected.planSha256
+    || plan.orderSha256 !== expected.orderSha256) {
+    throw new TypeError("Hosted persistence artifacts do not match the frozen closure");
+  }
+  if (resultArtifacts.some((result) =>
+    result.planSha256 !== plan.planSha256
+    || canonicalJson(result.target) !== canonicalJson(adoption.target)
+    || canonicalJson(result.operatorIdentity)
+      !== canonicalJson(adoption.operatorIdentity))) {
+    throw new TypeError("Hosted persistence evidence is not one operator chain");
+  }
+  const expectedPending = plan.migrations.slice(3).map(
+    ({ ordinal, version, file }) => ({ ordinal, version, file }),
+  );
+  const adopted = exactObject(adoption.state, [
+    "adoptedExisting", "adoptedThisRun", "adoptionAttestationSha256",
+    "adoptionDataSha256", "adoptionSourceCatalogSha256", "appliedCount",
+    "catalogSha256", "pending", "runtimeRoleStatus", "status",
+  ], "hosted adoption state");
+  const applied = exactObject(apply.state, [
+    "appliedCount", "appliedThisRun", "catalogSha256", "pending",
+    "roleCreated", "runtimeRoleStatus", "status",
+  ], "hosted apply state");
+  const verified = exactObject(verify.state, [
+    "appliedCount", "catalogSha256", "pending", "runtimeRoleStatus", "status",
+  ], "hosted verify state");
+  if (adoption.changed !== true
+    || adopted.status !== "pending" || adopted.appliedCount !== 3
+    || canonicalJson(adopted.pending) !== canonicalJson(expectedPending)
+    || adopted.runtimeRoleStatus !== "current"
+    || adopted.adoptedExisting !== true
+    || canonicalJson(adopted.adoptedThisRun) !== canonicalJson([
+      "0001", "0002", "0003",
+    ])
+    || !HEX_SHA256.test(adopted.catalogSha256)
+    || !HEX_SHA256.test(adopted.adoptionSourceCatalogSha256)
+    || !HEX_SHA256.test(adopted.adoptionDataSha256)
+    || !HEX_SHA256.test(adopted.adoptionAttestationSha256)) {
+    throw new TypeError("Hosted adoption evidence is not the exact 0001-0003 prefix");
+  }
+  if (apply.changed !== true
+    || applied.status !== "current" || applied.appliedCount !== 5
+    || canonicalJson(applied.pending) !== "[]"
+    || applied.runtimeRoleStatus !== "current"
+    || canonicalJson(applied.appliedThisRun) !== canonicalJson(["0004", "0005"])
+    || applied.roleCreated !== false
+    || !HEX_SHA256.test(applied.catalogSha256)) {
+    throw new TypeError("Hosted apply evidence is not exact through 0005");
+  }
+  if (verify.changed !== false
+    || verified.status !== "current" || verified.appliedCount !== 5
+    || canonicalJson(verified.pending) !== "[]"
+    || verified.runtimeRoleStatus !== "current"
+    || verified.catalogSha256 !== applied.catalogSha256
+    || verified.catalogSha256 !== expected.finalCatalogSha256) {
+    throw new TypeError("Hosted verify evidence does not close the 0005 catalog");
+  }
+  const normalized = Object.freeze({
+    target: adoption.target,
+    plan: Object.freeze({
+      repositoryCommit: plan.repositoryCommit,
+      repositoryTree: plan.repositoryTree,
+      planSha256: plan.planSha256,
+      orderSha256: plan.orderSha256,
+      migrations: Object.freeze(plan.migrations.map((migration) => Object.freeze({
+        ordinal: migration.ordinal,
+        version: migration.version,
+        file: migration.file,
+        fileSha256: migration.fileSha256,
+        executionSha256: migration.executionSha256,
+      }))),
+    }),
+    protectedArtifacts: Object.freeze({
+      planSha256: planArtifact.sha256,
+      adoptionSha256: adoptionArtifact.sha256,
+      applySha256: applyArtifact.sha256,
+      verifySha256: verifyArtifact.sha256,
+    }),
+    adoption: Object.freeze({
+      catalogSha256: adopted.catalogSha256,
+      sourceCatalogSha256: adopted.adoptionSourceCatalogSha256,
+      dataSha256: adopted.adoptionDataSha256,
+      attestationSha256: adopted.adoptionAttestationSha256,
+    }),
+    finalCatalogSha256: verified.catalogSha256,
+    migratedThrough: "0005",
+  });
+  return Object.freeze({
+    ...normalized,
+    closureHash: canonicalSha256(
+      "programmable.generic-launch-read-model-hosted-persistence-closure.v1",
+      normalized,
+    ),
+  });
+}
+
+function operatorResult(raw, operation) {
+  const value = exactObject(raw, [
+    "changed", "kind", "operation", "operatorIdentity", "planSha256",
+    "schemaVersion", "state", "target",
+  ], `hosted ${operation} result`);
+  const target = exactObject(value.target, [
+    "database", "host", "port", "projectRef", "sslMode",
+  ], `hosted ${operation} target`);
+  const operatorIdentity = exactObject(value.operatorIdentity, [
+    "effectiveRole", "mode", "sessionUser",
+  ], `hosted ${operation} operator`);
+  if (value.kind !== "programmable-website-projection-db-operator-result"
+    || value.schemaVersion !== 1 || value.operation !== operation
+    || !HEX_SHA256.test(value.planSha256)
+    || target.projectRef !== WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF
+    || target.host !== `db.${target.projectRef}.supabase.co`
+    || target.port !== 5432 || target.database !== "postgres"
+    || target.sslMode !== "verify-full"
+    || operatorIdentity.mode !== "database-owner"
+    || operatorIdentity.sessionUser !== "postgres"
+    || operatorIdentity.effectiveRole !== "postgres") {
+    throw new TypeError(`Hosted ${operation} evidence identity is invalid`);
+  }
+  return Object.freeze({
+    planSha256: value.planSha256,
+    target: Object.freeze({ ...target }),
+    operatorIdentity: Object.freeze({ ...operatorIdentity }),
+    state: value.state,
+    changed: value.changed,
+  });
+}
+
+async function readProtectedEvidenceArtifact(raw, label) {
+  const value = exactObject(raw, ["path", "sha256"], label);
+  const path = nonempty(value.path, `${label} path`);
+  const expected = digest(value.sha256, `${label} digest`);
+  const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || (stat.mode & 0o777) !== 0o600
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || stat.size <= 0 || stat.size > 1_048_576) {
+      throw new TypeError(`${label} must be an owner-only bounded regular file`);
+    }
+    const bytes = await handle.readFile();
+    if (sha256Bytes(bytes) !== expected) {
+      throw new TypeError(`${label} digest does not match`);
+    }
+    return Object.freeze({
+      sha256: expected,
+      value: JSON.parse(bytes.toString("utf8")),
+    });
+  } finally {
+    await handle.close();
+  }
 }
 
 async function readRegularArtifact(path, label) {
@@ -462,7 +871,12 @@ function exactObject(value, keys, label) {
 }
 
 function artifactPath(value, label) {
-  return match(value, ARTIFACT_PATH, label);
+  const path = match(value, ARTIFACT_PATH, label);
+  if (path.startsWith("./")
+    || path.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw new TypeError(`${label} is not canonical`);
+  }
+  return path;
 }
 
 function digest(value, label) {
@@ -510,6 +924,51 @@ export function currentGitIdentity(repoRoot) {
     commit: git(["rev-parse", "HEAD"]),
     tree: git(["rev-parse", "HEAD^{tree}"]),
   });
+}
+
+export function currentGitBlobIdentity(repoRoot, commit, path) {
+  const output = execFileSync("git", [
+    "ls-tree", "-z", "--full-tree", commit, "--", path,
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const match = /^(100644|100755) (blob) ([0-9a-f]{40}|[0-9a-f]{64})\t([^\0]+)\0$/u
+    .exec(output);
+  if (!match || match[4] !== path) {
+    throw new TypeError(`Website HEAD does not contain exact artifact ${path}`);
+  }
+  const bytes = execFileSync("git", ["cat-file", "blob", match[3]], {
+    cwd: repoRoot,
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "ignore"],
+    maxBuffer: 4_194_305,
+  });
+  if (bytes.byteLength <= 0 || bytes.byteLength > 4_194_304) {
+    throw new TypeError(`Website HEAD artifact is not bounded ${path}`);
+  }
+  return Object.freeze({
+    mode: match[1],
+    type: match[2],
+    oid: match[3],
+    contentSha256: sha256Bytes(bytes),
+  });
+}
+
+function assertWellFormedUnicode(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new TypeError("Canonical JSON contains a lone Unicode surrogate");
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      throw new TypeError("Canonical JSON contains a lone Unicode surrogate");
+    }
+  }
 }
 
 export async function readProtectedDerivationInput(path, expectedSha256) {

--- a/scripts/custom-v2-read-model-contract-v2.mjs
+++ b/scripts/custom-v2-read-model-contract-v2.mjs
@@ -1,0 +1,587 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { open, readFile, writeFile } from "node:fs/promises";
+import { resolve, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+const SHA256 = /^sha256:[0-9a-f]{64}$/u;
+const GIT_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const POSITIVE_DECIMAL = /^[1-9][0-9]{0,77}$/u;
+const ADDRESS = /^0x[0-9a-fA-F]{40}$/u;
+const HASH32 = /^0x[0-9a-f]{64}$/u;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
+const ARTIFACT_PATH = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9_./-]+$/u;
+
+const INPUT_KEYS = Object.freeze([
+  "approvalArtifactSchema",
+  "approvalRelease",
+  "implementation",
+  "persistence",
+  "queryContract",
+  "registryProjection",
+  "schemaVersion",
+  "websiteSource",
+]);
+
+export function canonicalJson(value) {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    return `{${Object.keys(value).sort().map(
+      (key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`,
+    ).join(",")}}`;
+  }
+  throw new TypeError("Canonical JSON contains an unsupported value");
+}
+
+export function sha256Bytes(value) {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export function canonicalSha256(domain, value) {
+  if (!/^programmable\.[a-z0-9.-]+\.v[1-9][0-9]*$/u.test(domain)) {
+    throw new TypeError("Hash domain must be a versioned Programmable namespace");
+  }
+  return sha256Bytes(Buffer.concat([
+    Buffer.from(domain, "utf8"),
+    Buffer.of(0),
+    Buffer.from(canonicalJson(value), "utf8"),
+  ]));
+}
+
+export async function deriveGenericLaunchReadModelContractV2(input, options) {
+  const repoRoot = resolve(options?.repoRoot ?? process.cwd());
+  const read = options?.readFile ?? readFile;
+  const value = exactObject(input, INPUT_KEYS, "derivation input");
+  if (value.schemaVersion
+    !== "programmable.generic-launch-read-model-contract-derivation-input.v1") {
+    throw new TypeError("Generic launch read-model derivation input is invalid");
+  }
+
+  const websiteSource = sourceIdentity(value.websiteSource, "Website source");
+  if (options?.gitIdentity) {
+    const actual = options.gitIdentity(repoRoot);
+    if (actual.commit !== websiteSource.commit || actual.tree !== websiteSource.tree) {
+      throw new TypeError("Website source identity does not match the checkout");
+    }
+  }
+
+  const implementation = await localArtifactComponent(
+    value.implementation,
+    websiteSource,
+    repoRoot,
+    read,
+    "implementation",
+  );
+  const persistence = await persistenceComponent(
+    value.persistence,
+    websiteSource,
+    repoRoot,
+    read,
+  );
+  const queryContract = await queryComponent(
+    value.queryContract,
+    websiteSource,
+    repoRoot,
+    read,
+  );
+  const approvalArtifactSchema = approvalSchemaComponent(value.approvalArtifactSchema);
+  const approvalRelease = approvalReleaseComponent(
+    value.approvalRelease,
+    approvalArtifactSchema.source,
+  );
+  const registryProjection = await registryComponent(
+    value.registryProjection,
+    websiteSource,
+    repoRoot,
+    read,
+  );
+
+  const componentBindingHashes = Object.freeze({
+    implementationBindingHash: canonicalSha256(
+      "programmable.generic-launch-read-model-implementation-binding.v1",
+      implementation,
+    ),
+    persistenceBindingHash: canonicalSha256(
+      "programmable.generic-launch-read-model-persistence-binding.v1",
+      persistence,
+    ),
+    queryContractBindingHash: canonicalSha256(
+      "programmable.generic-launch-read-model-query-contract-binding.v1",
+      queryContract,
+    ),
+    approvalArtifactSchemaBindingHash: canonicalSha256(
+      "programmable.generic-launch-read-model-approval-schema-binding.v1",
+      approvalArtifactSchema,
+    ),
+    approvalReleaseBindingHash: canonicalSha256(
+      "programmable.generic-launch-read-model-approval-release-binding.v1",
+      approvalRelease,
+    ),
+    registryProjectionBindingHash: canonicalSha256(
+      "programmable.generic-launch-read-model-registry-projection-binding.v1",
+      registryProjection,
+    ),
+  });
+  const contract = Object.freeze({
+    schemaVersion: "programmable.generic-launch-read-model-contract.v2",
+    sourceLane: "generic.finalized-launch-v2",
+    ...componentBindingHashes,
+  });
+  const readModelBindingHash = canonicalSha256(contract.schemaVersion, contract);
+  const core = Object.freeze({
+    schemaVersion: "programmable.generic-launch-read-model-contract-derivation.v1",
+    websiteSource,
+    components: Object.freeze({
+      implementation,
+      persistence,
+      queryContract,
+      approvalArtifactSchema,
+      approvalRelease,
+      registryProjection,
+    }),
+    componentBindingHashes,
+    contract,
+    readModelBindingHash,
+  });
+  return Object.freeze({
+    ...core,
+    derivationHash: canonicalSha256(core.schemaVersion, core),
+  });
+}
+
+async function localArtifactComponent(raw, websiteSource, repoRoot, read, label) {
+  const value = exactObject(raw, ["artifacts"], `${label} component`);
+  return Object.freeze({
+    source: websiteSource,
+    artifacts: await localArtifacts(value.artifacts, repoRoot, read, label),
+  });
+}
+
+async function persistenceComponent(raw, websiteSource, repoRoot, read) {
+  const value = exactObject(raw, ["artifacts", "hostedEvidence"],
+    "persistence component");
+  const evidence = exactObject(value.hostedEvidence, [
+    "catalogSha256",
+    "executionEvidenceSha256",
+    "migrationPlanSha256",
+    "migratedThrough",
+    "targetBindingHash",
+  ], "hosted persistence evidence");
+  if (evidence.migratedThrough !== "0005") {
+    throw new TypeError("Hosted persistence is not migrated through 0005");
+  }
+  return Object.freeze({
+    source: websiteSource,
+    artifacts: await localArtifacts(value.artifacts, repoRoot, read, "persistence"),
+    hostedEvidence: Object.freeze({
+      targetBindingHash: digest(evidence.targetBindingHash, "persistence target"),
+      migrationPlanSha256: digest(evidence.migrationPlanSha256, "migration plan"),
+      executionEvidenceSha256: digest(
+        evidence.executionEvidenceSha256,
+        "migration execution evidence",
+      ),
+      catalogSha256: digest(evidence.catalogSha256, "hosted catalog"),
+      migratedThrough: "0005",
+    }),
+  });
+}
+
+async function queryComponent(raw, websiteSource, repoRoot, read) {
+  const value = exactObject(raw, [
+    "artifacts", "detailPathTemplate", "feedPath", "readinessPath",
+  ], "query contract component");
+  if (value.feedPath !== "/api/custom-launch/generic/v2/launches"
+    || value.detailPathTemplate
+      !== "/api/custom-launch/generic/v2/launches/{recordHash}"
+    || value.readinessPath !== "/api/custom-launch/generic/v2/readiness") {
+    throw new TypeError("Generic launch V2 query paths are invalid");
+  }
+  return Object.freeze({
+    source: websiteSource,
+    artifacts: await localArtifacts(value.artifacts, repoRoot, read, "query contract"),
+    feedPath: value.feedPath,
+    detailPathTemplate: value.detailPathTemplate,
+    readinessPath: value.readinessPath,
+  });
+}
+
+function approvalSchemaComponent(raw) {
+  const value = exactObject(raw, [
+    "artifact", "audience", "domain", "handoffEvidenceSha256",
+    "schemaVersion", "source", "status",
+  ], "Approval artifact schema component");
+  if (value.status !== "frozen"
+    || value.domain !== "programmable.approval-registry-descriptor-binding.v3"
+    || value.audience !== "programmable.custom-registry.v2") {
+    throw new TypeError("Approval artifact schema is not frozen for Registry V2");
+  }
+  return Object.freeze({
+    status: "frozen",
+    source: sourceIdentity(value.source, "Approval schema source"),
+    schemaVersion: nonempty(value.schemaVersion, "Approval schema version"),
+    domain: value.domain,
+    audience: value.audience,
+    artifact: externalArtifact(value.artifact, "Approval schema artifact"),
+    handoffEvidenceSha256: digest(
+      value.handoffEvidenceSha256,
+      "Approval schema handoff evidence",
+    ),
+  });
+}
+
+function approvalReleaseComponent(raw, schemaSource) {
+  const value = exactObject(raw, [
+    "aggregateReadinessBindingHash",
+    "artifactVerifierBindingHash",
+    "liveDeploymentEvidenceSha256",
+    "packageArtifactSha256",
+    "source",
+    "status",
+  ], "Approval release component");
+  const source = sourceIdentity(value.source, "Approval release source");
+  if (value.status !== "live"
+    || source.repositoryFullName !== schemaSource.repositoryFullName) {
+    throw new TypeError("Approval release is not a live release of the frozen schema");
+  }
+  return Object.freeze({
+    status: "live",
+    source,
+    packageArtifactSha256: digest(
+      value.packageArtifactSha256,
+      "Approval package artifact",
+    ),
+    aggregateReadinessBindingHash: digest(
+      value.aggregateReadinessBindingHash,
+      "Approval aggregate readiness binding",
+    ),
+    artifactVerifierBindingHash: digest(
+      value.artifactVerifierBindingHash,
+      "Approval artifact verifier binding",
+    ),
+    liveDeploymentEvidenceSha256: digest(
+      value.liveDeploymentEvidenceSha256,
+      "Approval live deployment evidence",
+    ),
+  });
+}
+
+async function registryComponent(raw, websiteSource, repoRoot, read) {
+  const value = exactObject(raw, [
+    "abiArtifactSha256", "artifacts", "deploymentArtifactSha256",
+    "eventSetSha256", "liveVerificationEvidenceSha256",
+    "minimumFinalityBlocks", "registryAddress", "registryPolicyCommitment",
+    "registryRuntimeCodeKeccak256", "source", "sourceArtifactSha256",
+    "sourceVerificationEvidenceSha256", "status",
+  ], "Registry projection component");
+  if (value.status !== "live") {
+    throw new TypeError("Registry projection is not live");
+  }
+  const artifacts = await localArtifacts(value.artifacts, repoRoot, read,
+    "Registry projection");
+  const deployment = artifacts.find(({ path }) =>
+    path === "config/custom-registry-v2.deployment.prelaunch.json");
+  if (!deployment
+    || deployment.sha256 !== digest(
+      value.deploymentArtifactSha256,
+      "Registry deployment artifact",
+    )) {
+    throw new TypeError("Registry deployment artifact is not in the projection closure");
+  }
+  const registrySource = sourceIdentity(value.source, "Registry source");
+  const registryAddress = address(value.registryAddress, "Registry address");
+  const registryRuntimeCodeKeccak256 = hash32(
+    value.registryRuntimeCodeKeccak256,
+    "Registry runtime code hash",
+  );
+  const registryPolicyCommitment = hash32(
+    value.registryPolicyCommitment,
+    "Registry policy commitment",
+  );
+  const minimumFinalityBlocks = positiveDecimal(
+    value.minimumFinalityBlocks,
+    "Registry minimum finality blocks",
+  );
+  const sourceArtifactSha256 = digest(
+    value.sourceArtifactSha256,
+    "Registry source artifact",
+  );
+  const abiArtifactSha256 = digest(value.abiArtifactSha256, "Registry ABI artifact");
+  const eventSetSha256 = digest(value.eventSetSha256, "Registry event set");
+  const deploymentBytes = read === readFile
+    ? await readRegularArtifact(resolve(repoRoot, deployment.path), "Registry deployment")
+    : await read(resolve(repoRoot, deployment.path));
+  assertRegistryDeploymentConfig(JSON.parse(deploymentBytes.toString("utf8")), {
+    registrySource,
+    registryAddress,
+    registryRuntimeCodeKeccak256,
+    registryPolicyCommitment,
+    minimumFinalityBlocks,
+    sourceArtifactSha256,
+    abiArtifactSha256,
+    eventSetSha256,
+  });
+  return Object.freeze({
+    status: "live",
+    websiteSource,
+    registrySource,
+    artifacts,
+    deploymentArtifactSha256: deployment.sha256,
+    sourceArtifactSha256,
+    abiArtifactSha256,
+    eventSetSha256,
+    registryAddress,
+    registryRuntimeCodeKeccak256,
+    registryPolicyCommitment,
+    minimumFinalityBlocks,
+    liveVerificationEvidenceSha256: digest(
+      value.liveVerificationEvidenceSha256,
+      "Registry live verification evidence",
+    ),
+    sourceVerificationEvidenceSha256: digest(
+      value.sourceVerificationEvidenceSha256,
+      "Registry source verification evidence",
+    ),
+  });
+}
+
+function assertRegistryDeploymentConfig(raw, expected) {
+  const value = exactObject(raw, [
+    "caip2", "chainId", "finality", "generation", "indexingEnabled",
+    "profiles", "publicReadEnabled", "registry", "release", "schemaVersion",
+    "status",
+  ], "Registry deployment config");
+  const registry = exactObject(value.registry, [
+    "address", "deploymentBlock", "deploymentBlockHash",
+    "deploymentTransactionHash", "runtimeCodeKeccak256",
+  ], "Registry deployment identity");
+  const release = exactObject(value.release, [
+    "abiArtifactSha256", "eventSetSha256", "sourceArtifactSha256",
+    "sourceCommit", "sourceTree",
+  ], "Registry deployment release");
+  const finality = exactObject(value.finality, [
+    "minimumConfirmations", "policyBindingHash",
+  ], "Registry deployment finality");
+  if (value.schemaVersion !== "programmable.custom-registry-v2-deployment.v1"
+    || value.status !== "live" || value.generation !== "2"
+    || value.chainId !== "1" || value.caip2 !== "eip155:1"
+    || value.publicReadEnabled !== true || value.indexingEnabled !== true
+    || address(registry.address, "deployed Registry address")
+      !== expected.registryAddress
+    || registry.runtimeCodeKeccak256 !== expected.registryRuntimeCodeKeccak256
+    || release.sourceCommit !== expected.registrySource.commit
+    || release.sourceTree !== expected.registrySource.tree
+    || release.sourceArtifactSha256 !== expected.sourceArtifactSha256
+    || release.abiArtifactSha256 !== expected.abiArtifactSha256
+    || release.eventSetSha256 !== expected.eventSetSha256
+    || finality.minimumConfirmations !== expected.minimumFinalityBlocks
+    || finality.policyBindingHash !== expected.registryPolicyCommitment) {
+    throw new TypeError("Registry projection does not match the live deployment config");
+  }
+}
+
+async function localArtifacts(raw, repoRoot, read, label) {
+  if (!Array.isArray(raw) || raw.length === 0 || raw.length > 64) {
+    throw new TypeError(`${label} artifacts are invalid`);
+  }
+  const result = [];
+  for (const candidate of raw) {
+    const value = exactObject(candidate, ["path", "sha256"], `${label} artifact`);
+    const path = artifactPath(value.path, `${label} artifact path`);
+    const fullPath = resolve(repoRoot, path);
+    const rel = relative(repoRoot, fullPath);
+    if (rel.startsWith(`..${sep}`) || rel === ".." || rel === "") {
+      throw new TypeError(`${label} artifact escapes the repository`);
+    }
+    const expected = digest(value.sha256, `${label} artifact digest`);
+    const bytes = read === readFile
+      ? await readRegularArtifact(fullPath, label)
+      : await read(fullPath);
+    if (bytes.byteLength === 0 || bytes.byteLength > 4_194_304
+      || sha256Bytes(bytes) !== expected) {
+      throw new TypeError(`${label} artifact bytes do not match ${path}`);
+    }
+    result.push(Object.freeze({ path, sha256: expected }));
+  }
+  const paths = result.map(({ path }) => path);
+  if (new Set(paths).size !== paths.length
+    || canonicalJson(paths) !== canonicalJson([...paths].sort())) {
+    throw new TypeError(`${label} artifacts must be unique and sorted`);
+  }
+  return Object.freeze(result);
+}
+
+async function readRegularArtifact(path, label) {
+  const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size <= 0 || stat.size > 4_194_304) {
+      throw new TypeError(`${label} artifact is not a bounded regular file`);
+    }
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+function sourceIdentity(raw, label) {
+  const value = exactObject(raw, [
+    "commit", "repositoryFullName", "repositoryId", "tree",
+  ], label);
+  return Object.freeze({
+    repositoryId: positiveDecimal(value.repositoryId, `${label} repository ID`),
+    repositoryFullName: match(value.repositoryFullName, REPOSITORY,
+      `${label} repository name`),
+    commit: match(value.commit, GIT_OID, `${label} commit`),
+    tree: match(value.tree, GIT_OID, `${label} tree`),
+  });
+}
+
+function externalArtifact(raw, label) {
+  const value = exactObject(raw, ["path", "sha256"], label);
+  return Object.freeze({
+    path: artifactPath(value.path, `${label} path`),
+    sha256: digest(value.sha256, `${label} digest`),
+  });
+}
+
+function exactObject(value, keys, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)
+    || canonicalJson(Object.keys(value).sort()) !== canonicalJson([...keys].sort())) {
+    throw new TypeError(`${label} must contain exactly ${keys.join(", ")}`);
+  }
+  return value;
+}
+
+function artifactPath(value, label) {
+  return match(value, ARTIFACT_PATH, label);
+}
+
+function digest(value, label) {
+  return match(value, SHA256, label);
+}
+
+function hash32(value, label) {
+  return match(value, HASH32, label);
+}
+
+function address(value, label) {
+  const result = match(value, ADDRESS, label);
+  if (/^0x0{40}$/iu.test(result)) throw new TypeError(`${label} is zero`);
+  return result.toLowerCase();
+}
+
+function positiveDecimal(value, label) {
+  return match(value, POSITIVE_DECIMAL, label);
+}
+
+function nonempty(value, label) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 256) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function match(value, pattern, label) {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+export function currentGitIdentity(repoRoot) {
+  const git = (args) => execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  if (git(["status", "--porcelain"]) !== "") {
+    throw new TypeError("Website checkout must be clean");
+  }
+  return Object.freeze({
+    commit: git(["rev-parse", "HEAD"]),
+    tree: git(["rev-parse", "HEAD^{tree}"]),
+  });
+}
+
+export async function readProtectedDerivationInput(path, expectedSha256) {
+  const expected = digest(expectedSha256, "protected derivation input");
+  const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || (stat.mode & 0o777) !== 0o600
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())) {
+      throw new TypeError("Protected derivation input must be an owner-only regular file");
+    }
+    if (stat.size <= 0 || stat.size > 1_048_576) {
+      throw new TypeError("Protected derivation input size is invalid");
+    }
+    const bytes = await handle.readFile();
+    if (sha256Bytes(bytes) !== expected) {
+      throw new TypeError("Protected derivation input digest does not match");
+    }
+    return JSON.parse(bytes.toString("utf8"));
+  } finally {
+    await handle.close();
+  }
+}
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const repoRoot = resolve(args.repoRoot ?? process.cwd());
+  const inputPath = resolve(args.input);
+  const outputPath = resolve(args.output);
+  if (inputPath === outputPath) throw new TypeError("Input and output must differ");
+  const input = await readProtectedDerivationInput(inputPath, args.inputSha256);
+  const artifact = await deriveGenericLaunchReadModelContractV2(input, {
+    repoRoot,
+    gitIdentity: currentGitIdentity,
+  });
+  const bytes = `${canonicalJson(artifact)}\n`;
+  await writeFile(outputPath, bytes, { encoding: "utf8", flag: "wx", mode: 0o600 });
+  process.stdout.write(`${JSON.stringify({
+    outputPath,
+    artifactSha256: sha256Bytes(bytes),
+    derivationHash: artifact.derivationHash,
+    readModelBindingHash: artifact.readModelBindingHash,
+  })}\n`);
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!["--input", "--input-sha256", "--output", "--repo-root"].includes(key)) {
+      throw new TypeError(`Unknown argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new TypeError(`${key} is required`);
+    const field = key === "--repo-root"
+      ? "repoRoot"
+      : key === "--input-sha256" ? "inputSha256" : key.slice(2);
+    result[field] = value;
+    index += 1;
+  }
+  if (!result.input || !result.inputSha256 || !result.output) {
+    throw new TypeError(
+      "Usage: --input <protected.json> --input-sha256 <sha256:...> --output <new-artifact.json>",
+    );
+  }
+  return result;
+}
+
+if (process.argv[1]
+  && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -26,6 +26,10 @@ test("Custom V2 production proof is a dedicated versioned protected lane", () =>
     verify,
     /name: Verify exact Website projection database operator[\s\S]*node --test scripts\/website-projection-db-operator\.test\.mjs/u,
   );
+  assert.match(
+    verify,
+    /name: Verify exact Generic V2 read-model contract derivation[\s\S]*node --test scripts\/test\/custom-v2-read-model-contract-v2\.test\.mjs/u,
+  );
   assert.match(verify, /PRODUCTION_VERIFY_SCOPE_CUSTOM_V2:/u);
   assert.match(verify, /PRODUCTION_VERIFY_CUSTOM_V2_RESULT:/u);
   assert.match(verify, /verified Custom V2|CUSTOM_V2_RESULT/u);

--- a/scripts/test/custom-v2-read-model-contract-v2.test.mjs
+++ b/scripts/test/custom-v2-read-model-contract-v2.test.mjs
@@ -1,0 +1,360 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import {
+  canonicalJson,
+  canonicalSha256,
+  deriveGenericLaunchReadModelContractV2,
+  readProtectedDerivationInput,
+  sha256Bytes,
+} from "../custom-v2-read-model-contract-v2.mjs";
+
+const DIGEST = (label) => sha256Bytes(Buffer.from(label, "utf8"));
+
+async function fixture() {
+  const repoRoot = await mkdtemp(join(tmpdir(), "generic-v2-contract-"));
+  const registrySource = {
+    repositoryId: "101",
+    repositoryFullName: "0xprogrammable/programmable",
+    commit: "1".repeat(40),
+    tree: "2".repeat(40),
+  };
+  const registryAddress = "0x845506084a1afb969fa4def444a2bdeee794aaad";
+  const registryRuntimeCodeKeccak256 = `0x${"3".repeat(64)}`;
+  const registryPolicyCommitment = `0x${"4".repeat(64)}`;
+  const sourceArtifactSha256 = DIGEST("registry-source");
+  const abiArtifactSha256 = DIGEST("registry-abi");
+  const eventSetSha256 = DIGEST("registry-events");
+  const registryDeployment = {
+    schemaVersion: "programmable.custom-registry-v2-deployment.v1",
+    status: "live",
+    generation: "2",
+    chainId: "1",
+    caip2: "eip155:1",
+    publicReadEnabled: true,
+    indexingEnabled: true,
+    registry: {
+      address: registryAddress,
+      runtimeCodeKeccak256: registryRuntimeCodeKeccak256,
+      deploymentTransactionHash: `0x${"5".repeat(64)}`,
+      deploymentBlock: "100",
+      deploymentBlockHash: `0x${"6".repeat(64)}`,
+    },
+    release: {
+      sourceCommit: registrySource.commit,
+      sourceTree: registrySource.tree,
+      sourceArtifactSha256,
+      abiArtifactSha256,
+      eventSetSha256,
+    },
+    finality: {
+      minimumConfirmations: "12",
+      policyBindingHash: registryPolicyCommitment,
+    },
+    profiles: {
+      NoMarket0: { marketMode: 0, protocolFeeBps: 0 },
+      Standard10: { marketMode: 1, protocolFeeBps: 10 },
+    },
+  };
+  const files = {
+    "app/api/custom-launch/generic/v2/launches/route.ts": "feed\n",
+    "config/custom-registry-v2.deployment.prelaunch.json":
+      `${JSON.stringify(registryDeployment)}\n`,
+    "config/generic-launch-public.v2.schema.json": "schema\n",
+    "lib/server/custom-launch/generic-launch-postgres-v2.ts": "persistence\n",
+    "lib/server/custom-launch/generic-launch-projector-v2.ts": "projector\n",
+    "lib/server/custom-launch/generic-launch-read-v2.ts": "reader\n",
+    "ops/website-projection-target/migrations/0005_generic_launch_admission_v2.sql":
+      "migration\n",
+  };
+  for (const [path, source] of Object.entries(files)) {
+    await mkdir(dirname(join(repoRoot, path)), { recursive: true });
+    await writeFile(join(repoRoot, path), source, "utf8");
+  }
+  const artifact = (path) => ({
+    path,
+    sha256: sha256Bytes(Buffer.from(files[path], "utf8")),
+  });
+  const websiteSource = {
+    repositoryId: "101",
+    repositoryFullName: "0xprogrammable/programmable",
+    commit: "a".repeat(40),
+    tree: "b".repeat(40),
+  };
+  const input = {
+    schemaVersion:
+      "programmable.generic-launch-read-model-contract-derivation-input.v1",
+    websiteSource,
+    implementation: {
+      artifacts: [
+        artifact("lib/server/custom-launch/generic-launch-projector-v2.ts"),
+        artifact("lib/server/custom-launch/generic-launch-read-v2.ts"),
+      ],
+    },
+    persistence: {
+      artifacts: [
+        artifact("lib/server/custom-launch/generic-launch-postgres-v2.ts"),
+        artifact(
+          "ops/website-projection-target/migrations/0005_generic_launch_admission_v2.sql",
+        ),
+      ],
+      hostedEvidence: {
+        targetBindingHash: DIGEST("target"),
+        migrationPlanSha256: DIGEST("plan"),
+        executionEvidenceSha256: DIGEST("execution"),
+        catalogSha256: DIGEST("catalog"),
+        migratedThrough: "0005",
+      },
+    },
+    queryContract: {
+      artifacts: [
+        artifact("app/api/custom-launch/generic/v2/launches/route.ts"),
+        artifact("config/generic-launch-public.v2.schema.json"),
+      ],
+      feedPath: "/api/custom-launch/generic/v2/launches",
+      detailPathTemplate:
+        "/api/custom-launch/generic/v2/launches/{recordHash}",
+      readinessPath: "/api/custom-launch/generic/v2/readiness",
+    },
+    approvalArtifactSchema: {
+      status: "frozen",
+      source: {
+        repositoryId: "202",
+        repositoryFullName: "0xprogrammable/programmable-open-hook-v2-internal",
+        commit: "c".repeat(40),
+        tree: "d".repeat(40),
+      },
+      schemaVersion:
+        "programmable.approval-registry-v2-descriptor-binding.v2",
+      domain: "programmable.approval-registry-descriptor-binding.v3",
+      audience: "programmable.custom-registry.v2",
+      artifact: {
+        path: "services/autonomous-approval-v1/schemas/approval-registry-v2-descriptor-binding-v2.schema.json",
+        sha256: DIGEST("approval-schema"),
+      },
+      handoffEvidenceSha256: DIGEST("approval-schema-handoff"),
+    },
+    approvalRelease: {
+      status: "live",
+      source: {
+        repositoryId: "202",
+        repositoryFullName: "0xprogrammable/programmable-open-hook-v2-internal",
+        commit: "e".repeat(40),
+        tree: "f".repeat(40),
+      },
+      packageArtifactSha256: DIGEST("approval-package"),
+      aggregateReadinessBindingHash: DIGEST("approval-readiness"),
+      artifactVerifierBindingHash: DIGEST("approval-verifier"),
+      liveDeploymentEvidenceSha256: DIGEST("approval-live"),
+    },
+    registryProjection: {
+      status: "live",
+      source: registrySource,
+      artifacts: [
+        artifact("config/custom-registry-v2.deployment.prelaunch.json"),
+        artifact("lib/server/custom-launch/generic-launch-projector-v2.ts"),
+      ],
+      deploymentArtifactSha256: artifact(
+        "config/custom-registry-v2.deployment.prelaunch.json",
+      ).sha256,
+      sourceArtifactSha256,
+      abiArtifactSha256,
+      eventSetSha256,
+      registryAddress,
+      registryRuntimeCodeKeccak256,
+      registryPolicyCommitment,
+      minimumFinalityBlocks: "12",
+      liveVerificationEvidenceSha256: DIGEST("registry-live"),
+      sourceVerificationEvidenceSha256: DIGEST("registry-source-verification"),
+    },
+  };
+  return { repoRoot, input, files };
+}
+
+test("derives all six content-addressed bindings and the runtime contract", async (t) => {
+  const { repoRoot, input } = await fixture();
+  t.after(() => rm(repoRoot, { recursive: true, force: true }));
+  const result = await deriveGenericLaunchReadModelContractV2(input, { repoRoot });
+  const again = await deriveGenericLaunchReadModelContractV2(
+    JSON.parse(JSON.stringify(input)),
+    { repoRoot },
+  );
+
+  assert.equal(canonicalJson(result), canonicalJson(again));
+  assert.equal(result.contract.schemaVersion,
+    "programmable.generic-launch-read-model-contract.v2");
+  assert.equal(result.contract.sourceLane, "generic.finalized-launch-v2");
+  assert.deepEqual(
+    Object.keys(result.componentBindingHashes).sort(),
+    [
+      "approvalArtifactSchemaBindingHash",
+      "approvalReleaseBindingHash",
+      "implementationBindingHash",
+      "persistenceBindingHash",
+      "queryContractBindingHash",
+      "registryProjectionBindingHash",
+    ],
+  );
+  assert.equal(new Set(Object.values(result.componentBindingHashes)).size, 6);
+  assert.equal(
+    result.readModelBindingHash,
+    canonicalSha256(result.contract.schemaVersion, result.contract),
+  );
+  assert.equal(
+    result.derivationHash,
+    canonicalSha256(result.schemaVersion, {
+      schemaVersion: result.schemaVersion,
+      websiteSource: result.websiteSource,
+      components: result.components,
+      componentBindingHashes: result.componentBindingHashes,
+      contract: result.contract,
+      readModelBindingHash: result.readModelBindingHash,
+    }),
+  );
+});
+
+test("fails closed while the Approval release handoff is unresolved", async (t) => {
+  const { repoRoot, input } = await fixture();
+  t.after(() => rm(repoRoot, { recursive: true, force: true }));
+  input.approvalRelease.status = "pending";
+  input.approvalRelease.liveDeploymentEvidenceSha256 = null;
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    /Approval release|live deployment/u,
+  );
+});
+
+test("rejects a local artifact whose bytes drift after review", async (t) => {
+  const { repoRoot, input } = await fixture();
+  t.after(() => rm(repoRoot, { recursive: true, force: true }));
+  await writeFile(
+    join(repoRoot, "lib/server/custom-launch/generic-launch-read-v2.ts"),
+    "drift\n",
+    "utf8",
+  );
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    /artifact bytes do not match/u,
+  );
+
+  const linked = await fixture();
+  t.after(() => rm(linked.repoRoot, { recursive: true, force: true }));
+  const target = join(linked.repoRoot, "reader-target.ts");
+  const path = join(
+    linked.repoRoot,
+    "lib/server/custom-launch/generic-launch-read-v2.ts",
+  );
+  await writeFile(target, "reader\n", "utf8");
+  await rm(path);
+  await symlink(target, path);
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(linked.input, {
+      repoRoot: linked.repoRoot,
+    }),
+    /ELOOP|symbolic link/iu,
+  );
+});
+
+test("rejects unsorted, duplicate and escaping artifact inventories", async (t) => {
+  const { repoRoot, input } = await fixture();
+  t.after(() => rm(repoRoot, { recursive: true, force: true }));
+  input.implementation.artifacts.reverse();
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    /unique and sorted/u,
+  );
+
+  const duplicate = (await fixture());
+  t.after(() => rm(duplicate.repoRoot, { recursive: true, force: true }));
+  duplicate.input.queryContract.artifacts.push(
+    duplicate.input.queryContract.artifacts[1],
+  );
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(duplicate.input, {
+      repoRoot: duplicate.repoRoot,
+    }),
+    /unique and sorted/u,
+  );
+
+  const escaping = (await fixture());
+  t.after(() => rm(escaping.repoRoot, { recursive: true, force: true }));
+  escaping.input.implementation.artifacts[0].path = "../outside";
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(escaping.input, {
+      repoRoot: escaping.repoRoot,
+    }),
+    /path is invalid/u,
+  );
+});
+
+test("requires the exact live Registry deployment artifact in the closure", async (t) => {
+  const { repoRoot, input } = await fixture();
+  t.after(() => rm(repoRoot, { recursive: true, force: true }));
+  input.registryProjection.deploymentArtifactSha256 = DIGEST("other");
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    /deployment artifact is not in the projection closure/u,
+  );
+
+  const matrixDrift = await fixture();
+  t.after(() => rm(matrixDrift.repoRoot, { recursive: true, force: true }));
+  matrixDrift.input.registryProjection.sourceArtifactSha256 = DIGEST("drift");
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(matrixDrift.input, {
+      repoRoot: matrixDrift.repoRoot,
+    }),
+    /does not match the live deployment config/u,
+  );
+});
+
+test("binds generation-two routes and a clean exact Website checkout", async (t) => {
+  const { repoRoot, input } = await fixture();
+  t.after(() => rm(repoRoot, { recursive: true, force: true }));
+  input.queryContract.feedPath = "/api/custom-launch/generic/v1/launches";
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    /query paths are invalid/u,
+  );
+
+  const checkout = await fixture();
+  t.after(() => rm(checkout.repoRoot, { recursive: true, force: true }));
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(checkout.input, {
+      repoRoot: checkout.repoRoot,
+      gitIdentity: () => ({ commit: "9".repeat(40), tree: "8".repeat(40) }),
+    }),
+    /does not match the checkout/u,
+  );
+});
+
+test("reads only an owner-only content-addressed regular input file", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "generic-v2-protected-input-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const path = join(root, "input.json");
+  const bytes = Buffer.from('{"schemaVersion":"example"}\n', "utf8");
+  await writeFile(path, bytes, { mode: 0o600 });
+  assert.deepEqual(
+    await readProtectedDerivationInput(path, sha256Bytes(bytes)),
+    { schemaVersion: "example" },
+  );
+
+  await assert.rejects(
+    readProtectedDerivationInput(path, DIGEST("wrong")),
+    /digest does not match/u,
+  );
+  await chmod(path, 0o644);
+  await assert.rejects(
+    readProtectedDerivationInput(path, sha256Bytes(bytes)),
+    /owner-only regular file/u,
+  );
+  await chmod(path, 0o600);
+  const link = join(root, "input-link.json");
+  await symlink(path, link);
+  await assert.rejects(
+    readProtectedDerivationInput(link, sha256Bytes(bytes)),
+    /ELOOP|symbolic link/iu,
+  );
+});

--- a/scripts/test/custom-v2-read-model-contract-v2.test.mjs
+++ b/scripts/test/custom-v2-read-model-contract-v2.test.mjs
@@ -1,23 +1,35 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
 import test from "node:test";
 
 import {
   canonicalJson,
   canonicalSha256,
+  currentGitBlobIdentity,
   deriveGenericLaunchReadModelContractV2,
   readProtectedDerivationInput,
   sha256Bytes,
 } from "../custom-v2-read-model-contract-v2.mjs";
+import { discoverWebsiteProjectionPlan } from
+  "../website-projection-db-operator-core.mjs";
 
 const DIGEST = (label) => sha256Bytes(Buffer.from(label, "utf8"));
 
 async function fixture() {
   const repoRoot = await mkdtemp(join(tmpdir(), "generic-v2-contract-"));
+  const websiteSource = {
+    repositoryId: "1314365508",
+    repositoryFullName: "0xprogrammable/programmable",
+    commit: "a".repeat(40),
+    tree: "b".repeat(40),
+  };
   const registrySource = {
-    repositoryId: "101",
+    repositoryId: "1314365508",
     repositoryFullName: "0xprogrammable/programmable",
     commit: "1".repeat(40),
     tree: "2".repeat(40),
@@ -60,15 +72,34 @@ async function fixture() {
     },
   };
   const files = {
+    "app/api/custom-launch/generic/v2/launches/[recordHash]/route.ts":
+      "detail\n",
     "app/api/custom-launch/generic/v2/launches/route.ts": "feed\n",
+    "app/api/custom-launch/generic/v2/readiness/route.ts": "readiness\n",
+    "app/api/ops/custom-launch/generic-v2-projector/route.ts": "project\n",
+    "app/v2/internal/projections/approval-descriptors/[projectionKey]/route.ts":
+      "ingress\n",
     "config/custom-registry-v2.deployment.prelaunch.json":
       `${JSON.stringify(registryDeployment)}\n`,
     "config/generic-launch-public.v2.schema.json": "schema\n",
+    "lib/server/custom-launch/generic-launch-contract-v2.ts": "contract\n",
     "lib/server/custom-launch/generic-launch-postgres-v2.ts": "persistence\n",
+    "lib/server/custom-launch/generic-launch-production-v2.ts": "production\n",
     "lib/server/custom-launch/generic-launch-projector-v2.ts": "projector\n",
+    "lib/server/custom-launch/generic-launch-read-signer-v2.ts": "signer\n",
     "lib/server/custom-launch/generic-launch-read-v2.ts": "reader\n",
-    "ops/website-projection-target/migrations/0005_generic_launch_admission_v2.sql":
-      "migration\n",
+    "lib/server/custom-launch/generic-launch-registry-reader-v2.ts": "registry\n",
+    "lib/server/projection-target/approval-v3-target.ts": "approval\n",
+    "ops/website-projection-target/migrations/0001_projection_records_v1.sql":
+      "BEGIN;\nSELECT 1;\nCOMMIT;\n",
+    "ops/website-projection-target/migrations/0002_custom_launch_wallet_profile_v2.sql":
+      "BEGIN;\nSELECT 2;\nCOMMIT;\n",
+    "ops/website-projection-target/migrations/0003_registry_custom_public_read_v1.sql":
+      "BEGIN;\nSELECT 3;\nCOMMIT;\n",
+    "ops/website-projection-target/migrations/0004_approval_v3_artifacts_v1.sql":
+      "BEGIN;\nSELECT 4;\nCOMMIT;\n",
+    "ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql":
+      "BEGIN;\nSELECT 5;\nCOMMIT;\n",
   };
   for (const [path, source] of Object.entries(files)) {
     await mkdir(dirname(join(repoRoot, path)), { recursive: true });
@@ -77,42 +108,106 @@ async function fixture() {
   const artifact = (path) => ({
     path,
     sha256: sha256Bytes(Buffer.from(files[path], "utf8")),
+    gitBlobOid: sha256Bytes(Buffer.from(files[path], "utf8")).slice(7, 47),
   });
-  const websiteSource = {
-    repositoryId: "101",
-    repositoryFullName: "0xprogrammable/programmable",
-    commit: "a".repeat(40),
-    tree: "b".repeat(40),
+  const plan = await discoverWebsiteProjectionPlan({
+    workspace: repoRoot,
+    repositoryCommit: websiteSource.commit,
+    repositoryTree: websiteSource.tree,
+  });
+  const target = {
+    projectRef: "mnnvlrqwhfoppogslsje",
+    host: "db.mnnvlrqwhfoppogslsje.supabase.co",
+    port: 5432,
+    database: "postgres",
+    sslMode: "verify-full",
   };
+  const operatorIdentity = {
+    mode: "database-owner",
+    sessionUser: "postgres",
+    effectiveRole: "postgres",
+  };
+  const operatorResult = (operation, state, changed) => ({
+    kind: "programmable-website-projection-db-operator-result",
+    schemaVersion: 1,
+    operation,
+    planSha256: plan.planSha256,
+    target,
+    operatorIdentity,
+    state,
+    changed,
+  });
+  const catalog = `0x${"7".repeat(64)}`;
+  const protectedValues = {
+    plan,
+    adoption: operatorResult("adopt-existing", {
+      status: "pending",
+      appliedCount: 3,
+      pending: plan.migrations.slice(3).map(
+        ({ ordinal, version, file }) => ({ ordinal, version, file }),
+      ),
+      catalogSha256: `0x${"8".repeat(64)}`,
+      runtimeRoleStatus: "current",
+      adoptedExisting: true,
+      adoptedThisRun: ["0001", "0002", "0003"],
+      adoptionSourceCatalogSha256: `0x${"9".repeat(64)}`,
+      adoptionDataSha256: `0x${"a".repeat(64)}`,
+      adoptionAttestationSha256: `0x${"b".repeat(64)}`,
+    }, true),
+    apply: operatorResult("apply", {
+      status: "current",
+      appliedCount: 5,
+      pending: [],
+      catalogSha256: catalog,
+      runtimeRoleStatus: "current",
+      appliedThisRun: ["0004", "0005"],
+      roleCreated: false,
+    }, true),
+    verify: operatorResult("verify", {
+      status: "current",
+      appliedCount: 5,
+      pending: [],
+      catalogSha256: catalog,
+      runtimeRoleStatus: "current",
+    }, false),
+  };
+  const protectedArtifacts = {};
+  for (const [name, value] of Object.entries(protectedValues)) {
+    const path = join(repoRoot, `${name}.json`);
+    const bytes = Buffer.from(`${JSON.stringify(value)}\n`, "utf8");
+    await writeFile(path, bytes, { mode: 0o600 });
+    protectedArtifacts[name] = { path, sha256: sha256Bytes(bytes) };
+  }
   const input = {
     schemaVersion:
       "programmable.generic-launch-read-model-contract-derivation-input.v1",
     websiteSource,
     implementation: {
       artifacts: [
+        artifact("app/api/ops/custom-launch/generic-v2-projector/route.ts"),
+        artifact("app/v2/internal/projections/approval-descriptors/[projectionKey]/route.ts"),
+        artifact("lib/server/custom-launch/generic-launch-contract-v2.ts"),
+        artifact("lib/server/custom-launch/generic-launch-production-v2.ts"),
         artifact("lib/server/custom-launch/generic-launch-projector-v2.ts"),
-        artifact("lib/server/custom-launch/generic-launch-read-v2.ts"),
+        artifact("lib/server/custom-launch/generic-launch-registry-reader-v2.ts"),
+        artifact("lib/server/projection-target/approval-v3-target.ts"),
       ],
     },
     persistence: {
       artifacts: [
         artifact("lib/server/custom-launch/generic-launch-postgres-v2.ts"),
-        artifact(
-          "ops/website-projection-target/migrations/0005_generic_launch_admission_v2.sql",
-        ),
+        ...plan.migrations.map(({ file }) => artifact(file)),
       ],
-      hostedEvidence: {
-        targetBindingHash: DIGEST("target"),
-        migrationPlanSha256: DIGEST("plan"),
-        executionEvidenceSha256: DIGEST("execution"),
-        catalogSha256: DIGEST("catalog"),
-        migratedThrough: "0005",
-      },
+      hostedEvidence: protectedArtifacts,
     },
     queryContract: {
       artifacts: [
+        artifact("app/api/custom-launch/generic/v2/launches/[recordHash]/route.ts"),
         artifact("app/api/custom-launch/generic/v2/launches/route.ts"),
+        artifact("app/api/custom-launch/generic/v2/readiness/route.ts"),
         artifact("config/generic-launch-public.v2.schema.json"),
+        artifact("lib/server/custom-launch/generic-launch-read-signer-v2.ts"),
+        artifact("lib/server/custom-launch/generic-launch-read-v2.ts"),
       ],
       feedPath: "/api/custom-launch/generic/v2/launches",
       detailPathTemplate:
@@ -122,7 +217,7 @@ async function fixture() {
     approvalArtifactSchema: {
       status: "frozen",
       source: {
-        repositoryId: "202",
+        repositoryId: "1318883798",
         repositoryFullName: "0xprogrammable/programmable-open-hook-v2-internal",
         commit: "c".repeat(40),
         tree: "d".repeat(40),
@@ -140,7 +235,7 @@ async function fixture() {
     approvalRelease: {
       status: "live",
       source: {
-        repositoryId: "202",
+        repositoryId: "1318883798",
         repositoryFullName: "0xprogrammable/programmable-open-hook-v2-internal",
         commit: "e".repeat(40),
         tree: "f".repeat(40),
@@ -155,7 +250,9 @@ async function fixture() {
       source: registrySource,
       artifacts: [
         artifact("config/custom-registry-v2.deployment.prelaunch.json"),
+        artifact("lib/server/custom-launch/generic-launch-contract-v2.ts"),
         artifact("lib/server/custom-launch/generic-launch-projector-v2.ts"),
+        artifact("lib/server/custom-launch/generic-launch-registry-reader-v2.ts"),
       ],
       deploymentArtifactSha256: artifact(
         "config/custom-registry-v2.deployment.prelaunch.json",
@@ -171,16 +268,40 @@ async function fixture() {
       sourceVerificationEvidenceSha256: DIGEST("registry-source-verification"),
     },
   };
-  return { repoRoot, input, files };
+  const options = {
+    repoRoot,
+    hostedEvidenceIdentity: {
+      planArtifactSha256: protectedArtifacts.plan.sha256,
+      adoptionArtifactSha256: protectedArtifacts.adoption.sha256,
+      applyArtifactSha256: protectedArtifacts.apply.sha256,
+      verifyArtifactSha256: protectedArtifacts.verify.sha256,
+      planRepositoryCommit: plan.repositoryCommit,
+      planRepositoryTree: plan.repositoryTree,
+      planSha256: plan.planSha256,
+      orderSha256: plan.orderSha256,
+      finalCatalogSha256: catalog,
+    },
+    gitBlobIdentity: async (_root, commit, path) => {
+      assert.equal(commit, websiteSource.commit);
+      const value = artifact(path);
+      return {
+        mode: "100644",
+        type: "blob",
+        oid: value.gitBlobOid,
+        contentSha256: value.sha256,
+      };
+    },
+  };
+  return { repoRoot, input, files, options, protectedArtifacts };
 }
 
 test("derives all six content-addressed bindings and the runtime contract", async (t) => {
-  const { repoRoot, input } = await fixture();
+  const { repoRoot, input, options } = await fixture();
   t.after(() => rm(repoRoot, { recursive: true, force: true }));
-  const result = await deriveGenericLaunchReadModelContractV2(input, { repoRoot });
+  const result = await deriveGenericLaunchReadModelContractV2(input, options);
   const again = await deriveGenericLaunchReadModelContractV2(
     JSON.parse(JSON.stringify(input)),
-    { repoRoot },
+    options,
   );
 
   assert.equal(canonicalJson(result), canonicalJson(again));
@@ -217,18 +338,18 @@ test("derives all six content-addressed bindings and the runtime contract", asyn
 });
 
 test("fails closed while the Approval release handoff is unresolved", async (t) => {
-  const { repoRoot, input } = await fixture();
+  const { repoRoot, input, options } = await fixture();
   t.after(() => rm(repoRoot, { recursive: true, force: true }));
   input.approvalRelease.status = "pending";
   input.approvalRelease.liveDeploymentEvidenceSha256 = null;
   await assert.rejects(
-    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    deriveGenericLaunchReadModelContractV2(input, options),
     /Approval release|live deployment/u,
   );
 });
 
 test("rejects a local artifact whose bytes drift after review", async (t) => {
-  const { repoRoot, input } = await fixture();
+  const { repoRoot, input, options } = await fixture();
   t.after(() => rm(repoRoot, { recursive: true, force: true }));
   await writeFile(
     join(repoRoot, "lib/server/custom-launch/generic-launch-read-v2.ts"),
@@ -236,7 +357,7 @@ test("rejects a local artifact whose bytes drift after review", async (t) => {
     "utf8",
   );
   await assert.rejects(
-    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    deriveGenericLaunchReadModelContractV2(input, options),
     /artifact bytes do not match/u,
   );
 
@@ -251,19 +372,17 @@ test("rejects a local artifact whose bytes drift after review", async (t) => {
   await rm(path);
   await symlink(target, path);
   await assert.rejects(
-    deriveGenericLaunchReadModelContractV2(linked.input, {
-      repoRoot: linked.repoRoot,
-    }),
+    deriveGenericLaunchReadModelContractV2(linked.input, linked.options),
     /ELOOP|symbolic link/iu,
   );
 });
 
 test("rejects unsorted, duplicate and escaping artifact inventories", async (t) => {
-  const { repoRoot, input } = await fixture();
+  const { repoRoot, input, options } = await fixture();
   t.after(() => rm(repoRoot, { recursive: true, force: true }));
   input.implementation.artifacts.reverse();
   await assert.rejects(
-    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    deriveGenericLaunchReadModelContractV2(input, options),
     /unique and sorted/u,
   );
 
@@ -273,9 +392,7 @@ test("rejects unsorted, duplicate and escaping artifact inventories", async (t) 
     duplicate.input.queryContract.artifacts[1],
   );
   await assert.rejects(
-    deriveGenericLaunchReadModelContractV2(duplicate.input, {
-      repoRoot: duplicate.repoRoot,
-    }),
+    deriveGenericLaunchReadModelContractV2(duplicate.input, duplicate.options),
     /unique and sorted/u,
   );
 
@@ -283,19 +400,216 @@ test("rejects unsorted, duplicate and escaping artifact inventories", async (t) 
   t.after(() => rm(escaping.repoRoot, { recursive: true, force: true }));
   escaping.input.implementation.artifacts[0].path = "../outside";
   await assert.rejects(
-    deriveGenericLaunchReadModelContractV2(escaping.input, {
-      repoRoot: escaping.repoRoot,
-    }),
+    deriveGenericLaunchReadModelContractV2(escaping.input, escaping.options),
+    /path is (?:invalid|not canonical)/u,
+  );
+});
+
+test("binds every local artifact to its exact HEAD Git blob", async (t) => {
+  const value = await fixture();
+  t.after(() => rm(value.repoRoot, { recursive: true, force: true }));
+  const expected = value.options.gitBlobIdentity;
+  value.options.gitBlobIdentity = async (root, commit, path) => {
+    const identity = await expected(root, commit, path);
+    return path === "lib/server/custom-launch/generic-launch-projector-v2.ts"
+      ? { ...identity, oid: "0".repeat(40) }
+      : identity;
+  };
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(value.input, value.options),
+    /does not match the HEAD Git blob/u,
+  );
+});
+
+test("does not treat an ignored working-tree file as a reviewed Git blob", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "generic-v2-git-blob-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const git = (args) => execFileSync("git", args, {
+    cwd: root,
+    stdio: ["ignore", "pipe", "ignore"],
+    encoding: "utf8",
+  }).trim();
+  git(["init"]);
+  git(["config", "user.name", "Test"]);
+  git(["config", "user.email", "test@example.invalid"]);
+  await writeFile(join(root, ".gitignore"), "ignored.ts\n", "utf8");
+  await writeFile(join(root, "tracked.ts"), "tracked\n", "utf8");
+  await writeFile(join(root, "ignored.ts"), "ignored\n", "utf8");
+  git(["add", ".gitignore", "tracked.ts"]);
+  git(["commit", "-m", "fixture"]);
+  const commit = git(["rev-parse", "HEAD"]);
+  assert.equal(currentGitBlobIdentity(root, commit, "tracked.ts").type, "blob");
+  assert.throws(
+    () => currentGitBlobIdentity(root, commit, "ignored.ts"),
+    /does not contain exact artifact/u,
+  );
+
+  git(["update-index", "--assume-unchanged", "tracked.ts"]);
+  await writeFile(join(root, "tracked.ts"), "drift\n", "utf8");
+  assert.equal(git(["status", "--porcelain"]), "");
+  assert.notEqual(
+    currentGitBlobIdentity(root, commit, "tracked.ts").contentSha256,
+    sha256Bytes(Buffer.from("drift\n", "utf8")),
+  );
+
+  const value = await fixture();
+  t.after(() => rm(value.repoRoot, { recursive: true, force: true }));
+  const artifact = value.input.queryContract.artifacts.find(
+    ({ path }) => path === "lib/server/custom-launch/generic-launch-read-v2.ts",
+  );
+  await writeFile(
+    join(value.repoRoot, artifact.path),
+    "assume-unchanged drift\n",
+    "utf8",
+  );
+  artifact.sha256 = sha256Bytes(Buffer.from("assume-unchanged drift\n", "utf8"));
+  const original = value.options.gitBlobIdentity;
+  value.options.gitBlobIdentity = async (...args) => {
+    const identity = await original(...args);
+    return args[2] === artifact.path
+      ? { ...identity, contentSha256: sha256Bytes(Buffer.from("reader\n")) }
+      : identity;
+  };
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(value.input, value.options),
+    /does not match the HEAD Git blob/u,
+  );
+});
+
+test("rejects semantic artifact substitution and canonical path aliases", async (t) => {
+  const substituted = await fixture();
+  t.after(() => rm(substituted.repoRoot, { recursive: true, force: true }));
+  const replacement = substituted.input.queryContract.artifacts[0];
+  substituted.input.implementation.artifacts[0] = { ...replacement };
+  substituted.input.implementation.artifacts.sort((left, right) =>
+    left.path.localeCompare(right.path));
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(substituted.input, substituted.options),
+    /artifact inventory is not exact/u,
+  );
+
+  const alias = await fixture();
+  t.after(() => rm(alias.repoRoot, { recursive: true, force: true }));
+  alias.input.queryContract.artifacts[0].path =
+    "app/api/custom-launch/generic/v2//launches/[recordHash]/route.ts";
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(alias.input, alias.options),
     /path is invalid/u,
   );
 });
 
+test("requires one exact protected 0001-0005 adoption apply verify chain", async (t) => {
+  const frozen = await fixture();
+  t.after(() => rm(frozen.repoRoot, { recursive: true, force: true }));
+  const frozenRef = frozen.protectedArtifacts.verify;
+  const forged = JSON.parse(await readFile(frozenRef.path, "utf8"));
+  forged.state.catalogSha256 = `0x${"e".repeat(64)}`;
+  const forgedBytes = Buffer.from(`${JSON.stringify(forged)}\n`, "utf8");
+  await writeFile(frozenRef.path, forgedBytes, { mode: 0o600 });
+  frozenRef.sha256 = sha256Bytes(forgedBytes);
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(frozen.input, frozen.options),
+    /do not match the frozen closure/u,
+  );
+
+  const value = await fixture();
+  t.after(() => rm(value.repoRoot, { recursive: true, force: true }));
+  const ref = value.protectedArtifacts.verify;
+  const parsed = JSON.parse(await readFile(ref.path, "utf8"));
+  parsed.state.catalogSha256 = `0x${"f".repeat(64)}`;
+  const bytes = Buffer.from(`${JSON.stringify(parsed)}\n`, "utf8");
+  await writeFile(ref.path, bytes, { mode: 0o600 });
+  ref.sha256 = sha256Bytes(bytes);
+  value.options.hostedEvidenceIdentity.verifyArtifactSha256 = ref.sha256;
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(value.input, value.options),
+    /does not close the 0005 catalog/u,
+  );
+
+  const partial = await fixture();
+  t.after(() => rm(partial.repoRoot, { recursive: true, force: true }));
+  const applyRef = partial.protectedArtifacts.apply;
+  const apply = JSON.parse(await readFile(applyRef.path, "utf8"));
+  apply.state.appliedCount = 4;
+  const applyBytes = Buffer.from(`${JSON.stringify(apply)}\n`, "utf8");
+  await writeFile(applyRef.path, applyBytes, { mode: 0o600 });
+  applyRef.sha256 = sha256Bytes(applyBytes);
+  partial.options.hostedEvidenceIdentity.applyArtifactSha256 = applyRef.sha256;
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(partial.input, partial.options),
+    /not exact through 0005/u,
+  );
+});
+
+test("binds exact Registry profiles and repository identity", async (t) => {
+  const source = await fixture();
+  t.after(() => rm(source.repoRoot, { recursive: true, force: true }));
+  source.input.registryProjection.source.repositoryId = "999";
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(source.input, source.options),
+    /exact Website repository/u,
+  );
+
+  const profile = await fixture();
+  t.after(() => rm(profile.repoRoot, { recursive: true, force: true }));
+  const path = "config/custom-registry-v2.deployment.prelaunch.json";
+  const config = JSON.parse(profile.files[path]);
+  config.profiles.Standard10.protocolFeeBps = 11;
+  const contents = `${JSON.stringify(config)}\n`;
+  profile.files[path] = contents;
+  await writeFile(join(profile.repoRoot, path), contents, "utf8");
+  for (const component of [profile.input.registryProjection]) {
+    const artifact = component.artifacts.find((candidate) => candidate.path === path);
+    artifact.sha256 = sha256Bytes(Buffer.from(contents));
+    artifact.gitBlobOid = artifact.sha256.slice(7, 47);
+    component.deploymentArtifactSha256 = artifact.sha256;
+  }
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(profile.input, profile.options),
+    /does not match the live deployment config/u,
+  );
+
+  const deployment = await fixture();
+  t.after(() => rm(deployment.repoRoot, { recursive: true, force: true }));
+  const deploymentConfig = JSON.parse(deployment.files[path]);
+  deploymentConfig.registry.deploymentBlock = "0";
+  const deploymentContents = `${JSON.stringify(deploymentConfig)}\n`;
+  deployment.files[path] = deploymentContents;
+  await writeFile(join(deployment.repoRoot, path), deploymentContents, "utf8");
+  const deploymentArtifact = deployment.input.registryProjection.artifacts.find(
+    (candidate) => candidate.path === path,
+  );
+  deploymentArtifact.sha256 = sha256Bytes(Buffer.from(deploymentContents));
+  deploymentArtifact.gitBlobOid = deploymentArtifact.sha256.slice(7, 47);
+  deployment.input.registryProjection.deploymentArtifactSha256 =
+    deploymentArtifact.sha256;
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(deployment.input, deployment.options),
+    /deployment block is invalid/u,
+  );
+});
+
+test("binds Approval release to the immutable schema repository ID", async (t) => {
+  const value = await fixture();
+  t.after(() => rm(value.repoRoot, { recursive: true, force: true }));
+  value.input.approvalRelease.source.repositoryId = "203";
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(value.input, value.options),
+    /live release of the frozen schema/u,
+  );
+});
+
+test("canonical JSON rejects lone Unicode surrogates", () => {
+  assert.throws(() => canonicalJson({ value: "\ud800" }), /lone Unicode surrogate/u);
+  assert.equal(canonicalJson({ value: "\ud83d\ude80" }), '{"value":"🚀"}');
+});
+
 test("requires the exact live Registry deployment artifact in the closure", async (t) => {
-  const { repoRoot, input } = await fixture();
+  const { repoRoot, input, options } = await fixture();
   t.after(() => rm(repoRoot, { recursive: true, force: true }));
   input.registryProjection.deploymentArtifactSha256 = DIGEST("other");
   await assert.rejects(
-    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    deriveGenericLaunchReadModelContractV2(input, options),
     /deployment artifact is not in the projection closure/u,
   );
 
@@ -303,19 +617,42 @@ test("requires the exact live Registry deployment artifact in the closure", asyn
   t.after(() => rm(matrixDrift.repoRoot, { recursive: true, force: true }));
   matrixDrift.input.registryProjection.sourceArtifactSha256 = DIGEST("drift");
   await assert.rejects(
-    deriveGenericLaunchReadModelContractV2(matrixDrift.input, {
-      repoRoot: matrixDrift.repoRoot,
-    }),
+    deriveGenericLaunchReadModelContractV2(matrixDrift.input, matrixDrift.options),
     /does not match the live deployment config/u,
+  );
+
+  const raced = await fixture();
+  t.after(() => rm(raced.repoRoot, { recursive: true, force: true }));
+  const deploymentPath =
+    "config/custom-registry-v2.deployment.prelaunch.json";
+  let deploymentReads = 0;
+  raced.options.readFile = async (path) => {
+    if (path.endsWith(deploymentPath)) {
+      deploymentReads += 1;
+      if (deploymentReads === 2) {
+        return Buffer.from(
+          raced.files[deploymentPath].replace(
+            '"protocolFeeBps":10',
+            '"protocolFeeBps":11',
+          ),
+          "utf8",
+        );
+      }
+    }
+    return readFile(path);
+  };
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(raced.input, raced.options),
+    /changed during derivation/u,
   );
 });
 
 test("binds generation-two routes and a clean exact Website checkout", async (t) => {
-  const { repoRoot, input } = await fixture();
+  const { repoRoot, input, options } = await fixture();
   t.after(() => rm(repoRoot, { recursive: true, force: true }));
   input.queryContract.feedPath = "/api/custom-launch/generic/v1/launches";
   await assert.rejects(
-    deriveGenericLaunchReadModelContractV2(input, { repoRoot }),
+    deriveGenericLaunchReadModelContractV2(input, options),
     /query paths are invalid/u,
   );
 
@@ -323,7 +660,7 @@ test("binds generation-two routes and a clean exact Website checkout", async (t)
   t.after(() => rm(checkout.repoRoot, { recursive: true, force: true }));
   await assert.rejects(
     deriveGenericLaunchReadModelContractV2(checkout.input, {
-      repoRoot: checkout.repoRoot,
+      ...checkout.options,
       gitIdentity: () => ({ commit: "9".repeat(40), tree: "8".repeat(40) }),
     }),
     /does not match the checkout/u,


### PR DESCRIPTION
## Summary
- add the content-addressed Generic Launch V2 read-model contract generator
- bind exact Website HEAD blobs, hosted projection migration evidence, Approval release identity, and Registry V2 live projection
- keep Approval unresolved fail-closed until the final live handoff

## Exact source
- base: 91ec373124a863221e1f7930dfd7de6e60fcb8bf
- head: 58f31772a907b7544dcccb0d47a7b447ea325c52
- tree: 73063878f2a88f68c38d162d658460ae5e304138

## Validation
- independent audit: GO, P0/P1/P2/P3 = 0
- focused generator: 14/14
- classifier: 14/14
- production workflow contract: 6/6
- Custom V2 composed: 39/39 Node, 98/98 Vitest, production build green
- typecheck, targeted ESLint, diff-check green

Public Generic V2 activation remains dark; this PR adds source derivation and verification only.