### PR TITLE
Bound repeated dRPC launch catalog reads

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -693,6 +693,19 @@ jobs:
               Number.isSafeInteger(totalPages) &&
               totalPages === Math.ceil(total / 20);
           }
+          function exactCurrentLaunchIdentity(response) {
+            const launchIdentity = response.body?.dataQuality?.launchIdentity;
+            return launchIdentity?.status === "current" &&
+              launchIdentity.canonical === "current" &&
+              launchIdentity.custom === "current" &&
+              Number.isSafeInteger(launchIdentity.ageMs) &&
+              launchIdentity.ageMs >= 0 &&
+              launchIdentity.ageMs < 60_000 &&
+              positiveInteger.test(String(launchIdentity.asOfBlock ?? "")) &&
+              positiveInteger.test(
+                String(launchIdentity.referenceBlock ?? ""),
+              );
+          }
           function exactExploreIdentity(token) {
             if (typeof token?.id !== "string" || token.id.trim().length === 0) {
               return null;
@@ -829,7 +842,8 @@ jobs:
             highest.body?.sort !== "market-cap" ||
             highest.body?.sortMetric !== "fdv" ||
             highestTokens.length < 1 ||
-            !exactExplorePage(highest, highestTokens)
+            !exactExplorePage(highest, highestTokens) ||
+            !exactCurrentLaunchIdentity(highest)
           ) {
             throw new Error("Highest FDV is not ready");
           }
@@ -844,7 +858,8 @@ jobs:
             newest.body?.status !== "ready" ||
             newest.body?.sort !== "newest" ||
             newestTokens.length < 1 ||
-            !exactExplorePage(newest, newestTokens)
+            !exactExplorePage(newest, newestTokens) ||
+            !exactCurrentLaunchIdentity(newest)
           ) {
             throw new Error("Newest launches are not ready");
           }

--- a/lib/market-data/primary-rpc-launches.server.ts
+++ b/lib/market-data/primary-rpc-launches.server.ts
@@ -30,6 +30,8 @@ import {
 import { buildTokenLinks, sanitizeImageUrl } from "../onchain/metadata";
 import { productionMainnetRpcPrimary } from
   "../onchain/website-rpc-providers.server";
+import type { WebsiteRpcBinding } from
+  "../onchain/website-rpc-providers.server";
 import {
   STOCK_PAIRED_CREATOR_FEE_BPS,
   STOCK_PAIRED_PROGRAMMABLE_FEE_BPS,
@@ -38,6 +40,7 @@ import {
 import type { ExploreEntry, LauncherToken } from "../tokens";
 
 export const PRIMARY_RPC_LAUNCH_CATALOG_BUDGET_MS = 18_000;
+export const PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS = 60_000;
 
 const REQUEST_TIMEOUT_MS = 4_000;
 const LOG_WINDOW_RANGE = 4_096n;
@@ -252,6 +255,129 @@ export type PrimaryRpcLaunchCatalogReaderOptions = Readonly<{
   client?: PrimaryRpcLaunchCatalogClient;
 }>;
 
+type PrimaryRpcLaunchCatalogCacheReadOptions = Readonly<{
+  signal?: AbortSignal;
+}>;
+
+type PrimaryRpcLaunchCatalogCacheRefresh = {
+  readonly controller: AbortController;
+  readonly key: string;
+  waiters: number;
+  promise: Promise<PrimaryRpcExploreEntriesV1>;
+};
+
+type PrimaryRpcLaunchCatalogCacheBinding = Readonly<{
+  endpointCommitment: string;
+}>;
+
+export type PrimaryRpcLaunchCatalogCacheV1 = Readonly<{
+  read(
+    options?: PrimaryRpcLaunchCatalogCacheReadOptions,
+  ): Promise<PrimaryRpcExploreEntriesV1>;
+}>;
+
+export function createPrimaryRpcLaunchCatalogCacheV1<
+  Binding extends PrimaryRpcLaunchCatalogCacheBinding,
+>(
+  reader: (
+    options: PrimaryRpcLaunchCatalogCacheReadOptions,
+    binding: Binding,
+  ) => Promise<PrimaryRpcExploreEntriesV1>,
+  resolveBinding: () => Binding,
+  clock: () => number = Date.now,
+): PrimaryRpcLaunchCatalogCacheV1 {
+  let cached: Readonly<{
+    catalog: PrimaryRpcExploreEntriesV1;
+    key: string;
+  }> | null = null;
+  const refreshes = new Map<string, PrimaryRpcLaunchCatalogCacheRefresh>();
+
+  return Object.freeze({
+    async read(
+      options: PrimaryRpcLaunchCatalogCacheReadOptions = {},
+    ): Promise<PrimaryRpcExploreEntriesV1> {
+      if (options.signal?.aborted) throw catalogCacheAbortError();
+
+      const binding = resolveBinding();
+      const nowMs = clock();
+      if (cached !== null) {
+        const generatedAtMs = Date.parse(cached.catalog.generatedAt);
+        const ageMs = nowMs - generatedAtMs;
+        if (
+          cacheKeyHasCommitment(cached.key, binding.endpointCommitment) &&
+          Number.isFinite(generatedAtMs) &&
+          ageMs >= 0 &&
+          ageMs < PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS
+        ) {
+          return cached.catalog;
+        }
+        cached = null;
+      }
+
+      const refreshKey = binding.endpointCommitment;
+      let refresh = refreshes.get(refreshKey) ?? null;
+      if (refresh === null || refresh.controller.signal.aborted) {
+        const current: PrimaryRpcLaunchCatalogCacheRefresh = {
+          controller: new AbortController(),
+          key: refreshKey,
+          waiters: 0,
+          promise: Promise.resolve(undefined as never),
+        };
+        current.promise = (async () => {
+          try {
+            const catalog = await reader(
+              { signal: current.controller.signal },
+              binding,
+            );
+            if (current.controller.signal.aborted || current.waiters === 0) {
+              throw catalogCacheAbortError();
+            }
+            const completedAtMs = clock();
+            const generatedAtMs = Date.parse(catalog.generatedAt);
+            const ageMs = completedAtMs - generatedAtMs;
+            if (
+              !Number.isFinite(generatedAtMs) ||
+              ageMs < 0 ||
+              ageMs >= PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS
+            ) {
+              throw new PrimaryRpcLaunchCatalogError("integrity", "entries");
+            }
+            cached = Object.freeze({
+              catalog,
+              key: catalogCacheKey(
+                binding.endpointCommitment,
+                generatedAtMs,
+              ),
+            });
+            return catalog;
+          } finally {
+            if (refreshes.get(current.key) === current) {
+              refreshes.delete(current.key);
+            }
+          }
+        })();
+        refreshes.set(refreshKey, current);
+        refresh = current;
+      }
+
+      return await waitForCatalogRefresh(refresh, options.signal);
+    },
+  });
+}
+
+function catalogCacheKey(endpointCommitment: string, timeMs: number): string {
+  return `${endpointCommitment}:${Math.floor(
+    timeMs / PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS,
+  )}`;
+}
+
+function cacheKeyHasCommitment(
+  key: string,
+  endpointCommitment: string,
+): boolean {
+  return key.startsWith(`${endpointCommitment}:`);
+}
+
 type RpcEvent = Readonly<{
   release: ReleaseDefinition;
   source: "launcher" | "eth-launch-coordinator";
@@ -320,8 +446,27 @@ type BoundBlock = Readonly<{
   timestamp: bigint;
 }>;
 
+const primaryRpcLaunchCatalogCache = createPrimaryRpcLaunchCatalogCacheV1(
+  (options, binding) => readPrimaryRpcExploreEntriesUncachedV1({
+    ...options,
+    resolvedBinding: binding,
+  }),
+  resolvePrimaryRpcLaunchCatalogBinding,
+);
+
 export async function readPrimaryRpcExploreEntriesV1(
   options: PrimaryRpcLaunchCatalogReaderOptions = {},
+): Promise<PrimaryRpcExploreEntriesV1> {
+  if (isSharedExploreCatalogRead(options)) {
+    return await primaryRpcLaunchCatalogCache.read({ signal: options.signal });
+  }
+  return await readPrimaryRpcExploreEntriesUncachedV1(options);
+}
+
+async function readPrimaryRpcExploreEntriesUncachedV1(
+  options: PrimaryRpcLaunchCatalogReaderOptions & Readonly<{
+    resolvedBinding?: WebsiteRpcBinding;
+  }>,
 ): Promise<PrimaryRpcExploreEntriesV1> {
   const budget = createCatalogBudget(options.signal);
   const signal = budget.signal;
@@ -337,6 +482,7 @@ export async function readPrimaryRpcExploreEntriesV1(
     const client = options.client ?? createPrimaryRpcClient(
       options.environment,
       signal,
+      options.resolvedBinding,
     );
     const now = options.now ?? new Date();
 
@@ -430,6 +576,62 @@ export async function readPrimaryRpcExploreEntriesV1(
   }
 }
 
+function isSharedExploreCatalogRead(
+  options: PrimaryRpcLaunchCatalogReaderOptions,
+): boolean {
+  return options.requestedTokenAddress === undefined &&
+    options.environment === undefined &&
+    options.client === undefined &&
+    options.now === undefined;
+}
+
+function catalogCacheAbortError(): PrimaryRpcLaunchCatalogError {
+  return new PrimaryRpcLaunchCatalogError("transport", "initialization");
+}
+
+function resolvePrimaryRpcLaunchCatalogBinding(): WebsiteRpcBinding {
+  try {
+    return productionMainnetRpcPrimary();
+  } catch {
+    throw new PrimaryRpcLaunchCatalogError("configuration", "initialization");
+  }
+}
+
+function waitForCatalogRefresh(
+  refresh: PrimaryRpcLaunchCatalogCacheRefresh,
+  signal: AbortSignal | undefined,
+): Promise<PrimaryRpcExploreEntriesV1> {
+  refresh.waiters += 1;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const beginFinish = () => {
+      if (settled) return false;
+      settled = true;
+      signal?.removeEventListener("abort", onAbort);
+      refresh.waiters -= 1;
+      return true;
+    };
+    const onAbort = () => {
+      if (!beginFinish()) return;
+      reject(catalogCacheAbortError());
+      if (refresh.waiters === 0) refresh.controller.abort();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    void refresh.promise.then(
+      (catalog) => {
+        if (beginFinish()) resolve(catalog);
+      },
+      (error: unknown) => {
+        if (beginFinish()) reject(error);
+      },
+    );
+  });
+}
+
 function emptyCatalog(now: Date, head: BoundBlock): PrimaryRpcExploreEntriesV1 {
   return {
     source: "drpc",
@@ -443,13 +645,11 @@ function emptyCatalog(now: Date, head: BoundBlock): PrimaryRpcExploreEntriesV1 {
 function createPrimaryRpcClient(
   environment: Readonly<Record<string, string | undefined>> | undefined,
   signal: AbortSignal,
+  resolvedBinding?: WebsiteRpcBinding,
 ): PrimaryRpcLaunchCatalogClient {
-  let binding;
-  try {
-    binding = productionMainnetRpcPrimary(environment);
-  } catch {
-    throw new PrimaryRpcLaunchCatalogError("configuration");
-  }
+  const binding = resolvedBinding ?? resolvePrimaryRpcLaunchCatalogBindingFrom(
+    environment,
+  );
   const publicClient = createPublicClient({
     chain: mainnet,
     transport: http(binding.url, {
@@ -502,6 +702,16 @@ function createPrimaryRpcClient(
       });
     },
   };
+}
+
+function resolvePrimaryRpcLaunchCatalogBindingFrom(
+  environment: Readonly<Record<string, string | undefined>> | undefined,
+): WebsiteRpcBinding {
+  try {
+    return productionMainnetRpcPrimary(environment);
+  } catch {
+    throw new PrimaryRpcLaunchCatalogError("configuration");
+  }
 }
 
 async function scanSparseLogs(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2504,12 +2504,41 @@ export function evaluateReadModelOperationsSourceContracts(
   const stagedProfileProbe = stagedBitquerySmokeBlock.indexOf(
     "const profileToken =",
   );
+  const stagedLaunchIdentityContractStart = stagedBitquerySmokeBlock.indexOf(
+    "function exactCurrentLaunchIdentity(response)",
+  );
+  const stagedLaunchIdentityContractEnd = stagedBitquerySmokeBlock.indexOf(
+    "function exactExploreIdentity(token)",
+    stagedLaunchIdentityContractStart,
+  );
+  const stagedLaunchIdentityContractBlock =
+    stagedLaunchIdentityContractStart >= 0 &&
+    stagedLaunchIdentityContractEnd > stagedLaunchIdentityContractStart
+      ? stagedBitquerySmokeBlock.slice(
+          stagedLaunchIdentityContractStart,
+          stagedLaunchIdentityContractEnd,
+        )
+      : "";
+  const stagedLaunchIdentityContract = includesEverySourceFragment(
+    stagedLaunchIdentityContractBlock,
+    [
+      'launchIdentity?.status === "current"',
+      'launchIdentity.canonical === "current"',
+      'launchIdentity.custom === "current"',
+      "Number.isSafeInteger(launchIdentity.ageMs)",
+      "launchIdentity.ageMs >= 0",
+      "launchIdentity.ageMs < 60_000",
+      'positiveInteger.test(String(launchIdentity.asOfBlock ?? ""))',
+      'positiveInteger.test(\n                String(launchIdentity.referenceBlock ?? ""),',
+    ],
+  );
   const stagedBitqueryMarketReadStatusContract =
     stagedCurrentMarketBranch >= 0 &&
     stagedDetailProbe > stagedCurrentMarketBranch &&
     stagedChartProbe > stagedDetailProbe &&
     stagedDegradedMarketBranch > stagedChartProbe &&
     stagedProfileProbe > stagedDegradedMarketBranch &&
+    stagedLaunchIdentityContract &&
     includesEverySourceFragment(stagedBitquerySmokeBlock, [
       "status: response.status",
       "highest.status !== 200",
@@ -2523,6 +2552,17 @@ export function evaluateReadModelOperationsSourceContracts(
       "exactExplorePage(response, tokens) &&",
       "exactExplorePage(highest, highestTokens)",
       "exactExplorePage(newest, newestTokens)",
+      "function exactCurrentLaunchIdentity(response)",
+      'launchIdentity?.status === "current"',
+      'launchIdentity.canonical === "current"',
+      'launchIdentity.custom === "current"',
+      "Number.isSafeInteger(launchIdentity.ageMs)",
+      "launchIdentity.ageMs >= 0",
+      "launchIdentity.ageMs < 60_000",
+      'positiveInteger.test(String(launchIdentity.asOfBlock ?? ""))',
+      'positiveInteger.test(\n                String(launchIdentity.referenceBlock ?? ""),',
+      "!exactCurrentLaunchIdentity(highest)",
+      "!exactCurrentLaunchIdentity(newest)",
       "response.body?.page === 1",
       "response.body?.pageSize === 20",
       "total >= tokens.length",
@@ -2797,6 +2837,58 @@ export function evaluateReadModelOperationsSourceContracts(
       "...(marketTransportFailure === null &&\n" +
         "              dataQuality.valuation.asOfTime",
     ]);
+  const primaryRpcLaunchCatalogCacheStart =
+    primaryRpcLaunchCatalog.indexOf(
+      "export function createPrimaryRpcLaunchCatalogCacheV1",
+    );
+  const primaryRpcLaunchCatalogCacheEnd = primaryRpcLaunchCatalog.indexOf(
+    "function catalogCacheKey(",
+    primaryRpcLaunchCatalogCacheStart,
+  );
+  const primaryRpcLaunchCatalogCacheBlock =
+    primaryRpcLaunchCatalogCacheStart >= 0 &&
+    primaryRpcLaunchCatalogCacheEnd > primaryRpcLaunchCatalogCacheStart
+      ? primaryRpcLaunchCatalog.slice(
+          primaryRpcLaunchCatalogCacheStart,
+          primaryRpcLaunchCatalogCacheEnd,
+        )
+      : "";
+  const primaryRpcLaunchCatalogCacheContract =
+    primaryRpcLaunchCatalog.includes(
+      "export const PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS = 60_000;",
+    ) &&
+    includesEverySourceFragment(primaryRpcLaunchCatalogCacheBlock, [
+      "const refreshes = new Map<string, PrimaryRpcLaunchCatalogCacheRefresh>();",
+      "const binding = resolveBinding();",
+      "const generatedAtMs = Date.parse(cached.catalog.generatedAt);",
+      "cacheKeyHasCommitment(cached.key, binding.endpointCommitment)",
+      "Number.isFinite(generatedAtMs)",
+      "ageMs >= 0",
+      "ageMs < PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS",
+      "cached = null;",
+      "const refreshKey = binding.endpointCommitment;",
+      "let refresh = refreshes.get(refreshKey) ?? null;",
+      "refreshes.set(refreshKey, current);",
+      "const catalog = await reader(",
+      "const completedAtMs = clock();",
+      "const generatedAtMs = Date.parse(catalog.generatedAt);",
+      'throw new PrimaryRpcLaunchCatalogError("integrity", "entries");',
+      "key: catalogCacheKey(",
+      "binding.endpointCommitment,",
+      "return await waitForCatalogRefresh(refresh, options.signal);",
+    ]) &&
+    (primaryRpcLaunchCatalogCacheBlock.match(
+      /ageMs < PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS/gu,
+    )?.length ?? 0) === 1 &&
+    (primaryRpcLaunchCatalogCacheBlock.match(
+      /ageMs >= PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS/gu,
+    )?.length ?? 0) === 1 &&
+    !primaryRpcLaunchCatalogCacheBlock.includes("catch (");
+  check(
+    "ops-primary-rpc-launch-catalog-cache-contract",
+    primaryRpcLaunchCatalogCacheContract,
+    "the dRPC launch catalog cache is commitment-bound, singleflight, fresh for less than 60 seconds, and never serves stale data",
+  );
   check(
     "ops-public-provider-split-source-contract",
     exactEmptyEnvironmentKey(environmentExample, "BITQUERY_OAUTH_TOKEN") &&

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -127,6 +127,12 @@ test("Custom-only changes do not invoke the public data smoke", () => {
   assert.match(smoke, /exactExplorePage\(newest, newestTokens\)/u);
   assert.match(
     smoke,
+    /function exactCurrentLaunchIdentity\(response\)[\s\S]*launchIdentity\?\.status === "current"[\s\S]*launchIdentity\.canonical === "current"[\s\S]*launchIdentity\.custom === "current"[\s\S]*Number\.isSafeInteger\(launchIdentity\.ageMs\)[\s\S]*launchIdentity\.ageMs >= 0[\s\S]*launchIdentity\.ageMs < 60_000[\s\S]*positiveInteger\.test\(String\(launchIdentity\.asOfBlock \?\? ""\)\)[\s\S]*String\(launchIdentity\.referenceBlock \?\? ""\)/u,
+  );
+  assert.match(smoke, /!exactCurrentLaunchIdentity\(highest\)/u);
+  assert.match(smoke, /!exactCurrentLaunchIdentity\(newest\)/u);
+  assert.match(
+    smoke,
     /function exactExploreIdentity\(token\)[\s\S]*function exactDegradedLaunchOrder\([\s\S]*highest\.body\?\.total !== newest\.body\?\.total[\s\S]*highestTokens\.length !== newestTokens\.length[\s\S]*new Set\(highestIdentities\)\.size === highestIdentities\.length[\s\S]*identity === newestIdentities\[index\]/u,
   );
   assert.match(

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -827,6 +827,57 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it("pins the dRPC launch catalog cache to one fresh commitment-bound singleflight", () => {
+    const result = evaluateReadModelOperationsSourceContracts(ROOT);
+    expect(result.failures).toEqual([]);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "ops-primary-rpc-launch-catalog-cache-contract",
+          status: "pass",
+        }),
+      ]),
+    );
+  });
+
+  it.each([
+    [
+      "a ten-minute TTL",
+      "export const PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS = 60_000;",
+      "export const PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS = 600_000;",
+    ],
+    [
+      "no literal TTL",
+      "export const PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS = 60_000;\n",
+      "",
+    ],
+    [
+      "an unbound cache hit",
+      "cacheKeyHasCommitment(cached.key, binding.endpointCommitment)",
+      "true",
+    ],
+    [
+      "no shared in-flight refresh",
+      "let refresh = refreshes.get(refreshKey) ?? null;",
+      "let refresh = null;",
+    ],
+    [
+      "a stale cache return",
+      "cached = null;",
+      "return cached.catalog;",
+    ],
+  ])("rejects the dRPC launch catalog cache with %s", (_label, needle, replacement) => {
+    const path = "lib/market-data/primary-rpc-launches.server.ts";
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    expect(source).toContain(needle);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: source.replace(needle, replacement) },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-primary-rpc-launch-catalog-cache-contract",
+    );
+  });
+
   it("accepts the exact Explore transport-unavailable provider taxonomy", () => {
     const path = "app/api/explore/route.ts";
     const route = readFileSync(resolve(ROOT, path), "utf8");
@@ -1134,6 +1185,26 @@ describe("read-model operations source contract", () => {
       "a non-current launch identity",
       'launchIdentity?.status === "current"',
       'launchIdentity?.status !== "unavailable"',
+    ],
+    [
+      "a ten-minute launch identity age",
+      "launchIdentity.ageMs < 60_000",
+      "launchIdentity.ageMs < 600_000",
+    ],
+    [
+      "a non-integer launch identity age",
+      "Number.isSafeInteger(launchIdentity.ageMs)",
+      "Number.isFinite(launchIdentity.ageMs)",
+    ],
+    [
+      "a nullable launch identity block",
+      'positiveInteger.test(String(launchIdentity.asOfBlock ?? ""))',
+      "launchIdentity.asOfBlock !== undefined",
+    ],
+    [
+      "a nullable launch identity reference block",
+      'positiveInteger.test(\n                String(launchIdentity.referenceBlock ?? ""),',
+      "launchIdentity.referenceBlock !== undefined",
     ],
     [
       "an available degraded market read",

--- a/tests/primary-rpc-launch-catalog.test.ts
+++ b/tests/primary-rpc-launch-catalog.test.ts
@@ -18,10 +18,13 @@ import { rpcProviderCommitment } from
   "../lib/data-pipeline/rpc-provider-commitments";
 import {
   PRIMARY_RPC_LAUNCH_CATALOG_BUDGET_MS,
+  PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS,
   PrimaryRpcLaunchCatalogError,
+  createPrimaryRpcLaunchCatalogCacheV1,
   readPrimaryRpcExploreEntriesV1,
   safePrimaryRpcLaunchCatalogError,
   type PrimaryRpcContractRead,
+  type PrimaryRpcExploreEntriesV1,
   type PrimaryRpcLaunchCatalogClient,
   type PrimaryRpcLogQuery,
 } from "../lib/market-data/primary-rpc-launches.server";
@@ -33,6 +36,220 @@ const QUOTE = address(900);
 const RECIPIENT = address(901);
 const CREATOR = address(902);
 const VAULT = address(903);
+
+describe("verified dRPC Explore catalog cache", () => {
+  it("shares one verified catalog across query, sort, and page requests", async () => {
+    const nowMs = 1_800_000_000_001;
+    let reads = 0;
+    const cache = createPrimaryRpcLaunchCatalogCacheV1(async () => {
+      reads += 1;
+      return catalog(reads, nowMs);
+    }, () => cacheBinding(), () => nowMs);
+
+    const queryResult = await cache.read();
+    const sortResult = await cache.read();
+    const pageResult = await cache.read();
+
+    expect(reads).toBe(1);
+    expect(sortResult).toBe(queryResult);
+    expect(pageResult).toBe(queryResult);
+    expect(pageResult).toMatchObject({
+      source: "drpc",
+      asOfBlock: "25650001",
+      asOfBlockHash: bytes32(25_650_001),
+    });
+  });
+
+  it("coalesces concurrent cold requests into one dRPC catalog refresh", async () => {
+    const nowMs = 1_800_000_000_001;
+    let reads = 0;
+    let resolveRead!: (value: PrimaryRpcExploreEntriesV1) => void;
+    const cache = createPrimaryRpcLaunchCatalogCacheV1(() => {
+      reads += 1;
+      return new Promise((resolve) => {
+        resolveRead = resolve;
+      });
+    }, () => cacheBinding(), () => nowMs);
+
+    const newest = cache.read();
+    const highest = cache.read();
+    expect(reads).toBe(1);
+    resolveRead(catalog(1, nowMs));
+
+    await expect(Promise.all([newest, highest])).resolves.toEqual([
+      catalog(1, nowMs),
+      catalog(1, nowMs),
+    ]);
+    expect(reads).toBe(1);
+  });
+
+  it("refreshes dRPC at the exact 60-second TTL boundary", async () => {
+    let nowMs = 1_800_000_000_000;
+    let reads = 0;
+    const cache = createPrimaryRpcLaunchCatalogCacheV1(async () => {
+      reads += 1;
+      return catalog(reads, nowMs);
+    }, () => cacheBinding(), () => nowMs);
+
+    const initial = await cache.read();
+    nowMs += PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS - 1;
+    const fresh = await cache.read();
+    nowMs += 1;
+    const refreshed = await cache.read();
+
+    expect(reads).toBe(2);
+    expect(fresh).toBe(initial);
+    expect(refreshed).not.toBe(initial);
+    expect(refreshed.asOfBlock).toBe("25650002");
+  });
+
+  it("never serves stale data or caches a failed TTL refresh", async () => {
+    let nowMs = 1_800_000_000_000;
+    let reads = 0;
+    const cache = createPrimaryRpcLaunchCatalogCacheV1(async () => {
+      reads += 1;
+      if (reads === 2) {
+        throw new PrimaryRpcLaunchCatalogError("transport", "head");
+      }
+      return catalog(reads, nowMs);
+    }, () => cacheBinding(), () => nowMs);
+
+    await expect(cache.read()).resolves.toEqual(catalog(1, nowMs));
+    nowMs += PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS;
+    await expect(cache.read()).rejects.toMatchObject({
+      category: "transport",
+      phase: "head",
+    });
+    await expect(cache.read()).resolves.toEqual(catalog(3, nowMs));
+
+    expect(reads).toBe(3);
+  });
+
+  it("does not cache a refresh after its only request aborts", async () => {
+    const nowMs = 1_800_000_000_001;
+    let reads = 0;
+    let resolveFirst!: (value: PrimaryRpcExploreEntriesV1) => void;
+    const cache = createPrimaryRpcLaunchCatalogCacheV1(() => {
+      reads += 1;
+      if (reads === 1) {
+        return new Promise((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+      return Promise.resolve(catalog(reads, nowMs));
+    }, () => cacheBinding(), () => nowMs);
+    const controller = new AbortController();
+    const aborted = cache.read({ signal: controller.signal });
+
+    controller.abort();
+    resolveFirst(catalog(1, nowMs));
+    await expect(aborted).rejects.toMatchObject({
+      category: "transport",
+      phase: "initialization",
+    });
+    await Promise.resolve();
+    await expect(cache.read()).resolves.toEqual(catalog(2, nowMs));
+
+    expect(reads).toBe(2);
+  });
+
+  it("keeps a shared fill alive when only one concurrent waiter aborts", async () => {
+    const nowMs = 1_800_000_000_001;
+    let reads = 0;
+    let resolveRead!: (value: PrimaryRpcExploreEntriesV1) => void;
+    const cache = createPrimaryRpcLaunchCatalogCacheV1(() => {
+      reads += 1;
+      return new Promise((resolve) => {
+        resolveRead = resolve;
+      });
+    }, () => cacheBinding(), () => nowMs);
+    const controller = new AbortController();
+
+    const aborted = cache.read({ signal: controller.signal });
+    const active = cache.read();
+    controller.abort();
+    resolveRead(catalog(1, nowMs));
+
+    await expect(aborted).rejects.toMatchObject({
+      category: "transport",
+      phase: "initialization",
+    });
+    await expect(active).resolves.toEqual(catalog(1, nowMs));
+    await expect(cache.read()).resolves.toEqual(catalog(1, nowMs));
+    expect(reads).toBe(1);
+  });
+
+  it("validates the commitment binding before a hit and refreshes on rotation", async () => {
+    const nowMs = 1_800_000_000_001;
+    let reads = 0;
+    let bindingReads = 0;
+    let commitment = bytes32(700);
+    const cache = createPrimaryRpcLaunchCatalogCacheV1(async () => {
+      reads += 1;
+      return catalog(reads, nowMs);
+    }, () => {
+      bindingReads += 1;
+      return cacheBinding(commitment);
+    }, () => nowMs);
+
+    await cache.read();
+    await cache.read();
+    commitment = bytes32(701);
+    const rotated = await cache.read();
+
+    expect(bindingReads).toBe(3);
+    expect(reads).toBe(2);
+    expect(rotated.asOfBlock).toBe("25650002");
+  });
+
+  it("does not cache a cold refresh error and retries the exact failure", async () => {
+    const nowMs = 1_800_000_000_001;
+    let reads = 0;
+    const cache = createPrimaryRpcLaunchCatalogCacheV1(async () => {
+      reads += 1;
+      if (reads < 3) {
+        throw new PrimaryRpcLaunchCatalogError("transport", "logs");
+      }
+      return catalog(reads, nowMs);
+    }, () => cacheBinding(), () => nowMs);
+
+    await expect(cache.read()).rejects.toMatchObject({
+      category: "transport",
+      phase: "logs",
+    });
+    await expect(cache.read()).rejects.toMatchObject({
+      category: "transport",
+      phase: "logs",
+    });
+    await expect(cache.read()).resolves.toEqual(catalog(3, nowMs));
+    expect(reads).toBe(3);
+  });
+
+  it.each([
+    ["future", 1],
+    ["60 seconds old", -PRIMARY_RPC_LAUNCH_CATALOG_CACHE_TTL_MS],
+  ] as const)(
+    "fails closed instead of serving a %s generatedAt",
+    async (_label, generatedAtOffsetMs) => {
+      const nowMs = 1_800_000_000_001;
+      let reads = 0;
+      const cache = createPrimaryRpcLaunchCatalogCacheV1(async () => {
+        reads += 1;
+        return catalog(reads, nowMs + generatedAtOffsetMs);
+      }, () => cacheBinding(), () => nowMs);
+
+      await expect(cache.read()).rejects.toMatchObject({
+        category: "integrity",
+        phase: "entries",
+      });
+      await expect(cache.read()).rejects.toMatchObject({
+        category: "integrity",
+        phase: "entries",
+      });
+      expect(reads).toBe(2);
+    },
+  );
+});
 
 type FixtureRelease = Readonly<{
   launcher: `0x${string}`;
@@ -719,4 +936,22 @@ function address(value: number): `0x${string}` {
 
 function bytes32(value: bigint | number): `0x${string}` {
   return `0x${BigInt(value).toString(16).padStart(64, "0")}`;
+}
+
+function catalog(
+  sequence: number,
+  generatedAtMs = 1_800_000_000_000 + sequence,
+): PrimaryRpcExploreEntriesV1 {
+  const block = 25_650_000 + sequence;
+  return Object.freeze({
+    source: "drpc" as const,
+    generatedAt: new Date(generatedAtMs).toISOString(),
+    asOfBlock: String(block),
+    asOfBlockHash: bytes32(block),
+    entries: Object.freeze([]),
+  });
+}
+
+function cacheBinding(endpointCommitment = bytes32(700)) {
+  return Object.freeze({ endpointCommitment });
 }


### PR DESCRIPTION
## Outcome
- share one fully verified dRPC Explore catalog for less than 60 seconds across query, sort, and pagination reads in a warm instance
- coalesce concurrent fills per endpoint commitment
- never cache requested-token reads, errors, aborts, expired snapshots, or stale refresh failures
- bind the 60-second no-stale contract in operations tests and the staged Website smoke

## Scope
No secondary provider, identity fallback, stale-if-error, Bitquery launch source, environment change, or funding change.

## Validation
- 250 focused runtime and operations tests
- workflow contract 7/7
- operations source gate
- typecheck, scoped ESLint, actionlint, candidate-neutrality, diff-check, and gitleaks
- independent exact-tree review: no P0/P1