### PR TITLE
Fix claim feedback and Explore default

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -6,13 +6,14 @@ import { Suspense } from "react";
 import { GET as readExploreResponse } from "@/app/api/explore/route";
 import { ExploreView } from "@/components/explore-view";
 import type { ExploreInitialResponse } from "@/components/explore-view";
+import { DEFAULT_EXPLORE_VIEW_SORT } from "@/lib/explore-defaults";
 
 export const dynamic = "force-dynamic";
 
 const INITIAL_EXPLORE_TIMEOUT_MS = 12_000;
-const INITIAL_EXPLORE_QUERY = new URLSearchParams({
+export const INITIAL_EXPLORE_QUERY = new URLSearchParams({
   q: "",
-  sort: "newest",
+  sort: DEFAULT_EXPLORE_VIEW_SORT,
   page: "1",
   limit: "9",
 }).toString();

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -37,6 +37,7 @@ import {
   type ExploreValuation,
   type ValuedExploreEntry,
 } from "@/lib/explore-financial-data";
+import { DEFAULT_EXPLORE_VIEW_SORT } from "@/lib/explore-defaults";
 import {
   isTokenMarketDataV1,
   marketDataStatusLabel,
@@ -1576,7 +1577,7 @@ export function ExploreView({
   const [query, setQuery] = useState("");
   const normalizedQuery = query.trim();
   const [debouncedQuery, setDebouncedQuery] = useState("");
-  const [sort, setSort] = useState<TokenSort>("newest");
+  const [sort, setSort] = useState<TokenSort>(DEFAULT_EXPLORE_VIEW_SORT);
   const [socialFilter, setSocialFilter] = useState<ExploreSocialFilter>("all");
   const [modelFilter, setModelFilter] = useState<ExploreModelFilter>("all");
   const [currentPage, setCurrentPage] = useState(1);
@@ -2083,7 +2084,10 @@ export function ExploreView({
             {hasPublicTokens ? (
               <div className="token-section-heading">
                 <h2 className="sr-only">Launches</h2>
-                <div className="token-toolbar">
+                <div
+                  className="token-toolbar"
+                  inert={loadingOnly ? true : undefined}
+                >
                   <div
                     className="token-search liquid-glass-control"
                     role="search"

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -387,6 +387,9 @@ const walletChangedBeforeSubmission =
   "The connected wallet changed before submission";
 const insufficientNetworkFee =
   "This wallet needs more ETH to cover the network fee";
+const transactionCancelledInWallet = "Transaction cancelled in wallet";
+const creatorClaimNotSubmitted =
+  "The claim status could not be confirmed. Check your wallet activity before trying again.";
 
 export function profileCreatorClaimErrorMessage(error: unknown) {
   if (
@@ -399,11 +402,14 @@ export function profileCreatorClaimErrorMessage(error: unknown) {
   if (
     error instanceof Error &&
     (error.message === walletChangedBeforeSubmission ||
-      error.message === insufficientNetworkFee)
+      error.message === insufficientNetworkFee ||
+      error.message === transactionCancelledInWallet)
   ) {
-    return error.message;
+    return error.message === transactionCancelledInWallet
+      ? "Transaction cancelled. Your rewards are still available to claim."
+      : error.message;
   }
-  return "The creator claim was not completed. Check your wallet and try again.";
+  return creatorClaimNotSubmitted;
 }
 
 export function profileRewardActionErrorMessage(error: unknown) {

--- a/lib/explore-defaults.ts
+++ b/lib/explore-defaults.ts
@@ -1,0 +1,3 @@
+import type { ExploreSort } from "@/lib/onchain/types";
+
+export const DEFAULT_EXPLORE_VIEW_SORT = "market-cap" satisfies ExploreSort;

--- a/tests/explore-page-ssr.test.ts
+++ b/tests/explore-page-ssr.test.ts
@@ -4,13 +4,24 @@ vi.mock("@/app/api/explore/route", () => ({ GET: vi.fn() }));
 vi.mock("@/components/explore-view", () => ({ ExploreView: () => null }));
 vi.mock("next/headers", () => ({ headers: vi.fn() }));
 
-import { readInitialExploreWithinDeadline } from "../app/explore/page";
+import {
+  INITIAL_EXPLORE_QUERY,
+  readInitialExploreWithinDeadline,
+} from "../app/explore/page";
+import { DEFAULT_EXPLORE_VIEW_SORT } from "../lib/explore-defaults";
 
 afterEach(() => {
   vi.useRealTimers();
 });
 
 describe("Explore initial server read", () => {
+  it("starts with the highest available FDV ranking", () => {
+    const query = new URLSearchParams(INITIAL_EXPLORE_QUERY);
+
+    expect(DEFAULT_EXPLORE_VIEW_SORT).toBe("market-cap");
+    expect(query.get("sort")).toBe(DEFAULT_EXPLORE_VIEW_SORT);
+  });
+
   it("returns at the total deadline and safely consumes the aborted read", async () => {
     vi.useFakeTimers();
     let readSignal: AbortSignal | undefined;

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -29,6 +29,10 @@ describe("Explore UI contract", () => {
       "handledInitialExploreRequestKey(initialState, requestKey)",
     );
     expect(source).toContain("enabled: !preview && !loadingOnly");
+    expect(source).toContain(
+      "useState<TokenSort>(DEFAULT_EXPLORE_VIEW_SORT)",
+    );
+    expect(source).toContain("inert={loadingOnly ? true : undefined}");
   });
 
   it("keeps sort, socials and model choices in one persistent disclosure", () => {

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -123,7 +123,19 @@ describe("profile action error copy", () => {
         ),
       ),
     ).toBe(
-      "The creator claim was not completed. Check your wallet and try again.",
+      "The claim status could not be confirmed. Check your wallet activity before trying again.",
+    );
+    expect(
+      profileCreatorClaimErrorMessage(
+        new Error("Transaction cancelled in wallet"),
+      ),
+    ).toBe(
+      "Transaction cancelled. Your rewards are still available to claim.",
+    );
+    expect(
+      profileCreatorClaimErrorMessage(new Error("private provider detail")),
+    ).toBe(
+      "The claim status could not be confirmed. Check your wallet activity before trying again.",
     );
   });
 


### PR DESCRIPTION
## Summary
- show a precise wallet-cancellation message while keeping unknown claim status fail-safe
- make Highest FDV the shared server/client Explore default
- prevent the streamed loading toolbar from accepting state that disappears on remount

## Validation
- 165 independent relevant tests pass
- typecheck and scoped ESLint pass
- production build and bundle scan pass
- two independent exact-commit reviews report no P0/P1 blockers