### PR TITLE
Polish Explore and profile loading

### DIFF
--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -47,14 +47,6 @@
   text-wrap: balance;
 }
 
-.pageHeading h1 span {
-  display: block;
-  margin-inline: auto;
-  max-width: 100%;
-  text-align: center;
-  width: max-content;
-}
-
 .runnersSection {
   padding: 0 0 80px;
   position: relative;
@@ -284,30 +276,13 @@
   width: 18px;
 }
 
-.resultLabel {
-  color: var(--explore-ivory-muted);
-  font-size: 13px;
-  font-variant-numeric: tabular-nums;
-  line-height: 1.4;
-  margin: 12px auto 0;
-  min-height: 19px;
-  text-align: start;
-  width: min(100%, 1040px);
-}
-
-.resultLabel:focus-visible {
-  border-radius: 4px;
-  outline: 2px solid var(--explore-ivory);
-  outline-offset: 4px;
-}
-
 .runnerGrid {
   align-items: stretch;
   display: grid;
-  gap: 24px 20px;
+  gap: 22px 18px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   margin: 24px auto 0;
-  max-width: 1040px;
+  max-width: 980px;
   width: 100%;
 }
 
@@ -316,7 +291,7 @@
   backdrop-filter: blur(24px) saturate(1.08);
   background: rgba(248, 240, 233, 0.1);
   border: 0;
-  border-radius: 24px;
+  border-radius: 22px;
   box-shadow: 0 18px 54px rgba(1, 1, 3, 0.26);
   display: flex;
   flex-direction: column;
@@ -352,7 +327,7 @@
   aspect-ratio: 1;
   background: #010103;
   border: 0;
-  border-radius: 18px;
+  border-radius: 16px;
   box-shadow: none;
   contain: paint;
   isolation: isolate;
@@ -377,9 +352,9 @@
 
 .runnerBody {
   flex: 1 1 auto;
-  min-height: 118px;
+  min-height: 108px;
   min-width: 0;
-  padding: 18px 12px 8px;
+  padding: 16px 11px 7px;
 }
 
 .runnerHeading {
@@ -390,7 +365,7 @@
 
 .runnerHeading h3 {
   color: var(--explore-ivory);
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 570;
   letter-spacing: -0.035em;
   line-height: 1.15;
@@ -517,70 +492,8 @@
 }
 
 .loadingState {
+  min-height: clamp(280px, 46svh, 520px);
   width: 100%;
-}
-
-.skeletonCard {
-  min-height: 0;
-}
-
-.skeletonArt {
-  background: rgba(255, 253, 249, 0.07);
-}
-
-.skeletonBody {
-  min-height: 118px;
-}
-
-.skeletonTitle,
-.skeletonDescription,
-.skeletonDescriptionShort,
-.skeletonCategory,
-.skeletonMeta,
-.skeletonSocial {
-  background: rgba(255, 253, 249, 0.08);
-  border-radius: 6px;
-  display: block;
-}
-
-.skeletonTitle {
-  height: 24px;
-  width: 52%;
-}
-
-.skeletonDescription {
-  height: 12px;
-  margin-top: 16px;
-  width: 82%;
-}
-
-.skeletonDescriptionShort {
-  height: 12px;
-  margin-top: 8px;
-  width: 64%;
-}
-
-.skeletonMetaRow {
-  flex-wrap: nowrap;
-  gap: 8px;
-}
-
-.skeletonCategory {
-  height: 10px;
-  margin-inline-start: 4px;
-  width: 46px;
-}
-
-.skeletonMeta {
-  height: 10px;
-  width: 72px;
-}
-
-.skeletonSocial {
-  border-radius: 50%;
-  height: 24px;
-  margin-inline-start: auto;
-  width: 24px;
 }
 
 .messageState {
@@ -746,7 +659,7 @@
 @media (max-width: 900px) {
   .runnerGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    max-width: 720px;
+    max-width: 680px;
   }
 }
 
@@ -775,10 +688,6 @@
     max-width: 16ch;
     overflow-wrap: break-word;
     white-space: normal;
-  }
-
-  .pageHeading h1 span {
-    width: auto;
   }
 
   .runnersSection {
@@ -814,7 +723,8 @@
 
   .runnersIntro :global(.token-filter) {
     align-self: start;
-    width: 104px;
+    min-width: 122px;
+    width: auto;
   }
 
   .runnersIntro :global(.token-filter[open]) {
@@ -847,15 +757,11 @@
     justify-self: center;
   }
 
-  .resultLabel {
-    margin-top: 12px;
-  }
-
   .runnerGrid {
     gap: 18px;
     grid-template-columns: 1fr;
     margin-top: 18px;
-    max-width: 560px;
+    max-width: 520px;
   }
 
   .runnerCard {
@@ -869,18 +775,18 @@
   .runnerHitArea {
     display: grid;
     flex: none;
-    grid-template-columns: 112px minmax(0, 1fr);
+    grid-template-columns: 104px minmax(0, 1fr);
   }
 
   .runnerArt {
     align-self: start;
     border-radius: 16px;
-    width: 112px;
+    width: 104px;
   }
 
   .runnerBody {
     align-self: stretch;
-    min-height: 112px;
+    min-height: 104px;
     padding: 12px 12px 8px 16px;
   }
 
@@ -905,25 +811,6 @@
   .runnerSocialLink {
     height: 44px;
     width: 44px;
-  }
-
-  .skeletonCard {
-    display: flex;
-  }
-
-  .skeletonHitArea {
-    display: grid;
-    grid-template-columns: 112px minmax(0, 1fr);
-  }
-
-  .skeletonHitArea .skeletonArt {
-    align-self: start;
-    width: 112px;
-  }
-
-  .skeletonBody {
-    min-height: 112px;
-    padding: 16px 12px 8px 16px;
   }
 
   .emptyState {
@@ -963,13 +850,11 @@
     font-size: clamp(38px, 11vw, 44px);
   }
 
-  .runnerHitArea,
-  .skeletonHitArea {
+  .runnerHitArea {
     grid-template-columns: 104px minmax(0, 1fr);
   }
 
-  .runnerArt,
-  .skeletonHitArea .skeletonArt {
+  .runnerArt {
     width: 104px;
   }
 
@@ -1016,22 +901,11 @@
     gap: 8px;
   }
 
-  .runnersIntro :global(.token-filter) {
-    width: 48px;
-  }
-
-  .runnersIntro :global(.token-filter summary) {
-    padding: 0;
-    width: 48px;
-  }
-
-  .runnerHitArea,
-  .skeletonHitArea {
+  .runnerHitArea {
     grid-template-columns: 96px minmax(0, 1fr);
   }
 
-  .runnerArt,
-  .skeletonHitArea .skeletonArt {
+  .runnerArt {
     width: 96px;
   }
 
@@ -1055,7 +929,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .revealedGrid .runnerCard {
-    animation: explore-card-reveal 440ms cubic-bezier(0.32, 0.72, 0, 1) both;
+    animation: explore-card-reveal 420ms cubic-bezier(0.32, 0.72, 0, 1) both;
   }
 
   .revealedGrid .runnerCard:nth-child(2) {
@@ -1067,35 +941,17 @@
     animation-delay: 90ms;
   }
 
-  .skeletonArt,
-  .skeletonTitle,
-  .skeletonDescription,
-  .skeletonDescriptionShort,
-  .skeletonCategory,
-  .skeletonMeta,
-  .skeletonSocial {
-    animation: explore-skeleton-breathe 1.2s cubic-bezier(0.32, 0.72, 0, 1)
-      infinite alternate;
-  }
 }
 
 @keyframes explore-card-reveal {
   from {
     opacity: 0;
+    transform: translateY(10px);
   }
 
   to {
     opacity: 1;
-  }
-}
-
-@keyframes explore-skeleton-breathe {
-  from {
-    opacity: 0.56;
-  }
-
-  to {
-    opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1498,43 +1498,6 @@ function TokenLinkIcon({ kind }: { kind: TokenLink["kind"] }) {
   return <XBrandIcon />;
 }
 
-const exploreSkeletonItems = Array.from(
-  { length: EXPLORE_TOKENS_PER_PAGE },
-  (_, index) => index,
-);
-
-function ExploreGridSkeleton() {
-  return (
-    <div
-      className={`${styles.runnerGrid} ${styles.skeletonGrid}`}
-      role="status"
-      aria-label="Loading launches"
-    >
-      {exploreSkeletonItems.map((index) => (
-        <article
-          className={`${styles.runnerCard} ${styles.skeletonCard}`}
-          key={index}
-          aria-hidden="true"
-        >
-          <div className={`${styles.runnerHitArea} ${styles.skeletonHitArea}`}>
-            <div className={`${styles.runnerArt} ${styles.skeletonArt}`} />
-            <div className={`${styles.runnerBody} ${styles.skeletonBody}`}>
-              <span className={styles.skeletonTitle} />
-              <span className={styles.skeletonDescription} />
-              <span className={styles.skeletonDescriptionShort} />
-            </div>
-          </div>
-          <div className={`${styles.runnerMeta} ${styles.skeletonMetaRow}`}>
-            <span className={styles.skeletonCategory} />
-            <span className={styles.skeletonMeta} />
-            <span className={styles.skeletonSocial} />
-          </div>
-        </article>
-      ))}
-    </div>
-  );
-}
-
 function resultRangeLabel(payload: ExplorePayload | null) {
   if (!payload) return "Loading launch index";
   if (payload.status === "not-deployed") return "Explore unavailable";
@@ -1559,9 +1522,6 @@ export function exploreDataQualityMessage(
   }
   if (quality.valuation.status === "stale") {
     return "Prices may be out of date";
-  }
-  if (quality.valuation.status === "unavailable") {
-    return "Market data is temporarily unavailable";
   }
   return null;
 }
@@ -1834,6 +1794,8 @@ export function ExploreView({
       displayState.requestKey !== requestKey);
   const activeFilterCount =
     Number(socialFilter !== "all") + Number(modelFilter !== "all");
+  const activeSortLabel =
+    sortOptions.find((option) => option.id === sort)?.label ?? "Sort";
   const hasPublicTokens =
     displayState.phase !== "ready" ||
     displayState.payload.total > 0 ||
@@ -1852,8 +1814,10 @@ export function ExploreView({
       (displayState.phase === "error" && displayState.requestKey !== requestKey)
     ) {
       return (
-        <div className={styles.loadingState}>
-          <ExploreGridSkeleton />
+        <div className={styles.loadingState} aria-busy="true">
+          <span className="sr-only" role="status">
+            Loading launches
+          </span>
         </div>
       );
     }
@@ -1970,7 +1934,7 @@ export function ExploreView({
                   fill
                   loading={index < 3 ? "eager" : "lazy"}
                   priority={index < 3}
-                  sizes="(max-width: 360px) 96px, (max-width: 420px) 104px, (max-width: 700px) 112px, (max-width: 768px) calc(50vw - 54px), (max-width: 900px) 330px, 313px"
+                  sizes="(max-width: 360px) 96px, (max-width: 700px) 104px, (max-width: 768px) calc(50vw - 54px), (max-width: 900px) 330px, 299px"
                   unoptimized={!canOptimizeTokenImage(imageSource)}
                   draggable={false}
                 />
@@ -2069,10 +2033,7 @@ export function ExploreView({
     <>
       <div className={`${styles.page} explore-page page-width`}>
         <header className={styles.pageHeading}>
-          <h1 aria-label="Explore programmable launches">
-            <span>Explore programmable</span>
-            <span>launches</span>
-          </h1>
+          <h1>Explore Launches</h1>
         </header>
 
         <section
@@ -2140,14 +2101,14 @@ export function ExploreView({
                       aria-controls="explore-filter-panel"
                       aria-label={
                         activeFilterCount === 0
-                          ? "Filter and sort tokens"
-                          : `Filter and sort tokens, ${activeFilterCount} ${
+                          ? `Filter and sort tokens, ${activeSortLabel} selected`
+                          : `Filter and sort tokens, ${activeSortLabel} selected, ${activeFilterCount} ${
                               activeFilterCount === 1 ? "filter" : "filters"
                             } active`
                       }
                     >
                       <SlidersHorizontal aria-hidden="true" size={16} />
-                      <span>Filter</span>
+                      <span>{activeSortLabel}</span>
                       {activeFilterCount > 0 ? (
                         <span
                           className={styles.activeFilterCount}
@@ -2344,11 +2305,7 @@ export function ExploreView({
 
           <p
             ref={resultStatusRef}
-            className={
-              hasPublicTokens && displayState.phase !== "error"
-                ? styles.resultLabel
-                : "sr-only"
-            }
+            className="sr-only"
             role="status"
             aria-live="polite"
             aria-atomic="true"

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -557,8 +557,7 @@
 }
 
 .feePanel,
-.claimablePanel,
-.loadingPanel {
+.claimablePanel {
   min-width: 0;
 }
 
@@ -1246,123 +1245,9 @@
   width: 1px;
 }
 
-.sessionLoading {
-  display: grid;
-  gap: 18px;
+.profileLoadingState {
+  min-height: clamp(420px, 68svh, 680px);
   min-width: 0;
-}
-
-.sessionLoadingHero {
-  align-items: center;
-  display: grid;
-  gap: 16px;
-  grid-template-columns: 56px minmax(0, 1fr);
-  min-height: 64px;
-  min-width: 0;
-}
-
-.sessionLoadingAvatar,
-.sessionLoadingIdentity > span,
-.sessionLoadingWorkspace > span,
-.loadingPanelTitle,
-.loadingPanelTotal,
-.loadingPanelChart,
-.loadingClaimRows > span {
-  background: color-mix(in srgb, var(--surface-soft) 74%, transparent);
-}
-
-.sessionLoadingAvatar {
-  border-radius: 15px;
-  height: 56px;
-  width: 56px;
-}
-
-.sessionLoadingIdentity {
-  display: grid;
-  gap: 8px;
-  min-width: 0;
-}
-
-.sessionLoadingIdentity > span:first-child {
-  border-radius: 8px;
-  height: 30px;
-  max-width: 260px;
-  width: 48%;
-}
-
-.sessionLoadingIdentity > span:last-child {
-  border-radius: 5px;
-  height: 11px;
-  max-width: 145px;
-  width: 28%;
-}
-
-.sessionLoadingWorkspace {
-  background: var(--profile-panel);
-  border: 1px solid var(--profile-line);
-  border-radius: 24px;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  box-shadow: var(--liquid-glass-shadow);
-  display: grid;
-  gap: 8px;
-  grid-template-columns: minmax(0, 1fr) minmax(360px, 0.62fr);
-  min-width: 0;
-  padding: 8px;
-}
-
-.sessionLoadingWorkspace > span {
-  border-radius: 17px;
-  min-height: 470px;
-}
-
-.profileLoading {
-  margin-block-start: 18px;
-  min-width: 0;
-}
-
-.loadingPanel {
-  display: flex;
-  flex-direction: column;
-  min-height: 470px;
-  padding: 20px 22px;
-}
-
-.loadingPanel:last-child {
-  background: var(--profile-subtle);
-  border-radius: 17px;
-  padding: 18px;
-}
-
-.loadingPanelTitle {
-  border-radius: 7px;
-  height: 20px;
-  width: 118px;
-}
-
-.loadingPanelTotal {
-  border-radius: 9px;
-  height: 50px;
-  margin-block-start: 28px;
-  width: min(255px, 66%);
-}
-
-.loadingPanelChart {
-  border-radius: 14px;
-  flex: 1;
-  margin-block-start: 28px;
-  min-height: 210px;
-}
-
-.loadingClaimRows {
-  display: grid;
-  gap: 3px;
-  margin-block-start: 14px;
-}
-
-.loadingClaimRows > span {
-  border-radius: 12px;
-  min-height: 62px;
 }
 
 .accountState {
@@ -1480,18 +1365,8 @@
     );
   }
 
-  .sessionLoadingWorkspace {
-    height: clamp(
-      500px,
-      calc(100svh - var(--header-height) - 132px),
-      680px
-    );
-  }
-
   .feePanel,
-  .claimablePanel,
-  .loadingPanel,
-  .sessionLoadingWorkspace > span {
+  .claimablePanel {
     height: 100%;
     min-height: 0;
   }
@@ -1511,8 +1386,7 @@
 }
 
 @media (max-width: 980px) {
-  .profileWorkspace,
-  .sessionLoadingWorkspace {
+  .profileWorkspace {
     grid-template-columns: minmax(0, 1fr) minmax(340px, 0.68fr);
   }
 
@@ -1527,8 +1401,7 @@
     padding-block: 22px 36px;
   }
 
-  .profileWorkspace,
-  .sessionLoadingWorkspace {
+  .profileWorkspace {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -1541,9 +1414,7 @@
     min-height: 370px;
   }
 
-  .claimablePanel,
-  .loadingPanel,
-  .sessionLoadingWorkspace > span {
+  .claimablePanel {
     min-height: 340px;
   }
 
@@ -1603,8 +1474,7 @@
     padding: 48px 8px 54px;
   }
 
-  .profileWorkspace,
-  .sessionLoadingWorkspace {
+  .profileWorkspace {
     border-radius: 20px;
     padding: 6px;
   }
@@ -1618,8 +1488,7 @@
     padding: 18px 14px 14px;
   }
 
-  .claimablePanel,
-  .loadingPanel:last-child {
+  .claimablePanel {
     border-radius: 15px;
     padding: 16px 12px;
   }
@@ -1686,16 +1555,6 @@
     width: 100%;
   }
 
-  .sessionLoadingHero {
-    gap: 12px;
-    grid-template-columns: 50px minmax(0, 1fr);
-  }
-
-  .sessionLoadingAvatar {
-    border-radius: 13px;
-    height: 50px;
-    width: 50px;
-  }
 }
 
 @media (max-width: 380px) {
@@ -1744,9 +1603,7 @@
   }
 
   .feePanel,
-  .claimablePanel,
-  .loadingPanel,
-  .loadingPanel:last-child {
+  .claimablePanel {
     padding-inline: 11px;
   }
 
@@ -1790,25 +1647,21 @@
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .sessionLoadingAvatar,
-  .sessionLoadingIdentity > span,
-  .sessionLoadingWorkspace > span,
-  .loadingPanelTitle,
-  .loadingPanelTotal,
-  .loadingPanelChart,
-  .loadingClaimRows > span {
-    animation: profile-skeleton-pulse 1.6s ease-in-out infinite;
+  .profileReveal {
+    animation: profile-content-reveal 420ms cubic-bezier(0.32, 0.72, 0, 1)
+      both;
   }
 }
 
-@keyframes profile-skeleton-pulse {
-  0%,
-  100% {
-    opacity: 0.48;
+@keyframes profile-content-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
   }
 
-  50% {
-    opacity: 0.88;
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
@@ -1830,7 +1683,6 @@
 
 @media (forced-colors: active) {
   .profileWorkspace,
-  .sessionLoadingWorkspace,
   .claimablePanel,
   .claimDialogSurface,
   .claimDialogAction {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -2583,8 +2583,27 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     );
   }
 
+  const profileWorkspacePhase = getProfileWorkspacePhase(
+    [
+      scopedOnchainData.status,
+      scopedClassicV3Rewards.status,
+      scopedDeepRewards.status,
+      scopedDeepV3Profile.status,
+      scopedStockPairedRewards.status,
+    ],
+    terminalErrorReady,
+  );
+
+  if (profileWorkspacePhase === "loading") {
+    return (
+      <div className={`${styles.page} page-width`}>
+        <ProfileLoadingState />
+      </div>
+    );
+  }
+
   return (
-    <div className={`${styles.page} page-width`}>
+    <div className={`${styles.page} ${styles.profileReveal} page-width`}>
       <section
         className={`${styles.hero} ${
           editingProfile ? styles.heroEditing : ""
@@ -3446,27 +3465,13 @@ function ProfileSessionLoadingState() {
   return (
     <div className={`${styles.page} page-width`}>
       <section
-        className={styles.sessionLoading}
+        className={styles.profileLoadingState}
         aria-busy="true"
         aria-label="Restoring wallet profile"
       >
         <span className={styles.visuallyHidden} role="status">
           Restoring wallet profile
         </span>
-        <div className={styles.sessionLoadingHero} aria-hidden="true">
-          <span className={styles.sessionLoadingAvatar} />
-          <span className={styles.sessionLoadingIdentity}>
-            <span />
-            <span />
-          </span>
-        </div>
-        <div
-          className={`${styles.sessionLoadingWorkspace} liquid-glass-surface`}
-          aria-hidden="true"
-        >
-          <span />
-          <span />
-        </div>
       </section>
     </div>
   );
@@ -3475,31 +3480,13 @@ function ProfileSessionLoadingState() {
 function ProfileLoadingState() {
   return (
     <section
-      className={styles.profileLoading}
+      className={styles.profileLoadingState}
       aria-busy="true"
       aria-label="Loading profile"
     >
       <span className={styles.visuallyHidden} role="status">
         Loading profile
       </span>
-      <div
-        className={`${styles.profileWorkspace} liquid-glass-surface`}
-        aria-hidden="true"
-      >
-        <div className={styles.loadingPanel}>
-          <span className={styles.loadingPanelTitle} />
-          <span className={styles.loadingPanelTotal} />
-          <span className={styles.loadingPanelChart} />
-        </div>
-        <div className={styles.loadingPanel}>
-          <span className={styles.loadingPanelTitle} />
-          <div className={styles.loadingClaimRows}>
-            {Array.from({ length: profileClaimPageSize }, (_, index) => (
-              <span key={index} />
-            ))}
-          </div>
-        </div>
-      </div>
     </section>
   );
 }

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -33,6 +33,9 @@ describe("Explore UI contract", () => {
       "useState<TokenSort>(DEFAULT_EXPLORE_VIEW_SORT)",
     );
     expect(source).toContain("inert={loadingOnly ? true : undefined}");
+    expect(source).toContain("<h1>Explore Launches</h1>");
+    expect(source).not.toContain("ExploreGridSkeleton");
+    expect(source).toContain('className={styles.loadingState} aria-busy="true"');
   });
 
   it("keeps sort, socials and model choices in one persistent disclosure", () => {
@@ -50,6 +53,10 @@ describe("Explore UI contract", () => {
     );
     expect(source).toContain(
       'Number(socialFilter !== "all") + Number(modelFilter !== "all")',
+    );
+    expect(source).toContain("<span>{activeSortLabel}</span>");
+    expect(source).toContain(
+      'useState<TokenSort>(DEFAULT_EXPLORE_VIEW_SORT)',
     );
     expect(source).not.toMatch(
       /onClick=\{\(\) => \{[\s\S]{0,300}filterRef\.current/s,
@@ -87,7 +94,7 @@ describe("Explore UI contract", () => {
       /\.runnerHeading h3\s*\{[^}]*line-height:\s*1\.15;/s,
     );
     expect(source).toContain(
-      'sizes="(max-width: 360px) 96px, (max-width: 420px) 104px, (max-width: 700px) 112px, (max-width: 768px) calc(50vw - 54px), (max-width: 900px) 330px, 313px"',
+      'sizes="(max-width: 360px) 96px, (max-width: 700px) 104px, (max-width: 768px) calc(50vw - 54px), (max-width: 900px) 330px, 299px"',
     );
     expect(styles).toMatch(
       /\.runnerMarketStatus\s*\{[^}]*color:\s*var\(--explore-ivory-muted\);/s,
@@ -123,6 +130,10 @@ describe("Explore UI contract", () => {
       join(root, "components/explore-view.tsx"),
       "utf8",
     );
+    const styles = readFileSync(
+      join(root, "components/explore-experience.module.css"),
+      "utf8",
+    );
 
     expect(source).toContain("const resultStatusRef");
     expect(source).toContain("ref={resultStatusRef}");
@@ -134,10 +145,10 @@ describe("Explore UI contract", () => {
     expect(source).toContain(
       "resultStatusRef.current?.focus({ preventScroll: true })",
     );
-    expect(source).toContain(
-      'displayState.phase === "error" ? "" : resultRangeLabel(payload)',
-    );
+    expect(source).toContain('className="sr-only"');
+    expect(styles).not.toContain(".resultLabel");
     expect(source).toContain('return "Explore unavailable"');
+    expect(source).not.toContain("Market data is temporarily unavailable");
     expect(source).not.toContain("Loading tokens");
     expect(source).not.toContain("Updating tokens");
     expect(source).not.toContain("Page {activePage} of {pageCount}");

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -1040,10 +1040,8 @@ describe("Explore refresh state", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("shows calm copy while market data is transport-unavailable", () => {
-    expect(exploreDataQualityMessage(unavailableMarketDataQuality)).toBe(
-      "Market data is temporarily unavailable",
-    );
+  it("does not surface a market availability banner", () => {
+    expect(exploreDataQualityMessage(unavailableMarketDataQuality)).toBeNull();
   });
 
   it("retries the first non-USD FDV and returns the second fail-closed", async () => {

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -367,6 +367,24 @@ describe("profile workspace loading state", () => {
       /@media \(max-width: 820px\)[\s\S]*?\.profileWorkspace/,
     );
   });
+
+  it("keeps profile loading visually empty and reveals only resolved content", () => {
+    expect(profileViewSource).toContain(
+      'className={styles.profileLoadingState}',
+    );
+    expect(profileViewSource).toContain(
+      'if (profileWorkspacePhase === "loading")',
+    );
+    expect(profileViewSource).not.toContain("styles.sessionLoadingWorkspace");
+    expect(profileViewSource).not.toContain("styles.loadingPanelTitle");
+    expect(profileExperienceCss).toMatch(
+      /\.profileLoadingState\s*\{[^}]*min-height:/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.profileReveal\s*\{[^}]*animation: profile-content-reveal/s,
+    );
+    expect(profileExperienceCss).not.toContain("profile-skeleton-pulse");
+  });
 });
 
 describe("fee earnings chart", () => {


### PR DESCRIPTION
## Summary
- show Highest FDV as the immediate Explore default and shorten the page heading
- remove visible launch counts, market availability banners, and fake loading cards
- reveal compact resolved cards and the resolved profile with restrained motion
- replace profile skeleton layouts with an empty accessible loading state

## Verification
- 142 focused interface tests pass
- typecheck and full lint pass (37 pre-existing warnings)
- production build and bundle scan pass
- desktop and 390px mobile browser QA pass
- initial Explore HTML contains zero cards and zero skeleton markers
- full interface run: 3071 passed; one unrelated PGlite timeout reran focused 10/10 green