### PR TITLE
Keep launch completion feedback immediate

### DIFF
--- a/components/launch-builder.tsx
+++ b/components/launch-builder.tsx
@@ -177,6 +177,7 @@ const STOCK_PAIRED_DISPLAY_NAMES: Record<string, string> = {
 const LAUNCH_RECEIPT_POLL_ATTEMPTS = 12;
 export const LAUNCH_INDEX_POLL_ATTEMPTS = 18;
 export const PENDING_LAUNCH_STALE_AFTER_MS = 24 * 60 * 60 * 1_000;
+export const LAUNCH_SUCCESS_CELEBRATION_MAX_AGE_MS = 30 * 60 * 1_000;
 const PENDING_LAUNCH_MAX_CLOCK_SKEW_MS = 5 * 60 * 1_000;
 const PENDING_LAUNCH_STORAGE_PREFIX = "programmable.pending-launch.v2";
 const PENDING_LAUNCH_CHANGED_EVENT = "programmable:pending-launch-changed";
@@ -230,6 +231,32 @@ export function launchSubmissionUsesCurrentDraft(
         currentDraftSubmissionHash.toLowerCase() &&
       submittedDraftVersion !== null &&
       currentDraftVersion === submittedDraftVersion,
+  );
+}
+
+export function shouldCelebrateIndexedLaunch({
+  submission,
+  currentDraftSubmissionHash,
+  currentDraftVersion,
+  submittedDraftVersion,
+  nowMs = Date.now(),
+}: {
+  submission: PendingLaunchSubmission;
+  currentDraftSubmissionHash: string;
+  currentDraftVersion: number;
+  submittedDraftVersion: number | null;
+  nowMs?: number;
+}) {
+  const submissionAgeMs = nowMs - submission.submittedAtMs;
+  return (
+    launchSubmissionUsesCurrentDraft(
+      submission.transactionHash,
+      currentDraftSubmissionHash,
+      currentDraftVersion,
+      submittedDraftVersion,
+    ) &&
+    submissionAgeMs >= -PENDING_LAUNCH_MAX_CLOCK_SKEW_MS &&
+    submissionAgeMs < LAUNCH_SUCCESS_CELEBRATION_MAX_AGE_MS
   );
 }
 
@@ -1386,8 +1413,14 @@ function LaunchBuilderFormView({
           submission: confirmedSubmission,
         });
         clearSubmissionPhase();
-        setSuccessOpen(true);
-        setNotice("Token created");
+        const celebrateLaunch = shouldCelebrateIndexedLaunch({
+          submission: confirmedSubmission,
+          currentDraftSubmissionHash,
+          currentDraftVersion: draftVersion.current,
+          submittedDraftVersion,
+        });
+        setSuccessOpen(celebrateLaunch);
+        setNotice(celebrateLaunch ? "Token created" : "");
       } catch (caught) {
         if (caught instanceof DOMException && caught.name === "AbortError") {
           return;
@@ -1407,7 +1440,9 @@ function LaunchBuilderFormView({
     submittedAccount,
     submittedChainId,
     clearSubmissionPhase,
+    currentDraftSubmissionHash,
     setSubmissionPhaseFor,
+    submittedDraftVersion,
     transactionHash,
   ]);
 

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import {
   lazy,
@@ -228,6 +229,60 @@ export function LaunchModelPicker({
     void loadCustomLaunch();
   };
 
+  const customCardContent = (
+    <>
+      <span
+        className={`launch-model-art ${launchExperience.modelArt} ${launchExperience.customArt}`}
+        aria-hidden="true"
+      >
+        <Image
+          className={launchExperience.artImage}
+          src="/brand/create/custom-galaxy-v3.webp"
+          alt=""
+          fill
+          loading="eager"
+          sizes="(max-width: 760px) calc(100vw - 32px), (max-width: 1280px) calc((100vw - 96px) / 2), 560px"
+          priority
+        />
+        <Image
+          className={`${launchExperience.classicLogo} ${launchExperience.customLogo}`}
+          src="/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"
+          alt=""
+          width={1536}
+          height={1536}
+          sizes="128px"
+        />
+      </span>
+      <span
+        className={`launch-model-card-body ${launchExperience.modelBody}`}
+      >
+        <span
+          className={`launch-model-card-heading ${launchExperience.modelHeading}`}
+        >
+          <strong id="launch-model-custom-title">Custom Hook</strong>
+          <small data-status={customLaunchPublicEnabled ? "available" : "review"}>
+            {customLaunchPublicEnabled ? "Available" : "Review required"}
+          </small>
+        </span>
+        <span
+          className={`launch-model-description ${launchExperience.modelDescription}`}
+          id="launch-model-custom-description"
+        >
+          Launch a project only after its exact GitHub revision has been
+          reviewed and approved by Programmable.
+        </span>
+        <span
+          className={`launch-model-action ${launchExperience.modelAction}`}
+        >
+          {customLaunchPublicEnabled
+            ? "Open approved Custom Hook launch"
+            : "View Custom Hook requirements"}
+          <ArrowRight aria-hidden="true" size={16} />
+        </span>
+      </span>
+    </>
+  );
+
   return (
     <div
       className={`launch-model-page page-width ${launchExperience.pickerPage}`}
@@ -254,55 +309,21 @@ export function LaunchModelPicker({
             onFocus={preloadCustomLaunch}
             onClick={() => onChoose("custom")}
           >
-            <span
-              className={`launch-model-art ${launchExperience.modelArt} ${launchExperience.customArt}`}
-              aria-hidden="true"
-            >
-              <Image
-                className={launchExperience.artImage}
-                src="/brand/create/custom-galaxy-v3.webp"
-                alt=""
-                fill
-                loading="eager"
-                sizes="(max-width: 760px) calc(100vw - 32px), (max-width: 1280px) calc((100vw - 96px) / 4), 260px"
-                priority
-              />
-              <Image
-                className={`${launchExperience.classicLogo} ${launchExperience.customLogo}`}
-                src="/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"
-                alt=""
-                width={1536}
-                height={1536}
-                sizes="128px"
-              />
-            </span>
-            <span
-              className={`launch-model-card-body ${launchExperience.modelBody}`}
-            >
-              <span
-                className={`launch-model-card-heading ${launchExperience.modelHeading}`}
-              >
-                <strong id="launch-model-custom-title">
-                  Custom Hook
-                </strong>
-                <small data-status="available">Available</small>
-              </span>
-              <span
-                className={`launch-model-description ${launchExperience.modelDescription}`}
-                id="launch-model-custom-description"
-              >
-                Launch a project only after its exact GitHub revision has been
-                reviewed and approved by Programmable.
-              </span>
-              <span
-                className={`launch-model-action ${launchExperience.modelAction}`}
-              >
-                Open approved Custom Hook launch
-                <ArrowRight aria-hidden="true" size={16} />
-              </span>
-            </span>
+            {customCardContent}
           </button>
-        ) : null}
+        ) : (
+          <Link
+            className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
+            data-launch-model-option="custom"
+            data-launch-model-available="false"
+            data-launch-model-launchable="false"
+            href="/docs/models/custom"
+            aria-labelledby="launch-model-custom-title"
+            aria-describedby="launch-model-custom-description"
+          >
+            {customCardContent}
+          </Link>
+        )}
 
         <button
           className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
@@ -328,7 +349,7 @@ export function LaunchModelPicker({
               src="/brand/create/classic-botanical-v4.webp"
               alt=""
               fill
-              sizes="(max-width: 760px) calc(100vw - 32px), (max-width: 1280px) calc((100vw - 96px) / 4), 260px"
+              sizes="(max-width: 760px) calc(100vw - 32px), (max-width: 1280px) calc((100vw - 96px) / 2), 560px"
               priority
             />
             <Image

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -450,7 +450,6 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .modelCard.modelCard[data-launch-model-available="true"]:hover,
   .modelCard.modelCard[data-launch-model-available="true"]:hover {
     background: var(--liquid-glass-control-background-hover);
     border-color: var(--liquid-glass-border-strong);

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -219,14 +219,21 @@ describe("unreleased launch model gating", () => {
     expect(html).not.toContain("Liquidity Growth");
   });
 
-  it("does not render the removed legacy Custom Hook card", () => {
+  it("keeps Custom Hook visible without implying that a closed launch is available", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
         onChoose: () => undefined,
       }),
     );
-    expect(html).not.toContain('data-launch-model-option="custom"');
-    expect(html).not.toContain('id="launch-model-custom-title"');
+    expect(html.match(/data-launch-model-option=/g)).toHaveLength(2);
+    expect(html).toContain('data-launch-model-option="custom"');
+    expect(html).toContain('id="launch-model-custom-title"');
+    expect(html).toContain('href="/docs/models/custom"');
+    expect(html).toContain('data-launch-model-available="false"');
+    expect(html).toContain('data-launch-model-launchable="false"');
+    expect(html).toContain("Review required");
+    expect(html).toContain("View Custom Hook requirements");
+    expect(html).not.toContain("Open approved Custom Hook launch");
     expect(html).not.toContain("Coming soon");
     expect(html).not.toContain("Build or resume");
   });

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -23,6 +23,8 @@ describe("launch model artwork", () => {
     expect(source).toContain(
       'src="/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"',
     );
+    expect(source).toContain('calc((100vw - 96px) / 2), 560px');
+    expect(source).not.toContain('calc((100vw - 96px) / 4), 260px');
     for (const marker of removedPartnerMarkers) {
       expect(source).not.toContain(marker);
     }

--- a/tests/launch-success.test.ts
+++ b/tests/launch-success.test.ts
@@ -4,6 +4,7 @@ import {
   findClassicV3IndexedLaunch,
   findDeepV3IndexedLaunch,
   findIndexedLaunch,
+  LAUNCH_SUCCESS_CELEBRATION_MAX_AGE_MS,
   LAUNCH_INDEX_POLL_ATTEMPTS,
   launchDraftForSuccessDisplay,
   launchDraftIsLocked,
@@ -26,6 +27,7 @@ import {
   releaseConfirmedLaunchSubmission,
   removePendingLaunchSubmission,
   submissionPhaseForPendingLaunch,
+  shouldCelebrateIndexedLaunch,
   updatePendingLaunchSubmission,
   writePendingLaunchSubmission,
   type PendingLaunchStorage,
@@ -33,7 +35,7 @@ import {
 } from "../components/launch-builder";
 import { createClassicV3Draft } from "../lib/launch";
 
-const transactionHash = `0x${"12".repeat(32)}`;
+const transactionHash: `0x${string}` = `0x${"12".repeat(32)}`;
 const tokenAddress = "0x1111111111111111111111111111111111111111";
 const account = "0x2222222222222222222222222222222222222222";
 
@@ -89,6 +91,52 @@ describe("launch success indexing", () => {
         3,
         2,
       ),
+    ).toBe(false);
+  });
+
+  it("celebrates only a fresh launch submitted from the current draft", () => {
+    const submittedAtMs = 1_000_000;
+    const submission: PendingLaunchSubmission = {
+      version: 2,
+      transactionHash,
+      account,
+      chainId: 1,
+      model: "classic-v3",
+      submittedAtMs,
+      receiptConfirmedAtMs: submittedAtMs + 1_000,
+    };
+    const currentDraft = {
+      submission,
+      currentDraftSubmissionHash: transactionHash,
+      currentDraftVersion: 3,
+      submittedDraftVersion: 3,
+    };
+
+    expect(
+      shouldCelebrateIndexedLaunch({
+        ...currentDraft,
+        nowMs: submittedAtMs + LAUNCH_SUCCESS_CELEBRATION_MAX_AGE_MS - 1,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCelebrateIndexedLaunch({
+        ...currentDraft,
+        nowMs: submittedAtMs + LAUNCH_SUCCESS_CELEBRATION_MAX_AGE_MS,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCelebrateIndexedLaunch({
+        ...currentDraft,
+        currentDraftSubmissionHash: "",
+        nowMs: submittedAtMs + 10_000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCelebrateIndexedLaunch({
+        ...currentDraft,
+        submittedDraftVersion: 2,
+        nowMs: submittedAtMs + 10_000,
+      }),
     ).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- open the launch success dialog only for a fresh launch submitted from the current draft
- finish restored/indexed launches silently so an old browser record cannot celebrate days later
- keep Custom Hook visible on Create while preserving its public readiness gate
- correct model-card image sizing for the current two-column layout

## Validation
- production build PASS
- interface CI suite PASS: 287 files, 3,076 tests
- focused launch/model/accessibility tests PASS
- typecheck, candidate-neutrality, scoped ESLint, gitleaks and diff-check PASS
- rendered desktop + 390px mobile QA; Classic builder interaction PASS