### PR TITLE
Bind manual Generic release verification

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -74,6 +74,8 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      PRODUCTION_VERIFY_MODE: ${{ (inputs.custom_v2_registry_live || inputs.custom_v2_generic_public_read_enabled || inputs.custom_v2_detail_record_hash != '' || inputs.custom_v2_authenticated_ingress_evidence_sha256 != '' || inputs.custom_v2_generic_signer_probe_expected_json != '' || inputs.custom_v2_generic_signer_probe_expected_sha256 != '') && 'custom-v2-release' || 'change' }}
     outputs:
       verified_sha: ${{ steps.verify-proof.outputs.verified_sha }}
       verified_tree: ${{ steps.verify-proof.outputs.verified_tree }}
@@ -89,6 +91,8 @@ jobs:
       verified_indexer: ${{ steps.verify-proof.outputs.verified_indexer }}
       verified_interface: ${{ steps.verify-proof.outputs.verified_interface }}
       verified_read_model: ${{ steps.verify-proof.outputs.verified_read_model }}
+      verification_mode: ${{ steps.verify-proof.outputs.verification_mode }}
+      verify_event: ${{ steps.verify-proof.outputs.verify_event }}
 
     steps:
       - name: Check out exact production commit
@@ -111,6 +115,7 @@ jobs:
         run: >-
           node scripts/production-verify-proof.mjs resolve
           --repository-root "$GITHUB_WORKSPACE"
+          --verification-mode "$PRODUCTION_VERIFY_MODE"
           --github-output "$GITHUB_OUTPUT"
 
       - name: Download exact immutable production Verify proof
@@ -130,6 +135,7 @@ jobs:
           ARTIFACT_DIGEST: ${{ steps.resolve-proof.outputs.artifact_digest }}
           VERIFY_RUN_ID: ${{ steps.resolve-proof.outputs.verify_run_id }}
           VERIFY_RUN_ATTEMPT: ${{ steps.resolve-proof.outputs.verify_run_attempt }}
+          VERIFY_MODE: ${{ steps.resolve-proof.outputs.verification_mode }}
         run: |
           set -euo pipefail
           proof="$RUNNER_TEMP/production-verify-proof/production-verify-proof.json"
@@ -156,6 +162,7 @@ jobs:
             --run-id "$VERIFY_RUN_ID" \
             --run-attempt "$VERIFY_RUN_ATTEMPT" \
             --artifact-digest "$ARTIFACT_DIGEST" \
+            --verification-mode "$VERIFY_MODE" \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Record consumed production Verify proof
@@ -164,6 +171,8 @@ jobs:
           PROOF_COMPLETED_AT: ${{ steps.resolve-proof.outputs.proof_completed_at }}
           PROOF_SHA256: ${{ steps.verify-proof.outputs.proof_sha256 }}
           ARTIFACT_DIGEST: ${{ steps.verify-proof.outputs.artifact_digest }}
+          VERIFY_EVENT: ${{ steps.verify-proof.outputs.verify_event }}
+          VERIFY_MODE: ${{ steps.verify-proof.outputs.verification_mode }}
         run: |
           {
             echo "## Consumed production Verify proof"
@@ -171,6 +180,7 @@ jobs:
             echo "- Commit: \`$GITHUB_SHA\`"
             echo "- Verify run: $VERIFY_RUN_URL"
             echo "- Proof completed: \`$PROOF_COMPLETED_AT\`"
+            echo "- Verification: \`$VERIFY_EVENT\` / \`$VERIFY_MODE\`"
             echo "- Proof SHA-256: \`$PROOF_SHA256\`"
             echo "- Immutable artifact digest: \`$ARTIFACT_DIGEST\`"
             echo "- Custom V2 lane required: \`${{ steps.verify-proof.outputs.verified_custom_v2 }}\`"
@@ -219,6 +229,7 @@ jobs:
         run: >-
           node scripts/production-verify-proof.mjs resolve
           --repository-root "$GITHUB_WORKSPACE"
+          --verification-mode "${{ needs.release-gate.outputs.verification_mode }}"
           --github-output "$GITHUB_OUTPUT"
 
       - name: Confirm consumed Verify proof identity after production approval
@@ -229,12 +240,16 @@ jobs:
           EXPECTED_RUN_ATTEMPT: ${{ needs.release-gate.outputs.verify_run_attempt }}
           EXPECTED_ARTIFACT_ID: ${{ needs.release-gate.outputs.artifact_id }}
           EXPECTED_ARTIFACT_DIGEST: ${{ needs.release-gate.outputs.artifact_digest }}
+          EXPECTED_VERIFY_EVENT: ${{ needs.release-gate.outputs.verify_event }}
+          EXPECTED_VERIFY_MODE: ${{ needs.release-gate.outputs.verification_mode }}
           REVALIDATED_SHA: ${{ steps.revalidate-proof.outputs.verified_sha }}
           REVALIDATED_TREE: ${{ steps.revalidate-proof.outputs.verified_tree }}
           REVALIDATED_RUN_ID: ${{ steps.revalidate-proof.outputs.verify_run_id }}
           REVALIDATED_RUN_ATTEMPT: ${{ steps.revalidate-proof.outputs.verify_run_attempt }}
           REVALIDATED_ARTIFACT_ID: ${{ steps.revalidate-proof.outputs.artifact_id }}
           REVALIDATED_ARTIFACT_DIGEST: ${{ steps.revalidate-proof.outputs.artifact_digest }}
+          REVALIDATED_VERIFY_EVENT: ${{ steps.revalidate-proof.outputs.verify_event }}
+          REVALIDATED_VERIFY_MODE: ${{ steps.revalidate-proof.outputs.verification_mode }}
         run: |
           set -euo pipefail
           test "$GITHUB_SHA" = "$EXPECTED_SHA"
@@ -244,6 +259,8 @@ jobs:
           test "$REVALIDATED_RUN_ATTEMPT" = "$EXPECTED_RUN_ATTEMPT"
           test "$REVALIDATED_ARTIFACT_ID" = "$EXPECTED_ARTIFACT_ID"
           test "$REVALIDATED_ARTIFACT_DIGEST" = "$EXPECTED_ARTIFACT_DIGEST"
+          test "$REVALIDATED_VERIFY_EVENT" = "$EXPECTED_VERIFY_EVENT"
+          test "$REVALIDATED_VERIFY_MODE" = "$EXPECTED_VERIFY_MODE"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,6 +6,14 @@ on:
     branches:
       - main
       - production
+  workflow_dispatch:
+    inputs:
+      verification_mode:
+        description: Verify the complete current Custom V2 tree for an exact Generic production release
+        required: true
+        type: choice
+        options:
+          - custom-v2-release
 
 permissions:
   contents: read
@@ -39,11 +47,19 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          VERIFICATION_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.verification_mode || 'change' }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ -z "${BASE_SHA:-}" || "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "$BASE_SHA^{commit}"; then
+          if [ "$VERIFICATION_MODE" = custom-v2-release ]; then
+            test "$GITHUB_EVENT_NAME" = workflow_dispatch
+            test "$GITHUB_REF" = refs/heads/production
+            node scripts/ci/classify-verify-paths.mjs --custom-v2-release > "$RUNNER_TEMP/verify-scope.txt"
+          elif [ "$VERIFICATION_MODE" != change ]; then
+            echo "Verification mode is invalid" >&2
+            exit 1
+          elif [[ -z "${BASE_SHA:-}" || "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "$BASE_SHA^{commit}"; then
             node scripts/ci/classify-verify-paths.mjs --all > "$RUNNER_TEMP/verify-scope.txt"
           else
             git diff --no-renames --name-only "$BASE_SHA" "$HEAD_SHA" > "$RUNNER_TEMP/changed-paths.txt"
@@ -324,7 +340,11 @@ jobs:
 
   production-proof:
     name: Bind production Verify proof
-    if: github.event_name == 'push' && github.ref == 'refs/heads/production'
+    if: >-
+      github.ref == 'refs/heads/production' &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+      inputs.verification_mode == 'custom-v2-release'))
     needs:
       - scope
       - secret-scan
@@ -356,6 +376,7 @@ jobs:
 
       - name: Create exact production Verify proof
         env:
+          PRODUCTION_VERIFY_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.verification_mode || 'change' }}
           PRODUCTION_VERIFY_SCOPE_CONTRACTS: ${{ needs.scope.outputs.contracts }}
           PRODUCTION_VERIFY_SCOPE_CUSTOM_V2: ${{ needs.scope.outputs.custom_v2 }}
           PRODUCTION_VERIFY_SCOPE_DATABASE: ${{ needs.scope.outputs.database }}
@@ -393,12 +414,14 @@ jobs:
         env:
           ATTESTATION_URL: ${{ steps.attest-proof.outputs.attestation-url }}
           ARTIFACT_DIGEST: ${{ steps.upload-proof.outputs.artifact-digest }}
+          PRODUCTION_VERIFY_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.verification_mode || 'change' }}
         run: |
           {
             echo "## Production Verify proof"
             echo
             echo "- Commit: \`$GITHUB_SHA\`"
             echo "- Run: \`$GITHUB_RUN_ID\` attempt \`$GITHUB_RUN_ATTEMPT\`"
+            echo "- Event/mode: \`$GITHUB_EVENT_NAME\` / \`$PRODUCTION_VERIFY_MODE\`"
             echo "- Artifact SHA-256: \`$ARTIFACT_DIGEST\`"
             echo "- Sigstore attestation: $ATTESTATION_URL"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -406,7 +429,8 @@ jobs:
   aggregate:
     # Keep one stable, always-run PR context while the lane jobs remain
     # independently addressable and path-routed. The production proof above
-    # remains separate and binds the exact path-scoped push verification.
+    # remains separate and binds either exact path-scoped push verification or
+    # an explicit current-tree Custom V2 release verification.
     name: Verify aggregate
     needs:
       - scope

--- a/docs/operations/custom-v2-production-stage-gate.md
+++ b/docs/operations/custom-v2-production-stage-gate.md
@@ -20,11 +20,23 @@ change. On the first production commit, the trusted base classifier has no
 `custom_v2=true` once.
 
 The production proof schema is
-`programmable.production-verify-proof.v3`. Its exact added check is
+`programmable.production-verify-proof.v4`. Its exact added check is
 `custom-v2` / `Custom V2`, required precisely when the `custom_v2` scope is
 true. `scripts/production-verify-proof.mjs` continues to bind the production
 commit, tree, workflow digest, GitHub run and attempt, complete hosted-runner
 job inventory, immutable artifact, and Sigstore attestation.
+
+An exact Generic V2 production release first dispatches `Verify` on the
+`production` ref with `verification_mode=custom-v2-release`. That mode is
+classified as a current-tree release verification rather than as a changed
+path: it requires the complete Custom V2 lane, emits `scope.custom_v2=true`,
+and binds `run.event=workflow_dispatch` plus
+`run.verificationMode=custom-v2-release` in the v4 proof. The staging workflow
+selects that exact proof whenever any Custom V2 stage input is non-default.
+Ordinary production staging continues to consume the exact path-scoped
+`push` / `change` proof. This keeps unrelated production commits from
+silently downgrading a later Generic V2 release while never representing an
+unexecuted lane as verified.
 
 ## Workflow dispatch matrix
 

--- a/scripts/ci/classify-verify-paths.mjs
+++ b/scripts/ci/classify-verify-paths.mjs
@@ -73,12 +73,23 @@ function markAll(scope) {
   }
 }
 
-export function classifyVerifyPaths(paths, { forceAll = false } = {}) {
+export function classifyVerifyPaths(
+  paths,
+  { forceAll = false, customV2Release = false } = {},
+) {
   const scope = { ...EMPTY_SCOPE };
+  if (typeof customV2Release !== "boolean") {
+    throw new TypeError("Custom V2 release classification must be boolean");
+  }
   if (forceAll) {
     markAll(scope);
     return scope;
   }
+
+  // A manual Generic V2 production release verifies the complete, current
+  // Custom V2 tree, even when the production tip's last diff was unrelated.
+  // This is a distinct verification intent, not a changed-path claim.
+  if (customV2Release) scope.custom_v2 = true;
 
   for (const path of paths) {
     if (!path) continue;
@@ -203,11 +214,18 @@ function printGithubOutputs(scope) {
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   const forceAll = process.argv[2] === "--all";
-  const paths = forceAll
+  const customV2Release = process.argv[2] === "--custom-v2-release";
+  if ((forceAll || customV2Release) && process.argv.length !== 3) {
+    throw new Error("Verify scope mode does not accept a path file");
+  }
+  if (!forceAll && !customV2Release && process.argv.length !== 3) {
+    throw new Error("Exactly one changed-path file is required");
+  }
+  const paths = forceAll || customV2Release
     ? []
     : readFileSync(process.argv[2], "utf8")
         .split("\n")
         .map((path) => path.trim())
         .filter(Boolean);
-  printGithubOutputs(classifyVerifyPaths(paths, { forceAll }));
+  printGithubOutputs(classifyVerifyPaths(paths, { forceAll, customV2Release }));
 }

--- a/scripts/ci/classify-verify-paths.test.mjs
+++ b/scripts/ci/classify-verify-paths.test.mjs
@@ -79,6 +79,23 @@ test("routes ordinary website changes only to the interface lane", () => {
   });
 });
 
+test("classifies an explicit Custom V2 release against the current full tree", () => {
+  assert.deepEqual(
+    classifyVerifyPaths([], { customV2Release: true }),
+    { ...none, custom_v2: true },
+  );
+  assert.deepEqual(
+    classifyVerifyPaths(["components/token-card.tsx"], {
+      customV2Release: true,
+    }),
+    { ...none, custom_v2: true, interface: true },
+  );
+  assert.throws(
+    () => classifyVerifyPaths([], { customV2Release: "true" }),
+    /must be boolean/u,
+  );
+});
+
 test("routes read-model API changes to interface and operations checks", () => {
   for (const path of [
     "app/api/explore/route.ts",

--- a/scripts/production-verify-proof.mjs
+++ b/scripts/production-verify-proof.mjs
@@ -9,7 +9,7 @@ import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 export const PRODUCTION_VERIFY_PROOF_SCHEMA_VERSION =
-  "programmable.production-verify-proof.v3";
+  "programmable.production-verify-proof.v4";
 export const PRODUCTION_VERIFY_PROOF_MAX_AGE_MS = 6 * 60 * 60 * 1_000;
 export const PRODUCTION_REPOSITORY = "0xprogrammable/programmable";
 export const PRODUCTION_REPOSITORY_ID = 1_314_365_508;
@@ -19,6 +19,8 @@ export const VERIFY_WORKFLOW_NAME = "Verify";
 export const VERIFY_SCOPE_JOB_NAME = "Change scope";
 export const VERIFY_AGGREGATE_JOB_NAME = "Verify aggregate";
 export const VERIFY_PROOF_JOB_NAME = "Bind production Verify proof";
+export const PRODUCTION_VERIFY_CHANGE_MODE = "change";
+export const PRODUCTION_VERIFY_CUSTOM_V2_RELEASE_MODE = "custom-v2-release";
 
 export const PRODUCTION_VERIFY_SCOPE_KEYS = Object.freeze([
   "contracts",
@@ -67,9 +69,13 @@ export function buildProductionVerifyProofV1(input) {
   requirePattern(input.workflowFileSha256, SHA256, "workflow SHA-256");
   requirePositiveInteger(input.runId, "run ID");
   requirePositiveInteger(input.runAttempt, "run attempt");
-  requireExact(input.eventName, "push", "workflow event");
+  const verificationMode = validateVerificationMode(
+    input.verificationMode,
+    input.eventName,
+  );
 
   const scope = validateProductionVerifyScope(input.scopeResults);
+  validateVerificationModeScope(verificationMode, scope);
   const checks = REQUIRED_PRODUCTION_VERIFY_CHECKS.map((check) => {
     const required = check.scopeKey === null ? true : scope[check.scopeKey];
     const expectedResult = required ? "success" : "skipped";
@@ -112,7 +118,8 @@ export function buildProductionVerifyProofV1(input) {
     run: Object.freeze({
       id: input.runId,
       attempt: input.runAttempt,
-      event: "push",
+      event: input.eventName,
+      verificationMode,
     }),
     checks: Object.freeze(checks),
   });
@@ -125,6 +132,8 @@ export function encodeProductionVerifyProofV1(proof) {
     workflowFileSha256: proof?.workflow?.fileSha256,
     runId: proof?.run?.id,
     runAttempt: proof?.run?.attempt,
+    eventName: proof?.run?.event,
+    verificationMode: proof?.run?.verificationMode,
   });
   return Buffer.from(`${JSON.stringify(proof, null, 2)}\n`, "utf8");
 }
@@ -200,12 +209,26 @@ export function validateProductionVerifyProofV1(proof, expected) {
     expected.workflowFileSha256,
     "proof workflow SHA-256",
   );
-  assertExactKeys(proof.run, ["id", "attempt", "event"], "proof run");
+  assertExactKeys(
+    proof.run,
+    ["id", "attempt", "event", "verificationMode"],
+    "proof run",
+  );
   requirePositiveInteger(proof.run.id, "proof run ID");
   requirePositiveInteger(proof.run.attempt, "proof run attempt");
   requireExact(proof.run.id, expected.runId, "proof run ID");
   requireExact(proof.run.attempt, expected.runAttempt, "proof run attempt");
-  requireExact(proof.run.event, "push", "proof run event");
+  const verificationMode = validateVerificationMode(
+    proof.run.verificationMode,
+    proof.run.event,
+  );
+  requireExact(proof.run.event, expected.eventName, "proof run event");
+  requireExact(
+    verificationMode,
+    expected.verificationMode,
+    "proof verification mode",
+  );
+  validateVerificationModeScope(verificationMode, scope);
   if (
     !Array.isArray(proof.checks)
     || proof.checks.length !== REQUIRED_PRODUCTION_VERIFY_CHECKS.length
@@ -243,6 +266,7 @@ export async function resolveProductionVerifyProofFromGitHubV1(input) {
   requirePattern(input.commitSha, COMMIT, "expected commit");
   requirePattern(input.treeSha, COMMIT, "expected tree");
   requirePattern(input.workflowFileSha256, SHA256, "workflow SHA-256");
+  const eventName = verificationEventForMode(input.verificationMode);
   requireExact(input.githubApiUrl, EXPECTED_GITHUB_API_URL, "GitHub API origin");
   if (typeof input.githubToken !== "string" || input.githubToken.length < 1) {
     throw new Error("GitHub Actions read token is unavailable.");
@@ -270,7 +294,7 @@ export async function resolveProductionVerifyProofFromGitHubV1(input) {
     ),
     fetchGitHubJson(
       `${EXPECTED_GITHUB_API_URL}/repos/${encodedRepository}/actions/workflows/verify.yml/runs`
-        + `?branch=production&event=push&head_sha=${input.commitSha}&per_page=100`,
+        + `?branch=production&event=${eventName}&head_sha=${input.commitSha}&per_page=100`,
       input.githubToken,
       fetchImpl,
     ),
@@ -282,6 +306,7 @@ export async function resolveProductionVerifyProofFromGitHubV1(input) {
     workflowId,
     commitSha: input.commitSha,
     treeSha: input.treeSha,
+    eventName,
   });
 
   const [jobs, artifacts] = await Promise.all([
@@ -316,6 +341,8 @@ export async function resolveProductionVerifyProofFromGitHubV1(input) {
     artifactId: artifact.id,
     artifactName: artifact.name,
     artifactDigest: artifact.digest,
+    eventName,
+    verificationMode: input.verificationMode,
   });
 }
 
@@ -367,7 +394,7 @@ function selectLatestExactVerifyRun(response, expected) {
     || run.workflow_id !== expected.workflowId
     || run.name !== VERIFY_WORKFLOW_NAME
     || run.path !== VERIFY_WORKFLOW_PATH
-    || run.event !== "push"
+    || run.event !== expected.eventName
     || run.status !== "completed"
     || run.conclusion !== "success"
     || run.head_branch !== "production"
@@ -539,13 +566,14 @@ async function runCli() {
   const argumentsByName = parseArguments(rawArguments);
   const allowedArguments = {
     create: ["repository-root", "output"],
-    resolve: ["repository-root", "github-output"],
+    resolve: ["repository-root", "verification-mode", "github-output"],
     verify: [
       "repository-root",
       "proof",
       "run-id",
       "run-attempt",
       "artifact-digest",
+      "verification-mode",
       "github-output",
     ],
   }[command];
@@ -558,7 +586,8 @@ async function runCli() {
 
   if (command === "create") {
     const output = requiredArgument(argumentsByName, "output");
-    requireExact(process.env.GITHUB_EVENT_NAME, "push", "Actions event");
+    const verificationMode = process.env.PRODUCTION_VERIFY_MODE;
+    validateVerificationMode(verificationMode, process.env.GITHUB_EVENT_NAME);
     requireExact(
       process.env.GITHUB_WORKFLOW_REF,
       `${PRODUCTION_REPOSITORY}/${VERIFY_WORKFLOW_PATH}@${PRODUCTION_REF}`,
@@ -584,6 +613,7 @@ async function runCli() {
         "Actions run attempt",
       ),
       eventName: process.env.GITHUB_EVENT_NAME,
+      verificationMode,
       scopeResults: Object.fromEntries(
         PRODUCTION_VERIFY_SCOPE_KEYS.map((key) => [
           key,
@@ -606,6 +636,11 @@ async function runCli() {
 
   if (command === "resolve") {
     const githubOutput = requiredArgument(argumentsByName, "github-output");
+    const verificationMode = requiredArgument(
+      argumentsByName,
+      "verification-mode",
+    );
+    const eventName = verificationEventForMode(verificationMode);
     const resolution = await resolveProductionVerifyProofFromGitHubV1({
       repository: process.env.GITHUB_REPOSITORY,
       repositoryId: parsePositiveInteger(
@@ -615,6 +650,7 @@ async function runCli() {
       commitSha: context.commitSha,
       treeSha: context.treeSha,
       workflowFileSha256: context.workflowFileSha256,
+      verificationMode,
       githubApiUrl: process.env.GITHUB_API_URL,
       githubToken: process.env.GITHUB_TOKEN,
       nowMs: Date.now(),
@@ -630,6 +666,8 @@ async function runCli() {
       artifact_id: resolution.artifactId,
       artifact_name: resolution.artifactName,
       artifact_digest: resolution.artifactDigest,
+      verify_event: eventName,
+      verification_mode: verificationMode,
     });
     return;
   }
@@ -647,6 +685,11 @@ async function runCli() {
     );
     const artifactDigest = requiredArgument(argumentsByName, "artifact-digest");
     requirePattern(artifactDigest, SHA256, "resolved artifact digest");
+    const verificationMode = requiredArgument(
+      argumentsByName,
+      "verification-mode",
+    );
+    const eventName = verificationEventForMode(verificationMode);
     const proofBytes = readFileSync(proofPath);
     const proof = parseProductionVerifyProofV1(proofBytes, {
       commitSha: context.commitSha,
@@ -654,6 +697,8 @@ async function runCli() {
       workflowFileSha256: context.workflowFileSha256,
       runId,
       runAttempt,
+      eventName,
+      verificationMode,
     });
     appendGitHubOutput(githubOutput, {
       verified_sha: context.commitSha,
@@ -662,6 +707,8 @@ async function runCli() {
       verify_run_attempt: runAttempt,
       proof_sha256: prefixedSha256(proofBytes),
       artifact_digest: artifactDigest,
+      verify_event: eventName,
+      verification_mode: verificationMode,
       ...Object.fromEntries(
         PRODUCTION_VERIFY_SCOPE_KEYS.map((key) => [
           `verified_${key}`,
@@ -763,6 +810,34 @@ function parseBoolean(value, name) {
   if (value === "true") return true;
   if (value === "false") return false;
   throw new Error(`${name} is invalid.`);
+}
+
+function verificationEventForMode(mode) {
+  if (mode === PRODUCTION_VERIFY_CHANGE_MODE) return "push";
+  if (mode === PRODUCTION_VERIFY_CUSTOM_V2_RELEASE_MODE) {
+    return "workflow_dispatch";
+  }
+  throw new Error("Production verification mode is invalid.");
+}
+
+function validateVerificationMode(mode, eventName) {
+  requireExact(
+    eventName,
+    verificationEventForMode(mode),
+    "verification mode/event",
+  );
+  return mode;
+}
+
+function validateVerificationModeScope(mode, scope) {
+  if (mode !== PRODUCTION_VERIFY_CUSTOM_V2_RELEASE_MODE) return;
+  for (const key of PRODUCTION_VERIFY_SCOPE_KEYS) {
+    requireExact(
+      scope[key],
+      key === "custom_v2",
+      `Custom V2 release ${key} scope`,
+    );
+  }
 }
 
 function validateProductionVerifyScope(value) {

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -31,7 +31,7 @@ function stepBlock(source, name) {
 }
 
 test("Custom V2 production proof is a dedicated versioned protected lane", () => {
-  assert.match(proof, /programmable\.production-verify-proof\.v3/u);
+  assert.match(proof, /programmable\.production-verify-proof\.v4/u);
   assert.match(proof, /"custom_v2"/u);
   assert.match(proof, /id: "custom-v2", name: "Custom V2", scopeKey: "custom_v2"/u);
   assert.match(verify, /^  custom-v2:$/mu);
@@ -47,6 +47,40 @@ test("Custom V2 production proof is a dedicated versioned protected lane", () =>
   assert.match(verify, /PRODUCTION_VERIFY_SCOPE_CUSTOM_V2:/u);
   assert.match(verify, /PRODUCTION_VERIFY_CUSTOM_V2_RESULT:/u);
   assert.match(verify, /verified Custom V2|CUSTOM_V2_RESULT/u);
+});
+
+test("manual Generic release verification runs the complete current Custom V2 tree", () => {
+  assert.match(
+    verify,
+    /^  workflow_dispatch:[\s\S]*verification_mode:[\s\S]*custom-v2-release/mu,
+  );
+  const scope = stepBlock(verify, "Classify changed paths");
+  assert.match(scope, /VERIFICATION_MODE:/u);
+  assert.match(scope, /test "\$GITHUB_EVENT_NAME" = workflow_dispatch/u);
+  assert.match(scope, /test "\$GITHUB_REF" = refs\/heads\/production/u);
+  assert.match(
+    scope,
+    /classify-verify-paths\.mjs --custom-v2-release/u,
+  );
+  assert.match(
+    verify,
+    /name: Bind production Verify proof[\s\S]*github\.event_name == 'workflow_dispatch'[\s\S]*inputs\.verification_mode == 'custom-v2-release'/u,
+  );
+  assert.match(proof, /verificationMode/u);
+  assert.match(proof, /workflow_dispatch/u);
+  assert.match(proof, /validateVerificationModeScope/u);
+  assert.match(
+    deploy,
+    /PRODUCTION_VERIFY_MODE:[\s\S]*custom-v2-release[\s\S]*--verification-mode "\$PRODUCTION_VERIFY_MODE"/u,
+  );
+  assert.match(
+    deploy,
+    /--verification-mode "\$VERIFY_MODE"/u,
+  );
+  assert.match(
+    deploy,
+    /--verification-mode "\$\{\{ needs\.release-gate\.outputs\.verification_mode \}\}"/u,
+  );
 });
 
 test("trusted-base classification bootstraps Custom V2 without narrowing legacy lanes", () => {

--- a/scripts/test/production-verify-proof.test.mjs
+++ b/scripts/test/production-verify-proof.test.mjs
@@ -5,6 +5,8 @@ import {
   PRODUCTION_REF,
   PRODUCTION_REPOSITORY,
   PRODUCTION_REPOSITORY_ID,
+  PRODUCTION_VERIFY_CHANGE_MODE,
+  PRODUCTION_VERIFY_CUSTOM_V2_RELEASE_MODE,
   PRODUCTION_VERIFY_PROOF_MAX_AGE_MS,
   PRODUCTION_VERIFY_SCOPE_KEYS,
   REQUIRED_PRODUCTION_VERIFY_CHECKS,
@@ -44,6 +46,7 @@ function validProofInput() {
     runId: RUN_ID,
     runAttempt: RUN_ATTEMPT,
     eventName: "push",
+    verificationMode: PRODUCTION_VERIFY_CHANGE_MODE,
     scopeResults: Object.fromEntries(
       PRODUCTION_VERIFY_SCOPE_KEYS.map((key) => [key, true]),
     ),
@@ -191,7 +194,10 @@ function mockGitHub(fixtures) {
     let value;
     if (url.pathname.endsWith("/actions/workflows/verify.yml/runs")) {
       assert.equal(url.searchParams.get("branch"), "production");
-      assert.equal(url.searchParams.get("event"), "push");
+      assert.equal(
+        url.searchParams.get("event"),
+        fixtures.runs.workflow_runs[0].event,
+      );
       assert.equal(url.searchParams.get("head_sha"), COMMIT);
       value = fixtures.runs;
     } else if (url.pathname.endsWith("/actions/workflows/verify.yml")) {
@@ -219,6 +225,7 @@ async function resolveFixtures(fixtures = validApiFixtures(), overrides = {}) {
     commitSha: COMMIT,
     treeSha: TREE,
     workflowFileSha256: WORKFLOW_SHA256,
+    verificationMode: PRODUCTION_VERIFY_CHANGE_MODE,
     githubApiUrl: "https://api.github.com",
     githubToken: "test-token",
     nowMs: NOW_MS,
@@ -239,6 +246,8 @@ test("full production Verify proof is deterministic and exact", () => {
       workflowFileSha256: WORKFLOW_SHA256,
       runId: RUN_ID,
       runAttempt: RUN_ATTEMPT,
+      eventName: "push",
+      verificationMode: PRODUCTION_VERIFY_CHANGE_MODE,
     }),
     proof,
   );
@@ -285,6 +294,8 @@ test("proof binds the path scope and distinguishes skipped lanes", () => {
         workflowFileSha256: WORKFLOW_SHA256,
         runId: RUN_ID,
         runAttempt: RUN_ATTEMPT,
+        eventName: "push",
+        verificationMode: PRODUCTION_VERIFY_CHANGE_MODE,
       },
     ),
   );
@@ -335,6 +346,8 @@ test("downloaded proof rejects identity, schema, run, and byte drift", () => {
     workflowFileSha256: WORKFLOW_SHA256,
     runId: RUN_ID,
     runAttempt: RUN_ATTEMPT,
+    eventName: "push",
+    verificationMode: PRODUCTION_VERIFY_CHANGE_MODE,
   };
   const mutations = [
     (value) => { value.schemaVersion = "programmable.production-verify-proof.v0"; },
@@ -370,7 +383,58 @@ test("resolver accepts only a fresh exact successful run and immutable artifact"
     artifactId: 777,
     artifactName: `production-verify-proof-${RUN_ID}-${RUN_ATTEMPT}`,
     artifactDigest: ARTIFACT_DIGEST,
+    eventName: "push",
+    verificationMode: PRODUCTION_VERIFY_CHANGE_MODE,
   });
+});
+
+test("manual Custom V2 release proof binds dispatch intent and full-tree lane", async () => {
+  const input = validProofInput();
+  input.eventName = "workflow_dispatch";
+  input.verificationMode = PRODUCTION_VERIFY_CUSTOM_V2_RELEASE_MODE;
+  input.scopeResults = {
+    contracts: false,
+    custom_v2: true,
+    database: false,
+    dependencies: false,
+    indexer: false,
+    interface: false,
+    read_model: false,
+  };
+  input.checkResults = {
+    "secret-scan": "success",
+    "custom-v2": "success",
+    indexer: "skipped",
+    "database-pglite": "skipped",
+    interface: "skipped",
+    contracts: "skipped",
+  };
+  const proof = buildProductionVerifyProofV1(input);
+  assert.equal(proof.run.event, "workflow_dispatch");
+  assert.equal(
+    proof.run.verificationMode,
+    PRODUCTION_VERIFY_CUSTOM_V2_RELEASE_MODE,
+  );
+  assert.equal(proof.scope.custom_v2, true);
+
+  const fixtures = validApiFixtures();
+  fixtures.runs.workflow_runs[0].event = "workflow_dispatch";
+  assert.equal(
+    (await resolveFixtures(fixtures, {
+      verificationMode: PRODUCTION_VERIFY_CUSTOM_V2_RELEASE_MODE,
+    })).eventName,
+    "workflow_dispatch",
+  );
+});
+
+test("manual Custom V2 release proof rejects event or scope substitution", () => {
+  const input = validProofInput();
+  input.eventName = "workflow_dispatch";
+  input.verificationMode = PRODUCTION_VERIFY_CUSTOM_V2_RELEASE_MODE;
+  assert.throws(() => buildProductionVerifyProofV1(input), /release .* scope/u);
+
+  input.eventName = "push";
+  assert.throws(() => buildProductionVerifyProofV1(input), /mode\/event/u);
 });
 
 test("resolver rejects a newer canceled run instead of falling back to old success", async () => {


### PR DESCRIPTION
## Outcome

Generic V2 production staging now requires an exact current-tree Custom V2 release proof even when the latest production commit changed only an unrelated surface.

- adds `Verify` workflow dispatch mode `custom-v2-release`
- classifies release intent separately from changed paths and runs the complete Custom V2 lane
- advances the production proof to v4, binding the actual event, mode, scope, commit, tree, jobs, artifact and attestation
- makes production staging select and revalidate that exact manual proof for every non-default Custom V2 dispatch
- keeps ordinary production staging on exact push/change proofs

## Validation

- `actionlint .github/workflows/verify.yml .github/workflows/deploy-production.yml`
- targeted proof/classifier/workflow contract: 39/39
- `npm run verify:custom-v2:ci`: lint 0 errors, typecheck, Node 69/69, Vitest 101/101, production build and bundle scan
- `npm run perf:read-model:ops-gate`: pass
- clean CLI simulation emitted exact v4 `workflow_dispatch/custom-v2-release` proof with only `scope.custom_v2=true` and a required successful Custom V2 check

Independent pre-commit review: P0=0, P1=0, P2=0. Immutable audit is bound to commit `9570ad8990c422691e7e7d5df4c0c28566aaccd0`, tree `807b18b365d0ea6d0650cf46102049d1072edd07`.

## Existing baseline note

`npm run release:custom-launch:record:test` remains 49/50 because one stale Custom Launch workflow assertion already fails identically on parent `50ced4cf151e425aa88a4b027575f31104860338` with `proof-revalidation-attestations-read`, `canonical-attestation-origin`, and `canonical-summary-target`. This narrow Generic release-proof fix does not change that unrelated baseline.