### PR TITLE
Remove Hookathon from the public website

### DIFF
--- a/app/docs/creators/page.tsx
+++ b/app/docs/creators/page.tsx
@@ -161,23 +161,11 @@ export default function CreatorsDocsPage() {
             </a>
           </li>
           <li>
-            <Link href="/hookathon">
-              <span>
-                <strong>Hookathons</strong>
-                <small>
-                  Open the event page for its deadline, award and submission
-                  instructions.
-                </small>
-              </span>
-              <ArrowRight aria-hidden="true" size={17} strokeWidth={1.8} />
-            </Link>
-          </li>
-          <li>
             <Link href="/docs/creators/programs">
               <span>
                 <strong>Creator programs</strong>
                 <small>
-                  Understand Hookathons, partnerships and contribution work.
+                  Understand partnerships and contribution work.
                 </small>
               </span>
               <ArrowRight aria-hidden="true" size={17} strokeWidth={1.8} />

--- a/app/docs/creators/programs/page.tsx
+++ b/app/docs/creators/programs/page.tsx
@@ -1,21 +1,18 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 
 import { DocsExternalLink } from "@/components/docs-external-link";
 import docsStyles from "@/components/docs-experience.module.css";
-import styles from "@/components/docs-hub.module.css";
 import { PROGRAMMABLE_PUBLIC_REPOSITORIES } from "@/components/docs-public-policy";
 import { DocsShell } from "@/components/docs-shell";
 
 export const metadata: Metadata = {
   title: "Creator programs · Programmable",
   description:
-    "Understand Programmable Hookathons, partnerships and contribution opportunities.",
+    "Understand Programmable partnerships and contribution opportunities.",
   alternates: { canonical: "/docs/creators/programs" },
 };
 
 const sections = [
-  { id: "hookathons", label: "Hookathons" },
   { id: "partnerships", label: "Partnerships" },
   { id: "contributions", label: "Contributions" },
   { id: "support", label: "Support" },
@@ -31,22 +28,6 @@ export default function CreatorProgramsDocsPage() {
       sections={sections}
       title="Creator programs"
     >
-      <section id="hookathons">
-        <h2>Hookathons</h2>
-        <p>
-          Programmable runs Hookathons to fund useful experiments and bring new
-          hook projects onchain. Each event publishes its own deadline, award,
-          eligibility and submission path.
-        </p>
-        <p>
-          These permanent docs do not copy the current prize or countdown.
-          Always use the event page for those details.
-        </p>
-        <p className={styles.inlineAction}>
-          <Link href="/hookathon">Open Hookathon events</Link>
-        </p>
-      </section>
-
       <section id="partnerships">
         <h2>Partnerships</h2>
         <p>

--- a/app/hookathon/page.tsx
+++ b/app/hookathon/page.tsx
@@ -1,38 +1,20 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
-import { HookathonPage } from "@/components/hookathon-page";
-import { readHookathonServerNowMs } from "@/lib/hookathon/server-clock";
-
-export const dynamic = "force-dynamic";
-
-export function generateMetadata(): Metadata {
-  const isExactProduction = process.env.VERCEL_ENV === "production";
-
-  return {
-    title: "Hookathon · Programmable",
-    description: "Build, submit and launch a Programmable v4 hook project.",
-    alternates: {
-      canonical: "/hookathon",
+export const metadata: Metadata = {
+  title: "Not found · Programmable",
+  robots: {
+    index: false,
+    follow: false,
+    noarchive: true,
+    googleBot: {
+      index: false,
+      follow: false,
+      noimageindex: true,
     },
-    robots: isExactProduction
-      ? { index: true, follow: true }
-      : {
-          index: false,
-          follow: false,
-          noarchive: true,
-          googleBot: {
-            index: false,
-            follow: false,
-            noimageindex: true,
-          },
-        },
-    openGraph: null,
-    twitter: null,
-  };
-}
+  },
+};
 
-export default async function HookathonRoute() {
-  const initialNowMs = await readHookathonServerNowMs();
-
-  return <HookathonPage initialNowMs={initialNowMs} />;
+export default function HookathonRoute(): never {
+  notFound();
 }

--- a/app/interface.css
+++ b/app/interface.css
@@ -1739,7 +1739,7 @@ body:has([data-docs-shell]) .site-header::before {
     border-radius: 0;
     bottom: max(4px, env(safe-area-inset-bottom));
     box-shadow: none;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     height: 56px;
     inset-inline-end: max(12px, env(safe-area-inset-right));
     inset-inline-start: max(12px, env(safe-area-inset-left));
@@ -1834,7 +1834,7 @@ body:has([data-docs-shell]) .site-header::before {
     bottom: max(4px, env(safe-area-inset-bottom));
     box-shadow: none;
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     height: 56px;
     inset-inline-end: max(12px, env(safe-area-inset-right));
     inset-inline-start: max(12px, env(safe-area-inset-left));
@@ -1924,7 +1924,7 @@ body:has([data-docs-shell]) .site-header::before {
   }
 
   .mobile-nav {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     height: 56px;
     padding: 0;
   }

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -179,9 +179,9 @@ export const docsSearchItems: DocsSearchItem[] = [
   {
     title: "Creator programs",
     description:
-      "Find Hookathons, partnerships and contribution opportunities.",
+      "Find partnerships and contribution opportunities.",
     href: "/docs/creators/programs",
-    keywords: ["hookathon", "grant", "bounty"],
+    keywords: ["partnership", "grant", "bounty"],
   },
   {
     title: "Economics",

--- a/components/site-navigation.module.css
+++ b/components/site-navigation.module.css
@@ -143,7 +143,7 @@
     box-shadow: none;
     display: grid;
     gap: 4px;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     height: auto;
     inset: auto;
     max-width: none;
@@ -202,7 +202,7 @@
   }
 
   .mobileSheet.mobileSheet :global(.mobile-nav) {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -22,7 +22,6 @@ const desktopNavItems = [
   { href: "/launch", label: "Create" },
   { href: "/docs", label: "Docs" },
   { href: "/profile", label: "Profile" },
-  { href: "/hookathon", label: "Hookathon" },
 ];
 
 const mobileNavItems = desktopNavItems;

--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -8,7 +8,7 @@
   - [Launch a project](creators/launch.md)
   - [Public templates](creators/templates.md)
   - [Creator earnings](creators/earnings.md)
-  - [Programs and Hookathons](creators/programs.md)
+  - [Creator programs](creators/programs.md)
 - [Fees and revenue](economics.md)
 - [V4 token](v4-token.md)
 - [How Programmable works](infrastructure.md)

--- a/docs/public/creators/programs.md
+++ b/docs/public/creators/programs.md
@@ -1,11 +1,9 @@
 ---
-description: Public programs for building, reviewing and contributing to Programmable projects
+description: Public programs for partnering with and contributing to Programmable projects
 ---
 
-# Programs and Hookathons
+# Creator programs
 
-Programmable uses public programs for focused building periods, project review and ecosystem contributions. The current [Hookathon page](https://programmable.market/hookathon) contains the active event terms, prize information and submission links.
+Programmable uses public programs for focused partnerships, project review and ecosystem contributions. Participation does not replace the release process. A project can be interesting, complete or selected by a program and still require its own exact source review and execution binding before it launches through Programmable.
 
-Hookathon participation does not replace the release process. A project can be interesting, complete or selected by a program and still require its own exact source review and execution binding before it launches through Programmable.
-
-Builders who are not joining an event can use the same public tools. The [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest) is open source and accepts unfamiliar project shapes, while [Submit a Launch](https://github.com/0xprogrammable/submit-launch) keeps the review record public and revision bound.
+Builders can use the same public tools. The [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest) is open source and accepts unfamiliar project shapes, while [Submit a Launch](https://github.com/0xprogrammable/submit-launch) keeps the review record public and revision bound.

--- a/tests/hookathon-surface.test.ts
+++ b/tests/hookathon-surface.test.ts
@@ -1,13 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { generateMetadata } from "@/app/hookathon/page";
+import HookathonRoute, { metadata } from "@/app/hookathon/page";
 import { HookathonPage } from "@/components/hookathon-page";
 import { hookathonConfig } from "@/lib/hookathon/config";
 
 const confirmation = Date.parse(hookathonConfig.confirmationIso);
 const deadline = Date.parse(hookathonConfig.deadlineIso);
+const root = process.cwd();
 
 function renderHookathon(initialNowMs: number) {
   return renderToStaticMarkup(
@@ -18,10 +21,6 @@ function renderHookathon(initialNowMs: number) {
 }
 
 describe("Hookathon surface", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   it("renders the complete compact running state from one config", () => {
     const html = renderHookathon(confirmation);
 
@@ -69,41 +68,28 @@ describe("Hookathon surface", () => {
     expect(html).not.toContain("Copy builder prompt");
   });
 
-  it("keeps the local draft canonical but out of search indexes", () => {
-    vi.stubEnv("VERCEL_ENV", undefined);
-    expect(generateMetadata().robots).toMatchObject({
-      index: false,
-      follow: false,
-      noarchive: true,
-    });
-
-    vi.stubEnv("VERCEL_ENV", "preview");
-    vi.stubEnv("NODE_ENV", "production");
-    const metadata = generateMetadata();
-
-    expect(metadata.alternates).toEqual({ canonical: "/hookathon" });
+  it("keeps the retired route out of navigation and search indexes", () => {
     expect(metadata.robots).toMatchObject({
       index: false,
       follow: false,
       noarchive: true,
-      googleBot: {
-        index: false,
-        follow: false,
-        noimageindex: true,
-      },
     });
-    expect(metadata.openGraph).toBeNull();
-    expect(metadata.twitter).toBeNull();
+    expect(() => HookathonRoute()).toThrow("NEXT_HTTP_ERROR_FALLBACK;404");
   });
 
-  it("allows indexing only for the explicit production release", () => {
-    vi.stubEnv("VERCEL_ENV", "production");
-    vi.stubEnv("NODE_ENV", "test");
-    const metadata = generateMetadata();
+  it("removes every public Hookathon entry point", () => {
+    const publicSurfaces = [
+      "components/site-navigation.tsx",
+      "app/docs/creators/page.tsx",
+      "app/docs/creators/programs/page.tsx",
+      "components/docs-data.ts",
+      "docs/public/SUMMARY.md",
+      "docs/public/creators/programs.md",
+    ];
 
-    expect(metadata.robots).toEqual({ index: true, follow: true });
-    expect(metadata.alternates).toEqual({ canonical: "/hookathon" });
-    expect(metadata.openGraph).toBeNull();
-    expect(metadata.twitter).toBeNull();
+    for (const path of publicSurfaces) {
+      const source = readFileSync(join(root, path), "utf8");
+      expect(source, path).not.toMatch(/hookathons?|\/hookathon/i);
+    }
   });
 });

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -201,7 +201,7 @@ describe("interaction accessibility", () => {
     expect(css).toMatch(/\.docsLink\s*\{[^}]*min-height:\s*44px;/s);
   });
 
-  it("keeps all five primary routes semantic and reflow-safe in mobile navigation", () => {
+  it("keeps all four primary routes semantic and reflow-safe in mobile navigation", () => {
     const source = readFileSync(
       join(root, "components/site-navigation.tsx"),
       "utf8",
@@ -224,9 +224,8 @@ describe("interaction accessibility", () => {
     });
 
     expect(source).toContain('const mobileNavItems = desktopNavItems;');
-    expect(source).toMatch(
-      /\{ href: "\/profile", label: "Profile" \},\s*\{ href: "\/hookathon", label: "Hookathon" \}/,
-    );
+    expect(source).toContain('{ href: "/profile", label: "Profile" },');
+    expect(source).not.toContain('/hookathon');
     expect(source).toContain(
       '<nav className="mobile-nav" aria-label="Primary navigation">',
     );
@@ -238,7 +237,7 @@ describe("interaction accessibility", () => {
     expect(mobileMediaSegments).toEqual(
       expect.arrayContaining([
         expect.stringMatching(
-          /\.mobile-nav\s*\{[^}]*grid-template-columns:\s*repeat\(5,\s*minmax\(0,\s*1fr\)\)/,
+          /\.mobile-nav\s*\{[^}]*grid-template-columns:\s*repeat\(4,\s*minmax\(0,\s*1fr\)\)/,
         ),
         expect.stringMatching(
           /\.mobile-nav\s*\{[^}]*background:\s*transparent;[^}]*border:\s*0;[^}]*height:\s*56px/,


### PR DESCRIPTION
Removes Hookathon from desktop and mobile navigation, public creator and docs entry points, and makes the direct Hookathon route return a noindex 404. Keeps the four remaining mobile navigation items balanced. Validated with 33 focused tests, TypeScript, ESLint, production build and bundle scan, desktop/mobile Playwright QA, direct 404/noindex verification, and an exact one-commit gitleaks scan.