### PR TITLE
Add safe Bitquery failure diagnostics

### DIFF
--- a/lib/market-data/bitquery.server.ts
+++ b/lib/market-data/bitquery.server.ts
@@ -64,6 +64,7 @@ type FetchImplementation = typeof fetch;
 type GraphqlResponse = Readonly<{
   data: Record<string, unknown>;
   partial: boolean;
+  partialReason?: "graphql-errors";
 }>;
 
 type BitqueryMarketDataPhase =
@@ -73,6 +74,19 @@ type BitqueryMarketDataPhase =
   | "market-price"
   | "market-stats"
   | "chart"
+  | "unspecified";
+
+export type BitqueryMarketDataFailureReason =
+  | "body-too-large"
+  | "graphql-errors"
+  | "http-status"
+  | "invalid-content-type"
+  | "invalid-json"
+  | "missing-data"
+  | "missing-evm"
+  | "missing-token"
+  | "missing-trading"
+  | "request-transport"
   | "unspecified";
 
 type BitqueryReaderOptions = Readonly<{
@@ -125,6 +139,8 @@ export class BitqueryMarketDataError extends Error {
       | "response"
       | "integrity",
     readonly phase: BitqueryMarketDataPhase = "unspecified",
+    readonly reason: BitqueryMarketDataFailureReason = "unspecified",
+    readonly httpStatus?: number,
   ) {
     super("Market data is temporarily unavailable");
   }
@@ -134,14 +150,28 @@ export function safeBitqueryMarketDataError(error: unknown): Readonly<{
   name: string;
   category: string;
   phase: string;
+  reason: BitqueryMarketDataFailureReason;
+  httpStatus?: number;
 }> {
-  return error instanceof BitqueryMarketDataError
-    ? { name: error.name, category: error.category, phase: error.phase }
-    : {
-        name: "MarketDataError",
-        category: "unexpected",
-        phase: "unspecified",
-      };
+  if (!(error instanceof BitqueryMarketDataError)) {
+    return {
+      name: "MarketDataError",
+      category: "unexpected",
+      phase: "unspecified",
+      reason: "unspecified",
+    };
+  }
+  const httpStatus = Number.isInteger(error.httpStatus) &&
+      (error.httpStatus ?? 0) >= 100 && (error.httpStatus ?? 0) <= 599
+    ? error.httpStatus
+    : undefined;
+  return {
+    name: error.name,
+    category: error.category,
+    phase: error.phase,
+    reason: error.reason,
+    ...(httpStatus === undefined ? {} : { httpStatus }),
+  };
 }
 
 function marketDataErrorAtPhase(
@@ -149,9 +179,25 @@ function marketDataErrorAtPhase(
   phase: BitqueryMarketDataPhase,
 ): BitqueryMarketDataError {
   if (error instanceof BitqueryMarketDataError) {
-    return new BitqueryMarketDataError(error.category, phase);
+    return new BitqueryMarketDataError(
+      error.category,
+      phase,
+      error.reason,
+      error.httpStatus,
+    );
   }
   throw error;
+}
+
+function partialGraphqlResponseError(
+  response: GraphqlResponse,
+  phase: BitqueryMarketDataPhase,
+): BitqueryMarketDataError {
+  return new BitqueryMarketDataError(
+    "response",
+    phase,
+    response.partialReason ?? "unspecified",
+  );
 }
 
 export function bitqueryMarketDataConfigured(
@@ -197,7 +243,11 @@ export async function readBitqueryTokenMarketDataStrictV1(
   if (unique.length === 0) return new Map();
   const token = resolveToken(options.token);
   if (token === null) {
-    throw new BitqueryMarketDataError("configuration", "configuration");
+    throw new BitqueryMarketDataError(
+      "configuration",
+      "configuration",
+      "missing-token",
+    );
   }
   const pools = new Map<string, MarketPoolDataV1>();
   const batches: MarketDataIdentityV1[][] = [];
@@ -249,7 +299,11 @@ export async function readBitqueryTokenFdvRankingStrictV1(
   }
   const token = resolveToken(options.token);
   if (token === null) {
-    throw new BitqueryMarketDataError("configuration", "configuration");
+    throw new BitqueryMarketDataError(
+      "configuration",
+      "configuration",
+      "missing-token",
+    );
   }
 
   const tokenRequest = marketFdvRankingQuery(unique);
@@ -270,11 +324,15 @@ export async function readBitqueryTokenFdvRankingStrictV1(
     throw marketDataErrorAtPhase(tokenResult.reason, "market-core");
   }
   if (tokenResult.value.partial) {
-    throw new BitqueryMarketDataError("response", "market-core");
+    throw partialGraphqlResponseError(tokenResult.value, "market-core");
   }
   const trading = record(tokenResult.value.data.Trading);
   if (trading === null) {
-    throw new BitqueryMarketDataError("response", "market-core");
+    throw new BitqueryMarketDataError(
+      "response",
+      "market-core",
+      "missing-trading",
+    );
   }
 
   const expectedTokenAddresses = new Set(
@@ -302,11 +360,18 @@ export async function readBitqueryTokenFdvRankingStrictV1(
     );
   }
   if (liquidityResult.value.partial) {
-    throw new BitqueryMarketDataError("response", "market-liquidity");
+    throw partialGraphqlResponseError(
+      liquidityResult.value,
+      "market-liquidity",
+    );
   }
   const evm = record(liquidityResult.value.data.EVM);
   if (evm === null) {
-    throw new BitqueryMarketDataError("response", "market-liquidity");
+    throw new BitqueryMarketDataError(
+      "response",
+      "market-liquidity",
+      "missing-evm",
+    );
   }
   let liquidityRows: ReadonlyMap<string, unknown>;
   try {
@@ -784,12 +849,16 @@ async function readMarketBatch(
   }
   const response = coreResult.value;
   if (options.strict && response.partial) {
-    throw new BitqueryMarketDataError("response", "market-core");
+    throw partialGraphqlResponseError(response, "market-core");
   }
   const evm = record(response.data.EVM);
   const trading = record(response.data.Trading);
   if (evm === null) {
-    throw new BitqueryMarketDataError("response", "market-core");
+    throw new BitqueryMarketDataError(
+      "response",
+      "market-core",
+      "missing-evm",
+    );
   }
   const tradesByPool = indexUniqueRows(array(evm.latestTrades), tradeRowPoolId);
   const parsedTrades = identities.map((identity) => {
@@ -822,7 +891,11 @@ async function readMarketBatch(
     options.strict && priceResult.status === "fulfilled" &&
     priceResult.value.partial
   ) {
-    throw new BitqueryMarketDataError("response", "market-price");
+    throw new BitqueryMarketDataError(
+      "response",
+      "market-price",
+      "unspecified",
+    );
   }
   const liquidityEvm = liquidityResult.status === "fulfilled" &&
       !liquidityResult.value.partial
@@ -839,7 +912,13 @@ async function readMarketBatch(
     options.strict && options.includeStats !== false &&
     (statsEvm === null || statsResult.status !== "fulfilled" ||
       statsResult.value === null || statsResult.value.partial)
-  ) throw new BitqueryMarketDataError("response", "market-stats");
+  ) {
+    const reason = statsResult.status === "fulfilled" &&
+        statsResult.value?.partialReason === "graphql-errors"
+      ? "graphql-errors" as const
+      : "missing-evm" as const;
+    throw new BitqueryMarketDataError("response", "market-stats", reason);
+  }
 
   let liquidityReadPartial = liquidityResult.status !== "fulfilled" ||
     liquidityResult.value.partial || liquidityEvm === null;
@@ -1141,7 +1220,11 @@ async function executeBitqueryGraphql(
         message === "load failed" ||
         message === "networkerror when attempting to fetch resource."
       ) {
-        throw new BitqueryMarketDataError("transport");
+        throw new BitqueryMarketDataError(
+          "transport",
+          "unspecified",
+          "request-transport",
+        );
       }
       throw error;
     }
@@ -1152,32 +1235,63 @@ async function executeBitqueryGraphql(
             response.status === 429 || response.status >= 500
           ? "transport" as const
           : "response" as const;
-      throw new BitqueryMarketDataError(category);
+      throw new BitqueryMarketDataError(
+        category,
+        "unspecified",
+        "http-status",
+        response.status,
+      );
     }
     const declared = Number(response.headers.get("content-length") ?? "0");
-    if (
-      (Number.isFinite(declared) && declared > MAXIMUM_RESPONSE_BYTES) ||
-      !response.headers.get("content-type")?.toLowerCase().includes(
-        "application/json",
-      )
-    ) {
-      throw new BitqueryMarketDataError("response");
+    if (Number.isFinite(declared) && declared > MAXIMUM_RESPONSE_BYTES) {
+      throw new BitqueryMarketDataError(
+        "response",
+        "unspecified",
+        "body-too-large",
+      );
+    }
+    if (!response.headers.get("content-type")?.toLowerCase().includes(
+      "application/json",
+    )) {
+      throw new BitqueryMarketDataError(
+        "response",
+        "unspecified",
+        "invalid-content-type",
+      );
     }
     const bytes = new Uint8Array(await response.arrayBuffer());
     if (bytes.byteLength > MAXIMUM_RESPONSE_BYTES) {
-      throw new BitqueryMarketDataError("response");
+      throw new BitqueryMarketDataError(
+        "response",
+        "unspecified",
+        "body-too-large",
+      );
     }
     let payload: unknown;
     try {
       payload = JSON.parse(new TextDecoder().decode(bytes));
     } catch {
-      throw new BitqueryMarketDataError("response");
+      throw new BitqueryMarketDataError(
+        "response",
+        "unspecified",
+        "invalid-json",
+      );
     }
     const envelope = record(payload);
     const data = record(envelope?.data);
     const errors = array(envelope?.errors);
-    if (data === null) throw new BitqueryMarketDataError("response");
-    return { data, partial: errors.length > 0 };
+    if (data === null) {
+      throw new BitqueryMarketDataError(
+        "response",
+        "unspecified",
+        "missing-data",
+      );
+    }
+    return {
+      data,
+      partial: errors.length > 0,
+      ...(errors.length === 0 ? {} : { partialReason: "graphql-errors" }),
+    };
   } finally {
     clearTimeout(timeout);
     options.signal?.removeEventListener("abort", abort);

--- a/tests/bitquery-fdv-ranking.test.ts
+++ b/tests/bitquery-fdv-ranking.test.ts
@@ -6,6 +6,7 @@ import {
   BITQUERY_HTTP_ENDPOINT,
   BitqueryMarketDataError,
   readBitqueryTokenFdvRankingStrictV1,
+  safeBitqueryMarketDataError,
 } from "../lib/market-data/bitquery.server";
 import {
   isTokenMarketDataV1,
@@ -158,6 +159,7 @@ describe("strict lightweight Bitquery FDV ranking", () => {
     })).rejects.toMatchObject({
       category: "transport",
       phase: "market-liquidity",
+      reason: "request-transport",
     });
   });
 
@@ -205,7 +207,12 @@ describe("strict lightweight Bitquery FDV ranking", () => {
       await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
         fetchImpl,
         token: TOKEN,
-      })).rejects.toMatchObject({ category, phase: "market-liquidity" });
+      })).rejects.toMatchObject({
+        category,
+        phase: "market-liquidity",
+        reason: "http-status",
+        httpStatus: status,
+      });
     },
   );
 
@@ -229,6 +236,7 @@ describe("strict lightweight Bitquery FDV ranking", () => {
     })).rejects.toMatchObject({
       category: "response",
       phase: "market-liquidity",
+      reason: "graphql-errors",
     });
   });
 
@@ -309,6 +317,7 @@ describe("strict lightweight Bitquery FDV ranking", () => {
     })).rejects.toMatchObject({
       category: "transport",
       phase: "market-core",
+      reason: "request-transport",
     });
   });
 
@@ -331,9 +340,146 @@ describe("strict lightweight Bitquery FDV ranking", () => {
           status,
         })),
         token: TOKEN,
-      })).rejects.toMatchObject({ category, phase: "market-core" });
+      })).rejects.toMatchObject({
+        category,
+        phase: "market-core",
+        reason: "http-status",
+        httpStatus: status,
+      });
     },
   );
+
+  it.each([
+    [
+      "invalid-content-type",
+      () => new Response("not json", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    ],
+    [
+      "body-too-large",
+      () => new Response("{}", {
+        status: 200,
+        headers: {
+          "Content-Length": "1500001",
+          "Content-Type": "application/json",
+        },
+      }),
+    ],
+    [
+      "body-too-large",
+      () => new Response("x".repeat(1_500_001), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ],
+    [
+      "invalid-json",
+      () => new Response("{", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ],
+    [
+      "missing-data",
+      () => json({ errors: [{ message: "provider detail must stay private" }] }),
+    ],
+  ] as const)(
+    "classifies a provider %s response without logging its body",
+    async (reason, response) => {
+      await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+        fetchImpl: vi.fn(async () => response()) as typeof fetch,
+        token: TOKEN,
+      })).rejects.toMatchObject({
+        category: "response",
+        phase: "market-core",
+        reason,
+      });
+    },
+  );
+
+  it("classifies a GraphQL error envelope without retaining its messages", async () => {
+    const providerDetail = `private provider detail ${TOKEN}`;
+    let failure: unknown;
+    try {
+      await readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+        fetchImpl: vi.fn(async () => json({
+          data: { Trading: { rankingTokens: [rankingToken()] } },
+          errors: [{ message: providerDetail }],
+        })) as typeof fetch,
+        token: TOKEN,
+      });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toMatchObject({
+      category: "response",
+      phase: "market-core",
+      reason: "graphql-errors",
+    });
+    const safe = safeBitqueryMarketDataError(failure);
+    expect(safe).toEqual({
+      name: "BitqueryMarketDataError",
+      category: "response",
+      phase: "market-core",
+      reason: "graphql-errors",
+    });
+    expect(JSON.stringify(safe)).not.toContain(providerDetail);
+    expect(JSON.stringify(safe)).not.toContain(TOKEN);
+  });
+
+  it("publishes only the safe HTTP status and typed reason", () => {
+    const failure = new BitqueryMarketDataError(
+      "response",
+      "market-core",
+      "http-status",
+      400,
+    );
+    Object.defineProperty(failure, "cause", {
+      value: `private provider body ${TOKEN}`,
+    });
+
+    const safe = safeBitqueryMarketDataError(failure);
+    expect(safe).toEqual({
+      name: "BitqueryMarketDataError",
+      category: "response",
+      phase: "market-core",
+      reason: "http-status",
+      httpStatus: 400,
+    });
+    expect(JSON.stringify(safe)).not.toContain(TOKEN);
+  });
+
+  it("distinguishes missing Trading from missing liquidity EVM data", async () => {
+    await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl: vi.fn(async () => json({ data: {} })) as typeof fetch,
+      token: TOKEN,
+    })).rejects.toMatchObject({
+      category: "response",
+      phase: "market-core",
+      reason: "missing-trading",
+    });
+
+    const fetchImpl = vi.fn(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body));
+      return request.query.includes("ProgrammableExploreFdvRanking")
+        ? json({ data: { Trading: { rankingTokens: [rankingToken()] } } })
+        : json({ data: {} });
+    }) as typeof fetch;
+    await expect(readBitqueryTokenFdvRankingStrictV1([IDENTITY], {
+      fetchImpl,
+      token: TOKEN,
+    })).rejects.toMatchObject({
+      category: "response",
+      phase: "market-liquidity",
+      reason: "missing-evm",
+    });
+  });
 
   it("does not relabel an unknown internal failure as transport", async () => {
     const programmingError = new TypeError("unexpected internal failure");

--- a/tests/bitquery-market-data.test.ts
+++ b/tests/bitquery-market-data.test.ts
@@ -57,13 +57,19 @@ describe("strict Bitquery market reads", () => {
       token: OAUTH_TOKEN,
       now: new Date("2026-08-11T14:00:01.000Z"),
       fetchImpl: vi.fn().mockRejectedValue(new TypeError("fetch failed")),
-    })).rejects.toMatchObject({ category: "transport" });
+    })).rejects.toMatchObject({
+      category: "transport",
+      reason: "request-transport",
+    });
   });
 
   it("rejects missing credentials instead of returning unavailable data", async () => {
     await expect(readBitqueryTokenMarketDataStrictV1([PCAN], {
       token: null,
-    })).rejects.toMatchObject({ category: "configuration" });
+    })).rejects.toMatchObject({
+      category: "configuration",
+      reason: "missing-token",
+    });
   });
 });
 


### PR DESCRIPTION
## Outcome

Adds enum-only, non-sensitive Bitquery failure diagnostics so the current production Explore 503 can be distinguished without logging provider responses, GraphQL messages, or credentials. Runtime fail-closed/fail-soft behavior is unchanged.

## Scope

- classify bounded HTTP, response-envelope, content and schema failure reasons
- preserve reason/status across reader phases
- expose only the typed reason and valid numeric HTTP status through the existing safe error projection
- add focused privacy and classification coverage

## Validation

- 119 focused Vitest tests pass, including Explore API
- `tsc --noEmit` passes
- scoped ESLint passes
- candidate-neutrality passes
- read-model operations source contract passes
- `git diff --check` passes

No provider call, environment mutation, secret read, deployment, or routing change is included.