### PR TITLE
Degrade Explore safely when Bitquery returns HTTP 402

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1243,14 +1243,42 @@ jobs:
               (valuation.reason === "source-unavailable" || exactNoMarket) &&
               Object.keys(valuation).length === 2 &&
               token?.fdvUsdWad === undefined &&
-              token?.marketData === undefined;
+              token?.marketCapUsdWad === undefined &&
+              token?.marketCapEthWad === undefined &&
+              token?.priceUsdWad === undefined &&
+              token?.priceEthWad === undefined &&
+              token?.liquidityEvidence === undefined &&
+              token?.marketData === undefined &&
+              token?.uniswapV4Pool === undefined;
           }
-          function exactTransportUnavailableExplore(
+          function exactUnavailableMarketRead(marketRead, readStatus) {
+            const common = marketRead?.provider === "bitquery" &&
+              marketRead.status === "unavailable" &&
+              ["market-core", "market-liquidity", "market-price"].includes(
+                marketRead.phase,
+              );
+            if (!common) return false;
+            if (readStatus === "transport-unavailable") {
+              return marketRead.category === "transport" &&
+                marketRead.reason === undefined &&
+                marketRead.httpStatus === undefined;
+            }
+            if (readStatus === "response-unavailable") {
+              return marketRead.category === "response" &&
+                marketRead.reason === "http-status" &&
+                marketRead.httpStatus === 402;
+            }
+            return false;
+          }
+          function exactUnavailableExplore(
             response,
             tokens,
             rankingRequired,
           ) {
             const marketRead = response.body?.marketRead;
+            const readStatus = response.headers.get(
+              "x-programmable-market-read-status",
+            );
             const launchIdentity = response.body?.dataQuality?.launchIdentity;
             const valuation = response.body?.dataQuality?.valuation;
             const ranking = response.body?.ranking;
@@ -1259,8 +1287,9 @@ jobs:
               response.headers.get("x-programmable-launch-source") === "drpc" &&
               response.headers.get("x-programmable-read-source") === "drpc" &&
               response.headers.get("x-programmable-data-quality") === "partial" &&
-              response.headers.get("x-programmable-market-read-status") ===
-                "transport-unavailable" &&
+              ["transport-unavailable", "response-unavailable"].includes(
+                readStatus,
+              ) &&
               response.headers.get("x-programmable-market-provider") ===
                 "bitquery" &&
               !response.headers.has("x-programmable-market-source") &&
@@ -1270,12 +1299,7 @@ jobs:
               launchIdentity?.status === "current" &&
               launchIdentity.canonical === "current" &&
               launchIdentity.custom === "current" &&
-              marketRead?.provider === "bitquery" &&
-              marketRead.status === "unavailable" &&
-              marketRead.category === "transport" &&
-              ["market-core", "market-liquidity", "market-price"].includes(
-                marketRead.phase,
-              ) &&
+              exactUnavailableMarketRead(marketRead, readStatus) &&
               valuation?.status === "unavailable" &&
               valuation.metric === "fdv" &&
               valuation.available === 0 &&
@@ -1353,7 +1377,11 @@ jobs:
             "x-programmable-market-read-status",
           );
           if (
-            !["current", "transport-unavailable"].includes(
+            ![
+              "current",
+              "transport-unavailable",
+              "response-unavailable",
+            ].includes(
               highestMarketReadStatus,
             ) ||
             newestMarketReadStatus !== highestMarketReadStatus
@@ -1426,12 +1454,12 @@ jobs:
             chartStatus = "verified-" + chart.body.status;
           } else {
             if (
-              !exactTransportUnavailableExplore(
+              !exactUnavailableExplore(
                 highest,
                 highestTokens,
                 true,
               ) ||
-              !exactTransportUnavailableExplore(newest, newestTokens, false) ||
+              !exactUnavailableExplore(newest, newestTokens, false) ||
               !exactDegradedLaunchOrder(
                 highest,
                 highestTokens,
@@ -1440,7 +1468,7 @@ jobs:
               )
             ) {
               throw new Error(
-                "Explore transport-unavailable contract is invalid",
+                "Explore unavailable market-read contract is invalid",
               );
             }
             tokenAddress = highestTokens.find((token) =>
@@ -1480,7 +1508,9 @@ jobs:
           }
           const smokeStatus = marketReadStatus === "current"
             ? "verified-staged-drpc-bitquery-public-apis"
-            : "verified-staged-drpc-launches-bitquery-transport-unavailable";
+            : marketReadStatus === "transport-unavailable"
+              ? "verified-staged-drpc-launches-bitquery-transport-unavailable"
+              : "verified-staged-drpc-launches-bitquery-response-unavailable";
           const githubOutput = process.env.GITHUB_OUTPUT;
           if (!githubOutput) {
             throw new Error("GitHub output path is unavailable");

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -279,20 +279,41 @@ function generatedAgeMs(generatedAt: string): number | null {
   return Number.isFinite(value) ? Math.max(0, Date.now() - value) : null;
 }
 
-function isFailSoftMarketTransportFailure(
+type FailSoftMarketReadFailure =
+  | BitqueryMarketDataError & Readonly<{
+      category: "transport";
+      phase: "market-core" | "market-liquidity" | "market-price";
+    }>
+  | BitqueryMarketDataError & Readonly<{
+      category: "response";
+      phase: "market-core" | "market-liquidity" | "market-price";
+      reason: "http-status";
+      httpStatus: 402;
+    }>;
+
+function isFailSoftMarketReadFailure(
   error: unknown,
   signal: AbortSignal,
   identityEntryCount: number,
   marketIdentityCount: number,
-): error is BitqueryMarketDataError {
+): error is FailSoftMarketReadFailure {
   return identityEntryCount > 0 &&
     marketIdentityCount > 0 &&
     !signal.aborted &&
     error instanceof BitqueryMarketDataError &&
-    error.category === "transport" &&
+    (error.category === "transport" ||
+      (error.category === "response" &&
+        error.reason === "http-status" &&
+        error.httpStatus === 402)) &&
     (error.phase === "market-core" ||
       error.phase === "market-liquidity" ||
       error.phase === "market-price");
+}
+
+function unavailableMarketReadStatus(error: FailSoftMarketReadFailure) {
+  return error.category === "transport"
+    ? "transport-unavailable" as const
+    : "response-unavailable" as const;
 }
 
 export async function GET(request: NextRequest) {
@@ -325,7 +346,7 @@ export async function GET(request: NextRequest) {
     });
     const identityEntries = dedupeExploreEntriesV1(launches.entries);
     const now = new Date();
-    let marketTransportFailure: BitqueryMarketDataError | null = null;
+    let marketReadFailure: FailSoftMarketReadFailure | null = null;
     let paginated: ReturnType<typeof paginateExploreEntriesV1>;
     if (options.sort === "market-cap" || options.sort === "market-cap-asc") {
       const filtered = filterExploreEntries(
@@ -341,16 +362,16 @@ export async function GET(request: NextRequest) {
           { signal: request.signal },
         );
       } catch (error) {
-        if (!isFailSoftMarketTransportFailure(
+        if (!isFailSoftMarketReadFailure(
           error,
           request.signal,
           identityEntries.length,
           marketIdentities.length,
         )) throw error;
-        console.error("Explore market transport unavailable", {
+        console.error("Explore market read unavailable", {
           market: safeBitqueryMarketDataError(error),
         });
-        marketTransportFailure = error;
+        marketReadFailure = error;
         marketByToken = new Map();
       }
       const valued = filtered.map((entry): ValuedExploreEntry => {
@@ -381,16 +402,16 @@ export async function GET(request: NextRequest) {
           { signal: request.signal, includeStats: false },
         );
       } catch (error) {
-        if (!isFailSoftMarketTransportFailure(
+        if (!isFailSoftMarketReadFailure(
           error,
           request.signal,
           identityEntries.length,
           marketIdentities.length,
         )) throw error;
-        console.error("Explore market transport unavailable", {
+        console.error("Explore market read unavailable", {
           market: safeBitqueryMarketDataError(error),
         });
-        marketTransportFailure = error;
+        marketReadFailure = error;
         marketByToken = new Map();
       }
       const valued = identityPage.tokens.map((entry): ValuedExploreEntry => {
@@ -401,7 +422,7 @@ export async function GET(request: NextRequest) {
         if (
           marketIsRequired &&
           marketData === undefined &&
-          marketTransportFailure === null
+          marketReadFailure === null
         ) {
           throw new Error("Bitquery market response is incomplete");
         }
@@ -440,17 +461,23 @@ export async function GET(request: NextRequest) {
         sortMetric: "fdv" as const,
         dataQuality,
         snapshot: null,
-        ...(marketTransportFailure === null
+        ...(marketReadFailure === null
           ? {}
           : {
               marketRead: {
                 provider: "bitquery" as const,
                 status: "unavailable" as const,
-                category: "transport" as const,
-                phase: marketTransportFailure.phase,
+                category: marketReadFailure.category,
+                phase: marketReadFailure.phase,
+                ...(marketReadFailure.category === "response"
+                  ? {
+                      reason: "http-status" as const,
+                      httpStatus: 402 as const,
+                    }
+                  : {}),
               },
             }),
-        ...(marketTransportFailure !== null &&
+        ...(marketReadFailure !== null &&
             (options.sort === "market-cap" ||
               options.sort === "market-cap-asc")
           ? {
@@ -464,26 +491,26 @@ export async function GET(request: NextRequest) {
       },
       {
         headers: {
-          "Cache-Control": marketTransportFailure === null
+          "Cache-Control": marketReadFailure === null
             ? "public, max-age=0, s-maxage=2"
             : "no-store",
           "X-Programmable-Data-Quality": dataQuality.status,
           "X-Programmable-Launch-Source": "drpc",
-          "X-Programmable-Read-Source": marketTransportFailure === null
+          "X-Programmable-Read-Source": marketReadFailure === null
             ? "drpc+bitquery"
             : "drpc",
           "X-Programmable-Market-Read-Status":
-            marketTransportFailure === null
+            marketReadFailure === null
               ? "current"
-              : "transport-unavailable",
+              : unavailableMarketReadStatus(marketReadFailure),
           "X-Programmable-Market-Provider": "bitquery",
-          ...(marketTransportFailure === null
+          ...(marketReadFailure === null
             ? {
                 "X-Programmable-Market-Source": "bitquery",
                 "X-Programmable-Price-Source": "bitquery",
               }
             : {}),
-          ...(marketTransportFailure === null &&
+          ...(marketReadFailure === null &&
               dataQuality.valuation.asOfTime
             ? { "X-Programmable-Market-As-Of": dataQuality.valuation.asOfTime }
             : {}),

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -107,12 +107,23 @@ type TokenSort = "newest" | "oldest" | "market-cap" | "market-cap-asc";
 export type ExploreSocialFilter = "all" | "yes" | "no";
 export type ExploreModelFilter = "all" | "classic" | "custom-hook";
 
-type ExploreMarketRead = Readonly<{
+type ExploreMarketReadBase = Readonly<{
   provider: "bitquery";
   status: "unavailable";
-  category: "transport";
-  phase: "market-core" | "market-price";
+  phase: "market-core" | "market-liquidity" | "market-price";
 }>;
+
+type ExploreMarketRead =
+  | ExploreMarketReadBase & Readonly<{
+      category: "transport";
+      reason?: never;
+      httpStatus?: never;
+    }>
+  | ExploreMarketReadBase & Readonly<{
+      category: "response";
+      reason: "http-status";
+      httpStatus: 402;
+    }>;
 
 type ExploreRanking = Readonly<{
   status: "unavailable";
@@ -719,6 +730,28 @@ function positiveInteger(value: unknown, fallback: number) {
     : fallback;
 }
 
+function parseExploreMarketRead(value: unknown): ExploreMarketRead | null {
+  if (
+    !isRecord(value) ||
+    value.provider !== "bitquery" ||
+    value.status !== "unavailable" ||
+    (value.phase !== "market-core" &&
+      value.phase !== "market-liquidity" &&
+      value.phase !== "market-price")
+  ) return null;
+  if (
+    value.category === "transport" &&
+    value.reason === undefined &&
+    value.httpStatus === undefined
+  ) return value as ExploreMarketRead;
+  if (
+    value.category === "response" &&
+    value.reason === "http-status" &&
+    value.httpStatus === 402
+  ) return value as ExploreMarketRead;
+  return null;
+}
+
 function parseExplorePayload(value: unknown): ExplorePayload {
   if (!isRecord(value)) {
     throw new Error("The token registry returned an invalid response");
@@ -735,14 +768,7 @@ function parseExplorePayload(value: unknown): ExplorePayload {
   ) {
     throw new Error("The token registry returned invalid data quality");
   }
-  const marketRead = isRecord(value.marketRead) &&
-      value.marketRead.provider === "bitquery" &&
-      value.marketRead.status === "unavailable" &&
-      value.marketRead.category === "transport" &&
-      (value.marketRead.phase === "market-core" ||
-        value.marketRead.phase === "market-price")
-    ? value.marketRead as ExploreMarketRead
-    : null;
+  const marketRead = parseExploreMarketRead(value.marketRead);
   if (value.marketRead !== undefined && marketRead === null) {
     throw new Error("The token registry returned invalid market read data");
   }
@@ -1035,9 +1061,26 @@ async function fetchExplorePayload(
       const marketReadStatus = response.headers.get(
         "X-Programmable-Market-Read-Status",
       );
+      const expectedUnavailableStatus = payload.marketRead?.category === "transport"
+        ? "transport-unavailable"
+        : payload.marketRead?.category === "response"
+          ? "response-unavailable"
+          : null;
+      if (
+        expectedUnavailableStatus !== null &&
+        marketReadStatus !== expectedUnavailableStatus
+      ) {
+        throw new Error("The token registry returned inconsistent market read data");
+      }
       if (
         marketReadStatus === "transport-unavailable" &&
-        payload.marketRead?.status !== "unavailable"
+        payload.marketRead?.category !== "transport"
+      ) {
+        throw new Error("The token registry returned inconsistent market read data");
+      }
+      if (
+        marketReadStatus === "response-unavailable" &&
+        payload.marketRead?.category !== "response"
       ) {
         throw new Error("The token registry returned inconsistent market read data");
       }
@@ -1047,11 +1090,12 @@ async function fetchExplorePayload(
       ) {
         throw new Error("The token registry returned inconsistent market read data");
       }
-      const marketTransportUnavailable =
-        marketReadStatus === "transport-unavailable";
+      const marketReadUnavailable =
+        marketReadStatus === "transport-unavailable" ||
+        marketReadStatus === "response-unavailable";
       if (
         attempt === 0 &&
-        !marketTransportUnavailable &&
+        !marketReadUnavailable &&
         shouldRetryMissingBitqueryFdv(search, payload)
       ) {
         continue;
@@ -1193,6 +1237,8 @@ export async function loadExploreModelDataset(
       payload.marketRead?.status === degradedPage.marketRead?.status &&
       payload.marketRead?.category === degradedPage.marketRead?.category &&
       payload.marketRead?.phase === degradedPage.marketRead?.phase &&
+      payload.marketRead?.reason === degradedPage.marketRead?.reason &&
+      payload.marketRead?.httpStatus === degradedPage.marketRead?.httpStatus &&
       payload.ranking?.status === degradedPage.ranking?.status &&
       payload.ranking?.requested === degradedPage.ranking?.requested &&
       payload.ranking?.applied === degradedPage.ranking?.applied

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2488,6 +2488,10 @@ export function evaluateReadModelOperationsSourceContracts(
         '              emptyCurrentBitqueryFdvRanking(response, "market-cap"),',
     ) &&
     (stagedBitquerySmokeBlock.match(/emptyCurrentBitqueryFdvRanking/gu)?.length ?? 0) === 2;
+  const stagedAllowedMarketReadStatuses =
+    /\[\s*"current",\s*"transport-unavailable",\s*"response-unavailable",?\s*\]\.includes\(\s*highestMarketReadStatus,?\s*\)/u.test(
+      stagedBitquerySmokeBlock,
+    );
   const stagedCurrentMarketBranch = stagedBitquerySmokeBlock.indexOf(
     'if (marketReadStatus === "current")',
   );
@@ -2539,12 +2543,13 @@ export function evaluateReadModelOperationsSourceContracts(
     stagedDegradedMarketBranch > stagedChartProbe &&
     stagedProfileProbe > stagedDegradedMarketBranch &&
     stagedLaunchIdentityContract &&
+    stagedAllowedMarketReadStatuses &&
     includesEverySourceFragment(stagedBitquerySmokeBlock, [
       "status: response.status",
       "highest.status !== 200",
       "newest.status !== 200",
       '"x-programmable-market-read-status"',
-      '["current", "transport-unavailable"].includes(',
+      '"current",\n              "transport-unavailable",\n              "response-unavailable",',
       "newestMarketReadStatus !== highestMarketReadStatus",
       "exactCurrentExploreSources(highest)",
       "exactCurrentExploreSources(newest)",
@@ -2605,12 +2610,21 @@ export function evaluateReadModelOperationsSourceContracts(
       'launchIdentity?.status === "current"',
       'launchIdentity.canonical === "current"',
       'launchIdentity.custom === "current"',
+      "function exactUnavailableMarketRead(marketRead, readStatus)",
       'marketRead?.provider === "bitquery"',
       'marketRead.status === "unavailable"',
-      'marketRead.category === "transport"',
       '["market-core", "market-liquidity", "market-price"].includes(\n' +
         "                marketRead.phase,\n" +
         "              )",
+      'readStatus === "transport-unavailable"',
+      'marketRead.category === "transport"',
+      "marketRead.reason === undefined",
+      "marketRead.httpStatus === undefined",
+      'readStatus === "response-unavailable"',
+      'marketRead.category === "response"',
+      'marketRead.reason === "http-status"',
+      "marketRead.httpStatus === 402",
+      "exactUnavailableMarketRead(marketRead, readStatus)",
       'valuation?.status === "unavailable"',
       'valuation.metric === "fdv"',
       "valuation.available === 0",
@@ -2628,18 +2642,25 @@ export function evaluateReadModelOperationsSourceContracts(
       'valuation.reason === "source-unavailable" || exactNoMarket',
       "Object.keys(valuation).length === 2",
       "token?.fdvUsdWad === undefined",
+      "token?.marketCapUsdWad === undefined",
+      "token?.marketCapEthWad === undefined",
+      "token?.priceUsdWad === undefined",
+      "token?.priceEthWad === undefined",
+      "token?.liquidityEvidence === undefined",
       "token?.marketData === undefined",
+      "token?.uniswapV4Pool === undefined",
       'ranking?.status === "unavailable"',
       'ranking.requested === "fdv"',
       'ranking.applied === "launch-order"',
       ": ranking === undefined",
-      "exactTransportUnavailableExplore(\n                highest,\n                highestTokens,\n                true,",
-      "exactTransportUnavailableExplore(newest, newestTokens, false)",
+      "exactUnavailableExplore(\n                highest,\n                highestTokens,\n                true,",
+      "exactUnavailableExplore(newest, newestTokens, false)",
       "!exactDegradedLaunchOrder(\n                highest,\n                highestTokens,\n                newest,\n                newestTokens,",
       'detailStatus = "skipped-provider-unavailable"',
       'chartStatus = "skipped-provider-unavailable"',
       '"verified-staged-drpc-bitquery-public-apis"',
       '"verified-staged-drpc-launches-bitquery-transport-unavailable"',
+      '"verified-staged-drpc-launches-bitquery-response-unavailable"',
       '"market_read_status=" + marketReadStatus',
       '"detail_status=" + detailStatus',
       '"chart_status=" + chartStatus',
@@ -2779,6 +2800,35 @@ export function evaluateReadModelOperationsSourceContracts(
   const publicExploreHasMarketReadStatus = publicExplore.includes(
     '"X-Programmable-Market-Read-Status"',
   );
+  const publicExploreFailSoftStart = publicExplore.indexOf(
+    "function isFailSoftMarketReadFailure(",
+  );
+  const publicExploreFailSoftEnd = publicExplore.indexOf(
+    "function unavailableMarketReadStatus(",
+    publicExploreFailSoftStart,
+  );
+  const publicExploreFailSoftBlock =
+    publicExploreFailSoftStart >= 0 &&
+    publicExploreFailSoftEnd > publicExploreFailSoftStart
+      ? publicExplore.slice(publicExploreFailSoftStart, publicExploreFailSoftEnd)
+      : "";
+  const publicExploreFailSoftContract = includesEverySourceFragment(
+    publicExploreFailSoftBlock,
+    [
+      "identityEntryCount > 0",
+      "marketIdentityCount > 0",
+      "!signal.aborted",
+      "error instanceof BitqueryMarketDataError",
+      "): error is FailSoftMarketReadFailure {",
+      'error.category === "transport"',
+      'error.category === "response"',
+      'error.reason === "http-status"',
+      "error.httpStatus === 402",
+      '(error.phase === "market-core" ||\n' +
+        '      error.phase === "market-liquidity" ||\n' +
+        '      error.phase === "market-price")',
+    ],
+  );
   const publicExploreLegacyHealthyHeaderContract =
     !publicExploreHasMarketReadStatus &&
     includesEverySourceFragment(publicExplore, [
@@ -2789,52 +2839,61 @@ export function evaluateReadModelOperationsSourceContracts(
     ]);
   const publicExploreMarketReadContract =
     publicExploreHasMarketReadStatus &&
+    publicExploreFailSoftContract &&
     includesEverySourceFragment(publicExplore, [
-      "error instanceof BitqueryMarketDataError",
-      'error.category === "transport"',
-      '(error.phase === "market-core" ||\n' +
-        '      error.phase === "market-liquidity" ||\n' +
-        '      error.phase === "market-price")',
-      "identityEntryCount > 0",
-      "marketIdentityCount > 0",
-      "!signal.aborted",
-      "marketTransportFailure === null",
+      "function isFailSoftMarketReadFailure(",
+      "type FailSoftMarketReadFailure =",
+      "category: \"transport\";",
+      "category: \"response\";",
+      'reason: "http-status";',
+      "httpStatus: 402;",
+      "function unavailableMarketReadStatus(error: FailSoftMarketReadFailure)",
+      '? "transport-unavailable" as const',
+      ': "response-unavailable" as const',
+      "marketReadFailure === null",
+      "let marketReadFailure: FailSoftMarketReadFailure | null = null",
+      "marketReadFailure = error",
+      "marketByToken = new Map()",
+      'console.error("Explore market read unavailable", {',
+      "market: safeBitqueryMarketDataError(error)",
       'provider: "bitquery" as const',
       'status: "unavailable" as const',
-      'category: "transport" as const',
-      "phase: marketTransportFailure.phase",
+      "category: marketReadFailure.category",
+      "phase: marketReadFailure.phase",
+      'reason: "http-status" as const',
+      "httpStatus: 402 as const",
       'requested: "fdv" as const',
       'applied: "launch-order" as const',
       '? "public, max-age=0, s-maxage=2"',
       ': "no-store"',
       '"X-Programmable-Launch-Source": "drpc"',
-      '"X-Programmable-Read-Source": marketTransportFailure === null',
+      '"X-Programmable-Read-Source": marketReadFailure === null',
       '? "drpc+bitquery"',
       ': "drpc"',
       '"X-Programmable-Market-Read-Status":',
       '? "current"',
-      ': "transport-unavailable"',
+      ': unavailableMarketReadStatus(marketReadFailure)',
       '"X-Programmable-Market-Provider": "bitquery"',
       '"X-Programmable-Market-Source": "bitquery"',
       '"X-Programmable-Price-Source": "bitquery"',
-      "marketTransportFailure === null &&",
-      '"Cache-Control": marketTransportFailure === null\n' +
+      "marketReadFailure === null &&",
+      '"Cache-Control": marketReadFailure === null\n' +
         '            ? "public, max-age=0, s-maxage=2"\n' +
         '            : "no-store",',
-      '"X-Programmable-Read-Source": marketTransportFailure === null\n' +
+      '"X-Programmable-Read-Source": marketReadFailure === null\n' +
         '            ? "drpc+bitquery"\n' +
         '            : "drpc",',
       '"X-Programmable-Market-Read-Status":\n' +
-        "            marketTransportFailure === null\n" +
+        "            marketReadFailure === null\n" +
         '              ? "current"\n' +
-        '              : "transport-unavailable",',
-      "...(marketTransportFailure === null\n" +
+        "              : unavailableMarketReadStatus(marketReadFailure),",
+      "...(marketReadFailure === null\n" +
         "            ? {\n" +
         '                "X-Programmable-Market-Source": "bitquery",\n' +
         '                "X-Programmable-Price-Source": "bitquery",\n' +
         "              }\n" +
         "            : {}),",
-      "...(marketTransportFailure === null &&\n" +
+      "...(marketReadFailure === null &&\n" +
         "              dataQuality.valuation.asOfTime",
     ]);
   const primaryRpcLaunchCatalogCacheStart =
@@ -2982,7 +3041,7 @@ export function evaluateReadModelOperationsSourceContracts(
             route,
           ),
       ),
-    "public identity and action state use one commitment-bound dRPC primary, Custom Registry detail is a separate post-miss source, and market, FDV and charts use explicit Bitquery reads with bounded transport-unavailable Explore semantics",
+    "public identity and action state use one commitment-bound dRPC primary, Custom Registry detail is a separate post-miss source, and market, FDV and charts use explicit Bitquery reads with bounded transport or exact HTTP 402 Explore degradation",
   );
   check(
     "ops-protected-public-provider-stage-smoke",
@@ -3031,7 +3090,7 @@ export function evaluateReadModelOperationsSourceContracts(
       !/alchemy|blob|durable|graph|stateview|chainlink|envio|prewarm|secondary|fallback|quorum/iu.test(
         stagedBitquerySmokeBlock,
       ),
-    "the immutable staged candidate proves dRPC identity and profile responses plus either current Bitquery market reads or an exact transport-unavailable handoff without exposing an RPC endpoint",
+    "the immutable staged candidate proves dRPC identity and profile responses plus either current Bitquery market reads or an exact transport or HTTP 402 unavailable handoff without exposing an RPC endpoint",
   );
   check(
     "ops-obsolete-public-read-gates-absent",

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -20,7 +20,7 @@ const reconciler = readFileSync(
   "utf8",
 );
 const boundedReader = readFileSync("scripts/read-bounded-response.mjs", "utf8");
-const exactTransportUnavailableMarketPhases =
+const exactUnavailableMarketPhases =
   /\["market-core", "market-liquidity", "market-price"\]\.includes\(\s*marketRead\.phase,\s*\)/u;
 
 function stepBlock(source, name) {
@@ -321,7 +321,7 @@ test("Custom-only changes do not invoke the public data smoke", () => {
   );
   assert.match(
     smoke,
-    /\["current", "transport-unavailable"\]\.includes\([\s\S]*newestMarketReadStatus !== highestMarketReadStatus/u,
+    /"current",\s*"transport-unavailable",\s*"response-unavailable",[\s\S]*newestMarketReadStatus !== highestMarketReadStatus/u,
   );
   assert.match(
     smoke,
@@ -329,7 +329,7 @@ test("Custom-only changes do not invoke the public data smoke", () => {
   );
   assert.match(
     smoke,
-    /x-programmable-read-source"\) === "drpc"[\s\S]*x-programmable-data-quality"\) === "partial"[\s\S]*x-programmable-market-read-status"\) ===[\s\S]*"transport-unavailable"[\s\S]*x-programmable-market-provider"\) ===[\s\S]*"bitquery"/u,
+    /x-programmable-read-source"\) === "drpc"[\s\S]*x-programmable-data-quality"\) === "partial"[\s\S]*"transport-unavailable", "response-unavailable"[\s\S]*x-programmable-market-provider"\) ===[\s\S]*"bitquery"/u,
   );
   assert.match(
     smoke,
@@ -337,12 +337,16 @@ test("Custom-only changes do not invoke the public data smoke", () => {
   );
   assert.match(
     smoke,
-    /marketRead\?\.provider === "bitquery"[\s\S]*marketRead\.status === "unavailable"[\s\S]*marketRead\.category === "transport"/u,
+    /function exactUnavailableMarketRead\(marketRead, readStatus\)[\s\S]*marketRead\?\.provider === "bitquery"[\s\S]*marketRead\.status === "unavailable"[\s\S]*readStatus === "transport-unavailable"[\s\S]*marketRead\.category === "transport"[\s\S]*marketRead\.reason === undefined[\s\S]*marketRead\.httpStatus === undefined[\s\S]*readStatus === "response-unavailable"[\s\S]*marketRead\.category === "response"[\s\S]*marketRead\.reason === "http-status"[\s\S]*marketRead\.httpStatus === 402/u,
   );
-  assert.match(smoke, exactTransportUnavailableMarketPhases);
+  assert.match(smoke, exactUnavailableMarketPhases);
   assert.match(
     smoke,
     /valuation\?\.status === "unavailable"[\s\S]*valuation\.available === 0[\s\S]*valuation\.unavailable === tokens\.length[\s\S]*tokens\.every\(exactUnavailableValuation\)/u,
+  );
+  assert.match(
+    smoke,
+    /token\?\.fdvUsdWad === undefined[\s\S]*token\?\.marketCapUsdWad === undefined[\s\S]*token\?\.marketCapEthWad === undefined[\s\S]*token\?\.priceUsdWad === undefined[\s\S]*token\?\.priceEthWad === undefined[\s\S]*token\?\.liquidityEvidence === undefined[\s\S]*token\?\.marketData === undefined[\s\S]*token\?\.uniswapV4Pool === undefined/u,
   );
   assert.match(
     smoke,
@@ -381,6 +385,10 @@ test("Custom-only changes do not invoke the public data smoke", () => {
     /profile\.headers\.get\("x-programmable-rpc-provider"\) !==[\s\S]*"drpc-primary"/u,
   );
   assert.match(smoke, /verified-staged-drpc-bitquery-public-apis/u);
+  assert.match(
+    smoke,
+    /verified-staged-drpc-launches-bitquery-response-unavailable/u,
+  );
   assert.match(smoke, /creatorClaimPrepare: "separate-live-probe-required"/u);
   assert.match(smoke, /tradePrepare: "separate-live-probe-required"/u);
   assert.doesNotMatch(smoke, /\/api\/explore\/profile\/claim/u);
@@ -409,11 +417,11 @@ test("Custom-only changes do not invoke the public data smoke", () => {
   }
 });
 
-test("the staged transport contract rejects removal of exact-pool liquidity", () => {
+test("the staged unavailable-market contract rejects removal of exact-pool liquidity", () => {
   const smoke = stepBlock(deploy, "Smoke staged Bitquery public APIs");
   const mutated = smoke.replace('"market-liquidity", ', "");
   assert.notEqual(mutated, smoke);
-  assert.doesNotMatch(mutated, exactTransportUnavailableMarketPhases);
+  assert.doesNotMatch(mutated, exactUnavailableMarketPhases);
 });
 
 test("degraded Highest must match the exact Newest launch identity order", () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -878,7 +878,7 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("accepts the exact Explore transport-unavailable provider taxonomy", () => {
+  it("accepts the exact Explore transport and HTTP 402 provider taxonomy", () => {
     const path = "app/api/explore/route.ts";
     const route = readFileSync(resolve(ROOT, path), "utf8");
     expect(route).toContain('error.phase === "market-liquidity"');
@@ -897,6 +897,11 @@ describe("read-model operations source contract", () => {
       'error.category === "schema"',
     ],
     [
+      "an unbounded response status",
+      "error.httpStatus === 402",
+      "error.httpStatus >= 400",
+    ],
+    [
       "an unbounded failure phase",
       '(error.phase === "market-core" ||\n      error.phase === "market-liquidity" ||\n      error.phase === "market-price")',
       "Boolean(error.phase)",
@@ -908,13 +913,13 @@ describe("read-model operations source contract", () => {
     ],
     [
       "a combined degraded read source",
-      '"X-Programmable-Read-Source": marketTransportFailure === null\n            ? "drpc+bitquery"\n            : "drpc",',
-      '"X-Programmable-Read-Source": marketTransportFailure === null\n            ? "drpc+bitquery"\n            : "drpc+bitquery",',
+      '"X-Programmable-Read-Source": marketReadFailure === null\n            ? "drpc+bitquery"\n            : "drpc",',
+      '"X-Programmable-Read-Source": marketReadFailure === null\n            ? "drpc+bitquery"\n            : "drpc+bitquery",',
     ],
     [
       "an unknown degraded market marker",
-      '"X-Programmable-Market-Read-Status":\n            marketTransportFailure === null\n              ? "current"\n              : "transport-unavailable",',
-      '"X-Programmable-Market-Read-Status":\n            marketTransportFailure === null\n              ? "current"\n              : "unknown",',
+      ': unavailableMarketReadStatus(marketReadFailure),',
+      ': "unknown",',
     ],
     [
       "a different market provider",
@@ -923,8 +928,8 @@ describe("read-model operations source contract", () => {
     ],
     [
       "a healthy degraded cache policy",
-      '"Cache-Control": marketTransportFailure === null\n            ? "public, max-age=0, s-maxage=2"\n            : "no-store",',
-      '"Cache-Control": marketTransportFailure === null\n            ? "public, max-age=0, s-maxage=2"\n            : "public, max-age=0, s-maxage=2",',
+      '"Cache-Control": marketReadFailure === null\n            ? "public, max-age=0, s-maxage=2"\n            : "no-store",',
+      '"Cache-Control": marketReadFailure === null\n            ? "public, max-age=0, s-maxage=2"\n            : "public, max-age=0, s-maxage=2",',
     ],
     [
       "FDV ordering during provider degradation",
@@ -1126,8 +1131,8 @@ describe("read-model operations source contract", () => {
   it.each([
     [
       "an unknown market-read marker",
-      '["current", "transport-unavailable"].includes(',
-      '["current", "transport-unavailable", "unknown"].includes(',
+      '"current",\n              "transport-unavailable",\n              "response-unavailable",',
+      '"current",\n              "transport-unavailable",\n              "response-unavailable",\n              "unknown",',
     ],
     [
       "mixed Highest and Newest market-read states",
@@ -1217,6 +1222,16 @@ describe("read-model operations source contract", () => {
       'marketRead.category !== "schema"',
     ],
     [
+      "an arbitrary degraded response reason",
+      'marketRead.reason === "http-status"',
+      'marketRead.reason !== "schema"',
+    ],
+    [
+      "an arbitrary degraded response status",
+      "marketRead.httpStatus === 402",
+      "marketRead.httpStatus >= 400",
+    ],
+    [
       "an unbounded degraded failure phase",
       '["market-core", "market-liquidity", "market-price"].includes(\n                marketRead.phase,\n              )',
       "Boolean(marketRead.phase)",
@@ -1254,6 +1269,16 @@ describe("read-model operations source contract", () => {
     [
       "fabricated degraded market data",
       "token?.marketData === undefined",
+      "true",
+    ],
+    [
+      "fabricated degraded liquidity evidence",
+      "token?.liquidityEvidence === undefined",
+      "true",
+    ],
+    [
+      "fabricated degraded price",
+      "token?.priceUsdWad === undefined",
       "true",
     ],
     [

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -22,6 +22,8 @@ const mocks = vi.hoisted(() => {
         | "response"
         | "integrity",
       readonly phase = "unspecified",
+      readonly reason = "unspecified",
+      readonly httpStatus?: number,
     ) {
       super("Market data is temporarily unavailable");
     }
@@ -37,11 +39,16 @@ const mocks = vi.hoisted(() => {
             name: error.name,
             category: error.category,
             phase: error.phase,
+            reason: error.reason,
+            ...(error.httpStatus === undefined
+              ? {}
+              : { httpStatus: error.httpStatus }),
           }
         : {
             name: "MarketDataError",
             category: "unexpected",
             phase: "unspecified",
+            reason: "unspecified",
           }
     ),
   };
@@ -476,15 +483,129 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
   });
 
   it.each([
-    ["configuration", "configuration"],
-    ["response", "market-core"],
-    ["integrity", "market-core"],
-    ["transport", "market-stats"],
+    ["market-core", "market-cap", true],
+    ["market-liquidity", "market-cap-asc", true],
+    ["market-price", "newest", false],
   ] as const)(
-    "keeps Bitquery %s/%s failures fail-closed",
-    async (category, phase) => {
+    "serves identity-only launch data for Bitquery HTTP 402 in %s with %s",
+    async (phase, sort, expectsRanking) => {
+      const failure = new mocks.BitqueryMarketDataError(
+        "response",
+        phase,
+        "http-status",
+        402,
+      );
+      if (sort === "newest") {
+        mocks.readBitqueryTokenMarketDataStrictV1.mockRejectedValueOnce(failure);
+      } else {
+        mocks.readBitqueryTokenFdvRankingStrictV1.mockRejectedValueOnce(failure);
+      }
+
+      const response = await GET(request(`sort=${sort}&page=1&limit=9`));
+      const body = await json(response);
+      const tokens = body.tokens as Array<ExploreEntry & {
+        valuation: { status: string; reason?: string };
+      }>;
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        status: "ready",
+        sort,
+        marketRead: {
+          provider: "bitquery",
+          status: "unavailable",
+          category: "response",
+          phase,
+          reason: "http-status",
+          httpStatus: 402,
+        },
+        dataQuality: {
+          status: "partial",
+          launchIdentity: { status: "current" },
+          valuation: {
+            status: "unavailable",
+            metric: "fdv",
+            available: 0,
+            unavailable: 9,
+            asOfBlock: null,
+            asOfTime: null,
+          },
+        },
+      });
+      if (expectsRanking) {
+        expect(body.ranking).toEqual({
+          status: "unavailable",
+          requested: "fdv",
+          applied: "launch-order",
+        });
+      } else {
+        expect(body).not.toHaveProperty("ranking");
+      }
+      expect(tokens.map((entry) => entry.id)).toEqual(
+        [12, 11, 10, 9, 8, 7, 6, 5, 4].map(
+          (index) => entries[index - 1]!.id,
+        ),
+      );
+      expect(tokens.every((entry) =>
+        entry.valuation.status === "unavailable" &&
+        entry.valuation.reason === "source-unavailable"
+      )).toBe(true);
+      const forbiddenMarketFields = [
+        "fdvUsdWad",
+        "liquidityEvidence",
+        "marketCapUsdWad",
+        "marketCapEthWad",
+        "marketCapEth",
+        "marketCapEthWei",
+        "marketCapQuote",
+        "marketCapQuoteWad",
+        "marketData",
+        "priceUsdWad",
+        "priceEthWad",
+        "tokenPriceEth",
+        "tokenPriceEthWei",
+        "tokenPriceQuote",
+        "tokenPriceQuoteWad",
+        "tokenPriceUsdWad",
+        "uniswapV4Pool",
+      ];
+      expect(tokens.every((entry) =>
+        forbiddenMarketFields.every((field) => !(field in entry))
+      )).toBe(true);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(response.headers.get("x-programmable-data-quality")).toBe(
+        "partial",
+      );
+      expect(response.headers.get("x-programmable-read-source")).toBe("drpc");
+      expect(response.headers.get("x-programmable-market-read-status")).toBe(
+        "response-unavailable",
+      );
+      expect(response.headers.get("x-programmable-market-provider")).toBe(
+        "bitquery",
+      );
+      expect(response.headers.get("x-programmable-market-source")).toBeNull();
+      expect(response.headers.get("x-programmable-price-source")).toBeNull();
+      expect(response.headers.get("x-programmable-market-as-of")).toBeNull();
+    },
+  );
+
+  it.each([
+    ["configuration", "configuration", "missing-token", undefined],
+    ["response", "market-core", "http-status", 400],
+    ["response", "market-core", "missing-data", undefined],
+    ["response", "market-stats", "http-status", 402],
+    ["integrity", "market-core", "unspecified", undefined],
+    ["transport", "market-stats", "request-transport", undefined],
+  ] as const)(
+    "keeps Bitquery %s/%s/%s/%s failures fail-closed",
+    async (category, phase, reason, httpStatus) => {
       mocks.readBitqueryTokenFdvRankingStrictV1.mockRejectedValueOnce(
-        new mocks.BitqueryMarketDataError(category, phase),
+        new mocks.BitqueryMarketDataError(
+          category,
+          phase,
+          reason,
+          httpStatus,
+        ),
       );
 
       const response = await GET(request("sort=market-cap"));
@@ -511,9 +632,50 @@ describe("Explore API strict dRPC identity and Bitquery market contract", () => 
     expect(response.status).toBe(503);
   });
 
+  it("does not degrade Bitquery HTTP 402 without launch identities", async () => {
+    mocks.readPrimaryRpcExploreEntriesV1.mockResolvedValueOnce({
+      source: "drpc",
+      entries: [],
+      generatedAt: NOW,
+      asOfBlock: "25740000",
+    });
+    mocks.readBitqueryTokenFdvRankingStrictV1.mockRejectedValueOnce(
+      new mocks.BitqueryMarketDataError(
+        "response",
+        "market-core",
+        "http-status",
+        402,
+      ),
+    );
+
+    const response = await GET(request("sort=market-cap"));
+    expect(response.status).toBe(503);
+  });
+
   it("does not degrade a transport failure after the request is aborted", async () => {
     mocks.readBitqueryTokenFdvRankingStrictV1.mockRejectedValueOnce(
       new mocks.BitqueryMarketDataError("transport", "market-core"),
+    );
+    const controller = new AbortController();
+    controller.abort();
+    const abortedRequest = new NextRequest(
+      "http://localhost/api/explore?sort=market-cap",
+      { signal: controller.signal },
+    );
+
+    const response = await GET(abortedRequest);
+    expect(response.status).toBe(503);
+    expect(response.headers.get("x-programmable-market-read-status")).toBeNull();
+  });
+
+  it("does not degrade Bitquery HTTP 402 after the request is aborted", async () => {
+    mocks.readBitqueryTokenFdvRankingStrictV1.mockRejectedValueOnce(
+      new mocks.BitqueryMarketDataError(
+        "response",
+        "market-core",
+        "http-status",
+        402,
+      ),
     );
     const controller = new AbortController();
     controller.abort();

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -199,6 +199,24 @@ const transportUnavailableMarketPayload = {
   },
 } as const;
 
+const responseUnavailableMarketPayload = {
+  ...unvaluedMarketPayload,
+  dataQuality: unavailableMarketDataQuality,
+  marketRead: {
+    provider: "bitquery",
+    status: "unavailable",
+    category: "response",
+    phase: "market-core",
+    reason: "http-status",
+    httpStatus: 402,
+  },
+  ranking: {
+    status: "unavailable",
+    requested: "fdv",
+    applied: "launch-order",
+  },
+} as const;
+
 function modelCompatibilityMarketData() {
   return {
     schemaVersion: "programmable.market-data.v1" as const,
@@ -1038,6 +1056,82 @@ describe("Explore refresh state", () => {
       marketRead: { status: "unavailable" },
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns an honest HTTP 402 response-unavailable page without retrying or caching it", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => new Response(JSON.stringify(responseUnavailableMarketPayload), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Programmable-Market-Read-Status": "response-unavailable",
+        },
+      }),
+    );
+    const search = new URLSearchParams({
+      sort: "market-cap",
+      page: "1",
+      limit: "9",
+    });
+
+    const result = await loadExplorePayload(
+      "marked-market-http-402-response-unavailable",
+      search,
+    );
+
+    expect(result).toMatchObject({
+      marketRead: {
+        provider: "bitquery",
+        status: "unavailable",
+        category: "response",
+        phase: "market-core",
+        reason: "http-status",
+        httpStatus: 402,
+      },
+      ranking: {
+        status: "unavailable",
+        requested: "fdv",
+        applied: "launch-order",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getTokenCards(result.tokens)).toEqual([
+      expect.objectContaining({
+        valuation: undefined,
+        marketStatus: "Unavailable",
+      }),
+    ]);
+
+    await expect(loadExplorePayload(
+      "marked-market-http-402-response-unavailable",
+      search,
+    )).resolves.toMatchObject({
+      marketRead: {
+        status: "unavailable",
+        category: "response",
+        reason: "http-status",
+        httpStatus: 402,
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects an HTTP 402 marker without its exact response-unavailable header", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(responseUnavailableMarketPayload), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Programmable-Market-Read-Status": "transport-unavailable",
+        },
+      }),
+    );
+
+    await expect(loadExplorePayload(
+      "mismatched-market-http-402-response-unavailable",
+      new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+    )).rejects.toThrow("inconsistent market read data");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not surface a market availability banner", () => {


### PR DESCRIPTION
## Outcome

Keeps Explore usable when Bitquery returns the currently observed HTTP 402 while preserving fail-closed behavior for configuration, integrity, market-stats, other response failures, zero identities, and aborted reads.

## Safety boundary

- Applies only to `response/http-status/402` in the market core, liquidity, or price phases with nonempty launch and market identities.
- Discards the Bitquery payload and emits no FDV, price, liquidity, pool, market-source, price-source, or as-of claims.
- Returns explicit unavailable state, stable launch ordering, `response-unavailable`, and `Cache-Control: no-store`.
- Does not alter the released UI markup or styling.

## Validation

- API/client/card tests: 72/72
- Ops tests: 200/200
- Workflow contracts: 10/10
- TypeScript, scoped ESLint, YAML parse, source contracts, diff check: pass
- Production build, candidate-neutrality scan, production-bundle scan: pass