### PR TITLE
Restore homepage social preview metadata

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,15 +3,40 @@ import type { Metadata } from "next";
 import { LandingPage } from "@/components/landing-page";
 
 const pageDescription = "Shape what assets can do";
+const pageSocialImage =
+  "https://programmable.market/og/programmable-loop-og-1200x630.png";
 
 export const metadata: Metadata = {
   title: "Programmable",
   description: pageDescription,
   openGraph: {
+    type: "website",
+    url: "https://programmable.market",
+    siteName: "Programmable",
+    title: "Programmable",
     description: pageDescription,
+    images: [
+      {
+        url: pageSocialImage,
+        secureUrl: pageSocialImage,
+        width: 1200,
+        height: 630,
+        type: "image/png",
+        alt: "The white Programmable mark in a vivid floral night garden",
+      },
+    ],
   },
   twitter: {
+    card: "summary_large_image",
+    title: "Programmable",
     description: pageDescription,
+    creator: "@0xprogrammable",
+    images: [
+      {
+        url: pageSocialImage,
+        alt: "The white Programmable mark in a vivid floral night garden",
+      },
+    ],
   },
 };
 

--- a/tests/branding-assets.test.ts
+++ b/tests/branding-assets.test.ts
@@ -142,6 +142,7 @@ describe("Programmable branding assets", () => {
 
   it("uses the black-sky floral link preview and exact product description", async () => {
     const layout = read("app/layout.tsx");
+    const homePage = read("app/page.tsx");
     const path = "public/og/programmable-loop-og-1200x630.png";
     const metadata = await sharp(join(root, path)).metadata();
     const topCenter = await sharp(join(root, path))
@@ -153,6 +154,8 @@ describe("Programmable branding assets", () => {
     expect(layout).toContain('const siteDescription = "Shape what assets can do"');
     expect(layout).not.toContain("Create tokens with a clear launch model");
     expect(layout).toContain('"/og/programmable-loop-og-1200x630.png"');
+    expect(homePage).toContain("programmable-loop-og-1200x630.png");
+    expect(homePage).toContain('card: "summary_large_image"');
     expect(metadata.format).toBe("png");
     expect(metadata.width).toBe(1200);
     expect(metadata.height).toBe(630);


### PR DESCRIPTION
Fix the homepage metadata override so the production head retains the floral OG/Twitter preview image and summary-large-image card. Branding regression test passes.