### PR TITLE
Enable readiness-gated Custom launch UI

### DIFF
--- a/components/custom-launch-experience.module.css
+++ b/components/custom-launch-experience.module.css
@@ -896,6 +896,14 @@
   min-width: 180px;
 }
 
+.completionActions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
 .progressCopy {
   align-items: center;
   color: var(--text-soft);
@@ -1368,6 +1376,11 @@
   }
 
   .launchFooter :global(.primary-button) {
+    width: 100%;
+  }
+
+  .completionActions,
+  .completionActions > * {
     width: 100%;
   }
 

--- a/components/custom-launch-experience.tsx
+++ b/components/custom-launch-experience.tsx
@@ -179,6 +179,7 @@ export type LaunchProgress =
   | "idle"
   | "preparing"
   | "wallet-proof"
+  | "permit"
   | "wallet-transaction"
   | "reconciling"
   | "ambiguous"
@@ -369,6 +370,44 @@ export function customLaunchRecoveryDisplayV2(
       || "Checking the reserved launch before another wallet action can start.",
     submitted: false,
   };
+}
+
+export function customLaunchPendingActionLabelV1(
+  launchProgress: LaunchProgress,
+): string {
+  const labels: Readonly<Record<LaunchProgress, string>> = {
+    idle: "Confirm with wallet",
+    preparing: "Preparing launch",
+    "wallet-proof": "Confirm ownership in wallet",
+    permit: "Verifying launch permit",
+    "wallet-transaction": "Submit launch in wallet",
+    reconciling: "Checking reserved launch",
+    ambiguous: "Resolving submission status",
+    confirmation: "Waiting for confirmation",
+    publishing: "Publishing public record",
+    complete: "Launch complete",
+  };
+  return labels[launchProgress];
+}
+
+export function customLaunchWalletMatchesChainV1(
+  walletChainId: string | undefined,
+  approvedChainId: string | undefined,
+): boolean {
+  if (
+    !walletChainId
+    || !approvedChainId
+    || !/^[1-9][0-9]*$/u.test(approvedChainId)
+  ) return false;
+  const walletValue = walletChainId.startsWith("eip155:")
+    ? walletChainId.slice("eip155:".length)
+    : walletChainId;
+  if (!/^(?:0x[0-9a-f]+|[1-9][0-9]*)$/iu.test(walletValue)) return false;
+  try {
+    return BigInt(walletValue) === BigInt(approvedChainId);
+  } catch {
+    return false;
+  }
 }
 
 export function CustomLaunchRecoveryCopyV2({
@@ -1499,6 +1538,8 @@ function CustomLaunchRuntime({
     reauthorizeGithub,
     sendBrowserWalletAction,
     signLaunchMessage,
+    switchingNetwork,
+    switchNetwork,
     wallet,
   } = useWallet();
   const [screen, setScreen] = useState<CustomLaunchScreen>("intro");
@@ -2549,6 +2590,8 @@ function CustomLaunchRuntime({
           return authenticatedSession;
         },
         authorizeLaunch: async ({ challenge, preparation, authentication }) => {
+          setLaunchProgress("permit");
+          setStatusMessage("Verifying launch permit");
           const authorizeRequest: AuthorizeLaunchSessionRequestV2 = {
             schemaVersion: "programmable.launch-session-launch-authorize-request.v2",
             audience: "programmable.launch-session.v2",
@@ -2580,6 +2623,7 @@ function CustomLaunchRuntime({
           return { authorizeRequest, permit, verifiedPermitSigner };
         },
         createExecutionPreparation: async ({ preparation, authentication, authorization }) => {
+          setStatusMessage("Preparing exact wallet transaction");
           const execution = await client.createExecutionPreparation({
             schemaVersion: "programmable.browser-wallet-launch-preparation-request.v2",
             request: authorization.authorizeRequest,
@@ -2868,6 +2912,22 @@ function CustomLaunchRuntime({
     : null;
   const durableApproval = selected !== null
     && customApplicationHasDurableApprovalV2(selected, null);
+  const walletOnApprovedNetwork = wallet !== null
+    && customLaunchWalletMatchesChainV1(
+      wallet.chainId,
+      approvedRoute?.chainId,
+    );
+  const switchApprovedNetwork = async () => {
+    setError("");
+    setStatusMessage(`Switching to ${chainLabel(approvedRoute?.chainId)}`);
+    const switched = await switchNetwork(approvedRoute?.chainId);
+    if (switched) {
+      setStatusMessage(`${chainLabel(approvedRoute?.chainId)} connected`);
+      return;
+    }
+    setStatusMessage("");
+    setError(`Unable to switch to ${chainLabel(approvedRoute?.chainId)}. Try again`);
+  };
   const verifiedStages = resolveCustomLaunchVerifiedStagesV1({
     githubPrincipalVerified: githubPrincipalHash !== null,
     repositoriesLoaded: applicationsLoaded,
@@ -3140,7 +3200,10 @@ function CustomLaunchRuntime({
               <span>{statusMessage || (durableApproval ? "Approved — launch anytime" : "Launch details verified")}</span>
             </div>
             {launchProgress === "complete" ? (
-              <Link className="primary-button" href="/explore?model=custom">Open public record <ArrowRight aria-hidden="true" size={16} /></Link>
+              <div className={styles.completionActions}>
+                <Link className={styles.secondaryButton} href="/profile">View profile</Link>
+                <Link className="primary-button" href="/explore?model=custom">Open public record <ArrowRight aria-hidden="true" size={16} /></Link>
+              </div>
             ) : applicantRecovery !== "none" ? (
               <button className="primary-button" type="button" disabled={applicantReauthorizing} onClick={() => void recoverApplicantAccess()}>
                 {applicantRecoveryAction}
@@ -3154,13 +3217,33 @@ function CustomLaunchRuntime({
               >
                 Refresh launch setup
               </button>
+            ) : launchProgress !== "idle" ? (
+              <button className="primary-button" type="button" disabled>
+                <LoaderCircle aria-hidden="true" className={styles.spin} size={17} />
+                {customLaunchPendingActionLabelV1(launchProgress)}
+              </button>
+            ) : !wallet ? (
+              <button className="primary-button" type="button" onClick={openWallet}>
+                <Wallet aria-hidden="true" size={17} />
+                Connect wallet
+              </button>
+            ) : !walletOnApprovedNetwork ? (
+              <button
+                className="primary-button"
+                type="button"
+                disabled={switchingNetwork}
+                onClick={() => void switchApprovedNetwork()}
+              >
+                {switchingNetwork ? (
+                  <LoaderCircle aria-hidden="true" className={styles.spin} size={17} />
+                ) : null}
+                {switchingNetwork
+                  ? `Switching to ${chainLabel(approvedRoute?.chainId)}`
+                  : `Switch to ${chainLabel(approvedRoute?.chainId)}`}
+              </button>
             ) : (
               <button className="primary-button" type="submit" disabled={launchProgress !== "idle"}>
-                {launchProgress !== "idle"
-                  ? "Preparing launch"
-                  : !wallet
-                    ? "Connect wallet"
-                    : "Confirm with wallet"}
+                Confirm with wallet
               </button>
             )}
           </div>

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -208,6 +208,7 @@ function LaunchExperienceRuntime({
 }
 
 export function LaunchModelPicker({
+  customLaunchPublicEnabled = false,
   customLaunchButtonRef,
   onChoose,
 }: {
@@ -221,6 +222,10 @@ export function LaunchModelPicker({
 }) {
   const preloadAvailableForm = () => {
     void loadLaunchForm();
+  };
+  const preloadCustomLaunch = () => {
+    if (!customLaunchPublicEnabled) return;
+    void loadCustomLaunch();
   };
 
   const customCardContent = (
@@ -254,14 +259,26 @@ export function LaunchModelPicker({
           className={`launch-model-card-heading ${launchExperience.modelHeading}`}
         >
           <strong id="launch-model-custom-title">Custom</strong>
-          <small data-status="pending">Soon</small>
+          {!customLaunchPublicEnabled ? (
+            <small data-status="pending">Soon</small>
+          ) : null}
         </span>
         <span
           className={`launch-model-description ${launchExperience.modelDescription}`}
           id="launch-model-custom-description"
         >
-          Custom launch models are coming soon.
+          {customLaunchPublicEnabled
+            ? "Launch an approved GitHub revision through your browser wallet, then follow it to its public record."
+            : "Custom launch models are coming soon."}
         </span>
+        {customLaunchPublicEnabled ? (
+          <span
+            className={`launch-model-action ${launchExperience.modelAction}`}
+          >
+            Open approved Custom launch
+            <ArrowRight aria-hidden="true" size={16} />
+          </span>
+        ) : null}
       </span>
     </>
   );
@@ -281,12 +298,19 @@ export function LaunchModelPicker({
           ref={customLaunchButtonRef}
           className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
           data-launch-model-option="custom"
-          data-launch-model-available="false"
-          data-launch-model-launchable="false"
+          data-launch-model-available={customLaunchPublicEnabled}
+          data-launch-model-launchable={customLaunchPublicEnabled}
           type="button"
-          disabled
+          disabled={!customLaunchPublicEnabled}
           aria-labelledby="launch-model-custom-title"
           aria-describedby="launch-model-custom-description"
+          onPointerEnter={
+            customLaunchPublicEnabled ? preloadCustomLaunch : undefined
+          }
+          onFocus={customLaunchPublicEnabled ? preloadCustomLaunch : undefined}
+          onClick={
+            customLaunchPublicEnabled ? () => onChoose("custom") : undefined
+          }
         >
           {customCardContent}
         </button>

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -100,7 +100,9 @@ type WalletContextValue = {
   hasSession: boolean;
   connecting: boolean;
   disconnecting: boolean;
+  switchingNetwork: boolean;
   openWallet: () => void;
+  switchNetwork: (expectedChainId?: string) => Promise<boolean>;
   disconnect: (options?: {
     showDialogOnFailure?: boolean;
   }) => Promise<boolean>;
@@ -1103,16 +1105,31 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
     }
   }, [wallet]);
 
-  const switchToEthereum = useCallback(async () => {
-    if (!connectedWallet) return;
+  const switchToEthereum = useCallback(async (expectedChainId?: string) => {
+    if (!connectedWallet) return false;
+    if (expectedChainId && expectedChainId !== String(appChain.id)) {
+      setError("The approved launch network is not available in this environment.");
+      return false;
+    }
 
     setSwitchingNetwork(true);
     setError("");
 
     try {
       await connectedWallet.switchChain(appChain.id);
+      const provider = await connectedWallet.getEthereumProvider();
+      const connectedChainId = await provider.request({ method: "eth_chainId" });
+      if (
+        typeof connectedChainId !== "string"
+        || normalizeChainId(connectedChainId) !== appChainHex
+      ) {
+        setError(`Unable to verify ${appNetworkName}. Try again.`);
+        return false;
+      }
+      return true;
     } catch {
       setError(`Unable to switch to ${appNetworkName}. Try again.`);
+      return false;
     } finally {
       setSwitchingNetwork(false);
     }
@@ -1468,7 +1485,9 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       hasSession,
       connecting: !providerSettled && !providerTimedOut,
       disconnecting,
+      switchingNetwork,
       openWallet,
+      switchNetwork: switchToEthereum,
       disconnect,
       getAccessToken,
       getIdentityToken: getCurrentIdentityToken,
@@ -1507,6 +1526,8 @@ function PrivyWalletBridge({ children }: { children: ReactNode }) {
       sendBrowserWalletAction,
       sendTransaction,
       signLaunchMessage,
+      switchingNetwork,
+      switchToEthereum,
       providerSettled,
       setUsername,
       username,
@@ -1557,7 +1578,9 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
       hasSession: false,
       connecting: false,
       disconnecting: false,
+      switchingNetwork: false,
       openWallet: () => setDialogOpen(true),
+      switchNetwork: async () => false,
       disconnect: async () => false,
       getAccessToken: async () => null,
       getIdentityToken: async () => null,

--- a/tests/custom-launch-experience-v2.test.ts
+++ b/tests/custom-launch-experience-v2.test.ts
@@ -21,7 +21,9 @@ import {
   customLaunchErrorMessage,
   customLaunchFeeReviewV1,
   customLaunchFixedTokenIdentityCopyV1,
+  customLaunchPendingActionLabelV1,
   customLaunchRailInvalidationForRecoveryV1,
+  customLaunchWalletMatchesChainV1,
   defaultLaunchRoute,
   assertLaunchPermitFreshnessV2,
   fetchTrustedTimeV1,
@@ -576,6 +578,40 @@ function replacePermitArtifact(
 }
 
 describe("custom launch interface state line", () => {
+  it("names each pending wallet boundary without implying completion", () => {
+    expect(customLaunchPendingActionLabelV1("preparing")).toBe(
+      "Preparing launch",
+    );
+    expect(customLaunchPendingActionLabelV1("wallet-proof")).toBe(
+      "Confirm ownership in wallet",
+    );
+    expect(customLaunchPendingActionLabelV1("permit")).toBe(
+      "Verifying launch permit",
+    );
+    expect(customLaunchPendingActionLabelV1("wallet-transaction")).toBe(
+      "Submit launch in wallet",
+    );
+    expect(customLaunchPendingActionLabelV1("confirmation")).toBe(
+      "Waiting for confirmation",
+    );
+    expect(customLaunchPendingActionLabelV1("publishing")).toBe(
+      "Publishing public record",
+    );
+  });
+
+  it("requires the connected wallet to match the approved chain", () => {
+    expect(customLaunchWalletMatchesChainV1("0x1", "1")).toBe(true);
+    expect(customLaunchWalletMatchesChainV1("1", "1")).toBe(true);
+    expect(customLaunchWalletMatchesChainV1("eip155:1", "1")).toBe(true);
+    expect(customLaunchWalletMatchesChainV1("0xaa36a7", "11155111")).toBe(true);
+    expect(customLaunchWalletMatchesChainV1("0x2105", "1")).toBe(false);
+    expect(customLaunchWalletMatchesChainV1("ethereum", "1")).toBe(false);
+    expect(customLaunchWalletMatchesChainV1(" 1", "1")).toBe(false);
+    expect(customLaunchWalletMatchesChainV1("eip155:", "1")).toBe(false);
+    expect(customLaunchWalletMatchesChainV1(undefined, "1")).toBe(false);
+    expect(customLaunchWalletMatchesChainV1("0x1", undefined)).toBe(false);
+  });
+
   it("advances only when the exact preceding evidence is complete", () => {
     expect(resolveCustomLaunchStageV1({
       screen: "intro",

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -167,7 +167,7 @@ describe("unreleased launch model gating", () => {
     ).toEqual([-1, -1, 0, -1, -1, -1]);
   });
 
-  it("keeps Custom visibly deferred even when the public readiness gate is true", () => {
+  it("opens Custom only when the server readiness gate is true", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
         customLaunchPublicEnabled: true,
@@ -189,16 +189,18 @@ describe("unreleased launch model gating", () => {
     const customCard = html.match(
       /<button[^>]*data-launch-model-option="custom"[^>]*>/,
     )?.[0];
-    expect(customCard).toContain('data-launch-model-available="false"');
-    expect(customCard).toContain('data-launch-model-launchable="false"');
-    expect(customCard).toContain("disabled");
+    expect(customCard).toContain('data-launch-model-available="true"');
+    expect(customCard).toContain('data-launch-model-launchable="true"');
+    expect(customCard).not.toContain("disabled");
     expect(html).toContain(
       'id="launch-model-custom-title">Custom</strong>',
     );
     expect(html).toContain("Create a Classic coin");
-    expect(html).toContain('data-status="pending">Soon</small>');
-    expect(html).toContain("Custom launch models are coming soon.");
-    expect(html).not.toContain("Open approved Custom Hook launch");
+    expect(html).not.toContain('data-status="pending">Soon</small>');
+    expect(html).toContain(
+      "Launch an approved GitHub revision through your browser wallet, then follow it to its public record.",
+    );
+    expect(html).toContain("Open approved Custom launch");
     for (const marker of removedPartnerMarkers) {
       expect(html).not.toContain(marker);
     }
@@ -230,7 +232,7 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain('data-launch-model-launchable="false"');
     expect(html).toContain('data-status="pending">Soon</small>');
     expect(html).toContain("Custom launch models are coming soon.");
-    expect(html).not.toContain("Open approved Custom Hook launch");
+    expect(html).not.toContain("Open approved Custom launch");
     expect(html).not.toContain("Build or resume");
   });
 

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -53,7 +53,9 @@ describe("launch model artwork", () => {
     expect(source).toContain(
       'aria-describedby="launch-model-classic-description"',
     );
-    expect(source).not.toContain('onClick={() => onChoose("custom")}');
+    expect(source).toContain(
+      'customLaunchPublicEnabled ? () => onChoose("custom") : undefined',
+    );
     expect(source).toContain(
       'aria-labelledby="launch-model-custom-title"',
     );
@@ -61,8 +63,13 @@ describe("launch model artwork", () => {
       'aria-describedby="launch-model-custom-description"',
     );
     expect(source).toContain('data-launch-model-option="custom"');
-    expect(source).toContain('data-launch-model-available="false"');
-    expect(source).toContain('data-launch-model-launchable="false"');
+    expect(source).toContain(
+      "data-launch-model-available={customLaunchPublicEnabled}",
+    );
+    expect(source).toContain(
+      "data-launch-model-launchable={customLaunchPublicEnabled}",
+    );
+    expect(source).toContain("disabled={!customLaunchPublicEnabled}");
     for (const marker of removedPartnerMarkers) {
       expect(source).not.toContain(marker);
     }


### PR DESCRIPTION
## Summary

- Enables the Custom launch model card only when the existing server-side public readiness gate is true.
- Keeps the card disabled with the existing `Soon` state when readiness is false or incomplete.
- Makes the browser-wallet path explicit: connect wallet, switch to the approved chain, verify the short-lived permit, submit, confirm finality, then expose the existing profile/public-record links.
- Labels every pending boundary without implying approval, submission, or Registry finality early.

## Safety boundaries

- No backend, API, contract, Registry/indexer, Explore, provider, deployment, or secret changes.
- Exact GitHub commit/tree, durable approval and entitlement, wallet/account/chain binding, permit verification, ambiguity lock, and Registry finality remain unchanged and fail closed.
- Wrong, unknown, or environment-incompatible chains cannot reach the confirm action; a requested chain switch is re-read from the wallet provider before success is reported.
- Completion links remain behind the existing finalized `complete` state.

## Verification

- `npm run build` — passed, including candidate-neutral source/build checks and the Custom production-bundle scan.
- `npm run typecheck` — passed.
- `npm run lint` — 0 errors; 36 pre-existing warnings.
- Focused suite — 91/91 passed.
- Independent review — GO, P0/P1/P2 = 0; independent focused suite 60/60 passed.
- Rendered browser QA — readiness on/off, desktop 1440x900, mobile 390x844, keyboard focus/Tab/Enter, touch targets, horizontal overflow, and Custom approval-to-Registry local preview; 0 console errors.

## Frozen revision

- Commit: `e4074e93823701d7956391bca4fc74ef003ab854`
- Tree: `7dcbe16dad2f167e8c557e3377050fafa00f2c64`
- Parent: `3302e24a7fc3c91bdb9efcbbe04f6f0d5e2ce34a`
- Exact scope: four frontend/CSS files and three tests.

Do not merge or deploy until required CI is green and the release owner explicitly authorizes integration.
