### PR TITLE
Pace staged index recovery under RPC rate limits

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -43,7 +43,7 @@
       "providerPasses": 2,
       "requestDeadlineMs": 270000,
       "classicPrewarmStepCount": 32,
-      "prewarmProviderConcurrency": 2,
+      "prewarmProviderConcurrency": 1,
       "prewarmRequestDeadlineMs": 250000
     },
     "schedulerWatchdog": {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -54,7 +54,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       providerPasses: 2,
       requestDeadlineMs: 270_000,
       classicPrewarmStepCount: 32,
-      prewarmProviderConcurrency: 2,
+      prewarmProviderConcurrency: 1,
       prewarmRequestDeadlineMs: 250_000,
     }),
     schedulerWatchdog: Object.freeze({
@@ -670,12 +670,16 @@ export const STAGED_DURABLE_REFRESH_SOURCE_GUARDS = Object.freeze([
   "Authorization: `Bearer ${input.cronSecret}`",
   '"x-vercel-protection-bypass": input.automationBypassSecret',
   'redirect: "error"',
-  "const REQUEST_ATTEMPTS = 2;",
-  "const REQUEST_RETRY_DELAY_MS = 2_000;",
+  "const REQUEST_ATTEMPTS = 3;",
+  "const REQUEST_RETRY_DELAY_MS = 5_000;",
+  "const MAXIMUM_REQUEST_RETRY_DELAY_MS = 30_000;",
+  "const PREWARM_PHASE_DELAY_MS = 1_000;",
   "requestAttempts > 3",
-  "requestRetryDelayMs > 10_000",
+  "requestRetryDelayMs > 15_000",
+  "prewarmPhaseDelayMs > 10_000",
   "requestJsonWithRetry(",
   "return status === 429 || status >= 500;",
+  "retryDelayMs * (2 ** (attempt - 1))",
   "const PREWARM_STEP_COUNT = 32;",
   "const PREWARM_STEPS = Object.freeze([",
   '"01", "02", "03", "04", "05", "06", "07", "08"',
@@ -683,8 +687,9 @@ export const STAGED_DURABLE_REFRESH_SOURCE_GUARDS = Object.freeze([
   "const PREWARM_PHASES = Object.freeze(PREWARM_STEPS.flatMap((step) => [",
   "`classic-primary-${step}`",
   "`classic-secondary-${step}`",
-  "const results = await Promise.allSettled(phasePair.map(async (phase) => {",
-  'if (result.status !== "fulfilled") {',
+  "for (let index = 0; index < PREWARM_PHASES.length; index += 1) {",
+  "prewarm = await requestJsonWithRetry(",
+  "await sleepImpl(prewarmPhaseDelayMs);",
   "value.body.stepCount === PREWARM_STEP_COUNT",
   "blockNumber === expectedBlock",
   "blockNumber === confirmedBlock",
@@ -696,7 +701,7 @@ export const STAGED_DURABLE_REFRESH_SOURCE_GUARDS = Object.freeze([
   "portfolioHistoryPath: refresh.body.portfolioHistory.path",
 ]);
 const STAGED_DURABLE_REFRESH_SOURCE_SHA256 =
-  "bf7273c8dff2197e2bbb663419c5de3302bdccbe259418da5e916089890cea4c";
+  "b92a68025e9d3e2d58de47ae71a5e4d1da9a460621191f04eba6e76954afbe29";
 function expectedDigest(path, approved, overrides) {
   return overrides?.[path] ?? approved;
 }
@@ -1439,7 +1444,7 @@ export function evaluateReadModelOperationsSourceContracts(
       boundedRefresh?.eventFiltersPerRange === 2 &&
       boundedRefresh?.providerPasses === 2 &&
       boundedRefresh?.classicPrewarmStepCount === 32 &&
-      boundedRefresh?.prewarmProviderConcurrency === 2 &&
+      boundedRefresh?.prewarmProviderConcurrency === 1 &&
       boundedRefresh?.prewarmRequestDeadlineMs === 250_000 &&
       legacyRouteSource?.includes(
         "const INDEX_REFRESH_DEADLINE_MS = 270_000;",

--- a/scripts/perf/read-model-staged-refresh.mjs
+++ b/scripts/perf/read-model-staged-refresh.mjs
@@ -9,9 +9,11 @@ const REFRESH_PATH = "/api/ops/index-v2";
 const MAXIMUM_JSON_BYTES = 64 * 1024;
 const CANONICAL_UINT = /^(?:0|[1-9][0-9]{0,77})$/u;
 const HEX32 = /^0x[0-9a-f]{64}$/u;
-const REQUEST_ATTEMPTS = 2;
-const REQUEST_RETRY_DELAY_MS = 2_000;
+const REQUEST_ATTEMPTS = 3;
+const REQUEST_RETRY_DELAY_MS = 5_000;
+const MAXIMUM_REQUEST_RETRY_DELAY_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 330_000;
+const PREWARM_PHASE_DELAY_MS = 1_000;
 const PREWARM_STEP_COUNT = 32;
 const PREWARM_STEPS = Object.freeze([
   "01", "02", "03", "04", "05", "06", "07", "08",
@@ -159,7 +161,10 @@ async function requestJsonWithRetry(
       lastError = error;
       if (attempt === attempts) throw error;
     }
-    await sleepImpl(retryDelayMs);
+    await sleepImpl(Math.min(
+      retryDelayMs * (2 ** (attempt - 1)),
+      MAXIMUM_REQUEST_RETRY_DELAY_MS,
+    ));
   }
   throw lastError ?? new Error("staged refresh request failed");
 }
@@ -290,13 +295,18 @@ export async function refreshExactStagedReadModel(input) {
   const requestAttempts = input.requestAttempts ?? REQUEST_ATTEMPTS;
   const requestRetryDelayMs =
     input.requestRetryDelayMs ?? REQUEST_RETRY_DELAY_MS;
+  const prewarmPhaseDelayMs =
+    input.prewarmPhaseDelayMs ?? PREWARM_PHASE_DELAY_MS;
   if (
     !Number.isSafeInteger(requestAttempts) ||
     requestAttempts < 1 ||
     requestAttempts > 3 ||
     !Number.isSafeInteger(requestRetryDelayMs) ||
     requestRetryDelayMs < 0 ||
-    requestRetryDelayMs > 10_000
+    requestRetryDelayMs > 15_000 ||
+    !Number.isSafeInteger(prewarmPhaseDelayMs) ||
+    prewarmPhaseDelayMs < 0 ||
+    prewarmPhaseDelayMs > 10_000
   ) {
     throw new Error("staged refresh retry policy is invalid");
   }
@@ -304,12 +314,13 @@ export async function refreshExactStagedReadModel(input) {
     input.sleepImpl ??
     ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
   const previousPrewarmBlocks = new Map();
-  for (let index = 0; index < PREWARM_PHASES.length; index += 2) {
-    const phasePair = PREWARM_PHASES.slice(index, index + 2);
-    const results = await Promise.allSettled(phasePair.map(async (phase) => {
+  for (let index = 0; index < PREWARM_PHASES.length; index += 1) {
+    const phase = PREWARM_PHASES[index];
+    let prewarm;
+    try {
       const prewarmUrl = new URL(REFRESH_PATH, target);
       prewarmUrl.searchParams.set("phase", phase);
-      return requestJsonWithRetry(
+      prewarm = await requestJsonWithRetry(
         fetchImpl,
         prewarmUrl,
         protectedHeaders,
@@ -320,26 +331,23 @@ export async function refreshExactStagedReadModel(input) {
           timeoutMs: REQUEST_TIMEOUT_MS,
         },
       );
-    }));
-    for (let pairIndex = 0; pairIndex < phasePair.length; pairIndex += 1) {
-      const phase = phasePair[pairIndex];
-      const result = results[pairIndex];
-      if (result.status !== "fulfilled") {
-        throw new Error(`exact staged ${phase} prewarm request failed`);
-      }
-      const prewarm = result.value;
-      if (!exactPrewarmResponse(prewarm, phase)) {
-        throw new Error(
-          `exact staged ${phase} prewarm failed (${prewarm.response.status})`,
-        );
-      }
-      const provider = prewarm.body.provider;
-      const blockNumber = BigInt(prewarm.body.blockNumber);
-      const previousBlock = previousPrewarmBlocks.get(provider);
-      if (previousBlock !== undefined && blockNumber < previousBlock) {
-        throw new Error(`exact staged ${phase} prewarm moved backwards`);
-      }
-      previousPrewarmBlocks.set(provider, blockNumber);
+    } catch {
+      throw new Error(`exact staged ${phase} prewarm request failed`);
+    }
+    if (!exactPrewarmResponse(prewarm, phase)) {
+      throw new Error(
+        `exact staged ${phase} prewarm failed (${prewarm.response.status})`,
+      );
+    }
+    const provider = prewarm.body.provider;
+    const blockNumber = BigInt(prewarm.body.blockNumber);
+    const previousBlock = previousPrewarmBlocks.get(provider);
+    if (previousBlock !== undefined && blockNumber < previousBlock) {
+      throw new Error(`exact staged ${phase} prewarm moved backwards`);
+    }
+    previousPrewarmBlocks.set(provider, blockNumber);
+    if (index < PREWARM_PHASES.length - 1 && prewarmPhaseDelayMs > 0) {
+      await sleepImpl(prewarmPhaseDelayMs);
     }
   }
 

--- a/tests/data-pipeline/read-model-staged-refresh.test.ts
+++ b/tests/data-pipeline/read-model-staged-refresh.test.ts
@@ -133,6 +133,7 @@ function stagedRefreshInput(
     automationBypassSecret: AUTOMATION_BYPASS_SECRET,
     requestAttempts: 1,
     requestRetryDelayMs: 0,
+    prewarmPhaseDelayMs: 0,
     sleepImpl: vi.fn(async () => undefined),
     fetchImpl,
     ...overrides,
@@ -278,17 +279,74 @@ describe("exact staged durable refresh runtime", () => {
     ).rejects.toThrow("exact staged durable refresh failed");
   });
 
-  it("retries a transient prewarm response once and stays bounded", async () => {
+  it("serializes provider phases and backs off past a rolling 10-second 429 window", async () => {
     let transientFailures = 0;
+    let activePrewarms = 0;
+    let maximumActivePrewarms = 0;
     const sleepImpl = vi.fn(async () => undefined);
     const baseFetch = stagedFetch();
     const fetchImpl = async (request: URL | RequestInfo, init?: RequestInit) => {
       const url = new URL(String(request));
-      if (
-        url.searchParams.get("phase") === "classic-primary-01" &&
-        transientFailures === 0
-      ) {
-        transientFailures += 1;
+      if (/^classic-(?:primary|secondary)-[0-9]{2}$/u.test(
+        url.searchParams.get("phase") ?? "",
+      )) {
+        activePrewarms += 1;
+        maximumActivePrewarms = Math.max(
+          maximumActivePrewarms,
+          activePrewarms,
+        );
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          if (
+            url.searchParams.get("phase") === "classic-primary-01" &&
+            transientFailures < 2
+          ) {
+            transientFailures += 1;
+            return Response.json({ ok: false }, {
+              status: 503,
+              headers: { "cache-control": "no-store" },
+            });
+          }
+          return baseFetch(request, init);
+        } finally {
+          activePrewarms -= 1;
+        }
+      }
+      return baseFetch(request, init);
+    };
+    await expect(
+      refreshExactStagedReadModel(stagedRefreshInput(fetchImpl, {
+        requestAttempts: 3,
+        requestRetryDelayMs: 5_000,
+        sleepImpl,
+      })),
+    ).resolves.toMatchObject({ ok: true, tokenCount: 343 });
+    expect(transientFailures).toBe(2);
+    expect(maximumActivePrewarms).toBe(1);
+    expect(sleepImpl).toHaveBeenNthCalledWith(1, 5_000);
+    expect(sleepImpl).toHaveBeenNthCalledWith(2, 10_000);
+  });
+
+  it("paces successful prewarm phases without overlapping providers", async () => {
+    const sleepImpl = vi.fn(async (_delayMs: number) => undefined);
+    await expect(
+      refreshExactStagedReadModel(stagedRefreshInput(stagedFetch(), {
+        prewarmPhaseDelayMs: 1_000,
+        sleepImpl,
+      })),
+    ).resolves.toMatchObject({ ok: true, tokenCount: 343 });
+    expect(sleepImpl).toHaveBeenCalledTimes(63);
+    expect(sleepImpl.mock.calls.every(([delay]) => delay === 1_000)).toBe(true);
+  });
+
+  it("stops after three bounded transient failures before secondary or final refresh", async () => {
+    const requests: URL[] = [];
+    const sleepImpl = vi.fn(async () => undefined);
+    const baseFetch = stagedFetch();
+    const fetchImpl = async (request: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(String(request));
+      requests.push(url);
+      if (url.searchParams.get("phase") === "classic-primary-01") {
         return Response.json({ ok: false }, {
           status: 503,
           headers: { "cache-control": "no-store" },
@@ -298,12 +356,28 @@ describe("exact staged durable refresh runtime", () => {
     };
     await expect(
       refreshExactStagedReadModel(stagedRefreshInput(fetchImpl, {
-        requestAttempts: 2,
+        requestAttempts: 3,
+        requestRetryDelayMs: 5_000,
         sleepImpl,
       })),
-    ).resolves.toMatchObject({ ok: true, tokenCount: 343 });
-    expect(transientFailures).toBe(1);
-    expect(sleepImpl).toHaveBeenCalledTimes(1);
+    ).rejects.toThrow("classic-primary-01 prewarm failed (503)");
+    expect(
+      requests.filter((url) =>
+        url.searchParams.get("phase") === "classic-primary-01"
+      ),
+    ).toHaveLength(3);
+    expect(
+      requests.some((url) =>
+        url.searchParams.get("phase") === "classic-secondary-01"
+      ),
+    ).toBe(false);
+    expect(
+      requests.some((url) =>
+        url.pathname === "/api/ops/index-v2" &&
+        !url.searchParams.has("phase")
+      ),
+    ).toBe(false);
+    expect(sleepImpl.mock.calls).toEqual([[5_000], [10_000]]);
   });
 
   it("rejects a public origin and missing server-only credentials", async () => {


### PR DESCRIPTION
Serializes the 64 staged durable-catalog prewarm phases and applies a bounded 5s/10s retry schedule so the final attempt lands outside Alchemy's rolling 10-second window.

The dual-provider, exact-deployment, monotonic-block, non-empty catalog and fail-closed release gates remain unchanged. No public route, provider credential, contract, claim or UI code changes.

Local exact gates:
- 195 relevant Vitest tests passed (26 skipped)
- Typecheck passed
- Read-model ops gate passed
- Targeted ESLint and diff-check passed
- Production build, candidate-neutrality and bundle scan passed