### PR TITLE
Restore durable index recovery with Tenderly quorum

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -18,7 +18,7 @@
         },
         {
           "path": "lib/onchain/historical-read-rpc.server.ts",
-          "sha256": "c20db55489aa28c24a7eb888cbc80eb9d51944d3fe8908e9805d8984e15a2d6c"
+          "sha256": "543447b498ef2cfbe7e5fb75eb7457b596a34b9ccc75092a442292991fc262f9"
         },
         {
           "path": "lib/onchain/persistent-rpc-cache.server.ts",
@@ -83,7 +83,7 @@
         },
         "providerConfig": {
           "path": "lib/onchain/website-rpc-providers.server.ts",
-          "sha256": "d501b92d6a28b7e8e1a2a29cae329e2c3a530da941f9b1cbab65e8c6036ca342"
+          "sha256": "cb0115ba5f594d892e56e407f1a59a52d4c236d7924b78cce4ed727bede21400"
         },
         "currentMarketRpc": {
           "path": "lib/market-data/current-market-rpc.server.ts",

--- a/lib/onchain/historical-read-rpc.server.ts
+++ b/lib/onchain/historical-read-rpc.server.ts
@@ -16,10 +16,10 @@ export class HistoricalReadRpcBindingError extends Error {
 
 /**
  * Historical registry reconstruction requires two archive-capable readers.
- * It uses the exact commitment-bound Alchemy + QuickNode recovery pair so a
+ * It uses the fixed Tenderly + commitment-bound QuickNode recovery pair so a
  * depleted role-bound Website primary cannot block a durable index rebuild.
  * Both endpoints retain independent vendors and exact endpoint commitments;
- * no public, anonymous or generic-alias fallback may substitute either one.
+ * no runtime, environment or generic alias may substitute either one.
  */
 export function historicalReadOnchainDeployment(
   baseDeployment: ReadyOnchainDeployment,
@@ -40,7 +40,7 @@ export function historicalReadOnchainDeployment(
     const [primary, secondary] = providers;
     if (
       providers.length !== 2 ||
-      primary?.vendorGroup !== "alchemy" ||
+      primary?.vendorGroup !== "tenderly" ||
       secondary?.vendorGroup !== "quicknode" ||
       primary.endpointCommitment !== binding.primary.endpointCommitment ||
       secondary.endpointCommitment !== binding.secondary.endpointCommitment
@@ -53,7 +53,7 @@ export function historicalReadOnchainDeployment(
       rpcUrl: primary.endpoint,
       rpcUrlSecondary: secondary.endpoint,
       rpcProviderIds: {
-        primary: "alchemy",
+        primary: "tenderly",
         secondary: "quicknode",
       },
     };

--- a/lib/onchain/types.ts
+++ b/lib/onchain/types.ts
@@ -4,7 +4,11 @@ import type { LauncherToken } from "../tokens";
 
 export type DeploymentEnvironment = "production" | "rehearsal";
 export type ClassicReleaseVersion = "classic-v1" | "classic-v2";
-export type MainnetRpcProviderId = "alchemy" | "drpc" | "quicknode";
+export type MainnetRpcProviderId =
+  | "alchemy"
+  | "drpc"
+  | "quicknode"
+  | "tenderly";
 
 type OnchainDeploymentBase = {
   environment: DeploymentEnvironment;

--- a/lib/onchain/website-rpc-providers.server.ts
+++ b/lib/onchain/website-rpc-providers.server.ts
@@ -11,6 +11,10 @@ const DRPC_MAINNET_RPC_PATH = /^\/ethereum\/[A-Za-z0-9_-]{8,512}\/?$/u;
 const QUICKNODE_MAINNET_RPC_HOST =
   /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.ethereum-mainnet\.quiknode\.pro$/u;
 const QUICKNODE_MAINNET_RPC_PATH = /^\/[A-Za-z0-9_-]{8,256}\/?$/u;
+const TENDERLY_RECOVERY_MAINNET_RPC_URL =
+  "https://mainnet.gateway.tenderly.co/";
+const TENDERLY_RECOVERY_MAINNET_RPC_ENDPOINT_COMMITMENT =
+  "0x64d51011a3cc5cd1147970d28c3b771000e1ae0b89f4711d4898386f10fc167f";
 
 export const WEBSITE_MAINNET_RPC_ENV = Object.freeze({
   primaryProvider: "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER",
@@ -35,6 +39,16 @@ export type WebsiteMainnetRpcPair = Readonly<{
   source: "role-bound-v1" | "legacy-alchemy-quicknode";
   primary: WebsiteRpcBinding;
   secondary: WebsiteRpcBinding;
+}>;
+
+export type ProductionRecoveryMainnetRpcPair = Readonly<{
+  source: "fixed-tenderly-quicknode-v1";
+  primary: Readonly<{
+    provider: "tenderly";
+    url: string;
+    endpointCommitment: string;
+  }>;
+  secondary: WebsiteRpcBinding & Readonly<{ provider: "quicknode" }>;
 }>;
 
 export function productionMainnetRpcEnvironment(
@@ -91,6 +105,29 @@ function providerPathIsValid(parsed: URL, provider: MainnetRpcProviderId) {
       "docs-demo";
 }
 
+function fixedTenderlyRecoveryBinding() {
+  const parsed = new URL(TENDERLY_RECOVERY_MAINNET_RPC_URL);
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.hostname !== "mainnet.gateway.tenderly.co" ||
+    parsed.pathname !== "/" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.port !== "" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    rpcProviderCommitment("endpoint", parsed.href) !==
+      TENDERLY_RECOVERY_MAINNET_RPC_ENDPOINT_COMMITMENT
+  ) {
+    throw new Error("Production recovery primary RPC binding is invalid");
+  }
+  return Object.freeze({
+    provider: "tenderly" as const,
+    url: parsed.href,
+    endpointCommitment: TENDERLY_RECOVERY_MAINNET_RPC_ENDPOINT_COMMITMENT,
+  });
+}
+
 function strictRpcUrl(
   value: string | undefined,
   provider: MainnetRpcProviderId,
@@ -137,12 +174,12 @@ function requiredCommitment(
   return value;
 }
 
-function binding(
-  provider: MainnetRpcProviderId,
+function binding<Provider extends MainnetRpcProviderId>(
+  provider: Provider,
   rawUrl: string | undefined,
   rawCommitment: string | undefined,
   role: "primary" | "secondary",
-): WebsiteRpcBinding {
+): WebsiteRpcBinding & Readonly<{ provider: Provider }> {
   const url = strictRpcUrl(rawUrl, provider, role);
   const endpointCommitment = requiredCommitment(rawCommitment, role);
   if (rpcProviderCommitment("endpoint", url) !== endpointCommitment) {
@@ -216,24 +253,6 @@ function legacyPair(environment: RuntimeEnvironment) {
   );
 }
 
-function committedLegacyProviderPair(environment: RuntimeEnvironment) {
-  return pair(
-    "legacy-alchemy-quicknode",
-    binding(
-      "alchemy",
-      environment.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL,
-      environment.PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT,
-      "primary",
-    ),
-    binding(
-      "quicknode",
-      environment.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
-      environment.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT,
-      "secondary",
-    ),
-  );
-}
-
 /**
  * Resolves the fixed Website read quorum. Once any role-bound v1 field is
  * configured, all six fields become mandatory and legacy values are ignored.
@@ -270,8 +289,9 @@ export function productionMainnetRpcPair(
 }
 
 /**
- * Resolves the commitment-bound Alchemy + QuickNode recovery quorum used only
- * for Custom Registry deployment verification and historical index rebuilds.
+ * Resolves the fixed Tenderly + commitment-bound QuickNode recovery quorum
+ * used only for Custom Registry deployment verification and historical index
+ * rebuilds.
  * It deliberately ignores role-bound Website and generic RPC aliases so a
  * depleted public-read primary cannot block recovery or silently change the
  * reviewed recovery endpoints. Public Profile, Claim and Trade reads must
@@ -279,15 +299,25 @@ export function productionMainnetRpcPair(
  */
 export function productionRecoveryMainnetRpcPair(
   environment: RuntimeEnvironment = process.env,
-): WebsiteMainnetRpcPair {
-  const resolved = committedLegacyProviderPair(environment);
+): ProductionRecoveryMainnetRpcPair {
+  const primary = fixedTenderlyRecoveryBinding();
+  const secondary = binding(
+    "quicknode",
+    environment.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL,
+    environment.PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT,
+    "secondary",
+  );
   if (
-    resolved.primary.provider !== "alchemy" ||
-    resolved.secondary.provider !== "quicknode"
+    primary.url === secondary.url ||
+    primary.endpointCommitment === secondary.endpointCommitment
   ) {
     throw new Error("Production recovery RPC provider roles are invalid");
   }
-  return resolved;
+  return Object.freeze({
+    source: "fixed-tenderly-quicknode-v1",
+    primary,
+    secondary,
+  });
 }
 
 /**

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -26,7 +26,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         Object.freeze({
           path: "lib/onchain/historical-read-rpc.server.ts",
           sha256:
-            "c20db55489aa28c24a7eb888cbc80eb9d51944d3fe8908e9805d8984e15a2d6c",
+            "543447b498ef2cfbe7e5fb75eb7457b596a34b9ccc75092a442292991fc262f9",
         }),
         Object.freeze({
           path: "lib/onchain/persistent-rpc-cache.server.ts",
@@ -99,7 +99,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         providerConfig: Object.freeze({
           path: "lib/onchain/website-rpc-providers.server.ts",
           sha256:
-            "d501b92d6a28b7e8e1a2a29cae329e2c3a530da941f9b1cbab65e8c6036ca342",
+            "cb0115ba5f594d892e56e407f1a59a52d4c236d7924b78cce4ed727bede21400",
         }),
         currentMarketRpc: Object.freeze({
           path: "lib/market-data/current-market-rpc.server.ts",
@@ -1384,7 +1384,7 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       historicalRpcSource?.includes("primary: binding.primary.url") &&
       historicalRpcSource?.includes("secondary: binding.secondary.url") &&
-      historicalRpcSource?.includes('primary?.vendorGroup !== "alchemy"') &&
+      historicalRpcSource?.includes('primary?.vendorGroup !== "tenderly"') &&
       historicalRpcSource?.includes('secondary?.vendorGroup !== "quicknode"') &&
       historicalRpcSource?.includes(
         "primary.endpointCommitment !== binding.primary.endpointCommitment",

--- a/tests/custom-registry-v2-public-release.test.ts
+++ b/tests/custom-registry-v2-public-release.test.ts
@@ -23,8 +23,7 @@ const transactionHash = `0x${"34".repeat(32)}` as const;
 const blockHash = `0x${"56".repeat(32)}` as const;
 const policyBindingHash = `0x${"78".repeat(32)}` as const;
 const now = () => new Date("2026-08-13T00:00:00.000Z");
-const alchemyUrl =
-  "https://eth-mainnet.g.alchemy.com/v2/alchemy-test-key";
+const tenderlyUrl = "https://mainnet.gateway.tenderly.co/";
 const quicknodeUrl =
   "https://programmable-mainnet.ethereum-mainnet.quiknode.pro/quicknode-test-key/";
 
@@ -271,14 +270,6 @@ describe("Custom Registry V2 public release binding", () => {
       "https://lb.drpc.live/ethereum/depleted-test-key",
     );
     vi.stubEnv(
-      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL",
-      alchemyUrl,
-    );
-    vi.stubEnv(
-      "PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT",
-      rpcProviderCommitment("endpoint", alchemyUrl),
-    );
-    vi.stubEnv(
       "PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL",
       quicknodeUrl,
     );
@@ -299,7 +290,7 @@ describe("Custom Registry V2 public release binding", () => {
     expect(response.status).toBe(503);
     expect(rpcFetch).toHaveBeenCalledTimes(2);
     expect(rpcFetch.mock.calls.map(([url]) => url.toString())).toEqual([
-      alchemyUrl,
+      tenderlyUrl,
       quicknodeUrl,
     ]);
   });

--- a/tests/historical-read-rpc-server.test.ts
+++ b/tests/historical-read-rpc-server.test.ts
@@ -10,15 +10,11 @@ import type { ReadyOnchainDeployment } from "../lib/onchain/types";
 import { rpcProviderCommitment } from
   "../lib/data-pipeline/rpc-provider-commitments";
 
-const ALCHEMY_RPC_URL =
-  "https://eth-mainnet.g.alchemy.com/v2/alchemy-test-key";
+const TENDERLY_RPC_URL = "https://mainnet.gateway.tenderly.co/";
 const DRPC_RPC_URL = "https://lb.drpc.live/ethereum/drpc-test-key";
 const QUICKNODE_RPC_URL =
   "https://programmable-mainnet.ethereum-mainnet.quiknode.pro/quicknode-test-key/";
 const environment = {
-  PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL: ALCHEMY_RPC_URL,
-  PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT:
-    rpcProviderCommitment("endpoint", ALCHEMY_RPC_URL),
   PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL: QUICKNODE_RPC_URL,
   PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT:
     rpcProviderCommitment("endpoint", QUICKNODE_RPC_URL),
@@ -43,11 +39,11 @@ const deployment: ReadyOnchainDeployment = {
 };
 
 describe("historical read RPC deployment", () => {
-  it("uses the exact commitment-bound Alchemy and QuickNode recovery pair", () => {
+  it("uses the fixed Tenderly and commitment-bound QuickNode recovery pair", () => {
     expect(historicalReadOnchainDeployment(deployment, environment)).toMatchObject({
-      rpcUrl: ALCHEMY_RPC_URL,
+      rpcUrl: TENDERLY_RPC_URL,
       rpcUrlSecondary: QUICKNODE_RPC_URL,
-      rpcProviderIds: { primary: "alchemy", secondary: "quicknode" },
+      rpcProviderIds: { primary: "tenderly", secondary: "quicknode" },
     });
   });
 
@@ -58,7 +54,7 @@ describe("historical read RPC deployment", () => {
       rpcUrlSecondary: null,
     }, environment);
 
-    expect(historical.rpcUrl).toBe(ALCHEMY_RPC_URL);
+    expect(historical.rpcUrl).toBe(TENDERLY_RPC_URL);
     expect(historical.rpcUrlSecondary).toBe(QUICKNODE_RPC_URL);
   });
 

--- a/tests/website-rpc-providers.test.ts
+++ b/tests/website-rpc-providers.test.ts
@@ -15,6 +15,7 @@ const ALCHEMY_URL =
 const DRPC_URL = "https://lb.drpc.live/ethereum/drpc-test-key";
 const QUICKNODE_URL =
   "https://programmable-mainnet.ethereum-mainnet.quiknode.pro/quicknode-test-key/";
+const TENDERLY_RECOVERY_URL = "https://mainnet.gateway.tenderly.co/";
 
 function environment(input?: Readonly<{
   primaryProvider?: string;
@@ -76,7 +77,7 @@ describe("Website Mainnet RPC provider bindings", () => {
     }))).toThrow("Production RPC provider roles are invalid");
   });
 
-  it("binds recovery reads to the committed legacy Alchemy and QuickNode pair", () => {
+  it("binds recovery reads to the fixed Tenderly and committed QuickNode pair", () => {
     const recovery = productionRecoveryMainnetRpcPair({
       ...environment({ primaryUrl: "https://eth.drpc.org" }),
       ETHEREUM_RPC_URL: DRPC_URL,
@@ -90,11 +91,12 @@ describe("Website Mainnet RPC provider bindings", () => {
     });
 
     expect(recovery).toEqual({
-      source: "legacy-alchemy-quicknode",
+      source: "fixed-tenderly-quicknode-v1",
       primary: {
-        provider: "alchemy",
-        url: ALCHEMY_URL,
-        endpointCommitment: rpcProviderCommitment("endpoint", ALCHEMY_URL),
+        provider: "tenderly",
+        url: TENDERLY_RECOVERY_URL,
+        endpointCommitment:
+          rpcProviderCommitment("endpoint", TENDERLY_RECOVERY_URL),
       },
       secondary: {
         provider: "quicknode",
@@ -104,32 +106,36 @@ describe("Website Mainnet RPC provider bindings", () => {
     });
   });
 
-  it("keeps recovery closed on aliases, host drift and commitment drift", () => {
+  it("ignores recovery aliases and fails closed on QuickNode drift", () => {
     const committed = {
-      PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL: ALCHEMY_URL,
-      PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT:
-        rpcProviderCommitment("endpoint", ALCHEMY_URL),
       PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL: QUICKNODE_URL,
       PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT:
         rpcProviderCommitment("endpoint", QUICKNODE_URL),
     };
-    expect(() => productionRecoveryMainnetRpcPair({
+    expect(productionRecoveryMainnetRpcPair({
+      ...committed,
       ETHEREUM_RPC_URL: ALCHEMY_URL,
-      ETHEREUM_RPC_URL_B: QUICKNODE_URL,
+      ETHEREUM_RPC_URL_B: DRPC_URL,
+      PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL: DRPC_URL,
       PROGRAMMABLE_ALCHEMY_MAINNET_RPC_ENDPOINT_COMMITMENT:
-        rpcProviderCommitment("endpoint", ALCHEMY_URL),
-      PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT:
-        rpcProviderCommitment("endpoint", QUICKNODE_URL),
-    })).toThrow("Website primary RPC binding is unavailable");
+        rpcProviderCommitment("endpoint", DRPC_URL),
+      PROGRAMMABLE_TENDERLY_MAINNET_RPC_URL: "https://attacker.invalid/",
+    })).toMatchObject({
+      primary: { provider: "tenderly", url: TENDERLY_RECOVERY_URL },
+      secondary: { provider: "quicknode", url: QUICKNODE_URL },
+    });
     expect(() => productionRecoveryMainnetRpcPair({
       ...committed,
-      PROGRAMMABLE_ALCHEMY_MAINNET_RPC_URL: DRPC_URL,
-    })).toThrow("Website primary RPC binding is invalid");
+      PROGRAMMABLE_QUICKNODE_MAINNET_RPC_URL: DRPC_URL,
+    })).toThrow("Website secondary RPC binding is invalid");
     expect(() => productionRecoveryMainnetRpcPair({
       ...committed,
       PROGRAMMABLE_QUICKNODE_MAINNET_RPC_ENDPOINT_COMMITMENT:
         `0x${"ab".repeat(32)}`,
     })).toThrow("Website secondary RPC endpoint commitment mismatch");
+    expect(() => productionRecoveryMainnetRpcPair({})).toThrow(
+      "Website secondary RPC binding is unavailable",
+    );
   });
 
   it("binds only the committed dRPC primary without secondary configuration", () => {
@@ -205,6 +211,10 @@ describe("Website Mainnet RPC provider bindings", () => {
   it("rejects unknown providers, provider-host drift and public fallbacks", () => {
     expect(() => websiteMainnetRpcPair(environment({
       primaryProvider: "generic",
+    }))).toThrow("Website primary RPC provider binding is invalid");
+    expect(() => websiteMainnetRpcPair(environment({
+      primaryProvider: "tenderly",
+      primaryUrl: TENDERLY_RECOVERY_URL,
     }))).toThrow("Website primary RPC provider binding is invalid");
     expect(() => websiteMainnetRpcPair(environment({
       primaryProvider: "drpc",


### PR DESCRIPTION
## Summary
- replace the rate-limited Alchemy recovery reader with the fixed, source-bound Tenderly Mainnet archive endpoint
- retain the commitment-bound QuickNode secondary and both-provider agreement
- keep public Website, Profile, Claim, and Trade RPC bindings unchanged
- update the exact operations manifest and adversarial provider tests

## Verification
- focused provider, Registry, and ops suites: 132/132
- Custom V2 release gate: 89 Node + 102 Vitest, full build and bundle scans
- typecheck, full lint, targeted lint, ops source gate, and diff check pass
- direct read-only Tenderly proof: exact deployment block/hash, historical runtime code, known launch logs, and 5,000-block log ranges

Stage remains fail-closed: no promotion unless the durable seed is non-empty and the full public Fast-Lane smoke passes.