### PR TITLE
Bound historical recovery log windows

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -18,7 +18,7 @@
         },
         {
           "path": "lib/onchain/historical-read-rpc.server.ts",
-          "sha256": "543447b498ef2cfbe7e5fb75eb7457b596a34b9ccc75092a442292991fc262f9"
+          "sha256": "98ffdd09e07f7fd38ef412d27ece0aed69df6120d1ca910002d882aca1782ca6"
         },
         {
           "path": "lib/onchain/persistent-rpc-cache.server.ts",
@@ -40,6 +40,7 @@
         }
       ],
       "eventFiltersPerRange": 2,
+      "historicalRecoveryMaximumLogBlockRange": 500,
       "providerPasses": 2,
       "requestDeadlineMs": 270000,
       "classicPrewarmStepCount": 32,

--- a/lib/onchain/historical-read-rpc.server.ts
+++ b/lib/onchain/historical-read-rpc.server.ts
@@ -6,6 +6,8 @@ import type { ReadyOnchainDeployment } from "./types";
 import { productionRecoveryMainnetRpcPair } from
   "./website-rpc-providers.server";
 
+const RECOVERY_MAX_LOG_BLOCK_RANGE = 500n;
+
 export class HistoricalReadRpcBindingError extends Error {
   override name = "HistoricalReadRpcBindingError";
 
@@ -52,6 +54,10 @@ export function historicalReadOnchainDeployment(
       ...baseDeployment,
       rpcUrl: primary.endpoint,
       rpcUrlSecondary: secondary.endpoint,
+      logBlockRange:
+        baseDeployment.logBlockRange < RECOVERY_MAX_LOG_BLOCK_RANGE
+          ? baseDeployment.logBlockRange
+          : RECOVERY_MAX_LOG_BLOCK_RANGE,
       rpcProviderIds: {
         primary: "tenderly",
         secondary: "quicknode",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -26,7 +26,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         Object.freeze({
           path: "lib/onchain/historical-read-rpc.server.ts",
           sha256:
-            "543447b498ef2cfbe7e5fb75eb7457b596a34b9ccc75092a442292991fc262f9",
+            "98ffdd09e07f7fd38ef412d27ece0aed69df6120d1ca910002d882aca1782ca6",
         }),
         Object.freeze({
           path: "lib/onchain/persistent-rpc-cache.server.ts",
@@ -51,6 +51,7 @@ const APPROVED_OPERATIONS = Object.freeze({
         }),
       ]),
       eventFiltersPerRange: 2,
+      historicalRecoveryMaximumLogBlockRange: 500,
       providerPasses: 2,
       requestDeadlineMs: 270_000,
       classicPrewarmStepCount: 32,
@@ -1386,6 +1387,12 @@ export function evaluateReadModelOperationsSourceContracts(
       historicalRpcSource?.includes("secondary: binding.secondary.url") &&
       historicalRpcSource?.includes('primary?.vendorGroup !== "tenderly"') &&
       historicalRpcSource?.includes('secondary?.vendorGroup !== "quicknode"') &&
+      historicalRpcSource?.includes(
+        "const RECOVERY_MAX_LOG_BLOCK_RANGE = 500n;",
+      ) &&
+      historicalRpcSource?.includes(
+        "baseDeployment.logBlockRange < RECOVERY_MAX_LOG_BLOCK_RANGE",
+      ) &&
       historicalRpcSource?.includes(
         "primary.endpointCommitment !== binding.primary.endpointCommitment",
       ) &&

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -666,6 +666,12 @@ describe("read-model operations source contract", () => {
       "isPersistentCacheRangeLimitError(error)",
       "false",
     ],
+    [
+      "recovery-only 500-block log windows",
+      "lib/onchain/historical-read-rpc.server.ts",
+      "const RECOVERY_MAX_LOG_BLOCK_RANGE = 500n;",
+      "const RECOVERY_MAX_LOG_BLOCK_RANGE = 5_000n;",
+    ],
   ])(
     "rejects a legacy refresh missing %s",
     (_label, path, needle, replacement) => {

--- a/tests/historical-read-rpc-server.test.ts
+++ b/tests/historical-read-rpc-server.test.ts
@@ -43,8 +43,17 @@ describe("historical read RPC deployment", () => {
     expect(historicalReadOnchainDeployment(deployment, environment)).toMatchObject({
       rpcUrl: TENDERLY_RPC_URL,
       rpcUrlSecondary: QUICKNODE_RPC_URL,
+      logBlockRange: 500n,
       rpcProviderIds: { primary: "tenderly", secondary: "quicknode" },
     });
+  });
+
+  it("caps only recovery log windows and preserves a stricter deployment cap", () => {
+    expect(historicalReadOnchainDeployment({
+      ...deployment,
+      logBlockRange: 499n,
+    }, environment).logBlockRange).toBe(499n);
+    expect(deployment.logBlockRange).toBe(5_000n);
   });
 
   it("rejects the base deployment as authority and restores the bound pair", () => {


### PR DESCRIPTION
## Outcome

Caps only the historical recovery log range at 500 blocks so dense Classic phase-04 responses remain below the persistent-cache segment limit. Existing smaller caps are preserved; Website/Profile/Claim/Trade provider bindings are unchanged.

## Evidence

- 107 focused tests passed
- full typecheck passed
- full lint passed with baseline warnings only
- operations source gate passed
- Custom V2 node/Vitest gates passed
- production Next build, neutrality scans, and bundle scan passed
- prior staged runs failed closed at phase 04; no failed candidate was promoted