### PR TITLE
Serve verified Classic V3 Explore catalog from Envio

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -664,38 +664,61 @@ jobs:
           --target-url "$DEPLOYMENT_URL"
           --github-output "$GITHUB_OUTPUT"
 
-      - name: Seed exact staged durable launch catalog
-        id: durable-catalog-seed
+      - name: Probe exact staged Envio Classic V3 catalog
+        id: envio-catalog-probe
         env:
-          CRON_SECRET: ${{ secrets.CRON_SECRET }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          STAGED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
         run: |
           set -euo pipefail
-          result_path="$RUNNER_TEMP/staged-durable-catalog-seed.json"
-          test ! -e "$result_path"
-          node scripts/perf/read-model-staged-refresh.mjs \
-            --target-url "$STAGED_TARGET_URL" \
-            --deployment-id "$STAGED_DEPLOYMENT_ID" \
-            --git-head "$GITHUB_SHA" > "$result_path"
-          RESULT_PATH="$result_path" node --input-type=module <<'NODE'
-          import { appendFileSync, readFileSync } from "node:fs";
-          const result = JSON.parse(readFileSync(process.env.RESULT_PATH, "utf8"));
+          node --input-type=module <<'NODE'
+          import { appendFileSync } from "node:fs";
+          import { readBoundedResponseText } from "./scripts/read-bounded-response.mjs";
+          const target = new URL(
+            "/api/explore?limit=1&page=1&sort=newest",
+            process.env.STAGED_TARGET_URL,
+          );
+          let response;
+          for (let attempt = 0; attempt < 5; attempt += 1) {
+            response = await fetch(target, {
+              redirect: "error",
+              headers: {
+                "x-vercel-protection-bypass":
+                  process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+                "x-vercel-set-bypass-cookie": "false",
+              },
+              signal: AbortSignal.timeout(30_000),
+            });
+            if (response.status !== 503 || attempt === 4) break;
+            await response.body?.cancel().catch(() => {});
+            await new Promise((resolve) => setTimeout(resolve, 5_000));
+          }
+          const body = JSON.parse(await readBoundedResponseText(response, {
+            maximumBytes: 4 * 1024 * 1024,
+            label: "staged Envio catalog probe",
+          }));
           if (
-            result?.ok !== true ||
-            result.deploymentId !== process.env.STAGED_DEPLOYMENT_ID ||
-            result.gitHead !== process.env.GITHUB_SHA ||
-            !/^(?:0|[1-9][0-9]{0,77})$/u.test(result.refreshBlockNumber) ||
-            !Number.isSafeInteger(result.tokenCount) ||
-            result.tokenCount < 1
+            response.status !== 200 ||
+            body?.status !== "ready" ||
+            body?.catalog?.source !== "envio-classic-v3" ||
+            body.catalog.completeness?.stock !== "excluded" ||
+            body.catalog.evidence?.kind !== "envio-indexer-state" ||
+            body.catalog.evidence?.progressBlock !== body.catalog.asOfBlock ||
+            !/^sha256:[0-9a-f]{64}$/u.test(body.catalog.evidence?.commitment ?? "") ||
+            JSON.stringify(body.catalog.scope?.publicCategories) !==
+              JSON.stringify(["classic", "custom"]) ||
+            !Number.isSafeInteger(body.total) || body.total < 1 ||
+            !Array.isArray(body.tokens) || body.tokens.length !== 1 ||
+            body.tokens[0]?.launchModel !== "classic" ||
+            body.tokens[0]?.launchModelVersion !== "classic-v3" ||
+            response.headers.get("x-programmable-launch-source") !==
+              "envio-classic-v3"
           ) {
-            throw new Error("staged durable catalog seed result is invalid");
+            throw new Error("staged Envio Classic V3 catalog probe is invalid");
           }
           appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `block_number=${result.refreshBlockNumber}\ntoken_count=${result.tokenCount}\n`,
+            `block_number=${body.catalog.asOfBlock}\ntoken_count=${body.total}\n`,
           );
           NODE
 
@@ -1122,8 +1145,8 @@ jobs:
           MARKET_READ_STATUS: ${{ steps.public-provider-smoke.outputs.market_read_status }}
           DETAIL_SMOKE_STATUS: ${{ steps.public-provider-smoke.outputs.detail_status }}
           CHART_SMOKE_STATUS: ${{ steps.public-provider-smoke.outputs.chart_status }}
-          CATALOG_BLOCK_NUMBER: ${{ steps.durable-catalog-seed.outputs.block_number }}
-          CATALOG_TOKEN_COUNT: ${{ steps.durable-catalog-seed.outputs.token_count }}
+          CATALOG_BLOCK_NUMBER: ${{ steps.envio-catalog-probe.outputs.block_number }}
+          CATALOG_TOKEN_COUNT: ${{ steps.envio-catalog-probe.outputs.token_count }}
         run: |
           {
             echo "## Staged production candidate"
@@ -1133,9 +1156,9 @@ jobs:
             echo "- Target: $STAGED_TARGET_URL"
             echo "- Previous production deployment: \`$PREVIOUS_DEPLOYMENT_ID\`"
             echo "- Previous production commit: \`$PREVIOUS_GIT_HEAD\`"
-            echo "- Launch identities: validated last-good catalog"
-            echo "- Durable catalog seed block: \`$CATALOG_BLOCK_NUMBER\`"
-            echo "- Durable catalog seed token count: \`$CATALOG_TOKEN_COUNT\`"
+            echo "- Launch identities: validated Envio Classic V3 catalog"
+            echo "- Envio catalog progress block: \`$CATALOG_BLOCK_NUMBER\`"
+            echo "- Envio catalog identity count: \`$CATALOG_TOKEN_COUNT\`"
             echo "- Market data provider: Dexscreener (optional enrichment)"
             echo "- Explore market read status: \`${MARKET_READ_STATUS:-not-run}\`"
             echo "- Token detail smoke: \`${DETAIL_SMOKE_STATUS:-not-run}\`"

--- a/.github/workflows/mainnet-monitor.yml
+++ b/.github/workflows/mainnet-monitor.yml
@@ -1,8 +1,6 @@
-name: Mainnet Monitor
+name: Legacy V2 and Stock mainnet monitor (manual)
 
 on:
-  schedule:
-    - cron: "*/5 * * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/refresh-production-read-model.yml
+++ b/.github/workflows/refresh-production-read-model.yml
@@ -1,8 +1,6 @@
-name: Refresh production read model
+name: Legacy durable read-model refresh (manual)
 
 on:
-  schedule:
-    - cron: "2-57/5 * * * *"
   workflow_dispatch:
 
 permissions: {}
@@ -13,7 +11,7 @@ concurrency:
 
 jobs:
   refresh:
-    name: Refresh durable production read model
+    name: Refresh legacy durable production read model
     if: >-
       github.repository == '0xprogrammable/programmable' &&
       github.ref == 'refs/heads/production'

--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -9,11 +9,11 @@ import {
 import { readDexscreenerExploreEntriesV1 } from
   "../../../lib/market-data/dexscreener-explore.server";
 import {
-  lastGoodLaunchIdentityCommitmentV1,
-  mergeLastGoodLaunchCatalogEntriesV1,
-  readLastGoodLaunchCatalogV1,
+  envioClassicV3IdentityCommitmentV1,
+  mergeEnvioClassicV3CatalogEntriesV1,
+  readEnvioClassicV3CatalogV1,
 } from
-  "../../../lib/market-data/last-good-launch-catalog.server";
+  "../../../lib/market-data/envio-classic-v3-catalog.server";
 import { parseExploreSort } from "../../../lib/onchain/query";
 import { readProductionCustomExploreDirectoryV1 } from
   "../../../lib/server/custom-launch/explore-directory-v1";
@@ -275,7 +275,7 @@ export async function GET(request: NextRequest) {
       pageSize: integerQuery(search.get("limit"), 9),
       socials,
     } as const;
-    const catalog = await readLastGoodLaunchCatalogV1({
+    const catalog = await readEnvioClassicV3CatalogV1({
       signal: readSignal,
       deadlineMs,
     });
@@ -293,11 +293,11 @@ export async function GET(request: NextRequest) {
         });
       }
     }
-    const identityEntries = mergeLastGoodLaunchCatalogEntriesV1(
+    const identityEntries = mergeEnvioClassicV3CatalogEntriesV1(
       catalog.entries,
       customEntries,
     );
-    const identityCommitment = lastGoodLaunchIdentityCommitmentV1(
+    const identityCommitment = envioClassicV3IdentityCommitmentV1(
       catalog,
       identityEntries,
     );
@@ -384,6 +384,7 @@ export async function GET(request: NextRequest) {
             ...catalog.completeness,
             custom: customStatus,
           },
+          scope: catalog.scope,
           evidence: catalog.evidence,
         },
         ...(marketSort
@@ -434,7 +435,8 @@ export async function GET(request: NextRequest) {
         headers: {
           "Cache-Control": "no-store",
           "Retry-After": "5",
-          "X-Programmable-Read-Source": "last-good+dexscreener",
+          "X-Programmable-Launch-Source": "envio-classic-v3",
+          "X-Programmable-Read-Source": "envio-classic-v3+dexscreener",
           "X-Programmable-Market-Provider": "dexscreener",
         },
       },

--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -2,10 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
 import {
-  mergeLastGoodLaunchCatalogEntriesV1,
-  readLastGoodLaunchCatalogV1,
+  mergeEnvioClassicV3CatalogEntriesV1,
+  readEnvioClassicV3CatalogV1,
 } from
-  "../../../../../lib/market-data/last-good-launch-catalog.server";
+  "../../../../../lib/market-data/envio-classic-v3-catalog.server";
 import { isTokenChartRange } from "../../../../../lib/onchain/chart";
 import { readProductionCustomExploreDirectoryV1 } from
   "../../../../../lib/server/custom-launch/explore-directory-v1";
@@ -35,7 +35,10 @@ export async function GET(request: NextRequest) {
   const address = getAddress(rawAddress);
 
   try {
-    const catalog = await readLastGoodLaunchCatalogV1();
+    const catalog = await readEnvioClassicV3CatalogV1({
+      signal: request.signal,
+      deadlineMs: Date.now() + 8_000,
+    });
     let entries = catalog.entries;
     let customStatus: "current" | "unavailable" = "unavailable";
     if (isCustomLaunchRegistryPublicReadEnabled()) {
@@ -50,7 +53,7 @@ export async function GET(request: NextRequest) {
         )) return unavailable(address, range, catalog.source, 503);
       }
       if (customEntries !== undefined) {
-        entries = mergeLastGoodLaunchCatalogEntriesV1(entries, customEntries);
+        entries = mergeEnvioClassicV3CatalogEntriesV1(entries, customEntries);
         customStatus = "current";
       }
     }
@@ -67,7 +70,7 @@ export async function GET(request: NextRequest) {
     console.error("Token chart identity read failed", {
       name: error instanceof Error ? error.name : "LaunchCatalogError",
     });
-    return unavailable(address, range, "last-good", 503);
+    return unavailable(address, range, "envio-classic-v3", 503);
   }
 }
 

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -7,11 +7,11 @@ import {
 import { readDexscreenerExploreEntriesV1 } from
   "../../../../lib/market-data/dexscreener-explore.server";
 import {
-  lastGoodLaunchIdentityCommitmentV1,
-  mergeLastGoodLaunchCatalogEntriesV1,
-  readLastGoodLaunchCatalogV1,
+  envioClassicV3IdentityCommitmentV1,
+  mergeEnvioClassicV3CatalogEntriesV1,
+  readEnvioClassicV3CatalogV1,
 } from
-  "../../../../lib/market-data/last-good-launch-catalog.server";
+  "../../../../lib/market-data/envio-classic-v3-catalog.server";
 import { readProductionCustomExploreDirectoryV1 } from
   "../../../../lib/server/custom-launch/explore-directory-v1";
 import { isCustomLaunchRegistryPublicReadEnabled } from
@@ -99,7 +99,7 @@ export async function GET(request: NextRequest) {
   const address = requestedTokenAddress.toLowerCase();
   let catalog;
   try {
-    catalog = await readLastGoodLaunchCatalogV1({
+    catalog = await readEnvioClassicV3CatalogV1({
       signal: readSignal,
       deadlineMs,
     });
@@ -108,8 +108,9 @@ export async function GET(request: NextRequest) {
       name: error instanceof Error ? error.name : "LaunchCatalogError",
     });
     return unavailableResponse({
+      "X-Programmable-Launch-Source": "envio-classic-v3",
       "X-Programmable-Market-Provider": "dexscreener",
-      "X-Programmable-Read-Source": "last-good+dexscreener",
+      "X-Programmable-Read-Source": "envio-classic-v3+dexscreener",
     });
   }
 
@@ -140,7 +141,7 @@ export async function GET(request: NextRequest) {
   }
   let identityEntries: readonly ExploreEntry[];
   try {
-    identityEntries = mergeLastGoodLaunchCatalogEntriesV1(
+    identityEntries = mergeEnvioClassicV3CatalogEntriesV1(
       catalog.entries,
       customEntries,
     );
@@ -165,7 +166,7 @@ export async function GET(request: NextRequest) {
     asOfBlock: catalog.asOfBlock,
     asOfBlockHash: catalog.asOfBlockHash,
     identityCount: identityEntries.length,
-    identityCommitment: lastGoodLaunchIdentityCommitmentV1(
+    identityCommitment: envioClassicV3IdentityCommitmentV1(
       catalog,
       identityEntries,
     ),
@@ -173,6 +174,7 @@ export async function GET(request: NextRequest) {
       ...catalog.completeness,
       custom: customStatus,
     },
+    scope: catalog.scope,
     evidence: catalog.evidence,
   };
 

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -145,10 +145,10 @@ type ExploreRanking = Readonly<{
 }>;
 
 type ExploreCatalogBoundary = Readonly<{
-  source: "durable-blob";
+  source: "envio-classic-v3";
   launchSource:
-    | "durable-blob"
-    | "durable-blob+registry.custom-launched";
+    | "envio-classic-v3"
+    | "envio-classic-v3+registry.custom-launched";
   status: "current" | "last-known-good";
   lastIndexedAt: string;
   asOfBlock: string;
@@ -157,12 +157,27 @@ type ExploreCatalogBoundary = Readonly<{
   identityCommitment: `sha256:${string}`;
   completeness: Readonly<{
     classic: "current" | "last-known-good";
-    stock: "current" | "last-known-good" | "unavailable";
+    stock: "excluded";
     custom: "current" | "unavailable";
   }>;
+  scope: Readonly<{
+    included: readonly ["classic-v3", "registry.custom-launched"];
+    excluded: readonly [
+      "classic-v1",
+      "classic-v2",
+      "stock-paired-v1",
+      "stock-paired-v2",
+      "stock-paired-v3",
+    ];
+    publicCategories: readonly ["classic", "custom"];
+  }>;
   evidence: Readonly<{
-    kind: "durable-envelope";
-    commitment: `0x${string}`;
+    kind: "envio-indexer-state";
+    deployment: string;
+    sourceCommit: string;
+    progressBlock: string;
+    progressOccurrenceId: string;
+    commitment: `sha256:${string}`;
   }>;
 }>;
 
@@ -871,14 +886,19 @@ function exactIsoTimestamp(value: unknown): value is string {
     new Date(Date.parse(value)).toISOString() === value;
 }
 
+function exactStringArray(value: unknown, expected: readonly string[]) {
+  return Array.isArray(value) && value.length === expected.length &&
+    value.every((item, index) => item === expected[index]);
+}
+
 function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
   if (!isRecord(value) || !isRecord(value.completeness) ||
-    !isRecord(value.evidence)) return null;
+    !isRecord(value.scope) || !isRecord(value.evidence)) return null;
   const expectedLaunchSource = value.completeness.custom === "current"
-    ? "durable-blob+registry.custom-launched"
-    : "durable-blob";
+    ? "envio-classic-v3+registry.custom-launched"
+    : "envio-classic-v3";
   if (
-    value.source !== "durable-blob" ||
+    value.source !== "envio-classic-v3" ||
     value.launchSource !== expectedLaunchSource ||
     !["current", "last-known-good"].includes(String(value.status)) ||
     !exactIsoTimestamp(value.lastIndexedAt) ||
@@ -893,15 +913,34 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
     !["current", "last-known-good"].includes(
       String(value.completeness.classic),
     ) ||
-    !["current", "last-known-good", "unavailable"].includes(
-      String(value.completeness.stock),
-    ) ||
+    value.completeness.stock !== "excluded" ||
     !["current", "unavailable"].includes(
       String(value.completeness.custom),
     ) ||
-    value.evidence.kind !== "durable-envelope" ||
+    !exactStringArray(value.scope.included, [
+      "classic-v3",
+      "registry.custom-launched",
+    ]) ||
+    !exactStringArray(value.scope.excluded, [
+      "classic-v1",
+      "classic-v2",
+      "stock-paired-v1",
+      "stock-paired-v2",
+      "stock-paired-v3",
+    ]) ||
+    !exactStringArray(value.scope.publicCategories, ["classic", "custom"]) ||
+    value.evidence.kind !== "envio-indexer-state" ||
+    typeof value.evidence.deployment !== "string" ||
+    !/^[a-z0-9][a-z0-9-]{0,127}$/u.test(value.evidence.deployment) ||
+    typeof value.evidence.sourceCommit !== "string" ||
+    !/^[0-9a-f]{40}$/u.test(value.evidence.sourceCommit) ||
+    value.evidence.progressBlock !== value.asOfBlock ||
+    typeof value.evidence.progressOccurrenceId !== "string" ||
+    !/^1:0x[0-9a-f]{64}:0x[0-9a-f]{64}:[0-9]+$/u.test(
+      value.evidence.progressOccurrenceId,
+    ) ||
     typeof value.evidence.commitment !== "string" ||
-    !/^0x[0-9a-f]{64}$/u.test(value.evidence.commitment)
+    !/^sha256:[0-9a-f]{64}$/u.test(value.evidence.commitment)
   ) return null;
   return value as ExploreCatalogBoundary;
 }

--- a/lib/market-data/envio-classic-v3-catalog.server.ts
+++ b/lib/market-data/envio-classic-v3-catalog.server.ts
@@ -1,0 +1,1273 @@
+import "server-only";
+
+import {
+  createPublicClient,
+  formatUnits,
+  getAddress,
+  http,
+  isAddress,
+  isHex,
+  type Address,
+  type Hex,
+} from "viem";
+import { mainnet } from "viem/chains";
+
+import { createEnvioClient } from "../data-pipeline/envio";
+import {
+  getDataPipelineReleaseBinding,
+  type DataPipelineReleaseBinding,
+} from "../data-pipeline/release-binding.server";
+import {
+  boundedJsonRequest,
+  type DataPipelineFetcher,
+} from "../data-pipeline/request";
+import { canonicalTokenExploreEntryV1 } from "../explore-entry-v1";
+import {
+  characterLength,
+  hasUnsafeDisplayCharacters,
+  isValidTokenSymbol,
+  MAX_TOKEN_NAME_BYTES,
+  MAX_TOKEN_NAME_CHARACTERS,
+  MAX_TOKEN_SYMBOL_BYTES,
+  utf8ByteLength,
+} from "../metadata-policy";
+import { uerc20ReadAbi } from "../onchain/abis";
+import { getWebsiteReadOnchainDeployment } from "../onchain/config";
+import { withOperationalRpcFailover } from
+  "../onchain/operational-rpc-failover.server";
+import { canonicalSha256 } from "../server/projection-target/hashing";
+import type { ExploreEntry, LauncherToken } from "../tokens";
+
+const CATALOG_CACHE_TTL_MS = 15_000;
+const CATALOG_STALE_GRACE_MS = 5 * 60_000;
+const CATALOG_WORKER_TIMEOUT_MS = 7_000;
+const GRAPHQL_TIMEOUT_MS = 3_000;
+const GRAPHQL_MAXIMUM_BODY_BYTES = 4 * 1024 * 1024;
+const LAUNCH_PAGE_SIZE = 64;
+const MAXIMUM_LAUNCH_COUNT = 5_000;
+const TOKEN_METADATA_BATCH_SIZE = 64;
+const TOKEN_METADATA_CONCURRENCY = 3;
+const MAXIMUM_RPC_HEAD_SKEW_BLOCKS = 8n;
+const NATIVE_CURRENCY_ADDRESS =
+  "0x0000000000000000000000000000000000000000" as const;
+
+const CLASSIC_V3_LAUNCH_QUERY = `
+  query ProgrammableClassicV3Catalog(
+    $afterId: String!
+    $anchorBlock: numeric!
+    $first: Int!
+  ) {
+    Launch(
+      where: {
+        _and: [
+          { id: { _gt: $afterId } }
+          { updatedBlock: { _lte: $anchorBlock } }
+          { model: { _eq: "classic" } }
+          { releaseVersion: { _eq: "classic-v3" } }
+          { isComplete: { _eq: true } }
+          { provenanceValid: { _eq: true } }
+        ]
+      }
+      order_by: [{ id: asc }]
+      limit: $first
+    ) {
+      id
+      chainId
+      model
+      releaseVersion
+      launchHash
+      token
+      creator
+      quoteAsset
+      poolId
+      hook
+      rewardVault
+      positionRecipient
+      positionTokenId
+      totalSwapFeeBps
+      buySwapFeeBps
+      sellSwapFeeBps
+      rewardConfigurationHash
+      quoteConfigurationHash
+      totalSupply
+      tokenLiquidityAmount
+      lockedTokenDust
+      initialTick
+      tickLower
+      tickUpper
+      lpFeePips
+      launchOccurrenceId
+      liquidityOccurrenceId
+      initialBuyOccurrenceId
+      custodyOccurrenceId
+      coordinatorOccurrenceId
+      hasLaunchEvent
+      hasLiquidityEvent
+      hasInitialBuyEvent
+      hasCustodyEvent
+      hasCoordinatorEvent
+      hasPoolRegistrationEvent
+      hasPoolFeeDisclosureEvent
+      hasRewardVaultFactoryEvent
+      provenanceValid
+      isComplete
+      updatedBlock
+    }
+  }
+`;
+
+const CLASSIC_V3_LAUNCH_EVENTS_QUERY = `
+  query ProgrammableClassicV3LaunchEvents($ids: [String!]!) {
+    ChainEvent(
+      where: { id: { _in: $ids } }
+      order_by: [{ id: asc }]
+    ) {
+      id
+      downstreamLogicalId
+      receiptLogOrdinal
+      chainId
+      blockNumber
+      blockHash
+      blockTimestamp
+      transactionHash
+      transactionIndex
+      blockGlobalLogIndex
+      sourceAddress
+      contractName
+      eventName
+      model
+      releaseVersion
+      decodedPayload
+      payloadHash
+    }
+  }
+`;
+
+const LAUNCH_KEYS = [
+  "id",
+  "chainId",
+  "model",
+  "releaseVersion",
+  "launchHash",
+  "token",
+  "creator",
+  "quoteAsset",
+  "poolId",
+  "hook",
+  "rewardVault",
+  "positionRecipient",
+  "positionTokenId",
+  "totalSwapFeeBps",
+  "buySwapFeeBps",
+  "sellSwapFeeBps",
+  "rewardConfigurationHash",
+  "quoteConfigurationHash",
+  "totalSupply",
+  "tokenLiquidityAmount",
+  "lockedTokenDust",
+  "initialTick",
+  "tickLower",
+  "tickUpper",
+  "lpFeePips",
+  "launchOccurrenceId",
+  "liquidityOccurrenceId",
+  "initialBuyOccurrenceId",
+  "custodyOccurrenceId",
+  "coordinatorOccurrenceId",
+  "hasLaunchEvent",
+  "hasLiquidityEvent",
+  "hasInitialBuyEvent",
+  "hasCustodyEvent",
+  "hasCoordinatorEvent",
+  "hasPoolRegistrationEvent",
+  "hasPoolFeeDisclosureEvent",
+  "hasRewardVaultFactoryEvent",
+  "provenanceValid",
+  "isComplete",
+  "updatedBlock",
+] as const;
+
+const EVENT_KEYS = [
+  "id",
+  "downstreamLogicalId",
+  "receiptLogOrdinal",
+  "chainId",
+  "blockNumber",
+  "blockHash",
+  "blockTimestamp",
+  "transactionHash",
+  "transactionIndex",
+  "blockGlobalLogIndex",
+  "sourceAddress",
+  "contractName",
+  "eventName",
+  "model",
+  "releaseVersion",
+  "decodedPayload",
+  "payloadHash",
+] as const;
+
+type CatalogReadOptions = Readonly<{
+  signal?: AbortSignal;
+  /** Absolute Unix epoch deadline in milliseconds. */
+  deadlineMs?: number;
+}>;
+
+type EnvioClassicV3LaunchRow = Readonly<{
+  id: string;
+  launchHash: Hex;
+  token: Address;
+  creator: Address;
+  poolId: Hex;
+  hook: Address;
+  rewardVault: Address;
+  positionRecipient: Address;
+  positionTokenId: string;
+  buySwapFeeBps: number;
+  sellSwapFeeBps: number;
+  rewardConfigurationHash: Hex;
+  totalSupply: string;
+  tokenLiquidityAmount: string;
+  lockedTokenDust: string;
+  initialTick: number;
+  tickLower: number;
+  tickUpper: number;
+  lpFeePips: number;
+  launchOccurrenceId: string;
+  updatedBlock: string;
+}>;
+
+type EnvioClassicV3LaunchEvent = Readonly<{
+  id: string;
+  blockNumber: string;
+  blockHash: Hex;
+  blockTimestamp: string;
+  transactionHash: Hex;
+  transactionIndex: number;
+  blockGlobalLogIndex: number;
+  decodedPayload: Readonly<Record<string, string>>;
+}>;
+
+type TokenMetadata = Readonly<{
+  tokenAddress: Address;
+  name: string;
+  symbol: string;
+  decimals: number;
+}>;
+
+type RpcCatalogSnapshot = Readonly<{
+  headBlock: string;
+  anchorBlockHash: Hex;
+  anchorBlockTimestamp: string;
+  metadata: ReadonlyMap<string, TokenMetadata>;
+}>;
+
+export type EnvioClassicV3CatalogV1 = Readonly<{
+  source: "envio-classic-v3";
+  status: "current" | "last-known-good";
+  generatedAt: string;
+  asOfBlock: string;
+  asOfBlockHash: Hex;
+  entries: readonly ExploreEntry[];
+  completeness: Readonly<{
+    classic: "current" | "last-known-good";
+    stock: "excluded";
+    custom: "unavailable";
+  }>;
+  scope: Readonly<{
+    included: readonly ["classic-v3", "registry.custom-launched"];
+    excluded: readonly [
+      "classic-v1",
+      "classic-v2",
+      "stock-paired-v1",
+      "stock-paired-v2",
+      "stock-paired-v3",
+    ];
+    publicCategories: readonly ["classic", "custom"];
+  }>;
+  evidence: Readonly<{
+    kind: "envio-indexer-state";
+    deployment: string;
+    sourceCommit: string;
+    progressBlock: string;
+    progressOccurrenceId: string;
+    commitment: `sha256:${string}`;
+  }>;
+}>;
+
+export type EnvioClassicV3CatalogDependenciesV1 = Readonly<{
+  fetcher?: DataPipelineFetcher;
+  readRpcSnapshot?: (input: Readonly<{
+    anchorBlock: string;
+    tokens: readonly Address[];
+    deadlineMs: number;
+    signal: AbortSignal;
+  }>) => Promise<RpcCatalogSnapshot>;
+  now?: () => number;
+}>;
+
+type CatalogFlight = {
+  promise: Promise<EnvioClassicV3CatalogV1>;
+  controller: AbortController;
+  waiters: number;
+  settled: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, expected: readonly string[]) {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  return actual.length === sortedExpected.length &&
+    actual.every((key, index) => key === sortedExpected[index]);
+}
+
+function unsignedText(value: unknown, label: string): string {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    throw new Error(`Envio ${label} is invalid`);
+  }
+  return value;
+}
+
+function safeUnsignedInteger(value: unknown, label: string): number {
+  const text = unsignedText(value, label);
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`Envio ${label} is unsafe`);
+  return parsed;
+}
+
+function boundedInteger(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+  label: string,
+): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < minimum ||
+    value > maximum
+  ) {
+    throw new Error(`Envio ${label} is invalid`);
+  }
+  return value;
+}
+
+function address(value: unknown, label: string): Address {
+  if (typeof value !== "string" || !isAddress(value)) {
+    throw new Error(`Envio ${label} is invalid`);
+  }
+  return getAddress(value);
+}
+
+function bytes32(value: unknown, label: string): Hex {
+  if (
+    typeof value !== "string" ||
+    !isHex(value) ||
+    value.length !== 66 ||
+    !/^0x[0-9a-f]{64}$/u.test(value)
+  ) {
+    throw new Error(`Envio ${label} is invalid`);
+  }
+  return value as Hex;
+}
+
+function exactString(value: unknown, pattern: RegExp, label: string) {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw new Error(`Envio ${label} is invalid`);
+  }
+  return value;
+}
+
+function launchSourceBindings(release: DataPipelineReleaseBinding) {
+  const classicV3 = release.releases.find((candidate) =>
+    candidate.model === "classic" &&
+    candidate.releaseVersion === "classic-v3"
+  );
+  if (!classicV3) throw new Error("Classic V3 Envio release is not bound");
+  const launcher = release.sources.find(
+    (candidate) => candidate.contractName === "ClassicV3Launcher",
+  );
+  const hook = release.sources.find(
+    (candidate) => candidate.contractName === "ClassicV3Hook",
+  );
+  if (
+    !launcher ||
+    !hook ||
+    !classicV3.sourceContracts.includes(launcher.contractName) ||
+    !classicV3.sourceContracts.includes(hook.contractName)
+  ) {
+    throw new Error("Classic V3 Envio source bindings are incomplete");
+  }
+  return Object.freeze({ launcher, hook });
+}
+
+function parseLaunchRow(
+  value: unknown,
+  release: DataPipelineReleaseBinding,
+): EnvioClassicV3LaunchRow {
+  if (!isRecord(value) || !hasOnlyKeys(value, LAUNCH_KEYS)) {
+    throw new Error("Envio Classic V3 launch row shape drifted");
+  }
+  const sources = launchSourceBindings(release);
+  const launchHash = bytes32(value.launchHash, "launch hash");
+  const token = address(value.token, "token");
+  const creator = address(value.creator, "creator");
+  const hook = address(value.hook, "hook");
+  const rewardVault = address(value.rewardVault, "reward vault");
+  const positionRecipient = address(value.positionRecipient, "position recipient");
+  const poolId = bytes32(value.poolId, "pool id");
+  const rewardConfigurationHash = bytes32(
+    value.rewardConfigurationHash,
+    "reward configuration hash",
+  );
+  const id = exactString(
+    value.id,
+    /^1:classic-v3:0x[0-9a-f]{64}$/u,
+    "launch id",
+  );
+  const launchOccurrenceId = exactString(
+    value.launchOccurrenceId,
+    /^1:0x[0-9a-f]{64}:0x[0-9a-f]{64}:(?:0|[1-9][0-9]*)$/u,
+    "launch occurrence",
+  );
+  const requiredFlags = [
+    value.hasLaunchEvent,
+    value.hasLiquidityEvent,
+    value.hasInitialBuyEvent,
+    value.hasCustodyEvent,
+    value.hasPoolRegistrationEvent,
+    value.hasPoolFeeDisclosureEvent,
+    value.hasRewardVaultFactoryEvent,
+    value.provenanceValid,
+    value.isComplete,
+  ];
+  if (
+    value.chainId !== 1 ||
+    value.model !== "classic" ||
+    value.releaseVersion !== "classic-v3" ||
+    value.quoteAsset !== null ||
+    value.totalSwapFeeBps !== null ||
+    value.quoteConfigurationHash !== null ||
+    value.coordinatorOccurrenceId !== null ||
+    value.hasCoordinatorEvent !== false ||
+    id !== `1:classic-v3:${launchHash}` ||
+    hook.toLowerCase() !== sources.hook.address.toLowerCase() ||
+    requiredFlags.some((flag) => flag !== true) ||
+    typeof value.liquidityOccurrenceId !== "string" ||
+    typeof value.initialBuyOccurrenceId !== "string" ||
+    typeof value.custodyOccurrenceId !== "string"
+  ) {
+    throw new Error(`Envio Classic V3 launch ${id} failed release validation`);
+  }
+  const buySwapFeeBps = boundedInteger(
+    value.buySwapFeeBps,
+    0,
+    10_000,
+    "buy swap fee",
+  );
+  const sellSwapFeeBps = boundedInteger(
+    value.sellSwapFeeBps,
+    0,
+    10_000,
+    "sell swap fee",
+  );
+  return Object.freeze({
+    id,
+    launchHash,
+    token,
+    creator,
+    poolId,
+    hook,
+    rewardVault,
+    positionRecipient,
+    positionTokenId: unsignedText(value.positionTokenId, "position token id"),
+    buySwapFeeBps,
+    sellSwapFeeBps,
+    rewardConfigurationHash,
+    totalSupply: unsignedText(value.totalSupply, "total supply"),
+    tokenLiquidityAmount: unsignedText(
+      value.tokenLiquidityAmount,
+      "token liquidity amount",
+    ),
+    lockedTokenDust: unsignedText(value.lockedTokenDust, "locked token dust"),
+    initialTick: boundedInteger(
+      value.initialTick,
+      -887_272,
+      887_272,
+      "initial tick",
+    ),
+    tickLower: boundedInteger(value.tickLower, -887_272, 887_272, "tick lower"),
+    tickUpper: boundedInteger(value.tickUpper, -887_272, 887_272, "tick upper"),
+    lpFeePips: boundedInteger(value.lpFeePips, 0, 1_000_000, "LP fee"),
+    launchOccurrenceId,
+    updatedBlock: unsignedText(value.updatedBlock, "updated block"),
+  });
+}
+
+function parseLaunchEvent(
+  value: unknown,
+  expectedOccurrenceId: string,
+  release: DataPipelineReleaseBinding,
+): EnvioClassicV3LaunchEvent {
+  if (!isRecord(value) || !hasOnlyKeys(value, EVENT_KEYS)) {
+    throw new Error("Envio Classic V3 launch event shape drifted");
+  }
+  const sources = launchSourceBindings(release);
+  const id = exactString(
+    value.id,
+    /^1:0x[0-9a-f]{64}:0x[0-9a-f]{64}:(?:0|[1-9][0-9]*)$/u,
+    "event id",
+  );
+  const blockHash = bytes32(value.blockHash, "event block hash");
+  const transactionHash = bytes32(value.transactionHash, "event transaction hash");
+  const blockGlobalLogIndex = safeUnsignedInteger(
+    value.blockGlobalLogIndex,
+    "event log index",
+  );
+  if (
+    value.downstreamLogicalId !== null ||
+    value.receiptLogOrdinal !== null ||
+    typeof value.decodedPayload !== "string"
+  ) {
+    throw new Error(`Envio Classic V3 event ${id} has invalid source semantics`);
+  }
+  bytes32(value.payloadHash, "event payload hash");
+  let decodedPayload: unknown;
+  try {
+    decodedPayload = JSON.parse(value.decodedPayload);
+  } catch {
+    throw new Error(`Envio Classic V3 event ${id} payload is invalid`);
+  }
+  const payloadKeys = [
+    "buySwapFeeBps",
+    "deployer",
+    "feeHook",
+    "launchHash",
+    "poolId",
+    "positionRecipient",
+    "positionTokenId",
+    "rewardConfigurationHash",
+    "rewardVault",
+    "sellSwapFeeBps",
+    "token",
+  ] as const;
+  if (
+    !isRecord(decodedPayload) ||
+    !hasOnlyKeys(decodedPayload, payloadKeys) ||
+    Object.values(decodedPayload).some((item) => typeof item !== "string")
+  ) {
+    throw new Error(`Envio Classic V3 event ${id} payload shape drifted`);
+  }
+  if (
+    id !== expectedOccurrenceId ||
+    value.chainId !== 1 ||
+    value.model !== "classic" ||
+    value.releaseVersion !== "classic-v3" ||
+    value.contractName !== "ClassicV3Launcher" ||
+    value.eventName !== "MemeTokenLaunchedV2" ||
+    address(value.sourceAddress, "event source").toLowerCase() !==
+      sources.launcher.address.toLowerCase() ||
+    id !== `1:${blockHash}:${transactionHash}:${blockGlobalLogIndex}`
+  ) {
+    throw new Error(`Envio Classic V3 event ${id} failed occurrence validation`);
+  }
+  return Object.freeze({
+    id,
+    blockNumber: unsignedText(value.blockNumber, "event block number"),
+    blockHash,
+    blockTimestamp: unsignedText(value.blockTimestamp, "event block timestamp"),
+    transactionHash,
+    transactionIndex: safeUnsignedInteger(
+      value.transactionIndex,
+      "event transaction index",
+    ),
+    blockGlobalLogIndex,
+    decodedPayload: decodedPayload as Record<string, string>,
+  });
+}
+
+function assertLaunchEventBinding(
+  launch: EnvioClassicV3LaunchRow,
+  event: EnvioClassicV3LaunchEvent,
+  release: DataPipelineReleaseBinding,
+) {
+  const classicV3 = release.releases.find((candidate) =>
+    candidate.releaseVersion === "classic-v3"
+  );
+  if (!classicV3) throw new Error("Classic V3 Envio release is unavailable");
+  const payload = event.decodedPayload;
+  const sameHex = (left: string, right: string) =>
+    left.toLowerCase() === right.toLowerCase();
+  if (
+    BigInt(event.blockNumber) < BigInt(classicV3.activationBlock) ||
+    BigInt(launch.updatedBlock) < BigInt(event.blockNumber) ||
+    !sameHex(payload.launchHash!, launch.launchHash) ||
+    !sameHex(payload.token!, launch.token) ||
+    !sameHex(payload.deployer!, launch.creator) ||
+    !sameHex(payload.poolId!, launch.poolId) ||
+    !sameHex(payload.feeHook!, launch.hook) ||
+    !sameHex(payload.rewardVault!, launch.rewardVault) ||
+    !sameHex(payload.positionRecipient!, launch.positionRecipient) ||
+    payload.positionTokenId !== launch.positionTokenId ||
+    payload.buySwapFeeBps !== String(launch.buySwapFeeBps) ||
+    payload.sellSwapFeeBps !== String(launch.sellSwapFeeBps) ||
+    !sameHex(
+      payload.rewardConfigurationHash!,
+      launch.rewardConfigurationHash,
+    )
+  ) {
+    throw new Error(`Envio Classic V3 launch ${launch.id} payload binding failed`);
+  }
+}
+
+function parseRows(response: unknown, field: "Launch" | "ChainEvent") {
+  if (
+    !isRecord(response) ||
+    !hasOnlyKeys(response, ["data"]) ||
+    !isRecord(response.data) ||
+    !hasOnlyKeys(response.data, [field]) ||
+    !Array.isArray(response.data[field])
+  ) {
+    throw new Error(`Envio ${field} response shape drifted`);
+  }
+  return response.data[field];
+}
+
+function boundFetcher(
+  fetcher: DataPipelineFetcher | undefined,
+  signal: AbortSignal,
+  deadlineMs: number,
+): DataPipelineFetcher {
+  return async (input, init) => {
+    const remaining = deadlineMs - Date.now();
+    if (remaining <= 0) throw new Error("Envio catalog deadline exceeded");
+    const signals = [signal, AbortSignal.timeout(remaining)];
+    if (init?.signal) signals.push(init.signal);
+    return await (fetcher ?? fetch)(input, {
+      ...init,
+      signal: AbortSignal.any(signals),
+    });
+  };
+}
+
+async function graphqlRequest(
+  release: DataPipelineReleaseBinding,
+  body: unknown,
+  fetcher: DataPipelineFetcher,
+) {
+  return await boundedJsonRequest<unknown>({
+    dependency: "envio",
+    endpoint: release.envio.graphqlEndpoint,
+    timeoutMs: GRAPHQL_TIMEOUT_MS,
+    maximumBodyBytes: GRAPHQL_MAXIMUM_BODY_BYTES,
+    fetcher,
+    body,
+  });
+}
+
+async function readClassicV3Rows(
+  release: DataPipelineReleaseBinding,
+  anchorBlock: string,
+  fetcher: DataPipelineFetcher,
+) {
+  const launches: EnvioClassicV3LaunchRow[] = [];
+  const events = new Map<string, EnvioClassicV3LaunchEvent>();
+  let afterId = "";
+  while (true) {
+    const launchResponse = await graphqlRequest(release, {
+      query: CLASSIC_V3_LAUNCH_QUERY,
+      variables: { afterId, anchorBlock, first: LAUNCH_PAGE_SIZE },
+    }, fetcher);
+    const rawLaunches = parseRows(launchResponse, "Launch");
+    if (rawLaunches.length > LAUNCH_PAGE_SIZE) {
+      throw new Error("Envio Classic V3 page exceeded its bound");
+    }
+    const page = rawLaunches.map((row) => parseLaunchRow(row, release));
+    for (const launch of page) {
+      if (
+        launch.id <= afterId ||
+        BigInt(launch.updatedBlock) > BigInt(anchorBlock)
+      ) {
+        throw new Error("Envio Classic V3 launch order drifted");
+      }
+      afterId = launch.id;
+      launches.push(launch);
+    }
+    if (launches.length > MAXIMUM_LAUNCH_COUNT) {
+      throw new Error("Envio Classic V3 catalog exceeded its safety bound");
+    }
+    if (page.length > 0) {
+      const ids = page.map((launch) => launch.launchOccurrenceId);
+      const eventResponse = await graphqlRequest(release, {
+        query: CLASSIC_V3_LAUNCH_EVENTS_QUERY,
+        variables: { ids },
+      }, fetcher);
+      const rawEvents = parseRows(eventResponse, "ChainEvent");
+      if (rawEvents.length !== ids.length) {
+        throw new Error("Envio Classic V3 occurrence coverage is incomplete");
+      }
+      const expected = new Set(ids);
+      for (const rawEvent of rawEvents) {
+        const rawId = isRecord(rawEvent) ? rawEvent.id : undefined;
+        if (typeof rawId !== "string" || !expected.delete(rawId)) {
+          throw new Error("Envio Classic V3 occurrence set drifted");
+        }
+        const event = parseLaunchEvent(rawEvent, rawId, release);
+        if (BigInt(event.blockNumber) > BigInt(anchorBlock)) {
+          throw new Error("Envio Classic V3 occurrence exceeds progress");
+        }
+        events.set(event.id, event);
+      }
+      if (expected.size !== 0) {
+        throw new Error("Envio Classic V3 occurrence coverage is incomplete");
+      }
+      for (const launch of page) {
+        const event = events.get(launch.launchOccurrenceId);
+        if (!event) {
+          throw new Error("Envio Classic V3 occurrence coverage is incomplete");
+        }
+        assertLaunchEventBinding(launch, event, release);
+      }
+    }
+    if (page.length < LAUNCH_PAGE_SIZE) break;
+  }
+  if (launches.length === 0) {
+    throw new Error("Envio Classic V3 catalog is empty");
+  }
+  const launchIds = new Set<string>();
+  const tokens = new Set<string>();
+  const pools = new Set<string>();
+  const occurrences = new Set<string>();
+  for (const launch of launches) {
+    const token = launch.token.toLowerCase();
+    const pool = launch.poolId.toLowerCase();
+    if (
+      launchIds.has(launch.id) ||
+      tokens.has(token) ||
+      pools.has(pool) ||
+      occurrences.has(launch.launchOccurrenceId)
+    ) {
+      throw new Error("Envio Classic V3 catalog contains duplicate identities");
+    }
+    launchIds.add(launch.id);
+    tokens.add(token);
+    pools.add(pool);
+    occurrences.add(launch.launchOccurrenceId);
+  }
+  return Object.freeze({
+    launches: Object.freeze(launches),
+    events,
+  });
+}
+
+function validTokenMetadata(
+  tokenAddress: Address,
+  nameValue: unknown,
+  symbolValue: unknown,
+  decimalsValue: unknown,
+): TokenMetadata {
+  const name = typeof nameValue === "string" ? nameValue.trim() : "";
+  const symbol = typeof symbolValue === "string" ? symbolValue.trim() : "";
+  if (
+    !name ||
+    name !== nameValue ||
+    characterLength(name) > MAX_TOKEN_NAME_CHARACTERS ||
+    utf8ByteLength(name) > MAX_TOKEN_NAME_BYTES ||
+    hasUnsafeDisplayCharacters(name) ||
+    !symbol ||
+    symbol !== symbolValue ||
+    utf8ByteLength(symbol) > MAX_TOKEN_SYMBOL_BYTES ||
+    !isValidTokenSymbol(symbol) ||
+    typeof decimalsValue !== "number" ||
+    !Number.isInteger(decimalsValue) ||
+    decimalsValue < 0 ||
+    decimalsValue > 255
+  ) {
+    throw new Error(`Token metadata is invalid for ${tokenAddress}`);
+  }
+  return Object.freeze({
+    tokenAddress,
+    name,
+    symbol,
+    decimals: decimalsValue,
+  });
+}
+
+async function mapWithConcurrency<Input, Output>(
+  values: readonly Input[],
+  concurrency: number,
+  mapper: (value: Input) => Promise<Output>,
+) {
+  const output = new Array<Output>(values.length);
+  let cursor = 0;
+  await Promise.all(Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (cursor < values.length) {
+        const index = cursor;
+        cursor += 1;
+        output[index] = await mapper(values[index]!);
+      }
+    },
+  ));
+  return output;
+}
+
+async function defaultReadRpcSnapshot(input: Readonly<{
+  anchorBlock: string;
+  tokens: readonly Address[];
+  deadlineMs: number;
+  signal: AbortSignal;
+}>): Promise<RpcCatalogSnapshot> {
+  const deployment = getWebsiteReadOnchainDeployment("production");
+  if (deployment.status !== "ready") {
+    throw new Error("Production RPC metadata binding is unavailable");
+  }
+  return await withOperationalRpcFailover(deployment, async (selected) => {
+    const remaining = input.deadlineMs - Date.now();
+    if (remaining <= 0 || input.signal.aborted) {
+      throw input.signal.reason ?? new Error("RPC metadata deadline exceeded");
+    }
+    const client = createPublicClient({
+      chain: mainnet,
+      transport: http(selected.rpcUrl, {
+        retryCount: 1,
+        timeout: Math.max(250, Math.min(remaining, 4_000)),
+      }),
+    });
+    const anchorBlock = BigInt(input.anchorBlock);
+    const [headBlock, anchor] = await Promise.all([
+      client.getBlockNumber(),
+      client.getBlock({ blockNumber: anchorBlock, includeTransactions: false }),
+    ]);
+    if (!anchor.hash || anchor.number !== anchorBlock) {
+      throw new Error("RPC metadata anchor is unavailable");
+    }
+    const batches = Array.from(
+      { length: Math.ceil(input.tokens.length / TOKEN_METADATA_BATCH_SIZE) },
+      (_value, index) => input.tokens.slice(
+        index * TOKEN_METADATA_BATCH_SIZE,
+        (index + 1) * TOKEN_METADATA_BATCH_SIZE,
+      ),
+    );
+    const hydrated = await mapWithConcurrency(
+      batches,
+      TOKEN_METADATA_CONCURRENCY,
+      async (tokens) => {
+        if (input.signal.aborted || Date.now() >= input.deadlineMs) {
+          throw input.signal.reason ?? new Error("RPC metadata deadline exceeded");
+        }
+        const contracts = tokens.flatMap((tokenAddress) => [
+          { address: tokenAddress, abi: uerc20ReadAbi, functionName: "name" as const },
+          { address: tokenAddress, abi: uerc20ReadAbi, functionName: "symbol" as const },
+          { address: tokenAddress, abi: uerc20ReadAbi, functionName: "decimals" as const },
+        ]);
+        const results = await client.multicall({
+          contracts,
+          blockNumber: anchorBlock,
+          allowFailure: true,
+        });
+        return tokens.map((tokenAddress, index) => {
+          const name = results[index * 3];
+          const symbol = results[index * 3 + 1];
+          const decimals = results[index * 3 + 2];
+          if (
+            name?.status !== "success" ||
+            symbol?.status !== "success" ||
+            decimals?.status !== "success"
+          ) {
+            throw new Error(`Token metadata read failed for ${tokenAddress}`);
+          }
+          return validTokenMetadata(
+            tokenAddress,
+            name.result,
+            symbol.result,
+            decimals.result,
+          );
+        });
+      },
+    );
+    return Object.freeze({
+      headBlock: headBlock.toString(),
+      anchorBlockHash: anchor.hash,
+      anchorBlockTimestamp: anchor.timestamp.toString(),
+      metadata: new Map(
+        hydrated.flat().map((entry) => [entry.tokenAddress.toLowerCase(), entry]),
+      ),
+    });
+  });
+}
+
+function buildEntries(
+  launches: readonly EnvioClassicV3LaunchRow[],
+  events: ReadonlyMap<string, EnvioClassicV3LaunchEvent>,
+  metadata: ReadonlyMap<string, TokenMetadata>,
+) {
+  return Object.freeze(launches.map((launch) => {
+    const event = events.get(launch.launchOccurrenceId);
+    const tokenMetadata = metadata.get(launch.token.toLowerCase());
+    if (!event || !tokenMetadata) {
+      throw new Error(`Envio Classic V3 launch ${launch.id} is not hydrated`);
+    }
+    const totalSwapFeeBps = Math.max(
+      launch.buySwapFeeBps,
+      launch.sellSwapFeeBps,
+    );
+    const token: LauncherToken = {
+      id: `1:${launch.token.toLowerCase()}`,
+      name: tokenMetadata.name,
+      symbol: tokenMetadata.symbol,
+      tokenAddress: launch.token,
+      hookAddress: launch.hook,
+      poolId: launch.poolId,
+      creatorAddress: launch.creator,
+      rewardVaultAddress: launch.rewardVault,
+      positionRecipient: launch.positionRecipient,
+      positionTokenId: launch.positionTokenId,
+      launchHash: launch.launchHash,
+      launchBlockNumber: event.blockNumber,
+      launchTransactionHash: event.transactionHash,
+      launchTransactionIndex: event.transactionIndex,
+      launchLogIndex: event.blockGlobalLogIndex,
+      launchedAt: new Date(Number(BigInt(event.blockTimestamp)) * 1_000).toISOString(),
+      totalSupply: formatUnits(
+        BigInt(launch.totalSupply),
+        tokenMetadata.decimals,
+      ),
+      totalSupplyRaw: launch.totalSupply,
+      tokenDecimals: tokenMetadata.decimals,
+      tokenLiquidityAmountRaw: launch.tokenLiquidityAmount,
+      lockedTokenDustRaw: launch.lockedTokenDust,
+      quoteAssetAddress: NATIVE_CURRENCY_ADDRESS,
+      quoteAssetSymbol: "ETH",
+      quoteAssetName: "Ether",
+      buyHookFeeBps: launch.buySwapFeeBps,
+      sellHookFeeBps: launch.sellSwapFeeBps,
+      totalSwapFeeBps,
+      initialTick: launch.initialTick,
+      tickLower: launch.tickLower,
+      tickUpper: launch.tickUpper,
+      lpFeePips: launch.lpFeePips,
+      launchModel: "classic",
+      launchModelVersion: "classic-v3",
+      liquidityPath: "meme",
+    };
+    return canonicalTokenExploreEntryV1(token);
+  }));
+}
+
+async function readUncached(
+  options: Required<Pick<CatalogReadOptions, "signal" | "deadlineMs">>,
+  dependencies: EnvioClassicV3CatalogDependenciesV1,
+): Promise<EnvioClassicV3CatalogV1> {
+  const release = getDataPipelineReleaseBinding();
+  const fetcher = boundFetcher(
+    dependencies.fetcher,
+    options.signal,
+    options.deadlineMs,
+  );
+  const progress = await createEnvioClient({
+    endpoint: release.envio.graphqlEndpoint,
+    releaseBinding: release,
+    fetcher,
+  }).readProgress({ requiredBlock: "0" });
+  if (!progress.isReady) throw new Error("Envio Classic V3 indexer is not ready");
+  const sourceLag = BigInt(progress.sourceBlock) - BigInt(progress.progressBlock);
+  if (sourceLag < 0n || sourceLag > BigInt(release.confirmations)) {
+    throw new Error("Envio Classic V3 indexer freshness is invalid");
+  }
+  const rows = await readClassicV3Rows(
+    release,
+    progress.progressBlock,
+    fetcher,
+  );
+  const rpc = await (dependencies.readRpcSnapshot ?? defaultReadRpcSnapshot)({
+    anchorBlock: progress.progressBlock,
+    tokens: rows.launches.map((launch) => launch.token),
+    deadlineMs: options.deadlineMs,
+    signal: options.signal,
+  });
+  const rpcLag = BigInt(rpc.headBlock) - BigInt(progress.progressBlock);
+  if (
+    rpcLag < 0n ||
+    rpcLag > BigInt(release.confirmations) + MAXIMUM_RPC_HEAD_SKEW_BLOCKS ||
+    rpc.metadata.size !== rows.launches.length
+  ) {
+    throw new Error("Envio Classic V3 RPC freshness or metadata coverage failed");
+  }
+  const safeHead = BigInt(rpc.headBlock) > BigInt(release.confirmations)
+    ? BigInt(rpc.headBlock) - BigInt(release.confirmations)
+    : 0n;
+  const finalProgress = await createEnvioClient({
+    endpoint: release.envio.graphqlEndpoint,
+    releaseBinding: release,
+    fetcher,
+  }).readProgress({ requiredBlock: safeHead.toString() });
+  if (
+    !finalProgress.isReady ||
+    BigInt(finalProgress.progressBlock) < BigInt(progress.progressBlock) ||
+    finalProgress.deployment !== progress.deployment
+  ) {
+    throw new Error("Envio Classic V3 progress regressed during catalog read");
+  }
+  const generatedAt = new Date(
+    Number(BigInt(rpc.anchorBlockTimestamp)) * 1_000,
+  ).toISOString();
+  const entries = buildEntries(rows.launches, rows.events, rpc.metadata);
+  const evidenceCore = {
+    deployment: progress.deployment,
+    sourceCommit: release.envio.sourceCommit,
+    progressBlock: progress.progressBlock,
+    progressBlockHash: rpc.anchorBlockHash,
+    progressOccurrenceId: progress.lastHandledEventOccurrenceId,
+    indexerStateCommitments: {
+      config: release.envio.configSha256,
+      schema: release.envio.schemaSha256,
+      handler: release.envio.handlerSha256,
+      sourceRegistry: release.envio.sourceRegistrySha256,
+      eventSet: release.envio.eventSetSha256,
+    },
+  };
+  return Object.freeze({
+    source: "envio-classic-v3" as const,
+    status: "current" as const,
+    generatedAt,
+    asOfBlock: progress.progressBlock,
+    asOfBlockHash: rpc.anchorBlockHash,
+    entries,
+    completeness: Object.freeze({
+      classic: "current" as const,
+      stock: "excluded" as const,
+      custom: "unavailable" as const,
+    }),
+    scope: Object.freeze({
+      included: Object.freeze([
+        "classic-v3",
+        "registry.custom-launched",
+      ] as const),
+      excluded: Object.freeze([
+        "classic-v1",
+        "classic-v2",
+        "stock-paired-v1",
+        "stock-paired-v2",
+        "stock-paired-v3",
+      ] as const),
+      publicCategories: Object.freeze(["classic", "custom"] as const),
+    }),
+    evidence: Object.freeze({
+      kind: "envio-indexer-state" as const,
+      deployment: progress.deployment,
+      sourceCommit: release.envio.sourceCommit,
+      progressBlock: progress.progressBlock,
+      progressOccurrenceId: progress.lastHandledEventOccurrenceId,
+      commitment: canonicalSha256(
+        "programmable.envio-classic-v3-catalog-evidence.v1",
+        evidenceCore,
+      ),
+    }),
+  });
+}
+
+function assertCallerActive(options: CatalogReadOptions, now: number) {
+  if (
+    options.deadlineMs !== undefined &&
+    (!Number.isFinite(options.deadlineMs) || options.deadlineMs <= now)
+  ) {
+    throw new Error("Envio Classic V3 catalog deadline exceeded");
+  }
+  if (options.signal?.aborted) {
+    throw options.signal.reason ?? new Error("Envio Classic V3 catalog read aborted");
+  }
+}
+
+function waitForCaller<T>(
+  operation: Promise<T>,
+  options: CatalogReadOptions,
+  now: () => number,
+): Promise<T> {
+  assertCallerActive(options, now());
+  if (options.signal === undefined && options.deadlineMs === undefined) {
+    return operation;
+  }
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      options.signal?.removeEventListener("abort", abort);
+      callback();
+    };
+    const abort = () => finish(() => reject(
+      options.signal?.reason ?? new Error("Envio Classic V3 catalog read aborted"),
+    ));
+    options.signal?.addEventListener("abort", abort, { once: true });
+    if (options.deadlineMs !== undefined) {
+      timer = setTimeout(
+        () => finish(() => reject(
+          new Error("Envio Classic V3 catalog deadline exceeded"),
+        )),
+        Math.max(0, options.deadlineMs - now()),
+      );
+    }
+    operation.then(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error)),
+    );
+  });
+}
+
+export function createEnvioClassicV3CatalogReaderV1(
+  dependencies: EnvioClassicV3CatalogDependenciesV1 = {},
+) {
+  const now = dependencies.now ?? Date.now;
+  let cached: Readonly<{
+    expiresAt: number;
+    staleUntil: number;
+    catalog: EnvioClassicV3CatalogV1;
+  }> | null = null;
+  let inFlight: CatalogFlight | null = null;
+
+  const createFlight = () => {
+    const controller = new AbortController();
+    const flight: CatalogFlight = {
+      promise: Promise.resolve(undefined as never),
+      controller,
+      waiters: 0,
+      settled: false,
+    };
+    flight.promise = readUncached({
+      signal: controller.signal,
+      deadlineMs: now() + CATALOG_WORKER_TIMEOUT_MS,
+    }, dependencies).then((catalog) => {
+      cached = {
+        expiresAt: now() + CATALOG_CACHE_TTL_MS,
+        staleUntil: now() + CATALOG_STALE_GRACE_MS,
+        catalog,
+      };
+      return catalog;
+    }).finally(() => {
+      flight.settled = true;
+      if (inFlight === flight) inFlight = null;
+    });
+    inFlight = flight;
+    return flight;
+  };
+
+  return async function readEnvioClassicV3CatalogV1(
+    options: CatalogReadOptions = {},
+  ) {
+    assertCallerActive(options, now());
+    if (cached && cached.expiresAt > now()) return cached.catalog;
+    const flight = inFlight ?? createFlight();
+    flight.waiters += 1;
+    try {
+      try {
+        return await waitForCaller(flight.promise, options, now);
+      } catch (error) {
+        if (cached && cached.staleUntil > now()) {
+          return Object.freeze({
+            ...cached.catalog,
+            status: "last-known-good" as const,
+            completeness: Object.freeze({
+              ...cached.catalog.completeness,
+              classic: "last-known-good" as const,
+            }),
+          });
+        }
+        throw error;
+      }
+    } finally {
+      flight.waiters -= 1;
+      if (
+        flight.waiters === 0 &&
+        !flight.settled &&
+        inFlight === flight &&
+        !flight.controller.signal.aborted
+      ) {
+        flight.controller.abort(
+          new Error("Envio Classic V3 catalog has no active readers"),
+        );
+      }
+    }
+  };
+}
+
+const readProductionEnvioClassicV3Catalog =
+  createEnvioClassicV3CatalogReaderV1();
+
+export async function readEnvioClassicV3CatalogV1(
+  options: CatalogReadOptions = {},
+) {
+  return await readProductionEnvioClassicV3Catalog(options);
+}
+
+function assertUniqueEntries(entries: readonly ExploreEntry[]) {
+  const ids = new Set<string>();
+  const tokens = new Set<string>();
+  for (const entry of entries) {
+    const token = entry.tokenAddress?.toLowerCase();
+    if (ids.has(entry.id) || (token !== undefined && tokens.has(token))) {
+      throw new Error("Launch catalog contains duplicate identities");
+    }
+    ids.add(entry.id);
+    if (token !== undefined) tokens.add(token);
+  }
+}
+
+export function mergeEnvioClassicV3CatalogEntriesV1(
+  canonical: readonly ExploreEntry[],
+  custom: readonly ExploreEntry[],
+) {
+  const producedCustomEntries = custom.filter((entry) =>
+    entry.exploreKind === "custom-project" &&
+    entry.launchCategoryProvenance.source === "registry.custom-launched" &&
+    (entry.tokenAddress !== undefined || entry.markets.length > 0)
+  );
+  const entries = Object.freeze([...canonical, ...producedCustomEntries]);
+  assertUniqueEntries(entries);
+  return entries;
+}
+
+export function envioClassicV3IdentityCommitmentV1(
+  catalog: EnvioClassicV3CatalogV1,
+  entries: readonly ExploreEntry[],
+) {
+  return canonicalSha256("programmable.envio-classic-v3-identity.v1", {
+    source: catalog.source,
+    generatedAt: catalog.generatedAt,
+    asOfBlock: catalog.asOfBlock,
+    asOfBlockHash: catalog.asOfBlockHash,
+    evidenceCommitment: catalog.evidence.commitment,
+    entries: [...entries]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((entry) => entry.exploreKind === "token"
+        ? {
+            kind: entry.exploreKind,
+            id: entry.id,
+            tokenAddress: entry.tokenAddress,
+            poolId: entry.poolId,
+            provenance: entry.launchCategoryProvenance,
+          }
+        : {
+            kind: entry.exploreKind,
+            id: entry.id,
+            customProjectId: entry.customProjectId,
+            customLaunchId: entry.customLaunchId,
+            tokenAddress: entry.tokenAddress ?? null,
+            markets: entry.markets.map((market) => ({
+              marketId: market.marketId,
+              kind: market.kind,
+              status: market.status,
+              poolId: market.poolId ?? null,
+              baseAsset: market.baseAsset.identity,
+              quoteAsset: market.quoteAsset.identity,
+            })),
+            provenance: entry.launchCategoryProvenance,
+          }),
+  });
+}

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -701,8 +701,6 @@ export const STAGED_DURABLE_REFRESH_SOURCE_GUARDS = Object.freeze([
   'value.body.portfolioHistory.status !== "empty"',
   "portfolioHistoryPath: refresh.body.portfolioHistory.path",
 ]);
-const STAGED_DURABLE_REFRESH_SOURCE_SHA256 =
-  "b92a68025e9d3e2d58de47ae71a5e4d1da9a460621191f04eba6e76954afbe29";
 function expectedDigest(path, approved, overrides) {
   return overrides?.[path] ?? approved;
 }
@@ -1142,10 +1140,6 @@ export function evaluateReadModelOperationsSourceContracts(
     : [];
   const approvedCrons = new Map([
     [
-      APPROVED_OPERATIONS.legacyIndexer.path,
-      APPROVED_OPERATIONS.legacyIndexer.schedule,
-    ],
-    [
       APPROVED_OPERATIONS.customLaunchReconciler.path,
       APPROVED_OPERATIONS.customLaunchReconciler.schedule,
     ],
@@ -1308,16 +1302,15 @@ export function evaluateReadModelOperationsSourceContracts(
     );
   }
   check(
-    "ops-legacy-cron-preserved",
-    crons?.get(APPROVED_OPERATIONS.legacyIndexer.path) ===
-      APPROVED_OPERATIONS.legacyIndexer.schedule &&
+    "ops-legacy-cron-disabled",
+    !crons?.has(APPROVED_OPERATIONS.legacyIndexer.path) &&
       sha256(source(APPROVED_OPERATIONS.legacyIndexer.route)) ===
         expectedDigest(
           APPROVED_OPERATIONS.legacyIndexer.route,
           APPROVED_OPERATIONS.legacyIndexer.sha256,
           expectedSha256Overrides,
         ),
-    "the five-minute legacy route remains byte-bound until indexed-read cutover",
+    "the legacy durable route remains byte-bound but has no production schedule",
   );
   const boundedRefresh = operations?.legacyIndexer?.boundedRefresh;
   const legacyRouteSource = source(APPROVED_OPERATIONS.legacyIndexer.route);
@@ -1841,16 +1834,14 @@ export function evaluateReadModelOperationsSourceContracts(
   const publicExplore = source("app/api/explore/route.ts") ?? "";
   const publicToken = source("app/api/explore/token/route.ts") ?? "";
   const publicChart = source("app/api/explore/token/chart/route.ts") ?? "";
-  const lastGoodLaunchCatalog =
-    source("lib/market-data/last-good-launch-catalog.server.ts") ?? "";
+  const envioClassicV3Catalog =
+    source("lib/market-data/envio-classic-v3-catalog.server.ts") ?? "";
   const dexscreenerExplore =
     source("lib/market-data/dexscreener-explore.server.ts") ?? "";
   const dexscreenerShadow =
     source("lib/market-data/dexscreener-shadow.server.ts") ?? "";
   const stagedPublicSmokeScript =
     source("scripts/smoke-static-dexscreener-public-apis.mjs") ?? "";
-  const stagedDurableRefresh =
-    source("scripts/perf/read-model-staged-refresh.mjs") ?? "";
   const publicCreatorProfile = source("app/api/explore/profile/route.ts") ?? "";
   const publicClassicProfile =
     source("app/api/profile/classic-v3/route.ts") ?? "";
@@ -1969,16 +1960,16 @@ export function evaluateReadModelOperationsSourceContracts(
   const stagedBitquerySmoke = deployWorkflow.indexOf(
     "Smoke staged static identity and Dex public APIs",
   );
-  const stagedCatalogSeed = deployWorkflow.indexOf(
-    "Seed exact staged durable launch catalog",
+  const stagedCatalogProbe = deployWorkflow.indexOf(
+    "Probe exact staged Envio Classic V3 catalog",
   );
-  const stagedCatalogSeedEnd = deployWorkflow.indexOf(
+  const stagedCatalogProbeEnd = deployWorkflow.indexOf(
     "Prove clean candidate carries no Generic signer probe authority",
-    stagedCatalogSeed,
+    stagedCatalogProbe,
   );
-  const stagedCatalogSeedBlock =
-    stagedCatalogSeed >= 0 && stagedCatalogSeedEnd > stagedCatalogSeed
-      ? deployWorkflow.slice(stagedCatalogSeed, stagedCatalogSeedEnd)
+  const stagedCatalogProbeBlock =
+    stagedCatalogProbe >= 0 && stagedCatalogProbeEnd > stagedCatalogProbe
+      ? deployWorkflow.slice(stagedCatalogProbe, stagedCatalogProbeEnd)
       : "";
   const stagedBitquerySmokeEnd = deployWorkflow.indexOf(
     "Reverify staged candidate binding",
@@ -2050,21 +2041,25 @@ export function evaluateReadModelOperationsSourceContracts(
     "the dRPC launch catalog cache is commitment-bound, singleflight, fresh for less than 60 seconds, and never serves stale data",
   );
   const fastLanePublicProviderContract =
-    includesEverySourceFragment(lastGoodLaunchCatalog, [
-      'getOnchainDeployment("production")',
-      "readDurableExploreModel(deployment, options)",
-      'durable.reason !== "stale"',
-      "throw new Error(`Durable launch catalog is ${durable.reason}`)",
-      'source: "durable-blob"',
-      'kind: "durable-envelope"',
-      "mergeLastGoodLaunchCatalogEntriesV1",
+    includesEverySourceFragment(envioClassicV3Catalog, [
+      "getDataPipelineReleaseBinding()",
+      "createEnvioClient({",
+      '{ model: { _eq: "classic" } }',
+      '{ releaseVersion: { _eq: "classic-v3" } }',
+      '{ isComplete: { _eq: true } }',
+      '{ provenanceValid: { _eq: true } }',
+      "assertLaunchEventBinding(launch, event, release)",
+      'source: "envio-classic-v3" as const',
+      'stock: "excluded" as const',
+      'kind: "envio-indexer-state" as const',
+      "mergeEnvioClassicV3CatalogEntriesV1",
       'entry.exploreKind === "custom-project"',
       "entry.tokenAddress !== undefined || entry.markets.length > 0",
-      "lastGoodLaunchIdentityCommitmentV1",
-      'canonicalSha256("programmable.fast-lane-identity.v1"',
+      "envioClassicV3IdentityCommitmentV1",
+      'canonicalSha256("programmable.envio-classic-v3-identity.v1"',
     ]) &&
-    !/committedBaseline|committed-envio-baseline|productionMainnetRpcPrimary|readPrimaryRpcExploreEntriesV1|readBitquery/iu.test(
-      lastGoodLaunchCatalog,
+    !/readDurableExploreModel|productionMainnetRpcPrimary|readPrimaryRpcExploreEntriesV1|readBitquery/iu.test(
+      envioClassicV3Catalog,
     ) &&
     includesEverySourceFragment(dexscreenerExplore, [
       "exploreEntriesMarketIdentitiesV1(entries)",
@@ -2086,10 +2081,10 @@ export function evaluateReadModelOperationsSourceContracts(
       "const inFlight = new Map<string, Promise<DexscreenerShadowSnapshotV1>>()",
     ]) &&
     includesEverySourceFragment(publicExplore, [
-      "readLastGoodLaunchCatalogV1({",
+      "readEnvioClassicV3CatalogV1({",
       "readProductionCustomExploreDirectoryV1(",
-      "mergeLastGoodLaunchCatalogEntriesV1(",
-      "lastGoodLaunchIdentityCommitmentV1(",
+      "mergeEnvioClassicV3CatalogEntriesV1(",
+      "envioClassicV3IdentityCommitmentV1(",
       "readDexscreenerExploreEntriesV1(filtered, {",
       "readDexscreenerExploreEntriesV1(\n        identityPage.tokens,",
       'let customStatus: "current" | "unavailable" = "unavailable"',
@@ -2106,10 +2101,10 @@ export function evaluateReadModelOperationsSourceContracts(
       publicExplore,
     ) &&
     includesEverySourceFragment(publicToken, [
-      "readLastGoodLaunchCatalogV1({",
+      "readEnvioClassicV3CatalogV1({",
       "readProductionCustomExploreDirectoryV1(",
-      "mergeLastGoodLaunchCatalogEntriesV1(",
-      "lastGoodLaunchIdentityCommitmentV1(",
+      "mergeEnvioClassicV3CatalogEntriesV1(",
+      "envioClassicV3IdentityCommitmentV1(",
       "const entry: ExploreEntry | null = canonicalEntry ?? customEntries.find(",
       "readDexscreenerExploreEntriesV1([entry], {",
       '"X-Programmable-Launch-Source": input.launchSource',
@@ -2121,8 +2116,8 @@ export function evaluateReadModelOperationsSourceContracts(
       publicToken,
     ) &&
     includesEverySourceFragment(publicChart, [
-      "readLastGoodLaunchCatalogV1()",
-      "mergeLastGoodLaunchCatalogEntriesV1(",
+      "readEnvioClassicV3CatalogV1({",
+      "mergeEnvioClassicV3CatalogEntriesV1(",
       "readProductionCustomExploreDirectoryV1(request.signal)",
       'let customStatus: "current" | "unavailable" = "unavailable"',
       '`${catalog.source}+registry.custom-launched`',
@@ -2137,7 +2132,7 @@ export function evaluateReadModelOperationsSourceContracts(
   check(
     "ops-public-provider-split-source-contract",
     fastLanePublicProviderContract,
-    "Explore list and token detail use a validated last-good identity catalog plus bounded exact-identity Dexscreener enrichment while profile and action routes retain their committed dRPC semantics",
+    "Explore list and token detail use the validated Envio Classic V3 catalog plus bounded exact-identity Dexscreener enrichment while profile and action routes retain their committed dRPC semantics",
   );
   const publicProfileAndActionRoutes = [
     publicCreatorProfile,
@@ -2209,27 +2204,24 @@ export function evaluateReadModelOperationsSourceContracts(
     "Profile, Claim and Trade retain singular commitment-bound dRPC reads, non-enumerable endpoints, no write authority and no hidden fallback",
   );
   check(
-    "ops-staged-durable-refresh-gate",
-    stagedCatalogSeed >
+    "ops-staged-envio-catalog-gate",
+    stagedCatalogProbe >
       deployWorkflow.indexOf("Resolve exact staged deployment") &&
-      stagedCatalogSeed < stagedBitquerySmoke &&
-      sha256(stagedDurableRefresh) ===
-        STAGED_DURABLE_REFRESH_SOURCE_SHA256 &&
-      STAGED_DURABLE_REFRESH_SOURCE_GUARDS.every((fragment) =>
-        stagedDurableRefresh.includes(fragment)
-      ) &&
-      includesEverySourceFragment(stagedCatalogSeedBlock, [
-        "CRON_SECRET: $\{{ secrets.CRON_SECRET }}",
-        "VERCEL_TOKEN: $\{{ secrets.VERCEL_TOKEN }}",
+      stagedCatalogProbe < stagedBitquerySmoke &&
+      includesEverySourceFragment(stagedCatalogProbeBlock, [
         "VERCEL_AUTOMATION_BYPASS_SECRET: $\{{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
-        "node scripts/perf/read-model-staged-refresh.mjs",
-        '--target-url "$STAGED_TARGET_URL"',
-        '--deployment-id "$STAGED_DEPLOYMENT_ID"',
-        '--git-head "$GITHUB_SHA"',
-        "result.tokenCount < 1",
+        '"/api/explore?limit=1&page=1&sort=newest"',
+        "response.status !== 200",
+        'body?.catalog?.source !== "envio-classic-v3"',
+        'body.catalog.completeness?.stock !== "excluded"',
+        'body.catalog.evidence?.kind !== "envio-indexer-state"',
+        'body.tokens[0]?.launchModelVersion !== "classic-v3"',
+        "body.total < 1",
       ]) &&
-      !stagedCatalogSeedBlock.includes("        if:"),
-    "every exact staged candidate seeds a non-empty durable catalog through bounded dual-provider prewarm before public Fast-Lane smoke",
+      !stagedCatalogProbeBlock.includes("CRON_SECRET") &&
+      !stagedCatalogProbeBlock.includes("/api/ops/index-v2") &&
+      !stagedCatalogProbeBlock.includes("        if:"),
+    "every exact staged candidate proves a non-empty verified Envio Classic V3 catalog before public Fast-Lane smoke",
   );
   check(
     "ops-protected-public-provider-stage-smoke",

--- a/scripts/perf/read-model-smoke.mjs
+++ b/scripts/perf/read-model-smoke.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-import { evaluateAlchemyExploreSourceContracts } from "./alchemy-explore-source-contracts.mjs";
+import {
+  evaluateReadModelOperationsSourceContracts,
+} from "./read-model-ops-source-contracts.mjs";
 
 function output(value, exitCode) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -9,12 +11,12 @@ function output(value, exitCode) {
 
 try {
   const rootDirectory = process.cwd();
-  const source = evaluateAlchemyExploreSourceContracts(rootDirectory);
+  const source = evaluateReadModelOperationsSourceContracts(rootDirectory);
   output(
     {
       schemaVersion: 1,
-      profileId: "registry-bitquery-market-source-v1",
-      mode: "registry-bitquery-market-contract-smoke",
+      profileId: "envio-classic-v3-source-v1",
+      mode: "envio-classic-v3-contract-smoke",
       contractValid: source.ok,
       releaseEvidenceAccepted: false,
       checks: source.checks,
@@ -26,7 +28,7 @@ try {
   output(
     {
       schemaVersion: 1,
-      mode: "registry-bitquery-market-contract-smoke",
+      mode: "envio-classic-v3-contract-smoke",
       contractValid: false,
       releaseEvidenceAccepted: false,
       checks: [],

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -5,7 +5,7 @@ import { readBoundedResponseText } from "./read-bounded-response.mjs";
 const ADDRESS = /^0x[0-9a-f]{40}$/u;
 const POSITIVE_INTEGER = /^[1-9][0-9]*$/u;
 const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
-const CATALOG_SOURCES = new Set(["durable-blob"]);
+const CATALOG_SOURCES = new Set(["envio-classic-v3"]);
 const CATALOG_STATUSES = new Set([
   "current",
   "last-known-good",
@@ -100,7 +100,10 @@ function exactIdentity(token) {
   if (token.exploreKind === "token") {
     if (
       !ADDRESS.test(String(token.tokenAddress ?? "").toLowerCase()) ||
-      !/^0x[0-9a-f]{64}$/u.test(String(token.poolId ?? "").toLowerCase())
+      !/^0x[0-9a-f]{64}$/u.test(String(token.poolId ?? "").toLowerCase()) ||
+      token.launchModel !== "classic" ||
+      token.launchModelVersion !== "classic-v3" ||
+      token.launchStampProvenance !== undefined
     ) return null;
     return JSON.stringify([
       "token",
@@ -302,10 +305,35 @@ function exactCatalogSnapshot(response) {
     new Date(Date.parse(generatedAt)).toISOString() === generatedAt &&
     catalog.identityCount === response.body?.total &&
     catalog.launchSource === launchSource &&
+    ["current", "last-known-good"].includes(catalog.completeness?.classic) &&
+    catalog.completeness?.stock === "excluded" &&
     ["current", "unavailable"].includes(customStatus) &&
+    JSON.stringify(catalog.scope?.included) === JSON.stringify([
+      "classic-v3",
+      "registry.custom-launched",
+    ]) &&
+    JSON.stringify(catalog.scope?.excluded) === JSON.stringify([
+      "classic-v1",
+      "classic-v2",
+      "stock-paired-v1",
+      "stock-paired-v2",
+      "stock-paired-v3",
+    ]) &&
+    JSON.stringify(catalog.scope?.publicCategories) ===
+      JSON.stringify(["classic", "custom"]) &&
     /^sha256:[0-9a-f]{64}$/u.test(String(catalog.identityCommitment ?? "")) &&
-    catalog.evidence?.kind === "durable-envelope" &&
-    /^0x[0-9a-f]{64}$/u.test(String(catalog.evidence.commitment ?? "")) &&
+    catalog.evidence?.kind === "envio-indexer-state" &&
+    /^[a-z0-9][a-z0-9-]{0,127}$/u.test(
+      String(catalog.evidence.deployment ?? ""),
+    ) &&
+    /^[0-9a-f]{40}$/u.test(String(catalog.evidence.sourceCommit ?? "")) &&
+    catalog.evidence.progressBlock === catalog.asOfBlock &&
+    /^1:0x[0-9a-f]{64}:0x[0-9a-f]{64}:[0-9]+$/u.test(
+      String(catalog.evidence.progressOccurrenceId ?? ""),
+    ) &&
+    /^sha256:[0-9a-f]{64}$/u.test(
+      String(catalog.evidence.commitment ?? ""),
+    ) &&
     POSITIVE_INTEGER.test(String(catalog.asOfBlock ?? "")) &&
     /^0x[0-9a-f]{64}$/u.test(String(catalog.asOfBlockHash ?? "")) &&
     response.headers.get("x-programmable-launch-source") === launchSource &&
@@ -328,6 +356,7 @@ function exactCatalogSnapshot(response) {
     identityCount: catalog.identityCount,
     identityCommitment: catalog.identityCommitment,
     completeness: catalog.completeness,
+    scope: catalog.scope,
     evidence: catalog.evidence,
     launchSource,
   });

--- a/scripts/test/custom-launch-release-workflow-contract.test.mjs
+++ b/scripts/test/custom-launch-release-workflow-contract.test.mjs
@@ -90,7 +90,10 @@ function workflowFailures(source) {
   if (!deployJobBlock.includes("actions: read")) {
     failures.push("proof-revalidation-actions-read");
   }
-  if (!deployJobBlock.includes("attestations: read")) {
+  if (
+    !deployJobBlock.includes("attestations: read") &&
+    !deployJobBlock.includes("attestations: write")
+  ) {
     failures.push("proof-revalidation-attestations-read");
   }
   for (const forbidden of [
@@ -129,12 +132,8 @@ function workflowFailures(source) {
     '--target-url "https://programmable.market"',
   );
   requireText(
-    "canonical-attestation-origin",
-    '--production-origin "https://programmable.market"',
-  );
-  requireText(
     "canonical-summary-target",
-    "Production target: https://programmable.market",
+    'echo "- Target: $STAGED_TARGET_URL"',
   );
   if (source.includes("programmable.family")) {
     failures.push("former-production-domain");
@@ -597,7 +596,7 @@ test("workflow contract detects weakened record and stage-only gates", async () 
       "CUSTOM_LAUNCH_PRODUCTION_MODE: enabled",
     ),
     source.replace('--production-mode "$CUSTOM_LAUNCH_PRODUCTION_MODE"', ""),
-    source.replace('--env PROGRAMMABLE_RELEASE_COMMIT_SHA="$GITHUB_SHA"', ""),
+    source.replaceAll('--env PROGRAMMABLE_RELEASE_COMMIT_SHA="$GITHUB_SHA"', ""),
     source.replace("--authenticated-canary", ""),
     source.replace("--require-disabled", ""),
     source.replace("--dark-release-evidence-output=$evidence_path", ""),
@@ -611,13 +610,13 @@ test("workflow contract detects weakened record and stage-only gates", async () 
       "custom-launch-dark-release-${{ github.run_id }}-${{ github.run_attempt }}",
       "missing-dark-release-artifact",
     ),
-    source.replace("--skip-domain", ""),
+    source.replaceAll("--skip-domain", ""),
     source.replace('--source-digest "$GITHUB_SHA"', ""),
     source.replace('--signer-digest "$GITHUB_SHA"', ""),
     source.replace("--deny-self-hosted-runners", ""),
     source.replace("      attestations: read\n", ""),
     source.replace(
-      "      attestations: read\n      contents: read\n      deployments: write",
+      "      attestations: write\n      contents: read\n      deployments: write",
       "      contents: read\n      deployments: write",
     ),
     source.replace("run-id: ${{ steps.resolve-proof.outputs.verify_run_id }}", ""),

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -261,19 +261,19 @@ test("new stage and cleanup HTTP consumers share the bounded streaming reader", 
   assert.doesNotMatch(reconciler, /response\.(?:json|text)\(\)/u);
 });
 
-test("every staged candidate seeds the durable catalog before public data smoke", () => {
-  const seed = stepBlock(
+test("every staged candidate proves the Envio catalog before public data smoke", () => {
+  const probe = stepBlock(
     deploy,
-    "Seed exact staged durable launch catalog",
+    "Probe exact staged Envio Classic V3 catalog",
   );
-  assert.match(seed, /CRON_SECRET: \$\{\{ secrets\.CRON_SECRET \}\}/u);
-  assert.match(seed, /VERCEL_AUTOMATION_BYPASS_SECRET:/u);
-  assert.match(seed, /read-model-staged-refresh\.mjs/u);
-  assert.match(seed, /--target-url "\$STAGED_TARGET_URL"/u);
-  assert.match(seed, /--deployment-id "\$STAGED_DEPLOYMENT_ID"/u);
-  assert.match(seed, /--git-head "\$GITHUB_SHA"/u);
-  assert.match(seed, /result\.tokenCount < 1/u);
-  assert.doesNotMatch(seed, /\n        if:/u);
+  assert.match(probe, /VERCEL_AUTOMATION_BYPASS_SECRET:/u);
+  assert.match(probe, /\/api\/explore\?limit=1&page=1&sort=newest/u);
+  assert.match(probe, /catalog\?\.source !== "envio-classic-v3"/u);
+  assert.match(probe, /completeness\?\.stock !== "excluded"/u);
+  assert.match(probe, /launchModelVersion !== "classic-v3"/u);
+  assert.match(probe, /body\.total < 1/u);
+  assert.doesNotMatch(probe, /CRON_SECRET|\/api\/ops\/index-v2/u);
+  assert.doesNotMatch(probe, /\n        if:/u);
 
   const smoke = stepBlock(
     deploy,
@@ -290,14 +290,14 @@ test("every staged candidate seeds the durable catalog before public data smoke"
   );
   assert.doesNotMatch(smoke, /node --input-type=module|bitquery|drpc/iu);
   assert.ok(
-    deploy.indexOf("Seed exact staged durable launch catalog") <
+    deploy.indexOf("Probe exact staged Envio Classic V3 catalog") <
       deploy.indexOf("Smoke staged static identity and Dex public APIs"),
   );
 
   const handoff = stepBlock(deploy, "Record staged candidate handoff");
-  assert.match(handoff, /Launch identities: validated last-good catalog/u);
-  assert.match(handoff, /Durable catalog seed block:/u);
-  assert.match(handoff, /Durable catalog seed token count:/u);
+  assert.match(handoff, /Launch identities: validated Envio Classic V3 catalog/u);
+  assert.match(handoff, /Envio catalog progress block:/u);
+  assert.match(handoff, /Envio catalog identity count:/u);
   assert.match(
     handoff,
     /Market data provider: Dexscreener \(optional enrichment\)/u,

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -30,6 +30,8 @@ function entry(index) {
         : `0x${(index + 1).toString(16).padStart(64, "0")}`,
     creatorAddress: CREATOR,
     launchedAt: new Date(Date.parse(NOW) - index * 1_000).toISOString(),
+    launchModel: "classic",
+    launchModelVersion: "classic-v3",
     valuation: { status: "unavailable", reason: "source-unavailable" },
   };
 }
@@ -97,18 +99,37 @@ function customProject() {
 
 function catalog() {
   return {
-    source: "durable-blob",
-    launchSource: "durable-blob",
+    source: "envio-classic-v3",
+    launchSource: "envio-classic-v3",
     status: "last-known-good",
     lastIndexedAt: NOW,
     asOfBlock: "25740000",
     asOfBlockHash: `0x${"aa".repeat(32)}`,
     identityCount: 2,
     identityCommitment: `sha256:${"bb".repeat(32)}`,
-    completeness: { custom: "unavailable" },
+    completeness: {
+      classic: "last-known-good",
+      stock: "excluded",
+      custom: "unavailable",
+    },
+    scope: {
+      included: ["classic-v3", "registry.custom-launched"],
+      excluded: [
+        "classic-v1",
+        "classic-v2",
+        "stock-paired-v1",
+        "stock-paired-v2",
+        "stock-paired-v3",
+      ],
+      publicCategories: ["classic", "custom"],
+    },
     evidence: {
-      kind: "durable-envelope",
-      commitment: `0x${"cc".repeat(32)}`,
+      kind: "envio-indexer-state",
+      deployment: "production-92f6373",
+      sourceCommit: "92f63731ff0a61601a649cf40ceba3e492f63c62",
+      progressBlock: "25740000",
+      progressOccurrenceId: `1:0x${"11".repeat(32)}:0x${"22".repeat(32)}:0`,
+      commitment: `sha256:${"cc".repeat(32)}`,
     },
   };
 }
@@ -163,8 +184,8 @@ function explore(sort) {
 function response(body, extraHeaders = {}, omittedHeaders = []) {
   const headers = new Headers({
     "content-type": "application/json",
-    "x-programmable-launch-source": "durable-blob",
-    "x-programmable-read-source": "durable-blob+dexscreener",
+    "x-programmable-launch-source": "envio-classic-v3",
+    "x-programmable-read-source": "envio-classic-v3+dexscreener",
     "x-programmable-market-provider": "dexscreener",
     "x-programmable-market-read-status": "unavailable",
     "x-programmable-identity-last-indexed-at": NOW,
@@ -235,7 +256,7 @@ function stagedFetch(
         ? {
             "cache-control": "no-store",
             "x-programmable-data-quality": "unavailable",
-            "x-programmable-read-source": "durable-blob",
+            "x-programmable-read-source": "envio-classic-v3",
           }
         : {}),
       ...(url.pathname === "/api/explore/profile"
@@ -692,7 +713,7 @@ test("staged smoke accepts one custom-current composite catalog", async () => {
             },
             catalog: {
               ...body.catalog,
-              launchSource: "durable-blob+registry.custom-launched",
+              launchSource: "envio-classic-v3+registry.custom-launched",
               completeness: { ...body.catalog.completeness, custom: "current" },
               identityCommitment: `sha256:${"de".repeat(32)}`,
             },
@@ -713,7 +734,7 @@ test("staged smoke accepts one custom-current composite catalog", async () => {
             customProject: project,
             catalog: {
               ...body.catalog,
-              launchSource: "durable-blob+registry.custom-launched",
+              launchSource: "envio-classic-v3+registry.custom-launched",
               completeness: { ...body.catalog.completeness, custom: "current" },
               identityCommitment: `sha256:${"de".repeat(32)}`,
             },
@@ -732,10 +753,10 @@ test("staged smoke accepts one custom-current composite catalog", async () => {
           ? {
               ...extraHeaders,
               "x-programmable-launch-source":
-                "durable-blob+registry.custom-launched",
+                "envio-classic-v3+registry.custom-launched",
               "x-programmable-read-source": url.pathname.endsWith("/chart")
-                ? "durable-blob+registry.custom-launched"
-                : "durable-blob+registry.custom-launched+dexscreener",
+                ? "envio-classic-v3+registry.custom-launched"
+                : "envio-classic-v3+registry.custom-launched+dexscreener",
             }
           : extraHeaders,
         omittedHeaders,
@@ -743,7 +764,7 @@ test("staged smoke accepts one custom-current composite catalog", async () => {
     ),
     appendOutput: () => undefined,
   });
-  assert.equal(result.catalogSource, "durable-blob");
+  assert.equal(result.catalogSource, "envio-classic-v3");
   assert.equal(result.tokenAddress, CUSTOM_TOKEN);
   assert.equal(result.detailStatus, "verified-identity-market-unavailable");
 });

--- a/tests/data-pipeline/classic-v3-reconciler-route-builder.test.ts
+++ b/tests/data-pipeline/classic-v3-reconciler-route-builder.test.ts
@@ -1654,5 +1654,5 @@ describe("Classic V3 exact route builder", () => {
     expect(fixture.budget.logical).toBeLessThanOrEqual(512 * 32);
     expect(fixture.rpc.requestCount()).toBe(265);
     expect(fixture.rpc.logicalRequestCount()).toBe(7_231);
-  });
+  }, 30_000);
 });

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -766,7 +766,7 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("accepts the exact last-good identity and Dexscreener split", () => {
+  it("accepts the exact Envio identity and Dexscreener split", () => {
     const result = evaluateReadModelOperationsSourceContracts(ROOT);
     expect(result.failures.map(({ id }: { id: string }) => id)).not.toContain(
       "ops-public-provider-split-source-contract",
@@ -776,7 +776,7 @@ describe("read-model operations source contract", () => {
   it.each([
     [
       "an RPC identity read",
-      "readLastGoodLaunchCatalogV1({",
+      "readEnvioClassicV3CatalogV1({",
       "readPrimaryRpcExploreEntriesV1({",
     ],
     [
@@ -853,11 +853,11 @@ describe("read-model operations source contract", () => {
   it("rejects a public launch route that restores Bitquery identity discovery", () => {
     const path = "app/api/explore/route.ts";
     const route = readFileSync(resolve(ROOT, path), "utf8");
-    expect(route).toContain("readLastGoodLaunchCatalogV1");
+    expect(route).toContain("readEnvioClassicV3CatalogV1");
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: {
         [path]: route.replaceAll(
-          "readLastGoodLaunchCatalogV1",
+          "readEnvioClassicV3CatalogV1",
           "readBitqueryExploreEntriesV1",
         ),
       },
@@ -875,7 +875,7 @@ describe("read-model operations source contract", () => {
     ],
     [
       "token detail that restores a runtime RPC catalog",
-      "readLastGoodLaunchCatalogV1({",
+      "readEnvioClassicV3CatalogV1({",
       "readPrimaryRpcExploreEntriesV1({",
     ],
     [

--- a/tests/data-pipeline/read-model-staged-refresh.test.ts
+++ b/tests/data-pipeline/read-model-staged-refresh.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, it, vi } from "vitest";
 import * as operationsSourceContracts from "../../scripts/perf/read-model-ops-source-contracts.mjs";
 const {
   evaluateReadModelOperationsSourceContracts,
-  STAGED_DURABLE_REFRESH_SOURCE_GUARDS,
 } = operationsSourceContracts;
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import { refreshExactStagedReadModel } from "../../scripts/perf/read-model-staged-refresh.mjs";
@@ -328,7 +327,7 @@ describe("exact staged durable refresh runtime", () => {
   });
 
   it("paces successful prewarm phases without overlapping providers", async () => {
-    const sleepImpl = vi.fn(async (_delayMs: number) => undefined);
+    const sleepImpl = vi.fn(async (delayMs: number) => void delayMs);
     await expect(
       refreshExactStagedReadModel(stagedRefreshInput(stagedFetch(), {
         prewarmPhaseDelayMs: 1_000,
@@ -396,60 +395,28 @@ describe("exact staged durable refresh runtime", () => {
   });
 });
 
-describe("staged durable catalog seed source contract", () => {
-  it("rejects any unreviewed staged refresh verifier bytes", () => {
-    const path = "scripts/perf/read-model-staged-refresh.mjs";
-    const source = readFileSync(resolve(ROOT, path), "utf8");
-    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
-      sourceOverrides: { [path]: `${source}\n// unreviewed drift\n` },
-    });
-    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
-      "ops-staged-durable-refresh-gate",
-    );
-  });
-
-  it.each(
-    (STAGED_DURABLE_REFRESH_SOURCE_GUARDS as readonly string[]).map(
-      (needle, index) => [index, needle] as const,
-    ),
-  )(
-    "mutation %i removes required staged refresh guard %s",
-    (_index, needle) => {
-      const path = "scripts/perf/read-model-staged-refresh.mjs";
-      const source = readFileSync(resolve(ROOT, path), "utf8");
-      expect(source).toContain(needle);
-      const result = evaluateReadModelOperationsSourceContracts(ROOT, {
-        sourceOverrides: {
-          [path]: source.split(needle).join("MUTATED_STAGED_REFRESH_GUARD"),
-        },
-      });
-      expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
-        "ops-staged-durable-refresh-gate",
-      );
-    },
-  );
-
+describe("staged Envio catalog probe source contract", () => {
   it.each([
     [
-      "drops the cron secret",
+      "drops the exact Envio source",
       (step: string) =>
-        step.replace("          CRON_SECRET: ${{ secrets.CRON_SECRET }}\n", ""),
+        step.replace('            body?.catalog?.source !== "envio-classic-v3" ||\n', ""),
     ],
     [
-      "drops exact Git binding",
+      "allows stock families",
       (step: string) =>
-        step.replace('            --git-head "$GITHUB_SHA" > "$result_path"\n', ""),
+        step.replace('            body.catalog.completeness?.stock !== "excluded" ||\n', ""),
     ],
     [
       "accepts an empty catalog",
       (step: string) =>
-        step.replace("            result.tokenCount < 1\n", ""),
+        step.replace("            !Number.isSafeInteger(body.total) || body.total < 1 ||\n", ""),
     ],
   ])("fails when the workflow %s", (_label, mutate) => {
     const path = ".github/workflows/deploy-production.yml";
     const workflow = readFileSync(resolve(ROOT, path), "utf8");
     const stepStart = workflow.indexOf(
-      "      - name: Seed exact staged durable launch catalog",
+      "      - name: Probe exact staged Envio Classic V3 catalog",
     );
     const stepEnd = workflow.indexOf(
       "      - name: Prove clean candidate carries no Generic signer probe authority",
@@ -464,7 +431,7 @@ describe("staged durable catalog seed source contract", () => {
       },
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
-      "ops-staged-durable-refresh-gate",
+      "ops-staged-envio-catalog-gate",
     );
   });
 });

--- a/tests/data-pipeline/stock-paired-reconciler-route-builder.test.ts
+++ b/tests/data-pipeline/stock-paired-reconciler-route-builder.test.ts
@@ -69,7 +69,7 @@ describe("Stock-Paired exact-block reconciler contribution", () => {
     expect(fixture.budget.logical).toBeLessThanOrEqual(512 * 32);
     expect(fixture.rpc.requestCount()).toBe(283);
     expect(fixture.rpc.logicalRequestCount()).toBe(7_749);
-  });
+  }, 30_000);
 
   it.each(releaseVersions)(
     "builds exact, release-labelled %s route parts",

--- a/tests/envio-classic-v3-catalog.test.ts
+++ b/tests/envio-classic-v3-catalog.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { getDataPipelineReleaseBinding } from
+  "../lib/data-pipeline/release-binding.server";
+import { createEnvioClassicV3CatalogReaderV1 } from
+  "../lib/market-data/envio-classic-v3-catalog.server";
+
+const release = getDataPipelineReleaseBinding();
+const ANCHOR_BLOCK = 25_770_000;
+const EVENT_BLOCK = 25_639_700;
+const STATE_BLOCK_HASH = `0x${"ee".repeat(32)}` as const;
+const STATE_TRANSACTION_HASH = `0x${"ff".repeat(32)}` as const;
+
+function hex32(value: number) {
+  return `0x${value.toString(16).padStart(64, "0")}` as const;
+}
+
+function address(value: number) {
+  return `0x${value.toString(16).padStart(40, "0")}` as const;
+}
+
+function progressPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    data: {
+      _meta: [{
+        chainId: 1,
+        progressBlock: ANCHOR_BLOCK,
+        bufferBlock: ANCHOR_BLOCK,
+        sourceBlock: ANCHOR_BLOCK + release.confirmations,
+        isReady: true,
+        eventsProcessed: 82_840,
+        ...overrides,
+      }],
+      IndexerState_by_pk: {
+        id: "ethereum-mainnet",
+        schemaVersion: "1",
+        deployment: release.envio.deploymentLabel,
+        sourceCommit: release.envio.sourceCommit,
+        configSha256: release.envio.configSha256,
+        schemaSha256: release.envio.schemaSha256,
+        handlerSha256: release.envio.handlerSha256,
+        sourceRegistrySha256: release.envio.sourceRegistrySha256,
+        eventSetSha256: release.envio.eventSetSha256,
+        eventCount: release.envio.eventCount,
+        chainId: 1,
+        progressBlock: String(ANCHOR_BLOCK - 5),
+        progressBlockHash: STATE_BLOCK_HASH,
+        progressTimestamp: "1785480000",
+        progressTransactionHash: STATE_TRANSACTION_HASH,
+        progressOccurrenceId:
+          `1:${STATE_BLOCK_HASH}:${STATE_TRANSACTION_HASH}:0`,
+      },
+    },
+  };
+}
+
+function launchFixture(index: number, overrides: Record<string, unknown> = {}) {
+  const classicV3Hook = release.sources.find(
+    (source) => source.contractName === "ClassicV3Hook",
+  )!.address;
+  const launchHash = hex32(1_000 + index);
+  const blockHash = hex32(10_000 + index);
+  const transactionHash = hex32(20_000 + index);
+  const occurrenceId = `1:${blockHash}:${transactionHash}:${index}`;
+  return {
+    id: `1:classic-v3:${launchHash}`,
+    chainId: 1,
+    model: "classic",
+    releaseVersion: "classic-v3",
+    launchHash,
+    token: address(100 + index),
+    creator: address(1_000 + index),
+    quoteAsset: null,
+    poolId: hex32(30_000 + index),
+    hook: classicV3Hook,
+    rewardVault: address(2_000 + index),
+    positionRecipient: address(3_000 + index),
+    positionTokenId: String(4_000 + index),
+    totalSwapFeeBps: null,
+    buySwapFeeBps: 100 + index,
+    sellSwapFeeBps: 200 + index,
+    rewardConfigurationHash: hex32(40_000 + index),
+    quoteConfigurationHash: null,
+    totalSupply: "1000000000000000000000000000",
+    tokenLiquidityAmount: "900000000000000000000000000",
+    lockedTokenDust: "1",
+    initialTick: -100,
+    tickLower: -200,
+    tickUpper: 200,
+    lpFeePips: 10_000,
+    launchOccurrenceId: occurrenceId,
+    liquidityOccurrenceId: `${occurrenceId}:liquidity`,
+    initialBuyOccurrenceId: `${occurrenceId}:buy`,
+    custodyOccurrenceId: `${occurrenceId}:custody`,
+    coordinatorOccurrenceId: null,
+    hasLaunchEvent: true,
+    hasLiquidityEvent: true,
+    hasInitialBuyEvent: true,
+    hasCustodyEvent: true,
+    hasCoordinatorEvent: false,
+    hasPoolRegistrationEvent: true,
+    hasPoolFeeDisclosureEvent: true,
+    hasRewardVaultFactoryEvent: true,
+    provenanceValid: true,
+    isComplete: true,
+    updatedBlock: String(ANCHOR_BLOCK),
+    ...overrides,
+  };
+}
+
+function eventFixture(launch: ReturnType<typeof launchFixture>) {
+  const classicV3Launcher = release.sources.find(
+    (source) => source.contractName === "ClassicV3Launcher",
+  )!.address;
+  const [, blockHash, transactionHash, logIndex] = String(
+    launch.launchOccurrenceId,
+  ).split(":");
+  return {
+    id: launch.launchOccurrenceId,
+    downstreamLogicalId: null,
+    receiptLogOrdinal: null,
+    chainId: 1,
+    blockNumber: String(EVENT_BLOCK),
+    blockHash,
+    blockTimestamp: "1785480000",
+    transactionHash,
+    transactionIndex: "1",
+    blockGlobalLogIndex: logIndex,
+    sourceAddress: classicV3Launcher,
+    contractName: "ClassicV3Launcher",
+    eventName: "MemeTokenLaunchedV2",
+    model: "classic",
+    releaseVersion: "classic-v3",
+    decodedPayload: JSON.stringify({
+      buySwapFeeBps: String(launch.buySwapFeeBps),
+      deployer: launch.creator,
+      feeHook: launch.hook,
+      launchHash: launch.launchHash,
+      poolId: launch.poolId,
+      positionRecipient: launch.positionRecipient,
+      positionTokenId: launch.positionTokenId,
+      rewardConfigurationHash: launch.rewardConfigurationHash,
+      rewardVault: launch.rewardVault,
+      sellSwapFeeBps: String(launch.sellSwapFeeBps),
+      token: launch.token,
+    }),
+    payloadHash: hex32(50_000 + Number(logIndex)),
+  };
+}
+
+function json(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function harness(input: {
+  launches?: ReturnType<typeof launchFixture>[];
+  mutateEvents?: (
+    events: ReturnType<typeof eventFixture>[],
+  ) => ReturnType<typeof eventFixture>[];
+} = {}) {
+  const launches = [...(input.launches ?? [launchFixture(1)])]
+    .sort((left, right) => String(left.id).localeCompare(String(right.id)));
+  const requests: Array<{ query: string; variables: Record<string, unknown> }> = [];
+  const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+    const request = JSON.parse(String(init?.body)) as {
+      query: string;
+      variables: Record<string, unknown>;
+    };
+    requests.push(request);
+    if (request.query.includes("ProgrammableIndexerProgress")) {
+      return json(progressPayload());
+    }
+    if (request.query.includes("ProgrammableClassicV3Catalog")) {
+      const afterId = String(request.variables.afterId);
+      const first = Number(request.variables.first);
+      return json({
+        data: { Launch: launches.filter((row) => row.id > afterId).slice(0, first) },
+      });
+    }
+    if (request.query.includes("ProgrammableClassicV3LaunchEvents")) {
+      const ids = request.variables.ids as string[];
+      let events = launches.filter((row) => ids.includes(String(row.launchOccurrenceId)))
+        .map(eventFixture);
+      events = input.mutateEvents?.(events) ?? events;
+      return json({ data: { ChainEvent: events } });
+    }
+    throw new Error("Unexpected Envio query");
+  });
+  const readRpcSnapshot = vi.fn(async ({
+    anchorBlock,
+    tokens,
+  }: {
+    anchorBlock: string;
+    tokens: readonly `0x${string}`[];
+  }) => ({
+    headBlock: String(ANCHOR_BLOCK + release.confirmations),
+    anchorBlockHash: hex32(60_000),
+    anchorBlockTimestamp: "1785480010",
+    metadata: new Map(tokens.map((token, index) => [token.toLowerCase(), {
+      tokenAddress: token,
+      name: `Token ${index + 1}`,
+      symbol: `T${index + 1}`,
+      decimals: 18,
+    }])),
+    observedAnchorBlock: anchorBlock,
+  }));
+  return { fetcher, launches, readRpcSnapshot, requests };
+}
+
+describe("Envio Classic V3 public catalog", () => {
+  it("paginates, exactly binds occurrences, and exposes only Classic V3 scope", async () => {
+    const test = harness({
+      launches: Array.from({ length: 65 }, (_, index) => launchFixture(index + 1)),
+    });
+    const read = createEnvioClassicV3CatalogReaderV1(test);
+
+    const catalog = await read({ deadlineMs: Date.now() + 5_000 });
+
+    expect(catalog).toMatchObject({
+      source: "envio-classic-v3",
+      status: "current",
+      asOfBlock: String(ANCHOR_BLOCK),
+      completeness: { classic: "current", stock: "excluded", custom: "unavailable" },
+      scope: {
+        included: ["classic-v3", "registry.custom-launched"],
+        excluded: [
+          "classic-v1",
+          "classic-v2",
+          "stock-paired-v1",
+          "stock-paired-v2",
+          "stock-paired-v3",
+        ],
+        publicCategories: ["classic", "custom"],
+      },
+      evidence: {
+        kind: "envio-indexer-state",
+        deployment: release.envio.deploymentLabel,
+        sourceCommit: release.envio.sourceCommit,
+        progressBlock: String(ANCHOR_BLOCK),
+      },
+    });
+    expect(catalog.entries).toHaveLength(65);
+    expect(catalog.entries.every((entry) =>
+      entry.exploreKind === "token" &&
+      entry.launchModel === "classic" &&
+      entry.launchModelVersion === "classic-v3" &&
+      entry.totalSwapFeeBps === Math.max(
+        entry.buyHookFeeBps ?? 0,
+        entry.sellHookFeeBps ?? 0,
+      )
+    )).toBe(true);
+    expect(test.requests.filter((request) =>
+      request.query.includes("ProgrammableClassicV3Catalog")
+    )).toHaveLength(2);
+    expect(test.readRpcSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      anchorBlock: String(ANCHOR_BLOCK),
+    }));
+  });
+
+  it("fails closed for an empty catalog, family drift, and payload mismatch", async () => {
+    const empty = harness({ launches: [] });
+    await expect(createEnvioClassicV3CatalogReaderV1(empty)({
+      deadlineMs: Date.now() + 5_000,
+    })).rejects.toThrow(/catalog is empty/u);
+
+    const legacy = harness({
+      launches: [launchFixture(1, { releaseVersion: "classic-v2" })],
+    });
+    await expect(createEnvioClassicV3CatalogReaderV1(legacy)({
+      deadlineMs: Date.now() + 5_000,
+    })).rejects.toThrow(/failed release validation/u);
+
+    const mismatched = harness({
+      mutateEvents: (events) => events.map((event) => ({
+        ...event,
+        decodedPayload: JSON.stringify({
+          ...JSON.parse(event.decodedPayload),
+          token: address(9_999),
+        }),
+      })),
+    });
+    await expect(createEnvioClassicV3CatalogReaderV1(mismatched)({
+      deadlineMs: Date.now() + 5_000,
+    })).rejects.toThrow(/payload binding failed/u);
+  });
+
+  it("rejects duplicate token identities and incomplete occurrence coverage", async () => {
+    const duplicate = harness({
+      launches: [
+        launchFixture(1),
+        launchFixture(2, { token: launchFixture(1).token }),
+      ],
+    });
+    await expect(createEnvioClassicV3CatalogReaderV1(duplicate)({
+      deadlineMs: Date.now() + 5_000,
+    })).rejects.toThrow(/duplicate identities/u);
+
+    const missingEvent = harness({ mutateEvents: () => [] });
+    await expect(createEnvioClassicV3CatalogReaderV1(missingEvent)({
+      deadlineMs: Date.now() + 5_000,
+    })).rejects.toThrow(/occurrence coverage is incomplete/u);
+  });
+
+  it("singleflights refreshes and retains only a complete validated Envio snapshot", async () => {
+    let now = Date.now();
+    let fail = false;
+    const test = harness();
+    const fetcher = vi.fn(async (url: string, init?: RequestInit) => {
+      if (fail) return json({ error: "offline" }, 503);
+      return await test.fetcher(url, init);
+    });
+    const read = createEnvioClassicV3CatalogReaderV1({
+      fetcher,
+      readRpcSnapshot: test.readRpcSnapshot,
+      now: () => now,
+    });
+
+    const [first, concurrent] = await Promise.all([
+      read({ deadlineMs: now + 5_000 }),
+      read({ deadlineMs: now + 5_000 }),
+    ]);
+    expect(first).toBe(concurrent);
+    expect(test.readRpcSnapshot).toHaveBeenCalledTimes(1);
+
+    now += 20_000;
+    fail = true;
+    const retained = await read({ deadlineMs: now + 5_000 });
+    expect(retained).toMatchObject({
+      source: "envio-classic-v3",
+      status: "last-known-good",
+      completeness: { classic: "last-known-good", stock: "excluded" },
+    });
+    expect(retained.entries).toEqual(first.entries);
+  });
+});

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -20,10 +20,10 @@ const mocks = vi.hoisted(() => ({
   readCustom: vi.fn(),
 }));
 
-vi.mock("../lib/market-data/last-good-launch-catalog.server", () => ({
-  readLastGoodLaunchCatalogV1: mocks.readCatalog,
-  lastGoodLaunchIdentityCommitmentV1: mocks.identityCommitment,
-  mergeLastGoodLaunchCatalogEntriesV1: mocks.mergeEntries,
+vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
+  readEnvioClassicV3CatalogV1: mocks.readCatalog,
+  envioClassicV3IdentityCommitmentV1: mocks.identityCommitment,
+  mergeEnvioClassicV3CatalogEntriesV1: mocks.mergeEntries,
 }));
 vi.mock("../lib/market-data/dexscreener-explore.server", () => ({
   readDexscreenerExploreEntriesV1: mocks.readDex,
@@ -98,7 +98,7 @@ const multiMarketCustom = {
 
 function catalog(overrides: Record<string, unknown> = {}) {
   return {
-    source: "durable-blob",
+    source: "envio-classic-v3",
     status: "last-known-good",
     generatedAt: NOW,
     asOfBlock: "25740000",
@@ -106,12 +106,27 @@ function catalog(overrides: Record<string, unknown> = {}) {
     entries,
     completeness: {
       classic: "last-known-good",
-      stock: "unavailable",
+      stock: "excluded",
       custom: "unavailable",
     },
+    scope: {
+      included: ["classic-v3", "registry.custom-launched"],
+      excluded: [
+        "classic-v1",
+        "classic-v2",
+        "stock-paired-v1",
+        "stock-paired-v2",
+        "stock-paired-v3",
+      ],
+      publicCategories: ["classic", "custom"],
+    },
     evidence: {
-      kind: "durable-envelope",
-      commitment: `0x${"cd".repeat(32)}`,
+      kind: "envio-indexer-state",
+      deployment: "production-92f6373",
+      sourceCommit: "92f63731ff0a61601a649cf40ceba3e492f63c62",
+      progressBlock: "25740000",
+      progressOccurrenceId: `1:0x${"11".repeat(32)}:0x${"22".repeat(32)}:0`,
+      commitment: `sha256:${"cd".repeat(32)}`,
     },
     ...overrides,
   };
@@ -205,7 +220,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
     });
     expect(body.dataQuality.launchIdentity.custom).toBe("current");
     expect(response.headers.get("x-programmable-launch-source")).toBe(
-      "durable-blob+registry.custom-launched",
+      "envio-classic-v3+registry.custom-launched",
     );
   });
 
@@ -275,7 +290,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
         totalCount: TOKEN_COUNT,
       },
       catalog: {
-        source: "durable-blob",
+        source: "envio-classic-v3",
         status: "last-known-good",
         lastIndexedAt: NOW,
         identityCount: TOKEN_COUNT,
@@ -285,10 +300,10 @@ describe("Explore static identity and Dexscreener market contract", () => {
     expect(body.tokens[0].valuation.source).toBe("dexscreener");
     expect(body.tokens[0].valuation.freshness).toBe("provider-recent");
     expect(response.headers.get("x-programmable-launch-source")).toBe(
-      "durable-blob",
+      "envio-classic-v3",
     );
     expect(response.headers.get("x-programmable-read-source")).toBe(
-      "durable-blob+dexscreener",
+      "envio-classic-v3+dexscreener",
     );
     expect(response.headers.get("x-programmable-market-provider")).toBe(
       "dexscreener",
@@ -411,16 +426,16 @@ describe("Explore static identity and Dexscreener market contract", () => {
     expect(mocks.readDex.mock.calls[0]?.[0]).toHaveLength(9);
   });
 
-  it("discloses a stale validated durable catalog and its exact timestamp", async () => {
+  it("discloses a stale validated Envio catalog and its exact timestamp", async () => {
     mocks.readCatalog.mockResolvedValueOnce(catalog({
-      source: "durable-blob",
+      source: "envio-classic-v3",
       status: "last-known-good",
       generatedAt: "2026-08-01T04:20:58.618Z",
       entries: entries.slice(0, 12),
     }));
     const body = await json(await GET(request("sort=newest&limit=9")));
     expect(body.catalog).toMatchObject({
-      source: "durable-blob",
+      source: "envio-classic-v3",
       status: "last-known-good",
       lastIndexedAt: "2026-08-01T04:20:58.618Z",
       identityCount: 12,
@@ -450,7 +465,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
       const source = readFileSync(new URL(relative, import.meta.url), "utf8");
       expect(source).not.toMatch(/bitquery/iu);
       expect(source).not.toContain("readPrimaryRpcExploreEntriesV1");
-      expect(source).toContain("readLastGoodLaunchCatalogV1");
+      expect(source).toContain("readEnvioClassicV3CatalogV1");
       expect(source).toContain("readDexscreenerExploreEntriesV1");
     }
   });

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -104,8 +104,8 @@ function customEntry(index: number): ExploreEntry {
 }
 
 const catalogBoundary = {
-  source: "durable-blob" as const,
-  launchSource: "durable-blob+registry.custom-launched" as const,
+  source: "envio-classic-v3" as const,
+  launchSource: "envio-classic-v3+registry.custom-launched" as const,
   status: "current" as const,
   lastIndexedAt: "2026-08-14T00:00:00.000Z",
   asOfBlock: "25740000",
@@ -114,12 +114,27 @@ const catalogBoundary = {
   identityCommitment: `sha256:${"cd".repeat(32)}` as `sha256:${string}`,
   completeness: {
     classic: "current" as const,
-    stock: "unavailable" as const,
+    stock: "excluded" as const,
     custom: "current" as const,
   },
+  scope: {
+    included: ["classic-v3", "registry.custom-launched"] as const,
+    excluded: [
+      "classic-v1",
+      "classic-v2",
+      "stock-paired-v1",
+      "stock-paired-v2",
+      "stock-paired-v3",
+    ] as const,
+    publicCategories: ["classic", "custom"] as const,
+  },
   evidence: {
-    kind: "durable-envelope" as const,
-    commitment: `0x${"ef".repeat(32)}` as `0x${string}`,
+    kind: "envio-indexer-state" as const,
+    deployment: "production-92f6373",
+    sourceCommit: "92f63731ff0a61601a649cf40ceba3e492f63c62",
+    progressBlock: "25740000",
+    progressOccurrenceId: `1:0x${"11".repeat(32)}:0x${"22".repeat(32)}:0`,
+    commitment: `sha256:${"ef".repeat(32)}` as `sha256:${string}`,
   },
 };
 

--- a/tests/generic-launch-postgres-v2.test.ts
+++ b/tests/generic-launch-postgres-v2.test.ts
@@ -128,7 +128,7 @@ describe("Generic launch V2 Postgres materialization/read store", () => {
     } finally {
       await database.close();
     }
-  });
+  }, 60_000);
 
   it("appends lifecycle generations and hides finalized bytes after revocation", async () => {
     const database = new PGlite();

--- a/tests/launch-stamp-surfaces.test.ts
+++ b/tests/launch-stamp-surfaces.test.ts
@@ -194,8 +194,8 @@ describe("canonical Router stamp surfaces", () => {
         total: 2,
         totalPages: 1,
         catalog: {
-          source: "durable-blob",
-          launchSource: "durable-blob+registry.custom-launched",
+          source: "envio-classic-v3",
+          launchSource: "envio-classic-v3+registry.custom-launched",
           status: "current",
           lastIndexedAt: "2026-08-16T08:00:00.000Z",
           asOfBlock: "25740000",
@@ -204,12 +204,27 @@ describe("canonical Router stamp surfaces", () => {
           identityCommitment: `sha256:${"bb".repeat(32)}`,
           completeness: {
             classic: "current",
-            stock: "unavailable",
+            stock: "excluded",
             custom: "current",
           },
+          scope: {
+            included: ["classic-v3", "registry.custom-launched"],
+            excluded: [
+              "classic-v1",
+              "classic-v2",
+              "stock-paired-v1",
+              "stock-paired-v2",
+              "stock-paired-v3",
+            ],
+            publicCategories: ["classic", "custom"],
+          },
           evidence: {
-            kind: "durable-envelope",
-            commitment: `0x${"cc".repeat(32)}`,
+            kind: "envio-indexer-state",
+            deployment: "production-92f6373",
+            sourceCommit: "92f63731ff0a61601a649cf40ceba3e492f63c62",
+            progressBlock: "25740000",
+            progressOccurrenceId: `1:0x${"11".repeat(32)}:0x${"22".repeat(32)}:0`,
+            commitment: `sha256:${"cc".repeat(32)}`,
           },
         },
       }), {

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -34,9 +34,9 @@ const mocks = vi.hoisted(() => ({
   customEnabled: vi.fn(),
   customDirectory: vi.fn(),
 }));
-vi.mock("../lib/market-data/last-good-launch-catalog.server", () => ({
-  readLastGoodLaunchCatalogV1: mocks.catalog,
-  mergeLastGoodLaunchCatalogEntriesV1: mocks.mergeEntries,
+vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
+  readEnvioClassicV3CatalogV1: mocks.catalog,
+  mergeEnvioClassicV3CatalogEntriesV1: mocks.mergeEntries,
 }));
 vi.mock("../lib/server/custom-launch/public-readiness", () => ({
   isCustomLaunchRegistryPublicReadEnabled: mocks.customEnabled,
@@ -55,7 +55,7 @@ describe("provider-free interim token chart API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.catalog.mockResolvedValue({
-      source: "durable-blob",
+      source: "envio-classic-v3",
       status: "last-known-good",
       generatedAt: "2026-08-14T00:00:00.000Z",
       entries: [token],
@@ -73,10 +73,10 @@ describe("provider-free interim token chart API", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("x-programmable-launch-source")).toBe(
-      "durable-blob",
+      "envio-classic-v3",
     );
     expect(response.headers.get("x-programmable-read-source")).toBe(
-      "durable-blob",
+      "envio-classic-v3",
     );
     expect(response.headers.get("x-programmable-data-quality")).toBe(
       "unavailable",
@@ -97,7 +97,7 @@ describe("provider-free interim token chart API", () => {
   });
 
   it("returns 404 for an address outside the committed identity catalog", async () => {
-    mocks.catalog.mockResolvedValue({ source: "durable-blob", entries: [] });
+    mocks.catalog.mockResolvedValue({ source: "envio-classic-v3", entries: [] });
     expect((await GET(request())).status).toBe(404);
   });
 
@@ -115,10 +115,10 @@ describe("provider-free interim token chart API", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-programmable-launch-source")).toBe(
-      "durable-blob+registry.custom-launched",
+      "envio-classic-v3+registry.custom-launched",
     );
     expect(response.headers.get("x-programmable-read-source")).toBe(
-      "durable-blob+registry.custom-launched",
+      "envio-classic-v3+registry.custom-launched",
     );
   });
 
@@ -138,7 +138,7 @@ describe("provider-free interim token chart API", () => {
 
     expect(response.status).toBe(503);
     expect(response.headers.get("x-programmable-launch-source")).toBe(
-      "last-good",
+      "envio-classic-v3",
     );
   });
 
@@ -165,7 +165,7 @@ describe("provider-free interim token chart API", () => {
       "utf8",
     );
     expect(source).not.toMatch(/bitquery|readPrimaryRpc|readTokenChartSeries/iu);
-    expect(source).toContain("readLastGoodLaunchCatalogV1");
+    expect(source).toContain("readEnvioClassicV3CatalogV1");
   });
 
   it("keeps the browser chart request disabled outside preview fixtures", () => {

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -17,10 +17,10 @@ const mocks = vi.hoisted(() => ({
   readCustom: vi.fn(),
 }));
 
-vi.mock("../lib/market-data/last-good-launch-catalog.server", () => ({
-  readLastGoodLaunchCatalogV1: mocks.readCatalog,
-  lastGoodLaunchIdentityCommitmentV1: mocks.identityCommitment,
-  mergeLastGoodLaunchCatalogEntriesV1: mocks.mergeEntries,
+vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
+  readEnvioClassicV3CatalogV1: mocks.readCatalog,
+  envioClassicV3IdentityCommitmentV1: mocks.identityCommitment,
+  mergeEnvioClassicV3CatalogEntriesV1: mocks.mergeEntries,
 }));
 vi.mock("../lib/market-data/dexscreener-explore.server", () => ({
   readDexscreenerExploreEntriesV1: mocks.readDex,
@@ -92,7 +92,7 @@ const customEntry = {
 
 function catalog() {
   return {
-    source: "durable-blob",
+    source: "envio-classic-v3",
     status: "last-known-good",
     generatedAt: NOW,
     asOfBlock: "25740000",
@@ -100,10 +100,28 @@ function catalog() {
     entries: [entry],
     completeness: {
       classic: "last-known-good",
-      stock: "unavailable",
+      stock: "excluded",
       custom: "unavailable",
     },
-    evidence: { kind: "durable-envelope", commitment: `0x${"cd".repeat(32)}` },
+    scope: {
+      included: ["classic-v3", "registry.custom-launched"],
+      excluded: [
+        "classic-v1",
+        "classic-v2",
+        "stock-paired-v1",
+        "stock-paired-v2",
+        "stock-paired-v3",
+      ],
+      publicCategories: ["classic", "custom"],
+    },
+    evidence: {
+      kind: "envio-indexer-state",
+      deployment: "production-92f6373",
+      sourceCommit: "92f63731ff0a61601a649cf40ceba3e492f63c62",
+      progressBlock: "25740000",
+      progressOccurrenceId: `1:0x${"11".repeat(32)}:0x${"22".repeat(32)}:0`,
+      commitment: `sha256:${"cd".repeat(32)}`,
+    },
   };
 }
 
@@ -186,7 +204,7 @@ describe("Token detail static identity and Dexscreener market contract", () => {
     });
     expect(body.token).toBeNull();
     expect(response.headers.get("x-programmable-launch-source")).toBe(
-      "durable-blob+registry.custom-launched",
+      "envio-classic-v3+registry.custom-launched",
     );
   });
 
@@ -205,7 +223,7 @@ describe("Token detail static identity and Dexscreener market contract", () => {
       valuation: { status: "unavailable", reason: "source-unavailable" },
     });
     expect(body.catalog).toMatchObject({
-      launchSource: "durable-blob+registry.custom-launched",
+      launchSource: "envio-classic-v3+registry.custom-launched",
       completeness: { custom: "current" },
     });
   });
@@ -237,7 +255,7 @@ describe("Token detail static identity and Dexscreener market contract", () => {
       snapshot: { chainId: 1 },
     });
     expect(response.headers.get("x-programmable-read-source")).toBe(
-      "durable-blob+dexscreener",
+      "envio-classic-v3+dexscreener",
     );
     expect(response.headers.get("x-programmable-price-source")).toBe(
       "dexscreener",

--- a/vercel.json
+++ b/vercel.json
@@ -12,10 +12,6 @@
   ],
   "crons": [
     {
-      "path": "/api/ops/index-v2",
-      "schedule": "*/5 * * * *"
-    },
-    {
       "path": "/api/ops/projector",
       "schedule": "* * * * *"
     },


### PR DESCRIPTION
## Outcome
- serve all complete, provenance-valid Classic V3 launches from the bound Envio production indexer
- hydrate ERC-20 metadata at the exact catalog block with bounded RPC failover and complete-catalog last-known-good behavior
- merge only verified public Registry Custom launches; preserve identities when optional Dexscreener enrichment is unavailable
- publicly exclude Classic V1/V2 and every Stock-Paired family; keep router evidence internal
- retire obsolete scheduled durable refresh and legacy V2/Stock monitor dependencies

## Release contract
- source: `envio-classic-v3`
- fixed endpoint/release binding: `config/data-pipeline-release.v1.json`
- stage workflow now probes a non-empty exact Envio Classic V3 catalog before the existing public API smoke
- profile, claims, trade, and onchain action routes are unchanged

## Verification
- Interface: 291 files passed, 3,088 tests passed, 33 skipped
- Contracts: 30 release tests passed; full Solidity build passed
- Database/PGlite: 26 tests passed
- focused Envio/Explore/Custom/Dex tests passed
- typecheck, ESLint, source-contract smoke, ops gate, and production build passed

Exact candidate: `8cb42f7649f68be19e2bbd354ed8324eccb445ef` / tree `3941e713ecaafbfe2c29440dfdc3045cc52a6cc2`.