### PR TITLE
Fail over Envio metadata reads on dRPC plan timeouts

### DIFF
--- a/lib/onchain/operational-rpc-failover.server.ts
+++ b/lib/onchain/operational-rpc-failover.server.ts
@@ -10,7 +10,7 @@ import {
 import type { OnchainDeployment } from "./types";
 
 const CAPACITY_MESSAGE =
-  /(?:monthly[_\s-]*capacity[_\s-]*(?:exceeded|reached)|capacity[_\s-]*(?:exceeded|reached)|rate[_\s-]*limit(?:ed)?|too many requests)/iu;
+  /(?:monthly[_\s-]*capacity[_\s-]*(?:exceeded|reached)|capacity[_\s-]*(?:exceeded|reached)|rate[_\s-]*limit(?:ed)?|too many requests|request timeout on the free plan,? please upgrade to (?:a )?paid plan)/iu;
 const ARCHIVE_LIMITATION_MESSAGE =
   /archive requests require a personal token/iu;
 const PROVIDER_ROUTING_UNAVAILABLE_MESSAGE =

--- a/tests/operational-rpc-failover.test.ts
+++ b/tests/operational-rpc-failover.test.ts
@@ -107,6 +107,27 @@ describe("operational RPC failover", () => {
     ).toBe(true);
   });
 
+  it("uses the fixed secondary after the bound dRPC free-plan timeout", async () => {
+    const calls: string[] = [];
+    const read = vi.fn(async (candidate: ReadyOnchainDeployment) => {
+      calls.push(candidate.rpcUrl);
+      if (candidate.rpcUrl === deployment.rpcUrl) {
+        throw rpcFailure(
+          "Request timeout on the free plan, please upgrade to paid plan",
+        );
+      }
+      return "secondary-ready";
+    });
+
+    await expect(
+      withOperationalRpcFailover(deployment, read),
+    ).resolves.toBe("secondary-ready");
+    expect(calls).toEqual([
+      deployment.rpcUrl,
+      deployment.rpcUrlSecondary,
+    ]);
+  });
+
   it("uses the fixed secondary after an exact archive-read limitation", async () => {
     const calls: string[] = [];
     const read = vi.fn(async (candidate: ReadyOnchainDeployment) => {


### PR DESCRIPTION
## Outcome
- recognizes the exact dRPC free-plan timeout as provider capacity
- restarts the complete bound metadata snapshot on the fixed QuickNode secondary
- preserves endpoint redaction and the existing narrow failover boundary

## Evidence
- immutable Stage `dpl_AhHETgXtaeCYLs5JtXaHHUJiZPZZ` returned 503 and logged `OperationalRpcReadError`
- scheduled monitor captured the exact dRPC response: `Request timeout on the free plan, please upgrade to paid plan`
- focused operational failover, Envio catalog, and Explore API tests pass
- lint, typecheck, and production build pass