### PR TITLE
Bound Envio metadata RPC batches

### DIFF
--- a/lib/market-data/envio-classic-v3-catalog.server.ts
+++ b/lib/market-data/envio-classic-v3-catalog.server.ts
@@ -45,8 +45,8 @@ const GRAPHQL_TIMEOUT_MS = 3_000;
 const GRAPHQL_MAXIMUM_BODY_BYTES = 4 * 1024 * 1024;
 const LAUNCH_PAGE_SIZE = 64;
 const MAXIMUM_LAUNCH_COUNT = 5_000;
-const TOKEN_METADATA_BATCH_SIZE = 64;
-const TOKEN_METADATA_CONCURRENCY = 3;
+export const ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE = 32;
+export const ENVIO_CLASSIC_V3_TOKEN_METADATA_CONCURRENCY = 2;
 const MAXIMUM_RPC_HEAD_SKEW_BLOCKS = 8n;
 const NATIVE_CURRENCY_ADDRESS =
   "0x0000000000000000000000000000000000000000" as const;
@@ -847,15 +847,19 @@ async function defaultReadRpcSnapshot(input: Readonly<{
       throw new Error("RPC metadata anchor is unavailable");
     }
     const batches = Array.from(
-      { length: Math.ceil(input.tokens.length / TOKEN_METADATA_BATCH_SIZE) },
+      {
+        length: Math.ceil(
+          input.tokens.length / ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE,
+        ),
+      },
       (_value, index) => input.tokens.slice(
-        index * TOKEN_METADATA_BATCH_SIZE,
-        (index + 1) * TOKEN_METADATA_BATCH_SIZE,
+        index * ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE,
+        (index + 1) * ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE,
       ),
     );
     const hydrated = await mapWithConcurrency(
       batches,
-      TOKEN_METADATA_CONCURRENCY,
+      ENVIO_CLASSIC_V3_TOKEN_METADATA_CONCURRENCY,
       async (tokens) => {
         if (input.signal.aborted || Date.now() >= input.deadlineMs) {
           throw input.signal.reason ?? new Error("RPC metadata deadline exceeded");

--- a/tests/envio-classic-v3-catalog.test.ts
+++ b/tests/envio-classic-v3-catalog.test.ts
@@ -4,8 +4,11 @@ vi.mock("server-only", () => ({}));
 
 import { getDataPipelineReleaseBinding } from
   "../lib/data-pipeline/release-binding.server";
-import { createEnvioClassicV3CatalogReaderV1 } from
-  "../lib/market-data/envio-classic-v3-catalog.server";
+import {
+  createEnvioClassicV3CatalogReaderV1,
+  ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE,
+  ENVIO_CLASSIC_V3_TOKEN_METADATA_CONCURRENCY,
+} from "../lib/market-data/envio-classic-v3-catalog.server";
 
 const release = getDataPipelineReleaseBinding();
 const ANCHOR_BLOCK = 25_770_000;
@@ -213,6 +216,11 @@ function harness(input: {
 }
 
 describe("Envio Classic V3 public catalog", () => {
+  it("bounds RPC metadata work to 96 calls and two concurrent batches", () => {
+    expect(ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE).toBe(32);
+    expect(ENVIO_CLASSIC_V3_TOKEN_METADATA_CONCURRENCY).toBe(2);
+  });
+
   it("paginates, exactly binds occurrences, and exposes only Classic V3 scope", async () => {
     const test = harness({
       launches: Array.from({ length: 65 }, (_, index) => launchFixture(index + 1)),


### PR DESCRIPTION
## Outcome
- caps each Envio token metadata batch at 32 tokens / 96 contract calls
- caps metadata hydration at two concurrent batches
- binds both operational limits with a regression test

## Evidence
- immutable Stage `dpl_8DJkzJE4LCJG26HmGJLTkaPK98B7` remained 503 after dRPC correctly failed over to the fixed secondary
- runtime continued to report an endpoint-redacted `OperationalRpcReadError` during the oversized metadata snapshot
- focused failover, Envio catalog, and Explore tests pass
- lint, typecheck, and production build pass