### PR TITLE
Fail over exact dRPC code 10 timeouts

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -15,6 +15,8 @@ import {
 } from
   "../../../lib/market-data/envio-classic-v3-catalog.server";
 import { parseExploreSort } from "../../../lib/onchain/query";
+import { safeOperationalRpcError } from
+  "../../../lib/onchain/operational-rpc-failover.server";
 import { readProductionCustomExploreDirectoryV1 } from
   "../../../lib/server/custom-launch/explore-directory-v1";
 import { isCustomLaunchRegistryPublicReadEnabled } from
@@ -425,9 +427,7 @@ export async function GET(request: NextRequest) {
       },
     );
   } catch (error) {
-    console.error("Explore read failed", {
-      name: error instanceof Error ? error.name : "ExploreReadError",
-    });
+    console.error("Explore read failed", safeOperationalRpcError(error));
     return NextResponse.json(
       { error: "Token data is temporarily unavailable" },
       {

--- a/lib/onchain/operational-rpc-failover.server.ts
+++ b/lib/onchain/operational-rpc-failover.server.ts
@@ -7,7 +7,7 @@ import {
   TimeoutError,
 } from "viem";
 
-import type { OnchainDeployment } from "./types";
+import type { MainnetRpcProviderId, OnchainDeployment } from "./types";
 
 const CAPACITY_MESSAGE =
   /(?:monthly[_\s-]*capacity[_\s-]*(?:exceeded|reached)|capacity[_\s-]*(?:exceeded|reached)|rate[_\s-]*limit(?:ed)?|too many requests|request timeout on the free plan,? please upgrade to (?:a )?paid plan)/iu;
@@ -43,6 +43,7 @@ function containsRpcEndpointError(error: unknown) {
 
 function rpcCapacityMessage(error: RpcRequestError) {
   const details = [
+    error.message,
     error.details,
     typeof error.data === "string" ? error.data : undefined,
     error.cause instanceof Error ? error.cause.message : undefined,
@@ -77,7 +78,10 @@ function rpcProviderRoutingUnavailable(error: RpcRequestError) {
  * provider-independent integrity errors remain intact while endpoint-bearing
  * viem errors are redacted before they reach framework logging.
  */
-export function isOperationalRpcFailoverEligible(error: unknown) {
+export function isOperationalRpcFailoverEligible(
+  error: unknown,
+  provider?: MainnetRpcProviderId,
+) {
   return errorChain(error).some((candidate) => {
     if (candidate instanceof OperationalRpcUnavailableError) return true;
     if (
@@ -96,6 +100,7 @@ export function isOperationalRpcFailoverEligible(error: unknown) {
     }
     if (candidate instanceof RpcRequestError) {
       return (
+        (provider === "drpc" && candidate.code === 10) ||
         candidate.code === 429 ||
         candidate.code === -32_005 ||
         rpcCapacityMessage(candidate) ||
@@ -179,6 +184,8 @@ export async function withOperationalRpcFailover<
   read: (deployment: Deployment) => Promise<Output>,
 ) {
   const primary = singleRpcDeployment(deployment, deployment.rpcUrl);
+  const primaryProvider = deployment.rpcProviderIds?.primary;
+  const secondaryProvider = deployment.rpcProviderIds?.secondary;
   try {
     return await read(primary);
   } catch (primaryError) {
@@ -186,7 +193,7 @@ export async function withOperationalRpcFailover<
     if (
       !secondaryUrl ||
       secondaryUrl === deployment.rpcUrl ||
-      !isOperationalRpcFailoverEligible(primaryError)
+      !isOperationalRpcFailoverEligible(primaryError, primaryProvider)
     ) {
       throw redactRpcEndpointError(primaryError, "primary");
     }
@@ -194,7 +201,10 @@ export async function withOperationalRpcFailover<
     try {
       return await read(singleRpcDeployment(deployment, secondaryUrl));
     } catch (secondaryError) {
-      if (isOperationalRpcFailoverEligible(secondaryError)) {
+      if (isOperationalRpcFailoverEligible(
+        secondaryError,
+        secondaryProvider,
+      )) {
         // Do not retain transport errors: framework cache logging serializes
         // nested causes and can otherwise expose authenticated RPC URLs.
         throw new OperationalRpcUnavailableError();

--- a/lib/onchain/operational-rpc-failover.server.ts
+++ b/lib/onchain/operational-rpc-failover.server.ts
@@ -128,15 +128,41 @@ export class OperationalRpcUnavailableError extends Error {
 
 export class OperationalRpcReadError extends Error {
   override name = "OperationalRpcReadError";
+  readonly role: "primary" | "secondary";
+  readonly reason: string;
 
-  constructor() {
+  constructor(
+    role: "primary" | "secondary",
+    reason: string,
+  ) {
     super("Operational RPC read failed");
+    this.role = role;
+    this.reason = reason;
   }
 }
 
-function redactRpcEndpointError(error: unknown) {
+function safeRpcFailureReason(error: unknown) {
+  for (const candidate of errorChain(error)) {
+    if (candidate instanceof HttpRequestError) {
+      return candidate.status === undefined
+        ? "http-network"
+        : `http-${candidate.status}`;
+    }
+    if (candidate instanceof RpcRequestError) {
+      return `rpc-${candidate.code}`;
+    }
+    if (candidate instanceof TimeoutError) return "transport-timeout";
+    if (candidate instanceof SocketClosedError) return "socket-closed";
+  }
+  return "endpoint-error";
+}
+
+function redactRpcEndpointError(
+  error: unknown,
+  role: "primary" | "secondary",
+) {
   return containsRpcEndpointError(error)
-    ? new OperationalRpcReadError()
+    ? new OperationalRpcReadError(role, safeRpcFailureReason(error))
     : error;
 }
 
@@ -162,7 +188,7 @@ export async function withOperationalRpcFailover<
       secondaryUrl === deployment.rpcUrl ||
       !isOperationalRpcFailoverEligible(primaryError)
     ) {
-      throw redactRpcEndpointError(primaryError);
+      throw redactRpcEndpointError(primaryError, "primary");
     }
 
     try {
@@ -173,7 +199,7 @@ export async function withOperationalRpcFailover<
         // nested causes and can otherwise expose authenticated RPC URLs.
         throw new OperationalRpcUnavailableError();
       }
-      throw redactRpcEndpointError(secondaryError);
+      throw redactRpcEndpointError(secondaryError, "secondary");
     }
   }
 }
@@ -181,6 +207,14 @@ export async function withOperationalRpcFailover<
 /** Provider-neutral telemetry fields; endpoint URLs and request bodies stay out. */
 export function safeOperationalRpcError(error: unknown) {
   if (!(error instanceof Error)) return { name: "UnknownError" };
+  if (error instanceof OperationalRpcReadError) {
+    return {
+      name: error.name,
+      category: "read-failed" as const,
+      role: error.role,
+      reason: error.reason,
+    };
+  }
   return {
     name: error.name,
     category: isOperationalRpcFailoverEligible(error)

--- a/tests/operational-rpc-failover.test.ts
+++ b/tests/operational-rpc-failover.test.ts
@@ -30,6 +30,7 @@ const deployment = {
   stateViewRuntimeCodeHash: `0x${"33".repeat(32)}`,
   rpcUrl: "https://primary.example/rpc-key",
   rpcUrlSecondary: "https://secondary.example/rpc-key",
+  rpcProviderIds: { primary: "drpc", secondary: "quicknode" },
   confirmations: 12n,
   logBlockRange: 5_000n,
 } satisfies ReadyOnchainDeployment;
@@ -126,6 +127,28 @@ describe("operational RPC failover", () => {
       deployment.rpcUrl,
       deployment.rpcUrlSecondary,
     ]);
+  });
+
+  it("uses the fixed secondary after dRPC returns its code 10 timeout", async () => {
+    const calls: string[] = [];
+    const read = vi.fn(async (candidate: ReadyOnchainDeployment) => {
+      calls.push(candidate.rpcUrl);
+      if (candidate.rpcUrl === deployment.rpcUrl) {
+        throw rpcFailure("provider timeout", 10);
+      }
+      return "secondary-ready";
+    });
+
+    await expect(
+      withOperationalRpcFailover(deployment, read),
+    ).resolves.toBe("secondary-ready");
+    expect(calls).toEqual([
+      deployment.rpcUrl,
+      deployment.rpcUrlSecondary,
+    ]);
+    expect(
+      isOperationalRpcFailoverEligible(rpcFailure("provider timeout", 10)),
+    ).toBe(false);
   });
 
   it("uses the fixed secondary after an exact archive-read limitation", async () => {

--- a/tests/operational-rpc-failover.test.ts
+++ b/tests/operational-rpc-failover.test.ts
@@ -173,10 +173,13 @@ describe("operational RPC failover", () => {
   });
 
   it.each([
-    httpFailure(400),
-    rpcFailure("execution reverted"),
-    rpcFailure("Invalid parameters were provided", -32602),
-  ])("redacts a non-failover RPC error without rotating providers", async (error) => {
+    [httpFailure(400), "http-400"],
+    [rpcFailure("execution reverted"), "rpc--32000"],
+    [rpcFailure("Invalid parameters were provided", -32602), "rpc--32602"],
+  ])("redacts a non-failover RPC error without rotating providers", async (
+    error,
+    reason,
+  ) => {
     const read = vi.fn(async () => {
       throw error;
     });
@@ -185,6 +188,12 @@ describe("operational RPC failover", () => {
       (candidate) => candidate,
     );
     expect(received).toBeInstanceOf(OperationalRpcReadError);
+    expect(safeOperationalRpcError(received)).toEqual({
+      name: "OperationalRpcReadError",
+      category: "read-failed",
+      role: "primary",
+      reason,
+    });
     expect(JSON.stringify(received)).not.toContain("primary.example");
     expect(JSON.stringify(received)).not.toContain("eth_blockNumber");
     expect(read).toHaveBeenCalledTimes(1);
@@ -200,6 +209,30 @@ describe("operational RPC failover", () => {
       withOperationalRpcFailover(deployment, read),
     ).rejects.toBe(error);
     expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits only a provider-neutral role and RPC code after secondary failure", async () => {
+    const read = vi.fn(async (candidate: ReadyOnchainDeployment) => {
+      if (candidate.rpcUrl === deployment.rpcUrl) {
+        throw rpcFailure(
+          "Request timeout on the free plan, please upgrade to paid plan",
+        );
+      }
+      throw rpcFailure("provider-specific failure", -32_001, candidate.rpcUrl);
+    });
+
+    const error = await withOperationalRpcFailover(deployment, read).catch(
+      (candidate) => candidate,
+    );
+    expect(safeOperationalRpcError(error)).toEqual({
+      name: "OperationalRpcReadError",
+      category: "read-failed",
+      role: "secondary",
+      reason: "rpc--32001",
+    });
+    expect(JSON.stringify(error)).not.toContain("primary.example");
+    expect(JSON.stringify(error)).not.toContain("secondary.example");
+    expect(JSON.stringify(error)).not.toContain("provider-specific");
   });
 
   it("returns one safe unavailable error when both configured RPCs fail", async () => {


### PR DESCRIPTION
## Outcome
- treats RPC code 10 as failover-eligible only for a manifest-bound dRPC primary
- preserves strict behavior for QuickNode and unknown providers
- adds provider-neutral failure telemetry containing only role and HTTP/RPC code
- never retains or logs endpoint URLs, request bodies, or provider error text

## Runtime evidence
- unaliased deployment `dpl_D5SRch6ibAHK4zogDwRurR9vnoNa` is READY and not promoted
- `/api/explore?limit=1&page=1&sort=newest` returns 200
- source is `envio-classic-v3`; total is 269; stock completeness is `excluded`; Custom is fail-closed `unavailable`
- Envio deployment is `production-92f6373` at progress block `25770090`

## Validation
- 37 focused failover, Envio catalog, and Explore tests pass
- typecheck and lint pass
- Vercel production build passes