### PR TITLE
Keep Envio identity commitments snapshot-stable

### DIFF
--- a/lib/market-data/envio-classic-v3-catalog.server.ts
+++ b/lib/market-data/envio-classic-v3-catalog.server.ts
@@ -1243,10 +1243,6 @@ export function envioClassicV3IdentityCommitmentV1(
 ) {
   return canonicalSha256("programmable.envio-classic-v3-identity.v1", {
     source: catalog.source,
-    generatedAt: catalog.generatedAt,
-    asOfBlock: catalog.asOfBlock,
-    asOfBlockHash: catalog.asOfBlockHash,
-    evidenceCommitment: catalog.evidence.commitment,
     entries: [...entries]
       .sort((left, right) => left.id.localeCompare(right.id))
       .map((entry) => entry.exploreKind === "token"

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -349,15 +349,12 @@ function exactCatalogSnapshot(response) {
   )) return null;
   return JSON.stringify({
     source,
-    status: catalog.status,
-    lastIndexedAt: generatedAt,
-    asOfBlock: catalog.asOfBlock,
-    asOfBlockHash: catalog.asOfBlockHash,
     identityCount: catalog.identityCount,
     identityCommitment: catalog.identityCommitment,
     completeness: catalog.completeness,
     scope: catalog.scope,
-    evidence: catalog.evidence,
+    evidenceDeployment: catalog.evidence.deployment,
+    evidenceSourceCommit: catalog.evidence.sourceCommit,
     launchSource,
   });
 }

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -424,6 +424,51 @@ test("staged smoke accepts identity-only Explore and token responses", async () 
   assert.match(output[0][1], /market_read_status=unavailable/u);
 });
 
+test("staged smoke accepts monotonic Envio progress with stable identities", async () => {
+  const advancedAt = "2026-08-16T08:00:12.000Z";
+  const result = await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl: stagedFetch(
+      ({ body, url }) =>
+        url.pathname === "/api/explore" &&
+          url.searchParams.get("sort") === "newest"
+          ? {
+              ...body,
+              catalog: {
+                ...body.catalog,
+                lastIndexedAt: advancedAt,
+                asOfBlock: "25740012",
+                asOfBlockHash: `0x${"ab".repeat(32)}`,
+                evidence: {
+                  ...body.catalog.evidence,
+                  progressBlock: "25740012",
+                  commitment: `sha256:${"cd".repeat(32)}`,
+                },
+              },
+            }
+          : body,
+      ({ extraHeaders, omittedHeaders, url }) => ({
+        extraHeaders: url.pathname === "/api/explore" &&
+            url.searchParams.get("sort") === "newest"
+          ? {
+              ...extraHeaders,
+              "x-programmable-identity-last-indexed-at": advancedAt,
+            }
+          : extraHeaders,
+        omittedHeaders,
+      }),
+    ),
+    appendOutput: () => undefined,
+  });
+
+  assert.equal(result.catalogSource, "envio-classic-v3");
+  assert.equal(result.detailStatus, "verified-identity-market-unavailable");
+});
+
 test("staged smoke rejects a mixed Explore identity commitment", async () => {
   await assert.rejects(
     runStagedStaticDexscreenerSmokeV1({

--- a/tests/envio-classic-v3-catalog.test.ts
+++ b/tests/envio-classic-v3-catalog.test.ts
@@ -8,6 +8,7 @@ import {
   createEnvioClassicV3CatalogReaderV1,
   ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE,
   ENVIO_CLASSIC_V3_TOKEN_METADATA_CONCURRENCY,
+  envioClassicV3IdentityCommitmentV1,
 } from "../lib/market-data/envio-classic-v3-catalog.server";
 
 const release = getDataPipelineReleaseBinding();
@@ -268,6 +269,25 @@ describe("Envio Classic V3 public catalog", () => {
     expect(test.readRpcSnapshot).toHaveBeenCalledWith(expect.objectContaining({
       anchorBlock: String(ANCHOR_BLOCK),
     }));
+    const identityCommitment = envioClassicV3IdentityCommitmentV1(
+      catalog,
+      catalog.entries,
+    );
+    expect(envioClassicV3IdentityCommitmentV1({
+      ...catalog,
+      generatedAt: "2026-08-16T12:00:12.000Z",
+      asOfBlock: String(ANCHOR_BLOCK + 12),
+      asOfBlockHash: hex32(60_012),
+      evidence: {
+        ...catalog.evidence,
+        progressBlock: String(ANCHOR_BLOCK + 12),
+        commitment: `sha256:${"ab".repeat(32)}`,
+      },
+    }, catalog.entries)).toBe(identityCommitment);
+    expect(envioClassicV3IdentityCommitmentV1(
+      catalog,
+      catalog.entries.slice(1),
+    )).not.toBe(identityCommitment);
   });
 
   it("fails closed for an empty catalog, family drift, and payload mismatch", async () => {


### PR DESCRIPTION
## Outcome
- makes the Envio identity commitment bind only canonical identities, not volatile progress coordinates
- keeps full per-response validation of progress block, block hash, occurrence, evidence commitment, source, and scope
- lets staged smoke accept monotonic Envio progress across separate serverless instances
- still rejects identity count, identity commitment, scope, source, deployment, source-commit, or Custom-boundary drift

## Evidence
- Stage `31972985420` passed the exact Envio catalog probe, then failed only because market-cap and newest reads observed consecutive valid progress snapshots
- the exact merged runtime tree already returned 200 with 269 Classic V3 identities and Stock excluded
- new regression test accepts snapshot progress drift but unchanged identities
- existing mixed-identity commitment rejection remains green

## Validation
- 22 static/Dex smoke tests pass
- 32 Envio catalog, Explore, and detail tests pass
- typecheck, lint, and production build pass