### PR TITLE
Fix native mobile scrolling on the home page

### DIFF
--- a/app/interface.css
+++ b/app/interface.css
@@ -196,26 +196,6 @@ code,
   z-index: 1;
 }
 
-/* The home scene owns the viewport; it does not need the mobile nav reserve. */
-.app-frame:has(.landing-page-root) {
-  height: 100svh;
-  min-height: 100svh;
-  overflow: hidden;
-}
-
-.app-frame:has(.landing-page-root) > main {
-  padding-bottom: 0;
-  height: 100svh;
-  min-height: 0;
-  overflow: hidden;
-}
-
-.app-frame:has(.landing-page-root) .route-transition {
-  height: 100%;
-  min-height: 0;
-  overflow: hidden;
-}
-
 .site-header {
   position: sticky;
   top: 0;

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -111,6 +111,7 @@ describe("landing page contract", () => {
 
   it("restores native document scrolling instead of trapping the landing route", () => {
     const styles = read("components/landing-page.module.css");
+    const interfaceStyles = read("app/interface.css");
 
     expect(styles).toMatch(
       /:global\(body \.app-frame\):has\(\.page\)\s*\{[^}]*height:\s*auto;[^}]*overflow:\s*visible;/s,
@@ -120,6 +121,15 @@ describe("landing page contract", () => {
     );
     expect(styles).toMatch(
       /:global\(body \.app-frame\):has\(\.page\) :global\(\.route-transition\)\s*\{[^}]*height:\s*auto;[^}]*overflow:\s*visible;/s,
+    );
+    expect(interfaceStyles).not.toMatch(
+      /\.app-frame:has\(\.landing-page-root\)[^{]*\{[^}]*overflow:\s*hidden;/s,
+    );
+    expect(interfaceStyles).not.toMatch(
+      /\.app-frame:has\(\.landing-page-root\) > main\s*\{[^}]*overflow:\s*hidden;/s,
+    );
+    expect(interfaceStyles).not.toMatch(
+      /\.app-frame:has\(\.landing-page-root\) \.route-transition\s*\{[^}]*overflow:\s*hidden;/s,
     );
   });
 


### PR DESCRIPTION
## What changed
- remove the obsolete landing-page viewport lock that forced `100svh` and `overflow: hidden`
- keep the homepage on native document scrolling across mobile WebKit/Chrome
- add regression coverage that rejects the three legacy scroll traps

## Verification
- `npx vitest run tests/landing-page-contract.test.ts tests/interaction-accessibility.test.ts` (21/21)
- `npm run typecheck`
- scoped ESLint
- `npm run build`
- iPhone 13 WebKit: document/frame/main/route remain scrollable, cue navigation and browser Back return to the correct positions
- trusted mobile touch sequence: page scrolls 385px

## Scope
Two files only. No data, API, wallet, contract, provider, or deployment configuration changes.