### PR TITLE
Restore homepage top after mobile hash navigation

### DIFF
--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -38,7 +38,12 @@ export function LandingPage() {
   const pageRef = useRef<HTMLElement>(null);
 
   useLayoutEffect(() => {
-    const alignExploreHash = () => {
+    const alignLandingHash = () => {
+      if (window.location.hash === "") {
+        window.scrollTo({ behavior: "auto", left: 0, top: 0 });
+        return;
+      }
+
       if (window.location.hash !== "#explore") return;
 
       const target = document.getElementById("explore");
@@ -56,9 +61,9 @@ export function LandingPage() {
       window.scrollTo({ behavior: "auto", left: 0, top });
     };
 
-    alignExploreHash();
-    window.addEventListener("hashchange", alignExploreHash);
-    return () => window.removeEventListener("hashchange", alignExploreHash);
+    alignLandingHash();
+    window.addEventListener("hashchange", alignLandingHash);
+    return () => window.removeEventListener("hashchange", alignLandingHash);
   }, []);
 
   useEffect(() => {

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -98,6 +98,10 @@ describe("landing page contract", () => {
     expect(styles).toContain(".definitionLogoFrame");
     expect(landing).toContain("new IntersectionObserver(");
     expect(landing).toContain("useLayoutEffect(() =>");
+    expect(landing).toContain('if (window.location.hash === "")');
+    expect(landing).toContain(
+      'window.scrollTo({ behavior: "auto", left: 0, top: 0 })',
+    );
     expect(landing).toContain('window.location.hash !== "#explore"');
     expect(landing).toContain('window.scrollTo({ behavior: "auto"');
     expect(landing).toContain("data-reveal-section");


### PR DESCRIPTION
Fixes the remaining iPhone WebKit same-page Back edge case after the native mobile scroll repair.

- restores `/` to scroll position 0 whenever section hash navigation returns to the un-hashed homepage
- preserves the existing `#explore` header-offset behavior
- adds a regression contract

Validation:
- 21 focused tests
- typecheck
- scoped ESLint
- production build and bundle scan
- 10/10 iPhone WebKit rapid Back trials
- trusted mobile touch scroll (405px)

No provider, API, wallet, contract, or deployment-configuration changes.