### PR TITLE
Show official token media and social links

### DIFF
--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1288,6 +1288,11 @@
   width: 32px;
 }
 
+.runnerCopyButton[data-state="copied"] {
+  background: var(--webde-control);
+  color: var(--webde-ink);
+}
+
 .runnerSocialLink {
   border-radius: 7px;
   color: var(--webde-dim);

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -167,7 +167,11 @@ type ExploreCatalogBoundary = Readonly<{
     custom: "current" | "unavailable";
   }>;
   scope: Readonly<{
-    included: readonly ["classic-v3", "registry.custom-launched"];
+    included: readonly [
+      "classic-v3",
+      "official-main-token",
+      "registry.custom-launched",
+    ];
     excluded: readonly [
       "classic-v1",
       "classic-v2",
@@ -960,6 +964,7 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
     ) ||
     !exactStringArray(value.scope.included, [
       "classic-v3",
+      "official-main-token",
       "registry.custom-launched",
     ]) ||
     !exactStringArray(value.scope.excluded, [
@@ -1846,6 +1851,7 @@ export function ExploreView({
   const pageSize = useExploreTokensPerPage();
   const [retryKey, setRetryKey] = useState(0);
   const [copyFeedback, setCopyFeedback] = useState("");
+  const [copiedTokenId, setCopiedTokenId] = useState<string | null>(null);
   const refreshKey = useLiveDataRefresh({
     enabled: !preview && !loadingOnly,
   });
@@ -1902,15 +1908,18 @@ export function ExploreView({
     try {
       await navigator.clipboard.writeText(token.tokenAddress);
       setCopyFeedback(`${token.name} contract address copied`);
+      setCopiedTokenId(token.id);
       if (copyFeedbackTimerRef.current !== null) {
         window.clearTimeout(copyFeedbackTimerRef.current);
       }
       copyFeedbackTimerRef.current = window.setTimeout(() => {
         setCopyFeedback("");
+        setCopiedTokenId(null);
         copyFeedbackTimerRef.current = null;
       }, 1800);
     } catch {
       setCopyFeedback("Contract address could not be copied");
+      setCopiedTokenId(null);
     }
   }
 
@@ -2323,11 +2332,26 @@ export function ExploreView({
                     <button
                       className={styles.runnerCopyButton}
                       type="button"
-                      aria-label={`Copy ${token.name} contract address`}
-                      title="Copy contract address"
+                      aria-label={
+                        copiedTokenId === token.id
+                          ? `${token.name} contract address copied`
+                          : `Copy ${token.name} contract address`
+                      }
+                      title={
+                        copiedTokenId === token.id
+                          ? "Copied"
+                          : "Copy contract address"
+                      }
+                      data-state={
+                        copiedTokenId === token.id ? "copied" : undefined
+                      }
                       onClick={() => void copyContractAddress(token)}
                     >
-                      <Copy aria-hidden="true" size={14} strokeWidth={1.8} />
+                      {copiedTokenId === token.id ? (
+                        <Check aria-hidden="true" size={15} strokeWidth={2} />
+                      ) : (
+                        <Copy aria-hidden="true" size={14} strokeWidth={1.8} />
+                      )}
                     </button>
                   </div>
                 ) : null}

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -1499,28 +1499,6 @@ function TokenDetailContent({
               >
                 {token.name}
               </h1>
-              {projectLinks.length > 0 ? (
-                <nav className={styles.links} aria-label={`${token.name} links`}>
-                  {projectLinks.map((link) => {
-                    const label = getLinkLabel(link.kind);
-                    return (
-                      <a
-                        className={`${styles.socialLink} ${
-                          link.kind === "website" ? styles.websiteLink : ""
-                        }`}
-                        href={link.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        aria-label={`${token.name} on ${label}`}
-                        title={label}
-                        key={`${link.kind}:${link.url}`}
-                      >
-                        <TokenLinkIcon kind={link.kind} />
-                      </a>
-                    );
-                  })}
-                </nav>
-              ) : null}
               <div className={styles.addressActions}>
                 <button
                   className={styles.address}
@@ -1548,6 +1526,31 @@ function TokenDetailContent({
                     <Copy aria-hidden="true" size={14} />
                   )}
                 </button>
+                {projectLinks.length > 0 ? (
+                  <nav
+                    className={`${styles.links} ${styles.addressLinks}`}
+                    aria-label={`${token.name} links`}
+                  >
+                    {projectLinks.map((link) => {
+                      const label = getLinkLabel(link.kind);
+                      return (
+                        <a
+                          className={`${styles.socialLink} ${
+                            link.kind === "website" ? styles.websiteLink : ""
+                          }`}
+                          href={link.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          aria-label={`${token.name} on ${label}`}
+                          title={label}
+                          key={`${link.kind}:${link.url}`}
+                        >
+                          <TokenLinkIcon kind={link.kind} />
+                        </a>
+                      );
+                    })}
+                  </nav>
+                ) : null}
               </div>
 
               {token.description?.trim() ? (

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -156,7 +156,8 @@
 .addressActions {
   align-items: center;
   display: flex;
-  gap: 0;
+  flex-wrap: wrap;
+  gap: 6px;
   margin-top: 10px;
   min-width: 0;
 }
@@ -243,6 +244,11 @@
   flex-wrap: wrap;
   gap: 6px;
   margin: 10px 0 0;
+}
+
+.addressLinks {
+  flex: none;
+  margin: 0;
 }
 
 .socialLink {

--- a/lib/market-data/envio-classic-v3-catalog.server.ts
+++ b/lib/market-data/envio-classic-v3-catalog.server.ts
@@ -26,6 +26,7 @@ import {
   characterLength,
   hasUnsafeDisplayCharacters,
   isValidTokenSymbol,
+  MAX_TOKEN_DESCRIPTION_BYTES,
   MAX_TOKEN_NAME_BYTES,
   MAX_TOKEN_NAME_CHARACTERS,
   MAX_TOKEN_SYMBOL_BYTES,
@@ -33,6 +34,7 @@ import {
 } from "../metadata-policy";
 import { uerc20ReadAbi } from "../onchain/abis";
 import { getWebsiteReadOnchainDeployment } from "../onchain/config";
+import { buildTokenLinks, sanitizeImageUrl } from "../onchain/metadata";
 import { withOperationalRpcFailover } from
   "../onchain/operational-rpc-failover.server";
 import { canonicalSha256 } from "../server/projection-target/hashing";
@@ -45,11 +47,17 @@ const GRAPHQL_TIMEOUT_MS = 3_000;
 const GRAPHQL_MAXIMUM_BODY_BYTES = 4 * 1024 * 1024;
 const LAUNCH_PAGE_SIZE = 64;
 const MAXIMUM_LAUNCH_COUNT = 5_000;
-export const ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE = 32;
+export const ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE = 24;
 export const ENVIO_CLASSIC_V3_TOKEN_METADATA_CONCURRENCY = 2;
 const MAXIMUM_RPC_HEAD_SKEW_BLOCKS = 8n;
 const NATIVE_CURRENCY_ADDRESS =
   "0x0000000000000000000000000000000000000000" as const;
+const PROGRAMMABLE_MAIN_ASSET_ADDRESS =
+  "0x7987f03462200b3d8a072e02c89a8a41dcb124ee" as const;
+const OFFICIAL_MAIN_TOKEN_LAUNCH_ID =
+  "1:classic-v2:0xf62bfccb2c0e3832607d8e6c48c00b0411d1d9bf12337fd039c4821d25e8cd20" as const;
+const OFFICIAL_MAIN_TOKEN_OCCURRENCE_ID =
+  "1:0x17e7e16d94fdf07c3d06586080c68264a39756b326ecf9d55d5170542d8b733d:0x47668b99d392ba82fc82d2a38413bd679e6ec8a04e5cf9535bff2c558259732a:976" as const;
 
 const CLASSIC_V3_LAUNCH_QUERY = `
   query ProgrammableClassicV3Catalog(
@@ -207,6 +215,31 @@ const EVENT_KEYS = [
   "payloadHash",
 ] as const;
 
+const OFFICIAL_MAIN_TOKEN_QUERY = `
+  query ProgrammableOfficialMainToken($anchorBlock: numeric!) {
+    OfficialLaunch: Launch(
+      where: {
+        _and: [
+          { id: { _eq: "${OFFICIAL_MAIN_TOKEN_LAUNCH_ID}" } }
+          { token: { _eq: "${PROGRAMMABLE_MAIN_ASSET_ADDRESS}" } }
+          { updatedBlock: { _lte: $anchorBlock } }
+          { isComplete: { _eq: true } }
+          { provenanceValid: { _eq: true } }
+        ]
+      }
+      limit: 2
+    ) {
+      ${LAUNCH_KEYS.join("\n      ")}
+    }
+    OfficialEvent: ChainEvent(
+      where: { id: { _eq: "${OFFICIAL_MAIN_TOKEN_OCCURRENCE_ID}" } }
+      limit: 2
+    ) {
+      ${EVENT_KEYS.join("\n      ")}
+    }
+  }
+`;
+
 type CatalogReadOptions = Readonly<{
   signal?: AbortSignal;
   /** Absolute Unix epoch deadline in milliseconds. */
@@ -248,11 +281,46 @@ type EnvioClassicV3LaunchEvent = Readonly<{
   decodedPayload: Readonly<Record<string, string>>;
 }>;
 
+type OfficialMainTokenLaunchRow = Readonly<{
+  id: typeof OFFICIAL_MAIN_TOKEN_LAUNCH_ID;
+  launchHash: Hex;
+  token: Address;
+  creator: Address;
+  poolId: Hex;
+  hook: Address;
+  positionRecipient: Address;
+  positionTokenId: string;
+  totalSwapFeeBps: number;
+  totalSupply: string;
+  tokenLiquidityAmount: string;
+  lockedTokenDust: string;
+  initialTick: number;
+  tickLower: number;
+  tickUpper: number;
+  lpFeePips: number;
+  launchOccurrenceId: typeof OFFICIAL_MAIN_TOKEN_OCCURRENCE_ID;
+  updatedBlock: string;
+}>;
+
+type OfficialMainTokenLaunchEvent = Readonly<{
+  id: typeof OFFICIAL_MAIN_TOKEN_OCCURRENCE_ID;
+  blockNumber: string;
+  blockHash: Hex;
+  blockTimestamp: string;
+  transactionHash: Hex;
+  transactionIndex: number;
+  blockGlobalLogIndex: number;
+  decodedPayload: Readonly<Record<string, string>>;
+}>;
+
 type TokenMetadata = Readonly<{
   tokenAddress: Address;
   name: string;
   symbol: string;
   decimals: number;
+  description?: string;
+  imageUrl?: string;
+  links?: LauncherToken["links"];
 }>;
 
 type RpcCatalogSnapshot = Readonly<{
@@ -275,7 +343,11 @@ export type EnvioClassicV3CatalogV1 = Readonly<{
     custom: "unavailable";
   }>;
   scope: Readonly<{
-    included: readonly ["classic-v3", "registry.custom-launched"];
+    included: readonly [
+      "classic-v3",
+      "official-main-token",
+      "registry.custom-launched",
+    ];
     excluded: readonly [
       "classic-v1",
       "classic-v2",
@@ -402,6 +474,29 @@ function launchSourceBindings(release: DataPipelineReleaseBinding) {
     throw new Error("Classic V3 Envio source bindings are incomplete");
   }
   return Object.freeze({ launcher, hook });
+}
+
+function officialMainTokenSourceBindings(release: DataPipelineReleaseBinding) {
+  const classicV2 = release.releases.find((candidate) =>
+    candidate.model === "classic" &&
+    candidate.releaseVersion === "classic-v2"
+  );
+  const launcher = release.sources.find(
+    (candidate) => candidate.contractName === "ClassicV2Launcher",
+  );
+  const hook = release.sources.find(
+    (candidate) => candidate.contractName === "ClassicV2Hook",
+  );
+  if (
+    !classicV2 ||
+    !launcher ||
+    !hook ||
+    !classicV2.sourceContracts.includes(launcher.contractName) ||
+    !classicV2.sourceContracts.includes(hook.contractName)
+  ) {
+    throw new Error("Official main token Envio source bindings are incomplete");
+  }
+  return Object.freeze({ classicV2, launcher, hook });
 }
 
 function parseLaunchRow(
@@ -623,6 +718,217 @@ function assertLaunchEventBinding(
   }
 }
 
+function parseOfficialMainTokenLaunch(
+  value: unknown,
+  release: DataPipelineReleaseBinding,
+): OfficialMainTokenLaunchRow {
+  if (!isRecord(value) || !hasOnlyKeys(value, LAUNCH_KEYS)) {
+    throw new Error("Official main token launch row shape drifted");
+  }
+  const sources = officialMainTokenSourceBindings(release);
+  const id = exactString(value.id, /^1:classic-v2:0x[0-9a-f]{64}$/u, "official launch id");
+  const launchHash = bytes32(value.launchHash, "official launch hash");
+  const token = address(value.token, "official token");
+  const creator = address(value.creator, "official creator");
+  const poolId = bytes32(value.poolId, "official pool id");
+  const hook = address(value.hook, "official hook");
+  const positionRecipient = address(
+    value.positionRecipient,
+    "official position recipient",
+  );
+  const launchOccurrenceId = exactString(
+    value.launchOccurrenceId,
+    /^1:0x[0-9a-f]{64}:0x[0-9a-f]{64}:(?:0|[1-9][0-9]*)$/u,
+    "official launch occurrence",
+  );
+  if (
+    id !== OFFICIAL_MAIN_TOKEN_LAUNCH_ID ||
+    token.toLowerCase() !== PROGRAMMABLE_MAIN_ASSET_ADDRESS ||
+    value.chainId !== 1 ||
+    value.model !== "classic" ||
+    value.releaseVersion !== "classic-v2" ||
+    id !== `1:classic-v2:${launchHash}` ||
+    hook.toLowerCase() !== sources.hook.address.toLowerCase() ||
+    launchOccurrenceId !== OFFICIAL_MAIN_TOKEN_OCCURRENCE_ID ||
+    value.quoteAsset !== null ||
+    value.rewardVault !== null ||
+    value.buySwapFeeBps !== null ||
+    value.sellSwapFeeBps !== null ||
+    value.rewardConfigurationHash !== null ||
+    value.quoteConfigurationHash !== null ||
+    value.custodyOccurrenceId !== null ||
+    value.coordinatorOccurrenceId !== null ||
+    value.hasLaunchEvent !== true ||
+    value.hasLiquidityEvent !== true ||
+    value.hasInitialBuyEvent !== true ||
+    value.hasCustodyEvent !== false ||
+    value.hasCoordinatorEvent !== false ||
+    value.hasPoolRegistrationEvent !== true ||
+    value.hasPoolFeeDisclosureEvent !== true ||
+    value.hasRewardVaultFactoryEvent !== false ||
+    value.provenanceValid !== true ||
+    value.isComplete !== true ||
+    typeof value.liquidityOccurrenceId !== "string" ||
+    typeof value.initialBuyOccurrenceId !== "string"
+  ) {
+    throw new Error("Official main token failed exact release validation");
+  }
+  return Object.freeze({
+    id,
+    launchHash,
+    token,
+    creator,
+    poolId,
+    hook,
+    positionRecipient,
+    positionTokenId: unsignedText(
+      value.positionTokenId,
+      "official position token id",
+    ),
+    totalSwapFeeBps: boundedInteger(
+      value.totalSwapFeeBps,
+      0,
+      10_000,
+      "official total swap fee",
+    ),
+    totalSupply: unsignedText(value.totalSupply, "official total supply"),
+    tokenLiquidityAmount: unsignedText(
+      value.tokenLiquidityAmount,
+      "official token liquidity amount",
+    ),
+    lockedTokenDust: unsignedText(
+      value.lockedTokenDust,
+      "official locked token dust",
+    ),
+    initialTick: boundedInteger(
+      value.initialTick,
+      -887_272,
+      887_272,
+      "official initial tick",
+    ),
+    tickLower: boundedInteger(
+      value.tickLower,
+      -887_272,
+      887_272,
+      "official tick lower",
+    ),
+    tickUpper: boundedInteger(
+      value.tickUpper,
+      -887_272,
+      887_272,
+      "official tick upper",
+    ),
+    lpFeePips: boundedInteger(value.lpFeePips, 0, 1_000_000, "official LP fee"),
+    launchOccurrenceId,
+    updatedBlock: unsignedText(value.updatedBlock, "official updated block"),
+  });
+}
+
+function parseOfficialMainTokenEvent(
+  value: unknown,
+  release: DataPipelineReleaseBinding,
+): OfficialMainTokenLaunchEvent {
+  if (!isRecord(value) || !hasOnlyKeys(value, EVENT_KEYS)) {
+    throw new Error("Official main token event shape drifted");
+  }
+  const sources = officialMainTokenSourceBindings(release);
+  const id = exactString(
+    value.id,
+    /^1:0x[0-9a-f]{64}:0x[0-9a-f]{64}:(?:0|[1-9][0-9]*)$/u,
+    "official event id",
+  );
+  const blockHash = bytes32(value.blockHash, "official event block hash");
+  const transactionHash = bytes32(
+    value.transactionHash,
+    "official event transaction hash",
+  );
+  const blockGlobalLogIndex = safeUnsignedInteger(
+    value.blockGlobalLogIndex,
+    "official event log index",
+  );
+  bytes32(value.payloadHash, "official event payload hash");
+  if (
+    id !== OFFICIAL_MAIN_TOKEN_OCCURRENCE_ID ||
+    value.downstreamLogicalId !== null ||
+    value.receiptLogOrdinal !== null ||
+    value.chainId !== 1 ||
+    value.model !== "classic" ||
+    value.releaseVersion !== "classic-v2" ||
+    value.contractName !== "ClassicV2Launcher" ||
+    value.eventName !== "MemeTokenLaunched" ||
+    address(value.sourceAddress, "official event source").toLowerCase() !==
+      sources.launcher.address.toLowerCase() ||
+    id !== `1:${blockHash}:${transactionHash}:${blockGlobalLogIndex}` ||
+    typeof value.decodedPayload !== "string"
+  ) {
+    throw new Error("Official main token event failed exact validation");
+  }
+  let decodedPayload: unknown;
+  try {
+    decodedPayload = JSON.parse(value.decodedPayload);
+  } catch {
+    throw new Error("Official main token event payload is invalid");
+  }
+  const payloadKeys = [
+    "creator",
+    "feeHook",
+    "launchHash",
+    "poolId",
+    "positionRecipient",
+    "positionTokenId",
+    "token",
+    "totalSwapFeeBps",
+  ] as const;
+  if (
+    !isRecord(decodedPayload) ||
+    !hasOnlyKeys(decodedPayload, payloadKeys) ||
+    Object.values(decodedPayload).some((item) => typeof item !== "string")
+  ) {
+    throw new Error("Official main token event payload shape drifted");
+  }
+  return Object.freeze({
+    id,
+    blockNumber: unsignedText(value.blockNumber, "official event block number"),
+    blockHash,
+    blockTimestamp: unsignedText(
+      value.blockTimestamp,
+      "official event block timestamp",
+    ),
+    transactionHash,
+    transactionIndex: safeUnsignedInteger(
+      value.transactionIndex,
+      "official event transaction index",
+    ),
+    blockGlobalLogIndex,
+    decodedPayload: decodedPayload as Record<string, string>,
+  });
+}
+
+function assertOfficialMainTokenBinding(
+  launch: OfficialMainTokenLaunchRow,
+  event: OfficialMainTokenLaunchEvent,
+  release: DataPipelineReleaseBinding,
+) {
+  const { classicV2 } = officialMainTokenSourceBindings(release);
+  const payload = event.decodedPayload;
+  const sameHex = (left: string, right: string) =>
+    left.toLowerCase() === right.toLowerCase();
+  if (
+    BigInt(event.blockNumber) < BigInt(classicV2.activationBlock) ||
+    BigInt(launch.updatedBlock) < BigInt(event.blockNumber) ||
+    !sameHex(payload.launchHash!, launch.launchHash) ||
+    !sameHex(payload.token!, launch.token) ||
+    !sameHex(payload.creator!, launch.creator) ||
+    !sameHex(payload.poolId!, launch.poolId) ||
+    !sameHex(payload.feeHook!, launch.hook) ||
+    !sameHex(payload.positionRecipient!, launch.positionRecipient) ||
+    payload.positionTokenId !== launch.positionTokenId ||
+    payload.totalSwapFeeBps !== String(launch.totalSwapFeeBps)
+  ) {
+    throw new Error("Official main token event binding failed");
+  }
+}
+
 function parseRows(response: unknown, field: "Launch" | "ChainEvent") {
   if (
     !isRecord(response) ||
@@ -763,11 +1069,51 @@ async function readClassicV3Rows(
   });
 }
 
+async function readOfficialMainToken(
+  release: DataPipelineReleaseBinding,
+  anchorBlock: string,
+  fetcher: DataPipelineFetcher,
+) {
+  const response = await graphqlRequest(release, {
+    query: OFFICIAL_MAIN_TOKEN_QUERY,
+    variables: { anchorBlock },
+  }, fetcher);
+  if (
+    !isRecord(response) ||
+    !hasOnlyKeys(response, ["data"]) ||
+    !isRecord(response.data) ||
+    !hasOnlyKeys(response.data, ["OfficialLaunch", "OfficialEvent"]) ||
+    !Array.isArray(response.data.OfficialLaunch) ||
+    !Array.isArray(response.data.OfficialEvent) ||
+    response.data.OfficialLaunch.length !== 1 ||
+    response.data.OfficialEvent.length !== 1
+  ) {
+    throw new Error("Official main token Envio coverage is incomplete");
+  }
+  const launch = parseOfficialMainTokenLaunch(
+    response.data.OfficialLaunch[0],
+    release,
+  );
+  const event = parseOfficialMainTokenEvent(
+    response.data.OfficialEvent[0],
+    release,
+  );
+  if (
+    BigInt(launch.updatedBlock) > BigInt(anchorBlock) ||
+    BigInt(event.blockNumber) > BigInt(anchorBlock)
+  ) {
+    throw new Error("Official main token exceeds Envio progress");
+  }
+  assertOfficialMainTokenBinding(launch, event, release);
+  return Object.freeze({ launch, event });
+}
+
 function validTokenMetadata(
   tokenAddress: Address,
   nameValue: unknown,
   symbolValue: unknown,
   decimalsValue: unknown,
+  extendedValue?: unknown,
 ): TokenMetadata {
   const name = typeof nameValue === "string" ? nameValue.trim() : "";
   const symbol = typeof symbolValue === "string" ? symbolValue.trim() : "";
@@ -788,11 +1134,31 @@ function validTokenMetadata(
   ) {
     throw new Error(`Token metadata is invalid for ${tokenAddress}`);
   }
+  const extended = Array.isArray(extendedValue) && extendedValue.length === 4
+    ? extendedValue
+    : null;
+  const rawDescription = extended?.[0];
+  const description = typeof rawDescription === "string"
+    ? rawDescription.trim()
+    : "";
+  const safeDescription = description &&
+      utf8ByteLength(description) <= MAX_TOKEN_DESCRIPTION_BYTES &&
+      !hasUnsafeDisplayCharacters(description)
+    ? description
+    : undefined;
+  const imageUrl = sanitizeImageUrl(extended?.[2]) ?? undefined;
+  const extraData = typeof extended?.[3] === "string" && isHex(extended[3])
+    ? extended[3] as Hex
+    : "0x";
+  const links = buildTokenLinks(extended?.[1], extraData);
   return Object.freeze({
     tokenAddress,
     name,
     symbol,
     decimals: decimalsValue,
+    ...(safeDescription ? { description: safeDescription } : {}),
+    ...(imageUrl ? { imageUrl } : {}),
+    ...(links.length > 0 ? { links } : {}),
   });
 }
 
@@ -868,6 +1234,7 @@ async function defaultReadRpcSnapshot(input: Readonly<{
           { address: tokenAddress, abi: uerc20ReadAbi, functionName: "name" as const },
           { address: tokenAddress, abi: uerc20ReadAbi, functionName: "symbol" as const },
           { address: tokenAddress, abi: uerc20ReadAbi, functionName: "decimals" as const },
+          { address: tokenAddress, abi: uerc20ReadAbi, functionName: "metadata" as const },
         ]);
         const results = await client.multicall({
           contracts,
@@ -875,9 +1242,10 @@ async function defaultReadRpcSnapshot(input: Readonly<{
           allowFailure: true,
         });
         return tokens.map((tokenAddress, index) => {
-          const name = results[index * 3];
-          const symbol = results[index * 3 + 1];
-          const decimals = results[index * 3 + 2];
+          const name = results[index * 4];
+          const symbol = results[index * 4 + 1];
+          const decimals = results[index * 4 + 2];
+          const extended = results[index * 4 + 3];
           if (
             name?.status !== "success" ||
             symbol?.status !== "success" ||
@@ -890,6 +1258,7 @@ async function defaultReadRpcSnapshot(input: Readonly<{
             name.result,
             symbol.result,
             decimals.result,
+            extended?.status === "success" ? extended.result : undefined,
           );
         });
       },
@@ -908,9 +1277,13 @@ async function defaultReadRpcSnapshot(input: Readonly<{
 function buildEntries(
   launches: readonly EnvioClassicV3LaunchRow[],
   events: ReadonlyMap<string, EnvioClassicV3LaunchEvent>,
+  official: Readonly<{
+    launch: OfficialMainTokenLaunchRow;
+    event: OfficialMainTokenLaunchEvent;
+  }>,
   metadata: ReadonlyMap<string, TokenMetadata>,
 ) {
-  return Object.freeze(launches.map((launch) => {
+  const classicEntries = launches.map((launch) => {
     const event = events.get(launch.launchOccurrenceId);
     const tokenMetadata = metadata.get(launch.token.toLowerCase());
     if (!event || !tokenMetadata) {
@@ -924,6 +1297,11 @@ function buildEntries(
       id: `1:${launch.token.toLowerCase()}`,
       name: tokenMetadata.name,
       symbol: tokenMetadata.symbol,
+      ...(tokenMetadata.description
+        ? { description: tokenMetadata.description }
+        : {}),
+      ...(tokenMetadata.imageUrl ? { imageUrl: tokenMetadata.imageUrl } : {}),
+      ...(tokenMetadata.links ? { links: tokenMetadata.links } : {}),
       tokenAddress: launch.token,
       hookAddress: launch.hook,
       poolId: launch.poolId,
@@ -960,7 +1338,58 @@ function buildEntries(
       liquidityPath: "meme",
     };
     return canonicalTokenExploreEntryV1(token);
-  }));
+  });
+  const officialMetadata = metadata.get(official.launch.token.toLowerCase());
+  if (!officialMetadata) {
+    throw new Error("Official main token metadata is not hydrated");
+  }
+  const officialToken: LauncherToken = {
+    id: `1:${official.launch.token.toLowerCase()}`,
+    name: officialMetadata.name,
+    symbol: officialMetadata.symbol,
+    ...(officialMetadata.description
+      ? { description: officialMetadata.description }
+      : {}),
+    ...(officialMetadata.imageUrl ? { imageUrl: officialMetadata.imageUrl } : {}),
+    ...(officialMetadata.links ? { links: officialMetadata.links } : {}),
+    tokenAddress: official.launch.token,
+    hookAddress: official.launch.hook,
+    poolId: official.launch.poolId,
+    creatorAddress: official.launch.creator,
+    positionRecipient: official.launch.positionRecipient,
+    positionTokenId: official.launch.positionTokenId,
+    launchHash: official.launch.launchHash,
+    launchBlockNumber: official.event.blockNumber,
+    launchTransactionHash: official.event.transactionHash,
+    launchTransactionIndex: official.event.transactionIndex,
+    launchLogIndex: official.event.blockGlobalLogIndex,
+    launchedAt: new Date(
+      Number(BigInt(official.event.blockTimestamp)) * 1_000,
+    ).toISOString(),
+    totalSupply: formatUnits(
+      BigInt(official.launch.totalSupply),
+      officialMetadata.decimals,
+    ),
+    totalSupplyRaw: official.launch.totalSupply,
+    tokenDecimals: officialMetadata.decimals,
+    tokenLiquidityAmountRaw: official.launch.tokenLiquidityAmount,
+    lockedTokenDustRaw: official.launch.lockedTokenDust,
+    quoteAssetAddress: NATIVE_CURRENCY_ADDRESS,
+    quoteAssetSymbol: "ETH",
+    quoteAssetName: "Ether",
+    totalSwapFeeBps: official.launch.totalSwapFeeBps,
+    initialTick: official.launch.initialTick,
+    tickLower: official.launch.tickLower,
+    tickUpper: official.launch.tickUpper,
+    lpFeePips: official.launch.lpFeePips,
+    launchModel: "classic",
+    launchModelVersion: "classic-v2",
+    liquidityPath: "meme",
+  };
+  return Object.freeze([
+    ...classicEntries,
+    canonicalTokenExploreEntryV1(officialToken),
+  ]);
 }
 
 async function readUncached(
@@ -983,14 +1412,21 @@ async function readUncached(
   if (sourceLag < 0n || sourceLag > BigInt(release.confirmations)) {
     throw new Error("Envio Classic V3 indexer freshness is invalid");
   }
-  const rows = await readClassicV3Rows(
-    release,
-    progress.progressBlock,
-    fetcher,
-  );
+  const [rows, official] = await Promise.all([
+    readClassicV3Rows(release, progress.progressBlock, fetcher),
+    readOfficialMainToken(release, progress.progressBlock, fetcher),
+  ]);
+  if (rows.launches.some((launch) =>
+    launch.token.toLowerCase() === official.launch.token.toLowerCase()
+  )) {
+    throw new Error("Official main token identity collides with Classic V3");
+  }
   const rpc = await (dependencies.readRpcSnapshot ?? defaultReadRpcSnapshot)({
     anchorBlock: progress.progressBlock,
-    tokens: rows.launches.map((launch) => launch.token),
+    tokens: [
+      ...rows.launches.map((launch) => launch.token),
+      official.launch.token,
+    ],
     deadlineMs: options.deadlineMs,
     signal: options.signal,
   });
@@ -998,7 +1434,7 @@ async function readUncached(
   if (
     rpcLag < 0n ||
     rpcLag > BigInt(release.confirmations) + MAXIMUM_RPC_HEAD_SKEW_BLOCKS ||
-    rpc.metadata.size !== rows.launches.length
+    rpc.metadata.size !== rows.launches.length + 1
   ) {
     throw new Error("Envio Classic V3 RPC freshness or metadata coverage failed");
   }
@@ -1020,7 +1456,7 @@ async function readUncached(
   const generatedAt = new Date(
     Number(BigInt(rpc.anchorBlockTimestamp)) * 1_000,
   ).toISOString();
-  const entries = buildEntries(rows.launches, rows.events, rpc.metadata);
+  const entries = buildEntries(rows.launches, rows.events, official, rpc.metadata);
   const evidenceCore = {
     deployment: progress.deployment,
     sourceCommit: release.envio.sourceCommit,
@@ -1050,6 +1486,7 @@ async function readUncached(
     scope: Object.freeze({
       included: Object.freeze([
         "classic-v3",
+        "official-main-token",
         "registry.custom-launched",
       ] as const),
       excluded: Object.freeze([

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -520,6 +520,7 @@ export type LauncherToken = {
     | "stock-paired"
     | "custom-graph";
   launchModelVersion?:
+    | "classic-v2"
     | "classic-v3"
     | "stock-paired-v1"
     | "stock-paired-v2"

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -6,6 +6,8 @@ const ADDRESS = /^0x[0-9a-f]{40}$/u;
 const POSITIVE_INTEGER = /^[1-9][0-9]*$/u;
 const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
 const CATALOG_SOURCES = new Set(["envio-classic-v3"]);
+const PROGRAMMABLE_MAIN_ASSET_ADDRESS =
+  "0x7987f03462200b3d8a072e02c89a8a41dcb124ee";
 const CATALOG_STATUSES = new Set([
   "current",
   "last-known-good",
@@ -98,11 +100,15 @@ function exactExplorePage(response, tokens, expected = { page: 1, pageSize: 20 }
 function exactIdentity(token) {
   if (typeof token?.id !== "string" || token.id.trim() === "") return null;
   if (token.exploreKind === "token") {
+    const tokenAddress = String(token.tokenAddress ?? "").toLowerCase();
+    const exactOfficialException =
+      tokenAddress === PROGRAMMABLE_MAIN_ASSET_ADDRESS &&
+      token.launchModelVersion === "classic-v2";
     if (
-      !ADDRESS.test(String(token.tokenAddress ?? "").toLowerCase()) ||
+      !ADDRESS.test(tokenAddress) ||
       !/^0x[0-9a-f]{64}$/u.test(String(token.poolId ?? "").toLowerCase()) ||
       token.launchModel !== "classic" ||
-      token.launchModelVersion !== "classic-v3" ||
+      (token.launchModelVersion !== "classic-v3" && !exactOfficialException) ||
       token.launchStampProvenance !== undefined
     ) return null;
     return JSON.stringify([
@@ -310,6 +316,7 @@ function exactCatalogSnapshot(response) {
     ["current", "unavailable"].includes(customStatus) &&
     JSON.stringify(catalog.scope?.included) === JSON.stringify([
       "classic-v3",
+      "official-main-token",
       "registry.custom-launched",
     ]) &&
     JSON.stringify(catalog.scope?.excluded) === JSON.stringify([

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -113,7 +113,11 @@ function catalog() {
       custom: "unavailable",
     },
     scope: {
-      included: ["classic-v3", "registry.custom-launched"],
+      included: [
+        "classic-v3",
+        "official-main-token",
+        "registry.custom-launched",
+      ],
       excluded: [
         "classic-v1",
         "classic-v2",

--- a/tests/envio-classic-v3-catalog.test.ts
+++ b/tests/envio-classic-v3-catalog.test.ts
@@ -16,6 +16,12 @@ const ANCHOR_BLOCK = 25_770_000;
 const EVENT_BLOCK = 25_639_700;
 const STATE_BLOCK_HASH = `0x${"ee".repeat(32)}` as const;
 const STATE_TRANSACTION_HASH = `0x${"ff".repeat(32)}` as const;
+const PROGRAMMABLE_MAIN_ASSET_ADDRESS =
+  "0x7987f03462200b3d8a072e02c89a8a41dcb124ee" as const;
+const OFFICIAL_LAUNCH_HASH =
+  "0xf62bfccb2c0e3832607d8e6c48c00b0411d1d9bf12337fd039c4821d25e8cd20" as const;
+const OFFICIAL_OCCURRENCE =
+  "1:0x17e7e16d94fdf07c3d06586080c68264a39756b326ecf9d55d5170542d8b733d:0x47668b99d392ba82fc82d2a38413bd679e6ec8a04e5cf9535bff2c558259732a:976" as const;
 
 function hex32(value: number) {
   return `0x${value.toString(16).padStart(64, "0")}` as const;
@@ -154,6 +160,91 @@ function eventFixture(launch: ReturnType<typeof launchFixture>) {
   };
 }
 
+function officialLaunchFixture() {
+  const hook = release.sources.find(
+    (source) => source.contractName === "ClassicV2Hook",
+  )!.address;
+  return {
+    id: `1:classic-v2:${OFFICIAL_LAUNCH_HASH}`,
+    chainId: 1,
+    model: "classic",
+    releaseVersion: "classic-v2",
+    launchHash: OFFICIAL_LAUNCH_HASH,
+    token: PROGRAMMABLE_MAIN_ASSET_ADDRESS,
+    creator: "0x2bb333d48dfaf1596d9036671d2e43168994249e",
+    quoteAsset: null,
+    poolId: "0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0",
+    hook,
+    rewardVault: null,
+    positionRecipient: "0xe68da18043623c31a93426b084c0ad1ca494c566",
+    positionTokenId: "352224",
+    totalSwapFeeBps: 100,
+    buySwapFeeBps: null,
+    sellSwapFeeBps: null,
+    rewardConfigurationHash: null,
+    quoteConfigurationHash: null,
+    totalSupply: "1000000000000000000000000000",
+    tokenLiquidityAmount: "999999999999999999999987736",
+    lockedTokenDust: "12264",
+    initialTick: 204200,
+    tickLower: -887200,
+    tickUpper: 204200,
+    lpFeePips: 0,
+    launchOccurrenceId: OFFICIAL_OCCURRENCE,
+    liquidityOccurrenceId: `${OFFICIAL_OCCURRENCE}:liquidity`,
+    initialBuyOccurrenceId: `${OFFICIAL_OCCURRENCE}:buy`,
+    custodyOccurrenceId: null,
+    coordinatorOccurrenceId: null,
+    hasLaunchEvent: true,
+    hasLiquidityEvent: true,
+    hasInitialBuyEvent: true,
+    hasCustodyEvent: false,
+    hasCoordinatorEvent: false,
+    hasPoolRegistrationEvent: true,
+    hasPoolFeeDisclosureEvent: true,
+    hasRewardVaultFactoryEvent: false,
+    provenanceValid: true,
+    isComplete: true,
+    updatedBlock: "25627056",
+  };
+}
+
+function officialEventFixture() {
+  const launch = officialLaunchFixture();
+  const launcher = release.sources.find(
+    (source) => source.contractName === "ClassicV2Launcher",
+  )!.address;
+  const [, blockHash, transactionHash, logIndex] = OFFICIAL_OCCURRENCE.split(":");
+  return {
+    id: OFFICIAL_OCCURRENCE,
+    downstreamLogicalId: null,
+    receiptLogOrdinal: null,
+    chainId: 1,
+    blockNumber: "25627056",
+    blockHash,
+    blockTimestamp: "1785190343",
+    transactionHash,
+    transactionIndex: "279",
+    blockGlobalLogIndex: logIndex,
+    sourceAddress: launcher,
+    contractName: "ClassicV2Launcher",
+    eventName: "MemeTokenLaunched",
+    model: "classic",
+    releaseVersion: "classic-v2",
+    decodedPayload: JSON.stringify({
+      creator: launch.creator,
+      feeHook: launch.hook,
+      launchHash: launch.launchHash,
+      poolId: launch.poolId,
+      positionRecipient: launch.positionRecipient,
+      positionTokenId: launch.positionTokenId,
+      token: launch.token,
+      totalSwapFeeBps: String(launch.totalSwapFeeBps),
+    }),
+    payloadHash: hex32(70_000),
+  };
+}
+
 function json(value: unknown, status = 200) {
   return new Response(JSON.stringify(value), {
     status,
@@ -193,6 +284,14 @@ function harness(input: {
       events = input.mutateEvents?.(events) ?? events;
       return json({ data: { ChainEvent: events } });
     }
+    if (request.query.includes("ProgrammableOfficialMainToken")) {
+      return json({
+        data: {
+          OfficialLaunch: [officialLaunchFixture()],
+          OfficialEvent: [officialEventFixture()],
+        },
+      });
+    }
     throw new Error("Unexpected Envio query");
   });
   const readRpcSnapshot = vi.fn(async ({
@@ -210,6 +309,16 @@ function harness(input: {
       name: `Token ${index + 1}`,
       symbol: `T${index + 1}`,
       decimals: 18,
+      ...(token.toLowerCase() === PROGRAMMABLE_MAIN_ASSET_ADDRESS
+        ? {
+            description: "The official Programmable token",
+            imageUrl: "https://assets.example/programmble.webp",
+            links: [
+              { kind: "website" as const, url: "https://programmable.family/" },
+              { kind: "x" as const, url: "https://x.com/programmable" },
+            ],
+          }
+        : {}),
     }])),
     observedAnchorBlock: anchorBlock,
   }));
@@ -218,7 +327,7 @@ function harness(input: {
 
 describe("Envio Classic V3 public catalog", () => {
   it("bounds RPC metadata work to 96 calls and two concurrent batches", () => {
-    expect(ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE).toBe(32);
+    expect(ENVIO_CLASSIC_V3_TOKEN_METADATA_BATCH_SIZE).toBe(24);
     expect(ENVIO_CLASSIC_V3_TOKEN_METADATA_CONCURRENCY).toBe(2);
   });
 
@@ -236,7 +345,11 @@ describe("Envio Classic V3 public catalog", () => {
       asOfBlock: String(ANCHOR_BLOCK),
       completeness: { classic: "current", stock: "excluded", custom: "unavailable" },
       scope: {
-        included: ["classic-v3", "registry.custom-launched"],
+        included: [
+          "classic-v3",
+          "official-main-token",
+          "registry.custom-launched",
+        ],
         excluded: [
           "classic-v1",
           "classic-v2",
@@ -253,8 +366,13 @@ describe("Envio Classic V3 public catalog", () => {
         progressBlock: String(ANCHOR_BLOCK),
       },
     });
-    expect(catalog.entries).toHaveLength(65);
-    expect(catalog.entries.every((entry) =>
+    expect(catalog.entries).toHaveLength(66);
+    const classicV3Entries = catalog.entries.filter((entry) =>
+      entry.exploreKind === "token" &&
+      entry.launchModelVersion === "classic-v3"
+    );
+    expect(classicV3Entries).toHaveLength(65);
+    expect(classicV3Entries.every((entry) =>
       entry.exploreKind === "token" &&
       entry.launchModel === "classic" &&
       entry.launchModelVersion === "classic-v3" &&
@@ -263,6 +381,24 @@ describe("Envio Classic V3 public catalog", () => {
         entry.sellHookFeeBps ?? 0,
       )
     )).toBe(true);
+    expect(catalog.entries.find((entry) =>
+      entry.exploreKind === "token" &&
+      entry.tokenAddress.toLowerCase() === PROGRAMMABLE_MAIN_ASSET_ADDRESS
+    )).toMatchObject({
+      launchModel: "classic",
+      launchModelVersion: "classic-v2",
+      totalSwapFeeBps: 100,
+      description: "The official Programmable token",
+      imageUrl: "https://assets.example/programmble.webp",
+      links: [
+        { kind: "website", url: "https://programmable.family/" },
+        { kind: "x", url: "https://x.com/programmable" },
+      ],
+    });
+    expect(catalog.entries.filter((entry) =>
+      entry.exploreKind === "token" &&
+      entry.launchModelVersion === "classic-v2"
+    )).toHaveLength(1);
     expect(test.requests.filter((request) =>
       request.query.includes("ProgrammableClassicV3Catalog")
     )).toHaveLength(2);

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -110,7 +110,11 @@ function catalog(overrides: Record<string, unknown> = {}) {
       custom: "unavailable",
     },
     scope: {
-      included: ["classic-v3", "registry.custom-launched"],
+      included: [
+        "classic-v3",
+        "official-main-token",
+        "registry.custom-launched",
+      ],
       excluded: [
         "classic-v1",
         "classic-v2",

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -120,7 +120,11 @@ const catalogBoundary = {
     custom: "current" as const,
   },
   scope: {
-    included: ["classic-v3", "registry.custom-launched"] as const,
+    included: [
+      "classic-v3",
+      "official-main-token",
+      "registry.custom-launched",
+    ] as const,
     excluded: [
       "classic-v1",
       "classic-v2",

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -57,8 +57,9 @@ describe("interaction accessibility", () => {
       '<section\n      className={styles.tradeForm}',
     );
     expect(tokenSource).toContain(
-      '<nav className={styles.links} aria-label={`${token.name} links`}>',
+      'className={`${styles.links} ${styles.addressLinks}`}',
     );
+    expect(tokenSource).toContain('aria-label={`${token.name} links`}');
     expect(tokenSource).toContain(
       '<nav className={styles.links} aria-label={`${project.name} links`}>',
     );

--- a/tests/launch-stamp-surfaces.test.ts
+++ b/tests/launch-stamp-surfaces.test.ts
@@ -208,7 +208,11 @@ describe("canonical Router stamp surfaces", () => {
             custom: "current",
           },
           scope: {
-            included: ["classic-v3", "registry.custom-launched"],
+            included: [
+              "classic-v3",
+              "official-main-token",
+              "registry.custom-launched",
+            ],
             excluded: [
               "classic-v1",
               "classic-v2",

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -104,7 +104,11 @@ function catalog() {
       custom: "unavailable",
     },
     scope: {
-      included: ["classic-v3", "registry.custom-launched"],
+      included: [
+        "classic-v3",
+        "official-main-token",
+        "registry.custom-launched",
+      ],
       excluded: [
         "classic-v1",
         "classic-v2",


### PR DESCRIPTION
Adds the exact verified Programmable main token as the sole Classic V2 public exception.

Hydrates fail-soft onchain images, Website, X and Telegram for canonical catalog entries, preserves identities on metadata failure, adds visible CA copy confirmation, and positions social links beside the CA on cards and token details.

Validation: focused catalog/API/UI/smoke tests, typecheck, changed-path ESLint, production build.