### PR TITLE
Polish mobile Explore navigation

### DIFF
--- a/app/interface.css
+++ b/app/interface.css
@@ -219,6 +219,10 @@ code,
   outline-offset: 6px;
 }
 
+.route-transition h1[data-route-announcement-focus="true"]:focus {
+  outline: 0;
+}
+
 .app-frame::before,
 html[data-theme="dark"] .app-frame::before {
   background: transparent;

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1356,43 +1356,57 @@
 @media (max-width: 700px) {
   .page {
     min-height: calc(100svh - 72px);
-    padding-block: 24px 56px;
+    padding-block: 16px 48px;
   }
 
   .pageHeading {
-    min-height: 66px;
+    min-height: 0;
     padding: 0;
   }
 
   .pageHeading h1 {
-    font-size: clamp(46px, 14vw, 62px);
+    font-size: clamp(38px, 11vw, 48px);
     max-width: none;
   }
 
   .runnersIntro {
-    margin-top: 22px;
+    margin-top: 16px;
   }
 
   .runnersIntro :global(.token-toolbar) {
     align-items: stretch;
     display: grid;
+    gap: 8px;
+    grid-template-areas:
+      "search search"
+      "pages sort";
     grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .runnersIntro :global(.token-search) {
+    grid-area: search;
     max-width: none;
     width: 100%;
   }
 
+  .runnersIntro :global(.token-filter) {
+    grid-area: sort;
+    justify-self: end;
+  }
+
   .runnersIntro :global(.token-pagination) {
-    grid-column: 1 / -1;
+    grid-area: pages;
     justify-self: start;
   }
 
   .runnerGrid {
-    gap: 14px;
-    grid-template-columns: 1fr;
-    margin-top: 24px;
+    gap: 10px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-top: 16px;
+  }
+
+  .revealedGrid .runnerCard:nth-child(n + 5) {
+    display: none;
   }
 
   .runnerCard {
@@ -1403,24 +1417,59 @@
 
   .runnerHitArea {
     display: flex;
+    flex-direction: column;
   }
 
   .runnerArt {
-    aspect-ratio: 2.2 / 1;
+    aspect-ratio: 1.7 / 1;
     width: 100%;
   }
 
   .runnerBody {
-    min-height: 112px;
-    padding: 17px 16px 13px;
+    min-height: 72px;
+    padding: 12px 12px 10px;
   }
 
   .runnerHeading h3 {
-    font-size: 22px;
+    font-size: 17px;
+    letter-spacing: -0.025em;
+  }
+
+  .runnerHeading > span {
+    font-size: 10px;
+  }
+
+  .runnerData {
+    gap: 8px;
+    margin-top: 10px;
+  }
+
+  .runnerData small {
+    font-size: 10px;
+  }
+
+  .runnerData strong {
+    font-size: 12px;
   }
 
   .runnerMeta {
-    padding-inline-start: 12px;
+    min-height: 40px;
+    padding: 0 6px 0 10px;
+  }
+
+  .runnerCategory,
+  .runnerMarketStatus {
+    font-size: 10px;
+  }
+
+  .runnerContract {
+    display: none;
+  }
+
+  .runnerSocials {
+    flex-basis: auto;
+    justify-content: flex-end;
+    margin-inline-start: auto;
   }
 }
 
@@ -1464,16 +1513,15 @@
 
 @media (max-width: 360px) {
   .runnersIntro :global(.token-toolbar) {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr) auto;
   }
 
-  .runnersIntro :global(.token-filter),
   .runnersIntro :global(.token-filter summary) {
-    width: 100%;
+    min-width: 108px;
   }
 
   .runnersIntro :global(.token-pagination) {
-    grid-column: auto;
+    grid-area: pages;
   }
 
   /* Keep the filter affordance legible at the narrowest supported width.

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -11,7 +11,13 @@ import {
   Search,
   X as CloseIcon,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import {
   formatMarketCapMetric,
@@ -255,7 +261,42 @@ export function preserveExplorePayloadOnRefreshFailure(
 type PaginationItem = number | "start-gap" | "end-gap";
 
 export const EXPLORE_TOKENS_PER_PAGE = 9;
+export const EXPLORE_MOBILE_TOKENS_PER_PAGE = 4;
+export const EXPLORE_MOBILE_BREAKPOINT_PX = 700;
 export const EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE = 100;
+
+const EXPLORE_MOBILE_MEDIA_QUERY = `(max-width: ${EXPLORE_MOBILE_BREAKPOINT_PX}px)`;
+
+export function exploreTokensPerPageForViewport(width: number) {
+  return width <= EXPLORE_MOBILE_BREAKPOINT_PX
+    ? EXPLORE_MOBILE_TOKENS_PER_PAGE
+    : EXPLORE_TOKENS_PER_PAGE;
+}
+
+function subscribeToExploreViewport(onChange: () => void) {
+  const query = window.matchMedia(EXPLORE_MOBILE_MEDIA_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function exploreMobileViewportSnapshot() {
+  return window.matchMedia(EXPLORE_MOBILE_MEDIA_QUERY).matches;
+}
+
+function exploreMobileViewportServerSnapshot() {
+  return false;
+}
+
+function useExploreTokensPerPage() {
+  const mobile = useSyncExternalStore(
+    subscribeToExploreViewport,
+    exploreMobileViewportSnapshot,
+    exploreMobileViewportServerSnapshot,
+  );
+  return mobile
+    ? EXPLORE_MOBILE_TOKENS_PER_PAGE
+    : EXPLORE_TOKENS_PER_PAGE;
+}
 const QUERY_DEBOUNCE_MS = 200;
 const EXPLORE_REQUEST_TIMEOUT_MS = 12_000;
 export const EXPLORE_REFRESH_INTERVAL_MS = LIVE_DATA_REFRESH_INTERVAL_MS;
@@ -1534,12 +1575,14 @@ export function paginateExploreModelDataset(
   dataset: ExplorePayload,
   modelFilter: ExploreModelFilter,
   requestedPage: number,
+  pageSize = EXPLORE_TOKENS_PER_PAGE,
 ): ExplorePayload {
   const page = paginateTokensByExploreFilters(
     dataset.tokens,
     "all",
     modelFilter,
     requestedPage,
+    pageSize,
   );
   return {
     status: dataset.status,
@@ -1779,12 +1822,6 @@ export function exploreDataQualityMessage(
   quality: ExploreDataQuality | undefined,
 ) {
   if (!quality) return null;
-  if (quality.launchIdentity.status === "partial") {
-    return `Partial launch index · last indexed ${quality.generatedAt.slice(0, 10)}`;
-  }
-  if (quality.launchIdentity.status === "last-known-good") {
-    return `Launch index may be out of date · last indexed ${quality.generatedAt.slice(0, 10)}`;
-  }
   if (quality.valuation.status === "stale") {
     return "Prices may be out of date";
   }
@@ -1806,6 +1843,7 @@ export function ExploreView({
   const [socialFilter, setSocialFilter] = useState<ExploreSocialFilter>("all");
   const [modelFilter, setModelFilter] = useState<ExploreModelFilter>("all");
   const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = useExploreTokensPerPage();
   const [retryKey, setRetryKey] = useState(0);
   const [copyFeedback, setCopyFeedback] = useState("");
   const refreshKey = useLiveDataRefresh({
@@ -1820,7 +1858,7 @@ export function ExploreView({
     payload: ExplorePayload;
   } | null>(null);
   const filterRef = useRef<HTMLDetailsElement>(null);
-  const contentKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}`;
+  const contentKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
   const requestKey = `${contentKey}\u0000${retryKey}\u0000${refreshKey}`;
   const modelDatasetKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}\u0000${refreshKey}`;
   const activeRequestContentKey =
@@ -1888,6 +1926,10 @@ export function ExploreView({
   }, [debouncedQuery, normalizedQuery]);
 
   useEffect(() => {
+    return subscribeToExploreViewport(() => setCurrentPage(1));
+  }, []);
+
+  useEffect(() => {
     function closeFilter(event: PointerEvent | KeyboardEvent) {
       const filter = filterRef.current;
       if (!filter?.open) return;
@@ -1944,7 +1986,7 @@ export function ExploreView({
       q: debouncedQuery,
       sort,
       page: String(currentPage),
-      limit: String(EXPLORE_TOKENS_PER_PAGE),
+      limit: String(pageSize),
     });
     if (socialFilter !== "all") {
       search.set("socials", socialFilter);
@@ -1981,6 +2023,7 @@ export function ExploreView({
             dataset,
             modelFilter,
             currentPage,
+            pageSize,
           );
         }
         if (ignore) return;
@@ -2021,6 +2064,7 @@ export function ExploreView({
     activeRequestContentKey,
     modelDatasetKey,
     modelFilter,
+    pageSize,
     initialState,
     loadingOnly,
     preview,
@@ -2055,13 +2099,14 @@ export function ExploreView({
       socialFilter,
       modelFilter,
       currentPage,
+      pageSize,
     );
 
     return {
       status: "ready",
       ...paginated,
     };
-  }, [currentPage, debouncedQuery, modelFilter, socialFilter, sort]);
+  }, [currentPage, debouncedQuery, modelFilter, pageSize, socialFilter, sort]);
 
   const displayState: ExploreState = preview
     ? {
@@ -2226,9 +2271,9 @@ export function ExploreView({
                   src={imageSource}
                   alt={token.usesFallbackImage ? "" : `${token.name} artwork`}
                   fill
-                  loading={index < 3 ? "eager" : "lazy"}
-                  priority={index < 3}
-                  sizes="(max-width: 360px) 96px, (max-width: 700px) 104px, (max-width: 768px) calc(50vw - 54px), (max-width: 900px) 330px, 299px"
+                  loading={index < Math.min(pageSize, 4) ? "eager" : "lazy"}
+                  priority={index < Math.min(pageSize, 4)}
+                  sizes="(max-width: 700px) calc((100vw - 42px) / 2), (max-width: 900px) 330px, 299px"
                   unoptimized={!canOptimizeTokenImage(imageSource)}
                   draggable={false}
                 />

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -46,8 +46,9 @@ export function LandingPage() {
 
       if (window.location.hash !== "#explore") return;
 
-      const target = document.getElementById("explore");
-      const header = document.querySelector<HTMLElement>(".site-header");
+      const chapter = document.getElementById("explore");
+      const header = document.querySelector<HTMLElement>(".header-inner");
+      const target = chapter?.querySelector<HTMLElement>("h1") ?? chapter;
       if (!target) return;
 
       const headerHeight = header?.getBoundingClientRect().height ?? 0;

--- a/components/route-transition.tsx
+++ b/components/route-transition.tsx
@@ -64,6 +64,12 @@ export function RouteTransition({ children }: { children: ReactNode }) {
     const heading = contentRef.current?.querySelector<HTMLElement>("h1");
     if (heading) {
       heading.tabIndex = -1;
+      heading.dataset.routeAnnouncementFocus = "true";
+      heading.addEventListener(
+        "blur",
+        () => delete heading.dataset.routeAnnouncementFocus,
+        { once: true },
+      );
       heading.focus({ preventScroll: true });
       return;
     }

--- a/components/site-footer.module.css
+++ b/components/site-footer.module.css
@@ -153,22 +153,40 @@
 @media (max-width: 680px) {
   .footer {
     margin-bottom: 12px;
-    margin-top: 48px;
+    margin-top: 56px;
   }
 
   .surface {
-    gap: 28px 22px;
-    grid-template-columns: 1fr 1fr;
-    padding: 32px 0;
+    gap: 32px;
+    grid-template-columns: minmax(0, 1fr);
+    padding: 32px 0 calc(32px + env(safe-area-inset-bottom));
   }
 
   .brand,
+  .column,
   .risk {
     grid-column: 1 / -1;
   }
 
+  .brand {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .column {
+    gap: 8px;
+  }
+
+  .column ul {
+    gap: 0 20px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .column a {
+    margin-inline-start: 0;
     min-height: 44px;
+    padding-inline: 0;
   }
 
   .tagline {
@@ -178,13 +196,7 @@
 
 @media (max-width: 420px) {
   .surface {
-    gap: 24px 18px;
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .brand,
-  .risk {
-    grid-column: 1 / -1;
+    gap: 28px;
   }
 }
 

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -31,6 +31,35 @@ const desktopNavItems = [
 ];
 
 const mobileNavItems = desktopNavItems;
+const MOBILE_MENU_TRANSITION_MS = 300;
+
+function prepareLandingExploreNavigation(
+  event: MouseEvent<HTMLAnchorElement>,
+  pathname: string,
+  href: string,
+) {
+  if (
+    pathname !== "/" ||
+    href !== "/#explore" ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  ) {
+    return false;
+  }
+
+  event.preventDefault();
+  if (window.location.hash !== "#explore") {
+    window.history.pushState(null, "", "/#explore");
+  }
+  return true;
+}
+
+function alignLandingExplore() {
+  window.dispatchEvent(new Event("hashchange"));
+}
 
 function HeaderSocialLinks({ mobile = false }: { mobile?: boolean }) {
   return (
@@ -113,6 +142,7 @@ export function SiteHeader() {
   const menuId = useId();
   const headerRef = useRef<HTMLElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const exploreAlignmentTimerRef = useRef<number | null>(null);
   const [menuPath, setMenuPath] = useState<string | null>(null);
   const menuOpen = menuPath === pathname;
 
@@ -158,6 +188,27 @@ export function SiteHeader() {
     };
   }, [menuOpen]);
 
+  useEffect(
+    () => () => {
+      if (exploreAlignmentTimerRef.current !== null) {
+        window.clearTimeout(exploreAlignmentTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  function finishMobileNavigation(shouldAlignExplore: boolean) {
+    setMenuPath(null);
+    if (!shouldAlignExplore) return;
+    if (exploreAlignmentTimerRef.current !== null) {
+      window.clearTimeout(exploreAlignmentTimerRef.current);
+    }
+    exploreAlignmentTimerRef.current = window.setTimeout(() => {
+      exploreAlignmentTimerRef.current = null;
+      alignLandingExplore();
+    }, MOBILE_MENU_TRANSITION_MS + 20);
+  }
+
   return (
     <header ref={headerRef} className={`site-header ${styles.siteHeader}`}>
       <div className={`header-inner ${styles.headerInner}`}>
@@ -187,6 +238,17 @@ export function SiteHeader() {
               className={isCurrent(pathname, item) ? "active" : undefined}
               href={item.href}
               aria-current={isCurrent(pathname, item) ? "page" : undefined}
+              onClick={(event) => {
+                if (
+                  prepareLandingExploreNavigation(
+                    event,
+                    pathname,
+                    item.href,
+                  )
+                ) {
+                  alignLandingExplore();
+                }
+              }}
             >
               {item.label}
             </Link>
@@ -227,7 +289,7 @@ export function SiteHeader() {
           <MobileNavigation
             id={menuId}
             open={menuOpen}
-            onNavigate={() => setMenuPath(null)}
+            onNavigate={finishMobileNavigation}
           />
           <HeaderSocialLinks mobile />
         </div>
@@ -239,7 +301,7 @@ export function SiteHeader() {
 type MobileNavigationProps = {
   id?: string;
   open?: boolean;
-  onNavigate?: () => void;
+  onNavigate?: (shouldAlignExplore: boolean) => void;
 };
 
 export function MobileNavigation({
@@ -265,7 +327,17 @@ export function MobileNavigation({
             href={item.href}
             aria-current={current ? "page" : undefined}
             tabIndex={open ? undefined : -1}
-            onClick={onNavigate}
+            onClick={(event) => {
+              const shouldAlignExplore = prepareLandingExploreNavigation(
+                event,
+                pathname,
+                item.href,
+              );
+              onNavigate?.(shouldAlignExplore);
+              if (shouldAlignExplore && onNavigate === undefined) {
+                alignLandingExplore();
+              }
+            }}
           >
             <span>{item.label}</span>
           </Link>

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -69,7 +69,7 @@ describe("Explore UI contract", () => {
     );
   });
 
-  it("keeps nine stable cards and groups links next to market cap", () => {
+  it("keeps nine desktop cards and a compact four-card mobile page", () => {
     const source = readFileSync(
       join(root, "components/explore-view.tsx"),
       "utf8",
@@ -80,6 +80,9 @@ describe("Explore UI contract", () => {
     );
 
     expect(source).toContain("export const EXPLORE_TOKENS_PER_PAGE = 9");
+    expect(source).toContain("export const EXPLORE_MOBILE_TOKENS_PER_PAGE = 4");
+    expect(source).toContain("const pageSize = useExploreTokensPerPage()");
+    expect(source).toContain("limit: String(pageSize)");
     expect(styles).toMatch(
       /\.runnerGrid\s*\{[^}]*grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\);[^}]*width:\s*100%;/s,
     );
@@ -87,8 +90,14 @@ describe("Explore UI contract", () => {
       /\.runnerArt\s*\{[^}]*aspect-ratio:\s*1;[^}]*width:\s*100%;/s,
     );
     expect(styles).toMatch(/\.runnerMeta\s*\{[^}]*gap:\s*4px;/s);
-    expect(styles).not.toMatch(
-      /\.runnerSocials\s*\{[^}]*margin-inline-start:\s*auto;/s,
+    expect(styles).toMatch(
+      /@media \(max-width: 700px\)[\s\S]*?grid-template-areas:[\s\S]*?"search search"[\s\S]*?"pages sort";/s,
+    );
+    expect(styles).toMatch(
+      /@media \(max-width: 700px\)[\s\S]*?\.runnerGrid\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/s,
+    );
+    expect(styles).toMatch(
+      /\.revealedGrid \.runnerCard:nth-child\(n \+ 5\)\s*\{[^}]*display:\s*none;/s,
     );
     expect(source).not.toContain("styles.runnerIndex");
     expect(source).not.toContain("styles.sortReadout");
@@ -100,7 +109,7 @@ describe("Explore UI contract", () => {
       /\.runnerHeading h3\s*\{[^}]*line-height:\s*1\.15;/s,
     );
     expect(source).toContain(
-      'sizes="(max-width: 360px) 96px, (max-width: 700px) 104px, (max-width: 768px) calc(50vw - 54px), (max-width: 900px) 330px, 299px"',
+      'sizes="(max-width: 700px) calc((100vw - 42px) / 2), (max-width: 900px) 330px, 299px"',
     );
     expect(source).not.toContain("<small>CA</small>");
     expect(source).not.toContain('valuationLabel ?? "Unavailable"');
@@ -162,6 +171,8 @@ describe("Explore UI contract", () => {
     expect(source).not.toContain("Loading tokens");
     expect(source).not.toContain("Updating tokens");
     expect(source).not.toContain("Page {activePage} of {pageCount}");
+    expect(source).not.toContain("Partial launch index");
+    expect(source).not.toContain("Launch index may be out of date");
   });
 
   it("keeps phone controls readable while narrow mouse windows retain desktop popovers", () => {

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  EXPLORE_MOBILE_TOKENS_PER_PAGE,
   EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
   EXPLORE_TOKENS_PER_PAGE,
   EXPLORE_REFRESH_INTERVAL_MS,
@@ -8,6 +9,7 @@ import {
   exploreDataQualityMessage,
   exploreAppliedSortLabel,
   exploreMarketStatusLabel,
+  exploreTokensPerPageForViewport,
   handledInitialExploreRequestKey,
   filterTokensByLaunchModel,
   filterTokensBySocialPresence,
@@ -397,8 +399,12 @@ describe("Explore refresh state", () => {
     ).toBeNull();
   });
 
-  it("uses a balanced nine-card page and compact desktop pagination", () => {
+  it("uses nine desktop cards and four mobile cards per page", () => {
     expect(EXPLORE_TOKENS_PER_PAGE).toBe(9);
+    expect(EXPLORE_MOBILE_TOKENS_PER_PAGE).toBe(4);
+    expect(exploreTokensPerPageForViewport(390)).toBe(4);
+    expect(exploreTokensPerPageForViewport(700)).toBe(4);
+    expect(exploreTokensPerPageForViewport(701)).toBe(9);
     expect(getExplorePaginationItems(1, 10)).toEqual([
       1,
       2,
@@ -1227,6 +1233,20 @@ describe("Explore refresh state", () => {
 
   it("does not surface a market availability banner", () => {
     expect(exploreDataQualityMessage(unavailableMarketDataQuality)).toBeNull();
+    expect(exploreDataQualityMessage({
+      ...unavailableMarketDataQuality,
+      launchIdentity: {
+        ...unavailableMarketDataQuality.launchIdentity,
+        status: "partial",
+      },
+    })).toBeNull();
+    expect(exploreDataQualityMessage({
+      ...unavailableMarketDataQuality,
+      launchIdentity: {
+        ...unavailableMarketDataQuality.launchIdentity,
+        status: "last-known-good",
+      },
+    })).toBeNull();
   });
 
   it("retries the first non-USD FDV and returns the second fail-closed", async () => {

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -103,6 +103,8 @@ describe("landing page contract", () => {
       'window.scrollTo({ behavior: "auto", left: 0, top: 0 })',
     );
     expect(landing).toContain('window.location.hash !== "#explore"');
+    expect(landing).toContain('document.querySelector<HTMLElement>(".header-inner")');
+    expect(landing).toContain('chapter?.querySelector<HTMLElement>("h1")');
     expect(landing).toContain('window.scrollTo({ behavior: "auto"');
     expect(landing).toContain("data-reveal-section");
     expect(landing).not.toContain('addEventListener("wheel"');
@@ -168,6 +170,16 @@ describe("landing page contract", () => {
     expect(navigation).toContain("onClick={restartHome}");
     expect(navigation).toContain("event.metaKey");
     expect(navigation).toContain("event.ctrlKey");
+  });
+
+  it("realigns a repeated home Explore activation after the mobile menu closes", () => {
+    const navigation = read("components/site-navigation.tsx");
+
+    expect(navigation).toContain("prepareLandingExploreNavigation(");
+    expect(navigation).toContain('window.history.pushState(null, "", "/#explore")');
+    expect(navigation).toContain('window.dispatchEvent(new Event("hashchange"))');
+    expect(navigation).toContain("MOBILE_MENU_TRANSITION_MS + 20");
+    expect(navigation).toContain("onNavigate={finishMobileNavigation}");
   });
 
   it("uses fluid shared gutters instead of a desktop to mobile width jump", () => {

--- a/tests/shell-polish.test.ts
+++ b/tests/shell-polish.test.ts
@@ -30,12 +30,17 @@ describe("public shell polish", () => {
 
   it("keeps route motion measured, interruptible and compositor-friendly", () => {
     const source = read("components/route-transition.tsx");
+    const interfaceStyles = read("app/interface.css");
 
     expect(source).toContain('"(prefers-reduced-motion: reduce)"');
     expect(source).toContain("routeAnimationRef.current?.cancel()");
     expect(source).toContain("translate3d(0, 12px, 0)");
     expect(source).toContain("duration: enteringDocs ? 420 : 720");
     expect(source).not.toContain("key={pathname}");
+    expect(source).toContain('heading.dataset.routeAnnouncementFocus = "true"');
+    expect(interfaceStyles).toMatch(
+      /h1\[data-route-announcement-focus="true"\]:focus\s*\{[^}]*outline:\s*0;/s,
+    );
   });
 
   it("renders one shared footer after every route and keeps it below the fold", () => {

--- a/tests/site-footer.test.ts
+++ b/tests/site-footer.test.ts
@@ -5,6 +5,10 @@ const footerSource = readFileSync(
   new URL("../components/site-footer.tsx", import.meta.url),
   "utf8",
 );
+const footerStyles = readFileSync(
+  new URL("../components/site-footer.module.css", import.meta.url),
+  "utf8",
+);
 
 describe("Site footer", () => {
   it("keeps the landing footer frameless and links Explore to the landing chapter", () => {
@@ -38,5 +42,17 @@ describe("Site footer", () => {
     expect(dune).toBeGreaterThan(dexscreener);
     expect(discord).toBeGreaterThan(dune);
     expect(footerSource).toContain('label: "Dune"');
+  });
+
+  it("stacks evenly aligned link groups on narrow screens", () => {
+    expect(footerStyles).toMatch(
+      /@media \(max-width: 680px\)[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/s,
+    );
+    expect(footerStyles).toMatch(
+      /@media \(max-width: 680px\)[\s\S]*?\.column ul\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/s,
+    );
+    expect(footerStyles).toMatch(
+      /@media \(max-width: 680px\)[\s\S]*?\.brand\s*\{[^}]*justify-content:\s*space-between;/s,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- show a compact 2x2, four-token page on mobile while preserving the 3x3 desktop grid
- reorganize mobile search, pagination, and sorting; remove launch-index status copy
- make repeated Explore navigation realign correctly, suppress only programmatic heading focus outlines, and rebalance the mobile footer

## Verification
- `npm run verify:interface:ci`
- focused Explore/landing/shell/footer tests: 76/76
- rendered Chromium QA: iPhone 13, 320px mobile, 1440px desktop; no overflow or console errors
- gitleaks exact commit range: no leaks