### PR TITLE
Keep mobile token copy controls visible

### DIFF
--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1458,8 +1458,10 @@
   }
 
   .runnerMeta {
-    min-height: 40px;
-    padding: 0 6px 0 10px;
+    align-content: center;
+    min-height: 76px;
+    padding: 0 4px;
+    row-gap: 0;
   }
 
   .runnerCategory,
@@ -1467,14 +1469,42 @@
     font-size: 10px;
   }
 
+  .runnerCategory {
+    order: 1;
+  }
+
+  .runnerMarketStatus {
+    margin-inline-start: auto;
+    order: 2;
+    padding-inline-end: 2px;
+  }
+
   .runnerContract {
-    display: none;
+    display: inline-flex;
+    gap: 0;
+    order: 3;
+  }
+
+  .runnerContract code {
+    font-size: 9px;
+  }
+
+  .runnerCopyButton {
+    height: 36px;
+    width: 28px;
   }
 
   .runnerSocials {
     flex-basis: auto;
     justify-content: flex-end;
     margin-inline-start: auto;
+    min-height: 36px;
+    order: 4;
+  }
+
+  .runnerSocialLink {
+    height: 36px;
+    width: 30px;
   }
 }
 
@@ -1517,6 +1547,10 @@
 }
 
 @media (max-width: 360px) {
+  .runnerGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .runnersIntro :global(.token-toolbar) {
     grid-template-columns: minmax(0, 1fr) auto;
   }

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -97,6 +97,15 @@ describe("Explore UI contract", () => {
       /@media \(max-width: 700px\)[\s\S]*?\.runnerGrid\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/s,
     );
     expect(styles).toMatch(
+      /@media \(max-width: 700px\)[\s\S]*?\.runnerContract\s*\{[^}]*display:\s*inline-flex;[^}]*order:\s*3;/s,
+    );
+    expect(styles).toMatch(
+      /@media \(max-width: 700px\)[\s\S]*?\.runnerSocials\s*\{[^}]*order:\s*4;/s,
+    );
+    expect(styles).toMatch(
+      /@media \(max-width: 360px\)[\s\S]*?\.runnerGrid\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\);/s,
+    );
+    expect(styles).toMatch(
       /\.revealedGrid \.runnerCard:nth-child\(n \+ 5\)\s*\{[^}]*display:\s*none;/s,
     );
     expect(source).not.toContain("styles.runnerIndex");


### PR DESCRIPTION
## Summary
- keep the contract address and copy feedback visible on mobile Explore cards
- keep Website/X/Telegram actions directly after the CA controls
- use a single-column fallback below 360px instead of hiding identity actions

## Focused verification
- `npx vitest run tests/explore-ui-contract.test.ts tests/explore-view-state.test.ts` (57 passed)