### PR TITLE
Batch Classic launch preflight RPC reads

### DIFF
--- a/app/api/launch/preflight/route.ts
+++ b/app/api/launch/preflight/route.ts
@@ -133,6 +133,9 @@ const MAX_REQUEST_BYTES = 50_000;
 const REQUIRED_FEE_HOOK_FLAGS = 8_396n;
 const HOOK_FLAG_MASK = (1n << 14n) - 1n;
 const STOCK_PAIRED_CURRENCY0_SEARCH_BATCH_SIZE = 64;
+const LAUNCH_RPC_MULTICALL_BATCH_BYTES = 16_384;
+const LAUNCH_RPC_JSON_BATCH_SIZE = 32;
+const LAUNCH_RPC_BATCH_WAIT_MS = 4;
 
 const launchEnvironment =
   process.env.PROGRAMMABLE_ONCHAIN_NETWORK === "rehearsal"
@@ -154,7 +157,17 @@ const selectedStockPairedRelease =
 function createLaunchRpcClient(rpcUrl: string) {
   return createPublicClient({
     chain: launchChain,
+    batch: {
+      multicall: {
+        batchSize: LAUNCH_RPC_MULTICALL_BATCH_BYTES,
+        wait: LAUNCH_RPC_BATCH_WAIT_MS,
+      },
+    },
     transport: http(rpcUrl, {
+      batch: {
+        batchSize: LAUNCH_RPC_JSON_BATCH_SIZE,
+        wait: LAUNCH_RPC_BATCH_WAIT_MS,
+      },
       retryCount: 1,
       timeout: 12_000,
     }),

--- a/tests/launch.test.ts
+++ b/tests/launch.test.ts
@@ -48,6 +48,29 @@ describe("Classic launch plan", () => {
     );
   });
 
+  it("batches the immutable Classic preflight reads without weakening them", () => {
+    const preflightSource = readFileSync(
+      new URL("../app/api/launch/preflight/route.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(preflightSource).toContain(
+      "const LAUNCH_RPC_MULTICALL_BATCH_BYTES = 16_384;",
+    );
+    expect(preflightSource).toContain(
+      "const LAUNCH_RPC_JSON_BATCH_SIZE = 32;",
+    );
+    expect(preflightSource).toContain(
+      "batchSize: LAUNCH_RPC_MULTICALL_BATCH_BYTES",
+    );
+    expect(preflightSource).toContain(
+      "batchSize: LAUNCH_RPC_JSON_BATCH_SIZE",
+    );
+    expect(preflightSource).toContain(
+      "await assertClassicV3Infrastructure(",
+    );
+  });
+
   it("starts every new draft on the single supported launch path", () => {
     const draft = createEmptyDraft();
 


### PR DESCRIPTION
## Outcome
- batch immutable Classic launch contract reads through Multicall
- batch the remaining JSON-RPC requests to avoid provider rate bursts
- preserve every release, runtime-code, economics, balance and transaction simulation check

## Evidence
- `npx vitest run tests/launch.test.ts tests/operational-rpc-failover.test.ts` — 30 passed
- `npm run typecheck` — passed
- changed-path ESLint — passed

## Live incident
The current production `/api/launch/preflight` returned HTTP 502 with provider-neutral `OperationalRpcUnavailableError` after both configured providers rejected the unbatched RPC burst.