### PR TITLE
Open Explore as a dedicated page

### DIFF
--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -24,42 +24,13 @@ import { WalletButton } from "@/components/wallet-provider";
 import styles from "@/components/site-navigation.module.css";
 
 const desktopNavItems = [
-  { href: "/#explore", label: "Explore", activePath: "/explore" },
+  { href: "/explore", label: "Explore" },
   { href: "/launch", label: "Create" },
   { href: "/profile", label: "Profile" },
   { href: "/docs", label: "Docs" },
 ];
 
 const mobileNavItems = desktopNavItems;
-const MOBILE_MENU_TRANSITION_MS = 300;
-
-function prepareLandingExploreNavigation(
-  event: MouseEvent<HTMLAnchorElement>,
-  pathname: string,
-  href: string,
-) {
-  if (
-    pathname !== "/" ||
-    href !== "/#explore" ||
-    event.button !== 0 ||
-    event.metaKey ||
-    event.ctrlKey ||
-    event.shiftKey ||
-    event.altKey
-  ) {
-    return false;
-  }
-
-  event.preventDefault();
-  if (window.location.hash !== "#explore") {
-    window.history.pushState(null, "", "/#explore");
-  }
-  return true;
-}
-
-function alignLandingExplore() {
-  window.dispatchEvent(new Event("hashchange"));
-}
 
 function HeaderSocialLinks({ mobile = false }: { mobile?: boolean }) {
   return (
@@ -142,7 +113,6 @@ export function SiteHeader() {
   const menuId = useId();
   const headerRef = useRef<HTMLElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const exploreAlignmentTimerRef = useRef<number | null>(null);
   const [menuPath, setMenuPath] = useState<string | null>(null);
   const menuOpen = menuPath === pathname;
 
@@ -188,27 +158,6 @@ export function SiteHeader() {
     };
   }, [menuOpen]);
 
-  useEffect(
-    () => () => {
-      if (exploreAlignmentTimerRef.current !== null) {
-        window.clearTimeout(exploreAlignmentTimerRef.current);
-      }
-    },
-    [],
-  );
-
-  function finishMobileNavigation(shouldAlignExplore: boolean) {
-    setMenuPath(null);
-    if (!shouldAlignExplore) return;
-    if (exploreAlignmentTimerRef.current !== null) {
-      window.clearTimeout(exploreAlignmentTimerRef.current);
-    }
-    exploreAlignmentTimerRef.current = window.setTimeout(() => {
-      exploreAlignmentTimerRef.current = null;
-      alignLandingExplore();
-    }, MOBILE_MENU_TRANSITION_MS + 20);
-  }
-
   return (
     <header ref={headerRef} className={`site-header ${styles.siteHeader}`}>
       <div className={`header-inner ${styles.headerInner}`}>
@@ -238,17 +187,6 @@ export function SiteHeader() {
               className={isCurrent(pathname, item) ? "active" : undefined}
               href={item.href}
               aria-current={isCurrent(pathname, item) ? "page" : undefined}
-              onClick={(event) => {
-                if (
-                  prepareLandingExploreNavigation(
-                    event,
-                    pathname,
-                    item.href,
-                  )
-                ) {
-                  alignLandingExplore();
-                }
-              }}
             >
               {item.label}
             </Link>
@@ -289,7 +227,7 @@ export function SiteHeader() {
           <MobileNavigation
             id={menuId}
             open={menuOpen}
-            onNavigate={finishMobileNavigation}
+            onNavigate={() => setMenuPath(null)}
           />
           <HeaderSocialLinks mobile />
         </div>
@@ -301,7 +239,7 @@ export function SiteHeader() {
 type MobileNavigationProps = {
   id?: string;
   open?: boolean;
-  onNavigate?: (shouldAlignExplore: boolean) => void;
+  onNavigate?: () => void;
 };
 
 export function MobileNavigation({
@@ -327,17 +265,7 @@ export function MobileNavigation({
             href={item.href}
             aria-current={current ? "page" : undefined}
             tabIndex={open ? undefined : -1}
-            onClick={(event) => {
-              const shouldAlignExplore = prepareLandingExploreNavigation(
-                event,
-                pathname,
-                item.href,
-              );
-              onNavigate?.(shouldAlignExplore);
-              if (shouldAlignExplore && onNavigate === undefined) {
-                alignLandingExplore();
-              }
-            }}
+            onClick={onNavigate}
           >
             <span>{item.label}</span>
           </Link>

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -16,7 +16,7 @@ describe("landing page contract", () => {
     expect(explorePage).toContain("import { ExploreView }");
     expect(explorePage).toContain('canonical: "/explore"');
     expect(navigation).toContain(
-      '{ href: "/#explore", label: "Explore", activePath: "/explore" }',
+      '{ href: "/explore", label: "Explore" }',
     );
     expect(navigation).toContain('href="/"');
     expect(homePage).toContain(
@@ -172,14 +172,12 @@ describe("landing page contract", () => {
     expect(navigation).toContain("event.ctrlKey");
   });
 
-  it("realigns a repeated home Explore activation after the mobile menu closes", () => {
+  it("opens Explore as its own route from the shared topbar", () => {
     const navigation = read("components/site-navigation.tsx");
 
-    expect(navigation).toContain("prepareLandingExploreNavigation(");
-    expect(navigation).toContain('window.history.pushState(null, "", "/#explore")');
-    expect(navigation).toContain('window.dispatchEvent(new Event("hashchange"))');
-    expect(navigation).toContain("MOBILE_MENU_TRANSITION_MS + 20");
-    expect(navigation).toContain("onNavigate={finishMobileNavigation}");
+    expect(navigation).toContain('{ href: "/explore", label: "Explore" }');
+    expect(navigation).not.toContain("prepareLandingExploreNavigation(");
+    expect(navigation).not.toContain('window.history.pushState(null, "", "/#explore")');
   });
 
   it("uses fluid shared gutters instead of a desktop to mobile width jump", () => {


### PR DESCRIPTION
## Summary
- route the shared topbar Explore link directly to /explore
- remove the obsolete same-page hash alignment handlers
- keep the landing Explore section and footer anchor unchanged

## Validation
- 27 focused navigation and accessibility tests
- full interface CI: 3,094 tests, wallet browser tests, production build
- desktop and touch-mobile browser QA for navigation, active state, menu close, back navigation, and overflow
- typecheck, ESLint, diff check, and gitleaks