### PR TITLE
Serialize Classic preflight provider reads

### DIFF
--- a/app/api/launch/preflight/route.ts
+++ b/app/api/launch/preflight/route.ts
@@ -134,7 +134,6 @@ const REQUIRED_FEE_HOOK_FLAGS = 8_396n;
 const HOOK_FLAG_MASK = (1n << 14n) - 1n;
 const STOCK_PAIRED_CURRENCY0_SEARCH_BATCH_SIZE = 64;
 const LAUNCH_RPC_MULTICALL_BATCH_BYTES = 16_384;
-const LAUNCH_RPC_JSON_BATCH_SIZE = 32;
 const LAUNCH_RPC_BATCH_WAIT_MS = 4;
 
 const launchEnvironment =
@@ -164,10 +163,6 @@ function createLaunchRpcClient(rpcUrl: string) {
       },
     },
     transport: http(rpcUrl, {
-      batch: {
-        batchSize: LAUNCH_RPC_JSON_BATCH_SIZE,
-        wait: LAUNCH_RPC_BATCH_WAIT_MS,
-      },
       retryCount: 1,
       timeout: 12_000,
     }),
@@ -1000,74 +995,71 @@ async function assertClassicV3Infrastructure(
   rpcClient: LaunchRpcClient,
 ) {
   const client = rpcClient;
-  await Promise.all([
-    assertRuntimeCodeHash(
+  const runtimeCodeBindings = [
+    [
       officialPoolManager,
       selectedDeployments.contracts.poolManager.runtimeCodeHash as Hex,
       "Uniswap PoolManager",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       officialPositionManager,
       selectedDeployments.contracts.positionManager.runtimeCodeHash as Hex,
       "Uniswap PositionManager",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       officialTokenFactory,
       selectedDeployments.contracts.uerc20Factory.runtimeCodeHash as Hex,
       "Uniswap UERC20Factory",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       hookFactory,
       codeHashes.ethCreatorFeeHookFactoryV3,
       "Classic hook factory",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       hook,
       codeHashes.ethCreatorFeeHookV3,
       "Classic hook",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       vaultFactory,
       codeHashes.classicRewardVaultFactoryV1,
       "Classic reward factory",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       ctoAuthority,
       codeHashes.classicCtoAuthorityV1,
       "Classic CTO authority",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       initialBuyVestingWalletFactory,
       codeHashes.classicInitialBuyVestingWalletFactoryV1,
       "Classic Initial Buy custody factory",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       launchPolicy,
       codeHashes.classicLaunchPolicyV1,
       "Classic launch policy",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       positionForwarderFactory,
       codeHashes.lockedPositionFeeForwarderFactory,
       "Locked position factory",
-      rpcClient,
-    ),
-    assertRuntimeCodeHash(
+    ],
+    [
       launcher,
       codeHashes.memeLaunchV2,
       "Classic launcher",
+    ],
+  ] as const;
+  for (const [address, expected, label] of runtimeCodeBindings) {
+    await assertRuntimeCodeHash(
+      address,
+      expected,
+      label,
       rpcClient,
-    ),
-  ]);
+    );
+  }
 
   const [
     configuredPoolManager,

--- a/tests/launch.test.ts
+++ b/tests/launch.test.ts
@@ -48,7 +48,7 @@ describe("Classic launch plan", () => {
     );
   });
 
-  it("batches the immutable Classic preflight reads without weakening them", () => {
+  it("bounds the immutable Classic preflight reads without weakening them", () => {
     const preflightSource = readFileSync(
       new URL("../app/api/launch/preflight/route.ts", import.meta.url),
       "utf8",
@@ -58,13 +58,11 @@ describe("Classic launch plan", () => {
       "const LAUNCH_RPC_MULTICALL_BATCH_BYTES = 16_384;",
     );
     expect(preflightSource).toContain(
-      "const LAUNCH_RPC_JSON_BATCH_SIZE = 32;",
-    );
-    expect(preflightSource).toContain(
       "batchSize: LAUNCH_RPC_MULTICALL_BATCH_BYTES",
     );
+    expect(preflightSource).not.toContain("LAUNCH_RPC_JSON_BATCH_SIZE");
     expect(preflightSource).toContain(
-      "batchSize: LAUNCH_RPC_JSON_BATCH_SIZE",
+      "for (const [address, expected, label] of runtimeCodeBindings)",
     );
     expect(preflightSource).toContain(
       "await assertClassicV3Infrastructure(",


### PR DESCRIPTION
## Summary
- remove upstream-incompatible HTTP JSON-RPC batching
- retain viem Multicall batching for contract reads
- serialize the eleven immutable runtime bytecode checks without removing any validation

## Focused validation
- npx vitest run tests/launch.test.ts tests/operational-rpc-failover.test.ts (30 passed)
- npm run typecheck
- npx eslint app/api/launch/preflight/route.ts tests/launch.test.ts
- git diff --check