### PR TITLE
Modernize Classic launch success flow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6666,7 +6666,7 @@ html[data-theme="dark"] .theme-toggle-sun {
 .launch-success-backdrop {
   align-items: center;
   backdrop-filter: blur(12px);
-  background: var(--success-backdrop);
+  background: rgb(0 0 0 / 0.72);
   display: flex;
   inset: 0;
   justify-content: center;
@@ -6676,39 +6676,44 @@ html[data-theme="dark"] .theme-toggle-sun {
 }
 
 .launch-success-dialog {
-  background: var(--glass-98);
-  border: 1px solid var(--popover-border);
-  border-radius: 24px;
-  box-shadow: var(--overlay-shadow);
+  background: rgb(24 24 24 / 0.98);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  box-shadow: 0 32px 96px rgb(0 0 0 / 0.58);
   max-height: calc(100svh - 32px);
-  max-width: 460px;
+  max-width: 430px;
   overflow-y: auto;
-  padding: 34px;
+  padding: 24px;
   position: relative;
   text-align: center;
   width: 100%;
 }
 
 .launch-success-close {
+  background: var(--webde-control);
+  border-color: var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-muted);
   position: absolute;
   right: 14px;
   top: 14px;
 }
 
 .launch-success-icon {
-  color: var(--accent-strong);
-  margin-bottom: 18px;
+  color: var(--webde-ink);
+  margin-bottom: 12px;
 }
 
 .launch-success-dialog h2 {
-  font-size: 31px;
-  font-weight: 580;
+  color: var(--webde-ink);
+  font-size: 30px;
+  font-weight: 600;
   letter-spacing: -0.03em;
   margin-top: 7px;
 }
 
 .launch-success-dialog > p:not(.eyebrow) {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 14px;
   margin-top: 12px;
 }
@@ -6719,7 +6724,7 @@ html[data-theme="dark"] .theme-toggle-sun {
 }
 
 .launch-success-dialog > .launch-success-symbol {
-  color: var(--accent-strong);
+  color: var(--webde-ink);
   font-size: 15px;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -6733,17 +6738,17 @@ html[data-theme="dark"] .theme-toggle-sun {
 }
 
 .launch-success-address > span:first-child {
-  color: var(--muted);
+  color: var(--webde-dim);
   font-size: 11px;
   font-weight: 650;
 }
 
 .launch-success-address button {
   align-items: center;
-  background: var(--surface-soft);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  color: var(--text);
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
   cursor: pointer;
   display: flex;
   gap: 8px;
@@ -6753,11 +6758,12 @@ html[data-theme="dark"] .theme-toggle-sun {
 }
 
 .launch-success-address button:hover {
-  border-color: var(--popover-border);
+  background: var(--webde-surface-raised);
+  border-color: #4a4a4a;
 }
 
 .launch-success-address button:focus-visible {
-  outline: 2px solid var(--accent-strong);
+  outline: 2px solid var(--webde-ink);
   outline-offset: 2px;
 }
 
@@ -6770,14 +6776,14 @@ html[data-theme="dark"] .theme-toggle-sun {
 }
 
 .launch-success-address button > span {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 12px;
   font-weight: 650;
   margin-left: auto;
 }
 
 .launch-success-copy-status {
-  color: var(--muted);
+  color: var(--webde-dim);
   font-size: 11px;
   min-height: 14px;
 }
@@ -6788,9 +6794,9 @@ html[data-theme="dark"] .theme-toggle-sun {
 
 .launch-success-tokens > div {
   align-items: center;
-  background: var(--accent-soft);
-  border: 1px solid var(--popover-border);
-  border-radius: 12px;
+  background: var(--webde-surface-raised);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
   display: flex;
   gap: 12px;
   justify-content: space-between;
@@ -6798,7 +6804,7 @@ html[data-theme="dark"] .theme-toggle-sun {
 }
 
 .launch-success-tokens dt {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 11px;
   text-align: left;
 }
@@ -6822,12 +6828,12 @@ html[data-theme="dark"] .theme-toggle-sun {
   }
 
   .launch-success-dialog {
-    border-radius: 22px;
-    padding: 30px 20px 20px;
+    border-radius: var(--webde-radius-card);
+    padding: 24px 20px 20px;
   }
 
   .launch-success-dialog h2 {
-    font-size: 27px;
+    font-size: 24px;
   }
 }
 
@@ -7936,12 +7942,13 @@ html[data-theme="dark"] .launch-page[data-launch-model="classic-v3"] {
   display: grid;
   gap: 2px;
   padding: 9px;
-  border-radius: 12px;
-  background: var(--surface-soft);
+  background: var(--webde-surface-raised);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
 }
 
 .launch-success-v3 dt {
-  color: var(--muted);
+  color: var(--webde-dim);
   font-size: 10px;
 }
 

--- a/components/launch-builder.tsx
+++ b/components/launch-builder.tsx
@@ -190,6 +190,7 @@ const STOCK_PAIRED_DISPLAY_NAMES: Record<string, string> = {
 
 const LAUNCH_RECEIPT_POLL_ATTEMPTS = 12;
 export const LAUNCH_INDEX_POLL_ATTEMPTS = 18;
+export const LAUNCH_INDEX_AUTO_RETRY_DELAY_MS = 6_000;
 export const PENDING_LAUNCH_STALE_AFTER_MS = 24 * 60 * 60 * 1_000;
 export const LAUNCH_SUCCESS_CELEBRATION_MAX_AGE_MS = 30 * 60 * 1_000;
 const PENDING_LAUNCH_MAX_CLOCK_SKEW_MS = 5 * 60 * 1_000;
@@ -211,6 +212,17 @@ export function launchPollDelayMs(attempt: number) {
 export function launchIndexPollDelayMs(attempt: number) {
   const normalizedAttempt = Math.max(0, Math.floor(attempt));
   return Math.min(4_000 + normalizedAttempt * 1_000, 12_000);
+}
+
+export function launchIndexShouldRetryAutomatically(
+  confirmedButUnindexed: boolean,
+  submissionPhase: LaunchSubmissionPhase,
+) {
+  return (
+    confirmedButUnindexed &&
+    (submissionPhase === "index-unavailable" ||
+      submissionPhase === "index-timeout")
+  );
 }
 
 export function launchDraftIsLocked(
@@ -305,13 +317,9 @@ export function launchSuccessSummary(
   const symbol = indexedLaunch?.symbol ?? submission.tokenSymbol;
   if (!address || !name || !symbol) return null;
 
-  const explorer =
-    submission.chainId === 11_155_111
-      ? "https://sepolia.etherscan.io"
-      : "https://etherscan.io";
   return {
     address,
-    href: indexedLaunch?.href ?? `${explorer}/address/${address}`,
+    href: indexedLaunch?.href ?? `/token/${address}`,
     name,
     symbol,
     chainId: submission.chainId,
@@ -1250,6 +1258,7 @@ function LaunchBuilderFormView({
   const [indexedLaunchRecord, setIndexedLaunchRecord] =
     useState<IndexedLaunchRecord | null>(null);
   const [successOpen, setSuccessOpen] = useState(false);
+  const successShownTransactionRef = useRef("");
   const closeSuccessDialog = useCallback(() => {
     setSuccessOpen(false);
   }, []);
@@ -1364,6 +1373,36 @@ function LaunchBuilderFormView({
     const timer = window.setTimeout(() => setNotice(""), 2400);
     return () => window.clearTimeout(timer);
   }, [notice]);
+
+  useEffect(() => {
+    if (
+      !activeSubmission ||
+      !successLaunch ||
+      !shouldRestoreConfirmedLaunchSuccess(activeSubmission)
+    ) {
+      return;
+    }
+    const transactionKey = `${activeSubmission.chainId}:${activeSubmission.transactionHash.toLowerCase()}`;
+    if (successShownTransactionRef.current === transactionKey) return;
+    successShownTransactionRef.current = transactionKey;
+    setSuccessOpen(true);
+    setNotice("Launch successful");
+  }, [activeSubmission, successLaunch]);
+
+  useEffect(() => {
+    if (
+      !launchIndexShouldRetryAutomatically(
+        confirmedButUnindexed,
+        submissionPhase,
+      )
+    ) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      setConfirmationRetryKey((current) => current + 1);
+    }, LAUNCH_INDEX_AUTO_RETRY_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [confirmedButUnindexed, submissionPhase]);
 
   useEffect(() => {
     if (
@@ -1508,14 +1547,6 @@ function LaunchBuilderFormView({
         if (!activeSubmission.receiptConfirmedAtMs) {
           updateBrowserPendingLaunch(confirmedSubmission);
           setCurrentSubmission(confirmedSubmission);
-          const celebrateLaunch = shouldCelebrateIndexedLaunch({
-            submission: confirmedSubmission,
-            currentDraftSubmissionHash,
-            currentDraftVersion: draftVersion.current,
-            submittedDraftVersion,
-          });
-          setSuccessOpen(celebrateLaunch);
-          setNotice(celebrateLaunch ? "Launch successful" : "");
         }
 
         setSubmissionPhaseFor(confirmedSubmission, "indexing");
@@ -1545,13 +1576,6 @@ function LaunchBuilderFormView({
           submission: confirmedSubmission,
         });
         clearSubmissionPhase();
-        if (
-          !confirmedSubmission.tokenAddress &&
-          shouldRestoreConfirmedLaunchSuccess(confirmedSubmission)
-        ) {
-          setSuccessOpen(true);
-          setNotice("Launch successful");
-        }
       } catch (caught) {
         if (caught instanceof DOMException && caught.name === "AbortError") {
           return;
@@ -2067,7 +2091,7 @@ function LaunchBuilderFormView({
       ? "Token details are locked while the transaction is prepared."
       : unresolvedSubmission
         ? confirmedButUnindexed
-          ? "This transaction is confirmed and its hash remains saved while the token index catches up. You can safely go back."
+          ? "This launch is complete. View the token or go back."
           : "Token details are locked to the submitted transaction. Check its status before taking another action."
         : hasSubmittedTransaction
           ? "This completed launch is locked. View the token or go back."
@@ -2077,6 +2101,14 @@ function LaunchBuilderFormView({
     <p>
       {indexedLaunch.name} <span>·</span> ${indexedLaunch.symbol}
     </p>
+  ) : confirmedButUnindexed ? (
+    successLaunch ? (
+      <p>
+        {successLaunch.name} <span>·</span> ${successLaunch.symbol}
+      </p>
+    ) : (
+      <p>Launch confirmed</p>
+    )
   ) : transactionHash ? (
     <>
       <a
@@ -2119,8 +2151,25 @@ function LaunchBuilderFormView({
       className="primary-button classic-launch-button"
       href={indexedLaunch.href}
     >
-      View your token
+      View token
     </Link>
+  ) : confirmedButUnindexed ? (
+    successLaunch ? (
+      <Link
+        className="primary-button classic-launch-button"
+        href={successLaunch.href}
+      >
+        View token
+      </Link>
+    ) : (
+      <button
+        className="primary-button classic-launch-button"
+        type="button"
+        disabled
+      >
+        Launch confirmed
+      </button>
+    )
   ) : transactionHash ? (
     <button
       className="primary-button classic-launch-button"
@@ -2449,7 +2498,6 @@ function LaunchSuccessDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="launch-success-title"
-        aria-describedby="launch-success-description"
       >
         <button
           className="icon-button launch-success-close"
@@ -2467,11 +2515,6 @@ function LaunchSuccessDialog({
         />
         <p className="eyebrow">Launch successful</p>
         <h2 id="launch-success-title">{launch.name} was created</h2>
-        <p id="launch-success-description">
-          {launch.indexed
-            ? "Your token page is ready."
-            : "The transaction is confirmed. Your token page is being indexed."}
-        </p>
         <p className="launch-success-symbol">${launch.symbol}</p>
         <div className="launch-success-address">
           <span>Contract address</span>
@@ -2569,21 +2612,9 @@ function LaunchSuccessDialog({
             </div>
           </dl>
         ) : null}
-        {launch.indexed ? (
-          <Link ref={viewLinkRef} className="primary-button" href={launch.href}>
-            View your token
-          </Link>
-        ) : (
-          <a
-            ref={viewLinkRef}
-            className="primary-button"
-            href={launch.href}
-            target="_blank"
-            rel="noreferrer"
-          >
-            View on Etherscan
-          </a>
-        )}
+        <Link ref={viewLinkRef} className="primary-button" href={launch.href}>
+          View token
+        </Link>
       </section>
     </div>
   );

--- a/tests/launch-success.test.ts
+++ b/tests/launch-success.test.ts
@@ -4,12 +4,14 @@ import {
   findClassicV3IndexedLaunch,
   findDeepV3IndexedLaunch,
   findIndexedLaunch,
+  LAUNCH_INDEX_AUTO_RETRY_DELAY_MS,
   LAUNCH_SUCCESS_CELEBRATION_MAX_AGE_MS,
   LAUNCH_INDEX_POLL_ATTEMPTS,
   launchDraftForSuccessDisplay,
   launchDraftIsLocked,
   launchIsConfirmedButUnindexed,
   launchIndexPollDelayMs,
+  launchIndexShouldRetryAutomatically,
   launchPollDelayMs,
   launchSuccessSummary,
   launchSubmissionUsesCurrentDraft,
@@ -72,7 +74,7 @@ describe("launch success indexing", () => {
 
     expect(launchSuccessSummary(submission, null)).toEqual({
       address: tokenAddress,
-      href: `https://etherscan.io/address/${tokenAddress}`,
+      href: `/token/${tokenAddress}`,
       name: "Programmable Test",
       symbol: "PGT",
       chainId: 1,
@@ -86,6 +88,36 @@ describe("launch success indexing", () => {
         null,
       ),
     ).toBeNull();
+  });
+
+  it("keeps confirmed token navigation on Programmable while indexing catches up", () => {
+    const submission: PendingLaunchSubmission = {
+      version: 2,
+      transactionHash,
+      account,
+      chainId: 1,
+      model: "classic-v3",
+      submittedAtMs: 1_000_000,
+      receiptConfirmedAtMs: 1_001_000,
+      tokenAddress: tokenAddress as `0x${string}`,
+      tokenName: "Programmable Test",
+      tokenSymbol: "PGT",
+    };
+
+    expect(launchSuccessSummary(submission, null)?.href).toBe(
+      `/token/${tokenAddress}`,
+    );
+    expect(LAUNCH_INDEX_AUTO_RETRY_DELAY_MS).toBe(6_000);
+    expect(launchIndexShouldRetryAutomatically(true, "index-unavailable")).toBe(
+      true,
+    );
+    expect(launchIndexShouldRetryAutomatically(true, "index-timeout")).toBe(
+      true,
+    );
+    expect(launchIndexShouldRetryAutomatically(true, "indexing")).toBe(false);
+    expect(
+      launchIndexShouldRetryAutomatically(false, "index-unavailable"),
+    ).toBe(false);
   });
 
   it("upgrades the confirmed success link only for the same indexed token", () => {


### PR DESCRIPTION
## Outcome
- restyles the Classic launch confirmation in the current neutral Programmable design
- routes every confirmed token CTA to the Programmable token page
- restores the confirmation automatically after a confirmed launch
- retries transient catalog failures automatically without exposing index errors or requiring Check again

## Focused verification
- `vitest run tests/launch-success.test.ts` (27 passed)
- `npm run typecheck`
- changed-path ESLint
- `git diff --check`

No contract, profile, claim, trade, registry, database, or onchain behavior changed.