### PR TITLE
Clarify Explore market data states

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -64,6 +64,14 @@ import {
 } from "@/lib/tokens";
 import styles from "./explore-experience.module.css";
 
+type ExploreMarketStatus =
+  | "No market"
+  | "Waiting for first trade"
+  | "Last verified"
+  | "Provider recent"
+  | "Limited market data"
+  | "Unavailable";
+
 type TokenCard = {
   id: string;
   name: string;
@@ -73,13 +81,7 @@ type TokenCard = {
   links: readonly TokenLink[];
   valuation?: MarketCapMetric;
   valuationMetric?: "Market cap" | "FDV";
-  marketStatus?:
-    | "No market"
-    | "Waiting for first trade"
-    | "Last verified"
-    | "Provider recent"
-    | "Limited market data"
-    | "Unavailable";
+  marketStatus?: ExploreMarketStatus;
   usesFallbackImage: boolean;
   tokenAddress?: `0x${string}`;
   launchCategory: "Classic" | "Custom";
@@ -87,14 +89,7 @@ type TokenCard = {
 
 export function exploreMarketStatusLabel(
   entry: ExploreEntry | ValuedExploreEntry,
-):
-  | "No market"
-  | "Waiting for first trade"
-  | "Last verified"
-  | "Provider recent"
-  | "Limited market data"
-  | "Unavailable"
-  | undefined {
+): ExploreMarketStatus | undefined {
   const marketData = (entry as Partial<ValuedExploreEntry>).marketData;
   if (marketData && isTokenMarketDataV1(marketData)) {
     return marketDataStatusLabel(marketData);
@@ -111,6 +106,14 @@ export function exploreMarketStatusLabel(
   if (valuation.freshness === "stale") return "Last verified";
   if (valuation.freshness === "unknown") return "Unavailable";
   return undefined;
+}
+
+export function exploreUnavailableFdvLabel(
+  status: ExploreMarketStatus | undefined,
+) {
+  if (status === "Waiting for first trade") return status;
+  if (status === "No market") return "No market yet";
+  return "Not available yet";
 }
 
 type TokenSort = "newest" | "oldest" | "market-cap" | "market-cap-asc";
@@ -2293,14 +2296,15 @@ export function ExploreView({
                   <h3 title={token.name}>{token.name}</h3>
                   {token.symbol ? <span>${token.symbol}</span> : null}
                 </header>
-                {valuationLabel ? (
-                  <div className={styles.runnerData}>
-                    <span>
-                      <small>{token.valuationMetric ?? "Market cap"}</small>
-                      <strong>{valuationLabel}</strong>
-                    </span>
-                  </div>
-                ) : null}
+                <div className={styles.runnerData}>
+                  <span>
+                    <small>{token.valuationMetric ?? "FDV"}</small>
+                    <strong>
+                      {valuationLabel ??
+                        exploreUnavailableFdvLabel(token.marketStatus)}
+                    </strong>
+                  </span>
+                </div>
               </div>
             </>
           );
@@ -2472,7 +2476,7 @@ export function ExploreView({
                             } active`
                       }
                     >
-                      <span>Sort by</span>
+                      <span>{`Sort: ${activeSortLabel}`}</span>
                       {activeFilterCount > 0 ? (
                         <span
                           className={styles.activeFilterCount}
@@ -2527,10 +2531,10 @@ export function ExploreView({
                       <div
                         className={styles.filterGroup}
                         role="group"
-                        aria-labelledby="explore-market-cap-label"
+                        aria-labelledby="explore-fdv-label"
                       >
-                        <p className={styles.filterLabel} id="explore-market-cap-label">
-                          Market Cap
+                        <p className={styles.filterLabel} id="explore-fdv-label">
+                          FDV
                         </p>
                         {sortOptions.slice(2).map((option) => (
                           <button

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -912,7 +912,7 @@ export function buildTokenDetailMetrics(
   const values: Array<TokenMetric | null> = [
     {
       label: getValuationMetricLabel(valuation),
-      value: formattedFdv ?? "Unavailable",
+      value: formattedFdv ?? "Not available yet",
     },
     {
       label: "Category",
@@ -1779,11 +1779,11 @@ function customMarketMetrics(project: DetailCustomProject): TokenMetric[] {
         ? "Current"
         : project.marketData?.status === "partial"
           ? "Limited"
-          : "Unavailable";
+          : "Not available yet";
   return [
     {
       label: getValuationMetricLabel(valuation),
-      value: valuationValue ?? "Unavailable",
+      value: valuationValue ?? "Not available yet",
     },
     { label: "Market data", value: marketStatus },
     ...(primary?.volume24hUsdWad

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -45,7 +45,7 @@ describe("Explore UI contract", () => {
     );
 
     expect(source).toContain('id="explore-model-label"');
-    expect(source).toContain('id="explore-market-cap-label"');
+    expect(source).toContain('id="explore-fdv-label"');
     expect(source).toContain('id="explore-age-label"');
     expect(source).toContain('id="explore-socials-label"');
     expect(source).toContain('{ id: "classic", label: "Classic" }');
@@ -53,11 +53,11 @@ describe("Explore UI contract", () => {
     expect(source).toContain(
       'Number(socialFilter !== "all") + Number(modelFilter !== "all")',
     );
-    expect(source).toContain("<span>Sort by</span>");
+    expect(source).toContain('<span>{`Sort: ${activeSortLabel}`}</span>');
     expect(source.indexOf('id="explore-model-label"')).toBeLessThan(
-      source.indexOf('id="explore-market-cap-label"'),
+      source.indexOf('id="explore-fdv-label"'),
     );
-    expect(source.indexOf('id="explore-market-cap-label"')).toBeLessThan(
+    expect(source.indexOf('id="explore-fdv-label"')).toBeLessThan(
       source.indexOf('id="explore-age-label"'),
     );
     expect(source.indexOf('id="explore-age-label"')).toBeLessThan(
@@ -121,7 +121,9 @@ describe("Explore UI contract", () => {
       'sizes="(max-width: 700px) calc((100vw - 42px) / 2), (max-width: 900px) 330px, 299px"',
     );
     expect(source).not.toContain("<small>CA</small>");
-    expect(source).not.toContain('valuationLabel ?? "Unavailable"');
+    expect(source).toContain(
+      "exploreUnavailableFdvLabel(token.marketStatus)",
+    );
     expect(source).toContain("Copy ${token.name} contract address");
     expect(source).toContain('token.marketStatus !== "Unavailable"');
     expect(styles).toMatch(

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -9,6 +9,7 @@ import {
   exploreDataQualityMessage,
   exploreAppliedSortLabel,
   exploreMarketStatusLabel,
+  exploreUnavailableFdvLabel,
   exploreTokensPerPageForViewport,
   handledInitialExploreRequestKey,
   filterTokensByLaunchModel,
@@ -991,6 +992,17 @@ describe("Explore refresh state", () => {
       kind: "usd",
       value: 125,
     });
+  });
+
+  it("explains missing FDV without inventing a value", () => {
+    expect(exploreUnavailableFdvLabel("Waiting for first trade")).toBe(
+      "Waiting for first trade",
+    );
+    expect(exploreUnavailableFdvLabel("No market")).toBe("No market yet");
+    expect(exploreUnavailableFdvLabel("Unavailable")).toBe(
+      "Not available yet",
+    );
+    expect(exploreUnavailableFdvLabel(undefined)).toBe("Not available yet");
   });
 
   it("labels bounded offchain FDV as provider recent, never onchain current", () => {

--- a/tests/interaction-state-regressions.test.ts
+++ b/tests/interaction-state-regressions.test.ts
@@ -110,7 +110,7 @@ describe("interaction state regressions", () => {
     expect(exploreSource).not.toContain("<dt>Market cap</dt>");
     expect(exploreSource).toContain("runnerMeta");
     expect(exploreSource).toContain("runnerData");
-    expect(exploreSource).toContain('token.valuationMetric ?? "Market cap"');
+    expect(exploreSource).toContain('token.valuationMetric ?? "FDV"');
     expect(exploreSource).not.toContain("No description yet.");
     expect(exploreSource).not.toContain('{ id: "all", label: "Any" }');
     expect(exploreSource).toMatch(

--- a/tests/token-detail-view.test.ts
+++ b/tests/token-detail-view.test.ts
@@ -112,11 +112,11 @@ describe("token detail metrics", () => {
 
     expect(buildTokenDetailMetrics(withoutSupply)[0]).toEqual({
       label: "FDV",
-      value: "Unavailable",
+      value: "Not available yet",
     });
     expect(buildTokenDetailMetrics(withoutLiquidity, "$999M")[0]).toEqual({
       label: "FDV",
-      value: "Unavailable",
+      value: "Not available yet",
     });
   });
 


### PR DESCRIPTION
## Summary
- show a clear FDV state on every Explore card instead of leaving unpriced cards blank
- expose the active sort mode and label the control truthfully as FDV
- use consistent "Not available yet" copy on token and verified Custom detail metrics
- preserve existing token images, Website/X/Telegram links, identities, and provider-failure behavior

## Validation
- 83 focused tests passed
- TypeScript passed
- changed-path ESLint passed
- production build reached Next.js compilation but local Turbopack rejected the worktree node_modules symlink because it points outside the filesystem root; CI uses a clean dependency install
