### PR TITLE
Fallback failed token artwork

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -52,6 +52,7 @@ import {
   marketDataStatusLabel,
 } from "@/lib/market-data/market-data-v1";
 import {
+  applyTokenImageFallback,
   canOptimizeTokenImage,
   getTokenCardImageSource,
 } from "@/lib/token-image";
@@ -2288,6 +2289,12 @@ export function ExploreView({
                   sizes="(max-width: 700px) calc((100vw - 42px) / 2), (max-width: 900px) 330px, 299px"
                   unoptimized={!canOptimizeTokenImage(imageSource)}
                   draggable={false}
+                  onError={(event) => {
+                    applyTokenImageFallback(
+                      event.currentTarget,
+                      getFallbackTokenImage(token.tokenAddress ?? token.id),
+                    );
+                  }}
                 />
               </div>
 

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -47,6 +47,7 @@ import {
   type TokenMarketDataV1,
 } from "@/lib/market-data/market-data-v1";
 import {
+  applyTokenImageFallback,
   canOptimizeTokenImage,
   getTokenCardImageSource,
 } from "@/lib/token-image";
@@ -1483,6 +1484,12 @@ function TokenDetailContent({
                 priority
                 sizes="(max-width: 720px) 88px, 132px"
                 unoptimized={!canOptimizeTokenImage(imageSource)}
+                onError={(event) => {
+                  applyTokenImageFallback(
+                    event.currentTarget,
+                    getFallbackTokenImage(token.tokenAddress),
+                  );
+                }}
               />
             </div>
 
@@ -1863,6 +1870,14 @@ function CustomProjectDetailContent({
               priority
               sizes="(max-width: 720px) 88px, 132px"
               unoptimized={!canOptimizeTokenImage(imageSource)}
+              onError={(event) => {
+                applyTokenImageFallback(
+                  event.currentTarget,
+                  getFallbackTokenImage(
+                    project.tokenAddress ?? project.customProjectId,
+                  ),
+                );
+              }}
             />
           </div>
           <div className={styles.identityCopy}>

--- a/lib/token-image.ts
+++ b/lib/token-image.ts
@@ -54,6 +54,18 @@ export function getTokenCardImageSource(source: string) {
     : source;
 }
 
+export function applyTokenImageFallback(
+  image: HTMLImageElement,
+  fallbackSource: string,
+) {
+  if (image.dataset.tokenImageFallback === "true") return false;
+  image.dataset.tokenImageFallback = "true";
+  image.alt = "";
+  image.removeAttribute("srcset");
+  image.src = fallbackSource;
+  return true;
+}
+
 export function getTokenImageFileError(file: Pick<File, "size" | "type">) {
   if (!acceptedTokenImageTypes.has(file.type)) {
     return "Choose a JPG, PNG or WebP image";

--- a/tests/token-image.test.ts
+++ b/tests/token-image.test.ts
@@ -4,6 +4,7 @@ import sharp from "sharp";
 vi.mock("server-only", () => ({}));
 
 import {
+  applyTokenImageFallback,
   canOptimizeTokenImage,
   getProgrammableTokenImageAssetName,
   getTokenCardImageSource,
@@ -149,5 +150,35 @@ describe("token image policy", () => {
         `https://${PROGRAMMABLE_TOKEN_IMAGE_HOST}/token-images/nested/example.webp`,
       ),
     ).toBe("");
+  });
+
+  it("replaces a failed external image with one inert local fallback", () => {
+    const removed: string[] = [];
+    const image = {
+      alt: "Broken token artwork",
+      dataset: {} as DOMStringMap,
+      src: "https://example.com/broken.webp",
+      removeAttribute(name: string) {
+        removed.push(name);
+      },
+    } as unknown as HTMLImageElement;
+
+    expect(applyTokenImageFallback(
+      image,
+      "/brand/programmable-token-fallback-01-dawn.webp",
+    )).toBe(true);
+    expect(image).toMatchObject({
+      alt: "",
+      src: "/brand/programmable-token-fallback-01-dawn.webp",
+      dataset: { tokenImageFallback: "true" },
+    });
+    expect(removed).toEqual(["srcset"]);
+    expect(applyTokenImageFallback(
+      image,
+      "/brand/programmable-token-fallback-02-moon.webp",
+    )).toBe(false);
+    expect(image.src).toBe(
+      "/brand/programmable-token-fallback-01-dawn.webp",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- replace failed external token artwork with an existing deterministic local fallback
- cover Explore cards plus Classic and verified Custom detail views
- keep metadata, identities and social links unchanged

## Evidence
- live browser QA found the external Hooked on ETH image returning 404/ORB
- 25 focused tests passed
- TypeScript and changed-path ESLint passed
