### PR TITLE
Keep GitBook trailing slash links inside docs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "trailingSlash": false,
+  "redirects": [
+    {
+      "source": "/sites/site_V93gQ",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/sites/site_V93gQ/:match*",
+      "destination": "/docs/:match*",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     {
       "source": "/docs",


### PR DESCRIPTION
Fix the GitBook subdirectory edge case found during production QA.

- catches GitBook redirects from internal `/sites/site_V93gQ` paths
- sends them back to the canonical `/docs` path
- preserves nested paths such as `/docs/tokens/classic/`

QA:
- Vercel preview READY: dpl_BHhv3jjQJjTc9uXypwyb55dYihf4
- `/docs/` resolves to `/docs` and renders Programmable Docs
- `/docs/tokens/classic/` resolves to `/docs/tokens/classic` and renders Classic
- candidate-neutrality, Prettier, JSON validation and diff check pass