### PR TITLE
Stabilize Explore valuation display

### DIFF
--- a/app/interface.css
+++ b/app/interface.css
@@ -1410,27 +1410,6 @@ body:has([data-docs-shell]) .site-header::before {
   transform: none;
 }
 
-.token-refresh-warning {
-  align-items: center;
-  color: var(--muted);
-  display: flex;
-  font-size: 11.5px;
-  gap: 8px;
-  justify-content: center;
-  line-height: 1.2;
-  margin: 2px auto 0;
-  min-height: 22px;
-}
-
-.token-refresh-warning button {
-  background: transparent;
-  color: var(--accent-strong);
-  font-size: inherit;
-  font-weight: 650;
-  min-height: 44px;
-  padding: 8px 10px;
-}
-
 .token-card,
 .token-card:nth-child(10):last-child {
   animation: interface-card-fade 130ms ease-out both;

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -29,11 +29,6 @@ import {
   isInterfacePreviewHost,
   useInterfacePreview,
 } from "@/components/interface-preview";
-import {
-  LIVE_DATA_REFRESH_INTERVAL_MS,
-  shouldRefreshLiveData,
-  useLiveDataRefresh,
-} from "@/components/use-live-data-refresh";
 import { WebsiteLinkIcon } from "@/components/website-link-icon";
 import { parseDiscoverableMarketTradeCapabilityV1 } from "@/lib/custom-launch/trade-capability-v1";
 import {
@@ -81,7 +76,7 @@ type TokenCard = {
   imageUrl: string;
   links: readonly TokenLink[];
   valuation?: MarketCapMetric;
-  valuationMetric?: "Market cap" | "FDV";
+  valuationMetric?: "Market cap" | "Valuation";
   marketStatus?: ExploreMarketStatus;
   usesFallbackImage: boolean;
   tokenAddress?: `0x${string}`;
@@ -219,7 +214,7 @@ export function exploreAppliedSortLabel(
   if (
     (sort === "market-cap" || sort === "market-cap-asc") &&
     ranking?.status === "partial"
-  ) return "Available FDV";
+  ) return "Available valuation";
   return sortOptions.find((option) => option.id === sort)?.label ?? "Sort";
 }
 
@@ -236,7 +231,6 @@ type ExploreState =
       payload: ExplorePayload;
       requestKey: string;
       contentKey: string;
-      refreshError?: string;
     };
 
 export type ExploreInitialResponse = Readonly<{
@@ -256,7 +250,6 @@ export function preserveExplorePayloadOnRefreshFailure(
     ? {
         ...current,
         requestKey: input.requestKey,
-        refreshError: input.message,
       }
     : {
         phase: "error",
@@ -307,7 +300,6 @@ function useExploreTokensPerPage() {
 }
 const QUERY_DEBOUNCE_MS = 200;
 const EXPLORE_REQUEST_TIMEOUT_MS = 12_000;
-export const EXPLORE_REFRESH_INTERVAL_MS = LIVE_DATA_REFRESH_INTERVAL_MS;
 const fallbackTokenImages = [
   "/brand/programmable-token-fallback-01-dawn.webp",
   "/brand/programmable-token-fallback-02-moon.webp",
@@ -319,8 +311,8 @@ const fallbackTokenImages = [
 const sortOptions: { id: TokenSort; label: string }[] = [
   { id: "newest", label: "Newest" },
   { id: "oldest", label: "Oldest" },
-  { id: "market-cap", label: "Highest FDV" },
-  { id: "market-cap-asc", label: "Lowest FDV" },
+  { id: "market-cap", label: "Highest valuation" },
+  { id: "market-cap-asc", label: "Lowest valuation" },
 ];
 const socialFilterOptions: {
   id: Exclude<ExploreSocialFilter, "all">;
@@ -376,17 +368,6 @@ function comparePreviewLaunchOrder(left: LauncherToken, right: LauncherToken) {
   }
 
   return left.tokenAddress.localeCompare(right.tokenAddress);
-}
-
-export function shouldRefreshExplore(input: {
-  visibilityState: DocumentVisibilityState;
-  lastRefreshAt: number;
-  now: number;
-}) {
-  return shouldRefreshLiveData({
-    ...input,
-    intervalMs: EXPLORE_REFRESH_INTERVAL_MS,
-  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1776,7 +1757,7 @@ export function getTokenCards(
             valuationMetric:
               valuation.metric === "market-cap"
                 ? ("Market cap" as const)
-                : ("FDV" as const),
+                : ("Valuation" as const),
           }
         : {}),
       marketStatus: exploreMarketStatusLabel(token),
@@ -1827,16 +1808,6 @@ function resultRangeLabel(payload: ExplorePayload | null) {
   }`;
 }
 
-export function exploreDataQualityMessage(
-  quality: ExploreDataQuality | undefined,
-) {
-  if (!quality) return null;
-  if (quality.valuation.status === "stale") {
-    return "Prices may be out of date";
-  }
-  return null;
-}
-
 export function ExploreView({
   initialResponse,
   loadingOnly = false,
@@ -1856,9 +1827,6 @@ export function ExploreView({
   const [retryKey, setRetryKey] = useState(0);
   const [copyFeedback, setCopyFeedback] = useState("");
   const [copiedTokenId, setCopiedTokenId] = useState<string | null>(null);
-  const refreshKey = useLiveDataRefresh({
-    enabled: !preview && !loadingOnly,
-  });
   const activeExploreContentKey = useRef<string | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const resultStatusRef = useRef<HTMLParagraphElement>(null);
@@ -1869,8 +1837,8 @@ export function ExploreView({
   } | null>(null);
   const filterRef = useRef<HTMLDetailsElement>(null);
   const contentKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
-  const requestKey = `${contentKey}\u0000${retryKey}\u0000${refreshKey}`;
-  const modelDatasetKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}\u0000${refreshKey}`;
+  const requestKey = `${contentKey}\u0000${retryKey}`;
+  const modelDatasetKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}`;
   const activeRequestContentKey =
     modelFilter === "all" ? contentKey : modelDatasetKey;
   const [initialState] = useState(() =>
@@ -2139,7 +2107,6 @@ export function ExploreView({
   const activePage = Math.min(payload?.page ?? currentPage, pageCount);
   const resultLabel =
     displayState.phase === "error" ? "" : resultRangeLabel(payload);
-  const dataQualityMessage = exploreDataQualityMessage(payload?.dataQuality);
   const busy =
     !preview &&
     (displayState.phase === "loading" ||
@@ -2305,7 +2272,15 @@ export function ExploreView({
                 </header>
                 <div className={styles.runnerData}>
                   <span>
-                    <small>{token.valuationMetric ?? "FDV"}</small>
+                    <small
+                      title={
+                        token.valuationMetric === "Valuation"
+                          ? "Fully diluted valuation"
+                          : undefined
+                      }
+                    >
+                      {token.valuationMetric ?? "Valuation"}
+                    </small>
                     <strong>
                       {valuationLabel ??
                         exploreUnavailableFdvLabel(token.marketStatus)}
@@ -2538,10 +2513,14 @@ export function ExploreView({
                       <div
                         className={styles.filterGroup}
                         role="group"
-                        aria-labelledby="explore-fdv-label"
+                        aria-labelledby="explore-valuation-label"
                       >
-                        <p className={styles.filterLabel} id="explore-fdv-label">
-                          FDV
+                        <p
+                          className={styles.filterLabel}
+                          id="explore-valuation-label"
+                          title="Fully diluted valuation"
+                        >
+                          Valuation
                         </p>
                         {sortOptions.slice(2).map((option) => (
                           <button
@@ -2682,20 +2661,6 @@ export function ExploreView({
           <p className="sr-only" role="status" aria-live="polite">
             {copyFeedback}
           </p>
-
-          {displayState.phase === "ready" &&
-          (displayState.refreshError || dataQualityMessage) ? (
-            <div className="token-refresh-warning" role="status">
-              <span>
-                {displayState.refreshError
-                  ? "Prices may be out of date"
-                  : dataQualityMessage}
-              </span>
-              <button type="button" onClick={retryTokens}>
-                Refresh
-              </button>
-            </div>
-          ) : null}
 
           {renderTokenState()}
         </section>

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -28,7 +28,7 @@ describe("Explore UI contract", () => {
     expect(source).toContain(
       "handledInitialExploreRequestKey(initialState, requestKey)",
     );
-    expect(source).toContain("enabled: !preview && !loadingOnly");
+    expect(source).not.toContain("useLiveDataRefresh");
     expect(source).toContain("useState<TokenSort>(DEFAULT_EXPLORE_VIEW_SORT)");
     expect(source).toContain("inert={loadingOnly ? true : undefined}");
     expect(source).toContain("<h1>Explore Hooks</h1>");
@@ -45,7 +45,7 @@ describe("Explore UI contract", () => {
     );
 
     expect(source).toContain('id="explore-model-label"');
-    expect(source).toContain('id="explore-fdv-label"');
+    expect(source).toContain('id="explore-valuation-label"');
     expect(source).toContain('id="explore-age-label"');
     expect(source).toContain('id="explore-socials-label"');
     expect(source).toContain('{ id: "classic", label: "Classic" }');
@@ -55,9 +55,9 @@ describe("Explore UI contract", () => {
     );
     expect(source).toContain('<span>{`Sort: ${activeSortLabel}`}</span>');
     expect(source.indexOf('id="explore-model-label"')).toBeLessThan(
-      source.indexOf('id="explore-fdv-label"'),
+      source.indexOf('id="explore-valuation-label"'),
     );
-    expect(source.indexOf('id="explore-fdv-label"')).toBeLessThan(
+    expect(source.indexOf('id="explore-valuation-label"')).toBeLessThan(
       source.indexOf('id="explore-age-label"'),
     );
     expect(source.indexOf('id="explore-age-label"')).toBeLessThan(

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -4,9 +4,7 @@ import {
   EXPLORE_MOBILE_TOKENS_PER_PAGE,
   EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
   EXPLORE_TOKENS_PER_PAGE,
-  EXPLORE_REFRESH_INTERVAL_MS,
   createExploreInitialState,
-  exploreDataQualityMessage,
   exploreAppliedSortLabel,
   exploreMarketStatusLabel,
   exploreUnavailableFdvLabel,
@@ -24,7 +22,6 @@ import {
   paginateTokensByExploreFilters,
   paginateTokensBySocialPresence,
   preserveExplorePayloadOnRefreshFailure,
-  shouldRefreshExplore,
   tokenHasSocialLinks,
   tokenLaunchModelGroup,
 } from "../components/explore-view";
@@ -933,32 +930,7 @@ describe("Explore refresh state", () => {
     },
   );
 
-  it("refreshes only visible Explore content after the freshness interval", () => {
-    expect(EXPLORE_REFRESH_INTERVAL_MS).toBe(5_000);
-    expect(
-      shouldRefreshExplore({
-        visibilityState: "hidden",
-        lastRefreshAt: 0,
-        now: 20_000,
-      }),
-    ).toBe(false);
-    expect(
-      shouldRefreshExplore({
-        visibilityState: "visible",
-        lastRefreshAt: 5_000,
-        now: 9_999,
-      }),
-    ).toBe(false);
-    expect(
-      shouldRefreshExplore({
-        visibilityState: "visible",
-        lastRefreshAt: 5_000,
-        now: 10_000,
-      }),
-    ).toBe(true);
-  });
-
-  it("exposes total-supply valuation as FDV without calling it market cap", () => {
+  it("presents total-supply FDV as valuation without calling it market cap", () => {
     const token = {
       id: "1:test",
       name: "Test",
@@ -976,22 +948,25 @@ describe("Explore refresh state", () => {
       liquidityPath: "meme",
     } satisfies LauncherToken;
 
-    expect(getExploreValuationMetric({
+    const entry = {
       ...classicEntry(token),
       valuation: {
-        status: "available",
-        metric: "fdv",
-        supplyBasis: "total",
-        currency: "usd",
+        status: "available" as const,
+        metric: "fdv" as const,
+        supplyBasis: "total" as const,
+        currency: "usd" as const,
         valueWad: "125000000000000000000",
-        freshness: "current",
+        freshness: "current" as const,
         asOfBlock: "25730000",
         lagBlocks: "0",
       },
-    })).toEqual({
+    };
+
+    expect(getExploreValuationMetric(entry)).toEqual({
       kind: "usd",
       value: 125,
     });
+    expect(getTokenCards([entry])[0]?.valuationMetric).toBe("Valuation");
   });
 
   it("explains missing FDV without inventing a value", () => {
@@ -1043,7 +1018,6 @@ describe("Explore refresh state", () => {
       payload,
       contentKey: "same-content",
       requestKey: "refresh-request",
-      refreshError: "RPC unavailable",
     });
   });
 
@@ -1245,24 +1219,6 @@ describe("Explore refresh state", () => {
       new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
     )).rejects.toThrow("inconsistent market read data");
     expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not surface a market availability banner", () => {
-    expect(exploreDataQualityMessage(unavailableMarketDataQuality)).toBeNull();
-    expect(exploreDataQualityMessage({
-      ...unavailableMarketDataQuality,
-      launchIdentity: {
-        ...unavailableMarketDataQuality.launchIdentity,
-        status: "partial",
-      },
-    })).toBeNull();
-    expect(exploreDataQualityMessage({
-      ...unavailableMarketDataQuality,
-      launchIdentity: {
-        ...unavailableMarketDataQuality.launchIdentity,
-        status: "last-known-good",
-      },
-    })).toBeNull();
   });
 
   it("retries the first non-USD FDV and returns the second fail-closed", async () => {
@@ -1703,7 +1659,7 @@ describe("Explore refresh state", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(exploreAppliedSortLabel("market-cap", result.ranking)).toBe(
-      "Highest FDV",
+      "Highest valuation",
     );
   });
 
@@ -1916,7 +1872,7 @@ describe("Explore refresh state", () => {
       applied: "qualified-fdv-then-launch-order",
       qualifiedCount: 1,
       totalCount: 2,
-    })).toBe("Available FDV");
+    })).toBe("Available valuation");
   });
 
   it("rejects malformed Dexscreener counts fail closed", async () => {

--- a/tests/interaction-state-regressions.test.ts
+++ b/tests/interaction-state-regressions.test.ts
@@ -110,7 +110,9 @@ describe("interaction state regressions", () => {
     expect(exploreSource).not.toContain("<dt>Market cap</dt>");
     expect(exploreSource).toContain("runnerMeta");
     expect(exploreSource).toContain("runnerData");
-    expect(exploreSource).toContain('token.valuationMetric ?? "FDV"');
+    expect(exploreSource).toContain('token.valuationMetric ?? "Valuation"');
+    expect(exploreSource).not.toContain("Prices may be out of date");
+    expect(exploreSource).not.toContain("useLiveDataRefresh");
     expect(exploreSource).not.toContain("No description yet.");
     expect(exploreSource).not.toContain('{ id: "all", label: "Any" }');
     expect(exploreSource).toMatch(


### PR DESCRIPTION
## Summary
- remove the stale-price banner and its extra layout gap
- stop the open Explore page from polling and dimming every five seconds
- present total-supply pricing as neutral Valuation copy without mislabeling it as market cap

## Validation
- npx vitest run tests/explore-view-state.test.ts tests/interaction-state-regressions.test.ts (56 passed)
- changed-path ESLint
- npm run typecheck
- local default build blocked by the isolated worktree node_modules symlink; required Interface CI runs the production build in a clean checkout