### PR TITLE
Fix Explore combined filters and stable toolbar

### DIFF
--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1086,6 +1086,12 @@
   width: 230px;
 }
 
+.runnersIntro :global(.token-filter) {
+  flex: 0 0 122px;
+  min-width: 122px;
+  width: 122px;
+}
+
 .runnersIntro :global(.token-search:focus-within),
 .runnersIntro :global(.token-filter[open] summary) {
   background: var(--webde-surface-raised);
@@ -1099,8 +1105,10 @@
 }
 
 .runnersIntro :global(.token-filter summary) {
+  justify-content: center;
   min-height: 44px;
   padding-inline: 14px 12px;
+  width: 100%;
 }
 
 .runnersIntro :global(.token-pagination) {
@@ -1130,6 +1138,12 @@
   box-shadow: 0 24px 64px rgb(0 0 0 / 0.58);
   min-width: 230px;
   padding: 8px;
+}
+
+.runnersIntro .filterMenu {
+  left: auto;
+  right: 0;
+  transform-origin: top right;
 }
 
 .filterMenu button {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -113,6 +113,8 @@ export function exploreUnavailableFdvLabel(
 }
 
 type TokenSort = "newest" | "oldest" | "market-cap" | "market-cap-asc";
+export type ExploreValuationSort = "none" | "highest" | "lowest";
+export type ExploreAgeSort = "none" | "newest" | "oldest";
 export type ExploreSocialFilter = "all" | "yes" | "no";
 export type ExploreModelFilter = "all" | "classic" | "custom-hook";
 
@@ -215,7 +217,20 @@ export function exploreAppliedSortLabel(
     (sort === "market-cap" || sort === "market-cap-asc") &&
     ranking?.status === "partial"
   ) return "Available valuation";
-  return sortOptions.find((option) => option.id === sort)?.label ?? "Sort";
+  if (sort === "newest") return "Newest";
+  if (sort === "oldest") return "Oldest";
+  if (sort === "market-cap") return "Highest valuation";
+  return "Lowest valuation";
+}
+
+export function resolveExploreServerSort(
+  valuationSort: ExploreValuationSort,
+  ageSort: ExploreAgeSort,
+): TokenSort {
+  if (valuationSort === "highest") return "market-cap";
+  if (valuationSort === "lowest") return "market-cap-asc";
+  if (ageSort === "oldest") return "oldest";
+  return "newest";
 }
 
 type ExploreState =
@@ -308,11 +323,19 @@ const fallbackTokenImages = [
   "/brand/programmable-token-fallback-05-lavender.webp",
   "/brand/programmable-token-fallback-06-dusk.webp",
 ] as const;
-const sortOptions: { id: TokenSort; label: string }[] = [
+const valuationSortOptions: {
+  id: Exclude<ExploreValuationSort, "none">;
+  label: string;
+}[] = [
+  { id: "highest", label: "Highest" },
+  { id: "lowest", label: "Lowest" },
+];
+const ageSortOptions: {
+  id: Exclude<ExploreAgeSort, "none">;
+  label: string;
+}[] = [
   { id: "newest", label: "Newest" },
   { id: "oldest", label: "Oldest" },
-  { id: "market-cap", label: "Highest valuation" },
-  { id: "market-cap-asc", label: "Lowest valuation" },
 ];
 const socialFilterOptions: {
   id: Exclude<ExploreSocialFilter, "all">;
@@ -977,7 +1000,18 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
 }
 
 function exploreCatalogBoundaryKey(value: ExploreCatalogBoundary) {
-  return JSON.stringify(value);
+  return JSON.stringify({
+    source: value.source,
+    launchSource: value.launchSource,
+    status: value.status,
+    identityCount: value.identityCount,
+    identityCommitment: value.identityCommitment,
+    completeness: value.completeness,
+    scope: value.scope,
+    deployment: value.evidence.deployment,
+    sourceCommit: value.evidence.sourceCommit,
+    evidenceCommitment: value.evidence.commitment,
+  });
 }
 
 function parseExplorePayload(value: unknown): ExplorePayload {
@@ -1566,11 +1600,16 @@ export function paginateExploreModelDataset(
   modelFilter: ExploreModelFilter,
   requestedPage: number,
   pageSize = EXPLORE_TOKENS_PER_PAGE,
+  valuationSort: ExploreValuationSort = "none",
+  ageSort: ExploreAgeSort = "none",
+  socialFilter: ExploreSocialFilter = "all",
 ): ExplorePayload {
-  const page = paginateTokensByExploreFilters(
+  const page = paginateTokensByExploreSelections(
     dataset.tokens,
-    "all",
+    socialFilter,
     modelFilter,
+    valuationSort,
+    ageSort,
     requestedPage,
     pageSize,
   );
@@ -1657,6 +1696,98 @@ export function paginateTokensByExploreFilters<T extends ExploreEntry>(
     page,
     pageSize,
     total: filtered.length,
+    totalPages,
+  };
+}
+
+function compareExploreEntryAge(left: ExploreEntry, right: ExploreEntry) {
+  const leftTime = Date.parse(left.launchedAt);
+  const rightTime = Date.parse(right.launchedAt);
+  if (
+    Number.isFinite(leftTime) &&
+    Number.isFinite(rightTime) &&
+    leftTime !== rightTime
+  ) {
+    return leftTime - rightTime;
+  }
+  if (left.exploreKind === "token" && right.exploreKind === "token") {
+    return comparePreviewLaunchOrder(left, right);
+  }
+  return left.id.localeCompare(right.id);
+}
+
+function compareExploreEntryValuation(
+  left: ExploreEntry | ValuedExploreEntry,
+  right: ExploreEntry | ValuedExploreEntry,
+  direction: Exclude<ExploreValuationSort, "none">,
+) {
+  const leftValuation = valuationForEntry(left);
+  const rightValuation = valuationForEntry(right);
+  const leftQualified = isExploreValuationQualifiedV1(leftValuation);
+  const rightQualified = isExploreValuationQualifiedV1(rightValuation);
+  if (leftQualified !== rightQualified) return leftQualified ? -1 : 1;
+  if (!leftQualified || !rightQualified) return 0;
+  if (leftValuation.currency !== rightValuation.currency) return 0;
+
+  const leftValue = BigInt(leftValuation.valueWad);
+  const rightValue = BigInt(rightValuation.valueWad);
+  if (leftValue === rightValue) return 0;
+  const ascending = leftValue < rightValue ? -1 : 1;
+  return direction === "lowest" ? ascending : -ascending;
+}
+
+export function sortExploreEntriesBySelections<T extends ExploreEntry>(
+  tokens: T[],
+  valuationSort: ExploreValuationSort,
+  ageSort: ExploreAgeSort,
+) {
+  if (valuationSort === "none" && ageSort === "none") return tokens;
+  return [...tokens].sort((left, right) => {
+    if (valuationSort !== "none") {
+      const valuationComparison = compareExploreEntryValuation(
+        left,
+        right,
+        valuationSort,
+      );
+      if (valuationComparison !== 0) return valuationComparison;
+    }
+    if (ageSort !== "none") {
+      const ageComparison = compareExploreEntryAge(left, right);
+      if (ageComparison !== 0) {
+        return ageSort === "newest" ? -ageComparison : ageComparison;
+      }
+    }
+    return 0;
+  });
+}
+
+export function paginateTokensByExploreSelections<T extends ExploreEntry>(
+  tokens: T[],
+  socialFilter: ExploreSocialFilter,
+  modelFilter: ExploreModelFilter,
+  valuationSort: ExploreValuationSort,
+  ageSort: ExploreAgeSort,
+  requestedPage: number,
+  pageSize = EXPLORE_TOKENS_PER_PAGE,
+) {
+  const filtered = filterTokensByLaunchModel(
+    filterTokensBySocialPresence(tokens, socialFilter),
+    modelFilter,
+  );
+  const ranked = sortExploreEntriesBySelections(
+    filtered,
+    valuationSort,
+    ageSort,
+  );
+  const totalPages = Math.ceil(ranked.length / pageSize);
+  const page = totalPages === 0 ? 1 : Math.min(requestedPage, totalPages);
+  const offset = (page - 1) * pageSize;
+
+  return {
+    tokens: ranked.slice(offset, offset + pageSize),
+    page,
+    pageSize,
+    total: ranked.length,
     totalPages,
   };
 }
@@ -1819,7 +1950,10 @@ export function ExploreView({
   const [query, setQuery] = useState("");
   const normalizedQuery = query.trim();
   const [debouncedQuery, setDebouncedQuery] = useState("");
-  const [sort, setSort] = useState<TokenSort>(DEFAULT_EXPLORE_VIEW_SORT);
+  const [valuationSort, setValuationSort] = useState<ExploreValuationSort>(
+    DEFAULT_EXPLORE_VIEW_SORT === "market-cap" ? "highest" : "none",
+  );
+  const [ageSort, setAgeSort] = useState<ExploreAgeSort>("none");
   const [socialFilter, setSocialFilter] = useState<ExploreSocialFilter>("all");
   const [modelFilter, setModelFilter] = useState<ExploreModelFilter>("all");
   const [currentPage, setCurrentPage] = useState(1);
@@ -1836,11 +1970,15 @@ export function ExploreView({
     payload: ExplorePayload;
   } | null>(null);
   const filterRef = useRef<HTMLDetailsElement>(null);
-  const contentKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
+  const sort = resolveExploreServerSort(valuationSort, ageSort);
+  const requiresCompleteDataset =
+    modelFilter !== "all" ||
+    (valuationSort !== "none" && ageSort !== "none");
+  const contentKey = `${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
   const requestKey = `${contentKey}\u0000${retryKey}`;
-  const modelDatasetKey = `${debouncedQuery}\u0000${sort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}`;
+  const modelDatasetKey = `${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}`;
   const activeRequestContentKey =
-    modelFilter === "all" ? contentKey : modelDatasetKey;
+    requiresCompleteDataset ? modelDatasetKey : contentKey;
   const [initialState] = useState(() =>
     createExploreInitialState(initialResponse, {
       requestKey,
@@ -1976,7 +2114,7 @@ export function ExploreView({
     async function loadTokens() {
       try {
         let payload: ExplorePayload;
-        if (modelFilter === "all") {
+        if (!requiresCompleteDataset) {
           payload = await loadExplorePage(
             activeRequestContentKey,
             search,
@@ -2005,6 +2143,9 @@ export function ExploreView({
             modelFilter,
             currentPage,
             pageSize,
+            valuationSort,
+            ageSort,
+            socialFilter,
           );
         }
         if (ignore) return;
@@ -2050,8 +2191,11 @@ export function ExploreView({
     loadingOnly,
     preview,
     requestKey,
+    requiresCompleteDataset,
     socialFilter,
     sort,
+    valuationSort,
+    ageSort,
   ]);
 
   const previewPayload = useMemo<ExplorePayload>(() => {
@@ -2061,24 +2205,15 @@ export function ExploreView({
         value.toLowerCase().includes(searchValue),
       ),
     );
-    const ranked = [...filtered].sort((left, right) => {
-      if (sort === "newest" || sort === "oldest") {
-        const launchComparison = comparePreviewLaunchOrder(left, right);
-        return sort === "newest" ? -launchComparison : launchComparison;
-      }
-      const leftFdv = BigInt(left.indexedMarketCapUsdWad ?? "0");
-      const rightFdv = BigInt(right.indexedMarketCapUsdWad ?? "0");
-      const delta = leftFdv === rightFdv ? 0 : leftFdv > rightFdv ? -1 : 1;
-      return sort === "market-cap" ? delta : -delta;
-    });
-
-    const paginated = paginateTokensByExploreFilters(
-      ranked.map((entry) => ({
+    const paginated = paginateTokensByExploreSelections(
+      filtered.map((entry) => ({
         ...entry,
         valuation: exploreValuation(entry),
       })),
       socialFilter,
       modelFilter,
+      valuationSort,
+      ageSort,
       currentPage,
       pageSize,
     );
@@ -2087,7 +2222,15 @@ export function ExploreView({
       status: "ready",
       ...paginated,
     };
-  }, [currentPage, debouncedQuery, modelFilter, pageSize, socialFilter, sort]);
+  }, [
+    ageSort,
+    currentPage,
+    debouncedQuery,
+    modelFilter,
+    pageSize,
+    socialFilter,
+    valuationSort,
+  ]);
 
   const displayState: ExploreState = preview
     ? {
@@ -2112,9 +2255,31 @@ export function ExploreView({
     (displayState.phase === "loading" ||
       displayState.requestKey !== requestKey);
   const activeFilterCount =
-    Number(socialFilter !== "all") + Number(modelFilter !== "all");
-  const ranking = payload?.ranking;
-  const activeSortLabel = exploreAppliedSortLabel(sort, ranking);
+    Number(socialFilter !== "all") +
+    Number(modelFilter !== "all") +
+    Number(valuationSort !== "none") +
+    Number(ageSort !== "none");
+  const activeSelectionLabels = [
+    modelFilter === "classic"
+      ? "Classic"
+      : modelFilter === "custom-hook"
+        ? "Custom"
+        : null,
+    valuationSort === "highest"
+      ? "Highest valuation"
+      : valuationSort === "lowest"
+        ? "Lowest valuation"
+        : null,
+    ageSort === "newest" ? "Newest" : ageSort === "oldest" ? "Oldest" : null,
+    socialFilter === "yes"
+      ? "With socials"
+      : socialFilter === "no"
+        ? "Without socials"
+        : null,
+  ].filter((label): label is string => label !== null);
+  const activeSelectionSummary = activeSelectionLabels.length === 0
+    ? "No filters or sorts selected"
+    : `${activeSelectionLabels.join(", ")} selected`;
   const hasPublicTokens =
     displayState.phase !== "ready" ||
     displayState.payload.total > 0 ||
@@ -2167,26 +2332,6 @@ export function ExploreView({
     }
 
     if (cards.length === 0) {
-      if (payload?.dataQuality?.launchIdentity.status === "partial") {
-        return (
-          <div className={`${styles.emptyState} liquid-glass-surface`}>
-            <div>
-              <h2>Launches are catching up</h2>
-              <p>
-                Some launches are temporarily unavailable. Try again in a
-                moment.
-              </p>
-            </div>
-            <button
-              className={styles.emptyAction}
-              type="button"
-              onClick={retryTokens}
-            >
-              Refresh
-            </button>
-          </div>
-        );
-      }
       if (debouncedQuery || socialFilter !== "all" || modelFilter !== "all") {
         const hasActiveFilter = socialFilter !== "all" || modelFilter !== "all";
         const noMatchMessage = debouncedQuery
@@ -2207,11 +2352,33 @@ export function ExploreView({
                 setQuery("");
                 setSocialFilter("all");
                 setModelFilter("all");
+                setValuationSort("highest");
+                setAgeSort("none");
                 setCurrentPage(1);
                 searchInputRef.current?.focus();
               }}
             >
               Clear filters
+            </button>
+          </div>
+        );
+      }
+      if (payload?.dataQuality?.launchIdentity.status === "partial") {
+        return (
+          <div className={`${styles.emptyState} liquid-glass-surface`}>
+            <div>
+              <h2>Launches are catching up</h2>
+              <p>
+                Some launches are temporarily unavailable. Try again in a
+                moment.
+              </p>
+            </div>
+            <button
+              className={styles.emptyAction}
+              type="button"
+              onClick={retryTokens}
+            >
+              Refresh
             </button>
           </div>
         );
@@ -2450,23 +2617,17 @@ export function ExploreView({
                     <summary
                       className="liquid-glass-control"
                       aria-controls="explore-filter-panel"
-                      aria-label={
-                        activeFilterCount === 0
-                          ? `Filter and sort tokens, ${activeSortLabel} selected`
-                          : `Filter and sort tokens, ${activeSortLabel} selected, ${activeFilterCount} ${
-                              activeFilterCount === 1 ? "filter" : "filters"
-                            } active`
-                      }
+                      aria-label={`Filter and sort tokens. ${activeSelectionSummary}. ${activeFilterCount} ${
+                        activeFilterCount === 1 ? "selection" : "selections"
+                      } active.`}
                     >
-                      <span>{`Sort: ${activeSortLabel}`}</span>
-                      {activeFilterCount > 0 ? (
-                        <span
-                          className={styles.activeFilterCount}
-                          aria-hidden="true"
-                        >
-                          {activeFilterCount}
-                        </span>
-                      ) : null}
+                      <span>Filters</span>
+                      <span
+                        className={styles.activeFilterCount}
+                        aria-hidden="true"
+                      >
+                        {activeFilterCount}
+                      </span>
                       <ChevronDown
                         className="token-filter-chevron"
                         aria-hidden="true"
@@ -2522,19 +2683,25 @@ export function ExploreView({
                         >
                           Valuation
                         </p>
-                        {sortOptions.slice(2).map((option) => (
+                        {valuationSortOptions.map((option) => (
                           <button
                             key={option.id}
-                            className={sort === option.id ? "active" : undefined}
+                            className={
+                              valuationSort === option.id ? "active" : undefined
+                            }
                             type="button"
-                            aria-pressed={sort === option.id}
+                            aria-pressed={valuationSort === option.id}
                             onClick={() => {
-                              setSort(option.id);
+                              setValuationSort((current) =>
+                                current === option.id ? "none" : option.id,
+                              );
                               setCurrentPage(1);
                             }}
                           >
-                            <span>{option.id === "market-cap" ? "Highest" : "Lowest"}</span>
-                            {sort === option.id ? <Check aria-hidden="true" size={15} /> : null}
+                            <span>{option.label}</span>
+                            {valuationSort === option.id ? (
+                              <Check aria-hidden="true" size={15} />
+                            ) : null}
                           </button>
                         ))}
                       </div>
@@ -2547,19 +2714,25 @@ export function ExploreView({
                         <p className={styles.filterLabel} id="explore-age-label">
                           Age
                         </p>
-                        {sortOptions.slice(0, 2).map((option) => (
+                        {ageSortOptions.map((option) => (
                           <button
                             key={option.id}
-                            className={sort === option.id ? "active" : undefined}
+                            className={
+                              ageSort === option.id ? "active" : undefined
+                            }
                             type="button"
-                            aria-pressed={sort === option.id}
+                            aria-pressed={ageSort === option.id}
                             onClick={() => {
-                              setSort(option.id);
+                              setAgeSort((current) =>
+                                current === option.id ? "none" : option.id,
+                              );
                               setCurrentPage(1);
                             }}
                           >
                             <span>{option.label}</span>
-                            {sort === option.id ? <Check aria-hidden="true" size={15} /> : null}
+                            {ageSort === option.id ? (
+                              <Check aria-hidden="true" size={15} />
+                            ) : null}
                           </button>
                         ))}
                       </div>

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -29,7 +29,12 @@ describe("Explore UI contract", () => {
       "handledInitialExploreRequestKey(initialState, requestKey)",
     );
     expect(source).not.toContain("useLiveDataRefresh");
-    expect(source).toContain("useState<TokenSort>(DEFAULT_EXPLORE_VIEW_SORT)");
+    expect(source).toContain(
+      "const [valuationSort, setValuationSort] = useState<ExploreValuationSort>",
+    );
+    expect(source).toContain(
+      'const [ageSort, setAgeSort] = useState<ExploreAgeSort>("none")',
+    );
     expect(source).toContain("inert={loadingOnly ? true : undefined}");
     expect(source).toContain("<h1>Explore Hooks</h1>");
     expect(source).not.toContain("ExploreGridSkeleton");
@@ -43,6 +48,10 @@ describe("Explore UI contract", () => {
       join(root, "components/explore-view.tsx"),
       "utf8",
     );
+    const styles = readFileSync(
+      join(root, "components/explore-experience.module.css"),
+      "utf8",
+    );
 
     expect(source).toContain('id="explore-model-label"');
     expect(source).toContain('id="explore-valuation-label"');
@@ -50,10 +59,10 @@ describe("Explore UI contract", () => {
     expect(source).toContain('id="explore-socials-label"');
     expect(source).toContain('{ id: "classic", label: "Classic" }');
     expect(source).toContain('{ id: "custom-hook", label: "Custom" }');
-    expect(source).toContain(
-      'Number(socialFilter !== "all") + Number(modelFilter !== "all")',
-    );
-    expect(source).toContain('<span>{`Sort: ${activeSortLabel}`}</span>');
+    expect(source).toContain('Number(valuationSort !== "none")');
+    expect(source).toContain('Number(ageSort !== "none")');
+    expect(source).toContain("<span>Filters</span>");
+    expect(source).toContain("{activeFilterCount}");
     expect(source.indexOf('id="explore-model-label"')).toBeLessThan(
       source.indexOf('id="explore-valuation-label"'),
     );
@@ -63,7 +72,26 @@ describe("Explore UI contract", () => {
     expect(source.indexOf('id="explore-age-label"')).toBeLessThan(
       source.indexOf('id="explore-socials-label"'),
     );
-    expect(source).toContain("useState<TokenSort>(DEFAULT_EXPLORE_VIEW_SORT)");
+    expect(source).toContain("valuationSortOptions.map((option) => (");
+    expect(source).toContain("ageSortOptions.map((option) => (");
+    expect(source).toContain("setValuationSort((current) =>");
+    expect(source).toContain("setAgeSort((current) =>");
+    expect(source).not.toContain("setSort(option.id)");
+    expect(styles).toMatch(
+      /\.runnersIntro :global\(\.token-filter\)\s*\{[^}]*flex:\s*0 0 122px;[^}]*width:\s*122px;/s,
+    );
+    expect(styles).toMatch(
+      /\.runnersIntro \.filterMenu\s*\{[^}]*left:\s*auto;[^}]*right:\s*0;[^}]*transform-origin:\s*top right;/s,
+    );
+    expect(
+      source.indexOf(
+        'if (debouncedQuery || socialFilter !== "all" || modelFilter !== "all")',
+      ),
+    ).toBeLessThan(
+      source.indexOf(
+        'if (payload?.dataQuality?.launchIdentity.status === "partial")',
+      ),
+    );
     expect(source).not.toMatch(
       /onClick=\{\(\) => \{[\s\S]{0,300}filterRef\.current/s,
     );

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -20,8 +20,11 @@ import {
   loadExplorePayload,
   paginateExploreModelDataset,
   paginateTokensByExploreFilters,
+  paginateTokensByExploreSelections,
   paginateTokensBySocialPresence,
   preserveExplorePayloadOnRefreshFailure,
+  resolveExploreServerSort,
+  sortExploreEntriesBySelections,
   tokenHasSocialLinks,
   tokenLaunchModelGroup,
 } from "../components/explore-view";
@@ -584,6 +587,58 @@ describe("Explore refresh state", () => {
     ).toMatchObject({ total: 0, totalPages: 0, tokens: [] });
   });
 
+  it("combines Hook Type, valuation and age ordering without clearing a selection", () => {
+    const valued = (
+      index: number,
+      valueWad: string,
+      launchedAt: string,
+    ) => ({
+      ...modelFilterEntry(index, "available"),
+      launchedAt,
+      valuation: {
+        ...modelFilterEntry(index, "available").valuation,
+        valueWad,
+      },
+    });
+    const highOld = valued(1, "9000000000000000000", "2026-08-01T00:00:00.000Z");
+    const highNew = valued(2, "9000000000000000000", "2026-08-04T00:00:00.000Z");
+    const lowNewest = valued(3, "2000000000000000000", "2026-08-05T00:00:00.000Z");
+    const unavailable = {
+      ...modelFilterEntry(4, "unavailable"),
+      launchedAt: "2026-08-06T00:00:00.000Z",
+    };
+
+    expect(resolveExploreServerSort("highest", "newest")).toBe("market-cap");
+    expect(resolveExploreServerSort("none", "oldest")).toBe("oldest");
+    expect(
+      sortExploreEntriesBySelections(
+        [lowNewest, highOld, unavailable, highNew],
+        "highest",
+        "newest",
+      ).map((token) => token.id),
+    ).toEqual([highNew.id, highOld.id, lowNewest.id, unavailable.id]);
+    expect(
+      paginateTokensByExploreSelections(
+        [customEntry(99), lowNewest, highOld, unavailable, highNew],
+        "all",
+        "classic",
+        "highest",
+        "newest",
+        1,
+        2,
+      ),
+    ).toMatchObject({
+      page: 1,
+      pageSize: 2,
+      total: 4,
+      totalPages: 2,
+      tokens: [
+        expect.objectContaining({ id: highNew.id }),
+        expect.objectContaining({ id: highOld.id }),
+      ],
+    });
+  });
+
   it("loads every server page before model filtering and preserves server order", async () => {
     const tokens = Array.from({ length: 230 }, (_, index) => index < 145
       ? classicEntry({
@@ -698,6 +753,47 @@ describe("Explore refresh state", () => {
       "commitment-drift-model-dataset",
       new URLSearchParams({ sort: "newest", page: "1", limit: "9" }),
     )).rejects.toThrow("Tokens changed while filters were loading");
+  });
+
+  it("accepts index progress advancing between pages when identity stays exact", async () => {
+    const tokens = Array.from(
+      { length: EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE + 1 },
+      (_, index) => modelFilterEntry(index, "unavailable"),
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(String(input), "https://example.test");
+      const page = Number(url.searchParams.get("page"));
+      const pageSize = Number(url.searchParams.get("limit"));
+      const asOfBlock = page === 1 ? "25740000" : "25740001";
+      return new Response(JSON.stringify({
+        status: "ready",
+        tokens: tokens.slice((page - 1) * pageSize, page * pageSize),
+        page,
+        pageSize,
+        total: tokens.length,
+        totalPages: 2,
+        catalog: {
+          ...catalogBoundary,
+          lastIndexedAt: page === 1
+            ? "2026-08-14T00:00:00.000Z"
+            : "2026-08-14T00:00:12.000Z",
+          asOfBlock,
+          asOfBlockHash: page === 1
+            ? catalogBoundary.asOfBlockHash
+            : `0x${"bc".repeat(32)}`,
+          identityCount: tokens.length,
+          evidence: {
+            ...catalogBoundary.evidence,
+            progressBlock: asOfBlock,
+          },
+        },
+      }), { status: 200 });
+    });
+
+    await expect(loadExploreModelDataset(
+      "progress-only-drift-model-dataset",
+      new URLSearchParams({ sort: "newest", page: "1", limit: "9" }),
+    )).resolves.toMatchObject({ total: tokens.length, totalPages: 2 });
   });
 
   it("preserves an all-page transport marker and does not cache the degraded model dataset", async () => {


### PR DESCRIPTION
## What changed
- keep Hook Type, valuation and age selections independently active
- apply search first, then model filters and deterministic valuation plus age ordering
- keep the filter control fixed in place and anchor its popover inside the viewport
- accept index progress between pagination reads when the identity commitment is unchanged
- show a real no-results state for searches instead of an index warning

## Focused verification
- changed-path ESLint
- TypeScript typecheck
- 78 focused Explore, interaction, and accessibility tests
- desktop and mobile browser QA, including zero horizontal overflow