### PR TITLE
Fail over Classic trade preparation RPC

### DIFF
--- a/app/api/trade/prepare/route.ts
+++ b/app/api/trade/prepare/route.ts
@@ -28,7 +28,10 @@ import {
   ActionRpcIdentityError,
   readTradeActionModelFromRpc,
 } from "../../../../lib/server/action-rpc-identity.server";
-import { tradeActionRpcProvider } from "../../../../lib/server/action-rpc-quorum.server";
+import { getWebsiteReadOnchainDeployment } from
+  "../../../../lib/onchain/config";
+import { withOperationalRpcFailover } from
+  "../../../../lib/onchain/operational-rpc-failover.server";
 import { safeServerErrorSummary } from "../../../../lib/server/safe-error";
 
 export const dynamic = "force-dynamic";
@@ -127,52 +130,66 @@ export async function POST(request: NextRequest) {
         "Trading identity is only available on Ethereum mainnet",
       );
     }
-    const provider = tradeActionRpcProvider(actionChainId);
-    const client = createPublicClient({
-      chain: actionChainId === 1 ? mainnet : sepolia,
-      transport: http(provider.endpoint, {
-        retryCount: 1,
-        timeout: 12_000,
-      }),
-    });
-    const blockNumber = await client.getBlockNumber();
-    const block = await client.getBlock({ blockNumber });
-    if (!block.hash) throw new Error("The action snapshot has no block hash");
-    const registry = await readTradeActionModelFromRpc({
-      client,
-      chainId: actionChainId,
-      token: tradeRequest.token,
-      blockNumber,
-      blockHash: block.hash,
-    });
-    const indexedToken = registry.tokens.find(
-      (candidate) =>
-        candidate.tokenAddress.toLowerCase() ===
-        tradeRequest.token.toLowerCase(),
-    );
-    if (indexedToken?.launchModel === "stock-paired") {
-      const { deployment } = resolveStockPairedTradeDeployment(
-        tradeRequest.chainId,
-        registry,
-        tradeRequest.token,
+    const rpcDeployment = getWebsiteReadOnchainDeployment("production");
+    if (
+      rpcDeployment.status !== "ready" ||
+      rpcDeployment.chainId !== actionChainId
+    ) {
+      throw new ClassicTradeUnavailableError(
+        "The configured Ethereum RPC is unavailable",
       );
-      const prepared = await prepareStockPairedTrade(
-        runtimeClient(client),
-        deployment,
-        tradeRequest,
-      );
-      return json(prepared);
     }
-    const deployment = resolveTradeDeployment(
-      tradeRequest.chainId,
-      registry,
-      tradeRequest.token,
-    );
-    const prepared = await prepareClassicTrade(
-      runtimeClient(client),
-      deployment,
-      tradeRequest,
-      registry,
+    const prepared = await withOperationalRpcFailover(
+      rpcDeployment,
+      async ({ rpcUrl }) => {
+        const client = createPublicClient({
+          chain: actionChainId === 1 ? mainnet : sepolia,
+          transport: http(rpcUrl, {
+            retryCount: 1,
+            timeout: 12_000,
+          }),
+        });
+        const blockNumber = await client.getBlockNumber();
+        const block = await client.getBlock({ blockNumber });
+        if (!block.hash) {
+          throw new Error("The action snapshot has no block hash");
+        }
+        const registry = await readTradeActionModelFromRpc({
+          client,
+          chainId: actionChainId,
+          token: tradeRequest.token,
+          blockNumber,
+          blockHash: block.hash,
+        });
+        const indexedToken = registry.tokens.find(
+          (candidate) =>
+            candidate.tokenAddress.toLowerCase() ===
+            tradeRequest.token.toLowerCase(),
+        );
+        if (indexedToken?.launchModel === "stock-paired") {
+          const { deployment } = resolveStockPairedTradeDeployment(
+            tradeRequest.chainId,
+            registry,
+            tradeRequest.token,
+          );
+          return prepareStockPairedTrade(
+            runtimeClient(client),
+            deployment,
+            tradeRequest,
+          );
+        }
+        const deployment = resolveTradeDeployment(
+          tradeRequest.chainId,
+          registry,
+          tradeRequest.token,
+        );
+        return prepareClassicTrade(
+          runtimeClient(client),
+          deployment,
+          tradeRequest,
+          registry,
+        );
+      },
     );
     return json(prepared);
   } catch (error) {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2182,7 +2182,11 @@ export function evaluateReadModelOperationsSourceContracts(
       !/bitquery|alchemy|durable|blob|secondary|fallback|quorum|subgraph|stateview|chainlink|envio/iu.test(
         actionRpcIdentity,
       ) &&
-      tradePrepare.includes("tradeActionRpcProvider") &&
+      includesEverySourceFragment(tradePrepare, [
+        "getWebsiteReadOnchainDeployment",
+        "withOperationalRpcFailover",
+      ]) &&
+      !tradePrepare.includes("tradeActionRpcProvider") &&
       !tradePrepare.includes("tradeActionRpcProviders") &&
       tradePrepare.includes('"Cache-Control": "no-store"') &&
       creatorClaimPrepare.includes("creatorClaimRpcProvider") &&
@@ -2201,7 +2205,7 @@ export function evaluateReadModelOperationsSourceContracts(
         (route) =>
           !/Promise\.allSettled|secondaryProvider|fallbackProvider/u.test(route),
       ),
-    "Profile, Claim and Trade retain singular commitment-bound dRPC reads, non-enumerable endpoints, no write authority and no hidden fallback",
+    "Profile and Claim retain singular commitment-bound dRPC reads while Trade permits one complete-operation QuickNode retry only after an eligible dRPC transport or capacity failure; all action routes retain no write authority or hidden provider rotation",
   );
   check(
     "ops-staged-envio-catalog-gate",

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -895,15 +895,15 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("rejects a public action route that restores RPC quorum selection", () => {
+  it("rejects a public trade route that removes bounded operational failover", () => {
     const path = "app/api/trade/prepare/route.ts";
     const route = readFileSync(resolve(ROOT, path), "utf8");
-    expect(route).toContain("tradeActionRpcProvider");
+    expect(route).toContain("withOperationalRpcFailover");
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: {
         [path]: route.replaceAll(
-          "tradeActionRpcProvider",
-          "tradeActionRpcProviders",
+          "withOperationalRpcFailover",
+          "withoutOperationalRpcFailover",
         ),
       },
     });

--- a/tests/trade-action-activation.test.ts
+++ b/tests/trade-action-activation.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RpcRequestError } from "viem";
 
 vi.mock("server-only", () => ({}));
 
@@ -181,12 +182,19 @@ describe("trade action identity activation", () => {
   );
 
   it.each([true, false])(
-    "does not consult the configured secondary RPC with indexed lookup %s",
+    "keeps a healthy preparation on the primary RPC with indexed lookup %s",
     async (indexedEnabled) => {
       mocks.indexedEnabled = indexedEnabled;
       vi.stubEnv(
         "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_URL",
         "https://second-node.ethereum-mainnet.quiknode.pro/second-secret-key/",
+      );
+      vi.stubEnv(
+        "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT",
+        rpcProviderCommitment(
+          "endpoint",
+          "https://second-node.ethereum-mainnet.quiknode.pro/second-secret-key/",
+        ),
       );
 
       const response = await POST(request());
@@ -201,6 +209,32 @@ describe("trade action identity activation", () => {
       expect(serialized).not.toContain("second-secret-key");
     },
   );
+
+  it("retries the complete preparation once on the bound secondary after dRPC code 10", async () => {
+    const primaryRpcError = new RpcRequestError({
+      body: { method: "eth_blockNumber" },
+      error: { code: 10, message: "User balance exceeded" },
+      url: "https://lb.drpc.live/ethereum/drpc-action-key",
+    });
+    mocks.createPublicClient
+      .mockReturnValueOnce({
+        getBlockNumber: vi.fn().mockRejectedValue(primaryRpcError),
+      } as never)
+      .mockReturnValueOnce({
+        getBlockNumber: vi.fn().mockResolvedValue(101n),
+        getBlock: vi.fn().mockResolvedValue({ hash: `0x${"33".repeat(32)}` }),
+      } as never);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(2);
+    expect(mocks.readIdentity).toHaveBeenCalledTimes(1);
+    expect(mocks.prepare).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toMatchObject({
+      quote: { amountOut: "100" },
+    });
+  });
 
   it("rejects a primary endpoint that does not match its commitment", async () => {
     vi.stubEnv(


### PR DESCRIPTION
## Summary
- retry one complete Classic trade preparation on the commitment-bound QuickNode secondary only after an eligible dRPC transport or capacity failure
- preserve token/pool verification, quote construction, wallet simulation, and all semantic failures unchanged
- update the provider-boundary source contract and regression coverage

## Live cause
The production primary returned dRPC code 10 (`User balance exceeded`), causing `/api/trade/prepare` to return 502 before a trade could be prepared.

## Validation
- 115 focused trade/failover/source-contract tests passed
- `npm run typecheck`
- changed-path ESLint