### PR TITLE
Enable pool-bound token price charts

### DIFF
--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -1,11 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAddress, isAddress } from "viem";
 
+import { readBitqueryMarketChartV1 } from
+  "../../../../../lib/market-data/bitquery.server";
 import {
   mergeEnvioClassicV3CatalogEntriesV1,
   readEnvioClassicV3CatalogV1,
 } from
   "../../../../../lib/market-data/envio-classic-v3-catalog.server";
+import { exploreEntryMarketIdentitiesV1 } from
+  "../../../../../lib/market-data/explore-market-identities";
+import type {
+  MarketChartErrorV1,
+  MarketChartV1,
+} from "../../../../../lib/market-data/market-data-v1";
 import { isTokenChartRange } from "../../../../../lib/onchain/chart";
 import { readProductionCustomExploreDirectoryV1 } from
   "../../../../../lib/server/custom-launch/explore-directory-v1";
@@ -14,6 +22,9 @@ import { isCustomLaunchRegistryPublicReadEnabled } from
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+const TOKEN_CHART_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=2, stale-while-revalidate=2";
 
 export async function GET(request: NextRequest) {
   const search = request.nextUrl.searchParams;
@@ -50,27 +61,65 @@ export async function GET(request: NextRequest) {
         // canonical identity, but an unknown address remains indeterminate.
         if (!entries.some((entry) =>
           entry.tokenAddress?.toLowerCase() === address.toLowerCase()
-        )) return unavailable(address, range, catalog.source, 503);
+        )) {
+          return unavailable({
+            address,
+            range,
+            launchSource: catalog.source,
+            reason: "identity-unavailable",
+            status: 503,
+          });
+        }
       }
       if (customEntries !== undefined) {
         entries = mergeEnvioClassicV3CatalogEntriesV1(entries, customEntries);
         customStatus = "current";
       }
     }
-    if (!entries.some((entry) =>
-      entry.tokenAddress?.toLowerCase() === address.toLowerCase()
-    )) {
+    const entry = entries.find((candidate) =>
+      candidate.tokenAddress?.toLowerCase() === address.toLowerCase()
+    );
+    if (entry === undefined) {
       return json({ error: "Token not found" }, 404);
     }
     const launchSource = customStatus === "current"
       ? `${catalog.source}+registry.custom-launched`
       : catalog.source;
-    return unavailable(address, range, launchSource, 200);
+    const identities = exploreEntryMarketIdentitiesV1(entry);
+    if (identities.length !== 1) {
+      return unavailable({
+        address,
+        range,
+        launchSource,
+        reason: "identity-unavailable",
+      });
+    }
+    if (range === "all" && !Number.isFinite(Date.parse(entry.launchedAt))) {
+      return unavailable({
+        address,
+        range,
+        launchSource,
+        reason: "identity-unavailable",
+      });
+    }
+    const chart = await readBitqueryMarketChartV1({
+      identity: identities[0],
+      range,
+      ...(range === "all" ? { historyStart: entry.launchedAt } : {}),
+      signal: request.signal,
+    });
+    return chartResponse(chart, launchSource);
   } catch (error) {
     console.error("Token chart identity read failed", {
       name: error instanceof Error ? error.name : "LaunchCatalogError",
     });
-    return unavailable(address, range, "envio-classic-v3", 503);
+    return unavailable({
+      address,
+      range,
+      launchSource: "envio-classic-v3",
+      reason: "market-data-unavailable",
+      status: 503,
+    });
   }
 }
 
@@ -81,31 +130,64 @@ function json(body: unknown, status: number) {
   });
 }
 
-function unavailable(
-  address: `0x${string}`,
-  range: string,
-  launchSource: string,
-  status: 200 | 503,
-) {
+function unavailable(input: Readonly<{
+  address: `0x${string}`;
+  range: "1h" | "1d" | "1w" | "all";
+  launchSource: string;
+  reason: MarketChartErrorV1["reason"];
+  status?: 200 | 503;
+}>) {
+  const status = input.status ?? 200;
+  const body: MarketChartErrorV1 = {
+    schemaVersion: "programmable.market-chart-error.v1",
+    source: "bitquery",
+    status: "unavailable",
+    generatedAt: new Date().toISOString(),
+    address: input.address,
+    range: input.range,
+    reason: input.reason,
+    error: "Price history is temporarily unavailable",
+  };
   return NextResponse.json(
-    {
-      schemaVersion: "programmable.market-chart-unavailable.v1",
-      source: null,
-      status: "unavailable",
-      generatedAt: new Date().toISOString(),
-      address,
-      range,
-      reason: "history-provider-unavailable",
-    },
+    body,
     {
       status,
       headers: {
-        "Cache-Control": "no-store",
+        "Cache-Control": status === 503 ? "no-store" : TOKEN_CHART_CACHE_CONTROL,
         "X-Programmable-Data-Quality": "unavailable",
-        "X-Programmable-Launch-Source": launchSource,
-        "X-Programmable-Read-Source": launchSource,
+        "X-Programmable-Launch-Source": input.launchSource,
+        "X-Programmable-Read-Source": input.launchSource,
         ...(status === 503 ? { "Retry-After": "5" } : {}),
       },
     },
   );
+}
+
+function chartResponse(chart: MarketChartV1, launchSource: string) {
+  const dataQuality = chart.status === "ready" ||
+      chart.status === "insufficient-history"
+    ? "current"
+    : chart.status === "partial"
+      ? "partial"
+      : "unavailable";
+  const hasPriceHistory = chart.points.length > 0;
+  return NextResponse.json(chart, {
+    headers: {
+      "Cache-Control": TOKEN_CHART_CACHE_CONTROL,
+      "X-Programmable-Data-Quality": dataQuality,
+      "X-Programmable-Launch-Source": launchSource,
+      "X-Programmable-Read-Source": `${launchSource}+bitquery`,
+      "X-Programmable-Market-Provider": "bitquery",
+      "X-Programmable-Market-Read-Status": chart.readStatus,
+      ...(hasPriceHistory
+        ? {
+            "X-Programmable-Market-Source": "bitquery",
+            "X-Programmable-Price-Source": "bitquery",
+          }
+        : {}),
+      ...(chart.asOfTime
+        ? { "X-Programmable-Market-As-Of": chart.asOfTime }
+        : {}),
+    },
+  });
 }

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -273,6 +273,12 @@ const CHART_RANGES: ReadonlyArray<{
   { value: "all", label: "ALL" },
 ];
 
+function shouldEnablePriceHistory(
+  launchModel: ChartLaunchModel | undefined,
+): boolean {
+  return launchModel !== "stock-paired";
+}
+
 const VIEWBOX_WIDTH = 600;
 const VIEWBOX_HEIGHT = 132;
 const PLOT_LEFT = 7;
@@ -476,9 +482,9 @@ export function TokenPriceChart({
   preview?: boolean;
   onVolumeChange?: (volume: TokenChartVolume | null) => void;
 }) {
-  // The interim public runtime has no authoritative historical provider.
-  // Preview fixtures remain available without enabling any live request path.
-  const historyEnabled = preview;
+  // Live history is read only through the exact pool-bound chart endpoint.
+  // Stock-Paired families intentionally remain outside the public chart scope.
+  const historyEnabled = shouldEnablePriceHistory(launchModel);
   const [request, setRequest] = useState<ChartRequestState | null>(null);
   const [range, setRange] = useState<ChartRange>("1d");
   const [activePointIndex, setActivePointIndex] = useState<number | null>(

--- a/docs/operations/read-model-scheduler-cutover.md
+++ b/docs/operations/read-model-scheduler-cutover.md
@@ -79,9 +79,10 @@ normal release gate:
    `413` or `5xx` responses; the minute crons keep the read model progressing.
 
 Visible Explore and token detail clients continue their bounded refreshes while
-the tab is visible. Historical chart requests are disabled in the interim and
-the chart route reports `history-provider-unavailable`; it does not fall back to
-the retired dRPC/Bitquery history scan.
+the tab is visible. Historical chart requests use the bounded Bitquery reader
+only after exact token, quote-asset and Uniswap v4 pool binding. A provider
+outage returns an unavailable chart without hiding the verified token identity;
+the route does not fall back to the retired dRPC history scan.
 
 `/api/ops/index-v2` is the only legacy writer route. The former
 `/api/ops/index` alias is permanently closed and is not scheduled.

--- a/scripts/perf/read-model-capture.mjs
+++ b/scripts/perf/read-model-capture.mjs
@@ -340,7 +340,7 @@ function responseMatchesDatasetKey(route, body, datasetKey, expectedRange) {
   }
   if (route === "tokenChart") {
     return (
-      sameAddress(body.address, datasetKey) &&
+      sameAddress(body.identity?.tokenAddress, datasetKey) &&
       Array.isArray(body.points) &&
       body.range === expectedRange
     );

--- a/scripts/perf/read-model-live-verifier.mjs
+++ b/scripts/perf/read-model-live-verifier.mjs
@@ -399,8 +399,8 @@ export async function verifyLiveCacheAndKeyContracts(input) {
     {
       id: "cache-key-chart-address",
       condition:
-        sameAddress(chartPrimary.body?.address, primaryTokenAddress) &&
-        sameAddress(chartSecondary.body?.address, secondaryTokenAddress),
+        sameAddress(chartPrimary.body?.identity?.tokenAddress, primaryTokenAddress) &&
+        sameAddress(chartSecondary.body?.identity?.tokenAddress, secondaryTokenAddress),
       detail: "chart cache keys preserve distinct token addresses",
     },
     {
@@ -409,7 +409,7 @@ export async function verifyLiveCacheAndKeyContracts(input) {
         chartPrimary.body?.range === "all" &&
         chartSecondary.body?.range === "all" &&
         chartHour.body?.range === "1h" &&
-        sameAddress(chartHour.body?.address, primaryTokenAddress),
+        sameAddress(chartHour.body?.identity?.tokenAddress, primaryTokenAddress),
       detail: "chart cache keys preserve distinct ranges",
     },
     {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2116,23 +2116,27 @@ export function evaluateReadModelOperationsSourceContracts(
       publicToken,
     ) &&
     includesEverySourceFragment(publicChart, [
+      "readBitqueryMarketChartV1({",
       "readEnvioClassicV3CatalogV1({",
+      "exploreEntryMarketIdentitiesV1(entry)",
       "mergeEnvioClassicV3CatalogEntriesV1(",
       "readProductionCustomExploreDirectoryV1(request.signal)",
       'let customStatus: "current" | "unavailable" = "unavailable"',
       '`${catalog.source}+registry.custom-launched`',
-      'schemaVersion: "programmable.market-chart-unavailable.v1"',
-      'reason: "history-provider-unavailable"',
-      'source: null',
-      '"Cache-Control": "no-store"',
+      'schemaVersion: "programmable.market-chart-error.v1"',
+      'reason: "identity-unavailable"',
+      '"X-Programmable-Market-Provider": "bitquery"',
+      '"X-Programmable-Market-Read-Status": chart.readStatus',
+      '"X-Programmable-Read-Source": `${launchSource}+bitquery`',
+      "TOKEN_CHART_CACHE_CONTROL",
     ]) &&
-    !/readPrimaryRpcExploreEntriesV1|readBitquery|productionMainnetRpcPrimary/iu.test(
+    !/readPrimaryRpcExploreEntriesV1|productionMainnetRpcPrimary/iu.test(
       publicChart,
     );
   check(
     "ops-public-provider-split-source-contract",
     fastLanePublicProviderContract,
-    "Explore list and token detail use the validated Envio Classic V3 catalog plus bounded exact-identity Dexscreener enrichment while profile and action routes retain their committed dRPC semantics",
+    "Explore list and token detail use the validated Envio Classic V3 catalog plus bounded exact-identity Dexscreener enrichment; charts bind one exact pool through Bitquery while profile and action routes retain their committed dRPC semantics",
   );
   const publicProfileAndActionRoutes = [
     publicCreatorProfile,
@@ -2300,10 +2304,11 @@ export function evaluateReadModelOperationsSourceContracts(
         'profile.headers.get("x-programmable-launch-source") === "drpc"',
         'profile.headers.get("x-programmable-read-source") === "drpc"',
         'profile.headers.get("x-programmable-rpc-provider") === "drpc-primary"',
-        'schemaVersion !== "programmable.market-chart-unavailable.v1"',
-        'chart.headers.get("cache-control") !== "no-store"',
-        'chart.headers.get("x-programmable-data-quality") !== "unavailable"',
-        'chart.headers.get("x-programmable-market-provider") !== null',
+        'schemaVersion !== "programmable.market-chart.v1"',
+        'chart.body?.source !== "bitquery"',
+        'chart.body?.identity?.tokenAddress?.toLowerCase() !== tokenAddress.toLowerCase()',
+        'chart.headers.get("cache-control") !==\n      "public, max-age=0, s-maxage=2, stale-while-revalidate=2"',
+        'chart.headers.get("x-programmable-market-provider") !== "bitquery"',
         'chart.headers.get("x-programmable-valuation-block") !== null',
         'detail.headers.get("x-programmable-market-provider") !== "dexscreener"',
         'marketProvider: "dexscreener"',

--- a/scripts/perf/read-model-post-promotion.mjs
+++ b/scripts/perf/read-model-post-promotion.mjs
@@ -122,7 +122,7 @@ export async function verifyPostPromotion(input) {
     id: "production-static-identity-dexscreener-public-apis",
     status: publicSurface ? "pass" : "fail",
     detail:
-      "production serves one catalog-bound identity surface with optional exact-pool Dexscreener enrichment, profile reads, and an explicit provider-free chart",
+      "production serves one catalog-bound identity surface with optional exact-pool Dexscreener enrichment, profile reads, and an exact pool-bound Bitquery chart",
   });
   const failures = checks
     .filter(({ status }) => status !== "pass")

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -662,27 +662,44 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
     "/api/explore/token/chart?address=" + encodeURIComponent(tokenAddress) +
       "&range=1d",
   );
+  const chartHasHistory = Array.isArray(chart.body?.points) &&
+    chart.body.points.length > 0;
   if (
     chart.status !== 200 ||
-    chart.body?.schemaVersion !== "programmable.market-chart-unavailable.v1" ||
-    chart.body?.source !== null ||
-    chart.body?.status !== "unavailable" ||
-    chart.body?.reason !== "history-provider-unavailable" ||
-    chart.body?.address?.toLowerCase() !== tokenAddress.toLowerCase() ||
+    chart.body?.schemaVersion !== "programmable.market-chart.v1" ||
+    chart.body?.source !== "bitquery" ||
+    !["ready", "insufficient-history", "partial", "waiting-for-first-trade", "unavailable"].includes(chart.body?.status) ||
+    !["live", "cache-fallback"].includes(chart.body?.readStatus) ||
+    chart.body?.identity?.tokenAddress?.toLowerCase() !== tokenAddress.toLowerCase() ||
     chart.body?.range !== "1d" ||
-    chart.headers.get("cache-control") !== "no-store" ||
-    chart.headers.get("x-programmable-data-quality") !== "unavailable" ||
+    chart.body?.valuation?.status !== "unavailable" ||
+    chart.body?.valuation?.reason !== "source-unavailable" ||
+    chart.headers.get("cache-control") !==
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=2" ||
+    !["current", "partial", "unavailable"].includes(
+      chart.headers.get("x-programmable-data-quality"),
+    ) ||
     chart.headers.get("x-programmable-launch-source") !==
       catalogBoundary.launchSource ||
     chart.headers.get("x-programmable-read-source") !==
-      catalogBoundary.launchSource ||
-    chart.headers.get("x-programmable-market-provider") !== null ||
-    chart.headers.get("x-programmable-market-source") !== null ||
-    chart.headers.get("x-programmable-price-source") !== null ||
-    chart.headers.get("x-programmable-market-as-of") !== null ||
+      `${catalogBoundary.launchSource}+bitquery` ||
+    chart.headers.get("x-programmable-market-provider") !== "bitquery" ||
+    !["live", "cache-fallback"].includes(
+      chart.headers.get("x-programmable-market-read-status"),
+    ) ||
+    (chartHasHistory && (
+      chart.headers.get("x-programmable-market-source") !== "bitquery" ||
+      chart.headers.get("x-programmable-price-source") !== "bitquery" ||
+      chart.headers.get("x-programmable-market-as-of") !== chart.body?.asOfTime
+    )) ||
+    (!chartHasHistory && (
+      chart.headers.get("x-programmable-market-source") !== null ||
+      chart.headers.get("x-programmable-price-source") !== null ||
+      chart.headers.get("x-programmable-market-as-of") !== null
+    )) ||
     chart.headers.get("x-programmable-valuation-block") !== null
-  ) throw new Error("Token chart interim unavailable contract is invalid");
-  const chartStatus = "unavailable";
+  ) throw new Error("Token chart pool-bound contract is invalid");
+  const chartStatus = chart.body.status;
   if (githubOutput) {
     appendOutput(
       githubOutput,

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -228,12 +228,23 @@ function stagedFetch(
       };
     } else if (url.pathname === "/api/explore/token/chart") {
       body = {
-        schemaVersion: "programmable.market-chart-unavailable.v1",
-        source: null,
+        schemaVersion: "programmable.market-chart.v1",
+        source: "bitquery",
+        readStatus: "cache-fallback",
         status: "unavailable",
-        reason: "history-provider-unavailable",
-        address: url.searchParams.get("address"),
+        generatedAt: NOW,
+        identity: {
+          chainId: "1",
+          tokenAddress: url.searchParams.get("address"),
+          poolId: POOL,
+          quoteAddress: "0x0000000000000000000000000000000000000000",
+          protocol: "uniswap_v4",
+        },
         range: "1d",
+        points: [],
+        swapCount: 0,
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+        truncated: false,
       };
     } else if (url.pathname === "/api/explore/profile") {
       body = {
@@ -258,9 +269,11 @@ function stagedFetch(
         : {}),
       ...(url.pathname === "/api/explore/token/chart"
         ? {
-            "cache-control": "no-store",
+            "cache-control": "public, max-age=0, s-maxage=2, stale-while-revalidate=2",
             "x-programmable-data-quality": "unavailable",
-            "x-programmable-read-source": "envio-classic-v3",
+            "x-programmable-read-source": "envio-classic-v3+bitquery",
+            "x-programmable-market-provider": "bitquery",
+            "x-programmable-market-read-status": "cache-fallback",
           }
         : {}),
       ...(url.pathname === "/api/explore/profile"
@@ -279,8 +292,6 @@ function stagedFetch(
     };
     const omittedHeaders = url.pathname === "/api/explore/token/chart"
       ? [
-          "x-programmable-market-provider",
-          "x-programmable-market-read-status",
           "x-programmable-market-source",
           "x-programmable-price-source",
           "x-programmable-market-as-of",
@@ -804,7 +815,7 @@ test("staged smoke accepts one custom-current composite catalog", async () => {
               "x-programmable-launch-source":
                 "envio-classic-v3+registry.custom-launched",
               "x-programmable-read-source": url.pathname.endsWith("/chart")
-                ? "envio-classic-v3+registry.custom-launched"
+                ? "envio-classic-v3+registry.custom-launched+bitquery"
                 : "envio-classic-v3+registry.custom-launched+dexscreener",
             }
           : extraHeaders,
@@ -950,7 +961,7 @@ test("staged smoke rejects chart market provenance leakage", async () => {
       })),
       appendOutput: () => undefined,
     }),
-    /chart interim unavailable contract is invalid/u,
+    /chart pool-bound contract is invalid/u,
   );
 });
 

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -585,13 +585,12 @@ describe("read-model performance contract", () => {
       sourceContracts
         .evaluateReadModelSourceContracts(process.cwd(), profile)
         .failures.map((failure: { id: string }) => failure.id),
-    ).toEqual([
-      "source-cache-exploreList",
-      "source-cache-tokenDetail",
-      "source-cache-tokenChart",
-      "source-cache-tokenList",
-      "source-cache-publicIndexer",
-    ]);
+      ).toEqual([
+        "source-cache-exploreList",
+        "source-cache-tokenDetail",
+        "source-cache-tokenList",
+        "source-cache-publicIndexer",
+      ]);
 
     const fixture = createBundle(true);
     const result = gateCore.evaluateReadModelReleaseEvidence(
@@ -1147,7 +1146,7 @@ describe("read-model performance contract", () => {
         cacheControl = expectedCache.tokenDetail;
       } else if (url.pathname === "/api/explore/token/chart") {
         body = {
-          address: url.searchParams.get("address"),
+          identity: { tokenAddress: url.searchParams.get("address") },
           range: url.searchParams.get("range"),
         };
         cacheControl = expectedCache.tokenChart;
@@ -1280,7 +1279,10 @@ describe("read-model performance contract", () => {
         return new Response(
           JSON.stringify({
             ...body,
-            address: fixture.datasetManifest.keys.tokenAddresses[0],
+            identity: {
+              ...body.identity,
+              tokenAddress: fixture.datasetManifest.keys.tokenAddresses[0],
+            },
           }),
           {
             status: 200,

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -3,9 +3,13 @@ import { readFileSync } from "node:fs";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { MarketChartV1 } from "../lib/market-data/market-data-v1";
+
 vi.mock("server-only", () => ({}));
 
 const address = "0x1111111111111111111111111111111111111111";
+const poolId = `0x${"33".repeat(32)}` as const;
+const nativeEth = "0x0000000000000000000000000000000000000000" as const;
 const token = {
   exploreKind: "token",
   id: `1:${address}`,
@@ -13,7 +17,7 @@ const token = {
   symbol: "TEST",
   tokenAddress: address,
   hookAddress: "0x2222222222222222222222222222222222222222",
-  poolId: `0x${"33".repeat(32)}`,
+  poolId,
   launchedAt: "2026-08-11T00:00:00.000Z",
   totalSwapFeeBps: 100,
   launchModel: "classic",
@@ -28,15 +32,63 @@ const token = {
   },
 } as const;
 
+const chart = {
+  schemaVersion: "programmable.market-chart.v1",
+  source: "bitquery",
+  readStatus: "live",
+  status: "ready",
+  generatedAt: "2026-08-17T12:00:00.000Z",
+  identity: {
+    chainId: "1",
+    tokenAddress: address,
+    poolId,
+    quoteAddress: nativeEth,
+    protocol: "uniswap_v4",
+  },
+  range: "1d",
+  points: [
+    {
+      blockNumber: "25740000",
+      time: "2026-08-17T11:00:00.000Z",
+      bucketStart: "2026-08-17T10:40:00.000Z",
+      bucketEnd: "2026-08-17T11:00:00.000Z",
+      observedAt: "2026-08-17T11:00:00.000Z",
+      valueSemantics: "period-median",
+      priceQuote: "0.00001",
+      quoteSymbol: "ETH",
+      tradeCount: 1,
+    },
+    {
+      blockNumber: "25740001",
+      time: "2026-08-17T11:20:00.000Z",
+      bucketStart: "2026-08-17T11:00:00.000Z",
+      bucketEnd: "2026-08-17T11:20:00.000Z",
+      observedAt: "2026-08-17T11:20:00.000Z",
+      valueSemantics: "period-median",
+      priceQuote: "0.000011",
+      quoteSymbol: "ETH",
+      tradeCount: 1,
+    },
+  ],
+  swapCount: 2,
+  valuation: { status: "unavailable", reason: "source-unavailable" },
+  asOfTime: "2026-08-17T11:20:00.000Z",
+  truncated: false,
+} as const satisfies MarketChartV1;
+
 const mocks = vi.hoisted(() => ({
   catalog: vi.fn(),
   mergeEntries: vi.fn(),
   customEnabled: vi.fn(),
   customDirectory: vi.fn(),
+  readChart: vi.fn(),
 }));
 vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
   readEnvioClassicV3CatalogV1: mocks.catalog,
   mergeEnvioClassicV3CatalogEntriesV1: mocks.mergeEntries,
+}));
+vi.mock("../lib/market-data/bitquery.server", () => ({
+  readBitqueryMarketChartV1: mocks.readChart,
 }));
 vi.mock("../lib/server/custom-launch/public-readiness", () => ({
   isCustomLaunchRegistryPublicReadEnabled: mocks.customEnabled,
@@ -51,7 +103,7 @@ function request(query = `address=${address}&range=1d`) {
   return new NextRequest(`http://localhost/api/explore/token/chart?${query}`);
 }
 
-describe("provider-free interim token chart API", () => {
+describe("pool-bound token chart API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.catalog.mockResolvedValue({
@@ -66,50 +118,83 @@ describe("provider-free interim token chart API", () => {
       ...canonical,
       ...custom,
     ]);
+    mocks.readChart.mockResolvedValue(chart);
   });
 
-  it("returns an explicit neutral unavailable contract for a known identity", async () => {
+  it("reads a known Classic token through its exact quote-bound pool", async () => {
     const response = await GET(request());
+
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=2",
+    );
     expect(response.headers.get("x-programmable-launch-source")).toBe(
       "envio-classic-v3",
     );
     expect(response.headers.get("x-programmable-read-source")).toBe(
-      "envio-classic-v3",
+      "envio-classic-v3+bitquery",
     );
-    expect(response.headers.get("x-programmable-data-quality")).toBe(
-      "unavailable",
+    expect(response.headers.get("x-programmable-data-quality")).toBe("current");
+    expect(response.headers.get("x-programmable-market-provider")).toBe(
+      "bitquery",
     );
-    expect(response.headers.get("x-programmable-market-provider")).toBeNull();
-    expect(response.headers.get("x-programmable-market-source")).toBeNull();
-    expect(response.headers.get("x-programmable-price-source")).toBeNull();
-    expect(response.headers.get("x-programmable-market-as-of")).toBeNull();
-    expect(response.headers.get("x-programmable-valuation-block")).toBeNull();
-    await expect(response.json()).resolves.toMatchObject({
-      schemaVersion: "programmable.market-chart-unavailable.v1",
-      source: null,
-      status: "unavailable",
-      reason: "history-provider-unavailable",
-      address,
+    expect(response.headers.get("x-programmable-market-read-status")).toBe(
+      "live",
+    );
+    expect(response.headers.get("x-programmable-market-source")).toBe(
+      "bitquery",
+    );
+    expect(response.headers.get("x-programmable-price-source")).toBe(
+      "bitquery",
+    );
+    expect(response.headers.get("x-programmable-market-as-of")).toBe(
+      "2026-08-17T11:20:00.000Z",
+    );
+    await expect(response.json()).resolves.toEqual(chart);
+    expect(mocks.readChart).toHaveBeenCalledWith(expect.objectContaining({
+      identity: chart.identity,
       range: "1d",
-    });
+    }));
   });
 
-  it("returns 404 for an address outside the committed identity catalog", async () => {
-    mocks.catalog.mockResolvedValue({ source: "envio-classic-v3", entries: [] });
-    expect((await GET(request())).status).toBe(404);
+  it("binds an all-time chart to the verified launch timestamp", async () => {
+    mocks.readChart.mockResolvedValue({ ...chart, range: "all" });
+
+    const response = await GET(request(`address=${address}&range=all`));
+
+    expect(response.status).toBe(200);
+    expect(mocks.readChart).toHaveBeenCalledWith(expect.objectContaining({
+      identity: chart.identity,
+      range: "all",
+      historyStart: token.launchedAt,
+    }));
   });
 
-  it("labels a successful Custom Registry boundary explicitly", async () => {
+  it("labels a successful Custom Registry boundary and reads one verified pool", async () => {
     const customAddress = "0x9999999999999999999999999999999999999999";
+    const customPoolId = `0x${"99".repeat(32)}`;
     mocks.customEnabled.mockReturnValue(true);
     mocks.customDirectory.mockResolvedValue([{
       exploreKind: "custom-project",
       id: `custom:sha256:${"99".repeat(32)}`,
       tokenAddress: customAddress,
-      markets: [],
+      launchedAt: "2026-08-17T00:00:00.000Z",
+      chainId: "1",
+      markets: [{
+        status: "active",
+        poolId: customPoolId,
+        baseAsset: { identity: { value: customAddress } },
+        quoteAsset: { identity: { value: nativeEth } },
+      }],
     }]);
+    mocks.readChart.mockResolvedValue({
+      ...chart,
+      identity: {
+        ...chart.identity,
+        tokenAddress: customAddress,
+        poolId: customPoolId,
+      },
+    });
 
     const response = await GET(request(`address=${customAddress}&range=1d`));
 
@@ -118,8 +203,97 @@ describe("provider-free interim token chart API", () => {
       "envio-classic-v3+registry.custom-launched",
     );
     expect(response.headers.get("x-programmable-read-source")).toBe(
-      "envio-classic-v3+registry.custom-launched",
+      "envio-classic-v3+registry.custom-launched+bitquery",
     );
+    expect(mocks.readChart).toHaveBeenCalledWith(expect.objectContaining({
+      identity: expect.objectContaining({
+        tokenAddress: customAddress,
+        poolId: customPoolId,
+        quoteAddress: nativeEth,
+      }),
+    }));
+  });
+
+  it("fails closed instead of choosing between multiple verified Custom pools", async () => {
+    const customAddress = "0x9999999999999999999999999999999999999999";
+    mocks.customEnabled.mockReturnValue(true);
+    mocks.customDirectory.mockResolvedValue([{
+      exploreKind: "custom-project",
+      id: `custom:sha256:${"99".repeat(32)}`,
+      tokenAddress: customAddress,
+      launchedAt: "2026-08-17T00:00:00.000Z",
+      chainId: "1",
+      markets: [
+        {
+          status: "active",
+          poolId: `0x${"98".repeat(32)}`,
+          baseAsset: { identity: { value: customAddress } },
+          quoteAsset: { identity: { value: nativeEth } },
+        },
+        {
+          status: "active",
+          poolId: `0x${"99".repeat(32)}`,
+          baseAsset: { identity: { value: customAddress } },
+          quoteAsset: { identity: { value: nativeEth } },
+        },
+      ],
+    }]);
+
+    const response = await GET(request(`address=${customAddress}&range=1d`));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-programmable-data-quality")).toBe(
+      "unavailable",
+    );
+    expect(response.headers.get("x-programmable-market-provider")).toBeNull();
+    await expect(response.json()).resolves.toMatchObject({
+      schemaVersion: "programmable.market-chart-error.v1",
+      source: "bitquery",
+      status: "unavailable",
+      reason: "identity-unavailable",
+      address: customAddress,
+      range: "1d",
+    });
+    expect(mocks.readChart).not.toHaveBeenCalled();
+  });
+
+  it("preserves a known token identity when the market provider is unavailable", async () => {
+    mocks.readChart.mockResolvedValue({
+      ...chart,
+      readStatus: "cache-fallback",
+      status: "unavailable",
+      points: [],
+      swapCount: 0,
+      asOfTime: undefined,
+    });
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-programmable-launch-source")).toBe(
+      "envio-classic-v3",
+    );
+    expect(response.headers.get("x-programmable-read-source")).toBe(
+      "envio-classic-v3+bitquery",
+    );
+    expect(response.headers.get("x-programmable-data-quality")).toBe(
+      "unavailable",
+    );
+    expect(response.headers.get("x-programmable-market-provider")).toBe(
+      "bitquery",
+    );
+    expect(response.headers.get("x-programmable-market-source")).toBeNull();
+    await expect(response.json()).resolves.toMatchObject({
+      schemaVersion: "programmable.market-chart.v1",
+      identity: chart.identity,
+      status: "unavailable",
+      points: [],
+    });
+  });
+
+  it("returns 404 for an address outside the committed identity catalog", async () => {
+    mocks.catalog.mockResolvedValue({ source: "envio-classic-v3", entries: [] });
+    expect((await GET(request())).status).toBe(404);
   });
 
   it("fails closed when Custom identities collide with the catalog", async () => {
@@ -143,7 +317,7 @@ describe("provider-free interim token chart API", () => {
   });
 
   it("returns 503 only when the identity catalog cannot be read", async () => {
-    mocks.catalog.mockRejectedValue(new Error("blob unavailable"));
+    mocks.catalog.mockRejectedValue(new Error("catalog unavailable"));
     const response = await GET(request());
     expect(response.status).toBe(503);
     expect(response.headers.get("retry-after")).toBe("5");
@@ -159,17 +333,19 @@ describe("provider-free interim token chart API", () => {
     expect(mocks.catalog).not.toHaveBeenCalled();
   });
 
-  it("contains no dRPC, Bitquery or historical reader dependency", () => {
+  it("uses the bounded Bitquery reader without an RPC or historical scan", () => {
     const source = readFileSync(
       new URL("../app/api/explore/token/chart/route.ts", import.meta.url),
       "utf8",
     );
-    expect(source).not.toMatch(/bitquery|readPrimaryRpc|readTokenChartSeries/iu);
+    expect(source).toContain("readBitqueryMarketChartV1");
+    expect(source).toContain("exploreEntryMarketIdentitiesV1");
+    expect(source).not.toMatch(/readPrimaryRpc|readTokenChartSeries/iu);
     expect(source).toContain("readEnvioClassicV3CatalogV1");
   });
 
-  it("keeps the browser chart request disabled outside preview fixtures", () => {
-    const chart = readFileSync(
+  it("enables browser chart requests outside preview fixtures", () => {
+    const chartSource = readFileSync(
       new URL("../components/token-price-chart.tsx", import.meta.url),
       "utf8",
     );
@@ -177,8 +353,10 @@ describe("provider-free interim token chart API", () => {
       new URL("../components/token-detail-view.tsx", import.meta.url),
       "utf8",
     );
-    expect(chart).toContain("const historyEnabled = preview;");
-    expect(chart).not.toContain("historyAvailable");
+    expect(chartSource).toContain(
+      "const historyEnabled = shouldEnablePriceHistory(launchModel);",
+    );
+    expect(chartSource).not.toContain("historyAvailable");
     expect(detail).not.toContain("preloadTokenChart");
   });
 });

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -24,13 +24,15 @@ describe("token detail layout", () => {
     expect(chartSource).not.toContain(': "Onchain"');
   });
 
-  it("does not preload unavailable historical chart data", () => {
+  it("keeps detail charts lazy while enabling exact pool-bound history", () => {
     const viewSource = detailSource.slice(
       detailSource.indexOf("export function TokenDetailView"),
     );
 
     expect(viewSource).not.toContain("preloadTokenChart");
-    expect(chartSource).toContain("const historyEnabled = preview;");
+    expect(chartSource).toContain(
+      "const historyEnabled = shouldEnablePriceHistory(launchModel);",
+    );
   });
 
   it("announces the inspected chart value without duplicating the visual tooltip", () => {


### PR DESCRIPTION
## Summary
- serve public token history through the existing exact token, quote-asset and Uniswap v4 pool-bound Bitquery adapter
- enable the existing accessible detail chart UI for eligible public token families; Stock-Paired remains excluded
- update cache/source contracts, stage smoke, and post-promotion cache-key verification for the MarketChartV1 response

## Validation
- npm run typecheck
- npx eslint on changed paths
- focused Vitest: chart API, chart interaction/detail layout, operations contract, performance contract (142 passed, 1 existing skip)
- node --test scripts/test/smoke-static-dexscreener-public-apis.test.mjs
- node scripts/perf/read-model-ops-source-contracts.mjs
- npm run build