### PR TITLE
Accept Vercel chart cache normalization

### DIFF
--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -674,8 +674,13 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
     chart.body?.range !== "1d" ||
     chart.body?.valuation?.status !== "unavailable" ||
     chart.body?.valuation?.reason !== "source-unavailable" ||
-    chart.headers.get("cache-control") !==
-      "public, max-age=0, s-maxage=2, stale-while-revalidate=2" ||
+    // Vercel normalizes shared-cache directives on dynamic route responses to
+    // this publicly observable fresh-response policy. The route-level policy
+    // remains accepted for direct runtime tests; the stage probe must accept
+    // the exact header a browser receives.
+    (chart.headers.get("cache-control") !==
+      "public, max-age=0, s-maxage=2, stale-while-revalidate=2" &&
+      chart.headers.get("cache-control") !== "public, max-age=0") ||
     !["current", "partial", "unavailable"].includes(
       chart.headers.get("x-programmable-data-quality"),
     ) ||

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -269,7 +269,7 @@ function stagedFetch(
         : {}),
       ...(url.pathname === "/api/explore/token/chart"
         ? {
-            "cache-control": "public, max-age=0, s-maxage=2, stale-while-revalidate=2",
+            "cache-control": "public, max-age=0",
             "x-programmable-data-quality": "unavailable",
             "x-programmable-read-source": "envio-classic-v3+bitquery",
             "x-programmable-market-provider": "bitquery",


### PR DESCRIPTION
Accepts the exact public Vercel dynamic-route cache normalization in the Stage chart smoke. Product chart contract and source policy remain unchanged.