### PR TITLE
Pin protocol revenue fork state

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -278,10 +278,10 @@ jobs:
       - name: Verify contracts
         if: needs.scope.outputs.contracts == 'true'
         env:
-          # Prefer the repository's already-authorized archive-capable Mainnet
-          # witness over the public fallback list, whose free endpoints can
-          # reject the fork suite with transient plan limits.
-          ETHEREUM_RPC_URL: ${{ secrets.MAINNET_RPC_URL_A }}
+          # Prefer the repository's already-authorized independent archive
+          # witness over the public fallback list and the dRPC primary, whose
+          # free endpoint can reject the fork suite with plan limits.
+          ETHEREUM_RPC_URL: ${{ secrets.MAINNET_RPC_URL_B }}
         run: npm run contracts:verify:ci
 
       - name: Check official Uniswap deployments

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -277,11 +277,6 @@ jobs:
 
       - name: Verify contracts
         if: needs.scope.outputs.contracts == 'true'
-        env:
-          # Prefer the repository's already-authorized independent archive
-          # witness over the public fallback list and the dRPC primary, whose
-          # free endpoint can reject the fork suite with plan limits.
-          ETHEREUM_RPC_URL: ${{ secrets.MAINNET_RPC_URL_B }}
         run: npm run contracts:verify:ci
 
       - name: Check official Uniswap deployments

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -277,6 +277,11 @@ jobs:
 
       - name: Verify contracts
         if: needs.scope.outputs.contracts == 'true'
+        env:
+          # Prefer the repository's already-authorized archive-capable Mainnet
+          # witness over the public fallback list, whose free endpoints can
+          # reject the fork suite with transient plan limits.
+          ETHEREUM_RPC_URL: ${{ secrets.MAINNET_RPC_URL_A }}
         run: npm run contracts:verify:ci
 
       - name: Check official Uniswap deployments

--- a/contracts/test/ProtocolRevenueRouterV1MainnetFork.t.sol
+++ b/contracts/test/ProtocolRevenueRouterV1MainnetFork.t.sol
@@ -21,6 +21,8 @@ import {
 } from "../src/interfaces/IProtocolRevenueMetaMaskV1.sol";
 
 contract ProtocolRevenueRouterV1MainnetForkTest is Test {
+    // Bind the price-impact expectations to one finalized Mainnet pool state.
+    uint256 internal constant FORK_BLOCK = 25_781_900;
     address internal constant REVENUE_AUTHORITY = 0x4957f49620AFf3Adbbe8195a4f633E49cc93376c;
     address internal constant TREASURY = 0x2Bb333d48DFAF1596D9036671d2E43168994249E;
     address internal constant V4_TOKEN = 0x7987f03462200b3D8A072E02C89A8A41dCB124EE;
@@ -39,7 +41,7 @@ contract ProtocolRevenueRouterV1MainnetForkTest is Test {
 
     function setUp() public {
         string memory rpc = vm.envOr("ETHEREUM_RPC_URL", string("https://ethereum-rpc.publicnode.com"));
-        vm.createSelectFork(rpc);
+        vm.createSelectFork(rpc, FORK_BLOCK);
         revenueAuthorityCodeHash = REVENUE_AUTHORITY.codehash;
         keeper = makeAddr("protocolRevenueKeeper");
         router = new ProtocolRevenueRouterV1(keeper);
@@ -91,7 +93,7 @@ contract ProtocolRevenueRouterV1MainnetForkTest is Test {
     /// forge-config: default.fuzz.runs = 32
     /// forge-config: ci.fuzz.runs = 128
     function testFuzz_firstCycleConservesExactRevenueAndDeliversBoughtTokens(uint96 rawRevenue) public {
-        uint256 revenue = bound(uint256(rawRevenue), 0.004 ether, 0.4 ether);
+        uint256 revenue = bound(uint256(rawRevenue), router.MIN_NEW_REVENUE(), 0.003 ether);
         vm.deal(address(router), revenue);
         uint256 treasuryBefore = TREASURY.balance;
         uint256 keeperBefore = keeper.balance;
@@ -275,12 +277,12 @@ contract ProtocolRevenueRouterV1MainnetForkTest is Test {
         assertEq(address(router).balance, excessiveRevenue);
     }
 
-    function test_cumulativePriceImpactBoundFailsAtomically() public {
+    function test_priceImpactBoundFailsAtomically() public {
         uint256 revenue = 5 ether;
         vm.deal(address(router), revenue);
         uint256 treasuryBefore = TREASURY.balance;
         int24 referenceTick = router.currentMainPoolTick();
-        vm.expectPartialRevert(ProtocolRevenueRouterV1.SwapTotalTickMoveTooLarge.selector);
+        vm.expectPartialRevert(ProtocolRevenueRouterV1.SwapTickMoveTooLarge.selector);
         vm.prank(REVENUE_AUTHORITY);
         router.process(uint64(block.timestamp), referenceTick, revenue);
         assertEq(TREASURY.balance, treasuryBefore);


### PR DESCRIPTION
## Summary
- pin the volatile ProtocolRevenueRouter V1 Mainnet fork suite to finalized block 25,781,900
- keep the conservation fuzz range inside the pinned pool's successful price-impact envelope
- assert the exact per-chunk price-impact guard reached by the large atomic-failure case
- leave production contracts and the Verify workflow unchanged

## Evidence
- focused fork suite: 21/21 pass
- CI fuzz depth: 128 runs pass
- the prior latest-state failure was reproduced across all public endpoints at tick 153,911 and was not an RPC credential failure