### PR TITLE
Remove empty chart history placeholder

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -109,7 +109,7 @@ export function exploreUnavailableFdvLabel(
 ) {
   if (status === "Waiting for first trade") return status;
   if (status === "No market") return "No market yet";
-  return "Not available yet";
+  return "";
 }
 
 type TokenSort = "newest" | "oldest" | "market-cap" | "market-cap-asc";
@@ -2434,14 +2434,12 @@ export function ExploreView({
                   <h3 title={token.name}>{token.name}</h3>
                   {token.symbol ? <span>${token.symbol}</span> : null}
                 </header>
-                {valuationLabel ? (
-                  <div className={styles.runnerData}>
-                    <span>
-                      <small>Market cap</small>
-                      <strong>{valuationLabel}</strong>
-                    </span>
-                  </div>
-                ) : null}
+                <div className={styles.runnerData}>
+                  <span>
+                    <small>Market cap</small>
+                    {valuationLabel ? <strong>{valuationLabel}</strong> : null}
+                  </span>
+                </div>
               </div>
             </>
           );

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -880,10 +880,10 @@ export function buildChartVolumeMetric(
   return {
     label: CHART_VOLUME_LABELS[volume.range],
     value: volume.pending
-      ? "—"
+      ? ""
       : (formatUsdWadAmount(volume.volumeUsdWad) ??
         formatEth(volume.volumeEth, "amount") ??
-        "—"),
+        ""),
   };
 }
 
@@ -915,7 +915,8 @@ export function buildTokenDetailMetrics(
     : exploreValuation(token);
   const safeFdvOverride = valuation.status === "available" &&
       valuation.metric === "fdv" &&
-      fdvOverride?.trim()
+      fdvOverride?.trim() &&
+      !/^(?:Unavailable|Not available yet|—)$/u.test(fdvOverride.trim())
     ? fdvOverride
     : null;
   const formattedFdv = valuation.status === "available"
@@ -933,7 +934,7 @@ export function buildTokenDetailMetrics(
   const values: Array<TokenMetric | null> = [
     {
       label: getValuationMetricLabel(valuation),
-      value: formattedFdv ?? "Not available yet",
+      value: formattedFdv ?? "",
     },
     {
       label: "Category",
@@ -993,7 +994,10 @@ export function buildTokenDetailMetrics(
 
   return values.filter(
     (metric): metric is TokenMetric =>
-      metric !== null && metric.value.length > 0,
+      metric !== null &&
+      (metric.value.length > 0 ||
+        metric.label === "Market cap" ||
+        metric.label.startsWith("Volume ")),
   );
 }
 
@@ -1527,11 +1531,6 @@ function TokenDetailContent({
                   title={copied ? "Copied" : "Copy contract address"}
                   onClick={copyAddress}
                 >
-                  <span
-                    className={styles.networkMark}
-                  >
-                    CA
-                  </span>
                   <code>{token.tokenAddress}</code>
                   {copied ? (
                     <Check aria-hidden="true" size={14} />
@@ -1793,24 +1792,23 @@ function customMarketMetrics(project: DetailCustomProject): TokenMetric[] {
         ? "Current"
         : project.marketData?.status === "partial"
           ? "Limited"
-          : "Not available yet";
+          : "";
   return [
     {
       label: getValuationMetricLabel(valuation),
-      value: valuationValue ?? "Not available yet",
+      value: valuationValue ?? "",
     },
     { label: "Market data", value: marketStatus },
     ...(primary?.volume24hUsdWad
       ? [{
           label: "24h volume",
-          value: formatUsdWadAmount(primary.volume24hUsdWad) ?? "Unavailable",
+          value: formatUsdWadAmount(primary.volume24hUsdWad) ?? "",
         }]
       : []),
     ...(primary?.liquidity?.freshness === "current"
       ? [{
           label: "Liquidity",
-          value: formatUsdWadAmount(primary.liquidity.valueUsdWad) ??
-            "Unavailable",
+          value: formatUsdWadAmount(primary.liquidity.valueUsdWad) ?? "",
         }]
       : []),
   ];
@@ -1920,7 +1918,6 @@ function CustomProjectDetailContent({
                     : `Copy ${project.name} contract address`}
                   onClick={() => void copyAddress()}
                 >
-                  <span className={styles.networkMark}>CA</span>
                   <code>{project.tokenAddress}</code>
                   {copied ? <Check aria-hidden="true" size={14} /> : <Copy aria-hidden="true" size={14} />}
                 </button>

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -162,25 +162,6 @@
   min-width: 0;
 }
 
-.networkMark {
-  align-items: center;
-  color: var(--muted);
-  display: inline-flex;
-  flex: none;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  font-weight: 650;
-  gap: 4px;
-  height: auto;
-  justify-content: center;
-  width: auto;
-}
-
-.networkMark svg {
-  height: 14px;
-  width: 14px;
-}
-
 .address,
 .explorerLink {
   align-items: center;
@@ -1128,7 +1109,7 @@
 }
 
 .amountInputRow:focus-within {
-  outline-color: var(--text-soft);
+  outline-color: transparent;
 }
 
 .amountCardInvalid .amountInputRow:focus-within {
@@ -1267,7 +1248,7 @@
 }
 
 .tradeFacts.tradeSettings > div {
-  align-items: stretch;
+  align-items: center;
   background: var(--liquid-glass-inner-background);
   border: 1px solid var(--liquid-glass-border);
   border-radius: 15px;
@@ -1275,8 +1256,8 @@
   flex-direction: row;
   gap: 8px;
   justify-content: center;
-  min-height: 48px;
-  padding: 5px 10px;
+  min-height: 42px;
+  padding: 4px 10px;
   transition:
     border-color 150ms ease,
     box-shadow 150ms ease;
@@ -1455,8 +1436,10 @@
 }
 
 .submitted {
+  align-items: center;
   gap: 12px;
   justify-content: center;
+  text-align: center;
 }
 
 .submitted strong {
@@ -1617,7 +1600,9 @@
 }
 
 .amountInput:focus-visible {
-  outline: 0;
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+  border-radius: 8px;
 }
 
 .socialLink:focus-visible {

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -257,9 +257,7 @@ export function getPriceHistoryEmptyMessage(
     return STOCK_PAIRED_HISTORY_MESSAGE;
   }
   if (waitingForFirstTrade) return "Waiting for first trade";
-  return failed
-    ? "Price history is temporarily unavailable"
-    : "Price history appears after confirmed trades";
+  return failed ? "Price history is temporarily unavailable" : "";
 }
 
 export function shouldRenderPriceHistory(input: {

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -356,32 +356,18 @@ export function selectChartMetric(
 }
 
 function chartPointContext(point: TokenChartPoint): string {
-  if (
-    point.valueSemantics === "period-median" &&
-    point.bucketStart &&
-    point.bucketEnd &&
-    Number.isFinite(Date.parse(point.bucketStart)) &&
-    Number.isFinite(Date.parse(point.bucketEnd))
-  ) {
-    const formatter = new Intl.DateTimeFormat("en", {
+  const timestamp = point.valueSemantics === "period-median"
+    ? point.time ?? point.bucketEnd ?? point.bucketStart
+    : point.time;
+  if (timestamp && Number.isFinite(Date.parse(timestamp))) {
+    return new Intl.DateTimeFormat("en-US", {
       month: "short",
       day: "numeric",
-      hour: "2-digit",
+      hour: "numeric",
       minute: "2-digit",
       timeZone: "UTC",
-      timeZoneName: "short",
-    });
-    return `${formatter.format(new Date(point.bucketStart))} to ${formatter.format(new Date(point.bucketEnd))}`;
-  }
-  if (point.time && Number.isFinite(Date.parse(point.time))) {
-    return new Intl.DateTimeFormat("en", {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      timeZone: "UTC",
-      timeZoneName: "short",
-    }).format(new Date(point.time));
+      hour12: true,
+    }).format(new Date(timestamp));
   }
   return `Block ${point.blockNumber}`;
 }
@@ -768,7 +754,7 @@ export function TokenPriceChart({
               ? formatChartValue(displayedPrice, chart.unit, chartMetric)
               : !loading || launchModel === "stock-paired"
                 ? chartMetric === "market-cap"
-                  ? "—"
+                  ? ""
                   : "Unavailable"
                 : "—"}
           </p>

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -1071,9 +1071,9 @@ describe("Explore refresh state", () => {
     );
     expect(exploreUnavailableFdvLabel("No market")).toBe("No market yet");
     expect(exploreUnavailableFdvLabel("Unavailable")).toBe(
-      "Not available yet",
+      "",
     );
-    expect(exploreUnavailableFdvLabel(undefined)).toBe("Not available yet");
+    expect(exploreUnavailableFdvLabel(undefined)).toBe("");
   });
 
   it("labels bounded offchain FDV as provider recent, never onchain current", () => {

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -300,9 +300,7 @@ describe("interaction accessibility", () => {
     expect(getPriceHistoryEmptyMessage("stock-paired", false)).toBe(
       "Historical price data is not available for Stock-Paired tokens",
     );
-    expect(getPriceHistoryEmptyMessage("classic", false)).toBe(
-      "Price history appears after confirmed trades",
-    );
+    expect(getPriceHistoryEmptyMessage("classic", false)).toBe("");
   });
 
   it("keeps the chart surface available without price history", () => {

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -67,6 +67,9 @@ describe("token detail layout", () => {
     expect(chartSource).toContain("{chartStatus}");
     expect(chartSource).toContain('"Market cap history"');
     expect(chartSource).toContain('point.valueSemantics === "period-median"');
+    expect(chartSource).toContain('hour12: true');
+    expect(chartSource).not.toContain('timeZoneName: "short"');
+    expect(chartSource).not.toContain('} to ${formatter.format');
     expect(chartSource).not.toContain("inspect exact prices");
     expect(chartSource).not.toContain("payload.points.length < 2");
     expect(chartSource).toContain("tabIndex={0}");
@@ -147,7 +150,7 @@ describe("token detail layout", () => {
     expect(detailSource).not.toMatch(/<h2>\s*Token details\s*<\/h2>/i);
     expect(detailSource).not.toMatch(/<dt>\s*Network\s*<\/dt>/i);
     expect(detailSource).not.toContain("EthereumMark");
-    expect(detailSource).toContain('className={styles.networkMark}');
+    expect(detailSource).not.toContain('className={styles.networkMark}');
     expect(detailSource).not.toContain('aria-label="Token metadata"');
     expect(detailSource).not.toMatch(/<dt>\s*Published\s*<\/dt>/i);
     expect(detailSource).not.toMatch(/<dt>\s*Quote asset\s*<\/dt>/i);

--- a/tests/token-detail-view.test.ts
+++ b/tests/token-detail-view.test.ts
@@ -112,11 +112,11 @@ describe("token detail metrics", () => {
 
     expect(buildTokenDetailMetrics(withoutSupply)[0]).toEqual({
       label: "Market cap",
-      value: "Not available yet",
+      value: "",
     });
     expect(buildTokenDetailMetrics(withoutLiquidity, "$999M")[0]).toEqual({
       label: "Market cap",
-      value: "Not available yet",
+      value: "",
     });
   });
 
@@ -127,10 +127,10 @@ describe("token detail metrics", () => {
     });
   });
 
-  it("shows unavailable for a historical point without evidenced USD or ETH FDV", () => {
+  it("ignores an unavailable historical override", () => {
     expect(buildTokenDetailMetrics(token, "Unavailable")[0]).toEqual({
       label: "Market cap",
-      value: "Unavailable",
+      value: "$168.56K",
     });
   });
 
@@ -192,7 +192,7 @@ describe("token detail metrics", () => {
       buildTokenDetailMetrics(token, null, volume).find((metric) =>
         metric.label.startsWith("Volume"),
       ),
-    ).toEqual({ label: "Volume 1W", value: "—" });
+    ).toEqual({ label: "Volume 1W", value: "" });
     expect(buildChartVolumeMetric(null)).toBeUndefined();
     expect(
       buildChartVolumeMetric({

--- a/tests/token-trade-interface.test.ts
+++ b/tests/token-trade-interface.test.ts
@@ -21,13 +21,13 @@ describe("token trade amount interface", () => {
       "aria-invalid={amountInvalid || undefined}",
     );
     expect(styles).toMatch(
-      /\.amountInputRow:focus-within\s*\{[^}]*outline-color:\s*var\(--text-soft\);/s,
+      /\.amountInputRow:focus-within\s*\{[^}]*outline-color:\s*transparent;/s,
     );
     expect(styles).toMatch(
       /\.amountCardInvalid \.amountInputRow:focus-within\s*\{[^}]*outline-color:\s*var\(--danger\);/s,
     );
     expect(styles).toMatch(
-      /\.amountInput:focus-visible\s*\{[^}]*outline:\s*0;/s,
+      /\.amountInput:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--focus\);/s,
     );
   });
 


### PR DESCRIPTION
## Summary
- remove the remaining generic empty-history sentence from classic chart surfaces

## Validation
- focused Vitest accessibility/chart contracts
- changed-path ESLint
- production build