### PR TITLE
Polish market card and chart interactions

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -2434,12 +2434,14 @@ export function ExploreView({
                   <h3 title={token.name}>{token.name}</h3>
                   {token.symbol ? <span>${token.symbol}</span> : null}
                 </header>
-                <div className={styles.runnerData}>
-                  <span>
-                    <small>Market cap</small>
-                    {valuationLabel ? <strong>{valuationLabel}</strong> : null}
-                  </span>
-                </div>
+                {valuationLabel ? (
+                  <div className={styles.runnerData}>
+                    <span>
+                      <small>Market cap</small>
+                      <strong>{valuationLabel}</strong>
+                    </span>
+                  </div>
+                ) : null}
               </div>
             </>
           );

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -1600,9 +1600,17 @@
 }
 
 .amountInput:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 2px;
-  border-radius: 8px;
+  border-radius: 0;
+  box-shadow: inset 0 -2px 0 var(--focus);
+  outline: 0;
+}
+
+@media (forced-colors: active) {
+  .amountInput:focus-visible {
+    box-shadow: none;
+    outline: 2px solid ButtonText;
+    outline-offset: 2px;
+  }
 }
 
 .socialLink:focus-visible {

--- a/components/token-price-chart.module.css
+++ b/components/token-price-chart.module.css
@@ -41,6 +41,15 @@
   margin: 0;
 }
 
+.context {
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+  margin: 5px 0 0;
+  min-height: 14px;
+}
+
 .ranges {
   align-items: center;
   background: var(--liquid-glass-inner-background);
@@ -148,42 +157,6 @@
   transform: translate(-50%, -50%);
   width: 8px;
   z-index: 1;
-}
-
-.tooltip {
-  -webkit-backdrop-filter: var(--liquid-glass-backdrop);
-  backdrop-filter: var(--liquid-glass-backdrop);
-  background: var(--liquid-glass-surface-background-strong);
-  border: 1px solid var(--liquid-glass-border);
-  border-radius: 11px;
-  box-shadow: var(--liquid-glass-control-shadow);
-  display: grid;
-  gap: 2px;
-  max-width: calc(100% - 16px);
-  min-width: max-content;
-  padding: 7px 9px;
-  pointer-events: none;
-  position: absolute;
-  transform: translate(-50%, calc(-100% - 11px));
-  z-index: 2;
-}
-
-.tooltip[data-vertical="below"] {
-  transform: translate(-50%, 11px);
-}
-
-.tooltip strong {
-  color: var(--text);
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-  font-weight: 680;
-}
-
-.tooltip span {
-  color: var(--muted);
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-  overflow-wrap: anywhere;
 }
 
 .placeholder {
@@ -352,12 +325,4 @@
 .inspectionDot {
   background: #000;
   border-color: #fff;
-}
-
-.tooltip {
-  -webkit-backdrop-filter: blur(16px);
-  backdrop-filter: blur(16px);
-  background: rgb(24 24 24 / 0.96);
-  border-color: var(--webde-line);
-  box-shadow: 0 12px 34px rgb(0 0 0 / 0.5);
 }

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -756,6 +756,9 @@ export function TokenPriceChart({
                   : "Unavailable"
                 : "—"}
           </p>
+          <p className={styles.context} aria-hidden="true">
+            {activePoint ? chartPointContext(activePoint) : "\u00A0"}
+          </p>
         </div>
         {historyEnabled && launchModel !== "stock-paired" ? (
           <div className={styles.ranges} aria-label="Chart range" role="group">
@@ -866,28 +869,14 @@ export function TokenPriceChart({
             ) : null}
           </svg>
           {activePoint ? (
-            <>
-              <span
-                className={styles.inspectionDot}
-                style={{
-                  left: `${(activePoint.x / VIEWBOX_WIDTH) * 100}%`,
-                  top: `${(activePoint.y / VIEWBOX_HEIGHT) * 100}%`,
-                }}
-                aria-hidden="true"
-              />
-              <div
-                className={styles.tooltip}
-                data-vertical={activePoint.y < 44 ? "below" : "above"}
-                style={{
-                  left: `clamp(4.5rem, ${(activePoint.x / VIEWBOX_WIDTH) * 100}%, calc(100% - 4.5rem))`,
-                  top: `${(activePoint.y / VIEWBOX_HEIGHT) * 100}%`,
-                }}
-                aria-hidden="true"
-              >
-                <strong>{formatChartValue(activePoint.value, chart.unit, chartMetric)}</strong>
-                <span>{chartPointContext(activePoint)}</span>
-              </div>
-            </>
+            <span
+              className={styles.inspectionDot}
+              style={{
+                left: `${(activePoint.x / VIEWBOX_WIDTH) * 100}%`,
+                top: `${(activePoint.y / VIEWBOX_HEIGHT) * 100}%`,
+              }}
+              aria-hidden="true"
+            />
           ) : null}
           <span
             className="sr-only"

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -150,6 +150,9 @@ describe("Explore UI contract", () => {
     );
     expect(source).not.toContain("<small>CA</small>");
     expect(source).toContain("<small>Market cap</small>");
+    expect(source).toMatch(
+      /\{valuationLabel \? \([\s\S]*?<small>Market cap<\/small>[\s\S]*?\) : null\}/,
+    );
     expect(source).not.toContain("exploreUnavailableFdvLabel(token.marketStatus)");
     expect(source).toContain("Copy ${token.name} contract address");
     expect(source).not.toContain("runnerMarketStatus");

--- a/tests/interaction-state-regressions.test.ts
+++ b/tests/interaction-state-regressions.test.ts
@@ -111,6 +111,9 @@ describe("interaction state regressions", () => {
     expect(exploreSource).toContain("runnerMeta");
     expect(exploreSource).toContain("runnerData");
     expect(exploreSource).toContain("<small>Market cap</small>");
+    expect(exploreSource).toMatch(
+      /\{valuationLabel \? \([\s\S]*?<small>Market cap<\/small>[\s\S]*?\) : null\}/,
+    );
     expect(exploreSource).not.toContain(
       "exploreUnavailableFdvLabel(token.marketStatus)",
     );

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -35,7 +35,7 @@ describe("token detail layout", () => {
     );
   });
 
-  it("announces the inspected chart value without duplicating the visual tooltip", () => {
+  it("keeps the inspected date in the header without a floating tooltip", () => {
     const activeValueIdIndex = chartSource.indexOf("id={activeValueId}");
     const liveRegion = chartSource.slice(
       chartSource.lastIndexOf("<span", activeValueIdIndex),
@@ -45,20 +45,19 @@ describe("token detail layout", () => {
     expect(chartSource).toContain(
       "`${formatChartValue(activePoint.value, chart.unit, chartMetric)}, ${chartPointContext(activePoint)}`",
     );
+    expect(chartSource).toContain('className={styles.context} aria-hidden="true"');
     expect(chartSource).toContain(
-      "<strong>{formatChartValue(activePoint.value, chart.unit, chartMetric)}</strong>",
+      "{activePoint ? chartPointContext(activePoint) : \"\\u00A0\"}",
     );
+    expect(chartSource).not.toContain("className={styles.tooltip}");
     expect(activeValueIdIndex).toBeGreaterThan(-1);
     expect(liveRegion).toContain('className="sr-only"');
     expect(liveRegion).toContain('role="status"');
     expect(liveRegion).toContain('aria-live="polite"');
     expect(liveRegion).toContain('aria-atomic="true"');
     expect(liveRegion).toContain("chartPointContext(activePoint)");
-    expect(chartSource).toMatch(
-      /style=\{\{[\s\S]*?left:\s*`clamp\([^`]+\)`[\s\S]*?\}\}/,
-    );
     expect(chartSource).not.toContain("data-horizontal-edge");
-    expect(chartSource).toContain('data-vertical={activePoint.y < 44 ? "below" : "above"}');
+    expect(chartSource).not.toContain("data-vertical=");
   });
 
   it("keeps chart loading stable, labelled and separate from empty history", () => {

--- a/tests/token-trade-interface.test.ts
+++ b/tests/token-trade-interface.test.ts
@@ -27,7 +27,10 @@ describe("token trade amount interface", () => {
       /\.amountCardInvalid \.amountInputRow:focus-within\s*\{[^}]*outline-color:\s*var\(--danger\);/s,
     );
     expect(styles).toMatch(
-      /\.amountInput:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--focus\);/s,
+      /\.amountInput:focus-visible\s*\{[^}]*box-shadow:\s*inset 0 -2px 0 var\(--focus\);[^}]*outline:\s*0;/s,
+    );
+    expect(styles).toMatch(
+      /@media \(forced-colors: active\)[\s\S]*?\.amountInput:focus-visible\s*\{[^}]*outline:\s*2px solid ButtonText;/s,
     );
   });
 


### PR DESCRIPTION
## Summary
- hide the Market cap label on Explore cards when no valuation exists
- move the inspected chart date into the fixed Price header and remove the floating tooltip
- replace the amount input rectangle with a compact keyboard focus underline

## Validation
- 76 focused UI tests passed
- changed React/test ESLint passed
- production build and TypeScript passed