### PR TITLE
Fix mobile Explore hydration refetch

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1181,6 +1181,21 @@ export function handledInitialExploreRequestKey(
   return state?.phase === "ready" ? requestKey : null;
 }
 
+export function createResponsiveExploreInitialState(
+  response: ExploreInitialResponse | undefined,
+  input: Readonly<{
+    reuseAvailable: boolean;
+    isInitialRequest: boolean;
+    requestKey: string;
+    contentKey: string;
+    pageSize: number;
+  }>,
+): ExploreState | null {
+  if (!input.reuseAvailable || !input.isInitialRequest) return null;
+  const state = createExploreInitialState(response, input);
+  return state?.phase === "ready" ? state : null;
+}
+
 type PendingExploreRequest = {
   controller: AbortController;
   promise: Promise<ExplorePayload>;
@@ -2002,6 +2017,9 @@ export function ExploreView({
       pageSize,
     }),
   );
+  const initialResponseReuseAvailable = useRef(
+    initialState?.phase === "ready",
+  );
   const handledRequestKey = useRef<string | null>(
     handledInitialExploreRequestKey(initialState, requestKey),
   );
@@ -2101,6 +2119,39 @@ export function ExploreView({
       return;
     }
 
+    const initialValuationSort: ExploreValuationSort =
+      DEFAULT_EXPLORE_VIEW_SORT === "market-cap" ? "highest" : "none";
+    const isInitialRequest =
+      debouncedQuery === "" &&
+      valuationSort === initialValuationSort &&
+      ageSort === "none" &&
+      socialFilter === "all" &&
+      modelFilter === "all" &&
+      currentPage === 1 &&
+      retryKey === 0;
+    const responsiveInitialState = createResponsiveExploreInitialState(
+      initialResponse,
+      {
+        reuseAvailable: initialResponseReuseAvailable.current,
+        isInitialRequest,
+        requestKey,
+        contentKey,
+        pageSize,
+      },
+    );
+    if (responsiveInitialState?.phase === "ready") {
+      activeExploreContentKey.current = activeRequestContentKey;
+      cacheResolvedExplorePayload(
+        activeRequestContentKey,
+        responsiveInitialState.payload,
+      );
+      if (handledRequestKey.current !== requestKey) {
+        handledRequestKey.current = requestKey;
+        setState(responsiveInitialState);
+      }
+      return;
+    }
+
     if (handledRequestKey.current === requestKey) {
       activeExploreContentKey.current = activeRequestContentKey;
       if (initialState?.phase === "ready") {
@@ -2111,6 +2162,8 @@ export function ExploreView({
       }
       return;
     }
+
+    initialResponseReuseAvailable.current = false;
 
     let ignore = false;
     const previousContentKey = activeExploreContentKey.current;
@@ -2204,10 +2257,12 @@ export function ExploreView({
     modelDatasetKey,
     modelFilter,
     pageSize,
+    initialResponse,
     initialState,
     loadingOnly,
     preview,
     requestKey,
+    retryKey,
     requiresCompleteDataset,
     socialFilter,
     sort,

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -5,6 +5,7 @@ import {
   EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE,
   EXPLORE_TOKENS_PER_PAGE,
   createExploreInitialState,
+  createResponsiveExploreInitialState,
   exploreAppliedSortLabel,
   exploreMarketStatusLabel,
   exploreUnavailableFdvLabel,
@@ -411,9 +412,11 @@ describe("Explore refresh state", () => {
   });
 
   it("reuses the nine-token server page for the four-token mobile view", () => {
-    const initialState = createExploreInitialState(
+    const initialState = createResponsiveExploreInitialState(
       { ok: true, body: unvaluedMarketPayload },
       {
+        reuseAvailable: true,
+        isInitialRequest: true,
         contentKey: "initial-mobile-content",
         requestKey: "initial-mobile-request",
         pageSize: EXPLORE_MOBILE_TOKENS_PER_PAGE,
@@ -431,6 +434,28 @@ describe("Explore refresh state", () => {
     expect(
       handledInitialExploreRequestKey(initialState, "initial-mobile-request"),
     ).toBe("initial-mobile-request");
+  });
+
+  it("stops reusing the server page after the first non-initial request", () => {
+    const input = {
+      contentKey: "initial-mobile-content",
+      requestKey: "initial-mobile-request",
+      pageSize: EXPLORE_MOBILE_TOKENS_PER_PAGE,
+      isInitialRequest: true,
+    } as const;
+
+    expect(
+      createResponsiveExploreInitialState(
+        { ok: true, body: unvaluedMarketPayload },
+        { ...input, reuseAvailable: false },
+      ),
+    ).toBeNull();
+    expect(
+      createResponsiveExploreInitialState(
+        { ok: true, body: unvaluedMarketPayload },
+        { ...input, reuseAvailable: true, isInitialRequest: false },
+      ),
+    ).toBeNull();
   });
 
   it("uses nine desktop cards and four mobile cards per page", () => {


### PR DESCRIPTION
## What changed
- reuse the server-rendered first Explore page when hydration switches from the 9-card desktop snapshot to the 4-card mobile layout
- preserve the existing first-page response and avoid a duplicate /api/explore request
- stop reuse after a non-initial request

## Verification
- focused Explore and SSR tests: 57/57
- changed-path ESLint
- typecheck
- production build
- diff check