### PR TITLE
Gate Explore reads on the hydrated viewport

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -289,6 +289,13 @@ export function exploreTokensPerPageForViewport(width: number) {
     : EXPLORE_TOKENS_PER_PAGE;
 }
 
+export function explorePageSizeMatchesViewport(
+  pageSize: number,
+  viewportWidth: number,
+) {
+  return pageSize === exploreTokensPerPageForViewport(viewportWidth);
+}
+
 function subscribeToExploreViewport(onChange: () => void) {
   const query = window.matchMedia(EXPLORE_MOBILE_MEDIA_QUERY);
   query.addEventListener("change", onChange);
@@ -2115,6 +2122,13 @@ export function ExploreView({
       loadingOnly ||
       (typeof window !== "undefined" &&
         isInterfacePreviewHost(window.location.hostname))
+    ) {
+      return;
+    }
+
+    if (
+      typeof window !== "undefined" &&
+      !explorePageSizeMatchesViewport(pageSize, window.innerWidth)
     ) {
       return;
     }

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -8,6 +8,7 @@ import {
   createResponsiveExploreInitialState,
   exploreAppliedSortLabel,
   exploreMarketStatusLabel,
+  explorePageSizeMatchesViewport,
   exploreUnavailableFdvLabel,
   exploreTokensPerPageForViewport,
   handledInitialExploreRequestKey,
@@ -464,6 +465,9 @@ describe("Explore refresh state", () => {
     expect(exploreTokensPerPageForViewport(390)).toBe(4);
     expect(exploreTokensPerPageForViewport(700)).toBe(4);
     expect(exploreTokensPerPageForViewport(701)).toBe(9);
+    expect(explorePageSizeMatchesViewport(9, 1440)).toBe(true);
+    expect(explorePageSizeMatchesViewport(9, 390)).toBe(false);
+    expect(explorePageSizeMatchesViewport(4, 390)).toBe(true);
     expect(getExplorePaginationItems(1, 10)).toEqual([
       1,
       2,


### PR DESCRIPTION
## What changed
- suppress an initial Explore request while the server viewport snapshot still disagrees with the actual browser width
- allow only the correct mobile page-size request when the bounded SSR read is unavailable
- retain the responsive reuse path when the SSR response is ready

## Verification
- focused Explore and SSR tests: 57/57
- changed-path ESLint
- typecheck
- production build
- diff check
- live failure evidence on the prior deployment showed the exact 9-then-4 request sequence this patch gates