### PR TITLE
fix(chart): display market cap history

### DIFF
--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -115,6 +115,19 @@ function chartTotalSupply(input: {
     : undefined;
 }
 
+function chartCurrentMarketCapUsd(input: {
+  valuation?: ExploreValuation;
+  fdvUsdWad?: string;
+}) {
+  const valueWad = input.valuation?.status === "available" &&
+      input.valuation.currency === "usd"
+    ? input.valuation.valueWad
+    : input.fdvUsdWad;
+  return valueWad && /^\d+$/u.test(valueWad)
+    ? formatUnits(BigInt(valueWad), 18)
+    : undefined;
+}
+
 const CHART_VOLUME_LABELS = {
   "1h": "Volume 1H",
   "1d": "Volume 1D",
@@ -1652,6 +1665,7 @@ function TokenDetailContent({
               tokenName={token.name}
               launchModel={classicTradeLaunchModel}
               totalSupply={chartTotalSupply(token)}
+              currentMarketCapUsd={chartCurrentMarketCapUsd(token)}
               preview={preview}
               onVolumeChange={setChartVolume}
             />
@@ -2013,6 +2027,7 @@ function CustomProjectDetailContent({
               tokenAddress={project.tokenAddress}
               tokenName={project.name}
               totalSupply={chartTotalSupply(project)}
+              currentMarketCapUsd={chartCurrentMarketCapUsd(project)}
             />
             <MetricGrid metrics={metrics} />
           </section>

--- a/components/token-price-chart.tsx
+++ b/components/token-price-chart.tsx
@@ -342,16 +342,74 @@ function marketCapUsdForPoint(
     : undefined;
 }
 
+function positiveChartNumber(value: string | undefined) {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function bindMarketCapHistory(
+  points: readonly TokenChartPoint[],
+  totalSupply?: string,
+  currentMarketCapUsd?: string,
+): TokenChartPoint[] {
+  if (points.length === 0) return [];
+  if (points.every((point) => positiveChartNumber(point.marketCapUsd) !== null)) {
+    return points.map((point) => ({ ...point }));
+  }
+
+  if (
+    positiveChartNumber(totalSupply) !== null &&
+    points.every((point) => positiveChartNumber(point.priceUsd) !== null)
+  ) {
+    return points.map((point) => ({
+      ...point,
+      marketCapUsd: marketCapUsdForPoint(point, totalSupply),
+    }));
+  }
+
+  const anchorMarketCap = positiveChartNumber(currentMarketCapUsd);
+  if (anchorMarketCap === null) return points.map((point) => ({ ...point }));
+
+  const priceField = (["priceUsd", "priceEth", "priceQuote"] as const).find(
+    (field) => points.every((point) => positiveChartNumber(point[field]) !== null),
+  );
+  if (!priceField) return points.map((point) => ({ ...point }));
+  if (priceField === "priceQuote") {
+    const quoteSymbols = new Set(
+      points.map((point) => point.quoteSymbol?.trim()).filter(Boolean),
+    );
+    if (quoteSymbols.size !== 1) return points.map((point) => ({ ...point }));
+  }
+
+  const latestPrice = positiveChartNumber(points.at(-1)?.[priceField]);
+  if (latestPrice === null) return points.map((point) => ({ ...point }));
+
+  return points.map((point) => ({
+    ...point,
+    marketCapUsd: (
+      anchorMarketCap *
+      (positiveChartNumber(point[priceField]) as number) /
+      latestPrice
+    ).toString(),
+  }));
+}
+
 export function selectChartMetric(
   points: readonly TokenChartPoint[],
   totalSupply?: string,
+  currentMarketCapUsd?: string,
 ): "market-cap" | "price" {
-  if (!totalSupply || points.length === 0) return "price";
-  const hasUsdPriceHistory = points.every((point) => {
-    const value = Number(point.priceUsd);
-    return Number.isFinite(value) && value > 0;
-  });
-  return hasUsdPriceHistory ? "market-cap" : "price";
+  const boundPoints = bindMarketCapHistory(
+    points,
+    totalSupply,
+    currentMarketCapUsd,
+  );
+  return boundPoints.length > 0 && boundPoints.every(
+      (point) => positiveChartNumber(point.marketCapUsd) !== null,
+    )
+    ? "market-cap"
+    : "price";
 }
 
 function chartPointContext(point: TokenChartPoint): string {
@@ -515,6 +573,7 @@ export function TokenPriceChart({
   tokenName,
   launchModel,
   totalSupply,
+  currentMarketCapUsd,
   preview = false,
   onVolumeChange,
 }: {
@@ -522,6 +581,7 @@ export function TokenPriceChart({
   tokenName: string;
   launchModel?: ChartLaunchModel;
   totalSupply?: string;
+  currentMarketCapUsd?: string;
   preview?: boolean;
   onVolumeChange?: (volume: TokenChartVolume | null) => void;
 }) {
@@ -623,16 +683,15 @@ export function TokenPriceChart({
     refreshTaskRef.current?.request();
   }, [refreshKey]);
 
-  const chartMetric = selectChartMetric(payload?.points ?? [], totalSupply);
   const chartPoints = useMemo(
-    () => payload?.points.map((point) => ({
-      ...point,
-      ...(chartMetric === "market-cap"
-        ? { marketCapUsd: marketCapUsdForPoint(point, totalSupply) }
-        : {}),
-    })) ?? [],
-    [chartMetric, payload, totalSupply],
+    () => bindMarketCapHistory(
+      payload?.points ?? [],
+      totalSupply,
+      currentMarketCapUsd,
+    ),
+    [currentMarketCapUsd, payload, totalSupply],
   );
+  const chartMetric = selectChartMetric(chartPoints);
   const chart = useMemo(
     () => createChartGeometry(chartPoints, chartMetric),
     [chartMetric, chartPoints],

--- a/tests/token-price-chart-refresh.test.ts
+++ b/tests/token-price-chart-refresh.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   acceptChartPayload,
+  bindMarketCapHistory,
   createSerializedChartRefresh,
   createChartGeometry,
   formatPrice,
@@ -78,6 +79,23 @@ describe("token price chart inspection", () => {
         "1000000",
       ),
     ).toBe("market-cap");
+  });
+
+  it("anchors exact-pool quote history to the current USD market cap", () => {
+    const points = bindMarketCapHistory(
+      [
+        { blockNumber: "100", priceQuote: "0.0000002", quoteSymbol: "ETH" },
+        { blockNumber: "101", priceQuote: "0.00000025", quoteSymbol: "ETH" },
+      ],
+      "1000000000",
+      "400000",
+    );
+
+    expect(selectChartMetric(points)).toBe("market-cap");
+    expect(points.map((point) => Number(point.marketCapUsd))).toEqual([
+      320000,
+      400000,
+    ]);
   });
 
   it("maps the pointer to the nearest plotted price point", () => {


### PR DESCRIPTION
## Summary
- display the token chart as market-cap history instead of raw ETH price
- anchor exact pool quote history to the current bound USD market cap
- keep current USD price history support unchanged

## Validation
- focused chart/detail tests
- changed-path ESLint
- TypeScript
- production build
- diff check