### PR TITLE
Add release-bound GitHub launch sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,17 @@ NEXT_PUBLIC_PRIVY_APP_ID=
 # Required by server routes that verify Privy access tokens.
 PRIVY_APP_SECRET=
 
+# GitHub App user-to-server launch authority. The Website receives `ghu_`
+# tokens only through the registered PKCE callback, seals them in an HttpOnly
+# cookie, revalidates them with GitHub, and signs a 30-second release-bound
+# assertion. Keep the client secret, Ed25519 private key and 32-byte base64url
+# cookie key server-only. VERCEL_GIT_COMMIT_SHA must equal the release commit.
+PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_ID=
+PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_SECRET=
+PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_KEY_ID=
+PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_PRIVATE_KEY_PEM=
+PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_COOKIE_SEAL_KEY_BASE64URL=
+
 # Custom Launch website projection target. Use a dedicated PostgreSQL role
 # whose only runtime privileges are SELECT and INSERT on the immutable tables.
 PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL=

--- a/app/api/custom-launch/github-app/authorization/route.ts
+++ b/app/api/custom-launch/github-app/authorization/route.ts
@@ -1,0 +1,11 @@
+import {
+  handleProductionWebsiteGitHubAppAuthorizationStartV1,
+} from "@/lib/server/custom-launch/github-launch-session-v1";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 20;
+export const runtime = "nodejs";
+
+export function POST(request: Request): Promise<Response> {
+  return handleProductionWebsiteGitHubAppAuthorizationStartV1(request);
+}

--- a/app/api/custom-launch/github-app/callback/route.ts
+++ b/app/api/custom-launch/github-app/callback/route.ts
@@ -1,0 +1,11 @@
+import {
+  handleProductionWebsiteGitHubAppAuthorizationCallbackV1,
+} from "@/lib/server/custom-launch/github-launch-session-v1";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 20;
+export const runtime = "nodejs";
+
+export function GET(request: Request): Promise<Response> {
+  return handleProductionWebsiteGitHubAppAuthorizationCallbackV1(request);
+}

--- a/components/custom-launch-experience.tsx
+++ b/components/custom-launch-experience.tsx
@@ -1529,6 +1529,7 @@ function CustomLaunchRuntime({
   const {
     authReady,
     authenticated,
+    authorizeGithubLaunchApp,
     connectGithub,
     githubConnected,
     githubUserId,
@@ -2859,6 +2860,21 @@ function CustomLaunchRuntime({
       openWallet();
       return;
     }
+    if (applicantRecovery === "authorize-github-app") {
+      setError("");
+      setApplicantReauthorizing(true);
+      setStatusMessage("Reconnect GitHub to prove the current session");
+      try {
+        await authorizeGithubLaunchApp();
+      } catch {
+        setError("Unable to reconnect GitHub. Your last known approval stays visible");
+        setStatusMessage("Wallet actions remain unavailable until GitHub reconnects");
+        setApplicantRecovery("authorize-github-app");
+      } finally {
+        setApplicantReauthorizing(false);
+      }
+      return;
+    }
     if (applicantRecovery === "reconnect-github") {
       setError("");
       if (!githubConnected) {
@@ -2900,6 +2916,7 @@ function CustomLaunchRuntime({
   const applicantRecoveryAction = applicantRecovery === "connect-wallet"
     ? "Connect wallet"
     : applicantRecovery === "reconnect-github"
+      || applicantRecovery === "authorize-github-app"
       ? "Reconnect GitHub"
       : "Try again";
 

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -34,6 +34,9 @@ import {
   isApplicantRefreshUserUnavailableErrorV1,
   type ApplicantRefreshUserGateV1,
 } from "@/lib/custom-launch/applicant-refresh-user-gate-v1";
+import {
+  requestGitHubLaunchAppAuthorizationV1,
+} from "@/lib/custom-launch/github-app-authorization-v1";
 import { parseLocalProfile } from "@/lib/profile/local-profile";
 import {
   buildEip1193TransactionRequest,
@@ -104,6 +107,7 @@ type WalletContextValue = {
   githubUserId: string;
   githubUsername: string;
   connectGithub: () => void;
+  authorizeGithubLaunchApp: () => Promise<void>;
   reauthorizeGithub: () => Promise<void>;
   setUsername: (username: string) => void;
   signLaunchMessage: (signingMessageBase64Url: string) => Promise<string>;
@@ -770,6 +774,9 @@ function DeferredWalletProvider({
       githubUserId: "",
       githubUsername: "",
       connectGithub: () => onActivate("github"),
+      authorizeGithubLaunchApp: async () => {
+        throw new Error("GitHub sign-in is still loading");
+      },
       reauthorizeGithub: async () => {
         throw new Error("GitHub sign-in is still loading");
       },
@@ -1104,6 +1111,14 @@ function PrivyWalletBridge({
     ready,
     reauthorize,
   ]);
+  const authorizeGithubLaunchApp = useCallback(async () => {
+    const session = await refreshApplicantSession();
+    if (session === null) {
+      throw new Error("Sign in with your approved GitHub account");
+    }
+    const authorization = await requestGitHubLaunchAppAuthorizationV1({ session });
+    window.location.assign(authorization.toString());
+  }, [refreshApplicantSession]);
 
   const profileValue = useSyncExternalStore(
     subscribeToProfiles,
@@ -1688,6 +1703,7 @@ function PrivyWalletBridge({
       githubUserId,
       githubUsername,
       connectGithub,
+      authorizeGithubLaunchApp,
       reauthorizeGithub,
       setUsername,
       signLaunchMessage,
@@ -1699,6 +1715,7 @@ function PrivyWalletBridge({
     [
       activeAuthenticated,
       avatarDataUrl,
+      authorizeGithubLaunchApp,
       connectGithub,
       disconnect,
       disconnecting,
@@ -1782,6 +1799,9 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
       githubUserId: "",
       githubUsername: "",
       connectGithub: () => setDialogOpen(true),
+      authorizeGithubLaunchApp: async () => {
+        throw new Error("GitHub sign-in is unavailable");
+      },
       reauthorizeGithub: async () => {
         throw new Error("GitHub sign-in is unavailable");
       },

--- a/lib/custom-launch/applicant-session-v2.ts
+++ b/lib/custom-launch/applicant-session-v2.ts
@@ -10,6 +10,7 @@ import {
 
 export type CustomLaunchApplicantRecoveryV2 =
   | "none"
+  | "authorize-github-app"
   | "reconnect-github"
   | "connect-wallet"
   | "retry";
@@ -373,6 +374,9 @@ export function customLaunchApplicantRecoveryV2(
     return caught.reason === "wallet" ? "connect-wallet" : "reconnect-github";
   }
   if (caught instanceof CustomLaunchWebsiteRequestErrorV2) {
+    if (caught.code === "github_app_authorization_required") {
+      return "authorize-github-app";
+    }
     if (
       caught.status === 401
       || caught.status === 403

--- a/lib/custom-launch/github-app-authorization-v1.ts
+++ b/lib/custom-launch/github-app-authorization-v1.ts
@@ -1,0 +1,62 @@
+import type { CustomLaunchWebsiteSessionV2 } from "./contract-v2";
+
+const START_PATH = "/api/custom-launch/github-app/authorization" as const;
+const CALLBACK_URL =
+  "https://programmable.market/api/custom-launch/github-app/callback" as const;
+const BASE64URL = /^[A-Za-z0-9_-]+$/u;
+const GITHUB_CLIENT_ID = /^(?:Iv1\.[0-9a-f]{16}|[A-Za-z0-9_-]{8,128})$/u;
+
+export async function requestGitHubLaunchAppAuthorizationV1(input: Readonly<{
+  session: CustomLaunchWebsiteSessionV2;
+  fetch?: typeof fetch;
+}>): Promise<URL> {
+  const fetchV1 = input.fetch ?? globalThis.fetch.bind(globalThis);
+  if (!input.session.accessToken.trim() || !input.session.identityToken.trim()) {
+    throw new TypeError("Current GitHub session is unavailable");
+  }
+  const response = await fetchV1(START_PATH, {
+    method: "POST",
+    cache: "no-store",
+    credentials: "same-origin",
+    redirect: "error",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${input.session.accessToken}`,
+      "x-privy-identity-token": input.session.identityToken,
+    },
+  });
+  if (
+    response.status !== 200
+    || response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase()
+      !== "application/json"
+  ) throw new TypeError("GitHub launch authorization is unavailable");
+  const value = await response.json() as unknown;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("GitHub launch authorization response is invalid");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    Object.keys(record).sort().join("\0") !== ["authorizationUrl", "schemaVersion"].sort().join("\0")
+    || record.schemaVersion !== "programmable.website-github-app-authorization-start.v1"
+    || typeof record.authorizationUrl !== "string"
+  ) throw new TypeError("GitHub launch authorization response is invalid");
+  const authorization = new URL(record.authorizationUrl);
+  const entries = [...authorization.searchParams.entries()];
+  if (
+    authorization.origin !== "https://github.com"
+    || authorization.pathname !== "/login/oauth/authorize"
+    || authorization.hash !== ""
+    || entries.length !== 5
+    || entries[0]?.[0] !== "client_id"
+    || !GITHUB_CLIENT_ID.test(entries[0][1])
+    || entries[1]?.[0] !== "redirect_uri"
+    || entries[1][1] !== CALLBACK_URL
+    || entries[2]?.[0] !== "state"
+    || !BASE64URL.test(entries[2][1])
+    || entries[3]?.[0] !== "code_challenge"
+    || !BASE64URL.test(entries[3][1])
+    || entries[4]?.[0] !== "code_challenge_method"
+    || entries[4][1] !== "S256"
+  ) throw new TypeError("GitHub launch authorization URL is invalid");
+  return authorization;
+}

--- a/lib/server/custom-launch/github-launch-session-v1.ts
+++ b/lib/server/custom-launch/github-launch-session-v1.ts
@@ -1,0 +1,1031 @@
+import "server-only";
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  randomBytes,
+  randomUUID,
+  sign,
+  type KeyObject,
+} from "node:crypto";
+
+import {
+  createPrivyGitHubPrincipalAuthenticatorV1,
+  type AuthenticatedGitHubPrincipalV1,
+  type WebsiteEntitlementReadAuthenticatorV1,
+} from "../projection-target/github-entitlement";
+import {
+  canonicalizeJson,
+  parseStrictJson,
+  type JsonValue,
+} from "../projection-target/canonical-json";
+import { canonicalSha256, type Sha256Digest } from "../projection-target/hashing";
+
+const WEBSITE_ISSUER = "https://programmable.market" as const;
+const WEBSITE_SESSION_AUDIENCE =
+  "programmable.website-github-launch-session-credential.v1" as const;
+const OAUTH_START_PATH = "/api/custom-launch/github-app/authorization" as const;
+const OAUTH_CALLBACK_PATH = "/api/custom-launch/github-app/callback" as const;
+const OAUTH_STATE_COOKIE = "__Host-programmable-github-launch-oauth" as const;
+const GITHUB_HANDOFF_COOKIE = "__Host-programmable-github-launch-session" as const;
+const GITHUB_AUTHORIZE_ENDPOINT = "https://github.com/login/oauth/authorize" as const;
+const GITHUB_TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token" as const;
+const GITHUB_API_VERSION = "2022-11-28" as const;
+const WEBSITE_SESSION_LIFETIME_SECONDS = 30;
+const OAUTH_STATE_LIFETIME_SECONDS = 10 * 60;
+const GITHUB_USER_TOKEN_LIFETIME_SECONDS = 8 * 60 * 60;
+const GITHUB_TIMEOUT_MS = 8_000;
+const MAXIMUM_GITHUB_RESPONSE_BYTES = 65_536;
+const MAXIMUM_COOKIE_BYTES = 4_096;
+const GIT_OBJECT = /^[0-9a-f]{40}$/u;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const GITHUB_CLIENT_ID = /^(?:Iv1\.[0-9a-f]{16}|[A-Za-z0-9_-]{8,128})$/u;
+const GITHUB_USER_ID = /^[1-9][0-9]{0,19}$/u;
+const GITHUB_APP_USER_TOKEN = /^ghu_[A-Za-z0-9_]{20,16380}$/u;
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/+\-]{0,255}$/u;
+const BASE64URL = /^[A-Za-z0-9_-]+$/u;
+const OAUTH_CODE = /^[A-Za-z0-9_-]{16,1024}$/u;
+
+type Clock = () => Date;
+type RandomBytes = (size: number) => Buffer;
+
+export interface WebsiteGitHubLaunchSessionCredentialIssuerV1 {
+  issueCredential(input: Readonly<{
+    request: Request;
+    principal: AuthenticatedGitHubPrincipalV1;
+  }>): Promise<string>;
+}
+
+export class WebsiteGitHubLaunchSessionErrorV1 extends Error {
+  constructor(
+    readonly status: 400 | 401 | 403 | 503,
+    readonly code: string,
+  ) {
+    super(code);
+    this.name = "WebsiteGitHubLaunchSessionErrorV1";
+  }
+}
+
+export interface WebsiteGitHubLaunchSessionConfigurationV1 {
+  readonly sourceCommit: string;
+  readonly privyAppId: string;
+  readonly approvalServiceOrigin: string;
+  readonly approvalServicePackageArtifactHash: Sha256Digest;
+  readonly githubAppClientId: string;
+  readonly githubAppClientSecret: string;
+  readonly signerKeyId: string;
+  readonly signerPrivateKey: KeyObject;
+  readonly signerPublicKeySpkiSha256: Sha256Digest;
+  readonly cookieSealKey: Buffer;
+  readonly websiteReleaseBindingHash: Sha256Digest;
+}
+
+export function isProductionWebsiteGitHubLaunchSessionConfiguredV1(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  try {
+    productionConfiguration(environment);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function productionWebsiteGitHubLaunchSessionBindingV1(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): Readonly<{
+  schemaVersion: "programmable.website-github-launch-session-binding.v1";
+  issuer: typeof WEBSITE_ISSUER;
+  audience: typeof WEBSITE_SESSION_AUDIENCE;
+  githubAppClientId: string;
+  signerKeyId: string;
+  signerPublicKeyPem: string;
+  signerPublicKeySpkiSha256: Sha256Digest;
+  websiteReleaseBindingHash: Sha256Digest;
+  sourceCommit: string;
+}> {
+  const configuration = productionConfiguration(environment);
+  return Object.freeze({
+    schemaVersion: "programmable.website-github-launch-session-binding.v1",
+    issuer: WEBSITE_ISSUER,
+    audience: WEBSITE_SESSION_AUDIENCE,
+    githubAppClientId: configuration.githubAppClientId,
+    signerKeyId: configuration.signerKeyId,
+    signerPublicKeyPem: publicKeyFromPrivate(configuration.signerPrivateKey)
+      .export({ type: "spki", format: "pem" }).toString(),
+    signerPublicKeySpkiSha256: configuration.signerPublicKeySpkiSha256,
+    websiteReleaseBindingHash: configuration.websiteReleaseBindingHash,
+    sourceCommit: configuration.sourceCommit,
+  });
+}
+
+export function createProductionWebsiteGitHubLaunchSessionCredentialIssuerV1():
+WebsiteGitHubLaunchSessionCredentialIssuerV1 {
+  return createWebsiteGitHubLaunchSessionCredentialIssuerV1({
+    configuration: productionConfiguration(process.env),
+    githubFetch: globalThis.fetch.bind(globalThis),
+  });
+}
+
+export function createWebsiteGitHubLaunchSessionCredentialIssuerV1(input: Readonly<{
+  configuration: WebsiteGitHubLaunchSessionConfigurationV1;
+  githubFetch: typeof fetch;
+  now?: Clock;
+  randomId?: () => string;
+}>): WebsiteGitHubLaunchSessionCredentialIssuerV1 {
+  const configuration = exactConfiguration(input.configuration);
+  if (typeof input.githubFetch !== "function") {
+    throw new TypeError("GitHub launch-session fetch is invalid");
+  }
+  const now = input.now ?? (() => new Date());
+  const randomId = input.randomId ?? randomUUID;
+  return Object.freeze({
+    async issueCredential({ request, principal }: Readonly<{
+      request: Request;
+      principal: AuthenticatedGitHubPrincipalV1;
+    }>) {
+      const handoff = openGitHubHandoff(request, configuration, now());
+      assertPrincipalBinding(handoff, principal);
+      const observation = await inspectGitHubToken({
+        configuration,
+        token: handoff.githubAppUserToken,
+        githubFetch: input.githubFetch,
+        signal: request.signal,
+        now: now(),
+      });
+      if (
+        observation.githubUserId !== principal.githubUserId
+        || observation.expiresAtSeconds !== handoff.expiresAt
+      ) {
+        throw new WebsiteGitHubLaunchSessionErrorV1(
+          401,
+          "github_app_authorization_required",
+        );
+      }
+      const issuedAt = seconds(now());
+      const expiresAt = issuedAt + WEBSITE_SESSION_LIFETIME_SECONDS;
+      if (observation.expiresAtSeconds <= expiresAt) {
+        throw new WebsiteGitHubLaunchSessionErrorV1(
+          401,
+          "github_app_authorization_required",
+        );
+      }
+      const jti = randomId().toLowerCase();
+      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u
+        .test(jti)) {
+        throw new TypeError("Website session identifier is invalid");
+      }
+      const header = canonicalizeJson({
+        alg: "EdDSA",
+        kid: configuration.signerKeyId,
+        typ: "JWT",
+      });
+      const claims = canonicalizeJson({
+        aud: WEBSITE_SESSION_AUDIENCE,
+        exp: expiresAt,
+        githubAppClientId: configuration.githubAppClientId,
+        githubAppUserToken: handoff.githubAppUserToken,
+        githubUserId: principal.githubUserId,
+        iat: issuedAt,
+        iss: WEBSITE_ISSUER,
+        jti,
+        revocationCheckedAt: issuedAt,
+        schemaVersion: "programmable.website-github-launch-session-credential.v1",
+        sessionId: principalSessionId(principal),
+        sessionState: "active",
+        sub: principal.privyUserId,
+        websiteReleaseBindingHash: configuration.websiteReleaseBindingHash,
+      });
+      const signingInput = `${Buffer.from(header).toString("base64url")}.${
+        Buffer.from(claims).toString("base64url")}`;
+      const signature = sign(
+        null,
+        Buffer.from(signingInput, "ascii"),
+        configuration.signerPrivateKey,
+      );
+      if (signature.byteLength !== 64) {
+        throw new WebsiteGitHubLaunchSessionErrorV1(
+          503,
+          "github_launch_session_signer_unavailable",
+        );
+      }
+      return `${signingInput}.${signature.toString("base64url")}`;
+    },
+  });
+}
+
+export function createWebsiteGitHubAppAuthorizationStartHandlerV1(input: Readonly<{
+  authenticator: WebsiteEntitlementReadAuthenticatorV1;
+  configuration: WebsiteGitHubLaunchSessionConfigurationV1;
+  now?: Clock;
+  random?: RandomBytes;
+}>): (request: Request) => Promise<Response> {
+  if (typeof input.authenticator?.authenticate !== "function") {
+    throw new TypeError("GitHub App authorization authenticator is invalid");
+  }
+  const configuration = exactConfiguration(input.configuration);
+  const now = input.now ?? (() => new Date());
+  const random = input.random ?? randomBytes;
+  return async function startGitHubAppAuthorization(request: Request): Promise<Response> {
+    if (!exactStartRequest(request)) return oauthError(400, "invalid_request");
+    let principal: AuthenticatedGitHubPrincipalV1;
+    try {
+      principal = await input.authenticator.authenticate(request);
+    } catch {
+      return oauthError(401, "privy_session_rejected");
+    }
+    const issuedAt = seconds(now());
+    const state = exactRandom(random, 32);
+    const codeVerifier = exactRandom(random, 32);
+    const payload: OAuthStateV1 = Object.freeze({
+      schemaVersion: "programmable.website-github-app-oauth-state.v1",
+      codeVerifier,
+      expiresAt: issuedAt + OAUTH_STATE_LIFETIME_SECONDS,
+      githubAppClientId: configuration.githubAppClientId,
+      githubUserId: principal.githubUserId,
+      issuedAt,
+      privySessionId: principalSessionId(principal),
+      privyUserId: principal.privyUserId,
+      state,
+    });
+    const authorization = new URL(GITHUB_AUTHORIZE_ENDPOINT);
+    authorization.searchParams.set("client_id", configuration.githubAppClientId);
+    authorization.searchParams.set("redirect_uri", callbackUrl());
+    authorization.searchParams.set("state", state);
+    authorization.searchParams.set(
+      "code_challenge",
+      createHash("sha256").update(codeVerifier, "ascii").digest("base64url"),
+    );
+    authorization.searchParams.set("code_challenge_method", "S256");
+    const sealed = seal(payload, configuration.cookieSealKey, random);
+    return jsonResponse(200, {
+      schemaVersion: "programmable.website-github-app-authorization-start.v1",
+      authorizationUrl: authorization.toString(),
+    }, [cookie(OAUTH_STATE_COOKIE, sealed, OAUTH_STATE_LIFETIME_SECONDS, "Lax")]);
+  };
+}
+
+export function createWebsiteGitHubAppAuthorizationCallbackHandlerV1(input: Readonly<{
+  configuration: WebsiteGitHubLaunchSessionConfigurationV1;
+  githubFetch: typeof fetch;
+  now?: Clock;
+  random?: RandomBytes;
+}>): (request: Request) => Promise<Response> {
+  const configuration = exactConfiguration(input.configuration);
+  if (typeof input.githubFetch !== "function") {
+    throw new TypeError("GitHub App callback fetch is invalid");
+  }
+  const now = input.now ?? (() => new Date());
+  const random = input.random ?? randomBytes;
+  return async function completeGitHubAppAuthorization(request: Request): Promise<Response> {
+    const invalid = (): Response => oauthError(
+      400,
+      "github_app_authorization_rejected",
+      [expiredCookie(OAUTH_STATE_COOKIE, "Lax")],
+    );
+    let url: URL;
+    try {
+      url = new URL(request.url);
+    } catch {
+      return invalid();
+    }
+    const entries = [...url.searchParams.entries()];
+    if (
+      request.method !== "GET"
+      || url.origin !== WEBSITE_ISSUER
+      || url.pathname !== OAUTH_CALLBACK_PATH
+      || url.hash !== ""
+      || entries.length !== 2
+      || entries[0]?.[0] !== "code"
+      || entries[1]?.[0] !== "state"
+      || !OAUTH_CODE.test(entries[0][1])
+      || !BASE64URL.test(entries[1][1])
+    ) return invalid();
+    let state: OAuthStateV1;
+    try {
+      state = oauthState(open(
+        cookieValue(request, OAUTH_STATE_COOKIE),
+        configuration.cookieSealKey,
+        "programmable.website-github-app-oauth-state.v1",
+      ), now());
+      if (
+        state.state !== entries[1][1]
+        || state.githubAppClientId !== configuration.githubAppClientId
+      ) throw new TypeError("GitHub App OAuth state differs");
+    } catch {
+      return invalid();
+    }
+    try {
+      const token = await exchangeAuthorizationCode({
+        code: entries[0][1],
+        codeVerifier: state.codeVerifier,
+        configuration,
+        githubFetch: input.githubFetch,
+        signal: request.signal,
+      });
+      const observation = await inspectGitHubToken({
+        configuration,
+        token,
+        githubFetch: input.githubFetch,
+        signal: request.signal,
+        now: now(),
+      });
+      if (observation.githubUserId !== state.githubUserId) {
+        return oauthError(403, "github_identity_mismatch", [
+          expiredCookie(OAUTH_STATE_COOKIE, "Lax"),
+        ]);
+      }
+      const issuedAt = seconds(now());
+      const maximumAge = observation.expiresAtSeconds - issuedAt;
+      if (maximumAge <= WEBSITE_SESSION_LIFETIME_SECONDS) return invalid();
+      const handoff: GitHubHandoffV1 = Object.freeze({
+        schemaVersion: "programmable.website-github-app-handoff.v1",
+        expiresAt: observation.expiresAtSeconds,
+        githubAppClientId: configuration.githubAppClientId,
+        githubAppUserToken: token,
+        githubUserId: state.githubUserId,
+        issuedAt,
+        privySessionId: state.privySessionId,
+        privyUserId: state.privyUserId,
+      });
+      const sealed = seal(handoff, configuration.cookieSealKey, random);
+      return new Response(null, {
+        status: 303,
+        headers: responseHeaders([
+          expiredCookie(OAUTH_STATE_COOKIE, "Lax"),
+          cookie(
+            GITHUB_HANDOFF_COOKIE,
+            sealed,
+            Math.min(maximumAge, GITHUB_USER_TOKEN_LIFETIME_SECONDS),
+            "Strict",
+          ),
+        ], { location: `${WEBSITE_ISSUER}/launch` }),
+      });
+    } catch {
+      return oauthError(503, "github_app_authorization_unavailable", [
+        expiredCookie(OAUTH_STATE_COOKIE, "Lax"),
+      ]);
+    }
+  };
+}
+
+let productionStartHandler:
+ReturnType<typeof createWebsiteGitHubAppAuthorizationStartHandlerV1> | null = null;
+let productionCallbackHandler:
+ReturnType<typeof createWebsiteGitHubAppAuthorizationCallbackHandlerV1> | null = null;
+
+export function handleProductionWebsiteGitHubAppAuthorizationStartV1(
+  request: Request,
+): Promise<Response> {
+  try {
+    assertLaunchPublic(process.env);
+    productionStartHandler ??= createWebsiteGitHubAppAuthorizationStartHandlerV1({
+      authenticator: createPrivyGitHubPrincipalAuthenticatorV1(),
+      configuration: productionConfiguration(process.env),
+    });
+    return productionStartHandler(request);
+  } catch {
+    return Promise.resolve(oauthError(503, "github_app_authorization_not_configured"));
+  }
+}
+
+export function handleProductionWebsiteGitHubAppAuthorizationCallbackV1(
+  request: Request,
+): Promise<Response> {
+  try {
+    assertLaunchPublic(process.env);
+    productionCallbackHandler ??= createWebsiteGitHubAppAuthorizationCallbackHandlerV1({
+      configuration: productionConfiguration(process.env),
+      githubFetch: globalThis.fetch.bind(globalThis),
+    });
+    return productionCallbackHandler(request);
+  } catch {
+    return Promise.resolve(oauthError(503, "github_app_authorization_not_configured"));
+  }
+}
+
+function productionConfiguration(
+  environment: Readonly<Record<string, string | undefined>>,
+): WebsiteGitHubLaunchSessionConfigurationV1 {
+  const releaseCommit = required(environment, "PROGRAMMABLE_RELEASE_COMMIT_SHA").toLowerCase();
+  const vercelCommit = required(environment, "VERCEL_GIT_COMMIT_SHA").toLowerCase();
+  if (!GIT_OBJECT.test(releaseCommit) || vercelCommit !== releaseCommit) {
+    throw new TypeError("Website release commit is not exact");
+  }
+  const privyAppId = required(environment, "NEXT_PUBLIC_PRIVY_APP_ID");
+  const approvalServiceOrigin = exactOrigin(required(
+    environment,
+    "PROGRAMMABLE_APPROVAL_SERVICE_V2_ORIGIN",
+  ));
+  const approvalServicePackageArtifactHash = required(
+    environment,
+    "PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_PACKAGE_ARTIFACT_HASH",
+  );
+  const githubAppClientId = required(environment, "PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_ID");
+  const githubAppClientSecret = required(
+    environment,
+    "PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_SECRET",
+  );
+  const signerKeyId = required(
+    environment,
+    "PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_KEY_ID",
+  );
+  const privateKeySource = required(
+    environment,
+    "PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_PRIVATE_KEY_PEM",
+  ).replaceAll("\\n", "\n");
+  const signerPrivateKey = createPrivateKey(privateKeySource);
+  if (signerPrivateKey.asymmetricKeyType !== "ed25519") {
+    throw new TypeError("Website session signer must be Ed25519");
+  }
+  const signerPublicKeySpkiSha256 = rawSha256(publicKeyFromPrivate(signerPrivateKey)
+    .export({ type: "spki", format: "der" }));
+  const sealKeySource = required(
+    environment,
+    "PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_COOKIE_SEAL_KEY_BASE64URL",
+  );
+  if (!BASE64URL.test(sealKeySource)) throw new TypeError("Cookie seal key is invalid");
+  const cookieSealKey = Buffer.from(sealKeySource, "base64url");
+  if (cookieSealKey.byteLength !== 32 || cookieSealKey.toString("base64url") !== sealKeySource) {
+    throw new TypeError("Cookie seal key is invalid");
+  }
+  if (
+    !safeOpaque(privyAppId, 256)
+    || !DIGEST.test(approvalServicePackageArtifactHash)
+    || !GITHUB_CLIENT_ID.test(githubAppClientId)
+    || !safeOpaque(githubAppClientSecret, 512)
+    || !SAFE_ID.test(signerKeyId)
+  ) throw new TypeError("Website GitHub launch-session configuration is invalid");
+  const websiteReleaseBindingHash = derivedWebsiteReleaseBindingHash({
+    approvalServiceOrigin,
+    approvalServicePackageArtifactHash:
+      approvalServicePackageArtifactHash as Sha256Digest,
+    githubAppClientId,
+    privyAppId,
+    signerKeyId,
+    signerPublicKeySpkiSha256,
+    sourceCommit: releaseCommit,
+  });
+  return exactConfiguration(Object.freeze({
+    sourceCommit: releaseCommit,
+    privyAppId,
+    approvalServiceOrigin,
+    approvalServicePackageArtifactHash:
+      approvalServicePackageArtifactHash as Sha256Digest,
+    githubAppClientId,
+    githubAppClientSecret,
+    signerKeyId,
+    signerPrivateKey,
+    signerPublicKeySpkiSha256,
+    cookieSealKey,
+    websiteReleaseBindingHash,
+  }));
+}
+
+function assertLaunchPublic(
+  environment: Readonly<Record<string, string | undefined>>,
+): void {
+  if (
+    environment.PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED !== "true"
+    || environment.PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED !== "true"
+  ) throw new TypeError("Custom Launch is not public");
+}
+
+function exactConfiguration(
+  configuration: WebsiteGitHubLaunchSessionConfigurationV1,
+): WebsiteGitHubLaunchSessionConfigurationV1 {
+  if (
+    !GIT_OBJECT.test(configuration.sourceCommit)
+    || !safeOpaque(configuration.privyAppId, 256)
+    || exactOrigin(configuration.approvalServiceOrigin) !== configuration.approvalServiceOrigin
+    || !DIGEST.test(configuration.approvalServicePackageArtifactHash)
+    || !GITHUB_CLIENT_ID.test(configuration.githubAppClientId)
+    || !safeOpaque(configuration.githubAppClientSecret, 512)
+    || !SAFE_ID.test(configuration.signerKeyId)
+    || configuration.signerPrivateKey?.asymmetricKeyType !== "ed25519"
+    || !DIGEST.test(configuration.signerPublicKeySpkiSha256)
+    || rawSha256(publicKeyFromPrivate(configuration.signerPrivateKey)
+      .export({ type: "spki", format: "der" }))
+      !== configuration.signerPublicKeySpkiSha256
+    || !(configuration.cookieSealKey instanceof Buffer)
+    || configuration.cookieSealKey.byteLength !== 32
+    || !DIGEST.test(configuration.websiteReleaseBindingHash)
+    || configuration.websiteReleaseBindingHash
+      !== derivedWebsiteReleaseBindingHash(configuration)
+  ) throw new TypeError("Website GitHub launch-session configuration is invalid");
+  return configuration;
+}
+
+function derivedWebsiteReleaseBindingHash(input: Readonly<{
+  sourceCommit: string;
+  privyAppId: string;
+  approvalServiceOrigin: string;
+  approvalServicePackageArtifactHash: Sha256Digest;
+  githubAppClientId: string;
+  signerKeyId: string;
+  signerPublicKeySpkiSha256: Sha256Digest;
+}>): Sha256Digest {
+  return canonicalSha256(
+    "programmable.website-github-launch-session-release-binding.v1",
+    {
+      approvalServiceOrigin: input.approvalServiceOrigin,
+      approvalServicePackageArtifactHash: input.approvalServicePackageArtifactHash,
+      audience: WEBSITE_SESSION_AUDIENCE,
+      githubAppClientId: input.githubAppClientId,
+      issuer: WEBSITE_ISSUER,
+      privyAppId: input.privyAppId,
+      signerKeyId: input.signerKeyId,
+      signerPublicKeySpkiSha256: input.signerPublicKeySpkiSha256,
+      sourceCommit: input.sourceCommit,
+    },
+  );
+}
+
+type OAuthStateV1 = Readonly<{
+  schemaVersion: "programmable.website-github-app-oauth-state.v1";
+  codeVerifier: string;
+  expiresAt: number;
+  githubAppClientId: string;
+  githubUserId: string;
+  issuedAt: number;
+  privySessionId: string;
+  privyUserId: string;
+  state: string;
+}>;
+
+type GitHubHandoffV1 = Readonly<{
+  schemaVersion: "programmable.website-github-app-handoff.v1";
+  expiresAt: number;
+  githubAppClientId: string;
+  githubAppUserToken: string;
+  githubUserId: string;
+  issuedAt: number;
+  privySessionId: string;
+  privyUserId: string;
+}>;
+
+function oauthState(value: JsonValue, now: Date): OAuthStateV1 {
+  const state = record(value, "GitHub App OAuth state");
+  exactKeys(state, [
+    "codeVerifier", "expiresAt", "githubAppClientId", "githubUserId", "issuedAt",
+    "privySessionId", "privyUserId", "schemaVersion", "state",
+  ], "GitHub App OAuth state");
+  const current = seconds(now);
+  if (
+    state.schemaVersion !== "programmable.website-github-app-oauth-state.v1"
+    || typeof state.codeVerifier !== "string"
+    || !BASE64URL.test(state.codeVerifier)
+    || typeof state.state !== "string"
+    || !BASE64URL.test(state.state)
+    || typeof state.githubAppClientId !== "string"
+    || !GITHUB_CLIENT_ID.test(state.githubAppClientId)
+    || typeof state.githubUserId !== "string"
+    || !GITHUB_USER_ID.test(state.githubUserId)
+    || typeof state.privyUserId !== "string"
+    || !SAFE_ID.test(state.privyUserId)
+    || typeof state.privySessionId !== "string"
+    || !SAFE_ID.test(state.privySessionId)
+    || typeof state.issuedAt !== "number"
+    || !Number.isSafeInteger(state.issuedAt)
+    || typeof state.expiresAt !== "number"
+    || !Number.isSafeInteger(state.expiresAt)
+    || state.issuedAt > current
+    || state.expiresAt <= current
+    || state.expiresAt - state.issuedAt !== OAUTH_STATE_LIFETIME_SECONDS
+  ) throw new TypeError("GitHub App OAuth state is invalid");
+  return state as OAuthStateV1;
+}
+
+function openGitHubHandoff(
+  request: Request,
+  configuration: WebsiteGitHubLaunchSessionConfigurationV1,
+  now: Date,
+): GitHubHandoffV1 {
+  try {
+    const value = record(open(
+      cookieValue(request, GITHUB_HANDOFF_COOKIE),
+      configuration.cookieSealKey,
+      "programmable.website-github-app-handoff.v1",
+    ), "GitHub App handoff");
+    exactKeys(value, [
+      "expiresAt", "githubAppClientId", "githubAppUserToken", "githubUserId",
+      "issuedAt", "privySessionId", "privyUserId", "schemaVersion",
+    ], "GitHub App handoff");
+    const current = seconds(now);
+    if (
+      value.schemaVersion !== "programmable.website-github-app-handoff.v1"
+      || value.githubAppClientId !== configuration.githubAppClientId
+      || typeof value.githubAppUserToken !== "string"
+      || !GITHUB_APP_USER_TOKEN.test(value.githubAppUserToken)
+      || typeof value.githubUserId !== "string"
+      || !GITHUB_USER_ID.test(value.githubUserId)
+      || typeof value.privyUserId !== "string"
+      || !SAFE_ID.test(value.privyUserId)
+      || typeof value.privySessionId !== "string"
+      || !SAFE_ID.test(value.privySessionId)
+      || typeof value.issuedAt !== "number"
+      || !Number.isSafeInteger(value.issuedAt)
+      || typeof value.expiresAt !== "number"
+      || !Number.isSafeInteger(value.expiresAt)
+      || value.issuedAt > current
+      || value.expiresAt <= current + WEBSITE_SESSION_LIFETIME_SECONDS
+      || value.expiresAt - value.issuedAt > GITHUB_USER_TOKEN_LIFETIME_SECONDS
+    ) throw new TypeError("GitHub App handoff is invalid");
+    return value as GitHubHandoffV1;
+  } catch {
+    throw new WebsiteGitHubLaunchSessionErrorV1(
+      401,
+      "github_app_authorization_required",
+    );
+  }
+}
+
+function assertPrincipalBinding(
+  handoff: GitHubHandoffV1,
+  principal: AuthenticatedGitHubPrincipalV1,
+): void {
+  if (
+    handoff.githubUserId !== principal.githubUserId
+    || handoff.privyUserId !== principal.privyUserId
+    || handoff.privySessionId !== principal.privySessionId
+  ) throw new WebsiteGitHubLaunchSessionErrorV1(401, "github_app_authorization_required");
+}
+
+function principalSessionId(principal: AuthenticatedGitHubPrincipalV1): string {
+  if (typeof principal.privySessionId !== "string" || !SAFE_ID.test(principal.privySessionId)) {
+    throw new WebsiteGitHubLaunchSessionErrorV1(401, "privy_session_rejected");
+  }
+  return principal.privySessionId;
+}
+
+async function exchangeAuthorizationCode(input: Readonly<{
+  code: string;
+  codeVerifier: string;
+  configuration: WebsiteGitHubLaunchSessionConfigurationV1;
+  githubFetch: typeof fetch;
+  signal: AbortSignal;
+}>): Promise<string> {
+  const body = new URLSearchParams({
+    client_id: input.configuration.githubAppClientId,
+    client_secret: input.configuration.githubAppClientSecret,
+    code: input.code,
+    redirect_uri: callbackUrl(),
+    code_verifier: input.codeVerifier,
+  }).toString();
+  const response = await boundedGitHubJson(
+    input.githubFetch,
+    new URL(GITHUB_TOKEN_ENDPOINT),
+    {
+      method: "POST",
+      redirect: "error",
+      cache: "no-store",
+      credentials: "omit",
+      signal: input.signal,
+      headers: {
+        accept: "application/json",
+        "content-type": "application/x-www-form-urlencoded",
+        "content-length": String(Buffer.byteLength(body)),
+        "user-agent": "programmable-website-github-app-oauth-v1",
+      },
+      body,
+    },
+  );
+  if (
+    typeof response.access_token !== "string"
+    || !GITHUB_APP_USER_TOKEN.test(response.access_token)
+    || response.expires_in !== GITHUB_USER_TOKEN_LIFETIME_SECONDS
+    || response.scope !== ""
+    || response.token_type !== "bearer"
+  ) throw new TypeError("GitHub App token exchange response is invalid");
+  return response.access_token;
+}
+
+async function inspectGitHubToken(input: Readonly<{
+  configuration: WebsiteGitHubLaunchSessionConfigurationV1;
+  token: string;
+  githubFetch: typeof fetch;
+  signal: AbortSignal;
+  now: Date;
+}>): Promise<Readonly<{ githubUserId: string; expiresAtSeconds: number }>> {
+  if (!GITHUB_APP_USER_TOKEN.test(input.token)) {
+    throw new WebsiteGitHubLaunchSessionErrorV1(401, "github_app_authorization_required");
+  }
+  const body = canonicalizeJson({ access_token: input.token });
+  const response = await boundedGitHubJson(
+    input.githubFetch,
+    new URL(
+      `https://api.github.com/applications/${input.configuration.githubAppClientId}/token`,
+    ),
+    {
+      method: "POST",
+      redirect: "error",
+      cache: "no-store",
+      credentials: "omit",
+      signal: input.signal,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Basic ${Buffer.from(
+          `${input.configuration.githubAppClientId}:${
+            input.configuration.githubAppClientSecret}`,
+          "utf8",
+        ).toString("base64")}`,
+        "content-type": "application/json",
+        "content-length": String(Buffer.byteLength(body)),
+        "user-agent": "programmable-website-github-launch-session-v1",
+        "x-github-api-version": GITHUB_API_VERSION,
+      },
+      body,
+    },
+  );
+  const app = record(response.app, "GitHub token app");
+  const user = record(response.user, "GitHub token user");
+  const expiresAt = typeof response.expires_at === "string"
+    ? new Date(response.expires_at)
+    : new Date(Number.NaN);
+  const expiresAtSeconds = Math.floor(expiresAt.getTime() / 1_000);
+  const current = seconds(input.now);
+  if (
+    response.token !== input.token
+    || !Array.isArray(response.scopes)
+    || response.scopes.length !== 0
+    || app.client_id !== input.configuration.githubAppClientId
+    || !Number.isSafeInteger(user.id)
+    || !GITHUB_USER_ID.test(String(user.id))
+    || !Number.isFinite(expiresAt.getTime())
+    || expiresAt.toISOString() !== response.expires_at
+    || expiresAtSeconds <= current
+    || expiresAtSeconds - current > GITHUB_USER_TOKEN_LIFETIME_SECONDS
+  ) throw new WebsiteGitHubLaunchSessionErrorV1(401, "github_app_authorization_required");
+  return Object.freeze({
+    githubUserId: String(user.id),
+    expiresAtSeconds,
+  });
+}
+
+async function boundedGitHubJson(
+  githubFetch: typeof fetch,
+  endpoint: URL,
+  init: RequestInit,
+): Promise<Readonly<Record<string, JsonValue>>> {
+  const parent = init.signal;
+  const controller = new AbortController();
+  const abort = () => controller.abort(parent?.reason);
+  parent?.addEventListener("abort", abort, { once: true });
+  const timeout = setTimeout(() => controller.abort(), GITHUB_TIMEOUT_MS);
+  try {
+    const response = await githubFetch(endpoint, { ...init, signal: controller.signal });
+    if (
+      response.status !== 200
+      || response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase()
+        !== "application/json"
+    ) {
+      await response.body?.cancel();
+      throw new TypeError("GitHub response is unavailable");
+    }
+    const bytes = await readBounded(response, MAXIMUM_GITHUB_RESPONSE_BYTES);
+    const source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    return record(parseStrictJson(source, {
+      maximumBytes: MAXIMUM_GITHUB_RESPONSE_BYTES,
+      maximumDepth: 16,
+    }), "GitHub response");
+  } finally {
+    clearTimeout(timeout);
+    parent?.removeEventListener("abort", abort);
+  }
+}
+
+async function readBounded(response: Response, maximumBytes: number): Promise<Uint8Array> {
+  if (response.body === null) throw new TypeError("GitHub response body is missing");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+      total += result.value.byteLength;
+      if (total > maximumBytes) throw new TypeError("GitHub response is too large");
+      chunks.push(Uint8Array.from(result.value));
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => {});
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function seal(value: JsonValue, key: Buffer, random: RandomBytes): string {
+  const iv = random(12);
+  if (!(iv instanceof Buffer) || iv.byteLength !== 12) {
+    throw new TypeError("Cookie nonce source is invalid");
+  }
+  const plaintext = Buffer.from(canonicalizeJson(value), "utf8");
+  const schema = record(value, "sealed cookie").schemaVersion;
+  if (typeof schema !== "string") throw new TypeError("Sealed cookie schema is invalid");
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  cipher.setAAD(Buffer.from(schema, "utf8"));
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const result = `v1.${iv.toString("base64url")}.${ciphertext.toString("base64url")}.${
+    cipher.getAuthTag().toString("base64url")}`;
+  if (Buffer.byteLength(result) > MAXIMUM_COOKIE_BYTES) {
+    throw new TypeError("Sealed cookie is too large");
+  }
+  return result;
+}
+
+function open(value: string, key: Buffer, schema: string): JsonValue {
+  const segments = value.split(".");
+  if (
+    segments.length !== 4
+    || segments[0] !== "v1"
+    || segments.slice(1).some((segment) => !BASE64URL.test(segment))
+  ) throw new TypeError("Sealed cookie is invalid");
+  const iv = Buffer.from(segments[1]!, "base64url");
+  const ciphertext = Buffer.from(segments[2]!, "base64url");
+  const tag = Buffer.from(segments[3]!, "base64url");
+  if (
+    iv.byteLength !== 12
+    || tag.byteLength !== 16
+    || iv.toString("base64url") !== segments[1]
+    || ciphertext.toString("base64url") !== segments[2]
+    || tag.toString("base64url") !== segments[3]
+  ) throw new TypeError("Sealed cookie is invalid");
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAAD(Buffer.from(schema, "utf8"));
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  if (plaintext.byteLength > MAXIMUM_COOKIE_BYTES) throw new TypeError("Cookie is too large");
+  const source = new TextDecoder("utf-8", { fatal: true }).decode(plaintext);
+  const parsed = parseStrictJson(source, {
+    maximumBytes: MAXIMUM_COOKIE_BYTES,
+    maximumDepth: 8,
+  });
+  if (canonicalizeJson(parsed) !== source) throw new TypeError("Cookie is not canonical");
+  return parsed;
+}
+
+function exactStartRequest(request: Request): boolean {
+  try {
+    const url = new URL(request.url);
+    return request.method === "POST"
+      && url.origin === WEBSITE_ISSUER
+      && url.pathname === OAUTH_START_PATH
+      && url.search === ""
+      && url.hash === ""
+      && request.headers.get("accept")?.trim().toLowerCase() === "application/json"
+      && !request.headers.has("content-type")
+      && !request.headers.has("content-length")
+      && request.body === null;
+  } catch {
+    return false;
+  }
+}
+
+function cookieValue(request: Request, name: string): string {
+  const source = request.headers.get("cookie");
+  if (source === null || Buffer.byteLength(source) > 16_384) {
+    throw new TypeError("Cookie is missing");
+  }
+  const matches = source.split(";").map((part) => part.trim()).filter((part) =>
+    part.startsWith(`${name}=`));
+  if (matches.length !== 1) throw new TypeError("Cookie is ambiguous");
+  const value = matches[0]!.slice(name.length + 1);
+  if (!value || Buffer.byteLength(value) > MAXIMUM_COOKIE_BYTES) {
+    throw new TypeError("Cookie is invalid");
+  }
+  return value;
+}
+
+function cookie(
+  name: string,
+  value: string,
+  maximumAge: number,
+  sameSite: "Lax" | "Strict",
+): string {
+  if (!Number.isSafeInteger(maximumAge) || maximumAge < 1) {
+    throw new TypeError("Cookie lifetime is invalid");
+  }
+  return `${name}=${value}; Max-Age=${maximumAge}; Path=/; Secure; HttpOnly; SameSite=${sameSite}`;
+}
+
+function expiredCookie(name: string, sameSite: "Lax" | "Strict"): string {
+  return `${name}=; Max-Age=0; Path=/; Secure; HttpOnly; SameSite=${sameSite}`;
+}
+
+function jsonResponse(
+  status: number,
+  body: Readonly<Record<string, JsonValue>>,
+  cookies: readonly string[] = [],
+): Response {
+  return new Response(canonicalizeJson(body), {
+    status,
+    headers: responseHeaders(cookies),
+  });
+}
+
+function oauthError(status: number, code: string, cookies: readonly string[] = []): Response {
+  return jsonResponse(status, {
+    schemaVersion: "programmable.website-github-app-authorization-error.v1",
+    code,
+  }, cookies);
+}
+
+function responseHeaders(
+  cookies: readonly string[],
+  extra: Readonly<Record<string, string>> = {},
+): Headers {
+  const headers = new Headers({
+    "cache-control": "no-store, max-age=0",
+    "content-type": "application/json; charset=utf-8",
+    "x-content-type-options": "nosniff",
+    vary: "authorization, cookie, x-privy-identity-token",
+    ...extra,
+  });
+  for (const value of cookies) headers.append("set-cookie", value);
+  return headers;
+}
+
+function exactRandom(random: RandomBytes, size: number): string {
+  const value = random(size);
+  if (!(value instanceof Buffer) || value.byteLength !== size) {
+    throw new TypeError("Random source is invalid");
+  }
+  return value.toString("base64url");
+}
+
+function callbackUrl(): string {
+  return `${WEBSITE_ISSUER}${OAUTH_CALLBACK_PATH}`;
+}
+
+function seconds(value: Date): number {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new TypeError("Clock is invalid");
+  }
+  return Math.floor(value.getTime() / 1_000);
+}
+
+function exactOrigin(value: string): string {
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:"
+    || url.username !== ""
+    || url.password !== ""
+    || url.pathname !== "/"
+    || url.search !== ""
+    || url.hash !== ""
+  ) throw new TypeError("Approval service origin is invalid");
+  return url.origin;
+}
+
+function required(
+  environment: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string {
+  const value = environment[name]?.trim();
+  if (!value) throw new TypeError(`${name} is not configured`);
+  return value;
+}
+
+function safeOpaque(value: string, maximum: number): boolean {
+  return value.length >= 8
+    && value.length <= maximum
+    && !/[\s\u0000-\u001f\u007f]/u.test(value);
+}
+
+function rawSha256(value: Uint8Array): Sha256Digest {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function publicKeyFromPrivate(privateKey: KeyObject): KeyObject {
+  return createPublicKey(privateKey.export({ type: "pkcs8", format: "pem" }));
+}
+
+function record(value: JsonValue | undefined, label: string): Readonly<Record<string, JsonValue>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function exactKeys(
+  value: Readonly<Record<string, JsonValue>>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const keys = Object.keys(value).sort();
+  const canonical = [...expected].sort();
+  if (keys.length !== canonical.length || keys.some((key, index) => key !== canonical[index])) {
+    throw new TypeError(`${label} is invalid`);
+  }
+}

--- a/lib/server/custom-launch/launch-bridge-v2.ts
+++ b/lib/server/custom-launch/launch-bridge-v2.ts
@@ -13,6 +13,11 @@ import {
 import { isCustomLaunchPublicEnabled } from "./public-readiness";
 import { assertApprovalServiceReadiness } from "./deployment-readiness";
 import {
+  createProductionWebsiteGitHubLaunchSessionCredentialIssuerV1,
+  WebsiteGitHubLaunchSessionErrorV1,
+  type WebsiteGitHubLaunchSessionCredentialIssuerV1,
+} from "./github-launch-session-v1";
+import {
   exactReviewAuthorityModeV1,
   type ReviewAuthorityModeV1,
 } from "@/lib/custom-launch/review-authority-v1";
@@ -45,6 +50,8 @@ export type CustomLaunchBridgeOperationV2 =
 
 export interface CustomLaunchBridgeDependenciesV2 {
   readonly authenticator: WebsiteEntitlementReadAuthenticatorV1;
+  readonly githubLaunchSessionCredentialIssuer:
+    WebsiteGitHubLaunchSessionCredentialIssuerV1;
   readonly serviceOrigin: URL;
   readonly serviceFetch: typeof fetch;
   readonly expectedPackageArtifactHash: `sha256:${string}`;
@@ -57,6 +64,7 @@ export function createCustomLaunchBridgeHandlerV2(
   const origin = exactServiceOrigin(dependencies.serviceOrigin);
   if (
     typeof dependencies.authenticator?.authenticate !== "function"
+    || typeof dependencies.githubLaunchSessionCredentialIssuer?.issueCredential !== "function"
     || typeof dependencies.serviceFetch !== "function"
     || !SHA256_DIGEST.test(dependencies.expectedPackageArtifactHash)
     || exactReviewAuthorityModeV1(dependencies.expectedReviewAuthorityMode)
@@ -105,8 +113,9 @@ export function createCustomLaunchBridgeHandlerV2(
       || request.headers.get("accept")?.trim().toLowerCase() !== "application/json"
     ) return errorResponse(400, "invalid_request");
 
+    let principal;
     try {
-      await dependencies.authenticator.authenticate(request);
+      principal = await dependencies.authenticator.authenticate(request);
     } catch (error) {
       if (error instanceof GitHubPrincipalAuthenticationErrorV1) {
         return errorResponse(error.status, error.code);
@@ -152,6 +161,22 @@ export function createCustomLaunchBridgeHandlerV2(
       return errorResponse(503, "launch_service_release_unverified");
     }
 
+    let upstreamAuthorization = authorization;
+    if (requiresGitHubLaunchSessionCredential(operation)) {
+      try {
+        upstreamAuthorization = `Bearer ${
+          await dependencies.githubLaunchSessionCredentialIssuer.issueCredential({
+            request,
+            principal,
+          })}`;
+      } catch (error) {
+        if (error instanceof WebsiteGitHubLaunchSessionErrorV1) {
+          return errorResponse(error.status, error.code);
+        }
+        return errorResponse(503, "github_launch_session_unavailable");
+      }
+    }
+
     const controller = new AbortController();
     const abortRequest = () => controller.abort(request.signal.reason);
     request.signal.addEventListener("abort", abortRequest, { once: true });
@@ -166,7 +191,7 @@ export function createCustomLaunchBridgeHandlerV2(
         signal: controller.signal,
         headers: {
           accept: "application/json",
-          authorization,
+          authorization: upstreamAuthorization,
           ...(body === undefined ? {} : {
             "content-type": "application/json",
             "content-length": String(body.byteLength),
@@ -306,6 +331,8 @@ export function handleProductionCustomLaunchBridgeV2(
   try {
     productionHandler ??= createCustomLaunchBridgeHandlerV2({
       authenticator: createPrivyGitHubPrincipalAuthenticatorV1(),
+      githubLaunchSessionCredentialIssuer:
+        createProductionWebsiteGitHubLaunchSessionCredentialIssuerV1(),
       serviceOrigin: new URL(requiredEnvironment("PROGRAMMABLE_APPROVAL_SERVICE_V2_ORIGIN")),
       serviceFetch: globalThis.fetch.bind(globalThis),
       expectedPackageArtifactHash: requiredEnvironment(
@@ -319,6 +346,16 @@ export function handleProductionCustomLaunchBridgeV2(
   } catch {
     return Promise.resolve(errorResponse(503, "launch_bridge_not_configured"));
   }
+}
+
+function requiresGitHubLaunchSessionCredential(
+  operation: CustomLaunchBridgeOperationV2,
+): boolean {
+  return operation.kind === "challenge-create"
+    || operation.kind === "preparation-bind"
+    || operation.kind === "wallet-authenticate"
+    || operation.kind === "launch-authorize"
+    || operation.kind === "transaction-report";
 }
 
 function resolveOperation(operation: CustomLaunchBridgeOperationV2): Readonly<{

--- a/lib/server/custom-launch/public-readiness.ts
+++ b/lib/server/custom-launch/public-readiness.ts
@@ -7,6 +7,9 @@ import { isReviewAuthorityModeV1 } from "@/lib/custom-launch/review-authority-v1
 import {
   isProductionTokenImageUploadReceiptSignerConfiguredV1,
 } from "@/lib/server/token-image-upload-receipt-v1";
+import {
+  isProductionWebsiteGitHubLaunchSessionConfiguredV1,
+} from "./github-launch-session-v1";
 
 const SIGNER_KEYS = [
   "keyId",
@@ -47,6 +50,9 @@ export function isCustomLaunchPublicEnabled(
   ) return false;
   if (configuredLaunchPermitSignersV2(environment).length === 0) return false;
   if (!isProductionTokenImageUploadReceiptSignerConfiguredV1(environment)) {
+    return false;
+  }
+  if (!isProductionWebsiteGitHubLaunchSessionConfiguredV1(environment)) {
     return false;
   }
   try {

--- a/lib/server/projection-target/github-entitlement.ts
+++ b/lib/server/projection-target/github-entitlement.ts
@@ -24,6 +24,7 @@ const MAXIMUM_PRIVY_TOKEN_BYTES = 131_072;
 
 export interface AuthenticatedGitHubPrincipalV1 {
   readonly privyUserId: string;
+  readonly privySessionId?: string;
   readonly githubUserId: string;
   readonly githubUsername: string | null;
   readonly githubPrincipalHash: Sha256Digest;
@@ -267,6 +268,7 @@ export function createPrivyGitHubPrincipalAuthenticatorFromBoundaryV1(
       }
       return Object.freeze({
         privyUserId: user.id,
+        privySessionId: access.sessionId,
         githubUserId,
         githubUsername: account.username ?? null,
         githubPrincipalHash: canonicalSha256(

--- a/tests/custom-launch-applicant-session-v2.test.ts
+++ b/tests/custom-launch-applicant-session-v2.test.ts
@@ -794,6 +794,9 @@ describe("custom launch applicant session currentness", () => {
     expect(customLaunchApplicantRecoveryV2(
       new CustomLaunchWebsiteRequestErrorV2(401, "applicant_authentication_required"),
     )).toBe("reconnect-github");
+    expect(customLaunchApplicantRecoveryV2(
+      new CustomLaunchWebsiteRequestErrorV2(401, "github_app_authorization_required"),
+    )).toBe("authorize-github-app");
   });
 
   it("recovers with a fresh session after a temporary provider failure", async () => {

--- a/tests/custom-launch-deployment-readiness.test.ts
+++ b/tests/custom-launch-deployment-readiness.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, generateKeyPairSync } from "node:crypto";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -41,6 +41,8 @@ const receiptSigner = {
   providerIdentityHash: canonicalSha256(receiptSignerCore.schemaVersion, receiptSignerCore),
   credentialMode: "vercel-oidc-bearer",
 };
+const websiteSessionPrivateKeyPem = generateKeyPairSync("ed25519").privateKey
+  .export({ type: "pkcs8", format: "pem" }).toString();
 const configured = {
   PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED: "true",
   PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED: "true",
@@ -49,6 +51,14 @@ const configured = {
   PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_REVIEW_AUTHORITY_MODE: "manual_review",
   NEXT_PUBLIC_PRIVY_APP_ID: "privy-app",
   PRIVY_APP_SECRET: "privy-secret",
+  VERCEL_GIT_COMMIT_SHA: "1".repeat(40),
+  PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_ID: "Iv1.0123456789abcdef",
+  PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_SECRET: "github-client-secret-value",
+  PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_KEY_ID: "website-session-1",
+  PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_PRIVATE_KEY_PEM:
+    websiteSessionPrivateKeyPem,
+  PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_COOKIE_SEAL_KEY_BASE64URL:
+    Buffer.alloc(32, 7).toString("base64url"),
   TOKEN_IMAGE_BLOB_READ_WRITE_TOKEN: "blob-token",
   PROGRAMMABLE_LAUNCH_PERMIT_SIGNERS_V2_JSON: JSON.stringify([permitSigner]),
   PROGRAMMABLE_TOKEN_IMAGE_UPLOAD_RECEIPT_SIGNER_V1_JSON:

--- a/tests/custom-launch-public-readiness.test.ts
+++ b/tests/custom-launch-public-readiness.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, generateKeyPairSync } from "node:crypto";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -44,6 +44,8 @@ const receiptSigner = {
   providerIdentityHash: canonicalSha256(receiptSignerCore.schemaVersion, receiptSignerCore),
   credentialMode: "vercel-oidc-bearer",
 };
+const websiteSessionPrivateKeyPem = generateKeyPairSync("ed25519").privateKey
+  .export({ type: "pkcs8", format: "pem" }).toString();
 
 const configured = {
   PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED: "true",
@@ -53,6 +55,15 @@ const configured = {
   PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_REVIEW_AUTHORITY_MODE: "manual_review",
   NEXT_PUBLIC_PRIVY_APP_ID: "privy-app",
   PRIVY_APP_SECRET: "privy-secret",
+  PROGRAMMABLE_RELEASE_COMMIT_SHA: "7".repeat(40),
+  VERCEL_GIT_COMMIT_SHA: "7".repeat(40),
+  PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_ID: "Iv1.0123456789abcdef",
+  PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_SECRET: "github-client-secret-value",
+  PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_KEY_ID: "website-session-1",
+  PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_PRIVATE_KEY_PEM:
+    websiteSessionPrivateKeyPem,
+  PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_COOKIE_SEAL_KEY_BASE64URL:
+    Buffer.alloc(32, 7).toString("base64url"),
   TOKEN_IMAGE_BLOB_READ_WRITE_TOKEN: "blob-token",
   PROGRAMMABLE_LAUNCH_PERMIT_SIGNERS_V2_JSON: JSON.stringify([permitSigner]),
   PROGRAMMABLE_TOKEN_IMAGE_UPLOAD_RECEIPT_SIGNER_V1_JSON:

--- a/tests/custom-launch-website-bridge-v2.test.ts
+++ b/tests/custom-launch-website-bridge-v2.test.ts
@@ -17,6 +17,13 @@ const GRANT_ID = "123e4567-e89b-42d3-a456-426614174002";
 const EXECUTION_RESERVATION_ID = "123e4567-e89b-42d3-a456-426614174003";
 const APPLICATION_HANDLE = `github-${"a".repeat(64)}` as const;
 const PACKAGE_ARTIFACT_HASH = `sha256:${"9".repeat(64)}` as const;
+const WEBSITE_SESSION_CREDENTIAL = "website-session-credential-value";
+
+function testCredentialIssuer() {
+  return {
+    issueCredential: vi.fn(async () => WEBSITE_SESSION_CREDENTIAL),
+  };
+}
 
 function serviceResponse(data: object, status = 200): Response {
   return new Response(JSON.stringify({
@@ -55,12 +62,19 @@ function releaseAttestedServiceFetch(
 function createReleaseBoundBridge(
   dependencies: Omit<
     CustomLaunchBridgeDependenciesV2,
-    "expectedPackageArtifactHash" | "expectedReviewAuthorityMode"
-  >,
+    | "expectedPackageArtifactHash"
+    | "expectedReviewAuthorityMode"
+    | "githubLaunchSessionCredentialIssuer"
+  > & Readonly<{
+    githubLaunchSessionCredentialIssuer?:
+      CustomLaunchBridgeDependenciesV2["githubLaunchSessionCredentialIssuer"];
+  }>,
   reviewAuthorityMode: "manual_review" | "autonomous_ai" = "manual_review",
 ) {
   return createCustomLaunchBridgeHandlerV2({
     ...dependencies,
+    githubLaunchSessionCredentialIssuer:
+      dependencies.githubLaunchSessionCredentialIssuer ?? testCredentialIssuer(),
     serviceFetch: releaseAttestedServiceFetch(dependencies.serviceFetch, reviewAuthorityMode),
     expectedPackageArtifactHash: PACKAGE_ARTIFACT_HASH,
     expectedReviewAuthorityMode: reviewAuthorityMode,
@@ -70,6 +84,7 @@ function createReleaseBoundBridge(
 function authenticatedPrincipal() {
   return {
     privyUserId: "did:privy:user",
+    privySessionId: "privy-session-1",
     githubUserId: "123456789",
     githubUsername: "builder",
     githubPrincipalHash: `sha256:${"1".repeat(64)}` as const,
@@ -109,7 +124,7 @@ describe("custom launch Website bridge V2", () => {
     const serviceFetch = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
       expect(String(input)).toBe("https://approval.example/v2/launch-sessions/challenges");
       const headers = new Headers(init?.headers);
-      expect(headers.get("authorization")).toBe("Bearer access-token-value");
+      expect(headers.get("authorization")).toBe(`Bearer ${WEBSITE_SESSION_CREDENTIAL}`);
       expect(headers.get("x-privy-identity-token")).toBeNull();
       expect(headers.get("idempotency-key")).toBe("challenge-request-1");
       expect(init?.credentials).toBe("omit");
@@ -163,6 +178,7 @@ describe("custom launch Website bridge V2", () => {
     });
     const handler = createCustomLaunchBridgeHandlerV2({
       authenticator: { authenticate: async () => authenticatedPrincipal() },
+      githubLaunchSessionCredentialIssuer: testCredentialIssuer(),
       serviceOrigin: new URL("https://approval.example"),
       expectedPackageArtifactHash: PACKAGE_ARTIFACT_HASH,
       expectedReviewAuthorityMode: "manual_review",
@@ -187,6 +203,7 @@ describe("custom launch Website bridge V2", () => {
     });
     const handler = createCustomLaunchBridgeHandlerV2({
       authenticator: { authenticate: async () => authenticatedPrincipal() },
+      githubLaunchSessionCredentialIssuer: testCredentialIssuer(),
       serviceOrigin: new URL("https://approval.example"),
       expectedPackageArtifactHash: PACKAGE_ARTIFACT_HASH,
       expectedReviewAuthorityMode: "manual_review",
@@ -227,6 +244,7 @@ describe("custom launch Website bridge V2", () => {
     });
     const handler = createCustomLaunchBridgeHandlerV2({
       authenticator: { authenticate: async () => authenticatedPrincipal() },
+      githubLaunchSessionCredentialIssuer: testCredentialIssuer(),
       serviceOrigin: new URL("https://approval.example"),
       expectedPackageArtifactHash: PACKAGE_ARTIFACT_HASH,
       expectedReviewAuthorityMode: "manual_review",
@@ -722,7 +740,11 @@ describe("custom launch Website bridge V2", () => {
     const serviceFetch = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
       const url = String(input);
       const headers = new Headers(init?.headers);
-      expect(headers.get("authorization")).toBe("Bearer access-token-value");
+      expect(headers.get("authorization")).toBe(
+        url.endsWith(`/v2/launch-preparations/${EXECUTION_RESERVATION_ID}/report`)
+          ? `Bearer ${WEBSITE_SESSION_CREDENTIAL}`
+          : "Bearer access-token-value",
+      );
       expect(headers.get("x-privy-identity-token")).toBeNull();
       if (url.endsWith(`/v3/applications/${APPLICATION_HANDLE}/launch-descriptor`)) {
         expect(init?.method).toBe("GET");

--- a/tests/github-launch-session-v1.test.ts
+++ b/tests/github-launch-session-v1.test.ts
@@ -1,0 +1,272 @@
+import {
+  createHash,
+  createPublicKey,
+  generateKeyPairSync,
+  verify,
+} from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createWebsiteGitHubAppAuthorizationCallbackHandlerV1,
+  createWebsiteGitHubAppAuthorizationStartHandlerV1,
+  createWebsiteGitHubLaunchSessionCredentialIssuerV1,
+  isProductionWebsiteGitHubLaunchSessionConfiguredV1,
+  productionWebsiteGitHubLaunchSessionBindingV1,
+  type WebsiteGitHubLaunchSessionConfigurationV1,
+} from "../lib/server/custom-launch/github-launch-session-v1";
+import { canonicalSha256 } from "../lib/server/projection-target/hashing";
+
+const NOW = new Date("2026-08-20T12:00:00.000Z");
+const GITHUB_USER_ID = "123456789";
+const GITHUB_TOKEN = `ghu_${"a".repeat(40)}`;
+const EXPIRES_AT = new Date(NOW.getTime() + 8 * 60 * 60 * 1_000).toISOString();
+
+function fixture(): Readonly<{
+  configuration: WebsiteGitHubLaunchSessionConfigurationV1;
+  publicKey: ReturnType<typeof createPublicKey>;
+  privateKeyPem: string;
+}> {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  const signerPublicKeySpkiSha256 = `sha256:${createHashHex(
+    publicKey.export({ type: "spki", format: "der" }),
+  )}` as const;
+  const websiteReleaseBindingHash = canonicalSha256(
+    "programmable.website-github-launch-session-release-binding.v1",
+    {
+      approvalServiceOrigin: "https://approval.example",
+      approvalServicePackageArtifactHash: `sha256:${"2".repeat(64)}`,
+      audience: "programmable.website-github-launch-session-credential.v1",
+      githubAppClientId: "Iv1.0123456789abcdef",
+      issuer: "https://programmable.market",
+      privyAppId: "privy-app",
+      signerKeyId: "website-session-1",
+      signerPublicKeySpkiSha256,
+      sourceCommit: "1".repeat(40),
+    },
+  );
+  return Object.freeze({
+    publicKey,
+    privateKeyPem,
+    configuration: Object.freeze({
+      sourceCommit: "1".repeat(40),
+      privyAppId: "privy-app",
+      approvalServiceOrigin: "https://approval.example",
+      approvalServicePackageArtifactHash: `sha256:${"2".repeat(64)}`,
+      githubAppClientId: "Iv1.0123456789abcdef",
+      githubAppClientSecret: "github-client-secret-value",
+      signerKeyId: "website-session-1",
+      signerPrivateKey: privateKey,
+      signerPublicKeySpkiSha256,
+      cookieSealKey: Buffer.alloc(32, 7),
+      websiteReleaseBindingHash,
+    }),
+  });
+}
+
+function createHashHex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function principal(privySessionId = "privy-session-1") {
+  return Object.freeze({
+    privyUserId: "did:privy:user",
+    privySessionId,
+    githubUserId: GITHUB_USER_ID,
+    githubUsername: "builder",
+    githubPrincipalHash: `sha256:${"4".repeat(64)}` as const,
+  });
+}
+
+function deterministicRandom() {
+  let generation = 0;
+  return (size: number): Buffer => Buffer.alloc(size, generation += 1);
+}
+
+function json(value: object): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function cookiePair(response: Response, name: string): string {
+  const headers = response.headers as Headers & { getSetCookie?: () => string[] };
+  const source = headers.getSetCookie?.().join(", ") ?? headers.get("set-cookie") ?? "";
+  const match = new RegExp(`(?:^|, )(${name}=[^;]+)`, "u").exec(source);
+  if (match?.[1] === undefined) throw new TypeError(`${name} cookie is missing`);
+  return match[1];
+}
+
+function inspectResponse() {
+  return json({
+    token: GITHUB_TOKEN,
+    scopes: [],
+    expires_at: EXPIRES_AT,
+    app: { client_id: "Iv1.0123456789abcdef" },
+    user: { id: Number(GITHUB_USER_ID) },
+  });
+}
+
+describe("Website GitHub launch session V1", () => {
+  it("completes PKCE handoff and issues the exact release-bound Website assertion", async () => {
+    const { configuration, publicKey } = fixture();
+    const start = createWebsiteGitHubAppAuthorizationStartHandlerV1({
+      authenticator: { authenticate: async () => principal() },
+      configuration,
+      now: () => NOW,
+      random: deterministicRandom(),
+    });
+    const startResponse = await start(new Request(
+      "https://programmable.market/api/custom-launch/github-app/authorization",
+      {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: "Bearer privy-access-token-value",
+          "x-privy-identity-token": "privy-identity-token-value",
+        },
+      },
+    ));
+    expect(startResponse.status).toBe(200);
+    expect(startResponse.headers.get("cache-control")).toBe("no-store, max-age=0");
+    expect(startResponse.headers.get("set-cookie")).toContain("HttpOnly");
+    const startBody = await startResponse.json() as { authorizationUrl: string };
+    const authorization = new URL(startBody.authorizationUrl);
+    expect(authorization.origin).toBe("https://github.com");
+    expect(authorization.searchParams.has("scope")).toBe(false);
+    expect(authorization.searchParams.get("code_challenge_method")).toBe("S256");
+
+    const stateCookie = cookiePair(
+      startResponse,
+      "__Host-programmable-github-launch-oauth",
+    );
+    const githubFetch = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      if (String(input) === "https://github.com/login/oauth/access_token") {
+        expect(init?.method).toBe("POST");
+        expect(String(init?.body)).toContain("code_verifier=");
+        return json({
+          access_token: GITHUB_TOKEN,
+          expires_in: 28_800,
+          refresh_token: `ghr_${"b".repeat(40)}`,
+          refresh_token_expires_in: 15_897_600,
+          scope: "",
+          token_type: "bearer",
+        });
+      }
+      expect(String(input)).toBe(
+        "https://api.github.com/applications/Iv1.0123456789abcdef/token",
+      );
+      return inspectResponse();
+    });
+    const callback = createWebsiteGitHubAppAuthorizationCallbackHandlerV1({
+      configuration,
+      githubFetch: githubFetch as typeof fetch,
+      now: () => NOW,
+      random: deterministicRandom(),
+    });
+    const callbackUrl = new URL(
+      "https://programmable.market/api/custom-launch/github-app/callback",
+    );
+    callbackUrl.searchParams.set("code", `code_${"c".repeat(32)}`);
+    callbackUrl.searchParams.set("state", authorization.searchParams.get("state")!);
+    const callbackResponse = await callback(new Request(callbackUrl, {
+      headers: { cookie: stateCookie },
+    }));
+    expect(callbackResponse.status).toBe(303);
+    expect(callbackResponse.headers.get("location")).toBe(
+      "https://programmable.market/launch",
+    );
+    const handoffCookie = cookiePair(
+      callbackResponse,
+      "__Host-programmable-github-launch-session",
+    );
+    expect(handoffCookie).not.toContain(GITHUB_TOKEN);
+
+    const inspectFetch = vi.fn(async () => inspectResponse());
+    const issuer = createWebsiteGitHubLaunchSessionCredentialIssuerV1({
+      configuration,
+      githubFetch: inspectFetch as typeof fetch,
+      now: () => NOW,
+      randomId: () => "123e4567-e89b-42d3-a456-426614174000",
+    });
+    const request = new Request(
+      "https://programmable.market/api/custom-launch/v2/launch-sessions/challenges",
+      { headers: { cookie: handoffCookie } },
+    );
+    const credential = await issuer.issueCredential({
+      request,
+      principal: principal(),
+    });
+    const segments = credential.split(".");
+    expect(segments).toHaveLength(3);
+    expect(verify(
+      null,
+      Buffer.from(`${segments[0]}.${segments[1]}`, "ascii"),
+      publicKey,
+      Buffer.from(segments[2]!, "base64url"),
+    )).toBe(true);
+    expect(JSON.parse(Buffer.from(segments[0]!, "base64url").toString("utf8"))).toEqual({
+      alg: "EdDSA",
+      kid: "website-session-1",
+      typ: "JWT",
+    });
+    expect(JSON.parse(Buffer.from(segments[1]!, "base64url").toString("utf8"))).toEqual({
+      aud: "programmable.website-github-launch-session-credential.v1",
+      exp: Math.floor(NOW.getTime() / 1_000) + 30,
+      githubAppClientId: "Iv1.0123456789abcdef",
+      githubAppUserToken: GITHUB_TOKEN,
+      githubUserId: GITHUB_USER_ID,
+      iat: Math.floor(NOW.getTime() / 1_000),
+      iss: "https://programmable.market",
+      jti: "123e4567-e89b-42d3-a456-426614174000",
+      revocationCheckedAt: Math.floor(NOW.getTime() / 1_000),
+      schemaVersion: "programmable.website-github-launch-session-credential.v1",
+      sessionId: "privy-session-1",
+      sessionState: "active",
+      sub: "did:privy:user",
+      websiteReleaseBindingHash: configuration.websiteReleaseBindingHash,
+    });
+    expect(inspectFetch).toHaveBeenCalledOnce();
+
+    await expect(issuer.issueCredential({
+      request,
+      principal: principal("substituted-session"),
+    })).rejects.toMatchObject({ code: "github_app_authorization_required" });
+    expect(inspectFetch).toHaveBeenCalledOnce();
+  });
+
+  it("derives the release binding from exact source, Privy, backend and signer facts", () => {
+    const { privateKeyPem } = fixture();
+    const environment = {
+      PROGRAMMABLE_RELEASE_COMMIT_SHA: "1".repeat(40),
+      VERCEL_GIT_COMMIT_SHA: "1".repeat(40),
+      NEXT_PUBLIC_PRIVY_APP_ID: "privy-app",
+      PROGRAMMABLE_APPROVAL_SERVICE_V2_ORIGIN: "https://approval.example",
+      PROGRAMMABLE_APPROVAL_SERVICE_EXPECTED_PACKAGE_ARTIFACT_HASH:
+        `sha256:${"2".repeat(64)}`,
+      PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_ID: "Iv1.0123456789abcdef",
+      PROGRAMMABLE_GITHUB_LAUNCH_APP_CLIENT_SECRET: "github-client-secret-value",
+      PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_KEY_ID: "website-session-1",
+      PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_SESSION_SIGNER_PRIVATE_KEY_PEM: privateKeyPem,
+      PROGRAMMABLE_WEBSITE_GITHUB_LAUNCH_COOKIE_SEAL_KEY_BASE64URL:
+        Buffer.alloc(32, 7).toString("base64url"),
+    };
+    expect(isProductionWebsiteGitHubLaunchSessionConfiguredV1(environment)).toBe(true);
+    const binding = productionWebsiteGitHubLaunchSessionBindingV1(environment);
+    const changed = productionWebsiteGitHubLaunchSessionBindingV1({
+      ...environment,
+      NEXT_PUBLIC_PRIVY_APP_ID: "privy-app-replacement",
+    });
+    expect(binding.websiteReleaseBindingHash).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    expect(binding.signerPublicKeyPem).toContain("BEGIN PUBLIC KEY");
+    expect(changed.websiteReleaseBindingHash).not.toBe(binding.websiteReleaseBindingHash);
+    expect(isProductionWebsiteGitHubLaunchSessionConfiguredV1({
+      ...environment,
+      VERCEL_GIT_COMMIT_SHA: "9".repeat(40),
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Outcome

- Adds the normal GitHub App OAuth + PKCE handoff required for production Custom launch mutations.
- Keeps the short-lived ghu_ credential sealed in a Secure, HttpOnly, SameSite=Strict cookie.
- Revalidates the GitHub App token before every mutating launch request and issues a 30-second Ed25519 Website assertion bound to the exact Website release, Privy session, GitHub user, GitHub App, signer SPKI, and Backend artifact.
- Routes only the five launch mutation operations through the new assertion; read-only routes remain unchanged.

## Exact identity

- H: 08074989a2f698e1736f640c20fdbeafbc5845a0
- T: 7c274311bc9ce06a7d1cfca82a1e598009b17c36
- P: 288b1417edbdbd32aa0ca8c4655d8df267a05303
- Production base: 29d1d028e11a0c06f0b46b15b89ea10347d04a3f

## Focused verification

- Session producer Vitest: 50/50 PASS
- Deployment readiness regression: 14/14 PASS
- TypeScript: PASS
- Focused ESLint: PASS
- Diff check: PASS
- Independent P0/P1 review: no findings

No provider configuration or production traffic is changed by this PR. The callback, expiring user-token setting, signer key, cookie key, and Backend Session Authority binding remain deployment gates.