### PR TITLE
Restore creator reward reads with bound RPC failover

### DIFF
--- a/app/api/explore/profile/claim/route.ts
+++ b/app/api/explore/profile/claim/route.ts
@@ -16,7 +16,7 @@ import {
   CreatorClaimInputError,
   CreatorClaimUnavailableError,
   buildPreparedCreatorClaim,
-  getOnchainDeployment,
+  getWebsiteReadOnchainDeployment,
   parseCreatorClaimRequest,
 } from "../../../../../lib/onchain";
 import { creatorFeeHookReadAbi } from "../../../../../lib/onchain/abis";
@@ -26,9 +26,9 @@ import {
   type CreatorClaimTokenIdentity,
 } from "../../../../../lib/server/action-rpc-identity.server";
 import {
-  ActionRpcProviderError,
-  creatorClaimRpcProvider,
-} from "../../../../../lib/server/action-rpc-quorum.server";
+  OperationalRpcUnavailableError,
+  withOperationalRpcFailover,
+} from "../../../../../lib/onchain/operational-rpc-failover.server";
 import {
   errorChainIncludesData,
   safeServerErrorSummary,
@@ -43,7 +43,7 @@ const CLAIM_RPC_UNAVAILABLE_MESSAGE =
   "Creator claim reads are temporarily unavailable. Try again";
 
 function claimClient(
-  deployment: ReturnType<typeof getOnchainDeployment>,
+  deployment: ReturnType<typeof getWebsiteReadOnchainDeployment>,
   endpoint: string,
 ) {
   return createPublicClient({
@@ -60,15 +60,15 @@ function claimRpcUnavailable() {
 }
 
 async function currentClaimSnapshot(client: PublicClient) {
-  try {
-    const blockNumber = await client.getBlockNumber();
-    const block = await client.getBlock({ blockNumber });
-    if (!block.hash) throw claimRpcUnavailable();
-    return { blockNumber, blockHash: block.hash as Hex };
-  } catch (error) {
-    if (error instanceof CreatorClaimUnavailableError) throw error;
-    throw claimRpcUnavailable();
+  const blockNumber = await client.getBlockNumber();
+  const block = await client.getBlock({ blockNumber });
+  if (!block.hash) {
+    throw new CreatorClaimUnavailableError(
+      "runtime-mismatch",
+      "The creator claim snapshot has no block hash",
+    );
   }
+  return { blockNumber, blockHash: block.hash as Hex };
 }
 
 async function simulateCreatorClaim(input: {
@@ -101,7 +101,10 @@ async function simulateCreatorClaim(input: {
 
 async function readCurrentClaimState(input: {
   client: PublicClient;
-  deployment: Extract<ReturnType<typeof getOnchainDeployment>, { status: "ready" }>;
+  deployment: Extract<
+    ReturnType<typeof getWebsiteReadOnchainDeployment>,
+    { status: "ready" }
+  >;
   token: CreatorClaimTokenIdentity;
   blockNumber: bigint;
 }) {
@@ -229,7 +232,12 @@ export async function POST(request: NextRequest) {
 
   try {
     const claimRequest = parseCreatorClaimRequest(input);
-    const deployment = getOnchainDeployment();
+    let deployment: ReturnType<typeof getWebsiteReadOnchainDeployment>;
+    try {
+      deployment = getWebsiteReadOnchainDeployment();
+    } catch {
+      throw claimRpcUnavailable();
+    }
     if (deployment.status !== "ready") {
       throw new CreatorClaimUnavailableError(
         "not-deployed",
@@ -242,80 +250,85 @@ export async function POST(request: NextRequest) {
         `Switch to chain ${deployment.chainId}`,
       );
     }
-    const provider = creatorClaimRpcProvider(deployment);
-    const client = claimClient(deployment, provider.endpoint);
-    const snapshot = await currentClaimSnapshot(client);
-    const token = await readCreatorClaimIdentityFromRpc({
-      client,
+    const response = await withOperationalRpcFailover(
       deployment,
-      poolId: claimRequest.poolId,
-      blockNumber: snapshot.blockNumber,
-    });
-    if (
-      token.creatorAddress.toLowerCase() !== claimRequest.account.toLowerCase()
-    ) {
-      throw new CreatorClaimUnavailableError(
-        "not-creator",
-        "This account is not the recorded creator for the pool",
-      );
-    }
-    const state = await readCurrentClaimState({
-      client,
-      deployment,
-      token,
-      blockNumber: snapshot.blockNumber,
-    });
-    const claimable = state.claimable;
-    if (claimable <= 0n) {
-      throw new CreatorClaimUnavailableError(
-        "nothing-to-claim",
-        "There are no creator fees to claim for this pool",
-      );
-    }
-    const data = encodeFunctionData({
-      abi: creatorFeeHookReadAbi,
-      functionName: "claimCreatorFees",
-      args: [claimRequest.poolId],
-    });
-    const value = 0n;
-    const transaction = {
-      account: claimRequest.account,
-      to: deployment.feeHook,
-      data,
-      value,
-    };
-    const simulation = await simulateCreatorClaim({
-      client,
-      transaction,
-      blockNumber: snapshot.blockNumber,
-    });
-    const intent = {
-      account: claimRequest.account,
-      poolId: claimRequest.poolId,
-      tokenAddress: token.tokenAddress,
-      hookAddress: deployment.feeHook,
-      snapshotClaimableWei: claimable.toString(),
-      snapshotClaimableEth: formatUnits(claimable, 18),
-      snapshot: {
-        chainId: deployment.chainId,
-        blockNumber: snapshot.blockNumber.toString(),
-        blockHash: snapshot.blockHash,
-        confirmations: 0,
+      async (selected) => {
+        const client = claimClient(deployment, selected.rpcUrl);
+        const snapshot = await currentClaimSnapshot(client);
+        const token = await readCreatorClaimIdentityFromRpc({
+          client,
+          deployment,
+          poolId: claimRequest.poolId,
+          blockNumber: snapshot.blockNumber,
+        });
+        if (
+          token.creatorAddress.toLowerCase() !==
+          claimRequest.account.toLowerCase()
+        ) {
+          throw new CreatorClaimUnavailableError(
+            "not-creator",
+            "This account is not the recorded creator for the pool",
+          );
+        }
+        const state = await readCurrentClaimState({
+          client,
+          deployment,
+          token,
+          blockNumber: snapshot.blockNumber,
+        });
+        const claimable = state.claimable;
+        if (claimable <= 0n) {
+          throw new CreatorClaimUnavailableError(
+            "nothing-to-claim",
+            "There are no creator fees to claim for this pool",
+          );
+        }
+        const data = encodeFunctionData({
+          abi: creatorFeeHookReadAbi,
+          functionName: "claimCreatorFees",
+          args: [claimRequest.poolId],
+        });
+        const value = 0n;
+        const transaction = {
+          account: claimRequest.account,
+          to: deployment.feeHook,
+          data,
+          value,
+        };
+        const simulation = await simulateCreatorClaim({
+          client,
+          transaction,
+          blockNumber: snapshot.blockNumber,
+        });
+        const intent = {
+          account: claimRequest.account,
+          poolId: claimRequest.poolId,
+          tokenAddress: token.tokenAddress,
+          hookAddress: deployment.feeHook,
+          snapshotClaimableWei: claimable.toString(),
+          snapshotClaimableEth: formatUnits(claimable, 18),
+          snapshot: {
+            chainId: deployment.chainId,
+            blockNumber: snapshot.blockNumber.toString(),
+            blockHash: snapshot.blockHash,
+            confirmations: 0,
+          },
+          transaction: {
+            kind: "claim-creator-fees" as const,
+            chainId: deployment.chainId,
+            from: claimRequest.account,
+            to: deployment.feeHook,
+            data,
+            value: "0" as const,
+          },
+        };
+        return buildPreparedCreatorClaim(intent, {
+          estimatedGas: simulation.estimatedGas,
+          gasPriceWei: simulation.gasPrice,
+          accountBalanceWei: simulation.accountBalance,
+        });
       },
-      transaction: {
-        kind: "claim-creator-fees" as const,
-        chainId: deployment.chainId,
-        from: claimRequest.account,
-        to: deployment.feeHook,
-        data,
-        value: "0" as const,
-      },
-    };
-    const response = buildPreparedCreatorClaim(intent, {
-      estimatedGas: simulation.estimatedGas,
-      gasPriceWei: simulation.gasPrice,
-      accountBalanceWei: simulation.accountBalance,
-    });
+    );
     return json(response);
   } catch (error) {
     if (error instanceof CreatorClaimInputError) {
@@ -326,11 +339,11 @@ export async function POST(request: NextRequest) {
     }
     if (
       error instanceof CreatorClaimUnavailableError ||
-      error instanceof ActionRpcProviderError ||
-      error instanceof ActionRpcIdentityError
+      error instanceof ActionRpcIdentityError ||
+      error instanceof OperationalRpcUnavailableError
     ) {
       const unavailable =
-        error instanceof ActionRpcProviderError
+        error instanceof OperationalRpcUnavailableError
           ? claimRpcUnavailable()
           : error instanceof ActionRpcIdentityError
             ? new CreatorClaimUnavailableError(error.code, error.message)

--- a/app/api/explore/profile/route.ts
+++ b/app/api/explore/profile/route.ts
@@ -23,8 +23,9 @@ import type {
   CreatorClaim,
   CreatorProfile,
 } from "@/lib/onchain/types";
-import { productionMainnetRpcPrimary } from
-  "@/lib/onchain/website-rpc-providers.server";
+import { getWebsiteReadOnchainDeployment } from "@/lib/onchain";
+import { withOperationalRpcFailover } from
+  "@/lib/onchain/operational-rpc-failover.server";
 import { creatorProfileApiError } from "@/lib/profile/onchain-profile";
 import type {
   CanonicalTokenExploreEntry,
@@ -105,13 +106,21 @@ function releases(): readonly Release[] {
   ];
 }
 
-function profileClient() {
-  const provider = productionMainnetRpcPrimary();
+function profileClient(rpcUrl: string) {
   return createPublicClient({
     chain: mainnet,
     batch: { multicall: true },
-    transport: http(provider.url, { retryCount: 1, timeout: 12_000 }),
+    transport: http(rpcUrl, { retryCount: 1, timeout: 12_000 }),
   });
+}
+
+function profileRpcProviderHeader(
+  deployment: ReturnType<typeof getWebsiteReadOnchainDeployment>,
+  rpcUrl: string,
+) {
+  const role = rpcUrl === deployment.rpcUrl ? "primary" : "secondary";
+  const provider = deployment.rpcProviderIds?.[role] ?? "rpc";
+  return `${provider}-${role}`;
 }
 
 function minimum(left: bigint, right: bigint) {
@@ -512,18 +521,28 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const profile = await readCreatorProfile(getAddress(input), profileClient());
-    return NextResponse.json(profile, {
+    const deployment = getWebsiteReadOnchainDeployment("production");
+    const result = await withOperationalRpcFailover(
+      deployment,
+      async (selected) => ({
+        profile: await readCreatorProfile(
+          getAddress(input),
+          profileClient(selected.rpcUrl),
+        ),
+        provider: profileRpcProviderHeader(deployment, selected.rpcUrl),
+      }),
+    );
+    return NextResponse.json(result.profile, {
       headers: {
         "Cache-Control": "private, max-age=0, s-maxage=15",
-        "X-Programmable-Launch-Source": "drpc",
-        "X-Programmable-Read-Source": "drpc",
-        "X-Programmable-Rpc-Provider": "drpc-primary",
+        "X-Programmable-Launch-Source": "rpc",
+        "X-Programmable-Read-Source": "rpc",
+        "X-Programmable-Rpc-Provider": result.provider,
       },
     });
   } catch (error) {
     console.error(
-      "dRPC creator profile read failed",
+      "Creator profile RPC read failed",
       {
         name: error instanceof Error ? error.name : "UnknownError",
         category: "read-failed",

--- a/app/api/profile/classic-v3/route.ts
+++ b/app/api/profile/classic-v3/route.ts
@@ -26,16 +26,19 @@ import {
   isClassicV3ReleaseVerified,
 } from "@/lib/classic-v3-release";
 import { uerc20ReadAbi } from "@/lib/onchain/abis";
+import { getWebsiteReadOnchainDeployment } from "@/lib/onchain";
 import {
   readBitqueryClassicV3Profile,
 } from "@/lib/market-data/bitquery-profile.server";
-import { safeOperationalRpcError } from
+import {
+  safeOperationalRpcError,
+  withOperationalRpcFailover,
+} from
   "@/lib/onchain/operational-rpc-failover.server";
 import {
   classicV3ProfileApiError,
   encodeClassicV3RewardAction,
 } from "@/lib/profile/classic-v3-rewards";
-import { classicV3ActionRpcProvider } from "@/lib/server/action-rpc-quorum.server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -76,28 +79,36 @@ function json(body: unknown, status = 200) {
   });
 }
 
-function classicActionRpcEndpoints() {
-  return [classicV3ActionRpcProvider(environment)];
+function createActionClient(rpcUrl: string) {
+  return createPublicClient({
+    chain,
+    batch: { multicall: true },
+    transport: http(rpcUrl, { retryCount: 1, timeout: 12_000 }),
+  });
 }
 
-function createActionClients() {
-  return classicActionRpcEndpoints().map((provider) =>
-    createPublicClient({
-      chain,
-      batch: { multicall: true },
-      transport: http(provider.endpoint, { retryCount: 1, timeout: 12_000 }),
-    }),
-  );
-}
-
-async function sharedActionBlock(clients: readonly PublicClient[]) {
-  if (clients.length !== 1) {
-    throw new Error("Classic actions require the configured RPC");
-  }
-  const blockNumber = await clients[0]!.getBlockNumber();
-  const block = await clients[0]!.getBlock({ blockNumber });
+async function currentActionBlock(client: PublicClient) {
+  const blockNumber = await client.getBlockNumber();
+  const block = await client.getBlock({ blockNumber });
   if (!block.hash) throw new Error("The configured RPC returned no block hash");
   return blockNumber;
+}
+
+function classicActionDeployment() {
+  const deployment = getWebsiteReadOnchainDeployment(environment);
+  if (deployment.chainId !== chain.id) {
+    throw new Error("Classic action RPC chain does not match the release");
+  }
+  return deployment;
+}
+
+function classicRpcProviderHeader(
+  deployment: ReturnType<typeof classicActionDeployment>,
+  rpcUrl: string,
+) {
+  const role = rpcUrl === deployment.rpcUrl ? "primary" : "secondary";
+  const provider = deployment.rpcProviderIds?.[role] ?? "rpc";
+  return `${provider}-${role}`;
 }
 
 async function assertCodeHashAtBlock(
@@ -694,40 +705,56 @@ export async function GET(request: NextRequest) {
   }
   try {
     const launch = search.get("launch")?.trim();
+    const deployment = classicActionDeployment();
     if (launch) {
       if (!isHex(launch, { strict: true }) || launch.length !== 66) {
         return json({ error: "Enter a valid launch transaction hash" }, 400);
       }
-      const client = createActionClients()[0]!;
+      const result = await withOperationalRpcFailover(
+        deployment,
+        async (selected) => ({
+          profile: await readLaunchByTransactionFromClient(
+            getAddress(input),
+            launch as Hex,
+            createActionClient(selected.rpcUrl),
+          ),
+          provider: classicRpcProviderHeader(deployment, selected.rpcUrl),
+        }),
+      );
       return NextResponse.json(
-        await readLaunchByTransactionFromClient(
-          getAddress(input),
-          launch as Hex,
-          client,
-        ),
+        result.profile,
         {
           headers: {
             "Cache-Control": "private, max-age=0, s-maxage=15",
             "X-Programmable-Read-Source": "rpc",
-            "X-Programmable-Rpc-Provider": "drpc-primary",
+            "X-Programmable-Rpc-Provider": result.provider,
           },
         },
       );
     }
-    const client = createActionClients()[0]!;
+    const result = await withOperationalRpcFailover(
+      deployment,
+      async (selected) => ({
+        profile: await readRewardsFromClient(
+          getAddress(input),
+          createActionClient(selected.rpcUrl),
+        ),
+        provider: classicRpcProviderHeader(deployment, selected.rpcUrl),
+      }),
+    );
     return NextResponse.json(
-      await readRewardsFromClient(getAddress(input), client),
+      result.profile,
       {
         headers: {
           "Cache-Control": "private, max-age=0, s-maxage=15",
           "X-Programmable-Read-Source": "rpc",
-          "X-Programmable-Rpc-Provider": "drpc-primary",
+          "X-Programmable-Rpc-Provider": result.provider,
         },
       },
     );
   } catch (error) {
     console.error(
-      "dRPC Classic profile read failed",
+      "Classic profile RPC read failed",
       safeOperationalRpcError(error),
     );
     return json(classicV3ProfileApiError("temporary"), 503);
@@ -767,9 +794,10 @@ export async function POST(request: NextRequest) {
   }
   const account = getAddress(input.account);
   const vaultAddress = getAddress(input.vaultAddress);
+  const action = input.action as "claim" | "update-payout";
   let newPayoutAddress: Address | undefined;
   let allocationIndex: number | undefined;
-  if (input.action === "update-payout") {
+  if (action === "update-payout") {
     if (
       typeof input.allocationIndex !== "number" ||
       !Number.isSafeInteger(input.allocationIndex) ||
@@ -813,39 +841,45 @@ export async function POST(request: NextRequest) {
       transferTaxBps: 0,
       lpFeePips: 0,
     };
-    const clients = createActionClients();
-    const blockNumber = await sharedActionBlock(clients);
-    const actionStates = await Promise.all(
-      clients.map((client) =>
-        readClassicActionState({
+    const deployment = classicActionDeployment();
+    const prepared = await withOperationalRpcFailover(
+      deployment,
+      async (selected) => {
+        const client = createActionClient(selected.rpcUrl);
+        const blockNumber = await currentActionBlock(client);
+        const actionState = await readClassicActionState({
           client,
           reward,
           account,
           blockNumber,
           allocationIndex,
-        }),
-      ),
-    );
-    const actionState = actionStates[0]!;
-    if (
-      input.action === "update-payout" &&
-      !actionState.ownsAllocation
-    ) {
-      return json(
-        { error: "Only the current owner of this reward allocation can change it" },
-        403,
-      );
-    }
-    if (input.action === "claim" && BigInt(actionState.claimableWei) === 0n) {
-      return json({ error: "There are no rewards to claim" }, 409);
-    }
-    const data = encodeClassicV3RewardAction({
-      action: input.action,
-      allocationIndex,
-      newPayoutAddress,
-    });
-    const simulations = await Promise.all(
-      clients.map(async (client) => {
+        });
+        if (
+          action === "update-payout" &&
+          !actionState.ownsAllocation
+        ) {
+          return {
+            status: 403,
+            body: {
+              error:
+                "Only the current owner of this reward allocation can change it",
+            },
+          } as const;
+        }
+        if (
+          action === "claim" &&
+          BigInt(actionState.claimableWei) === 0n
+        ) {
+          return {
+            status: 409,
+            body: { error: "There are no rewards to claim" },
+          } as const;
+        }
+        const data = encodeClassicV3RewardAction({
+          action,
+          allocationIndex,
+          newPayoutAddress,
+        });
         const transaction = {
           account,
           to: vaultAddress,
@@ -858,52 +892,40 @@ export async function POST(request: NextRequest) {
           client.getGasPrice(),
           client.getBalance({ address: account }),
         ]);
-        return { estimatedGas, gasPrice, balance };
-      }),
-    );
-    const estimatedGas = simulations.reduce(
-      (largest, candidate) =>
-        candidate.estimatedGas > largest
-          ? candidate.estimatedGas
-          : largest,
-      0n,
-    );
-    const gasPrice = simulations.reduce(
-      (largest, candidate) =>
-        candidate.gasPrice > largest ? candidate.gasPrice : largest,
-      0n,
-    );
-    const balance = simulations.reduce(
-      (smallest, candidate) =>
-        candidate.balance < smallest ? candidate.balance : smallest,
-      simulations[0]!.balance,
-    );
-    const gasLimit = (estimatedGas * 120n + 99n) / 100n;
-    if (balance < gasLimit * gasPrice) {
-      return json(
-        { error: "This wallet needs more ETH for the network fee" },
-        409,
-      );
-    }
-    const kind =
-      input.action === "claim"
-        ? "claim-classic-v3-rewards"
-        : "update-classic-v3-payout";
-    return json({
-      status: "ready",
-      action: input.action,
-      account,
-      vaultAddress,
-      transaction: {
-        kind,
-        chainId: chain.id,
-        from: account,
-        to: vaultAddress,
-        data,
-        value: "0",
-        gasLimit: gasLimit.toString(),
+        const gasLimit = (estimatedGas * 120n + 99n) / 100n;
+        if (balance < gasLimit * gasPrice) {
+          return {
+            status: 409,
+            body: {
+              error: "This wallet needs more ETH for the network fee",
+            },
+          } as const;
+        }
+        const kind =
+          action === "claim"
+            ? "claim-classic-v3-rewards"
+            : "update-classic-v3-payout";
+        return {
+          status: 200,
+          body: {
+            status: "ready",
+            action,
+            account,
+            vaultAddress,
+            transaction: {
+              kind,
+              chainId: chain.id,
+              from: account,
+              to: vaultAddress,
+              data,
+              value: "0",
+              gasLimit: gasLimit.toString(),
+            },
+          },
+        } as const;
       },
-    });
+    );
+    return json(prepared.body, prepared.status);
   } catch (error) {
     console.error(
       "Classic reward preparation failed",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2136,7 +2136,7 @@ export function evaluateReadModelOperationsSourceContracts(
   check(
     "ops-public-provider-split-source-contract",
     fastLanePublicProviderContract,
-    "Explore list and token detail use the validated Envio Classic V3 catalog plus bounded exact-identity Dexscreener enrichment; charts bind one exact pool through Bitquery while profile and action routes retain their committed dRPC semantics",
+    "Explore list and token detail use the validated Envio Classic V3 catalog plus bounded exact-identity Dexscreener enrichment; charts bind one exact pool through Bitquery while profile and action routes retain their commitment-bound Website RPC semantics",
   );
   const publicProfileAndActionRoutes = [
     publicCreatorProfile,
@@ -2148,17 +2148,26 @@ export function evaluateReadModelOperationsSourceContracts(
     "ops-profile-claim-trade-provider-boundary",
     includesEverySourceFragment(publicCreatorProfile, [
       "readCreatorProfile",
-      "productionMainnetRpcPrimary",
-      '"X-Programmable-Launch-Source": "drpc"',
-      '"X-Programmable-Read-Source": "drpc"',
-      '"X-Programmable-Rpc-Provider": "drpc-primary"',
+      "getWebsiteReadOnchainDeployment",
+      "withOperationalRpcFailover",
+      "profileRpcProviderHeader",
+      '"X-Programmable-Launch-Source": "rpc"',
+      '"X-Programmable-Read-Source": "rpc"',
+      '"X-Programmable-Rpc-Provider": result.provider',
     ]) &&
-      publicClassicProfileGet.includes("classicV3ActionRpcProvider") &&
+      !publicCreatorProfile.includes("productionMainnetRpcPrimary") &&
+      includesEverySourceFragment(publicClassicProfileGet, [
+        "getWebsiteReadOnchainDeployment",
+        "withOperationalRpcFailover",
+        "classicRpcProviderHeader",
+        '"X-Programmable-Read-Source": "rpc"',
+        '"X-Programmable-Rpc-Provider": result.provider',
+      ]) &&
+      !publicClassicProfileGet.includes("classicV3ActionRpcProvider") &&
       publicStockProfileGet.includes("stockPairedActionRpcProvider") &&
-      [publicClassicProfileGet, publicStockProfileGet].every(
-        (route) =>
-          route.includes('"X-Programmable-Read-Source": "rpc"') &&
-          route.includes('"X-Programmable-Rpc-Provider": "drpc-primary"'),
+      publicStockProfileGet.includes('"X-Programmable-Read-Source": "rpc"') &&
+      publicStockProfileGet.includes(
+        '"X-Programmable-Rpc-Provider": "drpc-primary"',
       ) &&
       includesEverySourceFragment(websiteRpcProviders, [
         "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER",
@@ -2175,7 +2184,7 @@ export function evaluateReadModelOperationsSourceContracts(
       includesEverySourceFragment(actionRpcProviders, [
         "createCommittedActionRpcProvider",
         "tradeActionRpcProvider",
-        "creatorClaimRpcProvider",
+        "stockPairedActionRpcProvider",
         'Object.defineProperty(provider, "endpoint"',
         "enumerable: false",
       ]) &&
@@ -2193,7 +2202,11 @@ export function evaluateReadModelOperationsSourceContracts(
       !tradePrepare.includes("tradeActionRpcProvider") &&
       !tradePrepare.includes("tradeActionRpcProviders") &&
       tradePrepare.includes('"Cache-Control": "no-store"') &&
-      creatorClaimPrepare.includes("creatorClaimRpcProvider") &&
+      includesEverySourceFragment(creatorClaimPrepare, [
+        "getWebsiteReadOnchainDeployment",
+        "withOperationalRpcFailover",
+      ]) &&
+      !creatorClaimPrepare.includes("creatorClaimRpcProvider") &&
       !creatorClaimPrepare.includes("creatorClaimRpcProviders") &&
       creatorClaimPrepare.includes('status: "not-submitted"') &&
       creatorClaimPrepare.includes("transactionHash: null") &&
@@ -2209,7 +2222,7 @@ export function evaluateReadModelOperationsSourceContracts(
         (route) =>
           !/Promise\.allSettled|secondaryProvider|fallbackProvider/u.test(route),
       ),
-    "Profile and Claim retain singular commitment-bound dRPC reads while Trade permits one complete-operation QuickNode retry only after an eligible dRPC transport or capacity failure; all action routes retain no write authority or hidden provider rotation",
+    "Profile, Classic rewards, Claim, and Trade use the commitment-bound Website pair with at most one complete-operation QuickNode retry after an eligible dRPC transport or capacity failure; Stock retains its singular committed action provider and all action routes retain no write authority or hidden provider rotation",
   );
   check(
     "ops-staged-envio-catalog-gate",

--- a/tests/classic-v3-action-activation.test.ts
+++ b/tests/classic-v3-action-activation.test.ts
@@ -1,9 +1,11 @@
 import { NextRequest } from "next/server";
-import { getAddress, type Address, type Hex } from "viem";
+import {
+  getAddress,
+  RpcRequestError,
+  type Address,
+  type Hex,
+} from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-import { rpcProviderCommitment } from
-  "../lib/data-pipeline/rpc-provider-commitments";
 
 vi.mock("server-only", () => ({}));
 
@@ -12,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   lookup: vi.fn(),
   readProfile: vi.fn(),
   createPublicClient: vi.fn(),
+  getWebsiteReadOnchainDeployment: vi.fn(),
   runtimeHashes: {
     "0x01":
       "0x9cc9723456c471d90ac838c02fa4fc47ed4b7e82c85358e71deec978c48d2dc8",
@@ -35,6 +38,18 @@ const drpcRpcUrl =
   "https://lb.drpc.live/ethereum/drpc-classic-key";
 const quickNodeRpcUrl =
   "https://classic-mainnet.ethereum-mainnet.quiknode.pro/quicknode-classic-key/";
+const deployment = {
+  status: "ready" as const,
+  environment: "production" as const,
+  releaseVersion: "classic-v2" as const,
+  chainId: 1 as const,
+  rpcUrl: drpcRpcUrl,
+  rpcUrlSecondary: quickNodeRpcUrl,
+  rpcProviderIds: {
+    primary: "drpc",
+    secondary: "quicknode",
+  },
+};
 
 const indexedToken = {
   chainId: 1 as const,
@@ -204,6 +219,15 @@ vi.mock("../lib/market-data/bitquery-profile.server", () => ({
   })),
 }));
 
+vi.mock("../lib/onchain", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/onchain")>();
+  return {
+    ...actual,
+    getWebsiteReadOnchainDeployment:
+      mocks.getWebsiteReadOnchainDeployment,
+  };
+});
+
 vi.mock("viem", async (importOriginal) => {
   const actual = await importOriginal<typeof import("viem")>();
   return {
@@ -234,26 +258,7 @@ function request() {
 describe("Classic V3 action identity activation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.stubEnv("ETHEREUM_RPC_URL", drpcRpcUrl);
-    vi.stubEnv("ETHEREUM_RPC_URL_B", quickNodeRpcUrl);
-    vi.stubEnv("PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER", "drpc");
-    vi.stubEnv("PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL", drpcRpcUrl);
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
-      rpcProviderCommitment("endpoint", drpcRpcUrl),
-    );
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_PROVIDER",
-      "quicknode",
-    );
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_URL",
-      quickNodeRpcUrl,
-    );
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT",
-      rpcProviderCommitment("endpoint", quickNodeRpcUrl),
-    );
+    mocks.getWebsiteReadOnchainDeployment.mockReturnValue(deployment);
     mocks.lookup.mockResolvedValue(actionReward);
     mocks.readProfile.mockResolvedValue({
       status: "ready",
@@ -296,22 +301,25 @@ describe("Classic V3 action identity activation", () => {
     },
   );
 
-  it.each([true, false])(
-    "ignores the secondary RPC when indexed lookup is %s",
-    async (indexedEnabled) => {
-      mocks.indexedEnabled = indexedEnabled;
-      vi.stubEnv(
-        "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_URL",
-        "https://lb.drpc.live/ethereum/second-classic-secret",
-      );
+  it("retries the complete preparation once on the fixed secondary after primary capacity failure", async () => {
+    const primaryRpcError = new RpcRequestError({
+      body: { method: "eth_blockNumber" },
+      error: { code: 10, message: "User balance exceeded" },
+      url: drpcRpcUrl,
+    });
+    mocks.createPublicClient
+      .mockReturnValueOnce({
+        getBlockNumber: vi.fn().mockRejectedValue(primaryRpcError),
+      })
+      .mockReturnValueOnce(actionClient(1));
 
-      const response = await POST(request());
-      const serialized = JSON.stringify(await response.json());
+    const response = await POST(request());
+    const serialized = JSON.stringify(await response.json());
 
-      expect(response.status).toBe(200);
-      expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
-      expect(serialized).not.toContain("drpc-classic-key");
-      expect(serialized).not.toContain("second-classic-secret");
-    },
-  );
+    expect(response.status).toBe(200);
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(2);
+    expect(mocks.readProfile).toHaveBeenCalledTimes(1);
+    expect(serialized).not.toContain("drpc-classic-key");
+    expect(serialized).not.toContain("quicknode-classic-key");
+  });
 });

--- a/tests/creator-claim-action-activation.test.ts
+++ b/tests/creator-claim-action-activation.test.ts
@@ -2,13 +2,12 @@ import { NextRequest } from "next/server";
 import {
   getAddress,
   keccak256,
+  RpcRequestError,
   type Address,
   type Hex,
 } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { rpcProviderCommitment } from
-  "../lib/data-pipeline/rpc-provider-commitments";
 import { computeOfficialV4PoolId } from "../lib/uniswap/liquidity-launcher-sdk";
 
 vi.mock("server-only", () => ({}));
@@ -21,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   readBitquery: vi.fn(),
   readIdentity: vi.fn(),
   createPublicClient: vi.fn(),
+  getWebsiteReadOnchainDeployment: vi.fn(),
 }));
 
 const creator = getAddress("0x1111111111111111111111111111111111111111");
@@ -54,6 +54,10 @@ const deployment = {
   rpcUrlSecondary:
     "https://claim-node.ethereum-mainnet.quiknode.pro/quicknode-claim-key/" as
       string | null,
+  rpcProviderIds: {
+    primary: "drpc",
+    secondary: "quicknode",
+  },
   confirmations: 12n,
   logBlockRange: 10_000n,
 };
@@ -151,9 +155,13 @@ function rpcClient(estimatedGas: bigint, gasPrice: bigint, balance: bigint) {
   };
 }
 
-function unavailableRpcClient(message = "provider capacity unavailable") {
+function unavailableRpcClient(message = "provider capacity exceeded") {
   return {
-    getBlockNumber: vi.fn().mockRejectedValue(new Error(message)),
+    getBlockNumber: vi.fn().mockRejectedValue(new RpcRequestError({
+      body: { method: "eth_blockNumber" },
+      error: { code: 10, message },
+      url: deployment.rpcUrl,
+    })),
   };
 }
 
@@ -174,7 +182,8 @@ vi.mock("../lib/onchain", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/onchain")>();
   return {
     ...actual,
-    getOnchainDeployment: () => deployment,
+    getWebsiteReadOnchainDeployment:
+      mocks.getWebsiteReadOnchainDeployment,
     readExploreModel: mocks.readLegacy,
   };
 });
@@ -220,19 +229,9 @@ describe("creator claim action identity activation", () => {
     vi.clearAllMocks();
     deployment.rpcUrl =
       "https://lb.drpc.live/ethereum/drpc-claim-key";
-    deployment.rpcUrlSecondary = null;
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER",
-      "drpc",
-    );
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL",
-      deployment.rpcUrl,
-    );
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
-      rpcProviderCommitment("endpoint", deployment.rpcUrl),
-    );
+    deployment.rpcUrlSecondary =
+      "https://claim-node.ethereum-mainnet.quiknode.pro/quicknode-claim-key/";
+    mocks.getWebsiteReadOnchainDeployment.mockReturnValue(deployment);
     mocks.lookup.mockResolvedValue(indexedToken);
     mocks.readAlchemy.mockResolvedValue(legacyModel);
     mocks.readLegacy.mockResolvedValue(legacyModel);
@@ -281,22 +280,29 @@ describe("creator claim action identity activation", () => {
     },
   );
 
-  it("does not fall back to public providers when the private pair is unavailable", async () => {
+  it("retries the complete claim preparation on the fixed secondary after primary capacity failure", async () => {
     mocks.createPublicClient.mockReset();
-    mocks.createPublicClient.mockImplementation(() =>
-      unavailableRpcClient("monthly capacity exceeded"),
-    );
+    mocks.createPublicClient
+      .mockReturnValueOnce(
+        unavailableRpcClient("monthly capacity exceeded"),
+      )
+      .mockReturnValueOnce(
+        rpcClient(100_001n, 2_000_000_001n, 10n ** 18n),
+      );
 
     const response = await POST(request());
     const payload = await response.json();
 
-    expect(response.status).toBe(503);
+    expect(response.status).toBe(200);
     expect(payload).toMatchObject({
-      status: "blocked",
-      error: {
-        code: "rpc-unavailable",
+      status: "ready",
+      gas: {
+        estimatedGas: "100001",
+        gasPriceWei: "2000000001",
       },
     });
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(2);
+    expect(mocks.readIdentity).toHaveBeenCalledTimes(1);
   });
 
   it("does not expose a private RPC identity-read failure", async () => {
@@ -323,7 +329,9 @@ describe("creator claim action identity activation", () => {
 
   it("returns a retryable typed error when the configured provider is unavailable", async () => {
     mocks.createPublicClient.mockReset();
-    mocks.createPublicClient.mockImplementation(() => unavailableRpcClient());
+    mocks.createPublicClient
+      .mockReturnValueOnce(unavailableRpcClient())
+      .mockReturnValueOnce(unavailableRpcClient());
 
     const response = await POST(request());
     const payload = await response.json();
@@ -343,10 +351,9 @@ describe("creator claim action identity activation", () => {
     "fails closed before simulation when the primary commitment is invalid with indexed lookup %s",
     async (indexedEnabled) => {
       mocks.indexedEnabled = indexedEnabled;
-      vi.stubEnv(
-        "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
-        `0x${"00".repeat(32)}`,
-      );
+      mocks.getWebsiteReadOnchainDeployment.mockImplementationOnce(() => {
+        throw new Error("Website primary RPC binding is invalid");
+      });
 
       const response = await POST(request());
       const serialized = JSON.stringify(await response.json());

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -916,7 +916,7 @@ describe("read-model operations source contract", () => {
     [
       "profile provider provenance",
       "app/api/explore/profile/route.ts",
-      '"X-Programmable-Read-Source": "drpc"',
+      '"X-Programmable-Read-Source": "rpc"',
       '"X-Programmable-Read-Source": "unknown"',
     ],
     [

--- a/tests/public-route-handler-wiring.test.ts
+++ b/tests/public-route-handler-wiring.test.ts
@@ -1,8 +1,6 @@
 import { NextRequest } from "next/server";
+import { RpcRequestError } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-import { rpcProviderCommitment } from
-  "../lib/data-pipeline/rpc-provider-commitments";
 
 vi.mock("server-only", () => ({}));
 
@@ -13,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   coordinatePublicRouteRead: vi.fn(),
   createPublicClient: vi.fn(),
   getWebsiteChartOnchainDeployment: vi.fn(),
+  getWebsiteReadOnchainDeployment: vi.fn(),
   preparePublicRouteRequest: vi.fn(
     async (value: URLSearchParams, headers: Headers, _route: string) => {
       void _route;
@@ -122,6 +121,15 @@ vi.mock("../lib/onchain/config", () => ({
     mocks.getWebsiteChartOnchainDeployment,
 }));
 
+vi.mock("../lib/onchain", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/onchain")>();
+  return {
+    ...actual,
+    getWebsiteReadOnchainDeployment:
+      mocks.getWebsiteReadOnchainDeployment,
+  };
+});
+
 vi.mock("../lib/alchemy/profile.server", () => ({
   AlchemyCreatorProfileIntegrityError:
     mocks.AlchemyCreatorProfileIntegrityError,
@@ -152,12 +160,16 @@ describe("public route coordinator wiring", () => {
     rpcFixtures.client.getLogs.mockResolvedValue([]);
     mocks.createPublicClient.mockReturnValue(rpcFixtures.client);
     const drpc = "https://lb.drpc.live/ethereum/drpc-profile-key";
-    vi.stubEnv("PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER", "drpc");
-    vi.stubEnv("PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL", drpc);
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
-      rpcProviderCommitment("endpoint", drpc),
-    );
+    mocks.getWebsiteReadOnchainDeployment.mockReturnValue({
+      status: "ready",
+      environment: "production",
+      releaseVersion: "classic-v2",
+      chainId: 1,
+      rpcUrl: drpc,
+      rpcUrlSecondary:
+        "https://profile-node.ethereum-mainnet.quiknode.pro/quicknode-profile-key/",
+      rpcProviderIds: { primary: "drpc", secondary: "quicknode" },
+    });
   });
 
   it("derives current, generated and claimed totals from sparse dRPC state", async () => {
@@ -251,7 +263,7 @@ describe("public route coordinator wiring", () => {
 
   afterEach(() => vi.unstubAllEnvs());
 
-  it("reports the single committed dRPC creator profile source", async () => {
+  it("reports the healthy bound primary creator profile source", async () => {
     const response = await creatorProfile(
       new NextRequest(
         `http://localhost/api/explore/profile?account=${ACCOUNT}`,
@@ -267,19 +279,23 @@ describe("public route coordinator wiring", () => {
       "private, max-age=0, s-maxage=15",
     );
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
-      "drpc",
+      "rpc",
     );
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "drpc",
+      "rpc",
     );
     expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
       "drpc-primary",
     );
   });
 
-  it("fails closed with 503 when the sole dRPC read fails", async () => {
+  it("retries the whole creator profile read on the fixed secondary after primary capacity failure", async () => {
     rpcFixtures.client.getBlockNumber.mockRejectedValueOnce(
-      new Error("dRPC unavailable"),
+      new RpcRequestError({
+        body: { method: "eth_blockNumber" },
+        error: { code: 10, message: "User balance exceeded" },
+        url: "https://lb.drpc.live/ethereum/drpc-profile-key",
+      }),
     );
 
     const response = await creatorProfile(
@@ -288,24 +304,22 @@ describe("public route coordinator wiring", () => {
       ),
     );
 
-    expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toEqual({
-      status: "error",
-      error: {
-        kind: "temporary",
-        code: "creator_profile_temporarily_unavailable",
-        message: "Onchain creator data is temporarily unavailable",
-      },
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ready",
+      account: ACCOUNT,
     });
-    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+    expect(mocks.createPublicClient).toHaveBeenCalledTimes(2);
     expect(mocks.readBitqueryCreatorProfile).not.toHaveBeenCalled();
+    expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
+      "quicknode-secondary",
+    );
   });
 
-  it("fails closed before transport on a primary commitment mismatch", async () => {
-    vi.stubEnv(
-      "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
-      `0x${"00".repeat(32)}`,
-    );
+  it("fails closed before transport when the Website RPC binding is invalid", async () => {
+    mocks.getWebsiteReadOnchainDeployment.mockImplementationOnce(() => {
+      throw new Error("Website primary RPC binding is invalid");
+    });
 
     const response = await creatorProfile(
       new NextRequest(


### PR DESCRIPTION
## Outcome

Restores creator profile, Classic V3 reward reads, and claim preparation when the bound primary RPC is capacity-limited by retrying the complete operation exactly once on the existing commitment-bound secondary.

## Safety

- no provider rotation on identity or provenance failures
- no endpoint or credential values returned
- no transaction submission or wallet action
- existing Envio profile fallback remains fail-closed for claim amounts

## Focused verification

- 23/23 claim/profile route tests
- TypeScript
- changed-path ESLint
- production build + candidate-neutral bundle checks