### PR TITLE
Add source-owned website projection credential rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,6 +158,9 @@ PROGRAMMABLE_MIGRATOR_DATABASE_URL=
 # Bootstrap-only secret for the constrained Website projection runtime role.
 # Supply it from the operator's secret-manager session; never pass it on the CLI.
 PROGRAMMABLE_WEBSITE_PROJECTION_RUNTIME_PASSWORD=
+# Existing-role credential rotation does not read this environment variable.
+# Supply the new runtime password only through the protected file or non-TTY
+# stdin accepted by db:website-projection:rotate-credential.
 # Cutover-only loopback restore target and its independent trust root. These
 # values are never used by the website runtime or committed with credentials.
 PROGRAMMABLE_CUTOVER_RESTORE_DATABASE_URL=

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -324,7 +324,10 @@ jobs:
 
       - name: Verify exact Website projection database operator
         if: needs.scope.outputs.custom_v2 == 'true'
-        run: node --test scripts/website-projection-db-operator.test.mjs
+        run: >-
+          node --test
+          scripts/website-projection-db-operator.test.mjs
+          scripts/website-projection-db-credential-rotation.test.mjs
 
       - name: Verify exact Generic V2 read-model contract derivation
         if: needs.scope.outputs.custom_v2 == 'true'

--- a/docs/operations/WEBSITE-PROJECTION-DATABASE-BACKEND-HANDOFF-V1.json
+++ b/docs/operations/WEBSITE-PROJECTION-DATABASE-BACKEND-HANDOFF-V1.json
@@ -1,0 +1,178 @@
+{
+  "schemaVersion": "programmable.website-projection-database-backend-handoff.v1",
+  "contractType": "website-rotation-output-to-backend-vercel-materializer",
+  "target": {
+    "supabaseProjectRef": "mnnvlrqwhfoppogslsje",
+    "database": "postgres",
+    "runtimeRole": "programmable_website_projection_runtime",
+    "runtimeHost": "aws-0-eu-central-1.pooler.supabase.com",
+    "runtimePort": 6543,
+    "tlsMode": "verify-full-equivalent"
+  },
+  "websiteSourceIdentity": {
+    "transport": "signed-commit-handoff-receipt-v1",
+    "requiredFields": [
+      "repositoryCommit",
+      "repositoryTree",
+      "repositoryParent",
+      "sshSignaturePresent"
+    ],
+    "mustEqualRotationReceiptSource": true,
+    "embeddedInSource": false,
+    "reason": "A commit cannot contain its own Git object identity."
+  },
+  "protectedInputs": [
+    {
+      "id": "reviewedMigrationPlan",
+      "transport": "file",
+      "canonicalBasename": "reviewed-website-projection-plan.json",
+      "mode": "0600",
+      "ownerOnly": true,
+      "outsideGitCheckout": true,
+      "containsSecret": false
+    },
+    {
+      "id": "newRuntimePassword",
+      "transport": "file-or-non-tty-stdin",
+      "canonicalBasename": "new-website-projection-runtime-password",
+      "fileMode": "0600",
+      "ownerOnly": true,
+      "outsideGitCheckout": true,
+      "containsSecret": true,
+      "generatedByWebsiteOperator": false
+    }
+  ],
+  "operatorEnvironment": [
+    {
+      "name": "PROGRAMMABLE_MIGRATOR_DATABASE_URL",
+      "transport": "secret-manager-environment",
+      "cliFlagAllowed": false,
+      "target": "db.mnnvlrqwhfoppogslsje.supabase.co:5432/postgres"
+    },
+    {
+      "name": "PROGRAMMABLE_POSTGRES_SSL_CA_PEM",
+      "transport": "secret-manager-environment",
+      "cliFlagAllowed": false,
+      "target": "provider-server-root-ca"
+    }
+  ],
+  "protectedOutputDirectory": {
+    "mode": "0700",
+    "ownerOnly": true,
+    "outsideGitCheckout": true,
+    "mustNotExistBeforeRotation": true,
+    "publication": "atomic-directory-rename-after-fresh-runtime-probe"
+  },
+  "protectedOutputs": [
+    {
+      "filename": "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL",
+      "environmentName": "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL",
+      "mode": "0600",
+      "sensitive": true,
+      "valueFormat": "exact-postgresql-pooler-url-v1",
+      "digest": {
+        "algorithm": "sha256",
+        "canonicalBytes": "raw-file-bytes",
+        "websiteReceipt": "forbidden",
+        "backendCasReceipt": "required"
+      }
+    },
+    {
+      "filename": "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE",
+      "environmentName": "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE",
+      "mode": "0600",
+      "sensitive": false,
+      "exactValue": "programmable_website_projection_runtime",
+      "digest": {
+        "algorithm": "sha256",
+        "canonicalBytes": "raw-file-bytes",
+        "websiteReceipt": "optional",
+        "backendCasReceipt": "required"
+      }
+    },
+    {
+      "filename": "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM",
+      "environmentName": "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM",
+      "mode": "0600",
+      "sensitive": false,
+      "valueFormat": "provider-server-root-ca-pem",
+      "digest": {
+        "algorithm": "sha256",
+        "canonicalBytes": "raw-file-bytes",
+        "websiteReceipt": "required",
+        "backendCasReceipt": "required"
+      }
+    }
+  ],
+  "websiteReceipt": {
+    "filename": "programmable-website-projection-runtime-credential-rotation-v1.json",
+    "mode": "0600",
+    "schemaVersion": "programmable.website-projection-runtime-credential-rotation.v1",
+    "requiredClaims": [
+      "source.repositoryCommit",
+      "source.repositoryTree",
+      "source.repositoryParent",
+      "target.projectRef",
+      "target.runtimeEndpoint",
+      "target.runtimeRole",
+      "migrationEvidence",
+      "catalog.unchanged",
+      "runtimeProbe.leastPrivilege",
+      "tls.caSha256",
+      "tls.hostnameVerified",
+      "cutover.overlappingPasswordsSupported",
+      "cutover.postCommitFailure",
+      "cutover.vercelMutationPerformed",
+      "protectedOutputs.containsSecretDerivedDigest"
+    ],
+    "mustNotContainValues": [
+      "runtime-password",
+      "runtime-database-url",
+      "runtime-database-url-sha256",
+      "runtime-password-sha256"
+    ]
+  },
+  "backendMaterializer": {
+    "authorityBoundary": "separate-explicit-backend-release-authority",
+    "requiredLeaves": [
+      "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL",
+      "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE",
+      "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM"
+    ],
+    "digestRule": "sha256-of-exact-raw-input-bytes",
+    "casRule": "require-expected-prior-digest-before-each-vercel-write",
+    "readbackRule": "record-provider-returned-digest-or-fail-closed",
+    "plaintextReceiptAllowed": false,
+    "websiteReceiptMutationAllowed": false,
+    "receiptSchema": {
+      "schemaVersion": "programmable.backend.website-projection-vercel-materialization.v1",
+      "requiredFields": [
+        "websiteSource.repositoryCommit",
+        "websiteSource.repositoryTree",
+        "websiteSource.repositoryParent",
+        "websiteRotationReceiptSha256",
+        "target.vercelProjectId",
+        "target.environment",
+        "leaves[].environmentName",
+        "leaves[].inputSha256",
+        "leaves[].expectedPriorSha256",
+        "leaves[].providerReadbackSha256",
+        "changed",
+        "materializedAt"
+      ],
+      "forbiddenFields": [
+        "value",
+        "plaintext",
+        "databaseUrl",
+        "password",
+        "caPem"
+      ]
+    },
+    "cutoverSequence": [
+      "dark-stage",
+      "runtime-readiness",
+      "desktop-mobile-api-browser-proof",
+      "separate-promotion-authority"
+    ]
+  }
+}

--- a/docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md
+++ b/docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md
@@ -155,3 +155,67 @@ Success requires `current`, five exact evidence rows, the constrained role graph
 and application/operator catalog fingerprints matching the last atomic evidence
 row. Pending exits 2; drift is an error. Retain the verify JSON with the plan,
 dry-run result, and apply result.
+
+## Existing runtime credential rotation
+
+The bootstrap password is intentionally ignored once
+`programmable_website_projection_runtime` exists. Rotate that existing role only
+with the separate source-owned operator:
+
+```sh
+npm run --silent db:website-projection:rotate-credential -- preflight \
+  --expected-project-ref 'mnnvlrqwhfoppogslsje' \
+  --plan '/secure/operator/reviewed-website-projection-plan.json'
+
+npm run --silent db:website-projection:rotate-credential -- rotate \
+  --expected-project-ref 'mnnvlrqwhfoppogslsje' \
+  --plan '/secure/operator/reviewed-website-projection-plan.json' \
+  --password-file '/secure/operator/new-website-projection-runtime-password' \
+  --output-directory '/secure/operator/website-projection-runtime-v1' \
+  --confirm-rotate \
+    'programmable_website_projection_runtime@mnnvlrqwhfoppogslsje' \
+  --confirm-no-overlap 'single-password-forward-cutover-v1'
+```
+
+Use `--password-stdin yes` instead of `--password-file` only with a non-TTY
+secret-manager pipe. A password file must be an owner-only regular file with
+mode `0600`; it is never accepted as a flag value, environment variable, or
+printed output. The output directory must not exist and its parent must be an
+owner-only real directory with mode `0700`.
+Both protected paths must resolve outside the Git checkout.
+The retained reviewed migration plan must also be an owner-only `0600` regular
+file outside the checkout. Its exact evidence and adoption attestation must be
+current in the database, while its migration order and byte commitments must
+match the current rotation checkout.
+
+The operator reuses the authenticated migration boundary above, requires the
+exact current five-row migration evidence and catalog fingerprints, takes a
+shared migration advisory lock, and changes only the password with `ALTER ROLE`
+inside one database transaction. It then authenticates a fresh connection through the
+exact Frankfurt Supavisor transaction endpoint as
+`programmable_website_projection_runtime.mnnvlrqwhfoppogslsje`, with the
+separate provider CA, hostname verification and the runtime least-privilege
+attestation. Only after that probe succeeds does one atomic directory rename
+publish these owner-only `0600` files:
+
+- `PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL`;
+- `PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE`;
+- `PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM`;
+- `programmable-website-projection-runtime-credential-rotation-v1.json`.
+
+The JSON receipt contains no credential or credential-derived digest. The first
+three files are protected inputs for the Vercel environment controller; their
+creation is not a Vercel change or a Website cutover.
+
+PostgreSQL supports one password for this role, not overlapping old and new
+passwords. A failure before password mutation rolls back automatically. Existing
+sessions may continue after commit, but they are not overlap or cutover evidence.
+Every failure after password mutation begins, including a lost commit
+acknowledgement or a failed fresh probe, is conservatively `WPR01`: the new
+credential may be active and the staged output is removed. Rerun with the same
+protected secret or perform a forward rotation. Automatic restoration of an
+unavailable prior secret is impossible.
+Keep the current Vercel value until the protected new URL and CA exist, then use
+the normal dark-stage, readiness and promotion sequence.
+The exact cross-repository materialization contract is machine-readable in
+`WEBSITE-PROJECTION-DATABASE-BACKEND-HANDOFF-V1.json` beside this runbook.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "db:test:pglite": "node scripts/run-pglite-db-tests.mjs",
     "projector:provider-commitments": "node scripts/compute-projector-provider-commitments.mjs",
     "db:website-projection:operator": "node scripts/website-projection-db-operator.mjs",
+    "db:website-projection:rotate-credential": "node scripts/website-projection-db-credential-rotation.mjs",
     "verify:service-launch-permit-v2-golden": "node scripts/verify-service-launch-permit-v2-golden.mjs",
     "verify:service-launch-permit-v2-golden:cross-stack": "node scripts/verify-service-launch-permit-v2-golden.mjs --require-canonical",
     "verify:uniswap-launcher-sdk": "node scripts/verify-uniswap-liquidity-launcher-sdk.mjs",

--- a/scripts/ci/classify-verify-paths.mjs
+++ b/scripts/ci/classify-verify-paths.mjs
@@ -16,6 +16,7 @@ const CUSTOM_V2_EXACT_PATHS = new Set([
   "config/generic-launch-foundation.prelaunch.v1.json",
   "config/generic-launch-foundation.v1.schema.json",
   "config/generic-launch-public.v2.schema.json",
+  "docs/operations/WEBSITE-PROJECTION-DATABASE-BACKEND-HANDOFF-V1.json",
   "lib/custom-launch/registry-public-manifest-v2.ts",
   "lib/data-pipeline/custom-registry-v2-event-manifest.ts",
   "lib/server/custom-launch/registry-manifest-v2.ts",

--- a/scripts/ci/classify-verify-paths.test.mjs
+++ b/scripts/ci/classify-verify-paths.test.mjs
@@ -23,6 +23,7 @@ test("routes the versioned Custom V2 surface without legacy market lanes", () =>
   for (const path of [
     "config/custom-registry-v2.deployment.prelaunch.json",
     "config/generic-launch-foundation.prelaunch.v1.json",
+    "docs/operations/WEBSITE-PROJECTION-DATABASE-BACKEND-HANDOFF-V1.json",
     "app/api/custom-launch/registry/v2/manifest/route.ts",
     "app/api/custom-launch/generic/v2/readiness/route.ts",
     "app/api/ops/custom-launch/generic-v2-projector/route.ts",

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -32,9 +32,18 @@ test("Custom V2 production proof is a dedicated versioned protected lane", () =>
   assert.match(proof, /id: "custom-v2", name: "Custom V2", scopeKey: "custom_v2"/u);
   assert.match(verify, /^  custom-v2:$/mu);
   assert.match(verify, /name: Verify exact Custom V2 surface[\s\S]*npm run verify:custom-v2:ci/u);
-  assert.match(
+  const projectionDatabaseOperator = stepBlock(
     verify,
-    /name: Verify exact Website projection database operator[\s\S]*node --test scripts\/website-projection-db-operator\.test\.mjs/u,
+    "Verify exact Website projection database operator",
+  );
+  assert.match(projectionDatabaseOperator, /node --test/u);
+  assert.match(
+    projectionDatabaseOperator,
+    /scripts\/website-projection-db-operator\.test\.mjs/u,
+  );
+  assert.match(
+    projectionDatabaseOperator,
+    /scripts\/website-projection-db-credential-rotation\.test\.mjs/u,
   );
   assert.match(
     verify,

--- a/scripts/website-projection-db-credential-rotation-core.mjs
+++ b/scripts/website-projection-db-credential-rotation-core.mjs
@@ -1,0 +1,250 @@
+import { createHash } from "node:crypto";
+
+import {
+  validateWebsiteProjectionPlan,
+  WEBSITE_PROJECTION_RUNTIME_ROLE,
+} from "./website-projection-db-operator-core.mjs";
+
+export const WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF =
+  "mnnvlrqwhfoppogslsje";
+export const WEBSITE_PROJECTION_RUNTIME_POOLER_HOST =
+  "aws-0-eu-central-1.pooler.supabase.com";
+export const WEBSITE_PROJECTION_RUNTIME_POOLER_PORT = 6543;
+export const WEBSITE_PROJECTION_RUNTIME_DATABASE = "postgres";
+export const WEBSITE_PROJECTION_ROTATION_CONFIRMATION =
+  `${WEBSITE_PROJECTION_RUNTIME_ROLE}@${WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF}`;
+export const WEBSITE_PROJECTION_NO_OVERLAP_CONFIRMATION =
+  "single-password-forward-cutover-v1";
+export const WEBSITE_PROJECTION_ROTATION_RECEIPT_SCHEMA =
+  "programmable.website-projection-runtime-credential-rotation.v1";
+export const WEBSITE_PROJECTION_RUNTIME_DATABASE_URL_LEAF =
+  "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL";
+export const WEBSITE_PROJECTION_RUNTIME_DATABASE_ROLE_LEAF =
+  "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE";
+export const WEBSITE_PROJECTION_RUNTIME_DATABASE_CA_PEM_LEAF =
+  "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM";
+export const WEBSITE_PROJECTION_ROTATION_RECEIPT_LEAF =
+  "programmable-website-projection-runtime-credential-rotation-v1.json";
+
+const GIT_OBJECT = /^[0-9a-f]{40}$/u;
+const HEX_SHA256 = /^0x[0-9a-f]{64}$/u;
+const PROJECT_REF = /^[a-z0-9]{20}$/u;
+
+function plainObject(value) {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+export function validateWebsiteProjectionRotationPassword(value) {
+  if (typeof value !== "string"
+    || Buffer.byteLength(value, "utf8") < 24
+    || Buffer.byteLength(value, "utf8") > 512
+    || /[\u0000-\u001f\u007f]/u.test(value)) {
+    throw new Error("website projection rotation password is invalid");
+  }
+  return value;
+}
+
+export function assertWebsiteProjectionRotationConfirmation({
+  expectedProjectRef,
+  confirmRotate,
+  confirmNoOverlap,
+}) {
+  if (!PROJECT_REF.test(expectedProjectRef ?? "")
+    || expectedProjectRef !== WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF
+    || confirmRotate !== WEBSITE_PROJECTION_ROTATION_CONFIRMATION) {
+    throw new Error("rotation confirmation must equal the exact production role and project");
+  }
+  if (confirmNoOverlap !== WEBSITE_PROJECTION_NO_OVERLAP_CONFIRMATION) {
+    throw new Error("rotation requires explicit single-password cutover confirmation");
+  }
+}
+
+export function buildWebsiteProjectionRuntimeDatabaseUrl(password, {
+  projectRef = WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+} = {}) {
+  validateWebsiteProjectionRotationPassword(password);
+  if (projectRef !== WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF) {
+    throw new Error("runtime database target is not the production project");
+  }
+  const url = new URL("postgresql://invalid:invalid@invalid.invalid/postgres");
+  url.username = `${WEBSITE_PROJECTION_RUNTIME_ROLE}.${projectRef}`;
+  url.password = encodeURIComponent(password);
+  url.hostname = WEBSITE_PROJECTION_RUNTIME_POOLER_HOST;
+  url.port = String(WEBSITE_PROJECTION_RUNTIME_POOLER_PORT);
+  url.pathname = `/${WEBSITE_PROJECTION_RUNTIME_DATABASE}`;
+  return url.toString();
+}
+
+export function validateWebsiteProjectionRuntimeDatabaseUrl(value, {
+  projectRef = WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+} = {}) {
+  let url;
+  let loginRole;
+  let password;
+  try {
+    url = new URL(value);
+    loginRole = decodeURIComponent(url.username);
+    password = decodeURIComponent(url.password);
+    validateWebsiteProjectionRotationPassword(password);
+  } catch {
+    throw new Error("runtime database URL is invalid");
+  }
+  if (projectRef !== WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF
+    || url.protocol !== "postgresql:"
+    || loginRole !== `${WEBSITE_PROJECTION_RUNTIME_ROLE}.${projectRef}`
+    || url.hostname !== WEBSITE_PROJECTION_RUNTIME_POOLER_HOST
+    || url.port !== String(WEBSITE_PROJECTION_RUNTIME_POOLER_PORT)
+    || url.pathname !== `/${WEBSITE_PROJECTION_RUNTIME_DATABASE}`
+    || url.search !== ""
+    || url.hash !== "") {
+    throw new Error("runtime database URL is not the exact production pooler target");
+  }
+  return Object.freeze({
+    projectRef,
+    host: url.hostname,
+    port: Number(url.port),
+    database: WEBSITE_PROJECTION_RUNTIME_DATABASE,
+    loginRole,
+    effectiveRole: WEBSITE_PROJECTION_RUNTIME_ROLE,
+    tlsMode: "verify-full-equivalent",
+  });
+}
+
+export function assertWebsiteProjectionRotationSourcePlan({
+  reviewedPlan,
+  currentPlan,
+}) {
+  validateWebsiteProjectionPlan(reviewedPlan);
+  validateWebsiteProjectionPlan(currentPlan);
+  if (reviewedPlan.orderSha256 !== currentPlan.orderSha256
+    || reviewedPlan.migrationCount !== currentPlan.migrationCount
+    || JSON.stringify(reviewedPlan.migrations)
+      !== JSON.stringify(currentPlan.migrations)) {
+    throw new Error("reviewed rotation plan differs from the current migration closure");
+  }
+  return reviewedPlan;
+}
+
+export function assertWebsiteProjectionRuntimeCredentialProbe(value) {
+  if (!plainObject(value)
+    || value.runtime_role !== WEBSITE_PROJECTION_RUNTIME_ROLE
+    || value.session_role !== WEBSITE_PROJECTION_RUNTIME_ROLE
+    || value.database_name !== WEBSITE_PROJECTION_RUNTIME_DATABASE
+    || Number(value.server_version_num) < 150000
+    || value.rolsuper !== false
+    || value.rolinherit !== false
+    || value.rolcreaterole !== false
+    || value.rolcreatedb !== false
+    || value.rolreplication !== false
+    || value.rolbypassrls !== false
+    || value.schema_usage !== true
+    || value.schema_create !== false
+    || value.required_runtime_privileges !== true
+    || value.forbidden_runtime_privileges !== false
+    || value.owns_application_objects !== false
+    || value.has_forbidden_membership !== false
+    || value.ssl !== true
+    || typeof value.ssl_version !== "string"
+    || value.ssl_version.length === 0
+    || typeof value.ssl_cipher !== "string"
+    || value.ssl_cipher.length === 0
+    || Number(value.ssl_bits) < 128) {
+    throw new Error("website projection runtime credential probe failed");
+  }
+  return Object.freeze({
+    runtimeRole: value.runtime_role,
+    databaseName: value.database_name,
+    serverVersionNum: String(value.server_version_num),
+    sslVersion: value.ssl_version,
+    sslCipher: value.ssl_cipher,
+    sslBits: Number(value.ssl_bits),
+    leastPrivilege: true,
+  });
+}
+
+export function buildWebsiteProjectionRotationReceipt({
+  sourceCommit,
+  sourceTree,
+  sourceParent,
+  target,
+  migrationEvidence,
+  preRotationCatalogSha256,
+  postRotationCatalogSha256,
+  runtimeProbe,
+  caPem,
+  outputFiles,
+  rotatedAt,
+}) {
+  if (!GIT_OBJECT.test(sourceCommit ?? "")
+    || !GIT_OBJECT.test(sourceTree ?? "")
+    || !GIT_OBJECT.test(sourceParent ?? "")
+    || !plainObject(target)
+    || target.projectRef !== WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF
+    || target.database !== WEBSITE_PROJECTION_RUNTIME_DATABASE
+    || !plainObject(migrationEvidence)
+    || !HEX_SHA256.test(preRotationCatalogSha256 ?? "")
+    || postRotationCatalogSha256 !== preRotationCatalogSha256
+    || !plainObject(runtimeProbe)
+    || typeof caPem !== "string"
+    || !caPem.includes("-----BEGIN CERTIFICATE-----")
+    || !plainObject(outputFiles)
+    || outputFiles.databaseUrl !== WEBSITE_PROJECTION_RUNTIME_DATABASE_URL_LEAF
+    || outputFiles.databaseRole !== WEBSITE_PROJECTION_RUNTIME_DATABASE_ROLE_LEAF
+    || outputFiles.databaseCaPem
+      !== WEBSITE_PROJECTION_RUNTIME_DATABASE_CA_PEM_LEAF
+    || outputFiles.receipt !== WEBSITE_PROJECTION_ROTATION_RECEIPT_LEAF
+    || typeof rotatedAt !== "string"
+    || !Number.isFinite(Date.parse(rotatedAt))) {
+    throw new Error("website projection rotation receipt inputs are invalid");
+  }
+  return Object.freeze({
+    schemaVersion: WEBSITE_PROJECTION_ROTATION_RECEIPT_SCHEMA,
+    operation: "rotate-existing-runtime-role-password",
+    changed: true,
+    rotatedAt,
+    source: Object.freeze({
+      repositoryCommit: sourceCommit,
+      repositoryTree: sourceTree,
+      repositoryParent: sourceParent,
+    }),
+    target: Object.freeze({
+      projectRef: target.projectRef,
+      database: target.database,
+      authorityEndpoint: `db.${target.projectRef}.supabase.co:5432`,
+      runtimeEndpoint:
+        `${WEBSITE_PROJECTION_RUNTIME_POOLER_HOST}:${WEBSITE_PROJECTION_RUNTIME_POOLER_PORT}`,
+      runtimeRole: WEBSITE_PROJECTION_RUNTIME_ROLE,
+    }),
+    migrationEvidence,
+    catalog: Object.freeze({
+      beforeSha256: preRotationCatalogSha256,
+      afterSha256: postRotationCatalogSha256,
+      unchanged: true,
+    }),
+    runtimeProbe,
+    tls: Object.freeze({
+      mode: "verify-full-equivalent",
+      caSha256: `sha256:${createHash("sha256").update(caPem).digest("hex")}`,
+      hostnameVerified: true,
+    }),
+    cutover: Object.freeze({
+      passwordSlots: 1,
+      overlappingPasswordsSupported: false,
+      existingSessionsAreNotCutoverEvidence: true,
+      preCommitFailure: "automatic-transaction-rollback",
+      postCommitFailure: "forward-rotate-or-rerun-with-the-same-protected-secret",
+      vercelMutationPerformed: false,
+    }),
+    protectedOutputs: Object.freeze({
+      databaseUrl: outputFiles.databaseUrl,
+      databaseRole: outputFiles.databaseRole,
+      databaseCaPem: outputFiles.databaseCaPem,
+      receipt: outputFiles.receipt,
+      mode: "0600",
+      containsSecretDerivedDigest: false,
+    }),
+  });
+}

--- a/scripts/website-projection-db-credential-rotation-postgres.mjs
+++ b/scripts/website-projection-db-credential-rotation-postgres.mjs
@@ -1,0 +1,363 @@
+import { Pool } from "pg";
+
+import {
+  canonicalJson,
+} from "./data-pipeline/hosted-db-operator-core.mjs";
+import {
+  inspectWebsiteProjectionCurrentRotationPosture,
+} from "./website-projection-db-postgres.mjs";
+import {
+  assertWebsiteProjectionRuntimeCredentialProbe,
+  validateWebsiteProjectionRotationPassword,
+  validateWebsiteProjectionRuntimeDatabaseUrl,
+} from "./website-projection-db-credential-rotation-core.mjs";
+import {
+  WEBSITE_PROJECTION_RUNTIME_ROLE,
+} from "./website-projection-db-operator-core.mjs";
+
+const ROTATION_LOCK =
+  "programmable:website-projection-migrations:v1";
+
+async function queryRows(sql, statement, parameters = []) {
+  return await sql.unsafe(statement, parameters);
+}
+
+async function executeSimple(sql, statement) {
+  const operation = sql.unsafe(statement);
+  return await (typeof operation.simple === "function"
+    ? operation.simple()
+    : operation);
+}
+
+function samePosture(left, right) {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+export async function setWebsiteProjectionRuntimePassword(
+  transaction,
+  runtimePassword,
+) {
+  const password = validateWebsiteProjectionRotationPassword(runtimePassword);
+  await queryRows(transaction, `
+    SELECT pg_catalog.set_config(
+      'programmable.website_projection_runtime_rotation_password', $1, true
+    ) AS configured
+  `, [password]);
+  await executeSimple(transaction, `
+    DO $runtime_credential_rotation$
+    DECLARE
+      runtime_password text := pg_catalog.current_setting(
+        'programmable.website_projection_runtime_rotation_password', true
+      );
+    BEGIN
+      IF current_role::text <> 'postgres' THEN
+        RAISE EXCEPTION 'website projection rotation authority changed';
+      END IF;
+      IF runtime_password IS NULL
+        OR pg_catalog.octet_length(runtime_password) < 24
+        OR pg_catalog.octet_length(runtime_password) > 512
+      THEN
+        RAISE EXCEPTION 'website projection rotation password is unavailable';
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1
+          FROM pg_catalog.pg_roles
+         WHERE rolname = 'programmable_website_projection_runtime'
+           AND rolcanlogin
+           AND NOT rolinherit
+           AND NOT rolsuper
+           AND NOT rolcreaterole
+           AND NOT rolcreatedb
+           AND NOT rolreplication
+           AND NOT rolbypassrls
+      ) THEN
+        RAISE EXCEPTION 'website projection runtime role posture changed';
+      END IF;
+      EXECUTE pg_catalog.format(
+        'ALTER ROLE %I PASSWORD %L',
+        'programmable_website_projection_runtime',
+        runtime_password
+      );
+      PERFORM pg_catalog.set_config(
+        'programmable.website_projection_runtime_rotation_password', '', true
+      );
+    END
+    $runtime_credential_rotation$;
+  `);
+  const [cleared] = await queryRows(transaction, `
+    SELECT pg_catalog.current_setting(
+      'programmable.website_projection_runtime_rotation_password', true
+    ) AS value
+  `);
+  if (cleared?.value !== "") {
+    throw new Error("website projection rotation password was not cleared");
+  }
+}
+
+export async function rotateWebsiteProjectionRuntimeCredential({
+  sql,
+  plan,
+  expectedProjectRef,
+  sessionIdentity,
+  runtimePassword,
+}, {
+  postureInspector = inspectWebsiteProjectionCurrentRotationPosture,
+  passwordSetter = setWebsiteProjectionRuntimePassword,
+} = {}) {
+  validateWebsiteProjectionRotationPassword(runtimePassword);
+  const [lock] = await queryRows(sql, `
+    /* website-projection:credential-rotation-lock */
+    SELECT pg_catalog.pg_try_advisory_lock(
+      pg_catalog.hashtextextended('${ROTATION_LOCK}', 0)
+    ) AS acquired,
+    pg_catalog.pg_backend_pid() AS backend_pid,
+    session_user::text AS session_user,
+    current_role::text AS current_role
+  `);
+  if (lock?.acquired !== true
+    || Number(lock.backend_pid) !== Number(sessionIdentity?.backendPid)
+    || lock.session_user !== sessionIdentity?.sessionUser
+    || lock.current_role !== sessionIdentity?.currentRole) {
+    throw new Error("website projection credential rotation lock is unavailable");
+  }
+  let credentialMayBeCommitted = false;
+  let outcome;
+  let failure;
+  try {
+    const before = await postureInspector({
+      sql,
+      plan,
+      expectedProjectRef,
+      sessionIdentity,
+    });
+    const committed = await sql.begin(async (transaction) => {
+      await executeSimple(transaction,
+        "SET LOCAL lock_timeout = '4s'; SET LOCAL statement_timeout = '2min';");
+      const transactionBefore =
+        await postureInspector({
+          sql: transaction,
+          plan,
+          expectedProjectRef,
+          sessionIdentity,
+        });
+      if (!samePosture(transactionBefore, before)) {
+        throw new Error("website projection rotation posture changed before mutation");
+      }
+      credentialMayBeCommitted = true;
+      await passwordSetter(transaction, runtimePassword);
+      const transactionAfter =
+        await postureInspector({
+          sql: transaction,
+          plan,
+          expectedProjectRef,
+          sessionIdentity,
+        });
+      if (!samePosture(transactionAfter, transactionBefore)) {
+        throw new Error("website projection rotation changed non-credential state");
+      }
+      return transactionAfter;
+    });
+    const after = await postureInspector({
+      sql,
+      plan,
+      expectedProjectRef,
+      sessionIdentity,
+    });
+    if (!samePosture(after, committed) || !samePosture(after, before)) {
+      throw new Error("website projection posture changed across credential commit");
+    }
+    outcome = Object.freeze({ before, after });
+  } catch (error) {
+    failure = error;
+  }
+  try {
+    const [unlock] = await queryRows(sql, `
+      /* website-projection:credential-rotation-unlock */
+      SELECT CASE
+        WHEN pg_catalog.pg_backend_pid() = $1
+         AND session_user::text = $2
+         AND current_role::text = $3
+        THEN pg_catalog.pg_advisory_unlock(
+          pg_catalog.hashtextextended('${ROTATION_LOCK}', 0)
+        )
+        ELSE false
+      END AS released,
+      pg_catalog.pg_backend_pid() AS backend_pid,
+      session_user::text AS session_user,
+      current_role::text AS current_role
+    `, [
+      sessionIdentity.backendPid,
+      sessionIdentity.sessionUser,
+      sessionIdentity.currentRole,
+    ]);
+    if (unlock?.released !== true
+      || Number(unlock.backend_pid) !== Number(sessionIdentity.backendPid)
+      || unlock.session_user !== sessionIdentity.sessionUser
+      || unlock.current_role !== sessionIdentity.currentRole) {
+      throw new Error("website projection credential rotation lock was not released");
+    }
+  } catch (error) {
+    failure ??= error;
+  }
+  if (failure !== undefined) {
+    if (credentialMayBeCommitted) {
+      const postCommitFailure = new Error(
+        "website projection credential commit is active or ambiguous",
+        { cause: failure },
+      );
+      postCommitFailure.code = "WPR01";
+      throw postCommitFailure;
+    }
+    throw failure;
+  }
+  return outcome;
+}
+
+const RUNTIME_PROBE_SQL = `
+  SELECT current_user::text AS runtime_role,
+         session_user::text AS session_role,
+         pg_catalog.current_database() AS database_name,
+         pg_catalog.current_setting('server_version_num') AS server_version_num,
+         role.rolsuper, role.rolinherit, role.rolcreaterole, role.rolcreatedb,
+         role.rolreplication, role.rolbypassrls,
+         pg_catalog.has_schema_privilege(current_user,
+           'programmable_website_projection_v1', 'USAGE') AS schema_usage,
+         pg_catalog.has_schema_privilege(current_user,
+           'programmable_website_projection_v1', 'CREATE') AS schema_create,
+         (
+           pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.projection_records',
+             'SELECT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.projection_records',
+             'INSERT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.credential_uses',
+             'SELECT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.credential_uses',
+             'INSERT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.registry_custom_launch_records',
+             'SELECT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.registry_custom_launch_records',
+             'INSERT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.generic_launch_materializations_v2',
+             'SELECT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.generic_launch_materializations_v2',
+             'INSERT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.generic_launch_reconciliations_v2',
+             'SELECT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.generic_launch_reconciliations_v2',
+             'INSERT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2',
+             'SELECT')
+           AND pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2',
+             'INSERT')
+         ) AS required_runtime_privileges,
+         (
+           pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.projection_records',
+             'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+           OR pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.credential_uses',
+             'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+           OR pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.registry_custom_launch_records',
+             'DELETE,TRUNCATE,REFERENCES,TRIGGER')
+           OR pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.generic_launch_materializations_v2',
+             'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+           OR pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.generic_launch_reconciliations_v2',
+             'DELETE,TRUNCATE,REFERENCES,TRIGGER')
+           OR pg_catalog.has_table_privilege(current_user,
+             'programmable_website_projection_v1.generic_launch_reconciliation_attempts_v2',
+             'DELETE,TRUNCATE,REFERENCES,TRIGGER')
+         ) AS forbidden_runtime_privileges,
+         EXISTS (
+           SELECT 1
+             FROM pg_catalog.pg_class class
+             JOIN pg_catalog.pg_namespace namespace
+               ON namespace.oid = class.relnamespace
+            WHERE namespace.nspname IN (
+              'programmable_website_projection_v1',
+              'programmable_website_projection_migrations'
+            )
+              AND class.relowner = role.oid
+         ) OR EXISTS (
+           SELECT 1 FROM pg_catalog.pg_namespace namespace
+            WHERE namespace.nspname IN (
+              'programmable_website_projection_v1',
+              'programmable_website_projection_migrations'
+            )
+              AND namespace.nspowner = role.oid
+         ) AS owns_application_objects,
+         EXISTS (
+           SELECT 1 FROM pg_catalog.pg_auth_members membership
+            WHERE membership.member = role.oid
+         ) AS has_forbidden_membership,
+         COALESCE(ssl.ssl, false) AS ssl,
+         ssl.version AS ssl_version,
+         ssl.cipher AS ssl_cipher,
+         ssl.bits AS ssl_bits
+    FROM pg_catalog.pg_roles role
+    LEFT JOIN pg_catalog.pg_stat_ssl ssl
+      ON ssl.pid = pg_catalog.pg_backend_pid()
+   WHERE role.rolname = current_user
+`;
+
+export async function probeWebsiteProjectionRuntimeCredential({
+  databaseUrl,
+  expectedProjectRef,
+  sslCaPem,
+}, { PoolClass = Pool } = {}) {
+  const target = validateWebsiteProjectionRuntimeDatabaseUrl(databaseUrl, {
+    projectRef: expectedProjectRef,
+  });
+  if (typeof sslCaPem !== "string"
+    || sslCaPem.length < 64
+    || sslCaPem.length > 131_072
+    || !sslCaPem.includes("-----BEGIN CERTIFICATE-----")
+    || !sslCaPem.includes("-----END CERTIFICATE-----")) {
+    throw new Error("website projection runtime CA is invalid");
+  }
+  const pool = new PoolClass({
+    connectionString: databaseUrl,
+    ssl: {
+      ca: sslCaPem,
+      rejectUnauthorized: true,
+      servername: target.host,
+    },
+    max: 1,
+    connectionTimeoutMillis: 8_000,
+    idleTimeoutMillis: 1_000,
+    allowExitOnIdle: true,
+    application_name: "programmable-website-projection-credential-probe-v1",
+  });
+  try {
+    const result = await pool.query(RUNTIME_PROBE_SQL);
+    if (result.rows.length !== 1) {
+      throw new Error("website projection runtime credential probe failed");
+    }
+    return Object.freeze({
+      target,
+      attestation: assertWebsiteProjectionRuntimeCredentialProbe(result.rows[0]),
+    });
+  } finally {
+    await pool.end().catch(() => {});
+  }
+}
+
+export const WEBSITE_PROJECTION_ROTATION_POSTGRES_CONTRACT = Object.freeze({
+  lock: ROTATION_LOCK,
+  runtimeRole: WEBSITE_PROJECTION_RUNTIME_ROLE,
+  runtimeProbeSql: RUNTIME_PROBE_SQL,
+});

--- a/scripts/website-projection-db-credential-rotation.mjs
+++ b/scripts/website-projection-db-credential-rotation.mjs
@@ -1,0 +1,463 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  open,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import {
+  assertNoSecretOutput,
+  safeFailure,
+} from "./data-pipeline/hosted-db-operator-core.mjs";
+import {
+  openHostedDatabase,
+  closeHostedDatabase,
+} from "./data-pipeline/hosted-db-postgres.mjs";
+import {
+  inspectWebsiteProjectionCurrentRotationPosture,
+} from "./website-projection-db-postgres.mjs";
+import {
+  discoverWebsiteProjectionPlan,
+  validateWebsiteProjectionPlan,
+  WEBSITE_PROJECTION_RUNTIME_ROLE,
+} from "./website-projection-db-operator-core.mjs";
+import {
+  assertWebsiteProjectionRotationConfirmation,
+  assertWebsiteProjectionRotationSourcePlan,
+  buildWebsiteProjectionRotationReceipt,
+  buildWebsiteProjectionRuntimeDatabaseUrl,
+  validateWebsiteProjectionRotationPassword,
+  WEBSITE_PROJECTION_NO_OVERLAP_CONFIRMATION,
+  WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+  WEBSITE_PROJECTION_ROTATION_RECEIPT_LEAF,
+  WEBSITE_PROJECTION_ROTATION_CONFIRMATION,
+  WEBSITE_PROJECTION_RUNTIME_DATABASE_CA_PEM_LEAF,
+  WEBSITE_PROJECTION_RUNTIME_DATABASE_ROLE_LEAF,
+  WEBSITE_PROJECTION_RUNTIME_DATABASE_URL_LEAF,
+} from "./website-projection-db-credential-rotation-core.mjs";
+import {
+  probeWebsiteProjectionRuntimeCredential,
+  rotateWebsiteProjectionRuntimeCredential,
+} from "./website-projection-db-credential-rotation-postgres.mjs";
+
+const run = promisify(execFile);
+const workspace = fileURLToPath(new URL("../", import.meta.url));
+const HELP = `Usage:
+  node scripts/website-projection-db-credential-rotation.mjs preflight \\
+    --expected-project-ref ${WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF} \\
+    --plan /secure/reviewed-website-projection-plan.json
+
+  node scripts/website-projection-db-credential-rotation.mjs rotate \\
+    --expected-project-ref ${WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF} \\
+    --plan /secure/reviewed-website-projection-plan.json \\
+    --password-file /secure/new-runtime-password \\
+    --output-directory /secure/website-projection-runtime-v1 \\
+    --confirm-rotate '${WEBSITE_PROJECTION_ROTATION_CONFIRMATION}' \\
+    --confirm-no-overlap '${WEBSITE_PROJECTION_NO_OVERLAP_CONFIRMATION}'
+
+Use exactly one of --password-file FILE or --password-stdin yes. A password file
+must be an owner-only regular file with mode 0600. Stdin must be a non-TTY pipe.
+The output directory must not exist; its parent must be owner-only mode 0700.
+Both protected paths must resolve outside the Git checkout.
+The reviewed migration plan must also be an outside-checkout 0600 regular file.
+
+The authenticated migration authority remains PROGRAMMABLE_MIGRATOR_DATABASE_URL.
+The provider CA remains PROGRAMMABLE_POSTGRES_SSL_CA_PEM. Neither is accepted on
+the command line. No command changes Vercel or generates a password.
+`;
+
+function parseArguments(argv) {
+  const [command, ...rest] = argv;
+  if (!command || command === "help" || command === "--help") {
+    return { command: "help", flags: new Map() };
+  }
+  const flags = new Map();
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (!flag?.startsWith("--") || value === undefined
+      || value.startsWith("--") || flags.has(flag)) {
+      throw new Error("rotation operator arguments are invalid");
+    }
+    flags.set(flag, value);
+  }
+  return { command, flags };
+}
+
+function exactFlags(flags, allowed) {
+  for (const name of flags.keys()) {
+    if (!allowed.includes(name)) {
+      throw new Error("rotation operator argument is not allowed");
+    }
+  }
+}
+
+async function gitObject(expression) {
+  const { stdout } = await run("git", ["rev-parse", expression], {
+    cwd: workspace,
+  });
+  return stdout.trim();
+}
+
+async function exactCheckoutIdentity() {
+  const [{ stdout: status }, commit, tree, parent] = await Promise.all([
+    run("git", ["status", "--porcelain=v1", "--untracked-files=all"], {
+      cwd: workspace,
+    }),
+    gitObject("HEAD"),
+    gitObject("HEAD^{tree}"),
+    gitObject("HEAD^"),
+  ]);
+  if (status.trim() !== ""
+    || !/^[0-9a-f]{40}$/u.test(commit)
+    || !/^[0-9a-f]{40}$/u.test(tree)
+    || !/^[0-9a-f]{40}$/u.test(parent)) {
+    throw new Error("rotation operator requires an exact clean reviewed commit");
+  }
+  return Object.freeze({ commit, tree, parent });
+}
+
+function permissionMode(metadata) {
+  return metadata.mode & 0o777;
+}
+
+function assertCurrentOwner(metadata, label) {
+  if (typeof process.geteuid === "function" && metadata.uid !== process.geteuid()) {
+    throw new Error(`${label} must be owned by the operator user`);
+  }
+}
+
+function isInsideWorkspace(candidate) {
+  const relative = path.relative(workspace, candidate);
+  return relative === ""
+    || (!relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+async function readProtectedPasswordFile(filePath) {
+  if (!path.isAbsolute(filePath ?? "")) {
+    throw new Error("rotation password file path must be absolute");
+  }
+  const fileReal = await realpath(filePath);
+  if (fileReal !== filePath || isInsideWorkspace(fileReal)) {
+    throw new Error("rotation password file must be a bounded owner-only regular file");
+  }
+  let handle;
+  try {
+    handle = await open(
+      filePath,
+      fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0),
+    );
+    const metadata = await handle.stat();
+    assertCurrentOwner(metadata, "rotation password file");
+    if (!metadata.isFile()
+      || permissionMode(metadata) !== 0o600
+      || metadata.size < 24 || metadata.size > 512) {
+      throw new Error("rotation password file must be a bounded owner-only regular file");
+    }
+    return validateWebsiteProjectionRotationPassword(
+      await handle.readFile({ encoding: "utf8" }),
+    );
+  } finally {
+    await handle?.close();
+  }
+}
+
+async function readReviewedPlan(planPath, source) {
+  if (!path.isAbsolute(planPath ?? "")) {
+    throw new Error("reviewed rotation plan path must be absolute");
+  }
+  const planReal = await realpath(planPath);
+  if (planReal !== planPath || isInsideWorkspace(planReal)) {
+    throw new Error("reviewed rotation plan must be a protected regular file");
+  }
+  let handle;
+  let reviewedPlan;
+  try {
+    handle = await open(
+      planPath,
+      fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0),
+    );
+    const metadata = await handle.stat();
+    assertCurrentOwner(metadata, "reviewed rotation plan");
+    if (!metadata.isFile()
+      || permissionMode(metadata) !== 0o600
+      || metadata.size < 1 || metadata.size > 131_072) {
+      throw new Error("reviewed rotation plan must be a protected regular file");
+    }
+    reviewedPlan = validateWebsiteProjectionPlan(
+      JSON.parse(await handle.readFile({ encoding: "utf8" })),
+    );
+  } finally {
+    await handle?.close();
+  }
+  const currentPlan = await discoverWebsiteProjectionPlan({
+    workspace,
+    repositoryCommit: source.commit,
+    repositoryTree: source.tree,
+  });
+  return assertWebsiteProjectionRotationSourcePlan({
+    reviewedPlan,
+    currentPlan,
+  });
+}
+
+async function readProtectedPasswordStdin() {
+  if (process.stdin.isTTY) {
+    throw new Error("rotation password stdin must be a non-TTY pipe");
+  }
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of process.stdin) {
+    bytes += chunk.length;
+    if (bytes > 514) {
+      throw new Error("rotation password stdin is too large");
+    }
+    chunks.push(chunk);
+  }
+  let value = Buffer.concat(chunks).toString("utf8");
+  if (value.endsWith("\r\n")) value = value.slice(0, -2);
+  else if (value.endsWith("\n")) value = value.slice(0, -1);
+  return validateWebsiteProjectionRotationPassword(value);
+}
+
+async function readRotationPassword(flags) {
+  const passwordFile = flags.get("--password-file");
+  const passwordStdin = flags.get("--password-stdin");
+  if ((passwordFile === undefined) === (passwordStdin === undefined)
+    || (passwordStdin !== undefined && passwordStdin !== "yes")) {
+    throw new Error("rotation requires exactly one protected password input");
+  }
+  return passwordFile === undefined
+    ? await readProtectedPasswordStdin()
+    : await readProtectedPasswordFile(passwordFile);
+}
+
+async function prepareProtectedOutputDirectory(outputDirectory) {
+  if (!path.isAbsolute(outputDirectory ?? "")) {
+    throw new Error("rotation output directory path must be absolute");
+  }
+  const parent = path.dirname(outputDirectory);
+  const parentReal = await realpath(parent);
+  if (parentReal !== parent || isInsideWorkspace(parentReal)) {
+    throw new Error("rotation output parent must be an exact real path");
+  }
+  const parentMetadata = await lstat(parent);
+  assertCurrentOwner(parentMetadata, "rotation output parent");
+  if (!parentMetadata.isDirectory() || parentMetadata.isSymbolicLink()
+    || permissionMode(parentMetadata) !== 0o700) {
+    throw new Error("rotation output parent must be an owner-only directory");
+  }
+  try {
+    await lstat(outputDirectory);
+    throw new Error("rotation output directory already exists");
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  const stage = path.join(
+    parent,
+    `.${path.basename(outputDirectory)}.stage-${randomUUID()}`,
+  );
+  await mkdir(stage, { mode: 0o700 });
+  const stageMetadata = await lstat(stage);
+  if (!stageMetadata.isDirectory() || permissionMode(stageMetadata) !== 0o700) {
+    throw new Error("rotation staging directory is not protected");
+  }
+  return Object.freeze({ final: outputDirectory, stage });
+}
+
+async function writeProtectedFile(directory, name, value) {
+  const target = path.join(directory, name);
+  await writeFile(target, value, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  const metadata = await lstat(target);
+  assertCurrentOwner(metadata, "rotation output file");
+  if (!metadata.isFile() || metadata.isSymbolicLink()
+    || permissionMode(metadata) !== 0o600) {
+    throw new Error("rotation output file is not protected");
+  }
+}
+
+function secretValues(runtimePassword, runtimeDatabaseUrl) {
+  return [
+    runtimePassword,
+    runtimeDatabaseUrl,
+    process.env.PROGRAMMABLE_MIGRATOR_DATABASE_URL,
+  ].filter(Boolean);
+}
+
+async function writeStdout(value, secrets) {
+  assertNoSecretOutput(value, secrets);
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function withAuthority(expectedProjectRef, callback) {
+  const connection = await openHostedDatabase({
+    databaseUrl: process.env.PROGRAMMABLE_MIGRATOR_DATABASE_URL,
+    expectedProjectRef,
+    sslCaPem: process.env.PROGRAMMABLE_POSTGRES_SSL_CA_PEM,
+  });
+  try {
+    return await callback(connection);
+  } finally {
+    await closeHostedDatabase(connection.sql);
+  }
+}
+
+async function preflight(flags) {
+  exactFlags(flags, ["--expected-project-ref", "--plan"]);
+  const expectedProjectRef = flags.get("--expected-project-ref");
+  if (expectedProjectRef !== WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF) {
+    throw new Error("preflight target must be the exact production project");
+  }
+  const source = await exactCheckoutIdentity();
+  const plan = await readReviewedPlan(flags.get("--plan"), source);
+  const result = await withAuthority(expectedProjectRef, async (connection) => ({
+    schemaVersion:
+      "programmable.website-projection-runtime-credential-rotation-preflight.v1",
+    changed: false,
+    source,
+    target: connection.target,
+    operatorIdentity: connection.operatorIdentity,
+    posture: await inspectWebsiteProjectionCurrentRotationPosture({
+      sql: connection.sql,
+      plan,
+      expectedProjectRef,
+      sessionIdentity: connection.sessionIdentity,
+    }),
+  }));
+  await writeStdout(result, [process.env.PROGRAMMABLE_MIGRATOR_DATABASE_URL]);
+}
+
+async function rotate(flags) {
+  exactFlags(flags, [
+    "--expected-project-ref",
+    "--plan",
+    "--password-file",
+    "--password-stdin",
+    "--output-directory",
+    "--confirm-rotate",
+    "--confirm-no-overlap",
+  ]);
+  const expectedProjectRef = flags.get("--expected-project-ref");
+  assertWebsiteProjectionRotationConfirmation({
+    expectedProjectRef,
+    confirmRotate: flags.get("--confirm-rotate"),
+    confirmNoOverlap: flags.get("--confirm-no-overlap"),
+  });
+  const source = await exactCheckoutIdentity();
+  const plan = await readReviewedPlan(flags.get("--plan"), source);
+  const runtimePassword = await readRotationPassword(flags);
+  const runtimeDatabaseUrl = buildWebsiteProjectionRuntimeDatabaseUrl(
+    runtimePassword,
+    { projectRef: expectedProjectRef },
+  );
+  const output = await prepareProtectedOutputDirectory(
+    flags.get("--output-directory"),
+  );
+  const secrets = secretValues(runtimePassword, runtimeDatabaseUrl);
+  let published = false;
+  let credentialCommitted = false;
+  try {
+    await writeProtectedFile(
+      output.stage,
+      WEBSITE_PROJECTION_RUNTIME_DATABASE_URL_LEAF,
+      runtimeDatabaseUrl,
+    );
+    await writeProtectedFile(
+      output.stage,
+      WEBSITE_PROJECTION_RUNTIME_DATABASE_ROLE_LEAF,
+      WEBSITE_PROJECTION_RUNTIME_ROLE,
+    );
+    await writeProtectedFile(
+      output.stage,
+      WEBSITE_PROJECTION_RUNTIME_DATABASE_CA_PEM_LEAF,
+      process.env.PROGRAMMABLE_POSTGRES_SSL_CA_PEM,
+    );
+    const receipt = await withAuthority(expectedProjectRef, async (connection) => {
+      const rotation = await rotateWebsiteProjectionRuntimeCredential({
+        sql: connection.sql,
+        plan,
+        expectedProjectRef,
+        sessionIdentity: connection.sessionIdentity,
+        runtimePassword,
+      });
+      credentialCommitted = true;
+      const runtime = await probeWebsiteProjectionRuntimeCredential({
+        databaseUrl: runtimeDatabaseUrl,
+        expectedProjectRef,
+        sslCaPem: process.env.PROGRAMMABLE_POSTGRES_SSL_CA_PEM,
+      });
+      return buildWebsiteProjectionRotationReceipt({
+        sourceCommit: source.commit,
+        sourceTree: source.tree,
+        sourceParent: source.parent,
+        target: connection.target,
+        migrationEvidence: rotation.before.migrationEvidence,
+        preRotationCatalogSha256: rotation.before.catalogSha256,
+        postRotationCatalogSha256: rotation.after.catalogSha256,
+        runtimeProbe: runtime.attestation,
+        caPem: process.env.PROGRAMMABLE_POSTGRES_SSL_CA_PEM,
+        outputFiles: {
+          databaseUrl: WEBSITE_PROJECTION_RUNTIME_DATABASE_URL_LEAF,
+          databaseRole: WEBSITE_PROJECTION_RUNTIME_DATABASE_ROLE_LEAF,
+          databaseCaPem: WEBSITE_PROJECTION_RUNTIME_DATABASE_CA_PEM_LEAF,
+          receipt: WEBSITE_PROJECTION_ROTATION_RECEIPT_LEAF,
+        },
+        rotatedAt: new Date().toISOString(),
+      });
+    });
+    assertNoSecretOutput(receipt, secrets);
+    await writeProtectedFile(
+      output.stage,
+      WEBSITE_PROJECTION_ROTATION_RECEIPT_LEAF,
+      `${JSON.stringify(receipt, null, 2)}\n`,
+    );
+    await rename(output.stage, output.final);
+    published = true;
+    await writeStdout(receipt, secrets);
+  } catch (error) {
+    if (credentialCommitted && error?.code !== "WPR01") {
+      const postCommitFailure = new Error(
+        "website projection rotation failed after credential commit",
+        { cause: error },
+      );
+      postCommitFailure.code = "WPR01";
+      throw postCommitFailure;
+    }
+    throw error;
+  } finally {
+    if (!published) {
+      await rm(output.stage, { recursive: true, force: true });
+    }
+  }
+}
+
+async function main() {
+  const { command, flags } = parseArguments(process.argv.slice(2));
+  if (command === "help") {
+    process.stdout.write(HELP);
+    return;
+  }
+  if (command === "preflight") return await preflight(flags);
+  if (command === "rotate") return await rotate(flags);
+  throw new Error("unknown rotation operator command");
+}
+
+main().catch((error) => {
+  process.stderr.write(`${safeFailure(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/website-projection-db-credential-rotation.test.mjs
+++ b/scripts/website-projection-db-credential-rotation.test.mjs
@@ -1,0 +1,369 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { PGlite } from "@electric-sql/pglite";
+
+import {
+  assertWebsiteProjectionRotationConfirmation,
+  assertWebsiteProjectionRotationSourcePlan,
+  assertWebsiteProjectionRuntimeCredentialProbe,
+  buildWebsiteProjectionRotationReceipt,
+  buildWebsiteProjectionRuntimeDatabaseUrl,
+  validateWebsiteProjectionRotationPassword,
+  validateWebsiteProjectionRuntimeDatabaseUrl,
+  WEBSITE_PROJECTION_NO_OVERLAP_CONFIRMATION,
+  WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+  WEBSITE_PROJECTION_ROTATION_RECEIPT_LEAF,
+  WEBSITE_PROJECTION_ROTATION_RECEIPT_SCHEMA,
+  WEBSITE_PROJECTION_ROTATION_CONFIRMATION,
+  WEBSITE_PROJECTION_RUNTIME_DATABASE_CA_PEM_LEAF,
+  WEBSITE_PROJECTION_RUNTIME_DATABASE_ROLE_LEAF,
+  WEBSITE_PROJECTION_RUNTIME_DATABASE_URL_LEAF,
+} from "./website-projection-db-credential-rotation-core.mjs";
+import {
+  probeWebsiteProjectionRuntimeCredential,
+  rotateWebsiteProjectionRuntimeCredential,
+  setWebsiteProjectionRuntimePassword,
+} from "./website-projection-db-credential-rotation-postgres.mjs";
+import {
+  discoverWebsiteProjectionPlan,
+} from "./website-projection-db-operator-core.mjs";
+
+const PASSWORD = "correct horse battery staple rotation 2026";
+const CA = `-----BEGIN CERTIFICATE-----
+${"A".repeat(80)}
+-----END CERTIFICATE-----`;
+const OID = "a".repeat(40);
+const DIGEST = `0x${"b".repeat(64)}`;
+const WORKSPACE = fileURLToPath(new URL("../", import.meta.url));
+const FILES = [
+  "0001_projection_records_v1.sql",
+  "0002_custom_launch_wallet_profile_v2.sql",
+  "0003_registry_custom_public_read_v1.sql",
+  "0004_approval_v3_artifacts_v1.sql",
+  "0005_generic_launch_materializations_v2.sql",
+];
+const BACKEND_HANDOFF_CONTRACT = path.join(
+  WORKSPACE,
+  "docs/operations/WEBSITE-PROJECTION-DATABASE-BACKEND-HANDOFF-V1.json",
+);
+
+function probeRow(overrides = {}) {
+  return {
+    runtime_role: "programmable_website_projection_runtime",
+    session_role: "programmable_website_projection_runtime",
+    database_name: "postgres",
+    server_version_num: "170000",
+    rolsuper: false,
+    rolinherit: false,
+    rolcreaterole: false,
+    rolcreatedb: false,
+    rolreplication: false,
+    rolbypassrls: false,
+    schema_usage: true,
+    schema_create: false,
+    required_runtime_privileges: true,
+    forbidden_runtime_privileges: false,
+    owns_application_objects: false,
+    has_forbidden_membership: false,
+    ssl: true,
+    ssl_version: "TLSv1.3",
+    ssl_cipher: "TLS_AES_256_GCM_SHA384",
+    ssl_bits: 256,
+    ...overrides,
+  };
+}
+
+test("rotation accepts only the exact project and explicit no-overlap cutover", () => {
+  assert.doesNotThrow(() => assertWebsiteProjectionRotationConfirmation({
+    expectedProjectRef: WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+    confirmRotate: WEBSITE_PROJECTION_ROTATION_CONFIRMATION,
+    confirmNoOverlap: WEBSITE_PROJECTION_NO_OVERLAP_CONFIRMATION,
+  }));
+  assert.throws(() => assertWebsiteProjectionRotationConfirmation({
+    expectedProjectRef: WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+    confirmRotate: WEBSITE_PROJECTION_ROTATION_CONFIRMATION,
+    confirmNoOverlap: "assume-overlap",
+  }), /single-password/u);
+  assert.throws(() => assertWebsiteProjectionRotationConfirmation({
+    expectedProjectRef: "z".repeat(20),
+    confirmRotate: WEBSITE_PROJECTION_ROTATION_CONFIRMATION,
+    confirmNoOverlap: WEBSITE_PROJECTION_NO_OVERLAP_CONFIRMATION,
+  }), /exact production/u);
+});
+
+test("password stays bounded and the materialized URL is the exact TLS-owned pooler target", () => {
+  assert.equal(validateWebsiteProjectionRotationPassword(PASSWORD), PASSWORD);
+  for (const value of ["short", `valid long password${String.fromCharCode(10)}invalid`]) {
+    assert.throws(() => validateWebsiteProjectionRotationPassword(value), /invalid/u);
+  }
+  const databaseUrl = buildWebsiteProjectionRuntimeDatabaseUrl(
+    `${PASSWORD} /?#%`,
+  );
+  assert.ok(databaseUrl.includes("%20%2F%3F%23%"));
+  assert.deepEqual(validateWebsiteProjectionRuntimeDatabaseUrl(databaseUrl), {
+    projectRef: WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+    host: "aws-0-eu-central-1.pooler.supabase.com",
+    port: 6543,
+    database: "postgres",
+    loginRole:
+      `programmable_website_projection_runtime.${WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF}`,
+    effectiveRole: "programmable_website_projection_runtime",
+    tlsMode: "verify-full-equivalent",
+  });
+  assert.throws(() => validateWebsiteProjectionRuntimeDatabaseUrl(
+    `${databaseUrl}?sslmode=disable`,
+  ), /exact production pooler/u);
+});
+
+test("rotation binds the reviewed plan to the current migration byte closure", async (t) => {
+  const reviewedPlan = await discoverWebsiteProjectionPlan({
+    workspace: WORKSPACE,
+    repositoryCommit: OID,
+    repositoryTree: OID,
+  });
+  const currentPlan = await discoverWebsiteProjectionPlan({
+    workspace: WORKSPACE,
+    repositoryCommit: "c".repeat(40),
+    repositoryTree: "d".repeat(40),
+  });
+  assert.equal(assertWebsiteProjectionRotationSourcePlan({
+    reviewedPlan,
+    currentPlan,
+  }), reviewedPlan);
+
+  const driftWorkspace = await mkdtemp(
+    path.join(os.tmpdir(), "website-projection-rotation-plan-test-"),
+  );
+  t.after(() => rm(driftWorkspace, { recursive: true, force: true }));
+  const migrationRoot = path.join(
+    driftWorkspace,
+    "ops/website-projection-target/migrations",
+  );
+  await mkdir(migrationRoot, { recursive: true });
+  for (const [index, fileName] of FILES.entries()) {
+    const source = await readFile(path.join(
+      WORKSPACE,
+      "ops/website-projection-target/migrations",
+      fileName,
+    ), "utf8");
+    await writeFile(
+      path.join(migrationRoot, fileName),
+      index === 4
+        ? source.replace(/\nCOMMIT;\s*$/u, "\n-- reviewed-byte-drift\nCOMMIT;\n")
+        : source,
+    );
+  }
+  const driftPlan = await discoverWebsiteProjectionPlan({
+    workspace: driftWorkspace,
+    repositoryCommit: "e".repeat(40),
+    repositoryTree: "f".repeat(40),
+  });
+  assert.throws(() => assertWebsiteProjectionRotationSourcePlan({
+    reviewedPlan,
+    currentPlan: driftPlan,
+  }), /differs from the current migration closure/u);
+});
+
+test("ALTER ROLE password is transaction-safe and does not retain the plaintext GUC", async (t) => {
+  const database = new PGlite();
+  t.after(() => database.close());
+  await database.exec(`
+    CREATE ROLE programmable_website_projection_runtime WITH
+      LOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE
+      NOREPLICATION NOBYPASSRLS PASSWORD 'old protected password value 2026';
+  `);
+  const before = await storedPassword(database);
+  await assert.rejects(database.transaction(async (transaction) => {
+    await setWebsiteProjectionRuntimePassword(pgliteSql(transaction), PASSWORD);
+    throw new Error("injected rollback");
+  }), /injected rollback/u);
+  assert.equal(await storedPassword(database), before);
+
+  await database.transaction(async (transaction) => {
+    await setWebsiteProjectionRuntimePassword(pgliteSql(transaction), PASSWORD);
+  });
+  assert.notEqual(await storedPassword(database), before);
+  const [{ value }] = (await database.query(`
+    SELECT pg_catalog.current_setting(
+      'programmable.website_projection_runtime_rotation_password', true
+    ) AS value
+  `)).rows;
+  assert.ok(value === null || value === "");
+});
+
+test("lost credential commit acknowledgement fails closed as WPR01", async () => {
+  const posture = Object.freeze({
+    migrationEvidence: Object.freeze({ migrationCount: 5 }),
+    catalogSha256: DIGEST,
+    operatorCatalogSha256: DIGEST,
+    runtimeRoleStatus: "current",
+  });
+  const sessionIdentity = Object.freeze({
+    backendPid: 731,
+    sessionUser: "cli_login_postgres",
+    currentRole: "postgres",
+  });
+  const commitAcknowledgementLost = new Error("connection closed after commit");
+  const sql = {
+    unsafe(statement) {
+      if (statement.includes("credential-rotation-lock")) {
+        return pending([{
+          acquired: true,
+          backend_pid: 731,
+          session_user: "cli_login_postgres",
+          current_role: "postgres",
+        }]);
+      }
+      if (statement.includes("credential-rotation-unlock")) {
+        return pending([{
+          released: true,
+          backend_pid: 731,
+          session_user: "cli_login_postgres",
+          current_role: "postgres",
+        }]);
+      }
+      throw new Error("unexpected fake rotation statement");
+    },
+    async begin(callback) {
+      await callback({
+        unsafe() {
+          return pending([]);
+        },
+      });
+      throw commitAcknowledgementLost;
+    },
+  };
+  await assert.rejects(
+    rotateWebsiteProjectionRuntimeCredential({
+      sql,
+      plan: {},
+      expectedProjectRef: WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+      sessionIdentity,
+      runtimePassword: PASSWORD,
+    }, {
+      postureInspector: async () => posture,
+      passwordSetter: async () => {},
+    }),
+    (error) => error?.code === "WPR01"
+      && error.cause === commitAcknowledgementLost,
+  );
+});
+
+test("runtime credential probe binds hostname verification and least privilege", async () => {
+  const databaseUrl = buildWebsiteProjectionRuntimeDatabaseUrl(PASSWORD);
+  let observedConfiguration;
+  class FakePool {
+    constructor(configuration) {
+      observedConfiguration = configuration;
+    }
+
+    async query() {
+      return { rows: [probeRow()] };
+    }
+
+    async end() {}
+  }
+  const result = await probeWebsiteProjectionRuntimeCredential({
+    databaseUrl,
+    expectedProjectRef: WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+    sslCaPem: CA,
+  }, { PoolClass: FakePool });
+  assert.equal(observedConfiguration.ssl.servername,
+    "aws-0-eu-central-1.pooler.supabase.com");
+  assert.equal(observedConfiguration.ssl.rejectUnauthorized, true);
+  assert.equal(result.attestation.leastPrivilege, true);
+  assert.throws(() => assertWebsiteProjectionRuntimeCredentialProbe(
+    probeRow({ forbidden_runtime_privileges: true }),
+  ), /probe failed/u);
+});
+
+test("receipt is secret-free and records single-password forward recovery", () => {
+  const receipt = buildWebsiteProjectionRotationReceipt({
+    sourceCommit: OID,
+    sourceTree: OID,
+    sourceParent: OID,
+    target: {
+      projectRef: WEBSITE_PROJECTION_PRODUCTION_PROJECT_REF,
+      database: "postgres",
+    },
+    migrationEvidence: {
+      migrationCount: 5,
+      planSha256: DIGEST,
+      repositoryCommit: OID,
+      repositoryTree: OID,
+      catalogSha256: DIGEST,
+      operatorCatalogSha256: DIGEST,
+    },
+    preRotationCatalogSha256: DIGEST,
+    postRotationCatalogSha256: DIGEST,
+    runtimeProbe: assertWebsiteProjectionRuntimeCredentialProbe(probeRow()),
+    caPem: CA,
+    outputFiles: {
+      databaseUrl: WEBSITE_PROJECTION_RUNTIME_DATABASE_URL_LEAF,
+      databaseRole: WEBSITE_PROJECTION_RUNTIME_DATABASE_ROLE_LEAF,
+      databaseCaPem: WEBSITE_PROJECTION_RUNTIME_DATABASE_CA_PEM_LEAF,
+      receipt: WEBSITE_PROJECTION_ROTATION_RECEIPT_LEAF,
+    },
+    rotatedAt: "2026-08-20T12:00:00.000Z",
+  });
+  const serialized = JSON.stringify(receipt);
+  assert.equal(serialized.includes(PASSWORD), false);
+  assert.equal(receipt.schemaVersion, WEBSITE_PROJECTION_ROTATION_RECEIPT_SCHEMA);
+  assert.equal(receipt.protectedOutputs.databaseRole,
+    WEBSITE_PROJECTION_RUNTIME_DATABASE_ROLE_LEAF);
+  assert.equal(receipt.cutover.overlappingPasswordsSupported, false);
+  assert.equal(receipt.cutover.vercelMutationPerformed, false);
+  assert.equal(receipt.protectedOutputs.containsSecretDerivedDigest, false);
+});
+
+test("machine-readable Backend handoff binds exact leaves and digest boundary", async () => {
+  const contract = JSON.parse(await readFile(BACKEND_HANDOFF_CONTRACT, "utf8"));
+  assert.equal(contract.websiteReceipt.schemaVersion,
+    WEBSITE_PROJECTION_ROTATION_RECEIPT_SCHEMA);
+  assert.deepEqual(
+    contract.protectedOutputs.map(({ filename }) => filename),
+    [
+      WEBSITE_PROJECTION_RUNTIME_DATABASE_URL_LEAF,
+      WEBSITE_PROJECTION_RUNTIME_DATABASE_ROLE_LEAF,
+      WEBSITE_PROJECTION_RUNTIME_DATABASE_CA_PEM_LEAF,
+    ],
+  );
+  assert.equal(contract.protectedOutputs[0].digest.websiteReceipt, "forbidden");
+  assert.equal(contract.protectedOutputs[0].digest.backendCasReceipt, "required");
+  assert.equal(contract.backendMaterializer.plaintextReceiptAllowed, false);
+  assert.equal(contract.websiteSourceIdentity.embeddedInSource, false);
+});
+
+function pgliteSql(client) {
+  return {
+    unsafe(statement, parameters = []) {
+      const normalized = statement.trimStart().toLowerCase();
+      const operation = (parameters.length > 0 || normalized.startsWith("select"))
+        ? client.query(statement, parameters).then(({ rows }) => rows)
+        : client.exec(statement).then((results) => results.at(-1)?.rows ?? []);
+      operation.simple = () => operation;
+      return operation;
+    },
+  };
+}
+
+function pending(value) {
+  const operation = Promise.resolve(value);
+  operation.simple = () => operation;
+  return operation;
+}
+
+async function storedPassword(database) {
+  const [{ rolpassword }] = (await database.query(`
+    SELECT rolpassword
+      FROM pg_catalog.pg_authid
+     WHERE rolname = 'programmable_website_projection_runtime'
+  `)).rows;
+  assert.equal(typeof rolpassword, "string");
+  return rolpassword;
+}

--- a/scripts/website-projection-db-postgres.mjs
+++ b/scripts/website-projection-db-postgres.mjs
@@ -1421,6 +1421,58 @@ export async function inspectWebsiteProjectionDatabase({
   });
 }
 
+export async function inspectWebsiteProjectionCurrentRotationPosture({
+  sql,
+  plan,
+  expectedProjectRef,
+  sessionIdentity,
+}) {
+  validateWebsiteProjectionPlan(plan);
+  const session = expectedSession(sessionIdentity);
+  await assertSession(sql, session);
+  const remote = await readPresenceAndEvidence(sql);
+  const state = compareWebsiteProjectionEvidence({
+    plan,
+    expectedProjectRef,
+    evidenceTablePresent: remote.evidenceTablePresent,
+    applicationSchemaPresent: remote.applicationSchemaPresent,
+    evidenceRows: remote.evidenceRows,
+    adoptionRows: remote.adoptionRows,
+  });
+  const roleGraph = await readRoleGraph(
+    sql,
+    state.appliedCount,
+  );
+  const catalogSha256 = catalogSnapshotSha256(
+    await readApplicationCatalogSnapshot(sql, roleGraph),
+  );
+  const operatorCatalogSha256 = catalogSnapshotSha256(
+    await readEvidenceCatalogSnapshot(sql),
+  );
+  const latest = remote.evidenceRows.at(-1);
+  if (state.status !== "current"
+    || state.appliedCount !== plan.migrationCount
+    || catalogSha256 !== latest?.catalog_sha256
+    || operatorCatalogSha256 !== latest?.operator_catalog_sha256
+    || roleGraph.runtimeRoleStatus !== "current") {
+    throw new Error("website projection current rotation posture is invalid");
+  }
+  await assertSession(sql, session);
+  return Object.freeze({
+    migrationEvidence: Object.freeze({
+      migrationCount: state.appliedCount,
+      planSha256: plan.planSha256,
+      repositoryCommit: plan.repositoryCommit,
+      repositoryTree: plan.repositoryTree,
+      catalogSha256,
+      operatorCatalogSha256,
+    }),
+    catalogSha256,
+    operatorCatalogSha256,
+    runtimeRoleStatus: roleGraph.runtimeRoleStatus,
+  });
+}
+
 async function bootstrapRuntimeRole(transaction, runtimePassword) {
   const before = await readRoleGraph(transaction, 0);
   if (before.runtimeRoleStatus === "current") return false;


### PR DESCRIPTION
## Outcome

Adds a fail-closed, source-owned runtime credential rotation operator for the existing Website projection database role. It binds the reviewed migration posture, treats any lost commit acknowledgement as ambiguous, proves the new login before terminal success, and emits only digest-bound protected handoff metadata for Backend/Vercel.

## Exact source

- Current head: `fec98782757aa9b87760c9a5743c3f016208f0ab`
- Current tree: `0337d7a5bdda046cc4fa879283fd269068caa538`
- Current parent: `6895dcf863e8406d283aec700c705a37ff76a8a3`
- Operator implementation commit: `6895dcf863e8406d283aec700c705a37ff76a8a3`
- Operator implementation tree: `15d857a0965bd8d2a5e30ca00067f31201906177`
- Backend handoff contract blob: `37e52bd1a13d89e0a95bf7b30e2e1b365d9eddf1`

## Verification

- 46 focused operator tests pass
- Full `verify:custom-v2:ci` passes: lint, typecheck, 90 Node tests, 102 Vitest tests, production Next build and bundle scan
- Exact workflow-contract regression passes 9/9
- diff check passes
- independent P0/P1 review passes

No database, provider, Vercel environment, secret, deployment, or promotion mutation is performed by this PR.