### PR TITLE
Fix provider-bounded creator claim reads

### DIFF
--- a/app/api/explore/profile/route.ts
+++ b/app/api/explore/profile/route.ts
@@ -39,6 +39,7 @@ export const runtime = "nodejs";
 
 const CONFIRMATIONS = 12n;
 const LOG_RANGE = 10_000n;
+const LOG_RANGE_CONCURRENCY = 2;
 const TOTAL_SUPPLY_RAW = "1000000000000000000000000000";
 
 type Release = Readonly<{
@@ -127,6 +128,28 @@ function minimum(left: bigint, right: bigint) {
   return left < right ? left : right;
 }
 
+async function readBoundedLogRanges<Log>(
+  fromBlock: bigint,
+  toBlock: bigint,
+  readRange: (fromBlock: bigint, toBlock: bigint) => Promise<readonly Log[]>,
+) {
+  const ranges: Array<readonly [bigint, bigint]> = [];
+  for (let start = fromBlock; start <= toBlock; start += LOG_RANGE) {
+    ranges.push([start, minimum(toBlock, start + LOG_RANGE - 1n)]);
+  }
+  const results: Log[][] = Array.from({ length: ranges.length }, () => []);
+  let nextRange = 0;
+  const workerCount = Math.min(LOG_RANGE_CONCURRENCY, ranges.length);
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (nextRange < ranges.length) {
+      const index = nextRange++;
+      const range = ranges[index]!;
+      results[index] = [...await readRange(range[0], range[1])];
+    }
+  }));
+  return results.flat();
+}
+
 async function assertRuntime(
   client: PublicClient,
   address: Address,
@@ -149,49 +172,47 @@ async function readLaunches(
   toBlock: bigint,
 ) {
   const launches: ProfileLaunch[] = [];
-  for (
-    let fromBlock = release.startBlock;
-    fromBlock <= toBlock;
-    fromBlock += LOG_RANGE
-  ) {
-    const logs = await client.getLogs({
+  const logs = await readBoundedLogRanges(
+    release.startBlock,
+    toBlock,
+    (fromBlock, rangeToBlock) => client.getLogs({
       address: release.launcher,
       event: memeTokenLaunchedEvent,
       args: { creator: account },
       fromBlock,
-      toBlock: minimum(toBlock, fromBlock + LOG_RANGE - 1n),
+      toBlock: rangeToBlock,
       strict: true,
-    });
-    for (const log of logs) {
-      if (log.removed) continue;
-      if (
-        log.blockNumber === null ||
-        log.transactionHash === null || log.transactionIndex === null ||
-        log.logIndex === null
-      ) {
-        throw new Error("Creator launch identity is incomplete");
-      }
-      if (
-        log.args.creator.toLowerCase() !== account.toLowerCase() ||
-        log.args.feeHook.toLowerCase() !== release.hook.toLowerCase()
-      ) {
-        throw new Error("Creator launch identity does not match its manifest");
-      }
-      launches.push({
-        release,
-        creator: getAddress(log.args.creator),
-        token: getAddress(log.args.token),
-        poolId: log.args.poolId,
-        positionRecipient: getAddress(log.args.positionRecipient),
-        positionTokenId: log.args.positionTokenId,
-        totalSwapFeeBps: log.args.totalSwapFeeBps,
-        launchHash: log.args.launchHash,
-        blockNumber: log.blockNumber,
-        transactionHash: log.transactionHash,
-        transactionIndex: log.transactionIndex,
-        logIndex: log.logIndex,
-      });
+    }),
+  );
+  for (const log of logs) {
+    if (log.removed) continue;
+    if (
+      log.blockNumber === null ||
+      log.transactionHash === null || log.transactionIndex === null ||
+      log.logIndex === null
+    ) {
+      throw new Error("Creator launch identity is incomplete");
     }
+    if (
+      log.args.creator.toLowerCase() !== account.toLowerCase() ||
+      log.args.feeHook.toLowerCase() !== release.hook.toLowerCase()
+    ) {
+      throw new Error("Creator launch identity does not match its manifest");
+    }
+    launches.push({
+      release,
+      creator: getAddress(log.args.creator),
+      token: getAddress(log.args.token),
+      poolId: log.args.poolId,
+      positionRecipient: getAddress(log.args.positionRecipient),
+      positionTokenId: log.args.positionTokenId,
+      totalSwapFeeBps: log.args.totalSwapFeeBps,
+      launchHash: log.args.launchHash,
+      blockNumber: log.blockNumber,
+      transactionHash: log.transactionHash,
+      transactionIndex: log.transactionIndex,
+      logIndex: log.logIndex,
+    });
   }
   return launches;
 }
@@ -209,36 +230,34 @@ async function readClaims(
     launches.map((launch) => [launch.poolId.toLowerCase(), launch.token]),
   );
   const claims = [];
-  for (
-    let fromBlock = release.startBlock;
-    fromBlock <= toBlock;
-    fromBlock += LOG_RANGE
-  ) {
-    const logs = await client.getLogs({
+  const logs = await readBoundedLogRanges(
+    release.startBlock,
+    toBlock,
+    (fromBlock, rangeToBlock) => client.getLogs({
       address: release.hook,
       event: creatorFeesClaimedEvent,
       args: { poolId: poolIds, creator: account },
       fromBlock,
-      toBlock: minimum(toBlock, fromBlock + LOG_RANGE - 1n),
+      toBlock: rangeToBlock,
       strict: true,
-    });
-    for (const log of logs) {
-      if (log.removed) continue;
-      if (
-        log.blockNumber === null ||
-        log.transactionHash === null || log.transactionIndex === null ||
-        log.logIndex === null
-      ) {
-        throw new Error("Creator claim identity is incomplete");
-      }
-      if (
-        log.args.creator.toLowerCase() !== account.toLowerCase() ||
-        !tokenByPool.has(log.args.poolId.toLowerCase())
-      ) {
-        throw new Error("Creator claim is outside its verified profile");
-      }
-      claims.push({ log, token: tokenByPool.get(log.args.poolId.toLowerCase())! });
+    }),
+  );
+  for (const log of logs) {
+    if (log.removed) continue;
+    if (
+      log.blockNumber === null ||
+      log.transactionHash === null || log.transactionIndex === null ||
+      log.logIndex === null
+    ) {
+      throw new Error("Creator claim identity is incomplete");
     }
+    if (
+      log.args.creator.toLowerCase() !== account.toLowerCase() ||
+      !tokenByPool.has(log.args.poolId.toLowerCase())
+    ) {
+      throw new Error("Creator claim is outside its verified profile");
+    }
+    claims.push({ log, token: tokenByPool.get(log.args.poolId.toLowerCase())! });
   }
   return claims;
 }

--- a/lib/server/action-rpc-identity.server.ts
+++ b/lib/server/action-rpc-identity.server.ts
@@ -29,6 +29,7 @@ import { computeOfficialV4PoolId } from "../uniswap/liquidity-launcher-sdk";
 const ZERO_ADDRESS =
   "0x0000000000000000000000000000000000000000" as Address;
 const ZERO_HASH = `0x${"00".repeat(32)}` as Hex;
+const CREATOR_CLAIM_LOG_RANGE = 10_000n;
 
 const classicLauncherStateAbi = parseAbi([
   "function launchHashOf(address token) view returns (bytes32)",
@@ -417,14 +418,25 @@ export async function readCreatorClaimIdentityFromRpc(input: {
   poolId: Hex;
   blockNumber: bigint;
 }): Promise<CreatorClaimTokenIdentity> {
-  const logs = await input.client.getLogs({
-    address: input.deployment.launcher,
-    event: memeTokenLaunchedEvent,
-    args: { poolId: input.poolId },
-    fromBlock: input.deployment.deploymentBlock,
-    toBlock: input.blockNumber,
-    strict: true,
-  });
+  const logs = [];
+  for (
+    let fromBlock = input.deployment.deploymentBlock;
+    fromBlock <= input.blockNumber;
+    fromBlock += CREATOR_CLAIM_LOG_RANGE
+  ) {
+    const toBlock =
+      fromBlock + CREATOR_CLAIM_LOG_RANGE - 1n < input.blockNumber
+        ? fromBlock + CREATOR_CLAIM_LOG_RANGE - 1n
+        : input.blockNumber;
+    logs.push(...await input.client.getLogs({
+      address: input.deployment.launcher,
+      event: memeTokenLaunchedEvent,
+      args: { poolId: input.poolId },
+      fromBlock,
+      toBlock,
+      strict: true,
+    }));
+  }
   const matches = logs.filter(
     (log) => !log.removed && log.blockNumber !== null,
   );

--- a/tests/action-rpc-identity.test.ts
+++ b/tests/action-rpc-identity.test.ts
@@ -81,8 +81,7 @@ describe("single-RPC action identity", () => {
   });
 
   it("derives the fee creator from the launch event instead of token deployment authority", async () => {
-    const getLogs = vi.fn().mockResolvedValue([
-      {
+    const launchLog = {
         address: launcher,
         args: {
           creator,
@@ -99,8 +98,22 @@ describe("single-RPC action identity", () => {
         transactionIndex: 0,
         logIndex: 0,
         removed: false,
-      },
-    ]);
+      };
+    const getLogs = vi.fn(
+      ({ fromBlock, toBlock }: {
+        address: Address;
+        args: { poolId: Hex };
+        fromBlock: bigint;
+        toBlock: bigint;
+        strict: boolean;
+      }) =>
+        Promise.resolve(
+          fromBlock <= launchLog.blockNumber &&
+              launchLog.blockNumber <= toBlock
+            ? [launchLog]
+            : [],
+        ),
+    );
     const readContract = vi.fn(
       ({ functionName }: { functionName: string; blockNumber?: bigint }) => {
         if (functionName === "launchHashOf") return Promise.resolve(launchHash);
@@ -118,7 +131,7 @@ describe("single-RPC action identity", () => {
         client,
         deployment,
         poolId,
-        blockNumber: 100n,
+        blockNumber: 20_100n,
       }),
     ).resolves.toEqual({
       tokenAddress: token,
@@ -127,19 +140,24 @@ describe("single-RPC action identity", () => {
       creatorAddress: creator,
       totalSwapFeeBps: 100,
     });
-    expect(getLogs).toHaveBeenCalledTimes(1);
-    expect(getLogs).toHaveBeenCalledWith(
-      expect.objectContaining({
-        address: launcher,
-        args: { poolId },
-        fromBlock: 10n,
-        toBlock: 100n,
-        strict: true,
-      }),
-    );
+    expect(getLogs).toHaveBeenCalledTimes(3);
+    expect(getLogs.mock.calls.map(([call]) => [
+      call.fromBlock,
+      call.toBlock,
+    ])).toEqual([
+      [10n, 10_009n],
+      [10_010n, 20_009n],
+      [20_010n, 20_100n],
+    ]);
+    expect(getLogs.mock.calls.every(([call]) =>
+      call.address === launcher &&
+      call.args.poolId === poolId &&
+      call.strict === true &&
+      call.toBlock - call.fromBlock < 10_000n
+    )).toBe(true);
     expect(
       readContract.mock.calls.every(
-        ([call]) => call.blockNumber === 100n,
+        ([call]) => call.blockNumber === 20_100n,
       ),
     ).toBe(true);
     expect(readContract).toHaveBeenCalledTimes(3);
@@ -147,7 +165,7 @@ describe("single-RPC action identity", () => {
       expect.objectContaining({
         address: token,
         functionName: "creator",
-        blockNumber: 100n,
+        blockNumber: 20_100n,
       }),
     );
   });


### PR DESCRIPTION
## Outcome
- split creator claim identity logs into provider-safe 10,000-block windows
- preserve exact pool/launcher/event binding across every window
- run existing profile log windows with bounded concurrency so the fixed secondary finishes within the request budget

## Focused evidence
- `npx vitest run tests/action-rpc-identity.test.ts tests/creator-claim-action-activation.test.ts`
- changed-path ESLint
- `npx tsc --noEmit`
- `git diff --check`

No wallet transaction is signed or submitted.