### PR TITLE
Fix creator reward history and claim status UX

### DIFF
--- a/app/api/explore/profile/route.ts
+++ b/app/api/explore/profile/route.ts
@@ -31,6 +31,8 @@ import type {
   CanonicalTokenExploreEntry,
   LauncherToken,
 } from "@/lib/tokens";
+import { readEnvioClassicV2CreatorClaimsV1 } from
+  "@/lib/market-data/envio-classic-v2-creator-claims.server";
 import { readEnvioClassicV3CatalogV1 } from
   "@/lib/market-data/envio-classic-v3-catalog.server";
 
@@ -486,8 +488,9 @@ async function readEnvioCreatorProfile(
   const classicV2Tokens = tokens.filter(
     (token) => token.launchModelVersion === "classic-v2",
   );
-  const claimState = classicV2Tokens.length
-    ? await (async () => {
+  const [claimState, classicV2Claims] = await Promise.all([
+    classicV2Tokens.length
+      ? (async () => {
         const deployment = getWebsiteReadOnchainDeployment("production");
         if (deployment.status !== "ready") {
           throw new Error("Classic V2 creator rewards are not deployed");
@@ -553,12 +556,53 @@ async function readEnvioCreatorProfile(
           };
         });
       })()
-    : null;
+      : Promise.resolve(null),
+    classicV2Tokens.length
+      ? readEnvioClassicV2CreatorClaimsV1({
+          account,
+          poolIds: classicV2Tokens.map((token) => token.poolId),
+          throughBlock: catalog.asOfBlock,
+          signal,
+          deadlineMs: Date.now() + 5_000,
+        })
+      : Promise.resolve([]),
+  ]);
+  const claimedByPool = new Map<string, bigint>();
+  for (const claim of classicV2Claims) {
+    const key = claim.poolId.toLowerCase();
+    claimedByPool.set(
+      key,
+      (claimedByPool.get(key) ?? 0n) + BigInt(claim.amountWei),
+    );
+  }
+  const tokenByPool = new Map(
+    classicV2Tokens.map((token) => [token.poolId.toLowerCase(), token]),
+  );
+  const claims: CreatorClaim[] = classicV2Claims.map((claim) => {
+    const token = tokenByPool.get(claim.poolId.toLowerCase());
+    if (!token) throw new Error("Classic V2 claim token identity is unavailable");
+    return {
+      poolId: claim.poolId,
+      tokenAddress: token.tokenAddress,
+      creatorAddress: claim.creator,
+      recipientAddress: claim.recipient,
+      callerAddress: claim.caller,
+      amountWei: claim.amountWei,
+      amountEth: formatUnits(BigInt(claim.amountWei), 18),
+      blockNumber: claim.blockNumber,
+      transactionHash: claim.transactionHash,
+      transactionIndex: claim.transactionIndex,
+      logIndex: claim.logIndex,
+      claimedAt:
+        new Date(Number(claim.blockTimestamp) * 1_000).toISOString(),
+    };
+  });
   const pools = tokens.flatMap((token) =>
     typeof token.totalSwapFeeBps === "number"
       ? (() => {
           const claimable =
             claimState?.claimableByPool.get(token.poolId.toLowerCase()) ?? 0n;
+          const claimed = claimedByPool.get(token.poolId.toLowerCase()) ?? 0n;
           return [{
             tokenAddress: token.tokenAddress,
             name: token.name,
@@ -568,13 +612,15 @@ async function readEnvioCreatorProfile(
             launchModel: "classic" as const,
             claimableCreatorFeesWei: claimable.toString(),
             claimableCreatorFeesEth: formatUnits(claimable, 18),
-            generatedCreatorFeesWei: claimable.toString(),
-            generatedCreatorFeesEth: formatUnits(claimable, 18),
+            generatedCreatorFeesWei: (claimable + claimed).toString(),
+            generatedCreatorFeesEth: formatUnits(claimable + claimed, 18),
           }];
         })()
       : [],
   );
   const claimable = [...(claimState?.claimableByPool.values() ?? [])]
+    .reduce((sum, value) => sum + value, 0n);
+  const claimed = [...claimedByPool.values()]
     .reduce((sum, value) => sum + value, 0n);
   return {
     provider: claimState?.provider ?? "envio-indexer-state",
@@ -583,14 +629,14 @@ async function readEnvioCreatorProfile(
       account,
       tokens,
       pools,
-      claims: [],
+      claims,
       totals: {
         claimableWei: claimable.toString(),
         claimableEth: formatUnits(claimable, 18),
-        generatedWei: claimable.toString(),
-        generatedEth: formatUnits(claimable, 18),
-        claimedWei: "0",
-        claimedEth: "0",
+        generatedWei: (claimable + claimed).toString(),
+        generatedEth: formatUnits(claimable + claimed, 18),
+        claimedWei: claimed.toString(),
+        claimedEth: formatUnits(claimed, 18),
       },
       snapshot: claimState
         ? {

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -598,6 +598,32 @@
   margin: 0;
 }
 
+.claimPanelActions {
+  align-items: center;
+  display: flex;
+  gap: 5px;
+  margin-inline-start: auto;
+}
+
+.claimRefresh {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  color: var(--text-soft);
+  display: inline-flex;
+  font-size: 11px;
+  font-weight: 620;
+  gap: 6px;
+  min-height: 44px;
+  padding-inline: 10px;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease,
+    transform 120ms var(--ease-out);
+}
+
 .panelStatus {
   color: var(--muted);
   font-family: var(--font-instrument), Arial, sans-serif;
@@ -967,6 +993,16 @@
   white-space: nowrap;
 }
 
+.claimCopy small {
+  color: var(--text-soft);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .claimAmount {
   display: grid;
   justify-items: end;
@@ -1290,6 +1326,7 @@
   .editAction:hover,
   .secondaryAction:not(:disabled):hover,
   .retryButton:hover,
+  .claimRefresh:hover,
   .claimDialogClose:hover,
   .claimPagination button:not(:disabled):hover {
     background: color-mix(in srgb, var(--surface-soft) 90%, transparent);
@@ -1323,6 +1360,7 @@
 .claimButton:not(:disabled):active,
 .secondaryAction:not(:disabled):active,
 .retryButton:active,
+.claimRefresh:active,
 .claimDialogClose:active,
 .timeframeControls button:not(:disabled):active,
 .claimPagination button:not(:disabled):active {
@@ -1337,6 +1375,7 @@
 .claimButton:focus-visible,
 .secondaryAction:focus-visible,
 .retryButton:focus-visible,
+.claimRefresh:focus-visible,
 .claimDialogClose:focus-visible,
 .sourceWarning button:focus-visible,
 .claimIdentity:focus-visible,
@@ -1372,12 +1411,12 @@
   }
 
   .claimList {
-    flex: 1;
-    overflow-y: auto;
-    overscroll-behavior: contain;
-    padding-inline-end: 2px;
-    scrollbar-gutter: stable;
-    scrollbar-width: thin;
+    align-content: start;
+    flex: none;
+    grid-auto-rows: max-content;
+    overflow: visible;
+    padding-inline-end: 0;
+    scrollbar-gutter: auto;
   }
 
   .claimEmpty {
@@ -1491,6 +1530,16 @@
   .claimablePanel {
     border-radius: 15px;
     padding: 16px 12px;
+  }
+
+  .panelHeader {
+    flex-wrap: wrap;
+  }
+
+  .claimPanelActions {
+    justify-content: space-between;
+    margin-inline-start: 0;
+    width: 100%;
   }
 
   .feePanelHeader {
@@ -1967,12 +2016,20 @@
   padding: 0;
 }
 
-.feePanel,
-.claimablePanel {
+.feePanel {
   background: var(--webde-surface);
   border: 1px solid var(--webde-line);
   border-radius: var(--webde-radius-card);
   height: 360px !important;
+  min-height: 360px;
+  padding: 20px;
+}
+
+.claimablePanel {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  height: auto !important;
   min-height: 360px;
   padding: 20px;
 }
@@ -2045,7 +2102,12 @@
 }
 
 .claimList {
-  scrollbar-color: #474747 transparent;
+  align-content: start;
+  flex: none;
+  grid-auto-rows: max-content;
+  overflow: visible;
+  padding-inline-end: 0;
+  scrollbar-gutter: auto;
 }
 
 .claimRow {
@@ -2094,6 +2156,7 @@
   .editAction:hover,
   .secondaryAction:not(:disabled):hover,
   .retryButton:hover,
+  .claimRefresh:hover,
   .claimDialogClose:hover,
   .claimPagination button:not(:disabled):hover,
   .claimButton:not(:disabled):hover,

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -2,24 +2,23 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, X } from "lucide-react";
-import { formatUnits, parseUnits, type Hex } from "viem";
+import { ChevronLeft, ChevronRight, RefreshCw, X } from "lucide-react";
+import { formatUnits, type Hex } from "viem";
 import {
   useCallback,
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
   useSyncExternalStore,
   type ChangeEvent,
   type FormEvent,
-  type KeyboardEvent,
   type PointerEvent,
 } from "react";
 
 import { useWallet } from "@/components/wallet-provider";
 import { useLiveDataRefresh } from "@/components/use-live-data-refresh";
+import { formatMarketCapMetric } from "@/components/animated-market-cap";
 import { isConfiguredClassicV3ReleaseReady } from "@/lib/classic-v3-release";
 import {
   prepareAvatarImage,
@@ -83,7 +82,6 @@ import {
   ProfileResponseError,
   UNAVAILABLE_PROFILE_DATA,
   type ProfileClaim,
-  type ProfileActivity,
   type ProfileOnchainData,
   type ProfileToken,
 } from "@/lib/profile/onchain-profile";
@@ -248,17 +246,12 @@ export function resolveStockPairedReceiptGate(
   if (receiptStatus === "unavailable") {
     return {
       outcome: "hold",
-      message: "Status unavailable. Check the same transaction again",
+      message: "Confirming on Ethereum",
     };
   }
   return {
     outcome: "hold",
-    message:
-      pendingStage === "claim"
-        ? "Claim submitted. Check its status before converting"
-        : pendingStage === "swap"
-          ? "Conversion submitted. Check its status before showing it as complete"
-          : "Approval submitted. Check its status before continuing",
+    message: "Confirming on Ethereum",
   };
 }
 
@@ -396,7 +389,29 @@ const transactionCancelledInWallet = "Transaction cancelled in wallet";
 const creatorClaimNotSubmitted =
   "The claim status could not be confirmed. Check your wallet activity before trying again.";
 
+export function walletActionWasCancelled(error: unknown) {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5; depth += 1) {
+    if (!current || typeof current !== "object") break;
+    const record = current as { code?: unknown; message?: unknown; cause?: unknown };
+    if (record.code === 4001 || record.code === "ACTION_REJECTED") return true;
+    if (
+      typeof record.message === "string" &&
+      /(?:user|request|transaction).*(?:cancelled|canceled|denied|rejected)|(?:cancelled|canceled) in wallet/iu.test(
+        record.message,
+      )
+    ) {
+      return true;
+    }
+    current = record.cause;
+  }
+  return false;
+}
+
 export function profileCreatorClaimErrorMessage(error: unknown) {
+  if (walletActionWasCancelled(error)) {
+    return "Transaction cancelled. Rewards remain available.";
+  }
   if (
     error instanceof CreatorClaimClientError &&
     error.code !== "invalid-response" &&
@@ -418,10 +433,13 @@ export function profileCreatorClaimErrorMessage(error: unknown) {
 }
 
 export function profileRewardActionErrorMessage(error: unknown) {
+  if (walletActionWasCancelled(error)) {
+    return "Transaction cancelled. Rewards remain available.";
+  }
   return error instanceof Error &&
     error.message === walletChangedBeforeSubmission
     ? error.message
-    : "The reward action was not completed. Check your wallet and try again.";
+    : "Unable to claim. Try again.";
 }
 
 const pendingProfileTransactionStoragePrefix =
@@ -487,6 +505,29 @@ function formatEth(value?: string) {
 
 function formatWei(value: bigint) {
   return formatEth(formatUnits(value, 18));
+}
+
+function metricNumber(value: string | undefined) {
+  if (!value || !/^(?:0|[1-9][0-9]*)$/u.test(value)) return null;
+  const parsed = Number(formatUnits(BigInt(value), 18));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function profileTokenMarketCapLabel(token: ProfileToken) {
+  const usd = metricNumber(token.fdvUsdWad);
+  if (usd !== null) return formatMarketCapMetric({ kind: "usd", value: usd });
+  const quote = metricNumber(token.marketCapQuoteWad);
+  if (quote !== null && token.quoteAssetSymbol?.trim()) {
+    return formatMarketCapMetric({
+      kind: "quote",
+      symbol: token.quoteAssetSymbol.trim(),
+      value: quote,
+    });
+  }
+  const eth = metricNumber(token.marketCapEthWei);
+  return eth === null
+    ? null
+    : formatMarketCapMetric({ kind: "eth", value: eth });
 }
 
 function formatStockRewardEstimate(
@@ -653,7 +694,7 @@ export function preserveInterruptedTransactionStates<
     next[key] = {
       ...state,
       status: "pending",
-      message: "Status check paused. Check the same transaction again",
+      message: "Confirming on Ethereum",
     };
     changed = true;
   }
@@ -971,7 +1012,7 @@ function restoredPendingProfileActionState(
   return {
     account: record.account,
     status: "pending",
-    message: "Transaction submitted. Check its current status",
+    message: "Confirming on Ethereum",
     transactionHash: record.transactionHash,
     ...(record.source === "stock-paired" && record.pendingStage
       ? {
@@ -1119,6 +1160,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
   const transactionPollControllersRef = useRef<Set<AbortController>>(
     new Set(),
   );
+  const autoResumingProfileTransactionsRef = useRef<Set<string>>(new Set());
   const stockPairedActionLocksRef = useRef<Set<string>>(new Set());
   const hydratedPendingAccountRef = useRef<string | undefined>(undefined);
   const confirmedProfileTransactionsRef = useRef<
@@ -1198,6 +1240,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
 
     if (previousAccount !== normalizedAccount) {
       abortTransactionPolls();
+      autoResumingProfileTransactionsRef.current.clear();
       hydratedPendingAccountRef.current = undefined;
       for (const targets of Object.values(
         confirmedProfileTransactionsRef.current,
@@ -1267,7 +1310,12 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     const cached = readCachedCreatorProfile(account);
     queueMicrotask(() => {
       if (!controller.signal.aborted) {
-        setRemoteOnchainData(cached ?? loadingProfileData(account));
+        setRemoteOnchainData((current) =>
+          isProfileDataForAccount(current, account) &&
+            current.status === "ready"
+            ? current
+            : (cached ?? loadingProfileData(account))
+        );
       }
     });
 
@@ -1321,12 +1369,22 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     if (cachedProfile) {
       queueMicrotask(() => {
         if (cancelled || controller.signal.aborted) return;
-        setClassicV3Rewards(cachedProfile.data);
-        setClassicV3SourceState({
-          account,
-          quality: "stale",
-          verifiedAt: cachedProfile.verifiedAt,
-        });
+        setClassicV3Rewards((current) =>
+          current.status === "ready" &&
+            current.account?.toLowerCase() === account.toLowerCase()
+            ? current
+            : cachedProfile.data
+        );
+        setClassicV3SourceState((current) =>
+          current.account?.toLowerCase() === account.toLowerCase() &&
+            current.quality === "current"
+            ? current
+            : {
+                account,
+                quality: "stale",
+                verifiedAt: cachedProfile.verifiedAt,
+              }
+        );
       });
     }
     const confirmedTransactions = new Map(
@@ -1811,9 +1869,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       transactionPollControllersRef.current.add(controller);
       setActionState({
         status: "confirming",
-        message: manualCheck
-          ? "Checking transaction status"
-          : "Confirming on Ethereum",
+        message: "Confirming on Ethereum",
         transactionHash,
       });
 
@@ -1837,7 +1893,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         if (receiptStatus === "pending") {
           setActionState({
             status: "pending",
-            message: "Still pending on Ethereum. Check the status again",
+            message: "Confirming on Ethereum",
             transactionHash,
           });
           return;
@@ -1872,7 +1928,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         }
         setActionState({
           status: "pending",
-          message: "Status unavailable. Check the transaction again",
+          message: "Confirming on Ethereum",
           transactionHash,
         });
       } finally {
@@ -1881,6 +1937,66 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     },
     [],
   );
+
+  useEffect(() => {
+    if (!account) return;
+    let pending: PendingProfileTransactionRecord[] = [];
+    try {
+      pending = readPendingProfileTransactions(window.localStorage, account);
+    } catch {
+      return;
+    }
+    for (const record of pending) {
+      if (
+        (record.source !== "classic" && record.source !== "classic-v3") ||
+        (record.action !== "claim" && record.action !== "update-payout")
+      ) {
+        continue;
+      }
+      const resumeKey = [
+        record.source,
+        record.stateKey,
+        record.transactionHash,
+      ].join(":");
+      if (autoResumingProfileTransactionsRef.current.has(resumeKey)) continue;
+      autoResumingProfileTransactionsRef.current.add(resumeKey);
+      const setActionState = (
+        state: Omit<ProfileClaimActionState, "account">,
+      ) => {
+        const update = (
+          current: Record<string, ProfileClaimActionState>,
+        ) => ({
+          ...current,
+          [record.stateKey]: { account: record.account, ...state },
+        });
+        if (record.source === "classic") {
+          setClaimActionStates(update);
+        } else {
+          setClassicV3ActionStates(update);
+        }
+      };
+      void settleSubmittedTransaction({
+        transactionHash: record.transactionHash,
+        chainId: record.chainId,
+        actionAccount: record.account,
+        source: record.source,
+        stateKey: record.stateKey,
+        action: record.action,
+        confirmedMessage:
+          record.action === "claim"
+            ? "Claim confirmed"
+            : "Payout address updated",
+        revertedMessage:
+          record.action === "claim"
+            ? "Claim reverted"
+            : "Payout update reverted",
+        setActionState,
+      }).finally(() => {
+        autoResumingProfileTransactionsRef.current.delete(resumeKey);
+      });
+    }
+  }, [account, liveProfileRefresh, settleSubmittedTransaction]);
+
   const submitCreatorClaim = useCallback(
     async (claim: ProfileClaim) => {
       const claimAccount = account;
@@ -1991,6 +2107,14 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         if (
           activeAccountRef.current?.toLowerCase() !== claimAccount.toLowerCase()
         ) {
+          return;
+        }
+        if (walletActionWasCancelled(caught)) {
+          setClaimActionStates((current) => {
+            const next = { ...current };
+            delete next[stateKey];
+            return next;
+          });
           return;
         }
         setClaimState({
@@ -2123,6 +2247,14 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         ) {
           return;
         }
+        if (walletActionWasCancelled(caught)) {
+          setClassicV3ActionStates((current) => {
+            const next = { ...current };
+            delete next[stateKey];
+            return next;
+          });
+          return;
+        }
         setActionState({
           status: "error",
           message: profileRewardActionErrorMessage(caught),
@@ -2246,6 +2378,14 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
           activeAccountRef.current?.toLowerCase() !==
           actionAccount.toLowerCase()
         ) {
+          return;
+        }
+        if (walletActionWasCancelled(caught)) {
+          setDeepActionStates((current) => {
+            const next = { ...current };
+            delete next[stateKey];
+            return next;
+          });
           return;
         }
         setActionState({
@@ -4009,6 +4149,13 @@ function ProfileAccountWorkspace({
         profileEntryOptimisticallyClaimedWei(entry, account, actionStates),
       0n,
     );
+  const nativeClaimable = entries.reduce(
+    (total, entry) =>
+      total +
+      profileEntryActionableNativeWei(entry, account, actionStates),
+    0n,
+  );
+  const nativeEarned = nativeClaimed + nativeClaimable;
   const claimableEntries = sortProfileClaimableEntries(
     entries.filter((entry) =>
       profileEntryHasActionableReward(entry, account, actionStates),
@@ -4021,24 +4168,6 @@ function ProfileAccountWorkspace({
     claimPage,
   );
   const routerLaunchEntries = profileRouterLaunchEntries(entries);
-  const chainId = currentReady
-    ? data.chainId
-    : classicReady
-      ? classicV3Rewards.chainId
-      : deepReady
-        ? deepRewards.chainId
-        : deepV3Ready
-          ? deepV3Profile.chainId
-          : stockPairedReady
-            ? stockPairedRewards.chainId
-            : undefined;
-  const sourceStatuses = [
-    data.status,
-    classicV3Rewards.status,
-    deepRewards.status,
-    deepV3Profile.status,
-    stockPairedRewards.status,
-  ] as const;
   const nativeRewardSourceStatuses = [
     data.status,
     classicV3Rewards.status,
@@ -4049,16 +4178,6 @@ function ProfileAccountWorkspace({
     classicV3SourceState.quality,
     data.sourceQuality ?? "current",
   );
-  const sourceWarning =
-    data.sourceQuality === "stale"
-      ? "Showing the last verified reward totals. Refresh to check current values."
-      : classicV3SourceState.quality === "stale"
-        ? "Showing the last verified Classic rewards. Refresh to check current values."
-        : classicV3SourceState.quality === "unavailable"
-          ? "Classic rewards are temporarily unavailable. Refresh to check current values."
-          : sourceStatuses.some((status) => status === "error")
-            ? "Some reward values are temporarily unavailable. Refresh to check current totals."
-            : "";
   const emptyState =
     rewardDataQuality === "current"
       ? {
@@ -4081,25 +4200,17 @@ function ProfileAccountWorkspace({
       aria-label="Profile overview"
       aria-busy={loading || undefined}
     >
-      {sourceWarning ? (
-        <div className={styles.sourceWarning} role="status">
-          <span>{sourceWarning}</span>
-          <button type="button" onClick={onRetry}>
-            Refresh
-          </button>
-        </div>
-      ) : null}
-
       <ProfileRouterLaunches entries={routerLaunchEntries} />
 
       <div
         className={`${styles.profileWorkspace} liquid-glass-surface`}
       >
         <FeeEarningsPanel
-          nativeClaimed={
-            rewardDataQuality === "partial" ? null : nativeClaimed
+          nativeEarned={rewardDataQuality === "partial" ? null : nativeEarned}
+          nativeClaimable={
+            rewardDataQuality === "partial" ? null : nativeClaimable
           }
-          activity={currentReady ? data.activity : []}
+          nativeClaimed={rewardDataQuality === "partial" ? null : nativeClaimed}
         />
 
         <section
@@ -4115,43 +4226,54 @@ function ProfileAccountWorkspace({
                 Refreshing rewards
               </span>
             ) : null}
-            {claimPageData.totalPages > 1 ? (
-              <nav
-                className={styles.claimPagination}
-                aria-label="Claimable rewards pages"
+            <div className={styles.claimPanelActions}>
+              <button
+                className={styles.claimRefresh}
+                type="button"
+                aria-label="Refresh claimable rewards"
+                onClick={onRetry}
               >
-                <button
-                  type="button"
-                  aria-label="Previous claimable rewards page"
-                  disabled={claimPageData.currentPage === 1}
-                  onClick={() =>
-                    setClaimPage(Math.max(1, claimPageData.currentPage - 1))
-                  }
+                <RefreshCw aria-hidden="true" size={15} strokeWidth={1.8} />
+                <span>Refresh</span>
+              </button>
+              {claimPageData.totalPages > 1 ? (
+                <nav
+                  className={styles.claimPagination}
+                  aria-label="Claimable rewards pages"
                 >
-                  <ChevronLeft aria-hidden="true" size={17} strokeWidth={1.8} />
-                </button>
-                <span aria-live="polite" aria-atomic="true">
-                  {claimPageData.currentPage} / {claimPageData.totalPages}
-                </span>
-                <button
-                  type="button"
-                  aria-label="Next claimable rewards page"
-                  disabled={
-                    claimPageData.currentPage === claimPageData.totalPages
-                  }
-                  onClick={() =>
-                    setClaimPage(
-                      Math.min(
-                        claimPageData.totalPages,
-                        claimPageData.currentPage + 1,
-                      ),
-                    )
-                  }
-                >
-                  <ChevronRight aria-hidden="true" size={17} strokeWidth={1.8} />
-                </button>
-              </nav>
-            ) : null}
+                  <button
+                    type="button"
+                    aria-label="Previous claimable rewards page"
+                    disabled={claimPageData.currentPage === 1}
+                    onClick={() =>
+                      setClaimPage(Math.max(1, claimPageData.currentPage - 1))
+                    }
+                  >
+                    <ChevronLeft aria-hidden="true" size={17} strokeWidth={1.8} />
+                  </button>
+                  <span aria-live="polite" aria-atomic="true">
+                    {claimPageData.currentPage} / {claimPageData.totalPages}
+                  </span>
+                  <button
+                    type="button"
+                    aria-label="Next claimable rewards page"
+                    disabled={
+                      claimPageData.currentPage === claimPageData.totalPages
+                    }
+                    onClick={() =>
+                      setClaimPage(
+                        Math.min(
+                          claimPageData.totalPages,
+                          claimPageData.currentPage + 1,
+                        ),
+                      )
+                    }
+                  >
+                    <ChevronRight aria-hidden="true" size={17} strokeWidth={1.8} />
+                  </button>
+                </nav>
+              ) : null}
+            </div>
           </header>
 
           {claimableEntries.length ? (
@@ -4161,7 +4283,6 @@ function ProfileAccountWorkspace({
                   key={entry.token.address}
                   entry={entry}
                   account={account}
-                  chainId={chainId}
                   claimActionStates={claimActionStates}
                   classicV3ActionStates={classicV3ActionStates}
                   deepActionStates={deepActionStates}
@@ -4186,424 +4307,66 @@ function ProfileAccountWorkspace({
 }
 
 function FeeEarningsPanel({
+  nativeEarned,
+  nativeClaimable,
   nativeClaimed,
-  activity,
 }: {
+  nativeEarned: bigint | null;
+  nativeClaimable: bigint | null;
   nativeClaimed: bigint | null;
-  activity: readonly ProfileActivity[];
 }) {
-  const [chartNowMs, setChartNowMs] = useState<number | null>(null);
-  const [range, setRange] = useState<FeeEarningsRange>("all");
-  const initialChartReferenceMs = useMemo(
-    () =>
-      timestampedFeeClaims(activity).reduce(
-        (latest, claim) => Math.max(latest, claim.timestampMs),
-        0,
-      ),
-    [activity],
-  );
-  const chartReferenceMs = chartNowMs ?? initialChartReferenceMs;
-
-  useEffect(() => {
-    const frame = window.requestAnimationFrame(() => {
-      setChartNowMs(Date.now());
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [activity]);
-
-  const chart = useMemo(() => {
-    const confirmedFromHistory = timestampedFeeClaims(activity).reduce(
-      (total, claim) => total + claim.valueWei,
-      0n,
-    );
-    return buildFeeEarningsChart(
-      activity,
-      nativeClaimed ?? confirmedFromHistory,
-      0n,
-      {
-        nowMs: chartReferenceMs,
-        range,
-      },
-    );
-  }, [activity, chartReferenceMs, nativeClaimed, range]);
-  const [activePointIndex, setActivePointIndex] = useState(-1);
-  const activePointIndexRef = useRef(-1);
-  const gradientId = useId().replaceAll(":", "");
-  const chartHelpId = `${gradientId}-help`;
-  const resolvedActivePointIndex = chart
-    ? activePointIndex >= 0 && activePointIndex < chart.points.length
-      ? activePointIndex
-      : chart.points.length - 1
-    : -1;
-  const activePoint =
-    chart && activePointIndex >= 0 && activePointIndex < chart.points.length
-      ? chart.points[activePointIndex]
-      : undefined;
-  const displayedPoint = chart
-    ? (activePoint ?? chart.points[chart.points.length - 1])
-    : undefined;
-  const displayedHistoryMoment =
-    chart && displayedPoint
-      ? formatFeeChartMoment(displayedPoint.timestampMs, chart.nowMs)
-      : "Now";
-
-  function resetActivePoint() {
-    if (activePointIndexRef.current === -1) return;
-    activePointIndexRef.current = -1;
-    setActivePointIndex(-1);
-  }
-
-  function activateLastPoint() {
-    if (!chart || activePointIndexRef.current >= 0) return;
-    const lastPointIndex = chart.points.length - 1;
-    activePointIndexRef.current = lastPointIndex;
-    setActivePointIndex(lastPointIndex);
-  }
-
-  function selectPointFromPointer(event: PointerEvent<HTMLDivElement>) {
-    if (!chart) return;
-    const bounds = event.currentTarget.getBoundingClientRect();
-    if (bounds.width <= 0) return;
-    const pointerX = Math.min(
-      620,
-      Math.max(0, ((event.clientX - bounds.left) / bounds.width) * 620),
-    );
-    const nearestIndex = chart.points.reduce(
-      (nearest, point, index) =>
-        Math.abs(point.x - pointerX) <
-        Math.abs(chart.points[nearest].x - pointerX)
-          ? index
-          : nearest,
-      0,
-    );
-    if (activePointIndexRef.current === nearestIndex) return;
-    activePointIndexRef.current = nearestIndex;
-    setActivePointIndex(nearestIndex);
-  }
-
-  function handleChartKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    if (!chart) return;
-    let nextIndex = resolvedActivePointIndex;
-    if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
-      nextIndex = Math.max(0, resolvedActivePointIndex - 1);
-    } else if (event.key === "ArrowRight" || event.key === "ArrowUp") {
-      nextIndex = Math.min(
-        chart.points.length - 1,
-        resolvedActivePointIndex + 1,
-      );
-    } else if (event.key === "Home") {
-      nextIndex = 0;
-    } else if (event.key === "End") {
-      nextIndex = chart.points.length - 1;
-    } else {
-      return;
-    }
-    event.preventDefault();
-    activePointIndexRef.current = nextIndex;
-    setActivePointIndex(nextIndex);
-  }
+  const composition =
+    nativeEarned !== null && nativeEarned > 0n &&
+      nativeClaimable !== null && nativeClaimed !== null
+      ? {
+          available:
+            Number((nativeClaimable * 10_000n) / nativeEarned) / 100,
+          claimed: Number((nativeClaimed * 10_000n) / nativeEarned) / 100,
+        }
+      : null;
 
   return (
     <section
       className={styles.feePanel}
       aria-labelledby="fee-earnings-title"
     >
-      <h2 className={styles.visuallyHidden} id="fee-earnings-title">
-        Reward history
-      </h2>
+      <header className={styles.feePanelHeader}>
+        <div>
+          <h2 id="fee-earnings-title">Fees earned</h2>
+          <p>Lifetime fees for this wallet</p>
+        </div>
+      </header>
 
-      <figure
-        className={styles.feeChart}
-        aria-label="Confirmed claim history"
-      >
-        <figcaption className={styles.chartHeading}>
+      <div className={styles.feeSummary}>
+        <span className={styles.feeSummaryLabel}>Total earned</span>
+        {nativeEarned === null ? null : <strong>{formatWei(nativeEarned)}</strong>}
+        <div className={styles.feeBreakdown}>
           <span>
-            <strong>
-              {chart && displayedPoint
-                ? formatWei(displayedPoint.valueWei)
-                : nativeClaimed === null
-                  ? "Unavailable"
-                  : formatWei(nativeClaimed)}
-            </strong>
-            <small>{displayedHistoryMoment}</small>
+            Available <b>{nativeClaimable === null ? "—" : formatWei(nativeClaimable)}</b>
           </span>
-          <div className={styles.timeframeControls} aria-label="Chart range">
-            {feeEarningsRanges.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                aria-label={`Show ${option.description}`}
-                aria-pressed={range === option.value}
-                onClick={() => {
-                  setRange(option.value);
-                  activePointIndexRef.current = -1;
-                  setActivePointIndex(-1);
-                }}
-              >
-                {option.label}
-              </button>
-            ))}
+          <span>
+            Claimed <b>{nativeClaimed === null ? "—" : formatWei(nativeClaimed)}</b>
+          </span>
+        </div>
+        {composition ? (
+          <div
+            className={styles.feeComposition}
+            role="img"
+            aria-label={`${composition.available.toFixed(2)}% available and ${composition.claimed.toFixed(2)}% claimed`}
+          >
+            <span
+              className={styles.feeCompositionClaimable}
+              style={{ width: `${composition.available}%` }}
+            />
+            <span
+              className={styles.feeCompositionClaimed}
+              style={{ width: `${composition.claimed}%` }}
+            />
           </div>
-        </figcaption>
-        <div className={styles.chartGrid} aria-hidden="true" />
-        {chart && displayedPoint ? (
-          <>
-            <p className={styles.visuallyHidden} id={chartHelpId}>
-              Use the arrow keys to inspect each confirmed earnings point.
-            </p>
-            <div
-              aria-label="Confirmed claim history"
-              aria-describedby={chartHelpId}
-              aria-orientation="horizontal"
-              aria-valuemax={chart.points.length - 1}
-              aria-valuemin={0}
-              aria-valuenow={resolvedActivePointIndex}
-              aria-valuetext={`${formatWei(displayedPoint.valueWei)} at ${formatFeeChartMoment(displayedPoint.timestampMs, chart.nowMs)}`}
-              className={styles.feeChartInteraction}
-              onBlur={resetActivePoint}
-              onFocus={activateLastPoint}
-              onKeyDown={handleChartKeyDown}
-              onPointerDown={(event) => {
-                selectPointFromPointer(event);
-                event.currentTarget.focus();
-              }}
-              onPointerLeave={(event) => {
-                if (document.activeElement !== event.currentTarget) {
-                  resetActivePoint();
-                }
-              }}
-              onPointerMove={selectPointFromPointer}
-              role="slider"
-              tabIndex={0}
-            >
-              <svg
-                aria-hidden="true"
-                className={styles.feePlot}
-                viewBox="0 0 620 150"
-                preserveAspectRatio="none"
-              >
-                <defs>
-                  <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
-                    <stop
-                      offset="0%"
-                      stopColor="var(--brand-ivory)"
-                      stopOpacity="0.24"
-                    />
-                    <stop
-                      offset="100%"
-                      stopColor="var(--brand-ivory)"
-                      stopOpacity="0"
-                    />
-                  </linearGradient>
-                </defs>
-                <path
-                  className={styles.feeArea}
-                  d={chart.areaPath}
-                  fill={`url(#${gradientId})`}
-                />
-                <path className={styles.feeLine} d={chart.linePath} />
-                {activePoint ? (
-                  <line
-                    className={styles.feeCursor}
-                    x1={activePoint.x}
-                    x2={activePoint.x}
-                    y1="10"
-                    y2="140"
-                  />
-                ) : null}
-              </svg>
-            </div>
-            <div className={styles.chartScale} aria-hidden="true">
-              <span>
-                {formatFeeChartMoment(chart.rangeStartMs, chart.nowMs)}
-              </span>
-              <span>Now</span>
-            </div>
-          </>
-        ) : (
-          <div className={styles.chartEmpty}>
-            <strong>No confirmed claim history yet</strong>
-            <p>
-              Confirmed claims with exact timestamps will build this chart.
-            </p>
-          </div>
-        )}
-      </figure>
+        ) : null}
+      </div>
     </section>
   );
-}
-
-type FeeEarningsChartPoint = {
-  x: number;
-  y: number;
-  timestampMs: number;
-  valueWei: bigint;
-};
-
-export type FeeEarningsRange = "1h" | "1d" | "1w" | "all";
-
-const feeEarningsRanges: ReadonlyArray<{
-  description: string;
-  label: string;
-  value: FeeEarningsRange;
-}> = [
-  { description: "the last day", label: "1D", value: "1d" },
-  { description: "the last seven days", label: "7D", value: "1w" },
-  { description: "all time", label: "ALL", value: "all" },
-];
-
-const feeEarningsRangeMs: Record<Exclude<FeeEarningsRange, "all">, number> = {
-  "1h": 60 * 60 * 1_000,
-  "1d": 24 * 60 * 60 * 1_000,
-  "1w": 7 * 24 * 60 * 60 * 1_000,
-};
-
-function formatFeeChartMoment(timestampMs: number, nowMs: number) {
-  if (Math.abs(nowMs - timestampMs) < 1_000) return "Now";
-  return new Intl.DateTimeFormat("en", {
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    month: "short",
-  }).format(timestampMs);
-}
-
-export function parseClaimedFeeWei(detail: string) {
-  const match = detail.trim().match(/^([0-9]+(?:\.[0-9]+)?)\s+ETH\b/iu);
-  if (!match) return null;
-  try {
-    return parseUnits(match[1], 18);
-  } catch {
-    return null;
-  }
-}
-
-function timestampedFeeClaims(activity: readonly ProfileActivity[]) {
-  return activity.flatMap((item) => {
-    if (!/fees claimed/iu.test(item.label) || !item.occurredAtIso) {
-      return [];
-    }
-    const valueWei = parseClaimedFeeWei(item.detail);
-    const timestampMs = Date.parse(item.occurredAtIso);
-    if (valueWei === null || !Number.isFinite(timestampMs)) return [];
-    return [{ timestampMs, valueWei }];
-  });
-}
-
-export function getAvailableFeeEarningsRanges(
-  activity: readonly ProfileActivity[],
-  nowMs = Date.now(),
-) {
-  const claims = timestampedFeeClaims(activity).filter(
-    (claim) => claim.timestampMs <= nowMs,
-  );
-
-  return feeEarningsRanges.flatMap((range) => {
-    if (range.value === "all") return [range.value];
-    const rangeStartMs = nowMs - feeEarningsRangeMs[range.value];
-    return claims.some((claim) => claim.timestampMs >= rangeStartMs)
-      ? [range.value]
-      : [];
-  });
-}
-
-export function buildFeeEarningsChart(
-  activity: readonly ProfileActivity[],
-  nativeClaimed: bigint,
-  _nativeClaimable: bigint,
-  options: Readonly<{
-    nowMs?: number;
-    range?: FeeEarningsRange;
-  }> = {},
-) {
-  const nowMs = options.nowMs ?? Date.now();
-  const range = options.range ?? "all";
-  const claims = timestampedFeeClaims(activity)
-    .filter((claim) => claim.timestampMs <= nowMs)
-    .sort((first, second) => first.timestampMs - second.timestampMs);
-  if (claims.length === 0) return null;
-  const historyTotal = claims.reduce(
-    (total, claim) => total + claim.valueWei,
-    0n,
-  );
-  const rangeStartMs =
-    range === "all"
-      ? (claims[0]?.timestampMs ?? nowMs - 24 * 60 * 60 * 1_000)
-      : nowMs - feeEarningsRangeMs[range];
-  const visibleClaims =
-    range === "all"
-      ? claims
-      : claims.filter(
-          (claim) =>
-            claim.timestampMs >= rangeStartMs &&
-            claim.timestampMs <= nowMs,
-        );
-  const startingTotal =
-    range === "all" && nativeClaimed > historyTotal
-      ? nativeClaimed - historyTotal
-      : 0n;
-  const values = [{ timestampMs: rangeStartMs, valueWei: startingTotal }];
-  let cumulative = startingTotal;
-  for (const claim of visibleClaims) {
-    cumulative += claim.valueWei;
-    values.push({ timestampMs: claim.timestampMs, valueWei: cumulative });
-  }
-
-  const totalWei = cumulative;
-  values.push({ timestampMs: nowMs, valueWei: totalWei });
-  if (totalWei <= 0n || values.length < 2) return null;
-
-  const width = 620;
-  const height = 150;
-  const left = 8;
-  const right = width - 8;
-  const top = 12;
-  const bottom = height - 10;
-  const maximum = values.reduce(
-    (current, value) => (value.valueWei > current ? value.valueWei : current),
-    1n,
-  );
-  const timeSpanMs = Math.max(1, nowMs - rangeStartMs);
-  const points: FeeEarningsChartPoint[] = values.map(
-    ({ timestampMs, valueWei }) => ({
-      timestampMs,
-      valueWei,
-      x:
-        left +
-        ((Math.min(nowMs, Math.max(rangeStartMs, timestampMs)) - rangeStartMs) /
-          timeSpanMs) *
-          (right - left),
-      y:
-        bottom -
-        Number((valueWei * 1_000_000n) / maximum) /
-          1_000_000 *
-          (bottom - top),
-    }),
-  );
-  const linePath = points
-    .map((point, index) =>
-      index === 0
-        ? `M${point.x.toFixed(2)},${point.y.toFixed(2)}`
-        : `H${point.x.toFixed(2)} V${point.y.toFixed(2)}`,
-    )
-    .join(" ");
-
-  return {
-    areaPath: `${linePath} L${right},${height} L${left},${height} Z`,
-    linePath,
-    nowMs,
-    points,
-    rangeStartMs,
-    totalWei,
-  };
-}
-
-function transactionHref(chainId: number | undefined, hash: Hex) {
-  return `${
-    chainId === 11_155_111
-      ? "https://sepolia.etherscan.io"
-      : "https://etherscan.io"
-  }/tx/${hash}`;
 }
 
 export function actionPending(
@@ -4612,7 +4375,8 @@ export function actionPending(
   return (
     state?.status === "preparing" ||
     state?.status === "wallet" ||
-    state?.status === "confirming"
+    state?.status === "confirming" ||
+    state?.status === "pending"
   );
 }
 
@@ -4627,8 +4391,9 @@ export function actionLabel(
 ) {
   if (state?.status === "preparing") return "Preparing";
   if (state?.status === "wallet") return "Confirm in wallet";
-  if (state?.status === "confirming") return "Confirming";
-  if (actionCanCheckStatus(state)) return "Check status";
+  if (state?.status === "confirming" || state?.status === "pending") {
+    return "Confirming";
+  }
   if (state?.status === "confirmed") return "Confirmed";
   if (state?.status === "error") return "Try again";
   return "Claim";
@@ -4768,7 +4533,6 @@ function ProfileClaimDialog({
 function ProfileClaimRow({
   entry,
   account,
-  chainId,
   claimActionStates,
   classicV3ActionStates,
   deepActionStates,
@@ -4780,7 +4544,6 @@ function ProfileClaimRow({
 }: {
   entry: ProfilePortfolioEntry;
   account?: string;
-  chainId?: number;
   claimActionStates: Record<string, ProfileClaimActionState>;
   classicV3ActionStates: Record<string, ClassicV3ActionState>;
   deepActionStates: Record<string, DeepActionState>;
@@ -4917,6 +4680,7 @@ function ProfileClaimRow({
   const tokenImage =
     token.imageUrl?.trim() || getFallbackTokenImage(token.address);
   const tokenImageSource = getTokenCardImageSource(tokenImage);
+  const marketCapLabel = profileTokenMarketCapLabel(token);
   const currentClaimAvailable =
     Boolean(claim) && (currentClaimable > 0n || Boolean(activeClaimState));
   const formattedStockReward =
@@ -5077,6 +4841,9 @@ function ProfileClaimRow({
           <span className={styles.claimCopy}>
             <strong>{token.name}</strong>
             <span>${token.symbol}</span>
+            {marketCapLabel ? (
+              <small>Market cap {marketCapLabel}</small>
+            ) : null}
           </span>
         </Link>
 
@@ -5121,20 +4888,17 @@ function ProfileClaimRow({
 
       <ProfileActionState
         state={activeClaimState}
-        chainId={chainId}
       />
       {classicClaims.map(({ reward, state }) => (
         <ProfileActionState
           key={`${reward.vaultAddress}:state`}
           state={state}
-          chainId={chainId}
         />
       ))}
       {deepClaims.map(({ reward, state }) => (
         <ProfileActionState
           key={`${reward.vaultAddress}:deep-state`}
           state={state}
-          chainId={chainId}
         />
       ))}
       {stockPairedClaims.map(({ reward, claimState, ethState }) => {
@@ -5149,7 +4913,6 @@ function ProfileClaimRow({
           <ProfileActionState
             key={`${reward.vaultAddress}:stock-paired-state`}
             state={visibleState}
-            chainId={chainId}
           />
         );
       })}
@@ -5159,12 +4922,12 @@ function ProfileClaimRow({
 
 function ProfileActionState({
   state,
-  chainId,
 }: {
   state?: ProfileClaimActionState | ClassicV3ActionState;
-  chainId?: number;
 }) {
-  if (!state) return null;
+  if (!state || (state.status !== "confirmed" && state.status !== "error")) {
+    return null;
+  }
   return (
     <p
       className={
@@ -5173,15 +4936,6 @@ function ProfileActionState({
       role={state.status === "error" ? "alert" : "status"}
     >
       {state.message}
-      {state.transactionHash ? (
-        <a
-          href={transactionHref(chainId, state.transactionHash)}
-          target="_blank"
-          rel="noreferrer"
-        >
-          View transaction
-        </a>
-      ) : null}
     </p>
   );
 }

--- a/lib/market-data/envio-classic-v2-creator-claims.server.ts
+++ b/lib/market-data/envio-classic-v2-creator-claims.server.ts
@@ -1,0 +1,390 @@
+import "server-only";
+
+import {
+  getAddress,
+  isAddress,
+  isHex,
+  type Address,
+  type Hex,
+} from "viem";
+
+import {
+  getDataPipelineReleaseBinding,
+  type DataPipelineReleaseBinding,
+} from "../data-pipeline/release-binding.server";
+import {
+  boundedJsonRequest,
+  type DataPipelineFetcher,
+} from "../data-pipeline/request";
+
+const CLAIM_PAGE_SIZE = 64;
+const MAXIMUM_CLAIM_COUNT = 5_000;
+const GRAPHQL_TIMEOUT_MS = 3_000;
+const GRAPHQL_MAXIMUM_BODY_BYTES = 512 * 1024;
+
+const CLASSIC_V2_CREATOR_CLAIMS_QUERY = `
+  query ProgrammableClassicV2CreatorClaims(
+    $afterId: String!
+    $creator: String!
+    $hook: String!
+    $poolIds: [String!]!
+    $throughBlock: numeric!
+    $first: Int!
+  ) {
+    CreatorFeeClaim(
+      where: {
+        _and: [
+          { id: { _gt: $afterId } }
+          { chainId: { _eq: 1 } }
+          { blockNumber: { _lte: $throughBlock } }
+          { sourceAddress: { _eq: $hook } }
+          { model: { _eq: "classic" } }
+          { releaseVersion: { _eq: "classic-v2" } }
+          { poolId: { _in: $poolIds } }
+          { creator: { _eq: $creator } }
+        ]
+      }
+      order_by: [{ id: asc }]
+      limit: $first
+    ) {
+      id
+      receiptLogOrdinal
+      chainId
+      blockNumber
+      blockHash
+      blockTimestamp
+      transactionHash
+      transactionIndex
+      blockGlobalLogIndex
+      sourceAddress
+      model
+      releaseVersion
+      poolId
+      creator
+      rewardVault
+      recipient
+      quoteAsset
+      caller
+      amount
+    }
+  }
+`;
+
+const CLAIM_KEYS = [
+  "id",
+  "receiptLogOrdinal",
+  "chainId",
+  "blockNumber",
+  "blockHash",
+  "blockTimestamp",
+  "transactionHash",
+  "transactionIndex",
+  "blockGlobalLogIndex",
+  "sourceAddress",
+  "model",
+  "releaseVersion",
+  "poolId",
+  "creator",
+  "rewardVault",
+  "recipient",
+  "quoteAsset",
+  "caller",
+  "amount",
+] as const;
+
+export type EnvioClassicV2CreatorClaimV1 = Readonly<{
+  id: string;
+  blockNumber: string;
+  blockHash: Hex;
+  blockTimestamp: string;
+  transactionHash: Hex;
+  transactionIndex: number;
+  logIndex: number;
+  poolId: Hex;
+  creator: Address;
+  recipient: Address;
+  caller: Address;
+  amountWei: string;
+}>;
+
+export type EnvioClassicV2CreatorClaimReaderDependenciesV1 = Readonly<{
+  fetcher?: DataPipelineFetcher;
+  release?: DataPipelineReleaseBinding;
+}>;
+
+type ReadClaimsInput = Readonly<{
+  account: Address;
+  poolIds: readonly Hex[];
+  throughBlock: string;
+  signal?: AbortSignal;
+  deadlineMs?: number;
+}>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, expected: readonly string[]) {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  return actual.length === sortedExpected.length &&
+    actual.every((key, index) => key === sortedExpected[index]);
+}
+
+function unsignedText(value: unknown, label: string) {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    throw new Error(`Envio Classic V2 claim ${label} is invalid`);
+  }
+  return value;
+}
+
+function safeUnsignedInteger(value: unknown, label: string) {
+  const parsed = Number(unsignedText(value, label));
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`Envio Classic V2 claim ${label} is unsafe`);
+  }
+  return parsed;
+}
+
+function address(value: unknown, label: string) {
+  if (typeof value !== "string" || !isAddress(value)) {
+    throw new Error(`Envio Classic V2 claim ${label} is invalid`);
+  }
+  return getAddress(value);
+}
+
+function bytes32(value: unknown, label: string) {
+  if (
+    typeof value !== "string" ||
+    !isHex(value) ||
+    !/^0x[0-9a-f]{64}$/u.test(value)
+  ) {
+    throw new Error(`Envio Classic V2 claim ${label} is invalid`);
+  }
+  return value as Hex;
+}
+
+function classicV2Hook(release: DataPipelineReleaseBinding) {
+  const model = release.releases.find(
+    (candidate) =>
+      candidate.model === "classic" &&
+      candidate.releaseVersion === "classic-v2",
+  );
+  const hook = release.sources.find(
+    (candidate) => candidate.contractName === "ClassicV2Hook",
+  );
+  if (!model || !hook || !model.sourceContracts.includes(hook.contractName)) {
+    throw new Error("Classic V2 Envio claim binding is incomplete");
+  }
+  return Object.freeze({ hook, activationBlock: BigInt(model.activationBlock) });
+}
+
+function parseRows(value: unknown) {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, ["data"]) ||
+    !isRecord(value.data) ||
+    !hasOnlyKeys(value.data, ["CreatorFeeClaim"]) ||
+    !Array.isArray(value.data.CreatorFeeClaim)
+  ) {
+    throw new Error("Envio Classic V2 claim response shape drifted");
+  }
+  return value.data.CreatorFeeClaim;
+}
+
+function parseClaim(
+  value: unknown,
+  input: Readonly<{
+    account: Address;
+    hook: Address;
+    poolIds: ReadonlySet<string>;
+    throughBlock: bigint;
+  }>,
+): EnvioClassicV2CreatorClaimV1 {
+  if (!isRecord(value) || !hasOnlyKeys(value, CLAIM_KEYS)) {
+    throw new Error("Envio Classic V2 claim row shape drifted");
+  }
+  if (
+    value.chainId !== 1 ||
+    value.model !== "classic" ||
+    value.releaseVersion !== "classic-v2" ||
+    value.rewardVault !== null ||
+    value.quoteAsset !== null
+  ) {
+    throw new Error("Envio Classic V2 claim family drifted");
+  }
+  const blockNumber = unsignedText(value.blockNumber, "block number");
+  const blockTimestamp = unsignedText(value.blockTimestamp, "block timestamp");
+  safeUnsignedInteger(value.blockTimestamp, "block timestamp");
+  const transactionIndex = safeUnsignedInteger(
+    value.transactionIndex,
+    "transaction index",
+  );
+  const blockLogIndex = safeUnsignedInteger(
+    value.blockGlobalLogIndex,
+    "block log index",
+  );
+  const logIndex = value.receiptLogOrdinal === null
+    ? blockLogIndex
+    : safeUnsignedInteger(value.receiptLogOrdinal, "log index");
+  const blockHash = bytes32(value.blockHash, "block hash");
+  const transactionHash = bytes32(value.transactionHash, "transaction hash");
+  const poolId = bytes32(value.poolId, "pool id");
+  const creator = address(value.creator, "creator");
+  const sourceAddress = address(value.sourceAddress, "source address");
+  const recipient = address(value.recipient, "recipient");
+  const caller = address(value.caller, "caller");
+  const amountWei = unsignedText(value.amount, "amount");
+  if (
+    BigInt(blockNumber) > input.throughBlock ||
+    sourceAddress.toLowerCase() !== input.hook.toLowerCase() ||
+    creator.toLowerCase() !== input.account.toLowerCase() ||
+    !input.poolIds.has(poolId.toLowerCase()) ||
+    BigInt(amountWei) === 0n
+  ) {
+    throw new Error("Envio Classic V2 claim identity drifted");
+  }
+  if (typeof value.id !== "string") {
+    throw new Error("Envio Classic V2 claim occurrence is invalid");
+  }
+  const occurrence = value.id.match(
+    /^1:(0x[0-9a-f]{64}):(0x[0-9a-f]{64}):((?:0|[1-9][0-9]*))$/u,
+  );
+  if (
+    !occurrence ||
+    occurrence[1] !== blockHash ||
+    occurrence[2] !== transactionHash ||
+    occurrence[3] !== String(blockLogIndex)
+  ) {
+    throw new Error("Envio Classic V2 claim occurrence drifted");
+  }
+  return Object.freeze({
+    id: value.id,
+    blockNumber,
+    blockHash,
+    blockTimestamp,
+    transactionHash,
+    transactionIndex,
+    logIndex,
+    poolId,
+    creator,
+    recipient,
+    caller,
+    amountWei,
+  });
+}
+
+function boundFetcher(
+  fetcher: DataPipelineFetcher | undefined,
+  input: ReadClaimsInput,
+): DataPipelineFetcher {
+  return async (endpoint, init) => {
+    const deadlineMs = input.deadlineMs ?? Date.now() + 5_000;
+    const remaining = deadlineMs - Date.now();
+    if (remaining <= 0) throw new Error("Envio creator claims deadline exceeded");
+    const signals = [AbortSignal.timeout(remaining)];
+    if (input.signal) signals.push(input.signal);
+    if (init?.signal) signals.push(init.signal);
+    return await (fetcher ?? fetch)(endpoint, {
+      ...init,
+      signal: AbortSignal.any(signals),
+    });
+  };
+}
+
+export function createEnvioClassicV2CreatorClaimReaderV1(
+  dependencies: EnvioClassicV2CreatorClaimReaderDependenciesV1 = {},
+) {
+  return async function readEnvioClassicV2CreatorClaimsV1(
+    input: ReadClaimsInput,
+  ): Promise<readonly EnvioClassicV2CreatorClaimV1[]> {
+    if (!isAddress(input.account)) {
+      throw new Error("Envio creator claim account is invalid");
+    }
+    if (
+      input.poolIds.length === 0 ||
+      input.poolIds.length > 128 ||
+      new Set(input.poolIds.map((poolId) => poolId.toLowerCase())).size !==
+        input.poolIds.length ||
+      input.poolIds.some(
+        (poolId) => !isHex(poolId) || !/^0x[0-9a-f]{64}$/u.test(poolId),
+      ) ||
+      !/^(?:0|[1-9][0-9]*)$/u.test(input.throughBlock)
+    ) {
+      throw new Error("Envio creator claim request is invalid");
+    }
+    if (input.signal?.aborted) {
+      throw input.signal.reason ?? new Error("Envio creator claim read aborted");
+    }
+    const release = dependencies.release ?? getDataPipelineReleaseBinding();
+    const binding = classicV2Hook(release);
+    const throughBlock = BigInt(input.throughBlock);
+    if (throughBlock < binding.activationBlock) return Object.freeze([]);
+    const account = getAddress(input.account);
+    const poolIds = new Set(input.poolIds.map((poolId) => poolId.toLowerCase()));
+    const fetcher = boundFetcher(dependencies.fetcher, input);
+    const claims: EnvioClassicV2CreatorClaimV1[] = [];
+    const identities = new Set<string>();
+    let afterId = "";
+    while (true) {
+      const response = await boundedJsonRequest<unknown>({
+        dependency: "envio",
+        endpoint: release.envio.graphqlEndpoint,
+        timeoutMs: GRAPHQL_TIMEOUT_MS,
+        maximumBodyBytes: GRAPHQL_MAXIMUM_BODY_BYTES,
+        fetcher,
+        body: {
+          query: CLASSIC_V2_CREATOR_CLAIMS_QUERY,
+          variables: {
+            afterId,
+            creator: account.toLowerCase(),
+            hook: binding.hook.address,
+            poolIds: [...poolIds],
+            throughBlock: input.throughBlock,
+            first: CLAIM_PAGE_SIZE,
+          },
+        },
+      });
+      const rows = parseRows(response);
+      if (rows.length > CLAIM_PAGE_SIZE) {
+        throw new Error("Envio Classic V2 claim page exceeded its bound");
+      }
+      for (const row of rows) {
+        const claim = parseClaim(row, {
+          account,
+          hook: getAddress(binding.hook.address),
+          poolIds,
+          throughBlock,
+        });
+        if (claim.id <= afterId || identities.has(claim.id)) {
+          throw new Error("Envio Classic V2 claim order drifted");
+        }
+        identities.add(claim.id);
+        afterId = claim.id;
+        claims.push(claim);
+      }
+      if (claims.length > MAXIMUM_CLAIM_COUNT) {
+        throw new Error("Envio Classic V2 claim history exceeded its safety bound");
+      }
+      if (rows.length < CLAIM_PAGE_SIZE) break;
+    }
+    claims.sort((left, right) => {
+      const blockDifference = BigInt(right.blockNumber) - BigInt(left.blockNumber);
+      if (blockDifference !== 0n) return blockDifference < 0n ? -1 : 1;
+      if (left.transactionIndex !== right.transactionIndex) {
+        return right.transactionIndex - left.transactionIndex;
+      }
+      return right.logIndex - left.logIndex;
+    });
+    return Object.freeze(claims);
+  };
+}
+
+const readProductionEnvioClassicV2CreatorClaims =
+  createEnvioClassicV2CreatorClaimReaderV1();
+
+export async function readEnvioClassicV2CreatorClaimsV1(
+  input: ReadClaimsInput,
+) {
+  return await readProductionEnvioClassicV2CreatorClaims(input);
+}

--- a/tests/envio-classic-v2-creator-claims.test.ts
+++ b/tests/envio-classic-v2-creator-claims.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { getDataPipelineReleaseBinding } from
+  "../lib/data-pipeline/release-binding.server";
+import { createEnvioClassicV2CreatorClaimReaderV1 } from
+  "../lib/market-data/envio-classic-v2-creator-claims.server";
+
+const release = getDataPipelineReleaseBinding();
+const creator = "0x2Bb333d48DFAF1596D9036671d2E43168994249E" as const;
+const poolId =
+  "0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0" as const;
+const hook = release.sources.find(
+  (source) => source.contractName === "ClassicV2Hook",
+)!.address;
+
+function hex32(value: number) {
+  return `0x${value.toString(16).padStart(64, "0")}` as const;
+}
+
+function claimFixture(index: number, overrides: Record<string, unknown> = {}) {
+  const blockHash = hex32(10_000 + index);
+  const transactionHash = hex32(20_000 + index);
+  const blockLogIndex = 1_000 + index;
+  return {
+    id: `1:${blockHash}:${transactionHash}:${blockLogIndex}`,
+    receiptLogOrdinal: null,
+    chainId: 1,
+    blockNumber: String(25_624_200 + index),
+    blockHash,
+    blockTimestamp: String(1_787_250_000 + index),
+    transactionHash,
+    transactionIndex: String(200 + index),
+    blockGlobalLogIndex: String(blockLogIndex),
+    sourceAddress: hook,
+    model: "classic",
+    releaseVersion: "classic-v2",
+    poolId,
+    creator: creator.toLowerCase(),
+    rewardVault: null,
+    recipient: creator.toLowerCase(),
+    quoteAsset: null,
+    caller: creator.toLowerCase(),
+    amount: String(1_000_000 + index),
+    ...overrides,
+  };
+}
+
+function json(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("Envio Classic V2 creator claim history", () => {
+  it("paginates and binds exact creator, hook, pool, family and occurrence", async () => {
+    const rows = Array.from({ length: 65 }, (_, index) => claimFixture(index));
+    const requests: Array<Record<string, unknown>> = [];
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as {
+        variables: Record<string, unknown>;
+      };
+      requests.push(request.variables);
+      const afterId = String(request.variables.afterId);
+      const first = Number(request.variables.first);
+      return json({
+        data: {
+          CreatorFeeClaim: rows
+            .filter((row) => row.id > afterId)
+            .slice(0, first),
+        },
+      });
+    });
+    const read = createEnvioClassicV2CreatorClaimReaderV1({ fetcher, release });
+
+    const claims = await read({
+      account: creator,
+      poolIds: [poolId],
+      throughBlock: "25799000",
+      deadlineMs: Date.now() + 5_000,
+    });
+
+    expect(claims).toHaveLength(65);
+    expect(claims[0]).toMatchObject({
+      blockNumber: rows[64]!.blockNumber,
+      poolId,
+      creator,
+      amountWei: rows[64]!.amount,
+      logIndex: Number(rows[64]!.blockGlobalLogIndex),
+    });
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({
+      afterId: "",
+      creator: creator.toLowerCase(),
+      hook,
+      poolIds: [poolId],
+      throughBlock: "25799000",
+      first: 64,
+    });
+  });
+
+  it("rejects a claim whose indexed source drifts from the release binding", async () => {
+    const fetcher = vi.fn(async () => json({
+      data: {
+        CreatorFeeClaim: [claimFixture(1, {
+          sourceAddress: "0x1111111111111111111111111111111111111111",
+        })],
+      },
+    }));
+    const read = createEnvioClassicV2CreatorClaimReaderV1({ fetcher, release });
+
+    await expect(read({
+      account: creator,
+      poolIds: [poolId],
+      throughBlock: "25799000",
+    })).rejects.toThrow("identity drifted");
+  });
+
+  it("rejects duplicate pool bindings before transport", async () => {
+    const fetcher = vi.fn();
+    const read = createEnvioClassicV2CreatorClaimReaderV1({ fetcher, release });
+
+    await expect(read({
+      account: creator,
+      poolIds: [poolId, poolId],
+      throughBlock: "25799000",
+    })).rejects.toThrow("request is invalid");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/tests/interaction-state-regressions.test.ts
+++ b/tests/interaction-state-regressions.test.ts
@@ -49,16 +49,16 @@ describe("interaction state regressions", () => {
     expect(actionAccessibleName).toContain("${tokenSymbol}");
   });
 
-  it("uses the active profile network for transaction links", () => {
+  it("reconciles submitted profile claims without a manual status action", () => {
     const source = readFileSync(
       join(root, "components/profile-view.tsx"),
       "utf8",
     );
 
-    expect(source).toMatch(
-      /function transactionHref[\s\S]*?chainId === 11_155_111[\s\S]*?sepolia\.etherscan\.io[\s\S]*?etherscan\.io/,
-    );
-    expect(source).toContain("View transaction");
+    expect(source).toContain("autoResumingProfileTransactionsRef");
+    expect(source).toContain('message: "Confirming on Ethereum"');
+    expect(source).not.toContain('return "Check status"');
+    expect(source).not.toContain("View transaction");
   });
 
   it("remounts token-detail trade state when the connected account changes", () => {

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -9,7 +9,6 @@ import {
   actionCanCheckStatus,
   actionLabel,
   actionPending,
-  buildFeeEarningsChart,
   buildProfilePortfolio,
   clearConfirmedProfileActionStates,
   getProfileSessionView,
@@ -19,7 +18,6 @@ import {
   groupPendingProfileTransactionStates,
   groupProfileRewards,
   parsePendingProfileTransactions,
-  parseClaimedFeeWei,
   paginateProfileClaimableEntries,
   profileClaimableWei,
   profileClaimActionCount,
@@ -30,6 +28,7 @@ import {
   ProfileRouterLaunches,
   profileRewardsForAccount,
   profileRewardActionErrorMessage,
+  profileTokenMarketCapLabel,
   profileTransactionPollAttempts,
   reflectedConfirmedProfileTransactions,
   resolveCreatorProfileReadFailure,
@@ -42,6 +41,7 @@ import {
   stockPairedCheckpointAfterReceipt,
   upsertPendingProfileTransactionRecords,
   waitForTransaction,
+  walletActionWasCancelled,
   withoutClosedDeepProfileData,
   type PendingProfileTransactionRecord,
   type StockPairedPendingStage,
@@ -143,9 +143,7 @@ describe("profile action error copy", () => {
       profileCreatorClaimErrorMessage(
         new Error("Transaction cancelled in wallet"),
       ),
-    ).toBe(
-      "Transaction cancelled. Your rewards are still available to claim.",
-    );
+    ).toBe("Transaction cancelled. Rewards remain available.");
     expect(
       profileCreatorClaimErrorMessage(new Error("private provider detail")),
     ).toBe(
@@ -158,9 +156,18 @@ describe("profile action error copy", () => {
       profileRewardActionErrorMessage(
         new Error("Deep reward action is not ready"),
       ),
-    ).toBe(
-      "The reward action was not completed. Check your wallet and try again.",
-    );
+    ).toBe("Unable to claim. Try again.");
+  });
+
+  it("recognizes nested wallet rejection without leaving a claim error", () => {
+    expect(walletActionWasCancelled({
+      cause: { code: 4001, message: "User rejected the request" },
+    })).toBe(true);
+    expect(
+      profileRewardActionErrorMessage({
+        cause: { code: 4001, message: "User rejected the request" },
+      }),
+    ).toBe("Transaction cancelled. Rewards remain available.");
   });
 });
 
@@ -370,12 +377,12 @@ describe("profile workspace loading state", () => {
     });
   });
 
-  it("contains five desktop claim rows inside the workspace while mobile keeps page flow", () => {
+  it("keeps paginated desktop claim rows top-aligned without an internal scrollbar", () => {
     expect(profileExperienceCss).toMatch(
       /@media \(min-width: 821px\) and \(min-height: 700px\)[\s\S]*?\.profileWorkspace\s*\{[\s\S]*?height: clamp\(/,
     );
     expect(profileExperienceCss).toMatch(
-      /@media \(min-width: 821px\) and \(min-height: 700px\)[\s\S]*?\.claimList\s*\{[\s\S]*?overflow-y: auto;/,
+      /@media \(min-width: 821px\) and \(min-height: 700px\)[\s\S]*?\.claimList\s*\{[\s\S]*?align-content: start;[\s\S]*?overflow: visible;/,
     );
     expect(profileExperienceCss).toMatch(
       /@media \(max-width: 820px\)[\s\S]*?\.profileWorkspace/,
@@ -401,160 +408,15 @@ describe("profile workspace loading state", () => {
   });
 });
 
-describe("fee earnings chart", () => {
-  it("builds a cumulative chart from confirmed claims without inferred accrual", () => {
-    const activity = [
-      {
-        id: "claim:new",
-        label: "Creator fees claimed",
-        detail: "0.3 ETH from NEW",
-        occurredAt: "Today",
-        occurredAtIso: "2026-08-04T11:30:00.000Z",
-        href: "/token/new",
-      },
-      {
-        id: "claim:old",
-        label: "Creator fees claimed",
-        detail: "0.2 ETH from OLD",
-        occurredAt: "Yesterday",
-        occurredAtIso: "2026-08-03T11:30:00.000Z",
-        href: "/token/old",
-      },
-    ];
-
-    expect(parseClaimedFeeWei("0.25 ETH from TEST")).toBe(
-      250_000_000_000_000_000n,
-    );
-    const chart = buildFeeEarningsChart(
-      activity,
-      500_000_000_000_000_000n,
-      100_000_000_000_000_000n,
-    );
-
-    expect(chart?.points.map((point) => point.valueWei)).toEqual([
-      0n,
-      200_000_000_000_000_000n,
-      500_000_000_000_000_000n,
-      500_000_000_000_000_000n,
-    ]);
-    expect(chart?.totalWei).toBe(500_000_000_000_000_000n);
-  });
-
-  it("uses exact 1H, 1D, 1W and all-time earnings windows", () => {
-    const nowMs = Date.parse("2026-08-04T12:00:00.000Z");
-    const activity = [
-      {
-        id: "claim:hour",
-        label: "Creator fees claimed",
-        detail: "0.1 ETH from NOW",
-        occurredAt: "Today",
-        occurredAtIso: "2026-08-04T11:30:00.000Z",
-        href: "/token/now",
-      },
-      {
-        id: "claim:day",
-        label: "Creator fees claimed",
-        detail: "0.2 ETH from DAY",
-        occurredAt: "Today",
-        occurredAtIso: "2026-08-04T06:00:00.000Z",
-        href: "/token/day",
-      },
-      {
-        id: "claim:week",
-        label: "Creator fees claimed",
-        detail: "0.3 ETH from WEEK",
-        occurredAt: "This week",
-        occurredAtIso: "2026-08-01T12:00:00.000Z",
-        href: "/token/week",
-      },
-      {
-        id: "claim:all",
-        label: "Creator fees claimed",
-        detail: "0.4 ETH from OLD",
-        occurredAt: "Last week",
-        occurredAtIso: "2026-07-24T12:00:00.000Z",
-        href: "/token/old",
-      },
-    ];
-
-    const hourly = buildFeeEarningsChart(
-      activity,
-      1_000_000_000_000_000_000n,
-      50_000_000_000_000_000n,
-      { nowMs, range: "1h" },
-    );
-    const daily = buildFeeEarningsChart(
-      activity,
-      1_000_000_000_000_000_000n,
-      50_000_000_000_000_000n,
-      { nowMs, range: "1d" },
-    );
-    const weekly = buildFeeEarningsChart(
-      activity,
-      1_000_000_000_000_000_000n,
-      50_000_000_000_000_000n,
-      { nowMs, range: "1w" },
-    );
-    const allTime = buildFeeEarningsChart(
-      activity,
-      1_000_000_000_000_000_000n,
-      50_000_000_000_000_000n,
-      { nowMs, range: "all" },
-    );
-
-    expect(hourly?.totalWei).toBe(100_000_000_000_000_000n);
-    expect(daily?.totalWei).toBe(300_000_000_000_000_000n);
-    expect(weekly?.totalWei).toBe(600_000_000_000_000_000n);
-    expect(allTime?.totalWei).toBe(1_000_000_000_000_000_000n);
-    expect(profileViewSource).toContain('role="slider"');
-    expect(profileViewSource).not.toContain("styles.claimHistory");
-  });
-
-  it("keeps short and long histories finite without a permanent endpoint marker", () => {
-    const nowMs = Date.parse("2026-08-04T12:00:00.000Z");
-    const oneClaim = buildFeeEarningsChart(
-      [
-        {
-          id: "claim:only",
-          label: "Creator fees claimed",
-          detail: "0.1 ETH from ONE",
-          occurredAt: "Today",
-          occurredAtIso: "2026-08-04T11:30:00.000Z",
-          href: "/token/one",
-        },
-      ],
-      100_000_000_000_000_000n,
-      0n,
-      { nowMs, range: "all" },
-    );
-    const longHistory = buildFeeEarningsChart(
-      Array.from({ length: 80 }, (_, index) => ({
-        id: `claim:${index}`,
-        label: "Creator fees claimed",
-        detail: "0.001 ETH from MANY",
-        occurredAt: "This week",
-        occurredAtIso: new Date(nowMs - (80 - index) * 60_000).toISOString(),
-        href: "/token/many",
-      })),
-      80_000_000_000_000_000n,
-      0n,
-      { nowMs, range: "all" },
-    );
-
-    for (const chart of [oneClaim, longHistory]) {
-      expect(chart).not.toBeNull();
-      expect(
-        chart?.points.every(
-          (point) => Number.isFinite(point.x) && Number.isFinite(point.y),
-        ),
-      ).toBe(true);
-    }
-    expect(profileViewSource).not.toContain("<circle");
-    expect(profileViewSource).not.toContain("styles.feeActivePoint");
-    expect(profileViewSource).toMatch(
-      /\{activePoint \? \([\s\S]*?className=\{styles\.feeCursor\}/,
-    );
-    expect(profileViewSource).toContain("onFocus={activateLastPoint}");
+describe("fee earnings summary", () => {
+  it("shows lifetime earned, available and claimed totals without a claim-history chart", () => {
+    expect(profileViewSource).toContain(">Fees earned</h2>");
+    expect(profileViewSource).toContain(">Lifetime fees for this wallet</p>");
+    expect(profileViewSource).toContain(">Total earned</span>");
+    expect(profileViewSource).toContain("Available <b>");
+    expect(profileViewSource).toContain("Claimed <b>");
+    expect(profileViewSource).not.toContain('role="slider"');
+    expect(profileViewSource).not.toContain("No confirmed claim history");
   });
 
   it("keeps the claim dialog focused on the selected token and actions", () => {
@@ -786,6 +648,14 @@ describe("profile reward grouping", () => {
         (token) => token.symbol,
       ),
     ).toEqual(["ETH_HIGH", "ETH_LOW"]);
+  });
+
+  it("formats a compact USD market cap for claim reward rows", () => {
+    expect(profileTokenMarketCapLabel({
+      ...tokens[0],
+      fdvUsdWad: "502400000000000000000000",
+    })).toBe("$502K");
+    expect(profileTokenMarketCapLabel(tokens[0])).toBeNull();
   });
 
   it("renders one portfolio entry when current and split rewards share a token", () => {
@@ -1105,7 +975,7 @@ describe("profile transaction status", () => {
         message: "Still pending on Ethereum",
         transactionHash,
       }),
-    ).toBe("Check status");
+    ).toBe("Confirming");
     expect(
       actionPending({
         account: firstAddress,
@@ -1113,7 +983,7 @@ describe("profile transaction status", () => {
         message: "Still pending on Ethereum",
         transactionHash,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("uses one receipt request for a manual status check", async () => {


### PR DESCRIPTION
## Summary
- index exact Classic V2 creator claim receipts from the bound Envio release and include claimed amounts in lifetime fee totals
- automatically reconcile submitted claims and remove manual status/check-transaction UI
- top-align paginated reward rows, remove internal scrolling, add refresh, and show market cap when available

## Focused validation
- 72 focused tests passed
- TypeScript passed
- changed-path ESLint passed
- production build passed
- candidate-neutrality and Custom production bundle scan passed

## Scope
No wallet signature, transaction, contract, registry, trade, profile-storage, or onchain mutation changes.