### PR TITLE
Fix Classic V3 reward claim preparation

### DIFF
--- a/app/api/profile/classic-v3/route.ts
+++ b/app/api/profile/classic-v3/route.ts
@@ -28,8 +28,8 @@ import {
 import { uerc20ReadAbi } from "@/lib/onchain/abis";
 import { getWebsiteReadOnchainDeployment } from "@/lib/onchain";
 import {
-  readBitqueryClassicV3Profile,
-} from "@/lib/market-data/bitquery-profile.server";
+  readEnvioClassicV3CatalogV1,
+} from "@/lib/market-data/envio-classic-v3-catalog.server";
 import {
   safeOperationalRpcError,
   withOperationalRpcFailover,
@@ -39,6 +39,7 @@ import {
   classicV3ProfileApiError,
   encodeClassicV3RewardAction,
 } from "@/lib/profile/classic-v3-rewards";
+import type { CanonicalTokenExploreEntry } from "@/lib/tokens";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -816,30 +817,38 @@ export async function POST(request: NextRequest) {
     if (!isClassicV3ReleaseVerified(manifest, releaseManifest, chain.id)) {
       return json({ error: "Classic is not deployed yet" }, 409);
     }
-    const profile = await readBitqueryClassicV3Profile(account);
-    if (profile.status !== "ready") {
-      return json({ error: "Classic is not deployed yet" }, 409);
-    }
-    const bitqueryReward = profile.rewards.find(
-      (candidate) =>
-        candidate.vaultAddress.toLowerCase() === vaultAddress.toLowerCase(),
+    const catalog = await readEnvioClassicV3CatalogV1({
+      signal: request.signal,
+      deadlineMs: Date.now() + 7_000,
+    });
+    const catalogReward = catalog.entries.find(
+      (candidate): candidate is CanonicalTokenExploreEntry =>
+        candidate.exploreKind === "token" &&
+        candidate.launchModelVersion === "classic-v3" &&
+        candidate.rewardVaultAddress?.toLowerCase() ===
+          vaultAddress.toLowerCase(),
     );
-    if (!bitqueryReward) {
+    if (
+      !catalogReward ||
+      catalogReward.rewardVaultAddress === undefined ||
+      typeof catalogReward.buyHookFeeBps !== "number" ||
+      typeof catalogReward.sellHookFeeBps !== "number"
+    ) {
       return json(
         { error: "Only a current or historic payout wallet can continue" },
         403,
       );
     }
     const reward: ClassicActionRewardIdentity = {
-      vaultAddress: bitqueryReward.vaultAddress,
-      poolId: bitqueryReward.poolId,
-      buySwapFeeBps: bitqueryReward.buySwapFeeBps,
-      sellSwapFeeBps: bitqueryReward.sellSwapFeeBps,
+      vaultAddress: catalogReward.rewardVaultAddress,
+      poolId: catalogReward.poolId,
+      buySwapFeeBps: catalogReward.buyHookFeeBps,
+      sellSwapFeeBps: catalogReward.sellHookFeeBps,
       buyCreatorFeeBps: null,
       sellCreatorFeeBps: null,
-      launcherFeeBps: bitqueryReward.platformFeeBps,
+      launcherFeeBps: 10,
       transferTaxBps: 0,
-      lpFeePips: 0,
+      lpFeePips: catalogReward.lpFeePips ?? 0,
     };
     const deployment = classicActionDeployment();
     const prepared = await withOperationalRpcFailover(

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -332,11 +332,11 @@ export function getProfileWorkspacePhase(
   terminalErrorReady: boolean,
   integrityConflict = false,
 ): ProfileWorkspacePhase {
+  if (integrityConflict) return "error";
+  if (statuses.some((status) => status === "ready")) return "ready";
   if (statuses.some((status) => status === "loading")) {
     return "loading";
   }
-  if (integrityConflict) return "error";
-  if (statuses.some((status) => status === "ready")) return "ready";
   if (!terminalErrorReady) return "loading";
   return "error";
 }
@@ -436,10 +436,19 @@ export function profileRewardActionErrorMessage(error: unknown) {
   if (walletActionWasCancelled(error)) {
     return "Transaction cancelled. Rewards remain available.";
   }
-  return error instanceof Error &&
-    error.message === walletChangedBeforeSubmission
-    ? error.message
-    : "Unable to claim. Try again.";
+  if (error instanceof Error) {
+    const message = error.message.trim();
+    if (
+      message === walletChangedBeforeSubmission ||
+      message === insufficientNetworkFee ||
+      /^(?:Connect an Ethereum wallet|Your wallet session expired|The wallet session changed|Wallet connection was interrupted|The wallet could not open|This wallet needs more ETH|There are no rewards to claim|The reward action could not be simulated)/u.test(
+        message,
+      )
+    ) {
+      return message;
+    }
+  }
+  return "Unable to claim. Try again.";
 }
 
 const pendingProfileTransactionStoragePrefix =
@@ -2909,25 +2918,6 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
             Connect wallet
           </button>
         </section>
-      </div>
-    );
-  }
-
-  const profileWorkspacePhase = getProfileWorkspacePhase(
-    [
-      scopedOnchainData.status,
-      scopedClassicV3Rewards.status,
-      scopedDeepRewards.status,
-      scopedDeepV3Profile.status,
-      scopedStockPairedRewards.status,
-    ],
-    terminalErrorReady,
-  );
-
-  if (profileWorkspacePhase === "loading") {
-    return (
-      <div className={`${styles.page} page-width`}>
-        <ProfileLoadingState />
       </div>
     );
   }

--- a/tests/classic-v3-action-activation.test.ts
+++ b/tests/classic-v3-action-activation.test.ts
@@ -12,7 +12,7 @@ vi.mock("server-only", () => ({}));
 const mocks = vi.hoisted(() => ({
   indexedEnabled: true,
   lookup: vi.fn(),
-  readProfile: vi.fn(),
+  readCatalog: vi.fn(),
   createPublicClient: vi.fn(),
   getWebsiteReadOnchainDeployment: vi.fn(),
   runtimeHashes: {
@@ -210,13 +210,8 @@ vi.mock("../lib/data-pipeline/action-lookup", async (importOriginal) => {
   };
 });
 
-vi.mock("../lib/market-data/bitquery-profile.server", () => ({
-  readBitqueryClassicV3Profile: mocks.readProfile,
-  readBitqueryClassicV3Launch: vi.fn(),
-  safeBitqueryProfileError: vi.fn(() => ({
-    name: "BitqueryProfileError",
-    category: "unexpected",
-  })),
+vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
+  readEnvioClassicV3CatalogV1: mocks.readCatalog,
 }));
 
 vi.mock("../lib/onchain", async (importOriginal) => {
@@ -260,23 +255,22 @@ describe("Classic V3 action identity activation", () => {
     vi.clearAllMocks();
     mocks.getWebsiteReadOnchainDeployment.mockReturnValue(deployment);
     mocks.lookup.mockResolvedValue(actionReward);
-    mocks.readProfile.mockResolvedValue({
-      status: "ready",
-      account,
-      chainId: 1,
-      rewards: [{
-        vaultAddress: vault,
+    mocks.readCatalog.mockResolvedValue({
+      entries: [{
+        exploreKind: "token",
+        launchModelVersion: "classic-v3",
+        rewardVaultAddress: vault,
         poolId,
-        buySwapFeeBps: 100,
-        sellSwapFeeBps: 100,
-        platformFeeBps: 10,
+        buyHookFeeBps: 100,
+        sellHookFeeBps: 100,
+        lpFeePips: 0,
       }],
     });
     mocks.createPublicClient.mockImplementation(() => actionClient(0));
   });
 
   it.each([true, false])(
-    "uses Bitquery identity and one RPC when indexed lookup is %s",
+    "uses Envio identity and one RPC when indexed lookup is %s",
     async (indexedEnabled) => {
       mocks.indexedEnabled = indexedEnabled;
 
@@ -296,7 +290,7 @@ describe("Classic V3 action identity activation", () => {
         },
       });
       expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
-      expect(mocks.readProfile).toHaveBeenCalledTimes(1);
+      expect(mocks.readCatalog).toHaveBeenCalledTimes(1);
       expect(mocks.lookup).not.toHaveBeenCalled();
     },
   );
@@ -318,7 +312,7 @@ describe("Classic V3 action identity activation", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.createPublicClient).toHaveBeenCalledTimes(2);
-    expect(mocks.readProfile).toHaveBeenCalledTimes(1);
+    expect(mocks.readCatalog).toHaveBeenCalledTimes(1);
     expect(serialized).not.toContain("drpc-classic-key");
     expect(serialized).not.toContain("quicknode-classic-key");
   });

--- a/tests/classic-v3-profile-route.test.ts
+++ b/tests/classic-v3-profile-route.test.ts
@@ -33,8 +33,7 @@ const mocks = vi.hoisted(() => {
   return {
     client,
     createPublicClient: vi.fn(() => client),
-    readBitqueryClassicV3Launch: vi.fn(),
-    readBitqueryClassicV3Profile: vi.fn(),
+    readEnvioClassicV3CatalogV1: vi.fn(),
     runtimeCodes,
   };
 });
@@ -64,10 +63,8 @@ vi.mock("viem", async (importOriginal) => {
   };
 });
 
-vi.mock("../lib/market-data/bitquery-profile.server", () => ({
-  readBitqueryClassicV3Launch: mocks.readBitqueryClassicV3Launch,
-  readBitqueryClassicV3Profile: mocks.readBitqueryClassicV3Profile,
-  safeBitqueryProfileError: vi.fn((error) => error),
+vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
+  readEnvioClassicV3CatalogV1: mocks.readEnvioClassicV3CatalogV1,
 }));
 
 import {
@@ -86,12 +83,7 @@ describe("Classic profile release gate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.createPublicClient.mockReturnValue(mocks.client);
-    mocks.readBitqueryClassicV3Profile.mockResolvedValue({
-      status: "ready",
-      account,
-      chainId: 1,
-      rewards: [],
-    });
+    mocks.readEnvioClassicV3CatalogV1.mockResolvedValue({ entries: [] });
     vi.stubEnv("ETHEREUM_RPC_URL", drpcRpcUrl);
     vi.stubEnv("ETHEREUM_RPC_URL_B", quickNodeRpcUrl);
     vi.stubEnv("PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER", "drpc");
@@ -142,7 +134,6 @@ describe("Classic profile release gate", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.readBitqueryClassicV3Profile).not.toHaveBeenCalled();
     expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
       "rpc",
@@ -173,7 +164,6 @@ describe("Classic profile release gate", () => {
       },
     });
     expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
-    expect(mocks.readBitqueryClassicV3Profile).not.toHaveBeenCalled();
   });
 
   it("rejects invalid launch lookup hashes before reading a provider", async () => {
@@ -187,7 +177,6 @@ describe("Classic profile release gate", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Enter a valid launch transaction hash",
     });
-    expect(mocks.readBitqueryClassicV3Launch).not.toHaveBeenCalled();
     expect(mocks.createPublicClient).not.toHaveBeenCalled();
   });
 

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -157,6 +157,15 @@ describe("profile action error copy", () => {
         new Error("Deep reward action is not ready"),
       ),
     ).toBe("Unable to claim. Try again.");
+    expect(
+      profileRewardActionErrorMessage(
+        new Error(
+          "The reward action could not be simulated from current onchain state",
+        ),
+      ),
+    ).toBe(
+      "The reward action could not be simulated from current onchain state",
+    );
   });
 
   it("recognizes nested wallet rejection without leaving a claim error", () => {
@@ -266,10 +275,10 @@ describe("profile workspace loading state", () => {
     ).toBe("loading");
   });
 
-  it("reveals one complete workspace after optional reward sources finish", () => {
+  it("reveals verified rewards while optional sources continue loading", () => {
     expect(
       getProfileWorkspacePhase(["error", "ready", "loading"], false),
-    ).toBe("loading");
+    ).toBe("ready");
     expect(
       getProfileWorkspacePhase(
         ["error", "ready", "not-deployed"],
@@ -283,7 +292,7 @@ describe("profile workspace loading state", () => {
       ),
     ).toBe("error");
     expect(profileViewSource).toMatch(
-      /if \(statuses\.some\(\(status\) => status === "loading"\)\)[\s\S]*?return "loading";[\s\S]*?status === "ready"/,
+      /if \(integrityConflict\) return "error";[\s\S]*?status === "ready"[\s\S]*?status === "loading"/,
     );
   });
 
@@ -389,11 +398,14 @@ describe("profile workspace loading state", () => {
     );
   });
 
-  it("keeps profile loading visually empty and reveals only resolved content", () => {
+  it("reveals the profile shell while reward sources load progressively", () => {
     expect(profileViewSource).toContain(
       'className={styles.profileLoadingState}',
     );
     expect(profileViewSource).toContain(
+      'if (phase === "loading")',
+    );
+    expect(profileViewSource).not.toContain(
       'if (profileWorkspacePhase === "loading")',
     );
     expect(profileViewSource).not.toContain("styles.sessionLoadingWorkspace");


### PR DESCRIPTION
## Summary
- bind Classic V3 claim preparation to the verified Envio catalog instead of Bitquery availability
- retain exact current vault, pool, fee, simulation, gas, and balance verification through the bound Website RPC
- reveal verified profile content progressively and preserve actionable wallet/server errors

## Focused verification
- 63 focused Classic V3 action/profile/UI tests
- 91 read-model operations source-contract tests
- TypeScript typecheck
- changed-path ESLint
- git diff --check

No wallet transaction was submitted.