### PR TITLE
Harden trade slippage and reward action retries

### DIFF
--- a/components/custom-market-trade.tsx
+++ b/components/custom-market-trade.tsx
@@ -21,6 +21,34 @@ import styles from "./token-experience.module.css";
 
 type CustomMarket = CustomProjectExploreEntry["markets"][number];
 
+export const DEFAULT_CUSTOM_TRADE_SLIPPAGE_BPS = 500;
+
+export function customTradeSlippagePercent(
+  maximumSlippageBps: number,
+  currentPercent?: string,
+) {
+  if (!Number.isSafeInteger(maximumSlippageBps) || maximumSlippageBps < 1) {
+    throw new TypeError("Custom trade slippage policy is invalid");
+  }
+  const fallbackBps = Math.min(
+    DEFAULT_CUSTOM_TRADE_SLIPPAGE_BPS,
+    maximumSlippageBps,
+  );
+  if (currentPercent === undefined) return String(fallbackBps / 100);
+
+  const normalized = currentPercent.trim();
+  if (!/^\d+(?:\.\d{1,2})?$/u.test(normalized)) {
+    return String(fallbackBps / 100);
+  }
+  const [whole, fraction = ""] = normalized.split(".");
+  const currentBps = Number(whole) * 100
+    + Number(fraction.padEnd(2, "0"));
+  if (!Number.isSafeInteger(currentBps) || currentBps < 1) {
+    return String(fallbackBps / 100);
+  }
+  return String(Math.min(currentBps, maximumSlippageBps) / 100);
+}
+
 function assetLabel(asset: CustomMarket["baseAsset"]) {
   return asset.symbol?.trim() || asset.name?.trim() || asset.assetId;
 }
@@ -73,7 +101,10 @@ export function CustomMarketTrade({
   );
   const [amount, setAmount] = useState("");
   const [slippage, setSlippage] = useState(
-    String(Math.min(100, capability?.slippagePolicy.maximumSlippageBps ?? 100) / 100),
+    customTradeSlippagePercent(
+      capability?.slippagePolicy.maximumSlippageBps
+        ?? DEFAULT_CUSTOM_TRADE_SLIPPAGE_BPS,
+    ),
   );
   const [pending, setPending] = useState(false);
   const [error, setError] = useState("");
@@ -272,6 +303,12 @@ export function CustomMarketTrade({
           )?.tradeCapability;
           setMarketId(nextMarketId);
           setSelectedSide(nextCapability?.supportedSides[0] ?? "base-to-quote");
+          if (nextCapability) {
+            setSlippage((current) => customTradeSlippagePercent(
+              nextCapability.slippagePolicy.maximumSlippageBps,
+              current,
+            ));
+          }
           setAmount("");
           setError("");
         }}>

--- a/components/token-trade.tsx
+++ b/components/token-trade.tsx
@@ -33,7 +33,7 @@ type WalletTradeBalanceState =
       status: "error";
     };
 
-export const DEFAULT_TRADE_SLIPPAGE_BPS = 100;
+export const DEFAULT_TRADE_SLIPPAGE_BPS = 500;
 export const MIN_BUY_GAS_RESERVE_WEI = parseEther("0.003");
 const BUY_GAS_RESERVE_UNITS = 500_000n;
 const BUY_GAS_RESERVE_MULTIPLIER = 150n;

--- a/lib/profile/classic-v3-rewards.ts
+++ b/lib/profile/classic-v3-rewards.ts
@@ -603,31 +603,44 @@ export async function prepareClassicV3RewardAction(
   },
   signal?: AbortSignal,
   fetcher: FetchLike = fetch,
+  options: Readonly<{
+    retryDelayMs?: number;
+    wait?: (delayMs: number, signal?: AbortSignal) => Promise<void>;
+  }> = {},
 ) {
   assertClassicV3ReleaseAvailable(input.chainId);
-  const response = await fetcher("/api/profile/classic-v3", {
-    method: "POST",
-    cache: "no-store",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      action: input.action,
-      account: input.account,
-      vaultAddress: input.vaultAddress,
-      ...(input.action === "update-payout"
-        ? {
-            allocationIndex: input.allocationIndex,
-            newPayoutAddress: input.newPayoutAddress,
-          }
-        : {}),
-      chainId: input.chainId,
-    }),
-    signal,
-  });
-  const body = await response.json();
-  if (!response.ok) {
+  const wait = options.wait ?? waitForProfileRetry;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_PROFILE_RETRY_DELAY_MS;
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const response = await fetcher("/api/profile/classic-v3", {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        action: input.action,
+        account: input.account,
+        vaultAddress: input.vaultAddress,
+        ...(input.action === "update-payout"
+          ? {
+              allocationIndex: input.allocationIndex,
+              newPayoutAddress: input.newPayoutAddress,
+            }
+          : {}),
+        chainId: input.chainId,
+      }),
+      signal,
+    });
+    const body = await response.json();
+    if (response.ok) {
+      return validatePreparedClassicV3RewardAction(body, input);
+    }
+    if ((response.status === 502 || response.status === 503) && attempt === 1) {
+      await wait(retryDelayMs, signal);
+      continue;
+    }
     const record =
       body && typeof body === "object" && !Array.isArray(body)
         ? (body as Record<string, unknown>)
@@ -638,7 +651,7 @@ export async function prepareClassicV3RewardAction(
         : "Classic reward action could not be prepared",
     );
   }
-  return validatePreparedClassicV3RewardAction(body, input);
+  throw new Error("Classic reward action could not be prepared");
 }
 
 export function encodeClassicV3RewardAction(input: {

--- a/tests/classic-v3-profile.test.ts
+++ b/tests/classic-v3-profile.test.ts
@@ -7,6 +7,7 @@ import {
   classicV3ProfileApiError,
   fetchClassicV3ProfileRewards,
   parseClassicV3ProfileRewards,
+  prepareClassicV3RewardAction,
   validatePreparedClassicV3RewardAction,
 } from "../lib/profile/classic-v3-rewards";
 
@@ -315,6 +316,52 @@ describe("Classic V3 profile rewards", () => {
         },
       ),
     ).toThrow("not canonical");
+  });
+
+  it("retries one transient claim-preparation failure before opening the wallet", async () => {
+    const transaction = {
+      kind: "claim-classic-v3-rewards" as const,
+      chainId: 1 as const,
+      from: account,
+      to: vault,
+      data: encodeFunctionData({
+        abi: classicRewardVaultAbi,
+        functionName: "claim",
+      }),
+      value: "0",
+      gasLimit: "120000",
+    };
+    const responses = [
+      new Response(JSON.stringify({ error: "temporarily unavailable" }), {
+        status: 502,
+        headers: { "Content-Type": "application/json" },
+      }),
+      new Response(JSON.stringify({
+        status: "ready",
+        action: "claim",
+        account,
+        vaultAddress: vault,
+        transaction,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ];
+    const fetcher = vi.fn(async () => responses.shift()!);
+    const wait = vi.fn(async () => undefined);
+
+    await expect(prepareClassicV3RewardAction({
+      action: "claim",
+      account,
+      vaultAddress: vault,
+      chainId: 1,
+    }, undefined, fetcher, { wait })).resolves.toMatchObject({
+      action: "claim",
+      account,
+      vaultAddress: vault,
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledTimes(1);
   });
 
   it("updates payout in one step without changing claim authority", () => {

--- a/tests/custom-market-trade-v1.test.ts
+++ b/tests/custom-market-trade-v1.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  DEFAULT_CUSTOM_TRADE_SLIPPAGE_BPS,
+  customTradeSlippagePercent,
+} from "../components/custom-market-trade";
+
 import type { DiscoverableMarketTradeCapabilityV1 } from
   "../lib/custom-launch/contract-v2";
 import { parseDiscoverableMarketTradeCapabilityV1 } from
@@ -212,6 +217,15 @@ function preparation() {
 }
 
 describe("Custom market trade v1", () => {
+  it("defaults to five percent without exceeding the verified market cap", () => {
+    expect(DEFAULT_CUSTOM_TRADE_SLIPPAGE_BPS).toBe(500);
+    expect(customTradeSlippagePercent(1_000)).toBe("5");
+    expect(customTradeSlippagePercent(250)).toBe("2.5");
+    expect(customTradeSlippagePercent(250, "5")).toBe("2.5");
+    expect(customTradeSlippagePercent(1_000, "0.75")).toBe("0.75");
+    expect(customTradeSlippagePercent(1_000, "")).toBe("5");
+  });
+
   it("accepts only the complete canonical capability shape at the client boundary", () => {
     const parse = (value: unknown) => parseDiscoverableMarketTradeCapabilityV1({
       value,

--- a/tests/trade-component.test.ts
+++ b/tests/trade-component.test.ts
@@ -19,8 +19,8 @@ const OWNER = getAddress("0x5555555555555555555555555555555555555555");
 const TOKEN = getAddress("0x1111111111111111111111111111111111111111");
 
 describe("TokenTrade request construction", () => {
-  it("defaults to one percent slippage", () => {
-    expect(DEFAULT_TRADE_SLIPPAGE_BPS).toBe(100);
+  it("defaults to five percent slippage", () => {
+    expect(DEFAULT_TRADE_SLIPPAGE_BPS).toBe(500);
   });
 
   it("converts editable percentage input to basis points", () => {


### PR DESCRIPTION
## Outcome
- defaults Classic trades to editable 5% slippage
- defaults verified Custom markets to 5% or their lower Registry-bound maximum
- clamps slippage when switching to a Custom market with a lower verified limit
- retries Classic V3 reward preparation once only after a transient 502/503

## Focused verification
- 46 Trade/Custom/Classic V3 tests
- TypeScript typecheck
- changed-path ESLint
- diff check
- live browser: copy, filters+search, pagination, chart ranges, buy/sell, editable slippage, wallet modal; no console errors

## Explicit boundary
Custom V2 public readiness is currently 503 and its production activation bindings are absent. This PR does not invent a universal Custom claim ABI or bypass Registry verification.