### PR TITLE
fix(explore): allow index progress across filter pages

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1017,7 +1017,6 @@ function exploreCatalogBoundaryKey(value: ExploreCatalogBoundary) {
     scope: value.scope,
     deployment: value.evidence.deployment,
     sourceCommit: value.evidence.sourceCommit,
-    evidenceCommitment: value.evidence.commitment,
   });
 }
 

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -881,6 +881,9 @@ describe("Explore refresh state", () => {
           evidence: {
             ...catalogBoundary.evidence,
             progressBlock: asOfBlock,
+            commitment: page === 1
+              ? catalogBoundary.evidence.commitment
+              : `sha256:${"ef".repeat(32)}`,
           },
         },
       }), { status: 200 });


### PR DESCRIPTION
## Summary
- keep multi-page filtering bound to the exact token identity commitment, deployment, source commit and public scope
- allow the Envio progress evidence snapshot to advance between otherwise identity-identical pages
- cover the production-observed progress/evidence drift

## Validation
- `npx vitest run tests/explore-view-state.test.ts` (55/55)
- `npm run typecheck`
- changed-path ESLint
- `git diff --check`