### PR TITLE
Fix historical creator reward claims

### DIFF
--- a/app/api/explore/profile/claim/route.ts
+++ b/app/api/explore/profile/claim/route.ts
@@ -16,6 +16,7 @@ import {
   CreatorClaimInputError,
   CreatorClaimUnavailableError,
   buildPreparedCreatorClaim,
+  getCreatorClaimOnchainDeployments,
   getWebsiteReadOnchainDeployment,
   parseCreatorClaimRequest,
 } from "../../../../../lib/onchain";
@@ -101,26 +102,22 @@ async function simulateCreatorClaim(input: {
 
 async function readCurrentClaimState(input: {
   client: PublicClient;
-  deployment: Extract<
-    ReturnType<typeof getWebsiteReadOnchainDeployment>,
-    { status: "ready" }
-  >;
   token: CreatorClaimTokenIdentity;
   blockNumber: bigint;
 }) {
-  const { client, deployment, token, blockNumber } = input;
+  const { client, token, blockNumber } = input;
   const [hookCode, launcherCode, config, disclosure] = await Promise.all([
-    client.getCode({ address: deployment.feeHook, blockNumber }),
-    client.getCode({ address: deployment.launcher, blockNumber }),
+    client.getCode({ address: token.hookAddress, blockNumber }),
+    client.getCode({ address: token.launcherAddress, blockNumber }),
     client.readContract({
-      address: deployment.feeHook,
+      address: token.hookAddress,
       abi: creatorFeeHookReadAbi,
       functionName: "poolFeeConfig",
       args: [token.poolId],
       blockNumber,
     }),
     client.readContract({
-      address: deployment.feeHook,
+      address: token.hookAddress,
       abi: creatorFeeHookReadAbi,
       functionName: "feeDisclosure",
       args: [token.poolId],
@@ -131,11 +128,11 @@ async function readCurrentClaimState(input: {
     !hookCode ||
     hookCode === "0x" ||
     keccak256(hookCode).toLowerCase() !==
-      deployment.feeHookRuntimeCodeHash.toLowerCase() ||
+      token.hookRuntimeCodeHash.toLowerCase() ||
     !launcherCode ||
     launcherCode === "0x" ||
     keccak256(launcherCode).toLowerCase() !==
-      deployment.launcherRuntimeCodeHash.toLowerCase()
+      token.launcherRuntimeCodeHash.toLowerCase()
   ) {
     throw new CreatorClaimUnavailableError(
       "runtime-mismatch",
@@ -146,7 +143,8 @@ async function readCurrentClaimState(input: {
   if (
     !registered ||
     getAddress(creator).toLowerCase() !== token.creatorAddress.toLowerCase() ||
-    getAddress(registrar).toLowerCase() !== deployment.launcher.toLowerCase() ||
+    getAddress(registrar).toLowerCase() !==
+      token.launcherAddress.toLowerCase() ||
     Number(totalSwapFeeBps) !== token.totalSwapFeeBps ||
     disclosure.some(
       (value) => !Number.isSafeInteger(Number(value)) || Number(value) < 0,
@@ -250,6 +248,15 @@ export async function POST(request: NextRequest) {
         `Switch to chain ${deployment.chainId}`,
       );
     }
+    let releases;
+    try {
+      releases = getCreatorClaimOnchainDeployments(deployment);
+    } catch {
+      throw new CreatorClaimUnavailableError(
+        "runtime-mismatch",
+        "The creator claim releases do not match their manifests",
+      );
+    }
     const response = await withOperationalRpcFailover(
       deployment,
       async (selected) => {
@@ -257,7 +264,7 @@ export async function POST(request: NextRequest) {
         const snapshot = await currentClaimSnapshot(client);
         const token = await readCreatorClaimIdentityFromRpc({
           client,
-          deployment,
+          releases,
           poolId: claimRequest.poolId,
           blockNumber: snapshot.blockNumber,
         });
@@ -272,7 +279,6 @@ export async function POST(request: NextRequest) {
         }
         const state = await readCurrentClaimState({
           client,
-          deployment,
           token,
           blockNumber: snapshot.blockNumber,
         });
@@ -291,7 +297,7 @@ export async function POST(request: NextRequest) {
         const value = 0n;
         const transaction = {
           account: claimRequest.account,
-          to: deployment.feeHook,
+          to: token.hookAddress,
           data,
           value,
         };
@@ -304,7 +310,7 @@ export async function POST(request: NextRequest) {
           account: claimRequest.account,
           poolId: claimRequest.poolId,
           tokenAddress: token.tokenAddress,
-          hookAddress: deployment.feeHook,
+          hookAddress: token.hookAddress,
           snapshotClaimableWei: claimable.toString(),
           snapshotClaimableEth: formatUnits(claimable, 18),
           snapshot: {
@@ -317,7 +323,7 @@ export async function POST(request: NextRequest) {
             kind: "claim-creator-fees" as const,
             chainId: deployment.chainId,
             from: claimRequest.account,
-            to: deployment.feeHook,
+            to: token.hookAddress,
             data,
             value: "0" as const,
           },

--- a/lib/onchain/config.ts
+++ b/lib/onchain/config.ts
@@ -6,6 +6,7 @@ import sepoliaDependencies from "../../contracts/dependencies/ethereum-sepolia.j
 import type {
   DeploymentEnvironment,
   OnchainDeployment,
+  ReadyOnchainDeployment,
 } from "./types";
 import { productionMainnetRpcPair } from
   "./website-rpc-providers.server";
@@ -29,6 +30,18 @@ type DeploymentEntry = {
     releaseEligible?: boolean;
     requiredRelease?: string;
     independentRpcCount?: number;
+  };
+  historicalV1Deployment?: {
+    releaseVersion: "classic-v1";
+    ethCreatorFeeHook?: string | null;
+    memeLaunch?: string | null;
+    runtimeCodeHashes?: {
+      ethCreatorFeeHook?: string | null;
+      memeLaunch?: string | null;
+    };
+    deploymentBlocks?: {
+      memeLaunch?: number | null;
+    };
   };
 };
 
@@ -254,6 +267,77 @@ export function getWebsiteReadOnchainDeployment(
       secondary: rpc.secondary.provider,
     },
   };
+}
+
+export function getCreatorClaimOnchainDeployments(
+  current: ReadyOnchainDeployment,
+): readonly ReadyOnchainDeployment[] {
+  if (current.environment !== "production") return [current];
+  const production = (appDeploymentsJson as unknown as AppDeployments)
+    .production;
+  const historical = production.historicalV1Deployment;
+  const currentLauncher = asAddress(production.memeLaunch);
+  const currentHook = asAddress(production.ethCreatorFeeHook);
+  const currentLauncherHash = asBytes32(
+    production.runtimeCodeHashes?.memeLaunch,
+  );
+  const currentHookHash = asBytes32(
+    production.runtimeCodeHashes?.ethCreatorFeeHook,
+  );
+  if (
+    current.chainId !== 1 ||
+    current.releaseVersion !== "classic-v2" ||
+    !currentLauncher ||
+    !currentHook ||
+    !currentLauncherHash ||
+    !currentHookHash ||
+    current.launcher !== currentLauncher ||
+    current.feeHook !== currentHook ||
+    current.launcherRuntimeCodeHash.toLowerCase() !==
+      currentLauncherHash.toLowerCase() ||
+    current.feeHookRuntimeCodeHash.toLowerCase() !==
+      currentHookHash.toLowerCase()
+  ) {
+    throw new Error(
+      "Current creator claim deployment does not match its manifest",
+    );
+  }
+
+  const launcher = asAddress(historical?.memeLaunch);
+  const feeHook = asAddress(historical?.ethCreatorFeeHook);
+  const launcherRuntimeCodeHash = asBytes32(
+    historical?.runtimeCodeHashes?.memeLaunch,
+  );
+  const feeHookRuntimeCodeHash = asBytes32(
+    historical?.runtimeCodeHashes?.ethCreatorFeeHook,
+  );
+  const deploymentBlockValue = historical?.deploymentBlocks?.memeLaunch;
+  if (
+    historical?.releaseVersion !== "classic-v1" ||
+    !launcher ||
+    !feeHook ||
+    !launcherRuntimeCodeHash ||
+    !feeHookRuntimeCodeHash ||
+    typeof deploymentBlockValue !== "number" ||
+    !Number.isSafeInteger(deploymentBlockValue) ||
+    deploymentBlockValue < 0
+  ) {
+    throw new Error(
+      "Historical creator claim deployment is not manifest verified",
+    );
+  }
+  return [
+    {
+      ...current,
+      releaseVersion: "classic-v1",
+      launcher,
+      feeHook,
+      launcherRuntimeCodeHash,
+      feeHookRuntimeCodeHash,
+      deploymentBlock: BigInt(deploymentBlockValue),
+    },
+    current,
+  ];
 }
 
 /**

--- a/lib/onchain/index.ts
+++ b/lib/onchain/index.ts
@@ -1,4 +1,5 @@
 export {
+  getCreatorClaimOnchainDeployments,
   getOnchainDeployment,
   getOperationalOnchainDeployment,
   getPublicOnchainDeployment,

--- a/lib/server/action-rpc-identity.server.ts
+++ b/lib/server/action-rpc-identity.server.ts
@@ -407,6 +407,9 @@ export async function readTradeActionModelFromRpc(input: {
 export type CreatorClaimTokenIdentity = Readonly<{
   tokenAddress: Address;
   hookAddress: Address;
+  launcherAddress: Address;
+  launcherRuntimeCodeHash: Hex;
+  hookRuntimeCodeHash: Hex;
   poolId: Hex;
   creatorAddress: Address;
   totalSwapFeeBps: number;
@@ -414,32 +417,34 @@ export type CreatorClaimTokenIdentity = Readonly<{
 
 export async function readCreatorClaimIdentityFromRpc(input: {
   client: PublicClient;
-  deployment: ReadyOnchainDeployment;
+  releases: readonly ReadyOnchainDeployment[];
   poolId: Hex;
   blockNumber: bigint;
 }): Promise<CreatorClaimTokenIdentity> {
-  const logs = [];
-  for (
-    let fromBlock = input.deployment.deploymentBlock;
-    fromBlock <= input.blockNumber;
-    fromBlock += CREATOR_CLAIM_LOG_RANGE
-  ) {
-    const toBlock =
-      fromBlock + CREATOR_CLAIM_LOG_RANGE - 1n < input.blockNumber
-        ? fromBlock + CREATOR_CLAIM_LOG_RANGE - 1n
-        : input.blockNumber;
-    logs.push(...await input.client.getLogs({
-      address: input.deployment.launcher,
-      event: memeTokenLaunchedEvent,
-      args: { poolId: input.poolId },
-      fromBlock,
-      toBlock,
-      strict: true,
-    }));
-  }
-  const matches = logs.filter(
-    (log) => !log.removed && log.blockNumber !== null,
-  );
+  const matches = (await Promise.all(input.releases.map(async (release) => {
+    const logs = [];
+    for (
+      let fromBlock = release.deploymentBlock;
+      fromBlock <= input.blockNumber;
+      fromBlock += CREATOR_CLAIM_LOG_RANGE
+    ) {
+      const toBlock =
+        fromBlock + CREATOR_CLAIM_LOG_RANGE - 1n < input.blockNumber
+          ? fromBlock + CREATOR_CLAIM_LOG_RANGE - 1n
+          : input.blockNumber;
+      logs.push(...await input.client.getLogs({
+        address: release.launcher,
+        event: memeTokenLaunchedEvent,
+        args: { poolId: input.poolId },
+        fromBlock,
+        toBlock,
+        strict: true,
+      }));
+    }
+    return logs
+      .filter((log) => !log.removed && log.blockNumber !== null)
+      .map((launch) => ({ launch, release }));
+  }))).flat();
   if (matches.length === 0) {
     throw new ActionRpcIdentityError(
       "unknown-pool",
@@ -452,11 +457,11 @@ export async function readCreatorClaimIdentityFromRpc(input: {
       "The pool matches more than one canonical launch",
     );
   }
-  const launch = matches[0];
+  const { launch, release } = matches[0];
   const token = getAddress(launch.args.token);
   const hook = getAddress(launch.args.feeHook);
   const launchCreator = getAddress(launch.args.creator);
-  if (!sameHex(hook, input.deployment.feeHook)) {
+  if (!sameHex(hook, release.feeHook)) {
     throw new ActionRpcIdentityError(
       "identity-mismatch",
       "The pool does not use the canonical creator fee hook",
@@ -464,14 +469,14 @@ export async function readCreatorClaimIdentityFromRpc(input: {
   }
   const [launchHash, poolKey, tokenCreator] = await Promise.all([
     input.client.readContract({
-      address: input.deployment.launcher,
+      address: release.launcher,
       abi: classicLauncherStateAbi,
       functionName: "launchHashOf",
       args: [token],
       blockNumber: input.blockNumber,
     }),
     input.client.readContract({
-      address: input.deployment.launcher,
+      address: release.launcher,
       abi: classicLauncherStateAbi,
       functionName: "poolKey",
       args: [token],
@@ -494,7 +499,7 @@ export async function readCreatorClaimIdentityFromRpc(input: {
   if (
     !sameHex(launchHash, launch.args.launchHash) ||
     !sameHex(canonicalId, input.poolId) ||
-    !sameHex(tokenCreator, input.deployment.launcher)
+    !sameHex(tokenCreator, release.launcher)
   ) {
     throw new ActionRpcIdentityError(
       "identity-mismatch",
@@ -504,6 +509,9 @@ export async function readCreatorClaimIdentityFromRpc(input: {
   return {
     tokenAddress: token,
     hookAddress: hook,
+    launcherAddress: release.launcher,
+    launcherRuntimeCodeHash: release.launcherRuntimeCodeHash,
+    hookRuntimeCodeHash: release.feeHookRuntimeCodeHash,
     poolId: input.poolId,
     creatorAddress: launchCreator,
     totalSwapFeeBps: launch.args.totalSwapFeeBps,

--- a/tests/action-rpc-identity.test.ts
+++ b/tests/action-rpc-identity.test.ts
@@ -23,6 +23,12 @@ const creator = getAddress("0x1111111111111111111111111111111111111111");
 const token = getAddress("0x2222222222222222222222222222222222222222");
 const hook = getAddress("0x3333333333333333333333333333333333333333");
 const launcher = getAddress("0x4444444444444444444444444444444444444444");
+const historicalHook = getAddress(
+  "0x7777777777777777777777777777777777777777",
+);
+const historicalLauncher = getAddress(
+  "0x8888888888888888888888888888888888888888",
+);
 const blockHash = `0x${"55".repeat(32)}` as Hex;
 const launchHash = `0x${"66".repeat(32)}` as Hex;
 const poolId = computeOfficialV4PoolId({
@@ -129,13 +135,16 @@ describe("single-RPC action identity", () => {
     await expect(
       readCreatorClaimIdentityFromRpc({
         client,
-        deployment,
+        releases: [deployment],
         poolId,
         blockNumber: 20_100n,
       }),
     ).resolves.toEqual({
       tokenAddress: token,
       hookAddress: hook,
+      launcherAddress: launcher,
+      launcherRuntimeCodeHash: deployment.launcherRuntimeCodeHash,
+      hookRuntimeCodeHash: deployment.feeHookRuntimeCodeHash,
       poolId,
       creatorAddress: creator,
       totalSwapFeeBps: 100,
@@ -168,5 +177,98 @@ describe("single-RPC action identity", () => {
         blockNumber: 20_100n,
       }),
     );
+  });
+
+  it("resolves a creator claim against the exact historical release that launched the pool", async () => {
+    const historicalPoolId = computeOfficialV4PoolId({
+      currency0: ZERO,
+      currency1: token,
+      fee: 0,
+      tickSpacing: 200,
+      hooks: historicalHook,
+    });
+    const historicalDeployment: ReadyOnchainDeployment = {
+      ...deployment,
+      releaseVersion: "classic-v1",
+      launcher: historicalLauncher,
+      feeHook: historicalHook,
+      launcherRuntimeCodeHash: `0x${"99".repeat(32)}`,
+      feeHookRuntimeCodeHash: `0x${"aa".repeat(32)}`,
+      deploymentBlock: 5n,
+    };
+    const launchLog = {
+      address: historicalLauncher,
+      args: {
+        creator,
+        token,
+        poolId: historicalPoolId,
+        feeHook: historicalHook,
+        positionRecipient: creator,
+        positionTokenId: 1n,
+        totalSwapFeeBps: 100,
+        launchHash,
+      },
+      blockNumber: 50n,
+      transactionHash: `0x${"bb".repeat(32)}`,
+      transactionIndex: 0,
+      logIndex: 0,
+      removed: false,
+    };
+    const getLogs = vi.fn(
+      ({ address, fromBlock, toBlock }: {
+        address: Address;
+        fromBlock: bigint;
+        toBlock: bigint;
+      }) => Promise.resolve(
+        address === historicalLauncher &&
+          fromBlock <= launchLog.blockNumber &&
+          launchLog.blockNumber <= toBlock
+          ? [launchLog]
+          : [],
+      ),
+    );
+    const readContract = vi.fn(
+      ({ address, functionName }: { address: Address; functionName: string }) => {
+        if (address !== historicalLauncher && address !== token) {
+          throw new Error(`Unexpected release address ${address}`);
+        }
+        if (functionName === "launchHashOf") return Promise.resolve(launchHash);
+        if (functionName === "poolKey") {
+          return Promise.resolve([ZERO, token, 0, 200, historicalHook]);
+        }
+        if (functionName === "creator") {
+          return Promise.resolve(historicalLauncher);
+        }
+        throw new Error(`Unexpected function ${functionName}`);
+      },
+    );
+    const client = { getLogs, readContract } as unknown as PublicClient;
+
+    await expect(
+      readCreatorClaimIdentityFromRpc({
+        client,
+        releases: [historicalDeployment, deployment],
+        poolId: historicalPoolId,
+        blockNumber: 100n,
+      }),
+    ).resolves.toEqual({
+      tokenAddress: token,
+      hookAddress: historicalHook,
+      launcherAddress: historicalLauncher,
+      launcherRuntimeCodeHash:
+        historicalDeployment.launcherRuntimeCodeHash,
+      hookRuntimeCodeHash: historicalDeployment.feeHookRuntimeCodeHash,
+      poolId: historicalPoolId,
+      creatorAddress: creator,
+      totalSwapFeeBps: 100,
+    });
+    expect(getLogs).toHaveBeenCalledWith(expect.objectContaining({
+      address: historicalLauncher,
+      args: { poolId: historicalPoolId },
+    }));
+    expect(getLogs).toHaveBeenCalledWith(expect.objectContaining({
+      address: launcher,
+      args: { poolId: historicalPoolId },
+    }));
   });
 });

--- a/tests/creator-claim-action-activation.test.ts
+++ b/tests/creator-claim-action-activation.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   readBitquery: vi.fn(),
   readIdentity: vi.fn(),
   createPublicClient: vi.fn(),
+  getCreatorClaimOnchainDeployments: vi.fn(),
   getWebsiteReadOnchainDeployment: vi.fn(),
 }));
 
@@ -27,8 +28,16 @@ const creator = getAddress("0x1111111111111111111111111111111111111111");
 const token = getAddress("0x2222222222222222222222222222222222222222");
 const hook = getAddress("0x3333333333333333333333333333333333333333");
 const launcher = getAddress("0x4444444444444444444444444444444444444444");
+const historicalHook = getAddress(
+  "0x7777777777777777777777777777777777777777",
+);
+const historicalLauncher = getAddress(
+  "0x8888888888888888888888888888888888888888",
+);
 const hookCode = "0x6001600155" as Hex;
 const launcherCode = "0x6002600255" as Hex;
+const historicalHookCode = "0x6003600355" as Hex;
+const historicalLauncherCode = "0x6004600455" as Hex;
 const blockHash = `0x${"55".repeat(32)}` as Hex;
 const poolId = computeOfficialV4PoolId({
   currency0: "0x0000000000000000000000000000000000000000",
@@ -60,6 +69,16 @@ const deployment = {
   },
   confirmations: 12n,
   logBlockRange: 10_000n,
+};
+
+const historicalDeployment = {
+  ...deployment,
+  releaseVersion: "classic-v1" as const,
+  launcher: historicalLauncher,
+  feeHook: historicalHook,
+  launcherRuntimeCodeHash: keccak256(historicalLauncherCode),
+  feeHookRuntimeCodeHash: keccak256(historicalHookCode),
+  deploymentBlock: 1n,
 };
 
 const indexedToken = {
@@ -182,6 +201,8 @@ vi.mock("../lib/onchain", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/onchain")>();
   return {
     ...actual,
+    getCreatorClaimOnchainDeployments:
+      mocks.getCreatorClaimOnchainDeployments,
     getWebsiteReadOnchainDeployment:
       mocks.getWebsiteReadOnchainDeployment,
     readExploreModel: mocks.readLegacy,
@@ -232,6 +253,7 @@ describe("creator claim action identity activation", () => {
     deployment.rpcUrlSecondary =
       "https://claim-node.ethereum-mainnet.quiknode.pro/quicknode-claim-key/";
     mocks.getWebsiteReadOnchainDeployment.mockReturnValue(deployment);
+    mocks.getCreatorClaimOnchainDeployments.mockReturnValue([deployment]);
     mocks.lookup.mockResolvedValue(indexedToken);
     mocks.readAlchemy.mockResolvedValue(legacyModel);
     mocks.readLegacy.mockResolvedValue(legacyModel);
@@ -239,6 +261,9 @@ describe("creator claim action identity activation", () => {
     mocks.readIdentity.mockResolvedValue({
       tokenAddress: token,
       hookAddress: hook,
+      launcherAddress: launcher,
+      launcherRuntimeCodeHash: deployment.launcherRuntimeCodeHash,
+      hookRuntimeCodeHash: deployment.feeHookRuntimeCodeHash,
       poolId,
       creatorAddress: creator,
       totalSwapFeeBps: 100,
@@ -303,6 +328,84 @@ describe("creator claim action identity activation", () => {
     });
     expect(mocks.createPublicClient).toHaveBeenCalledTimes(2);
     expect(mocks.readIdentity).toHaveBeenCalledTimes(1);
+  });
+
+  it("prepares a historical claim against the exact launcher and hook that created the pool", async () => {
+    mocks.getCreatorClaimOnchainDeployments.mockReturnValue([
+      historicalDeployment,
+      deployment,
+    ]);
+    mocks.readIdentity.mockResolvedValueOnce({
+      tokenAddress: token,
+      hookAddress: historicalHook,
+      launcherAddress: historicalLauncher,
+      launcherRuntimeCodeHash:
+        historicalDeployment.launcherRuntimeCodeHash,
+      hookRuntimeCodeHash: historicalDeployment.feeHookRuntimeCodeHash,
+      poolId,
+      creatorAddress: creator,
+      totalSwapFeeBps: 100,
+    });
+    const client = {
+      getBlockNumber: vi.fn().mockResolvedValue(120n),
+      getBlock: vi.fn().mockResolvedValue({ hash: blockHash }),
+      getCode: vi.fn(({ address }: { address: Address }) => {
+        if (address === historicalHook) return Promise.resolve(historicalHookCode);
+        if (address === historicalLauncher) {
+          return Promise.resolve(historicalLauncherCode);
+        }
+        throw new Error(`Unexpected runtime address ${address}`);
+      }),
+      readContract: vi.fn(
+        ({ address, functionName }: { address: Address; functionName: string }) => {
+          if (address !== historicalHook) {
+            throw new Error(`Unexpected claim hook ${address}`);
+          }
+          if (functionName === "poolFeeConfig") {
+            return Promise.resolve([
+              creator,
+              historicalLauncher,
+              100,
+              true,
+              10n ** 16n,
+            ]);
+          }
+          if (functionName === "feeDisclosure") {
+            return Promise.resolve([100, 100, 90, 10, 0, 0]);
+          }
+          throw new Error(`Unexpected function ${functionName}`);
+        },
+      ),
+      call: vi.fn(({ to }: { to: Address }) => {
+        if (to !== historicalHook) throw new Error(`Unexpected target ${to}`);
+        return Promise.resolve({ data: "0x" });
+      }),
+      estimateGas: vi.fn().mockResolvedValue(100_000n),
+      getGasPrice: vi.fn().mockResolvedValue(2_000_000_000n),
+      getBalance: vi.fn().mockResolvedValue(10n ** 18n),
+    };
+    mocks.createPublicClient.mockReturnValue(client);
+
+    const response = await POST(request());
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      status: "ready",
+      claim: {
+        tokenAddress: token,
+        hookAddress: historicalHook,
+        poolId,
+      },
+      transaction: {
+        to: historicalHook,
+        value: "0",
+      },
+    });
+    expect(mocks.readIdentity).toHaveBeenCalledWith(expect.objectContaining({
+      releases: [historicalDeployment, deployment],
+      poolId,
+    }));
   });
 
   it("does not expose a private RPC identity-read failure", async () => {

--- a/tests/onchain-config.test.ts
+++ b/tests/onchain-config.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { rpcProviderCommitment } from
   "../lib/data-pipeline/rpc-provider-commitments";
 import {
+  getCreatorClaimOnchainDeployments,
   getOnchainDeployment,
   getOperationalOnchainDeployment,
   getPublicOnchainDeployment,
@@ -67,6 +68,26 @@ describe("onchain deployment manifest boundary", () => {
       launcher: "0xD240D06f8586eB799f20056054e5b527405E6bAd",
       feeHook: "0x025a386eAa79f6067d29848FD05ccC71bEAb20CC",
     });
+  });
+
+  it("binds creator claims to the manifest-verified historical and current releases", () => {
+    stubWebsiteRpcBindings();
+    const current = getWebsiteReadOnchainDeployment("production");
+    if (current.status !== "ready") throw new Error("production is not ready");
+
+    expect(getCreatorClaimOnchainDeployments(current)).toEqual([
+      expect.objectContaining({
+        releaseVersion: "classic-v1",
+        launcher: "0x51d702731db281EE223904A4663E05BfCA26C775",
+        feeHook: "0x48bB2672c7fd2a12e7fb5D46c441ccD3726520Cc",
+        launcherRuntimeCodeHash:
+          "0xa459ee6574d8bbd40ddcf9737dc5d1063adb3abbc11d9f367350c7f2a3cf738b",
+        feeHookRuntimeCodeHash:
+          "0x60fd96af952730792036d43d806046675817a5a2de609d87c06203a8d6037650",
+        deploymentBlock: 25_622_048n,
+      }),
+      current,
+    ]);
   });
 
   it("requires dual-RPC configuration for production operations", () => {


### PR DESCRIPTION
## Summary
- resolve creator claim pools across the manifest-bound Classic V1 and V2 releases
- verify the selected launcher, hook, runtime hashes, registrar, creator, fee disclosure and claimable balance before simulation
- prepare the transaction only against the exact hook that launched the pool

## Focused verification
- `vitest run tests/action-rpc-identity.test.ts tests/creator-claim-action-activation.test.ts tests/onchain-config.test.ts` (27 passed)
- changed-path ESLint
- `npm run typecheck`
- `git diff --check`

No wallet transaction is submitted by this change.