### PR TITLE
Support Classic V1 creator claim simulation

### DIFF
--- a/app/api/explore/profile/claim/route.ts
+++ b/app/api/explore/profile/claim/route.ts
@@ -116,13 +116,15 @@ async function readCurrentClaimState(input: {
       args: [token.poolId],
       blockNumber,
     }),
-    client.readContract({
-      address: token.hookAddress,
-      abi: creatorFeeHookReadAbi,
-      functionName: "feeDisclosure",
-      args: [token.poolId],
-      blockNumber,
-    }),
+    token.releaseVersion === "classic-v2"
+      ? client.readContract({
+        address: token.hookAddress,
+        abi: creatorFeeHookReadAbi,
+        functionName: "feeDisclosure",
+        args: [token.poolId],
+        blockNumber,
+      })
+      : Promise.resolve(null),
   ]);
   if (
     !hookCode ||
@@ -146,7 +148,7 @@ async function readCurrentClaimState(input: {
     getAddress(registrar).toLowerCase() !==
       token.launcherAddress.toLowerCase() ||
     Number(totalSwapFeeBps) !== token.totalSwapFeeBps ||
-    disclosure.some(
+    disclosure?.some(
       (value) => !Number.isSafeInteger(Number(value)) || Number(value) < 0,
     )
   ) {

--- a/lib/server/action-rpc-identity.server.ts
+++ b/lib/server/action-rpc-identity.server.ts
@@ -405,6 +405,7 @@ export async function readTradeActionModelFromRpc(input: {
 }
 
 export type CreatorClaimTokenIdentity = Readonly<{
+  releaseVersion: "classic-v1" | "classic-v2";
   tokenAddress: Address;
   hookAddress: Address;
   launcherAddress: Address;
@@ -507,6 +508,7 @@ export async function readCreatorClaimIdentityFromRpc(input: {
     );
   }
   return {
+    releaseVersion: release.releaseVersion,
     tokenAddress: token,
     hookAddress: hook,
     launcherAddress: release.launcher,

--- a/tests/action-rpc-identity.test.ts
+++ b/tests/action-rpc-identity.test.ts
@@ -140,6 +140,7 @@ describe("single-RPC action identity", () => {
         blockNumber: 20_100n,
       }),
     ).resolves.toEqual({
+      releaseVersion: "classic-v2",
       tokenAddress: token,
       hookAddress: hook,
       launcherAddress: launcher,
@@ -252,6 +253,7 @@ describe("single-RPC action identity", () => {
         blockNumber: 100n,
       }),
     ).resolves.toEqual({
+      releaseVersion: "classic-v1",
       tokenAddress: token,
       hookAddress: historicalHook,
       launcherAddress: historicalLauncher,

--- a/tests/creator-claim-action-activation.test.ts
+++ b/tests/creator-claim-action-activation.test.ts
@@ -259,6 +259,7 @@ describe("creator claim action identity activation", () => {
     mocks.readLegacy.mockResolvedValue(legacyModel);
     mocks.readBitquery.mockResolvedValue(legacyModel);
     mocks.readIdentity.mockResolvedValue({
+      releaseVersion: "classic-v2",
       tokenAddress: token,
       hookAddress: hook,
       launcherAddress: launcher,
@@ -336,6 +337,7 @@ describe("creator claim action identity activation", () => {
       deployment,
     ]);
     mocks.readIdentity.mockResolvedValueOnce({
+      releaseVersion: "classic-v1",
       tokenAddress: token,
       hookAddress: historicalHook,
       launcherAddress: historicalLauncher,
@@ -370,9 +372,6 @@ describe("creator claim action identity activation", () => {
               10n ** 16n,
             ]);
           }
-          if (functionName === "feeDisclosure") {
-            return Promise.resolve([100, 100, 90, 10, 0, 0]);
-          }
           throw new Error(`Unexpected function ${functionName}`);
         },
       ),
@@ -406,6 +405,9 @@ describe("creator claim action identity activation", () => {
       releases: [historicalDeployment, deployment],
       poolId,
     }));
+    expect(client.readContract).not.toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: "feeDisclosure" }),
+    );
   });
 
   it("does not expose a private RPC identity-read failure", async () => {


### PR DESCRIPTION
## Outcome
- retain exact manifest/runtime/pool/creator/fee-config checks for historical Classic V1 claims
- skip only the V2-only `feeDisclosure()` view on Classic V1
- preserve the existing V2 disclosure validation unchanged

## Evidence
- reproduced production failure on pool `0xc9883d4a9adb9613503409efaa5e6f57326f80895b8a29c2c9f9dad57407f280`
- both configured production RPCs return the exact V1 launch, registered fee config, `83475609738845474` wei claimable, successful `eth_call`, and gas estimate `67782`; only `feeDisclosure()` reverts on the V1 hook
- focused tests: 11/11 pass
- typecheck, changed-path lint, and diff check pass

No transaction was submitted.