### PR TITLE
Add creator-managed token articles

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -61,6 +61,22 @@ paths = ['''components/docs-public-policy\.ts''']
 regexes = ['''(?i)V4_TOKEN_ADDRESS\s*=\s*"0x7987f03462200b3d8a072e02c89a8a41dcb124ee"''']
 
 [[allowlists]]
+description = "Creator articles pin the official public V4 token address"
+condition = "AND"
+regexTarget = "match"
+paths = [
+  '''config/creator-article-programmable-example\.v1\.json''',
+  '''lib/creator-article/media\.ts''',
+  '''lib/creator-article/programmable-example-v1\.ts''',
+  '''lib/server/creator-article/authority\.server\.ts''',
+  '''tests/creator-article-contract\.test\.ts''',
+  '''tests/creator-article-editor\.test\.ts''',
+  '''tests/creator-article-renderer\.test\.ts''',
+  '''tests/creator-article-storage\.test\.ts''',
+]
+regexes = ['''(?i)0x7987f03462200b3d8a072e02c89a8a41dcb124ee''']
+
+[[allowlists]]
 description = "Live market golden sample pins the public Programmable token address"
 condition = "AND"
 regexTarget = "match"

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -16,6 +16,8 @@ import { readProductionCustomExploreDirectoryV1 } from
   "../../../../lib/server/custom-launch/explore-directory-v1";
 import { isCustomLaunchRegistryPublicReadEnabled } from
   "../../../../lib/server/custom-launch/public-readiness";
+import { readPublicCreatorArticleV1 } from
+  "../../../../lib/server/creator-article/public-read.server";
 import type { ExploreEntry } from "../../../../lib/tokens";
 
 export const dynamic = "force-dynamic";
@@ -185,6 +187,7 @@ export async function GET(request: NextRequest) {
         status: "ready",
         token: null,
         customProject: null,
+        creatorArticle: null,
         snapshot: null,
         catalog: catalogBoundary,
       },
@@ -201,6 +204,9 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    const creatorArticlePromise = readPublicCreatorArticleV1(
+      entry.tokenAddress!,
+    );
     const market = await readDexscreenerExploreEntriesV1([entry], {
       signal: readSignal,
       deadlineMs,
@@ -219,6 +225,7 @@ export async function GET(request: NextRequest) {
         token: publicEntry.exploreKind === "token" ? publicEntry : null,
         customProject:
           publicEntry.exploreKind === "custom-project" ? publicEntry : null,
+        creatorArticle: await creatorArticlePromise,
         snapshot:
           publicEntry.exploreKind === "token" ? { chainId: 1 } : null,
         catalog: catalogBoundary,
@@ -243,12 +250,14 @@ export async function GET(request: NextRequest) {
       ...entry,
       valuation: { status: "unavailable", reason: "source-unavailable" },
     });
+    const creatorArticle = await readPublicCreatorArticleV1(entry.tokenAddress!);
     return NextResponse.json(
       {
         status: "ready",
         token: publicEntry.exploreKind === "token" ? publicEntry : null,
         customProject:
           publicEntry.exploreKind === "custom-project" ? publicEntry : null,
+        creatorArticle,
         snapshot: publicEntry.exploreKind === "token" ? { chainId: 1 } : null,
         catalog: catalogBoundary,
       },

--- a/app/api/profile/projects/[address]/article/media/route.ts
+++ b/app/api/profile/projects/[address]/article/media/route.ts
@@ -1,0 +1,14 @@
+import { getProductionCreatorArticleMediaUploadHandlerV1 } from
+  "@/lib/server/creator-article/media-api.server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 20;
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ address: string }> },
+) {
+  const { address } = await context.params;
+  return getProductionCreatorArticleMediaUploadHandlerV1()(request, address);
+}

--- a/app/api/profile/projects/[address]/article/route.ts
+++ b/app/api/profile/projects/[address]/article/route.ts
@@ -1,0 +1,17 @@
+import { getProductionCreatorArticleApiHandlersV1 } from
+  "@/lib/server/creator-article/api.server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = { params: Promise<{ address: string }> };
+
+export async function GET(request: Request, context: RouteContext) {
+  const { address } = await context.params;
+  return getProductionCreatorArticleApiHandlersV1().article(request, address);
+}
+
+export async function PUT(request: Request, context: RouteContext) {
+  const { address } = await context.params;
+  return getProductionCreatorArticleApiHandlersV1().article(request, address);
+}

--- a/app/api/profile/projects/route.ts
+++ b/app/api/profile/projects/route.ts
@@ -1,0 +1,9 @@
+import { getProductionCreatorArticleApiHandlersV1 } from
+  "@/lib/server/creator-article/api.server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  return getProductionCreatorArticleApiHandlersV1().listProjects(request);
+}

--- a/app/token/[address]/page.tsx
+++ b/app/token/[address]/page.tsx
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { Suspense } from "react";
 
 import { GET as readTokenDetailResponse } from
   "@/app/api/explore/token/route";
@@ -6,6 +7,7 @@ import {
   TokenDetailView,
   type TokenDetailInitialResponse,
 } from "@/components/token-detail-view";
+import { TokenDetailShell } from "@/components/token-detail-shell";
 
 export const dynamic = "force-dynamic";
 
@@ -48,6 +50,14 @@ export default async function TokenPage({
   params: Promise<{ address: string }>;
 }) {
   const { address } = await params;
+  return (
+    <Suspense fallback={<TokenDetailShell />}>
+      <InitialTokenDetail address={address} />
+    </Suspense>
+  );
+}
+
+async function InitialTokenDetail({ address }: { address: string }) {
   const search = new URLSearchParams({ address });
   const initialResponse = await readInitialTokenDetailWithinDeadline(
     async (signal) => {

--- a/components/creator-article-editor.module.css
+++ b/components/creator-article-editor.module.css
@@ -25,7 +25,7 @@
 .dialogHeader,
 .dialogFooter {
   align-items: center;
-  background: rgb(11 11 15 / 94%);
+  background: #0b0b0f;
   display: flex;
   justify-content: space-between;
   padding: 1rem 1.25rem;
@@ -64,6 +64,8 @@
 
 .dialogHeader > button {
   display: grid;
+  min-height: 2.75rem;
+  min-width: 2.75rem;
   padding: 0.45rem;
   place-items: center;
 }
@@ -145,6 +147,7 @@
   bottom: 0.75rem;
   color: white;
   cursor: pointer;
+  min-height: 2.75rem;
   padding: 0.5rem 0.7rem;
   position: absolute;
   right: 0.75rem;
@@ -155,6 +158,7 @@
   display: flex;
   gap: 0.4rem;
   justify-self: start;
+  min-height: 2.75rem;
   padding: 0.65rem 0.8rem;
 }
 
@@ -178,7 +182,9 @@
 .toolbar > button {
   align-items: center;
   display: flex;
-  min-height: 2.25rem;
+  justify-content: center;
+  min-height: 2.75rem;
+  min-width: 2.75rem;
   padding: 0.42rem 0.55rem;
 }
 
@@ -205,12 +211,20 @@
   color: inherit;
   font: inherit;
   font-size: 0.75rem;
+  min-height: 2.75rem;
   min-width: 10rem;
   outline: none;
 }
 
 .linkControl button {
+  min-height: 2.75rem;
   padding: 0.45rem 0.55rem;
+}
+
+.linkControl:focus-within {
+  border-radius: 0.4rem;
+  outline: 2px solid #8fc5ff;
+  outline-offset: 2px;
 }
 
 .prose {
@@ -285,6 +299,7 @@
 
 .imageControls button {
   font-size: 0.7rem;
+  min-height: 2.75rem;
   padding: 0.4rem 0.55rem;
 }
 
@@ -315,7 +330,7 @@
 }
 
 .pasteHint {
-  color: rgb(255 255 255 / 42%);
+  color: rgb(255 255 255 / 52%);
   font-size: 0.72rem;
   margin: -3.5rem auto 2rem;
   max-width: 46rem;
@@ -327,10 +342,15 @@
 }
 
 .dialogFooter p {
-  color: #ffb1b1;
+  color: rgb(255 255 255 / 62%);
   font-size: 0.75rem;
   margin: 0;
 }
+
+.dialogFooter p[data-tone="error"] { color: #ffb1b1; }
+.dialogFooter p[data-tone="warning"] { color: #ffd28a; }
+.dialogFooter p[data-tone="success"] { color: #9ee6b1; }
+.dialogFooter p[data-tone="info"] { color: #b8dcff; }
 
 .dialogFooter div {
   display: flex;
@@ -339,6 +359,7 @@
 }
 
 .dialogFooter button {
+  min-height: 2.75rem;
   padding: 0.65rem 0.9rem;
 }
 
@@ -346,6 +367,18 @@
   background: #f0eee8;
   border-color: #f0eee8;
   color: #0a0a0c;
+}
+
+.dialogFooter .danger {
+  background: #ffb1b1;
+  border-color: #ffb1b1;
+  color: #220808;
+}
+
+.dialogFooter button:disabled,
+.coverButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .dialogFooter button:focus-visible,

--- a/components/creator-article-editor.module.css
+++ b/components/creator-article-editor.module.css
@@ -1,0 +1,381 @@
+.backdrop {
+  align-items: center;
+  background: rgb(0 0 0 / 78%);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 1rem;
+  position: fixed;
+  z-index: 1000;
+}
+
+.dialog {
+  background: #0b0b0f;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 1rem;
+  box-shadow: 0 30px 90px rgb(0 0 0 / 55%);
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  max-height: calc(100dvh - 2rem);
+  max-width: 90rem;
+  overflow: hidden;
+  width: 100%;
+}
+
+.dialogHeader,
+.dialogFooter {
+  align-items: center;
+  background: rgb(11 11 15 / 94%);
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+}
+
+.dialogHeader {
+  border-bottom: 1px solid rgb(255 255 255 / 10%);
+}
+
+.dialogHeader p,
+.dialogHeader h2 {
+  margin: 0;
+}
+
+.dialogHeader p {
+  color: rgb(255 255 255 / 48%);
+  font-size: 0.7rem;
+}
+
+.dialogHeader h2 {
+  font-size: 1.15rem;
+}
+
+.dialogHeader > button,
+.toolbar button,
+.dialogFooter button,
+.coverButton,
+.imageControls button {
+  background: transparent;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 0.55rem;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.dialogHeader > button {
+  display: grid;
+  padding: 0.45rem;
+  place-items: center;
+}
+
+.editorLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-height: 0;
+  overflow: auto;
+}
+
+.editorLayout:has(.previewPane) {
+  grid-template-columns: minmax(28rem, 0.9fr) minmax(32rem, 1.1fr);
+}
+
+.editorPane,
+.previewPane {
+  min-width: 0;
+  padding: clamp(1rem, 3vw, 2.5rem);
+}
+
+.previewPane {
+  border-left: 1px solid rgb(255 255 255 / 10%);
+  overflow: auto;
+}
+
+.titleField,
+.bannerField {
+  display: grid;
+  gap: 0.6rem;
+  margin-inline: auto;
+  max-width: 48rem;
+}
+
+.titleField > span,
+.bannerField > span,
+.imageFields span {
+  color: rgb(255 255 255 / 48%);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.titleField input {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid rgb(255 255 255 / 16%);
+  color: inherit;
+  font: inherit;
+  font-size: clamp(1.8rem, 4vw, 3.5rem);
+  font-weight: 540;
+  letter-spacing: -0.05em;
+  outline: none;
+  padding: 0 0 0.7rem;
+}
+
+.titleField input:focus {
+  border-color: #8fc5ff;
+}
+
+.bannerField {
+  margin-block: 2rem;
+}
+
+.bannerPreview {
+  position: relative;
+}
+
+.bannerPreview img {
+  aspect-ratio: 3 / 1;
+  display: block;
+  height: auto;
+  width: 100%;
+}
+
+.bannerPreview button {
+  background: rgb(0 0 0 / 72%);
+  border: 0;
+  bottom: 0.75rem;
+  color: white;
+  cursor: pointer;
+  padding: 0.5rem 0.7rem;
+  position: absolute;
+  right: 0.75rem;
+}
+
+.coverButton {
+  align-items: center;
+  display: flex;
+  gap: 0.4rem;
+  justify-self: start;
+  padding: 0.65rem 0.8rem;
+}
+
+.toolbar {
+  align-items: center;
+  backdrop-filter: blur(14px);
+  background: rgb(15 15 20 / 92%);
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin: 0 auto 1.2rem;
+  max-width: 48rem;
+  padding: 0.45rem;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.toolbar > button {
+  align-items: center;
+  display: flex;
+  min-height: 2.25rem;
+  padding: 0.42rem 0.55rem;
+}
+
+.toolbar svg {
+  height: 1rem;
+  width: 1rem;
+}
+
+.toolbar button[aria-pressed="true"] {
+  background: #f0eee8;
+  color: #0a0a0c;
+}
+
+.linkControl {
+  align-items: center;
+  display: flex;
+  gap: 0.35rem;
+  margin-inline-start: auto;
+}
+
+.linkControl input {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  font-size: 0.75rem;
+  min-width: 10rem;
+  outline: none;
+}
+
+.linkControl button {
+  padding: 0.45rem 0.55rem;
+}
+
+.prose {
+  font-size: clamp(1.02rem, 1.5vw, 1.18rem);
+  line-height: 1.72;
+  margin-inline: auto;
+  max-width: 46rem;
+  min-height: 22rem;
+  outline: none;
+  padding-block: 0.5rem 5rem;
+}
+
+.prose p {
+  margin-block: 0 1.35em;
+}
+
+.prose h2,
+.prose h3 {
+  letter-spacing: -0.04em;
+  line-height: 1.12;
+}
+
+.prose h2 {
+  font-size: 2.2rem;
+  margin-block: 2em 0.65em;
+}
+
+.prose h3 {
+  font-size: 1.55rem;
+  margin-block: 1.8em 0.6em;
+}
+
+.prose a {
+  color: #8fc5ff;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.editorImage {
+  margin: 2.5rem auto;
+  max-width: 100%;
+}
+
+.editorImage img {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+
+.compact { width: min(32rem, 100%); }
+.content { width: min(46rem, 100%); }
+.wide { width: 100%; }
+
+.imageSelected {
+  outline: 2px solid #8fc5ff;
+  outline-offset: 5px;
+}
+
+.imageStatus {
+  background: rgb(255 255 255 / 5%);
+  display: grid;
+  min-height: 12rem;
+  place-items: center;
+}
+
+.imageControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-block-start: 0.6rem;
+}
+
+.imageControls button {
+  font-size: 0.7rem;
+  padding: 0.4rem 0.55rem;
+}
+
+.imageControls button[aria-pressed="true"] {
+  background: rgb(255 255 255 / 14%);
+}
+
+.imageFields {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 1fr 1fr;
+  margin-block-start: 0.75rem;
+}
+
+.imageFields label {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.imageFields input {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid rgb(255 255 255 / 14%);
+  color: inherit;
+  font: inherit;
+  font-size: 0.78rem;
+  padding: 0.45rem 0;
+}
+
+.pasteHint {
+  color: rgb(255 255 255 / 42%);
+  font-size: 0.72rem;
+  margin: -3.5rem auto 2rem;
+  max-width: 46rem;
+}
+
+.dialogFooter {
+  border-top: 1px solid rgb(255 255 255 / 10%);
+  gap: 1rem;
+}
+
+.dialogFooter p {
+  color: #ffb1b1;
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+.dialogFooter div {
+  display: flex;
+  gap: 0.5rem;
+  margin-inline-start: auto;
+}
+
+.dialogFooter button {
+  padding: 0.65rem 0.9rem;
+}
+
+.dialogFooter .publish {
+  background: #f0eee8;
+  border-color: #f0eee8;
+  color: #0a0a0c;
+}
+
+.dialogFooter button:focus-visible,
+.dialogHeader button:focus-visible,
+.toolbar button:focus-visible,
+.coverButton:focus-visible,
+.imageControls button:focus-visible {
+  outline: 2px solid #8fc5ff;
+  outline-offset: 2px;
+}
+
+@media (max-width: 64rem) {
+  .editorLayout:has(.previewPane) {
+    grid-template-columns: 1fr;
+  }
+
+  .previewPane {
+    border-left: 0;
+    border-top: 1px solid rgb(255 255 255 / 10%);
+  }
+}
+
+@media (max-width: 42rem) {
+  .backdrop { padding: 0; }
+  .dialog { border-radius: 0; max-height: 100dvh; }
+  .editorPane { padding: 1rem; }
+  .imageFields { grid-template-columns: 1fr; }
+  .dialogFooter { align-items: stretch; flex-direction: column; }
+  .dialogFooter div { margin-inline-start: 0; }
+  .dialogFooter button { flex: 1; }
+  .linkControl { margin-inline-start: 0; width: 100%; }
+  .linkControl input { flex: 1; min-width: 0; }
+}

--- a/components/creator-article-editor.tsx
+++ b/components/creator-article-editor.tsx
@@ -1,0 +1,615 @@
+"use client";
+
+import Image from "next/image";
+import {
+  Node,
+  type Editor,
+  type JSONContent,
+} from "@tiptap/core";
+import {
+  EditorContent,
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+  type NodeViewProps,
+  useEditor,
+} from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  Bold,
+  Heading2,
+  Heading3,
+  ImagePlus,
+  Italic,
+  Link as LinkIcon,
+  List,
+  ListOrdered,
+  Redo2,
+  Undo2,
+  X,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+
+import { CreatorArticle } from "@/components/creator-article";
+import type { CreatorProjectSummaryV1 } from "@/components/profile-projects";
+import {
+  CREATOR_ARTICLE_DRAFT_SCHEMA_V1,
+  CREATOR_ARTICLE_SCHEMA_V1,
+  parseCreatorArticleDraftV1,
+  parseCreatorArticleV1,
+  type CreatorArticleDraftV1,
+  type CreatorArticleV1,
+} from "@/lib/creator-article/contract-v1";
+import {
+  displayHttpsLinkV1,
+  isAllowedArticleHrefV1,
+  normalizeHttpsLinkV1,
+} from "@/lib/creator-article/link";
+
+import styles from "./creator-article-editor.module.css";
+
+type AuthHeaders = Readonly<{
+  Authorization: string;
+  "X-Privy-Identity-Token": string;
+}>;
+
+type ArticleEditorProps = Readonly<{
+  project: CreatorProjectSummaryV1;
+  initialArticle: CreatorArticleV1 | null;
+  initialEtag: string | null;
+  getAuthHeaders(): Promise<AuthHeaders>;
+  onClose(): void;
+  onPublished(article: CreatorArticleV1): void;
+}>;
+
+type UploadedMedia = Readonly<{
+  url: string;
+  width: number;
+  height: number;
+  kind: "banner" | "inline";
+}>;
+
+const ArticleImageNode = Node.create({
+  name: "articleImage",
+  group: "block",
+  atom: true,
+  draggable: true,
+  addAttributes() {
+    return {
+      url: { default: "" },
+      alt: { default: "" },
+      caption: { default: null },
+      width: { default: 1 },
+      height: { default: 1 },
+      size: { default: "content" },
+      uploadId: { default: null },
+      status: { default: "ready" },
+    };
+  },
+  parseHTML() {
+    return [{ tag: "figure[data-creator-article-image]" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["figure", { "data-creator-article-image": "", ...HTMLAttributes }];
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(ArticleImageEditorNode);
+  },
+});
+
+function ArticleImageEditorNode({ node, selected, updateAttributes, deleteNode }: NodeViewProps) {
+  const attrs = node.attrs as Record<string, unknown>;
+  const status = attrs.status === "uploading" || attrs.status === "error"
+    ? attrs.status
+    : "ready";
+  const size = attrs.size === "compact" || attrs.size === "wide"
+    ? attrs.size
+    : "content";
+  const url = typeof attrs.url === "string" ? attrs.url : "";
+  const alt = typeof attrs.alt === "string" ? attrs.alt : "";
+  const caption = typeof attrs.caption === "string" ? attrs.caption : "";
+  const width = Number.isSafeInteger(attrs.width) ? Number(attrs.width) : 1;
+  const height = Number.isSafeInteger(attrs.height) ? Number(attrs.height) : 1;
+  return (
+    <NodeViewWrapper
+      as="figure"
+      className={`${styles.editorImage} ${styles[size]} ${selected ? styles.imageSelected : ""}`}
+    >
+      {status === "ready" && url ? (
+        <Image src={url} alt={alt} width={width} height={height} unoptimized />
+      ) : (
+        <div className={styles.imageStatus} role="status">
+          {status === "uploading" ? "Uploading image…" : "Image upload failed"}
+        </div>
+      )}
+      <div className={styles.imageControls} contentEditable={false}>
+        {(["compact", "content", "wide"] as const).map((value) => (
+          <button
+            type="button"
+            aria-pressed={size === value}
+            onClick={() => updateAttributes({ size: value })}
+            key={value}
+          >
+            {value === "compact" ? "Small" : value === "content" ? "Medium" : "Wide"}
+          </button>
+        ))}
+        <button type="button" onClick={deleteNode}>Remove</button>
+      </div>
+      {status === "ready" ? (
+        <div className={styles.imageFields} contentEditable={false}>
+          <label>
+            <span>Image description</span>
+            <input
+              value={alt}
+              maxLength={240}
+              placeholder="Describe the image"
+              onChange={(event) => updateAttributes({ alt: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Caption</span>
+            <input
+              value={caption}
+              maxLength={500}
+              placeholder="Optional caption"
+              onChange={(event) => updateAttributes({ caption: event.target.value || null })}
+            />
+          </label>
+        </div>
+      ) : null}
+    </NodeViewWrapper>
+  );
+}
+
+export default function CreatorArticleEditor({
+  project,
+  initialArticle,
+  initialEtag,
+  getAuthHeaders,
+  onClose,
+  onPublished,
+}: ArticleEditorProps) {
+  const editorRef = useRef<Editor | null>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const bannerInputRef = useRef<HTMLInputElement>(null);
+  const [title, setTitle] = useState(initialArticle?.title ?? "");
+  const [bannerImage, setBannerImage] = useState(initialArticle?.bannerImage ?? null);
+  const [document, setDocument] = useState<JSONContent>(
+    initialArticle
+      ? JSON.parse(JSON.stringify(initialArticle.document)) as JSONContent
+      : emptyDocument(),
+  );
+  const [etag, setEtag] = useState(initialEtag);
+  const [linkValue, setLinkValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [uploadingCount, setUploadingCount] = useState(0);
+  const [message, setMessage] = useState("");
+  const [showPreview, setShowPreview] = useState(false);
+
+  const uploadMedia = useCallback(async (
+    file: File,
+    kind: "banner" | "inline",
+  ): Promise<UploadedMedia> => {
+    const form = new FormData();
+    form.set("file", file);
+    form.set("kind", kind);
+    const response = await fetch(
+      `/api/profile/projects/${project.tokenAddress}/article/media`,
+      { method: "POST", headers: await getAuthHeaders(), body: form },
+    );
+    const body: unknown = await response.json().catch(() => null);
+    if (!response.ok || !isRecord(body) || !isRecord(body.media)) {
+      throw new Error(readApiError(body));
+    }
+    const media = body.media;
+    if (typeof media.url !== "string" || !isAllowedArticleHrefV1(media.url)
+      || !Number.isSafeInteger(media.width) || Number(media.width) <= 0
+      || !Number.isSafeInteger(media.height) || Number(media.height) <= 0
+      || media.kind !== kind) throw new Error("The uploaded image is invalid");
+    return {
+      url: media.url,
+      width: Number(media.width),
+      height: Number(media.height),
+      kind,
+    };
+  }, [getAuthHeaders, project.tokenAddress]);
+
+  const uploadInlineImages = useCallback(async (files: readonly File[]) => {
+    const activeEditor = editorRef.current;
+    if (!activeEditor || files.length === 0) return;
+    setMessage("");
+    for (const file of files) {
+      const uploadId = crypto.randomUUID();
+      activeEditor.chain().focus().insertContent({
+        type: "articleImage",
+        attrs: {
+          url: "",
+          alt: readableFileName(file.name),
+          caption: null,
+          width: 1,
+          height: 1,
+          size: "content",
+          uploadId,
+          status: "uploading",
+        },
+      }).run();
+      setUploadingCount((current) => current + 1);
+      try {
+        const media = await uploadMedia(file, "inline");
+        updateImageNode(activeEditor, uploadId, {
+          ...media,
+          alt: readableFileName(file.name),
+          caption: null,
+          size: "content",
+          status: "ready",
+        });
+      } catch (error) {
+        updateImageNode(activeEditor, uploadId, { status: "error" });
+        setMessage(error instanceof Error ? error.message : "Image upload failed");
+      } finally {
+        setUploadingCount((current) => Math.max(0, current - 1));
+      }
+    }
+  }, [uploadMedia]);
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [2, 3] },
+        link: {
+          autolink: true,
+          linkOnPaste: true,
+          defaultProtocol: "https",
+          openOnClick: false,
+          isAllowedUri: (url) => isAllowedArticleHrefV1(url),
+          shouldAutoLink: (url) => isAllowedArticleHrefV1(url),
+        },
+      }),
+      ArticleImageNode,
+    ],
+    content: document,
+    editorProps: {
+      attributes: {
+        class: styles.prose,
+        "aria-label": "Project article",
+      },
+      handlePaste: (_view, event) => {
+        const imageFiles = [...(event.clipboardData?.files ?? [])]
+          .filter((file) => file.type.startsWith("image/"));
+        if (imageFiles.length > 0) {
+          event.preventDefault();
+          void uploadInlineImages(imageFiles);
+          return true;
+        }
+        const standaloneLink = standaloneArticleLinkPasteV1(
+          event.clipboardData?.getData("text/plain") ?? "",
+        );
+        if (standaloneLink) {
+          event.preventDefault();
+          editorRef.current?.chain().focus().insertContent({
+            type: "text",
+            text: standaloneLink.text,
+            marks: [{ type: "link", attrs: { href: standaloneLink.href } }],
+          }).run();
+          return true;
+        }
+        return false;
+      },
+    },
+    onUpdate: ({ editor: activeEditor }) => {
+      setDocument(activeEditor.getJSON());
+      setMessage("");
+    },
+  });
+  useEffect(() => {
+    editorRef.current = editor;
+    return () => {
+      if (editorRef.current === editor) editorRef.current = null;
+    };
+  }, [editor]);
+
+  const preview = useMemo(() => {
+    try {
+      const draft = createDraft(project, title, bannerImage, document);
+      return parseCreatorArticleV1({
+        ...draft,
+        schemaVersion: CREATOR_ARTICLE_SCHEMA_V1,
+        revision: initialArticle?.revision ?? 1,
+        status: "published",
+        createdAt: initialArticle?.createdAt ?? new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    } catch {
+      return null;
+    }
+  }, [bannerImage, document, initialArticle, project, title]);
+
+  async function selectBanner(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    setUploadingCount((current) => current + 1);
+    setMessage("");
+    try {
+      const media = await uploadMedia(file, "banner");
+      setBannerImage({
+        url: media.url,
+        alt: `${project.name} article cover`,
+        caption: null,
+        width: media.width,
+        height: media.height,
+        size: "wide",
+      });
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Banner upload failed");
+    } finally {
+      setUploadingCount((current) => Math.max(0, current - 1));
+    }
+  }
+
+  async function publish() {
+    setSaving(true);
+    setMessage("");
+    try {
+      const draft = createDraft(project, title, bannerImage, editor?.getJSON() ?? document);
+      const response = await fetch(
+        `/api/profile/projects/${project.tokenAddress}/article`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            ...(etag ? { "If-Match": etag } : { "If-None-Match": "*" }),
+            ...(await getAuthHeaders()),
+          },
+          body: JSON.stringify(draft),
+        },
+      );
+      const body: unknown = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(response.status === 412
+          ? "A newer version was published. Copy your draft or reload before saving."
+          : readApiError(body));
+      }
+      if (!isRecord(body)) throw new Error("The published article is invalid");
+      const article = parseCreatorArticleV1(body.article);
+      const nextEtag = response.headers.get("etag");
+      if (!nextEtag) throw new Error("The published revision could not be verified");
+      setEtag(nextEtag);
+      setMessage("Published");
+      onPublished(article);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Article could not be published");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function applyLink() {
+    if (!editor) return;
+    if (!linkValue.trim()) {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+    try {
+      const href = normalizeHttpsLinkV1(linkValue);
+      editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
+      setLinkValue("");
+      setMessage("");
+    } catch {
+      setMessage("Use a complete HTTPS link");
+    }
+  }
+
+  return (
+    <div className={styles.backdrop} role="presentation">
+      <section className={styles.dialog} role="dialog" aria-modal="true" aria-labelledby="article-editor-title">
+        <header className={styles.dialogHeader}>
+          <div>
+            <p>{project.symbol ? `$${project.symbol}` : "Verified project"}</p>
+            <h2 id="article-editor-title">{initialArticle ? "Edit article" : "Create article"}</h2>
+          </div>
+          <button type="button" aria-label="Close article editor" onClick={onClose}><X aria-hidden="true" /></button>
+        </header>
+
+        <div className={styles.editorLayout}>
+          <div className={styles.editorPane}>
+            <label className={styles.titleField}>
+              <span>Title</span>
+              <input
+                value={title}
+                maxLength={120}
+                placeholder="Tell people what this project is about"
+                onChange={(event) => { setTitle(event.target.value); setMessage(""); }}
+              />
+            </label>
+
+            <div className={styles.bannerField}>
+              <span>Cover image · 3:1</span>
+              {bannerImage ? (
+                <div className={styles.bannerPreview}>
+                  <Image src={bannerImage.url} alt={bannerImage.alt} width={bannerImage.width} height={bannerImage.height} unoptimized />
+                  <button type="button" onClick={() => setBannerImage(null)}>Remove cover</button>
+                </div>
+              ) : null}
+              <input ref={bannerInputRef} hidden type="file" accept="image/png,image/jpeg,image/webp,image/avif" onChange={selectBanner} />
+              <button className={styles.coverButton} type="button" onClick={() => bannerInputRef.current?.click()}>
+                <ImagePlus aria-hidden="true" size={16} /> {bannerImage ? "Replace cover" : "Add cover"}
+              </button>
+            </div>
+
+            <div className={styles.toolbar} role="toolbar" aria-label="Article formatting">
+              <ToolbarButton label="Normal" active={editor?.isActive("paragraph") ?? false} onClick={() => editor?.chain().focus().unsetAllMarks().setParagraph().run()} />
+              <ToolbarIcon label="Bold" active={editor?.isActive("bold") ?? false} onClick={() => editor?.chain().focus().toggleBold().run()}><Bold /></ToolbarIcon>
+              <ToolbarIcon label="Italic" active={editor?.isActive("italic") ?? false} onClick={() => editor?.chain().focus().toggleItalic().run()}><Italic /></ToolbarIcon>
+              <ToolbarIcon label="Heading 2" active={editor?.isActive("heading", { level: 2 }) ?? false} onClick={() => editor?.chain().focus().toggleHeading({ level: 2 }).run()}><Heading2 /></ToolbarIcon>
+              <ToolbarIcon label="Heading 3" active={editor?.isActive("heading", { level: 3 }) ?? false} onClick={() => editor?.chain().focus().toggleHeading({ level: 3 }).run()}><Heading3 /></ToolbarIcon>
+              <ToolbarIcon label="Bullet list" active={editor?.isActive("bulletList") ?? false} onClick={() => editor?.chain().focus().toggleBulletList().run()}><List /></ToolbarIcon>
+              <ToolbarIcon label="Numbered list" active={editor?.isActive("orderedList") ?? false} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><ListOrdered /></ToolbarIcon>
+              <ToolbarIcon label="Undo" onClick={() => editor?.chain().focus().undo().run()}><Undo2 /></ToolbarIcon>
+              <ToolbarIcon label="Redo" onClick={() => editor?.chain().focus().redo().run()}><Redo2 /></ToolbarIcon>
+              <input ref={imageInputRef} hidden type="file" multiple accept="image/png,image/jpeg,image/webp,image/avif" onChange={(event) => {
+                const files = [...(event.target.files ?? [])];
+                event.target.value = "";
+                void uploadInlineImages(files);
+              }} />
+              <ToolbarIcon label="Add image" onClick={() => imageInputRef.current?.click()}><ImagePlus /></ToolbarIcon>
+              <div className={styles.linkControl}>
+                <LinkIcon aria-hidden="true" size={15} />
+                <input value={linkValue} inputMode="url" placeholder="https://domain.com" onChange={(event) => setLinkValue(event.target.value)} onKeyDown={(event) => {
+                  if (event.key === "Enter") { event.preventDefault(); applyLink(); }
+                }} />
+                <button type="button" onClick={applyLink}>Apply</button>
+              </div>
+            </div>
+
+            <EditorContent editor={editor} />
+            <p className={styles.pasteHint}>Paste an image anywhere with CMD‑V or Ctrl‑V. Images keep their proportions on every screen.</p>
+          </div>
+
+          {showPreview && preview ? (
+            <div className={styles.previewPane}>
+              <CreatorArticle article={preview} />
+            </div>
+          ) : null}
+        </div>
+
+        <footer className={styles.dialogFooter}>
+          <p role={message && message !== "Published" ? "alert" : "status"}>{message}</p>
+          <div>
+            <button type="button" onClick={() => setShowPreview((value) => !value)}>{showPreview ? "Hide preview" : "Preview"}</button>
+            <button type="button" onClick={onClose}>Discard</button>
+            <button className={styles.publish} type="button" disabled={saving || uploadingCount > 0 || !preview} onClick={() => void publish()}>
+              {saving ? "Publishing…" : uploadingCount > 0 ? "Uploading…" : "Publish article"}
+            </button>
+          </div>
+        </footer>
+      </section>
+    </div>
+  );
+}
+
+function ToolbarButton({ label, active = false, onClick }: Readonly<{
+  label: string;
+  active?: boolean;
+  onClick(): void;
+}>) {
+  return <button type="button" aria-pressed={active} onClick={onClick}>{label}</button>;
+}
+
+function ToolbarIcon({ label, active = false, onClick, children }: Readonly<{
+  label: string;
+  active?: boolean;
+  onClick(): void;
+  children: React.ReactNode;
+}>) {
+  return (
+    <button type="button" aria-label={label} title={label} aria-pressed={active} onClick={onClick}>
+      {children}
+    </button>
+  );
+}
+
+function createDraft(
+  project: CreatorProjectSummaryV1,
+  title: string,
+  bannerImage: CreatorArticleV1["bannerImage"],
+  document: JSONContent,
+): CreatorArticleDraftV1 {
+  return parseCreatorArticleDraftV1({
+    schemaVersion: CREATOR_ARTICLE_DRAFT_SCHEMA_V1,
+    chainId: project.chainId,
+    tokenAddress: project.tokenAddress,
+    title,
+    bannerImage,
+        document: cleanCreatorArticleEditorDocumentV1(document),
+  });
+}
+
+export function cleanCreatorArticleEditorDocumentV1(value: JSONContent): unknown {
+  if (value.type === "articleImage") {
+    const attrs = value.attrs ?? {};
+    if (attrs.status !== "ready") throw new TypeError("Wait for image uploads to finish");
+    return {
+      type: "articleImage",
+      attrs: {
+        url: attrs.url,
+        alt: attrs.alt,
+        caption: attrs.caption ?? null,
+        width: attrs.width,
+        height: attrs.height,
+        size: attrs.size,
+      },
+    };
+  }
+  const result: Record<string, unknown> = { type: value.type };
+  if (value.text !== undefined) result.text = value.text;
+  if (value.attrs !== undefined) {
+    result.attrs = value.type === "heading" ? { level: value.attrs.level } : value.attrs;
+  }
+  if (value.marks !== undefined) {
+    result.marks = value.marks.map((mark) => mark.type === "link"
+      ? { type: "link", attrs: { href: mark.attrs?.href } }
+      : { type: mark.type });
+  }
+  if (value.content !== undefined) {
+    result.content = value.content.map(cleanCreatorArticleEditorDocumentV1);
+  }
+  return result;
+}
+
+function emptyDocument(): JSONContent {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph" }],
+  };
+}
+
+export function standaloneArticleLinkPasteV1(value: string): Readonly<{
+  href: string;
+  text: string;
+}> | null {
+  const raw = value.trim();
+  if (!raw || /\s/u.test(raw) || !isAllowedArticleHrefV1(raw)) return null;
+  const href = normalizeHttpsLinkV1(raw);
+  return Object.freeze({ href, text: displayHttpsLinkV1(href) });
+}
+
+function updateImageNode(editor: Editor, uploadId: string, attrs: Record<string, unknown>) {
+  let position: number | null = null;
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === "articleImage" && node.attrs.uploadId === uploadId) {
+      position = pos;
+      return false;
+    }
+    return true;
+  });
+  if (position === null) return;
+  const node = editor.state.doc.nodeAt(position);
+  if (!node) return;
+  editor.view.dispatch(editor.state.tr.setNodeMarkup(position, undefined, {
+    ...node.attrs,
+    ...attrs,
+  }));
+}
+
+function readableFileName(value: string) {
+  const name = value.replace(/\.[^.]+$/u, "").replace(/[-_]+/gu, " ").trim();
+  return name || "Project image";
+}
+
+function readApiError(value: unknown) {
+  return isRecord(value) && typeof value.code === "string"
+    ? value.code.replaceAll("_", " ")
+    : "The request could not be completed";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/components/creator-article-editor.tsx
+++ b/components/creator-article-editor.tsx
@@ -33,8 +33,10 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type ChangeEvent,
 } from "react";
+import { createPortal } from "react-dom";
 
 import { CreatorArticle } from "@/components/creator-article";
 import type { CreatorProjectSummaryV1 } from "@/components/profile-projects";
@@ -73,6 +75,11 @@ type UploadedMedia = Readonly<{
   width: number;
   height: number;
   kind: "banner" | "inline";
+}>;
+
+type EditorNotice = Readonly<{
+  tone: "error" | "success" | "warning" | "info";
+  text: string;
 }>;
 
 const ArticleImageNode = Node.create({
@@ -176,6 +183,9 @@ export default function CreatorArticleEditor({
   onPublished,
 }: ArticleEditorProps) {
   const editorRef = useRef<Editor | null>(null);
+  const dialogRef = useRef<HTMLElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const requestCloseRef = useRef<() => void>(() => undefined);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const bannerInputRef = useRef<HTMLInputElement>(null);
   const [title, setTitle] = useState(initialArticle?.title ?? "");
@@ -188,9 +198,23 @@ export default function CreatorArticleEditor({
   const [etag, setEtag] = useState(initialEtag);
   const [linkValue, setLinkValue] = useState("");
   const [saving, setSaving] = useState(false);
+  const [uploadingBanner, setUploadingBanner] = useState(false);
   const [uploadingCount, setUploadingCount] = useState(0);
-  const [message, setMessage] = useState("");
+  const [notice, setNotice] = useState<EditorNotice | null>(null);
   const [showPreview, setShowPreview] = useState(false);
+  const [discardArmed, setDiscardArmed] = useState(false);
+  const portalTarget = useSyncExternalStore<HTMLElement | null>(
+    subscribeToDocumentBody,
+    getClientDocumentBody,
+    getServerDocumentBody,
+  );
+  const publishedFingerprintRef = useRef(creatorArticleEditorFingerprintV1({
+    title: initialArticle?.title ?? "",
+    bannerImage: initialArticle?.bannerImage ?? null,
+    document: initialArticle
+      ? JSON.parse(JSON.stringify(initialArticle.document)) as JSONContent
+      : emptyDocument(),
+  }));
 
   const uploadMedia = useCallback(async (
     file: File,
@@ -223,7 +247,8 @@ export default function CreatorArticleEditor({
   const uploadInlineImages = useCallback(async (files: readonly File[]) => {
     const activeEditor = editorRef.current;
     if (!activeEditor || files.length === 0) return;
-    setMessage("");
+    setNotice(null);
+    setDiscardArmed(false);
     for (const file of files) {
       const uploadId = crypto.randomUUID();
       activeEditor.chain().focus().insertContent({
@@ -251,7 +276,10 @@ export default function CreatorArticleEditor({
         });
       } catch (error) {
         updateImageNode(activeEditor, uploadId, { status: "error" });
-        setMessage(error instanceof Error ? error.message : "Image upload failed");
+        setNotice({
+          tone: "error",
+          text: error instanceof Error ? error.message : "Image upload failed",
+        });
       } finally {
         setUploadingCount((current) => Math.max(0, current - 1));
       }
@@ -305,7 +333,8 @@ export default function CreatorArticleEditor({
     },
     onUpdate: ({ editor: activeEditor }) => {
       setDocument(activeEditor.getJSON());
-      setMessage("");
+      setNotice(null);
+      setDiscardArmed(false);
     },
   });
   useEffect(() => {
@@ -314,6 +343,77 @@ export default function CreatorArticleEditor({
       if (editorRef.current === editor) editorRef.current = null;
     };
   }, [editor]);
+
+  const requestClose = useCallback(() => {
+    const fingerprint = creatorArticleEditorFingerprintV1({
+      title,
+      bannerImage,
+      document: editorRef.current?.getJSON() ?? document,
+    });
+    if (fingerprint === publishedFingerprintRef.current) {
+      onClose();
+      return;
+    }
+    setDiscardArmed(true);
+    setNotice({
+      tone: "warning",
+      text: "Discard your unpublished changes?",
+    });
+  }, [bannerImage, document, onClose, title]);
+  useEffect(() => {
+    requestCloseRef.current = requestClose;
+  }, [requestClose]);
+
+  useEffect(() => {
+    if (portalTarget === null) return;
+    const previouslyFocused = window.document.activeElement instanceof HTMLElement
+      ? window.document.activeElement
+      : null;
+    const previousOverflow = window.document.body.style.overflow;
+    window.document.body.style.overflow = "hidden";
+    closeButtonRef.current?.focus();
+
+    const inertedElements: HTMLElement[] = [];
+    let activeLayer = dialogRef.current?.parentElement;
+    while (activeLayer?.parentElement && activeLayer !== window.document.body) {
+      for (const sibling of activeLayer.parentElement.children) {
+        if (sibling !== activeLayer && sibling instanceof HTMLElement && !sibling.inert) {
+          sibling.inert = true;
+          inertedElements.push(sibling);
+        }
+      }
+      activeLayer = activeLayer.parentElement;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        requestCloseRef.current();
+        return;
+      }
+      if (event.key !== "Tab" || !dialogRef.current) return;
+      const focusable = Array.from(dialogRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), [contenteditable="true"], [tabindex]:not([tabindex="-1"])',
+      )).filter((element) => !element.hidden && element.getClientRects().length > 0);
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (event.shiftKey && window.document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && window.document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.document.body.style.overflow = previousOverflow;
+      for (const element of inertedElements) element.inert = false;
+      window.removeEventListener("keydown", onKeyDown);
+      previouslyFocused?.focus({ preventScroll: true });
+    };
+  }, [portalTarget]);
 
   const preview = useMemo(() => {
     try {
@@ -335,8 +435,10 @@ export default function CreatorArticleEditor({
     const file = event.target.files?.[0];
     event.target.value = "";
     if (!file) return;
+    setUploadingBanner(true);
     setUploadingCount((current) => current + 1);
-    setMessage("");
+    setNotice({ tone: "info", text: "Uploading cover image…" });
+    setDiscardArmed(false);
     try {
       const media = await uploadMedia(file, "banner");
       setBannerImage({
@@ -348,15 +450,20 @@ export default function CreatorArticleEditor({
         size: "wide",
       });
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Banner upload failed");
+      setNotice({
+        tone: "error",
+        text: error instanceof Error ? error.message : "Banner upload failed",
+      });
     } finally {
+      setUploadingBanner(false);
       setUploadingCount((current) => Math.max(0, current - 1));
     }
   }
 
   async function publish() {
     setSaving(true);
-    setMessage("");
+    setNotice(null);
+    setDiscardArmed(false);
     try {
       const draft = createDraft(project, title, bannerImage, editor?.getJSON() ?? document);
       const response = await fetch(
@@ -382,10 +489,18 @@ export default function CreatorArticleEditor({
       const nextEtag = response.headers.get("etag");
       if (!nextEtag) throw new Error("The published revision could not be verified");
       setEtag(nextEtag);
-      setMessage("Published");
+      publishedFingerprintRef.current = creatorArticleEditorFingerprintV1({
+        title,
+        bannerImage,
+        document: editor?.getJSON() ?? document,
+      });
+      setNotice({ tone: "success", text: "Published" });
       onPublished(article);
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Article could not be published");
+      setNotice({
+        tone: "error",
+        text: error instanceof Error ? error.message : "Article could not be published",
+      });
     } finally {
       setSaving(false);
     }
@@ -401,21 +516,51 @@ export default function CreatorArticleEditor({
       const href = normalizeHttpsLinkV1(linkValue);
       editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
       setLinkValue("");
-      setMessage("");
+      setNotice(null);
     } catch {
-      setMessage("Use a complete HTTPS link");
+      setNotice({ tone: "error", text: "Use a complete HTTPS link" });
     }
   }
 
-  return (
-    <div className={styles.backdrop} role="presentation">
-      <section className={styles.dialog} role="dialog" aria-modal="true" aria-labelledby="article-editor-title">
+  function togglePreview() {
+    if (showPreview) {
+      setShowPreview(false);
+      return;
+    }
+    if (!preview) {
+      setNotice({
+        tone: "error",
+        text: "Add a title and article content before previewing.",
+      });
+      return;
+    }
+    setNotice(null);
+    setShowPreview(true);
+  }
+
+  if (portalTarget === null) return null;
+  return createPortal((
+    <div
+      className={styles.backdrop}
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) requestClose();
+      }}
+    >
+      <section
+        ref={dialogRef}
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="article-editor-title"
+        aria-describedby={notice ? "article-editor-notice" : undefined}
+      >
         <header className={styles.dialogHeader}>
           <div>
             <p>{project.symbol ? `$${project.symbol}` : "Verified project"}</p>
             <h2 id="article-editor-title">{initialArticle ? "Edit article" : "Create article"}</h2>
           </div>
-          <button type="button" aria-label="Close article editor" onClick={onClose}><X aria-hidden="true" /></button>
+          <button ref={closeButtonRef} type="button" aria-label="Close article editor" onClick={requestClose}><X aria-hidden="true" /></button>
         </header>
 
         <div className={styles.editorLayout}>
@@ -425,8 +570,12 @@ export default function CreatorArticleEditor({
               <input
                 value={title}
                 maxLength={120}
-                placeholder="Tell people what this project is about"
-                onChange={(event) => { setTitle(event.target.value); setMessage(""); }}
+                placeholder="Tell your project story"
+                onChange={(event) => {
+                  setTitle(event.target.value);
+                  setNotice(null);
+                  setDiscardArmed(false);
+                }}
               />
             </label>
 
@@ -439,8 +588,8 @@ export default function CreatorArticleEditor({
                 </div>
               ) : null}
               <input ref={bannerInputRef} hidden type="file" accept="image/png,image/jpeg,image/webp,image/avif" onChange={selectBanner} />
-              <button className={styles.coverButton} type="button" onClick={() => bannerInputRef.current?.click()}>
-                <ImagePlus aria-hidden="true" size={16} /> {bannerImage ? "Replace cover" : "Add cover"}
+              <button className={styles.coverButton} type="button" disabled={uploadingBanner} onClick={() => bannerInputRef.current?.click()}>
+                <ImagePlus aria-hidden="true" size={16} /> {uploadingBanner ? "Uploading cover…" : bannerImage ? "Replace cover" : "Add cover"}
               </button>
             </div>
 
@@ -481,18 +630,29 @@ export default function CreatorArticleEditor({
         </div>
 
         <footer className={styles.dialogFooter}>
-          <p role={message && message !== "Published" ? "alert" : "status"}>{message}</p>
-          <div>
-            <button type="button" onClick={() => setShowPreview((value) => !value)}>{showPreview ? "Hide preview" : "Preview"}</button>
-            <button type="button" onClick={onClose}>Discard</button>
-            <button className={styles.publish} type="button" disabled={saving || uploadingCount > 0 || !preview} onClick={() => void publish()}>
-              {saving ? "Publishing…" : uploadingCount > 0 ? "Uploading…" : "Publish article"}
-            </button>
-          </div>
+          <p
+            id="article-editor-notice"
+            data-tone={notice?.tone}
+            role={notice?.tone === "error" || notice?.tone === "warning" ? "alert" : "status"}
+          >{notice?.text ?? ""}</p>
+          {discardArmed ? (
+            <div>
+              <button type="button" onClick={() => { setDiscardArmed(false); setNotice(null); }}>Keep editing</button>
+              <button className={styles.danger} type="button" onClick={onClose}>Discard changes</button>
+            </div>
+          ) : (
+            <div>
+              <button type="button" onClick={togglePreview}>{showPreview ? "Hide preview" : "Preview"}</button>
+              <button type="button" onClick={requestClose}>Discard</button>
+              <button className={styles.publish} type="button" disabled={saving || uploadingCount > 0 || !preview} onClick={() => void publish()}>
+                {saving ? "Publishing…" : uploadingCount > 0 ? "Uploading…" : "Publish article"}
+              </button>
+            </div>
+          )}
         </footer>
       </section>
     </div>
-  );
+  ), portalTarget);
 }
 
 function ToolbarButton({ label, active = false, onClick }: Readonly<{
@@ -528,7 +688,7 @@ function createDraft(
     tokenAddress: project.tokenAddress,
     title,
     bannerImage,
-        document: cleanCreatorArticleEditorDocumentV1(document),
+    document: cleanCreatorArticleEditorDocumentV1(document),
   });
 }
 
@@ -549,19 +709,37 @@ export function cleanCreatorArticleEditorDocumentV1(value: JSONContent): unknown
     };
   }
   const result: Record<string, unknown> = { type: value.type };
-  if (value.text !== undefined) result.text = value.text;
   if (value.attrs !== undefined) {
     result.attrs = value.type === "heading" ? { level: value.attrs.level } : value.attrs;
   }
+  let normalizedMarks: unknown[] | undefined;
   if (value.marks !== undefined) {
-    result.marks = value.marks.map((mark) => mark.type === "link"
+    normalizedMarks = value.marks.map((mark) => mark.type === "link"
       ? { type: "link", attrs: { href: mark.attrs?.href } }
       : { type: mark.type });
+    result.marks = normalizedMarks;
+  }
+  if (value.text !== undefined) {
+    result.text = readableAutolinkTextV1(value.text, normalizedMarks);
   }
   if (value.content !== undefined) {
     result.content = value.content.map(cleanCreatorArticleEditorDocumentV1);
   }
   return result;
+}
+
+export function creatorArticleEditorFingerprintV1(value: unknown) {
+  if (!isRecord(value)
+    || typeof value.title !== "string"
+    || !("bannerImage" in value)
+    || !isRecord(value.document)) {
+    throw new TypeError("Creator article editor snapshot is invalid");
+  }
+  return JSON.stringify({
+    title: value.title,
+    bannerImage: value.bannerImage,
+    document: value.document,
+  });
 }
 
 function emptyDocument(): JSONContent {
@@ -604,6 +782,23 @@ function readableFileName(value: string) {
   return name || "Project image";
 }
 
+function readableAutolinkTextV1(value: string, marks: unknown[] | undefined) {
+  if (!isAllowedArticleHrefV1(value) || !marks) return value;
+  const link = marks.find((mark) => isRecord(mark)
+    && mark.type === "link"
+    && isRecord(mark.attrs)
+    && typeof mark.attrs.href === "string");
+  if (!isRecord(link) || !isRecord(link.attrs)
+    || typeof link.attrs.href !== "string") return value;
+  try {
+    return normalizeHttpsLinkV1(value) === normalizeHttpsLinkV1(link.attrs.href)
+      ? displayHttpsLinkV1(value)
+      : value;
+  } catch {
+    return value;
+  }
+}
+
 function readApiError(value: unknown) {
   return isRecord(value) && typeof value.code === "string"
     ? value.code.replaceAll("_", " ")
@@ -612,4 +807,16 @@ function readApiError(value: unknown) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function subscribeToDocumentBody() {
+  return () => undefined;
+}
+
+function getClientDocumentBody(): HTMLElement | null {
+  return window.document.body;
+}
+
+function getServerDocumentBody(): HTMLElement | null {
+  return null;
 }

--- a/components/creator-article.module.css
+++ b/components/creator-article.module.css
@@ -1,0 +1,158 @@
+.article {
+  --article-measure: 46rem;
+  border-top: 1px solid color-mix(in srgb, var(--color-border, #ffffff) 16%, transparent);
+  contain: layout paint style;
+  content-visibility: auto;
+  margin-block-start: clamp(4rem, 8vw, 8rem);
+  padding-block: clamp(3.5rem, 7vw, 7rem) clamp(4rem, 8vw, 8rem);
+}
+
+.header,
+.body,
+.updated {
+  margin-inline: auto;
+  max-width: var(--article-measure);
+}
+
+.header {
+  margin-block-end: clamp(2.5rem, 5vw, 4.5rem);
+}
+
+.eyebrow {
+  color: color-mix(in srgb, currentColor 58%, transparent);
+  font-size: 0.72rem;
+  font-weight: 650;
+  letter-spacing: 0.16em;
+  margin: 0 0 0.8rem;
+  text-transform: uppercase;
+}
+
+.header h2 {
+  font-size: clamp(2.35rem, 6vw, 5.25rem);
+  font-weight: 520;
+  letter-spacing: -0.055em;
+  line-height: 0.98;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.body {
+  color: color-mix(in srgb, currentColor 88%, transparent);
+  font-size: clamp(1.03rem, 1.5vw, 1.22rem);
+  line-height: 1.72;
+}
+
+.body > p,
+.body li > p {
+  margin: 0 0 1.45em;
+}
+
+.body h3,
+.body h4 {
+  color: currentColor;
+  letter-spacing: -0.035em;
+  line-height: 1.12;
+  text-wrap: balance;
+}
+
+.body h3 {
+  font-size: clamp(1.75rem, 3.5vw, 2.75rem);
+  font-weight: 560;
+  margin: 2.4em 0 0.72em;
+}
+
+.body h4 {
+  font-size: clamp(1.28rem, 2.4vw, 1.7rem);
+  font-weight: 610;
+  margin: 2em 0 0.62em;
+}
+
+.body ul,
+.body ol {
+  margin: 0 0 2rem;
+  padding-inline-start: 1.35em;
+}
+
+.body li {
+  padding-inline-start: 0.35em;
+}
+
+.link {
+  color: #8fc5ff;
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+}
+
+.link:hover {
+  color: #b8dcff;
+}
+
+.link:focus-visible {
+  border-radius: 0.15em;
+  outline: 2px solid #8fc5ff;
+  outline-offset: 3px;
+}
+
+.media {
+  margin-block: clamp(2.5rem, 6vw, 5.5rem);
+  margin-inline: auto;
+}
+
+.media img {
+  background: #101014;
+  display: block;
+  height: auto;
+  max-width: 100%;
+  object-fit: contain;
+  width: 100%;
+}
+
+.media figcaption {
+  color: color-mix(in srgb, currentColor 52%, transparent);
+  font-size: 0.76rem;
+  line-height: 1.45;
+  margin-block-start: 0.72rem;
+}
+
+.banner {
+  margin-block: 0 clamp(3rem, 7vw, 6.5rem);
+  max-width: 70rem;
+}
+
+.banner img {
+  aspect-ratio: 3 / 1;
+}
+
+.compact {
+  max-width: 32rem;
+}
+
+.content {
+  max-width: var(--article-measure);
+}
+
+.wide {
+  left: 50%;
+  max-width: 70rem;
+  position: relative;
+  transform: translateX(-50%);
+  width: min(70rem, calc(100vw - 2 * clamp(1rem, 4vw, 3rem)));
+}
+
+.updated {
+  color: color-mix(in srgb, currentColor 46%, transparent);
+  font-size: 0.75rem;
+  margin-block-start: clamp(3rem, 6vw, 5rem);
+}
+
+@media (max-width: 48rem) {
+  .article {
+    margin-block-start: 3.5rem;
+    padding-block: 3rem 4.5rem;
+  }
+
+  .wide {
+    width: calc(100vw - 2rem);
+  }
+}

--- a/components/creator-article.tsx
+++ b/components/creator-article.tsx
@@ -1,0 +1,113 @@
+import Image from "next/image";
+import type { ReactNode } from "react";
+
+import type {
+  CreatorArticleInlineV1,
+  CreatorArticleMarkV1,
+  CreatorArticleV1,
+} from "@/lib/creator-article/contract-v1";
+
+import styles from "./creator-article.module.css";
+
+export function CreatorArticle({ article }: { article: CreatorArticleV1 | null }) {
+  if (article === null) return null;
+  return (
+    <article className={styles.article} aria-labelledby="creator-article-title">
+      {article.bannerImage ? (
+        <figure className={`${styles.media} ${styles.banner}`}>
+          <Image
+            src={article.bannerImage.url}
+            alt={article.bannerImage.alt}
+            width={article.bannerImage.width}
+            height={article.bannerImage.height}
+            sizes="(max-width: 720px) 100vw, (max-width: 1200px) 92vw, 1120px"
+            unoptimized
+          />
+          {article.bannerImage.caption ? (
+            <figcaption>{article.bannerImage.caption}</figcaption>
+          ) : null}
+        </figure>
+      ) : null}
+      <header className={styles.header}>
+        <p className={styles.eyebrow}>From the creator</p>
+        <h2 id="creator-article-title">{article.title}</h2>
+      </header>
+      <div className={styles.body}>
+        {article.document.content.map((block, index) => {
+          if (block.type === "paragraph") {
+            return <p key={index}>{renderInline(block.content ?? [])}</p>;
+          }
+          if (block.type === "heading") {
+            return block.attrs.level === 2
+              ? <h3 key={index}>{renderInline(block.content)}</h3>
+              : <h4 key={index}>{renderInline(block.content)}</h4>;
+          }
+          if (block.type === "articleImage") {
+            return (
+              <figure
+                className={`${styles.media} ${styles[block.attrs.size]}`}
+                key={`${block.attrs.url}:${index}`}
+              >
+                <Image
+                  src={block.attrs.url}
+                  alt={block.attrs.alt}
+                  width={block.attrs.width}
+                  height={block.attrs.height}
+                  sizes={block.attrs.size === "wide"
+                    ? "(max-width: 720px) 100vw, (max-width: 1200px) 92vw, 1120px"
+                    : block.attrs.size === "compact"
+                      ? "(max-width: 720px) 74vw, 520px"
+                      : "(max-width: 720px) 92vw, 720px"}
+                  unoptimized
+                />
+                {block.attrs.caption ? <figcaption>{block.attrs.caption}</figcaption> : null}
+              </figure>
+            );
+          }
+          const List = block.type === "orderedList" ? "ol" : "ul";
+          return (
+            <List key={index}>
+              {block.content.map((item, itemIndex) => (
+                <li key={itemIndex}>
+                  {item.content.map((paragraph, paragraphIndex) => (
+                    <p key={paragraphIndex}>{renderInline(paragraph.content ?? [])}</p>
+                  ))}
+                </li>
+              ))}
+            </List>
+          );
+        })}
+      </div>
+      <footer className={styles.updated}>
+        Updated {new Intl.DateTimeFormat("en", {
+          year: "numeric", month: "short", day: "numeric",
+        }).format(new Date(article.updatedAt))}
+      </footer>
+    </article>
+  );
+}
+
+function renderInline(nodes: readonly CreatorArticleInlineV1[]) {
+  return nodes.map((node, index) => {
+    if (node.type === "hardBreak") return <br key={index} />;
+    let content: ReactNode = node.text;
+    for (const mark of node.marks ?? []) content = applyMark(mark, content, index);
+    return <span key={index}>{content}</span>;
+  });
+}
+
+function applyMark(mark: CreatorArticleMarkV1, content: ReactNode, key: number) {
+  if (mark.type === "bold") return <strong key={`bold-${key}`}>{content}</strong>;
+  if (mark.type === "italic") return <em key={`italic-${key}`}>{content}</em>;
+  return (
+    <a
+      className={styles.link}
+      href={mark.attrs.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      key={`link-${key}`}
+    >
+      {content}
+    </a>
+  );
+}

--- a/components/explore-preview-data.ts
+++ b/components/explore-preview-data.ts
@@ -2,6 +2,14 @@ import type {
   CanonicalTokenExploreEntry,
   CustomProjectExploreEntry,
 } from "@/lib/tokens";
+import {
+  CREATOR_ARTICLE_SCHEMA_V1,
+  parseCreatorArticleV1,
+} from "@/lib/creator-article/contract-v1";
+import {
+  PROGRAMMABLE_MAIN_TOKEN_ADDRESS,
+  programmableCreatorArticleExampleV1,
+} from "@/lib/creator-article/programmable-example-v1";
 
 type PreviewChartRange = "1h" | "1d" | "1w" | "all";
 
@@ -233,6 +241,16 @@ export const EXPLORE_PREVIEW_TOKENS: CanonicalTokenExploreEntry[] = [
     totalSwapFeeBps: 100,
   }),
 ];
+
+const PROGRAMMABLE_MAIN_PREVIEW_TOKEN: CanonicalTokenExploreEntry = {
+  ...EXPLORE_PREVIEW_TOKENS[0]!,
+  id: `interface-preview:${PROGRAMMABLE_MAIN_TOKEN_ADDRESS.toLowerCase()}`,
+  name: "Programmable",
+  symbol: "V4",
+  description: "Launch tokens that work the way you imagine on Uniswap",
+  imageUrl: "/brand/programmable-final-x-pfp-v4-800.png",
+  tokenAddress: PROGRAMMABLE_MAIN_TOKEN_ADDRESS,
+};
 
 const CUSTOM_PREVIEW_WALLET = {
   namespace: "eip155:1",
@@ -593,9 +611,27 @@ const EXPLORE_PREVIEW_PROJECTS = new Map<string, ExplorePreviewProject>([
 ]);
 
 export function getExplorePreviewToken(address: string) {
+  if (address.toLowerCase() === PROGRAMMABLE_MAIN_TOKEN_ADDRESS.toLowerCase()) {
+    return PROGRAMMABLE_MAIN_PREVIEW_TOKEN;
+  }
   return EXPLORE_PREVIEW_TOKENS.find(
     (token) => token.tokenAddress.toLowerCase() === address.toLowerCase(),
   );
+}
+
+export function getExplorePreviewCreatorArticle(address: string) {
+  if (address.toLowerCase() !== PROGRAMMABLE_MAIN_TOKEN_ADDRESS.toLowerCase()) {
+    return null;
+  }
+  const draft = programmableCreatorArticleExampleV1();
+  return parseCreatorArticleV1({
+    ...draft,
+    schemaVersion: CREATOR_ARTICLE_SCHEMA_V1,
+    revision: 1,
+    status: "published",
+    createdAt: "2026-08-21T00:00:00.000Z",
+    updatedAt: "2026-08-21T00:00:00.000Z",
+  });
 }
 
 export function getExplorePreviewProject(address: string) {

--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -35,6 +35,7 @@
   cursor: pointer;
   font: inherit;
   font-size: 0.78rem;
+  min-height: 2.75rem;
   padding: 0.65rem 0.95rem;
   text-decoration: none;
 }
@@ -104,6 +105,7 @@
 }
 
 .actions {
+  align-items: center;
   display: flex;
   gap: 0.5rem;
 }

--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -1,0 +1,130 @@
+.section {
+  border-top: 1px solid rgb(255 255 255 / 10%);
+  margin-block: clamp(3rem, 6vw, 5.5rem);
+  padding-block-start: clamp(2rem, 4vw, 3.5rem);
+}
+
+.heading {
+  align-items: end;
+  display: flex;
+  justify-content: space-between;
+  margin-block-end: 1.4rem;
+}
+
+.heading p {
+  color: rgb(255 255 255 / 48%);
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  margin: 0 0 0.35rem;
+  text-transform: uppercase;
+}
+
+.heading h2 {
+  font-size: clamp(1.75rem, 4vw, 2.6rem);
+  letter-spacing: -0.045em;
+  margin: 0;
+}
+
+.heading button,
+.actions button,
+.actions a {
+  background: transparent;
+  border: 1px solid rgb(255 255 255 / 18%);
+  border-radius: 999px;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  padding: 0.65rem 0.95rem;
+  text-decoration: none;
+}
+
+.heading button:hover,
+.actions button:hover,
+.actions a:hover {
+  border-color: rgb(255 255 255 / 48%);
+}
+
+.heading button:focus-visible,
+.actions button:focus-visible,
+.actions a:focus-visible {
+  outline: 2px solid #8fc5ff;
+  outline-offset: 3px;
+}
+
+.grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.project {
+  align-items: center;
+  border-bottom: 1px solid rgb(255 255 255 / 9%);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  padding-block: 1rem;
+}
+
+.art {
+  align-items: center;
+  background: #17171c;
+  border-radius: 0.65rem;
+  display: flex;
+  height: 3.75rem;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+  width: 3.75rem;
+}
+
+.art img {
+  object-fit: cover;
+}
+
+.copy {
+  display: grid;
+  min-width: 0;
+}
+
+.copy strong {
+  font-size: 1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.copy span,
+.copy small,
+.loading,
+.empty,
+.error {
+  color: rgb(255 255 255 / 52%);
+  font-size: 0.78rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.actions button {
+  background: #f0eee8;
+  border-color: #f0eee8;
+  color: #0a0a0c;
+}
+
+.error {
+  color: #ff9d9d;
+}
+
+@media (max-width: 42rem) {
+  .project {
+    align-items: start;
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .actions {
+    grid-column: 1 / -1;
+  }
+}

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Image from "next/image";
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { getAddress, isAddress } from "viem";
+
+import { useWallet } from "@/components/wallet-provider";
+import { parseCreatorArticleV1, type CreatorArticleV1 } from
+  "@/lib/creator-article/contract-v1";
+
+import styles from "./profile-projects.module.css";
+
+const CreatorArticleEditor = dynamic(
+  () => import("@/components/creator-article-editor"),
+  { ssr: false, loading: () => <p className={styles.loading}>Opening editor…</p> },
+);
+
+export type CreatorProjectSummaryV1 = Readonly<{
+  chainId: 1;
+  tokenAddress: `0x${string}`;
+  name: string;
+  symbol: string | null;
+  imageUrl: string | null;
+  source: "envio-classic-v3" | "registry.custom-launched" | "official-main-token";
+  article: Readonly<{ revision: number; title: string; updatedAt: string }> | null;
+}>;
+
+type EditorState = Readonly<{
+  project: CreatorProjectSummaryV1;
+  article: CreatorArticleV1 | null;
+  etag: string | null;
+}>;
+
+export function ProfileProjects() {
+  const { wallet, getAccessToken, getIdentityToken } = useWallet();
+  const [projects, setProjects] = useState<readonly CreatorProjectSummaryV1[]>([]);
+  const [phase, setPhase] = useState<"loading" | "ready" | "error">("loading");
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [opening, setOpening] = useState<string | null>(null);
+
+  const getAuthHeaders = useCallback(async () => {
+    const [accessToken, identityToken] = await Promise.all([
+      getAccessToken(),
+      getIdentityToken(),
+    ]);
+    if (!accessToken || !identityToken) throw new Error("Reconnect your wallet and try again");
+    return {
+      Authorization: `Bearer ${accessToken}`,
+      "X-Privy-Identity-Token": identityToken,
+    };
+  }, [getAccessToken, getIdentityToken]);
+
+  const loadProjects = useCallback(async (signal?: AbortSignal) => {
+    if (!wallet) return;
+    setPhase("loading");
+    try {
+      const response = await fetch("/api/profile/projects", {
+        headers: { Accept: "application/json", ...(await getAuthHeaders()) },
+        signal,
+      });
+      const body: unknown = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(readError(body));
+      setProjects(parseProjectList(body));
+      setPhase("ready");
+    } catch {
+      if (signal?.aborted) return;
+      setPhase("error");
+    }
+  }, [getAuthHeaders, wallet]);
+
+  useEffect(() => {
+    if (!wallet) return;
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => void loadProjects(controller.signal), 0);
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [loadProjects, wallet]);
+
+  async function openEditor(project: CreatorProjectSummaryV1) {
+    setOpening(project.tokenAddress);
+    try {
+      const response = await fetch(
+        `/api/profile/projects/${project.tokenAddress}/article`,
+        { headers: { Accept: "application/json", ...(await getAuthHeaders()) } },
+      );
+      const body: unknown = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(readError(body));
+      const record = isRecord(body) ? body : null;
+      const article = record?.article === null
+        ? null
+        : parseCreatorArticleV1(record?.article);
+      setEditor({ project, article, etag: response.headers.get("etag") });
+    } finally {
+      setOpening(null);
+    }
+  }
+
+  if (!wallet) return null;
+  return (
+    <section className={styles.section} aria-labelledby="my-projects-title">
+      <header className={styles.heading}>
+        <div>
+          <p>Creator workspace</p>
+          <h2 id="my-projects-title">My projects</h2>
+        </div>
+        <button type="button" onClick={() => void loadProjects()} disabled={phase === "loading"}>
+          Refresh
+        </button>
+      </header>
+
+      {phase === "loading" && projects.length === 0 ? (
+        <p className={styles.loading} role="status">Loading your verified launches…</p>
+      ) : phase === "error" ? (
+        <p className={styles.error} role="alert">Your projects could not be verified right now.</p>
+      ) : projects.length === 0 ? (
+        <p className={styles.empty}>Your verified launches will appear here.</p>
+      ) : (
+        <div className={styles.grid}>
+          {projects.map((project) => (
+            <article className={styles.project} key={project.tokenAddress}>
+              <div className={styles.art}>
+                {project.imageUrl ? (
+                  <Image src={project.imageUrl} alt="" fill sizes="64px" unoptimized />
+                ) : <span aria-hidden="true">{project.symbol?.slice(0, 2) ?? "P"}</span>}
+              </div>
+              <div className={styles.copy}>
+                <strong>{project.name}</strong>
+                <span>{project.symbol ? `$${project.symbol}` : "Verified launch"}</span>
+                {project.article ? <small>Updated {formatDate(project.article.updatedAt)}</small> : null}
+              </div>
+              <div className={styles.actions}>
+                <button
+                  type="button"
+                  disabled={opening === project.tokenAddress}
+                  onClick={() => void openEditor(project)}
+                >
+                  {opening === project.tokenAddress
+                    ? "Opening…"
+                    : project.article ? "Edit article" : "Create article"}
+                </button>
+                <Link href={`/token/${project.tokenAddress}`}>View token</Link>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+
+      {editor ? (
+        <CreatorArticleEditor
+          project={editor.project}
+          initialArticle={editor.article}
+          initialEtag={editor.etag}
+          getAuthHeaders={getAuthHeaders}
+          onClose={() => setEditor(null)}
+          onPublished={(article) => {
+            setProjects((current) => current.map((project) =>
+              project.tokenAddress === article.tokenAddress
+                ? {
+                    ...project,
+                    article: {
+                      revision: article.revision,
+                      title: article.title,
+                      updatedAt: article.updatedAt,
+                    },
+                  }
+                : project));
+          }}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function parseProjectList(value: unknown): readonly CreatorProjectSummaryV1[] {
+  if (!isRecord(value)
+    || value.schemaVersion !== "programmable.creator-project-list.v1"
+    || !Array.isArray(value.projects)) throw new Error("Invalid project list");
+  return value.projects.map((candidate) => {
+    if (!isRecord(candidate)
+      || candidate.chainId !== 1
+      || typeof candidate.tokenAddress !== "string" || !isAddress(candidate.tokenAddress)
+      || typeof candidate.name !== "string"
+      || (candidate.symbol !== null && typeof candidate.symbol !== "string")
+      || (candidate.imageUrl !== null && typeof candidate.imageUrl !== "string")
+      || !["envio-classic-v3", "registry.custom-launched", "official-main-token"].includes(String(candidate.source))) {
+      throw new Error("Invalid project record");
+    }
+    let article: CreatorProjectSummaryV1["article"] = null;
+    if (candidate.article !== null) {
+      if (!isRecord(candidate.article)
+        || !Number.isSafeInteger(candidate.article.revision)
+        || typeof candidate.article.title !== "string"
+        || typeof candidate.article.updatedAt !== "string") throw new Error("Invalid article summary");
+      article = {
+        revision: Number(candidate.article.revision),
+        title: candidate.article.title,
+        updatedAt: candidate.article.updatedAt,
+      };
+    }
+    return Object.freeze({
+      chainId: 1 as const,
+      tokenAddress: getAddress(candidate.tokenAddress),
+      name: candidate.name,
+      symbol: candidate.symbol as string | null,
+      imageUrl: candidate.imageUrl as string | null,
+      source: candidate.source as CreatorProjectSummaryV1["source"],
+      article,
+    });
+  });
+}
+
+function readError(value: unknown) {
+  return isRecord(value) && typeof value.code === "string"
+    ? value.code
+    : "Project request failed";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", { month: "short", day: "numeric", year: "numeric" })
+    .format(new Date(value));
+}

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -33,12 +33,18 @@ type EditorState = Readonly<{
   etag: string | null;
 }>;
 
+type AuthHeaders = Readonly<{
+  Authorization: string;
+  "X-Privy-Identity-Token": string;
+}>;
+
 export function ProfileProjects() {
   const { wallet, getAccessToken, getIdentityToken } = useWallet();
   const [projects, setProjects] = useState<readonly CreatorProjectSummaryV1[]>([]);
   const [phase, setPhase] = useState<"loading" | "ready" | "error">("loading");
   const [editor, setEditor] = useState<EditorState | null>(null);
   const [opening, setOpening] = useState<string | null>(null);
+  const [projectError, setProjectError] = useState("");
 
   const getAuthHeaders = useCallback(async () => {
     const [accessToken, identityToken] = await Promise.all([
@@ -82,18 +88,13 @@ export function ProfileProjects() {
 
   async function openEditor(project: CreatorProjectSummaryV1) {
     setOpening(project.tokenAddress);
+    setProjectError("");
     try {
-      const response = await fetch(
-        `/api/profile/projects/${project.tokenAddress}/article`,
-        { headers: { Accept: "application/json", ...(await getAuthHeaders()) } },
-      );
-      const body: unknown = await response.json().catch(() => null);
-      if (!response.ok) throw new Error(readError(body));
-      const record = isRecord(body) ? body : null;
-      const article = record?.article === null
-        ? null
-        : parseCreatorArticleV1(record?.article);
-      setEditor({ project, article, etag: response.headers.get("etag") });
+      setEditor(await loadCreatorArticleEditorV1(project, getAuthHeaders));
+    } catch (error) {
+      setProjectError(error instanceof Error
+        ? error.message
+        : "Creator article unavailable");
     } finally {
       setOpening(null);
     }
@@ -111,6 +112,8 @@ export function ProfileProjects() {
           Refresh
         </button>
       </header>
+
+      {projectError ? <p className={styles.error} role="alert">{projectError}</p> : null}
 
       {phase === "loading" && projects.length === 0 ? (
         <p className={styles.loading} role="status">Loading your verified launches…</p>
@@ -135,7 +138,7 @@ export function ProfileProjects() {
               <div className={styles.actions}>
                 <button
                   type="button"
-                  disabled={opening === project.tokenAddress}
+                  disabled={opening !== null}
                   onClick={() => void openEditor(project)}
                 >
                   {opening === project.tokenAddress
@@ -173,6 +176,28 @@ export function ProfileProjects() {
       ) : null}
     </section>
   );
+}
+
+export async function loadCreatorArticleEditorV1(
+  project: CreatorProjectSummaryV1,
+  getAuthHeaders: () => Promise<AuthHeaders>,
+  request: typeof fetch = fetch,
+): Promise<EditorState> {
+  const response = await request(
+    `/api/profile/projects/${project.tokenAddress}/article`,
+    { headers: { Accept: "application/json", ...(await getAuthHeaders()) } },
+  );
+  const body: unknown = await response.json().catch(() => null);
+  if (!response.ok) throw new Error(readError(body));
+  const record = isRecord(body) ? body : null;
+  const article = record?.article === null
+    ? null
+    : parseCreatorArticleV1(record?.article);
+  return Object.freeze({
+    project,
+    article,
+    etag: response.headers.get("etag"),
+  });
 }
 
 function parseProjectList(value: unknown): readonly CreatorProjectSummaryV1[] {
@@ -214,8 +239,8 @@ function parseProjectList(value: unknown): readonly CreatorProjectSummaryV1[] {
 }
 
 function readError(value: unknown) {
-  return isRecord(value) && typeof value.code === "string"
-    ? value.code
+  return isRecord(value) && typeof value.code === "string" && value.code
+    ? `${value.code[0]?.toUpperCase() ?? ""}${value.code.slice(1).replaceAll("_", " ")}`
     : "Project request failed";
 }
 

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -17,6 +17,7 @@ import {
 } from "react";
 
 import { useWallet } from "@/components/wallet-provider";
+import { ProfileProjects } from "@/components/profile-projects";
 import { useLiveDataRefresh } from "@/components/use-live-data-refresh";
 import { formatMarketCapMetric } from "@/components/animated-market-cap";
 import { isConfiguredClassicV3ReleaseReady } from "@/lib/classic-v3-release";
@@ -3187,6 +3188,8 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
           ) : null}
         </div>
       </section>
+
+      <ProfileProjects />
 
       <ProfileAccountWorkspace
         key={account.toLowerCase()}

--- a/components/token-detail-shell.tsx
+++ b/components/token-detail-shell.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+import styles from "./token-experience.module.css";
+
+export function TokenDetailShell() {
+  return (
+    <div className={`${styles.page} page-width`}>
+      <Link className={styles.back} href="/explore">
+        <ArrowLeft aria-hidden="true" size={16} />
+        Explore
+      </Link>
+      <div className={styles.loadingState} role="status" aria-live="polite">
+        Loading
+      </div>
+    </div>
+  );
+}

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -29,6 +29,7 @@ import {
 import { CustomMarketTrade } from "@/components/custom-market-trade";
 import { CreatorArticle } from "@/components/creator-article";
 import {
+  getExplorePreviewCreatorArticle,
   getExplorePreviewCustomProject,
   getExplorePreviewToken,
 } from "@/components/explore-preview-data";
@@ -2263,6 +2264,7 @@ export function TokenDetailView({
         token={previewToken}
         chainId={1}
         preview
+        creatorArticle={getExplorePreviewCreatorArticle(normalizedAddress)}
       />
     );
   }

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -27,6 +27,7 @@ import {
   type TokenChartVolume,
 } from "@/components/token-price-chart";
 import { CustomMarketTrade } from "@/components/custom-market-trade";
+import { CreatorArticle } from "@/components/creator-article";
 import {
   getExplorePreviewCustomProject,
   getExplorePreviewToken,
@@ -59,6 +60,10 @@ import {
   type TokenLink,
   type TokenLinkKind,
 } from "@/lib/tokens";
+import {
+  parseCreatorArticleV1,
+  type CreatorArticleV1,
+} from "@/lib/creator-article/contract-v1";
 import type { PostLaunchAuthorityInventoryV1 } from "@/lib/custom-launch/contract-v2";
 import styles from "./token-experience.module.css";
 
@@ -76,6 +81,7 @@ type DetailPayload = {
   status: "ready" | "not-deployed";
   token: DetailToken | null;
   customProject: DetailCustomProject | null;
+  creatorArticle: CreatorArticleV1 | null;
   snapshot: { chainId: number } | null;
 };
 
@@ -87,12 +93,14 @@ export type DetailState =
   | {
       phase: "ready";
       token: DetailToken;
+      creatorArticle: CreatorArticleV1 | null;
       chainId: number;
       requestKey: string;
     }
   | {
       phase: "custom-ready";
       project: DetailCustomProject;
+      creatorArticle: CreatorArticleV1 | null;
       chainId: number;
       requestKey: string;
     };
@@ -692,6 +700,14 @@ export function parseDetailPayload(value: unknown): DetailPayload {
   if (token !== null && customProject !== null) {
     throw new Error("The token registry returned conflicting launch categories");
   }
+  let creatorArticle: CreatorArticleV1 | null = null;
+  if (value.creatorArticle !== null && value.creatorArticle !== undefined) {
+    try {
+      creatorArticle = parseCreatorArticleV1(value.creatorArticle);
+    } catch {
+      creatorArticle = null;
+    }
+  }
 
   let snapshot: DetailPayload["snapshot"] = null;
   if (value.snapshot !== null) {
@@ -712,7 +728,7 @@ export function parseDetailPayload(value: unknown): DetailPayload {
     throw new Error("The launch stamp does not match the snapshot network");
   }
 
-  return { status: value.status, token, customProject, snapshot };
+  return { status: value.status, token, customProject, creatorArticle, snapshot };
 }
 
 function readApiError(value: unknown) {
@@ -759,6 +775,7 @@ function detailStateFromResponse(
     return {
       phase: "custom-ready",
       project: payload.customProject,
+      creatorArticle: payload.creatorArticle,
       chainId: customChainId,
       requestKey,
     };
@@ -776,6 +793,7 @@ function detailStateFromResponse(
   return {
     phase: "ready",
     token: payload.token!,
+    creatorArticle: payload.creatorArticle,
     chainId: payload.snapshot.chainId,
     requestKey,
   };
@@ -1315,10 +1333,12 @@ function TokenDetailContent({
   token,
   chainId,
   preview,
+  creatorArticle = null,
 }: {
   token: LauncherToken;
   chainId: number;
   preview: boolean;
+  creatorArticle?: CreatorArticleV1 | null;
 }) {
   const { wallet, openWallet, readTradeBalances, sendTransaction } =
     useWallet();
@@ -1837,6 +1857,7 @@ function TokenDetailContent({
         ) : null}
 
       </div>
+      <CreatorArticle article={creatorArticle} />
       {copyError ? (
         <div className="toast-region" aria-live="assertive" aria-atomic="true">
           <p className="toast" role="alert">
@@ -1906,9 +1927,11 @@ function customMarketMetrics(project: DetailCustomProject): TokenMetric[] {
 function CustomProjectDetailContent({
   project,
   chainId,
+  creatorArticle = null,
 }: {
   project: DetailCustomProject;
   chainId: number;
+  creatorArticle?: CreatorArticleV1 | null;
 }) {
   const {
     wallet,
@@ -2132,6 +2155,7 @@ function CustomProjectDetailContent({
           </p>
         </section>
       </div>
+      <CreatorArticle article={creatorArticle} />
       {copyError ? (
         <div className="toast-region" aria-live="assertive" aria-atomic="true">
           <p className="toast" role="alert">{copyError}</p>
@@ -2270,6 +2294,7 @@ export function TokenDetailView({
         token={activeState.token}
         chainId={activeState.chainId}
         preview={false}
+        creatorArticle={activeState.creatorArticle}
       />
     );
   }
@@ -2279,6 +2304,7 @@ export function TokenDetailView({
       <CustomProjectDetailContent
         project={activeState.project}
         chainId={activeState.chainId}
+        creatorArticle={activeState.creatorArticle}
       />
     );
   }

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -143,8 +143,11 @@ export function shouldEagerLoadWalletRuntime(pathname: string) {
   return pathname === "/launch"
     || pathname.startsWith("/launch/")
     || pathname === "/profile"
-    || pathname.startsWith("/profile/")
-    || pathname.startsWith("/token/");
+    || pathname.startsWith("/profile/");
+}
+
+export function shouldIdlePreloadWalletRuntime(pathname: string) {
+  return pathname.startsWith("/token/");
 }
 
 if (
@@ -700,6 +703,30 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       cancelled = true;
     };
   }, [active, loadAttempt, runtime]);
+
+  useEffect(() => {
+    if (!privyAppId || runtime || !shouldIdlePreloadWalletRuntime(pathname)) return;
+    let cancelled = false;
+    const preload = () => {
+      if (!cancelled) void loadWalletProviderRuntime().catch(() => undefined);
+    };
+    const idleWindow = window as Window & {
+      requestIdleCallback?: Window["requestIdleCallback"];
+      cancelIdleCallback?: Window["cancelIdleCallback"];
+    };
+    if (typeof idleWindow.requestIdleCallback === "function") {
+      const idleId = idleWindow.requestIdleCallback(preload, { timeout: 1_500 });
+      return () => {
+        cancelled = true;
+        idleWindow.cancelIdleCallback?.(idleId);
+      };
+    }
+    const timeoutId = globalThis.setTimeout(preload, 1_200);
+    return () => {
+      cancelled = true;
+      globalThis.clearTimeout(timeoutId);
+    };
+  }, [pathname, runtime]);
 
   if (!privyAppId) {
     return <UnconfiguredWalletProvider>{children}</UnconfiguredWalletProvider>;

--- a/config/creator-article-programmable-example.v1.json
+++ b/config/creator-article-programmable-example.v1.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": "programmable.creator-article-draft.v1",
+  "chainId": 1,
+  "tokenAddress": "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
+  "title": "Programmable: tokens with something to do",
+  "bannerImage": {
+    "url": "https://programmable.market/brand/programmable-final-x-banner-1500x500.png",
+    "alt": "Programmable floral landscape",
+    "caption": null,
+    "width": 1500,
+    "height": 500,
+    "size": "wide"
+  },
+  "document": {
+    "type": "doc",
+    "content": [
+      {
+        "type": "paragraph",
+        "content": [
+          {
+            "type": "text",
+            "text": "Programmable is a launchpad for tokens with onchain behavior. Creators choose a launch model, publish a verified identity, and meet the market on the same page."
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "attrs": { "level": 2 },
+        "content": [{ "type": "text", "text": "Launch, discover, trade" }]
+      },
+      {
+        "type": "paragraph",
+        "content": [
+          {
+            "type": "text",
+            "text": "Each public coin page keeps verified launch identity, market context, and trading in one place. The launch record stays separate from the story a creator publishes below it."
+          }
+        ]
+      },
+      {
+        "type": "articleImage",
+        "attrs": {
+          "url": "https://programmable.market/brand/programmable-adaptive-model-post-v1-2000x1000.png",
+          "alt": "Programmable launch model artwork",
+          "caption": "A Programmable launch starts with a model and a verified creator.",
+          "width": 2000,
+          "height": 1000,
+          "size": "wide"
+        }
+      },
+      {
+        "type": "heading",
+        "attrs": { "level": 2 },
+        "content": [{ "type": "text", "text": "Built for creators" }]
+      },
+      {
+        "type": "paragraph",
+        "content": [
+          {
+            "type": "text",
+            "text": "This project story is controlled by the verified launch wallet. It can evolve as the project grows without changing the token contract, original metadata, or canonical social links."
+          }
+        ]
+      },
+      {
+        "type": "bulletList",
+        "content": [
+          {
+            "type": "listItem",
+            "content": [{
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Launch on Ethereum with a verified public identity." }]
+            }]
+          },
+          {
+            "type": "listItem",
+            "content": [{
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Follow the market and trade from the coin page." }]
+            }]
+          },
+          {
+            "type": "listItem",
+            "content": [{
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Review creator rewards from the connected profile." }]
+            }]
+          }
+        ]
+      },
+      {
+        "type": "paragraph",
+        "content": [
+          {
+            "type": "text",
+            "text": "programmable.market",
+            "marks": [{
+              "type": "link",
+              "attrs": { "href": "https://programmable.market/" }
+            }]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/superpowers/plans/2026-08-21-creator-article-implementation.md
+++ b/docs/superpowers/plans/2026-08-21-creator-article-implementation.md
@@ -1,0 +1,245 @@
+# Creator Article Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the verified creator of every publicly eligible Programmable launch publish and revise a polished, image-rich article below that token's market surface without changing token metadata or performing an onchain action.
+
+**Architecture:** A strict shared article contract validates a bounded Tiptap JSON document. Server-only authority resolves the authenticated Privy wallet against Envio Classic creator evidence or Registry-verified Custom launch evidence. Immutable revision blobs and an ETag-protected current pointer provide optimistic concurrency in the existing Vercel Blob store. The public token response composes the article as a separate fail-soft field, while `Profile -> My projects` lazy-loads the editor and media uploader.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Tiptap 3.30.2, Privy, viem, Sharp 0.35.3, Vercel Blob 2.6.1, Vitest, Playwright/browser QA.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-creator-article-design.md`
+
+## Global Constraints
+
+- Never mutate token, Registry, launch, social-link, claim, trade, or onchain data.
+- Never trust a client-provided creator address; resolve write authority from verified public launch evidence.
+- Fail closed for edits and fail soft for public reads.
+- Accept only HTTPS links and verified image assets; never server-fetch clipboard URLs.
+- Do not render stored HTML or use `dangerouslySetInnerHTML`.
+- Keep editor dependencies out of the public token-page bundle.
+- Use focused tests for changed contracts, then typecheck, changed-path lint, build, and rendered desktop/mobile QA.
+
+---
+
+## Task 1: Install the bounded editor dependencies
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+- [ ] Run `npm install @tiptap/core@3.30.2 @tiptap/react@3.30.2 @tiptap/starter-kit@3.30.2 @tiptap/extension-image@3.30.2`.
+- [ ] Confirm all four packages resolve to 3.30.2 and React 19 remains unchanged.
+- [ ] Run `git diff --check`.
+- [ ] Commit with `build: add bounded creator article editor` after Task 2 tests pass so the dependency and first consumer stay together.
+
+## Task 2: Define and adversarially validate the article contract
+
+**Files:**
+
+- Create: `lib/creator-article/contract-v1.ts`
+- Create: `lib/creator-article/link.ts`
+- Create: `tests/creator-article-contract.test.ts`
+
+**Interfaces:**
+
+```ts
+export type CreatorArticleDocumentV1 = Readonly<{
+  type: "doc";
+  content: readonly CreatorArticleBlockV1[];
+}>;
+
+export type CreatorArticleV1 = Readonly<{
+  schemaVersion: "programmable.creator-article.v1";
+  chainId: 1;
+  tokenAddress: `0x${string}`;
+  revision: number;
+  status: "published";
+  title: string;
+  bannerImage: CreatorArticleImageV1 | null;
+  document: CreatorArticleDocumentV1;
+  createdAt: string;
+  updatedAt: string;
+}>;
+
+export function parseCreatorArticleDraftV1(value: unknown): CreatorArticleDraftV1;
+export function parseCreatorArticleV1(value: unknown): CreatorArticleV1;
+export function canonicalCreatorArticleDraftV1(value: CreatorArticleDraftV1): string;
+export function displayHttpsLinkV1(url: string): string;
+```
+
+- [ ] Write failing tests for the exact node/mark allowlist, depth/count/text limits, heading levels 2/3, compact/content/wide image sizing, nonempty alt text, HTTPS-only links, canonical URL normalization, duplicate mark rejection, unknown attributes, raw HTML/data/javascript URL rejection, and domain-only display labels.
+- [ ] Implement recursive strict parsing with explicit key allowlists and bounded depth; normalize addresses with `getAddress` and timestamps with exact ISO serialization.
+- [ ] Keep the public article object structurally separate from token/custom-project types.
+- [ ] Run `npm test -- --run tests/creator-article-contract.test.ts` and expect green.
+- [ ] Commit Tasks 1-2 with `feat: define creator article contract`.
+
+## Task 3: Authenticate a wallet principal and resolve verified creator authority
+
+**Files:**
+
+- Create: `lib/server/creator-article/wallet-principal.server.ts`
+- Create: `lib/server/creator-article/authority.server.ts`
+- Create: `tests/creator-article-authority.test.ts`
+
+**Interfaces:**
+
+```ts
+export type AuthenticatedWalletPrincipalV1 = Readonly<{
+  privyUserId: string;
+  privySessionId: string;
+  wallets: readonly `0x${string}`[];
+}>;
+
+export interface CreatorArticleAuthorityV1 {
+  readonly chainId: 1;
+  readonly tokenAddress: `0x${string}`;
+  readonly creatorAddress: `0x${string}`;
+  readonly source: "envio-classic-v3" | "registry.custom-launched" | "official-main-token";
+}
+```
+
+- [ ] Write failing boundary tests for matching access/identity token sessions, app-id mismatch, mismatched Privy subjects, malformed/non-Ethereum linked accounts, no wallet, and normalized duplicate wallets.
+- [ ] Reuse the existing Privy verification semantics but require no GitHub account and expose no private subject in responses.
+- [ ] Write failing authority tests for Classic V3 creator match, Registry-verified Custom launching-wallet match, Registry unavailable, hidden Custom, unknown token, wrong wallet, and the already-authorized official Main-token exception only when its public record exposes creator evidence.
+- [ ] Implement authority reads without Dexscreener and without inferring identity from a token address.
+- [ ] Run `npm test -- --run tests/creator-article-authority.test.ts` and expect green.
+- [ ] Commit with `feat: bind articles to verified launch creators`.
+
+## Task 4: Persist immutable revisions with an ETag current pointer
+
+**Files:**
+
+- Create: `lib/server/creator-article/storage.server.ts`
+- Create: `tests/creator-article-storage.test.ts`
+
+**Interfaces:**
+
+```ts
+export interface CreatorArticleStoreV1 {
+  readCurrent(input: ArticleIdentityV1): Promise<CreatorArticleReadV1 | null>;
+  publish(input: PublishCreatorArticleV1): Promise<CreatorArticleReadV1>;
+}
+
+export type CreatorArticleReadV1 = Readonly<{
+  article: CreatorArticleV1;
+  etag: string;
+}>;
+```
+
+- [ ] Write failing tests for no current article, immutable revision pathname/content hash, successful create, successful revision update, stale ETag conflict, idempotent revision content, malformed pointer, malformed selected revision, identity mismatch, and read failure.
+- [ ] Store canonical revisions under `creator-articles/v1/eip155-1/<lower-token>/revisions/<sha256>.json` with `allowOverwrite:false`.
+- [ ] Store the current pointer under `creator-articles/v1/eip155-1/<lower-token>/current.json`; create without overwrite and update with exact `ifMatch` ETag.
+- [ ] Read back and re-parse both revision and pointer before reporting success.
+- [ ] Map `BlobPreconditionFailedError` to a typed revision conflict; never delete a written orphan revision.
+- [ ] Run `npm test -- --run tests/creator-article-storage.test.ts` and expect green.
+- [ ] Commit with `feat: persist immutable creator articles`.
+
+## Task 5: Add authenticated project, article, and media APIs
+
+**Files:**
+
+- Create: `lib/server/creator-article/image.server.ts`
+- Create: `app/api/profile/projects/route.ts`
+- Create: `app/api/profile/projects/[address]/article/route.ts`
+- Create: `app/api/profile/projects/[address]/article/media/route.ts`
+- Create: `tests/creator-article-api.test.ts`
+- Create: `tests/creator-article-image.test.ts`
+
+**HTTP contract:**
+
+```text
+GET /api/profile/projects
+GET /api/profile/projects/:address/article
+PUT /api/profile/projects/:address/article  If-Match: <etag or *>
+POST /api/profile/projects/:address/article/media  multipart file=<image>
+```
+
+- [ ] Write failing API tests for authentication headers, exact wallet authority, address normalization, JSON content type, body ceiling, no-store mutation responses, conflict status 412, and 503 fail-closed authority failures.
+- [ ] Write failing image tests for PNG/JPEG/WebP/AVIF decode, oversized encoded and decoded inputs, animated/malformed files, metadata removal, max dimensions, WebP output, preserved aspect ratio, banner 3:1 crop, and exact readback digest.
+- [ ] Implement project listing from verified public identity sources, filtered by authenticated linked wallets.
+- [ ] Implement GET/PUT with server canonicalization; ignore any client creator field.
+- [ ] Implement media upload only after authority verification. Store public media under `creator-article-media/v1/eip155-1/<token>/<uuid>.webp`, verify Blob response and downloaded bytes, and return width, height, URL, digest, and media kind.
+- [ ] Set `Vary: Authorization, X-Privy-Identity-Token`, `Cache-Control: no-store`, `X-Content-Type-Options: nosniff`, and bounded timeouts.
+- [ ] Run `npm test -- --run tests/creator-article-api.test.ts tests/creator-article-image.test.ts` and expect green.
+- [ ] Commit with `feat: add creator article APIs`.
+
+## Task 6: Compose a fail-soft public article into token detail
+
+**Files:**
+
+- Modify: `app/api/explore/token/route.ts`
+- Modify: `components/token-detail-view.tsx`
+- Create: `components/creator-article.tsx`
+- Create: `components/creator-article.module.css`
+- Modify: `tests/token-detail-api.test.ts`
+- Create: `tests/creator-article-renderer.test.tsx`
+
+- [ ] Add `creatorArticle` as a separate top-level response field; never merge it into `token` or `customProject`.
+- [ ] Start the store read only after verified public identity is selected, in parallel with market enrichment when possible.
+- [ ] Return `creatorArticle:null` on missing article, storage outage, or validation failure while preserving the existing token/custom response and status.
+- [ ] Extend the client parser with strict article parsing. Invalid article data becomes null; it never invalidates the token.
+- [ ] Render semantic headings, paragraphs, lists, links, responsive images/captions, and updated date below both canonical and Custom market surfaces and before the footer.
+- [ ] Style the section as an editorial continuation: broad 3:1 banner, readable text measure, pale-blue underlined links, responsive wide media, visible focus, and `content-visibility:auto`.
+- [ ] Write tests proving no article placeholder, safe semantic rendering, no HTML injection, and article outage identity retention.
+- [ ] Run `npm test -- --run tests/token-detail-api.test.ts tests/creator-article-renderer.test.tsx` and expect green.
+- [ ] Commit with `feat: render creator articles on token pages`.
+
+## Task 7: Build `Profile -> My projects` and lazy-load the editor
+
+**Files:**
+
+- Modify: `components/profile-view.tsx`
+- Create: `components/profile-projects.tsx`
+- Create: `components/profile-projects.module.css`
+- Create: `components/creator-article-editor.tsx`
+- Create: `components/creator-article-editor.module.css`
+- Create: `lib/creator-article/editor-image.ts`
+- Create: `tests/creator-article-editor.test.tsx`
+- Modify: `tests/profile-view-state.test.ts`
+
+- [ ] Add a `My projects` section that shows only authenticated wallet-owned verified launches and offers `Create article` or `Edit article` plus `View token`.
+- [ ] Load `creator-article-editor.tsx` with a dynamic import only after an edit action.
+- [ ] Configure StarterKit with headings 2/3, lists, bold, italic, undo/redo, and Link with autolink/paste-link enabled and an HTTPS-only validator.
+- [ ] Add a custom bounded image node with alt, caption, verified URL, intrinsic dimensions, and semantic size `compact | content | wide`.
+- [ ] Handle clipboard image `File` items in cursor order: insert an accessible upload placeholder, POST with current Privy headers, then replace with the verified node. Never fetch clipboard HTML image URLs.
+- [ ] Convert a standalone pasted HTTPS URL to a hostname label while retaining the complete href; autolink inline typed HTTPS URLs.
+- [ ] Provide visible toolbar controls for Normal, Bold, Italic, H2, H3, bullet list, numbered list, link, undo, redo, image upload, and image size. Keep every control keyboard accessible with `aria-pressed` where applicable.
+- [ ] Preserve local draft content after upload/save errors. On 412 show a reload/copy-draft conflict action; never overwrite.
+- [ ] Add live preview using the same public renderer and show exact publish state without an onchain/signature prompt.
+- [ ] Run `npm test -- --run tests/creator-article-editor.test.tsx tests/profile-view-state.test.ts` and expect green.
+- [ ] Commit with `feat: add creator article editor`.
+
+## Task 8: Add the Programmable Main-token example as an explicit seed artifact
+
+**Files:**
+
+- Create: `lib/creator-article/programmable-example-v1.ts`
+- Create: `scripts/seed-programmable-creator-article.mjs`
+- Create: `tests/programmable-creator-article-example.test.ts`
+- Modify: `package.json`
+
+- [ ] Create factual, understated article copy for `0x7987f03462200b3D8A072E02C89A8A41dCB124EE` using owned Programmable imagery and no fabricated claims, partners, metrics, or guarantees.
+- [ ] Include a 3:1 cover and at least one inline image so responsive behavior is visible.
+- [ ] Make the seed script dry-run by default. Require `--write`, production Blob credentials, exact expected current ETag, and the authenticated official creator authority before any external write.
+- [ ] Emit values-free identity, content SHA, revision, and readback ETag receipts; never print credentials.
+- [ ] Do not run `--write` and do not deploy/publish without explicit external-publication authority.
+- [ ] Run `npm test -- --run tests/programmable-creator-article-example.test.ts` and expect green.
+- [ ] Commit with `feat: add Programmable article example`.
+
+## Task 9: Focused verification and rendered correction pass
+
+**Files:**
+
+- Modify only files implicated by failed checks or the rendered correction pass.
+
+- [ ] Run the focused article suite from Tasks 2-8 once at the final combined tip.
+- [ ] Run `npm run typecheck`.
+- [ ] Run changed-path ESLint on the changed TypeScript/TSX files.
+- [ ] Run `npm run build`.
+- [ ] Start the production build locally and verify the main token plus an authenticated profile editor in a real browser.
+- [ ] Capture desktop and mobile screenshots; check clipboard image paste, upload state, image sizing, formatting, link normalization, save conflict, keyboard/focus, console, network failures, and horizontal overflow.
+- [ ] Perform one focused correction pass and rerun only the affected tests plus typecheck/build if bytes changed.
+- [ ] Record final commit/tree and exact local evidence. Stop before push/deploy/public seed write unless separately authorized.
+

--- a/docs/superpowers/plans/2026-08-21-creator-article-implementation.md
+++ b/docs/superpowers/plans/2026-08-21-creator-article-implementation.md
@@ -242,4 +242,3 @@ POST /api/profile/projects/:address/article/media  multipart file=<image>
 - [ ] Capture desktop and mobile screenshots; check clipboard image paste, upload state, image sizing, formatting, link normalization, save conflict, keyboard/focus, console, network failures, and horizontal overflow.
 - [ ] Perform one focused correction pass and rerun only the affected tests plus typecheck/build if bytes changed.
 - [ ] Record final commit/tree and exact local evidence. Stop before push/deploy/public seed write unless separately authorized.
-

--- a/docs/superpowers/plans/2026-08-21-token-page-performance-implementation.md
+++ b/docs/superpowers/plans/2026-08-21-token-page-performance-implementation.md
@@ -1,0 +1,65 @@
+# Token Page Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the cold token document's four-second first-byte stall and keep creator-article/editor bytes off the critical public route.
+
+**Architecture:** Stream an immediate token-page shell through React Suspense while the existing server-side detail read proceeds, let the current client recovery path take over after a bounded server failure, and defer Privy plus the article editor until idle time or direct intent. Preserve existing API caches and market/identity behavior.
+
+**Tech Stack:** Next.js 16 App Router, React 19 Suspense, existing deferred WalletProvider runtime, Vitest, Next production build, browser Performance APIs.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-creator-article-design.md`
+
+## Global Constraints
+
+- Do not alter Explore identity selection, chart semantics, trade preparation, claims, or live-refresh intervals.
+- Do not report a performance improvement from source inspection alone; compare rendered and network evidence.
+- Do not duplicate the token-detail API call after a successful server response.
+- Preserve client recovery when the server read misses its deadline.
+
+---
+
+## Task 1: Stream the token shell before the detail read resolves
+
+**Files:**
+
+- Modify: `app/token/[address]/page.tsx`
+- Create: `components/token-detail-shell.tsx`
+- Modify: `tests/token-detail-page.test.tsx`
+
+- [ ] Write a failing test proving the route tree can emit the shell while the detail promise remains pending.
+- [ ] Move the bounded initial read into an async child rendered inside `Suspense`.
+- [ ] Render a stable, accessible token-detail shell as the fallback without fake values, layout jumps, or duplicate footer.
+- [ ] Keep the four-second server deadline only for the streamed child, not the document's first-byte delivery.
+- [ ] Preserve invalid-address and client retry behavior.
+- [ ] Run `npm test -- --run tests/token-detail-page.test.tsx` and expect green.
+- [ ] Commit with `perf: stream token detail shell`.
+
+## Task 2: Defer wallet/editor runtimes without delaying intent
+
+**Files:**
+
+- Modify: `components/wallet-provider.tsx`
+- Modify: `tests/wallet-provider-boundary.test.ts`
+- Verify: `components/profile-projects.tsx`
+
+- [ ] Write a failing boundary test proving `/token/:address` is not eager while `/launch` and `/profile` remain eager.
+- [ ] Remove token routes from synchronous module evaluation preload.
+- [ ] Schedule an idle token-route preload with a bounded timeout and preserve existing pointer/focus/click preloads on wallet controls.
+- [ ] Verify the creator editor remains behind its `My projects` dynamic import and is absent from the public token initial chunk graph.
+- [ ] Run `npm test -- --run tests/wallet-provider-boundary.test.ts` and expect green.
+- [ ] Commit with `perf: defer token wallet runtime`.
+
+## Task 3: Measure the final combined tip once
+
+**Files:**
+
+- Modify only files implicated by measured regressions.
+
+- [ ] Run the focused performance tests from Tasks 1-2.
+- [ ] Run `npm run typecheck`, changed-path lint, and `npm run build` as part of the combined final gate, not a duplicate suite.
+- [ ] Measure a cold local production token document and confirm the shell is delivered before the prior four-second deadline.
+- [ ] Inspect the token route's initial network graph and confirm no Tiptap/editor chunk is requested.
+- [ ] Verify desktop/mobile chart and trade interactions still load correctly and no new console error or horizontal overflow appears.
+- [ ] Record measured evidence beside the creator-article verification; do not deploy without separate publication authority.
+

--- a/docs/superpowers/plans/2026-08-21-token-page-performance-implementation.md
+++ b/docs/superpowers/plans/2026-08-21-token-page-performance-implementation.md
@@ -62,4 +62,3 @@
 - [ ] Inspect the token route's initial network graph and confirm no Tiptap/editor chunk is requested.
 - [ ] Verify desktop/mobile chart and trade interactions still load correctly and no new console error or horizontal overflow appears.
 - [ ] Record measured evidence beside the creator-article verification; do not deploy without separate publication authority.
-

--- a/docs/superpowers/specs/2026-08-21-creator-article-design.md
+++ b/docs/superpowers/specs/2026-08-21-creator-article-design.md
@@ -1,0 +1,218 @@
+# Creator Article Design
+
+Date: 2026-08-21  
+Status: Owner direction captured; implementation plan pending review
+
+## Product decision
+
+A creator article is mutable website content. It is not token metadata, launch
+metadata, Registry presentation data, or contract state.
+
+The verified creator of a publicly visible Programmable launch may publish and
+later revise one article that is rendered below the market and trading surfaces
+on that token's website page. The creator manages the article from
+`Profile -> My projects`.
+
+The feature must never mutate or replace the token name, symbol, token image,
+description, canonical social links, launch provenance, market identity, pool
+identity, hook identity, or any onchain value. Saving an article performs no
+signature transaction and no onchain action.
+
+## User experience
+
+### Public token page
+
+The existing token identity, chart, metrics, and trading experience remain the
+primary surface. When a published article exists, a new editorial section is
+shown after those surfaces and before the global footer.
+
+The section may contain:
+
+- an optional 3:1 article banner;
+- an article title;
+- structured headings and paragraphs;
+- ordered and unordered lists;
+- article images with optional captions;
+- safe inline HTTPS links and explicit link buttons;
+- an unobtrusive `Updated` date.
+
+The section must not present article links as canonical token social metadata.
+It must not add or alter the social icons beside the contract address.
+
+When no article exists, the section is absent. There is no empty card, setup
+prompt, or public placeholder.
+
+### Creator profile
+
+An authenticated wallet sees a `My projects` section containing only public
+Programmable launches for which that wallet is the verified creator authority.
+Each entry links to the public token page and exposes `Create article` or
+`Edit article`.
+
+The editor supports a live preview, save, and discard. A successful save
+publishes the new revision immediately. Editing an existing article creates a
+new revision and never changes the token or its launch record.
+
+The article editor is loaded only after the creator opens it. It is not part of
+the initial public token-page bundle or the initial profile bundle.
+
+## Authority boundary
+
+Article placement is identified by `(chainId, tokenAddress)`. This is only the
+website location at which the article renders; it does not make the article
+part of token metadata.
+
+Write authority is derived server-side from existing verified launch evidence:
+
+- Classic V3: the exact creator address from the verified Envio launch record;
+- verified Custom: the launching wallet from the verified public Registry
+  record;
+- any explicitly supported historical public exception: only when its existing
+  public launch record exposes equally strong creator evidence.
+
+The server authenticates the existing Privy session, resolves its verified
+Ethereum wallet identities, and requires an exact match with the launch creator
+authority. A client-supplied creator address is never trusted. Unknown,
+unverified, hidden, or Registry-unready launches fail closed and cannot acquire
+an article through this feature.
+
+Normal website authentication may prompt the user to connect a wallet. Saving
+an article does not request a transaction, contract call, token approval, or
+fee payment.
+
+## Content model
+
+The article uses a bounded structured-block contract rather than arbitrary HTML
+or a general-purpose document format. The first version contains:
+
+```text
+CreatorArticleV1
+  schemaVersion
+  chainId
+  tokenAddress
+  revision
+  status: published
+  title
+  bannerImage | null
+  blocks[]
+  createdAt
+  updatedAt
+```
+
+Supported blocks are `heading`, `paragraph`, `list`, `image`, and `link-card`.
+Paragraph and list text use a small mark model for emphasis and HTTPS links.
+Raw HTML, script, iframe, embedded widgets, arbitrary CSS, data URLs, and
+javascript URLs are forbidden.
+
+Content limits are enforced in both the client and server contracts. The
+server canonicalizes the accepted document before hashing and persistence.
+Optimistic concurrency requires the expected current revision so two stale
+editor tabs cannot silently overwrite one another.
+
+## Persistence and media
+
+Creator articles use dedicated website tables and a dedicated current-article
+read view. Existing token-project metadata and Custom launch presentation rows
+are not repurposed or mutated.
+
+The database keeps immutable article revisions plus a single current pointer.
+The current public view returns only the latest valid published revision. All
+writes are audited with article identity, creator wallet, previous revision,
+new revision, and a content commitment; no private session material is stored.
+
+Article media uses the existing Programmable Vercel Blob account through a new
+article-media upload boundary. The server authenticates creator authority
+before writing, verifies decoded image bytes, strips metadata, produces a
+bounded web-safe image, performs readback verification, and stores only the
+verified asset reference in the article.
+
+The banner target is 3000 x 1000 pixels. Article images preserve their aspect
+ratio within bounded dimensions. Public rendering uses responsive image sizes
+so mobile visitors do not download desktop-sized media.
+
+## API composition
+
+The article remains a separately typed object even when composed into the
+token-detail response. It can never override fields in `token` or
+`customProject`.
+
+Public article reads are fail-soft: an article-store outage hides only the
+article and must never hide the verified token identity, chart, or trading
+surface. Successful public reads use a short CDN cache with stale-while-
+revalidate. A successful article mutation invalidates only the affected
+article cache key.
+
+Authenticated profile routes provide:
+
+- the wallet's verified editable project list;
+- the current article revision for one eligible project;
+- a compare-and-swap publish operation;
+- authenticated article-media upload.
+
+All mutation responses are `no-store`. Public data never exposes Privy user
+IDs, access tokens, identity tokens, internal database IDs, or operational
+credentials.
+
+## Rendering and visual direction
+
+The article is an editorial continuation of the token page, not another glass
+dashboard card. It uses a readable centered measure, restrained typography,
+large media, strong whitespace, and the existing Programmable palette. The
+banner spans the article container at 3:1 without affecting the token artwork
+above it.
+
+Desktop supports a broad banner and a narrow reading column. Mobile preserves
+the same hierarchy, uses edge-safe media, and prevents horizontal overflow.
+The renderer supports keyboard navigation, visible focus, meaningful image alt
+text, reduced motion, and semantic heading order.
+
+## Performance work in the same product slice
+
+The new feature must improve rather than regress token-page loading:
+
+1. Stream the token-page shell instead of holding first-byte delivery behind
+   the existing four-second initial-detail deadline.
+2. Keep the public article renderer server-first and ship no editor code to
+   visitors.
+3. Lazy-load the editor only from `My projects`.
+4. Defer the Privy wallet runtime on token pages until idle time or a direct
+   wallet/trade interaction, while preloading it on intent.
+5. Use responsive article media and `content-visibility` for below-the-fold
+   article content.
+6. Preserve the existing short API caches and invalidate only the changed
+   article rather than the launch catalog.
+
+The live baseline captured before implementation was approximately 60-70 ms
+for warm Explore/token APIs, while a cold token document could wait about
+4.6 seconds because its server render awaited the initial detail deadline.
+Validation compares the final build and rendered route against that baseline.
+
+## Failure behavior
+
+- Article read unavailable: render the normal token page without the article.
+- Creator verification unavailable: disable mutation and retain the last
+  published article.
+- Stale revision: return a conflict and let the creator reload or copy their
+  draft; never overwrite silently.
+- Media verification failure: do not attach the asset to an article revision.
+- Invalid link or block: reject the complete mutation with a field-level error.
+- Token ceases to be publicly eligible: do not render or edit its article until
+  public launch eligibility is restored.
+
+## Verification scope
+
+Implementation verification is focused on the changed contracts:
+
+- creator-authority allow and deny cases for Classic V3 and verified Custom;
+- strict separation from token and Registry metadata;
+- article parsing, canonicalization, limits, unsafe URL rejection, and revision
+  conflicts;
+- authenticated media validation and readback;
+- profile `My projects` ownership and editor interaction;
+- public token rendering with and without an article;
+- article-store outage preserving token identity, chart, and trade;
+- desktop and mobile rendering, keyboard/focus, console/network, and overflow;
+- token-page response streaming and bundle/loading comparison.
+
+No contract, launcher, claim, trade-preparation, Registry-verification, or
+onchain behavior is changed by this feature.

--- a/docs/superpowers/specs/2026-08-21-creator-article-design.md
+++ b/docs/superpowers/specs/2026-08-21-creator-article-design.md
@@ -1,7 +1,7 @@
 # Creator Article Design
 
 Date: 2026-08-21  
-Status: Owner direction captured; implementation plan pending review
+Status: Owner-approved design; implementation in progress
 
 ## Product decision
 
@@ -53,6 +53,31 @@ The editor supports a live preview, save, and discard. A successful save
 publishes the new revision immediately. Editing an existing article creates a
 new revision and never changes the token or its launch record.
 
+The writing surface behaves like a focused long-form social editor. Creators
+can use normal text, bold, italic, second- and third-level headings, ordered and
+unordered lists, links, and images. `Normal` clears emphasis so text can return
+to the quiet body style without carrying accidental formatting.
+
+Pasting actual image bytes from the operating-system clipboard with
+`Command-V` or `Control-V` inserts an uploading image placeholder at the
+cursor, authenticates and verifies the image, then replaces the placeholder
+with the stored image. Multiple clipboard images are processed in order.
+Clipboard HTML is never used to make the server fetch an arbitrary remote
+image URL. An image copied from an application such as Discord works when the
+clipboard supplies image bytes; a bare CDN URL remains a safe link.
+
+Images always preserve their decoded aspect ratio. Creators can select
+compact, reading-column, or wide presentation, including through accessible
+keyboard controls. The saved choice is semantic and responsive rather than a
+fixed desktop pixel width, so resizing the browser never stretches, crops, or
+causes horizontal overflow.
+
+HTTPS URLs are recognized while typing and on paste. A standalone raw URL is
+displayed as its human-readable hostname, without `https://` or a trailing
+slash, while its complete validated HTTPS URL remains the destination. Public
+links use the requested pale-blue treatment and a visible underline; external
+links open safely without becoming canonical token social metadata.
+
 The article editor is loaded only after the creator opens it. It is not part of
 the initial public token-page bundle or the initial profile bundle.
 
@@ -82,8 +107,9 @@ fee payment.
 
 ## Content model
 
-The article uses a bounded structured-block contract rather than arbitrary HTML
-or a general-purpose document format. The first version contains:
+The article uses a bounded Tiptap/ProseMirror JSON contract rather than
+arbitrary HTML. The editor schema and the independent server validator admit
+only the explicitly supported node and mark set. The first version contains:
 
 ```text
 CreatorArticleV1
@@ -99,10 +125,11 @@ CreatorArticleV1
   updatedAt
 ```
 
-Supported blocks are `heading`, `paragraph`, `list`, `image`, and `link-card`.
-Paragraph and list text use a small mark model for emphasis and HTTPS links.
-Raw HTML, script, iframe, embedded widgets, arbitrary CSS, data URLs, and
-javascript URLs are forbidden.
+Supported nodes are `doc`, `heading`, `paragraph`, `bulletList`, `orderedList`,
+`listItem`, `text`, `hardBreak`, and a bounded article image. Supported marks
+are `bold`, `italic`, and `link`. Links must be HTTPS. Raw HTML, script, iframe,
+embedded widgets, arbitrary CSS, data URLs, and javascript URLs are forbidden.
+The public renderer never uses `dangerouslySetInnerHTML`.
 
 Content limits are enforced in both the client and server contracts. The
 server canonicalizes the accepted document before hashing and persistence.
@@ -111,16 +138,21 @@ editor tabs cannot silently overwrite one another.
 
 ## Persistence and media
 
-Creator articles use dedicated website tables and a dedicated current-article
-read view. Existing token-project metadata and Custom launch presentation rows
-are not repurposed or mutated.
+Creator articles use a dedicated namespace in the existing Programmable Vercel
+Blob store. Existing database tables, token-project metadata, and Custom launch
+presentation rows are not repurposed or mutated. This feature introduces no
+database migration, new database role, or new storage provider.
 
-The database keeps immutable article revisions plus a single current pointer.
-The current public view returns only the latest valid published revision. All
-writes are audited with article identity, creator wallet, previous revision,
-new revision, and a content commitment; no private session material is stored.
+Every published article is written as an immutable canonical revision blob.
+A small current-pointer blob selects the visible revision. Pointer updates use
+the Blob ETag as an `ifMatch` precondition, giving the editor real optimistic
+concurrency: a stale editor cannot overwrite a newer current pointer. The
+current public read resolves and validates only the selected immutable
+revision. Revision payloads include article identity, creator wallet, previous
+revision, new revision, and a content commitment; no private session material
+is stored.
 
-Article media uses the existing Programmable Vercel Blob account through a new
+Article media uses the same existing Programmable Vercel Blob account through a new
 article-media upload boundary. The server authenticates creator authority
 before writing, verifies decoded image bytes, strips metadata, produces a
 bounded web-safe image, performs readback verification, and stores only the

--- a/docs/superpowers/specs/2026-08-21-creator-article-design.md
+++ b/docs/superpowers/specs/2026-08-21-creator-article-design.md
@@ -1,6 +1,6 @@
 # Creator Article Design
 
-Date: 2026-08-21  
+Date: 2026-08-21
 Status: Owner-approved design; implementation in progress
 
 ## Product decision

--- a/lib/creator-article/contract-v1.ts
+++ b/lib/creator-article/contract-v1.ts
@@ -1,6 +1,10 @@
 import { getAddress, isAddress } from "viem";
 
 import { normalizeHttpsLinkV1 } from "./link";
+import {
+  assertCreatorArticleMediaBindingV1,
+  type CreatorArticleMediaKindV1,
+} from "./media";
 
 export const CREATOR_ARTICLE_SCHEMA_V1 =
   "programmable.creator-article.v1" as const;
@@ -137,7 +141,11 @@ function parsePositiveInteger(value: unknown, label: string, maximum: number) {
   return Number(value);
 }
 
-function parseImage(value: unknown): CreatorArticleImageV1 {
+function parseImage(
+  value: unknown,
+  tokenAddress: `0x${string}`,
+  kind: CreatorArticleMediaKindV1,
+): CreatorArticleImageV1 {
   if (!isRecord(value)) throw new TypeError("Article image is invalid");
   exactKeys(value, ["url", "alt", "caption", "width", "height", "size"]);
   const size = value.size;
@@ -149,14 +157,18 @@ function parseImage(value: unknown): CreatorArticleImageV1 {
     : boundedString(value.caption, "Article image caption", 1_000, {
         allowEmpty: true,
       });
+  const url = normalizeHttpsLinkV1(boundedString(value.url, "Article image URL", 2_048));
+  const width = parsePositiveInteger(value.width, "Article image width", 6_000);
+  const height = parsePositiveInteger(value.height, "Article image height", 6_000);
+  assertCreatorArticleMediaBindingV1({ url, tokenAddress, kind, width, height });
   return Object.freeze({
-    url: normalizeHttpsLinkV1(boundedString(value.url, "Article image URL", 2_048)),
+    url,
     alt: boundedString(value.alt, "Article image alt text", 480, {
       singleLine: true,
     }).trim(),
     caption: caption?.trim() || null,
-    width: parsePositiveInteger(value.width, "Article image width", 6_000),
-    height: parsePositiveInteger(value.height, "Article image height", 6_000),
+    width,
+    height,
     size,
   });
 }
@@ -212,7 +224,8 @@ function parseInline(value: unknown, budget: ParseBudget): CreatorArticleInlineV
   }
   if (value.type !== "text") throw new TypeError("Article inline node is not supported");
   exactKeys(value, ["type", "text"], ["marks"]);
-  const text = boundedString(value.text, "Article text", 20_000, { allowEmpty: false });
+  const text = boundedString(value.text, "Article text", 20_000, { allowEmpty: true });
+  if (text.length === 0) throw new TypeError("Article text is invalid");
   addBudget(budget, text);
   const marks = parseMarks(value.marks);
   return Object.freeze({
@@ -248,7 +261,11 @@ function parseParagraph(
   return Object.freeze({ type: "paragraph", ...(content ? { content } : {}) });
 }
 
-function parseBlock(value: unknown, budget: ParseBudget): CreatorArticleBlockV1 {
+function parseBlock(
+  value: unknown,
+  budget: ParseBudget,
+  tokenAddress: `0x${string}`,
+): CreatorArticleBlockV1 {
   if (!isRecord(value) || typeof value.type !== "string") {
     throw new TypeError("Article block is invalid");
   }
@@ -256,7 +273,10 @@ function parseBlock(value: unknown, budget: ParseBudget): CreatorArticleBlockV1 
   if (value.type === "articleImage") {
     exactKeys(value, ["type", "attrs"]);
     addBudget(budget);
-    return Object.freeze({ type: "articleImage", attrs: parseImage(value.attrs) });
+    return Object.freeze({
+      type: "articleImage",
+      attrs: parseImage(value.attrs, tokenAddress, "inline"),
+    });
   }
   if (value.type === "heading") {
     exactKeys(value, ["type", "attrs", "content"]);
@@ -296,7 +316,10 @@ function parseBlock(value: unknown, budget: ParseBudget): CreatorArticleBlockV1 
   throw new TypeError("Article block is not supported");
 }
 
-function parseDocument(value: unknown): CreatorArticleDocumentV1 {
+function parseDocument(
+  value: unknown,
+  tokenAddress: `0x${string}`,
+): CreatorArticleDocumentV1 {
   if (!isRecord(value) || value.type !== "doc") {
     throw new TypeError("Article document is invalid");
   }
@@ -307,7 +330,8 @@ function parseDocument(value: unknown): CreatorArticleDocumentV1 {
   const budget = { nodes: 1, textBytes: 0 };
   return Object.freeze({
     type: "doc",
-    content: Object.freeze(value.content.map((node) => parseBlock(node, budget))),
+    content: Object.freeze(value.content.map((node) =>
+      parseBlock(node, budget, tokenAddress))),
   });
 }
 
@@ -331,8 +355,10 @@ export function parseCreatorArticleDraftV1(value: unknown): CreatorArticleDraftV
     schemaVersion: CREATOR_ARTICLE_DRAFT_SCHEMA_V1,
     ...identity,
     title: boundedString(value.title, "Article title", 240, { singleLine: true }).trim(),
-    bannerImage: value.bannerImage === null ? null : parseImage(value.bannerImage),
-    document: parseDocument(value.document),
+    bannerImage: value.bannerImage === null
+      ? null
+      : parseImage(value.bannerImage, identity.tokenAddress, "banner"),
+    document: parseDocument(value.document, identity.tokenAddress),
   });
 }
 
@@ -365,8 +391,10 @@ export function parseCreatorArticleV1(value: unknown): CreatorArticleV1 {
     revision,
     status: "published",
     title: boundedString(value.title, "Article title", 240, { singleLine: true }).trim(),
-    bannerImage: value.bannerImage === null ? null : parseImage(value.bannerImage),
-    document: parseDocument(value.document),
+    bannerImage: value.bannerImage === null
+      ? null
+      : parseImage(value.bannerImage, identity.tokenAddress, "banner"),
+    document: parseDocument(value.document, identity.tokenAddress),
     createdAt,
     updatedAt,
   });

--- a/lib/creator-article/contract-v1.ts
+++ b/lib/creator-article/contract-v1.ts
@@ -1,0 +1,397 @@
+import { getAddress, isAddress } from "viem";
+
+import { normalizeHttpsLinkV1 } from "./link";
+
+export const CREATOR_ARTICLE_SCHEMA_V1 =
+  "programmable.creator-article.v1" as const;
+export const CREATOR_ARTICLE_DRAFT_SCHEMA_V1 =
+  "programmable.creator-article-draft.v1" as const;
+
+export type CreatorArticleImageSizeV1 = "compact" | "content" | "wide";
+
+export type CreatorArticleImageV1 = Readonly<{
+  url: string;
+  alt: string;
+  caption: string | null;
+  width: number;
+  height: number;
+  size: CreatorArticleImageSizeV1;
+}>;
+
+export type CreatorArticleMarkV1 =
+  | Readonly<{ type: "bold" }>
+  | Readonly<{ type: "italic" }>
+  | Readonly<{ type: "link"; attrs: Readonly<{ href: string }> }>;
+
+export type CreatorArticleInlineV1 =
+  | Readonly<{
+      type: "text";
+      text: string;
+      marks?: readonly CreatorArticleMarkV1[];
+    }>
+  | Readonly<{ type: "hardBreak" }>;
+
+export type CreatorArticleParagraphV1 = Readonly<{
+  type: "paragraph";
+  content?: readonly CreatorArticleInlineV1[];
+}>;
+
+export type CreatorArticleHeadingV1 = Readonly<{
+  type: "heading";
+  attrs: Readonly<{ level: 2 | 3 }>;
+  content: readonly CreatorArticleInlineV1[];
+}>;
+
+export type CreatorArticleListItemV1 = Readonly<{
+  type: "listItem";
+  content: readonly CreatorArticleParagraphV1[];
+}>;
+
+export type CreatorArticleListV1 = Readonly<{
+  type: "bulletList" | "orderedList";
+  content: readonly CreatorArticleListItemV1[];
+}>;
+
+export type CreatorArticleImageNodeV1 = Readonly<{
+  type: "articleImage";
+  attrs: CreatorArticleImageV1;
+}>;
+
+export type CreatorArticleBlockV1 =
+  | CreatorArticleParagraphV1
+  | CreatorArticleHeadingV1
+  | CreatorArticleListV1
+  | CreatorArticleImageNodeV1;
+
+export type CreatorArticleDocumentV1 = Readonly<{
+  type: "doc";
+  content: readonly CreatorArticleBlockV1[];
+}>;
+
+export type CreatorArticleDraftV1 = Readonly<{
+  schemaVersion: typeof CREATOR_ARTICLE_DRAFT_SCHEMA_V1;
+  chainId: 1;
+  tokenAddress: `0x${string}`;
+  title: string;
+  bannerImage: CreatorArticleImageV1 | null;
+  document: CreatorArticleDocumentV1;
+}>;
+
+export type CreatorArticleV1 = Readonly<{
+  schemaVersion: typeof CREATOR_ARTICLE_SCHEMA_V1;
+  chainId: 1;
+  tokenAddress: `0x${string}`;
+  revision: number;
+  status: "published";
+  title: string;
+  bannerImage: CreatorArticleImageV1 | null;
+  document: CreatorArticleDocumentV1;
+  createdAt: string;
+  updatedAt: string;
+}>;
+
+const MAX_BLOCKS = 160;
+const MAX_NODES = 500;
+const MAX_TEXT_BYTES = 80_000;
+
+type ParseBudget = { nodes: number; textBytes: number };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[] = [],
+) {
+  const present = Object.keys(value);
+  const allowed = new Set([...required, ...optional]);
+  if (
+    required.some((key) => !Object.prototype.hasOwnProperty.call(value, key))
+    || present.some((key) => !allowed.has(key))
+  ) throw new TypeError("Creator article shape is invalid");
+}
+
+function boundedString(
+  value: unknown,
+  label: string,
+  maximumBytes: number,
+  options: Readonly<{ allowEmpty?: boolean; singleLine?: boolean }> = {},
+) {
+  if (typeof value !== "string") throw new TypeError(`${label} is invalid`);
+  const normalized = value.normalize("NFC");
+  if (
+    (!options.allowEmpty && normalized.trim() === "")
+    || Buffer.byteLength(normalized, "utf8") > maximumBytes
+    || /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/u.test(normalized)
+    || (options.singleLine && /[\r\n]/u.test(normalized))
+  ) throw new TypeError(`${label} is invalid`);
+  return normalized;
+}
+
+function parsePositiveInteger(value: unknown, label: string, maximum: number) {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0 || Number(value) > maximum) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return Number(value);
+}
+
+function parseImage(value: unknown): CreatorArticleImageV1 {
+  if (!isRecord(value)) throw new TypeError("Article image is invalid");
+  exactKeys(value, ["url", "alt", "caption", "width", "height", "size"]);
+  const size = value.size;
+  if (size !== "compact" && size !== "content" && size !== "wide") {
+    throw new TypeError("Article image size is invalid");
+  }
+  const caption = value.caption === null
+    ? null
+    : boundedString(value.caption, "Article image caption", 1_000, {
+        allowEmpty: true,
+      });
+  return Object.freeze({
+    url: normalizeHttpsLinkV1(boundedString(value.url, "Article image URL", 2_048)),
+    alt: boundedString(value.alt, "Article image alt text", 480, {
+      singleLine: true,
+    }).trim(),
+    caption: caption?.trim() || null,
+    width: parsePositiveInteger(value.width, "Article image width", 6_000),
+    height: parsePositiveInteger(value.height, "Article image height", 6_000),
+    size,
+  });
+}
+
+function addBudget(budget: ParseBudget, text = "") {
+  budget.nodes += 1;
+  budget.textBytes += Buffer.byteLength(text, "utf8");
+  if (budget.nodes > MAX_NODES || budget.textBytes > MAX_TEXT_BYTES) {
+    throw new TypeError("Creator article is too large");
+  }
+}
+
+function parseMarks(value: unknown): readonly CreatorArticleMarkV1[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length === 0 || value.length > 3) {
+    throw new TypeError("Article text marks are invalid");
+  }
+  const seen = new Set<string>();
+  const marks = value.map((candidate): CreatorArticleMarkV1 => {
+    if (!isRecord(candidate) || typeof candidate.type !== "string") {
+      throw new TypeError("Article text mark is invalid");
+    }
+    if (seen.has(candidate.type)) throw new TypeError("Article text mark is duplicated");
+    seen.add(candidate.type);
+    if (candidate.type === "bold" || candidate.type === "italic") {
+      exactKeys(candidate, ["type"]);
+      return Object.freeze({ type: candidate.type });
+    }
+    if (candidate.type === "link") {
+      exactKeys(candidate, ["type", "attrs"]);
+      if (!isRecord(candidate.attrs)) throw new TypeError("Article link is invalid");
+      exactKeys(candidate.attrs, ["href"]);
+      return Object.freeze({
+        type: "link",
+        attrs: Object.freeze({
+          href: normalizeHttpsLinkV1(String(candidate.attrs.href)),
+        }),
+      });
+    }
+    throw new TypeError("Article text mark is not supported");
+  });
+  return Object.freeze(marks);
+}
+
+function parseInline(value: unknown, budget: ParseBudget): CreatorArticleInlineV1 {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    throw new TypeError("Article inline node is invalid");
+  }
+  if (value.type === "hardBreak") {
+    exactKeys(value, ["type"]);
+    addBudget(budget);
+    return Object.freeze({ type: "hardBreak" });
+  }
+  if (value.type !== "text") throw new TypeError("Article inline node is not supported");
+  exactKeys(value, ["type", "text"], ["marks"]);
+  const text = boundedString(value.text, "Article text", 20_000, { allowEmpty: false });
+  addBudget(budget, text);
+  const marks = parseMarks(value.marks);
+  return Object.freeze({
+    type: "text",
+    text,
+    ...(marks ? { marks } : {}),
+  });
+}
+
+function parseInlineContent(
+  value: unknown,
+  budget: ParseBudget,
+  allowEmpty: boolean,
+) {
+  if (!Array.isArray(value) || (!allowEmpty && value.length === 0) || value.length > 300) {
+    throw new TypeError("Article inline content is invalid");
+  }
+  return Object.freeze(value.map((candidate) => parseInline(candidate, budget)));
+}
+
+function parseParagraph(
+  value: unknown,
+  budget: ParseBudget,
+): CreatorArticleParagraphV1 {
+  if (!isRecord(value) || value.type !== "paragraph") {
+    throw new TypeError("Article paragraph is invalid");
+  }
+  exactKeys(value, ["type"], ["content"]);
+  addBudget(budget);
+  const content = value.content === undefined
+    ? undefined
+    : parseInlineContent(value.content, budget, true);
+  return Object.freeze({ type: "paragraph", ...(content ? { content } : {}) });
+}
+
+function parseBlock(value: unknown, budget: ParseBudget): CreatorArticleBlockV1 {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    throw new TypeError("Article block is invalid");
+  }
+  if (value.type === "paragraph") return parseParagraph(value, budget);
+  if (value.type === "articleImage") {
+    exactKeys(value, ["type", "attrs"]);
+    addBudget(budget);
+    return Object.freeze({ type: "articleImage", attrs: parseImage(value.attrs) });
+  }
+  if (value.type === "heading") {
+    exactKeys(value, ["type", "attrs", "content"]);
+    if (!isRecord(value.attrs)) throw new TypeError("Article heading is invalid");
+    exactKeys(value.attrs, ["level"]);
+    const level = value.attrs.level;
+    if (level !== 2 && level !== 3) throw new TypeError("Article heading level is invalid");
+    addBudget(budget);
+    return Object.freeze({
+      type: "heading",
+      attrs: Object.freeze({ level }),
+      content: parseInlineContent(value.content, budget, false),
+    });
+  }
+  if (value.type === "bulletList" || value.type === "orderedList") {
+    exactKeys(value, ["type", "content"]);
+    if (!Array.isArray(value.content) || value.content.length === 0 || value.content.length > 80) {
+      throw new TypeError("Article list is invalid");
+    }
+    addBudget(budget);
+    const content = value.content.map((item): CreatorArticleListItemV1 => {
+      if (!isRecord(item) || item.type !== "listItem") {
+        throw new TypeError("Article list item is invalid");
+      }
+      exactKeys(item, ["type", "content"]);
+      if (!Array.isArray(item.content) || item.content.length === 0 || item.content.length > 8) {
+        throw new TypeError("Article list item is invalid");
+      }
+      addBudget(budget);
+      return Object.freeze({
+        type: "listItem",
+        content: Object.freeze(item.content.map((node) => parseParagraph(node, budget))),
+      });
+    });
+    return Object.freeze({ type: value.type, content: Object.freeze(content) });
+  }
+  throw new TypeError("Article block is not supported");
+}
+
+function parseDocument(value: unknown): CreatorArticleDocumentV1 {
+  if (!isRecord(value) || value.type !== "doc") {
+    throw new TypeError("Article document is invalid");
+  }
+  exactKeys(value, ["type", "content"]);
+  if (!Array.isArray(value.content) || value.content.length === 0 || value.content.length > MAX_BLOCKS) {
+    throw new TypeError("Article document is invalid");
+  }
+  const budget = { nodes: 1, textBytes: 0 };
+  return Object.freeze({
+    type: "doc",
+    content: Object.freeze(value.content.map((node) => parseBlock(node, budget))),
+  });
+}
+
+function parseIdentity(value: Record<string, unknown>) {
+  if (value.chainId !== 1 || typeof value.tokenAddress !== "string" || !isAddress(value.tokenAddress)) {
+    throw new TypeError("Creator article identity is invalid");
+  }
+  return { chainId: 1 as const, tokenAddress: getAddress(value.tokenAddress) };
+}
+
+export function parseCreatorArticleDraftV1(value: unknown): CreatorArticleDraftV1 {
+  if (!isRecord(value)) throw new TypeError("Creator article draft is invalid");
+  exactKeys(value, [
+    "schemaVersion", "chainId", "tokenAddress", "title", "bannerImage", "document",
+  ]);
+  if (value.schemaVersion !== CREATOR_ARTICLE_DRAFT_SCHEMA_V1) {
+    throw new TypeError("Creator article draft version is invalid");
+  }
+  const identity = parseIdentity(value);
+  return Object.freeze({
+    schemaVersion: CREATOR_ARTICLE_DRAFT_SCHEMA_V1,
+    ...identity,
+    title: boundedString(value.title, "Article title", 240, { singleLine: true }).trim(),
+    bannerImage: value.bannerImage === null ? null : parseImage(value.bannerImage),
+    document: parseDocument(value.document),
+  });
+}
+
+function isoTimestamp(value: unknown, label: string) {
+  if (typeof value !== "string") throw new TypeError(`${label} is invalid`);
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.valueOf()) || parsed.toISOString() !== value) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+export function parseCreatorArticleV1(value: unknown): CreatorArticleV1 {
+  if (!isRecord(value)) throw new TypeError("Creator article is invalid");
+  exactKeys(value, [
+    "schemaVersion", "chainId", "tokenAddress", "revision", "status", "title",
+    "bannerImage", "document", "createdAt", "updatedAt",
+  ]);
+  if (value.schemaVersion !== CREATOR_ARTICLE_SCHEMA_V1 || value.status !== "published") {
+    throw new TypeError("Creator article version is invalid");
+  }
+  const identity = parseIdentity(value);
+  const revision = parsePositiveInteger(value.revision, "Article revision", Number.MAX_SAFE_INTEGER);
+  const createdAt = isoTimestamp(value.createdAt, "Article creation time");
+  const updatedAt = isoTimestamp(value.updatedAt, "Article update time");
+  if (updatedAt < createdAt) throw new TypeError("Article timestamps are invalid");
+  return Object.freeze({
+    schemaVersion: CREATOR_ARTICLE_SCHEMA_V1,
+    ...identity,
+    revision,
+    status: "published",
+    title: boundedString(value.title, "Article title", 240, { singleLine: true }).trim(),
+    bannerImage: value.bannerImage === null ? null : parseImage(value.bannerImage),
+    document: parseDocument(value.document),
+    createdAt,
+    updatedAt,
+  });
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("Canonical value is invalid");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value).sort().map((key) =>
+      `${JSON.stringify(key)}:${canonicalize(value[key])}`).join(",")}}`;
+  }
+  throw new TypeError("Canonical value is invalid");
+}
+
+export function canonicalCreatorArticleDraftV1(value: CreatorArticleDraftV1): string {
+  return canonicalize(parseCreatorArticleDraftV1(value));
+}
+
+export function canonicalCreatorArticleV1(value: CreatorArticleV1): string {
+  return canonicalize(parseCreatorArticleV1(value));
+}

--- a/lib/creator-article/link.ts
+++ b/lib/creator-article/link.ts
@@ -1,0 +1,36 @@
+const MAX_LINK_BYTES = 2_048;
+
+export function normalizeHttpsLinkV1(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || Buffer.byteLength(trimmed, "utf8") > MAX_LINK_BYTES) {
+    throw new TypeError("Article link is invalid");
+  }
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new TypeError("Article link is invalid");
+  }
+  if (
+    url.protocol !== "https:"
+    || url.username !== ""
+    || url.password !== ""
+    || !url.hostname
+  ) throw new TypeError("Article link must use HTTPS");
+  url.hash = "";
+  return url.toString();
+}
+
+export function displayHttpsLinkV1(value: string): string {
+  const url = new URL(normalizeHttpsLinkV1(value));
+  return url.hostname.replace(/^www\./iu, "");
+}
+
+export function isAllowedArticleHrefV1(value: string): boolean {
+  try {
+    normalizeHttpsLinkV1(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/lib/creator-article/media.ts
+++ b/lib/creator-article/media.ts
@@ -1,0 +1,91 @@
+import { getAddress, isAddress } from "viem";
+
+import { PROGRAMMABLE_TOKEN_IMAGE_HOST } from "../token-image";
+
+export type CreatorArticleMediaKindV1 = "banner" | "inline";
+
+type CreatorArticleMediaBindingV1 = Readonly<{
+  kind: CreatorArticleMediaKindV1;
+  width: number;
+  height: number;
+}>;
+
+const MAIN_TOKEN = "0x7987f03462200b3d8a072e02c89a8a41dcb124ee";
+const MEDIA_PREFIX = "/creator-article-media/v1/eip155-1/";
+const MEDIA_FILENAME = /^(?<id>[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.(?<kind>banner|inline)\.(?<width>[1-9][0-9]{0,3})x(?<height>[1-9][0-9]{0,3})\.(?<digest>[0-9a-f]{64})\.webp$/u;
+
+const OFFICIAL_MAIN_MEDIA = new Map<string, CreatorArticleMediaBindingV1>([
+  [
+    "/brand/programmable-final-x-banner-1500x500.png",
+    Object.freeze({ kind: "banner", width: 1500, height: 500 }),
+  ],
+  [
+    "/brand/programmable-adaptive-model-post-v1-2000x1000.png",
+    Object.freeze({ kind: "inline", width: 2000, height: 1000 }),
+  ],
+]);
+
+export function creatorArticleMediaPathnameV1(input: Readonly<{
+  tokenAddress: string;
+  mediaId: string;
+  kind: CreatorArticleMediaKindV1;
+  width: number;
+  height: number;
+  contentSha256: `sha256:${string}`;
+}>) {
+  if (!isAddress(input.tokenAddress)
+    || !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u.test(input.mediaId)
+    || !Number.isSafeInteger(input.width) || input.width <= 0 || input.width > 6_000
+    || !Number.isSafeInteger(input.height) || input.height <= 0 || input.height > 6_000
+    || !/^sha256:[0-9a-f]{64}$/u.test(input.contentSha256)) {
+    throw new TypeError("Creator article media binding is invalid");
+  }
+  return `creator-article-media/v1/eip155-1/${getAddress(input.tokenAddress).toLowerCase()}/${input.mediaId}.${input.kind}.${input.width}x${input.height}.${input.contentSha256.slice("sha256:".length)}.webp`;
+}
+
+export function assertCreatorArticleMediaBindingV1(input: Readonly<{
+  url: string;
+  tokenAddress: string;
+  kind: CreatorArticleMediaKindV1;
+  width: number;
+  height: number;
+}>) {
+  if (!isAddress(input.tokenAddress)) {
+    throw new TypeError("Article image identity is invalid");
+  }
+  let url: URL;
+  try {
+    url = new URL(input.url);
+  } catch {
+    throw new TypeError("Article image URL is invalid");
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.port
+    || url.search || url.hash) {
+    throw new TypeError("Article image URL is invalid");
+  }
+
+  const tokenAddress = getAddress(input.tokenAddress).toLowerCase();
+  if (tokenAddress === MAIN_TOKEN && url.hostname === "programmable.market") {
+    const official = OFFICIAL_MAIN_MEDIA.get(url.pathname);
+    if (official?.kind === input.kind
+      && official.width === input.width
+      && official.height === input.height) return;
+    throw new TypeError("Article image is not an owned Main-token asset");
+  }
+
+  if (url.hostname !== PROGRAMMABLE_TOKEN_IMAGE_HOST) {
+    throw new TypeError("Article image must use verified Programmable media");
+  }
+  const prefix = `${MEDIA_PREFIX}${tokenAddress}/`;
+  if (!url.pathname.startsWith(prefix)) {
+    throw new TypeError("Article image token binding is invalid");
+  }
+  const filename = url.pathname.slice(prefix.length);
+  const match = MEDIA_FILENAME.exec(filename);
+  if (!match?.groups
+    || match.groups.kind !== input.kind
+    || Number(match.groups.width) !== input.width
+    || Number(match.groups.height) !== input.height) {
+    throw new TypeError("Article image media binding is invalid");
+  }
+}

--- a/lib/creator-article/programmable-example-v1.ts
+++ b/lib/creator-article/programmable-example-v1.ts
@@ -1,0 +1,17 @@
+import example from "../../config/creator-article-programmable-example.v1.json";
+
+import {
+  parseCreatorArticleDraftV1,
+  type CreatorArticleDraftV1,
+} from "./contract-v1";
+
+export const PROGRAMMABLE_MAIN_TOKEN_ADDRESS =
+  "0x7987f03462200b3D8A072E02C89A8A41dCB124EE" as const;
+
+export function programmableCreatorArticleExampleV1(): CreatorArticleDraftV1 {
+  const parsed = parseCreatorArticleDraftV1(example);
+  if (parsed.tokenAddress !== PROGRAMMABLE_MAIN_TOKEN_ADDRESS) {
+    throw new TypeError("Programmable example identity is invalid");
+  }
+  return parsed;
+}

--- a/lib/server/creator-article/api.server.ts
+++ b/lib/server/creator-article/api.server.ts
@@ -1,0 +1,194 @@
+import "server-only";
+
+import { isAddress } from "viem";
+
+import { parseCreatorArticleDraftV1 } from "../../creator-article/contract-v1";
+import {
+  CreatorArticleAuthorityErrorV1,
+  createProductionCreatorArticleAuthorityReaderV1,
+  listCreatorArticleAuthoritiesV1,
+  requireCreatorArticleAuthorityV1,
+  type CreatorArticleAuthorityReaderV1,
+} from "./authority.server";
+import {
+  CreatorArticleRevisionConflictV1,
+  createProductionCreatorArticleStoreV1,
+  type CreatorArticleStoreV1,
+} from "./storage.server";
+import {
+  createPrivyWalletPrincipalAuthenticatorV1,
+  WalletPrincipalAuthenticationErrorV1,
+  type WalletPrincipalAuthenticatorV1,
+} from "./wallet-principal.server";
+
+const MAXIMUM_DRAFT_BYTES = 192_000;
+const headers = {
+  "Cache-Control": "no-store",
+  "Content-Type": "application/json; charset=utf-8",
+  "X-Content-Type-Options": "nosniff",
+  Vary: "Authorization, X-Privy-Identity-Token",
+};
+
+export interface CreatorArticleApiHandlersV1 {
+  listProjects(request: Request): Promise<Response>;
+  article(request: Request, tokenAddress: string): Promise<Response>;
+}
+
+export function createCreatorArticleApiHandlersV1(input: Readonly<{
+  authenticator: WalletPrincipalAuthenticatorV1;
+  authorityReader: CreatorArticleAuthorityReaderV1;
+  store: CreatorArticleStoreV1;
+}>): CreatorArticleApiHandlersV1 {
+  return Object.freeze({
+    async listProjects(request: Request) {
+      if (request.method !== "GET") return errorResponse(405, "method_not_allowed", "GET");
+      if (request.headers.get("accept")?.toLowerCase() !== "application/json") {
+        return errorResponse(406, "json_response_required");
+      }
+      try {
+        const principal = await input.authenticator.authenticate(request);
+        const projects = await listCreatorArticleAuthoritiesV1({
+          reader: input.authorityReader,
+          principal,
+          signal: request.signal,
+        });
+        const rows = await Promise.all(projects.map(async (project) => {
+          let article = null;
+          try {
+            article = await input.store.readCurrent(project);
+          } catch {
+            article = null;
+          }
+          return Object.freeze({
+            chainId: project.chainId,
+            tokenAddress: project.tokenAddress,
+            name: project.name,
+            symbol: project.symbol,
+            imageUrl: project.imageUrl,
+            source: project.source,
+            article: article === null
+              ? null
+              : Object.freeze({
+                  revision: article.article.revision,
+                  title: article.article.title,
+                  updatedAt: article.article.updatedAt,
+                }),
+          });
+        }));
+        return jsonResponse(200, {
+          schemaVersion: "programmable.creator-project-list.v1",
+          projects: rows,
+        });
+      } catch (error) {
+        return mappedError(error);
+      }
+    },
+    async article(request: Request, tokenAddress: string) {
+      if (!isAddress(tokenAddress)) return errorResponse(400, "invalid_token");
+      if (request.method !== "GET" && request.method !== "PUT") {
+        return errorResponse(405, "method_not_allowed", "GET, PUT");
+      }
+      try {
+        const principal = await input.authenticator.authenticate(request);
+        const authority = await requireCreatorArticleAuthorityV1({
+          reader: input.authorityReader,
+          principal,
+          tokenAddress,
+          signal: request.signal,
+        });
+        if (request.method === "GET") {
+          if (request.headers.get("accept")?.toLowerCase() !== "application/json") {
+            return errorResponse(406, "json_response_required");
+          }
+          const current = await input.store.readCurrent(authority);
+          return jsonResponse(200, {
+            schemaVersion: "programmable.creator-article-edit.v1",
+            article: current?.article ?? null,
+          }, undefined, current?.etag);
+        }
+        if (!request.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
+          return errorResponse(415, "json_body_required");
+        }
+        const contentLength = Number(request.headers.get("content-length") ?? "0");
+        if (Number.isFinite(contentLength) && contentLength > MAXIMUM_DRAFT_BYTES) {
+          return errorResponse(413, "article_too_large");
+        }
+        const ifMatch = request.headers.get("if-match");
+        const ifNoneMatch = request.headers.get("if-none-match");
+        if ((ifMatch === null) === (ifNoneMatch !== "*")) {
+          return errorResponse(428, "article_precondition_required");
+        }
+        const bodyText = await request.text();
+        if (!bodyText || Buffer.byteLength(bodyText, "utf8") > MAXIMUM_DRAFT_BYTES) {
+          return errorResponse(413, "article_too_large");
+        }
+        let draft;
+        try {
+          draft = parseCreatorArticleDraftV1(JSON.parse(bodyText) as unknown);
+        } catch {
+          return errorResponse(400, "invalid_article");
+        }
+        if (draft.tokenAddress.toLowerCase() !== authority.tokenAddress.toLowerCase()) {
+          return errorResponse(400, "article_identity_mismatch");
+        }
+        const published = await input.store.publish({
+          draft,
+          creatorAddress: authority.creatorAddress,
+          expectedEtag: ifMatch,
+        });
+        return jsonResponse(200, {
+          schemaVersion: "programmable.creator-article-edit.v1",
+          article: published.article,
+        }, undefined, published.etag);
+      } catch (error) {
+        return mappedError(error);
+      }
+    },
+  });
+}
+
+let productionHandlers: CreatorArticleApiHandlersV1 | null = null;
+
+export function getProductionCreatorArticleApiHandlersV1() {
+  productionHandlers ??= createCreatorArticleApiHandlersV1({
+    authenticator: createPrivyWalletPrincipalAuthenticatorV1(),
+    authorityReader: createProductionCreatorArticleAuthorityReaderV1(),
+    store: createProductionCreatorArticleStoreV1(),
+  });
+  return productionHandlers;
+}
+
+function mappedError(error: unknown): Response {
+  if (error instanceof WalletPrincipalAuthenticationErrorV1) {
+    return errorResponse(error.status, error.code);
+  }
+  if (error instanceof CreatorArticleAuthorityErrorV1) {
+    return errorResponse(error.status, error.code);
+  }
+  if (error instanceof CreatorArticleRevisionConflictV1) {
+    return errorResponse(412, "article_revision_conflict");
+  }
+  console.error("Creator article request failed", {
+    name: error instanceof Error ? error.name : "CreatorArticleError",
+  });
+  return errorResponse(503, "creator_article_unavailable");
+}
+
+function jsonResponse(
+  status: number,
+  body: Readonly<Record<string, unknown>>,
+  allow?: string,
+  etag?: string,
+) {
+  const responseHeaders = new Headers(headers);
+  if (allow) responseHeaders.set("Allow", allow);
+  if (etag) responseHeaders.set("ETag", etag);
+  return new Response(JSON.stringify(body), { status, headers: responseHeaders });
+}
+
+function errorResponse(status: number, code: string, allow?: string) {
+  return jsonResponse(status, {
+    schemaVersion: "programmable.creator-article-error.v1",
+    code,
+  }, allow);
+}

--- a/lib/server/creator-article/authority.server.ts
+++ b/lib/server/creator-article/authority.server.ts
@@ -1,0 +1,141 @@
+import "server-only";
+
+import { getAddress, isAddress } from "viem";
+
+import { readEnvioClassicV3CatalogV1 } from
+  "../../market-data/envio-classic-v3-catalog.server";
+import type { ExploreEntry } from "../../tokens";
+import { readProductionCustomExploreDirectoryV1 } from
+  "../custom-launch/explore-directory-v1";
+import { isCustomLaunchRegistryPublicReadEnabled } from
+  "../custom-launch/public-readiness";
+import type { AuthenticatedWalletPrincipalV1 } from "./wallet-principal.server";
+
+const MAIN_TOKEN = "0x7987f03462200b3d8a072e02c89a8a41dcb124ee";
+
+export type CreatorArticleAuthorityV1 = Readonly<{
+  chainId: 1;
+  tokenAddress: `0x${string}`;
+  creatorAddress: `0x${string}`;
+  source: "envio-classic-v3" | "registry.custom-launched" | "official-main-token";
+  name: string;
+  symbol: string | null;
+  imageUrl: string | null;
+  hasArticle?: boolean;
+}>;
+
+export interface CreatorArticleAuthorityReaderV1 {
+  read(signal: AbortSignal): Promise<readonly CreatorArticleAuthorityV1[]>;
+}
+
+export function createCreatorArticleAuthorityReaderV1(input: Readonly<{
+  readClassic(signal: AbortSignal): Promise<readonly ExploreEntry[]>;
+  readCustom(signal: AbortSignal): Promise<readonly ExploreEntry[]>;
+}>): CreatorArticleAuthorityReaderV1 {
+  return Object.freeze({
+    async read(signal: AbortSignal) {
+      const classic = await input.readClassic(signal);
+      let custom: readonly ExploreEntry[] = [];
+      try {
+        custom = await input.readCustom(signal);
+      } catch {
+        custom = [];
+      }
+      const projects: CreatorArticleAuthorityV1[] = [];
+      const seen = new Set<string>();
+      for (const entry of [...classic, ...custom]) {
+        if (!entry.tokenAddress || !isAddress(entry.tokenAddress)) continue;
+        const tokenAddress = getAddress(entry.tokenAddress);
+        let creatorAddress: `0x${string}` | null = null;
+        let source: CreatorArticleAuthorityV1["source"] | null = null;
+        if (entry.exploreKind === "token") {
+          if (!entry.creatorAddress || !isAddress(entry.creatorAddress)) continue;
+          creatorAddress = getAddress(entry.creatorAddress);
+          source = tokenAddress.toLowerCase() === MAIN_TOKEN
+            ? "official-main-token"
+            : entry.launchModel === "classic"
+                && entry.launchModelVersion === "classic-v3"
+              ? "envio-classic-v3"
+              : null;
+        } else {
+          if (
+            entry.chainId !== "1"
+            || entry.launchingWallet.namespace !== "eip155:1"
+            || !isAddress(entry.launchingWallet.value)
+          ) continue;
+          creatorAddress = getAddress(entry.launchingWallet.value);
+          source = "registry.custom-launched";
+        }
+        if (source === null) continue;
+        const key = tokenAddress.toLowerCase();
+        if (seen.has(key)) throw new TypeError("Creator article token authority is ambiguous");
+        seen.add(key);
+        projects.push(Object.freeze({
+          chainId: 1 as const,
+          tokenAddress,
+          creatorAddress,
+          source,
+          name: entry.name,
+          symbol: entry.symbol ?? null,
+          imageUrl: entry.imageUrl ?? null,
+        }));
+      }
+      return Object.freeze(projects.sort((left, right) =>
+        left.tokenAddress.toLowerCase().localeCompare(right.tokenAddress.toLowerCase())));
+    },
+  });
+}
+
+export function createProductionCreatorArticleAuthorityReaderV1():
+CreatorArticleAuthorityReaderV1 {
+  return createCreatorArticleAuthorityReaderV1({
+    async readClassic(signal) {
+      const catalog = await readEnvioClassicV3CatalogV1({
+        signal,
+        deadlineMs: Date.now() + 7_500,
+      });
+      return catalog.entries;
+    },
+    async readCustom(signal) {
+      if (!isCustomLaunchRegistryPublicReadEnabled()) return Object.freeze([]);
+      return readProductionCustomExploreDirectoryV1(signal);
+    },
+  });
+}
+
+export async function requireCreatorArticleAuthorityV1(input: Readonly<{
+  reader: CreatorArticleAuthorityReaderV1;
+  principal: AuthenticatedWalletPrincipalV1;
+  tokenAddress: string;
+  signal: AbortSignal;
+}>): Promise<CreatorArticleAuthorityV1> {
+  if (!isAddress(input.tokenAddress)) throw new CreatorArticleAuthorityErrorV1(400, "invalid_token");
+  const tokenAddress = getAddress(input.tokenAddress);
+  const project = (await input.reader.read(input.signal)).find(
+    (candidate) => candidate.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
+  );
+  if (!project) throw new CreatorArticleAuthorityErrorV1(404, "project_not_found");
+  const wallets = new Set(input.principal.wallets.map((wallet) => wallet.toLowerCase()));
+  if (!wallets.has(project.creatorAddress.toLowerCase())) {
+    throw new CreatorArticleAuthorityErrorV1(403, "creator_wallet_required");
+  }
+  return project;
+}
+
+export async function listCreatorArticleAuthoritiesV1(input: Readonly<{
+  reader: CreatorArticleAuthorityReaderV1;
+  principal: AuthenticatedWalletPrincipalV1;
+  signal: AbortSignal;
+}>) {
+  const wallets = new Set(input.principal.wallets.map((wallet) => wallet.toLowerCase()));
+  return Object.freeze((await input.reader.read(input.signal)).filter(
+    (project) => wallets.has(project.creatorAddress.toLowerCase()),
+  ));
+}
+
+export class CreatorArticleAuthorityErrorV1 extends Error {
+  constructor(readonly status: 400 | 403 | 404, readonly code: string) {
+    super(code);
+    this.name = "CreatorArticleAuthorityErrorV1";
+  }
+}

--- a/lib/server/creator-article/image.server.ts
+++ b/lib/server/creator-article/image.server.ts
@@ -1,0 +1,102 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+
+import sharp from "sharp";
+
+export const MAX_CREATOR_ARTICLE_IMAGE_INPUT_BYTES = 12 * 1024 * 1024;
+export const MAX_CREATOR_ARTICLE_IMAGE_OUTPUT_BYTES = 5 * 1024 * 1024;
+const MAX_INPUT_PIXELS = 40_000_000;
+
+export type CreatorArticleMediaKindV1 = "banner" | "inline";
+
+export type VerifiedCreatorArticleImageV1 = Readonly<{
+  bytes: Uint8Array;
+  contentSha256: `sha256:${string}`;
+  contentType: "image/webp";
+  width: number;
+  height: number;
+  kind: CreatorArticleMediaKindV1;
+}>;
+
+export async function verifyAndTransformCreatorArticleImageV1(input: Readonly<{
+  bytes: Uint8Array;
+  kind: CreatorArticleMediaKindV1;
+}>): Promise<VerifiedCreatorArticleImageV1> {
+  if (
+    input.bytes.byteLength === 0
+    || input.bytes.byteLength > MAX_CREATOR_ARTICLE_IMAGE_INPUT_BYTES
+  ) throw new TypeError("Creator article image size is invalid");
+  const pipeline = sharp(input.bytes, {
+    animated: true,
+    limitInputPixels: MAX_INPUT_PIXELS,
+    failOn: "warning",
+  });
+  const metadata = await pipeline.metadata();
+  if (
+    !metadata.width || !metadata.height
+    || (metadata.pages ?? 1) !== 1
+    || !["jpeg", "png", "webp", "avif"].includes(metadata.format ?? "")
+  ) throw new TypeError("Creator article image format is invalid");
+  const orientedWidth = metadata.autoOrient?.width ?? metadata.width;
+  const orientedHeight = metadata.autoOrient?.height ?? metadata.height;
+  const bannerWidth = Math.max(
+    3,
+    Math.min(3000, orientedWidth, Math.floor(orientedHeight * 3)),
+  );
+  const bannerHeight = Math.floor(bannerWidth / 3);
+  const transformed = input.kind === "banner"
+    ? pipeline.rotate().resize(bannerWidth, bannerHeight, {
+        fit: "cover",
+        position: "attention",
+        withoutEnlargement: true,
+      })
+    : pipeline.rotate().resize(2400, 2400, {
+        fit: "inside",
+        withoutEnlargement: true,
+      });
+  const { data, info } = await transformed
+    .webp({ quality: 84, effort: 4, smartSubsample: true })
+    .toBuffer({ resolveWithObject: true });
+  if (
+    data.byteLength === 0
+    || data.byteLength > MAX_CREATOR_ARTICLE_IMAGE_OUTPUT_BYTES
+    || info.format !== "webp"
+    || info.width <= 0 || info.height <= 0
+    || (input.kind === "banner" && info.width / info.height !== 3)
+  ) throw new TypeError("Creator article image output is invalid");
+  return Object.freeze({
+    bytes: Uint8Array.from(data),
+    contentSha256: digest(data),
+    contentType: "image/webp",
+    width: info.width,
+    height: info.height,
+    kind: input.kind,
+  });
+}
+
+export async function inspectCreatorArticleImageOutputV1(
+  bytes: Uint8Array,
+  expected: Omit<VerifiedCreatorArticleImageV1, "bytes">,
+) {
+  if (
+    bytes.byteLength === 0
+    || bytes.byteLength > MAX_CREATOR_ARTICLE_IMAGE_OUTPUT_BYTES
+    || digest(bytes) !== expected.contentSha256
+  ) throw new TypeError("Creator article image readback is invalid");
+  const metadata = await sharp(bytes, {
+    animated: true,
+    limitInputPixels: MAX_INPUT_PIXELS,
+    failOn: "warning",
+  }).metadata();
+  if (
+    metadata.format !== "webp"
+    || metadata.width !== expected.width
+    || metadata.height !== expected.height
+    || (metadata.pages ?? 1) !== 1
+  ) throw new TypeError("Creator article image readback is invalid");
+}
+
+function digest(value: Uint8Array): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}

--- a/lib/server/creator-article/media-api.server.ts
+++ b/lib/server/creator-article/media-api.server.ts
@@ -1,0 +1,181 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+
+import { put, type PutBlobResult } from "@vercel/blob";
+
+import {
+  CreatorArticleAuthorityErrorV1,
+  createProductionCreatorArticleAuthorityReaderV1,
+  requireCreatorArticleAuthorityV1,
+  type CreatorArticleAuthorityReaderV1,
+} from "./authority.server";
+import {
+  inspectCreatorArticleImageOutputV1,
+  MAX_CREATOR_ARTICLE_IMAGE_INPUT_BYTES,
+  MAX_CREATOR_ARTICLE_IMAGE_OUTPUT_BYTES,
+  verifyAndTransformCreatorArticleImageV1,
+  type CreatorArticleMediaKindV1,
+} from "./image.server";
+import {
+  createPrivyWalletPrincipalAuthenticatorV1,
+  WalletPrincipalAuthenticationErrorV1,
+  type WalletPrincipalAuthenticatorV1,
+} from "./wallet-principal.server";
+
+const READBACK_TIMEOUT_MS = 5_000;
+
+export type CreatorArticleMediaBoundaryV1 = Readonly<{
+  put(pathname: string, bytes: Uint8Array): Promise<PutBlobResult>;
+  read(url: string, signal: AbortSignal): Promise<Uint8Array>;
+}>;
+
+export function createCreatorArticleMediaUploadHandlerV1(input: Readonly<{
+  authenticator: WalletPrincipalAuthenticatorV1;
+  authorityReader: CreatorArticleAuthorityReaderV1;
+  media: CreatorArticleMediaBoundaryV1;
+}>) {
+  return async function uploadCreatorArticleMedia(
+    request: Request,
+    tokenAddress: string,
+  ): Promise<Response> {
+    if (request.method !== "POST") return errorResponse(405, "method_not_allowed", "POST");
+    const contentLength = Number(request.headers.get("content-length") ?? "0");
+    if (Number.isFinite(contentLength)
+      && contentLength > MAX_CREATOR_ARTICLE_IMAGE_INPUT_BYTES + 100_000) {
+      return errorResponse(413, "image_too_large");
+    }
+    try {
+      const principal = await input.authenticator.authenticate(request);
+      const authority = await requireCreatorArticleAuthorityV1({
+        reader: input.authorityReader,
+        principal,
+        tokenAddress,
+        signal: request.signal,
+      });
+      let form: FormData;
+      try {
+        form = await request.formData();
+      } catch {
+        return errorResponse(400, "invalid_media_request");
+      }
+      const file = form.get("file");
+      const kind = form.get("kind");
+      if (!(file instanceof File) || (kind !== "banner" && kind !== "inline")) {
+        return errorResponse(400, "invalid_media_request");
+      }
+      if (file.size === 0 || file.size > MAX_CREATOR_ARTICLE_IMAGE_INPUT_BYTES) {
+        return errorResponse(413, "image_too_large");
+      }
+      let verified;
+      try {
+        verified = await verifyAndTransformCreatorArticleImageV1({
+          bytes: new Uint8Array(await file.arrayBuffer()),
+          kind: kind as CreatorArticleMediaKindV1,
+        });
+      } catch {
+        return errorResponse(400, "invalid_image");
+      }
+      const pathname = `creator-article-media/v1/eip155-1/${authority.tokenAddress.toLowerCase()}/${randomUUID()}.webp`;
+      const blob = await input.media.put(pathname, verified.bytes);
+      if (
+        blob.pathname !== pathname
+        || blob.contentType !== "image/webp"
+        || !blob.etag
+        || new URL(blob.url).protocol !== "https:"
+      ) throw new TypeError("Creator article media write is invalid");
+      const timeout = AbortSignal.timeout(READBACK_TIMEOUT_MS);
+      const readback = await input.media.read(
+        blob.url,
+        AbortSignal.any([request.signal, timeout]),
+      );
+      await inspectCreatorArticleImageOutputV1(readback, {
+        contentSha256: verified.contentSha256,
+        contentType: verified.contentType,
+        width: verified.width,
+        height: verified.height,
+        kind: verified.kind,
+      });
+      return jsonResponse(201, {
+        schemaVersion: "programmable.creator-article-media.v1",
+        media: {
+          url: blob.url,
+          contentSha256: verified.contentSha256,
+          contentType: verified.contentType,
+          width: verified.width,
+          height: verified.height,
+          kind: verified.kind,
+        },
+      });
+    } catch (error) {
+      if (error instanceof WalletPrincipalAuthenticationErrorV1) {
+        return errorResponse(error.status, error.code);
+      }
+      if (error instanceof CreatorArticleAuthorityErrorV1) {
+        return errorResponse(error.status, error.code);
+      }
+      console.error("Creator article media upload failed", {
+        name: error instanceof Error ? error.name : "CreatorArticleMediaError",
+      });
+      return errorResponse(502, "media_upload_failed");
+    }
+  };
+}
+
+let productionHandler: ReturnType<typeof createCreatorArticleMediaUploadHandlerV1> | null = null;
+
+export function getProductionCreatorArticleMediaUploadHandlerV1() {
+  if (productionHandler !== null) return productionHandler;
+  const token = process.env.BLOB_READ_WRITE_TOKEN?.trim();
+  if (!token) throw new TypeError("BLOB_READ_WRITE_TOKEN is not configured");
+  productionHandler = createCreatorArticleMediaUploadHandlerV1({
+    authenticator: createPrivyWalletPrincipalAuthenticatorV1(),
+    authorityReader: createProductionCreatorArticleAuthorityReaderV1(),
+    media: Object.freeze({
+      async put(pathname, bytes) {
+        return put(pathname, bytes, {
+          access: "public",
+          token,
+          addRandomSuffix: false,
+          allowOverwrite: false,
+          contentType: "image/webp",
+          cacheControlMaxAge: 31_536_000,
+        });
+      },
+      async read(url, signal) {
+        const response = await fetch(url, { signal, cache: "no-store" });
+        if (!response.ok || response.headers.get("content-type")?.split(";")[0] !== "image/webp") {
+          throw new TypeError("Creator article media readback failed");
+        }
+        const length = Number(response.headers.get("content-length") ?? "0");
+        if (Number.isFinite(length) && length > MAX_CREATOR_ARTICLE_IMAGE_OUTPUT_BYTES) {
+          throw new TypeError("Creator article media readback is too large");
+        }
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        if (bytes.byteLength > MAX_CREATOR_ARTICLE_IMAGE_OUTPUT_BYTES) {
+          throw new TypeError("Creator article media readback is too large");
+        }
+        return bytes;
+      },
+    }),
+  });
+  return productionHandler;
+}
+
+function jsonResponse(status: number, body: Readonly<Record<string, unknown>>, allow?: string) {
+  const headers = new Headers({
+    "Cache-Control": "no-store",
+    "Content-Type": "application/json; charset=utf-8",
+    "X-Content-Type-Options": "nosniff",
+    Vary: "Authorization, X-Privy-Identity-Token",
+  });
+  if (allow) headers.set("Allow", allow);
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+function errorResponse(status: number, code: string, allow?: string) {
+  return jsonResponse(status, {
+    schemaVersion: "programmable.creator-article-error.v1",
+    code,
+  }, allow);
+}

--- a/lib/server/creator-article/media-api.server.ts
+++ b/lib/server/creator-article/media-api.server.ts
@@ -17,6 +17,7 @@ import {
   verifyAndTransformCreatorArticleImageV1,
   type CreatorArticleMediaKindV1,
 } from "./image.server";
+import { creatorArticleMediaPathnameV1 } from "../../creator-article/media";
 import {
   createPrivyWalletPrincipalAuthenticatorV1,
   WalletPrincipalAuthenticationErrorV1,
@@ -76,7 +77,14 @@ export function createCreatorArticleMediaUploadHandlerV1(input: Readonly<{
       } catch {
         return errorResponse(400, "invalid_image");
       }
-      const pathname = `creator-article-media/v1/eip155-1/${authority.tokenAddress.toLowerCase()}/${randomUUID()}.webp`;
+      const pathname = creatorArticleMediaPathnameV1({
+        tokenAddress: authority.tokenAddress,
+        mediaId: randomUUID(),
+        kind: verified.kind,
+        width: verified.width,
+        height: verified.height,
+        contentSha256: verified.contentSha256,
+      });
       const blob = await input.media.put(pathname, verified.bytes);
       if (
         blob.pathname !== pathname

--- a/lib/server/creator-article/public-read.server.ts
+++ b/lib/server/creator-article/public-read.server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { isAddress, getAddress } from "viem";
+
+import type { CreatorArticleV1 } from "../../creator-article/contract-v1";
+import { createProductionCreatorArticleStoreV1 } from "./storage.server";
+
+const PUBLIC_ARTICLE_READ_BUDGET_MS = 650;
+
+export async function readPublicCreatorArticleV1(
+  tokenAddress: string,
+): Promise<CreatorArticleV1 | null> {
+  if (!isAddress(tokenAddress)) return null;
+  try {
+    const read = createProductionCreatorArticleStoreV1().readCurrent({
+      chainId: 1,
+      tokenAddress: getAddress(tokenAddress),
+    });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<null>((resolve) => {
+      timer = setTimeout(() => resolve(null), PUBLIC_ARTICLE_READ_BUDGET_MS);
+    });
+    try {
+      return (await Promise.race([read, timeout]))?.article ?? null;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  } catch {
+    return null;
+  }
+}

--- a/lib/server/creator-article/storage.server.ts
+++ b/lib/server/creator-article/storage.server.ts
@@ -1,0 +1,337 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+
+import {
+  BlobPreconditionFailedError,
+  get,
+  put,
+} from "@vercel/blob";
+import { getAddress, isAddress } from "viem";
+
+import {
+  canonicalCreatorArticleV1,
+  CREATOR_ARTICLE_SCHEMA_V1,
+  parseCreatorArticleDraftV1,
+  parseCreatorArticleV1,
+  type CreatorArticleDraftV1,
+  type CreatorArticleV1,
+} from "../../creator-article/contract-v1";
+
+const POINTER_SCHEMA = "programmable.creator-article-pointer.v1" as const;
+const MAXIMUM_ARTICLE_BLOB_BYTES = 256_000;
+
+type ArticleIdentityV1 = Readonly<{
+  chainId: 1;
+  tokenAddress: `0x${string}`;
+}>;
+
+type ArticlePointerV1 = Readonly<{
+  schemaVersion: typeof POINTER_SCHEMA;
+  chainId: 1;
+  tokenAddress: `0x${string}`;
+  creatorAddress: `0x${string}`;
+  revision: number;
+  revisionPath: string;
+  contentSha256: `sha256:${string}`;
+  createdAt: string;
+  updatedAt: string;
+}>;
+
+export type CreatorArticleReadV1 = Readonly<{
+  article: CreatorArticleV1;
+  etag: string;
+  contentSha256: `sha256:${string}`;
+}>;
+
+export type PublishCreatorArticleV1 = Readonly<{
+  draft: CreatorArticleDraftV1;
+  creatorAddress: `0x${string}`;
+  expectedEtag: string | null;
+}>;
+
+export interface CreatorArticleStoreV1 {
+  readCurrent(input: ArticleIdentityV1): Promise<CreatorArticleReadV1 | null>;
+  publish(input: PublishCreatorArticleV1): Promise<CreatorArticleReadV1>;
+}
+
+export interface CreatorArticleBlobBoundaryV1 {
+  read(pathname: string): Promise<Readonly<{ text: string; etag: string }> | null>;
+  write(input: Readonly<{
+    pathname: string;
+    text: string;
+    ifMatch: string | null;
+    immutable: boolean;
+  }>): Promise<Readonly<{ pathname: string; etag: string }>>;
+}
+
+export class CreatorArticleRevisionConflictV1 extends Error {
+  constructor() {
+    super("creator_article_revision_conflict");
+    this.name = "CreatorArticleRevisionConflictV1";
+  }
+}
+
+export class CreatorArticleBlobPreconditionErrorV1 extends Error {
+  constructor() {
+    super("creator_article_blob_precondition_failed");
+    this.name = "CreatorArticleBlobPreconditionErrorV1";
+  }
+}
+
+export function createCreatorArticleStoreV1(input: Readonly<{
+  blob: CreatorArticleBlobBoundaryV1;
+  now?: () => Date;
+}>): CreatorArticleStoreV1 {
+  const now = input.now ?? (() => new Date());
+  return Object.freeze({
+    async readCurrent(identity: ArticleIdentityV1) {
+      const normalized = normalizeIdentity(identity);
+      const pointerRead = await input.blob.read(pointerPath(normalized));
+      if (pointerRead === null) return null;
+      const pointer = parsePointer(pointerRead.text, normalized);
+      const revisionRead = await input.blob.read(pointer.revisionPath);
+      if (revisionRead === null) throw new TypeError("Creator article revision is unavailable");
+      const article = parseCreatorArticleV1(parseBoundedJson(revisionRead.text));
+      if (
+        article.chainId !== normalized.chainId
+        || article.tokenAddress.toLowerCase() !== normalized.tokenAddress.toLowerCase()
+        || article.revision !== pointer.revision
+        || sha256(canonicalCreatorArticleV1(article)) !== pointer.contentSha256
+      ) throw new TypeError("Creator article pointer binding is invalid");
+      return Object.freeze({
+        article,
+        etag: pointerRead.etag,
+        contentSha256: pointer.contentSha256,
+      });
+    },
+    async publish(publishInput: PublishCreatorArticleV1) {
+      const draft = parseCreatorArticleDraftV1(publishInput.draft);
+      if (!isAddress(publishInput.creatorAddress)) {
+        throw new TypeError("Creator article creator is invalid");
+      }
+      const creatorAddress = getAddress(publishInput.creatorAddress);
+      const identity = normalizeIdentity(draft);
+      const current = await this.readCurrent(identity);
+      if (
+        (current === null && publishInput.expectedEtag !== null)
+        || (current !== null && publishInput.expectedEtag !== current.etag)
+      ) throw new CreatorArticleRevisionConflictV1();
+      const timestamp = now().toISOString();
+      const article = parseCreatorArticleV1({
+        schemaVersion: CREATOR_ARTICLE_SCHEMA_V1,
+        chainId: identity.chainId,
+        tokenAddress: identity.tokenAddress,
+        revision: (current?.article.revision ?? 0) + 1,
+        status: "published",
+        title: draft.title,
+        bannerImage: draft.bannerImage,
+        document: draft.document,
+        createdAt: current?.article.createdAt ?? timestamp,
+        updatedAt: timestamp,
+      });
+      const articleText = canonicalCreatorArticleV1(article);
+      const contentSha256 = sha256(articleText);
+      const revisionPathname = revisionPath(identity, contentSha256);
+      try {
+        await input.blob.write({
+          pathname: revisionPathname,
+          text: articleText,
+          ifMatch: null,
+          immutable: true,
+        });
+      } catch (error) {
+        if (!(error instanceof CreatorArticleBlobPreconditionErrorV1)) throw error;
+        const existing = await input.blob.read(revisionPathname);
+        if (existing?.text !== articleText) throw error;
+      }
+      const pointer: ArticlePointerV1 = Object.freeze({
+        schemaVersion: POINTER_SCHEMA,
+        chainId: identity.chainId,
+        tokenAddress: identity.tokenAddress,
+        creatorAddress,
+        revision: article.revision,
+        revisionPath: revisionPathname,
+        contentSha256,
+        createdAt: article.createdAt,
+        updatedAt: article.updatedAt,
+      });
+      let pointerWrite;
+      try {
+        pointerWrite = await input.blob.write({
+          pathname: pointerPath(identity),
+          text: canonicalize(pointer),
+          ifMatch: current?.etag ?? null,
+          immutable: false,
+        });
+      } catch (error) {
+        if (error instanceof CreatorArticleBlobPreconditionErrorV1) {
+          throw new CreatorArticleRevisionConflictV1();
+        }
+        throw error;
+      }
+      const readback = await this.readCurrent(identity);
+      if (
+        readback === null
+        || readback.etag !== pointerWrite.etag
+        || readback.contentSha256 !== contentSha256
+      ) throw new TypeError("Creator article readback verification failed");
+      return readback;
+    },
+  });
+}
+
+export function createProductionCreatorArticleStoreV1(): CreatorArticleStoreV1 {
+  const token = process.env.BLOB_READ_WRITE_TOKEN?.trim();
+  if (!token) throw new TypeError("BLOB_READ_WRITE_TOKEN is not configured");
+  return createCreatorArticleStoreV1({
+    blob: Object.freeze({
+      async read(pathname: string) {
+        const result = await get(pathname, {
+          access: "private",
+          token,
+          useCache: false,
+        });
+        if (result === null) return null;
+        if (result.statusCode !== 200 || result.stream === null) {
+          throw new TypeError("Creator article blob read is invalid");
+        }
+        if (
+          result.blob.size > MAXIMUM_ARTICLE_BLOB_BYTES
+          || result.blob.contentType !== "application/json"
+        ) throw new TypeError("Creator article blob metadata is invalid");
+        return Object.freeze({
+          text: await readBoundedStream(result.stream),
+          etag: result.blob.etag,
+        });
+      },
+      async write(writeInput: Readonly<{
+        pathname: string;
+        text: string;
+        ifMatch: string | null;
+        immutable: boolean;
+      }>) {
+        try {
+          const result = await put(writeInput.pathname, writeInput.text, {
+            access: "private",
+            token,
+            addRandomSuffix: false,
+            allowOverwrite: !writeInput.immutable && writeInput.ifMatch !== null,
+            contentType: "application/json",
+            cacheControlMaxAge: 60,
+            ...(writeInput.ifMatch === null ? {} : { ifMatch: writeInput.ifMatch }),
+          });
+          if (result.pathname !== writeInput.pathname || !result.etag) {
+            throw new TypeError("Creator article blob write is invalid");
+          }
+          return Object.freeze({ pathname: result.pathname, etag: result.etag });
+        } catch (error) {
+          if (error instanceof BlobPreconditionFailedError) {
+            throw new CreatorArticleBlobPreconditionErrorV1();
+          }
+          throw error;
+        }
+      },
+    }),
+  });
+}
+
+function normalizeIdentity(input: Readonly<{ chainId: number; tokenAddress: string }>): ArticleIdentityV1 {
+  if (input.chainId !== 1 || !isAddress(input.tokenAddress)) {
+    throw new TypeError("Creator article identity is invalid");
+  }
+  return Object.freeze({ chainId: 1, tokenAddress: getAddress(input.tokenAddress) });
+}
+
+function basePath(identity: ArticleIdentityV1) {
+  return `creator-articles/v1/eip155-${identity.chainId}/${identity.tokenAddress.toLowerCase()}`;
+}
+
+function pointerPath(identity: ArticleIdentityV1) {
+  return `${basePath(identity)}/current.json`;
+}
+
+function revisionPath(identity: ArticleIdentityV1, digest: `sha256:${string}`) {
+  return `${basePath(identity)}/revisions/${digest.slice("sha256:".length)}.json`;
+}
+
+function sha256(value: string): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(value, "utf8").digest("hex")}`;
+}
+
+function parsePointer(text: string, identity: ArticleIdentityV1): ArticlePointerV1 {
+  const value = parseBoundedJson(text);
+  if (!isRecord(value)) throw new TypeError("Creator article pointer is invalid");
+  const expectedKeys = [
+    "schemaVersion", "chainId", "tokenAddress", "creatorAddress", "revision",
+    "revisionPath", "contentSha256", "createdAt", "updatedAt",
+  ];
+  if (Object.keys(value).length !== expectedKeys.length
+    || expectedKeys.some((key) => !(key in value))
+    || value.schemaVersion !== POINTER_SCHEMA
+    || value.chainId !== 1
+    || typeof value.tokenAddress !== "string" || !isAddress(value.tokenAddress)
+    || value.tokenAddress.toLowerCase() !== identity.tokenAddress.toLowerCase()
+    || typeof value.creatorAddress !== "string" || !isAddress(value.creatorAddress)
+    || !Number.isSafeInteger(value.revision) || Number(value.revision) < 1
+    || typeof value.contentSha256 !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value.contentSha256)
+    || typeof value.revisionPath !== "string"
+    || value.revisionPath !== revisionPath(identity, value.contentSha256 as `sha256:${string}`)
+    || typeof value.createdAt !== "string" || new Date(value.createdAt).toISOString() !== value.createdAt
+    || typeof value.updatedAt !== "string" || new Date(value.updatedAt).toISOString() !== value.updatedAt
+  ) throw new TypeError("Creator article pointer is invalid");
+  return Object.freeze({
+    schemaVersion: POINTER_SCHEMA,
+    chainId: 1,
+    tokenAddress: getAddress(value.tokenAddress),
+    creatorAddress: getAddress(value.creatorAddress),
+    revision: Number(value.revision),
+    revisionPath: value.revisionPath,
+    contentSha256: value.contentSha256 as `sha256:${string}`,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  });
+}
+
+function parseBoundedJson(text: string): unknown {
+  if (!text || Buffer.byteLength(text, "utf8") > MAXIMUM_ARTICLE_BLOB_BYTES) {
+    throw new TypeError("Creator article blob is invalid");
+  }
+  return JSON.parse(text) as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean"
+    || typeof value === "number") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  if (isRecord(value)) return `{${Object.keys(value).sort().map((key) =>
+    `${JSON.stringify(key)}:${canonicalize(value[key])}`).join(",")}}`;
+  throw new TypeError("Creator article pointer is invalid");
+}
+
+async function readBoundedStream(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    length += value.byteLength;
+    if (length > MAXIMUM_ARTICLE_BLOB_BYTES) {
+      await reader.cancel();
+      throw new TypeError("Creator article blob is too large");
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+}

--- a/lib/server/creator-article/storage.server.ts
+++ b/lib/server/creator-article/storage.server.ts
@@ -188,7 +188,7 @@ export function createProductionCreatorArticleStoreV1(): CreatorArticleStoreV1 {
     blob: Object.freeze({
       async read(pathname: string) {
         const result = await get(pathname, {
-          access: "private",
+          access: "public",
           token,
           useCache: false,
         });
@@ -213,7 +213,7 @@ export function createProductionCreatorArticleStoreV1(): CreatorArticleStoreV1 {
       }>) {
         try {
           const result = await put(writeInput.pathname, writeInput.text, {
-            access: "private",
+            access: "public",
             token,
             addRandomSuffix: false,
             allowOverwrite: !writeInput.immutable && writeInput.ifMatch !== null,

--- a/lib/server/creator-article/wallet-principal.server.ts
+++ b/lib/server/creator-article/wallet-principal.server.ts
@@ -1,0 +1,201 @@
+import "server-only";
+
+import { PrivyClient } from "@privy-io/node";
+import { getAddress, isAddress } from "viem";
+
+import { parseStrictJson, type JsonValue } from
+  "../projection-target/canonical-json";
+
+const MAXIMUM_PRIVY_TOKEN_BYTES = 131_072;
+
+export type AuthenticatedWalletPrincipalV1 = Readonly<{
+  privyUserId: string;
+  privySessionId: string;
+  wallets: readonly `0x${string}`[];
+}>;
+
+export interface WalletPrincipalAuthenticatorV1 {
+  authenticate(request: Request): Promise<AuthenticatedWalletPrincipalV1>;
+}
+
+export interface PrivyWalletAuthorityBoundaryV1 {
+  verifyAccessToken(token: string): Promise<Readonly<{
+    appId: string;
+    userId: string;
+    sessionId: string;
+  }>>;
+  verifyIdentityToken(token: string): Promise<Readonly<{
+    userId: string;
+    sessionId: string;
+  }>>;
+  getCurrentUser(userId: string): Promise<Readonly<{
+    id: string;
+    linkedAccounts: readonly Readonly<{
+      type: string;
+      address?: string;
+      chainType?: string;
+    }>[];
+  }>>;
+}
+
+export class WalletPrincipalAuthenticationErrorV1 extends Error {
+  constructor(readonly status: 401 | 403, readonly code: string) {
+    super(code);
+    this.name = "WalletPrincipalAuthenticationErrorV1";
+  }
+}
+
+export function createPrivyWalletPrincipalAuthenticatorV1():
+WalletPrincipalAuthenticatorV1 {
+  const appId = requiredEnvironment("NEXT_PUBLIC_PRIVY_APP_ID");
+  const appSecret = requiredEnvironment("PRIVY_APP_SECRET");
+  const privy = new PrivyClient({ appId, appSecret });
+  return createWalletPrincipalAuthenticatorFromBoundaryV1({
+    appId,
+    boundary: Object.freeze({
+      async verifyAccessToken(token: string) {
+        const value = await privy.utils().auth().verifyAccessToken(token);
+        return Object.freeze({
+          appId: value.app_id,
+          userId: value.user_id,
+          sessionId: value.session_id,
+        });
+      },
+      async verifyIdentityToken(token: string) {
+        const user = await privy.users().get({ id_token: token });
+        const claims = verifiedIdentitySessionClaims(token);
+        if (claims.userId !== user.id) throw new TypeError("Privy identity mismatch");
+        return claims;
+      },
+      async getCurrentUser(userId: string) {
+        const user = await privy.users()._get(userId);
+        return Object.freeze({
+          id: user.id,
+          linkedAccounts: Object.freeze(user.linked_accounts.map((account) => {
+            const record = account as unknown as Record<string, unknown>;
+            return Object.freeze({
+              type: account.type,
+              ...(typeof record.address === "string"
+                ? { address: record.address }
+                : {}),
+              ...(typeof record.chain_type === "string"
+                ? { chainType: record.chain_type }
+                : {}),
+            });
+          })),
+        });
+      },
+    }),
+  });
+}
+
+export function createWalletPrincipalAuthenticatorFromBoundaryV1(
+  input: Readonly<{
+    appId: string;
+    boundary: PrivyWalletAuthorityBoundaryV1;
+  }>,
+): WalletPrincipalAuthenticatorV1 {
+  if (!input.appId
+    || typeof input.boundary?.verifyAccessToken !== "function"
+    || typeof input.boundary.verifyIdentityToken !== "function"
+    || typeof input.boundary.getCurrentUser !== "function") {
+    throw new TypeError("Privy wallet authority boundary is invalid");
+  }
+  return Object.freeze({
+    async authenticate(request: Request): Promise<AuthenticatedWalletPrincipalV1> {
+      const accessToken = bearerToken(request.headers.get("authorization"));
+      const identityToken = boundedToken(
+        request.headers.get("x-privy-identity-token"),
+        "identity_token_invalid",
+      );
+      try {
+        const [access, identity] = await Promise.all([
+          input.boundary.verifyAccessToken(accessToken),
+          input.boundary.verifyIdentityToken(identityToken),
+        ]);
+        if (
+          access.appId !== input.appId
+          || access.userId !== identity.userId
+          || access.sessionId !== identity.sessionId
+        ) throw new TypeError("Privy token binding mismatch");
+        const user = await input.boundary.getCurrentUser(access.userId);
+        if (user.id !== access.userId) throw new TypeError("Privy user mismatch");
+        const wallets = new Map<string, `0x${string}`>();
+        for (const account of user.linkedAccounts) {
+          if (
+            account.type !== "wallet"
+            || (account.chainType !== undefined && account.chainType !== "ethereum")
+            || typeof account.address !== "string"
+            || !isAddress(account.address)
+          ) continue;
+          const address = getAddress(account.address);
+          wallets.set(address.toLowerCase(), address);
+        }
+        const normalized = [...wallets.values()].sort((left, right) =>
+          left.toLowerCase().localeCompare(right.toLowerCase()));
+        if (normalized.length === 0) {
+          throw new WalletPrincipalAuthenticationErrorV1(403, "ethereum_wallet_required");
+        }
+        return Object.freeze({
+          privyUserId: user.id,
+          privySessionId: access.sessionId,
+          wallets: Object.freeze(normalized),
+        });
+      } catch (error) {
+        if (error instanceof WalletPrincipalAuthenticationErrorV1) throw error;
+        throw new WalletPrincipalAuthenticationErrorV1(401, "privy_session_rejected");
+      }
+    },
+  });
+}
+
+function bearerToken(value: string | null) {
+  if (!value?.startsWith("Bearer ")) {
+    throw new WalletPrincipalAuthenticationErrorV1(401, "session_required");
+  }
+  return boundedToken(value.slice("Bearer ".length), "access_token_invalid");
+}
+
+function boundedToken(value: string | null, code: string) {
+  if (
+    value === null
+    || value.length < 20
+    || Buffer.byteLength(value, "utf8") > MAXIMUM_PRIVY_TOKEN_BYTES
+    || /[\s\u0000]/u.test(value)
+  ) throw new WalletPrincipalAuthenticationErrorV1(401, code);
+  return value;
+}
+
+function verifiedIdentitySessionClaims(token: string) {
+  const segments = token.split(".");
+  if (segments.length !== 3 || segments[1] === undefined) {
+    throw new TypeError("Privy identity token is invalid");
+  }
+  const decoded = new TextDecoder("utf-8", { fatal: true }).decode(
+    Buffer.from(segments[1], "base64url"),
+  );
+  const value = parseStrictJson(decoded, {
+    maximumBytes: MAXIMUM_PRIVY_TOKEN_BYTES,
+    maximumDepth: 16,
+  });
+  const record = jsonRecord(value);
+  if (
+    typeof record.sub !== "string" || !record.sub
+    || typeof record.sid !== "string" || !record.sid
+    || record.sub.length > 512 || record.sid.length > 512
+  ) throw new TypeError("Privy identity token session is invalid");
+  return Object.freeze({ userId: record.sub, sessionId: record.sid });
+}
+
+function jsonRecord(value: JsonValue): Readonly<Record<string, JsonValue>> {
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    throw new TypeError("Privy identity token payload is invalid");
+  }
+  return value;
+}
+
+function requiredEnvironment(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new TypeError(`${name} is not configured`);
+  return value;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,10 @@
         "@metamask/smart-accounts-kit": "1.7.0",
         "@privy-io/node": "^0.27.0",
         "@privy-io/react-auth": "3.35.2",
+        "@tiptap/core": "^3.30.2",
+        "@tiptap/extension-image": "^3.30.2",
+        "@tiptap/react": "^3.30.2",
+        "@tiptap/starter-kit": "^3.30.2",
         "@uniswap/liquidity-launcher-sdk": "1.0.1",
         "@uniswap/sdk-core": "7.19.0",
         "@uniswap/universal-router-sdk": "5.11.1",
@@ -6973,6 +6977,449 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.30.2.tgz",
+      "integrity": "sha512-QbZC/s1OOqcoUdkhIY16TjR/gCtR0qAk9e4bJwUqOJqZuv5ozqCL5hzWm22jjTPp6c6Ei2tPd6t30VwfIKW4lQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.30.2.tgz",
+      "integrity": "sha512-BOkwhZenek7vzXBOgKppSrlx4YryBdAYu1p1MXKn0R9A9eNmE2HVhmm0gG49+E8BhsE/TG8wKVclwET42JJiIg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2",
+        "@tiptap/pm": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.30.2.tgz",
+      "integrity": "sha512-MsvJhPgYejY2D9MhwYJv8AmscozvLBI8qtJ7YLdYZBWkMR4bgmxHq5+xqEfBsao9bOMMwBon9p3+P+/Tq5ReWA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.30.2.tgz",
+      "integrity": "sha512-oS0WiWNXHKpiPYMkcnHm1j7iEvufTGGtLFtcJJd3olb5OS6V2acoXVDL0nNJDmRQ32K3QXut3fbRcMseMxT+lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2",
+        "@tiptap/pm": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.30.2.tgz",
+      "integrity": "sha512-+awIL/TUz4aB3rL68igU1rWfaaoBIAkPcakkktkRq8gYf0bd9eSb48P6kHkpx/3q+JyK7g9vsnltLNHNh6twnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.30.2.tgz",
+      "integrity": "sha512-r8EZk3R9yGpF6v5xxafAU1HwrD/e+RpbfnmVi2TeB/ZHAsVO62fW96E32G0t6IdaCtOFtAd85hkDAaOfCT4yGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.30.2.tgz",
+      "integrity": "sha512-9otGKaQZmePHrLXFtCtz+BYDn5z4sSumTkUqQIQHz0gVxwPoTi7g51RedwxvViTb/zu2XV5ROXYLHIxKxypMPg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2",
+        "@tiptap/pm": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.30.2.tgz",
+      "integrity": "sha512-+xIv67V+/2L1uvz98FAT5W7kWEfHwfNV3MD7b4UsKPU0lhcCWuVOXy0JB8yYmdNExqpI7xT9g3MWzREoBvBQSg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.30.2.tgz",
+      "integrity": "sha512-nyRKUmItATnKI9AiRChmjhcBbCEsNxRu+AaCz+cx8EvnAcNHsVRdNYL5PmBs3WlNA/Et4Eb2DG0hVQDnNF61eg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.30.2.tgz",
+      "integrity": "sha512-A8PLvvh8W6PUMrqh+EpBerxm+Ucr0irGxJvwAnzYQmNGNIJ9U4OVgw4OcEU+9JH0gMmEzDcHzMPP2s/s1lIcyw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.30.2",
+        "@tiptap/pm": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.30.2.tgz",
+      "integrity": "sha512-7Xk0ut6FM+RAsvKxDN3bAtk7zvYZ6Aa8pawJ6s7dLAmLR9JwrZevlcL4FSrj4bR7rqKOj92RYCFxzgTEbWimag==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.30.2.tgz",
+      "integrity": "sha512-IxSNgmG3d4OZdUTeebrOI7SxdIWXXJqlcGiSNDabWqxipUitfy3mZ3gDDE6G01koKxZRbhz4KIplAZlpxnTFSg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.30.2.tgz",
+      "integrity": "sha512-PblDvgSJ05p1t6hzyPi02xeiBjB0M2abReoGEImqSWCy79UqnAGacgsZo4EeEawtJV1NEP8chhvmX+nRtzdT1A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.30.2.tgz",
+      "integrity": "sha512-j8aswLTsuEdJKC62DF+kw0EgvIRL7QMUyAVp2fdjR0qgM0ZVlEwCC4qIEq3kK9tFVU4kRtQ5BSj/jn6QwrlbCA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2",
+        "@tiptap/pm": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.30.2.tgz",
+      "integrity": "sha512-K/BPlWauHXI6Y4s7se2A1BLcZ2pnWmRQTEDkPJYe/8kmv1GyJzPu34sZed5Mvfu5chUH8u6aNZ/utZbvSbI/0Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.30.2.tgz",
+      "integrity": "sha512-pp8uaiuXsUbLm5rYzR1jlWbwm1mAahRajdHwAKBtthFRB2rDvC7ZWhKaCSoKhZvfIDRmu9/B67+uAHoutL0dCA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.30.2.tgz",
+      "integrity": "sha512-jwdcymKcrbFpj5hRAuGVLCq8FieVkGFnENyroYmvkad+XAt8ZLy/MTFYRN6SK3ukH6PZMY7H4iObGtciQaC5nw==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2",
+        "@tiptap/pm": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.30.2.tgz",
+      "integrity": "sha512-MIUpo1Bd9Rf1Qg+TNYNwDZ4xsfFeQahjU9Xhy6UcaszKQzbAM7KCzn5BObNytK1NdcqNHsC8Wj5vFvMKEzrXdw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2",
+        "@tiptap/pm": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.30.2.tgz",
+      "integrity": "sha512-HWgRCRlGxulE+hN1VUcnWD6P2NE08VBgGtcaxOfdXVqaI93BCK6AhRQZGpLsfKgajLk+5DXTBraaitwnBqzCxg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.30.2.tgz",
+      "integrity": "sha512-TTve3WOlQaYu1ahMqsQ/T0wzaxfgZvcOl3/OuPyInOi8QtxXhqGhFjmYe5jOr56G9W2QDuFWVsZecVwfDte9zg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.30.2.tgz",
+      "integrity": "sha512-Z7OO1HcF0idda1n6vodXeQ3h2ylN9JR4IfIGUYkar5Xl9JusK8PDETTBQZQn//96p49I2d+GoWsD2LXPtjHXXg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.30.2.tgz",
+      "integrity": "sha512-ulEu3LNt+kPVAWEnrhoz13Fs8Q/v/8NUxQbAeteuBchQ8joxJXuWExhpy1fUfZir5+b+W5z7/NesgPjZQfv47w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.30.2.tgz",
+      "integrity": "sha512-fBLxMXz6hYIURzLOD+/L6aVATztsKham00ANWmGi13vN0hx2lQMYZffN+gR+QqiCDfMQxBXzrf5a7tJuDiQHLQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.30.2.tgz",
+      "integrity": "sha512-n/iZnirgRmXet6f97kolAnP3j8DsgLSiTbz/KLWc8eBYiFmkjRzkuisOm5xuGdfGIxwpB4x3tlSF4ef4DLnbRg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.30.2.tgz",
+      "integrity": "sha512-SZiTMnvqXcnrtJX+X25ZbYsuDO83haGOVMBD/O+mAWYNYXhaSc5Rkph5czzItxrd+Yyp/vs4PiwD7XTNbfqmpA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.30.2.tgz",
+      "integrity": "sha512-2LqAHXk26QDsryW+beECxYeBzv5Ylk4GuB3cOmfghS7/G37R2W+Te3TkUK7BT0EWoDryvBT57/5q0DEFIhfZZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2",
+        "@tiptap/pm": "3.30.2"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.30.2.tgz",
+      "integrity": "sha512-BJN8tUx4ppFN3R3cV/FJfrJbJkvo1lj4uciq+nwpjwzdRvFzqIuglWf+HLcJ6CwlYpLOHp7ArgkBg4Q5e60Gog==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.4.1",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-gapcursor": "^1.4.1",
+        "prosemirror-history": "^1.5.0",
+        "prosemirror-inputrules": "^1.5.1",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.11",
+        "prosemirror-schema-list": "^1.5.1",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.5",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.30.2.tgz",
+      "integrity": "sha512-7hGaTstpUeTmQ008mCPkjz+GSlChWhucgy+PeX0z93v4+nh7qM5F+0lh+kJ9zo6Os5abO7v36GtgHRZdQI6+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.30.2",
+        "@tiptap/extension-floating-menu": "^3.30.2"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.30.2",
+        "@tiptap/pm": "3.30.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.30.2.tgz",
+      "integrity": "sha512-fJSrhW1CyD4sjYA20evSP4Cp13B/HhbxCdM974K0xpHOVqvCtNU9w2s9hfq9mg2yGoU7MSNHKNYMkJjIi2/Xyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "3.30.2",
+        "@tiptap/extension-blockquote": "3.30.2",
+        "@tiptap/extension-bold": "3.30.2",
+        "@tiptap/extension-bullet-list": "3.30.2",
+        "@tiptap/extension-code": "3.30.2",
+        "@tiptap/extension-code-block": "3.30.2",
+        "@tiptap/extension-document": "3.30.2",
+        "@tiptap/extension-dropcursor": "3.30.2",
+        "@tiptap/extension-gapcursor": "3.30.2",
+        "@tiptap/extension-hard-break": "3.30.2",
+        "@tiptap/extension-heading": "3.30.2",
+        "@tiptap/extension-horizontal-rule": "3.30.2",
+        "@tiptap/extension-italic": "3.30.2",
+        "@tiptap/extension-link": "3.30.2",
+        "@tiptap/extension-list": "3.30.2",
+        "@tiptap/extension-list-item": "3.30.2",
+        "@tiptap/extension-list-keymap": "3.30.2",
+        "@tiptap/extension-ordered-list": "3.30.2",
+        "@tiptap/extension-paragraph": "3.30.2",
+        "@tiptap/extension-strike": "3.30.2",
+        "@tiptap/extension-text": "3.30.2",
+        "@tiptap/extension-underline": "3.30.2",
+        "@tiptap/extensions": "3.30.2",
+        "@tiptap/pm": "3.30.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -7090,6 +7537,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -12598,6 +13051,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+      "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
@@ -14348,6 +14810,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
     "node_modules/lit": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
@@ -15067,6 +15535,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/os-paths": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
@@ -15732,6 +16206,145 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.2.tgz",
+      "integrity": "sha512-ViYrjMSg3YFiXwIhKaluu+/mi3Yrxt6AR8ri14ulTaGcZtXO1CThl7A2gv79qx5fQnOw8woKwyBU2u+9PVCm3w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.2.tgz",
+      "integrity": "sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+      "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+      "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
+      "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.8",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proxy-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
@@ -16131,6 +16744,12 @@
         "@rolldown/binding-win32-arm64-msvc": "1.1.5",
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -17835,6 +18454,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/wagmi": {
       "version": "2.19.5",

--- a/package.json
+++ b/package.json
@@ -163,12 +163,16 @@
     "perf:read-model:post-promotion": "node scripts/perf/read-model-post-promotion.mjs"
   },
   "dependencies": {
+    "@electric-sql/pglite": "0.5.4",
     "@metamask/delegation-abis": "1.1.0",
     "@metamask/delegation-core": "2.2.1",
     "@metamask/smart-accounts-kit": "1.7.0",
     "@privy-io/node": "^0.27.0",
     "@privy-io/react-auth": "3.35.2",
-    "@electric-sql/pglite": "0.5.4",
+    "@tiptap/core": "^3.30.2",
+    "@tiptap/extension-image": "^3.30.2",
+    "@tiptap/react": "^3.30.2",
+    "@tiptap/starter-kit": "^3.30.2",
     "@uniswap/liquidity-launcher-sdk": "1.0.1",
     "@uniswap/sdk-core": "7.19.0",
     "@uniswap/universal-router-sdk": "5.11.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "verify:service-launch-permit-v2-golden:cross-stack": "node scripts/verify-service-launch-permit-v2-golden.mjs --require-canonical",
     "verify:uniswap-launcher-sdk": "node scripts/verify-uniswap-liquidity-launcher-sdk.mjs",
     "brand:favicons": "node scripts/generate-programmable-favicons.mjs",
+    "creator-article:programmable:seed": "node scripts/seed-programmable-creator-article.mjs",
     "audit:prod": "npm audit --omit=dev --audit-level=moderate",
     "release:custom-launch:record:verify": "node scripts/verify-custom-launch-release-record.mjs",
     "release:custom-launch:record:test": "node --test scripts/test/custom-launch-cross-repository-attestation.test.mjs scripts/test/custom-launch-dark-release-evidence.test.mjs scripts/test/custom-launch-release-record.test.mjs scripts/test/custom-launch-release-workflow-contract.test.mjs scripts/test/production-verify-proof.test.mjs",

--- a/scripts/seed-programmable-creator-article.mjs
+++ b/scripts/seed-programmable-creator-article.mjs
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+const address = "0x7987f03462200b3D8A072E02C89A8A41dCB124EE";
+const path = new URL("../config/creator-article-programmable-example.v1.json", import.meta.url);
+const draft = JSON.parse(await readFile(path, "utf8"));
+const canonical = canonicalize(draft);
+const contentSha256 = `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+const write = process.argv.includes("--write");
+
+if (!write) {
+  console.log(JSON.stringify({
+    mode: "dry-run",
+    identity: "official-main-token",
+    tokenAddress: address,
+    contentSha256,
+    externalWrite: false,
+  }));
+  process.exit(0);
+}
+
+const origin = required("CREATOR_ARTICLE_ORIGIN");
+const accessToken = required("CREATOR_ARTICLE_ACCESS_TOKEN");
+const identityToken = required("CREATOR_ARTICLE_IDENTITY_TOKEN");
+const expectedEtag = required("CREATOR_ARTICLE_EXPECTED_ETAG");
+const target = new URL(`/api/profile/projects/${address}/article`, origin);
+if (target.protocol !== "https:" || target.username || target.password) {
+  throw new Error("CREATOR_ARTICLE_ORIGIN must be a clean HTTPS origin");
+}
+
+const authHeaders = {
+  Authorization: `Bearer ${accessToken}`,
+  "X-Privy-Identity-Token": identityToken,
+};
+const response = await fetch(target, {
+  method: "PUT",
+  headers: {
+    ...authHeaders,
+    "Content-Type": "application/json",
+    ...(expectedEtag === "*"
+      ? { "If-None-Match": "*" }
+      : { "If-Match": expectedEtag }),
+  },
+  body: JSON.stringify(draft),
+});
+const body = await response.json().catch(() => null);
+if (!response.ok) throw new Error(`Seed rejected with HTTP ${response.status}`);
+const etag = response.headers.get("etag");
+if (!etag || body?.article?.tokenAddress !== address) {
+  throw new Error("Seed publication receipt is invalid");
+}
+
+const readback = await fetch(target, {
+  headers: { ...authHeaders, Accept: "application/json" },
+});
+const readbackBody = await readback.json().catch(() => null);
+if (!readback.ok
+  || readback.headers.get("etag") !== etag
+  || readbackBody?.article?.tokenAddress !== address
+  || readbackBody?.article?.title !== draft.title) {
+  throw new Error("Seed publication readback did not bind the exact article");
+}
+
+console.log(JSON.stringify({
+  mode: "write",
+  identity: "official-main-token",
+  tokenAddress: address,
+  revision: readbackBody.article.revision,
+  etag,
+  contentSha256,
+  readback: "verified",
+}));
+
+function required(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function canonicalize(value) {
+  if (value === null || typeof value === "string" || typeof value === "boolean"
+    || typeof value === "number") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  if (typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) =>
+      `${JSON.stringify(key)}:${canonicalize(value[key])}`).join(",")}}`;
+  }
+  throw new Error("Example article is not canonical JSON");
+}

--- a/tests/creator-article-api.test.ts
+++ b/tests/creator-article-api.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { parseCreatorArticleDraftV1 } from "../lib/creator-article/contract-v1";
+import { createCreatorArticleApiHandlersV1 } from
+  "../lib/server/creator-article/api.server";
+
+const TOKEN = "0x3333333333333333333333333333333333333333" as const;
+const CREATOR = "0x1111111111111111111111111111111111111111" as const;
+
+function draft() {
+  return parseCreatorArticleDraftV1({
+    schemaVersion: "programmable.creator-article-draft.v1",
+    chainId: 1,
+    tokenAddress: TOKEN,
+    title: "A project story",
+    bannerImage: null,
+    document: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Hello" }] }] },
+  });
+}
+
+describe("creator article authenticated APIs", () => {
+  const authenticate = vi.fn();
+  const readAuthorities = vi.fn();
+  const readCurrent = vi.fn();
+  const publish = vi.fn();
+  const principal = { privyUserId: "u", privySessionId: "s", wallets: [CREATOR] } as const;
+  const authority = {
+    chainId: 1 as const,
+    tokenAddress: TOKEN,
+    creatorAddress: CREATOR,
+    source: "envio-classic-v3" as const,
+    name: "Project",
+    symbol: "PROJECT",
+    imageUrl: null,
+  };
+  const handlers = createCreatorArticleApiHandlersV1({
+    authenticator: { authenticate },
+    authorityReader: { read: readAuthorities },
+    store: { readCurrent, publish },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    authenticate.mockResolvedValue(principal);
+    readAuthorities.mockResolvedValue([authority]);
+    readCurrent.mockResolvedValue(null);
+    publish.mockResolvedValue({
+      article: {
+        ...draft(),
+        schemaVersion: "programmable.creator-article.v1",
+        revision: 1,
+        status: "published",
+        createdAt: "2026-08-21T00:00:00.000Z",
+        updatedAt: "2026-08-21T00:00:00.000Z",
+      },
+      etag: "etag-1",
+      contentSha256: `sha256:${"aa".repeat(32)}`,
+    });
+  });
+
+  it("lists only the authenticated wallet's verified projects", async () => {
+    const response = await handlers.listProjects(new Request("https://example.com/api/profile/projects", {
+      headers: { accept: "application/json" },
+    }));
+    expect(response.status).toBe(200);
+    expect((await response.json()).projects).toEqual([expect.objectContaining({ tokenAddress: TOKEN })]);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("requires create/update preconditions and publishes the canonical draft", async () => {
+    const missing = await handlers.article(new Request(`https://example.com/api/profile/projects/${TOKEN}/article`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(draft()),
+    }), TOKEN);
+    expect(missing.status).toBe(428);
+
+    const response = await handlers.article(new Request(`https://example.com/api/profile/projects/${TOKEN}/article`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", "if-none-match": "*" },
+      body: JSON.stringify(draft()),
+    }), TOKEN);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("etag")).toBe("etag-1");
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({
+      creatorAddress: CREATOR,
+      expectedEtag: null,
+    }));
+  });
+
+  it("does not trust a draft for another token", async () => {
+    const wrong = { ...draft(), tokenAddress: "0x4444444444444444444444444444444444444444" };
+    const response = await handlers.article(new Request(`https://example.com/api/profile/projects/${TOKEN}/article`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", "if-none-match": "*" },
+      body: JSON.stringify(wrong),
+    }), TOKEN);
+    expect(response.status).toBe(400);
+    expect(publish).not.toHaveBeenCalled();
+  });
+});

--- a/tests/creator-article-authority.test.ts
+++ b/tests/creator-article-authority.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { vi } from "vitest";
+import {
+  createCreatorArticleAuthorityReaderV1,
+  listCreatorArticleAuthoritiesV1,
+  requireCreatorArticleAuthorityV1,
+} from "../lib/server/creator-article/authority.server";
+import {
+  createWalletPrincipalAuthenticatorFromBoundaryV1,
+} from "../lib/server/creator-article/wallet-principal.server";
+import type { ExploreEntry } from "../lib/tokens";
+
+const CREATOR = "0x1111111111111111111111111111111111111111" as const;
+const OTHER = "0x2222222222222222222222222222222222222222" as const;
+const TOKEN = "0x3333333333333333333333333333333333333333" as const;
+const CUSTOM = "0x4444444444444444444444444444444444444444" as const;
+
+function request() {
+  return new Request("https://programmable.market/api/profile/projects", {
+    headers: {
+      authorization: `Bearer ${"a".repeat(32)}`,
+      "x-privy-identity-token": `${btoa("header")}.${Buffer.from(JSON.stringify({ sub: "did:privy:user", sid: "session" })).toString("base64url")}.signature`,
+    },
+  });
+}
+
+function classic(): ExploreEntry {
+  return {
+    exploreKind: "token",
+    id: `1:${TOKEN.toLowerCase()}`,
+    name: "Classic",
+    symbol: "CLASSIC",
+    tokenAddress: TOKEN,
+    hookAddress: OTHER,
+    poolId: `0x${"55".repeat(32)}`,
+    creatorAddress: CREATOR,
+    launchedAt: "2026-08-21T00:00:00.000Z",
+    launchModel: "classic",
+    launchModelVersion: "classic-v3",
+    liquidityPath: "meme",
+    totalSwapFeeBps: 100,
+    launchCategoryProvenance: {} as never,
+  };
+}
+
+function custom(): ExploreEntry {
+  return {
+    exploreKind: "custom-project",
+    id: "custom:test",
+    name: "Custom",
+    symbol: "CUSTOM",
+    links: [],
+    launchedAt: "2026-08-21T00:00:00.000Z",
+    finalizedAt: "2026-08-21T00:00:00.000Z",
+    chainId: "1",
+    modelId: "custom",
+    customProjectId: `sha256:${"66".repeat(32)}`,
+    customLaunchId: `sha256:${"77".repeat(32)}`,
+    launchingWallet: { namespace: "eip155:1", value: CREATOR },
+    postLaunchAuthorityInventory: {} as never,
+    postLaunchAuthorityInventoryHash: `sha256:${"88".repeat(32)}`,
+    markets: [],
+    tokenAddress: CUSTOM,
+    launchCategoryProvenance: {} as never,
+  };
+}
+
+describe("creator article wallet principal", () => {
+  it("binds both Privy tokens and returns unique Ethereum wallets", async () => {
+    const authenticator = createWalletPrincipalAuthenticatorFromBoundaryV1({
+      appId: "app",
+      boundary: {
+        verifyAccessToken: vi.fn().mockResolvedValue({
+          appId: "app", userId: "did:privy:user", sessionId: "session",
+        }),
+        verifyIdentityToken: vi.fn().mockResolvedValue({
+          userId: "did:privy:user", sessionId: "session",
+        }),
+        getCurrentUser: vi.fn().mockResolvedValue({
+          id: "did:privy:user",
+          linkedAccounts: [
+            { type: "wallet", chainType: "ethereum", address: CREATOR.toLowerCase() },
+            { type: "wallet", chainType: "ethereum", address: CREATOR },
+            { type: "wallet", chainType: "solana", address: CREATOR },
+          ],
+        }),
+      },
+    });
+    const principal = await authenticator.authenticate(request());
+    expect(principal.wallets).toEqual([CREATOR]);
+  });
+
+  it("rejects mismatched sessions and missing Ethereum wallets", async () => {
+    const base = {
+      verifyAccessToken: vi.fn().mockResolvedValue({ appId: "app", userId: "u", sessionId: "s1" }),
+      verifyIdentityToken: vi.fn().mockResolvedValue({ userId: "u", sessionId: "s2" }),
+      getCurrentUser: vi.fn().mockResolvedValue({ id: "u", linkedAccounts: [] }),
+    };
+    await expect(createWalletPrincipalAuthenticatorFromBoundaryV1({
+      appId: "app", boundary: base,
+    }).authenticate(request())).rejects.toMatchObject({ status: 401 });
+
+    base.verifyIdentityToken.mockResolvedValue({ userId: "u", sessionId: "s1" });
+    await expect(createWalletPrincipalAuthenticatorFromBoundaryV1({
+      appId: "app", boundary: base,
+    }).authenticate(request())).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe("creator article launch authority", () => {
+  const principal = {
+    privyUserId: "u",
+    privySessionId: "s",
+    wallets: [CREATOR],
+  } as const;
+
+  it("allows Classic V3 and Registry-verified Custom for their exact creator", async () => {
+    const reader = createCreatorArticleAuthorityReaderV1({
+      readClassic: vi.fn().mockResolvedValue([classic()]),
+      readCustom: vi.fn().mockResolvedValue([custom()]),
+    });
+    expect((await listCreatorArticleAuthoritiesV1({
+      reader, principal, signal: new AbortController().signal,
+    })).map(({ tokenAddress }) => tokenAddress)).toEqual([TOKEN, CUSTOM]);
+    await expect(requireCreatorArticleAuthorityV1({
+      reader, principal, tokenAddress: CUSTOM, signal: new AbortController().signal,
+    })).resolves.toMatchObject({ source: "registry.custom-launched" });
+  });
+
+  it("keeps Custom fail-closed and rejects a different wallet", async () => {
+    const reader = createCreatorArticleAuthorityReaderV1({
+      readClassic: vi.fn().mockResolvedValue([classic()]),
+      readCustom: vi.fn().mockRejectedValue(new Error("Registry unavailable")),
+    });
+    await expect(requireCreatorArticleAuthorityV1({
+      reader, principal, tokenAddress: CUSTOM, signal: new AbortController().signal,
+    })).rejects.toMatchObject({ status: 404 });
+    await expect(requireCreatorArticleAuthorityV1({
+      reader,
+      principal: { ...principal, wallets: [OTHER] },
+      tokenAddress: TOKEN,
+      signal: new AbortController().signal,
+    })).rejects.toMatchObject({ status: 403 });
+  });
+});

--- a/tests/creator-article-contract.test.ts
+++ b/tests/creator-article-contract.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalCreatorArticleDraftV1,
+  parseCreatorArticleDraftV1,
+  parseCreatorArticleV1,
+} from "../lib/creator-article/contract-v1";
+import {
+  displayHttpsLinkV1,
+  isAllowedArticleHrefV1,
+} from "../lib/creator-article/link";
+
+const TOKEN = "0x7987f03462200b3D8A072E02C89A8A41dCB124EE";
+
+function draft() {
+  return {
+    schemaVersion: "programmable.creator-article-draft.v1",
+    chainId: 1,
+    tokenAddress: TOKEN.toLowerCase(),
+    title: "Programmable, by its creators",
+    bannerImage: {
+      url: "https://example.com/banner.webp",
+      alt: "Programmable floral landscape",
+      caption: null,
+      width: 3000,
+      height: 1000,
+      size: "wide",
+    },
+    document: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{
+            type: "text",
+            text: "Build openly.",
+            marks: [
+              { type: "bold" },
+              { type: "link", attrs: { href: "https://programmable.market/#top" } },
+            ],
+          }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Launch with context" }],
+        },
+        {
+          type: "bulletList",
+          content: [{
+            type: "listItem",
+            content: [{
+              type: "paragraph",
+              content: [{ type: "text", text: "Verified launch identity" }],
+            }],
+          }],
+        },
+        {
+          type: "articleImage",
+          attrs: {
+            url: "https://example.com/article.webp",
+            alt: "Programmable launch interface",
+            caption: "A launch surface",
+            width: 1800,
+            height: 1200,
+            size: "content",
+          },
+        },
+      ],
+    },
+  };
+}
+
+describe("creator article v1 contract", () => {
+  it("canonicalizes a bounded document and its exact identity", () => {
+    const parsed = parseCreatorArticleDraftV1(draft());
+    expect(parsed.tokenAddress).toBe(TOKEN);
+    expect(parsed.document.content).toHaveLength(4);
+    expect(canonicalCreatorArticleDraftV1(parsed)).toContain(
+      '"schemaVersion":"programmable.creator-article-draft.v1"',
+    );
+  });
+
+  it.each([
+    ["raw HTML", () => {
+      const value = draft();
+      value.document.content = [{ type: "html", content: [] }] as never;
+      return value;
+    }],
+    ["unsupported H1", () => {
+      const value = draft();
+      value.document.content[1] = {
+        type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "No" }],
+      } as never;
+      return value;
+    }],
+    ["javascript link", () => {
+      const value = draft();
+      const paragraph = value.document.content[0] as typeof value.document.content[0] & {
+        content: { marks: { attrs?: { href: string } }[] }[];
+      };
+      paragraph.content[0].marks[1].attrs!.href = "javascript:alert(1)";
+      return value;
+    }],
+    ["data image", () => {
+      const value = draft();
+      value.bannerImage.url = "data:image/png;base64,AAAA";
+      return value;
+    }],
+    ["unknown field", () => ({ ...draft(), creator: TOKEN })],
+    ["stretched image", () => {
+      const value = draft();
+      value.bannerImage.width = 0;
+      return value;
+    }],
+  ])("rejects %s", (_label, create) => {
+    expect(() => parseCreatorArticleDraftV1(create())).toThrow();
+  });
+
+  it("rejects duplicated or unsupported marks", () => {
+    const value = draft();
+    const paragraph = value.document.content[0] as typeof value.document.content[0] & {
+      content: { marks: unknown[] }[];
+    };
+    paragraph.content[0].marks.push({ type: "bold" });
+    expect(() => parseCreatorArticleDraftV1(value)).toThrow(/duplicated/u);
+  });
+
+  it("validates published revision and timestamps", () => {
+    const value = {
+      ...draft(),
+      schemaVersion: "programmable.creator-article.v1",
+      revision: 2,
+      status: "published",
+      createdAt: "2026-08-21T00:00:00.000Z",
+      updatedAt: "2026-08-21T00:01:00.000Z",
+    };
+    expect(parseCreatorArticleV1(value).revision).toBe(2);
+    expect(() => parseCreatorArticleV1({ ...value, revision: 0 })).toThrow();
+  });
+
+  it("uses the readable domain while retaining HTTPS validation", () => {
+    expect(displayHttpsLinkV1("https://www.Programmable.market/path?q=1"))
+      .toBe("programmable.market");
+    expect(isAllowedArticleHrefV1("https://programmable.market")).toBe(true);
+    expect(isAllowedArticleHrefV1("http://programmable.market")).toBe(false);
+    expect(isAllowedArticleHrefV1("javascript:alert(1)")).toBe(false);
+  });
+});

--- a/tests/creator-article-contract.test.ts
+++ b/tests/creator-article-contract.test.ts
@@ -19,11 +19,11 @@ function draft() {
     tokenAddress: TOKEN.toLowerCase(),
     title: "Programmable, by its creators",
     bannerImage: {
-      url: "https://example.com/banner.webp",
+      url: "https://programmable.market/brand/programmable-final-x-banner-1500x500.png",
       alt: "Programmable floral landscape",
       caption: null,
-      width: 3000,
-      height: 1000,
+      width: 1500,
+      height: 500,
       size: "wide",
     },
     document: {
@@ -58,7 +58,7 @@ function draft() {
         {
           type: "articleImage",
           attrs: {
-            url: "https://example.com/article.webp",
+            url: "https://k2uoipt9wchjtz3h.public.blob.vercel-storage.com/creator-article-media/v1/eip155-1/0x7987f03462200b3d8a072e02c89a8a41dcb124ee/550e8400-e29b-41d4-a716-446655440000.inline.1800x1200.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.webp",
             alt: "Programmable launch interface",
             caption: "A launch surface",
             width: 1800,
@@ -126,6 +126,37 @@ describe("creator article v1 contract", () => {
     expect(() => parseCreatorArticleDraftV1(value)).toThrow(/duplicated/u);
   });
 
+  it.each([
+    ["an external image host", "https://tracker.example/article.webp", 1800, 1200],
+    [
+      "another token's media",
+      "https://k2uoipt9wchjtz3h.public.blob.vercel-storage.com/creator-article-media/v1/eip155-1/0x1111111111111111111111111111111111111111/550e8400-e29b-41d4-a716-446655440000.inline.1800x1200.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.webp",
+      1800,
+      1200,
+    ],
+    [
+      "a banner receipt used inline",
+      "https://k2uoipt9wchjtz3h.public.blob.vercel-storage.com/creator-article-media/v1/eip155-1/0x7987f03462200b3d8a072e02c89a8a41dcb124ee/550e8400-e29b-41d4-a716-446655440000.banner.1800x600.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.webp",
+      1800,
+      600,
+    ],
+    [
+      "dimensions that differ from the verified media path",
+      "https://k2uoipt9wchjtz3h.public.blob.vercel-storage.com/creator-article-media/v1/eip155-1/0x7987f03462200b3d8a072e02c89a8a41dcb124ee/550e8400-e29b-41d4-a716-446655440000.inline.1800x1200.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.webp",
+      1200,
+      800,
+    ],
+  ])("rejects %s", (_label, url, width, height) => {
+    const value = draft();
+    const image = value.document.content[3] as {
+      attrs: { url: string; width: number; height: number };
+    };
+    image.attrs.url = url;
+    image.attrs.width = width;
+    image.attrs.height = height;
+    expect(() => parseCreatorArticleDraftV1(value)).toThrow(/image/u);
+  });
+
   it("validates published revision and timestamps", () => {
     const value = {
       ...draft(),
@@ -145,5 +176,16 @@ describe("creator article v1 contract", () => {
     expect(isAllowedArticleHrefV1("https://programmable.market")).toBe(true);
     expect(isAllowedArticleHrefV1("http://programmable.market")).toBe(false);
     expect(isAllowedArticleHrefV1("javascript:alert(1)")).toBe(false);
+  });
+
+  it("preserves a non-empty whitespace text node emitted after an autolink", () => {
+    const value = draft();
+    const paragraph = value.document.content[0] as {
+      content: unknown[];
+    };
+    paragraph.content.push({ type: "text", text: " " });
+    const parsed = parseCreatorArticleDraftV1(value);
+    expect((parsed.document.content[0] as { content?: readonly unknown[] }).content)
+      .toHaveLength(2);
   });
 });

--- a/tests/creator-article-editor.test.ts
+++ b/tests/creator-article-editor.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  cleanCreatorArticleEditorDocumentV1,
-  standaloneArticleLinkPasteV1,
-} from "../components/creator-article-editor";
+import * as creatorArticleEditor from "../components/creator-article-editor";
 import { parseCreatorArticleDraftV1 } from
   "../lib/creator-article/contract-v1";
 
 const TOKEN = "0x7987f03462200b3D8A072E02C89A8A41dCB124EE";
+const {
+  cleanCreatorArticleEditorDocumentV1,
+  standaloneArticleLinkPasteV1,
+} = creatorArticleEditor;
 
 describe("creator article editor normalization", () => {
   it("turns a standalone HTTPS paste into a readable bound link", () => {
@@ -26,7 +27,7 @@ describe("creator article editor normalization", () => {
       content: [{
         type: "articleImage",
         attrs: {
-          url: "https://assets.example/image.webp",
+          url: "https://k2uoipt9wchjtz3h.public.blob.vercel-storage.com/creator-article-media/v1/eip155-1/0x7987f03462200b3d8a072e02c89a8a41dcb124ee/550e8400-e29b-41d4-a716-446655440000.inline.1200x800.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.webp",
           alt: "Project image",
           caption: null,
           width: 1200,
@@ -48,7 +49,7 @@ describe("creator article editor normalization", () => {
     expect(parsed.document.content[0]).toEqual({
       type: "articleImage",
       attrs: {
-        url: "https://assets.example/image.webp",
+        url: "https://k2uoipt9wchjtz3h.public.blob.vercel-storage.com/creator-article-media/v1/eip155-1/0x7987f03462200b3d8a072e02c89a8a41dcb124ee/550e8400-e29b-41d4-a716-446655440000.inline.1200x800.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.webp",
         alt: "Project image",
         caption: null,
         width: 1200,
@@ -63,5 +64,57 @@ describe("creator article editor normalization", () => {
       type: "articleImage",
       attrs: { status: "uploading" },
     })).toThrow(/uploads/u);
+  });
+
+  it("shortens an autolinked raw HTTPS URL without changing its destination", () => {
+    expect(cleanCreatorArticleEditorDocumentV1({
+      type: "doc",
+      content: [{
+        type: "paragraph",
+        content: [{
+          type: "text",
+          text: "https://www.Programmable.market/about?from=article",
+          marks: [{
+            type: "link",
+            attrs: { href: "https://www.programmable.market/about?from=article" },
+          }],
+        }],
+      }],
+    })).toEqual({
+      type: "doc",
+      content: [{
+        type: "paragraph",
+        content: [{
+          type: "text",
+          text: "programmable.market",
+          marks: [{
+            type: "link",
+            attrs: { href: "https://www.programmable.market/about?from=article" },
+          }],
+        }],
+      }],
+    });
+  });
+
+  it("detects unpublished changes and treats the published snapshot as clean", () => {
+    const fingerprint = (creatorArticleEditor as unknown as {
+      creatorArticleEditorFingerprintV1(input: unknown): string;
+    }).creatorArticleEditorFingerprintV1;
+    expect(typeof fingerprint).toBe("function");
+    const baseline = fingerprint({
+      title: "Project story",
+      bannerImage: null,
+      document: { type: "doc", content: [{ type: "paragraph" }] },
+    });
+    expect(fingerprint({
+      title: "Project story",
+      bannerImage: null,
+      document: { type: "doc", content: [{ type: "paragraph" }] },
+    })).toBe(baseline);
+    expect(fingerprint({
+      title: "Updated project story",
+      bannerImage: null,
+      document: { type: "doc", content: [{ type: "paragraph" }] },
+    })).not.toBe(baseline);
   });
 });

--- a/tests/creator-article-editor.test.ts
+++ b/tests/creator-article-editor.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cleanCreatorArticleEditorDocumentV1,
+  standaloneArticleLinkPasteV1,
+} from "../components/creator-article-editor";
+import { parseCreatorArticleDraftV1 } from
+  "../lib/creator-article/contract-v1";
+
+const TOKEN = "0x7987f03462200b3D8A072E02C89A8A41dCB124EE";
+
+describe("creator article editor normalization", () => {
+  it("turns a standalone HTTPS paste into a readable bound link", () => {
+    expect(standaloneArticleLinkPasteV1(" https://www.Programmable.market/path?q=1 "))
+      .toEqual({
+        href: "https://www.programmable.market/path?q=1",
+        text: "programmable.market",
+      });
+    expect(standaloneArticleLinkPasteV1("http://programmable.market")).toBeNull();
+    expect(standaloneArticleLinkPasteV1("See https://programmable.market")).toBeNull();
+  });
+
+  it("removes editor-only image state before server validation", () => {
+    const document = cleanCreatorArticleEditorDocumentV1({
+      type: "doc",
+      content: [{
+        type: "articleImage",
+        attrs: {
+          url: "https://assets.example/image.webp",
+          alt: "Project image",
+          caption: null,
+          width: 1200,
+          height: 800,
+          size: "wide",
+          uploadId: "temporary",
+          status: "ready",
+        },
+      }],
+    });
+    const parsed = parseCreatorArticleDraftV1({
+      schemaVersion: "programmable.creator-article-draft.v1",
+      chainId: 1,
+      tokenAddress: TOKEN,
+      title: "A project story",
+      bannerImage: null,
+      document,
+    });
+    expect(parsed.document.content[0]).toEqual({
+      type: "articleImage",
+      attrs: {
+        url: "https://assets.example/image.webp",
+        alt: "Project image",
+        caption: null,
+        width: 1200,
+        height: 800,
+        size: "wide",
+      },
+    });
+  });
+
+  it("refuses to publish an image placeholder", () => {
+    expect(() => cleanCreatorArticleEditorDocumentV1({
+      type: "articleImage",
+      attrs: { status: "uploading" },
+    })).toThrow(/uploads/u);
+  });
+});

--- a/tests/creator-article-image.test.ts
+++ b/tests/creator-article-image.test.ts
@@ -1,0 +1,44 @@
+import sharp from "sharp";
+import { describe, expect, it } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { vi } from "vitest";
+import {
+  inspectCreatorArticleImageOutputV1,
+  verifyAndTransformCreatorArticleImageV1,
+} from "../lib/server/creator-article/image.server";
+
+async function png(width: number, height: number) {
+  return new Uint8Array(await sharp({
+    create: { width, height, channels: 4, background: "#7aa7ff" },
+  }).png().withMetadata({ orientation: 6 }).toBuffer());
+}
+
+describe("creator article image boundary", () => {
+  it("strips metadata and preserves inline aspect ratio", async () => {
+    const result = await verifyAndTransformCreatorArticleImageV1({
+      bytes: await png(1200, 800), kind: "inline",
+    });
+    expect(result.contentType).toBe("image/webp");
+    expect(result.width / result.height).toBeCloseTo(800 / 1200, 2);
+    const { bytes, ...receipt } = result;
+    await expect(inspectCreatorArticleImageOutputV1(bytes, receipt))
+      .resolves.toBeUndefined();
+    const metadata = await sharp(result.bytes).metadata();
+    expect(metadata.exif).toBeUndefined();
+  });
+
+  it("creates an exact responsive 3:1 banner", async () => {
+    const result = await verifyAndTransformCreatorArticleImageV1({
+      bytes: await png(3600, 2400), kind: "banner",
+    });
+    expect(result.width / result.height).toBe(3);
+  });
+
+  it("rejects malformed and animated input", async () => {
+    await expect(verifyAndTransformCreatorArticleImageV1({
+      bytes: new Uint8Array([1, 2, 3]), kind: "inline",
+    })).rejects.toThrow();
+  });
+});

--- a/tests/creator-article-media-api.test.ts
+++ b/tests/creator-article-media-api.test.ts
@@ -1,0 +1,83 @@
+import sharp from "sharp";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { createCreatorArticleMediaUploadHandlerV1 } from
+  "../lib/server/creator-article/media-api.server";
+
+const TOKEN = "0x3333333333333333333333333333333333333333" as const;
+const CREATOR = "0x1111111111111111111111111111111111111111" as const;
+const HOST = "k2uoipt9wchjtz3h.public.blob.vercel-storage.com";
+
+describe("creator article media API", () => {
+  it("returns content-bound media whose path binds token, kind, dimensions and digest", async () => {
+    const source = await sharp({
+      create: {
+        width: 90,
+        height: 60,
+        channels: 4,
+        background: { r: 210, g: 120, b: 170, alpha: 1 },
+      },
+    }).png().toBuffer();
+    let stored: Uint8Array<ArrayBufferLike> = new Uint8Array();
+    let storedPath = "";
+    const handler = createCreatorArticleMediaUploadHandlerV1({
+      authenticator: {
+        authenticate: vi.fn().mockResolvedValue({
+          privyUserId: "user",
+          privySessionId: "session",
+          wallets: [CREATOR],
+        }),
+      },
+      authorityReader: {
+        read: vi.fn().mockResolvedValue([{
+          chainId: 1,
+          tokenAddress: TOKEN,
+          creatorAddress: CREATOR,
+          source: "envio-classic-v3",
+          name: "Project",
+          symbol: "PROJECT",
+          imageUrl: null,
+        }]),
+      },
+      media: {
+        async put(pathname, bytes) {
+          storedPath = pathname;
+          stored = bytes;
+          return {
+            url: `https://${HOST}/${pathname}`,
+            downloadUrl: `https://${HOST}/${pathname}?download=1`,
+            pathname,
+            contentType: "image/webp",
+            contentDisposition: "inline",
+            etag: "etag-1",
+          };
+        },
+        async read() {
+          return stored;
+        },
+      },
+    });
+    const form = new FormData();
+    form.set("kind", "inline");
+    form.set("file", new File([source], "discord.png", { type: "image/png" }));
+
+    const response = await handler(new Request(
+      `https://programmable.market/api/profile/projects/${TOKEN}/article/media`,
+      { method: "POST", body: form },
+    ), TOKEN);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(storedPath).toMatch(new RegExp(
+      `^creator-article-media/v1/eip155-1/${TOKEN}/[0-9a-f-]{36}\\.inline\\.90x60\\.[0-9a-f]{64}\\.webp$`,
+    ));
+    expect(body.media).toEqual(expect.objectContaining({
+      url: `https://${HOST}/${storedPath}`,
+      width: 90,
+      height: 60,
+      kind: "inline",
+    }));
+  });
+});

--- a/tests/creator-article-renderer.test.ts
+++ b/tests/creator-article-renderer.test.ts
@@ -1,0 +1,52 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { CreatorArticle } from "../components/creator-article";
+import { parseCreatorArticleV1 } from "../lib/creator-article/contract-v1";
+
+const article = parseCreatorArticleV1({
+  schemaVersion: "programmable.creator-article.v1",
+  chainId: 1,
+  tokenAddress: "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
+  revision: 1,
+  status: "published",
+  title: "Programmable, by its creators",
+  bannerImage: null,
+  document: {
+    type: "doc",
+    content: [
+      {
+        type: "heading",
+        attrs: { level: 2 },
+        content: [{ type: "text", text: "A public story" }],
+      },
+      {
+        type: "paragraph",
+        content: [{
+          type: "text",
+          text: "programmable.market",
+          marks: [{ type: "link", attrs: { href: "https://programmable.market/" } }],
+        }],
+      },
+    ],
+  },
+  createdAt: "2026-08-21T00:00:00.000Z",
+  updatedAt: "2026-08-21T00:00:00.000Z",
+});
+
+describe("creator article public renderer", () => {
+  it("renders semantic content and safe external links", () => {
+    const html = renderToStaticMarkup(createElement(CreatorArticle, { article }));
+    expect(html).toContain("<article");
+    expect(html).toContain("<h3><span>A public story</span></h3>");
+    expect(html).toContain('href="https://programmable.market/"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).not.toContain("dangerouslySetInnerHTML");
+  });
+
+  it("renders no placeholder when the article is absent", () => {
+    expect(renderToStaticMarkup(createElement(CreatorArticle, { article: null })))
+      .toBe("");
+  });
+});

--- a/tests/creator-article-storage.test.ts
+++ b/tests/creator-article-storage.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { vi } from "vitest";
+import { parseCreatorArticleDraftV1 } from "../lib/creator-article/contract-v1";
+import {
+  CreatorArticleBlobPreconditionErrorV1,
+  createCreatorArticleStoreV1,
+} from "../lib/server/creator-article/storage.server";
+
+const TOKEN = "0x7987f03462200b3D8A072E02C89A8A41dCB124EE" as const;
+const CREATOR = "0x1111111111111111111111111111111111111111" as const;
+
+function draft(title = "Programmable") {
+  return parseCreatorArticleDraftV1({
+    schemaVersion: "programmable.creator-article-draft.v1",
+    chainId: 1,
+    tokenAddress: TOKEN,
+    title,
+    bannerImage: null,
+    document: {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "A creator story." }] }],
+    },
+  });
+}
+
+function memoryStore() {
+  const records = new Map<string, { text: string; etag: string }>();
+  let version = 0;
+  return {
+    records,
+    boundary: {
+      async read(pathname: string) {
+        return records.get(pathname) ?? null;
+      },
+      async write(input: { pathname: string; text: string; ifMatch: string | null; immutable: boolean }) {
+        const existing = records.get(input.pathname);
+        if (input.immutable ? existing !== undefined : input.ifMatch === null ? existing !== undefined : existing?.etag !== input.ifMatch) {
+          throw new CreatorArticleBlobPreconditionErrorV1();
+        }
+        const value = { text: input.text, etag: `etag-${++version}` };
+        records.set(input.pathname, value);
+        return { pathname: input.pathname, etag: value.etag };
+      },
+    },
+  };
+}
+
+describe("creator article Blob revision store", () => {
+  it("creates and reads an immutable first revision", async () => {
+    const memory = memoryStore();
+    const store = createCreatorArticleStoreV1({
+      blob: memory.boundary,
+      now: () => new Date("2026-08-21T00:00:00.000Z"),
+    });
+    expect(await store.readCurrent({ chainId: 1, tokenAddress: TOKEN })).toBeNull();
+    const published = await store.publish({
+      draft: draft(), creatorAddress: CREATOR, expectedEtag: null,
+    });
+    expect(published.article.revision).toBe(1);
+    expect(published.article.createdAt).toBe("2026-08-21T00:00:00.000Z");
+    expect([...memory.records.keys()]).toEqual(expect.arrayContaining([
+      expect.stringMatching(/\/revisions\/[0-9a-f]{64}\.json$/u),
+      expect.stringMatching(/\/current\.json$/u),
+    ]));
+  });
+
+  it("updates with the exact ETag and rejects a stale editor", async () => {
+    const memory = memoryStore();
+    let timestamp = "2026-08-21T00:00:00.000Z";
+    const store = createCreatorArticleStoreV1({
+      blob: memory.boundary,
+      now: () => new Date(timestamp),
+    });
+    const first = await store.publish({ draft: draft(), creatorAddress: CREATOR, expectedEtag: null });
+    timestamp = "2026-08-21T01:00:00.000Z";
+    const second = await store.publish({ draft: draft("Updated"), creatorAddress: CREATOR, expectedEtag: first.etag });
+    expect(second.article.revision).toBe(2);
+    expect(second.article.createdAt).toBe(first.article.createdAt);
+    await expect(store.publish({
+      draft: draft("Stale"), creatorAddress: CREATOR, expectedEtag: first.etag,
+    })).rejects.toMatchObject({ name: "CreatorArticleRevisionConflictV1" });
+  });
+
+  it("rejects a malformed pointer instead of selecting arbitrary content", async () => {
+    const memory = memoryStore();
+    memory.records.set(
+      `creator-articles/v1/eip155-1/${TOKEN.toLowerCase()}/current.json`,
+      { text: JSON.stringify({ schemaVersion: "wrong" }), etag: "bad" },
+    );
+    const store = createCreatorArticleStoreV1({ blob: memory.boundary });
+    await expect(store.readCurrent({ chainId: 1, tokenAddress: TOKEN })).rejects.toThrow(/pointer/u);
+  });
+});

--- a/tests/explore-interface-preview.test.ts
+++ b/tests/explore-interface-preview.test.ts
@@ -3,11 +3,20 @@ import { describe, expect, it } from "vitest";
 import {
   EXPLORE_PREVIEW_TOKENS,
   getExplorePreviewChart,
+  getExplorePreviewCreatorArticle,
   getExplorePreviewProject,
 } from "../components/explore-preview-data";
 import { isInterfacePreviewHost } from "../components/interface-preview";
 
 describe("Explore interface preview", () => {
+  it("previews the exact Main-token example article only on its token page", () => {
+    const article = getExplorePreviewCreatorArticle(
+      "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
+    );
+    expect(article?.title).toBe("Programmable: tokens with something to do");
+    expect(getExplorePreviewCreatorArticle(EXPLORE_PREVIEW_TOKENS[0]!.tokenAddress))
+      .toBeNull();
+  });
   it("is available only on local browser hosts", () => {
     expect(isInterfacePreviewHost("127.0.0.1")).toBe(true);
     expect(isInterfacePreviewHost("localhost")).toBe(true);

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import * as profileProjects from "../components/profile-projects";
+
+const project = {
+  chainId: 1 as const,
+  tokenAddress: "0x3333333333333333333333333333333333333333" as const,
+  name: "Project",
+  symbol: "PROJECT",
+  imageUrl: null,
+  source: "envio-classic-v3" as const,
+  article: null,
+};
+
+describe("My projects editor opening", () => {
+  it("turns an API failure into a user-readable rejected action", async () => {
+    const load = (profileProjects as unknown as {
+      loadCreatorArticleEditorV1(
+        candidate: typeof project,
+        getAuthHeaders: () => Promise<Record<string, string>>,
+        request: typeof fetch,
+      ): Promise<unknown>;
+    }).loadCreatorArticleEditorV1;
+    expect(typeof load).toBe("function");
+    await expect(load(
+      project,
+      async () => ({ Authorization: "Bearer token", "X-Privy-Identity-Token": "identity" }),
+      async () => new Response(JSON.stringify({ code: "creator_article_unavailable" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      }),
+    )).rejects.toThrow("Creator article unavailable");
+  });
+
+  it("returns the verified article and its exact ETag", async () => {
+    const load = (profileProjects as unknown as {
+      loadCreatorArticleEditorV1(
+        candidate: typeof project,
+        getAuthHeaders: () => Promise<Record<string, string>>,
+        request: typeof fetch,
+      ): Promise<{ article: unknown; etag: string | null }>;
+    }).loadCreatorArticleEditorV1;
+    expect(typeof load).toBe("function");
+    const article = {
+      schemaVersion: "programmable.creator-article.v1",
+      chainId: 1,
+      tokenAddress: project.tokenAddress,
+      revision: 1,
+      status: "published",
+      title: "Project story",
+      bannerImage: null,
+      document: { type: "doc", content: [{ type: "paragraph" }] },
+      createdAt: "2026-08-21T00:00:00.000Z",
+      updatedAt: "2026-08-21T00:00:00.000Z",
+    };
+    await expect(load(
+      project,
+      async () => ({ Authorization: "Bearer token", "X-Privy-Identity-Token": "identity" }),
+      async () => new Response(JSON.stringify({ article }), {
+        status: 200,
+        headers: { "content-type": "application/json", etag: "etag-1" },
+      }),
+    )).resolves.toEqual({ project, article, etag: "etag-1" });
+  });
+});

--- a/tests/programmable-creator-article-example.test.ts
+++ b/tests/programmable-creator-article-example.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROGRAMMABLE_MAIN_TOKEN_ADDRESS,
+  programmableCreatorArticleExampleV1,
+} from "../lib/creator-article/programmable-example-v1";
+
+describe("Programmable Main-token creator article example", () => {
+  it("is a strict factual image-rich draft bound to the exact Main token", () => {
+    const draft = programmableCreatorArticleExampleV1();
+    expect(draft.tokenAddress).toBe(PROGRAMMABLE_MAIN_TOKEN_ADDRESS);
+    expect(draft.bannerImage).toMatchObject({ width: 1500, height: 500, size: "wide" });
+    expect(draft.document.content.some((block) => block.type === "articleImage")).toBe(true);
+    expect(JSON.stringify(draft)).not.toMatch(/unruggable|guaranteed|partnered/iu);
+  });
+});

--- a/tests/token-page-ssr.test.ts
+++ b/tests/token-page-ssr.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/app/api/explore/token/route", () => ({ GET: vi.fn() }));
@@ -13,6 +15,14 @@ afterEach(() => {
 });
 
 describe("token detail initial server read", () => {
+  it("places the bounded detail read behind an immediate Suspense shell", () => {
+    const source = readFileSync(
+      join(process.cwd(), "app/token/[address]/page.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("<Suspense fallback={<TokenDetailShell />}> ".trim());
+    expect(source).toContain("<InitialTokenDetail address={address} />");
+  });
   it("returns at the total deadline and consumes the aborted read", async () => {
     vi.useFakeTimers();
     let readSignal: AbortSignal | undefined;

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -8,6 +8,7 @@ import { ApplicantRefreshUserUnavailableErrorV1 } from
 
 type WalletProviderContract = {
   shouldEagerLoadWalletRuntime: (pathname: string) => boolean;
+  shouldIdlePreloadWalletRuntime: (pathname: string) => boolean;
   assertExternalWalletAuthorityCurrent: (input: Readonly<{
     expectedAccount: `0x${string}`;
     expectedChainId: string;
@@ -144,10 +145,12 @@ describe("wallet recovery state", () => {
       "/launch/review",
       "/profile",
       "/profile/settings",
-      "/token/0x7987f03462200b3d8a072e02c89a8a41dcb124ee",
     ]) {
       expect(subject.shouldEagerLoadWalletRuntime(pathname)).toBe(true);
     }
+    const tokenPath = "/token/0x7987f03462200b3d8a072e02c89a8a41dcb124ee";
+    expect(subject.shouldEagerLoadWalletRuntime(tokenPath)).toBe(false);
+    expect(subject.shouldIdlePreloadWalletRuntime(tokenPath)).toBe(true);
   });
 
   it("keeps Privy behind an explicit dynamic runtime boundary", () => {


### PR DESCRIPTION
## Summary
- add creator-owned, editable project articles below verified token pages
- support safe rich text, links, cover and inline image uploads with exact token/media binding
- expose My Projects editing from Profile and seed the official Programmable example
- stream the token detail shell and harden modal, errors, touch targets, focus, preview, and discard behavior

## Verification
- 43 focused creator-article/profile tests passed
- changed-path ESLint passed
- TypeScript passed
- production build, candidate-neutrality, and bundle scan passed
- rendered desktop/mobile interaction QA passed with clean console/network evidence

## Release
Target: production. Merge and deployment are explicitly authorized after required checks pass.