### PR TITLE
Fix Creator workspace session refresh

### DIFF
--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -46,17 +46,13 @@ export function ProfileProjects() {
   const [opening, setOpening] = useState<string | null>(null);
   const [projectError, setProjectError] = useState("");
 
-  const getAuthHeaders = useCallback(async () => {
-    const [accessToken, identityToken] = await Promise.all([
-      getAccessToken(),
-      getIdentityToken(),
-    ]);
-    if (!accessToken || !identityToken) throw new Error("Reconnect your wallet and try again");
-    return {
-      Authorization: `Bearer ${accessToken}`,
-      "X-Privy-Identity-Token": identityToken,
-    };
-  }, [getAccessToken, getIdentityToken]);
+  const getAuthHeaders = useCallback(
+    () => acquireCreatorArticleAuthHeadersV1({
+      getAccessToken,
+      getIdentityToken,
+    }),
+    [getAccessToken, getIdentityToken],
+  );
 
   const loadProjects = useCallback(async (signal?: AbortSignal) => {
     if (!wallet) return;
@@ -176,6 +172,24 @@ export function ProfileProjects() {
       ) : null}
     </section>
   );
+}
+
+export async function acquireCreatorArticleAuthHeadersV1(input: Readonly<{
+  getAccessToken: () => Promise<string | null>;
+  getIdentityToken: () => Promise<string | null>;
+}>): Promise<AuthHeaders> {
+  // Privy refreshes the user and identity token through `/users/me`. Read the
+  // access token only after that refresh so both headers describe one current
+  // session rather than racing the refresh.
+  const identityToken = await input.getIdentityToken();
+  const accessToken = await input.getAccessToken();
+  if (!accessToken || !identityToken) {
+    throw new Error("Reconnect your wallet and try again");
+  }
+  return Object.freeze({
+    Authorization: `Bearer ${accessToken}`,
+    "X-Privy-Identity-Token": identityToken,
+  });
 }
 
 export async function loadCreatorArticleEditorV1(

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -13,6 +13,34 @@ const project = {
 };
 
 describe("My projects editor opening", () => {
+  it("refreshes the Privy identity before reading the bound access token", async () => {
+    const acquire = (profileProjects as unknown as {
+      acquireCreatorArticleAuthHeadersV1(input: Readonly<{
+        getAccessToken: () => Promise<string | null>;
+        getIdentityToken: () => Promise<string | null>;
+      }>): Promise<Record<string, string>>;
+    }).acquireCreatorArticleAuthHeadersV1;
+    expect(typeof acquire).toBe("function");
+
+    let identityCurrent = false;
+    const events: string[] = [];
+    await expect(acquire({
+      getIdentityToken: async () => {
+        events.push("identity");
+        identityCurrent = true;
+        return "identity-token";
+      },
+      getAccessToken: async () => {
+        events.push("access");
+        return identityCurrent ? "access-token" : null;
+      },
+    })).resolves.toEqual({
+      Authorization: "Bearer access-token",
+      "X-Privy-Identity-Token": "identity-token",
+    });
+    expect(events).toEqual(["identity", "access"]);
+  });
+
   it("turns an API failure into a user-readable rejected action", async () => {
     const load = (profileProjects as unknown as {
       loadCreatorArticleEditorV1(


### PR DESCRIPTION
## Summary
- refresh the Privy identity before acquiring the bound access token
- prevent My projects from failing before `/api/profile/projects` is requested
- add a regression test for the session ordering

## Validation
- `npx vitest run tests/profile-projects-editor-open.test.ts tests/wallet-state.test.ts`
- `npx eslint components/profile-projects.tsx tests/profile-projects-editor-open.test.ts`
- `npm run typecheck`
- `npm run build`