### PR TITLE
Fix Creator projects when Privy omits identity token

### DIFF
--- a/components/creator-article-editor.tsx
+++ b/components/creator-article-editor.tsx
@@ -58,7 +58,7 @@ import styles from "./creator-article-editor.module.css";
 
 type AuthHeaders = Readonly<{
   Authorization: string;
-  "X-Privy-Identity-Token": string;
+  "X-Privy-Identity-Token"?: string;
 }>;
 
 type ArticleEditorProps = Readonly<{

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -35,7 +35,7 @@ type EditorState = Readonly<{
 
 type AuthHeaders = Readonly<{
   Authorization: string;
-  "X-Privy-Identity-Token": string;
+  "X-Privy-Identity-Token"?: string;
 }>;
 
 export function ProfileProjects() {
@@ -183,12 +183,14 @@ export async function acquireCreatorArticleAuthHeadersV1(input: Readonly<{
   // session rather than racing the refresh.
   const identityToken = await input.getIdentityToken();
   const accessToken = await input.getAccessToken();
-  if (!accessToken || !identityToken) {
+  if (!accessToken) {
     throw new Error("Reconnect your wallet and try again");
   }
   return Object.freeze({
     Authorization: `Bearer ${accessToken}`,
-    "X-Privy-Identity-Token": identityToken,
+    ...(identityToken
+      ? { "X-Privy-Identity-Token": identityToken }
+      : {}),
   });
 }
 

--- a/lib/server/creator-article/wallet-principal.server.ts
+++ b/lib/server/creator-article/wallet-principal.server.ts
@@ -104,19 +104,26 @@ export function createWalletPrincipalAuthenticatorFromBoundaryV1(
   return Object.freeze({
     async authenticate(request: Request): Promise<AuthenticatedWalletPrincipalV1> {
       const accessToken = bearerToken(request.headers.get("authorization"));
-      const identityToken = boundedToken(
-        request.headers.get("x-privy-identity-token"),
-        "identity_token_invalid",
-      );
+      const identityHeader = request.headers.get("x-privy-identity-token");
+      // Privy can return a current user without issuing an identity token.
+      // The access token remains mandatory and verified; when an identity
+      // token is available, bind it to the exact same user and session.
+      const identityToken = identityHeader === null
+        ? null
+        : boundedToken(identityHeader, "identity_token_invalid");
       try {
         const [access, identity] = await Promise.all([
           input.boundary.verifyAccessToken(accessToken),
-          input.boundary.verifyIdentityToken(identityToken),
+          identityToken === null
+            ? Promise.resolve(null)
+            : input.boundary.verifyIdentityToken(identityToken),
         ]);
         if (
           access.appId !== input.appId
-          || access.userId !== identity.userId
-          || access.sessionId !== identity.sessionId
+          || (identity !== null && (
+            access.userId !== identity.userId
+            || access.sessionId !== identity.sessionId
+          ))
         ) throw new TypeError("Privy token binding mismatch");
         const user = await input.boundary.getCurrentUser(access.userId);
         if (user.id !== access.userId) throw new TypeError("Privy user mismatch");

--- a/tests/creator-article-authority.test.ts
+++ b/tests/creator-article-authority.test.ts
@@ -93,6 +93,36 @@ describe("creator article wallet principal", () => {
     expect(principal.wallets).toEqual([CREATOR]);
   });
 
+  it("accepts a verified access session when Privy omits the identity token", async () => {
+    const verifyIdentityToken = vi.fn();
+    const authenticator = createWalletPrincipalAuthenticatorFromBoundaryV1({
+      appId: "app",
+      boundary: {
+        verifyAccessToken: vi.fn().mockResolvedValue({
+          appId: "app", userId: "did:privy:user", sessionId: "session",
+        }),
+        verifyIdentityToken,
+        getCurrentUser: vi.fn().mockResolvedValue({
+          id: "did:privy:user",
+          linkedAccounts: [
+            { type: "wallet", chainType: "ethereum", address: CREATOR },
+          ],
+        }),
+      },
+    });
+    const accessOnlyRequest = new Request(
+      "https://programmable.market/api/profile/projects",
+      { headers: { authorization: `Bearer ${"a".repeat(32)}` } },
+    );
+
+    await expect(authenticator.authenticate(accessOnlyRequest)).resolves.toEqual({
+      privyUserId: "did:privy:user",
+      privySessionId: "session",
+      wallets: [CREATOR],
+    });
+    expect(verifyIdentityToken).not.toHaveBeenCalled();
+  });
+
   it("rejects mismatched sessions and missing Ethereum wallets", async () => {
     const base = {
       verifyAccessToken: vi.fn().mockResolvedValue({ appId: "app", userId: "u", sessionId: "s1" }),

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -41,6 +41,20 @@ describe("My projects editor opening", () => {
     expect(events).toEqual(["identity", "access"]);
   });
 
+  it("uses the verified access token when Privy omits an identity token", async () => {
+    const acquire = (profileProjects as unknown as {
+      acquireCreatorArticleAuthHeadersV1(input: Readonly<{
+        getAccessToken: () => Promise<string | null>;
+        getIdentityToken: () => Promise<string | null>;
+      }>): Promise<Record<string, string>>;
+    }).acquireCreatorArticleAuthHeadersV1;
+
+    await expect(acquire({
+      getIdentityToken: async () => null,
+      getAccessToken: async () => "access-token",
+    })).resolves.toEqual({ Authorization: "Bearer access-token" });
+  });
+
   it("turns an API failure into a user-readable rejected action", async () => {
     const load = (profileProjects as unknown as {
       loadCreatorArticleEditorV1(


### PR DESCRIPTION
## Summary
- keep the verified Privy access token mandatory for Creator workspace APIs
- accept sessions when Privy returns a current user without an identity token
- preserve exact user/session binding whenever an identity token is present
- keep server-side current-user and linked-wallet authorization unchanged

## Root cause
The authenticated live `/users/me` response is `200` and contains the current user, but no `identity_token`; the client therefore aborted before `/api/profile/projects`.

## Validation
- 46 focused auth/API/wallet tests
- changed-path ESLint
- TypeScript
- production build