### PR TITLE
Polish creator workspace and article editor

### DIFF
--- a/components/creator-article-editor.module.css
+++ b/components/creator-article-editor.module.css
@@ -15,7 +15,7 @@
   border-radius: 1rem;
   box-shadow: 0 30px 90px rgb(0 0 0 / 55%);
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
   max-height: calc(100dvh - 2rem);
   max-width: 90rem;
   overflow: hidden;
@@ -33,6 +33,8 @@
 
 .dialogHeader {
   border-bottom: 1px solid rgb(255 255 255 / 10%);
+  gap: 1rem;
+  padding-block: 0.75rem;
 }
 
 .dialogHeader p,
@@ -47,6 +49,49 @@
 
 .dialogHeader h2 {
   font-size: 1.15rem;
+}
+
+.dialogIdentity {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.dialogIdentity > div:last-child {
+  min-width: 0;
+}
+
+.dialogIdentity p,
+.dialogIdentity h2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dialogArt {
+  align-items: center;
+  background: #17171c;
+  border-radius: 0.65rem;
+  display: flex;
+  flex: none;
+  height: 2.625rem;
+  justify-content: center;
+  outline: 1px solid rgb(255 255 255 / 12%);
+  outline-offset: -1px;
+  overflow: hidden;
+  position: relative;
+  width: 2.625rem;
+}
+
+.dialogArt img {
+  object-fit: cover;
+}
+
+.dialogArt span {
+  color: rgb(255 255 255 / 68%);
+  font-size: 0.7rem;
+  font-weight: 650;
 }
 
 .dialogHeader > button,
@@ -164,25 +209,28 @@
 
 .toolbar {
   align-items: center;
-  backdrop-filter: blur(14px);
-  background: rgb(15 15 20 / 92%);
-  border: 1px solid rgb(255 255 255 / 12%);
-  border-radius: 0.75rem;
+  background: #0e0e13;
+  border-bottom: 1px solid rgb(255 255 255 / 10%);
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.3rem;
-  margin: 0 auto 1.2rem;
-  max-width: 48rem;
-  padding: 0.45rem;
-  position: sticky;
-  top: 0;
-  z-index: 2;
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  padding: 0.45rem 1rem;
+  scrollbar-width: none;
+  z-index: 3;
+}
+
+.toolbar::-webkit-scrollbar {
+  display: none;
 }
 
 .toolbar > button {
   align-items: center;
   display: flex;
   justify-content: center;
+  flex: none;
   min-height: 2.75rem;
   min-width: 2.75rem;
   padding: 0.42rem 0.55rem;
@@ -200,9 +248,14 @@
 
 .linkControl {
   align-items: center;
+  background: rgb(255 255 255 / 4%);
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 0.55rem;
   display: flex;
+  flex: none;
   gap: 0.35rem;
   margin-inline-start: auto;
+  padding-inline-start: 0.65rem;
 }
 
 .linkControl input {
@@ -212,13 +265,17 @@
   font: inherit;
   font-size: 0.75rem;
   min-height: 2.75rem;
-  min-width: 10rem;
+  min-width: 8rem;
   outline: none;
 }
 
 .linkControl button {
+  border-block: 0;
+  border-inline-end: 0;
+  border-radius: 0 0.5rem 0.5rem 0;
   min-height: 2.75rem;
-  padding: 0.45rem 0.55rem;
+  padding: 0.45rem 0.7rem;
+  white-space: nowrap;
 }
 
 .linkControl:focus-within {
@@ -329,13 +386,6 @@
   padding: 0.45rem 0;
 }
 
-.pasteHint {
-  color: rgb(255 255 255 / 52%);
-  font-size: 0.72rem;
-  margin: -3.5rem auto 2rem;
-  max-width: 46rem;
-}
-
 .dialogFooter {
   border-top: 1px solid rgb(255 255 255 / 10%);
   gap: 1rem;
@@ -404,11 +454,14 @@
 @media (max-width: 42rem) {
   .backdrop { padding: 0; }
   .dialog { border-radius: 0; max-height: 100dvh; }
+  .dialogHeader { padding-inline: 0.75rem; }
+  .dialogIdentity p { max-width: 13rem; }
+  .toolbar { padding-inline: 0.75rem; }
   .editorPane { padding: 1rem; }
   .imageFields { grid-template-columns: 1fr; }
   .dialogFooter { align-items: stretch; flex-direction: column; }
   .dialogFooter div { margin-inline-start: 0; }
   .dialogFooter button { flex: 1; }
-  .linkControl { margin-inline-start: 0; width: 100%; }
+  .linkControl { flex: 0 0 14rem; margin-inline-start: 0; width: auto; }
   .linkControl input { flex: 1; min-width: 0; }
 }

--- a/components/creator-article-editor.tsx
+++ b/components/creator-article-editor.tsx
@@ -556,12 +556,53 @@ export default function CreatorArticleEditor({
         aria-describedby={notice ? "article-editor-notice" : undefined}
       >
         <header className={styles.dialogHeader}>
-          <div>
-            <p>{project.symbol ? `$${project.symbol}` : "Verified project"}</p>
-            <h2 id="article-editor-title">{initialArticle ? "Edit article" : "Create article"}</h2>
+          <div className={styles.dialogIdentity}>
+            <div className={styles.dialogArt}>
+              {project.imageUrl ? (
+                <Image src={project.imageUrl} alt="" fill sizes="42px" unoptimized />
+              ) : (
+                <span aria-hidden="true">{project.symbol?.slice(0, 2) ?? "P"}</span>
+              )}
+            </div>
+            <div>
+              <p>{project.symbol ? `$${project.symbol}` : "Verified project"} · Creator workspace</p>
+              <h2 id="article-editor-title">{initialArticle ? "Edit article" : "Create article"}</h2>
+            </div>
           </div>
           <button ref={closeButtonRef} type="button" aria-label="Close article editor" onClick={requestClose}><X aria-hidden="true" /></button>
         </header>
+
+        <div className={styles.toolbar} role="toolbar" aria-label="Article formatting">
+          <ToolbarButton label="Normal" active={editor?.isActive("paragraph") ?? false} onClick={() => editor?.chain().focus().unsetAllMarks().setParagraph().run()} />
+          <ToolbarIcon label="Bold" active={editor?.isActive("bold") ?? false} onClick={() => editor?.chain().focus().toggleBold().run()}><Bold /></ToolbarIcon>
+          <ToolbarIcon label="Italic" active={editor?.isActive("italic") ?? false} onClick={() => editor?.chain().focus().toggleItalic().run()}><Italic /></ToolbarIcon>
+          <ToolbarIcon label="Heading 2" active={editor?.isActive("heading", { level: 2 }) ?? false} onClick={() => editor?.chain().focus().toggleHeading({ level: 2 }).run()}><Heading2 /></ToolbarIcon>
+          <ToolbarIcon label="Heading 3" active={editor?.isActive("heading", { level: 3 }) ?? false} onClick={() => editor?.chain().focus().toggleHeading({ level: 3 }).run()}><Heading3 /></ToolbarIcon>
+          <ToolbarIcon label="Bullet list" active={editor?.isActive("bulletList") ?? false} onClick={() => editor?.chain().focus().toggleBulletList().run()}><List /></ToolbarIcon>
+          <ToolbarIcon label="Numbered list" active={editor?.isActive("orderedList") ?? false} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><ListOrdered /></ToolbarIcon>
+          <ToolbarIcon label="Undo" onClick={() => editor?.chain().focus().undo().run()}><Undo2 /></ToolbarIcon>
+          <ToolbarIcon label="Redo" onClick={() => editor?.chain().focus().redo().run()}><Redo2 /></ToolbarIcon>
+          <input ref={imageInputRef} hidden type="file" multiple accept="image/png,image/jpeg,image/webp,image/avif" onChange={(event) => {
+            const files = [...(event.target.files ?? [])];
+            event.target.value = "";
+            void uploadInlineImages(files);
+          }} />
+          <ToolbarIcon label="Add image" onClick={() => imageInputRef.current?.click()}><ImagePlus /></ToolbarIcon>
+          <div className={styles.linkControl}>
+            <LinkIcon aria-hidden="true" size={15} />
+            <input
+              value={linkValue}
+              aria-label="Link URL"
+              inputMode="url"
+              placeholder="Paste link"
+              onChange={(event) => setLinkValue(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") { event.preventDefault(); applyLink(); }
+              }}
+            />
+            <button type="button" onClick={applyLink}>Add link</button>
+          </div>
+        </div>
 
         <div className={styles.editorLayout}>
           <div className={styles.editorPane}>
@@ -593,33 +634,7 @@ export default function CreatorArticleEditor({
               </button>
             </div>
 
-            <div className={styles.toolbar} role="toolbar" aria-label="Article formatting">
-              <ToolbarButton label="Normal" active={editor?.isActive("paragraph") ?? false} onClick={() => editor?.chain().focus().unsetAllMarks().setParagraph().run()} />
-              <ToolbarIcon label="Bold" active={editor?.isActive("bold") ?? false} onClick={() => editor?.chain().focus().toggleBold().run()}><Bold /></ToolbarIcon>
-              <ToolbarIcon label="Italic" active={editor?.isActive("italic") ?? false} onClick={() => editor?.chain().focus().toggleItalic().run()}><Italic /></ToolbarIcon>
-              <ToolbarIcon label="Heading 2" active={editor?.isActive("heading", { level: 2 }) ?? false} onClick={() => editor?.chain().focus().toggleHeading({ level: 2 }).run()}><Heading2 /></ToolbarIcon>
-              <ToolbarIcon label="Heading 3" active={editor?.isActive("heading", { level: 3 }) ?? false} onClick={() => editor?.chain().focus().toggleHeading({ level: 3 }).run()}><Heading3 /></ToolbarIcon>
-              <ToolbarIcon label="Bullet list" active={editor?.isActive("bulletList") ?? false} onClick={() => editor?.chain().focus().toggleBulletList().run()}><List /></ToolbarIcon>
-              <ToolbarIcon label="Numbered list" active={editor?.isActive("orderedList") ?? false} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><ListOrdered /></ToolbarIcon>
-              <ToolbarIcon label="Undo" onClick={() => editor?.chain().focus().undo().run()}><Undo2 /></ToolbarIcon>
-              <ToolbarIcon label="Redo" onClick={() => editor?.chain().focus().redo().run()}><Redo2 /></ToolbarIcon>
-              <input ref={imageInputRef} hidden type="file" multiple accept="image/png,image/jpeg,image/webp,image/avif" onChange={(event) => {
-                const files = [...(event.target.files ?? [])];
-                event.target.value = "";
-                void uploadInlineImages(files);
-              }} />
-              <ToolbarIcon label="Add image" onClick={() => imageInputRef.current?.click()}><ImagePlus /></ToolbarIcon>
-              <div className={styles.linkControl}>
-                <LinkIcon aria-hidden="true" size={15} />
-                <input value={linkValue} inputMode="url" placeholder="https://domain.com" onChange={(event) => setLinkValue(event.target.value)} onKeyDown={(event) => {
-                  if (event.key === "Enter") { event.preventDefault(); applyLink(); }
-                }} />
-                <button type="button" onClick={applyLink}>Apply</button>
-              </div>
-            </div>
-
             <EditorContent editor={editor} />
-            <p className={styles.pasteHint}>Paste an image anywhere with CMD‑V or Ctrl‑V. Images keep their proportions on every screen.</p>
           </div>
 
           {showPreview && preview ? (

--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -1,132 +1,279 @@
 .section {
-  border-top: 1px solid rgb(255 255 255 / 10%);
-  margin-block: clamp(3rem, 6vw, 5.5rem);
-  padding-block-start: clamp(2rem, 4vw, 3.5rem);
+  background: var(--webde-surface, var(--profile-panel, #111));
+  border: 1px solid var(--webde-line, var(--profile-line, rgb(255 255 255 / 10%)));
+  border-radius: var(--webde-radius-card, 17px);
+  margin-block: clamp(2rem, 4vw, 3.5rem) 1rem;
+  min-width: 0;
+  padding: 20px;
 }
 
 .heading {
-  align-items: end;
+  align-items: center;
   display: flex;
+  gap: 14px;
   justify-content: space-between;
-  margin-block-end: 1.4rem;
+  margin-block-end: 12px;
+  min-width: 0;
 }
 
 .heading p {
-  color: rgb(255 255 255 / 48%);
-  font-size: 0.7rem;
-  letter-spacing: 0.15em;
-  margin: 0 0 0.35rem;
+  color: var(--muted, rgb(255 255 255 / 48%));
+  font-size: 10px;
+  font-weight: 620;
+  letter-spacing: 0.12em;
+  margin: 0 0 4px;
   text-transform: uppercase;
 }
 
 .heading h2 {
-  font-size: clamp(1.75rem, 4vw, 2.6rem);
-  letter-spacing: -0.045em;
+  font-size: 20px;
+  font-weight: 640;
+  letter-spacing: -0.026em;
+  line-height: 1.1;
   margin: 0;
 }
 
-.heading button,
+.headerActions,
+.pagination,
+.refresh,
+.actions {
+  align-items: center;
+  display: flex;
+}
+
+.headerActions {
+  flex: none;
+  gap: 5px;
+  margin-inline-start: auto;
+}
+
+.refresh,
+.pagination button,
 .actions button,
 .actions a {
   background: transparent;
-  border: 1px solid rgb(255 255 255 / 18%);
-  border-radius: 999px;
-  color: inherit;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  color: var(--text-soft, rgb(255 255 255 / 72%));
   cursor: pointer;
   font: inherit;
-  font-size: 0.78rem;
-  min-height: 2.75rem;
-  padding: 0.65rem 0.95rem;
+  font-size: 11px;
+  font-weight: 620;
+  min-height: 44px;
   text-decoration: none;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease,
+    opacity 150ms ease,
+    transform 120ms var(--ease-out, ease-out);
 }
 
-.heading button:hover,
-.actions button:hover,
-.actions a:hover {
-  border-color: rgb(255 255 255 / 48%);
+.refresh {
+  gap: 6px;
+  padding-inline: 10px;
 }
 
-.heading button:focus-visible,
-.actions button:focus-visible,
-.actions a:focus-visible {
-  outline: 2px solid #8fc5ff;
-  outline-offset: 3px;
+.pagination {
+  flex: none;
+  gap: 3px;
 }
 
-.grid {
+.pagination button {
+  justify-content: center;
+  padding: 0;
+  width: 44px;
+}
+
+.pagination > span {
+  color: var(--muted, rgb(255 255 255 / 52%));
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  min-width: 34px;
+  text-align: center;
+}
+
+.refresh:disabled,
+.pagination button:disabled,
+.actions button:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+
+.list {
   display: grid;
-  gap: 0.75rem;
+  gap: 3px;
+  min-width: 0;
 }
 
 .project {
   align-items: center;
-  border-bottom: 1px solid rgb(255 255 255 / 9%);
+  border-radius: 8px;
   display: grid;
-  gap: 1rem;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  padding-block: 1rem;
+  gap: 9px;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  min-height: 68px;
+  min-width: 0;
+  padding: 7px 8px;
+  transition: background-color 150ms ease;
 }
 
 .art {
   align-items: center;
-  background: #17171c;
-  border-radius: 0.65rem;
+  background: var(--surface-soft, #17171c);
+  border-radius: 10px;
   display: flex;
-  height: 3.75rem;
+  height: 42px;
   justify-content: center;
+  outline: 1px solid var(--liquid-glass-border, rgb(255 255 255 / 10%));
+  outline-offset: -1px;
   overflow: hidden;
   position: relative;
-  width: 3.75rem;
+  width: 42px;
 }
 
 .art img {
   object-fit: cover;
 }
 
+.art span {
+  color: var(--text-soft, rgb(255 255 255 / 72%));
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 11px;
+  font-weight: 650;
+}
+
 .copy {
   display: grid;
+  gap: 2px;
   min-width: 0;
 }
 
-.copy strong {
-  font-size: 1rem;
+.copy strong,
+.copy span,
+.copy small {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.copy span,
+.copy strong {
+  font-size: 13px;
+  font-weight: 640;
+  letter-spacing: -0.012em;
+}
+
+.copy span {
+  color: var(--muted, rgb(255 255 255 / 52%));
+  font-size: 12px;
+  font-weight: 540;
+}
+
 .copy small,
 .loading,
 .empty,
 .error {
-  color: rgb(255 255 255 / 52%);
-  font-size: 0.78rem;
+  color: var(--text-soft, rgb(255 255 255 / 62%));
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.3;
 }
 
 .actions {
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.actions button,
+.actions a {
   align-items: center;
-  display: flex;
-  gap: 0.5rem;
+  border-color: var(--webde-line, rgb(255 255 255 / 14%));
+  display: inline-flex;
+  justify-content: center;
+  padding-inline: 12px;
+  white-space: nowrap;
 }
 
 .actions button {
-  background: #f0eee8;
-  border-color: #f0eee8;
+  background: var(--brand-ivory, #f0eee8);
+  border-color: var(--brand-ivory, #f0eee8);
   color: #0a0a0c;
+}
+
+.loading,
+.empty,
+.error {
+  margin: 0;
+  min-height: 92px;
+  padding: 24px 8px;
 }
 
 .error {
   color: #ff9d9d;
 }
 
+.refresh:focus-visible,
+.pagination button:focus-visible,
+.actions button:focus-visible,
+.actions a:focus-visible {
+  outline: 2px solid #8fc5ff;
+  outline-offset: 2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .refresh:not(:disabled):hover,
+  .pagination button:not(:disabled):hover,
+  .actions a:hover {
+    background: var(--profile-subtle, rgb(255 255 255 / 6%));
+    border-color: var(--webde-line, rgb(255 255 255 / 16%));
+    color: var(--text, #fff);
+  }
+
+  .actions button:not(:disabled):hover {
+    filter: brightness(0.94);
+  }
+
+  .project:hover {
+    background: var(--profile-subtle, rgb(255 255 255 / 4%));
+  }
+}
+
 @media (max-width: 42rem) {
+  .section {
+    padding: 16px;
+  }
+
+  .heading {
+    align-items: flex-start;
+  }
+
+  .refresh span {
+    display: none;
+  }
+
   .project {
-    align-items: start;
-    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    grid-template-columns: 42px minmax(0, 1fr);
+    padding-block: 9px;
   }
 
   .actions {
     grid-column: 1 / -1;
+  }
+
+  .actions button,
+  .actions a {
+    flex: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .project,
+  .refresh,
+  .pagination button,
+  .actions button,
+  .actions a {
+    transition: none;
   }
 }

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -3,7 +3,8 @@
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getAddress, isAddress } from "viem";
 
 import { useWallet } from "@/components/wallet-provider";
@@ -12,10 +13,17 @@ import { parseCreatorArticleV1, type CreatorArticleV1 } from
 
 import styles from "./profile-projects.module.css";
 
+const loadCreatorArticleEditorModule = () =>
+  import("@/components/creator-article-editor");
+const preloadCreatorArticleEditorModule = () => {
+  void loadCreatorArticleEditorModule().catch(() => undefined);
+};
 const CreatorArticleEditor = dynamic(
-  () => import("@/components/creator-article-editor"),
+  loadCreatorArticleEditorModule,
   { ssr: false, loading: () => <p className={styles.loading}>Opening editor…</p> },
 );
+
+export const creatorProjectPageSize = 5;
 
 export type CreatorProjectSummaryV1 = Readonly<{
   chainId: 1;
@@ -25,6 +33,13 @@ export type CreatorProjectSummaryV1 = Readonly<{
   imageUrl: string | null;
   source: "envio-classic-v3" | "registry.custom-launched" | "official-main-token";
   article: Readonly<{ revision: number; title: string; updatedAt: string }> | null;
+}>;
+
+export type CreatorProjectMarketCapV1 = Readonly<{
+  tokenAddress: `0x${string}`;
+  usdWad: string | null;
+  ethWei: string | null;
+  label: string | null;
 }>;
 
 type EditorState = Readonly<{
@@ -38,13 +53,17 @@ type AuthHeaders = Readonly<{
   "X-Privy-Identity-Token"?: string;
 }>;
 
-export function ProfileProjects() {
+export function ProfileProjects({ marketCaps = [] }: Readonly<{
+  marketCaps?: readonly CreatorProjectMarketCapV1[];
+}>) {
   const { wallet, getAccessToken, getIdentityToken } = useWallet();
   const [projects, setProjects] = useState<readonly CreatorProjectSummaryV1[]>([]);
   const [phase, setPhase] = useState<"loading" | "ready" | "error">("loading");
   const [editor, setEditor] = useState<EditorState | null>(null);
   const [opening, setOpening] = useState<string | null>(null);
+  const [projectPage, setProjectPage] = useState(1);
   const [projectError, setProjectError] = useState("");
+  const editorRequestsRef = useRef(new Map<string, Promise<EditorState>>());
 
   const getAuthHeaders = useCallback(
     () => acquireCreatorArticleAuthHeadersV1({
@@ -64,7 +83,11 @@ export function ProfileProjects() {
       });
       const body: unknown = await response.json().catch(() => null);
       if (!response.ok) throw new Error(readError(body));
-      setProjects(parseProjectList(body));
+      const nextProjects = parseProjectList(body);
+      setProjects(nextProjects);
+      setProjectPage(1);
+      editorRequestsRef.current.clear();
+      if (nextProjects.length > 0) preloadCreatorArticleEditorModule();
       setPhase("ready");
     } catch {
       if (signal?.aborted) return;
@@ -82,11 +105,41 @@ export function ProfileProjects() {
     };
   }, [loadProjects, wallet]);
 
+  const pageData = useMemo(
+    () => paginateCreatorProjectsV1(projects, marketCaps, projectPage),
+    [marketCaps, projectPage, projects],
+  );
+  const marketCapByToken = useMemo(() => new Map(
+    marketCaps.map((marketCap) => [marketCap.tokenAddress.toLowerCase(), marketCap]),
+  ), [marketCaps]);
+
+  const getEditorState = useCallback((project: CreatorProjectSummaryV1) => {
+    const key = project.tokenAddress.toLowerCase();
+    const current = editorRequestsRef.current.get(key);
+    if (current) return current;
+    const request = loadCreatorArticleEditorV1(project, getAuthHeaders).catch((error) => {
+      editorRequestsRef.current.delete(key);
+      throw error;
+    });
+    editorRequestsRef.current.set(key, request);
+    return request;
+  }, [getAuthHeaders]);
+
+  const warmEditor = useCallback((project: CreatorProjectSummaryV1) => {
+    preloadCreatorArticleEditorModule();
+    void getEditorState(project).catch(() => undefined);
+  }, [getEditorState]);
+
   async function openEditor(project: CreatorProjectSummaryV1) {
     setOpening(project.tokenAddress);
     setProjectError("");
     try {
-      setEditor(await loadCreatorArticleEditorV1(project, getAuthHeaders));
+      const [, nextEditor] = await Promise.all([
+        loadCreatorArticleEditorModule(),
+        getEditorState(project),
+      ]);
+      editorRequestsRef.current.delete(project.tokenAddress.toLowerCase());
+      setEditor(nextEditor);
     } catch (error) {
       setProjectError(error instanceof Error
         ? error.message
@@ -104,9 +157,43 @@ export function ProfileProjects() {
           <p>Creator workspace</p>
           <h2 id="my-projects-title">My projects</h2>
         </div>
-        <button type="button" onClick={() => void loadProjects()} disabled={phase === "loading"}>
-          Refresh
-        </button>
+        <div className={styles.headerActions}>
+          <button
+            className={styles.refresh}
+            type="button"
+            onClick={() => void loadProjects()}
+            disabled={phase === "loading"}
+          >
+            <RefreshCw aria-hidden="true" size={15} strokeWidth={1.8} />
+            <span>Refresh</span>
+          </button>
+          {pageData.totalPages > 1 ? (
+            <nav className={styles.pagination} aria-label="Creator project pages">
+              <button
+                type="button"
+                aria-label="Previous creator projects page"
+                disabled={pageData.currentPage === 1}
+                onClick={() => setProjectPage(Math.max(1, pageData.currentPage - 1))}
+              >
+                <ChevronLeft aria-hidden="true" size={17} strokeWidth={1.8} />
+              </button>
+              <span aria-live="polite" aria-atomic="true">
+                {pageData.currentPage} / {pageData.totalPages}
+              </span>
+              <button
+                type="button"
+                aria-label="Next creator projects page"
+                disabled={pageData.currentPage === pageData.totalPages}
+                onClick={() => setProjectPage(Math.min(
+                  pageData.totalPages,
+                  pageData.currentPage + 1,
+                ))}
+              >
+                <ChevronRight aria-hidden="true" size={17} strokeWidth={1.8} />
+              </button>
+            </nav>
+          ) : null}
+        </div>
       </header>
 
       {projectError ? <p className={styles.error} role="alert">{projectError}</p> : null}
@@ -118,8 +205,8 @@ export function ProfileProjects() {
       ) : projects.length === 0 ? (
         <p className={styles.empty}>Your verified launches will appear here.</p>
       ) : (
-        <div className={styles.grid}>
-          {projects.map((project) => (
+        <div className={styles.list}>
+          {pageData.items.map((project) => (
             <article className={styles.project} key={project.tokenAddress}>
               <div className={styles.art}>
                 {project.imageUrl ? (
@@ -129,12 +216,20 @@ export function ProfileProjects() {
               <div className={styles.copy}>
                 <strong>{project.name}</strong>
                 <span>{project.symbol ? `$${project.symbol}` : "Verified launch"}</span>
+                {marketCapByToken.get(project.tokenAddress.toLowerCase())?.label ? (
+                  <small>
+                    Market cap {marketCapByToken.get(project.tokenAddress.toLowerCase())?.label}
+                  </small>
+                ) : null}
                 {project.article ? <small>Updated {formatDate(project.article.updatedAt)}</small> : null}
               </div>
               <div className={styles.actions}>
                 <button
                   type="button"
                   disabled={opening !== null}
+                  onPointerEnter={() => warmEditor(project)}
+                  onPointerDown={preloadCreatorArticleEditorModule}
+                  onFocus={() => warmEditor(project)}
                   onClick={() => void openEditor(project)}
                 >
                   {opening === project.tokenAddress
@@ -172,6 +267,48 @@ export function ProfileProjects() {
       ) : null}
     </section>
   );
+}
+
+export function paginateCreatorProjectsV1(
+  projects: readonly CreatorProjectSummaryV1[],
+  marketCaps: readonly CreatorProjectMarketCapV1[],
+  requestedPage: number,
+) {
+  const byToken = new Map(
+    marketCaps.map((marketCap) => [marketCap.tokenAddress.toLowerCase(), marketCap]),
+  );
+  const source = projects.some((project) =>
+    unsignedMarketCap(byToken.get(project.tokenAddress.toLowerCase())?.usdWad) !== null)
+    ? "usdWad"
+    : "ethWei";
+  const ordered = [...projects].sort((first, second) => {
+    const firstCap = unsignedMarketCap(
+      byToken.get(first.tokenAddress.toLowerCase())?.[source],
+    );
+    const secondCap = unsignedMarketCap(
+      byToken.get(second.tokenAddress.toLowerCase())?.[source],
+    );
+    if (firstCap !== null && secondCap !== null && firstCap !== secondCap) {
+      return firstCap > secondCap ? -1 : 1;
+    }
+    if (firstCap !== null) return -1;
+    if (secondCap !== null) return 1;
+    const nameOrder = first.name.localeCompare(second.name);
+    return nameOrder !== 0
+      ? nameOrder
+      : first.tokenAddress.toLowerCase().localeCompare(second.tokenAddress.toLowerCase());
+  });
+  const totalPages = Math.max(1, Math.ceil(ordered.length / creatorProjectPageSize));
+  const currentPage = Math.min(
+    totalPages,
+    Number.isSafeInteger(requestedPage) && requestedPage > 0 ? requestedPage : 1,
+  );
+  const offset = (currentPage - 1) * creatorProjectPageSize;
+  return Object.freeze({
+    currentPage,
+    totalPages,
+    items: Object.freeze(ordered.slice(offset, offset + creatorProjectPageSize)),
+  });
 }
 
 export async function acquireCreatorArticleAuthHeadersV1(input: Readonly<{
@@ -258,6 +395,12 @@ function readError(value: unknown) {
   return isRecord(value) && typeof value.code === "string" && value.code
     ? `${value.code[0]?.toUpperCase() ?? ""}${value.code.slice(1).replaceAll("_", " ")}`
     : "Project request failed";
+}
+
+function unsignedMarketCap(value: string | null | undefined) {
+  return value && /^(?:0|[1-9][0-9]*)$/u.test(value) && value.length <= 78
+    ? BigInt(value)
+    : null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -17,7 +17,10 @@ import {
 } from "react";
 
 import { useWallet } from "@/components/wallet-provider";
-import { ProfileProjects } from "@/components/profile-projects";
+import {
+  ProfileProjects,
+  type CreatorProjectMarketCapV1,
+} from "@/components/profile-projects";
 import { useLiveDataRefresh } from "@/components/use-live-data-refresh";
 import { formatMarketCapMetric } from "@/components/animated-market-cap";
 import { isConfiguredClassicV3ReleaseReady } from "@/lib/classic-v3-release";
@@ -1790,6 +1793,15 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       ? requestedOnchainData
       : loadingProfileData(account)
     : UNAVAILABLE_PROFILE_DATA;
+  const creatorProjectMarketCaps = useMemo<readonly CreatorProjectMarketCapV1[]>(
+    () => scopedOnchainData.tokens.map((token) => ({
+      tokenAddress: token.address,
+      usdWad: token.fdvUsdWad ?? null,
+      ethWei: token.marketCapEthWei ?? null,
+      label: profileTokenMarketCapLabel(token),
+    })),
+    [scopedOnchainData.tokens],
+  );
   const scopedClassicV3Rewards = useMemo<ClassicV3ProfileRewards>(() => {
     if (!account || !classicV3ReleaseAvailable) {
       return EMPTY_CLASSIC_V3_PROFILE;
@@ -3189,7 +3201,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         </div>
       </section>
 
-      <ProfileProjects />
+      <ProfileProjects marketCaps={creatorProjectMarketCaps} />
 
       <ProfileAccountWorkspace
         key={account.toLowerCase()}

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import * as profileProjects from "../components/profile-projects";
+import type {
+  CreatorProjectMarketCapV1,
+  CreatorProjectSummaryV1,
+} from "../components/profile-projects";
 
 const project = {
   chainId: 1 as const,
@@ -13,6 +17,44 @@ const project = {
 };
 
 describe("My projects editor opening", () => {
+  it("paginates verified projects by highest available market cap", () => {
+    const paginate = (profileProjects as unknown as {
+      paginateCreatorProjectsV1(
+        projects: readonly CreatorProjectSummaryV1[],
+        marketCaps: readonly CreatorProjectMarketCapV1[],
+        requestedPage: number,
+      ): Readonly<{
+        currentPage: number;
+        totalPages: number;
+        items: readonly CreatorProjectSummaryV1[];
+      }>;
+    }).paginateCreatorProjectsV1;
+    expect(typeof paginate).toBe("function");
+
+    const projects = Array.from({ length: 7 }, (_, index) => ({
+      ...project,
+      tokenAddress: `0x${String(index + 1).padStart(40, "0")}` as `0x${string}`,
+      name: `Project ${index + 1}`,
+    }));
+    const marketCaps = [100, 700, 300, 600, 200, 500, 400].map((value, index) => ({
+      tokenAddress: projects[index].tokenAddress,
+      usdWad: String(BigInt(value) * 10n ** 18n),
+      ethWei: null,
+      label: `$${value}`,
+    }));
+
+    expect(paginate(projects, marketCaps, 1)).toMatchObject({
+      currentPage: 1,
+      totalPages: 2,
+      items: [projects[1], projects[3], projects[5], projects[6], projects[2]],
+    });
+    expect(paginate(projects, marketCaps, 99)).toMatchObject({
+      currentPage: 2,
+      totalPages: 2,
+      items: [projects[4], projects[0]],
+    });
+  });
+
   it("refreshes the Privy identity before reading the bound access token", async () => {
     const acquire = (profileProjects as unknown as {
       acquireCreatorArticleAuthHeadersV1(input: Readonly<{


### PR DESCRIPTION
## Summary
- keep the article formatting toolbar pinned above the scrolling editor and simplify link controls
- preload editor code and the selected article to reduce opening latency
- present verified projects in a compact five-row paginated panel ordered by available market cap
- remove the redundant image paste hint

## Verification
- `npx vitest run tests/profile-projects-editor-open.test.ts tests/creator-article-editor.test.ts tests/creator-article-authority.test.ts tests/creator-article-api.test.ts` (18 passed)
- changed-path ESLint
- `npm run typecheck`
- `npm run build`