### PR TITLE
Fix Generic read-model current evidence closure

### DIFF
--- a/scripts/custom-v2-read-model-contract-v2.mjs
+++ b/scripts/custom-v2-read-model-contract-v2.mjs
@@ -78,6 +78,25 @@ const HOSTED_PERSISTENCE_EVIDENCE_IDENTITY = Object.freeze({
   finalCatalogSha256:
     "0x92a17ae38c7562cea0609bc8a8263ff190486a389b886072fb9ef30f0cffc0c4",
 });
+const CURRENT_HOSTED_PERSISTENCE_EVIDENCE_IDENTITY = Object.freeze({
+  planArtifactSha256:
+    "sha256:4bea658e36b40af2d4d6ee7e71039d302704e6ddc2f4ca8f4190a17c2ad50d57",
+  rotationReceiptArtifactSha256:
+    "sha256:25991a95896673cbcffc60aefab8353a9562ef132e63bf2fb343f9b61411b163",
+  planRepositoryCommit: "c235fbd55259f76d8356d6f07073c48b00eb294d",
+  planRepositoryTree: "57d09edb4793d6fe9f8a3bfad8e311accbb4caec",
+  planSha256:
+    "0xbcdb49c686413cd5eab15514e0182eb929f5771e58059ce0fe59f928c44e6f3f",
+  orderSha256:
+    "0xce50954bfa6ff3b66b849bb5b53e8f1adf93abbe12cf865c19375100f2571cc2",
+  finalCatalogSha256:
+    "0x92a17ae38c7562cea0609bc8a8263ff190486a389b886072fb9ef30f0cffc0c4",
+  operatorCatalogSha256:
+    "0xf8127e64734fd233765f8d41fedde1d4b0e5af5035eef599bdb144764bd63baa",
+  rotationSourceCommit: "fec98782757aa9b87760c9a5743c3f016208f0ab",
+  rotationSourceTree: "0337d7a5bdda046cc4fa879283fd269068caa538",
+  rotationSourceParent: "6895dcf863e8406d283aec700c705a37ff76a8a3",
+});
 
 const INPUT_KEYS = Object.freeze([
   "approvalArtifactSchema",
@@ -134,6 +153,8 @@ export async function deriveGenericLaunchReadModelContractV2(input, options) {
   const gitBlobIdentity = options?.gitBlobIdentity ?? currentGitBlobIdentity;
   const hostedEvidenceIdentity = options?.hostedEvidenceIdentity
     ?? HOSTED_PERSISTENCE_EVIDENCE_IDENTITY;
+  const currentHostedEvidenceIdentity = options?.currentHostedEvidenceIdentity
+    ?? CURRENT_HOSTED_PERSISTENCE_EVIDENCE_IDENTITY;
   const value = exactObject(input, INPUT_KEYS, "derivation input");
   if (value.schemaVersion
     !== "programmable.generic-launch-read-model-contract-derivation-input.v1") {
@@ -168,6 +189,7 @@ export async function deriveGenericLaunchReadModelContractV2(input, options) {
     read,
     gitBlobIdentity,
     hostedEvidenceIdentity,
+    currentHostedEvidenceIdentity,
   );
   const queryContract = await queryComponent(
     value.queryContract,
@@ -277,6 +299,7 @@ async function persistenceComponent(
   read,
   gitBlobIdentity,
   hostedEvidenceIdentity,
+  currentHostedEvidenceIdentity,
 ) {
   const value = exactObject(raw, ["artifacts", "hostedEvidence"],
     "persistence component");
@@ -291,6 +314,7 @@ async function persistenceComponent(
   const evidence = await hostedPersistenceEvidence(
     value.hostedEvidence,
     hostedEvidenceIdentity,
+    currentHostedEvidenceIdentity,
   );
   assertExactArtifactInventory(artifacts, PERSISTENCE_ARTIFACTS, "persistence");
   for (const migration of evidence.plan.migrations) {
@@ -638,7 +662,15 @@ function assertExactArtifactInventory(artifacts, expected, label) {
   return artifacts;
 }
 
-async function hostedPersistenceEvidence(raw, expectedIdentity) {
+async function hostedPersistenceEvidence(
+  raw,
+  expectedIdentity,
+  currentExpectedIdentity,
+) {
+  if (raw !== null && typeof raw === "object" && !Array.isArray(raw)
+    && Object.keys(raw).includes("rotationReceipt")) {
+    return currentHostedPersistenceEvidence(raw, currentExpectedIdentity);
+  }
   const expected = exactObject(expectedIdentity, [
     "adoptionArtifactSha256", "applyArtifactSha256", "finalCatalogSha256",
     "orderSha256", "planArtifactSha256", "planRepositoryCommit",
@@ -770,6 +802,206 @@ async function hostedPersistenceEvidence(raw, expectedIdentity) {
       "programmable.generic-launch-read-model-hosted-persistence-closure.v1",
       normalized,
     ),
+  });
+}
+
+async function currentHostedPersistenceEvidence(raw, expectedIdentity) {
+  const expected = exactObject(expectedIdentity, [
+    "finalCatalogSha256", "operatorCatalogSha256", "orderSha256",
+    "planArtifactSha256", "planRepositoryCommit", "planRepositoryTree",
+    "planSha256", "rotationReceiptArtifactSha256", "rotationSourceCommit",
+    "rotationSourceParent", "rotationSourceTree",
+  ], "current hosted persistence expected identity");
+  const value = exactObject(raw, [
+    "currentVerify", "plan", "rotationReceipt",
+  ], "current hosted persistence evidence");
+  const [planArtifact, rotationArtifact, verifyArtifact] = await Promise.all([
+    readProtectedEvidenceArtifact(value.plan, "hosted migration plan"),
+    readProtectedEvidenceArtifact(
+      value.rotationReceipt,
+      "hosted credential rotation receipt",
+    ),
+    readProtectedEvidenceArtifact(
+      value.currentVerify,
+      "hosted current read-only verify evidence",
+    ),
+  ]);
+  const plan = validateWebsiteProjectionPlan(planArtifact.value);
+  if (planArtifact.sha256 !== digest(
+    expected.planArtifactSha256,
+    "expected hosted plan artifact",
+  )
+    || rotationArtifact.sha256 !== digest(
+      expected.rotationReceiptArtifactSha256,
+      "expected hosted rotation receipt artifact",
+    )
+    || plan.repositoryCommit !== expected.planRepositoryCommit
+    || plan.repositoryTree !== expected.planRepositoryTree
+    || plan.planSha256 !== expected.planSha256
+    || plan.orderSha256 !== expected.orderSha256) {
+    throw new TypeError(
+      "Current hosted persistence artifacts do not match the frozen closure",
+    );
+  }
+  const rotation = credentialRotationReceipt(rotationArtifact.value, expected);
+  const verified = operatorResult(verifyArtifact.value, "verify");
+  const verifyState = exactObject(verified.state, [
+    "appliedCount", "catalogSha256", "pending", "runtimeRoleStatus", "status",
+  ], "hosted current verify state");
+  if (verified.changed !== false
+    || verified.planSha256 !== plan.planSha256
+    || canonicalJson(verified.target) !== canonicalJson({
+      projectRef: rotation.target.projectRef,
+      host: rotation.target.authorityEndpoint.split(":")[0],
+      port: 5432,
+      database: rotation.target.database,
+      sslMode: "verify-full",
+    })
+    || verifyState.status !== "current"
+    || verifyState.appliedCount !== plan.migrationCount
+    || canonicalJson(verifyState.pending) !== "[]"
+    || verifyState.runtimeRoleStatus !== "current"
+    || verifyState.catalogSha256 !== expected.finalCatalogSha256
+    || verifyState.catalogSha256 !== rotation.catalog.afterSha256) {
+    throw new TypeError(
+      "Current hosted verify evidence does not close the exact 0005 catalog",
+    );
+  }
+  const normalized = Object.freeze({
+    evidenceBasis: "authenticated-rotation-plus-current-read-only-verify",
+    target: verified.target,
+    plan: Object.freeze({
+      repositoryCommit: plan.repositoryCommit,
+      repositoryTree: plan.repositoryTree,
+      planSha256: plan.planSha256,
+      orderSha256: plan.orderSha256,
+      migrations: Object.freeze(plan.migrations.map((migration) => Object.freeze({
+        ordinal: migration.ordinal,
+        version: migration.version,
+        file: migration.file,
+        fileSha256: migration.fileSha256,
+        executionSha256: migration.executionSha256,
+      }))),
+    }),
+    protectedArtifacts: Object.freeze({
+      planSha256: planArtifact.sha256,
+      rotationReceiptSha256: rotationArtifact.sha256,
+      currentVerifySha256: verifyArtifact.sha256,
+    }),
+    rotation,
+    currentVerify: Object.freeze({
+      operatorIdentity: verified.operatorIdentity,
+      state: Object.freeze({ ...verifyState }),
+    }),
+    finalCatalogSha256: verifyState.catalogSha256,
+    migratedThrough: "0005",
+  });
+  return Object.freeze({
+    ...normalized,
+    closureHash: canonicalSha256(
+      "programmable.generic-launch-read-model-hosted-persistence-current-closure.v1",
+      normalized,
+    ),
+  });
+}
+
+function credentialRotationReceipt(raw, expected) {
+  const value = exactObject(raw, [
+    "catalog", "changed", "cutover", "migrationEvidence", "operation",
+    "protectedOutputs", "rotatedAt", "runtimeProbe", "schemaVersion", "source",
+    "target", "tls",
+  ], "hosted credential rotation receipt");
+  const source = exactObject(value.source, [
+    "repositoryCommit", "repositoryParent", "repositoryTree",
+  ], "hosted credential rotation source");
+  const target = exactObject(value.target, [
+    "authorityEndpoint", "database", "projectRef", "runtimeEndpoint", "runtimeRole",
+  ], "hosted credential rotation target");
+  const migrationEvidence = exactObject(value.migrationEvidence, [
+    "catalogSha256", "migrationCount", "operatorCatalogSha256", "planSha256",
+    "repositoryCommit", "repositoryTree",
+  ], "hosted credential rotation migration evidence");
+  const catalog = exactObject(value.catalog, [
+    "afterSha256", "beforeSha256", "unchanged",
+  ], "hosted credential rotation catalog");
+  const runtimeProbe = exactObject(value.runtimeProbe, [
+    "databaseName", "leastPrivilege", "runtimeRole", "serverVersionNum", "sslBits",
+    "sslCipher", "sslVersion",
+  ], "hosted credential rotation runtime probe");
+  const tls = exactObject(value.tls, [
+    "caSha256", "hostnameVerified", "mode",
+  ], "hosted credential rotation TLS evidence");
+  const cutover = exactObject(value.cutover, [
+    "existingSessionsAreNotCutoverEvidence", "overlappingPasswordsSupported",
+    "passwordSlots", "postCommitFailure", "preCommitFailure",
+    "vercelMutationPerformed",
+  ], "hosted credential rotation cutover evidence");
+  const protectedOutputs = exactObject(value.protectedOutputs, [
+    "containsSecretDerivedDigest", "databaseCaPem", "databaseRole", "databaseUrl",
+    "mode", "receipt",
+  ], "hosted credential rotation protected outputs");
+  if (value.schemaVersion
+      !== "programmable.website-projection-runtime-credential-rotation.v1"
+    || value.operation !== "rotate-existing-runtime-role-password"
+    || value.changed !== true
+    || typeof value.rotatedAt !== "string"
+    || !Number.isFinite(Date.parse(value.rotatedAt))
+    || source.repositoryCommit !== expected.rotationSourceCommit
+    || source.repositoryTree !== expected.rotationSourceTree
+    || source.repositoryParent !== expected.rotationSourceParent
+    || target.projectRef !== WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF
+    || target.database !== "postgres"
+    || target.authorityEndpoint !== `db.${target.projectRef}.supabase.co:5432`
+    || target.runtimeEndpoint !== "aws-0-eu-central-1.pooler.supabase.com:6543"
+    || target.runtimeRole !== "programmable_website_projection_runtime"
+    || migrationEvidence.migrationCount !== 5
+    || migrationEvidence.planSha256 !== expected.planSha256
+    || migrationEvidence.repositoryCommit !== expected.planRepositoryCommit
+    || migrationEvidence.repositoryTree !== expected.planRepositoryTree
+    || migrationEvidence.catalogSha256 !== expected.finalCatalogSha256
+    || migrationEvidence.operatorCatalogSha256 !== expected.operatorCatalogSha256
+    || catalog.beforeSha256 !== expected.finalCatalogSha256
+    || catalog.afterSha256 !== expected.finalCatalogSha256
+    || catalog.unchanged !== true
+    || runtimeProbe.runtimeRole !== target.runtimeRole
+    || runtimeProbe.databaseName !== target.database
+    || !/^[1-9][0-9]{5,}$/u.test(runtimeProbe.serverVersionNum)
+    || runtimeProbe.leastPrivilege !== true
+    || runtimeProbe.sslVersion !== "TLSv1.3"
+    || runtimeProbe.sslCipher !== "TLS_AES_256_GCM_SHA384"
+    || runtimeProbe.sslBits !== 256
+    || tls.mode !== "verify-full-equivalent"
+    || !SHA256.test(tls.caSha256)
+    || tls.hostnameVerified !== true
+    || cutover.passwordSlots !== 1
+    || cutover.overlappingPasswordsSupported !== false
+    || cutover.existingSessionsAreNotCutoverEvidence !== true
+    || cutover.preCommitFailure !== "automatic-transaction-rollback"
+    || cutover.postCommitFailure
+      !== "forward-rotate-or-rerun-with-the-same-protected-secret"
+    || cutover.vercelMutationPerformed !== false
+    || protectedOutputs.databaseUrl
+      !== "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL"
+    || protectedOutputs.databaseRole
+      !== "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE"
+    || protectedOutputs.databaseCaPem
+      !== "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM"
+    || protectedOutputs.receipt
+      !== "programmable-website-projection-runtime-credential-rotation-v1.json"
+    || protectedOutputs.mode !== "0600"
+    || protectedOutputs.containsSecretDerivedDigest !== false) {
+    throw new TypeError(
+      "Hosted credential rotation receipt is not the authenticated current state",
+    );
+  }
+  return Object.freeze({
+    rotatedAt: value.rotatedAt,
+    source: Object.freeze({ ...source }),
+    target: Object.freeze({ ...target }),
+    migrationEvidence: Object.freeze({ ...migrationEvidence }),
+    catalog: Object.freeze({ ...catalog }),
+    runtimeProbe: Object.freeze({ ...runtimeProbe }),
+    tls: Object.freeze({ ...tls }),
   });
 }
 

--- a/scripts/test/custom-v2-read-model-contract-v2.test.mjs
+++ b/scripts/test/custom-v2-read-model-contract-v2.test.mjs
@@ -300,6 +300,111 @@ async function fixture() {
   return { repoRoot, input, files, options, protectedArtifacts };
 }
 
+async function currentEvidenceFixture() {
+  const value = await fixture();
+  const plan = JSON.parse(await readFile(
+    value.protectedArtifacts.plan.path,
+    "utf8",
+  ));
+  const currentVerify = JSON.parse(await readFile(
+    value.protectedArtifacts.verify.path,
+    "utf8",
+  ));
+  const finalCatalogSha256 = currentVerify.state.catalogSha256;
+  const operatorCatalogSha256 = `0x${"6".repeat(64)}`;
+  const rotationSource = {
+    repositoryCommit: "1".repeat(40),
+    repositoryTree: "2".repeat(40),
+    repositoryParent: "3".repeat(40),
+  };
+  const rotationReceipt = {
+    schemaVersion:
+      "programmable.website-projection-runtime-credential-rotation.v1",
+    operation: "rotate-existing-runtime-role-password",
+    changed: true,
+    rotatedAt: "2026-08-21T07:34:02.793Z",
+    source: rotationSource,
+    target: {
+      projectRef: "mnnvlrqwhfoppogslsje",
+      database: "postgres",
+      authorityEndpoint: "db.mnnvlrqwhfoppogslsje.supabase.co:5432",
+      runtimeEndpoint: "aws-0-eu-central-1.pooler.supabase.com:6543",
+      runtimeRole: "programmable_website_projection_runtime",
+    },
+    migrationEvidence: {
+      migrationCount: 5,
+      planSha256: plan.planSha256,
+      repositoryCommit: plan.repositoryCommit,
+      repositoryTree: plan.repositoryTree,
+      catalogSha256: finalCatalogSha256,
+      operatorCatalogSha256,
+    },
+    catalog: {
+      beforeSha256: finalCatalogSha256,
+      afterSha256: finalCatalogSha256,
+      unchanged: true,
+    },
+    runtimeProbe: {
+      runtimeRole: "programmable_website_projection_runtime",
+      databaseName: "postgres",
+      serverVersionNum: "170006",
+      sslVersion: "TLSv1.3",
+      sslCipher: "TLS_AES_256_GCM_SHA384",
+      sslBits: 256,
+      leastPrivilege: true,
+    },
+    tls: {
+      mode: "verify-full-equivalent",
+      caSha256: DIGEST("provider-ca"),
+      hostnameVerified: true,
+    },
+    cutover: {
+      passwordSlots: 1,
+      overlappingPasswordsSupported: false,
+      existingSessionsAreNotCutoverEvidence: true,
+      preCommitFailure: "automatic-transaction-rollback",
+      postCommitFailure:
+        "forward-rotate-or-rerun-with-the-same-protected-secret",
+      vercelMutationPerformed: false,
+    },
+    protectedOutputs: {
+      databaseUrl: "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL",
+      databaseRole: "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE",
+      databaseCaPem: "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM",
+      receipt:
+        "programmable-website-projection-runtime-credential-rotation-v1.json",
+      mode: "0600",
+      containsSecretDerivedDigest: false,
+    },
+  };
+  const rotationPath = join(value.repoRoot, "rotation-receipt.json");
+  const rotationBytes = Buffer.from(`${JSON.stringify(rotationReceipt)}\n`, "utf8");
+  await writeFile(rotationPath, rotationBytes, { mode: 0o600 });
+  const rotationArtifact = {
+    path: rotationPath,
+    sha256: sha256Bytes(rotationBytes),
+  };
+  value.input.persistence.hostedEvidence = {
+    plan: value.protectedArtifacts.plan,
+    rotationReceipt: rotationArtifact,
+    currentVerify: value.protectedArtifacts.verify,
+  };
+  value.options.currentHostedEvidenceIdentity = {
+    planArtifactSha256: value.protectedArtifacts.plan.sha256,
+    rotationReceiptArtifactSha256: rotationArtifact.sha256,
+    planRepositoryCommit: plan.repositoryCommit,
+    planRepositoryTree: plan.repositoryTree,
+    planSha256: plan.planSha256,
+    orderSha256: plan.orderSha256,
+    finalCatalogSha256,
+    operatorCatalogSha256,
+    rotationSourceCommit: rotationSource.repositoryCommit,
+    rotationSourceTree: rotationSource.repositoryTree,
+    rotationSourceParent: rotationSource.repositoryParent,
+  };
+  return { ...value, rotationArtifact };
+}
+
 test("derives all six content-addressed bindings and the runtime contract", async (t) => {
   const { repoRoot, input, options } = await fixture();
   t.after(() => rm(repoRoot, { recursive: true, force: true }));
@@ -339,6 +444,60 @@ test("derives all six content-addressed bindings and the runtime contract", asyn
       contract: result.contract,
       readModelBindingHash: result.readModelBindingHash,
     }),
+  );
+});
+
+test("accepts the authenticated rotation receipt plus one current verify", async (t) => {
+  const value = await currentEvidenceFixture();
+  t.after(() => rm(value.repoRoot, { recursive: true, force: true }));
+  const result = await deriveGenericLaunchReadModelContractV2(
+    value.input,
+    value.options,
+  );
+  const evidence = result.components.persistence.hostedEvidence;
+  assert.equal(
+    evidence.evidenceBasis,
+    "authenticated-rotation-plus-current-read-only-verify",
+  );
+  assert.equal(
+    evidence.protectedArtifacts.rotationReceiptSha256,
+    value.rotationArtifact.sha256,
+  );
+  assert.equal(
+    evidence.protectedArtifacts.currentVerifySha256,
+    value.protectedArtifacts.verify.sha256,
+  );
+  assert.equal(evidence.migratedThrough, "0005");
+});
+
+test("rejects fabricated current evidence and historical substitutes", async (t) => {
+  const forged = await currentEvidenceFixture();
+  t.after(() => rm(forged.repoRoot, { recursive: true, force: true }));
+  const verify = JSON.parse(await readFile(
+    forged.protectedArtifacts.verify.path,
+    "utf8",
+  ));
+  verify.operation = "apply";
+  verify.changed = true;
+  const verifyBytes = Buffer.from(`${JSON.stringify(verify)}\n`, "utf8");
+  await writeFile(forged.protectedArtifacts.verify.path, verifyBytes, {
+    mode: 0o600,
+  });
+  forged.protectedArtifacts.verify.sha256 = sha256Bytes(verifyBytes);
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(forged.input, forged.options),
+    /Hosted verify evidence identity|current verify/u,
+  );
+
+  const historical = await currentEvidenceFixture();
+  t.after(() => rm(historical.repoRoot, { recursive: true, force: true }));
+  historical.input.persistence.hostedEvidence.rotationReceipt =
+    historical.protectedArtifacts.adoption;
+  historical.options.currentHostedEvidenceIdentity.rotationReceiptArtifactSha256 =
+    historical.protectedArtifacts.adoption.sha256;
+  await assert.rejects(
+    deriveGenericLaunchReadModelContractV2(historical.input, historical.options),
+    /credential rotation receipt/u,
   );
 });
 


### PR DESCRIPTION
## Summary
- accept the retained authenticated Website projection credential-rotation receipt as the historical provenance anchor
- require a fresh official read-only `verify` result for the exact reviewed five-migration catalog
- reject fabricated current-state payloads and historical artifact substitutions

## Focused verification
- `node --test scripts/test/custom-v2-read-model-contract-v2.test.mjs` (16/16)
- `git diff --check`

## Release boundary
This PR changes only the source-owned writer and its focused test. It performs no database mutation and no deployment. Do not merge until the Serving/Vercel CAS ordering is reviewed because `production` has advanced past the currently pinned Website deployment source.