### PR TITLE
Polish creator project and article experience

### DIFF
--- a/components/creator-article-editor.module.css
+++ b/components/creator-article-editor.module.css
@@ -246,6 +246,11 @@
   color: #0a0a0c;
 }
 
+.toolbar button:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
 .linkControl {
   align-items: center;
   background: rgb(255 255 255 / 4%);
@@ -269,6 +274,16 @@
   outline: none;
 }
 
+.linkProviderIcon {
+  display: inline-flex;
+  flex: none;
+}
+
+.linkProviderIcon svg {
+  height: 0.95rem;
+  width: 0.95rem;
+}
+
 .linkControl button {
   border-block: 0;
   border-inline-end: 0;
@@ -276,6 +291,11 @@
   min-height: 2.75rem;
   padding: 0.45rem 0.7rem;
   white-space: nowrap;
+}
+
+.linkControl button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
 }
 
 .linkControl:focus-within {

--- a/components/creator-article-editor.tsx
+++ b/components/creator-article-editor.tsx
@@ -20,7 +20,6 @@ import {
   Heading3,
   ImagePlus,
   Italic,
-  Link as LinkIcon,
   List,
   ListOrdered,
   Redo2,
@@ -39,6 +38,7 @@ import {
 import { createPortal } from "react-dom";
 
 import { CreatorArticle } from "@/components/creator-article";
+import { CreatorArticleLinkIcon } from "@/components/creator-article-link-icon";
 import type { CreatorProjectSummaryV1 } from "@/components/profile-projects";
 import {
   CREATOR_ARTICLE_DRAFT_SCHEMA_V1,
@@ -506,7 +506,7 @@ export default function CreatorArticleEditor({
     }
   }
 
-  function applyLink() {
+  function applySocial() {
     if (!editor) return;
     if (!linkValue.trim()) {
       editor.chain().focus().extendMarkRange("link").unsetLink().run();
@@ -514,7 +514,15 @@ export default function CreatorArticleEditor({
     }
     try {
       const href = normalizeHttpsLinkV1(linkValue);
-      editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
+      if (editor.state.selection.empty) {
+        editor.chain().focus().insertContent({
+          type: "text",
+          text: displayHttpsLinkV1(href),
+          marks: [{ type: "link", attrs: { href } }],
+        }).run();
+      } else {
+        editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
+      }
       setLinkValue("");
       setNotice(null);
     } catch {
@@ -565,7 +573,7 @@ export default function CreatorArticleEditor({
               )}
             </div>
             <div>
-              <p>{project.symbol ? `$${project.symbol}` : "Verified project"} · Creator workspace</p>
+              <p>{project.symbol ? `$${project.symbol}` : "Verified project"}</p>
               <h2 id="article-editor-title">{initialArticle ? "Edit article" : "Create article"}</h2>
             </div>
           </div>
@@ -580,8 +588,8 @@ export default function CreatorArticleEditor({
           <ToolbarIcon label="Heading 3" active={editor?.isActive("heading", { level: 3 }) ?? false} onClick={() => editor?.chain().focus().toggleHeading({ level: 3 }).run()}><Heading3 /></ToolbarIcon>
           <ToolbarIcon label="Bullet list" active={editor?.isActive("bulletList") ?? false} onClick={() => editor?.chain().focus().toggleBulletList().run()}><List /></ToolbarIcon>
           <ToolbarIcon label="Numbered list" active={editor?.isActive("orderedList") ?? false} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><ListOrdered /></ToolbarIcon>
-          <ToolbarIcon label="Undo" onClick={() => editor?.chain().focus().undo().run()}><Undo2 /></ToolbarIcon>
-          <ToolbarIcon label="Redo" onClick={() => editor?.chain().focus().redo().run()}><Redo2 /></ToolbarIcon>
+          <ToolbarIcon label="Undo" disabled={!editor?.can().undo()} onClick={() => editor?.chain().focus().undo().run()}><Undo2 /></ToolbarIcon>
+          <ToolbarIcon label="Redo" disabled={!editor?.can().redo()} onClick={() => editor?.chain().focus().redo().run()}><Redo2 /></ToolbarIcon>
           <input ref={imageInputRef} hidden type="file" multiple accept="image/png,image/jpeg,image/webp,image/avif" onChange={(event) => {
             const files = [...(event.target.files ?? [])];
             event.target.value = "";
@@ -589,18 +597,22 @@ export default function CreatorArticleEditor({
           }} />
           <ToolbarIcon label="Add image" onClick={() => imageInputRef.current?.click()}><ImagePlus /></ToolbarIcon>
           <div className={styles.linkControl}>
-            <LinkIcon aria-hidden="true" size={15} />
+            <CreatorArticleLinkIcon href={linkValue} className={styles.linkProviderIcon} />
             <input
               value={linkValue}
-              aria-label="Link URL"
+              aria-label="Social URL"
               inputMode="url"
-              placeholder="Paste link"
+              placeholder="Social or website URL"
               onChange={(event) => setLinkValue(event.target.value)}
               onKeyDown={(event) => {
-                if (event.key === "Enter") { event.preventDefault(); applyLink(); }
+                if (event.key === "Enter") { event.preventDefault(); applySocial(); }
               }}
             />
-            <button type="button" onClick={applyLink}>Add link</button>
+            <button
+              type="button"
+              disabled={!linkValue.trim()}
+              onClick={applySocial}
+            >Add Socials</button>
           </div>
         </div>
 
@@ -678,14 +690,22 @@ function ToolbarButton({ label, active = false, onClick }: Readonly<{
   return <button type="button" aria-pressed={active} onClick={onClick}>{label}</button>;
 }
 
-function ToolbarIcon({ label, active = false, onClick, children }: Readonly<{
+function ToolbarIcon({ label, active = false, disabled = false, onClick, children }: Readonly<{
   label: string;
   active?: boolean;
+  disabled?: boolean;
   onClick(): void;
   children: React.ReactNode;
 }>) {
   return (
-    <button type="button" aria-label={label} title={label} aria-pressed={active} onClick={onClick}>
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      aria-pressed={active}
+      disabled={disabled}
+      onClick={onClick}
+    >
       {children}
     </button>
   );
@@ -753,8 +773,22 @@ export function creatorArticleEditorFingerprintV1(value: unknown) {
   return JSON.stringify({
     title: value.title,
     bannerImage: value.bannerImage,
-    document: value.document,
+    document: normalizeEditorFingerprintDocumentV1(value.document),
   });
+}
+
+function normalizeEditorFingerprintDocumentV1(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeEditorFingerprintDocumentV1);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(Object.entries(value).map(([key, candidate]) => {
+    if (key !== "attrs" || value.type !== "articleImage" || !isRecord(candidate)) {
+      return [key, normalizeEditorFingerprintDocumentV1(candidate)];
+    }
+    return [key, Object.fromEntries(Object.entries(candidate).flatMap(([attribute, current]) => {
+      if (attribute === "uploadId" || (attribute === "status" && current === "ready")) return [];
+      return [[attribute, normalizeEditorFingerprintDocumentV1(current)]];
+    }))];
+  }));
 }
 
 function emptyDocument(): JSONContent {

--- a/components/creator-article-link-icon.tsx
+++ b/components/creator-article-link-icon.tsx
@@ -1,0 +1,127 @@
+import {
+  BookOpen,
+  MessageCircle,
+} from "lucide-react";
+
+import {
+  DiscordBrandIcon,
+  DuneBrandIcon,
+  GitHubBrandIcon,
+  XBrandIcon,
+} from "@/components/brand-icons";
+import { WebsiteLinkIcon } from "@/components/website-link-icon";
+
+export type CreatorArticleLinkProviderV1 =
+  | "discord"
+  | "dune"
+  | "farcaster"
+  | "github"
+  | "gitbook"
+  | "instagram"
+  | "linkedin"
+  | "telegram"
+  | "website"
+  | "x"
+  | "youtube";
+
+const providers = [
+  ["github", ["github.com"]],
+  ["discord", ["discord.com", "discord.gg"]],
+  ["x", ["x.com", "twitter.com"]],
+  ["telegram", ["t.me", "telegram.me"]],
+  ["gitbook", ["gitbook.com", "gitbook.io"]],
+  ["dune", ["dune.com"]],
+  ["youtube", ["youtube.com", "youtu.be"]],
+  ["instagram", ["instagram.com"]],
+  ["linkedin", ["linkedin.com"]],
+  ["farcaster", ["farcaster.xyz", "warpcast.com"]],
+] as const satisfies readonly (readonly [
+  Exclude<CreatorArticleLinkProviderV1, "website">,
+  readonly string[],
+])[];
+
+export function creatorArticleLinkProviderV1(
+  href: string,
+): CreatorArticleLinkProviderV1 {
+  try {
+    const hostname = new URL(href).hostname.toLowerCase().replace(/\.$/u, "");
+    for (const [provider, domains] of providers) {
+      if (domains.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`))) {
+        return provider;
+      }
+    }
+  } catch {
+    // Invalid or incomplete editor input uses the neutral website icon.
+  }
+  return "website";
+}
+
+export function CreatorArticleLinkIcon({
+  href,
+  className,
+}: Readonly<{ href: string; className?: string }>) {
+  const provider = creatorArticleLinkProviderV1(href);
+  return (
+    <span
+      aria-hidden="true"
+      className={className}
+      data-creator-link-provider={provider}
+    >
+      {provider === "github" ? <GitHubBrandIcon />
+        : provider === "discord" ? <DiscordBrandIcon />
+          : provider === "x" ? <XBrandIcon />
+            : provider === "telegram" ? <TelegramBrandIcon />
+              : provider === "gitbook" ? <BookOpen />
+                : provider === "dune" ? <DuneBrandIcon />
+                  : provider === "youtube" ? <YouTubeBrandIcon />
+                    : provider === "instagram" ? <InstagramBrandIcon />
+                      : provider === "linkedin" ? <LinkedInBrandIcon />
+                        : provider === "farcaster" ? <MessageCircle />
+                          : <WebsiteLinkIcon />}
+    </span>
+  );
+}
+
+function TelegramBrandIcon() {
+  return (
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        d="M22.8 3.2 19.5 20.1c-.25 1.2-.91 1.5-1.85.94l-5.03-3.71-2.43 2.34c-.27.27-.5.5-1.02.5l.36-5.13 9.34-8.44c.41-.36-.09-.56-.63-.2L6.7 13.67l-4.98-1.56c-1.08-.34-1.1-1.08.23-1.6L21.36 3c.9-.33 1.69.2 1.44 1.2Z"
+      />
+    </svg>
+  );
+}
+
+function YouTubeBrandIcon() {
+  return (
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        d="M23.5 6.19a3.02 3.02 0 0 0-2.12-2.14C19.5 3.55 12 3.55 12 3.55s-7.5 0-9.38.5A3.02 3.02 0 0 0 .5 6.19 31.4 31.4 0 0 0 0 12a31.4 31.4 0 0 0 .5 5.81 3.02 3.02 0 0 0 2.12 2.14c1.88.5 9.38.5 9.38.5s7.5 0 9.38-.5a3.02 3.02 0 0 0 2.12-2.14A31.4 31.4 0 0 0 24 12a31.4 31.4 0 0 0-.5-5.81ZM9.55 15.57V8.43L15.82 12l-6.27 3.57Z"
+      />
+    </svg>
+  );
+}
+
+function InstagramBrandIcon() {
+  return (
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        d="M12 2.16c3.2 0 3.58.01 4.85.07 3.25.15 4.77 1.69 4.92 4.92.06 1.27.07 1.65.07 4.85s-.01 3.58-.07 4.85c-.15 3.22-1.66 4.77-4.92 4.92-1.27.06-1.64.07-4.85.07s-3.58-.01-4.85-.07c-3.26-.15-4.77-1.7-4.92-4.92-.06-1.27-.07-1.65-.07-4.85s.01-3.58.07-4.85c.15-3.23 1.67-4.77 4.92-4.92C8.42 2.17 8.8 2.16 12 2.16ZM12 0C8.74 0 8.33.01 7.05.07 2.7.27.27 2.69.07 7.05.01 8.33 0 8.74 0 12s.01 3.67.07 4.95c.2 4.36 2.62 6.78 6.98 6.98C8.33 23.99 8.74 24 12 24s3.67-.01 4.95-.07c4.35-.2 6.78-2.62 6.98-6.98.06-1.28.07-1.69.07-4.95s-.01-3.67-.07-4.95C23.73 2.7 21.31.27 16.95.07 15.67.01 15.26 0 12 0Zm0 5.84a6.16 6.16 0 1 0 0 12.32 6.16 6.16 0 0 0 0-12.32ZM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8Zm6.41-11.85a1.44 1.44 0 1 0 0 2.88 1.44 1.44 0 0 0 0-2.88Z"
+      />
+    </svg>
+  );
+}
+
+function LinkedInBrandIcon() {
+  return (
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        d="M20.45 20.45h-3.55v-5.57c0-1.33-.03-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V8.99h3.42v1.57h.05c.47-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.46v6.28ZM5.34 7.43a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12Zm1.78 13.02H3.56V8.99h3.56v11.46ZM22.23 0H1.77C.79 0 0 .77 0 1.73v20.54C0 23.23.79 24 1.77 24h20.46c.98 0 1.77-.77 1.77-1.73V1.73C24 .77 23.21 0 22.23 0Z"
+      />
+    </svg>
+  );
+}

--- a/components/creator-article.module.css
+++ b/components/creator-article.module.css
@@ -78,10 +78,24 @@
 }
 
 .link {
+  align-items: baseline;
   color: #8fc5ff;
+  display: inline-flex;
+  gap: 0.28em;
   text-decoration-line: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 0.2em;
+}
+
+.linkIcon {
+  display: inline-flex;
+  flex: none;
+  transform: translateY(0.08em);
+}
+
+.linkIcon svg {
+  height: 0.9em;
+  width: 0.9em;
 }
 
 .link:hover {

--- a/components/creator-article.tsx
+++ b/components/creator-article.tsx
@@ -6,8 +6,14 @@ import type {
   CreatorArticleMarkV1,
   CreatorArticleV1,
 } from "@/lib/creator-article/contract-v1";
+import {
+  CreatorArticleLinkIcon,
+  creatorArticleLinkProviderV1,
+} from "@/components/creator-article-link-icon";
 
 import styles from "./creator-article.module.css";
+
+export { creatorArticleLinkProviderV1 };
 
 export function CreatorArticle({ article }: { article: CreatorArticleV1 | null }) {
   if (article === null) return null;
@@ -102,11 +108,13 @@ function applyMark(mark: CreatorArticleMarkV1, content: ReactNode, key: number) 
   return (
     <a
       className={styles.link}
+      data-creator-link-provider={creatorArticleLinkProviderV1(mark.attrs.href)}
       href={mark.attrs.href}
       target="_blank"
       rel="noopener noreferrer"
       key={`link-${key}`}
     >
+      <CreatorArticleLinkIcon href={mark.attrs.href} className={styles.linkIcon} />
       {content}
     </a>
   );

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -2016,20 +2016,12 @@
   padding: 0;
 }
 
-.feePanel {
-  background: var(--webde-surface);
-  border: 1px solid var(--webde-line);
-  border-radius: var(--webde-radius-card);
-  height: 360px !important;
-  min-height: 360px;
-  padding: 20px;
-}
-
+.feePanel,
 .claimablePanel {
   background: var(--webde-surface);
   border: 1px solid var(--webde-line);
   border-radius: var(--webde-radius-card);
-  height: auto !important;
+  height: 100% !important;
   min-height: 360px;
   padding: 20px;
 }

--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -16,21 +16,116 @@
   min-width: 0;
 }
 
-.heading p {
-  color: var(--muted, rgb(255 255 255 / 48%));
-  font-size: 10px;
-  font-weight: 620;
-  letter-spacing: 0.12em;
-  margin: 0 0 4px;
-  text-transform: uppercase;
-}
-
 .heading h2 {
   font-size: 20px;
   font-weight: 640;
   letter-spacing: -0.026em;
   line-height: 1.1;
   margin: 0;
+}
+
+.openingBackdrop {
+  align-items: center;
+  background: rgb(0 0 0 / 78%);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 1rem;
+  position: fixed;
+  z-index: 1001;
+}
+
+.openingDialog {
+  align-items: center;
+  background: #0b0b0f;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 1rem;
+  box-shadow: 0 30px 90px rgb(0 0 0 / 55%);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  max-width: 32rem;
+  padding: 1rem;
+  width: 100%;
+}
+
+.openingIdentity {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.openingIdentity > div:last-child {
+  min-width: 0;
+}
+
+.openingIdentity p,
+.openingIdentity h2 {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.openingIdentity p {
+  color: rgb(255 255 255 / 48%);
+  font-size: 0.7rem;
+}
+
+.openingIdentity h2 {
+  font-size: 1rem;
+  margin-block-start: 0.15rem;
+}
+
+.openingArt {
+  align-items: center;
+  background: #17171c;
+  border-radius: 0.7rem;
+  display: flex;
+  flex: none;
+  height: 3rem;
+  justify-content: center;
+  outline: 1px solid rgb(255 255 255 / 12%);
+  outline-offset: -1px;
+  overflow: hidden;
+  position: relative;
+  width: 3rem;
+}
+
+.openingArt img {
+  object-fit: cover;
+}
+
+.openingProgress {
+  animation: opening-spin 800ms linear infinite;
+  border: 2px solid rgb(255 255 255 / 18%);
+  border-radius: 999px;
+  border-top-color: #f0eee8;
+  height: 1.25rem;
+  width: 1.25rem;
+}
+
+.openingDialog > button {
+  align-items: center;
+  background: transparent;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 0.55rem;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  height: 2.75rem;
+  justify-content: center;
+  width: 2.75rem;
+}
+
+.openingDialog > button:focus-visible {
+  outline: 2px solid #8fc5ff;
+  outline-offset: 2px;
+}
+
+@keyframes opening-spin {
+  to { transform: rotate(360deg); }
 }
 
 .headerActions,
@@ -266,6 +361,17 @@
   .actions a {
     flex: 1;
   }
+
+  .openingBackdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .openingDialog {
+    border-radius: 1rem 1rem 0 0;
+    border-width: 1px 0 0;
+    max-width: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -275,5 +381,9 @@
   .actions button,
   .actions a {
     transition: none;
+  }
+
+  .openingProgress {
+    animation: none;
   }
 }

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -3,8 +3,9 @@
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { getAddress, isAddress } from "viem";
 
 import { useWallet } from "@/components/wallet-provider";
@@ -60,10 +61,12 @@ export function ProfileProjects({ marketCaps = [] }: Readonly<{
   const [projects, setProjects] = useState<readonly CreatorProjectSummaryV1[]>([]);
   const [phase, setPhase] = useState<"loading" | "ready" | "error">("loading");
   const [editor, setEditor] = useState<EditorState | null>(null);
-  const [opening, setOpening] = useState<string | null>(null);
+  const [openingProject, setOpeningProject] = useState<CreatorProjectSummaryV1 | null>(null);
   const [projectPage, setProjectPage] = useState(1);
   const [projectError, setProjectError] = useState("");
   const editorRequestsRef = useRef(new Map<string, Promise<EditorState>>());
+  const editorTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const openRequestRef = useRef(0);
 
   const getAuthHeaders = useCallback(
     () => acquireCreatorArticleAuthHeadersV1({
@@ -130,33 +133,62 @@ export function ProfileProjects({ marketCaps = [] }: Readonly<{
     void getEditorState(project).catch(() => undefined);
   }, [getEditorState]);
 
-  async function openEditor(project: CreatorProjectSummaryV1) {
-    setOpening(project.tokenAddress);
+  useEffect(() => {
+    if (phase !== "ready" || pageData.items.length === 0) return;
+    const timer = window.setTimeout(() => {
+      preloadCreatorArticleEditorModule();
+      void preloadCreatorArticlePageV1(pageData.items, getEditorState, 2);
+    }, 80);
+    return () => window.clearTimeout(timer);
+  }, [getEditorState, pageData.items, phase]);
+
+  const focusEditorTrigger = useCallback(() => {
+    window.requestAnimationFrame(() => editorTriggerRef.current?.focus());
+  }, []);
+
+  async function openEditor(
+    project: CreatorProjectSummaryV1,
+    trigger: HTMLButtonElement,
+  ) {
+    const requestId = ++openRequestRef.current;
+    editorTriggerRef.current = trigger;
+    setOpeningProject(project);
     setProjectError("");
     try {
       const [, nextEditor] = await Promise.all([
         loadCreatorArticleEditorModule(),
         getEditorState(project),
       ]);
+      if (openRequestRef.current !== requestId) return;
       editorRequestsRef.current.delete(project.tokenAddress.toLowerCase());
       setEditor(nextEditor);
     } catch (error) {
+      if (openRequestRef.current !== requestId) return;
       setProjectError(error instanceof Error
         ? error.message
         : "Creator article unavailable");
+      focusEditorTrigger();
     } finally {
-      setOpening(null);
+      if (openRequestRef.current === requestId) setOpeningProject(null);
     }
   }
+
+  const closeOpeningEditor = useCallback(() => {
+    openRequestRef.current += 1;
+    setOpeningProject(null);
+    focusEditorTrigger();
+  }, [focusEditorTrigger]);
+
+  const closeEditor = useCallback(() => {
+    setEditor(null);
+    focusEditorTrigger();
+  }, [focusEditorTrigger]);
 
   if (!wallet) return null;
   return (
     <section className={styles.section} aria-labelledby="my-projects-title">
       <header className={styles.heading}>
-        <div>
-          <p>Creator workspace</p>
-          <h2 id="my-projects-title">My projects</h2>
-        </div>
+        <h2 id="my-projects-title">My projects</h2>
         <div className={styles.headerActions}>
           <button
             className={styles.refresh}
@@ -226,13 +258,13 @@ export function ProfileProjects({ marketCaps = [] }: Readonly<{
               <div className={styles.actions}>
                 <button
                   type="button"
-                  disabled={opening !== null}
+                  disabled={openingProject !== null}
                   onPointerEnter={() => warmEditor(project)}
                   onPointerDown={preloadCreatorArticleEditorModule}
                   onFocus={() => warmEditor(project)}
-                  onClick={() => void openEditor(project)}
+                  onClick={(event) => void openEditor(project, event.currentTarget)}
                 >
-                  {opening === project.tokenAddress
+                  {openingProject?.tokenAddress === project.tokenAddress
                     ? "Opening…"
                     : project.article ? "Edit article" : "Create article"}
                 </button>
@@ -249,7 +281,7 @@ export function ProfileProjects({ marketCaps = [] }: Readonly<{
           initialArticle={editor.article}
           initialEtag={editor.etag}
           getAuthHeaders={getAuthHeaders}
-          onClose={() => setEditor(null)}
+          onClose={closeEditor}
           onPublished={(article) => {
             setProjects((current) => current.map((project) =>
               project.tokenAddress === article.tokenAddress
@@ -265,8 +297,89 @@ export function ProfileProjects({ marketCaps = [] }: Readonly<{
           }}
         />
       ) : null}
+      {openingProject ? (
+        <CreatorArticleEditorOpening
+          project={openingProject}
+          onClose={closeOpeningEditor}
+        />
+      ) : null}
     </section>
   );
+}
+
+export async function preloadCreatorArticlePageV1(
+  projects: readonly CreatorProjectSummaryV1[],
+  load: (project: CreatorProjectSummaryV1) => Promise<unknown>,
+  concurrency = 2,
+): Promise<void> {
+  if (projects.length === 0) return;
+  const workerCount = Math.min(
+    projects.length,
+    Number.isSafeInteger(concurrency) && concurrency > 0 ? concurrency : 1,
+  );
+  let cursor = 0;
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (cursor < projects.length) {
+      const project = projects[cursor];
+      cursor += 1;
+      try {
+        await load(project);
+      } catch {
+        // Prewarming is best effort. An explicit open retries failed requests.
+      }
+    }
+  }));
+}
+
+function CreatorArticleEditorOpening({
+  project,
+  onClose,
+}: Readonly<{ project: CreatorProjectSummaryV1; onClose(): void }>) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const previousOverflow = window.document.body.style.overflow;
+    window.document.body.style.overflow = "hidden";
+    closeRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onClose]);
+
+  if (typeof document === "undefined") return null;
+  return createPortal((
+    <div className={styles.openingBackdrop} role="presentation">
+      <section
+        className={styles.openingDialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="opening-creator-article-title"
+      >
+        <div className={styles.openingIdentity}>
+          <div className={styles.openingArt}>
+            {project.imageUrl ? (
+              <Image src={project.imageUrl} alt="" fill sizes="48px" unoptimized />
+            ) : <span aria-hidden="true">{project.symbol?.slice(0, 2) ?? "P"}</span>}
+          </div>
+          <div>
+            <p>{project.symbol ? `$${project.symbol}` : "Verified project"}</p>
+            <h2 id="opening-creator-article-title">Opening article…</h2>
+          </div>
+        </div>
+        <span className={styles.openingProgress} aria-label="Loading" role="status" />
+        <button ref={closeRef} type="button" aria-label="Cancel opening article" onClick={onClose}>
+          <X aria-hidden="true" size={18} />
+        </button>
+      </section>
+    </div>
+  ), document.body);
 }
 
 export function paginateCreatorProjectsV1(

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -3249,7 +3249,7 @@ type ProfileActionStateCollections = {
   stockPaired: Record<string, StockPairedActionState>;
 };
 
-export const profileClaimPageSize = 5;
+export const profileClaimPageSize = 4;
 
 export function groupProfileRewards(
   tokens: readonly ProfileToken[],
@@ -4336,10 +4336,7 @@ function FeeEarningsPanel({
       aria-labelledby="fee-earnings-title"
     >
       <header className={styles.feePanelHeader}>
-        <div>
-          <h2 id="fee-earnings-title">Fees earned</h2>
-          <p>Lifetime fees for this wallet</p>
-        </div>
+        <h2 id="fee-earnings-title">Fees earned</h2>
       </header>
 
       <div className={styles.feeSummary}>

--- a/tests/creator-article-editor.test.ts
+++ b/tests/creator-article-editor.test.ts
@@ -117,4 +117,37 @@ describe("creator article editor normalization", () => {
       document: { type: "doc", content: [{ type: "paragraph" }] },
     })).not.toBe(baseline);
   });
+
+  it("treats editor-only ready image state as the published document", () => {
+    const fingerprint = (creatorArticleEditor as unknown as {
+      creatorArticleEditorFingerprintV1(input: unknown): string;
+    }).creatorArticleEditorFingerprintV1;
+    const image = {
+      url: "https://k2uoipt9wchjtz3h.public.blob.vercel-storage.com/creator-article-media/v1/eip155-1/0x7987f03462200b3d8a072e02c89a8a41dcb124ee/550e8400-e29b-41d4-a716-446655440000.inline.1200x800.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.webp",
+      alt: "Project image",
+      caption: null,
+      width: 1200,
+      height: 800,
+      size: "wide",
+    };
+
+    expect(fingerprint({
+      title: "Project story",
+      bannerImage: null,
+      document: {
+        type: "doc",
+        content: [{ type: "articleImage", attrs: image }],
+      },
+    })).toBe(fingerprint({
+      title: "Project story",
+      bannerImage: null,
+      document: {
+        type: "doc",
+        content: [{
+          type: "articleImage",
+          attrs: { ...image, uploadId: null, status: "ready" },
+        }],
+      },
+    }));
+  });
 });

--- a/tests/creator-article-renderer.test.ts
+++ b/tests/creator-article-renderer.test.ts
@@ -2,6 +2,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import * as creatorArticleRenderer from "../components/creator-article";
 import { CreatorArticle } from "../components/creator-article";
 import { parseCreatorArticleV1 } from "../lib/creator-article/contract-v1";
 
@@ -48,5 +49,45 @@ describe("creator article public renderer", () => {
   it("renders no placeholder when the article is absent", () => {
     expect(renderToStaticMarkup(createElement(CreatorArticle, { article: null })))
       .toBe("");
+  });
+
+  it("recognizes common social providers and keeps an icon for unknown HTTPS links", () => {
+    const provider = (creatorArticleRenderer as unknown as {
+      creatorArticleLinkProviderV1(href: string): string;
+    }).creatorArticleLinkProviderV1;
+    expect(typeof provider).toBe("function");
+    expect(provider("https://github.com/0xprogrammable/programmable")).toBe("github");
+    expect(provider("https://discord.gg/programmable")).toBe("discord");
+    expect(provider("https://x.com/0xProgrammable")).toBe("x");
+    expect(provider("https://t.me/programmable")).toBe("telegram");
+    expect(provider("https://docs.programmable.gitbook.io/docs")).toBe("gitbook");
+    expect(provider("https://dune.com/0xprogrammable6098")).toBe("dune");
+    expect(provider("https://programmable.market/docs")).toBe("website");
+  });
+
+  it("renders a provider-bound icon next to a published social link", () => {
+    const githubArticle = parseCreatorArticleV1({
+      ...article,
+      document: {
+        type: "doc",
+        content: [{
+          type: "paragraph",
+          content: [{
+            type: "text",
+            text: "github.com",
+            marks: [{
+              type: "link",
+              attrs: { href: "https://github.com/0xprogrammable/programmable" },
+            }],
+          }],
+        }],
+      },
+    });
+    const html = renderToStaticMarkup(createElement(CreatorArticle, {
+      article: githubArticle,
+    }));
+    expect(html).toContain('data-creator-link-provider="github"');
+    expect(html).toContain("<svg");
+    expect(html).toContain(">github.com<");
   });
 });

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -17,6 +17,37 @@ const project = {
 };
 
 describe("My projects editor opening", () => {
+  it("preloads every visible project with bounded concurrency", async () => {
+    const preload = (profileProjects as unknown as {
+      preloadCreatorArticlePageV1(
+        projects: readonly CreatorProjectSummaryV1[],
+        load: (candidate: CreatorProjectSummaryV1) => Promise<unknown>,
+        concurrency?: number,
+      ): Promise<void>;
+    }).preloadCreatorArticlePageV1;
+    expect(typeof preload).toBe("function");
+
+    const projects = Array.from({ length: 5 }, (_, index) => ({
+      ...project,
+      tokenAddress: `0x${String(index + 1).padStart(40, "0")}` as `0x${string}`,
+      name: `Project ${index + 1}`,
+    }));
+    let active = 0;
+    let maximumActive = 0;
+    const attempted: string[] = [];
+    await preload(projects, async (candidate) => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      attempted.push(candidate.tokenAddress);
+      await Promise.resolve();
+      active -= 1;
+      if (candidate === projects[2]) throw new Error("transient");
+    }, 2);
+
+    expect(maximumActive).toBe(2);
+    expect(attempted).toEqual(projects.map(({ tokenAddress }) => tokenAddress));
+  });
+
   it("paginates verified projects by highest available market cap", () => {
     const paginate = (profileProjects as unknown as {
       paginateCreatorProjectsV1(

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -423,7 +423,7 @@ describe("profile workspace loading state", () => {
 describe("fee earnings summary", () => {
   it("shows lifetime earned, available and claimed totals without a claim-history chart", () => {
     expect(profileViewSource).toContain(">Fees earned</h2>");
-    expect(profileViewSource).toContain(">Lifetime fees for this wallet</p>");
+    expect(profileViewSource).not.toContain(">Lifetime fees for this wallet</p>");
     expect(profileViewSource).toContain(">Total earned</span>");
     expect(profileViewSource).toContain("Available <b>");
     expect(profileViewSource).toContain("Claimed <b>");
@@ -727,7 +727,7 @@ describe("profile reward grouping", () => {
     );
   });
 
-  it("sorts six claimable entries before splitting them into five-row pages", () => {
+  it("sorts six claimable entries before splitting them into four-row pages", () => {
     const claimableAmounts = [1n, 9n, 3n, 7n, 5n, 2n];
     const claimTokens = claimableAmounts.map((_, index) => {
       const address = getAddress(
@@ -771,10 +771,10 @@ describe("profile reward grouping", () => {
       "C4",
       "C5",
       "C3",
-      "C6",
     ]);
     expect(secondPage).toMatchObject({ currentPage: 2, totalPages: 2 });
     expect(secondPage.items.map((entry) => entry.token.symbol)).toEqual([
+      "C6",
       "C1",
     ]);
     expect(claimTokens.map((token) => token.symbol)).toEqual([


### PR DESCRIPTION
Summary
- align fees and claim cards, paginate claim rewards four per page, and simplify profile copy
- prewarm visible creator articles and show an immediate accessible opening state
- add provider-aware social links, correct editor history states, and normalize unchanged image drafts

Validation
- 71 focused Vitest checks
- changed-path ESLint
- TypeScript noEmit
- production Next.js build and bundle scan
- local desktop and 390px mobile browser QA with clean console