### PR TITLE
Fix article editor link fingerprint

### DIFF
--- a/components/creator-article-editor.tsx
+++ b/components/creator-article-editor.tsx
@@ -781,6 +781,9 @@ function normalizeEditorFingerprintDocumentV1(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(normalizeEditorFingerprintDocumentV1);
   if (!isRecord(value)) return value;
   return Object.fromEntries(Object.entries(value).map(([key, candidate]) => {
+    if (key === "attrs" && value.type === "link" && isRecord(candidate)) {
+      return [key, { href: candidate.href }];
+    }
     if (key !== "attrs" || value.type !== "articleImage" || !isRecord(candidate)) {
       return [key, normalizeEditorFingerprintDocumentV1(candidate)];
     }

--- a/tests/creator-article-editor.test.ts
+++ b/tests/creator-article-editor.test.ts
@@ -150,4 +150,34 @@ describe("creator article editor normalization", () => {
       },
     }));
   });
+
+  it("treats editor-added link attributes as the published link", () => {
+    const fingerprint = (creatorArticleEditor as unknown as {
+      creatorArticleEditorFingerprintV1(input: unknown): string;
+    }).creatorArticleEditorFingerprintV1;
+    const article = (attrs: Record<string, unknown>) => ({
+      title: "Project story",
+      bannerImage: null,
+      document: {
+        type: "doc",
+        content: [{
+          type: "paragraph",
+          content: [{
+            type: "text",
+            text: "programmable.market",
+            marks: [{ type: "link", attrs }],
+          }],
+        }],
+      },
+    });
+
+    expect(fingerprint(article({ href: "https://programmable.market/" }))).toBe(
+      fingerprint(article({
+        href: "https://programmable.market/",
+        target: "_blank",
+        rel: "noopener noreferrer nofollow",
+        class: null,
+      })),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- normalize TipTap-added link attributes in the editor fingerprint
- prevent a false unpublished-changes prompt when reopening a published article with links
- add a focused regression test

## Verification
- `npx vitest run tests/creator-article-editor.test.ts` (7/7)
- `npm run typecheck`
- `npx eslint components/creator-article-editor.tsx tests/creator-article-editor.test.ts`
- live reproduction was isolated to the published-link fingerprint; no article was mutated during QA