### PR TITLE
Canonicalize article editor fingerprints

### DIFF
--- a/components/creator-article-editor.tsx
+++ b/components/creator-article-editor.tsx
@@ -780,18 +780,20 @@ export function creatorArticleEditorFingerprintV1(value: unknown) {
 function normalizeEditorFingerprintDocumentV1(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(normalizeEditorFingerprintDocumentV1);
   if (!isRecord(value)) return value;
-  return Object.fromEntries(Object.entries(value).map(([key, candidate]) => {
-    if (key === "attrs" && value.type === "link" && isRecord(candidate)) {
-      return [key, { href: candidate.href }];
-    }
-    if (key !== "attrs" || value.type !== "articleImage" || !isRecord(candidate)) {
-      return [key, normalizeEditorFingerprintDocumentV1(candidate)];
-    }
-    return [key, Object.fromEntries(Object.entries(candidate).flatMap(([attribute, current]) => {
-      if (attribute === "uploadId" || (attribute === "status" && current === "ready")) return [];
-      return [[attribute, normalizeEditorFingerprintDocumentV1(current)]];
-    }))];
-  }));
+  return Object.fromEntries(Object.entries(value)
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+    .map(([key, candidate]) => {
+      if (key === "attrs" && value.type === "link" && isRecord(candidate)) {
+        return [key, { href: candidate.href }];
+      }
+      if (key !== "attrs" || value.type !== "articleImage" || !isRecord(candidate)) {
+        return [key, normalizeEditorFingerprintDocumentV1(candidate)];
+      }
+      return [key, Object.fromEntries(Object.entries(candidate).flatMap(([attribute, current]) => {
+        if (attribute === "uploadId" || (attribute === "status" && current === "ready")) return [];
+        return [[attribute, normalizeEditorFingerprintDocumentV1(current)]];
+      }))];
+    }));
 }
 
 function emptyDocument(): JSONContent {

--- a/tests/creator-article-editor.test.ts
+++ b/tests/creator-article-editor.test.ts
@@ -180,4 +180,26 @@ describe("creator article editor normalization", () => {
       })),
     );
   });
+
+  it("ignores semantically irrelevant editor object-key order", () => {
+    const fingerprint = (creatorArticleEditor as unknown as {
+      creatorArticleEditorFingerprintV1(input: unknown): string;
+    }).creatorArticleEditorFingerprintV1;
+    const link = { type: "link", attrs: { href: "https://programmable.market/" } };
+    const article = (content: Record<string, unknown>) => ({
+      title: "Project story",
+      bannerImage: null,
+      document: { type: "doc", content: [{ type: "paragraph", content: [content] }] },
+    });
+
+    expect(fingerprint(article({
+      type: "text",
+      text: "programmable.market",
+      marks: [link],
+    }))).toBe(fingerprint(article({
+      type: "text",
+      marks: [link],
+      text: "programmable.market",
+    })));
+  });
 });


### PR DESCRIPTION
## Summary
- canonicalize JSON object-key order before comparing published and edited article documents
- keep array and content order fully binding
- prevent false discard warnings on untouched published articles
- add the exact `text` / `marks` ordering regression

## Verification
- `npx vitest run tests/creator-article-editor.test.ts` (8/8)
- `npm run typecheck`
- `npx eslint components/creator-article-editor.tsx tests/creator-article-editor.test.ts`
- exact live cause reproduced from the current V4 article and TipTap JSON: equal values, different object-key order only