### PR TITLE
Polish creator article story and direct editing

### DIFF
--- a/components/creator-article-edit-action.tsx
+++ b/components/creator-article-edit-action.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Pencil } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  acquireCreatorArticleAuthHeadersV1,
+  loadCreatorArticleEditorV1,
+  type CreatorArticleEditorStateV1,
+  type CreatorProjectSummaryV1,
+} from "@/components/creator-article-editor-loader";
+import { useWallet } from "@/components/wallet-provider";
+import type { CreatorArticleV1 } from "@/lib/creator-article/contract-v1";
+
+import styles from "./creator-article.module.css";
+
+const loadCreatorArticleEditorModule = () =>
+  import("@/components/creator-article-editor");
+const CreatorArticleEditor = dynamic(
+  loadCreatorArticleEditorModule,
+  { ssr: false },
+);
+
+export function CreatorArticleEditAction({
+  project,
+  creatorAddress,
+  onPublished,
+}: Readonly<{
+  project: CreatorProjectSummaryV1;
+  creatorAddress: `0x${string}`;
+  onPublished(article: CreatorArticleV1): void;
+}>) {
+  const { wallet, getAccessToken, getIdentityToken } = useWallet();
+  const walletAccount = wallet?.account.toLowerCase() ?? null;
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const requestRef = useRef<Readonly<{
+    account: string;
+    request: Promise<CreatorArticleEditorStateV1>;
+  }> | null>(null);
+  const [verifiedAccount, setVerifiedAccount] = useState<string | null>(null);
+  const [editorAccount, setEditorAccount] = useState<string | null>(null);
+  const [opening, setOpening] = useState(false);
+  const [editorState, setEditorState] =
+    useState<CreatorArticleEditorStateV1 | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [error, setError] = useState("");
+  const walletMatchesCreator = walletAccount === creatorAddress.toLowerCase();
+
+  const getAuthHeaders = useCallback(
+    () => acquireCreatorArticleAuthHeadersV1({
+      getAccessToken,
+      getIdentityToken,
+    }),
+    [getAccessToken, getIdentityToken],
+  );
+
+  const loadEditorState = useCallback(() => {
+    if (walletAccount === null) {
+      return Promise.reject(new Error("Connect your wallet to edit this article"));
+    }
+    if (requestRef.current?.account === walletAccount) {
+      return requestRef.current.request;
+    }
+    const request = loadCreatorArticleEditorV1(project, getAuthHeaders)
+      .then((next) => {
+        setEditorState(next);
+        setEditorAccount(walletAccount);
+        setVerifiedAccount(walletAccount);
+        return next;
+      })
+      .finally(() => {
+        if (requestRef.current?.request === request) requestRef.current = null;
+      });
+    requestRef.current = Object.freeze({ account: walletAccount, request });
+    return request;
+  }, [getAuthHeaders, project, walletAccount]);
+
+  useEffect(() => {
+    if (walletAccount === null) return;
+    void loadEditorState().catch(() => undefined);
+  }, [loadEditorState, walletAccount]);
+
+  if (
+    walletAccount === null
+    || (!walletMatchesCreator && verifiedAccount !== walletAccount)
+  ) return null;
+
+  async function openEditor() {
+    setOpening(true);
+    setError("");
+    try {
+      const currentEditorState = editorAccount === walletAccount
+        ? editorState
+        : null;
+      const [, nextEditorState] = await Promise.all([
+        loadCreatorArticleEditorModule(),
+        currentEditorState
+          ? Promise.resolve(currentEditorState)
+          : loadEditorState(),
+      ]);
+      setEditorState(nextEditorState);
+      setEditorOpen(true);
+    } catch {
+      setError("Article editor unavailable. Try again.");
+    } finally {
+      setOpening(false);
+    }
+  }
+
+  return (
+    <>
+      <div className={styles.editActionGroup}>
+        <button
+          ref={triggerRef}
+          className={styles.editAction}
+          type="button"
+          disabled={opening}
+          onPointerEnter={() => void loadCreatorArticleEditorModule()}
+          onFocus={() => void loadCreatorArticleEditorModule()}
+          onClick={() => void openEditor()}
+        >
+          <Pencil aria-hidden="true" size={15} strokeWidth={1.8} />
+          {opening ? "Opening…" : "Edit article"}
+        </button>
+        {error ? <p className={styles.editActionError} role="alert">{error}</p> : null}
+      </div>
+      {editorOpen && editorState ? (
+        <CreatorArticleEditor
+          project={editorState.project}
+          initialArticle={editorState.article}
+          initialEtag={editorState.etag}
+          getAuthHeaders={getAuthHeaders}
+          onClose={() => {
+            setEditorOpen(false);
+            window.requestAnimationFrame(() => triggerRef.current?.focus());
+          }}
+          onPublished={(article) => {
+            setEditorState((current) => current
+              ? { ...current, article }
+              : current);
+            onPublished(article);
+          }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/components/creator-article-editor-loader.ts
+++ b/components/creator-article-editor-loader.ts
@@ -1,0 +1,75 @@
+import { parseCreatorArticleV1, type CreatorArticleV1 } from
+  "@/lib/creator-article/contract-v1";
+
+export type CreatorProjectSummaryV1 = Readonly<{
+  chainId: 1;
+  tokenAddress: `0x${string}`;
+  name: string;
+  symbol: string | null;
+  imageUrl: string | null;
+  source: "envio-classic-v3" | "registry.custom-launched" | "official-main-token";
+  article: Readonly<{ revision: number; title: string; updatedAt: string }> | null;
+}>;
+
+export type CreatorArticleAuthHeadersV1 = Readonly<{
+  Authorization: string;
+  "X-Privy-Identity-Token"?: string;
+}>;
+
+export type CreatorArticleEditorStateV1 = Readonly<{
+  project: CreatorProjectSummaryV1;
+  article: CreatorArticleV1 | null;
+  etag: string | null;
+}>;
+
+export async function acquireCreatorArticleAuthHeadersV1(input: Readonly<{
+  getAccessToken: () => Promise<string | null>;
+  getIdentityToken: () => Promise<string | null>;
+}>): Promise<CreatorArticleAuthHeadersV1> {
+  // Privy refreshes the user and identity token through `/users/me`. Read the
+  // access token only after that refresh so both headers describe one current
+  // session rather than racing the refresh.
+  const identityToken = await input.getIdentityToken();
+  const accessToken = await input.getAccessToken();
+  if (!accessToken) {
+    throw new Error("Reconnect your wallet and try again");
+  }
+  return Object.freeze({
+    Authorization: `Bearer ${accessToken}`,
+    ...(identityToken
+      ? { "X-Privy-Identity-Token": identityToken }
+      : {}),
+  });
+}
+
+export async function loadCreatorArticleEditorV1(
+  project: CreatorProjectSummaryV1,
+  getAuthHeaders: () => Promise<CreatorArticleAuthHeadersV1>,
+  request: typeof fetch = fetch,
+): Promise<CreatorArticleEditorStateV1> {
+  const response = await request(
+    `/api/profile/projects/${project.tokenAddress}/article`,
+    { headers: { Accept: "application/json", ...(await getAuthHeaders()) } },
+  );
+  const body: unknown = await response.json().catch(() => null);
+  if (!response.ok) throw new Error(readCreatorArticleEditorErrorV1(body));
+  const record = isRecord(body) ? body : null;
+  const article = record?.article === null
+    ? null
+    : parseCreatorArticleV1(record?.article);
+  return Object.freeze({
+    project,
+    article,
+    etag: response.headers.get("etag"),
+  });
+}
+
+function readCreatorArticleEditorErrorV1(value: unknown) {
+  return isRecord(value) && typeof value.code === "string" && value.code
+    ? `${value.code[0]?.toUpperCase() ?? ""}${value.code.slice(1).replaceAll("_", " ")}`
+    : "Project request failed";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/components/creator-article-editor.tsx
+++ b/components/creator-article-editor.tsx
@@ -39,7 +39,8 @@ import { createPortal } from "react-dom";
 
 import { CreatorArticle } from "@/components/creator-article";
 import { CreatorArticleLinkIcon } from "@/components/creator-article-link-icon";
-import type { CreatorProjectSummaryV1 } from "@/components/profile-projects";
+import type { CreatorProjectSummaryV1 } from
+  "@/components/creator-article-editor-loader";
 import {
   CREATOR_ARTICLE_DRAFT_SCHEMA_V1,
   CREATOR_ARTICLE_SCHEMA_V1,

--- a/components/creator-article-link-icon.tsx
+++ b/components/creator-article-link-icon.tsx
@@ -13,6 +13,7 @@ import { WebsiteLinkIcon } from "@/components/website-link-icon";
 
 export type CreatorArticleLinkProviderV1 =
   | "discord"
+  | "docs"
   | "dune"
   | "farcaster"
   | "github"
@@ -44,7 +45,12 @@ export function creatorArticleLinkProviderV1(
   href: string,
 ): CreatorArticleLinkProviderV1 {
   try {
-    const hostname = new URL(href).hostname.toLowerCase().replace(/\.$/u, "");
+    const url = new URL(href);
+    const hostname = url.hostname.toLowerCase().replace(/\.$/u, "");
+    if (
+      (hostname === "programmable.market" || hostname.endsWith(".programmable.market"))
+      && (url.pathname === "/docs" || url.pathname.startsWith("/docs/"))
+    ) return "docs";
     for (const [provider, domains] of providers) {
       if (domains.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`))) {
         return provider;
@@ -54,6 +60,21 @@ export function creatorArticleLinkProviderV1(
     // Invalid or incomplete editor input uses the neutral website icon.
   }
   return "website";
+}
+
+export function creatorArticleLinkLabelV1(href: string) {
+  const provider = creatorArticleLinkProviderV1(href);
+  return provider === "x" ? "X"
+    : provider === "github" ? "GitHub"
+      : provider === "discord" ? "Discord"
+        : provider === "telegram" ? "Telegram"
+          : provider === "gitbook" || provider === "docs" ? "Docs"
+            : provider === "dune" ? "Dune analytics"
+              : provider === "youtube" ? "YouTube"
+                : provider === "instagram" ? "Instagram"
+                  : provider === "linkedin" ? "LinkedIn"
+                    : provider === "farcaster" ? "Farcaster"
+                      : "Website";
 }
 
 export function CreatorArticleLinkIcon({
@@ -70,8 +91,8 @@ export function CreatorArticleLinkIcon({
       {provider === "github" ? <GitHubBrandIcon />
         : provider === "discord" ? <DiscordBrandIcon />
           : provider === "x" ? <XBrandIcon />
-            : provider === "telegram" ? <TelegramBrandIcon />
-              : provider === "gitbook" ? <BookOpen />
+              : provider === "telegram" ? <TelegramBrandIcon />
+              : provider === "gitbook" || provider === "docs" ? <BookOpen />
                 : provider === "dune" ? <DuneBrandIcon />
                   : provider === "youtube" ? <YouTubeBrandIcon />
                     : provider === "instagram" ? <InstagramBrandIcon />

--- a/components/creator-article.module.css
+++ b/components/creator-article.module.css
@@ -1,50 +1,155 @@
 .article {
-  --article-measure: 46rem;
+  --article-width: 70rem;
   border-top: 1px solid color-mix(in srgb, var(--color-border, #ffffff) 16%, transparent);
-  contain: layout paint style;
-  content-visibility: auto;
   margin-block-start: clamp(4rem, 8vw, 8rem);
-  padding-block: clamp(3.5rem, 7vw, 7rem) clamp(4rem, 8vw, 8rem);
+  padding-block: clamp(1.25rem, 2.5vw, 2rem) clamp(4rem, 8vw, 8rem);
 }
 
 .header,
 .body,
-.updated {
+.actionRow {
   margin-inline: auto;
-  max-width: var(--article-measure);
+  max-width: var(--article-width);
+  width: 100%;
+}
+
+.actionRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-block-end: clamp(1rem, 2vw, 1.5rem);
+}
+
+.actionRow:empty {
+  display: none;
+}
+
+.editActionGroup {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.editAction {
+  align-items: center;
+  background: color-mix(in srgb, currentColor 7%, transparent);
+  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+  border-radius: 999px;
+  color: currentColor;
+  display: inline-flex;
+  font-size: 0.82rem;
+  font-weight: 620;
+  gap: 0.5rem;
+  justify-content: center;
+  min-height: 44px;
+  padding-inline: 1rem;
+  transition: background 150ms ease, border-color 150ms ease, transform 150ms ease;
+}
+
+.editAction:hover:not(:disabled) {
+  background: color-mix(in srgb, currentColor 11%, transparent);
+  border-color: color-mix(in srgb, currentColor 34%, transparent);
+  transform: translateY(-1px);
+}
+
+.editAction:focus-visible {
+  outline: 2px solid #8fc5ff;
+  outline-offset: 3px;
+}
+
+.editAction:disabled {
+  cursor: progress;
+  opacity: 0.62;
+}
+
+.editActionError {
+  color: #ffb1aa;
+  font-size: 0.78rem;
+  margin: 0;
 }
 
 .header {
-  margin-block-end: clamp(2.5rem, 5vw, 4.5rem);
-}
-
-.eyebrow {
-  color: color-mix(in srgb, currentColor 58%, transparent);
-  font-size: 0.72rem;
-  font-weight: 650;
-  letter-spacing: 0.16em;
-  margin: 0 0 0.8rem;
-  text-transform: uppercase;
+  margin-block-end: clamp(2.5rem, 4.5vw, 4rem);
 }
 
 .header h2 {
-  font-size: clamp(2.35rem, 6vw, 5.25rem);
+  font-size: clamp(2.7rem, 6vw, 5.1rem);
   font-weight: 520;
   letter-spacing: -0.055em;
-  line-height: 0.98;
+  line-height: 0.96;
   margin: 0;
   text-wrap: balance;
 }
 
+.updated {
+  color: color-mix(in srgb, currentColor 54%, transparent);
+  display: block;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  margin-block-start: 1rem;
+}
+
+.socials {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-block-start: 1.4rem;
+}
+
+.socials a {
+  align-items: center;
+  background: color-mix(in srgb, currentColor 6%, transparent);
+  border: 1px solid color-mix(in srgb, currentColor 17%, transparent);
+  border-radius: 50%;
+  color: color-mix(in srgb, currentColor 82%, transparent);
+  display: inline-flex;
+  height: 44px;
+  justify-content: center;
+  transition: background 150ms ease, border-color 150ms ease, color 150ms ease, transform 150ms ease;
+  width: 44px;
+}
+
+.socials a:hover {
+  background: color-mix(in srgb, currentColor 11%, transparent);
+  border-color: color-mix(in srgb, currentColor 34%, transparent);
+  color: currentColor;
+  transform: translateY(-1px);
+}
+
+.socials a:focus-visible {
+  outline: 2px solid #8fc5ff;
+  outline-offset: 3px;
+}
+
+.socialIcon,
+.socialIcon svg {
+  display: block;
+  height: 18px;
+  width: 18px;
+}
+
 .body {
   color: color-mix(in srgb, currentColor 88%, transparent);
-  font-size: clamp(1.03rem, 1.5vw, 1.22rem);
-  line-height: 1.72;
+  font-size: clamp(1.06rem, 1.45vw, 1.24rem);
+  line-height: 1.66;
+  overflow-wrap: break-word;
 }
 
 .body > p,
 .body li > p {
-  margin: 0 0 1.45em;
+  margin: 0 0 1.5em;
+}
+
+.body > p:first-child {
+  color: currentColor;
+  font-size: clamp(1.28rem, 2.2vw, 1.65rem);
+  letter-spacing: -0.018em;
+  line-height: 1.5;
+  margin-block-end: 2.1em;
+  text-wrap: pretty;
 }
 
 .body h3,
@@ -56,9 +161,9 @@
 }
 
 .body h3 {
-  font-size: clamp(1.75rem, 3.5vw, 2.75rem);
+  font-size: clamp(1.9rem, 3.5vw, 2.9rem);
   font-weight: 560;
-  margin: 2.4em 0 0.72em;
+  margin: 1.85em 0 0.65em;
 }
 
 .body h4 {
@@ -123,15 +228,15 @@
 }
 
 .media figcaption {
-  color: color-mix(in srgb, currentColor 52%, transparent);
-  font-size: 0.76rem;
-  line-height: 1.45;
-  margin-block-start: 0.72rem;
+  color: color-mix(in srgb, currentColor 64%, transparent);
+  font-size: clamp(0.88rem, 1.2vw, 1rem);
+  line-height: 1.5;
+  margin-block-start: 0.85rem;
 }
 
 .banner {
-  margin-block: 0 clamp(3rem, 7vw, 6.5rem);
-  max-width: 70rem;
+  margin-block: 0 clamp(1.7rem, 3.2vw, 2.75rem);
+  max-width: var(--article-width);
 }
 
 .banner img {
@@ -143,30 +248,61 @@
 }
 
 .content {
-  max-width: var(--article-measure);
+  max-width: var(--article-width);
 }
 
 .wide {
-  left: 50%;
-  max-width: 70rem;
-  position: relative;
-  transform: translateX(-50%);
-  width: min(70rem, calc(100vw - 2 * clamp(1rem, 4vw, 3rem)));
+  max-width: var(--article-width);
+  width: 100%;
 }
 
-.updated {
-  color: color-mix(in srgb, currentColor 46%, transparent);
-  font-size: 0.75rem;
-  margin-block-start: clamp(3rem, 6vw, 5rem);
+@media (min-width: 64rem) {
+  .header h2[data-single-line="true"] {
+    text-wrap: nowrap;
+    white-space: nowrap;
+  }
 }
 
 @media (max-width: 48rem) {
   .article {
     margin-block-start: 3.5rem;
-    padding-block: 3rem 4.5rem;
+    padding-block: 1.25rem 4.5rem;
   }
 
-  .wide {
-    width: calc(100vw - 2rem);
+  .actionRow {
+    margin-block-end: 1rem;
+  }
+
+  .banner {
+    margin-block-end: 1.65rem;
+  }
+
+  .header {
+    margin-block-end: 2.5rem;
+  }
+
+  .header h2 {
+    font-size: clamp(2.45rem, 12vw, 3.6rem);
+  }
+
+  .socials {
+    gap: 0.65rem;
+  }
+
+  .body {
+    font-size: 1.05rem;
+    line-height: 1.65;
+  }
+
+  .body > p:first-child {
+    font-size: 1.22rem;
+  }
+
+  .body h3 {
+    font-size: clamp(1.75rem, 9vw, 2.35rem);
+  }
+
+  .media {
+    margin-block: 2.75rem;
   }
 }

--- a/components/creator-article.tsx
+++ b/components/creator-article.tsx
@@ -2,12 +2,14 @@ import Image from "next/image";
 import type { ReactNode } from "react";
 
 import type {
+  CreatorArticleBlockV1,
   CreatorArticleInlineV1,
   CreatorArticleMarkV1,
   CreatorArticleV1,
 } from "@/lib/creator-article/contract-v1";
 import {
   CreatorArticleLinkIcon,
+  creatorArticleLinkLabelV1,
   creatorArticleLinkProviderV1,
 } from "@/components/creator-article-link-icon";
 
@@ -15,10 +17,29 @@ import styles from "./creator-article.module.css";
 
 export { creatorArticleLinkProviderV1 };
 
-export function CreatorArticle({ article }: { article: CreatorArticleV1 | null }) {
+type CreatorArticleHeaderLinkV1 = Readonly<{
+  href: string;
+  label: string;
+}>;
+
+export function CreatorArticle({
+  article,
+  editAction = null,
+}: Readonly<{
+  article: CreatorArticleV1 | null;
+  editAction?: ReactNode;
+}>) {
   if (article === null) return null;
+  const headerContent = creatorArticleHeaderContentV1(article.document.content);
+  const updated = new Intl.DateTimeFormat("en", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(article.updatedAt));
   return (
     <article className={styles.article} aria-labelledby="creator-article-title">
+      {editAction ? <div className={styles.actionRow}>{editAction}</div> : null}
       {article.bannerImage ? (
         <figure className={`${styles.media} ${styles.banner}`}>
           <Image
@@ -35,11 +56,38 @@ export function CreatorArticle({ article }: { article: CreatorArticleV1 | null }
         </figure>
       ) : null}
       <header className={styles.header}>
-        <p className={styles.eyebrow}>From the creator</p>
-        <h2 id="creator-article-title">{article.title}</h2>
+        <h2
+          id="creator-article-title"
+          data-single-line={article.title.trim().length <= 32 ? "true" : undefined}
+        >
+          {article.title}
+        </h2>
+        <time className={styles.updated} dateTime={article.updatedAt}>
+          Updated {updated}
+        </time>
+        {headerContent.links.length > 0 ? (
+          <nav className={styles.socials} aria-label="Project links">
+            {headerContent.links.map((link) => (
+              <a
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={link.label}
+                title={link.label}
+                data-creator-link-provider={creatorArticleLinkProviderV1(link.href)}
+                key={link.href}
+              >
+                <CreatorArticleLinkIcon
+                  href={link.href}
+                  className={styles.socialIcon}
+                />
+              </a>
+            ))}
+          </nav>
+        ) : null}
       </header>
       <div className={styles.body}>
-        {article.document.content.map((block, index) => {
+        {headerContent.body.map((block, index) => {
           if (block.type === "paragraph") {
             return <p key={index}>{renderInline(block.content ?? [])}</p>;
           }
@@ -84,13 +132,46 @@ export function CreatorArticle({ article }: { article: CreatorArticleV1 | null }
           );
         })}
       </div>
-      <footer className={styles.updated}>
-        Updated {new Intl.DateTimeFormat("en", {
-          year: "numeric", month: "short", day: "numeric",
-        }).format(new Date(article.updatedAt))}
-      </footer>
     </article>
   );
+}
+
+export function creatorArticleHeaderContentV1(
+  blocks: readonly CreatorArticleBlockV1[],
+): Readonly<{
+  body: readonly CreatorArticleBlockV1[];
+  links: readonly CreatorArticleHeaderLinkV1[];
+}> {
+  for (let blockIndex = 0; blockIndex < blocks.length; blockIndex += 1) {
+    const block = blocks[blockIndex];
+    if (block?.type !== "paragraph" || !block.content) continue;
+    const links: CreatorArticleHeaderLinkV1[] = [];
+    let linkOnly = true;
+    for (const node of block.content) {
+      if (node.type === "hardBreak") continue;
+      const link = node.marks?.find((mark) => mark.type === "link");
+      if (!link) {
+        if (!/^[\s·|•,/]*$/u.test(node.text)) linkOnly = false;
+        continue;
+      }
+      if (node.text.trim() === "") continue;
+      links.push(Object.freeze({
+        href: link.attrs.href,
+        label: creatorArticleLinkLabelV1(link.attrs.href),
+      }));
+    }
+    if (!linkOnly || links.length < 2) continue;
+    const seen = new Set<string>();
+    return Object.freeze({
+      body: Object.freeze(blocks.filter((_, index) => index !== blockIndex)),
+      links: Object.freeze(links.filter(({ href }) => {
+        if (seen.has(href)) return false;
+        seen.add(href);
+        return true;
+      })),
+    });
+  }
+  return Object.freeze({ body: blocks, links: Object.freeze([]) });
 }
 
 function renderInline(nodes: readonly CreatorArticleInlineV1[]) {

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -8,11 +8,22 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { getAddress, isAddress } from "viem";
 
+import {
+  acquireCreatorArticleAuthHeadersV1,
+  loadCreatorArticleEditorV1,
+  type CreatorArticleEditorStateV1 as EditorState,
+  type CreatorProjectSummaryV1,
+} from "@/components/creator-article-editor-loader";
 import { useWallet } from "@/components/wallet-provider";
-import { parseCreatorArticleV1, type CreatorArticleV1 } from
-  "@/lib/creator-article/contract-v1";
 
 import styles from "./profile-projects.module.css";
+
+export {
+  acquireCreatorArticleAuthHeadersV1,
+  loadCreatorArticleEditorV1,
+} from "@/components/creator-article-editor-loader";
+export type { CreatorProjectSummaryV1 } from
+  "@/components/creator-article-editor-loader";
 
 const loadCreatorArticleEditorModule = () =>
   import("@/components/creator-article-editor");
@@ -26,32 +37,11 @@ const CreatorArticleEditor = dynamic(
 
 export const creatorProjectPageSize = 5;
 
-export type CreatorProjectSummaryV1 = Readonly<{
-  chainId: 1;
-  tokenAddress: `0x${string}`;
-  name: string;
-  symbol: string | null;
-  imageUrl: string | null;
-  source: "envio-classic-v3" | "registry.custom-launched" | "official-main-token";
-  article: Readonly<{ revision: number; title: string; updatedAt: string }> | null;
-}>;
-
 export type CreatorProjectMarketCapV1 = Readonly<{
   tokenAddress: `0x${string}`;
   usdWad: string | null;
   ethWei: string | null;
   label: string | null;
-}>;
-
-type EditorState = Readonly<{
-  project: CreatorProjectSummaryV1;
-  article: CreatorArticleV1 | null;
-  etag: string | null;
-}>;
-
-type AuthHeaders = Readonly<{
-  Authorization: string;
-  "X-Privy-Identity-Token"?: string;
 }>;
 
 export function ProfileProjects({ marketCaps = [] }: Readonly<{
@@ -421,48 +411,6 @@ export function paginateCreatorProjectsV1(
     currentPage,
     totalPages,
     items: Object.freeze(ordered.slice(offset, offset + creatorProjectPageSize)),
-  });
-}
-
-export async function acquireCreatorArticleAuthHeadersV1(input: Readonly<{
-  getAccessToken: () => Promise<string | null>;
-  getIdentityToken: () => Promise<string | null>;
-}>): Promise<AuthHeaders> {
-  // Privy refreshes the user and identity token through `/users/me`. Read the
-  // access token only after that refresh so both headers describe one current
-  // session rather than racing the refresh.
-  const identityToken = await input.getIdentityToken();
-  const accessToken = await input.getAccessToken();
-  if (!accessToken) {
-    throw new Error("Reconnect your wallet and try again");
-  }
-  return Object.freeze({
-    Authorization: `Bearer ${accessToken}`,
-    ...(identityToken
-      ? { "X-Privy-Identity-Token": identityToken }
-      : {}),
-  });
-}
-
-export async function loadCreatorArticleEditorV1(
-  project: CreatorProjectSummaryV1,
-  getAuthHeaders: () => Promise<AuthHeaders>,
-  request: typeof fetch = fetch,
-): Promise<EditorState> {
-  const response = await request(
-    `/api/profile/projects/${project.tokenAddress}/article`,
-    { headers: { Accept: "application/json", ...(await getAuthHeaders()) } },
-  );
-  const body: unknown = await response.json().catch(() => null);
-  if (!response.ok) throw new Error(readError(body));
-  const record = isRecord(body) ? body : null;
-  const article = record?.article === null
-    ? null
-    : parseCreatorArticleV1(record?.article);
-  return Object.freeze({
-    project,
-    article,
-    etag: response.headers.get("etag"),
   });
 }
 

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -28,6 +28,8 @@ import {
 } from "@/components/token-price-chart";
 import { CustomMarketTrade } from "@/components/custom-market-trade";
 import { CreatorArticle } from "@/components/creator-article";
+import { CreatorArticleEditAction } from
+  "@/components/creator-article-edit-action";
 import {
   getExplorePreviewCreatorArticle,
   getExplorePreviewCustomProject,
@@ -65,6 +67,8 @@ import {
   parseCreatorArticleV1,
   type CreatorArticleV1,
 } from "@/lib/creator-article/contract-v1";
+import { PROGRAMMABLE_MAIN_TOKEN_ADDRESS } from
+  "@/lib/creator-article/programmable-example-v1";
 import type { PostLaunchAuthorityInventoryV1 } from "@/lib/custom-launch/contract-v2";
 import styles from "./token-experience.module.css";
 
@@ -1346,6 +1350,8 @@ function TokenDetailContent({
   const [copied, setCopied] = useState(false);
   const [copyError, setCopyError] = useState("");
   const [chartVolume, setChartVolume] = useState<TokenChartVolume | null>(null);
+  const [publishedCreatorArticle, setPublishedCreatorArticle] =
+    useState<CreatorArticleV1 | null>(null);
   const [tradeFlow, setTradeFlow] = useState<TradeFlow>({
     phase: "form",
   });
@@ -1370,6 +1376,45 @@ function TokenDetailContent({
   const classicSwapFeeBps = typeof defaultSwapFeeBps === "number"
     ? defaultSwapFeeBps
     : null;
+  const visibleCreatorArticle = publishedCreatorArticle
+      && (!creatorArticle || publishedCreatorArticle.revision >= creatorArticle.revision)
+    ? publishedCreatorArticle
+    : creatorArticle;
+  const creatorProject = useMemo(() => {
+    if (
+      preview
+      || chainId !== 1
+      || !token.creatorAddress
+      || !isAddress(token.creatorAddress)
+    ) return null;
+    return Object.freeze({
+      chainId: 1 as const,
+      tokenAddress: getAddress(token.tokenAddress),
+      name: token.name,
+      symbol: token.symbol || null,
+      imageUrl: token.imageUrl?.trim() || null,
+      source: token.tokenAddress.toLowerCase()
+          === PROGRAMMABLE_MAIN_TOKEN_ADDRESS.toLowerCase()
+        ? "official-main-token" as const
+        : "envio-classic-v3" as const,
+      article: visibleCreatorArticle
+        ? Object.freeze({
+            revision: visibleCreatorArticle.revision,
+            title: visibleCreatorArticle.title,
+            updatedAt: visibleCreatorArticle.updatedAt,
+          })
+        : null,
+    });
+  }, [
+    chainId,
+    preview,
+    token.creatorAddress,
+    token.imageUrl,
+    token.name,
+    token.symbol,
+    token.tokenAddress,
+    visibleCreatorArticle,
+  ]);
 
   useEffect(
     () => () => {
@@ -1858,7 +1903,16 @@ function TokenDetailContent({
         ) : null}
 
       </div>
-      <CreatorArticle article={creatorArticle} />
+      <CreatorArticle
+        article={visibleCreatorArticle}
+        editAction={creatorProject && token.creatorAddress ? (
+          <CreatorArticleEditAction
+            project={creatorProject}
+            creatorAddress={getAddress(token.creatorAddress)}
+            onPublished={setPublishedCreatorArticle}
+          />
+        ) : null}
+      />
       {copyError ? (
         <div className="toast-region" aria-live="assertive" aria-atomic="true">
           <p className="toast" role="alert">
@@ -1943,12 +1997,42 @@ function CustomProjectDetailContent({
   } = useWallet();
   const [copied, setCopied] = useState(false);
   const [copyError, setCopyError] = useState("");
+  const [publishedCreatorArticle, setPublishedCreatorArticle] =
+    useState<CreatorArticleV1 | null>(null);
   const copyResetTimer = useRef<number | null>(null);
   const imageUrl = project.imageUrl?.trim()
     || getFallbackTokenImage(project.tokenAddress ?? project.customProjectId);
   const imageSource = getTokenCardImageSource(imageUrl);
   const authorities = project.postLaunchAuthorityInventory.postLaunchAuthorities;
   const metrics = customMarketMetrics(project);
+  const visibleCreatorArticle = publishedCreatorArticle
+      && (!creatorArticle || publishedCreatorArticle.revision >= creatorArticle.revision)
+    ? publishedCreatorArticle
+    : creatorArticle;
+  const creatorProject = useMemo(() => {
+    if (
+      chainId !== 1
+      || !project.tokenAddress
+      || project.chainId !== "1"
+      || project.launchingWallet.namespace !== "eip155:1"
+      || !isAddress(project.launchingWallet.value)
+    ) return null;
+    return Object.freeze({
+      chainId: 1 as const,
+      tokenAddress: getAddress(project.tokenAddress),
+      name: project.name,
+      symbol: project.symbol?.trim() || null,
+      imageUrl: project.imageUrl?.trim() || null,
+      source: "registry.custom-launched" as const,
+      article: visibleCreatorArticle
+        ? Object.freeze({
+            revision: visibleCreatorArticle.revision,
+            title: visibleCreatorArticle.title,
+            updatedAt: visibleCreatorArticle.updatedAt,
+          })
+        : null,
+    });
+  }, [chainId, project, visibleCreatorArticle]);
 
   useEffect(() => () => {
     if (copyResetTimer.current !== null) window.clearTimeout(copyResetTimer.current);
@@ -2156,7 +2240,16 @@ function CustomProjectDetailContent({
           </p>
         </section>
       </div>
-      <CreatorArticle article={creatorArticle} />
+      <CreatorArticle
+        article={visibleCreatorArticle}
+        editAction={creatorProject && isAddress(project.launchingWallet.value) ? (
+          <CreatorArticleEditAction
+            project={creatorProject}
+            creatorAddress={getAddress(project.launchingWallet.value)}
+            onPublished={setPublishedCreatorArticle}
+          />
+        ) : null}
+      />
       {copyError ? (
         <div className="toast-region" aria-live="assertive" aria-atomic="true">
           <p className="toast" role="alert">{copyError}</p>

--- a/config/creator-article-programmable-example.v1.json
+++ b/config/creator-article-programmable-example.v1.json
@@ -2,10 +2,10 @@
   "schemaVersion": "programmable.creator-article-draft.v1",
   "chainId": 1,
   "tokenAddress": "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
-  "title": "Programmable: tokens with something to do",
+  "title": "Shape what assets can do",
   "bannerImage": {
     "url": "https://programmable.market/brand/programmable-final-x-banner-1500x500.png",
-    "alt": "Programmable floral landscape",
+    "alt": "Programmable floral night garden",
     "caption": null,
     "width": 1500,
     "height": 500,
@@ -19,87 +19,121 @@
         "content": [
           {
             "type": "text",
-            "text": "Programmable is a launchpad for tokens with onchain behavior. Creators choose a launch model, publish a verified identity, and meet the market on the same page."
+            "text": "Website",
+            "marks": [{ "type": "link", "attrs": { "href": "https://programmable.market/" } }]
+          },
+          { "type": "text", "text": "   " },
+          {
+            "type": "text",
+            "text": "Docs",
+            "marks": [{ "type": "link", "attrs": { "href": "https://programmable.market/docs" } }]
+          },
+          { "type": "text", "text": "   " },
+          {
+            "type": "text",
+            "text": "X",
+            "marks": [{ "type": "link", "attrs": { "href": "https://x.com/0xProgrammable" } }]
+          },
+          { "type": "text", "text": "   " },
+          {
+            "type": "text",
+            "text": "GitHub",
+            "marks": [{ "type": "link", "attrs": { "href": "https://github.com/0xprogrammable" } }]
+          },
+          { "type": "text", "text": "   " },
+          {
+            "type": "text",
+            "text": "Discord",
+            "marks": [{ "type": "link", "attrs": { "href": "https://discord.com/invite/programmable" } }]
+          },
+          { "type": "text", "text": "   " },
+          {
+            "type": "text",
+            "text": "Analytics",
+            "marks": [{ "type": "link", "attrs": { "href": "https://dune.com/0xprogrammable6098/programmable-analytics" } }]
           }
         ]
+      },
+      {
+        "type": "paragraph",
+        "content": [{
+          "type": "text",
+          "text": "Most tokens begin with a name, an image and a market. We think they can begin with an idea."
+        }]
+      },
+      {
+        "type": "paragraph",
+        "content": [{
+          "type": "text",
+          "text": "Programmable is a place to launch and discover assets built to do something. A creator can start with a straightforward token, or bring a product whose rules live in a Uniswap v4 Hook. Either way, the goal is the same: turn an idea into something people can understand, use and follow in public."
+        }]
       },
       {
         "type": "heading",
         "attrs": { "level": 2 },
-        "content": [{ "type": "text", "text": "Launch, discover, trade" }]
+        "content": [{ "type": "text", "text": "A launch should feel simple" }]
       },
       {
         "type": "paragraph",
-        "content": [
-          {
-            "type": "text",
-            "text": "Each public coin page keeps verified launch identity, market context, and trading in one place. The launch record stays separate from the story a creator publishes below it."
-          }
-        ]
-      },
-      {
-        "type": "articleImage",
-        "attrs": {
-          "url": "https://programmable.market/brand/programmable-adaptive-model-post-v1-2000x1000.png",
-          "alt": "Programmable launch model artwork",
-          "caption": "A Programmable launch starts with a model and a verified creator.",
-          "width": 2000,
-          "height": 1000,
-          "size": "wide"
-        }
+        "content": [{
+          "type": "text",
+          "text": "Creating a token should not feel like assembling infrastructure. On Programmable, the important choices sit in one flow. You shape the launch, review what your wallet will sign and arrive at a page that is ready to share. The contract address stays visible, the market sits beside the story and the project has one clear home from day one."
+        }]
       },
       {
         "type": "heading",
         "attrs": { "level": 2 },
-        "content": [{ "type": "text", "text": "Built for creators" }]
+        "content": [{ "type": "text", "text": "More than a token page" }]
       },
       {
         "type": "paragraph",
-        "content": [
-          {
-            "type": "text",
-            "text": "This project story is controlled by the verified launch wallet. It can evolve as the project grows without changing the token contract, original metadata, or canonical social links."
-          }
-        ]
+        "content": [{
+          "type": "text",
+          "text": "Markets move quickly, but projects grow slowly. A token is permanent; its story is not. Creators can return to their page to explain what they are building, add images, publish changes and point people toward the places where the community lives. The token itself does not change. The context around it can become richer as the work moves forward."
+        }]
       },
       {
-        "type": "bulletList",
-        "content": [
-          {
-            "type": "listItem",
-            "content": [{
-              "type": "paragraph",
-              "content": [{ "type": "text", "text": "Launch on Ethereum with a verified public identity." }]
-            }]
-          },
-          {
-            "type": "listItem",
-            "content": [{
-              "type": "paragraph",
-              "content": [{ "type": "text", "text": "Follow the market and trade from the coin page." }]
-            }]
-          },
-          {
-            "type": "listItem",
-            "content": [{
-              "type": "paragraph",
-              "content": [{ "type": "text", "text": "Review creator rewards from the connected profile." }]
-            }]
-          }
-        ]
+        "type": "heading",
+        "attrs": { "level": 2 },
+        "content": [{ "type": "text", "text": "Hooks make room for ideas" }]
       },
       {
         "type": "paragraph",
-        "content": [
-          {
-            "type": "text",
-            "text": "programmable.market",
-            "marks": [{
-              "type": "link",
-              "attrs": { "href": "https://programmable.market/" }
-            }]
-          }
-        ]
+        "content": [{
+          "type": "text",
+          "text": "A Hook is a smart contract attached to a Uniswap v4 pool. In plain language, it gives the market rules: when a fee changes, when a reward is earned, or what may happen around a trade. Programmable exists to make those possibilities easier to explore and, over time, easier to create without asking every creator to become a Solidity engineer."
+        }]
+      },
+      {
+        "type": "heading",
+        "attrs": { "level": 2 },
+        "content": [{ "type": "text", "text": "Built in public" }]
+      },
+      {
+        "type": "paragraph",
+        "content": [{
+          "type": "text",
+          "text": "Anyone should be able to see what they are looking at. Programmable publishes supported launches only after their token, pool and creator record can be tied together. Custom products follow a separate review before they appear. Price and chart services can come and go; the identity of a real launch should not disappear with them."
+        }]
+      },
+      {
+        "type": "heading",
+        "attrs": { "level": 2 },
+        "content": [{ "type": "text", "text": "A place creators can return to" }]
+      },
+      {
+        "type": "paragraph",
+        "content": [{
+          "type": "text",
+          "text": "Launching is the beginning. From the same profile, creators can update their project story and see the rewards their work has earned. Visitors can explore the market, read the context and decide for themselves what they want to do next."
+        }]
+      },
+      {
+        "type": "paragraph",
+        "content": [{
+          "type": "text",
+          "text": "That is the whole idea behind Programmable: make the first step understandable, keep the important facts visible and leave more room for people to decide what an asset can become."
+        }]
       }
     ]
   }

--- a/lib/server/creator-article/api.server.ts
+++ b/lib/server/creator-article/api.server.ts
@@ -113,7 +113,9 @@ export function createCreatorArticleApiHandlersV1(input: Readonly<{
         if (Number.isFinite(contentLength) && contentLength > MAXIMUM_DRAFT_BYTES) {
           return errorResponse(413, "article_too_large");
         }
-        const ifMatch = request.headers.get("if-match");
+        const ifMatch = normalizeCreatorArticleIfMatchV1(
+          request.headers.get("if-match"),
+        );
         const ifNoneMatch = request.headers.get("if-none-match");
         if ((ifMatch === null) === (ifNoneMatch !== "*")) {
           return errorResponse(428, "article_precondition_required");
@@ -145,6 +147,12 @@ export function createCreatorArticleApiHandlersV1(input: Readonly<{
       }
     },
   });
+}
+
+export function normalizeCreatorArticleIfMatchV1(value: string | null) {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.startsWith("W/") ? trimmed.slice(2).trimStart() : trimmed;
 }
 
 let productionHandlers: CreatorArticleApiHandlersV1 | null = null;

--- a/lib/server/creator-article/storage.server.ts
+++ b/lib/server/creator-article/storage.server.ts
@@ -170,13 +170,15 @@ export function createCreatorArticleStoreV1(input: Readonly<{
         }
         throw error;
       }
-      const readback = await this.readCurrent(identity);
-      if (
-        readback === null
-        || readback.etag !== pointerWrite.etag
-        || readback.contentSha256 !== contentSha256
-      ) throw new TypeError("Creator article readback verification failed");
-      return readback;
+      // Vercel Blob's public pointer can remain cached briefly after an exact
+      // conditional overwrite. The immutable article bytes and the successful
+      // pointer-write receipt already bind this revision; re-reading the public
+      // URL here can only turn a completed publish into a false 503.
+      return Object.freeze({
+        article,
+        etag: pointerWrite.etag,
+        contentSha256,
+      });
     },
   });
 }

--- a/tests/creator-article-api.test.ts
+++ b/tests/creator-article-api.test.ts
@@ -91,6 +91,24 @@ describe("creator article authenticated APIs", () => {
     }));
   });
 
+  it("normalizes a weak HTTP ETag before the exact Blob precondition", async () => {
+    const response = await handlers.article(new Request(
+      `https://example.com/api/profile/projects/${TOKEN}/article`,
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          "if-match": 'W/"etag-1"',
+        },
+        body: JSON.stringify(draft()),
+      },
+    ), TOKEN);
+    expect(response.status).toBe(200);
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({
+      expectedEtag: '"etag-1"',
+    }));
+  });
+
   it("does not trust a draft for another token", async () => {
     const wrong = { ...draft(), tokenAddress: "0x4444444444444444444444444444444444444444" };
     const response = await handlers.article(new Request(`https://example.com/api/profile/projects/${TOKEN}/article`, {

--- a/tests/creator-article-renderer.test.ts
+++ b/tests/creator-article-renderer.test.ts
@@ -62,7 +62,7 @@ describe("creator article public renderer", () => {
     expect(provider("https://t.me/programmable")).toBe("telegram");
     expect(provider("https://docs.programmable.gitbook.io/docs")).toBe("gitbook");
     expect(provider("https://dune.com/0xprogrammable6098")).toBe("dune");
-    expect(provider("https://programmable.market/docs")).toBe("website");
+    expect(provider("https://programmable.market/docs")).toBe("docs");
   });
 
   it("renders a provider-bound icon next to a published social link", () => {
@@ -89,5 +89,51 @@ describe("creator article public renderer", () => {
     expect(html).toContain('data-creator-link-provider="github"');
     expect(html).toContain("<svg");
     expect(html).toContain(">github.com<");
+  });
+
+  it("lifts a social link row into an icon-only header with accessible names", () => {
+    const socialArticle = parseCreatorArticleV1({
+      ...article,
+      document: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "Website",
+                marks: [{ type: "link", attrs: { href: "https://programmable.market/" } }],
+              },
+              { type: "text", text: "   " },
+              {
+                type: "text",
+                text: "Docs",
+                marks: [{ type: "link", attrs: { href: "https://programmable.market/docs" } }],
+              },
+              { type: "text", text: "   " },
+              {
+                type: "text",
+                text: "Analytics",
+                marks: [{ type: "link", attrs: { href: "https://dune.com/0xprogrammable6098/programmable-analytics" } }],
+              },
+            ],
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "The article story remains visible." }],
+          },
+        ],
+      },
+    });
+    const html = renderToStaticMarkup(createElement(CreatorArticle, {
+      article: socialArticle,
+    }));
+    expect(html).toContain('aria-label="Project links"');
+    expect(html).toContain('aria-label="Website"');
+    expect(html).toContain('aria-label="Docs"');
+    expect(html).toContain('aria-label="Dune analytics"');
+    expect(html).not.toContain(">Analytics<");
+    expect(html).toContain("The article story remains visible.");
   });
 });

--- a/tests/creator-article-storage.test.ts
+++ b/tests/creator-article-storage.test.ts
@@ -84,6 +84,31 @@ describe("creator article Blob revision store", () => {
     })).rejects.toMatchObject({ name: "CreatorArticleRevisionConflictV1" });
   });
 
+  it("returns the exact write receipt when the public pointer read is still stale", async () => {
+    const memory = memoryStore();
+    let pointerWritten = false;
+    const store = createCreatorArticleStoreV1({
+      blob: {
+        async read(pathname) {
+          if (pointerWritten && pathname.endsWith("/current.json")) return null;
+          return memory.boundary.read(pathname);
+        },
+        async write(input) {
+          const receipt = await memory.boundary.write(input);
+          if (input.pathname.endsWith("/current.json")) pointerWritten = true;
+          return receipt;
+        },
+      },
+      now: () => new Date("2026-08-21T00:00:00.000Z"),
+    });
+    const published = await store.publish({
+      draft: draft(), creatorAddress: CREATOR, expectedEtag: null,
+    });
+    expect(published.article.revision).toBe(1);
+    expect(published.etag).toMatch(/^etag-/u);
+    expect(published.contentSha256).toMatch(/^sha256:[0-9a-f]{64}$/u);
+  });
+
   it("rejects a malformed pointer instead of selecting arbitrary content", async () => {
     const memory = memoryStore();
     memory.records.set(

--- a/tests/explore-interface-preview.test.ts
+++ b/tests/explore-interface-preview.test.ts
@@ -13,7 +13,7 @@ describe("Explore interface preview", () => {
     const article = getExplorePreviewCreatorArticle(
       "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
     );
-    expect(article?.title).toBe("Programmable: tokens with something to do");
+    expect(article?.title).toBe("Shape what assets can do");
     expect(getExplorePreviewCreatorArticle(EXPLORE_PREVIEW_TOKENS[0]!.tokenAddress))
       .toBeNull();
   });

--- a/tests/programmable-creator-article-example.test.ts
+++ b/tests/programmable-creator-article-example.test.ts
@@ -6,11 +6,13 @@ import {
 } from "../lib/creator-article/programmable-example-v1";
 
 describe("Programmable Main-token creator article example", () => {
-  it("is a strict factual image-rich draft bound to the exact Main token", () => {
+  it("is a strict factual creator story bound to the exact Main token", () => {
     const draft = programmableCreatorArticleExampleV1();
     expect(draft.tokenAddress).toBe(PROGRAMMABLE_MAIN_TOKEN_ADDRESS);
     expect(draft.bannerImage).toMatchObject({ width: 1500, height: 500, size: "wide" });
-    expect(draft.document.content.some((block) => block.type === "articleImage")).toBe(true);
+    expect(draft.document.content.some((block) => block.type === "articleImage")).toBe(false);
+    expect(JSON.stringify(draft)).toContain("https://programmable.market/docs");
+    expect(JSON.stringify(draft)).toContain("https://dune.com/0xprogrammable6098/programmable-analytics");
     expect(JSON.stringify(draft)).not.toMatch(/unruggable|guaranteed|partnered/iu);
   });
 });


### PR DESCRIPTION
## Outcome
- reshapes the public creator story into a full-width editorial surface with the updated date below the title and icon-only project links
- adds a direct Edit article action on verified creators own token pages while reusing the existing protected editor
- replaces the Programmable example with a human-readable project story, Docs and Dune links, and no obsolete inline Explore image
- prevents weak ETags and short-lived Blob pointer cache lag from turning valid article updates into failed publishes

## Focused verification
- 20 creator-article and editor tests passed
- TypeScript passed
- changed-path ESLint passed
- production build passed
- desktop, mobile, narrow-width, keyboard-focus and overflow browser checks passed