### PR TITLE
Stabilize wallet and profile loading

### DIFF
--- a/app/api/explore/profile/route.ts
+++ b/app/api/explore/profile/route.ts
@@ -43,6 +43,7 @@ const CONFIRMATIONS = 12n;
 const LOG_RANGE = 10_000n;
 const LOG_RANGE_CONCURRENCY = 2;
 const TOTAL_SUPPLY_RAW = "1000000000000000000000000000";
+const LEGACY_RPC_PROFILE_FALLBACK_ENABLED: boolean = false;
 
 type Release = Readonly<{
   launcher: Address;
@@ -678,56 +679,55 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const deployment = getWebsiteReadOnchainDeployment("production");
-    const result = await withOperationalRpcFailover(
-      deployment,
-      async (selected) => ({
-        profile: await readCreatorProfile(
-          getAddress(input),
-          profileClient(selected.rpcUrl),
-        ),
-        provider: profileRpcProviderHeader(deployment, selected.rpcUrl),
-      }),
+    const result = await readEnvioCreatorProfile(
+      getAddress(input),
+      request.signal,
     );
     return NextResponse.json(result.profile, {
       headers: {
         "Cache-Control": "private, max-age=0, s-maxage=15",
-        "X-Programmable-Launch-Source": "rpc",
-        "X-Programmable-Read-Source": "rpc",
+        "X-Programmable-Launch-Source": "envio-classic-v3",
+        "X-Programmable-Read-Source":
+          result.provider === "envio-indexer-state"
+            ? "envio-classic-v3"
+            : "envio-classic-v3+rpc",
         "X-Programmable-Rpc-Provider": result.provider,
       },
     });
   } catch (error) {
-    console.error(
-      "Creator profile RPC read failed",
-      {
-        name: error instanceof Error ? error.name : "UnknownError",
-        category: "read-failed",
-      },
-    );
-    try {
-      const fallback = await readEnvioCreatorProfile(
-        getAddress(input),
-        request.signal,
-      );
-      return NextResponse.json(fallback.profile, {
-        headers: {
-          "Cache-Control": "private, max-age=0, s-maxage=15",
-          "X-Programmable-Launch-Source": "envio-classic-v3",
-          "X-Programmable-Read-Source":
-            fallback.provider === "envio-indexer-state"
-              ? "envio-classic-v3"
-              : "envio-classic-v3+rpc",
-          "X-Programmable-Rpc-Provider": fallback.provider,
-        },
-      });
-    } catch (fallbackError) {
-      console.error("Envio creator profile fallback failed", {
-        name:
-          fallbackError instanceof Error
-            ? fallbackError.name
-            : "EnvioCreatorProfileError",
-      });
+    console.error("Envio creator profile read failed", {
+      name: error instanceof Error ? error.name : "EnvioCreatorProfileError",
+      category: "read-failed",
+    });
+    if (LEGACY_RPC_PROFILE_FALLBACK_ENABLED) {
+      try {
+        const deployment = getWebsiteReadOnchainDeployment("production");
+        const fallback = await withOperationalRpcFailover(
+          deployment,
+          async (selected) => ({
+            profile: await readCreatorProfile(
+              getAddress(input),
+              profileClient(selected.rpcUrl),
+            ),
+            provider: profileRpcProviderHeader(deployment, selected.rpcUrl),
+          }),
+        );
+        return NextResponse.json(fallback.profile, {
+          headers: {
+            "Cache-Control": "private, max-age=0, s-maxage=15",
+            "X-Programmable-Launch-Source": "rpc",
+            "X-Programmable-Read-Source": "rpc",
+            "X-Programmable-Rpc-Provider": fallback.provider,
+          },
+        });
+      } catch (fallbackError) {
+        console.error("Legacy creator profile fallback failed", {
+          name:
+            fallbackError instanceof Error
+              ? fallbackError.name
+              : "LegacyCreatorProfileError",
+        });
+      }
     }
     return NextResponse.json(creatorProfileApiError("temporary"), {
       status: 503,

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -337,10 +337,10 @@ export function getProfileWorkspacePhase(
   integrityConflict = false,
 ): ProfileWorkspacePhase {
   if (integrityConflict) return "error";
-  if (statuses.some((status) => status === "ready")) return "ready";
   if (statuses.some((status) => status === "loading")) {
     return "loading";
   }
+  if (statuses.some((status) => status === "ready")) return "ready";
   if (!terminalErrorReady) return "loading";
   return "error";
 }

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -140,14 +140,11 @@ function loadWalletProviderRuntime() {
 }
 
 export function shouldEagerLoadWalletRuntime(pathname: string) {
-  return pathname === "/launch"
-    || pathname.startsWith("/launch/")
-    || pathname === "/profile"
-    || pathname.startsWith("/profile/");
+  return pathname.startsWith("/");
 }
 
 export function shouldIdlePreloadWalletRuntime(pathname: string) {
-  return pathname.startsWith("/token/");
+  return !shouldEagerLoadWalletRuntime(pathname);
 }
 
 if (
@@ -2216,8 +2213,8 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
     ? "Disconnecting"
     : connecting
       ? compact
-        ? "Connect"
-        : "Connect wallet"
+        ? "Wallet"
+        : "Loading wallet"
       : wallet
         ? username || shortenAddress(wallet.account)
         : authenticated

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2136,7 +2136,7 @@ export function evaluateReadModelOperationsSourceContracts(
   check(
     "ops-public-provider-split-source-contract",
     fastLanePublicProviderContract,
-    "Explore list and token detail use the validated Envio Classic V3 catalog plus bounded exact-identity Dexscreener enrichment; charts bind one exact pool through Bitquery while profile and action routes retain their commitment-bound Website RPC semantics",
+    "Explore list, token detail and creator identity use the validated Envio Classic V3 catalog; Dexscreener remains bounded exact-identity enrichment, charts bind one exact pool through Bitquery and action routes retain their commitment-bound Website RPC semantics",
   );
   const publicProfileAndActionRoutes = [
     publicCreatorProfile,
@@ -2147,12 +2147,16 @@ export function evaluateReadModelOperationsSourceContracts(
   check(
     "ops-profile-claim-trade-provider-boundary",
     includesEverySourceFragment(publicCreatorProfile, [
-      "readCreatorProfile",
+      "readEnvioCreatorProfile",
+      "readEnvioClassicV3CatalogV1",
+      "readEnvioClassicV2CreatorClaimsV1",
+      "LEGACY_RPC_PROFILE_FALLBACK_ENABLED: boolean = false",
       "getWebsiteReadOnchainDeployment",
       "withOperationalRpcFailover",
       "profileRpcProviderHeader",
-      '"X-Programmable-Launch-Source": "rpc"',
-      '"X-Programmable-Read-Source": "rpc"',
+      '"X-Programmable-Launch-Source": "envio-classic-v3"',
+      '? "envio-classic-v3"',
+      ': "envio-classic-v3+rpc"',
       '"X-Programmable-Rpc-Provider": result.provider',
     ]) &&
       !publicCreatorProfile.includes("productionMainnetRpcPrimary") &&
@@ -2222,7 +2226,7 @@ export function evaluateReadModelOperationsSourceContracts(
         (route) =>
           !/Promise\.allSettled|secondaryProvider|fallbackProvider/u.test(route),
       ),
-    "Profile, Classic rewards, Claim, and Trade use the commitment-bound Website pair with at most one complete-operation QuickNode retry after an eligible dRPC transport or capacity failure; Stock retains its singular committed action provider and all action routes retain no write authority or hidden provider rotation",
+    "Profile identity is Envio-first and fail-closed, while the sole official Classic V2 reward read, Classic rewards, Claim, and Trade use the commitment-bound Website pair with at most one complete-operation QuickNode retry after an eligible dRPC transport or capacity failure; Stock retains its singular committed action provider and all action routes retain no write authority or hidden provider rotation",
   );
   check(
     "ops-staged-envio-catalog-gate",

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -916,8 +916,8 @@ describe("read-model operations source contract", () => {
     [
       "profile provider provenance",
       "app/api/explore/profile/route.ts",
-      '"X-Programmable-Read-Source": "rpc"',
-      '"X-Programmable-Read-Source": "unknown"',
+      '"X-Programmable-Launch-Source": "envio-classic-v3"',
+      '"X-Programmable-Launch-Source": "unknown"',
     ],
     [
       "claim receipt binding",

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -275,10 +275,10 @@ describe("profile workspace loading state", () => {
     ).toBe("loading");
   });
 
-  it("reveals verified rewards while optional sources continue loading", () => {
+  it("reveals rewards only after every active source has settled", () => {
     expect(
       getProfileWorkspacePhase(["error", "ready", "loading"], false),
-    ).toBe("ready");
+    ).toBe("loading");
     expect(
       getProfileWorkspacePhase(
         ["error", "ready", "not-deployed"],
@@ -292,7 +292,7 @@ describe("profile workspace loading state", () => {
       ),
     ).toBe("error");
     expect(profileViewSource).toMatch(
-      /if \(integrityConflict\) return "error";[\s\S]*?status === "ready"[\s\S]*?status === "loading"/,
+      /if \(integrityConflict\) return "error";[\s\S]*?status === "loading"[\s\S]*?status === "ready"/,
     );
   });
 

--- a/tests/public-route-handler-wiring.test.ts
+++ b/tests/public-route-handler-wiring.test.ts
@@ -39,6 +39,8 @@ const mocks = vi.hoisted(() => ({
       };
     },
   ),
+  readEnvioClassicV2CreatorClaimsV1: vi.fn(),
+  readEnvioClassicV3CatalogV1: vi.fn(),
   readBitqueryCreatorProfile: vi.fn(),
   readAlchemyCreatorProfile: vi.fn(),
   readAlchemyExploreModel: vi.fn(),
@@ -141,11 +143,66 @@ vi.mock("../lib/market-data/bitquery-profile.server", () => ({
   safeBitqueryProfileError: vi.fn((error) => error),
 }));
 
+vi.mock("../lib/market-data/envio-classic-v2-creator-claims.server", () => ({
+  readEnvioClassicV2CreatorClaimsV1:
+    mocks.readEnvioClassicV2CreatorClaimsV1,
+}));
+
+vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
+  readEnvioClassicV3CatalogV1: mocks.readEnvioClassicV3CatalogV1,
+}));
+
 import { GET as creatorProfile } from "../app/api/explore/profile/route";
 import { GET as stockLaunchLookup } from "../app/api/explore/launch/stock-paired/route";
 
 const ACCOUNT = "0x1111111111111111111111111111111111111111";
 const TRANSACTION = `0x${"22".repeat(32)}`;
+const PROFILE_TOKEN = "0x3333333333333333333333333333333333333333";
+const PROFILE_POOL = `0x${"44".repeat(32)}`;
+const PROFILE_HOOK = "0x025a386eAa79f6067d29848FD05ccC71bEAb20CC";
+const PROFILE_LAUNCHER = "0xD240D06f8586eB799f20056054e5b527405E6bAd";
+
+function profileCatalog(releaseVersion: "classic-v2" | "classic-v3" = "classic-v3") {
+  return {
+    source: "envio-classic-v3",
+    status: "current",
+    generatedAt: "2026-08-22T08:00:00.000Z",
+    asOfBlock: "25624188",
+    asOfBlockHash: `0x${"99".repeat(32)}`,
+    entries: [{
+      exploreKind: "token",
+      id: `1:${releaseVersion}:${PROFILE_TOKEN}`,
+      name: "Envio Token",
+      symbol: "ENVIO",
+      tokenAddress: PROFILE_TOKEN,
+      hookAddress: PROFILE_HOOK,
+      poolId: PROFILE_POOL,
+      creatorAddress: ACCOUNT,
+      positionRecipient: ACCOUNT,
+      positionTokenId: "7",
+      launchHash: `0x${"66".repeat(32)}`,
+      launchedAt: "2026-08-22T07:00:00.000Z",
+      totalSupply: "1000000000",
+      totalSupplyRaw: "1000000000000000000000000000",
+      tokenDecimals: 18,
+      totalSwapFeeBps: 100,
+      buyHookFeeBps: 100,
+      sellHookFeeBps: 100,
+      launchModel: "classic",
+      launchModelVersion: releaseVersion,
+      liquidityPath: "meme",
+      links: [],
+      launchCategoryProvenance: {
+        schemaVersion: "programmable.explore-launch-category-provenance.v1",
+        category: "classic",
+        source: "canonical-launch-read-model",
+        recordId: `1:${releaseVersion}:${PROFILE_TOKEN}`,
+        modelId: "classic",
+        modelVersion: releaseVersion,
+      },
+    }],
+  };
+}
 
 describe("public route coordinator wiring", () => {
   beforeEach(() => {
@@ -159,6 +216,8 @@ describe("public route coordinator wiring", () => {
     );
     rpcFixtures.client.getLogs.mockResolvedValue([]);
     mocks.createPublicClient.mockReturnValue(rpcFixtures.client);
+    mocks.readEnvioClassicV3CatalogV1.mockResolvedValue(profileCatalog());
+    mocks.readEnvioClassicV2CreatorClaimsV1.mockResolvedValue([]);
     const drpc = "https://lb.drpc.live/ethereum/drpc-profile-key";
     mocks.getWebsiteReadOnchainDeployment.mockReturnValue({
       status: "ready",
@@ -169,74 +228,14 @@ describe("public route coordinator wiring", () => {
       rpcUrlSecondary:
         "https://profile-node.ethereum-mainnet.quiknode.pro/quicknode-profile-key/",
       rpcProviderIds: { primary: "drpc", secondary: "quicknode" },
+      launcher: PROFILE_LAUNCHER,
+      feeHook: PROFILE_HOOK,
+      launcherRuntimeCodeHash: rpcFixtures.runtimeCodes["0x03"],
+      feeHookRuntimeCodeHash: rpcFixtures.runtimeCodes["0x04"],
     });
   });
 
-  it("derives current, generated and claimed totals from sparse dRPC state", async () => {
-    const launcher = "0xD240D06f8586eB799f20056054e5b527405E6bAd";
-    const hook = "0x025a386eAa79f6067d29848FD05ccC71bEAb20CC";
-    const token = "0x3333333333333333333333333333333333333333";
-    const poolId = `0x${"44".repeat(32)}`;
-    const transactionHash = `0x${"55".repeat(32)}`;
-    rpcFixtures.client.getLogs.mockImplementation(async (inputValue?: unknown) => {
-      const input = inputValue as {
-        address: string;
-        event: { name: string };
-      };
-      if (
-        input.address.toLowerCase() === launcher.toLowerCase() &&
-        input.event.name === "MemeTokenLaunched"
-      ) {
-        return [{
-          removed: false,
-          blockNumber: 25_624_150n,
-          transactionHash,
-          transactionIndex: 2,
-          logIndex: 3,
-          args: {
-            creator: ACCOUNT,
-            token,
-            poolId,
-            feeHook: hook,
-            positionRecipient: ACCOUNT,
-            positionTokenId: 7n,
-            totalSwapFeeBps: 100,
-            launchHash: `0x${"66".repeat(32)}`,
-          },
-        }];
-      }
-      if (
-        input.address.toLowerCase() === hook.toLowerCase() &&
-        input.event.name === "CreatorFeesClaimed"
-      ) {
-        return [{
-          removed: false,
-          blockNumber: 25_624_160n,
-          transactionHash: `0x${"77".repeat(32)}`,
-          transactionIndex: 1,
-          logIndex: 4,
-          args: {
-            poolId,
-            creator: ACCOUNT,
-            recipient: ACCOUNT,
-            caller: ACCOUNT,
-            amount: 40n,
-          },
-        }];
-      }
-      return [];
-    });
-    rpcFixtures.client.readContract.mockImplementation(async (input: {
-      functionName: string;
-    }) => {
-      if (input.functionName === "name") return "dRPC Token";
-      if (input.functionName === "symbol") return "DRPC";
-      if (input.functionName === "poolFeeConfig") {
-        return [ACCOUNT, launcher, 100, true, 60n];
-      }
-      throw new Error(`Unexpected read ${input.functionName}`);
-    });
-
+  it("returns verified catalog identities without a historical RPC scan", async () => {
     const response = await creatorProfile(new NextRequest(
       `http://localhost/api/explore/profile?account=${ACCOUNT}`,
     ));
@@ -245,25 +244,26 @@ describe("public route coordinator wiring", () => {
     await expect(response.json()).resolves.toMatchObject({
       status: "ready",
       account: ACCOUNT,
-      tokens: [{ tokenAddress: token, creatorFeesAccruedWei: "60" }],
+      tokens: [{ tokenAddress: PROFILE_TOKEN, launchModelVersion: "classic-v3" }],
       pools: [{
-        tokenAddress: token,
-        claimableCreatorFeesWei: "60",
-        generatedCreatorFeesWei: "100",
+        tokenAddress: PROFILE_TOKEN,
+        claimableCreatorFeesWei: "0",
+        generatedCreatorFeesWei: "0",
       }],
-      claims: [{ amountWei: "40", tokenAddress: token }],
+      claims: [],
       totals: {
-        claimableWei: "60",
-        generatedWei: "100",
-        claimedWei: "40",
+        claimableWei: "0",
+        generatedWei: "0",
+        claimedWei: "0",
       },
     });
-    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+    expect(mocks.readEnvioClassicV3CatalogV1).toHaveBeenCalledTimes(1);
+    expect(mocks.createPublicClient).not.toHaveBeenCalled();
   });
 
   afterEach(() => vi.unstubAllEnvs());
 
-  it("reports the healthy bound primary creator profile source", async () => {
+  it("reports the healthy bound Envio creator profile source", async () => {
     const response = await creatorProfile(
       new NextRequest(
         `http://localhost/api/explore/profile?account=${ACCOUNT}`,
@@ -271,7 +271,7 @@ describe("public route coordinator wiring", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.createPublicClient).toHaveBeenCalledTimes(1);
+    expect(mocks.createPublicClient).not.toHaveBeenCalled();
     expect(mocks.readBitqueryCreatorProfile).not.toHaveBeenCalled();
     expect(mocks.readAlchemyCreatorProfile).not.toHaveBeenCalled();
     expect(mocks.coordinatePublicRouteRead).not.toHaveBeenCalled();
@@ -279,17 +279,27 @@ describe("public route coordinator wiring", () => {
       "private, max-age=0, s-maxage=15",
     );
     expect(response.headers.get("X-Programmable-Launch-Source")).toBe(
-      "rpc",
+      "envio-classic-v3",
     );
     expect(response.headers.get("X-Programmable-Read-Source")).toBe(
-      "rpc",
+      "envio-classic-v3",
     );
     expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
-      "drpc-primary",
+      "envio-indexer-state",
     );
   });
 
-  it("retries the whole creator profile read on the fixed secondary after primary capacity failure", async () => {
+  it("uses bounded RPC failover only for the official Classic V2 reward state", async () => {
+    mocks.readEnvioClassicV3CatalogV1.mockResolvedValue(
+      profileCatalog("classic-v2"),
+    );
+    rpcFixtures.client.readContract.mockResolvedValue([
+      ACCOUNT,
+      PROFILE_LAUNCHER,
+      100,
+      true,
+      60n,
+    ]);
     rpcFixtures.client.getBlockNumber.mockRejectedValueOnce(
       new RpcRequestError({
         body: { method: "eth_blockNumber" },
@@ -314,12 +324,15 @@ describe("public route coordinator wiring", () => {
     expect(response.headers.get("X-Programmable-Rpc-Provider")).toBe(
       "quicknode-secondary",
     );
+    expect(response.headers.get("X-Programmable-Read-Source")).toBe(
+      "envio-classic-v3+rpc",
+    );
   });
 
-  it("fails closed before transport when the Website RPC binding is invalid", async () => {
-    mocks.getWebsiteReadOnchainDeployment.mockImplementationOnce(() => {
-      throw new Error("Website primary RPC binding is invalid");
-    });
+  it("fails closed without restoring historical RPC identities when Envio is unavailable", async () => {
+    mocks.readEnvioClassicV3CatalogV1.mockRejectedValueOnce(
+      new Error("Envio temporarily unavailable"),
+    );
 
     const response = await creatorProfile(
       new NextRequest(

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -136,21 +136,21 @@ function applicantUser(overrides?: Partial<{
 }
 
 describe("wallet recovery state", () => {
-  it("defers the Privy runtime on read-only routes and keeps wallet routes eager", () => {
-    for (const pathname of ["/", "/explore", "/docs", "/docs/creators"]) {
-      expect(subject.shouldEagerLoadWalletRuntime(pathname)).toBe(false);
-    }
+  it("hydrates the wallet session before every public route renders its wallet action", () => {
     for (const pathname of [
+      "/",
+      "/explore",
+      "/docs",
+      "/docs/creators",
       "/launch",
       "/launch/review",
       "/profile",
       "/profile/settings",
+      "/token/0x7987f03462200b3d8a072e02c89a8a41dcb124ee",
     ]) {
       expect(subject.shouldEagerLoadWalletRuntime(pathname)).toBe(true);
+      expect(subject.shouldIdlePreloadWalletRuntime(pathname)).toBe(false);
     }
-    const tokenPath = "/token/0x7987f03462200b3d8a072e02c89a8a41dcb124ee";
-    expect(subject.shouldEagerLoadWalletRuntime(tokenPath)).toBe(false);
-    expect(subject.shouldIdlePreloadWalletRuntime(tokenPath)).toBe(true);
   });
 
   it("keeps Privy behind an explicit dynamic runtime boundary", () => {
@@ -166,6 +166,8 @@ describe("wallet recovery state", () => {
     expect(provider).toContain('import("./wallet-provider-runtime")');
     expect(provider).toContain("onPointerEnter={preloadWallet}");
     expect(provider).toContain("onFocus={preloadWallet}");
+    expect(provider).toContain('? "Wallet"');
+    expect(provider).toContain(': "Loading wallet"');
     expect(provider).not.toMatch(
       /import\s*\{[\s\S]*?PrivyProvider[\s\S]*?\}\s*from\s*["']@privy-io\/react-auth["']/u,
     );


### PR DESCRIPTION
## Outcome
- hydrate the wallet session before any public wallet action renders, with an honest neutral loading label
- keep Claim Rewards in one stable loading state until active sources settle
- use the verified Envio catalog as the creator-profile identity source and keep the historical RPC identity scan disabled
- retain bounded Website RPC only for the sole official Classic V2 reward-state exception

## Focused verification
- `vitest`: wallet/profile/route behavior (96 tests)
- read-model operations contract (91 tests)
- TypeScript and changed-path ESLint
- production `next build` and custom-launch bundle scan

Base: `production`
Commit: `7c05eda2021dc4a114ec7a934f331ee2019b3c8e`
Tree: `7893a7ee98adc30ad6c2516e9ead617d2b40acb2`