### PR TITLE
Fix Markdown cache variation for agents

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -2,9 +2,9 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { negotiatePageRepresentation } from "@/lib/content-negotiation";
+import { buildProgrammableHomeMarkdown } from "@/lib/developer-docs-content";
 
 const MARKDOWN_DESTINATIONS = new Map([
-  ["/", "/index.md"],
   ["/docs/developers", "/docs/developers.md"],
 ]);
 
@@ -18,6 +18,17 @@ function withAcceptVariation(response: NextResponse): NextResponse {
   values.add("Accept");
   response.headers.set("Vary", [...values].join(", "));
   return response;
+}
+
+function homeMarkdownResponse(): NextResponse {
+  return new NextResponse(buildProgrammableHomeMarkdown(), {
+    headers: {
+      "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://programmable.market/>; rel="canonical"; type="text/html"',
+      Vary: "Accept",
+    },
+  });
 }
 
 export function proxy(request: NextRequest) {
@@ -42,6 +53,9 @@ export function proxy(request: NextRequest) {
     );
   }
   if (representation === "markdown") {
+    if (request.nextUrl.pathname === "/") {
+      return homeMarkdownResponse();
+    }
     const destination = MARKDOWN_DESTINATIONS.get(request.nextUrl.pathname);
     if (destination !== undefined) {
       return withAcceptVariation(

--- a/tests/agent-readiness.test.ts
+++ b/tests/agent-readiness.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { NextRequest } from "next/server";
 import { describe, expect, it } from "vitest";
 
@@ -144,16 +146,20 @@ describe("agent-readable public surface", () => {
     );
   });
 
-  it("rewrites direct Markdown requests and varies both representations on Accept", () => {
+  it("serves direct Markdown requests and varies both representations on Accept", async () => {
     const markdownResponse = proxy(
       new NextRequest(`${ORIGIN}/`, {
         headers: { Accept: "text/markdown" },
       }),
     );
     expect(markdownResponse.status).toBe(200);
-    expect(markdownResponse.headers.get("vary")).toContain("Accept");
-    expect(markdownResponse.headers.get("x-middleware-rewrite")).toBe(
-      `${ORIGIN}/index.md`,
+    expect(markdownResponse.headers.get("content-type")).toContain(
+      "text/markdown",
+    );
+    expect(markdownResponse.headers.get("vary")).toBe("Accept");
+    expect(markdownResponse.headers.get("x-middleware-rewrite")).toBeNull();
+    expect((await markdownResponse.text()).startsWith("# Programmable")).toBe(
+      true,
     );
 
     const htmlResponse = proxy(
@@ -171,6 +177,29 @@ describe("agent-readable public surface", () => {
     );
     expect(unacceptableResponse.status).toBe(406);
     expect(unacceptableResponse.headers.get("vary")).toBe("Accept");
+  });
+
+  it("keeps Accept and the Next RSC keys in the public CDN variation", () => {
+    const config = JSON.parse(
+      readFileSync(new URL("../vercel.json", import.meta.url), "utf8"),
+    ) as {
+      headers: Array<{
+        source: string;
+        headers: Array<{ key: string; value: string }>;
+      }>;
+    };
+    const root = config.headers.find(({ source }) => source === "/");
+    const vary = root?.headers.find(({ key }) => key === "Vary")?.value ?? "";
+    expect(vary.split(/,\s*/u)).toEqual(
+      expect.arrayContaining([
+        "Accept",
+        "Accept-Encoding",
+        "RSC",
+        "Next-Router-State-Tree",
+        "Next-Router-Prefetch",
+        "Next-Router-Segment-Prefetch",
+      ]),
+    );
   });
 
   it("serves compact Markdown documents with canonical HTML alternates", async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, Accept-Encoding, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+        }
+      ]
+    }
+  ],
   "redirects": [
     {
       "source": "/sites/site_V93gQ",


### PR DESCRIPTION
## Summary

- return the homepage Markdown representation directly from Proxy so Vercel preserves the negotiated response headers
- bind the root CDN variation to Accept plus the existing Next.js RSC headers
- keep the existing HTML experience and API behavior unchanged

## Production evidence closed

The first exact deployment returned text/markdown correctly but Vercel replaced Vary: Accept with the Next.js RSC variation after the internal rewrite. This patch removes that rewrite for the homepage Markdown response.

## Verification

- 9/9 focused agent-readiness tests
- TypeScript
- changed-path ESLint
- production build and candidate-neutral/custom-bundle gates
- local production HTTP: Markdown 200 text/markdown with Vary: Accept; HTML 200; visual HTML 404 remains 404; unknown API remains structured JSON 404
