### PR TITLE
Fix prediction RPC block reconciliation

### DIFF
--- a/lib/prediction-market-trading.ts
+++ b/lib/prediction-market-trading.ts
@@ -504,6 +504,36 @@ function assertSame(primary: unknown, secondary: unknown, label: string) {
   }
 }
 
+type PredictionConfirmedBlock = Readonly<{
+  hash: Hex | null;
+  number: bigint | null;
+  parentHash: Hex;
+  timestamp: bigint;
+}>;
+
+function predictionConfirmedBlockIdentity(block: PredictionConfirmedBlock) {
+  if (block.hash === null || block.number === null) {
+    throw new Error("The confirmed Robinhood block has no canonical identity");
+  }
+  return {
+    hash: block.hash,
+    number: block.number,
+    parentHash: block.parentHash,
+    timestamp: block.timestamp,
+  };
+}
+
+export function assertPredictionConfirmedBlocksMatch(
+  primary: PredictionConfirmedBlock,
+  secondary: PredictionConfirmedBlock,
+) {
+  assertSame(
+    predictionConfirmedBlockIdentity(primary),
+    predictionConfirmedBlockIdentity(secondary),
+    "the confirmed block",
+  );
+}
+
 function stateName(value: number): PredictionMarketState {
   const states = ["OPEN", "FINAL_YES", "FINAL_NO", "FINAL_INVALID"] as const;
   if (!Number.isInteger(value) || value < 0 || value >= states.length) {
@@ -944,7 +974,7 @@ export async function readPredictionMarketDirectory({
     Promise.all(clients.map((client) => client.getBlock({ blockNumber }))),
     Promise.all(clients.map((client) => client.readContract({ address: config.factoryAddress, abi: factoryAbi, blockNumber, functionName: "marketCount" }))),
   ]);
-  assertSame(blocks[0], blocks[1], "the confirmed block");
+  assertPredictionConfirmedBlocksMatch(blocks[0], blocks[1]);
   assertSame(counts[0], counts[1], "the market count");
   const marketCount = counts[0];
   const page = predictionMarketPageIndices({ cursor, limit, marketCount });

--- a/tests/prediction-market-trading.test.ts
+++ b/tests/prediction-market-trading.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   applyPredictionSlippageFloor,
+  assertPredictionConfirmedBlocksMatch,
   parsePredictionBuyAmount,
   parsePredictionSellAmount,
   predictionMarketPageIndices,
@@ -80,5 +81,34 @@ describe("prediction market trading math", () => {
       12n, 11n, 10n, 9n, 8n, 7n, 6n, 5n, 4n, 3n, 2n, 1n,
     ]);
     expect(last).toEqual({ indices: [0n], nextCursor: 0n });
+  });
+
+  it("reconciles canonical block identity without comparing provider-shaped transaction fields", () => {
+    const canonical = {
+      hash: `0x${"11".repeat(32)}`,
+      number: 43_457_445n,
+      parentHash: `0x${"22".repeat(32)}`,
+      timestamp: 1_787_433_219n,
+    } as const;
+    const official = {
+      ...canonical,
+      transactions: [`0x${"33".repeat(32)}`],
+      l1BlockNumber: 25_813_295n,
+    };
+    const independent = {
+      ...canonical,
+      blobGasUsed: null,
+      transactions: [],
+    };
+
+    expect(() =>
+      assertPredictionConfirmedBlocksMatch(official, independent),
+    ).not.toThrow();
+    expect(() =>
+      assertPredictionConfirmedBlocksMatch(official, {
+        ...independent,
+        hash: `0x${"44".repeat(32)}`,
+      }),
+    ).toThrow("confirmed block");
   });
 });


### PR DESCRIPTION
## What changed

- compare the canonical confirmed-block identity across both Robinhood RPC providers
- ignore provider-shaped transaction and optional L1 response fields
- retain fail-closed checks for hash, number, parent hash, timestamp, market count, and market reads
- add a regression test for the exact official-RPC versus Blockreq response difference

## Why

Live browser QA of the first staged prediction release showed a false `READS BLOCKED` state. Both providers returned the same canonical block, but one included transaction hashes and custom L1 fields while the other returned an empty transaction list and null optional fields. Comparing the complete viem block object therefore rejected equivalent chain state.

The failed candidate was rolled back before this fix; the prediction UI is not being treated as live until this PR, release verification, a new staged candidate, and browser QA pass.

## Local evidence

- `npx vitest run tests/prediction-market-trading.test.ts` (7/7)
- `npm run typecheck`
- focused ESLint on both changed files
- `npm run build`
- real dual-RPC directory read at the same confirmed block: 1 open market, 2.00005 USDG liability, no disagreement