### PR TITLE
Harden prediction market RPC quorum reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ NEXT_PUBLIC_PRIVY_APP_ID=
 
 # BTC prediction markets stay fail-closed until these values bind the Website
 # to one reviewed Robinhood Chain deployment and its quoting path. Browser
-# reads use the two public RPCs declared in lib/chains.ts; no hosted backend is
-# required.
+# reads compare Robinhood's official endpoint with a domain-restricted Alchemy
+# Robinhood endpoint; no hosted backend is required.
 NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_DEPLOYMENT_BLOCK=
 NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_FACTORY_ADDRESS=
 NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_FACTORY_RUNTIME_CODE_HASH=
@@ -12,6 +12,7 @@ NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_ROUTER_RUNTIME_CODE_HASH=
 NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_HOOK_RUNTIME_CODE_HASH=
 NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_QUOTER_ADDRESS=
 NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_QUOTER_RUNTIME_CODE_HASH=
+NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_SECONDARY_RPC_URL=
 
 # Required by server routes that verify Privy access tokens.
 PRIVY_APP_SECRET=

--- a/components/prediction-market-detail.tsx
+++ b/components/prediction-market-detail.tsx
@@ -51,6 +51,7 @@ import {
   PREDICTION_PERMIT_DURATION_SECONDS,
   ROBINHOOD_USDG_ADDRESS,
 } from "@/lib/prediction-market";
+import { predictionMarketErrorMessage } from "@/lib/prediction-market-errors";
 
 type MarketLoadState =
   | { kind: "loading" }
@@ -80,7 +81,7 @@ function quoteDepthLabel(priceImpactBps: number) {
 }
 
 function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : "The market action failed";
+  return predictionMarketErrorMessage(error, "The market action failed");
 }
 
 function probabilityLabel(bps: number) {

--- a/components/prediction-market-directory.tsx
+++ b/components/prediction-market-directory.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import styles from "@/components/prediction-market-experience.module.css";
 import { predictionPreviewMarkets } from "@/components/prediction-market-preview";
 import { getPredictionMarketReleaseConfig } from "@/lib/prediction-market-chain";
+import { predictionMarketErrorMessage } from "@/lib/prediction-market-errors";
 import {
   formatPredictionUsdg,
   readPredictionMarketDirectory,
@@ -28,7 +29,7 @@ type DirectoryState =
 const DIRECTORY_PAGE_SIZE = 12;
 
 function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : "Markets are temporarily unavailable";
+  return predictionMarketErrorMessage(error, "Markets are temporarily unavailable");
 }
 
 function countdown(target: bigint, now: bigint) {

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -1064,7 +1064,7 @@
   }
 
   .detailLayout {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .tradeTerminal {

--- a/components/prediction-market-launch.tsx
+++ b/components/prediction-market-launch.tsx
@@ -32,6 +32,7 @@ import {
   validatePredictionMarketDraft,
   type PredictionMarketDraft,
 } from "@/lib/prediction-market";
+import { predictionMarketErrorMessage } from "@/lib/prediction-market-errors";
 
 type PredictionMarketLaunchProps = Readonly<{
   onBack: () => void;
@@ -53,7 +54,7 @@ type LaunchPhase =
   | "error";
 
 function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : "Market creation failed";
+  return predictionMarketErrorMessage(error, "Market creation failed");
 }
 
 function formatEthMaximum(value: bigint) {

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import styles from "@/components/prediction-market-experience.module.css";
 import { useWallet } from "@/components/wallet-provider";
 import { getPredictionMarketReleaseConfig } from "@/lib/prediction-market-chain";
+import { predictionMarketErrorMessage } from "@/lib/prediction-market-errors";
 import {
   formatPredictionOutcome,
   readPredictionMarketDirectory,
@@ -27,7 +28,7 @@ type PortfolioState =
 const PORTFOLIO_SCAN_PAGE_SIZE = 24;
 
 function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : "Prediction positions are unavailable";
+  return predictionMarketErrorMessage(error, "Prediction positions are unavailable");
 }
 
 export function PredictionMarketPortfolio() {

--- a/lib/chains.ts
+++ b/lib/chains.ts
@@ -3,8 +3,6 @@ import { defineChain } from "viem";
 export const ROBINHOOD_CHAIN_ID = 4_663 as const;
 export const ROBINHOOD_MAINNET_RPC_URL =
   "https://rpc.mainnet.chain.robinhood.com";
-export const ROBINHOOD_MAINNET_FALLBACK_RPC_URL =
-  "https://robinhood-mainnet-rpc.blockreq.com/v1/rpc/public";
 export const ROBINHOOD_BLOCK_EXPLORER_URL =
   "https://robinhoodchain.blockscout.com";
 export const ROBINHOOD_MULTICALL3_ADDRESS =

--- a/lib/prediction-market-chain.ts
+++ b/lib/prediction-market-chain.ts
@@ -10,7 +10,6 @@ import {
 } from "viem";
 
 import {
-  ROBINHOOD_MAINNET_FALLBACK_RPC_URL,
   ROBINHOOD_MAINNET_RPC_URL,
   ROBINHOOD_MULTICALL3_ADDRESS,
   ROBINHOOD_MULTICALL3_RUNTIME_CODE_HASH,
@@ -36,6 +35,8 @@ const PREDICTION_RPC_CONFIRMATIONS = 3n;
 const PREDICTION_MAX_RPC_HEAD_DIVERGENCE = 300n;
 const PREDICTION_GAS_BUFFER_PERCENT = 120n;
 const PREDICTION_MAX_GAS_LIMIT = 10_000_000n;
+const PREDICTION_MULTICALL_BATCH_SIZE = 64;
+const PREDICTION_SECONDARY_RPC_HOST = "robinhood-mainnet.g.alchemy.com";
 const UINT256_MAX = (1n << 256n) - 1n;
 
 export const ROBINHOOD_V4_POOL_MANAGER_ADDRESS =
@@ -59,6 +60,7 @@ export type PredictionMarketReleaseConfig = Readonly<{
   predictionQuoterRuntimeCodeHash: Hex;
   routerRuntimeCodeHash: Hex;
   runtimeCodeHash: Hex;
+  secondaryRpcUrl: string;
 }>;
 
 export type PredictionMarketReleaseConfigInput = Readonly<{
@@ -69,6 +71,7 @@ export type PredictionMarketReleaseConfigInput = Readonly<{
   predictionQuoterRuntimeCodeHash?: string;
   routerRuntimeCodeHash?: string;
   runtimeCodeHash?: string;
+  secondaryRpcUrl?: string;
 }>;
 
 export type PredictionLaunchSnapshot = Readonly<{
@@ -362,6 +365,7 @@ export function parsePredictionMarketReleaseConfig(
     input.predictionQuoterRuntimeCodeHash?.trim() ?? "";
   const routerRuntimeCodeHash = input.routerRuntimeCodeHash?.trim() ?? "";
   const runtimeCodeHash = input.runtimeCodeHash?.trim() ?? "";
+  const secondaryRpcUrl = input.secondaryRpcUrl?.trim() ?? "";
   if (
     !deploymentBlock &&
     !factoryAddress &&
@@ -369,7 +373,8 @@ export function parsePredictionMarketReleaseConfig(
     !predictionQuoterAddress &&
     !predictionQuoterRuntimeCodeHash &&
     !routerRuntimeCodeHash &&
-    !runtimeCodeHash
+    !runtimeCodeHash &&
+    !secondaryRpcUrl
   ) {
     return null;
   }
@@ -394,6 +399,25 @@ export function parsePredictionMarketReleaseConfig(
     }
   }
 
+  let parsedSecondaryRpcUrl: URL;
+  try {
+    parsedSecondaryRpcUrl = new URL(secondaryRpcUrl);
+  } catch {
+    throw new Error("The configured prediction secondary RPC URL is invalid");
+  }
+  if (
+    parsedSecondaryRpcUrl.protocol !== "https:" ||
+    parsedSecondaryRpcUrl.hostname !== PREDICTION_SECONDARY_RPC_HOST ||
+    parsedSecondaryRpcUrl.port ||
+    parsedSecondaryRpcUrl.username ||
+    parsedSecondaryRpcUrl.password ||
+    parsedSecondaryRpcUrl.search ||
+    parsedSecondaryRpcUrl.hash ||
+    !/^\/v2\/[A-Za-z0-9_-]{16,}$/u.test(parsedSecondaryRpcUrl.pathname)
+  ) {
+    throw new Error("The configured prediction secondary RPC URL is invalid");
+  }
+
   return {
     deploymentBlock: BigInt(deploymentBlock),
     factoryAddress: getAddress(factoryAddress),
@@ -403,6 +427,7 @@ export function parsePredictionMarketReleaseConfig(
       predictionQuoterRuntimeCodeHash.toLowerCase() as Hex,
     routerRuntimeCodeHash: routerRuntimeCodeHash.toLowerCase() as Hex,
     runtimeCodeHash: runtimeCodeHash.toLowerCase() as Hex,
+    secondaryRpcUrl: parsedSecondaryRpcUrl.toString(),
   };
 }
 
@@ -422,13 +447,25 @@ export function getPredictionMarketReleaseConfig() {
       process.env.NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_ROUTER_RUNTIME_CODE_HASH,
     runtimeCodeHash:
       process.env.NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_FACTORY_RUNTIME_CODE_HASH,
+    secondaryRpcUrl:
+      process.env.NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_SECONDARY_RPC_URL,
   });
 }
 
-export function createPredictionMarketPublicClients() {
+export function createPredictionMarketPublicClients(
+  config = getPredictionMarketReleaseConfig(),
+) {
+  if (!config) {
+    throw new Error("The prediction market release is not configured");
+  }
   return [
     createPublicClient({
-      batch: { multicall: true },
+      batch: {
+        multicall: {
+          batchSize: PREDICTION_MULTICALL_BATCH_SIZE,
+          wait: 0,
+        },
+      },
       chain: robinhoodChain,
       transport: http(ROBINHOOD_MAINNET_RPC_URL, {
         retryCount: 1,
@@ -436,9 +473,14 @@ export function createPredictionMarketPublicClients() {
       }),
     }),
     createPublicClient({
-      batch: { multicall: true },
+      batch: {
+        multicall: {
+          batchSize: PREDICTION_MULTICALL_BATCH_SIZE,
+          wait: 0,
+        },
+      },
       chain: robinhoodChain,
-      transport: http(ROBINHOOD_MAINNET_FALLBACK_RPC_URL, {
+      transport: http(config.secondaryRpcUrl, {
         retryCount: 1,
         timeout: 10_000,
       }),

--- a/lib/prediction-market-errors.ts
+++ b/lib/prediction-market-errors.ts
@@ -1,0 +1,24 @@
+type ErrorWithShortMessage = Readonly<{
+  shortMessage?: unknown;
+}>;
+
+const urlPattern = /https?:\/\/[^\s)\]}>,"']+/giu;
+
+function readShortMessage(error: unknown) {
+  if (typeof error !== "object" || error === null) return "";
+  const shortMessage = (error as ErrorWithShortMessage).shortMessage;
+  return typeof shortMessage === "string" ? shortMessage : "";
+}
+
+export function predictionMarketErrorMessage(
+  error: unknown,
+  fallback: string,
+) {
+  const shortMessage = readShortMessage(error);
+  const source = shortMessage || (error instanceof Error ? error.message : "");
+  const firstLine = source.split(/\r?\n/u, 1)[0]?.trim() ?? "";
+  const safeMessage = firstLine
+    .replace(urlPattern, "the configured provider")
+    .trim();
+  return safeMessage || fallback;
+}

--- a/lib/prediction-market-trading.ts
+++ b/lib/prediction-market-trading.ts
@@ -44,6 +44,7 @@ const UINT256_MAX = (1n << 256n) - 1n;
 const Q192 = 1n << 192n;
 const FACE_SCALE = 10n;
 const MAX_BUY_COLLATERAL_ATOMS = UINT128_MAX * FACE_SCALE;
+const PREDICTION_DIRECTORY_MARKET_BATCH_SIZE = 4;
 const MIN_SQRT_PRICE = 4_295_128_739n;
 const MAX_SQRT_PRICE =
   1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342n;
@@ -629,6 +630,27 @@ export function predictionMarketPageIndices({
   } as const;
 }
 
+async function mapPredictionMarketsInBatches<Input, Output>(
+  values: readonly Input[],
+  mapper: (value: Input) => Promise<Output>,
+) {
+  const output: Output[] = [];
+  for (
+    let index = 0;
+    index < values.length;
+    index += PREDICTION_DIRECTORY_MARKET_BATCH_SIZE
+  ) {
+    output.push(
+      ...(await Promise.all(
+        values
+          .slice(index, index + PREDICTION_DIRECTORY_MARKET_BATCH_SIZE)
+          .map(mapper),
+      )),
+    );
+  }
+  return output;
+}
+
 export function formatPredictionUsdg(atoms: bigint) {
   const value = formatUnits(atoms, PREDICTION_COLLATERAL_DECIMALS);
   return `${trimDecimal(value, 6)} USDG`;
@@ -990,16 +1012,18 @@ export async function readPredictionMarketDirectory({
   );
   assertSame(keysByClient[0], keysByClient[1], "the market directory");
   const marketsByClient = await Promise.all(
-    clients.map((client) => Promise.all(keysByClient[0].map((key) =>
-      readMarketAt(
-        client,
-        config,
-        release,
-        key,
-        blockNumber,
-        account ? getAddress(account) : undefined,
+    clients.map((client) =>
+      mapPredictionMarketsInBatches(keysByClient[0], (key) =>
+        readMarketAt(
+          client,
+          config,
+          release,
+          key,
+          blockNumber,
+          account ? getAddress(account) : undefined,
+        ),
       ),
-    ))),
+    ),
   );
   assertSame(marketsByClient[0], marketsByClient[1], "the market directory state");
   return {
@@ -1592,5 +1616,6 @@ export const predictionMarketInternal = {
   checkpointAbi,
   erc20Abi,
   factoryAbi,
+  mapPredictionMarketsInBatches,
   vaultAbi,
 } as const;

--- a/tests/prediction-market-chain.test.ts
+++ b/tests/prediction-market-chain.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createPredictionMarketPublicClients,
+  parsePredictionMarketReleaseConfig,
+  type PredictionMarketReleaseConfig,
+} from "../lib/prediction-market-chain";
+
+const secondaryRpcUrl =
+  "https://robinhood-mainnet.g.alchemy.com/v2/test_api_key_1234";
+const config = {
+  deploymentBlock: 1n,
+  factoryAddress: "0x1111111111111111111111111111111111111111",
+  hookRuntimeCodeHash: `0x${"11".repeat(32)}`,
+  predictionQuoterAddress: "0x2222222222222222222222222222222222222222",
+  predictionQuoterRuntimeCodeHash: `0x${"22".repeat(32)}`,
+  routerRuntimeCodeHash: `0x${"33".repeat(32)}`,
+  runtimeCodeHash: `0x${"44".repeat(32)}`,
+  secondaryRpcUrl,
+} as const satisfies PredictionMarketReleaseConfig;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("prediction market RPC policy", () => {
+  it("uses bounded Multicall3 on both independent providers", () => {
+    const [primary, secondary] = createPredictionMarketPublicClients(config);
+
+    expect(primary.batch?.multicall).toEqual({ batchSize: 64, wait: 0 });
+    expect(secondary.batch?.multicall).toEqual({ batchSize: 64, wait: 0 });
+  });
+
+  it("binds the secondary client to the configured Alchemy endpoint", async () => {
+    const requests: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input) => {
+        requests.push(String(input));
+        return new Response(
+          JSON.stringify({ id: 0, jsonrpc: "2.0", result: "0x1" }),
+          { headers: { "content-type": "application/json" }, status: 200 },
+        );
+      }),
+    );
+    const secondary = createPredictionMarketPublicClients(config)[1];
+
+    await secondary.getBlockNumber();
+
+    expect(requests).toEqual([secondaryRpcUrl]);
+  });
+
+  it("rejects missing, public, or cross-chain secondary RPCs", () => {
+    const input = {
+      deploymentBlock: "1",
+      factoryAddress: config.factoryAddress,
+      hookRuntimeCodeHash: config.hookRuntimeCodeHash,
+      predictionQuoterAddress: config.predictionQuoterAddress,
+      predictionQuoterRuntimeCodeHash: config.predictionQuoterRuntimeCodeHash,
+      routerRuntimeCodeHash: config.routerRuntimeCodeHash,
+      runtimeCodeHash: config.runtimeCodeHash,
+    };
+
+    expect(() => parsePredictionMarketReleaseConfig(input)).toThrow(
+      "secondary RPC URL",
+    );
+    expect(() =>
+      parsePredictionMarketReleaseConfig({
+        ...input,
+        secondaryRpcUrl:
+          "https://robinhood-mainnet-rpc.blockreq.com/v1/rpc/public",
+      }),
+    ).toThrow("secondary RPC URL");
+    expect(() =>
+      parsePredictionMarketReleaseConfig({
+        ...input,
+        secondaryRpcUrl: "https://eth-mainnet.g.alchemy.com/v2/test_api_key_1234",
+      }),
+    ).toThrow("secondary RPC URL");
+  });
+});

--- a/tests/prediction-market-errors.test.ts
+++ b/tests/prediction-market-errors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { predictionMarketErrorMessage } from "../lib/prediction-market-errors";
+
+describe("prediction market error messages", () => {
+  it("prefers the provider-safe short message", () => {
+    expect(
+      predictionMarketErrorMessage(
+        {
+          message:
+            "Request failed at https://robinhood-mainnet.g.alchemy.com/v2/private_key_value",
+          shortMessage: "HTTP request failed.",
+        },
+        "Markets are temporarily unavailable",
+      ),
+    ).toBe("HTTP request failed.");
+  });
+
+  it("removes provider URLs from ordinary errors", () => {
+    const message = predictionMarketErrorMessage(
+      new Error(
+        "Request failed at https://robinhood-mainnet.g.alchemy.com/v2/private_key_value",
+      ),
+      "Markets are temporarily unavailable",
+    );
+
+    expect(message).toBe("Request failed at the configured provider");
+    expect(message).not.toContain("private_key_value");
+  });
+
+  it("uses the supplied fallback for unknown or empty errors", () => {
+    expect(
+      predictionMarketErrorMessage(null, "Prediction positions are unavailable"),
+    ).toBe("Prediction positions are unavailable");
+    expect(
+      predictionMarketErrorMessage(new Error(""), "Market creation failed"),
+    ).toBe("Market creation failed");
+  });
+});

--- a/tests/prediction-market-trading.test.ts
+++ b/tests/prediction-market-trading.test.ts
@@ -5,6 +5,7 @@ import {
   assertPredictionConfirmedBlocksMatch,
   parsePredictionBuyAmount,
   parsePredictionSellAmount,
+  predictionMarketInternal,
   predictionMarketPageIndices,
   predictionDirectionalProtocolFee,
   predictionYesProbabilityBps,
@@ -110,5 +111,25 @@ describe("prediction market trading math", () => {
         hash: `0x${"44".repeat(32)}`,
       }),
     ).toThrow("confirmed block");
+  });
+
+  it("bounds concurrent market reads while preserving directory order", async () => {
+    let active = 0;
+    let maximumActive = 0;
+    const values = Array.from({ length: 11 }, (_, index) => index);
+
+    const result = await predictionMarketInternal.mapPredictionMarketsInBatches(
+      values,
+      async (value) => {
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        active -= 1;
+        return value * 2;
+      },
+    );
+
+    expect(maximumActive).toBe(4);
+    expect(result).toEqual(values.map((value) => value * 2));
   });
 });

--- a/tests/prediction-market.test.ts
+++ b/tests/prediction-market.test.ts
@@ -282,6 +282,8 @@ describe("prediction market release boundary", () => {
   const predictionQuoterRuntimeCodeHash = `0x${"de".repeat(32)}` as const;
   const predictionQuoterAddress =
     "0x7777777777777777777777777777777777777777";
+  const secondaryRpcUrl =
+    "https://robinhood-mainnet.g.alchemy.com/v2/test_api_key_1234";
   const release = {
     deploymentBlock: 900n,
     factoryAddress: factory,
@@ -290,6 +292,7 @@ describe("prediction market release boundary", () => {
     predictionQuoterRuntimeCodeHash,
     routerRuntimeCodeHash,
     runtimeCodeHash,
+    secondaryRpcUrl,
   } as const;
   const marketValidation = validatePredictionMarketDraft(
     { observationUtc: "2026-08-24T12:00", thresholdUsd: "60000" },
@@ -346,6 +349,7 @@ describe("prediction market release boundary", () => {
         predictionQuoterRuntimeCodeHash,
         routerRuntimeCodeHash,
         runtimeCodeHash,
+        secondaryRpcUrl,
       }),
     ).toEqual(release);
     expect(() =>


### PR DESCRIPTION
## Outcome

- replaces the rate-limited public fallback with a required, domain-restricted Robinhood Alchemy release binding
- bounds Multicall3 batches to 64 calls and directory reads to four markets per wave
- keeps both RPC providers in the confirmed-state quorum and fails closed when the secondary binding is missing or invalid
- removes provider URLs from user-visible errors
- fixes the prediction detail grid overflow at the 390 px mobile breakpoint

## Validation

- 32 focused Vitest checks
- TypeScript and focused ESLint
- production Next.js build and candidate-neutral bundle scan
- live local Robinhood read through both providers: existing BTC market and 2.00005 USDG liability loaded
- Chrome desktop and 390x844 mobile interaction and console checks

The production environment already contains the new release binding. No contract state or user funds are changed by this PR.