### PR TITLE
Unify token and prediction discovery under Explore

### DIFF
--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1029,6 +1029,7 @@
 
 .pageHeading {
   align-items: flex-start;
+  gap: 24px;
   margin: 0;
   max-width: none;
   min-height: 102px;
@@ -1379,6 +1380,7 @@
   }
 
   .pageHeading {
+    gap: 18px;
     min-height: 0;
     padding: 0;
   }

--- a/components/explore-mode-switch.module.css
+++ b/components/explore-mode-switch.module.css
@@ -1,0 +1,55 @@
+.modeSwitch {
+  align-items: center;
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: 10px;
+  display: inline-grid;
+  gap: 4px;
+  grid-template-columns: repeat(2, minmax(104px, 1fr));
+  padding: 4px;
+}
+
+.modeLink {
+  align-items: center;
+  border-radius: 6px;
+  color: var(--webde-muted);
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 600;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  text-decoration: none;
+  transition:
+    background-color 160ms var(--webde-ease),
+    color 160ms var(--webde-ease);
+}
+
+.modeLink:hover {
+  background: var(--webde-control);
+  color: var(--webde-ink);
+}
+
+.modeLinkActive,
+.modeLinkActive:hover {
+  background: var(--webde-ink);
+  color: var(--webde-canvas);
+}
+
+.modeLink:focus-visible {
+  outline: 2px solid var(--webde-ink);
+  outline-offset: 3px;
+}
+
+@media (max-width: 420px) {
+  .modeSwitch {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modeLink {
+    transition: none;
+  }
+}

--- a/components/explore-mode-switch.tsx
+++ b/components/explore-mode-switch.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+import styles from "@/components/explore-mode-switch.module.css";
+
+type ExploreMode = "token" | "prediction";
+
+const exploreModes = [
+  { id: "token", href: "/explore", label: "Token" },
+  { id: "prediction", href: "/markets", label: "Prediction" },
+] as const;
+
+export function ExploreModeSwitch({ active }: { active: ExploreMode }) {
+  return (
+    <nav className={styles.modeSwitch} aria-label="Explore categories">
+      {exploreModes.map((mode) => {
+        const current = mode.id === active;
+
+        return (
+          <Link
+            key={mode.id}
+            className={`${styles.modeLink} ${
+              current ? styles.modeLinkActive : ""
+            }`}
+            href={mode.href}
+            prefetch={false}
+            aria-current={current ? "page" : undefined}
+          >
+            {mode.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -24,6 +24,7 @@ import {
   type MarketCapMetric,
 } from "@/components/animated-market-cap";
 import { XBrandIcon } from "@/components/brand-icons";
+import { ExploreModeSwitch } from "@/components/explore-mode-switch";
 import { EXPLORE_PREVIEW_TOKENS } from "@/components/explore-preview-data";
 import {
   isInterfacePreviewHost,
@@ -2652,7 +2653,8 @@ export function ExploreView({
   return (
     <div className={`${styles.page} explore-page page-width`}>
         <header className={styles.pageHeading}>
-          <Heading data-explore-heading>Explore Hooks</Heading>
+          <Heading data-explore-heading>Explore</Heading>
+          <ExploreModeSwitch active="token" />
         </header>
 
         <section

--- a/components/prediction-market-directory.tsx
+++ b/components/prediction-market-directory.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Activity, ArrowRight, Clock3, Plus, ShieldCheck } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
+import { ExploreModeSwitch } from "@/components/explore-mode-switch";
 import styles from "@/components/prediction-market-experience.module.css";
 import { predictionPreviewMarkets } from "@/components/prediction-market-preview";
 import { getPredictionMarketReleaseConfig } from "@/lib/prediction-market-chain";
@@ -172,10 +173,18 @@ export function PredictionMarketDirectoryView() {
 
   return (
     <main className={`page-width ${styles.directoryPage}`}>
-      <section className={styles.directoryHero} aria-labelledby="markets-title">
+      <header className={styles.exploreHeader}>
+        <h1>Explore</h1>
+        <ExploreModeSwitch active="prediction" />
+      </header>
+
+      <section
+        className={styles.directoryHero}
+        aria-labelledby="prediction-intro-title"
+      >
         <div className={styles.heroCopy}>
           <span className={styles.kicker}>PREDICTION MARKETS · ROBINHOOD CHAIN</span>
-          <h1 id="markets-title">Trade the outcome.<br />Keep the rules onchain.</h1>
+          <h2 id="prediction-intro-title">Trade the outcome.<br />Keep the rules onchain.</h2>
           <p>
             Permissionless BTC markets, fully backed by USDG and priced through
             a native Uniswap v4 YES/NO pool.

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -7,6 +7,27 @@
   padding-top: clamp(42px, 7vw, 88px);
 }
 
+.directoryPage {
+  padding-top: 34px;
+}
+
+.exploreHeader {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding-bottom: 56px;
+}
+
+.exploreHeader h1 {
+  color: var(--text);
+  font-size: clamp(58px, 6.5vw, 96px);
+  font-weight: 520;
+  letter-spacing: -0.062em;
+  line-height: 0.92;
+  margin: 0;
+}
+
 .directoryHero {
   align-items: flex-end;
   display: flex;
@@ -41,7 +62,7 @@
   margin-bottom: 20px;
 }
 
-.heroCopy h1 {
+.heroCopy h2 {
   color: var(--text);
   font-size: clamp(48px, 7.4vw, 98px);
   font-weight: 520;
@@ -1095,7 +1116,16 @@
     padding-top: 34px;
   }
 
-  .heroCopy h1 {
+  .exploreHeader {
+    gap: 18px;
+    padding-bottom: 48px;
+  }
+
+  .exploreHeader h1 {
+    font-size: clamp(38px, 11vw, 48px);
+  }
+
+  .heroCopy h2 {
     font-size: clamp(43px, 13vw, 64px);
     line-height: 0.94;
   }

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -25,7 +25,6 @@ import styles from "@/components/site-navigation.module.css";
 
 const desktopNavItems = [
   { href: "/explore", label: "Explore" },
-  { href: "/markets", label: "Markets" },
   { href: "/launch", label: "Create" },
   { href: "/profile", label: "Profile" },
   { href: "/docs", label: "Docs" },
@@ -113,6 +112,14 @@ function HeaderSocialLinks({ mobile = false }: { mobile?: boolean }) {
 function isCurrent(pathname: string, item: (typeof desktopNavItems)[number]) {
   const activePath = "activePath" in item ? item.activePath : item.href;
 
+  if (activePath === "/explore") {
+    return (
+      pathname === "/explore" ||
+      pathname.startsWith("/explore/") ||
+      pathname === "/markets" ||
+      pathname.startsWith("/markets/")
+    );
+  }
   if (activePath === "/docs") {
     return pathname === "/docs" || pathname.startsWith("/docs/");
   }

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -37,12 +37,38 @@ describe("Explore UI contract", () => {
     );
     expect(source).toContain("inert={loadingOnly ? true : undefined}");
     expect(source).toContain('const Heading = embedded ? "h2" : "h1"');
-    expect(source).toContain("<Heading data-explore-heading>Explore Hooks</Heading>");
+    expect(source).toContain("<Heading data-explore-heading>Explore</Heading>");
+    expect(source).toContain('<ExploreModeSwitch active="token" />');
     expect(source).toContain("const eagerImage = !embedded");
     expect(source).not.toContain("ExploreGridSkeleton");
     expect(source).toContain(
       'className={styles.loadingState} aria-busy="true"',
     );
+  });
+
+  it("keeps token and prediction discovery inside one Explore destination", () => {
+    const navigation = readFileSync(
+      join(root, "components/site-navigation.tsx"),
+      "utf8",
+    );
+    const switchSource = readFileSync(
+      join(root, "components/explore-mode-switch.tsx"),
+      "utf8",
+    );
+    const predictionSource = readFileSync(
+      join(root, "components/prediction-market-directory.tsx"),
+      "utf8",
+    );
+
+    expect(navigation).not.toContain('{ href: "/markets", label: "Markets" }');
+    expect(navigation).toContain('pathname.startsWith("/markets/")');
+    expect(switchSource).toContain('{ id: "token", href: "/explore", label: "Token" }');
+    expect(switchSource).toContain(
+      '{ id: "prediction", href: "/markets", label: "Prediction" }',
+    );
+    expect(switchSource).toContain('aria-label="Explore categories"');
+    expect(predictionSource).toContain('<h1>Explore</h1>');
+    expect(predictionSource).toContain('<ExploreModeSwitch active="prediction" />');
   });
 
   it("keeps sort, socials and model choices in one persistent disclosure", () => {


### PR DESCRIPTION
## Summary

- remove the standalone Markets item from desktop and mobile navigation
- add a shared Token / Prediction selector under Explore
- keep existing market routes and deep links while marking Explore active across them
- preserve one semantic page heading in both modes

## Verification

- npm run lint
- npm run typecheck
- npm run test:interface:ci
- npm run build
- rendered browser QA at 1440x900, 390x844, and 320x700
- verified both mode links, mobile menu, responsive overflow, and console output