### PR TITLE
Keep Explore mode switch clickable

### DIFF
--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1056,6 +1056,16 @@
   max-width: none;
 }
 
+@media (min-width: 1101px) {
+  .runnersIntro {
+    pointer-events: none;
+  }
+
+  .runnersIntro :global(.token-section-heading) {
+    pointer-events: auto;
+  }
+}
+
 .runnersIntro :global(.token-section-heading),
 .runnersIntro :global(.token-toolbar) {
   align-items: center;

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -59,6 +59,10 @@ describe("Explore UI contract", () => {
       join(root, "components/prediction-market-directory.tsx"),
       "utf8",
     );
+    const exploreStyles = readFileSync(
+      join(root, "components/explore-experience.module.css"),
+      "utf8",
+    );
 
     expect(navigation).not.toContain('{ href: "/markets", label: "Markets" }');
     expect(navigation).toContain('pathname.startsWith("/markets/")');
@@ -69,6 +73,9 @@ describe("Explore UI contract", () => {
     expect(switchSource).toContain('aria-label="Explore categories"');
     expect(predictionSource).toContain('<h1>Explore</h1>');
     expect(predictionSource).toContain('<ExploreModeSwitch active="prediction" />');
+    expect(exploreStyles).toMatch(
+      /@media \(min-width: 1101px\)[\s\S]*?\.runnersIntro\s*\{[^}]*pointer-events:\s*none;[^}]*\}[\s\S]*?\.runnersIntro :global\(\.token-section-heading\)\s*\{[^}]*pointer-events:\s*auto;/s,
+    );
   });
 
   it("keeps sort, socials and model choices in one persistent disclosure", () => {


### PR DESCRIPTION
## Summary
- keep the desktop Explore mode switch above the overlapping toolbar hitbox
- preserve toolbar interactions by restoring pointer events on its actual control container
- add a focused UI contract regression check

## Validation
- `vitest run tests/explore-ui-contract.test.ts` (7/7)
- `npm run typecheck`
- real Chrome: Prediction link receives the hit target and navigates from `/explore` to `/markets`