### PR TITLE
Polish the prediction market experience

### DIFF
--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -242,7 +242,7 @@ function LaunchExperienceRuntime({
 
   if (selectedModel === "prediction") {
     return (
-      <Suspense fallback={<LaunchFormLoading title="Create a BTC market" onBack={returnToModels} />}>
+      <Suspense fallback={<LaunchFormLoading title="Create a prediction" onBack={returnToModels} />}>
         <LazyPredictionMarketLaunch onBack={returnToModels} />
       </Suspense>
     );
@@ -357,96 +357,6 @@ export function LaunchModelPicker({
 
       <div className={`launch-model-grid ${launchExperience.modelGrid}`}>
         <button
-          ref={predictionButtonRef}
-          className={`launch-model-card ${launchExperience.modelCard} ${launchExperience.predictionCard} liquid-glass-surface`}
-          data-launch-model-option="prediction"
-          data-launch-model-available="true"
-          data-launch-model-launchable="false"
-          data-launch-model-preview="true"
-          type="button"
-          aria-labelledby="launch-model-prediction-title"
-          aria-describedby="launch-model-prediction-description"
-          onPointerEnter={preloadPredictionMarket}
-          onPointerDown={preloadPredictionMarket}
-          onFocus={preloadPredictionMarket}
-          onClick={() => void onChoose("prediction")}
-        >
-          <span
-            className={`launch-model-art ${launchExperience.modelArt} ${launchExperience.predictionArt}`}
-            aria-hidden="true"
-          >
-            <span className={launchExperience.predictionRail}>
-              <span
-                className={`${launchExperience.predictionSide} ${launchExperience.predictionYes}`}
-              >
-                <span>YES</span>
-                <strong>50</strong>
-                <small>cents</small>
-              </span>
-              <span className={launchExperience.predictionCondition}>
-                <span>BTC</span>
-                <strong>&ge; $60K</strong>
-                <small>UTC close</small>
-              </span>
-              <span
-                className={`${launchExperience.predictionSide} ${launchExperience.predictionNo}`}
-              >
-                <span>NO</span>
-                <strong>50</strong>
-                <small>cents</small>
-              </span>
-            </span>
-          </span>
-          <span
-            className={`launch-model-card-body ${launchExperience.modelBody}`}
-          >
-            <span
-              className={`launch-model-card-heading ${launchExperience.modelHeading}`}
-            >
-              <strong id="launch-model-prediction-title">Prediction</strong>
-              <small data-status="preview">Technical preview</small>
-            </span>
-            <span
-              className={`launch-model-description ${launchExperience.modelDescription}`}
-              id="launch-model-prediction-description"
-            >
-              Create a BTC price market with YES and NO outcome tokens, a fixed
-              UTC result time, and a 2 USDG seed instead of a separate liquidity
-              deposit.
-            </span>
-            <span
-              className={`launch-model-action ${launchExperience.modelAction}`}
-            >
-              Design a BTC market
-              <ArrowRight aria-hidden="true" size={16} />
-            </span>
-          </span>
-        </button>
-
-        <button
-          ref={customLaunchButtonRef}
-          className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
-          data-launch-model-option="custom"
-          data-launch-model-available={customLaunchPublicEnabled}
-          data-launch-model-launchable={customLaunchPublicEnabled}
-          type="button"
-          disabled={!customLaunchPublicEnabled}
-          aria-labelledby="launch-model-custom-title"
-          aria-describedby="launch-model-custom-description"
-          onPointerEnter={
-            customLaunchPublicEnabled ? preloadCustomLaunch : undefined
-          }
-          onFocus={customLaunchPublicEnabled ? preloadCustomLaunch : undefined}
-          onClick={
-            customLaunchPublicEnabled
-              ? () => void onChoose("custom")
-              : undefined
-          }
-        >
-          {customCardContent}
-        </button>
-
-        <button
           className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
           data-launch-model-option="classic"
           data-launch-model-available={classicV3LaunchAvailable}
@@ -516,6 +426,91 @@ export function LaunchModelPicker({
                 <ArrowRight aria-hidden="true" size={16} />
               </span>
             ) : null}
+          </span>
+        </button>
+
+        <button
+          ref={customLaunchButtonRef}
+          className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
+          data-launch-model-option="custom"
+          data-launch-model-available={customLaunchPublicEnabled}
+          data-launch-model-launchable={customLaunchPublicEnabled}
+          type="button"
+          disabled={!customLaunchPublicEnabled}
+          aria-labelledby="launch-model-custom-title"
+          aria-describedby="launch-model-custom-description"
+          onPointerEnter={
+            customLaunchPublicEnabled ? preloadCustomLaunch : undefined
+          }
+          onFocus={customLaunchPublicEnabled ? preloadCustomLaunch : undefined}
+          onClick={
+            customLaunchPublicEnabled
+              ? () => void onChoose("custom")
+              : undefined
+          }
+        >
+          {customCardContent}
+        </button>
+
+        <button
+          ref={predictionButtonRef}
+          className={`launch-model-card ${launchExperience.modelCard} ${launchExperience.predictionCard} liquid-glass-surface`}
+          data-launch-model-option="prediction"
+          data-launch-model-available="true"
+          data-launch-model-launchable="false"
+          data-launch-model-preview="true"
+          type="button"
+          aria-labelledby="launch-model-prediction-title"
+          aria-describedby="launch-model-prediction-description"
+          onPointerEnter={preloadPredictionMarket}
+          onPointerDown={preloadPredictionMarket}
+          onFocus={preloadPredictionMarket}
+          onClick={() => void onChoose("prediction")}
+        >
+          <span
+            className={`launch-model-art ${launchExperience.modelArt} ${launchExperience.predictionArt}`}
+            aria-hidden="true"
+          >
+            <span className={launchExperience.predictionRail}>
+              <span
+                className={`${launchExperience.predictionSide} ${launchExperience.predictionYes}`}
+              >
+                <span>YES</span>
+                <strong>50¢</strong>
+              </span>
+              <span className={launchExperience.predictionCondition}>
+                <span>BTC</span>
+                <strong>&ge; $60K</strong>
+              </span>
+              <span
+                className={`${launchExperience.predictionSide} ${launchExperience.predictionNo}`}
+              >
+                <span>NO</span>
+                <strong>50¢</strong>
+              </span>
+            </span>
+          </span>
+          <span
+            className={`launch-model-card-body ${launchExperience.modelBody}`}
+          >
+            <span
+              className={`launch-model-card-heading ${launchExperience.modelHeading}`}
+            >
+              <strong id="launch-model-prediction-title">Prediction</strong>
+              <small data-status="preview">Beta</small>
+            </span>
+            <span
+              className={`launch-model-description ${launchExperience.modelDescription}`}
+              id="launch-model-prediction-description"
+            >
+              Create a BTC prediction with YES and NO.
+            </span>
+            <span
+              className={`launch-model-action ${launchExperience.modelAction}`}
+            >
+              Create a prediction
+              <ArrowRight aria-hidden="true" size={16} />
+            </span>
           </span>
         </button>
 

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -1977,10 +1977,6 @@
   padding: 0;
 }
 
-.modelCard[data-launch-model-option="classic"] {
-  order: -1;
-}
-
 .modelCard.modelCard:disabled {
   cursor: default;
   opacity: 0.56;
@@ -2092,11 +2088,10 @@
 /* Prediction is a two-sided market, so its picker art is the product model. */
 .predictionCard {
   grid-column: 1 / -1;
-  order: -2;
 }
 
 .predictionCard.modelCard {
-  min-height: 278px;
+  min-height: 244px;
 }
 
 .predictionArt {
@@ -2114,38 +2109,33 @@
 .predictionSide {
   align-content: center;
   display: grid;
-  gap: 2px;
+  gap: 6px;
   min-width: 0;
   padding: 28px clamp(24px, 4vw, 54px);
 }
 
 .predictionSide > span {
-  font-size: 12px;
-  font-weight: 760;
-  letter-spacing: 0.08em;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
 }
 
 .predictionSide strong {
-  font-size: clamp(56px, 7vw, 92px);
+  font-size: clamp(56px, 6vw, 82px);
   font-weight: 540;
   letter-spacing: -0.07em;
   line-height: 0.88;
 }
 
-.predictionSide small {
-  font-size: 11px;
-  opacity: 0.72;
-}
-
 .predictionYes {
-  background: #12362c;
-  color: #9ce3bd;
+  background: linear-gradient(135deg, #12372d, #173f33);
+  color: #b1eccb;
   text-align: left;
 }
 
 .predictionNo {
-  background: #381527;
-  color: #f4a8cb;
+  background: linear-gradient(225deg, #3d172a, #321321);
+  color: #f3b4d1;
   text-align: right;
 }
 
@@ -2153,14 +2143,14 @@
   align-content: center;
   background: #f4eee7;
   border: 1px solid rgb(0 0 0 / 0.18);
-  border-radius: 999px;
+  border-radius: 14px;
   color: #111;
   display: grid;
-  gap: 1px;
+  gap: 3px;
   left: 50%;
-  min-height: 96px;
-  min-width: 142px;
-  padding: 15px 20px;
+  min-height: 82px;
+  min-width: 150px;
+  padding: 14px 20px;
   position: absolute;
   text-align: center;
   top: 50%;
@@ -2170,21 +2160,41 @@
 
 .predictionCondition > span,
 .predictionCondition > small {
-  font-size: 9px;
+  font-size: 10px;
   font-weight: 720;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .predictionCondition strong {
-  font-size: 20px;
+  font-size: 22px;
   letter-spacing: -0.04em;
+}
+
+.predictionCard .modelHeading small {
+  background: var(--webde-control);
+  border-radius: 999px;
+  color: var(--webde-muted);
+  padding: 5px 9px;
+}
+
+.predictionCard .modelAction {
+  align-items: center;
+  align-self: start;
+  background: var(--webde-ink);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-canvas);
+  display: inline-flex;
+  gap: 8px;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 15px;
 }
 
 @media (min-width: 761px) {
   .predictionCard.modelCard {
     display: grid;
-    grid-template-columns: minmax(0, 1.35fr) minmax(310px, 0.65fr);
+    grid-template-columns: minmax(0, 1.45fr) minmax(300px, 0.55fr);
   }
 
   .predictionCard .predictionArt {
@@ -2196,7 +2206,7 @@
 
   .predictionCard .modelBody {
     align-content: center;
-    min-height: 278px;
+    min-height: 244px;
     padding: 28px;
   }
 }
@@ -2207,7 +2217,7 @@
   }
 
   .predictionArt {
-    aspect-ratio: 1.35 / 1;
+    aspect-ratio: 1.7 / 1;
   }
 
   .predictionSide {
@@ -2215,12 +2225,12 @@
   }
 
   .predictionCondition {
-    min-height: 82px;
-    min-width: 118px;
+    min-height: 72px;
+    min-width: 116px;
     padding: 12px 14px;
   }
 
   .predictionCondition strong {
-    font-size: 17px;
+    font-size: 18px;
   }
 }

--- a/components/prediction-market-detail.tsx
+++ b/components/prediction-market-detail.tsx
@@ -6,10 +6,8 @@ import {
   CheckCircle2,
   Clock3,
   ExternalLink,
-  Info,
   LockKeyhole,
   RefreshCw,
-  ShieldCheck,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -264,7 +262,7 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   async function handleQuote() {
     if (!market || busy) return;
     setPhase("quoting");
-    setMessage(preview ? "Calculating the interface preview…" : "Reconciling the exact route across two RPCs and the official v4 Quoter…");
+    setMessage(preview ? "Checking the preview price…" : "Finding your price…");
     try {
       if (preview || !release.config) {
         setShownQuote(previewQuote(market, mode, outcome, amount));
@@ -457,18 +455,25 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   }
 
   if (loadState.kind === "loading") {
-    return <main className={`page-width ${styles.detailPage}`}><div className={styles.detailLoading}>Verifying the market across both Robinhood RPCs…</div></main>;
+    return (
+      <main className={`page-width ${styles.detailPage}`}>
+        <div className={styles.detailLoading}>Loading market…</div>
+      </main>
+    );
   }
   if (loadState.kind === "error" || !market) {
     return (
       <main className={`page-width ${styles.detailPage}`}>
-        <Link className={styles.detailBack} href="/markets"><ArrowLeft size={15} /> Markets</Link>
+        <Link className={styles.detailBack} href="/markets">
+          <ArrowLeft aria-hidden="true" size={15} /> Predictions
+        </Link>
         <div className={styles.detailError}><strong>Market unavailable</strong><p>{loadState.kind === "error" ? loadState.message : "Unknown market"}</p></div>
       </main>
     );
   }
 
   const tradingOpen = market.state === "OPEN" && market.blockTimestamp < market.cutoff;
+  const displayTitle = `Will BTC be at or above ${formatPredictionPriceAtoms(market.thresholdAtoms)}?`;
   const selectedBalance = outcome === "YES" ? market.yesBalanceAtoms : market.noBalanceAtoms;
   const selectedProtocolFee = liveQuote
     ? predictionDirectionalProtocolFee(liveQuote.value.swap.protocolFee, liveQuote.value.zeroForOne)
@@ -485,22 +490,29 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
 
   return (
     <main className={`page-width ${styles.detailPage}`}>
-      <Link className={styles.detailBack} href="/markets"><ArrowLeft aria-hidden="true" size={15} /> All markets</Link>
+      <Link className={styles.detailBack} href="/markets">
+        <ArrowLeft aria-hidden="true" size={15} /> Predictions
+      </Link>
       {preview ? (
-        <p className={styles.previewBanner}><strong>Interface preview.</strong> Values below are sample data; signatures and transactions are disabled.</p>
+        <p className={styles.previewBanner}>
+          <strong>Preview data.</strong> No wallet signatures or transactions.
+        </p>
       ) : null}
-      {release.error ? <p className={styles.errorBanner}>{release.error}</p> : null}
 
       <div className={styles.detailLayout}>
         <section className={styles.marketCanvas}>
-          <span className={styles.detailEyebrow}>BTC · PRICE AT UTC SNAPSHOT</span>
-          <h1>{market.title}</h1>
+          <h1>{displayTitle}</h1>
           <div className={styles.detailMeta}>
             <span className={tradingOpen ? styles.openBadge : styles.closedBadge}>
-              {tradingOpen ? "Trading open" : market.state === "OPEN" ? "Trading closed" : market.state.replaceAll("_", " ")}
+              {tradingOpen ? "Open" : "Closed"}
             </span>
-            <span><Clock3 aria-hidden="true" size={14} /> {utcDate(market.observationTime)}</span>
-            <span>{countdown(market.observationTime, market.blockTimestamp)}</span>
+            <span>
+              <Clock3 aria-hidden="true" size={15} />
+              {tradingOpen
+                ? `Closes in ${countdown(market.cutoff, market.blockTimestamp)}`
+                : "Trading closed"}
+            </span>
+            <span>Resolves {utcDate(market.observationTime)}</span>
           </div>
 
           <div className={styles.heroProbability}>
@@ -517,39 +529,38 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
             </span>
           </div>
 
-          <div className={styles.marketFacts}>
-            <div><span className={styles.factLabel}>BACKING</span><strong>{formatPredictionUsdg(market.accountedLiabilityAtoms)}</strong><small>held by this market vault</small></div>
-            <div><span className={styles.factLabel}>POOL</span><strong>Uniswap v4</strong><small>native YES / NO pair</small></div>
-            <div><span className={styles.factLabel}>LP FEE</span><strong>2 bps</strong><small>no app trading fee</small></div>
-            <div><span className={styles.factLabel}>RESULT</span><strong>{market.state === "OPEN" ? "Chainlink" : formatPredictionPriceAtoms(market.resolvedPriceAtoms)}</strong><small>last completed round at or before T</small></div>
-          </div>
-
-          <section className={styles.rulesPanel}>
-            <header><ShieldCheck aria-hidden="true" size={18} /><strong>One rule. No human vote.</strong></header>
-            <p>
-              YES wins when the last completed Chainlink BTC/USD round at or before
-              {` ${utcDate(market.observationTime)} `}
-              is at least {formatPredictionPriceAtoms(market.thresholdAtoms)}. The next
-              adjacent round proves the boundary. Invalid oracle evidence pays both
-              sides 0.50 USDG.
-            </p>
-          </section>
-
-          {!preview ? (
-            <div className={styles.contractLinks}>
-              <a href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.vault}`} target="_blank" rel="noreferrer">Vault <ExternalLink size={12} /></a>
-              <a href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.yesToken}`} target="_blank" rel="noreferrer">YES token <ExternalLink size={12} /></a>
-              <a href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.noToken}`} target="_blank" rel="noreferrer">NO token <ExternalLink size={12} /></a>
+          <details className={styles.marketInfo}>
+            <summary>
+              <span>How this market resolves</span>
+              <i aria-hidden="true" />
+            </summary>
+            <div className={styles.marketInfoBody}>
+              <p>
+                <strong>YES wins</strong> if BTC is {formatPredictionPriceAtoms(market.thresholdAtoms)}
+                {" "}or higher at {utcDate(market.observationTime)}.
+              </p>
+              <p>
+                The result uses Chainlink&apos;s last completed BTC/USD price at or
+                before that time. If no valid result can be proven, YES and NO
+                each redeem for 0.50 USDG.
+              </p>
+              {!preview ? (
+                <div className={styles.contractLinks}>
+                  <a href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.vault}`} target="_blank" rel="noreferrer">Market contract <ExternalLink size={12} /></a>
+                  <a href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.yesToken}`} target="_blank" rel="noreferrer">YES token <ExternalLink size={12} /></a>
+                  <a href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.noToken}`} target="_blank" rel="noreferrer">NO token <ExternalLink size={12} /></a>
+                </div>
+              ) : null}
             </div>
-          ) : null}
+          </details>
         </section>
 
         <aside className={styles.tradeTerminal} aria-label="Prediction market trade terminal">
           {tradingOpen ? (
             <>
               <div className={styles.terminalTopline}>
-                <span className={styles.terminalLabel}>EXECUTE</span>
-                <span><span className={preview ? styles.previewDot : styles.liveDot} /> {preview ? "PREVIEW" : `BLOCK ${market.blockNumber}`}</span>
+                <h2>Trade</h2>
+                {preview ? <span>Preview</span> : null}
               </div>
               <div className={styles.modeTabs} role="tablist" aria-label="Trade direction">
                 {(["BUY", "SELL"] as const).map((value) => (
@@ -572,13 +583,17 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
               {shownQuote ? (
                 <div className={styles.quoteReceipt} aria-live="polite">
                   <div><span>You receive</span><strong>{shownQuote.outputLabel}</strong></div>
-                  <div><span>Minimum at {PREDICTION_DEFAULT_SLIPPAGE_BPS / 100}% slippage</span><strong>{shownQuote.minimumLabel}</strong></div>
+                  <div><span>Minimum received</span><strong>{shownQuote.minimumLabel}</strong></div>
                   <div><span>Average price</span><strong>{centsLabel(shownQuote.averagePriceBps)}</strong></div>
-                  <div><span>Probability</span><strong>{probabilityLabel(market.probabilityYesBps)} → {probabilityLabel(shownQuote.afterYesBps)} YES</strong></div>
-                  <div><span>Price impact</span><strong>{probabilityLabel(shownQuote.priceImpactBps)}</strong></div>
-                  <div><span>Depth</span><strong>{shownQuote.depthLabel}</strong></div>
-                  {shownQuote.refundLabel ? <div><span>Residual refund</span><strong>{shownQuote.refundLabel}</strong></div> : null}
-                  <div><span>Fees</span><strong>2 bps LP{selectedProtocolFee ? ` + ${selectedProtocolFee / 100} bps protocol` : " · 0 app"}</strong></div>
+                  <div><span>Trading fee</span><strong>0.02%{selectedProtocolFee ? ` + ${selectedProtocolFee / 100} bps protocol` : ""}</strong></div>
+                  <details className={styles.quoteDetails}>
+                    <summary>Price details</summary>
+                    <div><span>YES chance after trade</span><strong>{probabilityLabel(shownQuote.afterYesBps)}</strong></div>
+                    <div><span>Price impact</span><strong>{probabilityLabel(shownQuote.priceImpactBps)}</strong></div>
+                    <div><span>Market depth</span><strong>{shownQuote.depthLabel}</strong></div>
+                    {shownQuote.refundLabel ? <div><span>Refund</span><strong>{shownQuote.refundLabel}</strong></div> : null}
+                    <div><span>Slippage limit</span><strong>{PREDICTION_DEFAULT_SLIPPAGE_BPS / 100}%</strong></div>
+                  </details>
                 </div>
               ) : null}
 
@@ -593,18 +608,21 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
                 }}
               >
                 {busy
-                  ? phase === "signing" ? "Sign exact permit" : phase === "confirming" ? "Confirming onchain" : "Checking quote"
-                  : !shownQuote ? preview ? "Preview quote" : "Get executable quote"
-                  : preview ? "Refresh preview"
+                  ? phase === "signing" ? "Sign in wallet" : phase === "confirming" ? "Confirming" : "Getting price"
+                  : !shownQuote ? preview ? "Preview price" : "Review price"
+                  : preview ? "Update preview"
                   : !wallet ? "Connect wallet"
                   : `${mode} ${outcome}`}
               </button>
-              <p className={styles.terminalNote}><Info aria-hidden="true" size={13} /> Quotes must match both public RPCs and the official Uniswap v4 Quoter. Gas is shown separately by your wallet.</p>
+              <p className={styles.terminalNote}>
+                Your wallet shows the final amount and network fee before you
+                confirm.
+              </p>
             </>
           ) : market.state !== "OPEN" ? (
             <div className={styles.settlementTerminal}>
               <CheckCircle2 aria-hidden="true" size={24} />
-              <span className={styles.terminalLabel}>MARKET FINAL</span>
+              <span className={styles.terminalLabel}>Market resolved</span>
               <h2>{market.state === "FINAL_INVALID" ? "Neutral payout" : market.state === "FINAL_YES" ? "YES won" : "NO won"}</h2>
               <p>{market.state === "FINAL_INVALID" ? "Every YES and NO token redeems for 0.50 USDG." : "Each winning token redeems for 1 USDG. Losing tokens redeem for zero."}</p>
               {wallet ? <div className={styles.balancePair}><span>YES <strong>{formatPredictionOutcome(market.yesBalanceAtoms)}</strong></span><span>NO <strong>{formatPredictionOutcome(market.noBalanceAtoms)}</strong></span></div> : null}
@@ -615,21 +633,21 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
           ) : (
             <div className={styles.settlementTerminal}>
               <LockKeyhole aria-hidden="true" size={24} />
-              <span className={styles.terminalLabel}>TRADING CLOSED</span>
+              <span className={styles.terminalLabel}>Trading closed</span>
               <h2>{market.blockTimestamp <= market.observationTime ? "Waiting for result time" : "Ready to resolve"}</h2>
-              <p>{market.blockTimestamp <= market.observationTime ? `Trading stopped one minute before the snapshot. Resolution opens after ${utcDate(market.observationTime)}.` : "Anyone can submit the unique adjacent Chainlink rounds. No keeper or admin is required."}</p>
+              <p>{market.blockTimestamp <= market.observationTime ? `Trading stopped one minute before the result time. The result can be checked after ${utcDate(market.observationTime)}.` : "The result can now be checked from Chainlink. Anyone can finish the market."}</p>
               {market.blockTimestamp > market.observationTime ? (
-                <button className={styles.terminalAction} disabled={busy} type="button" onClick={() => preview ? setMessage("Preview only. Resolution will be permissionless after deployment.") : wallet ? void handleLifecycle("RESOLVE") : openWallet()}>{busy ? "Checking Chainlink rounds" : !wallet ? "Connect to resolve" : "Resolve market"}</button>
+                <button className={styles.terminalAction} disabled={busy} type="button" onClick={() => preview ? setMessage("Preview only. No wallet request will be made.") : wallet ? void handleLifecycle("RESOLVE") : openWallet()}>{busy ? "Checking result" : !wallet ? "Connect to resolve" : "Resolve market"}</button>
               ) : null}
               {lifecycleAction && market.blockTimestamp > market.observationTime ? (
                 <button className={styles.secondaryTerminalAction} disabled={busy} type="button" onClick={() => preview ? setMessage("Preview only.") : wallet ? void handleLifecycle(lifecycleAction) : openWallet()}>
-                  {lifecycleAction === "FINALIZE_CHECKPOINT" ? "Apply resolved checkpoint" : lifecycleAction === "FINALIZE_UNAVAILABLE" ? "Try neutral unavailable exit" : lifecycleAction === "REQUEST_UNPROVEN_FALLBACK" ? "Start 72h neutral challenge" : "Finalize neutral fallback"}
+                  {lifecycleAction === "FINALIZE_CHECKPOINT" ? "Use confirmed result" : lifecycleAction === "FINALIZE_UNAVAILABLE" ? "Close as neutral" : lifecycleAction === "REQUEST_UNPROVEN_FALLBACK" ? "Start neutral fallback" : "Finish neutral fallback"}
                 </button>
               ) : null}
             </div>
           )}
           {message ? <p className={styles.terminalStatus} role="status">{message}</p> : null}
-          <button className={styles.refreshMarket} type="button" disabled={busy} onClick={() => void refresh()}><RefreshCw aria-hidden="true" size={13} /> Refresh confirmed state</button>
+          <button className={styles.refreshMarket} type="button" disabled={busy} onClick={() => void refresh()}><RefreshCw aria-hidden="true" size={13} /> Refresh market</button>
         </aside>
       </div>
     </main>

--- a/components/prediction-market-directory.tsx
+++ b/components/prediction-market-directory.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { Activity, ArrowRight, Clock3, Plus, ShieldCheck } from "lucide-react";
+import { ArrowRight, Plus } from "lucide-react";
+import type { CSSProperties } from "react";
 import { useEffect, useMemo, useState } from "react";
 
 import { ExploreModeSwitch } from "@/components/explore-mode-switch";
@@ -10,7 +11,7 @@ import { predictionPreviewMarkets } from "@/components/prediction-market-preview
 import { getPredictionMarketReleaseConfig } from "@/lib/prediction-market-chain";
 import { predictionMarketErrorMessage } from "@/lib/prediction-market-errors";
 import {
-  formatPredictionUsdg,
+  formatPredictionPriceAtoms,
   readPredictionMarketDirectory,
   type PredictionMarketView,
 } from "@/lib/prediction-market-trading";
@@ -20,8 +21,6 @@ type DirectoryState =
   | { kind: "preview"; markets: readonly PredictionMarketView[] }
   | {
       kind: "live";
-      blockNumber: bigint;
-      marketCount: bigint;
       markets: readonly PredictionMarketView[];
       nextCursor: bigint;
     }
@@ -43,40 +42,66 @@ function countdown(target: bigint, now: bigint) {
   return `${minutes}m`;
 }
 
-function MarketRow({ market, preview }: { market: PredictionMarketView; preview: boolean }) {
+function MarketCard({
+  market,
+  preview,
+}: {
+  market: PredictionMarketView;
+  preview: boolean;
+}) {
   const yes = market.probabilityYesBps / 100;
   const no = 100 - yes;
-  const tradingOpen = market.state === "OPEN" && market.blockTimestamp < market.cutoff;
+  const cardTitle = `Will BTC be at or above ${formatPredictionPriceAtoms(market.thresholdAtoms)}?`;
+  const tradingOpen =
+    market.state === "OPEN" && market.blockTimestamp < market.cutoff;
+  const marketStatus = tradingOpen
+    ? `Closes in ${countdown(market.cutoff, market.blockTimestamp)}`
+    : market.state === "OPEN"
+      ? "Trading closed"
+      : market.state === "FINAL_YES"
+        ? "YES won"
+        : market.state === "FINAL_NO"
+          ? "NO won"
+          : market.state === "FINAL_INVALID"
+            ? "Neutral result"
+            : "Closed";
+
   return (
-    <Link
-      className={styles.marketRow}
-      href={`/markets/${market.semanticKey}`}
-      aria-label={`${market.title}, YES ${yes.toFixed(0)} percent`}
-    >
-      <span className={styles.assetMark} aria-hidden="true">₿</span>
-      <span className={styles.marketIdentity}>
-        <span className={styles.marketMeta}>
-          <span>{tradingOpen ? "TRADING" : market.state.replaceAll("_", " ")}</span>
-          <span>BTC</span>
-          {preview ? <span>PREVIEW</span> : null}
+    <article className={styles.marketCard}>
+      <Link
+        className={styles.marketCardLink}
+        href={`/markets/${market.semanticKey}`}
+        aria-label={`${market.title}, YES ${yes.toFixed(0)} percent`}
+      >
+        <span
+          className={styles.marketCardArt}
+          style={{ "--yes-share": `${yes}%` } as CSSProperties}
+          aria-hidden="true"
+        >
+          <span className={styles.marketCardChance}>
+            <strong>{yes.toFixed(0)}%</strong>
+            <span>YES chance</span>
+          </span>
+          <span className={styles.marketCardPrices}>
+            <span>YES {yes.toFixed(0)}¢</span>
+            <span>NO {no.toFixed(0)}¢</span>
+          </span>
         </span>
-        <strong>{market.title}</strong>
-        <span className={styles.marketFoot}>
-          <span><Clock3 aria-hidden="true" size={13} /> {countdown(market.observationTime, market.blockTimestamp)}</span>
-          <span>{formatPredictionUsdg(market.accountedLiabilityAtoms)} backed</span>
+
+        <span className={styles.marketCardBody}>
+          <strong>{cardTitle}</strong>
         </span>
-      </span>
-      <span className={styles.marketProbability}>
-        <span className={styles.probabilityNumbers}>
-          <span><small>YES</small><strong>{yes.toFixed(0)}¢</strong></span>
-          <span><small>NO</small><strong>{no.toFixed(0)}¢</strong></span>
+
+        <span className={styles.marketCardMeta}>
+          <span>
+            <i data-open={tradingOpen ? "true" : undefined} />
+            {marketStatus}
+          </span>
+          {preview ? <span>Preview</span> : null}
+          <ArrowRight aria-hidden="true" size={17} />
         </span>
-        <span className={styles.probabilityRail} aria-hidden="true">
-          <span style={{ width: `${yes}%` }} />
-        </span>
-      </span>
-      <ArrowRight className={styles.rowArrow} aria-hidden="true" size={20} />
-    </Link>
+      </Link>
+    </article>
   );
 }
 
@@ -115,8 +140,6 @@ export function PredictionMarketDirectoryView() {
         if (active) {
           setState({
             kind: "live",
-            blockNumber: directory.blockNumber,
-            marketCount: directory.marketCount,
             markets: directory.markets,
             nextCursor: directory.nextCursor,
           });
@@ -145,7 +168,6 @@ export function PredictionMarketDirectoryView() {
         const known = new Set(current.markets.map((market) => market.semanticKey.toLowerCase()));
         return {
           ...current,
-          blockNumber: directory.blockNumber,
           markets: [
             ...current.markets,
             ...directory.markets.filter(
@@ -163,13 +185,6 @@ export function PredictionMarketDirectoryView() {
   }
 
   const markets = "markets" in state ? state.markets : [];
-  const totalBacking = markets.reduce(
-    (total, market) => total + market.accountedLiabilityAtoms,
-    0n,
-  );
-  const openMarkets = markets.filter(
-    (market) => market.state === "OPEN" && market.blockTimestamp < market.cutoff,
-  ).length;
 
   return (
     <main className={`page-width ${styles.directoryPage}`}>
@@ -178,58 +193,17 @@ export function PredictionMarketDirectoryView() {
         <ExploreModeSwitch active="prediction" />
       </header>
 
-      <section
-        className={styles.directoryHero}
-        aria-labelledby="prediction-intro-title"
-      >
-        <div className={styles.heroCopy}>
-          <span className={styles.kicker}>PREDICTION MARKETS · ROBINHOOD CHAIN</span>
-          <h2 id="prediction-intro-title">Trade the outcome.<br />Keep the rules onchain.</h2>
-          <p>
-            Permissionless BTC markets, fully backed by USDG and priced through
-            a native Uniswap v4 YES/NO pool.
-          </p>
-        </div>
+      <div className={styles.directoryToolbar}>
         <Link className={styles.createMarketLink} href="/launch">
           <Plus aria-hidden="true" size={17} />
           Create market
         </Link>
-      </section>
-
-      <section className={styles.marketStatusStrip} aria-label="Market system status">
-        <div>
-          <Activity aria-hidden="true" size={17} />
-          <span><small>OPEN IN VIEW</small><strong>{state.kind === "loading" ? "—" : openMarkets}</strong></span>
-        </div>
-        <div>
-          <ShieldCheck aria-hidden="true" size={17} />
-          <span><small>VISIBLE BACKING</small><strong>{state.kind === "loading" ? "—" : formatPredictionUsdg(totalBacking)}</strong></span>
-        </div>
-        <div>
-          <span className={styles.v4Glyph}>v4</span>
-          <span><small>POOL FEE</small><strong>2 bps</strong></span>
-        </div>
-        <div className={styles.systemMode}>
-          <span className={state.kind === "live" ? styles.liveDot : styles.previewDot} />
-          <span>
-            <small>SYSTEM</small>
-            <strong>
-              {state.kind === "live"
-                ? `LIVE · BLOCK ${state.blockNumber}`
-                : state.kind === "preview"
-                  ? "TECHNICAL PREVIEW"
-                  : state.kind === "error"
-                    ? "READS BLOCKED"
-                    : "CHECKING"}
-            </strong>
-          </span>
-        </div>
-      </section>
+      </div>
 
       {state.kind === "preview" ? (
         <p className={styles.previewBanner} role="status">
-          <strong>Interface preview.</strong> The reviewed release is not configured,
-          so these sample markets cannot request signatures or transactions.
+          <strong>Preview data.</strong> These sample markets never request a
+          wallet signature.
         </p>
       ) : null}
       {release.error ? <p className={styles.errorBanner}>{release.error}</p> : null}
@@ -237,24 +211,15 @@ export function PredictionMarketDirectoryView() {
         <p className={styles.errorBanner} role="alert">{state.message}</p>
       ) : null}
 
-      <section className={styles.directoryList} aria-labelledby="open-markets-title">
-        <header>
-          <div>
-            <span className={styles.sectionIndex}>01</span>
-            <h2 id="open-markets-title">Markets</h2>
-          </div>
-          <span>
-            {state.kind === "live"
-              ? `Showing ${markets.length} of ${state.marketCount.toString()} · probability · UTC`
-              : "Probability · backing · UTC result time"}
-          </span>
-        </header>
+      <section className={styles.directoryList} aria-label="Prediction markets">
         {state.kind === "loading" ? (
-          <div className={styles.marketLoading} aria-live="polite">Checking both public Robinhood RPCs…</div>
+          <div className={styles.marketLoading} aria-live="polite">
+            Loading predictions…
+          </div>
         ) : markets.length ? (
-          <div className={styles.marketRows}>
+          <div className={styles.marketGrid}>
             {markets.map((market) => (
-              <MarketRow
+              <MarketCard
                 key={market.semanticKey}
                 market={market}
                 preview={state.kind === "preview"}
@@ -263,7 +228,8 @@ export function PredictionMarketDirectoryView() {
           </div>
         ) : state.kind === "live" ? (
           <div className={styles.marketLoading}>
-            No market exists yet. The first creator can launch one for 2 USDG plus gas.
+            <strong>No predictions yet</strong>
+            <span>Create the first market.</span>
           </div>
         ) : null}
         {state.kind === "live" && state.nextCursor > 0n ? (
@@ -273,7 +239,7 @@ export function PredictionMarketDirectoryView() {
             onClick={() => void loadOlderMarkets()}
             type="button"
           >
-            {loadingOlder ? "Checking both RPCs…" : "Load older markets"}
+            {loadingOlder ? "Loading…" : "Show more"}
           </button>
         ) : null}
         {olderError ? <p className={styles.errorBanner} role="alert">{olderError}</p> : null}

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -16,7 +16,9 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
-  padding-bottom: 56px;
+  margin: 0;
+  min-height: 102px;
+  padding: 0;
 }
 
 .exploreHeader h1 {
@@ -28,176 +30,55 @@
   margin: 0;
 }
 
-.directoryHero {
-  align-items: flex-end;
+.directoryToolbar {
   display: flex;
-  gap: 40px;
-  justify-content: space-between;
-  padding-bottom: 52px;
-}
-
-.heroCopy {
-  max-width: 760px;
-}
-
-.kicker,
-.marketMeta,
-.sectionIndex,
-.marketStatusStrip small,
-.probabilityNumbers small,
-.detailEyebrow,
-.terminalLabel,
-.factLabel {
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.kicker,
-.detailEyebrow {
-  color: var(--market-pink);
-  display: block;
-  margin-bottom: 20px;
-}
-
-.heroCopy h2 {
-  color: var(--text);
-  font-size: clamp(48px, 7.4vw, 98px);
-  font-weight: 520;
-  letter-spacing: -0.065em;
-  line-height: 0.9;
-  margin: 0;
-  text-wrap: balance;
-}
-
-.heroCopy p {
-  color: var(--text-soft);
-  font-size: clamp(17px, 2vw, 21px);
-  line-height: 1.5;
-  margin: 28px 0 0;
-  max-width: 620px;
+  justify-content: flex-end;
+  margin: -62px 0 0 auto;
+  position: relative;
+  z-index: 1;
 }
 
 .createMarketLink {
   align-items: center;
-  background: var(--accent-strong);
-  border: 1px solid var(--accent-strong);
-  border-radius: 999px;
-  color: var(--accent-ink);
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
   display: inline-flex;
   flex: 0 0 auto;
-  font-size: 14px;
-  font-weight: 650;
-  gap: 9px;
+  font-size: 13px;
+  font-weight: 600;
+  gap: 8px;
   justify-content: center;
-  min-height: 48px;
-  padding: 0 20px;
+  min-height: 44px;
+  padding: 0 16px;
   text-decoration: none;
-  transition: transform 160ms ease, background 160ms ease;
-}
-
-:global([data-theme="dark"]) .createMarketLink,
-:global([data-theme="dark"]) .terminalAction {
-  color: #0b141d;
-}
-
-:global([data-theme="light"]) .createMarketLink,
-:global([data-theme="light"]) .terminalAction {
-  color: #fffafc;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
 }
 
 .createMarketLink:hover {
-  background: var(--accent-hover);
+  background: var(--webde-surface-raised);
+  border-color: #505050;
   transform: translateY(-1px);
-}
-
-.marketStatusStrip {
-  border-bottom: 1px solid var(--border);
-  border-top: 1px solid var(--border);
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.marketStatusStrip > div {
-  align-items: center;
-  border-right: 1px solid var(--border);
-  display: flex;
-  gap: 13px;
-  min-height: 84px;
-  padding: 16px 22px;
-}
-
-.marketStatusStrip > div:first-child {
-  padding-left: 0;
-}
-
-.marketStatusStrip > div:last-child {
-  border-right: 0;
-}
-
-.marketStatusStrip svg {
-  color: var(--muted);
-  flex: 0 0 auto;
-}
-
-.marketStatusStrip span:not(.liveDot, .previewDot, .v4Glyph) {
-  display: grid;
-  gap: 5px;
-}
-
-.marketStatusStrip small {
-  color: var(--dim);
-}
-
-.marketStatusStrip strong {
-  color: var(--text);
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1.3;
-}
-
-.v4Glyph {
-  color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 15px;
-  font-weight: 600;
-}
-
-.liveDot,
-.previewDot {
-  border-radius: 999px;
-  display: block;
-  flex: 0 0 auto;
-  height: 8px;
-  width: 8px;
-}
-
-.liveDot {
-  background: var(--market-green);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--market-green) 14%, transparent);
-}
-
-.previewDot {
-  background: var(--market-pink);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--market-pink) 14%, transparent);
 }
 
 .previewBanner,
 .errorBanner {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  color: var(--text-soft);
-  font-size: 14px;
-  line-height: 1.5;
-  margin: 24px 0 0;
-  padding: 14px 16px;
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-muted);
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 58px 0 0;
+  padding: 12px 14px;
 }
 
 .previewBanner {
-  background: color-mix(in srgb, var(--market-pink) 8%, transparent);
-  border-color: color-mix(in srgb, var(--market-pink) 30%, var(--border));
+  border-color: color-mix(in srgb, var(--market-pink) 22%, var(--webde-line));
 }
 
 .errorBanner {
@@ -207,188 +88,198 @@
 
 .previewBanner strong,
 .errorBanner strong {
-  color: var(--text);
+  color: var(--webde-ink);
 }
 
 .directoryList {
-  margin-top: 70px;
+  margin-top: 58px;
 }
 
-.directoryList > header {
-  align-items: flex-end;
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 18px;
+.previewBanner + .directoryList,
+.errorBanner + .directoryList {
+  margin-top: 16px;
 }
 
-.directoryList > header > div {
-  align-items: baseline;
-  display: flex;
+.marketGrid {
+  display: grid;
   gap: 16px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.directoryList h2 {
-  color: var(--text);
-  font-size: clamp(27px, 3vw, 38px);
-  font-weight: 560;
-  letter-spacing: -0.035em;
-  margin: 0;
+.marketCard {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  min-width: 0;
+  overflow: hidden;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
 }
 
-.sectionIndex,
-.directoryList > header > span {
-  color: var(--dim);
-}
-
-.directoryList > header > span {
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-}
-
-.marketRows {
-  border-top: 1px solid var(--border-strong);
-}
-
-.marketRow {
-  align-items: center;
-  border-bottom: 1px solid var(--border);
+.marketCardLink {
   color: inherit;
   display: grid;
-  gap: clamp(16px, 2.4vw, 30px);
-  grid-template-columns: 46px minmax(0, 1fr) minmax(230px, 32%) 20px;
-  min-height: 148px;
-  padding: 25px 14px 25px 4px;
+  grid-template-rows: auto 1fr auto;
+  height: 100%;
   text-decoration: none;
-  transition: background 160ms ease, padding 160ms ease;
 }
 
-.marketRow:hover {
-  background: color-mix(in srgb, var(--surface-raised) 52%, transparent);
-  padding-left: 14px;
-}
-
-.assetMark {
+.marketCardArt {
   align-items: center;
-  border: 1px solid var(--border-strong);
-  border-radius: 50%;
-  color: var(--text);
+  aspect-ratio: 2.42 / 1;
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--market-green) 24%, #101614) 0 var(--yes-share),
+      color-mix(in srgb, var(--market-red) 22%, #171114) var(--yes-share) 100%
+    );
+  border-bottom: 1px solid var(--webde-line);
   display: flex;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 20px;
-  height: 42px;
   justify-content: center;
-  width: 42px;
+  overflow: hidden;
+  padding: 16px;
+  position: relative;
 }
 
-.marketIdentity {
-  display: grid;
-  gap: 10px;
-  min-width: 0;
+.marketCardArt::after {
+  background: linear-gradient(180deg, transparent 45%, rgb(0 0 0 / 0.2));
+  content: "";
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
 }
 
-.marketIdentity > strong {
-  color: var(--text);
-  font-size: clamp(17px, 2vw, 22px);
-  font-weight: 560;
-  letter-spacing: -0.02em;
-  line-height: 1.28;
-}
-
-.marketMeta {
-  color: var(--dim);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.marketMeta span:first-child {
-  color: var(--market-green);
-}
-
-.marketFoot {
-  color: var(--muted);
-  display: flex;
-  flex-wrap: wrap;
-  font-size: 12px;
-  gap: 18px;
-}
-
-.marketFoot > span {
-  align-items: center;
-  display: inline-flex;
-  gap: 5px;
-}
-
-.marketProbability {
-  display: grid;
-  gap: 14px;
-}
-
-.probabilityNumbers {
-  display: flex;
-  justify-content: space-between;
-}
-
-.probabilityNumbers > span {
+.marketCardChance {
   align-items: baseline;
+  color: #f8f0e9;
   display: flex;
-  gap: 8px;
+  gap: 9px;
+  position: relative;
+  z-index: 1;
 }
 
-.probabilityNumbers small {
-  color: var(--dim);
+.marketCardChance strong {
+  font-size: clamp(44px, 5vw, 68px);
+  font-variant-numeric: tabular-nums;
+  font-weight: 520;
+  letter-spacing: -0.065em;
+  line-height: 0.9;
 }
 
-.probabilityNumbers strong {
-  color: var(--text);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 19px;
-  font-weight: 500;
+.marketCardChance span {
+  color: rgb(248 240 233 / 0.76);
+  font-size: 14px;
+  font-weight: 580;
 }
 
-.probabilityRail {
-  background: color-mix(in srgb, var(--market-red) 32%, var(--surface-soft));
-  border-radius: 999px;
+.marketCardPrices {
+  bottom: 12px;
+  color: rgb(248 240 233 / 0.82);
+  display: flex;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  justify-content: space-between;
+  left: 14px;
+  position: absolute;
+  right: 14px;
+  z-index: 1;
+}
+
+.marketCardBody {
   display: block;
-  height: 6px;
+  min-height: 118px;
+  padding: 18px 18px 14px;
+}
+
+.marketCardBody > strong {
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  color: var(--webde-ink);
+  display: -webkit-box;
+  font-size: 20px;
+  font-weight: 570;
+  letter-spacing: -0.025em;
+  line-height: 1.25;
   overflow: hidden;
 }
 
-.probabilityRail > span {
-  background: var(--market-green);
-  border-radius: inherit;
+.marketCardMeta {
+  align-items: center;
+  border-top: 1px solid var(--webde-line);
+  color: var(--webde-dim);
+  display: flex;
+  font-size: 12px;
+  gap: 10px;
+  min-height: 48px;
+  padding: 0 14px;
+}
+
+.marketCardMeta > span {
+  align-items: center;
+  display: inline-flex;
+  gap: 7px;
+}
+
+.marketCardMeta i {
+  background: var(--webde-dim);
+  border-radius: 50%;
   display: block;
-  height: 100%;
-  min-width: 2px;
-  transition: width 260ms ease;
+  height: 6px;
+  width: 6px;
 }
 
-.rowArrow {
-  color: var(--dim);
-  transition: color 160ms ease, transform 160ms ease;
+.marketCardMeta i[data-open="true"] {
+  background: var(--market-green);
 }
 
-.marketRow:hover .rowArrow {
-  color: var(--text);
-  transform: translateX(3px);
+.marketCardMeta svg {
+  margin-left: auto;
+  transition: transform 180ms ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .marketCard:hover {
+    background: var(--webde-surface-raised);
+    border-color: #505050;
+    box-shadow: 0 18px 48px rgb(0 0 0 / 0.3);
+    transform: translate3d(0, -2px, 0);
+  }
+
+  .marketCard:hover .marketCardMeta svg {
+    transform: translateX(3px);
+  }
 }
 
 .marketLoading {
   align-items: center;
-  border-bottom: 1px solid var(--border);
-  border-top: 1px solid var(--border-strong);
-  color: var(--muted);
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  color: var(--webde-muted);
   display: flex;
+  flex-direction: column;
   font-size: 15px;
-  min-height: 150px;
-  padding: 28px 4px;
+  gap: 5px;
+  justify-content: center;
+  min-height: 250px;
+  padding: 28px;
+  text-align: center;
+}
+
+.marketLoading strong {
+  color: var(--webde-ink);
+  font-size: 21px;
 }
 
 .loadMoreMarkets {
-  background: transparent;
-  border: 1px solid var(--border-strong);
-  border-radius: 10px;
-  color: var(--text);
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
   cursor: pointer;
   display: block;
   font: inherit;
@@ -399,17 +290,17 @@
 }
 
 .loadMoreMarkets:disabled {
-  color: var(--dim);
+  color: var(--webde-dim);
   cursor: wait;
 }
 
 .detailBack {
   align-items: center;
-  color: var(--muted);
+  color: var(--webde-muted);
   display: inline-flex;
-  font-size: 13px;
+  font-size: 14px;
   gap: 7px;
-  margin-bottom: 36px;
+  margin-bottom: 32px;
   text-decoration: none;
 }
 
@@ -420,8 +311,8 @@
 .detailLayout {
   align-items: start;
   display: grid;
-  gap: clamp(38px, 6vw, 90px);
-  grid-template-columns: minmax(0, 1.35fr) minmax(340px, 0.65fr);
+  gap: clamp(34px, 5vw, 64px);
+  grid-template-columns: minmax(0, 1.25fr) minmax(360px, 0.75fr);
 }
 
 .marketCanvas {
@@ -429,11 +320,11 @@
 }
 
 .marketCanvas h1 {
-  color: var(--text);
-  font-size: clamp(40px, 5.7vw, 74px);
+  color: var(--webde-ink);
+  font-size: clamp(38px, 4.8vw, 64px);
   font-weight: 530;
-  letter-spacing: -0.055em;
-  line-height: 0.98;
+  letter-spacing: -0.05em;
+  line-height: 1;
   margin: 0;
   max-width: 920px;
   text-wrap: balance;
@@ -441,13 +332,12 @@
 
 .detailMeta {
   align-items: center;
-  color: var(--muted);
+  color: var(--webde-muted);
   display: flex;
   flex-wrap: wrap;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  gap: 10px 18px;
-  margin-top: 26px;
+  font-size: 14px;
+  gap: 10px 16px;
+  margin-top: 24px;
 }
 
 .detailMeta > span {
@@ -460,8 +350,9 @@
 .closedBadge {
   border: 1px solid currentColor;
   border-radius: 999px;
-  padding: 5px 9px;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 650;
+  padding: 5px 10px;
 }
 
 .openBadge {
@@ -474,35 +365,40 @@
 
 .heroProbability {
   display: grid;
-  gap: 18px 26px;
+  gap: 12px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-top: clamp(46px, 7vw, 82px);
+  margin-top: clamp(38px, 5vw, 58px);
 }
 
 .heroProbability > div {
-  align-items: baseline;
-  display: flex;
-  gap: 13px;
+  background: color-mix(in srgb, var(--market-green) 10%, var(--webde-surface));
+  border: 1px solid color-mix(in srgb, var(--market-green) 28%, var(--webde-line));
+  border-radius: var(--webde-radius-card);
+  display: grid;
+  gap: 7px;
+  min-height: 132px;
+  padding: 20px;
 }
 
 .heroProbability > div:nth-child(2) {
-  justify-content: flex-end;
+  background: color-mix(in srgb, var(--market-red) 9%, var(--webde-surface));
+  border-color: color-mix(in srgb, var(--market-red) 25%, var(--webde-line));
+  text-align: right;
 }
 
 .heroProbability span:not(.heroRail, .heroRail span) {
-  color: var(--dim);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  color: var(--webde-muted);
+  font-size: 14px;
+  font-weight: 650;
 }
 
 .heroProbability strong {
-  color: var(--text);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: clamp(38px, 5vw, 66px);
-  font-weight: 450;
+  color: var(--webde-ink);
+  font-size: clamp(42px, 5vw, 62px);
+  font-variant-numeric: tabular-nums;
+  font-weight: 520;
   letter-spacing: -0.06em;
+  line-height: 0.9;
 }
 
 .heroRail {
@@ -510,7 +406,7 @@
   border-radius: 999px;
   display: block;
   grid-column: 1 / -1;
-  height: 12px;
+  height: 8px;
   overflow: hidden;
 }
 
@@ -521,98 +417,99 @@
   height: 100%;
 }
 
-.marketFacts {
-  border-bottom: 1px solid var(--border);
-  border-top: 1px solid var(--border);
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  margin-top: 54px;
+.marketInfo {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  margin-top: 24px;
+  overflow: hidden;
 }
 
-.marketFacts > div {
-  border-right: 1px solid var(--border);
-  display: grid;
-  gap: 7px;
-  min-height: 118px;
-  padding: 22px 17px;
-}
-
-.marketFacts > div:first-child {
-  padding-left: 0;
-}
-
-.marketFacts > div:last-child {
-  border-right: 0;
-}
-
-.factLabel {
-  color: var(--dim);
-}
-
-.marketFacts strong {
-  color: var(--text);
-  font-size: 16px;
-  font-weight: 600;
-}
-
-.marketFacts small {
-  color: var(--muted);
-  font-size: 11px;
-  line-height: 1.4;
-}
-
-.rulesPanel {
-  background: color-mix(in srgb, var(--surface-raised) 68%, transparent);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  margin-top: 38px;
-  padding: 20px 22px;
-}
-
-.rulesPanel header {
+.marketInfo summary {
   align-items: center;
-  color: var(--text);
+  color: var(--webde-ink);
+  cursor: pointer;
   display: flex;
-  gap: 10px;
+  font-size: 15px;
+  font-weight: 620;
+  justify-content: space-between;
+  list-style: none;
+  min-height: 58px;
+  padding: 0 18px;
 }
 
-.rulesPanel header svg {
-  color: var(--market-green);
+.marketInfo summary::-webkit-details-marker {
+  display: none;
 }
 
-.rulesPanel p {
-  color: var(--text-soft);
-  font-size: 14px;
-  line-height: 1.6;
-  margin: 12px 0 0;
+.marketInfo summary i,
+.marketInfo summary i::after {
+  background: currentColor;
+  display: block;
+  height: 1px;
+  transition: transform 160ms ease;
+  width: 13px;
+}
+
+.marketInfo summary i {
+  position: relative;
+}
+
+.marketInfo summary i::after {
+  content: "";
+  position: absolute;
+  transform: rotate(90deg);
+}
+
+.marketInfo[open] summary i::after {
+  transform: rotate(0deg);
+}
+
+.marketInfoBody {
+  border-top: 1px solid var(--webde-line);
+  padding: 18px;
+}
+
+.marketInfoBody p {
+  color: var(--webde-muted);
+  font-size: 15px;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.marketInfoBody p + p {
+  margin-top: 10px;
+}
+
+.marketInfoBody strong {
+  color: var(--webde-ink);
 }
 
 .contractLinks {
   display: flex;
   flex-wrap: wrap;
   gap: 18px;
-  margin-top: 22px;
+  margin-top: 18px;
 }
 
 .contractLinks a {
   align-items: center;
-  color: var(--muted);
+  color: var(--webde-muted);
   display: inline-flex;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
+  font-size: 12px;
   gap: 5px;
   text-decoration: none;
 }
 
 .contractLinks a:hover {
-  color: var(--text);
+  color: var(--webde-ink);
 }
 
 .tradeTerminal {
-  background: color-mix(in srgb, var(--surface-raised) 92%, transparent);
-  border: 1px solid var(--border-strong);
-  border-radius: 18px;
-  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.13);
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  box-shadow: 0 24px 70px rgb(0 0 0 / 0.18);
   padding: 22px;
   position: sticky;
   top: 92px;
@@ -624,17 +521,26 @@
   justify-content: space-between;
 }
 
-.terminalTopline > span:last-child {
-  align-items: center;
-  color: var(--dim);
-  display: inline-flex;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 9px;
-  gap: 7px;
+.terminalTopline h2 {
+  color: var(--webde-ink);
+  font-size: 28px;
+  font-weight: 590;
+  letter-spacing: -0.035em;
+  margin: 0;
+}
+
+.terminalTopline > span {
+  background: var(--webde-control);
+  border-radius: 999px;
+  color: var(--webde-muted);
+  font-size: 12px;
+  padding: 5px 9px;
 }
 
 .terminalLabel {
-  color: var(--dim);
+  color: var(--webde-muted);
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .modeTabs {
@@ -658,10 +564,9 @@
 .modeTabs button {
   background: transparent;
   border-radius: 7px;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
-  min-height: 38px;
+  min-height: 42px;
 }
 
 .modeTabs .activeMode {
@@ -684,20 +589,19 @@
   border-radius: 11px;
   display: flex;
   justify-content: space-between;
-  min-height: 58px;
+  min-height: 62px;
   padding: 0 14px;
 }
 
 .outcomeToggle button span {
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
 }
 
 .outcomeToggle button strong {
   color: var(--text);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 17px;
+  font-size: 18px;
+  font-variant-numeric: tabular-nums;
 }
 
 .outcomeToggle .yesSelected {
@@ -719,8 +623,8 @@
 }
 
 .amountField > span:first-child {
-  color: var(--dim);
-  font-size: 12px;
+  color: var(--webde-muted);
+  font-size: 13px;
 }
 
 .amountField > span:nth-child(2) {
@@ -749,9 +653,9 @@
 }
 
 .amountField small {
-  color: var(--dim);
+  color: var(--webde-dim);
   font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
+  font-size: 11px;
   text-align: right;
 }
 
@@ -766,20 +670,43 @@
 
 .quoteReceipt > div {
   align-items: baseline;
-  color: var(--muted);
+  color: var(--webde-muted);
   display: flex;
-  font-size: 11px;
+  font-size: 13px;
   gap: 12px;
   justify-content: space-between;
 }
 
 .quoteReceipt strong {
-  color: var(--text);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 10px;
-  font-weight: 500;
+  color: var(--webde-ink);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 580;
   max-width: 58%;
   text-align: right;
+}
+
+.quoteDetails {
+  border-top: 1px solid var(--webde-line);
+  margin-top: 2px;
+  padding-top: 10px;
+}
+
+.quoteDetails summary {
+  color: var(--webde-muted);
+  cursor: pointer;
+  font-size: 12px;
+  list-style-position: inside;
+}
+
+.quoteDetails > div {
+  align-items: baseline;
+  color: var(--webde-muted);
+  display: flex;
+  font-size: 12px;
+  gap: 12px;
+  justify-content: space-between;
+  margin-top: 9px;
 }
 
 .terminalAction,
@@ -801,6 +728,14 @@
   margin-top: 20px;
 }
 
+:global([data-theme="dark"]) .terminalAction {
+  color: #0b141d;
+}
+
+:global([data-theme="light"]) .terminalAction {
+  color: #fffafc;
+}
+
 .secondaryTerminalAction {
   background: transparent;
   border: 1px solid var(--border-strong);
@@ -816,21 +751,13 @@
 
 .terminalNote,
 .terminalStatus {
-  color: var(--dim);
-  font-size: 10px;
+  color: var(--webde-dim);
+  font-size: 12px;
   line-height: 1.5;
 }
 
 .terminalNote {
-  align-items: flex-start;
-  display: flex;
-  gap: 7px;
   margin: 13px 0 0;
-}
-
-.terminalNote svg {
-  flex: 0 0 auto;
-  margin-top: 1px;
 }
 
 .terminalStatus {
@@ -845,11 +772,11 @@
   align-items: center;
   background: transparent;
   border: 0;
-  color: var(--dim);
+  color: var(--webde-dim);
   cursor: pointer;
   display: flex;
   font: inherit;
-  font-size: 10px;
+  font-size: 12px;
   gap: 6px;
   justify-content: center;
   margin: 14px auto 0;
@@ -1049,39 +976,8 @@
 }
 
 @media (max-width: 900px) {
-  .directoryHero {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .marketStatusStrip {
+  .marketGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .marketStatusStrip > div:nth-child(2) {
-    border-right: 0;
-  }
-
-  .marketStatusStrip > div:nth-child(-n + 2) {
-    border-bottom: 1px solid var(--border);
-  }
-
-  .marketStatusStrip > div:first-child,
-  .marketStatusStrip > div:nth-child(3) {
-    padding-left: 0;
-  }
-
-  .marketRow {
-    grid-template-columns: 42px minmax(0, 1fr) 18px;
-  }
-
-  .marketProbability {
-    grid-column: 2 / 3;
-  }
-
-  .rowArrow {
-    grid-column: 3;
-    grid-row: 1 / span 2;
   }
 
   .detailLayout {
@@ -1092,102 +988,97 @@
     position: static;
   }
 
-  .marketFacts {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .marketFacts > div:nth-child(2) {
-    border-right: 0;
-  }
-
-  .marketFacts > div:nth-child(-n + 2) {
-    border-bottom: 1px solid var(--border);
-  }
-
-  .marketFacts > div:nth-child(3) {
-    padding-left: 0;
-  }
 }
 
-@media (max-width: 620px) {
-  .directoryPage,
-  .detailPage {
-    padding-bottom: 64px;
-    padding-top: 34px;
+@media (max-width: 700px) {
+  .directoryPage {
+    min-height: calc(100svh - 72px);
+    padding-bottom: 48px;
+    padding-top: 16px;
   }
 
   .exploreHeader {
     gap: 18px;
-    padding-bottom: 48px;
+    min-height: 0;
   }
 
   .exploreHeader h1 {
     font-size: clamp(38px, 11vw, 48px);
   }
 
-  .heroCopy h2 {
-    font-size: clamp(43px, 13vw, 64px);
-    line-height: 0.94;
-  }
-
-  .directoryHero {
-    gap: 30px;
-    padding-bottom: 38px;
-  }
-
-  .createMarketLink {
-    width: 100%;
-  }
-
-  .marketStatusStrip > div {
-    min-height: 74px;
-    padding: 12px 10px;
-  }
-
-  .marketStatusStrip > div:nth-child(odd) {
-    padding-left: 0;
-  }
-
-  .marketStatusStrip strong {
-    font-size: 12px;
+  .directoryToolbar {
+    justify-content: flex-start;
+    margin-top: 16px;
   }
 
   .directoryList {
-    margin-top: 50px;
+    margin-top: 16px;
   }
 
-  .directoryList > header > span {
-    display: none;
+  .previewBanner,
+  .errorBanner {
+    margin-top: 16px;
   }
 
-  .marketRow {
-    gap: 12px;
-    grid-template-columns: 36px minmax(0, 1fr);
-    min-height: 0;
-    padding: 22px 0;
-  }
-
-  .marketRow:hover {
-    padding-left: 0;
-  }
-
-  .assetMark {
-    font-size: 16px;
-    height: 34px;
-    width: 34px;
-  }
-
-  .marketProbability {
-    grid-column: 1 / -1;
-    margin-left: 48px;
-  }
-
-  .rowArrow {
-    display: none;
-  }
-
-  .marketFoot {
+  .marketGrid {
     gap: 10px;
+  }
+
+  .marketCardArt {
+    aspect-ratio: 1.7 / 1;
+    padding: 12px;
+  }
+
+  .marketCardChance {
+    align-items: center;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .marketCardChance strong {
+    font-size: clamp(35px, 11vw, 48px);
+  }
+
+  .marketCardChance span {
+    font-size: 11px;
+  }
+
+  .marketCardPrices {
+    bottom: 9px;
+    font-size: 10px;
+    left: 10px;
+    right: 10px;
+  }
+
+  .marketCardBody {
+    min-height: 94px;
+    padding: 12px 12px 10px;
+  }
+
+  .marketCardBody > strong {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+
+  .marketCardMeta {
+    align-items: flex-start;
+    flex-direction: column;
+    font-size: 10px;
+    gap: 3px;
+    justify-content: center;
+    min-height: 58px;
+    padding: 8px 10px;
+  }
+
+  .marketCardMeta svg {
+    display: none;
+  }
+}
+
+@media (max-width: 620px) {
+  .detailPage {
+    padding-bottom: 64px;
+    padding-top: 34px;
   }
 
   .marketCanvas h1 {
@@ -1213,15 +1104,6 @@
     align-items: flex-end;
   }
 
-  .marketFacts {
-    margin-top: 38px;
-  }
-
-  .marketFacts > div {
-    min-height: 105px;
-    padding: 17px 12px;
-  }
-
   .tradeTerminal {
     border-radius: 14px;
     padding: 18px;
@@ -1237,5 +1119,11 @@
 
   .positionRows > a > svg {
     display: none;
+  }
+}
+
+@media (max-width: 360px) {
+  .marketGrid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/components/prediction-market-launch.module.css
+++ b/components/prediction-market-launch.module.css
@@ -41,77 +41,65 @@
   text-align: center;
 }
 
-.heading > span,
-.eyebrow,
 .previewTopline {
   color: var(--muted);
-  font-size: 11px;
-  font-weight: 670;
-  letter-spacing: 0.045em;
-  text-transform: uppercase;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .heading h1 {
-  font-size: clamp(28px, 3.4vw, 42px);
+  font-size: clamp(30px, 3.4vw, 44px);
   font-weight: 570;
   letter-spacing: -0.04em;
   line-height: 1;
-  margin: 5px 0 0;
+  margin: 0;
 }
 
 .previewNotice {
   align-items: center;
-  background: color-mix(in srgb, var(--warning-background) 76%, transparent);
-  border: 1px solid var(--warning-border);
-  border-radius: 14px;
-  color: var(--warning-text);
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-muted);
   display: flex;
-  font-size: 12px;
+  font-size: 13px;
   gap: 9px;
   line-height: 1.45;
   margin: 12px auto 16px;
-  max-width: 930px;
+  max-width: 1060px;
   min-height: 44px;
-  padding: 10px 13px;
+  padding: 10px 14px;
 }
 
 .previewNotice strong {
+  color: var(--webde-ink);
   flex: 0 0 auto;
-}
-
-.releaseReady {
-  background: color-mix(in srgb, var(--success) 10%, transparent);
-  border-color: color-mix(in srgb, var(--success) 34%, transparent);
-  color: var(--text-soft);
 }
 
 .layout {
   align-items: start;
   display: grid;
   gap: 16px;
-  grid-template-columns: minmax(0, 1.03fr) minmax(340px, 0.97fr);
+  grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
   margin-inline: auto;
   max-width: 1060px;
 }
 
 .form,
 .preview {
-  background: var(--liquid-glass-surface-background);
-  border: 1px solid var(--liquid-glass-border);
-  border-radius: 24px;
-  box-shadow: 0 24px 68px rgb(1 1 3 / 0.22);
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  box-shadow: none;
   min-width: 0;
 }
 
 .form {
-  padding: 24px;
+  padding: 28px;
 }
 
 .formIntro {
-  align-items: start;
-  display: flex;
-  gap: 20px;
-  justify-content: space-between;
+  display: block;
 }
 
 .formIntro h2,
@@ -123,71 +111,23 @@
 }
 
 .formIntro h2 {
-  font-size: 22px;
+  font-size: 26px;
   line-height: 1.16;
+  margin: 0;
 }
 
-.chainBadge,
-.fixedLabel {
-  background: var(--accent-soft);
-  border: 1px solid var(--panel-border-soft);
-  border-radius: 999px;
-  color: var(--text-soft);
-  flex: 0 0 auto;
-  font-size: 11px;
-  font-weight: 630;
-  padding: 7px 9px;
-}
-
-.fixedAsset {
-  align-items: center;
-  background: var(--liquid-glass-inner-background);
-  border: 1px solid var(--liquid-glass-border);
-  border-radius: 17px;
-  display: grid;
-  gap: 11px;
-  grid-template-columns: 42px minmax(0, 1fr) auto;
-  margin-top: 21px;
-  min-height: 66px;
-  padding: 10px 12px;
-}
-
-.bitcoinMark {
-  align-items: center;
-  background: #f7931a;
-  border-radius: 50%;
-  color: #17100a;
-  display: inline-flex;
-  font-size: 23px;
-  font-weight: 760;
-  height: 42px;
-  justify-content: center;
-  width: 42px;
-}
-
-.fixedAsset > span:nth-child(2) {
-  display: grid;
-  gap: 2px;
-}
-
-.fixedAsset strong {
-  font-size: 14px;
-}
-
-.fixedAsset small,
 .field small,
-.costRow small,
-.actionNote {
-  color: var(--muted);
-  font-size: 11px;
-  line-height: 1.4;
+.costRow small {
+  color: var(--webde-muted);
+  font-size: 12px;
+  line-height: 1.45;
 }
 
 .fields {
   display: grid;
   gap: 14px;
   grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.22fr);
-  margin-top: 18px;
+  margin-top: 26px;
 }
 
 .field {
@@ -197,19 +137,19 @@
 }
 
 .field > span:first-child {
-  color: var(--text-soft);
-  font-size: 12px;
+  color: var(--webde-ink);
+  font-size: 14px;
   font-weight: 650;
 }
 
 .field input {
-  background: var(--liquid-glass-control-background);
-  border: 1px solid var(--liquid-glass-border);
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
   border-radius: 13px;
   color: var(--text);
   font: inherit;
-  font-size: 14px;
-  height: 50px;
+  font-size: 16px;
+  height: 56px;
   min-width: 0;
   padding: 0 13px;
   width: 100%;
@@ -228,7 +168,7 @@
 
 .priceInput > span {
   color: var(--muted);
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 680;
   left: 14px;
   pointer-events: none;
@@ -245,22 +185,29 @@
 }
 
 .costRow {
-  border-top: 1px solid var(--panel-border-soft);
+  align-items: baseline;
+  border-top: 1px solid var(--webde-line);
   display: grid;
-  gap: 10px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: 20px;
-  padding-top: 17px;
+  gap: 6px 18px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin-top: 24px;
+  padding-top: 18px;
 }
 
 .costRow > span {
-  display: grid;
-  gap: 3px;
+  color: var(--webde-muted);
+  font-size: 13px;
 }
 
 .costRow strong {
-  font-size: 13px;
-  font-weight: 680;
+  color: var(--webde-ink);
+  font-size: 14px;
+  font-weight: 650;
+  text-align: right;
+}
+
+.costRow small {
+  grid-column: 1 / -1;
 }
 
 .createButton {
@@ -274,6 +221,14 @@
   margin-top: 20px;
   min-height: 50px;
   width: 100%;
+}
+
+:global([data-theme="dark"]) .createButton:not(:disabled) {
+  color: #0b141d;
+}
+
+:global([data-theme="light"]) .createButton:not(:disabled) {
+  color: #fffafc;
 }
 
 .createButton:not(:disabled):hover {
@@ -293,12 +248,6 @@
   color: var(--text-soft);
   cursor: not-allowed;
   opacity: 1;
-}
-
-.actionNote {
-  margin: 9px auto 0;
-  max-width: 52ch;
-  text-align: center;
 }
 
 .launchStatus {
@@ -372,7 +321,7 @@
 
 .preview {
   overflow: hidden;
-  padding: 24px;
+  padding: 28px;
 }
 
 .previewTopline {
@@ -386,17 +335,25 @@
 }
 
 .preview h2 {
-  font-size: clamp(22px, 2.4vw, 29px);
-  line-height: 1.16;
-  min-height: 100px;
+  font-size: clamp(27px, 3vw, 36px);
+  line-height: 1.08;
+  min-height: 0;
+  margin-top: 20px;
   text-wrap: balance;
+}
+
+.previewTime {
+  color: var(--webde-muted);
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 12px 0 0;
 }
 
 .outcomes {
   display: grid;
   gap: 8px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-top: 18px;
+  margin-top: 26px;
 }
 
 .outcomes > div {
@@ -404,18 +361,18 @@
   border-radius: 16px;
   display: grid;
   gap: 3px;
-  min-height: 92px;
-  padding: 14px;
+  min-height: 116px;
+  padding: 16px;
 }
 
 .outcomes span {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 740;
   letter-spacing: 0.055em;
 }
 
 .outcomes strong {
-  font-size: 31px;
+  font-size: 40px;
   font-weight: 590;
   letter-spacing: -0.04em;
 }
@@ -430,49 +387,20 @@
   color: var(--brand-pink);
 }
 
-.facts {
-  display: grid;
-  gap: 0;
-  margin: 18px 0 0;
-}
-
-.facts > div {
-  border-top: 1px solid var(--panel-border-soft);
-  display: grid;
-  gap: 4px;
-  padding: 13px 0;
-}
-
-.facts dt {
-  align-items: center;
-  color: var(--text-soft);
-  display: flex;
-  font-size: 12px;
-  font-weight: 670;
-  gap: 7px;
-}
-
-.facts dd {
-  color: var(--muted);
-  font-size: 12px;
-  line-height: 1.48;
-  margin: 0;
-  padding-left: 23px;
-}
-
 .details {
-  border-top: 1px solid var(--panel-border-soft);
-  padding-top: 4px;
+  border-top: 1px solid var(--webde-line);
+  margin-top: 24px;
+  padding-top: 5px;
 }
 
 .details summary {
   align-items: center;
   color: var(--text-soft);
   display: flex;
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 650;
   list-style: none;
-  min-height: 44px;
+  min-height: 48px;
 }
 
 .details summary::-webkit-details-marker {
@@ -491,10 +419,10 @@
 }
 
 .details p {
-  color: var(--muted);
-  font-size: 12px;
+  color: var(--webde-muted);
+  font-size: 14px;
   line-height: 1.55;
-  margin: 2px 0 10px;
+  margin: 4px 0 12px;
 }
 
 @media (max-width: 860px) {
@@ -521,10 +449,6 @@
     padding-right: 44px;
   }
 
-  .heading > span {
-    display: none;
-  }
-
   .heading h1 {
     font-size: 25px;
     margin-top: 0;
@@ -542,22 +466,8 @@
     padding: 19px;
   }
 
-  .formIntro {
-    display: grid;
-    gap: 12px;
-  }
-
-  .chainBadge {
-    justify-self: start;
-  }
-
-  .fields,
-  .costRow {
+  .fields {
     grid-template-columns: minmax(0, 1fr);
-  }
-
-  .costRow > span {
-    grid-template-columns: 110px minmax(0, 1fr);
   }
 }
 
@@ -575,11 +485,4 @@
     font-size: 22px;
   }
 
-  .fixedLabel {
-    display: none;
-  }
-
-  .fixedAsset {
-    grid-template-columns: 42px minmax(0, 1fr);
-  }
 }

--- a/components/prediction-market-launch.tsx
+++ b/components/prediction-market-launch.tsx
@@ -5,10 +5,7 @@ import { useEffect, useMemo, useState, type FormEvent } from "react";
 import {
   ArrowLeft,
   CheckCircle2,
-  Clock3,
-  Database,
   ExternalLink,
-  ShieldCheck,
 } from "lucide-react";
 import { formatEther } from "viem";
 
@@ -26,9 +23,7 @@ import {
 } from "@/lib/prediction-market-chain";
 import {
   defaultPredictionObservationUtc,
-  formatUtcObservation,
   PREDICTION_PERMIT_DURATION_SECONDS,
-  ROBINHOOD_CHAIN_ID,
   validatePredictionMarketDraft,
   type PredictionMarketDraft,
 } from "@/lib/prediction-market";
@@ -78,17 +73,11 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
     signPredictionPermit,
     wallet,
   } = useWallet();
-  const release = useMemo(() => {
+  const releaseConfig = useMemo(() => {
     try {
-      return {
-        config: getPredictionMarketReleaseConfig(),
-        error: "",
-      };
-    } catch (error) {
-      return {
-        config: null,
-        error: getErrorMessage(error),
-      };
+      return getPredictionMarketReleaseConfig();
+    } catch {
+      return null;
     }
   }, []);
 
@@ -127,21 +116,21 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
     phase === "submitting" ||
     phase === "confirming";
   const createButtonLabel = (() => {
-    if (!release.config) return release.error ? "Release configuration blocked" : "Deployment pending";
+    if (!releaseConfig) return "Preview only";
     if (connecting) return "Wallet loading";
     if (!wallet) return "Connect wallet";
-    if (phase === "checking") return "Checking both RPCs";
-    if (phase === "signing") return "Sign 2 USDG permit";
-    if (phase === "estimating") return "Simulating creation";
+    if (phase === "checking") return "Checking market";
+    if (phase === "signing") return "Approve 2 USDG";
+    if (phase === "estimating") return "Preparing market";
     if (phase === "submitting") return "Confirm in wallet";
-    if (phase === "confirming") return "Confirming onchain";
+    if (phase === "confirming") return "Creating market";
     if (phase === "confirmed") return "Market created";
     return "Create market · 2 USDG";
   })();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!release.config || busy) return;
+    if (!releaseConfig || busy) return;
     if (!wallet) {
       openWallet();
       return;
@@ -158,10 +147,10 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
     try {
       const clients = createPredictionMarketPublicClients();
       setPhase("checking");
-      setStatus("Checking the reviewed release against two public Robinhood RPCs…");
+      setStatus("Checking your market…");
       const preflight = await preflightPredictionMarketLaunch({
         clients,
-        config: release.config,
+        config: releaseConfig,
         market: latestValidation.market,
         owner: wallet.account,
       });
@@ -170,18 +159,18 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
         BigInt(PREDICTION_PERMIT_DURATION_SECONDS);
 
       setPhase("signing");
-      setStatus("Sign the exact 2 USDG permit. This signature alone spends no gas.");
+      setStatus("Approve 2 USDG in your wallet.");
       const permit = await signPredictionPermit({
         deadline,
-        factoryAddress: release.config.factoryAddress,
+        factoryAddress: releaseConfig.factoryAddress,
         nonce: preflight.nonce,
       });
 
       setPhase("estimating");
-      setStatus("Rechecking state and simulating the exact market transaction…");
+      setStatus("Preparing your market…");
       const recheck = await preflightPredictionMarketLaunch({
         clients,
-        config: release.config,
+        config: releaseConfig,
         market: latestValidation.market,
         owner: wallet.account,
       });
@@ -189,11 +178,11 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
         recheck.nonce !== preflight.nonce ||
         recheck.semanticKey.toLowerCase() !== preflight.semanticKey.toLowerCase()
       ) {
-        throw new Error("Market state changed while signing. Start again with a fresh permit.");
+        throw new Error("The market changed while you were approving. Please try again.");
       }
       const prepared = await preparePredictionMarketLaunch({
         client: clients[0],
-        config: release.config,
+        config: releaseConfig,
         expectedNonce: preflight.nonce,
         expectedSemanticKey: preflight.semanticKey,
         market: latestValidation.market,
@@ -204,30 +193,30 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
 
       setPhase("submitting");
       setStatus(
-        `Your wallet will show the market transaction. Estimated maximum gas: ${formatEthMaximum(prepared.maximumGasCostWei)}.`,
+        `Confirm in your wallet. Maximum estimated network fee: ${formatEthMaximum(prepared.maximumGasCostWei)}.`,
       );
       const transactionHash = await sendTransaction(prepared.transaction);
 
       setPhase("confirming");
-      setStatus("Transaction submitted. Verifying the canonical market and its YES/NO contracts…");
+      setStatus("Transaction sent. Creating your market…");
       const confirmed = await waitForPredictionMarketCreation({
         clients,
-        config: release.config,
+        config: releaseConfig,
         creator: wallet.account,
         expectedSemanticKey: preflight.semanticKey,
         transactionHash,
       });
       setConfirmedMarket(confirmed);
       setPhase("confirmed");
-      setStatus("Market created and matched against the factory registry.");
+      setStatus("Market created.");
       const sourceMatches = await requestPredictionMarketSourceMatches(confirmed);
       const verifiedSourceCount = sourceMatches.filter(
         (result) => result.verified,
       ).length;
       setStatus(
         verifiedSourceCount === sourceMatches.length
-          ? "Market created. All four market contracts are publicly source-verified."
-          : `Market created. Public source verification is pending or temporarily unavailable (${verifiedSourceCount}/4 verified).`,
+          ? "Market created. Contracts verified."
+          : "Market created. Contract verification is still processing.",
       );
     } catch (error) {
       setPhase("error");
@@ -243,43 +232,26 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
           Back
         </button>
         <div className={styles.heading}>
-          <span>Prediction · BTC V1</span>
-          <h1>Create a BTC market</h1>
+          <h1>Create a prediction</h1>
         </div>
       </header>
 
-      <p
-        className={`${styles.previewNotice} ${release.config ? styles.releaseReady : ""}`}
-        role="status"
-      >
-        <strong>{release.config ? "Zero-server launch" : "Technical preview"}</strong>
-        {release.config
-          ? "Every launch is checked against two free public RPCs. No hosted backend or monitoring subscription is required."
-          : release.error || "The reviewed contracts are not deployed. This page cannot request a signature or transaction."}
-      </p>
+      {!releaseConfig ? (
+        <p className={styles.previewNotice} role="status">
+          <strong>Preview only</strong>
+          <span>Market creation is not available in this environment.</span>
+        </p>
+      ) : null}
 
       <div className={styles.layout}>
         <form className={styles.form} onSubmit={handleSubmit}>
           <div className={styles.formIntro}>
-            <div>
-              <span className={styles.eyebrow}>One market, two outcomes</span>
-              <h2>Set the price and UTC result time</h2>
-            </div>
-            <span className={styles.chainBadge}>Robinhood Chain · {ROBINHOOD_CHAIN_ID}</span>
-          </div>
-
-          <div className={styles.fixedAsset} aria-label="Market asset Bitcoin">
-            <span className={styles.bitcoinMark} aria-hidden="true">₿</span>
-            <span>
-              <strong>Bitcoin</strong>
-              <small>BTC</small>
-            </span>
-            <span className={styles.fixedLabel}>Fixed for V1</span>
+            <h2>Set the BTC price and result time</h2>
           </div>
 
           <div className={styles.fields}>
             <label className={styles.field}>
-              <span>Target price</span>
+              <span>BTC price</span>
               <span className={styles.priceInput}>
                 <span aria-hidden="true">$</span>
                 <input
@@ -310,7 +282,7 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
             </label>
 
             <label className={styles.field}>
-              <span>Result time · UTC</span>
+              <span>Result time (UTC)</span>
               <input
                 aria-describedby={errors.observationUtc ? "prediction-time-error" : "prediction-time-help"}
                 aria-invalid={Boolean(errors.observationUtc)}
@@ -344,31 +316,22 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
                   {errors.observationUtc}
                 </small>
               ) : (
-                <small id="prediction-time-help">Always interpreted as UTC, not your device timezone.</small>
+                <small id="prediction-time-help">Shown and resolved in UTC.</small>
               )}
             </label>
           </div>
 
           <div className={styles.costRow}>
-            <span>
-              <strong>2 USDG</strong>
-              <small>Non-refundable market seed</small>
-            </span>
-            <span>
-              <strong>1 signature</strong>
-              <small>USDG permit</small>
-            </span>
-            <span>
-              <strong>1 transaction</strong>
-              <small>Plus Robinhood gas</small>
-            </span>
+            <span>Creation cost</span>
+            <strong>2 USDG + network fee</strong>
+            <small>The 2 USDG starts the market and is not refunded.</small>
           </div>
 
           <button
             className={styles.createButton}
             type="submit"
             disabled={Boolean(
-              !release.config ||
+              !releaseConfig ||
               busy ||
               connecting ||
               phase === "confirmed" ||
@@ -385,14 +348,10 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
               {phase === "confirmed" ? <CheckCircle2 aria-hidden="true" size={15} /> : null}
               <span>{status}</span>
             </p>
-          ) : (
-            <p className={styles.actionNote}>
-              After creation, the creator can make an optional YES or NO trade like any other trader.
-            </p>
-          )}
+          ) : null}
           {maximumGasCostWei !== null && phase !== "submitting" ? (
             <p className={styles.gasNote}>
-              Last simulated gas ceiling: {formatEthMaximum(maximumGasCostWei)}
+              Estimated maximum network fee: {formatEthMaximum(maximumGasCostWei)}
             </p>
           ) : null}
           {confirmedMarket ? (
@@ -418,12 +377,19 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
 
         <section className={styles.preview} aria-labelledby="prediction-preview-title" aria-live="polite">
           <div className={styles.previewTopline}>
-            <span>Market preview</span>
+            <span>Preview</span>
             {market ? <span>in {market.countdownLabel}</span> : null}
           </div>
           <h2 id="prediction-preview-title">
-            {market?.marketTitle ?? "Enter a valid price and UTC result time."}
+            {market
+              ? `Will BTC be at or above ${market.thresholdLabel}?`
+              : "Enter a valid price and result time."}
           </h2>
+          {market ? (
+            <p className={styles.previewTime}>
+              Resolves {market.observationLabel} · Trading closes one minute earlier
+            </p>
+          ) : null}
 
           <div className={styles.outcomes} aria-label="Initial market outcomes">
             <div className={styles.yesOutcome}>
@@ -436,29 +402,13 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
             </div>
           </div>
 
-          <dl className={styles.facts}>
-            <div>
-              <dt><Clock3 aria-hidden="true" size={16} />Trading</dt>
-              <dd>
-                {market
-                  ? `Closes ${formatUtcObservation(market.cutoffTime)}`
-                  : "Closes 60 seconds before the result time"}
-              </dd>
-            </div>
-            <div>
-              <dt><Database aria-hidden="true" size={16} />Result source</dt>
-              <dd>Last completed Chainlink BTC/USD round at or before the UTC result time, proven by the next adjacent round</dd>
-            </div>
-            <div>
-              <dt><ShieldCheck aria-hidden="true" size={16} />Invalid result</dt>
-              <dd>Each YES or NO token keeps half-value if a result cannot be proven safely</dd>
-            </div>
-          </dl>
-
           <details className={styles.details}>
-            <summary>Exact resolution rule</summary>
+            <summary>How this market resolves</summary>
             <p>
-              Anyone can submit the adjacent Chainlink rounds that bracket the result time. The earlier completed round decides the market and must be no more than 25 hours old; the following round must arrive within 25 hours. Otherwise the market settles neutrally at 0.50 USDG per side.
+              YES wins if BTC is at or above the chosen price at the result
+              time. Chainlink&apos;s last completed BTC/USD price at or before
+              that time is used. If no valid result can be proven, YES and NO
+              each redeem for 0.50 USDG.
             </p>
           </details>
         </section>

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -59,6 +59,14 @@ describe("Explore UI contract", () => {
       join(root, "components/prediction-market-directory.tsx"),
       "utf8",
     );
+    const predictionStyles = readFileSync(
+      join(root, "components/prediction-market-experience.module.css"),
+      "utf8",
+    );
+    const predictionLaunchSource = readFileSync(
+      join(root, "components/prediction-market-launch.tsx"),
+      "utf8",
+    );
     const exploreStyles = readFileSync(
       join(root, "components/explore-experience.module.css"),
       "utf8",
@@ -73,6 +81,28 @@ describe("Explore UI contract", () => {
     expect(switchSource).toContain('aria-label="Explore categories"');
     expect(predictionSource).toContain('<h1>Explore</h1>');
     expect(predictionSource).toContain('<ExploreModeSwitch active="prediction" />');
+    expect(predictionSource).toContain("styles.marketGrid");
+    expect(predictionSource).toContain(
+      "Will BTC be at or above ${formatPredictionPriceAtoms(market.thresholdAtoms)}?",
+    );
+    expect(predictionSource).not.toContain("PREDICTION MARKETS · ROBINHOOD CHAIN");
+    expect(predictionSource).not.toContain("Market system status");
+    expect(predictionSource).not.toContain("VISIBLE BACKING");
+    expect(predictionSource).not.toContain("LIVE · BLOCK");
+    expect(predictionStyles).toMatch(
+      /\.marketGrid\s*\{[^}]*grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\);/s,
+    );
+    expect(predictionStyles).toMatch(
+      /@media \(max-width: 900px\)[\s\S]*?\.marketGrid\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/s,
+    );
+    expect(predictionLaunchSource).toContain("Create a prediction");
+    expect(predictionLaunchSource).toContain(
+      "Set the BTC price and result time",
+    );
+    expect(predictionLaunchSource).not.toContain("Technical preview");
+    expect(predictionLaunchSource).not.toContain("Robinhood Chain ·");
+    expect(predictionLaunchSource).not.toContain("1 signature");
+    expect(predictionLaunchSource).not.toContain("1 transaction");
     expect(exploreStyles).toMatch(
       /@media \(min-width: 1101px\)[\s\S]*?\.runnersIntro\s*\{[^}]*pointer-events:\s*none;[^}]*\}[\s\S]*?\.runnersIntro :global\(\.token-section-heading\)\s*\{[^}]*pointer-events:\s*auto;/s,
     );

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -188,9 +188,9 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain(
       'id="launch-model-prediction-title">Prediction</strong>',
     );
-    expect(html).toContain('data-status="preview">Technical preview</small>');
-    expect(html).toContain("Design a BTC market");
-    expect(html).toContain("2 USDG seed instead of a separate liquidity deposit");
+    expect(html).toContain('data-status="preview">Beta</small>');
+    expect(html).toContain("Create a prediction");
+    expect(html).toContain("Create a BTC prediction with YES and NO.");
     expect(html).toContain('data-launch-model-option="classic"');
     const classicCard = html.match(
       /<button[^>]*data-launch-model-option="classic"[^>]*>/,
@@ -215,6 +215,12 @@ describe("unreleased launch model gating", () => {
       "Launch an approved GitHub revision through your browser wallet, then follow it to its public record.",
     );
     expect(html).toContain("Open approved Custom launch");
+    expect(html.indexOf('data-launch-model-option="classic"')).toBeLessThan(
+      html.indexOf('data-launch-model-option="custom"'),
+    );
+    expect(html.indexOf('data-launch-model-option="custom"')).toBeLessThan(
+      html.indexOf('data-launch-model-option="prediction"'),
+    );
     for (const marker of removedPartnerMarkers) {
       expect(html).not.toContain(marker);
     }


### PR DESCRIPTION
## Summary

- match Prediction discovery to the existing Token Explore card grid
- remove chain, block, backing and other operational noise from the primary market UI
- place Prediction below Classic and Custom with a stronger YES/NO launch card
- simplify market creation, detail and trading copy while keeping resolution and contract details available on demand
- preserve all existing prediction-market contracts, APIs and settlement logic

## Verification

- `npm run lint` (0 errors; repository baseline warnings only)
- `npm run typecheck`
- `npm run test:interface:ci` (3,251 passed; 33 skipped)
- focused prediction and UI tests (54 passed)
- `npm run build` with exact candidate-neutral bundle verification
- rendered browser QA at 1440x900, 390x844 and 320x700
- verified launch selection, market detail, quote disclosure, responsive overflow and application console output

## Scope

Nine frontend and UI-contract test files only. No contracts, APIs, workflows, dependencies or production configuration changed.