### PR TITLE
fix(profile): show verified wallet launches in My Projects

### DIFF
--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -44,8 +44,14 @@ export type CreatorProjectMarketCapV1 = Readonly<{
   label: string | null;
 }>;
 
-export function ProfileProjects({ marketCaps = [] }: Readonly<{
+export function ProfileProjects({
+  marketCaps = [],
+  onRefresh,
+  walletProjects = [],
+}: Readonly<{
   marketCaps?: readonly CreatorProjectMarketCapV1[];
+  onRefresh?: () => void;
+  walletProjects?: readonly CreatorProjectSummaryV1[];
 }>) {
   const { wallet, getAccessToken, getIdentityToken } = useWallet();
   const [projects, setProjects] = useState<readonly CreatorProjectSummaryV1[]>([]);
@@ -97,9 +103,17 @@ export function ProfileProjects({ marketCaps = [] }: Readonly<{
     };
   }, [loadProjects, wallet]);
 
+  const visibleProjects = useMemo(
+    () => mergeCreatorWalletProjectsV1(walletProjects, projects),
+    [projects, walletProjects],
+  );
+  const editableTokens = useMemo(
+    () => new Set(projects.map((project) => project.tokenAddress.toLowerCase())),
+    [projects],
+  );
   const pageData = useMemo(
-    () => paginateCreatorProjectsV1(projects, marketCaps, projectPage),
-    [marketCaps, projectPage, projects],
+    () => paginateCreatorProjectsV1(visibleProjects, marketCaps, projectPage),
+    [marketCaps, projectPage, visibleProjects],
   );
   const marketCapByToken = useMemo(() => new Map(
     marketCaps.map((marketCap) => [marketCap.tokenAddress.toLowerCase(), marketCap]),
@@ -173,7 +187,10 @@ export function ProfileProjects({ marketCaps = [] }: Readonly<{
           <button
             className={styles.refresh}
             type="button"
-            onClick={() => void loadProjects()}
+            onClick={() => {
+              onRefresh?.();
+              void loadProjects();
+            }}
             disabled={phase === "loading"}
           >
             <RefreshCw aria-hidden="true" size={15} strokeWidth={1.8} />
@@ -210,11 +227,11 @@ export function ProfileProjects({ marketCaps = [] }: Readonly<{
 
       {projectError ? <p className={styles.error} role="alert">{projectError}</p> : null}
 
-      {phase === "loading" && projects.length === 0 ? (
+      {phase === "loading" && visibleProjects.length === 0 ? (
         <p className={styles.loading} role="status">Loading your verified launches…</p>
-      ) : phase === "error" ? (
+      ) : phase === "error" && visibleProjects.length === 0 ? (
         <p className={styles.error} role="alert">Your projects could not be verified right now.</p>
-      ) : projects.length === 0 ? (
+      ) : visibleProjects.length === 0 ? (
         <p className={styles.empty}>Your verified launches will appear here.</p>
       ) : (
         <div className={styles.list}>
@@ -236,18 +253,20 @@ export function ProfileProjects({ marketCaps = [] }: Readonly<{
                 {project.article ? <small>Updated {formatDate(project.article.updatedAt)}</small> : null}
               </div>
               <div className={styles.actions}>
-                <button
-                  type="button"
-                  disabled={openingProject !== null}
-                  onPointerEnter={() => warmEditor(project)}
-                  onPointerDown={() => warmEditor(project)}
-                  onFocus={() => warmEditor(project)}
-                  onClick={(event) => void openEditor(project, event.currentTarget)}
-                >
-                  {openingProject?.tokenAddress === project.tokenAddress
-                    ? "Opening…"
-                    : project.article ? "Edit article" : "Create article"}
-                </button>
+                {editableTokens.has(project.tokenAddress.toLowerCase()) ? (
+                  <button
+                    type="button"
+                    disabled={openingProject !== null}
+                    onPointerEnter={() => warmEditor(project)}
+                    onPointerDown={() => warmEditor(project)}
+                    onFocus={() => warmEditor(project)}
+                    onClick={(event) => void openEditor(project, event.currentTarget)}
+                  >
+                    {openingProject?.tokenAddress === project.tokenAddress
+                      ? "Opening…"
+                      : project.article ? "Edit article" : "Create article"}
+                  </button>
+                ) : null}
                 <Link href={`/token/${project.tokenAddress}`}>View token</Link>
               </div>
             </article>
@@ -378,6 +397,20 @@ export function paginateCreatorProjectsV1(
     totalPages,
     items: Object.freeze(ordered.slice(offset, offset + creatorProjectPageSize)),
   });
+}
+
+export function mergeCreatorWalletProjectsV1(
+  walletProjects: readonly CreatorProjectSummaryV1[],
+  authenticatedProjects: readonly CreatorProjectSummaryV1[],
+) {
+  const byToken = new Map<string, CreatorProjectSummaryV1>();
+  for (const project of walletProjects) {
+    byToken.set(project.tokenAddress.toLowerCase(), project);
+  }
+  for (const project of authenticatedProjects) {
+    byToken.set(project.tokenAddress.toLowerCase(), project);
+  }
+  return Object.freeze([...byToken.values()]);
 }
 
 function parseProjectList(value: unknown): readonly CreatorProjectSummaryV1[] {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -20,6 +20,7 @@ import { useWallet } from "@/components/wallet-provider";
 import {
   ProfileProjects,
   type CreatorProjectMarketCapV1,
+  type CreatorProjectSummaryV1,
 } from "@/components/profile-projects";
 import { PredictionMarketPortfolio } from "@/components/prediction-market-portfolio";
 import { useLiveDataRefresh } from "@/components/use-live-data-refresh";
@@ -71,6 +72,8 @@ import {
   canOptimizeTokenImage,
   getTokenCardImageSource,
 } from "@/lib/token-image";
+import { PROGRAMMABLE_MAIN_TOKEN_ADDRESS } from
+  "@/lib/creator-article/programmable-example-v1";
 import {
   getProfileStorageKey,
   getProfileUsernameError,
@@ -1803,6 +1806,20 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     })),
     [scopedOnchainData.tokens],
   );
+  const creatorWalletProjects = useMemo<readonly CreatorProjectSummaryV1[]>(
+    () => scopedOnchainData.tokens.map((token) => ({
+      chainId: 1 as const,
+      tokenAddress: token.address,
+      name: token.name,
+      symbol: token.symbol || null,
+      imageUrl: token.imageUrl ?? null,
+      source: token.address.toLowerCase() === PROGRAMMABLE_MAIN_TOKEN_ADDRESS
+        ? "official-main-token" as const
+        : "envio-classic-v3" as const,
+      article: null,
+    })),
+    [scopedOnchainData.tokens],
+  );
   const scopedClassicV3Rewards = useMemo<ClassicV3ProfileRewards>(() => {
     if (!account || !classicV3ReleaseAvailable) {
       return EMPTY_CLASSIC_V3_PROFILE;
@@ -3202,7 +3219,11 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         </div>
       </section>
 
-      <ProfileProjects marketCaps={creatorProjectMarketCaps} />
+      <ProfileProjects
+        marketCaps={creatorProjectMarketCaps}
+        walletProjects={creatorWalletProjects}
+        onRefresh={retryProfileData}
+      />
       <PredictionMarketPortfolio />
 
       <ProfileAccountWorkspace

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -72,6 +72,25 @@ describe("My projects editor opening", () => {
     });
   });
 
+  it("keeps verified wallet launches visible and lets authenticated data override them", () => {
+    const merge = (profileProjects as unknown as {
+      mergeCreatorWalletProjectsV1(
+        walletProjects: readonly CreatorProjectSummaryV1[],
+        authenticatedProjects: readonly CreatorProjectSummaryV1[],
+      ): readonly CreatorProjectSummaryV1[];
+    }).mergeCreatorWalletProjectsV1;
+    const article = {
+      revision: 2,
+      title: "Updated project",
+      updatedAt: "2026-08-23T00:00:00.000Z",
+    };
+
+    expect(merge([project], [])).toEqual([project]);
+    expect(merge([project], [{ ...project, article }])).toEqual([
+      { ...project, article },
+    ]);
+  });
+
   it("refreshes the Privy identity before reading the bound access token", async () => {
     const acquire = (profileProjects as unknown as {
       acquireCreatorArticleAuthHeadersV1(input: Readonly<{


### PR DESCRIPTION
## What
- merge verified creator launches already loaded for the connected wallet into My Projects
- retain authenticated project records as the authority for article create/edit controls
- refresh both creator profile data and authenticated project data together

## Why
Classic V3 launches could be correctly attributed onchain and visible in the public creator profile but omitted from My Projects when the connected wallet was not yet present in Privy server-side linked accounts.

## Validation
- `npx vitest run tests/profile-projects-editor-open.test.ts` (7/7)
- changed-file ESLint
- `npm run typecheck`
- `git diff --check`