### PR TITLE
Fix the prediction Explore toggle hitbox

### DIFF
--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -35,6 +35,7 @@
   justify-content: flex-end;
   margin: -62px 0 0 auto;
   position: relative;
+  width: fit-content;
   z-index: 1;
 }
 

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -95,6 +95,9 @@ describe("Explore UI contract", () => {
     expect(predictionStyles).toMatch(
       /@media \(max-width: 900px\)[\s\S]*?\.marketGrid\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/s,
     );
+    expect(predictionStyles).toMatch(
+      /\.directoryToolbar\s*\{[^}]*width:\s*fit-content;/s,
+    );
     expect(predictionLaunchSource).toContain("Create a prediction");
     expect(predictionLaunchSource).toContain(
       "Set the BTC price and result time",


### PR DESCRIPTION
## Outcome\n- Keep the prediction directory toolbar from covering the Explore mode switch.\n- Preserve the intended desktop alignment while keeping the full Token hit target interactive.\n- Lock the layout invariant into the Explore UI contract test.\n\n## Verification\n- Focused Explore UI contract: 7 tests passed.\n- Focused ESLint: passed.\n- TypeScript typecheck: passed.\n- Rendered QA: 1440x900 and 390x844.\n- Token is the topmost hit element and the click navigates to /explore.\n- No horizontal overflow at either viewport.