### PR TITLE
Show initial buy custody in creator projects

### DIFF
--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -275,6 +275,50 @@
   line-height: 1.3;
 }
 
+.initialBuy {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 8px;
+  margin-block-start: 2px;
+  min-width: 0;
+}
+
+.initialBuy small {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.initialBuyStatus {
+  align-items: center;
+  display: inline-flex;
+  gap: 5px;
+}
+
+.initialBuyStatus::before {
+  background: currentcolor;
+  border-radius: 999px;
+  content: "";
+  flex: none;
+  height: 4px;
+  opacity: 0.8;
+  width: 4px;
+}
+
+.initialBuyStatus[data-state="locked"] {
+  color: #e6b46f;
+}
+
+.initialBuyStatus[data-state="vesting"] {
+  color: #9ec7ef;
+}
+
+.initialBuyStatus[data-state="unlocked"],
+.initialBuyStatus[data-state="complete"] {
+  color: #9bd2ae;
+}
+
 .actions {
   gap: 6px;
   justify-content: flex-end;

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { ChevronLeft, ChevronRight, RefreshCw, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { getAddress, isAddress } from "viem";
+import { formatUnits, getAddress, isAddress } from "viem";
 
 import {
   acquireCreatorArticleAuthHeadersV1,
@@ -44,11 +44,26 @@ export type CreatorProjectMarketCapV1 = Readonly<{
   label: string | null;
 }>;
 
+export type CreatorProjectInitialBuyV1 = Readonly<{
+  tokenAddress: `0x${string}`;
+  ethAmountWei: string;
+  tokenAmountRaw: string;
+  tokenDecimals: number;
+  custodyAddress: `0x${string}` | null;
+  custodyMode: "unlocked" | "fixed-lock" | "linear" | "cliff-linear";
+  durationDays: number;
+  cliffDays: number;
+  cliffAt: string;
+  releaseAt: string;
+}>;
+
 export function ProfileProjects({
+  initialBuys = [],
   marketCaps = [],
   onRefresh,
   walletProjects = [],
 }: Readonly<{
+  initialBuys?: readonly CreatorProjectInitialBuyV1[];
   marketCaps?: readonly CreatorProjectMarketCapV1[];
   onRefresh?: () => void;
   walletProjects?: readonly CreatorProjectSummaryV1[];
@@ -118,6 +133,12 @@ export function ProfileProjects({
   const marketCapByToken = useMemo(() => new Map(
     marketCaps.map((marketCap) => [marketCap.tokenAddress.toLowerCase(), marketCap]),
   ), [marketCaps]);
+  const initialBuyByToken = useMemo(() => new Map(
+    initialBuys.map((initialBuy) => [
+      initialBuy.tokenAddress.toLowerCase(),
+      initialBuy,
+    ]),
+  ), [initialBuys]);
 
   const getEditorState = useCallback((project: CreatorProjectSummaryV1) => {
     const key = project.tokenAddress.toLowerCase();
@@ -235,7 +256,14 @@ export function ProfileProjects({
         <p className={styles.empty}>Your verified launches will appear here.</p>
       ) : (
         <div className={styles.list}>
-          {pageData.items.map((project) => (
+          {pageData.items.map((project) => {
+            const initialBuy = initialBuyByToken.get(
+              project.tokenAddress.toLowerCase(),
+            );
+            const initialBuyLabel = initialBuy
+              ? formatCreatorProjectInitialBuyV1(initialBuy, project.symbol)
+              : null;
+            return (
             <article className={styles.project} key={project.tokenAddress}>
               <div className={styles.art}>
                 {project.imageUrl ? (
@@ -251,6 +279,17 @@ export function ProfileProjects({
                   </small>
                 ) : null}
                 {project.article ? <small>Updated {formatDate(project.article.updatedAt)}</small> : null}
+                {initialBuyLabel ? (
+                  <div className={styles.initialBuy}>
+                    <small>{initialBuyLabel.amount}</small>
+                    <small
+                      className={styles.initialBuyStatus}
+                      data-state={initialBuyLabel.state}
+                    >
+                      {initialBuyLabel.status}
+                    </small>
+                  </div>
+                ) : null}
               </div>
               <div className={styles.actions}>
                 {editableTokens.has(project.tokenAddress.toLowerCase()) ? (
@@ -270,7 +309,8 @@ export function ProfileProjects({
                 <Link href={`/token/${project.tokenAddress}`}>View token</Link>
               </div>
             </article>
-          ))}
+            );
+          })}
         </div>
       )}
 
@@ -411,6 +451,70 @@ export function mergeCreatorWalletProjectsV1(
     byToken.set(project.tokenAddress.toLowerCase(), project);
   }
   return Object.freeze([...byToken.values()]);
+}
+
+export function formatCreatorProjectInitialBuyV1(
+  initialBuy: CreatorProjectInitialBuyV1,
+  symbol: string | null,
+  now = Date.now(),
+) {
+  const ethAmount = Number(formatUnits(BigInt(initialBuy.ethAmountWei), 18));
+  const tokenAmount = Number(formatUnits(
+    BigInt(initialBuy.tokenAmountRaw),
+    initialBuy.tokenDecimals,
+  ));
+  const ethLabel = Number.isFinite(ethAmount)
+    ? new Intl.NumberFormat("en-US", { maximumSignificantDigits: 6 }).format(ethAmount)
+    : formatUnits(BigInt(initialBuy.ethAmountWei), 18);
+  const tokenLabel = Number.isFinite(tokenAmount)
+    ? new Intl.NumberFormat("en-US", {
+        compactDisplay: "short",
+        maximumFractionDigits: 2,
+        notation: "compact",
+      }).format(tokenAmount)
+    : formatUnits(BigInt(initialBuy.tokenAmountRaw), initialBuy.tokenDecimals);
+  const ticker = symbol ? `$${symbol}` : "tokens";
+  const date = (value: string) => new Intl.DateTimeFormat("en", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(value));
+  const releaseTime = Date.parse(initialBuy.releaseAt);
+  const cliffTime = Date.parse(initialBuy.cliffAt);
+  if (initialBuy.custodyMode === "unlocked") {
+    return Object.freeze({
+      amount: `Initial buy ${ethLabel} ETH → ${tokenLabel} ${ticker}`,
+      status: "Unlocked at launch",
+      state: "unlocked" as const,
+    });
+  }
+  if (initialBuy.custodyMode === "fixed-lock") {
+    return Object.freeze({
+      amount: `Initial buy ${ethLabel} ETH → ${tokenLabel} ${ticker}`,
+      status: now < releaseTime
+        ? `Locked until ${date(initialBuy.releaseAt)}`
+        : `Lock ended ${date(initialBuy.releaseAt)}`,
+      state: now < releaseTime ? "locked" as const : "complete" as const,
+    });
+  }
+  if (
+    initialBuy.custodyMode === "cliff-linear" &&
+    now < cliffTime
+  ) {
+    return Object.freeze({
+      amount: `Initial buy ${ethLabel} ETH → ${tokenLabel} ${ticker}`,
+      status: `Cliff until ${date(initialBuy.cliffAt)} · vests by ${date(initialBuy.releaseAt)}`,
+      state: "locked" as const,
+    });
+  }
+  return Object.freeze({
+    amount: `Initial buy ${ethLabel} ETH → ${tokenLabel} ${ticker}`,
+    status: now < releaseTime
+      ? `Vesting until ${date(initialBuy.releaseAt)}`
+      : `Vesting ended ${date(initialBuy.releaseAt)}`,
+    state: now < releaseTime ? "vesting" as const : "complete" as const,
+  });
 }
 
 function parseProjectList(value: unknown): readonly CreatorProjectSummaryV1[] {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -19,6 +19,7 @@ import {
 import { useWallet } from "@/components/wallet-provider";
 import {
   ProfileProjects,
+  type CreatorProjectInitialBuyV1,
   type CreatorProjectMarketCapV1,
   type CreatorProjectSummaryV1,
 } from "@/components/profile-projects";
@@ -1806,6 +1807,12 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     })),
     [scopedOnchainData.tokens],
   );
+  const creatorProjectInitialBuys = useMemo<readonly CreatorProjectInitialBuyV1[]>(
+    () => scopedOnchainData.tokens.flatMap((token) => token.initialBuy
+      ? [{ tokenAddress: token.address, ...token.initialBuy }]
+      : []),
+    [scopedOnchainData.tokens],
+  );
   const creatorWalletProjects = useMemo<readonly CreatorProjectSummaryV1[]>(
     () => scopedOnchainData.tokens.map((token) => ({
       chainId: 1 as const,
@@ -3220,6 +3227,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       </section>
 
       <ProfileProjects
+        initialBuys={creatorProjectInitialBuys}
         marketCaps={creatorProjectMarketCaps}
         walletProjects={creatorWalletProjects}
         onRefresh={retryProfileData}

--- a/lib/market-data/envio-classic-v3-catalog.server.ts
+++ b/lib/market-data/envio-classic-v3-catalog.server.ts
@@ -104,6 +104,9 @@ const CLASSIC_V3_LAUNCH_QUERY = `
       tickLower
       tickUpper
       lpFeePips
+      initialBuyQuoteAmount
+      initialBuyTokenAmount
+      initialBuyEthAmount
       launchOccurrenceId
       liquidityOccurrenceId
       initialBuyOccurrenceId
@@ -177,6 +180,9 @@ const LAUNCH_KEYS = [
   "tickLower",
   "tickUpper",
   "lpFeePips",
+  "initialBuyQuoteAmount",
+  "initialBuyTokenAmount",
+  "initialBuyEthAmount",
   "launchOccurrenceId",
   "liquidityOccurrenceId",
   "initialBuyOccurrenceId",
@@ -266,7 +272,10 @@ type EnvioClassicV3LaunchRow = Readonly<{
   tickLower: number;
   tickUpper: number;
   lpFeePips: number;
+  initialBuyQuoteAmount: string;
+  initialBuyTokenAmount: string;
   launchOccurrenceId: string;
+  custodyOccurrenceId: string;
   updatedBlock: string;
 }>;
 
@@ -279,6 +288,26 @@ type EnvioClassicV3LaunchEvent = Readonly<{
   transactionIndex: number;
   blockGlobalLogIndex: number;
   decodedPayload: Readonly<Record<string, string>>;
+}>;
+
+type EnvioClassicV3CustodyEvent = Readonly<{
+  id: string;
+  blockNumber: string;
+  blockHash: Hex;
+  blockTimestamp: string;
+  transactionHash: Hex;
+  transactionIndex: number;
+  blockGlobalLogIndex: number;
+  decodedPayload: Readonly<{
+    cliffDays: string;
+    configurationHash: string;
+    custody: string;
+    deployer: string;
+    durationDays: string;
+    launchHash: string;
+    mode: string;
+    token: string;
+  }>;
 }>;
 
 type OfficialMainTokenLaunchRow = Readonly<{
@@ -528,6 +557,11 @@ function parseLaunchRow(
     /^1:0x[0-9a-f]{64}:0x[0-9a-f]{64}:(?:0|[1-9][0-9]*)$/u,
     "launch occurrence",
   );
+  const custodyOccurrenceId = exactString(
+    value.custodyOccurrenceId,
+    /^1:0x[0-9a-f]{64}:0x[0-9a-f]{64}:(?:0|[1-9][0-9]*)$/u,
+    "custody occurrence",
+  );
   const requiredFlags = [
     value.hasLaunchEvent,
     value.hasLiquidityEvent,
@@ -544,6 +578,7 @@ function parseLaunchRow(
     value.model !== "classic" ||
     value.releaseVersion !== "classic-v3" ||
     value.quoteAsset !== null ||
+    value.initialBuyEthAmount !== null ||
     value.totalSwapFeeBps !== null ||
     value.quoteConfigurationHash !== null ||
     value.coordinatorOccurrenceId !== null ||
@@ -553,7 +588,7 @@ function parseLaunchRow(
     requiredFlags.some((flag) => flag !== true) ||
     typeof value.liquidityOccurrenceId !== "string" ||
     typeof value.initialBuyOccurrenceId !== "string" ||
-    typeof value.custodyOccurrenceId !== "string"
+    custodyOccurrenceId === launchOccurrenceId
   ) {
     throw new Error(`Envio Classic V3 launch ${id} failed release validation`);
   }
@@ -569,6 +604,20 @@ function parseLaunchRow(
     10_000,
     "sell swap fee",
   );
+  const initialBuyQuoteAmount = unsignedText(
+    value.initialBuyQuoteAmount,
+    "initial buy quote amount",
+  );
+  const initialBuyTokenAmount = unsignedText(
+    value.initialBuyTokenAmount,
+    "initial buy token amount",
+  );
+  if (
+    BigInt(initialBuyQuoteAmount) === 0n ||
+    BigInt(initialBuyTokenAmount) === 0n
+  ) {
+    throw new Error(`Envio Classic V3 launch ${id} has an empty initial buy`);
+  }
   return Object.freeze({
     id,
     launchHash,
@@ -597,7 +646,10 @@ function parseLaunchRow(
     tickLower: boundedInteger(value.tickLower, -887_272, 887_272, "tick lower"),
     tickUpper: boundedInteger(value.tickUpper, -887_272, 887_272, "tick upper"),
     lpFeePips: boundedInteger(value.lpFeePips, 0, 1_000_000, "LP fee"),
+    initialBuyQuoteAmount,
+    initialBuyTokenAmount,
     launchOccurrenceId,
+    custodyOccurrenceId,
     updatedBlock: unsignedText(value.updatedBlock, "updated block"),
   });
 }
@@ -716,6 +768,134 @@ function assertLaunchEventBinding(
   ) {
     throw new Error(`Envio Classic V3 launch ${launch.id} payload binding failed`);
   }
+}
+
+function parseCustodyEvent(
+  value: unknown,
+  expectedOccurrenceId: string,
+  release: DataPipelineReleaseBinding,
+): EnvioClassicV3CustodyEvent {
+  if (!isRecord(value) || !hasOnlyKeys(value, EVENT_KEYS)) {
+    throw new Error("Envio Classic V3 custody event shape drifted");
+  }
+  const sources = launchSourceBindings(release);
+  const id = exactString(
+    value.id,
+    /^1:0x[0-9a-f]{64}:0x[0-9a-f]{64}:(?:0|[1-9][0-9]*)$/u,
+    "custody event id",
+  );
+  const blockHash = bytes32(value.blockHash, "custody event block hash");
+  const transactionHash = bytes32(
+    value.transactionHash,
+    "custody event transaction hash",
+  );
+  const blockGlobalLogIndex = safeUnsignedInteger(
+    value.blockGlobalLogIndex,
+    "custody event log index",
+  );
+  if (
+    value.downstreamLogicalId !== null ||
+    value.receiptLogOrdinal !== null ||
+    typeof value.decodedPayload !== "string"
+  ) {
+    throw new Error(`Envio Classic V3 custody event ${id} has invalid source semantics`);
+  }
+  bytes32(value.payloadHash, "custody event payload hash");
+  let decodedPayload: unknown;
+  try {
+    decodedPayload = JSON.parse(value.decodedPayload);
+  } catch {
+    throw new Error(`Envio Classic V3 custody event ${id} payload is invalid`);
+  }
+  const payloadKeys = [
+    "cliffDays",
+    "configurationHash",
+    "custody",
+    "deployer",
+    "durationDays",
+    "launchHash",
+    "mode",
+    "token",
+  ] as const;
+  if (
+    !isRecord(decodedPayload) ||
+    !hasOnlyKeys(decodedPayload, payloadKeys) ||
+    Object.values(decodedPayload).some((item) => typeof item !== "string")
+  ) {
+    throw new Error(`Envio Classic V3 custody event ${id} payload shape drifted`);
+  }
+  if (
+    id !== expectedOccurrenceId ||
+    value.chainId !== 1 ||
+    value.model !== "classic" ||
+    value.releaseVersion !== "classic-v3" ||
+    value.contractName !== "ClassicV3Launcher" ||
+    value.eventName !== "MemeCreatorInitialBuyCustodyV2" ||
+    address(value.sourceAddress, "custody event source").toLowerCase() !==
+      sources.launcher.address.toLowerCase() ||
+    id !== `1:${blockHash}:${transactionHash}:${blockGlobalLogIndex}`
+  ) {
+    throw new Error(`Envio Classic V3 custody event ${id} failed occurrence validation`);
+  }
+  return Object.freeze({
+    id,
+    blockNumber: unsignedText(value.blockNumber, "custody event block number"),
+    blockHash,
+    blockTimestamp: unsignedText(
+      value.blockTimestamp,
+      "custody event block timestamp",
+    ),
+    transactionHash,
+    transactionIndex: safeUnsignedInteger(
+      value.transactionIndex,
+      "custody event transaction index",
+    ),
+    blockGlobalLogIndex,
+    decodedPayload: decodedPayload as EnvioClassicV3CustodyEvent["decodedPayload"],
+  });
+}
+
+function assertCustodyEventBinding(
+  launch: EnvioClassicV3LaunchRow,
+  launchEvent: EnvioClassicV3LaunchEvent,
+  custodyEvent: EnvioClassicV3CustodyEvent,
+) {
+  const payload = custodyEvent.decodedPayload;
+  const custody = address(payload.custody, "initial buy custody");
+  const mode = safeUnsignedInteger(payload.mode, "initial buy custody mode");
+  const durationDays = safeUnsignedInteger(
+    payload.durationDays,
+    "initial buy custody duration",
+  );
+  const cliffDays = safeUnsignedInteger(
+    payload.cliffDays,
+    "initial buy custody cliff",
+  );
+  const validSchedule = mode === 0
+    ? durationDays === 0 && cliffDays === 0 && custody === NATIVE_CURRENCY_ADDRESS
+    : mode === 1 || mode === 2
+      ? durationDays >= 1 && durationDays <= 3_650 && cliffDays === 0 &&
+        custody !== NATIVE_CURRENCY_ADDRESS
+      : mode === 3
+        ? durationDays >= 2 && durationDays <= 3_650 && cliffDays >= 1 &&
+          cliffDays < durationDays && custody !== NATIVE_CURRENCY_ADDRESS
+        : false;
+  if (
+    !validSchedule ||
+    custodyEvent.blockNumber !== launchEvent.blockNumber ||
+    custodyEvent.blockHash.toLowerCase() !== launchEvent.blockHash.toLowerCase() ||
+    custodyEvent.blockTimestamp !== launchEvent.blockTimestamp ||
+    custodyEvent.transactionHash.toLowerCase() !==
+      launchEvent.transactionHash.toLowerCase() ||
+    custodyEvent.transactionIndex !== launchEvent.transactionIndex ||
+    custodyEvent.blockGlobalLogIndex <= launchEvent.blockGlobalLogIndex ||
+    payload.deployer.toLowerCase() !== launch.creator.toLowerCase() ||
+    payload.token.toLowerCase() !== launch.token.toLowerCase() ||
+    payload.launchHash.toLowerCase() !== launch.launchHash.toLowerCase()
+  ) {
+    throw new Error(`Envio Classic V3 launch ${launch.id} custody binding failed`);
+  }
+  bytes32(payload.configurationHash, "initial buy custody configuration hash");
 }
 
 function parseOfficialMainTokenLaunch(
@@ -981,6 +1161,7 @@ async function readClassicV3Rows(
 ) {
   const launches: EnvioClassicV3LaunchRow[] = [];
   const events = new Map<string, EnvioClassicV3LaunchEvent>();
+  const custodyEvents = new Map<string, EnvioClassicV3CustodyEvent>();
   let afterId = "";
   while (true) {
     const launchResponse = await graphqlRequest(release, {
@@ -1006,7 +1187,9 @@ async function readClassicV3Rows(
       throw new Error("Envio Classic V3 catalog exceeded its safety bound");
     }
     if (page.length > 0) {
-      const ids = page.map((launch) => launch.launchOccurrenceId);
+      const launchIds = page.map((launch) => launch.launchOccurrenceId);
+      const custodyIds = page.map((launch) => launch.custodyOccurrenceId);
+      const ids = [...launchIds, ...custodyIds];
       const eventResponse = await graphqlRequest(release, {
         query: CLASSIC_V3_LAUNCH_EVENTS_QUERY,
         variables: { ids },
@@ -1021,11 +1204,17 @@ async function readClassicV3Rows(
         if (typeof rawId !== "string" || !expected.delete(rawId)) {
           throw new Error("Envio Classic V3 occurrence set drifted");
         }
-        const event = parseLaunchEvent(rawEvent, rawId, release);
+        const event = launchIds.includes(rawId)
+          ? parseLaunchEvent(rawEvent, rawId, release)
+          : parseCustodyEvent(rawEvent, rawId, release);
         if (BigInt(event.blockNumber) > BigInt(anchorBlock)) {
           throw new Error("Envio Classic V3 occurrence exceeds progress");
         }
-        events.set(event.id, event);
+        if (launchIds.includes(rawId)) {
+          events.set(event.id, event as EnvioClassicV3LaunchEvent);
+        } else {
+          custodyEvents.set(event.id, event as EnvioClassicV3CustodyEvent);
+        }
       }
       if (expected.size !== 0) {
         throw new Error("Envio Classic V3 occurrence coverage is incomplete");
@@ -1035,7 +1224,12 @@ async function readClassicV3Rows(
         if (!event) {
           throw new Error("Envio Classic V3 occurrence coverage is incomplete");
         }
+        const custodyEvent = custodyEvents.get(launch.custodyOccurrenceId);
+        if (!custodyEvent) {
+          throw new Error("Envio Classic V3 custody coverage is incomplete");
+        }
         assertLaunchEventBinding(launch, event, release);
+        assertCustodyEventBinding(launch, event, custodyEvent);
       }
     }
     if (page.length < LAUNCH_PAGE_SIZE) break;
@@ -1066,6 +1260,7 @@ async function readClassicV3Rows(
   return Object.freeze({
     launches: Object.freeze(launches),
     events,
+    custodyEvents,
   });
 }
 
@@ -1274,9 +1469,54 @@ async function defaultReadRpcSnapshot(input: Readonly<{
   });
 }
 
+function buildInitialBuyCustody(
+  event: EnvioClassicV3CustodyEvent,
+): NonNullable<LauncherToken["initialBuyCustody"]> {
+  const payload = event.decodedPayload;
+  const modeCode = safeUnsignedInteger(payload.mode, "initial buy custody mode");
+  const mode = ([
+    "unlocked",
+    "fixed-lock",
+    "linear",
+    "cliff-linear",
+  ] as const)[modeCode];
+  if (!mode) throw new Error("Envio initial buy custody mode is unsupported");
+  const durationDays = safeUnsignedInteger(
+    payload.durationDays,
+    "initial buy custody duration",
+  );
+  const cliffDays = safeUnsignedInteger(
+    payload.cliffDays,
+    "initial buy custody cliff",
+  );
+  const launchTimestamp = BigInt(event.blockTimestamp);
+  const releaseTimestamp = launchTimestamp + BigInt(durationDays) * 86_400n;
+  const cliffOffsetDays = mode === "fixed-lock"
+    ? durationDays
+    : mode === "cliff-linear"
+      ? cliffDays
+      : 0;
+  const cliffTimestamp = launchTimestamp + BigInt(cliffOffsetDays) * 86_400n;
+  const custodyAddress = address(payload.custody, "initial buy custody");
+  return Object.freeze({
+    custodyAddress:
+      custodyAddress === NATIVE_CURRENCY_ADDRESS ? null : custodyAddress,
+    mode,
+    durationDays,
+    cliffDays,
+    configurationHash: bytes32(
+      payload.configurationHash,
+      "initial buy custody configuration hash",
+    ),
+    cliffTimestamp: new Date(Number(cliffTimestamp) * 1_000).toISOString(),
+    releaseTimestamp: new Date(Number(releaseTimestamp) * 1_000).toISOString(),
+  });
+}
+
 function buildEntries(
   launches: readonly EnvioClassicV3LaunchRow[],
   events: ReadonlyMap<string, EnvioClassicV3LaunchEvent>,
+  custodyEvents: ReadonlyMap<string, EnvioClassicV3CustodyEvent>,
   official: Readonly<{
     launch: OfficialMainTokenLaunchRow;
     event: OfficialMainTokenLaunchEvent;
@@ -1285,8 +1525,9 @@ function buildEntries(
 ) {
   const classicEntries = launches.map((launch) => {
     const event = events.get(launch.launchOccurrenceId);
+    const custodyEvent = custodyEvents.get(launch.custodyOccurrenceId);
     const tokenMetadata = metadata.get(launch.token.toLowerCase());
-    if (!event || !tokenMetadata) {
+    if (!event || !custodyEvent || !tokenMetadata) {
       throw new Error(`Envio Classic V3 launch ${launch.id} is not hydrated`);
     }
     const totalSwapFeeBps = Math.max(
@@ -1323,6 +1564,9 @@ function buildEntries(
       tokenDecimals: tokenMetadata.decimals,
       tokenLiquidityAmountRaw: launch.tokenLiquidityAmount,
       lockedTokenDustRaw: launch.lockedTokenDust,
+      initialBuyEthAmountWei: launch.initialBuyQuoteAmount,
+      initialBuyTokenAmountRaw: launch.initialBuyTokenAmount,
+      initialBuyCustody: buildInitialBuyCustody(custodyEvent),
       quoteAssetAddress: NATIVE_CURRENCY_ADDRESS,
       quoteAssetSymbol: "ETH",
       quoteAssetName: "Ether",
@@ -1456,7 +1700,13 @@ async function readUncached(
   const generatedAt = new Date(
     Number(BigInt(rpc.anchorBlockTimestamp)) * 1_000,
   ).toISOString();
-  const entries = buildEntries(rows.launches, rows.events, official, rpc.metadata);
+  const entries = buildEntries(
+    rows.launches,
+    rows.events,
+    rows.custodyEvents,
+    official,
+    rpc.metadata,
+  );
   const evidenceCore = {
     deployment: progress.deployment,
     sourceCommit: release.envio.sourceCommit,

--- a/lib/profile/onchain-profile.ts
+++ b/lib/profile/onchain-profile.ts
@@ -15,6 +15,18 @@ import {
 export type ProfileDataStatus =
   "unavailable" | "not-deployed" | "loading" | "ready" | "error";
 
+export type ProfileInitialBuy = Readonly<{
+  ethAmountWei: string;
+  tokenAmountRaw: string;
+  tokenDecimals: number;
+  custodyAddress: Address | null;
+  custodyMode: "unlocked" | "fixed-lock" | "linear" | "cliff-linear";
+  durationDays: number;
+  cliffDays: number;
+  cliffAt: string;
+  releaseAt: string;
+}>;
+
 export type ProfileToken = {
   address: Address;
   name: string;
@@ -33,6 +45,7 @@ export type ProfileToken = {
     | "stock-paired"
     | "custom-graph";
   launchProvenance?: "canonical-router";
+  initialBuy?: ProfileInitialBuy;
 };
 
 export type ProfilePosition = {
@@ -426,6 +439,138 @@ function tokenHref(address: Address) {
   return `/token/${address}`;
 }
 
+function parseInitialBuy(
+  token: Record<string, unknown>,
+  launchModel: ProfileToken["launchModel"],
+  launchedAt: string,
+): ProfileInitialBuy | undefined {
+  const rawValues = [
+    token.initialBuyEthAmountWei,
+    token.initialBuyTokenAmountRaw,
+    token.initialBuyCustody,
+    token.tokenDecimals,
+  ];
+  if (rawValues.every((value) => value === undefined || value === null)) {
+    return undefined;
+  }
+  if (rawValues.some((value) => value === undefined || value === null)) {
+    throw new ProfileResponseError("Profile token contains incomplete initial buy data");
+  }
+  if (launchModel !== "classic") {
+    throw new ProfileResponseError("Initial buy data is not bound to a Classic launch");
+  }
+  const ethAmountWei = readIntegerString(
+    token,
+    "initialBuyEthAmountWei",
+    "initial buy ETH amount",
+  );
+  const tokenAmountRaw = readIntegerString(
+    token,
+    "initialBuyTokenAmountRaw",
+    "initial buy token amount",
+  );
+  const tokenDecimals = readSafeInteger(
+    token,
+    "tokenDecimals",
+    "initial buy token decimals",
+  );
+  if (
+    BigInt(ethAmountWei) === 0n ||
+    BigInt(tokenAmountRaw) === 0n ||
+    tokenDecimals > 255
+  ) {
+    throw new ProfileResponseError("Profile token contains invalid initial buy amounts");
+  }
+  const custody = asRecord(token.initialBuyCustody, "initial buy custody");
+  const custodyKeys = Object.keys(custody).sort();
+  const expectedCustodyKeys = [
+    "cliffDays",
+    "cliffTimestamp",
+    "configurationHash",
+    "custodyAddress",
+    "durationDays",
+    "mode",
+    "releaseTimestamp",
+  ].sort();
+  if (
+    custodyKeys.length !== expectedCustodyKeys.length ||
+    custodyKeys.some((key, index) => key !== expectedCustodyKeys[index])
+  ) {
+    throw new ProfileResponseError("Invalid initial buy custody shape");
+  }
+  const custodyMode = custody.mode;
+  if (
+    custodyMode !== "unlocked" &&
+    custodyMode !== "fixed-lock" &&
+    custodyMode !== "linear" &&
+    custodyMode !== "cliff-linear"
+  ) {
+    throw new ProfileResponseError("Invalid initial buy custody mode");
+  }
+  const durationDays = readSafeInteger(
+    custody,
+    "durationDays",
+    "initial buy custody duration",
+  );
+  const cliffDays = readSafeInteger(
+    custody,
+    "cliffDays",
+    "initial buy custody cliff",
+  );
+  readHex(
+    custody,
+    "configurationHash",
+    "initial buy custody configuration hash",
+    32,
+  );
+  const custodyAddress = custody.custodyAddress === null
+    ? null
+    : readAddress(custody, "custodyAddress", "initial buy custody address");
+  const validSchedule = custodyMode === "unlocked"
+    ? durationDays === 0 && cliffDays === 0 && custodyAddress === null
+    : custodyMode === "fixed-lock" || custodyMode === "linear"
+      ? durationDays >= 1 && durationDays <= 3_650 && cliffDays === 0 &&
+        custodyAddress !== null
+      : durationDays >= 2 && durationDays <= 3_650 && cliffDays >= 1 &&
+        cliffDays < durationDays && custodyAddress !== null;
+  if (!validSchedule) {
+    throw new ProfileResponseError("Invalid initial buy custody schedule");
+  }
+  const cliffAt = readTimestamp(
+    custody,
+    "cliffTimestamp",
+    "initial buy custody cliff time",
+  );
+  const releaseAt = readTimestamp(
+    custody,
+    "releaseTimestamp",
+    "initial buy custody release time",
+  );
+  const launchedAtMs = Date.parse(launchedAt);
+  const expectedCliffDays = custodyMode === "fixed-lock"
+    ? durationDays
+    : custodyMode === "cliff-linear"
+      ? cliffDays
+      : 0;
+  if (
+    Date.parse(cliffAt) !== launchedAtMs + expectedCliffDays * 86_400_000 ||
+    Date.parse(releaseAt) !== launchedAtMs + durationDays * 86_400_000
+  ) {
+    throw new ProfileResponseError("Initial buy custody dates do not match the launch");
+  }
+  return Object.freeze({
+    ethAmountWei,
+    tokenAmountRaw,
+    tokenDecimals,
+    custodyAddress,
+    custodyMode,
+    durationDays,
+    cliffDays,
+    cliffAt,
+    releaseAt,
+  });
+}
+
 function formatActivityDate(timestamp: string) {
   return new Intl.DateTimeFormat("en-US", {
     day: "numeric",
@@ -483,6 +628,8 @@ function parseToken(
     token.launchModel === "custom-graph"
       ? token.launchModel
       : undefined;
+  const launchedAt = readTimestamp(token, "launchedAt", "launch timestamp");
+  const initialBuy = parseInitialBuy(token, launchModel, launchedAt);
   const launchStampProvenance = readLaunchStampProvenance(token, {
     tokenAddress: address,
     hookAddress,
@@ -549,7 +696,7 @@ function parseToken(
     address,
     name: readString(token, "name", "token name"),
     symbol: readString(token, "symbol", "token symbol"),
-    launchedAt: readTimestamp(token, "launchedAt", "launch timestamp"),
+    launchedAt,
     href: tokenHref(address),
     ...(imageUrl ? { imageUrl } : {}),
     ...(marketCapEthWei ? { marketCapEthWei } : {}),
@@ -557,6 +704,7 @@ function parseToken(
     ...(marketCapQuoteWad ? { marketCapQuoteWad } : {}),
     ...(quoteAssetSymbol ? { quoteAssetSymbol } : {}),
     ...(launchModel ? { launchModel } : {}),
+    ...(initialBuy ? { initialBuy } : {}),
     poolId,
     hookAddress,
     creatorAddress,
@@ -859,6 +1007,7 @@ export function mapCreatorProfileResponse(
       quoteAssetSymbol,
       launchModel,
       launchStampProvenance,
+      initialBuy,
     }) => ({
       address,
       name,
@@ -871,6 +1020,7 @@ export function mapCreatorProfileResponse(
       ...(marketCapQuoteWad ? { marketCapQuoteWad } : {}),
       ...(quoteAssetSymbol ? { quoteAssetSymbol } : {}),
       ...(launchModel ? { launchModel } : {}),
+      ...(initialBuy ? { initialBuy } : {}),
       ...(launchStampProvenance
         ? { launchProvenance: "canonical-router" as const }
         : {}),

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -415,6 +415,17 @@ export type LauncherToken = {
   tokenDecimals?: number;
   tokenLiquidityAmountRaw?: string;
   lockedTokenDustRaw?: string;
+  initialBuyEthAmountWei?: string;
+  initialBuyTokenAmountRaw?: string;
+  initialBuyCustody?: Readonly<{
+    custodyAddress: `0x${string}` | null;
+    mode: "unlocked" | "fixed-lock" | "linear" | "cliff-linear";
+    durationDays: number;
+    cliffDays: number;
+    configurationHash: `0x${string}`;
+    cliffTimestamp: string;
+    releaseTimestamp: string;
+  }>;
   tokenPriceEth?: string;
   tokenPriceEthWei?: string;
   tokenPriceUsdWad?: string;

--- a/tests/envio-classic-v3-catalog.test.ts
+++ b/tests/envio-classic-v3-catalog.test.ts
@@ -74,6 +74,8 @@ function launchFixture(index: number, overrides: Record<string, unknown> = {}) {
   const blockHash = hex32(10_000 + index);
   const transactionHash = hex32(20_000 + index);
   const occurrenceId = `1:${blockHash}:${transactionHash}:${index}`;
+  const custodyOccurrenceId =
+    `1:${blockHash}:${transactionHash}:${5_000 + index}`;
   return {
     id: `1:classic-v3:${launchHash}`,
     chainId: 1,
@@ -100,10 +102,13 @@ function launchFixture(index: number, overrides: Record<string, unknown> = {}) {
     tickLower: -200,
     tickUpper: 200,
     lpFeePips: 10_000,
+    initialBuyQuoteAmount: "50000000000000000",
+    initialBuyTokenAmount: "34883942100954326694409764",
+    initialBuyEthAmount: null,
     launchOccurrenceId: occurrenceId,
     liquidityOccurrenceId: `${occurrenceId}:liquidity`,
     initialBuyOccurrenceId: `${occurrenceId}:buy`,
-    custodyOccurrenceId: `${occurrenceId}:custody`,
+    custodyOccurrenceId,
     coordinatorOccurrenceId: null,
     hasLaunchEvent: true,
     hasLiquidityEvent: true,
@@ -117,6 +122,43 @@ function launchFixture(index: number, overrides: Record<string, unknown> = {}) {
     isComplete: true,
     updatedBlock: String(ANCHOR_BLOCK),
     ...overrides,
+  };
+}
+
+function custodyEventFixture(launch: ReturnType<typeof launchFixture>) {
+  const classicV3Launcher = release.sources.find(
+    (source) => source.contractName === "ClassicV3Launcher",
+  )!.address;
+  const [, blockHash, transactionHash, logIndex] = String(
+    launch.custodyOccurrenceId,
+  ).split(":");
+  return {
+    id: launch.custodyOccurrenceId,
+    downstreamLogicalId: null,
+    receiptLogOrdinal: null,
+    chainId: 1,
+    blockNumber: String(EVENT_BLOCK),
+    blockHash,
+    blockTimestamp: "1785480000",
+    transactionHash,
+    transactionIndex: "1",
+    blockGlobalLogIndex: logIndex,
+    sourceAddress: classicV3Launcher,
+    contractName: "ClassicV3Launcher",
+    eventName: "MemeCreatorInitialBuyCustodyV2",
+    model: "classic",
+    releaseVersion: "classic-v3",
+    decodedPayload: JSON.stringify({
+      cliffDays: "0",
+      configurationHash: hex32(80_000 + Number(logIndex)),
+      custody: address(8_000 + Number(logIndex)),
+      deployer: launch.creator,
+      durationDays: "30",
+      launchHash: launch.launchHash,
+      mode: "1",
+      token: launch.token,
+    }),
+    payloadHash: hex32(90_000 + Number(logIndex)),
   };
 }
 
@@ -190,6 +232,9 @@ function officialLaunchFixture() {
     tickLower: -887200,
     tickUpper: 204200,
     lpFeePips: 0,
+    initialBuyQuoteAmount: "2000000000000000",
+    initialBuyTokenAmount: "1458415534058453948045650",
+    initialBuyEthAmount: null,
     launchOccurrenceId: OFFICIAL_OCCURRENCE,
     liquidityOccurrenceId: `${OFFICIAL_OCCURRENCE}:liquidity`,
     initialBuyOccurrenceId: `${OFFICIAL_OCCURRENCE}:buy`,
@@ -255,8 +300,8 @@ function json(value: unknown, status = 200) {
 function harness(input: {
   launches?: ReturnType<typeof launchFixture>[];
   mutateEvents?: (
-    events: ReturnType<typeof eventFixture>[],
-  ) => ReturnType<typeof eventFixture>[];
+    events: Array<ReturnType<typeof eventFixture> | ReturnType<typeof custodyEventFixture>>,
+  ) => Array<ReturnType<typeof eventFixture> | ReturnType<typeof custodyEventFixture>>;
 } = {}) {
   const launches = [...(input.launches ?? [launchFixture(1)])]
     .sort((left, right) => String(left.id).localeCompare(String(right.id)));
@@ -279,8 +324,14 @@ function harness(input: {
     }
     if (request.query.includes("ProgrammableClassicV3LaunchEvents")) {
       const ids = request.variables.ids as string[];
-      let events = launches.filter((row) => ids.includes(String(row.launchOccurrenceId)))
-        .map(eventFixture);
+      let events = launches.flatMap((row) => [
+        ...(ids.includes(String(row.launchOccurrenceId))
+          ? [eventFixture(row)]
+          : []),
+        ...(ids.includes(String(row.custodyOccurrenceId))
+          ? [custodyEventFixture(row)]
+          : []),
+      ]);
       events = input.mutateEvents?.(events) ?? events;
       return json({ data: { ChainEvent: events } });
     }
@@ -381,6 +432,15 @@ describe("Envio Classic V3 public catalog", () => {
         entry.sellHookFeeBps ?? 0,
       )
     )).toBe(true);
+    expect(classicV3Entries[0]).toMatchObject({
+      initialBuyEthAmountWei: "50000000000000000",
+      initialBuyTokenAmountRaw: "34883942100954326694409764",
+      initialBuyCustody: {
+        mode: "fixed-lock",
+        durationDays: 30,
+        cliffDays: 0,
+      },
+    });
     expect(catalog.entries.find((entry) =>
       entry.exploreKind === "token" &&
       entry.tokenAddress.toLowerCase() === PROGRAMMABLE_MAIN_ASSET_ADDRESS

--- a/tests/profile-client.test.ts
+++ b/tests/profile-client.test.ts
@@ -297,6 +297,56 @@ describe("profile API client", () => {
       .toBe(true);
   });
 
+  it("maps an exactly bound initial buy lock into the creator profile", () => {
+    const response = profileResponse();
+    response.tokens[0] = {
+      ...response.tokens[0],
+      launchModel: "classic",
+      tokenDecimals: 18,
+      initialBuyEthAmountWei: "50000000000000000",
+      initialBuyTokenAmountRaw: "34883942100954326694409764",
+      initialBuyCustody: {
+        custodyAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        mode: "fixed-lock",
+        durationDays: 30,
+        cliffDays: 0,
+        configurationHash: `0x${"ab".repeat(32)}`,
+        cliffTimestamp: "2026-08-25T12:00:00.000Z",
+        releaseTimestamp: "2026-08-25T12:00:00.000Z",
+      },
+    } as (typeof response.tokens)[number];
+
+    const profile = mapCreatorProfileResponse(response, account);
+
+    expect(profile.tokens[0]?.initialBuy).toEqual({
+      ethAmountWei: "50000000000000000",
+      tokenAmountRaw: "34883942100954326694409764",
+      tokenDecimals: 18,
+      custodyAddress: getAddress(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ),
+      custodyMode: "fixed-lock",
+      durationDays: 30,
+      cliffDays: 0,
+      cliffAt: "2026-08-25T12:00:00.000Z",
+      releaseAt: "2026-08-25T12:00:00.000Z",
+    });
+
+    const initialBuyCustody = (
+      response.tokens[0] as Record<string, unknown>
+    ).initialBuyCustody as Record<string, unknown>;
+    response.tokens[0] = {
+      ...response.tokens[0],
+      initialBuyCustody: {
+        ...initialBuyCustody,
+        releaseTimestamp: "2026-08-26T12:00:00.000Z",
+      },
+    } as (typeof response.tokens)[number];
+    expect(() => mapCreatorProfileResponse(response, account)).toThrow(
+      "custody dates do not match",
+    );
+  });
+
   it("keeps verified launches that use a model-specific reward route", () => {
     const response = profileResponse();
     const stockToken = {

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import * as profileProjects from "../components/profile-projects";
 import type {
+  CreatorProjectInitialBuyV1,
   CreatorProjectMarketCapV1,
   CreatorProjectSummaryV1,
 } from "../components/profile-projects";
@@ -89,6 +90,40 @@ describe("My projects editor opening", () => {
     expect(merge([project], [{ ...project, article }])).toEqual([
       { ...project, article },
     ]);
+  });
+
+  it("shows the initial buy amount and immutable custody schedule", () => {
+    const format = (profileProjects as unknown as {
+      formatCreatorProjectInitialBuyV1(
+        initialBuy: CreatorProjectInitialBuyV1,
+        symbol: string | null,
+        now: number,
+      ): Readonly<{ amount: string; status: string; state: string }>;
+    }).formatCreatorProjectInitialBuyV1;
+    const lock = {
+      tokenAddress: project.tokenAddress,
+      ethAmountWei: "50000000000000000",
+      tokenAmountRaw: "34883942100954326694409764",
+      tokenDecimals: 18,
+      custodyAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const,
+      custodyMode: "fixed-lock" as const,
+      durationDays: 360,
+      cliffDays: 0,
+      cliffAt: "2027-08-18T08:32:59.000Z",
+      releaseAt: "2027-08-18T08:32:59.000Z",
+    };
+
+    expect(format(lock, "DIGITALCAT", Date.parse("2026-08-23T12:00:00Z")))
+      .toEqual({
+        amount: "Initial buy 0.05 ETH → 34.88M $DIGITALCAT",
+        status: "Locked until Aug 18, 2027",
+        state: "locked",
+      });
+    expect(format(
+      { ...lock, custodyAddress: null, custodyMode: "unlocked", durationDays: 0 },
+      "DIGITALCAT",
+      Date.parse("2026-08-23T12:00:00Z"),
+    )).toMatchObject({ status: "Unlocked at launch", state: "unlocked" });
   });
 
   it("refreshes the Privy identity before reading the bound access token", async () => {


### PR DESCRIPTION
## Outcome
- shows each verified Classic V3 initial buy in My Projects as ETH paid and tokens received
- shows the exact onchain custody schedule: unlocked, locked, or vesting with the UTC-derived end date
- binds the UI data to the Envio Launch and matching custody occurrence before display

## Verification
- 25 focused tests passed
- TypeScript passed
- changed-file ESLint passed
- git diff check passed

No contract, claim, trade, or wallet-write behavior changes.