### PR TITLE
Fail closed on stale claims and article reads

### DIFF
--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -247,6 +247,11 @@ export function ProfileProjects({
       </header>
 
       {projectError ? <p className={styles.error} role="alert">{projectError}</p> : null}
+      {phase === "error" && visibleProjects.length > 0 ? (
+        <p className={styles.error} role="alert">
+          Article controls are temporarily unavailable. Refresh to try again.
+        </p>
+      ) : null}
 
       {phase === "loading" && visibleProjects.length === 0 ? (
         <p className={styles.loading} role="status">Loading your verified launches…</p>
@@ -292,7 +297,8 @@ export function ProfileProjects({
                 ) : null}
               </div>
               <div className={styles.actions}>
-                {editableTokens.has(project.tokenAddress.toLowerCase()) ? (
+                {phase === "ready" &&
+                editableTokens.has(project.tokenAddress.toLowerCase()) ? (
                   <button
                     type="button"
                     disabled={openingProject !== null}

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -367,6 +367,12 @@ export function getProfileRewardDataQuality(
   return "current";
 }
 
+export function profileClaimSubmissionAllowed(
+  quality: ProfileRewardDataQuality,
+) {
+  return quality === "current";
+}
+
 export function resolveCreatorProfileReadFailure(
   current: ProfileOnchainData,
   account: string,
@@ -4193,18 +4199,6 @@ function ProfileAccountWorkspace({
     0n,
   );
   const nativeEarned = nativeClaimed + nativeClaimable;
-  const claimableEntries = sortProfileClaimableEntries(
-    entries.filter((entry) =>
-      profileEntryHasActionableReward(entry, account, actionStates),
-    ),
-    account,
-    actionStates,
-  );
-  const claimPageData = paginateProfileClaimableEntries(
-    claimableEntries,
-    claimPage,
-  );
-  const routerLaunchEntries = profileRouterLaunchEntries(entries);
   const nativeRewardSourceStatuses = [
     data.status,
     classicV3Rewards.status,
@@ -4215,6 +4209,23 @@ function ProfileAccountWorkspace({
     classicV3SourceState.quality,
     data.sourceQuality ?? "current",
   );
+  const claimSubmissionAllowed = profileClaimSubmissionAllowed(
+    rewardDataQuality,
+  );
+  const claimableEntries = claimSubmissionAllowed
+    ? sortProfileClaimableEntries(
+        entries.filter((entry) =>
+          profileEntryHasActionableReward(entry, account, actionStates),
+        ),
+        account,
+        actionStates,
+      )
+    : [];
+  const claimPageData = paginateProfileClaimableEntries(
+    claimableEntries,
+    claimPage,
+  );
+  const routerLaunchEntries = profileRouterLaunchEntries(entries);
   const emptyState =
     rewardDataQuality === "current"
       ? {
@@ -4243,11 +4254,9 @@ function ProfileAccountWorkspace({
         className={`${styles.profileWorkspace} liquid-glass-surface`}
       >
         <FeeEarningsPanel
-          nativeEarned={rewardDataQuality === "partial" ? null : nativeEarned}
-          nativeClaimable={
-            rewardDataQuality === "partial" ? null : nativeClaimable
-          }
-          nativeClaimed={rewardDataQuality === "partial" ? null : nativeClaimed}
+          nativeEarned={claimSubmissionAllowed ? nativeEarned : null}
+          nativeClaimable={claimSubmissionAllowed ? nativeClaimable : null}
+          nativeClaimed={claimSubmissionAllowed ? nativeClaimed : null}
         />
 
         <section

--- a/lib/server/creator-article/api.server.ts
+++ b/lib/server/creator-article/api.server.ts
@@ -53,12 +53,7 @@ export function createCreatorArticleApiHandlersV1(input: Readonly<{
           signal: request.signal,
         });
         const rows = await Promise.all(projects.map(async (project) => {
-          let article = null;
-          try {
-            article = await input.store.readCurrent(project);
-          } catch {
-            article = null;
-          }
+          const article = await input.store.readCurrent(project);
           return Object.freeze({
             chainId: project.chainId,
             tokenAddress: project.tokenAddress,

--- a/tests/creator-article-api.test.ts
+++ b/tests/creator-article-api.test.ts
@@ -70,6 +70,20 @@ describe("creator article authenticated APIs", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
+  it("fails closed when an article read cannot distinguish absence from outage", async () => {
+    readCurrent.mockRejectedValueOnce(new Error("Blob read failed"));
+    const response = await handlers.listProjects(new Request(
+      "https://example.com/api/profile/projects",
+      { headers: { accept: "application/json" } },
+    ));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      schemaVersion: "programmable.creator-article-error.v1",
+      code: "creator_article_unavailable",
+    });
+  });
+
   it("requires create/update preconditions and publishes the canonical draft", async () => {
     const missing = await handlers.article(new Request(`https://example.com/api/profile/projects/${TOKEN}/article`, {
       method: "PUT",

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -46,6 +46,20 @@ describe("My projects editor opening", () => {
     );
   });
 
+  it("exposes article controls only after a current authenticated read", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/profile-projects.tsx"),
+      "utf8",
+    );
+
+    expect(source).toMatch(
+      /phase === "ready" &&\s*editableTokens\.has\(project\.tokenAddress\.toLowerCase\(\)\)/u,
+    );
+    expect(source).toContain(
+      "Article controls are temporarily unavailable. Refresh to try again.",
+    );
+  });
+
   it("paginates verified projects by highest available market cap", () => {
     const paginate = (profileProjects as unknown as {
       paginateCreatorProjectsV1(

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -21,6 +21,7 @@ import {
   paginateProfileClaimableEntries,
   profileClaimableWei,
   profileClaimActionCount,
+  profileClaimSubmissionAllowed,
   profileCreatorClaimErrorMessage,
   profileEntryHasClaimableReward,
   profileHasRewardSurface,
@@ -327,6 +328,21 @@ describe("profile workspace loading state", () => {
     );
     expect(profileViewSource).toContain(
       "PROFILE_LIVE_REFRESH_INTERVAL_MS = 30_000",
+    );
+  });
+
+  it("allows new claims only from current verified reward data", () => {
+    expect(profileClaimSubmissionAllowed("current")).toBe(true);
+    expect(profileClaimSubmissionAllowed("stale")).toBe(false);
+    expect(profileClaimSubmissionAllowed("partial")).toBe(false);
+    expect(profileViewSource).toContain(
+      "profileClaimSubmissionAllowed(\n    rewardDataQuality,",
+    );
+    expect(profileViewSource).toContain(
+      "const claimableEntries = claimSubmissionAllowed",
+    );
+    expect(profileViewSource).toContain(
+      "nativeEarned={claimSubmissionAllowed ? nativeEarned : null}",
     );
   });
 


### PR DESCRIPTION
## Summary
- hide claim actions and monetary totals until reward data is current and verified
- preserve fresh onchain preparation as the only transaction source
- return 503 when authenticated article storage cannot distinguish absence from outage
- expose article controls only after a current authenticated read

## Verification
- `npx vitest run tests/profile-view.test.ts tests/creator-article-api.test.ts tests/profile-projects-editor-open.test.ts` (71 passed)
- `npm run typecheck`
- changed-path ESLint
- `git diff --check`
- production `BLOB_READ_WRITE_TOKEN` binding confirmed present without reading its value