### PR TITLE
Ship complete prediction market profile and payout UX

### DIFF
--- a/components/prediction-market-detail.tsx
+++ b/components/prediction-market-detail.tsx
@@ -9,7 +9,14 @@ import {
   LockKeyhole,
   RefreshCw,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import styles from "@/components/prediction-market-experience.module.css";
 import { predictionPreviewMarkets } from "@/components/prediction-market-preview";
@@ -27,10 +34,12 @@ import {
   formatPredictionMarketObservation,
   formatPredictionOutcome,
   formatPredictionPriceAtoms,
+  isPredictionMarketLoadRequestCurrent,
   parsePredictionBuyAmount,
   parsePredictionSellAmount,
   predictionBuyPayoutSummary,
   predictionDirectionalProtocolFee,
+  predictionMarketRedeemableAtoms,
   preparePredictionBuy,
   preparePredictionFallbackAction,
   preparePredictionRedeem,
@@ -44,6 +53,7 @@ import {
   type PredictionBuyQuote,
   type PredictionFallbackAction,
   type PredictionMarketView,
+  type PredictionMarketLoadRequestV1,
   type PredictionOutcome,
   type PredictionSellQuote,
 } from "@/lib/prediction-market-trading";
@@ -67,9 +77,9 @@ type LiveQuote =
 type DisplayBuyPayout = Readonly<{
   estimatedCostLabel: string;
   maximumLossLabel: string;
+  minimumNeutralPayoutLabel: string;
   minimumWinningProfitLabel: string;
   minimumWinningPayoutLabel: string;
-  neutralPayoutLabel: string;
   outcome: PredictionOutcome;
   potentialProfitAtoms: bigint;
   potentialProfitLabel: string;
@@ -105,17 +115,24 @@ function centsLabel(bps: number) {
   return `${(bps / 100).toFixed(1).replace(/\.0$/u, "")}¢`;
 }
 
-function traderUsdgLabel(atoms: bigint) {
+function traderUsdgLabel(
+  atoms: bigint,
+  precision: "adaptive" | "exact" = "adaptive",
+) {
   const negative = atoms < 0n;
   const absolute = negative ? -atoms : atoms;
   const collateralScale = 10n ** BigInt(PREDICTION_COLLATERAL_DECIMALS);
-  const fractionDigits = absolute >= collateralScale
-    ? 2
-    : absolute >= collateralScale / 100n
-      ? 4
-      : PREDICTION_COLLATERAL_DECIMALS;
+  const fractionDigits = precision === "exact"
+    ? PREDICTION_COLLATERAL_DECIMALS
+    : absolute >= collateralScale
+      ? 2
+      : absolute >= collateralScale / 100n
+        ? 4
+        : PREDICTION_COLLATERAL_DECIMALS;
   const roundingScale = 10n ** BigInt(PREDICTION_COLLATERAL_DECIMALS - fractionDigits);
-  const rounded = (absolute + roundingScale / 2n) / roundingScale;
+  const rounded = precision === "exact"
+    ? absolute
+    : (absolute + roundingScale / 2n) / roundingScale;
   const displayScale = 10n ** BigInt(fractionDigits);
   const whole = (rounded / displayScale).toString();
   const fraction = (rounded % displayScale)
@@ -126,9 +143,15 @@ function traderUsdgLabel(atoms: bigint) {
   return `${negative ? "−" : ""}${grouped}${fraction ? `.${fraction}` : ""} USDG`;
 }
 
-function signedUsdgLabel(atoms: bigint) {
-  if (atoms === 0n) return traderUsdgLabel(0n);
-  return `${atoms > 0n ? "+" : "−"}${traderUsdgLabel(atoms > 0n ? atoms : -atoms)}`;
+function signedUsdgLabel(
+  atoms: bigint,
+  precision: "adaptive" | "exact" = "adaptive",
+) {
+  if (atoms === 0n) return traderUsdgLabel(0n, precision);
+  return `${atoms > 0n ? "+" : "−"}${traderUsdgLabel(
+    atoms > 0n ? atoms : -atoms,
+    precision,
+  )}`;
 }
 
 function traderOutcomeLabel(atoms: bigint, outcome: PredictionOutcome) {
@@ -148,14 +171,19 @@ function displayBuyPayout(
   const payout = predictionBuyPayoutSummary(quote);
   return {
     estimatedCostLabel: traderUsdgLabel(payout.estimatedCostAtoms),
-    maximumLossLabel: traderUsdgLabel(payout.maximumLossAtoms),
+    maximumLossLabel: traderUsdgLabel(payout.maximumLossAtoms, "exact"),
     minimumWinningProfitLabel: signedUsdgLabel(
       payout.minimumWinningProfitAtoms,
+      "exact",
     ),
     minimumWinningPayoutLabel: traderUsdgLabel(
       payout.minimumWinningPayoutAtoms,
+      "exact",
     ),
-    neutralPayoutLabel: traderUsdgLabel(payout.neutralPayoutAtoms),
+    minimumNeutralPayoutLabel: traderUsdgLabel(
+      payout.minimumNeutralPayoutAtoms,
+      "exact",
+    ),
     outcome,
     potentialProfitAtoms: payout.potentialProfitAtoms,
     potentialProfitLabel: signedUsdgLabel(payout.potentialProfitAtoms),
@@ -199,17 +227,30 @@ function displayQuote(quote: LiveQuote): DisplayQuote {
         : {}),
     };
   }
+  const complement = quote.value.outcome === "YES" ? "NO" : "YES";
+  const returnedShares = [
+    quote.value.soldRefundAtoms > 0n
+      ? formatPredictionOutcome(
+          quote.value.soldRefundAtoms,
+          quote.value.outcome,
+        )
+      : null,
+    quote.value.complementRefundAtoms > 0n
+      ? formatPredictionOutcome(
+          quote.value.complementRefundAtoms,
+          complement,
+        )
+      : null,
+  ].filter((label): label is string => label !== null);
   return {
     afterYesBps: quote.value.probabilityAfterBps,
     averagePriceBps: quote.value.averagePriceBps,
     depthLabel: quoteDepthLabel(quote.value.priceImpactBps),
-    minimumLabel: traderUsdgLabel(quote.value.minCollateralAtoms),
+    minimumLabel: traderUsdgLabel(quote.value.minCollateralAtoms, "exact"),
     outputLabel: traderUsdgLabel(quote.value.collateralAtoms),
     priceImpactBps: quote.value.priceImpactBps,
-    ...(quote.value.soldRefundAtoms || quote.value.complementRefundAtoms
-      ? {
-          refundLabel: `${formatPredictionOutcome(quote.value.soldRefundAtoms)} sold + ${formatPredictionOutcome(quote.value.complementRefundAtoms)} complement`,
-        }
+    ...(returnedShares.length > 0
+      ? { refundLabel: `${returnedShares.join(" + ")} returned` }
       : {}),
   };
 }
@@ -276,7 +317,10 @@ function previewQuote(
     afterYesBps,
     averagePriceBps,
     depthLabel: quoteDepthLabel(impact),
-    minimumLabel: traderUsdgLabel(outputAtoms * 9_950n / 10_000n),
+    minimumLabel: traderUsdgLabel(
+      outputAtoms * 9_950n / 10_000n,
+      "exact",
+    ),
     outputLabel: traderUsdgLabel(outputAtoms),
     priceImpactBps: impact,
   };
@@ -292,6 +336,8 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   }, []);
   const { openWallet, sendTransaction, signPredictionTokenPermit, wallet } = useWallet();
   const walletAccount = wallet?.account;
+  const walletAccountKey = walletAccount?.toLowerCase() ?? "";
+  const normalizedSemanticKey = semanticKey.toLowerCase();
   const [loadState, setLoadState] = useState<MarketLoadState>({ kind: "loading" });
   const [mode, setMode] = useState<TradeMode>("BUY");
   const [outcome, setOutcome] = useState<PredictionOutcome>("YES");
@@ -301,21 +347,78 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   const [phase, setPhase] = useState<"idle" | "quoting" | "signing" | "submitting" | "confirming">("idle");
   const [message, setMessage] = useState("");
   const quoteRequestId = useRef(0);
+  const quotePhaseRequestId = useRef<number | null>(null);
+  const marketLoadGeneration = useRef(0);
+  const activeMarketLoadRequest = useRef<PredictionMarketLoadRequestV1 | null>(null);
+  const marketActionGeneration = useRef(0);
+  const activeMarketActionRequest = useRef<PredictionMarketLoadRequestV1 | null>(null);
+  const walletAccountKeyRef = useRef(walletAccountKey);
+  const semanticKeyRef = useRef(normalizedSemanticKey);
+
+  useLayoutEffect(() => {
+    walletAccountKeyRef.current = walletAccountKey;
+    semanticKeyRef.current = normalizedSemanticKey;
+    return () => {
+      activeMarketLoadRequest.current = null;
+      marketLoadGeneration.current += 1;
+      quoteRequestId.current += 1;
+      quotePhaseRequestId.current = null;
+      activeMarketActionRequest.current = null;
+      marketActionGeneration.current += 1;
+    };
+  }, [normalizedSemanticKey, walletAccountKey]);
+
+  function marketActionIsCurrent(request: PredictionMarketLoadRequestV1) {
+    return isPredictionMarketLoadRequestCurrent(
+      request,
+      activeMarketActionRequest.current,
+    )
+      && request.accountKey === walletAccountKeyRef.current
+      && request.semanticKey === semanticKeyRef.current;
+  }
+
+  function requireCurrentMarketAction(request: PredictionMarketLoadRequestV1) {
+    if (!marketActionIsCurrent(request)) {
+      throw new Error(
+        "The wallet or market changed. The action was stopped before submission.",
+      );
+    }
+  }
 
   const refresh = useCallback(async () => {
+    const request = {
+      accountKey: walletAccountKey,
+      generation: ++marketLoadGeneration.current,
+      semanticKey: normalizedSemanticKey,
+    } satisfies PredictionMarketLoadRequestV1;
+    activeMarketLoadRequest.current = request;
     quoteRequestId.current += 1;
+    if (quotePhaseRequestId.current !== null) {
+      quotePhaseRequestId.current = null;
+      setPhase((current) => current === "quoting" ? "idle" : current);
+    }
+    if (activeMarketActionRequest.current !== null) {
+      activeMarketActionRequest.current = null;
+      marketActionGeneration.current += 1;
+      setPhase("idle");
+    }
     setLiveQuote(null);
     setShownQuote(null);
     await Promise.resolve();
+    if (!isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) return;
     if (!release.config) {
       const market = predictionPreviewMarkets(Math.floor(Date.now() / 1_000)).find(
         (candidate) => candidate.semanticKey.toLowerCase() === semanticKey.toLowerCase(),
       );
       if (!market) {
-        setLoadState({ kind: "error", message: "This preview market does not exist" });
+        if (isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) {
+          setLoadState({ kind: "error", message: "This preview market does not exist" });
+        }
         return;
       }
-      setLoadState({ kind: "preview", market });
+      if (isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) {
+        setLoadState({ kind: "preview", market });
+      }
       return;
     }
     setLoadState({ kind: "loading" });
@@ -325,17 +428,35 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         config: release.config,
         semanticKey,
       });
-      setLoadState({ kind: "live", market });
+      if (isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) {
+        setLoadState({ kind: "live", market });
+      }
     } catch (error) {
-      setLoadState({ kind: "error", message: getErrorMessage(error) });
+      if (isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) {
+        setLoadState({ kind: "error", message: getErrorMessage(error) });
+      }
     }
-  }, [release.config, semanticKey, walletAccount]);
+  }, [normalizedSemanticKey, release.config, semanticKey, walletAccount, walletAccountKey]);
 
   useEffect(() => {
+    quoteRequestId.current += 1;
+    quotePhaseRequestId.current = null;
+    activeMarketActionRequest.current = null;
+    marketActionGeneration.current += 1;
     const timer = window.setTimeout(() => {
+      setPhase("idle");
+      setMessage("");
       void refresh();
     }, 0);
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(timer);
+      activeMarketLoadRequest.current = null;
+      marketLoadGeneration.current += 1;
+      quoteRequestId.current += 1;
+      quotePhaseRequestId.current = null;
+      activeMarketActionRequest.current = null;
+      marketActionGeneration.current += 1;
+    };
   }, [refresh]);
 
   const market = "market" in loadState ? loadState.market : null;
@@ -344,6 +465,10 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
 
   function clearQuote() {
     quoteRequestId.current += 1;
+    if (quotePhaseRequestId.current !== null) {
+      quotePhaseRequestId.current = null;
+      setPhase((current) => current === "quoting" ? "idle" : current);
+    }
     setLiveQuote(null);
     setShownQuote(null);
     setMessage("");
@@ -356,6 +481,7 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
     const requestedMarket = market;
     const requestedMode = mode;
     const requestedOutcome = outcome;
+    quotePhaseRequestId.current = requestId;
     setPhase("quoting");
     setMessage(preview ? "Checking the preview price…" : "Finding your price…");
     try {
@@ -405,7 +531,10 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
       setShownQuote(null);
       setMessage(getErrorMessage(error));
     } finally {
-      setPhase("idle");
+      if (requestId === quoteRequestId.current) {
+        quotePhaseRequestId.current = null;
+        setPhase("idle");
+      }
     }
   }
 
@@ -415,52 +544,66 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
       openWallet();
       return;
     }
+    const actionRequest = {
+      accountKey: wallet.account.toLowerCase(),
+      generation: ++marketActionGeneration.current,
+      semanticKey: semanticKey.toLowerCase(),
+    } satisfies PredictionMarketLoadRequestV1;
+    activeMarketActionRequest.current = actionRequest;
+    const requestedMarket = market;
+    const requestedQuote = liveQuote;
+    const requestedWallet = wallet;
+    const requestedMode = mode;
+    const requestedOutcome = outcome;
     const clients = createPredictionMarketPublicClients();
     const permitDeadline = BigInt(Math.floor(Date.now() / 1_000) + PREDICTION_PERMIT_DURATION_SECONDS);
-    const tokenAddress = liveQuote.kind === "BUY"
+    const tokenAddress = requestedQuote.kind === "BUY"
       ? ROBINHOOD_USDG_ADDRESS
-      : liveQuote.value.outcome === "YES"
-        ? market.yesToken
-        : market.noToken;
-    const tokenName = liveQuote.kind === "BUY"
+      : requestedQuote.value.outcome === "YES"
+        ? requestedMarket.yesToken
+        : requestedMarket.noToken;
+    const tokenName = requestedQuote.kind === "BUY"
       ? "Global Dollar"
-      : liveQuote.value.outcome === "YES"
-        ? market.yesTokenName
-        : market.noTokenName;
-    const value = liveQuote.kind === "BUY"
-      ? liveQuote.value.collateralInAtoms
-      : liveQuote.value.outcomeAtoms;
+      : requestedQuote.value.outcome === "YES"
+        ? requestedMarket.yesTokenName
+        : requestedMarket.noTokenName;
+    const value = requestedQuote.kind === "BUY"
+      ? requestedQuote.value.collateralInAtoms
+      : requestedQuote.value.outcomeAtoms;
     try {
       setPhase("signing");
-      setMessage(`Sign an exact ${mode === "BUY" ? "USDG" : outcome} permit. The signature alone spends no gas.`);
+      setMessage(`Sign an exact ${requestedMode === "BUY" ? "USDG" : requestedOutcome} permit. The signature alone spends no gas.`);
       const { nonce } = await readPredictionPermitNonceQuorum({
         clients,
         config: release.config,
-        owner: wallet.account,
+        owner: requestedWallet.account,
         token: tokenAddress,
       });
+      requireCurrentMarketAction(actionRequest);
       const permit = await signPredictionTokenPermit({
         deadline: permitDeadline,
         nonce,
-        spender: market.router,
+        spender: requestedMarket.router,
         tokenAddress,
         tokenName,
         value,
       });
+      requireCurrentMarketAction(actionRequest);
 
       setPhase("quoting");
       setMessage("Refreshing the executable quote after signature…");
       const tradeDeadline = BigInt(Math.floor(Date.now() / 1_000) + 5 * 60);
       let prepared;
-      if (liveQuote.kind === "BUY") {
+      if (requestedQuote.kind === "BUY") {
         const freshQuote = await quotePredictionBuy({
-            collateralAtoms: liveQuote.value.collateralInAtoms,
-            clients,
-            config: release.config,
-            outcome: liveQuote.value.outcome,
-            semanticKey,
-          });
-        if (freshQuote.outcomeAtoms < liveQuote.value.minOutcomeAtoms) {
+          collateralAtoms: requestedQuote.value.collateralInAtoms,
+          clients,
+          config: release.config,
+          outcome: requestedQuote.value.outcome,
+          semanticKey,
+        });
+        requireCurrentMarketAction(actionRequest);
+        if (freshQuote.outcomeAtoms < requestedQuote.value.minOutcomeAtoms) {
           setLiveQuote(null);
           setShownQuote(null);
           throw new Error("The price moved beyond the minimum you reviewed. Get a new quote before trading.");
@@ -468,22 +611,23 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         prepared = await preparePredictionBuy({
           client: clients[0],
           deadline: tradeDeadline,
-          owner: wallet.account,
+          owner: requestedWallet.account,
           permit,
           quote: {
             ...freshQuote,
-            minOutcomeAtoms: liveQuote.value.minOutcomeAtoms,
+            minOutcomeAtoms: requestedQuote.value.minOutcomeAtoms,
           },
         });
       } else {
         const freshQuote = await quotePredictionSell({
           clients,
           config: release.config,
-          outcome: liveQuote.value.outcome,
-          outcomeAtoms: liveQuote.value.outcomeAtoms,
+          outcome: requestedQuote.value.outcome,
+          outcomeAtoms: requestedQuote.value.outcomeAtoms,
           semanticKey,
         });
-        if (freshQuote.collateralAtoms < liveQuote.value.minCollateralAtoms) {
+        requireCurrentMarketAction(actionRequest);
+        if (freshQuote.collateralAtoms < requestedQuote.value.minCollateralAtoms) {
           setLiveQuote(null);
           setShownQuote(null);
           throw new Error("The price moved beyond the minimum you reviewed. Get a new quote before trading.");
@@ -491,28 +635,40 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         prepared = await preparePredictionSell({
           client: clients[0],
           deadline: tradeDeadline,
-          owner: wallet.account,
+          owner: requestedWallet.account,
           permit,
           quote: {
             ...freshQuote,
-            minCollateralAtoms: liveQuote.value.minCollateralAtoms,
+            minCollateralAtoms: requestedQuote.value.minCollateralAtoms,
           },
         });
       }
+      requireCurrentMarketAction(actionRequest);
       setPhase("submitting");
       setMessage("Confirm the simulated market transaction in your wallet.");
       const transactionHash = await sendTransaction(prepared);
+      if (!marketActionIsCurrent(actionRequest)) return;
       setPhase("confirming");
       setMessage("Transaction submitted. Waiting for both RPCs to confirm the same receipt…");
       await waitForPredictionAction({ clients, transactionHash });
-      setMessage("Trade confirmed onchain.");
-      setLiveQuote(null);
-      setShownQuote(null);
-      await refresh();
+      if (marketActionIsCurrent(actionRequest)) {
+        setMessage("Trade confirmed onchain.");
+        setLiveQuote(null);
+        setShownQuote(null);
+        await refresh();
+      }
     } catch (error) {
-      setMessage(getErrorMessage(error));
+      if (marketActionIsCurrent(actionRequest)) {
+        setMessage(getErrorMessage(error));
+      }
     } finally {
-      setPhase("idle");
+      if (isPredictionMarketLoadRequestCurrent(
+        actionRequest,
+        activeMarketActionRequest.current,
+      )) {
+        activeMarketActionRequest.current = null;
+        setPhase("idle");
+      }
     }
   }
 
@@ -522,40 +678,69 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
       openWallet();
       return;
     }
+    const actionRequest = {
+      accountKey: wallet.account.toLowerCase(),
+      generation: ++marketActionGeneration.current,
+      semanticKey: semanticKey.toLowerCase(),
+    } satisfies PredictionMarketLoadRequestV1;
+    activeMarketActionRequest.current = actionRequest;
+    const requestedMarket = market;
+    const requestedWallet = wallet;
     const clients = createPredictionMarketPublicClients();
     try {
       setPhase("quoting");
       setMessage(action === "RESOLVE" ? "Finding the unique adjacent Chainlink rounds across both RPCs…" : "Simulating the exact lifecycle transaction…");
-      const prepared = action === "RESOLVE"
-        ? await discoverPredictionResolutionProof({
-            clients,
-            config: release.config,
-            semanticKey,
-          }).then((proof) => preparePredictionResolution({
-            client: clients[0],
-            owner: wallet.account,
-            proof,
-          }))
-        : action === "REDEEM"
-          ? await preparePredictionRedeem({ client: clients[0], market, owner: wallet.account })
-          : await preparePredictionFallbackAction({
-              action,
-              client: clients[0],
-              market,
-              owner: wallet.account,
-            });
+      let prepared;
+      if (action === "RESOLVE") {
+        const proof = await discoverPredictionResolutionProof({
+          clients,
+          config: release.config,
+          semanticKey,
+        });
+        requireCurrentMarketAction(actionRequest);
+        prepared = await preparePredictionResolution({
+          client: clients[0],
+          owner: requestedWallet.account,
+          proof,
+        });
+      } else if (action === "REDEEM") {
+        prepared = await preparePredictionRedeem({
+          client: clients[0],
+          market: requestedMarket,
+          owner: requestedWallet.account,
+        });
+      } else {
+        prepared = await preparePredictionFallbackAction({
+          action,
+          client: clients[0],
+          market: requestedMarket,
+          owner: requestedWallet.account,
+        });
+      }
+      requireCurrentMarketAction(actionRequest);
       setPhase("submitting");
       setMessage("Confirm the simulated lifecycle transaction in your wallet.");
       const transactionHash = await sendTransaction(prepared);
+      if (!marketActionIsCurrent(actionRequest)) return;
       setPhase("confirming");
       setMessage("Waiting for both RPCs to confirm the same receipt…");
       await waitForPredictionAction({ clients, transactionHash });
-      setMessage(action === "REDEEM" ? "Payout confirmed in your wallet." : "Market state updated onchain.");
-      await refresh();
+      if (marketActionIsCurrent(actionRequest)) {
+        setMessage(action === "REDEEM" ? "Payout confirmed in your wallet." : "Market state updated onchain.");
+        await refresh();
+      }
     } catch (error) {
-      setMessage(getErrorMessage(error));
+      if (marketActionIsCurrent(actionRequest)) {
+        setMessage(getErrorMessage(error));
+      }
     } finally {
-      setPhase("idle");
+      if (isPredictionMarketLoadRequestCurrent(
+        actionRequest,
+        activeMarketActionRequest.current,
+      )) {
+        activeMarketActionRequest.current = null;
+        setPhase("idle");
+      }
     }
   }
 
@@ -580,6 +765,7 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   const tradingOpen = market.state === "OPEN" && market.blockTimestamp < market.cutoff;
   const displayTitle = `Will BTC be at or above ${formatPredictionPriceAtoms(market.thresholdAtoms)}?`;
   const selectedBalance = outcome === "YES" ? market.yesBalanceAtoms : market.noBalanceAtoms;
+  const redeemableAtoms = predictionMarketRedeemableAtoms(market);
   const selectedProtocolFee = liveQuote
     ? predictionDirectionalProtocolFee(liveQuote.value.swap.protocolFee, liveQuote.value.zeroForOne)
     : 0;
@@ -736,7 +922,7 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
                       <div><span>Market depth</span><strong>{shownQuote.depthLabel}</strong></div>
                       {shownQuote.buyPayout ? <div><span>Minimum payout</span><strong>{shownQuote.buyPayout.minimumWinningPayoutLabel}</strong></div> : null}
                       {shownQuote.buyPayout ? <div><span>Minimum profit if {shownQuote.buyPayout.outcome} wins</span><strong>{shownQuote.buyPayout.minimumWinningProfitLabel}</strong></div> : null}
-                      {shownQuote.buyPayout ? <div><span>Neutral result</span><strong>{shownQuote.buyPayout.neutralPayoutLabel}</strong></div> : null}
+                      {shownQuote.buyPayout ? <div><span>Minimum neutral payout</span><strong>{shownQuote.buyPayout.minimumNeutralPayoutLabel}</strong></div> : null}
                       {shownQuote.refundLabel ? <div><span>Estimated refund</span><strong>{shownQuote.refundLabel}</strong></div> : null}
                       {shownQuote.refundLabel && shownQuote.buyPayout ? <div><span>Estimated cost after refund</span><strong>{shownQuote.buyPayout.estimatedCostLabel}</strong></div> : null}
                       <div><span>Slippage limit</span><strong>{PREDICTION_DEFAULT_SLIPPAGE_BPS / 100}%</strong></div>
@@ -774,8 +960,8 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
               <h2>{market.state === "FINAL_INVALID" ? "Neutral payout" : market.state === "FINAL_YES" ? "YES won" : "NO won"}</h2>
               <p>{market.state === "FINAL_INVALID" ? "Every YES and NO token redeems for 0.50 USDG." : "Each winning token redeems for 1 USDG. Losing tokens redeem for zero."}</p>
               {wallet ? <div className={styles.balancePair}><span>YES <strong>{formatPredictionOutcome(market.yesBalanceAtoms)}</strong></span><span>NO <strong>{formatPredictionOutcome(market.noBalanceAtoms)}</strong></span></div> : null}
-              <button className={styles.terminalAction} disabled={busy || Boolean(wallet && market.yesBalanceAtoms === 0n && market.noBalanceAtoms === 0n)} type="button" onClick={() => preview ? setMessage("Preview only. No wallet request will be made.") : wallet ? void handleLifecycle("REDEEM") : openWallet()}>
-                {busy ? "Confirming payout" : !wallet ? "Connect to redeem" : "Redeem to wallet"}
+              <button className={styles.terminalAction} disabled={busy || Boolean(wallet && redeemableAtoms === 0n)} type="button" onClick={() => preview ? setMessage("Preview only. No wallet request will be made.") : wallet ? void handleLifecycle("REDEEM") : openWallet()}>
+                {busy ? "Confirming payout" : !wallet ? "Connect to redeem" : redeemableAtoms > 0n ? "Redeem to wallet" : "No payout available"}
               </button>
             </div>
           ) : (

--- a/components/prediction-market-detail.tsx
+++ b/components/prediction-market-detail.tsx
@@ -9,7 +9,7 @@ import {
   LockKeyhole,
   RefreshCw,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import styles from "@/components/prediction-market-experience.module.css";
 import { predictionPreviewMarkets } from "@/components/prediction-market-preview";
@@ -21,13 +21,15 @@ import {
 } from "@/lib/prediction-market-chain";
 import {
   PREDICTION_DEFAULT_SLIPPAGE_BPS,
+  PREDICTION_COLLATERAL_DECIMALS,
+  applyPredictionSlippageFloor,
   discoverPredictionResolutionProof,
   formatPredictionMarketObservation,
   formatPredictionOutcome,
   formatPredictionPriceAtoms,
-  formatPredictionUsdg,
   parsePredictionBuyAmount,
   parsePredictionSellAmount,
+  predictionBuyPayoutSummary,
   predictionDirectionalProtocolFee,
   preparePredictionBuy,
   preparePredictionFallbackAction,
@@ -62,9 +64,22 @@ type LiveQuote =
   | { kind: "BUY"; value: PredictionBuyQuote }
   | { kind: "SELL"; value: PredictionSellQuote };
 
+type DisplayBuyPayout = Readonly<{
+  estimatedCostLabel: string;
+  maximumLossLabel: string;
+  minimumWinningProfitLabel: string;
+  minimumWinningPayoutLabel: string;
+  neutralPayoutLabel: string;
+  outcome: PredictionOutcome;
+  potentialProfitAtoms: bigint;
+  potentialProfitLabel: string;
+  winningPayoutLabel: string;
+}>;
+
 type DisplayQuote = Readonly<{
   afterYesBps: number;
   averagePriceBps: number;
+  buyPayout?: DisplayBuyPayout;
   depthLabel: string;
   minimumLabel: string;
   outputLabel: string;
@@ -90,6 +105,64 @@ function centsLabel(bps: number) {
   return `${(bps / 100).toFixed(1).replace(/\.0$/u, "")}¢`;
 }
 
+function traderUsdgLabel(atoms: bigint) {
+  const negative = atoms < 0n;
+  const absolute = negative ? -atoms : atoms;
+  const collateralScale = 10n ** BigInt(PREDICTION_COLLATERAL_DECIMALS);
+  const fractionDigits = absolute >= collateralScale
+    ? 2
+    : absolute >= collateralScale / 100n
+      ? 4
+      : PREDICTION_COLLATERAL_DECIMALS;
+  const roundingScale = 10n ** BigInt(PREDICTION_COLLATERAL_DECIMALS - fractionDigits);
+  const rounded = (absolute + roundingScale / 2n) / roundingScale;
+  const displayScale = 10n ** BigInt(fractionDigits);
+  const whole = (rounded / displayScale).toString();
+  const fraction = (rounded % displayScale)
+    .toString()
+    .padStart(fractionDigits, "0")
+    .replace(/0+$/u, "");
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/gu, ",");
+  return `${negative ? "−" : ""}${grouped}${fraction ? `.${fraction}` : ""} USDG`;
+}
+
+function signedUsdgLabel(atoms: bigint) {
+  if (atoms === 0n) return traderUsdgLabel(0n);
+  return `${atoms > 0n ? "+" : "−"}${traderUsdgLabel(atoms > 0n ? atoms : -atoms)}`;
+}
+
+function traderOutcomeLabel(atoms: bigint, outcome: PredictionOutcome) {
+  const [amount] = formatPredictionOutcome(atoms, outcome).split(" ");
+  const [whole, fraction] = amount.split(".");
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/gu, ",");
+  return `${grouped}${fraction ? `.${fraction}` : ""} ${outcome}`;
+}
+
+function displayBuyPayout(
+  quote: Pick<
+    PredictionBuyQuote,
+    "collateralInAtoms" | "collateralRefundAtoms" | "minOutcomeAtoms" | "outcomeAtoms"
+  >,
+  outcome: PredictionOutcome,
+): DisplayBuyPayout {
+  const payout = predictionBuyPayoutSummary(quote);
+  return {
+    estimatedCostLabel: traderUsdgLabel(payout.estimatedCostAtoms),
+    maximumLossLabel: traderUsdgLabel(payout.maximumLossAtoms),
+    minimumWinningProfitLabel: signedUsdgLabel(
+      payout.minimumWinningProfitAtoms,
+    ),
+    minimumWinningPayoutLabel: traderUsdgLabel(
+      payout.minimumWinningPayoutAtoms,
+    ),
+    neutralPayoutLabel: traderUsdgLabel(payout.neutralPayoutAtoms),
+    outcome,
+    potentialProfitAtoms: payout.potentialProfitAtoms,
+    potentialProfitLabel: signedUsdgLabel(payout.potentialProfitAtoms),
+    winningPayoutLabel: traderUsdgLabel(payout.winningPayoutAtoms),
+  };
+}
+
 function utcDate(timestamp: bigint) {
   return formatPredictionMarketObservation(timestamp);
 }
@@ -110,18 +183,19 @@ function displayQuote(quote: LiveQuote): DisplayQuote {
     return {
       afterYesBps: quote.value.probabilityAfterBps,
       averagePriceBps: quote.value.averagePriceBps,
+      buyPayout: displayBuyPayout(quote.value, quote.value.outcome),
       depthLabel: quoteDepthLabel(quote.value.priceImpactBps),
-      minimumLabel: formatPredictionOutcome(
+      minimumLabel: traderOutcomeLabel(
         quote.value.minOutcomeAtoms,
         quote.value.outcome,
       ),
-      outputLabel: formatPredictionOutcome(
+      outputLabel: traderOutcomeLabel(
         quote.value.outcomeAtoms,
         quote.value.outcome,
       ),
       priceImpactBps: quote.value.priceImpactBps,
       ...(quote.value.collateralRefundAtoms
-        ? { refundLabel: formatPredictionUsdg(quote.value.collateralRefundAtoms) }
+        ? { refundLabel: traderUsdgLabel(quote.value.collateralRefundAtoms) }
         : {}),
     };
   }
@@ -129,8 +203,8 @@ function displayQuote(quote: LiveQuote): DisplayQuote {
     afterYesBps: quote.value.probabilityAfterBps,
     averagePriceBps: quote.value.averagePriceBps,
     depthLabel: quoteDepthLabel(quote.value.priceImpactBps),
-    minimumLabel: formatPredictionUsdg(quote.value.minCollateralAtoms),
-    outputLabel: formatPredictionUsdg(quote.value.collateralAtoms),
+    minimumLabel: traderUsdgLabel(quote.value.minCollateralAtoms),
+    outputLabel: traderUsdgLabel(quote.value.collateralAtoms),
     priceImpactBps: quote.value.priceImpactBps,
     ...(quote.value.soldRefundAtoms || quote.value.complementRefundAtoms
       ? {
@@ -177,12 +251,23 @@ function previewQuote(
   const afterYesBps = outcome === "YES" ? selectedAfter : 10_000 - selectedAfter;
   if (mode === "BUY") {
     const outputAtoms = amountAtoms * 10_000n / (BigInt(averagePriceBps) * 10n);
+    const minOutcomeAtoms = applyPredictionSlippageFloor(
+      outputAtoms,
+      PREDICTION_DEFAULT_SLIPPAGE_BPS,
+    );
+    const payoutQuote = {
+      collateralInAtoms: amountAtoms,
+      collateralRefundAtoms: 0n,
+      minOutcomeAtoms,
+      outcomeAtoms: outputAtoms,
+    };
     return {
       afterYesBps,
       averagePriceBps,
+      buyPayout: displayBuyPayout(payoutQuote, outcome),
       depthLabel: quoteDepthLabel(impact),
-      minimumLabel: formatPredictionOutcome(outputAtoms * 9_950n / 10_000n, outcome),
-      outputLabel: formatPredictionOutcome(outputAtoms, outcome),
+      minimumLabel: traderOutcomeLabel(minOutcomeAtoms, outcome),
+      outputLabel: traderOutcomeLabel(outputAtoms, outcome),
       priceImpactBps: impact,
     };
   }
@@ -191,8 +276,8 @@ function previewQuote(
     afterYesBps,
     averagePriceBps,
     depthLabel: quoteDepthLabel(impact),
-    minimumLabel: formatPredictionUsdg(outputAtoms * 9_950n / 10_000n),
-    outputLabel: formatPredictionUsdg(outputAtoms),
+    minimumLabel: traderUsdgLabel(outputAtoms * 9_950n / 10_000n),
+    outputLabel: traderUsdgLabel(outputAtoms),
     priceImpactBps: impact,
   };
 }
@@ -215,8 +300,12 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   const [shownQuote, setShownQuote] = useState<DisplayQuote | null>(null);
   const [phase, setPhase] = useState<"idle" | "quoting" | "signing" | "submitting" | "confirming">("idle");
   const [message, setMessage] = useState("");
+  const quoteRequestId = useRef(0);
 
   const refresh = useCallback(async () => {
+    quoteRequestId.current += 1;
+    setLiveQuote(null);
+    setShownQuote(null);
     await Promise.resolve();
     if (!release.config) {
       const market = predictionPreviewMarkets(Math.floor(Date.now() / 1_000)).find(
@@ -254,6 +343,7 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   const busy = phase !== "idle";
 
   function clearQuote() {
+    quoteRequestId.current += 1;
     setLiveQuote(null);
     setShownQuote(null);
     setMessage("");
@@ -261,41 +351,56 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
 
   async function handleQuote() {
     if (!market || busy) return;
+    const requestId = ++quoteRequestId.current;
+    const requestedAmount = amount;
+    const requestedMarket = market;
+    const requestedMode = mode;
+    const requestedOutcome = outcome;
     setPhase("quoting");
     setMessage(preview ? "Checking the preview price…" : "Finding your price…");
     try {
+      let nextLiveQuote: LiveQuote | null = null;
+      let nextShownQuote: DisplayQuote;
       if (preview || !release.config) {
-        setShownQuote(previewQuote(market, mode, outcome, amount));
-        setLiveQuote(null);
-      } else if (mode === "BUY") {
-        const collateralAtoms = parsePredictionBuyAmount(amount);
+        nextShownQuote = previewQuote(
+          requestedMarket,
+          requestedMode,
+          requestedOutcome,
+          requestedAmount,
+        );
+      } else if (requestedMode === "BUY") {
+        const collateralAtoms = parsePredictionBuyAmount(requestedAmount);
         if (collateralAtoms === null) throw new Error("Enter a positive USDG amount with no more than five decimals");
         const quote = await quotePredictionBuy({
           collateralAtoms,
           config: release.config,
-          outcome,
+          outcome: requestedOutcome,
           semanticKey,
         });
-        const wrapped = { kind: "BUY" as const, value: quote };
-        setLiveQuote(wrapped);
-        setShownQuote(displayQuote(wrapped));
+        nextLiveQuote = { kind: "BUY", value: quote };
+        nextShownQuote = displayQuote(nextLiveQuote);
       } else {
-        const outcomeAtoms = parsePredictionSellAmount(amount);
+        const outcomeAtoms = parsePredictionSellAmount(requestedAmount);
         if (outcomeAtoms === null) throw new Error("Enter a positive token amount with no more than five decimals");
-        const balance = outcome === "YES" ? market.yesBalanceAtoms : market.noBalanceAtoms;
-        if (wallet && outcomeAtoms > balance) throw new Error(`Your wallet does not hold enough ${outcome}`);
+        const balance = requestedOutcome === "YES"
+          ? requestedMarket.yesBalanceAtoms
+          : requestedMarket.noBalanceAtoms;
+        if (wallet && outcomeAtoms > balance) throw new Error(`Your wallet does not hold enough ${requestedOutcome}`);
         const quote = await quotePredictionSell({
           config: release.config,
-          outcome,
+          outcome: requestedOutcome,
           outcomeAtoms,
           semanticKey,
         });
-        const wrapped = { kind: "SELL" as const, value: quote };
-        setLiveQuote(wrapped);
-        setShownQuote(displayQuote(wrapped));
+        nextLiveQuote = { kind: "SELL", value: quote };
+        nextShownQuote = displayQuote(nextLiveQuote);
       }
+      if (requestId !== quoteRequestId.current) return;
+      setLiveQuote(nextLiveQuote);
+      setShownQuote(nextShownQuote);
       setMessage(preview ? "Preview only. No wallet request will be made." : "Quote reconciled at one confirmed block. Review the minimum before submitting.");
     } catch (error) {
+      if (requestId !== quoteRequestId.current) return;
       setLiveQuote(null);
       setShownQuote(null);
       setMessage(getErrorMessage(error));
@@ -478,6 +583,11 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   const selectedProtocolFee = liveQuote
     ? predictionDirectionalProtocolFee(liveQuote.value.swap.protocolFee, liveQuote.value.zeroForOne)
     : 0;
+  const orderAnnouncement = shownQuote?.buyPayout
+    ? `Potential payout ${shownQuote.buyPayout.winningPayoutLabel} if ${shownQuote.buyPayout.outcome} wins, based on the current quote; potential profit ${shownQuote.buyPayout.potentialProfitLabel}; max market loss ${shownQuote.buyPayout.maximumLossLabel}; network fee excluded.`
+    : shownQuote
+      ? `Estimated proceeds ${shownQuote.outputLabel}; minimum proceeds ${shownQuote.minimumLabel}.`
+      : "";
   const lifecycleAction = market.checkpointStatus !== "AWAITING" && market.state === "OPEN"
     ? "FINALIZE_CHECKPOINT"
     : market.fallbackChallengeDeadline && market.blockTimestamp > market.fallbackChallengeDeadline
@@ -562,38 +672,76 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
                 <h2>Trade</h2>
                 {preview ? <span>Preview</span> : null}
               </div>
-              <div className={styles.modeTabs} role="tablist" aria-label="Trade direction">
+              <div className={styles.modeTabs} role="group" aria-label="Trade direction">
                 {(["BUY", "SELL"] as const).map((value) => (
-                  <button key={value} type="button" role="tab" aria-selected={mode === value} className={mode === value ? styles.activeMode : ""} onClick={() => { setMode(value); clearQuote(); }}>{value}</button>
+                  <button key={value} type="button" disabled={busy} aria-pressed={mode === value} className={mode === value ? styles.activeMode : ""} onClick={() => { setMode(value); clearQuote(); }}>{value}</button>
                 ))}
               </div>
-              <div className={styles.outcomeToggle}>
+              <div className={styles.outcomeToggle} role="group" aria-label="Outcome">
                 {(["YES", "NO"] as const).map((value) => (
-                  <button key={value} type="button" className={outcome === value ? (value === "YES" ? styles.yesSelected : styles.noSelected) : ""} onClick={() => { setOutcome(value); clearQuote(); }}>
+                  <button key={value} type="button" disabled={busy} aria-pressed={outcome === value} className={outcome === value ? (value === "YES" ? styles.yesSelected : styles.noSelected) : ""} onClick={() => { setOutcome(value); clearQuote(); }}>
                     <span>{value}</span><strong>{centsLabel(value === "YES" ? market.probabilityYesBps : 10_000 - market.probabilityYesBps)}</strong>
                   </button>
                 ))}
               </div>
               <label className={styles.amountField}>
                 <span>{mode === "BUY" ? "You pay" : "You sell"}</span>
-                <span><input inputMode="decimal" value={amount} onChange={(event) => { setAmount(event.target.value); clearQuote(); }} aria-label={mode === "BUY" ? "USDG amount" : `${outcome} amount`} /><strong>{mode === "BUY" ? "USDG" : outcome}</strong></span>
+                <span><input inputMode="decimal" disabled={busy} value={amount} onChange={(event) => { setAmount(event.target.value); clearQuote(); }} aria-label={mode === "BUY" ? "USDG amount" : `${outcome} amount`} /><strong>{mode === "BUY" ? "USDG" : outcome}</strong></span>
                 {mode === "SELL" && wallet ? <small>Balance {formatPredictionOutcome(selectedBalance, outcome)}</small> : null}
               </label>
 
               {shownQuote ? (
-                <div className={styles.quoteReceipt} aria-live="polite">
-                  <div><span>You receive</span><strong>{shownQuote.outputLabel}</strong></div>
-                  <div><span>Minimum received</span><strong>{shownQuote.minimumLabel}</strong></div>
-                  <div><span>Average price</span><strong>{centsLabel(shownQuote.averagePriceBps)}</strong></div>
-                  <div><span>Trading fee</span><strong>0.02%{selectedProtocolFee ? ` + ${selectedProtocolFee / 100} bps protocol` : ""}</strong></div>
-                  <details className={styles.quoteDetails}>
-                    <summary>Price details</summary>
-                    <div><span>YES chance after trade</span><strong>{probabilityLabel(shownQuote.afterYesBps)}</strong></div>
-                    <div><span>Price impact</span><strong>{probabilityLabel(shownQuote.priceImpactBps)}</strong></div>
-                    <div><span>Market depth</span><strong>{shownQuote.depthLabel}</strong></div>
-                    {shownQuote.refundLabel ? <div><span>Refund</span><strong>{shownQuote.refundLabel}</strong></div> : null}
-                    <div><span>Slippage limit</span><strong>{PREDICTION_DEFAULT_SLIPPAGE_BPS / 100}%</strong></div>
-                  </details>
+                <div className={styles.orderPreview}>
+                  <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+                    {orderAnnouncement}
+                  </p>
+                  {shownQuote.buyPayout ? (
+                    <section
+                      className={styles.payoutSummary}
+                      data-outcome={shownQuote.buyPayout.outcome}
+                      aria-label="Potential payout"
+                    >
+                      <div className={styles.payoutHeadline}>
+                        <span>Potential payout</span>
+                        <strong>{shownQuote.buyPayout.winningPayoutLabel}</strong>
+                        <small>
+                          This order if {shownQuote.buyPayout.outcome} wins, based
+                          {" "}on the current quote. Trading fees included;
+                          {" "}network fee excluded.
+                        </small>
+                      </div>
+                      <dl className={styles.payoutMetrics}>
+                        <div>
+                          <dt>Potential profit</dt>
+                          <dd data-tone={shownQuote.buyPayout.potentialProfitAtoms >= 0n ? "positive" : "negative"}>
+                            {shownQuote.buyPayout.potentialProfitLabel}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt>Max market loss</dt>
+                          <dd>{shownQuote.buyPayout.maximumLossLabel}</dd>
+                        </div>
+                      </dl>
+                    </section>
+                  ) : null}
+                  <div className={styles.quoteReceipt}>
+                    <div><span>{shownQuote.buyPayout ? "Shares received" : "Estimated proceeds"}</span><strong>{shownQuote.outputLabel}</strong></div>
+                    <div><span>{shownQuote.buyPayout ? "Minimum shares" : "Minimum proceeds"}</span><strong>{shownQuote.minimumLabel}</strong></div>
+                    <div><span>Average price</span><strong>{centsLabel(shownQuote.averagePriceBps)}</strong></div>
+                    <div><span>Trading fee</span><strong>0.02%{selectedProtocolFee ? ` + ${selectedProtocolFee / 100} bps protocol` : ""}</strong></div>
+                    <details className={styles.quoteDetails}>
+                      <summary>Price details</summary>
+                      <div><span>YES chance after trade</span><strong>{probabilityLabel(shownQuote.afterYesBps)}</strong></div>
+                      <div><span>Price impact</span><strong>{probabilityLabel(shownQuote.priceImpactBps)}</strong></div>
+                      <div><span>Market depth</span><strong>{shownQuote.depthLabel}</strong></div>
+                      {shownQuote.buyPayout ? <div><span>Minimum payout</span><strong>{shownQuote.buyPayout.minimumWinningPayoutLabel}</strong></div> : null}
+                      {shownQuote.buyPayout ? <div><span>Minimum profit if {shownQuote.buyPayout.outcome} wins</span><strong>{shownQuote.buyPayout.minimumWinningProfitLabel}</strong></div> : null}
+                      {shownQuote.buyPayout ? <div><span>Neutral result</span><strong>{shownQuote.buyPayout.neutralPayoutLabel}</strong></div> : null}
+                      {shownQuote.refundLabel ? <div><span>Estimated refund</span><strong>{shownQuote.refundLabel}</strong></div> : null}
+                      {shownQuote.refundLabel && shownQuote.buyPayout ? <div><span>Estimated cost after refund</span><strong>{shownQuote.buyPayout.estimatedCostLabel}</strong></div> : null}
+                      <div><span>Slippage limit</span><strong>{PREDICTION_DEFAULT_SLIPPAGE_BPS / 100}%</strong></div>
+                    </details>
+                  </div>
                 </div>
               ) : null}
 
@@ -609,7 +757,7 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
               >
                 {busy
                   ? phase === "signing" ? "Sign in wallet" : phase === "confirming" ? "Confirming" : "Getting price"
-                  : !shownQuote ? preview ? "Preview price" : "Review price"
+                  : !shownQuote ? preview ? "Preview order" : "Review order"
                   : preview ? "Update preview"
                   : !wallet ? "Connect wallet"
                   : `${mode} ${outcome}`}

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -981,7 +981,6 @@
 .portfolioRefresh,
 .portfolioPrimaryAction,
 .portfolioSecondaryAction,
-.portfolioLoadMore,
 .portfolioError button,
 .portfolioInlineError button,
 .portfolioCardActions a {
@@ -1007,8 +1006,7 @@
   padding-inline: 11px;
 }
 
-.portfolioRefresh:disabled,
-.portfolioLoadMore:disabled {
+.portfolioRefresh:disabled {
   cursor: default;
   opacity: 0.42;
 }
@@ -1439,30 +1437,11 @@
   overflow-wrap: break-word;
 }
 
-.portfolioLoadMore {
-  background: transparent;
-  border: 1px solid var(--webde-line, var(--profile-line, var(--border)));
-  border-radius: 10px;
-  color: var(--text-soft, rgb(255 255 255 / 72%));
-  cursor: pointer;
-  margin-block-start: 10px;
-  width: 100%;
-}
-
-.portfolioLoadMoreError {
-  color: var(--danger, #ff9d9d);
-  font-size: 12px;
-  line-height: 1.45;
-  margin: 10px 0 0;
-  text-wrap: pretty;
-}
-
 .portfolioRefresh:focus-visible,
 .portfolioTabs button:focus-visible,
 .portfolioTabPanel:focus-visible,
 .portfolioPrimaryAction:focus-visible,
 .portfolioSecondaryAction:focus-visible,
-.portfolioLoadMore:focus-visible,
 .portfolioError button:focus-visible,
 .portfolioInlineError button:focus-visible,
 .portfolioCardCopy h3 a:focus-visible,
@@ -1474,7 +1453,6 @@
 @media (hover: hover) and (pointer: fine) {
   .portfolioRefresh:not(:disabled):hover,
   .portfolioSecondaryAction:hover,
-  .portfolioLoadMore:not(:disabled):hover,
   .portfolioInlineError button:hover,
   .portfolioCardActions a[data-tone="quiet"]:hover {
     background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
@@ -1500,7 +1478,6 @@
   .portfolioRefresh,
   .portfolioPrimaryAction,
   .portfolioSecondaryAction,
-  .portfolioLoadMore,
   .portfolioError button,
   .portfolioInlineError button,
   .portfolioCardActions a {
@@ -1516,7 +1493,6 @@
   .portfolioRefresh:not(:disabled):active,
   .portfolioPrimaryAction:active,
   .portfolioSecondaryAction:active,
-  .portfolioLoadMore:not(:disabled):active,
   .portfolioError button:active,
   .portfolioInlineError button:active,
   .portfolioCardActions a:active {

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -567,7 +567,7 @@
   border-radius: 7px;
   font-size: 13px;
   font-weight: 600;
-  min-height: 42px;
+  min-height: 44px;
 }
 
 .modeTabs .activeMode {
@@ -633,6 +633,11 @@
   border-bottom: 1px solid var(--border-strong);
   display: flex;
   min-height: 60px;
+}
+
+.amountField > span:nth-child(2):focus-within {
+  border-bottom-color: var(--focus);
+  box-shadow: 0 2px 0 var(--focus);
 }
 
 .amountField input {
@@ -776,9 +781,12 @@
 }
 
 .quoteDetails summary {
+  align-items: center;
   color: var(--webde-muted);
   cursor: pointer;
+  display: flex;
   font-size: 12px;
+  min-height: 44px;
   list-style-position: inside;
 }
 
@@ -863,6 +871,8 @@
   gap: 6px;
   justify-content: center;
   margin: 14px auto 0;
+  min-height: 44px;
+  padding: 0 10px;
 }
 
 .settlementTerminal {
@@ -1223,6 +1233,24 @@
   min-width: 0;
 }
 
+.portfolioShowMore {
+  align-items: center;
+  background: transparent;
+  border: 1px solid var(--profile-line, var(--border));
+  border-radius: 9px;
+  color: var(--text-soft, rgb(255 255 255 / 72%));
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  justify-content: center;
+  margin: 12px auto 0;
+  min-height: 44px;
+  padding: 0 16px;
+  width: fit-content;
+}
+
 .portfolioHoldings > span {
   align-items: baseline;
   border-inline-start: 2px solid var(--portfolio-yes);
@@ -1446,7 +1474,12 @@
 .portfolioInlineError button:focus-visible,
 .portfolioCardCopy h3 a:focus-visible,
 .portfolioCardActions a:focus-visible {
-  outline: 2px solid #8fc5ff;
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.portfolioShowMore:focus-visible {
+  outline: 2px solid var(--focus);
   outline-offset: 2px;
 }
 
@@ -1455,6 +1488,12 @@
   .portfolioSecondaryAction:hover,
   .portfolioInlineError button:hover,
   .portfolioCardActions a[data-tone="quiet"]:hover {
+    background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+    border-color: var(--border-strong, rgb(255 255 255 / 18%));
+    color: var(--text, #fff);
+  }
+
+  .portfolioShowMore:hover {
     background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
     border-color: var(--border-strong, rgb(255 255 255 / 18%));
     color: var(--text, #fff);
@@ -1490,12 +1529,26 @@
       transform 120ms ease-out;
   }
 
+
+  .portfolioShowMore {
+    transition:
+      background-color 150ms ease,
+      border-color 150ms ease,
+      color 150ms ease,
+      transform 120ms ease-out;
+  }
+
   .portfolioRefresh:not(:disabled):active,
   .portfolioPrimaryAction:active,
   .portfolioSecondaryAction:active,
   .portfolioError button:active,
   .portfolioInlineError button:active,
   .portfolioCardActions a:active {
+    transform: scale(0.96);
+  }
+
+
+  .portfolioShowMore:active {
     transform: scale(0.96);
   }
 }

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -932,115 +932,596 @@
 }
 
 .portfolioSection {
-  margin: clamp(54px, 8vw, 96px) auto 0;
-  max-width: 1180px;
-  width: min(calc(100% - 32px), 1180px);
+  --portfolio-no: #e58d96;
+  --portfolio-pending: #e6b46f;
+  --portfolio-yes: #72d3a4;
+  background: var(--webde-surface, var(--profile-panel, var(--surface-raised)));
+  border: 1px solid var(--webde-line, var(--profile-line, var(--border)));
+  border-radius: var(--webde-radius-card, 17px);
+  margin-block: 1rem;
+  min-width: 0;
+  padding: 20px;
+  width: 100%;
 }
 
-.portfolioSection > header {
-  align-items: flex-end;
+.portfolioHeading {
+  align-items: center;
   display: flex;
+  gap: 14px;
   justify-content: space-between;
-  margin-bottom: 18px;
+  margin-block-end: 12px;
+  min-width: 0;
 }
 
-.portfolioSection > header > div {
+.portfolioHeading > div {
   display: grid;
-  gap: 7px;
+  gap: 3px;
+  min-width: 0;
 }
 
-.portfolioSection h2 {
-  color: var(--text);
-  font-size: clamp(27px, 3vw, 38px);
+.portfolioEyebrow {
+  color: var(--muted, rgb(255 255 255 / 52%));
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 11px;
   font-weight: 560;
-  letter-spacing: -0.04em;
+  letter-spacing: 0.045em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.portfolioHeading h2 {
+  color: var(--text);
+  font-size: 20px;
+  font-weight: 640;
+  letter-spacing: -0.026em;
+  line-height: 1.1;
   margin: 0;
 }
 
-.portfolioSection > header > a {
+.portfolioRefresh,
+.portfolioPrimaryAction,
+.portfolioSecondaryAction,
+.portfolioLoadMore,
+.portfolioError button,
+.portfolioInlineError button,
+.portfolioCardActions a {
   align-items: center;
-  color: var(--muted);
   display: inline-flex;
+  font: inherit;
   font-size: 12px;
+  font-weight: 620;
+  justify-content: center;
+  min-height: 44px;
+  text-decoration: none;
+  touch-action: manipulation;
+}
+
+.portfolioRefresh {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  color: var(--text-soft, rgb(255 255 255 / 72%));
+  cursor: pointer;
+  flex: none;
+  gap: 7px;
+  padding-inline: 11px;
+}
+
+.portfolioRefresh:disabled,
+.portfolioLoadMore:disabled {
+  cursor: default;
+  opacity: 0.42;
+}
+
+.portfolioTabs {
+  background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+  border-radius: 12px;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 4px;
+}
+
+.portfolioTabs button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  color: var(--muted, rgb(255 255 255 / 56%));
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 620;
   gap: 6px;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 0;
+  padding-inline: 10px;
+  touch-action: manipulation;
+}
+
+.portfolioTabs button[aria-selected="true"] {
+  background: var(--brand-ivory, #f0eee8);
+  box-shadow:
+    0 0 0 1px rgb(0 0 0 / 7%),
+    0 1px 2px rgb(0 0 0 / 12%);
+  color: #0a0a0c;
+}
+
+.portfolioTabs small {
+  align-items: center;
+  background: rgb(255 255 255 / 8%);
+  border-radius: 999px;
+  display: inline-flex;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  justify-content: center;
+  line-height: 1;
+  min-height: 20px;
+  min-width: 20px;
+  padding-inline: 5px;
+}
+
+.portfolioTabs button[aria-selected="true"] small {
+  background: rgb(10 10 12 / 8%);
+}
+
+.portfolioTabPanel {
+  min-width: 0;
+  padding-block-start: 12px;
+}
+
+.portfolioCards {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.portfolioCard {
+  align-items: center;
+  background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+  border-radius: 13px;
+  box-shadow: 0 0 0 1px var(--webde-line, var(--profile-line, var(--border)));
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 58px minmax(210px, 1.35fr) minmax(220px, 0.9fr) auto;
+  min-width: 0;
+  padding: 10px;
+}
+
+.portfolioArtwork {
+  --portfolio-probability: 50%;
+  align-items: center;
+  align-self: start;
+  background: conic-gradient(
+    from -90deg,
+    var(--portfolio-yes) 0 var(--portfolio-probability),
+    var(--portfolio-no) var(--portfolio-probability) 100%
+  );
+  border-radius: 15px;
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 10%),
+    0 1px 2px rgb(0 0 0 / 10%);
+  color: var(--text, #fff);
+  display: flex;
+  flex-direction: column;
+  height: 58px;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+  width: 58px;
+}
+
+.portfolioArtwork::before {
+  background: color-mix(
+    in srgb,
+    var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft))) 94%,
+    transparent
+  );
+  border-radius: 9px;
+  content: "";
+  inset: 7px;
+  position: absolute;
+}
+
+.portfolioArtwork span,
+.portfolioArtwork strong {
+  font-family: var(--font-plex-mono), monospace;
+  font-variant-numeric: tabular-nums;
+  position: relative;
+  z-index: 1;
+}
+
+.portfolioArtwork span {
+  color: var(--muted, rgb(255 255 255 / 58%));
+  font-size: 11px;
+  font-weight: 640;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+.portfolioArtwork strong {
+  font-size: 13px;
+  font-weight: 680;
+  line-height: 1.15;
+  margin-block-start: 3px;
+}
+
+.portfolioCardCopy {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.portfolioCardStatus {
+  align-items: center;
+  color: var(--text-soft, rgb(255 255 255 / 68%));
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 11px;
+  gap: 3px 10px;
+  line-height: 1.35;
+  min-width: 0;
+}
+
+.portfolioCardStatus > span {
+  align-items: center;
+  display: inline-flex;
+  font-weight: 620;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.portfolioCardStatus > span::before {
+  background: currentcolor;
+  border-radius: 999px;
+  content: "";
+  flex: none;
+  height: 5px;
+  width: 5px;
+}
+
+.portfolioCardStatus[data-tone="open"] > span {
+  color: var(--portfolio-yes);
+}
+
+.portfolioCardStatus[data-tone="pending"] > span {
+  color: var(--portfolio-pending);
+}
+
+.portfolioCardStatus[data-tone="final"] > span {
+  color: var(--text-soft, rgb(255 255 255 / 76%));
+}
+
+.portfolioCardStatus small {
+  color: var(--muted, rgb(255 255 255 / 52%));
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.portfolioCardCopy h3 {
+  font-size: 13px;
+  font-weight: 640;
+  letter-spacing: -0.012em;
+  line-height: 1.4;
+  margin: 0;
+  min-width: 0;
+  text-wrap: pretty;
+}
+
+.portfolioCardCopy h3 a {
+  color: var(--text, #fff);
   text-decoration: none;
 }
 
+.portfolioHoldings {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 14px;
+  min-width: 0;
+}
+
+.portfolioHoldings > span {
+  align-items: baseline;
+  border-inline-start: 2px solid var(--portfolio-yes);
+  display: inline-flex;
+  gap: 6px;
+  min-width: 0;
+  padding-inline-start: 7px;
+}
+
+.portfolioHoldings > span[data-outcome="NO"] {
+  border-inline-start-color: var(--portfolio-no);
+}
+
+.portfolioHoldings strong,
+.portfolioHoldings small,
+.portfolioHoldings > small {
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.3;
+}
+
+.portfolioHoldings strong {
+  color: var(--text-soft, rgb(255 255 255 / 72%));
+}
+
+.portfolioHoldings small,
+.portfolioHoldings > small {
+  color: var(--muted, rgb(255 255 255 / 54%));
+  overflow-wrap: anywhere;
+}
+
+.portfolioMetrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(90px, 0.65fr) minmax(132px, 1.35fr);
+  margin: 0;
+  min-width: 0;
+}
+
+.portfolioMetrics > div {
+  border-inline-start: 1px solid var(--webde-line, var(--profile-line, var(--border)));
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  padding-inline-start: 12px;
+}
+
+.portfolioMetrics dt {
+  color: var(--muted, rgb(255 255 255 / 52%));
+  font-size: 11px;
+  font-weight: 520;
+  line-height: 1.3;
+}
+
+.portfolioMetrics dd {
+  color: var(--text, #fff);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 640;
+  line-height: 1.35;
+  margin: 2px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.portfolioMetrics > div[data-tone="ready"] dd {
+  color: var(--portfolio-yes);
+}
+
+.portfolioMetrics > div[data-tone="pending"] dd {
+  color: var(--portfolio-pending);
+}
+
+.portfolioMetrics small {
+  color: var(--muted, rgb(255 255 255 / 52%));
+  font-size: 11px;
+  line-height: 1.4;
+  margin-block-start: 3px;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+
+.portfolioCardActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.portfolioCardActions a {
+  border: 1px solid var(--webde-line, var(--profile-line, var(--border)));
+  border-radius: 10px;
+  color: var(--text-soft, rgb(255 255 255 / 72%));
+  gap: 6px;
+  padding-inline: 13px 11px;
+  white-space: nowrap;
+}
+
+.portfolioCardActions a[data-tone="primary"] {
+  background: var(--brand-ivory, #f0eee8);
+  border-color: var(--brand-ivory, #f0eee8);
+  color: #0a0a0c;
+}
+
 .portfolioEmpty,
-.portfolioConnect {
+.portfolioError {
   align-items: center;
   background: transparent;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  color: var(--muted);
-  display: flex;
-  font: inherit;
-  font-size: 13px;
+  border-radius: 11px;
+  box-shadow: 0 0 0 1px var(--webde-line, var(--profile-line, var(--border)));
+  display: grid;
   gap: 12px;
-  min-height: 98px;
-  padding: 20px;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
+  min-height: 92px;
+  padding: 14px;
   width: 100%;
 }
 
 .portfolioEmpty > span {
   display: grid;
   gap: 4px;
+  min-width: 0;
 }
 
-.portfolioEmpty strong {
-  color: var(--text);
-}
-
-.portfolioEmpty small {
-  color: var(--muted);
-}
-
-.portfolioConnect {
-  cursor: pointer;
-  justify-content: center;
-}
-
-.positionRows + .portfolioConnect,
-.portfolioEmpty + .portfolioConnect {
-  margin-top: 12px;
-}
-
-.positionRows {
-  border-top: 1px solid var(--border-strong);
-}
-
-.positionRows > a {
-  align-items: center;
-  border-bottom: 1px solid var(--border);
-  color: inherit;
-  display: grid;
-  gap: 18px;
-  grid-template-columns: minmax(0, 1fr) 110px 110px 20px;
-  min-height: 84px;
-  padding: 14px 4px;
-  text-decoration: none;
-}
-
-.positionRows > a > span {
-  display: grid;
-  gap: 4px;
-}
-
-.positionRows > a > span:not(:first-child) {
-  text-align: right;
-}
-
-.positionRows strong {
+.portfolioEmpty strong,
+.portfolioError strong {
   color: var(--text);
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 640;
+  line-height: 1.35;
 }
 
-.positionRows small {
-  color: var(--dim);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 9px;
-  text-transform: uppercase;
+.portfolioEmpty small,
+.portfolioError small {
+  color: var(--muted, rgb(255 255 255 / 54%));
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+
+.portfolioEmptyIcon {
+  align-items: center;
+  background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+  border-radius: 10px;
+  color: var(--text-soft, rgb(255 255 255 / 68%));
+  display: inline-flex !important;
+  height: 44px;
+  justify-content: center;
+  width: 44px;
+}
+
+.portfolioEmptyAction {
+  display: flex;
+  flex: none;
+}
+
+.portfolioPrimaryAction,
+.portfolioSecondaryAction,
+.portfolioError button,
+.portfolioInlineError button {
+  border-radius: 10px;
+  cursor: pointer;
+  padding-inline: 14px;
+  white-space: nowrap;
+}
+
+.portfolioPrimaryAction,
+.portfolioError button {
+  background: var(--brand-ivory, #f0eee8);
+  border: 1px solid var(--brand-ivory, #f0eee8);
+  color: #0a0a0c;
+}
+
+.portfolioSecondaryAction,
+.portfolioInlineError button {
+  background: transparent;
+  border: 1px solid var(--webde-line, var(--profile-line, var(--border)));
+  color: var(--text-soft, rgb(255 255 255 / 72%));
+}
+
+.portfolioError {
+  border: 1px solid color-mix(in srgb, var(--danger, #ff8888) 34%, transparent);
+  box-shadow: none;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.portfolioError > span {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.portfolioInlineError {
+  align-items: center;
+  background: color-mix(in srgb, var(--danger, #ff8888) 7%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger, #ff8888) 28%, transparent);
+  border-radius: 10px;
+  color: var(--text-soft, rgb(255 255 255 / 76%));
+  display: flex;
+  font-size: 12px;
+  gap: 12px;
+  justify-content: space-between;
+  line-height: 1.45;
+  margin-block-end: 10px;
+  min-width: 0;
+  padding: 10px 10px 10px 12px;
+}
+
+.portfolioInlineError span {
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+.portfolioLoadMore {
+  background: transparent;
+  border: 1px solid var(--webde-line, var(--profile-line, var(--border)));
+  border-radius: 10px;
+  color: var(--text-soft, rgb(255 255 255 / 72%));
+  cursor: pointer;
+  margin-block-start: 10px;
+  width: 100%;
+}
+
+.portfolioLoadMoreError {
+  color: var(--danger, #ff9d9d);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 10px 0 0;
+  text-wrap: pretty;
+}
+
+.portfolioRefresh:focus-visible,
+.portfolioTabs button:focus-visible,
+.portfolioTabPanel:focus-visible,
+.portfolioPrimaryAction:focus-visible,
+.portfolioSecondaryAction:focus-visible,
+.portfolioLoadMore:focus-visible,
+.portfolioError button:focus-visible,
+.portfolioInlineError button:focus-visible,
+.portfolioCardCopy h3 a:focus-visible,
+.portfolioCardActions a:focus-visible {
+  outline: 2px solid #8fc5ff;
+  outline-offset: 2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .portfolioRefresh:not(:disabled):hover,
+  .portfolioSecondaryAction:hover,
+  .portfolioLoadMore:not(:disabled):hover,
+  .portfolioInlineError button:hover,
+  .portfolioCardActions a[data-tone="quiet"]:hover {
+    background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+    border-color: var(--border-strong, rgb(255 255 255 / 18%));
+    color: var(--text, #fff);
+  }
+
+  .portfolioPrimaryAction:hover,
+  .portfolioError button:hover,
+  .portfolioCardActions a[data-tone="primary"]:hover {
+    filter: brightness(0.94);
+  }
+
+  .portfolioCardCopy h3 a:hover {
+    text-decoration: underline;
+    text-decoration-skip-ink: auto;
+    text-decoration-thickness: from-font;
+    text-underline-offset: 0.18em;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .portfolioRefresh,
+  .portfolioPrimaryAction,
+  .portfolioSecondaryAction,
+  .portfolioLoadMore,
+  .portfolioError button,
+  .portfolioInlineError button,
+  .portfolioCardActions a {
+    transition:
+      background-color 150ms ease,
+      border-color 150ms ease,
+      color 150ms ease,
+      filter 150ms ease,
+      opacity 150ms ease,
+      transform 120ms ease-out;
+  }
+
+  .portfolioRefresh:not(:disabled):active,
+  .portfolioPrimaryAction:active,
+  .portfolioSecondaryAction:active,
+  .portfolioLoadMore:not(:disabled):active,
+  .portfolioError button:active,
+  .portfolioInlineError button:active,
+  .portfolioCardActions a:active {
+    transform: scale(0.96);
+  }
 }
 
 .detailError {
@@ -1071,6 +1552,34 @@
     position: static;
   }
 
+}
+
+@media (max-width: 52rem) {
+  .portfolioCard {
+    align-items: start;
+    grid-template-columns: 52px minmax(0, 1fr);
+    row-gap: 12px;
+  }
+
+  .portfolioArtwork {
+    border-radius: 13px;
+    height: 52px;
+    width: 52px;
+  }
+
+  .portfolioArtwork::before {
+    border-radius: 8px;
+    inset: 6px;
+  }
+
+  .portfolioMetrics,
+  .portfolioCardActions {
+    grid-column: 1 / -1;
+  }
+
+  .portfolioCardActions a {
+    width: 100%;
+  }
 }
 
 @media (max-width: 700px) {
@@ -1193,20 +1702,102 @@
   }
 
   .portfolioSection {
-    width: min(calc(100% - 24px), 1180px);
+    padding: 16px;
   }
 
-  .positionRows > a {
-    grid-template-columns: minmax(0, 1fr) 64px 64px;
+  .portfolioCard {
+    grid-template-columns: minmax(0, 1fr);
+    padding: 10px;
+    position: relative;
   }
 
-  .positionRows > a > svg {
-    display: none;
+  .portfolioArtwork {
+    inset-block-start: 10px;
+    inset-inline-start: 10px;
+    position: absolute;
+  }
+
+  .portfolioCardCopy {
+    min-height: 52px;
+    padding-inline-start: 64px;
+  }
+
+  .portfolioMetrics,
+  .portfolioCardActions {
+    grid-column: auto;
+  }
+
+  .portfolioMetrics {
+    gap: 8px;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .portfolioMetrics > div {
+    min-height: 52px;
+  }
+
+  .portfolioHoldings {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .portfolioEmpty,
+  .portfolioError {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .portfolioEmptyAction,
+  .portfolioError button {
+    grid-column: 1 / -1;
+  }
+
+  .portfolioEmptyAction > *,
+  .portfolioError button {
+    width: 100%;
+  }
+
+  .portfolioInlineError {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .portfolioInlineError button {
+    width: 100%;
   }
 }
 
 @media (max-width: 360px) {
   .marketGrid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .portfolioSection {
+    border-radius: 14px;
+    padding: 12px;
+  }
+
+  .portfolioRefresh {
+    padding: 0;
+    width: 44px;
+  }
+
+  .portfolioRefresh span {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  .portfolioTabs button {
+    font-size: 11px;
+    padding-inline: 5px;
+  }
+
+  .portfolioTabs small {
+    display: none;
   }
 }

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -660,12 +660,94 @@
   text-align: right;
 }
 
+.orderPreview {
+  display: grid;
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.payoutSummary {
+  --payout-accent: var(--market-green);
+  border-inline-start: 3px solid var(--payout-accent);
+  display: grid;
+  gap: 14px;
+  padding: 2px 0 2px 14px;
+}
+
+.payoutSummary[data-outcome="NO"] {
+  --payout-accent: var(--market-red);
+}
+
+.payoutHeadline {
+  display: grid;
+  gap: 5px;
+}
+
+.payoutHeadline > span {
+  color: var(--webde-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.payoutHeadline > strong {
+  color: var(--webde-ink);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: clamp(22px, 2.4vw, 28px);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  letter-spacing: -0.045em;
+  line-height: 1.08;
+  overflow-wrap: anywhere;
+}
+
+.payoutHeadline > small {
+  color: var(--webde-dim);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.payoutMetrics {
+  border-top: 1px solid var(--webde-line);
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding-top: 11px;
+}
+
+.payoutMetrics > div {
+  align-items: baseline;
+  display: flex;
+  font-size: 12px;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.payoutMetrics dt {
+  color: var(--webde-muted);
+}
+
+.payoutMetrics dd {
+  color: var(--webde-ink);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  margin: 0;
+  text-align: right;
+}
+
+.payoutMetrics dd[data-tone="positive"] {
+  color: var(--market-green);
+}
+
+.payoutMetrics dd[data-tone="negative"] {
+  color: var(--market-red);
+}
+
 .quoteReceipt {
   border-bottom: 1px solid var(--border);
   border-top: 1px solid var(--border);
   display: grid;
   gap: 10px;
-  margin-top: 18px;
+  margin-top: 0;
   padding: 15px 0;
 }
 

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -1,38 +1,334 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, CircleDollarSign } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import {
+  ArrowRight,
+  CircleDollarSign,
+  Plus,
+  RefreshCw,
+  WalletCards,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 
 import styles from "@/components/prediction-market-experience.module.css";
 import { useWallet } from "@/components/wallet-provider";
 import { getPredictionMarketReleaseConfig } from "@/lib/prediction-market-chain";
-import { predictionMarketErrorMessage } from "@/lib/prediction-market-errors";
 import {
+  formatPredictionMarketObservation,
   formatPredictionOutcome,
   readPredictionMarketDirectory,
   type PredictionMarketView,
+  type PredictionOutcome,
 } from "@/lib/prediction-market-trading";
 
-type PortfolioState =
-  | { kind: "idle" }
-  | { kind: "loading" }
-  | {
-      kind: "ready";
-      nextCursor: bigint;
-      positions: readonly PredictionMarketView[];
-      scannedMarkets: number;
-    }
-  | { kind: "error"; message: string };
+export type PredictionPortfolioTabV1 = "positions" | "created" | "history";
+export type PredictionPortfolioPhaseV1 = "loading" | "ready" | "error";
+
+export type PredictionPortfolioSideViewModelV1 = Readonly<{
+  outcome: PredictionOutcome;
+  shares: string;
+}>;
+
+export type PredictionPortfolioPositionSourceV1 = Readonly<{
+  finalOutcome: "YES" | "NO" | "INVALID" | null;
+  lifecycle:
+    | "open"
+    | "trading_closed"
+    | "final_yes"
+    | "final_no"
+    | "final_invalid";
+  market: PredictionMarketView;
+  noAtoms: bigint;
+  redeemableAtoms: bigint;
+  result: "pending" | "won" | "lost" | "neutral";
+  tradingClosed: boolean;
+  yesAtoms: bigint;
+}>;
+
+export type PredictionPortfolioItemViewModelV1 = Readonly<{
+  actionLabel: string;
+  actionTone: "primary" | "quiet";
+  artworkLabel: string;
+  href: string;
+  id: string;
+  payoutDetail: string;
+  payoutLabel: string;
+  payoutTone: "pending" | "ready" | "settled";
+  positionLabel: string;
+  probabilityLabel: string;
+  probabilityYesPercent: number;
+  sides: readonly PredictionPortfolioSideViewModelV1[];
+  statusLabel: string;
+  statusTone: "open" | "pending" | "final";
+  timeLabel: string;
+  title: string;
+}>;
+
+/**
+ * Stable presentation boundary for the profile activity API. The current
+ * component builds this from the directory reader; a profile API can provide
+ * all three arrays without changing the panel or card layout.
+ */
+export type PredictionPortfolioViewModelV1 = Readonly<{
+  canLoadMorePositions: boolean;
+  created: readonly PredictionPortfolioItemViewModelV1[];
+  errorMessage: string | null;
+  history: readonly PredictionPortfolioItemViewModelV1[];
+  loadMoreErrorMessage: string | null;
+  loadingMorePositions: boolean;
+  phase: PredictionPortfolioPhaseV1;
+  positions: readonly PredictionPortfolioItemViewModelV1[];
+  refreshing: boolean;
+  statusMessage: string;
+}>;
+
+export type PredictionMarketPortfolioProps = Readonly<{
+  onLoadMorePositions?: () => void | Promise<void>;
+  onRefresh?: () => void | Promise<void>;
+  onRetry?: () => void | Promise<void>;
+  viewModel?: PredictionPortfolioViewModelV1;
+}>;
+
+type InternalPortfolioState = Readonly<{
+  accountKey: string | null;
+  errorMessage: string;
+  markets: readonly PredictionMarketView[];
+  nextCursor: bigint;
+  phase: "idle" | PredictionPortfolioPhaseV1;
+}>;
+
+type InternalPortfolioRequest = Readonly<{
+  accountKey: string;
+  requestKey: string;
+}>;
+
+const INITIAL_INTERNAL_STATE: InternalPortfolioState = Object.freeze({
+  accountKey: null,
+  errorMessage: "",
+  markets: Object.freeze([]),
+  nextCursor: 0n,
+  phase: "idle",
+});
 
 const PORTFOLIO_SCAN_PAGE_SIZE = 24;
+const OUTCOME_FACE_SCALE = 10n;
+const PORTFOLIO_ERROR =
+  "Unable to load your prediction activity. Check your connection and try again.";
+const PORTFOLIO_OLDER_ERROR =
+  "Unable to load older positions. Check your connection and try again.";
 
-function errorMessage(error: unknown) {
-  return predictionMarketErrorMessage(error, "Prediction positions are unavailable");
+const PORTFOLIO_TABS = [
+  { id: "positions", label: "Positions" },
+  { id: "created", label: "Created" },
+  { id: "history", label: "History" },
+] as const;
+
+function isInternalPortfolioRequestCurrent(
+  candidate: InternalPortfolioRequest,
+  current: InternalPortfolioRequest | null,
+) {
+  return Boolean(
+    current
+    && candidate.accountKey === current.accountKey
+    && candidate.requestKey === current.requestKey,
+  );
 }
 
-export function PredictionMarketPortfolio() {
+function clampProbability(probabilityYesBps: number) {
+  return Math.min(100, Math.max(0, probabilityYesBps / 100));
+}
+
+function countdown(target: bigint, current: bigint) {
+  const seconds = target > current ? Number(target - current) : 0;
+  const days = Math.floor(seconds / 86_400);
+  const hours = Math.floor((seconds % 86_400) / 3_600);
+  const minutes = Math.floor((seconds % 3_600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${Math.max(1, minutes)}m`;
+}
+
+function resultTimeLabel(timestamp: bigint) {
+  try {
+    return formatPredictionMarketObservation(timestamp);
+  } catch {
+    return "Result time unavailable";
+  }
+}
+
+export function predictionPortfolioPositionViewModelV1(
+  input: PredictionMarketView | PredictionPortfolioPositionSourceV1,
+): PredictionPortfolioItemViewModelV1 {
+  const source = "market" in input ? input : predictionPortfolioPositionSourceV1(input);
+  const market = source.market;
+  const probabilityYesPercent = clampProbability(market.probabilityYesBps);
+  const sides = ([
+    ["YES", source.yesAtoms],
+    ["NO", source.noAtoms],
+  ] as const).flatMap(([outcome, balance]) => balance > 0n
+    ? [{ outcome, shares: formatPredictionOutcome(balance) }]
+    : []);
+  const resultTime = resultTimeLabel(market.observationTime);
+  const tradingOpen = source.lifecycle === "open" && !source.tradingClosed;
+
+  if (tradingOpen) {
+    return Object.freeze({
+      actionLabel: "Trade",
+      actionTone: "primary",
+      artworkLabel: "BTC",
+      href: `/markets/${market.semanticKey}`,
+      id: market.semanticKey,
+      payoutDetail: "Payout is available after the result is final.",
+      payoutLabel: "Not settled",
+      payoutTone: "pending",
+      positionLabel: "Open position",
+      probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
+      probabilityYesPercent,
+      sides: Object.freeze(sides),
+      statusLabel: "Trading open",
+      statusTone: "open",
+      timeLabel: `Closes in ${countdown(market.cutoff, market.blockTimestamp)}`,
+      title: market.title,
+    });
+  }
+
+  if (source.result === "pending") {
+    return Object.freeze({
+      actionLabel: "View market",
+      actionTone: "quiet",
+      artworkLabel: "BTC",
+      href: `/markets/${market.semanticKey}`,
+      id: market.semanticKey,
+      payoutDetail: "Payout is available when the result is final.",
+      payoutLabel: "Awaiting result",
+      payoutTone: "pending",
+      positionLabel: "Position held",
+      probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
+      probabilityYesPercent,
+      sides: Object.freeze(sides),
+      statusLabel: "Awaiting result",
+      statusTone: "pending",
+      timeLabel: `Result ${resultTime}`,
+      title: market.title,
+    });
+  }
+
+  const invalid = source.result === "neutral";
+  const winningOutcome = source.finalOutcome === "YES" ? "YES" : "NO";
+  const redeemable = source.redeemableAtoms > 0n;
+  const resultLabel = source.result === "won"
+    ? "Won"
+    : source.result === "lost"
+      ? "Lost"
+      : "Neutral";
+  const payoutDetail = invalid
+    ? "YES and NO each redeem for 0.50 USDG per share."
+    : source.result === "won"
+      ? `${winningOutcome} redeems for 1 USDG per share; the other side settles at zero.`
+      : `${winningOutcome} won; your held side settles at zero.`;
+
+  return Object.freeze({
+    actionLabel: redeemable ? "Redeem payout" : "View market",
+    actionTone: redeemable ? "primary" : "quiet",
+    artworkLabel: "BTC",
+    href: `/markets/${market.semanticKey}`,
+    id: market.semanticKey,
+    payoutDetail,
+    payoutLabel: redeemable ? "Redeemable" : "Settled",
+    payoutTone: redeemable ? "ready" : "settled",
+    positionLabel: "Final position",
+    probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
+    probabilityYesPercent,
+    sides: Object.freeze(sides),
+    statusLabel: resultLabel,
+    statusTone: "final",
+    timeLabel: `Result ${resultTime}`,
+    title: market.title,
+  });
+}
+
+function predictionPortfolioPositionSourceV1(
+  market: PredictionMarketView,
+): PredictionPortfolioPositionSourceV1 {
+  const yesAtoms = market.yesBalanceAtoms;
+  const noAtoms = market.noBalanceAtoms;
+  if (market.state === "FINAL_YES") {
+    return {
+      finalOutcome: "YES",
+      lifecycle: "final_yes",
+      market,
+      noAtoms,
+      redeemableAtoms: yesAtoms * OUTCOME_FACE_SCALE,
+      result: yesAtoms > 0n ? "won" : "lost",
+      tradingClosed: true,
+      yesAtoms,
+    };
+  }
+  if (market.state === "FINAL_NO") {
+    return {
+      finalOutcome: "NO",
+      lifecycle: "final_no",
+      market,
+      noAtoms,
+      redeemableAtoms: noAtoms * OUTCOME_FACE_SCALE,
+      result: noAtoms > 0n ? "won" : "lost",
+      tradingClosed: true,
+      yesAtoms,
+    };
+  }
+  if (market.state === "FINAL_INVALID") {
+    return {
+      finalOutcome: "INVALID",
+      lifecycle: "final_invalid",
+      market,
+      noAtoms,
+      redeemableAtoms: (yesAtoms + noAtoms) * OUTCOME_FACE_SCALE / 2n,
+      result: "neutral",
+      tradingClosed: true,
+      yesAtoms,
+    };
+  }
+  const tradingClosed = market.blockTimestamp >= market.cutoff;
+  return {
+    finalOutcome: null,
+    lifecycle: tradingClosed ? "trading_closed" : "open",
+    market,
+    noAtoms,
+    redeemableAtoms: 0n,
+    result: "pending",
+    tradingClosed,
+    yesAtoms,
+  };
+}
+
+function tabLabel(tab: PredictionPortfolioTabV1) {
+  return PORTFOLIO_TABS.find((candidate) => candidate.id === tab)?.label ?? "Prediction activity";
+}
+
+function itemCount(
+  model: PredictionPortfolioViewModelV1,
+  tab: PredictionPortfolioTabV1,
+) {
+  return model[tab].length;
+}
+
+export function PredictionMarketPortfolio({
+  onLoadMorePositions,
+  onRefresh,
+  onRetry,
+  viewModel,
+}: PredictionMarketPortfolioProps = {}) {
   const { openWallet, wallet } = useWallet();
+  const account = wallet?.account ?? null;
   const release = useMemo(() => {
     try {
       return getPredictionMarketReleaseConfig();
@@ -40,127 +336,497 @@ export function PredictionMarketPortfolio() {
       return null;
     }
   }, []);
-  const [state, setState] = useState<PortfolioState>({ kind: "idle" });
+  const [state, setState] = useState<InternalPortfolioState>(INITIAL_INTERNAL_STATE);
+  const [refreshing, setRefreshing] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [olderError, setOlderError] = useState("");
+  const [announcement, setAnnouncement] = useState("");
+  const [activeTab, setActiveTab] = useState<PredictionPortfolioTabV1>("positions");
+  const requestSequenceRef = useRef(0);
+  const activeRequestRef = useRef<InternalPortfolioRequest | null>(null);
+  const tabRefs = useRef(new Map<PredictionPortfolioTabV1, HTMLButtonElement>());
 
-  useEffect(() => {
-    if (!wallet || !release) return;
-    let active = true;
-    const timer = window.setTimeout(() => {
-      if (!active) return;
-      setState({ kind: "loading" });
-      void readPredictionMarketDirectory({
-        account: wallet.account,
-        config: release,
-        limit: PORTFOLIO_SCAN_PAGE_SIZE,
-      })
-        .then((directory) => {
-          if (!active) return;
-          setState({
-            kind: "ready",
-            nextCursor: directory.nextCursor,
-            positions: directory.markets.filter(
-              (market) => market.yesBalanceAtoms > 0n || market.noBalanceAtoms > 0n,
-            ),
-            scannedMarkets: directory.markets.length,
-          });
-        })
-        .catch((error) => {
-          if (active) setState({ kind: "error", message: errorMessage(error) });
-        });
-    }, 0);
-    return () => {
-      active = false;
-      window.clearTimeout(timer);
-    };
-  }, [release, wallet]);
-
-  async function loadOlderPositions() {
-    if (!wallet || !release || state.kind !== "ready" || state.nextCursor === 0n || loadingOlder) return;
-    setLoadingOlder(true);
+  const loadPortfolio = useCallback(async (mode: "initial" | "refresh" | "retry") => {
+    if (!account || !release) return;
+    const accountKey = account.toLowerCase();
+    const request = {
+      accountKey,
+      requestKey: `${mode}:${++requestSequenceRef.current}`,
+    } satisfies InternalPortfolioRequest;
+    activeRequestRef.current = request;
     setOlderError("");
+    setLoadingOlder(false);
+    setRefreshing(true);
+    setAnnouncement(mode === "initial"
+      ? "Loading prediction activity."
+      : "Refreshing prediction activity.");
+    setState((current) => ({
+      ...(mode === "refresh"
+        && current.accountKey === accountKey
+        && current.phase === "ready"
+        ? current
+        : INITIAL_INTERNAL_STATE),
+      accountKey,
+      errorMessage: "",
+      phase: mode === "refresh"
+        && current.accountKey === accountKey
+        && current.phase === "ready"
+        ? "ready"
+        : "loading",
+    }));
     try {
       const directory = await readPredictionMarketDirectory({
-        account: wallet.account,
+        account,
+        config: release,
+        limit: PORTFOLIO_SCAN_PAGE_SIZE,
+      });
+      if (!isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) return;
+      const markets = directory.markets.filter(
+        (market) => market.yesBalanceAtoms > 0n || market.noBalanceAtoms > 0n,
+      );
+      setState({
+        accountKey,
+        errorMessage: "",
+        markets,
+        nextCursor: directory.nextCursor,
+        phase: "ready",
+      });
+      setAnnouncement(mode === "initial"
+        ? `Prediction activity loaded. ${markets.length} ${markets.length === 1 ? "position" : "positions"}.`
+        : `Prediction activity refreshed. ${markets.length} ${markets.length === 1 ? "position" : "positions"}.`);
+    } catch {
+      if (!isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) return;
+      setState((current) => current.accountKey === accountKey && current.phase === "ready"
+        ? { ...current, errorMessage: PORTFOLIO_ERROR }
+        : {
+            ...INITIAL_INTERNAL_STATE,
+            accountKey,
+            errorMessage: PORTFOLIO_ERROR,
+            phase: "error",
+          });
+      setAnnouncement("Prediction activity could not be loaded.");
+    } finally {
+      if (isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) {
+        setRefreshing(false);
+      }
+    }
+  }, [account, release]);
+
+  useEffect(() => {
+    if (viewModel || !account || !release) return;
+    const timer = window.setTimeout(() => void loadPortfolio("initial"), 0);
+    return () => {
+      window.clearTimeout(timer);
+      if (activeRequestRef.current?.accountKey === account.toLowerCase()) {
+        activeRequestRef.current = null;
+      }
+    };
+  }, [account, loadPortfolio, release, viewModel]);
+
+  const loadOlderPositions = useCallback(async () => {
+    if (
+      !account
+      || !release
+      || state.accountKey !== account.toLowerCase()
+      || state.phase !== "ready"
+      || state.nextCursor === 0n
+      || loadingOlder
+    ) return;
+    const accountKey = account.toLowerCase();
+    const request = {
+      accountKey,
+      requestKey: `older:${++requestSequenceRef.current}`,
+    } satisfies InternalPortfolioRequest;
+    activeRequestRef.current = request;
+    setLoadingOlder(true);
+    setOlderError("");
+    setAnnouncement("Loading older positions.");
+    try {
+      const directory = await readPredictionMarketDirectory({
+        account,
         config: release,
         cursor: state.nextCursor,
         limit: PORTFOLIO_SCAN_PAGE_SIZE,
       });
-      const positions = directory.markets.filter(
+      if (!isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) return;
+      const markets = directory.markets.filter(
         (market) => market.yesBalanceAtoms > 0n || market.noBalanceAtoms > 0n,
       );
       setState((current) => {
-        if (current.kind !== "ready") return current;
-        const known = new Set(current.positions.map((market) => market.semanticKey.toLowerCase()));
+        if (current.accountKey !== accountKey || current.phase !== "ready") return current;
+        const known = new Set(current.markets.map((market) => market.semanticKey.toLowerCase()));
         return {
-          kind: "ready",
-          nextCursor: directory.nextCursor,
-          positions: [
-            ...current.positions,
-            ...positions.filter(
-              (market) => !known.has(market.semanticKey.toLowerCase()),
-            ),
+          ...current,
+          markets: [
+            ...current.markets,
+            ...markets.filter((market) => !known.has(market.semanticKey.toLowerCase())),
           ],
-          scannedMarkets: current.scannedMarkets + directory.markets.length,
+          nextCursor: directory.nextCursor,
         };
       });
-    } catch (error) {
-      setOlderError(errorMessage(error));
+      setAnnouncement(
+        `${markets.length} older ${markets.length === 1 ? "position" : "positions"} loaded.`,
+      );
+    } catch {
+      if (!isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) return;
+      setOlderError(PORTFOLIO_OLDER_ERROR);
+      setAnnouncement("Older positions could not be loaded.");
     } finally {
-      setLoadingOlder(false);
+      if (isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) {
+        setLoadingOlder(false);
+      }
     }
+  }, [account, loadingOlder, release, state.accountKey, state.nextCursor, state.phase]);
+
+  const internalViewModel = useMemo<PredictionPortfolioViewModelV1>(() => {
+    const accountKey = account?.toLowerCase() ?? null;
+    const isCurrentAccount = state.accountKey === accountKey;
+    return {
+      canLoadMorePositions: isCurrentAccount
+        && state.phase === "ready"
+        && state.nextCursor > 0n,
+      created: Object.freeze([]),
+      errorMessage: isCurrentAccount ? state.errorMessage || null : null,
+      history: Object.freeze([]),
+      loadMoreErrorMessage: olderError || null,
+      loadingMorePositions: loadingOlder,
+      phase: !isCurrentAccount || state.phase === "idle" ? "loading" : state.phase,
+      positions: isCurrentAccount
+        ? state.markets.map(predictionPortfolioPositionViewModelV1)
+        : Object.freeze([]),
+      refreshing,
+      statusMessage: announcement,
+    };
+  }, [account, announcement, loadingOlder, olderError, refreshing, state]);
+  const model = viewModel ?? internalViewModel;
+  const accessState = viewModel
+    ? "ready"
+    : !release
+      ? "unavailable"
+      : !account
+        ? "wallet"
+        : "ready";
+  const isBusy = accessState === "ready"
+    && (model.phase === "loading" || model.refreshing || model.loadingMorePositions);
+  const canRefresh = viewModel
+    ? Boolean(onRefresh || onRetry)
+    : accessState === "ready";
+  const visibleItems = model[activeTab];
+
+  const runControlledAction = useCallback(async (
+    action: (() => void | Promise<void>) | undefined,
+    pendingMessage: string,
+  ) => {
+    if (!action) return;
+    setAnnouncement(pendingMessage);
+    try {
+      await action();
+      setAnnouncement("");
+    } catch {
+      setAnnouncement("Prediction activity could not be updated.");
+    }
+  }, []);
+
+  const refreshPortfolio = useCallback(() => {
+    if (viewModel) {
+      void runControlledAction(onRefresh ?? onRetry, "Refreshing prediction activity.");
+      return;
+    }
+    void loadPortfolio("refresh");
+  }, [loadPortfolio, onRefresh, onRetry, runControlledAction, viewModel]);
+
+  const retryPortfolio = useCallback(() => {
+    if (viewModel) {
+      void runControlledAction(onRetry ?? onRefresh, "Retrying prediction activity.");
+      return;
+    }
+    void loadPortfolio("retry");
+  }, [loadPortfolio, onRefresh, onRetry, runControlledAction, viewModel]);
+
+  const requestOlderPositions = useCallback(() => {
+    if (viewModel) {
+      void runControlledAction(onLoadMorePositions, "Loading older positions.");
+      return;
+    }
+    void loadOlderPositions();
+  }, [loadOlderPositions, onLoadMorePositions, runControlledAction, viewModel]);
+
+  function selectTab(tab: PredictionPortfolioTabV1, moveFocus = false) {
+    const count = itemCount(model, tab);
+    setActiveTab(tab);
+    setAnnouncement(
+      `${tabLabel(tab)} tab. ${count} ${count === 1 ? "item" : "items"}.`,
+    );
+    if (moveFocus) window.requestAnimationFrame(() => tabRefs.current.get(tab)?.focus());
+  }
+
+  function handleTabKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    tab: PredictionPortfolioTabV1,
+  ) {
+    const currentIndex = PORTFOLIO_TABS.findIndex((candidate) => candidate.id === tab);
+    let nextIndex: number | null = null;
+    if (event.key === "ArrowRight") nextIndex = (currentIndex + 1) % PORTFOLIO_TABS.length;
+    if (event.key === "ArrowLeft") nextIndex = (currentIndex - 1 + PORTFOLIO_TABS.length) % PORTFOLIO_TABS.length;
+    if (event.key === "Home") nextIndex = 0;
+    if (event.key === "End") nextIndex = PORTFOLIO_TABS.length - 1;
+    if (nextIndex === null) return;
+    event.preventDefault();
+    selectTab(PORTFOLIO_TABS[nextIndex].id, true);
   }
 
   return (
-    <section className={styles.portfolioSection} aria-labelledby="prediction-portfolio-title">
-      <header>
+    <section
+      className={styles.portfolioSection}
+      aria-busy={isBusy}
+      aria-labelledby="prediction-portfolio-title"
+    >
+      <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {announcement || model.statusMessage}
+      </p>
+
+      <header className={styles.portfolioHeading}>
         <div>
-          <span className={styles.sectionIndex}>PREDICTION</span>
-          <h2 id="prediction-portfolio-title">Prediction positions</h2>
+          <span className={styles.portfolioEyebrow}>Profile activity</span>
+          <h2 id="prediction-portfolio-title">Predictions</h2>
         </div>
-        <Link href="/markets">All markets <ArrowRight aria-hidden="true" size={14} /></Link>
+        {canRefresh ? (
+          <button
+            className={styles.portfolioRefresh}
+            type="button"
+            disabled={isBusy}
+            onClick={refreshPortfolio}
+          >
+            <RefreshCw aria-hidden="true" size={15} strokeWidth={2} />
+            <span>{model.refreshing ? "Refreshing" : "Refresh"}</span>
+          </button>
+        ) : null}
       </header>
-      {!release ? (
-        <div className={styles.portfolioEmpty}>
-          <CircleDollarSign aria-hidden="true" size={20} />
-          <span><strong>Deployment pending</strong><small>Positions appear here after the reviewed Robinhood release is configured.</small></span>
-        </div>
-      ) : !wallet ? (
-        <button className={styles.portfolioConnect} type="button" onClick={openWallet}>Connect wallet to read positions</button>
-      ) : state.kind === "loading" || state.kind === "idle" ? (
-        <div className={styles.portfolioEmpty}>
-          Checking the {PORTFOLIO_SCAN_PAGE_SIZE} most recent markets across both RPCs…
-        </div>
-      ) : state.kind === "error" ? (
-        <div className={styles.portfolioEmpty}>{state.message}</div>
-      ) : state.positions.length === 0 ? (
-        <div className={styles.portfolioEmpty}>
-          No YES or NO balance in the {state.scannedMarkets} markets checked so far.
-        </div>
-      ) : (
-        <div className={styles.positionRows}>
-          {state.positions.map((market) => (
-            <Link href={`/markets/${market.semanticKey}`} key={market.semanticKey}>
-              <span><strong>{market.title}</strong><small>{market.state.replaceAll("_", " ")}</small></span>
-              <span><small>YES</small><strong>{formatPredictionOutcome(market.yesBalanceAtoms)}</strong></span>
-              <span><small>NO</small><strong>{formatPredictionOutcome(market.noBalanceAtoms)}</strong></span>
-              <ArrowRight aria-hidden="true" size={15} />
-            </Link>
-          ))}
-        </div>
-      )}
-      {state.kind === "ready" && state.nextCursor > 0n ? (
-        <button
-          className={styles.portfolioConnect}
-          disabled={loadingOlder}
-          onClick={() => void loadOlderPositions()}
-          type="button"
+
+      <div className={styles.portfolioTabs} role="tablist" aria-label="Prediction activity">
+        {PORTFOLIO_TABS.map((tab) => (
+          <button
+            aria-controls={`prediction-${tab.id}-panel`}
+            aria-selected={activeTab === tab.id}
+            id={`prediction-${tab.id}-tab`}
+            key={tab.id}
+            onClick={() => selectTab(tab.id)}
+            onKeyDown={(event) => handleTabKeyDown(event, tab.id)}
+            ref={(node) => {
+              if (node) tabRefs.current.set(tab.id, node);
+              else tabRefs.current.delete(tab.id);
+            }}
+            role="tab"
+            tabIndex={activeTab === tab.id ? 0 : -1}
+            type="button"
+          >
+            <span>{tab.label}</span>
+            {model[tab.id].length > 0 ? <small>{model[tab.id].length}</small> : null}
+          </button>
+        ))}
+      </div>
+
+      {PORTFOLIO_TABS.map((tab) => (
+        <div
+          aria-labelledby={`prediction-${tab.id}-tab`}
+          className={styles.portfolioTabPanel}
+          hidden={activeTab !== tab.id}
+          id={`prediction-${tab.id}-panel`}
+          key={tab.id}
+          role="tabpanel"
+          tabIndex={activeTab === tab.id ? 0 : -1}
         >
-          {loadingOlder ? "Checking older markets across both RPCs…" : "Check older markets for positions"}
-        </button>
-      ) : null}
-      {olderError ? <div className={styles.portfolioEmpty}>{olderError}</div> : null}
+          {activeTab === tab.id ? (
+            <>
+              {accessState === "wallet" ? (
+                <PortfolioEmptyState
+                  icon={<WalletCards aria-hidden="true" size={21} strokeWidth={1.8} />}
+                  title="Connect to see prediction activity"
+                  description="Your positions, markets and payouts stay tied to your wallet."
+                  action={(
+                    <button
+                      className={styles.portfolioPrimaryAction}
+                      type="button"
+                      onClick={openWallet}
+                    >
+                      Connect wallet
+                    </button>
+                  )}
+                />
+              ) : accessState === "unavailable" ? (
+                <PortfolioEmptyState
+                  icon={<CircleDollarSign aria-hidden="true" size={21} strokeWidth={1.8} />}
+                  title="Prediction activity is unavailable"
+                  description="Browse current markets while profile activity is being restored."
+                  action={(
+                    <Link className={styles.portfolioSecondaryAction} href="/markets">
+                      Browse markets
+                    </Link>
+                  )}
+                />
+              ) : model.phase === "loading" && visibleItems.length === 0 ? (
+                <PortfolioEmptyState
+                  icon={<CircleDollarSign aria-hidden="true" size={21} strokeWidth={1.8} />}
+                  title="Loading prediction activity"
+                  description="Your latest positions will appear here."
+                />
+              ) : model.phase === "error" && visibleItems.length === 0 ? (
+                <div className={styles.portfolioError} role="alert">
+                  <span>
+                    <strong>Prediction activity could not be loaded</strong>
+                    <small>{model.errorMessage ?? PORTFOLIO_ERROR}</small>
+                  </span>
+                  <button type="button" onClick={retryPortfolio}>Retry</button>
+                </div>
+              ) : (
+                <>
+                  {model.errorMessage ? (
+                    <div className={styles.portfolioInlineError} role="alert">
+                      <span>{model.errorMessage}</span>
+                      <button type="button" onClick={retryPortfolio}>Retry</button>
+                    </div>
+                  ) : null}
+                  {visibleItems.length > 0 ? (
+                    <div className={styles.portfolioCards}>
+                      {visibleItems.map((item) => (
+                        <PortfolioCard item={item} key={item.id} />
+                      ))}
+                    </div>
+                  ) : (
+                    <PortfolioTabEmptyState tab={activeTab} />
+                  )}
+                </>
+              )}
+
+              {accessState === "ready"
+                && activeTab === "positions"
+                && model.canLoadMorePositions ? (
+                  <button
+                    className={styles.portfolioLoadMore}
+                    disabled={model.loadingMorePositions}
+                    onClick={requestOlderPositions}
+                    type="button"
+                  >
+                    {model.loadingMorePositions
+                      ? "Loading older positions"
+                      : "Show older positions"}
+                  </button>
+                ) : null}
+              {activeTab === "positions" && model.loadMoreErrorMessage ? (
+                <p className={styles.portfolioLoadMoreError} role="alert">
+                  {model.loadMoreErrorMessage}
+                </p>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      ))}
     </section>
+  );
+}
+
+function PortfolioCard({ item }: Readonly<{ item: PredictionPortfolioItemViewModelV1 }>) {
+  const probabilityStyle = {
+    "--portfolio-probability": `${item.probabilityYesPercent}%`,
+  } as CSSProperties;
+
+  return (
+    <article className={styles.portfolioCard}>
+      <div className={styles.portfolioArtwork} style={probabilityStyle} aria-hidden="true">
+        <span>{item.artworkLabel}</span>
+        <strong>{item.probabilityYesPercent.toFixed(0)}%</strong>
+      </div>
+
+      <div className={styles.portfolioCardCopy}>
+        <div className={styles.portfolioCardStatus} data-tone={item.statusTone}>
+          <span>{item.statusLabel}</span>
+          <small>{item.timeLabel}</small>
+        </div>
+        <h3>
+          <Link href={item.href}>{item.title}</Link>
+        </h3>
+        <div className={styles.portfolioHoldings} aria-label={item.positionLabel}>
+          {item.sides.length > 0 ? item.sides.map((side) => (
+            <span data-outcome={side.outcome} key={side.outcome}>
+              <strong>{side.outcome}</strong>
+              <small>{side.shares} shares</small>
+            </span>
+          )) : <small>{item.positionLabel}</small>}
+        </div>
+      </div>
+
+      <dl className={styles.portfolioMetrics}>
+        <div>
+          <dt>Probability</dt>
+          <dd>{item.probabilityLabel}</dd>
+        </div>
+        <div data-tone={item.payoutTone}>
+          <dt>Payout</dt>
+          <dd>{item.payoutLabel}</dd>
+          <small>{item.payoutDetail}</small>
+        </div>
+      </dl>
+
+      <div className={styles.portfolioCardActions}>
+        <Link data-tone={item.actionTone} href={item.href}>
+          <span>{item.actionLabel}</span>
+          <ArrowRight aria-hidden="true" size={15} strokeWidth={2} />
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+function PortfolioTabEmptyState({ tab }: Readonly<{ tab: PredictionPortfolioTabV1 }>) {
+  if (tab === "created") {
+    return (
+      <PortfolioEmptyState
+        icon={<Plus aria-hidden="true" size={21} strokeWidth={1.8} />}
+        title="No created markets yet"
+        description="Create a prediction and it will appear here."
+        action={<Link className={styles.portfolioPrimaryAction} href="/launch">Create a prediction</Link>}
+      />
+    );
+  }
+  if (tab === "history") {
+    return (
+      <PortfolioEmptyState
+        icon={<CircleDollarSign aria-hidden="true" size={21} strokeWidth={1.8} />}
+        title="No prediction history yet"
+        description="Completed positions and payouts will appear here."
+        action={<Link className={styles.portfolioSecondaryAction} href="/markets">Browse markets</Link>}
+      />
+    );
+  }
+  return (
+    <PortfolioEmptyState
+      icon={<WalletCards aria-hidden="true" size={21} strokeWidth={1.8} />}
+      title="No open positions yet"
+      description="Markets you trade will appear here with their current result status."
+      action={<Link className={styles.portfolioPrimaryAction} href="/markets">Find a market</Link>}
+    />
+  );
+}
+
+function PortfolioEmptyState({
+  action,
+  description,
+  icon,
+  title,
+}: Readonly<{
+  action?: ReactNode;
+  description: string;
+  icon: ReactNode;
+  title: string;
+}>) {
+  return (
+    <div className={styles.portfolioEmpty}>
+      <span className={styles.portfolioEmptyIcon}>{icon}</span>
+      <span>
+        <strong>{title}</strong>
+        <small>{description}</small>
+      </span>
+      {action ? <div className={styles.portfolioEmptyAction}>{action}</div> : null}
+    </div>
   );
 }

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -23,9 +23,19 @@ import styles from "@/components/prediction-market-experience.module.css";
 import { useWallet } from "@/components/wallet-provider";
 import { getPredictionMarketReleaseConfig } from "@/lib/prediction-market-chain";
 import {
+  PredictionPortfolioReadError,
+  createPredictionPortfolioRequest,
+  isPredictionPortfolioRequestCurrent,
+  readPredictionMarketPortfolio,
+  type PredictionMarketPortfolio as PredictionMarketPortfolioData,
+  type PredictionPortfolioCreatedMarket,
+  type PredictionPortfolioHistoryEntry,
+  type PredictionPortfolioRequest,
+} from "@/lib/prediction-market-portfolio";
+import {
   formatPredictionMarketObservation,
   formatPredictionOutcome,
-  readPredictionMarketDirectory,
+  formatPredictionUsdg,
   type PredictionMarketView,
   type PredictionOutcome,
 } from "@/lib/prediction-market-trading";
@@ -60,6 +70,7 @@ export type PredictionPortfolioItemViewModelV1 = Readonly<{
   artworkLabel: string;
   href: string;
   id: string;
+  metricLabel: string;
   payoutDetail: string;
   payoutLabel: string;
   payoutTone: "pending" | "ready" | "settled";
@@ -79,12 +90,9 @@ export type PredictionPortfolioItemViewModelV1 = Readonly<{
  * all three arrays without changing the panel or card layout.
  */
 export type PredictionPortfolioViewModelV1 = Readonly<{
-  canLoadMorePositions: boolean;
   created: readonly PredictionPortfolioItemViewModelV1[];
   errorMessage: string | null;
   history: readonly PredictionPortfolioItemViewModelV1[];
-  loadMoreErrorMessage: string | null;
-  loadingMorePositions: boolean;
   phase: PredictionPortfolioPhaseV1;
   positions: readonly PredictionPortfolioItemViewModelV1[];
   refreshing: boolean;
@@ -92,7 +100,6 @@ export type PredictionPortfolioViewModelV1 = Readonly<{
 }>;
 
 export type PredictionMarketPortfolioProps = Readonly<{
-  onLoadMorePositions?: () => void | Promise<void>;
   onRefresh?: () => void | Promise<void>;
   onRetry?: () => void | Promise<void>;
   viewModel?: PredictionPortfolioViewModelV1;
@@ -100,48 +107,29 @@ export type PredictionMarketPortfolioProps = Readonly<{
 
 type InternalPortfolioState = Readonly<{
   accountKey: string | null;
+  data: PredictionMarketPortfolioData | null;
   errorMessage: string;
-  markets: readonly PredictionMarketView[];
-  nextCursor: bigint;
   phase: "idle" | PredictionPortfolioPhaseV1;
-}>;
-
-type InternalPortfolioRequest = Readonly<{
-  accountKey: string;
-  requestKey: string;
 }>;
 
 const INITIAL_INTERNAL_STATE: InternalPortfolioState = Object.freeze({
   accountKey: null,
+  data: null,
   errorMessage: "",
-  markets: Object.freeze([]),
-  nextCursor: 0n,
   phase: "idle",
 });
 
-const PORTFOLIO_SCAN_PAGE_SIZE = 24;
 const OUTCOME_FACE_SCALE = 10n;
 const PORTFOLIO_ERROR =
   "Unable to load your prediction activity. Check your connection and try again.";
-const PORTFOLIO_OLDER_ERROR =
-  "Unable to load older positions. Check your connection and try again.";
+const PORTFOLIO_PARTIAL_ERROR =
+  "Some markets could not be verified. Refresh to try them again.";
 
 const PORTFOLIO_TABS = [
   { id: "positions", label: "Positions" },
   { id: "created", label: "Created" },
   { id: "history", label: "History" },
 ] as const;
-
-function isInternalPortfolioRequestCurrent(
-  candidate: InternalPortfolioRequest,
-  current: InternalPortfolioRequest | null,
-) {
-  return Boolean(
-    current
-    && candidate.accountKey === current.accountKey
-    && candidate.requestKey === current.requestKey,
-  );
-}
 
 function clampProbability(probabilityYesBps: number) {
   return Math.min(100, Math.max(0, probabilityYesBps / 100));
@@ -179,6 +167,13 @@ export function predictionPortfolioPositionViewModelV1(
     : []);
   const resultTime = resultTimeLabel(market.observationTime);
   const tradingOpen = source.lifecycle === "open" && !source.tradingClosed;
+  const maximumPayoutAtoms = (source.yesAtoms > source.noAtoms
+    ? source.yesAtoms
+    : source.noAtoms) * OUTCOME_FACE_SCALE;
+  const potentialPayoutLabel = formatPredictionUsdg(maximumPayoutAtoms);
+  const potentialPayoutDetail = source.yesAtoms > 0n && source.noAtoms > 0n
+    ? "The winning side pays 1 USDG per share; a neutral result pays 0.50 per YES and NO share."
+    : "Pays 1 USDG per share if your held side wins; a neutral result pays 0.50 per share.";
 
   if (tradingOpen) {
     return Object.freeze({
@@ -187,8 +182,9 @@ export function predictionPortfolioPositionViewModelV1(
       artworkLabel: "BTC",
       href: `/markets/${market.semanticKey}`,
       id: market.semanticKey,
-      payoutDetail: "Payout is available after the result is final.",
-      payoutLabel: "Not settled",
+      metricLabel: "Potential payout",
+      payoutDetail: potentialPayoutDetail,
+      payoutLabel: potentialPayoutLabel,
       payoutTone: "pending",
       positionLabel: "Open position",
       probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
@@ -208,8 +204,9 @@ export function predictionPortfolioPositionViewModelV1(
       artworkLabel: "BTC",
       href: `/markets/${market.semanticKey}`,
       id: market.semanticKey,
-      payoutDetail: "Payout is available when the result is final.",
-      payoutLabel: "Awaiting result",
+      metricLabel: "Potential payout",
+      payoutDetail: potentialPayoutDetail,
+      payoutLabel: potentialPayoutLabel,
       payoutTone: "pending",
       positionLabel: "Position held",
       probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
@@ -231,9 +228,9 @@ export function predictionPortfolioPositionViewModelV1(
       ? "Lost"
       : "Neutral";
   const payoutDetail = invalid
-    ? "YES and NO each redeem for 0.50 USDG per share."
+    ? `${redeemable ? "Redeemable now. " : ""}YES and NO each redeem for 0.50 USDG per share.`
     : source.result === "won"
-      ? `${winningOutcome} redeems for 1 USDG per share; the other side settles at zero.`
+      ? `Redeemable now. ${winningOutcome} redeems for 1 USDG per share; the other side settles at zero.`
       : `${winningOutcome} won; your held side settles at zero.`;
 
   return Object.freeze({
@@ -242,8 +239,9 @@ export function predictionPortfolioPositionViewModelV1(
     artworkLabel: "BTC",
     href: `/markets/${market.semanticKey}`,
     id: market.semanticKey,
+    metricLabel: "Final payout",
     payoutDetail,
-    payoutLabel: redeemable ? "Redeemable" : "Settled",
+    payoutLabel: formatPredictionUsdg(source.redeemableAtoms),
     payoutTone: redeemable ? "ready" : "settled",
     positionLabel: "Final position",
     probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
@@ -310,6 +308,167 @@ function predictionPortfolioPositionSourceV1(
   };
 }
 
+function marketLifecycleSummary(market: PredictionMarketView) {
+  const resultTime = resultTimeLabel(market.observationTime);
+  if (market.state === "FINAL_YES") {
+    return {
+      statusLabel: "YES won",
+      statusTone: "final" as const,
+      timeLabel: `Result ${resultTime}`,
+    };
+  }
+  if (market.state === "FINAL_NO") {
+    return {
+      statusLabel: "NO won",
+      statusTone: "final" as const,
+      timeLabel: `Result ${resultTime}`,
+    };
+  }
+  if (market.state === "FINAL_INVALID") {
+    return {
+      statusLabel: "Neutral result",
+      statusTone: "final" as const,
+      timeLabel: `Result ${resultTime}`,
+    };
+  }
+  if (market.blockTimestamp >= market.cutoff) {
+    return {
+      statusLabel: "Awaiting result",
+      statusTone: "pending" as const,
+      timeLabel: `Result ${resultTime}`,
+    };
+  }
+  return {
+    statusLabel: "Trading open",
+    statusTone: "open" as const,
+    timeLabel: `Closes in ${countdown(market.cutoff, market.blockTimestamp)}`,
+  };
+}
+
+export function predictionPortfolioCreatedViewModelV1(
+  entry: PredictionPortfolioCreatedMarket,
+): PredictionPortfolioItemViewModelV1 {
+  const market = entry.market;
+  const probabilityYesPercent = clampProbability(market.probabilityYesBps);
+  const lifecycle = marketLifecycleSummary(market);
+  return Object.freeze({
+    actionLabel: "View market",
+    actionTone: "quiet",
+    artworkLabel: "BTC",
+    href: `/markets/${market.semanticKey}`,
+    id: `created:${market.semanticKey}:${entry.transactionHash}:${entry.logIndex}`,
+    metricLabel: "Position",
+    payoutDetail: "Creating a market does not add YES or NO shares.",
+    payoutLabel: "No shares",
+    payoutTone: "pending",
+    positionLabel: "Created market",
+    probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
+    probabilityYesPercent,
+    sides: Object.freeze([]),
+    ...lifecycle,
+    title: market.title,
+  });
+}
+
+function historySides(
+  entry: PredictionPortfolioHistoryEntry,
+): readonly PredictionPortfolioSideViewModelV1[] {
+  if (entry.kind === "bought" || entry.kind === "sold" || entry.kind === "transfer") {
+    return Object.freeze([{
+      outcome: entry.outcome,
+      shares: formatPredictionOutcome(entry.outcomeAtoms),
+    }]);
+  }
+  if (entry.kind === "redeemed") {
+    return Object.freeze(([
+      ["YES", entry.yesAtoms],
+      ["NO", entry.noAtoms],
+    ] as const).flatMap(([outcome, atoms]) => atoms > 0n
+      ? [{ outcome, shares: formatPredictionOutcome(atoms) }]
+      : []));
+  }
+  return Object.freeze([]);
+}
+
+function historyPresentation(entry: PredictionPortfolioHistoryEntry) {
+  if (entry.kind === "created") {
+    return {
+      metricLabel: "Activity",
+      payoutDetail: "Market created by this wallet.",
+      payoutLabel: "Created",
+      payoutTone: "pending" as const,
+      statusLabel: "Market created",
+      statusTone: "pending" as const,
+    };
+  }
+  if (entry.kind === "bought") {
+    const spent = entry.collateralInAtoms - entry.collateralRefundAtoms;
+    return {
+      metricLabel: "Spent",
+      payoutDetail: `${formatPredictionOutcome(entry.outcomeAtoms)} ${entry.outcome} shares received.`,
+      payoutLabel: formatPredictionUsdg(spent),
+      payoutTone: "pending" as const,
+      statusLabel: `Bought ${entry.outcome}`,
+      statusTone: "open" as const,
+    };
+  }
+  if (entry.kind === "sold") {
+    return {
+      metricLabel: "Received",
+      payoutDetail: `${formatPredictionOutcome(entry.outcomeAtoms)} ${entry.outcome} shares sold.`,
+      payoutLabel: formatPredictionUsdg(entry.collateralAtoms),
+      payoutTone: "settled" as const,
+      statusLabel: `Sold ${entry.outcome}`,
+      statusTone: "pending" as const,
+    };
+  }
+  if (entry.kind === "redeemed") {
+    return {
+      metricLabel: "Payout",
+      payoutDetail: "Outcome shares redeemed onchain.",
+      payoutLabel: formatPredictionUsdg(entry.collateralAtoms),
+      payoutTone: "settled" as const,
+      statusLabel: "Payout redeemed",
+      statusTone: "final" as const,
+    };
+  }
+  const direction = entry.direction === "in"
+    ? "Received"
+    : entry.direction === "out"
+      ? "Sent"
+      : "Moved";
+  return {
+    metricLabel: "Shares",
+    payoutDetail: "Outcome shares transferred onchain.",
+    payoutLabel: `${formatPredictionOutcome(entry.outcomeAtoms)} ${entry.outcome}`,
+    payoutTone: "pending" as const,
+    statusLabel: `${direction} ${entry.outcome}`,
+    statusTone: "pending" as const,
+  };
+}
+
+export function predictionPortfolioHistoryViewModelV1(
+  entry: PredictionPortfolioHistoryEntry,
+): PredictionPortfolioItemViewModelV1 {
+  const market = entry.market;
+  const probabilityYesPercent = clampProbability(market.probabilityYesBps);
+  const presentation = historyPresentation(entry);
+  return Object.freeze({
+    actionLabel: "View market",
+    actionTone: "quiet",
+    artworkLabel: "BTC",
+    href: `/markets/${market.semanticKey}`,
+    id: `history:${entry.transactionHash}:${entry.logIndex}`,
+    positionLabel: presentation.statusLabel,
+    probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
+    probabilityYesPercent,
+    sides: historySides(entry),
+    timeLabel: "Confirmed onchain",
+    title: market.title,
+    ...presentation,
+  });
+}
+
 function tabLabel(tab: PredictionPortfolioTabV1) {
   return PORTFOLIO_TABS.find((candidate) => candidate.id === tab)?.label ?? "Prediction activity";
 }
@@ -322,7 +481,6 @@ function itemCount(
 }
 
 export function PredictionMarketPortfolio({
-  onLoadMorePositions,
   onRefresh,
   onRetry,
   viewModel,
@@ -338,24 +496,20 @@ export function PredictionMarketPortfolio({
   }, []);
   const [state, setState] = useState<InternalPortfolioState>(INITIAL_INTERNAL_STATE);
   const [refreshing, setRefreshing] = useState(false);
-  const [loadingOlder, setLoadingOlder] = useState(false);
-  const [olderError, setOlderError] = useState("");
   const [announcement, setAnnouncement] = useState("");
   const [activeTab, setActiveTab] = useState<PredictionPortfolioTabV1>("positions");
   const requestSequenceRef = useRef(0);
-  const activeRequestRef = useRef<InternalPortfolioRequest | null>(null);
+  const activeRequestRef = useRef<PredictionPortfolioRequest | null>(null);
   const tabRefs = useRef(new Map<PredictionPortfolioTabV1, HTMLButtonElement>());
 
   const loadPortfolio = useCallback(async (mode: "initial" | "refresh" | "retry") => {
     if (!account || !release) return;
     const accountKey = account.toLowerCase();
-    const request = {
-      accountKey,
-      requestKey: `${mode}:${++requestSequenceRef.current}`,
-    } satisfies InternalPortfolioRequest;
+    const request = createPredictionPortfolioRequest(
+      account,
+      `${mode}:${++requestSequenceRef.current}`,
+    );
     activeRequestRef.current = request;
-    setOlderError("");
-    setLoadingOlder(false);
     setRefreshing(true);
     setAnnouncement(mode === "initial"
       ? "Loading prediction activity."
@@ -375,28 +529,29 @@ export function PredictionMarketPortfolio({
         : "loading",
     }));
     try {
-      const directory = await readPredictionMarketDirectory({
-        account,
+      const data = await readPredictionMarketPortfolio({
         config: release,
-        limit: PORTFOLIO_SCAN_PAGE_SIZE,
+        request,
       });
-      if (!isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) return;
-      const markets = directory.markets.filter(
-        (market) => market.yesBalanceAtoms > 0n || market.noBalanceAtoms > 0n,
-      );
+      if (!isPredictionPortfolioRequestCurrent(data, activeRequestRef.current)) return;
       setState({
         accountKey,
-        errorMessage: "",
-        markets,
-        nextCursor: directory.nextCursor,
+        data,
+        errorMessage: data.failures.length > 0 ? PORTFOLIO_PARTIAL_ERROR : "",
         phase: "ready",
       });
+      const count = data.positions.length;
       setAnnouncement(mode === "initial"
-        ? `Prediction activity loaded. ${markets.length} ${markets.length === 1 ? "position" : "positions"}.`
-        : `Prediction activity refreshed. ${markets.length} ${markets.length === 1 ? "position" : "positions"}.`);
-    } catch {
-      if (!isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) return;
-      setState((current) => current.accountKey === accountKey && current.phase === "ready"
+        ? `Prediction activity loaded. ${count} ${count === 1 ? "position" : "positions"}.`
+        : `Prediction activity refreshed. ${count} ${count === 1 ? "position" : "positions"}.`);
+    } catch (error) {
+      const failedRequest = error instanceof PredictionPortfolioReadError
+        ? error.request
+        : request;
+      if (!isPredictionPortfolioRequestCurrent(failedRequest, activeRequestRef.current)) return;
+      setState((current) => current.accountKey === accountKey
+        && current.phase === "ready"
+        && current.data
         ? { ...current, errorMessage: PORTFOLIO_ERROR }
         : {
             ...INITIAL_INTERNAL_STATE,
@@ -406,7 +561,7 @@ export function PredictionMarketPortfolio({
           });
       setAnnouncement("Prediction activity could not be loaded.");
     } finally {
-      if (isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) {
+      if (isPredictionPortfolioRequestCurrent(request, activeRequestRef.current)) {
         setRefreshing(false);
       }
     }
@@ -417,87 +572,32 @@ export function PredictionMarketPortfolio({
     const timer = window.setTimeout(() => void loadPortfolio("initial"), 0);
     return () => {
       window.clearTimeout(timer);
-      if (activeRequestRef.current?.accountKey === account.toLowerCase()) {
+      if (activeRequestRef.current?.account.toLowerCase() === account.toLowerCase()) {
         activeRequestRef.current = null;
       }
     };
   }, [account, loadPortfolio, release, viewModel]);
 
-  const loadOlderPositions = useCallback(async () => {
-    if (
-      !account
-      || !release
-      || state.accountKey !== account.toLowerCase()
-      || state.phase !== "ready"
-      || state.nextCursor === 0n
-      || loadingOlder
-    ) return;
-    const accountKey = account.toLowerCase();
-    const request = {
-      accountKey,
-      requestKey: `older:${++requestSequenceRef.current}`,
-    } satisfies InternalPortfolioRequest;
-    activeRequestRef.current = request;
-    setLoadingOlder(true);
-    setOlderError("");
-    setAnnouncement("Loading older positions.");
-    try {
-      const directory = await readPredictionMarketDirectory({
-        account,
-        config: release,
-        cursor: state.nextCursor,
-        limit: PORTFOLIO_SCAN_PAGE_SIZE,
-      });
-      if (!isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) return;
-      const markets = directory.markets.filter(
-        (market) => market.yesBalanceAtoms > 0n || market.noBalanceAtoms > 0n,
-      );
-      setState((current) => {
-        if (current.accountKey !== accountKey || current.phase !== "ready") return current;
-        const known = new Set(current.markets.map((market) => market.semanticKey.toLowerCase()));
-        return {
-          ...current,
-          markets: [
-            ...current.markets,
-            ...markets.filter((market) => !known.has(market.semanticKey.toLowerCase())),
-          ],
-          nextCursor: directory.nextCursor,
-        };
-      });
-      setAnnouncement(
-        `${markets.length} older ${markets.length === 1 ? "position" : "positions"} loaded.`,
-      );
-    } catch {
-      if (!isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) return;
-      setOlderError(PORTFOLIO_OLDER_ERROR);
-      setAnnouncement("Older positions could not be loaded.");
-    } finally {
-      if (isInternalPortfolioRequestCurrent(request, activeRequestRef.current)) {
-        setLoadingOlder(false);
-      }
-    }
-  }, [account, loadingOlder, release, state.accountKey, state.nextCursor, state.phase]);
-
   const internalViewModel = useMemo<PredictionPortfolioViewModelV1>(() => {
     const accountKey = account?.toLowerCase() ?? null;
     const isCurrentAccount = state.accountKey === accountKey;
+    const data = isCurrentAccount ? state.data : null;
     return {
-      canLoadMorePositions: isCurrentAccount
-        && state.phase === "ready"
-        && state.nextCursor > 0n,
-      created: Object.freeze([]),
+      created: data
+        ? data.created.map(predictionPortfolioCreatedViewModelV1)
+        : Object.freeze([]),
       errorMessage: isCurrentAccount ? state.errorMessage || null : null,
-      history: Object.freeze([]),
-      loadMoreErrorMessage: olderError || null,
-      loadingMorePositions: loadingOlder,
+      history: data
+        ? data.history.map(predictionPortfolioHistoryViewModelV1)
+        : Object.freeze([]),
       phase: !isCurrentAccount || state.phase === "idle" ? "loading" : state.phase,
-      positions: isCurrentAccount
-        ? state.markets.map(predictionPortfolioPositionViewModelV1)
+      positions: data
+        ? data.positions.map(predictionPortfolioPositionViewModelV1)
         : Object.freeze([]),
       refreshing,
       statusMessage: announcement,
     };
-  }, [account, announcement, loadingOlder, olderError, refreshing, state]);
+  }, [account, announcement, refreshing, state]);
   const model = viewModel ?? internalViewModel;
   const accessState = viewModel
     ? "ready"
@@ -507,7 +607,7 @@ export function PredictionMarketPortfolio({
         ? "wallet"
         : "ready";
   const isBusy = accessState === "ready"
-    && (model.phase === "loading" || model.refreshing || model.loadingMorePositions);
+    && (model.phase === "loading" || model.refreshing);
   const canRefresh = viewModel
     ? Boolean(onRefresh || onRetry)
     : accessState === "ready";
@@ -542,14 +642,6 @@ export function PredictionMarketPortfolio({
     }
     void loadPortfolio("retry");
   }, [loadPortfolio, onRefresh, onRetry, runControlledAction, viewModel]);
-
-  const requestOlderPositions = useCallback(() => {
-    if (viewModel) {
-      void runControlledAction(onLoadMorePositions, "Loading older positions.");
-      return;
-    }
-    void loadOlderPositions();
-  }, [loadOlderPositions, onLoadMorePositions, runControlledAction, viewModel]);
 
   function selectTab(tab: PredictionPortfolioTabV1, moveFocus = false) {
     const count = itemCount(model, tab);
@@ -698,25 +790,6 @@ export function PredictionMarketPortfolio({
                 </>
               )}
 
-              {accessState === "ready"
-                && activeTab === "positions"
-                && model.canLoadMorePositions ? (
-                  <button
-                    className={styles.portfolioLoadMore}
-                    disabled={model.loadingMorePositions}
-                    onClick={requestOlderPositions}
-                    type="button"
-                  >
-                    {model.loadingMorePositions
-                      ? "Loading older positions"
-                      : "Show older positions"}
-                  </button>
-                ) : null}
-              {activeTab === "positions" && model.loadMoreErrorMessage ? (
-                <p className={styles.portfolioLoadMoreError} role="alert">
-                  {model.loadMoreErrorMessage}
-                </p>
-              ) : null}
             </>
           ) : null}
         </div>
@@ -761,7 +834,7 @@ function PortfolioCard({ item }: Readonly<{ item: PredictionPortfolioItemViewMod
           <dd>{item.probabilityLabel}</dd>
         </div>
         <div data-tone={item.payoutTone}>
-          <dt>Payout</dt>
+          <dt>{item.metricLabel}</dt>
           <dd>{item.payoutLabel}</dd>
           <small>{item.payoutDetail}</small>
         </div>

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -25,11 +25,13 @@ import { getPredictionMarketReleaseConfig } from "@/lib/prediction-market-chain"
 import {
   PredictionPortfolioReadError,
   createPredictionPortfolioRequest,
+  derivePredictionPortfolioPosition,
   isPredictionPortfolioRequestCurrent,
   readPredictionMarketPortfolio,
   type PredictionMarketPortfolio as PredictionMarketPortfolioData,
   type PredictionPortfolioCreatedMarket,
   type PredictionPortfolioHistoryEntry,
+  type PredictionPortfolioPosition,
   type PredictionPortfolioRequest,
 } from "@/lib/prediction-market-portfolio";
 import {
@@ -48,21 +50,7 @@ export type PredictionPortfolioSideViewModelV1 = Readonly<{
   shares: string;
 }>;
 
-export type PredictionPortfolioPositionSourceV1 = Readonly<{
-  finalOutcome: "YES" | "NO" | "INVALID" | null;
-  lifecycle:
-    | "open"
-    | "trading_closed"
-    | "final_yes"
-    | "final_no"
-    | "final_invalid";
-  market: PredictionMarketView;
-  noAtoms: bigint;
-  redeemableAtoms: bigint;
-  result: "pending" | "won" | "lost" | "neutral";
-  tradingClosed: boolean;
-  yesAtoms: bigint;
-}>;
+export type PredictionPortfolioPositionSourceV1 = PredictionPortfolioPosition;
 
 export type PredictionPortfolioItemViewModelV1 = Readonly<{
   actionLabel: string;
@@ -76,6 +64,7 @@ export type PredictionPortfolioItemViewModelV1 = Readonly<{
   payoutTone: "pending" | "ready" | "settled";
   positionLabel: string;
   probabilityLabel: string;
+  probabilityMetricLabel: "Probability" | "Result";
   probabilityYesPercent: number;
   sides: readonly PredictionPortfolioSideViewModelV1[];
   statusLabel: string;
@@ -86,7 +75,7 @@ export type PredictionPortfolioItemViewModelV1 = Readonly<{
 
 /**
  * Stable presentation boundary for the profile activity API. The current
- * component builds this from the directory reader; a profile API can provide
+ * component builds this from the complete portfolio reader; a profile API can provide
  * all three arrays without changing the panel or card layout.
  */
 export type PredictionPortfolioViewModelV1 = Readonly<{
@@ -124,6 +113,9 @@ const PORTFOLIO_ERROR =
   "Unable to load your prediction activity. Check your connection and try again.";
 const PORTFOLIO_PARTIAL_ERROR =
   "Some markets could not be verified. Refresh to try them again.";
+const PORTFOLIO_INITIAL_VISIBLE_ITEMS = 12;
+const PORTFOLIO_VISIBLE_ITEM_STEP = 12;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 const PORTFOLIO_TABS = [
   { id: "positions", label: "Positions" },
@@ -133,6 +125,36 @@ const PORTFOLIO_TABS = [
 
 function clampProbability(probabilityYesBps: number) {
   return Math.min(100, Math.max(0, probabilityYesBps / 100));
+}
+
+function marketProbabilityPresentation(market: PredictionMarketView) {
+  if (market.state === "FINAL_YES") {
+    return {
+      probabilityLabel: "YES won",
+      probabilityMetricLabel: "Result" as const,
+      probabilityYesPercent: 100,
+    };
+  }
+  if (market.state === "FINAL_NO") {
+    return {
+      probabilityLabel: "NO won",
+      probabilityMetricLabel: "Result" as const,
+      probabilityYesPercent: 0,
+    };
+  }
+  if (market.state === "FINAL_INVALID") {
+    return {
+      probabilityLabel: "Neutral",
+      probabilityMetricLabel: "Result" as const,
+      probabilityYesPercent: 50,
+    };
+  }
+  const probabilityYesPercent = clampProbability(market.probabilityYesBps);
+  return {
+    probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
+    probabilityMetricLabel: "Probability" as const,
+    probabilityYesPercent,
+  };
 }
 
 function countdown(target: bigint, current: bigint) {
@@ -158,7 +180,7 @@ export function predictionPortfolioPositionViewModelV1(
 ): PredictionPortfolioItemViewModelV1 {
   const source = "market" in input ? input : predictionPortfolioPositionSourceV1(input);
   const market = source.market;
-  const probabilityYesPercent = clampProbability(market.probabilityYesBps);
+  const probability = marketProbabilityPresentation(market);
   const sides = ([
     ["YES", source.yesAtoms],
     ["NO", source.noAtoms],
@@ -187,8 +209,7 @@ export function predictionPortfolioPositionViewModelV1(
       payoutLabel: potentialPayoutLabel,
       payoutTone: "pending",
       positionLabel: "Open position",
-      probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
-      probabilityYesPercent,
+      ...probability,
       sides: Object.freeze(sides),
       statusLabel: "Trading open",
       statusTone: "open",
@@ -209,8 +230,7 @@ export function predictionPortfolioPositionViewModelV1(
       payoutLabel: potentialPayoutLabel,
       payoutTone: "pending",
       positionLabel: "Position held",
-      probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
-      probabilityYesPercent,
+      ...probability,
       sides: Object.freeze(sides),
       statusLabel: "Awaiting result",
       statusTone: "pending",
@@ -226,10 +246,12 @@ export function predictionPortfolioPositionViewModelV1(
     ? "Won"
     : source.result === "lost"
       ? "Lost"
-      : "Neutral";
+      : source.result === "mixed"
+        ? `${winningOutcome} won`
+        : "Neutral";
   const payoutDetail = invalid
     ? `${redeemable ? "Redeemable now. " : ""}YES and NO each redeem for 0.50 USDG per share.`
-    : source.result === "won"
+    : redeemable
       ? `Redeemable now. ${winningOutcome} redeems for 1 USDG per share; the other side settles at zero.`
       : `${winningOutcome} won; your held side settles at zero.`;
 
@@ -244,8 +266,7 @@ export function predictionPortfolioPositionViewModelV1(
     payoutLabel: formatPredictionUsdg(source.redeemableAtoms),
     payoutTone: redeemable ? "ready" : "settled",
     positionLabel: "Final position",
-    probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
-    probabilityYesPercent,
+    ...probability,
     sides: Object.freeze(sides),
     statusLabel: resultLabel,
     statusTone: "final",
@@ -257,55 +278,7 @@ export function predictionPortfolioPositionViewModelV1(
 function predictionPortfolioPositionSourceV1(
   market: PredictionMarketView,
 ): PredictionPortfolioPositionSourceV1 {
-  const yesAtoms = market.yesBalanceAtoms;
-  const noAtoms = market.noBalanceAtoms;
-  if (market.state === "FINAL_YES") {
-    return {
-      finalOutcome: "YES",
-      lifecycle: "final_yes",
-      market,
-      noAtoms,
-      redeemableAtoms: yesAtoms * OUTCOME_FACE_SCALE,
-      result: yesAtoms > 0n ? "won" : "lost",
-      tradingClosed: true,
-      yesAtoms,
-    };
-  }
-  if (market.state === "FINAL_NO") {
-    return {
-      finalOutcome: "NO",
-      lifecycle: "final_no",
-      market,
-      noAtoms,
-      redeemableAtoms: noAtoms * OUTCOME_FACE_SCALE,
-      result: noAtoms > 0n ? "won" : "lost",
-      tradingClosed: true,
-      yesAtoms,
-    };
-  }
-  if (market.state === "FINAL_INVALID") {
-    return {
-      finalOutcome: "INVALID",
-      lifecycle: "final_invalid",
-      market,
-      noAtoms,
-      redeemableAtoms: (yesAtoms + noAtoms) * OUTCOME_FACE_SCALE / 2n,
-      result: "neutral",
-      tradingClosed: true,
-      yesAtoms,
-    };
-  }
-  const tradingClosed = market.blockTimestamp >= market.cutoff;
-  return {
-    finalOutcome: null,
-    lifecycle: tradingClosed ? "trading_closed" : "open",
-    market,
-    noAtoms,
-    redeemableAtoms: 0n,
-    result: "pending",
-    tradingClosed,
-    yesAtoms,
-  };
+  return derivePredictionPortfolioPosition(market);
 }
 
 function marketLifecycleSummary(market: PredictionMarketView) {
@@ -349,7 +322,7 @@ export function predictionPortfolioCreatedViewModelV1(
   entry: PredictionPortfolioCreatedMarket,
 ): PredictionPortfolioItemViewModelV1 {
   const market = entry.market;
-  const probabilityYesPercent = clampProbability(market.probabilityYesBps);
+  const probability = marketProbabilityPresentation(market);
   const lifecycle = marketLifecycleSummary(market);
   return Object.freeze({
     actionLabel: "View market",
@@ -362,8 +335,7 @@ export function predictionPortfolioCreatedViewModelV1(
     payoutLabel: "No shares",
     payoutTone: "pending",
     positionLabel: "Created market",
-    probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
-    probabilityYesPercent,
+    ...probability,
     sides: Object.freeze([]),
     ...lifecycle,
     title: market.title,
@@ -373,18 +345,63 @@ export function predictionPortfolioCreatedViewModelV1(
 function historySides(
   entry: PredictionPortfolioHistoryEntry,
 ): readonly PredictionPortfolioSideViewModelV1[] {
-  if (entry.kind === "bought" || entry.kind === "sold" || entry.kind === "transfer") {
+  const signed = (atoms: bigint, sign: "+" | "-") =>
+    `${sign}${formatPredictionOutcome(atoms)}`;
+  if (entry.kind === "bought") {
     return Object.freeze([{
       outcome: entry.outcome,
-      shares: formatPredictionOutcome(entry.outcomeAtoms),
+      shares: signed(entry.outcomeAtoms, "+"),
     }]);
   }
+  if (entry.kind === "sold") {
+    const complement: PredictionOutcome = entry.outcome === "YES" ? "NO" : "YES";
+    const netSoldAtoms = entry.outcomeAtoms - entry.soldRefundAtoms;
+    return Object.freeze([
+      ...(netSoldAtoms > 0n
+        ? [{ outcome: entry.outcome, shares: signed(netSoldAtoms, "-") }]
+        : []),
+      ...(entry.complementRefundAtoms > 0n
+        ? [{
+            outcome: complement,
+            shares: signed(entry.complementRefundAtoms, "+"),
+          }]
+        : []),
+    ]);
+  }
+  if (entry.kind === "transfer") {
+    const sign = entry.direction === "in" ? "+" : entry.direction === "out" ? "-" : null;
+    return Object.freeze([{
+      outcome: entry.outcome,
+      shares: sign
+        ? signed(entry.outcomeAtoms, sign)
+        : formatPredictionOutcome(entry.outcomeAtoms),
+    }]);
+  }
+  if (
+    entry.kind === "split" &&
+    (entry.accountRole === "recipient" || entry.accountRole === "self")
+  ) {
+    return Object.freeze(([
+      { outcome: "YES", shares: signed(entry.outcomeAtoms, "+") },
+      { outcome: "NO", shares: signed(entry.outcomeAtoms, "+") },
+    ] as const));
+  }
+  if (
+    entry.kind === "merged" &&
+    (entry.accountRole === "holder" || entry.accountRole === "self")
+  ) {
+    return Object.freeze(([
+      { outcome: "YES", shares: signed(entry.outcomeAtoms, "-") },
+      { outcome: "NO", shares: signed(entry.outcomeAtoms, "-") },
+    ] as const));
+  }
   if (entry.kind === "redeemed") {
+    if (entry.accountRole === "recipient") return Object.freeze([]);
     return Object.freeze(([
       ["YES", entry.yesAtoms],
       ["NO", entry.noAtoms],
     ] as const).flatMap(([outcome, atoms]) => atoms > 0n
-      ? [{ outcome, shares: formatPredictionOutcome(atoms) }]
+      ? [{ outcome, shares: signed(atoms, "-") }]
       : []));
   }
   return Object.freeze([]);
@@ -413,33 +430,90 @@ function historyPresentation(entry: PredictionPortfolioHistoryEntry) {
     };
   }
   if (entry.kind === "sold") {
+    const complement = entry.outcome === "YES" ? "NO" : "YES";
+    const soldAtoms = entry.outcomeAtoms - entry.soldRefundAtoms;
+    const returned = [
+      entry.soldRefundAtoms > 0n
+        ? `${formatPredictionOutcome(entry.soldRefundAtoms)} ${entry.outcome}`
+        : null,
+      entry.complementRefundAtoms > 0n
+        ? `${formatPredictionOutcome(entry.complementRefundAtoms)} ${complement}`
+        : null,
+    ].filter((value): value is string => Boolean(value));
     return {
       metricLabel: "Received",
-      payoutDetail: `${formatPredictionOutcome(entry.outcomeAtoms)} ${entry.outcome} shares sold.`,
+      payoutDetail: `${formatPredictionOutcome(soldAtoms)} ${entry.outcome} sold.${returned.length > 0 ? ` ${returned.join(" and ")} returned.` : " No outcome shares returned."}`,
       payoutLabel: formatPredictionUsdg(entry.collateralAtoms),
       payoutTone: "settled" as const,
       statusLabel: `Sold ${entry.outcome}`,
       statusTone: "pending" as const,
     };
   }
+  if (entry.kind === "split") {
+    const shares = formatPredictionOutcome(entry.outcomeAtoms);
+    if (entry.accountRole === "recipient") {
+      return {
+        metricLabel: "Shares received",
+        payoutDetail: `Received ${shares} YES and ${shares} NO from a direct split.`,
+        payoutLabel: `${shares} each`,
+        payoutTone: "pending" as const,
+        statusLabel: "Received YES + NO",
+        statusTone: "open" as const,
+      };
+    }
+    return {
+      metricLabel: "Spent",
+      payoutDetail: entry.accountRole === "self"
+        ? `Created ${shares} YES and ${shares} NO shares.`
+        : `Created ${shares} YES and ${shares} NO for another wallet.`,
+      payoutLabel: formatPredictionUsdg(entry.collateralAtoms),
+      payoutTone: "pending" as const,
+      statusLabel: entry.accountRole === "self" ? "Split USDG" : "Funded split",
+      statusTone: "open" as const,
+    };
+  }
+  if (entry.kind === "merged") {
+    const shares = formatPredictionOutcome(entry.outcomeAtoms);
+    return {
+      metricLabel: entry.accountRole === "holder" ? "Released" : "Received",
+      payoutDetail: entry.accountRole === "self"
+        ? `Merged ${shares} YES and ${shares} NO into USDG.`
+        : entry.accountRole === "holder"
+          ? `Merged ${shares} YES and ${shares} NO; USDG went to another wallet.`
+          : "Received USDG from another wallet's direct merge.",
+      payoutLabel: formatPredictionUsdg(entry.collateralAtoms),
+      payoutTone: "settled" as const,
+      statusLabel: "Merged YES + NO",
+      statusTone: "pending" as const,
+    };
+  }
   if (entry.kind === "redeemed") {
     return {
-      metricLabel: "Payout",
-      payoutDetail: "Outcome shares redeemed onchain.",
+      metricLabel: entry.accountRole === "holder" ? "Payout sent" : "Payout",
+      payoutDetail: entry.accountRole === "self"
+        ? "Outcome shares redeemed to this wallet."
+        : entry.accountRole === "holder"
+          ? "Outcome shares redeemed; payout sent to another wallet."
+          : "Payout received from another wallet's redemption.",
       payoutLabel: formatPredictionUsdg(entry.collateralAtoms),
       payoutTone: "settled" as const,
       statusLabel: "Payout redeemed",
       statusTone: "final" as const,
     };
   }
-  const direction = entry.direction === "in"
+  const burned = entry.direction === "out" && entry.to.toLowerCase() === ZERO_ADDRESS;
+  const direction = burned
+    ? "Burned"
+    : entry.direction === "in"
     ? "Received"
     : entry.direction === "out"
       ? "Sent"
       : "Moved";
   return {
     metricLabel: "Shares",
-    payoutDetail: "Outcome shares transferred onchain.",
+    payoutDetail: burned
+      ? "Outcome shares burned onchain."
+      : "Outcome shares transferred onchain.",
     payoutLabel: `${formatPredictionOutcome(entry.outcomeAtoms)} ${entry.outcome}`,
     payoutTone: "pending" as const,
     statusLabel: `${direction} ${entry.outcome}`,
@@ -451,7 +525,7 @@ export function predictionPortfolioHistoryViewModelV1(
   entry: PredictionPortfolioHistoryEntry,
 ): PredictionPortfolioItemViewModelV1 {
   const market = entry.market;
-  const probabilityYesPercent = clampProbability(market.probabilityYesBps);
+  const probability = marketProbabilityPresentation(market);
   const presentation = historyPresentation(entry);
   return Object.freeze({
     actionLabel: "View market",
@@ -460,10 +534,9 @@ export function predictionPortfolioHistoryViewModelV1(
     href: `/markets/${market.semanticKey}`,
     id: `history:${entry.transactionHash}:${entry.logIndex}`,
     positionLabel: presentation.statusLabel,
-    probabilityLabel: `${probabilityYesPercent.toFixed(0)}% YES`,
-    probabilityYesPercent,
+    ...probability,
     sides: historySides(entry),
-    timeLabel: "Confirmed onchain",
+    timeLabel: "Observed onchain",
     title: market.title,
     ...presentation,
   });
@@ -498,6 +571,11 @@ export function PredictionMarketPortfolio({
   const [refreshing, setRefreshing] = useState(false);
   const [announcement, setAnnouncement] = useState("");
   const [activeTab, setActiveTab] = useState<PredictionPortfolioTabV1>("positions");
+  const [visibleCounts, setVisibleCounts] = useState<Record<PredictionPortfolioTabV1, number>>({
+    positions: PORTFOLIO_INITIAL_VISIBLE_ITEMS,
+    created: PORTFOLIO_INITIAL_VISIBLE_ITEMS,
+    history: PORTFOLIO_INITIAL_VISIBLE_ITEMS,
+  });
   const requestSequenceRef = useRef(0);
   const activeRequestRef = useRef<PredictionPortfolioRequest | null>(null);
   const tabRefs = useRef(new Map<PredictionPortfolioTabV1, HTMLButtonElement>());
@@ -611,7 +689,9 @@ export function PredictionMarketPortfolio({
   const canRefresh = viewModel
     ? Boolean(onRefresh || onRetry)
     : accessState === "ready";
-  const visibleItems = model[activeTab];
+  const activeItems = model[activeTab];
+  const visibleItems = activeItems.slice(0, visibleCounts[activeTab]);
+  const remainingItemCount = Math.max(0, activeItems.length - visibleItems.length);
 
   const runControlledAction = useCallback(async (
     action: (() => void | Promise<void>) | undefined,
@@ -779,11 +859,39 @@ export function PredictionMarketPortfolio({
                     </div>
                   ) : null}
                   {visibleItems.length > 0 ? (
-                    <div className={styles.portfolioCards}>
-                      {visibleItems.map((item) => (
-                        <PortfolioCard item={item} key={item.id} />
-                      ))}
-                    </div>
+                    <>
+                      <div className={styles.portfolioCards}>
+                        {visibleItems.map((item) => (
+                          <PortfolioCard item={item} key={item.id} />
+                        ))}
+                      </div>
+                      {remainingItemCount > 0 ? (
+                        <button
+                          className={styles.portfolioShowMore}
+                          type="button"
+                          onClick={() => {
+                            const increment = Math.min(
+                              PORTFOLIO_VISIBLE_ITEM_STEP,
+                              remainingItemCount,
+                            );
+                            setVisibleCounts((current) => ({
+                              ...current,
+                              [activeTab]: current[activeTab] + increment,
+                            }));
+                            setAnnouncement(
+                              `${increment} more items shown in ${tabLabel(activeTab)}.`,
+                            );
+                            if (increment === remainingItemCount) {
+                              window.requestAnimationFrame(() => {
+                                tabRefs.current.get(activeTab)?.focus();
+                              });
+                            }
+                          }}
+                        >
+                          Show {Math.min(PORTFOLIO_VISIBLE_ITEM_STEP, remainingItemCount)} more
+                        </button>
+                      ) : null}
+                    </>
                   ) : (
                     <PortfolioTabEmptyState tab={activeTab} />
                   )}
@@ -818,7 +926,8 @@ function PortfolioCard({ item }: Readonly<{ item: PredictionPortfolioItemViewMod
         <h3>
           <Link href={item.href}>{item.title}</Link>
         </h3>
-        <div className={styles.portfolioHoldings} aria-label={item.positionLabel}>
+        <span className="sr-only">{item.positionLabel}: </span>
+        <div className={styles.portfolioHoldings}>
           {item.sides.length > 0 ? item.sides.map((side) => (
             <span data-outcome={side.outcome} key={side.outcome}>
               <strong>{side.outcome}</strong>
@@ -830,7 +939,7 @@ function PortfolioCard({ item }: Readonly<{ item: PredictionPortfolioItemViewMod
 
       <dl className={styles.portfolioMetrics}>
         <div>
-          <dt>Probability</dt>
+          <dt>{item.probabilityMetricLabel}</dt>
           <dd>{item.probabilityLabel}</dd>
         </div>
         <div data-tone={item.payoutTone}>
@@ -866,7 +975,7 @@ function PortfolioTabEmptyState({ tab }: Readonly<{ tab: PredictionPortfolioTabV
       <PortfolioEmptyState
         icon={<CircleDollarSign aria-hidden="true" size={21} strokeWidth={1.8} />}
         title="No prediction history yet"
-        description="Completed positions and payouts will appear here."
+        description="Trades, transfers and payouts will appear here."
         action={<Link className={styles.portfolioSecondaryAction} href="/markets">Browse markets</Link>}
       />
     );

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -1371,6 +1371,7 @@
 .imageAction:focus-visible,
 .editAction:focus-visible,
 .usernameRow input:focus-visible,
+.bannerPositionFields input:focus-visible,
 .connectButton:focus-visible,
 .claimButton:focus-visible,
 .secondaryAction:focus-visible,
@@ -1791,7 +1792,7 @@
   isolation: isolate;
   overflow: hidden;
   position: relative;
-  touch-action: none;
+  touch-action: auto;
 }
 
 .profileBanner::after {
@@ -1804,12 +1805,16 @@
 }
 
 .profileBannerEditing {
-  cursor: grab;
   outline: 1px dashed rgb(255 255 255 / 0.24);
   outline-offset: -8px;
 }
 
-.profileBannerEditing:active {
+.profileBannerPositionable {
+  cursor: grab;
+  touch-action: none;
+}
+
+.profileBannerPositionable:active {
   cursor: grabbing;
 }
 
@@ -1923,6 +1928,57 @@
   align-items: start;
   gap: 16px;
   grid-template-columns: minmax(190px, 0.65fr) minmax(360px, 1.35fr);
+}
+
+.bannerPositionControl {
+  border: 0;
+  grid-column: 1 / -1;
+  margin: 0;
+  min-width: 0;
+  padding: 0;
+}
+
+.bannerPositionControl legend {
+  margin-bottom: 7px;
+  padding: 0;
+}
+
+.bannerPositionFields {
+  align-items: center;
+  background: #111;
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  display: grid;
+  gap: 4px 18px;
+  grid-template-columns: repeat(2, minmax(190px, 1fr));
+  padding: 8px 13px 9px;
+}
+
+.bannerPositionFields label {
+  align-items: center;
+  color: var(--webde-muted);
+  display: grid;
+  font-size: 12px;
+  gap: 12px;
+  grid-template-columns: auto minmax(96px, 1fr);
+  min-height: 44px;
+  min-width: 0;
+}
+
+.bannerPositionFields input {
+  accent-color: var(--webde-ink);
+  cursor: pointer;
+  height: 44px;
+  margin: 0;
+  min-width: 0;
+  width: 100%;
+}
+
+.bannerPositionStatus {
+  color: var(--webde-dim);
+  font-size: 11px;
+  grid-column: 1 / -1;
+  line-height: 1.45;
 }
 
 .bioControl,
@@ -2235,6 +2291,10 @@
 
   .editGrid,
   .profileLinkFields {
+    grid-template-columns: 1fr;
+  }
+
+  .bannerPositionFields {
     grid-template-columns: 1fr;
   }
 

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -1168,6 +1168,35 @@ export function withoutClosedDeepProfileData(
   };
 }
 
+type BannerPositionAxis = "horizontal" | "vertical";
+
+export function formatBannerPositionValue(
+  axis: BannerPositionAxis,
+  value: number,
+) {
+  const roundedValue = Math.max(0, Math.min(100, Math.round(value)));
+  if (axis === "horizontal") {
+    if (roundedValue === 0) return "aligned to the left edge";
+    if (roundedValue === 50) return "centered horizontally";
+    if (roundedValue === 100) return "aligned to the right edge";
+    return `${roundedValue}% from the left`;
+  }
+  if (roundedValue === 0) return "aligned to the top edge";
+  if (roundedValue === 50) return "centered vertically";
+  if (roundedValue === 100) return "aligned to the bottom edge";
+  return `${roundedValue}% from the top`;
+}
+
+export function formatBannerPositionStatus(position: {
+  x: number;
+  y: number;
+}) {
+  return `Banner position: ${formatBannerPositionValue(
+    "horizontal",
+    position.x,
+  )}, ${formatBannerPositionValue("vertical", position.y)}.`;
+}
+
 export function ProfileView({ onchainData }: ProfileViewProps = {}) {
   const { wallet, openWallet, sendTransaction, connecting } = useWallet();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -2976,6 +3005,10 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         <div
           className={`${styles.profileBanner} ${
             editingProfile ? styles.profileBannerEditing : ""
+          } ${
+            editingProfile && bannerDraft
+              ? styles.profileBannerPositionable
+              : ""
           }`}
           onPointerDown={startBannerDrag}
           onPointerMove={moveBannerDrag}
@@ -3023,7 +3056,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
                 {preparingImage ? "Preparing…" : "Choose banner"}
               </button>
               {bannerDraft ? (
-                <span>Drag the image to choose the visible area</span>
+                <span>Drag to position · keyboard controls below</span>
               ) : (
                 <span>Choose or drop an image · 3000 × 1000 recommended</span>
               )}
@@ -3156,6 +3189,69 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
                     </button>
                   </div>
                 </div>
+
+                {bannerDraft ? (
+                  <fieldset className={styles.bannerPositionControl}>
+                    <legend className={styles.fieldLabel}>
+                      Banner position
+                    </legend>
+                    <div className={styles.bannerPositionFields}>
+                      <label>
+                        <span>Horizontal position</span>
+                        <input
+                          type="range"
+                          min="0"
+                          max="100"
+                          step="1"
+                          value={Math.round(bannerPositionDraft.x)}
+                          aria-valuetext={formatBannerPositionValue(
+                            "horizontal",
+                            bannerPositionDraft.x,
+                          )}
+                          aria-describedby="profile-banner-position-status"
+                          onChange={(event) => {
+                            const x = Number(event.currentTarget.value);
+                            setBannerPositionDraft((current) => ({
+                              ...current,
+                              x,
+                            }));
+                            setSaveError("");
+                          }}
+                        />
+                      </label>
+                      <label>
+                        <span>Vertical position</span>
+                        <input
+                          type="range"
+                          min="0"
+                          max="100"
+                          step="1"
+                          value={Math.round(bannerPositionDraft.y)}
+                          aria-valuetext={formatBannerPositionValue(
+                            "vertical",
+                            bannerPositionDraft.y,
+                          )}
+                          aria-describedby="profile-banner-position-status"
+                          onChange={(event) => {
+                            const y = Number(event.currentTarget.value);
+                            setBannerPositionDraft((current) => ({
+                              ...current,
+                              y,
+                            }));
+                            setSaveError("");
+                          }}
+                        />
+                      </label>
+                      <output
+                        id="profile-banner-position-status"
+                        className={styles.bannerPositionStatus}
+                        role="status"
+                      >
+                        {formatBannerPositionStatus(bannerPositionDraft)}
+                      </output>
+                    </div>
+                  </fieldset>
+                ) : null}
 
                 <div className={styles.bioControl}>
                   <label className={styles.fieldLabel} htmlFor="profile-bio">

--- a/lib/prediction-market-chain.ts
+++ b/lib/prediction-market-chain.ts
@@ -323,7 +323,7 @@ const exposureReadAbi = [
   },
 ] as const;
 
-const marketCreatedEventAbi = [
+export const predictionMarketFactoryEventAbi = [
   {
     type: "event",
     name: "MarketCreated",
@@ -1045,11 +1045,11 @@ export async function waitForPredictionMarketCreation({
   }
 
   let created: Extract<
-    ReturnType<typeof decodeEventLog<typeof marketCreatedEventAbi>>,
+    ReturnType<typeof decodeEventLog<typeof predictionMarketFactoryEventAbi>>,
     { eventName: "MarketCreated" }
   > | null = null;
   let components: Extract<
-    ReturnType<typeof decodeEventLog<typeof marketCreatedEventAbi>>,
+    ReturnType<typeof decodeEventLog<typeof predictionMarketFactoryEventAbi>>,
     { eventName: "MarketComponents" }
   > | null = null;
   for (const log of receipt.logs) {
@@ -1058,7 +1058,7 @@ export async function waitForPredictionMarketCreation({
     }
     try {
       const decoded = decodeEventLog({
-        abi: marketCreatedEventAbi,
+        abi: predictionMarketFactoryEventAbi,
         data: log.data,
         topics: log.topics,
       });

--- a/lib/prediction-market-portfolio.ts
+++ b/lib/prediction-market-portfolio.ts
@@ -538,6 +538,7 @@ function indexPredictionMarketComponents(
 
 async function readOutcomeTransferLogs({
   account,
+  addresses,
   allowedTokens,
   clients,
   direction,
@@ -545,48 +546,37 @@ async function readOutcomeTransferLogs({
   toBlock,
 }: {
   account: Address;
+  addresses: readonly Address[];
   allowedTokens: ReadonlySet<string>;
   clients: PredictionMarketClients;
   direction: "from" | "to";
   fromBlock: bigint;
   toBlock: bigint;
 }) {
-  if (direction === "from") {
-    return readPredictionPortfolioLogs({
-      clients,
-      fromBlock,
-      read: (client, range) =>
-        client
-          .getLogs({
-            args: { from: account },
-            event: outcomeTransferEvent,
-            fromBlock: range.fromBlock,
-            strict: true,
-            toBlock: range.toBlock,
-          })
-          .then((logs) =>
-            filterPredictionOutcomeLogs(logs, allowedTokens),
-          ),
-      toBlock,
-    });
+  const logs = [];
+  for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
+    logs.push(
+      ...(await readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client
+            .getLogs({
+              address: addressBatch,
+              args: direction === "from" ? { from: account } : { to: account },
+              event: outcomeTransferEvent,
+              fromBlock: range.fromBlock,
+              strict: true,
+              toBlock: range.toBlock,
+            })
+            .then((providerLogs) =>
+              filterPredictionOutcomeLogs(providerLogs, allowedTokens),
+            ),
+        toBlock,
+      })),
+    );
   }
-  return readPredictionPortfolioLogs({
-    clients,
-    fromBlock,
-    read: (client, range) =>
-      client
-        .getLogs({
-          args: { to: account },
-          event: outcomeTransferEvent,
-          fromBlock: range.fromBlock,
-          strict: true,
-          toBlock: range.toBlock,
-      })
-      .then((logs) =>
-        filterPredictionOutcomeLogs(logs, allowedTokens),
-      ),
-    toBlock,
-  });
+  return dedupePortfolioLogs(logs);
 }
 
 async function readPredictionRedeemedLogs({
@@ -705,6 +695,9 @@ async function readPredictionMarketPortfolioAtRequest({
   const vaultAddresses = [...componentIndex.byVault.values()].map(
     (component) => component.vault,
   );
+  const outcomeTokenAddresses = [...componentIndex.byToken.values()].map(
+    ({ component, outcome }) => outcome === "YES" ? component.yesToken : component.noToken,
+  );
   const allowedTokens = new Set(componentIndex.byToken.keys());
 
   const [createdLogs, boughtLogs, soldLogs, incomingTransfers, outgoingTransfers, redeemedLogs] =
@@ -753,6 +746,7 @@ async function readPredictionMarketPortfolioAtRequest({
       }),
       readOutcomeTransferLogs({
         account: request.account,
+        addresses: outcomeTokenAddresses,
         allowedTokens,
         clients,
         direction: "to",
@@ -761,6 +755,7 @@ async function readPredictionMarketPortfolioAtRequest({
       }),
       readOutcomeTransferLogs({
         account: request.account,
+        addresses: outcomeTokenAddresses,
         allowedTokens,
         clients,
         direction: "from",

--- a/lib/prediction-market-portfolio.ts
+++ b/lib/prediction-market-portfolio.ts
@@ -1,0 +1,1029 @@
+import {
+  getAddress,
+  isAddress,
+  type Address,
+  type Hex,
+} from "viem";
+
+import {
+  createPredictionMarketPublicClients,
+  predictionMarketFactoryEventAbi,
+  type PredictionMarketPublicClient,
+  type PredictionMarketReleaseConfig,
+} from "./prediction-market-chain";
+import { predictionMarketErrorMessage } from "./prediction-market-errors";
+import {
+  readPredictionMarketSnapshot,
+  readPredictionMarketsAtSnapshot,
+  type PredictionMarketBatchFailure,
+  type PredictionMarketView,
+} from "./prediction-market-trading";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const ZERO_BYTES32 = `0x${"00".repeat(32)}`;
+const FACE_SCALE = 10n;
+const LOG_BLOCK_SPAN = 50_000n;
+const LOG_ADDRESS_BATCH_SIZE = 32;
+
+const marketCreatedEvent = predictionMarketFactoryEventAbi[0];
+const marketComponentsEvent = predictionMarketFactoryEventAbi[1];
+
+const outcomeBoughtEvent = {
+  type: "event",
+  name: "OutcomeBought",
+  anonymous: false,
+  inputs: [
+    { name: "user", type: "address", indexed: true },
+    { name: "vault", type: "address", indexed: true },
+    { name: "yes", type: "bool", indexed: true },
+    { name: "collateralInAtoms", type: "uint256", indexed: false },
+    { name: "collateralRefundAtoms", type: "uint256", indexed: false },
+    { name: "outcomeAtoms", type: "uint256", indexed: false },
+  ],
+} as const;
+
+const outcomeSoldEvent = {
+  type: "event",
+  name: "OutcomeSold",
+  anonymous: false,
+  inputs: [
+    { name: "user", type: "address", indexed: true },
+    { name: "vault", type: "address", indexed: true },
+    { name: "yes", type: "bool", indexed: true },
+    { name: "outcomeInAtoms", type: "uint256", indexed: false },
+    { name: "collateralAtoms", type: "uint256", indexed: false },
+    { name: "soldRefundAtoms", type: "uint256", indexed: false },
+    { name: "complementRefundAtoms", type: "uint256", indexed: false },
+  ],
+} as const;
+
+const outcomeTransferEvent = {
+  type: "event",
+  name: "Transfer",
+  anonymous: false,
+  inputs: [
+    { name: "from", type: "address", indexed: true },
+    { name: "to", type: "address", indexed: true },
+    { name: "value", type: "uint256", indexed: false },
+  ],
+} as const;
+
+const predictionRedeemedEvent = {
+  type: "event",
+  name: "Redeemed",
+  anonymous: false,
+  inputs: [
+    { name: "holder", type: "address", indexed: true },
+    { name: "recipient", type: "address", indexed: true },
+    { name: "yesAtoms", type: "uint256", indexed: false },
+    { name: "noAtoms", type: "uint256", indexed: false },
+    { name: "collateralAtoms", type: "uint256", indexed: false },
+  ],
+} as const;
+
+export type PredictionPortfolioRequest = Readonly<{
+  account: Address;
+  requestKey: string;
+}>;
+
+export type PredictionPortfolioLifecycle =
+  | "open"
+  | "trading_closed"
+  | "final_yes"
+  | "final_no"
+  | "final_invalid";
+
+export type PredictionPortfolioResult = "pending" | "won" | "lost" | "neutral";
+
+export type PredictionPortfolioPosition = Readonly<{
+  finalOutcome: "YES" | "NO" | "INVALID" | null;
+  lifecycle: PredictionPortfolioLifecycle;
+  market: PredictionMarketView;
+  noAtoms: bigint;
+  redeemableAtoms: bigint;
+  result: PredictionPortfolioResult;
+  tradingClosed: boolean;
+  yesAtoms: bigint;
+}>;
+
+type PredictionPortfolioHistoryBase = Readonly<{
+  blockNumber: bigint;
+  logIndex: number;
+  market: PredictionMarketView;
+  semanticKey: Hex;
+  transactionHash: Hex;
+  transactionIndex: number;
+  vault: Address;
+}>;
+
+export type PredictionPortfolioCreatedMarket = Readonly<{
+  blockNumber: bigint;
+  logIndex: number;
+  market: PredictionMarketView;
+  transactionHash: Hex;
+  transactionIndex: number;
+}>;
+
+export type PredictionPortfolioHistoryEntry =
+  | Readonly<
+      PredictionPortfolioHistoryBase & {
+        creator: Address;
+        kind: "created";
+      }
+    >
+  | Readonly<
+      PredictionPortfolioHistoryBase & {
+        collateralInAtoms: bigint;
+        collateralRefundAtoms: bigint;
+        kind: "bought";
+        outcome: "YES" | "NO";
+        outcomeAtoms: bigint;
+      }
+    >
+  | Readonly<
+      PredictionPortfolioHistoryBase & {
+        collateralAtoms: bigint;
+        complementRefundAtoms: bigint;
+        kind: "sold";
+        outcome: "YES" | "NO";
+        outcomeAtoms: bigint;
+        soldRefundAtoms: bigint;
+      }
+    >
+  | Readonly<
+      PredictionPortfolioHistoryBase & {
+        direction: "in" | "out" | "self";
+        from: Address;
+        kind: "transfer";
+        outcome: "YES" | "NO";
+        outcomeAtoms: bigint;
+        to: Address;
+      }
+    >
+  | Readonly<
+      PredictionPortfolioHistoryBase & {
+        collateralAtoms: bigint;
+        kind: "redeemed";
+        noAtoms: bigint;
+        recipient: Address;
+        yesAtoms: bigint;
+      }
+    >;
+
+export type PredictionPortfolioMarketFailure = PredictionMarketBatchFailure;
+
+export type PredictionMarketPortfolio = Readonly<{
+  blockNumber: bigint;
+  blockTimestamp: bigint;
+  created: readonly PredictionPortfolioCreatedMarket[];
+  failures: readonly PredictionPortfolioMarketFailure[];
+  history: readonly PredictionPortfolioHistoryEntry[];
+  positions: readonly PredictionPortfolioPosition[];
+  relevantMarketCount: number;
+  request: PredictionPortfolioRequest;
+  scannedMarketCount: bigint;
+}>;
+
+export class PredictionPortfolioReadError extends Error {
+  readonly request: PredictionPortfolioRequest;
+
+  constructor(request: PredictionPortfolioRequest, error: unknown) {
+    super(
+      predictionMarketErrorMessage(
+        error,
+        "Prediction portfolio history is unavailable",
+      ),
+    );
+    this.name = "PredictionPortfolioReadError";
+    this.request = request;
+  }
+}
+
+export function createPredictionPortfolioRequest(
+  account: string,
+  requestKey: string,
+): PredictionPortfolioRequest {
+  if (!isAddress(account) || account.toLowerCase() === ZERO_ADDRESS) {
+    throw new Error("The portfolio wallet address is invalid");
+  }
+  const normalizedKey = requestKey.trim();
+  if (!normalizedKey || normalizedKey.length > 128) {
+    throw new Error("The portfolio request key is invalid");
+  }
+  return { account: getAddress(account), requestKey: normalizedKey };
+}
+
+type PredictionPortfolioRequestCarrier =
+  | PredictionPortfolioRequest
+  | Readonly<{ request: PredictionPortfolioRequest }>;
+
+export function isPredictionPortfolioRequestCurrent(
+  candidate: PredictionPortfolioRequestCarrier,
+  current: PredictionPortfolioRequest | null | undefined,
+) {
+  if (!current) return false;
+  const request = "request" in candidate ? candidate.request : candidate;
+  return (
+    request.account.toLowerCase() === current.account.toLowerCase() &&
+    request.requestKey === current.requestKey
+  );
+}
+
+export function derivePredictionPortfolioPosition(
+  market: PredictionMarketView,
+): PredictionPortfolioPosition {
+  const yesAtoms = market.yesBalanceAtoms;
+  const noAtoms = market.noBalanceAtoms;
+  if (yesAtoms < 0n || noAtoms < 0n || (yesAtoms === 0n && noAtoms === 0n)) {
+    throw new Error("A prediction portfolio position needs a positive outcome balance");
+  }
+
+  if (market.state === "FINAL_YES") {
+    return {
+      finalOutcome: "YES",
+      lifecycle: "final_yes",
+      market,
+      noAtoms,
+      redeemableAtoms: yesAtoms * FACE_SCALE,
+      result: yesAtoms > 0n ? "won" : "lost",
+      tradingClosed: true,
+      yesAtoms,
+    };
+  }
+  if (market.state === "FINAL_NO") {
+    return {
+      finalOutcome: "NO",
+      lifecycle: "final_no",
+      market,
+      noAtoms,
+      redeemableAtoms: noAtoms * FACE_SCALE,
+      result: noAtoms > 0n ? "won" : "lost",
+      tradingClosed: true,
+      yesAtoms,
+    };
+  }
+  if (market.state === "FINAL_INVALID") {
+    return {
+      finalOutcome: "INVALID",
+      lifecycle: "final_invalid",
+      market,
+      noAtoms,
+      redeemableAtoms: (yesAtoms + noAtoms) * FACE_SCALE / 2n,
+      result: "neutral",
+      tradingClosed: true,
+      yesAtoms,
+    };
+  }
+
+  const tradingClosed = market.blockTimestamp >= market.cutoff;
+  return {
+    finalOutcome: null,
+    lifecycle: tradingClosed ? "trading_closed" : "open",
+    market,
+    noAtoms,
+    redeemableAtoms: 0n,
+    result: "pending",
+    tradingClosed,
+    yesAtoms,
+  };
+}
+
+type PredictionMarketClients = ReturnType<
+  typeof createPredictionMarketPublicClients
+>;
+
+type ConfirmedPortfolioLog = Readonly<{
+  address: Address;
+  blockHash: Hex;
+  blockNumber: bigint;
+  data: Hex;
+  logIndex: number;
+  removed: boolean;
+  topics: readonly Hex[];
+  transactionHash: Hex;
+  transactionIndex: number;
+}>;
+
+type PredictionPortfolioBlockRange = Readonly<{
+  fromBlock: bigint;
+  toBlock: bigint;
+}>;
+
+function predictionPortfolioBlockRanges(
+  fromBlock: bigint,
+  toBlock: bigint,
+  span = LOG_BLOCK_SPAN,
+): readonly PredictionPortfolioBlockRange[] {
+  if (fromBlock < 0n || toBlock < fromBlock || span <= 0n) {
+    throw new Error("The prediction portfolio log range is invalid");
+  }
+  const ranges: PredictionPortfolioBlockRange[] = [];
+  for (let start = fromBlock; start <= toBlock; start += span) {
+    const end = start + span - 1n;
+    ranges.push({
+      fromBlock: start,
+      toBlock: end < toBlock ? end : toBlock,
+    });
+  }
+  return ranges;
+}
+
+function comparePortfolioLogs(
+  left: ConfirmedPortfolioLog,
+  right: ConfirmedPortfolioLog,
+) {
+  if (left.blockNumber !== right.blockNumber) {
+    return left.blockNumber < right.blockNumber ? -1 : 1;
+  }
+  if (left.transactionIndex !== right.transactionIndex) {
+    return left.transactionIndex - right.transactionIndex;
+  }
+  return left.logIndex - right.logIndex;
+}
+
+function normalizedPortfolioLog(log: ConfirmedPortfolioLog) {
+  if (
+    log.removed ||
+    log.blockHash === null ||
+    log.blockNumber === null ||
+    log.transactionHash === null ||
+    log.transactionIndex === null ||
+    log.logIndex === null
+  ) {
+    throw new Error("A prediction portfolio RPC returned a pending or removed log");
+  }
+  return {
+    address: log.address.toLowerCase(),
+    blockHash: log.blockHash.toLowerCase(),
+    blockNumber: log.blockNumber.toString(),
+    data: log.data.toLowerCase(),
+    logIndex: log.logIndex,
+    topics: log.topics.map((topic) => topic.toLowerCase()),
+    transactionHash: log.transactionHash.toLowerCase(),
+    transactionIndex: log.transactionIndex,
+  };
+}
+
+async function readPredictionPortfolioLogs<Log extends ConfirmedPortfolioLog>({
+  clients,
+  fromBlock,
+  read,
+  toBlock,
+}: {
+  clients: PredictionMarketClients;
+  fromBlock: bigint;
+  read: (
+    client: PredictionMarketPublicClient,
+    range: PredictionPortfolioBlockRange,
+  ) => Promise<readonly Log[]>;
+  toBlock: bigint;
+}): Promise<readonly Log[]> {
+  const logs: Log[] = [];
+  for (const range of predictionPortfolioBlockRanges(fromBlock, toBlock)) {
+    const byClient = await Promise.all(
+      clients.map((client) => read(client, range)),
+    );
+    const normalized = byClient.map((providerLogs) =>
+      [...providerLogs]
+        .sort(comparePortfolioLogs)
+        .map(normalizedPortfolioLog),
+    );
+    if (JSON.stringify(normalized[0]) !== JSON.stringify(normalized[1])) {
+      throw new Error(
+        "The two Robinhood RPCs disagree about prediction portfolio history",
+      );
+    }
+    logs.push(...[...byClient[0]].sort(comparePortfolioLogs));
+  }
+  return logs;
+}
+
+function predictionPortfolioAddressBatches(
+  addresses: readonly Address[],
+): readonly Address[][] {
+  const batches: Address[][] = [];
+  for (let index = 0; index < addresses.length; index += LOG_ADDRESS_BATCH_SIZE) {
+    batches.push(addresses.slice(index, index + LOG_ADDRESS_BATCH_SIZE));
+  }
+  return batches;
+}
+
+function portfolioLogKey(log: ConfirmedPortfolioLog) {
+  return `${log.transactionHash.toLowerCase()}:${log.logIndex}`;
+}
+
+function dedupePortfolioLogs<Log extends ConfirmedPortfolioLog>(
+  logs: readonly Log[],
+) {
+  const deduped = new Map<string, Log>();
+  for (const log of logs) deduped.set(portfolioLogKey(log), log);
+  return [...deduped.values()].sort(comparePortfolioLogs);
+}
+
+function filterPredictionOutcomeLogs<Log extends ConfirmedPortfolioLog>(
+  logs: readonly Log[],
+  allowedTokens: ReadonlySet<string>,
+) {
+  return logs.filter((log) => allowedTokens.has(log.address.toLowerCase()));
+}
+
+type PredictionMarketComponent = Readonly<{
+  checkpoint: Address;
+  cutoff: bigint;
+  noToken: Address;
+  observationTime: bigint;
+  poolId: Hex;
+  semanticKey: Hex;
+  thresholdAtoms: bigint;
+  vault: Address;
+  yesToken: Address;
+}>;
+
+type PredictionMarketTokenIdentity = Readonly<{
+  component: PredictionMarketComponent;
+  outcome: "YES" | "NO";
+}>;
+
+type PredictionMarketComponentIndex = Readonly<{
+  bySemanticKey: ReadonlyMap<string, PredictionMarketComponent>;
+  byToken: ReadonlyMap<string, PredictionMarketTokenIdentity>;
+  byVault: ReadonlyMap<string, PredictionMarketComponent>;
+  failures: readonly PredictionPortfolioMarketFailure[];
+}>;
+
+function componentIdentity(component: PredictionMarketComponent) {
+  return JSON.stringify(component, (_, value: unknown) =>
+    typeof value === "bigint" ? value.toString() : value,
+  );
+}
+
+function indexPredictionMarketComponents(
+  components: readonly PredictionMarketComponent[],
+): PredictionMarketComponentIndex {
+  const bySemanticKey = new Map<string, PredictionMarketComponent>();
+  const invalidKeys = new Set<string>();
+  const reasons = new Map<string, string>();
+  for (const component of components) {
+    const key = component.semanticKey.toLowerCase();
+    if (
+      component.semanticKey.toLowerCase() === ZERO_BYTES32 ||
+      component.poolId.toLowerCase() === ZERO_BYTES32 ||
+      component.vault.toLowerCase() === ZERO_ADDRESS ||
+      component.checkpoint.toLowerCase() === ZERO_ADDRESS ||
+      component.yesToken.toLowerCase() === ZERO_ADDRESS ||
+      component.noToken.toLowerCase() === ZERO_ADDRESS ||
+      component.yesToken.toLowerCase() === component.noToken.toLowerCase() ||
+      component.vault.toLowerCase() === component.yesToken.toLowerCase() ||
+      component.vault.toLowerCase() === component.noToken.toLowerCase() ||
+      component.cutoff <= 0n ||
+      component.observationTime <= component.cutoff ||
+      component.thresholdAtoms <= 0n
+    ) {
+      invalidKeys.add(key);
+      reasons.set(key, "The market component event has invalid addresses");
+      continue;
+    }
+    const existing = bySemanticKey.get(key);
+    if (existing && componentIdentity(existing) !== componentIdentity(component)) {
+      invalidKeys.add(key);
+      reasons.set(key, "The factory emitted conflicting market components");
+      continue;
+    }
+    bySemanticKey.set(key, component);
+  }
+
+  const addressOwners = new Map<string, string>();
+  for (const [key, component] of bySemanticKey) {
+    for (const address of [component.vault, component.yesToken, component.noToken]) {
+      const normalized = address.toLowerCase();
+      const existing = addressOwners.get(normalized);
+      if (existing && existing !== key) {
+        invalidKeys.add(existing);
+        invalidKeys.add(key);
+        reasons.set(existing, "Two markets claim the same vault or outcome token");
+        reasons.set(key, "Two markets claim the same vault or outcome token");
+      } else {
+        addressOwners.set(normalized, key);
+      }
+    }
+  }
+
+  const validBySemanticKey = new Map<string, PredictionMarketComponent>();
+  const byVault = new Map<string, PredictionMarketComponent>();
+  const byToken = new Map<string, PredictionMarketTokenIdentity>();
+  for (const [key, component] of bySemanticKey) {
+    if (invalidKeys.has(key)) continue;
+    validBySemanticKey.set(key, component);
+    byVault.set(component.vault.toLowerCase(), component);
+    byToken.set(component.yesToken.toLowerCase(), {
+      component,
+      outcome: "YES",
+    });
+    byToken.set(component.noToken.toLowerCase(), {
+      component,
+      outcome: "NO",
+    });
+  }
+
+  return {
+    bySemanticKey: validBySemanticKey,
+    byToken,
+    byVault,
+    failures: [...invalidKeys].map((semanticKey) => ({
+      reason: reasons.get(semanticKey) ?? "The market components are invalid",
+      semanticKey: semanticKey as Hex,
+    })),
+  };
+}
+
+async function readOutcomeTransferLogs({
+  account,
+  allowedTokens,
+  clients,
+  direction,
+  fromBlock,
+  toBlock,
+}: {
+  account: Address;
+  allowedTokens: ReadonlySet<string>;
+  clients: PredictionMarketClients;
+  direction: "from" | "to";
+  fromBlock: bigint;
+  toBlock: bigint;
+}) {
+  if (direction === "from") {
+    return readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client
+          .getLogs({
+            args: { from: account },
+            event: outcomeTransferEvent,
+            fromBlock: range.fromBlock,
+            strict: true,
+            toBlock: range.toBlock,
+          })
+          .then((logs) =>
+            filterPredictionOutcomeLogs(logs, allowedTokens),
+          ),
+      toBlock,
+    });
+  }
+  return readPredictionPortfolioLogs({
+    clients,
+    fromBlock,
+    read: (client, range) =>
+      client
+        .getLogs({
+          args: { to: account },
+          event: outcomeTransferEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+      })
+      .then((logs) =>
+        filterPredictionOutcomeLogs(logs, allowedTokens),
+      ),
+    toBlock,
+  });
+}
+
+async function readPredictionRedeemedLogs({
+  account,
+  addresses,
+  clients,
+  fromBlock,
+  toBlock,
+}: {
+  account: Address;
+  addresses: readonly Address[];
+  clients: PredictionMarketClients;
+  fromBlock: bigint;
+  toBlock: bigint;
+}) {
+  const logs = [];
+  for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
+    logs.push(
+      ...(await readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client.getLogs({
+            address: addressBatch,
+            args: { holder: account },
+            event: predictionRedeemedEvent,
+            fromBlock: range.fromBlock,
+            strict: true,
+            toBlock: range.toBlock,
+          }),
+        toBlock,
+      })),
+    );
+  }
+  return dedupePortfolioLogs(logs);
+}
+
+type PortfolioActivityPosition = Readonly<{
+  blockNumber: bigint;
+  logIndex: number;
+  transactionIndex: number;
+}>;
+
+function compareActivityPosition(
+  left: PortfolioActivityPosition,
+  right: PortfolioActivityPosition,
+) {
+  if (left.blockNumber !== right.blockNumber) {
+    return left.blockNumber < right.blockNumber ? -1 : 1;
+  }
+  if (left.transactionIndex !== right.transactionIndex) {
+    return left.transactionIndex - right.transactionIndex;
+  }
+  return left.logIndex - right.logIndex;
+}
+
+function historyBase(
+  log: ConfirmedPortfolioLog,
+  market: PredictionMarketView,
+  vault = market.vault,
+): PredictionPortfolioHistoryBase {
+  return {
+    blockNumber: log.blockNumber,
+    logIndex: log.logIndex,
+    market,
+    semanticKey: market.semanticKey,
+    transactionHash: log.transactionHash,
+    transactionIndex: log.transactionIndex,
+    vault,
+  };
+}
+
+async function readPredictionMarketPortfolioAtRequest({
+  clients,
+  config,
+  request,
+}: {
+  clients: PredictionMarketClients;
+  config: PredictionMarketReleaseConfig;
+  request: PredictionPortfolioRequest;
+}): Promise<PredictionMarketPortfolio> {
+  const snapshot = await readPredictionMarketSnapshot({ clients, config });
+  const fromBlock = config.deploymentBlock;
+  const toBlock = snapshot.blockNumber;
+  const componentLogs = await readPredictionPortfolioLogs({
+    clients,
+    fromBlock,
+    read: (client, range) =>
+      client.getLogs({
+        address: config.factoryAddress,
+        event: marketComponentsEvent,
+        fromBlock: range.fromBlock,
+        strict: true,
+        toBlock: range.toBlock,
+      }),
+    toBlock,
+  });
+  if (BigInt(componentLogs.length) !== snapshot.marketCount) {
+    throw new Error(
+      "The prediction factory market count does not match its component history",
+    );
+  }
+  const componentIndex = indexPredictionMarketComponents(
+    componentLogs.map((log) => ({
+      checkpoint: getAddress(log.args.checkpoint),
+      cutoff: BigInt(log.args.cutoff),
+      noToken: getAddress(log.args.noToken),
+      observationTime: BigInt(log.args.observationTime),
+      poolId: log.args.poolId,
+      semanticKey: log.args.semanticKey,
+      thresholdAtoms: log.args.threshold,
+      vault: getAddress(log.args.vault),
+      yesToken: getAddress(log.args.yesToken),
+    })),
+  );
+  const vaultAddresses = [...componentIndex.byVault.values()].map(
+    (component) => component.vault,
+  );
+  const allowedTokens = new Set(componentIndex.byToken.keys());
+
+  const [createdLogs, boughtLogs, soldLogs, incomingTransfers, outgoingTransfers, redeemedLogs] =
+    await Promise.all([
+      readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client.getLogs({
+            address: config.factoryAddress,
+            args: { creator: request.account },
+            event: marketCreatedEvent,
+            fromBlock: range.fromBlock,
+            strict: true,
+            toBlock: range.toBlock,
+          }),
+        toBlock,
+      }),
+      readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client.getLogs({
+            address: snapshot.router,
+            args: { user: request.account },
+            event: outcomeBoughtEvent,
+            fromBlock: range.fromBlock,
+            strict: true,
+            toBlock: range.toBlock,
+          }),
+        toBlock,
+      }),
+      readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client.getLogs({
+            address: snapshot.router,
+            args: { user: request.account },
+            event: outcomeSoldEvent,
+            fromBlock: range.fromBlock,
+            strict: true,
+            toBlock: range.toBlock,
+          }),
+        toBlock,
+      }),
+      readOutcomeTransferLogs({
+        account: request.account,
+        allowedTokens,
+        clients,
+        direction: "to",
+        fromBlock,
+        toBlock,
+      }),
+      readOutcomeTransferLogs({
+        account: request.account,
+        allowedTokens,
+        clients,
+        direction: "from",
+        fromBlock,
+        toBlock,
+      }),
+      readPredictionRedeemedLogs({
+        account: request.account,
+        addresses: vaultAddresses,
+        clients,
+        fromBlock,
+        toBlock,
+      }),
+    ]);
+  const transferLogs = dedupePortfolioLogs([
+    ...incomingTransfers,
+    ...outgoingTransfers,
+  ]);
+
+  const candidateActivity = new Map<string, PortfolioActivityPosition>();
+  const noteCandidate = (semanticKey: Hex, log: ConfirmedPortfolioLog) => {
+    const key = semanticKey.toLowerCase();
+    const next = {
+      blockNumber: log.blockNumber,
+      logIndex: log.logIndex,
+      transactionIndex: log.transactionIndex,
+    };
+    const current = candidateActivity.get(key);
+    if (!current || compareActivityPosition(current, next) < 0) {
+      candidateActivity.set(key, next);
+    }
+  };
+  for (const log of createdLogs) noteCandidate(log.args.semanticKey, log);
+  for (const log of [...boughtLogs, ...soldLogs]) {
+    const component = componentIndex.byVault.get(log.args.vault.toLowerCase());
+    if (component) noteCandidate(component.semanticKey, log);
+  }
+  for (const log of transferLogs) {
+    const token = componentIndex.byToken.get(log.address.toLowerCase());
+    if (token) noteCandidate(token.component.semanticKey, log);
+  }
+  for (const log of redeemedLogs) {
+    const component = componentIndex.byVault.get(log.address.toLowerCase());
+    if (component) noteCandidate(component.semanticKey, log);
+  }
+
+  const semanticKeys = [...candidateActivity.entries()]
+    .sort((left, right) => compareActivityPosition(right[1], left[1]))
+    .map(([semanticKey]) => semanticKey as Hex);
+  const canonical = semanticKeys.length > 0
+    ? await readPredictionMarketsAtSnapshot({
+        account: request.account,
+        clients,
+        config,
+        semanticKeys,
+        snapshot,
+      })
+    : { failures: [], markets: [], snapshot };
+  const marketsByKey = new Map(
+    canonical.markets.map((market) => [market.semanticKey.toLowerCase(), market]),
+  );
+  const failureByKey = new Map<string, PredictionPortfolioMarketFailure>();
+  for (const failure of [...componentIndex.failures, ...canonical.failures]) {
+    failureByKey.set(failure.semanticKey.toLowerCase(), failure);
+  }
+  const addFailure = (semanticKey: Hex, reason: string) => {
+    const key = semanticKey.toLowerCase();
+    if (!failureByKey.has(key)) {
+      failureByKey.set(key, { reason, semanticKey });
+    }
+  };
+  const usableMarket = (semanticKey: Hex) => {
+    const key = semanticKey.toLowerCase();
+    return failureByKey.has(key) ? undefined : marketsByKey.get(key);
+  };
+
+  const history: PredictionPortfolioHistoryEntry[] = [];
+  for (const log of createdLogs) {
+    const market = usableMarket(log.args.semanticKey);
+    if (!market) continue;
+    if (
+      market.vault.toLowerCase() !== log.args.vault.toLowerCase() ||
+      market.checkpoint.toLowerCase() !== log.args.checkpoint.toLowerCase() ||
+      market.poolId.toLowerCase() !== log.args.poolId.toLowerCase()
+    ) {
+      addFailure(
+        log.args.semanticKey,
+        "The market creation event does not match the canonical market",
+      );
+      continue;
+    }
+    history.push({
+      ...historyBase(log, market),
+      creator: getAddress(log.args.creator),
+      kind: "created",
+    });
+  }
+  for (const log of boughtLogs) {
+    const component = componentIndex.byVault.get(log.args.vault.toLowerCase());
+    if (!component) continue;
+    const market = usableMarket(component.semanticKey);
+    if (!market || market.vault.toLowerCase() !== log.args.vault.toLowerCase()) {
+      if (market) addFailure(component.semanticKey, "The buy event vault is not canonical");
+      continue;
+    }
+    history.push({
+      ...historyBase(log, market),
+      collateralInAtoms: log.args.collateralInAtoms,
+      collateralRefundAtoms: log.args.collateralRefundAtoms,
+      kind: "bought",
+      outcome: log.args.yes ? "YES" : "NO",
+      outcomeAtoms: log.args.outcomeAtoms,
+    });
+  }
+  for (const log of soldLogs) {
+    const component = componentIndex.byVault.get(log.args.vault.toLowerCase());
+    if (!component) continue;
+    const market = usableMarket(component.semanticKey);
+    if (!market || market.vault.toLowerCase() !== log.args.vault.toLowerCase()) {
+      if (market) addFailure(component.semanticKey, "The sell event vault is not canonical");
+      continue;
+    }
+    history.push({
+      ...historyBase(log, market),
+      collateralAtoms: log.args.collateralAtoms,
+      complementRefundAtoms: log.args.complementRefundAtoms,
+      kind: "sold",
+      outcome: log.args.yes ? "YES" : "NO",
+      outcomeAtoms: log.args.outcomeInAtoms,
+      soldRefundAtoms: log.args.soldRefundAtoms,
+    });
+  }
+  for (const log of redeemedLogs) {
+    const component = componentIndex.byVault.get(log.address.toLowerCase());
+    if (!component) continue;
+    const market = usableMarket(component.semanticKey);
+    if (!market || market.vault.toLowerCase() !== log.address.toLowerCase()) {
+      if (market) addFailure(component.semanticKey, "The redemption event vault is not canonical");
+      continue;
+    }
+    history.push({
+      ...historyBase(log, market),
+      collateralAtoms: log.args.collateralAtoms,
+      kind: "redeemed",
+      noAtoms: log.args.noAtoms,
+      recipient: getAddress(log.args.recipient),
+      yesAtoms: log.args.yesAtoms,
+    });
+  }
+  for (const log of transferLogs) {
+    const token = componentIndex.byToken.get(log.address.toLowerCase());
+    if (!token) continue;
+    const market = usableMarket(token.component.semanticKey);
+    const expectedToken = token.outcome === "YES" ? market?.yesToken : market?.noToken;
+    if (!market || expectedToken?.toLowerCase() !== log.address.toLowerCase()) {
+      if (market) addFailure(token.component.semanticKey, "The outcome transfer token is not canonical");
+      continue;
+    }
+    const from = getAddress(log.args.from);
+    const to = getAddress(log.args.to);
+    const fromAccount = from.toLowerCase() === request.account.toLowerCase();
+    const toAccount = to.toLowerCase() === request.account.toLowerCase();
+    if (!fromAccount && !toAccount) continue;
+    history.push({
+      ...historyBase(log, market),
+      direction: fromAccount && toAccount ? "self" : toAccount ? "in" : "out",
+      from,
+      kind: "transfer",
+      outcome: token.outcome,
+      outcomeAtoms: log.args.value,
+      to,
+    });
+  }
+
+  const invalidHistoryKeys = new Set(failureByKey.keys());
+  const canonicalHistory = history.filter(
+    (entry) => !invalidHistoryKeys.has(entry.semanticKey.toLowerCase()),
+  );
+  const richerTransactions = new Set(
+    canonicalHistory
+      .filter((entry) =>
+        entry.kind === "bought" || entry.kind === "sold" || entry.kind === "redeemed",
+      )
+      .map(
+        (entry) =>
+          `${entry.transactionHash.toLowerCase()}:${entry.semanticKey.toLowerCase()}`,
+      ),
+  );
+  const visibleHistory = canonicalHistory
+    .filter(
+      (entry) =>
+        entry.kind !== "transfer" ||
+        !richerTransactions.has(
+          `${entry.transactionHash.toLowerCase()}:${entry.semanticKey.toLowerCase()}`,
+        ),
+    )
+    .sort((left, right) => compareActivityPosition(right, left));
+  const created = visibleHistory.flatMap((entry) =>
+    entry.kind === "created"
+      ? [{
+          blockNumber: entry.blockNumber,
+          logIndex: entry.logIndex,
+          market: entry.market,
+          transactionHash: entry.transactionHash,
+          transactionIndex: entry.transactionIndex,
+        }]
+      : [],
+  );
+  const positions = semanticKeys.flatMap((semanticKey) => {
+    const market = usableMarket(semanticKey);
+    return market && (market.yesBalanceAtoms > 0n || market.noBalanceAtoms > 0n)
+      ? [derivePredictionPortfolioPosition(market)]
+      : [];
+  });
+
+  return {
+    blockNumber: snapshot.blockNumber,
+    blockTimestamp: snapshot.blockTimestamp,
+    created,
+    failures: [...failureByKey.values()],
+    history: visibleHistory,
+    positions,
+    relevantMarketCount: semanticKeys.length,
+    request,
+    scannedMarketCount: snapshot.marketCount,
+  };
+}
+
+export async function readPredictionMarketPortfolio({
+  clients = createPredictionMarketPublicClients(),
+  config,
+  request,
+}: {
+  clients?: PredictionMarketClients;
+  config: PredictionMarketReleaseConfig;
+  request: PredictionPortfolioRequest;
+}): Promise<PredictionMarketPortfolio> {
+  const normalizedRequest = createPredictionPortfolioRequest(
+    request.account,
+    request.requestKey,
+  );
+  try {
+    return await readPredictionMarketPortfolioAtRequest({
+      clients,
+      config,
+      request: normalizedRequest,
+    });
+  } catch (error) {
+    if (error instanceof PredictionPortfolioReadError) throw error;
+    throw new PredictionPortfolioReadError(normalizedRequest, error);
+  }
+}
+
+export const predictionMarketPortfolioInternal = {
+  dedupePortfolioLogs,
+  filterPredictionOutcomeLogs,
+  indexPredictionMarketComponents,
+  marketComponentsEvent,
+  marketCreatedEvent,
+  outcomeBoughtEvent,
+  outcomeSoldEvent,
+  outcomeTransferEvent,
+  predictionPortfolioBlockRanges,
+  predictionRedeemedEvent,
+  readPredictionPortfolioLogs,
+} as const;

--- a/lib/prediction-market-portfolio.ts
+++ b/lib/prediction-market-portfolio.ts
@@ -1,6 +1,8 @@
 import {
   getAddress,
   isAddress,
+  LimitExceededRpcError,
+  ResponseBodyTooLargeError,
   type Address,
   type Hex,
 } from "viem";
@@ -13,16 +15,20 @@ import {
 } from "./prediction-market-chain";
 import { predictionMarketErrorMessage } from "./prediction-market-errors";
 import {
+  assertPredictionConfirmedBlocksMatch,
+  predictionMarketRedeemableAtoms,
   readPredictionMarketSnapshot,
   readPredictionMarketsAtSnapshot,
   type PredictionMarketBatchFailure,
+  type PredictionMarketSnapshot,
   type PredictionMarketView,
 } from "./prediction-market-trading";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const ZERO_BYTES32 = `0x${"00".repeat(32)}`;
 const FACE_SCALE = 10n;
-const LOG_BLOCK_SPAN = 50_000n;
+const LOG_BLOCK_SPAN = 1_000_000n;
+const LOG_MINIMUM_BLOCK_SPAN = 1n;
 const LOG_ADDRESS_BATCH_SIZE = 32;
 
 const marketCreatedEvent = predictionMarketFactoryEventAbi[0];
@@ -68,6 +74,30 @@ const outcomeTransferEvent = {
   ],
 } as const;
 
+const predictionSplitEvent = {
+  type: "event",
+  name: "Split",
+  anonymous: false,
+  inputs: [
+    { name: "payer", type: "address", indexed: true },
+    { name: "recipient", type: "address", indexed: true },
+    { name: "outcomeAtoms", type: "uint256", indexed: false },
+    { name: "collateralAtoms", type: "uint256", indexed: false },
+  ],
+} as const;
+
+const predictionMergedEvent = {
+  type: "event",
+  name: "Merged",
+  anonymous: false,
+  inputs: [
+    { name: "holder", type: "address", indexed: true },
+    { name: "recipient", type: "address", indexed: true },
+    { name: "outcomeAtoms", type: "uint256", indexed: false },
+    { name: "collateralAtoms", type: "uint256", indexed: false },
+  ],
+} as const;
+
 const predictionRedeemedEvent = {
   type: "event",
   name: "Redeemed",
@@ -93,7 +123,12 @@ export type PredictionPortfolioLifecycle =
   | "final_no"
   | "final_invalid";
 
-export type PredictionPortfolioResult = "pending" | "won" | "lost" | "neutral";
+export type PredictionPortfolioResult =
+  | "pending"
+  | "won"
+  | "lost"
+  | "mixed"
+  | "neutral";
 
 export type PredictionPortfolioPosition = Readonly<{
   finalOutcome: "YES" | "NO" | "INVALID" | null;
@@ -162,7 +197,29 @@ export type PredictionPortfolioHistoryEntry =
     >
   | Readonly<
       PredictionPortfolioHistoryBase & {
+        accountRole: "payer" | "recipient" | "self";
         collateralAtoms: bigint;
+        kind: "split";
+        outcomeAtoms: bigint;
+        payer: Address;
+        recipient: Address;
+      }
+    >
+  | Readonly<
+      PredictionPortfolioHistoryBase & {
+        accountRole: "holder" | "recipient" | "self";
+        collateralAtoms: bigint;
+        holder: Address;
+        kind: "merged";
+        outcomeAtoms: bigint;
+        recipient: Address;
+      }
+    >
+  | Readonly<
+      PredictionPortfolioHistoryBase & {
+        accountRole: "holder" | "recipient" | "self";
+        collateralAtoms: bigint;
+        holder: Address;
         kind: "redeemed";
         noAtoms: bigint;
         recipient: Address;
@@ -244,8 +301,8 @@ export function derivePredictionPortfolioPosition(
       lifecycle: "final_yes",
       market,
       noAtoms,
-      redeemableAtoms: yesAtoms * FACE_SCALE,
-      result: yesAtoms > 0n ? "won" : "lost",
+      redeemableAtoms: predictionMarketRedeemableAtoms(market),
+      result: yesAtoms > 0n ? noAtoms > 0n ? "mixed" : "won" : "lost",
       tradingClosed: true,
       yesAtoms,
     };
@@ -256,8 +313,8 @@ export function derivePredictionPortfolioPosition(
       lifecycle: "final_no",
       market,
       noAtoms,
-      redeemableAtoms: noAtoms * FACE_SCALE,
-      result: noAtoms > 0n ? "won" : "lost",
+      redeemableAtoms: predictionMarketRedeemableAtoms(market),
+      result: noAtoms > 0n ? yesAtoms > 0n ? "mixed" : "won" : "lost",
       tradingClosed: true,
       yesAtoms,
     };
@@ -268,7 +325,7 @@ export function derivePredictionPortfolioPosition(
       lifecycle: "final_invalid",
       market,
       noAtoms,
-      redeemableAtoms: (yesAtoms + noAtoms) * FACE_SCALE / 2n,
+      redeemableAtoms: predictionMarketRedeemableAtoms(market),
       result: "neutral",
       tradingClosed: true,
       yesAtoms,
@@ -378,11 +435,36 @@ async function readPredictionPortfolioLogs<Log extends ConfirmedPortfolioLog>({
   ) => Promise<readonly Log[]>;
   toBlock: bigint;
 }): Promise<readonly Log[]> {
-  const logs: Log[] = [];
-  for (const range of predictionPortfolioBlockRanges(fromBlock, toBlock)) {
-    const byClient = await Promise.all(
-      clients.map((client) => read(client, range)),
-    );
+  const readRange = async (
+    range: PredictionPortfolioBlockRange,
+  ): Promise<readonly Log[]> => {
+    let byClient: readonly (readonly Log[])[];
+    try {
+      byClient = await Promise.all(
+        clients.map((client) => read(client, range)),
+      );
+    } catch (error) {
+      const size = range.toBlock - range.fromBlock + 1n;
+      if (
+        size <= LOG_MINIMUM_BLOCK_SPAN ||
+        !(
+          error instanceof LimitExceededRpcError ||
+          error instanceof ResponseBodyTooLargeError
+        )
+      ) {
+        throw error;
+      }
+      const midpoint = range.fromBlock + (size / 2n) - 1n;
+      const left = await readRange({
+        fromBlock: range.fromBlock,
+        toBlock: midpoint,
+      });
+      const right = await readRange({
+        fromBlock: midpoint + 1n,
+        toBlock: range.toBlock,
+      });
+      return [...left, ...right].sort(comparePortfolioLogs);
+    }
     const normalized = byClient.map((providerLogs) =>
       [...providerLogs]
         .sort(comparePortfolioLogs)
@@ -393,9 +475,26 @@ async function readPredictionPortfolioLogs<Log extends ConfirmedPortfolioLog>({
         "The two Robinhood RPCs disagree about prediction portfolio history",
       );
     }
-    logs.push(...[...byClient[0]].sort(comparePortfolioLogs));
+    return [...byClient[0]].sort(comparePortfolioLogs);
+  };
+
+  return [...await readRange({ fromBlock, toBlock })].sort(comparePortfolioLogs);
+}
+
+async function assertPredictionPortfolioSnapshotAnchor(
+  clients: PredictionMarketClients,
+  snapshot: PredictionMarketSnapshot,
+) {
+  const blocks = await Promise.all(
+    clients.map((client) => client.getBlock({ blockNumber: snapshot.blockNumber })),
+  );
+  assertPredictionConfirmedBlocksMatch(blocks[0], blocks[1]);
+  if (
+    blocks[0].hash === null ||
+    blocks[0].hash.toLowerCase() !== snapshot.blockHash.toLowerCase()
+  ) {
+    throw new Error("The prediction portfolio snapshot changed during the history read");
   }
-  return logs;
 }
 
 function predictionPortfolioAddressBatches(
@@ -425,6 +524,25 @@ function filterPredictionOutcomeLogs<Log extends ConfirmedPortfolioLog>(
   allowedTokens: ReadonlySet<string>,
 ) {
   return logs.filter((log) => allowedTokens.has(log.address.toLowerCase()));
+}
+
+function filterNonzeroPredictionOutcomeTransfers<
+  Log extends ConfirmedPortfolioLog & Readonly<{ args: Readonly<{ value: bigint }> }>,
+>(
+  logs: readonly Log[],
+  allowedTokens: ReadonlySet<string>,
+) {
+  return filterPredictionOutcomeLogs(logs, allowedTokens).filter(
+    (log) => log.args.value > 0n,
+  );
+}
+
+function filterFundedPredictionRedemptionRecipients<
+  Log extends ConfirmedPortfolioLog & Readonly<{
+    args: Readonly<{ collateralAtoms: bigint }>;
+  }>,
+>(logs: readonly Log[]) {
+  return logs.filter((log) => log.args.collateralAtoms > 0n);
 }
 
 type PredictionMarketComponent = Readonly<{
@@ -536,6 +654,84 @@ function indexPredictionMarketComponents(
   };
 }
 
+function requirePredictionPortfolioComponent(
+  index: PredictionMarketComponentIndex,
+  address: Address,
+  errorMessage: string,
+) {
+  const component = index.byVault.get(address.toLowerCase());
+  if (!component) throw new Error(errorMessage);
+  return component;
+}
+
+function predictionPortfolioBuyAmountsAreValid({
+  collateralInAtoms,
+  collateralRefundAtoms,
+  outcomeAtoms,
+}: {
+  collateralInAtoms: bigint;
+  collateralRefundAtoms: bigint;
+  outcomeAtoms: bigint;
+}) {
+  return outcomeAtoms > 0n && collateralRefundAtoms <= collateralInAtoms;
+}
+
+function predictionPortfolioSellAmountsAreValid({
+  outcomeInAtoms,
+  soldRefundAtoms,
+}: {
+  outcomeInAtoms: bigint;
+  soldRefundAtoms: bigint;
+}) {
+  return outcomeInAtoms > 0n && soldRefundAtoms <= outcomeInAtoms;
+}
+
+function predictionPortfolioPairAmountsAreValid(
+  outcomeAtoms: bigint,
+  collateralAtoms: bigint,
+) {
+  return outcomeAtoms > 0n && collateralAtoms === outcomeAtoms * FACE_SCALE;
+}
+
+function predictionPortfolioRedemptionAmountsAreValid({
+  collateralAtoms,
+  noAtoms,
+  state,
+  yesAtoms,
+}: {
+  collateralAtoms: bigint;
+  noAtoms: bigint;
+  state: PredictionMarketView["state"];
+  yesAtoms: bigint;
+}) {
+  if (yesAtoms === 0n && noAtoms === 0n) return false;
+  const expectedCollateralAtoms = state === "FINAL_YES"
+    ? yesAtoms * FACE_SCALE
+    : state === "FINAL_NO"
+      ? noAtoms * FACE_SCALE
+      : state === "FINAL_INVALID"
+        ? (yesAtoms + noAtoms) * FACE_SCALE / 2n
+        : -1n;
+  return collateralAtoms === expectedCollateralAtoms;
+}
+
+function predictionPortfolioAccountRole<PrimaryRole extends "holder" | "payer">(
+  account: Address,
+  primary: Address,
+  recipient: Address,
+  primaryRole: PrimaryRole,
+): PrimaryRole | "recipient" | "self" | null {
+  const normalizedAccount = account.toLowerCase();
+  const primaryAccount = primary.toLowerCase() === normalizedAccount;
+  const recipientAccount = recipient.toLowerCase() === normalizedAccount;
+  if (!primaryAccount && !recipientAccount) return null;
+  return primaryAccount && recipientAccount
+    ? "self"
+    : primaryAccount
+      ? primaryRole
+      : "recipient";
+}
+
 async function readOutcomeTransferLogs({
   account,
   addresses,
@@ -570,7 +766,7 @@ async function readOutcomeTransferLogs({
               toBlock: range.toBlock,
             })
             .then((providerLogs) =>
-              filterPredictionOutcomeLogs(providerLogs, allowedTokens),
+              filterNonzeroPredictionOutcomeTransfers(providerLogs, allowedTokens),
             ),
         toBlock,
       })),
@@ -594,8 +790,8 @@ async function readPredictionRedeemedLogs({
 }) {
   const logs = [];
   for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
-    logs.push(
-      ...(await readPredictionPortfolioLogs({
+    const [holderLogs, recipientLogs] = await Promise.all([
+      readPredictionPortfolioLogs({
         clients,
         fromBlock,
         read: (client, range) =>
@@ -608,7 +804,133 @@ async function readPredictionRedeemedLogs({
             toBlock: range.toBlock,
           }),
         toBlock,
-      })),
+      }),
+      readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client
+            .getLogs({
+              address: addressBatch,
+              args: { recipient: account },
+              event: predictionRedeemedEvent,
+              fromBlock: range.fromBlock,
+              strict: true,
+              toBlock: range.toBlock,
+            })
+            .then(filterFundedPredictionRedemptionRecipients),
+        toBlock,
+      }),
+    ]);
+    logs.push(
+      ...holderLogs,
+      ...recipientLogs,
+    );
+  }
+  return dedupePortfolioLogs(logs);
+}
+
+async function readPredictionSplitLogs({
+  account,
+  addresses,
+  clients,
+  fromBlock,
+  toBlock,
+}: {
+  account: Address;
+  addresses: readonly Address[];
+  clients: PredictionMarketClients;
+  fromBlock: bigint;
+  toBlock: bigint;
+}) {
+  const logs = [];
+  for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
+    const [payerLogs, recipientLogs] = await Promise.all([
+      readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client.getLogs({
+            address: addressBatch,
+            args: { payer: account },
+            event: predictionSplitEvent,
+            fromBlock: range.fromBlock,
+            strict: true,
+            toBlock: range.toBlock,
+          }),
+        toBlock,
+      }),
+      readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client.getLogs({
+            address: addressBatch,
+            args: { recipient: account },
+            event: predictionSplitEvent,
+            fromBlock: range.fromBlock,
+            strict: true,
+            toBlock: range.toBlock,
+          }),
+        toBlock,
+      }),
+    ]);
+    logs.push(
+      ...payerLogs,
+      ...recipientLogs,
+    );
+  }
+  return dedupePortfolioLogs(logs);
+}
+
+async function readPredictionMergedLogs({
+  account,
+  addresses,
+  clients,
+  fromBlock,
+  toBlock,
+}: {
+  account: Address;
+  addresses: readonly Address[];
+  clients: PredictionMarketClients;
+  fromBlock: bigint;
+  toBlock: bigint;
+}) {
+  const logs = [];
+  for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
+    const [holderLogs, recipientLogs] = await Promise.all([
+      readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client.getLogs({
+            address: addressBatch,
+            args: { holder: account },
+            event: predictionMergedEvent,
+            fromBlock: range.fromBlock,
+            strict: true,
+            toBlock: range.toBlock,
+          }),
+        toBlock,
+      }),
+      readPredictionPortfolioLogs({
+        clients,
+        fromBlock,
+        read: (client, range) =>
+          client.getLogs({
+            address: addressBatch,
+            args: { recipient: account },
+            event: predictionMergedEvent,
+            fromBlock: range.fromBlock,
+            strict: true,
+            toBlock: range.toBlock,
+          }),
+        toBlock,
+      }),
+    ]);
+    logs.push(
+      ...holderLogs,
+      ...recipientLogs,
     );
   }
   return dedupePortfolioLogs(logs);
@@ -647,6 +969,117 @@ function historyBase(
     transactionIndex: log.transactionIndex,
     vault,
   };
+}
+
+function suppressPredictionPortfolioTransferLegs(
+  canonicalHistory: readonly PredictionPortfolioHistoryEntry[],
+) {
+  const transferLegKey = (
+    transactionHash: Hex,
+    semanticKey: Hex,
+    outcome: "YES" | "NO",
+    direction: "in" | "out",
+    outcomeAtoms: bigint,
+  ) => [
+    transactionHash.toLowerCase(),
+    semanticKey.toLowerCase(),
+    outcome,
+    direction,
+    outcomeAtoms.toString(),
+  ].join(":");
+  const expectedTransferLegs: Array<{
+    eventLogIndex: number;
+    key: string;
+  }> = [];
+  const expectTransferLeg = (
+    entry: PredictionPortfolioHistoryEntry,
+    outcome: "YES" | "NO",
+    direction: "in" | "out",
+    outcomeAtoms: bigint,
+  ) => {
+    if (outcomeAtoms <= 0n) return;
+    expectedTransferLegs.push({
+      eventLogIndex: entry.logIndex,
+      key: transferLegKey(
+        entry.transactionHash,
+        entry.semanticKey,
+        outcome,
+        direction,
+        outcomeAtoms,
+      ),
+    });
+  };
+  for (const entry of canonicalHistory) {
+    if (entry.kind === "bought") {
+      expectTransferLeg(entry, entry.outcome, "in", entry.outcomeAtoms);
+    }
+    if (entry.kind === "sold") {
+      const complement = entry.outcome === "YES" ? "NO" : "YES";
+      expectTransferLeg(entry, entry.outcome, "out", entry.outcomeAtoms);
+      expectTransferLeg(entry, entry.outcome, "in", entry.soldRefundAtoms);
+      expectTransferLeg(entry, complement, "in", entry.complementRefundAtoms);
+    }
+    if (
+      entry.kind === "split" &&
+      (entry.accountRole === "recipient" || entry.accountRole === "self")
+    ) {
+      expectTransferLeg(entry, "YES", "in", entry.outcomeAtoms);
+      expectTransferLeg(entry, "NO", "in", entry.outcomeAtoms);
+    }
+    if (
+      entry.kind === "merged" &&
+      (entry.accountRole === "holder" || entry.accountRole === "self")
+    ) {
+      expectTransferLeg(entry, "YES", "out", entry.outcomeAtoms);
+      expectTransferLeg(entry, "NO", "out", entry.outcomeAtoms);
+    }
+    if (
+      entry.kind === "redeemed" &&
+      (entry.accountRole === "holder" || entry.accountRole === "self")
+    ) {
+      expectTransferLeg(entry, "YES", "out", entry.yesAtoms);
+      expectTransferLeg(entry, "NO", "out", entry.noAtoms);
+    }
+  }
+  const transferEntries = canonicalHistory.filter(
+    (entry): entry is Extract<PredictionPortfolioHistoryEntry, { kind: "transfer" }> =>
+      entry.kind === "transfer",
+  );
+  const suppressedTransfers = new Set<string>();
+  for (const expected of expectedTransferLegs.sort(
+    (left, right) => left.eventLogIndex - right.eventLogIndex,
+  )) {
+    const matched = transferEntries
+      .filter((entry) =>
+        entry.direction !== "self" &&
+        entry.logIndex < expected.eventLogIndex &&
+        !suppressedTransfers.has(
+          `${entry.transactionHash.toLowerCase()}:${entry.logIndex}`,
+        ) &&
+        transferLegKey(
+          entry.transactionHash,
+          entry.semanticKey,
+          entry.outcome,
+          entry.direction,
+          entry.outcomeAtoms,
+        ) === expected.key,
+      )
+      .sort((left, right) => right.logIndex - left.logIndex)[0];
+    if (matched) {
+      suppressedTransfers.add(
+        `${matched.transactionHash.toLowerCase()}:${matched.logIndex}`,
+      );
+    }
+  }
+  return canonicalHistory
+    .filter(
+      (entry) =>
+        entry.kind !== "transfer" ||
+        !suppressedTransfers.has(
+          `${entry.transactionHash.toLowerCase()}:${entry.logIndex}`,
+        ),
+    )
+    .sort((left, right) => compareActivityPosition(right, left));
 }
 
 async function readPredictionMarketPortfolioAtRequest({
@@ -700,7 +1133,16 @@ async function readPredictionMarketPortfolioAtRequest({
   );
   const allowedTokens = new Set(componentIndex.byToken.keys());
 
-  const [createdLogs, boughtLogs, soldLogs, incomingTransfers, outgoingTransfers, redeemedLogs] =
+  const [
+    createdLogs,
+    boughtLogs,
+    soldLogs,
+    incomingTransfers,
+    outgoingTransfers,
+    splitLogs,
+    mergedLogs,
+    redeemedLogs,
+  ] =
     await Promise.all([
       readPredictionPortfolioLogs({
         clients,
@@ -762,6 +1204,20 @@ async function readPredictionMarketPortfolioAtRequest({
         fromBlock,
         toBlock,
       }),
+      readPredictionSplitLogs({
+        account: request.account,
+        addresses: vaultAddresses,
+        clients,
+        fromBlock,
+        toBlock,
+      }),
+      readPredictionMergedLogs({
+        account: request.account,
+        addresses: vaultAddresses,
+        clients,
+        fromBlock,
+        toBlock,
+      }),
       readPredictionRedeemedLogs({
         account: request.account,
         addresses: vaultAddresses,
@@ -788,18 +1244,37 @@ async function readPredictionMarketPortfolioAtRequest({
       candidateActivity.set(key, next);
     }
   };
-  for (const log of createdLogs) noteCandidate(log.args.semanticKey, log);
+  const knownComponentKeys = new Set([
+    ...componentIndex.bySemanticKey.keys(),
+    ...componentIndex.failures.map((failure) => failure.semanticKey.toLowerCase()),
+  ]);
+  for (const log of createdLogs) {
+    if (!knownComponentKeys.has(log.args.semanticKey.toLowerCase())) {
+      throw new Error(
+        "The prediction factory emitted creator activity without market components",
+      );
+    }
+    noteCandidate(log.args.semanticKey, log);
+  }
   for (const log of [...boughtLogs, ...soldLogs]) {
-    const component = componentIndex.byVault.get(log.args.vault.toLowerCase());
-    if (component) noteCandidate(component.semanticKey, log);
+    const component = requirePredictionPortfolioComponent(
+      componentIndex,
+      log.args.vault,
+      "The reviewed prediction router emitted activity for an unknown market",
+    );
+    noteCandidate(component.semanticKey, log);
   }
   for (const log of transferLogs) {
     const token = componentIndex.byToken.get(log.address.toLowerCase());
     if (token) noteCandidate(token.component.semanticKey, log);
   }
-  for (const log of redeemedLogs) {
-    const component = componentIndex.byVault.get(log.address.toLowerCase());
-    if (component) noteCandidate(component.semanticKey, log);
+  for (const log of [...splitLogs, ...mergedLogs, ...redeemedLogs]) {
+    const component = requirePredictionPortfolioComponent(
+      componentIndex,
+      log.address,
+      "A prediction vault emitted activity for an unknown market",
+    );
+    noteCandidate(component.semanticKey, log);
   }
 
   const semanticKeys = [...candidateActivity.entries()]
@@ -814,6 +1289,7 @@ async function readPredictionMarketPortfolioAtRequest({
         snapshot,
       })
     : { failures: [], markets: [], snapshot };
+  await assertPredictionPortfolioSnapshotAnchor(clients, snapshot);
   const marketsByKey = new Map(
     canonical.markets.map((market) => [market.semanticKey.toLowerCase(), market]),
   );
@@ -854,11 +1330,18 @@ async function readPredictionMarketPortfolioAtRequest({
     });
   }
   for (const log of boughtLogs) {
-    const component = componentIndex.byVault.get(log.args.vault.toLowerCase());
-    if (!component) continue;
+    const component = requirePredictionPortfolioComponent(
+      componentIndex,
+      log.args.vault,
+      "The reviewed prediction router buy cannot be mapped to a market",
+    );
     const market = usableMarket(component.semanticKey);
     if (!market || market.vault.toLowerCase() !== log.args.vault.toLowerCase()) {
       if (market) addFailure(component.semanticKey, "The buy event vault is not canonical");
+      continue;
+    }
+    if (!predictionPortfolioBuyAmountsAreValid(log.args)) {
+      addFailure(component.semanticKey, "The buy event amounts are invalid");
       continue;
     }
     history.push({
@@ -871,11 +1354,18 @@ async function readPredictionMarketPortfolioAtRequest({
     });
   }
   for (const log of soldLogs) {
-    const component = componentIndex.byVault.get(log.args.vault.toLowerCase());
-    if (!component) continue;
+    const component = requirePredictionPortfolioComponent(
+      componentIndex,
+      log.args.vault,
+      "The reviewed prediction router sell cannot be mapped to a market",
+    );
     const market = usableMarket(component.semanticKey);
     if (!market || market.vault.toLowerCase() !== log.args.vault.toLowerCase()) {
       if (market) addFailure(component.semanticKey, "The sell event vault is not canonical");
+      continue;
+    }
+    if (!predictionPortfolioSellAmountsAreValid(log.args)) {
+      addFailure(component.semanticKey, "The sell event amounts are invalid");
       continue;
     }
     history.push({
@@ -888,20 +1378,117 @@ async function readPredictionMarketPortfolioAtRequest({
       soldRefundAtoms: log.args.soldRefundAtoms,
     });
   }
+  for (const log of splitLogs) {
+    const component = requirePredictionPortfolioComponent(
+      componentIndex,
+      log.address,
+      "The prediction split cannot be mapped to a market",
+    );
+    const market = usableMarket(component.semanticKey);
+    if (!market || market.vault.toLowerCase() !== log.address.toLowerCase()) {
+      if (market) addFailure(component.semanticKey, "The split event vault is not canonical");
+      continue;
+    }
+    if (!predictionPortfolioPairAmountsAreValid(
+      log.args.outcomeAtoms,
+      log.args.collateralAtoms,
+    )) {
+      addFailure(component.semanticKey, "The split event amounts are invalid");
+      continue;
+    }
+    const payer = getAddress(log.args.payer);
+    const recipient = getAddress(log.args.recipient);
+    const accountRole = predictionPortfolioAccountRole(
+      request.account,
+      payer,
+      recipient,
+      "payer",
+    );
+    if (!accountRole) continue;
+    history.push({
+      ...historyBase(log, market),
+      accountRole,
+      collateralAtoms: log.args.collateralAtoms,
+      kind: "split",
+      outcomeAtoms: log.args.outcomeAtoms,
+      payer,
+      recipient,
+    });
+  }
+  for (const log of mergedLogs) {
+    const component = requirePredictionPortfolioComponent(
+      componentIndex,
+      log.address,
+      "The prediction merge cannot be mapped to a market",
+    );
+    const market = usableMarket(component.semanticKey);
+    if (!market || market.vault.toLowerCase() !== log.address.toLowerCase()) {
+      if (market) addFailure(component.semanticKey, "The merge event vault is not canonical");
+      continue;
+    }
+    if (!predictionPortfolioPairAmountsAreValid(
+      log.args.outcomeAtoms,
+      log.args.collateralAtoms,
+    )) {
+      addFailure(component.semanticKey, "The merge event amounts are invalid");
+      continue;
+    }
+    const holder = getAddress(log.args.holder);
+    const recipient = getAddress(log.args.recipient);
+    const accountRole = predictionPortfolioAccountRole(
+      request.account,
+      holder,
+      recipient,
+      "holder",
+    );
+    if (!accountRole) continue;
+    history.push({
+      ...historyBase(log, market),
+      accountRole,
+      collateralAtoms: log.args.collateralAtoms,
+      holder,
+      kind: "merged",
+      outcomeAtoms: log.args.outcomeAtoms,
+      recipient,
+    });
+  }
   for (const log of redeemedLogs) {
-    const component = componentIndex.byVault.get(log.address.toLowerCase());
-    if (!component) continue;
+    const component = requirePredictionPortfolioComponent(
+      componentIndex,
+      log.address,
+      "The prediction redemption cannot be mapped to a market",
+    );
     const market = usableMarket(component.semanticKey);
     if (!market || market.vault.toLowerCase() !== log.address.toLowerCase()) {
       if (market) addFailure(component.semanticKey, "The redemption event vault is not canonical");
       continue;
     }
+    if (!predictionPortfolioRedemptionAmountsAreValid({
+      collateralAtoms: log.args.collateralAtoms,
+      noAtoms: log.args.noAtoms,
+      state: market.state,
+      yesAtoms: log.args.yesAtoms,
+    })) {
+      addFailure(component.semanticKey, "The redemption event amounts are invalid");
+      continue;
+    }
+    const holder = getAddress(log.args.holder);
+    const recipient = getAddress(log.args.recipient);
+    const accountRole = predictionPortfolioAccountRole(
+      request.account,
+      holder,
+      recipient,
+      "holder",
+    );
+    if (!accountRole) continue;
     history.push({
       ...historyBase(log, market),
+      accountRole,
       collateralAtoms: log.args.collateralAtoms,
+      holder,
       kind: "redeemed",
       noAtoms: log.args.noAtoms,
-      recipient: getAddress(log.args.recipient),
+      recipient,
       yesAtoms: log.args.yesAtoms,
     });
   }
@@ -934,25 +1521,7 @@ async function readPredictionMarketPortfolioAtRequest({
   const canonicalHistory = history.filter(
     (entry) => !invalidHistoryKeys.has(entry.semanticKey.toLowerCase()),
   );
-  const richerTransactions = new Set(
-    canonicalHistory
-      .filter((entry) =>
-        entry.kind === "bought" || entry.kind === "sold" || entry.kind === "redeemed",
-      )
-      .map(
-        (entry) =>
-          `${entry.transactionHash.toLowerCase()}:${entry.semanticKey.toLowerCase()}`,
-      ),
-  );
-  const visibleHistory = canonicalHistory
-    .filter(
-      (entry) =>
-        entry.kind !== "transfer" ||
-        !richerTransactions.has(
-          `${entry.transactionHash.toLowerCase()}:${entry.semanticKey.toLowerCase()}`,
-        ),
-    )
-    .sort((left, right) => compareActivityPosition(right, left));
+  const visibleHistory = suppressPredictionPortfolioTransferLegs(canonicalHistory);
   const created = visibleHistory.flatMap((entry) =>
     entry.kind === "created"
       ? [{
@@ -1010,7 +1579,10 @@ export async function readPredictionMarketPortfolio({
 }
 
 export const predictionMarketPortfolioInternal = {
+  assertPredictionPortfolioSnapshotAnchor,
   dedupePortfolioLogs,
+  filterFundedPredictionRedemptionRecipients,
+  filterNonzeroPredictionOutcomeTransfers,
   filterPredictionOutcomeLogs,
   indexPredictionMarketComponents,
   marketComponentsEvent,
@@ -1018,7 +1590,16 @@ export const predictionMarketPortfolioInternal = {
   outcomeBoughtEvent,
   outcomeSoldEvent,
   outcomeTransferEvent,
+  predictionPortfolioAccountRole,
+  predictionPortfolioBuyAmountsAreValid,
+  predictionPortfolioPairAmountsAreValid,
+  predictionPortfolioRedemptionAmountsAreValid,
+  predictionPortfolioSellAmountsAreValid,
+  predictionMergedEvent,
   predictionPortfolioBlockRanges,
   predictionRedeemedEvent,
+  predictionSplitEvent,
   readPredictionPortfolioLogs,
+  requirePredictionPortfolioComponent,
+  suppressPredictionPortfolioTransferLegs,
 } as const;

--- a/lib/prediction-market-trading.ts
+++ b/lib/prediction-market-trading.ts
@@ -26,6 +26,7 @@ import {
   formatPredictionThreshold,
   type PredictionPermitSignature,
 } from "./prediction-market";
+import { predictionMarketErrorMessage } from "./prediction-market-errors";
 import {
   ROBINHOOD_MULTICALL3_ADDRESS,
   ROBINHOOD_MULTICALL3_RUNTIME_CODE_HASH,
@@ -107,6 +108,24 @@ export type PredictionMarketDirectory = Readonly<{
   marketCount: bigint;
   markets: readonly PredictionMarketView[];
   nextCursor: bigint;
+}>;
+
+export type PredictionMarketSnapshot = Readonly<{
+  blockNumber: bigint;
+  blockTimestamp: bigint;
+  marketCount: bigint;
+  router: Address;
+}>;
+
+export type PredictionMarketBatchFailure = Readonly<{
+  reason: string;
+  semanticKey: Hex;
+}>;
+
+export type PredictionMarketBatchRead = Readonly<{
+  failures: readonly PredictionMarketBatchFailure[];
+  markets: readonly PredictionMarketView[];
+  snapshot: PredictionMarketSnapshot;
 }>;
 
 export type PredictionSwapQuote = Readonly<{
@@ -778,6 +797,38 @@ async function confirmedBlock(
   return blockNumber;
 }
 
+export async function readPredictionMarketSnapshot({
+  clients = createPredictionMarketPublicClients(),
+  config,
+}: {
+  clients?: ReturnType<typeof createPredictionMarketPublicClients>;
+  config: PredictionMarketReleaseConfig;
+}): Promise<PredictionMarketSnapshot> {
+  const blockNumber = await confirmedBlock(clients, config);
+  const [release, blocks, counts] = await Promise.all([
+    verifiedRelease(clients, config, blockNumber),
+    Promise.all(clients.map((client) => client.getBlock({ blockNumber }))),
+    Promise.all(
+      clients.map((client) =>
+        client.readContract({
+          address: config.factoryAddress,
+          abi: factoryAbi,
+          blockNumber,
+          functionName: "marketCount",
+        }),
+      ),
+    ),
+  ]);
+  assertPredictionConfirmedBlocksMatch(blocks[0], blocks[1]);
+  assertSame(counts[0], counts[1], "the market count");
+  return {
+    blockNumber,
+    blockTimestamp: blocks[0].timestamp,
+    marketCount: counts[0],
+    router: release.router,
+  };
+}
+
 async function readReleaseBindings(
   client: PredictionMarketPublicClient,
   config: PredictionMarketReleaseConfig,
@@ -1001,6 +1052,93 @@ async function readVerifiedMarket(
   );
   assertSame(markets[0], markets[1], "the market state");
   return markets[0];
+}
+
+export async function readPredictionMarketsAtSnapshot({
+  account,
+  clients = createPredictionMarketPublicClients(),
+  config,
+  semanticKeys,
+  snapshot,
+}: {
+  account: Address;
+  clients?: ReturnType<typeof createPredictionMarketPublicClients>;
+  config: PredictionMarketReleaseConfig;
+  semanticKeys: readonly string[];
+  snapshot: PredictionMarketSnapshot;
+}): Promise<PredictionMarketBatchRead> {
+  if (!isAddress(account)) throw new Error("The wallet address is invalid");
+  if (
+    snapshot.blockNumber < config.deploymentBlock ||
+    snapshot.blockTimestamp <= 0n ||
+    snapshot.marketCount < 0n ||
+    !isAddress(snapshot.router)
+  ) {
+    throw new Error("The prediction market snapshot is invalid");
+  }
+  const keys = [...new Set(semanticKeys.map(requireSemanticKey))];
+  const [release, blocks] = await Promise.all([
+    verifiedRelease(clients, config, snapshot.blockNumber),
+    Promise.all(
+      clients.map((client) =>
+        client.getBlock({ blockNumber: snapshot.blockNumber }),
+      ),
+    ),
+  ]);
+  assertPredictionConfirmedBlocksMatch(blocks[0], blocks[1]);
+  assertSame(
+    {
+      blockNumber: blocks[0].number,
+      blockTimestamp: blocks[0].timestamp,
+      marketCount: snapshot.marketCount,
+      router: release.router,
+    },
+    snapshot,
+    "the portfolio snapshot",
+  );
+
+  const normalizedAccount = getAddress(account);
+  const results = await mapPredictionMarketsInBatches(keys, async (semanticKey) => {
+    try {
+      const markets = await Promise.all(
+        clients.map((client) =>
+          readMarketAt(
+            client,
+            config,
+            release,
+            semanticKey,
+            snapshot.blockNumber,
+            normalizedAccount,
+          ),
+        ),
+      );
+      assertSame(markets[0], markets[1], "the market state");
+      return { kind: "market", market: markets[0] } as const;
+    } catch (error) {
+      return {
+        kind: "failure",
+        failure: {
+          reason: predictionMarketErrorMessage(
+            error,
+            "Canonical market verification failed",
+          ),
+          semanticKey,
+        },
+      } as const;
+    }
+  });
+
+  const failures: PredictionMarketBatchFailure[] = [];
+  const markets: PredictionMarketView[] = [];
+  for (const result of results) {
+    if (result.kind === "failure") failures.push(result.failure);
+    if (result.kind === "market") markets.push(result.market);
+  }
+  return {
+    failures,
+    markets,
+    snapshot,
+  };
 }
 
 function requireSemanticKey(value: string) {

--- a/lib/prediction-market-trading.ts
+++ b/lib/prediction-market-trading.ts
@@ -59,6 +59,22 @@ export type PredictionOutcome = "YES" | "NO";
 export type PredictionMarketState = "OPEN" | "FINAL_YES" | "FINAL_NO" | "FINAL_INVALID";
 export type PredictionCheckpointStatus = "AWAITING" | "FINAL" | "INVALID";
 
+export type PredictionMarketLoadRequestV1 = Readonly<{
+  accountKey: string;
+  generation: number;
+  semanticKey: string;
+}>;
+
+export function isPredictionMarketLoadRequestCurrent(
+  candidate: PredictionMarketLoadRequestV1,
+  current: PredictionMarketLoadRequestV1 | null,
+) {
+  return current !== null
+    && candidate.accountKey === current.accountKey
+    && candidate.generation === current.generation
+    && candidate.semanticKey === current.semanticKey;
+}
+
 export type PredictionPoolKey = Readonly<{
   currency0: Address;
   currency1: Address;
@@ -111,6 +127,7 @@ export type PredictionMarketDirectory = Readonly<{
 }>;
 
 export type PredictionMarketSnapshot = Readonly<{
+  blockHash: Hex;
   blockNumber: bigint;
   blockTimestamp: bigint;
   marketCount: bigint;
@@ -691,6 +708,22 @@ export function formatPredictionOutcome(atoms: bigint, outcome?: PredictionOutco
   return outcome ? `${value} ${outcome}` : value;
 }
 
+export function predictionMarketRedeemableAtoms({
+  noBalanceAtoms,
+  state,
+  yesBalanceAtoms,
+}: Pick<PredictionMarketView, "noBalanceAtoms" | "state" | "yesBalanceAtoms">) {
+  if (yesBalanceAtoms < 0n || noBalanceAtoms < 0n) {
+    throw new Error("Prediction outcome balances cannot be negative");
+  }
+  if (state === "FINAL_YES") return yesBalanceAtoms * FACE_SCALE;
+  if (state === "FINAL_NO") return noBalanceAtoms * FACE_SCALE;
+  if (state === "FINAL_INVALID") {
+    return (yesBalanceAtoms + noBalanceAtoms) * FACE_SCALE / 2n;
+  }
+  return 0n;
+}
+
 export function predictionBuyPayoutSummary({
   collateralInAtoms,
   collateralRefundAtoms,
@@ -821,7 +854,11 @@ export async function readPredictionMarketSnapshot({
   ]);
   assertPredictionConfirmedBlocksMatch(blocks[0], blocks[1]);
   assertSame(counts[0], counts[1], "the market count");
+  if (blocks[0].hash === null) {
+    throw new Error("The confirmed Robinhood block has no canonical hash");
+  }
   return {
+    blockHash: blocks[0].hash,
     blockNumber,
     blockTimestamp: blocks[0].timestamp,
     marketCount: counts[0],
@@ -1069,6 +1106,7 @@ export async function readPredictionMarketsAtSnapshot({
 }): Promise<PredictionMarketBatchRead> {
   if (!isAddress(account)) throw new Error("The wallet address is invalid");
   if (
+    snapshot.blockHash.length !== 66 ||
     snapshot.blockNumber < config.deploymentBlock ||
     snapshot.blockTimestamp <= 0n ||
     snapshot.marketCount < 0n ||
@@ -1088,6 +1126,7 @@ export async function readPredictionMarketsAtSnapshot({
   assertPredictionConfirmedBlocksMatch(blocks[0], blocks[1]);
   assertSame(
     {
+      blockHash: blocks[0].hash,
       blockNumber: blocks[0].number,
       blockTimestamp: blocks[0].timestamp,
       marketCount: snapshot.marketCount,
@@ -1722,6 +1761,13 @@ export async function preparePredictionRedeem({
   if (market.state === "OPEN") throw new Error("The market is not final yet");
   if (yesAtoms < 0n || noAtoms < 0n || (yesAtoms === 0n && noAtoms === 0n)) {
     throw new Error("There are no outcome tokens to redeem");
+  }
+  if (predictionMarketRedeemableAtoms({
+    noBalanceAtoms: noAtoms,
+    state: market.state,
+    yesBalanceAtoms: yesAtoms,
+  }) === 0n) {
+    throw new Error("These outcome tokens have no payout to redeem");
   }
   const data = encodeFunctionData({
     abi: vaultAbi,

--- a/lib/prediction-market-trading.ts
+++ b/lib/prediction-market-trading.ts
@@ -134,6 +134,17 @@ export type PredictionBuyQuote = Readonly<{
   zeroForOne: boolean;
 }>;
 
+export type PredictionBuyPayoutSummary = Readonly<{
+  estimatedCostAtoms: bigint;
+  maximumLossAtoms: bigint;
+  minimumNeutralPayoutAtoms: bigint;
+  minimumWinningProfitAtoms: bigint;
+  minimumWinningPayoutAtoms: bigint;
+  neutralPayoutAtoms: bigint;
+  potentialProfitAtoms: bigint;
+  winningPayoutAtoms: bigint;
+}>;
+
 export type PredictionSellQuote = Readonly<{
   averagePriceBps: number;
   blockNumber: bigint;
@@ -659,6 +670,46 @@ export function formatPredictionUsdg(atoms: bigint) {
 export function formatPredictionOutcome(atoms: bigint, outcome?: PredictionOutcome) {
   const value = trimDecimal(formatUnits(atoms, PREDICTION_OUTCOME_DECIMALS), 5);
   return outcome ? `${value} ${outcome}` : value;
+}
+
+export function predictionBuyPayoutSummary({
+  collateralInAtoms,
+  collateralRefundAtoms,
+  minOutcomeAtoms,
+  outcomeAtoms,
+}: Pick<
+  PredictionBuyQuote,
+  "collateralInAtoms" | "collateralRefundAtoms" | "minOutcomeAtoms" | "outcomeAtoms"
+>): PredictionBuyPayoutSummary {
+  if (
+    collateralInAtoms <= 0n ||
+    collateralInAtoms > MAX_BUY_COLLATERAL_ATOMS ||
+    collateralInAtoms % FACE_SCALE !== 0n ||
+    collateralRefundAtoms < 0n ||
+    collateralRefundAtoms >= collateralInAtoms ||
+    collateralRefundAtoms % FACE_SCALE !== 0n ||
+    outcomeAtoms <= 0n ||
+    outcomeAtoms > UINT128_MAX ||
+    minOutcomeAtoms <= 0n ||
+    minOutcomeAtoms > outcomeAtoms ||
+    minOutcomeAtoms > UINT128_MAX
+  ) {
+    throw new Error("The prediction buy payout quote is invalid");
+  }
+
+  const estimatedCostAtoms = collateralInAtoms - collateralRefundAtoms;
+  const winningPayoutAtoms = outcomeAtoms * FACE_SCALE;
+  const minimumWinningPayoutAtoms = minOutcomeAtoms * FACE_SCALE;
+  return {
+    estimatedCostAtoms,
+    maximumLossAtoms: collateralInAtoms,
+    minimumNeutralPayoutAtoms: minOutcomeAtoms * FACE_SCALE / 2n,
+    minimumWinningPayoutAtoms,
+    minimumWinningProfitAtoms: minimumWinningPayoutAtoms - collateralInAtoms,
+    neutralPayoutAtoms: outcomeAtoms * FACE_SCALE / 2n,
+    potentialProfitAtoms: winningPayoutAtoms - estimatedCostAtoms,
+    winningPayoutAtoms,
+  };
 }
 
 export function formatPredictionMarketObservation(timestamp: bigint) {

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -111,6 +111,30 @@ describe("Explore UI contract", () => {
     );
   });
 
+  it("shows quote-derived prediction payouts without allowing stale orders", () => {
+    const source = readFileSync(
+      join(root, "components/prediction-market-detail.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("Potential payout");
+    expect(source).toContain("Potential profit");
+    expect(source).toContain("Max market loss");
+    expect(source).toContain("This order if");
+    expect(source).toContain("based on the current quote");
+    expect(source).toContain("network fee excluded");
+    expect(source).toContain('shownQuote.buyPayout ? "Shares received" : "Estimated proceeds"');
+    expect(source).toContain('shownQuote.buyPayout ? "Minimum shares" : "Minimum proceeds"');
+    expect(source).toContain('role="group" aria-label="Trade direction"');
+    expect(source).toContain('role="group" aria-label="Outcome"');
+    expect(source).toContain("aria-pressed={mode === value}");
+    expect(source).toContain("aria-pressed={outcome === value}");
+    expect(source).toContain("const requestId = ++quoteRequestId.current");
+    expect(source.match(/requestId !== quoteRequestId\.current/gu)).toHaveLength(2);
+    expect(source).not.toContain('className={styles.orderPreview} aria-live="polite"');
+    expect(source).toContain('className="sr-only" role="status" aria-live="polite"');
+  });
+
   it("keeps sort, socials and model choices in one persistent disclosure", () => {
     const source = readFileSync(
       join(root, "components/explore-view.tsx"),

--- a/tests/prediction-market-portfolio-view-model.test.ts
+++ b/tests/prediction-market-portfolio-view-model.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { predictionPreviewMarkets } from "../components/prediction-market-preview";
+import { predictionPortfolioPositionViewModelV1 } from
+  "../components/prediction-market-portfolio";
+import type { PredictionMarketView } from "../lib/prediction-market-trading";
+
+const now = 1_800_000_000;
+const baseMarket = predictionPreviewMarkets(now)[0];
+
+function market(overrides: Partial<PredictionMarketView>) {
+  return { ...baseMarket, ...overrides } satisfies PredictionMarketView;
+}
+
+describe("prediction portfolio position view model", () => {
+  it("shows an open side, shares, probability, time and trade action", () => {
+    const view = predictionPortfolioPositionViewModelV1(baseMarket);
+
+    expect(view.statusLabel).toBe("Trading open");
+    expect(view.timeLabel).toMatch(/^Closes in /u);
+    expect(view.probabilityLabel).toBe("64% YES");
+    expect(view.sides).toEqual([
+      { outcome: "YES", shares: "0.824" },
+      { outcome: "NO", shares: "0.375" },
+    ]);
+    expect(view.payoutLabel).toBe("Not settled");
+    expect(view.actionLabel).toBe("Trade");
+  });
+
+  it("closes trading at the cutoff without offering an early payout", () => {
+    const view = predictionPortfolioPositionViewModelV1(market({
+      blockTimestamp: baseMarket.cutoff,
+    }));
+
+    expect(view.statusLabel).toBe("Awaiting result");
+    expect(view.payoutLabel).toBe("Awaiting result");
+    expect(view.actionLabel).toBe("View market");
+    expect(view.actionTone).toBe("quiet");
+  });
+
+  it("labels winning outcome shares as won and redeemable", () => {
+    const view = predictionPortfolioPositionViewModelV1(market({
+      checkpointStatus: "FINAL",
+      noBalanceAtoms: 0n,
+      state: "FINAL_YES",
+      yesBalanceAtoms: 125_000n,
+    }));
+
+    expect(view.statusLabel).toBe("Won");
+    expect(view.payoutLabel).toBe("Redeemable");
+    expect(view.payoutDetail).toContain("1 USDG per share");
+    expect(view.actionLabel).toBe("Redeem payout");
+    expect(view.actionTone).toBe("primary");
+  });
+
+  it("labels a losing held side without inventing profit or loss", () => {
+    const view = predictionPortfolioPositionViewModelV1(market({
+      checkpointStatus: "FINAL",
+      noBalanceAtoms: 75_000n,
+      state: "FINAL_YES",
+      yesBalanceAtoms: 0n,
+    }));
+
+    expect(view.statusLabel).toBe("Lost");
+    expect(view.payoutLabel).toBe("Settled");
+    expect(view.actionLabel).toBe("View market");
+    expect(view.payoutDetail).toContain("settles at zero");
+    expect(`${view.payoutLabel} ${view.payoutDetail}`).not.toMatch(/profit|P&L/iu);
+  });
+
+  it("keeps a neutral result distinct and redeemable", () => {
+    const view = predictionPortfolioPositionViewModelV1(market({
+      checkpointStatus: "INVALID",
+      noBalanceAtoms: 50_000n,
+      state: "FINAL_INVALID",
+      yesBalanceAtoms: 25_000n,
+    }));
+
+    expect(view.statusLabel).toBe("Neutral");
+    expect(view.payoutLabel).toBe("Redeemable");
+    expect(view.payoutDetail).toContain("0.50 USDG per share");
+    expect(view.actionLabel).toBe("Redeem payout");
+  });
+
+  it("accepts the data API position shape as its stable adapter boundary", () => {
+    const view = predictionPortfolioPositionViewModelV1({
+      finalOutcome: "YES",
+      lifecycle: "final_yes",
+      market: market({ state: "FINAL_YES" }),
+      noAtoms: 0n,
+      redeemableAtoms: 1_250_000n,
+      result: "won",
+      tradingClosed: true,
+      yesAtoms: 125_000n,
+    });
+
+    expect(view).toMatchObject({
+      actionLabel: "Redeem payout",
+      payoutLabel: "Redeemable",
+      statusLabel: "Won",
+    });
+  });
+});

--- a/tests/prediction-market-portfolio-view-model.test.ts
+++ b/tests/prediction-market-portfolio-view-model.test.ts
@@ -23,7 +23,8 @@ describe("prediction portfolio position view model", () => {
       { outcome: "YES", shares: "0.824" },
       { outcome: "NO", shares: "0.375" },
     ]);
-    expect(view.payoutLabel).toBe("Not settled");
+    expect(view.metricLabel).toBe("Potential payout");
+    expect(view.payoutLabel).toBe("0.824 USDG");
     expect(view.actionLabel).toBe("Trade");
   });
 
@@ -33,7 +34,8 @@ describe("prediction portfolio position view model", () => {
     }));
 
     expect(view.statusLabel).toBe("Awaiting result");
-    expect(view.payoutLabel).toBe("Awaiting result");
+    expect(view.metricLabel).toBe("Potential payout");
+    expect(view.payoutLabel).toBe("0.824 USDG");
     expect(view.actionLabel).toBe("View market");
     expect(view.actionTone).toBe("quiet");
   });
@@ -47,7 +49,8 @@ describe("prediction portfolio position view model", () => {
     }));
 
     expect(view.statusLabel).toBe("Won");
-    expect(view.payoutLabel).toBe("Redeemable");
+    expect(view.metricLabel).toBe("Final payout");
+    expect(view.payoutLabel).toBe("1.25 USDG");
     expect(view.payoutDetail).toContain("1 USDG per share");
     expect(view.actionLabel).toBe("Redeem payout");
     expect(view.actionTone).toBe("primary");
@@ -62,7 +65,7 @@ describe("prediction portfolio position view model", () => {
     }));
 
     expect(view.statusLabel).toBe("Lost");
-    expect(view.payoutLabel).toBe("Settled");
+    expect(view.payoutLabel).toBe("0 USDG");
     expect(view.actionLabel).toBe("View market");
     expect(view.payoutDetail).toContain("settles at zero");
     expect(`${view.payoutLabel} ${view.payoutDetail}`).not.toMatch(/profit|P&L/iu);
@@ -77,7 +80,7 @@ describe("prediction portfolio position view model", () => {
     }));
 
     expect(view.statusLabel).toBe("Neutral");
-    expect(view.payoutLabel).toBe("Redeemable");
+    expect(view.payoutLabel).toBe("0.375 USDG");
     expect(view.payoutDetail).toContain("0.50 USDG per share");
     expect(view.actionLabel).toBe("Redeem payout");
   });
@@ -96,7 +99,7 @@ describe("prediction portfolio position view model", () => {
 
     expect(view).toMatchObject({
       actionLabel: "Redeem payout",
-      payoutLabel: "Redeemable",
+      payoutLabel: "1.25 USDG",
       statusLabel: "Won",
     });
   });

--- a/tests/prediction-market-portfolio-view-model.test.ts
+++ b/tests/prediction-market-portfolio-view-model.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { predictionPreviewMarkets } from "../components/prediction-market-preview";
-import { predictionPortfolioPositionViewModelV1 } from
-  "../components/prediction-market-portfolio";
+import {
+  predictionPortfolioHistoryViewModelV1,
+  predictionPortfolioPositionViewModelV1,
+} from "../components/prediction-market-portfolio";
+import type { PredictionPortfolioHistoryEntry } from
+  "../lib/prediction-market-portfolio";
 import type { PredictionMarketView } from "../lib/prediction-market-trading";
 
 const now = 1_800_000_000;
@@ -49,6 +53,9 @@ describe("prediction portfolio position view model", () => {
     }));
 
     expect(view.statusLabel).toBe("Won");
+    expect(view.probabilityMetricLabel).toBe("Result");
+    expect(view.probabilityLabel).toBe("YES won");
+    expect(view.probabilityYesPercent).toBe(100);
     expect(view.metricLabel).toBe("Final payout");
     expect(view.payoutLabel).toBe("1.25 USDG");
     expect(view.payoutDetail).toContain("1 USDG per share");
@@ -80,9 +87,53 @@ describe("prediction portfolio position view model", () => {
     }));
 
     expect(view.statusLabel).toBe("Neutral");
+    expect(view.probabilityMetricLabel).toBe("Result");
+    expect(view.probabilityLabel).toBe("Neutral");
+    expect(view.probabilityYesPercent).toBe(50);
     expect(view.payoutLabel).toBe("0.375 USDG");
     expect(view.payoutDetail).toContain("0.50 USDG per share");
     expect(view.actionLabel).toBe("Redeem payout");
+  });
+
+  it("shows a final NO result at zero instead of freezing the closing probability", () => {
+    const view = predictionPortfolioPositionViewModelV1(market({
+      checkpointStatus: "FINAL",
+      noBalanceAtoms: 125_000n,
+      probabilityYesBps: 8_700,
+      state: "FINAL_NO",
+      yesBalanceAtoms: 0n,
+    }));
+
+    expect(view).toMatchObject({
+      probabilityLabel: "NO won",
+      probabilityMetricLabel: "Result",
+      probabilityYesPercent: 0,
+      statusLabel: "Won",
+    });
+  });
+
+  it("states the winning side factually when the wallet holds winning and losing shares", () => {
+    const view = predictionPortfolioPositionViewModelV1({
+      finalOutcome: "YES",
+      lifecycle: "final_yes",
+      market: market({ state: "FINAL_YES" }),
+      noAtoms: 1_000_000n,
+      redeemableAtoms: 1_000_000n,
+      result: "mixed",
+      tradingClosed: true,
+      yesAtoms: 100_000n,
+    });
+
+    expect(view).toMatchObject({
+      payoutLabel: "1 USDG",
+      probabilityLabel: "YES won",
+      probabilityYesPercent: 100,
+      statusLabel: "YES won",
+    });
+    expect(view.sides).toEqual([
+      { outcome: "YES", shares: "1" },
+      { outcome: "NO", shares: "10" },
+    ]);
   });
 
   it("accepts the data API position shape as its stable adapter boundary", () => {
@@ -102,5 +153,114 @@ describe("prediction portfolio position view model", () => {
       payoutLabel: "1.25 USDG",
       statusLabel: "Won",
     });
+  });
+});
+
+const historyBase = {
+  blockNumber: 101n,
+  logIndex: 4,
+  market: baseMarket,
+  semanticKey: baseMarket.semanticKey,
+  transactionHash: `0x${"ab".repeat(32)}`,
+  transactionIndex: 2,
+  vault: baseMarket.vault,
+} as const;
+
+describe("prediction portfolio history view model", () => {
+  it("shows a sell as the net original-side debit plus its complement refund", () => {
+    const entry = {
+      ...historyBase,
+      collateralAtoms: 500_000n,
+      complementRefundAtoms: 10_000n,
+      kind: "sold",
+      outcome: "YES",
+      outcomeAtoms: 100_000n,
+      soldRefundAtoms: 25_000n,
+    } satisfies PredictionPortfolioHistoryEntry;
+
+    const view = predictionPortfolioHistoryViewModelV1(entry);
+
+    expect(view.sides).toEqual([
+      { outcome: "YES", shares: "-0.75" },
+      { outcome: "NO", shares: "+0.1" },
+    ]);
+    expect(view.payoutDetail).toBe(
+      "0.75 YES sold. 0.25 YES and 0.1 NO returned.",
+    );
+    expect(view.timeLabel).toBe("Observed onchain");
+  });
+
+  it("presents direct split and merge legs without hiding share movement", () => {
+    const split = predictionPortfolioHistoryViewModelV1({
+      ...historyBase,
+      accountRole: "self",
+      collateralAtoms: 1_000_000n,
+      kind: "split",
+      outcomeAtoms: 100_000n,
+      payer: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    } satisfies PredictionPortfolioHistoryEntry);
+    const merged = predictionPortfolioHistoryViewModelV1({
+      ...historyBase,
+      accountRole: "holder",
+      collateralAtoms: 1_000_000n,
+      holder: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      kind: "merged",
+      outcomeAtoms: 100_000n,
+      recipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    } satisfies PredictionPortfolioHistoryEntry);
+
+    expect(split).toMatchObject({
+      payoutDetail: "Created 1 YES and 1 NO shares.",
+      statusLabel: "Split USDG",
+    });
+    expect(split.sides).toEqual([
+      { outcome: "YES", shares: "+1" },
+      { outcome: "NO", shares: "+1" },
+    ]);
+    expect(merged).toMatchObject({
+      payoutDetail: "Merged 1 YES and 1 NO; USDG went to another wallet.",
+      statusLabel: "Merged YES + NO",
+    });
+    expect(merged.sides).toEqual([
+      { outcome: "YES", shares: "-1" },
+      { outcome: "NO", shares: "-1" },
+    ]);
+  });
+
+  it("distinguishes redemption by the holder from payout-only receipt", () => {
+    const self = predictionPortfolioHistoryViewModelV1({
+      ...historyBase,
+      accountRole: "self",
+      collateralAtoms: 1_250_000n,
+      holder: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      kind: "redeemed",
+      noAtoms: 0n,
+      recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      yesAtoms: 125_000n,
+    } satisfies PredictionPortfolioHistoryEntry);
+    const recipient = predictionPortfolioHistoryViewModelV1({
+      ...historyBase,
+      accountRole: "recipient",
+      collateralAtoms: 1_250_000n,
+      holder: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      kind: "redeemed",
+      noAtoms: 0n,
+      recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      yesAtoms: 125_000n,
+    } satisfies PredictionPortfolioHistoryEntry);
+
+    expect(self).toMatchObject({
+      payoutDetail: "Outcome shares redeemed to this wallet.",
+      payoutLabel: "1.25 USDG",
+      statusLabel: "Payout redeemed",
+    });
+    expect(self.sides).toEqual([{ outcome: "YES", shares: "-1.25" }]);
+    expect(recipient).toMatchObject({
+      payoutDetail: "Payout received from another wallet's redemption.",
+      payoutLabel: "1.25 USDG",
+      statusLabel: "Payout redeemed",
+    });
+    expect(recipient.sides).toEqual([]);
   });
 });

--- a/tests/prediction-market-portfolio.test.ts
+++ b/tests/prediction-market-portfolio.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import { toEventSelector, type Address, type Hex } from "viem";
+
+import {
+  PredictionPortfolioReadError,
+  createPredictionPortfolioRequest,
+  derivePredictionPortfolioPosition,
+  isPredictionPortfolioRequestCurrent,
+  predictionMarketPortfolioInternal,
+} from "../lib/prediction-market-portfolio";
+import type { PredictionMarketView } from "../lib/prediction-market-trading";
+
+const accountA = "0x1111111111111111111111111111111111111111";
+const accountB = "0x2222222222222222222222222222222222222222";
+const semanticKey = `0x${"aa".repeat(32)}` as Hex;
+
+function market(
+  overrides: Partial<PredictionMarketView> = {},
+): PredictionMarketView {
+  return {
+    accountedLiabilityAtoms: 1_000_000n,
+    blockNumber: 100n,
+    blockTimestamp: 100n,
+    canonicalPoolId: `0x${"bb".repeat(32)}`,
+    checkpoint: "0x3333333333333333333333333333333333333333",
+    checkpointStatus: "AWAITING",
+    cutoff: 101n,
+    fallbackChallengeDeadline: 0n,
+    fallbackRequestedAt: 0n,
+    hardResolutionDeadline: 200n,
+    liquidity: 1n,
+    noBalanceAtoms: 2n,
+    noToken: "0x4444444444444444444444444444444444444444",
+    noTokenName: "NO",
+    observationTime: 150n,
+    poolId: `0x${"bb".repeat(32)}`,
+    poolKey: {
+      currency0: "0x4444444444444444444444444444444444444444",
+      currency1: "0x5555555555555555555555555555555555555555",
+      fee: 200,
+      hooks: "0x6666666666666666666666666666666666666666",
+      tickSpacing: 10,
+    },
+    probabilityYesBps: 5_000,
+    protocolFee: 0,
+    resolvedPriceAtoms: 0n,
+    resolutionDeadline: 175n,
+    router: "0x7777777777777777777777777777777777777777",
+    semanticKey,
+    sqrtPriceX96: 1n << 96n,
+    state: "OPEN",
+    thresholdAtoms: 100_000n,
+    tick: 0,
+    title: "Will BTC finish above the threshold?",
+    vault: "0x8888888888888888888888888888888888888888",
+    yesBalanceAtoms: 3n,
+    yesToken: "0x5555555555555555555555555555555555555555",
+    yesTokenName: "YES",
+    ...overrides,
+  };
+}
+
+function log({
+  address = "0x9999999999999999999999999999999999999999",
+  index,
+  transactionHash,
+}: {
+  address?: Address;
+  index: number;
+  transactionHash: Hex;
+}) {
+  return {
+    address,
+    blockHash: `0x${"cc".repeat(32)}` as Hex,
+    blockNumber: 10n,
+    data: "0x" as Hex,
+    logIndex: index,
+    removed: false,
+    topics: [`0x${"dd".repeat(32)}` as Hex],
+    transactionHash,
+    transactionIndex: 1,
+  };
+}
+
+describe("prediction portfolio request identity", () => {
+  it("binds every result and error to both account and request key", () => {
+    const current = createPredictionPortfolioRequest(accountA, "request-7");
+    const staleKey = createPredictionPortfolioRequest(accountA, "request-6");
+    const staleAccount = createPredictionPortfolioRequest(accountB, "request-7");
+
+    expect(isPredictionPortfolioRequestCurrent(current, current)).toBe(true);
+    expect(isPredictionPortfolioRequestCurrent({ request: current }, current)).toBe(true);
+    expect(isPredictionPortfolioRequestCurrent(staleKey, current)).toBe(false);
+    expect(isPredictionPortfolioRequestCurrent(staleAccount, current)).toBe(false);
+    expect(isPredictionPortfolioRequestCurrent(current, null)).toBe(false);
+
+    const error = new PredictionPortfolioReadError(
+      current,
+      new Error("RPC failed at https://secret.example/key"),
+    );
+    expect(isPredictionPortfolioRequestCurrent(error, current)).toBe(true);
+    expect(error.message).not.toContain("https://");
+  });
+
+  it("rejects zero accounts and ambiguous request keys before discovery", () => {
+    expect(() =>
+      createPredictionPortfolioRequest(
+        "0x0000000000000000000000000000000000000000",
+        "request-1",
+      ),
+    ).toThrow("wallet address");
+    expect(() => createPredictionPortfolioRequest(accountA, "   ")).toThrow(
+      "request key",
+    );
+  });
+});
+
+describe("prediction portfolio lifecycle", () => {
+  it("distinguishes open trading from an elapsed cutoff at the confirmed block", () => {
+    const open = derivePredictionPortfolioPosition(market());
+    const closed = derivePredictionPortfolioPosition(
+      market({ blockTimestamp: 101n }),
+    );
+
+    expect(open).toMatchObject({
+      lifecycle: "open",
+      redeemableAtoms: 0n,
+      result: "pending",
+      tradingClosed: false,
+    });
+    expect(closed).toMatchObject({
+      lifecycle: "trading_closed",
+      redeemableAtoms: 0n,
+      result: "pending",
+      tradingClosed: true,
+    });
+  });
+
+  it("maps final YES, NO, and INVALID to exact vault redemption atoms", () => {
+    const yes = derivePredictionPortfolioPosition(
+      market({ state: "FINAL_YES", yesBalanceAtoms: 3n, noBalanceAtoms: 8n }),
+    );
+    const no = derivePredictionPortfolioPosition(
+      market({ state: "FINAL_NO", yesBalanceAtoms: 7n, noBalanceAtoms: 0n }),
+    );
+    const invalid = derivePredictionPortfolioPosition(
+      market({ state: "FINAL_INVALID", yesBalanceAtoms: 1n, noBalanceAtoms: 0n }),
+    );
+
+    expect(yes).toMatchObject({
+      finalOutcome: "YES",
+      lifecycle: "final_yes",
+      redeemableAtoms: 30n,
+      result: "won",
+    });
+    expect(no).toMatchObject({
+      finalOutcome: "NO",
+      lifecycle: "final_no",
+      redeemableAtoms: 0n,
+      result: "lost",
+    });
+    expect(invalid).toMatchObject({
+      finalOutcome: "INVALID",
+      lifecycle: "final_invalid",
+      redeemableAtoms: 5n,
+      result: "neutral",
+    });
+    expect(yes).not.toHaveProperty("profitAtoms");
+  });
+
+  it("does not synthesize a position without a current outcome balance", () => {
+    expect(() =>
+      derivePredictionPortfolioPosition(
+        market({ yesBalanceAtoms: 0n, noBalanceAtoms: 0n }),
+      ),
+    ).toThrow("positive outcome balance");
+  });
+});
+
+describe("prediction portfolio event discovery", () => {
+  it("pins the deployed event signatures and their indexed field layouts", () => {
+    const internal = predictionMarketPortfolioInternal;
+    expect(toEventSelector(internal.marketCreatedEvent)).toBe(
+      "0x5363df88d9e0be66ba2205029623eaeabb936c765f3871c155adebe782f85e57",
+    );
+    expect(toEventSelector(internal.marketComponentsEvent)).toBe(
+      "0xcd019721cdabfc0b300656539a8065e71f92053c0c964ae940fd1170e2168cba",
+    );
+    expect(toEventSelector(internal.outcomeBoughtEvent)).toBe(
+      "0xb67b7cf42e7ed224ac72001e5c6217d4046938c4b25701bad82e117521539bb4",
+    );
+    expect(toEventSelector(internal.outcomeSoldEvent)).toBe(
+      "0x8cb3335c1e07da3d831aa68d0b87e959be6015b97318f803bded31f993753890",
+    );
+    expect(toEventSelector(internal.outcomeTransferEvent)).toBe(
+      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+    );
+    expect(toEventSelector(internal.predictionRedeemedEvent)).toBe(
+      "0x764aeeb2d1ec3f2945d6486e2f7e3fae9ac5fe11aa56b7a9d90c92212e33050c",
+    );
+    expect(internal.outcomeBoughtEvent.inputs.slice(0, 3).every((input) => input.indexed)).toBe(true);
+    expect(internal.predictionRedeemedEvent.inputs.slice(0, 2).every((input) => input.indexed)).toBe(true);
+  });
+
+  it("chunks inclusive log ranges without gaps or overlaps", () => {
+    expect(
+      predictionMarketPortfolioInternal.predictionPortfolioBlockRanges(
+        100n,
+        110n,
+        4n,
+      ),
+    ).toEqual([
+      { fromBlock: 100n, toBlock: 103n },
+      { fromBlock: 104n, toBlock: 107n },
+      { fromBlock: 108n, toBlock: 110n },
+    ]);
+  });
+
+  it("accepts provider logs in different order but fails closed on disagreement", async () => {
+    const internal = predictionMarketPortfolioInternal;
+    type ReadArguments = Parameters<typeof internal.readPredictionPortfolioLogs>[0];
+    const official = {} as ReadArguments["clients"][number];
+    const independent = {} as ReadArguments["clients"][number];
+    const clients = [official, independent] as ReadArguments["clients"];
+    const first = log({ index: 1, transactionHash: `0x${"01".repeat(32)}` });
+    const second = log({ index: 2, transactionHash: `0x${"02".repeat(32)}` });
+
+    const accepted = await internal.readPredictionPortfolioLogs({
+      clients,
+      fromBlock: 1n,
+      read: async (client) =>
+        client === official ? [second, first] : [first, second],
+      toBlock: 1n,
+    });
+    expect(accepted.map((entry) => entry.logIndex)).toEqual([1, 2]);
+
+    await expect(
+      internal.readPredictionPortfolioLogs({
+        clients,
+        fromBlock: 1n,
+        read: async (client) =>
+          client === official ? [first] : [second],
+        toBlock: 1n,
+      }),
+    ).rejects.toThrow("disagree");
+  });
+
+  it("deduplicates the same self-transfer observed in both account topic queries", () => {
+    const shared = log({ index: 7, transactionHash: `0x${"03".repeat(32)}` });
+    const other = log({ index: 8, transactionHash: `0x${"03".repeat(32)}` });
+    expect(
+      predictionMarketPortfolioInternal.dedupePortfolioLogs([
+        shared,
+        shared,
+        other,
+      ]).map((entry) => entry.logIndex),
+    ).toEqual([7, 8]);
+  });
+
+  it("keeps direct outcome-token transfers and drops unrelated ERC-20 emitters", () => {
+    const outcomeToken = "0x9999999999999999999999999999999999999999";
+    const relevant = log({ index: 1, transactionHash: `0x${"04".repeat(32)}` });
+    const unrelated = log({
+      address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      index: 2,
+      transactionHash: `0x${"05".repeat(32)}`,
+    });
+
+    expect(
+      predictionMarketPortfolioInternal.filterPredictionOutcomeLogs(
+        [unrelated, relevant],
+        new Set([outcomeToken.toLowerCase()]),
+      ),
+    ).toEqual([relevant]);
+  });
+
+  it("isolates one malformed market component without dropping valid markets", () => {
+    const internal = predictionMarketPortfolioInternal;
+    type Component = Parameters<typeof internal.indexPredictionMarketComponents>[0][number];
+    const valid = {
+      checkpoint: "0x3333333333333333333333333333333333333333",
+      cutoff: 100n,
+      noToken: "0x4444444444444444444444444444444444444444",
+      observationTime: 200n,
+      poolId: `0x${"11".repeat(32)}`,
+      semanticKey: `0x${"22".repeat(32)}`,
+      thresholdAtoms: 100_000n,
+      vault: "0x5555555555555555555555555555555555555555",
+      yesToken: "0x6666666666666666666666666666666666666666",
+    } as const satisfies Component;
+    const malformed = {
+      ...valid,
+      noToken: "0x8888888888888888888888888888888888888888",
+      poolId: `0x${"33".repeat(32)}`,
+      semanticKey: `0x${"44".repeat(32)}`,
+      vault: "0x0000000000000000000000000000000000000000",
+      yesToken: "0x9999999999999999999999999999999999999999",
+    } as const satisfies Component;
+
+    const index = internal.indexPredictionMarketComponents([valid, malformed]);
+    expect([...index.bySemanticKey.keys()]).toEqual([
+      valid.semanticKey.toLowerCase(),
+    ]);
+    expect(index.failures).toEqual([
+      expect.objectContaining({ semanticKey: malformed.semanticKey }),
+    ]);
+  });
+});

--- a/tests/prediction-market-portfolio.test.ts
+++ b/tests/prediction-market-portfolio.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { toEventSelector, type Address, type Hex } from "viem";
+import {
+  LimitExceededRpcError,
+  TimeoutError,
+  toEventSelector,
+  type Address,
+  type Hex,
+} from "viem";
 
 import {
   PredictionPortfolioReadError,
@@ -7,6 +13,7 @@ import {
   derivePredictionPortfolioPosition,
   isPredictionPortfolioRequestCurrent,
   predictionMarketPortfolioInternal,
+  type PredictionPortfolioHistoryEntry,
 } from "../lib/prediction-market-portfolio";
 import type { PredictionMarketView } from "../lib/prediction-market-trading";
 
@@ -138,6 +145,9 @@ describe("prediction portfolio lifecycle", () => {
 
   it("maps final YES, NO, and INVALID to exact vault redemption atoms", () => {
     const yes = derivePredictionPortfolioPosition(
+      market({ state: "FINAL_YES", yesBalanceAtoms: 3n, noBalanceAtoms: 0n }),
+    );
+    const mixed = derivePredictionPortfolioPosition(
       market({ state: "FINAL_YES", yesBalanceAtoms: 3n, noBalanceAtoms: 8n }),
     );
     const no = derivePredictionPortfolioPosition(
@@ -158,6 +168,10 @@ describe("prediction portfolio lifecycle", () => {
       lifecycle: "final_no",
       redeemableAtoms: 0n,
       result: "lost",
+    });
+    expect(mixed).toMatchObject({
+      redeemableAtoms: 30n,
+      result: "mixed",
     });
     expect(invalid).toMatchObject({
       finalOutcome: "INVALID",
@@ -195,10 +209,18 @@ describe("prediction portfolio event discovery", () => {
     expect(toEventSelector(internal.outcomeTransferEvent)).toBe(
       "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
     );
+    expect(toEventSelector(internal.predictionSplitEvent)).toBe(
+      "0x06225bdd82eadd60c8cb630dbf5258a8124705f704edcd0a6e8dd3177bc6dedd",
+    );
+    expect(toEventSelector(internal.predictionMergedEvent)).toBe(
+      "0xb8c37da3b01e50f1f61e39dd11b34d8aed5d3049d8746eee080f1c89ef88e92e",
+    );
     expect(toEventSelector(internal.predictionRedeemedEvent)).toBe(
       "0x764aeeb2d1ec3f2945d6486e2f7e3fae9ac5fe11aa56b7a9d90c92212e33050c",
     );
     expect(internal.outcomeBoughtEvent.inputs.slice(0, 3).every((input) => input.indexed)).toBe(true);
+    expect(internal.predictionSplitEvent.inputs.slice(0, 2).every((input) => input.indexed)).toBe(true);
+    expect(internal.predictionMergedEvent.inputs.slice(0, 2).every((input) => input.indexed)).toBe(true);
     expect(internal.predictionRedeemedEvent.inputs.slice(0, 2).every((input) => input.indexed)).toBe(true);
   });
 
@@ -245,6 +267,366 @@ describe("prediction portfolio event discovery", () => {
     ).rejects.toThrow("disagree");
   });
 
+  it("reads the whole history first and halves only when a provider rejects it", async () => {
+    const internal = predictionMarketPortfolioInternal;
+    type ReadArguments = Parameters<typeof internal.readPredictionPortfolioLogs>[0];
+    const official = {} as ReadArguments["clients"][number];
+    const independent = {} as ReadArguments["clients"][number];
+    const clients = [official, independent] as ReadArguments["clients"];
+    const attemptedRanges: Array<{ fromBlock: bigint; toBlock: bigint }> = [];
+
+    await expect(internal.readPredictionPortfolioLogs({
+      clients,
+      fromBlock: 1n,
+      read: async (client, range) => {
+        if (client === official) attemptedRanges.push(range);
+        if (range.toBlock - range.fromBlock + 1n > 50_000n) {
+          throw new LimitExceededRpcError(new Error("too many results"));
+        }
+        return [];
+      },
+      toBlock: 1_250_001n,
+    })).resolves.toEqual([]);
+
+    expect(attemptedRanges[0]).toEqual({ fromBlock: 1n, toBlock: 1_250_001n });
+    expect(attemptedRanges.some((range) =>
+      range.toBlock - range.fromBlock + 1n <= 50_000n,
+    )).toBe(true);
+  });
+
+  it("fails fast on transport timeouts instead of multiplying history reads", async () => {
+    const internal = predictionMarketPortfolioInternal;
+    type ReadArguments = Parameters<typeof internal.readPredictionPortfolioLogs>[0];
+    const clients = [{}, {}] as unknown as ReadArguments["clients"];
+    let attempts = 0;
+
+    await expect(internal.readPredictionPortfolioLogs({
+      clients,
+      fromBlock: 1n,
+      read: async () => {
+        attempts += 1;
+        throw new TimeoutError({ body: {}, url: "https://rpc.invalid" });
+      },
+      toBlock: 1_250_001n,
+    })).rejects.toBeInstanceOf(TimeoutError);
+    expect(attempts).toBe(2);
+  });
+
+  it("fails closed if the snapshot block changes during a portfolio read", async () => {
+    const internal = predictionMarketPortfolioInternal;
+    type AnchorClients = Parameters<
+      typeof internal.assertPredictionPortfolioSnapshotAnchor
+    >[0];
+    type AnchorSnapshot = Parameters<
+      typeof internal.assertPredictionPortfolioSnapshotAnchor
+    >[1];
+    const canonical = {
+      hash: `0x${"11".repeat(32)}` as Hex,
+      number: 100n,
+      parentHash: `0x${"22".repeat(32)}` as Hex,
+      timestamp: 90n,
+    };
+    const client = (hash: Hex) => ({
+      getBlock: async () => ({ ...canonical, hash }),
+    });
+    const snapshot = {
+      blockHash: canonical.hash,
+      blockNumber: canonical.number,
+      blockTimestamp: canonical.timestamp,
+      marketCount: 1n,
+      router: "0x7777777777777777777777777777777777777777",
+    } satisfies AnchorSnapshot;
+
+    await expect(internal.assertPredictionPortfolioSnapshotAnchor(
+      [client(canonical.hash), client(canonical.hash)] as unknown as AnchorClients,
+      snapshot,
+    )).resolves.toBeUndefined();
+    await expect(internal.assertPredictionPortfolioSnapshotAnchor(
+      [
+        client(`0x${"33".repeat(32)}`),
+        client(`0x${"33".repeat(32)}`),
+      ] as unknown as AnchorClients,
+      snapshot,
+    )).rejects.toThrow("changed during");
+  });
+
+  it("validates settlement amounts and derives the wallet participant role", () => {
+    const internal = predictionMarketPortfolioInternal;
+
+    expect(internal.predictionPortfolioBuyAmountsAreValid({
+      collateralInAtoms: 100n,
+      collateralRefundAtoms: 20n,
+      outcomeAtoms: 8n,
+    })).toBe(true);
+    expect(internal.predictionPortfolioBuyAmountsAreValid({
+      collateralInAtoms: 100n,
+      collateralRefundAtoms: 101n,
+      outcomeAtoms: 8n,
+    })).toBe(false);
+    expect(internal.predictionPortfolioSellAmountsAreValid({
+      outcomeInAtoms: 100n,
+      soldRefundAtoms: 20n,
+    })).toBe(true);
+    expect(internal.predictionPortfolioSellAmountsAreValid({
+      outcomeInAtoms: 100n,
+      soldRefundAtoms: 101n,
+    })).toBe(false);
+    expect(internal.predictionPortfolioPairAmountsAreValid(7n, 70n)).toBe(true);
+    expect(internal.predictionPortfolioPairAmountsAreValid(7n, 69n)).toBe(false);
+    expect(internal.predictionPortfolioRedemptionAmountsAreValid({
+      collateralAtoms: 70n,
+      noAtoms: 0n,
+      state: "FINAL_YES",
+      yesAtoms: 7n,
+    })).toBe(true);
+    expect(internal.predictionPortfolioRedemptionAmountsAreValid({
+      collateralAtoms: 69n,
+      noAtoms: 0n,
+      state: "FINAL_YES",
+      yesAtoms: 7n,
+    })).toBe(false);
+
+    expect(internal.predictionPortfolioAccountRole(
+      accountA,
+      accountA,
+      accountA,
+      "payer",
+    )).toBe("self");
+    expect(internal.predictionPortfolioAccountRole(
+      accountA,
+      accountA,
+      accountB,
+      "payer",
+    )).toBe("payer");
+    expect(internal.predictionPortfolioAccountRole(
+      accountA,
+      accountB,
+      accountA,
+      "holder",
+    )).toBe("recipient");
+    expect(internal.predictionPortfolioAccountRole(
+      accountA,
+      accountB,
+      "0x3333333333333333333333333333333333333333",
+      "holder",
+    )).toBeNull();
+  });
+
+  it("fails closed when reviewed router or vault activity names an unknown vault", () => {
+    const internal = predictionMarketPortfolioInternal;
+    type Component = Parameters<typeof internal.indexPredictionMarketComponents>[0][number];
+    const component = {
+      checkpoint: "0x3333333333333333333333333333333333333333",
+      cutoff: 100n,
+      noToken: "0x4444444444444444444444444444444444444444",
+      observationTime: 200n,
+      poolId: `0x${"11".repeat(32)}`,
+      semanticKey: `0x${"22".repeat(32)}`,
+      thresholdAtoms: 100_000n,
+      vault: "0x5555555555555555555555555555555555555555",
+      yesToken: "0x6666666666666666666666666666666666666666",
+    } as const satisfies Component;
+    const index = internal.indexPredictionMarketComponents([component]);
+
+    expect(internal.requirePredictionPortfolioComponent(
+      index,
+      component.vault,
+      "unknown router market",
+    )).toEqual(component);
+    expect(() => internal.requirePredictionPortfolioComponent(
+      index,
+      "0x7777777777777777777777777777777777777777",
+      "unknown router market",
+    )).toThrow("unknown router market");
+    expect(() => internal.requirePredictionPortfolioComponent(
+      index,
+      "0x8888888888888888888888888888888888888888",
+      "unknown vault market",
+    )).toThrow("unknown vault market");
+  });
+
+  it("suppresses only exact sell/refund transfer legs and keeps batched transfers", () => {
+    const internal = predictionMarketPortfolioInternal;
+    const transactionHash = `0x${"66".repeat(32)}` as Hex;
+    const selectedMarket = market();
+    const base = (logIndex: number) => ({
+      blockNumber: 10n,
+      logIndex,
+      market: selectedMarket,
+      semanticKey,
+      transactionHash,
+      transactionIndex: 1,
+      vault: selectedMarket.vault,
+    });
+    const transfer = ({
+      direction,
+      logIndex,
+      outcome,
+      outcomeAtoms,
+    }: {
+      direction: "in" | "out";
+      logIndex: number;
+      outcome: "YES" | "NO";
+      outcomeAtoms: bigint;
+    }): Extract<PredictionPortfolioHistoryEntry, { kind: "transfer" }> => ({
+      ...base(logIndex),
+      direction,
+      from: direction === "out" ? accountA : accountB,
+      kind: "transfer",
+      outcome,
+      outcomeAtoms,
+      to: direction === "out" ? accountB : accountA,
+    });
+    const history = [
+      transfer({ direction: "out", logIndex: 1, outcome: "YES", outcomeAtoms: 100n }),
+      transfer({ direction: "in", logIndex: 2, outcome: "YES", outcomeAtoms: 20n }),
+      transfer({ direction: "in", logIndex: 3, outcome: "NO", outcomeAtoms: 30n }),
+      transfer({ direction: "in", logIndex: 4, outcome: "YES", outcomeAtoms: 7n }),
+      {
+        ...base(5),
+        collateralAtoms: 500n,
+        complementRefundAtoms: 30n,
+        kind: "sold",
+        outcome: "YES",
+        outcomeAtoms: 100n,
+        soldRefundAtoms: 20n,
+      },
+      transfer({ direction: "in", logIndex: 6, outcome: "YES", outcomeAtoms: 20n }),
+    ] satisfies PredictionPortfolioHistoryEntry[];
+
+    const visible = internal.suppressPredictionPortfolioTransferLegs(history);
+
+    expect(visible.map((entry) => entry.logIndex)).toEqual([6, 5, 4]);
+    expect(visible.find((entry) => entry.kind === "sold")).toMatchObject({
+      complementRefundAtoms: 30n,
+      outcome: "YES",
+      outcomeAtoms: 100n,
+      soldRefundAtoms: 20n,
+    });
+    expect(visible.filter((entry) => entry.kind === "transfer")).toMatchObject([
+      { logIndex: 6, outcomeAtoms: 20n },
+      { logIndex: 4, outcomeAtoms: 7n },
+    ]);
+  });
+
+  it("suppresses exact buy, split, merge, and redeem token legs only", () => {
+    const internal = predictionMarketPortfolioInternal;
+    const selectedMarket = market();
+    const base = (transactionHash: Hex, logIndex: number) => ({
+      blockNumber: 10n,
+      logIndex,
+      market: selectedMarket,
+      semanticKey,
+      transactionHash,
+      transactionIndex: 1,
+      vault: selectedMarket.vault,
+    });
+    const transfer = (
+      transactionHash: Hex,
+      logIndex: number,
+      direction: "in" | "out",
+      outcome: "YES" | "NO",
+      outcomeAtoms: bigint,
+    ): Extract<PredictionPortfolioHistoryEntry, { kind: "transfer" }> => ({
+      ...base(transactionHash, logIndex),
+      direction,
+      from: direction === "out" ? accountA : accountB,
+      kind: "transfer",
+      outcome,
+      outcomeAtoms,
+      to: direction === "out" ? accountB : accountA,
+    });
+    const buyHash = `0x${"71".repeat(32)}` as Hex;
+    const splitHash = `0x${"72".repeat(32)}` as Hex;
+    const mergeHash = `0x${"73".repeat(32)}` as Hex;
+    const redeemHash = `0x${"74".repeat(32)}` as Hex;
+    const scenarios = [
+      {
+        eventKind: "bought",
+        history: [
+          transfer(buyHash, 1, "in", "YES", 100n),
+          transfer(buyHash, 2, "in", "NO", 7n),
+          {
+            ...base(buyHash, 3),
+            collateralInAtoms: 1_000n,
+            collateralRefundAtoms: 0n,
+            kind: "bought",
+            outcome: "YES",
+            outcomeAtoms: 100n,
+          },
+        ],
+      },
+      {
+        eventKind: "split",
+        history: [
+          transfer(splitHash, 1, "in", "YES", 50n),
+          transfer(splitHash, 2, "in", "NO", 50n),
+          transfer(splitHash, 3, "in", "YES", 7n),
+          {
+            ...base(splitHash, 4),
+            accountRole: "self",
+            collateralAtoms: 500n,
+            kind: "split",
+            outcomeAtoms: 50n,
+            payer: accountA,
+            recipient: accountA,
+          },
+        ],
+      },
+      {
+        eventKind: "merged",
+        history: [
+          transfer(mergeHash, 1, "out", "YES", 40n),
+          transfer(mergeHash, 2, "out", "NO", 40n),
+          transfer(mergeHash, 3, "in", "YES", 7n),
+          {
+            ...base(mergeHash, 4),
+            accountRole: "self",
+            collateralAtoms: 400n,
+            holder: accountA,
+            kind: "merged",
+            outcomeAtoms: 40n,
+            recipient: accountA,
+          },
+        ],
+      },
+      {
+        eventKind: "redeemed",
+        history: [
+          transfer(redeemHash, 1, "out", "YES", 25n),
+          transfer(redeemHash, 2, "out", "NO", 10n),
+          transfer(redeemHash, 3, "in", "YES", 7n),
+          {
+            ...base(redeemHash, 4),
+            accountRole: "self",
+            collateralAtoms: 250n,
+            holder: accountA,
+            kind: "redeemed",
+            noAtoms: 10n,
+            recipient: accountA,
+            yesAtoms: 25n,
+          },
+        ],
+      },
+    ] as const satisfies readonly Readonly<{
+      eventKind: PredictionPortfolioHistoryEntry["kind"];
+      history: readonly PredictionPortfolioHistoryEntry[];
+    }>[];
+
+    for (const scenario of scenarios) {
+      const visible = internal.suppressPredictionPortfolioTransferLegs(
+        scenario.history,
+      );
+      expect(visible.map((entry) => entry.logIndex)).toEqual(
+        scenario.eventKind === "bought" ? [3, 2] : [4, 3],
+      );
+      expect(visible.some((entry) => entry.kind === scenario.eventKind)).toBe(true);
+      expect(visible.find((entry) => entry.kind === "transfer")).toMatchObject({
+        outcomeAtoms: 7n,
+      });
+    }
+  });
+
   it("deduplicates the same self-transfer observed in both account topic queries", () => {
     const shared = log({ index: 7, transactionHash: `0x${"03".repeat(32)}` });
     const other = log({ index: 8, transactionHash: `0x${"03".repeat(32)}` });
@@ -272,6 +654,49 @@ describe("prediction portfolio event discovery", () => {
         new Set([outcomeToken.toLowerCase()]),
       ),
     ).toEqual([relevant]);
+  });
+
+  it("drops zero-value transfer spam and unrelated token emitters", () => {
+    const internal = predictionMarketPortfolioInternal;
+    const outcomeToken = "0x9999999999999999999999999999999999999999";
+    const positive = {
+      ...log({ index: 1, transactionHash: `0x${"04".repeat(32)}` }),
+      args: { value: 1n },
+    };
+    const zero = {
+      ...log({ index: 2, transactionHash: `0x${"05".repeat(32)}` }),
+      args: { value: 0n },
+    };
+    const unrelated = {
+      ...log({
+        address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        index: 3,
+        transactionHash: `0x${"06".repeat(32)}`,
+      }),
+      args: { value: 10n },
+    };
+
+    expect(internal.filterNonzeroPredictionOutcomeTransfers(
+      [zero, unrelated, positive],
+      new Set([outcomeToken.toLowerCase()]),
+    )).toEqual([positive]);
+  });
+
+  it("keeps only funded recipient redemption activity", () => {
+    const internal = predictionMarketPortfolioInternal;
+    const zero = {
+      ...log({ index: 1, transactionHash: `0x${"07".repeat(32)}` }),
+      args: { collateralAtoms: 0n },
+    };
+    const funded = {
+      ...log({ index: 2, transactionHash: `0x${"08".repeat(32)}` }),
+      args: { collateralAtoms: 10n },
+    };
+
+    expect(internal.filterFundedPredictionRedemptionRecipients([
+      zero,
+      funded,
+    ])).toEqual([funded]);
   });
 
   it("isolates one malformed market component without dropping valid markets", () => {

--- a/tests/prediction-market-trading.test.ts
+++ b/tests/prediction-market-trading.test.ts
@@ -5,6 +5,7 @@ import {
   assertPredictionConfirmedBlocksMatch,
   parsePredictionBuyAmount,
   parsePredictionSellAmount,
+  predictionBuyPayoutSummary,
   predictionMarketInternal,
   predictionMarketPageIndices,
   predictionDirectionalProtocolFee,
@@ -60,6 +61,100 @@ describe("prediction market trading math", () => {
     const packed = (321 << 12) | 123;
     expect(predictionDirectionalProtocolFee(packed, true)).toBe(123);
     expect(predictionDirectionalProtocolFee(packed, false)).toBe(321);
+  });
+
+  it("derives payout, profit, max loss, and neutral value from the executable buy quote", () => {
+    expect(
+      predictionBuyPayoutSummary({
+        collateralInAtoms: 100_000n,
+        collateralRefundAtoms: 0n,
+        minOutcomeAtoms: 19_423n,
+        outcomeAtoms: 19_521n,
+      }),
+    ).toEqual({
+      estimatedCostAtoms: 100_000n,
+      maximumLossAtoms: 100_000n,
+      minimumNeutralPayoutAtoms: 97_115n,
+      minimumWinningProfitAtoms: 94_230n,
+      minimumWinningPayoutAtoms: 194_230n,
+      neutralPayoutAtoms: 97_605n,
+      potentialProfitAtoms: 95_210n,
+      winningPayoutAtoms: 195_210n,
+    });
+  });
+
+  it("uses a quoted refund for estimated profit without understating max loss", () => {
+    expect(
+      predictionBuyPayoutSummary({
+        collateralInAtoms: 1_000_000n,
+        collateralRefundAtoms: 100_000n,
+        minOutcomeAtoms: 190_000n,
+        outcomeAtoms: 200_000n,
+      }),
+    ).toEqual({
+      estimatedCostAtoms: 900_000n,
+      maximumLossAtoms: 1_000_000n,
+      minimumNeutralPayoutAtoms: 950_000n,
+      minimumWinningProfitAtoms: 900_000n,
+      minimumWinningPayoutAtoms: 1_900_000n,
+      neutralPayoutAtoms: 1_000_000n,
+      potentialProfitAtoms: 1_100_000n,
+      winningPayoutAtoms: 2_000_000n,
+    });
+  });
+
+  it("rejects payout summaries that could misstate a malformed quote", () => {
+    expect(() =>
+      predictionBuyPayoutSummary({
+        collateralInAtoms: 1_000_000n,
+        collateralRefundAtoms: 1_000_001n,
+        minOutcomeAtoms: 100_000n,
+        outcomeAtoms: 100_000n,
+      }),
+    ).toThrow("payout quote");
+    expect(() =>
+      predictionBuyPayoutSummary({
+        collateralInAtoms: 1_000_000n,
+        collateralRefundAtoms: 0n,
+        minOutcomeAtoms: 100_001n,
+        outcomeAtoms: 100_000n,
+      }),
+    ).toThrow("payout quote");
+    expect(() =>
+      predictionBuyPayoutSummary({
+        collateralInAtoms: 1_000_001n,
+        collateralRefundAtoms: 0n,
+        minOutcomeAtoms: 100_000n,
+        outcomeAtoms: 100_000n,
+      }),
+    ).toThrow("payout quote");
+    expect(() =>
+      predictionBuyPayoutSummary({
+        collateralInAtoms: 1_000_000n,
+        collateralRefundAtoms: 1_000_000n,
+        minOutcomeAtoms: 100_000n,
+        outcomeAtoms: 100_000n,
+      }),
+    ).toThrow("payout quote");
+    expect(() =>
+      predictionBuyPayoutSummary({
+        collateralInAtoms: 1_000_000n,
+        collateralRefundAtoms: 0n,
+        minOutcomeAtoms: 100_000n,
+        outcomeAtoms: 1n << 128n,
+      }),
+    ).toThrow("payout quote");
+  });
+
+  it("keeps conservative minimum profit signed when slippage crosses cost", () => {
+    expect(
+      predictionBuyPayoutSummary({
+        collateralInAtoms: 1_000_000n,
+        collateralRefundAtoms: 0n,
+        minOutcomeAtoms: 90_000n,
+        outcomeAtoms: 105_000n,
+      }).minimumWinningProfitAtoms,
+    ).toBe(-100_000n);
   });
 
   it("pages newest-first with a stable cursor and no gaps", () => {

--- a/tests/prediction-market-trading.test.ts
+++ b/tests/prediction-market-trading.test.ts
@@ -3,13 +3,17 @@ import { describe, expect, it } from "vitest";
 import {
   applyPredictionSlippageFloor,
   assertPredictionConfirmedBlocksMatch,
+  isPredictionMarketLoadRequestCurrent,
   parsePredictionBuyAmount,
   parsePredictionSellAmount,
+  preparePredictionRedeem,
   predictionBuyPayoutSummary,
   predictionMarketInternal,
+  predictionMarketRedeemableAtoms,
   predictionMarketPageIndices,
   predictionDirectionalProtocolFee,
   predictionYesProbabilityBps,
+  type PredictionMarketView,
 } from "../lib/prediction-market-trading";
 
 const Q96 = 1n << 96n;
@@ -18,6 +22,29 @@ const MAX_SQRT_PRICE =
   1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342n;
 
 describe("prediction market trading math", () => {
+  it("rejects stale market reads after a wallet, market, or generation change", () => {
+    const request = {
+      accountKey: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      generation: 7,
+      semanticKey: `0x${"11".repeat(32)}`,
+    } as const;
+
+    expect(isPredictionMarketLoadRequestCurrent(request, { ...request })).toBe(true);
+    expect(isPredictionMarketLoadRequestCurrent(request, {
+      ...request,
+      accountKey: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    })).toBe(false);
+    expect(isPredictionMarketLoadRequestCurrent(request, {
+      ...request,
+      generation: 8,
+    })).toBe(false);
+    expect(isPredictionMarketLoadRequestCurrent(request, {
+      ...request,
+      semanticKey: `0x${"22".repeat(32)}`,
+    })).toBe(false);
+    expect(isPredictionMarketLoadRequestCurrent(request, null)).toBe(false);
+  });
+
   it("maps the v4 YES/NO ratio to a stable binary probability", () => {
     expect(predictionYesProbabilityBps(Q96, true)).toBe(5_000);
     expect(predictionYesProbabilityBps(Q96, false)).toBe(5_000);
@@ -101,6 +128,46 @@ describe("prediction market trading math", () => {
       potentialProfitAtoms: 1_100_000n,
       winningPayoutAtoms: 2_000_000n,
     });
+  });
+
+  it("enables redemption only for outcome balances with a positive payout", () => {
+    expect(predictionMarketRedeemableAtoms({
+      noBalanceAtoms: 25n,
+      state: "FINAL_YES",
+      yesBalanceAtoms: 10n,
+    })).toBe(100n);
+    expect(predictionMarketRedeemableAtoms({
+      noBalanceAtoms: 25n,
+      state: "FINAL_YES",
+      yesBalanceAtoms: 0n,
+    })).toBe(0n);
+    expect(predictionMarketRedeemableAtoms({
+      noBalanceAtoms: 25n,
+      state: "FINAL_NO",
+      yesBalanceAtoms: 10n,
+    })).toBe(250n);
+    expect(predictionMarketRedeemableAtoms({
+      noBalanceAtoms: 25n,
+      state: "FINAL_INVALID",
+      yesBalanceAtoms: 10n,
+    })).toBe(175n);
+    expect(predictionMarketRedeemableAtoms({
+      noBalanceAtoms: 25n,
+      state: "OPEN",
+      yesBalanceAtoms: 10n,
+    })).toBe(0n);
+  });
+
+  it("stops a loser-only zero-payout redemption before RPC or wallet work", async () => {
+    await expect(preparePredictionRedeem({
+      client: null as never,
+      market: {
+        noBalanceAtoms: 25n,
+        state: "FINAL_YES",
+        yesBalanceAtoms: 0n,
+      } as PredictionMarketView,
+      owner: "0x1111111111111111111111111111111111111111",
+    })).rejects.toThrow("no payout");
   });
 
   it("rejects payout summaries that could misstate a malformed quote", () => {

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -204,41 +204,26 @@ describe("prediction portfolio data contract", () => {
 });
 
 describe("prediction profile regression contract", () => {
-  it("keys asynchronous reads to the normalized wallet account and rejects stale responses", () => {
+  it("keys the complete activity read to the normalized wallet and rejects stale responses", () => {
     expect(portfolioSource).toMatch(/wallet\?\.account/u);
     expect(portfolioSource).toMatch(/accountKey[\s\S]{0,180}\.toLowerCase\(\)/u);
-    expect(portfolioSource).toContain("requestKey");
-    expect(portfolioSource).toMatch(
-      /is(?:Prediction|Internal)PortfolioRequestCurrent\(/u,
-    );
+    expect(portfolioSource).toContain("createPredictionPortfolioRequest(");
+    expect(portfolioSource).toContain("readPredictionMarketPortfolio({");
+    expect(portfolioSource).toContain("isPredictionPortfolioRequestCurrent(");
+    expect(portfolioSource).not.toContain("readPredictionMarketDirectory({");
+    expect(portfolioSource).not.toContain("loadOlderPositions");
 
     const accountCapture = portfolioSource.search(
       /(?:const|let)\s+\w*(?:account|key)\w*\s*=\s*[^;]*wallet\?*\.account/iu,
     );
-    const portfolioRead = [
-      portfolioSource.indexOf("readPredictionMarketPortfolio({"),
-      portfolioSource.indexOf("readPredictionMarketDirectory({"),
-    ].find((index) => index >= 0) ?? -1;
-    const staleGuard = portfolioSource.search(
-      /is(?:Prediction|Internal)PortfolioRequestCurrent\(/u,
-    );
+    const portfolioRead = portfolioSource.indexOf("readPredictionMarketPortfolio({");
     expect(accountCapture).toBeGreaterThan(-1);
     expect(portfolioRead).toBeGreaterThan(accountCapture);
     expect(
-      portfolioSource.slice(portfolioRead).search(
-        /is(?:Prediction|Internal)PortfolioRequestCurrent\(/u,
+      portfolioSource.slice(portfolioRead).indexOf(
+        "isPredictionPortfolioRequestCurrent(",
       ),
     ).toBeGreaterThan(0);
-
-    const olderLoad = portfolioSource.slice(
-      portfolioSource.indexOf("loadOlderPositions"),
-      portfolioSource.indexOf("const internalViewModel"),
-    );
-    expect(staleGuard).toBeGreaterThan(-1);
-    expect(olderLoad).toContain("requestKey");
-    expect(olderLoad).toMatch(
-      /is(?:Prediction|Internal)PortfolioRequestCurrent\(/u,
-    );
   });
 
   it("exposes Positions, Created, and History as one accessible tab set", () => {
@@ -311,7 +296,6 @@ describe("prediction profile regression contract", () => {
       ".portfolioRefresh",
       ".portfolioPrimaryAction",
       ".portfolioSecondaryAction",
-      ".portfolioLoadMore",
       ".portfolioError button",
       ".portfolioInlineError button",
       ".portfolioCardActions a",

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -16,6 +16,10 @@ const portfolioSource = readFileSync(
   join(root, "components/prediction-market-portfolio.tsx"),
   "utf8",
 );
+const detailSource = readFileSync(
+  join(root, "components/prediction-market-detail.tsx"),
+  "utf8",
+);
 const portfolioStyles = readFileSync(
   join(root, "components/prediction-market-experience.module.css"),
   "utf8",
@@ -183,6 +187,16 @@ describe("prediction portfolio data contract", () => {
       result: "won",
       redeemableAtoms: 90n,
     });
+
+    expect(
+      derivePredictionPortfolioPosition(
+        market({ noBalanceAtoms: 90n, state: "FINAL_YES", yesBalanceAtoms: 9n }),
+      ),
+    ).toMatchObject({
+      lifecycle: "final_yes",
+      result: "mixed",
+      redeemableAtoms: 90n,
+    });
   });
 
   it("keeps an invalid resolution neutral and computes its exact half-face redemption", () => {
@@ -243,7 +257,9 @@ describe("prediction profile regression contract", () => {
   });
 
   it("does not present an OPEN market as tradable after its cutoff", () => {
-    expect(portfolioSource).toContain("trading_closed");
+    expect(portfolioSource).toMatch(
+      /source\.lifecycle\s*===\s*["']open["']\s*&&\s*!source\.tradingClosed/u,
+    );
     expect(portfolioSource).toMatch(/Trading closed|Awaiting result/u);
     expect(portfolioSource).not.toContain('market.state.replaceAll("_", " ")');
   });
@@ -252,6 +268,30 @@ describe("prediction profile regression contract", () => {
     for (const label of ["Won", "Lost", "Neutral", "Redeemable"]) {
       expect(portfolioSource).toMatch(new RegExp(label, "iu"));
     }
+  });
+
+  it("labels live reads honestly and progressively reveals long activity lists", () => {
+    expect(portfolioSource).toContain('timeLabel: "Observed onchain"');
+    expect(portfolioSource).toMatch(
+      /PORTFOLIO_INITIAL_VISIBLE_ITEMS\s*=\s*12/u,
+    );
+    expect(portfolioSource).toMatch(
+      /activeItems\.slice\(0,\s*visibleCounts\[activeTab\]\)/u,
+    );
+    expect(portfolioSource).toContain("remainingItemCount > 0");
+    expect(portfolioSource).toMatch(
+      /Show \{Math\.min\([\s\S]{0,100}remainingItemCount/u,
+    );
+    expect(portfolioSource).toContain(
+      "more items shown in ${tabLabel(activeTab)}",
+    );
+    expect(portfolioSource).toContain(
+      "tabRefs.current.get(activeTab)?.focus()",
+    );
+    expect(
+      hasTouchHeight(cssDeclarationsFor(portfolioStyles, ".portfolioShowMore")),
+      ".portfolioShowMore needs a minimum 44px touch target",
+    ).toBe(true);
   });
 
   it("offers refresh and retry without turning routine progress into an alert", () => {
@@ -292,6 +332,9 @@ describe("prediction profile regression contract", () => {
 
   it("keeps tabs, refresh, retry, and row actions at least 44px tall", () => {
     for (const selector of [
+      ".modeTabs button",
+      ".quoteDetails summary",
+      ".refreshMarket",
       ".portfolioTabs button",
       ".portfolioRefresh",
       ".portfolioPrimaryAction",
@@ -305,5 +348,42 @@ describe("prediction profile regression contract", () => {
         `${selector} needs a minimum 44px touch target`,
       ).toBe(true);
     }
+  });
+
+  it("restores a visible amount-input focus treatment around the whole field", () => {
+    const focusWithin = cssDeclarationsFor(
+      portfolioStyles,
+      ".amountField > span:nth-child(2):focus-within",
+    );
+
+    expect(focusWithin).toMatch(/border-bottom-color\s*:/u);
+    expect(focusWithin).toMatch(/box-shadow\s*:/u);
+    expect(focusWithin).toContain("var(--focus)");
+  });
+
+  it("keeps financial safety labels conservative and explicit", () => {
+    expect(detailSource).toContain("maximumLossAtoms, \"exact\"");
+    expect(detailSource).toContain("minimumWinningPayoutAtoms,");
+    expect(detailSource).toContain("minimumWinningProfitAtoms,");
+    expect(detailSource).toContain("minimumNeutralPayoutAtoms,");
+    expect(detailSource).toContain("Minimum neutral payout");
+    expect(detailSource).not.toContain("neutralPayoutLabel");
+  });
+
+  it("invalidates wallet actions before submission across wallet, market, and unmount changes", () => {
+    expect(detailSource).toContain("useLayoutEffect(() => {");
+    expect(detailSource).toContain("activeMarketActionRequest.current = null");
+    expect(detailSource).toContain("marketActionGeneration.current += 1");
+    expect(detailSource.match(/requireCurrentMarketAction\(actionRequest\)/gu)?.length)
+      .toBeGreaterThanOrEqual(5);
+    expect(detailSource.match(
+      /await sendTransaction\(prepared\);\s*if \(!marketActionIsCurrent\(actionRequest\)\) return;/gu,
+    )?.length).toBe(2);
+  });
+
+  it("never offers a gas-only redemption for a zero-payout position", () => {
+    expect(detailSource).toContain("predictionMarketRedeemableAtoms(market)");
+    expect(detailSource).toContain("redeemableAtoms === 0n");
+    expect(detailSource).toContain("No payout available");
   });
 });

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -1,0 +1,325 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { getAddress } from "viem";
+
+import {
+  createPredictionPortfolioRequest,
+  derivePredictionPortfolioPosition,
+  isPredictionPortfolioRequestCurrent,
+} from "../lib/prediction-market-portfolio";
+import type { PredictionMarketView } from "../lib/prediction-market-trading";
+
+const root = process.cwd();
+const portfolioSource = readFileSync(
+  join(root, "components/prediction-market-portfolio.tsx"),
+  "utf8",
+);
+const portfolioStyles = readFileSync(
+  join(root, "components/prediction-market-experience.module.css"),
+  "utf8",
+);
+
+function mediaBodiesAtOrBelow(css: string, maximumWidth: number) {
+  const bodies: string[] = [];
+  const mediaStart = /@media\s*\(\s*max-width:\s*(\d+)px\s*\)\s*\{/gu;
+  for (const match of css.matchAll(mediaStart)) {
+    const width = Number(match[1]);
+    if (width > maximumWidth || match.index === undefined) continue;
+
+    const openingBrace = match.index + match[0].lastIndexOf("{");
+    let depth = 1;
+    let cursor = openingBrace + 1;
+    while (cursor < css.length && depth > 0) {
+      if (css[cursor] === "{") depth += 1;
+      if (css[cursor] === "}") depth -= 1;
+      cursor += 1;
+    }
+    if (depth === 0) bodies.push(css.slice(openingBrace + 1, cursor - 1));
+  }
+  return bodies.join("\n");
+}
+
+function cssDeclarationsFor(css: string, selectorFragment: string) {
+  return [...css.matchAll(/([^{}]+)\{([^{}]*)\}/gu)]
+    .filter(([, selectors]) => selectors.split(",").some(
+      (selector) => selector.trim() === selectorFragment,
+    ))
+    .map(([, , declarations]) => declarations)
+    .join("\n");
+}
+
+function hasTouchHeight(declarations: string) {
+  return [...declarations.matchAll(/(?:min-)?height\s*:\s*(\d+)px/gu)]
+    .some((match) => Number(match[1]) >= 44);
+}
+
+const account = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const otherAccount = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+function market(
+  overrides: Partial<PredictionMarketView> = {},
+): PredictionMarketView {
+  return {
+    accountedLiabilityAtoms: 1_000n,
+    blockNumber: 101n,
+    blockTimestamp: 90n,
+    canonicalPoolId: `0x${"11".repeat(32)}`,
+    checkpoint: "0x1111111111111111111111111111111111111111",
+    checkpointStatus: "AWAITING",
+    cutoff: 100n,
+    fallbackChallengeDeadline: 130n,
+    fallbackRequestedAt: 0n,
+    hardResolutionDeadline: 140n,
+    liquidity: 1_000n,
+    noBalanceAtoms: 0n,
+    noToken: "0x2222222222222222222222222222222222222222",
+    noTokenName: "Test NO",
+    observationTime: 110n,
+    poolId: `0x${"22".repeat(32)}`,
+    poolKey: {
+      currency0: "0x3333333333333333333333333333333333333333",
+      currency1: "0x4444444444444444444444444444444444444444",
+      fee: 200,
+      hooks: "0x5555555555555555555555555555555555555555",
+      tickSpacing: 60,
+    },
+    probabilityYesBps: 5_000,
+    protocolFee: 0,
+    resolvedPriceAtoms: 0n,
+    resolutionDeadline: 120n,
+    router: "0x6666666666666666666666666666666666666666",
+    semanticKey: `0x${"33".repeat(32)}`,
+    sqrtPriceX96: 1n << 96n,
+    state: "OPEN",
+    thresholdAtoms: 6_000_000_000_000n,
+    tick: 0,
+    title: "Will BTC finish above the threshold?",
+    vault: "0x7777777777777777777777777777777777777777",
+    yesBalanceAtoms: 10n,
+    yesToken: "0x8888888888888888888888888888888888888888",
+    yesTokenName: "Test YES",
+    ...overrides,
+  };
+}
+
+describe("prediction portfolio data contract", () => {
+  it("binds each response to both a checksummed account and a request key", () => {
+    const request = createPredictionPortfolioRequest(account, "initial:1");
+
+    expect(request).toEqual({
+      account: getAddress(account),
+      requestKey: "initial:1",
+    });
+    expect(
+      isPredictionPortfolioRequestCurrent(
+        request,
+        createPredictionPortfolioRequest(account, "initial:1"),
+      ),
+    ).toBe(true);
+    expect(
+      isPredictionPortfolioRequestCurrent(
+        { request },
+        createPredictionPortfolioRequest(account, "initial:1"),
+      ),
+    ).toBe(true);
+    expect(
+      isPredictionPortfolioRequestCurrent(
+        request,
+        createPredictionPortfolioRequest(account, "refresh:2"),
+      ),
+    ).toBe(false);
+    expect(
+      isPredictionPortfolioRequestCurrent(
+        request,
+        createPredictionPortfolioRequest(otherAccount, "initial:1"),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats cutoff as the end of trading even while the contract state is OPEN", () => {
+    expect(
+      derivePredictionPortfolioPosition(
+        market({ blockTimestamp: 99n, cutoff: 100n, state: "OPEN" }),
+      ),
+    ).toMatchObject({ lifecycle: "open", result: "pending" });
+    expect(
+      derivePredictionPortfolioPosition(
+        market({ blockTimestamp: 100n, cutoff: 100n, state: "OPEN" }),
+      ),
+    ).toMatchObject({ lifecycle: "trading_closed", result: "pending" });
+  });
+
+  it("derives won and lost outcomes from the held side", () => {
+    expect(
+      derivePredictionPortfolioPosition(
+        market({ state: "FINAL_YES", yesBalanceAtoms: 12n }),
+      ),
+    ).toMatchObject({
+      lifecycle: "final_yes",
+      result: "won",
+      redeemableAtoms: 120n,
+    });
+    expect(
+      derivePredictionPortfolioPosition(
+        market({
+          noBalanceAtoms: 12n,
+          state: "FINAL_YES",
+          yesBalanceAtoms: 0n,
+        }),
+      ),
+    ).toMatchObject({
+      lifecycle: "final_yes",
+      result: "lost",
+      redeemableAtoms: 0n,
+    });
+    expect(
+      derivePredictionPortfolioPosition(
+        market({ noBalanceAtoms: 9n, state: "FINAL_NO", yesBalanceAtoms: 0n }),
+      ),
+    ).toMatchObject({
+      lifecycle: "final_no",
+      result: "won",
+      redeemableAtoms: 90n,
+    });
+  });
+
+  it("keeps an invalid resolution neutral and computes its exact half-face redemption", () => {
+    const largeBalance = 1n << 120n;
+    expect(
+      derivePredictionPortfolioPosition(
+        market({
+          noBalanceAtoms: 7n,
+          state: "FINAL_INVALID",
+          yesBalanceAtoms: largeBalance,
+        }),
+      ),
+    ).toMatchObject({
+      lifecycle: "final_invalid",
+      result: "neutral",
+      redeemableAtoms: (largeBalance + 7n) * 10n / 2n,
+    });
+  });
+});
+
+describe("prediction profile regression contract", () => {
+  it("keys asynchronous reads to the normalized wallet account and rejects stale responses", () => {
+    expect(portfolioSource).toMatch(/wallet\?\.account/u);
+    expect(portfolioSource).toMatch(/accountKey[\s\S]{0,180}\.toLowerCase\(\)/u);
+    expect(portfolioSource).toContain("requestKey");
+    expect(portfolioSource).toMatch(
+      /is(?:Prediction|Internal)PortfolioRequestCurrent\(/u,
+    );
+
+    const accountCapture = portfolioSource.search(
+      /(?:const|let)\s+\w*(?:account|key)\w*\s*=\s*[^;]*wallet\?*\.account/iu,
+    );
+    const portfolioRead = [
+      portfolioSource.indexOf("readPredictionMarketPortfolio({"),
+      portfolioSource.indexOf("readPredictionMarketDirectory({"),
+    ].find((index) => index >= 0) ?? -1;
+    const staleGuard = portfolioSource.search(
+      /is(?:Prediction|Internal)PortfolioRequestCurrent\(/u,
+    );
+    expect(accountCapture).toBeGreaterThan(-1);
+    expect(portfolioRead).toBeGreaterThan(accountCapture);
+    expect(
+      portfolioSource.slice(portfolioRead).search(
+        /is(?:Prediction|Internal)PortfolioRequestCurrent\(/u,
+      ),
+    ).toBeGreaterThan(0);
+
+    const olderLoad = portfolioSource.slice(
+      portfolioSource.indexOf("loadOlderPositions"),
+      portfolioSource.indexOf("const internalViewModel"),
+    );
+    expect(staleGuard).toBeGreaterThan(-1);
+    expect(olderLoad).toContain("requestKey");
+    expect(olderLoad).toMatch(
+      /is(?:Prediction|Internal)PortfolioRequestCurrent\(/u,
+    );
+  });
+
+  it("exposes Positions, Created, and History as one accessible tab set", () => {
+    for (const label of ["Positions", "Created", "History"]) {
+      expect(portfolioSource).toMatch(new RegExp(`(?:["']${label}["']|>${label}<)`, "u"));
+    }
+
+    expect(portfolioSource).toContain('role="tablist"');
+    expect(portfolioSource).toContain('role="tab"');
+    expect(portfolioSource).toContain("aria-selected=");
+    expect(portfolioSource).toContain("aria-controls=");
+    expect(portfolioSource).toContain('role="tabpanel"');
+    expect(portfolioSource).toMatch(
+      /useState<[^>]*(?:Tab|"positions")[^>]*>\(["']positions["']\)/u,
+    );
+    expect(portfolioSource).toMatch(/(?:model|viewModel)\s*\[\s*activeTab\s*\]/u);
+  });
+
+  it("does not present an OPEN market as tradable after its cutoff", () => {
+    expect(portfolioSource).toContain("trading_closed");
+    expect(portfolioSource).toMatch(/Trading closed|Awaiting result/u);
+    expect(portfolioSource).not.toContain('market.state.replaceAll("_", " ")');
+  });
+
+  it("distinguishes resolved won, lost, neutral, and redeemable positions", () => {
+    for (const label of ["Won", "Lost", "Neutral", "Redeemable"]) {
+      expect(portfolioSource).toMatch(new RegExp(label, "iu"));
+    }
+  });
+
+  it("offers refresh and retry without turning routine progress into an alert", () => {
+    expect(portfolioSource).toMatch(/Refresh/u);
+    expect(portfolioSource).toMatch(/Retry/u);
+    expect(portfolioSource).toContain("aria-busy=");
+    expect(portfolioSource).toMatch(/role=["']status["']|aria-live=["']polite["']/u);
+    expect(portfolioSource).toContain('role="alert"');
+
+    const alertCount = portfolioSource.match(/role=["']alert["']/gu)?.length ?? 0;
+    const statusCount =
+      portfolioSource.match(/role=["']status["']|aria-live=["']polite["']/gu)
+        ?.length ?? 0;
+    expect(alertCount).toBeGreaterThan(0);
+    expect(statusCount).toBeGreaterThan(0);
+  });
+
+  it("reflows balances on narrow screens and lets large amounts wrap", () => {
+    const narrowStyles = mediaBodiesAtOrBelow(portfolioStyles, 700);
+    const narrowPositionRules = [...narrowStyles.matchAll(
+      /([^{}]*(?:position|portfolio)[^{}]*)\{([^{}]*)\}/giu,
+    )];
+    const narrowBalanceLayout = narrowPositionRules
+      .filter(([, selector]) => /card|holding|metric|row|balance|amount/iu.test(selector))
+      .map(([, , declarations]) => declarations)
+      .join("\n");
+
+    expect(narrowBalanceLayout).not.toMatch(
+      /grid-template-columns\s*:[^;}]*(?:64px|110px)/u,
+    );
+    expect(narrowBalanceLayout).toMatch(
+      /grid-template-columns\s*:\s*minmax\(0,\s*1fr\)|flex-wrap\s*:\s*wrap|display\s*:\s*block/u,
+    );
+    expect(portfolioStyles).toMatch(
+      /(?:position|portfolio|balance|amount)[^{]*\{[^}]*(?:overflow-wrap\s*:\s*anywhere|word-break\s*:\s*break-word)/isu,
+    );
+  });
+
+  it("keeps tabs, refresh, retry, and row actions at least 44px tall", () => {
+    for (const selector of [
+      ".portfolioTabs button",
+      ".portfolioRefresh",
+      ".portfolioPrimaryAction",
+      ".portfolioSecondaryAction",
+      ".portfolioLoadMore",
+      ".portfolioError button",
+      ".portfolioInlineError button",
+      ".portfolioCardActions a",
+    ]) {
+      expect(
+        hasTouchHeight(cssDeclarationsFor(portfolioStyles, selector)),
+        `${selector} needs a minimum 44px touch target`,
+      ).toBe(true);
+    }
+  });
+});

--- a/tests/profile-banner-accessibility.test.ts
+++ b/tests/profile-banner-accessibility.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  formatBannerPositionStatus,
+  formatBannerPositionValue,
+} from "../components/profile-view";
+
+const profileSource = readFileSync(
+  new URL("../components/profile-view.tsx", import.meta.url),
+  "utf8",
+);
+const profileCss = readFileSync(
+  new URL("../components/profile-experience.module.css", import.meta.url),
+  "utf8",
+);
+
+describe("profile banner accessibility", () => {
+  it("keeps normal mobile scrolling outside the editable crop state", () => {
+    expect(profileCss).toMatch(
+      /\.profileBanner\s*\{[^}]*touch-action:\s*auto;/s,
+    );
+    expect(profileCss).not.toMatch(
+      /\.profileBanner\s*\{[^}]*touch-action:\s*none;/s,
+    );
+    expect(profileCss).toMatch(
+      /\.profileBannerPositionable\s*\{[^}]*touch-action:\s*none;/s,
+    );
+    expect(profileSource).toContain("editingProfile && bannerDraft");
+  });
+
+  it("offers two labelled native range controls for keyboard positioning", () => {
+    expect(profileSource.match(/type="range"/g)).toHaveLength(2);
+    expect(profileSource).toContain("Horizontal position");
+    expect(profileSource).toContain("Vertical position");
+    expect(profileSource.match(/min="0"/g)).toHaveLength(2);
+    expect(profileSource.match(/max="100"/g)).toHaveLength(2);
+    expect(profileSource.match(/step="1"/g)).toHaveLength(2);
+    expect(profileSource.match(/aria-valuetext=/g)).toHaveLength(2);
+    expect(profileSource.match(/profile-banner-position-status/g)).toHaveLength(
+      3,
+    );
+    expect(profileCss).toMatch(
+      /\.bannerPositionFields input\s*\{[^}]*height:\s*44px;/s,
+    );
+    expect(profileCss).toMatch(
+      /\.bannerPositionFields input:focus-visible[^}]*outline:\s*2px solid var\(--focus\);/s,
+    );
+  });
+
+  it("retains pointer capture for direct banner dragging", () => {
+    expect(profileSource).toContain("onPointerDown={startBannerDrag}");
+    expect(profileSource).toContain("onPointerMove={moveBannerDrag}");
+    expect(profileSource).toContain("onPointerUp={stopBannerDrag}");
+    expect(profileSource).toContain("onPointerCancel={stopBannerDrag}");
+    expect(profileSource).toContain(
+      "event.currentTarget.setPointerCapture(event.pointerId)",
+    );
+  });
+
+  it("describes keyboard and pointer positions in human terms", () => {
+    expect(formatBannerPositionValue("horizontal", 0)).toBe(
+      "aligned to the left edge",
+    );
+    expect(formatBannerPositionValue("horizontal", 50)).toBe(
+      "centered horizontally",
+    );
+    expect(formatBannerPositionValue("vertical", 100)).toBe(
+      "aligned to the bottom edge",
+    );
+    expect(formatBannerPositionStatus({ x: 27.6, y: 64.2 })).toBe(
+      "Banner position: 28% from the left, 64% from the top.",
+    );
+  });
+});


### PR DESCRIPTION
## What changed
- integrate wallet-bound prediction positions, created markets, and complete onchain history into Profile
- add quote-derived payout, profit, minimum, refund, and max-loss details to market trading
- harden dual-RPC history reads, reorg anchoring, event correlation, stale wallet/market actions, and zero-payout redemption guards
- align cards, responsive behavior, focus states, and progressive activity disclosure with the existing token profile experience

## Validation
- TypeScript and focused ESLint pass
- 96 focused prediction/profile tests pass on the rebased production head
- wallet-lock browser suite passes 2/2
- full interface suite and production build are running in required CI

This changes the website/read model only. It does not deploy or modify prediction contracts.