### PR TITLE
Decouple verified Custom reads from launch writes

### DIFF
--- a/lib/server/custom-launch/public-readiness.ts
+++ b/lib/server/custom-launch/public-readiness.ts
@@ -72,8 +72,7 @@ export function isCustomLaunchPublicEnabled(
 export function isCustomLaunchRegistryPublicReadEnabled(
   environment: Readonly<Record<string, string | undefined>> = process.env,
 ): boolean {
-  return environment.PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED === "true"
-    && environment.PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED === "true";
+  return environment.PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED === "true";
 }
 
 export function configuredLaunchPermitSignersV2(

--- a/tests/custom-launch-public-readiness.test.ts
+++ b/tests/custom-launch-public-readiness.test.ts
@@ -124,6 +124,11 @@ describe("Custom launch public readiness", () => {
     expect(isCustomLaunchRegistryPublicReadEnabled({
       PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED: "false",
       PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED: "true",
+    })).toBe(true);
+    expect(isCustomLaunchPublicEnabled({
+      ...configured,
+      PROGRAMMABLE_CUSTOM_LAUNCH_PUBLIC_ENABLED: "false",
+      PROGRAMMABLE_CUSTOM_REGISTRY_PUBLIC_ENABLED: "true",
     })).toBe(false);
     expect(isCustomLaunchRegistryPublicReadEnabled({
       ...configured,


### PR DESCRIPTION
## Summary
- allow the verified Registry V2 public directory to serve its read-only feed when the registry read flag is enabled
- keep Custom launch/write activation behind the existing full launch flag and all approval, signer, storage, session, and production-mode checks
- preserve fail-closed behavior when Registry readiness is unavailable

## Safety invariants
- no Custom write, signing, intake, or trading activation
- no unverified Custom identity becomes public
- Classic V3, official-main-token exception, Stock exclusions, Router privacy, profile, claim, and trade behavior remain unchanged

## Focused validation
- 47 focused API/readiness tests passed
- TypeScript typecheck passed
- changed-file ESLint passed
- git diff --check passed

Commit: 8695d2ba89dbd32b70891570153cb8a9c16e407c
Tree: 546f1a00c906893d97e6c49af24336bfb1afa2be