### PR TITLE
Fix mobile sticky header overlap

### DIFF
--- a/components/site-navigation.module.css
+++ b/components/site-navigation.module.css
@@ -7,6 +7,7 @@
 /* The full navigation stops fitting comfortably below this content breakpoint. */
 @media (max-width: 60rem) {
   .siteHeader.siteHeader {
+    background-color: var(--webde-canvas, #000);
     height: calc(72px + env(safe-area-inset-top));
     min-height: calc(72px + env(safe-area-inset-top));
     padding-top: env(safe-area-inset-top);

--- a/tests/topbar-hero-polish.test.ts
+++ b/tests/topbar-hero-polish.test.ts
@@ -17,6 +17,14 @@ describe("topbar and Explore hero polish", () => {
     );
   });
 
+  it("masks scrolling content below the sticky mobile navigation", () => {
+    const css = read("components/site-navigation.module.css");
+
+    expect(css).toMatch(
+      /@media \(max-width: 60rem\)[\s\S]*?\.siteHeader\.siteHeader\s*\{[^}]*background-color:\s*var\(--webde-canvas, #000\);/s,
+    );
+  });
+
   it("uses large white navigation text without an active underline", () => {
     const css = read("app/webde-final-ui.css");
 


### PR DESCRIPTION
## What changed
- make the sticky mobile header opaque so scrolled market content cannot paint through it
- preserve the transparent desktop header
- lock the mobile behavior with a focused regression test

## Verification
- 21 focused tests passed
- TypeScript passed
- focused ESLint passed
- mobile 390px: opaque header and no horizontal overflow
- desktop 1440px: header remains transparent