### PR TITLE
Accept verified Custom source in stage smoke

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -697,10 +697,15 @@ jobs:
             maximumBytes: 4 * 1024 * 1024,
             label: "staged Envio catalog probe",
           }));
+          const expectedLaunchSource =
+            body?.catalog?.completeness?.custom === "current"
+              ? "envio-classic-v3+registry.custom-launched"
+              : "envio-classic-v3";
           if (
             response.status !== 200 ||
             body?.status !== "ready" ||
             body?.catalog?.source !== "envio-classic-v3" ||
+            body.catalog.launchSource !== expectedLaunchSource ||
             body.catalog.completeness?.stock !== "excluded" ||
             body.catalog.evidence?.kind !== "envio-indexer-state" ||
             body.catalog.evidence?.progressBlock !== body.catalog.asOfBlock ||
@@ -712,7 +717,7 @@ jobs:
             body.tokens[0]?.launchModel !== "classic" ||
             body.tokens[0]?.launchModelVersion !== "classic-v3" ||
             response.headers.get("x-programmable-launch-source") !==
-              "envio-classic-v3"
+              expectedLaunchSource
           ) {
             throw new Error("staged Envio Classic V3 catalog probe is invalid");
           }


### PR DESCRIPTION
## Summary
- make the immutable Stage catalog probe derive the exact public source from Custom completeness
- require `envio-classic-v3+registry.custom-launched` only when verified Custom reads are current
- retain the original `envio-classic-v3` requirement when that read lane is unavailable

## Evidence
Stage run 32640895474 built READY deployment dpl_BoCNpzy7rEgmmY3cxWtwy4Q871yy at exact parent SHA 7cbe69a02a1ac087a20da4d296b3d14d53af3379. The API was 200/ready with 280 identities, Envio block 25818018, stock excluded, Custom current, and a Classic V3 newest token. The sole failed predicate was the stale exact header assertion: expected `envio-classic-v3`, observed `envio-classic-v3+registry.custom-launched`.

## Scope
One workflow contract only. No product/runtime behavior, environment, signer, launch/write, provider, database, or onchain change.

Commit: ee702ed5838072c6eeb6d296aac17da64694852a
Tree: c508da7a08278771bd356b6fcd338dee955e7665