### PR TITLE
feat: polish and document prediction markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <h3 align="center">Shape what assets can do</h3>
 
 <p align="center">
-  The public product, contracts, read model and release evidence for Programmable on Ethereum.
+  The public application, Ethereum contracts, read model and maintained product documentation for Programmable.
 </p>
 
 <p align="center">
@@ -40,21 +40,26 @@ Programmable is a launch platform for Uniswap v4 products. This repository conta
 contract workspace, the public read model and the evidence that binds what the product shows to deployed code.
 
 Classic is the direct launch model for a fixed supply token, a permanently locked ETH pool and configurable creator
-rewards. Custom is the reviewed path for products that need their own hook, application logic or execution graph. In
-both models, the connected wallet reviews and signs its own Ethereum transaction.
+rewards. Custom is the reviewed path for products that need their own hook, application logic or execution graph.
+Prediction Markets is a separately versioned Uniswap v4 launch model for onchain outcome markets. Its current
+capabilities, contracts and release evidence live in the public
+[`programmable-prediction-markets`](https://github.com/0xprogrammable/programmable-prediction-markets) repository.
+Each release defines its funding and signing path. User-funded flows keep the connected wallet in control of its own
+transaction.
 
 ## Launch models
 
-| Model       | What it creates                                                       | Access                                                    |
-| ----------- | --------------------------------------------------------------------- | --------------------------------------------------------- |
-| **Classic** | A fixed supply token with configurable buy and sell transaction fees  | Open through [Create](https://programmable.market/launch) |
-| **Custom**  | A token or application with an individually reviewed hook and release | Accepted and activated revisions only                     |
+| Model                  | What it creates                                                       | Access                                                    |
+| ---------------------- | --------------------------------------------------------------------- | --------------------------------------------------------- |
+| **Classic**            | A fixed supply token with configurable buy and sell transaction fees  | Open through [Create](https://programmable.market/launch) |
+| **Custom**             | A token or application with an individually reviewed hook and release | Accepted and activated revisions only                     |
+| **Prediction Markets** | Onchain outcome markets powered by Uniswap v4                         | Open through [Create](https://programmable.market/launch) |
 
 A hook is a smart contract attached to a Uniswap v4 pool. The pool calls it at defined points in a transaction, which
 lets the product apply behavior at the pool level. A hook can change fees, accounting, access or other pool behavior,
 but the word hook does not establish safety, compatibility or launch approval.
 
-[Compare Classic and Custom](https://programmable.market/docs/tokens)
+[Compare the launch models](https://programmable.market/docs/tokens)
 
 <p align="center">
   <img
@@ -66,10 +71,11 @@ but the word hook does not establish safety, compatibility or launch approval.
 
 ## How public state is built
 
-1. A creator configures Classic or prepares one exact reviewed Custom release.
-2. The connected wallet checks the network, destination, calldata and value before signing.
-3. Ethereum confirms the transaction and the launch reaches the required finality.
-4. The read model publishes the canonical token, pool and launch identity.
+1. A launch request is normalized under the active Classic, Custom or Prediction Markets release.
+2. The active release authenticates and submits the required transaction under its published signer and funding
+   policy.
+3. The required network confirms the transaction and the launch reaches the required finality.
+4. The product read layer publishes the canonical token, pool or prediction market identity.
 5. Optional price, chart and liquidity data are attached only when their providers return current evidence.
 
 Canonical launch identity remains visible when optional market data is unavailable. The application does not invent
@@ -124,22 +130,25 @@ provider availability or onchain lifecycle completion.
 | ------------------- | -------------------------------------------------------------------------------------------------------- |
 | Product             | [programmable.market](https://programmable.market)                                                       |
 | Explore             | [programmable.market/explore](https://programmable.market/explore)                                       |
+| Prediction Markets  | [programmable.market/markets](https://programmable.market/markets)                                       |
 | Documentation       | [programmable.market/docs](https://programmable.market/docs)                                             |
 | Developer reference | [programmable.market/docs/developers](https://programmable.market/docs/developers)                       |
 | Service status      | [developers.programmable.family/api/v2/status](https://developers.programmable.family/api/v2/status)     |
 | Deployment manifest | [developers.programmable.family/api/v2/manifest](https://developers.programmable.family/api/v2/manifest) |
 
-Contract addresses and integration data should come from the versioned manifest rather than screenshots, token names
-or third-party metadata.
+Ethereum contract addresses and integration data should come from the versioned manifest rather than screenshots,
+token names or third-party metadata. For Prediction Markets, use the canonical repository for the current networks,
+supported market types, economics, resolution rules, contract addresses and release evidence.
 
 ## Related repositories
 
-| Repository                                                             | Responsibility                                                            |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| [`hookbuilder`](https://github.com/0xprogrammable/hookbuilder)         | Agent Skill and local tools for building reproducible Uniswap v4 projects |
-| [`submit-launch`](https://github.com/0xprogrammable/submit-launch)     | Exact-revision intake and public review records for one completed project |
-| [`submit-template`](https://github.com/0xprogrammable/submit-template) | Requirements and version binding for reusable hook templates              |
-| [`developers`](https://github.com/0xprogrammable/developers)           | Discovery manifests, API contracts and direct verification rules          |
+| Repository                                                                                             | Responsibility                                                              |
+| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| [`hookbuilder`](https://github.com/0xprogrammable/hookbuilder)                                         | Agent Skill and local tools for building reproducible Uniswap v4 projects   |
+| [`submit-launch`](https://github.com/0xprogrammable/submit-launch)                                     | Exact-revision intake and public review records for one completed project   |
+| [`submit-template`](https://github.com/0xprogrammable/submit-template)                                 | Requirements and version binding for reusable hook templates                |
+| [`developers`](https://github.com/0xprogrammable/developers)                                           | Discovery manifests, API contracts and direct verification rules            |
+| [`programmable-prediction-markets`](https://github.com/0xprogrammable/programmable-prediction-markets) | Prediction market contracts, release specifications and deployment evidence |
 
 ## Release and security boundaries
 

--- a/app/docs/models/[model]/page.tsx
+++ b/app/docs/models/[model]/page.tsx
@@ -6,7 +6,7 @@ import { DocsExternalLink } from "@/components/docs-external-link";
 import { DocsShell } from "@/components/docs-shell";
 import styles from "@/components/docs-experience.module.css";
 
-type ModelSlug = "classic" | "custom" | "stock-paired";
+type ModelSlug = "classic" | "custom" | "prediction-markets" | "stock-paired";
 
 const classicEvidenceCommit = "1fb9558af4f0248de75d5c7983f80036e32f47cb";
 const stockPairedEvidenceCommit = "db30e8609002cdee16d7cbe5a2c5a0309b63ce9b";
@@ -31,6 +31,12 @@ const customSections = [
   { id: "project-presentation", label: "What activation does not prove" },
 ] as const;
 
+const predictionMarketSections = [
+  { id: "overview", label: "Overview" },
+  { id: "current-release", label: "Current release" },
+  { id: "boundaries", label: "Boundaries" },
+] as const;
+
 const stockPairedSections = [
   { id: "overview", label: "Historical model" },
   { id: "token-boundary", label: "Token boundary" },
@@ -53,6 +59,11 @@ const modelMetadata: Record<ModelSlug, { description: string; title: string }> =
       title: "Custom hooks",
       description:
         "Requirements and provenance for releases that use individual Uniswap v4 hooks.",
+    },
+    "prediction-markets": {
+      title: "Prediction Markets",
+      description:
+        "The open-source Uniswap v4 launch model for onchain outcome markets.",
     },
     "stock-paired": {
       title: "Stock-Paired",
@@ -449,6 +460,74 @@ function CustomDocs() {
   );
 }
 
+function PredictionMarketsDocs() {
+  return (
+    <DocsShell
+      currentPath="/docs/models/prediction-markets"
+      kicker="Launch model"
+      title="Prediction Markets"
+      description="Programmable's open-source Uniswap v4 launch model for onchain outcome markets."
+      sections={predictionMarketSections}
+    >
+      <section id="overview">
+        <h2>Overview</h2>
+        <p>
+          Prediction Markets lets people create and trade onchain outcome
+          markets through Programmable. The product interface and the protocol
+          release are maintained separately so the current implementation can
+          evolve without turning this overview into a stale specification.
+        </p>
+        <div className={styles.sourceLinks}>
+          <DocsExternalLink
+            href="https://programmable.market/markets"
+            variant="chip"
+          >
+            Open Prediction Markets
+          </DocsExternalLink>
+          <DocsExternalLink
+            href="https://github.com/0xprogrammable/programmable-prediction-markets"
+            variant="chip"
+          >
+            Current source and release details
+          </DocsExternalLink>
+        </div>
+      </section>
+
+      <section id="current-release">
+        <h2>Use the current release</h2>
+        <p>
+          The canonical Prediction Markets repository is the source of truth for
+          the active protocol release. It defines:
+        </p>
+        <ul className={styles.contentList}>
+          <li>Current networks and supported market types.</li>
+          <li>Collateral and activation rules.</li>
+          <li>Fees, recipients and creator rewards.</li>
+          <li>Trading, resolution and payout rules.</li>
+          <li>Contract addresses, verified source and release evidence.</li>
+        </ul>
+        <div className={styles.callout}>
+          <strong>Do not copy release details from this overview.</strong>
+          <p>
+            Before creating, trading, integrating or describing a market, check
+            the current source and release record in the canonical repository.
+          </p>
+        </div>
+      </section>
+
+      <section id="boundaries">
+        <h2>Boundaries</h2>
+        <p>
+          A visible market, verified source or passing test does not guarantee
+          liquidity, execution at a chosen price, support in another application
+          or safety. Outcome assets can lose all value. Follow the current
+          security and integration guidance in the canonical repository.
+        </p>
+      </section>
+    </DocsShell>
+  );
+}
+
 function StockPairedDocs() {
   const contractRows = [
     {
@@ -749,5 +828,6 @@ export default async function ModelDocsPage({
 
   if (model === "classic") return <ClassicDocs />;
   if (model === "custom") return <CustomDocs />;
+  if (model === "prediction-markets") return <PredictionMarketsDocs />;
   return <StockPairedDocs />;
 }

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -62,6 +62,12 @@ const launchTypes = [
   },
   {
     description:
+      "Create and trade onchain outcome markets through a separately versioned Uniswap v4 release.",
+    href: "/docs/models/prediction-markets",
+    label: "Prediction Markets",
+  },
+  {
+    description:
       "Existing records use supported Ondo Global Markets quote assets; see the reference for its market and integration details.",
     href: "/docs/models/stock-paired",
     label: "Stock-Paired",
@@ -195,6 +201,11 @@ export default function DocsIndexPage() {
           public provenance record. That record can identify a Programmable
           Classic or Programmable Custom launch. It does not promise safety,
           liquidity, price or support in another application.
+        </p>
+        <p>
+          Prediction Markets has its own versioned protocol release. Use the
+          canonical Prediction Markets repository for current networks, market
+          types, economics, resolution rules and contract identity.
         </p>
       </section>
 

--- a/app/docs/tokens/page.tsx
+++ b/app/docs/tokens/page.tsx
@@ -8,7 +8,7 @@ import { DocsShell } from "@/components/docs-shell";
 export const metadata: Metadata = {
   title: "Tokens and launches · Programmable",
   description:
-    "Compare Programmable Classic, Custom and Stock-Paired launches by market, fee path and identity.",
+    "Compare Programmable Classic, Custom, Prediction Markets and Stock-Paired launches by market, fee path and identity.",
   alternates: { canonical: "/docs/tokens" },
 };
 
@@ -35,6 +35,14 @@ const launchTypes = [
     label: "Custom hooks",
     market:
       "Token market with Uniswap v4 hook logic and a configuration defined for that release.",
+  },
+  {
+    feePath:
+      "Current fees, recipients and creator rewards are defined by the active release in the canonical Prediction Markets repository.",
+    href: "/docs/models/prediction-markets",
+    label: "Prediction Markets",
+    market:
+      "Onchain outcome markets powered by a separately versioned Uniswap v4 release.",
   },
   {
     feePath:
@@ -92,9 +100,9 @@ export default function TokensDocsPage() {
       <section id="identity">
         <h2>What every launch has in common</h2>
         <p>
-          Every documented launch creates an ERC-20 token and a Uniswap v4
-          market. The hook, quote asset, fee path, reward flow and available
-          actions can differ.
+          Every documented launch creates one or more ERC-20 tokens and a
+          Uniswap v4 market. The network, hook, quote asset, fee path, reward
+          flow and available actions can differ.
         </p>
         <ul className={styles.plainList}>
           <li>
@@ -123,6 +131,11 @@ export default function TokensDocsPage() {
           <code>CustomGraph</code> is the Router enum name for kind 1. It is not
           a public product label. A verified label describes Router provenance,
           not current safety, liquidity or tradability.
+        </p>
+        <p>
+          Prediction Markets is separately versioned. Use its canonical
+          repository for the current network, market and contract identity rules
+          rather than inferring them from a name or ticker.
         </p>
       </section>
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,6 +6,7 @@ const PUBLIC_ROUTES = [
   "",
   "/explore",
   "/launch",
+  "/markets",
   "/docs",
   "/docs/economics",
   "/docs/v4-token",
@@ -25,6 +26,7 @@ const PUBLIC_ROUTES = [
   "/docs/launch-stamps",
   "/docs/models/classic",
   "/docs/models/custom",
+  "/docs/models/prediction-markets",
   "/docs/models/stock-paired",
   "/profile",
 ] as const;

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -20,6 +20,7 @@ export type DocsNavigationGroup = {
 const tokenModelPaths = [
   "/docs/models/classic",
   "/docs/models/custom",
+  "/docs/models/prediction-markets",
   "/docs/models/stock-paired",
 ] as const;
 
@@ -80,6 +81,11 @@ export const docsNavigation: readonly DocsNavigationGroup[] = [
       },
       { depth: 1, href: "/docs/models/classic", label: "Classic" },
       { depth: 1, href: "/docs/models/custom", label: "Custom hooks" },
+      {
+        depth: 1,
+        href: "/docs/models/prediction-markets",
+        label: "Prediction Markets",
+      },
       {
         depth: 1,
         href: "/docs/models/stock-paired",
@@ -171,15 +177,13 @@ export const docsSearchItems: DocsSearchItem[] = [
   },
   {
     title: "Creator earnings",
-    description:
-      "Compare Classic rewards and public template shares.",
+    description: "Compare Classic rewards and public template shares.",
     href: "/docs/creators/earnings",
     keywords: ["fees", "rewards", "revenue"],
   },
   {
     title: "Creator programs",
-    description:
-      "Find partnerships and contribution opportunities.",
+    description: "Find partnerships and contribution opportunities.",
     href: "/docs/creators/programs",
     keywords: ["partnership", "grant", "bounty"],
   },
@@ -226,6 +230,13 @@ export const docsSearchItems: DocsSearchItem[] = [
     title: "Custom hooks",
     description: "Understand launches that use an individual Uniswap v4 hook.",
     href: "/docs/models/custom",
+  },
+  {
+    title: "Prediction Markets",
+    description:
+      "Open the Uniswap v4 outcome-market model and its current release source.",
+    href: "/docs/models/prediction-markets",
+    keywords: ["prediction", "outcome", "YES NO", "Uniswap v4"],
   },
   {
     title: "Stock-Paired",

--- a/components/prediction-market-detail.tsx
+++ b/components/prediction-market-detail.tsx
@@ -62,6 +62,10 @@ import {
   ROBINHOOD_USDG_ADDRESS,
 } from "@/lib/prediction-market";
 import { predictionMarketErrorMessage } from "@/lib/prediction-market-errors";
+import {
+  predictionQuoteSelectionKey,
+  type PredictionTradeMode,
+} from "@/lib/prediction-market-quote-selection";
 
 type MarketLoadState =
   | { kind: "loading" }
@@ -69,7 +73,6 @@ type MarketLoadState =
   | { kind: "live"; market: PredictionMarketView }
   | { kind: "error"; message: string };
 
-type TradeMode = "BUY" | "SELL";
 type LiveQuote =
   | { kind: "BUY"; value: PredictionBuyQuote }
   | { kind: "SELL"; value: PredictionSellQuote };
@@ -122,17 +125,20 @@ function traderUsdgLabel(
   const negative = atoms < 0n;
   const absolute = negative ? -atoms : atoms;
   const collateralScale = 10n ** BigInt(PREDICTION_COLLATERAL_DECIMALS);
-  const fractionDigits = precision === "exact"
-    ? PREDICTION_COLLATERAL_DECIMALS
-    : absolute >= collateralScale
-      ? 2
-      : absolute >= collateralScale / 100n
-        ? 4
-        : PREDICTION_COLLATERAL_DECIMALS;
-  const roundingScale = 10n ** BigInt(PREDICTION_COLLATERAL_DECIMALS - fractionDigits);
-  const rounded = precision === "exact"
-    ? absolute
-    : (absolute + roundingScale / 2n) / roundingScale;
+  const fractionDigits =
+    precision === "exact"
+      ? PREDICTION_COLLATERAL_DECIMALS
+      : absolute >= collateralScale
+        ? 2
+        : absolute >= collateralScale / 100n
+          ? 4
+          : PREDICTION_COLLATERAL_DECIMALS;
+  const roundingScale =
+    10n ** BigInt(PREDICTION_COLLATERAL_DECIMALS - fractionDigits);
+  const rounded =
+    precision === "exact"
+      ? absolute
+      : (absolute + roundingScale / 2n) / roundingScale;
   const displayScale = 10n ** BigInt(fractionDigits);
   const whole = (rounded / displayScale).toString();
   const fraction = (rounded % displayScale)
@@ -164,7 +170,10 @@ function traderOutcomeLabel(atoms: bigint, outcome: PredictionOutcome) {
 function displayBuyPayout(
   quote: Pick<
     PredictionBuyQuote,
-    "collateralInAtoms" | "collateralRefundAtoms" | "minOutcomeAtoms" | "outcomeAtoms"
+    | "collateralInAtoms"
+    | "collateralRefundAtoms"
+    | "minOutcomeAtoms"
+    | "outcomeAtoms"
   >,
   outcome: PredictionOutcome,
 ): DisplayBuyPayout {
@@ -236,10 +245,7 @@ function displayQuote(quote: LiveQuote): DisplayQuote {
         )
       : null,
     quote.value.complementRefundAtoms > 0n
-      ? formatPredictionOutcome(
-          quote.value.complementRefundAtoms,
-          complement,
-        )
+      ? formatPredictionOutcome(quote.value.complementRefundAtoms, complement)
       : null,
   ].filter((label): label is string => label !== null);
   return {
@@ -257,13 +263,14 @@ function displayQuote(quote: LiveQuote): DisplayQuote {
 
 function previewQuote(
   market: PredictionMarketView,
-  mode: TradeMode,
+  mode: PredictionTradeMode,
   outcome: PredictionOutcome,
   amount: string,
 ): DisplayQuote {
-  const amountAtoms = mode === "BUY"
-    ? parsePredictionBuyAmount(amount)
-    : parsePredictionSellAmount(amount);
+  const amountAtoms =
+    mode === "BUY"
+      ? parsePredictionBuyAmount(amount)
+      : parsePredictionSellAmount(amount);
   if (amountAtoms === null) {
     throw new Error(
       mode === "BUY"
@@ -271,27 +278,31 @@ function previewQuote(
         : "Enter a positive token amount with no more than five decimals",
     );
   }
-  const selectedProbability = outcome === "YES"
-    ? market.probabilityYesBps
-    : 10_000 - market.probabilityYesBps;
+  const selectedProbability =
+    outcome === "YES"
+      ? market.probabilityYesBps
+      : 10_000 - market.probabilityYesBps;
   const notionalCollateral = mode === "BUY" ? amountAtoms : amountAtoms * 10n;
   const impact = Math.max(
     1,
     Math.min(
       1_200,
-      Number(notionalCollateral * 1_500n / market.accountedLiabilityAtoms),
+      Number((notionalCollateral * 1_500n) / market.accountedLiabilityAtoms),
     ),
   );
-  const selectedAfter = mode === "BUY"
-    ? Math.min(9_900, selectedProbability + impact)
-    : Math.max(100, selectedProbability - impact);
+  const selectedAfter =
+    mode === "BUY"
+      ? Math.min(9_900, selectedProbability + impact)
+      : Math.max(100, selectedProbability - impact);
   const averagePriceBps = Math.max(
     1,
     Math.round((selectedProbability + selectedAfter) / 2),
   );
-  const afterYesBps = outcome === "YES" ? selectedAfter : 10_000 - selectedAfter;
+  const afterYesBps =
+    outcome === "YES" ? selectedAfter : 10_000 - selectedAfter;
   if (mode === "BUY") {
-    const outputAtoms = amountAtoms * 10_000n / (BigInt(averagePriceBps) * 10n);
+    const outputAtoms =
+      (amountAtoms * 10_000n) / (BigInt(averagePriceBps) * 10n);
     const minOutcomeAtoms = applyPredictionSlippageFloor(
       outputAtoms,
       PREDICTION_DEFAULT_SLIPPAGE_BPS,
@@ -312,21 +323,22 @@ function previewQuote(
       priceImpactBps: impact,
     };
   }
-  const outputAtoms = amountAtoms * 10n * BigInt(averagePriceBps) / 10_000n;
+  const outputAtoms = (amountAtoms * 10n * BigInt(averagePriceBps)) / 10_000n;
   return {
     afterYesBps,
     averagePriceBps,
     depthLabel: quoteDepthLabel(impact),
-    minimumLabel: traderUsdgLabel(
-      outputAtoms * 9_950n / 10_000n,
-      "exact",
-    ),
+    minimumLabel: traderUsdgLabel((outputAtoms * 9_950n) / 10_000n, "exact"),
     outputLabel: traderUsdgLabel(outputAtoms),
     priceImpactBps: impact,
   };
 }
 
-export function PredictionMarketDetail({ semanticKey }: { semanticKey: string }) {
+export function PredictionMarketDetail({
+  semanticKey,
+}: {
+  semanticKey: string;
+}) {
   const release = useMemo(() => {
     try {
       return { config: getPredictionMarketReleaseConfig(), error: "" };
@@ -334,24 +346,35 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
       return { config: null, error: getErrorMessage(error) };
     }
   }, []);
-  const { openWallet, sendTransaction, signPredictionTokenPermit, wallet } = useWallet();
+  const { openWallet, sendTransaction, signPredictionTokenPermit, wallet } =
+    useWallet();
   const walletAccount = wallet?.account;
   const walletAccountKey = walletAccount?.toLowerCase() ?? "";
   const normalizedSemanticKey = semanticKey.toLowerCase();
-  const [loadState, setLoadState] = useState<MarketLoadState>({ kind: "loading" });
-  const [mode, setMode] = useState<TradeMode>("BUY");
+  const [loadState, setLoadState] = useState<MarketLoadState>({
+    kind: "loading",
+  });
+  const [mode, setMode] = useState<PredictionTradeMode>("BUY");
   const [outcome, setOutcome] = useState<PredictionOutcome>("YES");
   const [amount, setAmount] = useState("10");
-  const [liveQuote, setLiveQuote] = useState<LiveQuote | null>(null);
-  const [shownQuote, setShownQuote] = useState<DisplayQuote | null>(null);
-  const [phase, setPhase] = useState<"idle" | "quoting" | "signing" | "submitting" | "confirming">("idle");
+  const [storedLiveQuote, setLiveQuote] = useState<LiveQuote | null>(null);
+  const [storedShownQuote, setShownQuote] = useState<DisplayQuote | null>(null);
+  const [quotedSelectionKey, setQuotedSelectionKey] = useState<string | null>(
+    null,
+  );
+  const [phase, setPhase] = useState<
+    "idle" | "quoting" | "signing" | "submitting" | "confirming"
+  >("idle");
   const [message, setMessage] = useState("");
   const quoteRequestId = useRef(0);
   const quotePhaseRequestId = useRef<number | null>(null);
   const marketLoadGeneration = useRef(0);
-  const activeMarketLoadRequest = useRef<PredictionMarketLoadRequestV1 | null>(null);
+  const activeMarketLoadRequest = useRef<PredictionMarketLoadRequestV1 | null>(
+    null,
+  );
   const marketActionGeneration = useRef(0);
-  const activeMarketActionRequest = useRef<PredictionMarketLoadRequestV1 | null>(null);
+  const activeMarketActionRequest =
+    useRef<PredictionMarketLoadRequestV1 | null>(null);
   const walletAccountKeyRef = useRef(walletAccountKey);
   const semanticKeyRef = useRef(normalizedSemanticKey);
 
@@ -369,12 +392,14 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   }, [normalizedSemanticKey, walletAccountKey]);
 
   function marketActionIsCurrent(request: PredictionMarketLoadRequestV1) {
-    return isPredictionMarketLoadRequestCurrent(
-      request,
-      activeMarketActionRequest.current,
-    )
-      && request.accountKey === walletAccountKeyRef.current
-      && request.semanticKey === semanticKeyRef.current;
+    return (
+      isPredictionMarketLoadRequestCurrent(
+        request,
+        activeMarketActionRequest.current,
+      ) &&
+      request.accountKey === walletAccountKeyRef.current &&
+      request.semanticKey === semanticKeyRef.current
+    );
   }
 
   function requireCurrentMarketAction(request: PredictionMarketLoadRequestV1) {
@@ -395,7 +420,7 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
     quoteRequestId.current += 1;
     if (quotePhaseRequestId.current !== null) {
       quotePhaseRequestId.current = null;
-      setPhase((current) => current === "quoting" ? "idle" : current);
+      setPhase((current) => (current === "quoting" ? "idle" : current));
     }
     if (activeMarketActionRequest.current !== null) {
       activeMarketActionRequest.current = null;
@@ -404,19 +429,42 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
     }
     setLiveQuote(null);
     setShownQuote(null);
+    setQuotedSelectionKey(null);
     await Promise.resolve();
-    if (!isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) return;
+    if (
+      !isPredictionMarketLoadRequestCurrent(
+        request,
+        activeMarketLoadRequest.current,
+      )
+    )
+      return;
     if (!release.config) {
-      const market = predictionPreviewMarkets(Math.floor(Date.now() / 1_000)).find(
-        (candidate) => candidate.semanticKey.toLowerCase() === semanticKey.toLowerCase(),
+      const market = predictionPreviewMarkets(
+        Math.floor(Date.now() / 1_000),
+      ).find(
+        (candidate) =>
+          candidate.semanticKey.toLowerCase() === semanticKey.toLowerCase(),
       );
       if (!market) {
-        if (isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) {
-          setLoadState({ kind: "error", message: "This preview market does not exist" });
+        if (
+          isPredictionMarketLoadRequestCurrent(
+            request,
+            activeMarketLoadRequest.current,
+          )
+        ) {
+          setLoadState({
+            kind: "error",
+            message: "This preview market does not exist",
+          });
         }
         return;
       }
-      if (isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) {
+      if (
+        isPredictionMarketLoadRequestCurrent(
+          request,
+          activeMarketLoadRequest.current,
+        )
+      ) {
         setLoadState({ kind: "preview", market });
       }
       return;
@@ -428,15 +476,31 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         config: release.config,
         semanticKey,
       });
-      if (isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) {
+      if (
+        isPredictionMarketLoadRequestCurrent(
+          request,
+          activeMarketLoadRequest.current,
+        )
+      ) {
         setLoadState({ kind: "live", market });
       }
     } catch (error) {
-      if (isPredictionMarketLoadRequestCurrent(request, activeMarketLoadRequest.current)) {
+      if (
+        isPredictionMarketLoadRequestCurrent(
+          request,
+          activeMarketLoadRequest.current,
+        )
+      ) {
         setLoadState({ kind: "error", message: getErrorMessage(error) });
       }
     }
-  }, [normalizedSemanticKey, release.config, semanticKey, walletAccount, walletAccountKey]);
+  }, [
+    normalizedSemanticKey,
+    release.config,
+    semanticKey,
+    walletAccount,
+    walletAccountKey,
+  ]);
 
   useEffect(() => {
     quoteRequestId.current += 1;
@@ -462,15 +526,28 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
   const market = "market" in loadState ? loadState.market : null;
   const preview = loadState.kind === "preview";
   const busy = phase !== "idle";
+  const currentQuoteSelectionKey = predictionQuoteSelectionKey({
+    amount,
+    marketIdentity: market
+      ? `${market.semanticKey}:${market.canonicalPoolId}:${market.vault}`
+      : normalizedSemanticKey,
+    mode,
+    outcome,
+  });
+  const quoteSelectionIsCurrent =
+    quotedSelectionKey === currentQuoteSelectionKey;
+  const liveQuote = quoteSelectionIsCurrent ? storedLiveQuote : null;
+  const shownQuote = quoteSelectionIsCurrent ? storedShownQuote : null;
 
   function clearQuote() {
     quoteRequestId.current += 1;
     if (quotePhaseRequestId.current !== null) {
       quotePhaseRequestId.current = null;
-      setPhase((current) => current === "quoting" ? "idle" : current);
+      setPhase((current) => (current === "quoting" ? "idle" : current));
     }
     setLiveQuote(null);
     setShownQuote(null);
+    setQuotedSelectionKey(null);
     setMessage("");
   }
 
@@ -481,6 +558,7 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
     const requestedMarket = market;
     const requestedMode = mode;
     const requestedOutcome = outcome;
+    const requestedSelectionKey = currentQuoteSelectionKey;
     quotePhaseRequestId.current = requestId;
     setPhase("quoting");
     setMessage(preview ? "Checking the preview price…" : "Finding your price…");
@@ -496,7 +574,10 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         );
       } else if (requestedMode === "BUY") {
         const collateralAtoms = parsePredictionBuyAmount(requestedAmount);
-        if (collateralAtoms === null) throw new Error("Enter a positive USDG amount with no more than five decimals");
+        if (collateralAtoms === null)
+          throw new Error(
+            "Enter a positive USDG amount with no more than five decimals",
+          );
         const quote = await quotePredictionBuy({
           collateralAtoms,
           config: release.config,
@@ -507,11 +588,18 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         nextShownQuote = displayQuote(nextLiveQuote);
       } else {
         const outcomeAtoms = parsePredictionSellAmount(requestedAmount);
-        if (outcomeAtoms === null) throw new Error("Enter a positive token amount with no more than five decimals");
-        const balance = requestedOutcome === "YES"
-          ? requestedMarket.yesBalanceAtoms
-          : requestedMarket.noBalanceAtoms;
-        if (wallet && outcomeAtoms > balance) throw new Error(`Your wallet does not hold enough ${requestedOutcome}`);
+        if (outcomeAtoms === null)
+          throw new Error(
+            "Enter a positive token amount with no more than five decimals",
+          );
+        const balance =
+          requestedOutcome === "YES"
+            ? requestedMarket.yesBalanceAtoms
+            : requestedMarket.noBalanceAtoms;
+        if (wallet && outcomeAtoms > balance)
+          throw new Error(
+            `Your wallet does not hold enough ${requestedOutcome}`,
+          );
         const quote = await quotePredictionSell({
           config: release.config,
           outcome: requestedOutcome,
@@ -524,11 +612,17 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
       if (requestId !== quoteRequestId.current) return;
       setLiveQuote(nextLiveQuote);
       setShownQuote(nextShownQuote);
-      setMessage(preview ? "Preview only. No wallet request will be made." : "Quote reconciled at one confirmed block. Review the minimum before submitting.");
+      setQuotedSelectionKey(requestedSelectionKey);
+      setMessage(
+        preview
+          ? "Preview only. No wallet request will be made."
+          : "Quote reconciled at one confirmed block. Review the minimum before submitting.",
+      );
     } catch (error) {
       if (requestId !== quoteRequestId.current) return;
       setLiveQuote(null);
       setShownQuote(null);
+      setQuotedSelectionKey(null);
       setMessage(getErrorMessage(error));
     } finally {
       if (requestId === quoteRequestId.current) {
@@ -556,23 +650,30 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
     const requestedMode = mode;
     const requestedOutcome = outcome;
     const clients = createPredictionMarketPublicClients();
-    const permitDeadline = BigInt(Math.floor(Date.now() / 1_000) + PREDICTION_PERMIT_DURATION_SECONDS);
-    const tokenAddress = requestedQuote.kind === "BUY"
-      ? ROBINHOOD_USDG_ADDRESS
-      : requestedQuote.value.outcome === "YES"
-        ? requestedMarket.yesToken
-        : requestedMarket.noToken;
-    const tokenName = requestedQuote.kind === "BUY"
-      ? "Global Dollar"
-      : requestedQuote.value.outcome === "YES"
-        ? requestedMarket.yesTokenName
-        : requestedMarket.noTokenName;
-    const value = requestedQuote.kind === "BUY"
-      ? requestedQuote.value.collateralInAtoms
-      : requestedQuote.value.outcomeAtoms;
+    const permitDeadline = BigInt(
+      Math.floor(Date.now() / 1_000) + PREDICTION_PERMIT_DURATION_SECONDS,
+    );
+    const tokenAddress =
+      requestedQuote.kind === "BUY"
+        ? ROBINHOOD_USDG_ADDRESS
+        : requestedQuote.value.outcome === "YES"
+          ? requestedMarket.yesToken
+          : requestedMarket.noToken;
+    const tokenName =
+      requestedQuote.kind === "BUY"
+        ? "Global Dollar"
+        : requestedQuote.value.outcome === "YES"
+          ? requestedMarket.yesTokenName
+          : requestedMarket.noTokenName;
+    const value =
+      requestedQuote.kind === "BUY"
+        ? requestedQuote.value.collateralInAtoms
+        : requestedQuote.value.outcomeAtoms;
     try {
       setPhase("signing");
-      setMessage(`Sign an exact ${requestedMode === "BUY" ? "USDG" : requestedOutcome} permit. The signature alone spends no gas.`);
+      setMessage(
+        `Sign an exact ${requestedMode === "BUY" ? "USDG" : requestedOutcome} permit. The signature alone spends no gas.`,
+      );
       const { nonce } = await readPredictionPermitNonceQuorum({
         clients,
         config: release.config,
@@ -606,7 +707,10 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         if (freshQuote.outcomeAtoms < requestedQuote.value.minOutcomeAtoms) {
           setLiveQuote(null);
           setShownQuote(null);
-          throw new Error("The price moved beyond the minimum you reviewed. Get a new quote before trading.");
+          setQuotedSelectionKey(null);
+          throw new Error(
+            "The price moved beyond the minimum you reviewed. Get a new quote before trading.",
+          );
         }
         prepared = await preparePredictionBuy({
           client: clients[0],
@@ -627,10 +731,15 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
           semanticKey,
         });
         requireCurrentMarketAction(actionRequest);
-        if (freshQuote.collateralAtoms < requestedQuote.value.minCollateralAtoms) {
+        if (
+          freshQuote.collateralAtoms < requestedQuote.value.minCollateralAtoms
+        ) {
           setLiveQuote(null);
           setShownQuote(null);
-          throw new Error("The price moved beyond the minimum you reviewed. Get a new quote before trading.");
+          setQuotedSelectionKey(null);
+          throw new Error(
+            "The price moved beyond the minimum you reviewed. Get a new quote before trading.",
+          );
         }
         prepared = await preparePredictionSell({
           client: clients[0],
@@ -649,12 +758,15 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
       const transactionHash = await sendTransaction(prepared);
       if (!marketActionIsCurrent(actionRequest)) return;
       setPhase("confirming");
-      setMessage("Transaction submitted. Waiting for both RPCs to confirm the same receipt…");
+      setMessage(
+        "Transaction submitted. Waiting for both RPCs to confirm the same receipt…",
+      );
       await waitForPredictionAction({ clients, transactionHash });
       if (marketActionIsCurrent(actionRequest)) {
         setMessage("Trade confirmed onchain.");
         setLiveQuote(null);
         setShownQuote(null);
+        setQuotedSelectionKey(null);
         await refresh();
       }
     } catch (error) {
@@ -662,17 +774,21 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         setMessage(getErrorMessage(error));
       }
     } finally {
-      if (isPredictionMarketLoadRequestCurrent(
-        actionRequest,
-        activeMarketActionRequest.current,
-      )) {
+      if (
+        isPredictionMarketLoadRequestCurrent(
+          actionRequest,
+          activeMarketActionRequest.current,
+        )
+      ) {
         activeMarketActionRequest.current = null;
         setPhase("idle");
       }
     }
   }
 
-  async function handleLifecycle(action: "RESOLVE" | "REDEEM" | PredictionFallbackAction) {
+  async function handleLifecycle(
+    action: "RESOLVE" | "REDEEM" | PredictionFallbackAction,
+  ) {
     if (!market || !release.config || busy) return;
     if (!wallet) {
       openWallet();
@@ -689,7 +805,11 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
     const clients = createPredictionMarketPublicClients();
     try {
       setPhase("quoting");
-      setMessage(action === "RESOLVE" ? "Finding the unique adjacent Chainlink rounds across both RPCs…" : "Simulating the exact lifecycle transaction…");
+      setMessage(
+        action === "RESOLVE"
+          ? "Finding the unique adjacent Chainlink rounds across both RPCs…"
+          : "Simulating the exact lifecycle transaction…",
+      );
       let prepared;
       if (action === "RESOLVE") {
         const proof = await discoverPredictionResolutionProof({
@@ -726,7 +846,11 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
       setMessage("Waiting for both RPCs to confirm the same receipt…");
       await waitForPredictionAction({ clients, transactionHash });
       if (marketActionIsCurrent(actionRequest)) {
-        setMessage(action === "REDEEM" ? "Payout confirmed in your wallet." : "Market state updated onchain.");
+        setMessage(
+          action === "REDEEM"
+            ? "Payout confirmed in your wallet."
+            : "Market state updated onchain.",
+        );
         await refresh();
       }
     } catch (error) {
@@ -734,10 +858,12 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         setMessage(getErrorMessage(error));
       }
     } finally {
-      if (isPredictionMarketLoadRequestCurrent(
-        actionRequest,
-        activeMarketActionRequest.current,
-      )) {
+      if (
+        isPredictionMarketLoadRequestCurrent(
+          actionRequest,
+          activeMarketActionRequest.current,
+        )
+      ) {
         activeMarketActionRequest.current = null;
         setPhase("idle");
       }
@@ -757,32 +883,45 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         <Link className={styles.detailBack} href="/markets">
           <ArrowLeft aria-hidden="true" size={15} /> Predictions
         </Link>
-        <div className={styles.detailError}><strong>Market unavailable</strong><p>{loadState.kind === "error" ? loadState.message : "Unknown market"}</p></div>
+        <div className={styles.detailError}>
+          <strong>Market unavailable</strong>
+          <p>
+            {loadState.kind === "error" ? loadState.message : "Unknown market"}
+          </p>
+        </div>
       </main>
     );
   }
 
-  const tradingOpen = market.state === "OPEN" && market.blockTimestamp < market.cutoff;
+  const tradingOpen =
+    market.state === "OPEN" && market.blockTimestamp < market.cutoff;
   const displayTitle = `Will BTC be at or above ${formatPredictionPriceAtoms(market.thresholdAtoms)}?`;
-  const selectedBalance = outcome === "YES" ? market.yesBalanceAtoms : market.noBalanceAtoms;
+  const selectedBalance =
+    outcome === "YES" ? market.yesBalanceAtoms : market.noBalanceAtoms;
   const redeemableAtoms = predictionMarketRedeemableAtoms(market);
   const selectedProtocolFee = liveQuote
-    ? predictionDirectionalProtocolFee(liveQuote.value.swap.protocolFee, liveQuote.value.zeroForOne)
+    ? predictionDirectionalProtocolFee(
+        liveQuote.value.swap.protocolFee,
+        liveQuote.value.zeroForOne,
+      )
     : 0;
   const orderAnnouncement = shownQuote?.buyPayout
     ? `Potential payout ${shownQuote.buyPayout.winningPayoutLabel} if ${shownQuote.buyPayout.outcome} wins, based on the current quote; potential profit ${shownQuote.buyPayout.potentialProfitLabel}; max market loss ${shownQuote.buyPayout.maximumLossLabel}; network fee excluded.`
     : shownQuote
       ? `Estimated proceeds ${shownQuote.outputLabel}; minimum proceeds ${shownQuote.minimumLabel}.`
       : "";
-  const lifecycleAction = market.checkpointStatus !== "AWAITING" && market.state === "OPEN"
-    ? "FINALIZE_CHECKPOINT"
-    : market.fallbackChallengeDeadline && market.blockTimestamp > market.fallbackChallengeDeadline
-      ? "FINALIZE_UNPROVEN"
-      : market.blockTimestamp >= market.hardResolutionDeadline && market.fallbackRequestedAt === 0n
-        ? "REQUEST_UNPROVEN_FALLBACK"
-        : market.blockTimestamp >= market.resolutionDeadline
-          ? "FINALIZE_UNAVAILABLE"
-          : null;
+  const lifecycleAction =
+    market.checkpointStatus !== "AWAITING" && market.state === "OPEN"
+      ? "FINALIZE_CHECKPOINT"
+      : market.fallbackChallengeDeadline &&
+          market.blockTimestamp > market.fallbackChallengeDeadline
+        ? "FINALIZE_UNPROVEN"
+        : market.blockTimestamp >= market.hardResolutionDeadline &&
+            market.fallbackRequestedAt === 0n
+          ? "REQUEST_UNPROVEN_FALLBACK"
+          : market.blockTimestamp >= market.resolutionDeadline
+            ? "FINALIZE_UNAVAILABLE"
+            : null;
 
   return (
     <main className={`page-width ${styles.detailPage}`}>
@@ -799,7 +938,9 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
         <section className={styles.marketCanvas}>
           <h1>{displayTitle}</h1>
           <div className={styles.detailMeta}>
-            <span className={tradingOpen ? styles.openBadge : styles.closedBadge}>
+            <span
+              className={tradingOpen ? styles.openBadge : styles.closedBadge}
+            >
               {tradingOpen ? "Open" : "Closed"}
             </span>
             <span>
@@ -818,7 +959,9 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
             </div>
             <div>
               <span>NO</span>
-              <strong>{probabilityLabel(10_000 - market.probabilityYesBps)}</strong>
+              <strong>
+                {probabilityLabel(10_000 - market.probabilityYesBps)}
+              </strong>
             </div>
             <span className={styles.heroRail} aria-hidden="true">
               <span style={{ width: `${market.probabilityYesBps / 100}%` }} />
@@ -827,58 +970,143 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
 
           <details className={styles.marketInfo}>
             <summary>
-              <span>How this market resolves</span>
+              <span>Rules</span>
               <i aria-hidden="true" />
             </summary>
             <div className={styles.marketInfoBody}>
               <p>
-                <strong>YES wins</strong> if BTC is {formatPredictionPriceAtoms(market.thresholdAtoms)}
-                {" "}or higher at {utcDate(market.observationTime)}.
-              </p>
-              <p>
-                The result uses Chainlink&apos;s last completed BTC/USD price at or
-                before that time. If no valid result can be proven, YES and NO
-                each redeem for 0.50 USDG.
+                <strong>YES wins</strong> when Chainlink&apos;s last completed
+                BTC/USD price at or before {utcDate(market.observationTime)} is{" "}
+                {formatPredictionPriceAtoms(market.thresholdAtoms)} or higher.
+                If no valid result can be proven, YES and NO each redeem for
+                0.50 USDG.
               </p>
               {!preview ? (
                 <div className={styles.contractLinks}>
-                  <a href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.vault}`} target="_blank" rel="noreferrer">Market contract <ExternalLink size={12} /></a>
-                  <a href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.yesToken}`} target="_blank" rel="noreferrer">YES token <ExternalLink size={12} /></a>
-                  <a href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.noToken}`} target="_blank" rel="noreferrer">NO token <ExternalLink size={12} /></a>
+                  <a
+                    href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.vault}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Market contract <ExternalLink size={12} />
+                  </a>
+                  <a
+                    href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.yesToken}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    YES token <ExternalLink size={12} />
+                  </a>
+                  <a
+                    href={`${ROBINHOOD_BLOCK_EXPLORER_URL}/address/${market.noToken}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    NO token <ExternalLink size={12} />
+                  </a>
                 </div>
               ) : null}
             </div>
           </details>
         </section>
 
-        <aside className={styles.tradeTerminal} aria-label="Prediction market trade terminal">
+        <aside
+          className={styles.tradeTerminal}
+          aria-label="Prediction market trade terminal"
+        >
           {tradingOpen ? (
             <>
               <div className={styles.terminalTopline}>
                 <h2>Trade</h2>
                 {preview ? <span>Preview</span> : null}
               </div>
-              <div className={styles.modeTabs} role="group" aria-label="Trade direction">
+              <div
+                className={styles.modeTabs}
+                role="group"
+                aria-label="Trade direction"
+              >
                 {(["BUY", "SELL"] as const).map((value) => (
-                  <button key={value} type="button" disabled={busy} aria-pressed={mode === value} className={mode === value ? styles.activeMode : ""} onClick={() => { setMode(value); clearQuote(); }}>{value}</button>
+                  <button
+                    key={value}
+                    type="button"
+                    disabled={busy}
+                    aria-pressed={mode === value}
+                    className={mode === value ? styles.activeMode : ""}
+                    onClick={() => {
+                      setMode(value);
+                      clearQuote();
+                    }}
+                  >
+                    {value}
+                  </button>
                 ))}
               </div>
-              <div className={styles.outcomeToggle} role="group" aria-label="Outcome">
+              <div
+                className={styles.outcomeToggle}
+                role="group"
+                aria-label="Outcome"
+              >
                 {(["YES", "NO"] as const).map((value) => (
-                  <button key={value} type="button" disabled={busy} aria-pressed={outcome === value} className={outcome === value ? (value === "YES" ? styles.yesSelected : styles.noSelected) : ""} onClick={() => { setOutcome(value); clearQuote(); }}>
-                    <span>{value}</span><strong>{centsLabel(value === "YES" ? market.probabilityYesBps : 10_000 - market.probabilityYesBps)}</strong>
+                  <button
+                    key={value}
+                    type="button"
+                    disabled={busy}
+                    aria-pressed={outcome === value}
+                    className={
+                      outcome === value
+                        ? value === "YES"
+                          ? styles.yesSelected
+                          : styles.noSelected
+                        : ""
+                    }
+                    onClick={() => {
+                      setOutcome(value);
+                      clearQuote();
+                    }}
+                  >
+                    <span>{value}</span>
+                    <strong>
+                      {centsLabel(
+                        value === "YES"
+                          ? market.probabilityYesBps
+                          : 10_000 - market.probabilityYesBps,
+                      )}
+                    </strong>
                   </button>
                 ))}
               </div>
               <label className={styles.amountField}>
                 <span>{mode === "BUY" ? "You pay" : "You sell"}</span>
-                <span><input inputMode="decimal" disabled={busy} value={amount} onChange={(event) => { setAmount(event.target.value); clearQuote(); }} aria-label={mode === "BUY" ? "USDG amount" : `${outcome} amount`} /><strong>{mode === "BUY" ? "USDG" : outcome}</strong></span>
-                {mode === "SELL" && wallet ? <small>Balance {formatPredictionOutcome(selectedBalance, outcome)}</small> : null}
+                <span>
+                  <input
+                    inputMode="decimal"
+                    disabled={busy}
+                    value={amount}
+                    onChange={(event) => {
+                      setAmount(event.target.value);
+                      clearQuote();
+                    }}
+                    aria-label={
+                      mode === "BUY" ? "USDG amount" : `${outcome} amount`
+                    }
+                  />
+                  <strong>{mode === "BUY" ? "USDG" : outcome}</strong>
+                </span>
+                {mode === "SELL" && wallet ? (
+                  <small>
+                    Balance {formatPredictionOutcome(selectedBalance, outcome)}
+                  </small>
+                ) : null}
               </label>
 
               {shownQuote ? (
                 <div className={styles.orderPreview}>
-                  <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+                  <p
+                    className="sr-only"
+                    role="status"
+                    aria-live="polite"
+                    aria-atomic="true"
+                  >
                     {orderAnnouncement}
                   </p>
                   {shownQuote.buyPayout ? (
@@ -889,17 +1117,25 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
                     >
                       <div className={styles.payoutHeadline}>
                         <span>Potential payout</span>
-                        <strong>{shownQuote.buyPayout.winningPayoutLabel}</strong>
+                        <strong>
+                          {shownQuote.buyPayout.winningPayoutLabel}
+                        </strong>
                         <small>
-                          This order if {shownQuote.buyPayout.outcome} wins, based
-                          {" "}on the current quote. Trading fees included;
-                          {" "}network fee excluded.
+                          This order if {shownQuote.buyPayout.outcome} wins,
+                          based on the current quote. Trading fees included;{" "}
+                          network fee excluded.
                         </small>
                       </div>
                       <dl className={styles.payoutMetrics}>
                         <div>
                           <dt>Potential profit</dt>
-                          <dd data-tone={shownQuote.buyPayout.potentialProfitAtoms >= 0n ? "positive" : "negative"}>
+                          <dd
+                            data-tone={
+                              shownQuote.buyPayout.potentialProfitAtoms >= 0n
+                                ? "positive"
+                                : "negative"
+                            }
+                          >
                             {shownQuote.buyPayout.potentialProfitLabel}
                           </dd>
                         </div>
@@ -911,21 +1147,100 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
                     </section>
                   ) : null}
                   <div className={styles.quoteReceipt}>
-                    <div><span>{shownQuote.buyPayout ? "Shares received" : "Estimated proceeds"}</span><strong>{shownQuote.outputLabel}</strong></div>
-                    <div><span>{shownQuote.buyPayout ? "Minimum shares" : "Minimum proceeds"}</span><strong>{shownQuote.minimumLabel}</strong></div>
-                    <div><span>Average price</span><strong>{centsLabel(shownQuote.averagePriceBps)}</strong></div>
-                    <div><span>Trading fee</span><strong>0.02%{selectedProtocolFee ? ` + ${selectedProtocolFee / 100} bps protocol` : ""}</strong></div>
+                    <div>
+                      <span>
+                        {shownQuote.buyPayout
+                          ? "Shares received"
+                          : "Estimated proceeds"}
+                      </span>
+                      <strong>{shownQuote.outputLabel}</strong>
+                    </div>
+                    <div>
+                      <span>
+                        {shownQuote.buyPayout
+                          ? "Minimum shares"
+                          : "Minimum proceeds"}
+                      </span>
+                      <strong>{shownQuote.minimumLabel}</strong>
+                    </div>
+                    <div>
+                      <span>Average price</span>
+                      <strong>{centsLabel(shownQuote.averagePriceBps)}</strong>
+                    </div>
+                    <div>
+                      <span>Trading fee</span>
+                      <strong>
+                        0.02%
+                        {selectedProtocolFee
+                          ? ` + ${selectedProtocolFee / 100} bps protocol`
+                          : ""}
+                      </strong>
+                    </div>
                     <details className={styles.quoteDetails}>
                       <summary>Price details</summary>
-                      <div><span>YES chance after trade</span><strong>{probabilityLabel(shownQuote.afterYesBps)}</strong></div>
-                      <div><span>Price impact</span><strong>{probabilityLabel(shownQuote.priceImpactBps)}</strong></div>
-                      <div><span>Market depth</span><strong>{shownQuote.depthLabel}</strong></div>
-                      {shownQuote.buyPayout ? <div><span>Minimum payout</span><strong>{shownQuote.buyPayout.minimumWinningPayoutLabel}</strong></div> : null}
-                      {shownQuote.buyPayout ? <div><span>Minimum profit if {shownQuote.buyPayout.outcome} wins</span><strong>{shownQuote.buyPayout.minimumWinningProfitLabel}</strong></div> : null}
-                      {shownQuote.buyPayout ? <div><span>Minimum neutral payout</span><strong>{shownQuote.buyPayout.minimumNeutralPayoutLabel}</strong></div> : null}
-                      {shownQuote.refundLabel ? <div><span>Estimated refund</span><strong>{shownQuote.refundLabel}</strong></div> : null}
-                      {shownQuote.refundLabel && shownQuote.buyPayout ? <div><span>Estimated cost after refund</span><strong>{shownQuote.buyPayout.estimatedCostLabel}</strong></div> : null}
-                      <div><span>Slippage limit</span><strong>{PREDICTION_DEFAULT_SLIPPAGE_BPS / 100}%</strong></div>
+                      <div>
+                        <span>YES chance after trade</span>
+                        <strong>
+                          {probabilityLabel(shownQuote.afterYesBps)}
+                        </strong>
+                      </div>
+                      <div>
+                        <span>Price impact</span>
+                        <strong>
+                          {probabilityLabel(shownQuote.priceImpactBps)}
+                        </strong>
+                      </div>
+                      <div>
+                        <span>Market depth</span>
+                        <strong>{shownQuote.depthLabel}</strong>
+                      </div>
+                      {shownQuote.buyPayout ? (
+                        <div>
+                          <span>Minimum payout</span>
+                          <strong>
+                            {shownQuote.buyPayout.minimumWinningPayoutLabel}
+                          </strong>
+                        </div>
+                      ) : null}
+                      {shownQuote.buyPayout ? (
+                        <div>
+                          <span>
+                            Minimum profit if {shownQuote.buyPayout.outcome}{" "}
+                            wins
+                          </span>
+                          <strong>
+                            {shownQuote.buyPayout.minimumWinningProfitLabel}
+                          </strong>
+                        </div>
+                      ) : null}
+                      {shownQuote.buyPayout ? (
+                        <div>
+                          <span>Minimum neutral payout</span>
+                          <strong>
+                            {shownQuote.buyPayout.minimumNeutralPayoutLabel}
+                          </strong>
+                        </div>
+                      ) : null}
+                      {shownQuote.refundLabel ? (
+                        <div>
+                          <span>Estimated refund</span>
+                          <strong>{shownQuote.refundLabel}</strong>
+                        </div>
+                      ) : null}
+                      {shownQuote.refundLabel && shownQuote.buyPayout ? (
+                        <div>
+                          <span>Estimated cost after refund</span>
+                          <strong>
+                            {shownQuote.buyPayout.estimatedCostLabel}
+                          </strong>
+                        </div>
+                      ) : null}
+                      <div>
+                        <span>Slippage limit</span>
+                        <strong>
+                          {PREDICTION_DEFAULT_SLIPPAGE_BPS / 100}%
+                        </strong>
+                      </div>
                     </details>
                   </div>
                 </div>
@@ -942,11 +1257,20 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
                 }}
               >
                 {busy
-                  ? phase === "signing" ? "Sign in wallet" : phase === "confirming" ? "Confirming" : "Getting price"
-                  : !shownQuote ? preview ? "Preview order" : "Review order"
-                  : preview ? "Update preview"
-                  : !wallet ? "Connect wallet"
-                  : `${mode} ${outcome}`}
+                  ? phase === "signing"
+                    ? "Sign in wallet"
+                    : phase === "confirming"
+                      ? "Confirming"
+                      : "Getting price"
+                  : !shownQuote
+                    ? preview
+                      ? "Preview order"
+                      : "Review order"
+                    : preview
+                      ? "Update preview"
+                      : !wallet
+                        ? "Connect wallet"
+                        : `${mode} ${outcome}`}
               </button>
               <p className={styles.terminalNote}>
                 Your wallet shows the final amount and network fee before you
@@ -957,31 +1281,131 @@ export function PredictionMarketDetail({ semanticKey }: { semanticKey: string })
             <div className={styles.settlementTerminal}>
               <CheckCircle2 aria-hidden="true" size={24} />
               <span className={styles.terminalLabel}>Market resolved</span>
-              <h2>{market.state === "FINAL_INVALID" ? "Neutral payout" : market.state === "FINAL_YES" ? "YES won" : "NO won"}</h2>
-              <p>{market.state === "FINAL_INVALID" ? "Every YES and NO token redeems for 0.50 USDG." : "Each winning token redeems for 1 USDG. Losing tokens redeem for zero."}</p>
-              {wallet ? <div className={styles.balancePair}><span>YES <strong>{formatPredictionOutcome(market.yesBalanceAtoms)}</strong></span><span>NO <strong>{formatPredictionOutcome(market.noBalanceAtoms)}</strong></span></div> : null}
-              <button className={styles.terminalAction} disabled={busy || Boolean(wallet && redeemableAtoms === 0n)} type="button" onClick={() => preview ? setMessage("Preview only. No wallet request will be made.") : wallet ? void handleLifecycle("REDEEM") : openWallet()}>
-                {busy ? "Confirming payout" : !wallet ? "Connect to redeem" : redeemableAtoms > 0n ? "Redeem to wallet" : "No payout available"}
+              <h2>
+                {market.state === "FINAL_INVALID"
+                  ? "Neutral payout"
+                  : market.state === "FINAL_YES"
+                    ? "YES won"
+                    : "NO won"}
+              </h2>
+              <p>
+                {market.state === "FINAL_INVALID"
+                  ? "Every YES and NO token redeems for 0.50 USDG."
+                  : "Each winning token redeems for 1 USDG. Losing tokens redeem for zero."}
+              </p>
+              {wallet ? (
+                <div className={styles.balancePair}>
+                  <span>
+                    YES{" "}
+                    <strong>
+                      {formatPredictionOutcome(market.yesBalanceAtoms)}
+                    </strong>
+                  </span>
+                  <span>
+                    NO{" "}
+                    <strong>
+                      {formatPredictionOutcome(market.noBalanceAtoms)}
+                    </strong>
+                  </span>
+                </div>
+              ) : null}
+              <button
+                className={styles.terminalAction}
+                disabled={busy || Boolean(wallet && redeemableAtoms === 0n)}
+                type="button"
+                onClick={() =>
+                  preview
+                    ? setMessage(
+                        "Preview only. No wallet request will be made.",
+                      )
+                    : wallet
+                      ? void handleLifecycle("REDEEM")
+                      : openWallet()
+                }
+              >
+                {busy
+                  ? "Confirming payout"
+                  : !wallet
+                    ? "Connect to redeem"
+                    : redeemableAtoms > 0n
+                      ? "Redeem to wallet"
+                      : "No payout available"}
               </button>
             </div>
           ) : (
             <div className={styles.settlementTerminal}>
               <LockKeyhole aria-hidden="true" size={24} />
               <span className={styles.terminalLabel}>Trading closed</span>
-              <h2>{market.blockTimestamp <= market.observationTime ? "Waiting for result time" : "Ready to resolve"}</h2>
-              <p>{market.blockTimestamp <= market.observationTime ? `Trading stopped one minute before the result time. The result can be checked after ${utcDate(market.observationTime)}.` : "The result can now be checked from Chainlink. Anyone can finish the market."}</p>
+              <h2>
+                {market.blockTimestamp <= market.observationTime
+                  ? "Waiting for result time"
+                  : "Ready to resolve"}
+              </h2>
+              <p>
+                {market.blockTimestamp <= market.observationTime
+                  ? `Trading stopped one minute before the result time. The result can be checked after ${utcDate(market.observationTime)}.`
+                  : "The result can now be checked from Chainlink. Anyone can finish the market."}
+              </p>
               {market.blockTimestamp > market.observationTime ? (
-                <button className={styles.terminalAction} disabled={busy} type="button" onClick={() => preview ? setMessage("Preview only. No wallet request will be made.") : wallet ? void handleLifecycle("RESOLVE") : openWallet()}>{busy ? "Checking result" : !wallet ? "Connect to resolve" : "Resolve market"}</button>
+                <button
+                  className={styles.terminalAction}
+                  disabled={busy}
+                  type="button"
+                  onClick={() =>
+                    preview
+                      ? setMessage(
+                          "Preview only. No wallet request will be made.",
+                        )
+                      : wallet
+                        ? void handleLifecycle("RESOLVE")
+                        : openWallet()
+                  }
+                >
+                  {busy
+                    ? "Checking result"
+                    : !wallet
+                      ? "Connect to resolve"
+                      : "Resolve market"}
+                </button>
               ) : null}
-              {lifecycleAction && market.blockTimestamp > market.observationTime ? (
-                <button className={styles.secondaryTerminalAction} disabled={busy} type="button" onClick={() => preview ? setMessage("Preview only.") : wallet ? void handleLifecycle(lifecycleAction) : openWallet()}>
-                  {lifecycleAction === "FINALIZE_CHECKPOINT" ? "Use confirmed result" : lifecycleAction === "FINALIZE_UNAVAILABLE" ? "Close as neutral" : lifecycleAction === "REQUEST_UNPROVEN_FALLBACK" ? "Start neutral fallback" : "Finish neutral fallback"}
+              {lifecycleAction &&
+              market.blockTimestamp > market.observationTime ? (
+                <button
+                  className={styles.secondaryTerminalAction}
+                  disabled={busy}
+                  type="button"
+                  onClick={() =>
+                    preview
+                      ? setMessage("Preview only.")
+                      : wallet
+                        ? void handleLifecycle(lifecycleAction)
+                        : openWallet()
+                  }
+                >
+                  {lifecycleAction === "FINALIZE_CHECKPOINT"
+                    ? "Use confirmed result"
+                    : lifecycleAction === "FINALIZE_UNAVAILABLE"
+                      ? "Close as neutral"
+                      : lifecycleAction === "REQUEST_UNPROVEN_FALLBACK"
+                        ? "Start neutral fallback"
+                        : "Finish neutral fallback"}
                 </button>
               ) : null}
             </div>
           )}
-          {message ? <p className={styles.terminalStatus} role="status">{message}</p> : null}
-          <button className={styles.refreshMarket} type="button" disabled={busy} onClick={() => void refresh()}><RefreshCw aria-hidden="true" size={13} /> Refresh market</button>
+          {message ? (
+            <p className={styles.terminalStatus} role="status">
+              {message}
+            </p>
+          ) : null}
+          <button
+            className={styles.refreshMarket}
+            type="button"
+            disabled={busy}
+            onClick={() => void refresh()}
+          >
+            <RefreshCw aria-hidden="true" size={13} /> Refresh market
+          </button>
         </aside>
       </div>
     </main>

--- a/components/prediction-market-directory.tsx
+++ b/components/prediction-market-directory.tsx
@@ -29,17 +29,32 @@ type DirectoryState =
 const DIRECTORY_PAGE_SIZE = 12;
 
 function errorMessage(error: unknown) {
-  return predictionMarketErrorMessage(error, "Markets are temporarily unavailable");
+  return predictionMarketErrorMessage(
+    error,
+    "Markets are temporarily unavailable",
+  );
 }
 
-function countdown(target: bigint, now: bigint) {
-  const seconds = target > now ? Number(target - now) : 0;
-  const days = Math.floor(seconds / 86_400);
-  const hours = Math.floor((seconds % 86_400) / 3_600);
-  const minutes = Math.floor((seconds % 3_600) / 60);
-  if (days) return `${days}d ${hours}h`;
-  if (hours) return `${hours}h ${minutes}m`;
-  return `${minutes}m`;
+function compactUtcDate(timestamp: bigint) {
+  const date = new Date(Number(timestamp) * 1_000);
+  if (!Number.isFinite(date.getTime())) return "Date unavailable";
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  const hour = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  return `${months[date.getUTCMonth()]} ${date.getUTCDate()} · ${hour}:${minute} UTC`;
 }
 
 function MarketCard({
@@ -55,7 +70,7 @@ function MarketCard({
   const tradingOpen =
     market.state === "OPEN" && market.blockTimestamp < market.cutoff;
   const marketStatus = tradingOpen
-    ? `Closes in ${countdown(market.cutoff, market.blockTimestamp)}`
+    ? `Closes ${compactUtcDate(market.cutoff)}`
     : market.state === "OPEN"
       ? "Trading closed"
       : market.state === "FINAL_YES"
@@ -71,7 +86,6 @@ function MarketCard({
       <Link
         className={styles.marketCardLink}
         href={`/markets/${market.semanticKey}`}
-        aria-label={`${market.title}, YES ${yes.toFixed(0)} percent`}
       >
         <span
           className={styles.marketCardArt}
@@ -93,10 +107,7 @@ function MarketCard({
         </span>
 
         <span className={styles.marketCardMeta}>
-          <span>
-            <i data-open={tradingOpen ? "true" : undefined} />
-            {marketStatus}
-          </span>
+          <span>{marketStatus}</span>
           {preview ? <span>Preview</span> : null}
           <ArrowRight aria-hidden="true" size={17} />
         </span>
@@ -154,7 +165,13 @@ export function PredictionMarketDirectoryView() {
   }, [release.config]);
 
   async function loadOlderMarkets() {
-    if (!release.config || state.kind !== "live" || state.nextCursor === 0n || loadingOlder) return;
+    if (
+      !release.config ||
+      state.kind !== "live" ||
+      state.nextCursor === 0n ||
+      loadingOlder
+    )
+      return;
     setLoadingOlder(true);
     setOlderError("");
     try {
@@ -165,7 +182,9 @@ export function PredictionMarketDirectoryView() {
       });
       setState((current) => {
         if (current.kind !== "live") return current;
-        const known = new Set(current.markets.map((market) => market.semanticKey.toLowerCase()));
+        const known = new Set(
+          current.markets.map((market) => market.semanticKey.toLowerCase()),
+        );
         return {
           ...current,
           markets: [
@@ -206,9 +225,13 @@ export function PredictionMarketDirectoryView() {
           wallet signature.
         </p>
       ) : null}
-      {release.error ? <p className={styles.errorBanner}>{release.error}</p> : null}
+      {release.error ? (
+        <p className={styles.errorBanner}>{release.error}</p>
+      ) : null}
       {state.kind === "error" ? (
-        <p className={styles.errorBanner} role="alert">{state.message}</p>
+        <p className={styles.errorBanner} role="alert">
+          {state.message}
+        </p>
       ) : null}
 
       <section className={styles.directoryList} aria-label="Prediction markets">
@@ -242,7 +265,11 @@ export function PredictionMarketDirectoryView() {
             {loadingOlder ? "Loading…" : "Show more"}
           </button>
         ) : null}
-        {olderError ? <p className={styles.errorBanner} role="alert">{olderError}</p> : null}
+        {olderError ? (
+          <p className={styles.errorBanner} role="alert">
+            {olderError}
+          </p>
+        ) : null}
       </section>
     </main>
   );

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -131,12 +131,11 @@
 .marketCardArt {
   align-items: center;
   aspect-ratio: 2.42 / 1;
-  background:
-    linear-gradient(
-      90deg,
-      color-mix(in srgb, var(--market-green) 24%, #101614) 0 var(--yes-share),
-      color-mix(in srgb, var(--market-red) 22%, #171114) var(--yes-share) 100%
-    );
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--market-green) 24%, #101614) 0 var(--yes-share),
+    color-mix(in srgb, var(--market-red) 22%, #171114) var(--yes-share) 100%
+  );
   border-bottom: 1px solid var(--webde-line);
   display: flex;
   justify-content: center;
@@ -213,7 +212,8 @@
   border-top: 1px solid var(--webde-line);
   color: var(--webde-dim);
   display: flex;
-  font-size: 12px;
+  font-size: 13px;
+  font-weight: 600;
   gap: 10px;
   min-height: 48px;
   padding: 0 14px;
@@ -223,18 +223,6 @@
   align-items: center;
   display: inline-flex;
   gap: 7px;
-}
-
-.marketCardMeta i {
-  background: var(--webde-dim);
-  border-radius: 50%;
-  display: block;
-  height: 6px;
-  width: 6px;
-}
-
-.marketCardMeta i[data-open="true"] {
-  background: var(--market-green);
 }
 
 .marketCardMeta svg {
@@ -373,7 +361,8 @@
 
 .heroProbability > div {
   background: color-mix(in srgb, var(--market-green) 10%, var(--webde-surface));
-  border: 1px solid color-mix(in srgb, var(--market-green) 28%, var(--webde-line));
+  border: 1px solid
+    color-mix(in srgb, var(--market-green) 28%, var(--webde-line));
   border-radius: var(--webde-radius-card);
   display: grid;
   gap: 7px;
@@ -1022,7 +1011,10 @@
 }
 
 .portfolioTabs {
-  background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+  background: var(
+    --profile-subtle,
+    var(--webde-surface-raised, var(--surface-soft))
+  );
   border-radius: 12px;
   display: grid;
   gap: 4px;
@@ -1089,7 +1081,10 @@
 
 .portfolioCard {
   align-items: center;
-  background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+  background: var(
+    --profile-subtle,
+    var(--webde-surface-raised, var(--surface-soft))
+  );
   border-radius: 13px;
   box-shadow: 0 0 0 1px var(--webde-line, var(--profile-line, var(--border)));
   display: grid;
@@ -1292,7 +1287,8 @@
 }
 
 .portfolioMetrics > div {
-  border-inline-start: 1px solid var(--webde-line, var(--profile-line, var(--border)));
+  border-inline-start: 1px solid
+    var(--webde-line, var(--profile-line, var(--border)));
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -1394,7 +1390,10 @@
 
 .portfolioEmptyIcon {
   align-items: center;
-  background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+  background: var(
+    --profile-subtle,
+    var(--webde-surface-raised, var(--surface-soft))
+  );
   border-radius: 10px;
   color: var(--text-soft, rgb(255 255 255 / 68%));
   display: inline-flex !important;
@@ -1488,13 +1487,19 @@
   .portfolioSecondaryAction:hover,
   .portfolioInlineError button:hover,
   .portfolioCardActions a[data-tone="quiet"]:hover {
-    background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+    background: var(
+      --profile-subtle,
+      var(--webde-surface-raised, var(--surface-soft))
+    );
     border-color: var(--border-strong, rgb(255 255 255 / 18%));
     color: var(--text, #fff);
   }
 
   .portfolioShowMore:hover {
-    background: var(--profile-subtle, var(--webde-surface-raised, var(--surface-soft)));
+    background: var(
+      --profile-subtle,
+      var(--webde-surface-raised, var(--surface-soft))
+    );
     border-color: var(--border-strong, rgb(255 255 255 / 18%));
     color: var(--text, #fff);
   }
@@ -1529,7 +1534,6 @@
       transform 120ms ease-out;
   }
 
-
   .portfolioShowMore {
     transition:
       background-color 150ms ease,
@@ -1546,7 +1550,6 @@
   .portfolioCardActions a:active {
     transform: scale(0.96);
   }
-
 
   .portfolioShowMore:active {
     transform: scale(0.96);
@@ -1580,7 +1583,6 @@
   .tradeTerminal {
     position: static;
   }
-
 }
 
 @media (max-width: 52rem) {
@@ -1684,7 +1686,7 @@
   .marketCardMeta {
     align-items: flex-start;
     flex-direction: column;
-    font-size: 10px;
+    font-size: 12px;
     gap: 3px;
     justify-content: center;
     min-height: 58px;

--- a/components/prediction-market-launch.module.css
+++ b/components/prediction-market-launch.module.css
@@ -10,7 +10,10 @@
   align-items: center;
   display: grid;
   grid-template-columns: 140px minmax(0, 1fr) 140px;
+  margin-inline: auto;
+  max-width: 1060px;
   min-height: 64px;
+  width: 100%;
 }
 
 .back {
@@ -30,8 +33,7 @@
 }
 
 .back:focus-visible,
-.field input:focus-visible,
-.details summary:focus-visible {
+.field input:focus-visible {
   outline: 2px solid var(--focus);
   outline-offset: 3px;
 }
@@ -77,7 +79,7 @@
 }
 
 .layout {
-  align-items: start;
+  align-items: stretch;
   display: grid;
   gap: 16px;
   grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
@@ -116,7 +118,7 @@
   margin: 0;
 }
 
-.field small,
+.fieldFeedback,
 .costRow small {
   color: var(--webde-muted);
   font-size: 12px;
@@ -133,6 +135,7 @@
 .field {
   display: grid;
   gap: 7px;
+  grid-template-rows: auto 56px minmax(35px, auto);
   min-width: 0;
 }
 
@@ -182,6 +185,10 @@
 
 .field .error {
   color: var(--danger);
+}
+
+.fieldFeedback {
+  min-height: 35px;
 }
 
 .costRow {
@@ -337,7 +344,7 @@
 .preview h2 {
   font-size: clamp(27px, 3vw, 36px);
   line-height: 1.08;
-  min-height: 0;
+  min-height: 3.24em;
   margin-top: 20px;
   text-wrap: balance;
 }
@@ -347,6 +354,7 @@
   font-size: 13px;
   line-height: 1.45;
   margin: 12px 0 0;
+  min-height: 1.45em;
 }
 
 .outcomes {
@@ -387,52 +395,10 @@
   color: var(--brand-pink);
 }
 
-.details {
-  border-top: 1px solid var(--webde-line);
-  margin-top: 24px;
-  padding-top: 5px;
-}
-
-.details summary {
-  align-items: center;
-  color: var(--text-soft);
-  display: flex;
-  font-size: 14px;
-  font-weight: 650;
-  list-style: none;
-  min-height: 48px;
-}
-
-.details summary::-webkit-details-marker {
-  display: none;
-}
-
-.details summary::after {
-  color: var(--brand-pink);
-  content: "+";
-  font-size: 18px;
-  margin-left: auto;
-}
-
-.details[open] summary::after {
-  content: "−";
-}
-
-.details p {
-  color: var(--webde-muted);
-  font-size: 14px;
-  line-height: 1.55;
-  margin: 4px 0 12px;
-}
-
 @media (max-width: 860px) {
   .layout {
     grid-template-columns: minmax(0, 1fr);
     max-width: 680px;
-  }
-
-  .preview h2 {
-    min-height: 0;
   }
 }
 
@@ -484,5 +450,4 @@
   .heading h1 {
     font-size: 22px;
   }
-
 }

--- a/components/prediction-market-launch.tsx
+++ b/components/prediction-market-launch.tsx
@@ -2,11 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import {
-  ArrowLeft,
-  CheckCircle2,
-  ExternalLink,
-} from "lucide-react";
+import { ArrowLeft, CheckCircle2, ExternalLink } from "lucide-react";
 import { formatEther } from "viem";
 
 import styles from "@/components/prediction-market-launch.module.css";
@@ -58,12 +54,16 @@ function formatEthMaximum(value: bigint) {
   return `${whole}${shortFraction ? `.${shortFraction}` : ""} ETH`;
 }
 
-export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) {
+export function PredictionMarketLaunch({
+  onBack,
+}: PredictionMarketLaunchProps) {
   const [draft, setDraft] = useState<PredictionMarketDraft>(initialDraft);
   const [nowMs, setNowMs] = useState(0);
   const [phase, setPhase] = useState<LaunchPhase>("idle");
   const [status, setStatus] = useState("");
-  const [maximumGasCostWei, setMaximumGasCostWei] = useState<bigint | null>(null);
+  const [maximumGasCostWei, setMaximumGasCostWei] = useState<bigint | null>(
+    null,
+  );
   const [confirmedMarket, setConfirmedMarket] =
     useState<ConfirmedPredictionMarket | null>(null);
   const {
@@ -176,9 +176,12 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
       });
       if (
         recheck.nonce !== preflight.nonce ||
-        recheck.semanticKey.toLowerCase() !== preflight.semanticKey.toLowerCase()
+        recheck.semanticKey.toLowerCase() !==
+          preflight.semanticKey.toLowerCase()
       ) {
-        throw new Error("The market changed while you were approving. Please try again.");
+        throw new Error(
+          "The market changed while you were approving. Please try again.",
+        );
       }
       const prepared = await preparePredictionMarketLaunch({
         client: clients[0],
@@ -209,7 +212,8 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
       setConfirmedMarket(confirmed);
       setPhase("confirmed");
       setStatus("Market created.");
-      const sourceMatches = await requestPredictionMarketSourceMatches(confirmed);
+      const sourceMatches =
+        await requestPredictionMarketSourceMatches(confirmed);
       const verifiedSourceCount = sourceMatches.filter(
         (result) => result.verified,
       ).length;
@@ -255,7 +259,11 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
               <span className={styles.priceInput}>
                 <span aria-hidden="true">$</span>
                 <input
-                  aria-describedby={errors.thresholdUsd ? "prediction-threshold-error" : "prediction-threshold-help"}
+                  aria-describedby={
+                    errors.thresholdUsd
+                      ? "prediction-threshold-error"
+                      : undefined
+                  }
                   aria-invalid={Boolean(errors.thresholdUsd)}
                   autoComplete="off"
                   inputMode="decimal"
@@ -272,33 +280,35 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
                   value={draft.thresholdUsd}
                 />
               </span>
-              {errors.thresholdUsd ? (
-                <small className={styles.error} id="prediction-threshold-error">
-                  {errors.thresholdUsd}
-                </small>
-              ) : (
-                <small id="prediction-threshold-help">YES wins at this price or higher.</small>
-              )}
+              <small
+                className={`${styles.fieldFeedback} ${errors.thresholdUsd ? styles.error : ""}`}
+                id="prediction-threshold-error"
+                aria-live="polite"
+              >
+                {errors.thresholdUsd ?? ""}
+              </small>
             </label>
 
             <label className={styles.field}>
               <span>Result time (UTC)</span>
               <input
-                aria-describedby={errors.observationUtc ? "prediction-time-error" : "prediction-time-help"}
+                aria-describedby={
+                  errors.observationUtc ? "prediction-time-error" : undefined
+                }
                 aria-invalid={Boolean(errors.observationUtc)}
                 name="observationUtc"
                 min={
                   nowMs
-                    ? new Date(
-                        nowMs + (24 * 60 * 60 + 60) * 1_000,
-                      ).toISOString().slice(0, 16)
+                    ? new Date(nowMs + (24 * 60 * 60 + 60) * 1_000)
+                        .toISOString()
+                        .slice(0, 16)
                     : undefined
                 }
                 max={
                   nowMs
-                    ? new Date(
-                        nowMs + 30 * 24 * 60 * 60 * 1_000,
-                      ).toISOString().slice(0, 16)
+                    ? new Date(nowMs + 30 * 24 * 60 * 60 * 1_000)
+                        .toISOString()
+                        .slice(0, 16)
                     : undefined
                 }
                 onChange={(event) =>
@@ -311,13 +321,13 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
                 type="datetime-local"
                 value={draft.observationUtc}
               />
-              {errors.observationUtc ? (
-                <small className={styles.error} id="prediction-time-error">
-                  {errors.observationUtc}
-                </small>
-              ) : (
-                <small id="prediction-time-help">Shown and resolved in UTC.</small>
-              )}
+              <small
+                className={`${styles.fieldFeedback} ${errors.observationUtc ? styles.error : ""}`}
+                id="prediction-time-error"
+                aria-live="polite"
+              >
+                {errors.observationUtc ?? ""}
+              </small>
             </label>
           </div>
 
@@ -345,13 +355,16 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
               className={`${styles.launchStatus} ${phase === "error" ? styles.launchError : ""}`}
               role={phase === "error" ? "alert" : "status"}
             >
-              {phase === "confirmed" ? <CheckCircle2 aria-hidden="true" size={15} /> : null}
+              {phase === "confirmed" ? (
+                <CheckCircle2 aria-hidden="true" size={15} />
+              ) : null}
               <span>{status}</span>
             </p>
           ) : null}
           {maximumGasCostWei !== null && phase !== "submitting" ? (
             <p className={styles.gasNote}>
-              Estimated maximum network fee: {formatEthMaximum(maximumGasCostWei)}
+              Estimated maximum network fee:{" "}
+              {formatEthMaximum(maximumGasCostWei)}
             </p>
           ) : null}
           {confirmedMarket ? (
@@ -375,7 +388,11 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
           ) : null}
         </form>
 
-        <section className={styles.preview} aria-labelledby="prediction-preview-title" aria-live="polite">
+        <section
+          className={styles.preview}
+          aria-labelledby="prediction-preview-title"
+          aria-live="polite"
+        >
           <div className={styles.previewTopline}>
             <span>Preview</span>
             {market ? <span>in {market.countdownLabel}</span> : null}
@@ -385,11 +402,12 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
               ? `Will BTC be at or above ${market.thresholdLabel}?`
               : "Enter a valid price and result time."}
           </h2>
-          {market ? (
-            <p className={styles.previewTime}>
-              Resolves {market.observationLabel} · Trading closes one minute earlier
-            </p>
-          ) : null}
+          <p
+            className={styles.previewTime}
+            aria-hidden={market ? undefined : "true"}
+          >
+            {market ? `Result: ${market.observationLabel}` : "\u00a0"}
+          </p>
 
           <div className={styles.outcomes} aria-label="Initial market outcomes">
             <div className={styles.yesOutcome}>
@@ -401,16 +419,6 @@ export function PredictionMarketLaunch({ onBack }: PredictionMarketLaunchProps) 
               <strong>50%</strong>
             </div>
           </div>
-
-          <details className={styles.details}>
-            <summary>How this market resolves</summary>
-            <p>
-              YES wins if BTC is at or above the chosen price at the result
-              time. Chainlink&apos;s last completed BTC/USD price at or before
-              that time is used. If no valid result can be proven, YES and NO
-              each redeem for 0.50 USDG.
-            </p>
-          </details>
         </section>
       </div>
     </div>

--- a/docs/public/.gitbook/STYLEGUIDE.md
+++ b/docs/public/.gitbook/STYLEGUIDE.md
@@ -22,7 +22,9 @@ When a fact can drift, link readers to the live status endpoint, developer manif
 
 ## Product terminology
 
-Use “Programmable” with this capitalization. Use “Classic” and “Custom” for the documented launch models. Use “Custom project” when referring to a project submitted through the public Custom Launch intake. Use “hook” only when the technical mechanism matters, and explain it in plain English when it first appears on a reader facing page.
+Use “Programmable” with this capitalization. Use “Classic”, “Custom” and “Prediction Markets” for the documented launch models. Use “Custom project” when referring to a project submitted through the public Custom Launch intake. Use “hook” only when the technical mechanism matters, and explain it in plain English when it first appears on a reader facing page.
+
+The canonical Prediction Markets repository owns current networks, supported markets, collateral and activation rules, fees and creator rewards, resolution rules, contract addresses and security or release evidence. Do not duplicate those release-specific facts in these docs; link to the canonical repository instead.
 
 Identify a token by contract address when identity matters. Distinguish a token contract from its pool, hook, launcher, Registry record, price record and liquidity record.
 

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -1,14 +1,14 @@
 ---
-description: Official documentation for launching, reviewing and integrating Programmable on Ethereum
+description: Official documentation for launching, reviewing and integrating Programmable products
 cover: .gitbook/assets/programmable-night-garden-v2.png
 coverY: 0
 ---
 
 # Programmable
 
-Programmable is a launch platform for Uniswap v4 products. Classic turns a focused set of choices into a fixed supply token, a permanently locked ETH pool and creator rewards. Custom is the reviewed path for products that need their own hook, application logic or execution graph.
+Programmable is a launch platform for Uniswap v4 products. Classic turns a focused set of choices into a fixed supply token, a permanently locked ETH pool and creator rewards. Custom is the reviewed path for products that need their own hook, application logic or execution graph. Prediction Markets is the separately versioned launch model for onchain outcome markets.
 
-The public interface runs on Ethereum. Classic is available directly from Create. A Custom project moves through public source review and an exact release binding before the named creator wallet receives an executable launch path. In both cases, the wallet reviews and signs its own transaction.
+Classic and Prediction Markets are available from Create. A Custom project moves through public source review and an exact release binding before the named creator wallet receives an executable launch path. In every case, the wallet reviews and signs its own transaction on the required network.
 
 {% hint style="info" %}
 These docs describe current public products and the evidence available for them. A successful check, accepted source revision or visible token page is not a guarantee of safety, liquidity or future value.
@@ -19,6 +19,7 @@ These docs describe current public products and the evidence available for them.
 | I want to                    | Start here                                                                               | What happens next                                                                                                            |
 | ---------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | Launch a standard token      | [Create Classic](https://programmable.market/launch)                                     | Configure the token, fees, reward recipients and Initial Buy before signing one Ethereum transaction                         |
+| Create a prediction market   | [Create Prediction Market](https://programmable.market/launch)                           | Choose an available market and review the current release requirements before signing                                        |
 | Build with a custom hook     | [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest) | Prepare one exact public revision, then submit it through [Submit a Launch](https://github.com/0xprogrammable/submit-launch) |
 | Verify or integrate launches | [Developer reference](developers/README.md)                                              | Resolve current deployments from the manifest and reproduce provenance from Ethereum                                         |
 
@@ -40,15 +41,15 @@ To inspect an existing token, begin with [Explore](https://programmable.market/e
 
 1. The creator configures a supported launch or prepares one exact reviewed Custom release.
 2. The creator wallet checks the network, destination, calldata and value, then signs the transaction.
-3. Ethereum confirms the transaction and the launch reaches the required finality.
-4. Explore and the developer feeds publish the canonical token and pool identity. Optional price, chart and liquidity data remain separate.
+3. The required network confirms the transaction and the launch reaches the required finality.
+4. The appropriate website surface publishes the canonical token, pool or prediction market identity. The developer feeds currently cover the Ethereum launch records. Optional price, chart and liquidity data remain separate.
 
 ## What Programmable proves
 
-Each supported launch has a token, pool identity and launch model. Router based launches can also carry a launch stamp that binds the token, hook, PoolManager and pool to one canonical execution record. Historical launches remain discoverable through the public data service even when they predate the Router.
+Each supported launch has one or more tokens, a pool identity and a launch model. Router based Ethereum launches can also carry a launch stamp that binds the token, hook, PoolManager and pool to one canonical execution record. Historical Ethereum launches remain discoverable through the public data service even when they predate the Router. Prediction Markets has its own versioned identity and release records.
 
 Programmable keeps source review, launch authority, wallet execution, chain finality and public indexing separate. That separation is deliberate: it makes it possible to say exactly what has been proven without turning one green check into a broader claim.
 
 ## Official sources
 
-The website is [programmable.market](https://programmable.market), the public organization is [0xprogrammable](https://github.com/0xprogrammable), and the read only developer service is [developers.programmable.family](https://developers.programmable.family). Contract addresses and integration data should come from the versioned developer manifest rather than copied screenshots or third party token metadata.
+The website is [programmable.market](https://programmable.market), the public organization is [0xprogrammable](https://github.com/0xprogrammable), and the read only Ethereum developer service is [developers.programmable.family](https://developers.programmable.family). Prediction Markets source and current release details live in the [public Prediction Markets repository](https://github.com/0xprogrammable/programmable-prediction-markets). Contract addresses and integration data should come from canonical release evidence rather than copied screenshots or third party token metadata.

--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -4,6 +4,7 @@
 - [Launch models](tokens.md)
   - [Classic](models/classic.md)
   - [Custom hooks](models/custom.md)
+  - [Prediction Markets](models/prediction-markets.md)
 - [Create](creators/README.md)
   - [Launch a project](creators/launch.md)
   - [Creator earnings](creators/earnings.md)

--- a/docs/public/creators/README.md
+++ b/docs/public/creators/README.md
@@ -1,14 +1,18 @@
 ---
-description: Start a Classic token or prepare one exact Custom project for review
+description: Start a Classic token or prediction market, or prepare one exact Custom project for review
 ---
 
 # Create
 
-Choose Classic when the product fits the standard launch settings. Choose Custom when its behavior depends on project specific hook code or a wider execution graph. The two paths share one public product, but they use different review and release evidence.
+Choose Classic when the product fits the standard token launch settings. Choose Prediction Markets for an onchain outcome market. Choose Custom when behavior depends on project specific hook code or a wider execution graph. The paths share one public product, but their transaction and release requirements differ.
 
 ## Launch Classic
 
 Classic is available from [Create](https://programmable.market/launch). The launch wallet supplies token metadata, selects buy and sell transaction fees, chooses reward recipients and Initial Buy custody, then reviews one Ethereum transaction. No source repository or public review application is required for the standard model.
+
+## Create a Prediction Market
+
+Prediction Markets is available from [Create](https://programmable.market/launch). The creator configures an available market and reviews the transaction required by the active release. Check the [canonical Prediction Markets repository](https://github.com/0xprogrammable/programmable-prediction-markets) for current networks, market types, costs, fees, creator rewards and resolution rules.
 
 ## Build a Custom project
 

--- a/docs/public/economics.md
+++ b/docs/public/economics.md
@@ -4,15 +4,16 @@ description: Transaction fees, creator rewards and Programmable revenue
 
 # Fees and revenue
 
-Programmable fees depend on the transaction that actually executes. A launch model alone does not determine the fee. Each release must state the complete rate, how it is divided and which transactions pay it.
+Costs and fee paths depend on the transaction that actually executes. A launch model alone does not determine them. Each release must state the complete rate, how it is divided and which transactions pay it.
 
-| Path            | Share                                                    | How it works                                           |
-| --------------- | -------------------------------------------------------- | ------------------------------------------------------ |
-| Classic         | 0.1% of the gross ETH amount exchanged                   | Included in the selected buy or sell transaction fee   |
-| Standard Custom | 0.1% of the gross amount exchanged on the approved route | Defined by the exact accepted release                  |
-| Public template | Intended 0.1% share inside a 0.2% total transaction fee  | Not active while public template intake remains closed |
+| Path               | Share                                                    | How it works                                                     |
+| ------------------ | -------------------------------------------------------- | ---------------------------------------------------------------- |
+| Classic            | 0.1% of the gross ETH amount exchanged                   | Included in the selected buy or sell transaction fee             |
+| Standard Custom    | 0.1% of the gross amount exchanged on the approved route | Defined by the exact accepted release                            |
+| Prediction Markets | Defined by the active protocol release                   | Current rates, recipients and creator rewards live in its source |
+| Public template    | Intended 0.1% share inside a 0.2% total transaction fee  | Not active while public template intake remains closed           |
 
-In these docs, transaction fee means the percentage charged when a token is bought or sold. It is separate from Ethereum gas and from the Uniswap pool fee. The active contract and release determine the exact rate and recipient.
+In these docs, transaction fee means the percentage charged when a token is bought or sold. It is separate from network gas and from the Uniswap pool fee. The active contract and release determine the exact rate and recipient.
 
 ## Classic rewards
 
@@ -21,6 +22,10 @@ Classic creators select buy and sell transaction fees from 1% through 10%. Progr
 ## Custom releases
 
 Custom fees are specific to each release. The only accepted production policy assigns 0.1% of the gross amount exchanged on the exact reviewed market path to Programmable. A release without a qualifying market has no fee legs. Every other Custom fee mode fails closed.
+
+## Prediction Markets
+
+Prediction Markets economics are separately versioned. Use the [canonical Prediction Markets repository](https://github.com/0xprogrammable/programmable-prediction-markets) for current activation costs, trading and pool fees, fee recipients, creator rewards and the treatment of protocol or liquidity-provider fees. Do not infer those terms from Classic or an older Prediction Markets release.
 
 ## Protocol revenue
 

--- a/docs/public/infrastructure.md
+++ b/docs/public/infrastructure.md
@@ -4,7 +4,7 @@ description: How Programmable separates launch creation, review, execution, fina
 
 # How Programmable works
 
-Programmable records each part of a launch separately. The product interface prepares the launch, the creator wallet signs its transaction, Ethereum finalizes it, and the public data service adds the resulting token and pool to Explore and the developer feeds.
+Programmable records each part of a launch separately. The product interface prepares the launch, the creator wallet signs its transaction, the required network finalizes it, and the public product adds the resulting token, pool or prediction market to the appropriate discovery surface.
 
 ## Classic execution
 
@@ -14,13 +14,17 @@ Classic uses the current launcher and shared hook on Ethereum. One transaction c
 
 Custom begins with an exact public source revision and review application. An accepted release identifies the code, wallet, permissions and transaction plan that may use the route. The creator wallet still submits the transaction, and the resulting launch must agree with the release and final chain record.
 
+## Prediction Markets execution
+
+Prediction Markets uses a separately versioned Uniswap v4 protocol release. Its [canonical repository](https://github.com/0xprogrammable/programmable-prediction-markets) defines the current network, market components, transaction paths, resolution rules and deployment evidence. The public Ethereum developer feed covers Ethereum Router records; use the canonical repository for Prediction Markets integrations.
+
 ## Launch stamps
 
 The Launch Stamp Router provides a canonical provenance record for future Router based Classic and Custom launches. Its Ethereum deployment is live, and the developer manifest publishes the address, code hash, ABI hash, start block and finality rules required for independent verification.
 
 ## Public discovery
 
-The website combines verified launch records with price and liquidity data when those values are available. The read only developer service publishes consistent Classic and Custom records for terminals, scanners, explorers and applications. Integrators should treat origin, indexing freshness, chart availability and transaction support as separate capabilities.
+The website combines verified launch records with price and liquidity data when those values are available. The read only Ethereum developer service publishes consistent Classic and Custom records for terminals, scanners, explorers and applications. Prediction Markets uses its own versioned release records. Integrators should treat origin, indexing freshness, chart availability and transaction support as separate capabilities.
 
 {% content-ref url="launch-stamps.md" %}
 [launch-stamps.md](launch-stamps.md)

--- a/docs/public/models/prediction-markets.md
+++ b/docs/public/models/prediction-markets.md
@@ -1,0 +1,25 @@
+---
+description: The open-source Uniswap v4 launch model for onchain outcome markets
+---
+
+# Prediction Markets
+
+Prediction Markets is Programmable's open-source Uniswap v4 launch model for onchain outcome markets.
+
+[Open Prediction Markets](https://programmable.market/markets)
+
+## Current release
+
+The [canonical Prediction Markets repository](https://github.com/0xprogrammable/programmable-prediction-markets) is the source of truth for the active protocol release. It defines:
+
+- Current networks and supported market types.
+- Collateral and activation rules.
+- Fees, recipients and creator rewards.
+- Trading, resolution and payout rules.
+- Contract addresses, verified source and release evidence.
+
+Check that repository before creating, trading, integrating or describing a market. Do not copy addresses, economics or resolution details from this overview.
+
+## Boundaries
+
+A visible market, verified source or passing test does not guarantee liquidity, execution at a chosen price, support in another application or safety. Outcome assets can lose all value. Follow the current security and integration guidance in the canonical repository.

--- a/docs/public/reference/official-links.md
+++ b/docs/public/reference/official-links.md
@@ -9,7 +9,9 @@ description: Official Programmable product, source, community and analytics link
 | Website                 | [programmable.market](https://programmable.market)                                                                 |
 | Create                  | [programmable.market/launch](https://programmable.market/launch)                                                   |
 | Explore                 | [programmable.market/explore](https://programmable.market/explore)                                                 |
+| Prediction Markets      | [programmable.market/markets](https://programmable.market/markets)                                                 |
 | GitHub                  | [github.com/0xprogrammable](https://github.com/0xprogrammable)                                                     |
+| Prediction source       | [programmable-prediction-markets](https://github.com/0xprogrammable/programmable-prediction-markets)               |
 | Programmable v4 Builder | [Latest stable release](https://github.com/0xprogrammable/hookbuilder/releases/latest)                             |
 | Submit a Launch         | [github.com/0xprogrammable/submit-launch](https://github.com/0xprogrammable/submit-launch)                         |
 | Developer service       | [developers.programmable.family](https://developers.programmable.family)                                           |
@@ -18,4 +20,4 @@ description: Official Programmable product, source, community and analytics link
 | Dune                    | [Programmable analytics](https://dune.com/0xprogrammable6098/programmable-analytics)                               |
 | V4 token                | [Dexscreener](https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0) |
 
-Use the GitHub organization and current developer manifest when verifying source or deployment data. Community posts and analytics are useful context but do not replace the contract address, canonical chain record or versioned release evidence.
+Use the GitHub organization and current developer manifest when verifying Ethereum source or deployment data. Use the Prediction Markets repository for its current networks, contracts and release evidence. Community posts and analytics are useful context but do not replace the contract address, canonical chain record or versioned release evidence.

--- a/docs/public/tokens.md
+++ b/docs/public/tokens.md
@@ -1,15 +1,16 @@
 ---
-description: Compare Classic and Custom, and understand how a Uniswap v4 hook changes a pool
+description: Compare Programmable launch models and understand how their token, market and fee paths differ
 ---
 
 # Launch models
 
-Programmable separates a direct standard model from individually reviewed Custom releases. Choose the model by the behavior the product needs, not by how unusual its name or branding is.
+Programmable separates direct public models from individually reviewed Custom releases. Prediction Markets is a separately versioned launch model. Choose the model by the behavior the product needs, not by how unusual its name or branding is.
 
-| Model   | What it creates                                                            | Trading pair                                  | Access                                |
-| ------- | -------------------------------------------------------------------------- | --------------------------------------------- | ------------------------------------- |
-| Classic | Fixed supply tokens with configurable buy and sell transaction fees        | ETH on Uniswap v4                             | Open through Create                   |
-| Custom  | Tokens or applications that need an individually reviewed hook and release | The pool and route named in the exact release | Accepted and activated revisions only |
+| Model              | What it creates                                                            | Market                                        | Access                                |
+| ------------------ | -------------------------------------------------------------------------- | --------------------------------------------- | ------------------------------------- |
+| Classic            | Fixed supply tokens with configurable buy and sell transaction fees        | ETH on Uniswap v4                             | Open through Create                   |
+| Custom             | Tokens or applications that need an individually reviewed hook and release | The pool and route named in the exact release | Accepted and activated revisions only |
+| Prediction Markets | Onchain outcome markets                                                    | A separately versioned Uniswap v4 release     | Open through Create                   |
 
 ## What is a hook
 
@@ -31,4 +32,12 @@ Custom releases are for products whose behavior cannot be represented by the Cla
 
 {% content-ref url="models/custom.md" %}
 [custom.md](models/custom.md)
+{% endcontent-ref %}
+
+## Prediction Markets
+
+Prediction Markets lets a creator configure an available onchain outcome market. The [canonical Prediction Markets repository](https://github.com/0xprogrammable/programmable-prediction-markets) defines the current networks, market types, collateral and activation rules, fees and creator rewards, resolution rules, contract addresses and release evidence.
+
+{% content-ref url="models/prediction-markets.md" %}
+[prediction-markets.md](models/prediction-markets.md)
 {% endcontent-ref %}

--- a/lib/prediction-market-quote-selection.ts
+++ b/lib/prediction-market-quote-selection.ts
@@ -1,0 +1,27 @@
+import type { PredictionOutcome } from "@/lib/prediction-market-trading";
+
+export type PredictionTradeMode = "BUY" | "SELL";
+
+export type PredictionQuoteSelection = Readonly<{
+  amount: string;
+  marketIdentity: string;
+  mode: PredictionTradeMode;
+  outcome: PredictionOutcome;
+}>;
+
+/**
+ * Binds a reviewed quote to the exact market and controls that produced it.
+ * The JSON tuple is unambiguous and intentionally preserves the raw amount so
+ * every edit invalidates the previous quote, even when two strings parse to the
+ * same numeric value.
+ */
+export function predictionQuoteSelectionKey(
+  selection: PredictionQuoteSelection,
+) {
+  return JSON.stringify([
+    selection.marketIdentity.toLowerCase(),
+    selection.mode,
+    selection.outcome,
+    selection.amount,
+  ]);
+}

--- a/tests/docs-information-architecture.test.ts
+++ b/tests/docs-information-architecture.test.ts
@@ -71,6 +71,11 @@ describe("Docs information architecture", () => {
           { depth: 1, href: "/docs/models/custom", label: "Custom hooks" },
           {
             depth: 1,
+            href: "/docs/models/prediction-markets",
+            label: "Prediction Markets",
+          },
+          {
+            depth: 1,
             href: "/docs/models/stock-paired",
             label: "Stock-Paired",
           },
@@ -159,6 +164,7 @@ describe("Docs information architecture", () => {
           "/docs/launch-stamps",
           "/docs/models/classic",
           "/docs/models/custom",
+          "/docs/models/prediction-markets",
           "/docs/models/stock-paired",
         ].map((route) => `https://programmable.market${route}`),
       ),

--- a/tests/docs-navigation.test.ts
+++ b/tests/docs-navigation.test.ts
@@ -284,12 +284,14 @@ describe("Docs navigation state", () => {
     const stockResults = getDocsSearchResults("stock");
     const classicResults = getDocsSearchResults("classic");
     const customResults = getDocsSearchResults("custom");
+    const predictionResults = getDocsSearchResults("prediction");
 
     expect(deepResults).toEqual([]);
     expect(stockResults[0]?.title).toBe("Stock-Paired");
     expect(getDocsSearchResults("stock paired")[0]?.title).toBe("Stock-Paired");
     expect(classicResults[0]?.title).toBe("Classic");
     expect(customResults[0]?.title).toBe("Custom hooks");
+    expect(predictionResults[0]?.title).toBe("Prediction Markets");
     expect(
       customResults.some(
         (result) => result.title === "Classic and Custom launch kinds",

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -67,6 +67,10 @@ describe("Explore UI contract", () => {
       join(root, "components/prediction-market-launch.tsx"),
       "utf8",
     );
+    const predictionLaunchStyles = readFileSync(
+      join(root, "components/prediction-market-launch.module.css"),
+      "utf8",
+    );
     const exploreStyles = readFileSync(
       join(root, "components/explore-experience.module.css"),
       "utf8",
@@ -74,21 +78,32 @@ describe("Explore UI contract", () => {
 
     expect(navigation).not.toContain('{ href: "/markets", label: "Markets" }');
     expect(navigation).toContain('pathname.startsWith("/markets/")');
-    expect(switchSource).toContain('{ id: "token", href: "/explore", label: "Token" }');
+    expect(switchSource).toContain(
+      '{ id: "token", href: "/explore", label: "Token" }',
+    );
     expect(switchSource).toContain(
       '{ id: "prediction", href: "/markets", label: "Prediction" }',
     );
     expect(switchSource).toContain('aria-label="Explore categories"');
-    expect(predictionSource).toContain('<h1>Explore</h1>');
-    expect(predictionSource).toContain('<ExploreModeSwitch active="prediction" />');
+    expect(predictionSource).toContain("<h1>Explore</h1>");
+    expect(predictionSource).toContain(
+      '<ExploreModeSwitch active="prediction" />',
+    );
     expect(predictionSource).toContain("styles.marketGrid");
     expect(predictionSource).toContain(
       "Will BTC be at or above ${formatPredictionPriceAtoms(market.thresholdAtoms)}?",
     );
-    expect(predictionSource).not.toContain("PREDICTION MARKETS · ROBINHOOD CHAIN");
+    expect(predictionSource).not.toContain(
+      "PREDICTION MARKETS · ROBINHOOD CHAIN",
+    );
     expect(predictionSource).not.toContain("Market system status");
     expect(predictionSource).not.toContain("VISIBLE BACKING");
     expect(predictionSource).not.toContain("LIVE · BLOCK");
+    expect(predictionSource).not.toContain("<i data-open=");
+    expect(predictionSource).not.toContain("aria-label={`${market.title}");
+    expect(predictionSource).toContain(
+      "Closes ${compactUtcDate(market.cutoff)}",
+    );
     expect(predictionStyles).toMatch(
       /\.marketGrid\s*\{[^}]*grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\);/s,
     );
@@ -106,6 +121,24 @@ describe("Explore UI contract", () => {
     expect(predictionLaunchSource).not.toContain("Robinhood Chain ·");
     expect(predictionLaunchSource).not.toContain("1 signature");
     expect(predictionLaunchSource).not.toContain("1 transaction");
+    expect(predictionLaunchSource).not.toContain(
+      "YES wins at this price or higher.",
+    );
+    expect(predictionLaunchSource).not.toContain("Shown and resolved in UTC.");
+    expect(predictionLaunchSource).not.toContain("How this market resolves");
+    expect(predictionLaunchSource).not.toContain("Trades close 1 min early");
+    expect(predictionLaunchSource).not.toContain("styles.rulesLink");
+    expect(predictionLaunchSource).toContain("styles.fieldFeedback");
+    expect(predictionLaunchSource).toContain(
+      'market ? `Result: ${market.observationLabel}` : "\\u00a0"',
+    );
+    expect(predictionStyles).not.toContain(".marketCardMeta i");
+    expect(predictionLaunchStyles).toMatch(
+      /\.header\s*\{[^}]*max-width:\s*1060px;[^}]*width:\s*100%;/s,
+    );
+    expect(predictionLaunchStyles).toMatch(
+      /\.layout\s*\{[^}]*align-items:\s*stretch;/s,
+    );
     expect(exploreStyles).toMatch(
       /@media \(min-width: 1101px\)[\s\S]*?\.runnersIntro\s*\{[^}]*pointer-events:\s*none;[^}]*\}[\s\S]*?\.runnersIntro :global\(\.token-section-heading\)\s*\{[^}]*pointer-events:\s*auto;/s,
     );
@@ -116,6 +149,7 @@ describe("Explore UI contract", () => {
       join(root, "components/prediction-market-detail.tsx"),
       "utf8",
     );
+    const normalized = source.replace(/\s+/g, " ");
 
     expect(source).toContain("Potential payout");
     expect(source).toContain("Potential profit");
@@ -123,16 +157,39 @@ describe("Explore UI contract", () => {
     expect(source).toContain("This order if");
     expect(source).toContain("based on the current quote");
     expect(source).toContain("network fee excluded");
-    expect(source).toContain('shownQuote.buyPayout ? "Shares received" : "Estimated proceeds"');
-    expect(source).toContain('shownQuote.buyPayout ? "Minimum shares" : "Minimum proceeds"');
-    expect(source).toContain('role="group" aria-label="Trade direction"');
-    expect(source).toContain('role="group" aria-label="Outcome"');
+    expect(source).toMatch(
+      /shownQuote\.buyPayout\s*\?\s*"Shares received"\s*:\s*"Estimated proceeds"/s,
+    );
+    expect(source).toMatch(
+      /shownQuote\.buyPayout\s*\?\s*"Minimum shares"\s*:\s*"Minimum proceeds"/s,
+    );
+    expect(normalized).toContain('role="group" aria-label="Trade direction"');
+    expect(normalized).toContain('role="group" aria-label="Outcome"');
     expect(source).toContain("aria-pressed={mode === value}");
     expect(source).toContain("aria-pressed={outcome === value}");
     expect(source).toContain("const requestId = ++quoteRequestId.current");
-    expect(source.match(/requestId !== quoteRequestId\.current/gu)).toHaveLength(2);
-    expect(source).not.toContain('className={styles.orderPreview} aria-live="polite"');
-    expect(source).toContain('className="sr-only" role="status" aria-live="polite"');
+    expect(
+      source.match(/requestId !== quoteRequestId\.current/gu),
+    ).toHaveLength(2);
+    expect(source).toContain(
+      "const requestedSelectionKey = currentQuoteSelectionKey",
+    );
+    expect(source).toContain("quotedSelectionKey === currentQuoteSelectionKey");
+    expect(source).toContain(
+      "const liveQuote = quoteSelectionIsCurrent ? storedLiveQuote : null",
+    );
+    expect(source).toContain(
+      "const shownQuote = quoteSelectionIsCurrent ? storedShownQuote : null",
+    );
+    expect(source).toContain("setQuotedSelectionKey(requestedSelectionKey)");
+    expect(normalized).not.toContain(
+      'className={styles.orderPreview} aria-live="polite"',
+    );
+    expect(normalized).toContain(
+      'className="sr-only" role="status" aria-live="polite"',
+    );
+    expect(source).toContain("<span>Rules</span>");
+    expect(source).not.toContain("How this market resolves");
   });
 
   it("keeps sort, socials and model choices in one persistent disclosure", () => {
@@ -245,7 +302,9 @@ describe("Explore UI contract", () => {
     expect(source).toMatch(
       /\{valuationLabel \? \([\s\S]*?<small>Market cap<\/small>[\s\S]*?\) : null\}/,
     );
-    expect(source).not.toContain("exploreUnavailableFdvLabel(token.marketStatus)");
+    expect(source).not.toContain(
+      "exploreUnavailableFdvLabel(token.marketStatus)",
+    );
     expect(source).toContain("Copy ${token.name} contract address");
     expect(source).not.toContain("runnerMarketStatus");
   });

--- a/tests/prediction-market-docs.test.ts
+++ b/tests/prediction-market-docs.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { docsNavigation, docsSearchItems } from "../components/docs-data";
+import sitemap from "../app/sitemap";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+const modelPage = read("app/docs/models/[model]/page.tsx");
+const gitBookPage = read("docs/public/models/prediction-markets.md");
+const readme = read("README.md");
+const styleGuide = read("docs/public/.gitbook/STYLEGUIDE.md");
+const predictionModelPage = modelPage.slice(
+  modelPage.indexOf("function PredictionMarketsDocs()"),
+  modelPage.indexOf("function StockPairedDocs()"),
+);
+const canonicalSource =
+  "https://github.com/0xprogrammable/programmable-prediction-markets";
+const releaseBridgeSources = [
+  predictionModelPage,
+  gitBookPage,
+  readme,
+  read("app/docs/page.tsx"),
+  read("app/docs/tokens/page.tsx"),
+  read("components/docs-data.ts"),
+  read("docs/public/README.md"),
+  read("docs/public/creators/README.md"),
+  read("docs/public/economics.md"),
+  read("docs/public/infrastructure.md"),
+  read("docs/public/tokens.md"),
+];
+
+describe("Prediction Markets documentation", () => {
+  it("publishes one website and GitBook model route", () => {
+    const navigationEntries = docsNavigation.flatMap((group) => group.items);
+
+    expect(navigationEntries).toContainEqual(
+      expect.objectContaining({
+        href: "/docs/models/prediction-markets",
+        label: "Prediction Markets",
+      }),
+    );
+    expect(docsSearchItems).toContainEqual(
+      expect.objectContaining({
+        href: "/docs/models/prediction-markets",
+        title: "Prediction Markets",
+      }),
+    );
+    expect(sitemap().map((entry) => entry.url)).toContain(
+      "https://programmable.market/docs/models/prediction-markets",
+    );
+    expect(sitemap().map((entry) => entry.url)).toContain(
+      "https://programmable.market/markets",
+    );
+    expect(modelPage).toContain(
+      'currentPath="/docs/models/prediction-markets"',
+    );
+    expect(gitBookPage).toContain("# Prediction Markets");
+  });
+
+  it("keeps current release facts in the canonical source repository", () => {
+    for (const source of [predictionModelPage, gitBookPage]) {
+      const normalized = source.replace(/\s+/g, " ").toLowerCase();
+      expect(source).toContain(canonicalSource);
+      expect(normalized).toContain("current networks");
+      expect(normalized).toContain("supported market types");
+      expect(normalized).toContain("collateral and activation rules");
+      expect(normalized).toContain("fees");
+      expect(normalized).toContain("creator rewards");
+      expect(normalized).toContain("resolution");
+      expect(normalized).toContain("contract addresses");
+      expect(normalized).toContain("release evidence");
+    }
+    expect(readme).toContain(canonicalSource);
+    expect(styleGuide).toContain(
+      "Do not duplicate those release-specific facts in these docs",
+    );
+  });
+
+  it("does not duplicate release-specific values in the bridge docs", () => {
+    const releaseSpecificValues = [
+      "4663",
+      "BTC/USD",
+      "Robinhood Chain",
+      "Chainlink",
+      "2 USDG",
+      "0.02%",
+      "60 seconds",
+      "25 hours",
+    ];
+
+    for (const source of releaseBridgeSources) {
+      for (const value of releaseSpecificValues) {
+        expect(source).not.toContain(value);
+      }
+    }
+    expect(predictionModelPage).not.toMatch(/0x[a-fA-F0-9]{40}/);
+    expect(gitBookPage).not.toMatch(/0x[a-fA-F0-9]{40}/);
+  });
+});

--- a/tests/prediction-market-quote-selection.test.ts
+++ b/tests/prediction-market-quote-selection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  predictionQuoteSelectionKey,
+  type PredictionQuoteSelection,
+} from "@/lib/prediction-market-quote-selection";
+
+const selection = {
+  amount: "10",
+  marketIdentity: "0xMARKET:0xPOOL:0xVAULT",
+  mode: "BUY",
+  outcome: "YES",
+} satisfies PredictionQuoteSelection;
+
+describe("prediction quote selection binding", () => {
+  it("is deterministic and normalizes the market identity", () => {
+    expect(predictionQuoteSelectionKey(selection)).toBe(
+      predictionQuoteSelectionKey({
+        ...selection,
+        marketIdentity: selection.marketIdentity.toLowerCase(),
+      }),
+    );
+  });
+
+  it.each([
+    ["market", { marketIdentity: "0xOTHER:0xPOOL:0xVAULT" }],
+    ["mode", { mode: "SELL" }],
+    ["outcome", { outcome: "NO" }],
+    ["amount", { amount: "11" }],
+    ["raw amount representation", { amount: "10.0" }],
+  ] as const)("invalidates a quote after a %s change", (_label, change) => {
+    expect(predictionQuoteSelectionKey({ ...selection, ...change })).not.toBe(
+      predictionQuoteSelectionKey(selection),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- align and stabilize the Prediction Market creation layout across validation states
- simplify Explore cards and market rules while adding quote-based payout, profit, and loss details
- bind executable quotes to the exact market, side, outcome, and amount to reject stale async responses
- add a generic Prediction Markets docs bridge and keep release-specific facts in the dedicated repository
- add the Prediction Markets routes to public discovery and sitemap

## Validation
- production build passed, including candidate-neutrality and bundle verification
- 90/90 focused prediction, docs, Explore, and launch tests passed
- TypeScript, ESLint, Prettier, and git diff checks passed
- browser QA passed at 1440x900 and 390x844: alignment, validation stability, focus restoration, no overflow, no console errors
- local full Vitest run: 3,378 passed; 7 unrelated release-verifier tests require contract artifacts/submodules absent from this isolated clone; mandatory CI remains authoritative

No contract deployment or onchain state change. Dune is intentionally excluded.