### PR TITLE
Fix Prediction Markets canonical docs route

### DIFF
--- a/app/docs/models/[model]/page.tsx
+++ b/app/docs/models/[model]/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 import { DocsAddress } from "@/components/docs-address";
 import { DocsExternalLink } from "@/components/docs-external-link";
 import { DocsShell } from "@/components/docs-shell";
 import styles from "@/components/docs-experience.module.css";
+import { predictionMarketsDocsMetadata } from "@/components/prediction-markets-docs";
 
 type ModelSlug = "classic" | "custom" | "prediction-markets" | "stock-paired";
 
@@ -29,12 +30,6 @@ const customSections = [
   { id: "launch-information", label: "Launch information" },
   { id: "router-provenance", label: "Router provenance" },
   { id: "project-presentation", label: "What activation does not prove" },
-] as const;
-
-const predictionMarketSections = [
-  { id: "overview", label: "Overview" },
-  { id: "current-release", label: "Current release" },
-  { id: "boundaries", label: "Boundaries" },
 ] as const;
 
 const stockPairedSections = [
@@ -87,6 +82,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { model } = await params;
   if (!isModelSlug(model)) return {};
+  if (model === "prediction-markets") return predictionMarketsDocsMetadata;
 
   const metadata = modelMetadata[model];
   return {
@@ -460,74 +456,6 @@ function CustomDocs() {
   );
 }
 
-function PredictionMarketsDocs() {
-  return (
-    <DocsShell
-      currentPath="/docs/models/prediction-markets"
-      kicker="Launch model"
-      title="Prediction Markets"
-      description="Programmable's open-source Uniswap v4 launch model for onchain outcome markets."
-      sections={predictionMarketSections}
-    >
-      <section id="overview">
-        <h2>Overview</h2>
-        <p>
-          Prediction Markets lets people create and trade onchain outcome
-          markets through Programmable. The product interface and the protocol
-          release are maintained separately so the current implementation can
-          evolve without turning this overview into a stale specification.
-        </p>
-        <div className={styles.sourceLinks}>
-          <DocsExternalLink
-            href="https://programmable.market/markets"
-            variant="chip"
-          >
-            Open Prediction Markets
-          </DocsExternalLink>
-          <DocsExternalLink
-            href="https://github.com/0xprogrammable/programmable-prediction-markets"
-            variant="chip"
-          >
-            Current source and release details
-          </DocsExternalLink>
-        </div>
-      </section>
-
-      <section id="current-release">
-        <h2>Use the current release</h2>
-        <p>
-          The canonical Prediction Markets repository is the source of truth for
-          the active protocol release. It defines:
-        </p>
-        <ul className={styles.contentList}>
-          <li>Current networks and supported market types.</li>
-          <li>Collateral and activation rules.</li>
-          <li>Fees, recipients and creator rewards.</li>
-          <li>Trading, resolution and payout rules.</li>
-          <li>Contract addresses, verified source and release evidence.</li>
-        </ul>
-        <div className={styles.callout}>
-          <strong>Do not copy release details from this overview.</strong>
-          <p>
-            Before creating, trading, integrating or describing a market, check
-            the current source and release record in the canonical repository.
-          </p>
-        </div>
-      </section>
-
-      <section id="boundaries">
-        <h2>Boundaries</h2>
-        <p>
-          A visible market, verified source or passing test does not guarantee
-          liquidity, execution at a chosen price, support in another application
-          or safety. Outcome assets can lose all value. Follow the current
-          security and integration guidance in the canonical repository.
-        </p>
-      </section>
-    </DocsShell>
-  );
-}
-
 function StockPairedDocs() {
   const contractRows = [
     {
@@ -825,9 +753,11 @@ export default async function ModelDocsPage({
 }) {
   const { model } = await params;
   if (!isModelSlug(model)) notFound();
+  if (model === "prediction-markets") {
+    redirect("/docs/tokens/prediction-markets");
+  }
 
   if (model === "classic") return <ClassicDocs />;
   if (model === "custom") return <CustomDocs />;
-  if (model === "prediction-markets") return <PredictionMarketsDocs />;
   return <StockPairedDocs />;
 }

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -63,7 +63,7 @@ const launchTypes = [
   {
     description:
       "Create and trade onchain outcome markets through a separately versioned Uniswap v4 release.",
-    href: "/docs/models/prediction-markets",
+    href: "/docs/tokens/prediction-markets",
     label: "Prediction Markets",
   },
   {

--- a/app/docs/tokens/page.tsx
+++ b/app/docs/tokens/page.tsx
@@ -39,7 +39,7 @@ const launchTypes = [
   {
     feePath:
       "Current fees, recipients and creator rewards are defined by the active release in the canonical Prediction Markets repository.",
-    href: "/docs/models/prediction-markets",
+    href: "/docs/tokens/prediction-markets",
     label: "Prediction Markets",
     market:
       "Onchain outcome markets powered by a separately versioned Uniswap v4 release.",

--- a/app/docs/tokens/prediction-markets/page.tsx
+++ b/app/docs/tokens/prediction-markets/page.tsx
@@ -1,0 +1,10 @@
+import {
+  PredictionMarketsDocs,
+  predictionMarketsDocsMetadata,
+} from "@/components/prediction-markets-docs";
+
+export const metadata = predictionMarketsDocsMetadata;
+
+export default function PredictionMarketsPage() {
+  return <PredictionMarketsDocs />;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -26,7 +26,7 @@ const PUBLIC_ROUTES = [
   "/docs/launch-stamps",
   "/docs/models/classic",
   "/docs/models/custom",
-  "/docs/models/prediction-markets",
+  "/docs/tokens/prediction-markets",
   "/docs/models/stock-paired",
   "/profile",
 ] as const;

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -20,7 +20,7 @@ export type DocsNavigationGroup = {
 const tokenModelPaths = [
   "/docs/models/classic",
   "/docs/models/custom",
-  "/docs/models/prediction-markets",
+  "/docs/tokens/prediction-markets",
   "/docs/models/stock-paired",
 ] as const;
 
@@ -83,7 +83,7 @@ export const docsNavigation: readonly DocsNavigationGroup[] = [
       { depth: 1, href: "/docs/models/custom", label: "Custom hooks" },
       {
         depth: 1,
-        href: "/docs/models/prediction-markets",
+        href: "/docs/tokens/prediction-markets",
         label: "Prediction Markets",
       },
       {
@@ -235,7 +235,7 @@ export const docsSearchItems: DocsSearchItem[] = [
     title: "Prediction Markets",
     description:
       "Open the Uniswap v4 outcome-market model and its current release source.",
-    href: "/docs/models/prediction-markets",
+    href: "/docs/tokens/prediction-markets",
     keywords: ["prediction", "outcome", "YES NO", "Uniswap v4"],
   },
   {

--- a/components/prediction-markets-docs.tsx
+++ b/components/prediction-markets-docs.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from "next";
+
+import { DocsExternalLink } from "@/components/docs-external-link";
+import { DocsShell } from "@/components/docs-shell";
+import styles from "@/components/docs-experience.module.css";
+
+const predictionMarketSections = [
+  { id: "overview", label: "Overview" },
+  { id: "current-release", label: "Current release" },
+  { id: "boundaries", label: "Boundaries" },
+] as const;
+
+export const predictionMarketsDocsMetadata: Metadata = {
+  title: "Prediction Markets · Programmable",
+  description:
+    "The open-source Uniswap v4 launch model for onchain outcome markets.",
+  alternates: { canonical: "/docs/tokens/prediction-markets" },
+};
+
+export function PredictionMarketsDocs() {
+  return (
+    <DocsShell
+      currentPath="/docs/tokens/prediction-markets"
+      kicker="Launch model"
+      title="Prediction Markets"
+      description="Programmable's open-source Uniswap v4 launch model for onchain outcome markets."
+      sections={predictionMarketSections}
+    >
+      <section id="overview">
+        <h2>Overview</h2>
+        <p>
+          Prediction Markets lets people create and trade onchain outcome
+          markets through Programmable. The product interface and the protocol
+          release are maintained separately so the current implementation can
+          evolve without turning this overview into a stale specification.
+        </p>
+        <div className={styles.sourceLinks}>
+          <DocsExternalLink
+            href="https://programmable.market/markets"
+            variant="chip"
+          >
+            Open Prediction Markets
+          </DocsExternalLink>
+          <DocsExternalLink
+            href="https://github.com/0xprogrammable/programmable-prediction-markets"
+            variant="chip"
+          >
+            Current source and release details
+          </DocsExternalLink>
+        </div>
+      </section>
+
+      <section id="current-release">
+        <h2>Use the current release</h2>
+        <p>
+          The canonical Prediction Markets repository is the source of truth for
+          the active protocol release. It defines:
+        </p>
+        <ul className={styles.contentList}>
+          <li>Current networks and supported market types.</li>
+          <li>Collateral and activation rules.</li>
+          <li>Fees, recipients and creator rewards.</li>
+          <li>Trading, resolution and payout rules.</li>
+          <li>Contract addresses, verified source and release evidence.</li>
+        </ul>
+        <div className={styles.callout}>
+          <strong>Do not copy release details from this overview.</strong>
+          <p>
+            Before creating, trading, integrating or describing a market, check
+            the current source and release record in the canonical repository.
+          </p>
+        </div>
+      </section>
+
+      <section id="boundaries">
+        <h2>Boundaries</h2>
+        <p>
+          A visible market, verified source or passing test does not guarantee
+          liquidity, execution at a chosen price, support in another application
+          or safety. Outcome assets can lose all value. Follow the current
+          security and integration guidance in the canonical repository.
+        </p>
+      </section>
+    </DocsShell>
+  );
+}

--- a/tests/docs-information-architecture.test.ts
+++ b/tests/docs-information-architecture.test.ts
@@ -71,7 +71,7 @@ describe("Docs information architecture", () => {
           { depth: 1, href: "/docs/models/custom", label: "Custom hooks" },
           {
             depth: 1,
-            href: "/docs/models/prediction-markets",
+            href: "/docs/tokens/prediction-markets",
             label: "Prediction Markets",
           },
           {
@@ -164,7 +164,7 @@ describe("Docs information architecture", () => {
           "/docs/launch-stamps",
           "/docs/models/classic",
           "/docs/models/custom",
-          "/docs/models/prediction-markets",
+          "/docs/tokens/prediction-markets",
           "/docs/models/stock-paired",
         ].map((route) => `https://programmable.market${route}`),
       ),

--- a/tests/prediction-market-docs.test.ts
+++ b/tests/prediction-market-docs.test.ts
@@ -10,13 +10,19 @@ const root = process.cwd();
 const read = (path: string) => readFileSync(join(root, path), "utf8");
 
 const modelPage = read("app/docs/models/[model]/page.tsx");
+const canonicalPage = read("app/docs/tokens/prediction-markets/page.tsx");
+const predictionDocsComponent = read("components/prediction-markets-docs.tsx");
 const gitBookPage = read("docs/public/models/prediction-markets.md");
 const readme = read("README.md");
 const styleGuide = read("docs/public/.gitbook/STYLEGUIDE.md");
-const predictionModelPage = modelPage.slice(
-  modelPage.indexOf("function PredictionMarketsDocs()"),
-  modelPage.indexOf("function StockPairedDocs()"),
-);
+const vercelConfig = JSON.parse(read("vercel.json")) as {
+  redirects?: Array<{
+    destination: string;
+    permanent: boolean;
+    source: string;
+  }>;
+};
+const predictionModelPage = predictionDocsComponent;
 const canonicalSource =
   "https://github.com/0xprogrammable/programmable-prediction-markets";
 const releaseBridgeSources = [
@@ -39,26 +45,39 @@ describe("Prediction Markets documentation", () => {
 
     expect(navigationEntries).toContainEqual(
       expect.objectContaining({
-        href: "/docs/models/prediction-markets",
+        href: "/docs/tokens/prediction-markets",
         label: "Prediction Markets",
       }),
     );
     expect(docsSearchItems).toContainEqual(
       expect.objectContaining({
-        href: "/docs/models/prediction-markets",
+        href: "/docs/tokens/prediction-markets",
         title: "Prediction Markets",
       }),
     );
     expect(sitemap().map((entry) => entry.url)).toContain(
-      "https://programmable.market/docs/models/prediction-markets",
+      "https://programmable.market/docs/tokens/prediction-markets",
     );
     expect(sitemap().map((entry) => entry.url)).toContain(
       "https://programmable.market/markets",
     );
+    expect(predictionDocsComponent).toContain(
+      'currentPath="/docs/tokens/prediction-markets"',
+    );
+    expect(canonicalPage).toContain("<PredictionMarketsDocs />");
     expect(modelPage).toContain(
-      'currentPath="/docs/models/prediction-markets"',
+      'if (model === "prediction-markets") return predictionMarketsDocsMetadata;',
+    );
+    expect(modelPage).toContain('redirect("/docs/tokens/prediction-markets")');
+    expect(predictionDocsComponent).toContain(
+      'canonical: "/docs/tokens/prediction-markets"',
     );
     expect(gitBookPage).toContain("# Prediction Markets");
+    expect(vercelConfig.redirects).toContainEqual({
+      destination: "/docs/tokens/prediction-markets",
+      permanent: true,
+      source: "/docs/models/prediction-markets",
+    });
   });
 
   it("keeps current release facts in the canonical source repository", () => {

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,11 @@
   ],
   "redirects": [
     {
+      "source": "/docs/models/prediction-markets",
+      "destination": "/docs/tokens/prediction-markets",
+      "permanent": true
+    },
+    {
       "source": "/sites/site_V93gQ",
       "destination": "/docs",
       "permanent": true


### PR DESCRIPTION
## Summary
- point Prediction Markets docs navigation and sitemap at the published GitBook canonical path
- add the matching local Next.js route and redirect the legacy model path
- preserve the canonical prediction repository as the release-specific source of truth

## Validation
- `npm run build`
- `npm run typecheck`
- focused ESLint on changed TypeScript files
- 35 focused Vitest assertions
- local HTTP: canonical route 200, legacy route 307, canonical metadata matches

Dune is unchanged. Gates and indexer worktrees are unchanged.